### PR TITLE
Add max width based on char count to markdown tables

### DIFF
--- a/crates/markdown_preview/src/markdown_renderer.rs
+++ b/crates/markdown_preview/src/markdown_renderer.rs
@@ -491,6 +491,7 @@ fn render_markdown_table(parsed: &ParsedMarkdownTable, cx: &mut RenderContext) -
         &parsed.header,
         &parsed.column_alignments,
         &max_column_widths,
+        total_max_length,
         true,
         cx,
     );
@@ -503,6 +504,7 @@ fn render_markdown_table(parsed: &ParsedMarkdownTable, cx: &mut RenderContext) -
                 row,
                 &parsed.column_alignments,
                 &max_column_widths,
+                total_max_length,
                 false,
                 cx,
             )
@@ -520,6 +522,7 @@ fn render_markdown_table_row(
     parsed: &ParsedMarkdownTableRow,
     alignments: &Vec<ParsedMarkdownTableAlignment>,
     max_column_widths: &Vec<f32>,
+    total_max_length: usize,
     is_header: bool,
     cx: &mut RenderContext,
 ) -> AnyElement {
@@ -569,7 +572,9 @@ fn render_markdown_table_row(
         row = row.border_b_1();
     }
 
-    row.children(items).into_any_element()
+    let char_based_width = cx.scaled_rems(total_max_length as f32 * 0.7);
+
+    row.children(items).max_w(char_based_width).into_any_element()
 }
 
 fn render_markdown_block_quote(


### PR DESCRIPTION
Closes [39152](https://github.com/zed-industries/zed/issues/39152)

Output:
<img width="1708" height="860" alt="image" src="https://github.com/user-attachments/assets/9b92966a-232e-4e5b-815f-423713cddb0d" />

Release Notes:

- N/A *or* Added/Fixed/Improved ...
