### PR TITLE
prompts: Clarify inline assist prompt to exclude non-content text

### DIFF
--- a/assets/prompts/content_prompt.hbs
+++ b/assets/prompts/content_prompt.hbs
@@ -72,6 +72,8 @@ Return ONLY the rewritten {{content_type}}. Do NOT include any XML tags like <do
 
 Respond with a code block containing the rewritten {{content_type}}. Replace \{{REWRITTEN_CODE}} with your actual rewritten {{content_type}}:
 
+**Important:** do not include any text that shouldn't become part of the content. Do not include any text that should be ignored. Do not include any text that is not part of the content.
+
 ```
 \{{REWRITTEN_CODE}}
 ```


### PR DESCRIPTION
GPT-5 models had unwanted behavior when used with the inline assistant.

For example, it would put `{{REWRITTEN_CODE}}` as part of the diff. Or unwanted similar XML tags. I made a small change to the prompt that reinforces that the model shouldn't do this, and from my testing this has fixed the issue.

Before:
<img width="1512" height="249" alt="image" src="https://github.com/user-attachments/assets/25167fee-0493-42d9-9c2a-75bf8f4c4dad" />

After:
<img width="1512" height="306" alt="image" src="https://github.com/user-attachments/assets/88e72f19-0f37-48dd-bf3e-92c0e8bfbd3c" />

Release Notes:

- Improved the content prompt for the inline assistant
