### PR TITLE
terminal: Fix terminal cloning on WSL

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -2131,14 +2131,9 @@ impl Terminal {
         self.vi_mode_enabled
     }
 
-    pub fn clone_builder(
-        &self,
-        cx: &App,
-        cwd: impl FnOnce() -> Option<PathBuf>,
-    ) -> Result<TerminalBuilder> {
-        let working_directory = self.working_directory().or_else(cwd);
+    pub fn clone_builder(&self, cx: &App, cwd: Option<PathBuf>) -> Result<TerminalBuilder> {
         TerminalBuilder::new(
-            working_directory,
+            cwd,
             None,
             self.template.shell.clone(),
             self.template.env.clone(),

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -2132,8 +2132,9 @@ impl Terminal {
     }
 
     pub fn clone_builder(&self, cx: &App, cwd: Option<PathBuf>) -> Result<TerminalBuilder> {
+        let working_directory = self.working_directory().or_else(|| cwd);
         TerminalBuilder::new(
-            cwd,
+            working_directory,
             None,
             self.template.shell.clone(),
             self.template.env.clone(),

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -466,7 +466,7 @@ impl TerminalPanel {
                     Some(view) => Task::ready(project.clone_terminal(
                         &view.read(cx).terminal.clone(),
                         cx,
-                        || working_directory,
+                        working_directory,
                     )),
                     None => project.create_terminal_shell(working_directory, cx),
                 })

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -1225,7 +1225,7 @@ impl Item for TerminalView {
                 let cwd = project
                     .active_project_directory(cx)
                     .map(|it| it.to_path_buf());
-                project.clone_terminal(self.terminal(), cx, || cwd)
+                project.clone_terminal(self.terminal(), cx, cwd)
             })
             .ok()?
             .log_err()?;


### PR DESCRIPTION
Should close #39428

The working directory of the `wsl.exe` program is set to a Linux path, which is invalid on the Windows side, causing the terminal to crash. The first spawn works because there is no active terminal view, allowing a new shell (which checks for the remote) to be created. I cannot explain why it works on SSH remote clients, but I may be missing something in the remote connection implementation.

I don't have a Windows machine to test this, so I would appreciate someone testing it. 🙏🏼

Release Notes:

- Fixed an issue where WSL terminals could not be splitted
