### PR TITLE
Emit less update events for odd FS events

### DIFF
--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -1890,6 +1890,10 @@ impl FakeFs {
             .unwrap_or(0)
     }
 
+    pub fn emit_fs_event(&self, path: impl Into<PathBuf>, event: Option<PathEventKind>) {
+        self.state.lock().emit_event(std::iter::once((path, event)));
+    }
+
     fn simulate_random_delay(&self) -> impl futures::Future<Output = ()> {
         self.executor.simulate_random_delay()
     }

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -749,13 +749,11 @@ impl Fs for RealFs {
                         events
                             .into_iter()
                             .map(|event| {
-                                dbg!(&event);
                                 let kind = if event.flags.contains(StreamFlags::ITEM_REMOVED) {
                                     Some(PathEventKind::Removed)
                                 } else if event.flags.contains(StreamFlags::ITEM_CREATED) {
                                     Some(PathEventKind::Created)
                                 } else if event.flags.contains(StreamFlags::ITEM_MODIFIED)
-                                // TODO kb is this correct? What about other platforms?
                                     | event.flags.contains(StreamFlags::ITEM_RENAMED)
                                 {
                                     Some(PathEventKind::Changed)
@@ -1335,7 +1333,7 @@ impl FakeFs {
                 }
             })
             .unwrap();
-        state.emit_event([(path, Some(PathEventKind::Changed))]);
+        state.emit_event([(path, Some(PathEventKind::Created))]);
     }
 
     fn write_file_internal(
@@ -2061,7 +2059,7 @@ impl Fs for FakeFs {
                 }
             })
             .unwrap();
-        state.emit_event([(path, Some(PathEventKind::Changed))]);
+        state.emit_event([(path, Some(PathEventKind::Created))]);
 
         Ok(())
     }

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -298,7 +298,7 @@ pub enum RepositoryState {
     },
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum RepositoryEvent {
     Updated { full_scan: bool, new_instance: bool },
     MergeHeadsChanged,
@@ -4839,17 +4839,20 @@ impl Repository {
                         this.snapshot.scan_id += 1;
                     }
 
-                    if needs_update && let Some(updates_tx) = updates_tx {
-                        updates_tx
-                            .unbounded_send(DownstreamUpdate::UpdateRepository(
-                                this.snapshot.clone(),
-                            ))
-                            .ok();
+                    if needs_update {
+                        if let Some(updates_tx) = updates_tx {
+                            updates_tx
+                                .unbounded_send(DownstreamUpdate::UpdateRepository(
+                                    this.snapshot.clone(),
+                                ))
+                                .ok();
+                        }
+
+                        cx.emit(RepositoryEvent::Updated {
+                            full_scan: false,
+                            new_instance: false,
+                        });
                     }
-                    cx.emit(RepositoryEvent::Updated {
-                        full_scan: false,
-                        new_instance: false,
-                    });
                 })
             },
         );

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -496,8 +496,10 @@ impl ProjectPanel {
             })
             .detach();
 
-            cx.subscribe_in(&git_store, window, |this, _, event, window, cx| {
-                match dbg!(event) {
+            cx.subscribe_in(
+                &git_store,
+                window,
+                |this, _, event, window, cx| match event {
                     GitStoreEvent::RepositoryUpdated(_, _, _)
                     | GitStoreEvent::RepositoryAdded(_)
                     | GitStoreEvent::RepositoryRemoved(_) => {
@@ -505,14 +507,14 @@ impl ProjectPanel {
                         cx.notify();
                     }
                     _ => {}
-                }
-            })
+                },
+            )
             .detach();
 
             cx.subscribe_in(
                 &project,
                 window,
-                |this, project, event, window, cx| match dbg!(event) {
+                |this, project, event, window, cx| match event {
                     project::Event::ActiveEntryChanged(Some(entry_id)) => {
                         if ProjectPanelSettings::get_global(cx).auto_reveal_entries {
                             this.reveal_entry(project.clone(), *entry_id, true, window, cx)
@@ -565,7 +567,6 @@ impl ProjectPanel {
                         this.update_visible_entries(None, false, false, window, cx);
                         cx.notify();
                     }
-                    // TODO kb can exclude doing this, if only files are updated (not added/removed and not directories)
                     project::Event::WorktreeUpdatedEntries(_, _)
                     | project::Event::WorktreeAdded(_)
                     | project::Event::WorktreeOrderChanged => {
@@ -3182,7 +3183,6 @@ impl ProjectPanel {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        dbg!("$$$$$$$$$$$$$$$$$$$$$$update_visible_entries");
         let now = Instant::now();
         let settings = ProjectPanelSettings::get_global(cx);
         let auto_collapse_dirs = settings.auto_fold_dirs;

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -496,10 +496,8 @@ impl ProjectPanel {
             })
             .detach();
 
-            cx.subscribe_in(
-                &git_store,
-                window,
-                |this, _, event, window, cx| match event {
+            cx.subscribe_in(&git_store, window, |this, _, event, window, cx| {
+                match dbg!(event) {
                     GitStoreEvent::RepositoryUpdated(_, _, _)
                     | GitStoreEvent::RepositoryAdded(_)
                     | GitStoreEvent::RepositoryRemoved(_) => {
@@ -507,14 +505,14 @@ impl ProjectPanel {
                         cx.notify();
                     }
                     _ => {}
-                },
-            )
+                }
+            })
             .detach();
 
             cx.subscribe_in(
                 &project,
                 window,
-                |this, project, event, window, cx| match event {
+                |this, project, event, window, cx| match dbg!(event) {
                     project::Event::ActiveEntryChanged(Some(entry_id)) => {
                         if ProjectPanelSettings::get_global(cx).auto_reveal_entries {
                             this.reveal_entry(project.clone(), *entry_id, true, window, cx)
@@ -567,6 +565,7 @@ impl ProjectPanel {
                         this.update_visible_entries(None, false, false, window, cx);
                         cx.notify();
                     }
+                    // TODO kb can exclude doing this, if only files are updated (not added/removed and not directories)
                     project::Event::WorktreeUpdatedEntries(_, _)
                     | project::Event::WorktreeAdded(_)
                     | project::Event::WorktreeOrderChanged => {
@@ -3183,6 +3182,7 @@ impl ProjectPanel {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        dbg!("$$$$$$$$$$$$$$$$$$$$$$update_visible_entries");
         let now = Instant::now();
         let settings = ProjectPanelSettings::get_global(cx);
         let auto_collapse_dirs = settings.auto_fold_dirs;

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -3696,11 +3696,7 @@ impl BackgroundScanner {
                     while let Poll::Ready(Some(more_paths)) = futures::poll!(fs_events_rx.next()) {
                         paths.extend(more_paths);
                     }
-                    // TODO kb breaks other things
-                    self.process_events(paths.into_iter().filter(|e| {
-                        dbg!(&e);
-                        e.kind.is_some()
-                    }).map(Into::into).collect()).await;
+                    self.process_events(paths.into_iter().filter(|e| e.kind.is_some()).map(Into::into).collect()).await;
                 }
 
                 paths = global_gitignore_events.next().fuse() => {

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -3644,8 +3644,14 @@ impl BackgroundScanner {
             while let Poll::Ready(Some(more_paths)) = futures::poll!(fs_events_rx.next()) {
                 paths.extend(more_paths);
             }
-            self.process_events(paths.into_iter().map(Into::into).collect())
-                .await;
+            self.process_events(
+                paths
+                    .into_iter()
+                    .filter(|e| e.kind.is_some())
+                    .map(Into::into)
+                    .collect(),
+            )
+            .await;
         }
         if let Some(abs_path) = containing_git_repository {
             self.process_events(vec![abs_path]).await;
@@ -3690,7 +3696,11 @@ impl BackgroundScanner {
                     while let Poll::Ready(Some(more_paths)) = futures::poll!(fs_events_rx.next()) {
                         paths.extend(more_paths);
                     }
-                    self.process_events(paths.into_iter().map(Into::into).collect()).await;
+                    // TODO kb breaks other things
+                    self.process_events(paths.into_iter().filter(|e| {
+                        dbg!(&e);
+                        e.kind.is_some()
+                    }).map(Into::into).collect()).await;
                 }
 
                 paths = global_gitignore_events.next().fuse() => {


### PR DESCRIPTION
When running flycheck, I've noticed that scrolling starts to lag:

https://github.com/user-attachments/assets/b0bef0a3-ccbd-479d-a385-273398086d38

When checking the trace, it is notable that project panel updates its entire tree multiple times during flycheck:

<img width="2032" height="1136" alt="image" src="https://github.com/user-attachments/assets/d1935e77-3b00-4be5-a12a-8a17a9d64202" />

[scrolling.trace.zip](https://github.com/user-attachments/files/22710852/scrolling.trace.zip)

Turns out, `target/debug` directory is loaded by Zed (presumably, reported by langserver as there are sources generated by bindgen and proto that need to be loaded), and `target/debug/build` directory received multiple events of a `None` kind for Zed, which trigger the rescans.

Rework the logic to omit the `None`-kind events in Zed, and to avoid excessive repo updates if not needed.


Release Notes:

- Improved worktree FS event emits in gitignored directories
