### PR TITLE
linux: Remove `file_finder::Toggle` key binding

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -1051,7 +1051,6 @@
   {
     "context": "FileFinder || (FileFinder > Picker > Editor)",
     "bindings": {
-      "ctrl-p": "file_finder::Toggle",
       "ctrl-shift-a": "file_finder::ToggleSplitMenu",
       "ctrl-shift-i": "file_finder::ToggleFilterMenu"
     }


### PR DESCRIPTION
This reverts commit 85d12548a1a867b07cb47e1ca3edd52468184255.
This reverts PR #34380


The intended behavior of `ctrl-p` in the file finder is to scroll to the previous element. #34379 was not a bug.

Release Notes:

- `ctrl-p` scrolls to previous element in file finder
