### PR TITLE
vim: Add command line to status bar

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -1,6 +1,13 @@
 [
   {
-    "context": "VimControl && !menu",
+    "context": "VimCommandLine",
+    "bindings": {
+      "enter": "vim::ConfirmCommand",
+      "escape": "editor::Cancel"
+    }
+  },
+  {
+    "context": "VimControl && !menu && !VimCommandLine",
     "bindings": {
       "i": ["vim::PushObject", { "around": false }],
       "a": ["vim::PushObject", { "around": true }],
@@ -233,7 +240,7 @@
       "i": "vim::InsertBefore",
       "a": "vim::InsertAfter",
       "ctrl-[": "editor::Cancel",
-      ":": "command_palette::Toggle",
+      ":": "vim::CountCommand",
       "c": "vim::PushChange",
       "shift-c": "vim::ChangeToEndOfLine",
       "d": "vim::PushDelete",
@@ -266,7 +273,7 @@
     }
   },
   {
-    "context": "VimControl && VimCount",
+    "context": "VimControl && VimCount && !VimCommandLine",
     "bindings": {
       "0": ["vim::Number", 0],
       ":": "vim::CountCommand",
@@ -425,7 +432,7 @@
     "context": "(vim_mode == helix_normal || vim_mode == helix_select) && !menu",
     "bindings": {
       ";": "vim::HelixCollapseSelection",
-      ":": "command_palette::Toggle",
+      ":": "vim::CountCommand",
       "m": "vim::PushHelixMatch",
       "s": "vim::HelixSelectRegex",
       "]": ["vim::PushHelixNext", { "around": true }],
@@ -811,7 +818,7 @@
     }
   },
   {
-    "context": "VimControl || !Editor && !Terminal",
+    "context": "(VimControl || !Editor && !Terminal) && !VimCommandLine",
     "bindings": {
       // window related commands (ctrl-w X)
       "ctrl-w": null,
@@ -952,7 +959,7 @@
     }
   },
   {
-    "context": "Editor && mode == auto_height && VimControl",
+    "context": "Editor && mode == auto_height && VimControl && !VimCommandLine",
     "bindings": {
       // TODO: Implement search
       "/": null,
@@ -972,7 +979,7 @@
     }
   },
   {
-    "context": "GitCommit > Editor && VimControl && vim_mode == normal",
+    "context": "GitCommit > Editor && VimControl && vim_mode == normal && !VimCommandLine",
     "bindings": {
       "ctrl-c": "menu::Cancel",
       "escape": "menu::Cancel"
@@ -987,7 +994,7 @@
     }
   },
   {
-    "context": "MessageEditor > Editor && VimControl",
+    "context": "MessageEditor > Editor && VimControl && !VimCommandLine",
     "bindings": {
       "enter": "agent::Chat"
     }

--- a/crates/vim/src/command_line.rs
+++ b/crates/vim/src/command_line.rs
@@ -1,0 +1,221 @@
+use editor::{Editor, EditorElement, EditorEvent, EditorStyle, actions::Cancel};
+use gpui::{
+    App, Context, Entity, FocusHandle, Focusable, IntoElement, KeyContext, ParentElement, Render,
+    Styled, Subscription, TextStyle, WeakEntity, Window, actions, div, px, relative, rems,
+    transparent_black,
+};
+use settings::Settings;
+use theme::ThemeSettings;
+use ui::{h_flex, prelude::*};
+use workspace::{StatusItemView, Workspace, item::ItemHandle};
+
+use crate::{Vim, VimEvent, command::command_interceptor};
+
+actions!(vim, [ConfirmCommand]);
+
+pub struct VimCommandLine {
+    editor: Entity<Editor>,
+    pub(crate) active: bool,
+    prefix: String,
+    workspace: WeakEntity<Workspace>,
+    vim_subscription: Option<Subscription>,
+    _editor_subscription: Subscription,
+}
+
+impl VimCommandLine {
+    pub fn new(
+        workspace: WeakEntity<Workspace>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let editor = cx.new(|cx| {
+            let mut editor = Editor::single_line(window, cx);
+            editor.set_placeholder_text("", window, cx);
+            editor.set_use_autoclose(false);
+            editor.set_use_modal_editing(false);
+            editor.set_input_enabled(true);
+            editor.set_show_gutter(false, cx);
+            editor.set_show_wrap_guides(false, cx);
+            editor.set_show_indent_guides(false, cx);
+            editor
+        });
+
+        let window_handle = window.window_handle();
+        let self_weak = cx.entity().downgrade();
+
+        let mut this = Self {
+            editor: editor.clone(),
+            active: false,
+            prefix: String::new(),
+            workspace,
+            vim_subscription: None,
+            _editor_subscription: cx.subscribe(&editor, {
+                let self_weak = self_weak.clone();
+                move |this, editor, _event: &EditorEvent, cx| {
+                    // Check if text is empty or prefix was removed after the event is processed
+                    if this.active {
+                        let prefix = this.prefix.clone();
+                        let self_weak = self_weak.clone();
+                        cx.defer(move |cx| {
+                            cx.update_window(window_handle, |_, window, cx| {
+                                let text = editor.read(cx).text(cx);
+                                if text.is_empty() || !text.starts_with(&prefix) {
+                                    if let Some(command_line) = self_weak.upgrade() {
+                                        command_line.update(cx, |this, cx| {
+                                            this.dismiss(window, cx);
+                                        });
+                                    }
+                                }
+                            })
+                            .ok();
+                        });
+                    }
+
+                    cx.notify();
+                }
+            }),
+        };
+
+        this.subscribe_to_vim(window, cx);
+
+        Vim::update_globals(cx, |globals, _| {
+            globals.command_line = Some(self_weak);
+        });
+
+        this
+    }
+
+    fn subscribe_to_vim(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let handle = cx.entity();
+        let window_handle = window.window_handle();
+
+        self.vim_subscription = Some(cx.observe_new::<Vim>(move |_, window, cx| {
+            let Some(window) = window else {
+                return;
+            };
+            if window.window_handle() != window_handle {
+                return;
+            }
+            let vim = cx.entity();
+            handle.update(cx, |_, cx| {
+                cx.subscribe(&vim, |_this, _vim, event, cx| match event {
+                    VimEvent::Focused => {
+                        cx.notify();
+                    }
+                })
+                .detach()
+            })
+        }));
+    }
+
+    pub fn activate(&mut self, prefix: String, window: &mut Window, cx: &mut Context<Self>) {
+        self.active = true;
+        self.prefix = prefix.clone();
+        self.editor.update(cx, |editor, cx| {
+            editor.clear(window, cx);
+            editor.set_text(prefix, window, cx);
+        });
+
+        window.focus(&self.editor.focus_handle(cx));
+        cx.notify();
+    }
+
+    pub fn dismiss(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.active = false;
+        self.prefix.clear();
+        self.editor.update(cx, |editor, cx| {
+            editor.clear(window, cx);
+        });
+
+        if let Some(workspace) = self.workspace.upgrade() {
+            workspace.update(cx, |workspace, cx| {
+                if let Some(active_item) = workspace.active_item(cx) {
+                    window.focus(&active_item.item_focus_handle(cx));
+                }
+            });
+        }
+        cx.notify();
+    }
+
+    fn execute_command(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let full_command = self.editor.read(cx).text(cx);
+
+        self.dismiss(window, cx);
+
+        let results = command_interceptor(&full_command, cx);
+        if let Some(first_result) = results.first() {
+            window.dispatch_action(first_result.action.boxed_clone(), cx);
+        }
+    }
+
+    fn confirm_command(&mut self, _: &ConfirmCommand, window: &mut Window, cx: &mut Context<Self>) {
+        self.execute_command(window, cx);
+    }
+
+    fn cancel(&mut self, _: &Cancel, window: &mut Window, cx: &mut Context<Self>) {
+        self.dismiss(window, cx);
+    }
+}
+
+impl Render for VimCommandLine {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        if !self.active {
+            return div().into_any();
+        }
+
+        let mut key_context = KeyContext::new_with_defaults();
+        key_context.add("VimCommandLine");
+        key_context.add("Editor");
+
+        let theme_colors = cx.theme().colors();
+        let settings = ThemeSettings::get_global(cx);
+        let text_style = TextStyle {
+            color: theme_colors.text,
+            font_family: settings.buffer_font.family.clone(),
+            font_features: settings.buffer_font.features.clone(),
+            font_fallbacks: settings.buffer_font.fallbacks.clone(),
+            font_size: rems(0.875).into(),
+            font_weight: settings.buffer_font.weight,
+            line_height: relative(1.3),
+            ..TextStyle::default()
+        };
+
+        let editor_style = EditorStyle {
+            background: transparent_black(),
+            local_player: cx.theme().players().local(),
+            text: text_style,
+            syntax: cx.theme().syntax().clone(),
+            ..EditorStyle::default()
+        };
+
+        h_flex()
+            .items_center()
+            .key_context(key_context)
+            .child(
+                div().flex_1().min_w(px(200.0)).flex().items_center().child(
+                    div()
+                        .flex_1()
+                        .child(EditorElement::new(&self.editor, editor_style)),
+                ),
+            )
+            .on_action(cx.listener(VimCommandLine::confirm_command))
+            .on_action(cx.listener(VimCommandLine::cancel))
+            .into_any()
+    }
+}
+
+impl Focusable for VimCommandLine {
+    fn focus_handle(&self, cx: &App) -> FocusHandle {
+        self.editor.focus_handle(cx)
+    }
+}
+
+impl StatusItemView for VimCommandLine {
+    fn set_active_pane_item(
+        &mut self,
+        _active_pane_item: Option<&dyn ItemHandle>,
+        _window: &mut Window,
+        _cx: &mut Context<Self>,
+    ) {
+    }
+}

--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -234,6 +234,7 @@ pub struct VimGlobals {
     pub recordings: HashMap<char, Vec<ReplayableAction>>,
 
     pub focused_vim: Option<WeakEntity<Vim>>,
+    pub command_line: Option<WeakEntity<crate::command_line::VimCommandLine>>,
 
     pub marks: HashMap<EntityId, Entity<MarksState>>,
 }

--- a/crates/vim/src/test/vim_test_context.rs
+++ b/crates/vim/src/test/vim_test_context.rs
@@ -106,7 +106,10 @@ impl VimTestContext {
                     toolbar.add_item(project_search_bar, window, cx);
                 })
             });
+            let workspace_weak = workspace.weak_handle();
             workspace.status_bar().update(cx, |status_bar, cx| {
+                let vim_command_line = cx.new(|cx| VimCommandLine::new(workspace_weak, window, cx));
+                status_bar.add_left_item(vim_command_line, window, cx);
                 let vim_mode_indicator = cx.new(|cx| ModeIndicator::new(window, cx));
                 status_bar.add_right_item(vim_mode_indicator, window, cx);
             });

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -5,6 +5,7 @@ mod test;
 
 mod change_list;
 mod command;
+mod command_line;
 mod digraph;
 mod helix;
 mod indent;
@@ -20,6 +21,7 @@ mod surrounds;
 mod visual;
 
 use collections::HashMap;
+pub use command_line::VimCommandLine;
 use editor::{
     Anchor, Bias, Editor, EditorEvent, EditorSettings, HideMouseCursorOrigin, SelectionEffects,
     ToPoint,
@@ -491,7 +493,7 @@ impl Vim {
             (initial_vim_mode, Mode::Normal)
         };
 
-        cx.new(|cx| Vim {
+        let vim = cx.new(|cx| Vim {
             mode,
             last_mode,
             temp_mode: false,
@@ -519,7 +521,9 @@ impl Vim {
                     this.handle_editor_event(event, window, cx)
                 }),
             ],
-        })
+        });
+
+        vim
     }
 
     fn register(editor: &mut Editor, window: Option<&mut Window>, cx: &mut Context<Editor>) {

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -581,6 +581,7 @@ pub fn main() {
         diagnostics::init(cx);
 
         audio::init(cx);
+        vim::init(cx);
         workspace::init(app_state.clone(), cx);
         ui_prompt::init(cx);
 
@@ -595,7 +596,6 @@ pub fn main() {
         snippets_ui::init(cx);
         channel::init(&app_state.client.clone(), app_state.user_store.clone(), cx);
         search::init(cx);
-        vim::init(cx);
         terminal_view::init(cx);
         journal::init(app_state.clone(), cx);
         language_selector::init(cx);

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -400,6 +400,8 @@ pub fn initialize_workspace(
         let active_toolchain_language =
             cx.new(|cx| toolchain_selector::ActiveToolchain::new(workspace, window, cx));
         let vim_mode_indicator = cx.new(|cx| vim::ModeIndicator::new(window, cx));
+        let workspace_weak = cx.entity().downgrade();
+        let vim_command_line = cx.new(|cx| vim::VimCommandLine::new(workspace_weak, window, cx));
         let image_info = cx.new(|_cx| ImageInfo::new(workspace));
 
         let lsp_button_menu_handle = PopoverMenuHandle::default();
@@ -418,6 +420,7 @@ pub fn initialize_workspace(
             status_bar.add_left_item(lsp_button, window, cx);
             status_bar.add_left_item(diagnostic_summary, window, cx);
             status_bar.add_left_item(activity_indicator, window, cx);
+            status_bar.add_left_item(vim_command_line, window, cx);
             status_bar.add_right_item(edit_prediction_button, window, cx);
             status_bar.add_right_item(active_buffer_language, window, cx);
             status_bar.add_right_item(active_toolchain_language, window, cx);


### PR DESCRIPTION
This is as much a proposal as it is a feature request. One thing that has bothered me with zeds vim mode compared to vim proper/vscodevim/ideavim, is that `:` opens the full command palette, covering my editor. 

In an effort to be more out of the way like classic vim, this PR  integrates a vim command line directly into the status bar instead of opening the command palette. When ':' is pressed in normal mode, a command editor appears in the status bar where vim commands can be typed and executed.

This is one of my first real swings at claude code for something real, but I did gently guide and review it with my human eyes.  I'm sure I/Claude did non idomatic things, forgive us.

<img width="1017" height="29" alt="Screenshot 2025-10-05 at 9 22 29 PM" src="https://github.com/user-attachments/assets/b8856f5a-ce5b-4e04-8f62-73d98dccd593" />

Taking a look, I think it would be pretty easy to add basic tab completion, but I wanted to solicit some feedback here first.
