### PR TITLE
gpui: Assert validity of text runs for `StyleText`

### DIFF
--- a/crates/file_finder/src/open_path_prompt.rs
+++ b/crates/file_finder/src/open_path_prompt.rs
@@ -755,7 +755,7 @@ impl PickerDelegate for OpenPathDelegate {
                                     .with_default_highlights(
                                         &window.text_style(),
                                         vec![(
-                                            delta..delta + label_len,
+                                            delta..label_len,
                                             HighlightStyle::color(Color::Conflict.color(cx)),
                                         )],
                                     )
@@ -765,7 +765,7 @@ impl PickerDelegate for OpenPathDelegate {
                                     .with_default_highlights(
                                         &window.text_style(),
                                         vec![(
-                                            delta..delta + label_len,
+                                            delta..label_len,
                                             HighlightStyle::color(Color::Created.color(cx)),
                                         )],
                                     )

--- a/crates/gpui/src/text_system/line_wrapper.rs
+++ b/crates/gpui/src/text_system/line_wrapper.rs
@@ -225,18 +225,14 @@ impl LineWrapper {
 
 fn update_runs_after_truncation(result: &str, ellipsis: &str, runs: &mut Vec<TextRun>) {
     let mut truncate_at = result.len() - ellipsis.len();
-    let mut run_end = None;
     for (run_index, run) in runs.iter_mut().enumerate() {
         if run.len <= truncate_at {
             truncate_at -= run.len;
         } else {
             run.len = truncate_at + ellipsis.len();
-            run_end = Some(run_index + 1);
+            runs.truncate(run_index + 1);
             break;
         }
-    }
-    if let Some(run_end) = run_end {
-        runs.truncate(run_end);
     }
 }
 


### PR DESCRIPTION
Should help with figuring out the char boundary panic in text shaping on windows

Release Notes:

- N/A *or* Added/Fixed/Improved ...
