### PR TITLE
editor: Fix clangd switch source header action failing on wsl

### DIFF
--- a/crates/editor/src/clangd_ext.rs
+++ b/crates/editor/src/clangd_ext.rs
@@ -1,9 +1,10 @@
+use std::path::PathBuf;
+
 use anyhow::Context as _;
 use gpui::{App, Context, Entity, Window};
 use language::Language;
 use project::lsp_store::lsp_ext_command::SwitchSourceHeaderResult;
 use rpc::proto;
-use url::Url;
 use util::paths::PathStyle;
 use workspace::{OpenOptions, OpenVisible};
 
@@ -77,16 +78,17 @@ pub fn switch_source_header(
             return Ok(());
         }
 
-        let goto = Url::parse(&switch_source_header.0).with_context(|| {
-            format!(
-                "Parsing URL \"{}\" returned from switch source/header failed",
-                switch_source_header.0
-            )
-        })?;
+        let goto = switch_source_header
+            .0
+            .strip_prefix("file://")
+            .with_context(|| {
+                format!(
+                    "Parsing file url \"{}\" returned from switch source/header failed",
+                    switch_source_header.0
+                )
+            })?;
 
-        let path = goto
-            .to_file_path()
-            .map_err(|()| anyhow::anyhow!("URL conversion to file path failed for \"{goto}\""))?;
+        let path = PathBuf::from(goto);
 
         workspace
             .update_in(cx, |workspace, window, cx| {


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/39180

Release Notes:

- Fixed clangd switch source header action failing on wsl
