### PR TITLE
Optimize fs_watcher to use less RAM by doing less work

### DIFF
--- a/crates/fs/src/fs_watcher.rs
+++ b/crates/fs/src/fs_watcher.rs
@@ -46,8 +46,6 @@ impl Drop for FsWatcher {
 
 impl Watcher for FsWatcher {
     fn add(&self, path: &std::path::Path) -> anyhow::Result<()> {
-        let root_path = SanitizedPath::new_arc(path);
-
         let tx = self.tx.clone();
         let pending_paths = self.pending_path_events.clone();
 
@@ -63,6 +61,7 @@ impl Watcher for FsWatcher {
             return Ok(());
         }
 
+        let root_path = SanitizedPath::new_arc(path);
         let path: Arc<std::path::Path> = path.into();
 
         let registration_id = global({

--- a/crates/fs/src/fs_watcher.rs
+++ b/crates/fs/src/fs_watcher.rs
@@ -49,61 +49,71 @@ impl Watcher for FsWatcher {
         let tx = self.tx.clone();
         let pending_paths = self.pending_path_events.clone();
 
-        // Return early if an ancestor of this path was already being watched.
-        // saves a huge amount of memory
-        if let Some((watched_path, _)) = self
-            .registrations
-            .lock()
-            .range::<std::path::Path, _>((Bound::Unbounded, Bound::Included(path)))
-            .next_back()
-            && path.starts_with(watched_path.as_ref())
+        #[cfg(target_os = "windows")]
         {
-            return Ok(());
+            // Return early if an ancestor of this path was already being watched.
+            // saves a huge amount of memory
+            if let Some((watched_path, _)) = self
+                .registrations
+                .lock()
+                .range::<std::path::Path, _>((Bound::Unbounded, Bound::Included(path)))
+                .next_back()
+                && path.starts_with(watched_path.as_ref())
+            {
+                return Ok(());
+            }
+        }
+        #[cfg(target_os = "linux")]
+        {
+            if self.registrations.lock().contains_key(path) {
+                return Ok(());
+            }
         }
 
         let root_path = SanitizedPath::new_arc(path);
         let path: Arc<std::path::Path> = path.into();
 
+        #[cfg(target_os = "windows")]
+        let mode = notify::RecursiveMode::Recursive;
+        #[cfg(target_os = "linux")]
+        let mode = notify::RecursiveMode::NonRecursive;
+
         let registration_id = global({
             let path = path.clone();
             |g| {
-                g.add(
-                    path,
-                    notify::RecursiveMode::Recursive,
-                    move |event: &notify::Event| {
-                        let kind = match event.kind {
-                            EventKind::Create(_) => Some(PathEventKind::Created),
-                            EventKind::Modify(_) => Some(PathEventKind::Changed),
-                            EventKind::Remove(_) => Some(PathEventKind::Removed),
-                            _ => None,
-                        };
-                        let mut path_events = event
-                            .paths
-                            .iter()
-                            .filter_map(|event_path| {
-                                let event_path = SanitizedPath::new(event_path);
-                                event_path.starts_with(&root_path).then(|| PathEvent {
-                                    path: event_path.as_path().to_path_buf(),
-                                    kind,
-                                })
+                g.add(path, mode, move |event: &notify::Event| {
+                    let kind = match event.kind {
+                        EventKind::Create(_) => Some(PathEventKind::Created),
+                        EventKind::Modify(_) => Some(PathEventKind::Changed),
+                        EventKind::Remove(_) => Some(PathEventKind::Removed),
+                        _ => None,
+                    };
+                    let mut path_events = event
+                        .paths
+                        .iter()
+                        .filter_map(|event_path| {
+                            let event_path = SanitizedPath::new(event_path);
+                            event_path.starts_with(&root_path).then(|| PathEvent {
+                                path: event_path.as_path().to_path_buf(),
+                                kind,
                             })
-                            .collect::<Vec<_>>();
+                        })
+                        .collect::<Vec<_>>();
 
-                        if !path_events.is_empty() {
-                            path_events.sort();
-                            let mut pending_paths = pending_paths.lock();
-                            if pending_paths.is_empty() {
-                                tx.try_send(()).ok();
-                            }
-                            util::extend_sorted(
-                                &mut *pending_paths,
-                                path_events,
-                                usize::MAX,
-                                |a, b| a.path.cmp(&b.path),
-                            );
+                    if !path_events.is_empty() {
+                        path_events.sort();
+                        let mut pending_paths = pending_paths.lock();
+                        if pending_paths.is_empty() {
+                            tx.try_send(()).ok();
                         }
-                    },
-                )
+                        util::extend_sorted(
+                            &mut *pending_paths,
+                            path_events,
+                            usize::MAX,
+                            |a, b| a.path.cmp(&b.path),
+                        );
+                    }
+                })
             }
         })??;
 

--- a/crates/fs/src/fs_watcher.rs
+++ b/crates/fs/src/fs_watcher.rs
@@ -2,7 +2,7 @@ use notify::EventKind;
 use parking_lot::Mutex;
 use std::{
     collections::{BTreeMap, HashMap},
-    ops::{Bound, DerefMut},
+    ops::DerefMut,
     sync::{Arc, OnceLock},
 };
 use util::{ResultExt, paths::SanitizedPath};
@@ -56,7 +56,10 @@ impl Watcher for FsWatcher {
             if let Some((watched_path, _)) = self
                 .registrations
                 .lock()
-                .range::<std::path::Path, _>((Bound::Unbounded, Bound::Included(path)))
+                .range::<std::path::Path, _>((
+                    std::ops::Bound::Unbounded,
+                    std::ops::Bound::Included(path),
+                ))
                 .next_back()
                 && path.starts_with(watched_path.as_ref())
             {


### PR DESCRIPTION
mac_watcher already does this so it would make more sense to also do this on Windows and it saves ~500-600mb of ram on the chromium project.

This does not improve memory usage on linux because inotify cannot do recursive directory monitoring

Release Notes:

- N/A