### PR TITLE
extensions_ui: Fix uneven horizontal padding

### DIFF
--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -1503,39 +1503,28 @@ impl Render for ExtensionsPage {
                     })),
             )
             .child(self.render_feature_upsells(cx))
-            .child(
-                v_flex()
-                    .pl_4()
-                    .pr_6()
-                    .size_full()
-                    .overflow_y_hidden()
-                    .map(|this| {
-                        let mut count = self.filtered_remote_extension_indices.len();
-                        if self.filter.include_dev_extensions() {
-                            count += self.dev_extension_entries.len();
-                        }
+            .child(v_flex().px_4().size_full().overflow_y_hidden().map(|this| {
+                let mut count = self.filtered_remote_extension_indices.len();
+                if self.filter.include_dev_extensions() {
+                    count += self.dev_extension_entries.len();
+                }
 
-                        if count == 0 {
-                            this.py_4()
-                                .child(self.render_empty_state(cx))
-                                .into_any_element()
-                        } else {
-                            let scroll_handle = self.list.clone();
-                            this.child(
-                                uniform_list(
-                                    "entries",
-                                    count,
-                                    cx.processor(Self::render_extensions),
-                                )
-                                .flex_grow()
-                                .pb_4()
-                                .track_scroll(scroll_handle.clone()),
-                            )
-                            .vertical_scrollbar_for(scroll_handle, window, cx)
-                            .into_any_element()
-                        }
-                    }),
-            )
+                if count == 0 {
+                    this.py_4()
+                        .child(self.render_empty_state(cx))
+                        .into_any_element()
+                } else {
+                    let scroll_handle = self.list.clone();
+                    this.child(
+                        uniform_list("entries", count, cx.processor(Self::render_extensions))
+                            .flex_grow()
+                            .pb_4()
+                            .track_scroll(scroll_handle.clone()),
+                    )
+                    .vertical_scrollbar_for(scroll_handle, window, cx)
+                    .into_any_element()
+                }
+            }))
     }
 }
 


### PR DESCRIPTION
This fixes an issue where the horizontal padding on the extensions page was uneven and where the padding on the right side would be much larger.

| Before | After |
| --- | --- |
| <img width="2550" height="1694" alt="Bildschirmfoto 2025-10-06 um 19 26 56" src="https://github.com/user-attachments/assets/cf05b77b-4a9e-4ad9-8fa7-381f9b6b45af" /> | <img width="2546" height="1694" alt="Bildschirmfoto 2025-10-06 um 19 25 49" src="https://github.com/user-attachments/assets/493ba188-534a-4e7a-b2c1-2b1380be7150" /> |

Release Notes:

- Improved the horizontal padding on the extensions tab.