### PR TITLE
node_runtime: Bump minimum version for system node to match copilot's requirement

### DIFF
--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -613,7 +613,7 @@ pub struct SystemNodeRuntime {
 }
 
 impl SystemNodeRuntime {
-    const MIN_VERSION: semver::Version = Version::new(20, 0, 0);
+    const MIN_VERSION: semver::Version = Version::new(22, 0, 0);
     async fn new(node: PathBuf, npm: PathBuf) -> Result<Self> {
         let output = util::command::new_smol_command(&node)
             .arg("--version")


### PR DESCRIPTION
Copilot now requires 22.x. See the last min node version bump: https://github.com/zed-industries/zed/pull/27912

Closes #39461

<img width="1040" height="97" alt="image" src="https://github.com/user-attachments/assets/8f0490e3-b9b5-45fd-b7f1-321691b862f0" />

Release Notes:

- Zed will no longer use `node` from your `$PATH` if it's older than 22.x (previously, the minimum version was 20.x). Instead, it will fall back to its bundled `node`. This fixes being unable to use Copilot if an older `node` was installed system-wide.