### PR TITLE
settings ui: Move selected nav bar entry on scroll

### DIFF
--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -1095,7 +1095,7 @@ impl SettingsWindow {
                                                         .map(|pair| pair.0)
                                                     {
                                                         this.scroll_handle
-                                                            .scroll_to_item(section_index);
+                                                            .scroll_to_top_of_item(section_index);
                                                     }
                                                 }
 

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -944,7 +944,11 @@ impl SettingsWindow {
     }
 
     fn calculate_navbar_entry_from_scroll_position(&mut self) {
-        let scroll_index = self.scroll_handle.logical_scroll_top().0;
+        let top = self.scroll_handle.top_item();
+        let bottom = self.scroll_handle.bottom_item();
+
+        let scroll_index = (top + bottom) / 2;
+        let scroll_index = scroll_index.clamp(top, bottom);
         let mut page_index = self.navbar_entry;
 
         while !self.navbar_entries[page_index].is_root {

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -943,6 +943,25 @@ impl SettingsWindow {
         cx.notify();
     }
 
+    fn calculate_navbar_entry_from_scroll_position(&mut self) {
+        let scroll_index = self.scroll_handle.logical_scroll_top().0;
+        let mut page_index = self.navbar_entry;
+
+        while !self.navbar_entries[page_index].is_root {
+            page_index -= 1;
+        }
+
+        if self.navbar_entries[page_index].expanded {
+            let section_index = self
+                .page_items()
+                .take(scroll_index + 1)
+                .filter(|item| matches!(item, SettingsPageItem::SectionHeader(_)))
+                .count();
+
+            self.navbar_entry = section_index + page_index;
+        }
+    }
+
     fn fetch_files(&mut self, cx: &mut Context<SettingsWindow>) {
         let prev_files = self.files.clone();
         let settings_store = cx.global::<SettingsStore>();
@@ -1365,23 +1384,7 @@ impl SettingsWindow {
 impl Render for SettingsWindow {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let ui_font = theme::setup_ui_font(window, cx);
-
-        let scroll_index = self.scroll_handle.logical_scroll_top().0;
-        let mut page_index = self.navbar_entry;
-
-        while !self.navbar_entries[page_index].is_root {
-            page_index -= 1;
-        }
-
-        if self.navbar_entries[page_index].expanded {
-            let section_index = self
-                .page_items()
-                .take(scroll_index + 1)
-                .filter(|item| matches!(item, SettingsPageItem::SectionHeader(_)))
-                .count();
-
-            self.navbar_entry = section_index + page_index;
-        }
+        self.calculate_navbar_entry_from_scroll_position();
 
         div()
             .id("settings-window")

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -1021,9 +1021,7 @@ impl SettingsWindow {
         window: &mut Window,
         cx: &mut Context<SettingsWindow>,
     ) -> impl IntoElement {
-        let visible_entries: Vec<_> = self.visible_navbar_entries().collect();
-        let visible_count = visible_entries.len();
-
+        let visible_count = self.visible_navbar_entries().count();
         let nav_background = cx.theme().colors().panel_background;
 
         v_flex()
@@ -1193,26 +1191,7 @@ impl SettingsWindow {
             .size_full()
             .gap_4()
             .overflow_y_scroll()
-            .track_scroll(&self.scroll_handle)
-            .on_scroll_wheel(cx.listener(move |this, _, _, _| {
-                let scroll_index = this.scroll_handle.logical_scroll_top().0;
-
-                let mut page_index = this.navbar_entry;
-
-                while !this.navbar_entries[page_index].is_root {
-                    page_index -= 1;
-                }
-
-                if this.navbar_entries[page_index].expanded {
-                    let section_index = this
-                        .page_items()
-                        .take(scroll_index + 1)
-                        .filter(|item| matches!(item, SettingsPageItem::SectionHeader(_)))
-                        .count();
-
-                    this.navbar_entry = section_index + page_index;
-                }
-            }));
+            .track_scroll(&self.scroll_handle);
 
         let items: Vec<_> = items.collect();
         let items_len = items.len();
@@ -1386,6 +1365,23 @@ impl SettingsWindow {
 impl Render for SettingsWindow {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let ui_font = theme::setup_ui_font(window, cx);
+
+        let scroll_index = self.scroll_handle.logical_scroll_top().0;
+        let mut page_index = self.navbar_entry;
+
+        while !self.navbar_entries[page_index].is_root {
+            page_index -= 1;
+        }
+
+        if self.navbar_entries[page_index].expanded {
+            let section_index = self
+                .page_items()
+                .take(scroll_index + 1)
+                .filter(|item| matches!(item, SettingsPageItem::SectionHeader(_)))
+                .count();
+
+            self.navbar_entry = section_index + page_index;
+        }
 
         div()
             .id("settings-window")


### PR DESCRIPTION
This PR makes selecting a sub-entry in the settings UI nav bar scroll to that section in the settings page. It also updates the selected sub-entry when scrolling through a settings page to match what a user is viewing on the page. 

I also added a new helper method to `ScrollHandle` type called `scroll_to_top_of_item` that scrolls until an item is the top element visible. 

Release Notes:

- N/A
