### PR TITLE
ci: Show output of failed tests at the end too

### DIFF
--- a/.github/actions/run_tests/action.yml
+++ b/.github/actions/run_tests/action.yml
@@ -20,4 +20,4 @@ runs:
 
     - name: Run tests
       shell: bash -euxo pipefail {0}
-      run: cargo nextest run --workspace --no-fail-fast
+      run: cargo nextest run --workspace --no-fail-fast --failure-output immediate-final

--- a/.github/actions/run_tests_windows/action.yml
+++ b/.github/actions/run_tests_windows/action.yml
@@ -24,4 +24,4 @@ runs:
       shell: powershell
       working-directory: ${{ inputs.working-directory }}
       run: |
-        cargo nextest run --workspace --no-fail-fast
+        cargo nextest run --workspace --no-fail-fast --failure-output immediate-final


### PR DESCRIPTION
This makes it a bit easier to read GHA logs of failed CI runs.

Release Notes:

- N/A