### PR TITLE
Don't construct an agent panel when `disable_ai` is set

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1748,6 +1748,19 @@ impl Workspace {
         });
     }
 
+    pub fn remove_panel<T: Panel>(
+        &mut self,
+        panel: &Entity<T>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        for dock in [&self.left_dock, &self.bottom_dock, &self.right_dock] {
+            dock.update(cx, |dock, cx| {
+                dock.remove_panel(panel, window, cx);
+            })
+        }
+    }
+
     pub fn status_bar(&self) -> &Entity<StatusBar> {
         &self.status_bar
     }


### PR DESCRIPTION
Follow-up to #39649, possible fix for #39669

This implements an alternate strategy for showing/hiding the agent panel in response to `disable_ai`. We don't load the panel at all if AI is disabled at startup, and when the value of `disable_ai` changes, we load the panel or destroy it as needed.

Release Notes:

- N/A