### PR TITLE
inspector_ui: Align with title bar, other visual tweaks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8027,6 +8027,7 @@ dependencies = [
  "serde_json",
  "serde_json_lenient",
  "theme",
+ "title_bar",
  "ui",
  "workspace",
  "workspace-hack",

--- a/crates/inspector_ui/Cargo.toml
+++ b/crates/inspector_ui/Cargo.toml
@@ -22,6 +22,7 @@ project.workspace = true
 serde_json.workspace = true
 serde_json_lenient.workspace = true
 theme.workspace = true
+title_bar.workspace = true
 ui.workspace = true
 util.workspace = true
 util_macros.workspace = true


### PR DESCRIPTION
# How

Few tweaks for the GPUI Inspector panel, including toolbar align with title bar, buffer font for source link, few other layout, spacing and wording tweaks.

Release Notes:

- N/A

# Preview

### Before

<img width="1286" height="602" alt="Screenshot 2025-10-07 at 19 33 20" src="https://github.com/user-attachments/assets/515ddcdf-a2c8-4f5f-b37e-b1668df2147f" />

### After

<img width="1286" height="542" alt="Screenshot 2025-10-07 at 19 09 24" src="https://github.com/user-attachments/assets/3a777974-3427-4545-afda-37fabcb012ba" />
