### PR TITLE
inspector_ui: Split out size from bounds string

### DIFF
--- a/crates/inspector_ui/src/div_inspector.rs
+++ b/crates/inspector_ui/src/div_inspector.rs
@@ -576,7 +576,12 @@ fn render_layout_state(inspector_state: &DivInspectorState, cx: &App) -> Div {
         .child(
             div()
                 .text_ui(cx)
-                .child(format!("Bounds: {}", inspector_state.bounds)),
+                .child(format!(
+                    "Bounds: ⌜{} - {}⌟",
+                    inspector_state.bounds.origin,
+                    inspector_state.bounds.bottom_right()
+                ))
+                .child(format!("Size: {}", inspector_state.bounds.size)),
         )
         .child(
             div()


### PR DESCRIPTION
# How

Tweak the way in which inspected element bounds and size are printed to improved readability of GPUI Inspector data.

> [!note]
> It looks like the only place in the workspace where bounds are used within formatted print is GPUI Inspector panel, but I decided to do not alter [GPUI `geometry.rs` default format](https://github.com/zed-industries/zed/blob/a7e7f460205bc6eaa397f20c1bcf8c4105d93403/crates/gpui/src/geometry.rs#L1579-L1587), since adding multiline output and additional labels in there does not feel like the beast approach, but maybe I'm wrong?

Release Notes:

- N/A

# Preview

<img width="1168" height="224" alt="Screenshot 2025-10-07 at 20 08 35" src="https://github.com/user-attachments/assets/97753fc1-68d7-4cf8-ad92-afe85319f3d8" />

<img width="1168" height="228" alt="Screenshot 2025-10-07 at 20 09 24" src="https://github.com/user-attachments/assets/beed2a92-0817-4ed2-bb62-4d7b931e8709" />
