### PR TITLE
Revert "gpui: Assert validity of text runs for `StyleText`"

### DIFF
--- a/crates/file_finder/src/open_path_prompt.rs
+++ b/crates/file_finder/src/open_path_prompt.rs
@@ -755,7 +755,7 @@ impl PickerDelegate for OpenPathDelegate {
                                     .with_default_highlights(
                                         &window.text_style(),
                                         vec![(
-                                            delta..label_len,
+                                            delta..delta + label_len,
                                             HighlightStyle::color(Color::Conflict.color(cx)),
                                         )],
                                     )
@@ -765,7 +765,7 @@ impl PickerDelegate for OpenPathDelegate {
                                     .with_default_highlights(
                                         &window.text_style(),
                                         vec![(
-                                            delta..label_len,
+                                            delta..delta + label_len,
                                             HighlightStyle::color(Color::Created.color(cx)),
                                         )],
                                     )

--- a/crates/gpui/src/elements/text.rs
+++ b/crates/gpui/src/elements/text.rs
@@ -180,7 +180,8 @@ impl StyledText {
             "Can't use `with_default_highlights` and `with_highlights`"
         );
         let runs = Self::compute_runs(&self.text, default_style, highlights);
-        self.with_runs(runs)
+        self.runs = Some(runs);
+        self
     }
 
     /// Set the styling attributes for the given text, as well as
@@ -193,15 +194,7 @@ impl StyledText {
             self.runs.is_none(),
             "Can't use `with_highlights` and `with_default_highlights`"
         );
-        self.delayed_highlights = Some(
-            highlights
-                .into_iter()
-                .inspect(|(run, _)| {
-                    debug_assert!(self.text.is_char_boundary(run.start));
-                    debug_assert!(self.text.is_char_boundary(run.end));
-                })
-                .collect::<Vec<_>>(),
-        );
+        self.delayed_highlights = Some(highlights.into_iter().collect::<Vec<_>>());
         self
     }
 
@@ -214,10 +207,8 @@ impl StyledText {
         let mut ix = 0;
         for (range, highlight) in highlights {
             if ix < range.start {
-                debug_assert!(text.is_char_boundary(range.start));
                 runs.push(default_style.clone().to_run(range.start - ix));
             }
-            debug_assert!(text.is_char_boundary(range.end));
             runs.push(
                 default_style
                     .clone()
@@ -234,11 +225,6 @@ impl StyledText {
 
     /// Set the text runs for this piece of text.
     pub fn with_runs(mut self, runs: Vec<TextRun>) -> Self {
-        let mut text = &**self.text;
-        for run in &runs {
-            text = text.get(run.len..).expect("invalid text run");
-        }
-        assert!(text.is_empty(), "invalid text run");
         self.runs = Some(runs);
         self
     }

--- a/crates/gpui/src/text_system/line_wrapper.rs
+++ b/crates/gpui/src/text_system/line_wrapper.rs
@@ -225,14 +225,18 @@ impl LineWrapper {
 
 fn update_runs_after_truncation(result: &str, ellipsis: &str, runs: &mut Vec<TextRun>) {
     let mut truncate_at = result.len() - ellipsis.len();
+    let mut run_end = None;
     for (run_index, run) in runs.iter_mut().enumerate() {
         if run.len <= truncate_at {
             truncate_at -= run.len;
         } else {
             run.len = truncate_at + ellipsis.len();
-            runs.truncate(run_index + 1);
+            run_end = Some(run_index + 1);
             break;
         }
+    }
+    if let Some(run_end) = run_end {
+        runs.truncate(run_end);
     }
 }
 


### PR DESCRIPTION
Reverts zed-industries/zed#39581

This has done its job uncovering incorrect constructions of the highlight ranges pretty fast. Reverting this to prevent this from spilling into preview until I can fix the call sites next week