### PR TITLE
languages: Add comment injections for Rust

### DIFF
--- a/crates/languages/src/rust/injections.scm
+++ b/crates/languages/src/rust/injections.scm
@@ -1,3 +1,6 @@
+((line_comment) @injection.content
+    (#set! injection.language "comment"))
+
 (macro_invocation
     macro: (identifier) @_macro_name
     (#not-any-of? @_macro_name "view" "html")


### PR DESCRIPTION
This PR adds comment injections for Rust.

Release Notes:

- Rust: Added comment injections.
