### PR TITLE
project_panel: Fix clicking away to create file or directory doesn't create it

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -643,9 +643,17 @@ impl ProjectPanel {
                             .as_ref()
                             .is_some_and(|state| state.processing_filename.is_none())
                         {
-                            project_panel.state.edit_state = None;
-                            project_panel.update_visible_entries(None, false, false, window, cx);
-                            cx.notify();
+                            match project_panel.confirm_edit(window, cx) {
+                                Some(task) => {
+                                    task.detach_and_notify_err(window, cx);
+                                }
+                                None => {
+                                    project_panel.state.edit_state = None;
+                                    project_panel
+                                        .update_visible_entries(None, false, false, window, cx);
+                                    cx.notify();
+                                }
+                            }
                         }
                     }
                     _ => {}


### PR DESCRIPTION
Closes #38919

Now, when unfocusing the filename editor while creating a file or directory in the project panel, it will create it by default unless the name is empty or already exists.

Release Notes:

- Improved behavior where unfocusing while creating a new file or directory in the project panel now creates it instead of discarding it.
