### PR TITLE
Update doc comments for `agent_buffer_font_size`

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -76,7 +76,7 @@
   "ui_font_size": 16,
   // The default font size for agent responses in the agent panel. Falls back to the UI font size if unset.
   "agent_ui_font_size": null,
-  // The default font size for user messages in the agent panel. Falls back to the buffer font size if unset.
+  // The default font size for user messages in the agent panel.
   "agent_buffer_font_size": 12,
   // How much to fade out unused code.
   "unnecessary_code_fade": 0.3,

--- a/crates/settings/src/settings_content/theme.rs
+++ b/crates/settings/src/settings_content/theme.rs
@@ -57,7 +57,7 @@ pub struct ThemeSettingsContent {
     /// The font size for agent responses in the agent panel. Falls back to the UI font size if unset.
     #[serde(default)]
     pub agent_ui_font_size: Option<f32>,
-    /// The font size for user messages in the agent panel. Falls back to the buffer font size if unset.
+    /// The font size for user messages in the agent panel.
     #[serde(default)]
     pub agent_buffer_font_size: Option<f32>,
     /// The name of the Zed theme to use.

--- a/crates/theme/src/settings.rs
+++ b/crates/theme/src/settings.rs
@@ -116,7 +116,7 @@ pub struct ThemeSettings {
     pub buffer_font: Font,
     /// The agent font size. Determines the size of text in the agent panel. Falls back to the UI font size if unset.
     agent_ui_font_size: Option<Pixels>,
-    /// The agent buffer font size. Determines the size of user messages in the agent panel. Falls back to the buffer font size if unset.
+    /// The agent buffer font size. Determines the size of user messages in the agent panel.
     agent_buffer_font_size: Option<Pixels>,
     /// The line height for buffers, and the terminal.
     ///
@@ -549,7 +549,7 @@ impl ThemeSettings {
             .unwrap_or_else(|| self.ui_font_size(cx))
     }
 
-    /// Returns the agent panel buffer font size. Falls back to the buffer font size if unset.
+    /// Returns the agent panel buffer font size.
     pub fn agent_buffer_font_size(&self, cx: &App) -> Pixels {
         cx.try_global::<AgentFontSize>()
             .map(|size| size.0)


### PR DESCRIPTION
Follow up to https://github.com/zed-industries/zed/pull/39468.

Unlike `agent_ui_font_size`, the `agent_buffer_font_size` setting does have a default value, which means it does not fall back to the regular UI font size, but rather to its default value.

Release Notes:

- N/A
