### PR TITLE
agent2: Fix `test_save_load_thread` for Windows paths

### DIFF
--- a/crates/agent2/src/agent.rs
+++ b/crates/agent2/src/agent.rs
@@ -1418,7 +1418,6 @@ mod tests {
     }
 
     #[gpui::test]
-    #[cfg_attr(target_os = "windows", ignore)] // TODO: Fix this test on Windows
     async fn test_save_load_thread(cx: &mut TestAppContext) {
         init_test(cx);
         let fs = FakeFs::new(cx.executor());
@@ -1498,7 +1497,8 @@ mod tests {
         model.send_last_completion_stream_text_chunk("Lorem.");
         model.end_last_completion_stream();
         cx.run_until_parked();
-        summary_model.send_last_completion_stream_text_chunk("Explaining /a/b.md");
+        summary_model
+            .send_last_completion_stream_text_chunk(&format!("Explaining {}", path!("/a/b.md")));
         summary_model.end_last_completion_stream();
 
         send.await.unwrap();
@@ -1538,7 +1538,7 @@ mod tests {
             history_entries(&history_store, cx),
             vec![(
                 HistoryEntryId::AcpThread(session_id.clone()),
-                "Explaining /a/b.md".into()
+                format!("Explaining {}", path!("/a/b.md"))
             )]
         );
         let acp_thread = agent


### PR DESCRIPTION
Use path! macro for platform-specific path formatting in test assertions, fixing hardcoded Unix-style paths that failed on Windows.

Release Notes:

- N/A