### PR TITLE
language_model: Add image decoding support for BMP and TIFF image formats

### DIFF
--- a/crates/language_model/src/request.rs
+++ b/crates/language_model/src/request.rs
@@ -99,6 +99,10 @@ impl LanguageModelImage {
                     .and_then(image::DynamicImage::from_decoder),
                 ImageFormat::Gif => image::codecs::gif::GifDecoder::new(image_bytes)
                     .and_then(image::DynamicImage::from_decoder),
+                ImageFormat::Bmp => image::codecs::bmp::BmpDecoder::new(image_bytes)
+                    .and_then(image::DynamicImage::from_decoder),
+                ImageFormat::Tiff => image::codecs::tiff::TiffDecoder::new(image_bytes)
+                    .and_then(image::DynamicImage::from_decoder),
                 _ => return None,
             }
             .log_err()?;


### PR DESCRIPTION
Related: #39745

Release Notes:

- Added support for pasting TIFF and BMP images in the agent panel.
