### PR TITLE
windows: Do not exit from app in dev builds when cli is not found

### DIFF
--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -224,7 +224,9 @@ pub fn main() {
         Ok(path) => askpass::set_askpass_program(path),
         Err(err) => {
             eprintln!("Error: {}", err);
-            process::exit(1);
+            if std::option_env!("ZED_BUNDLE").is_some() {
+                process::exit(1);
+            }
         }
     }
 


### PR DESCRIPTION
Release Notes:

- N/A
