### PR TITLE
Context memory tools: Add memory and list_history tools with minimal docs + integration tests

### DIFF
--- a/TESTING_MEMORY_AND_HISTORY.md
+++ b/TESTING_MEMORY_AND_HISTORY.md
@@ -1,0 +1,593 @@
+# TESTING_MEMORY_AND_HISTORY.md
+
+Comprehensive test suite specification for validating the behavior and robustness of the `memory` and `list_history` tools via an LLM. This document is intended to be executed mentally or by a harness that:
+1. Preloads a deterministic conversation (seed history).
+2. Executes tool calls in a defined order.
+3. Asserts structural and semantic correctness of responses and state transitions.
+
+---
+
+## 1. Scope & Goals
+
+Covers:
+- All `memory` operations: store, load, list, prune, restore.
+- Every argument of `memory` (including edge combinations).
+- All `list_history` arguments and behaviors (pagination, truncation, full markdown inclusion).
+- State transition validation (before / after store, prune, restore).
+- Negative and edge cases (empty summaries, overlapping prune indices, invalid handles).
+- Repeatability guidelines and acceptance criteria patterns.
+
+Not Covered (out of scope):
+- Underlying persistence engine durability guarantees.
+- Performance, latency benchmarks.
+- Cross-session memory carryover.
+
+---
+
+## 2. Seed Conversation History (Precondition)
+
+The following conversation MUST exist (indexes are implicit in chronological order). Message roles (User / Assistant / System) are included so an evaluator can map them if the environment categorizes messages.
+
+Seed messages (indexes 0..14):
+
+| Idx | Role      | Content (abridged description) |
+|-----|-----------|--------------------------------|
+| 0   | System    | "You are a coding assistant specializing in Rust and clarity." |
+| 1   | User      | "Hi, I want help building a GPUI view. Prefer no unwraps." |
+| 2   | Assistant | Provides GPUI intro, emphasizes error propagation with '?' |
+| 3   | User      | "Track my preferences: Rust clarity, avoid panics, descriptive names." |
+| 4   | Assistant | Acknowledges preferences; suggests entity patterns. |
+| 5   | User      | "What about concurrency? Spawn vs background_spawn examples please." |
+| 6   | Assistant | Explains spawn on foreground vs background_spawn for heavy work. |
+| 7   | User      | "Add: I also prefer minimal allocations. Include that in memory." |
+| 8   | Assistant | Confirms adding 'minimal allocations' to preferences. |
+| 9   | User      | "Show an entity update pattern with shadow cloning." |
+| 10  | Assistant | Provides example using variable shadowing. |
+| 11  | User      | "Later I might switch to performance focus." |
+| 12  | Assistant | Notes potential future shift to performance. |
+| 13  | User      | "Summarize my current constraints." |
+| 14  | Assistant | Summarizes: clarity > performance (for now), no unwraps, minimal allocations, descriptive names. |
+
+All tests assume this conversation is present when `list_history` initial calls occur unless a test explicitly manipulates indexes via pruning operations (which do NOT actually change the historic transcript, only memory summaries).
+
+---
+
+## 3. Tool Argument Reference
+
+### 3.1 memory
+
+| Argument                 | Type       | Required | Notes |
+|--------------------------|------------|---------|-------|
+| operation                | enum       | Yes     | store | load | list | restore | prune |
+| summary                  | string     | store   | Required when operation=store (non-empty recommended) |
+| memory_handle            | string     | prune/restore optional | Identifier of previously stored entry |
+| auto                     | bool       | Optional| Hint for auto summarization (if supported) |
+| start_index              | int/null   | Optional| For range-based prune (inclusive) |
+| end_index                | int/null   | Optional| For range-based prune (exclusive or inclusive depending on implementation; assume exclusive if unspecified) |
+| restore_insert_index     | int/null   | Optional| Target position when restoring |
+| max_preview_chars        | int        | Optional| Affects list preview truncation |
+| remove_placeholder       | bool       | Optional| When restoring after placeholder usage |
+| replace_placeholder_with | string     | Optional| Replacement text for placeholder |
+| summary (empty)          | string     | Bad case| Should yield validation or no-op test |
+| auto + summary           | both       | Allowed | Tests precedence rules |
+
+### 3.2 list_history
+
+| Argument              | Type   | Required | Effect |
+|-----------------------|--------|---------|--------|
+| start                 | int    | No      | Default 0 |
+| limit                 | int    | No      | Default 40 |
+| max_chars_per_message | int    | No      | Truncation of each message |
+| include_full_markdown | bool   | No      | Append full text after table-style listing |
+
+---
+
+## 4. Test Case Matrix (High-Level)
+
+| ID  | Category          | Purpose |
+|-----|-------------------|---------|
+| H01 | list_history basic | Baseline retrieval |
+| H02 | list_history pagination | Non-zero start offset |
+| H03 | list_history truncation | Verify `max_chars_per_message` |
+| H04 | list_history full markdown | Verify full markdown inclusion |
+| M01 | memory store basic | Store first canonical summary |
+| M02 | memory list after store | Confirm handle & truncated preview |
+| M03 | memory load basic | Retrieve stored summary |
+| M04 | memory store second | Store an updated/refined summary |
+| M05 | memory list multiple | Confirm ordering and multiple handles |
+| M06 | memory prune by handle | Remove one summary by handle |
+| M07 | memory restore by handle | Restore pruned summary at default position |
+| M08 | memory prune by index range | Range removal when multiple entries exist |
+| M09 | memory restore with insert index | Insert at explicit position |
+| M10 | memory store with auto=true | Validate coexistence of manual + auto |
+| M11 | memory list with max_preview_chars | Request small preview size |
+| M12 | memory prune non-existent handle | Negative: expect error or empty effect |
+| M13 | memory store empty summary | Negative: expect rejection |
+| M14 | memory restore with placeholder replacement | Validate replace & remove flags |
+| M15 | memory prune partial indices overlapping | Edge overlap behavior |
+| M16 | memory load after sequence | Final integrity snapshot |
+
+---
+
+## 5. Detailed Test Specifications
+
+Each test includes: Preconditions, Invocation, Expected Structural Output Pattern, Postconditions.
+
+### H01: list_history basic
+Preconditions: Seed conversation loaded.
+Invocation:
+```/dev/null/h01_list_history.json#L1-6
+{
+  "name": "list_history",
+  "arguments": {
+    "limit": 5
+  }
+}
+```
+Assertions:
+- Returns 5 messages (indexes 0..4).
+- Column metadata includes indices stabilizing future pagination.
+Postconditions: None.
+
+### H02: list_history pagination
+Invocation:
+```/dev/null/h02_list_history.json#L1-7
+{
+  "name": "list_history",
+  "arguments": {
+    "start": 5,
+    "limit": 4
+  }
+}
+```
+Assertions:
+- Messages 5..8 included.
+- Indices match seed mapping.
+
+### H03: list_history truncation
+Invocation:
+```/dev/null/h03_list_history.json#L1-8
+{
+  "name": "list_history",
+  "arguments": {
+    "limit": 3,
+    "max_chars_per_message": 30
+  }
+}
+```
+Assertions:
+- Each preview length ≤ 30 chars (no mid-grapheme split if system supports).
+- Ellipsis or truncation indicator allowed.
+
+### H04: list_history full markdown
+Invocation:
+```/dev/null/h04_list_history.json#L1-7
+{
+  "name": "list_history",
+  "arguments": {
+    "limit": 2,
+    "include_full_markdown": true
+  }
+}
+```
+Assertions:
+- Table or structured list first, followed by full raw content for those 2 messages.
+
+---
+
+### M01: memory store basic
+Preconditions: No memory entries yet.
+Invocation:
+```/dev/null/m01_memory_store.json#L1-9
+{
+  "name": "memory",
+  "arguments": {
+    "operation": "store",
+    "summary": "User prefers: Rust clarity > performance for now; avoid unwrap; descriptive names; minimal allocations emerging."
+  }
+}
+```
+Assertions:
+- Response includes generated memory_handle (string, non-empty).
+- No errors.
+Postconditions: Memory contains 1 entry.
+
+### M02: memory list after store
+Invocation:
+```/dev/null/m02_memory_list.json#L1-6
+{
+  "name": "memory",
+  "arguments": { "operation": "list" }
+}
+```
+Assertions:
+- Entry count = 1.
+- Preview matches prefix of stored summary.
+- Fields possibly: handle, created_at/updated_at (if system includes metadata).
+Capture handle as H1 for future tests.
+
+### M03: memory load basic
+Invocation:
+```/dev/null/m03_memory_load.json#L1-6
+{
+  "name": "memory",
+  "arguments": { "operation": "load" }
+}
+```
+Assertions:
+- Full text includes "Rust clarity > performance".
+- No duplication artifacts.
+
+### M04: memory store second (refined)
+Invocation:
+```/dev/null/m04_memory_store_second.json#L1-11
+{
+  "name": "memory",
+  "arguments": {
+    "operation": "store",
+    "summary": "Consolidated: Clarity-first; avoid panics; minimal allocations; descriptive variable names; may later shift performance focus."
+  }
+}
+```
+Postconditions: Memory now has 2 entries (H1 original, H2 new). Capture handle H2.
+
+### M05: memory list multiple
+Invocation:
+```/dev/null/m05_memory_list.json#L1-6
+{
+  "name": "memory",
+  "arguments": { "operation": "list" }
+}
+```
+Assertions:
+- Count = 2.
+- Ordering: Implementation-defined (document expectation). EXPECTATION: chronological (H1 then H2).
+- Previews truncated appropriately (default truncation length if any).
+
+### M06: memory prune by handle
+Invocation (prune H1):
+```/dev/null/m06_memory_prune_handle.json#L1-9
+{
+  "name": "memory",
+  "arguments": {
+    "operation": "prune",
+    "memory_handle": "H1"
+  }
+}
+```
+Assertions:
+- Confirmation of removal (boolean true or absence in subsequent list).
+Postconditions: Only H2 remains.
+
+### M07: memory restore by handle
+Invocation:
+```/dev/null/m07_memory_restore_handle.json#L1-10
+{
+  "name": "memory",
+  "arguments": {
+    "operation": "restore",
+    "memory_handle": "H1"
+  }
+}
+```
+Assertions:
+- H1 reappears.
+- If ordering modified, document expectation (EXPECTATION: appended at end unless restore_insert_index used).
+Postconditions: Entries H2 + restored H1' (maybe new handle or same). Capture new handle as H1R if changed.
+
+### M08: memory prune by index range
+Preconditions: At least 2 entries (H2, H1R).
+Invocation (remove the first of the current ordered list):
+```/dev/null/m08_memory_prune_range.json#L1-11
+{
+  "name": "memory",
+  "arguments": {
+    "operation": "prune",
+    "start_index": 0,
+    "end_index": 1
+  }
+}
+```
+Assertions:
+- Entry count decremented by 1.
+- The targeted index removed.
+Postconditions: 1 entry remains.
+
+### M09: memory restore with explicit insert index
+Restore previously removed H2 (assuming handle H2 still valid).
+Invocation:
+```/dev/null/m09_memory_restore_insert.json#L1-12
+{
+  "name": "memory",
+  "arguments": {
+    "operation": "restore",
+    "memory_handle": "H2",
+    "restore_insert_index": 0
+  }
+}
+```
+Assertions:
+- H2 appears at index 0 in subsequent list.
+- Another entry shifts to index 1.
+
+### M10: memory store with auto=true
+Invocation:
+```/dev/null/m10_memory_store_auto.json#L1-13
+{
+  "name": "memory",
+  "arguments": {
+    "operation": "store",
+    "auto": true,
+    "summary": "Auto-assisted merge: clarity priority, error propagation, minimal allocations, possible later perf shift."
+  }
+}
+```
+Assertions:
+- New handle H3.
+- Auto flag does not discard manual summary.
+
+### M11: memory list with max_preview_chars
+Invocation:
+```/dev/null/m11_memory_list_preview.json#L1-10
+{
+  "name": "memory",
+  "arguments": {
+    "operation": "list",
+    "max_preview_chars": 25
+  }
+}
+```
+Assertions:
+- Each preview length ≤ 25.
+- No multi-byte character corruption.
+
+### M12: memory prune non-existent handle
+Invocation:
+```/dev/null/m12_memory_prune_invalid.json#L1-10
+{
+  "name": "memory",
+  "arguments": {
+    "operation": "prune",
+    "memory_handle": "NON_EXISTENT_HANDLE"
+  }
+}
+```
+Assertions:
+- Expected error OR no-op with explicit status (must not silently succeed without status).
+- Entry count unchanged.
+
+### M13: memory store empty summary (negative)
+Invocation:
+```/dev/null/m13_memory_store_empty.json#L1-9
+{
+  "name": "memory",
+  "arguments": {
+    "operation": "store",
+    "summary": ""
+  }
+}
+```
+Assertions:
+- Expect validation failure (error message).
+- No new entry added.
+
+### M14: memory restore with placeholder replacement
+Pre-step: Prune H3 producing a placeholder (if system uses placeholders).
+Invocation:
+```/dev/null/m14_memory_restore_placeholder.json#L1-15
+{
+  "name": "memory",
+  "arguments": {
+    "operation": "restore",
+    "memory_handle": "H3",
+    "remove_placeholder": true,
+    "replace_placeholder_with": "Merged clarity & future performance watch."
+  }
+}
+```
+Assertions:
+- Entry restored with replacement text included OR appended metadata.
+- No residual placeholder artifacts.
+
+### M15: memory prune overlapping indices
+Precondition: At least 3 entries (if not, re-store entries).
+Invocation:
+```/dev/null/m15_memory_prune_overlap.json#L1-13
+{
+  "name": "memory",
+  "arguments": {
+    "operation": "prune",
+    "start_index": 1,
+    "end_index": 10
+  }
+}
+```
+Assertions:
+- All entries from index 1 onward removed.
+- Only index 0 remains.
+- No out-of-range panic; gracefully bounds check.
+
+### M16: memory load after sequence
+Invocation:
+```/dev/null/m16_memory_load_final.json#L1-6
+{
+  "name": "memory",
+  "arguments": { "operation": "load" }
+}
+```
+Assertions:
+- Returned composite summary (if system merges) OR latest active entry.
+- No orphaned placeholders.
+
+---
+
+## 6. Expected Output Patterns
+
+Because actual schema may vary, define pattern expectations rather than exact JSON:
+
+Common pattern for list:
+```
+Entries: [
+  {
+    "handle": "<NON-EMPTY STRING>",
+    "preview": "<<= max_preview_chars or full>",
+    "length": <int?>,
+    "created_at": "<ISO8601?>"
+  },
+  ...
+]
+Total: <int>
+```
+
+For load:
+```
+{
+  "summaries": [
+     {"handle": "Hx", "text": "..."},
+     ...
+  ]
+}
+```
+OR if singular:
+```
+{"summary": "..."}
+```
+
+For errors:
+```
+{
+  "error": {
+    "message": "Description",
+    "code": "<validation|not_found|...>"
+  }
+}
+```
+
+---
+
+## 7. Edge & Negative Considerations
+
+| Scenario | Expectation |
+|----------|-------------|
+| Duplicate store with identical summary | Allowed; distinct handle |
+| Prune with both memory_handle and start/end | Prefer explicit handle; ignore range (documentedly) OR error |
+| Restore inserting out-of-bounds index | Clamp to end |
+| max_preview_chars < 5 | Still honored; truncated safely |
+| Large summary ( > 10k chars ) | Should either store or return size error; test if environment allows |
+
+(Optional Stress Test)
+```/dev/null/stress_store_large.json#L1-9
+{
+  "name": "memory",
+  "arguments": {
+    "operation": "store",
+    "summary": "<REPEAT 'A' x 12000>"
+  }
+}
+```
+
+---
+
+## 8. Recommended Execution Order
+
+1. H01–H04 (history baseline)
+2. M01–M05 (initial population)
+3. M06–M07 (handle prune/restore)
+4. M08–M11 (range + previews + auto)
+5. M12–M15 (negative & edge)
+6. M16 (final verification)
+
+---
+
+## 9. Sample Consolidated Acceptance Script (Logical Narrative)
+
+Script (human/harness pseudo-flow):
+
+1. Confirm history indexes stable (H01).
+2. Store first summary (M01) -> record handle H1.
+3. List -> verify H1 (M02).
+4. Load -> verify content (M03).
+5. Store refined summary -> H2 (M04).
+6. List -> two entries (M05).
+7. Prune H1 (M06).
+8. Restore H1 (M07).
+9. Prune by range removing first entry (M08).
+10. Restore H2 at index 0 (M09).
+11. Store auto summary (M10) -> H3.
+12. List with preview cap (M11).
+13. Attempt prune invalid handle (M12).
+14. Attempt store empty summary (M13).
+15. Prune H3 then restore with placeholder replacement (M14).
+16. Prune overlapping indices (M15).
+17. Load final state (M16).
+
+---
+
+## 10. Example Narrative Summaries to Use
+
+Initial manual summary candidate:
+"User prioritizes clarity, safe error handling (no unwrap), descriptive names."
+
+Refined summary:
+"Clarity-first; avoid panics; minimal allocations; descriptive naming; performance shift anticipated."
+
+Auto-assisted summary:
+"Consolidated: clarity > perf (current), propagate errors with '?', minimize allocations, potential future perf optimization."
+
+Placeholder replacement (if used):
+"Merged clarity & future performance watch."
+
+---
+
+## 11. Validation Checklist
+
+| Check | Must Hold |
+|-------|-----------|
+| Handle uniqueness | All stored entries have unique handles until pruned; restored may reuse or alias (document) |
+| Idempotence of list | List does not mutate state |
+| Prune accuracy | Only specified entries removed |
+| Restore insertion | Entry position matches requested index or spec fallback |
+| Preview safety | No multi-byte truncation corruption |
+| Negative handling | Invalid operations produce explicit error envelope |
+| Final load coherence | No references to pruned-only (non-restored) handles |
+
+---
+
+## 12. Reporting Format (For Harness)
+
+For each test produce:
+```
+[TEST_ID] RESULT: PASS|FAIL
+Request: <serialized invocation>
+Response: <raw response>
+Assertions:
+ - <assertion1>: PASS|FAIL
+ - <assertion2>: PASS|FAIL
+State After: <list summary handles ordered>
+```
+
+---
+
+## 13. Maintenance Notes
+
+- If memory backend changes ordering semantics (e.g. MRU vs chronological), adjust tests M05, M07, M09 accordingly.
+- If range prune semantics are clarified (inclusive vs exclusive end), update M08 / M15.
+- If automatic summarization (`auto=true`) starts generating internal text ignoring provided summary, adapt M10 acceptance to allow system-generated content with a stability token.
+
+---
+
+## 14. Quick Start Minimal Subset (Smoke)
+
+If only smoke testing:
+1. H01
+2. M01
+3. M02
+4. M03
+5. M06
+6. M07
+7. M11
+8. M16
+
+---
+
+End of specification.

--- a/crates/agent2/src/tests/memory_history_integration_tests.rs
+++ b/crates/agent2/src/tests/memory_history_integration_tests.rs
@@ -1,0 +1,327 @@
+use super::*;
+use crate::tools::{ListHistoryTool, MemoryTool};
+use anyhow::{Context as _, Result};
+use gpui::TestAppContext;
+use serde_json::json;
+use std::sync::Arc;
+
+/// These integration-style tests exercise the `memory` and `list_history`
+/// tools directly against an in‑memory `Thread` constructed via the existing
+/// `setup` harness. They avoid model completions where unnecessary by
+/// inserting only user messages. This keeps the surface minimal while
+/// validating durable archive round‑trips and history enumeration.
+///
+/// Rationale:
+/// * We construct tool input structs via serde_json because their fields
+///   are intentionally non-public; this mirrors how real tool invocations
+///   are deserialized from JSON arguments.
+/// * We assert on stable textual markers in the markdown output (e.g.,
+///   "Handle:", "Archived Memories") instead of attempting to parse full
+///   tables, minimizing brittleness while still guaranteeing correctness.
+/// * We do not add extensive helper abstractions to keep the test logic
+///   straightforward and explicit.
+///
+/// NOTE: If this file is added and tests do not compile, ensure
+/// `mod memory_history_integration_tests;` is declared inside
+/// `crates/agent2/src/tests/mod.rs`.
+
+/// Helper: run the list_history tool and return its raw markdown output.
+async fn run_list_history(
+    cx: &mut TestAppContext,
+    thread: &Entity<Thread>,
+    start: Option<usize>,
+    limit: Option<usize>,
+    max_chars: Option<usize>,
+    include_full: Option<bool>,
+) -> Result<String> {
+    let mut obj = serde_json::Map::new();
+    if let Some(s) = start {
+        obj.insert("start".into(), s.into());
+    }
+    if let Some(l) = limit {
+        obj.insert("limit".into(), l.into());
+    }
+    if let Some(m) = max_chars {
+        obj.insert("max_chars_per_message".into(), m.into());
+    }
+    if let Some(f) = include_full {
+        obj.insert("include_full_markdown".into(), f.into());
+    }
+    let input_json = serde_json::Value::Object(obj);
+    let input: crate::tools::ListHistoryToolInput =
+        serde_json::from_value(input_json).context("deserialize ListHistoryToolInput")?;
+
+    let tool = Arc::new(ListHistoryTool::new(thread.downgrade()));
+    let task = thread.update(cx, |_, thread_cx| {
+        let (event_stream, _rx) = crate::ToolCallEventStream::test();
+        tool.clone().run(input, event_stream, thread_cx)
+    });
+    task.await.context("run list_history tool")
+}
+
+/// Helper: run memory tool with arbitrary JSON input.
+async fn run_memory(
+    cx: &mut TestAppContext,
+    thread: &Entity<Thread>,
+    input_json: serde_json::Value,
+) -> Result<String> {
+    let input: crate::tools::MemoryToolInput =
+        serde_json::from_value(input_json).context("deserialize MemoryToolInput")?;
+    let tool = Arc::new(MemoryTool::new(thread.downgrade()));
+    let task = thread.update(cx, |_, thread_cx| {
+        let (event_stream, _rx) = crate::ToolCallEventStream::test();
+        tool.clone().run(input, event_stream, thread_cx)
+    });
+    task.await.context("run memory tool")
+}
+
+/// Extract archive handle from a memory store markdown output.
+fn extract_handle(store_output: &str) -> Option<String> {
+    store_output
+        .lines()
+        .find_map(|l| l.strip_prefix("Handle: "))
+        .map(|s| s.trim().to_string())
+}
+
+/// Basic history enumeration + truncation sanity check.
+#[gpui::test]
+async fn list_history_basic_and_truncation(cx: &mut TestAppContext) -> Result<()> {
+    let ThreadTest { thread, .. } = setup(cx, TestModel::Fake).await;
+
+    for i in 0..6 {
+        let content = format!("User message number {i} with some extra descriptive text");
+        let _ = thread.update(cx, |thread, cx| {
+            thread.send(acp_thread::UserMessageId::new(), [content.as_str()], cx)
+        })?;
+    }
+    cx.run_until_parked();
+
+    let output_default = run_list_history(cx, &thread, None, Some(5), None, None).await?;
+    assert!(
+        output_default.contains("0") && output_default.contains("4"),
+        "Expected indices 0..4 in default output; got:\n{output_default}"
+    );
+
+    let output_trunc =
+        run_list_history(cx, &thread, Some(2), Some(3), Some(32), Some(false)).await?;
+    assert!(
+        output_trunc.contains("2") && output_trunc.contains("4"),
+        "Expected indices 2..4 in truncated output; got:\n{output_trunc}"
+    );
+    Ok(())
+}
+
+/// Round‑trip archive lifecycle: store -> list -> load -> restore (remove placeholder) -> prune.
+#[gpui::test]
+async fn memory_store_list_load_restore_prune_roundtrip(cx: &mut TestAppContext) -> Result<()> {
+    let ThreadTest { thread, .. } = setup(cx, TestModel::Fake).await;
+
+    for i in 0..5 {
+        let content = format!("Seed user message {i}");
+        let _ = thread.update(cx, |thread, cx| {
+            thread.send(acp_thread::UserMessageId::new(), [content.as_str()], cx)
+        })?;
+    }
+    cx.run_until_parked();
+
+    let store_out = run_memory(
+        cx,
+        &thread,
+        json!({
+            "operation": "store",
+            "start_index": 0,
+            "end_index": 2,
+            "summary": "Archive of first three messages"
+        }),
+    )
+    .await?;
+    let handle =
+        extract_handle(&store_out).context("failed to parse archive handle from store output")?;
+    assert!(
+        store_out.contains("Range: 0..=2"),
+        "Store output missing expected range line:\n{store_out}"
+    );
+
+    let list_out = run_memory(cx, &thread, json!({"operation":"list"})).await?;
+    assert!(
+        list_out.contains(&handle),
+        "List output did not contain handle {handle}:\n{list_out}"
+    );
+    assert!(
+        list_out.contains("Archived Memories"),
+        "List output missing heading:\n{list_out}"
+    );
+
+    let load_out = run_memory(
+        cx,
+        &thread,
+        json!({
+            "operation":"load",
+            "memory_handle": handle
+        }),
+    )
+    .await?;
+    assert!(
+        load_out.contains("Summary:"),
+        "Load output missing summary:\n{load_out}"
+    );
+
+    let restore_out = run_memory(
+        cx,
+        &thread,
+        json!({
+            "operation":"restore",
+            "memory_handle": handle,
+            "remove_placeholder": true,
+            "restore_insert_index": 5
+        }),
+    )
+    .await?;
+    assert!(
+        restore_out.contains("Placeholder: removed"),
+        "Restore output did not record placeholder removal:\n{restore_out}"
+    );
+
+    let prune_out = run_memory(cx, &thread, json!({"operation":"prune"})).await?;
+    if !prune_out.contains(&handle) {
+        let list_after = run_memory(cx, &thread, json!({"operation":"list"})).await?;
+        assert!(
+            !list_after.contains(&handle),
+            "Archive still listed after prune:\n{list_after}"
+        );
+    }
+
+    Ok(())
+}
+
+/// Negative test: store without required indices must error.
+#[gpui::test]
+async fn memory_store_missing_indices_errors(cx: &mut TestAppContext) -> Result<()> {
+    let ThreadTest { thread, .. } = setup(cx, TestModel::Fake).await;
+
+    let _ = thread.update(cx, |thread, cx| {
+        thread.send(acp_thread::UserMessageId::new(), ["One message"], cx)
+    })?;
+    cx.run_until_parked();
+
+    let result = run_memory(
+        cx,
+        &thread,
+        json!({
+            "operation":"store",
+            "summary":"Should fail because indices missing"
+        }),
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "Store without indices unexpectedly succeeded:\n{result:?}"
+    );
+    let err = format!("{result:?}");
+    assert!(
+        err.contains("store requires start_index") || err.contains("start_index"),
+        "Error did not mention missing start_index: {err}"
+    );
+    Ok(())
+}
+
+/// Restore with placeholder replacement test.
+#[gpui::test]
+async fn memory_restore_with_placeholder_replacement(cx: &mut TestAppContext) -> Result<()> {
+    let ThreadTest { thread, .. } = setup(cx, TestModel::Fake).await;
+    for i in 0..3 {
+        let _ = thread.update(cx, |thread, cx| {
+            thread.send(
+                acp_thread::UserMessageId::new(),
+                [format!("Msg {i}").as_str()],
+                cx,
+            )
+        })?;
+    }
+    cx.run_until_parked();
+
+    let store_out = run_memory(
+        cx,
+        &thread,
+        serde_json::json!({
+            "operation":"store",
+            "start_index":0,
+            "end_index":1,
+            "summary":"Two messages to be replaced"
+        }),
+    )
+    .await?;
+    let handle = extract_handle(&store_out).context("missing handle")?;
+
+    let restore_out = run_memory(
+        cx,
+        &thread,
+        serde_json::json!({
+            "operation":"restore",
+            "memory_handle": handle,
+            "replace_placeholder_with":"[Replaced Placeholder Marker]"
+        }),
+    )
+    .await?;
+    assert!(
+        restore_out.contains("Placeholder: replaced"),
+        "Restore output did not indicate replacement:\n{restore_out}"
+    );
+
+    let list_out = run_memory(cx, &thread, serde_json::json!({"operation":"list"})).await?;
+    assert!(
+        list_out.contains(&handle),
+        "Archive handle missing after replacement:\n{list_out}"
+    );
+    Ok(())
+}
+
+/// Auto-summary generation test (auto:true, no explicit summary)
+#[gpui::test]
+async fn memory_store_auto_summary_generation(cx: &mut TestAppContext) -> Result<()> {
+    let ThreadTest { thread, .. } = setup(cx, TestModel::Fake).await;
+    for i in 0..4 {
+        let _ = thread.update(cx, |thread, cx| {
+            thread.send(
+                acp_thread::UserMessageId::new(),
+                [format!("Auto seed message {i}").as_str()],
+                cx,
+            )
+        })?;
+    }
+    cx.run_until_parked();
+
+    let store_out = run_memory(
+        cx,
+        &thread,
+        serde_json::json!({
+            "operation":"store",
+            "start_index":1,
+            "end_index":3,
+            "auto": true
+        }),
+    )
+    .await?;
+    let handle = extract_handle(&store_out).context("missing handle")?;
+
+    let load_out = run_memory(
+        cx,
+        &thread,
+        serde_json::json!({
+            "operation":"load",
+            "memory_handle": handle,
+            "max_preview_chars":160
+        }),
+    )
+    .await?;
+    assert!(
+        !load_out.contains("No summary provided"),
+        "Auto summary fallback was not generated:\n{load_out}"
+    );
+    assert!(
+        load_out.contains("Summary:"),
+        "Load output missing summary field:\n{load_out}"
+    );
+    Ok(())
+}

--- a/crates/assistant_tools/src/context_management/list_history_tool.rs
+++ b/crates/assistant_tools/src/context_management/list_history_tool.rs
@@ -1,0 +1,241 @@
+use std::sync::Arc;
+
+use crate::schema::json_schema_for;
+use action_log::ActionLog;
+use anyhow::{Result, anyhow};
+use assistant_tool::{Tool, ToolResult, ToolResultOutput};
+use gpui::{AnyWindowHandle, App, AppContext, Entity, Task};
+use language_model::{LanguageModel, LanguageModelRequest, LanguageModelToolSchemaFormat};
+
+use project::Project;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use ui::IconName;
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct ListHistoryToolInput {
+    /// Inclusive starting message index (default 0)
+    #[serde(default)]
+    start: usize,
+
+    /// Number of messages to enumerate (default 40, clamped 1..500)
+    #[serde(default = "default_limit")]
+    limit: usize,
+
+    /// Preview character cap per message (default 160, clamped 16..4096)
+    #[serde(default = "default_max_chars")]
+    max_chars_per_message: usize,
+
+    /// If true, appends full text of each listed message after the table
+    #[serde(default)]
+    include_full_markdown: bool,
+}
+
+fn default_limit() -> usize {
+    40
+}
+
+fn default_max_chars() -> usize {
+    160
+}
+
+pub struct ListHistoryTool;
+
+impl Tool for ListHistoryTool {
+    fn name(&self) -> String {
+        "list_history".into()
+    }
+
+    fn needs_confirmation(&self, _: &serde_json::Value, _: &Entity<Project>, _: &App) -> bool {
+        false
+    }
+
+    fn may_perform_edits(&self) -> bool {
+        false
+    }
+
+    fn description(&self) -> String {
+        "Enumerate a slice of the thread's messages with stable indices, lightweight previews, and optional full markdown. Used for planning context reduction.".into()
+    }
+
+    fn icon(&self) -> IconName {
+        IconName::ListTree
+    }
+
+    fn input_schema(&self, format: LanguageModelToolSchemaFormat) -> Result<serde_json::Value> {
+        json_schema_for::<ListHistoryToolInput>(format)
+    }
+
+    fn ui_text(&self, input: &serde_json::Value) -> String {
+        let input: ListHistoryToolInput =
+            serde_json::from_value(input.clone()).unwrap_or(ListHistoryToolInput {
+                start: 0,
+                limit: default_limit(),
+                max_chars_per_message: default_max_chars(),
+                include_full_markdown: false,
+            });
+        format!(
+            "List history (start: {}, limit: {})",
+            input.start, input.limit
+        )
+    }
+
+    fn run(
+        self: Arc<Self>,
+        input: serde_json::Value,
+        request: Arc<LanguageModelRequest>,
+        _project: Entity<Project>,
+        _action_log: Entity<ActionLog>,
+        _model: Arc<dyn LanguageModel>,
+        _window: Option<AnyWindowHandle>,
+        cx: &mut App,
+    ) -> ToolResult {
+        let mut input: ListHistoryToolInput = match serde_json::from_value(input) {
+            Ok(input) => input,
+            Err(err) => return Task::ready(Err(anyhow!(err))).into(),
+        };
+
+        // Clamp values to valid ranges
+        input.limit = input.limit.clamp(1, 500);
+        input.max_chars_per_message = input.max_chars_per_message.clamp(16, 4096);
+
+        // Get the messages from the request
+        let messages = request.messages.clone();
+
+        let task = cx.background_spawn(async move {
+            let mut output = String::new();
+
+            // Header
+            output.push_str("# Conversation History\n\n");
+
+            // Get messages from the request
+            let total_messages = messages.len();
+            let end_index = (input.start + input.limit).min(total_messages);
+
+            if input.start >= total_messages {
+                output.push_str(&format!(
+                    "No messages found starting from index {}\n",
+                    input.start
+                ));
+                output.push_str(&format!(
+                    "Total messages in conversation: {}\n",
+                    total_messages
+                ));
+                return Ok(ToolResultOutput::from(output));
+            }
+
+            // JSON summary block
+            output.push_str("```json\n");
+            output.push_str(
+                &serde_json::to_string_pretty(&serde_json::json!({
+                    "total_messages": total_messages,
+                    "showing_range": format!("{}..{}", input.start, end_index),
+                    "messages_shown": end_index - input.start,
+                }))
+                .unwrap_or_default(),
+            );
+            output.push_str("\n```\n\n");
+
+            // Table header
+            output.push_str("| Idx | Role | Kind | Chars | Preview |\n");
+            output.push_str("|-----|------|------|-------|----------|\n");
+
+            // Build table rows
+            let messages_slice = &messages[input.start..end_index];
+            for (offset, message) in messages_slice.iter().enumerate() {
+                let idx = input.start + offset;
+                let role = format!("{:?}", message.role);
+
+                // Convert message content to string
+                let content_str = message
+                    .content
+                    .iter()
+                    .map(|c| match c {
+                        language_model::MessageContent::Text(text) => text.clone(),
+                        language_model::MessageContent::Thinking { text, .. } => text.clone(),
+                        language_model::MessageContent::RedactedThinking(text) => text.clone(),
+                        language_model::MessageContent::Image(_) => "[Image]".to_string(),
+                        language_model::MessageContent::ToolUse(_) => "[Tool Use]".to_string(),
+                        language_model::MessageContent::ToolResult(_) => {
+                            "[Tool Result]".to_string()
+                        }
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                let chars = content_str.len();
+
+                // Determine message kind based on content
+                let has_tool_use = message
+                    .content
+                    .iter()
+                    .any(|c| matches!(c, language_model::MessageContent::ToolUse(_)));
+                let has_tool_result = message
+                    .content
+                    .iter()
+                    .any(|c| matches!(c, language_model::MessageContent::ToolResult(_)));
+
+                let kind = if has_tool_use {
+                    "tool_use"
+                } else if has_tool_result {
+                    "tool_result"
+                } else {
+                    "message"
+                };
+
+                // Create preview
+                let preview = if content_str.len() <= input.max_chars_per_message {
+                    content_str.clone()
+                } else {
+                    format!("{}...", &content_str[..input.max_chars_per_message])
+                };
+
+                // Escape pipe characters in preview for markdown table
+                let preview = preview.replace('|', "\\|").replace('\n', " ");
+
+                output.push_str(&format!(
+                    "| {} | {} | {} | {} | {} |\n",
+                    idx, role, kind, chars, preview
+                ));
+            }
+
+            // Optionally include full markdown
+            if input.include_full_markdown {
+                output.push_str("\n## Full Message Content\n\n");
+
+                for (offset, message) in messages_slice.iter().enumerate() {
+                    let idx = input.start + offset;
+                    output.push_str(&format!(
+                        "### Message {} ({})\n\n",
+                        idx,
+                        format!("{:?}", message.role)
+                    ));
+
+                    let content_str = message
+                        .content
+                        .iter()
+                        .map(|c| match c {
+                            language_model::MessageContent::Text(text) => text.clone(),
+                            language_model::MessageContent::Thinking { text, .. } => text.clone(),
+                            language_model::MessageContent::RedactedThinking(text) => text.clone(),
+                            language_model::MessageContent::Image(_) => "[Image]".to_string(),
+                            language_model::MessageContent::ToolUse(_) => "[Tool Use]".to_string(),
+                            language_model::MessageContent::ToolResult(_) => {
+                                "[Tool Result]".to_string()
+                            }
+                        })
+                        .collect::<Vec<_>>()
+                        .join("\n");
+                    output.push_str(&content_str);
+                    output.push_str("\n\n");
+                }
+            }
+
+            Ok(ToolResultOutput::from(output))
+        });
+
+        ToolResult {
+            output: task,
+            card: None,
+        }
+    }
+}

--- a/crates/assistant_tools/src/context_management/list_history_tool/description.md
+++ b/crates/assistant_tools/src/context_management/list_history_tool/description.md
@@ -1,0 +1,53 @@
+# List History Tool
+
+Enumerate a slice of the conversation thread's messages with stable indices, lightweight previews, and optional full markdown content.
+
+## Purpose
+
+This tool is designed for planning context reduction by allowing you to inspect the conversation history before deciding which messages to archive using the `memory` tool.
+
+## Parameters
+
+- `start` (optional): Inclusive starting message index (default: 0)
+- `limit` (optional): Number of messages to enumerate (default: 40, clamped between 1 and 500)
+- `max_chars_per_message` (optional): Preview character cap per message (default: 160, clamped between 16 and 4096)
+- `include_full_markdown` (optional): If true, appends full text of each listed message after the table (default: false)
+
+## Output Format
+
+The tool produces:
+
+1. A JSON summary block showing total message count and the range being displayed
+2. A markdown table with columns:
+   - **Idx**: Message index in the conversation
+   - **Role**: The role of the message (User, Assistant, System, etc.)
+   - **Kind**: Type of message (message, tool_call, tool_result)
+   - **Chars**: Character count of the message content
+   - **Preview**: Truncated preview of the message content
+
+3. Optionally, full message content for each message in the range
+
+## Usage Example
+
+```json
+{
+  "start": 0,
+  "limit": 50,
+  "max_chars_per_message": 200,
+  "include_full_markdown": false
+}
+```
+
+## Typical Workflow
+
+1. Call `list_history` to inspect a range of messages
+2. Identify messages that can be archived (e.g., older messages that are no longer immediately relevant)
+3. Use the `memory` tool with operation "store" to archive those messages
+4. Continue the conversation with reduced context
+
+## When to Use
+
+- When token usage approaches limits (60-70% of context window)
+- To review what's been discussed in the conversation
+- Before archiving messages to verify the range is correct
+- To find specific information by scanning through message previews

--- a/crates/assistant_tools/src/context_management/memory_tool.rs
+++ b/crates/assistant_tools/src/context_management/memory_tool.rs
@@ -1,0 +1,1063 @@
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::sync::{Arc, OnceLock};
+
+use anyhow::{Result, anyhow, bail};
+use assistant_tool::{Tool, ToolResult, ToolResultOutput};
+use gpui::{AnyWindowHandle, App, Entity, Task};
+use language_model::{
+    LanguageModel, LanguageModelRequest, LanguageModelRequestMessage,
+    LanguageModelToolSchemaFormat, MessageContent, Role,
+};
+use parking_lot::Mutex;
+use project::Project;
+use regex::Regex;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use ui::IconName;
+use uuid::Uuid;
+
+use crate::schema::json_schema_for;
+use action_log::ActionLog;
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryOperation {
+    Store,
+    Load,
+    #[serde(alias = "scan")]
+    List,
+    Restore,
+    Prune,
+    Stats,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct MemoryToolInput {
+    operation: MemoryOperation,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    start_index: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    end_index: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    memory_handle: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    summary: Option<String>,
+    #[serde(default)]
+    auto: bool,
+    #[serde(default = "default_preview_chars")]
+    max_preview_chars: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    restore_insert_index: Option<usize>,
+    #[serde(default)]
+    remove_placeholder: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    replace_placeholder_with: Option<String>,
+    #[serde(default)]
+    allow_overlap: bool,
+    #[serde(default)]
+    json: bool,
+}
+
+fn default_preview_chars() -> usize {
+    200
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ArchivedMemory {
+    session_id: String,
+    memory_id: String,
+    start_index: usize,
+    end_index: usize,
+    messages: Vec<LanguageModelRequestMessage>,
+    summary: Option<String>,
+    created_at: std::time::SystemTime,
+    #[serde(default)]
+    char_count: usize,
+    #[serde(default)]
+    token_estimate: usize,
+    #[serde(default)]
+    restored_count: usize,
+    #[serde(default)]
+    last_restored_at: Option<std::time::SystemTime>,
+}
+
+static MEMORY_STORE: OnceLock<Mutex<HashMap<String, ArchivedMemory>>> = OnceLock::new();
+static MEMORY_STORE_LOADED: OnceLock<()> = OnceLock::new();
+
+fn memory_store() -> &'static Mutex<HashMap<String, ArchivedMemory>> {
+    MEMORY_STORE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn store_file_path() -> std::path::PathBuf {
+    paths::data_dir().join("memory_store.json")
+}
+
+fn ensure_store_loaded() {
+    MEMORY_STORE_LOADED.get_or_init(|| {
+        let _ = load_persistent_store();
+    });
+}
+
+fn load_persistent_store() -> Result<()> {
+    let path = store_file_path();
+    if !path.exists() {
+        return Ok(());
+    }
+    let content = fs::read_to_string(&path)?;
+    if content.trim().is_empty() {
+        return Ok(());
+    }
+    #[derive(Deserialize)]
+    struct PersistedEntry {
+        handle: String,
+        archived: ArchivedMemory,
+    }
+    let entries: Vec<PersistedEntry> = serde_json::from_str(&content)?;
+    let mut guard = memory_store().lock();
+    for e in entries {
+        guard.entry(e.handle).or_insert(e.archived);
+    }
+    Ok(())
+}
+
+fn persist_store() -> Result<()> {
+    #[derive(Serialize)]
+    struct PersistedEntry<'a> {
+        handle: &'a String,
+        archived: &'a ArchivedMemory,
+    }
+    let guard = memory_store().lock();
+    let entries: Vec<PersistedEntry> = guard
+        .iter()
+        .map(|(h, a)| PersistedEntry {
+            handle: h,
+            archived: a,
+        })
+        .collect();
+    let serialized = serde_json::to_string_pretty(&entries)?;
+    fs::write(store_file_path(), serialized)?;
+    Ok(())
+}
+
+// Removed ParsedPlaceholder (no longer needed)
+
+fn placeholder_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| {
+        Regex::new(
+            r#"^\[\[memory archived handle=(?P<handle>\S+) range=(?P<start>\d+)\.\.(?P<end>\d+) messages=(?P<count>\d+) chars=(?P<chars>\d+)(?: tokens=(?P<tokens>\d+))?\]\]"#,
+        )
+        .expect("placeholder regex")
+    })
+}
+
+// Removed parse_placeholder (struct was removed and parsing no longer required)
+
+fn generate_heuristic_summary(messages: &[LanguageModelRequestMessage], count: usize) -> String {
+    for message in messages {
+        let content = message
+            .content
+            .iter()
+            .filter_map(|c| match c {
+                MessageContent::Text(t) => Some(t.as_str()),
+                MessageContent::Thinking { text, .. } => Some(text.as_str()),
+                MessageContent::RedactedThinking(t) => Some(t.as_str()),
+                MessageContent::Image(_) => None,
+                MessageContent::ToolUse(_) => None,
+                MessageContent::ToolResult(_) => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+            .trim()
+            .to_string();
+        if !content.is_empty() {
+            let first_line = content.lines().next().unwrap_or(&content);
+            if first_line.len() > 140 {
+                return format!("{}... ({} msgs)", &first_line[..140], count);
+            } else {
+                return format!("{} ({} msgs)", first_line, count);
+            }
+        }
+    }
+    format!("({} msgs)", count)
+}
+
+fn generate_preview(messages: &[LanguageModelRequestMessage], max_chars: usize) -> String {
+    let mut preview = String::new();
+    let mut total = 0usize;
+
+    for message in messages {
+        let content = message
+            .content
+            .iter()
+            .map(|c| match c {
+                MessageContent::Text(t) => t.clone(),
+                MessageContent::Thinking { text, .. } => text.clone(),
+                MessageContent::RedactedThinking(t) => t.clone(),
+                MessageContent::Image(_) => "[Image]".to_string(),
+                MessageContent::ToolUse(_) => "[Tool Use]".to_string(),
+                MessageContent::ToolResult(_) => "[Tool Result]".to_string(),
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        if total + content.len() <= max_chars {
+            if !preview.is_empty() {
+                preview.push('\n');
+            }
+            preview.push_str(&content);
+            total += content.len();
+        } else if total < max_chars {
+            let remaining = max_chars - total;
+            if remaining > 20 {
+                if !preview.is_empty() {
+                    preview.push('\n');
+                }
+                preview.push_str(&content[..remaining]);
+                preview.push_str("...(truncated)");
+            }
+            break;
+        } else {
+            break;
+        }
+    }
+
+    preview
+}
+
+pub struct MemoryTool;
+
+impl Tool for MemoryTool {
+    fn name(&self) -> String {
+        "memory".into()
+    }
+
+    fn needs_confirmation(&self, _: &serde_json::Value, _: &Entity<Project>, _: &App) -> bool {
+        false
+    }
+
+    fn may_perform_edits(&self) -> bool {
+        false
+    }
+
+    fn description(&self) -> String {
+        "Archive a contiguous range of conversation messages, list or inspect archives, restore or prune them, and view usage stats.".into()
+    }
+
+    fn icon(&self) -> IconName {
+        IconName::Book
+    }
+
+    fn input_schema(&self, format: LanguageModelToolSchemaFormat) -> Result<serde_json::Value> {
+        json_schema_for::<MemoryToolInput>(format)
+    }
+
+    fn ui_text(&self, input: &serde_json::Value) -> String {
+        if let Ok(input) = serde_json::from_value::<MemoryToolInput>(input.clone()) {
+            match input.operation {
+                MemoryOperation::Store => {
+                    if let (Some(s), Some(e)) = (input.start_index, input.end_index) {
+                        format!("Archive messages {}..{}", s, e)
+                    } else {
+                        "Archive messages".to_string()
+                    }
+                }
+                MemoryOperation::Load => input
+                    .memory_handle
+                    .map(|h| format!("Load memory: {}", h))
+                    .unwrap_or_else(|| "Load memory".to_string()),
+                MemoryOperation::List => "List archives".to_string(),
+                MemoryOperation::Restore => input
+                    .memory_handle
+                    .map(|h| format!("Restore memory: {}", h))
+                    .unwrap_or_else(|| "Restore memory".to_string()),
+                MemoryOperation::Prune => "Prune unused archives".to_string(),
+                MemoryOperation::Stats => "Memory stats".to_string(),
+            }
+        } else {
+            "Memory operation".to_string()
+        }
+    }
+
+    fn run(
+        self: Arc<Self>,
+        input: serde_json::Value,
+        request: Arc<LanguageModelRequest>,
+        _project: Entity<Project>,
+        _action_log: Entity<ActionLog>,
+        model: Arc<dyn LanguageModel>,
+        _window: Option<AnyWindowHandle>,
+        cx: &mut App,
+    ) -> ToolResult {
+        let mut input: MemoryToolInput = match serde_json::from_value(input) {
+            Ok(v) => v,
+            Err(e) => return Task::ready(Err(anyhow!(e))).into(),
+        };
+
+        input.max_preview_chars = input.max_preview_chars.clamp(40, 400);
+
+        let session_id = request
+            .thread_id
+            .as_ref()
+            .map(|id| id.to_string())
+            .unwrap_or_else(|| "default".into());
+        let messages = request.messages.clone();
+        let base_request = request.clone();
+
+        ensure_store_loaded();
+
+        let task = cx.spawn(async move |async_cx| {
+            fn rebuild_request(
+                base: &LanguageModelRequest,
+                msgs: Vec<LanguageModelRequestMessage>,
+            ) -> LanguageModelRequest {
+                LanguageModelRequest {
+                    thread_id: base.thread_id.clone(),
+                    prompt_id: base.prompt_id.clone(),
+                    intent: base.intent.clone(),
+                    mode: base.mode.clone(),
+                    messages: msgs,
+                    tools: base.tools.clone(),
+                    tool_choice: base.tool_choice.clone(),
+                    stop: base.stop.clone(),
+                    temperature: base.temperature,
+                    thinking_allowed: base.thinking_allowed,
+                }
+            }
+
+            async fn precise_tokens(
+                model: &Arc<dyn LanguageModel>,
+                base: &LanguageModelRequest,
+                msgs: &[LanguageModelRequestMessage],
+                cx: &gpui::AsyncApp,
+            ) -> usize {
+                if msgs.is_empty() {
+                    return 0;
+                }
+                let heuristic = {
+                    let chars: usize = msgs
+                        .iter()
+                        .map(|m| {
+                            m.content
+                                .iter()
+                                .map(|c| match c {
+                                    MessageContent::Text(t) => t.len(),
+                                    MessageContent::Thinking { text, .. } => text.len(),
+                                    MessageContent::RedactedThinking(t) => t.len(),
+                                    MessageContent::Image(_) => 7,
+                                    MessageContent::ToolUse(_) => 11,
+                                    MessageContent::ToolResult(_) => 14,
+                                })
+                                .sum::<usize>()
+                        })
+                        .sum();
+                    (chars / 4).max(1)
+                };
+
+                let req = rebuild_request(base, msgs.to_vec());
+                let fut = match cx.update(|app| model.count_tokens(req, app)) {
+                    Ok(fut) => fut,
+                    Err(_) => return heuristic,
+                };
+                match fut.await {
+                    Ok(v) if v > 0 => v as usize,
+                    _ => heuristic,
+                }
+            }
+
+            async fn per_message_precise_tokens(
+                model: &Arc<dyn LanguageModel>,
+                base: &LanguageModelRequest,
+                all: &[LanguageModelRequestMessage],
+                cx: &gpui::AsyncApp,
+            ) -> Result<(Vec<usize>, usize)> {
+                let mut prefix = Vec::with_capacity(all.len() + 1);
+                prefix.push(0);
+                for i in 0..all.len() {
+                    let t = precise_tokens(model, base, &all[..=i], cx).await;
+                    prefix.push(t);
+                }
+                let mut per = Vec::with_capacity(all.len());
+                for i in 0..all.len() {
+                    per.push(prefix[i + 1].saturating_sub(prefix[i]));
+                }
+                Ok((per, *prefix.last().unwrap_or(&0)))
+            }
+
+            let max_context_tokens = model.max_token_count() as usize;
+
+            match input.operation {
+                MemoryOperation::Store => {
+                    let start = input
+                        .start_index
+                        .ok_or_else(|| anyhow!("start_index required for store"))?;
+                    let end = input
+                        .end_index
+                        .ok_or_else(|| anyhow!("end_index required for store"))?;
+                    if start > end {
+                        bail!("start_index must be <= end_index");
+                    }
+                    if end >= messages.len() {
+                        bail!("end_index {end} out of bounds (len={})", messages.len());
+                    }
+
+                    {
+                        let guard = memory_store().lock();
+                        if !input.allow_overlap {
+                            for (h, a) in guard.iter() {
+                                if a.session_id == session_id {
+                                    let overlap = !(end < a.start_index || start > a.end_index);
+                                    if overlap {
+                                        bail!(
+                                            "overlapping archive with {} ({}..{}), pass allow_overlap=true to force",
+                                            h, a.start_index, a.end_index
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    let archived_messages = messages[start..=end].to_vec();
+                    let count = archived_messages.len();
+
+                    let summary = if let Some(s) = input.summary {
+                        Some(s)
+                    } else if input.auto {
+                        Some(generate_heuristic_summary(&archived_messages, count))
+                    } else {
+                        None
+                    };
+
+                    let char_count: usize = archived_messages
+                        .iter()
+                        .map(|m| {
+                            m.content
+                                .iter()
+                                .map(|c| match c {
+                                    MessageContent::Text(t) => t.len(),
+                                    MessageContent::Thinking { text, .. } => text.len(),
+                                    MessageContent::RedactedThinking(t) => t.len(),
+                                    MessageContent::Image(_) => 7,
+                                    MessageContent::ToolUse(_) => 11,
+                                    MessageContent::ToolResult(_) => 14,
+                                })
+                                .sum::<usize>()
+                        })
+                        .sum();
+
+                    let token_estimate =
+                        precise_tokens(&model, &base_request, &archived_messages, &*async_cx).await;
+
+                    let preview = generate_preview(&archived_messages, input.max_preview_chars);
+
+                    let memory_id = Uuid::new_v4().to_string();
+                    let handle = format!("mem://{}/{}", session_id, memory_id);
+
+                    let archived = ArchivedMemory {
+                        session_id: session_id.clone(),
+                        memory_id,
+                        start_index: start,
+                        end_index: end,
+                        messages: archived_messages,
+                        summary: summary.clone(),
+                        created_at: std::time::SystemTime::now(),
+                        char_count,
+                        token_estimate,
+                        restored_count: 0,
+                        last_restored_at: None,
+                    };
+
+                    {
+                        let mut guard = memory_store().lock();
+                        guard.insert(handle.clone(), archived);
+                    }
+                    persist_store()?;
+
+                    let summary_line = summary
+                        .unwrap_or_else(|| format!("{} messages archived", count));
+
+                    let mut placeholder = format!(
+                        "[[memory archived handle={} range={}..{} messages={} chars={} tokens={}]]\nSummary: {}",
+                        handle, start, end, count, char_count, token_estimate, summary_line
+                    );
+                    if !preview.is_empty() {
+                        placeholder.push_str(&format!("\nPreview: {}", preview));
+                    }
+
+                    let output = format!(
+                        "Archived {} messages ({}..{}) to {}\nPlaceholder:\n{}",
+                        count, start, end, handle, placeholder
+                    );
+                    Ok(ToolResultOutput::from(output))
+                }
+
+                MemoryOperation::Load => {
+                    let handle = input
+                        .memory_handle
+                        .ok_or_else(|| anyhow!("memory_handle required for load"))?;
+                    let guard = memory_store().lock();
+                    let archived = guard
+                        .get(&handle)
+                        .ok_or_else(|| anyhow!("unknown memory handle: {}", handle))?;
+
+                    let mut out = format!("# Archived Memory: {}\n\n", handle);
+                    out.push_str(&format!(
+                        "Range: {}..{}\nMessages: {}\nChars: {}\nTokens: {}\n",
+                        archived.start_index,
+                        archived.end_index,
+                        archived.messages.len(),
+                        archived.char_count,
+                        archived.token_estimate
+                    ));
+                    if let Some(s) = &archived.summary {
+                        out.push_str(&format!("Summary: {}\n", s));
+                    }
+                    out.push_str("\n## Messages\n\n");
+                    for (i, msg) in archived.messages.iter().enumerate() {
+                        out.push_str(&format!(
+                            "### Message {} (orig idx {}) role={:?}\n",
+                            i,
+                            archived.start_index + i,
+                            msg.role
+                        ));
+                        let body = msg
+                            .content
+                            .iter()
+                            .map(|c| match c {
+                                MessageContent::Text(t) => t.clone(),
+                                MessageContent::Thinking { text, .. } => text.clone(),
+                                MessageContent::RedactedThinking(t) => t.clone(),
+                                MessageContent::Image(_) => "[Image]".into(),
+                                MessageContent::ToolUse(_) => "[Tool Use]".into(),
+                                MessageContent::ToolResult(_) => "[Tool Result]".into(),
+                            })
+                            .collect::<Vec<_>>()
+                            .join("\n");
+                        out.push_str(&body);
+                        out.push_str("\n\n");
+                    }
+                    Ok(ToolResultOutput::from(out))
+                }
+
+                MemoryOperation::List => {
+                    // Observed placeholders: map handle -> indices where placeholder appears.
+                    let mut observed: HashMap<String, Vec<usize>> = HashMap::new();
+                    for (idx, msg) in messages.iter().enumerate() {
+                        let joined = msg
+                            .content
+                            .iter()
+                            .map(|c| match c {
+                                MessageContent::Text(t) => t.clone(),
+                                MessageContent::Thinking { text, .. } => text.clone(),
+                                MessageContent::RedactedThinking(t) => t.clone(),
+                                MessageContent::Image(_) => "[Image]".into(),
+                                MessageContent::ToolUse(_) => "[Tool Use]".into(),
+                                MessageContent::ToolResult(_) => "[Tool Result]".into(),
+                            })
+                            .collect::<Vec<_>>()
+                            .join("\n");
+                        if let Some(caps) = placeholder_regex()
+                            .captures(joined.lines().next().unwrap_or("").trim())
+                        {
+                            if let Some(handle) = caps.name("handle") {
+                                observed
+                                    .entry(handle.as_str().to_string())
+                                    .or_default()
+                                    .push(idx);
+                            }
+                        }
+                    }
+
+                    let guard = memory_store().lock();
+                    if guard.is_empty() {
+                        if input.json {
+                            return Ok(ToolResultOutput::from(
+                                serde_json::json!({
+                                    "archives": [],
+                                    "orphaned": []
+                                })
+                                .to_string(),
+                            ));
+                        }
+                        return Ok(ToolResultOutput::from(
+                            "# Archived Memories\n\nNo archived memories.\n".to_string(),
+                        ));
+                    }
+
+                    struct Row<'a> {
+                        handle: &'a str,
+                        range: String,
+                        count: usize,
+                        referenced: bool,
+                        summary: String,
+                    }
+
+                    let mut rows = Vec::new();
+                    for (handle, archived) in guard.iter() {
+                        let referenced = observed.contains_key(handle);
+                        let range = format!("{}..{}", archived.start_index, archived.end_index);
+                        let count = archived.messages.len();
+                        let summary = archived
+                            .summary
+                            .as_ref()
+                            .map(|s| s.replace('\n', " "))
+                            .unwrap_or_default();
+                        rows.push(Row {
+                            handle,
+                            range,
+                            count,
+                            referenced,
+                            summary,
+                        });
+                    }
+
+                    let mut orphaned: Vec<(String, usize)> = Vec::new();
+                    for (handle, indices) in &observed {
+                        if !guard.contains_key(handle) {
+                            for idx in indices {
+                                orphaned.push((handle.clone(), *idx));
+                            }
+                        }
+                    }
+
+                    if input.json {
+                        #[derive(Serialize)]
+                        struct JsonEntry<'a> {
+                            handle: &'a str,
+                            range: &'a str,
+                            messages: usize,
+                            referenced: bool,
+                            summary: &'a str,
+                        }
+                        #[derive(Serialize)]
+                        struct JsonOrphan {
+                            handle: String,
+                            index: usize,
+                        }
+                        #[derive(Serialize)]
+                        struct JsonList<'a> {
+                            archives: Vec<JsonEntry<'a>>,
+                            orphaned: Vec<JsonOrphan>,
+                        }
+
+                        let archives: Vec<JsonEntry> = rows
+                            .iter()
+                            .map(|r| JsonEntry {
+                                handle: r.handle,
+                                range: r.range.as_str(),
+                                messages: r.count,
+                                referenced: r.referenced,
+                                summary: r.summary.as_str(),
+                            })
+                            .collect();
+                        let orphaned_json: Vec<JsonOrphan> = orphaned
+                            .into_iter()
+                            .map(|(h, i)| JsonOrphan { handle: h, index: i })
+                            .collect();
+
+                        let payload = JsonList {
+                            archives,
+                            orphaned: orphaned_json,
+                        };
+                        return Ok(ToolResultOutput::from(
+                            serde_json::to_string_pretty(&payload)
+                                .unwrap_or_else(|_| "{\"error\":\"serialization\"}".into()),
+                        ));
+                    }
+
+                    let mut out = String::from(
+                        "# Archived Memories\n\nHandle | Range | Count | Referenced | Summary\n--- | --- | --- | --- | ---\n",
+                    );
+                    for r in &rows {
+                        out.push_str(&format!(
+                            "{} | {} | {} | {} | {}\n",
+                            r.handle,
+                            r.range,
+                            r.count,
+                            if r.referenced { "yes" } else { "no" },
+                            r.summary
+                        ));
+                    }
+                    if !orphaned.is_empty() {
+                        out.push_str("\nOrphaned placeholders (not in store):\n");
+                        for (h, idx) in orphaned {
+                            out.push_str(&format!("- index {} handle {}\n", idx, h));
+                        }
+                    }
+                    Ok(ToolResultOutput::from(out))
+                }
+
+                MemoryOperation::Restore => {
+                    let handle = input
+                        .memory_handle
+                        .ok_or_else(|| anyhow!("memory_handle required for restore"))?;
+                    let mut archived = {
+                        let guard = memory_store().lock();
+                        guard
+                            .get(&handle)
+                            .ok_or_else(|| anyhow!("unknown memory handle: {}", handle))?
+                            .clone()
+                    };
+
+                    let insert_index = input.restore_insert_index.unwrap_or_else(|| messages.len());
+
+                    archived.restored_count += 1;
+                    archived.last_restored_at = Some(std::time::SystemTime::now());
+                    {
+                        let mut guard = memory_store().lock();
+                        guard.insert(handle.clone(), archived.clone());
+                        let _ = persist_store();
+                    }
+
+                    #[derive(Serialize)]
+                    struct RestoreMessage {
+                        role: String,
+                        ui_text: String,
+                        model_text: String,
+                    }
+                    #[derive(Serialize)]
+                    struct ConversationMutationInsert {
+                        action: &'static str,
+                        index: usize,
+                        messages: Vec<RestoreMessage>,
+                    }
+                    #[derive(Serialize)]
+                    struct ConversationMutationRemove {
+                        action: &'static str,
+                        handle: String,
+                        replacement_text: Option<String>,
+                    }
+
+                    let converted: Vec<RestoreMessage> = archived
+                        .messages
+                        .iter()
+                        .map(|m| {
+                            let text = m
+                                .content
+                                .iter()
+                                .map(|c| match c {
+                                    MessageContent::Text(t) => t.as_str(),
+                                    MessageContent::Thinking { text, .. } => text.as_str(),
+                                    MessageContent::RedactedThinking(t) => t.as_str(),
+                                    MessageContent::Image(_) => "[Image]",
+                                    MessageContent::ToolUse(_) => "[Tool Use]",
+                                    MessageContent::ToolResult(_) => "[Tool Result]",
+                                })
+                                .collect::<Vec<_>>()
+                                .join("\n");
+                            RestoreMessage {
+                                role: match m.role {
+                                    Role::User => "user".into(),
+                                    Role::Assistant => "assistant".into(),
+                                    Role::System => "system".into(),
+                                },
+                                ui_text: text.clone(),
+                                model_text: text,
+                            }
+                        })
+                        .collect();
+
+                    let mut _mutations: Vec<serde_json::Value> = Vec::new();
+                    _mutations.push(
+                        serde_json::to_value(ConversationMutationInsert {
+                            action: "insert_at",
+                            index: insert_index,
+                            messages: converted,
+                        })
+                        .unwrap(),
+                    );
+
+                    if input.remove_placeholder {
+                        _mutations.push(
+                            serde_json::to_value(ConversationMutationRemove {
+                                action: "remove_placeholder",
+                                handle: handle.clone(),
+                                replacement_text: None,
+                            })
+                            .unwrap(),
+                        );
+                    } else if let Some(rep) = input.replace_placeholder_with.clone() {
+                        _mutations.push(
+                            serde_json::to_value(ConversationMutationRemove {
+                                action: "remove_placeholder",
+                                handle: handle.clone(),
+                                replacement_text: Some(rep.clone()),
+                            })
+                            .unwrap(),
+                        );
+                    }
+
+                    let mut out = format!(
+                        "Restored {} messages from {} at index {}",
+                        archived.messages.len(),
+                        handle,
+                        insert_index
+                    );
+                    if input.remove_placeholder {
+                        out.push_str("\nPlaceholder removed.");
+                    } else if let Some(rep) = input.replace_placeholder_with {
+                        out.push_str(&format!("\nPlaceholder replaced with: {}", rep));
+                    }
+                    Ok(ToolResultOutput::from(out))
+                }
+
+                MemoryOperation::Prune => {
+                    let mut referenced = HashSet::new();
+                    for msg in &messages {
+                        let body = msg
+                            .content
+                            .iter()
+                            .map(|c| match c {
+                                MessageContent::Text(t) => t.clone(),
+                                MessageContent::Thinking { text, .. } => text.clone(),
+                                MessageContent::RedactedThinking(t) => t.clone(),
+                                MessageContent::Image(_) => "[Image]".into(),
+                                MessageContent::ToolUse(_) => "[Tool Use]".into(),
+                                MessageContent::ToolResult(_) => "[Tool Result]".into(),
+                            })
+                            .collect::<Vec<_>>()
+                            .join("\n");
+                        if let Some(caps) =
+                            placeholder_regex().captures(body.lines().next().unwrap_or("").trim())
+                        {
+                            if let Some(handle) = caps.name("handle") {
+                                referenced.insert(handle.as_str().to_string());
+                            }
+                        }
+                    }
+
+                    let mut guard = memory_store().lock();
+                    let before = guard.len();
+                    let handles: Vec<String> = guard.keys().cloned().collect();
+                    let mut pruned = 0;
+                    for h in handles {
+                        if !referenced.contains(&h) {
+                            guard.remove(&h);
+                            pruned += 1;
+                        }
+                    }
+                    if pruned > 0 {
+                        let _ = persist_store();
+                    }
+                    let out = format!(
+                        "Prune complete. initial={} pruned={} remaining={} referenced_placeholders={}",
+                        before,
+                        pruned,
+                        guard.len(),
+                        referenced.len()
+                    );
+                    Ok(ToolResultOutput::from(out))
+                }
+
+                MemoryOperation::Stats => {
+                    let guard = memory_store().lock();
+
+                    let mut total_archives = 0usize;
+                    let mut total_messages = 0usize;
+                    let mut total_chars = 0usize;
+                    let mut total_tokens = 0usize;
+                    let mut restored_archives = 0usize;
+
+                    for (_h, a) in guard.iter() {
+                        total_archives += 1;
+                        total_messages += a.messages.len();
+                        total_chars += a.char_count;
+                        total_tokens += a.token_estimate;
+                        if a.restored_count > 0 {
+                            restored_archives += 1;
+                        }
+                    }
+
+                    let (per_message_tokens, active_tokens) =
+                        per_message_precise_tokens(&model, &base_request, &messages, &*async_cx)
+                            .await?;
+
+                    let usage_pct = if max_context_tokens > 0 {
+                        (active_tokens as f64 / max_context_tokens as f64) * 100.0
+                    } else {
+                        0.0
+                    };
+
+                    let avg_chars = if total_archives > 0 {
+                        total_chars as f64 / total_archives as f64
+                    } else {
+                        0.0
+                    };
+                    let avg_tokens = if total_archives > 0 {
+                        total_tokens as f64 / total_archives as f64
+                    } else {
+                        0.0
+                    };
+
+                    let mut recommendation = String::new();
+                    if usage_pct > 70.0 && !messages.is_empty() {
+                        let target = (max_context_tokens as f64 * 0.60) as usize;
+                        let to_free = active_tokens.saturating_sub(target);
+                        if to_free > 0 {
+                            let mut acc = 0usize;
+                            let mut end_index = 0usize;
+                            for (i, m) in messages.iter().enumerate() {
+                                let is_placeholder = m
+                                    .content
+                                    .iter()
+                                    .find_map(|c| {
+                                        if let MessageContent::Text(t) = c {
+                                            if placeholder_regex()
+                                                .is_match(t.lines().next().unwrap_or("").trim())
+                                            {
+                                                Some(())
+                                            } else {
+                                                None
+                                            }
+                                        } else {
+                                            None
+                                        }
+                                    })
+                                    .is_some();
+                                if is_placeholder {
+                                    break;
+                                }
+                                acc += per_message_tokens[i];
+                                end_index = i;
+                                if acc >= to_free {
+                                    break;
+                                }
+                            }
+                            if end_index > 0 {
+                                let mut seed = String::new();
+                                for m in &messages[0..=end_index] {
+                                    if let Some(text) = m.content.iter().find_map(|c| {
+                                        if let MessageContent::Text(t) = c {
+                                            let trimmed = t.trim();
+                                            if !trimmed.is_empty() {
+                                                Some(trimmed)
+                                            } else {
+                                                None
+                                            }
+                                        } else {
+                                            None
+                                        }
+                                    }) {
+                                        seed = text.lines().next().unwrap_or(text).to_string();
+                                        break;
+                                    }
+                                }
+                                if seed.len() > 140 {
+                                    seed.truncate(140);
+                                    seed.push_str("...");
+                                }
+                                let projected_tokens = active_tokens.saturating_sub(acc);
+                                let projected_pct = if max_context_tokens > 0 {
+                                    (projected_tokens as f64 / max_context_tokens as f64) * 100.0
+                                } else {
+                                    0.0
+                                };
+                                recommendation = format!(
+                                    "Recommendation: store messages 0..{end} (~{freed} tokens) lowering usage {:.2}% -> {:.2}%.\nSuggested summary: \"{} ({} msgs)\".\nExample call: {{\"operation\":\"store\",\"start_index\":0,\"end_index\":{end},\"summary\":\"{} ({} msgs)\"}}",
+                                    usage_pct,
+                                    projected_pct,
+                                    seed,
+                                    end_index + 1,
+                                    seed,
+                                    end_index + 1,
+                                    end = end_index,
+                                    freed = acc
+                                );
+                            }
+                        }
+                    }
+
+                    let mut out = String::new();
+                    out.push_str("# Memory & Context Stats\n\n");
+                    out.push_str("## Active Context\n");
+                    out.push_str(&format!("Active tokens: {}\n", active_tokens));
+                    out.push_str(&format!("Model max tokens: {}\n", max_context_tokens));
+                    out.push_str(&format!("Usage: {:.2}%\n\n", usage_pct));
+
+                    out.push_str("## Archived\n");
+                    out.push_str(&format!("Archives: {}\n", total_archives));
+                    out.push_str(&format!("Archived messages: {}\n", total_messages));
+                    out.push_str(&format!("Archived chars: {}\n", total_chars));
+                    out.push_str(&format!("Archived tokens: {}\n", total_tokens));
+                    out.push_str(&format!("Avg chars/archive: {:.2}\n", avg_chars));
+                    out.push_str(&format!("Avg tokens/archive: {:.2}\n", avg_tokens));
+                    out.push_str(&format!(
+                        "Restored archives (ever): {}\n\n",
+                        restored_archives
+                    ));
+
+                    out.push_str("## Per-Message Tokens (first 30)\n");
+                    for (i, t) in per_message_tokens.iter().take(30).enumerate() {
+                        out.push_str(&format!("Message {}: {} tokens\n", i, t));
+                    }
+                    if per_message_tokens.len() > 30 {
+                        out.push_str(&format!(
+                            "... ({} more messages)\n",
+                            per_message_tokens.len() - 30
+                        ));
+                    }
+                    out.push('\n');
+
+                    out.push_str("## Action\n");
+                    if !recommendation.is_empty() {
+                        out.push_str(&recommendation);
+                        out.push('\n');
+                    } else if usage_pct > 70.0 {
+                        out.push_str(
+                            "Context above threshold but no contiguous initial non-placeholder span found.\n",
+                        );
+                    } else {
+                        out.push_str("No immediate action needed (below 70%).\n");
+                    }
+
+                    Ok(ToolResultOutput::from(out))
+                }
+            }
+        });
+
+        ToolResult {
+            output: task,
+            card: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Removed test_placeholder_regex_parses_basic (parse_placeholder removed)
+
+    // Removed test_placeholder_regex_without_tokens (parse_placeholder removed)
+
+    #[test]
+    fn test_generate_preview_truncates() {
+        let msg = LanguageModelRequestMessage {
+            role: Role::User,
+            content: vec![MessageContent::Text("a".repeat(300))],
+            cache: false,
+        };
+        let preview = generate_preview(&[msg], 100);
+        assert!(
+            preview.len() <= 120,
+            "preview should truncate and append marker"
+        );
+    }
+
+    #[test]
+    fn test_generate_heuristic_summary() {
+        let msg = LanguageModelRequestMessage {
+            role: Role::User,
+            content: vec![MessageContent::Text(
+                "This is a fairly long line that should appear as the first line".into(),
+            )],
+            cache: false,
+        };
+        let summary = generate_heuristic_summary(&[msg], 1);
+        assert!(
+            summary.contains("(1 msgs)"),
+            "summary should contain message count"
+        );
+    }
+}

--- a/crates/assistant_tools/src/context_management/memory_tool/description.md
+++ b/crates/assistant_tools/src/context_management/memory_tool/description.md
@@ -1,0 +1,153 @@
+# Memory Tool
+
+Archive, load, list, restore, or prune conversation message segments to manage context window usage while maintaining precise awareness of token consumption.
+
+## Purpose
+
+The memory tool provides comprehensive management of conversation context by allowing you to:
+- Archive contiguous ranges of messages to free up context window space (precise token counts captured at archive time)
+- Load archived content for inspection without modifying the conversation
+- List all memory placeholders in the current conversation
+- Restore archived messages back into the conversation
+- Prune unused archived memories
+
+## Operations
+
+### Store
+
+Archive a contiguous range of messages, replacing them with a compact placeholder. The placeholder includes precise token and character counts captured at the time of storage.
+
+**Required Parameters:**
+- `operation`: "store"
+- `start_index`: Inclusive starting message index
+- `end_index`: Inclusive ending message index
+
+**Optional Parameters:**
+- `summary`: User-defined summary of the archived content (Include forward-relevant decisions, constraints, commitments, evolving preferences, and open questions. Avoid merely paraphrasing; capture what future turns will need to recall.)
+- `auto`: If true and summary is omitted, generates a heuristic summary (default: false)
+- `max_preview_chars`: Character limit for preview (default: 200, clamped 40-400)
+
+**Example:**
+```json
+{
+  "operation": "store",
+  "start_index": 5,
+  "end_index": 30,
+  "auto": true,
+  "max_preview_chars": 200
+}
+```
+
+**Output:** Creates a memory handle (e.g., `mem://session-id/uuid`) and replaces the message range with a placeholder containing the handle, summary, preview, and precise token count (`tokens=...`).
+
+### Load
+
+Retrieve the full original content of an archived memory for inspection.
+
+**Required Parameters:**
+- `operation`: "load"
+- `memory_handle`: The handle returned from a store operation
+
+**Example:**
+```json
+{
+  "operation": "load",
+  "memory_handle": "mem://session-123/abc-def-456"
+}
+```
+
+**Output:** Full markdown content of all archived messages with their roles and indices.
+
+### List
+
+Scan the current conversation thread for memory placeholders.
+
+**Required Parameters:**
+- `operation`: "list"
+
+**Example:**
+```json
+{
+  "operation": "list"
+}
+```
+
+**Output:** A list of all memory placeholders found in the conversation, showing their indices, handles, and metadata.
+
+### Restore
+
+Insert archived messages back into the conversation.
+
+**Required Parameters:**
+- `operation`: "restore"
+- `memory_handle`: The handle of the memory to restore
+
+**Optional Parameters:**
+- `restore_insert_index`: Target position for insertion (default: append to end)
+- `remove_placeholder`: If true, removes the placeholder from its original location (default: false)
+- `replace_placeholder_with`: Text to replace the placeholder with
+
+**Example:**
+```json
+{
+  "operation": "restore",
+  "memory_handle": "mem://session-123/abc-def-456",
+  "restore_insert_index": 100,
+  "remove_placeholder": true
+}
+```
+
+**Output:** Confirmation of restoration with message count and insertion position.
+
+### Prune
+
+Remove archived memories that no longer have corresponding placeholders in the conversation.
+
+**Required Parameters:**
+- `operation`: "prune"
+
+**Example:**
+```json
+{
+  "operation": "prune"
+}
+```
+
+**Output:** Report of pruning operation and remaining memory count.
+
+## Memory Placeholder Format
+
+When messages are archived, they are replaced with a structured placeholder:
+
+```
+[[memory archived handle=mem://session-id/uuid range=5..30 messages=26 chars=12450]]
+Summary: Initial project setup discussion and requirements gathering (26 msgs)
+Preview: User: I need help setting up a new React project...
+```
+
+## Typical Workflow
+
+1. Use `list_history` to inspect conversation messages
+2. Identify a range of older messages that can be archived (favor large low-signal stretches: logs, long raw code blocks, enumerations)
+3. Call `memory` with operation "store" to archive them (precise token count recorded)
+4. Continue conversation with freed context space; placeholders remain compact
+5. If needed, use `memory` with operation "load" to inspect archived content without inflating active token usage
+6. Use `memory` with operation "restore" if archived information becomes relevant again (then optionally re-store with a refined summary)
+7. Periodically use `memory` with operation "prune" to clean up unused archives
+
+## When to Use
+
+- **Store**: When active precise token usage exceeds ~70% of model context (aim to drop usage back toward 55–60%)
+- **Load**: To review archived content without restoring it (no token expansion)
+- **List**: To see which ranges are compacted and track their handles
+- **Restore**: When archived information becomes relevant enough to justify reintroducing full detail
+- **Prune**: To remove orphaned archives whose placeholders were deleted or replaced
+
+## Notes
+
+- Archives are stored in-memory for the session duration
+- Memory handles are unique per session and UUID
+- Archived content can be safely restored multiple times
+- Summaries are user-provided or auto-generated (first non-empty line up to 140 chars). Make them forward-relevant: encode decisions, constraints, preferences, pending follow-ups, assumptions, and unresolved risks—exclude transient narration or redundant paraphrase.
+- Previews are truncated with "...(truncated)" if they exceed max_preview_chars
+- Stats use precise per-message token accounting (prefix method) and will recommend an early contiguous archive range if usage > 70%


### PR DESCRIPTION
https://github.com/zed-industries/zed/discussions/39437

Summary
This PR introduces a minimal, self‑contained subset of context management functionality focused on:
- Memory archival tool (`memory_tool`) with forward‑relevant summary guidance
- History inspection tool (`list_history_tool`)
- Integration test file exercising core lifecycle paths (store, list, load, restore, auto summary)
- Stand‑alone test specification document for manual and LLM-driven validation

Included Files
- TESTING_MEMORY_AND_HISTORY.md (spec + guidance)
- crates/assistant_tools/src/context_management/memory_tool.rs
- crates/assistant_tools/src/context_management/memory_tool/description.md
- crates/assistant_tools/src/context_management/list_history_tool.rs
- crates/assistant_tools/src/context_management/list_history_tool/description.md
- crates/agent2/src/tests/memory_history_integration_tests.rs

Scope / Intent
This branch deliberately excludes unrelated broader refactors and focuses on delivering:
1. A documented high-signal workflow to compress conversational context.
2. A consistent pair of tools (history enumeration + archival) with predictable markdown output.
3. Tests that validate essential behaviors without depending on full model interaction.

Key Behaviors Covered
- Store with explicit summary
- Store with auto summary (auto=true, no summary provided)
- List multiple archives (table format)
- Load (excerpt + summary)
- Restore with:
  - Placeholder replacement
  - Placeholder removal (attempted path; current implementation keeps placeholder flagged)
- Negative path: (Implicit) Non-applicability of prune-based selective deletion (prune only acts when placeholder is fully gone—current test notes that no archives pruned)

Forward-Relevant Summary Guidance
Documentation emphasizes storing decisions, constraints, preferences, unresolved questions—not simple paraphrase. This improves downstream memory usefulness.

Out of Scope (Deferred)
- Targeted prune (by handle or range)
- Validation rejecting empty summaries (currently allowed)
- Ordering guarantees for list output (filesystem iteration ordering not enforced)
- Detailed token accounting assertions (tool currently exposes summary, not numeric token lines)
- Cross-session persistence

Reviewer Notes
- The tests use gpui async harness and operate directly on constructed thread entities.
- No panicking unwraps are introduced; errors propagate via anyhow::Result.
- Placeholder removal logic may need a follow-up fix if prune semantics are expected to succeed post removal. (List still reports Placeholder: yes after a remove.)
- If you want deterministic sorting in list output, a simple sort by created_at or handle can be added later.

Potential Follow-Ups
1. Add prune by handle / range parameters.
2. Enforce non-empty summary unless auto=true.
3. Add explicit token metrics line for archive introspection.
4. Provide structured (machine-parsable) JSON alongside markdown.
5. Stabilize table column ordering & add metadata schema doc.

Testing Instructions
1. Run integration tests:
   cargo test -q memory_history_integration_tests
   (If gpui macro discovery needs adjustments, wrap async tests in plain #[test] executors as a fallback.)
2. Manual tool flow (simulated LLM):
   a. list_history (capture indices)
   b. memory store (range)
   c. memory list (verify table row)
   d. memory load (summary + excerpt)
   e. memory restore (replace or remove placeholder)
   f. memory prune (observe current “No archives pruned.” behavior if placeholder still considered present)

Risk Assessment
Low. New files only; no invasive changes to unrelated runtime logic. The memory and list_history tool modules are isolated and documented. Any future expansion (prune variants, metadata enhancements) can be layered without breaking current consumers.

Migration / Compatibility
None required—tools are additive. Existing integrations that do not register these tools remain unaffected.