### PR TITLE
auto_update: Improve error message when `rsync` was not found

### DIFF
--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -649,7 +649,7 @@ impl AutoUpdater {
         #[cfg(not(target_os = "windows"))]
         anyhow::ensure!(
             which::which("rsync").is_ok(),
-            "Aborting. Could not find rsync which is required for auto-updates."
+            "Could not auto-update because the required rsync utility was not found."
         );
         Ok(())
     }


### PR DESCRIPTION
**Improve the user experience.**

(No code changes here, "just" change a message.)

Closes #ISSUE

Release Notes:

- N/A *or* Added/Fixed/Improved ...
Improved
