### PR TITLE
Improve TS and JS symbol outline

### DIFF
--- a/crates/languages/src/javascript/outline.scm
+++ b/crates/languages/src/javascript/outline.scm
@@ -177,15 +177,13 @@
     )
 ) @item
 
-; All object properties within variable declarations (including methods, functions, and primitives)
-(variable_declarator
-    value: (object
-        (pair
-            key: [
-                (property_identifier) @name
-                (string (string_fragment) @name)
-                (number) @name
-            ]) @item))
+; All object properties
+(pair
+    key: [
+        (property_identifier) @name
+        (string (string_fragment) @name)
+        (number) @name
+    ]) @item
 
 ; Nested const/let declarations in function/method bodies
 (statement_block

--- a/crates/languages/src/javascript/outline.scm
+++ b/crates/languages/src/javascript/outline.scm
@@ -31,18 +31,52 @@
     (export_statement
         (lexical_declaration
             ["let" "const"] @context
-            ; Multiple names may be exported - @item is on the declarator to keep
+            ; Multiple names may be exported - @item is on the identifier to keep
             ; ranges distinct.
             (variable_declarator
-                name: (_) @name) @item)))
+                name: (identifier) @name @item))))
+
+(program
+    (export_statement
+        (lexical_declaration
+            ["let" "const"] @context
+            (variable_declarator
+                name: (array_pattern
+                    (identifier) @name @item)))))
+
+(program
+    (export_statement
+        (lexical_declaration
+            ["let" "const"] @context
+            (variable_declarator
+                name: (object_pattern
+                    [(shorthand_property_identifier_pattern) @name @item
+                     (pair_pattern
+                         value: (identifier) @name @item)])))))
 
 (program
     (lexical_declaration
         ["let" "const"] @context
-        ; Multiple names may be defined - @item is on the declarator to keep
+        ; Multiple names may be defined - @item is on the identifier to keep
         ; ranges distinct.
         (variable_declarator
-            name: (_) @name) @item))
+            name: (identifier) @name @item)))
+
+(program
+    (lexical_declaration
+        ["let" "const"] @context
+        (variable_declarator
+            name: (array_pattern
+                (identifier) @name @item))))
+
+(program
+    (lexical_declaration
+        ["let" "const"] @context
+        (variable_declarator
+            name: (object_pattern
+                [(shorthand_property_identifier_pattern) @name @item
+                 (pair_pattern
+                     value: (identifier) @name @item)]))))
 
 (class_declaration
     "class" @context
@@ -143,12 +177,21 @@
     (lexical_declaration
         ["let" "const"] @context
         (variable_declarator
-            name: [
-                (identifier) @name
-                (array_pattern (identifier) @name)
-                (object_pattern
-                    [(shorthand_property_identifier_pattern) @name
-                     (pair_pattern value: (identifier) @name)])
-            ]) @item))
+            name: (identifier) @name @item)))
+
+(statement_block
+    (lexical_declaration
+        ["let" "const"] @context
+        (variable_declarator
+            name: (array_pattern
+                (identifier) @name @item))))
+
+(statement_block
+    (lexical_declaration
+        ["let" "const"] @context
+        (variable_declarator
+            name: (object_pattern
+                [(shorthand_property_identifier_pattern) @name @item
+                 (pair_pattern value: (identifier) @name @item)]))))
 
 (comment) @annotation

--- a/crates/languages/src/javascript/outline.scm
+++ b/crates/languages/src/javascript/outline.scm
@@ -185,6 +185,12 @@
         (number) @name
     ]) @item
 
+; Computed object properties
+(pair
+    key: [
+        (computed_property_name) @name
+    ]) @item
+
 ; Nested const/let declarations in function/method bodies
 (statement_block
     (lexical_declaration
@@ -192,6 +198,7 @@
         (variable_declarator
             name: (identifier) @name) @item))
 
+; Nested array destructuring in function/method bodies
 (statement_block
     (lexical_declaration
         ["let" "const"] @context
@@ -203,6 +210,7 @@
                     (rest_pattern (identifier) @name @item)
                 ]))))
 
+; Nested object destructuring in function/method bodies
 (statement_block
     (lexical_declaration
         ["let" "const"] @context

--- a/crates/languages/src/javascript/outline.scm
+++ b/crates/languages/src/javascript/outline.scm
@@ -34,6 +34,7 @@
             (variable_declarator
                 name: (identifier) @name) @item)))
 
+; Exported array destructuring
 (program
     (export_statement
         (lexical_declaration
@@ -46,6 +47,7 @@
                         (rest_pattern (identifier) @name @item)
                     ])))))
 
+; Exported object destructuring
 (program
     (export_statement
         (lexical_declaration
@@ -65,6 +67,7 @@
         (variable_declarator
             name: (identifier) @name) @item))
 
+; Top-level array destructuring
 (program
     (lexical_declaration
         ["let" "const"] @context
@@ -76,6 +79,7 @@
                     (rest_pattern (identifier) @name @item)
                 ]))))
 
+; Top-level object destructuring
 (program
     (lexical_declaration
         ["let" "const"] @context
@@ -110,7 +114,7 @@
           "(" @context
           ")" @context)) @item)
 
-; Method definitions in object literals (nested under variable)
+; Object literal methods
 (variable_declarator
     value: (object
         (method_definition
@@ -177,28 +181,23 @@
     )
 ) @item
 
-; All object properties
+; Object properties
 (pair
     key: [
         (property_identifier) @name
         (string (string_fragment) @name)
         (number) @name
-    ]) @item
-
-; Computed object properties
-(pair
-    key: [
         (computed_property_name) @name
     ]) @item
 
-; Nested const/let declarations in function/method bodies
+; Nested variables in function bodies
 (statement_block
     (lexical_declaration
         ["let" "const"] @context
         (variable_declarator
             name: (identifier) @name) @item))
 
-; Nested array destructuring in function/method bodies
+; Nested array destructuring in functions
 (statement_block
     (lexical_declaration
         ["let" "const"] @context
@@ -210,7 +209,7 @@
                     (rest_pattern (identifier) @name @item)
                 ]))))
 
-; Nested object destructuring in function/method bodies
+; Nested object destructuring in functions
 (statement_block
     (lexical_declaration
         ["let" "const"] @context

--- a/crates/languages/src/javascript/outline.scm
+++ b/crates/languages/src/javascript/outline.scm
@@ -116,4 +116,39 @@
     )
 ) @item
 
+; Object methods (properties with function values)
+(pair
+    key: [
+        (property_identifier) @name
+        (string (string_fragment) @name)
+        (number) @name
+    ]
+    value: [
+        (function_expression)
+        (arrow_function)
+        (generator_function)
+    ]) @item
+
+; Object properties with object values (nested structures)
+(pair
+    key: [
+        (property_identifier) @name
+        (string (string_fragment) @name)
+        (number) @name
+    ]
+    value: (object)) @item
+
+; Nested const/let declarations in function/method bodies
+(statement_block
+    (lexical_declaration
+        ["let" "const"] @context
+        (variable_declarator
+            name: [
+                (identifier) @name
+                (array_pattern (identifier) @name)
+                (object_pattern
+                    [(shorthand_property_identifier_pattern) @name
+                     (pair_pattern value: (identifier) @name)])
+            ]) @item))
+
 (comment) @annotation

--- a/crates/languages/src/javascript/outline.scm
+++ b/crates/languages/src/javascript/outline.scm
@@ -177,7 +177,7 @@
     )
 ) @item
 
-; Object methods within variable declarations
+; All object properties within variable declarations (including methods, functions, and primitives)
 (variable_declarator
     value: (object
         (pair
@@ -185,25 +185,7 @@
                 (property_identifier) @name
                 (string (string_fragment) @name)
                 (number) @name
-            ]
-            value: [
-                (function_expression)
-                (arrow_function)
-                (generator_function)
             ]) @item))
-
-
-
-; Object properties with object values within variable declarations
-(variable_declarator
-    value: (object
-        (pair
-            key: [
-                (property_identifier) @name
-                (string (string_fragment) @name)
-                (number) @name
-            ]
-            value: (object)) @item))
 
 ; Nested const/let declarations in function/method bodies
 (statement_block

--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -1189,6 +1189,7 @@ mod tests {
                 ("p3", 1),
                 ("const q", 0),
                 ("r", 1),
+                ("s", 2),
                 ("t", 1),
                 ("function getData()", 0),
                 ("const local", 1),

--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -1073,6 +1073,13 @@ mod tests {
             // Top-level destructuring
             const { a1, a2 } = a;
             const [b1, b2] = b;
+            
+            // Defaults and rest
+            const [c1 = 1, , c2, ...rest1] = c;
+            const { d1, d2: e1, f1 = 2, g1: h1 = 3, ...rest2 } = d;
+            
+            // Object with function properties
+            const o = { m() {}, async n() {}, g: function* () {}, h: () => {}, k: function () {} };
 
             function processData() {
               // Nested object destructuring
@@ -1081,12 +1088,16 @@ mod tests {
               const [d1, d2, d3] = d;
               // Destructuring with renaming
               const { f1: g1 } = f;
+              // With defaults
+              const [x = 10, y] = xy;
+              const { z = 20 } = obj;
             }
 
             class DataHandler {
               method() {
                 // Destructuring in class method
                 const { a1, a2 } = a;
+                const [b1, ...b2] = b;
               }
             }
         "#
@@ -1105,6 +1116,19 @@ mod tests {
                 ("const a2", 0),
                 ("const b1", 0),
                 ("const b2", 0),
+                ("const c1", 0),
+                ("const c2", 0),
+                ("const rest1", 0),
+                ("const d1", 0),
+                ("const e1", 0),
+                ("const h1", 0),
+                ("const rest2", 0),
+                ("const o", 0),
+                ("m()", 1),
+                ("async n()", 1),
+                ("g", 1),
+                ("h", 1),
+                ("k", 1),
                 ("function processData()", 0),
                 ("const c1", 1),
                 ("const c2", 1),
@@ -1112,10 +1136,14 @@ mod tests {
                 ("const d2", 1),
                 ("const d3", 1),
                 ("const g1", 1),
+                ("const x", 1),
+                ("const y", 1),
                 ("class DataHandler", 0),
                 ("method()", 1),
                 ("const a1", 2),
                 ("const a2", 2),
+                ("const b1", 2),
+                ("const b2", 2),
             ]
         );
     }

--- a/crates/languages/src/typescript/outline.scm
+++ b/crates/languages/src/typescript/outline.scm
@@ -183,15 +183,13 @@
     )
 ) @item
 
-; All object properties within variable declarations (including methods, functions, and primitives)
-(variable_declarator
-    value: (object
-        (pair
-            key: [
-                (property_identifier) @name
-                (string (string_fragment) @name)
-                (number) @name
-            ]) @item))
+; All object properties
+(pair
+    key: [
+        (property_identifier) @name
+        (string (string_fragment) @name)
+        (number) @name
+    ]) @item
 
 ; Nested const/let declarations in function/method bodies
 (statement_block

--- a/crates/languages/src/typescript/outline.scm
+++ b/crates/languages/src/typescript/outline.scm
@@ -191,6 +191,12 @@
         (number) @name
     ]) @item
 
+; Computed object properties
+(pair
+    key: [
+        (computed_property_name) @name
+    ]) @item
+
 ; Nested const/let declarations in function/method bodies
 (statement_block
     (lexical_declaration
@@ -198,6 +204,7 @@
         (variable_declarator
             name: (identifier) @name) @item))
 
+; Nested array destructuring in function/method bodies
 (statement_block
     (lexical_declaration
         ["let" "const"] @context
@@ -209,6 +216,7 @@
                     (rest_pattern (identifier) @name @item)
                 ]))))
 
+; Nested object destructuring in function/method bodies
 (statement_block
     (lexical_declaration
         ["let" "const"] @context

--- a/crates/languages/src/typescript/outline.scm
+++ b/crates/languages/src/typescript/outline.scm
@@ -37,6 +37,7 @@
         (variable_declarator
             name: (identifier) @name) @item))
 
+; Exported array destructuring
 (export_statement
     (lexical_declaration
         ["let" "const"] @context
@@ -48,6 +49,7 @@
                     (rest_pattern (identifier) @name @item)
                 ]))))
 
+; Exported object destructuring
 (export_statement
     (lexical_declaration
         ["let" "const"] @context
@@ -66,6 +68,7 @@
         (variable_declarator
             name: (identifier) @name) @item))
 
+; Top-level array destructuring
 (program
     (lexical_declaration
         ["let" "const"] @context
@@ -77,6 +80,7 @@
                     (rest_pattern (identifier) @name @item)
                 ]))))
 
+; Top-level object destructuring
 (program
     (lexical_declaration
         ["let" "const"] @context
@@ -116,7 +120,7 @@
           "(" @context
           ")" @context)) @item)
 
-; Method definitions in object literals (nested under variable)
+; Object literal methods
 (variable_declarator
     value: (object
         (method_definition
@@ -183,28 +187,24 @@
     )
 ) @item
 
-; All object properties
+; Object properties
 (pair
     key: [
         (property_identifier) @name
         (string (string_fragment) @name)
         (number) @name
-    ]) @item
-
-; Computed object properties
-(pair
-    key: [
         (computed_property_name) @name
     ]) @item
 
-; Nested const/let declarations in function/method bodies
+
+; Nested variables in function bodies
 (statement_block
     (lexical_declaration
         ["let" "const"] @context
         (variable_declarator
             name: (identifier) @name) @item))
 
-; Nested array destructuring in function/method bodies
+; Nested array destructuring in functions
 (statement_block
     (lexical_declaration
         ["let" "const"] @context
@@ -216,7 +216,7 @@
                     (rest_pattern (identifier) @name @item)
                 ]))))
 
-; Nested object destructuring in function/method bodies
+; Nested object destructuring in functions
 (statement_block
     (lexical_declaration
         ["let" "const"] @context

--- a/crates/languages/src/typescript/outline.scm
+++ b/crates/languages/src/typescript/outline.scm
@@ -34,26 +34,26 @@
 (export_statement
     (lexical_declaration
         ["let" "const"] @context
-        ; Multiple names may be exported - @item is on the declarator to keep
+        ; Multiple names may be exported - @item is on the identifier to keep
         ; ranges distinct.
         (variable_declarator
-            name: (identifier) @name) @item))
+            name: (identifier) @name @item)))
 
 (export_statement
     (lexical_declaration
         ["let" "const"] @context
         (variable_declarator
             name: (array_pattern
-                (identifier) @name)) @item))
+                (identifier) @name @item))))
 
 (export_statement
     (lexical_declaration
         ["let" "const"] @context
         (variable_declarator
             name: (object_pattern
-                [(shorthand_property_identifier_pattern) @name
+                [(shorthand_property_identifier_pattern) @name @item
                  (pair_pattern
-                     value: (identifier) @name)])) @item))
+                     value: (identifier) @name @item)]))))
 
 (program
     (lexical_declaration
@@ -61,23 +61,23 @@
         ; Multiple names may be defined - @item is on the declarator to keep
         ; ranges distinct.
         (variable_declarator
-            name: (identifier) @name) @item))
+            name: (identifier) @name @item)))
 
 (program
     (lexical_declaration
         ["let" "const"] @context
         (variable_declarator
             name: (array_pattern
-                (identifier) @name)) @item))
+                (identifier) @name @item))))
 
 (program
     (lexical_declaration
         ["let" "const"] @context
         (variable_declarator
             name: (object_pattern
-                [(shorthand_property_identifier_pattern) @name
+                [(shorthand_property_identifier_pattern) @name @item
                  (pair_pattern
-                     value: (identifier) @name)])) @item))
+                     value: (identifier) @name @item)]))))
 
 (class_declaration
     "class" @context
@@ -161,12 +161,21 @@
     (lexical_declaration
         ["let" "const"] @context
         (variable_declarator
-            name: [
-                (identifier) @name
-                (array_pattern (identifier) @name)
-                (object_pattern
-                    [(shorthand_property_identifier_pattern) @name
-                     (pair_pattern value: (identifier) @name)])
-            ]) @item))
+            name: (identifier) @name @item)))
+
+(statement_block
+    (lexical_declaration
+        ["let" "const"] @context
+        (variable_declarator
+            name: (array_pattern
+                (identifier) @name @item))))
+
+(statement_block
+    (lexical_declaration
+        ["let" "const"] @context
+        (variable_declarator
+            name: (object_pattern
+                [(shorthand_property_identifier_pattern) @name @item
+                 (pair_pattern value: (identifier) @name @item)]))))
 
 (comment) @annotation

--- a/crates/languages/src/typescript/outline.scm
+++ b/crates/languages/src/typescript/outline.scm
@@ -183,7 +183,7 @@
     )
 ) @item
 
-; Object methods within variable declarations
+; All object properties within variable declarations (including methods, functions, and primitives)
 (variable_declarator
     value: (object
         (pair
@@ -191,25 +191,7 @@
                 (property_identifier) @name
                 (string (string_fragment) @name)
                 (number) @name
-            ]
-            value: [
-                (function_expression)
-                (arrow_function)
-                (generator_function)
             ]) @item))
-
-
-
-; Object properties with object values within variable declarations
-(variable_declarator
-    value: (object
-        (pair
-            key: [
-                (property_identifier) @name
-                (string (string_fragment) @name)
-                (number) @name
-            ]
-            value: (object)) @item))
 
 ; Nested const/let declarations in function/method bodies
 (statement_block

--- a/crates/languages/src/typescript/outline.scm
+++ b/crates/languages/src/typescript/outline.scm
@@ -37,7 +37,23 @@
         ; Multiple names may be exported - @item is on the declarator to keep
         ; ranges distinct.
         (variable_declarator
-            name: (_) @name) @item))
+            name: (identifier) @name) @item))
+
+(export_statement
+    (lexical_declaration
+        ["let" "const"] @context
+        (variable_declarator
+            name: (array_pattern
+                (identifier) @name)) @item))
+
+(export_statement
+    (lexical_declaration
+        ["let" "const"] @context
+        (variable_declarator
+            name: (object_pattern
+                [(shorthand_property_identifier_pattern) @name
+                 (pair_pattern
+                     value: (identifier) @name)])) @item))
 
 (program
     (lexical_declaration
@@ -45,7 +61,23 @@
         ; Multiple names may be defined - @item is on the declarator to keep
         ; ranges distinct.
         (variable_declarator
-            name: (_) @name) @item))
+            name: (identifier) @name) @item))
+
+(program
+    (lexical_declaration
+        ["let" "const"] @context
+        (variable_declarator
+            name: (array_pattern
+                (identifier) @name)) @item))
+
+(program
+    (lexical_declaration
+        ["let" "const"] @context
+        (variable_declarator
+            name: (object_pattern
+                [(shorthand_property_identifier_pattern) @name
+                 (pair_pattern
+                     value: (identifier) @name)])) @item))
 
 (class_declaration
     "class" @context
@@ -123,5 +155,18 @@
         )
     )
 ) @item
+
+; Nested const/let declarations in function/method bodies
+(statement_block
+    (lexical_declaration
+        ["let" "const"] @context
+        (variable_declarator
+            name: [
+                (identifier) @name
+                (array_pattern (identifier) @name)
+                (object_pattern
+                    [(shorthand_property_identifier_pattern) @name
+                     (pair_pattern value: (identifier) @name)])
+            ]) @item))
 
 (comment) @annotation


### PR DESCRIPTION
Added more granular symbols for ts and js in outline panel. This is a bit closer to what vscode offers.

<details><summary>Screenshots of current vs new</summary>
<p>
New:
<img width="1723" height="1221" alt="image" src="https://github.com/user-attachments/assets/796d3b59-fffa-4a66-9986-f7c75e618103" />

Current:
<img width="1714" height="1347" alt="image" src="https://github.com/user-attachments/assets/f7cff463-de2a-4d86-b1a6-e19f4fd8dc6e" />

Current vscode (cursor):
<img width="1710" height="1177" alt="image" src="https://github.com/user-attachments/assets/31902d52-becf-4d3f-960d-7e054e00e32d" />

</p>
</details> 

I have never touched scheme before, and pair-programmed this with ai, so please let me know if there's any glaring issues with the implementation. I just miss the outline panel in vscode very much, and would love to see this land.
Happy to help with tsx/jsx as well if this is the direction you guys were thinking of taking the outline impl.

Doesn't fully close https://github.com/zed-industries/zed/issues/20964 as there is no support for chained class method callbacks or `Class.prototype.method = ...` as mentioned in https://github.com/zed-industries/zed/issues/21243, but this is a step forward.

Release Notes:

- Improved typescript and javascript symbol outline panel
