### PR TITLE
docs: Ensure macOS and Linux keybindings are escaped in HTML

### DIFF
--- a/crates/docs_preprocessor/src/main.rs
+++ b/crates/docs_preprocessor/src/main.rs
@@ -163,6 +163,10 @@ fn template_big_table_of_actions(book: &mut Book) {
     });
 }
 
+fn format_binding(binding: String) -> String {
+    binding.replace("\\", "\\\\")
+}
+
 fn template_and_validate_keybindings(book: &mut Book, errors: &mut HashSet<PreprocessorError>) {
     let regex = Regex::new(r"\{#kb (.*?)\}").unwrap();
 
@@ -183,7 +187,10 @@ fn template_and_validate_keybindings(book: &mut Book, errors: &mut HashSet<Prepr
                     return "<div>No default binding</div>".to_string();
                 }
 
-                format!("<kbd class=\"keybinding\">{macos_binding}|{linux_binding}</kbd>")
+                let formatted_macos_binding = format_binding(macos_binding);
+                let formatted_linux_binding = format_binding(linux_binding);
+
+                format!("<kbd class=\"keybinding\">{formatted_macos_binding}|{formatted_linux_binding}</kbd>")
             })
             .into_owned()
     });


### PR DESCRIPTION
Closes #39654

Release Notes:

- Fixed the formatting of macOS and Linux keybindings in the Zed docs to escape the backslash character when templating.

