### PR TITLE
audio: Move `log::info` into a global import

### DIFF
--- a/crates/audio/src/audio.rs
+++ b/crates/audio/src/audio.rs
@@ -1,12 +1,12 @@
 use anyhow::{Context as _, Result};
 use collections::HashMap;
 use gpui::{App, BackgroundExecutor, BorrowAppContext, Global};
+use log::info;
 
 #[cfg(not(any(all(target_os = "windows", target_env = "gnu"), target_os = "freebsd")))]
 mod non_windows_and_freebsd_deps {
     pub(super) use gpui::AsyncApp;
     pub(super) use libwebrtc::native::apm;
-    pub(super) use log::info;
     pub(super) use parking_lot::Mutex;
     pub(super) use rodio::cpal::Sample;
     pub(super) use rodio::source::LimitSettings;


### PR DESCRIPTION
I didn't find a commit, but it's now required for all platforms, I got this compile error with 0.207.3 tag

``` 
  error: cannot find macro `info` in this scope
     --> crates\audio\src\audio.rs:121:13
      |
  121 |             info!("Output stream: {:?}", output_handle);
      |             ^^^^
      |
  help: consider importing this macro
      |
    1 + use log::info;
      |
  
  error: could not compile `audio` (lib) due to 1 previous error
```

Closes #ISSUE

Release Notes:

- N/A
