### PR TITLE
Do not deselect in terminal on copy by default

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1427,8 +1427,8 @@
     // Whether or not selecting text in the terminal will automatically
     // copy to the system clipboard.
     "copy_on_select": false,
-    // Whether to keep the text selection after copying it to the clipboard
-    "keep_selection_on_copy": false,
+    // Whether to keep the text selection after copying it to the clipboard.
+    "keep_selection_on_copy": true,
     // Whether to show the terminal button in the status bar
     "button": true,
     // Any key-value pairs added to this list will be added to the terminal's

--- a/crates/settings/src/settings_content/terminal.rs
+++ b/crates/settings/src/settings_content/terminal.rs
@@ -89,7 +89,7 @@ pub struct TerminalSettingsContent {
     pub copy_on_select: Option<bool>,
     /// Whether to keep the text selection after copying it to the clipboard.
     ///
-    /// Default: false
+    /// Default: true
     pub keep_selection_on_copy: Option<bool>,
     /// Whether to show the terminal button in the status bar.
     ///

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -3512,7 +3512,7 @@ List of `integer` column numbers
     "alternate_scroll": "off",
     "blinking": "terminal_controlled",
     "copy_on_select": false,
-    "keep_selection_on_copy": false,
+    "keep_selection_on_copy": true,
     "dock": "bottom",
     "default_width": 640,
     "default_height": 320,
@@ -3690,7 +3690,7 @@ List of `integer` column numbers
 
 - Description: Whether or not to keep the selection in the terminal after copying text.
 - Setting: `keep_selection_on_copy`
-- Default: `false`
+- Default: `true`
 
 **Options**
 
@@ -3701,7 +3701,7 @@ List of `integer` column numbers
 ```json
 {
   "terminal": {
-    "keep_selection_on_copy": true
+    "keep_selection_on_copy": false
   }
 }
 ```


### PR DESCRIPTION
Release Notes:

- Changed the `terminal.keep_selection_on_copy` setting's default to `true` to match the default behavior of many terminals. ([#39814](https://github.com/zed-industries/zed/pull/39814))
  - Thanks for the heads up, [Steve Ruiz](https://x.com/steveruizok/status/1976030698420175162)!
