### PR TITLE
Persist agent permission mode selection across sessions

### DIFF
--- a/crates/agent_ui/src/acp/mode_selector.rs
+++ b/crates/agent_ui/src/acp/mode_selector.rs
@@ -118,9 +118,9 @@ impl ModeSelector {
                                         ))
                                         .child(div().map(|this| {
                                             if is_default {
-                                                this.child("to also unset as default")
+                                                this.child("to unset as default")
                                             } else {
-                                                this.child("to also set as default")
+                                                this.child("to toggle as default")
                                             }
                                         })),
                                 )
@@ -144,6 +144,12 @@ impl ModeSelector {
                                         } else {
                                             Some(mode_id.clone())
                                         },
+                                        this.fs.clone(),
+                                        cx,
+                                    );
+                                } else {
+                                    this.agent_server.set_default_mode(
+                                        Some(mode_id.clone()),
                                         this.fs.clone(),
                                         cx,
                                     );


### PR DESCRIPTION
Closes #39392

## Summary

Fixes an issue where the "Bypass Permissions" setting (and other permission modes) in Claude Code agent would automatically revert when creating new threads or sessions.

## Problem

When users selected a permission mode like "Bypass Permissions" from the dropdown:
- The mode would change for the current session only
- Creating a new thread or continuing work would revert to the previous default mode
- Users had to manually re-select their preferred mode repeatedly

## Solution

Modified the mode selector behavior in `crates/agent_ui/src/acp/mode_selector.rs`:
- Mode selection now automatically persists as the default (saves to settings)
- This ensures the selected mode is used for all new threads/sessions
- Holding the secondary modifier key (Ctrl/Cmd) allows toggling/unsetting the default

## Changes

- When clicking a mode: Sets it for the current session **and** saves as default
- When Ctrl/Cmd + clicking a mode: Toggles whether it's the default (allows unsetting)
- Updated tooltip text to reflect this behavior

## Testing

- ✅ Passed `./script/clippy -p agent_ui`
- Verified mode persists across new threads

---

**Release Notes:**

- Fixed: Claude Code permission mode (like "Bypass Permissions") now persists across sessions as expected