### PR TITLE
settings_ui: Improve keyboard nav

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -1267,5 +1267,17 @@
       "ctrl-pageup": "settings_editor::FocusPreviousFile",
       "ctrl-pagedown": "settings_editor::FocusNextFile"
     }
+  },
+  {
+    "context": "SettingsWindow > NavigationMenu",
+    "use_key_equivalents": true,
+    "bindings": {
+      "right": "settings_editor::ExpandNavEntry",
+      "left": "settings_editor::CollapseNavEntry",
+      "pageup": "settings_editor::FocusPreviousRootNavEntry",
+      "pagedown": "settings_editor::FocusNextRootNavEntry",
+      "home": "settings_editor::FocusFirstNavEntry",
+      "end": "settings_editor::FocusLastNavEntry"
+    }
   }
 ]

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -1372,5 +1372,13 @@
       "cmd-{": "settings_editor::FocusPreviousFile",
       "cmd-}": "settings_editor::FocusNextFile"
     }
+  },
+  {
+    "context": "SettingsWindow > NavigationMenu",
+    "use_key_equivalents": true,
+    "bindings": {
+      "right": "settings_editor::ExpandNavEntry",
+      "left": "settings_editor::CollapseNavEntry"
+    }
   }
 ]

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -1378,7 +1378,11 @@
     "use_key_equivalents": true,
     "bindings": {
       "right": "settings_editor::ExpandNavEntry",
-      "left": "settings_editor::CollapseNavEntry"
+      "left": "settings_editor::CollapseNavEntry",
+      "pageup": "settings_editor::FocusPreviousRootNavEntry",
+      "pagedown": "settings_editor::FocusNextRootNavEntry",
+      "home": "settings_editor::FocusFirstNavEntry",
+      "end": "settings_editor::FocusLastNavEntry"
     }
   }
 ]

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -1288,5 +1288,17 @@
       "ctrl-pageup": "settings_editor::FocusPreviousFile",
       "ctrl-pagedown": "settings_editor::FocusNextFile"
     }
+  },
+  {
+    "context": "SettingsWindow > NavigationMenu",
+    "use_key_equivalents": true,
+    "bindings": {
+      "right": "settings_editor::ExpandNavEntry",
+      "left": "settings_editor::CollapseNavEntry",
+      "pageup": "settings_editor::FocusPreviousRootNavEntry",
+      "pagedown": "settings_editor::FocusNextRootNavEntry",
+      "home": "settings_editor::FocusFirstNavEntry",
+      "end": "settings_editor::FocusLastNavEntry"
+    }
   }
 ]

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -581,18 +581,6 @@ pub(crate) fn settings_data() -> Vec<SettingsPage> {
                     metadata: None,
                     files: USER,
                 }),
-                SettingsPageItem::SettingItem(SettingItem {
-                    title: "Use System Window Tabs",
-                    description: "(macOS-only) Whether to allow windows to merge based on the user's tabbing preference",
-                    field: Box::new(SettingField {
-                        pick: |settings_content| &settings_content.workspace.use_system_window_tabs,
-                        pick_mut: |settings_content| {
-                            &mut settings_content.workspace.use_system_window_tabs
-                        },
-                    }),
-                    metadata: None,
-                    files: USER,
-                }),
                 SettingsPageItem::SectionHeader("Window"),
                 // todo(settings_ui): Should we filter by platform?
                 SettingsPageItem::SettingItem(SettingItem {

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -554,7 +554,7 @@ struct SubPage {
     section_header: &'static str,
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(Debug)]
 struct NavBarEntry {
     title: &'static str,
     is_root: bool,
@@ -2350,6 +2350,17 @@ mod test {
         fn item(mut self, item: SettingsPageItem) -> Self {
             self.items.push(item);
             self
+        }
+    }
+
+    impl PartialEq for NavBarEntry {
+        fn eq(&self, other: &Self) -> bool {
+            self.title == other.title
+                && self.is_root == other.is_root
+                && self.expanded == other.expanded
+                && self.page_index == other.page_index
+                && self.item_index == other.item_index
+            // ignoring focus_handle
         }
     }
 

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -1603,12 +1603,6 @@ impl SettingsWindow {
         }
     }
 
-    fn focus_first_nav_item(&self, window: &mut Window, cx: &mut Context<Self>) {
-        self.navbar_focus_handle.focus_handle(cx).focus(window);
-        window.focus_next();
-        cx.notify();
-    }
-
     fn focus_and_scroll_to_nav_entry(&self, nav_entry_index: usize, window: &mut Window) {
         let Some(position) = self
             .visible_navbar_entries()
@@ -1619,12 +1613,6 @@ impl SettingsWindow {
         self.list_handle
             .scroll_to_item(position, gpui::ScrollStrategy::Top);
         window.focus(&self.navbar_entries[nav_entry_index].focus_handle);
-    }
-
-    fn focus_first_content_item(&self, window: &mut Window, cx: &mut Context<Self>) {
-        self.content_focus_handle.focus_handle(cx).focus(window);
-        window.focus_next();
-        cx.notify();
     }
 
     fn page_items(&self) -> impl Iterator<Item = (usize, &SettingsPageItem)> {

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -1473,8 +1473,11 @@ impl SettingsWindow {
                                         .toggle_state(this.is_navbar_entry_selected(ix))
                                         .when(entry.is_root, |item| {
                                             item.expanded(entry.expanded).on_toggle(cx.listener(
-                                                move |this, _, _, cx| {
+                                                move |this, _, window, cx| {
                                                     this.toggle_navbar_entry(ix);
+                                                    window.focus(
+                                                        &this.navbar_entries[ix].focus_handle,
+                                                    );
                                                     cx.notify();
                                                 },
                                             ))

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -1427,8 +1427,10 @@ impl SettingsWindow {
                 let Some(focused_entry) = this.focused_nav_entry(window) else {
                     return;
                 };
-                if this.navbar_entries[focused_entry].expanded {
-                    this.toggle_navbar_entry(focused_entry);
+                let focused_entry_parent = this.root_entry_containing(focused_entry);
+                if this.navbar_entries[focused_entry_parent].expanded {
+                    this.toggle_navbar_entry(focused_entry_parent);
+                    window.focus(&this.navbar_entries[focused_entry_parent].focus_handle);
                 }
                 cx.notify();
             }))
@@ -1436,6 +1438,9 @@ impl SettingsWindow {
                 let Some(focused_entry) = this.focused_nav_entry(window) else {
                     return;
                 };
+                if !this.navbar_entries[focused_entry].is_root {
+                    return;
+                }
                 if !this.navbar_entries[focused_entry].expanded {
                     this.toggle_navbar_entry(focused_entry);
                 }
@@ -1916,6 +1921,16 @@ impl SettingsWindow {
             }
         }
         None
+    }
+
+    fn root_entry_containing(&self, focused_entry: usize) -> usize {
+        let mut index = Some(focused_entry);
+        while let Some(prev_index) = index
+            && !self.navbar_entries[prev_index].is_root
+        {
+            index = prev_index.checked_sub(1);
+        }
+        return index.expect("No root entry found");
     }
 }
 

--- a/crates/ui/src/components/tree_view_item.rs
+++ b/crates/ui/src/components/tree_view_item.rs
@@ -21,6 +21,7 @@ pub struct TreeViewItem {
     on_toggle: Option<Arc<dyn Fn(&ClickEvent, &mut Window, &mut App) + 'static>>,
     on_secondary_mouse_down: Option<Box<dyn Fn(&MouseDownEvent, &mut Window, &mut App) + 'static>>,
     tab_index: Option<isize>,
+    focus_handle: Option<gpui::FocusHandle>,
 }
 
 impl TreeViewItem {
@@ -41,6 +42,7 @@ impl TreeViewItem {
             on_toggle: None,
             on_secondary_mouse_down: None,
             tab_index: None,
+            focus_handle: None,
         }
     }
 
@@ -107,6 +109,11 @@ impl TreeViewItem {
         self.focused = focused;
         self
     }
+
+    pub fn track_focus(mut self, focus_handle: &gpui::FocusHandle) -> Self {
+        self.focus_handle = Some(focus_handle.clone());
+        self
+    }
 }
 
 impl Disableable for TreeViewItem {
@@ -163,6 +170,9 @@ impl RenderOnce for TreeViewItem {
                                 })
                                 .focus(|s| s.border_color(focused_border))
                                 .hover(|s| s.bg(cx.theme().colors().element_hover))
+                                .when_some(self.focus_handle, |this, handle| {
+                                    this.track_focus(&handle)
+                                })
                                 .when_some(self.tab_index, |this, index| this.tab_index(index))
                                 .child(
                                     Disclosure::new("toggle", self.expanded)
@@ -221,6 +231,9 @@ impl RenderOnce for TreeViewItem {
                                     })
                                     .focus(|s| s.border_color(focused_border))
                                     .hover(|s| s.bg(cx.theme().colors().element_hover))
+                                    .when_some(self.focus_handle, |this, handle| {
+                                        this.track_focus(&handle)
+                                    })
                                     .when_some(self.tab_index, |this, index| this.tab_index(index))
                                     .child(
                                         Label::new(label)

--- a/crates/ui/src/components/tree_view_item.rs
+++ b/crates/ui/src/components/tree_view_item.rs
@@ -192,22 +192,7 @@ impl RenderOnce for TreeViewItem {
                                 .when_some(self.on_hover, |this, on_hover| this.on_hover(on_hover))
                                 .when_some(
                                     self.on_click.filter(|_| !self.disabled),
-                                    |this, on_click| {
-                                        if self.root_item
-                                            && let Some(on_toggle) = self.on_toggle.clone()
-                                        {
-                                            this.on_click(move |event, window, cx| {
-                                                if event.is_keyboard() {
-                                                    on_click(event, window, cx);
-                                                    on_toggle(event, window, cx);
-                                                } else {
-                                                    on_click(event, window, cx);
-                                                }
-                                            })
-                                        } else {
-                                            this.on_click(on_click)
-                                        }
-                                    },
+                                    |this, on_click| this.on_click(on_click),
                                 )
                                 .when_some(self.on_secondary_mouse_down, |this, on_mouse_down| {
                                     this.on_mouse_down(


### PR DESCRIPTION
Closes #ISSUE

From notes:

```markdown
  - [x] Clicking on the disclsoure icon button in the root-level tree view item should steal focus and move it to the root item (not the icon button)
  - [x] [@ben] Allow left/right arrow keys to expand/collapse root tree view items in the nav
    - [x] With this, make enter/space work the same as clicking (activate page, don't expand root items, focus moves to the content and leaves nav — becomes consistent with mouse interaction)
  - [x] Smart cmd-shift-e: toggling focus should take you to the selected item
  - [x] [@ben] pageup + pagedown in nav -> jump between root items
  - [x] [@ben] home + end buttons should work
    - in nav:
      - home always goes to first section header
      - end always goes to last _visible_ item (does not expand)
```

Release Notes:

- N/A *or* Added/Fixed/Improved ...
