### PR TITLE
project search: Reduce hangs on main thread

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -6616,11 +6616,12 @@ impl Editor {
             let (start_buffer, start, _, end, newest_selection) = this
                 .update(cx, |this, cx| {
                     let newest_selection = this.selections.newest_anchor().clone();
-                    let newest_selection_adjusted = this.selections.newest_adjusted(cx);
-                    let buffer = this.buffer.read(cx);
                     if newest_selection.head().diff_base_anchor.is_some() {
                         return None;
                     }
+                    let newest_selection_adjusted = this.selections.newest_adjusted(cx);
+                    let buffer = this.buffer.read(cx);
+
                     let (start_buffer, start) =
                         buffer.text_anchor_for_position(newest_selection_adjusted.start, cx)?;
                     let (end_buffer, end) =

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -3172,7 +3172,7 @@ impl Editor {
             self.refresh_code_actions(window, cx);
             self.refresh_document_highlights(cx);
             self.refresh_selected_text_highlights(false, window, cx);
-            refresh_matching_bracket_highlights(self, window, cx);
+            refresh_matching_bracket_highlights(self, cx);
             self.update_visible_edit_prediction(window, cx);
             self.edit_prediction_requires_modifier_in_indent_conflict = true;
             linked_editing_ranges::refresh_linked_ranges(self, window, cx);
@@ -20814,7 +20814,7 @@ impl Editor {
                 self.refresh_code_actions(window, cx);
                 self.refresh_selected_text_highlights(true, window, cx);
                 self.refresh_single_line_folds(window, cx);
-                refresh_matching_bracket_highlights(self, window, cx);
+                refresh_matching_bracket_highlights(self, cx);
                 if self.has_active_edit_prediction() {
                     self.update_visible_edit_prediction(window, cx);
                 }

--- a/crates/editor/src/highlight_matching_bracket.rs
+++ b/crates/editor/src/highlight_matching_bracket.rs
@@ -1,5 +1,5 @@
 use crate::{Editor, RangeToAnchorExt};
-use gpui::{Context, HighlightStyle, Window};
+use gpui::{Context, HighlightStyle};
 use language::CursorShape;
 use multi_buffer::ToOffset;
 use theme::ActiveTheme;

--- a/crates/editor/src/highlight_matching_bracket.rs
+++ b/crates/editor/src/highlight_matching_bracket.rs
@@ -1,47 +1,46 @@
 use crate::{Editor, RangeToAnchorExt};
 use gpui::{Context, HighlightStyle, Window};
 use language::CursorShape;
+use multi_buffer::ToOffset;
 use theme::ActiveTheme;
 
 enum MatchingBracketHighlight {}
 
-pub fn refresh_matching_bracket_highlights(
-    editor: &mut Editor,
-    window: &mut Window,
-    cx: &mut Context<Editor>,
-) {
+pub fn refresh_matching_bracket_highlights(editor: &mut Editor, cx: &mut Context<Editor>) {
     editor.clear_highlights::<MatchingBracketHighlight>(cx);
 
-    let newest_selection = editor.selections.newest::<usize>(cx);
+    let buffer_snapshot = editor.buffer.read(cx).snapshot(cx);
+    let newest_selection = editor
+        .selections
+        .newest_anchor()
+        .map(|anchor| anchor.to_offset(&buffer_snapshot));
     // Don't highlight brackets if the selection isn't empty
     if !newest_selection.is_empty() {
         return;
     }
 
-    let snapshot = editor.snapshot(window, cx);
     let head = newest_selection.head();
-    if head > snapshot.buffer_snapshot().len() {
+    if head > buffer_snapshot.len() {
         log::error!("bug: cursor offset is out of range while refreshing bracket highlights");
         return;
     }
 
     let mut tail = head;
     if (editor.cursor_shape == CursorShape::Block || editor.cursor_shape == CursorShape::Hollow)
-        && head < snapshot.buffer_snapshot().len()
+        && head < buffer_snapshot.len()
     {
-        if let Some(tail_ch) = snapshot.buffer_snapshot().chars_at(tail).next() {
+        if let Some(tail_ch) = buffer_snapshot.chars_at(tail).next() {
             tail += tail_ch.len_utf8();
         }
     }
 
-    if let Some((opening_range, closing_range)) = snapshot
-        .buffer_snapshot()
-        .innermost_enclosing_bracket_ranges(head..tail, None)
+    if let Some((opening_range, closing_range)) =
+        buffer_snapshot.innermost_enclosing_bracket_ranges(head..tail, None)
     {
         editor.highlight_text::<MatchingBracketHighlight>(
             vec![
-                opening_range.to_anchors(&snapshot.buffer_snapshot()),
-                closing_range.to_anchors(&snapshot.buffer_snapshot()),
+                opening_range.to_anchors(&buffer_snapshot),
+                closing_range.to_anchors(&buffer_snapshot),
             ],
             HighlightStyle {
                 background_color: Some(

--- a/crates/editor/src/selections_collection.rs
+++ b/crates/editor/src/selections_collection.rs
@@ -184,6 +184,27 @@ impl SelectionsCollection {
         selections
     }
 
+    /// Returns all of the selections, adjusted to take into account the selection line_mode. Uses a provided snapshot to resolve selections.
+    pub fn all_adjusted_with_snapshot(
+        &self,
+        snapshot: &MultiBufferSnapshot,
+    ) -> Vec<Selection<Point>> {
+        let mut selections = self
+            .disjoint
+            .iter()
+            .chain(self.pending_anchor())
+            .map(|anchor| anchor.map(|anchor| anchor.to_point(&snapshot)))
+            .collect::<Vec<_>>();
+        if self.line_mode {
+            for selection in &mut selections {
+                let new_range = snapshot.expand_to_line(selection.range());
+                selection.start = new_range.start;
+                selection.end = new_range.end;
+            }
+        }
+        selections
+    }
+
     /// Returns the newest selection, adjusted to take into account the selection line_mode
     pub fn newest_adjusted(&self, cx: &mut App) -> Selection<Point> {
         let mut selection = self.newest::<Point>(cx);

--- a/crates/go_to_line/src/cursor_position.rs
+++ b/crates/go_to_line/src/cursor_position.rs
@@ -113,7 +113,9 @@ impl CursorPosition {
                                 let mut last_selection = None::<Selection<Point>>;
                                 let snapshot = editor.buffer().read(cx).snapshot(cx);
                                 if snapshot.excerpts().count() > 0 {
-                                    for selection in editor.selections.all_adjusted(cx) {
+                                    for selection in
+                                        editor.selections.all_adjusted_with_snapshot(&snapshot)
+                                    {
                                         let selection_summary = snapshot
                                             .text_summary_for_range::<text::TextSummary, _>(
                                                 selection.start..selection.end,

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -6385,6 +6385,17 @@ impl MultiBufferSnapshot {
             debug_ranges.insert(key, text_ranges, format!("{value:?}").into())
         });
     }
+
+    // used by line_mode selections and tries to match vim behavior
+    pub fn expand_to_line(&self, range: Range<Point>) -> Range<Point> {
+        let new_start = MultiBufferPoint::new(range.start.row, 0);
+        let new_end = if range.end.column > 0 {
+            MultiBufferPoint::new(range.end.row, self.line_len(MultiBufferRow(range.end.row)))
+        } else {
+            range.end
+        };
+        new_start..new_end
+    }
 }
 
 #[cfg(any(test, feature = "test-support"))]


### PR DESCRIPTION
This takes the idea that @RemcoSmitsDev started on in https://github.com/zed-industries/zed/pull/39354. We did away with grabbing a snapshot of the display map when buffer coordinates were sufficient.
Closes #37267

Release Notes:

- Reduced micro-stutters in project search with large multi-buffer contents.
