### PR TITLE
git_hosting_providers: Fix permalinks for files with special characters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6828,6 +6828,7 @@ dependencies = [
  "serde_json",
  "settings",
  "url",
+ "urlencoding",
  "workspace-hack",
  "zed-http-client",
  "zed-util",

--- a/crates/git_hosting_providers/Cargo.toml
+++ b/crates/git_hosting_providers/Cargo.toml
@@ -23,6 +23,7 @@ serde.workspace = true
 serde_json.workspace = true
 settings.workspace = true
 url.workspace = true
+urlencoding.workspace = true
 util.workspace = true
 workspace-hack.workspace = true
 

--- a/crates/git_hosting_providers/src/git_hosting_providers.rs
+++ b/crates/git_hosting_providers/src/git_hosting_providers.rs
@@ -47,6 +47,13 @@ pub fn register_additional_providers(
     }
 }
 
+pub fn encode_path_segments(path: &str) -> String {
+    path.split('/')
+        .map(|segment| urlencoding::encode(segment))
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
 pub fn get_host_from_git_remote_url(remote_url: &str) -> Result<String> {
     maybe!({
         if let Some(remote_url) = remote_url.strip_prefix("git@")

--- a/crates/git_hosting_providers/src/providers/bitbucket.rs
+++ b/crates/git_hosting_providers/src/providers/bitbucket.rs
@@ -95,9 +95,10 @@ impl GitHostingProvider for Bitbucket {
             selection,
         } = params;
 
+        let encoded_path = crate::encode_path_segments(&path);
         let mut permalink = self
             .base_url()
-            .join(&format!("{owner}/{repo}/src/{sha}/{path}"))
+            .join(&format!("{owner}/{repo}/src/{sha}/{encoded_path}"))
             .unwrap();
         permalink.set_fragment(
             selection

--- a/crates/git_hosting_providers/src/providers/chromium.rs
+++ b/crates/git_hosting_providers/src/providers/chromium.rs
@@ -139,9 +139,10 @@ impl GitHostingProvider for Chromium {
             selection,
         } = params;
 
+        let encoded_path = crate::encode_path_segments(&path);
         let mut permalink = self
             .base_url()
-            .join(&format!("{repo}/+/{sha}/{path}"))
+            .join(&format!("{repo}/+/{sha}/{encoded_path}"))
             .unwrap();
         permalink.set_fragment(
             selection

--- a/crates/git_hosting_providers/src/providers/codeberg.rs
+++ b/crates/git_hosting_providers/src/providers/codeberg.rs
@@ -173,9 +173,10 @@ impl GitHostingProvider for Codeberg {
             selection,
         } = params;
 
+        let encoded_path = crate::encode_path_segments(&path);
         let mut permalink = self
             .base_url()
-            .join(&format!("{owner}/{repo}/src/commit/{sha}/{path}"))
+            .join(&format!("{owner}/{repo}/src/commit/{sha}/{encoded_path}"))
             .unwrap();
         permalink.set_fragment(
             selection

--- a/crates/git_hosting_providers/src/providers/gitee.rs
+++ b/crates/git_hosting_providers/src/providers/gitee.rs
@@ -1,7 +1,6 @@
 use std::str::FromStr;
 
 use url::Url;
-use urlencoding;
 
 use git::{
     BuildCommitPermalinkParams, BuildPermalinkParams, GitHostingProvider, ParsedGitRemote,
@@ -70,10 +69,9 @@ impl GitHostingProvider for Gitee {
             selection,
         } = params;
 
-        let encoded_path = crate::encode_path_segments(&path);
         let mut permalink = self
             .base_url()
-            .join(&format!("{owner}/{repo}/blob/{sha}/{encoded_path}"))
+            .join(&format!("{owner}/{repo}/blob/{sha}/{path}"))
             .unwrap();
         permalink.set_fragment(
             selection

--- a/crates/git_hosting_providers/src/providers/gitee.rs
+++ b/crates/git_hosting_providers/src/providers/gitee.rs
@@ -1,6 +1,7 @@
 use std::str::FromStr;
 
 use url::Url;
+use urlencoding;
 
 use git::{
     BuildCommitPermalinkParams, BuildPermalinkParams, GitHostingProvider, ParsedGitRemote,
@@ -69,9 +70,10 @@ impl GitHostingProvider for Gitee {
             selection,
         } = params;
 
+        let encoded_path = crate::encode_path_segments(&path);
         let mut permalink = self
             .base_url()
-            .join(&format!("{owner}/{repo}/blob/{sha}/{path}"))
+            .join(&format!("{owner}/{repo}/blob/{sha}/{encoded_path}"))
             .unwrap();
         permalink.set_fragment(
             selection

--- a/crates/git_hosting_providers/src/providers/github.rs
+++ b/crates/git_hosting_providers/src/providers/github.rs
@@ -9,7 +9,6 @@ use http_client::{AsyncBody, HttpClient, HttpRequestExt, Request};
 use regex::Regex;
 use serde::Deserialize;
 use url::Url;
-use urlencoding;
 
 use git::{
     BuildCommitPermalinkParams, BuildPermalinkParams, GitHostingProvider, ParsedGitRemote,

--- a/crates/git_hosting_providers/src/providers/github.rs
+++ b/crates/git_hosting_providers/src/providers/github.rs
@@ -9,6 +9,7 @@ use http_client::{AsyncBody, HttpClient, HttpRequestExt, Request};
 use regex::Regex;
 use serde::Deserialize;
 use url::Url;
+use urlencoding;
 
 use git::{
     BuildCommitPermalinkParams, BuildPermalinkParams, GitHostingProvider, ParsedGitRemote,
@@ -209,9 +210,10 @@ impl GitHostingProvider for Github {
             selection,
         } = params;
 
+        let encoded_path = crate::encode_path_segments(&path);
         let mut permalink = self
             .base_url()
-            .join(&format!("{owner}/{repo}/blob/{sha}/{path}"))
+            .join(&format!("{owner}/{repo}/blob/{sha}/{encoded_path}"))
             .unwrap();
         if path.ends_with(".md") {
             permalink.set_query(Some("plain=1"));

--- a/crates/git_hosting_providers/src/providers/gitlab.rs
+++ b/crates/git_hosting_providers/src/providers/gitlab.rs
@@ -2,7 +2,6 @@ use std::str::FromStr;
 
 use anyhow::{Result, bail};
 use url::Url;
-use urlencoding;
 
 use git::{
     BuildCommitPermalinkParams, BuildPermalinkParams, GitHostingProvider, ParsedGitRemote,

--- a/crates/git_hosting_providers/src/providers/gitlab.rs
+++ b/crates/git_hosting_providers/src/providers/gitlab.rs
@@ -2,6 +2,7 @@ use std::str::FromStr;
 
 use anyhow::{Result, bail};
 use url::Url;
+use urlencoding;
 
 use git::{
     BuildCommitPermalinkParams, BuildPermalinkParams, GitHostingProvider, ParsedGitRemote,
@@ -108,9 +109,10 @@ impl GitHostingProvider for Gitlab {
             selection,
         } = params;
 
+        let encoded_path = crate::encode_path_segments(&path);
         let mut permalink = self
             .base_url()
-            .join(&format!("{owner}/{repo}/-/blob/{sha}/{path}"))
+            .join(&format!("{owner}/{repo}/-/blob/{sha}/{encoded_path}"))
             .unwrap();
         if path.ends_with(".md") {
             permalink.set_query(Some("plain=1"));

--- a/crates/git_hosting_providers/src/providers/sourcehut.rs
+++ b/crates/git_hosting_providers/src/providers/sourcehut.rs
@@ -74,9 +74,10 @@ impl GitHostingProvider for Sourcehut {
             selection,
         } = params;
 
+        let encoded_path = crate::encode_path_segments(&path);
         let mut permalink = self
             .base_url()
-            .join(&format!("~{owner}/{repo}/tree/{sha}/item/{path}"))
+            .join(&format!("~{owner}/{repo}/tree/{sha}/item/{encoded_path}"))
             .unwrap();
         permalink.set_fragment(
             selection


### PR DESCRIPTION
Closes #39875

Release Notes:

- Fixed: File permalinks now work correctly for files with special characters (like [ and ]) in their paths, which are common in Next.js and other frontend frameworks
