### PR TITLE
markdown_preview: Improve the link decoration logic

### DIFF
--- a/crates/markdown_preview/src/markdown_elements.rs
+++ b/crates/markdown_preview/src/markdown_elements.rs
@@ -175,11 +175,7 @@ pub enum MarkdownHighlight {
 
 impl MarkdownHighlight {
     /// Converts this [`MarkdownHighlight`] to a [`HighlightStyle`].
-    pub fn to_highlight_style(
-        &self,
-        theme: &theme::SyntaxTheme,
-        link_color: Hsla,
-    ) -> Option<HighlightStyle> {
+    pub fn to_highlight_style(&self, theme: &theme::SyntaxTheme) -> Option<HighlightStyle> {
         match self {
             MarkdownHighlight::Style(style) => {
                 let mut highlight = HighlightStyle::default();
@@ -209,10 +205,8 @@ impl MarkdownHighlight {
                 if style.link {
                     highlight.underline = Some(UnderlineStyle {
                         thickness: px(1.),
-                        color: Some(link_color),
                         ..Default::default()
                     });
-                    highlight.color = Some(link_color);
                 }
 
                 Some(highlight)

--- a/crates/markdown_preview/src/markdown_elements.rs
+++ b/crates/markdown_preview/src/markdown_elements.rs
@@ -1,5 +1,5 @@
 use gpui::{
-    DefiniteLength, FontStyle, FontWeight, HighlightStyle, Hsla, SharedString, StrikethroughStyle,
+    DefiniteLength, FontStyle, FontWeight, HighlightStyle, SharedString, StrikethroughStyle,
     UnderlineStyle, px,
 };
 use language::HighlightId;

--- a/crates/markdown_preview/src/markdown_renderer.rs
+++ b/crates/markdown_preview/src/markdown_renderer.rs
@@ -672,7 +672,7 @@ fn render_markdown_text(parsed_new: &MarkdownParagraph, cx: &mut RenderContext) 
                 let highlights = gpui::combine_highlights(
                     parsed.highlights.iter().filter_map(|(range, highlight)| {
                         highlight
-                            .to_highlight_style(&syntax_theme, link_color)
+                            .to_highlight_style(&syntax_theme)
                             .map(|style| (range.clone(), style))
                     }),
                     parsed.regions.iter().zip(&parsed.region_ranges).filter_map(
@@ -682,6 +682,14 @@ fn render_markdown_text(parsed_new: &MarkdownParagraph, cx: &mut RenderContext) 
                                     range.clone(),
                                     HighlightStyle {
                                         background_color: Some(code_span_bg_color),
+                                        ..Default::default()
+                                    },
+                                ))
+                            } else if region.link.is_some() {
+                                Some((
+                                    range.clone(),
+                                    HighlightStyle {
+                                        color: Some(link_color),
                                         ..Default::default()
                                     },
                                 ))


### PR DESCRIPTION
Closes #39838

Refs:
* https://github.com/zed-industries/zed/pull/39149#issuecomment-3383015060

# How

After digging a bit more to find out why raw links are not colored in Markdown renderer I have found a simpler approach to applying color decoration, which also fixed the lack of colors on raw links mentioned in issue and comment above.

Release Notes:

- Improved decoration logic for links in Markdown

# Preview

<img width="1712" height="820" alt="Screenshot 2025-10-09 at 23 39 09" src="https://github.com/user-attachments/assets/3864cb6c-3fc6-4110-8067-6158cd4b58f5" />
