### PR TITLE
git_ui: When no changes, disable stage/unstage toolbar buttons

### DIFF
--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -947,6 +947,7 @@ impl Render for ProjectDiffToolbar {
                                     &StageAndNext,
                                     &focus_handle,
                                 ))
+                                .disabled(!button_states.stage)
                                 .on_click(cx.listener(|this, _, window, cx| {
                                     this.dispatch_action(&StageAndNext, window, cx)
                                 })),
@@ -958,6 +959,7 @@ impl Render for ProjectDiffToolbar {
                                     &UnstageAndNext,
                                     &focus_handle,
                                 ))
+                                .disabled(!button_states.unstage)
                                 .on_click(cx.listener(|this, _, window, cx| {
                                     this.dispatch_action(&UnstageAndNext, window, cx)
                                 })),

--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -947,7 +947,11 @@ impl Render for ProjectDiffToolbar {
                                     &StageAndNext,
                                     &focus_handle,
                                 ))
-                                .disabled(!button_states.stage)
+                                .disabled(
+                                    !button_states.prev_next
+                                        && !button_states.stage_all
+                                        && !button_states.unstage_all,
+                                )
                                 .on_click(cx.listener(|this, _, window, cx| {
                                     this.dispatch_action(&StageAndNext, window, cx)
                                 })),
@@ -959,7 +963,11 @@ impl Render for ProjectDiffToolbar {
                                     &UnstageAndNext,
                                     &focus_handle,
                                 ))
-                                .disabled(!button_states.unstage)
+                                .disabled(
+                                    !button_states.prev_next
+                                        && !button_states.stage_all
+                                        && !button_states.unstage_all,
+                                )
                                 .on_click(cx.listener(|this, _, window, cx| {
                                     this.dispatch_action(&UnstageAndNext, window, cx)
                                 })),


### PR DESCRIPTION
# Why

While working on recent PR I have spotted that "Stage" and "Unstage" buttons in "Uncommited Changes" toolbar are always active, even when there is no changes made locally.

<img width="1628" height="656" alt="Screenshot 2025-10-10 at 00 49 06" src="https://github.com/user-attachments/assets/6bdb9ded-17c8-4f84-8649-b297162c1992" />

# How

Re-use already existing button states for managing the disabled state of "Uncommited Changes" toolbar buttons when changeset is empty.

Release Notes:

- Added disabled state for "Uncommited Changes" toolbar buttons when there are no changes present

# Preview

<img width="1728" height="772" alt="Screenshot 2025-10-10 at 08 40 14" src="https://github.com/user-attachments/assets/ff41d852-974e-4ce1-9163-ecd30e17d5d8" />

