### PR TITLE
Select to closest character in popover

### DIFF
--- a/crates/gpui/src/elements/text.rs
+++ b/crates/gpui/src/elements/text.rs
@@ -467,6 +467,19 @@ impl TextLayout {
 
     /// Get the byte index into the input of the pixel position.
     pub fn index_for_position(&self, mut position: Point<Pixels>) -> Result<usize, usize> {
+        self._index_for_position(position, false)
+    }
+
+    /// Get the closest byte index into the input of the pixel position.
+    pub fn closest_index_for_position(&self, mut position: Point<Pixels>) -> Result<usize, usize> {
+        self._index_for_position(position, true)
+    }
+
+    fn _index_for_position(
+        &self,
+        mut position: Point<Pixels>,
+        closest: bool,
+    ) -> Result<usize, usize> {
         let element_state = self.0.borrow();
         let element_state = element_state
             .as_ref()
@@ -489,7 +502,12 @@ impl TextLayout {
                 line_start_ix += line.len() + 1;
             } else {
                 let position_within_line = position - line_origin;
-                match line.index_for_position(position_within_line, line_height) {
+                let index_for_position = if closest {
+                    line.closest_index_for_position(position_within_line, line_height)
+                } else {
+                    line.index_for_position(position_within_line, line_height)
+                };
+                match index_for_position {
                     Ok(index_within_line) => return Ok(line_start_ix + index_within_line),
                     Err(index_within_line) => return Err(line_start_ix + index_within_line),
                 }


### PR DESCRIPTION
When trying to select text in the popover, when hovering over text in the editor, the character that was getting selected under the mouse cursor didn’t seem “correct”. The behavior was not matching how the selection of text works in the editor. This now aligns the text selection of the markdown text in the popover with the text selection in the editor.

<details><summary>Before:</summary>
<p>

https://github.com/user-attachments/assets/2820194a-d245-4288-a85b-854dbc3a3cea

</p>
</details> 

<details><summary>After:</summary>
<p>

https://github.com/user-attachments/assets/e5b96f42-5d6d-4fe1-9fca-6463107c6650

Notice the character is selected when the cursor is mostly passed it instead of all the way.
</p>
</details> 



Release Notes:

- Nicer selection in popovers
