### PR TITLE
gpui: Prevent KeyDown events during IME composition on Linux

### DIFF
--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -1316,9 +1316,11 @@ impl Dispatch<wl_keyboard::WlKeyboard, ()> for WaylandClientStatePtr {
                                         compose.utf8().or(Keystroke::underlying_dead_key(keysym));
                                     let pre_edit =
                                         state.pre_edit_text.clone().unwrap_or(String::default());
+                                    state.compose_state = Some(compose);
                                     drop(state);
                                     focused_window.handle_ime(ImeInput::SetMarkedText(pre_edit));
-                                    state = client.borrow_mut();
+                                    // Don't dispatch KeyDown event when composing IME text
+                                    return;
                                 }
 
                                 xkb::Status::Composed => {

--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -1021,9 +1021,11 @@ impl X11Client {
                                     .or(crate::Keystroke::underlying_dead_key(keysym));
                                 let pre_edit =
                                     state.pre_edit_text.clone().unwrap_or(String::default());
+                                state.compose_state = Some(compose_state);
                                 drop(state);
                                 window.handle_ime_preedit(pre_edit);
-                                state = self.0.borrow_mut();
+                                // Don't dispatch KeyDown event when composing IME text
+                                return Some(());
                             }
                             xkbc::Status::Cancelled => {
                                 let pre_edit = state.pre_edit_text.take();


### PR DESCRIPTION
## Summary
  Fix issue where pressing Enter while composing text with IME (e.g., Chinese input methods) incorrectly triggers actions like sending messages in the Agent panel.

  ## Changes
  - Wayland: Return early when compose status is `Composing` to prevent KeyDown dispatch
  - X11: Return early when compose status is `Composing` to prevent KeyDown dispatch

  ## Testing
  Tested with Chinese IME (fcitx5/ibus) on both Wayland and X11.

  ## Related
  This aligns Linux behavior with macOS, which already checks for marked text before dispatching key events.



Release Notes:

N/A