### PR TITLE
docs: Fix link/reference in CSS language doc

### DIFF
--- a/docs/src/languages/css.md
+++ b/docs/src/languages/css.md
@@ -4,7 +4,7 @@ Zed has built-in support for CSS.
 
 - Tree-sitter: [tree-sitter/tree-sitter-css](https://github.com/tree-sitter/tree-sitter-css)
 - Language Servers:
-  - [microsoft/vscode-html-languageservice](https://github.com/microsoft/vscode-html-languageservice)
+  - [microsoft/vscode-css-languageservice](https://github.com/microsoft/vscode-css-languageservice)
   - [tailwindcss-language-server](https://github.com/tailwindlabs/tailwindcss-intellisense)
 
 ## Tailwind CSS


### PR DESCRIPTION
Looking at https://github.com/zed-industries/zed/blob/5698636c92d015738843ad1ce982b887a236110a/crates/languages/src/css.rs#L19 it appears that the vscode-css-languageservice is used so I think this was a typo.

Release Notes:

- N/A
