### PR TITLE
Remove unnecessary clone from `Rope::append`

### DIFF
--- a/crates/rope/src/rope.rs
+++ b/crates/rope/src/rope.rs
@@ -114,11 +114,9 @@ impl Rope {
             chunks.next();
             chunks.next();
             self.chunks.append(chunks.suffix(), ());
-            self.check_invariants();
-            return;
+        } else {
+            self.chunks.append(rope.chunks, ());
         }
-
-        self.chunks.append(rope.chunks.clone(), ());
         self.check_invariants();
     }
 


### PR DESCRIPTION
The previous code clones all the rope chunks, but the rope is passed by value so the chunks are about to be dropped anyhow.

I thought this may slightly help performance but it has no very noticeable effect, with a mix of small changes up and down probably attributable to noise on my machine?

I wonder if the benchmarks might just not hit this path well? I'm looking into that separately (see #39949, #39951), but this seemed clear enough to be worth proposing by itself. 

Incidentally it surprised me this did not generate a warning already, but I think it's because we're taking only one field from the struct that's about to be dropped: https://github.com/rust-lang/rust-clippy/issues/7429.

<details>

```

     Running benches/rope_benchmark.rs (target/release/deps/rope_benchmark-4c5c71666e7c1729)
push/4096               time:   [362.58 µs 366.40 µs 370.69 µs]
                        thrpt:  [10.538 MiB/s 10.661 MiB/s 10.773 MiB/s]
                 change:
                        time:   [+0.0646% +1.2362% +2.4681%] (p = 0.04 < 0.05)
                        thrpt:  [-2.4086% -1.2211% -0.0646%]
                        Change within noise threshold.
Found 10 outliers among 100 measurements (10.00%)
  7 (7.00%) high mild
  3 (3.00%) high severe
Benchmarking push/65536: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.4s, enable flat sampling, or reduce sample count to 50.
push/65536              time:   [1.6185 ms 1.6353 ms 1.6557 ms]
                        thrpt:  [37.747 MiB/s 38.219 MiB/s 38.616 MiB/s]
                 change:
                        time:   [+1.9135% +2.9548% +3.9838%] (p = 0.00 < 0.05)
                        thrpt:  [-3.8312% -2.8700% -1.8776%]
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe

append/4096             time:   [1.1052 µs 1.1104 µs 1.1162 µs]
                        thrpt:  [3.4177 GiB/s 3.4354 GiB/s 3.4516 GiB/s]
                 change:
                        time:   [-2.5075% -0.3430% +1.5095%] (p = 0.76 > 0.05)
                        thrpt:  [-1.4871% +0.3441% +2.5720%]
                        No change in performance detected.
Found 8 outliers among 100 measurements (8.00%)
  7 (7.00%) high mild
  1 (1.00%) high severe
append/65536            time:   [12.404 µs 12.444 µs 12.487 µs]
                        thrpt:  [4.8881 GiB/s 4.9049 GiB/s 4.9204 GiB/s]
                 change:
                        time:   [-0.1408% +0.5573% +1.2016%] (p = 0.10 > 0.05)
                        thrpt:  [-1.1874% -0.5542% +0.1410%]
                        No change in performance detected.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe

slice/4096              time:   [32.963 µs 33.185 µs 33.466 µs]
                        thrpt:  [116.72 MiB/s 117.71 MiB/s 118.51 MiB/s]
                 change:
                        time:   [-6.4303% -5.1234% -3.6394%] (p = 0.00 < 0.05)
                        thrpt:  [+3.7769% +5.4000% +6.8722%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
slice/65536             time:   [668.67 µs 670.49 µs 672.65 µs]
                        thrpt:  [92.916 MiB/s 93.215 MiB/s 93.469 MiB/s]
                 change:
                        time:   [+0.0846% +0.5573% +1.0199%] (p = 0.02 < 0.05)
                        thrpt:  [-1.0096% -0.5542% -0.0845%]
                        Change within noise threshold.
Found 10 outliers among 100 measurements (10.00%)
  6 (6.00%) high mild
  4 (4.00%) high severe

bytes_in_range/4096     time:   [5.1513 µs 5.1594 µs 5.1674 µs]
                        thrpt:  [755.95 MiB/s 757.12 MiB/s 758.31 MiB/s]
                 change:
                        time:   [-4.9410% -4.2051% -3.3835%] (p = 0.00 < 0.05)
                        thrpt:  [+3.5020% +4.3897% +5.1978%]
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low mild
  3 (3.00%) high severe
bytes_in_range/65536    time:   [139.87 µs 140.17 µs 140.55 µs]
                        thrpt:  [444.67 MiB/s 445.89 MiB/s 446.85 MiB/s]
                 change:
                        time:   [-0.6267% -0.0474% +0.4635%] (p = 0.87 > 0.05)
                        thrpt:  [-0.4614% +0.0475% +0.6306%]
                        No change in performance detected.
Found 9 outliers among 100 measurements (9.00%)
  7 (7.00%) high mild
  2 (2.00%) high severe

chars/4096              time:   [1.0243 µs 1.0250 µs 1.0257 µs]
                        thrpt:  [3.7190 GiB/s 3.7217 GiB/s 3.7243 GiB/s]
                 change:
                        time:   [+4.0106% +4.5396% +5.3062%] (p = 0.00 < 0.05)
                        thrpt:  [-5.0388% -4.3425% -3.8559%]
                        Performance has regressed.
Found 10 outliers among 100 measurements (10.00%)
  2 (2.00%) high mild
  8 (8.00%) high severe
chars/65536             time:   [17.540 µs 17.576 µs 17.614 µs]
                        thrpt:  [3.4652 GiB/s 3.4727 GiB/s 3.4797 GiB/s]
                 change:
                        time:   [+2.5201% +3.3922% +4.1639%] (p = 0.00 < 0.05)
                        thrpt:  [-3.9974% -3.2809% -2.4581%]
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe

clip_point/4096         time:   [58.857 µs 59.162 µs 59.490 µs]
                        thrpt:  [65.662 MiB/s 66.026 MiB/s 66.368 MiB/s]
                 change:
                        time:   [+1.6900% +2.8088% +3.8521%] (p = 0.00 < 0.05)
                        thrpt:  [-3.7092% -2.7321% -1.6619%]
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
clip_point/65536        time:   [1.8609 ms 1.8633 ms 1.8660 ms]
                        thrpt:  [33.494 MiB/s 33.543 MiB/s 33.585 MiB/s]
                 change:
                        time:   [+0.0577% +0.2579% +0.4495%] (p = 0.01 < 0.05)
                        thrpt:  [-0.4474% -0.2572% -0.0577%]
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe

point_to_offset/4096    time:   [19.246 µs 19.287 µs 19.331 µs]
                        thrpt:  [202.07 MiB/s 202.54 MiB/s 202.97 MiB/s]
                 change:
                        time:   [+1.1073% +2.9754% +5.3818%] (p = 0.00 < 0.05)
                        thrpt:  [-5.1069% -2.8894% -1.0951%]
                        Performance has regressed.
Found 13 outliers among 100 measurements (13.00%)
  5 (5.00%) high mild
  8 (8.00%) high severe
Benchmarking point_to_offset/65536: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 6.6s, enable flat sampling, or reduce sample count to 60.
point_to_offset/65536   time:   [741.87 µs 743.28 µs 744.74 µs]
                        thrpt:  [83.922 MiB/s 84.086 MiB/s 84.247 MiB/s]
                 change:
                        time:   [+5.0577% +5.6751% +6.3133%] (p = 0.00 < 0.05)
                        thrpt:  [-5.9384% -5.3703% -4.8142%]
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe

cursor/4096             time:   [27.407 µs 27.483 µs 27.600 µs]
                        thrpt:  [141.53 MiB/s 142.13 MiB/s 142.53 MiB/s]
                 change:
                        time:   [-7.1479% -6.2928% -5.6378%] (p = 0.00 < 0.05)
                        thrpt:  [+5.9747% +6.7154% +7.6981%]
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) high mild
  8 (8.00%) high severe
cursor/65536            time:   [848.91 µs 849.70 µs 850.59 µs]
                        thrpt:  [73.478 MiB/s 73.555 MiB/s 73.624 MiB/s]
                 change:
                        time:   [+0.0281% +0.3487% +0.6686%] (p = 0.04 < 0.05)
                        thrpt:  [-0.6642% -0.3475% -0.0281%]
                        Change within noise threshold.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe

```
</details>

Release Notes:

- N/A