### PR TITLE
Fix redirect stdin command for fish shell

### DIFF
--- a/crates/task/src/shell_builder.rs
+++ b/crates/task/src/shell_builder.rs
@@ -87,9 +87,12 @@ impl ShellBuilder {
             });
             if self.redirect_stdin {
                 match self.kind {
+                    ShellKind::Fish => {
+                        combined_command.insert_str(0, "begin; ");
+                        combined_command.push_str("; end </dev/null");
+                    }
                     ShellKind::Posix
                     | ShellKind::Nushell
-                    | ShellKind::Fish
                     | ShellKind::Csh
                     | ShellKind::Tcsh
                     | ShellKind::Rc
@@ -158,5 +161,18 @@ mod test {
 
         assert_eq!(program, "nu");
         assert_eq!(args, vec!["-i", "-c", "(echo nothing) </dev/null"]);
+    }
+
+    #[test]
+    fn redirect_stdin_to_dev_null_fish() {
+        let shell = Shell::Program("fish".to_owned());
+        let shell_builder = ShellBuilder::new(&shell);
+
+        let (program, args) = shell_builder
+            .redirect_stdin_to_dev_null()
+            .build(Some("echo".into()), &["test".to_string()]);
+
+        assert_eq!(program, "fish");
+        assert_eq!(args, vec!["-i", "-c", "begin; echo test; end </dev/null"]);
     }
 }


### PR DESCRIPTION
This fixes an issue introduced via [v0.208.0-pre](https://github.com/zed-industries/zed/releases/tag/v0.208.0-pre) and reported via https://github.com/zed-industries/zed/issues/34530#issuecomment-3386042577 where, when using fish shell as the default shell and using a Claude Code thread in Zed, all commands were failing because `(command)` in fish is for command substitution. Using it creates this type of error:

```
fish: command substitutions not allowed in command position. Try var=(your-cmd) $var ...
(npm ci) </dev/null
^~~~~~~~~~~~^
```

or in the editor itself:

<img width="1624" height="1060" alt="image" src="https://github.com/user-attachments/assets/64fc3126-2cdd-450e-bc85-ef91c56b3705" />


Using the appropriate syntax to redirect to stdin for fish fixes the issue.

Release Notes:

- Fixed redirect stdin command for fish shell
