### PR TITLE
Fix menu navigation in remote projects modal

### DIFF
--- a/crates/recent_projects/src/remote_servers.rs
+++ b/crates/recent_projects/src/remote_servers.rs
@@ -2030,8 +2030,11 @@ impl RemoteServerProjects {
                 )
                 .into_any_element(),
         )
-        .entry(state.add_new_server.clone())
-        .entry(state.add_new_wsl.clone());
+        .entry(state.add_new_server.clone());
+
+        if cfg!(target_os = "windows") {
+            modal_section = modal_section.entry(state.add_new_wsl.clone());
+        }
 
         for server in &state.servers {
             match server {


### PR DESCRIPTION
Previously we were always adding a `Navigable` entry for the "new WSL connection" option in this modal, even though we don't have the corresponding button on non-Windows. This was causing `menu::SelectNext` to behave incorrectly (focusing the center pane instead) when `Connect New Server` was selected on macOS and Linux.

Release Notes:

- Fixed a bug with keyboard navigation in the remote project modal.