### PR TITLE
Add `tool_call_none` setting

### DIFF
--- a/crates/agent_ui/src/agent_configuration/add_llm_provider_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/add_llm_provider_modal.rs
@@ -112,6 +112,7 @@ impl ModelInput {
             images,
             parallel_tool_calls,
             prompt_cache_key,
+            ..
         } = ModelCapabilities::default();
         Self {
             name: model_name,
@@ -160,6 +161,7 @@ impl ModelInput {
                 images: self.capabilities.supports_images.selected(),
                 parallel_tool_calls: self.capabilities.supports_parallel_tool_calls.selected(),
                 prompt_cache_key: self.capabilities.supports_prompt_cache_key.selected(),
+                tool_choice_none: false,
             },
         })
     }

--- a/crates/language_models/src/provider/open_ai_compatible.rs
+++ b/crates/language_models/src/provider/open_ai_compatible.rs
@@ -271,7 +271,7 @@ impl LanguageModel for OpenAiCompatibleLanguageModel {
         match choice {
             LanguageModelToolChoice::Auto => self.model.capabilities.tools,
             LanguageModelToolChoice::Any => self.model.capabilities.tools,
-            LanguageModelToolChoice::None => true,
+            LanguageModelToolChoice::None => self.model.capabilities.tool_choice_none,
         }
     }
 

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -261,7 +261,7 @@ pub struct Request {
     /// Whether to enable parallel function calling during tool use.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parallel_tool_calls: Option<bool>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     pub tools: Vec<ToolDefinition>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub prompt_cache_key: Option<String>,

--- a/crates/settings/src/settings_content/language_model.rs
+++ b/crates/settings/src/settings_content/language_model.rs
@@ -240,6 +240,8 @@ pub struct OpenAiCompatibleModelCapabilities {
     pub images: bool,
     pub parallel_tool_calls: bool,
     pub prompt_cache_key: bool,
+    #[serde(default)]
+    pub tool_choice_none: bool,
 }
 
 impl Default for OpenAiCompatibleModelCapabilities {
@@ -249,6 +251,7 @@ impl Default for OpenAiCompatibleModelCapabilities {
             images: false,
             parallel_tool_calls: false,
             prompt_cache_key: false,
+            tool_choice_none: false,
         }
     }
 }


### PR DESCRIPTION
Closes #ISSUE

Never opened issue. Just fixed it myself.

Release Notes:

- Added a tool_call_none variable for setting to keep zed agent from sending mangled conversations to litellm, which does not enforce the required specs for bedrock or anthropic [tool calls must be paired with response and have content not be empty]
- works on my computer