### PR TITLE
Fix Hangul Toggle

### DIFF
--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -1334,8 +1334,12 @@ where
             } else {
                 vkey
             };
-            let keystroke = parse_normal_key(vkey, lparam, modifiers)?;
-            Some(f(keystroke))
+            if let Some(keystroke) = parse_normal_key(vkey, lparam, modifiers) {
+                Some(f(keystroke))
+            } else {
+                translate_message(handle, wparam, lparam);
+                None
+            }
         }
     }
 }


### PR DESCRIPTION
Call translate_message for key events which are not recognized as normal key input.

Closes #39971

Release Notes:

- N/A *or* Added/Fixed/Improved ...
