### PR TITLE
zeta2: Collect overlapping declaration score components

### DIFF
--- a/crates/cloud_llm_client/src/predict_edits_v3.rs
+++ b/crates/cloud_llm_client/src/predict_edits_v3.rs
@@ -142,6 +142,8 @@ pub struct DeclarationScoreComponents {
     pub normalized_import_similarity: f32,
     pub wildcard_import_similarity: f32,
     pub normalized_wildcard_import_similarity: f32,
+    pub included_by_others: usize,
+    pub includes_others: usize,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
Collects the number of declarations included by a given declaration in both directions as score components.

Release Notes:

- N/A 
