### PR TITLE
Cleanup `default.json`

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "zed://schemas/settings",
   /// The displayed name of this project. If not set or empty, the root directory name
   /// will be displayed.
   "project_name": "",
@@ -2051,7 +2052,7 @@
   //     }
   //   }
   // }
-  "profiles": [],
+  "profiles": {},
 
   // A map of log scopes to the desired log level.
   // Useful for filtering out noisy logs or enabling more verbose logging.

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -215,6 +215,7 @@ impl From<settings::DiagnosticSeverityContent> for DiagnosticSeverity {
             settings::DiagnosticSeverityContent::Warning => DiagnosticSeverity::Warning,
             settings::DiagnosticSeverityContent::Info => DiagnosticSeverity::Info,
             settings::DiagnosticSeverityContent::Hint => DiagnosticSeverity::Hint,
+            settings::DiagnosticSeverityContent::All => DiagnosticSeverity::Hint,
         }
     }
 }

--- a/crates/settings/src/settings_content/project.rs
+++ b/crates/settings/src/settings_content/project.rs
@@ -470,8 +470,8 @@ pub enum DiagnosticSeverityContent {
     Error,
     Warning,
     Info,
-    #[serde(alias = "all")]
     Hint,
+    All,
 }
 
 /// A custom Git hosting provider.


### PR DESCRIPTION
Closes #ISSUE

Annotated our `default.json` with `$schema` to get diagnostics, then fixed the non-language not installed warnings.

Release Notes:

- N/A *or* Added/Fixed/Improved ...
