### PR TITLE
settings_ui: Fix content page title

### DIFF
--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -1793,14 +1793,17 @@ impl SettingsWindow {
                 .find(|(_, (_, item))| !matches!(item, SettingsPageItem::SectionHeader(_)))
                 .map(|(index, _)| index);
 
+            let root_nav_label = self
+                .navbar_entries
+                .iter()
+                .find(|entry| entry.is_root && entry.page_index == self.current_page_index())
+                .map(|entry| entry.title);
+
             page_content = page_content
                 .when(sub_page_stack().is_empty(), |this| {
-                    this.when_some(
-                        self.navbar_entries
-                            .get(self.navbar_entry)
-                            .map(|entry| entry.title),
-                        |this, title| this.child(Label::new(title).size(LabelSize::Large).mb_3()),
-                    )
+                    this.when_some(root_nav_label, |this, title| {
+                        this.child(Label::new(title).size(LabelSize::Large).mt_2().mb_3())
+                    })
                 })
                 .children(items.clone().into_iter().enumerate().map(
                     |(index, (actual_item_index, item))| {


### PR DESCRIPTION
Follow up to https://github.com/zed-industries/zed/pull/39979. The previous PR made it the title would change even if you were on a non-root tree view item. This PR fixes that by fixating the title to show only the root tree view item.

Release Notes:

- N/A
