### PR TITLE
windows: Fix shader rotation order for pattern rendering

### DIFF
--- a/crates/gpui/src/platform/windows/shaders.hlsl
+++ b/crates/gpui/src/platform/windows/shaders.hlsl
@@ -390,7 +390,7 @@ float4 gradient_color(Background background,
             float pattern_period = pattern_height * sin(stripe_angle);
             float2x2 rotation = rotate2d(stripe_angle);
             float2 relative_position = position - bounds.origin;
-            float2 rotated_point = mul(rotation, relative_position);
+            float2 rotated_point = mul(relative_position, rotation);
             float pattern = fmod(rotated_point.x, pattern_period);
             float distance = min(pattern, pattern_period - pattern) - pattern_period * (pattern_width / pattern_height) /  2.0f;
             color = solid_color;


### PR DESCRIPTION
old

<img width="1076" height="1008" alt="image" src="https://github.com/user-attachments/assets/e1cd8238-e869-4abb-98b4-4790467c59d1" />


new

<img width="989" height="1004" alt="image" src="https://github.com/user-attachments/assets/42b7fd59-0038-4490-82a7-979983da5416" />


Release Notes:

- N/A
