### PR TITLE
Fix regression on SSH remotes not running NuShell

### DIFF
--- a/crates/remote/src/transport/ssh.rs
+++ b/crates/remote/src/transport/ssh.rs
@@ -789,7 +789,7 @@ impl SshSocket {
     }
 
     async fn platform(&self) -> Result<RemotePlatform> {
-        let uname = self.run_command("uname", &["-sm"]).await?;
+        let uname = self.run_command("sh", &["-c", "uname -sm"]).await?;
         let Some((os, arch)) = uname.split_once(" ") else {
             anyhow::bail!("unknown uname: {uname:?}")
         };


### PR DESCRIPTION
This was already patched and merged a few months ago in #25613, which fixed the original issue (#21005) but there seems to have been a regression of sorts, maybe when migrating/refactoring something.

NuShell does not support `uname -sm`, so invoke `sh -c "uname -sm"` instead which will also work under nushell. See nushell/nushell#12570 for the choice quote: "being posix/bash compliant is a non-goal".

Release Notes:

- Fixed ssh remotes running Nushell (yet again)
