### PR TITLE
Update Cargo.toml svg dependencies to 0.45.1

### DIFF
--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -109,12 +109,12 @@ profiling.workspace = true
 rand = { optional = true, workspace = true }
 raw-window-handle = "0.6"
 refineable.workspace = true
-resvg = { version = "0.45.0", default-features = false, features = [
+resvg = { version = "0.45.1", default-features = false, features = [
     "text",
     "system-fonts",
     "memmap-fonts",
 ] }
-usvg = { version = "0.45.0", default-features = false }
+usvg = { version = "0.45.1", default-features = false }
 util_macros.workspace = true
 schemars.workspace = true
 seahash = "4.1"


### PR DESCRIPTION
The versions of resvg and usvg should be updated, 
if I am understanding all the moving parts correctly.

Closes #ISSUE

Release Notes:

- N/A *or* Added/Fixed/Improved ...
