### PR TITLE
ui: Change scrollbar hitbox insertion order

### DIFF
--- a/crates/ui/src/components/scrollbar.rs
+++ b/crates/ui/src/components/scrollbar.rs
@@ -1102,7 +1102,6 @@ impl<T: ScrollableHandle> Element for ScrollbarElement<T> {
             .disabled()
             .not()
             .then(|| ScrollbarPrepaintState {
-                parent_bounds_hitbox: window.insert_hitbox(bounds, HitboxBehavior::Normal),
                 thumbs: {
                     let thumb_ranges = self.state.read(cx).thumb_ranges().collect::<Vec<_>>();
                     let width = self.state.read(cx).width.to_pixels();
@@ -1178,6 +1177,7 @@ impl<T: ScrollableHandle> Element for ScrollbarElement<T> {
                         })
                         .collect()
                 },
+                parent_bounds_hitbox: window.insert_hitbox(bounds, HitboxBehavior::Normal),
             });
         if prepaint_state
             .as_ref()


### PR DESCRIPTION
Closes #39974

Since the thumb hitboxes themselves do not propagate events, we need to paint the normal parent hitbox on top of the other ones. This also caused hover detection to fail, which caused the issue linked.

Release Notes:

- Fixed an issue where hovering scrollbars in hovers would dismiss these.