### PR TITLE
Theme mode switch action: switch between light and dark themes

### DIFF
--- a/crates/onboarding/src/basics_page.rs
+++ b/crates/onboarding/src/basics_page.rs
@@ -5,7 +5,7 @@ use fs::Fs;
 use gpui::{Action, App, IntoElement};
 use settings::{BaseKeymap, Settings, update_settings_file};
 use theme::{
-    Appearance, SystemAppearance, ThemeMode, ThemeName, ThemeRegistry, ThemeSelection,
+    Appearance, SystemAppearance, ThemeAppearanceMode, ThemeName, ThemeRegistry, ThemeSelection,
     ThemeSettings,
 };
 use ui::{
@@ -44,8 +44,8 @@ fn render_theme_section(tab_index: &mut isize, cx: &mut App) -> impl IntoElement
     let theme_mode = theme_selection
         .mode()
         .unwrap_or_else(|| match *system_appearance {
-            Appearance::Light => ThemeMode::Light,
-            Appearance::Dark => ThemeMode::Dark,
+            Appearance::Light => ThemeAppearanceMode::Light,
+            Appearance::Dark => ThemeAppearanceMode::Dark,
         });
 
     return v_flex()
@@ -54,7 +54,12 @@ fn render_theme_section(tab_index: &mut isize, cx: &mut App) -> impl IntoElement
             h_flex().justify_between().child(Label::new("Theme")).child(
                 ToggleButtonGroup::single_row(
                     "theme-selector-onboarding-dark-light",
-                    [ThemeMode::Light, ThemeMode::Dark, ThemeMode::System].map(|mode| {
+                    [
+                        ThemeAppearanceMode::Light,
+                        ThemeAppearanceMode::Dark,
+                        ThemeAppearanceMode::System,
+                    ]
+                    .map(|mode| {
                         const MODE_NAMES: [SharedString; 3] = [
                             SharedString::new_static("Light"),
                             SharedString::new_static("Dark"),
@@ -100,13 +105,13 @@ fn render_theme_section(tab_index: &mut isize, cx: &mut App) -> impl IntoElement
         let theme_mode = theme_selection
             .mode()
             .unwrap_or_else(|| match *system_appearance {
-                Appearance::Light => ThemeMode::Light,
-                Appearance::Dark => ThemeMode::Dark,
+                Appearance::Light => ThemeAppearanceMode::Light,
+                Appearance::Dark => ThemeAppearanceMode::Dark,
             });
         let appearance = match theme_mode {
-            ThemeMode::Light => Appearance::Light,
-            ThemeMode::Dark => Appearance::Dark,
-            ThemeMode::System => *system_appearance,
+            ThemeAppearanceMode::Light => Appearance::Light,
+            ThemeAppearanceMode::Dark => Appearance::Dark,
+            ThemeAppearanceMode::System => *system_appearance,
         };
         let current_theme_name: SharedString = theme_selection.name(appearance).0.into();
 
@@ -164,7 +169,7 @@ fn render_theme_section(tab_index: &mut isize, cx: &mut App) -> impl IntoElement
                             }
                         })
                         .map(|this| {
-                            if theme_mode == ThemeMode::System {
+                            if theme_mode == ThemeAppearanceMode::System {
                                 let (light, dark) = (
                                     theme_registry.get(LIGHT_THEMES[index]).unwrap(),
                                     theme_registry.get(DARK_THEMES[index]).unwrap(),
@@ -189,23 +194,27 @@ fn render_theme_section(tab_index: &mut isize, cx: &mut App) -> impl IntoElement
         })
     }
 
-    fn write_mode_change(mode: ThemeMode, cx: &mut App) {
+    fn write_mode_change(mode: ThemeAppearanceMode, cx: &mut App) {
         let fs = <dyn Fs>::global(cx);
         update_settings_file(fs, cx, move |settings, _cx| {
             theme::set_mode(settings, mode);
         });
     }
 
-    fn write_theme_change(theme: impl Into<Arc<str>>, theme_mode: ThemeMode, cx: &mut App) {
+    fn write_theme_change(
+        theme: impl Into<Arc<str>>,
+        theme_mode: ThemeAppearanceMode,
+        cx: &mut App,
+    ) {
         let fs = <dyn Fs>::global(cx);
         let theme = theme.into();
         update_settings_file(fs, cx, move |settings, cx| {
-            if theme_mode == ThemeMode::System {
+            if theme_mode == ThemeAppearanceMode::System {
                 let (light_theme, dark_theme) =
                     get_theme_family_themes(&theme).unwrap_or((theme.as_ref(), theme.as_ref()));
 
                 settings.theme.theme = Some(settings::ThemeSelection::Dynamic {
-                    mode: ThemeMode::System,
+                    mode: ThemeAppearanceMode::System,
                     light: ThemeName(light_theme.into()),
                     dark: ThemeName(dark_theme.into()),
                 });

--- a/crates/settings/src/settings_content/theme.rs
+++ b/crates/settings/src/settings_content/theme.rs
@@ -157,7 +157,7 @@ pub enum ThemeSelection {
     Dynamic {
         /// The mode used to determine which theme to use.
         #[serde(default)]
-        mode: ThemeMode,
+        mode: ThemeAppearanceMode,
         /// The theme to use for light mode.
         light: ThemeName,
         /// The theme to use for dark mode.
@@ -186,7 +186,7 @@ pub enum IconThemeSelection {
     Dynamic {
         /// The mode used to determine which theme to use.
         #[serde(default)]
-        mode: ThemeMode,
+        mode: ThemeAppearanceMode,
         /// The icon theme to use for light mode.
         light: IconThemeName,
         /// The icon theme to use for dark mode.
@@ -194,7 +194,6 @@ pub enum IconThemeSelection {
     },
 }
 
-// TODO: Rename ThemeMode -> ThemeAppearanceMode
 /// The mode use to select a theme.
 ///
 /// `Light` and `Dark` will select their respective themes.
@@ -215,7 +214,7 @@ pub enum IconThemeSelection {
     strum::VariantNames,
 )]
 #[serde(rename_all = "snake_case")]
-pub enum ThemeMode {
+pub enum ThemeAppearanceMode {
     /// Use the specified `light` theme.
     Light,
 

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -300,9 +300,9 @@ pub(crate) fn settings_data(cx: &App) -> Vec<SettingsPage> {
                                             settings::ThemeSelection::Static(_) => return,
                                             settings::ThemeSelection::Dynamic { mode, light, dark } => {
                                                 match mode {
-                                                    theme::ThemeMode::Light => light.clone(),
-                                                    theme::ThemeMode::Dark => dark.clone(),
-                                                    theme::ThemeMode::System => dark.clone(), // no cx, can't determine correct choice
+                                                    theme::ThemeAppearanceMode::Light => light.clone(),
+                                                    theme::ThemeAppearanceMode::Dark => dark.clone(),
+                                                    theme::ThemeAppearanceMode::System => dark.clone(), // no cx, can't determine correct choice
                                                 }
                                             },
                                         };
@@ -315,7 +315,7 @@ pub(crate) fn settings_data(cx: &App) -> Vec<SettingsPage> {
                                         };
 
                                         settings::ThemeSelection::Dynamic {
-                                            mode: settings::ThemeMode::System,
+                                            mode: settings::ThemeAppearanceMode::System,
                                             light: static_name.clone(),
                                             dark: static_name,
                                         }
@@ -470,9 +470,9 @@ pub(crate) fn settings_data(cx: &App) -> Vec<SettingsPage> {
                                             settings::IconThemeSelection::Static(_) => return,
                                             settings::IconThemeSelection::Dynamic { mode, light, dark } => {
                                                 match mode {
-                                                    theme::ThemeMode::Light => light.clone(),
-                                                    theme::ThemeMode::Dark => dark.clone(),
-                                                    theme::ThemeMode::System => dark.clone(), // no cx, can't determine correct choice
+                                                    theme::ThemeAppearanceMode::Light => light.clone(),
+                                                    theme::ThemeAppearanceMode::Dark => dark.clone(),
+                                                    theme::ThemeAppearanceMode::System => dark.clone(), // no cx, can't determine correct choice
                                                 }
                                             },
                                         };
@@ -485,7 +485,7 @@ pub(crate) fn settings_data(cx: &App) -> Vec<SettingsPage> {
                                         };
 
                                         settings::IconThemeSelection::Dynamic {
-                                            mode: settings::ThemeMode::System,
+                                            mode: settings::ThemeAppearanceMode::System,
                                             light: static_name.clone(),
                                             dark: static_name,
                                         }

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -486,7 +486,7 @@ fn init_renderers(cx: &mut App) {
         .add_basic_renderer::<settings::PaneSplitDirectionVertical>(render_dropdown)
         .add_basic_renderer::<settings::DocumentColorsRenderMode>(render_dropdown)
         .add_basic_renderer::<settings::ThemeSelectionDiscriminants>(render_dropdown)
-        .add_basic_renderer::<settings::ThemeMode>(render_dropdown)
+        .add_basic_renderer::<settings::ThemeAppearanceMode>(render_dropdown)
         .add_basic_renderer::<settings::ThemeName>(render_theme_picker)
         .add_basic_renderer::<settings::IconThemeSelectionDiscriminants>(render_dropdown)
         .add_basic_renderer::<settings::IconThemeName>(render_icon_theme_picker)

--- a/crates/theme/src/settings.rs
+++ b/crates/theme/src/settings.rs
@@ -199,6 +199,12 @@ pub struct AgentFontSize(Pixels);
 impl Global for AgentFontSize {}
 
 /// Represents the selection of a theme, which can be either static or dynamic.
+///
+/// If a user sets their "theme" setting to a single name (for example, `"theme": "One Dark"`), then
+/// the selection is `Static`.
+///
+/// By default, the settings are set to `Dynamic` with `"mode": "system"`, `"light": "One Light"`,
+/// and `"dark": "One Dark"`.
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(untagged)]
 pub enum ThemeSelection {

--- a/crates/theme/src/settings.rs
+++ b/crates/theme/src/settings.rs
@@ -11,7 +11,7 @@ use gpui::{
 use refineable::Refineable;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-pub use settings::{FontFamilyName, IconThemeName, ThemeMode, ThemeName};
+pub use settings::{FontFamilyName, IconThemeName, ThemeAppearanceMode, ThemeName};
 use settings::{RegisterSetting, Settings, SettingsContent};
 use std::sync::Arc;
 
@@ -208,7 +208,7 @@ pub enum ThemeSelection {
     Dynamic {
         /// The mode used to determine which theme to use.
         #[serde(default)]
-        mode: ThemeMode,
+        mode: ThemeAppearanceMode,
         /// The theme to use for light mode.
         light: ThemeName,
         /// The theme to use for dark mode.
@@ -233,9 +233,9 @@ impl ThemeSelection {
         match self {
             Self::Static(theme) => theme.clone(),
             Self::Dynamic { mode, light, dark } => match mode {
-                ThemeMode::Light => light.clone(),
-                ThemeMode::Dark => dark.clone(),
-                ThemeMode::System => match system_appearance {
+                ThemeAppearanceMode::Light => light.clone(),
+                ThemeAppearanceMode::Dark => dark.clone(),
+                ThemeAppearanceMode::System => match system_appearance {
                     Appearance::Light => light.clone(),
                     Appearance::Dark => dark.clone(),
                 },
@@ -244,7 +244,7 @@ impl ThemeSelection {
     }
 
     /// Returns the [ThemeMode] for the [ThemeSelection].
-    pub fn mode(&self) -> Option<ThemeMode> {
+    pub fn mode(&self) -> Option<ThemeAppearanceMode> {
         match self {
             ThemeSelection::Static(_) => None,
             ThemeSelection::Dynamic { mode, .. } => Some(*mode),
@@ -260,7 +260,7 @@ pub enum IconThemeSelection {
     /// A dynamic icon theme selection, which can change based on the [`ThemeMode`].
     Dynamic {
         /// The mode used to determine which theme to use.
-        mode: ThemeMode,
+        mode: ThemeAppearanceMode,
         /// The icon theme to use for light mode.
         light: IconThemeName,
         /// The icon theme to use for dark mode.
@@ -285,9 +285,9 @@ impl IconThemeSelection {
         match self {
             Self::Static(theme) => theme.clone(),
             Self::Dynamic { mode, light, dark } => match mode {
-                ThemeMode::Light => light.clone(),
-                ThemeMode::Dark => dark.clone(),
-                ThemeMode::System => match system_appearance {
+                ThemeAppearanceMode::Light => light.clone(),
+                ThemeAppearanceMode::Dark => dark.clone(),
+                ThemeAppearanceMode::System => match system_appearance {
                     Appearance::Light => light.clone(),
                     Appearance::Dark => dark.clone(),
                 },
@@ -296,7 +296,7 @@ impl IconThemeSelection {
     }
 
     /// Returns the [`ThemeMode`] for the [`IconThemeSelection`].
-    pub fn mode(&self) -> Option<ThemeMode> {
+    pub fn mode(&self) -> Option<ThemeAppearanceMode> {
         match self {
             IconThemeSelection::Static(_) => None,
             IconThemeSelection::Dynamic { mode, .. } => Some(*mode),
@@ -315,9 +315,9 @@ pub fn set_theme(
         let theme_to_update = match selection {
             settings::ThemeSelection::Static(theme) => theme,
             settings::ThemeSelection::Dynamic { mode, light, dark } => match mode {
-                ThemeMode::Light => light,
-                ThemeMode::Dark => dark,
-                ThemeMode::System => match appearance {
+                ThemeAppearanceMode::Light => light,
+                ThemeAppearanceMode::Dark => dark,
+                ThemeAppearanceMode::System => match appearance {
                     Appearance::Light => light,
                     Appearance::Dark => dark,
                 },
@@ -342,9 +342,9 @@ pub fn set_icon_theme(
         let icon_theme_to_update = match selection {
             settings::IconThemeSelection::Static(theme) => theme,
             settings::IconThemeSelection::Dynamic { mode, light, dark } => match mode {
-                ThemeMode::Light => light,
-                ThemeMode::Dark => dark,
-                ThemeMode::System => match appearance {
+                ThemeAppearanceMode::Light => light,
+                ThemeAppearanceMode::Dark => dark,
+                ThemeAppearanceMode::System => match appearance {
                     Appearance::Light => light,
                     Appearance::Dark => dark,
                 },
@@ -358,7 +358,7 @@ pub fn set_icon_theme(
 }
 
 /// Sets the mode for the theme.
-pub fn set_mode(content: &mut SettingsContent, mode: ThemeMode) {
+pub fn set_mode(content: &mut SettingsContent, mode: ThemeAppearanceMode) {
     let theme = content.theme.as_mut();
 
     if let Some(selection) = theme.theme.as_mut() {

--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -83,6 +83,11 @@ pub fn app_menus(cx: &mut App) -> Vec<Menu> {
                             "Select Theme...",
                             zed_actions::theme_selector::Toggle::default(),
                         ),
+                        // TODO(connor): Figure out a better description.
+                        MenuItem::action(
+                            "Switch Theme Mode",
+                            zed_actions::theme_selector::SwitchMode,
+                        ),
                         MenuItem::action(
                             "Select Icon Theme...",
                             zed_actions::icon_theme_selector::Toggle::default(),

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -262,7 +262,7 @@ pub mod feedback {
 }
 
 pub mod theme_selector {
-    use gpui::Action;
+    use gpui::{Action, actions};
     use schemars::JsonSchema;
     use serde::Deserialize;
 
@@ -274,6 +274,16 @@ pub mod theme_selector {
         /// A list of theme names to filter the theme selector down to.
         pub themes_filter: Option<Vec<String>>,
     }
+
+    actions!(
+        theme_selector,
+        [
+            /// Switches between light and dark mode.
+            ///
+            /// TODO(connor) figure out a better name and describe the edge cases.
+            SwitchMode
+        ]
+    );
 }
 
 pub mod icon_theme_selector {


### PR DESCRIPTION
_This is my first real contribution to Zed so there are likely a lot of weird things in here..._

Closes: https://github.com/zed-industries/zed/issues/35552

I've made a few changes here and they can be mostly understood by the 4 different commits. The non-cosmetic changes are the last 2.

The third commit attempts to solve #35552, but imo my attempt is incredibly hacky and the semantics are not super obvious (which is why this PR description is so long). The fourth commit makes a change that only makes sense with the new action.

## Implementation

The change is based on https://github.com/zed-industries/zed/pull/35697, but instead of updating the settings file (with `update_settings_file::<ThemeSettings>`) I decided to use `SettingsStore::update_global` because this seems to keep changes in memory rather than forcing them onto the user's settings file (I could be wrong though?).

The semantics are pretty obvious for the `ThemeSelection::Dynamic` case, we just toggle/switch the mode based on the light/dark appearance, and if the mode is `System` we rely on the `theme.appearance().is_light()` function. However, for the `ThemeSelection::Static` case, I don't think there is such a clear solution, and my lack of understanding of how Zed's settings system works doesn't help here.

### `Static` theme switch semantics

My understanding is that the current `ThemeSelection` setting is based on [this](https://zed.dev/docs/themes#configuring-a-theme) user setting, and I believe the _only_ way to get a `Static` theme (without opening the `ThemeSelector` modal, I'll get to that later) is for a user to manually specify `"theme": "SpecificTheme"` in their settings file. This means that if a user has done that, and then they trigger this action, it is not obvious what they want to switch to.

So I chose to just hard code "One Dark" and "One Light" as fallback themes in this case. This of course assumes that they are already available in the theme registry, and I have no idea if that is always true.

### `ThemeSelector` semantics

Right now, when you choose a theme with the theme selector, it will set the `ThemeSelection` setting to `Static`, regardless of what the current selection is. This is totally fine in current Zed since that is currently the only way to change themes. With this new action, we need to maintain that `Dynamic` setting if enabled, so that is what the fourth commit does.

## Naming

I don't really know what a good name for this action should be. At first "Toggle" seems like a reasonable name, but that conflicts with the `theme_selector::Toggle` action that toggles opening the theme selector, so I don't think it should be called that. "Switch Mode" is what I went with in this PR, but I don't really like the name either because it doesn't obviously describe everything that needs to happen. I'm not even sure if `theme_selector` is the right place for this?

### Unresolved Questions

So TLDR; here are the unresolved questions:

- [ ] Should this action only change settings in memory (not on disk)?
- [ ] What should the semantics of a "switch between light and dark mode" action be in the case of a `Static` theme?
- [ ] Are the "One Dark" and "One Light" themes the defaults? Are they guaranteed to be in the registry? Should this action default to these if the current theme is `Static`?
- [ ] What should this action be named? Is `theme_selector` the right namespace?

Release Notes:

- N/A