### PR TITLE
Fix ctrl-v paste binding for Windows terminal

### DIFF
--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -1117,6 +1117,7 @@
       "ctrl-insert": "terminal::Copy",
       "ctrl-shift-c": "terminal::Copy",
       "shift-insert": "terminal::Paste",
+      "ctrl-v": "terminal::Paste",
       "ctrl-shift-v": "terminal::Paste",
       "ctrl-enter": "assistant::InlineAssist",
       "alt-b": ["terminal::SendText", "\u001bb"],


### PR DESCRIPTION
Closes #40034

Release Notes:

-  Fixed: Pasting with `ctrl-v` now works in Git Bash terminal on Windows
