### PR TITLE
gpui: Add a transitions API

### DIFF
--- a/crates/gpui/src/elements/animation.rs
+++ b/crates/gpui/src/elements/animation.rs
@@ -175,7 +175,8 @@ impl<E: IntoElement + 'static> animatable::AnimatableExt for AnimationElement<E>
 mod animatable {
     use crate::{
         AnyElement, App, Element, ElementId, GlobalElementId, InspectorElementId,
-        InteractiveElement, IntoElement, StyleRefinement, Styled, Window,
+        InteractiveElement, IntoElement, ParentElement, StatefulInteractiveElement,
+        StyleRefinement, Styled, Window,
     };
 
     /// An extension trait that reduces the boilerplate required to make an element animated.
@@ -295,6 +296,20 @@ mod animatable {
         fn interactivity(&mut self) -> &mut crate::Interactivity {
             self.element_mut().unwrap().interactivity()
         }
+    }
+
+    impl<E: AnimatableExt + 'static> ParentElement for E
+    where
+        <Self as AnimatableExt>::Element: ParentElement,
+    {
+        fn extend(&mut self, elements: impl IntoIterator<Item = AnyElement>) {
+            self.element_mut().unwrap().extend(elements);
+        }
+    }
+
+    impl<E: AnimatableExt + 'static> StatefulInteractiveElement for E where
+        <Self as AnimatableExt>::Element: StatefulInteractiveElement
+    {
     }
 }
 

--- a/crates/gpui/src/elements/animation.rs
+++ b/crates/gpui/src/elements/animation.rs
@@ -3,12 +3,10 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::{
-    AnyElement, App, ElementId, GlobalElementId, InspectorElementId, IntoElement, Window
-};
+use crate::{AnyElement, App, ElementId, GlobalElementId, InspectorElementId, IntoElement, Window};
 
-pub use easing::*;
 pub use animatable::*;
+pub use easing::*;
 use smallvec::SmallVec;
 
 /// An animation that can be applied to an element.
@@ -173,7 +171,8 @@ impl<E: IntoElement + 'static> animatable::AnimatableExt for AnimationElement<E>
 
 mod animatable {
     use crate::{
-        AnyElement, App, Element, ElementId, GlobalElementId, InspectorElementId, IntoElement, Window,
+        AnyElement, App, Element, ElementId, GlobalElementId, InspectorElementId, IntoElement,
+        Window,
     };
 
     /// An extension trait that reduces the boilerplate required to make an element animated.

--- a/crates/gpui/src/elements/mod.rs
+++ b/crates/gpui/src/elements/mod.rs
@@ -9,6 +9,7 @@ mod list;
 mod surface;
 mod svg;
 mod text;
+mod transition;
 mod uniform_list;
 
 pub use anchored::*;
@@ -22,4 +23,5 @@ pub use list::*;
 pub use surface::*;
 pub use svg::*;
 pub use text::*;
+pub use transition::*;
 pub use uniform_list::*;

--- a/crates/gpui/src/elements/transition.rs
+++ b/crates/gpui/src/elements/transition.rs
@@ -167,7 +167,7 @@ pub struct TransitionElement<'a, E, T: TransitionValues<'a>> {
     animator: Box<dyn Fn(&mut App, E, T::Values) -> E + 'a>,
 }
 
-impl<E: IntoElement + 'static, T: TransitionValues<'static> + Clone + 'static> AnimatableExt
+impl<E: IntoElement + 'static, T: TransitionValues<'static> + 'static> AnimatableExt
     for TransitionElement<'static, E, T>
 {
     type Element = E;

--- a/crates/gpui/src/elements/transition.rs
+++ b/crates/gpui/src/elements/transition.rs
@@ -209,7 +209,7 @@ impl<E: IntoElement + 'static, T: TransitionValues<'static> + Clone + 'static> A
     }
 }
 
-/// A data type which can be used as a transition goal.
+/// A type which can be used as a transition goal.
 pub trait TransitionGoal {
     /// Defines how a delta is applied to a value.
     fn apply_delta(&self, to: &Self, delta: f32) -> Self;

--- a/crates/gpui/src/elements/transition.rs
+++ b/crates/gpui/src/elements/transition.rs
@@ -1,9 +1,15 @@
 use std::{
-    fmt::Debug, ops::{Add, Mul, Sub}, rc::Rc, time::{Duration, Instant}, borrow::BorrowMut
+    borrow::BorrowMut,
+    fmt::Debug,
+    ops::{Add, Mul, Sub},
+    rc::Rc,
+    time::{Duration, Instant},
 };
 
 use crate::{
-    AnimatableExt, AnyElement, App, Bounds, Corners, DevicePixels, Edges, ElementId, Entity, GlobalElementId, Hsla, InspectorElementId, IntoElement, Percentage, Pixels, Point, Radians, Rems, Rgba, ScaledPixels, Size, Window, colors::Colors, linear
+    AnimatableExt, AnyElement, App, Bounds, Corners, DevicePixels, Edges, ElementId, Entity,
+    GlobalElementId, Hsla, InspectorElementId, IntoElement, Percentage, Pixels, Point, Radians,
+    Rems, Rgba, ScaledPixels, Size, Window, colors::Colors, linear,
 };
 
 /// A transition that can be applied to an element.
@@ -16,7 +22,7 @@ pub struct Transition<T: TransitionGoal + Clone> {
     /// between 0 and 1 based on the given easing function.
     easing: Rc<dyn Fn(f32) -> f32>,
 
-    state: Entity<TransitionState<T>>
+    state: Entity<TransitionState<T>>,
 }
 
 impl<T: TransitionGoal + Clone + PartialEq + 'static> Transition<T> {
@@ -24,13 +30,15 @@ impl<T: TransitionGoal + Clone + PartialEq + 'static> Transition<T> {
     pub fn read_goal<'a>(&self, cx: &'a App) -> &'a T {
         &self.state.read(cx).current_goal
     }
-    
+
     /// Updates the goal for the transition without notifying gpui of any changes.
     pub fn update_goal_silently(&self, new_goal: T, cx: &mut App) -> bool {
         let mut was_updated = false;
 
         self.state.update(cx, |state, _cx| {
-            if state.current_goal == new_goal { return };
+            if state.current_goal == new_goal {
+                return;
+            };
 
             state.goal_last_updated_at = Instant::now();
             state.last_goal = std::mem::replace(&mut state.current_goal, new_goal);
@@ -79,11 +87,18 @@ impl<T: TransitionGoal + Clone> TransitionState<T> {
 
 impl<T: TransitionGoal + Clone + 'static> Transition<T> {
     /// Create a new transition with the given duration and goal.
-    pub fn new(id: impl Into<ElementId>, duration: Duration, initial_goal: T, window: &mut Window, cx: &mut App) -> Self {
+    pub fn new(
+        id: impl Into<ElementId>,
+        duration: Duration,
+        initial_goal: T,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> Self {
         Self {
             duration_secs: duration.as_secs_f32(),
             easing: Rc::new(linear),
-            state: window.use_keyed_state(id, cx, |_window, _cx| TransitionState::new(initial_goal))
+            state: window
+                .use_keyed_state(id, cx, |_window, _cx| TransitionState::new(initial_goal)),
         }
     }
 
@@ -92,7 +107,7 @@ impl<T: TransitionGoal + Clone + 'static> Transition<T> {
         Self {
             duration_secs: duration.as_secs_f32(),
             easing: Rc::new(linear),
-            state
+            state,
         }
     }
 
@@ -142,7 +157,9 @@ impl<E, T: TransitionGoal + Clone> TransitionElement<E, T> {
     }
 }
 
-impl<E: IntoElement + 'static, T: TransitionGoal + Clone + 'static> IntoElement for TransitionElement<E, T> {
+impl<E: IntoElement + 'static, T: TransitionGoal + Clone + 'static> IntoElement
+    for TransitionElement<E, T>
+{
     type Element = TransitionElement<E, T>;
 
     fn into_element(self) -> Self::Element {
@@ -150,7 +167,9 @@ impl<E: IntoElement + 'static, T: TransitionGoal + Clone + 'static> IntoElement 
     }
 }
 
-impl<E: IntoElement + 'static, T: TransitionGoal + Clone + 'static> AnimatableExt for TransitionElement<E, T> {
+impl<E: IntoElement + 'static, T: TransitionGoal + Clone + 'static> AnimatableExt
+    for TransitionElement<E, T>
+{
     fn request_layout(
         &mut self,
         _global_id: Option<&GlobalElementId>,
@@ -163,7 +182,8 @@ impl<E: IntoElement + 'static, T: TransitionGoal + Clone + 'static> AnimatableEx
 
         let elapsed_secs = state.goal_last_updated_at.elapsed().as_secs_f32();
         let duration_secs = self.transition.duration_secs;
-        let delta = (self.transition.easing)((state.start_delta + (elapsed_secs / duration_secs)).min(1.));
+        let delta =
+            (self.transition.easing)((state.start_delta + (elapsed_secs / duration_secs)).min(1.));
 
         debug_assert!(
             (0.0..=1.0).contains(&delta),
@@ -215,8 +235,18 @@ macro_rules! int_transition_goals {
 }
 
 int_transition_goals!(
-    usize as f32, u8 as f32, u16 as f32, u32 as f32, u64 as f64, u128 as f64,
-    isize as f32, i8 as f32, i16 as f32, i32 as f32, i64 as f64, i128 as f64
+    usize as f32,
+    u8 as f32,
+    u16 as f32,
+    u32 as f32,
+    u64 as f64,
+    u128 as f64,
+    isize as f32,
+    i8 as f32,
+    i16 as f32,
+    i32 as f32,
+    i64 as f64,
+    i128 as f64
 );
 
 macro_rules! struct_transition_goals {

--- a/crates/gpui/src/elements/transition.rs
+++ b/crates/gpui/src/elements/transition.rs
@@ -26,6 +26,39 @@ pub struct Transition<T: TransitionGoal + Clone + PartialEq + 'static> {
 }
 
 impl<T: TransitionGoal + Clone + PartialEq + 'static> Transition<T> {
+    /// Create a new transition with the given duration and goal.
+    pub fn new(
+        id: impl Into<ElementId>,
+        duration: Duration,
+        initial_goal: T,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> Self {
+        Self {
+            duration_secs: duration.as_secs_f32(),
+            easing: Rc::new(linear),
+            state: window
+                .use_keyed_state(id, cx, |_window, _cx| TransitionState::new(initial_goal)),
+        }
+    }
+
+    /// Create a new transition with the given duration using the specified state.
+    pub fn from_state(state: Entity<TransitionState<T>>, duration: Duration) -> Self {
+        Self {
+            duration_secs: duration.as_secs_f32(),
+            easing: Rc::new(linear),
+            state,
+        }
+    }
+
+    /// Set the easing function to use for this transition.
+    /// The easing function will take a time delta between 0 and 1 and return a new delta
+    /// between 0 and 1
+    pub fn with_easing(mut self, easing: impl Fn(f32) -> f32 + 'static) -> Self {
+        self.easing = Rc::new(easing);
+        self
+    }
+
     /// Reads the transition's goal.
     pub fn read_goal<'a>(&self, cx: &'a App) -> &'a T {
         &self.state.read(cx).end_goal
@@ -102,41 +135,6 @@ impl<T: TransitionGoal + Clone + PartialEq + 'static> TransitionState<T> {
             end_goal: initial_goal,
             last_delta: 1.,
         }
-    }
-}
-
-impl<T: TransitionGoal + Clone + PartialEq + 'static> Transition<T> {
-    /// Create a new transition with the given duration and goal.
-    pub fn new(
-        id: impl Into<ElementId>,
-        duration: Duration,
-        initial_goal: T,
-        window: &mut Window,
-        cx: &mut App,
-    ) -> Self {
-        Self {
-            duration_secs: duration.as_secs_f32(),
-            easing: Rc::new(linear),
-            state: window
-                .use_keyed_state(id, cx, |_window, _cx| TransitionState::new(initial_goal)),
-        }
-    }
-
-    /// Create a new transition with the given duration using the specified state.
-    pub fn from_state(state: Entity<TransitionState<T>>, duration: Duration) -> Self {
-        Self {
-            duration_secs: duration.as_secs_f32(),
-            easing: Rc::new(linear),
-            state,
-        }
-    }
-
-    /// Set the easing function to use for this transition.
-    /// The easing function will take a time delta between 0 and 1 and return a new delta
-    /// between 0 and 1
-    pub fn with_easing(mut self, easing: impl Fn(f32) -> f32 + 'static) -> Self {
-        self.easing = Rc::new(easing);
-        self
     }
 }
 

--- a/crates/gpui/src/elements/transition.rs
+++ b/crates/gpui/src/elements/transition.rs
@@ -8,8 +8,8 @@ use std::{
 
 use crate::{
     AnimatableExt, AnyElement, App, Bounds, Corners, DevicePixels, Edges, ElementId, Entity,
-    GlobalElementId, Hsla, InspectorElementId, IntoElement, Percentage, Pixels, Point, Radians,
-    Rems, Rgba, ScaledPixels, Size, Window, colors::Colors, linear,
+    GlobalElementId, InspectorElementId, IntoElement, Percentage, Pixels, Point, Radians, Rems,
+    Rgba, ScaledPixels, Size, Window, colors::Colors, linear,
 };
 
 /// A transition that can be applied to an element.
@@ -269,7 +269,6 @@ struct_transition_goals!(
     Corners<T> { top_left, top_right, bottom_right, bottom_left },
     Bounds<T> { origin, size },
     Rgba { r, g, b, a },
-    Hsla { h, s, l, a },
     Colors { text, selected_text, background, disabled, selected, border, separator, container }
 );
 

--- a/crates/gpui/src/elements/transition.rs
+++ b/crates/gpui/src/elements/transition.rs
@@ -65,7 +65,8 @@ impl<T: TransitionGoal + Clone + PartialEq + 'static> Transition<T> {
     }
 
     /// Updates the goal for the transition without notifying gpui of any changes.
-    pub fn update_goal_silently(&self, new_goal: T, cx: &mut App) -> bool {
+    pub fn update_goal_silently(&self, cx: &mut App, new_goal: impl Into<T>) -> bool {
+        let new_goal = new_goal.into();
         let mut was_updated = false;
 
         self.state.update(cx, |state, _cx| {
@@ -87,8 +88,8 @@ impl<T: TransitionGoal + Clone + PartialEq + 'static> Transition<T> {
 
     /// Updates the goal for the transition and notifies gpui
     /// of the change if the new goal is different from the last.
-    pub fn update_goal(&self, new_goal: impl Into<T>, cx: &mut App) -> bool {
-        let was_updated = self.update_goal_silently(new_goal.into(), cx);
+    pub fn update_goal(&self, cx: &mut App, new_goal: impl Into<T>) -> bool {
+        let was_updated = self.update_goal_silently(cx, new_goal.into());
 
         if was_updated {
             cx.notify(self.state.entity_id());

--- a/crates/gpui/src/elements/transition.rs
+++ b/crates/gpui/src/elements/transition.rs
@@ -62,7 +62,7 @@ impl<T: TransitionGoal + Clone + PartialEq + 'static> Transition<T> {
         was_updated
     }
 
-    // Evaluates the value for the transition based on the previous and current goal.
+    // Evaluates the value for the transition based on the last and current goal.
     fn evaluate(&self, cx: &mut App) -> (bool, T) {
         let mut state_entity = self.state.as_mut(cx);
         let state: &mut TransitionState<T> = state_entity.borrow_mut();
@@ -211,7 +211,7 @@ impl<E: IntoElement + 'static, T: TransitionValues<'static> + Clone + 'static> A
 
 /// A type which can be used as a transition goal.
 pub trait TransitionGoal {
-    /// Defines how a delta is applied to a value.
+    /// Defines how a value is calculated from the last and current goal.
     fn apply_delta(&self, to: &Self, delta: f32) -> Self;
 }
 
@@ -316,7 +316,7 @@ pub trait TransitionValues<'a> {
     /// The underlying type of the values.
     type Values;
 
-    /// Evaluates the values for the transitions based on the previous and current goal.
+    /// Evaluates the values for the transitions based on the last and current goal.
     fn evaluate(&self, cx: &mut App) -> (bool, Self::Values);
 }
 

--- a/crates/gpui/src/elements/transition.rs
+++ b/crates/gpui/src/elements/transition.rs
@@ -76,10 +76,9 @@ impl<T: TransitionGoal + Clone + PartialEq + 'static> Transition<T> {
             "delta should always be between 0 and 1"
         );
 
-        let evaluated_value = state.last_goal.apply_delta(&state.current_goal, delta);
-
         state.last_delta = delta;
-        drop(state_entity);
+
+        let evaluated_value = state.last_goal.apply_delta(&state.current_goal, delta);
 
         (delta != 1., evaluated_value)
     }

--- a/crates/gpui/src/elements/transition.rs
+++ b/crates/gpui/src/elements/transition.rs
@@ -316,7 +316,7 @@ pub trait TransitionValues<'a> {
     /// The underlying type of the values.
     type Values;
 
-    /// Evaluates the values for the transitions based on the last and current goal.
+    /// Evaluates the values for the transitions based on the last and current goals.
     fn evaluate(&self, cx: &mut App) -> (bool, Self::Values);
 }
 

--- a/crates/gpui/src/elements/transition.rs
+++ b/crates/gpui/src/elements/transition.rs
@@ -331,7 +331,7 @@ macro_rules! impl_with_transitions {
     (@recurse ($($prefix:ident),*) ) => {};
 
     // Generates an impl for the current prefix + head,
-    // then recurse to include the next identifier in the prefix.
+    // then recurses to include the next identifier in the prefix.
     (@recurse ($($prefix:ident),*) $head:ident $(,$tail:ident)*) => {
         impl_with_transitions!(@gen ($($prefix,)* $head));
         impl_with_transitions!(@recurse ($($prefix,)* $head) $($tail),*);

--- a/crates/gpui/src/elements/transition.rs
+++ b/crates/gpui/src/elements/transition.rs
@@ -1,0 +1,275 @@
+use std::{
+    fmt::Debug, ops::{Add, Mul, Sub}, rc::Rc, time::{Duration, Instant}, borrow::BorrowMut
+};
+
+use crate::{
+    AnimatableExt, AnyElement, App, Bounds, Corners, DevicePixels, Edges, ElementId, Entity, GlobalElementId, Hsla, InspectorElementId, IntoElement, Percentage, Pixels, Point, Radians, Rems, Rgba, ScaledPixels, Size, Window, colors::Colors, linear
+};
+
+/// A transition that can be applied to an element.
+#[derive(Clone)]
+pub struct Transition<T: TransitionGoal + Clone> {
+    /// The amount of time for which this transtion should run.
+    duration_secs: f32,
+
+    /// A function that takes a delta between 0 and 1 and returns a new delta
+    /// between 0 and 1 based on the given easing function.
+    easing: Rc<dyn Fn(f32) -> f32>,
+
+    state: Entity<TransitionState<T>>
+}
+
+impl<T: TransitionGoal + Clone + PartialEq + 'static> Transition<T> {
+    /// Reads the transition's goal.
+    pub fn read_goal<'a>(&self, cx: &'a App) -> &'a T {
+        &self.state.read(cx).current_goal
+    }
+    
+    /// Updates the goal for the transition without notifying gpui of any changes.
+    pub fn update_goal_silently(&self, new_goal: T, cx: &mut App) -> bool {
+        let mut was_updated = false;
+
+        self.state.update(cx, |state, _cx| {
+            if state.current_goal == new_goal { return };
+
+            state.goal_last_updated_at = Instant::now();
+            state.last_goal = std::mem::replace(&mut state.current_goal, new_goal);
+            state.start_delta = 1. - state.last_delta;
+
+            was_updated = true;
+        });
+
+        was_updated
+    }
+
+    /// Updates the goal for the transition and notifies gpui
+    /// of the change if the new goal is different from the last.
+    pub fn update_goal(&self, new_goal: impl Into<T>, cx: &mut App) -> bool {
+        let was_updated = self.update_goal_silently(new_goal.into(), cx);
+
+        if was_updated {
+            cx.notify(self.state.entity_id());
+        }
+
+        was_updated
+    }
+}
+
+/// State for a transition.
+#[derive(Clone)]
+pub struct TransitionState<T: TransitionGoal + Clone> {
+    goal_last_updated_at: Instant,
+    current_goal: T,
+    start_delta: f32,
+    last_delta: f32,
+    last_goal: T,
+}
+
+impl<T: TransitionGoal + Clone> TransitionState<T> {
+    fn new(initial_goal: T) -> Self {
+        Self {
+            goal_last_updated_at: Instant::now(),
+            current_goal: initial_goal.clone(),
+            start_delta: 1.,
+            last_delta: 1.,
+            last_goal: initial_goal,
+        }
+    }
+}
+
+impl<T: TransitionGoal + Clone + 'static> Transition<T> {
+    /// Create a new transition with the given duration and goal.
+    pub fn new(id: impl Into<ElementId>, duration: Duration, initial_goal: T, window: &mut Window, cx: &mut App) -> Self {
+        Self {
+            duration_secs: duration.as_secs_f32(),
+            easing: Rc::new(linear),
+            state: window.use_keyed_state(id, cx, |_window, _cx| TransitionState::new(initial_goal))
+        }
+    }
+
+    /// Create a new transition with the given duration using the specified state.
+    pub fn from_state(state: Entity<TransitionState<T>>, duration: Duration) -> Self {
+        Self {
+            duration_secs: duration.as_secs_f32(),
+            easing: Rc::new(linear),
+            state
+        }
+    }
+
+    /// Set the easing function to use for this transition.
+    /// The easing function will take a time delta between 0 and 1 and return a new delta
+    /// between 0 and 1
+    pub fn with_easing(mut self, easing: impl Fn(f32) -> f32 + 'static) -> Self {
+        self.easing = Rc::new(easing);
+        self
+    }
+}
+
+/// An extension trait for adding the transition wrapper to both Elements and Components
+pub trait TransitionExt {
+    /// Render this component or element with a transition
+    fn with_transition<T: TransitionGoal + Clone>(
+        self,
+        transition: Transition<T>,
+        animator: impl Fn(&mut App, Self, T) -> Self + 'static,
+    ) -> TransitionElement<Self, T>
+    where
+        Self: Sized,
+    {
+        TransitionElement {
+            element: Some(self),
+            animator: Box::new(animator),
+            transition,
+        }
+    }
+}
+
+impl<E: IntoElement + 'static> TransitionExt for E {}
+
+/// A GPUI element that applies a transition to another element
+pub struct TransitionElement<E, T: TransitionGoal + Clone> {
+    element: Option<E>,
+    transition: Transition<T>,
+    animator: Box<dyn Fn(&mut App, E, T) -> E + 'static>,
+}
+
+impl<E, T: TransitionGoal + Clone> TransitionElement<E, T> {
+    /// Returns a new [`TransitionElement<E, T>`] after applying the given function
+    /// to the element being animated.
+    pub fn map_element(mut self, f: impl FnOnce(E) -> E) -> TransitionElement<E, T> {
+        self.element = self.element.map(f);
+        self
+    }
+}
+
+impl<E: IntoElement + 'static, T: TransitionGoal + Clone + 'static> IntoElement for TransitionElement<E, T> {
+    type Element = TransitionElement<E, T>;
+
+    fn into_element(self) -> Self::Element {
+        self
+    }
+}
+
+impl<E: IntoElement + 'static, T: TransitionGoal + Clone + 'static> AnimatableExt for TransitionElement<E, T> {
+    fn request_layout(
+        &mut self,
+        _global_id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        _window: &mut Window,
+        cx: &mut App,
+    ) -> (bool, AnyElement) {
+        let mut state_entity = self.transition.state.as_mut(cx);
+        let state: &mut TransitionState<T> = state_entity.borrow_mut();
+
+        let elapsed_secs = state.goal_last_updated_at.elapsed().as_secs_f32();
+        let duration_secs = self.transition.duration_secs;
+        let delta = (self.transition.easing)((state.start_delta + (elapsed_secs / duration_secs)).min(1.));
+
+        debug_assert!(
+            (0.0..=1.0).contains(&delta),
+            "delta should always be between 0 and 1"
+        );
+
+        let transition_value = state.last_goal.apply_delta(&state.current_goal, delta);
+
+        state.last_delta = delta;
+        drop(state_entity);
+
+        let element = self.element.take().expect("should only be called once");
+        let mut element = (self.animator)(cx, element, transition_value).into_any_element();
+
+        (delta != 1., element)
+    }
+}
+
+/// A data type which can be used as a transition goal.
+pub trait TransitionGoal {
+    /// Defines how a delta is applied to a value.
+    fn apply_delta(&self, to: &Self, delta: f32) -> Self;
+}
+
+macro_rules! float_transition_goals {
+    ( $( $ty:ty ),+ ) => {
+        $(
+            impl TransitionGoal for $ty {
+                fn apply_delta(&self, to: &Self, delta: f32) -> Self {
+                    lerp(*self, *to, delta as $ty)
+                }
+            }
+        )+
+    };
+}
+
+float_transition_goals!(f32, f64);
+
+macro_rules! int_transition_goals {
+    ( $( $ty:ident as $ty_into:ident ),+ ) => {
+        $(
+            impl TransitionGoal for $ty {
+                fn apply_delta(&self, to: &Self, delta: f32) -> Self {
+                    lerp(*self as $ty_into, *to as $ty_into, delta as $ty_into) as $ty
+                }
+            }
+        )+
+    };
+}
+
+int_transition_goals!(
+    usize as f32, u8 as f32, u16 as f32, u32 as f32, u64 as f64, u128 as f64,
+    isize as f32, i8 as f32, i16 as f32, i32 as f32, i64 as f64, i128 as f64
+);
+
+macro_rules! struct_transition_goals {
+    ( $( $ty:ident $( < $gen:ident > )? { $( $n:ident ),+ } ),+ $(,)? ) => {
+        $(
+            impl$(<$gen: TransitionGoal + Clone + Debug + Default + PartialEq>)? TransitionGoal for $ty$(<$gen>)? {
+                fn apply_delta(&self, to: &Self, delta: f32) -> Self {
+                    $ty$(::<$gen>)? {
+                        $(
+                            $n: self.$n.apply_delta(&to.$n, delta)
+                        ),+
+                    }
+                }
+            }
+        )+
+    };
+}
+
+struct_transition_goals!(
+    Point<T> { x, y },
+    Size<T> { width, height },
+    Edges<T> { top, right, bottom, left },
+    Corners<T> { top_left, top_right, bottom_right, bottom_left },
+    Bounds<T> { origin, size },
+    Rgba { r, g, b, a },
+    Hsla { h, s, l, a },
+    Colors { text, selected_text, background, disabled, selected, border, separator, container }
+);
+
+macro_rules! tuple_struct_transition_goals {
+    ( $( $ty:ident ( $n:ty ) ),+ ) => {
+        $(
+            impl TransitionGoal for $ty {
+                fn apply_delta(&self, to: &Self, delta: f32) -> Self {
+                    $ty(self.0.apply_delta(&to.0, delta))
+                }
+            }
+        )+
+    };
+}
+
+tuple_struct_transition_goals!(
+    Radians(f32),
+    Percentage(f32),
+    Pixels(f32),
+    DevicePixels(i32),
+    ScaledPixels(f32),
+    Rems(f32)
+);
+
+fn lerp<T>(a: T, b: T, t: T) -> T
+where
+    T: Copy + Add<Output = T> + Sub<Output = T> + Mul<Output = T>,
+{
+    a + (b - a) * t
+}


### PR DESCRIPTION
Adds transitions which provide a way to animate between values.

Out of the box the following types can be used as a transition goal: 
`f32`, `f64`, `usize`, `u8`, `u16`, `u32`, `u64`, `u128`, `isize`, `i8`, `i16`, `i32`, `i64`, `i128`, `Point`, `Size`, `Edges`, `Corners`, `Bounds`, `Rgba`, `Colors`, `Radians`, `Percentage`, `Pixels`, `DevicePixels`, `ScaledPixels`, `Rems`.

Support for other types can trivially be added by implementing the `TransitionGoal` trait.

### Example Usage
```rs
let hover_transition = Transition::new(
    "hover_transition", Duration::from_millis(400),
    0. /* the initial value */, window, cx
).with_easing(ease_out_quint());

element
    .map(|this| {
        let hover_transition = hover_transition.clone();
        this.on_hover(move |hovered, _window, cx| {
            hover_transition.update_goal(cx, *hovered as u8 as f32);
        })
    })
    .with_transitions(
        hover_transition,
        |_cx, this, a| this
            .bg(Rgba { r: 1., g: 0., b: 0., a })
    )
    
    // Or alternatively with multiple transitions.
    .with_transitions(
        (hover_transition, other_transition),
        |_cx, this, (a, _b)| this
            .bg(Rgba { r: 1., g: 0., b: 0., a })
    )
```

Release Notes:
- implemented transitions.

- Added an `AnimatableExt` trait which provides basic boilerplate for animatable elements. Both `AnimationElement` and `TransitionElement` implement it.