### PR TITLE
lsp colors: Reduce flickering while typing

### DIFF
--- a/crates/collab/src/tests/editor_tests.rs
+++ b/crates/collab/src/tests/editor_tests.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use call::ActiveCall;
 use editor::{
-    DocumentColorsRenderMode, Editor, RowInfo, SelectionEffects,
+    DocumentColorsRenderMode, Editor, FETCH_COLORS_DEBOUNCE_TIMEOUT, RowInfo, SelectionEffects,
     actions::{
         ConfirmCodeAction, ConfirmCompletion, ConfirmRename, ContextMenuFirst,
         ExpandMacroRecursively, MoveToEnd, Redo, Rename, SelectAll, ToggleCodeActions, Undo,
@@ -2409,6 +2409,7 @@ async fn test_lsp_document_color(cx_a: &mut TestAppContext, cx_b: &mut TestAppCo
         .unwrap();
 
     color_request_handle.next().await.unwrap();
+    executor.advance_clock(FETCH_COLORS_DEBOUNCE_TIMEOUT);
     executor.run_until_parked();
 
     assert_eq!(

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -226,6 +226,7 @@ pub const SELECTION_HIGHLIGHT_DEBOUNCE_TIMEOUT: Duration = Duration::from_millis
 pub(crate) const CODE_ACTION_TIMEOUT: Duration = Duration::from_secs(5);
 pub(crate) const FORMAT_TIMEOUT: Duration = Duration::from_secs(5);
 pub(crate) const SCROLL_CENTER_TOP_BOTTOM_DEBOUNCE_TIMEOUT: Duration = Duration::from_secs(1);
+pub const FETCH_COLORS_DEBOUNCE_TIMEOUT: Duration = Duration::from_millis(150);
 
 pub(crate) const EDIT_PREDICTION_KEY_CONTEXT: &str = "edit_prediction";
 pub(crate) const EDIT_PREDICTION_CONFLICT_KEY_CONTEXT: &str = "edit_prediction_conflict";

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1189,6 +1189,7 @@ pub struct Editor {
     inline_value_cache: InlineValueCache,
     selection_drag_state: SelectionDragState,
     colors: Option<LspColorData>,
+    refresh_colors_task: Task<()>,
     folding_newlines: Task<()>,
     pub lookup_key: Option<Box<dyn Any + Send + Sync>>,
 }
@@ -2244,6 +2245,7 @@ impl Editor {
             tasks_update_task: None,
             pull_diagnostics_task: Task::ready(()),
             colors: None,
+            refresh_colors_task: Task::ready(()),
             next_color_inlay_id: 0,
             linked_edit_ranges: Default::default(),
             in_project_search: false,

--- a/crates/editor/src/lsp_colors.rs
+++ b/crates/editor/src/lsp_colors.rs
@@ -1,4 +1,4 @@
-use std::{cmp, ops::Range, time::Duration};
+use std::{cmp, ops::Range};
 
 use collections::HashMap;
 use futures::future::join_all;
@@ -13,8 +13,8 @@ use ui::{App, Context, Window};
 use util::post_inc;
 
 use crate::{
-    DisplayPoint, Editor, EditorSettings, EditorSnapshot, InlayId, InlaySplice, RangeToAnchorExt,
-    display_map::Inlay, editor_settings::DocumentColorsRenderMode,
+    DisplayPoint, Editor, EditorSettings, EditorSnapshot, FETCH_COLORS_DEBOUNCE_TIMEOUT, InlayId,
+    InlaySplice, RangeToAnchorExt, display_map::Inlay, editor_settings::DocumentColorsRenderMode,
 };
 
 #[derive(Debug)]
@@ -196,7 +196,7 @@ impl Editor {
 
         self.refresh_colors_task = cx.spawn(async move |editor, cx| {
             cx.background_executor()
-                .timer(Duration::from_millis(150))
+                .timer(FETCH_COLORS_DEBOUNCE_TIMEOUT)
                 .await;
 
             let all_colors = join_all(all_colors_task).await;

--- a/crates/editor/src/lsp_colors.rs
+++ b/crates/editor/src/lsp_colors.rs
@@ -1,4 +1,4 @@
-use std::{cmp, ops::Range};
+use std::{cmp, ops::Range, time::Duration};
 
 use collections::HashMap;
 use futures::future::join_all;
@@ -193,7 +193,12 @@ impl Editor {
                 })
                 .collect::<Vec<_>>()
         });
-        cx.spawn(async move |editor, cx| {
+
+        self.refresh_colors_task = cx.spawn(async move |editor, cx| {
+            cx.background_executor()
+                .timer(Duration::from_millis(150))
+                .await;
+
             let all_colors = join_all(all_colors_task).await;
             if all_colors.is_empty() {
                 return;
@@ -420,7 +425,6 @@ impl Editor {
                     }
                 })
                 .ok();
-        })
-        .detach();
+        });
     }
 }


### PR DESCRIPTION
Closes #40019

Follow-up https://github.com/zed-industries/zed/pull/40025

This PR reduces/removes the flickering of inlay colors. This is done by adding a debounce, and not detaching the task that fetches the new colors.

**Result**

https://github.com/user-attachments/assets/5dae278b-b821-4e64-8adb-c4d8376ba1df

Release Notes:

- Lsp colors: Reduce flickering while typing.
