### PR TITLE
Make the Yarn SDK path relative to the worktree

### DIFF
--- a/crates/languages/src/vtsls.rs
+++ b/crates/languages/src/vtsls.rs
@@ -29,6 +29,7 @@ impl VtslsLspAdapter {
 
     const TYPESCRIPT_PACKAGE_NAME: &'static str = "typescript";
     const TYPESCRIPT_TSDK_PATH: &'static str = "node_modules/typescript/lib";
+    const TYPESCRIPT_YARN_TSDK_PATH: &'static str = ".yarn/sdks/typescript/lib";
 
     pub fn new(node: NodeRuntime, fs: Arc<dyn Fs>) -> Self {
         VtslsLspAdapter { node, fs }
@@ -37,10 +38,10 @@ impl VtslsLspAdapter {
     async fn tsdk_path(&self, adapter: &Arc<dyn LspAdapterDelegate>) -> Option<&'static str> {
         let yarn_sdk = adapter
             .worktree_root_path()
-            .join(".yarn/sdks/typescript/lib/typescript.js");
+            .join(Self::TYPESCRIPT_YARN_TSDK_PATH);
 
-        let tsdk_path = if self.fs.is_file(&yarn_sdk).await {
-            ".yarn/sdks/typescript/lib"
+        let tsdk_path = if self.fs.is_dir(&yarn_sdk).await {
+            Self::TYPESCRIPT_YARN_TSDK_PATH
         } else {
             Self::TYPESCRIPT_TSDK_PATH
         };

--- a/crates/languages/src/vtsls.rs
+++ b/crates/languages/src/vtsls.rs
@@ -12,7 +12,7 @@ use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
-use util::{ResultExt, maybe, merge_json_value_into, rel_path::RelPath};
+use util::{ResultExt, maybe, merge_json_value_into};
 
 fn typescript_server_binary_arguments(server_path: &Path) -> Vec<OsString> {
     vec![server_path.into(), "--stdio".into()]
@@ -35,12 +35,11 @@ impl VtslsLspAdapter {
     }
 
     async fn tsdk_path(&self, adapter: &Arc<dyn LspAdapterDelegate>) -> Option<&'static str> {
-        let is_yarn = adapter
-            .read_text_file(RelPath::unix(".yarn/sdks/typescript/lib/typescript.js").unwrap())
-            .await
-            .is_ok();
+        let yarn_sdk = adapter
+            .worktree_root_path()
+            .join(".yarn/sdks/typescript/lib/typescript.js");
 
-        let tsdk_path = if is_yarn {
+        let tsdk_path = if self.fs.is_file(&yarn_sdk).await {
             ".yarn/sdks/typescript/lib"
         } else {
             Self::TYPESCRIPT_TSDK_PATH


### PR DESCRIPTION
Let's say you run this:

```
cd ~/proj-a
zed ~/proj-b
```

The `zed` process will execute with `current_dir() = ~/proj-a`, but a `worktree_root_path() = ~/proj-b`. The old detection was then checking if the Yarn SDK was installed in `proj-a` to decide whether to set the tsdk value or not. This was incorrect, as we should instead check for the SDK presence inside `proj-b`.

Release Notes:

- Fixed the Yarn SDK detection when the Zed pwd is different from the opened folder.
