### PR TITLE
Add vim-style split keybindings for FileFinder

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -1000,5 +1000,26 @@
       // and Windows.
       "alt-l": "editor::AcceptEditPrediction"
     }
+  },
+  {
+    "context": "FileFinder",
+    "bindings": {
+      "ctrl-v": "pane::SplitRight",
+      "ctrl-x": "pane::SplitDown"
+    }
+  },
+  {
+    "context": "FileFinder > Picker > Editor",
+    "bindings": {
+      "ctrl-v": "pane::SplitRight",
+      "ctrl-x": "pane::SplitDown"
+    }
+  },
+  {
+    "context": "FileFinder > Picker > menu",
+    "bindings": {
+      "ctrl-v": "pane::SplitRight",
+      "ctrl-x": "pane::SplitDown"
+    }
   }
 ]


### PR DESCRIPTION
Add Ctrl+V and Ctrl+X keybindings in vim mode to quickly split files from the FileFinder without going through the split menu.

- Ctrl+V: Opens file in vertical split (right)
- Ctrl+X: Opens file in horizontal split (down)

This provides a familiar experience for vim users.

Addresses: https://github.com/zed-industries/zed/discussions/39894

An alternative is for vim users to set these themselves I suppose but since it's a pretty common set of vim keymaps I figured a PR might be worthwhile.