### PR TITLE
git: Preseve commit messages starting with '#'

### DIFF
--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -1456,7 +1456,7 @@ impl GitRepository for RealGitRepository {
                     .envs(env.iter())
                     .args(["commit", "--quiet", "-m"])
                     .arg(&message.to_string())
-                    .arg("--cleanup=strip");
+                    .arg("--cleanup=verbatim");
 
                 if options.amend {
                     cmd.arg("--amend");


### PR DESCRIPTION
- Changed git commit cleanup mode from 'strip' to 'verbatim' to prevent removal of lines beginning with '#'

- This allows uses to commit messages that start with issue numbers or other hash-prefixed content

Closes #39955 

Release Notes:

- Fixed: Commit messages starting with '#' are now preserved correctly instead of being treated as comments