### PR TITLE
theme_selector: Fix mouse clicks not updating the theme properly

### DIFF
--- a/crates/theme_selector/src/theme_selector.rs
+++ b/crates/theme_selector/src/theme_selector.rs
@@ -7,7 +7,7 @@ use gpui::{
     Window, actions,
 };
 use picker::{Picker, PickerDelegate};
-use settings::{SettingsStore, update_settings_file};
+use settings::{Settings, SettingsStore, update_settings_file};
 use std::sync::Arc;
 use theme::{Appearance, Theme, ThemeMeta, ThemeRegistry, ThemeSettings};
 use ui::{ListItem, ListItemSpacing, prelude::*, v_flex};
@@ -231,11 +231,14 @@ impl PickerDelegate for ThemeSelectorDelegate {
     ) {
         self.selection_completed = true;
 
-        let theme_name = cx.theme().name.clone();
+        let appearance = Appearance::from(window.appearance());
+        let theme_name = ThemeSettings::get_global(cx)
+            .theme
+            .name(appearance)
+            .0
+            .clone();
 
         telemetry::event!("Settings Changed", setting = "theme", value = theme_name);
-
-        let appearance = Appearance::from(window.appearance());
 
         update_settings_file(self.fs.clone(), cx, move |settings, _| {
             theme::set_theme(settings, theme_name.to_string(), appearance);

--- a/crates/theme_selector/src/theme_selector.rs
+++ b/crates/theme_selector/src/theme_selector.rs
@@ -232,11 +232,7 @@ impl PickerDelegate for ThemeSelectorDelegate {
         self.selection_completed = true;
 
         let appearance = Appearance::from(window.appearance());
-        let theme_name = ThemeSettings::get_global(cx)
-            .theme
-            .name(appearance)
-            .0
-            .clone();
+        let theme_name = ThemeSettings::get_global(cx).theme.name(appearance).0;
 
         telemetry::event!("Settings Changed", setting = "theme", value = theme_name);
 


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/40080

Follow-up to https://github.com/zed-industries/zed/pull/39720

We were already doing this for icon themes, but not for normal themes. 

Issue here is that we would only update the `cx.theme()` on the next frame. On mouse confirmation, we would override the theme and confirm it on the same frame, yet the global would only be peropely updated on the next frame and then instantly reset to the new settings file, which would again be the old theme. This caused a flicker and the selection to not persist.. Keyboard interactions worked still, because there would be a rendered frame inbetween selection and confirmation.

Release Notes:

- N/A
