### PR TITLE
task: Do not wrap tasks in extra shell invocations unless requested

### DIFF
--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -1628,11 +1628,8 @@ impl AcpThreadView {
 
         window.spawn(cx, async move |cx| {
             let mut task = login.clone();
-            task.shell = task::Shell::WithArguments {
-                program: task.command.take().expect("login command should be set"),
-                args: std::mem::take(&mut task.args),
-                title_override: None
-            };
+            task.command = task.command.clone();
+            task.args = task.args.clone();
             task.full_label = task.label.clone();
             task.id = task::TaskId(format!("external-agent-{}-login", task.label));
             task.command_label = task.label.clone();
@@ -1641,7 +1638,7 @@ impl AcpThreadView {
             task.hide = task::HideStrategy::Always;
 
             let terminal = terminal_panel.update_in(cx, |terminal_panel, window, cx| {
-                terminal_panel.spawn_task(&task, window, cx)
+                terminal_panel.spawn_task(task, window, cx)
             })?;
 
             let terminal = terminal.await?;

--- a/crates/debugger_ui/src/new_process_modal.rs
+++ b/crates/debugger_ui/src/new_process_modal.rs
@@ -193,8 +193,22 @@ impl NewProcessModal {
 
                             let (used_tasks, current_resolved_tasks) = task_inventory
                                 .update(cx, |task_inventory, cx| {
-                                    task_inventory
-                                        .used_and_current_resolved_tasks(task_contexts.clone(), cx)
+                                    let remote_shell = workspace
+                                        .read_with(cx, |workspace, cx| {
+                                            workspace
+                                                .project()
+                                                .read(cx)
+                                                .remote_client()?
+                                                .read(cx)
+                                                .shell()
+                                        })
+                                        .ok()
+                                        .flatten();
+                                    task_inventory.used_and_current_resolved_tasks(
+                                        task_contexts.clone(),
+                                        move || remote_shell.clone(),
+                                        cx,
+                                    )
                                 })?
                                 .await;
 

--- a/crates/debugger_ui/src/session/running.rs
+++ b/crates/debugger_ui/src/session/running.rs
@@ -989,7 +989,7 @@ impl RunningState {
                         (task, None)
                     }
                 };
-                let Some(mut task) = task_template.resolve_task("debug-build-task", &task_context) else {
+                let Some(mut task) = task_template.resolve_task("debug-build-task",&|| remote_shell.clone(), &task_context) else {
                     anyhow::bail!("Could not resolve task variables within a debug scenario");
                 };
 
@@ -1026,7 +1026,7 @@ impl RunningState {
                     None
                 };
 
-                if let Some(remote_shell) = remote_shell && task.resolved.shell == Shell::System {
+                if task.resolved.shell == Shell::System && let Some(remote_shell) = remote_shell.clone() {
                     task.resolved.shell = Shell::Program(remote_shell);
                 }
 

--- a/crates/project/src/debugger/locators/go.rs
+++ b/crates/project/src/debugger/locators/go.rs
@@ -246,7 +246,7 @@ impl DapLocator for GoLocator {
 mod tests {
     use super::*;
     use gpui::TestAppContext;
-    use task::{HideStrategy, RevealStrategy, RevealTarget, Shell, TaskTemplate};
+    use task::{HideStrategy, RevealStrategy, RevealTarget, TaskTemplate};
 
     #[gpui::test]
     async fn test_create_scenario_for_go_build(_: &mut TestAppContext) {
@@ -262,7 +262,7 @@ mod tests {
             reveal: RevealStrategy::Always,
             reveal_target: RevealTarget::Dock,
             hide: HideStrategy::Never,
-            shell: Shell::System,
+            shell: None,
             tags: vec![],
             show_summary: true,
             show_command: true,
@@ -289,7 +289,7 @@ mod tests {
             reveal: RevealStrategy::Always,
             reveal_target: RevealTarget::Dock,
             hide: HideStrategy::Never,
-            shell: Shell::System,
+            shell: None,
             tags: vec![],
             show_summary: true,
             show_command: true,
@@ -427,7 +427,7 @@ mod tests {
             reveal: RevealStrategy::Always,
             reveal_target: RevealTarget::Dock,
             hide: HideStrategy::Never,
-            shell: Shell::System,
+            shell: None,
             tags: vec![],
             show_summary: true,
             show_command: true,

--- a/crates/project/src/debugger/locators/python.rs
+++ b/crates/project/src/debugger/locators/python.rs
@@ -116,7 +116,7 @@ mod test {
             reveal_target: task::RevealTarget::Dock,
             hide: task::HideStrategy::Never,
             tags: vec!["python-module-main-method".into()],
-            shell: task::Shell::System,
+            shell: None,
             show_summary: false,
             show_command: false,
         };

--- a/crates/project/src/lsp_store/lsp_ext_command.rs
+++ b/crates/project/src/lsp_store/lsp_ext_command.rs
@@ -23,7 +23,7 @@ use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
-use task::TaskTemplate;
+use task::{ShellKind, TaskTemplate};
 use text::{BufferId, PointUtf16, ToPointUtf16};
 
 pub enum LspExtExpandMacro {}
@@ -657,7 +657,12 @@ impl LspCommand for GetLspRunnables {
                     );
                     task_template.args.extend(cargo.cargo_args);
                     if !cargo.executable_args.is_empty() {
-                        let shell_kind = task_template.shell.shell_kind(cfg!(windows));
+                        let shell_kind = task_template
+                            .shell
+                            .as_ref()
+                            .map_or_else(ShellKind::system, |shell| {
+                                shell.shell_kind(cfg!(windows))
+                            });
                         task_template.args.push("--".to_string());
                         task_template.args.extend(
                             cargo

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -9812,9 +9812,14 @@ fn get_all_tasks(
     cx: &mut App,
 ) -> Task<Vec<(TaskSourceKind, ResolvedTask)>> {
     let new_tasks = project.update(cx, |project, cx| {
+        let remote_shell = project.remote_client().and_then(|it| it.read(cx).shell());
         project.task_store.update(cx, |task_store, cx| {
             task_store.task_inventory().unwrap().update(cx, |this, cx| {
-                this.used_and_current_resolved_tasks(task_contexts, cx)
+                this.used_and_current_resolved_tasks(
+                    task_contexts,
+                    move || remote_shell.clone(),
+                    cx,
+                )
             })
         })
     });

--- a/crates/project/src/task_store.rs
+++ b/crates/project/src/task_store.rs
@@ -155,6 +155,7 @@ impl TaskStore {
                 .into_iter()
                 .map(|(variable_name, variable_value)| (variable_name.to_string(), variable_value))
                 .collect(),
+            is_windows: cfg!(windows),
         })
     }
 
@@ -345,6 +346,7 @@ fn local_task_context_for_location(
             project_env: project_env.unwrap_or_default(),
             cwd: worktree_abs_path.map(|p| p.to_path_buf()),
             task_variables,
+            is_windows: cfg!(windows),
         })
     })
 }
@@ -414,6 +416,7 @@ fn remote_task_context_for_location(
                 )
                 .collect(),
             project_env: task_context.project_env.into_iter().collect(),
+            is_windows: task_context.is_windows,
         })
     })
 }

--- a/crates/proto/proto/task.proto
+++ b/crates/proto/proto/task.proto
@@ -13,6 +13,7 @@ message TaskContext {
     optional string cwd = 1;
     map<string, string> task_variables = 2;
     map<string, string> project_env = 3;
+    bool is_windows = 4;
 }
 
 message Shell {

--- a/crates/task/src/task.rs
+++ b/crates/task/src/task.rs
@@ -310,6 +310,7 @@ pub struct TaskContext {
     /// This is the environment one would get when `cd`ing in a terminal
     /// into the project's root directory.
     pub project_env: HashMap<String, String>,
+    pub is_windows: bool,
 }
 
 /// This is a new type representing a 'tag' on a 'runnable symbol', typically a test of main() function, found via treesitter.

--- a/crates/workspace/src/tasks.rs
+++ b/crates/workspace/src/tasks.rs
@@ -20,7 +20,8 @@ impl Workspace {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        match self.project.read(cx).remote_connection_state(cx) {
+        let project = self.project.read(cx);
+        match project.remote_connection_state(cx) {
             None | Some(ConnectionState::Connected) => {}
             Some(
                 ConnectionState::Connecting
@@ -33,9 +34,11 @@ impl Workspace {
             }
         }
 
-        if let Some(spawn_in_terminal) =
-            task_to_resolve.resolve_task(&task_source_kind.to_id_base(), task_cx)
-        {
+        if let Some(spawn_in_terminal) = task_to_resolve.resolve_task(
+            &task_source_kind.to_id_base(),
+            &|| project.remote_client()?.read(cx).shell(),
+            task_cx,
+        ) {
             self.schedule_resolved_task(
                 task_source_kind,
                 spawn_in_terminal,


### PR DESCRIPTION
This makes the shell property of tasks optional with the following interpretation:

- If `shell` is none and command contains no whitespace, we interpret the command as an invocable process, not wrapping the invocation in a shell
- Otherwise we retain the previous behavior, wrapping the command in a shell

Release Notes:

- Improved task behavior by not unnecessarily wrapping spawned tasks in shell invocations
