### PR TITLE
settings_ui: Fix garbage value for terminal font size

### DIFF
--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -3342,7 +3342,9 @@ pub(crate) fn settings_data() -> Vec<SettingsPage> {
                     description: "Font size for terminal text. If not set, defaults to buffer font size",
                     field: Box::new(SettingField {
                         pick: |settings_content| {
-                            if let Some(terminal) = &settings_content.terminal {
+                            if let Some(terminal) = &settings_content.terminal
+                                && terminal.font_size.is_some()
+                            {
                                 &terminal.font_size
                             } else if settings_content.theme.buffer_font_size.is_some() {
                                 &settings_content.theme.buffer_font_size


### PR DESCRIPTION
Closes #40086

Release Notes:

- Fixed garbage value shown for terminal font size in the settings UI when no font size is defined in `settings.json`.

