### PR TITLE
settings_ui: Make arrow keys up and down activate page content

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -1249,8 +1249,8 @@
       "escape": "workspace::CloseWindow",
       "ctrl-m": "settings_editor::Minimize",
       "ctrl-f": "search::FocusSearch",
-      "ctrl-shift-e": "settings_editor::ToggleFocusNav",
       "left": "settings_editor::ToggleFocusNav",
+      "ctrl-shift-e": "settings_editor::ToggleFocusNav",
       // todo(settings_ui): cut this down based on the max files and overflow UI
       "ctrl-1": ["settings_editor::FocusFile", 0],
       "ctrl-2": ["settings_editor::FocusFile", 1],

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -1269,6 +1269,8 @@
     "context": "SettingsWindow > NavigationMenu",
     "use_key_equivalents": true,
     "bindings": {
+      "up": "settings_editor::FocusPreviousNavEntry",
+      "down": "settings_editor::FocusNextNavEntry",
       "right": "settings_editor::ExpandNavEntry",
       "left": "settings_editor::CollapseNavEntry",
       "pageup": "settings_editor::FocusPreviousRootNavEntry",

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -1250,6 +1250,7 @@
       "ctrl-m": "settings_editor::Minimize",
       "ctrl-f": "search::FocusSearch",
       "ctrl-shift-e": "settings_editor::ToggleFocusNav",
+      "left": "settings_editor::ToggleFocusNav",
       // todo(settings_ui): cut this down based on the max files and overflow UI
       "ctrl-1": ["settings_editor::FocusFile", 0],
       "ctrl-2": ["settings_editor::FocusFile", 1],

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -1354,8 +1354,8 @@
       "escape": "workspace::CloseWindow",
       "cmd-m": "settings_editor::Minimize",
       "cmd-f": "search::FocusSearch",
-      "cmd-shift-e": "settings_editor::ToggleFocusNav",
       "left": "settings_editor::ToggleFocusNav",
+      "cmd-shift-e": "settings_editor::ToggleFocusNav",
       // todo(settings_ui): cut this down based on the max files and overflow UI
       "ctrl-1": ["settings_editor::FocusFile", 0],
       "ctrl-2": ["settings_editor::FocusFile", 1],

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -1374,6 +1374,8 @@
     "context": "SettingsWindow > NavigationMenu",
     "use_key_equivalents": true,
     "bindings": {
+      "up": "settings_editor::FocusPreviousNavEntry",
+      "down": "settings_editor::FocusNextNavEntry",
       "right": "settings_editor::ExpandNavEntry",
       "left": "settings_editor::CollapseNavEntry",
       "pageup": "settings_editor::FocusPreviousRootNavEntry",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -1355,6 +1355,7 @@
       "cmd-m": "settings_editor::Minimize",
       "cmd-f": "search::FocusSearch",
       "cmd-shift-e": "settings_editor::ToggleFocusNav",
+      "left": "settings_editor::ToggleFocusNav",
       // todo(settings_ui): cut this down based on the max files and overflow UI
       "ctrl-1": ["settings_editor::FocusFile", 0],
       "ctrl-2": ["settings_editor::FocusFile", 1],

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -1271,6 +1271,7 @@
       "ctrl-m": "settings_editor::Minimize",
       "ctrl-f": "search::FocusSearch",
       "ctrl-shift-e": "settings_editor::ToggleFocusNav",
+      "left": "settings_editor::ToggleFocusNav",
       // todo(settings_ui): cut this down based on the max files and overflow UI
       "ctrl-1": ["settings_editor::FocusFile", 0],
       "ctrl-2": ["settings_editor::FocusFile", 1],

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -1290,6 +1290,8 @@
     "context": "SettingsWindow > NavigationMenu",
     "use_key_equivalents": true,
     "bindings": {
+      "up": "settings_editor::FocusPreviousNavEntry",
+      "down": "settings_editor::FocusNextNavEntry",
       "right": "settings_editor::ExpandNavEntry",
       "left": "settings_editor::CollapseNavEntry",
       "pageup": "settings_editor::FocusPreviousRootNavEntry",

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -1270,8 +1270,8 @@
       "escape": "workspace::CloseWindow",
       "ctrl-m": "settings_editor::Minimize",
       "ctrl-f": "search::FocusSearch",
-      "ctrl-shift-e": "settings_editor::ToggleFocusNav",
       "left": "settings_editor::ToggleFocusNav",
+      "ctrl-shift-e": "settings_editor::ToggleFocusNav",
       // todo(settings_ui): cut this down based on the max files and overflow UI
       "ctrl-1": ["settings_editor::FocusFile", 0],
       "ctrl-2": ["settings_editor::FocusFile", 1],

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -1666,6 +1666,9 @@ impl SettingsWindow {
                                                 .on_toggle(cx.listener(
                                                     move |this, _, window, cx| {
                                                         this.toggle_navbar_entry(ix);
+                                                        // Update selection state immediately before cx.notify
+                                                        // to prevent double selection flash
+                                                        this.navbar_entry = ix;
                                                         window.focus(
                                                             &this.navbar_entries[ix].focus_handle,
                                                         );

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -75,7 +75,11 @@ actions!(
         /// Focuses the first navigation entry.
         FocusFirstNavEntry,
         /// Focuses the last navigation entry.
-        FocusLastNavEntry
+        FocusLastNavEntry,
+        /// Focuses and opens the next navigation entry without moving focus to content.
+        FocusNextNavEntry,
+        /// Focuses and opens the previous navigation entry without moving focus to content.
+        FocusPreviousNavEntry
     ]
 );
 
@@ -1355,7 +1359,7 @@ impl SettingsWindow {
             .visible_navbar_entries()
             .any(|(index, _)| index == self.navbar_entry)
         {
-            self.open_and_scroll_to_navbar_entry(self.navbar_entry, window, cx);
+            self.open_and_scroll_to_navbar_entry(self.navbar_entry, window, cx, true);
         } else {
             self.open_first_nav_page();
         };
@@ -1571,6 +1575,38 @@ impl SettingsWindow {
                     this.focus_and_scroll_to_nav_entry(last_entry_index, window, cx);
                 }
             }))
+            .on_action(cx.listener(|this, _: &FocusNextNavEntry, window, cx| {
+                let entry_index = this
+                    .focused_nav_entry(window, cx)
+                    .unwrap_or(this.navbar_entry);
+                let mut next_index = None;
+                for (index, _) in this.visible_navbar_entries() {
+                    if index > entry_index {
+                        next_index = Some(index);
+                        break;
+                    }
+                }
+                let Some(next_entry_index) = next_index else {
+                    return;
+                };
+                this.open_and_scroll_to_navbar_entry(next_entry_index, window, cx, false);
+            }))
+            .on_action(cx.listener(|this, _: &FocusPreviousNavEntry, window, cx| {
+                let entry_index = this
+                    .focused_nav_entry(window, cx)
+                    .unwrap_or(this.navbar_entry);
+                let mut prev_index = None;
+                for (index, _) in this.visible_navbar_entries() {
+                    if index >= entry_index {
+                        break;
+                    }
+                    prev_index = Some(index);
+                }
+                let Some(prev_entry_index) = prev_index else {
+                    return;
+                };
+                this.open_and_scroll_to_navbar_entry(prev_entry_index, window, cx, false);
+            }))
             .border_color(cx.theme().colors().border)
             .bg(cx.theme().colors().panel_background)
             .child(self.render_search(window, cx))
@@ -1612,7 +1648,7 @@ impl SettingsWindow {
                                         .on_click(
                                             cx.listener(move |this, _, window, cx| {
                                                 this.open_and_scroll_to_navbar_entry(
-                                                    ix, window, cx,
+                                                    ix, window, cx, true,
                                                 );
                                             }),
                                         )
@@ -1651,6 +1687,7 @@ impl SettingsWindow {
         navbar_entry_index: usize,
         window: &mut Window,
         cx: &mut Context<Self>,
+        focus_content: bool,
     ) {
         self.open_navbar_entry_page(navbar_entry_index);
         cx.notify();
@@ -1658,12 +1695,17 @@ impl SettingsWindow {
         if self.navbar_entries[navbar_entry_index].is_root
             || !self.is_nav_entry_visible(navbar_entry_index)
         {
-            let Some(first_item_index) = self.visible_page_items().next().map(|(index, _)| index)
-            else {
-                return;
-            };
-            self.focus_content_element(first_item_index, window, cx);
             self.page_scroll_handle.set_offset(point(px(0.), px(0.)));
+            if focus_content {
+                let Some(first_item_index) =
+                    self.visible_page_items().next().map(|(index, _)| index)
+                else {
+                    return;
+                };
+                self.focus_content_element(first_item_index, window, cx);
+            } else {
+                window.focus(&self.navbar_entries[navbar_entry_index].focus_handle);
+            }
         } else {
             let entry_item_index = self.navbar_entries[navbar_entry_index]
                 .item_index
@@ -1676,7 +1718,12 @@ impl SettingsWindow {
             };
             self.page_scroll_handle
                 .scroll_to_top_of_item(selected_item_index);
-            self.focus_content_element(entry_item_index, window, cx);
+
+            if focus_content {
+                self.focus_content_element(entry_item_index, window, cx);
+            } else {
+                window.focus(&self.navbar_entries[navbar_entry_index].focus_handle);
+            }
         }
 
         // Page scroll handle updates the active item index
@@ -2132,7 +2179,12 @@ impl Render for SettingsWindow {
                                 .focus_handle(cx)
                                 .contains_focused(window, cx)
                             {
-                                this.open_and_scroll_to_navbar_entry(this.navbar_entry, window, cx);
+                                this.open_and_scroll_to_navbar_entry(
+                                    this.navbar_entry,
+                                    window,
+                                    cx,
+                                    true,
+                                );
                             } else {
                                 this.focus_and_scroll_to_nav_entry(this.navbar_entry, window, cx);
                             }


### PR DESCRIPTION
Release Notes:

- settings ui: Navigating the settings navbar with arrow keys up and down now also activates the page, allowing users to more quickly see the content for a given page before moving focus to the page itself.
