### PR TITLE
settings: Make "auto" and "language_server" valid format steps

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1107,22 +1107,28 @@
   // Whether or not to perform a buffer format before saving: [on, off]
   // Keep in mind, if the autosave with delay is enabled, format_on_save will be ignored
   "format_on_save": "on",
-  // How to perform a buffer format. This setting can take 4 values:
+  // How to perform a buffer format. This setting can take multiple values:
   //
-  // 1. Format code using the current language server:
+  // 1. Default. Format files using Zed's Prettier integration (if applicable),
+  //    or falling back to formatting via language server:
+  //     "formatter": "auto"
+  // 2. Format code using the current language server:
   //     "formatter": "language_server"
-  // 2. Format code using an external command:
+  // 3. Format code using a specific language server:
+  //     "formatter": {"language_server": {"name": "ruff"}}
+  // 4. Format code using an external command:
   //     "formatter": {
   //       "external": {
   //         "command": "prettier",
   //         "arguments": ["--stdin-filepath", "{buffer_path}"]
   //       }
   //     }
-  // 3. Format code using Zed's Prettier integration:
+  // 5. Format code using Zed's Prettier integration:
   //     "formatter": "prettier"
-  // 4. Default. Format files using Zed's Prettier integration (if applicable),
-  //    or falling back to formatting via language server:
-  //     "formatter": "auto"
+  // 6. Format code using a code action
+  //     "formatter": {"code_action": "source.fixAll.eslint"}
+  // 7. An array of any format step specified above to apply in order
+  //     "formatter": [{"code_action": "source.fixAll.eslint"}, "prettier"]
   "formatter": "auto",
   // How to soft-wrap long lines of text.
   // Possible values:
@@ -1690,7 +1696,7 @@
       "preferred_line_length": 72
     },
     "Go": {
-      "formatter": [{ "code_action": "source.organizeImports" }, { "language_server": {} }],
+      "formatter": [{ "code_action": "source.organizeImports" }, "language_server"],
       "debuggers": ["Delve"]
     },
     "GraphQL": {

--- a/crates/agent2/src/tools/edit_file_tool.rs
+++ b/crates/agent2/src/tools/edit_file_tool.rs
@@ -790,7 +790,7 @@ mod tests {
                 store.update_user_settings(cx, |settings| {
                     settings.project.all_languages.defaults.format_on_save = Some(FormatOnSave::On);
                     settings.project.all_languages.defaults.formatter =
-                        Some(language::language_settings::SelectedFormatter::Auto);
+                        Some(language::language_settings::FormatterList::default());
                 });
             });
         });

--- a/crates/assistant_tools/src/edit_file_tool.rs
+++ b/crates/assistant_tools/src/edit_file_tool.rs
@@ -1538,7 +1538,7 @@ mod tests {
                 store.update_user_settings(cx, |settings| {
                     settings.project.all_languages.defaults.format_on_save = Some(FormatOnSave::On);
                     settings.project.all_languages.defaults.formatter =
-                        Some(language::language_settings::SelectedFormatter::Auto);
+                        Some(language::language_settings::FormatterList::default());
                 });
             });
         });

--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -25,7 +25,7 @@ use gpui::{
 use language::{
     Diagnostic, DiagnosticEntry, DiagnosticSourceKind, FakeLspAdapter, Language, LanguageConfig,
     LanguageMatcher, LineEnding, OffsetRangeExt, Point, Rope,
-    language_settings::{Formatter, FormatterList, SelectedFormatter},
+    language_settings::{Formatter, FormatterList},
     tree_sitter_rust, tree_sitter_typescript,
 };
 use lsp::{LanguageServerId, OneOf};
@@ -4610,14 +4610,13 @@ async fn test_formatting_buffer(
         cx_a.update(|cx| {
             SettingsStore::update_global(cx, |store, cx| {
                 store.update_user_settings(cx, |file| {
-                    file.project.all_languages.defaults.formatter = Some(SelectedFormatter::List(
-                        FormatterList::Single(Formatter::External {
+                    file.project.all_languages.defaults.formatter =
+                        Some(FormatterList::Single(Formatter::External {
                             command: "awk".into(),
                             arguments: Some(
                                 vec!["{sub(/two/,\"{buffer_path}\")}1".to_string()].into(),
                             ),
-                        }),
-                    ));
+                        }));
                 });
             });
         });
@@ -4708,7 +4707,7 @@ async fn test_prettier_formatting_buffer(
     cx_a.update(|cx| {
         SettingsStore::update_global(cx, |store, cx| {
             store.update_user_settings(cx, |file| {
-                file.project.all_languages.defaults.formatter = Some(SelectedFormatter::Auto);
+                file.project.all_languages.defaults.formatter = Some(FormatterList::default());
                 file.project.all_languages.defaults.prettier = Some(PrettierSettingsContent {
                     allowed: Some(true),
                     ..Default::default()
@@ -4719,9 +4718,10 @@ async fn test_prettier_formatting_buffer(
     cx_b.update(|cx| {
         SettingsStore::update_global(cx, |store, cx| {
             store.update_user_settings(cx, |file| {
-                file.project.all_languages.defaults.formatter = Some(SelectedFormatter::List(
-                    FormatterList::Single(Formatter::LanguageServer { name: None }),
-                ));
+                file.project.all_languages.defaults.formatter =
+                    Some(FormatterList::Single(Formatter::LanguageServer {
+                        name: None,
+                    }));
                 file.project.all_languages.defaults.prettier = Some(PrettierSettingsContent {
                     allowed: Some(true),
                     ..Default::default()

--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -39,7 +39,7 @@ use project::{
 use prompt_store::PromptBuilder;
 use rand::prelude::*;
 use serde_json::json;
-use settings::{LanguageServerSpecifier, PrettierSettingsContent, SettingsStore};
+use settings::{LanguageServerFormatterSpecifier, PrettierSettingsContent, SettingsStore};
 use std::{
     cell::{Cell, RefCell},
     env, future, mem,
@@ -4719,7 +4719,7 @@ async fn test_prettier_formatting_buffer(
         SettingsStore::update_global(cx, |store, cx| {
             store.update_user_settings(cx, |file| {
                 file.project.all_languages.defaults.formatter = Some(FormatterList::Single(
-                    Formatter::LanguageServer(LanguageServerSpecifier::Current),
+                    Formatter::LanguageServer(LanguageServerFormatterSpecifier::Current),
                 ));
                 file.project.all_languages.defaults.prettier = Some(PrettierSettingsContent {
                     allowed: Some(true),

--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -39,7 +39,7 @@ use project::{
 use prompt_store::PromptBuilder;
 use rand::prelude::*;
 use serde_json::json;
-use settings::{PrettierSettingsContent, SettingsStore};
+use settings::{LanguageServerSpecifier, PrettierSettingsContent, SettingsStore};
 use std::{
     cell::{Cell, RefCell},
     env, future, mem,
@@ -4718,10 +4718,9 @@ async fn test_prettier_formatting_buffer(
     cx_b.update(|cx| {
         SettingsStore::update_global(cx, |store, cx| {
             store.update_user_settings(cx, |file| {
-                file.project.all_languages.defaults.formatter =
-                    Some(FormatterList::Single(Formatter::LanguageServer {
-                        name: None,
-                    }));
+                file.project.all_languages.defaults.formatter = Some(FormatterList::Single(
+                    Formatter::LanguageServer(LanguageServerSpecifier::Current),
+                ));
                 file.project.all_languages.defaults.prettier = Some(PrettierSettingsContent {
                     allowed: Some(true),
                     ..Default::default()

--- a/crates/collab/src/tests/remote_editing_collaboration_tests.rs
+++ b/crates/collab/src/tests/remote_editing_collaboration_tests.rs
@@ -27,7 +27,7 @@ use remote::RemoteClient;
 use remote_server::{HeadlessAppState, HeadlessProject};
 use rpc::proto;
 use serde_json::json;
-use settings::{LanguageServerSpecifier, PrettierSettingsContent, SettingsStore};
+use settings::{LanguageServerFormatterSpecifier, PrettierSettingsContent, SettingsStore};
 use std::{
     path::Path,
     sync::{Arc, atomic::AtomicUsize},
@@ -503,7 +503,7 @@ async fn test_ssh_collaboration_formatting_with_prettier(
         SettingsStore::update_global(cx, |store, cx| {
             store.update_user_settings(cx, |file| {
                 file.project.all_languages.defaults.formatter = Some(FormatterList::Single(
-                    Formatter::LanguageServer(LanguageServerSpecifier::Current),
+                    Formatter::LanguageServer(LanguageServerFormatterSpecifier::Current),
                 ));
                 file.project.all_languages.defaults.prettier = Some(PrettierSettingsContent {
                     allowed: Some(true),

--- a/crates/collab/src/tests/remote_editing_collaboration_tests.rs
+++ b/crates/collab/src/tests/remote_editing_collaboration_tests.rs
@@ -14,7 +14,7 @@ use gpui::{
 use http_client::BlockedHttpClient;
 use language::{
     FakeLspAdapter, Language, LanguageConfig, LanguageMatcher, LanguageRegistry,
-    language_settings::{Formatter, FormatterList, SelectedFormatter, language_settings},
+    language_settings::{Formatter, FormatterList, language_settings},
     tree_sitter_typescript,
 };
 use node_runtime::NodeRuntime;
@@ -491,7 +491,7 @@ async fn test_ssh_collaboration_formatting_with_prettier(
     cx_a.update(|cx| {
         SettingsStore::update_global(cx, |store, cx| {
             store.update_user_settings(cx, |file| {
-                file.project.all_languages.defaults.formatter = Some(SelectedFormatter::Auto);
+                file.project.all_languages.defaults.formatter = Some(FormatterList::default());
                 file.project.all_languages.defaults.prettier = Some(PrettierSettingsContent {
                     allowed: Some(true),
                     ..Default::default()
@@ -502,9 +502,10 @@ async fn test_ssh_collaboration_formatting_with_prettier(
     cx_b.update(|cx| {
         SettingsStore::update_global(cx, |store, cx| {
             store.update_user_settings(cx, |file| {
-                file.project.all_languages.defaults.formatter = Some(SelectedFormatter::List(
-                    FormatterList::Single(Formatter::LanguageServer { name: None }),
-                ));
+                file.project.all_languages.defaults.formatter =
+                    Some(FormatterList::Single(Formatter::LanguageServer {
+                        name: None,
+                    }));
                 file.project.all_languages.defaults.prettier = Some(PrettierSettingsContent {
                     allowed: Some(true),
                     ..Default::default()
@@ -550,7 +551,7 @@ async fn test_ssh_collaboration_formatting_with_prettier(
     cx_a.update(|cx| {
         SettingsStore::update_global(cx, |store, cx| {
             store.update_user_settings(cx, |file| {
-                file.project.all_languages.defaults.formatter = Some(SelectedFormatter::Auto);
+                file.project.all_languages.defaults.formatter = Some(FormatterList::default());
                 file.project.all_languages.defaults.prettier = Some(PrettierSettingsContent {
                     allowed: Some(true),
                     ..Default::default()

--- a/crates/collab/src/tests/remote_editing_collaboration_tests.rs
+++ b/crates/collab/src/tests/remote_editing_collaboration_tests.rs
@@ -27,7 +27,7 @@ use remote::RemoteClient;
 use remote_server::{HeadlessAppState, HeadlessProject};
 use rpc::proto;
 use serde_json::json;
-use settings::{PrettierSettingsContent, SettingsStore};
+use settings::{LanguageServerSpecifier, PrettierSettingsContent, SettingsStore};
 use std::{
     path::Path,
     sync::{Arc, atomic::AtomicUsize},
@@ -502,10 +502,9 @@ async fn test_ssh_collaboration_formatting_with_prettier(
     cx_b.update(|cx| {
         SettingsStore::update_global(cx, |store, cx| {
             store.update_user_settings(cx, |file| {
-                file.project.all_languages.defaults.formatter =
-                    Some(FormatterList::Single(Formatter::LanguageServer {
-                        name: None,
-                    }));
+                file.project.all_languages.defaults.formatter = Some(FormatterList::Single(
+                    Formatter::LanguageServer(LanguageServerSpecifier::Current),
+                ));
                 file.project.all_languages.defaults.prettier = Some(PrettierSettingsContent {
                     allowed: Some(true),
                     ..Default::default()

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -11890,7 +11890,7 @@ async fn test_range_format_respects_language_tab_size_override(cx: &mut TestAppC
 async fn test_document_format_manual_trigger(cx: &mut TestAppContext) {
     init_test(cx, |settings| {
         settings.defaults.formatter = Some(FormatterList::Single(Formatter::LanguageServer(
-            settings::LanguageServerSpecifier::Current,
+            settings::LanguageServerFormatterSpecifier::Current,
         )))
     });
 
@@ -12016,7 +12016,7 @@ async fn test_multiple_formatters(cx: &mut TestAppContext) {
     init_test(cx, |settings| {
         settings.defaults.remove_trailing_whitespace_on_save = Some(true);
         settings.defaults.formatter = Some(FormatterList::Vec(vec![
-            Formatter::LanguageServer(settings::LanguageServerSpecifier::Current),
+            Formatter::LanguageServer(settings::LanguageServerFormatterSpecifier::Current),
             Formatter::CodeAction("code-action-1".into()),
             Formatter::CodeAction("code-action-2".into()),
         ]))
@@ -12275,7 +12275,7 @@ async fn test_multiple_formatters(cx: &mut TestAppContext) {
 async fn test_organize_imports_manual_trigger(cx: &mut TestAppContext) {
     init_test(cx, |settings| {
         settings.defaults.formatter = Some(FormatterList::Vec(vec![Formatter::LanguageServer(
-            settings::LanguageServerSpecifier::Current,
+            settings::LanguageServerFormatterSpecifier::Current,
         )]))
     });
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -27,7 +27,6 @@ use language::{
     LanguageConfigOverride, LanguageMatcher, LanguageName, Override, Point,
     language_settings::{
         CompletionSettingsContent, FormatterList, LanguageSettingsContent, LspInsertMode,
-        SelectedFormatter,
     },
     tree_sitter_python,
 };
@@ -11890,9 +11889,9 @@ async fn test_range_format_respects_language_tab_size_override(cx: &mut TestAppC
 #[gpui::test]
 async fn test_document_format_manual_trigger(cx: &mut TestAppContext) {
     init_test(cx, |settings| {
-        settings.defaults.formatter = Some(SelectedFormatter::List(FormatterList::Single(
-            Formatter::LanguageServer { name: None },
-        )))
+        settings.defaults.formatter = Some(FormatterList::Single(Formatter::LanguageServer {
+            name: None,
+        }))
     });
 
     let fs = FakeFs::new(cx.executor());
@@ -12016,11 +12015,11 @@ async fn test_document_format_manual_trigger(cx: &mut TestAppContext) {
 async fn test_multiple_formatters(cx: &mut TestAppContext) {
     init_test(cx, |settings| {
         settings.defaults.remove_trailing_whitespace_on_save = Some(true);
-        settings.defaults.formatter = Some(SelectedFormatter::List(FormatterList::Vec(vec![
+        settings.defaults.formatter = Some(FormatterList::Vec(vec![
             Formatter::LanguageServer { name: None },
             Formatter::CodeAction("code-action-1".into()),
             Formatter::CodeAction("code-action-2".into()),
-        ])))
+        ]))
     });
 
     let fs = FakeFs::new(cx.executor());
@@ -12275,9 +12274,9 @@ async fn test_multiple_formatters(cx: &mut TestAppContext) {
 #[gpui::test]
 async fn test_organize_imports_manual_trigger(cx: &mut TestAppContext) {
     init_test(cx, |settings| {
-        settings.defaults.formatter = Some(SelectedFormatter::List(FormatterList::Vec(vec![
-            Formatter::LanguageServer { name: None },
-        ])))
+        settings.defaults.formatter = Some(FormatterList::Vec(vec![Formatter::LanguageServer {
+            name: None,
+        }]))
     });
 
     let fs = FakeFs::new(cx.executor());
@@ -12480,7 +12479,7 @@ async fn test_concurrent_format_requests(cx: &mut TestAppContext) {
 #[gpui::test]
 async fn test_strip_whitespace_and_format_via_lsp(cx: &mut TestAppContext) {
     init_test(cx, |settings| {
-        settings.defaults.formatter = Some(SelectedFormatter::Auto)
+        settings.defaults.formatter = Some(FormatterList::default())
     });
 
     let mut cx = EditorLspTestContext::new_rust(
@@ -18169,9 +18168,7 @@ fn completion_menu_entries(menu: &CompletionsMenu) -> Vec<String> {
 #[gpui::test]
 async fn test_document_format_with_prettier(cx: &mut TestAppContext) {
     init_test(cx, |settings| {
-        settings.defaults.formatter = Some(SelectedFormatter::List(FormatterList::Single(
-            Formatter::Prettier,
-        )))
+        settings.defaults.formatter = Some(FormatterList::Single(Formatter::Prettier))
     });
 
     let fs = FakeFs::new(cx.executor());
@@ -18238,7 +18235,7 @@ async fn test_document_format_with_prettier(cx: &mut TestAppContext) {
     );
 
     update_test_language_settings(cx, |settings| {
-        settings.defaults.formatter = Some(SelectedFormatter::Auto)
+        settings.defaults.formatter = Some(FormatterList::default())
     });
     let format = editor.update_in(cx, |editor, window, cx| {
         editor.perform_format(

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -11889,9 +11889,9 @@ async fn test_range_format_respects_language_tab_size_override(cx: &mut TestAppC
 #[gpui::test]
 async fn test_document_format_manual_trigger(cx: &mut TestAppContext) {
     init_test(cx, |settings| {
-        settings.defaults.formatter = Some(FormatterList::Single(Formatter::LanguageServer {
-            name: None,
-        }))
+        settings.defaults.formatter = Some(FormatterList::Single(Formatter::LanguageServer(
+            settings::LanguageServerSpecifier::Current,
+        )))
     });
 
     let fs = FakeFs::new(cx.executor());
@@ -12016,7 +12016,7 @@ async fn test_multiple_formatters(cx: &mut TestAppContext) {
     init_test(cx, |settings| {
         settings.defaults.remove_trailing_whitespace_on_save = Some(true);
         settings.defaults.formatter = Some(FormatterList::Vec(vec![
-            Formatter::LanguageServer { name: None },
+            Formatter::LanguageServer(settings::LanguageServerSpecifier::Current),
             Formatter::CodeAction("code-action-1".into()),
             Formatter::CodeAction("code-action-2".into()),
         ]))
@@ -12274,9 +12274,9 @@ async fn test_multiple_formatters(cx: &mut TestAppContext) {
 #[gpui::test]
 async fn test_organize_imports_manual_trigger(cx: &mut TestAppContext) {
     init_test(cx, |settings| {
-        settings.defaults.formatter = Some(FormatterList::Vec(vec![Formatter::LanguageServer {
-            name: None,
-        }]))
+        settings.defaults.formatter = Some(FormatterList::Vec(vec![Formatter::LanguageServer(
+            settings::LanguageServerSpecifier::Current,
+        )]))
     });
 
     let fs = FakeFs::new(cx.executor());

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -13,7 +13,7 @@ use itertools::{Either, Itertools};
 pub use settings::{
     CompletionSettingsContent, EditPredictionProvider, EditPredictionsMode, FormatOnSave,
     Formatter, FormatterList, InlayHintKind, LanguageSettingsContent, LspInsertMode,
-    RewrapBehavior, SelectedFormatter, ShowWhitespaceSetting, SoftWrap, WordsCompletionMode,
+    RewrapBehavior, ShowWhitespaceSetting, SoftWrap, WordsCompletionMode,
 };
 use settings::{ExtendingVec, Settings, SettingsContent, SettingsLocation, SettingsStore};
 use shellexpand;
@@ -96,7 +96,7 @@ pub struct LanguageSettings {
     /// when saving it.
     pub ensure_final_newline_on_save: bool,
     /// How to perform a buffer format.
-    pub formatter: settings::SelectedFormatter,
+    pub formatter: settings::FormatterList,
     /// Zed's Prettier integration settings.
     pub prettier: PrettierSettings,
     /// Whether to automatically close JSX tags.

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -1347,7 +1347,7 @@ impl LocalLspStore {
                     &Formatter::Prettier
                 } else {
                     zlog::trace!(logger => "Formatter set to auto: defaulting to primary language server");
-                    &Formatter::LanguageServer(settings::LanguageServerSpecifier::Current)
+                    &Formatter::LanguageServer(settings::LanguageServerFormatterSpecifier::Current)
                 }
             } else {
                 formatter
@@ -1419,7 +1419,7 @@ impl LocalLspStore {
                     };
 
                     let language_server = match specifier {
-                        settings::LanguageServerSpecifier::Specific { name } => {
+                        settings::LanguageServerFormatterSpecifier::Specific { name } => {
                             adapters_and_servers.iter().find_map(|(adapter, server)| {
                                 if adapter.name.0.as_ref() == name {
                                     Some(server.clone())
@@ -1428,7 +1428,7 @@ impl LocalLspStore {
                                 }
                             })
                         }
-                        settings::LanguageServerSpecifier::Current => {
+                        settings::LanguageServerFormatterSpecifier::Current => {
                             adapters_and_servers.first().map(|e| e.1.clone())
                         }
                     };

--- a/crates/project/src/prettier_store.rs
+++ b/crates/project/src/prettier_store.rs
@@ -16,7 +16,7 @@ use futures::{
 use gpui::{AppContext as _, AsyncApp, Context, Entity, EventEmitter, Task, WeakEntity};
 use language::{
     Buffer, LanguageRegistry, LocalFile,
-    language_settings::{Formatter, LanguageSettings, SelectedFormatter},
+    language_settings::{Formatter, LanguageSettings},
 };
 use lsp::{LanguageServer, LanguageServerId, LanguageServerName};
 use node_runtime::NodeRuntime;
@@ -700,14 +700,11 @@ impl PrettierStore {
 pub fn prettier_plugins_for_language(
     language_settings: &LanguageSettings,
 ) -> Option<&HashSet<String>> {
-    match &language_settings.formatter {
-        SelectedFormatter::Auto => Some(&language_settings.prettier.plugins),
-
-        SelectedFormatter::List(list) => list
-            .as_ref()
-            .contains(&Formatter::Prettier)
-            .then_some(&language_settings.prettier.plugins),
+    let formatters = language_settings.formatter.as_ref();
+    if formatters.contains(&Formatter::Prettier) || formatters.contains(&Formatter::Auto) {
+        return Some(&language_settings.prettier.plugins);
     }
+    None
 }
 
 pub(super) async fn format_with_prettier(

--- a/crates/settings/src/settings_content/language.rs
+++ b/crates/settings/src/settings_content/language.rs
@@ -765,7 +765,7 @@ pub enum Formatter {
     },
     /// Files should be formatted using a code action executed by language servers.
     CodeAction(String),
-    /// Format code using the current language server.
+    /// Format code using a language server.
     #[serde(untagged)]
     LanguageServer(LanguageServerSpecifier),
 }
@@ -773,6 +773,7 @@ pub enum Formatter {
 #[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema, MergeFrom)]
 #[serde(
     rename_all = "snake_case",
+    // allow specifying language servers as "language_server" or {"language_server": {"name": ...}}
     from = "LanguageServerVariantContent",
     into = "LanguageServerVariantContent"
 )]
@@ -810,80 +811,28 @@ impl From<LanguageServerSpecifier> for LanguageServerVariantContent {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema, MergeFrom)]
 #[serde(rename_all = "snake_case", untagged)]
-pub enum LanguageServerVariantContent {
+enum LanguageServerVariantContent {
+    /// Format code using a specific language server.
     Specific {
         language_server: LanguageServerSpecifierContent,
     },
+    /// Format code using the current language server.
     Current(CurrentLanguageServerContent),
 }
 
 #[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema, MergeFrom)]
 #[serde(rename_all = "snake_case")]
-pub enum CurrentLanguageServerContent {
+enum CurrentLanguageServerContent {
     #[default]
     LanguageServer,
 }
 
 #[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema, MergeFrom)]
 #[serde(rename_all = "snake_case")]
-pub struct LanguageServerSpecifierContent {
-    pub name: Option<String>,
+struct LanguageServerSpecifierContent {
+    /// The name of the language server to format with
+    name: Option<String>,
 }
-// pub struct LanguageServerVariant {
-//     name: Option<String>,
-// }
-
-// impl std::str::FromStr for LanguageServerVariant {
-//     type Err = &'static str;
-
-//     fn from_str(s: &str) -> Result<Self, Self::Err> {
-//         if s == "language_server" {
-//             Ok(LanguageServerVariant { name: None })
-//         } else {
-//             Err("Invalid language server string")
-//         }
-//     }
-// }
-
-// fn string_or_struct<'de, T, D>(deserializer: D) -> Result<T, D::Error>
-// where
-//     T: Deserialize<'de> + std::str::FromStr,
-//     <T as std::str::FromStr>::Err: std::fmt::Display,
-//     D: Deserializer<'de>,
-// {
-//     use serde::de::{self, MapAccess, Visitor};
-//     use std::marker::PhantomData;
-
-//     struct StringOrStruct<T>(PhantomData<fn() -> T>);
-
-//     impl<'de, T> Visitor<'de> for StringOrStruct<T>
-//     where
-//         T: Deserialize<'de> + std::str::FromStr,
-//         <T as std::str::FromStr>::Err: std::fmt::Display,
-//     {
-//         type Value = T;
-
-//         fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-//             formatter.write_str("string or map")
-//         }
-
-//         fn visit_str<E>(self, value: &str) -> Result<T, E>
-//         where
-//             E: de::Error,
-//         {
-//             std::str::FromStr::from_str(value).map_err(de::Error::custom)
-//         }
-
-//         fn visit_map<M>(self, map: M) -> Result<T, M::Error>
-//         where
-//             M: MapAccess<'de>,
-//         {
-//             Deserialize::deserialize(de::value::MapAccessDeserializer::new(map))
-//         }
-//     }
-
-//     deserializer.deserialize_any(StringOrStruct(PhantomData))
-// }
 
 /// The settings for indent guides.
 #[skip_serializing_none]

--- a/crates/settings/src/settings_content/language.rs
+++ b/crates/settings/src/settings_content/language.rs
@@ -1,12 +1,9 @@
-use std::{borrow::Cow, num::NonZeroU32};
+use std::num::NonZeroU32;
 
 use collections::{HashMap, HashSet};
 use gpui::{Modifiers, SharedString};
-use schemars::{JsonSchema, json_schema};
-use serde::{
-    Deserialize, Deserializer, Serialize,
-    de::{self, IntoDeserializer, MapAccess, SeqAccess, Visitor},
-};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use settings_macros::MergeFrom;
 use std::sync::Arc;


### PR DESCRIPTION
Follow up for: #39983 and https://github.com/zed-industries/zed/pull/40040#issuecomment-3393902691

Previously it was possible to have formatting done using prettier or language server using `"formatter": "auto"` and specify code actions to apply on format using the `"code_actions_on_format"` setting. However, post #39983 this is no longer possible due to the removal of the `"code_actions_on_format"` setting. To rectify this regression, this PR makes it so that the `"auto"` and `"language_server"` strings that were previously only allowed as top level values on the `"formatter"` key, are now allowed as format steps like so:
```json
{
      "formatter": ["auto", "language_server"]
}
```

Therefore to replicate the previous behavior using `"auto"` and `"code_actions_on_format"` you can use the following configuration:

```json
{
      "formatter": [{"code_action": ...}, "auto"]
}
```

Release Notes:

- N/A *or* Added/Fixed/Improved ...
