### PR TITLE
Fix inconsistent font size in toolbar code actions

### DIFF
--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -1518,6 +1518,7 @@ impl CodeActionsMenu {
                                     this.child(
                                         h_flex()
                                             .overflow_hidden()
+                                            .when(is_quick_action_bar, |this| this.text_ui(cx))
                                             .child(task.resolved_label.replace("\n", ""))
                                             .when(selected, |this| {
                                                 this.text_color(colors.text_accent)
@@ -1528,6 +1529,7 @@ impl CodeActionsMenu {
                                     this.child(
                                         h_flex()
                                             .overflow_hidden()
+                                            .when(is_quick_action_bar, |this| this.text_ui(cx))
                                             .child("debug: ")
                                             .child(scenario.label.clone())
                                             .when(selected, |this| {


### PR DESCRIPTION
Release Notes:

- N/A

<img width="695" height="254" alt="before" src="https://github.com/user-attachments/assets/7b180fb8-a6d3-409a-a0ee-1def447e8235" />
<img width="695" height="254" alt="after" src="https://github.com/user-attachments/assets/3a035be0-3b74-433b-b0e7-5766b67bfcc1" />