### PR TITLE
git_ui: Apply accented color to links in Blame tooltip

### DIFF
--- a/crates/git_ui/src/blame_ui.rs
+++ b/crates/git_ui/src/blame_ui.rs
@@ -8,8 +8,8 @@ use git::{
     repository::CommitSummary,
 };
 use gpui::{
-    ClipboardItem, Entity, Hsla, MouseButton, ScrollHandle, Subscription, TextStyle, WeakEntity,
-    prelude::*,
+    ClipboardItem, Entity, Hsla, MouseButton, ScrollHandle, Subscription, TextStyle,
+    TextStyleRefinement, UnderlineStyle, WeakEntity, prelude::*,
 };
 use markdown::{Markdown, MarkdownElement};
 use project::{git_store::Repository, project_settings::ProjectSettings};
@@ -209,11 +209,21 @@ impl BlameRenderer for GitBlameRenderer {
             OffsetDateTime::now_utc(),
             time_format::TimestampFormat::MediumAbsolute,
         );
+        let link_color = cx.theme().colors().text_accent;
         let markdown_style = {
             let mut style = hover_markdown_style(window, cx);
             if let Some(code_block) = &style.code_block.text {
                 style.base_text_style.refine(code_block);
             }
+            style.link.refine(&TextStyleRefinement {
+                color: Some(link_color),
+                underline: Some(UnderlineStyle {
+                    color: Some(link_color),
+                    thickness: px(1.0),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            });
             style
         };
 

--- a/crates/git_ui/src/blame_ui.rs
+++ b/crates/git_ui/src/blame_ui.rs
@@ -218,7 +218,7 @@ impl BlameRenderer for GitBlameRenderer {
             style.link.refine(&TextStyleRefinement {
                 color: Some(link_color),
                 underline: Some(UnderlineStyle {
-                    color: Some(link_color),
+                    color: Some(link_color.opacity(0.4)),
                     thickness: px(1.0),
                     ..Default::default()
                 }),


### PR DESCRIPTION
# Why

Follow up to:
* #39905

# How

Apply accented color to links in message content inside Blame tooltip, to match appearance in Markdown Preview panel.

Release Notes:

- Improved appearance of links in message content inside Blame tooltip.

# Preview

### Before

<img width="1186" height="798" alt="Screenshot 2025-10-13 at 19 33 37" src="https://github.com/user-attachments/assets/33ab4fb5-7910-4d28-9152-c692d6ddeaa6" />

### After

<img width="1186" height="798" alt="Screenshot 2025-10-13 at 19 33 10" src="https://github.com/user-attachments/assets/38082c5c-50d6-4fb3-90ca-410accff9aad" />

