### PR TITLE
acp: Hide completion menu when typing slash command argument

### DIFF
--- a/crates/agent_ui/src/acp/completion_provider.rs
+++ b/crates/agent_ui/src/acp/completion_provider.rs
@@ -775,7 +775,7 @@ impl CompletionProvider for ContextPickerCompletionProvider {
                                                 }
                                             });
                                         }
-                                        is_missing_argument
+                                        false
                                     }
                                 })),
                             }
@@ -910,6 +910,17 @@ impl CompletionProvider for ContextPickerCompletionProvider {
                 offset_to_line,
                 self.prompt_capabilities.borrow().embedded_context,
             )
+            .filter(|completion| {
+                // Right now we don't support completing arguments of slash commands
+                let is_slash_command_with_argument = matches!(
+                    completion,
+                    ContextCompletion::SlashCommand(SlashCommandCompletion {
+                        argument: Some(_),
+                        ..
+                    })
+                );
+                !is_slash_command_with_argument
+            })
             .map(|completion| {
                 completion.source_range().start <= offset_to_line + position.column as usize
                     && completion.source_range().end >= offset_to_line + position.column as usize

--- a/crates/agent_ui/src/acp/message_editor.rs
+++ b/crates/agent_ui/src/acp/message_editor.rs
@@ -2021,20 +2021,10 @@ mod tests {
         editor.update_in(&mut cx, |editor, _window, cx| {
             assert_eq!(editor.text(cx), "/say-hello ");
             assert_eq!(editor.display_text(cx), "/say-hello <name>");
-            assert!(editor.has_visible_completions_menu());
-
-            assert_eq!(
-                current_completion_labels_with_documentation(editor),
-                &[("say-hello".into(), "Say hello to whoever you want".into())]
-            );
+            assert!(!editor.has_visible_completions_menu());
         });
 
         cx.simulate_input("GPT5");
-
-        editor.update_in(&mut cx, |editor, window, cx| {
-            assert!(editor.has_visible_completions_menu());
-            editor.confirm_completion(&editor::actions::ConfirmCompletion::default(), window, cx);
-        });
 
         cx.run_until_parked();
 
@@ -2044,7 +2034,7 @@ mod tests {
             assert!(!editor.has_visible_completions_menu());
 
             // Delete argument
-            for _ in 0..4 {
+            for _ in 0..5 {
                 editor.backspace(&editor::actions::Backspace, window, cx);
             }
         });
@@ -2052,12 +2042,11 @@ mod tests {
         cx.run_until_parked();
 
         editor.update_in(&mut cx, |editor, window, cx| {
-            assert_eq!(editor.text(cx), "/say-hello ");
+            assert_eq!(editor.text(cx), "/say-hello");
             // Hint is visible because argument was deleted
             assert_eq!(editor.display_text(cx), "/say-hello <name>");
 
             // Delete last command letter
-            editor.backspace(&editor::actions::Backspace, window, cx);
             editor.backspace(&editor::actions::Backspace, window, cx);
         });
 


### PR DESCRIPTION
Release Notes:

- acp: Fix an issue where the completion menu would still be active after confirming a slash command
