### PR TITLE
workspace: Fix auto-reveal-in-project-panel for Images, Notebooks and Terminals

### DIFF
--- a/crates/image_viewer/src/image_viewer.rs
+++ b/crates/image_viewer/src/image_viewer.rs
@@ -188,6 +188,9 @@ impl Item for ImageView {
     fn has_deleted_file(&self, cx: &App) -> bool {
         self.image_item.read(cx).file.disk_state() == DiskState::Deleted
     }
+    fn buffer_kind(&self, _: &App) -> workspace::item::ItemBufferKind {
+        workspace::item::ItemBufferKind::Singleton
+    }
 }
 
 fn breadcrumbs_text_for_image(project: &Project, image: &ImageItem, cx: &App) -> String {

--- a/crates/repl/src/notebook/notebook_ui.rs
+++ b/crates/repl/src/notebook/notebook_ui.rs
@@ -716,6 +716,10 @@ impl Item for NotebookEditor {
         Some(cx.new(|cx| Self::new(self.project.clone(), self.notebook_item.clone(), window, cx)))
     }
 
+    fn buffer_kind(&self, _: &App) -> workspace::item::ItemBufferKind {
+        workspace::item::ItemBufferKind::Singleton
+    }
+
     fn for_each_project_item(
         &self,
         cx: &App,

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -1211,6 +1211,10 @@ impl Item for TerminalView {
         None
     }
 
+    fn buffer_kind(&self, _: &App) -> workspace::item::ItemBufferKind {
+        workspace::item::ItemBufferKind::Singleton
+    }
+
     fn clone_on_split(
         &self,
         workspace_id: Option<WorkspaceId>,


### PR DESCRIPTION
This regressed in #39199

Release Notes:

- Fixed image files not getting auto-revealed in project panel.
