### PR TITLE
Add `.ZedSans` as a possible fallback font

### DIFF
--- a/crates/gpui/src/text_system.rs
+++ b/crates/gpui/src/text_system.rs
@@ -73,6 +73,7 @@ impl TextSystem {
             fallback_font_stack: smallvec![
                 // TODO: Remove this when Linux have implemented setting fallbacks.
                 font(".ZedMono"),
+                font(".ZedSans"),
                 font("Helvetica"),
                 font("Segoe UI"),  // Windows
                 font("Cantarell"), // Gnome


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/40121

Release Notes:

- Fixes a bug where users couldn't return the UI font family to the default value through the UI.
