### PR TITLE
Remove obsolete contents tool and add open to write profile

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -906,6 +906,7 @@
           "now": true,
           "find_path": true,
           "read_file": true,
+          "open": true,
           "grep": true,
           "terminal": true,
           "thinking": true,
@@ -917,7 +918,6 @@
         // We don't know which of the context server tools are safe for the "Ask" profile, so we don't enable them by default.
         // "enable_all_context_servers": true,
         "tools": {
-          "contents": true,
           "diagnostics": true,
           "fetch": true,
           "list_directory": true,


### PR DESCRIPTION
`contents` doesn't exist anymore.
`open` was only set for `ask` and not `write`.

Release Notes:

- N/A
