### PR TITLE
Don't show Zed usage when a user logged out

### DIFF
--- a/crates/client/src/user.rs
+++ b/crates/client/src/user.rs
@@ -754,6 +754,10 @@ impl UserStore {
     }
 
     pub fn model_request_usage(&self) -> Option<ModelRequestUsage> {
+        if self.current_user().is_none() {
+            return None;
+        }
+
         if self.plan().is_some_and(|plan| plan.is_v2()) {
             return None;
         }
@@ -767,6 +771,10 @@ impl UserStore {
     }
 
     pub fn edit_prediction_usage(&self) -> Option<EditPredictionUsage> {
+        if self.current_user().is_none() {
+            return None;
+        }
+
         self.edit_prediction_usage
     }
 


### PR DESCRIPTION
If you log out, this will still show up. PR fixes this.

<img width="633" height="387" alt="Screenshot 2025-10-13 at 2 22 43 PM" src="https://github.com/user-attachments/assets/e8ec6a88-fd93-4469-bdff-1419b5f4a097" />


Release Notes:

- N/A