### PR TITLE
Don't probe for local workspaces pointing to WSL filesystem on startup

### DIFF
--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -1347,36 +1347,31 @@ impl WorkspaceDb {
                 continue;
             }
 
-            let has_wsl_path = {
-                #[cfg(windows)]
-                {
-                    fn is_wsl_path(path: &PathBuf) -> bool {
-                        use std::path::{Component, Prefix};
+            let has_wsl_path = if cfg!(windows) {
+                fn is_wsl_path(path: &PathBuf) -> bool {
+                    use std::path::{Component, Prefix};
 
-                        path.components()
-                            .next()
-                            .and_then(|component| match component {
-                                Component::Prefix(prefix) => Some(prefix),
-                                _ => None,
-                            })
-                            .and_then(|prefix| match prefix.kind() {
-                                Prefix::UNC(server, _) => Some(server),
-                                Prefix::VerbatimUNC(server, _) => Some(server),
-                                _ => None,
-                            })
-                            .map(|server| {
-                                let server_str = server.to_string_lossy();
-                                server_str == "wsl.localhost" || server_str == "wsl$"
-                            })
-                            .unwrap_or(false)
-                    }
+                    path.components()
+                        .next()
+                        .and_then(|component| match component {
+                            Component::Prefix(prefix) => Some(prefix),
+                            _ => None,
+                        })
+                        .and_then(|prefix| match prefix.kind() {
+                            Prefix::UNC(server, _) => Some(server),
+                            Prefix::VerbatimUNC(server, _) => Some(server),
+                            _ => None,
+                        })
+                        .map(|server| {
+                            let server_str = server.to_string_lossy();
+                            server_str == "wsl.localhost" || server_str == "wsl$"
+                        })
+                        .unwrap_or(false)
+                }
 
-                    paths.paths().iter().any(|path| is_wsl_path(path))
-                }
-                #[cfg(not(windows))]
-                {
-                    false
-                }
+                paths.paths().iter().any(|path| is_wsl_path(path))
+            } else {
+                false
             };
 
             // Delete the workspace if any of the paths are WSL paths.

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -1348,7 +1348,7 @@ impl WorkspaceDb {
             }
 
             let has_wsl_path = {
-                #[cfg(target_os = "windows")]
+                #[cfg(windows)]
                 {
                     fn is_wsl_path(path: &PathBuf) -> bool {
                         use std::path::{Component, Prefix};
@@ -1373,7 +1373,7 @@ impl WorkspaceDb {
 
                     paths.paths().iter().any(|path| is_wsl_path(path))
                 }
-                #[cfg(not(target_os = "windows"))]
+                #[cfg(not(windows))]
                 {
                     false
                 }


### PR DESCRIPTION
We automatically delete a local workspace if the folders comprising it no longer exist.
If a local workspace points to folders in the WSL filesystem, checking whether those folders exist will make us wait for the WSL VM and file server to boot up. This can block Zed startup for many seconds.

Supported scenarios use remote workspaces, so delete these local workspaces to ensure that we don't try to access their folders on the startup path.

Release Notes:

- N/A
