### PR TITLE
collab_ui: Make collaboration panel label responsive on resize

### DIFF
--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -2250,7 +2250,7 @@ impl CollabPanel {
                             })),
                     )
                     .child(
-                        div().flex().w_full().items_center().child(
+                        v_flex().w_full().items_center().child(
                             Label::new("Sign in to enable collaboration.")
                                 .color(Color::Muted)
                                 .size(LabelSize::Small),


### PR DESCRIPTION
Closes #40156

Release Notes:

- Fixed collaboration panel label responsive on resize
<img width="350" height="829" alt="Screenshot 2025-10-14 at 2 52 58 pm" src="https://github.com/user-attachments/assets/94e21f1b-83a2-44f0-9f15-44a85155fda9" />
