### PR TITLE
acp: Don't collapse tool calls by default

### DIFF
--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -278,7 +278,7 @@ pub struct AcpThreadView {
     thread_feedback: ThreadFeedbackState,
     list_state: ListState,
     auth_task: Option<Task<()>>,
-    expanded_tool_calls: HashSet<acp::ToolCallId>,
+    collapsed_tool_calls: HashSet<acp::ToolCallId>,
     expanded_thinking_blocks: HashSet<(usize, usize)>,
     edits_expanded: bool,
     plan_expanded: bool,
@@ -419,7 +419,7 @@ impl AcpThreadView {
             thread_error: None,
             thread_feedback: Default::default(),
             auth_task: None,
-            expanded_tool_calls: HashSet::default(),
+            collapsed_tool_calls: HashSet::default(),
             expanded_thinking_blocks: HashSet::default(),
             editing_message: None,
             edits_expanded: false,
@@ -954,17 +954,17 @@ impl AcpThreadView {
     ) {
         match &event.view_event {
             ViewEvent::NewDiff(tool_call_id) => {
-                if AgentSettings::get_global(cx).expand_edit_card {
-                    self.expanded_tool_calls.insert(tool_call_id.clone());
+                if !AgentSettings::get_global(cx).expand_edit_card {
+                    self.collapsed_tool_calls.insert(tool_call_id.clone());
                 }
             }
             ViewEvent::NewTerminal(tool_call_id) => {
-                if AgentSettings::get_global(cx).expand_terminal_card {
-                    self.expanded_tool_calls.insert(tool_call_id.clone());
+                if !AgentSettings::get_global(cx).expand_terminal_card {
+                    self.collapsed_tool_calls.insert(tool_call_id.clone());
                 }
             }
             ViewEvent::TerminalMovedToBackground(tool_call_id) => {
-                self.expanded_tool_calls.remove(tool_call_id);
+                self.collapsed_tool_calls.insert(tool_call_id.clone());
             }
             ViewEvent::MessageEditorEvent(_editor, MessageEditorEvent::Focus) => {
                 if let Some(thread) = self.thread()
@@ -2119,7 +2119,7 @@ impl AcpThreadView {
 
         let is_collapsible = !tool_call.content.is_empty() && !needs_confirmation;
 
-        let is_open = needs_confirmation || self.expanded_tool_calls.contains(&tool_call.id);
+        let is_open = needs_confirmation || !self.collapsed_tool_calls.contains(&tool_call.id);
 
         let tool_output_display =
             if is_open {
@@ -2269,9 +2269,9 @@ impl AcpThreadView {
                                                     let id = tool_call.id.clone();
                                                     move |this: &mut Self, _, _, cx: &mut Context<Self>| {
                                                         if is_open {
-                                                            this.expanded_tool_calls.remove(&id);
+                                                            this.collapsed_tool_calls.insert(id.clone());
                                                         } else {
-                                                            this.expanded_tool_calls.insert(id.clone());
+                                                            this.collapsed_tool_calls.remove(&id);
                                                         }
                                                         cx.notify();
                                                     }
@@ -2473,7 +2473,7 @@ impl AcpThreadView {
                         .icon_color(Color::Muted)
                         .on_click(cx.listener({
                             move |this: &mut Self, _, _, cx: &mut Context<Self>| {
-                                this.expanded_tool_calls.remove(&tool_call_id);
+                                this.collapsed_tool_calls.insert(tool_call_id.clone());
                                 cx.notify();
                             }
                         })),
@@ -2751,7 +2751,7 @@ impl AcpThreadView {
             .map(|path| path.display().to_string())
             .unwrap_or_else(|| "current directory".to_string());
 
-        let is_expanded = self.expanded_tool_calls.contains(&tool_call.id);
+        let is_expanded = !self.collapsed_tool_calls.contains(&tool_call.id);
 
         let header = h_flex()
             .id(header_id)
@@ -2886,9 +2886,9 @@ impl AcpThreadView {
                     let id = tool_call.id.clone();
                     move |this, _event, _window, _cx| {
                         if is_expanded {
-                            this.expanded_tool_calls.remove(&id);
+                            this.collapsed_tool_calls.insert(id.clone());
                         } else {
-                            this.expanded_tool_calls.insert(id.clone());
+                            this.collapsed_tool_calls.remove(&id);
                         }
                     }
                 })),


### PR DESCRIPTION
Previously, if a tool call's output was just text, it would be collapsed with no way to open it.

Now we track the collapsed cards instead of the expanded ones to allow all tool calls to be expanded by default, and only collapse the ones required by settings changes

Release Notes:

- acp: Fix tool call markdown output unintentionally being collapsed by default 
