### PR TITLE
editor: Fix highlight and selection overlap causing flicker while selecting

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -7001,6 +7001,7 @@ impl Editor {
                 ) else {
                     return Vec::default();
                 };
+                let query_range = query_range.to_anchors(&multi_buffer_snapshot);
                 for (buffer_snapshot, search_range, excerpt_id) in buffer_ranges {
                     match_ranges.extend(
                         regex


### PR DESCRIPTION
Regressed in https://github.com/zed-industries/zed/pull/39857, only on Nightly.

Release Notes:

- N/A
