### PR TITLE
Fix newline and assistant/agent shortcuts conflict on Windows and Linux

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -214,7 +214,7 @@
   {
     "context": "ContextEditor > Editor",
     "bindings": {
-      "ctrl-enter": "assistant::Assist",
+      "ctrl-i": "assistant::Assist",
       "ctrl-s": "workspace::Save",
       "save": "workspace::Save",
       "ctrl-<": "assistant::InsertIntoEditor",
@@ -287,7 +287,7 @@
     "context": "MessageEditor && !Picker > Editor && !use_modifier_to_send",
     "bindings": {
       "enter": "agent::Chat",
-      "ctrl-enter": "agent::ChatWithFollow",
+      "ctrl-shift-alt-i": "agent::ChatWithFollow",
       "ctrl-i": "agent::ToggleProfileSelector",
       "shift-ctrl-r": "agent::OpenAgentDiff",
       "ctrl-shift-y": "agent::KeepAll",
@@ -297,7 +297,7 @@
   {
     "context": "MessageEditor && !Picker > Editor && use_modifier_to_send",
     "bindings": {
-      "ctrl-enter": "agent::Chat",
+      "ctrl-shift-alt-i": "agent::Chat",
       "enter": "editor::Newline",
       "ctrl-i": "agent::ToggleProfileSelector",
       "shift-ctrl-r": "agent::OpenAgentDiff",
@@ -352,7 +352,7 @@
     "context": "AcpThread > Editor && use_modifier_to_send",
     "use_key_equivalents": true,
     "bindings": {
-      "ctrl-enter": "agent::Chat",
+      "ctrl-shift-alt-i": "agent::Chat",
       "shift-ctrl-r": "agent::OpenAgentDiff",
       "ctrl-shift-y": "agent::KeepAll",
       "ctrl-shift-n": "agent::RejectAll",
@@ -799,7 +799,7 @@
       "ctrl-shift-e": "pane::RevealInProjectPanel",
       "ctrl-f8": "editor::GoToHunk",
       "ctrl-shift-f8": "editor::GoToPreviousHunk",
-      "ctrl-enter": "assistant::InlineAssist",
+      "ctrl-i": "assistant::InlineAssist",
       "ctrl-:": "editor::ToggleInlayHints"
     }
   },
@@ -1093,7 +1093,7 @@
       "paste": "terminal::Paste",
       "shift-insert": "terminal::Paste",
       "ctrl-shift-v": "terminal::Paste",
-      "ctrl-enter": "assistant::InlineAssist",
+      "ctrl-i": "assistant::InlineAssist",
       "alt-b": ["terminal::SendText", "\u001bb"],
       "alt-f": ["terminal::SendText", "\u001bf"],
       "alt-.": ["terminal::SendText", "\u001b."],

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -215,7 +215,7 @@
     "context": "ContextEditor > Editor",
     "use_key_equivalents": true,
     "bindings": {
-      "ctrl-enter": "assistant::Assist",
+      "ctrl-i": "assistant::Assist",
       "ctrl-s": "workspace::Save",
       "ctrl-shift-,": "assistant::InsertIntoEditor",
       "shift-enter": "assistant::Split",
@@ -290,7 +290,7 @@
     "use_key_equivalents": true,
     "bindings": {
       "enter": "agent::Chat",
-      "ctrl-enter": "agent::ChatWithFollow",
+      "ctrl-shift-alt-i": "agent::ChatWithFollow",
       "ctrl-i": "agent::ToggleProfileSelector",
       "ctrl-shift-r": "agent::OpenAgentDiff",
       "ctrl-shift-y": "agent::KeepAll",
@@ -301,7 +301,7 @@
     "context": "MessageEditor && !Picker > Editor && use_modifier_to_send",
     "use_key_equivalents": true,
     "bindings": {
-      "ctrl-enter": "agent::Chat",
+      "ctrl-shift-alt-i": "agent::Chat",
       "enter": "editor::Newline",
       "ctrl-i": "agent::ToggleProfileSelector",
       "ctrl-shift-r": "agent::OpenAgentDiff",
@@ -360,7 +360,7 @@
     "context": "AcpThread > Editor && use_modifier_to_send",
     "use_key_equivalents": true,
     "bindings": {
-      "ctrl-enter": "agent::Chat",
+      "ctrl-shift-alt-i": "agent::Chat",
       "ctrl-shift-r": "agent::OpenAgentDiff",
       "ctrl-shift-y": "agent::KeepAll",
       "ctrl-shift-n": "agent::RejectAll",
@@ -812,7 +812,7 @@
       "ctrl-shift-e": "pane::RevealInProjectPanel",
       "ctrl-f8": "editor::GoToHunk",
       "ctrl-shift-f8": "editor::GoToPreviousHunk",
-      "ctrl-enter": "assistant::InlineAssist",
+      "ctrl-i": "assistant::InlineAssist",
       "ctrl-shift-;": "editor::ToggleInlayHints"
     }
   },
@@ -1118,7 +1118,7 @@
       "ctrl-shift-c": "terminal::Copy",
       "shift-insert": "terminal::Paste",
       "ctrl-shift-v": "terminal::Paste",
-      "ctrl-enter": "assistant::InlineAssist",
+      "ctrl-i": "assistant::InlineAssist",
       "alt-b": ["terminal::SendText", "\u001bb"],
       "alt-f": ["terminal::SendText", "\u001bf"],
       "alt-.": ["terminal::SendText", "\u001b."],


### PR DESCRIPTION
Closes #39278 #33843

Release Notes:
- Fix newline and assistant/agent shortcuts conflict on Windows and Linux

Change some (inline) assistant / agent shortcuts from `ctrl-enter` to `ctrl-i` or `ctrl-shift-alt-i` to avoid conflicts with newline (above/below) shorcuts on windows and linux.

Make it compatible with VSCode keyboard shorts.

The shortcut `ctrl-i` is the same as the assistant shortcut in VS Code, while the `ctrl-shift-alt-i` isn't used in the current default keymap and is also consistent with VS Code. 

The current default keymaps of windows and linux are neither compatible with VS Code nor free of conflicts. I've notified that many issues are related to this, and some have been opened for over a year. 