### PR TITLE
util: Respect user-defined SHELL environment variable

### DIFF
--- a/crates/util/src/util.rs
+++ b/crates/util/src/util.rs
@@ -279,7 +279,11 @@ fn load_shell_from_passwd() -> Result<()> {
     );
 
     let shell = unsafe { std::ffi::CStr::from_ptr(entry.pw_shell).to_str().unwrap() };
-    if env::var("SHELL").map_or(true, |shell_env| shell_env != shell) {
+    let should_set_shell = env::var("SHELL").map_or(true, |shell_env| {
+        shell_env != shell && !std::Path::new(&shell_env).exists()
+    });
+
+    if should_set_shell {
         log::info!(
             "updating SHELL environment variable to value from passwd entry: {:?}",
             shell,

--- a/crates/util/src/util.rs
+++ b/crates/util/src/util.rs
@@ -280,7 +280,7 @@ fn load_shell_from_passwd() -> Result<()> {
 
     let shell = unsafe { std::ffi::CStr::from_ptr(entry.pw_shell).to_str().unwrap() };
     let should_set_shell = env::var("SHELL").map_or(true, |shell_env| {
-        shell_env != shell && !std::Path::new(&shell_env).exists()
+        shell_env != shell && !std::path::Path::new(&shell_env).exists()
     });
 
     if should_set_shell {


### PR DESCRIPTION
Fix issue where Zed would unconditionally override user's custom shell with system default from passwd entry.

Closes https://github.com/zed-industries/zed/issues/40171

Release Notes:

- Fix issue where Zed would unconditionally override user's custom shell with system default from passwd entry.
