### PR TITLE
Fix command for changing inside brackets in vim.md

### DIFF
--- a/docs/src/vim.md
+++ b/docs/src/vim.md
@@ -239,7 +239,7 @@ With this configuration, you can use commands like:
 - `cib` - Change inside brackets using AnyBrackets behavior
 - `ciB` - Change inside brackets using MiniBrackets behavior
 - `ciq` - Change inside quotes using AnyQuotes behavior
-- `ciM` - Change inside quotes using MiniQuotes behavior
+- `ciQ` - Change inside quotes using MiniQuotes behavior
 
 ## Command palette
 

--- a/docs/src/vim.md
+++ b/docs/src/vim.md
@@ -237,7 +237,7 @@ To use these text objects, you need to add bindings to your keymap. Here's an ex
 With this configuration, you can use commands like:
 
 - `cib` - Change inside brackets using AnyBrackets behavior
-- `cim` - Change inside brackets using MiniBrackets behavior
+- `ciB` - Change inside brackets using MiniBrackets behavior
 - `ciq` - Change inside quotes using AnyQuotes behavior
 - `ciM` - Change inside quotes using MiniQuotes behavior
 


### PR DESCRIPTION
As code in example configuration, it should be `ciB` to make **Change inside brackets using MiniBrackets behavior**