### PR TITLE
zeta2: Numbered lines prompt format

### DIFF
--- a/crates/cloud_llm_client/src/predict_edits_v3.rs
+++ b/crates/cloud_llm_client/src/predict_edits_v3.rs
@@ -1,7 +1,7 @@
 use chrono::Duration;
 use serde::{Deserialize, Serialize};
 use std::{
-    ops::Range,
+    ops::{Add, Range, Sub},
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -18,8 +18,8 @@ pub struct PredictEditsRequest {
     pub excerpt_path: Arc<Path>,
     /// Within file
     pub excerpt_range: Range<usize>,
-    /// Within `excerpt`
-    pub cursor_offset: usize,
+    pub excerpt_line_range: Range<Line>,
+    pub cursor_point: Point,
     /// Within `signatures`
     pub excerpt_parent: Option<usize>,
     pub signatures: Vec<Signature>,
@@ -47,6 +47,7 @@ pub struct PredictEditsRequest {
 pub enum PromptFormat {
     MarkedExcerpt,
     LabeledSections,
+    NumberedLines,
     /// Prompt format intended for use via zeta_cli
     OnlySnippets,
 }
@@ -73,6 +74,7 @@ impl std::fmt::Display for PromptFormat {
             PromptFormat::MarkedExcerpt => write!(f, "Marked Excerpt"),
             PromptFormat::LabeledSections => write!(f, "Labeled Sections"),
             PromptFormat::OnlySnippets => write!(f, "Only Snippets"),
+            PromptFormat::NumberedLines => write!(f, "Numbered Lines"),
         }
     }
 }
@@ -97,7 +99,7 @@ pub struct Signature {
     pub parent_index: Option<usize>,
     /// Range of `text` within the file, possibly truncated according to `text_is_truncated`. The
     /// file is implicitly the file that contains the descendant declaration or excerpt.
-    pub range: Range<usize>,
+    pub range: Range<Line>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -106,7 +108,7 @@ pub struct ReferencedDeclaration {
     pub text: String,
     pub text_is_truncated: bool,
     /// Range of `text` within file, possibly truncated according to `text_is_truncated`
-    pub range: Range<usize>,
+    pub range: Range<Line>,
     /// Range within `text`
     pub signature_range: Range<usize>,
     /// Index within `signatures`.
@@ -169,10 +171,36 @@ pub struct DebugInfo {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Edit {
     pub path: Arc<Path>,
-    pub range: Range<usize>,
+    pub range: Range<Line>,
     pub content: String,
 }
 
 fn is_default<T: Default + PartialEq>(value: &T) -> bool {
     *value == T::default()
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, PartialOrd, Eq, Ord)]
+pub struct Point {
+    pub line: Line,
+    pub column: u32,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, PartialOrd, Eq, Ord)]
+#[serde(transparent)]
+pub struct Line(pub u32);
+
+impl Add for Line {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self(self.0 + rhs.0)
+    }
+}
+
+impl Sub for Line {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self(self.0 - rhs.0)
+    }
 }

--- a/crates/cloud_llm_client/src/predict_edits_v3.rs
+++ b/crates/cloud_llm_client/src/predict_edits_v3.rs
@@ -53,7 +53,7 @@ pub enum PromptFormat {
 }
 
 impl PromptFormat {
-    pub const DEFAULT: PromptFormat = PromptFormat::LabeledSections;
+    pub const DEFAULT: PromptFormat = PromptFormat::NumberedLines;
 }
 
 impl Default for PromptFormat {

--- a/crates/cloud_zeta2_prompt/src/cloud_zeta2_prompt.rs
+++ b/crates/cloud_zeta2_prompt/src/cloud_zeta2_prompt.rs
@@ -45,7 +45,6 @@ const LABELED_SECTIONS_SYSTEM_PROMPT: &str = indoc! {r#"
     }
 "#};
 
-// todo! confirm with oleksiy
 const NUMBERED_LINES_SYSTEM_PROMPT: &str = indoc! {r#"
     # Instructions
 

--- a/crates/cloud_zeta2_prompt/src/cloud_zeta2_prompt.rs
+++ b/crates/cloud_zeta2_prompt/src/cloud_zeta2_prompt.rs
@@ -404,7 +404,11 @@ impl<'a> PlannedPrompt<'a> {
 
         let mut prompt = String::new();
         prompt.push_str("## User Edits\n\n");
-        Self::push_events(&mut prompt, &self.request.events);
+        if self.request.events.is_empty() {
+            prompt.push_str("No edits yet.\n");
+        } else {
+            Self::push_events(&mut prompt, &self.request.events);
+        }
 
         prompt.push_str("\n## Code\n\n");
         let section_labels =
@@ -442,13 +446,17 @@ impl<'a> PlannedPrompt<'a> {
                     if *predicted {
                         writeln!(
                             output,
-                            "User accepted prediction {:?}:\n```diff\n{}\n```\n",
+                            "User accepted prediction {:?}:\n`````diff\n{}\n`````\n",
                             path, diff
                         )
                         .unwrap();
                     } else {
-                        writeln!(output, "User edited {:?}:\n```diff\n{}\n```\n", path, diff)
-                            .unwrap();
+                        writeln!(
+                            output,
+                            "User edited {:?}:\n`````diff\n{}\n`````\n",
+                            path, diff
+                        )
+                        .unwrap();
                     }
                 }
             }
@@ -488,7 +496,8 @@ impl<'a> PlannedPrompt<'a> {
                 disjoint_snippets.push(current_snippet);
             }
 
-            writeln!(output, "```{}", file_path.display()).ok();
+            // TODO: remove filename=?
+            writeln!(output, "`````filename={}", file_path.display()).ok();
             let mut skipped_last_snippet = false;
             for (snippet, range) in disjoint_snippets {
                 let section_index = section_ranges.len();
@@ -589,7 +598,7 @@ impl<'a> PlannedPrompt<'a> {
                 section_ranges.push((snippet.path.clone(), range));
             }
 
-            output.push_str("```\n\n");
+            output.push_str("`````\n\n");
         }
 
         Ok(SectionLabels {

--- a/crates/cloud_zeta2_prompt/src/cloud_zeta2_prompt.rs
+++ b/crates/cloud_zeta2_prompt/src/cloud_zeta2_prompt.rs
@@ -479,11 +479,9 @@ impl<'a> PlannedPrompt<'a> {
             let mut disjoint_snippets: Vec<(&PlannedSnippet, Range<Line>)> = Vec::new();
             for snippet in snippets {
                 if let Some((_, current_snippet_range)) = current_snippet.as_mut()
-                    && snippet.range.start < current_snippet_range.end
+                    && snippet.range.start <= current_snippet_range.end
                 {
-                    if snippet.range.end > current_snippet_range.end {
-                        current_snippet_range.end = snippet.range.end;
-                    }
+                    current_snippet_range.end = current_snippet_range.end.max(snippet.range.end);
                     continue;
                 }
                 if let Some(current_snippet) = current_snippet.take() {

--- a/crates/edit_prediction_context/src/declaration.rs
+++ b/crates/edit_prediction_context/src/declaration.rs
@@ -1,3 +1,4 @@
+use cloud_llm_client::predict_edits_v3::{self, Line};
 use language::{Language, LanguageId};
 use project::ProjectEntryId;
 use std::ops::Range;
@@ -91,6 +92,18 @@ impl Declaration {
         }
     }
 
+    pub fn item_line_range(&self) -> Range<Line> {
+        match self {
+            Declaration::File { declaration, .. } => declaration.item_line_range.clone(),
+            Declaration::Buffer {
+                declaration, rope, ..
+            } => {
+                Line(rope.offset_to_point(declaration.item_range.start).row)
+                    ..Line(rope.offset_to_point(declaration.item_range.end).row)
+            }
+        }
+    }
+
     pub fn item_text(&self) -> (Cow<'_, str>, bool) {
         match self {
             Declaration::File { declaration, .. } => (
@@ -130,6 +143,18 @@ impl Declaration {
         }
     }
 
+    pub fn signature_line_range(&self) -> Range<Line> {
+        match self {
+            Declaration::File { declaration, .. } => declaration.signature_line_range.clone(),
+            Declaration::Buffer {
+                declaration, rope, ..
+            } => {
+                Line(rope.offset_to_point(declaration.signature_range.start).row)
+                    ..Line(rope.offset_to_point(declaration.signature_range.end).row)
+            }
+        }
+    }
+
     pub fn signature_range_in_item_text(&self) -> Range<usize> {
         let signature_range = self.signature_range();
         let item_range = self.item_range();
@@ -142,7 +167,7 @@ fn expand_range_to_line_boundaries_and_truncate(
     range: &Range<usize>,
     limit: usize,
     rope: &Rope,
-) -> (Range<usize>, bool) {
+) -> (Range<usize>, Range<predict_edits_v3::Line>, bool) {
     let mut point_range = rope.offset_to_point(range.start)..rope.offset_to_point(range.end);
     point_range.start.column = 0;
     point_range.end.row += 1;
@@ -155,7 +180,10 @@ fn expand_range_to_line_boundaries_and_truncate(
         item_range.end = item_range.start + limit;
     }
     item_range.end = rope.clip_offset(item_range.end, Bias::Left);
-    (item_range, is_truncated)
+
+    let line_range =
+        predict_edits_v3::Line(point_range.start.row)..predict_edits_v3::Line(point_range.end.row);
+    (item_range, line_range, is_truncated)
 }
 
 #[derive(Debug, Clone)]
@@ -164,25 +192,30 @@ pub struct FileDeclaration {
     pub identifier: Identifier,
     /// offset range of the declaration in the file, expanded to line boundaries and truncated
     pub item_range: Range<usize>,
+    /// line range of the declaration in the file, potentially truncated
+    pub item_line_range: Range<predict_edits_v3::Line>,
     /// text of `item_range`
     pub text: Arc<str>,
     /// whether `text` was truncated
     pub text_is_truncated: bool,
     /// offset range of the signature in the file, expanded to line boundaries and truncated
     pub signature_range: Range<usize>,
+    /// line range of the signature in the file, truncated
+    pub signature_line_range: Range<Line>,
     /// whether `signature` was truncated
     pub signature_is_truncated: bool,
 }
 
 impl FileDeclaration {
     pub fn from_outline(declaration: OutlineDeclaration, rope: &Rope) -> FileDeclaration {
-        let (item_range_in_file, text_is_truncated) = expand_range_to_line_boundaries_and_truncate(
-            &declaration.item_range,
-            ITEM_TEXT_TRUNCATION_LENGTH,
-            rope,
-        );
+        let (item_range_in_file, item_line_range_in_file, text_is_truncated) =
+            expand_range_to_line_boundaries_and_truncate(
+                &declaration.item_range,
+                ITEM_TEXT_TRUNCATION_LENGTH,
+                rope,
+            );
 
-        let (mut signature_range_in_file, mut signature_is_truncated) =
+        let (mut signature_range_in_file, signature_line_range, mut signature_is_truncated) =
             expand_range_to_line_boundaries_and_truncate(
                 &declaration.signature_range,
                 ITEM_TEXT_TRUNCATION_LENGTH,
@@ -202,6 +235,7 @@ impl FileDeclaration {
             parent: None,
             identifier: declaration.identifier,
             signature_range: signature_range_in_file,
+            signature_line_range,
             signature_is_truncated,
             text: rope
                 .chunks_in_range(item_range_in_file.clone())
@@ -209,6 +243,7 @@ impl FileDeclaration {
                 .into(),
             text_is_truncated,
             item_range: item_range_in_file,
+            item_line_range: item_line_range_in_file,
         }
     }
 }
@@ -225,12 +260,13 @@ pub struct BufferDeclaration {
 
 impl BufferDeclaration {
     pub fn from_outline(declaration: OutlineDeclaration, rope: &Rope) -> Self {
-        let (item_range, item_range_is_truncated) = expand_range_to_line_boundaries_and_truncate(
-            &declaration.item_range,
-            ITEM_TEXT_TRUNCATION_LENGTH,
-            rope,
-        );
-        let (signature_range, signature_range_is_truncated) =
+        let (item_range, _item_line_range, item_range_is_truncated) =
+            expand_range_to_line_boundaries_and_truncate(
+                &declaration.item_range,
+                ITEM_TEXT_TRUNCATION_LENGTH,
+                rope,
+            );
+        let (signature_range, _signature_line_range, signature_range_is_truncated) =
             expand_range_to_line_boundaries_and_truncate(
                 &declaration.signature_range,
                 ITEM_TEXT_TRUNCATION_LENGTH,

--- a/crates/zeta_cli/src/main.rs
+++ b/crates/zeta_cli/src/main.rs
@@ -98,10 +98,11 @@ struct Zeta2Args {
 
 #[derive(clap::ValueEnum, Default, Debug, Clone)]
 enum PromptFormat {
-    #[default]
     MarkedExcerpt,
     LabeledSections,
     OnlySnippets,
+    #[default]
+    NumberedLines,
 }
 
 impl Into<predict_edits_v3::PromptFormat> for PromptFormat {
@@ -110,6 +111,7 @@ impl Into<predict_edits_v3::PromptFormat> for PromptFormat {
             Self::MarkedExcerpt => predict_edits_v3::PromptFormat::MarkedExcerpt,
             Self::LabeledSections => predict_edits_v3::PromptFormat::LabeledSections,
             Self::OnlySnippets => predict_edits_v3::PromptFormat::OnlySnippets,
+            Self::NumberedLines => predict_edits_v3::PromptFormat::NumberedLines,
         }
     }
 }


### PR DESCRIPTION
Adds a new `NumberedLines` format which is similar to `MarkedExcerpt` but each line is prefixed with its line number.

Also fixes a bug where contagious snippets wouldn't get merged.

Release Notes:

- N/A 
