### PR TITLE
Fix a couple of bugs in remote browser debugging implementation

### DIFF
--- a/crates/project/src/debugger/session.rs
+++ b/crates/project/src/debugger/session.rs
@@ -2898,7 +2898,7 @@ impl Session {
             }
             if !companion_started {
                 console_output
-                    .send(format!("Browser companion failed to start"))
+                    .send("Browser companion failed to start".into())
                     .await
                     .ok();
                 bail!("Browser companion failed to start");

--- a/crates/remote/src/transport/ssh.rs
+++ b/crates/remote/src/transport/ssh.rs
@@ -152,13 +152,14 @@ impl RemoteConnection for SshRemoteConnection {
         host: String,
         remote_port: u16,
     ) -> Result<CommandTemplate> {
+        let Self { socket, .. } = self;
+        let mut args = socket.ssh_args();
+        args.push("-N".into());
+        args.push("-L".into());
+        args.push(format!("{local_port}:{host}:{remote_port}"));
         Ok(CommandTemplate {
             program: "ssh".into(),
-            args: vec![
-                "-N".into(),
-                "-L".into(),
-                format!("{local_port}:{host}:{remote_port}"),
-            ],
+            args,
             env: Default::default(),
         })
     }

--- a/crates/remote/src/transport/ssh.rs
+++ b/crates/remote/src/transport/ssh.rs
@@ -146,17 +146,17 @@ impl RemoteConnection for SshRemoteConnection {
         )
     }
 
-    fn build_forward_port_command(
+    fn build_forward_ports_command(
         &self,
-        local_port: u16,
-        host: String,
-        remote_port: u16,
+        forwards: Vec<(u16, String, u16)>,
     ) -> Result<CommandTemplate> {
         let Self { socket, .. } = self;
         let mut args = socket.ssh_args();
         args.push("-N".into());
-        args.push("-L".into());
-        args.push(format!("{local_port}:{host}:{remote_port}"));
+        for (local_port, host, remote_port) in forwards {
+            args.push("-L".into());
+            args.push(format!("{local_port}:{host}:{remote_port}"));
+        }
         Ok(CommandTemplate {
             program: "ssh".into(),
             args,

--- a/crates/remote/src/transport/wsl.rs
+++ b/crates/remote/src/transport/wsl.rs
@@ -485,11 +485,9 @@ impl RemoteConnection for WslRemoteConnection {
         })
     }
 
-    fn build_forward_port_command(
+    fn build_forward_ports_command(
         &self,
-        _: u16,
-        _: String,
-        _: u16,
+        _: Vec<(u16, String, u16)>,
     ) -> anyhow::Result<CommandTemplate> {
         Err(anyhow!("WSL shares a network interface with the host"))
     }


### PR DESCRIPTION
Follow-up to #39248 

- Correctly forward ports over SSH, including the port from the debug scenario's `url`
- Give the companion time to start up, instead of bailing if the first connection attempt fails

Release Notes:

- Fixed not being able to launch a browser debugging session in an SSH project.