### PR TITLE
terminal_ui: Terminal failed to spawn UI

### DIFF
--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -12,8 +12,8 @@ use db::kvp::KEY_VALUE_STORE;
 use futures::{channel::oneshot, future::join_all};
 use gpui::{
     Action, AnyView, App, AsyncApp, AsyncWindowContext, Context, Corner, Entity, EventEmitter,
-    ExternalPaths, FocusHandle, Focusable, IntoElement, ParentElement, Pixels, Render,
-    Styled, Task, WeakEntity, Window, actions,
+    ExternalPaths, FocusHandle, Focusable, IntoElement, ParentElement, Pixels, Render, Styled,
+    Task, WeakEntity, Window, actions,
 };
 use itertools::Itertools;
 use project::{Fs, Project, ProjectEntryId};
@@ -1365,7 +1365,7 @@ impl FailedToSpawnTerminal {
         PopoverMenu::new(id.into())
             .trigger(
                 ui::ButtonLike::new_rounded_right((
-                    "failed-to-spawn-terminal-settings-button-popover-menu",
+                    "failed-to-spawn-terminal-settings-button-popover-menu-popover",
                     cx.entity_id(),
                 ))
                 .layer(ui::ElevationIndex::ModalSurface)

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -12,7 +12,7 @@ use db::kvp::KEY_VALUE_STORE;
 use futures::{channel::oneshot, future::join_all};
 use gpui::{
     Action, AnyView, App, AsyncApp, AsyncWindowContext, Context, Corner, Entity, EventEmitter,
-    ExternalPaths, FocusHandle, Focusable, IntoElement, Length, ParentElement, Pixels, Render,
+    ExternalPaths, FocusHandle, Focusable, IntoElement, ParentElement, Pixels, Render,
     Styled, Task, WeakEntity, Window, actions,
 };
 use itertools::Itertools;
@@ -1334,7 +1334,7 @@ impl Render for FailedToSpawnTerminal {
         );
         let button = SplitButton::new(
             ButtonLike::new(("failed-to-spawn-terminal-settings-button", cx.entity_id()))
-                .child("Edit settings")
+                .child(Label::new("Edit settings").size(LabelSize::Small))
                 .on_click(|_, window, cx| {
                     window.dispatch_action(zed_actions::OpenSettings.boxed_clone(), cx);
                 }),

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -1884,7 +1884,7 @@ mod tests {
             .unwrap_err();
 
         window_handle
-            .update(cx, |_, window, cx| {
+            .update(cx, |_, _, cx| {
                 terminal_panel.update(cx, |terminal_panel, cx| {
                     assert!(
                         terminal_panel

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -870,7 +870,7 @@ impl TerminalPanel {
                     pane.update_in(cx, |pane, window, cx| {
                         let focus = pane.has_focus(window, cx);
                         let failed_to_spawn = cx.new(|cx| FailedToSpawnTerminal {
-                            error: format!("{:#}", error),
+                            error: error.to_string(),
                             focus_handle: cx.focus_handle(),
                         });
                         pane.add_item(Box::new(failed_to_spawn), true, focus, None, window, cx);


### PR DESCRIPTION
Adds a simple UI to the terminal panel if we fail to spawn the process.
Previously this would just render an empty box, but would log the error.

New UI:
<img width="1240" height="322" alt="image" src="https://github.com/user-attachments/assets/2d252785-a38f-41a6-9fe8-e2eb7330e3ed" />



Co-authored-by: Piotr piotr@zed.dev
Co-authored-by: Lukas lukas@zed.dev

Release Notes:

- Failing to spawn a terminal will now render a UI with an error message and links to settings
