### PR TITLE
dap: Enable adapter logs for StdioTransport delegate

### DIFF
--- a/crates/dap/src/transport.rs
+++ b/crates/dap/src/transport.rs
@@ -676,7 +676,7 @@ impl StdioTransport {
 
         let mut process = Child::spawn(command, Stdio::piped())?;
 
-        let err_task = process.stderr.take().map(|stderr| {
+        let _stderr_task = process.stderr.take().map(|stderr| {
             cx.background_spawn(TransportDelegate::handle_adapter_log(
                 stderr,
                 IoKind::StdErr,
@@ -688,14 +688,14 @@ impl StdioTransport {
 
         Ok(Self {
             process,
-            _stderr_task: err_task,
+            _stderr_task,
         })
     }
 }
 
 impl Transport for StdioTransport {
     fn has_adapter_logs(&self) -> bool {
-        false
+        true
     }
 
     fn kill(&mut self) {


### PR DESCRIPTION
This is the first towards better logs for adapter binaries. Next up I intend to somehow allow `codelldb` adapter in Zed to permit simple log level so that we can pass `RUST_LOG=level` when spawning the child process.

Release Notes:

- N/A
