### PR TITLE
title bar: Remove chevron to the side of the avatar when logged in

### DIFF
--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -189,10 +189,18 @@ impl Render for TitleBar {
         let status = &*status.borrow();
         let user = self.user_store.read(cx).current_user();
 
+        let signed_in = user.is_some();
+
         children.push(
             h_flex()
+                .map(|this| {
+                    if signed_in {
+                        this.pr_1p5()
+                    } else {
+                        this.pr_1()
+                    }
+                })
                 .gap_1()
-                .pr_1()
                 .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
                 .children(self.render_call_controls(window, cx))
                 .children(self.render_connection_status(status, cx))
@@ -755,24 +763,13 @@ impl TitleBar {
             .map(|this| {
                 if is_signed_in {
                     this.trigger_with_tooltip(
-                        ButtonLike::new("user-menu")
-                            .child(
-                                h_flex()
-                                    .gap_0p5()
-                                    .children(
-                                        TitleBarSettings::get_global(cx)
-                                            .show_user_picture
-                                            .then(|| user_avatar.clone())
-                                            .flatten()
-                                            .map(|avatar| Avatar::new(avatar)),
-                                    )
-                                    .child(
-                                        Icon::new(IconName::ChevronDown)
-                                            .size(IconSize::Small)
-                                            .color(Color::Muted),
-                                    ),
-                            )
-                            .style(ButtonStyle::Subtle),
+                        ButtonLike::new("user-menu").children(
+                            TitleBarSettings::get_global(cx)
+                                .show_user_picture
+                                .then(|| user_avatar.clone())
+                                .flatten()
+                                .map(|avatar| Avatar::new(avatar)),
+                        ),
                         Tooltip::text("Toggle User Menu"),
                     )
                 } else {


### PR DESCRIPTION
Having the chevron to the side of the avatar is arguably unnecessary at this point; most apps out there (Reddit, YouTube, etc.), including here on GitHub, have the avatar without any icon, pointing to how there doesn't seem to be a problem with knowing that there's a menu behind it. Therefore, figured we could simplify the UI a bit more here.

This also looks better on platforms where the window controls are on the right (Linux/Windows).

Release Notes:

- N/A
