### PR TITLE
Remove unnecessary languages mapping in Tailwind for Ruby example

### DIFF
--- a/docs/src/languages/ruby.md
+++ b/docs/src/languages/ruby.md
@@ -260,10 +260,6 @@ In order to do that, you need to configure the language server so that it knows 
   "lsp": {
     "tailwindcss-language-server": {
       "settings": {
-        "includeLanguages": {
-          "html+erb": "html",
-          "ruby": "html"
-        },
         "experimental": {
           "classRegex": ["\\bclass:\\s*['\"]([^'\"]*)['\"]"]
         }


### PR DESCRIPTION
The built-in Tailwind language already maps `HTML+ERB` to `erb`, and it seems that `Ruby` files work as well just from enabling the language server, so we can remove the unnecessary mapping.
