### PR TITLE
Restart crash handler if it dies

### DIFF
--- a/crates/crashes/src/crashes.rs
+++ b/crates/crashes/src/crashes.rs
@@ -327,7 +327,7 @@ pub fn panic_hook(info: &PanicHookInfo) {
     // if it's still not there just write panic info and no minidump
     let retry_frequency = Duration::from_millis(100);
     for _ in 0..5 {
-        if let Some(client) = CRASH_HANDLER.get().map(|c| c.try_lock()).flatten() {
+        if let Some(client) = CRASH_HANDLER.get().and_then(|c| c.try_lock()) {
             client
                 .send_message(
                     2,

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -368,7 +368,7 @@ pub fn initialize_workspace(
             if let Some((crash_server, message)) = crashes::CRASH_HANDLER
                 .get()
                 .zip(bincode::serialize(&specs).ok())
-                && let Err(err) = crash_server.send_message(3, message)
+                && let Err(err) = smol::block_on(crash_server.lock()).send_message(3, message)
             {
                 log::warn!(
                     "Failed to store active gpu info for crash reporting: {}",


### PR DESCRIPTION
Previously if the crash handler process was killed for whatever reason, zed would silently fail to ping it, and in rare cases we observed hangs during panics probably due to it blocking while trying to request a minidump of the process when there was no handler to get the message.

Now whenever the editor pings the crash handler to keep it alive (currently every 10 seconds) it also checks whether the ping succeeded, and if it doesn't it restarts the process and replaces the current socket connection with that new one.

Still need to manually test on:
- [ ] Linux
- [ ] MacOS

Release Notes:

- N/A
