### PR TITLE
project_panel: Add `open_file_on_paste` setting to configure auto opening of file on paste

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -724,7 +724,9 @@
     // Whether to hide the root entry when only one folder is open in the window.
     "hide_root": false,
     // Whether to hide the hidden entries in the project panel.
-    "hide_hidden": false
+    "hide_hidden": false,
+    // Whether to automatically open files when pasting them in the project panel.
+    "open_file_on_paste": true
   },
   "outline_panel": {
     // Whether to show the outline panel button in the status bar

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -2698,9 +2698,10 @@ impl ProjectPanel {
                             });
 
                             if item_count == 1 {
-                                let should_open_file = ProjectPanelSettings::get_global(cx).open_file_on_paste;
                                 // open entry if not dir, setting is enabled, and only focus if rename is not pending
-                                if !entry.is_dir() && should_open_file {
+                                if !entry.is_dir()
+                                    && ProjectPanelSettings::get_global(cx).open_file_on_paste
+                                {
                                     project_panel.open_entry(
                                         entry.id,
                                         disambiguation_range.is_none(),

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -2698,10 +2698,9 @@ impl ProjectPanel {
                             });
 
                             if item_count == 1 {
-                                let should_open_files =
-                                    ProjectPanelSettings::get_global(cx).open_file_on_paste;
+                                let should_open_file = ProjectPanelSettings::get_global(cx).open_file_on_paste;
                                 // open entry if not dir, setting is enabled, and only focus if rename is not pending
-                                if !entry.is_dir() && should_open_files {
+                                if !entry.is_dir() && should_open_file {
                                     project_panel.open_entry(
                                         entry.id,
                                         disambiguation_range.is_none(),

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -2698,8 +2698,10 @@ impl ProjectPanel {
                             });
 
                             if item_count == 1 {
-                                // open entry if not dir, and only focus if rename is not pending
-                                if !entry.is_dir() {
+                                let should_open_files =
+                                    ProjectPanelSettings::get_global(cx).open_file_on_paste;
+                                // open entry if not dir, setting is enabled, and only focus if rename is not pending
+                                if !entry.is_dir() && should_open_files {
                                     project_panel.open_entry(
                                         entry.id,
                                         disambiguation_range.is_none(),

--- a/crates/project_panel/src/project_panel_settings.rs
+++ b/crates/project_panel/src/project_panel_settings.rs
@@ -83,7 +83,7 @@ impl Settings for ProjectPanelSettings {
             hide_root: project_panel.hide_root.unwrap(),
             hide_hidden: project_panel.hide_hidden.unwrap(),
             drag_and_drop: project_panel.drag_and_drop.unwrap(),
-            open_file_on_paste: project_panel.open_file_on_paste.unwrap_or(true),
+            open_file_on_paste: project_panel.open_file_on_paste.unwrap(),
         }
     }
 

--- a/crates/project_panel/src/project_panel_settings.rs
+++ b/crates/project_panel/src/project_panel_settings.rs
@@ -32,6 +32,7 @@ pub struct ProjectPanelSettings {
     pub hide_root: bool,
     pub hide_hidden: bool,
     pub drag_and_drop: bool,
+    pub open_file_on_paste: bool,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -82,6 +83,7 @@ impl Settings for ProjectPanelSettings {
             hide_root: project_panel.hide_root.unwrap(),
             hide_hidden: project_panel.hide_hidden.unwrap(),
             drag_and_drop: project_panel.drag_and_drop.unwrap(),
+            open_file_on_paste: project_panel.open_file_on_paste.unwrap_or(true),
         }
     }
 

--- a/crates/settings/src/settings_content/workspace.rs
+++ b/crates/settings/src/settings_content/workspace.rs
@@ -566,6 +566,10 @@ pub struct ProjectPanelSettingsContent {
     ///
     /// Default: true
     pub drag_and_drop: Option<bool>,
+    /// Whether to automatically open files when pasting them in the project panel.
+    ///
+    /// Default: true
+    pub open_file_on_paste: Option<bool>,
 }
 
 #[derive(

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -3120,6 +3120,27 @@ pub(crate) fn settings_data(cx: &App) -> Vec<SettingsPage> {
                     metadata: None,
                     files: USER,
                 }),
+                SettingsPageItem::SettingItem(SettingItem {
+                    title: "Open File on Paste",
+                    description: "Whether to automatically open files when pasting them in the project panel",
+                    field: Box::new(SettingField {
+                        pick: |settings_content| {
+                            if let Some(project_panel) = &settings_content.project_panel {
+                                &project_panel.open_file_on_paste
+                            } else {
+                                &None
+                            }
+                        },
+                        pick_mut: |settings_content| {
+                            &mut settings_content
+                                .project_panel
+                                .get_or_insert_default()
+                                .open_file_on_paste
+                        },
+                    }),
+                    metadata: None,
+                    files: USER,
+                }),
                 SettingsPageItem::SectionHeader("Terminal Panel"),
                 SettingsPageItem::SettingItem(SettingItem {
                     title: "Terminal Dock",

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -4155,7 +4155,8 @@ Run the {#action theme_selector::Toggle} action in the command palette to see a 
     },
     "hide_root": false,
     "hide_hidden": false,
-    "starts_open": true
+    "starts_open": true,
+    "open_file_on_paste": true
   }
 }
 ```


### PR DESCRIPTION
Closes #40234

Release Notes:

- Added `open_file_on_paste` setting to configure auto opening of file on paste in the project panel.