### PR TITLE
markdown_preview: Fix block quote last child bottom padding

### DIFF
--- a/crates/markdown_preview/src/markdown_renderer.rs
+++ b/crates/markdown_preview/src/markdown_renderer.rs
@@ -61,6 +61,7 @@ pub struct RenderContext {
     syntax_theme: Arc<SyntaxTheme>,
     indent: usize,
     checkbox_clicked_callback: Option<CheckboxClickedCallback>,
+    is_last_child: bool,
 }
 
 impl RenderContext {
@@ -94,6 +95,7 @@ impl RenderContext {
             code_block_background_color: theme.colors().surface_background,
             code_span_background_color: theme.colors().editor_document_highlight_read_background,
             checkbox_clicked_callback: None,
+            is_last_child: false,
         }
     }
 
@@ -135,11 +137,24 @@ impl RenderContext {
     /// We give padding between "This is a block quote."
     /// and "And this is the next paragraph."
     fn with_common_p(&self, element: Div) -> Div {
-        if self.indent > 0 {
+        if self.indent > 0 && !self.is_last_child {
             element.pb(self.scaled_rems(0.75))
         } else {
             element
         }
+    }
+
+    /// The is used to indicate that the current element is the last child or not of its parent.
+    ///
+    /// Then we can avoid adding padding to the bottom of the last child.
+    fn with_last_child<R>(&mut self, is_last: bool, render: R) -> AnyElement
+    where
+        R: FnOnce(&mut Self) -> AnyElement,
+    {
+        self.is_last_child = is_last;
+        let element = render(self);
+        self.is_last_child = false;
+        element
     }
 }
 
@@ -585,7 +600,12 @@ fn render_markdown_block_quote(
     let children: Vec<AnyElement> = parsed
         .children
         .iter()
-        .map(|child| render_markdown_block(child, cx))
+        .enumerate()
+        .map(|(ix, child)| {
+            cx.with_last_child(ix + 1 == parsed.children.len(), |cx| {
+                render_markdown_block(child, cx)
+            })
+        })
         .collect();
 
     cx.indent -= 1;


### PR DESCRIPTION
Release Notes:

- Fixed block quote last child bottom padding in Markdown preview.

| Before | After |
| --- | --- |
| <img width="577" height="665" alt="image" src="https://github.com/user-attachments/assets/f2ff9fff-b4a6-44ed-b83c-6811e13fb3b8" /> |  <img width="612" height="634" alt="SCR-20251016-okfv" src="https://github.com/user-attachments/assets/b4c5b706-49aa-4348-9553-22b0eb98e201" /> |

