### PR TITLE
dap: Enable info level logs for CodeLLDB adapter

### DIFF
--- a/crates/dap/src/transport.rs
+++ b/crates/dap/src/transport.rs
@@ -262,11 +262,15 @@ impl TransportDelegate {
                     break;
                 }
             }
+
+            // Clean up logs by trimming unnecessary whitespace/newlines before inserting into log.
+            let line = line.trim();
+
             log::debug!("stderr: {line}");
 
             for (kind, handler) in log_handlers.lock().iter_mut() {
                 if matches!(kind, LogKind::Adapter) {
-                    handler(iokind, None, line.as_str());
+                    handler(iokind, None, line);
                 }
             }
         }

--- a/crates/dap_adapters/src/codelldb.rs
+++ b/crates/dap_adapters/src/codelldb.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, path::PathBuf, sync::OnceLock};
+use std::{path::PathBuf, sync::OnceLock};
 
 use anyhow::{Context as _, Result};
 use async_trait::async_trait;
@@ -377,6 +377,12 @@ impl DebugAdapter for CodeLldbDebugAdapter {
             command = Some(path);
         };
         let mut json_config = config.config.clone();
+
+        // Enable info level for CodeLLDB by default.
+        // Logs can then be viewed in our DAP logs.
+        let mut envs = collections::HashMap::default();
+        envs.insert("RUST_LOG".to_string(), "info".to_string());
+
         Ok(DebugAdapterBinary {
             command: Some(command.unwrap()),
             cwd: Some(delegate.worktree_root_path().to_path_buf()),
@@ -401,7 +407,7 @@ impl DebugAdapter for CodeLldbDebugAdapter {
             request_args: self
                 .request_args(delegate, json_config, &config.label)
                 .await?,
-            envs: HashMap::default(),
+            envs,
             connection: None,
         })
     }


### PR DESCRIPTION
Trim whitespace/newline when committing the logs in Zed.

Release Notes:

- N/A
