### PR TITLE
acp: Add nicer WSL warning for Codex

### DIFF
--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -5054,8 +5054,7 @@ impl AcpThreadView {
                             .on_click(cx.listener({
                                 move |_, _, window, cx| {
                                     window.dispatch_action(
-                                        zed_actions::wsl_actions::OpenFolderInWsl::default()
-                                            .boxed_clone(),
+                                        zed_actions::wsl_actions::OpenWsl::default().boxed_clone(),
                                         cx,
                                     );
                                     cx.notify();

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -5037,11 +5037,7 @@ impl AcpThreadView {
     }
 
     #[cfg(target_os = "windows")]
-    fn render_codex_windows_warning(
-        &self,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) -> Option<Callout> {
+    fn render_codex_windows_warning(&self, cx: &mut Context<Self>) -> Option<Callout> {
         if self.show_codex_windows_warning {
             Some(
                 Callout::new()
@@ -5051,6 +5047,21 @@ impl AcpThreadView {
                     .description(
                         "For best performance, run Codex in Windows Subsystem for Linux (WSL2)",
                     )
+                    .actions_slot(
+                        Button::new("open-wsl-modal", "Open in WSL")
+                            .icon_size(IconSize::Small)
+                            .icon_color(Color::Muted)
+                            .on_click(cx.listener({
+                                move |_, _, window, cx| {
+                                    window.dispatch_action(
+                                        zed_actions::wsl_actions::OpenFolderInWsl::default()
+                                            .boxed_clone(),
+                                        cx,
+                                    );
+                                    cx.notify();
+                                }
+                            })),
+                    )
                     .dismiss_action(
                         IconButton::new("dismiss", IconName::Close)
                             .icon_size(IconSize::Small)
@@ -5059,11 +5070,6 @@ impl AcpThreadView {
                             .on_click(cx.listener({
                                 move |this, _, _, cx| {
                                     this.show_codex_windows_warning = false;
-                                    window.dispatch_action(
-                                        zed_actions::wsl_actions::OpenFolderInWsl::default()
-                                            .boxed_clone(),
-                                        cx,
-                                    );
                                     cx.notify();
                                 }
                             })),
@@ -5564,7 +5570,7 @@ impl Render for AcpThreadView {
             .children({
                 #[cfg(target_os = "windows")]
                 {
-                    self.render_codex_windows_warning(window, cx)
+                    self.render_codex_windows_warning(cx)
                 }
                 #[cfg(not(target_os = "windows"))]
                 {

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -161,10 +161,9 @@ pub struct NewNativeAgentThreadFromSummary {
 }
 
 // TODO unify this with AgentType
-#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-enum ExternalAgent {
-    #[default]
+pub enum ExternalAgent {
     Gemini,
     ClaudeCode,
     Codex,
@@ -184,13 +183,13 @@ fn placeholder_command() -> AgentServerCommand {
 }
 
 impl ExternalAgent {
-    fn name(&self) -> &'static str {
-        match self {
-            Self::NativeAgent => "zed",
-            Self::Gemini => "gemini-cli",
-            Self::ClaudeCode => "claude-code",
-            Self::Codex => "codex",
-            Self::Custom { .. } => "custom",
+    pub fn parse_built_in(server: &dyn agent_servers::AgentServer) -> Option<Self> {
+        match server.telemetry_id() {
+            "gemini-cli" => Some(Self::Gemini),
+            "claude-code" => Some(Self::ClaudeCode),
+            "codex" => Some(Self::Codex),
+            "zed" => Some(Self::NativeAgent),
+            _ => None,
         }
     }
 


### PR DESCRIPTION
Moves the Codex warning into the thread so that we can render it nicer, as well as provide an option to open the folder in WSL.

Release Notes:

- N/A
