### PR TITLE
Time out hanging credential store reads

### DIFF
--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -336,7 +336,7 @@ impl Credentials {
     }
 }
 
-pub const CREDENTIAL_READ_TIMEOUT: Duration = Duration::from_secs(10);
+pub const CREDENTIAL_READ_TIMEOUT: Duration = Duration::from_secs(25);
 pub struct ClientCredentialsProvider {
     provider: Arc<dyn CredentialsProvider>,
 }

--- a/crates/gpui/src/util.rs
+++ b/crates/gpui/src/util.rs
@@ -65,7 +65,7 @@ pub trait FluentBuilder {
 /// Extensions for Future types that provide additional combinators and utilities.
 pub trait FutureExt {
     /// Requires a Future to complete before the specified duration has elapsed.
-    /// Similar to tokio::timeout.
+    /// Similar to tokio::timeout. Resolves to `Result<T, Timeout>`
     fn with_timeout(self, timeout: Duration, executor: &BackgroundExecutor) -> WithTimeout<Self>
     where
         Self: Sized;


### PR DESCRIPTION
When the desktop env on Linux does not provide a polkit authentication agent the call to `keyring.unlock()` hangs forever. This puts a 25 second timeout on reading credentials.

This does mean an end user needs to put in their password within 25 seconds or they will get an error.

A better solution would be detecting whether an authentication agent launched or not. I've asked for help upstream in [oo7](https://github.com/bilelmoussaoui/oo7/issues/332).

Release Notes:

- N/A
