### PR TITLE
Round the scroll offset in editor to fix jumping text

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -7212,9 +7212,16 @@ impl EditorElement {
                             * ScrollPixelOffset::from(max_glyph_advance)
                             - ScrollPixelOffset::from(delta.x * scroll_sensitivity))
                             / ScrollPixelOffset::from(max_glyph_advance);
-                        let y = (current_scroll_position.y * ScrollPixelOffset::from(line_height)
+
+                        let scale_factor = window.scale_factor();
+                        let y = (current_scroll_position.y
+                            * ScrollPixelOffset::from(line_height)
+                            * ScrollPixelOffset::from(scale_factor)
                             - ScrollPixelOffset::from(delta.y * scroll_sensitivity))
-                            / ScrollPixelOffset::from(line_height);
+                        .round()
+                            / ScrollPixelOffset::from(line_height)
+                            / ScrollPixelOffset::from(scale_factor);
+
                         let mut scroll_position =
                             point(x, y).clamp(&point(0., 0.), &position_map.scroll_max);
                         let forbid_vertical_scroll = editor.scroll_manager.forbid_vertical_scroll();


### PR DESCRIPTION
Release Notes:

- Improved editor font rendering on lodpi displays
