### PR TITLE
ui_input: Adjust step values for Font Weight stepper

### DIFF
--- a/crates/ui_input/src/number_field.rs
+++ b/crates/ui_input/src/number_field.rs
@@ -33,13 +33,13 @@ pub trait NumberFieldType: Display + Copy + Clone + Sized + PartialOrd + FromStr
 
 impl NumberFieldType for gpui::FontWeight {
     fn default_step() -> Self {
-        FontWeight(10.0)
-    }
-    fn large_step() -> Self {
         FontWeight(50.0)
     }
+    fn large_step() -> Self {
+        FontWeight(100.0)
+    }
     fn small_step() -> Self {
-        FontWeight(5.0)
+        FontWeight(10.0)
     }
     fn min_value() -> Self {
         gpui::FontWeight::THIN


### PR DESCRIPTION
# Why

While playing with new Settings UI I have spotted that changing font weight requires a lot of clicks. This is also a bit more annoying due to lack of ability to enter the desired value by hand.

# How

Adjust step values for Font Weight stepper, the default increment has been changed from 10 to 50, to cover (defined in spec `950` weight) which some fonts might use, small step has been changed from 5 to 10, and large step from 50 to 100.

Release Notes:

- Adjusted default step values for number input UI element used for changing Font Weight in Settings UI.
