### PR TITLE
file_finder: Include worktree root name in multi-worktrees workspace

### DIFF
--- a/crates/file_finder/src/file_finder_tests.rs
+++ b/crates/file_finder/src/file_finder_tests.rs
@@ -2567,6 +2567,10 @@ async fn test_history_items_uniqueness_for_multiple_worktree_open_all_files(
             let panel_match = panel_match.as_ref().unwrap();
             assert_eq!(panel_match.0.path_prefix, rel_path("repo2").into());
             assert_eq!(panel_match.0.path, rel_path("package.json").into());
+            assert_eq!(
+                panel_match.0.positions,
+                vec![6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]
+            );
         }
 
         if let Match::History { path, panel_match } = &matches[1] {
@@ -2575,6 +2579,10 @@ async fn test_history_items_uniqueness_for_multiple_worktree_open_all_files(
             let panel_match = panel_match.as_ref().unwrap();
             assert_eq!(panel_match.0.path_prefix, rel_path("repo1").into());
             assert_eq!(panel_match.0.path, rel_path("package.json").into());
+            assert_eq!(
+                panel_match.0.positions,
+                vec![6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]
+            );
         }
     });
 }

--- a/crates/file_finder/src/file_finder_tests.rs
+++ b/crates/file_finder/src/file_finder_tests.rs
@@ -2447,6 +2447,139 @@ async fn test_search_results_refreshed_on_adding_and_removing_worktrees(
 }
 
 #[gpui::test]
+async fn test_history_items_uniqueness_for_multiple_worktree_open_all_files(
+    cx: &mut TestAppContext,
+) {
+    let app_state = init_test(cx);
+    app_state
+        .fs
+        .as_fake()
+        .insert_tree(
+            path!("/repo1"),
+            json!({
+                "package.json": r#"{"name": "repo1"}"#,
+                "src": {
+                    "index.js": "// Repo 1 index",
+                }
+            }),
+        )
+        .await;
+
+    app_state
+        .fs
+        .as_fake()
+        .insert_tree(
+            path!("/repo2"),
+            json!({
+                "package.json": r#"{"name": "repo2"}"#,
+                "src": {
+                    "index.js": "// Repo 2 index",
+                }
+            }),
+        )
+        .await;
+
+    let project = Project::test(
+        app_state.fs.clone(),
+        [path!("/repo1").as_ref(), path!("/repo2").as_ref()],
+        cx,
+    )
+    .await;
+
+    let (workspace, cx) = cx.add_window_view(|window, cx| Workspace::test_new(project, window, cx));
+    let (worktree_id1, worktree_id2) = cx.read(|cx| {
+        let worktrees = workspace.read(cx).worktrees(cx).collect::<Vec<_>>();
+        (worktrees[0].read(cx).id(), worktrees[1].read(cx).id())
+    });
+
+    workspace
+        .update_in(cx, |workspace, window, cx| {
+            workspace.open_path(
+                ProjectPath {
+                    worktree_id: worktree_id1,
+                    path: rel_path("package.json").into(),
+                },
+                None,
+                true,
+                window,
+                cx,
+            )
+        })
+        .await
+        .unwrap();
+
+    cx.dispatch_action(workspace::CloseActiveItem {
+        save_intent: None,
+        close_pinned: false,
+    });
+    workspace
+        .update_in(cx, |workspace, window, cx| {
+            workspace.open_path(
+                ProjectPath {
+                    worktree_id: worktree_id2,
+                    path: rel_path("package.json").into(),
+                },
+                None,
+                true,
+                window,
+                cx,
+            )
+        })
+        .await
+        .unwrap();
+
+    cx.dispatch_action(workspace::CloseActiveItem {
+        save_intent: None,
+        close_pinned: false,
+    });
+
+    let picker = open_file_picker(&workspace, cx);
+    cx.simulate_input("package.json");
+
+    picker.update(cx, |finder, _| {
+        let matches = &finder.delegate.matches.matches;
+
+        assert_eq!(
+            matches.len(),
+            2,
+            "Expected 1 history match + 1 search matches, but got {} matches: {:?}",
+            matches.len(),
+            matches
+        );
+
+        assert_matches!(matches[0], Match::History { .. });
+
+        let search_matches = collect_search_matches(finder);
+        assert_eq!(
+            search_matches.history.len(),
+            2,
+            "Should have exactly 2 history match"
+        );
+        assert_eq!(
+            search_matches.search.len(),
+            0,
+            "Should have exactly 0 search match (because we already opened the 2 package.json)"
+        );
+
+        if let Match::History { path, panel_match } = &matches[0] {
+            assert_eq!(path.project.worktree_id, worktree_id2);
+            assert_eq!(path.project.path.as_ref(), rel_path("package.json"));
+            let panel_match = panel_match.as_ref().unwrap();
+            assert_eq!(panel_match.0.path_prefix, rel_path("repo2").into());
+            assert_eq!(panel_match.0.path, rel_path("package.json").into());
+        }
+
+        if let Match::History { path, panel_match } = &matches[1] {
+            assert_eq!(path.project.worktree_id, worktree_id1);
+            assert_eq!(path.project.path.as_ref(), rel_path("package.json"));
+            let panel_match = panel_match.as_ref().unwrap();
+            assert_eq!(panel_match.0.path_prefix, rel_path("repo1").into());
+            assert_eq!(panel_match.0.path, rel_path("package.json").into());
+        }
+    });
+}
+
+#[gpui::test]
 async fn test_selected_match_stays_selected_after_matches_refreshed(cx: &mut gpui::TestAppContext) {
     let app_state = init_test(cx);
 

--- a/crates/fuzzy/src/paths.rs
+++ b/crates/fuzzy/src/paths.rs
@@ -88,6 +88,7 @@ impl Ord for PathMatch {
 pub fn match_fixed_path_set(
     candidates: Vec<PathMatchCandidate>,
     worktree_id: usize,
+    worktree_root_name: Option<Arc<RelPath>>,
     query: &str,
     smart_case: bool,
     max_results: usize,
@@ -111,7 +112,10 @@ pub fn match_fixed_path_set(
             positions: positions.clone(),
             is_dir: candidate.is_dir,
             path: candidate.path.into(),
-            path_prefix: RelPath::empty().into(),
+            path_prefix: match worktree_root_name.clone() {
+                Some(worktree_root_name) => worktree_root_name,
+                None => RelPath::empty().into(),
+            },
             distance_to_relative_ancestor: usize::MAX,
         },
     );

--- a/crates/fuzzy/src/paths.rs
+++ b/crates/fuzzy/src/paths.rs
@@ -209,7 +209,7 @@ pub async fn match_path_sets<'a, Set: PathMatchCandidateSet<'a>>(
                             let worktree_id = candidate_set.id();
                             let mut prefix = candidate_set
                                 .prefix()
-                                .as_unix_str() // Would it be an issue here for windows ?
+                                .as_unix_str()
                                 .chars()
                                 .collect::<Vec<_>>();
                             if !candidate_set.root_is_file() && !prefix.is_empty() {

--- a/crates/fuzzy/src/paths.rs
+++ b/crates/fuzzy/src/paths.rs
@@ -101,17 +101,27 @@ pub fn match_fixed_path_set(
     let mut matcher = Matcher::new(&query, &lowercase_query, query_char_bag, smart_case, true);
 
     let mut results = Vec::with_capacity(candidates.len());
-    let path_prefix = match worktree_root_name {
-        Some(worktree_root_name) => worktree_root_name,
-        None => RelPath::empty().into(),
+    let (path_prefix, path_prefix_chars, lowercase_prefix) = match worktree_root_name {
+        Some(worktree_root_name) => {
+            let mut path_prefix_chars = worktree_root_name
+                .display(path_style)
+                .chars()
+                .collect::<Vec<_>>();
+            path_prefix_chars.extend(path_style.separator().chars());
+            let lowercase_pfx = path_prefix_chars
+                .iter()
+                .map(|c| c.to_ascii_lowercase())
+                .collect::<Vec<_>>();
+
+            (worktree_root_name, path_prefix_chars, lowercase_pfx)
+        }
+        None => (
+            RelPath::empty().into(),
+            Default::default(),
+            Default::default(),
+        ),
     };
 
-    let mut path_prefix_chars = path_prefix.display(path_style).chars().collect::<Vec<_>>();
-    path_prefix_chars.extend(path_style.separator().chars());
-    let lowercase_prefix = path_prefix_chars
-        .iter()
-        .map(|c| c.to_ascii_lowercase())
-        .collect::<Vec<_>>();
     matcher.match_candidates(
         &path_prefix_chars,
         &lowercase_prefix,


### PR DESCRIPTION
Closes #39865

Release Notes:

- Fixed file finder display when searching for files in history if you had several worktrees opened in a workspace. It now displays the worktree root name to avoid confusion if you have several files with same name in different worktrees.
