### PR TITLE
gpui: Do not use a single shared parker within a Dispatcher

### DIFF
--- a/crates/gpui/src/executor.rs
+++ b/crates/gpui/src/executor.rs
@@ -262,11 +262,14 @@ impl BackgroundExecutor {
         } else {
             usize::MAX
         };
+
         let parker = Parker::new();
         let unparker = parker.unparker();
+
         let awoken = Arc::new(AtomicBool::new(false));
         let waker = waker_fn({
             let awoken = awoken.clone();
+            let unparker = unparker.clone();
             move || {
                 awoken.store(true, SeqCst);
                 unparker.unpark();
@@ -305,6 +308,7 @@ impl BackgroundExecutor {
                                 "parked with nothing left to run{waiting_message}{backtrace_message}",
                             )
                         }
+                        dispatcher.set_unparker(unparker.clone());
                         parker.park();
                     }
                 }

--- a/crates/gpui/src/executor.rs
+++ b/crates/gpui/src/executor.rs
@@ -210,7 +210,8 @@ impl BackgroundExecutor {
         }
         let deadline = timeout.map(|timeout| Instant::now() + timeout);
 
-        let unparker = self.dispatcher.unparker();
+        let parker = parking::Parker::new();
+        let unparker = parker.unparker();
         let waker = waker_fn(move || {
             unparker.unpark();
         });
@@ -222,10 +223,14 @@ impl BackgroundExecutor {
                 Poll::Pending => {
                     let timeout =
                         deadline.map(|deadline| deadline.saturating_duration_since(Instant::now()));
-                    if !self.dispatcher.park(timeout)
-                        && deadline.is_some_and(|deadline| deadline < Instant::now())
-                    {
-                        return Err(future);
+                    if let Some(timeout) = timeout {
+                        if !parker.park_timeout(timeout)
+                            && deadline.is_some_and(|deadline| deadline < Instant::now())
+                        {
+                            return Err(future);
+                        }
+                    } else {
+                        parker.park();
                     }
                 }
             }
@@ -242,6 +247,8 @@ impl BackgroundExecutor {
     ) -> Result<Fut::Output, impl Future<Output = Fut::Output> + use<Fut>> {
         use std::sync::atomic::AtomicBool;
 
+        use parking::Parker;
+
         let mut future = Box::pin(future);
         if timeout == Some(Duration::ZERO) {
             return Err(future);
@@ -255,7 +262,8 @@ impl BackgroundExecutor {
         } else {
             usize::MAX
         };
-        let unparker = self.dispatcher.unparker();
+        let parker = Parker::new();
+        let unparker = parker.unparker();
         let awoken = Arc::new(AtomicBool::new(false));
         let waker = waker_fn({
             let awoken = awoken.clone();
@@ -297,7 +305,7 @@ impl BackgroundExecutor {
                                 "parked with nothing left to run{waiting_message}{backtrace_message}",
                             )
                         }
-                        self.dispatcher.park(None);
+                        parker.park();
                     }
                 }
             }

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -48,7 +48,6 @@ use async_task::Runnable;
 use futures::channel::oneshot;
 use image::codecs::gif::GifDecoder;
 use image::{AnimationDecoder as _, Frame};
-use parking::Unparker;
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
 use schemars::JsonSchema;
 use seahash::SeaHasher;
@@ -564,8 +563,6 @@ pub trait PlatformDispatcher: Send + Sync {
     fn dispatch(&self, runnable: Runnable, label: Option<TaskLabel>);
     fn dispatch_on_main_thread(&self, runnable: Runnable);
     fn dispatch_after(&self, duration: Duration, runnable: Runnable);
-    fn park(&self, timeout: Option<Duration>) -> bool;
-    fn unparker(&self) -> Unparker;
     fn now(&self) -> Instant {
         Instant::now()
     }

--- a/crates/gpui/src/platform/mac/dispatcher.rs
+++ b/crates/gpui/src/platform/mac/dispatcher.rs
@@ -9,12 +9,9 @@ use objc::{
     runtime::{BOOL, YES},
     sel, sel_impl,
 };
-use parking::{Parker, Unparker};
-use parking_lot::Mutex;
 use std::{
     ffi::c_void,
     ptr::{NonNull, addr_of},
-    sync::Arc,
     time::Duration,
 };
 
@@ -29,23 +26,7 @@ pub(crate) fn dispatch_get_main_queue() -> dispatch_queue_t {
     addr_of!(_dispatch_main_q) as *const _ as dispatch_queue_t
 }
 
-pub(crate) struct MacDispatcher {
-    parker: Arc<Mutex<Parker>>,
-}
-
-impl Default for MacDispatcher {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl MacDispatcher {
-    pub fn new() -> Self {
-        MacDispatcher {
-            parker: Arc::new(Mutex::new(Parker::new())),
-        }
-    }
-}
+pub(crate) struct MacDispatcher;
 
 impl PlatformDispatcher for MacDispatcher {
     fn is_main_thread(&self) -> bool {
@@ -85,19 +66,6 @@ impl PlatformDispatcher for MacDispatcher {
                 Some(trampoline),
             );
         }
-    }
-
-    fn park(&self, timeout: Option<Duration>) -> bool {
-        if let Some(timeout) = timeout {
-            self.parker.lock().park_timeout(timeout)
-        } else {
-            self.parker.lock().park();
-            true
-        }
-    }
-
-    fn unparker(&self) -> Unparker {
-        self.parker.lock().unparker()
     }
 }
 

--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -187,7 +187,7 @@ impl Default for MacPlatform {
 
 impl MacPlatform {
     pub(crate) fn new(headless: bool) -> Self {
-        let dispatcher = Arc::new(MacDispatcher::new());
+        let dispatcher = Arc::new(MacDispatcher);
 
         #[cfg(feature = "font-kit")]
         let text_system = Arc::new(crate::MacTextSystem::new());

--- a/crates/gpui/src/platform/mac/text_system.rs
+++ b/crates/gpui/src/platform/mac/text_system.rs
@@ -450,7 +450,6 @@ impl MacTextSystemState {
                 // to prevent core text from forming ligatures between them
                 let needs_zwnj = last_font_run.replace(run.font_id) == Some(run.font_id);
 
-                let n_zwnjs = self.zwnjs_scratch_space.len(); // from previous loop
                 let utf16_start = string.char_len(); // insert at end of string
                 ix_converter.advance_to_utf8_ix(ix_converter.utf8_ix + run.len);
 

--- a/crates/gpui/src/platform/test/dispatcher.rs
+++ b/crates/gpui/src/platform/test/dispatcher.rs
@@ -2,6 +2,7 @@ use crate::{PlatformDispatcher, TaskLabel};
 use async_task::Runnable;
 use backtrace::Backtrace;
 use collections::{HashMap, HashSet, VecDeque};
+use parking::Unparker;
 use parking_lot::Mutex;
 use rand::prelude::*;
 use std::{
@@ -38,6 +39,7 @@ struct TestDispatcherState {
     waiting_backtrace: Option<Backtrace>,
     deprioritized_task_labels: HashSet<TaskLabel>,
     block_on_ticks: RangeInclusive<usize>,
+    last_parked: Option<Unparker>,
 }
 
 impl TestDispatcher {
@@ -57,6 +59,7 @@ impl TestDispatcher {
             waiting_backtrace: None,
             deprioritized_task_labels: Default::default(),
             block_on_ticks: 0..=1000,
+            last_parked: None,
         };
 
         TestDispatcher {
@@ -237,6 +240,21 @@ impl TestDispatcher {
         let block_on_ticks = lock.block_on_ticks.clone();
         lock.random.random_range(block_on_ticks)
     }
+    pub fn unpark_last(&self) {
+        self.state
+            .lock()
+            .last_parked
+            .take()
+            .as_ref()
+            .map(Unparker::unpark);
+    }
+
+    pub fn set_unparker(&self, unparker: Unparker) {
+        let last = { self.state.lock().last_parked.replace(unparker) };
+        if let Some(last) = last {
+            last.unpark();
+        }
+    }
 }
 
 impl Clone for TestDispatcher {
@@ -268,6 +286,7 @@ impl PlatformDispatcher for TestDispatcher {
                 state.background.push(runnable);
             }
         }
+        self.unpark_last();
     }
 
     fn dispatch_on_main_thread(&self, runnable: Runnable) {
@@ -277,6 +296,7 @@ impl PlatformDispatcher for TestDispatcher {
             .entry(self.id)
             .or_default()
             .push_back(runnable);
+        self.unpark_last();
     }
 
     fn dispatch_after(&self, duration: std::time::Duration, runnable: Runnable) {


### PR DESCRIPTION
This caused issues with #40172, as it made Zed execute and block on tad
few more background tasks. Parker is ~cheap to create, hence we should
be ok to just create it at the time it is needed.

Release Notes:

- N/A
