### PR TITLE
Bind `ctrl-c` and `ctrl-v` in the windows terminal

### DIFF
--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -1117,6 +1117,7 @@
       "ctrl-insert": "terminal::Copy",
       "ctrl-shift-c": "terminal::Copy",
       "shift-insert": "terminal::Paste",
+      "ctrl-v": "terminal::Paste",
       "ctrl-shift-v": "terminal::Paste",
       "ctrl-i": "assistant::InlineAssist",
       "alt-b": ["terminal::SendText", "\u001bb"],
@@ -1151,6 +1152,12 @@
       "ctrl-shift-r": "terminal::RerunTask",
       "ctrl-alt-r": "terminal::RerunTask",
       "alt-t": "terminal::RerunTask"
+    }
+  },
+  {
+    "context": "Terminal && selection",
+    "bindings": {
+      "ctrl-c": "terminal::Copy"
     }
   },
   {


### PR DESCRIPTION
Fixes #40034

Release Notes:

- `ctrl-c` (when you have a selection) and `ctrl-v` are now bound to copy and paste by default in the windows terminal.