### PR TITLE
project_panel: Add granular `auto-open` file settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13078,6 +13078,7 @@ dependencies = [
  "settings",
  "smallvec",
  "telemetry",
+ "tempfile",
  "theme",
  "ui",
  "util",

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -748,13 +748,13 @@
     "hide_root": false,
     // Whether to hide the hidden entries in the project panel.
     "hide_hidden": false,
-    // Settings for automatically opening files in various operations.
+    // Settings for automatically opening files.
     "auto_open": {
-      // Automatically open newly created files in the editor
+      // Whether to automatically open newly created files in the editor.
       "on_create": true,
-      // Automatically open files after pasting or duplicating them
-      "on_paste": false,
-      // Automatically open files dropped from external sources
+      // Whether to automatically open files after pasting or duplicating them.
+      "on_paste": true,
+      // Whether to automatically open files dropped from external sources.
       "on_drop": true
     }
   },

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -748,8 +748,15 @@
     "hide_root": false,
     // Whether to hide the hidden entries in the project panel.
     "hide_hidden": false,
-    // Whether to automatically open files when pasting them in the project panel.
-    "open_file_on_paste": true
+    // Settings for automatically opening files in various operations.
+    "auto_open": {
+      // Automatically open newly created files in the editor
+      "on_create": true,
+      // Automatically open files after pasting or duplicating them
+      "on_paste": false,
+      // Automatically open files dropped from external sources
+      "on_drop": true
+    }
   },
   "outline_panel": {
     // Whether to show the outline panel button in the status bar

--- a/crates/migrator/src/migrations.rs
+++ b/crates/migrator/src/migrations.rs
@@ -135,3 +135,9 @@ pub(crate) mod m_2025_10_21 {
 
     pub(crate) use settings::make_relative_line_numbers_an_enum;
 }
+
+pub(crate) mod m_2025_11_12 {
+    mod settings;
+
+    pub(crate) use settings::SETTINGS_PATTERNS;
+}

--- a/crates/migrator/src/migrations/m_2025_11_12/settings.rs
+++ b/crates/migrator/src/migrations/m_2025_11_12/settings.rs
@@ -1,0 +1,84 @@
+use std::ops::Range;
+use tree_sitter::{Query, QueryMatch};
+
+use crate::MigrationPatterns;
+use crate::patterns::SETTINGS_NESTED_KEY_VALUE_PATTERN;
+
+pub const SETTINGS_PATTERNS: MigrationPatterns = &[
+    (
+        SETTINGS_NESTED_KEY_VALUE_PATTERN,
+        rename_open_file_on_paste_setting,
+    ),
+    (
+        SETTINGS_NESTED_KEY_VALUE_PATTERN,
+        replace_open_file_on_paste_setting_value,
+    ),
+];
+
+fn rename_open_file_on_paste_setting(
+    contents: &str,
+    mat: &QueryMatch,
+    query: &Query,
+) -> Option<(Range<usize>, String)> {
+    if !is_project_panel_open_file_on_paste(contents, mat, query) {
+        return None;
+    }
+
+    let setting_name_ix = query.capture_index_for_name("setting_name")?;
+    let setting_name_range = mat
+        .nodes_for_capture_index(setting_name_ix)
+        .next()?
+        .byte_range();
+
+    Some((setting_name_range, "auto_open".to_string()))
+}
+
+fn replace_open_file_on_paste_setting_value(
+    contents: &str,
+    mat: &QueryMatch,
+    query: &Query,
+) -> Option<(Range<usize>, String)> {
+    if !is_project_panel_open_file_on_paste(contents, mat, query) {
+        return None;
+    }
+
+    let value_ix = query.capture_index_for_name("setting_value")?;
+    let value_node = mat.nodes_for_capture_index(value_ix).next()?;
+    let value_range = value_node.byte_range();
+    let value_text = contents.get(value_range.clone())?.trim();
+
+    let normalized_value = match value_text {
+        "true" => "true",
+        "false" => "false",
+        _ => return None,
+    };
+
+    Some((
+        value_range,
+        format!("{{ \"on_paste\": {normalized_value} }}"),
+    ))
+}
+
+fn is_project_panel_open_file_on_paste(contents: &str, mat: &QueryMatch, query: &Query) -> bool {
+    let parent_key_ix = match query.capture_index_for_name("parent_key") {
+        Some(ix) => ix,
+        None => return false,
+    };
+    let parent_range = match mat.nodes_for_capture_index(parent_key_ix).next() {
+        Some(node) => node.byte_range(),
+        None => return false,
+    };
+    if contents.get(parent_range) != Some("project_panel") {
+        return false;
+    }
+
+    let setting_name_ix = match query.capture_index_for_name("setting_name") {
+        Some(ix) => ix,
+        None => return false,
+    };
+    let setting_name_range = match mat.nodes_for_capture_index(setting_name_ix).next() {
+        Some(node) => node.byte_range(),
+        None => return false,
+    };
+    contents.get(setting_name_range) == Some("open_file_on_paste")
+}

--- a/crates/migrator/src/migrator.rs
+++ b/crates/migrator/src/migrator.rs
@@ -2217,7 +2217,7 @@ mod tests {
                 &r#"
                 {
                     "project_panel": {
-                        "auto_open": {"on_paste": true}
+                        "auto_open": { "on_paste": true }
                     }
                 }
                 "#
@@ -2238,7 +2238,7 @@ mod tests {
                 &r#"
                 {
                     "project_panel": {
-                        "auto_open": {"on_paste": false}
+                        "auto_open": { "on_paste": false }
                     }
                 }
                 "#

--- a/crates/migrator/src/migrator.rs
+++ b/crates/migrator/src/migrator.rs
@@ -215,6 +215,10 @@ pub fn migrate_settings(text: &str) -> Result<Option<String>> {
         MigrationType::Json(migrations::m_2025_10_16::restore_code_actions_on_format),
         MigrationType::Json(migrations::m_2025_10_17::make_file_finder_include_ignored_an_enum),
         MigrationType::Json(migrations::m_2025_10_21::make_relative_line_numbers_an_enum),
+        MigrationType::TreeSitter(
+            migrations::m_2025_11_12::SETTINGS_PATTERNS,
+            &SETTINGS_QUERY_2025_11_12,
+        ),
     ];
     run_migrations(text, migrations)
 }
@@ -332,6 +336,10 @@ define_query!(
 define_query!(
     SETTINGS_QUERY_2025_10_03,
     migrations::m_2025_10_03::SETTINGS_PATTERNS
+);
+define_query!(
+    SETTINGS_QUERY_2025_11_12,
+    migrations::m_2025_11_12::SETTINGS_PATTERNS
 );
 
 // custom query
@@ -2189,6 +2197,51 @@ mod tests {
                         "include_ignored": "smart"
                     }
                 }"#
+                .unindent(),
+            ),
+        );
+    }
+
+    #[test]
+    fn test_project_panel_open_file_on_paste_migration() {
+        assert_migrate_settings(
+            &r#"
+            {
+                "project_panel": {
+                    "open_file_on_paste": true
+                }
+            }
+            "#
+            .unindent(),
+            Some(
+                &r#"
+                {
+                    "project_panel": {
+                        "auto_open": {"on_paste": true}
+                    }
+                }
+                "#
+                .unindent(),
+            ),
+        );
+
+        assert_migrate_settings(
+            &r#"
+            {
+                "project_panel": {
+                    "open_file_on_paste": false
+                }
+            }
+            "#
+            .unindent(),
+            Some(
+                &r#"
+                {
+                    "project_panel": {
+                        "auto_open": {"on_paste": false}
+                    }
+                }
+                "#
                 .unindent(),
             ),
         );

--- a/crates/project_panel/Cargo.toml
+++ b/crates/project_panel/Cargo.toml
@@ -53,4 +53,5 @@ editor = { workspace = true, features = ["test-support"] }
 gpui = { workspace = true, features = ["test-support"] }
 language = { workspace = true, features = ["test-support"] }
 serde_json.workspace = true
+tempfile.workspace = true
 workspace = { workspace = true, features = ["test-support"] }

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1655,7 +1655,10 @@ impl ProjectPanel {
                             }
                         project_panel.update_visible_entries(None, false, false, window, cx);
                         if is_new_entry && !is_dir {
-                            project_panel.open_entry(new_entry.id, true, false, cx);
+                            let settings = ProjectPanelSettings::get_global(cx);
+                            if settings.auto_open.should_open_on_create() {
+                                project_panel.open_entry(new_entry.id, true, false, cx);
+                            }
                         }
                         cx.notify();
                     })?;
@@ -2708,16 +2711,16 @@ impl ProjectPanel {
                             });
 
                             if item_count == 1 {
-                                // open entry if not dir, setting is enabled, and only focus if rename is not pending
-                                if !entry.is_dir()
-                                    && ProjectPanelSettings::get_global(cx).open_file_on_paste
-                                {
-                                    project_panel.open_entry(
-                                        entry.id,
-                                        disambiguation_range.is_none(),
-                                        false,
-                                        cx,
-                                    );
+                                if !entry.is_dir() {
+                                    let settings = ProjectPanelSettings::get_global(cx);
+                                    if settings.auto_open.should_open_on_paste() {
+                                        project_panel.open_entry(
+                                            entry.id,
+                                            disambiguation_range.is_none(),
+                                            false,
+                                            cx,
+                                        );
+                                    }
                                 }
 
                                 // if only one entry was pasted and it was disambiguated, open the rename editor
@@ -3592,11 +3595,13 @@ impl ProjectPanel {
 
                 let opened_entries = task.await.with_context(|| "failed to copy external paths")?;
                 this.update(cx, |this, cx| {
-                    if open_file_after_drop && !opened_entries.is_empty() {
+                if open_file_after_drop && !opened_entries.is_empty() {
+                    let settings = ProjectPanelSettings::get_global(cx);
+                    if settings.auto_open.should_open_on_drop() {
                         this.open_entry(opened_entries[0], true, false, cx);
                     }
-                })
-            }
+                }
+            })
             .log_err().await
         })
         .detach();

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -2711,6 +2711,7 @@ impl ProjectPanel {
                             });
 
                             if item_count == 1 {
+                                // open entry if not dir, setting is enabled, and only focus if rename is not pending
                                 if !entry.is_dir() {
                                     let settings = ProjectPanelSettings::get_global(cx);
                                     if settings.auto_open.should_open_on_paste() {
@@ -3595,13 +3596,14 @@ impl ProjectPanel {
 
                 let opened_entries = task.await.with_context(|| "failed to copy external paths")?;
                 this.update(cx, |this, cx| {
-                if open_file_after_drop && !opened_entries.is_empty() {
-                    let settings = ProjectPanelSettings::get_global(cx);
-                    if settings.auto_open.should_open_on_drop() {
-                        this.open_entry(opened_entries[0], true, false, cx);
+                    if open_file_after_drop && !opened_entries.is_empty() {
+                        let settings = ProjectPanelSettings::get_global(cx);
+                        if settings.auto_open.should_open_on_drop() {
+                            this.open_entry(opened_entries[0], true, false, cx);
+                        }
                     }
-                }
-            })
+                })
+            }
             .log_err().await
         })
         .detach();

--- a/crates/project_panel/src/project_panel_settings.rs
+++ b/crates/project_panel/src/project_panel_settings.rs
@@ -32,7 +32,7 @@ pub struct ProjectPanelSettings {
     pub hide_root: bool,
     pub hide_hidden: bool,
     pub drag_and_drop: bool,
-    pub open_file_on_paste: bool,
+    pub auto_open: AutoOpenSettings,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -46,6 +46,30 @@ pub struct ScrollbarSettings {
     ///
     /// Default: inherits editor scrollbar settings
     pub show: Option<ShowScrollbar>,
+}
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct AutoOpenSettings {
+    pub on_create: bool,
+    pub on_paste: bool,
+    pub on_drop: bool,
+}
+
+impl AutoOpenSettings {
+    #[inline]
+    pub fn should_open_on_create(self) -> bool {
+        self.on_create
+    }
+
+    #[inline]
+    pub fn should_open_on_paste(self) -> bool {
+        self.on_paste
+    }
+
+    #[inline]
+    pub fn should_open_on_drop(self) -> bool {
+        self.on_drop
+    }
 }
 
 impl ScrollbarVisibility for ProjectPanelSettings {
@@ -83,7 +107,52 @@ impl Settings for ProjectPanelSettings {
             hide_root: project_panel.hide_root.unwrap(),
             hide_hidden: project_panel.hide_hidden.unwrap(),
             drag_and_drop: project_panel.drag_and_drop.unwrap(),
-            open_file_on_paste: project_panel.open_file_on_paste.unwrap(),
+            auto_open: {
+                let auto_open = project_panel.auto_open.unwrap();
+                AutoOpenSettings {
+                    on_create: auto_open.on_create.unwrap(),
+                    on_paste: auto_open.on_paste.unwrap(),
+                    on_drop: auto_open.on_drop.unwrap(),
+                }
+            },
+        }
+    }
+
+    fn import_from_vscode(
+        vscode: &settings::VsCodeSettings,
+        current: &mut settings::SettingsContent,
+    ) {
+        if let Some(hide_gitignore) = vscode.read_bool("explorer.excludeGitIgnore") {
+            current.project_panel.get_or_insert_default().hide_gitignore = Some(hide_gitignore);
+        }
+        if let Some(auto_reveal) = vscode.read_bool("explorer.autoReveal") {
+            current
+                .project_panel
+                .get_or_insert_default()
+                .auto_reveal_entries = Some(auto_reveal);
+        }
+        if let Some(compact_folders) = vscode.read_bool("explorer.compactFolders") {
+            current.project_panel.get_or_insert_default().auto_fold_dirs = Some(compact_folders);
+        }
+
+        if Some(false) == vscode.read_bool("git.decorations.enabled") {
+            current.project_panel.get_or_insert_default().git_status = Some(false);
+        }
+        if Some(false) == vscode.read_bool("problems.decorations.enabled") {
+            current
+                .project_panel
+                .get_or_insert_default()
+                .show_diagnostics = Some(ShowDiagnostics::Off);
+        }
+        if let (Some(false), Some(false)) = (
+            vscode.read_bool("explorer.decorations.badges"),
+            vscode.read_bool("explorer.decorations.colors"),
+        ) {
+            current.project_panel.get_or_insert_default().git_status = Some(false);
+            current
+                .project_panel
+                .get_or_insert_default()
+                .show_diagnostics = Some(ShowDiagnostics::Off);
         }
     }
 }

--- a/crates/project_panel/src/project_panel_settings.rs
+++ b/crates/project_panel/src/project_panel_settings.rs
@@ -117,42 +117,4 @@ impl Settings for ProjectPanelSettings {
             },
         }
     }
-
-    fn import_from_vscode(
-        vscode: &settings::VsCodeSettings,
-        current: &mut settings::SettingsContent,
-    ) {
-        if let Some(hide_gitignore) = vscode.read_bool("explorer.excludeGitIgnore") {
-            current.project_panel.get_or_insert_default().hide_gitignore = Some(hide_gitignore);
-        }
-        if let Some(auto_reveal) = vscode.read_bool("explorer.autoReveal") {
-            current
-                .project_panel
-                .get_or_insert_default()
-                .auto_reveal_entries = Some(auto_reveal);
-        }
-        if let Some(compact_folders) = vscode.read_bool("explorer.compactFolders") {
-            current.project_panel.get_or_insert_default().auto_fold_dirs = Some(compact_folders);
-        }
-
-        if Some(false) == vscode.read_bool("git.decorations.enabled") {
-            current.project_panel.get_or_insert_default().git_status = Some(false);
-        }
-        if Some(false) == vscode.read_bool("problems.decorations.enabled") {
-            current
-                .project_panel
-                .get_or_insert_default()
-                .show_diagnostics = Some(ShowDiagnostics::Off);
-        }
-        if let (Some(false), Some(false)) = (
-            vscode.read_bool("explorer.decorations.badges"),
-            vscode.read_bool("explorer.decorations.colors"),
-        ) {
-            current.project_panel.get_or_insert_default().git_status = Some(false);
-            current
-                .project_panel
-                .get_or_insert_default()
-                .show_diagnostics = Some(ShowDiagnostics::Off);
-        }
-    }
 }

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -2194,7 +2194,7 @@ async fn test_auto_open_on_drop_when_enabled(cx: &mut gpui::TestAppContext) {
 
     let root_entry = find_project_entry(&panel, "root", cx).unwrap();
     panel.update_in(cx, |panel, window, cx| {
-        panel.drop_external_files(&vec![external_path.clone()], root_entry, window, cx);
+        panel.drop_external_files(std::slice::from_ref(&external_path), root_entry, window, cx);
     });
     cx.executor().run_until_parked();
 
@@ -2229,7 +2229,7 @@ async fn test_auto_open_on_drop_when_disabled(cx: &mut gpui::TestAppContext) {
 
     let root_entry = find_project_entry(&panel, "root", cx).unwrap();
     panel.update_in(cx, |panel, window, cx| {
-        panel.drop_external_files(&vec![external_path.clone()], root_entry, window, cx);
+        panel.drop_external_files(std::slice::from_ref(&external_path), root_entry, window, cx);
     });
     cx.executor().run_until_parked();
 

--- a/crates/settings/src/settings_content/workspace.rs
+++ b/crates/settings/src/settings_content/workspace.rs
@@ -511,7 +511,7 @@ impl OnLastWindowClosed {
 }
 
 #[skip_serializing_none]
-#[derive(Copy, Clone, Debug, Default, Serialize, Deserialize, JsonSchema, MergeFrom, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Default, Serialize, Deserialize, JsonSchema, MergeFrom, Debug)]
 pub struct ProjectPanelAutoOpenSettings {
     /// Whether to automatically open newly created files in the editor.
     ///
@@ -519,7 +519,7 @@ pub struct ProjectPanelAutoOpenSettings {
     pub on_create: Option<bool>,
     /// Whether to automatically open files after pasting or duplicating them.
     ///
-    /// Default: false
+    /// Default: true
     pub on_paste: Option<bool>,
     /// Whether to automatically open files dropped from external sources.
     ///
@@ -607,7 +607,7 @@ pub struct ProjectPanelSettingsContent {
     ///
     /// Default: true
     pub drag_and_drop: Option<bool>,
-    /// Settings for automatically opening files in various operations.
+    /// Settings for automatically opening files.
     pub auto_open: Option<ProjectPanelAutoOpenSettings>,
 }
 

--- a/crates/settings/src/settings_content/workspace.rs
+++ b/crates/settings/src/settings_content/workspace.rs
@@ -511,6 +511,23 @@ impl OnLastWindowClosed {
 }
 
 #[skip_serializing_none]
+#[derive(Copy, Clone, Debug, Default, Serialize, Deserialize, JsonSchema, MergeFrom, PartialEq, Eq)]
+pub struct ProjectPanelAutoOpenSettings {
+    /// Whether to automatically open newly created files in the editor.
+    ///
+    /// Default: true
+    pub on_create: Option<bool>,
+    /// Whether to automatically open files after pasting or duplicating them.
+    ///
+    /// Default: false
+    pub on_paste: Option<bool>,
+    /// Whether to automatically open files dropped from external sources.
+    ///
+    /// Default: true
+    pub on_drop: Option<bool>,
+}
+
+#[skip_serializing_none]
 #[derive(Clone, PartialEq, Default, Serialize, Deserialize, JsonSchema, MergeFrom, Debug)]
 pub struct ProjectPanelSettingsContent {
     /// Whether to show the project panel button in the status bar.
@@ -590,10 +607,8 @@ pub struct ProjectPanelSettingsContent {
     ///
     /// Default: true
     pub drag_and_drop: Option<bool>,
-    /// Whether to automatically open files when pasting them in the project panel.
-    ///
-    /// Default: true
-    pub open_file_on_paste: Option<bool>,
+    /// Settings for automatically opening files in various operations.
+    pub auto_open: Option<ProjectPanelAutoOpenSettings>,
 }
 
 #[derive(

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -664,7 +664,6 @@ impl VsCodeSettings {
             hide_root: None,
             indent_guides: None,
             indent_size: None,
-            open_file_on_paste: None,
             scrollbar: None,
             show_diagnostics: self
                 .read_bool("problems.decorations.enabled")

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -670,6 +670,7 @@ impl VsCodeSettings {
                 .and_then(|b| if b { Some(ShowDiagnostics::Off) } else { None }),
             starts_open: None,
             sticky_scroll: None,
+            auto_open: None,
         };
 
         if let (Some(false), Some(false)) = (

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -3784,15 +3784,7 @@ pub(crate) fn settings_data(cx: &App) -> Vec<SettingsPage> {
                     field: Box::new(SettingField {
                         json_path: Some("project_panel.open_file_on_paste"),
                         pick: |settings_content| {
-                            if let Some(project_panel) = &settings_content.project_panel {
-                                if let Some(auto_open) = &project_panel.auto_open {
-                                    &auto_open.on_create
-                                } else {
-                                    &None
-                                }
-                            } else {
-                                &None
-                            }
+                            settings_content.project_panel.as_ref()?.auto_open.as_ref()?.on_create.as_ref()
                         },
                         write: |settings_content, value| {
                             settings_content.project_panel.get_or_insert_default().auto_open.get_or_insert_default().on_create = value;
@@ -3806,15 +3798,7 @@ pub(crate) fn settings_data(cx: &App) -> Vec<SettingsPage> {
                     description: "Automatically open files after pasting or duplicating them in the project panel",
                     field: Box::new(SettingField {
                         pick: |settings_content| {
-                            if let Some(project_panel) = &settings_content.project_panel {
-                                if let Some(auto_open) = &project_panel.auto_open {
-                                    &auto_open.on_paste
-                                } else {
-                                    &None
-                                }
-                            } else {
-                                &None
-                            }
+                            settings_content.project_panel.as_ref()?.auto_open.as_ref()?.on_paste.as_ref()
                         },
                         write: |settings_content, value| {
                             settings_content.project_panel.get_or_insert_default().auto_open.get_or_insert_default().on_paste = value;
@@ -3828,15 +3812,7 @@ pub(crate) fn settings_data(cx: &App) -> Vec<SettingsPage> {
                     description: "Automatically open files dropped from external sources into the project panel",
                     field: Box::new(SettingField {
                         pick: |settings_content| {
-                            if let Some(project_panel) = &settings_content.project_panel {
-                                if let Some(auto_open) = &project_panel.auto_open {
-                                    &auto_open.on_drop
-                                } else {
-                                    &None
-                                }
-                            } else {
-                                &None
-                            }
+                            settings_content.project_panel.as_ref()?.auto_open.as_ref()?.on_drop.as_ref()
                         },
                         write: |settings_content, value| {
                             settings_content.project_panel.get_or_insert_default().auto_open.get_or_insert_default().on_drop = value;

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -3758,8 +3758,6 @@ pub(crate) fn settings_data(cx: &App) -> Vec<SettingsPage> {
                     metadata: None,
                     files: USER,
                 }),
-
-                SettingsPageItem::SectionHeader("Auto Open Files"),
                 SettingsPageItem::SettingItem(SettingItem {
                     title: "Hidden Files",
                     description: "Globs to match files that will be considered \"hidden\" and can be hidden from the project panel.",
@@ -3778,11 +3776,12 @@ pub(crate) fn settings_data(cx: &App) -> Vec<SettingsPage> {
                     metadata: None,
                     files: USER,
                 }),
+                SettingsPageItem::SectionHeader("Auto Open Files"),
                 SettingsPageItem::SettingItem(SettingItem {
                     title: "On Create",
-                    description: "Automatically open newly created files in the editor",
+                    description: "Whether to automatically open newly created files in the editor.",
                     field: Box::new(SettingField {
-                        json_path: Some("project_panel.open_file_on_paste"),
+                        json_path: Some("project_panel.auto_open.on_create"),
                         pick: |settings_content| {
                             settings_content.project_panel.as_ref()?.auto_open.as_ref()?.on_create.as_ref()
                         },
@@ -3795,8 +3794,9 @@ pub(crate) fn settings_data(cx: &App) -> Vec<SettingsPage> {
                 }),
                 SettingsPageItem::SettingItem(SettingItem {
                     title: "On Paste",
-                    description: "Automatically open files after pasting or duplicating them in the project panel",
+                    description: "Whether to automatically open files after pasting or duplicating them.",
                     field: Box::new(SettingField {
+                        json_path: Some("project_panel.auto_open.on_paste"),
                         pick: |settings_content| {
                             settings_content.project_panel.as_ref()?.auto_open.as_ref()?.on_paste.as_ref()
                         },
@@ -3809,8 +3809,9 @@ pub(crate) fn settings_data(cx: &App) -> Vec<SettingsPage> {
                 }),
                 SettingsPageItem::SettingItem(SettingItem {
                     title: "On Drop",
-                    description: "Automatically open files dropped from external sources into the project panel",
+                    description: "Whether to automatically open files dropped from external sources.",
                     field: Box::new(SettingField {
+                        json_path: Some("project_panel.auto_open.on_drop"),
                         pick: |settings_content| {
                             settings_content.project_panel.as_ref()?.auto_open.as_ref()?.on_drop.as_ref()
                         },

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -3758,6 +3758,8 @@ pub(crate) fn settings_data(cx: &App) -> Vec<SettingsPage> {
                     metadata: None,
                     files: USER,
                 }),
+
+                SettingsPageItem::SectionHeader("Auto Open Files"),
                 SettingsPageItem::SettingItem(SettingItem {
                     title: "Hidden Files",
                     description: "Globs to match files that will be considered \"hidden\" and can be hidden from the project panel.",
@@ -3777,22 +3779,67 @@ pub(crate) fn settings_data(cx: &App) -> Vec<SettingsPage> {
                     files: USER,
                 }),
                 SettingsPageItem::SettingItem(SettingItem {
-                    title: "Open File on Paste",
-                    description: "Whether to automatically open files when pasting them in the project panel.",
+                    title: "On Create",
+                    description: "Automatically open newly created files in the editor",
                     field: Box::new(SettingField {
                         json_path: Some("project_panel.open_file_on_paste"),
                         pick: |settings_content| {
-                            settings_content
-                                .project_panel
-                                .as_ref()?
-                                .open_file_on_paste
-                                .as_ref()
+                            if let Some(project_panel) = &settings_content.project_panel {
+                                if let Some(auto_open) = &project_panel.auto_open {
+                                    &auto_open.on_create
+                                } else {
+                                    &None
+                                }
+                            } else {
+                                &None
+                            }
                         },
                         write: |settings_content, value| {
-                            settings_content
-                                .project_panel
-                                .get_or_insert_default()
-                                .open_file_on_paste = value;
+                            settings_content.project_panel.get_or_insert_default().auto_open.get_or_insert_default().on_create = value;
+                        },
+                    }),
+                    metadata: None,
+                    files: USER,
+                }),
+                SettingsPageItem::SettingItem(SettingItem {
+                    title: "On Paste",
+                    description: "Automatically open files after pasting or duplicating them in the project panel",
+                    field: Box::new(SettingField {
+                        pick: |settings_content| {
+                            if let Some(project_panel) = &settings_content.project_panel {
+                                if let Some(auto_open) = &project_panel.auto_open {
+                                    &auto_open.on_paste
+                                } else {
+                                    &None
+                                }
+                            } else {
+                                &None
+                            }
+                        },
+                        write: |settings_content, value| {
+                            settings_content.project_panel.get_or_insert_default().auto_open.get_or_insert_default().on_paste = value;
+                        },
+                    }),
+                    metadata: None,
+                    files: USER,
+                }),
+                SettingsPageItem::SettingItem(SettingItem {
+                    title: "On Drop",
+                    description: "Automatically open files dropped from external sources into the project panel",
+                    field: Box::new(SettingField {
+                        pick: |settings_content| {
+                            if let Some(project_panel) = &settings_content.project_panel {
+                                if let Some(auto_open) = &project_panel.auto_open {
+                                    &auto_open.on_drop
+                                } else {
+                                    &None
+                                }
+                            } else {
+                                &None
+                            }
+                        },
+                        write: |settings_content, value| {
+                            settings_content.project_panel.get_or_insert_default().auto_open.get_or_insert_default().on_drop = value;
                         },
                     }),
                     metadata: None,

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -4279,7 +4279,7 @@ Run the {#action theme_selector::Toggle} action in the command palette to see a 
     "hide_root": false,
     "hide_hidden": false,
     "starts_open": true,
-    "open_file_on_paste": true
+
   }
 }
 ```
@@ -4487,6 +4487,104 @@ Run the {#action theme_selector::Toggle} action in the command palette to see a 
   }
 }
 ```
+
+### Auto Open Files
+
+- Description: Control when files are automatically opened in the editor during various project panel operations
+- Setting: `auto_open`
+- Default:
+
+```json [settings]
+{
+  "auto_open": {
+    "on_create": true,
+    "on_paste": false,
+    "on_drop": true
+  }
+}
+```
+
+**Sub-settings**
+
+#### On Create
+
+Whether to automatically open newly created files in the editor. When enabled, files created via the "New File" action will open immediately in the editor.
+
+**Options**
+
+1. Enable auto-open on create (default)
+
+```json [settings]
+{
+  "auto_open": {
+    "on_create": true
+  }
+}
+```
+
+2. Disable auto-open on create
+
+```json [settings]
+{
+  "auto_open": {
+    "on_create": false
+  }
+}
+```
+
+#### On Paste
+
+Whether to automatically open files after pasting or duplicating them in the project panel. When disabled (default), this prevents auto-opening of potentially problematic files like binary files or fonts that may cause errors.
+
+**Options**
+
+1. Disable auto-open on paste (default - prevents binary file errors)
+
+```json [settings]
+{
+  "auto_open": {
+    "on_paste": false
+  }
+}
+```
+
+2. Enable auto-open on paste
+
+```json [settings]
+{
+  "auto_open": {
+    "on_paste": true
+  }
+}
+```
+
+#### On Drop
+
+Whether to automatically open files dropped from external sources (e.g., from file explorer, desktop). When enabled (default), the first file dropped will open in the editor.
+
+**Options**
+
+1. Enable auto-open on drop (default)
+
+```json [settings]
+{
+  "auto_open": {
+    "on_drop": true
+  }
+}
+```
+
+2. Disable auto-open on drop
+
+```json [settings]
+{
+  "auto_open": {
+    "on_drop": false
+  }
+}
+```
+
+**Note**: These settings control when files open, not how they open. The behavior of preview tabs is controlled separately by the [`preview_tabs`](#preview-tabs) settings.
 
 ## Agent
 

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -2846,7 +2846,6 @@ Configuration object for defining settings profiles. Example:
 - Description:
   Preview tabs allow you to open files in preview mode, where they close automatically when you switch to another file unless you explicitly pin them. This is useful for quickly viewing files without cluttering your workspace. Preview tabs display their file names in italics. \
    There are several ways to convert a preview tab into a regular tab:
-
   - Double-clicking on the file
   - Double-clicking on the tab header
   - Using the {#action project_panel::OpenPermanent} action
@@ -4279,7 +4278,11 @@ Run the {#action theme_selector::Toggle} action in the command palette to see a 
     "hide_root": false,
     "hide_hidden": false,
     "starts_open": true,
-
+    "auto_open": {
+      "on_create": true,
+      "on_paste": true,
+      "on_drop": true
+    }
   }
 }
 ```

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -4491,103 +4491,25 @@ Run the {#action theme_selector::Toggle} action in the command palette to see a 
 }
 ```
 
-### Auto Open Files
+### Auto Open
 
-- Description: Control when files are automatically opened in the editor during various project panel operations
+- Description: Control whether files are opened automatically after different creation flows in the project panel.
 - Setting: `auto_open`
 - Default:
 
 ```json [settings]
-{
-  "auto_open": {
-    "on_create": true,
-    "on_paste": false,
-    "on_drop": true
-  }
+"auto_open": {
+  "on_create": true,
+  "on_paste": true,
+  "on_drop": true
 }
 ```
-
-**Sub-settings**
-
-#### On Create
-
-Whether to automatically open newly created files in the editor. When enabled, files created via the "New File" action will open immediately in the editor.
 
 **Options**
 
-1. Enable auto-open on create (default)
-
-```json [settings]
-{
-  "auto_open": {
-    "on_create": true
-  }
-}
-```
-
-2. Disable auto-open on create
-
-```json [settings]
-{
-  "auto_open": {
-    "on_create": false
-  }
-}
-```
-
-#### On Paste
-
-Whether to automatically open files after pasting or duplicating them in the project panel. When disabled (default), this prevents auto-opening of potentially problematic files like binary files or fonts that may cause errors.
-
-**Options**
-
-1. Disable auto-open on paste (default - prevents binary file errors)
-
-```json [settings]
-{
-  "auto_open": {
-    "on_paste": false
-  }
-}
-```
-
-2. Enable auto-open on paste
-
-```json [settings]
-{
-  "auto_open": {
-    "on_paste": true
-  }
-}
-```
-
-#### On Drop
-
-Whether to automatically open files dropped from external sources (e.g., from file explorer, desktop). When enabled (default), the first file dropped will open in the editor.
-
-**Options**
-
-1. Enable auto-open on drop (default)
-
-```json [settings]
-{
-  "auto_open": {
-    "on_drop": true
-  }
-}
-```
-
-2. Disable auto-open on drop
-
-```json [settings]
-{
-  "auto_open": {
-    "on_drop": false
-  }
-}
-```
-
-**Note**: These settings control when files open, not how they open. The behavior of preview tabs is controlled separately by the [`preview_tabs`](#preview-tabs) settings.
+- `on_create`: Whether to automatically open newly created files in the editor.
+- `on_paste`: Whether to automatically open files after pasting or duplicating them.
+- `on_drop`: Whether to automatically open files dropped from external sources.
 
 ## Agent
 

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -2846,6 +2846,7 @@ Configuration object for defining settings profiles. Example:
 - Description:
   Preview tabs allow you to open files in preview mode, where they close automatically when you switch to another file unless you explicitly pin them. This is useful for quickly viewing files without cluttering your workspace. Preview tabs display their file names in italics. \
    There are several ways to convert a preview tab into a regular tab:
+
   - Double-clicking on the file
   - Double-clicking on the tab header
   - Using the {#action project_panel::OpenPermanent} action


### PR DESCRIPTION
- Based on #40234, and improvement of #40331

Release Notes:

- Added granular settings to control when files auto-open in the project panel (project_panel.auto_open.on_create, on_paste, on_drop)

<img width="662" height="367" alt="Screenshot_2025-10-16_17-28-31" src="https://github.com/user-attachments/assets/930a0a50-fc89-4c5d-8d05-b1fa2279de8b" />
