### PR TITLE
Disable slang-server for verilog extension

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1818,6 +1818,7 @@
     },
     "SystemVerilog": {
       "format_on_save": "off",
+      "language_servers": ["!slang", "..."],
       "use_on_type_format": false
     },
     "Vue.js": {


### PR DESCRIPTION
Should be merged with https://github.com/zed-industries/extensions/pull/3584, which adds `slang-server` as a new language server, but should be disabled by default due to an issue with it not initializing on Windows and being a relatively new language server in general.

Release Notes:

- N/A
