### PR TITLE
Add dock state to workspace context

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1395,6 +1395,10 @@ impl Panel for AgentPanel {
         "AgentPanel"
     }
 
+    fn panel_key() -> &'static str {
+        AGENT_PANEL_KEY
+    }
+    
     fn position(&self, _window: &Window, cx: &App) -> DockPosition {
         agent_panel_dock_position(cx)
     }

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1398,7 +1398,7 @@ impl Panel for AgentPanel {
     fn panel_key() -> &'static str {
         AGENT_PANEL_KEY
     }
-    
+
     fn position(&self, _window: &Window, cx: &App) -> DockPosition {
         agent_panel_dock_position(cx)
     }

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -3040,7 +3040,7 @@ impl Panel for CollabPanel {
     fn panel_key() -> &'static str {
         COLLABORATION_PANEL_KEY
     }
-    
+
     fn activation_priority(&self) -> u32 {
         6
     }

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -3037,6 +3037,10 @@ impl Panel for CollabPanel {
         "CollabPanel"
     }
 
+    fn panel_key() -> &'static str {
+        COLLABORATION_PANEL_KEY
+    }
+    
     fn activation_priority(&self) -> u32 {
         6
     }

--- a/crates/collab_ui/src/notification_panel.rs
+++ b/crates/collab_ui/src/notification_panel.rs
@@ -612,6 +612,10 @@ impl Panel for NotificationPanel {
         "NotificationPanel"
     }
 
+    fn panel_key() -> &'static str {
+        NOTIFICATION_PANEL_KEY
+    }
+    
     fn position(&self, _: &Window, cx: &App) -> DockPosition {
         NotificationPanelSettings::get_global(cx).dock
     }

--- a/crates/collab_ui/src/notification_panel.rs
+++ b/crates/collab_ui/src/notification_panel.rs
@@ -615,7 +615,7 @@ impl Panel for NotificationPanel {
     fn panel_key() -> &'static str {
         NOTIFICATION_PANEL_KEY
     }
-    
+
     fn position(&self, _: &Window, cx: &App) -> DockPosition {
         NotificationPanelSettings::get_global(cx).dock
     }

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -43,6 +43,8 @@ use workspace::{
 };
 use zed_actions::ToggleFocus;
 
+const DEBUG_PANEL_KEY: &str = "DebugPanel";
+
 pub struct DebugPanel {
     size: Pixels,
     active_session: Option<Entity<DebugSession>>,
@@ -1414,6 +1416,10 @@ impl Panel for DebugPanel {
         "DebugPanel"
     }
 
+    fn panel_key() -> &'static str {
+        DEBUG_PANEL_KEY
+    }
+    
     fn position(&self, _window: &Window, cx: &App) -> DockPosition {
         DebuggerSettings::get_global(cx).dock.into()
     }

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -1419,7 +1419,7 @@ impl Panel for DebugPanel {
     fn panel_key() -> &'static str {
         DEBUG_PANEL_KEY
     }
-    
+
     fn position(&self, _window: &Window, cx: &App) -> DockPosition {
         DebuggerSettings::get_global(cx).dock.into()
     }

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -4422,7 +4422,7 @@ impl Panel for GitPanel {
     fn panel_key() -> &'static str {
         GIT_PANEL_KEY
     }
-    
+
     fn position(&self, _: &Window, cx: &App) -> DockPosition {
         GitPanelSettings::get_global(cx).dock
     }

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -4419,6 +4419,10 @@ impl Panel for GitPanel {
         "GitPanel"
     }
 
+    fn panel_key() -> &'static str {
+        GIT_PANEL_KEY
+    }
+    
     fn position(&self, _: &Window, cx: &App) -> DockPosition {
         GitPanelSettings::get_global(cx).dock
     }

--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -4841,7 +4841,7 @@ impl Panel for OutlinePanel {
     fn panel_key() -> &'static str {
         OUTLINE_PANEL_KEY
     }
-    
+
     fn position(&self, _: &Window, cx: &App) -> DockPosition {
         match OutlinePanelSettings::get_global(cx).dock {
             DockSide::Left => DockPosition::Left,

--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -4838,6 +4838,10 @@ impl Panel for OutlinePanel {
         "Outline Panel"
     }
 
+    fn panel_key() -> &'static str {
+        OUTLINE_PANEL_KEY
+    }
+    
     fn position(&self, _: &Window, cx: &App) -> DockPosition {
         match OutlinePanelSettings::get_global(cx).dock {
             DockSide::Left => DockPosition::Left,

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -6011,6 +6011,10 @@ impl Panel for ProjectPanel {
         "Project Panel"
     }
 
+    fn panel_key() -> &'static str {
+        PROJECT_PANEL_KEY
+    }
+    
     fn starts_open(&self, _: &Window, cx: &App) -> bool {
         if !ProjectPanelSettings::get_global(cx).starts_open {
             return false;

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -6014,7 +6014,7 @@ impl Panel for ProjectPanel {
     fn panel_key() -> &'static str {
         PROJECT_PANEL_KEY
     }
-    
+
     fn starts_open(&self, _: &Window, cx: &App) -> bool {
         if !ProjectPanelSettings::get_global(cx).starts_open {
             return false;

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -1575,7 +1575,7 @@ impl Panel for TerminalPanel {
     fn panel_key() -> &'static str {
         TERMINAL_PANEL_KEY
     }
-    
+
     fn icon(&self, _window: &Window, cx: &App) -> Option<IconName> {
         if (self.is_enabled(cx) || !self.has_no_terminals(cx))
             && TerminalSettings::get_global(cx).button

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -1572,6 +1572,10 @@ impl Panel for TerminalPanel {
         "TerminalPanel"
     }
 
+    fn panel_key() -> &'static str {
+        TERMINAL_PANEL_KEY
+    }
+    
     fn icon(&self, _window: &Window, cx: &App) -> Option<IconName> {
         if (self.is_enabled(cx) || !self.has_no_terminals(cx))
             && TerminalSettings::get_global(cx).button

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -109,7 +109,7 @@ where
     fn persistent_name(&self) -> &'static str {
         T::persistent_name()
     }
-    
+
     fn panel_key(&self) -> &'static str {
         T::panel_key()
     }
@@ -1025,7 +1025,7 @@ pub mod test {
         fn panel_key() -> &'static str {
             "TestPanel"
         }
-        
+
         fn position(&self, _window: &Window, _: &App) -> super::DockPosition {
             self.position
         }

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -27,6 +27,7 @@ pub use proto::PanelId;
 
 pub trait Panel: Focusable + EventEmitter<PanelEvent> + Render + Sized {
     fn persistent_name() -> &'static str;
+    fn panel_key() -> &'static str;
     fn position(&self, window: &Window, cx: &App) -> DockPosition;
     fn position_is_valid(&self, position: DockPosition) -> bool;
     fn set_position(&mut self, position: DockPosition, window: &mut Window, cx: &mut Context<Self>);
@@ -61,6 +62,7 @@ pub trait Panel: Focusable + EventEmitter<PanelEvent> + Render + Sized {
 pub trait PanelHandle: Send + Sync {
     fn panel_id(&self) -> EntityId;
     fn persistent_name(&self) -> &'static str;
+    fn panel_key(&self) -> &'static str;
     fn position(&self, window: &Window, cx: &App) -> DockPosition;
     fn position_is_valid(&self, position: DockPosition, cx: &App) -> bool;
     fn set_position(&self, position: DockPosition, window: &mut Window, cx: &mut App);
@@ -106,6 +108,10 @@ where
 
     fn persistent_name(&self) -> &'static str {
         T::persistent_name()
+    }
+    
+    fn panel_key(&self) -> &'static str {
+        T::panel_key()
     }
 
     fn position(&self, window: &Window, cx: &App) -> DockPosition {
@@ -1016,6 +1022,10 @@ pub mod test {
             "TestPanel"
         }
 
+        fn panel_key() -> &'static str {
+            "TestPanel"
+        }
+        
         fn position(&self, _window: &Window, _: &App) -> super::DockPosition {
             self.position
         }

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -6367,6 +6367,24 @@ impl Render for Workspace {
             }
         }
 
+        if self.left_dock.read(cx).is_open() {
+            if let Some(active_panel) = self.left_dock.read(cx).active_panel() {
+                context.set("left_dock", active_panel.panel_key());
+            }
+        }
+
+        if self.right_dock.read(cx).is_open() {
+            if let Some(active_panel) = self.right_dock.read(cx).active_panel() {
+                context.set("right_dock", active_panel.panel_key());
+            }
+        }
+
+        if self.bottom_dock.read(cx).is_open() {
+            if let Some(active_panel) = self.bottom_dock.read(cx).active_panel() {
+                context.set("bottom_dock", active_panel.panel_key());
+            }
+        }
+
         let centered_layout = self.centered_layout
             && self.center.panes().len() == 1
             && self.active_item(cx).is_some();


### PR DESCRIPTION
I love keybindings.

I spend way to much time thinking about them.

I also REALLY like working in Zed. 

so far, however, I have found the key context system in Zed to be less flexible than in VSCode.
the HUGE context that is available in VSCode helps you create keybindings for very specific targeted scenarios.

the tree like structure of the Zed key context means you loose some information as focus moves throughout the application.
For example, it is not currently possible to create a keybinding in the editor that will only work when one of the Docks is open, or if a specific dock is open.

this would be useful in implementing solutions to ideas like #24222 
we already have an action for moving focus to the dock, and we have an action for opening/closing the dock, but to my knowledge (very limited lol) we cannot determine if that dock *is open* unless we are focused on it.

I think it is possible to create a more flexible key binding system by adding more context information to the higher up context ancestors.
while:
``` 
Workspace right_dock=GitPanel
    Dock
        GitPanel
            Editor
```
may seem redundant, it actually communicates fundamentally different information than:
```
Workspace right_dock=GitPanel
    Pane
        Editor
```  

the first says "the GitPanel is in the right hand dock AND IT IS FOCUSED", 
while the second means "Focus is on the Editor, and the GitPanel just happens to be open in the right hand dock"

This change adds a new set of identifiers to the `Workspace` key_context that will indicate which docks are open and what is the specific panel that is currently visible in that dock.

examples:
- `left_dock=ProjectPanel`
- `bottom_dock=TerminalPanel`
- `right_dock=GitPanel`

in my testing the following types of keybindings seem to be supported with this change:
```jsonc
// match for any value of the identifier
"context": "Workspace && bottom_dock"
"context": "Workspace && !bottom_dock"
// match only a specific value to an identifier
"context": "Workspace && bottom_dock=TerminalPanel"
// match only in a child context if the ancestor workspace has the correct identifier
"context": "Workspace && !bottom_dock=DebugPanel > Editor"
```

some screen shots of the context matching in different circumstances:
<img width="2032" height="1167" alt="Screenshot 2025-10-16 at 23 20 34" src="https://github.com/user-attachments/assets/116d0575-a1ae-4577-95b9-8415cda57e52" />
<img width="2032" height="1167" alt="Screenshot 2025-10-16 at 23 20 57" src="https://github.com/user-attachments/assets/000fdbb6-80bd-46e9-b668-f4b54ab708d2" />
<img width="2032" height="1167" alt="Screenshot 2025-10-16 at 23 21 37" src="https://github.com/user-attachments/assets/7b1c82da-b82f-4e14-a97c-3cd0e71bbca0" />
<img width="2032" height="1167" alt="Screenshot 2025-10-16 at 23 21 52" src="https://github.com/user-attachments/assets/1fd4b65a-09f7-47a9-a9b7-fdce4252aec3" />
<img width="2032" height="1167" alt="Screenshot 2025-10-16 at 23 22 38" src="https://github.com/user-attachments/assets/f4c2ac5c-e6f9-4e0e-b683-522b237e3328" />


the persistent_name values for `ProjectPanel` and `OutlinePanel` needed to be updated to not have a space in them in order to pass the `Identifier` check. all the other Panels already had names that did not include spaces, so it just makes these conform with the other ones.

I think this is a great place to start with adding more context identifiers and i think this type of additional information will make it possible to create really dynamic keybindings!

Release Notes:

- Workspace key context now includes the state of the 3 docks