### PR TITLE
Remote CLI/Open Current Window

### DIFF
--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -145,6 +145,16 @@ impl Project {
             .unwrap_or_default();
 
             project.update(cx, move |this, cx| {
+                let mut activation_script = activation_script.clone();
+                // Make `zed` available in remote terminals by prepending the per-connection bin dir to PATH.
+                if let Some(rc) = remote_client.clone() {
+                    let identifier = rc.read(cx).unique_identifier();
+                    let prepend = format!(
+                        "export PATH=\"$HOME/.local/share/zed/server_state/{}/bin:$PATH\"",
+                        identifier
+                    );
+                    activation_script.insert(0, prepend);
+                }
                 let format_to_run = || {
                     if let Some(command) = &spawn_task.command {
                         let mut command: Option<Cow<str>> = shell_kind.try_quote(command);

--- a/crates/proto/proto/app.proto
+++ b/crates/proto/proto/app.proto
@@ -23,6 +23,39 @@ message OpenServerSettings {
     uint64 project_id = 1;
 }
 
+// Request sent from the remote host to ask the local Zed app
+// to open paths/urls in the current window (or a new one).
+message RemoteCliOpen {
+    // Local file system paths on the remote host, possibly using
+    // path:line:column syntax. The local handler will canonicalize
+    // and choose an appropriate window.
+    repeated string paths = 1;
+
+    // URLs such as zed://, file://, http(s):// or ssh://.
+    repeated string urls = 2;
+
+    // Pairs of file paths to diff.
+    message DiffPair {
+        string old_path = 1;
+        string new_path = 2;
+    }
+    repeated DiffPair diff_paths = 3;
+
+    // Wait for the opened items to close before returning.
+    bool wait = 4;
+
+    // If set, overrides default window selection behavior.
+    optional bool open_new_workspace = 5;
+}
+
+message RemoteCliOpenResponse {
+    // Exit status code semantics: 0 success, non-zero indicates failure.
+    int32 status = 1;
+    // Optional stderr/stdout text for diagnostics.
+    string stderr = 2;
+    string stdout = 3;
+}
+
 message GetCrashFiles {
 }
 

--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -421,7 +421,11 @@ message Envelope {
         RemoteStarted remote_started = 381;
 
         GetDirectoryEnvironment get_directory_environment = 382;
-        DirectoryEnvironment directory_environment = 383; // current max
+        DirectoryEnvironment directory_environment = 383;
+
+        // Remote CLI open request/response.
+        RemoteCliOpen remote_cli_open = 384;
+        RemoteCliOpenResponse remote_cli_open_response = 385; // current max
     }
 
     reserved 87 to 88;

--- a/crates/proto/src/proto.rs
+++ b/crates/proto/src/proto.rs
@@ -187,6 +187,8 @@ messages!(
     (OpenContextResponse, Foreground),
     (OpenNewBuffer, Foreground),
     (OpenServerSettings, Foreground),
+    (RemoteCliOpen, Foreground),
+    (RemoteCliOpenResponse, Foreground),
     (PerformRename, Background),
     (PerformRenameResponse, Background),
     (Ping, Foreground),
@@ -503,6 +505,7 @@ request_messages!(
     (GetProcesses, GetProcessesResponse),
     (GetAgentServerCommand, AgentServerCommand),
     (RemoteStarted, Ack),
+    (RemoteCliOpen, RemoteCliOpenResponse),
 );
 
 lsp_messages!(

--- a/crates/remote/src/remote_client.rs
+++ b/crates/remote/src/remote_client.rs
@@ -884,6 +884,10 @@ impl RemoteClient {
         self.path_style
     }
 
+    pub fn unique_identifier(&self) -> String {
+        self.unique_identifier.clone()
+    }
+
     #[cfg(any(test, feature = "test-support"))]
     pub fn simulate_disconnect(&self, client_cx: &mut App) -> Task<()> {
         let opts = self.connection_options();

--- a/crates/remote_server/src/remote_server.rs
+++ b/crates/remote_server/src/remote_server.rs
@@ -32,6 +32,35 @@ pub enum Commands {
         identifier: String,
     },
     Version,
+    /// CLI mode used by remote terminals to control the local Zed instance
+    /// through the remote server.
+    #[command(subcommand)]
+    Cli(CliCommand),
+}
+
+#[derive(Subcommand)]
+pub enum CliCommand {
+    /// Open paths/urls in the connected local Zed window
+    Open {
+        /// Unique connection identifier for this remote session
+        #[arg(long)]
+        identifier: String,
+        /// Wait for all opened items to close before exiting
+        #[arg(long)]
+        wait: bool,
+        /// Create a new workspace window
+        #[arg(short = 'n', long)]
+        new: bool,
+        /// Add to the current workspace (overrides --new)
+        #[arg(short = 'a', long)]
+        add: bool,
+        /// Pairs of file paths to diff. Use --diff old --diff new
+        #[arg(long, action = clap::ArgAction::Append, num_args = 2, value_names = ["OLD", "NEW"])]
+        diff: Vec<String>,
+        /// Paths or urls to open
+        #[arg(value_name = "PATHS_OR_URLS")] 
+        paths_or_urls: Vec<String>,
+    },
 }
 
 #[cfg(not(windows))]
@@ -78,6 +107,68 @@ pub fn run(command: Commands) -> anyhow::Result<()> {
                 }
             };
             Ok(())
+        }
+        Commands::Cli(CliCommand::Open {
+            identifier,
+            wait,
+            new,
+            add,
+            diff,
+            paths_or_urls,
+        }) => {
+            use smol::io::{AsyncReadExt as _, AsyncWriteExt as _};
+            // Compute cli.sock based on server state dir
+            let server_dir = paths::remote_server_state_dir().join(&identifier);
+            let cli_socket = server_dir.join("cli.sock");
+
+            // Build payload and send as JSON
+            #[derive(serde::Serialize)]
+            struct DiffPair<'a> { old_path: &'a str, new_path: &'a str }
+            #[derive(serde::Serialize)]
+            struct CliOpenArgs<'a> {
+                paths: Vec<&'a str>,
+                urls: Vec<&'a str>,
+                diff_paths: Vec<DiffPair<'a>>,
+                wait: bool,
+                open_new_workspace: Option<bool>,
+            }
+            let mut paths = Vec::new();
+            let mut urls = Vec::new();
+            for arg in &paths_or_urls {
+                if arg.starts_with("http://")
+                    || arg.starts_with("https://")
+                    || arg.starts_with("file://")
+                    || arg.starts_with("zed://")
+                    || arg.starts_with("ssh://")
+                {
+                    urls.push(arg.as_str());
+                } else {
+                    paths.push(arg.as_str());
+                }
+            }
+            let mut diff_pairs = Vec::new();
+            for chunk in diff.chunks(2) {
+                if chunk.len() == 2 {
+                    diff_pairs.push(DiffPair { old_path: &chunk[0], new_path: &chunk[1] });
+                }
+            }
+            let open_new_workspace = if new { Some(true) } else if add { Some(false) } else { None };
+            let payload = CliOpenArgs { paths, urls, diff_paths: diff_pairs, wait, open_new_workspace };
+            let payload = serde_json::to_vec(&payload)?;
+
+            let status: i32 = smol::block_on(async move {
+                let mut stream = smol::net::unix::UnixStream::connect(&cli_socket).await?;
+                stream.write_all(&payload).await?;
+                stream.flush().await?;
+                // Signal EOF so server's read_to_end completes
+                stream.close().await?;
+                let mut resp_buf = Vec::new();
+                stream.read_to_end(&mut resp_buf).await?;
+                let response: serde_json::Value = serde_json::from_slice(&resp_buf).unwrap_or(serde_json::json!({"status": 1}));
+                let status = response.get("status").and_then(|s| s.as_i64()).unwrap_or(1) as i32;
+                anyhow::Ok(status)
+            })?;
+            std::process::exit(status);
         }
     }
 }

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -595,6 +595,12 @@ pub fn main() {
 
         audio::init(cx);
         workspace::init(app_state.clone(), cx);
+        // Allow remote terminals to open files in this local Zed via remote_server CLI.
+        zed::open_listener::register_remote_cli_bridge(
+            app_state.clone(),
+            app_state.client.clone(),
+            cx,
+        );
         ui_prompt::init(cx);
 
         go_to_line::init(cx);


### PR DESCRIPTION
Closes #32214

  Discussion:

  - https://github.com/zed-industries/zed/discussions/32214

  Summary:

  - Introduces a remote-side zed CLI so users can run zed . or zed path:line:col inside a Zed remote terminal and open in the current local window.
  - Mirrors VS Code’s UX: a per-connection shim on the remote talks to the local app over an IPC channel.

  Details:

  - Protocol: add RemoteCliOpen(+Response) to forward open requests (paths, urls, diffs, wait/new/add flags) to the local app.
  - Local: register a handler that reuses existing open logic (open_paths_with_positions, OpenRequest parsing for URLs), preserving -n/--new,
    -a/--add, --wait semantics and diff pairs.
  - Remote server:
      - Expose per-connection CLI socket at ~/.local/share/zed/server_state/<id>/cli.sock.
      - Add remote_server cli open to send a single JSON request and exit with the returned status.
      - Install a per-connection shim at ~/.local/share/zed/server_state/<id>/bin/zed; remote terminals prepend PATH so zed is available without
        user config.

  Usage:

  - From a Zed remote terminal:
      - zed .
      - zed file.rs:42:7
      - zed --diff old.txt --diff new.txt
      - zed -n <path>      # open in new window
      - zed -a <path>      # add to current window
      - zed --wait <path>  # wait until closed

  Release Notes:

  - Added: Support running zed from a remote terminal to open files/folders in the current local window.
  - Added: Per-connection remote CLI shim available on PATH inside remote terminals.
  - Added: remote_server cli open to forward open requests (paths/urls/diffs; -n/--new, -a/--add, --wait).
  - Added: Protocol messages to bridge remote CLI to the local window-opening logic.