### PR TITLE
multi_buffer: Make `anchor_in_excerpt` fallible for bad text anchors

### DIFF
--- a/crates/agent_ui/src/inline_assistant.rs
+++ b/crates/agent_ui/src/inline_assistant.rs
@@ -1880,9 +1880,7 @@ impl CodeActionProvider for AssistantCodeActionProvider {
                         let multibuffer_snapshot = multibuffer.read(cx);
                         Some(
                             multibuffer_snapshot
-                                .anchor_in_excerpt(excerpt_id, action.range.start)?
-                                ..multibuffer_snapshot
-                                    .anchor_in_excerpt(excerpt_id, action.range.end)?,
+                                .anchor_range_in_excerpt(excerpt_id, action.range)?,
                         )
                     })
                 })?

--- a/crates/agent_ui/src/inline_assistant.rs
+++ b/crates/agent_ui/src/inline_assistant.rs
@@ -1878,10 +1878,7 @@ impl CodeActionProvider for AssistantCodeActionProvider {
                         }
 
                         let multibuffer_snapshot = multibuffer.read(cx);
-                        Some(
-                            multibuffer_snapshot
-                                .anchor_range_in_excerpt(excerpt_id, action.range)?,
-                        )
+                        multibuffer_snapshot.anchor_range_in_excerpt(excerpt_id, action.range)
                     })
                 })?
                 .context("invalid range")?;

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5989,15 +5989,8 @@ impl Editor {
         let snapshot = self.buffer.read(cx).snapshot(cx);
         let newest_anchor = self.selections.newest_anchor();
         let replace_range_multibuffer = {
-            let excerpt = snapshot.excerpt_containing(newest_anchor.range()).unwrap();
-            let multibuffer_anchor = snapshot
-                .anchor_in_excerpt(excerpt.id(), buffer.anchor_before(replace_range.start))
-                .unwrap()
-                ..snapshot
-                    .anchor_in_excerpt(excerpt.id(), buffer.anchor_before(replace_range.end))
-                    .unwrap();
-            multibuffer_anchor.start.to_offset(&snapshot)
-                ..multibuffer_anchor.end.to_offset(&snapshot)
+            let mut excerpt = snapshot.excerpt_containing(newest_anchor.range()).unwrap();
+            excerpt.map_range_from_buffer(replace_range.clone())
         };
         if snapshot.buffer_id_for_anchor(newest_anchor.head()) != Some(buffer.remote_id()) {
             return None;

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -7974,9 +7974,10 @@ impl Editor {
         let edits = edits
             .into_iter()
             .flat_map(|(range, new_text)| {
-                let start = multibuffer.anchor_in_excerpt(excerpt_id, range.start)?;
-                let end = multibuffer.anchor_in_excerpt(excerpt_id, range.end)?;
-                Some((start..end, new_text))
+                Some((
+                    multibuffer.anchor_range_in_excerpt(excerpt_id, range)?,
+                    new_text,
+                ))
             })
             .collect::<Vec<_>>();
         if edits.is_empty() {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -7464,8 +7464,8 @@ impl EditorElement {
                         }
                         let clipped_start = range.start.max(&buffer_range.start, buffer);
                         let clipped_end = range.end.min(&buffer_range.end, buffer);
-                        let range = buffer_snapshot.anchor_in_excerpt(excerpt_id, clipped_start)?
-                            ..buffer_snapshot.anchor_in_excerpt(excerpt_id, clipped_end)?;
+                        let range = buffer_snapshot
+                            .anchor_range_in_excerpt(excerpt_id, clipped_start..clipped_end)?;
                         let start = range.start.to_display_point(display_snapshot);
                         let end = range.end.to_display_point(display_snapshot);
                         let selection_layout = SelectionLayout {

--- a/crates/editor/src/hover_links.rs
+++ b/crates/editor/src/hover_links.rs
@@ -534,10 +534,9 @@ pub fn show_link_definition(
                     if let Some((url_range, url)) = find_url(&buffer, text_anchor, cx.clone()) {
                         this.read_with(cx, |_, _| {
                             let range = maybe!({
-                                let start =
-                                    snapshot.anchor_in_excerpt(excerpt_id, url_range.start)?;
-                                let end = snapshot.anchor_in_excerpt(excerpt_id, url_range.end)?;
-                                Some(RangeInEditor::Text(start..end))
+                                let range =
+                                    snapshot.anchor_range_in_excerpt(excerpt_id, url_range)?;
+                                Some(RangeInEditor::Text(range))
                             });
                             (range, vec![HoverLink::Url(url)])
                         })
@@ -546,10 +545,9 @@ pub fn show_link_definition(
                         find_file(&buffer, project.clone(), text_anchor, cx).await
                     {
                         let range = maybe!({
-                            let start =
-                                snapshot.anchor_in_excerpt(excerpt_id, filename_range.start)?;
-                            let end = snapshot.anchor_in_excerpt(excerpt_id, filename_range.end)?;
-                            Some(RangeInEditor::Text(start..end))
+                            let range =
+                                snapshot.anchor_range_in_excerpt(excerpt_id, filename_range)?;
+                            Some(RangeInEditor::Text(range))
                         });
 
                         Some((range, vec![HoverLink::File(filename)]))
@@ -562,13 +560,11 @@ pub fn show_link_definition(
                                 (
                                     definition_result.iter().find_map(|link| {
                                         link.origin.as_ref().and_then(|origin| {
-                                            let start = snapshot.anchor_in_excerpt(
+                                            let range = snapshot.anchor_range_in_excerpt(
                                                 excerpt_id,
-                                                origin.range.start,
+                                                origin.range.clone(),
                                             )?;
-                                            let end = snapshot
-                                                .anchor_in_excerpt(excerpt_id, origin.range.end)?;
-                                            Some(RangeInEditor::Text(start..end))
+                                            Some(RangeInEditor::Text(range))
                                         })
                                     }),
                                     definition_result.into_iter().map(HoverLink::Text).collect(),

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -467,13 +467,10 @@ fn show_hover(
                 let range = hover_result
                     .range
                     .and_then(|range| {
-                        let start = snapshot
+                        let range = snapshot
                             .buffer_snapshot()
-                            .anchor_in_excerpt(excerpt_id, range.start)?;
-                        let end = snapshot
-                            .buffer_snapshot()
-                            .anchor_in_excerpt(excerpt_id, range.end)?;
-                        Some(start..end)
+                            .anchor_range_in_excerpt(excerpt_id, range)?;
+                        Some(range)
                     })
                     .or_else(|| {
                         let snapshot = &snapshot.buffer_snapshot();

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -367,7 +367,9 @@ impl FollowableItem for Editor {
         let Some((excerpt_id, _, _)) = buffer.as_singleton() else {
             return;
         };
-        let position = buffer.anchor_in_excerpt(*excerpt_id, location).unwrap();
+        let Some(position) = buffer.anchor_in_excerpt(*excerpt_id, location) else {
+            return;
+        };
         let selection = Selection {
             id: 0,
             reversed: false,

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -364,10 +364,7 @@ impl FollowableItem for Editor {
     ) {
         let buffer = self.buffer.read(cx);
         let buffer = buffer.read(cx);
-        let Some((excerpt_id, _, _)) = buffer.as_singleton() else {
-            return;
-        };
-        let Some(position) = buffer.anchor_in_excerpt(*excerpt_id, location) else {
+        let Some(position) = buffer.as_singleton_anchor(location) else {
             return;
         };
         let selection = Selection {

--- a/crates/editor/src/lsp_colors.rs
+++ b/crates/editor/src/lsp_colors.rs
@@ -251,25 +251,14 @@ impl Editor {
                                     {
                                         continue;
                                     }
-                                    let Some(color_start_anchor) = multi_buffer_snapshot
-                                        .anchor_in_excerpt(
-                                            *excerpt_id,
-                                            buffer_snapshot.anchor_before(
-                                                buffer_snapshot
-                                                    .clip_point_utf16(color_start, Bias::Left),
-                                            ),
-                                        )
-                                    else {
-                                        continue;
-                                    };
-                                    let Some(color_end_anchor) = multi_buffer_snapshot
-                                        .anchor_in_excerpt(
-                                            *excerpt_id,
-                                            buffer_snapshot.anchor_after(
-                                                buffer_snapshot
-                                                    .clip_point_utf16(color_end, Bias::Right),
-                                            ),
-                                        )
+                                    let start = buffer_snapshot.anchor_before(
+                                        buffer_snapshot.clip_point_utf16(color_start, Bias::Left),
+                                    );
+                                    let end = buffer_snapshot.anchor_after(
+                                        buffer_snapshot.clip_point_utf16(color_end, Bias::Right),
+                                    );
+                                    let Some(range) = multi_buffer_snapshot
+                                        .anchor_range_in_excerpt(*excerpt_id, start..end)
                                     else {
                                         continue;
                                     };
@@ -285,16 +274,14 @@ impl Editor {
                                         new_buffer_colors.binary_search_by(|(probe, _)| {
                                             probe
                                                 .start
-                                                .cmp(&color_start_anchor, &multi_buffer_snapshot)
+                                                .cmp(&range.start, &multi_buffer_snapshot)
                                                 .then_with(|| {
-                                                    probe.end.cmp(
-                                                        &color_end_anchor,
-                                                        &multi_buffer_snapshot,
-                                                    )
+                                                    probe
+                                                        .end
+                                                        .cmp(&range.end, &multi_buffer_snapshot)
                                                 })
                                         });
-                                    new_buffer_colors
-                                        .insert(i, (color_start_anchor..color_end_anchor, color));
+                                    new_buffer_colors.insert(i, (range, color));
                                     break;
                                 }
                             }

--- a/crates/git_ui/src/conflict_view.rs
+++ b/crates/git_ui/src/conflict_view.rs
@@ -321,27 +321,15 @@ fn update_conflict_highlighting(
     buffer: &editor::MultiBufferSnapshot,
     excerpt_id: editor::ExcerptId,
     cx: &mut Context<Editor>,
-) {
+) -> Option<()> {
     log::debug!("update conflict highlighting for {conflict:?}");
 
-    let outer_start = buffer
-        .anchor_in_excerpt(excerpt_id, conflict.range.start)
-        .unwrap();
-    let outer_end = buffer
-        .anchor_in_excerpt(excerpt_id, conflict.range.end)
-        .unwrap();
-    let our_start = buffer
-        .anchor_in_excerpt(excerpt_id, conflict.ours.start)
-        .unwrap();
-    let our_end = buffer
-        .anchor_in_excerpt(excerpt_id, conflict.ours.end)
-        .unwrap();
-    let their_start = buffer
-        .anchor_in_excerpt(excerpt_id, conflict.theirs.start)
-        .unwrap();
-    let their_end = buffer
-        .anchor_in_excerpt(excerpt_id, conflict.theirs.end)
-        .unwrap();
+    let outer_start = buffer.anchor_in_excerpt(excerpt_id, conflict.range.start)?;
+    let outer_end = buffer.anchor_in_excerpt(excerpt_id, conflict.range.end)?;
+    let our_start = buffer.anchor_in_excerpt(excerpt_id, conflict.ours.start)?;
+    let our_end = buffer.anchor_in_excerpt(excerpt_id, conflict.ours.end)?;
+    let their_start = buffer.anchor_in_excerpt(excerpt_id, conflict.theirs.start)?;
+    let their_end = buffer.anchor_in_excerpt(excerpt_id, conflict.theirs.end)?;
 
     let ours_background = cx.theme().colors().version_control_conflict_marker_ours;
     let theirs_background = cx.theme().colors().version_control_conflict_marker_theirs;
@@ -378,6 +366,8 @@ fn update_conflict_highlighting(
         options,
         cx,
     );
+
+    Some(())
 }
 
 fn render_conflict_buttons(
@@ -488,12 +478,9 @@ pub(crate) fn resolve_conflict(
                     })
                     .ok()?;
                 let &(_, block_id) = &state.block_ids[ix];
-                let start = snapshot
-                    .anchor_in_excerpt(excerpt_id, resolved_conflict.range.start)
-                    .unwrap();
-                let end = snapshot
-                    .anchor_in_excerpt(excerpt_id, resolved_conflict.range.end)
-                    .unwrap();
+                let start =
+                    snapshot.anchor_in_excerpt(excerpt_id, resolved_conflict.range.start)?;
+                let end = snapshot.anchor_in_excerpt(excerpt_id, resolved_conflict.range.end)?;
 
                 editor.remove_gutter_highlights::<ConflictsOuter>(vec![start..end], cx);
 

--- a/crates/git_ui/src/conflict_view.rs
+++ b/crates/git_ui/src/conflict_view.rs
@@ -475,7 +475,7 @@ pub(crate) fn resolve_conflict(
                 editor.remove_highlighted_rows::<ConflictsOurs>(vec![range.clone()], cx);
                 editor.remove_highlighted_rows::<ConflictsTheirs>(vec![range.clone()], cx);
                 editor.remove_highlighted_rows::<ConflictsOursMarker>(vec![range.clone()], cx);
-                editor.remove_highlighted_rows::<ConflictsTheirsMarker>(vec![range.clone()], cx);
+                editor.remove_highlighted_rows::<ConflictsTheirsMarker>(vec![range], cx);
                 editor.remove_blocks(HashSet::from_iter([block_id]), None, cx);
                 Some((workspace, project, multibuffer, buffer))
             })

--- a/crates/git_ui/src/conflict_view.rs
+++ b/crates/git_ui/src/conflict_view.rs
@@ -234,11 +234,7 @@ fn conflicts_updated(
                 continue;
             };
             let excerpt_id = *excerpt_id;
-            let Some(range) = snapshot
-                .anchor_in_excerpt(excerpt_id, conflict_range.start)
-                .zip(snapshot.anchor_in_excerpt(excerpt_id, conflict_range.end))
-                .map(|(start, end)| start..end)
-            else {
+            let Some(range) = snapshot.anchor_range_in_excerpt(excerpt_id, conflict_range) else {
                 continue;
             };
             removed_highlighted_ranges.push(range.clone());
@@ -324,12 +320,9 @@ fn update_conflict_highlighting(
 ) -> Option<()> {
     log::debug!("update conflict highlighting for {conflict:?}");
 
-    let outer_start = buffer.anchor_in_excerpt(excerpt_id, conflict.range.start)?;
-    let outer_end = buffer.anchor_in_excerpt(excerpt_id, conflict.range.end)?;
-    let our_start = buffer.anchor_in_excerpt(excerpt_id, conflict.ours.start)?;
-    let our_end = buffer.anchor_in_excerpt(excerpt_id, conflict.ours.end)?;
-    let their_start = buffer.anchor_in_excerpt(excerpt_id, conflict.theirs.start)?;
-    let their_end = buffer.anchor_in_excerpt(excerpt_id, conflict.theirs.end)?;
+    let outer = buffer.anchor_range_in_excerpt(excerpt_id, conflict.range.clone())?;
+    let ours = buffer.anchor_range_in_excerpt(excerpt_id, conflict.ours.clone())?;
+    let theirs = buffer.anchor_range_in_excerpt(excerpt_id, conflict.theirs.clone())?;
 
     let ours_background = cx.theme().colors().version_control_conflict_marker_ours;
     let theirs_background = cx.theme().colors().version_control_conflict_marker_theirs;
@@ -340,28 +333,23 @@ fn update_conflict_highlighting(
     };
 
     editor.insert_gutter_highlight::<ConflictsOuter>(
-        outer_start..their_end,
+        outer.start..theirs.end,
         |cx| cx.theme().colors().editor_background,
         cx,
     );
 
     // Prevent diff hunk highlighting within the entire conflict region.
-    editor.highlight_rows::<ConflictsOuter>(outer_start..outer_end, theirs_background, options, cx);
-    editor.highlight_rows::<ConflictsOurs>(our_start..our_end, ours_background, options, cx);
+    editor.highlight_rows::<ConflictsOuter>(outer.clone(), theirs_background, options, cx);
+    editor.highlight_rows::<ConflictsOurs>(ours.clone(), ours_background, options, cx);
     editor.highlight_rows::<ConflictsOursMarker>(
-        outer_start..our_start,
+        outer.start..ours.start,
         ours_background,
         options,
         cx,
     );
-    editor.highlight_rows::<ConflictsTheirs>(
-        their_start..their_end,
-        theirs_background,
-        options,
-        cx,
-    );
+    editor.highlight_rows::<ConflictsTheirs>(theirs.clone(), theirs_background, options, cx);
     editor.highlight_rows::<ConflictsTheirsMarker>(
-        their_end..outer_end,
+        theirs.end..outer.end,
         theirs_background,
         options,
         cx,
@@ -478,17 +466,16 @@ pub(crate) fn resolve_conflict(
                     })
                     .ok()?;
                 let &(_, block_id) = &state.block_ids[ix];
-                let start =
-                    snapshot.anchor_in_excerpt(excerpt_id, resolved_conflict.range.start)?;
-                let end = snapshot.anchor_in_excerpt(excerpt_id, resolved_conflict.range.end)?;
+                let range =
+                    snapshot.anchor_range_in_excerpt(excerpt_id, resolved_conflict.range)?;
 
-                editor.remove_gutter_highlights::<ConflictsOuter>(vec![start..end], cx);
+                editor.remove_gutter_highlights::<ConflictsOuter>(vec![range.clone()], cx);
 
-                editor.remove_highlighted_rows::<ConflictsOuter>(vec![start..end], cx);
-                editor.remove_highlighted_rows::<ConflictsOurs>(vec![start..end], cx);
-                editor.remove_highlighted_rows::<ConflictsTheirs>(vec![start..end], cx);
-                editor.remove_highlighted_rows::<ConflictsOursMarker>(vec![start..end], cx);
-                editor.remove_highlighted_rows::<ConflictsTheirsMarker>(vec![start..end], cx);
+                editor.remove_highlighted_rows::<ConflictsOuter>(vec![range.clone()], cx);
+                editor.remove_highlighted_rows::<ConflictsOurs>(vec![range.clone()], cx);
+                editor.remove_highlighted_rows::<ConflictsTheirs>(vec![range.clone()], cx);
+                editor.remove_highlighted_rows::<ConflictsOursMarker>(vec![range.clone()], cx);
+                editor.remove_highlighted_rows::<ConflictsTheirsMarker>(vec![range.clone()], cx);
                 editor.remove_blocks(HashSet::from_iter([block_id]), None, cx);
                 Some((workspace, project, multibuffer, buffer))
             })

--- a/crates/language_tools/src/syntax_tree_view.rs
+++ b/crates/language_tools/src/syntax_tree_view.rs
@@ -356,8 +356,7 @@ impl SyntaxTreeView {
         let multibuffer = editor_state.editor.read(cx).buffer();
         let multibuffer = multibuffer.read(cx).snapshot(cx);
         let excerpt_id = buffer_state.excerpt_id;
-        let range = multibuffer.anchor_in_excerpt(excerpt_id, range.start)?
-            ..multibuffer.anchor_in_excerpt(excerpt_id, range.end)?;
+        let range = multibuffer.anchor_range_in_excerpt(excerpt_id, range)?;
 
         // Update the editor with the anchor range.
         editor_state.editor.update(cx, |editor, cx| {

--- a/crates/language_tools/src/syntax_tree_view.rs
+++ b/crates/language_tools/src/syntax_tree_view.rs
@@ -356,12 +356,8 @@ impl SyntaxTreeView {
         let multibuffer = editor_state.editor.read(cx).buffer();
         let multibuffer = multibuffer.read(cx).snapshot(cx);
         let excerpt_id = buffer_state.excerpt_id;
-        let range = multibuffer
-            .anchor_in_excerpt(excerpt_id, range.start)
-            .unwrap()
-            ..multibuffer
-                .anchor_in_excerpt(excerpt_id, range.end)
-                .unwrap();
+        let range = multibuffer.anchor_in_excerpt(excerpt_id, range.start)?
+            ..multibuffer.anchor_in_excerpt(excerpt_id, range.end)?;
 
         // Update the editor with the anchor range.
         editor_state.editor.update(cx, |editor, cx| {

--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -3192,13 +3192,13 @@ impl OutlinePanel {
             .into_iter()
             .flat_map(|excerpt| excerpt.iter_outlines())
             .flat_map(|outline| {
-                let start = multi_buffer_snapshot
-                    .anchor_in_excerpt(excerpt_id, outline.range.start)?
-                    .to_display_point(&editor_snapshot);
-                let end = multi_buffer_snapshot
-                    .anchor_in_excerpt(excerpt_id, outline.range.end)?
-                    .to_display_point(&editor_snapshot);
-                Some((start..end, outline))
+                let range = multi_buffer_snapshot
+                    .anchor_range_in_excerpt(excerpt_id, outline.range.clone())?;
+                Some((
+                    range.start.to_display_point(&editor_snapshot)
+                        ..range.end.to_display_point(&editor_snapshot),
+                    outline,
+                ))
             })
             .collect::<Vec<_>>();
 


### PR DESCRIPTION
`MultiBuffer::anchor_in_excerpt` currently just wraps the given text anchor in a multibuffer anchor. This allows one to get a multibuffer anchor that points outside its excerpt which is basically never what one wants. This PR now does a bounds check and returns `None` if the given text anchor is not within the bounds of the excerpt.

Release Notes:

- N/A *or* Added/Fixed/Improved ...

Co-authored-by: Kirill Bulatov <kirill@zed.dev>