### PR TITLE
remote: Use SFTP over SCP for uploading files and directories

### DIFF
--- a/crates/remote/src/transport/ssh.rs
+++ b/crates/remote/src/transport/ssh.rs
@@ -679,7 +679,7 @@ impl SshRemoteConnection {
 
     fn build_sftp_command(&self) -> process::Command {
         let mut command = util::command::new_smol_command("sftp");
-        self.socket.ssh_options(&mut command).args(
+        self.socket.ssh_options(&mut command, false).args(
             self.socket
                 .connection_options
                 .port

--- a/crates/remote/src/transport/ssh.rs
+++ b/crates/remote/src/transport/ssh.rs
@@ -737,12 +737,7 @@ impl SshRemoteConnection {
     }
 
     async fn is_sftp_available() -> bool {
-        util::command::new_smol_command("which")
-            .arg("sftp")
-            .output()
-            .await
-            .map(|output| output.status.success())
-            .unwrap_or(false)
+        which::which("sftp").is_ok()
     }
 }
 


### PR DESCRIPTION
Closes #37322

Uses SFTP if available, otherwise falls back to SCP for uploading files and directories to remote. This fixes an issue on older macOS versions where outdated SCP can throw an ambiguous target error.

Release Notes:

- Fixed an issue where extensions wouldn’t work when SSHing into a remote from older macOS versions.
