### PR TITLE
vim: Fix cursor movement after entering Helix normal mode

### DIFF
--- a/crates/vim/src/insert.rs
+++ b/crates/vim/src/insert.rs
@@ -50,17 +50,23 @@ impl Vim {
         if count <= 1 || Vim::globals(cx).dot_replaying {
             self.create_mark("^".into(), window, cx);
 
+            if HelixModeSetting::get_global(cx).0 {
+                self.update_editor(cx, |_, editor, cx| {
+                    editor.dismiss_menus_and_popups(false, window, cx);
+                });
+                self.switch_mode(Mode::HelixNormal, false, window, cx);
+                return
+            }
+
             self.update_editor(cx, |_, editor, cx| {
                 editor.dismiss_menus_and_popups(false, window, cx);
 
-                if !HelixModeSetting::get_global(cx).0 {
-                    editor.change_selections(Default::default(), window, cx, |s| {
-                        s.move_cursors_with(|map, mut cursor, _| {
-                            *cursor.column_mut() = cursor.column().saturating_sub(1);
-                            (map.clip_point(cursor, Bias::Left), SelectionGoal::None)
-                        });
+                editor.change_selections(Default::default(), window, cx, |s| {
+                    s.move_cursors_with(|map, mut cursor, _| {
+                        *cursor.column_mut() = cursor.column().saturating_sub(1);
+                        (map.clip_point(cursor, Bias::Left), SelectionGoal::None)
                     });
-                }
+                });
             });
 
             self.switch_mode(Mode::Normal, false, window, cx);

--- a/crates/vim/src/insert.rs
+++ b/crates/vim/src/insert.rs
@@ -55,7 +55,7 @@ impl Vim {
                     editor.dismiss_menus_and_popups(false, window, cx);
                 });
                 self.switch_mode(Mode::HelixNormal, false, window, cx);
-                return
+                return;
             }
 
             self.update_editor(cx, |_, editor, cx| {


### PR DESCRIPTION
Closes #40009 

Release Notes:

- `vim::NormalBefore` now enters `helix_normal` correctly.
