### PR TITLE
settings_ui: Fix titlebar linux

### DIFF
--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -472,6 +472,12 @@ pub fn open_settings_editor(
         let scale_factor = current_rem_size / default_rem_size;
         let scaled_bounds: gpui::Size<Pixels> = default_bounds.map(|axis| axis * scale_factor);
 
+        let window_decorations = match std::env::var("ZED_WINDOW_DECORATIONS") {
+            Ok(val) if val == "server" => gpui::WindowDecorations::Server,
+            Ok(val) if val == "client" => gpui::WindowDecorations::Client,
+            _ => gpui::WindowDecorations::Client,
+        };
+
         cx.open_window(
             WindowOptions {
                 titlebar: Some(TitlebarOptions {
@@ -485,6 +491,7 @@ pub fn open_settings_editor(
                 kind: gpui::WindowKind::Floating,
                 window_background: cx.theme().window_background_appearance(),
                 window_min_size: Some(scaled_bounds),
+                window_decorations: Some(window_decorations),
                 window_bounds: Some(WindowBounds::centered(scaled_bounds, cx)),
                 ..Default::default()
             },


### PR DESCRIPTION
Closes #39826 (unless there are more bugs besides titlebar not rendering)

|Before|After|
|-|-|
|<img width="3072" height="1920" alt="image" src="https://github.com/user-attachments/assets/f849f648-bfa0-4bc5-a8ad-52cb0a25d0fe" />|<img width="3072" height="1920" alt="image" src="https://github.com/user-attachments/assets/6ebfd46e-6cc2-4e58-b0b7-206db8823869" />|

Release Notes:

- Fix titlebar missing on settings ui on linux
