### PR TITLE
Set the minimum log level to `info` for the remote server

### DIFF
--- a/crates/remote_server/src/unix.rs
+++ b/crates/remote_server/src/unix.rs
@@ -103,7 +103,9 @@ fn init_logging_server(log_file_path: PathBuf) -> Result<Receiver<Vec<u8>>> {
         buffer: Vec::new(),
     });
 
-    env_logger::Builder::from_default_env()
+    env_logger::Builder::new()
+        .filter_level(log::LevelFilter::Info)
+        .parse_default_env()
         .target(env_logger::Target::Pipe(target))
         .format(|buf, record| {
             let mut log_record = LogRecord::new(record);


### PR DESCRIPTION
`env_logger` defaults to only showing error-level logs, but we show info-level logs and above for the main Zed process, so I think it makes sense for the remote server to behave the same way.

Release Notes:

- N/A