### PR TITLE
command_palette: Allow users to resize width and persist value

### DIFF
--- a/assets/icons/drag_handle.svg
+++ b/assets/icons/drag_handle.svg
@@ -1,0 +1,8 @@
+<svg width="10" height="10" viewBox="0 0 10 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M10 9C10 8.44772 9.55228 8 9 8C8.44772 8 8 8.44772 8 9C8 9.55228 8.44772 10 9 10C9.55228 10 10 9.55228 10 9Z" fill="black" style="fill:black;fill-opacity:1;"/>
+<path d="M6 9C6 8.44772 5.55228 8 5 8C4.44772 8 4 8.44772 4 9C4 9.55228 4.44772 10 5 10C5.55228 10 6 9.55228 6 9Z" fill="black" style="fill:black;fill-opacity:1;"/>
+<path d="M2 9C2 8.44772 1.55228 8 1 8C0.447715 8 0 8.44772 0 9C0 9.55228 0.447715 10 1 10C1.55228 10 2 9.55228 2 9Z" fill="black" style="fill:black;fill-opacity:1;"/>
+<path d="M10 5C10 4.44772 9.55228 4 9 4C8.44772 4 8 4.44772 8 5C8 5.55228 8.44772 6 9 6C9.55228 6 10 5.55228 10 5Z" fill="black" style="fill:black;fill-opacity:1;"/>
+<path d="M6 5C6 4.44772 5.55228 4 5 4C4.44772 4 4 4.44772 4 5C4 5.55228 4.44772 6 5 6C5.55228 6 6 5.55228 6 5Z" fill="black" style="fill:black;fill-opacity:1;"/>
+<path d="M10 1C10 0.447715 9.55228 0 9 0C8.44772 0 8 0.447715 8 1C8 1.55228 8.44772 2 9 2C9.55228 2 10 1.55228 10 1Z" fill="black" style="fill:black;fill-opacity:1;"/>
+</svg>

--- a/assets/icons/resize.svg
+++ b/assets/icons/resize.svg
@@ -1,0 +1,4 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M13 8L8 13" stroke="black" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" />
+<path d="M12 2.5L2.5 12" stroke="black" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" />
+</svg>

--- a/assets/icons/resize.svg
+++ b/assets/icons/resize.svg
@@ -1,4 +1,0 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M13 8L8 13" stroke="black" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" />
-<path d="M12 2.5L2.5 12" stroke="black" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round" />
-</svg>

--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -216,7 +216,12 @@ impl Render for CommandPalette {
                 .right(px(0.))
                 .w(RESIZE_HANDLE_SIZE)
                 .h(RESIZE_HANDLE_SIZE)
-                .cursor_nwse_resize(),
+                .cursor_nwse_resize()
+                .child(
+                    Icon::new(IconName::Resize)
+                        .size(IconSize::XSmall)
+                        .color(Color::Muted),
+                ),
         );
 
         v_flex()

--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -216,11 +216,12 @@ impl Render for CommandPalette {
                 .right(px(0.))
                 .w(RESIZE_HANDLE_SIZE)
                 .h(RESIZE_HANDLE_SIZE)
+                .opacity(0.5)
                 .cursor_nwse_resize()
                 .child(
-                    Icon::new(IconName::Resize)
-                        .size(IconSize::XSmall)
-                        .color(Color::Muted),
+                    Icon::new(IconName::DragHandle)
+                        .size(IconSize::Indicator)
+                        .color(Color::Disabled),
                 ),
         );
 

--- a/crates/command_palette/src/persistence.rs
+++ b/crates/command_palette/src/persistence.rs
@@ -59,17 +59,25 @@ pub struct CommandPaletteDB(ThreadSafeConnection);
 
 impl Domain for CommandPaletteDB {
     const NAME: &str = stringify!(CommandPaletteDB);
-    const MIGRATIONS: &[&str] = &[sql!(
-        CREATE TABLE IF NOT EXISTS command_invocations(
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            command_name TEXT NOT NULL,
-            user_query TEXT NOT NULL,
-            last_invoked INTEGER DEFAULT (unixepoch())  NOT NULL
-        ) STRICT;
-    )];
+    const MIGRATIONS: &[&str] = &[
+        sql!(
+            CREATE TABLE IF NOT EXISTS command_invocations(
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                command_name TEXT NOT NULL,
+                user_query TEXT NOT NULL,
+                last_invoked INTEGER DEFAULT (unixepoch())  NOT NULL
+            ) STRICT;
+        ),
+        sql!(
+            CREATE TABLE IF NOT EXISTS command_palette_settings(
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                width REAL
+            ) STRICT;
+        ),
+    ];
 }
 
-db::static_connection!(COMMAND_PALETTE_HISTORY, CommandPaletteDB, []);
+db::static_connection!(COMMAND_PALETTE, CommandPaletteDB, []);
 
 impl CommandPaletteDB {
     pub async fn write_command_invocation(
@@ -121,6 +129,19 @@ impl CommandPaletteDB {
             FROM command_invocations
             GROUP BY command_name
             ORDER BY COUNT(1) DESC
+        }
+    }
+
+    query! {
+        pub fn get_command_palette_width() -> Result<Option<f32>> {
+            SELECT width FROM command_palette_settings WHERE id = 1
+        }
+    }
+
+    query! {
+        pub async fn set_command_palette_width(width: f32) -> Result<()> {
+            INSERT OR REPLACE INTO command_palette_settings (id, width) VALUES (1, ?)
+            ON CONFLICT(id) DO UPDATE SET width = excluded.width
         }
     }
 }
@@ -222,5 +243,25 @@ mod tests {
 
         assert!(some_command.is_some());
         assert_eq!(some_command.expect("is some").invocations, 1000);
+    }
+
+    #[gpui::test]
+    async fn test_saves_and_retrieves_width() {
+        let db = CommandPaletteDB::open_test_db("test_saves_and_retrieves_width").await;
+
+        let retrieved_width = db.get_command_palette_width().unwrap();
+        assert!(retrieved_width.is_none());
+
+        db.set_command_palette_width(700.0).await.unwrap();
+
+        let retrieved_width = db.get_command_palette_width().unwrap();
+        assert!(retrieved_width.is_some());
+        assert_eq!(retrieved_width.unwrap(), 700.0);
+
+        db.set_command_palette_width(800.0).await.unwrap();
+
+        let retrieved_width = db.get_command_palette_width().unwrap();
+        assert!(retrieved_width.is_some());
+        assert_eq!(retrieved_width.unwrap(), 800.0);
     }
 }

--- a/crates/icons/src/icons.rs
+++ b/crates/icons/src/icons.rs
@@ -186,6 +186,7 @@ pub enum IconName {
     ReplaceNext,
     ReplyArrowRight,
     Rerun,
+    Resize,
     Return,
     RotateCcw,
     RotateCw,

--- a/crates/icons/src/icons.rs
+++ b/crates/icons/src/icons.rs
@@ -91,6 +91,7 @@ pub enum IconName {
     Diff,
     Disconnected,
     Download,
+    DragHandle,
     EditorAtom,
     EditorCursor,
     EditorEmacs,

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -352,6 +352,10 @@ impl<D: PickerDelegate> Picker<D> {
         self
     }
 
+    pub fn set_max_height(&mut self, max_height: Option<gpui::Length>) {
+        self.max_height = max_height;
+    }
+
     pub fn list_measure_all(mut self) -> Self {
         match self.element_container {
             ElementContainer::List(state) => {


### PR DESCRIPTION
# Why

Closes #36180

# How

Allow users to resize Command Palette width by dragging left or right side of popover. Persists value in local DB, so the preferred width is retained between openings and app restarts.

The popover width is restrained between declared static values, I have chosen them arbitrarily based on the feeling when playing with the feature locally. Happy to adjust them to any other values.

The mentioned issue only requested horizontal resize, but let me know if the height of popover should also by customizable. I can address this within this PR or a separate one.

Release Notes:

- Added an ability to resize Command Palette width.

# Preview

https://github.com/user-attachments/assets/4219f7aa-f5be-4981-a3bb-28d4b4146a7b


