### PR TITLE
Fix duplicate process entries in WSL debug attach list

### DIFF
--- a/crates/debugger_ui/src/attach_modal.rs
+++ b/crates/debugger_ui/src/attach_modal.rs
@@ -367,6 +367,7 @@ fn get_processes_for_project(project: &Entity<Project>, cx: &mut App) -> Task<Ar
         let mut processes: Box<[_]> = System::new_with_specifics(refresh_kind)
             .processes()
             .values()
+            .filter(|p| p.thread_kind().is_none())
             .map(|process| {
                 let name = process.name().to_string_lossy().into_owned();
                 Candidate {

--- a/crates/debugger_ui/src/attach_modal.rs
+++ b/crates/debugger_ui/src/attach_modal.rs
@@ -9,7 +9,7 @@ use task::ZedDebugConfig;
 use util::debug_panic;
 
 use std::sync::Arc;
-use sysinfo::System;
+use sysinfo::{ProcessRefreshKind, RefreshKind, System, UpdateKind};
 use ui::{Context, Tooltip, prelude::*};
 use ui::{ListItem, ListItemSpacing};
 use workspace::{ModalView, Workspace};
@@ -362,7 +362,9 @@ fn get_processes_for_project(project: &Entity<Project>, cx: &mut App) -> Task<Ar
             Arc::from(processes.into_boxed_slice())
         })
     } else {
-        let mut processes: Box<[_]> = System::new_all()
+        let refresh_kind = RefreshKind::nothing()
+            .with_processes(ProcessRefreshKind::nothing().with_cmd(UpdateKind::Always));
+        let mut processes: Box<[_]> = System::new_with_specifics(refresh_kind)
             .processes()
             .values()
             .map(|process| {

--- a/crates/debugger_ui/src/attach_modal.rs
+++ b/crates/debugger_ui/src/attach_modal.rs
@@ -362,12 +362,14 @@ fn get_processes_for_project(project: &Entity<Project>, cx: &mut App) -> Task<Ar
             Arc::from(processes.into_boxed_slice())
         })
     } else {
-        let refresh_kind = RefreshKind::nothing()
-            .with_processes(ProcessRefreshKind::nothing().with_cmd(UpdateKind::Always));
+        let refresh_kind = RefreshKind::nothing().with_processes(
+            ProcessRefreshKind::nothing()
+                .without_tasks()
+                .with_cmd(UpdateKind::Always),
+        );
         let mut processes: Box<[_]> = System::new_with_specifics(refresh_kind)
             .processes()
             .values()
-            .filter(|p| p.thread_kind().is_none())
             .map(|process| {
                 let name = process.name().to_string_lossy().into_owned();
                 Candidate {

--- a/crates/remote_server/src/headless_project.rs
+++ b/crates/remote_server/src/headless_project.rs
@@ -746,13 +746,15 @@ impl HeadlessProject {
         _cx: AsyncApp,
     ) -> Result<proto::GetProcessesResponse> {
         let mut processes = Vec::new();
-        let refresh_kind = RefreshKind::nothing()
-            .with_processes(ProcessRefreshKind::nothing().with_cmd(UpdateKind::Always));
+        let refresh_kind = RefreshKind::nothing().with_processes(
+            ProcessRefreshKind::nothing()
+                .without_tasks()
+                .with_cmd(UpdateKind::Always),
+        );
 
         for process in System::new_with_specifics(refresh_kind)
             .processes()
             .values()
-            .filter(|p| p.thread_kind().is_none())
         {
             let name = process.name().to_string_lossy().into_owned();
             let command = process


### PR DESCRIPTION
Closes #40589

Replaced `System::new_all()` with `System::new_with_specifics` to fetch only essential process information and exclude non-main threads from the process list

after fix:
<img width="641" height="474" alt="image" src="https://github.com/user-attachments/assets/32335552-2f7a-4317-8c01-f37b2eadfdc1" />


Release Notes:

- Fix duplicate process entries in WSL debug attach list
