### PR TITLE
agent chat export: Export raw tool input

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -35,6 +35,7 @@ use std::rc::Rc;
 use std::time::{Duration, Instant};
 use std::{fmt::Display, mem, path::PathBuf, sync::Arc};
 use ui::App;
+use util::markdown::MarkdownCodeBlock;
 use util::{ResultExt, get_default_system_shell_preferring_bash};
 use uuid::Uuid;
 
@@ -313,10 +314,20 @@ impl ToolCall {
 
     fn to_markdown(&self, cx: &App) -> String {
         let mut markdown = format!(
-            "**Tool Call: {}**\nStatus: {}\n\n",
+            "**Tool Call: {}**\nStatus: {}\n",
             self.label.read(cx).source(),
             self.status
         );
+        if let Some(raw_input) = self.raw_input.as_ref() {
+            markdown.push_str(&format!(
+                "\n### Input: \n{}\n### Output:",
+                MarkdownCodeBlock {
+                    tag: "json",
+                    text: &raw_input.to_string()
+                }
+            ));
+        }
+        markdown.push('\n');
         for content in &self.content {
             markdown.push_str(content.to_markdown(cx).as_str());
             markdown.push_str("\n\n");


### PR DESCRIPTION
I was looking at better understanding how the agent interact with the tools, but some tools lack to report all their input parameters in the label (such as calling the brave search MCP).

<img width="1070" height="768" alt="image" src="https://github.com/user-attachments/assets/c4f1bd76-f8e6-4faf-8ac0-98199c658ff3" />

I might do some other work in that area. I suspect that some better explaining to the agent might help with making them use better. In particular when it comes to the expected path.

(also, damn, rust-analyser + GDB consume pretty much all my RAM)

Release Notes:

- Added raw tool inputs in the agent chat markdown export