### PR TITLE
Fix Git UI truncation for long branch names

### DIFF
--- a/crates/git_ui/src/branch_picker.rs
+++ b/crates/git_ui/src/branch_picker.rs
@@ -511,8 +511,12 @@ impl PickerDelegate for BranchListDelegate {
                 )
                 .into_any_element()
         } else {
-            HighlightedLabel::new(entry.branch.name().to_owned(), entry.positions.clone())
-                .truncate()
+            h_flex()
+                .max_w_48()
+                .child(
+                    HighlightedLabel::new(entry.branch.name().to_owned(), entry.positions.clone())
+                        .truncate(),
+                )
                 .into_any_element()
         };
 


### PR DESCRIPTION
Closes #40524

Release Notes:
- Fixed branch names not truncating properly in git branch picker.

Please review if you have time.

PS. I’m not fully sure if this completely fixes the issue, but I’ve tested it on my local build and it seems to work fine.

Before Fix:
<img width="773" height="799" alt="502782621-91ac0578-9f55-4fb3-b0da-49a49e862a33" src="https://github.com/user-attachments/assets/a9597949-c46a-47d0-a9ef-eddd637a9dc7" />

After Fix:
<img width="545" height="766" alt="FixedRound2" src="https://github.com/user-attachments/assets/0d9770dc-a9da-46cd-a69a-4c8de2ca1abd" />