### PR TITLE
image_viewer: Use buffer font in breadcrumbs

### DIFF
--- a/crates/image_viewer/src/image_viewer.rs
+++ b/crates/image_viewer/src/image_viewer.rs
@@ -13,7 +13,7 @@ use language::{DiskState, File as _};
 use persistence::IMAGE_VIEWER;
 use project::{ImageItem, Project, ProjectPath, image_store::ImageItemEvent};
 use settings::Settings;
-use theme::Theme;
+use theme::{Theme, ThemeSettings};
 use ui::prelude::*;
 use util::paths::PathExt;
 use workspace::{
@@ -162,10 +162,12 @@ impl Item for ImageView {
 
     fn breadcrumbs(&self, _theme: &Theme, cx: &App) -> Option<Vec<BreadcrumbText>> {
         let text = breadcrumbs_text_for_image(self.project.read(cx), self.image_item.read(cx), cx);
+        let settings = ThemeSettings::get_global(cx);
+
         Some(vec![BreadcrumbText {
             text,
             highlights: None,
-            font: None,
+            font: Some(settings.buffer_font.clone()),
         }])
     }
 


### PR DESCRIPTION
# Why

Spotted that image path in editor breadcrumb uses regular (UI) font in comparison to paths of any other code-related files.

<img width="842" height="214" alt="Screenshot 2025-10-18 at 19 32 55" src="https://github.com/user-attachments/assets/07823fd2-778a-4341-a647-3ab50192c8fa" />

# How

Use buffer font for image path in Image Viewer breadcrumbs.

Release Notes:

- Aligned appearance of path displayed by Image Viewer breadcrumbs with other panes.

# Preview

### Before

<img width="842" height="214" alt="Screenshot 2025-10-18 at 19 26 17" src="https://github.com/user-attachments/assets/921df27f-c104-457e-908c-e4beaea3a27e" />

### After

<img width="842" height="214" alt="Screenshot 2025-10-18 at 19 24 17" src="https://github.com/user-attachments/assets/112ce5f3-1a2b-40e4-bf4f-e258f3518812" />
