### PR TITLE
python: Only enable basedpyright and ruff by default

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1776,8 +1776,8 @@
           "name": "ruff"
         }
       },
-      "language_servers": ["basedpyright", "ruff", "!ty", "!pyrefly", "!pyright", "!pylsp", "..."],
-      "debuggers": ["Debugpy"]
+      "debuggers": ["Debugpy"],
+      "language_servers": ["basedpyright", "ruff", "!ty", "!pyrefly", "!pyright", "!pylsp", "..."]
     },
     "Ruby": {
       "language_servers": ["solargraph", "!ruby-lsp", "!rubocop", "!sorbet", "!steep", "..."]

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1776,6 +1776,7 @@
           "name": "ruff"
         }
       },
+      "language_servers": ["basedpyright", "ruff", "!ty", "!pyright", "!pyrefly", "!python-lsp-server ", "..."],
       "debuggers": ["Debugpy"]
     },
     "Ruby": {

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1776,7 +1776,7 @@
           "name": "ruff"
         }
       },
-      "language_servers": ["basedpyright", "ruff", "!ty", "!pyright", "!pyrefly", "!python-lsp-server ", "..."],
+      "language_servers": ["basedpyright", "ruff", "!ty", "!pyrefly", "!pyright", "!python-lsp-server ", "..."],
       "debuggers": ["Debugpy"]
     },
     "Ruby": {

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1776,7 +1776,7 @@
           "name": "ruff"
         }
       },
-      "language_servers": ["basedpyright", "ruff", "!ty", "!pyrefly", "!pyright", "!python-lsp-server ", "..."],
+      "language_servers": ["basedpyright", "ruff", "!ty", "!pyrefly", "!pyright", "!pylsp", "..."],
       "debuggers": ["Debugpy"]
     },
     "Ruby": {


### PR DESCRIPTION
Though we ship with `basedpyright`, `ruff` and a few other laps for python, we run them all at once.

Release Notes:

- Only enable `basedpyright` and `ruff` by default when opening Python files. If you prefer one of the other.
