### PR TITLE
editor: Add `diffs_expanded` to key context when diff hunks are expanded

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2508,6 +2508,10 @@ impl Editor {
         {
             key_context.add("end_of_input");
         }
+        
+        if self.has_any_expanded_diff_hunks(cx) {
+            key_context.add("diffs_expanded");
+        }
 
         key_context
     }
@@ -18881,6 +18885,14 @@ impl Editor {
                 false
             }
         })
+    }
+
+    fn has_any_expanded_diff_hunks(&self, cx: &App) -> bool {
+        if self.buffer.read(cx).all_diff_hunks_expanded() {
+            return true;
+        }
+        let ranges = vec![Anchor::min()..Anchor::max()];
+        self.buffer.read(cx).has_expanded_diff_hunks_in_ranges(&ranges, cx)
     }
 
     fn toggle_diff_hunks_in_ranges(

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2508,7 +2508,7 @@ impl Editor {
         {
             key_context.add("end_of_input");
         }
-        
+
         if self.has_any_expanded_diff_hunks(cx) {
             key_context.add("diffs_expanded");
         }
@@ -18892,7 +18892,9 @@ impl Editor {
             return true;
         }
         let ranges = vec![Anchor::min()..Anchor::max()];
-        self.buffer.read(cx).has_expanded_diff_hunks_in_ranges(&ranges, cx)
+        self.buffer
+            .read(cx)
+            .has_expanded_diff_hunks_in_ranges(&ranges, cx)
     }
 
     fn toggle_diff_hunks_in_ranges(


### PR DESCRIPTION
including a new identifier on the Editor key context will allow for some more flexibility when creating keybindings.

for example i would like to be able to set the following:
```json
{
  "context": "Editor",
  "bindings": {
    "pageup": ["editor::MovePageUp", { "center_cursor": true }],
    "pagedown": ["editor::MovePageDown", { "center_cursor": true }],
  }
},
{
  "context": "Editor && diffs_expanded",
  "bindings": {
    "pageup": "editor::GoToPrevHunk",
    "pagedown": "editor::GoToHunk",
  }
},
```

<img width="1392" height="1167" alt="Screenshot 2025-10-18 at 23 51 46" src="https://github.com/user-attachments/assets/cf4e262e-97e7-4dd9-bbda-cd272770f1ac" />


very open to suggestions for the name. that's the best i could come up with.

the action *IS* called `editor::ExpandAllDiffHunks` so this seems fitting.

the identifier is included if *any* diff hunk is visible, even if some of them have been closed using `editor::ToggleSelectedDiffHunk`


Release Notes:

- The Editor key context now includes 'diffs_expanded' when diff changes are visible