### PR TITLE
emacs: Improve default keymap to better match the emacs behavior

### DIFF
--- a/assets/keymaps/linux/emacs.json
+++ b/assets/keymaps/linux/emacs.json
@@ -11,6 +11,18 @@
   {
     // Workaround to avoid falling back to default bindings.
     // Unbind so Zed ignores these keys and lets emacs handle them.
+    // NOTE: since `Editor` bindings always take precedence over `Workspace` ones, this can
+    // also be safely defined after the main bindings. Just in case though, define them beforehand.
+    // NOTE: in macos this is not needed, since the defaults are bound to 'cmd', not 'ctrl'
+    "context": "Workspace",
+    "bindings": {
+      "ctrl-p": null, // currently activates `file_finder::Toggle` when the cursor is on the first character of the buffer
+      "ctrl-n": null // currently activates `workspace::NewFile` when the cursor is on the last character of the buffer
+    }
+  },
+  {
+    // Workaround to avoid falling back to default bindings.
+    // Unbind so Zed ignores these keys and lets emacs handle them.
     // NOTE: must be declared before the `Editor` override.
     // NOTE: in macos the 'ctrl-x' rebind is not needed, since it defaults to 'cmd'.
     "context": "Editor",
@@ -153,16 +165,6 @@
       "ctrl-x ctrl-s": "workspace::Save", // save-buffer
       "ctrl-x ctrl-w": "workspace::SaveAs", // write-file
       "ctrl-x s": "workspace::SaveAll" // save-some-buffers
-    }
-  },
-  {
-    // Workaround to avoid falling back to default bindings.
-    // Unbind so Zed ignores these keys and lets emacs handle them.
-    // NOTE: in macos this is not needed, since the defaults are bound to 'cmd', not 'ctrl'
-    "context": "Workspace",
-    "bindings": {
-      "ctrl-p": null, // currently activates `file_finder::Toggle` when the cursor is on the first character of the buffer
-      "ctrl-n": null // currently activates `workspace::NewFile` when the cursor is on the last character of the buffer
     }
   },
   {

--- a/assets/keymaps/linux/emacs.json
+++ b/assets/keymaps/linux/emacs.json
@@ -146,18 +146,28 @@
       "ctrl-n": "editor::SignatureHelpNext"
     }
   },
+  // Example setting for using emacs-style tab
+  // (i.e. indent the current line / selection or perform symbol completion depending on context)
+  // {
+  //   "context": "Editor && !showing_code_actions && !showing_completions",
+  //   "bindings": {
+  //     "tab": "editor::AutoIndent" // indent-for-tab-command
+  //   }
+  // },
   {
     "context": "Workspace",
     "bindings": {
-      "alt-x": "command_palette::Toggle",
+      "alt-x": "command_palette::Toggle", // execute-extended-command
       "ctrl-x b": "tab_switcher::Toggle", // switch-to-buffer
       "ctrl-x ctrl-b": "tab_switcher::Toggle", // list-buffers
+      // "ctrl-x ctrl-c": "workspace::CloseWindow" // in case you only want to exit the current Zed instance
       "ctrl-x ctrl-c": "zed::Quit", // save-buffers-kill-terminal
       "ctrl-x 5 0": "workspace::CloseWindow", // delete-frame
       "ctrl-x 5 2": "workspace::NewWindow", // make-frame-command
       "ctrl-x o": "workspace::ActivateNextPane", // other-window
       "ctrl-x k": "pane::CloseActiveItem", // kill-buffer
       "ctrl-x 0": "pane::CloseActiveItem", // delete-window
+      // "ctrl-x 1": "pane::JoinAll", // in case you prefer to delete the splits but keep the buffers open
       "ctrl-x 1": "pane::CloseOtherItems", // delete-other-windows
       "ctrl-x 2": "pane::SplitDown", // split-window-below
       "ctrl-x 3": "pane::SplitRight", // split-window-right

--- a/assets/keymaps/linux/emacs.json
+++ b/assets/keymaps/linux/emacs.json
@@ -124,6 +124,15 @@
     }
   },
   {
+    // Workaround to clear the selection after copy/paste commands.
+    // TODO: allow to do the same on minibuffers without closing them
+    "context": "Editor && mode == full",
+    "bindings": {
+      "ctrl-w": ["workspace::SendKeystrokes", "ctrl-w ctrl-g"],
+      "alt-w": ["workspace::SendKeystrokes", "alt-w ctrl-g"]
+    }
+  },
+  {
     "context": "Editor && (showing_code_actions || showing_completions)",
     "bindings": {
       "ctrl-p": "editor::ContextMenuPrevious",

--- a/assets/keymaps/linux/emacs.json
+++ b/assets/keymaps/linux/emacs.json
@@ -12,9 +12,11 @@
     // Workaround to avoid falling back to default bindings.
     // Unbind so Zed ignores these keys and lets emacs handle them.
     // NOTE: must be declared before the `Editor` override.
+    // NOTE: in macos the 'ctrl-x' rebind is not needed, since it defaults to 'cmd-x'.
     "context": "Editor",
     "bindings": {
-      "ctrl-g": null // currently activates `go_to_line::Toggle` when there is nothing to cancel
+      "ctrl-g": null, // currently activates `go_to_line::Toggle` when there is nothing to cancel
+      "ctrl-x": null // currently activates `editor::Cut` if no following key is pressed for 1 second
     }
   },
   {

--- a/assets/keymaps/linux/emacs.json
+++ b/assets/keymaps/linux/emacs.json
@@ -57,10 +57,10 @@
       "alt-d": ["editor::DeleteToNextWordEnd", { "ignore_newlines": false, "ignore_brackets": false }], // kill-word
       "alt-backspace": "editor::DeleteToPreviousWordStart", // backward-kill-word
       "alt-delete": "editor::DeleteToPreviousWordStart", // backward-kill-word
-      "ctrl-k": "editor::CutToEndOfLine", // kill-line
+      "ctrl-k": "editor::KillRingCut", // kill-line
       "ctrl-w": "editor::Cut", // kill-region
       "alt-w": "editor::Copy", // kill-ring-save
-      "ctrl-y": "editor::Paste", // yank
+      "ctrl-y": "editor::KillRingYank", // yank
       "ctrl-_": "editor::Undo", // undo
       "ctrl-/": "editor::Undo", // undo
       "ctrl-x u": "editor::Undo", // undo

--- a/assets/keymaps/linux/emacs.json
+++ b/assets/keymaps/linux/emacs.json
@@ -121,15 +121,6 @@
     }
   },
   {
-    // Workaround to clear the selection after copy/paste commands.
-    // TODO: allow to do the same on minibuffers without closing them
-    "context": "Editor && mode == full",
-    "bindings": {
-      "ctrl-w": ["workspace::SendKeystrokes", "ctrl-w ctrl-g"],
-      "alt-w": ["workspace::SendKeystrokes", "alt-w ctrl-g"]
-    }
-  },
-  {
     "context": "Editor && (showing_code_actions || showing_completions)",
     "bindings": {
       "ctrl-p": "editor::ContextMenuPrevious",

--- a/assets/keymaps/linux/emacs.json
+++ b/assets/keymaps/linux/emacs.json
@@ -58,10 +58,10 @@
       "alt-d": ["editor::DeleteToNextWordEnd", { "ignore_newlines": false, "ignore_brackets": false }], // kill-word
       "alt-backspace": "editor::DeleteToPreviousWordStart", // backward-kill-word
       "alt-delete": "editor::DeleteToPreviousWordStart", // backward-kill-word
-      "ctrl-k": "editor::KillRingCut", // kill-line
+      "ctrl-k": "editor::CutToEndOfLine", // kill-line
       "ctrl-w": "editor::Cut", // kill-region
       "alt-w": "editor::Copy", // kill-ring-save
-      "ctrl-y": "editor::KillRingYank", // yank
+      "ctrl-y": "editor::Paste", // yank
       "ctrl-_": "editor::Undo", // undo
       "ctrl-/": "editor::Undo", // undo
       "ctrl-x u": "editor::Undo", // undo

--- a/assets/keymaps/linux/emacs.json
+++ b/assets/keymaps/linux/emacs.json
@@ -172,7 +172,7 @@
     // Unbind so Zed ignores these keys and lets emacs handle them.
     // NOTE:
     //  "terminal::SendKeystroke" only works for a single key stroke (e.g. ctrl-x),
-    //  so overwride with null for compound sequences (e.g. ctrl-x ctrl-c).
+    //  so override with null for compound sequences (e.g. ctrl-x ctrl-c).
     "context": "Terminal",
     "bindings": {
       // If you want to perfect your emacs-in-zed setup, also consider the following.

--- a/assets/keymaps/linux/emacs.json
+++ b/assets/keymaps/linux/emacs.json
@@ -168,10 +168,19 @@
     }
   },
   {
-    // Workaround to enable using emacs in the Zed terminal.
+    // Workaround to enable using native emacs from the Zed terminal.
     // Unbind so Zed ignores these keys and lets emacs handle them.
+    // NOTE:
+    //  "terminal::SendKeystroke" only works for a single key stroke (e.g. ctrl-x),
+    //  so overwride with null for compound sequences (e.g. ctrl-x ctrl-c).
     "context": "Terminal",
     "bindings": {
+      // If you want to perfect your emacs-in-zed setup, also consider the following.
+      // You may need to enable "option_as_meta" from the Zed settings for "alt-x" to work.
+      // "alt-x": ["terminal::SendKeystroke", "alt-x"],
+      // "ctrl-x": ["terminal::SendKeystroke", "ctrl-x"],
+      // "ctrl-n": ["terminal::SendKeystroke", "ctrl-n"],
+      // ...
       "ctrl-x ctrl-c": null, // save-buffers-kill-terminal
       "ctrl-x ctrl-f": null, // find-file
       "ctrl-x ctrl-s": null, // save-buffer

--- a/assets/keymaps/linux/emacs.json
+++ b/assets/keymaps/linux/emacs.json
@@ -11,24 +11,14 @@
   {
     // Workaround to avoid falling back to default bindings.
     // Unbind so Zed ignores these keys and lets emacs handle them.
-    // NOTE: since `Editor` bindings always take precedence over `Workspace` ones, this can
-    // also be safely defined after the main bindings. Just in case though, define them beforehand.
-    // NOTE: in macos this is not needed, since the defaults are bound to 'cmd', not 'ctrl'
-    "context": "Workspace",
-    "bindings": {
-      "ctrl-p": null, // currently activates `file_finder::Toggle` when the cursor is on the first character of the buffer
-      "ctrl-n": null // currently activates `workspace::NewFile` when the cursor is on the last character of the buffer
-    }
-  },
-  {
-    // Workaround to avoid falling back to default bindings.
-    // Unbind so Zed ignores these keys and lets emacs handle them.
     // NOTE: must be declared before the `Editor` override.
-    // NOTE: in macos the 'ctrl-x' rebind is not needed, since it defaults to 'cmd'.
+    // NOTE: in macos the 'ctrl-x' 'ctrl-p' and 'ctrl-n' rebindings are not needed, since they default to 'cmd'.
     "context": "Editor",
     "bindings": {
       "ctrl-g": null, // currently activates `go_to_line::Toggle` when there is nothing to cancel
-      "ctrl-x": null // currently activates `editor::Cut` if no following key is pressed for 1 second
+      "ctrl-x": null, // currently activates `editor::Cut` if no following key is pressed for 1 second
+      "ctrl-p": null, // currently activates `file_finder::Toggle` when the cursor is on the first character of the buffer
+      "ctrl-n": null // currently activates `workspace::NewFile` when the cursor is on the last character of the buffer
     }
   },
   {

--- a/assets/keymaps/linux/emacs.json
+++ b/assets/keymaps/linux/emacs.json
@@ -22,7 +22,6 @@
   {
     "context": "Editor",
     "bindings": {
-      "alt-x": "command_palette::Toggle",
       "ctrl-g": "editor::Cancel",
       "ctrl-x b": "tab_switcher::Toggle", // switch-to-buffer
       "ctrl-x ctrl-b": "tab_switcher::Toggle", // list-buffers
@@ -149,6 +148,7 @@
   {
     "context": "Workspace",
     "bindings": {
+      "alt-x": "command_palette::Toggle",
       "ctrl-x ctrl-c": "zed::Quit", // save-buffers-kill-terminal
       "ctrl-x 5 0": "workspace::CloseWindow", // delete-frame
       "ctrl-x 5 2": "workspace::NewWindow", // make-frame-command

--- a/assets/keymaps/linux/emacs.json
+++ b/assets/keymaps/linux/emacs.json
@@ -12,7 +12,7 @@
     // Workaround to avoid falling back to default bindings.
     // Unbind so Zed ignores these keys and lets emacs handle them.
     // NOTE: must be declared before the `Editor` override.
-    // NOTE: in macos the 'ctrl-x' rebind is not needed, since it defaults to 'cmd-x'.
+    // NOTE: in macos the 'ctrl-x' rebind is not needed, since it defaults to 'cmd'.
     "context": "Editor",
     "bindings": {
       "ctrl-g": null, // currently activates `go_to_line::Toggle` when there is nothing to cancel
@@ -167,7 +167,7 @@
   {
     // Workaround to avoid falling back to default bindings.
     // Unbind so Zed ignores these keys and lets emacs handle them.
-    // NOTE: in macos this is not needed, since the defaults are bound to 'cmd-', and not 'ctrl-'
+    // NOTE: in macos this is not needed, since the defaults are bound to 'cmd', not 'ctrl'
     "context": "Workspace",
     "bindings": {
       "ctrl-p": null, // currently activates `file_finder::Toggle` when the cursor is on the first character of the buffer

--- a/assets/keymaps/linux/emacs.json
+++ b/assets/keymaps/linux/emacs.json
@@ -42,8 +42,8 @@
       "alt-m": ["editor::MoveToBeginningOfLine", { "stop_at_soft_wraps": false, "stop_at_indent": true }], // back-to-indentation
       "alt-left": "editor::MoveToPreviousWordStart", // left-word
       "alt-right": "editor::MoveToNextWordEnd", // right-word
-      "alt-f": "editor::MoveToNextSubwordEnd", // forward-word
-      "alt-b": "editor::MoveToPreviousSubwordStart", // backward-word
+      "alt-f": "editor::MoveToNextWordEnd", // forward-word
+      "alt-b": "editor::MoveToPreviousWordStart", // backward-word
       "alt-u": "editor::ConvertToUpperCase", // upcase-word
       "alt-l": "editor::ConvertToLowerCase", // downcase-word
       "alt-c": "editor::ConvertToUpperCamelCase", // capitalize-word
@@ -107,7 +107,7 @@
       "ctrl-e": ["editor::SelectToEndOfLine", { "stop_at_soft_wraps": false }],
       "alt-m": ["editor::SelectToBeginningOfLine", { "stop_at_soft_wraps": false, "stop_at_indent": true }],
       "alt-f": "editor::SelectToNextWordEnd",
-      "alt-b": "editor::SelectToPreviousSubwordStart",
+      "alt-b": "editor::SelectToPreviousWordStart",
       "alt-{": "editor::SelectToStartOfParagraph",
       "alt-}": "editor::SelectToEndOfParagraph",
       "ctrl-up": "editor::SelectToStartOfParagraph",

--- a/assets/keymaps/linux/emacs.json
+++ b/assets/keymaps/linux/emacs.json
@@ -9,6 +9,15 @@
     }
   },
   {
+    // Workaround to avoid falling back to default bindings.
+    // Unbind so Zed ignores these keys and lets emacs handle them.
+    // NOTE: must be declared before the `Editor` override.
+    "context": "Editor",
+    "bindings": {
+      "ctrl-g": null // currently activates `go_to_line::Toggle` when there is nothing to cancel
+    }
+  },
+  {
     "context": "Editor",
     "bindings": {
       "alt-x": "command_palette::Toggle",
@@ -142,6 +151,16 @@
       "ctrl-x ctrl-s": "workspace::Save", // save-buffer
       "ctrl-x ctrl-w": "workspace::SaveAs", // write-file
       "ctrl-x s": "workspace::SaveAll" // save-some-buffers
+    }
+  },
+  {
+    // Workaround to avoid falling back to default bindings.
+    // Unbind so Zed ignores these keys and lets emacs handle them.
+    // NOTE: in macos this is not needed, since the defaults are bound to 'cmd-', and not 'ctrl-'
+    "context": "Workspace",
+    "bindings": {
+      "ctrl-p": null, // currently activates `file_finder::Toggle` when the cursor is on the first character of the buffer
+      "ctrl-n": null // currently activates `workspace::NewFile` when the cursor is on the last character of the buffer
     }
   },
   {

--- a/assets/keymaps/linux/emacs.json
+++ b/assets/keymaps/linux/emacs.json
@@ -23,8 +23,6 @@
     "context": "Editor",
     "bindings": {
       "ctrl-g": "editor::Cancel",
-      "ctrl-x b": "tab_switcher::Toggle", // switch-to-buffer
-      "ctrl-x ctrl-b": "tab_switcher::Toggle", // list-buffers
       "alt-g g": "go_to_line::Toggle", // goto-line
       "alt-g alt-g": "go_to_line::Toggle", // goto-line
       "ctrl-space": "editor::SetMark", // set-mark
@@ -149,6 +147,8 @@
     "context": "Workspace",
     "bindings": {
       "alt-x": "command_palette::Toggle",
+      "ctrl-x b": "tab_switcher::Toggle", // switch-to-buffer
+      "ctrl-x ctrl-b": "tab_switcher::Toggle", // list-buffers
       "ctrl-x ctrl-c": "zed::Quit", // save-buffers-kill-terminal
       "ctrl-x 5 0": "workspace::CloseWindow", // delete-frame
       "ctrl-x 5 2": "workspace::NewWindow", // make-frame-command

--- a/assets/keymaps/macos/emacs.json
+++ b/assets/keymaps/macos/emacs.json
@@ -123,6 +123,15 @@
     }
   },
   {
+    // Workaround to clear the selection after copy/paste commands.
+    // TODO: allow to do the same on minibuffers without closing them
+    "context": "Editor && mode == full",
+    "bindings": {
+      "ctrl-w": ["workspace::SendKeystrokes", "ctrl-w ctrl-g"],
+      "alt-w": ["workspace::SendKeystrokes", "alt-w ctrl-g"]
+    }
+  },
+  {
     "context": "Editor && (showing_code_actions || showing_completions)",
     "bindings": {
       "ctrl-p": "editor::ContextMenuPrevious",

--- a/assets/keymaps/macos/emacs.json
+++ b/assets/keymaps/macos/emacs.json
@@ -10,6 +10,15 @@
     }
   },
   {
+    // Workaround to avoid falling back to default bindings.
+    // Unbind so Zed ignores these keys and lets emacs handle them.
+    // NOTE: must be declared before the `Editor` override.
+    "context": "Editor",
+    "bindings": {
+      "ctrl-g": null // currently activates `go_to_line::Toggle` when there is nothing to cancel
+    }
+  },
+  {
     "context": "Editor",
     "bindings": {
       "alt-x": "command_palette::Toggle",

--- a/assets/keymaps/macos/emacs.json
+++ b/assets/keymaps/macos/emacs.json
@@ -22,8 +22,6 @@
     "context": "Editor",
     "bindings": {
       "ctrl-g": "editor::Cancel",
-      "ctrl-x b": "tab_switcher::Toggle", // switch-to-buffer
-      "ctrl-x ctrl-b": "tab_switcher::Toggle", // list-buffers
       "alt-g g": "go_to_line::Toggle", // goto-line
       "alt-g alt-g": "go_to_line::Toggle", // goto-line
       "ctrl-space": "editor::SetMark", // set-mark
@@ -148,6 +146,8 @@
     "context": "Workspace",
     "bindings": {
       "alt-x": "command_palette::Toggle",
+      "ctrl-x b": "tab_switcher::Toggle", // switch-to-buffer
+      "ctrl-x ctrl-b": "tab_switcher::Toggle", // list-buffers
       "ctrl-x ctrl-c": "zed::Quit", // save-buffers-kill-terminal
       "ctrl-x 5 0": "workspace::CloseWindow", // delete-frame
       "ctrl-x 5 2": "workspace::NewWindow", // make-frame-command

--- a/assets/keymaps/macos/emacs.json
+++ b/assets/keymaps/macos/emacs.json
@@ -59,10 +59,10 @@
       "alt-d": ["editor::DeleteToNextWordEnd", { "ignore_newlines": false, "ignore_brackets": false }], // kill-word
       "alt-backspace": "editor::DeleteToPreviousWordStart", // backward-kill-word
       "alt-delete": "editor::DeleteToPreviousWordStart", // backward-kill-word
-      "ctrl-k": "editor::KillRingCut", // kill-line
+      "ctrl-k": "editor::CutToEndOfLine", // kill-line
       "ctrl-w": "editor::Cut", // kill-region
       "alt-w": "editor::Copy", // kill-ring-save
-      "ctrl-y": "editor::KillRingYank", // yank
+      "ctrl-y": "editor::Paste", // yank
       "ctrl-_": "editor::Undo", // undo
       "ctrl-/": "editor::Undo", // undo
       "ctrl-x u": "editor::Undo", // undo

--- a/assets/keymaps/macos/emacs.json
+++ b/assets/keymaps/macos/emacs.json
@@ -133,18 +133,28 @@
       "ctrl-n": "editor::SignatureHelpNext"
     }
   },
+  // Example setting for using emacs-style tab
+  // (i.e. indent the current line / selection or perform symbol completion depending on context)
+  // {
+  //   "context": "Editor && !showing_code_actions && !showing_completions",
+  //   "bindings": {
+  //     "tab": "editor::AutoIndent" // indent-for-tab-command
+  //   }
+  // },
   {
     "context": "Workspace",
     "bindings": {
-      "alt-x": "command_palette::Toggle",
+      "alt-x": "command_palette::Toggle", // execute-extended-command
       "ctrl-x b": "tab_switcher::Toggle", // switch-to-buffer
       "ctrl-x ctrl-b": "tab_switcher::Toggle", // list-buffers
+      // "ctrl-x ctrl-c": "workspace::CloseWindow" // in case you only want to exit the current Zed instance
       "ctrl-x ctrl-c": "zed::Quit", // save-buffers-kill-terminal
       "ctrl-x 5 0": "workspace::CloseWindow", // delete-frame
       "ctrl-x 5 2": "workspace::NewWindow", // make-frame-command
       "ctrl-x o": "workspace::ActivateNextPane", // other-window
       "ctrl-x k": "pane::CloseActiveItem", // kill-buffer
       "ctrl-x 0": "pane::CloseActiveItem", // delete-window
+      // "ctrl-x 1": "pane::JoinAll", // in case you prefer to delete the splits but keep the buffers open
       "ctrl-x 1": "pane::CloseOtherItems", // delete-other-windows
       "ctrl-x 2": "pane::SplitDown", // split-window-below
       "ctrl-x 3": "pane::SplitRight", // split-window-right

--- a/assets/keymaps/macos/emacs.json
+++ b/assets/keymaps/macos/emacs.json
@@ -155,10 +155,19 @@
     }
   },
   {
-    // Workaround to enable using emacs in the Zed terminal.
+    // Workaround to enable using native emacs from the Zed terminal.
     // Unbind so Zed ignores these keys and lets emacs handle them.
+    // NOTE:
+    //  "terminal::SendKeystroke" only works for a single key stroke (e.g. ctrl-x),
+    //  so overwride with null for compound sequences (e.g. ctrl-x ctrl-c).
     "context": "Terminal",
     "bindings": {
+      // If you want to perfect your emacs-in-zed setup, also consider the following.
+      // You may need to enable "option_as_meta" from the Zed settings for "alt-x" to work.
+      // "alt-x": ["terminal::SendKeystroke", "alt-x"],
+      // "ctrl-x": ["terminal::SendKeystroke", "ctrl-x"],
+      // "ctrl-n": ["terminal::SendKeystroke", "ctrl-n"],
+      // ...
       "ctrl-x ctrl-c": null, // save-buffers-kill-terminal
       "ctrl-x ctrl-f": null, // find-file
       "ctrl-x ctrl-s": null, // save-buffer

--- a/assets/keymaps/macos/emacs.json
+++ b/assets/keymaps/macos/emacs.json
@@ -56,10 +56,10 @@
       "alt-d": ["editor::DeleteToNextWordEnd", { "ignore_newlines": false, "ignore_brackets": false }], // kill-word
       "alt-backspace": "editor::DeleteToPreviousWordStart", // backward-kill-word
       "alt-delete": "editor::DeleteToPreviousWordStart", // backward-kill-word
-      "ctrl-k": "editor::CutToEndOfLine", // kill-line
+      "ctrl-k": "editor::KillRingCut", // kill-line
       "ctrl-w": "editor::Cut", // kill-region
       "alt-w": "editor::Copy", // kill-ring-save
-      "ctrl-y": "editor::Paste", // yank
+      "ctrl-y": "editor::KillRingYank", // yank
       "ctrl-_": "editor::Undo", // undo
       "ctrl-/": "editor::Undo", // undo
       "ctrl-x u": "editor::Undo", // undo

--- a/assets/keymaps/macos/emacs.json
+++ b/assets/keymaps/macos/emacs.json
@@ -21,7 +21,6 @@
   {
     "context": "Editor",
     "bindings": {
-      "alt-x": "command_palette::Toggle",
       "ctrl-g": "editor::Cancel",
       "ctrl-x b": "tab_switcher::Toggle", // switch-to-buffer
       "ctrl-x ctrl-b": "tab_switcher::Toggle", // list-buffers
@@ -148,6 +147,7 @@
   {
     "context": "Workspace",
     "bindings": {
+      "alt-x": "command_palette::Toggle",
       "ctrl-x ctrl-c": "zed::Quit", // save-buffers-kill-terminal
       "ctrl-x 5 0": "workspace::CloseWindow", // delete-frame
       "ctrl-x 5 2": "workspace::NewWindow", // make-frame-command

--- a/assets/keymaps/macos/emacs.json
+++ b/assets/keymaps/macos/emacs.json
@@ -169,7 +169,7 @@
     // Unbind so Zed ignores these keys and lets emacs handle them.
     // NOTE:
     //  "terminal::SendKeystroke" only works for a single key stroke (e.g. ctrl-x),
-    //  so overwride with null for compound sequences (e.g. ctrl-x ctrl-c).
+    //  so override with null for compound sequences (e.g. ctrl-x ctrl-c).
     "context": "Terminal",
     "bindings": {
       // If you want to perfect your emacs-in-zed setup, also consider the following.

--- a/assets/keymaps/macos/emacs.json
+++ b/assets/keymaps/macos/emacs.json
@@ -120,15 +120,6 @@
     }
   },
   {
-    // Workaround to clear the selection after copy/paste commands.
-    // TODO: allow to do the same on minibuffers without closing them
-    "context": "Editor && mode == full",
-    "bindings": {
-      "ctrl-w": ["workspace::SendKeystrokes", "ctrl-w ctrl-g"],
-      "alt-w": ["workspace::SendKeystrokes", "alt-w ctrl-g"]
-    }
-  },
-  {
     "context": "Editor && (showing_code_actions || showing_completions)",
     "bindings": {
       "ctrl-p": "editor::ContextMenuPrevious",

--- a/assets/keymaps/macos/emacs.json
+++ b/assets/keymaps/macos/emacs.json
@@ -43,8 +43,8 @@
       "alt-m": ["editor::MoveToBeginningOfLine", { "stop_at_soft_wraps": false, "stop_at_indent": true }], // back-to-indentation
       "alt-left": "editor::MoveToPreviousWordStart", // left-word
       "alt-right": "editor::MoveToNextWordEnd", // right-word
-      "alt-f": "editor::MoveToNextSubwordEnd", // forward-word
-      "alt-b": "editor::MoveToPreviousSubwordStart", // backward-word
+      "alt-f": "editor::MoveToNextWordEnd", // forward-word
+      "alt-b": "editor::MoveToPreviousWordStart", // backward-word
       "alt-u": "editor::ConvertToUpperCase", // upcase-word
       "alt-l": "editor::ConvertToLowerCase", // downcase-word
       "alt-c": "editor::ConvertToUpperCamelCase", // capitalize-word
@@ -108,7 +108,7 @@
       "ctrl-e": ["editor::SelectToEndOfLine", { "stop_at_soft_wraps": false }],
       "alt-m": ["editor::SelectToBeginningOfLine", { "stop_at_soft_wraps": false, "stop_at_indent": true }],
       "alt-f": "editor::SelectToNextWordEnd",
-      "alt-b": "editor::SelectToPreviousSubwordStart",
+      "alt-b": "editor::SelectToPreviousWordStart",
       "alt-{": "editor::SelectToStartOfParagraph",
       "alt-}": "editor::SelectToEndOfParagraph",
       "ctrl-up": "editor::SelectToStartOfParagraph",


### PR DESCRIPTION
Hello,
I am having a great time setting up the editor, but with a few problems related to the Emacs keymap.

In this PR I have compiled changes in the default `emacs.json` that I believe make the onboarding smoother for incoming emacs users.
This includes points that may need further discussion and some breaking changes, although nothing that cannot be reverted with a quick `keymap.json` overwrite.

(Please let me know if it is better to split up the PR)

### 1. Avoid fallbacks to the default keymap
all platforms:
- `ctrl-g` activating `go_to_line::Toggle` when there is nothing to cancel

linux / windows:
- `ctrl-x` activating `editor::Cut` on the 1 second timeout
- `ctrl-p` activating `file_finder::Toggle` when the cursor is on the first character of the buffer
- `ctrl-n` activating `workspace::NewFile` when the cursor is on the last character of the buffer

### 2. Make all move commands operate on full words
In the current Zed implementation some commands run on full words and others on subwords.
Although ultimately a matter of user preference, I think it is sensible to use full words as the default, since that is what is shipped with emacs.

### ~~3. Cancel selections after copy/cut commands~~ Moved to #40904
Canceling the selection is the default emacs behavior, but the way to achieve it might need some brushing.
Currently I am using `workspace::SendKeystrokes` to copy -> cancel(`ctrl-g`), but this has the following problems:
- can only be used in the main buffer (since `editor::Cancel` would typically close secondary buffers)
- may cause problems downstream if the user overwrites the `ctrl-g` binding

### ~~4. Replace killring with normal cut/paste commands~~ Moved to #40905
Ideally Zed would support emacs-like killrings (#25270 and #22490).
However, I understand that making an emacs emulator is not a project goal, and the Zed team should have a bunch of tasks with higher priority.

By using a unified clipboard and standard cut/paste commands, we can provide an experience that is closer to the out-of-the-box emacs behavior (#33351) while also avoiding some pitfalls of the current killring implementation (#28715).

### 5. Promote some bindings to workspace commands
- `alt-x` as `command_palette::Toggle`
- `ctrl-x b` and `ctrl-x ctrl-b` as `tab_switcher::Toggle`

---

Release Notes:

- emacs: Fixed a problem where keys would fallback to their default keymap binding on certain conditions
- emacs: Changed `alt-f` and `alt-b` to operate on full words, as in the emacs default
- emacs: `alt-x`, `ctrl-x b`, and `ctrl-x ctrl-b` are now Workspace bindings

