### PR TITLE
Add comment injections for Python

### DIFF
--- a/crates/languages/src/python/injections.scm
+++ b/crates/languages/src/python/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+    (#set! injection.language "comment"))


### PR DESCRIPTION
Previous Rust support for comment highlighting by the file "zed/crates/languages/src/rust/injections.scm" improved experiences. We now extend this to Python based the extension `Comment` (https://github.com/thedadams/zed-comment)

------------

Screenshot comparison:

<img width="414" height="64" alt="Screenshot from 2025-10-19 09-26-11" src="https://github.com/user-attachments/assets/3beeb622-fdad-44da-8203-a04541314bc9" />

<img width="407" height="62" alt="Screenshot from 2025-10-19 09-25-14" src="https://github.com/user-attachments/assets/46f7ed8e-6a44-4db1-af40-29f0a3ede527" />

------------

Release Notes:

- Added native Python support to extension `Comment`.
