### PR TITLE
file_finder: Respect .gitignore and file_scan_inclusions with ** in glob

### DIFF
--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -1574,6 +1574,21 @@ mod tests {
     }
 
     #[perf]
+    fn file_in_dirs() {
+        let path = Path::new("/work/.env");
+        let path_matcher = PathMatcher::new(&["**/.env".to_owned()], PathStyle::Posix).unwrap();
+        assert!(
+            path_matcher.is_match(path),
+            "Path matcher should match {path:?}"
+        );
+        let path = Path::new("/work/package.json");
+        assert!(
+            !path_matcher.is_match(path),
+            "Path matcher should not match {path:?}"
+        );
+    }
+
+    #[perf]
     fn project_search() {
         let path = Path::new("/Users/someonetoignore/work/zed/zed.dev/node_modules");
         let path_matcher =

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -505,7 +505,7 @@ impl Worktree {
                 project_id,
                 replica_id,
                 snapshot,
-                file_scan_inclusions: settings.file_scan_inclusions.clone(),
+                file_scan_inclusions: settings.parent_dir_scan_inclusions.clone(),
                 background_snapshot: background_snapshot.clone(),
                 updates_tx: Some(background_updates_tx),
                 update_observer: None,
@@ -520,8 +520,10 @@ impl Worktree {
                 while let Some(update) = background_updates_rx.next().await {
                     {
                         let mut lock = background_snapshot.lock();
-                        lock.0
-                            .apply_remote_update(update.clone(), &settings.file_scan_inclusions);
+                        lock.0.apply_remote_update(
+                            update.clone(),
+                            &settings.parent_dir_scan_inclusions,
+                        );
                         lock.1.push(update);
                     }
                     snapshot_updated_tx.send(()).await.ok();

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -4290,7 +4290,8 @@ impl BackgroundScanner {
 
             if child_entry.is_dir() {
                 child_entry.is_ignored = ignore_stack.is_abs_path_ignored(&child_abs_path, true);
-                child_entry.is_always_included = self.settings.is_path_always_included(&child_path);
+                child_entry.is_always_included =
+                    self.settings.is_path_always_included(&child_path, true);
 
                 // Avoid recursing until crash in the case of a recursive symlink
                 if job.ancestor_inodes.contains(&child_entry.inode) {
@@ -4315,7 +4316,8 @@ impl BackgroundScanner {
                 }
             } else {
                 child_entry.is_ignored = ignore_stack.is_abs_path_ignored(&child_abs_path, false);
-                child_entry.is_always_included = self.settings.is_path_always_included(&child_path);
+                child_entry.is_always_included =
+                    self.settings.is_path_always_included(&child_path, false);
             }
 
             {
@@ -4450,7 +4452,8 @@ impl BackgroundScanner {
                     fs_entry.is_ignored = ignore_stack.is_abs_path_ignored(&abs_path, is_dir);
                     fs_entry.is_external = is_external;
                     fs_entry.is_private = self.is_path_private(path);
-                    fs_entry.is_always_included = self.settings.is_path_always_included(path);
+                    fs_entry.is_always_included =
+                        self.settings.is_path_always_included(path, is_dir);
 
                     let parent_is_hidden = path
                         .parent()

--- a/crates/worktree/src/worktree_settings.rs
+++ b/crates/worktree/src/worktree_settings.rs
@@ -16,6 +16,7 @@ pub struct WorktreeSettings {
     pub file_scan_inclusions: PathMatcher,
     // Mainly useful when a glob contains ** or * for directories
     pub parent_dir_scan_inclusions: PathMatcher,
+||||||| parent of c0a9841ba3 (file_finder: respect .gitignore and file_scan_inclusions with ** in glob)
     pub file_scan_exclusions: PathMatcher,
     pub private_files: PathMatcher,
 }

--- a/crates/worktree/src/worktree_settings.rs
+++ b/crates/worktree/src/worktree_settings.rs
@@ -15,7 +15,7 @@ pub struct WorktreeSettings {
     pub prevent_sharing_in_public_channels: bool,
     pub file_scan_inclusions: PathMatcher,
     // Mainly useful when a glob contains ** or * for directories
-    pub parsed_file_scan_inclusions: PathMatcher,
+    pub parent_dir_scan_inclusions: PathMatcher,
     pub file_scan_exclusions: PathMatcher,
     pub private_files: PathMatcher,
 }
@@ -33,8 +33,7 @@ impl WorktreeSettings {
 
     pub fn is_path_always_included(&self, path: &RelPath, is_dir: bool) -> bool {
         if is_dir {
-            self.parsed_file_scan_inclusions
-                .is_match(path.as_std_path())
+            self.parent_dir_scan_inclusions.is_match(path.as_std_path())
         } else {
             self.file_scan_inclusions.is_match(path.as_std_path())
         }
@@ -52,6 +51,7 @@ impl Settings for WorktreeSettings {
             .flat_map(|glob| {
                 Path::new(glob)
                     .ancestors()
+                    .skip(1)
                     .map(|a| a.to_string_lossy().into())
             })
             .filter(|p: &String| !p.is_empty())
@@ -63,7 +63,7 @@ impl Settings for WorktreeSettings {
             file_scan_exclusions: path_matchers(file_scan_exclusions, "file_scan_exclusions")
                 .log_err()
                 .unwrap_or_default(),
-            parsed_file_scan_inclusions: path_matchers(
+            parent_dir_scan_inclusions: path_matchers(
                 parsed_file_scan_inclusions,
                 "file_scan_inclusions",
             )

--- a/crates/worktree/src/worktree_settings.rs
+++ b/crates/worktree/src/worktree_settings.rs
@@ -13,11 +13,11 @@ pub struct WorktreeSettings {
     pub project_name: Option<String>,
     /// Whether to prevent this project from being shared in public channels.
     pub prevent_sharing_in_public_channels: bool,
-    pub file_scan_inclusions: PathMatcher,
-    // Mainly useful when a glob contains ** or * for directories
-    pub parent_dir_scan_inclusions: PathMatcher,
-||||||| parent of c0a9841ba3 (file_finder: respect .gitignore and file_scan_inclusions with ** in glob)
     pub file_scan_exclusions: PathMatcher,
+    pub file_scan_inclusions: PathMatcher,
+    /// This field contains all ancestors of the `file_scan_inclusions`. It's used to
+    /// determine whether to terminate worktree scanning for a given dir.
+    pub parent_dir_scan_inclusions: PathMatcher,
     pub private_files: PathMatcher,
 }
 

--- a/crates/worktree/src/worktree_settings.rs
+++ b/crates/worktree/src/worktree_settings.rs
@@ -14,6 +14,8 @@ pub struct WorktreeSettings {
     /// Whether to prevent this project from being shared in public channels.
     pub prevent_sharing_in_public_channels: bool,
     pub file_scan_inclusions: PathMatcher,
+    // Mainly useful when a glob contains ** or * for directories
+    pub parsed_file_scan_inclusions: PathMatcher,
     pub file_scan_exclusions: PathMatcher,
     pub private_files: PathMatcher,
 }
@@ -29,9 +31,13 @@ impl WorktreeSettings {
             .any(|ancestor| self.file_scan_exclusions.is_match(ancestor.as_std_path()))
     }
 
-    pub fn is_path_always_included(&self, path: &RelPath) -> bool {
-        path.ancestors()
-            .any(|ancestor| self.file_scan_inclusions.is_match(ancestor.as_std_path()))
+    pub fn is_path_always_included(&self, path: &RelPath, is_dir: bool) -> bool {
+        if is_dir {
+            self.parsed_file_scan_inclusions
+                .is_match(path.as_std_path())
+        } else {
+            self.file_scan_inclusions.is_match(path.as_std_path())
+        }
     }
 }
 
@@ -57,11 +63,13 @@ impl Settings for WorktreeSettings {
             file_scan_exclusions: path_matchers(file_scan_exclusions, "file_scan_exclusions")
                 .log_err()
                 .unwrap_or_default(),
-            file_scan_inclusions: path_matchers(
+            parsed_file_scan_inclusions: path_matchers(
                 parsed_file_scan_inclusions,
                 "file_scan_inclusions",
             )
             .unwrap(),
+            file_scan_inclusions: path_matchers(file_scan_inclusions, "file_scan_inclusions")
+                .unwrap(),
             private_files: path_matchers(private_files, "private_files")
                 .log_err()
                 .unwrap_or_default(),

--- a/crates/worktree/src/worktree_tests.rs
+++ b/crates/worktree/src/worktree_tests.rs
@@ -765,6 +765,7 @@ async fn test_file_scan_inclusions(cx: &mut TestAppContext) {
             "prettier": {
                 "package.json": "{}",
             },
+            "package.json": "//package.json"
         },
         "src": {
             ".DS_Store": "",


### PR DESCRIPTION
Closes #39037 

Previously, the code split the `**/.env` glob in `file_scan_inclusions` into two sources for the `PathMatcher`: `["**", "**/.env"]`. This approach works for directories, but including `**` will match all directories and their files. To address this, I now select the appropriate `PathMatcher` using only `**/.env` when specifically targeting a file to determine whether to include it in the file finder.

Release Notes:

- Fixed: respect `.gitignore` and `file_scan_inclusions` settings with `**` in glob for file finder
