### PR TITLE
docs: Add section about MCP servers with external agents

### DIFF
--- a/docs/src/ai/external-agents.md
+++ b/docs/src/ai/external-agents.md
@@ -210,11 +210,7 @@ When using external agents in Zed, you can access the debug view via with `dev: 
 
 ## MCP Servers
 
-Note that for external agents, access to MCP servers installed from Zed may vary depending on the ACP agent implementation.
+Note that for external agents, access to MCP servers [installed from Zed](./mcp.md) may vary depending on the ACP agent implementation.
 
-In case the ACP agent implementation doesn't support it, we recommend configuring MCP servers directly through the agent's own CLI.
-Learn how to do that for each built-in one through the documentation below:
-
-- [Anthropic's Claude Code](https://docs.claude.com/en/docs/claude-code/mcp#installing-mcp-servers)
-- [OpenAI's Codex](https://developers.openai.com/codex/mcp/#connect-codex-to-a-mcp-server)
-- [Google's Gemini CLI](https://github.com/google-gemini/gemini-cli?tab=readme-ov-file#using-mcp-servers)
+Regarding the built-in ones, Claude Code and Codex both support it, and Gemini CLI does not yet.
+In the meantime, learn how to add MCP server support to Gemini CLI through [their documentation](https://github.com/google-gemini/gemini-cli?tab=readme-ov-file#using-mcp-servers).

--- a/docs/src/ai/external-agents.md
+++ b/docs/src/ai/external-agents.md
@@ -209,10 +209,9 @@ When using external agents in Zed, you can access the debug view via with `dev: 
 
 ## MCP Servers
 
-Note that, currently, MCP servers installed _from_ Zed won't be picked up by external agents connected through ACP.
-This is valid for Claude Code, Codex, Gemini CLI, and any other one you may come to add.
+Note that for external agents, access to MCP servers installed from Zed may vary depending on the ACP agent implementation.
 
-You need to configure MCP servers for each external agent directly through their own CLI.
+In case the ACP agent implementation doesn't support it, we recommend configuring MCP servers directly through the agent's own CLI.
 Learn how to do that for each built-in one through the documentation below:
 
 - [Anthropic's Claude Code](https://docs.claude.com/en/docs/claude-code/mcp#installing-mcp-servers)

--- a/docs/src/ai/external-agents.md
+++ b/docs/src/ai/external-agents.md
@@ -206,3 +206,15 @@ You can also specify a custom path, arguments, or environment for the builtin in
 When using external agents in Zed, you can access the debug view via with `dev: open acp logs` from the Command Palette. This lets you see the messages being sent and received between Zed and the agent.
 
 ![The debug view for ACP logs.](https://zed.dev/img/acp/acp-logs.webp)
+
+## MCP Servers
+
+Note that, currently, MCP servers installed _from_ Zed won't be picked up by external agents connected through ACP.
+This is valid for Claude Code, Codex, Gemini CLI, and any other one you may come to add.
+
+You need to configure MCP servers for each external agent directly through their own CLI.
+Learn how to do that for each built-in one through the documentation below:
+
+- [Anthropic's Claude Code](https://docs.claude.com/en/docs/claude-code/mcp#installing-mcp-servers)
+- [OpenAI's Codex](https://developers.openai.com/codex/mcp/#connect-codex-to-a-mcp-server)
+- [Google's Gemini CLI](https://github.com/google-gemini/gemini-cli?tab=readme-ov-file#using-mcp-servers)

--- a/docs/src/ai/external-agents.md
+++ b/docs/src/ai/external-agents.md
@@ -3,9 +3,10 @@
 Zed supports terminal-based agents through the [Agent Client Protocol (ACP)](https://agentclientprotocol.com).
 
 Currently, [Gemini CLI](https://github.com/google-gemini/gemini-cli) serves as the reference implementation.
-[Claude Code](https://www.anthropic.com/claude-code) is also included by default, and you can [add custom ACP-compatible agents](#add-custom-agents) as well.
+[Claude Code](https://www.anthropic.com/claude-code) and [Codex](https://developers.openai.com/codex) are also included by default, and you can [add custom ACP-compatible agents](#add-custom-agents) as well.
 
-Zed's affordance for external agents is strictly UI-based; the billing and legal/terms arrangement is directly between you and the agent provider. Zed does not charge for use of external agents, and our [zero-data retention agreements/privacy guarantees](./ai-improvement.md) are **_only_** applicable for Zed's hosted models.
+> Note that Zed's affordance for external agents is strictly UI-based; the billing and legal/terms arrangement is directly between you and the agent provider.
+> Zed does not charge for use of external agents, and our [zero-data retention agreements/privacy guarantees](./ai-improvement.md) are **_only_** applicable for Zed's hosted models.
 
 ## Gemini CLI {#gemini-cli}
 

--- a/docs/src/ai/mcp.md
+++ b/docs/src/ai/mcp.md
@@ -68,7 +68,7 @@ To check if your MCP server is properly configured, go to the Agent Panel's sett
 If they're running correctly, the indicator will be green and its tooltip will say "Server is active".
 If not, other colors and tooltip messages will indicate what is happening.
 
-### Usage in the Agent Panel
+### Agent Panel Usage
 
 Once installation is complete, you can return to the Agent Panel and start prompting.
 

--- a/docs/src/ai/mcp.md
+++ b/docs/src/ai/mcp.md
@@ -11,7 +11,7 @@ Check out the [Anthropic news post](https://www.anthropic.com/news/model-context
 ### As Extensions
 
 One of the ways you can use MCP servers in Zed is by exposing them as an extension.
-To learn how to create your own, check out the [MCP Server Extensions](../extensions/mcp-extensions.md) page for more details.
+Check out the [MCP Server Extensions](../extensions/mcp-extensions.md) page to learn how to create your own.
 
 Thanks to our awesome community, many MCP servers have already been added as extensions.
 You can check which ones are available via any of these routes:
@@ -20,7 +20,7 @@ You can check which ones are available via any of these routes:
 2. in the app, open the Command Palette and run the `zed: extensions` action
 3. in the app, go to the Agent Panel's top-right menu and look for the "View Server Extensions" menu item
 
-In any case, here are some of the ones available:
+In any case, here are some popular available servers:
 
 - [Context7](https://zed.dev/extensions/context7-mcp-server)
 - [GitHub](https://zed.dev/extensions/github-mcp-server)
@@ -57,9 +57,9 @@ From there, you can add it through the modal that appears when you click the "Ad
 
 ### Configuration Check
 
-Regardless of how you've installed MCP servers, whether as an extension or adding them directly, most servers out there still require some sort of configuration as part of the set up process.
+Regardless of how you've installed MCP servers, whether as an extension or adding them directly, most servers out there still require some sort of configuration as part of the setup process.
 
-In the case of server extensions, after installing it, Zed will pop up a modal displaying what is required for you to properly set it up.
+In the case of extensions, after installing it, Zed will pop up a modal displaying what is required for you to properly set it up.
 For example, the GitHub MCP extension requires you to add a [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens).
 
 In the case of custom servers, make sure you check the provider documentation to determine what type of command, arguments, and environment variables need to be added to the JSON.
@@ -68,14 +68,14 @@ To check if your MCP server is properly configured, go to the Agent Panel's sett
 If they're running correctly, the indicator will be green and its tooltip will say "Server is active".
 If not, other colors and tooltip messages will indicate what is happening.
 
-### Using it in the Agent Panel
+### Usage in the Agent Panel
 
 Once installation is complete, you can return to the Agent Panel and start prompting.
 
 Some models are better than others when it comes to picking up tools from MCP servers.
 Mentioning your server by name always helps the model to pick it up.
 
-However, if you want to ensure a given MCP server will be used, you can create [a custom profile](./agent-panel.md#custom-profiles) where all built-in tools (or the ones that could cause conflicts with the server's tools) are turned off and only the tools coming from the MCP server are turned on.
+However, if you want to _ensure_ a given MCP server will be used, you can create [a custom profile](./agent-panel.md#custom-profiles) where all built-in tools (or the ones that could cause conflicts with the server's tools) are turned off and only the tools coming from the MCP server are turned on.
 
 As an example, [the Dagger team suggests](https://container-use.com/agent-integrations#zed) doing that with their [Container Use MCP server](https://zed.dev/extensions/mcp-server-container-use):
 
@@ -127,3 +127,15 @@ As an example, [the Dagger team suggests](https://container-use.com/agent-integr
 Zed's Agent Panel includes the `agent.always_allow_tool_actions` setting that, if set to `false`, will require you to give permission for any editing attempt as well as tool calls coming from MCP servers.
 
 You can change this by setting this key to `true` in either your `settings.json` or through the Agent Panel's settings view.
+
+### External Agents
+
+Note that, currently, MCP servers installed _from_ Zed won't be picked up by [external agents](./external-agents.md) connected through the [Agent Client Protocol (ACP)](https://agentclientprotocol.com/overview/introduction).
+This is valid for Claude Code, Codex, Gemini CLI, and any other one you may come to add.
+
+You need to configure MCP servers for each external agent directly through their own CLI.
+Learn how to do that for each built-in one through the documentation below:
+
+- [Anthropic's Claude Code](https://docs.claude.com/en/docs/claude-code/mcp#installing-mcp-servers)
+- [OpenAI's Codex](https://developers.openai.com/codex/mcp/#connect-codex-to-a-mcp-server)
+- [Google's Gemini CLI](https://github.com/google-gemini/gemini-cli?tab=readme-ov-file#using-mcp-servers)

--- a/docs/src/ai/mcp.md
+++ b/docs/src/ai/mcp.md
@@ -130,11 +130,7 @@ You can change this by setting this key to `true` in either your `settings.json`
 
 ### External Agents
 
-Note that for external agents connected through the [Agent Client Protocol](https://agentclientprotocol.com/overview/introduction), access to MCP servers installed from Zed may vary depending on the ACP agent implementation.
+Note that for [external agents](./external-agents.md) connected through the [Agent Client Protocol](https://agentclientprotocol.com/), access to MCP servers installed from Zed may vary depending on the ACP agent implementation.
 
-In case the ACP agent implementation doesn't support it, we recommend configuring MCP servers directly through the agent's own CLI.
-Learn how to do that for each built-in one through the documentation below:
-
-- [Anthropic's Claude Code](https://docs.claude.com/en/docs/claude-code/mcp#installing-mcp-servers)
-- [OpenAI's Codex](https://developers.openai.com/codex/mcp/#connect-codex-to-a-mcp-server)
-- [Google's Gemini CLI](https://github.com/google-gemini/gemini-cli?tab=readme-ov-file#using-mcp-servers)
+Regarding the built-in ones, Claude Code and Codex both support it, and Gemini CLI does not yet.
+In the meantime, learn how to add MCP server support to Gemini CLI through [their documentation](https://github.com/google-gemini/gemini-cli?tab=readme-ov-file#using-mcp-servers).

--- a/docs/src/ai/mcp.md
+++ b/docs/src/ai/mcp.md
@@ -130,10 +130,9 @@ You can change this by setting this key to `true` in either your `settings.json`
 
 ### External Agents
 
-Note that, currently, MCP servers installed _from_ Zed won't be picked up by [external agents](./external-agents.md) connected through the [Agent Client Protocol (ACP)](https://agentclientprotocol.com/overview/introduction).
-This is valid for Claude Code, Codex, Gemini CLI, and any other one you may come to add.
+Note that for external agents connected through the [Agent Client Protocol](https://agentclientprotocol.com/overview/introduction), access to MCP servers installed from Zed may vary depending on the ACP agent implementation.
 
-You need to configure MCP servers for each external agent directly through their own CLI.
+In case the ACP agent implementation doesn't support it, we recommend configuring MCP servers directly through the agent's own CLI.
 Learn how to do that for each built-in one through the documentation below:
 
 - [Anthropic's Claude Code](https://docs.claude.com/en/docs/claude-code/mcp#installing-mcp-servers)

--- a/docs/src/ai/overview.md
+++ b/docs/src/ai/overview.md
@@ -18,11 +18,11 @@ Learn how to get started using AI with Zed and all its capabilities.
 
 - [Rules](./rules.md): How to define rules for AI interactions.
 
-- [Tools](./tools.md): Explore the tools that enable agentic capabilities.
+- [Tools](./tools.md): Explore the tools that power Zed's built-in agent.
 
-- [Model Context Protocol](./mcp.md): Learn about how to install and configure MCP servers.
+- [Model Context Protocol](./mcp.md): Learn about how to configure and use MCP servers.
 
-- [Inline Assistant](./inline-assistant.md): Discover how to use the agent to power inline transformations directly within a file or terminal.
+- [Inline Assistant](./inline-assistant.md): Discover how to use AI to generate inline transformations directly within a file or terminal.
 
 ## Edit Prediction
 
@@ -30,4 +30,4 @@ Learn how to get started using AI with Zed and all its capabilities.
 
 ## Text Threads
 
-- [Text Threads](./text-threads.md): Learn about an alternative, text-based interface for interacting with language models.
+- [Text Threads](./text-threads.md): Learn about an editor-based interface for interacting with language models.


### PR DESCRIPTION
Adding this content after seeing people ask about how to make MCP servers installed from Zed be picked up by external agents. At the moment, this varies depending on the agent, and felt relevant to be documented.

Release Notes:

- N/A
