### PR TITLE
docs: Change tab character representation in docs

### DIFF
--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -182,7 +182,7 @@ TBD: Centered layout related settings
   "show_whitespaces": "selection",
   "whitespace_map": { // Which characters to show when `show_whitespaces` enabled
     "space": "•",
-    "tab": "→"
+    "tab": "⟶"       // use "→", for a shorter arrow
   },
 
   "unnecessary_code_fade": 0.3, // How much to fade out unused code.


### PR DESCRIPTION
The suggested `→` appears tiny, and almost looks like just a dot on my monitor, and I got quite confused for a while thinking the `whitespace_map.tab` setting wasn't working properly.
<img width="630" height="105" alt="Image" src="https://github.com/user-attachments/assets/98feced2-39b3-4734-83e4-b4573b4e52c2" />

I think it would be really helpful if `⟶` was suggested instead since that displays properly.
<img width="625" height="104" alt="Image" src="https://github.com/user-attachments/assets/176886ab-cf88-4079-90a8-91a8e8182092" />

---

I am using `Fira Code` as my font on windows, however when I remove that config to get the default font, it also still appears the same size. So I don't believe this is just a font issue on my machine.
Thought I am using Windows, so I would be willing to believe this a render issue specific to windows

Release Notes:

- N/A