### PR TITLE
CollapseAllDiffHunks action for editor

### DIFF
--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -458,6 +458,8 @@ actions!(
         /// Expands all diff hunks in the editor.
         #[action(deprecated_aliases = ["editor::ExpandAllHunkDiffs"])]
         ExpandAllDiffHunks,
+        /// Collapses all diff hunks in the editor.
+        CollapseAllDiffHunks,
         /// Expands macros recursively at cursor position.
         ExpandMacroRecursively,
         /// Finds all references to the symbol at cursor.

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -18782,6 +18782,17 @@ impl Editor {
         });
     }
 
+    pub fn collapse_all_diff_hunks(
+        &mut self,
+        _: &CollapseAllDiffHunks,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.buffer.update(cx, |buffer, cx| {
+            buffer.collapse_diff_hunks(vec![Anchor::min()..Anchor::max()], cx)
+        });
+    }
+
     pub fn toggle_selected_diff_hunks(
         &mut self,
         _: &ToggleSelectedDiffHunks,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -493,6 +493,7 @@ impl EditorElement {
         register_action(editor, window, Editor::stage_and_next);
         register_action(editor, window, Editor::unstage_and_next);
         register_action(editor, window, Editor::expand_all_diff_hunks);
+        register_action(editor, window, Editor::collapse_all_diff_hunks);
         register_action(editor, window, Editor::go_to_previous_change);
         register_action(editor, window, Editor::go_to_next_change);
 


### PR DESCRIPTION
This PR adds a new action `editor::CollapseAllDiffHunks`
which will allow the user to choose any keybinding for hiding the Expanded Diff Hunks.

Release Notes:

- Added the `editor::CollapseAllDiffHunks` action, mirroring the existing `editor::ExpandAllDiffHunks`.