### PR TITLE
Make editor::Cancel no longer clear expanded diffs

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -3963,10 +3963,6 @@ impl Editor {
         self.selection_mark_mode = false;
         self.selection_drag_state = SelectionDragState::None;
 
-        if self.clear_expanded_diff_hunks(cx) {
-            cx.notify();
-            return;
-        }
         if self.dismiss_menus_and_popups(true, window, cx) {
             return;
         }

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -19310,24 +19310,6 @@ async fn test_toggle_selected_diff_hunks(executor: BackgroundExecutor, cx: &mut 
         .unindent(),
     );
 
-    cx.update_editor(|editor, window, cx| {
-        editor.cancel(&Cancel, window, cx);
-    });
-
-    cx.assert_state_with_diff(
-        r#"
-          use some::modified;
-
-          ˇ
-          fn main() {
-              println!("hello there");
-
-              println!("around the");
-              println!("world");
-          }
-        "#
-        .unindent(),
-    );
 }
 
 #[gpui::test]

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -19309,7 +19309,6 @@ async fn test_toggle_selected_diff_hunks(executor: BackgroundExecutor, cx: &mut 
         "#
         .unindent(),
     );
-
 }
 
 #[gpui::test]


### PR DESCRIPTION
Selfishly.

i really don't like that `editor::Cancel` dismisses the diff hunks.

before coming to zed, i would fairly regularly work with the git changes visible in the file. I find it useful sometimes to see what i have moved or deleted.

with the only way of dismissing the diff hunks trapped inside of `editor::Cancel`
it creates a lot of friction to try and edit with these intentionally left open.
the diffs are removed before i can dismiss a notification. or before i can cancel a pop up, or ANYTHING else because dismissing the diff hunks is the first item in the `editor::Cancel` function.

My preference would be to have a dedicated keybinding that shows/hides the diff hunks that is not part of the cancel action.

with the addition of a new context `diffs_expanded` from #40617 

and the new action `editor::CollapseAllDiffHunks` from #40668 

adding the following keybinding to the base keymap, would make it so that nothing changes for most users
```json
{
  "context": "Editor && diffs_expanded",
  "bindings": {
    "escape" : "editor::CollapseAllDiffHunks"
  }
}
```


however it would be more flexible for other users, like me, who would prefer a more toggle style experience
```json
{
  "context": "Editor",
  "bindings": {
    "cmd-alt-g" : "editor::ExpandAllDiffHunks"
  }
},
{
  "context": "Editor && diffs_expanded",
  "bindings": {
    "cmd-alt-g" : "editor::CollapseAllDiffHunks"
  }
}
```

please note that just adding `CollapseAllDiffHunks` and `diffs_expanded` will not be enough to make this behavior more flexible for users. the functionality *must* be removed from `editor::Cancel` otherwise it won't be possible to leave the diff hunks open and continue working normally.

I would expect that I would need to update the tests, keymap, and docs before a PR like this would be accepted. I just wanted to get some feedback here first.

thanks!

