### PR TITLE
fs: Reintroduce benchmarks crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6342,6 +6342,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_benchmarks"
+version = "0.1.0"
+dependencies = [
+ "fs",
+ "gpui",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ members = [
     "crates/file_finder",
     "crates/file_icons",
     "crates/fs",
+    "crates/fs_benchmarks",
     "crates/fsevent",
     "crates/fuzzy",
     "crates/git",

--- a/crates/fs_benchmarks/Cargo.toml
+++ b/crates/fs_benchmarks/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "fs_benchmarks"
+version = "0.1.0"
+publish.workspace = true
+edition.workspace = true
+
+[dependencies]
+fs.workspace = true
+gpui = {workspace = true, features = ["windows-manifest"]}
+
+[lints]
+workspace = true


### PR DESCRIPTION
It was erroenously removed in #40216

Release Notes:

- N/A
