### PR TITLE
terminal_view: Clear bell flag on terminal close to allow auto-close

### DIFF
--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -959,7 +959,10 @@ fn subscribe_for_terminal_events(
                     ),
                 },
                 Event::BreadcrumbsChanged => cx.emit(ItemEvent::UpdateBreadcrumbs),
-                Event::CloseTerminal => cx.emit(ItemEvent::CloseItem),
+                Event::CloseTerminal => {
+                    terminal_view.has_bell = false;
+                    cx.emit(ItemEvent::CloseItem);
+                }
                 Event::SelectionsChanged => {
                     window.invalidate_character_coordinates();
                     cx.emit(SearchEvent::ActiveMatchChanged)


### PR DESCRIPTION
When a terminal process exits normally (e.g., typing 'exit' in an SSH session), the terminal panel should automatically close. However, if a bell event occurred during the session and the user didn't type anything afterwards to clear it, the terminal remained open.

The issue was that the `has_bell` flag was still set to `true` when the terminal exited, causing `is_dirty()` to return `true`. This prevented the pane from auto-closing the terminal, as dirty items require user confirmation before closing.

This fix clears the `has_bell` flag when receiving the `CloseTerminal` event, ensuring that terminals with historical bell events can close automatically when the process exits successfully.

Release Notes:

- N/A
