### PR TITLE
acp: Fix following for agents that only provide locations

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -1400,11 +1400,9 @@ impl AcpThread {
             this.update(cx, |this, cx| {
                 let project = this.project.clone();
 
-                for location in &resolved_locations {
-                    if let Some((_, buffer)) = location {
-                        let snapshot = buffer.read(cx).snapshot();
-                        this.shared_buffers.insert(buffer.clone(), snapshot);
-                    }
+                for (_, buffer) in resolved_locations.iter().flatten() {
+                    let snapshot = buffer.read(cx).snapshot();
+                    this.shared_buffers.insert(buffer.clone(), snapshot);
                 }
 
                 let resolved_locations = resolved_locations


### PR DESCRIPTION
We were dropping the entities once we created the buffers, so the weak
entities could never be upgraded. This treats new locations we see the
same as we would for a read/write call and stores the entity so that we
can follow like we normally would.

Release Notes:

- acp: Fix following not working with certain tool calls.
