### PR TITLE
theme: Change the icon used for JSONC files

### DIFF
--- a/crates/theme/src/icon_theme.rs
+++ b/crates/theme/src/icon_theme.rs
@@ -152,7 +152,7 @@ const FILE_SUFFIXES_BY_ICON_KEY: &[(&str, &[&str])] = &[
     ),
     ("java", &["java"]),
     ("javascript", &["cjs", "js", "mjs"]),
-    ("json", &["json"]),
+    ("json", &["json", "jsonc"]),
     ("julia", &["jl"]),
     ("kdl", &["kdl"]),
     ("kotlin", &["kt"]),
@@ -199,9 +199,9 @@ const FILE_SUFFIXES_BY_ICON_KEY: &[(&str, &[&str])] = &[
     (
         "storage",
         &[
-            "accdb", "csv", "dat", "db", "dbf", "dll", "fmp", "fp7", "frm", "gdb", "ib", "jsonc",
-            "ldf", "mdb", "mdf", "myd", "myi", "pdb", "RData", "rdata", "sav", "sdf", "sql",
-            "sqlite", "tsv",
+            "accdb", "csv", "dat", "db", "dbf", "dll", "fmp", "fp7", "frm", "gdb", "ib", "ldf",
+            "mdb", "mdf", "myd", "myi", "pdb", "RData", "rdata", "sav", "sdf", "sql", "sqlite",
+            "tsv",
         ],
     ),
     (


### PR DESCRIPTION
Closes #40683

Release Notes:
This pull request updates the mapping of file extensions to icon keys in the `icon_theme.rs` file. The main change is to improve how `.jsonc` files are classified, ensuring they are now associated with the JSON icon rather than the storage icon.

File icon mapping updates:

* Added the `jsonc` file extension to the `json` icon key, so `.jsonc` files now use the JSON icon instead of being grouped with storage-related files.
* Removed the `jsonc` extension from the `storage` icon key to prevent `.jsonc` files from being incorrectly classified as storage files.