### PR TITLE
vim: Fix hang in visual block motion

### DIFF
--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -366,7 +366,8 @@ impl Vim {
 
             let mut selections = Vec::new();
             let mut row = tail.row();
-            let direction = if tail.row() > head.row() { -1 } else { 1 };
+            let going_up = tail.row() > head.row();
+            let direction = if going_up { -1 } else { 1 };
 
             loop {
                 let laid_out_line = map.layout_row(row, &text_layout_details);
@@ -398,27 +399,20 @@ impl Vim {
                     selections.push(selection);
                 }
 
-                if row == head.row() {
+                // When dealing with soft wrapped lines, it's possible that
+                // `row` ends up being set to a value other than `head.row()` as
+                // `head.row()` might be a `DisplayPoint` mapped to a soft
+                // wrapped line, hence the need for `<=` and `>=` instead of
+                // `==`.
+                if going_up && row <= head.row() || !going_up && row >= head.row() {
                     break;
                 }
 
                 // Find the next or previous buffer row where the `row` should
                 // be moved to, so that wrapped lines are skipped.
-                let buffer_row = map
+                row = map
                     .start_of_relative_buffer_row(DisplayPoint::new(row, 0), direction)
                     .row();
-
-                while row != buffer_row {
-                    if tail.row() > head.row() {
-                        row.0 -= 1;
-                    } else {
-                        row.0 += 1;
-                    }
-
-                    if row == head.row() {
-                        break;
-                    }
-                }
             }
 
             s.select(selections);

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -366,6 +366,7 @@ impl Vim {
 
             let mut selections = Vec::new();
             let mut row = tail.row();
+            let direction = if tail.row() > head.row() { -1 } else { 1 };
 
             loop {
                 let laid_out_line = map.layout_row(row, &text_layout_details);
@@ -396,13 +397,13 @@ impl Vim {
 
                     selections.push(selection);
                 }
-                if row == head.row() {
+
+                if direction == -1 && row <= head.row() || direction == 1 && row >= head.row() {
                     break;
                 }
 
                 // Move to the next or previous buffer row, ensuring that
                 // wrapped lines are handled correctly.
-                let direction = if tail.row() > head.row() { -1 } else { 1 };
                 row = map
                     .start_of_relative_buffer_row(DisplayPoint::new(row, 0), direction)
                     .row();

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -398,15 +398,27 @@ impl Vim {
                     selections.push(selection);
                 }
 
-                if direction == -1 && row <= head.row() || direction == 1 && row >= head.row() {
+                if row == head.row() {
                     break;
                 }
 
-                // Move to the next or previous buffer row, ensuring that
-                // wrapped lines are handled correctly.
-                row = map
+                // Find the next or previous buffer row where the `row` should
+                // be moved to, so that wrapped lines are skipped.
+                let buffer_row = map
                     .start_of_relative_buffer_row(DisplayPoint::new(row, 0), direction)
                     .row();
+
+                while row != buffer_row {
+                    if tail.row() > head.row() {
+                        row.0 -= 1;
+                    } else {
+                        row.0 += 1;
+                    }
+
+                    if row == head.row() {
+                        break;
+                    }
+                }
             }
 
             s.select(selections);


### PR DESCRIPTION
The `vim::visual::Vim.visual_block_motion` method was recently updated (https://github.com/zed-industries/zed/pull/39355) in order to jump between buffer rows instead of display rows. However, with this now being the case, the `break` condition was never met when the motion was horizontal rather than vertical and soft wrapped lines were used. As such, this commit udpates the condition to ensure it's always reached, preventing the hanging from happening.

Release Notes:

- Fixed hang in Vim's visual block motions when updating selections
