### PR TITLE
gpui: Box `Window` instances

### DIFF
--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -455,7 +455,7 @@ impl TestAppContext {
             .windows
             .get_mut(window.id)
             .unwrap()
-            .as_mut()
+            .as_deref_mut()
             .unwrap()
             .platform_window
             .as_test()

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -4718,7 +4718,7 @@ impl<V: 'static + Render> WindowHandle<V> {
             .get(self.id)
             .and_then(|window| {
                 window
-                    .as_ref()
+                    .as_deref()
                     .and_then(|window| window.root.clone())
                     .map(|root_view| root_view.downcast::<V>())
             })


### PR DESCRIPTION
We very frequently move this in and out of the windows slot map on `update_window_id` calls (and we call this a lot!). This alone showed up as `memmove`s at roughly 1% perf in Instruments when scrolling a buffer which makes sense, `Window` itself is 4kb in size. The fix is simple, just box the `Window` instances, moving a pointer is cheap in comparison.

Release Notes:

- N/A *or* Added/Fixed/Improved ...
