### PR TITLE
settings ui: Autoscroll content during keyboard navigation

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -1271,7 +1271,9 @@
     "use_key_equivalents": true,
     "bindings": {
       "up": "settings_editor::FocusPreviousNavEntry",
+      "shift-tab": "settings_editor::FocusPreviousNavEntry",
       "down": "settings_editor::FocusNextNavEntry",
+      "tab": "settings_editor::FocusNextNavEntry",
       "right": "settings_editor::ExpandNavEntry",
       "left": "settings_editor::CollapseNavEntry",
       "pageup": "settings_editor::FocusPreviousRootNavEntry",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -1376,7 +1376,9 @@
     "use_key_equivalents": true,
     "bindings": {
       "up": "settings_editor::FocusPreviousNavEntry",
+      "shift-tab": "settings_editor::FocusPreviousNavEntry",
       "down": "settings_editor::FocusNextNavEntry",
+      "tab": "settings_editor::FocusNextNavEntry",
       "right": "settings_editor::ExpandNavEntry",
       "left": "settings_editor::CollapseNavEntry",
       "pageup": "settings_editor::FocusPreviousRootNavEntry",

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -1299,7 +1299,9 @@
     "use_key_equivalents": true,
     "bindings": {
       "up": "settings_editor::FocusPreviousNavEntry",
+      "shift-tab": "settings_editor::FocusPreviousNavEntry",
       "down": "settings_editor::FocusNextNavEntry",
+      "tab": "settings_editor::FocusNextNavEntry",
       "right": "settings_editor::ExpandNavEntry",
       "left": "settings_editor::CollapseNavEntry",
       "pageup": "settings_editor::FocusPreviousRootNavEntry",

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -4313,14 +4313,14 @@ impl Window {
     }
 
     /// Returns a generic handler that invokes the given handler with the view and context associated with the given view handle.
-    pub fn handler_for<V: Render, Callback: Fn(&mut V, &mut Window, &mut Context<V>) + 'static>(
+    pub fn handler_for<E: 'static, Callback: Fn(&mut E, &mut Window, &mut Context<E>) + 'static>(
         &self,
-        view: &Entity<V>,
+        entity: &Entity<E>,
         f: Callback,
-    ) -> impl Fn(&mut Window, &mut App) + use<V, Callback> {
-        let view = view.downgrade();
+    ) -> impl Fn(&mut Window, &mut App) + 'static {
+        let entity = entity.downgrade();
         move |window: &mut Window, cx: &mut App| {
-            view.update(cx, |view, cx| f(view, window, cx)).ok();
+            entity.update(cx, |entity, cx| f(entity, window, cx)).ok();
         }
     }
 

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -2413,7 +2413,6 @@ impl SettingsWindow {
                     window.focus_prev();
                     return;
                 }
-                dbg!("select prev");
                 let mut prev_was_header = false;
                 for (logical_index, (actual_index, item)) in this.visible_page_items().enumerate() {
                     let is_header = matches!(item, SettingsPageItem::SectionHeader(_));
@@ -2425,7 +2424,6 @@ impl SettingsWindow {
                         offset -= 1;
                     }
                     if handle.contains_focused(window, cx) {
-                        dbg!("found focus handle and scroll to reveal item two");
                         let next_logical_index = logical_index + offset - 1;
                         this.list_state.scroll_to_reveal_item(next_logical_index);
                         // We need to render the next item to ensure it's focus handle is in the element tree

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -2636,19 +2636,6 @@ impl SettingsWindow {
         self.content_handles[page_index][actual_item_index].focus_handle(cx)
     }
 
-    fn focus_content_element(
-        &self,
-        actual_item_index: usize,
-        window: &mut Window,
-        cx: &mut Context<SettingsWindow>,
-    ) {
-        if !sub_page_stack().is_empty() {
-            return;
-        }
-
-        window.focus(&self.focus_handle_for_content_element(actual_item_index, cx));
-    }
-
     fn focused_nav_entry(&self, window: &Window, cx: &App) -> Option<usize> {
         if !self
             .navbar_focus_handle


### PR DESCRIPTION
Closes #40608

This fixes tabbing in both the settings ui nav bar and page content going off screen instead of scrolling the focused element into a visible view.

The bug occurred because `gpui::list` and `gpui::uniform_list` only render visible elements, preventing non-visible elements in a view from having their focus handle added to the element tree. Thus making the tab stop map skip over those elements because they weren't present.

The fix for this is scrolling to reveal non-visible elements and then focus the selected element on the next frame.  

Release Notes:

- settings ui: Auto-scroll to reveal items in navigation bar and window when tabbing
