### PR TITLE
Editor end of input context

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2551,6 +2551,10 @@ impl Editor {
             key_context.add("selection_mode");
         }
 
+        if self.selections.all(self.snapshot(window, cx)).iter().all(|s| todo!("figure out if text is in selection")) {
+            key_context.add("end_of_line")
+        }
+
         key_context
     }
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -1753,7 +1753,6 @@ fn test_beginning_end_of_line(cx: &mut TestAppContext) {
 
     _ = editor.update(cx, |editor, window, cx| {
         editor.move_to_beginning_of_line(&move_to_beg, window, cx);
-        assert!(!editor.key_context(window, cx).contains("end_of_buffer"));
         assert_eq!(
             editor.selections.display_ranges(cx),
             &[
@@ -1765,7 +1764,6 @@ fn test_beginning_end_of_line(cx: &mut TestAppContext) {
 
     _ = editor.update(cx, |editor, window, cx| {
         editor.move_to_end_of_line(&move_to_end, window, cx);
-        assert!(editor.key_context(window, cx).contains("end_of_buffer"));
         assert_eq!(
             editor.selections.display_ranges(cx),
             &[
@@ -1778,7 +1776,6 @@ fn test_beginning_end_of_line(cx: &mut TestAppContext) {
     // Moving to the end of line again is a no-op.
     _ = editor.update(cx, |editor, window, cx| {
         editor.move_to_end_of_line(&move_to_end, window, cx);
-        assert!(editor.key_context(window, cx).contains("end_of_buffer"));
         assert_eq!(
             editor.selections.display_ranges(cx),
             &[
@@ -1798,7 +1795,6 @@ fn test_beginning_end_of_line(cx: &mut TestAppContext) {
             window,
             cx,
         );
-        assert!(!editor.key_context(window, cx).contains("end_of_buffer"));
         assert_eq!(
             editor.selections.display_ranges(cx),
             &[

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -26853,7 +26853,6 @@ async fn test_end_of_editor_context(cx: &mut TestAppContext) {
     cx.set_state("ˇline1\nline2");
     cx.update_editor(|e, window, cx| {
         assert!(!e.key_context(window, cx).contains("end_of_input"));
-
     });
     cx.set_state("line1ˇ\nline2");
     cx.update_editor(|e, window, cx| {


### PR DESCRIPTION
This is needed for #38914 and seems generally useful to have for contextual keybindings.

Release Notes:

- N/A
