### PR TITLE
Fix inlay hint cleanup on excerpts removal

### DIFF
--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -594,7 +594,11 @@ impl DisplayMap {
         self.block_map.read(snapshot, edits);
     }
 
-    pub fn remove_inlays_for_excerpts(&mut self, excerpts_removed: &[ExcerptId]) {
+    pub fn remove_inlays_for_excerpts(
+        &mut self,
+        excerpts_removed: &[ExcerptId],
+        cx: &mut Context<Self>,
+    ) {
         let to_remove = self
             .inlay_map
             .current_inlays()
@@ -606,7 +610,7 @@ impl DisplayMap {
                 }
             })
             .collect::<Vec<_>>();
-        self.inlay_map.splice(&to_remove, Vec::new());
+        self.splice_inlays(&to_remove, Vec::new(), cx);
     }
 
     fn tab_size(buffer: &Entity<MultiBuffer>, cx: &App) -> NonZeroU32 {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5298,8 +5298,8 @@ impl Editor {
                 {
                     self.splice_inlays(&to_remove, to_insert, cx);
                 }
-                self.display_map.update(cx, |display_map, _| {
-                    display_map.remove_inlays_for_excerpts(&excerpts_removed)
+                self.display_map.update(cx, |display_map, cx| {
+                    display_map.remove_inlays_for_excerpts(&excerpts_removed, cx)
                 });
                 return;
             }


### PR DESCRIPTION
A cherry-pick of https://github.com/zed-industries/zed/pull/40183/commits/f5188d55fbcbb3856038967bce8e824ddb42bdba

This fixes a hard-to-reproduce crash caused excerpts removal not updating previous snapshot data after corresponding inlay data was removed.
Same branch has a test: https://github.com/zed-industries/zed/pull/40183/commits/8783a9eb4fbc60e3fbe0654c2d330bddfaa7ef0a that does not fail on `main` due to different way inlays are queried, it will be merged later. 

Release Notes:

- N/A
