### PR TITLE
Add `line_endings_button` in VSCode settings to fix semantic merge conflict

### DIFF
--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -635,6 +635,7 @@ impl VsCodeSettings {
             show: self.read_bool("workbench.statusBar.visible"),
             active_language_button: None,
             cursor_position_button: None,
+            line_endings_button: None,
         })
     }
 


### PR DESCRIPTION
I have partially solved a problem caused by a structure in commit: f7a0971d2b9c366338dabad13fb494fe0a2c83b1

Release Notes:

- N/A

Before:
<img width="723" height="480" alt="image" src="https://github.com/user-attachments/assets/6600e0af-36cf-4aec-ace1-7ee4921e001e" />

After: 
<img width="764" height="217" alt="image" src="https://github.com/user-attachments/assets/52111c27-c67a-4224-82bd-782cc6e07f97" />
