### PR TITLE
Fix enum variant names in BaseKeymap

### DIFF
--- a/crates/settings/src/base_keymap_setting.rs
+++ b/crates/settings/src/base_keymap_setting.rs
@@ -7,13 +7,13 @@ use settings::Settings;
 
 /// Base key bindings scheme. Base keymaps can be overridden with user keymaps.
 ///
-/// Default: VSCode
+/// Default: VS Code
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq, Default)]
 pub enum BaseKeymap {
     #[default]
-    VSCode,
+    VS Code,
     JetBrains,
-    SublimeText,
+    Sublime Text,
     Atom,
     TextMate,
     Emacs,


### PR DESCRIPTION
Updated enum variant names for consistency.

Two product names with minor typos.

Closes #ISSUE

Release Notes:

- N/A 
