### PR TITLE
ci: Do not use full debug info in CI builds

### DIFF
--- a/.cargo/ci-config.toml
+++ b/.cargo/ci-config.toml
@@ -11,6 +11,10 @@
 [target.'cfg(all())']
 rustflags = ["-D", "warnings"]
 
+# We don't need fullest debug information for dev stuff (tests etc.) in CI.
+[profile.dev]
+debug = "limited"
+
 # Use Mold on Linux, because it's faster than GNU ld and LLD.
 #
 # We no longer set this in the default `config.toml` so that developers can opt in to Wild, which


### PR DESCRIPTION
For good backtraces in tests 'limited' is all we need.

Closes #ISSUE

Release Notes:

- N/A
