### PR TITLE
Make `kotlin-lsp` the default language server

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1741,7 +1741,7 @@
       }
     },
     "Kotlin": {
-      "language_servers": ["kotlin-language-server", "!kotlin-lsp", "..."]
+      "language_servers": ["!kotlin-language-server", "kotlin-lsp", "..."]
     },
     "LaTeX": {
       "formatter": "language_server",


### PR DESCRIPTION
Following a conversation with the maintainer/owner of kotlin-language-server, he recommended switching to the official language server, which is better in many aspects and also more actively maintained.

Release Notes:

- Made the official Kotlin Language Server the default language server for Kotlin.