### PR TITLE
ci: Bump max target directory size on Mac to 300GB

### DIFF
--- a/.github/actions/run_tests/action.yml
+++ b/.github/actions/run_tests/action.yml
@@ -15,8 +15,11 @@ runs:
         node-version: "18"
 
     - name: Limit target directory size
+      env:
+        MAX_SIZE: ${{ runner.os == 'macOS' && 300 || 100 }}
       shell: bash -euxo pipefail {0}
-      run: script/clear-target-dir-if-larger-than 100
+      # Use the variable in the run command
+      run: script/clear-target-dir-if-larger-than ${{ env.MAX_SIZE }}
 
     - name: Run tests
       shell: bash -euxo pipefail {0}


### PR DESCRIPTION
I did not bump it for Linux as some machines have smaller disks (~300GB or so); with Mac, we have at least 1TB on all of our boxes

Release Notes:

- N/A
