### PR TITLE
ci: Update `typos` versions and fix new occurrences

### DIFF
--- a/.cargo/ci-config.toml
+++ b/.cargo/ci-config.toml
@@ -5,7 +5,7 @@
 # Arrays are merged together though. See: https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure
 # The intent for this file is to configure CI build process with a divergance from Zed developers experience; for example, in this config file
 # we use `-D warnings` for rustflags (which makes compilation fail in presence of warnings during build process). Placing that in developers `config.toml`
-# would be incovenient.
+# would be inconvenient.
 # The reason for not using the RUSTFLAGS environment variable is that doing so would override all the settings in the config.toml file, even if the contents of the latter are completely nonsensical. See: https://github.com/rust-lang/cargo/issues/5376
 # Here, we opted to use `[target.'cfg(all())']` instead of `[build]` because `[target.'**']` is guaranteed to be cumulative.
 [target.'cfg(all())']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
         uses: ./.github/actions/check_style
 
       - name: Check for typos
-        uses: crate-ci/typos@8e6a4285bcbde632c5d79900a7779746e8b7ea3f # v1.24.6
+        uses: crate-ci/typos@80c8a4945eec0f6d464eaf9e65ed98ef085283d1 # v1.38.1
         with:
           config: ./typos.toml
 

--- a/crates/audio/src/rodio_ext.rs
+++ b/crates/audio/src/rodio_ext.rs
@@ -433,7 +433,7 @@ where
     /// Stores already emitted samples, once its full we call the callback.
     buffer: [Sample; N],
     /// Next free element in buffer. If this is equal to the buffer length
-    /// we have no more free lements.
+    /// we have no more free elements.
     free: usize,
 }
 

--- a/crates/client/src/proxy/socks_proxy.rs
+++ b/crates/client/src/proxy/socks_proxy.rs
@@ -23,7 +23,7 @@ pub(super) struct Socks5Authorization<'a> {
 
 /// Socks Proxy Protocol Version
 ///
-/// V4 allows idenfication using a user_id
+/// V4 allows identification using a user_id
 /// V5 allows authorization using a username and password
 pub(super) enum SocksVersion<'a> {
     V4 {

--- a/crates/clock/src/clock.rs
+++ b/crates/clock/src/clock.rs
@@ -83,7 +83,7 @@ impl Global {
         self.values.get(replica_id.0 as usize).copied().unwrap_or(0) as Seq
     }
 
-    /// Observe the lamport timestampe.
+    /// Observe the lamport timestamp.
     ///
     /// This sets the current sequence number of the observed replica ID to the maximum of this global's observed sequence and the observed timestamp.
     pub fn observe(&mut self, timestamp: Lamport) {

--- a/crates/collab/src/tests/editor_tests.rs
+++ b/crates/collab/src/tests/editor_tests.rs
@@ -505,7 +505,7 @@ async fn test_collaborating_with_completion(cx_a: &mut TestAppContext, cx_b: &mu
                     label: "third_method(…)".into(),
                     detail: Some("fn(&mut self, B, C, D) -> E".into()),
                     text_edit: Some(lsp::CompletionTextEdit::Edit(lsp::TextEdit {
-                        // no snippet placehodlers
+                        // no snippet placeholders
                         new_text: "third_method".to_string(),
                         range: lsp::Range::new(
                             lsp::Position::new(1, 32),

--- a/crates/edit_prediction_context/src/syntax_index.rs
+++ b/crates/edit_prediction_context/src/syntax_index.rs
@@ -854,7 +854,7 @@ mod tests {
     }
 
     #[gpui::test]
-    async fn test_declarations_limt(cx: &mut TestAppContext) {
+    async fn test_declarations_limit(cx: &mut TestAppContext) {
         let (_, index, rust_lang_id) = init_test(cx).await;
 
         let index_state = index.read_with(cx, |index, _cx| index.state().clone());

--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -836,7 +836,7 @@ impl VisualTestContext {
         })
     }
 
-    /// Simulate an event from the platform, e.g. a SrollWheelEvent
+    /// Simulate an event from the platform, e.g. a ScrollWheelEvent
     /// Make sure you've called [VisualTestContext::draw] first!
     pub fn simulate_event<E: InputEvent>(&mut self, event: E) {
         self.test_window(self.window)

--- a/crates/language_model/src/request.rs
+++ b/crates/language_model/src/request.rs
@@ -77,7 +77,7 @@ impl std::fmt::Debug for LanguageModelImage {
 }
 
 /// Anthropic wants uploaded images to be smaller than this in both dimensions.
-const ANTHROPIC_SIZE_LIMT: f32 = 1568.;
+const ANTHROPIC_SIZE_LIMIT: f32 = 1568.;
 
 impl LanguageModelImage {
     pub fn empty() -> Self {
@@ -112,13 +112,13 @@ impl LanguageModelImage {
             let image_size = size(DevicePixels(width as i32), DevicePixels(height as i32));
 
             let base64_image = {
-                if image_size.width.0 > ANTHROPIC_SIZE_LIMT as i32
-                    || image_size.height.0 > ANTHROPIC_SIZE_LIMT as i32
+                if image_size.width.0 > ANTHROPIC_SIZE_LIMIT as i32
+                    || image_size.height.0 > ANTHROPIC_SIZE_LIMIT as i32
                 {
                     let new_bounds = ObjectFit::ScaleDown.get_bounds(
                         gpui::Bounds {
                             origin: point(px(0.0), px(0.0)),
-                            size: size(px(ANTHROPIC_SIZE_LIMT), px(ANTHROPIC_SIZE_LIMT)),
+                            size: size(px(ANTHROPIC_SIZE_LIMIT), px(ANTHROPIC_SIZE_LIMIT)),
                         },
                         image_size,
                     );

--- a/crates/workspace/src/notifications.rs
+++ b/crates/workspace/src/notifications.rs
@@ -499,7 +499,7 @@ impl NotificationFrame {
     }
 
     /// Determines whether the given notification ID should be suppressible
-    /// Suppressed motifications will not be shown anymore
+    /// Suppressed notifications will not be shown anymore
     pub fn show_suppress_button(mut self, show: bool) -> Self {
         self.show_suppress_button = show;
         self
@@ -761,8 +761,8 @@ pub mod simple_message_notification {
             self
         }
 
-        /// Determines whether the given notification ID should be supressable
-        /// Suppressed motifications will not be shown anymor
+        /// Determines whether the given notification ID should be suppressible
+        /// Suppressed notifications will not be shown anymor
         pub fn show_suppress_button(mut self, show: bool) -> Self {
             self.show_suppress_button = show;
             self

--- a/docs/src/languages/yaml.md
+++ b/docs/src/languages/yaml.md
@@ -74,7 +74,7 @@ You can override any auto-detected schema via the `schemas` settings key (demons
 name: Issue Assignment
 on:
   issues:
-    types: [oppened]
+    types: [opened]
 ```
 
 You can disable the automatic detection and retrieval of schemas from the JSON Schema if desired:

--- a/script/bundle-linux
+++ b/script/bundle-linux
@@ -91,7 +91,7 @@ else
     if [[ -n "${SENTRY_AUTH_TOKEN:-}" ]]; then
         echo "Uploading zed debug symbols to sentry..."
         # note: this uploads the unstripped binary which is needed because it contains
-        # .eh_frame data for stack unwinindg. see https://github.com/getsentry/symbolic/issues/783
+        # .eh_frame data for stack unwinding. see https://github.com/getsentry/symbolic/issues/783
         sentry-cli debug-files upload --include-sources --wait -p zed -o zed-dev \
             "${target_dir}/${target_triple}"/release/zed \
             "${target_dir}/${remote_server_triple}"/release/remote_server

--- a/script/bundle-mac
+++ b/script/bundle-mac
@@ -375,7 +375,7 @@ function upload_debug_info() {
     if [[ -n "${SENTRY_AUTH_TOKEN:-}" ]]; then
         echo "Uploading zed debug symbols to sentry..."
         # note: this uploads the unstripped binary which is needed because it contains
-        # .eh_frame data for stack unwinindg. see https://github.com/getsentry/symbolic/issues/783
+        # .eh_frame data for stack unwinding. see https://github.com/getsentry/symbolic/issues/783
         sentry-cli debug-files upload --include-sources --wait -p zed -o zed-dev \
             "target/${architecture}/${target_dir}/zed" \
             "target/${architecture}/${target_dir}/remote_server" \

--- a/tooling/perf/src/implementation.rs
+++ b/tooling/perf/src/implementation.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::{num::NonZero, time::Duration};
 
 pub mod consts {
-    //! Preset idenitifiers and constants so that the profiler and proc macro agree
+    //! Preset identifiers and constants so that the profiler and proc macro agree
     //! on their communication protocol.
 
     /// The suffix on the actual test function.


### PR DESCRIPTION
I noticed we had some typos that were getting through CI, but it looks like the new version of `typos` catches them. So I updated it and fixed them.

Release Notes:

- N/A 