### PR TITLE
language: Fix hang when editing certain tailwind class names

### DIFF
--- a/crates/language/Cargo.toml
+++ b/crates/language/Cargo.toml
@@ -67,6 +67,7 @@ tree-sitter.workspace = true
 unicase = "2.6"
 util.workspace = true
 watch.workspace = true
+zlog.workspace = true
 diffy = "0.4.2"
 
 [dev-dependencies]

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -2589,7 +2589,12 @@ pub fn range_from_lsp(range: lsp::Range) -> Range<Unclipped<PointUtf16>> {
     let mut start = point_from_lsp(range.start);
     let mut end = point_from_lsp(range.end);
     if start > end {
-        log::warn!("range_from_lsp called with inverted range {start:?}-{end:?}");
+        // We debug instead of warn so that this is not logged by default unless explicitly requested.
+        // Using warn would write to the log file, and since we receive an enormous amount of
+        // range_from_lsp calls (especially during completions), that can hang the main thread.
+        //
+        // See issue #36223.
+        zlog::debug!("range_from_lsp called with inverted range {start:?}-{end:?}");
         mem::swap(&mut start, &mut end);
     }
     start..end


### PR DESCRIPTION
Closes #36223

Upsteam issue to track: https://github.com/tailwindlabs/tailwindcss-intellisense/issues/1479 (now fixed too!)

Release Notes:

- Fixed an issue where Zed hanged when editing certain Tailwind class names.