### PR TITLE
markdown: Don't adjust indentation when inserting with multiple cursors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5385,6 +5385,7 @@ dependencies = [
  "tree-sitter-bash",
  "tree-sitter-c",
  "tree-sitter-html",
+ "tree-sitter-md",
  "tree-sitter-python",
  "tree-sitter-rust",
  "tree-sitter-typescript",

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -115,6 +115,7 @@ tree-sitter-rust.workspace = true
 tree-sitter-typescript.workspace = true
 tree-sitter-yaml.workspace = true
 tree-sitter-bash.workspace = true
+tree-sitter-md.workspace = true
 unindent.workspace = true
 util = { workspace = true, features = ["test-support"] }
 workspace = { workspace = true, features = ["test-support"] }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4097,8 +4097,6 @@ impl Editor {
         let snapshot = self.buffer.read(cx).read(cx);
         let mut clear_linked_edit_ranges = false;
 
-        let selections_len = selections.len();
-
         for (selection, autoclose_region) in
             self.selections_with_autoclose_regions(selections, &snapshot)
         {
@@ -4350,14 +4348,8 @@ impl Editor {
             let initial_buffer_versions =
                 jsx_tag_auto_close::construct_initial_buffer_versions_map(this, &edits, cx);
 
-            let autoindent = if selections_len > 1 {
-                None
-            } else {
-                this.autoindent_mode.clone()
-            };
-
             this.buffer.update(cx, |buffer, cx| {
-                buffer.edit(edits, autoindent, cx);
+                buffer.edit(edits, this.autoindent_mode.clone(), cx);
             });
             for (buffer, edits) in linked_edits {
                 buffer.update(cx, |buffer, cx| {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4097,7 +4097,7 @@ impl Editor {
         let snapshot = self.buffer.read(cx).read(cx);
         let mut clear_linked_edit_ranges = false;
 
-        let selections_len = selections.len().clone();
+        let selections_len = selections.len();
 
         for (selection, autoclose_region) in
             self.selections_with_autoclose_regions(selections, &snapshot)

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4097,6 +4097,8 @@ impl Editor {
         let snapshot = self.buffer.read(cx).read(cx);
         let mut clear_linked_edit_ranges = false;
 
+        let selections_len = selections.len().clone();
+
         for (selection, autoclose_region) in
             self.selections_with_autoclose_regions(selections, &snapshot)
         {
@@ -4348,8 +4350,14 @@ impl Editor {
             let initial_buffer_versions =
                 jsx_tag_auto_close::construct_initial_buffer_versions_map(this, &edits, cx);
 
+            let autoindent = if selections_len > 1 {
+                None
+            } else {
+                this.autoindent_mode.clone()
+            };
+
             this.buffer.update(cx, |buffer, cx| {
-                buffer.edit(edits, this.autoindent_mode.clone(), cx);
+                buffer.edit(edits, autoindent, cx);
             });
             for (buffer, edits) in linked_edits {
                 buffer.update(cx, |buffer, cx| {

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -26476,6 +26476,39 @@ async fn test_paste_url_from_other_app_creates_markdown_link_over_selected_text(
 }
 
 #[gpui::test]
+async fn test_markdown_indentation_on_multicursor(cx: &mut gpui::TestAppContext) {
+    init_test(cx, |_| {});
+
+    let markdown_language = Arc::new(Language::new(
+        LanguageConfig {
+            name: "Markdown".into(),
+            ..LanguageConfig::default()
+        },
+        None,
+    ));
+
+    let mut cx = EditorTestContext::new(cx).await;
+
+    cx.update_buffer(|buffer, cx| buffer.set_language(Some(markdown_language), cx));
+
+    cx.set_state(&indoc! {"
+        - [ ] Item 1
+            - [ ] Item 1.a
+        - [ˇ] Item 2
+            - [ˇ] Item 2.a
+            - [ˇ] Item 2.b
+        "
+    });
+
+    cx.update_editor(|editor, window, cx| {
+        editor.handle_input("X", window, cx);
+    });
+
+    // Weird, this issue doesn't happen on the test, something that i'm doing wrong most likely.
+    println!("{}", cx.editor_state());
+}
+
+#[gpui::test]
 async fn test_paste_url_from_zed_copy_creates_markdown_link_over_selected_text(
     cx: &mut gpui::TestAppContext,
 ) {

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -26479,14 +26479,7 @@ async fn test_paste_url_from_other_app_creates_markdown_link_over_selected_text(
 async fn test_markdown_indentation_on_multicursor(cx: &mut gpui::TestAppContext) {
     init_test(cx, |_| {});
 
-    let markdown_language = Arc::new(Language::new(
-        LanguageConfig {
-            name: "Markdown".into(),
-            ..LanguageConfig::default()
-        },
-        None,
-    ));
-
+    let markdown_language = languages::language("markdown", tree_sitter_md::LANGUAGE.into());
     let mut cx = EditorTestContext::new(cx).await;
 
     cx.update_buffer(|buffer, cx| buffer.set_language(Some(markdown_language), cx));
@@ -26504,8 +26497,14 @@ async fn test_markdown_indentation_on_multicursor(cx: &mut gpui::TestAppContext)
         editor.handle_input("X", window, cx);
     });
 
-    // Weird, this issue doesn't happen on the test, something that i'm doing wrong most likely.
-    println!("{}", cx.editor_state());
+    cx.assert_editor_state(indoc! {"
+        - [ ] Item 1
+            - [ ] Item 1.a
+        - [Xˇ] Item 2
+            - [Xˇ] Item 2.a
+            - [Xˇ] Item 2.b
+        "
+    });
 }
 
 #[gpui::test]

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -26476,7 +26476,7 @@ async fn test_paste_url_from_other_app_creates_markdown_link_over_selected_text(
 }
 
 #[gpui::test]
-async fn test_markdown_indentation_on_multicursor(cx: &mut gpui::TestAppContext) {
+async fn test_markdown_list_indent_with_multi_cursor(cx: &mut gpui::TestAppContext) {
     init_test(cx, |_| {});
 
     let markdown_language = languages::language("markdown", tree_sitter_md::LANGUAGE.into());
@@ -26503,6 +26503,33 @@ async fn test_markdown_indentation_on_multicursor(cx: &mut gpui::TestAppContext)
         - [Xˇ] Item 2
             - [Xˇ] Item 2.a
             - [Xˇ] Item 2.b
+        "
+    });
+}
+
+#[gpui::test]
+async fn test_markdown_list_indent_with_newline(cx: &mut gpui::TestAppContext) {
+    init_test(cx, |_| {});
+
+    let markdown_language = languages::language("markdown", tree_sitter_md::LANGUAGE.into());
+    let mut cx = EditorTestContext::new(cx).await;
+
+    cx.update_buffer(|buffer, cx| buffer.set_language(Some(markdown_language), cx));
+
+    cx.set_state(indoc! {"
+        - [x] list item
+          - [x] sub list itemˇ
+        "
+    });
+
+    cx.update_editor(|editor, window, cx| {
+        editor.newline(&Newline, window, cx);
+    });
+
+    cx.assert_editor_state(indoc! {"
+        - [x] list item
+          - [x] sub list item
+          ˇ
         "
     });
 }

--- a/crates/languages/src/markdown/config.toml
+++ b/crates/languages/src/markdown/config.toml
@@ -24,4 +24,5 @@ rewrap_prefixes = [
 auto_indent_on_paste = false
 auto_indent_using_last_non_empty_line = false
 tab_size = 2
+decrease_indent_pattern = "^\\s*$"
 prettier_parser_name = "markdown"

--- a/crates/languages/src/markdown/indents.scm
+++ b/crates/languages/src/markdown/indents.scm
@@ -1,3 +1,3 @@
-(list (list_item) @indent )
+(list (list_item) @indent)
 
-(list_item (list) @indent )
+(list_item (list) @indent)

--- a/crates/languages/src/markdown/indents.scm
+++ b/crates/languages/src/markdown/indents.scm
@@ -1,0 +1,3 @@
+(list (list_item) @indent )
+
+(list_item (list) @indent )


### PR DESCRIPTION
Closes #40757

## Summary

This PR addresses an issue where Zed incorrectly adjusts the indentation of Markdown lists when inserting text using multiple cursors. Currently:

- Editing individual lines with a single cursor behaves correctly (no unwanted indentation changes).
- Using multiple cursors, Zed automatically adjusts the indentation, unlike VS Code, which preserves the existing formatting.

## Tasks
- [x] Implement a new test to verify correct Markdown indentation behavior with multiple cursors.
- [x] Apply the fix to prevent Zed from adjusting indentation when inserting text on multiple cursors.

------------------------

Release Notes:

- Fixed an issue where inserting text with multiple cursors inside a nested Markdown list would cause it to lose its indentation.

