### PR TITLE
extensions_ui: Increase affordance of download button in cards

### DIFF
--- a/crates/extensions_ui/src/components/extension_card.rs
+++ b/crates/extensions_ui/src/components/extension_card.rs
@@ -32,14 +32,14 @@ impl RenderOnce for ExtensionCard {
     fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
         div().w_full().child(
             v_flex()
-                .w_full()
-                .h(rems(7.))
-                .p_3()
                 .mt_4()
+                .w_full()
+                .h(rems_from_px(110.))
+                .p_3()
                 .gap_2()
-                .bg(cx.theme().colors().elevated_surface_background)
+                .bg(cx.theme().colors().elevated_surface_background.opacity(0.5))
                 .border_1()
-                .border_color(cx.theme().colors().border)
+                .border_color(cx.theme().colors().border_variant)
                 .rounded_md()
                 .children(self.children)
                 .when(self.overridden_by_dev_extension, |card| {
@@ -51,7 +51,6 @@ impl RenderOnce for ExtensionCard {
                             .block_mouse_except_scroll()
                             .cursor_default()
                             .size_full()
-                            .items_center()
                             .justify_center()
                             .bg(cx.theme().colors().elevated_surface_background.alpha(0.8))
                             .child(Label::new("Overridden by dev extension.")),

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -801,7 +801,7 @@ impl ExtensionsPage {
                                     .color(Color::Muted),
                             )
                             .child(
-                                Label::new(format!("{}", extension.manifest.authors.join(", ")))
+                                Label::new(extension.manifest.authors.join(", ").to_string())
                                     .size(LabelSize::Small)
                                     .color(Color::Muted)
                                     .truncate(),

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -804,7 +804,7 @@ impl ExtensionsPage {
                                     .color(Color::Muted),
                             )
                             .child(
-                                Label::new(extension.manifest.authors.join(", ").to_string())
+                                Label::new(extension.manifest.authors.join(", "))
                                     .size(LabelSize::Small)
                                     .color(Color::Muted)
                                     .truncate(),

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -965,7 +965,7 @@ impl ExtensionsPage {
                     SharedString::from(extension.id.clone()),
                     "Install",
                 )
-                .style(ButtonStyle::Outlined)
+                .style(ButtonStyle::Tinted(ui::TintColor::Accent))
                 .icon(IconName::Download)
                 .icon_size(IconSize::Small)
                 .icon_color(Color::Muted)
@@ -987,7 +987,7 @@ impl ExtensionsPage {
                     SharedString::from(extension.id.clone()),
                     "Install",
                 )
-                .style(ButtonStyle::Outlined)
+                .style(ButtonStyle::Tinted(ui::TintColor::Accent))
                 .icon(IconName::Download)
                 .icon_size(IconSize::Small)
                 .icon_color(Color::Muted)

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -725,7 +725,10 @@ impl ExtensionsPage {
                     .child(
                         h_flex()
                             .gap_2()
-                            .child(Headline::new(extension.manifest.name.clone()))
+                            .child(
+                                Headline::new(extension.manifest.name.clone())
+                                    .size(HeadlineSize::Small),
+                            )
                             .child(Headline::new(format!("v{version}")).size(HeadlineSize::XSmall))
                             .children(
                                 installed_version


### PR DESCRIPTION
Hopefully, this will make the install/configure/uninstall buttons in the right stand out a bit more and make their presence a bit more obvious for newcomers.

| Before | After |
|--------|--------|
| <img width="1938" height="1276" alt="Screenshot 2025-10-21 at 10  58@2x" src="https://github.com/user-attachments/assets/b76115e1-0be2-4d5b-a677-525663d86c7c" />  | <img width="1938" height="1276" alt="Screenshot 2025-10-21 at 10  53@2x" src="https://github.com/user-attachments/assets/9e563b71-b11a-4b69-b687-c0b469ca4eec" /> | 

Release Notes:

- Increased affordance of the download button in each extension card in the extensions page.
