### PR TITLE
Add `linux_repo_snapshot` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@
 /crates/collab/seed.json
 /crates/theme/schemas/theme.json
 /crates/zed/resources/flatpak/flatpak-cargo-sources.json
+/crates/project_panel/benches/linux_repo_snapshot.txt
 /dev.zed.Zed*.json
 /node_modules/
 /plugins/bin


### PR DESCRIPTION
It keeps popping up in my project searches ... This prevents that. Not like we are planning on editing that file again.

Release Notes:

- N/A *or* Added/Fixed/Improved ...
