### PR TITLE
Centralize Zed.log documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/11_crash_report.yml
+++ b/.github/ISSUE_TEMPLATE/11_crash_report.yml
@@ -33,9 +33,10 @@ body:
       required: true
   - type: textarea
     attributes:
-      label: If applicable, attach your `~/Library/Logs/Zed/Zed.log` file to this issue.
+      label: If applicable, attach your `Zed.log` file to this issue.
       description: |
         macOS: `~/Library/Logs/Zed/Zed.log`
+        Windows: `C:\Users\YOU\AppData\Local\Zed\logs\Zed.log`
         Linux: `~/.local/share/zed/logs/Zed.log` or $XDG_DATA_HOME
         If you only need the most recent lines, you can run the `zed: open log` command palette action to see the last 1000.
       value: |

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -9,6 +9,7 @@
 - [Windows](./windows.md)
 - [Telemetry](./telemetry.md)
 - [Workspace Persistence](./workspace-persistence.md)
+- [Troubleshooting](./troubleshooting.md)
 - [Additional Learning Materials](./additional-learning-materials.md)
 
 # Configuration

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -11,6 +11,6 @@ If you want to view the full file, you can find it at the respective location on
 - Linux: `~/.local/share/zed/logs/Zed.log` or `$XDG_DATA_HOME`
 
 > Note: In some cases, it might be useful to monitor the log live, such as when [developing a Zed extension](https://zed.dev/docs/extensions/developing-extensions).
-  Example: `tail -f ~/Library/Logs/Zed/Zed.log`
+> Example: `tail -f ~/Library/Logs/Zed/Zed.log`
 
 The log may contain enough context to help you debug the issue yourself, or you may find specific errors that are useful when filing a [GitHub Issue](https://github.com/zed-industries/zed/issues/new/choose) or when talking to Zed staff in our [Discord server](https://zed.dev/community-links#forums-and-discussions).

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -1,0 +1,16 @@
+# Troubleshooting
+
+## Zed Log
+
+Often, a good first place to look when troubleshooting any issue in Zed is the Zed log, which might contain clues about what's going wrong.
+You can review the most recent 1000 lines of the log by running the {#action zed::OpenLog} command from the command palette (`cmd-shift-p` on macOS or `ctrl-shift-p` on Windows/Linux).
+If you want to view the full file, you can find it at the respective location on each operating system:
+
+- macOS: `~/Library/Logs/Zed/Zed.log`
+- Windows: `C:\Users\YOU\AppData\Local\Zed\logs\Zed.log`
+- Linux: `~/.local/share/zed/logs/Zed.log` or `$XDG_DATA_HOME`
+
+> Note: In some cases, it might be useful to monitor the log live, such as when [developing a Zed extension](https://zed.dev/docs/extensions/developing-extensions).
+  Example: `tail -f ~/Library/Logs/Zed/Zed.log`
+
+The log may contain enough context to help you debug the issue yourself, or you may find specific errors that are useful when filing a [GitHub Issue](https://github.com/zed-industries/zed/issues/new/choose) or when talking to Zed staff in our [Discord server](https://zed.dev/community-links#forums-and-discussions).

--- a/extensions/slash-commands-example/README.md
+++ b/extensions/slash-commands-example/README.md
@@ -76,8 +76,7 @@ Rebuild to see these changes reflected:
 
 ## Troubleshooting / Logs
 
-- MacOS: `tail -f ~/Library/Logs/Zed/Zed.log`
-- Linux: `tail -f ~/.local/share/zed/logs/Zed.log`
+- [zed.dev docs: Troubleshooting](https://zed.dev/docs/troubleshooting)
 
 ## Documentation
 


### PR DESCRIPTION
Just wanted a single location to point people to for telling them where to find their log file. I left duplicate text in GitHub Issue templates, as it seems annoying to have to follow a link when making an issue.

Release Notes:

- N/A
