### PR TITLE
Fix default settings entry for basedpyright

### DIFF
--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -1811,12 +1811,8 @@ impl LspAdapter for BasedPyrightLspAdapter {
                 }
                 // Basedpyright by default uses `strict` type checking, we tone it down as to not surpris users
                 maybe!({
-                    let basedpyright = object
-                        .entry("basedpyright")
-                        .or_insert(Value::Object(serde_json::Map::default()));
-                    let analysis = basedpyright
-                        .as_object_mut()?
-                        .entry("analysis")
+                    let analysis = object
+                        .entry("basedpyright.analysis")
                         .or_insert(Value::Object(serde_json::Map::default()));
                     if let serde_json::map::Entry::Vacant(v) =
                         analysis.as_object_mut()?.entry("typeCheckingMode")


### PR DESCRIPTION
If you set `{"basedpyright": {"analysis": {"typeCheckingMode": "off"}}}`, you will notice that it doesn't actually work, but `{"basedpyright.analysis": {"typeCheckingMode": "off"}}` does.

Made the change on how the default is being set.

Release Notes:

- N/A
