### PR TITLE
Add an action to reveal log file in system file manager

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -7017,7 +7017,7 @@ actions!(
         /// Opens the Zed log file.
         OpenLog,
         /// Reveals the Zed log file in the system file manager.
-        RevealLogInFinder
+        RevealLogInFileManager
     ]
 );
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -7015,7 +7015,9 @@ actions!(
     zed,
     [
         /// Opens the Zed log file.
-        OpenLog
+        OpenLog,
+        /// Reveals the Zed log file in the system file manager.
+        RevealLogInFinder
     ]
 );
 

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -178,7 +178,7 @@ pub fn init(cx: &mut App) {
             open_log_file(workspace, window, cx);
         });
     });
-    cx.on_action(|_: &workspace::RevealLogInFinder, cx| {
+    cx.on_action(|_: &workspace::RevealLogInFileManager, cx| {
         cx.reveal_path(paths::log_file().as_path());
     });
     cx.on_action(|_: &zed_actions::OpenLicenses, cx| {

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -178,6 +178,9 @@ pub fn init(cx: &mut App) {
             open_log_file(workspace, window, cx);
         });
     });
+    cx.on_action(|_: &workspace::RevealLogInFinder, cx| {
+        cx.reveal_path(paths::log_file().as_path());
+    });
     cx.on_action(|_: &zed_actions::OpenLicenses, cx| {
         with_active_or_new_workspace(cx, |workspace, window, cx| {
             open_bundled_file(


### PR DESCRIPTION
We document the location of the log file in many places, we should just make it easy to open directly within your file browser. The one thing here is naming. We use dynamic naming for "reveal" actions in the project panel, to reflect the right file manager name per OS, but for a command palette action, I dont think we want to have dynamic code for the action name, just going with finder at the moment.

Release Notes:

- Added a `zed: reveal log in file manager` action to the command palette.
