### PR TITLE
Open keymap editor from command palette entry

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -1059,6 +1059,13 @@
     }
   },
   {
+    "context": "CommandPalette || (CommandPalette > Picker > Editor)",
+    "bindings": {
+      "ctrl-enter": "command_palette::AddKeybinding",
+      "alt-enter": "command_palette::ChangeKeybinding"
+    }
+  },
+  {
     "context": "FileFinder || (FileFinder > Picker > Editor) || (FileFinder > Picker > menu)",
     "bindings": {
       "ctrl-shift-p": "file_finder::SelectPrevious",

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -1059,13 +1059,6 @@
     }
   },
   {
-    "context": "CommandPalette || (CommandPalette > Picker > Editor)",
-    "bindings": {
-      "ctrl-enter": "command_palette::AddKeybinding",
-      "alt-enter": "command_palette::ChangeKeybinding"
-    }
-  },
-  {
     "context": "FileFinder || (FileFinder > Picker > Editor) || (FileFinder > Picker > menu)",
     "bindings": {
       "ctrl-shift-p": "file_finder::SelectPrevious",

--- a/crates/command_palette/Cargo.toml
+++ b/crates/command_palette/Cargo.toml
@@ -20,6 +20,7 @@ command_palette_hooks.workspace = true
 db.workspace = true
 fuzzy.workspace = true
 gpui.workspace = true
+menu.workspace = true
 log.workspace = true
 picker.workspace = true
 postage.workspace = true

--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -467,7 +467,7 @@ impl PickerDelegate for CommandPaletteDelegate {
                             command.name.clone(),
                             matching_command.positions.clone(),
                         ))
-                        .child(div().when_else(
+                        .when_else(
                             keybind.has_binding(window),
                             |this| {
                                 this.child(
@@ -506,7 +506,7 @@ impl PickerDelegate for CommandPaletteDelegate {
                                         .into_any_element(),
                                 )
                             },
-                        )),
+                        ),
                 ),
         )
     }

--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -427,7 +427,6 @@ impl PickerDelegate for CommandPaletteDelegate {
             let open_keymap = Box::new(zed_actions::ChangeKeybinding {
                 action: action_name.to_string(),
             });
-            // window.focus(&self.previous_focus_handle);
             window.dispatch_action(open_keymap, cx);
             self.dismissed(window, cx);
             return;

--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -132,25 +132,6 @@ impl CommandPalette {
         self.picker
             .update(cx, |picker, cx| picker.set_query(query, window, cx))
     }
-
-    fn handle_open_keymap(
-        &mut self,
-        _: &ChangeKeybinding,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) {
-        let picker = &self.picker.read(cx).delegate;
-        let selected_command = picker.selected_command();
-
-        let action_name = selected_command.action.name();
-        let open_keymap_action = move || {
-            Box::new(zed_actions::ChangeKeybinding {
-                action: action_name.to_string(),
-            })
-        };
-
-        window.dispatch_action(open_keymap_action(), cx);
-    }
 }
 
 impl EventEmitter<DismissEvent> for CommandPalette {}
@@ -162,12 +143,9 @@ impl Focusable for CommandPalette {
 }
 
 impl Render for CommandPalette {
-    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, _window: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
         v_flex()
             .key_context("CommandPalette")
-            .on_action(
-                cx.listener(|this, action, window, cx| this.handle_open_keymap(action, window, cx)),
-            )
             .w(rems(34.))
             .child(self.picker.clone())
     }
@@ -541,10 +519,7 @@ impl PickerDelegate for CommandPaletteDelegate {
                         .map(|kb| kb.size(rems_from_px(12.))),
                 )
                 .on_click(move |_, window, cx| {
-                    let open_keymap = Box::new(zed_actions::ChangeKeybinding { action: "".to_string() });
-                    // window.focus(&self.previous_focus_handle);
-                    window.dispatch_action(open_keymap, cx);
-                    // window.dispatch_action(menu::SecondaryConfirm.boxed_clone(), cx);
+                    window.dispatch_action(menu::SecondaryConfirm.boxed_clone(), cx);
                 })
         };
 

--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -25,7 +25,7 @@ use settings::Settings;
 use ui::{HighlightedLabel, KeyBinding, ListItem, ListItemSpacing, prelude::*};
 use util::ResultExt;
 use workspace::{ModalView, Workspace, WorkspaceSettings};
-use zed_actions::{ChangeKeybinding, OpenZedUrl, command_palette::Toggle};
+use zed_actions::{OpenZedUrl, command_palette::Toggle};
 
 pub fn init(cx: &mut App) {
     client::init_settings(cx);

--- a/crates/keymap_editor/src/keymap_editor.rs
+++ b/crates/keymap_editor/src/keymap_editor.rs
@@ -1,9 +1,10 @@
 use std::{
+    cell::RefCell,
     cmp::{self},
     ops::{Not as _, Range},
     rc::Rc,
     sync::Arc,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 mod ui_components;
@@ -41,7 +42,7 @@ use workspace::{
 };
 
 pub use ui_components::*;
-use zed_actions::OpenKeymap;
+use zed_actions::{OpenKeymap, OpenKeymapWithFilter};
 
 use crate::{
     persistence::KEYBINDING_EDITORS,
@@ -80,35 +81,73 @@ pub fn init(cx: &mut App) {
     let keymap_event_channel = KeymapEventChannel::new();
     cx.set_global(keymap_event_channel);
 
-    cx.on_action(|_: &OpenKeymap, cx| {
+    fn common(filter: String, cx: &mut App) {
         workspace::with_active_or_new_workspace(cx, move |workspace, window, cx| {
             workspace
-                .with_local_workspace(window, cx, |workspace, window, cx| {
+                .with_local_workspace(window, cx, move |workspace, window, cx| {
                     let existing = workspace
                         .active_pane()
                         .read(cx)
                         .items()
                         .find_map(|item| item.downcast::<KeymapEditor>());
 
-                    if let Some(existing) = existing {
+                    let keymap_editor = if let Some(existing) = existing {
                         workspace.activate_item(&existing, true, true, window, cx);
+                        existing
                     } else {
                         let keymap_editor =
                             cx.new(|cx| KeymapEditor::new(workspace.weak_handle(), window, cx));
                         workspace.add_item_to_active_pane(
-                            Box::new(keymap_editor),
+                            Box::new(keymap_editor.clone()),
                             None,
                             true,
                             window,
                             cx,
                         );
-                    }
+                        keymap_editor
+                    };
+
+                    keymap_editor.update(cx, |editor, cx| {
+                        editor.filter_editor.update(cx, |editor, cx| {
+                            editor.clear(window, cx);
+                            editor.insert(&filter, window, cx);
+                        });
+                        if !editor.has_binding_for(&filter) {
+                            open_binding_modal_after_loading(cx)
+                        }
+                    })
                 })
                 .detach();
         })
-    });
+    }
+
+    cx.on_action(|_: &OpenKeymap, cx| common(String::new(), cx));
+    cx.on_action(|action: &OpenKeymapWithFilter, cx| common(action.filter.clone(), cx));
 
     register_serializable_item::<KeymapEditor>(cx);
+}
+
+fn open_binding_modal_after_loading(cx: &mut Context<KeymapEditor>) {
+    let started_at = Instant::now();
+    let observer = Rc::new(RefCell::new(None));
+    let handle = {
+        let observer = Rc::clone(&observer);
+        cx.observe(&cx.entity(), move |editor, _, cx| {
+            let subscription = observer.borrow_mut().take();
+
+            if started_at.elapsed().as_secs() > 10 {
+                return;
+            }
+            if !editor.matches.is_empty() {
+                editor.selected_index = Some(0);
+                cx.dispatch_action(&CreateBinding);
+                return;
+            }
+
+            *observer.borrow_mut() = subscription;
+        })
+    };
+    *observer.borrow_mut() = Some(handle);
 }
 
 pub struct KeymapEventChannel {}
@@ -1324,6 +1363,13 @@ impl KeymapEditor {
         self.keystroke_editor.update(cx, |editor, cx| {
             editor.set_keystrokes(keystrokes, cx);
         });
+    }
+
+    fn has_binding_for(&self, action_name: &str) -> bool {
+        self.keybindings
+            .iter()
+            .filter(|kb| kb.keystrokes().is_some())
+            .any(|kb| kb.action().name == action_name)
     }
 }
 

--- a/crates/ui/src/components/keybinding.rs
+++ b/crates/ui/src/components/keybinding.rs
@@ -68,6 +68,17 @@ impl KeyBinding {
     pub fn for_action_in(action: &dyn Action, focus: &FocusHandle, cx: &App) -> Self {
         Self::new(action, Some(focus.clone()), cx)
     }
+    pub fn has_binding(&self, window: &Window) -> bool {
+        match &self.source {
+            Source::Action {
+                action,
+                focus_handle: Some(focus),
+            } => window
+                .highest_precedence_binding_for_action_in(action.as_ref(), focus)
+                .is_some(),
+            _ => false,
+        }
+    }
 
     pub fn set_vim_mode(cx: &mut App, enabled: bool) {
         cx.set_global(VimStyle(enabled));

--- a/crates/ui/src/components/keybinding.rs
+++ b/crates/ui/src/components/keybinding.rs
@@ -75,6 +75,7 @@ impl KeyBinding {
                 focus_handle: Some(focus),
             } => window
                 .highest_precedence_binding_for_action_in(action.as_ref(), focus)
+                .or_else(|| window.highest_precedence_binding_for_action(action.as_ref()))
                 .is_some(),
             _ => false,
         }

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -27,6 +27,13 @@ pub struct OpenZedUrl {
     pub url: String,
 }
 
+/// Opens the keymap editor.
+#[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
+#[action(namespace = zed)]
+pub struct OpenKeymapWithFilter {
+    pub filter: String,
+}
+
 actions!(
     zed,
     [

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -27,11 +27,11 @@ pub struct OpenZedUrl {
     pub url: String,
 }
 
-/// Opens the keymap editor.
-#[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
+/// Opens the keymap to either add a keybinding or change an existing
+#[derive(PartialEq, Clone, Default, Action, JsonSchema, Serialize, Deserialize)]
 #[action(namespace = zed)]
-pub struct OpenKeymapWithFilter {
-    pub filter: String,
+pub struct ChangeKeybinding {
+    pub action: String,
 }
 
 actions!(
@@ -240,10 +240,6 @@ pub mod command_palette {
         [
             /// Toggles the command palette.
             Toggle,
-            /// Change keybinding for the selected action in the command palette.
-            ChangeKeybinding,
-            /// Add keybinding for the selected action in the command palette.
-            AddKeybinding,
         ]
     );
 }

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -239,7 +239,11 @@ pub mod command_palette {
         command_palette,
         [
             /// Toggles the command palette.
-            Toggle
+            Toggle,
+            /// Change keybinding for the selected action in the command palette.
+            ChangeKeybinding,
+            /// Add keybinding for the selected action in the command palette.
+            AddKeybinding,
         ]
     );
 }

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -27,9 +27,9 @@ pub struct OpenZedUrl {
     pub url: String,
 }
 
-/// Opens the keymap to either add a keybinding or change an existing
+/// Opens the keymap to either add a keybinding or change an existing one
 #[derive(PartialEq, Clone, Default, Action, JsonSchema, Serialize, Deserialize)]
-#[action(namespace = zed)]
+#[action(namespace = zed, no_json, no_register)]
 pub struct ChangeKeybinding {
     pub action: String,
 }

--- a/docs/src/key-bindings.md
+++ b/docs/src/key-bindings.md
@@ -23,7 +23,7 @@ For more information, see the documentation for [Vim mode](./vim.md) and [Helix 
 
 ## Keymap Editor
 
-You can access the keymap editor through the {#kb zed::OpenKeymap} action or by running {#action zed::OpenKeymap} action from the command palette
+You can access the keymap editor through the {#kb zed::OpenKeymap} action or by running {#action zed::OpenKeymap} action from the command palette. You can easily add or change a keybind for an action with the `Change Keybinding` or `Add Keybinding` button on the command pallets left bottom corner.
 
 In there, you can see all of the existing actions in Zed as well as the associated keybindings set to them by default.
 


### PR DESCRIPTION
Release Notes:

- Adds footer to the command palette with buttons to add or change the selected actions keybinding. Both open the keymap editor though the add button takes you directly to the modal for recording a new keybind.

https://github.com/user-attachments/assets/0ee6b91e-b1dd-4d7f-ad64-cc79689ceeb2
