### PR TITLE
Switch to fork of `async-tar`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1185,8 +1185,7 @@ dependencies = [
 [[package]]
 name = "async-tar"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a42f905d4f623faf634bbd1e001e84e0efc24694afa64be9ad239bf6ca49e1f8"
+source = "git+https://github.com/zed-industries/async-tar?rev=8af312477196311c9ea4097f2a22022f6d609bf6#8af312477196311c9ea4097f2a22022f6d609bf6"
 dependencies = [
  "async-std",
  "filetime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -454,7 +454,7 @@ async-fs = "2.1"
 async-lock = "2.1"
 async-pipe = { git = "https://github.com/zed-industries/async-pipe-rs", rev = "82d00a04211cf4e1236029aa03e6b6ce2a74c553" }
 async-recursion = "1.0.0"
-async-tar = "0.5.0"
+async-tar = { git = "https://github.com/zed-industries/async-tar", rev = "8af312477196311c9ea4097f2a22022f6d609bf6" }
 async-task = "4.7"
 async-trait = "0.1"
 async-tungstenite = "0.31.0"


### PR DESCRIPTION
This PR switches to our own fork of `async-tar`.

Release Notes:

- N/A
