### PR TITLE
docs: Document per-release channel configuration

### DIFF
--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -23,7 +23,7 @@ The syntax for configuration files is a super-set of JSON that allows `//` comme
 
 ### Per-release channel overrides
 
-Zed reads the same `settings.json` across all release channels (Stable, Preview or Nightly). However, you can scope overrides to a specific channel by adding top-level `stable`, `preview`, `nightly` or `dev` objects. They are merged into the base configuration with settings from these keys taking precedence upon launching the speficied build. For example:
+Zed reads the same `settings.json` across all release channels (Stable, Preview or Nightly). However, you can scope overrides to a specific channel by adding top-level `stable`, `preview`, `nightly` or `dev` objects. They are merged into the base configuration with settings from these keys taking precedence upon launching the specified build. For example:
 
 ```json [settings]
 {
@@ -2814,7 +2814,6 @@ Configuration object for defining settings profiles. Example:
 - Description:
   Preview tabs allow you to open files in preview mode, where they close automatically when you switch to another file unless you explicitly pin them. This is useful for quickly viewing files without cluttering your workspace. Preview tabs display their file names in italics. \
    There are several ways to convert a preview tab into a regular tab:
-
   - Double-clicking on the file
   - Double-clicking on the tab header
   - Using the {#action project_panel::OpenPermanent} action

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -19,6 +19,28 @@ This configuration is merged with any local configuration inside your projects. 
 
 Although most projects will only need one settings file at the root, you can add more local settings files for subdirectories as needed. Not all settings can be set in local files, just those that impact the behavior of the editor and language tooling. For example you can set `tab_size`, `formatter` etc. but not `theme`, `vim_mode` and similar.
 
+### Per-release channel overrides
+
+Zed reads the same user `settings.json` no matter which release channel (Stable, Preview, Nightly) you launch, but you can scope overrides to a specific channel by adding top-level `stable`, `preview`, or `nightly` objects. Each section merges with the base config when that build starts. For example:
+
+```json [settings]
+{
+  "theme": "sunset",
+  "vim_mode": false,
+  "nightly": {
+    "theme": "cave-light",
+    "vim_mode": true
+  },
+  "preview": {
+    "theme": "zed-dark"
+  }
+}
+```
+
+In this configuration, Stable keeps the base preferences, Preview switches to `zed-dark`, and Nightly enables Vim mode with a different theme. Channel-specific blocks must include every setting you want overridden -- they do not merge arrays with the base copy.
+
+Note that changing options via the UI (for example toggling Vim mode or picking a theme) edits the root of `settings.json`. To keep per-channel differences, edit the relevant release section manually after making UI tweaks.
+
 The syntax for configuration files is a super-set of JSON that allows `//` comments.
 
 ## Default settings

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -2814,6 +2814,7 @@ Configuration object for defining settings profiles. Example:
 - Description:
   Preview tabs allow you to open files in preview mode, where they close automatically when you switch to another file unless you explicitly pin them. This is useful for quickly viewing files without cluttering your workspace. Preview tabs display their file names in italics. \
    There are several ways to convert a preview tab into a regular tab:
+
   - Double-clicking on the file
   - Double-clicking on the tab header
   - Using the {#action project_panel::OpenPermanent} action

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -19,6 +19,8 @@ This configuration is merged with any local configuration inside your projects. 
 
 Although most projects will only need one settings file at the root, you can add more local settings files for subdirectories as needed. Not all settings can be set in local files, just those that impact the behavior of the editor and language tooling. For example you can set `tab_size`, `formatter` etc. but not `theme`, `vim_mode` and similar.
 
+The syntax for configuration files is a super-set of JSON that allows `//` comments.
+
 ### Per-release channel overrides
 
 Zed reads the same user `settings.json` no matter which release channel (Stable, Preview, Nightly) you launch, but you can scope overrides to a specific channel by adding top-level `stable`, `preview`, or `nightly` objects. Each section merges with the base config when that build starts. For example:
@@ -40,8 +42,6 @@ Zed reads the same user `settings.json` no matter which release channel (Stable,
 In this configuration, Stable keeps the base preferences, Preview switches to `zed-dark`, and Nightly enables Vim mode with a different theme. Channel-specific blocks must include every setting you want overridden -- they do not merge arrays with the base copy.
 
 Note that changing options via the UI (for example toggling Vim mode or picking a theme) edits the root of `settings.json`. To keep per-channel differences, edit the relevant release section manually after making UI tweaks.
-
-The syntax for configuration files is a super-set of JSON that allows `//` comments.
 
 ## Default settings
 

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -23,7 +23,7 @@ The syntax for configuration files is a super-set of JSON that allows `//` comme
 
 ### Per-release channel overrides
 
-Zed reads the same user `settings.json` no matter which release channel (Stable, Preview, Nightly) you launch, but you can scope overrides to a specific channel by adding top-level `stable`, `preview`, or `nightly` objects. Each section merges with the base config when that build starts. For example:
+Zed reads the same `settings.json` across all release channels (Stable, Preview or Nightly). However, you can scope overrides to a specific channel by adding top-level `stable`, `preview`, `nightly` or `dev` objects. They are merged into the base configuration with settings from these keys taking precedence upon launching the speficied build. For example:
 
 ```json [settings]
 {
@@ -39,9 +39,9 @@ Zed reads the same user `settings.json` no matter which release channel (Stable,
 }
 ```
 
-In this configuration, Stable keeps the base preferences, Preview switches to `zed-dark`, and Nightly enables Vim mode with a different theme. Channel-specific blocks must include every setting you want overridden -- they do not merge arrays with the base copy.
+With this configuration, Stable keeps all base preferences, Preview switches to `zed-dark`, and Nightly enables Vim mode with a different theme.
 
-Note that changing options via the UI (for example toggling Vim mode or picking a theme) edits the root of `settings.json`. To keep per-channel differences, edit the relevant release section manually after making UI tweaks.
+Changing settings via the UI will always apply the change across all channels.
 
 ## Default settings
 


### PR DESCRIPTION
## Summary
- Document the `stable`/`preview`/`nightly` top-level keys that let users scope settings overrides per release channel.
- Provide an example `settings.json` snippet and call out that overrides replace array values rather than merging them.
- Mention that UI-driven changes edit the root config so per-channel blocks might need manual updates.

## Testing
- Not run (docs only).

Fixes #40458.

Release Notes:

- N/A