### PR TITLE
Document global debug.json usage and fix REPL error copy

### DIFF
--- a/crates/repl/src/outputs/plain.rs
+++ b/crates/repl/src/outputs/plain.rs
@@ -198,7 +198,16 @@ impl TerminalOutput {
     }
 
     fn full_text(&self) -> String {
-        let mut full_text = String::new();
+        fn sanitize(mut line: String) -> Option<String> {
+            line.retain(|ch| ch != '\u{0}' && ch != '\r');
+            if line.trim().is_empty() {
+                return None;
+            }
+            let trimmed = line.trim_end_matches([' ', '\t']);
+            Some(trimmed.to_owned())
+        }
+
+        let mut lines = Vec::new();
 
         // Get the total number of lines, including history
         let total_lines = self.handler.grid().total_lines();
@@ -210,11 +219,8 @@ impl TerminalOutput {
             let line_index = Line(-(line as i32) - 1);
             let start = Point::new(line_index, Column(0));
             let end = Point::new(line_index, Column(self.handler.columns() - 1));
-            let line_content = self.handler.bounds_to_string(start, end);
-
-            if !line_content.trim().is_empty() {
-                full_text.push_str(&line_content);
-                full_text.push('\n');
+            if let Some(cleaned) = sanitize(self.handler.bounds_to_string(start, end)) {
+                lines.push(cleaned);
             }
         }
 
@@ -223,15 +229,18 @@ impl TerminalOutput {
             let line_index = Line(line as i32);
             let start = Point::new(line_index, Column(0));
             let end = Point::new(line_index, Column(self.handler.columns() - 1));
-            let line_content = self.handler.bounds_to_string(start, end);
-
-            if !line_content.trim().is_empty() {
-                full_text.push_str(&line_content);
-                full_text.push('\n');
+            if let Some(cleaned) = sanitize(self.handler.bounds_to_string(start, end)) {
+                lines.push(cleaned);
             }
         }
 
-        full_text
+        if lines.is_empty() {
+            String::new()
+        } else {
+            let mut full_text = lines.join("\n");
+            full_text.push('\n');
+            full_text
+        }
     }
 }
 

--- a/docs/src/debugger.md
+++ b/docs/src/debugger.md
@@ -56,6 +56,16 @@ Check the documentation for your language for example configurations covering ty
 
 Zed will also load debug configurations from `.vscode/launch.json`, and show them in the new process modal if no configurations are found in `.zed/debug.json`.
 
+#### Global debug configurations
+
+If you run the same launch profiles across multiple projects, you can store them once in your user configuration. Invoke {#action zed::OpenDebugTasks} from the command palette to open the global `debug.json` file; Zed creates it next to your user `settings.json` and keeps it in sync with the debugger UI. The file lives at:
+
+- **macOS:** `~/Library/Application Support/Zed/debug.json`
+- **Linux/BSD:** `$XDG_CONFIG_HOME/zed/debug.json` (falls back to `~/.config/zed/debug.json`)
+- **Windows:** `%APPDATA%\Zed\debug.json`
+
+Populate this file with the same array of objects you would place in `.zed/debug.json`. Any scenarios defined there are merged into every workspace, so your favorite launch presets appear automatically in the "New Debug Session" dialog.
+
 ### Launching & Attaching
 
 Zed debugger offers two ways to debug your program; you can either _launch_ a new instance of your program or _attach_ to an existing process.


### PR DESCRIPTION
﻿## Overview
- document how to keep a per-user debug.json so global launch tasks show up everywhere (Fixes #39849)
- sanitize REPL terminal text before copying so error blocks can be copied and opened in buffers (Fixes #40207)

## Design Decisions
- reused the existing user debug file (paths::debug_scenarios_file) and pointed docs at the zed::OpenDebugTasks command to stay aligned with the settings UX
- extract a sanitize helper inside TerminalOutput::full_text to strip \r/null padding while keeping indentation intact, then join the cleaned lines so clipboard and buffers get readable text

## Testing
- Not run (cargo is unavailable in this environment)

Fixes #39849.
Fixes #40207.
