### PR TITLE
helix: Fix picker ctrl-p/ctrl-n navigation

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -1,5 +1,12 @@
 [
   {
+    "context": "Picker || menu",
+    "bindings": {
+      "ctrl-n": "menu::SelectNext",
+      "ctrl-p": "menu::SelectPrevious"
+    }
+  },
+  {
     "context": "VimControl && !menu",
     "bindings": {
       "i": ["vim::PushObject", { "around": false }],


### PR DESCRIPTION
﻿## Overview
- Allow Helix mode users to navigate picker-style prompts (Search Project Files, command palette, etc.) with Ctrl+P/Ctrl+N, matching Helix expectations and closing #40619.
- Added a picker/menu-specific binding block to the Helix keymap so those chords call menu::SelectPrevious and menu::SelectNext, preventing the global ile_finder::Toggle binding from hijacking the keys while a prompt is open.

## Design Decisions
- Scoped the bindings to Picker || menu to mirror the default keymap and avoid affecting Helix behaviour outside picker UIs.
- Kept the fix purely in the keymap so existing picker code continues to handle menu navigation uniformly.

## Testing
- Not run (Rust toolchain/cargo is unavailable in this environment).

Fixes #40619.
