### PR TITLE
collab: Pin sea-orm-macro crate version together with sea-orm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3392,6 +3392,7 @@ dependencies = [
  "rpc",
  "scrypt",
  "sea-orm",
+ "sea-orm-macros",
  "semantic_version",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -900,4 +900,5 @@ ignored = [
     "serde",
     "component",
     "documented",
+    "sea-orm-macros",
 ]

--- a/crates/collab/Cargo.toml
+++ b/crates/collab/Cargo.toml
@@ -47,7 +47,9 @@ reqwest = { version = "0.11", features = ["json"] }
 reqwest_client.workspace = true
 rpc.workspace = true
 scrypt = "0.11"
+# sea-orm and sea-orm-macros versions must match exactly.
 sea-orm = { version = "=1.1.10", features = ["sqlx-postgres", "postgres-array", "runtime-tokio-rustls", "with-uuid"] }
+sea-orm-macros = "=1.1.10"
 semantic_version.workspace = true
 semver.workspace = true
 serde.workspace = true


### PR DESCRIPTION
Currently running `cargo update` on Zed will break the collab crate because the versions of sea-orm and sea-orm-macros will not match. This results in a bunch of noisy warnings from rust-analyzer.

Release Notes:

- N/A
