### PR TITLE
agent_ui: Remove ellipses from some menu entries

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1660,11 +1660,11 @@ impl AgentPanel {
                                     id: None,
                                 }),
                             )
-                            .action("Add Custom Server…", Box::new(AddContextServer))
+                            .action("Add Custom Server", Box::new(AddContextServer))
                             .separator();
 
                         menu = menu
-                            .action("Rules…", Box::new(OpenRulesLibrary::default()))
+                            .action("Rules", Box::new(OpenRulesLibrary::default()))
                             .action("Settings", Box::new(OpenSettings))
                             .separator()
                             .action(full_screen_label, Box::new(ToggleZoom));

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1660,7 +1660,7 @@ impl AgentPanel {
                                     id: None,
                                 }),
                             )
-                            .action("Add Custom Server", Box::new(AddContextServer))
+                            .action("Add Custom Server…", Box::new(AddContextServer))
                             .separator();
 
                         menu = menu


### PR DESCRIPTION
<img width="335" height="236" alt="image" src="https://github.com/user-attachments/assets/5e09e9ed-f0f3-48df-ac22-032edfc6c114" />

This PR fixes inconsistent use of trailing ellipsis (…) in the MCP Server menu. This change removes unnecessary ellipses to align with standard UI/UX conventions used across Zed’s menus.

Release Notes:

- N/A
