### PR TITLE
Add keybindings for menu navigation in vim.json

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -970,7 +970,9 @@
     "bindings": {
       "ctrl-h": "editor::Backspace",
       "ctrl-u": "editor::DeleteToBeginningOfLine",
-      "ctrl-w": "editor::DeleteToPreviousWordStart"
+      "ctrl-w": "editor::DeleteToPreviousWordStart",
+      "ctrl-p": "menu::SelectPrevious",
+      "ctrl-n": "menu::SelectNext"
     }
   },
   {


### PR DESCRIPTION
- Added "ctrl-p" for selecting the previous menu item
- Added "ctrl-n" for selecting the next menu item

Closes #40619 

Release Notes:
- Ctrl+P now moves to the previous result; Ctrl+N moves to the next.