### PR TITLE
Accelerate agent tests with SIMD instructions

### DIFF
--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -1,3 +1,6 @@
+#[macro_use]
+mod macros;
+
 mod db;
 mod edit_agent;
 mod history_store;

--- a/crates/agent/src/edit_agent/evals/fixtures/translate_doc_comments/before.rs
+++ b/crates/agent/src/edit_agent/evals/fixtures/translate_doc_comments/before.rs
@@ -293,10 +293,21 @@ struct BlitRgb24ToA8;
 impl Blit for BlitRgb24ToA8 {
     #[inline]
     fn blit(dest: &mut [u8], src: &[u8]) {
-        // TODO(pcwalton): SIMD.
-        for (dest, src) in dest.iter_mut().zip(src.chunks(3)) {
-            *dest = src[1]
+        fn copy(dest: &mut [u8], src: &[u8]) {
+            for (dest, src) in dest.iter_mut().zip(src.chunks(3)) {
+                *dest = src[1]
+            }
         }
+        _simd_slice!(
+            ((src, 3),),
+            ((dest, 1),),
+            ((local_src,), (local_dest,)) => {
+                for (dest_chunk, src_chunk) in local_dest.iter_mut().zip(local_src) {
+                    copy(dest_chunk, src_chunk)
+                }
+            },
+            ((local_src,), (local_dest,)) => copy(local_dest, local_src),
+        );
     }
 }
 
@@ -318,10 +329,22 @@ struct BlitRgba32ToRgb24;
 impl Blit for BlitRgba32ToRgb24 {
     #[inline]
     fn blit(dest: &mut [u8], src: &[u8]) {
-        // TODO(pcwalton): SIMD.
-        for (dest, src) in dest.chunks_mut(3).zip(src.chunks(4)) {
-            dest.copy_from_slice(&src[0..3])
+        fn copy(dest: &mut [u8], src: &[u8]) {
+            for (for_dest, for_src) in dest.chunks_mut(3).zip(src.chunks(4)) {
+                for_dest.copy_from_slice(&(for_src[0..3]))
+            }
         }
+
+        _simd_slice!(
+            ((src, 4),),
+            ((dest, 3),),
+            ((local_src,), (local_dest,)) => {
+                for (dest_chunk, src_chunk) in local_dest.iter_mut().zip(local_src) {
+                    copy(dest_chunk, src_chunk)
+                }
+            },
+            ((local_src,), (local_dest,)) => copy(local_dest, local_src),
+        );
     }
 }
 

--- a/crates/agent/src/macros.rs
+++ b/crates/agent/src/macros.rs
@@ -1,0 +1,81 @@
+macro_rules! _simd {
+    (
+        8 => $_8:expr,
+        16 => $_16:expr,
+        32 => $_32:expr,
+        64 => $_64:expr $(,)?
+    ) => {{
+        #[cfg(not(any(
+            target_feature = "avx2",
+            target_feature = "avx512f",
+            target_feature = "neon",
+            target_feature = "sse2"
+        )))]
+        let rslt = $_8;
+
+        #[cfg(all(
+            target_feature = "neon",
+            not(any(target_feature = "avx2", target_feature = "avx512f"))
+        ))]
+        let rslt = $_16;
+
+        #[cfg(all(
+            target_feature = "sse2",
+            not(any(
+                target_feature = "avx2",
+                target_feature = "avx512f",
+                target_feature = "neon"
+            ))
+        ))]
+        let rslt = $_16;
+
+        #[cfg(all(target_feature = "avx2", not(target_feature = "avx512f")))]
+        let rslt = $_32;
+
+        #[cfg(target_feature = "avx512f")]
+        let rslt = $_64;
+
+        rslt
+    }};
+}
+
+macro_rules! _simd_slice {
+    (
+        ($(($immutables_ident:ident, $immutables_chunk:expr)),* $(,)?),
+        ($(($mutables_ident:ident, $mutables_chunk:expr)),* $(,)?),
+        $_chunk_pat:pat => $_chunk_expr:expr,
+        $_rest_pat:pat => $_rest_expr:expr $(,)?
+    ) => {{
+        const fn calc(simd: usize, chunk: usize) -> usize {
+            (simd / chunk) * chunk
+        }
+        let (($($immutables_ident,)*), ($($mutables_ident,)*)) = _simd! {
+          8 => (
+              ($($immutables_ident.as_chunks::<{calc(8, $immutables_chunk)}>(),)*),
+              ($($mutables_ident.as_chunks_mut::<{calc(8, $mutables_chunk)}>(),)*)
+          ),
+          16 => (
+              ($($immutables_ident.as_chunks::<{calc(16, $immutables_chunk)}>(),)*),
+              ($($mutables_ident.as_chunks_mut::<{calc(16, $mutables_chunk)}>(),)*)
+          ),
+          32 => (
+              ($($immutables_ident.as_chunks::<{calc(32, $immutables_chunk)}>(),)*),
+              ($($mutables_ident.as_chunks_mut::<{calc(32, $mutables_chunk)}>(),)*)
+          ),
+          64 => (
+              ($($immutables_ident.as_chunks::<{calc(64, $immutables_chunk)}>(),)*),
+              ($($mutables_ident.as_chunks_mut::<{calc(64, $mutables_chunk)}>(),)*)
+          )
+        };
+        let $_chunk_pat = (
+            ($({ $immutables_ident.0 },)*),
+            ($({ $mutables_ident.0 },)*)
+        );
+        $_chunk_expr
+        let $_rest_pat = (
+            ($({ $immutables_ident.1 },)*),
+            ($({ $mutables_ident.1 },)*)
+        );
+        $_rest_expr
+    }};
+}


### PR DESCRIPTION
Fix 4 TODOs

Uses a not-great/not-terrible but much safer SIMD macro that hints the compiler about the intended width.

https://godbolt.org/z/6n4xh7sT4 shows the usage of `AVX512` registers in `x86-64-v4` with ~4x instructions, which shouldn't be a problem in modern platforms. My local `x86-64-v2` machine rendered a ~2x improvement in a micro benchmarks.

```
# Before
test blit_rgba32_to_rgb24 ... bench:   4,784,195.90 ns/iter (+/- 104,752.15)

# After
test blit_rgba32_to_rgb24 ... bench:   2,264,071.70 ns/iter (+/- 167,212.39)
```
