### PR TITLE
crashes: Avoid crash handler on detached threads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4132,6 +4132,7 @@ dependencies = [
  "bincode 1.3.3",
  "cfg-if",
  "crash-handler",
+ "extension_host",
  "log",
  "mach2 0.5.0",
  "minidumper",

--- a/crates/crashes/Cargo.toml
+++ b/crates/crashes/Cargo.toml
@@ -9,6 +9,7 @@ license = "GPL-3.0-or-later"
 bincode.workspace = true
 cfg-if.workspace = true
 crash-handler.workspace = true
+extension_host.workspace = true
 log.workspace = true
 minidumper.workspace = true
 paths.workspace = true

--- a/crates/crashes/src/crashes.rs
+++ b/crates/crashes/src/crashes.rs
@@ -286,6 +286,11 @@ impl minidumper::ServerHandler for CrashServer {
 }
 
 pub fn panic_hook(info: &PanicHookInfo) {
+    // Don't handle a panic on threads that are not relevant to the main execution.
+    if extension_host::wasm_host::IS_WASM_THREAD.with(|v| v.load(Ordering::Acquire)) {
+        return;
+    }
+
     let message = info
         .payload()
         .downcast_ref::<&str>()


### PR DESCRIPTION
Set a TLS bit to skip invoking the crash handler when a detached thread panics.

cc @P1n3appl3 - is this at odds with what we need the crash handler to do?

May close(?) #39289, cannot repro without a nightly build

Release Notes:

- Fixed extension panics crashing Zed on Linux
