### PR TITLE
Revert "gpui: Fix uniform list scrolling with vertical padding present"

### DIFF
--- a/crates/gpui/src/elements/uniform_list.rs
+++ b/crates/gpui/src/elements/uniform_list.rs
@@ -364,7 +364,17 @@ impl Element for UniformList {
             content_size,
             window,
             cx,
-            |_style, mut scroll_offset, hitbox, window, cx| {
+            |style, mut scroll_offset, hitbox, window, cx| {
+                let border = style.border_widths.to_pixels(window.rem_size());
+                let padding = style
+                    .padding
+                    .to_pixels(bounds.size.into(), window.rem_size());
+
+                let padded_bounds = Bounds::from_corners(
+                    bounds.origin + point(border.left + padding.left, border.top),
+                    bounds.bottom_right() - point(border.right + padding.right, border.bottom),
+                );
+
                 let y_flipped = if let Some(scroll_handle) = &self.scroll_handle {
                     let scroll_state = scroll_handle.0.borrow();
                     scroll_state.y_flipped


### PR DESCRIPTION
Reverts zed-industries/zed#40719

This unveiled some bigger issues with the UniformList size computations, which are more crucial than what was fixed here. 

Release Notes:

- NOTE: BUGFIX "Fixed a rare issue where the extension page would stutter while scrolling." was reverted due to some other issues