### PR TITLE
editor: Fix singleton multibuffer titles not being replicated

### DIFF
--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -226,7 +226,7 @@ impl FollowableItem for Editor {
 
         Some(proto::view::Variant::Editor(proto::view::Editor {
             singleton: buffer.is_singleton(),
-            title: (!buffer.is_singleton()).then(|| buffer.title(cx).into()),
+            title: buffer.explicit_title().map(ToOwned::to_owned),
             excerpts,
             scroll_top_anchor: Some(serialize_anchor(&scroll_anchor.anchor, &snapshot)),
             scroll_x: scroll_anchor.offset.x,

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -2556,6 +2556,10 @@ impl MultiBuffer {
         self.buffers.values().for_each(|state| f(&state.buffer))
     }
 
+    pub fn explicit_title(&self) -> Option<&str> {
+        self.title.as_deref()
+    }
+
     pub fn title<'a>(&'a self, cx: &'a App) -> Cow<'a, str> {
         if let Some(title) = self.title.as_ref() {
             return title.into();


### PR DESCRIPTION

Release Notes:

- Fixed title overrides of singleton buffers not being replicated
