### PR TITLE
Fix migration from #40409 for users who haven't been migrated yet

### DIFF
--- a/crates/migrator/src/migrations/m_2025_10_16/settings.rs
+++ b/crates/migrator/src/migrations/m_2025_10_16/settings.rs
@@ -58,7 +58,8 @@ fn restore_code_actions_on_format_inner(value: &mut Value, path: &[&str]) -> Res
             .map(|code_action| (code_action, Value::Bool(true))),
     );
 
-    obj.remove("formatter");
+    // Does this actually work?
+    obj.insert("formatter".to_string(), Value::Array(vec![]));
     obj.insert(
         "code_actions_on_format".into(),
         Value::Object(code_actions_map),

--- a/crates/migrator/src/migrations/m_2025_10_16/settings.rs
+++ b/crates/migrator/src/migrations/m_2025_10_16/settings.rs
@@ -58,7 +58,6 @@ fn restore_code_actions_on_format_inner(value: &mut Value, path: &[&str]) -> Res
             .map(|code_action| (code_action, Value::Bool(true))),
     );
 
-    // Does this actually work?
     obj.insert("formatter".to_string(), Value::Array(vec![]));
     obj.insert(
         "code_actions_on_format".into(),

--- a/crates/migrator/src/migrator.rs
+++ b/crates/migrator/src/migrator.rs
@@ -2016,9 +2016,9 @@ mod tests {
                 &r#"{
                     "code_actions_on_format": {
                         "foo": true
-                    }
-                }
-                "#
+                    },
+                    "formatter": []
+                }"#
                 .unindent(),
             ),
         );
@@ -2053,6 +2053,7 @@ mod tests {
             .unindent(),
             Some(
                 &r#"{
+                    "formatter": [],
                     "code_actions_on_format": {
                         "foo": true,
                         "bar": true,
@@ -2080,6 +2081,7 @@ mod tests {
             .unindent(),
             Some(
                 &r#"{
+                    "formatter": [],
                     "code_actions_on_format": {
                         "foo": true,
                         "qux": true,


### PR DESCRIPTION
Closes #40874

Co-Authored-By: Cole <cole@zed.dev>
Co-Authored-By: Mikayla <mikayla@zed.dev>

Release Notes:

- Fixed an issue where migrating settings after v0.208.5+  would spuriously enable prettier or the default language server formatting. This fix only affects those who have not updated or migrated yet. For those who have already updated to version v0.208.5 or later, placing `"formatter": []` in your settings in the affected languages will fix the issue.
