### PR TITLE
editor: Reduce selection opacity when editor is not focused

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1422,7 +1422,11 @@ impl EditorElement {
                     layouts.push(layout);
                 }
 
-                let player = editor.current_user_player_color(cx);
+                let mut player = editor.current_user_player_color(cx);
+                if !editor.is_focused(window) {
+                    const UNFOCUS_EDITOR_SELECTION_OPACITY: f32 = 0.5;
+                    player.selection = player.selection.opacity(UNFOCUS_EDITOR_SELECTION_OPACITY);
+                }
                 selections.push((player, layouts));
 
                 if let SelectionDragState::Dragging {


### PR DESCRIPTION
Focus:
<img width="420" alt="image" src="https://github.com/user-attachments/assets/97b0c7ed-8ad4-400c-9f36-01d8bd9b362d" />

Unfocus:
<img width="420" alt="image" src="https://github.com/user-attachments/assets/19805293-b419-4669-8a93-e9cf41900403" />

Release Notes:

- Reduced selection opacity when the editor is out of focus to make inactive states clearer.

