### PR TITLE
Fix keybind hints flickering in certain scenarios

### DIFF
--- a/crates/agent_ui/src/acp/mode_selector.rs
+++ b/crates/agent_ui/src/acp/mode_selector.rs
@@ -194,7 +194,7 @@ impl Render for ModeSelector {
                 trigger_button,
                 Tooltip::element({
                     let focus_handle = self.focus_handle.clone();
-                    move |window, cx| {
+                    move |_window, cx| {
                         v_flex()
                             .gap_1()
                             .child(
@@ -205,10 +205,9 @@ impl Render for ModeSelector {
                                     .border_b_1()
                                     .border_color(cx.theme().colors().border_variant)
                                     .child(Label::new("Cycle Through Modes"))
-                                    .children(KeyBinding::for_action_in(
+                                    .child(KeyBinding::for_action_in(
                                         &CycleModeSelector,
                                         &focus_handle,
-                                        window,
                                         cx,
                                     )),
                             )
@@ -217,10 +216,9 @@ impl Render for ModeSelector {
                                     .gap_2()
                                     .justify_between()
                                     .child(Label::new("Toggle Mode Menu"))
-                                    .children(KeyBinding::for_action_in(
+                                    .child(KeyBinding::for_action_in(
                                         &ToggleProfileSelector,
                                         &focus_handle,
-                                        window,
                                         cx,
                                     )),
                             )

--- a/crates/agent_ui/src/acp/model_selector_popover.rs
+++ b/crates/agent_ui/src/acp/model_selector_popover.rs
@@ -77,14 +77,8 @@ impl Render for AcpModelSelectorPopover {
                         .ml_0p5(),
                 )
                 .child(Icon::new(icon).color(Color::Muted).size(IconSize::XSmall)),
-            move |window, cx| {
-                Tooltip::for_action_in(
-                    "Change Model",
-                    &ToggleModelSelector,
-                    &focus_handle,
-                    window,
-                    cx,
-                )
+            move |_window, cx| {
+                Tooltip::for_action_in("Change Model", &ToggleModelSelector, &focus_handle, cx)
             },
             gpui::Corner::BottomRight,
             cx,

--- a/crates/agent_ui/src/acp/thread_history.rs
+++ b/crates/agent_ui/src/acp/thread_history.rs
@@ -423,8 +423,8 @@ impl AcpThreadHistory {
                                 .shape(IconButtonShape::Square)
                                 .icon_size(IconSize::XSmall)
                                 .icon_color(Color::Muted)
-                                .tooltip(move |window, cx| {
-                                    Tooltip::for_action("Delete", &RemoveSelectedThread, window, cx)
+                                .tooltip(move |_window, cx| {
+                                    Tooltip::for_action("Delete", &RemoveSelectedThread, cx)
                                 })
                                 .on_click(
                                     cx.listener(move |this, _, _, cx| this.remove_thread(ix, cx)),
@@ -595,8 +595,8 @@ impl RenderOnce for AcpHistoryEntryElement {
                         .shape(IconButtonShape::Square)
                         .icon_size(IconSize::XSmall)
                         .icon_color(Color::Muted)
-                        .tooltip(move |window, cx| {
-                            Tooltip::for_action("Delete", &RemoveSelectedThread, window, cx)
+                        .tooltip(move |_window, cx| {
+                            Tooltip::for_action("Delete", &RemoveSelectedThread, cx)
                         })
                         .on_click({
                             let thread_view = self.thread_view.clone();

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -2157,7 +2157,6 @@ impl AcpThreadView {
                             options,
                             entry_ix,
                             tool_call.id.clone(),
-                            window,
                             cx,
                         ))
                         .into_any(),
@@ -2558,7 +2557,6 @@ impl AcpThreadView {
         options: &[acp::PermissionOption],
         entry_ix: usize,
         tool_call_id: acp::ToolCallId,
-        window: &Window,
         cx: &Context<Self>,
     ) -> Div {
         let is_first = self.thread().is_some_and(|thread| {
@@ -2615,7 +2613,7 @@ impl AcpThreadView {
                         seen_kinds.push(option.kind);
 
                         this.key_binding(
-                            KeyBinding::for_action_in(action, &self.focus_handle, window, cx)
+                            KeyBinding::for_action_in(action, &self.focus_handle, cx)
                                 .map(|kb| kb.size(rems_from_px(10.))),
                         )
                     })
@@ -2796,12 +2794,11 @@ impl AcpThreadView {
                         .icon_size(IconSize::Small)
                         .icon_color(Color::Error)
                         .label_size(LabelSize::Small)
-                        .tooltip(move |window, cx| {
+                        .tooltip(move |_window, cx| {
                             Tooltip::with_meta(
                                 "Stop This Command",
                                 None,
                                 "Also possible by placing your cursor inside the terminal and using regular terminal bindings.",
-                                window,
                                 cx,
                             )
                         })
@@ -3102,7 +3099,7 @@ impl AcpThreadView {
         )
     }
 
-    fn render_recent_history(&self, window: &mut Window, cx: &mut Context<Self>) -> AnyElement {
+    fn render_recent_history(&self, cx: &mut Context<Self>) -> AnyElement {
         let render_history = self
             .agent
             .clone()
@@ -3131,7 +3128,6 @@ impl AcpThreadView {
                                             KeyBinding::for_action_in(
                                                 &OpenHistory,
                                                 &self.focus_handle(cx),
-                                                window,
                                                 cx,
                                             )
                                             .map(|kb| kb.size(rems_from_px(12.))),
@@ -3459,7 +3455,6 @@ impl AcpThreadView {
                     &changed_buffers,
                     self.edits_expanded,
                     pending_edits,
-                    window,
                     cx,
                 ))
                 .when(self.edits_expanded, |parent| {
@@ -3619,7 +3614,6 @@ impl AcpThreadView {
         changed_buffers: &BTreeMap<Entity<Buffer>, Entity<BufferDiff>>,
         expanded: bool,
         pending_edits: bool,
-        window: &mut Window,
         cx: &Context<Self>,
     ) -> Div {
         const EDIT_NOT_READY_TOOLTIP_LABEL: &str = "Wait until file edits are complete.";
@@ -3695,12 +3689,11 @@ impl AcpThreadView {
                             .icon_size(IconSize::Small)
                             .tooltip({
                                 let focus_handle = focus_handle.clone();
-                                move |window, cx| {
+                                move |_window, cx| {
                                     Tooltip::for_action_in(
                                         "Review Changes",
                                         &OpenAgentDiff,
                                         &focus_handle,
-                                        window,
                                         cx,
                                     )
                                 }
@@ -3718,13 +3711,8 @@ impl AcpThreadView {
                                 this.tooltip(Tooltip::text(EDIT_NOT_READY_TOOLTIP_LABEL))
                             })
                             .key_binding(
-                                KeyBinding::for_action_in(
-                                    &RejectAll,
-                                    &focus_handle.clone(),
-                                    window,
-                                    cx,
-                                )
-                                .map(|kb| kb.size(rems_from_px(10.))),
+                                KeyBinding::for_action_in(&RejectAll, &focus_handle.clone(), cx)
+                                    .map(|kb| kb.size(rems_from_px(10.))),
                             )
                             .on_click(cx.listener(move |this, _, window, cx| {
                                 this.reject_all(&RejectAll, window, cx);
@@ -3738,7 +3726,7 @@ impl AcpThreadView {
                                 this.tooltip(Tooltip::text(EDIT_NOT_READY_TOOLTIP_LABEL))
                             })
                             .key_binding(
-                                KeyBinding::for_action_in(&KeepAll, &focus_handle, window, cx)
+                                KeyBinding::for_action_in(&KeepAll, &focus_handle, cx)
                                     .map(|kb| kb.size(rems_from_px(10.))),
                             )
                             .on_click(cx.listener(move |this, _, window, cx| {
@@ -3968,12 +3956,11 @@ impl AcpThreadView {
                                     .icon_size(IconSize::Small)
                                     .icon_color(Color::Muted)
                                     .tooltip({
-                                        move |window, cx| {
+                                        move |_window, cx| {
                                             Tooltip::for_action_in(
                                                 expand_tooltip,
                                                 &ExpandMessageEditor,
                                                 &focus_handle,
-                                                window,
                                                 cx,
                                             )
                                         }
@@ -4198,8 +4185,8 @@ impl AcpThreadView {
             IconButton::new("stop-generation", IconName::Stop)
                 .icon_color(Color::Error)
                 .style(ButtonStyle::Tinted(ui::TintColor::Error))
-                .tooltip(move |window, cx| {
-                    Tooltip::for_action("Stop Generation", &editor::actions::Cancel, window, cx)
+                .tooltip(move |_window, cx| {
+                    Tooltip::for_action("Stop Generation", &editor::actions::Cancel, cx)
                 })
                 .on_click(cx.listener(|this, _event, _, cx| this.cancel_generation(cx)))
                 .into_any_element()
@@ -4221,7 +4208,7 @@ impl AcpThreadView {
                         this.icon_color(Color::Accent)
                     }
                 })
-                .tooltip(move |window, cx| Tooltip::for_action(send_btn_tooltip, &Chat, window, cx))
+                .tooltip(move |_window, cx| Tooltip::for_action(send_btn_tooltip, &Chat, cx))
                 .on_click(cx.listener(|this, _, window, cx| {
                     this.send(window, cx);
                 }))
@@ -4282,15 +4269,14 @@ impl AcpThreadView {
             .icon_color(Color::Muted)
             .toggle_state(following)
             .selected_icon_color(Some(Color::Custom(cx.theme().players().agent().cursor)))
-            .tooltip(move |window, cx| {
+            .tooltip(move |_window, cx| {
                 if following {
-                    Tooltip::for_action(tooltip_label.clone(), &Follow, window, cx)
+                    Tooltip::for_action(tooltip_label.clone(), &Follow, cx)
                 } else {
                     Tooltip::with_meta(
                         tooltip_label.clone(),
                         Some(&Follow),
                         "Track the agent's location as it reads and edits files.",
-                        window,
                         cx,
                     )
                 }
@@ -5079,7 +5065,7 @@ impl AcpThreadView {
         }
     }
 
-    fn render_thread_error(&self, window: &mut Window, cx: &mut Context<Self>) -> Option<Div> {
+    fn render_thread_error(&self, cx: &mut Context<Self>) -> Option<Div> {
         let content = match self.thread_error.as_ref()? {
             ThreadError::Other(error) => self.render_any_thread_error(error.clone(), cx),
             ThreadError::Refusal => self.render_refusal_error(cx),
@@ -5090,9 +5076,7 @@ impl AcpThreadView {
             ThreadError::ModelRequestLimitReached(plan) => {
                 self.render_model_request_limit_reached_error(*plan, cx)
             }
-            ThreadError::ToolUseLimitReached => {
-                self.render_tool_use_limit_reached_error(window, cx)?
-            }
+            ThreadError::ToolUseLimitReached => self.render_tool_use_limit_reached_error(cx)?,
         };
 
         Some(div().child(content))
@@ -5283,11 +5267,7 @@ impl AcpThreadView {
             .dismiss_action(self.dismiss_error_button(cx))
     }
 
-    fn render_tool_use_limit_reached_error(
-        &self,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) -> Option<Callout> {
+    fn render_tool_use_limit_reached_error(&self, cx: &mut Context<Self>) -> Option<Callout> {
         let thread = self.as_native_thread(cx)?;
         let supports_burn_mode = thread
             .read(cx)
@@ -5314,7 +5294,6 @@ impl AcpThreadView {
                                         KeyBinding::for_action_in(
                                             &ContinueWithBurnMode,
                                             &focus_handle,
-                                            window,
                                             cx,
                                         )
                                         .map(|kb| kb.size(rems_from_px(10.))),
@@ -5338,13 +5317,8 @@ impl AcpThreadView {
                                 .layer(ElevationIndex::ModalSurface)
                                 .label_size(LabelSize::Small)
                                 .key_binding(
-                                    KeyBinding::for_action_in(
-                                        &ContinueThread,
-                                        &focus_handle,
-                                        window,
-                                        cx,
-                                    )
-                                    .map(|kb| kb.size(rems_from_px(10.))),
+                                    KeyBinding::for_action_in(&ContinueThread, &focus_handle, cx)
+                                        .map(|kb| kb.size(rems_from_px(10.))),
                                 )
                                 .on_click(cx.listener(|this, _, _window, cx| {
                                     this.resume_chat(cx);
@@ -5520,7 +5494,7 @@ impl Render for AcpThreadView {
                     .into_any(),
                 ThreadState::Loading { .. } => v_flex()
                     .flex_1()
-                    .child(self.render_recent_history(window, cx))
+                    .child(self.render_recent_history(cx))
                     .into_any(),
                 ThreadState::LoadError(e) => v_flex()
                     .flex_1()
@@ -5551,8 +5525,7 @@ impl Render for AcpThreadView {
                         .vertical_scrollbar_for(self.list_state.clone(), window, cx)
                         .into_any()
                     } else {
-                        this.child(self.render_recent_history(window, cx))
-                            .into_any()
+                        this.child(self.render_recent_history(cx)).into_any()
                     }
                 }),
             })
@@ -5576,7 +5549,7 @@ impl Render for AcpThreadView {
                     Vec::<Empty>::new()
                 }
             })
-            .children(self.render_thread_error(window, cx))
+            .children(self.render_thread_error(cx))
             .when_some(
                 self.new_server_version_available.as_ref().filter(|_| {
                     !has_messages || !matches!(self.thread_state, ThreadState::Ready { .. })

--- a/crates/agent_ui/src/agent_configuration/add_llm_provider_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/add_llm_provider_modal.rs
@@ -431,7 +431,7 @@ impl Focusable for AddLlmProviderModal {
 impl ModalView for AddLlmProviderModal {}
 
 impl Render for AddLlmProviderModal {
-    fn render(&mut self, window: &mut ui::Window, cx: &mut ui::Context<Self>) -> impl IntoElement {
+    fn render(&mut self, _window: &mut ui::Window, cx: &mut ui::Context<Self>) -> impl IntoElement {
         let focus_handle = self.focus_handle(cx);
 
         div()
@@ -484,7 +484,6 @@ impl Render for AddLlmProviderModal {
                                             KeyBinding::for_action_in(
                                                 &menu::Cancel,
                                                 &focus_handle,
-                                                window,
                                                 cx,
                                             )
                                             .map(|kb| kb.size(rems_from_px(12.))),
@@ -499,7 +498,6 @@ impl Render for AddLlmProviderModal {
                                             KeyBinding::for_action_in(
                                                 &menu::Confirm,
                                                 &focus_handle,
-                                                window,
                                                 cx,
                                             )
                                             .map(|kb| kb.size(rems_from_px(12.))),

--- a/crates/agent_ui/src/agent_configuration/configure_context_server_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/configure_context_server_modal.rs
@@ -566,7 +566,7 @@ impl ConfigureContextServerModal {
             .into_any_element()
     }
 
-    fn render_modal_footer(&self, window: &mut Window, cx: &mut Context<Self>) -> ModalFooter {
+    fn render_modal_footer(&self, cx: &mut Context<Self>) -> ModalFooter {
         let focus_handle = self.focus_handle(cx);
         let is_connecting = matches!(self.state, State::Waiting);
 
@@ -584,12 +584,11 @@ impl ConfigureContextServerModal {
                             .icon_size(IconSize::Small)
                             .tooltip({
                                 let repository_url = repository_url.clone();
-                                move |window, cx| {
+                                move |_window, cx| {
                                     Tooltip::with_meta(
                                         "Open Repository",
                                         None,
                                         repository_url.clone(),
-                                        window,
                                         cx,
                                     )
                                 }
@@ -616,7 +615,7 @@ impl ConfigureContextServerModal {
                             },
                         )
                         .key_binding(
-                            KeyBinding::for_action_in(&menu::Cancel, &focus_handle, window, cx)
+                            KeyBinding::for_action_in(&menu::Cancel, &focus_handle, cx)
                                 .map(|kb| kb.size(rems_from_px(12.))),
                         )
                         .on_click(
@@ -634,7 +633,7 @@ impl ConfigureContextServerModal {
                         )
                         .disabled(is_connecting)
                         .key_binding(
-                            KeyBinding::for_action_in(&menu::Confirm, &focus_handle, window, cx)
+                            KeyBinding::for_action_in(&menu::Confirm, &focus_handle, cx)
                                 .map(|kb| kb.size(rems_from_px(12.))),
                         )
                         .on_click(
@@ -709,7 +708,7 @@ impl Render for ConfigureContextServerModal {
                                 State::Error(error) => Self::render_modal_error(error.clone()),
                             }),
                     )
-                    .footer(self.render_modal_footer(window, cx)),
+                    .footer(self.render_modal_footer(cx)),
             )
     }
 }

--- a/crates/agent_ui/src/agent_configuration/manage_profiles_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/manage_profiles_modal.rs
@@ -341,10 +341,9 @@ impl ManageProfilesModal {
                                         .size(LabelSize::Small)
                                         .color(Color::Muted),
                                 )
-                                .children(KeyBinding::for_action_in(
+                                .child(KeyBinding::for_action_in(
                                     &menu::Confirm,
                                     &self.focus_handle,
-                                    window,
                                     cx,
                                 )),
                         )
@@ -638,14 +637,13 @@ impl ManageProfilesModal {
                                         )
                                         .child(Label::new("Go Back"))
                                         .end_slot(
-                                            div().children(
+                                            div().child(
                                                 KeyBinding::for_action_in(
                                                     &menu::Cancel,
                                                     &self.focus_handle,
-                                                    window,
                                                     cx,
                                                 )
-                                                .map(|kb| kb.size(rems_from_px(12.))),
+                                                .size(rems_from_px(12.)),
                                             ),
                                         )
                                         .on_click({
@@ -689,14 +687,9 @@ impl Render for ManageProfilesModal {
                     )
                     .child(Label::new("Go Back"))
                     .end_slot(
-                        div().children(
-                            KeyBinding::for_action_in(
-                                &menu::Cancel,
-                                &self.focus_handle,
-                                window,
-                                cx,
-                            )
-                            .map(|kb| kb.size(rems_from_px(12.))),
+                        div().child(
+                            KeyBinding::for_action_in(&menu::Cancel, &self.focus_handle, cx)
+                                .size(rems_from_px(12.)),
                         ),
                     )
                     .on_click({

--- a/crates/agent_ui/src/agent_diff.rs
+++ b/crates/agent_ui/src/agent_diff.rs
@@ -671,7 +671,7 @@ impl Item for AgentDiffPane {
 }
 
 impl Render for AgentDiffPane {
-    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let is_empty = self.multibuffer.read(cx).is_empty();
         let focus_handle = &self.focus_handle;
 
@@ -704,7 +704,6 @@ impl Render for AgentDiffPane {
                                 .key_binding(KeyBinding::for_action_in(
                                     &ToggleFocus,
                                     &focus_handle.clone(),
-                                    window,
                                     cx,
                                 ))
                                 .on_click(|_event, window, cx| {
@@ -721,14 +720,7 @@ fn diff_hunk_controls(thread: &AgentDiffThread) -> editor::RenderDiffHunkControl
     let thread = thread.clone();
 
     Arc::new(
-        move |row,
-              status: &DiffHunkStatus,
-              hunk_range,
-              is_created_file,
-              line_height,
-              editor: &Entity<Editor>,
-              window: &mut Window,
-              cx: &mut App| {
+        move |row, status, hunk_range, is_created_file, line_height, editor, _, cx| {
             {
                 render_diff_hunk_controls(
                     row,
@@ -738,7 +730,6 @@ fn diff_hunk_controls(thread: &AgentDiffThread) -> editor::RenderDiffHunkControl
                     line_height,
                     &thread,
                     editor,
-                    window,
                     cx,
                 )
             }
@@ -754,7 +745,6 @@ fn render_diff_hunk_controls(
     line_height: Pixels,
     thread: &AgentDiffThread,
     editor: &Entity<Editor>,
-    window: &mut Window,
     cx: &mut App,
 ) -> AnyElement {
     let editor = editor.clone();
@@ -777,13 +767,8 @@ fn render_diff_hunk_controls(
             Button::new(("reject", row as u64), "Reject")
                 .disabled(is_created_file)
                 .key_binding(
-                    KeyBinding::for_action_in(
-                        &Reject,
-                        &editor.read(cx).focus_handle(cx),
-                        window,
-                        cx,
-                    )
-                    .map(|kb| kb.size(rems_from_px(12.))),
+                    KeyBinding::for_action_in(&Reject, &editor.read(cx).focus_handle(cx), cx)
+                        .map(|kb| kb.size(rems_from_px(12.))),
                 )
                 .on_click({
                     let editor = editor.clone();
@@ -804,7 +789,7 @@ fn render_diff_hunk_controls(
                 }),
             Button::new(("keep", row as u64), "Keep")
                 .key_binding(
-                    KeyBinding::for_action_in(&Keep, &editor.read(cx).focus_handle(cx), window, cx)
+                    KeyBinding::for_action_in(&Keep, &editor.read(cx).focus_handle(cx), cx)
                         .map(|kb| kb.size(rems_from_px(12.))),
                 )
                 .on_click({
@@ -835,14 +820,8 @@ fn render_diff_hunk_controls(
                         // .disabled(!has_multiple_hunks)
                         .tooltip({
                             let focus_handle = editor.focus_handle(cx);
-                            move |window, cx| {
-                                Tooltip::for_action_in(
-                                    "Next Hunk",
-                                    &GoToHunk,
-                                    &focus_handle,
-                                    window,
-                                    cx,
-                                )
+                            move |_window, cx| {
+                                Tooltip::for_action_in("Next Hunk", &GoToHunk, &focus_handle, cx)
                             }
                         })
                         .on_click({
@@ -871,12 +850,11 @@ fn render_diff_hunk_controls(
                         // .disabled(!has_multiple_hunks)
                         .tooltip({
                             let focus_handle = editor.focus_handle(cx);
-                            move |window, cx| {
+                            move |_window, cx| {
                                 Tooltip::for_action_in(
                                     "Previous Hunk",
                                     &GoToPreviousHunk,
                                     &focus_handle,
-                                    window,
                                     cx,
                                 )
                             }
@@ -1041,7 +1019,7 @@ impl ToolbarItemView for AgentDiffToolbar {
 }
 
 impl Render for AgentDiffToolbar {
-    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let spinner_icon = div()
             .px_0p5()
             .id("generating")
@@ -1116,7 +1094,6 @@ impl Render for AgentDiffToolbar {
                                         KeyBinding::for_action_in(
                                             &RejectAll,
                                             &editor_focus_handle,
-                                            window,
                                             cx,
                                         )
                                         .map(|kb| kb.size(rems_from_px(12.)))
@@ -1131,7 +1108,6 @@ impl Render for AgentDiffToolbar {
                                         KeyBinding::for_action_in(
                                             &KeepAll,
                                             &editor_focus_handle,
-                                            window,
                                             cx,
                                         )
                                         .map(|kb| kb.size(rems_from_px(12.)))
@@ -1208,13 +1184,8 @@ impl Render for AgentDiffToolbar {
                             .child(
                                 Button::new("reject-all", "Reject All")
                                     .key_binding({
-                                        KeyBinding::for_action_in(
-                                            &RejectAll,
-                                            &focus_handle,
-                                            window,
-                                            cx,
-                                        )
-                                        .map(|kb| kb.size(rems_from_px(12.)))
+                                        KeyBinding::for_action_in(&RejectAll, &focus_handle, cx)
+                                            .map(|kb| kb.size(rems_from_px(12.)))
                                     })
                                     .on_click(cx.listener(|this, _, window, cx| {
                                         this.dispatch_action(&RejectAll, window, cx)
@@ -1223,13 +1194,8 @@ impl Render for AgentDiffToolbar {
                             .child(
                                 Button::new("keep-all", "Keep All")
                                     .key_binding({
-                                        KeyBinding::for_action_in(
-                                            &KeepAll,
-                                            &focus_handle,
-                                            window,
-                                            cx,
-                                        )
-                                        .map(|kb| kb.size(rems_from_px(12.)))
+                                        KeyBinding::for_action_in(&KeepAll, &focus_handle, cx)
+                                            .map(|kb| kb.size(rems_from_px(12.)))
                                     })
                                     .on_click(cx.listener(|this, _, window, cx| {
                                         this.dispatch_action(&KeepAll, window, cx)

--- a/crates/agent_ui/src/agent_model_selector.rs
+++ b/crates/agent_ui/src/agent_model_selector.rs
@@ -96,14 +96,8 @@ impl Render for AgentModelSelector {
                         .color(color)
                         .size(IconSize::XSmall),
                 ),
-            move |window, cx| {
-                Tooltip::for_action_in(
-                    "Change Model",
-                    &ToggleModelSelector,
-                    &focus_handle,
-                    window,
-                    cx,
-                )
+            move |_window, cx| {
+                Tooltip::for_action_in("Change Model", &ToggleModelSelector, &focus_handle, cx)
             },
             gpui::Corner::TopRight,
             cx,

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1595,12 +1595,11 @@ impl AgentPanel {
                     .icon_size(IconSize::Small),
                 {
                     let focus_handle = focus_handle.clone();
-                    move |window, cx| {
+                    move |_window, cx| {
                         Tooltip::for_action_in(
                             "Toggle Agent Menu",
                             &ToggleOptionsMenu,
                             &focus_handle,
-                            window,
                             cx,
                         )
                     }
@@ -1691,12 +1690,11 @@ impl AgentPanel {
             .trigger_with_tooltip(
                 IconButton::new("agent-nav-menu", icon).icon_size(IconSize::Small),
                 {
-                    move |window, cx| {
+                    move |_window, cx| {
                         Tooltip::for_action_in(
                             "Toggle Recent Threads",
                             &ToggleNavigationMenu,
                             &focus_handle,
-                            window,
                             cx,
                         )
                     }
@@ -1730,8 +1728,8 @@ impl AgentPanel {
                 this.go_back(&workspace::GoBack, window, cx);
             }))
             .tooltip({
-                move |window, cx| {
-                    Tooltip::for_action_in("Go Back", &workspace::GoBack, &focus_handle, window, cx)
+                move |_window, cx| {
+                    Tooltip::for_action_in("Go Back", &workspace::GoBack, &focus_handle, cx)
                 }
             })
     }
@@ -1752,12 +1750,11 @@ impl AgentPanel {
                 IconButton::new("new_thread_menu_btn", IconName::Plus).icon_size(IconSize::Small),
                 {
                     let focus_handle = focus_handle.clone();
-                    move |window, cx| {
+                    move |_window, cx| {
                         Tooltip::for_action_in(
                             "New…",
                             &ToggleNewThreadMenu,
                             &focus_handle,
-                            window,
                             cx,
                         )
                     }
@@ -2003,14 +2000,8 @@ impl AgentPanel {
             .when_some(self.selected_agent.icon(), |this, icon| {
                 this.px(DynamicSpacing::Base02.rems(cx))
                     .child(Icon::new(icon).color(Color::Muted))
-                    .tooltip(move |window, cx| {
-                        Tooltip::with_meta(
-                            selected_agent_label.clone(),
-                            None,
-                            "Selected Agent",
-                            window,
-                            cx,
-                        )
+                    .tooltip(move |_window, cx| {
+                        Tooltip::with_meta(selected_agent_label.clone(), None, "Selected Agent", cx)
                     })
             })
             .into_any_element();
@@ -2186,7 +2177,6 @@ impl AgentPanel {
         border_bottom: bool,
         configuration_error: &ConfigurationError,
         focus_handle: &FocusHandle,
-        window: &mut Window,
         cx: &mut App,
     ) -> impl IntoElement {
         let zed_provider_configured = AgentSettings::get_global(cx)
@@ -2235,7 +2225,7 @@ impl AgentPanel {
                         .style(ButtonStyle::Tinted(ui::TintColor::Warning))
                         .label_size(LabelSize::Small)
                         .key_binding(
-                            KeyBinding::for_action_in(&OpenSettings, focus_handle, window, cx)
+                            KeyBinding::for_action_in(&OpenSettings, focus_handle, cx)
                                 .map(|kb| kb.size(rems_from_px(12.))),
                         )
                         .on_click(|_event, window, cx| {
@@ -2453,7 +2443,6 @@ impl Render for AgentPanel {
                                     true,
                                     err,
                                     &self.focus_handle(cx),
-                                    window,
                                     cx,
                                 ))
                             } else {

--- a/crates/agent_ui/src/context_strip.rs
+++ b/crates/agent_ui/src/context_strip.rs
@@ -483,12 +483,11 @@ impl Render for ContextStrip {
                             .style(ui::ButtonStyle::Filled),
                         {
                             let focus_handle = focus_handle.clone();
-                            move |window, cx| {
+                            move |_window, cx| {
                                 Tooltip::for_action_in(
                                     "Add Context",
                                     &ToggleContextPicker,
                                     &focus_handle,
-                                    window,
                                     cx,
                                 )
                             }
@@ -558,12 +557,11 @@ impl Render for ContextStrip {
                             .icon_size(IconSize::Small)
                             .tooltip({
                                 let focus_handle = focus_handle.clone();
-                                move |window, cx| {
+                                move |_window, cx| {
                                     Tooltip::for_action_in(
                                         "Remove All Context",
                                         &RemoveAllContext,
                                         &focus_handle,
-                                        window,
                                         cx,
                                     )
                                 }

--- a/crates/agent_ui/src/inline_prompt_editor.rs
+++ b/crates/agent_ui/src/inline_prompt_editor.rs
@@ -468,12 +468,11 @@ impl<T: 'static> PromptEditor<T> {
                 IconButton::new("stop", IconName::Stop)
                     .icon_color(Color::Error)
                     .shape(IconButtonShape::Square)
-                    .tooltip(move |window, cx| {
+                    .tooltip(move |_window, cx| {
                         Tooltip::with_meta(
                             mode.tooltip_interrupt(),
                             Some(&menu::Cancel),
                             "Changes won't be discarded",
-                            window,
                             cx,
                         )
                     })
@@ -487,12 +486,11 @@ impl<T: 'static> PromptEditor<T> {
                         IconButton::new("restart", IconName::RotateCw)
                             .icon_color(Color::Info)
                             .shape(IconButtonShape::Square)
-                            .tooltip(move |window, cx| {
+                            .tooltip(move |_window, cx| {
                                 Tooltip::with_meta(
                                     mode.tooltip_restart(),
                                     Some(&menu::Confirm),
                                     "Changes will be discarded",
-                                    window,
                                     cx,
                                 )
                             })
@@ -505,8 +503,8 @@ impl<T: 'static> PromptEditor<T> {
                     let accept = IconButton::new("accept", IconName::Check)
                         .icon_color(Color::Info)
                         .shape(IconButtonShape::Square)
-                        .tooltip(move |window, cx| {
-                            Tooltip::for_action(mode.tooltip_accept(), &menu::Confirm, window, cx)
+                        .tooltip(move |_window, cx| {
+                            Tooltip::for_action(mode.tooltip_accept(), &menu::Confirm, cx)
                         })
                         .on_click(cx.listener(|_, _, _, cx| {
                             cx.emit(PromptEditorEvent::ConfirmRequested { execute: false });
@@ -519,11 +517,10 @@ impl<T: 'static> PromptEditor<T> {
                             IconButton::new("confirm", IconName::PlayFilled)
                                 .icon_color(Color::Info)
                                 .shape(IconButtonShape::Square)
-                                .tooltip(|window, cx| {
+                                .tooltip(|_window, cx| {
                                     Tooltip::for_action(
                                         "Execute Generated Command",
                                         &menu::SecondaryConfirm,
-                                        window,
                                         cx,
                                     )
                                 })
@@ -615,13 +612,12 @@ impl<T: 'static> PromptEditor<T> {
                     .shape(IconButtonShape::Square)
                     .tooltip({
                         let focus_handle = self.editor.focus_handle(cx);
-                        move |window, cx| {
+                        move |_window, cx| {
                             cx.new(|cx| {
                                 let mut tooltip = Tooltip::new("Previous Alternative").key_binding(
                                     KeyBinding::for_action_in(
                                         &CyclePreviousInlineAssist,
                                         &focus_handle,
-                                        window,
                                         cx,
                                     ),
                                 );
@@ -657,13 +653,12 @@ impl<T: 'static> PromptEditor<T> {
                     .shape(IconButtonShape::Square)
                     .tooltip({
                         let focus_handle = self.editor.focus_handle(cx);
-                        move |window, cx| {
+                        move |_window, cx| {
                             cx.new(|cx| {
                                 let mut tooltip = Tooltip::new("Next Alternative").key_binding(
                                     KeyBinding::for_action_in(
                                         &CycleNextInlineAssist,
                                         &focus_handle,
-                                        window,
                                         cx,
                                     ),
                                 );

--- a/crates/agent_ui/src/profile_selector.rs
+++ b/crates/agent_ui/src/profile_selector.rs
@@ -162,12 +162,11 @@ impl Render for ProfileSelector {
         PickerPopoverMenu::new(
             picker,
             trigger_button,
-            move |window, cx| {
+            move |_window, cx| {
                 Tooltip::for_action_in(
                     "Toggle Profile Menu",
                     &ToggleProfileSelector,
                     &focus_handle,
-                    window,
                     cx,
                 )
             },

--- a/crates/agent_ui/src/text_thread_editor.rs
+++ b/crates/agent_ui/src/text_thread_editor.rs
@@ -1085,12 +1085,11 @@ impl TextThreadEditor {
                                             .child(label)
                                             .children(spinner),
                                     )
-                                    .tooltip(|window, cx| {
+                                    .tooltip(|_window, cx| {
                                         Tooltip::with_meta(
                                             "Toggle message role",
                                             None,
                                             "Available roles: You (User), Agent, System",
-                                            window,
                                             cx,
                                         )
                                     })
@@ -1126,12 +1125,11 @@ impl TextThreadEditor {
                                                     .size(IconSize::XSmall)
                                                     .color(Color::Hint),
                                             )
-                                            .tooltip(|window, cx| {
+                                            .tooltip(|_window, cx| {
                                                 Tooltip::with_meta(
                                                     "Context Cached",
                                                     None,
                                                     "Large messages cached to optimize performance",
-                                                    window,
                                                     cx,
                                                 )
                                             })
@@ -1947,7 +1945,7 @@ impl TextThreadEditor {
             })
             .layer(ElevationIndex::ModalSurface)
             .key_binding(
-                KeyBinding::for_action_in(&Assist, &focus_handle, window, cx)
+                KeyBinding::for_action_in(&Assist, &focus_handle, cx)
                     .map(|kb| kb.size(rems_from_px(12.))),
             )
             .on_click(move |_event, window, cx| {
@@ -1982,14 +1980,8 @@ impl TextThreadEditor {
                 .icon_color(Color::Muted)
                 .selected_icon_color(Color::Accent)
                 .selected_style(ButtonStyle::Filled),
-            move |window, cx| {
-                Tooltip::with_meta(
-                    "Add Context",
-                    None,
-                    "Type / to insert via keyboard",
-                    window,
-                    cx,
-                )
+            move |_window, cx| {
+                Tooltip::with_meta("Add Context", None, "Type / to insert via keyboard", cx)
             },
         )
     }
@@ -2078,14 +2070,8 @@ impl TextThreadEditor {
                         )
                         .child(Icon::new(icon).color(color).size(IconSize::XSmall)),
                 ),
-            move |window, cx| {
-                Tooltip::for_action_in(
-                    "Change Model",
-                    &ToggleModelSelector,
-                    &focus_handle,
-                    window,
-                    cx,
-                )
+            move |_window, cx| {
+                Tooltip::for_action_in("Change Model", &ToggleModelSelector, &focus_handle, cx)
             },
             gpui::Corner::BottomRight,
             cx,

--- a/crates/agent_ui/src/ui/burn_mode_tooltip.rs
+++ b/crates/agent_ui/src/ui/burn_mode_tooltip.rs
@@ -18,7 +18,7 @@ impl BurnModeTooltip {
 }
 
 impl Render for BurnModeTooltip {
-    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let (icon, color) = if self.selected {
             (IconName::ZedBurnModeOn, Color::Error)
         } else {
@@ -45,8 +45,7 @@ impl Render for BurnModeTooltip {
             .child(Label::new("Burn Mode"))
             .when(self.selected, |title| title.child(turned_on));
 
-        let keybinding = KeyBinding::for_action(&ToggleBurnMode, window, cx)
-            .map(|kb| kb.size(rems_from_px(12.)));
+        let keybinding = KeyBinding::for_action(&ToggleBurnMode, cx).size(rems_from_px(12.));
 
         tooltip_container(cx, |this, _| {
             this
@@ -54,7 +53,7 @@ impl Render for BurnModeTooltip {
                     h_flex()
                         .justify_between()
                         .child(title)
-                        .children(keybinding)
+                        .child(keybinding)
                 )
                 .child(
                     div()

--- a/crates/agent_ui/src/ui/context_pill.rs
+++ b/crates/agent_ui/src/ui/context_pill.rs
@@ -244,8 +244,8 @@ impl RenderOnce for ContextPill {
                             .truncate(),
                     ),
                 )
-                .tooltip(|window, cx| {
-                    Tooltip::with_meta("Suggested Context", None, "Click to add it", window, cx)
+                .tooltip(|_window, cx| {
+                    Tooltip::with_meta("Suggested Context", None, "Click to add it", cx)
                 })
                 .when_some(on_click.as_ref(), |element, on_click| {
                     let on_click = on_click.clone();

--- a/crates/breadcrumbs/src/breadcrumbs.rs
+++ b/crates/breadcrumbs/src/breadcrumbs.rs
@@ -119,21 +119,19 @@ impl Render for Breadcrumbs {
                             }
                         }
                     })
-                    .tooltip(move |window, cx| {
+                    .tooltip(move |_window, cx| {
                         if let Some(editor) = editor.upgrade() {
                             let focus_handle = editor.read(cx).focus_handle(cx);
                             Tooltip::for_action_in(
                                 "Show Symbol Outline",
                                 &zed_actions::outline::ToggleOutline,
                                 &focus_handle,
-                                window,
                                 cx,
                             )
                         } else {
                             Tooltip::for_action(
                                 "Show Symbol Outline",
                                 &zed_actions::outline::ToggleOutline,
-                                window,
                                 cx,
                             )
                         }

--- a/crates/collab_ui/src/notification_panel.rs
+++ b/crates/collab_ui/src/notification_panel.rs
@@ -738,19 +738,17 @@ impl Render for NotificationToast {
             .on_modifiers_changed(cx.listener(|_, _, _, cx| cx.notify()))
             .child(
                 IconButton::new(close_id, close_icon)
-                    .tooltip(move |window, cx| {
+                    .tooltip(move |_window, cx| {
                         if suppress {
                             Tooltip::for_action(
                                 "Suppress.\nClose with click.",
                                 &workspace::SuppressNotification,
-                                window,
                                 cx,
                             )
                         } else {
                             Tooltip::for_action(
                                 "Close.\nSuppress with shift-click",
                                 &menu::Cancel,
-                                window,
                                 cx,
                             )
                         }

--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -443,7 +443,7 @@ impl PickerDelegate for CommandPaletteDelegate {
         &self,
         ix: usize,
         selected: bool,
-        window: &mut Window,
+        _: &mut Window,
         cx: &mut Context<Picker<Self>>,
     ) -> Option<Self::ListItem> {
         let matching_command = self.matches.get(ix)?;
@@ -462,10 +462,9 @@ impl PickerDelegate for CommandPaletteDelegate {
                             command.name.clone(),
                             matching_command.positions.clone(),
                         ))
-                        .children(KeyBinding::for_action_in(
+                        .child(KeyBinding::for_action_in(
                             &*command.action,
                             &self.previous_focus_handle,
-                            window,
                             cx,
                         )),
                 ),

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -616,12 +616,11 @@ impl DebugPanel {
                 })
                 .tooltip({
                     let focus_handle = focus_handle.clone();
-                    move |window, cx| {
+                    move |_window, cx| {
                         Tooltip::for_action_in(
                             "Start Debug Session",
                             &crate::Start,
                             &focus_handle,
-                            window,
                             cx,
                         )
                     }
@@ -694,12 +693,11 @@ impl DebugPanel {
                                                 ))
                                                 .tooltip({
                                                     let focus_handle = focus_handle.clone();
-                                                    move |window, cx| {
+                                                    move |_window, cx| {
                                                         Tooltip::for_action_in(
                                                             "Pause Program",
                                                             &Pause,
                                                             &focus_handle,
-                                                            window,
                                                             cx,
                                                         )
                                                     }
@@ -719,12 +717,11 @@ impl DebugPanel {
                                                 .disabled(thread_status != ThreadStatus::Stopped)
                                                 .tooltip({
                                                     let focus_handle = focus_handle.clone();
-                                                    move |window, cx| {
+                                                    move |_window, cx| {
                                                         Tooltip::for_action_in(
                                                             "Continue Program",
                                                             &Continue,
                                                             &focus_handle,
-                                                            window,
                                                             cx,
                                                         )
                                                     }
@@ -744,12 +741,11 @@ impl DebugPanel {
                                             .disabled(thread_status != ThreadStatus::Stopped)
                                             .tooltip({
                                                 let focus_handle = focus_handle.clone();
-                                                move |window, cx| {
+                                                move |_window, cx| {
                                                     Tooltip::for_action_in(
                                                         "Step Over",
                                                         &StepOver,
                                                         &focus_handle,
-                                                        window,
                                                         cx,
                                                     )
                                                 }
@@ -770,12 +766,11 @@ impl DebugPanel {
                                         .disabled(thread_status != ThreadStatus::Stopped)
                                         .tooltip({
                                             let focus_handle = focus_handle.clone();
-                                            move |window, cx| {
+                                            move |_window, cx| {
                                                 Tooltip::for_action_in(
                                                     "Step In",
                                                     &StepInto,
                                                     &focus_handle,
-                                                    window,
                                                     cx,
                                                 )
                                             }
@@ -793,12 +788,11 @@ impl DebugPanel {
                                             .disabled(thread_status != ThreadStatus::Stopped)
                                             .tooltip({
                                                 let focus_handle = focus_handle.clone();
-                                                move |window, cx| {
+                                                move |_window, cx| {
                                                     Tooltip::for_action_in(
                                                         "Step Out",
                                                         &StepOut,
                                                         &focus_handle,
-                                                        window,
                                                         cx,
                                                     )
                                                 }
@@ -816,12 +810,11 @@ impl DebugPanel {
                                             ))
                                             .tooltip({
                                                 let focus_handle = focus_handle.clone();
-                                                move |window, cx| {
+                                                move |_window, cx| {
                                                     Tooltip::for_action_in(
                                                         "Rerun Session",
                                                         &RerunSession,
                                                         &focus_handle,
-                                                        window,
                                                         cx,
                                                     )
                                                 }
@@ -861,12 +854,11 @@ impl DebugPanel {
                                                 } else {
                                                     "Terminate All Threads"
                                                 };
-                                                move |window, cx| {
+                                                move |_window, cx| {
                                                     Tooltip::for_action_in(
                                                         label,
                                                         &Stop,
                                                         &focus_handle,
-                                                        window,
                                                         cx,
                                                     )
                                                 }
@@ -893,12 +885,11 @@ impl DebugPanel {
                                                 ))
                                                 .tooltip({
                                                     let focus_handle = focus_handle.clone();
-                                                    move |window, cx| {
+                                                    move |_window, cx| {
                                                         Tooltip::for_action_in(
                                                             "Detach",
                                                             &Detach,
                                                             &focus_handle,
-                                                            window,
                                                             cx,
                                                         )
                                                     }

--- a/crates/debugger_ui/src/new_process_modal.rs
+++ b/crates/debugger_ui/src/new_process_modal.rs
@@ -745,22 +745,15 @@ impl Render for NewProcessModal {
                                 == 0;
                         let secondary_action = menu::SecondaryConfirm.boxed_clone();
                         container
-                            .child(div().children(
-                                KeyBinding::for_action(&*secondary_action, window, cx).map(
-                                    |keybind| {
-                                        Button::new("edit-attach-task", "Edit in debug.json")
-                                            .label_size(LabelSize::Small)
-                                            .key_binding(keybind)
-                                            .on_click(move |_, window, cx| {
-                                                window.dispatch_action(
-                                                    secondary_action.boxed_clone(),
-                                                    cx,
-                                                )
-                                            })
-                                            .disabled(disabled)
-                                    },
-                                ),
-                            ))
+                            .child(div().child({
+                                Button::new("edit-attach-task", "Edit in debug.json")
+                                    .label_size(LabelSize::Small)
+                                    .key_binding(KeyBinding::for_action(&*secondary_action, cx))
+                                    .on_click(move |_, window, cx| {
+                                        window.dispatch_action(secondary_action.boxed_clone(), cx)
+                                    })
+                                    .disabled(disabled)
+                            }))
                             .child(
                                 h_flex()
                                     .child(div().child(self.adapter_drop_down_menu(window, cx))),
@@ -1447,56 +1440,48 @@ impl PickerDelegate for DebugDelegate {
             .justify_between()
             .border_t_1()
             .border_color(cx.theme().colors().border_variant)
-            .children({
+            .child({
                 let action = menu::SecondaryConfirm.boxed_clone();
                 if self.matches.is_empty() {
-                    Some(
-                        Button::new("edit-debug-json", "Edit debug.json")
-                            .label_size(LabelSize::Small)
-                            .on_click(cx.listener(|_picker, _, window, cx| {
-                                window.dispatch_action(
-                                    zed_actions::OpenProjectDebugTasks.boxed_clone(),
-                                    cx,
-                                );
-                                cx.emit(DismissEvent);
-                            })),
-                    )
+                    Button::new("edit-debug-json", "Edit debug.json")
+                        .label_size(LabelSize::Small)
+                        .on_click(cx.listener(|_picker, _, window, cx| {
+                            window.dispatch_action(
+                                zed_actions::OpenProjectDebugTasks.boxed_clone(),
+                                cx,
+                            );
+                            cx.emit(DismissEvent);
+                        }))
                 } else {
-                    KeyBinding::for_action(&*action, window, cx).map(|keybind| {
-                        Button::new("edit-debug-task", "Edit in debug.json")
-                            .label_size(LabelSize::Small)
-                            .key_binding(keybind)
-                            .on_click(move |_, window, cx| {
-                                window.dispatch_action(action.boxed_clone(), cx)
-                            })
-                    })
+                    Button::new("edit-debug-task", "Edit in debug.json")
+                        .label_size(LabelSize::Small)
+                        .key_binding(KeyBinding::for_action(&*action, cx))
+                        .on_click(move |_, window, cx| {
+                            window.dispatch_action(action.boxed_clone(), cx)
+                        })
                 }
             })
             .map(|this| {
                 if (current_modifiers.alt || self.matches.is_empty()) && !self.prompt.is_empty() {
                     let action = picker::ConfirmInput { secondary: false }.boxed_clone();
-                    this.children(KeyBinding::for_action(&*action, window, cx).map(|keybind| {
+                    this.child({
                         Button::new("launch-custom", "Launch Custom")
-                            .key_binding(keybind)
+                            .key_binding(KeyBinding::for_action(&*action, cx))
                             .on_click(move |_, window, cx| {
                                 window.dispatch_action(action.boxed_clone(), cx)
                             })
-                    }))
+                    })
                 } else {
-                    this.children(KeyBinding::for_action(&menu::Confirm, window, cx).map(
-                        |keybind| {
-                            let is_recent_selected =
-                                self.divider_index >= Some(self.selected_index);
-                            let run_entry_label =
-                                if is_recent_selected { "Rerun" } else { "Spawn" };
+                    this.child({
+                        let is_recent_selected = self.divider_index >= Some(self.selected_index);
+                        let run_entry_label = if is_recent_selected { "Rerun" } else { "Spawn" };
 
-                            Button::new("spawn", run_entry_label)
-                                .key_binding(keybind)
-                                .on_click(|_, window, cx| {
-                                    window.dispatch_action(menu::Confirm.boxed_clone(), cx);
-                                })
-                        },
-                    ))
+                        Button::new("spawn", run_entry_label)
+                            .key_binding(KeyBinding::for_action(&menu::Confirm, cx))
+                            .on_click(|_, window, cx| {
+                                window.dispatch_action(menu::Confirm.boxed_clone(), cx);
+                            })
+                    })
                 }
             });
         Some(footer.into_any_element())

--- a/crates/debugger_ui/src/session/running.rs
+++ b/crates/debugger_ui/src/session/running.rs
@@ -566,14 +566,13 @@ pub(crate) fn new_debugger_pane(
                                 }))
                                 .tooltip({
                                     let focus_handle = focus_handle.clone();
-                                    move |window, cx| {
+                                    move |_window, cx| {
                                         let zoomed_text =
                                             if zoomed { "Minimize" } else { "Expand" };
                                         Tooltip::for_action_in(
                                             zoomed_text,
                                             &ToggleExpandItem,
                                             &focus_handle,
-                                            window,
                                             cx,
                                         )
                                     }

--- a/crates/debugger_ui/src/session/running/breakpoint_list.rs
+++ b/crates/debugger_ui/src/session/running/breakpoint_list.rs
@@ -607,13 +607,12 @@ impl BreakpointList {
                 .when_some(toggle_label, |this, (label, meta)| {
                     this.tooltip({
                         let focus_handle = focus_handle.clone();
-                        move |window, cx| {
+                        move |_window, cx| {
                             Tooltip::with_meta_in(
                                 label,
                                 Some(&ToggleEnableBreakpoint),
                                 meta,
                                 &focus_handle,
-                                window,
                                 cx,
                             )
                         }
@@ -634,13 +633,12 @@ impl BreakpointList {
                     .when_some(remove_breakpoint_tooltip, |this, tooltip| {
                         this.tooltip({
                             let focus_handle = focus_handle.clone();
-                            move |window, cx| {
+                            move |_window, cx| {
                                 Tooltip::with_meta_in(
                                     "Remove Breakpoint",
                                     Some(&UnsetBreakpoint),
                                     tooltip,
                                     &focus_handle,
-                                    window,
                                     cx,
                                 )
                             }
@@ -819,7 +817,7 @@ impl LineBreakpoint {
             )
             .tooltip({
                 let focus_handle = focus_handle.clone();
-                move |window, cx| {
+                move |_window, cx| {
                     Tooltip::for_action_in(
                         if is_enabled {
                             "Disable Breakpoint"
@@ -828,7 +826,6 @@ impl LineBreakpoint {
                         },
                         &ToggleEnableBreakpoint,
                         &focus_handle,
-                        window,
                         cx,
                     )
                 }
@@ -980,7 +977,7 @@ impl DataBreakpoint {
                 )
                 .tooltip({
                     let focus_handle = focus_handle.clone();
-                    move |window, cx| {
+                    move |_window, cx| {
                         Tooltip::for_action_in(
                             if is_enabled {
                                 "Disable Data Breakpoint"
@@ -989,7 +986,6 @@ impl DataBreakpoint {
                             },
                             &ToggleEnableBreakpoint,
                             &focus_handle,
-                            window,
                             cx,
                         )
                     }
@@ -1085,7 +1081,7 @@ impl ExceptionBreakpoint {
                 )
                 .tooltip({
                     let focus_handle = focus_handle.clone();
-                    move |window, cx| {
+                    move |_window, cx| {
                         Tooltip::for_action_in(
                             if is_enabled {
                                 "Disable Exception Breakpoint"
@@ -1094,7 +1090,6 @@ impl ExceptionBreakpoint {
                             },
                             &ToggleEnableBreakpoint,
                             &focus_handle,
-                            window,
                             cx,
                         )
                     }
@@ -1402,12 +1397,11 @@ impl RenderOnce for BreakpointOptionsStrip {
                         .disabled(!supports_logs)
                         .toggle_state(self.is_toggled(ActiveBreakpointStripMode::Log))
                         .on_click(self.on_click_callback(ActiveBreakpointStripMode::Log))
-                        .tooltip(|window, cx| {
+                        .tooltip(|_window, cx|  {
                             Tooltip::with_meta(
                                 "Set Log Message",
                                 None,
                                 "Set log message to display (instead of stopping) when a breakpoint is hit.",
-                                window,
                                 cx,
                             )
                         }),
@@ -1438,12 +1432,11 @@ impl RenderOnce for BreakpointOptionsStrip {
                         .disabled(!supports_condition)
                         .toggle_state(self.is_toggled(ActiveBreakpointStripMode::Condition))
                         .on_click(self.on_click_callback(ActiveBreakpointStripMode::Condition))
-                        .tooltip(|window, cx| {
+                        .tooltip(|_window, cx|  {
                             Tooltip::with_meta(
                                 "Set Condition",
                                 None,
                                 "Set condition to evaluate when a breakpoint is hit. Program execution will stop only when the condition is met.",
-                                window,
                                 cx,
                             )
                         }),
@@ -1474,12 +1467,11 @@ impl RenderOnce for BreakpointOptionsStrip {
                         .disabled(!supports_hit_condition)
                         .toggle_state(self.is_toggled(ActiveBreakpointStripMode::HitCondition))
                         .on_click(self.on_click_callback(ActiveBreakpointStripMode::HitCondition))
-                        .tooltip(|window, cx| {
+                        .tooltip(|_window, cx|  {
                             Tooltip::with_meta(
                                 "Set Hit Condition",
                                 None,
                                 "Set expression that controls how many hits of the breakpoint are ignored.",
-                                window,
                                 cx,
                             )
                         }),

--- a/crates/debugger_ui/src/session/running/console.rs
+++ b/crates/debugger_ui/src/session/running/console.rs
@@ -484,12 +484,11 @@ impl Render for Console {
                             .tooltip({
                                 let query_focus_handle = query_focus_handle.clone();
 
-                                move |window, cx| {
+                                move |_window, cx| {
                                     Tooltip::for_action_in(
                                         "Evaluate",
                                         &Confirm,
                                         &query_focus_handle,
-                                        window,
                                         cx,
                                     )
                                 }

--- a/crates/debugger_ui/src/session/running/stack_frame_list.rs
+++ b/crates/debugger_ui/src/session/running/stack_frame_list.rs
@@ -872,8 +872,8 @@ impl StackFrameList {
                     "filter-by-visible-worktree-stack-frame-list",
                     IconName::ListFilter,
                 )
-                .tooltip(move |window, cx| {
-                    Tooltip::for_action(tooltip_title, &ToggleUserFrames, window, cx)
+                .tooltip(move |_window, cx| {
+                    Tooltip::for_action(tooltip_title, &ToggleUserFrames, cx)
                 })
                 .toggle_state(self.list_filter == StackFrameFilter::OnlyUserFrames)
                 .icon_size(IconSize::Small)

--- a/crates/debugger_ui/src/session/running/variable_list.rs
+++ b/crates/debugger_ui/src/session/running/variable_list.rs
@@ -1306,14 +1306,8 @@ impl VariableList {
                             .ok();
                         }
                     })
-                    .tooltip(move |window, cx| {
-                        Tooltip::for_action_in(
-                            "Remove Watch",
-                            &RemoveWatch,
-                            &focus_handle,
-                            window,
-                            cx,
-                        )
+                    .tooltip(move |_window, cx| {
+                        Tooltip::for_action_in("Remove Watch", &RemoveWatch, &focus_handle, cx)
                     })
                     .icon_size(ui::IconSize::Indicator),
                 ),

--- a/crates/diagnostics/src/items.rs
+++ b/crates/diagnostics/src/items.rs
@@ -67,11 +67,10 @@ impl Render for DiagnosticIndicator {
             Some(
                 Button::new("diagnostic_message", SharedString::new(message))
                     .label_size(LabelSize::Small)
-                    .tooltip(|window, cx| {
+                    .tooltip(|_window, cx| {
                         Tooltip::for_action(
                             "Next Diagnostic",
                             &editor::actions::GoToDiagnostic::default(),
-                            window,
                             cx,
                         )
                     })
@@ -87,8 +86,8 @@ impl Render for DiagnosticIndicator {
             .child(
                 ButtonLike::new("diagnostic-indicator")
                     .child(diagnostic_indicator)
-                    .tooltip(|window, cx| {
-                        Tooltip::for_action("Project Diagnostics", &Deploy, window, cx)
+                    .tooltip(move |_window, cx| {
+                        Tooltip::for_action("Project Diagnostics", &Deploy, cx)
                     })
                     .on_click(cx.listener(|this, _, window, cx| {
                         if let Some(workspace) = this.workspace.upgrade() {

--- a/crates/edit_prediction_button/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_button/src/edit_prediction_button.rs
@@ -123,8 +123,8 @@ impl Render for EditPredictionButton {
                                     });
                                 }
                             }))
-                            .tooltip(|window, cx| {
-                                Tooltip::for_action("GitHub Copilot", &ToggleMenu, window, cx)
+                            .tooltip(|_window, cx| {
+                                Tooltip::for_action("GitHub Copilot", &ToggleMenu, cx)
                             }),
                     );
                 }
@@ -146,9 +146,7 @@ impl Render for EditPredictionButton {
                         .anchor(Corner::BottomRight)
                         .trigger_with_tooltip(
                             IconButton::new("copilot-icon", icon),
-                            |window, cx| {
-                                Tooltip::for_action("GitHub Copilot", &ToggleMenu, window, cx)
-                            },
+                            |_window, cx| Tooltip::for_action("GitHub Copilot", &ToggleMenu, cx),
                         )
                         .with_handle(self.popover_menu_handle.clone()),
                 )
@@ -220,12 +218,7 @@ impl Render for EditPredictionButton {
                             IconButton::new("supermaven-icon", icon),
                             move |window, cx| {
                                 if has_menu {
-                                    Tooltip::for_action(
-                                        tooltip_text.clone(),
-                                        &ToggleMenu,
-                                        window,
-                                        cx,
-                                    )
+                                    Tooltip::for_action(tooltip_text.clone(), &ToggleMenu, cx)
                                 } else {
                                     Tooltip::text(tooltip_text.clone())(window, cx)
                                 }
@@ -288,9 +281,7 @@ impl Render for EditPredictionButton {
                                             cx.theme().colors().status_bar_background,
                                         ))
                                 }),
-                            move |window, cx| {
-                                Tooltip::for_action("Codestral", &ToggleMenu, window, cx)
-                            },
+                            move |_window, cx| Tooltip::for_action("Codestral", &ToggleMenu, cx),
                         )
                         .with_handle(self.popover_menu_handle.clone()),
                 )
@@ -317,14 +308,8 @@ impl Render for EditPredictionButton {
                             .shape(IconButtonShape::Square)
                             .indicator(Indicator::dot().color(Color::Muted))
                             .indicator_border_color(Some(cx.theme().colors().status_bar_background))
-                            .tooltip(move |window, cx| {
-                                Tooltip::with_meta(
-                                    "Edit Predictions",
-                                    None,
-                                    tooltip_meta,
-                                    window,
-                                    cx,
-                                )
+                            .tooltip(move |_window, cx| {
+                                Tooltip::with_meta("Edit Predictions", None, tooltip_meta, cx)
                             })
                             .on_click(cx.listener(move |_, _, window, cx| {
                                 telemetry::event!(
@@ -365,16 +350,15 @@ impl Render for EditPredictionButton {
                         },
                     )
                     .when(!self.popover_menu_handle.is_deployed(), |element| {
-                        element.tooltip(move |window, cx| {
+                        element.tooltip(move |_window, cx| {
                             if enabled {
                                 if show_editor_predictions {
-                                    Tooltip::for_action("Edit Prediction", &ToggleMenu, window, cx)
+                                    Tooltip::for_action("Edit Prediction", &ToggleMenu, cx)
                                 } else {
                                     Tooltip::with_meta(
                                         "Edit Prediction",
                                         Some(&ToggleMenu),
                                         "Hidden For This File",
-                                        window,
                                         cx,
                                     )
                                 }
@@ -383,7 +367,6 @@ impl Render for EditPredictionButton {
                                     "Edit Prediction",
                                     Some(&ToggleMenu),
                                     "Disabled For This File",
-                                    window,
                                     cx,
                                 )
                             }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -6625,7 +6625,7 @@ impl Editor {
             .when(show_tooltip, |this| {
                 this.tooltip({
                     let focus_handle = self.focus_handle.clone();
-                    move |window, cx| {
+                    move |_window, cx| {
                         Tooltip::for_action_in(
                             "Toggle Code Actions",
                             &ToggleCodeActions {
@@ -6633,7 +6633,6 @@ impl Editor {
                                 quick_launch: false,
                             },
                             &focus_handle,
-                            window,
                             cx,
                         )
                     }
@@ -8498,13 +8497,12 @@ impl Editor {
                     cx,
                 );
             }))
-            .tooltip(move |window, cx| {
+            .tooltip(move |_window, cx| {
                 Tooltip::with_meta_in(
                     primary_action_text,
                     Some(&ToggleBreakpoint),
                     meta.clone(),
                     &focus_handle,
-                    window,
                     cx,
                 )
             })
@@ -24873,12 +24871,11 @@ fn render_diff_hunk_controls(
                 .alpha(if status.is_pending() { 0.66 } else { 1.0 })
                 .tooltip({
                     let focus_handle = editor.focus_handle(cx);
-                    move |window, cx| {
+                    move |_window, cx| {
                         Tooltip::for_action_in(
                             "Stage Hunk",
                             &::git::ToggleStaged,
                             &focus_handle,
-                            window,
                             cx,
                         )
                     }
@@ -24900,12 +24897,11 @@ fn render_diff_hunk_controls(
                 .alpha(if status.is_pending() { 0.66 } else { 1.0 })
                 .tooltip({
                     let focus_handle = editor.focus_handle(cx);
-                    move |window, cx| {
+                    move |_window, cx| {
                         Tooltip::for_action_in(
                             "Unstage Hunk",
                             &::git::ToggleStaged,
                             &focus_handle,
-                            window,
                             cx,
                         )
                     }
@@ -24927,14 +24923,8 @@ fn render_diff_hunk_controls(
             Button::new(("restore", row as u64), "Restore")
                 .tooltip({
                     let focus_handle = editor.focus_handle(cx);
-                    move |window, cx| {
-                        Tooltip::for_action_in(
-                            "Restore Hunk",
-                            &::git::Restore,
-                            &focus_handle,
-                            window,
-                            cx,
-                        )
+                    move |_window, cx| {
+                        Tooltip::for_action_in("Restore Hunk", &::git::Restore, &focus_handle, cx)
                     }
                 })
                 .on_click({
@@ -24959,14 +24949,8 @@ fn render_diff_hunk_controls(
                         // .disabled(!has_multiple_hunks)
                         .tooltip({
                             let focus_handle = editor.focus_handle(cx);
-                            move |window, cx| {
-                                Tooltip::for_action_in(
-                                    "Next Hunk",
-                                    &GoToHunk,
-                                    &focus_handle,
-                                    window,
-                                    cx,
-                                )
+                            move |_window, cx| {
+                                Tooltip::for_action_in("Next Hunk", &GoToHunk, &focus_handle, cx)
                             }
                         })
                         .on_click({
@@ -24995,12 +24979,11 @@ fn render_diff_hunk_controls(
                         // .disabled(!has_multiple_hunks)
                         .tooltip({
                             let focus_handle = editor.focus_handle(cx);
-                            move |window, cx| {
+                            move |_window, cx| {
                                 Tooltip::for_action_in(
                                     "Previous Hunk",
                                     &GoToPreviousHunk,
                                     &focus_handle,
-                                    window,
                                     cx,
                                 )
                             }

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -3910,7 +3910,7 @@ impl EditorElement {
                                         .children(toggle_chevron_icon)
                                         .tooltip({
                                             let focus_handle = focus_handle.clone();
-                                            move |window, cx| {
+                                            move |_window, cx| {
                                                 Tooltip::with_meta_in(
                                                     "Toggle Excerpt Fold",
                                                     Some(&ToggleFold),
@@ -3923,7 +3923,6 @@ impl EditorElement {
                                                         )
                                                     ),
                                                     &focus_handle,
-                                                    window,
                                                     cx,
                                                 )
                                             }
@@ -4024,15 +4023,11 @@ impl EditorElement {
                                             .id("jump-to-file-button")
                                             .gap_2p5()
                                             .child(Label::new("Jump To File"))
-                                            .children(
-                                                KeyBinding::for_action_in(
-                                                    &OpenExcerpts,
-                                                    &focus_handle,
-                                                    window,
-                                                    cx,
-                                                )
-                                                .map(|binding| binding.into_any_element()),
-                                            ),
+                                            .child(KeyBinding::for_action_in(
+                                                &OpenExcerpts,
+                                                &focus_handle,
+                                                cx,
+                                            )),
                                     )
                                 },
                             )

--- a/crates/editor/src/proposed_changes_editor.rs
+++ b/crates/editor/src/proposed_changes_editor.rs
@@ -370,17 +370,15 @@ impl ProposedChangesEditorToolbar {
 }
 
 impl Render for ProposedChangesEditorToolbar {
-    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let button_like = ButtonLike::new("apply-changes").child(Label::new("Apply All"));
 
         match &self.current_editor {
             Some(editor) => {
                 let focus_handle = editor.focus_handle(cx);
-                let keybinding =
-                    KeyBinding::for_action_in(&ApplyAllDiffHunks, &focus_handle, window, cx)
-                        .map(|binding| binding.into_any_element());
+                let keybinding = KeyBinding::for_action_in(&ApplyAllDiffHunks, &focus_handle, cx);
 
-                button_like.children(keybinding).on_click({
+                button_like.child(keybinding).on_click({
                     move |_event, window, cx| {
                         focus_handle.dispatch_action(&ApplyAllDiffHunks, window, cx)
                     }

--- a/crates/editor/src/signature_help.rs
+++ b/crates/editor/src/signature_help.rs
@@ -396,13 +396,8 @@ impl SignatureHelpPopover {
                 .shape(IconButtonShape::Square)
                 .style(ButtonStyle::Subtle)
                 .icon_size(IconSize::Small)
-                .tooltip(move |window, cx| {
-                    ui::Tooltip::for_action(
-                        "Previous Signature",
-                        &crate::SignatureHelpPrevious,
-                        window,
-                        cx,
-                    )
+                .tooltip(move |_window, cx| {
+                    ui::Tooltip::for_action("Previous Signature", &crate::SignatureHelpPrevious, cx)
                 })
                 .on_click(cx.listener(|editor, _, window, cx| {
                     editor.signature_help_prev(&crate::SignatureHelpPrevious, window, cx);
@@ -412,8 +407,8 @@ impl SignatureHelpPopover {
                 .shape(IconButtonShape::Square)
                 .style(ButtonStyle::Subtle)
                 .icon_size(IconSize::Small)
-                .tooltip(move |window, cx| {
-                    ui::Tooltip::for_action("Next Signature", &crate::SignatureHelpNext, window, cx)
+                .tooltip(move |_window, cx| {
+                    ui::Tooltip::for_action("Next Signature", &crate::SignatureHelpNext, cx)
                 })
                 .on_click(cx.listener(|editor, _, window, cx| {
                     editor.signature_help_next(&crate::SignatureHelpNext, window, cx);

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -1663,11 +1663,7 @@ impl PickerDelegate for FileFinderDelegate {
         )
     }
 
-    fn render_footer(
-        &self,
-        window: &mut Window,
-        cx: &mut Context<Picker<Self>>,
-    ) -> Option<AnyElement> {
+    fn render_footer(&self, _: &mut Window, cx: &mut Context<Picker<Self>>) -> Option<AnyElement> {
         let focus_handle = self.focus_handle.clone();
 
         Some(
@@ -1696,12 +1692,11 @@ impl PickerDelegate for FileFinderDelegate {
                                 }),
                             {
                                 let focus_handle = focus_handle.clone();
-                                move |window, cx| {
+                                move |_window, cx| {
                                     Tooltip::for_action_in(
                                         "Filter Options",
                                         &ToggleFilterMenu,
                                         &focus_handle,
-                                        window,
                                         cx,
                                     )
                                 }
@@ -1751,14 +1746,13 @@ impl PickerDelegate for FileFinderDelegate {
                                     ButtonLike::new("split-trigger")
                                         .child(Label::new("Split…"))
                                         .selected_style(ButtonStyle::Tinted(TintColor::Accent))
-                                        .children(
+                                        .child(
                                             KeyBinding::for_action_in(
                                                 &ToggleSplitMenu,
                                                 &focus_handle,
-                                                window,
                                                 cx,
                                             )
-                                            .map(|kb| kb.size(rems_from_px(12.))),
+                                            .size(rems_from_px(12.)),
                                         ),
                                 )
                                 .menu({
@@ -1790,13 +1784,8 @@ impl PickerDelegate for FileFinderDelegate {
                         .child(
                             Button::new("open-selection", "Open")
                                 .key_binding(
-                                    KeyBinding::for_action_in(
-                                        &menu::Confirm,
-                                        &focus_handle,
-                                        window,
-                                        cx,
-                                    )
-                                    .map(|kb| kb.size(rems_from_px(12.))),
+                                    KeyBinding::for_action_in(&menu::Confirm, &focus_handle, cx)
+                                        .map(|kb| kb.size(rems_from_px(12.))),
                                 )
                                 .on_click(|_, window, cx| {
                                     window.dispatch_action(menu::Confirm.boxed_clone(), cx)

--- a/crates/git_ui/src/branch_picker.rs
+++ b/crates/git_ui/src/branch_picker.rs
@@ -466,11 +466,10 @@ impl PickerDelegate for BranchListDelegate {
                         this.delegate.set_selected_index(ix, window, cx);
                         this.delegate.confirm(true, window, cx);
                     }))
-                    .tooltip(move |window, cx| {
+                    .tooltip(move |_window, cx| {
                         Tooltip::for_action(
                             format!("Create branch based off default: {default_branch}"),
                             &menu::SecondaryConfirm,
-                            window,
                             cx,
                         )
                     }),

--- a/crates/git_ui/src/commit_modal.rs
+++ b/crates/git_ui/src/commit_modal.rs
@@ -327,7 +327,7 @@ impl CommitModal {
             .anchor(Corner::TopRight)
     }
 
-    pub fn render_footer(&self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    pub fn render_footer(&self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let (
             can_commit,
             tooltip,
@@ -388,7 +388,7 @@ impl CommitModal {
             });
         let focus_handle = self.focus_handle(cx);
 
-        let close_kb_hint = ui::KeyBinding::for_action(&menu::Cancel, window, cx).map(|close_kb| {
+        let close_kb_hint = ui::KeyBinding::for_action(&menu::Cancel, cx).map(|close_kb| {
             KeybindingHint::new(close_kb, cx.theme().colors().editor_background).suffix("Cancel")
         });
 
@@ -423,7 +423,7 @@ impl CommitModal {
                     .flex_none()
                     .px_1()
                     .gap_4()
-                    .children(close_kb_hint)
+                    .child(close_kb_hint)
                     .child(SplitButton::new(
                         ui::ButtonLike::new_rounded_left(ElementId::Name(
                             format!("split-button-left-{}", commit_label).into(),
@@ -452,7 +452,7 @@ impl CommitModal {
                         .disabled(!can_commit)
                         .tooltip({
                             let focus_handle = focus_handle.clone();
-                            move |window, cx| {
+                            move |_window, cx| {
                                 if can_commit {
                                     Tooltip::with_meta_in(
                                         tooltip,
@@ -467,7 +467,6 @@ impl CommitModal {
                                             if is_signoff_enabled { " --signoff" } else { "" }
                                         ),
                                         &focus_handle.clone(),
-                                        window,
                                         cx,
                                     )
                                 } else {

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -3091,13 +3091,12 @@ impl GitPanel {
             IconButton::new("generate-commit-message", IconName::AiEdit)
                 .shape(ui::IconButtonShape::Square)
                 .icon_color(Color::Muted)
-                .tooltip(move |window, cx| {
+                .tooltip(move |_window, cx| {
                     if can_commit {
                         Tooltip::for_action_in(
                             "Generate Commit Message",
                             &git::GenerateCommitMessage,
                             &editor_focus_handle,
-                            window,
                             cx,
                         )
                     } else {
@@ -3459,12 +3458,11 @@ impl GitPanel {
                                 panel_icon_button("expand-commit-editor", IconName::Maximize)
                                     .icon_size(IconSize::Small)
                                     .size(ui::ButtonSize::Default)
-                                    .tooltip(move |window, cx| {
+                                    .tooltip(move |_window, cx| {
                                         Tooltip::for_action_in(
                                             "Open Commit Modal",
                                             &git::ExpandCommitEditor,
                                             &expand_tooltip_focus_handle,
-                                            window,
                                             cx,
                                         )
                                     })
@@ -3526,7 +3524,7 @@ impl GitPanel {
                 .disabled(!can_commit || self.modal_open)
                 .tooltip({
                     let handle = commit_tooltip_focus_handle.clone();
-                    move |window, cx| {
+                    move |_window, cx| {
                         if can_commit {
                             Tooltip::with_meta_in(
                                 tooltip,
@@ -3537,7 +3535,6 @@ impl GitPanel {
                                     if signoff { " --signoff" } else { "" }
                                 ),
                                 &handle.clone(),
-                                window,
                                 cx,
                             )
                         } else {
@@ -3640,7 +3637,7 @@ impl GitPanel {
                         panel_icon_button("undo", IconName::Undo)
                             .icon_size(IconSize::XSmall)
                             .icon_color(Color::Muted)
-                            .tooltip(move |window, cx| {
+                            .tooltip(move |_window, cx| {
                                 Tooltip::with_meta(
                                     "Uncommit",
                                     Some(&git::Uncommit),
@@ -3649,7 +3646,6 @@ impl GitPanel {
                                     } else {
                                         "git reset HEAD^"
                                     },
-                                    window,
                                     cx,
                                 )
                             })
@@ -4120,13 +4116,13 @@ impl GitPanel {
                                     .ok();
                                 }
                             })
-                            .tooltip(move |window, cx| {
+                            .tooltip(move |_window, cx| {
                                 let is_staged = entry_staging.is_fully_staged();
 
                                 let action = if is_staged { "Unstage" } else { "Stage" };
                                 let tooltip_name = action.to_string();
 
-                                Tooltip::for_action(tooltip_name, &ToggleStaged, window, cx)
+                                Tooltip::for_action(tooltip_name, &ToggleStaged, cx)
                             }),
                     ),
             )

--- a/crates/git_ui/src/git_ui.rs
+++ b/crates/git_ui/src/git_ui.rs
@@ -435,13 +435,12 @@ mod remote_button {
             move |_, window, cx| {
                 window.dispatch_action(Box::new(git::Fetch), cx);
             },
-            move |window, cx| {
+            move |_window, cx| {
                 git_action_tooltip(
                     "Fetch updates from remote",
                     &git::Fetch,
                     "git fetch",
                     keybinding_target.clone(),
-                    window,
                     cx,
                 )
             },
@@ -463,13 +462,12 @@ mod remote_button {
             move |_, window, cx| {
                 window.dispatch_action(Box::new(git::Push), cx);
             },
-            move |window, cx| {
+            move |_window, cx| {
                 git_action_tooltip(
                     "Push committed changes to remote",
                     &git::Push,
                     "git push",
                     keybinding_target.clone(),
-                    window,
                     cx,
                 )
             },
@@ -492,13 +490,12 @@ mod remote_button {
             move |_, window, cx| {
                 window.dispatch_action(Box::new(git::Pull), cx);
             },
-            move |window, cx| {
+            move |_window, cx| {
                 git_action_tooltip(
                     "Pull",
                     &git::Pull,
                     "git pull",
                     keybinding_target.clone(),
-                    window,
                     cx,
                 )
             },
@@ -519,13 +516,12 @@ mod remote_button {
             move |_, window, cx| {
                 window.dispatch_action(Box::new(git::Push), cx);
             },
-            move |window, cx| {
+            move |_window, cx| {
                 git_action_tooltip(
                     "Publish branch to remote",
                     &git::Push,
                     "git push --set-upstream",
                     keybinding_target.clone(),
-                    window,
                     cx,
                 )
             },
@@ -546,13 +542,12 @@ mod remote_button {
             move |_, window, cx| {
                 window.dispatch_action(Box::new(git::Push), cx);
             },
-            move |window, cx| {
+            move |_window, cx| {
                 git_action_tooltip(
                     "Re-publish branch to remote",
                     &git::Push,
                     "git push --set-upstream",
                     keybinding_target.clone(),
-                    window,
                     cx,
                 )
             },
@@ -564,16 +559,15 @@ mod remote_button {
         action: &dyn Action,
         command: impl Into<SharedString>,
         focus_handle: Option<FocusHandle>,
-        window: &mut Window,
         cx: &mut App,
     ) -> AnyView {
         let label = label.into();
         let command = command.into();
 
         if let Some(handle) = focus_handle {
-            Tooltip::with_meta_in(label, Some(action), command, &handle, window, cx)
+            Tooltip::with_meta_in(label, Some(action), command, &handle, cx)
         } else {
-            Tooltip::with_meta(label, Some(action), command, window, cx)
+            Tooltip::with_meta(label, Some(action), command, cx)
         }
     }
 

--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -714,7 +714,7 @@ impl Item for ProjectDiff {
 }
 
 impl Render for ProjectDiff {
-    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let is_empty = self.multibuffer.read(cx).is_empty();
 
         div()
@@ -759,7 +759,6 @@ impl Render for ProjectDiff {
                                     .key_binding(KeyBinding::for_action_in(
                                         &CloseActiveItem::default(),
                                         &keybinding_focus_handle,
-                                        window,
                                         cx,
                                     ))
                                     .on_click(move |_, window, cx| {

--- a/crates/git_ui/src/stash_picker.rs
+++ b/crates/git_ui/src/stash_picker.rs
@@ -523,11 +523,7 @@ impl PickerDelegate for StashListDelegate {
         Some("No stashes found".into())
     }
 
-    fn render_footer(
-        &self,
-        window: &mut Window,
-        cx: &mut Context<Picker<Self>>,
-    ) -> Option<AnyElement> {
+    fn render_footer(&self, _: &mut Window, cx: &mut Context<Picker<Self>>) -> Option<AnyElement> {
         let focus_handle = self.focus_handle.clone();
 
         Some(
@@ -541,7 +537,7 @@ impl PickerDelegate for StashListDelegate {
                 .child(
                     Button::new("apply-stash", "Apply")
                         .key_binding(
-                            KeyBinding::for_action_in(&menu::Confirm, &focus_handle, window, cx)
+                            KeyBinding::for_action_in(&menu::Confirm, &focus_handle, cx)
                                 .map(|kb| kb.size(rems_from_px(12.))),
                         )
                         .on_click(|_, window, cx| {
@@ -551,13 +547,8 @@ impl PickerDelegate for StashListDelegate {
                 .child(
                     Button::new("pop-stash", "Pop")
                         .key_binding(
-                            KeyBinding::for_action_in(
-                                &menu::SecondaryConfirm,
-                                &focus_handle,
-                                window,
-                                cx,
-                            )
-                            .map(|kb| kb.size(rems_from_px(12.))),
+                            KeyBinding::for_action_in(&menu::SecondaryConfirm, &focus_handle, cx)
+                                .map(|kb| kb.size(rems_from_px(12.))),
                         )
                         .on_click(|_, window, cx| {
                             window.dispatch_action(menu::SecondaryConfirm.boxed_clone(), cx)
@@ -569,7 +560,6 @@ impl PickerDelegate for StashListDelegate {
                             KeyBinding::for_action_in(
                                 &stash_picker::DropStashItem,
                                 &focus_handle,
-                                window,
                                 cx,
                             )
                             .map(|kb| kb.size(rems_from_px(12.))),

--- a/crates/go_to_line/src/cursor_position.rs
+++ b/crates/go_to_line/src/cursor_position.rs
@@ -238,18 +238,16 @@ impl Render for CursorPosition {
                             });
                         }
                     }))
-                    .tooltip(move |window, cx| match context.as_ref() {
+                    .tooltip(move |_window, cx| match context.as_ref() {
                         Some(context) => Tooltip::for_action_in(
                             "Go to Line/Column",
                             &editor::actions::ToggleGoToLine,
                             context,
-                            window,
                             cx,
                         ),
                         None => Tooltip::for_action(
                             "Go to Line/Column",
                             &editor::actions::ToggleGoToLine,
-                            window,
                             cx,
                         ),
                     }),

--- a/crates/gpui/src/keymap.rs
+++ b/crates/gpui/src/keymap.rs
@@ -118,10 +118,12 @@ impl Keymap {
     pub fn all_bindings_for_input(&self, input: &[Keystroke]) -> Vec<KeyBinding> {
         self.bindings()
             .rev()
-            .filter_map(|binding| {
-                binding.match_keystrokes(input).filter(|pending| !pending)?;
-                Some(binding.clone())
+            .filter(|binding| {
+                binding
+                    .match_keystrokes(input)
+                    .is_some_and(|pending| !pending)
             })
+            .cloned()
             .collect()
     }
 

--- a/crates/keymap_editor/src/keymap_editor.rs
+++ b/crates/keymap_editor/src/keymap_editor.rs
@@ -1,6 +1,7 @@
 use std::{
     cmp::{self},
     ops::{Not as _, Range},
+    rc::Rc,
     sync::Arc,
     time::Duration,
 };
@@ -173,7 +174,7 @@ impl FilterState {
 
 #[derive(Debug, Default, PartialEq, Eq, Clone, Hash)]
 struct ActionMapping {
-    keystrokes: Vec<KeybindingKeystroke>,
+    keystrokes: Rc<[KeybindingKeystroke]>,
     context: Option<SharedString>,
 }
 
@@ -235,7 +236,7 @@ struct ConflictState {
 }
 
 type ConflictKeybindMapping = HashMap<
-    Vec<KeybindingKeystroke>,
+    Rc<[KeybindingKeystroke]>,
     Vec<(
         Option<gpui::KeyBindingContextPredicate>,
         Vec<ConflictOrigin>,
@@ -257,7 +258,7 @@ impl ConflictState {
                 .context
                 .and_then(|ctx| gpui::KeyBindingContextPredicate::parse(&ctx).ok());
             let entry = action_keybind_mapping
-                .entry(mapping.keystrokes)
+                .entry(mapping.keystrokes.clone())
                 .or_default();
             let origin = ConflictOrigin::new(binding.source, index);
             if let Some((_, origins)) =
@@ -685,8 +686,7 @@ impl KeymapEditor {
                 .unwrap_or(KeybindSource::Unknown);
 
             let keystroke_text = ui::text_for_keybinding_keystrokes(key_binding.keystrokes(), cx);
-            let ui_key_binding = ui::KeyBinding::new_from_gpui(key_binding.clone(), cx)
-                .vim_mode(source == KeybindSource::Vim);
+            let binding = KeyBinding::new(key_binding, source);
 
             let context = key_binding
                 .predicate()
@@ -717,7 +717,7 @@ impl KeymapEditor {
                 StringMatchCandidate::new(index, &action_information.humanized_name);
             processed_bindings.push(ProcessedBinding::new_mapped(
                 keystroke_text,
-                ui_key_binding,
+                binding,
                 context,
                 source,
                 action_information,
@@ -975,12 +975,11 @@ impl KeymapEditor {
             if conflict.is_user_keybind_conflict() {
                 base_button_style(index, IconName::Warning)
                     .icon_color(Color::Warning)
-                    .tooltip(|window, cx| {
+                    .tooltip(|_window, cx| {
                         Tooltip::with_meta(
                             "View conflicts",
                             Some(&ToggleConflictFilter),
                             "Use alt+click to show all conflicts",
-                            window,
                             cx,
                         )
                     })
@@ -995,12 +994,11 @@ impl KeymapEditor {
                     }))
             } else if self.search_mode.exact_match() {
                 base_button_style(index, IconName::Info)
-                    .tooltip(|window, cx| {
+                    .tooltip(|_window, cx| {
                         Tooltip::with_meta(
                             "Edit this binding",
                             Some(&ShowMatchingKeybinds),
                             "This binding is overridden by other bindings.",
-                            window,
                             cx,
                         )
                     })
@@ -1011,12 +1009,11 @@ impl KeymapEditor {
                     }))
             } else {
                 base_button_style(index, IconName::Info)
-                    .tooltip(|window, cx| {
+                    .tooltip(|_window, cx|  {
                         Tooltip::with_meta(
                             "Show matching keybinds",
                             Some(&ShowMatchingKeybinds),
                             "This binding is overridden by other bindings.\nUse alt+click to edit this binding",
-                            window,
                             cx,
                         )
                     })
@@ -1349,9 +1346,24 @@ impl HumanizedActionNameCache {
 }
 
 #[derive(Clone)]
+struct KeyBinding {
+    keystrokes: Rc<[KeybindingKeystroke]>,
+    source: KeybindSource,
+}
+
+impl KeyBinding {
+    fn new(binding: &gpui::KeyBinding, source: KeybindSource) -> Self {
+        Self {
+            keystrokes: Rc::from(binding.keystrokes()),
+            source,
+        }
+    }
+}
+
+#[derive(Clone)]
 struct KeybindInformation {
     keystroke_text: SharedString,
-    ui_binding: ui::KeyBinding,
+    binding: KeyBinding,
     context: KeybindContextString,
     source: KeybindSource,
 }
@@ -1359,7 +1371,7 @@ struct KeybindInformation {
 impl KeybindInformation {
     fn get_action_mapping(&self) -> ActionMapping {
         ActionMapping {
-            keystrokes: self.ui_binding.keystrokes.clone(),
+            keystrokes: self.binding.keystrokes.clone(),
             context: self.context.local().cloned(),
         }
     }
@@ -1401,7 +1413,7 @@ enum ProcessedBinding {
 impl ProcessedBinding {
     fn new_mapped(
         keystroke_text: impl Into<SharedString>,
-        ui_key_binding: ui::KeyBinding,
+        binding: KeyBinding,
         context: KeybindContextString,
         source: KeybindSource,
         action_information: ActionInformation,
@@ -1409,7 +1421,7 @@ impl ProcessedBinding {
         Self::Mapped(
             KeybindInformation {
                 keystroke_text: keystroke_text.into(),
-                ui_binding: ui_key_binding,
+                binding,
                 context,
                 source,
             },
@@ -1427,8 +1439,8 @@ impl ProcessedBinding {
     }
 
     fn keystrokes(&self) -> Option<&[KeybindingKeystroke]> {
-        self.ui_key_binding()
-            .map(|binding| binding.keystrokes.as_slice())
+        self.key_binding()
+            .map(|binding| binding.keystrokes.as_ref())
     }
 
     fn keybind_information(&self) -> Option<&KeybindInformation> {
@@ -1446,9 +1458,8 @@ impl ProcessedBinding {
         self.keybind_information().map(|keybind| &keybind.context)
     }
 
-    fn ui_key_binding(&self) -> Option<&ui::KeyBinding> {
-        self.keybind_information()
-            .map(|keybind| &keybind.ui_binding)
+    fn key_binding(&self) -> Option<&KeyBinding> {
+        self.keybind_information().map(|keybind| &keybind.binding)
     }
 
     fn keystroke_text(&self) -> Option<&SharedString> {
@@ -1599,12 +1610,11 @@ impl Render for KeymapEditor {
                                         .tooltip({
                                             let focus_handle = focus_handle.clone();
 
-                                            move |window, cx| {
+                                            move |_window, cx| {
                                                 Tooltip::for_action_in(
                                                     "Search by Keystroke",
                                                     &ToggleKeystrokeSearch,
                                                     &focus_handle.clone(),
-                                                    window,
                                                     cx,
                                                 )
                                             }
@@ -1636,7 +1646,7 @@ impl Render for KeymapEditor {
                                                 let filter_state = self.filter_state;
                                                 let focus_handle = focus_handle.clone();
 
-                                                move |window, cx| {
+                                                move |_window, cx| {
                                                     Tooltip::for_action_in(
                                                         match filter_state {
                                                             FilterState::All => "Show Conflicts",
@@ -1646,7 +1656,6 @@ impl Render for KeymapEditor {
                                                         },
                                                         &ToggleConflictFilter,
                                                         &focus_handle.clone(),
-                                                        window,
                                                         cx,
                                                     )
                                                 }
@@ -1698,12 +1707,11 @@ impl Render for KeymapEditor {
                                                         .icon_size(IconSize::Small),
                                                         {
                                                             let focus_handle = focus_handle.clone();
-                                                            move |window, cx| {
+                                                            move |_window, cx| {
                                                                 Tooltip::for_action_in(
                                                                     "View Default...",
                                                                     &zed_actions::OpenKeymapFile,
                                                                     &focus_handle,
-                                                                    window,
                                                                     cx,
                                                                 )
                                                             }
@@ -1745,12 +1753,11 @@ impl Render for KeymapEditor {
                                                     let keystroke_focus_handle =
                                                         self.keystroke_editor.read(cx).focus_handle(cx);
 
-                                                    move |window, cx| {
+                                                    move |_window, cx| {
                                                         Tooltip::for_action_in(
                                                             "Toggle Exact Match Mode",
                                                             &ToggleExactKeystrokeMatching,
                                                             &keystroke_focus_handle,
-                                                            window,
                                                             cx,
                                                         )
                                                     }
@@ -1856,13 +1863,13 @@ impl Render for KeymapEditor {
                                         )
                                         .into_any_element();
 
-                                    let keystrokes = binding.ui_key_binding().cloned().map_or(
+                                    let keystrokes = binding.key_binding().map_or(
                                         binding
                                             .keystroke_text()
                                             .cloned()
                                             .unwrap_or_default()
                                             .into_any_element(),
-                                        IntoElement::into_any_element,
+                                        |binding| ui::KeyBinding::from_keystrokes(binding.keystrokes.clone(), binding.source).into_any_element()
                                     );
 
                                     let action_arguments = match binding.action().arguments.clone()
@@ -2301,7 +2308,7 @@ impl KeybindingEditorModal {
             .map_err(InputError::error)?;
 
         let action_mapping = ActionMapping {
-            keystrokes: new_keystrokes,
+            keystrokes: Rc::from(new_keystrokes.as_slice()),
             context: new_context.map(SharedString::from),
         };
 

--- a/crates/language_selector/src/active_buffer_language.rs
+++ b/crates/language_selector/src/active_buffer_language.rs
@@ -62,9 +62,7 @@ impl Render for ActiveBufferLanguage {
                             });
                         }
                     }))
-                    .tooltip(|window, cx| {
-                        Tooltip::for_action("Select Language", &Toggle, window, cx)
-                    }),
+                    .tooltip(|_window, cx| Tooltip::for_action("Select Language", &Toggle, cx)),
             )
         })
     }

--- a/crates/language_tools/src/key_context_view.rs
+++ b/crates/language_tools/src/key_context_view.rs
@@ -167,7 +167,7 @@ impl Item for KeyContextView {
 }
 
 impl Render for KeyContextView {
-    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl ui::IntoElement {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl ui::IntoElement {
         use itertools::Itertools;
 
         let key_equivalents = cx.keyboard_mapper().get_key_equivalents();
@@ -212,7 +212,6 @@ impl Render for KeyContextView {
                             .style(ButtonStyle::Filled)
                             .key_binding(ui::KeyBinding::for_action(
                                 &zed_actions::OpenDefaultKeymap,
-                                window,
                                 cx
                             ))
                             .on_click(|_, window, cx| {
@@ -222,7 +221,7 @@ impl Render for KeyContextView {
                     .child(
                         Button::new("edit_your_keymap", "Edit Keymap File")
                             .style(ButtonStyle::Filled)
-                            .key_binding(ui::KeyBinding::for_action(&zed_actions::OpenKeymapFile, window, cx))
+                            .key_binding(ui::KeyBinding::for_action(&zed_actions::OpenKeymapFile, cx))
                             .on_click(|_, window, cx| {
                                 window.dispatch_action(zed_actions::OpenKeymapFile.boxed_clone(), cx);
                             }),

--- a/crates/language_tools/src/lsp_button.rs
+++ b/crates/language_tools/src/lsp_button.rs
@@ -1065,14 +1065,8 @@ impl Render for LspButton {
                         .when_some(indicator, IconButton::indicator)
                         .icon_size(IconSize::Small)
                         .indicator_border_color(Some(cx.theme().colors().status_bar_background)),
-                    move |window, cx| {
-                        Tooltip::with_meta(
-                            "Language Servers",
-                            Some(&ToggleMenu),
-                            description,
-                            window,
-                            cx,
-                        )
+                    move |_window, cx| {
+                        Tooltip::with_meta("Language Servers", Some(&ToggleMenu), description, cx)
                     },
                 ),
         )

--- a/crates/line_ending_selector/src/line_ending_indicator.rs
+++ b/crates/line_ending_selector/src/line_ending_indicator.rs
@@ -43,9 +43,7 @@ impl Render for LineEndingIndicator {
                             LineEndingSelector::toggle(editor, window, cx);
                         }
                     }))
-                    .tooltip(|window, cx| {
-                        Tooltip::for_action("Select Line Ending", &Toggle, window, cx)
-                    }),
+                    .tooltip(|_window, cx| Tooltip::for_action("Select Line Ending", &Toggle, cx)),
             )
         })
     }

--- a/crates/onboarding/src/onboarding.rs
+++ b/crates/onboarding/src/onboarding.rs
@@ -337,10 +337,9 @@ impl Render for Onboarding {
                                                 KeyBinding::for_action_in(
                                                     &Finish,
                                                     &self.focus_handle,
-                                                    window,
                                                     cx,
                                                 )
-                                                .map(|kb| kb.size(rems_from_px(12.))),
+                                                .size(rems_from_px(12.)),
                                             )
                                             .on_click(|_, window, cx| {
                                                 window.dispatch_action(Finish.boxed_clone(), cx);

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -4678,12 +4678,11 @@ impl ProjectPanel {
                             div()
                                 .id("symlink_icon")
                                 .pr_3()
-                                .tooltip(move |window, cx| {
+                                .tooltip(move |_window, cx| {
                                     Tooltip::with_meta(
                                         path.to_string(),
                                         None,
                                         "Symbolic Link",
-                                        window,
                                         cx,
                                     )
                                 })
@@ -5863,7 +5862,6 @@ impl Render for ProjectPanel {
                         .key_binding(KeyBinding::for_action_in(
                             &workspace::Open,
                             &focus_handle,
-                            window,
                             cx,
                         ))
                         .on_click(cx.listener(|this, _, window, cx| {

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -547,11 +547,7 @@ impl PickerDelegate for RecentProjectsDelegate {
         )
     }
 
-    fn render_footer(
-        &self,
-        window: &mut Window,
-        cx: &mut Context<Picker<Self>>,
-    ) -> Option<AnyElement> {
+    fn render_footer(&self, _: &mut Window, cx: &mut Context<Picker<Self>>) -> Option<AnyElement> {
         Some(
             h_flex()
                 .w_full()
@@ -567,7 +563,6 @@ impl PickerDelegate for RecentProjectsDelegate {
                                 from_existing_connection: false,
                                 create_new_window: false,
                             },
-                            window,
                             cx,
                         ))
                         .on_click(|_, window, cx| {
@@ -583,7 +578,7 @@ impl PickerDelegate for RecentProjectsDelegate {
                 )
                 .child(
                     Button::new("local", "Open Local Folder")
-                        .key_binding(KeyBinding::for_action(&workspace::Open, window, cx))
+                        .key_binding(KeyBinding::for_action(&workspace::Open, cx))
                         .on_click(|_, window, cx| {
                             window.dispatch_action(workspace::Open.boxed_clone(), cx)
                         }),

--- a/crates/repl/src/notebook/notebook_ui.rs
+++ b/crates/repl/src/notebook/notebook_ui.rs
@@ -326,7 +326,7 @@ impl NotebookEditor {
                                     cx,
                                 )
                                 .tooltip(move |window, cx| {
-                                    Tooltip::for_action("Execute all cells", &RunAll, window, cx)
+                                    Tooltip::for_action("Execute all cells", &RunAll, cx)
                                 })
                                 .on_click(|_, window, cx| {
                                     window.dispatch_action(Box::new(RunAll), cx);
@@ -341,12 +341,7 @@ impl NotebookEditor {
                                 )
                                 .disabled(!has_outputs)
                                 .tooltip(move |window, cx| {
-                                    Tooltip::for_action(
-                                        "Clear all outputs",
-                                        &ClearOutputs,
-                                        window,
-                                        cx,
-                                    )
+                                    Tooltip::for_action("Clear all outputs", &ClearOutputs, cx)
                                 })
                                 .on_click(|_, window, cx| {
                                     window.dispatch_action(Box::new(ClearOutputs), cx);
@@ -363,7 +358,7 @@ impl NotebookEditor {
                                     cx,
                                 )
                                 .tooltip(move |window, cx| {
-                                    Tooltip::for_action("Move cell up", &MoveCellUp, window, cx)
+                                    Tooltip::for_action("Move cell up", &MoveCellUp, cx)
                                 })
                                 .on_click(|_, window, cx| {
                                     window.dispatch_action(Box::new(MoveCellUp), cx);
@@ -377,7 +372,7 @@ impl NotebookEditor {
                                     cx,
                                 )
                                 .tooltip(move |window, cx| {
-                                    Tooltip::for_action("Move cell down", &MoveCellDown, window, cx)
+                                    Tooltip::for_action("Move cell down", &MoveCellDown, cx)
                                 })
                                 .on_click(|_, window, cx| {
                                     window.dispatch_action(Box::new(MoveCellDown), cx);
@@ -394,12 +389,7 @@ impl NotebookEditor {
                                     cx,
                                 )
                                 .tooltip(move |window, cx| {
-                                    Tooltip::for_action(
-                                        "Add markdown block",
-                                        &AddMarkdownBlock,
-                                        window,
-                                        cx,
-                                    )
+                                    Tooltip::for_action("Add markdown block", &AddMarkdownBlock, cx)
                                 })
                                 .on_click(|_, window, cx| {
                                     window.dispatch_action(Box::new(AddMarkdownBlock), cx);
@@ -413,7 +403,7 @@ impl NotebookEditor {
                                     cx,
                                 )
                                 .tooltip(move |window, cx| {
-                                    Tooltip::for_action("Add code block", &AddCodeBlock, window, cx)
+                                    Tooltip::for_action("Add code block", &AddCodeBlock, cx)
                                 })
                                 .on_click(|_, window, cx| {
                                     window.dispatch_action(Box::new(AddCodeBlock), cx);

--- a/crates/repl/src/repl_sessions_ui.rs
+++ b/crates/repl/src/repl_sessions_ui.rs
@@ -197,7 +197,7 @@ impl Item for ReplSessionsPage {
 }
 
 impl Render for ReplSessionsPage {
-    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let store = ReplStore::global(cx);
 
         let (kernel_specifications, sessions) = store.update(cx, |store, _cx| {
@@ -241,7 +241,7 @@ impl Render for ReplSessionsPage {
             return ReplSessionsContainer::new("No Jupyter Kernel Sessions").child(
                 v_flex()
                     .child(Label::new(instructions))
-                    .children(KeyBinding::for_action(&Run, window, cx)),
+                    .child(KeyBinding::for_action(&Run, cx)),
             );
         }
 

--- a/crates/rules_library/src/rules_library.rs
+++ b/crates/rules_library/src/rules_library.rs
@@ -390,12 +390,11 @@ impl PickerDelegate for RulePickerDelegate {
                                     div()
                                         .id("built-in-rule")
                                         .child(Icon::new(IconName::FileLock).color(Color::Muted))
-                                        .tooltip(move |window, cx| {
+                                        .tooltip(move |_window, cx| {
                                             Tooltip::with_meta(
                                                 "Built-in rule",
                                                 None,
                                                 BUILT_IN_TOOLTIP_TEXT,
-                                                window,
                                                 cx,
                                             )
                                         })
@@ -426,12 +425,11 @@ impl PickerDelegate for RulePickerDelegate {
                                                     "Remove from Default Rules",
                                                 ))
                                             } else {
-                                                this.tooltip(move |window, cx| {
+                                                this.tooltip(move |_window, cx| {
                                                     Tooltip::with_meta(
                                                         "Add to Default Rules",
                                                         None,
                                                         "Always included in every thread.",
-                                                        window,
                                                         cx,
                                                     )
                                                 })
@@ -1112,8 +1110,8 @@ impl RulesLibrary {
                     .justify_end()
                     .child(
                         IconButton::new("new-rule", IconName::Plus)
-                            .tooltip(move |window, cx| {
-                                Tooltip::for_action("New Rule", &NewRule, window, cx)
+                            .tooltip(move |_window, cx| {
+                                Tooltip::for_action("New Rule", &NewRule, cx)
                             })
                             .on_click(|_, window, cx| {
                                 window.dispatch_action(Box::new(NewRule), cx);
@@ -1215,7 +1213,7 @@ impl RulesLibrary {
                                                 .id("token_count")
                                                 .mr_1()
                                                 .flex_shrink_0()
-                                                .tooltip(move |window, cx| {
+                                                .tooltip(move |_window, cx| {
                                                     Tooltip::with_meta(
                                                         "Token Estimation",
                                                         None,
@@ -1226,7 +1224,6 @@ impl RulesLibrary {
                                                                 .map(|model| model.name().0)
                                                                 .unwrap_or_default()
                                                         ),
-                                                        window,
                                                         cx,
                                                     )
                                                 })
@@ -1245,23 +1242,21 @@ impl RulesLibrary {
                                                     Icon::new(IconName::FileLock)
                                                         .color(Color::Muted),
                                                 )
-                                                .tooltip(move |window, cx| {
+                                                .tooltip(move |_window, cx| {
                                                     Tooltip::with_meta(
                                                         "Built-in rule",
                                                         None,
                                                         BUILT_IN_TOOLTIP_TEXT,
-                                                        window,
                                                         cx,
                                                     )
                                                 })
                                                 .into_any()
                                         } else {
                                             IconButton::new("delete-rule", IconName::Trash)
-                                                .tooltip(move |window, cx| {
+                                                .tooltip(move |_window, cx| {
                                                     Tooltip::for_action(
                                                         "Delete Rule",
                                                         &DeleteRule,
-                                                        window,
                                                         cx,
                                                     )
                                                 })
@@ -1273,11 +1268,10 @@ impl RulesLibrary {
                                         })
                                         .child(
                                             IconButton::new("duplicate-rule", IconName::BookCopy)
-                                                .tooltip(move |window, cx| {
+                                                .tooltip(move |_window, cx| {
                                                     Tooltip::for_action(
                                                         "Duplicate Rule",
                                                         &DuplicateRule,
-                                                        window,
                                                         cx,
                                                     )
                                                 })
@@ -1305,12 +1299,11 @@ impl RulesLibrary {
                                                         "Remove from Default Rules",
                                                     ))
                                                 } else {
-                                                    this.tooltip(move |window, cx| {
+                                                    this.tooltip(move |_window, cx| {
                                                         Tooltip::with_meta(
                                                             "Add to Default Rules",
                                                             None,
                                                             "Always included in every thread.",
-                                                            window,
                                                             cx,
                                                         )
                                                     })
@@ -1417,7 +1410,7 @@ impl Render for RulesLibrary {
                                                                 .full_width()
                                                                 .key_binding(
                                                                     KeyBinding::for_action(
-                                                                        &NewRule, window, cx,
+                                                                        &NewRule, cx,
                                                                     ),
                                                                 )
                                                                 .on_click(|_, window, cx| {

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -266,12 +266,11 @@ impl Render for BufferSearchBar {
                     .toggle_state(self.selection_search_enabled.is_some())
                     .tooltip({
                         let focus_handle = focus_handle.clone();
-                        move |window, cx| {
+                        move |_window, cx| {
                             Tooltip::for_action_in(
                                 "Toggle Search Selection",
                                 &ToggleSelection,
                                 &focus_handle,
-                                window,
                                 cx,
                             )
                         }

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -391,7 +391,7 @@ pub enum ViewEvent {
 impl EventEmitter<ViewEvent> for ProjectSearchView {}
 
 impl Render for ProjectSearchView {
-    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         if self.has_matches() {
             div()
                 .flex_1()
@@ -426,7 +426,7 @@ impl Render for ProjectSearchView {
                     None
                 }
             } else {
-                Some(self.landing_text_minor(window, cx).into_any_element())
+                Some(self.landing_text_minor(cx).into_any_element())
             };
 
             let page_content = page_content.map(|text| div().child(text));
@@ -1446,7 +1446,7 @@ impl ProjectSearchView {
         self.active_match_index.is_some()
     }
 
-    fn landing_text_minor(&self, window: &mut Window, cx: &App) -> impl IntoElement {
+    fn landing_text_minor(&self, cx: &App) -> impl IntoElement {
         let focus_handle = self.focus_handle.clone();
         v_flex()
             .gap_1()
@@ -1460,12 +1460,7 @@ impl ProjectSearchView {
                     .icon(IconName::Filter)
                     .icon_position(IconPosition::Start)
                     .icon_size(IconSize::Small)
-                    .key_binding(KeyBinding::for_action_in(
-                        &ToggleFilters,
-                        &focus_handle,
-                        window,
-                        cx,
-                    ))
+                    .key_binding(KeyBinding::for_action_in(&ToggleFilters, &focus_handle, cx))
                     .on_click(|_event, window, cx| {
                         window.dispatch_action(ToggleFilters.boxed_clone(), cx)
                     }),
@@ -1475,12 +1470,7 @@ impl ProjectSearchView {
                     .icon(IconName::Replace)
                     .icon_position(IconPosition::Start)
                     .icon_size(IconSize::Small)
-                    .key_binding(KeyBinding::for_action_in(
-                        &ToggleReplace,
-                        &focus_handle,
-                        window,
-                        cx,
-                    ))
+                    .key_binding(KeyBinding::for_action_in(&ToggleReplace, &focus_handle, cx))
                     .on_click(|_event, window, cx| {
                         window.dispatch_action(ToggleReplace.boxed_clone(), cx)
                     }),
@@ -1490,12 +1480,7 @@ impl ProjectSearchView {
                     .icon(IconName::Regex)
                     .icon_position(IconPosition::Start)
                     .icon_size(IconSize::Small)
-                    .key_binding(KeyBinding::for_action_in(
-                        &ToggleRegex,
-                        &focus_handle,
-                        window,
-                        cx,
-                    ))
+                    .key_binding(KeyBinding::for_action_in(&ToggleRegex, &focus_handle, cx))
                     .on_click(|_event, window, cx| {
                         window.dispatch_action(ToggleRegex.boxed_clone(), cx)
                     }),
@@ -1508,7 +1493,6 @@ impl ProjectSearchView {
                     .key_binding(KeyBinding::for_action_in(
                         &ToggleCaseSensitive,
                         &focus_handle,
-                        window,
                         cx,
                     ))
                     .on_click(|_event, window, cx| {
@@ -1523,7 +1507,6 @@ impl ProjectSearchView {
                     .key_binding(KeyBinding::for_action_in(
                         &ToggleWholeWord,
                         &focus_handle,
-                        window,
                         cx,
                     ))
                     .on_click(|_event, window, cx| {
@@ -2049,8 +2032,8 @@ impl Render for ProjectSearchBar {
             .child(
                 IconButton::new("project-search-filter-button", IconName::Filter)
                     .shape(IconButtonShape::Square)
-                    .tooltip(|window, cx| {
-                        Tooltip::for_action("Toggle Filters", &ToggleFilters, window, cx)
+                    .tooltip(|_window, cx| {
+                        Tooltip::for_action("Toggle Filters", &ToggleFilters, cx)
                     })
                     .on_click(cx.listener(|this, _, window, cx| {
                         this.toggle_filters(window, cx);
@@ -2063,12 +2046,11 @@ impl Render for ProjectSearchBar {
                     )
                     .tooltip({
                         let focus_handle = focus_handle.clone();
-                        move |window, cx| {
+                        move |_window, cx| {
                             Tooltip::for_action_in(
                                 "Toggle Filters",
                                 &ToggleFilters,
                                 &focus_handle,
-                                window,
                                 cx,
                             )
                         }

--- a/crates/search/src/search.rs
+++ b/crates/search/src/search.rs
@@ -158,9 +158,7 @@ impl SearchOption {
         .style(ButtonStyle::Subtle)
         .shape(IconButtonShape::Square)
         .toggle_state(active.contains(self.as_options()))
-        .tooltip({
-            move |window, cx| Tooltip::for_action_in(label, action, &focus_handle, window, cx)
-        })
+        .tooltip(move |_window, cx| Tooltip::for_action_in(label, action, &focus_handle, cx))
     }
 }
 

--- a/crates/search/src/search_bar.rs
+++ b/crates/search/src/search_bar.rs
@@ -32,7 +32,7 @@ pub(super) fn render_action_button(
             window.dispatch_action(action.boxed_clone(), cx)
         }
     })
-    .tooltip(move |window, cx| Tooltip::for_action_in(tooltip, action, &focus_handle, window, cx))
+    .tooltip(move |_window, cx| Tooltip::for_action_in(tooltip, action, &focus_handle, cx))
     .when_some(button_state, |this, state| match state {
         ActionButtonState::Toggled => this.toggle_state(true),
         ActionButtonState::Disabled => this.disabled(true),

--- a/crates/search/src/search_status_button.rs
+++ b/crates/search/src/search_status_button.rs
@@ -24,13 +24,8 @@ impl Render for SearchButton {
         button.child(
             IconButton::new("project-search-indicator", SEARCH_ICON)
                 .icon_size(IconSize::Small)
-                .tooltip(|window, cx| {
-                    Tooltip::for_action(
-                        "Project Search",
-                        &workspace::DeploySearch::default(),
-                        window,
-                        cx,
-                    )
+                .tooltip(|_window, cx| {
+                    Tooltip::for_action("Project Search", &workspace::DeploySearch::default(), cx)
                 })
                 .on_click(cx.listener(|_this, _, window, cx| {
                     window.dispatch_action(Box::new(workspace::DeploySearch::default()), cx);

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -2159,20 +2159,16 @@ impl SettingsWindow {
                     .flex_shrink_0()
                     .border_t_1()
                     .border_color(cx.theme().colors().border_variant)
-                    .children(
-                        KeyBinding::for_action_in(
-                            &ToggleFocusNav,
-                            &self.navbar_focus_handle.focus_handle(cx),
-                            window,
-                            cx,
+                    .child(
+                        KeybindingHint::new(
+                            KeyBinding::for_action_in(
+                                &ToggleFocusNav,
+                                &self.navbar_focus_handle.focus_handle(cx),
+                                cx,
+                            ),
+                            cx.theme().colors().surface_background.opacity(0.5),
                         )
-                        .map(|this| {
-                            KeybindingHint::new(
-                                this,
-                                cx.theme().colors().surface_background.opacity(0.5),
-                            )
-                            .suffix(focus_keybind_label)
-                        }),
+                        .suffix(focus_keybind_label),
                     ),
             )
     }

--- a/crates/tasks_ui/src/modal.rs
+++ b/crates/tasks_ui/src/modal.rs
@@ -664,10 +664,10 @@ impl PickerDelegate for TasksModalDelegate {
                 .child(
                     left_button
                         .map(|(label, action)| {
-                            let keybind = KeyBinding::for_action(&*action, window, cx);
+                            let keybind = KeyBinding::for_action(&*action, cx);
 
                             Button::new("edit-current-task", label)
-                                .when_some(keybind, |this, keybind| this.key_binding(keybind))
+                                .key_binding(keybind)
                                 .on_click(move |_, window, cx| {
                                     window.dispatch_action(action.boxed_clone(), cx);
                                 })
@@ -682,7 +682,7 @@ impl PickerDelegate for TasksModalDelegate {
                             secondary: current_modifiers.secondary(),
                         }
                         .boxed_clone();
-                        this.children(KeyBinding::for_action(&*action, window, cx).map(|keybind| {
+                        this.child({
                             let spawn_oneshot_label = if current_modifiers.secondary() {
                                 "Spawn Oneshot Without History"
                             } else {
@@ -690,44 +690,35 @@ impl PickerDelegate for TasksModalDelegate {
                             };
 
                             Button::new("spawn-onehshot", spawn_oneshot_label)
-                                .key_binding(keybind)
+                                .key_binding(KeyBinding::for_action(&*action, cx))
                                 .on_click(move |_, window, cx| {
                                     window.dispatch_action(action.boxed_clone(), cx)
                                 })
-                        }))
+                        })
                     } else if current_modifiers.secondary() {
-                        this.children(
-                            KeyBinding::for_action(&menu::SecondaryConfirm, window, cx).map(
-                                |keybind| {
-                                    let label = if is_recent_selected {
-                                        "Rerun Without History"
-                                    } else {
-                                        "Spawn Without History"
-                                    };
-                                    Button::new("spawn", label).key_binding(keybind).on_click(
-                                        move |_, window, cx| {
-                                            window.dispatch_action(
-                                                menu::SecondaryConfirm.boxed_clone(),
-                                                cx,
-                                            )
-                                        },
-                                    )
-                                },
-                            ),
-                        )
+                        this.child({
+                            let label = if is_recent_selected {
+                                "Rerun Without History"
+                            } else {
+                                "Spawn Without History"
+                            };
+                            Button::new("spawn", label)
+                                .key_binding(KeyBinding::for_action(&menu::SecondaryConfirm, cx))
+                                .on_click(move |_, window, cx| {
+                                    window.dispatch_action(menu::SecondaryConfirm.boxed_clone(), cx)
+                                })
+                        })
                     } else {
-                        this.children(KeyBinding::for_action(&menu::Confirm, window, cx).map(
-                            |keybind| {
-                                let run_entry_label =
-                                    if is_recent_selected { "Rerun" } else { "Spawn" };
+                        this.child({
+                            let run_entry_label =
+                                if is_recent_selected { "Rerun" } else { "Spawn" };
 
-                                Button::new("spawn", run_entry_label)
-                                    .key_binding(keybind)
-                                    .on_click(|_, window, cx| {
-                                        window.dispatch_action(menu::Confirm.boxed_clone(), cx);
-                                    })
-                            },
-                        ))
+                            Button::new("spawn", run_entry_label)
+                                .key_binding(KeyBinding::for_action(&menu::Confirm, cx))
+                                .on_click(|_, window, cx| {
+                                    window.dispatch_action(menu::Confirm.boxed_clone(), cx);
+                                })
+                        })
                     }
                 })
                 .into_any_element(),

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -210,11 +210,10 @@ impl TerminalPanel {
                             .on_click(cx.listener(|pane, _, window, cx| {
                                 pane.toggle_zoom(&workspace::ToggleZoom, window, cx);
                             }))
-                            .tooltip(move |window, cx| {
+                            .tooltip(move |_window, cx| {
                                 Tooltip::for_action(
                                     if zoomed { "Zoom Out" } else { "Zoom In" },
                                     &ToggleZoom,
-                                    window,
                                     cx,
                                 )
                             })
@@ -1739,14 +1738,8 @@ impl Render for InlineAssistTabBarButton {
             .on_click(cx.listener(|_, _, window, cx| {
                 window.dispatch_action(InlineAssist::default().boxed_clone(), cx);
             }))
-            .tooltip(move |window, cx| {
-                Tooltip::for_action_in(
-                    "Inline Assist",
-                    &InlineAssist::default(),
-                    &focus_handle,
-                    window,
-                    cx,
-                )
+            .tooltip(move |_window, cx| {
+                Tooltip::for_action_in("Inline Assist", &InlineAssist::default(), &focus_handle, cx)
             })
     }
 }

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -840,9 +840,7 @@ impl TerminalView {
                 .size(ButtonSize::Compact)
                 .icon_color(Color::Default)
                 .shape(ui::IconButtonShape::Square)
-                .tooltip(move |window, cx| {
-                    Tooltip::for_action("Rerun task", &RerunTask, window, cx)
-                })
+                .tooltip(move |_window, cx| Tooltip::for_action("Rerun task", &RerunTask, cx))
                 .on_click(move |_, window, cx| {
                     window.dispatch_action(Box::new(terminal_rerun_override(&task_id)), cx);
                 }),

--- a/crates/title_bar/src/collab.rs
+++ b/crates/title_bar/src/collab.rs
@@ -403,14 +403,13 @@ impl TitleBar {
                         IconName::Mic
                     },
                 )
-                .tooltip(move |window, cx| {
+                .tooltip(move |_window, cx| {
                     if is_muted {
                         if is_deafened {
                             Tooltip::with_meta(
                                 "Unmute Microphone",
                                 None,
                                 "Audio will be unmuted",
-                                window,
                                 cx,
                             )
                         } else {
@@ -444,12 +443,12 @@ impl TitleBar {
             .selected_style(ButtonStyle::Tinted(TintColor::Error))
             .icon_size(IconSize::Small)
             .toggle_state(is_deafened)
-            .tooltip(move |window, cx| {
+            .tooltip(move |_window, cx| {
                 if is_deafened {
                     let label = "Unmute Audio";
 
                     if !muted_by_user {
-                        Tooltip::with_meta(label, None, "Microphone will be unmuted", window, cx)
+                        Tooltip::with_meta(label, None, "Microphone will be unmuted", cx)
                     } else {
                         Tooltip::simple(label, cx)
                     }
@@ -457,7 +456,7 @@ impl TitleBar {
                     let label = "Mute Audio";
 
                     if !muted_by_user {
-                        Tooltip::with_meta(label, None, "Microphone will be muted", window, cx)
+                        Tooltip::with_meta(label, None, "Microphone will be muted", cx)
                     } else {
                         Tooltip::simple(label, cx)
                     }

--- a/crates/title_bar/src/onboarding_banner.rs
+++ b/crates/title_bar/src/onboarding_banner.rs
@@ -154,12 +154,11 @@ impl Render for OnboardingBanner {
                             telemetry::event!("Banner Dismissed", source = this.source);
                             this.dismiss(cx)
                         }))
-                        .tooltip(|window, cx| {
+                        .tooltip(|_window, cx| {
                             Tooltip::with_meta(
                                 "Close Announcement Banner",
                                 None,
                                 "It won't show again for this feature",
-                                window,
                                 cx,
                             )
                         }),

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -379,7 +379,7 @@ impl TitleBar {
                         )
                         .child(Label::new(nickname).size(LabelSize::Small).truncate()),
                 )
-                .tooltip(move |window, cx| {
+                .tooltip(move |_window, cx| {
                     Tooltip::with_meta(
                         "Remote Project",
                         Some(&OpenRemote {
@@ -387,7 +387,6 @@ impl TitleBar {
                             create_new_window: false,
                         }),
                         meta.clone(),
-                        window,
                         cx,
                     )
                 })
@@ -481,13 +480,12 @@ impl TitleBar {
             .when(!is_project_selected, |b| b.color(Color::Muted))
             .style(ButtonStyle::Subtle)
             .label_size(LabelSize::Small)
-            .tooltip(move |window, cx| {
+            .tooltip(move |_window, cx| {
                 Tooltip::for_action(
                     "Recent Projects",
                     &zed_actions::OpenRecent {
                         create_new_window: false,
                     },
-                    window,
                     cx,
                 )
             })
@@ -527,12 +525,11 @@ impl TitleBar {
                 .color(Color::Muted)
                 .style(ButtonStyle::Subtle)
                 .label_size(LabelSize::Small)
-                .tooltip(move |window, cx| {
+                .tooltip(move |_window, cx| {
                     Tooltip::with_meta(
                         "Recent Branches",
                         Some(&zed_actions::git::Branch),
                         "Local branches only",
-                        window,
                         cx,
                     )
                 })

--- a/crates/toolchain_selector/src/toolchain_selector.rs
+++ b/crates/toolchain_selector/src/toolchain_selector.rs
@@ -490,7 +490,6 @@ impl Render for AddToolchainState {
                                                 .key_binding(KeyBinding::for_action_in(
                                                     &menu::Confirm,
                                                     &handle,
-                                                    window,
                                                     cx,
                                                 ))
                                                 .on_click(cx.listener(|this, _, window, cx| {
@@ -1117,7 +1116,6 @@ impl PickerDelegate for ToolchainSelectorDelegate {
                                 .key_binding(KeyBinding::for_action_in(
                                     &AddToolchain,
                                     &self.focus_handle,
-                                    _window,
                                     cx,
                                 ))
                                 .on_click(|_, window, cx| {
@@ -1129,7 +1127,6 @@ impl PickerDelegate for ToolchainSelectorDelegate {
                                 .key_binding(KeyBinding::for_action_in(
                                     &menu::Confirm,
                                     &self.focus_handle,
-                                    _window,
                                     cx,
                                 ))
                                 .on_click(|_, window, cx| {

--- a/crates/ui/src/components/keybinding_hint.rs
+++ b/crates/ui/src/components/keybinding_hint.rs
@@ -17,7 +17,7 @@ use theme::Appearance;
 ///
 /// # fn example(cx: &App) {
 /// let hint = KeybindingHint::new(
-///     KeyBinding::new(vec![KeybindingKeystroke::from_keystroke(Keystroke::parse("ctrl-s").unwrap())], cx),
+///     KeyBinding::from_keystrokes(vec![KeybindingKeystroke::from_keystroke(Keystroke::parse("ctrl-s").unwrap())], Source::Base),
 ///     Hsla::black()
 /// )
 ///     .prefix("Save:")
@@ -43,12 +43,13 @@ impl KeybindingHint {
     ///
     /// ```no_run
     /// use gpui::{App, Hsla, KeybindingKeystroke, Keystroke};
+    /// use settings::KeybindSource;
     /// use ui::prelude::*;
     /// use ui::{KeyBinding, KeybindingHint};
     ///
     /// # fn example(cx: &App) {
     /// let hint = KeybindingHint::new(
-    ///     KeyBinding::new(vec![KeybindingKeystroke::from_keystroke(Keystroke::parse("ctrl-c").unwrap())], cx),
+    ///     KeyBinding::from_keystrokes(vec![KeybindingKeystroke::from_keystroke(Keystroke::parse("ctrl-c").unwrap())], Source::Base),
     ///     Hsla::black()
     /// );
     /// # }
@@ -74,11 +75,12 @@ impl KeybindingHint {
     /// use gpui::{App, Hsla, KeybindingKeystroke, Keystroke};
     /// use ui::prelude::*;
     /// use ui::{KeyBinding, KeybindingHint};
+    /// use settings::KeybindSource;
     ///
     /// # fn example(cx: &App) {
     /// let hint = KeybindingHint::with_prefix(
     ///     "Copy:",
-    ///     KeyBinding::new(vec![KeybindingKeystroke::from_keystroke(Keystroke::parse("ctrl-c").unwrap())], cx),
+    ///     KeyBinding::from_keystrokes(vec![KeybindingKeystroke::from_keystroke(Keystroke::parse("ctrl-c").unwrap())], Source::Base),
     ///     Hsla::black()
     /// );
     /// # }
@@ -108,10 +110,11 @@ impl KeybindingHint {
     /// use gpui::{App, Hsla, KeybindingKeystroke, Keystroke};
     /// use ui::prelude::*;
     /// use ui::{KeyBinding, KeybindingHint};
+    /// use settings::KeybindSource;
     ///
     /// # fn example(cx: &App) {
     /// let hint = KeybindingHint::with_suffix(
-    ///     KeyBinding::new(vec![KeybindingKeystroke::from_keystroke(Keystroke::parse("ctrl-v").unwrap())], cx),
+    ///     KeyBinding::from_keystrokes(vec![KeybindingKeystroke::from_keystroke(Keystroke::parse("ctrl-v").unwrap())], Source::Base),
     ///     "Paste",
     ///     Hsla::black()
     /// );
@@ -141,10 +144,11 @@ impl KeybindingHint {
     /// use gpui::{App, Hsla, KeybindingKeystroke, Keystroke};
     /// use ui::prelude::*;
     /// use ui::{KeyBinding, KeybindingHint};
+    /// use settings::KeybindSource;
     ///
     /// # fn example(cx: &App) {
     /// let hint = KeybindingHint::new(
-    ///     KeyBinding::new(vec![KeybindingKeystroke::from_keystroke(Keystroke::parse("ctrl-x").unwrap())], cx),
+    ///     KeyBinding::from_keystrokes(vec![KeybindingKeystroke::from_keystroke(Keystroke::parse("ctrl-x").unwrap())], Source::Base),
     ///     Hsla::black()
     /// )
     ///     .prefix("Cut:");
@@ -165,10 +169,11 @@ impl KeybindingHint {
     /// use gpui::{App, Hsla, KeybindingKeystroke, Keystroke};
     /// use ui::prelude::*;
     /// use ui::{KeyBinding, KeybindingHint};
+    /// use settings::KeybindSource;
     ///
     /// # fn example(cx: &App) {
     /// let hint = KeybindingHint::new(
-    ///     KeyBinding::new(vec![KeybindingKeystroke::from_keystroke(Keystroke::parse("ctrl-f").unwrap())], cx),
+    ///     KeyBinding::from_keystrokes(vec![KeybindingKeystroke::from_keystroke(Keystroke::parse("ctrl-f").unwrap())], Source::Base),
     ///     Hsla::black()
     /// )
     ///     .suffix("Find");
@@ -189,10 +194,11 @@ impl KeybindingHint {
     /// use gpui::{App, Hsla, KeybindingKeystroke, Keystroke};
     /// use ui::prelude::*;
     /// use ui::{KeyBinding, KeybindingHint};
+    /// use settings::KeybindSource;
     ///
     /// # fn example(cx: &App) {
     /// let hint = KeybindingHint::new(
-    ///     KeyBinding::new(vec![KeybindingKeystroke::from_keystroke(Keystroke::parse("ctrl-z").unwrap())], cx),
+    ///     KeyBinding::from_keystrokes(vec![KeybindingKeystroke::from_keystroke(Keystroke::parse("ctrl-z").unwrap())], Source::Base),
     ///     Hsla::black()
     /// )
     ///     .size(Pixels::from(16.0));

--- a/crates/ui/src/components/keybinding_hint.rs
+++ b/crates/ui/src/components/keybinding_hint.rs
@@ -265,10 +265,8 @@ impl Component for KeybindingHint {
         Some("Displays a keyboard shortcut hint with optional prefix and suffix text")
     }
 
-    fn preview(window: &mut Window, cx: &mut App) -> Option<AnyElement> {
-        let enter_fallback = gpui::KeyBinding::new("enter", menu::Confirm, None);
-        let enter = KeyBinding::for_action(&menu::Confirm, window, cx)
-            .unwrap_or(KeyBinding::new_from_gpui(enter_fallback, cx));
+    fn preview(_window: &mut Window, cx: &mut App) -> Option<AnyElement> {
+        let enter = KeyBinding::for_action(&menu::Confirm, cx);
 
         let bg_color = cx.theme().colors().surface_background;
 

--- a/crates/ui/src/components/keybinding_hint.rs
+++ b/crates/ui/src/components/keybinding_hint.rs
@@ -18,7 +18,7 @@ use theme::Appearance;
 ///
 /// # fn example(cx: &App) {
 /// let hint = KeybindingHint::new(
-///     KeyBinding::from_keystrokes(vec![KeybindingKeystroke::from_keystroke(Keystroke::parse("ctrl-s").unwrap())].into(), Source::Base),
+///     KeyBinding::from_keystrokes(vec![KeybindingKeystroke::from_keystroke(Keystroke::parse("ctrl-s").unwrap())].into(), KeybindSource::Base),
 ///     Hsla::black()
 /// )
 ///     .prefix("Save:")
@@ -50,7 +50,7 @@ impl KeybindingHint {
     ///
     /// # fn example(cx: &App) {
     /// let hint = KeybindingHint::new(
-    ///     KeyBinding::from_keystrokes(vec![KeybindingKeystroke::from_keystroke(Keystroke::parse("ctrl-c").unwrap())].into(), Source::Base),
+    ///     KeyBinding::from_keystrokes(vec![KeybindingKeystroke::from_keystroke(Keystroke::parse("ctrl-c").unwrap())].into(), KeybindSource::Base),
     ///     Hsla::black()
     /// );
     /// # }
@@ -81,7 +81,7 @@ impl KeybindingHint {
     /// # fn example(cx: &App) {
     /// let hint = KeybindingHint::with_prefix(
     ///     "Copy:",
-    ///     KeyBinding::from_keystrokes(vec![KeybindingKeystroke::from_keystroke(Keystroke::parse("ctrl-c").unwrap())].into(), Source::Base),
+    ///     KeyBinding::from_keystrokes(vec![KeybindingKeystroke::from_keystroke(Keystroke::parse("ctrl-c").unwrap())].into(), KeybindSource::Base),
     ///     Hsla::black()
     /// );
     /// # }
@@ -115,7 +115,7 @@ impl KeybindingHint {
     ///
     /// # fn example(cx: &App) {
     /// let hint = KeybindingHint::with_suffix(
-    ///     KeyBinding::from_keystrokes(vec![KeybindingKeystroke::from_keystroke(Keystroke::parse("ctrl-v").unwrap())].into(), Source::Base),
+    ///     KeyBinding::from_keystrokes(vec![KeybindingKeystroke::from_keystroke(Keystroke::parse("ctrl-v").unwrap())].into(), KeybindSource::Base),
     ///     "Paste",
     ///     Hsla::black()
     /// );
@@ -149,7 +149,7 @@ impl KeybindingHint {
     ///
     /// # fn example(cx: &App) {
     /// let hint = KeybindingHint::new(
-    ///     KeyBinding::from_keystrokes(vec![KeybindingKeystroke::from_keystroke(Keystroke::parse("ctrl-x").unwrap())].into(), Source::Base),
+    ///     KeyBinding::from_keystrokes(vec![KeybindingKeystroke::from_keystroke(Keystroke::parse("ctrl-x").unwrap())].into(), KeybindSource::Base),
     ///     Hsla::black()
     /// )
     ///     .prefix("Cut:");
@@ -174,7 +174,7 @@ impl KeybindingHint {
     ///
     /// # fn example(cx: &App) {
     /// let hint = KeybindingHint::new(
-    ///     KeyBinding::from_keystrokes(vec![KeybindingKeystroke::from_keystroke(Keystroke::parse("ctrl-f").unwrap())].into(), Source::Base),
+    ///     KeyBinding::from_keystrokes(vec![KeybindingKeystroke::from_keystroke(Keystroke::parse("ctrl-f").unwrap())].into(), KeybindSource::Base),
     ///     Hsla::black()
     /// )
     ///     .suffix("Find");
@@ -199,7 +199,7 @@ impl KeybindingHint {
     ///
     /// # fn example(cx: &App) {
     /// let hint = KeybindingHint::new(
-    ///     KeyBinding::from_keystrokes(vec![KeybindingKeystroke::from_keystroke(Keystroke::parse("ctrl-z").unwrap())].into(), Source::Base),
+    ///     KeyBinding::from_keystrokes(vec![KeybindingKeystroke::from_keystroke(Keystroke::parse("ctrl-z").unwrap())].into(), KeybindSource::Base),
     ///     Hsla::black()
     /// )
     ///     .size(Pixels::from(16.0));

--- a/crates/ui/src/components/keybinding_hint.rs
+++ b/crates/ui/src/components/keybinding_hint.rs
@@ -17,7 +17,7 @@ use theme::Appearance;
 ///
 /// # fn example(cx: &App) {
 /// let hint = KeybindingHint::new(
-///     KeyBinding::from_keystrokes(vec![KeybindingKeystroke::from_keystroke(Keystroke::parse("ctrl-s").unwrap())], Source::Base),
+///     KeyBinding::from_keystrokes(vec![KeybindingKeystroke::from_keystroke(Keystroke::parse("ctrl-s").unwrap())].into(), Source::Base),
 ///     Hsla::black()
 /// )
 ///     .prefix("Save:")
@@ -49,7 +49,7 @@ impl KeybindingHint {
     ///
     /// # fn example(cx: &App) {
     /// let hint = KeybindingHint::new(
-    ///     KeyBinding::from_keystrokes(vec![KeybindingKeystroke::from_keystroke(Keystroke::parse("ctrl-c").unwrap())], Source::Base),
+    ///     KeyBinding::from_keystrokes(vec![KeybindingKeystroke::from_keystroke(Keystroke::parse("ctrl-c").unwrap())].into(), Source::Base),
     ///     Hsla::black()
     /// );
     /// # }
@@ -80,7 +80,7 @@ impl KeybindingHint {
     /// # fn example(cx: &App) {
     /// let hint = KeybindingHint::with_prefix(
     ///     "Copy:",
-    ///     KeyBinding::from_keystrokes(vec![KeybindingKeystroke::from_keystroke(Keystroke::parse("ctrl-c").unwrap())], Source::Base),
+    ///     KeyBinding::from_keystrokes(vec![KeybindingKeystroke::from_keystroke(Keystroke::parse("ctrl-c").unwrap())].into(), Source::Base),
     ///     Hsla::black()
     /// );
     /// # }
@@ -114,7 +114,7 @@ impl KeybindingHint {
     ///
     /// # fn example(cx: &App) {
     /// let hint = KeybindingHint::with_suffix(
-    ///     KeyBinding::from_keystrokes(vec![KeybindingKeystroke::from_keystroke(Keystroke::parse("ctrl-v").unwrap())], Source::Base),
+    ///     KeyBinding::from_keystrokes(vec![KeybindingKeystroke::from_keystroke(Keystroke::parse("ctrl-v").unwrap())].into(), Source::Base),
     ///     "Paste",
     ///     Hsla::black()
     /// );
@@ -148,7 +148,7 @@ impl KeybindingHint {
     ///
     /// # fn example(cx: &App) {
     /// let hint = KeybindingHint::new(
-    ///     KeyBinding::from_keystrokes(vec![KeybindingKeystroke::from_keystroke(Keystroke::parse("ctrl-x").unwrap())], Source::Base),
+    ///     KeyBinding::from_keystrokes(vec![KeybindingKeystroke::from_keystroke(Keystroke::parse("ctrl-x").unwrap())].into(), Source::Base),
     ///     Hsla::black()
     /// )
     ///     .prefix("Cut:");
@@ -173,7 +173,7 @@ impl KeybindingHint {
     ///
     /// # fn example(cx: &App) {
     /// let hint = KeybindingHint::new(
-    ///     KeyBinding::from_keystrokes(vec![KeybindingKeystroke::from_keystroke(Keystroke::parse("ctrl-f").unwrap())], Source::Base),
+    ///     KeyBinding::from_keystrokes(vec![KeybindingKeystroke::from_keystroke(Keystroke::parse("ctrl-f").unwrap())].into(), Source::Base),
     ///     Hsla::black()
     /// )
     ///     .suffix("Find");
@@ -198,7 +198,7 @@ impl KeybindingHint {
     ///
     /// # fn example(cx: &App) {
     /// let hint = KeybindingHint::new(
-    ///     KeyBinding::from_keystrokes(vec![KeybindingKeystroke::from_keystroke(Keystroke::parse("ctrl-z").unwrap())], Source::Base),
+    ///     KeyBinding::from_keystrokes(vec![KeybindingKeystroke::from_keystroke(Keystroke::parse("ctrl-z").unwrap())].into(), Source::Base),
     ///     Hsla::black()
     /// )
     ///     .size(Pixels::from(16.0));

--- a/crates/ui/src/components/keybinding_hint.rs
+++ b/crates/ui/src/components/keybinding_hint.rs
@@ -14,6 +14,7 @@ use theme::Appearance;
 /// use gpui::{App, Hsla, KeybindingKeystroke, Keystroke};
 /// use ui::prelude::*;
 /// use ui::{KeyBinding, KeybindingHint};
+/// use settings::KeybindSource;
 ///
 /// # fn example(cx: &App) {
 /// let hint = KeybindingHint::new(
@@ -43,9 +44,9 @@ impl KeybindingHint {
     ///
     /// ```no_run
     /// use gpui::{App, Hsla, KeybindingKeystroke, Keystroke};
-    /// use settings::KeybindSource;
     /// use ui::prelude::*;
     /// use ui::{KeyBinding, KeybindingHint};
+    /// use settings::KeybindSource;
     ///
     /// # fn example(cx: &App) {
     /// let hint = KeybindingHint::new(

--- a/crates/ui/src/components/stories/keybinding.rs
+++ b/crates/ui/src/components/stories/keybinding.rs
@@ -1,6 +1,7 @@
 use gpui::NoAction;
 use gpui::Render;
 use itertools::Itertools;
+use settings::KeybindSource;
 use story::Story;
 
 use crate::{KeyBinding, prelude::*};
@@ -15,19 +16,36 @@ impl Render for KeybindingStory {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let all_modifier_permutations = ["ctrl", "alt", "cmd", "shift"].into_iter().permutations(2);
 
+        const SOURCE: KeybindSource = KeybindSource::Base;
+
         Story::container(cx)
             .child(Story::title_for::<KeyBinding>(cx))
             .child(Story::label("Single Key", cx))
-            .child(KeyBinding::new_from_gpui(binding("Z"), cx))
+            .child(KeyBinding::from_keystrokes(
+                binding("Z").keystrokes().into(),
+                SOURCE,
+            ))
             .child(Story::label("Single Key with Modifier", cx))
             .child(
                 div()
                     .flex()
                     .gap_3()
-                    .child(KeyBinding::new_from_gpui(binding("ctrl-c"), cx))
-                    .child(KeyBinding::new_from_gpui(binding("alt-c"), cx))
-                    .child(KeyBinding::new_from_gpui(binding("cmd-c"), cx))
-                    .child(KeyBinding::new_from_gpui(binding("shift-c"), cx)),
+                    .child(KeyBinding::from_keystrokes(
+                        binding("ctrl-c").keystrokes().into(),
+                        SOURCE,
+                    ))
+                    .child(KeyBinding::from_keystrokes(
+                        binding("alt-c").keystrokes().into(),
+                        SOURCE,
+                    ))
+                    .child(KeyBinding::from_keystrokes(
+                        binding("cmd-c").keystrokes().into(),
+                        SOURCE,
+                    ))
+                    .child(KeyBinding::from_keystrokes(
+                        binding("shift-c").keystrokes().into(),
+                        SOURCE,
+                    )),
             )
             .child(Story::label("Single Key with Modifier (Permuted)", cx))
             .child(
@@ -41,58 +59,77 @@ impl Render for KeybindingStory {
                                 .gap_4()
                                 .py_3()
                                 .children(chunk.map(|permutation| {
-                                    KeyBinding::new_from_gpui(
-                                        binding(&(permutation.join("-") + "-x")),
-                                        cx,
+                                    KeyBinding::from_keystrokes(
+                                        binding(&(permutation.join("-") + "-x"))
+                                            .keystrokes()
+                                            .into(),
+                                        SOURCE,
                                     )
                                 }))
                         }),
                 ),
             )
             .child(Story::label("Single Key with All Modifiers", cx))
-            .child(KeyBinding::new_from_gpui(
-                binding("ctrl-alt-cmd-shift-z"),
-                cx,
+            .child(KeyBinding::from_keystrokes(
+                binding("ctrl-alt-cmd-shift-z").keystrokes().into(),
+                SOURCE,
             ))
             .child(Story::label("Chord", cx))
-            .child(KeyBinding::new_from_gpui(binding("a z"), cx))
+            .child(KeyBinding::from_keystrokes(
+                binding("a z").keystrokes().into(),
+                SOURCE,
+            ))
             .child(Story::label("Chord with Modifier", cx))
-            .child(KeyBinding::new_from_gpui(binding("ctrl-a shift-z"), cx))
-            .child(KeyBinding::new_from_gpui(binding("fn-s"), cx))
+            .child(KeyBinding::from_keystrokes(
+                binding("ctrl-a shift-z").keystrokes().into(),
+                SOURCE,
+            ))
+            .child(KeyBinding::from_keystrokes(
+                binding("fn-s").keystrokes().into(),
+                SOURCE,
+            ))
             .child(Story::label("Single Key with All Modifiers (Linux)", cx))
             .child(
-                KeyBinding::new_from_gpui(binding("ctrl-alt-cmd-shift-z"), cx)
-                    .platform_style(PlatformStyle::Linux),
+                KeyBinding::from_keystrokes(
+                    binding("ctrl-alt-cmd-shift-z").keystrokes().into(),
+                    SOURCE,
+                )
+                .platform_style(PlatformStyle::Linux),
             )
             .child(Story::label("Chord (Linux)", cx))
             .child(
-                KeyBinding::new_from_gpui(binding("a z"), cx).platform_style(PlatformStyle::Linux),
+                KeyBinding::from_keystrokes(binding("a z").keystrokes().into(), SOURCE)
+                    .platform_style(PlatformStyle::Linux),
             )
             .child(Story::label("Chord with Modifier (Linux)", cx))
             .child(
-                KeyBinding::new_from_gpui(binding("ctrl-a shift-z"), cx)
+                KeyBinding::from_keystrokes(binding("ctrl-a shift-z").keystrokes().into(), SOURCE)
                     .platform_style(PlatformStyle::Linux),
             )
             .child(
-                KeyBinding::new_from_gpui(binding("fn-s"), cx).platform_style(PlatformStyle::Linux),
+                KeyBinding::from_keystrokes(binding("fn-s").keystrokes().into(), SOURCE)
+                    .platform_style(PlatformStyle::Linux),
             )
             .child(Story::label("Single Key with All Modifiers (Windows)", cx))
             .child(
-                KeyBinding::new_from_gpui(binding("ctrl-alt-cmd-shift-z"), cx)
-                    .platform_style(PlatformStyle::Windows),
+                KeyBinding::from_keystrokes(
+                    binding("ctrl-alt-cmd-shift-z").keystrokes().into(),
+                    SOURCE,
+                )
+                .platform_style(PlatformStyle::Windows),
             )
             .child(Story::label("Chord (Windows)", cx))
             .child(
-                KeyBinding::new_from_gpui(binding("a z"), cx)
+                KeyBinding::from_keystrokes(binding("a z").keystrokes().into(), SOURCE)
                     .platform_style(PlatformStyle::Windows),
             )
             .child(Story::label("Chord with Modifier (Windows)", cx))
             .child(
-                KeyBinding::new_from_gpui(binding("ctrl-a shift-z"), cx)
+                KeyBinding::from_keystrokes(binding("ctrl-a shift-z").keystrokes().into(), SOURCE)
                     .platform_style(PlatformStyle::Windows),
             )
             .child(
-                KeyBinding::new_from_gpui(binding("fn-s"), cx)
+                KeyBinding::from_keystrokes(binding("fn-s").keystrokes().into(), SOURCE)
                     .platform_style(PlatformStyle::Windows),
             )
     }

--- a/crates/ui/src/components/tooltip.rs
+++ b/crates/ui/src/components/tooltip.rs
@@ -64,11 +64,11 @@ impl Tooltip {
     ) -> impl Fn(&mut Window, &mut App) -> AnyView + use<T> {
         let title = title.into();
         let action = action.boxed_clone();
-        move |window, cx| {
+        move |_, cx| {
             cx.new(|cx| Self {
                 title: Title::Str(title.clone()),
                 meta: None,
-                key_binding: KeyBinding::for_action(action.as_ref(), window, cx),
+                key_binding: Some(KeyBinding::for_action(action.as_ref(), cx)),
             })
             .into()
         }
@@ -82,11 +82,15 @@ impl Tooltip {
         let title = title.into();
         let action = action.boxed_clone();
         let focus_handle = focus_handle.clone();
-        move |window, cx| {
+        move |_, cx| {
             cx.new(|cx| Self {
                 title: Title::Str(title.clone()),
                 meta: None,
-                key_binding: KeyBinding::for_action_in(action.as_ref(), &focus_handle, window, cx),
+                key_binding: Some(KeyBinding::for_action_in(
+                    action.as_ref(),
+                    &focus_handle,
+                    cx,
+                )),
             })
             .into()
         }
@@ -95,13 +99,12 @@ impl Tooltip {
     pub fn for_action(
         title: impl Into<SharedString>,
         action: &dyn Action,
-        window: &mut Window,
         cx: &mut App,
     ) -> AnyView {
         cx.new(|cx| Self {
             title: Title::Str(title.into()),
             meta: None,
-            key_binding: KeyBinding::for_action(action, window, cx),
+            key_binding: Some(KeyBinding::for_action(action, cx)),
         })
         .into()
     }
@@ -110,13 +113,12 @@ impl Tooltip {
         title: impl Into<SharedString>,
         action: &dyn Action,
         focus_handle: &FocusHandle,
-        window: &mut Window,
         cx: &mut App,
     ) -> AnyView {
         cx.new(|cx| Self {
             title: title.into().into(),
             meta: None,
-            key_binding: KeyBinding::for_action_in(action, focus_handle, window, cx),
+            key_binding: Some(KeyBinding::for_action_in(action, focus_handle, cx)),
         })
         .into()
     }
@@ -125,13 +127,12 @@ impl Tooltip {
         title: impl Into<SharedString>,
         action: Option<&dyn Action>,
         meta: impl Into<SharedString>,
-        window: &mut Window,
         cx: &mut App,
     ) -> AnyView {
         cx.new(|cx| Self {
             title: title.into().into(),
             meta: Some(meta.into()),
-            key_binding: action.and_then(|action| KeyBinding::for_action(action, window, cx)),
+            key_binding: action.map(|action| KeyBinding::for_action(action, cx)),
         })
         .into()
     }
@@ -141,14 +142,12 @@ impl Tooltip {
         action: Option<&dyn Action>,
         meta: impl Into<SharedString>,
         focus_handle: &FocusHandle,
-        window: &mut Window,
         cx: &mut App,
     ) -> AnyView {
         cx.new(|cx| Self {
             title: title.into().into(),
             meta: Some(meta.into()),
-            key_binding: action
-                .and_then(|action| KeyBinding::for_action_in(action, focus_handle, window, cx)),
+            key_binding: action.map(|action| KeyBinding::for_action_in(action, focus_handle, cx)),
         })
         .into()
     }

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -948,8 +948,8 @@ impl Render for PanelButtons {
                                     }
                                 })
                                 .when(!is_active, |this| {
-                                    this.tooltip(move |window, cx| {
-                                        Tooltip::for_action(tooltip.clone(), &*action, window, cx)
+                                    this.tooltip(move |_window, cx| {
+                                        Tooltip::for_action(tooltip.clone(), &*action, cx)
                                     })
                                 })
                         }),

--- a/crates/workspace/src/invalid_item_view.rs
+++ b/crates/workspace/src/invalid_item_view.rs
@@ -75,7 +75,7 @@ impl Focusable for InvalidItemView {
 }
 
 impl Render for InvalidItemView {
-    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl gpui::IntoElement {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl gpui::IntoElement {
         let abs_path = self.abs_path.clone();
         v_flex()
             .size_full()
@@ -103,11 +103,7 @@ impl Render for InvalidItemView {
                                             cx.open_with_system(&abs_path);
                                         })
                                         .style(ButtonStyle::Outlined)
-                                        .key_binding(KeyBinding::for_action(
-                                            &OpenWithSystem,
-                                            window,
-                                            cx,
-                                        )),
+                                        .key_binding(KeyBinding::for_action(&OpenWithSystem, cx)),
                                 ),
                             )
                         }),

--- a/crates/workspace/src/notifications.rs
+++ b/crates/workspace/src/notifications.rs
@@ -315,19 +315,17 @@ impl Render for LanguageServerPrompt {
                                     )
                                     .child(
                                         IconButton::new(close_id, close_icon)
-                                            .tooltip(move |window, cx| {
+                                            .tooltip(move |_window, cx| {
                                                 if suppress {
                                                     Tooltip::for_action(
                                                         "Suppress.\nClose with click.",
                                                         &SuppressNotification,
-                                                        window,
                                                         cx,
                                                     )
                                                 } else {
                                                     Tooltip::for_action(
                                                         "Close.\nSuppress with shift-click.",
                                                         &menu::Cancel,
-                                                        window,
                                                         cx,
                                                     )
                                                 }
@@ -556,23 +554,21 @@ impl RenderOnce for NotificationFrame {
                         this.on_modifiers_changed(move |_, _, cx| cx.notify(entity))
                             .child(
                                 IconButton::new(close_id, close_icon)
-                                    .tooltip(move |window, cx| {
+                                    .tooltip(move |_window, cx| {
                                         if suppress {
                                             Tooltip::for_action(
                                                 "Suppress.\nClose with click.",
                                                 &SuppressNotification,
-                                                window,
                                                 cx,
                                             )
                                         } else if show_suppress_button {
                                             Tooltip::for_action(
                                                 "Close.\nSuppress with shift-click.",
                                                 &menu::Cancel,
-                                                window,
                                                 cx,
                                             )
                                         } else {
-                                            Tooltip::for_action("Close", &menu::Cancel, window, cx)
+                                            Tooltip::for_action("Close", &menu::Cancel, cx)
                                         }
                                     })
                                     .on_click({

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -2730,12 +2730,11 @@ impl Pane {
                 .map(|this| {
                     if is_active {
                         let focus_handle = focus_handle.clone();
-                        this.tooltip(move |window, cx| {
+                        this.tooltip(move |_window, cx| {
                             Tooltip::for_action_in(
                                 end_slot_tooltip_text,
                                 end_slot_action,
                                 &focus_handle,
-                                window,
                                 cx,
                             )
                         })
@@ -3038,9 +3037,7 @@ impl Pane {
             .disabled(!self.can_navigate_backward())
             .tooltip({
                 let focus_handle = focus_handle.clone();
-                move |window, cx| {
-                    Tooltip::for_action_in("Go Back", &GoBack, &focus_handle, window, cx)
-                }
+                move |_window, cx| Tooltip::for_action_in("Go Back", &GoBack, &focus_handle, cx)
             });
 
         let navigate_forward = IconButton::new("navigate_forward", IconName::ArrowRight)
@@ -3056,8 +3053,8 @@ impl Pane {
             .disabled(!self.can_navigate_forward())
             .tooltip({
                 let focus_handle = focus_handle.clone();
-                move |window, cx| {
-                    Tooltip::for_action_in("Go Forward", &GoForward, &focus_handle, window, cx)
+                move |_window, cx| {
+                    Tooltip::for_action_in("Go Forward", &GoForward, &focus_handle, cx)
                 }
             });
 
@@ -3660,11 +3657,10 @@ fn default_render_tab_bar_buttons(
                 .on_click(cx.listener(|pane, _, window, cx| {
                     pane.toggle_zoom(&crate::ToggleZoom, window, cx);
                 }))
-                .tooltip(move |window, cx| {
+                .tooltip(move |_window, cx| {
                     Tooltip::for_action(
                         if zoomed { "Zoom Out" } else { "Zoom In" },
                         &ToggleZoom,
-                        window,
                         cx,
                     )
                 })

--- a/crates/workspace/src/theme_preview.rs
+++ b/crates/workspace/src/theme_preview.rs
@@ -319,13 +319,7 @@ impl ThemePreview {
                                 .style(ButtonStyle::Transparent)
                                 .tooltip(move |window, cx| {
                                     let name = name.clone();
-                                    Tooltip::with_meta(
-                                        name,
-                                        None,
-                                        format!("{:?}", color),
-                                        window,
-                                        cx,
-                                    )
+                                    Tooltip::with_meta(name, None, format!("{:?}", color), cx)
                                 }),
                         )
                     })),

--- a/crates/zed/src/zed/quick_action_bar.rs
+++ b/crates/zed/src/zed/quick_action_bar.rs
@@ -655,8 +655,8 @@ impl RenderOnce for QuickActionBarButton {
             .icon_size(IconSize::Small)
             .style(ButtonStyle::Subtle)
             .toggle_state(self.toggled)
-            .tooltip(move |window, cx| {
-                Tooltip::for_action_in(tooltip.clone(), &*action, &self.focus_handle, window, cx)
+            .tooltip(move |_window, cx| {
+                Tooltip::for_action_in(tooltip.clone(), &*action, &self.focus_handle, cx)
             })
             .on_click(move |event, window, cx| (self.on_click)(event, window, cx))
     }

--- a/crates/zed/src/zed/quick_action_bar/preview.rs
+++ b/crates/zed/src/zed/quick_action_bar/preview.rs
@@ -68,7 +68,7 @@ impl QuickActionBar {
         let button = IconButton::new(button_id, IconName::Eye)
             .icon_size(IconSize::Small)
             .style(ButtonStyle::Subtle)
-            .tooltip(move |window, cx| {
+            .tooltip(move |_window, cx| {
                 Tooltip::with_meta(
                     tooltip_text,
                     Some(open_action_for_tooltip),
@@ -76,7 +76,6 @@ impl QuickActionBar {
                         "{} to open in a split",
                         text_for_keystroke(&alt_click.modifiers, &alt_click.key, cx)
                     ),
-                    window,
                     cx,
                 )
             })

--- a/crates/zeta/src/rate_completion_modal.rs
+++ b/crates/zeta/src/rate_completion_modal.rs
@@ -382,11 +382,7 @@ impl RateCompletionModal {
         )
     }
 
-    fn render_active_completion(
-        &mut self,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) -> Option<impl IntoElement> {
+    fn render_active_completion(&mut self, cx: &mut Context<Self>) -> Option<impl IntoElement> {
         let active_completion = self.active_completion.as_ref()?;
         let completion_id = active_completion.completion.id;
         let focus_handle = &self.focus_handle(cx);
@@ -500,7 +496,6 @@ impl RateCompletionModal {
                                         .key_binding(KeyBinding::for_action_in(
                                             &ThumbsDownActiveCompletion,
                                             focus_handle,
-                                            window,
                                             cx
                                         ))
                                         .on_click(cx.listener(move |this, _, window, cx| {
@@ -521,7 +516,6 @@ impl RateCompletionModal {
                                         .key_binding(KeyBinding::for_action_in(
                                             &ThumbsUpActiveCompletion,
                                             focus_handle,
-                                            window,
                                             cx
                                         ))
                                         .on_click(cx.listener(move |this, _, window, cx| {
@@ -658,7 +652,7 @@ impl Render for RateCompletionModal {
                             )
                     ),
             )
-            .children(self.render_active_completion(window, cx))
+            .children(self.render_active_completion( cx))
             .on_mouse_down_out(cx.listener(|_, _, _, cx| cx.emit(DismissEvent)))
     }
 }

--- a/crates/zeta2_tools/src/zeta2_tools.rs
+++ b/crates/zeta2_tools/src/zeta2_tools.rs
@@ -873,16 +873,14 @@ impl Zeta2Inspector {
             })
     }
 
-    fn render_content(&self, window: &mut Window, cx: &mut Context<Self>) -> AnyElement {
+    fn render_content(&self, _: &mut Window, cx: &mut Context<Self>) -> AnyElement {
         if !cx.has_flag::<Zeta2FeatureFlag>() {
             return Self::render_message("`zeta2` feature flag is not enabled");
         }
 
         match self.last_prediction.as_ref() {
             None => Self::render_message("No prediction"),
-            Some(prediction) => self
-                .render_last_prediction(prediction, window, cx)
-                .into_any(),
+            Some(prediction) => self.render_last_prediction(prediction, cx).into_any(),
         }
     }
 
@@ -895,12 +893,7 @@ impl Zeta2Inspector {
             .into_any()
     }
 
-    fn render_last_prediction(
-        &self,
-        prediction: &LastPrediction,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) -> Div {
+    fn render_last_prediction(&self, prediction: &LastPrediction, cx: &mut Context<Self>) -> Div {
         match &self.active_view {
             ActiveView::Context => div().size_full().child(prediction.context_editor.clone()),
             ActiveView::Inference => h_flex()
@@ -989,13 +982,12 @@ impl Zeta2Inspector {
                                                         *feedback_state == Some(Feedback::Positive),
                                                         |this| this.style(ButtonStyle::Filled),
                                                     )
-                                                    .children(
+                                                    .child(
                                                         KeyBinding::for_action(
                                                             &Zeta2RatePredictionPositive,
-                                                            window,
                                                             cx,
                                                         )
-                                                        .map(|k| k.size(TextSize::Small.rems(cx))),
+                                                        .size(TextSize::Small.rems(cx)),
                                                     )
                                                     .child(ui::Icon::new(ui::IconName::ThumbsUp))
                                                     .on_click(cx.listener(
@@ -1014,13 +1006,12 @@ impl Zeta2Inspector {
                                                         *feedback_state == Some(Feedback::Negative),
                                                         |this| this.style(ButtonStyle::Filled),
                                                     )
-                                                    .children(
+                                                    .child(
                                                         KeyBinding::for_action(
                                                             &Zeta2RatePredictionNegative,
-                                                            window,
                                                             cx,
                                                         )
-                                                        .map(|k| k.size(TextSize::Small.rems(cx))),
+                                                        .size(TextSize::Small.rems(cx)),
                                                     )
                                                     .child(ui::Icon::new(ui::IconName::ThumbsDown))
                                                     .on_click(cx.listener(


### PR DESCRIPTION
Closes #39172

This refactors when we resolve UI keybindings in an effort to reduce flickering whilst painting these: Previously, we would always resolve these upon creating the binding. This could lead to cases where the corresponding context was not yet available and no binding could be resolved, even if the binding was then available on the next presented frame. Following that, on the next rerender of whatever requested this keybinding, the keybind for that context would then be found, we would render that and then also win a layout shift in that process, as we went from nothing rendered to something rendered between these frames.

With these changes, this now happens less often, because we only look for the keybinding once the context can actually be resolved in the window.

| Before | After | 
| --- | --- |
| https://github.com/user-attachments/assets/adebf8ac-217d-4c7f-ae5a-bab3aa0b0ee8 | https://github.com/user-attachments/assets/70a82b4b-488f-4a9f-94d7-b6d0a49aada9 |

Also reduced cloning in the keymap editor in this process, since that requiered changing due to this anyway.

Release Notes:

- Fixed some cases where keybinds would appear with a slight delay, causing a flicker in the process
