### PR TITLE
Don't migrate empty formatter array

### DIFF
--- a/crates/migrator/src/migrations/m_2025_10_16/settings.rs
+++ b/crates/migrator/src/migrations/m_2025_10_16/settings.rs
@@ -37,6 +37,9 @@ fn restore_code_actions_on_format_inner(value: &mut Value, path: &[&str]) -> Res
     } else {
         vec![formatter.clone()]
     };
+    if formatter_array.is_empty() {
+        return Ok(());
+    }
     let mut code_action_formatters = Vec::new();
     for formatter in formatter_array {
         let Some(code_action) = formatter.get("code_action") else {

--- a/crates/migrator/src/migrator.rs
+++ b/crates/migrator/src/migrator.rs
@@ -2090,6 +2090,21 @@ mod tests {
                 .unindent(),
             ),
         );
+
+        assert_migrate_settings_with_migrations(
+            &[MigrationType::Json(
+                migrations::m_2025_10_16::restore_code_actions_on_format,
+            )],
+            &r#"{
+                "formatter": [],
+                "code_actions_on_format": {
+                    "bar": true,
+                    "baz": false
+                }
+            }"#
+            .unindent(),
+            None,
+        );
     }
 
     #[test]


### PR DESCRIPTION
Follow up for #40409
Fix for https://github.com/zed-industries/zed/issues/40874#issuecomment-3433759849

Release Notes:

- Fixed an issue where having an empty formatter array in your settings `"formatter": []` would result in an erroneous prompt to migrate settings 
