### PR TITLE
agent_ui: Focus the message editor after regenerating a user message

### DIFF
--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -1259,6 +1259,7 @@ impl AcpThreadView {
                 .await?;
             this.update_in(cx, |this, window, cx| {
                 this.send_impl(message_editor, window, cx);
+                this.focus_handle(cx).focus(window);
             })?;
             anyhow::Ok(())
         })


### PR DESCRIPTION
Release Notes:

- agent: Improved the editing previous messages UX by focusing in the agent panel's message editor after regenerating a prompt, instead of moving focus to the nearest regular buffer.
