### PR TITLE
rope: Implement `Rope::is_char_boundary` via chars bitmap

### DIFF
--- a/crates/rope/src/chunk.rs
+++ b/crates/rope/src/chunk.rs
@@ -93,6 +93,11 @@ impl Chunk {
     pub fn tabs(&self) -> Bitmap {
         self.tabs
     }
+
+    #[inline(always)]
+    pub fn is_char_boundary(&self, offset: usize) -> bool {
+        (1 as Bitmap).unbounded_shl(offset as u32) & self.chars != 0 || offset == self.text.len()
+    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -123,8 +128,8 @@ impl<'a> ChunkSlice<'a> {
     }
 
     #[inline(always)]
-    pub fn is_char_boundary(self, offset: usize) -> bool {
-        self.text.is_char_boundary(offset)
+    pub fn is_char_boundary(&self, offset: usize) -> bool {
+        (1 as Bitmap).unbounded_shl(offset as u32) & self.chars != 0 || offset == self.text.len()
     }
 
     #[inline(always)]

--- a/crates/rope/src/rope.rs
+++ b/crates/rope/src/rope.rs
@@ -44,7 +44,7 @@ impl Rope {
         }
         let (start, _, item) = self.chunks.find::<usize, _>((), &offset, Bias::Left);
         let chunk_offset = offset - start;
-        item.map(|chunk| chunk.text.is_char_boundary(chunk_offset))
+        item.map(|chunk| chunk.is_char_boundary(chunk_offset))
             .unwrap_or(false)
     }
 


### PR DESCRIPTION
Slightly more efficient. No new tests as we already have tests verifiying this.

Release Notes:

- N/A *or* Added/Fixed/Improved ...
