### PR TITLE
go_to_line: Avoid byte slicing crash in short status labels

### DIFF
--- a/crates/go_to_line/src/cursor_position.rs
+++ b/crates/go_to_line/src/cursor_position.rs
@@ -216,7 +216,7 @@ impl CursorPosition {
         text.push(')');
     }
 
-    fn short_label<'a>(name: &'a str) -> &'a str {
+    fn short_label(name: &str) -> &str {
         match name.char_indices().nth(1) {
             Some((index, _)) => &name[..index],
             None => name,


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/40962

Release Notes:

- Fixed avoid byte slicing crash in short status labels
