### PR TITLE
settings_ui: Enable editing project settings for worktrees without setting file

### DIFF
--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -1778,8 +1778,7 @@ impl SettingsWindow {
             ui_files.push((settings_ui_file, focus_handle));
         }
 
-        self.worktree_root_dirs
-            .extend(missing_worktrees.into_iter());
+        self.worktree_root_dirs.extend(missing_worktrees);
 
         self.files = ui_files;
         let current_file_still_exists = self
@@ -2820,7 +2819,7 @@ impl SettingsWindow {
                             })
                             .ok()
                             .flatten()
-                            .zip(Some(workspace.clone()))
+                            .zip(Some(*workspace))
                     })
                 else {
                     log::error!(


### PR DESCRIPTION
I made three significant changes in this PR. 

1. `SettingsWindow::fetch_files` now creates `SettingsUiFile::Project(..)` for any worktree that contains no project settings. 
2. `update_settings_file` now creates an empty settings file if a worktree doesn't contain one.
3. `open_current_settings_file` also creates a settings file if the current one doesn't exist.

Release Notes:

- settings ui: Enable editing project settings for worktrees that don't have a project setting file.
