### PR TITLE
debugger: Fix debug scenario picker not showing language subtitles

### DIFF
--- a/crates/debugger_ui/src/new_process_modal.rs
+++ b/crates/debugger_ui/src/new_process_modal.rs
@@ -96,7 +96,9 @@ impl NewProcessModal {
                     let debug_picker = cx.new(|cx| {
                         let delegate =
                             DebugDelegate::new(debug_panel.downgrade(), task_store.clone());
-                        Picker::uniform_list(delegate, window, cx).modal(false)
+                        Picker::list(delegate, window, cx)
+                            .modal(false)
+                            .list_measure_all()
                     });
 
                     let configure_mode = ConfigureMode::new(window, cx);

--- a/crates/debugger_ui/src/new_process_modal.rs
+++ b/crates/debugger_ui/src/new_process_modal.rs
@@ -1050,7 +1050,7 @@ impl DebugDelegate {
             Some(TaskSourceKind::Lsp { language_name, .. }) => {
                 Some(format!("LSP: {language_name}"))
             }
-            Some(TaskSourceKind::Language { .. }) => None,
+            Some(TaskSourceKind::Language { name }) => Some(format!("Lang: {name}")),
             _ => context.clone().and_then(|ctx| {
                 ctx.task_context
                     .task_variables

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -352,6 +352,16 @@ impl<D: PickerDelegate> Picker<D> {
         self
     }
 
+    pub fn list_measure_all(mut self) -> Self {
+        match self.element_container {
+            ElementContainer::List(state) => {
+                self.element_container = ElementContainer::List(state.measure_all());
+            }
+            _ => {}
+        }
+        self
+    }
+
     pub fn focus(&self, window: &mut Window, cx: &mut App) {
         self.focus_handle(cx).focus(window);
     }


### PR DESCRIPTION
### Before 
<img width="544" height="403" alt="Screenshot 2025-10-23 at 2 58 44 AM" src="https://github.com/user-attachments/assets/f5a69d27-e54a-4c1e-80f7-5cfff5b0bd47" />

### After
<img width="550" height="372" alt="Screenshot 2025-10-23 at 3 08 59 AM" src="https://github.com/user-attachments/assets/33dd9c5e-054e-4ed1-ba1e-16746a5a697a" />

I also changed the debug picker to use a material list to cover the edge case where there isn't a subtitle for an entry

Release Notes:

- debugger: Fix debug scenario picker not showing language subtitles
