### PR TITLE
gpui: Arc `GlobalElementId`

### DIFF
--- a/crates/gpui/src/inspector.rs
+++ b/crates/gpui/src/inspector.rs
@@ -39,7 +39,7 @@ mod conditional {
     impl Clone for InspectorElementPath {
         fn clone(&self) -> Self {
             Self {
-                global_id: crate::GlobalElementId(self.global_id.0.clone()),
+                global_id: self.global_id.clone(),
                 source_location: self.source_location,
             }
         }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1848,7 +1848,8 @@ impl Window {
         f: impl FnOnce(&GlobalElementId, &mut Self) -> R,
     ) -> R {
         self.element_id_stack.push(element_id);
-        let global_id = GlobalElementId(self.element_id_stack.clone());
+        let global_id = GlobalElementId(Arc::from(&*self.element_id_stack));
+
         let result = f(&global_id, self);
         self.element_id_stack.pop();
         result
@@ -2260,7 +2261,7 @@ impl Window {
             self.rendered_frame.accessed_element_states[range.start.accessed_element_states_index
                 ..range.end.accessed_element_states_index]
                 .iter()
-                .map(|(id, type_id)| (GlobalElementId(id.0.clone()), *type_id)),
+                .map(|(id, type_id)| (id.clone(), *type_id)),
         );
         self.text_system
             .reuse_layouts(range.start.line_layout_index..range.end.line_layout_index);
@@ -2328,7 +2329,7 @@ impl Window {
             self.rendered_frame.accessed_element_states[range.start.accessed_element_states_index
                 ..range.end.accessed_element_states_index]
                 .iter()
-                .map(|(id, type_id)| (GlobalElementId(id.0.clone()), *type_id)),
+                .map(|(id, type_id)| (id.clone(), *type_id)),
         );
         self.next_frame.tab_stops.replay(
             &self.rendered_frame.tab_stops.insertion_history
@@ -2650,10 +2651,8 @@ impl Window {
     {
         self.invalidator.debug_assert_paint_or_prepaint();
 
-        let key = (GlobalElementId(global_id.0.clone()), TypeId::of::<S>());
-        self.next_frame
-            .accessed_element_states
-            .push((GlobalElementId(key.0.clone()), TypeId::of::<S>()));
+        let key = (global_id.clone(), TypeId::of::<S>());
+        self.next_frame.accessed_element_states.push(key.clone());
 
         if let Some(any) = self
             .next_frame


### PR DESCRIPTION
This shrinks it from roughly a ~kilobyte to 8 byte, removing a bunch of memmoves emitted by the compiler. Also `Arc`'s it instead of boxing as we do clone it a couple times here and there, making that also a fair bit cheaper

Release Notes:

- N/A *or* Added/Fixed/Improved ...
