### PR TITLE
build(config): Apply +crt-static for MSVC on Windows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -12,8 +12,12 @@ perf-compare = ["run", "--profile", "release-fast", "-p", "perf", "--config", "t
 rustflags = [
     "--cfg",
     "windows_slim_errors",        # This cfg will reduce the size of `windows::core::Error` from 16 bytes to 4 bytes
+]
+
+[target.'cfg(target_os = "windows", target_env = "msvc")']
+rustflags = [
     "-C",
-    "target-feature=+crt-static", # This fixes the linking issue when compiling livekit on Windows
+    "target-feature=+crt-static", # This fixes the linking issue when compiling livekit with MSVC
 ]
 
 [env]


### PR DESCRIPTION
Currently livekit is compilable only on MSVC environment

Release Notes:

- N/A
