### PR TITLE
Add project panel padding setting

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -658,6 +658,8 @@
     "hide_gitignore": false,
     // Default width of the project panel.
     "default_width": 240,
+    // Padding inside the project panel, in pixels.
+    "padding": 0,
     // Where to dock the project panel. Can be 'left' or 'right'.
     "dock": "left",
     // Spacing between worktree entries in the project panel. Can be 'comfortable' or 'standard'.

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -5409,6 +5409,7 @@ impl Render for ProjectPanel {
                         .on_drag_move(cx.listener(handle_drag_move::<DraggedSelection>))
                 })
                 .size_full()
+                .p(px(panel_settings.padding))
                 .relative()
                 .on_modifiers_changed(cx.listener(
                     |this, event: &ModifiersChangedEvent, window, cx| {

--- a/crates/project_panel/src/project_panel_settings.rs
+++ b/crates/project_panel/src/project_panel_settings.rs
@@ -30,6 +30,7 @@ pub struct ProjectPanelSettings {
     pub hide_hidden: bool,
     pub drag_and_drop: bool,
     pub open_file_on_paste: bool,
+    pub padding: f32,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -81,6 +82,7 @@ impl Settings for ProjectPanelSettings {
             hide_hidden: project_panel.hide_hidden.unwrap(),
             drag_and_drop: project_panel.drag_and_drop.unwrap(),
             open_file_on_paste: project_panel.open_file_on_paste.unwrap(),
+            padding: project_panel.padding.unwrap(),
         }
     }
 }

--- a/crates/settings/src/settings_content/workspace.rs
+++ b/crates/settings/src/settings_content/workspace.rs
@@ -594,6 +594,10 @@ pub struct ProjectPanelSettingsContent {
     ///
     /// Default: true
     pub open_file_on_paste: Option<bool>,
+    /// Padding around the project panel content
+    ///
+    /// Default: 0.0
+    pub padding: Option<f32>,
 }
 
 #[derive(

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -663,6 +663,7 @@ impl VsCodeSettings {
                 .and_then(|b| if b { Some(ShowDiagnostics::Off) } else { None }),
             starts_open: None,
             sticky_scroll: None,
+            padding: None,
         };
 
         if let (Some(false), Some(false)) = (

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -3365,6 +3365,28 @@ pub(crate) fn settings_data(cx: &App) -> Vec<SettingsPage> {
                     files: USER,
                 }),
                 SettingsPageItem::SettingItem(SettingItem {
+                    title: "Project Panel Padding",
+                    description: "Padding for the project panel in pixels.",
+                    field: Box::new(SettingField {
+                        json_path: Some("project_panel.padding"),
+                        pick: |settings_content| {
+                            settings_content
+                                .project_panel
+                                .as_ref()?
+                                .padding
+                                .as_ref()
+                        },
+                        write: |settings_content, value| {
+                            settings_content
+                                .project_panel
+                                .get_or_insert_default()
+                                .padding = value;
+                        },
+                    }),
+                    metadata: None,
+                    files: USER,
+                }),
+                SettingsPageItem::SettingItem(SettingItem {
                     title: "Hide .gitignore",
                     description: "Whether to hide the gitignore entries in the project panel.",
                     field: Box::new(SettingField {

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -4137,6 +4137,7 @@ Run the {#action theme_selector::Toggle} action in the command palette to see a 
   "project_panel": {
     "button": true,
     "default_width": 240,
+    "padding": 0,
     "dock": "left",
     "entry_spacing": "comfortable",
     "file_icons": true,


### PR DESCRIPTION
This PR introduces a new `project_panel.padding` setting which allows setting a custom padding in pixels for the project panel.

The default padding is set to `0` to match the existing behaviour.

For now this setting applies the same padding in all directions, but if it's desirable, I'm open to decomposing this in `top_padding`,  `right_padding`, `bottom_padding`, and `left_padding` options.

Screenshots:

<table>
<tr>
<th>Without padding</th>
<th>With 10px padding</th>
<th>Settings UI</th>
</tr>
<tr>
 <td>
<img width="973" height="780" alt="Screenshot 2025-10-23 at 15 13 30" src="https://github.com/user-attachments/assets/039dbfdd-6ad2-48b8-a336-990f8f8c5528" />
</td>
 <td>
<img width="973" height="780" alt="Screenshot 2025-10-23 at 15 13 54" src="https://github.com/user-attachments/assets/a689b3c6-10f3-4f0f-b0f8-12e19d42ea8a" />
</td>
 <td>
<img width="1012" height="862" alt="Screenshot 2025-10-23 at 15 14 06" src="https://github.com/user-attachments/assets/f9de656a-8370-4d72-8229-0d86f89e527e" />
</td>
</table>

Motivation:

While I really like Zed, I sometimes find myself wishing for a little bit more breathing room, so I thought I'd contribute this feature as my first contribution.

Release Notes:

- Added a new setting for applying padding to the project panel
