### PR TITLE
project: Fix inability to open file after save as

### DIFF
--- a/crates/project/src/buffer_store.rs
+++ b/crates/project/src/buffer_store.rs
@@ -909,7 +909,14 @@ impl BufferStore {
         };
         cx.spawn(async move |this, cx| {
             task.await?;
-            this.update(cx, |_, cx| {
+            this.update(cx, |this, cx| {
+                old_file.clone().and_then(|file| {
+                    this.path_to_buffer_id.remove(&ProjectPath {
+                        worktree_id: file.worktree_id(cx),
+                        path: file.path().clone(),
+                    })
+                });
+
                 cx.emit(BufferStoreEvent::BufferChangedFilePath { buffer, old_file });
             })
         })

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -4256,10 +4256,10 @@ async fn test_save_as_existing_file(cx: &mut gpui::TestAppContext) {
     init_test(cx);
 
     let fs = FakeFs::new(cx.executor());
-    let project = Project::test(fs.clone(), ["/dir".as_ref()], cx).await;
+    let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
 
     fs.insert_tree(
-        "/dir",
+        path!("/dir"),
         json!({
                 "data_a.txt": "data about a"
         }),
@@ -4268,7 +4268,7 @@ async fn test_save_as_existing_file(cx: &mut gpui::TestAppContext) {
 
     let buffer = project
         .update(cx, |project, cx| {
-            project.open_local_buffer("/dir/data_a.txt", cx)
+            project.open_local_buffer(path!("/dir/data_a.txt"), cx)
         })
         .await
         .unwrap();
@@ -4304,7 +4304,7 @@ async fn test_save_as_existing_file(cx: &mut gpui::TestAppContext) {
     // unchanged and the resulting buffer's associated file is `data_a.txt`.
     let original_buffer = project
         .update(cx, |project, cx| {
-            project.open_local_buffer("/dir/data_a.txt", cx)
+            project.open_local_buffer(path!("/dir/data_a.txt"), cx)
         })
         .await
         .unwrap();


### PR DESCRIPTION
Update `project::buffer_store::BufferStore.save_buffer_as` in order to correctly update the `path_to_buffer_id` hash map, ensuring that the currently open file's path is dissociated from the buffer's id, to prevent the new buffer from being open when trying to open the original file.

Closes #29783 

Release Notes:

- Fixed issue where using `workspace: save as` would prevent users from opening the original file from which the new file was created
