### PR TITLE
Try working around spurious rebuild bug in cargo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -775,6 +775,8 @@ windows-capture = { git = "https://github.com/zed-industries/windows-capture.git
 
 [profile.dev]
 split-debuginfo = "unpacked"
+# https://github.com/rust-lang/cargo/issues/16104
+incremental = false
 codegen-units = 16
 
 # mirror configuration for crates compiled for the build platform


### PR DESCRIPTION
We've been seeing a lot of weird constant rebuilds recently with rust-anaylzer's check, either with cargo thinking build scripts are too new timestamp wise or all fingerprints having gone missing somehow (???). Reading through some related bug reports hints at disabling incremental potentially working around this for now so let's test that out

cc https://github.com/rust-lang/cargo/issues/16104

Release Notes:

- N/A *or* Added/Fixed/Improved ...
