### PR TITLE
Fix overly noisy direnv error notification

### DIFF
--- a/crates/project/src/environment.rs
+++ b/crates/project/src/environment.rs
@@ -324,7 +324,9 @@ async fn load_direnv_environment(
     env: &HashMap<String, String>,
     dir: &Path,
 ) -> anyhow::Result<HashMap<String, Option<String>>> {
-    let direnv_path = which::which("direnv").context("finding direnv binary")?;
+    let Some(direnv_path) = which::which("direnv").ok() else {
+        return Ok(HashMap::default());
+    };
 
     let args = &["export", "json"];
     let direnv_output = smol::process::Command::new(&direnv_path)


### PR DESCRIPTION
Updates #40531, restoring the previous behavior which didn't surface an error when no direnv binary was found.

Release Notes:

- N/A