### PR TITLE
Make 'wrap selections in tag' work with line selection mode

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -10520,16 +10520,13 @@ impl Editor {
         self.hide_mouse_cursor(HideMouseCursorOrigin::TypingAction, cx);
 
         let snapshot = self.buffer.read(cx).snapshot(cx);
-        let max_point = snapshot.max_point();
 
         let mut edits = Vec::new();
         let mut boundaries = Vec::new();
 
-        let is_line_mode = self.selections.line_mode();
-
         for selection in self
             .selections
-            .all::<Point>(&self.display_snapshot(cx))
+            .all_adjusted(&self.display_snapshot(cx))
             .iter()
         {
             let Some(wrap_config) = snapshot
@@ -10542,19 +10539,8 @@ impl Editor {
             let open_tag = format!("{}{}", wrap_config.start_prefix, wrap_config.start_suffix);
             let close_tag = format!("{}{}", wrap_config.end_prefix, wrap_config.end_suffix);
 
-            let start_point: Point;
-            let end_point: Point;
-
-            if is_line_mode {
-                start_point = Point::new(selection.start.row, 0);
-                end_point = cmp::min(max_point, Point::new(selection.end.row + 1, 0));
-            } else {
-                start_point = selection.start;
-                end_point = selection.end;
-            }
-
-            let start_before = snapshot.anchor_before(start_point);
-            let end_after = snapshot.anchor_after(end_point);
+            let start_before = snapshot.anchor_before(selection.start);
+            let end_after = snapshot.anchor_after(selection.end);
 
             edits.push((start_before..start_before, open_tag));
             edits.push((end_after..end_after, close_tag));

--- a/crates/vim/src/test.rs
+++ b/crates/vim/src/test.rs
@@ -2359,8 +2359,8 @@ async fn test_wrap_selections_in_tag_line_mode(cx: &mut gpui::TestAppContext) {
         indoc! {
             "
             <ˇ>aaaaa
-            bbbbb
-            </ˇ>"
+            bbbbb</ˇ>
+            "
         },
         Mode::VisualLine,
     );

--- a/crates/vim/src/test.rs
+++ b/crates/vim/src/test.rs
@@ -2,19 +2,21 @@ mod neovim_backed_test_context;
 mod neovim_connection;
 mod vim_test_context;
 
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use collections::HashMap;
 use command_palette::CommandPalette;
 use editor::{
-    AnchorRangeExt, DisplayPoint, Editor, EditorMode, MultiBuffer, actions::DeleteLine,
-    code_context_menus::CodeContextMenu, display_map::DisplayRow,
+    AnchorRangeExt, DisplayPoint, Editor, EditorMode, MultiBuffer,
+    actions::{DeleteLine, WrapSelectionsInTag},
+    code_context_menus::CodeContextMenu,
+    display_map::DisplayRow,
     test::editor_test_context::EditorTestContext,
 };
 use futures::StreamExt;
 use gpui::{KeyBinding, Modifiers, MouseButton, TestAppContext, px};
 use itertools::Itertools;
-use language::Point;
+use language::{Language, LanguageConfig, Point};
 pub use neovim_backed_test_context::*;
 use settings::SettingsStore;
 use ui::Pixels;
@@ -2317,5 +2319,49 @@ async fn test_clipping_on_mode_change(cx: &mut gpui::TestAppContext) {
         "
         },
         Mode::Normal,
+    );
+}
+
+#[gpui::test]
+async fn test_wrap_selections_in_tag_line_mode(cx: &mut gpui::TestAppContext) {
+    let mut cx = VimTestContext::new(cx, true).await;
+
+    let js_language = Arc::new(Language::new(
+        LanguageConfig {
+            name: "JavaScript".into(),
+            wrap_characters: Some(language::WrapCharactersConfig {
+                start_prefix: "<".into(),
+                start_suffix: ">".into(),
+                end_prefix: "</".into(),
+                end_suffix: ">".into(),
+            }),
+            ..LanguageConfig::default()
+        },
+        None,
+    ));
+
+    cx.update_buffer(|buffer, cx| buffer.set_language(Some(js_language), cx));
+
+    cx.set_state(
+        indoc! {
+        "
+        ˇaaaaa
+        bbbbb
+        "
+        },
+        Mode::Normal,
+    );
+
+    cx.simulate_keystrokes("shift-v j");
+    cx.dispatch_action(WrapSelectionsInTag);
+
+    cx.assert_state(
+        indoc! {
+            "
+            <ˇ>aaaaa
+            bbbbb
+            </ˇ>"
+        },
+        Mode::VisualLine,
     );
 }


### PR DESCRIPTION
The `wrap selections in tag` action currently did not take line_mode into account, which means when selecting lines with `shift-v`, the start/end tags would be inserted into the middle of the selection (where the cursor sits)

https://github.com/user-attachments/assets/a1cbf3da-d52a-42e2-aecf-1a7b6d1dbb32

This PR fixes this behaviour by checking if the selection uses line_mode and then adjusting start and end points accordingly.

NOTE: I looked into amending the test cases for this, but I am unsure how to express line mode with range markers. I would appreciate some guidance on this and then I am happy to add test cases.

After:

https://github.com/user-attachments/assets/a212c41f-b0db-4f50-866f-fced7bc677ca

Release Notes:

- Fixed `Editor: wrap selection in tags` when in vim visual line mode