### PR TITLE
docs: Update docs for `theme_overrides` setting

### DIFF
--- a/docs/src/configuring-languages.md
+++ b/docs/src/configuring-languages.md
@@ -364,18 +364,20 @@ Zed offers customization options for syntax highlighting and themes, allowing yo
 
 ### Customizing Syntax Highlighting
 
-Zed uses Tree-sitter grammars for syntax highlighting. Override the default highlighting using the `experimental.theme_overrides` setting.
+Zed uses Tree-sitter grammars for syntax highlighting. Override the default highlighting using the `theme_overrides` setting.
 
 This example makes comments italic and changes the color of strings:
 
 ```json [settings]
-"experimental.theme_overrides": {
-  "syntax": {
-    "comment": {
-      "font_style": "italic"
-    },
-    "string": {
-      "color": "#00AA00"
+"theme_overrides": {
+  "One Dark": {
+    "syntax": {
+      "comment": {
+        "font_style": "italic"
+      },
+      "string": {
+        "color": "#00AA00"
+      }
     }
   }
 }

--- a/docs/src/themes.md
+++ b/docs/src/themes.md
@@ -32,20 +32,22 @@ By default, Zed maintains two themes: one for light mode and one for dark mode. 
 
 ## Theme Overrides
 
-To override specific attributes of a theme, use the `experimental.theme_overrides` setting.
+To override specific attributes of a theme, use the `theme_overrides` setting. This setting can be used to configure theme-specific overrides.
 
 For example, add the following to your `settings.json` if you wish to override the background color of the editor and display comments and doc comments as italics:
 
 ```json [settings]
 {
-  "experimental.theme_overrides": {
-    "editor.background": "#333",
-    "syntax": {
-      "comment": {
-        "font_style": "italic"
-      },
-      "comment.doc": {
-        "font_style": "italic"
+  "theme_overrides": {
+    "One Dark": {
+      "editor.background": "#333",
+      "syntax": {
+        "comment": {
+          "font_style": "italic"
+        },
+        "comment.doc": {
+          "font_style": "italic"
+        }
       }
     }
   }


### PR DESCRIPTION
This PR updates the docs to reference the `theme_overrides` setting instead of the old `experimental.theme_overrides` setting.

Release Notes:

- N/A
