### PR TITLE
agent_panel: Trim leading and trailing whitespace on agent panel messages

### DIFF
--- a/crates/agent_ui/src/acp/message_editor.rs
+++ b/crates/agent_ui/src/acp/message_editor.rs
@@ -791,7 +791,7 @@ impl MessageEditor {
                         // } else {
                         //     text[ix..].trim_end().to_owned()
                         // };
-                        let last_chunk = text[ix..].trim_end().to_owned();
+                        let last_chunk = text[ix..].trim().to_owned();
                         if !last_chunk.is_empty() {
                             chunks.push(last_chunk.into());
                         }


### PR DESCRIPTION
Closes #41017

Release Notes:

- fixed leading white-space not being trimmed in agent panel messages.
