### PR TITLE
git: Only save dirty files during staging

### DIFF
--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -2008,7 +2008,7 @@ impl Buffer {
         self.end_transaction(cx)
     }
 
-    fn has_unsaved_edits(&self) -> bool {
+    pub fn has_unsaved_edits(&self) -> bool {
         let (last_version, has_unsaved_edits) = self.has_unsaved_edits.take();
 
         if last_version == self.version {

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -3618,6 +3618,7 @@ impl Repository {
                             .read(cx)
                             .file()
                             .is_some_and(|file| file.disk_state().exists())
+                        && buffer.read(cx).has_unsaved_edits()
                     {
                         save_futures.push(buffer_store.save_buffer(buffer, cx));
                     }
@@ -3684,6 +3685,7 @@ impl Repository {
                             .read(cx)
                             .file()
                             .is_some_and(|file| file.disk_state().exists())
+                        && buffer.read(cx).has_unsaved_edits()
                     {
                         save_futures.push(buffer_store.save_buffer(buffer, cx));
                     }


### PR DESCRIPTION
Closes #40581

Release Notes:

- git: No longer save clean files when staging (to avoid triggering unnecessary rebuilds in external file watchers like vite)
