### PR TITLE
cli: Use --wait to prefer focused window

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -7306,6 +7306,7 @@ pub struct OpenOptions {
     pub visible: Option<OpenVisible>,
     pub focus: Option<bool>,
     pub open_new_workspace: Option<bool>,
+    pub prefer_focused_window: bool,
     pub replace_window: Option<WindowHandle<Workspace>>,
     pub env: Option<HashMap<String, String>>,
 }
@@ -7358,7 +7359,7 @@ pub fn open_paths(
             })?;
 
             if open_options.open_new_workspace.is_none()
-                && existing.is_none()
+                && (existing.is_none() || open_options.prefer_focused_window)
                 && all_metadatas.iter().all(|file| !file.is_dir)
             {
                 cx.update(|cx| {

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -5083,15 +5083,15 @@ mod tests {
             )
             .await;
 
-        let project_a = Project::test(app_state.fs.clone(), [Path::new("/dir")], cx).await;
+        let project_a = Project::test(app_state.fs.clone(), [path!("/dir").as_ref()], cx).await;
         let window_a =
             cx.add_window(|window, cx| Workspace::test_new(project_a.clone(), window, cx));
 
-        let project_b = Project::test(app_state.fs.clone(), [Path::new("/dir")], cx).await;
+        let project_b = Project::test(app_state.fs.clone(), [path!("/dir").as_ref()], cx).await;
         let window_b =
             cx.add_window(|window, cx| Workspace::test_new(project_b.clone(), window, cx));
 
-        let project_c = Project::test(app_state.fs.clone(), [Path::new("/dir")], cx).await;
+        let project_c = Project::test(app_state.fs.clone(), [path!("/dir").as_ref()], cx).await;
         let window_c =
             cx.add_window(|window, cx| Workspace::test_new(project_c.clone(), window, cx));
 
@@ -5118,11 +5118,9 @@ mod tests {
                 let pane = workspace.active_pane().read(cx);
                 let project_path = pane.active_item().unwrap().project_path(cx).unwrap();
 
-                assert!(
-                    project_path
-                        .path
-                        .as_ref()
-                        .ends_with(rel_path("document.txt"))
+                assert_eq!(
+                    project_path.path.as_ref().as_std_path().to_str().unwrap(),
+                    path!("document.txt")
                 )
             });
         }

--- a/crates/zed/src/zed/open_listener.rs
+++ b/crates/zed/src/zed/open_listener.rs
@@ -531,6 +531,7 @@ async fn open_local_workspace(
         workspace::OpenOptions {
             open_new_workspace: effective_open_new_workspace,
             replace_window,
+            prefer_focused_window: wait,
             env: env.cloned(),
             ..Default::default()
         },


### PR DESCRIPTION
Closes #40551 

Release Notes:

- Improved the `--wait` flag in Zed's CLI so as to always open the provided file in the currently focused window
