### PR TITLE
Document `zed: reveal log in file manager` in crash report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/11_crash_report.yml
+++ b/.github/ISSUE_TEMPLATE/11_crash_report.yml
@@ -35,10 +35,8 @@ body:
     attributes:
       label: If applicable, attach your `Zed.log` file to this issue.
       description: |
-        macOS: `~/Library/Logs/Zed/Zed.log`
-        Windows: `C:\Users\YOU\AppData\Local\Zed\logs\Zed.log`
-        Linux: `~/.local/share/zed/logs/Zed.log` or $XDG_DATA_HOME
-        If you only need the most recent lines, you can run the `zed: open log` command palette action to see the last 1000.
+        From the command palette, run `zed: open log` to see the last 1000 lines.
+        Or run `zed: reveal log in file manager` to reveal the log file itself.
       value: |
         <details><summary>Zed.log</summary>
 


### PR DESCRIPTION
Merge once stable is v0.210 (10/29/2025).

Release Notes:

- N/A
