### PR TITLE
docs: Fix small grammatical typo in JSX section

### DIFF
--- a/docs/src/languages/javascript.md
+++ b/docs/src/languages/javascript.md
@@ -34,7 +34,7 @@ For example, if you have Prettier installed and on your `PATH`, you can use it t
 
 Zed supports JSX syntax highlighting out of the box.
 
-In JSX strings, the [`tailwindcss-language-server`](./tailwindcss.md) is used provide autocompletion for Tailwind CSS classes.
+In JSX strings, the [`tailwindcss-language-server`](./tailwindcss.md) is used to provide autocompletion for Tailwind CSS classes.
 
 ## JSDoc
 


### PR DESCRIPTION
Happened to notice this typo while going through the docs.

Release Notes:

- N/A

---

💖