### PR TITLE
Fix typo in Font Features description, s/b "OpenType"

### DIFF
--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -796,7 +796,7 @@ pub(crate) fn settings_data(cx: &App) -> Vec<SettingsPage> {
                 SettingsPageItem::SettingItem(SettingItem {
                     files: USER,
                     title: "Font Features",
-                    description: "The Opentype features to enable for rendering in UI elements.",
+                    description: "The OpenType features to enable for rendering in UI elements.",
                     field: Box::new(
                         SettingField {
                             json_path: Some("ui_font_features"),


### PR DESCRIPTION
Fix typo (regression?), 
"Opentype" should be "OpenType"

Closes #ISSUE

Release Notes:

- N/A