### PR TITLE
gpui: Impl Default for TextRun

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1701,9 +1701,7 @@ impl EditorElement {
                                         len,
                                         font,
                                         color,
-                                        background_color: None,
-                                        strikethrough: None,
-                                        underline: None,
+                                        ..Default::default()
                                     }],
                                     None,
                                 )
@@ -3583,9 +3581,7 @@ impl EditorElement {
                         len: line.len(),
                         font: style.text.font(),
                         color: placeholder_color,
-                        background_color: None,
-                        underline: None,
-                        strikethrough: None,
+                        ..Default::default()
                     };
                     let line = window.text_system().shape_line(
                         line.to_string().into(),
@@ -7440,9 +7436,7 @@ impl EditorElement {
                 len: column,
                 font: style.text.font(),
                 color: Hsla::default(),
-                background_color: None,
-                underline: None,
-                strikethrough: None,
+                ..Default::default()
             }],
             None,
         );
@@ -7465,9 +7459,7 @@ impl EditorElement {
             len: text.len(),
             font: self.style.text.font(),
             color,
-            background_color: None,
-            underline: None,
-            strikethrough: None,
+            ..Default::default()
         };
         window.text_system().shape_line(
             text,
@@ -9568,9 +9560,7 @@ impl Element for EditorElement {
                             len: tab_len,
                             font: self.style.text.font(),
                             color: cx.theme().colors().editor_invisible,
-                            background_color: None,
-                            underline: None,
-                            strikethrough: None,
+                            ..Default::default()
                         }],
                         None,
                     );
@@ -9584,9 +9574,7 @@ impl Element for EditorElement {
                             len: space_len,
                             font: self.style.text.font(),
                             color: cx.theme().colors().editor_invisible,
-                            background_color: None,
-                            underline: None,
-                            strikethrough: None,
+                            ..Default::default()
                         }],
                         None,
                     );
@@ -11573,11 +11561,8 @@ mod tests {
     fn generate_test_run(len: usize, color: Hsla) -> TextRun {
         TextRun {
             len,
-            font: gpui::font(".SystemUIFont"),
             color,
-            background_color: None,
-            underline: None,
-            strikethrough: None,
+            ..Default::default()
         }
     }
 

--- a/crates/gpui/src/text_system.rs
+++ b/crates/gpui/src/text_system.rs
@@ -739,7 +739,7 @@ impl Display for FontStyle {
 }
 
 /// A styled run of text, for use in [`crate::TextLayout`].
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
 pub struct TextRun {
     /// A number of utf8 bytes
     pub len: usize,
@@ -811,6 +811,12 @@ pub struct Font {
 
     /// The font style.
     pub style: FontStyle,
+}
+
+impl Default for Font {
+    fn default() -> Self {
+        font(".SystemUIFont")
+    }
 }
 
 /// Get a [`Font`] for a given name.

--- a/crates/gpui/src/text_system/line_wrapper.rs
+++ b/crates/gpui/src/text_system/line_wrapper.rs
@@ -315,9 +315,7 @@ impl Boundary {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        Font, FontFeatures, FontStyle, FontWeight, Hsla, TestAppContext, TestDispatcher, font,
-    };
+    use crate::{Font, FontFeatures, FontStyle, FontWeight, TestAppContext, TestDispatcher, font};
     #[cfg(target_os = "macos")]
     use crate::{TextRun, WindowTextSystem, WrapBoundary};
     use rand::prelude::*;
@@ -341,10 +339,7 @@ mod tests {
                     weight: FontWeight::default(),
                     style: FontStyle::Normal,
                 },
-                color: Hsla::default(),
-                background_color: None,
-                underline: None,
-                strikethrough: None,
+                ..Default::default()
             })
             .collect()
     }
@@ -691,16 +686,12 @@ mod tests {
                 font: font("Helvetica"),
                 color: Default::default(),
                 underline: Default::default(),
-                strikethrough: None,
-                background_color: None,
+                ..Default::default()
             };
             let bold = TextRun {
                 len: 0,
                 font: font("Helvetica").bold(),
-                color: Default::default(),
-                underline: Default::default(),
-                strikethrough: None,
-                background_color: None,
+                ..Default::default()
             };
 
             let text = "aa bbb cccc ddddd eeee".into();

--- a/crates/repl/src/outputs/table.rs
+++ b/crates/repl/src/outputs/table.rs
@@ -101,9 +101,7 @@ impl TableView {
             len: 0,
             font: text_font,
             color: text_style.color,
-            background_color: None,
-            underline: None,
-            strikethrough: None,
+            ..Default::default()
         }];
 
         for field in table.schema.fields.iter() {

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -1112,9 +1112,7 @@ impl Element for TerminalElement {
                                 len,
                                 font: text_style.font(),
                                 color: theme.colors().terminal_ansi_background,
-                                background_color: None,
-                                underline: Default::default(),
-                                strikethrough: None,
+                                ..Default::default()
                             }],
                             None,
                         )
@@ -1322,9 +1320,8 @@ impl Element for TerminalElement {
                                         len: text_to_mark.len(),
                                         font: ime_style.font(),
                                         color: ime_style.color,
-                                        background_color: None,
                                         underline: ime_style.underline,
-                                        strikethrough: None,
+                                        ..Default::default()
                                     }],
                                     None
                                 );
@@ -1842,27 +1839,21 @@ mod tests {
             len: 1,
             font: font("Helvetica"),
             color: Hsla::red(),
-            background_color: None,
-            underline: None,
-            strikethrough: None,
+            ..Default::default()
         };
 
         let style2 = TextRun {
             len: 1,
             font: font("Helvetica"),
             color: Hsla::red(),
-            background_color: None,
-            underline: None,
-            strikethrough: None,
+            ..Default::default()
         };
 
         let style3 = TextRun {
             len: 1,
             font: font("Helvetica"),
             color: Hsla::blue(), // Different color
-            background_color: None,
-            underline: None,
-            strikethrough: None,
+            ..Default::default()
         };
 
         let font_size = AbsoluteLength::Pixels(px(12.0));
@@ -1881,9 +1872,7 @@ mod tests {
             len: 1,
             font: font("Helvetica"),
             color: Hsla::red(),
-            background_color: None,
-            underline: None,
-            strikethrough: None,
+            ..Default::default()
         };
 
         let font_size = AbsoluteLength::Pixels(px(12.0));
@@ -1912,9 +1901,7 @@ mod tests {
             len: 1,
             font: font("Helvetica"),
             color: Hsla::red(),
-            background_color: None,
-            underline: None,
-            strikethrough: None,
+            ..Default::default()
         };
 
         let font_size = AbsoluteLength::Pixels(px(12.0));
@@ -1944,9 +1931,7 @@ mod tests {
             len: 1,
             font: font("Helvetica"),
             color: Hsla::red(),
-            background_color: None,
-            underline: None,
-            strikethrough: None,
+            ..Default::default()
         };
 
         let font_size = AbsoluteLength::Pixels(px(12.0));


### PR DESCRIPTION
Release Notes:

- N/A

When I was implementing Input, I often used `TextRun`, but `background`, `underline` and `strikethrough` were often not used. 

So make change to simplify it.

