### PR TITLE
ui_input: Don’t focus previous on decrement in `NumberField`

### DIFF
--- a/crates/ui_input/src/number_field.rs
+++ b/crates/ui_input/src/number_field.rs
@@ -369,7 +369,6 @@ impl<T: NumberFieldType> RenderOnce for NumberField<T> {
                                 let new_value = value.saturating_sub(step);
                                 let new_value = if new_value < min { min } else { new_value };
                                 on_change(&new_value, window, cx);
-                                window.focus_prev();
                             }
                         };
 


### PR DESCRIPTION
This PR removes the behavior that the number_field changes focus to the previous element when using the decrement button.

I mainly noticed this while decreasing the tab-size of a language, since it there closes the page...

Please note that I am unsure what if any purpose this code has.
I was unable to find a use case and since it is not present in the `increment_handler` I guess it should never have been here

---

Release Notes:

* Fixed wrongly focus previous element on number_field decrement