### PR TITLE
Enable `source.organizeImports.ruff` by default for Python

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1772,6 +1772,9 @@
       "allow_rewrap": "anywhere"
     },
     "Python": {
+      "code_actions_on_format": {
+        "source.organizeImports.ruff": true
+      },
       "formatter": {
         "language_server": {
           "name": "ruff"


### PR DESCRIPTION
Release Notes:

- Enabled automatic import organization, via [ruff](https://github.com/astral-sh/ruff), when saving Python files. To disable this, use:

```json
"Python": {
  "code_actions_on_format": { "source.organizeImports.ruff": false }
}
```
