### PR TITLE
markdown: Fix HTML tables with mismatching columns

### DIFF
--- a/crates/markdown_preview/src/markdown_renderer.rs
+++ b/crates/markdown_preview/src/markdown_renderer.rs
@@ -553,6 +553,23 @@ fn render_markdown_table(parsed: &ParsedMarkdownTable, cx: &mut RenderContext) -
 
             col_idx += cell.col_span;
         }
+
+        // Fill remaining columns with empty cells if needed
+        while col_idx < max_column_count {
+            if grid_occupied[row_idx][col_idx] {
+                col_idx += 1;
+                continue;
+            }
+
+            let empty_cell = div()
+                .border_1()
+                .size_full()
+                .border_color(cx.border_color)
+                .when(row_idx % 2 == 1, |this| this.bg(cx.panel_background_color));
+
+            cells.push(empty_cell);
+            col_idx += 1;
+        }
     }
 
     cx.with_common_p(div())


### PR DESCRIPTION
Follow-up: https://github.com/zed-industries/zed/pull/39898

Right now, we don't fill the empty column when the current row count is less than the max row count. This PR fixes that by filling it with an empty cell. So the table columns don't flow in the wrong direction, as you can see inside the first screenshot.

**Before**
<img width="1095" height="182" alt="Screenshot 2025-10-24 at 16 09 02" src="https://github.com/user-attachments/assets/e3abf24e-c190-4bd7-b43a-39f2f01ecd1c" />

**After**
<img width="1165" height="178" alt="Screenshot 2025-10-24 at 16 19 17" src="https://github.com/user-attachments/assets/427c25f9-82a7-498b-a1a2-d71e4c288fe5" />

**Code example**
```html
<table>
    <tr>
        <th rowspan="2">Region</th>
        <th colspan="2">Revenue</th>
        <th rowspan="2">Growth</th>
    </tr>
    <tr>
        <th>Q2 2024</th>
        <th>Q3 2024</th>
    </tr>
    <tr>
        <td>North America</td>
        <td>$2.8M</td>
        <td>$2.4B</td>
        <td>+85,614%</td>
        <td>+99%</td> // extra column here
    </tr>
    <tr>
        <td>Europe</td>
        <td>$1.2M</td>
        <td>$1.9B</td>
        <td>+158,233%</td>
    </tr>
    <tr>
        <td>Asia-Pacific</td>
        <td>$0.5M</td>
        <td>$1.4B</td>
        <td>+279,900%</td>
    </tr>
</table>
```

**Note** there are no release notes, as the previous PR didn't get released yet.

Release Notes:

- N/A
