### PR TITLE
markdown: Add LaTeX syntax highlighting injection

### DIFF
--- a/crates/languages/src/markdown-inline/injections.scm
+++ b/crates/languages/src/markdown-inline/injections.scm
@@ -1,3 +1,2 @@
 ((latex_block) @injection.content
-  (#set! injection.language "latex")
-  (#set! injection.include-children))
+  (#set! injection.language "latex"))

--- a/crates/languages/src/markdown-inline/injections.scm
+++ b/crates/languages/src/markdown-inline/injections.scm
@@ -1,0 +1,3 @@
+((latex_block) @injection.content
+  (#set! injection.language "latex")
+  (#set! injection.include-children))


### PR DESCRIPTION
Closes [#30264](https://github.com/zed-industries/zed/issues/30264)

Small addition based on [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter/blob/main/runtime/queries/markdown_inline/injections.scm)

<img width="1122" height="356" alt="Screenshot From 2025-10-24 15-47-58" src="https://github.com/user-attachments/assets/33e7387d-a299-4921-9db8-622d2657bec1" />

This does require the LaTeX extension to be installed.

Release Notes:

- Provide LaTeX highlighting for inline and display equations in Markdown
