### PR TITLE
Fix include ignored migration rerunning

### DIFF
--- a/crates/migrator/src/migrations/m_2025_10_17/settings.rs
+++ b/crates/migrator/src/migrations/m_2025_10_17/settings.rs
@@ -17,6 +17,7 @@ pub fn make_file_finder_include_ignored_an_enum(value: &mut Value) -> Result<()>
         Value::Bool(true) => Value::String("all".to_string()),
         Value::Bool(false) => Value::String("indexed".to_string()),
         Value::Null => Value::String("smart".to_string()),
+        Value::String(s) if s == "all" || s == "indexed" || s == "smart" => return Ok(()),
         _ => anyhow::bail!("Expected include_ignored to be a boolean or null"),
     };
     Ok(())

--- a/crates/migrator/src/migrator.rs
+++ b/crates/migrator/src/migrator.rs
@@ -366,7 +366,13 @@ mod tests {
     #[track_caller]
     fn assert_migrate_settings(input: &str, output: Option<&str>) {
         let migrated = migrate_settings(input).unwrap();
-        assert_migrated_correctly(migrated, output);
+        assert_migrated_correctly(migrated.clone(), output);
+
+        // expect that rerunning the migration does not result in another migration
+        if let Some(migrated) = migrated {
+            let rerun = migrate_settings(&migrated).unwrap();
+            assert_migrated_correctly(rerun, None);
+        }
     }
 
     #[track_caller]
@@ -376,7 +382,13 @@ mod tests {
         output: Option<&str>,
     ) {
         let migrated = run_migrations(input, migrations).unwrap();
-        assert_migrated_correctly(migrated, output);
+        assert_migrated_correctly(migrated.clone(), output);
+
+        // expect that rerunning the migration does not result in another migration
+        if let Some(migrated) = migrated {
+            let rerun = run_migrations(&migrated, migrations).unwrap();
+            assert_migrated_correctly(rerun, None);
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #ISSUE

Release Notes:

- Fixed an issue where having a correct `file_finder.include_ignored` setting would result in failed to migrate errors
