### PR TITLE
agent: Scale the agent UI and buffer font proportionally

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1059,13 +1059,21 @@ impl AgentPanel {
                     update_settings_file(self.fs.clone(), cx, move |settings, cx| {
                         let agent_ui_font_size =
                             ThemeSettings::get_global(cx).agent_ui_font_size(cx) + delta;
+                        let agent_buffer_font_size =
+                            ThemeSettings::get_global(cx).agent_buffer_font_size(cx) + delta;
+
                         let _ = settings
                             .theme
                             .agent_ui_font_size
                             .insert(theme::clamp_font_size(agent_ui_font_size).into());
+                        let _ = settings
+                            .theme
+                            .agent_buffer_font_size
+                            .insert(theme::clamp_font_size(agent_buffer_font_size).into());
                     });
                 } else {
                     theme::adjust_agent_ui_font_size(cx, |size| size + delta);
+                    theme::adjust_agent_buffer_font_size(cx, |size| size + delta);
                 }
             }
             WhichFontSize::BufferFont => {

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1094,9 +1094,11 @@ impl AgentPanel {
         if action.persist {
             update_settings_file(self.fs.clone(), cx, move |settings, _| {
                 settings.theme.agent_ui_font_size = None;
+                settings.theme.agent_buffer_font_size = None;
             });
         } else {
             theme::reset_agent_ui_font_size(cx);
+            theme::reset_agent_buffer_font_size(cx);
         }
     }
 


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/41094

This PR adds the `agent_buffer_font_size` settings to be scaled in the same proportion as the agent panel's UI font size, which was the only setting that was being accounted for. This is something that I forgot to do when we broke down the agent panel's font size controls into these two values.

Release Notes:

- agent: Fixed an issue where the agent panel's buffer and UI font size wouldn't scale proportionally.
