### PR TITLE
Add `ResetAllZoom` and `ResetAgentZoom ` actions

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -72,7 +72,9 @@ use workspace::{
 };
 use zed_actions::{
     DecreaseBufferFontSize, IncreaseBufferFontSize, ResetBufferFontSize,
-    agent::{OpenAcpOnboardingModal, OpenOnboardingModal, OpenSettings, ResetOnboarding},
+    agent::{
+        OpenAcpOnboardingModal, OpenOnboardingModal, OpenSettings, ResetAgentZoom, ResetOnboarding,
+    },
     assistant::{OpenRulesLibrary, ToggleFocus},
 };
 
@@ -193,6 +195,13 @@ pub fn init(cx: &mut App) {
                 })
                 .register_action(|_workspace, _: &ResetTrialEndUpsell, _window, cx| {
                     TrialEndUpsell::set_dismissed(false, cx);
+                })
+                .register_action(|workspace, _: &ResetAgentZoom, window, cx| {
+                    if let Some(panel) = workspace.panel::<AgentPanel>(cx) {
+                        panel.update(cx, |panel, cx| {
+                            panel.reset_agent_zoom(window, cx);
+                        });
+                    }
                 });
         },
     )
@@ -1090,6 +1099,11 @@ impl AgentPanel {
         } else {
             theme::reset_agent_ui_font_size(cx);
         }
+    }
+
+    pub fn reset_agent_zoom(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
+        theme::reset_agent_ui_font_size(cx);
+        theme::reset_agent_buffer_font_size(cx);
     }
 
     pub fn toggle_zoom(&mut self, _: &ToggleZoom, window: &mut Window, cx: &mut Context<Self>) {

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -870,6 +870,24 @@ fn register_actions(
                 }
             }
         })
+        .register_action({
+            let fs = app_state.fs.clone();
+            move |_, action: &zed_actions::ResetAllZoom, _window, cx| {
+                if action.persist {
+                    update_settings_file(fs.clone(), cx, move |settings, _| {
+                        settings.theme.ui_font_size = None;
+                        settings.theme.buffer_font_size = None;
+                        settings.theme.agent_ui_font_size = None;
+                        settings.theme.agent_buffer_font_size = None;
+                    });
+                } else {
+                    theme::reset_ui_font_size(cx);
+                    theme::reset_buffer_font_size(cx);
+                    theme::reset_agent_ui_font_size(cx);
+                    theme::reset_agent_buffer_font_size(cx);
+                }
+            }
+        })
         .register_action(|_, _: &install_cli::RegisterZedScheme, window, cx| {
             cx.spawn_in(window, async move |workspace, cx| {
                 install_cli::register_zed_scheme(cx).await?;

--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -20,6 +20,10 @@ pub fn app_menus(cx: &mut App) -> Vec<Menu> {
             "Reset Zoom",
             zed_actions::ResetBufferFontSize { persist: false },
         ),
+        MenuItem::action(
+            "Reset All Zoom",
+            zed_actions::ResetAllZoom { persist: false },
+        ),
         MenuItem::separator(),
         MenuItem::action("Toggle Left Dock", workspace::ToggleLeftDock),
         MenuItem::action("Toggle Right Dock", workspace::ToggleRightDock),

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -154,6 +154,15 @@ pub struct ResetUiFontSize {
     pub persist: bool,
 }
 
+/// Resets all zoom levels (UI and buffer font sizes, including in the agent panel) to their default values.
+#[derive(PartialEq, Clone, Default, Debug, Deserialize, JsonSchema, Action)]
+#[action(namespace = zed)]
+#[serde(deny_unknown_fields)]
+pub struct ResetAllZoom {
+    #[serde(default)]
+    pub persist: bool,
+}
+
 pub mod dev {
     use gpui::actions;
 
@@ -311,6 +320,8 @@ pub mod agent {
             /// Add the current selection as context for threads in the agent panel.
             #[action(deprecated_aliases = ["assistant::QuoteSelection", "agent::QuoteSelection"])]
             AddSelectionToThread,
+            /// Resets the agent panel zoom levels (agent UI and buffer font sizes).
+            ResetAgentZoom,
         ]
     );
 }


### PR DESCRIPTION
Very often, when I'm testing or playing around with the zoom feature, including the agent panel, I find myself missing one quick action that would bring everything back to normal. That's what `ResetAllZoom` does. If you have customized your zoom level in all areas of Zed, that action returns everything to its default state. Similarly, if you're playing around with zoom just in the agent panel, `ResetAgentZoom` does the same in that context.

Release Notes:

- Added the `ResetAllZoom` and `ResetAgentZoom ` actions, allowing to return the zoom level across the whole app and/or just in the agent panel to its default/original value.
