### PR TITLE
agent: Add save to markdown button for AI responses

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -71,7 +71,7 @@ impl UserMessage {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct AssistantMessage {
     pub chunks: Vec<AssistantMessageChunk>,
 }
@@ -86,9 +86,21 @@ impl AssistantMessage {
                 .join("\n\n")
         )
     }
+
+    pub fn to_markdown_without_thoughts(&self, cx: &App) -> String {
+        self.chunks
+            .iter()
+            .filter_map(|chunk| match chunk {
+                AssistantMessageChunk::Message { block } => {
+                    Some(block.to_markdown(cx).to_string())
+                }
+                AssistantMessageChunk::Thought { .. } => None,
+            })
+            .join("\n\n")
+    }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum AssistantMessageChunk {
     Message { block: ContentBlock },
     Thought { block: ContentBlock },


### PR DESCRIPTION
Add a hover-revealed download button after each assistant message that allows saving the response to a markdown file.

- Add Clone derive to AssistantMessage and related types
- Implement to_markdown_without_thoughts to export responses without thinking blocks
- Add save_assistant_message_to_file method with file picker dialog
- Auto-append .md extension if not provided using Cow for efficiency
- Show save button only on message hover using VisibleOnHover trait

