### PR TITLE
Do not report the itemDefaults LSP capability

### DIFF
--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -780,13 +780,7 @@ impl LanguageServer {
                         }),
                         insert_text_mode: Some(InsertTextMode::ADJUST_INDENTATION),
                         completion_list: Some(CompletionListCapability {
-                            item_defaults: Some(vec![
-                                "commitCharacters".to_owned(),
-                                "editRange".to_owned(),
-                                "insertTextMode".to_owned(),
-                                "insertTextFormat".to_owned(),
-                                "data".to_owned(),
-                            ]),
+                            item_defaults: None,
                         }),
                         context_support: Some(true),
                         dynamic_registration: Some(true),


### PR DESCRIPTION
Closes https://github.com/zed-extensions/java/issues/101
This is a fix for an issue I encountered with JDTLS, but it turns out it might actually be a Zed issue at heart.
 
[This field of CompletionItem from the LSP spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#:~:text=/**%0A%09%20*%20The%20edit%20text,%3F%3A%20string%3B) does not exist within [Zed's lsp-types CompletionItem](https://github.com/zed-industries/lsp-types/blob/14af3dbeb635ff83606c4e0d9316460d7978f58f/src/completion.rs#L420). The spec suggests that itemDefaults capability implies honoring this field, but at the moment Zed does not. This causes issues with completions for JDTLS, and I imagine other language servers that make use of this capability, too. 
This PR simply removes reporting that capability in the default `initialize` request to language servers, until proper support for this feature is implemented within Zed. 
For some reference on the specifics, have a look at [this issue from the Java Extension](https://github.com/zed-extensions/java/issues/101).

Release Notes:

- N/A
