### PR TITLE
Avoid menu clipping with debugger welcome panel on resize

### DIFF
--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -1774,6 +1774,7 @@ impl Render for DebugPanel {
                     this.child(
                         v_flex()
                             .size_full()
+                            .overflow_hidden()
                             .gap_1()
                             .items_center()
                             .justify_center()


### PR DESCRIPTION
Before:
<img width="1345" height="58" alt="before" src="https://github.com/user-attachments/assets/cba79bba-6437-47fd-ad2b-b4ceaf03ef5d" />

After:
<img width="1756" height="90" alt="after" src="https://github.com/user-attachments/assets/3442c7f6-a4dc-4c4c-92c5-2ca5ad9beb0d" />


Release Notes:

- N/A
