### PR TITLE
Add buffer_search_deployed key context

### DIFF
--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -468,6 +468,12 @@ impl Focusable for BufferSearchBar {
 }
 
 impl ToolbarItemView for BufferSearchBar {
+    fn contribute_context(&self, context: &mut KeyContext, _cx: &App) {
+        if !self.dismissed {
+            context.add("buffer_search_deployed");
+        }
+    }
+
     fn set_active_pane_item(
         &mut self,
         item: Option<&dyn ItemHandle>,

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -3677,6 +3677,10 @@ impl Render for Pane {
             key_context.add("EmptyPane");
         }
 
+        self.toolbar
+            .read(cx)
+            .contribute_context(&mut key_context, cx);
+
         let should_display_tab_bar = self.should_display_tab_bar.clone();
         let display_tab_bar = should_display_tab_bar(window, cx);
         let Some(project) = self.project.upgrade() else {


### PR DESCRIPTION
Release Notes:

- Pane key context now includes 'buffer_search_deployed' identifier

The goal of this PR is to add a new identifier in the key context that will let the user target when the BufferSearchBar is deployed even if they are not focused on it.

requested in #36930

Same rational as #40454 this will allow users to make more flexible keybindings, by including some additional information higher up the key context tree.

i thought adding this context to `Pane` seemed more appropriate  than `Editor` since `Terminal` also has a `BufferSearchBar`; however, I ran into some import issues between BufferSearchBar, Search, Pane, and Workspace which made it difficult to implement adding this context directly inside `Pane`'s  render function.

instead i added a new method called `contributes_context` to `ToolbarItem` which will allow any toolbar item to add additional context to the `Pane` level, which feels like it might come in handy. 

here are some screen shots of the context being displayed in the Editor and the Terminal

<img width="1653" height="1051" alt="Screenshot 2025-10-25 at 14 34 03" src="https://github.com/user-attachments/assets/21c5b07a-8d36-4e0b-ad09-378b12d2ea38" />

<img width="1444" height="1167" alt="Screenshot 2025-10-25 at 12 32 21" src="https://github.com/user-attachments/assets/86afe72f-b238-43cd-8230-9cb59fb93b2c" />
