### PR TITLE
Fix dismissal of language server notifications

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -2074,7 +2074,7 @@
     // Whether to show the LSP servers button in the status bar.
     "button": true,
     "notifications": {
-      // Wether to automatically dismiss language server notifications.
+      // Whether to automatically dismiss language server notifications.
       "auto_dismiss": "always"
     }
   },

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -2072,7 +2072,11 @@
   // Common language server settings.
   "global_lsp_settings": {
     // Whether to show the LSP servers button in the status bar.
-    "button": true
+    "button": true,
+    "notifications": {
+      // Wether to automatically dismiss language server notifications.
+      "auto_dismiss": "always"
+    }
   },
   // Jupyter settings
   "jupyter": {

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -140,6 +140,7 @@ const SERVER_LAUNCHING_BEFORE_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5
 pub const SERVER_PROGRESS_THROTTLE_TIMEOUT: Duration = Duration::from_millis(100);
 const WORKSPACE_DIAGNOSTICS_TOKEN_START: &str = "id:";
 const SERVER_DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(10);
+static NEXT_PROMPT_REQUEST_ID: AtomicUsize = AtomicUsize::new(0);
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 pub enum ProgressToken {
@@ -13194,7 +13195,7 @@ struct LspBufferSnapshot {
 /// A prompt requested by LSP server.
 #[derive(Clone, Debug)]
 pub struct LanguageServerPromptRequest {
-    pub id: u64,
+    pub id: usize,
     pub level: PromptLevel,
     pub message: String,
     pub actions: Vec<MessageActionItem>,
@@ -13210,7 +13211,7 @@ impl LanguageServerPromptRequest {
         lsp_name: String,
         response_channel: Sender<MessageActionItem>,
     ) -> Self {
-        let id = rand::random::<u64>();
+        let id = NEXT_PROMPT_REQUEST_ID.fetch_add(1, atomic::Ordering::AcqRel);
         LanguageServerPromptRequest {
             id,
             level,

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -1,5 +1,4 @@
-//! LSP store provides unified access to the language server protocol.
-//! The consumers of LSP store can interact with language servers without knowing exactly which language server they're interacting with.
+//! LSP store provides unified access to the language server protocol. //! The consumers of LSP store can interact with language servers without knowing exactly which language server they're interacting with.
 //!
 //! # Local/Remote LSP Stores
 //! This module is split up into three distinct parts:
@@ -13210,6 +13209,23 @@ impl LanguageServerPromptRequest {
             self.response_channel.send(response).await.ok()
         } else {
             None
+        }
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn test(
+        level: PromptLevel,
+        message: String,
+        actions: Vec<MessageActionItem>,
+        lsp_name: String,
+    ) -> Self {
+        let (tx, _rx) = smol::channel::unbounded();
+        Self {
+            level,
+            message,
+            actions,
+            lsp_name,
+            response_channel: tx,
         }
     }
 }

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -1,4 +1,5 @@
-//! LSP store provides unified access to the language server protocol. //! The consumers of LSP store can interact with language servers without knowing exactly which language server they're interacting with.
+//! LSP store provides unified access to the language server protocol.
+//! The consumers of LSP store can interact with language servers without knowing exactly which language server they're interacting with.
 //!
 //! # Local/Remote LSP Stores
 //! This module is split up into three distinct parts:

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -4662,13 +4662,15 @@ impl Project {
             })
             .collect();
         this.update(&mut cx, |_, cx| {
-            cx.emit(Event::LanguageServerPrompt(LanguageServerPromptRequest {
-                level: proto_to_prompt(envelope.payload.level.context("Invalid prompt level")?),
-                message: envelope.payload.message,
-                actions: actions.clone(),
-                lsp_name: envelope.payload.lsp_name,
-                response_channel: tx,
-            }));
+            cx.emit(Event::LanguageServerPrompt(
+                LanguageServerPromptRequest::new(
+                    proto_to_prompt(envelope.payload.level.context("Invalid prompt level")?),
+                    envelope.payload.message,
+                    actions.clone(),
+                    envelope.payload.lsp_name,
+                    tx,
+                ),
+            ));
 
             anyhow::Ok(())
         })??;

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -20,8 +20,9 @@ use serde::{Deserialize, Serialize};
 pub use settings::DirenvSettings;
 pub use settings::LspSettings;
 use settings::{
-    DapSettingsContent, InvalidSettingsError, LocalSettingsKind, RegisterSetting, Settings,
-    SettingsLocation, SettingsStore, parse_json_with_comments, watch_config_file,
+    DapSettingsContent, InvalidSettingsError, LocalSettingsKind, NotificationAutoDismissalSetting,
+    RegisterSetting, Settings, SettingsLocation, SettingsStore, parse_json_with_comments,
+    watch_config_file,
 };
 use std::{path::PathBuf, sync::Arc, time::Duration};
 use task::{DebugTaskFile, TaskTemplates, VsCodeDebugTaskFile, VsCodeTaskFile};
@@ -112,6 +113,16 @@ pub struct GlobalLspSettings {
     ///
     /// Default: `true`
     pub button: bool,
+    pub notifications: LspNotificationSettings,
+}
+
+#[derive(Deserialize, Serialize, Clone, PartialEq, Eq, JsonSchema, Debug)]
+#[serde(tag = "source", rename_all = "snake_case")]
+pub struct LspNotificationSettings {
+    /// Whether to automatically dismiss notifications for language servers.
+    ///
+    /// Default: `Always`
+    pub auto_dismiss: NotificationAutoDismissalSetting,
 }
 
 #[derive(Deserialize, Serialize, Clone, PartialEq, Eq, JsonSchema, Debug)]
@@ -543,6 +554,16 @@ impl Settings for ProjectSettings {
                     .unwrap()
                     .button
                     .unwrap(),
+                notifications: LspNotificationSettings {
+                    auto_dismiss: content
+                        .global_lsp_settings
+                        .as_ref()
+                        .unwrap()
+                        .notifications
+                        .as_ref()
+                        .unwrap()
+                        .auto_dismiss,
+                },
             },
             dap: project
                 .dap

--- a/crates/settings/src/settings_content/project.rs
+++ b/crates/settings/src/settings_content/project.rs
@@ -179,6 +179,7 @@ pub struct LspNotificationSettingsContent {
 
 #[with_fallible_options]
 #[derive(Debug, Copy, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema, MergeFrom)]
+#[serde(rename_all = "snake_case")]
 pub enum NotificationAutoDismissalSetting {
     /// Automatically dismiss notifications.
     #[default]

--- a/crates/settings/src/settings_content/project.rs
+++ b/crates/settings/src/settings_content/project.rs
@@ -172,13 +172,15 @@ pub struct GlobalLspSettingsContent {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, MergeFrom)]
 pub struct LspNotificationSettingsContent {
     /// Whether to automatically dismiss notifications for language servers.
-    /// 
+    ///
     /// Default: `Always`
-    pub auto_dismiss: NotificationAutoDismissalSetting
+    pub auto_dismiss: NotificationAutoDismissalSetting,
 }
 
 #[with_fallible_options]
-#[derive(Debug, Copy, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema, MergeFrom)]
+#[derive(
+    Debug, Copy, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema, MergeFrom,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum NotificationAutoDismissalSetting {
     /// Automatically dismiss notifications.
@@ -187,7 +189,7 @@ pub enum NotificationAutoDismissalSetting {
     /// Never dismiss notifications automatically.
     Never,
     /// Dismiss notifications automatically after a certain amount of time.
-    After(u64)
+    After(u64),
 }
 
 #[with_fallible_options]

--- a/crates/settings/src/settings_content/project.rs
+++ b/crates/settings/src/settings_content/project.rs
@@ -164,6 +164,29 @@ pub struct GlobalLspSettingsContent {
     ///
     /// Default: `true`
     pub button: Option<bool>,
+    /// Settings for language server notifications
+    pub notifications: Option<LspNotificationSettingsContent>,
+}
+
+#[with_fallible_options]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, MergeFrom)]
+pub struct LspNotificationSettingsContent {
+    /// Whether to automatically dismiss notifications for language servers.
+    /// 
+    /// Default: `Always`
+    pub auto_dismiss: NotificationAutoDismissalSetting
+}
+
+#[with_fallible_options]
+#[derive(Debug, Copy, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema, MergeFrom)]
+pub enum NotificationAutoDismissalSetting {
+    /// Automatically dismiss notifications.
+    #[default]
+    Always,
+    /// Never dismiss notifications automatically.
+    Never,
+    /// Dismiss notifications automatically after a certain amount of time.
+    After(u64)
 }
 
 #[with_fallible_options]

--- a/crates/workspace/src/notifications.rs
+++ b/crates/workspace/src/notifications.rs
@@ -104,7 +104,7 @@ impl Workspace {
                     .read(cx)
                     .request
                     .as_ref()
-                    .map_or(false, |r| r.actions.is_empty())
+                    .is_some_and(|request| request.actions.is_empty())
                 {
                     let task = cx.spawn({
                         let id = id.clone();

--- a/crates/workspace/src/notifications.rs
+++ b/crates/workspace/src/notifications.rs
@@ -291,13 +291,10 @@ impl LanguageServerPrompt {
     }
 
     fn dismiss_notification(&mut self, cx: &mut Context<Self>) {
-        self.cancel_dismiss_task();
+        self.dismiss_task = None;
         cx.emit(DismissEvent);
     }
 
-    fn cancel_dismiss_task(&mut self) {
-        self.dismiss_task = None;
-    }
 }
 
 impl Render for LanguageServerPrompt {
@@ -380,8 +377,7 @@ impl Render for LanguageServerPrompt {
                                                     if suppress {
                                                         cx.emit(SuppressEvent);
                                                     } else {
-                                                        this.cancel_dismiss_task();
-                                                        cx.emit(DismissEvent);
+                                                        this.dismiss_notification(cx);
                                                     }
                                                 },
                                             )),

--- a/crates/workspace/src/notifications.rs
+++ b/crates/workspace/src/notifications.rs
@@ -1226,24 +1226,24 @@ mod tests {
             workspace.read_with(cx, |workspace, _| workspace.notification_ids().len())
         };
 
-        let show_notification =
-            |lsp_name: &str, workspace: &Entity<Workspace>, cx: &mut TestAppContext| {
-                workspace.update(cx, |workspace, cx| {
-                    let lsp_name = lsp_name.to_string();
-                    let request = LanguageServerPromptRequest::test(
-                        gpui::PromptLevel::Warning,
-                        "Test notification".to_string(),
-                        vec![], // Empty actions triggers auto-dismiss
-                        lsp_name,
-                    );
-                    let notification_id =
-                        NotificationId::composite::<LanguageServerPrompt>(request.id as usize);
+        let show_notification = |lsp_name: &str,
+                                 workspace: &Entity<Workspace>,
+                                 cx: &mut TestAppContext| {
+            workspace.update(cx, |workspace, cx| {
+                let lsp_name = lsp_name.to_string();
+                let request = LanguageServerPromptRequest::test(
+                    gpui::PromptLevel::Warning,
+                    "Test notification".to_string(),
+                    vec![], // Empty actions triggers auto-dismiss
+                    lsp_name,
+                );
+                let notification_id = NotificationId::composite::<LanguageServerPrompt>(request.id);
 
-                    workspace.show_notification(notification_id, cx, |cx| {
-                        cx.new(|cx| LanguageServerPrompt::new(request, cx))
-                    });
-                })
-            };
+                workspace.show_notification(notification_id, cx, |cx| {
+                    cx.new(|cx| LanguageServerPrompt::new(request, cx))
+                });
+            })
+        };
 
         show_notification(lsp_name, &workspace, cx);
         assert_eq!(count_notifications(&workspace, cx), 1);

--- a/crates/workspace/src/notifications.rs
+++ b/crates/workspace/src/notifications.rs
@@ -13,6 +13,8 @@ use std::{any::TypeId, time::Duration};
 use ui::{Tooltip, prelude::*};
 use util::ResultExt;
 
+const NOTIFICATION_AUTO_DISMISS_DURATION: Duration = Duration::from_millis(5000);
+
 #[derive(Default)]
 pub struct Notifications {
     notifications: Vec<(NotificationId, AnyView)>,
@@ -109,7 +111,7 @@ impl Workspace {
                     let task = cx.spawn({
                         let id = id.clone();
                         async move |this, cx| {
-                            gpui::Timer::after(Duration::from_secs(5)).await;
+                            cx.background_executor().timer(NOTIFICATION_AUTO_DISMISS_DURATION).await;
                             let _ = this.update(cx, |workspace, cx| {
                                 workspace.dismiss_notification(&id, cx);
                             });
@@ -195,7 +197,7 @@ impl Workspace {
         if toast.autohide {
             cx.spawn(async move |workspace, cx| {
                 cx.background_executor()
-                    .timer(Duration::from_millis(5000))
+                    .timer(NOTIFICATION_AUTO_DISMISS_DURATION)
                     .await;
                 workspace
                     .update(cx, |workspace, cx| workspace.dismiss_toast(&toast.id, cx))

--- a/crates/workspace/src/notifications.rs
+++ b/crates/workspace/src/notifications.rs
@@ -109,7 +109,7 @@ impl Workspace {
                     let task = cx.spawn({
                         let id = id.clone();
                         async move |this, cx| {
-                            cx.background_executor().timer(Duration::from_secs(5)).await;
+                            gpui::Timer::after(Duration::from_secs(5)).await;
                             let _ = this.update(cx, |workspace, cx| {
                                 workspace.dismiss_notification(&id, cx);
                             });

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -96,9 +96,9 @@ use std::{
     borrow::Cow,
     cell::RefCell,
     cmp,
-    collections::{VecDeque, hash_map::DefaultHasher},
+    collections::VecDeque,
     env,
-    hash::{Hash, Hasher},
+    hash::Hash,
     path::{Path, PathBuf},
     process::ExitStatus,
     rc::Rc,
@@ -1260,12 +1260,8 @@ impl Workspace {
                 project::Event::LanguageServerPrompt(request) => {
                     struct LanguageServerPrompt;
 
-                    let mut hasher = DefaultHasher::new();
-                    request.lsp_name.as_str().hash(&mut hasher);
-                    let id = hasher.finish();
-
                     this.show_notification(
-                        NotificationId::composite::<LanguageServerPrompt>(id as usize),
+                        NotificationId::composite::<LanguageServerPrompt>(request.id as usize),
                         cx,
                         |cx| {
                             cx.new(|cx| {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1261,7 +1261,7 @@ impl Workspace {
                     struct LanguageServerPrompt;
 
                     this.show_notification(
-                        NotificationId::composite::<LanguageServerPrompt>(request.id as usize),
+                        NotificationId::composite::<LanguageServerPrompt>(request.id),
                         cx,
                         |cx| {
                             cx.new(|cx| {


### PR DESCRIPTION
Closes #38769

This is my second attempt at this, this time building on the suggestions by @SomeoneToIgnore (which can be found [here](https://github.com/zed-industries/zed/pull/39535#pullrequestreview-3316127584)).

The idea is that when a notification is shown to the user, and if this notification does not require input from the user, to start a timer and send a dismisssal event when the timer finishes.

I also took care of cancelling the dismissal task in case the user manually closes the notification.

There is no test, but I would be happy to add one if you consider this approach viable.

Release Notes:

- Fixes a bug where notifications from language servers are not closed.
