### PR TITLE
gpui: Implement trackpad pinch-to-zoom on macOS

### DIFF
--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -322,7 +322,7 @@ impl Interactivity {
     }
 
     /// Bind the given callback to zoom events (e.g. from pinch-to-zoom) during the bubble phase.
-    /// The imperative API equivalent to [`InteractiveElement::on_scroll_wheel`].
+    /// The imperative API equivalent to [`InteractiveElement::on_zoom`].
     ///
     /// See [`Context::listener`](crate::Context::listener) to get access to a view's state from this callback.
     pub fn on_zoom(&mut self, listener: impl Fn(&ZoomEvent, &mut Window, &mut App) + 'static) {
@@ -849,7 +849,7 @@ pub trait InteractiveElement: Sized {
     }
 
     /// Bind the given callback to zoom events (e.g. from pinch-to-zoom) during the bubble phase.
-    /// The fluent API equivalent to [`Interactivity::on_scroll_wheel`].
+    /// The fluent API equivalent to [`Interactivity::on_zoom`].
     ///
     /// See [`Context::listener`](crate::Context::listener) to get access to a view's state from this callback.
     fn on_zoom(mut self, listener: impl Fn(&ZoomEvent, &mut Window, &mut App) + 'static) -> Self {

--- a/crates/gpui/src/interactive.rs
+++ b/crates/gpui/src/interactive.rs
@@ -465,6 +465,55 @@ impl ScrollDelta {
     }
 }
 
+/// A zoom event from the platform (e.g. pinch-to-zoom).
+#[derive(Clone, Debug, Default)]
+pub struct ZoomEvent {
+    /// The position of the mouse on the window.
+    pub position: Point<Pixels>,
+
+    /// The change in zoom amount for this event.
+    pub delta: ZoomDelta,
+
+    /// The modifiers that were held down when the zoom amount changed.
+    pub modifiers: Modifiers,
+
+    /// The phase of the touch event.
+    pub touch_phase: TouchPhase,
+}
+
+impl Sealed for ZoomEvent {}
+impl InputEvent for ZoomEvent {
+    fn to_platform_input(self) -> PlatformInput {
+        PlatformInput::Zoom(self)
+    }
+}
+impl MouseEvent for ZoomEvent {}
+
+impl Deref for ZoomEvent {
+    type Target = Modifiers;
+
+    fn deref(&self) -> &Self::Target {
+        &self.modifiers
+    }
+}
+
+/// The zoom delta for a zoom event.
+///
+/// Marked non-exhaustive until pinch-to-zoom is implemented for Windows/Linux, which
+/// may represent zoom amount with a pixel distance instead.
+#[derive(Clone, Copy, Debug)]
+#[non_exhaustive]
+pub enum ZoomDelta {
+    /// How much the zoom amount (1 = no zoom) would change.
+    ZoomAmount(f32),
+}
+
+impl Default for ZoomDelta {
+    fn default() -> Self {
+        Self::ZoomAmount(Default::default())
+    }
+}
+
 /// A mouse exit event from the platform, generated when the mouse leaves the window.
 #[derive(Clone, Debug, Default)]
 pub struct MouseExitEvent {
@@ -561,6 +610,8 @@ pub enum PlatformInput {
     MouseExited(MouseExitEvent),
     /// The scroll wheel was used.
     ScrollWheel(ScrollWheelEvent),
+    /// The window was zoomed in or out (e.g. with pinch-to-zoom).
+    Zoom(ZoomEvent),
     /// Files were dragged and dropped onto the window.
     FileDrop(FileDropEvent),
 }
@@ -576,6 +627,7 @@ impl PlatformInput {
             PlatformInput::MouseMove(event) => Some(event),
             PlatformInput::MouseExited(event) => Some(event),
             PlatformInput::ScrollWheel(event) => Some(event),
+            PlatformInput::Zoom(event) => Some(event),
             PlatformInput::FileDrop(event) => Some(event),
         }
     }
@@ -590,6 +642,7 @@ impl PlatformInput {
             PlatformInput::MouseMove(_) => None,
             PlatformInput::MouseExited(_) => None,
             PlatformInput::ScrollWheel(_) => None,
+            PlatformInput::Zoom(_) => None,
             PlatformInput::FileDrop(_) => None,
         }
     }

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -170,6 +170,10 @@ unsafe fn build_classes() {
                     handle_view_event as extern "C" fn(&Object, Sel, id),
                 );
                 decl.add_method(
+                    sel!(magnifyWithEvent:),
+                    handle_view_event as extern "C" fn(&Object, Sel, id),
+                );
+                decl.add_method(
                     sel!(flagsChanged:),
                     handle_view_event as extern "C" fn(&Object, Sel, id),
                 );


### PR DESCRIPTION
Implements trackpad pinch-to-zoom on macOS. Windows and Linux should be straightforward but I don't have requisite test devices with me right now.

* All behavior tested on macOS. Does not cause any issues with existing scroll handling.
* Follows the same propagation and blocking behavior as scroll events. Documentation has been updated accordingly.
* I considered integrating into the scroll system, similar to what JavaScript does, but using a separate event is both more logical (the events are separate on every platform) and more backwards-compatible.
* The `ZoomDelta` is temporarily tagged `#[non_exhaustive]` because implementations on future platforms might handle zoom deltas differently from macOS (e.g. pixel distance instead of a magnification change). Consumers of this API can just have a `_ => {}` match arm, which worst-case means their apps will continue to not have zoom functionality on Windows/Linux without intervention.

Release Notes:

- N/A
