### PR TITLE
agent_ui: Trim editor text before processing

### DIFF
--- a/crates/agent_ui/src/acp/message_editor.rs
+++ b/crates/agent_ui/src/acp/message_editor.rs
@@ -704,7 +704,8 @@ impl MessageEditor {
             let result = editor.update(cx, |editor, cx| {
                 let mut ix = 0;
                 let mut chunks: Vec<acp::ContentBlock> = Vec::new();
-                let text = editor.text(cx);
+                let editor_text = editor.text(cx);
+                let text = editor_text.trim().to_string();
                 editor.display_map.update(cx, |map, cx| {
                     let snapshot = map.snapshot(cx);
                     for (crease_id, crease) in snapshot.crease_snapshot.creases() {


### PR DESCRIPTION
This change fixes #41017 by trimming the editor text before processing.

## Screenshots
Previous Behaviour
<img width="625" height="386" alt="image" src="https://github.com/user-attachments/assets/8149355f-0a98-44c7-b100-712bea88f7d1" />

New Behaviour
<img width="633" height="293" alt="image" src="https://github.com/user-attachments/assets/3c1d95b8-f883-4023-9f5d-3eff52503809" />



Closes #41017 

Release Notes:

- Fixes the message in the Agent Panel by trimming the leading and trailing whitespace.
