### PR TITLE
editor: Use a single newline between each copied line from a multi-cursor selection

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -12633,7 +12633,7 @@ impl Editor {
                 for trimmed_range in trimmed_selections {
                     if is_first {
                         is_first = false;
-                    } else {
+                    } else if !is_entire_line {
                         text += "\n";
                     }
                     let mut len = 0;

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -12641,9 +12641,12 @@ impl Editor {
                         text.push_str(chunk);
                         len += chunk.len();
                     }
-                    if add_trailing_newline {
+                    if is_entire_line {
+                        len -= 1;
+                    }
+                    if is_entire_line && add_trailing_newline {
                         text.push('\n');
-                        len += 1;
+                        len += 2;
                     }
                     clipboard_selections.push(ClipboardSelection {
                         len,

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -26992,19 +26992,36 @@ async fn test_multi_selection_copy_with_newline_between_copied_lines(cx: &mut Te
 
     let mut cx = EditorTestContext::new(cx).await;
 
-    cx.set_state("line1\nline2\nline3\nˇ");
-
-    cx.update_editor(|e, window, cx| {
-        e.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
-            s.select_display_ranges([
-                DisplayPoint::new(DisplayRow(0), 0)..DisplayPoint::new(DisplayRow(0), 0),
-                DisplayPoint::new(DisplayRow(1), 0)..DisplayPoint::new(DisplayRow(1), 0),
-                DisplayPoint::new(DisplayRow(2), 0)..DisplayPoint::new(DisplayRow(2), 0),
-            ]);
-        });
-    });
+    cx.set_state("ˇline1\nˇline2\nˇline3\n");
 
     cx.update_editor(|e, window, cx| e.copy(&Copy, window, cx));
+
+    let clipboard_text = cx
+        .read_from_clipboard()
+        .and_then(|item| item.text().as_deref().map(str::to_string));
+
+    assert_eq!(
+        clipboard_text,
+        Some("line1\nline2\nline3\n".to_string()),
+        "Copying multiple lines should include a single newline between lines"
+    );
+
+    cx.set_state("lineA\nˇ");
+
+    cx.update_editor(|e, window, cx| e.paste(&Paste, window, cx));
+
+    cx.assert_editor_state("lineA\nline1\nline2\nline3\nˇ");
+}
+
+#[gpui::test]
+async fn test_multi_selection_cut_with_newline_between_copied_lines(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+
+    cx.set_state("ˇline1\nˇline2\nˇline3\n");
+
+    cx.update_editor(|e, window, cx| e.cut(&Cut, window, cx));
 
     let clipboard_text = cx
         .read_from_clipboard()


### PR DESCRIPTION
Closes #40923

Release Notes:

- Fixed the amount of newlines between copied lines from a multi-cursor selection of multiple full-line copies.

---

https://github.com/user-attachments/assets/ab7474d6-0e49-4c29-9700-7692cd019cef

