### PR TITLE
settings_ui: Fix tabbing in settings UI main page content

### DIFF
--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -2732,8 +2732,11 @@ impl SettingsWindow {
                         this.list_state.scroll_to_reveal_item(next_logical_index);
                         // We need to render the next item to ensure it's focus handle is in the element tree
                         cx.on_next_frame(window, |_, window, cx| {
-                            window.focus_next();
                             cx.notify();
+                            cx.on_next_frame(window, |_, window, cx| {
+                                window.focus_next();
+                                cx.notify();
+                            });
                         });
                         cx.notify();
                         return;
@@ -2761,8 +2764,11 @@ impl SettingsWindow {
                         this.list_state.scroll_to_reveal_item(next_logical_index);
                         // We need to render the next item to ensure it's focus handle is in the element tree
                         cx.on_next_frame(window, |_, window, cx| {
-                            window.focus_prev();
                             cx.notify();
+                            cx.on_next_frame(window, |_, window, cx| {
+                                window.focus_prev();
+                                cx.notify();
+                            });
                         });
                         cx.notify();
                         return;


### PR DESCRIPTION
Tabbing into the main page would move focus to the navigation panel instead of auto-scrolling. This PR fixes that bug.


Release Notes:

- N/A 
