### PR TITLE
gpui: Fix `TextLayout::layout` producing invalid text runs

### DIFF
--- a/crates/gpui/src/elements/text.rs
+++ b/crates/gpui/src/elements/text.rs
@@ -339,7 +339,6 @@ impl TextLayout {
         } else {
             vec![text_style.to_run(text.len())]
         };
-
         window.request_measured_layout(Default::default(), {
             let element_state = self.clone();
 

--- a/crates/gpui/src/elements/text.rs
+++ b/crates/gpui/src/elements/text.rs
@@ -8,6 +8,7 @@ use crate::{
 use anyhow::Context as _;
 use smallvec::SmallVec;
 use std::{
+    borrow::Cow,
     cell::{Cell, RefCell},
     mem,
     ops::Range,
@@ -334,7 +335,7 @@ impl TextLayout {
             .line_height
             .to_pixels(font_size.into(), window.rem_size());
 
-        let mut runs = if let Some(runs) = runs {
+        let runs = if let Some(runs) = runs {
             runs
         } else {
             vec![text_style.to_run(text.len())]
@@ -377,15 +378,15 @@ impl TextLayout {
                 }
 
                 let mut line_wrapper = cx.text_system().line_wrapper(text_style.font(), font_size);
-                let text = if let Some(truncate_width) = truncate_width {
+                let (text, runs) = if let Some(truncate_width) = truncate_width {
                     line_wrapper.truncate_line(
                         text.clone(),
                         truncate_width,
                         &truncation_suffix,
-                        &mut runs,
+                        &runs,
                     )
                 } else {
-                    text.clone()
+                    (text.clone(), Cow::Borrowed(&*runs))
                 };
                 let len = text.len();
 

--- a/crates/gpui/src/styled.rs
+++ b/crates/gpui/src/styled.rs
@@ -9,7 +9,6 @@ pub use gpui_macros::{
     overflow_style_methods, padding_style_methods, position_style_methods,
     visibility_style_methods,
 };
-
 const ELLIPSIS: SharedString = SharedString::new_static("…");
 
 /// A trait for elements that can be styled.

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -3255,14 +3255,11 @@ impl Window {
     /// returns a `Size`.
     ///
     /// This method should only be called as part of the request_layout or prepaint phase of element drawing.
-    pub fn request_measured_layout<
-        F: FnMut(Size<Option<Pixels>>, Size<AvailableSpace>, &mut Window, &mut App) -> Size<Pixels>
+    pub fn request_measured_layout<F>(&mut self, style: Style, measure: F) -> LayoutId
+    where
+        F: Fn(Size<Option<Pixels>>, Size<AvailableSpace>, &mut Window, &mut App) -> Size<Pixels>
             + 'static,
-    >(
-        &mut self,
-        style: Style,
-        measure: F,
-    ) -> LayoutId {
+    {
         self.invalidator.debug_assert_prepaint();
 
         let rem_size = self.rem_size();


### PR DESCRIPTION
The issues is that the closure supplied to `request_measured_layout` could be run multiple times with differing `known_dimensions`. This in turn will mean we truncate the font runs once, inserting a multibyte char at the end but then in the next iteration use those truncated runs for possibly the original untruncated string which has multibyte characters overlapping the now truncated run end resulting in a faulty utf8 boundary index.

Solution to this is simple, truncate a clone of the runs when needed instead of modifying the original.

Fixes https://github.com/zed-industries/zed/issues/36925
Fixed ZED-2FF
Fixes ZED-2KM
Fixes ZED-2KK
Fixes ZED-1FF
Fixes ZED-255
Fixes ZED-2JD
Fixes ZED-2FX
Fixes ZED-2K2
Fixes ZED-2JX
Fixes ZED-2GE
Fixes ZED-2FC
Fixes ZED-2GD
Fixes ZED-2HY
Fixes ZED-2HR
Fixes ZED-2FN
Fixes ZED-2GT
Fixes ZED-2FK
Fixes ZED-2EY
Fixes ZED-27E
Fixes ZED-272
Fixes ZED-2EM
Fixes ZED-2CC
Fixes ZED-29V
Fixes ZED-25B
Fixes ZED-257
Fixes ZED-24R
Fixes ZED-24Q
Fixes ZED-23Z
Fixes ZED-227

Release Notes:

- Fixed a crash in text shaping when truncating rendered text
