### PR TITLE
agent: Clarify `include_pattern` parameter usage for grep tool

### DIFF
--- a/crates/agent/src/tools/grep_tool.rs
+++ b/crates/agent/src/tools/grep_tool.rs
@@ -32,8 +32,21 @@ pub struct GrepToolInput {
     /// Do NOT specify a path here! This will only be matched against the code **content**.
     pub regex: String,
     /// A glob pattern for the paths of files to include in the search.
-    /// Supports standard glob patterns like "**/*.rs" or "src/**/*.ts".
+    /// Supports standard glob patterns like "**/*.rs" or "frontend/src/**/*.ts".
     /// If omitted, all files in the project will be searched.
+    ///
+    /// The glob pattern is matched against the full path including the project root directory.
+    ///
+    /// <example>
+    /// If the project has the following root directories:
+    ///
+    /// - /a/b/backend
+    /// - /c/d/frontend
+    ///
+    /// Use "backend/**/*.rs" to search only Rust files in the backend root directory.
+    /// Use "frontend/src/**/*.ts" to search TypeScript files only in the frontend root directory (sub-directory "src").
+    /// Use "**/*.rs" to search Rust files across all root directories.
+    /// </example>
     pub include_pattern: Option<String>,
     /// Optional starting position for paginated results (0-based).
     /// When not provided, starts from the beginning.


### PR DESCRIPTION
Adds clarifying examples and information about the `include_pattern` parameter for the grep tool, analogous to the `path` parameter of the read and list tools and others. 

The lack of clarity led to unexpected agent behavior described in #41189. This change is confirmed to improve the precision of Claude Sonnet 4.5 when searching for code in an empty conversation (without it, it leaves out the root directory in the query).

Closes #41189.

```
Release Notes:

- Clarify grep tool description to improve agent precision when using it with the `include_pattern` parameter
```