### PR TITLE
file_finder: Add support for word-order independent search

### DIFF
--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -1358,7 +1358,7 @@ impl PickerDelegate for FileFinderDelegate {
         window: &mut Window,
         cx: &mut Context<Picker<Self>>,
     ) -> Task<()> {
-        let raw_query = raw_query.replace(' ', "");
+        // Keep spaces for word-based matching
         let raw_query = raw_query.trim();
 
         let raw_query = match &raw_query.get(0..2) {

--- a/crates/fuzzy/src/matcher.rs
+++ b/crates/fuzzy/src/matcher.rs
@@ -121,7 +121,11 @@ impl<'a> Matcher<'a> {
             // If we have word-based query, check if all words exist in the path
             let use_word_matching = !query_words.is_empty();
             if use_word_matching {
-                if !Self::check_words_match(query_words, lowercase_prefix, &lowercase_candidate_chars) {
+                if !Self::check_words_match(
+                    query_words,
+                    lowercase_prefix,
+                    &lowercase_candidate_chars,
+                ) {
                     continue;
                 }
             } else {
@@ -537,25 +541,57 @@ mod tests {
         let results = match_single_path_query("page manager", false, &paths);
         assert!(results.iter().any(|(path, _)| *path == "manager/page.tsx"));
         assert!(results.iter().any(|(path, _)| *path == "page/manager.tsx"));
-        assert!(results.iter().any(|(path, _)| *path == "apps/web/manager/page.tsx"));
-        assert!(results.iter().any(|(path, _)| *path == "apps/web/page/manager.tsx"));
+        assert!(
+            results
+                .iter()
+                .any(|(path, _)| *path == "apps/web/manager/page.tsx")
+        );
+        assert!(
+            results
+                .iter()
+                .any(|(path, _)| *path == "apps/web/page/manager.tsx")
+        );
 
         // Test "manager page" should also find the same paths
         let results = match_single_path_query("manager page", false, &paths);
         assert!(results.iter().any(|(path, _)| *path == "manager/page.tsx"));
         assert!(results.iter().any(|(path, _)| *path == "page/manager.tsx"));
-        assert!(results.iter().any(|(path, _)| *path == "apps/web/manager/page.tsx"));
-        assert!(results.iter().any(|(path, _)| *path == "apps/web/page/manager.tsx"));
+        assert!(
+            results
+                .iter()
+                .any(|(path, _)| *path == "apps/web/manager/page.tsx")
+        );
+        assert!(
+            results
+                .iter()
+                .any(|(path, _)| *path == "apps/web/page/manager.tsx")
+        );
 
         // Test "user controller" should find user/controller paths
         let results = match_single_path_query("user controller", false, &paths);
-        assert!(results.iter().any(|(path, _)| *path == "controller/user.rs"));
-        assert!(results.iter().any(|(path, _)| *path == "user/controller.rs"));
+        assert!(
+            results
+                .iter()
+                .any(|(path, _)| *path == "controller/user.rs")
+        );
+        assert!(
+            results
+                .iter()
+                .any(|(path, _)| *path == "user/controller.rs")
+        );
 
         // Test "controller user" should also find the same paths
         let results = match_single_path_query("controller user", false, &paths);
-        assert!(results.iter().any(|(path, _)| *path == "controller/user.rs"));
-        assert!(results.iter().any(|(path, _)| *path == "user/controller.rs"));
+        assert!(
+            results
+                .iter()
+                .any(|(path, _)| *path == "controller/user.rs")
+        );
+        assert!(
+            results
+                .iter()
+                .any(|(path, _)| *path == "user/controller.rs")
+        );
     }
 
     #[test]
@@ -740,12 +776,18 @@ mod tests {
         };
 
         let query_for_processing = if has_spaces {
-            query.chars().filter(|c| !c.is_whitespace()).collect::<String>()
+            query
+                .chars()
+                .filter(|c| !c.is_whitespace())
+                .collect::<String>()
         } else {
             query.to_string()
         };
 
-        let lowercase_query = query_for_processing.to_lowercase().chars().collect::<Vec<_>>();
+        let lowercase_query = query_for_processing
+            .to_lowercase()
+            .chars()
+            .collect::<Vec<_>>();
         let query = query_for_processing.chars().collect::<Vec<_>>();
         let query_chars = CharBag::from(&lowercase_query[..]);
 

--- a/crates/fuzzy/src/paths.rs
+++ b/crates/fuzzy/src/paths.rs
@@ -103,12 +103,18 @@ pub fn match_fixed_path_set(
     };
 
     let query_without_spaces = if has_spaces {
-        query.chars().filter(|c| !c.is_whitespace()).collect::<String>()
+        query
+            .chars()
+            .filter(|c| !c.is_whitespace())
+            .collect::<String>()
     } else {
         query.to_string()
     };
 
-    let lowercase_query = query_without_spaces.to_lowercase().chars().collect::<Vec<_>>();
+    let lowercase_query = query_without_spaces
+        .to_lowercase()
+        .chars()
+        .collect::<Vec<_>>();
     let query = query_without_spaces.chars().collect::<Vec<_>>();
     let query_char_bag = CharBag::from(&lowercase_query[..]);
 
@@ -183,7 +189,10 @@ pub async fn match_path_sets<'a, Set: PathMatchCandidateSet<'a>>(
 
     // For word-based queries, concatenate words for char bag but keep words separate for matching
     let query_for_processing = if has_spaces {
-        query.chars().filter(|c| !c.is_whitespace()).collect::<String>()
+        query
+            .chars()
+            .filter(|c| !c.is_whitespace())
+            .collect::<String>()
     } else {
         query.to_string()
     };


### PR DESCRIPTION
Implements word-based matching for file finder queries containing spaces. Previously, searching for 'page manager' would not find files like '/manager/page.tsx'. Now both 'page manager' and 'manager page' find the same files, matching behavior of other editors.

- Modified file_finder.rs to preserve spaces in queries
- Extended fuzzy matcher to support word-independent matching
- Added word-based scoring that matches all words regardless of order
- Added comprehensive tests for word-order independent matching

Fixes issue #14428

Original behaviour:
<img width="1513" height="945" alt="image" src="https://github.com/user-attachments/assets/a91381ce-fd92-43ad-a7f2-e4b1a7317392" />
<img width="1513" height="945" alt="image" src="https://github.com/user-attachments/assets/d850ba4f-be3d-44be-8add-1cfe6004b58f" />


Fixed behaviour:
<img width="1513" height="945" alt="image" src="https://github.com/user-attachments/assets/431c8358-ee69-4c36-a33f-92813b020332" />

Release Notes:

- N/A


