### PR TITLE
git_ui: Add timezone to absolute timestamp of commit in git blame popover

### DIFF
--- a/crates/git/src/blame.rs
+++ b/crates/git/src/blame.rs
@@ -183,6 +183,21 @@ impl BlameEntry {
             Ok(time::OffsetDateTime::now_utc())
         }
     }
+
+    pub fn committer_offset_date_time(&self) -> Result<time::OffsetDateTime> {
+        if let (Some(committer_time), Some(committer_tz)) =
+            (self.committer_time, &self.committer_tz)
+        {
+            let format = format_description!("[offset_hour][offset_minute]");
+            let offset = UtcOffset::parse(committer_tz, &format)?;
+            let date_time_utc = OffsetDateTime::from_unix_timestamp(committer_time)?;
+
+            Ok(date_time_utc.to_offset(offset))
+        } else {
+            // Directly return current time in UTC if there's no committer time or timezone
+            Ok(time::OffsetDateTime::now_utc())
+        }
+    }
 }
 
 // parse_git_blame parses the output of `git blame --incremental`, which returns

--- a/crates/git_ui/src/blame_ui.rs
+++ b/crates/git_ui/src/blame_ui.rs
@@ -170,8 +170,7 @@ impl BlameRenderer for GitBlameRenderer {
         cx: &mut App,
     ) -> Option<AnyElement> {
         let commit_time = blame
-            .committer_time
-            .and_then(|t| OffsetDateTime::from_unix_timestamp(t).ok())
+            .committer_offset_date_time()
             .unwrap_or(OffsetDateTime::now_utc());
 
         let sha = blame.sha.to_string().into();
@@ -193,6 +192,14 @@ impl BlameRenderer for GitBlameRenderer {
             OffsetDateTime::now_utc(),
             time_format::TimestampFormat::MediumAbsolute,
         );
+        let absolute_timestamp_with_tz = match commit_time.offset().whole_hours() {
+            0 => absolute_timestamp,
+            _ => format!(
+                "{} ({})",
+                absolute_timestamp,
+                commit_time.offset().to_string()
+            ),
+        };
         let link_color = cx.theme().colors().text_accent;
         let markdown_style = {
             let mut style = hover_markdown_style(window, cx);
@@ -286,7 +293,7 @@ impl BlameRenderer for GitBlameRenderer {
                                     .pt_1()
                                     .border_t_1()
                                     .border_color(cx.theme().colors().border_variant)
-                                    .child(absolute_timestamp)
+                                    .child(absolute_timestamp_with_tz)
                                     .child(
                                         h_flex()
                                             .gap_1()


### PR DESCRIPTION
…ver ui

The UI improvement for inline git blame popover.

When I view the commit time in the Git blame popover, I get confused because it shows the absolute time in `UTC+0`, while my local time zone is `UTC+8`, and there’s no any indication of the shown time's zone.

<img width="951" height="261" alt="image" src="https://github.com/user-attachments/assets/35be06ae-2953-4191-b222-1bb6a641b454" />


This is very counterintuitive, so I think it needs to display the committer's local time. 

<img width="1068" height="251" alt="image" src="https://github.com/user-attachments/assets/19137343-b28a-468e-952d-c161963ff45a" />


