### PR TITLE
gpui: Add support for super ellipse corner rendering

### DIFF
--- a/crates/gpui/examples/squircle.rs
+++ b/crates/gpui/examples/squircle.rs
@@ -1,0 +1,173 @@
+use std::{fs, path::PathBuf};
+
+use gpui::{
+    App, Application, AssetSource, Bounds, Context, Div, Fill, FontWeight, ObjectFit, SharedString,
+    Window, WindowBounds, WindowOptions, div, img, prelude::*, px, rgb, size,
+};
+
+const IMAGE: &str = "image/black-cat-typing.gif";
+
+struct Assets {
+    base: PathBuf,
+}
+
+impl AssetSource for Assets {
+    fn load(&self, path: &str) -> anyhow::Result<Option<std::borrow::Cow<'static, [u8]>>> {
+        fs::read(self.base.join(path))
+            .map(|data| Some(std::borrow::Cow::Owned(data)))
+            .map_err(Into::into)
+    }
+
+    fn list(&self, path: &str) -> anyhow::Result<Vec<SharedString>> {
+        fs::read_dir(self.base.join(path))
+            .map(|entries| {
+                entries
+                    .filter_map(|entry| {
+                        entry
+                            .ok()
+                            .and_then(|entry| entry.file_name().into_string().ok())
+                            .map(SharedString::from)
+                    })
+                    .collect()
+            })
+            .map_err(Into::into)
+    }
+}
+
+struct SquircleDemo;
+
+impl Render for SquircleDemo {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .flex()
+            .flex_col()
+            .gap_4()
+            .p_8()
+            .bg(rgb(0xf0f0f0))
+            .size_full()
+            .children([
+                div()
+                    .text_xl()
+                    .font_weight(FontWeight::BOLD)
+                    .child("Squircle Corner Rendering"),
+                div().flex().gap_4().children([
+                    example_card("Circular", ".smoothness(0.0)", 0.0, rgb(0x3b82f6)),
+                    example_card("Subtle", ".smoothness_0p3()", 0.3, rgb(0x06b6d4)),
+                    example_card("Squircle", ".smoothness_0p5()", 0.5, rgb(0x8b5cf6)),
+                    example_card("Rounded", ".smoothness_0p7()", 0.7, rgb(0xec4899)),
+                ]),
+                div()
+                    .text_lg()
+                    .font_weight(FontWeight::BOLD)
+                    .child("Smoothness Gradient"),
+                div().flex().gap_2().children(
+                    (0..=10)
+                        .map(|i| {
+                            let smoothness = i as f32 / 10.0;
+                            gradient_example(smoothness, rgb(0x10b981))
+                        })
+                        .collect::<Vec<_>>(),
+                ),
+                div()
+                    .text_lg()
+                    .font_weight(FontWeight::BOLD)
+                    .child("Image with Squircle Corners"),
+                div().flex().gap_4().children([
+                    image_example("Circular", 0.0),
+                    image_example("Subtle", 0.3),
+                    image_example("Squircle", 0.5),
+                    image_example("Rounded", 0.7),
+                ]),
+                div()
+                    .mt_4()
+                    .p_4()
+                    .rounded(px(8.0))
+                    .bg(rgb(0x1f2937))
+                    .text_sm()
+                    .text_color(rgb(0xe5e7eb))
+                    .font_family("monospace")
+                    .child(
+                        r#"// Usage Examples
+div()
+    .rounded(px(40.0))
+    .smoothness_0p5()  // Squircle corners
+    .bg(blue())
+
+div()
+    .rounded(px(40.0))
+    .smoothness(0.7)   // Custom value
+    .bg(green())"#,
+                    ),
+            ])
+    }
+}
+
+fn example_card(
+    title: &'static str,
+    description: &'static str,
+    smoothness: f32,
+    color: impl Clone + Into<Fill>,
+) -> Div {
+    div().flex().flex_col().gap_2().items_center().children([
+        div()
+            .w(px(150.0))
+            .h(px(150.0))
+            .rounded(px(40.0))
+            .smoothness(smoothness)
+            .bg(color)
+            .shadow_lg(),
+        div().font_weight(FontWeight::BOLD).child(title),
+        div().text_sm().text_color(rgb(0x6b7280)).child(description),
+    ])
+}
+
+fn gradient_example(smoothness: f32, color: impl Clone + Into<Fill>) -> Div {
+    div()
+        .w(px(60.0))
+        .h(px(60.0))
+        .rounded(px(15.0))
+        .smoothness(smoothness)
+        .bg(color)
+        .flex()
+        .items_center()
+        .justify_center()
+        .text_xs()
+        .text_color(gpui::white())
+        .child(format!("{:.1}", smoothness))
+}
+
+fn image_example(label: &'static str, smoothness: f32) -> Div {
+    div()
+        .flex()
+        .flex_col()
+        .gap_2()
+        .items_center()
+        .child(
+            img(IMAGE)
+                .w(px(150.0))
+                .h(px(150.0))
+                .rounded(px(40.0))
+                .smoothness(smoothness)
+                .object_fit(ObjectFit::Cover),
+        )
+        .child(div().text_sm().text_color(rgb(0x6b7280)).child(label))
+}
+
+fn main() {
+    Application::new()
+        .with_assets(Assets {
+            base: PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("examples"),
+        })
+        .run(|cx: &mut App| {
+            let bounds = Bounds::centered(None, size(px(800.0), px(600.0)), cx);
+            cx.open_window(
+                WindowOptions {
+                    window_bounds: Some(WindowBounds::Windowed(bounds)),
+                    ..Default::default()
+                },
+                |_, cx| cx.new(|_| SquircleDemo),
+            )
+            .unwrap();
+            cx.activate(true);
+        });
+}

--- a/crates/gpui/examples/squircle.rs
+++ b/crates/gpui/examples/squircle.rs
@@ -51,7 +51,7 @@ impl Render for SquircleDemo {
                     .font_weight(FontWeight::BOLD)
                     .child("Squircle Corner Rendering"),
                 div().flex().gap_4().children([
-                    example_card("Circular", ".smoothness(0.0)", 0.0, rgb(0x3b82f6)),
+                    example_card("Circular", ".smoothness_0()", 0.0, rgb(0x3b82f6)),
                     example_card("Subtle", ".smoothness_0p3()", 0.3, rgb(0x06b6d4)),
                     example_card("Squircle", ".smoothness_0p5()", 0.5, rgb(0x8b5cf6)),
                     example_card("Rounded", ".smoothness_0p7()", 0.7, rgb(0xec4899)),

--- a/crates/gpui/src/elements/img.rs
+++ b/crates/gpui/src/elements/img.rs
@@ -472,13 +472,15 @@ impl Element for Img {
                         .corner_radii
                         .to_pixels(window.rem_size())
                         .clamp_radii_for_quad_size(new_bounds.size);
+
                     window
-                        .paint_image(
+                        .paint_image_with_smoothness(
                             new_bounds,
                             corner_radii,
                             data,
                             layout_state.frame_index,
                             self.style.grayscale,
+                            style.smoothness.unwrap_or(0.0),
                         )
                         .log_err();
                 } else if let Some(replacement) = &mut layout_state.replacement {

--- a/crates/gpui/src/platform/blade/shaders.wgsl
+++ b/crates/gpui/src/platform/blade/shaders.wgsl
@@ -1274,7 +1274,6 @@ fn fs_poly_sprite(input: PolySpriteVarying) -> @location(0) vec4<f32> {
 
     let sprite = b_poly_sprites[input.sprite_id];
 
-    // Use squircle SDF if smoothness > 0, otherwise use circular SDF
     var distance: f32;
     if (sprite.smoothness > 0.0) {
         distance = squircle_sdf(input.position.xy, sprite.bounds, sprite.corner_radii, sprite.smoothness);

--- a/crates/gpui/src/platform/blade/shaders.wgsl
+++ b/crates/gpui/src/platform/blade/shaders.wgsl
@@ -361,6 +361,31 @@ fn quad_sdf_impl(corner_center_to_point: vec2<f32>, corner_radius: f32) -> f32 {
     }
 }
 
+// Squircle SDF: smoothness 0.0 = circle, 0.5 = squircle, 1.0 = square
+fn squircle_sdf(point: vec2<f32>, bounds: Bounds, corner_radii: Corners, smoothness: f32) -> f32 {
+    let half_size = bounds.size / 2.0;
+    let center = bounds.origin + half_size;
+    let center_to_point = point - center;
+    let corner_radius = pick_corner_radius(center_to_point, corner_radii);
+
+    if (corner_radius == 0.0) {
+        // No corner radius, use sharp corners
+        let corner_to_point = abs(center_to_point) - half_size;
+        return max(corner_to_point.x, corner_to_point.y);
+    }
+
+    // Power factor: 2 = circle, 4 = squircle, 8+ = square
+    let p = pow(2.0, 1.0 + smoothness * 2.0);
+
+    let corner_to_point = abs(center_to_point) - half_size + corner_radius;
+    let corner_max = max(corner_to_point, vec2<f32>(0.0));
+
+    // Superellipse SDF approximation
+    let dist = pow(pow(abs(corner_max.x), p) + pow(abs(corner_max.y), p), 1.0 / p);
+
+    return dist + min(0.0, max(corner_to_point.x, corner_to_point.y)) - corner_radius;
+}
+
 // Abstract away the final color transformation based on the
 // target alpha compositing mode.
 fn blend_color(color: vec4<f32>, alpha_factor: f32) -> vec4<f32> {
@@ -487,6 +512,8 @@ struct Quad {
     border_color: Hsla,
     corner_radii: Corners,
     border_widths: Edges,
+    smoothness: f32,
+    pad: u32,
 }
 var<storage, read> b_quads: array<Quad>;
 
@@ -618,7 +645,12 @@ fn fs_quad(input: QuadVarying) -> @location(0) vec4<f32> {
 
     // Signed distance of the point to the outside edge of the quad's border. It
     // is positive outside this edge, and negative inside.
-    let outer_sdf = quad_sdf_impl(corner_center_to_point, corner_radius);
+    var outer_sdf: f32;
+    if (quad.smoothness > 0.0) {
+        outer_sdf = squircle_sdf(input.position.xy, quad.bounds, quad.corner_radii, quad.smoothness);
+    } else {
+        outer_sdf = quad_sdf_impl(corner_center_to_point, corner_radius);
+    }
 
     // Approximate signed distance of the point to the inside edge of the quad's
     // border. It is negative outside this edge (within the border), and
@@ -1205,6 +1237,10 @@ struct PolychromeSprite {
     content_mask: Bounds,
     corner_radii: Corners,
     tile: AtlasTile,
+    smoothness: f32,
+    pad2: u32,
+    pad3: u32,
+    pad4: u32,
 }
 var<storage, read> b_poly_sprites: array<PolychromeSprite>;
 
@@ -1237,7 +1273,14 @@ fn fs_poly_sprite(input: PolySpriteVarying) -> @location(0) vec4<f32> {
     }
 
     let sprite = b_poly_sprites[input.sprite_id];
-    let distance = quad_sdf(input.position.xy, sprite.bounds, sprite.corner_radii);
+
+    // Use squircle SDF if smoothness > 0, otherwise use circular SDF
+    var distance: f32;
+    if (sprite.smoothness > 0.0) {
+        distance = squircle_sdf(input.position.xy, sprite.bounds, sprite.corner_radii, sprite.smoothness);
+    } else {
+        distance = quad_sdf(input.position.xy, sprite.bounds, sprite.corner_radii);
+    }
 
     var color = sample;
     if ((sprite.grayscale & 0xFFu) != 0u) {

--- a/crates/gpui/src/platform/mac/shaders.metal
+++ b/crates/gpui/src/platform/mac/shaders.metal
@@ -712,7 +712,6 @@ fragment float4 polychrome_sprite_fragment(
   float4 sample =
       atlas_texture.sample(atlas_texture_sampler, input.tile_position);
 
-  // Use squircle SDF if smoothness > 0, otherwise use circular SDF
   float distance;
   if (sprite.smoothness > 0.0) {
     distance = squircle_sdf(input.position.xy, sprite.bounds, sprite.corner_radii, sprite.smoothness);

--- a/crates/gpui/src/platform/mac/shaders.metal
+++ b/crates/gpui/src/platform/mac/shaders.metal
@@ -28,6 +28,8 @@ float pick_corner_radius(float2 center_to_point, Corners_ScaledPixels corner_rad
 float quad_sdf(float2 point, Bounds_ScaledPixels bounds,
                Corners_ScaledPixels corner_radii);
 float quad_sdf_impl(float2 center_to_point, float corner_radius);
+float squircle_sdf(float2 point, Bounds_ScaledPixels bounds,
+                   Corners_ScaledPixels corner_radii, float smoothness);
 float gaussian(float x, float sigma);
 float2 erf(float2 x);
 float blur_along_x(float x, float y, float sigma, float corner,

--- a/crates/gpui/src/platform/mac/shaders.metal
+++ b/crates/gpui/src/platform/mac/shaders.metal
@@ -179,7 +179,12 @@ fragment float4 quad_fragment(QuadFragmentInput input [[stage_in]],
   }
 
   // Signed distance of the point to the outside edge of the quad's border
-  float outer_sdf = quad_sdf_impl(corner_center_to_point, corner_radius);
+  float outer_sdf;
+  if (quad.smoothness > 0.0) {
+    outer_sdf = squircle_sdf(input.position.xy, quad.bounds, quad.corner_radii, quad.smoothness);
+  } else {
+    outer_sdf = quad_sdf_impl(corner_center_to_point, corner_radius);
+  }
 
   // Approximate signed distance of the point to the inside edge of the quad's
   // border. It is negative outside this edge (within the border), and
@@ -704,8 +709,14 @@ fragment float4 polychrome_sprite_fragment(
                                           min_filter::linear);
   float4 sample =
       atlas_texture.sample(atlas_texture_sampler, input.tile_position);
-  float distance =
-      quad_sdf(input.position.xy, sprite.bounds, sprite.corner_radii);
+
+  // Use squircle SDF if smoothness > 0, otherwise use circular SDF
+  float distance;
+  if (sprite.smoothness > 0.0) {
+    distance = squircle_sdf(input.position.xy, sprite.bounds, sprite.corner_radii, sprite.smoothness);
+  } else {
+    distance = quad_sdf(input.position.xy, sprite.bounds, sprite.corner_radii);
+  }
 
   float4 color = sample;
   if (sprite.grayscale) {
@@ -1074,6 +1085,32 @@ float quad_sdf_impl(float2 corner_center_to_point, float corner_radius) {
 
         return signed_distance_to_inset_quad - corner_radius;
     }
+}
+
+// Squircle SDF: smoothness 0.0 = circle, 0.5 = squircle, 1.0 = square
+float squircle_sdf(float2 point, Bounds_ScaledPixels bounds,
+                   Corners_ScaledPixels corner_radii, float smoothness) {
+    float2 half_size = float2(bounds.size.width, bounds.size.height) / 2.0;
+    float2 center = float2(bounds.origin.x, bounds.origin.y) + half_size;
+    float2 center_to_point = point - center;
+    float corner_radius = pick_corner_radius(center_to_point, corner_radii);
+
+    if (corner_radius == 0.0) {
+        // No corner radius, use sharp corners
+        float2 corner_to_point = abs(center_to_point) - half_size;
+        return max(corner_to_point.x, corner_to_point.y);
+    }
+
+    // Power factor: 2 = circle, 4 = squircle, 8+ = square
+    float p = pow(2.0, 1.0 + smoothness * 2.0);
+
+    float2 corner_to_point = abs(center_to_point) - half_size + corner_radius;
+    float2 corner_max = max(corner_to_point, float2(0.0));
+
+    // Superellipse SDF approximation
+    float dist = pow(pow(abs(corner_max.x), p) + pow(abs(corner_max.y), p), 1.0 / p);
+
+    return dist + min(0.0, max(corner_to_point.x, corner_to_point.y)) - corner_radius;
 }
 
 // A standard gaussian function, used for weighting samples

--- a/crates/gpui/src/platform/windows/shaders.hlsl
+++ b/crates/gpui/src/platform/windows/shaders.hlsl
@@ -302,6 +302,31 @@ float quad_sdf(float2 pt, Bounds bounds, Corners corner_radii) {
     return quad_sdf_impl(corner_center_to_point, corner_radius);
 }
 
+// Squircle SDF: smoothness 0.0 = circle, 0.5 = squircle, 1.0 = square
+float squircle_sdf(float2 pt, Bounds bounds, Corners corner_radii, float smoothness) {
+    float2 half_size = bounds.size / 2.;
+    float2 center = bounds.origin + half_size;
+    float2 center_to_point = pt - center;
+    float corner_radius = pick_corner_radius(center_to_point, corner_radii);
+
+    if (corner_radius == 0.0) {
+        // No corner radius, use sharp corners
+        float2 corner_to_point = abs(center_to_point) - half_size;
+        return max(corner_to_point.x, corner_to_point.y);
+    }
+
+    // Power factor: 2 = circle, 4 = squircle, 8+ = square
+    float p = pow(2.0, 1.0 + smoothness * 2.0);
+
+    float2 corner_to_point = abs(center_to_point) - half_size + corner_radius;
+    float2 corner_max = max(corner_to_point, float2(0.0, 0.0));
+
+    // Superellipse SDF approximation
+    float dist = pow(pow(abs(corner_max.x), p) + pow(abs(corner_max.y), p), 1.0 / p);
+
+    return dist + min(0.0, max(corner_to_point.x, corner_to_point.y)) - corner_radius;
+}
+
 GradientColor prepare_gradient_color(uint tag, uint color_space, Hsla solid, LinearColorStop colors[2]) {
     GradientColor output;
     if (tag == 0 || tag == 2) {
@@ -468,6 +493,8 @@ struct Quad {
     Hsla border_color;
     Corners corner_radii;
     Edges border_widths;
+    float smoothness;
+    uint pad;
 };
 
 struct QuadVertexOutput {
@@ -595,7 +622,12 @@ float4 quad_fragment(QuadFragmentInput input): SV_Target {
     }
 
     // Signed distance of the point to the outside edge of the quad's border
-    float outer_sdf = quad_sdf_impl(corner_center_to_point, corner_radius);
+    float outer_sdf;
+    if (quad.smoothness > 0.0) {
+        outer_sdf = squircle_sdf(input.position.xy, quad.bounds, quad.corner_radii, quad.smoothness);
+    } else {
+        outer_sdf = quad_sdf_impl(corner_center_to_point, corner_radius);
+    }
 
     // Approximate signed distance of the point to the inside edge of the quad's
     // border. It is negative outside this edge (within the border), and
@@ -1134,6 +1166,10 @@ struct PolychromeSprite {
     Bounds content_mask;
     Corners corner_radii;
     AtlasTile tile;
+    float smoothness;
+    uint pad2;
+    uint pad3;
+    uint pad4;
 };
 
 struct PolychromeSpriteVertexOutput {
@@ -1170,7 +1206,14 @@ PolychromeSpriteVertexOutput polychrome_sprite_vertex(uint vertex_id: SV_VertexI
 float4 polychrome_sprite_fragment(PolychromeSpriteFragmentInput input): SV_Target {
     PolychromeSprite sprite = poly_sprites[input.sprite_id];
     float4 sample = t_sprite.Sample(s_sprite, input.tile_position);
-    float distance = quad_sdf(input.position.xy, sprite.bounds, sprite.corner_radii);
+
+    // Use squircle SDF if smoothness > 0, otherwise use circular SDF
+    float distance;
+    if (sprite.smoothness > 0.0) {
+        distance = squircle_sdf(input.position.xy, sprite.bounds, sprite.corner_radii, sprite.smoothness);
+    } else {
+        distance = quad_sdf(input.position.xy, sprite.bounds, sprite.corner_radii);
+    }
 
     float4 color = sample;
     if ((sprite.grayscale & 0xFFu) != 0u) {

--- a/crates/gpui/src/platform/windows/shaders.hlsl
+++ b/crates/gpui/src/platform/windows/shaders.hlsl
@@ -1207,7 +1207,6 @@ float4 polychrome_sprite_fragment(PolychromeSpriteFragmentInput input): SV_Targe
     PolychromeSprite sprite = poly_sprites[input.sprite_id];
     float4 sample = t_sprite.Sample(s_sprite, input.tile_position);
 
-    // Use squircle SDF if smoothness > 0, otherwise use circular SDF
     float distance;
     if (sprite.smoothness > 0.0) {
         distance = squircle_sdf(input.position.xy, sprite.bounds, sprite.corner_radii, sprite.smoothness);

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -459,6 +459,8 @@ pub(crate) struct Quad {
     pub border_color: Hsla,
     pub corner_radii: Corners<ScaledPixels>,
     pub border_widths: Edges<ScaledPixels>,
+    pub smoothness: f32,
+    pub pad: u32,
 }
 
 impl From<Quad> for Primitive {
@@ -645,6 +647,10 @@ pub(crate) struct PolychromeSprite {
     pub content_mask: ContentMask<ScaledPixels>,
     pub corner_radii: Corners<ScaledPixels>,
     pub tile: AtlasTile,
+    pub smoothness: f32,
+    pub pad2: u32,
+    pub pad3: u32,
+    pub pad4: u32,
 }
 
 impl From<PolychromeSprite> for Primitive {

--- a/crates/gpui/src/style.rs
+++ b/crates/gpui/src/style.rs
@@ -248,6 +248,9 @@ pub struct Style {
     #[refineable]
     pub corner_radii: Corners<AbsoluteLength>,
 
+    /// The smoothness of corners (0.0 = circle, 0.5 = squircle, 1.0 = square)
+    pub smoothness: Option<f32>,
+
     /// Box shadow of the element
     pub box_shadow: Vec<BoxShadow>,
 
@@ -641,14 +644,17 @@ impl Style {
                 None => Hsla::default(),
             };
             border_color.a = 0.;
-            window.paint_quad(quad(
-                bounds,
-                corner_radii,
-                background_color.unwrap_or_default(),
-                Edges::default(),
-                border_color,
-                self.border_style,
-            ));
+            window.paint_quad(
+                quad(
+                    bounds,
+                    corner_radii,
+                    background_color.unwrap_or_default(),
+                    Edges::default(),
+                    border_color,
+                    self.border_style,
+                )
+                .smoothness(self.smoothness.unwrap_or(0.0)),
+            );
         }
 
         continuation(window, cx);
@@ -684,7 +690,8 @@ impl Style {
                 border_widths,
                 self.border_color.unwrap_or_default(),
                 self.border_style,
-            );
+            )
+            .smoothness(self.smoothness.unwrap_or(0.0));
 
             window.with_content_mask(Some(ContentMask { bounds: top_bounds }), |window| {
                 window.paint_quad(quad.clone());
@@ -765,6 +772,7 @@ impl Default for Style {
             border_color: None,
             border_style: BorderStyle::default(),
             corner_radii: Corners::default(),
+            smoothness: None,
             box_shadow: Default::default(),
             text: TextStyleRefinement::default(),
             mouse_cursor: None,

--- a/crates/gpui/src/styled.rs
+++ b/crates/gpui/src/styled.rs
@@ -770,6 +770,12 @@ pub trait Styled: Sized {
         self
     }
 
+    /// Sets corner smoothness to 0.0 (circular).
+    fn smoothness_0(mut self) -> Self {
+        self.style().smoothness = Some(0.0);
+        self
+    }
+
     /// Sets corner smoothness to 0.1.
     fn smoothness_0p1(mut self) -> Self {
         self.style().smoothness = Some(0.1);

--- a/crates/gpui/src/styled.rs
+++ b/crates/gpui/src/styled.rs
@@ -763,4 +763,70 @@ pub trait Styled: Sized {
         self.style().debug_below = Some(true);
         self
     }
+
+    /// Sets the corner smoothness (0.0 = circle, 0.5 = squircle, 1.0 = square).
+    fn smoothness(mut self, smoothness: f32) -> Self {
+        self.style().smoothness = Some(smoothness.clamp(0.0, 1.0));
+        self
+    }
+
+    /// Sets corner smoothness to 0.1.
+    fn smoothness_0p1(mut self) -> Self {
+        self.style().smoothness = Some(0.1);
+        self
+    }
+
+    /// Sets corner smoothness to 0.2.
+    fn smoothness_0p2(mut self) -> Self {
+        self.style().smoothness = Some(0.2);
+        self
+    }
+
+    /// Sets corner smoothness to 0.3.
+    fn smoothness_0p3(mut self) -> Self {
+        self.style().smoothness = Some(0.3);
+        self
+    }
+
+    /// Sets corner smoothness to 0.4.
+    fn smoothness_0p4(mut self) -> Self {
+        self.style().smoothness = Some(0.4);
+        self
+    }
+
+    /// Sets corner smoothness to 0.5 (squircle).
+    fn smoothness_0p5(mut self) -> Self {
+        self.style().smoothness = Some(0.5);
+        self
+    }
+
+    /// Sets corner smoothness to 0.6.
+    fn smoothness_0p6(mut self) -> Self {
+        self.style().smoothness = Some(0.6);
+        self
+    }
+
+    /// Sets corner smoothness to 0.7.
+    fn smoothness_0p7(mut self) -> Self {
+        self.style().smoothness = Some(0.7);
+        self
+    }
+
+    /// Sets corner smoothness to 0.8.
+    fn smoothness_0p8(mut self) -> Self {
+        self.style().smoothness = Some(0.8);
+        self
+    }
+
+    /// Sets corner smoothness to 0.9.
+    fn smoothness_0p9(mut self) -> Self {
+        self.style().smoothness = Some(0.9);
+        self
+    }
+
+    /// Sets corner smoothness to 1.0 (more rounded).
+    fn smoothness_1(mut self) -> Self {
+        self.style().smoothness = Some(1.0);
+        self
+    }
 }


### PR DESCRIPTION
This PR adds support for squircle (superellipse) corner rendering to GPUI elements using GPU-accelerated signed distance field (SDF) calculations.

**Key features:**
- New `.smoothness()` method on all styled elements (div, img, etc.)
- Smoothness parameter: 0.0 (circle) to 0.5 (squircle) to 1.0 (square)
- GPU-based SDF rendering for high performance
- Cross-platform: WGSL (Linux), Metal (macOS), HLSL (Windows)
- Fully backward compatible (defaults to 0.0)

**Implementation:**
- Extended Style struct with optional smoothness field
- Added smoothness to PaintQuad for quad rendering
- Updated all three shader backends to use squircle_sdf() when smoothness > 0.0
- Reuses existing squircle SDF infrastructure from sprite rendering
- Proper struct alignment (168 bytes) for GPU compatibility

**Usage:**
```rust
div()
    .rounded(px(40.0))
    .smoothness(0.5)  // Squircle corners
    .bg(red())

img(path)
    .rounded(px(50.0))
    .smoothness(0.5)
```

**Demo:**
<img width="1900" height="2062" alt="2025-10-26-155802_hyprshot" src="https://github.com/user-attachments/assets/62324fbf-bb20-4f1a-a165-ab2f0f3621f6" />

*Linux/Wayland - WGSL demo*

<img width="1073" height="1115" alt="image" src="https://github.com/user-attachments/assets/3ba3c76e-aecd-4f14-b69f-fb5223bc800a" />

*macOS - Metal demo*

<img width="1293" height="1268" alt="image" src="https://github.com/user-attachments/assets/799db2ac-5a1e-4d2e-bc9f-69e1db6015b5" />

*Windows - HLSL demo*


**Testing:**
- [x] Linux/Wayland - WGSL ✅ Tested
- [x] macOS - Metal ✅ Tested
- [x] Windows - HLSL ✅ Tested
- [x] Various smoothness values (0.0, 0.25, 0.5, 0.75, 1.0)
- [x] Borders with smoothness
- [x] Large corner radii
- [x] Small corner radii

Release Notes:

- N/A