### PR TITLE
Implement `vimMotion::Shortcut` action

### DIFF
--- a/crates/vim/src/test/vim_test_context.rs
+++ b/crates/vim/src/test/vim_test_context.rs
@@ -101,15 +101,14 @@ impl VimTestContext {
             key_binding.set_meta(settings::KeybindSource::Default.meta());
         }
         cx.bind_keys(default_key_bindings);
-        if enabled {
-            let vim_key_bindings = settings::KeymapFile::load_asset(
-                "keymaps/vim.json",
-                Some(settings::KeybindSource::Vim),
-                cx,
-            )
-            .unwrap();
-            cx.bind_keys(vim_key_bindings);
-        }
+        // Always bind Vim keymap; contexts keep it inert unless Vim is active.
+        let vim_key_bindings = settings::KeymapFile::load_asset(
+            "keymaps/vim.json",
+            Some(settings::KeybindSource::Vim),
+            cx,
+        )
+        .unwrap();
+        cx.bind_keys(vim_key_bindings);
     }
 
     pub fn new_with_lsp(mut cx: EditorLspTestContext, enabled: bool) -> VimTestContext {

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -58,9 +58,8 @@ use rope::Rope;
 use search::project_search::ProjectSearchBar;
 use settings::{
     BaseKeymap, DEFAULT_KEYMAP_PATH, InvalidSettingsError, KeybindSource, KeymapFile,
-    KeymapFileLoadResult, Settings, SettingsStore, VIM_KEYMAP_PATH,
-    initial_local_debug_tasks_content, initial_project_settings_content, initial_tasks_content,
-    update_settings_file,
+    KeymapFileLoadResult, Settings, SettingsStore, initial_local_debug_tasks_content,
+    initial_project_settings_content, initial_tasks_content, update_settings_file,
 };
 use std::time::Duration;
 use std::{
@@ -1637,11 +1636,9 @@ pub fn load_default_keymap(cx: &mut App) {
         cx.bind_keys(KeymapFile::load_asset(asset_path, Some(KeybindSource::Base), cx).unwrap());
     }
 
-    if VimModeSetting::get_global(cx).0 || vim_mode_setting::HelixModeSetting::get_global(cx).0 {
-        cx.bind_keys(
-            KeymapFile::load_asset(VIM_KEYMAP_PATH, Some(KeybindSource::Vim), cx).unwrap(),
-        );
-    }
+    // Always ensure Vim keymap is bound in case the user has a vimMotion::Shortcut binding;
+    // The Context(s) control when it applies.
+    vim::bind_keymap(cx);
 }
 
 pub fn handle_settings_changed(error: Option<anyhow::Error>, cx: &mut App) {


### PR DESCRIPTION
- Add vimMotion::Shortcut (Vim-agnostic motion playback)
      - New action type: vimMotion::Shortcut that replays a whitespace-separated keystroke sequence.
      - Registered at the workspace level so it’s available even when Vim is disabled.
      - If the focused Editor lacks a Vim addon, temporarily “loan” Vim around playback (activate → dispatch → deactivate) and restore the original modal state.
      - Dispatches via Workspace::send_keystrokes_impl to match existing sequencing and focus-change flushing.
      - Parsing uses Keystroke::parse(...).log_err() to skip invalid tokens without failing.
      - Always bind Vim keymap as part of default keymap loading, so MotionShortcut works regardless of Vim mode.

- Tests
      - Expanded parity test to assume Normal mode and compare shortcut vs raw keystrokes across multiple sequences.
      - Added broader “Vim disabled” test that runs the same sequences with Vim off and asserts:
          - Visual state matches Vim-enabled raw keystrokes.
          - VimAddon is not left attached after playback.
      - Test harness always binds Vim keymap (contexts keep it inert when Vim is disabled).
  
Motivation
https://x.com/adamwathan/status/1980348738280497601

Examples
```json
{
     "secondary-alt-y": ["vimMotion::Shortcut", "y i w"], // yank inner word
     "secondary-alt-u": ["vimMotion::Shortcut", "g U i w"], // uppercase inner word
}
```

Release Notes:
- Added support for vimMotion::Shortcut action keymap e.g `{"cmd-+": ["vimMotion::Shortcut": "v i q"]}`
