### PR TITLE
Add Rust convenience Tree-sitter injections for common crates

### DIFF
--- a/crates/languages/src/rust/injections.scm
+++ b/crates/languages/src/rust/injections.scm
@@ -2,8 +2,10 @@
     (#set! injection.language "comment"))
 
 (macro_invocation
-    macro: [(identifier) (scoped_identifier)] @_macro_name
-    (#not-any-of? @_macro_name "view" "html")
+    macro: [
+        ((identifier) @_macro_name)
+        (scoped_identifier (identifier) @_macro_name .)
+    ]
     (token_tree) @injection.content
     (#set! injection.language "rust"))
 
@@ -11,25 +13,48 @@
 ; it wants to inject inside of rust, instead of modifying the rust
 ; injections to support leptos injections
 (macro_invocation
-    macro: [(identifier) (scoped_identifier)] @_macro_name
+    macro: [
+        ((identifier) @_macro_name)
+        (scoped_identifier (identifier) @_macro_name .)
+    ]
     (#any-of? @_macro_name "view" "html")
     (token_tree) @injection.content
     (#set! injection.language "rstml")
     )
 
-(call_expression
-    function: (scoped_identifier
-       path: (_) @_ty_path
-       name: (identifier) @_assoc_fn_name
+(macro_invocation
+    macro: [
+        ((identifier) @_macro_name)
+        (scoped_identifier (identifier) @_macro_name .)
+    ]
+    (#any-of? @_macro_name "sql")
+    (_) @injection.content
+    (#set! injection.language "sql")
     )
+
+; lazy_regex
+(macro_invocation
+    macro: [
+        ((identifier) @_macro_name)
+        (scoped_identifier (identifier) @_macro_name .)
+    ]
+    (token_tree [
+        (string_literal (string_content) @injection.content)
+        (raw_string_literal (string_content) @injection.content)
+    ])
+    (#set! injection.language "regex")
+    (#any-of? @_macro_name "regex" "bytes_regex")
+)
+
+(call_expression
+    function: (scoped_identifier) @_fn_path
     arguments: (arguments
         [
             (string_literal (string_content) @injection.content)
             (raw_string_literal (string_content) @injection.content)
         ]
     )
-    
-    (#match? @_ty_path ".*Regex") 
-    (#eq! @_assoc_fn_name "new")
+
+    (#match? @_fn_path ".*Regex(Builder)?::new")
     (#set! injection.language "regex")
 )

--- a/crates/languages/src/rust/injections.scm
+++ b/crates/languages/src/rust/injections.scm
@@ -16,3 +16,20 @@
     (token_tree) @injection.content
     (#set! injection.language "rstml")
     )
+
+(call_expression
+    function: (scoped_identifier
+       path: (_) @_ty_path
+       name: (identifier) @_assoc_fn_name
+    )
+    arguments: (arguments
+        [
+            (string_literal (string_content) @injection.content)
+            (raw_string_literal (string_content) @injection.content)
+        ]
+    )
+    
+    (#match? @_ty_path ".*Regex") 
+    (#eq! @_assoc_fn_name "new")
+    (#set! injection.language "regex")
+)


### PR DESCRIPTION
Adds injections for:
- `regex!("...")` (from `lazy_regex`)
- `Regex::new("...") (from `regex`, and a few others)
- `sql!(...)` from `sqlez`

Also minor cleanup on the existing Rust injections

Release Notes:

- N/A
