### PR TITLE
debugger: Add horizontal scrollbar for frame item and tooltip for variables

### DIFF
--- a/crates/debugger_ui/src/session/running/stack_frame_list.rs
+++ b/crates/debugger_ui/src/session/running/stack_frame_list.rs
@@ -566,6 +566,7 @@ impl StackFrameList {
                 this.activate_selected_entry(window, cx);
             }))
             .hover(|style| style.bg(cx.theme().colors().element_hover).cursor_pointer())
+            .overflow_x_scroll()
             .child(
                 v_flex()
                     .gap_0p5()

--- a/crates/debugger_ui/src/session/running/variable_list.rs
+++ b/crates/debugger_ui/src/session/running/variable_list.rs
@@ -1129,6 +1129,7 @@ impl VariableList {
                                         this.color(Color::from(color))
                                     }),
                             )
+                            .tooltip(Tooltip::text(value))
                     }
                 })
                 .into_any_element()


### PR DESCRIPTION
Closes #40360 

I first tried to use an horizontal scrollbar also for variables but as it's a List that can be collapsed it didn't feel natural so I ended up adding a tooltip to have to full value of the variable when you hover the item. (cf screenshots).



https://github.com/user-attachments/assets/70c4150d-b967-46b0-8720-82bbad9c9cca



https://github.com/user-attachments/assets/d0b52189-b090-4824-8eb7-2f455fa58b33



Release Notes:

- Added: for debugger UI horizontal scrollbar for frame item and tooltip for variables.
