### PR TITLE
svg_preview: Update preview on every buffer edit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16380,12 +16380,8 @@ version = "0.1.0"
 dependencies = [
  "editor",
  "file_icons",
- "futures 0.3.31",
  "gpui",
- "image",
  "language",
- "smallvec",
- "smol",
  "ui",
  "workspace",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16380,8 +16380,12 @@ version = "0.1.0"
 dependencies = [
  "editor",
  "file_icons",
+ "futures 0.3.31",
  "gpui",
- "multi_buffer",
+ "image",
+ "language",
+ "smallvec",
+ "smol",
  "ui",
  "workspace",
 ]

--- a/crates/gpui/src/elements/img.rs
+++ b/crates/gpui/src/elements/img.rs
@@ -632,7 +632,7 @@ impl Asset for ImageAssetLoader {
                 }
             };
 
-            let data = if let Ok(format) = image::guess_format(&bytes) {
+            if let Ok(format) = image::guess_format(&bytes) {
                 let data = match format {
                     ImageFormat::Gif => {
                         let decoder = GifDecoder::new(Cursor::new(&bytes))?;
@@ -690,12 +690,12 @@ impl Asset for ImageAssetLoader {
                     }
                 };
 
-                RenderImage::new(data)
+                Ok(Arc::new(RenderImage::new(data)))
             } else {
-                return Ok(svg_renderer.render_single_frame(&bytes, 1.0, true)?);
-            };
-
-            Ok(Arc::new(data))
+                svg_renderer
+                    .render_single_frame(&bytes, 1.0, true)
+                    .map_err(Into::into)
+            }
         }
     }
 }

--- a/crates/gpui/src/elements/img.rs
+++ b/crates/gpui/src/elements/img.rs
@@ -159,16 +159,15 @@ pub trait StyledImage: Sized {
         self
     }
 
-    /// Set the object fit for the image.
-    fn with_fallback<T>(mut self, fallback: impl Fn() -> T + 'static) -> Self
-    where
-        T: IntoElement,
-    {
-        self.image_style().fallback = Some(Box::new(move || fallback().into_any_element()));
+    /// Set a fallback function that will be invoked to render an error view should
+    /// the image fail to load.
+    fn with_fallback(mut self, fallback: impl Fn() -> AnyElement + 'static) -> Self {
+        self.image_style().fallback = Some(Box::new(fallback));
         self
     }
 
-    /// Set the object fit for the image.
+    /// Set a fallback function that will be invoked to render a view while the image
+    /// is still being loaded.
     fn with_loading(mut self, loading: impl Fn() -> AnyElement + 'static) -> Self {
         self.image_style().loading = Some(Box::new(loading));
         self

--- a/crates/gpui/src/gpui.rs
+++ b/crates/gpui/src/gpui.rs
@@ -95,7 +95,7 @@ pub use smol::Timer;
 pub use style::*;
 pub use styled::*;
 pub use subscription::*;
-use svg_renderer::*;
+pub use svg_renderer::*;
 pub(crate) use tab_stop::*;
 pub use taffy::{AvailableSpace, LayoutId};
 #[cfg(any(test, feature = "test-support"))]

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -1817,7 +1817,9 @@ impl Image {
             ImageFormat::Tiff => frames_for_image(&self.bytes, image::ImageFormat::Tiff)?,
             ImageFormat::Ico => frames_for_image(&self.bytes, image::ImageFormat::Ico)?,
             ImageFormat::Svg => {
-                return Ok(svg_renderer.render_single_frame(&self.bytes, 1.0, false)?);
+                return svg_renderer
+                    .render_single_frame(&self.bytes, 1.0, false)
+                    .map_err(Into::into);
             }
         };
 

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -40,7 +40,7 @@ use crate::{
     DEFAULT_WINDOW_SIZE, DevicePixels, DispatchEventResult, Font, FontId, FontMetrics, FontRun,
     ForegroundExecutor, GlyphId, GpuSpecs, ImageSource, Keymap, LineLayout, Pixels, PlatformInput,
     Point, RenderGlyphParams, RenderImage, RenderImageParams, RenderSvgParams, Scene, ShapedGlyph,
-    ShapedRun, SharedString, Size, SvgRenderer, SvgSize, SystemWindowTab, Task, TaskLabel, Window,
+    ShapedRun, SharedString, Size, SvgRenderer, SystemWindowTab, Task, TaskLabel, Window,
     WindowControlArea, hash, point, px, size,
 };
 use anyhow::Result;
@@ -1817,13 +1817,7 @@ impl Image {
             ImageFormat::Tiff => frames_for_image(&self.bytes, image::ImageFormat::Tiff)?,
             ImageFormat::Ico => frames_for_image(&self.bytes, image::ImageFormat::Ico)?,
             ImageFormat::Svg => {
-                let pixmap = svg_renderer.render_pixmap(&self.bytes, SvgSize::ScaleFactor(1.0))?;
-
-                let buffer =
-                    image::ImageBuffer::from_raw(pixmap.width(), pixmap.height(), pixmap.take())
-                        .unwrap();
-
-                SmallVec::from_elem(Frame::new(buffer), 1)
+                return Ok(svg_renderer.render_single_frame(&self.bytes, 1.0, false)?);
             }
         };
 

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -3098,7 +3098,7 @@ impl Window {
         let Some(tile) =
             self.sprite_atlas
                 .get_or_insert_with(&params.clone().into(), &mut || {
-                    let Some((size, bytes)) = cx.svg_renderer.render(&params)? else {
+                    let Some((size, bytes)) = cx.svg_renderer.render_alpha_mask(&params)? else {
                         return Ok(None);
                     };
                     Ok(Some((size, Cow::Owned(bytes))))

--- a/crates/svg_preview/Cargo.toml
+++ b/crates/svg_preview/Cargo.toml
@@ -14,11 +14,7 @@ path = "src/svg_preview.rs"
 [dependencies]
 editor.workspace = true
 file_icons.workspace = true
-futures.workspace = true
 gpui.workspace = true
-image.workspace = true
 language.workspace = true
-smallvec.workspace = true
-smol.workspace = true
 ui.workspace = true
 workspace.workspace = true

--- a/crates/svg_preview/Cargo.toml
+++ b/crates/svg_preview/Cargo.toml
@@ -14,7 +14,11 @@ path = "src/svg_preview.rs"
 [dependencies]
 editor.workspace = true
 file_icons.workspace = true
+futures.workspace = true
 gpui.workspace = true
-multi_buffer.workspace = true
+image.workspace = true
+language.workspace = true
+smallvec.workspace = true
+smol.workspace = true
 ui.workspace = true
 workspace.workspace = true

--- a/crates/svg_preview/src/svg_preview_view.rs
+++ b/crates/svg_preview/src/svg_preview_view.rs
@@ -1,13 +1,12 @@
-use std::path::PathBuf;
+use std::sync::Arc;
 
 use editor::Editor;
 use file_icons::FileIcons;
 use gpui::{
-    App, Context, Entity, EventEmitter, FocusHandle, Focusable, ImageSource, IntoElement,
-    ParentElement, Render, Resource, RetainAllImageCache, Styled, Subscription, WeakEntity, Window,
-    div, img,
+    App, Context, Entity, EventEmitter, FocusHandle, Focusable, IntoElement, ParentElement, Render,
+    RenderImage, Styled, Subscription, Task, WeakEntity, Window, div, img,
 };
-use multi_buffer::{Event as MultiBufferEvent, MultiBuffer};
+use language::{Buffer, BufferEvent};
 use ui::prelude::*;
 use workspace::item::Item;
 use workspace::{Pane, Workspace};
@@ -16,9 +15,11 @@ use crate::{OpenFollowingPreview, OpenPreview, OpenPreviewToTheSide};
 
 pub struct SvgPreviewView {
     focus_handle: FocusHandle,
-    svg_path: Option<PathBuf>,
-    image_cache: Entity<RetainAllImageCache>,
-    _buffer_subscription: Subscription,
+    buffer: Option<Entity<Buffer>>,
+    current_svg: Option<Arc<RenderImage>>,
+    error: Option<SharedString>,
+    _refresh: Task<()>,
+    _buffer_subscription: Option<Subscription>,
     _workspace_subscription: Option<Subscription>,
 }
 
@@ -31,6 +32,176 @@ pub enum SvgPreviewMode {
 }
 
 impl SvgPreviewView {
+    pub fn new(
+        mode: SvgPreviewMode,
+        active_editor: Entity<Editor>,
+        workspace_handle: WeakEntity<Workspace>,
+        window: &mut Window,
+        cx: &mut Context<Workspace>,
+    ) -> Entity<Self> {
+        cx.new(|cx| {
+            let workspace_subscription = if mode == SvgPreviewMode::Follow
+                && let Some(workspace) = workspace_handle.upgrade()
+            {
+                Some(Self::subscribe_to_workspace(workspace, window, cx))
+            } else {
+                None
+            };
+
+            let buffer = active_editor
+                .read(cx)
+                .buffer()
+                .clone()
+                .read_with(cx, |buffer, _cx| buffer.as_singleton());
+
+            let subscription = buffer
+                .as_ref()
+                .map(|buffer| Self::create_buffer_subscription(buffer, window, cx));
+
+            let mut this = Self {
+                focus_handle: cx.focus_handle(),
+                buffer,
+                error: None,
+                current_svg: None,
+                _buffer_subscription: subscription,
+                _workspace_subscription: workspace_subscription,
+                _refresh: Task::ready(()),
+            };
+            this.render_image(window, cx);
+
+            this
+        })
+    }
+
+    fn subscribe_to_workspace(
+        workspace: Entity<Workspace>,
+        window: &Window,
+        cx: &mut Context<Self>,
+    ) -> Subscription {
+        cx.subscribe_in(
+            &workspace,
+            window,
+            move |this: &mut SvgPreviewView, workspace, event: &workspace::Event, window, cx| {
+                if let workspace::Event::ActiveItemChanged = event {
+                    let workspace = workspace.read(cx);
+                    if let Some(active_item) = workspace.active_item(cx)
+                        && let Some(editor) = active_item.downcast::<Editor>()
+                        && Self::is_svg_file(&editor, cx)
+                    {
+                        let Some(buffer) = editor.read(cx).buffer().read(cx).as_singleton() else {
+                            return;
+                        };
+                        if this.buffer.as_ref() != Some(&buffer) {
+                            this._buffer_subscription =
+                                Some(Self::create_buffer_subscription(&buffer, window, cx));
+                            this.buffer = Some(buffer);
+                            this.render_image(window, cx);
+                            cx.notify();
+                        }
+                    }
+                }
+            },
+        )
+    }
+
+    fn render_image(&mut self, window: &Window, cx: &mut Context<Self>) {
+        let Some(buffer) = self.buffer.as_ref() else {
+            return;
+        };
+        const SCALE_FACTOR: f32 = 1.0;
+
+        let renderer = cx.svg_renderer();
+        let content = buffer.read(cx).snapshot();
+        let background_task = cx.background_spawn(async move {
+            renderer.render_single_frame(content.text().as_bytes(), SCALE_FACTOR, true)
+        });
+
+        self._refresh = cx.spawn_in(window, async move |this, cx| {
+            let result = background_task.await;
+
+            this.update_in(cx, |view, window, cx| match result {
+                Ok(image) => {
+                    if let Some(image) = view.current_svg.take() {
+                        window.drop_image(image).ok();
+                    }
+                    view.current_svg = Some(image);
+                    view.error = None;
+                    cx.notify();
+                }
+                Err(e) => view.error = Some(format!("{}", e).into()),
+            })
+            .ok();
+        });
+    }
+
+    fn find_existing_preview_item_idx(
+        pane: &Pane,
+        editor: &Entity<Editor>,
+        cx: &App,
+    ) -> Option<usize> {
+        let buffer_id = editor.read(cx).buffer().entity_id();
+        pane.items_of_type::<SvgPreviewView>()
+            .find(|view| {
+                view.read(cx)
+                    .buffer
+                    .as_ref()
+                    .is_some_and(|buffer| buffer.entity_id() == buffer_id)
+            })
+            .and_then(|view| pane.index_for_item(&view))
+    }
+
+    pub fn resolve_active_item_as_svg_editor(
+        workspace: &Workspace,
+        cx: &mut Context<Workspace>,
+    ) -> Option<Entity<Editor>> {
+        workspace
+            .active_item(cx)?
+            .act_as::<Editor>(cx)
+            .filter(|editor| Self::is_svg_file(&editor, cx))
+    }
+
+    fn create_svg_view(
+        mode: SvgPreviewMode,
+        workspace: &mut Workspace,
+        editor: Entity<Editor>,
+        window: &mut Window,
+        cx: &mut Context<Workspace>,
+    ) -> Entity<SvgPreviewView> {
+        let workspace_handle = workspace.weak_handle();
+        SvgPreviewView::new(mode, editor, workspace_handle, window, cx)
+    }
+
+    fn create_buffer_subscription(
+        buffer: &Entity<Buffer>,
+        window: &Window,
+        cx: &mut Context<Self>,
+    ) -> Subscription {
+        cx.subscribe_in(
+            buffer,
+            window,
+            move |this, _buffer, event: &BufferEvent, window, cx| match event {
+                BufferEvent::Edited | BufferEvent::Saved => {
+                    this.render_image(window, cx);
+                }
+                _ => {}
+            },
+        )
+    }
+
+    pub fn is_svg_file(editor: &Entity<Editor>, cx: &App) -> bool {
+        editor
+            .read(cx)
+            .buffer()
+            .read(cx)
+            .as_singleton()
+            .and_then(|buffer| buffer.read(cx).file())
+            .is_some_and(|file| {
+                file.path()
+                    .extension()
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("svg"))
+            })
+    }
+
     pub fn register(workspace: &mut Workspace, _window: &mut Window, _cx: &mut Context<Workspace>) {
         workspace.register_action(move |workspace, _: &OpenPreview, window, cx| {
             if let Some(editor) = Self::resolve_active_item_as_svg_editor(workspace, cx)
@@ -104,154 +275,6 @@ impl SvgPreviewView {
             }
         });
     }
-
-    fn find_existing_preview_item_idx(
-        pane: &Pane,
-        editor: &Entity<Editor>,
-        cx: &App,
-    ) -> Option<usize> {
-        let editor_path = Self::get_svg_path(editor.read(cx).buffer(), cx);
-        pane.items_of_type::<SvgPreviewView>()
-            .find(|view| {
-                let view_read = view.read(cx);
-                view_read.svg_path.is_some() && view_read.svg_path == editor_path
-            })
-            .and_then(|view| pane.index_for_item(&view))
-    }
-
-    pub fn resolve_active_item_as_svg_editor(
-        workspace: &Workspace,
-        cx: &mut Context<Workspace>,
-    ) -> Option<Entity<Editor>> {
-        let editor = workspace.active_item(cx)?.act_as::<Editor>(cx)?;
-
-        if Self::is_svg_file(&editor, cx) {
-            Some(editor)
-        } else {
-            None
-        }
-    }
-
-    fn create_svg_view(
-        mode: SvgPreviewMode,
-        workspace: &mut Workspace,
-        editor: Entity<Editor>,
-        window: &mut Window,
-        cx: &mut Context<Workspace>,
-    ) -> Entity<SvgPreviewView> {
-        let workspace_handle = workspace.weak_handle();
-        SvgPreviewView::new(mode, editor, workspace_handle, window, cx)
-    }
-
-    pub fn new(
-        mode: SvgPreviewMode,
-        active_editor: Entity<Editor>,
-        workspace_handle: WeakEntity<Workspace>,
-        window: &mut Window,
-        cx: &mut Context<Workspace>,
-    ) -> Entity<Self> {
-        cx.new(|cx| {
-            let image_cache = RetainAllImageCache::new(cx);
-            let buffer = active_editor.read(cx).buffer();
-            let svg_path = Self::get_svg_path(buffer, cx);
-            let subscription = Self::create_buffer_subscription(&buffer.clone(), window, cx);
-
-            // Subscribe to workspace active item changes to follow SVG files
-            let workspace_subscription = if mode == SvgPreviewMode::Follow {
-                workspace_handle.upgrade().map(|workspace_handle| {
-                    cx.subscribe_in(
-                        &workspace_handle,
-                        window,
-                        |this: &mut SvgPreviewView,
-                         workspace,
-                         event: &workspace::Event,
-                         window,
-                         cx| {
-                            if let workspace::Event::ActiveItemChanged = event {
-                                let workspace_read = workspace.read(cx);
-                                if let Some(active_item) = workspace_read.active_item(cx)
-                                    && let Some(editor) = active_item.downcast::<Editor>()
-                                    && Self::is_svg_file(&editor, cx)
-                                {
-                                    let buffer = editor.read(cx).buffer();
-                                    let new_path = Self::get_svg_path(&buffer, cx);
-                                    if this.svg_path != new_path {
-                                        this.svg_path = new_path;
-                                        this._buffer_subscription =
-                                            Self::create_buffer_subscription(
-                                                &buffer.clone(),
-                                                window,
-                                                cx,
-                                            );
-                                        cx.notify();
-                                    }
-                                }
-                            }
-                        },
-                    )
-                })
-            } else {
-                None
-            };
-
-            Self {
-                focus_handle: cx.focus_handle(),
-                svg_path,
-                image_cache,
-                _buffer_subscription: subscription,
-                _workspace_subscription: workspace_subscription,
-            }
-        })
-    }
-
-    fn create_buffer_subscription(
-        active_buffer: &Entity<MultiBuffer>,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) -> Subscription {
-        cx.subscribe_in(
-            active_buffer,
-            window,
-            |this: &mut SvgPreviewView, buffer, event: &MultiBufferEvent, window, cx| {
-                let potential_path_change = event == &MultiBufferEvent::FileHandleChanged;
-                if event == &MultiBufferEvent::Saved || potential_path_change {
-                    // Remove cached image to force reload
-                    if let Some(svg_path) = &this.svg_path {
-                        let resource = Resource::Path(svg_path.clone().into());
-                        this.image_cache.update(cx, |cache, cx| {
-                            cache.remove(&resource, window, cx);
-                        });
-                    }
-
-                    if potential_path_change {
-                        this.svg_path = Self::get_svg_path(buffer, cx);
-                    }
-                    cx.notify();
-                }
-            },
-        )
-    }
-
-    pub fn is_svg_file(editor: &Entity<Editor>, cx: &App) -> bool {
-        let buffer = editor.read(cx).buffer().read(cx);
-        if let Some(buffer) = buffer.as_singleton()
-            && let Some(file) = buffer.read(cx).file()
-        {
-            return file
-                .path()
-                .extension()
-                .map(|ext| ext.eq_ignore_ascii_case("svg"))
-                .unwrap_or(false);
-        }
-        false
-    }
-
-    fn get_svg_path(buffer: &Entity<MultiBuffer>, cx: &App) -> Option<PathBuf> {
-        let buffer = buffer.read(cx).as_singleton()?;
-        let file = buffer.read(cx).file()?;
-        let local_file = file.as_local()?;
-        Some(local_file.abs_path(cx))
-    }
 }
 
 impl Render for SvgPreviewView {
@@ -265,20 +288,19 @@ impl Render for SvgPreviewView {
             .flex()
             .justify_center()
             .items_center()
-            .child(if let Some(svg_path) = &self.svg_path {
-                img(ImageSource::from(svg_path.clone()))
-                    .image_cache(&self.image_cache)
-                    .max_w_full()
-                    .max_h_full()
-                    .with_fallback(|| {
-                        div()
+            .map(|this| {
+                if let Some(content) = self.current_svg.clone() {
+                    this.child(img(content).max_w_full().max_h_full().with_fallback(|| {
+                        h_flex()
                             .p_4()
-                            .child("Failed to load SVG file")
+                            .gap_2()
+                            .child(Icon::new(IconName::Warning))
+                            .child("Failed to load SVG image")
                             .into_any_element()
-                    })
-                    .into_any_element()
-            } else {
-                div().p_4().child("No SVG file selected").into_any_element()
+                    }))
+                } else {
+                    this.child(div().p_4().child("No SVG file selected").into_any_element())
+                }
             })
     }
 }
@@ -295,20 +317,19 @@ impl Item for SvgPreviewView {
     type Event = ();
 
     fn tab_icon(&self, _window: &Window, cx: &App) -> Option<Icon> {
-        // Use the same icon as SVG files in the file tree
-        self.svg_path
+        self.buffer
             .as_ref()
-            .and_then(|svg_path| FileIcons::get_icon(svg_path, cx))
+            .and_then(|buffer| buffer.read(cx).file())
+            .and_then(|file| FileIcons::get_icon(file.path().as_std_path(), cx))
             .map(Icon::from_path)
             .or_else(|| Some(Icon::new(IconName::Image)))
     }
 
-    fn tab_content_text(&self, _detail: usize, _cx: &App) -> SharedString {
-        self.svg_path
+    fn tab_content_text(&self, _detail: usize, cx: &App) -> SharedString {
+        self.buffer
             .as_ref()
-            .and_then(|svg_path| svg_path.file_name())
-            .map(|name| name.to_string_lossy())
-            .map(|name| format!("Preview {}", name).into())
+            .and_then(|svg_path| svg_path.read(cx).file())
+            .map(|name| format!("Preview {}", name.file_name(cx)).into())
             .unwrap_or_else(|| "SVG Preview".into())
     }
 

--- a/crates/zlog/src/filter.rs
+++ b/crates/zlog/src/filter.rs
@@ -41,6 +41,8 @@ const DEFAULT_FILTERS: &[(&str, log::LevelFilter)] = &[
     ("blade_graphics", log::LevelFilter::Warn),
     #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "windows"))]
     ("naga::back::spv::writer", log::LevelFilter::Warn),
+    // usvg prints a lot of warnings on rendering an SVG with partial errors, which
+    // can happen a lot with the SVG preview
     ("usvg::parser::style", log::LevelFilter::Error),
 ];
 

--- a/crates/zlog/src/filter.rs
+++ b/crates/zlog/src/filter.rs
@@ -41,6 +41,7 @@ const DEFAULT_FILTERS: &[(&str, log::LevelFilter)] = &[
     ("blade_graphics", log::LevelFilter::Warn),
     #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "windows"))]
     ("naga::back::spv::writer", log::LevelFilter::Warn),
+    ("usvg::parser::style", log::LevelFilter::Error),
 ];
 
 pub fn init_env_filter(filter: env_config::EnvFilter) {


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/39104

This fixes an issue where the preview would not work for remote buffers in the process.

Release Notes:

- Fixed an issue where the SVG preview would not work in remote scenarios.
- The SVG preview will now rerender on every keypress instead of only on saves.
