### PR TITLE
debugger: Support empty message in DAP

### DIFF
--- a/crates/dap/src/transport.rs
+++ b/crates/dap/src/transport.rs
@@ -411,6 +411,9 @@ impl TransportDelegate {
             };
 
             if buffer == "\r\n" {
+                if content_length == None {
+                    continue;
+                }
                 break;
             }
 


### PR DESCRIPTION
Closes #ISSUE

[debug-adapter-protocol](https://microsoft.github.io/debug-adapter-protocol/overview)

```
Content-Length: 119\r\n
\r\n
{
    "seq": 153,
    "type": "request",
    "command": "next",
    "arguments": {
        "threadId": 3
    }
}
```

Although the message structure is defined, it is found that some implementations send `\r\n` between messages.

```
Content-Length: 119\r\n
\r\n
{
    "seq": 153,
    "type": "request",
    "command": "next",
    "arguments": {
        "threadId": 3
    }
}
\r\n
Content-Length: 119\r\n
\r\n
{
    "seq": 153,
    "type": "request",
    "command": "next",
    "arguments": {
        "threadId": 3
    }
}
\r\n
```

Release Notes:

- N/A
