### PR TITLE
gpui: Fix copying files across apps on x11

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -1044,7 +1044,7 @@ impl App {
 
     /// Writes file to the platform clipboard.
     #[cfg(feature = "x11")]
-    pub fn write_file_to_clipboard(&self, item: ClipboardItem) {
+    pub fn write_file_to_clipboard(&self, item: Vec<ClipboardItem>) {
         self.platform.write_file_to_clipboard(item);
     }
 

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -1042,6 +1042,12 @@ impl App {
         self.platform.write_to_clipboard(item)
     }
 
+    /// Writes file to the platform clipboard.
+    #[cfg(feature = "x11")]
+    pub fn write_file_to_clipboard(&self, item: ClipboardItem) {
+        self.platform.write_file_to_clipboard(item);
+    }
+
     /// Reads data from the primary selection buffer.
     /// Only available on Linux.
     #[cfg(any(target_os = "linux", target_os = "freebsd"))]

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -262,6 +262,8 @@ pub(crate) trait Platform: 'static {
     #[cfg(any(target_os = "linux", target_os = "freebsd"))]
     fn write_to_primary(&self, item: ClipboardItem);
     fn write_to_clipboard(&self, item: ClipboardItem);
+    #[cfg(feature = "x11")]
+    fn write_file_to_clipboard(&self, item: ClipboardItem);
     #[cfg(any(target_os = "linux", target_os = "freebsd"))]
     fn read_from_primary(&self) -> Option<ClipboardItem>;
     fn read_from_clipboard(&self) -> Option<ClipboardItem>;

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -263,7 +263,7 @@ pub(crate) trait Platform: 'static {
     fn write_to_primary(&self, item: ClipboardItem);
     fn write_to_clipboard(&self, item: ClipboardItem);
     #[cfg(feature = "x11")]
-    fn write_file_to_clipboard(&self, item: ClipboardItem);
+    fn write_file_to_clipboard(&self, item: Vec<ClipboardItem>);
     #[cfg(any(target_os = "linux", target_os = "freebsd"))]
     fn read_from_primary(&self) -> Option<ClipboardItem>;
     fn read_from_clipboard(&self) -> Option<ClipboardItem>;

--- a/crates/gpui/src/platform/linux/headless/client.rs
+++ b/crates/gpui/src/platform/linux/headless/client.rs
@@ -113,6 +113,8 @@ impl LinuxClient for HeadlessClient {
 
     fn write_to_clipboard(&self, _item: crate::ClipboardItem) {}
 
+    fn write_file_to_clipboard(&self, _item: crate::ClipboardItem) {}
+
     fn read_from_primary(&self) -> Option<crate::ClipboardItem> {
         None
     }

--- a/crates/gpui/src/platform/linux/headless/client.rs
+++ b/crates/gpui/src/platform/linux/headless/client.rs
@@ -113,7 +113,7 @@ impl LinuxClient for HeadlessClient {
 
     fn write_to_clipboard(&self, _item: crate::ClipboardItem) {}
 
-    fn write_file_to_clipboard(&self, _item: crate::ClipboardItem) {}
+    fn write_file_to_clipboard(&self, _item: Vec<crate::ClipboardItem>) {}
 
     fn read_from_primary(&self) -> Option<crate::ClipboardItem> {
         None

--- a/crates/gpui/src/platform/linux/headless/client.rs
+++ b/crates/gpui/src/platform/linux/headless/client.rs
@@ -113,6 +113,7 @@ impl LinuxClient for HeadlessClient {
 
     fn write_to_clipboard(&self, _item: crate::ClipboardItem) {}
 
+    #[cfg(feature = "x11")]
     fn write_file_to_clipboard(&self, _item: Vec<crate::ClipboardItem>) {}
 
     fn read_from_primary(&self) -> Option<crate::ClipboardItem> {

--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -69,7 +69,7 @@ pub trait LinuxClient {
     fn write_to_primary(&self, item: ClipboardItem);
     fn write_to_clipboard(&self, item: ClipboardItem);
     #[cfg(feature = "x11")]
-    fn write_file_to_clipboard(&self, item: ClipboardItem);
+    fn write_file_to_clipboard(&self, item: Vec<ClipboardItem>);
     fn read_from_primary(&self) -> Option<ClipboardItem>;
     fn read_from_clipboard(&self) -> Option<ClipboardItem>;
     fn active_window(&self) -> Option<AnyWindowHandle>;
@@ -584,7 +584,7 @@ impl<P: LinuxClient + 'static> Platform for P {
     }
 
     #[cfg(feature = "x11")]
-    fn write_file_to_clipboard(&self, item: ClipboardItem) {
+    fn write_file_to_clipboard(&self, item: Vec<ClipboardItem>) {
         self.write_file_to_clipboard(item)
     }
 

--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -68,6 +68,8 @@ pub trait LinuxClient {
     fn reveal_path(&self, path: PathBuf);
     fn write_to_primary(&self, item: ClipboardItem);
     fn write_to_clipboard(&self, item: ClipboardItem);
+    #[cfg(feature = "x11")]
+    fn write_file_to_clipboard(&self, item: ClipboardItem);
     fn read_from_primary(&self) -> Option<ClipboardItem>;
     fn read_from_clipboard(&self) -> Option<ClipboardItem>;
     fn active_window(&self) -> Option<AnyWindowHandle>;
@@ -579,6 +581,11 @@ impl<P: LinuxClient + 'static> Platform for P {
 
     fn write_to_clipboard(&self, item: ClipboardItem) {
         self.write_to_clipboard(item)
+    }
+
+    #[cfg(feature = "x11")]
+    fn write_file_to_clipboard(&self, item: ClipboardItem) {
+        self.write_file_to_clipboard(item)
     }
 
     fn read_from_primary(&self) -> Option<ClipboardItem> {

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -839,6 +839,8 @@ impl LinuxClient for WaylandClient {
         }
     }
 
+    fn write_file_to_clipboard(&self, _item: crate::ClipboardItem) {}
+
     fn read_from_primary(&self) -> Option<crate::ClipboardItem> {
         self.0.borrow_mut().clipboard.read_primary()
     }

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -839,7 +839,7 @@ impl LinuxClient for WaylandClient {
         }
     }
 
-    fn write_file_to_clipboard(&self, _item: crate::ClipboardItem) {}
+    fn write_file_to_clipboard(&self, _item: Vec<crate::ClipboardItem>) {}
 
     fn read_from_primary(&self) -> Option<crate::ClipboardItem> {
         self.0.borrow_mut().clipboard.read_primary()

--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -1570,9 +1570,7 @@ impl LinuxClient for X11Client {
         let mut state = self.0.borrow_mut();
         let abs_item_paths = item
             .iter()
-            .map(|item| {
-                format!("file://{}", item.text().unwrap_or_default())
-            })
+            .map(|item| format!("file://{}", item.text().unwrap_or_default()))
             .collect::<Vec<String>>()
             .join("\n");
         state

--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -1566,19 +1566,25 @@ impl LinuxClient for X11Client {
         state.clipboard_item.replace(item);
     }
 
-    fn write_file_to_clipboard(&self, item: crate::ClipboardItem) {
+    fn write_file_to_clipboard(&self, item: Vec<crate::ClipboardItem>) {
         let mut state = self.0.borrow_mut();
-        let file_path = format!("file://{}", item.text().unwrap_or_default());
+        let abs_item_paths = item
+            .iter()
+            .map(|item| {
+                format!("file://{}", item.text().unwrap_or_default())
+            })
+            .collect::<Vec<String>>()
+            .join("\n");
         state
             .clipboard
             .set_file(
-                std::borrow::Cow::Owned(file_path),
+                std::borrow::Cow::Owned(abs_item_paths),
                 clipboard::ClipboardKind::Clipboard,
                 clipboard::WaitConfig::None,
             )
             .context("X11: Failed to write to clipboard (clipboard)")
             .log_with_level(log::Level::Debug);
-        state.clipboard_item.replace(item);
+        state.clipboard_item.replace(item.first().unwrap().clone());
     }
 
     fn read_from_primary(&self) -> Option<crate::ClipboardItem> {

--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -1566,6 +1566,21 @@ impl LinuxClient for X11Client {
         state.clipboard_item.replace(item);
     }
 
+    fn write_file_to_clipboard(&self, item: crate::ClipboardItem) {
+        let mut state = self.0.borrow_mut();
+        let file_path = format!("file://{}", item.text().unwrap_or_default());
+        state
+            .clipboard
+            .set_file(
+                std::borrow::Cow::Owned(file_path),
+                clipboard::ClipboardKind::Clipboard,
+                clipboard::WaitConfig::None,
+            )
+            .context("X11: Failed to write to clipboard (clipboard)")
+            .log_with_level(log::Level::Debug);
+        state.clipboard_item.replace(item);
+    }
+
     fn read_from_primary(&self) -> Option<crate::ClipboardItem> {
         let state = self.0.borrow_mut();
         state

--- a/crates/gpui/src/platform/linux/x11/clipboard.rs
+++ b/crates/gpui/src/platform/linux/x11/clipboard.rs
@@ -77,7 +77,7 @@ x11rb::atom_manager! {
         TEXT_MIME_UNKNOWN: b"text/plain",
 
         // HTML: b"text/html",
-        // URI_LIST: b"text/uri-list",
+        URI_LIST: b"text/uri-list",
 
         PNG__MIME: ImageFormat::mime_type(ImageFormat::Png ).as_bytes(),
         JPEG_MIME: ImageFormat::mime_type(ImageFormat::Jpeg).as_bytes(),
@@ -985,6 +985,19 @@ impl Clipboard {
         let data = vec![ClipboardData {
             bytes: message.into_owned().into_bytes(),
             format: self.inner.atoms.UTF8_STRING,
+        }];
+        self.inner.write(data, selection, wait)
+    }
+
+    pub(crate) fn set_file(
+        &self,
+        message: Cow<'_, str>,
+        selection: ClipboardKind,
+        wait: WaitConfig,
+    ) -> Result<()> {
+        let data = vec![ClipboardData {
+            bytes: message.into_owned().into_bytes(),
+            format: self.inner.atoms.URI_LIST,
         }];
         self.inner.write(data, selection, wait)
     }

--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -1099,6 +1099,8 @@ impl Platform for MacPlatform {
         }
     }
 
+    fn write_file_to_clipboard(&self, item: Vec<ClipboardItem>) {}
+
     fn read_from_clipboard(&self) -> Option<ClipboardItem> {
         let state = self.0.lock();
         let pasteboard = state.pasteboard;

--- a/crates/gpui/src/platform/test/platform.rs
+++ b/crates/gpui/src/platform/test/platform.rs
@@ -403,6 +403,9 @@ impl Platform for TestPlatform {
         *self.current_clipboard_item.lock() = Some(item);
     }
 
+    #[cfg(feature = "x11")]
+    fn write_file_to_clipboard(&self, _item: Vec<ClipboardItem>) {}
+
     #[cfg(any(target_os = "linux", target_os = "freebsd"))]
     fn read_from_primary(&self) -> Option<ClipboardItem> {
         self.current_primary_item.lock().clone()

--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -571,6 +571,8 @@ impl Platform for WindowsPlatform {
         write_to_clipboard(item);
     }
 
+    fn write_file_to_clipboard(&self, item: Vec<ClipboardItem>) {}
+
     fn read_from_clipboard(&self) -> Option<ClipboardItem> {
         read_from_clipboard()
     }

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -2573,6 +2573,19 @@ impl ProjectPanel {
     fn copy(&mut self, _: &Copy, _: &mut Window, cx: &mut Context<Self>) {
         let entries = self.disjoint_entries(cx);
         if !entries.is_empty() {
+            let first_entry = entries.last().unwrap();
+
+            let project = self.project.read(cx);
+            let entry_path = project.path_for_entry(first_entry.entry_id, cx).unwrap().path;
+            let abs_entry_path = project
+                .worktree_for_id(first_entry.worktree_id, cx).unwrap()
+                .read(cx)
+                .absolutize(&entry_path)
+                .to_string_lossy()
+                .to_string();
+
+            cx.write_file_to_clipboard(ClipboardItem::new_string(abs_entry_path));
+
             self.clipboard = Some(ClipboardEntry::Copied(entries));
             cx.notify();
         }

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -2573,18 +2573,22 @@ impl ProjectPanel {
     fn copy(&mut self, _: &Copy, _: &mut Window, cx: &mut Context<Self>) {
         let entries = self.disjoint_entries(cx);
         if !entries.is_empty() {
-            let first_entry = entries.last().unwrap();
-
             let project = self.project.read(cx);
-            let entry_path = project.path_for_entry(first_entry.entry_id, cx).unwrap().path;
-            let abs_entry_path = project
-                .worktree_for_id(first_entry.worktree_id, cx).unwrap()
-                .read(cx)
-                .absolutize(&entry_path)
-                .to_string_lossy()
-                .to_string();
+            let items: Vec<ClipboardItem> = entries
+                .iter()
+                .map(|entry| {
+                    let entry_path = project.path_for_entry(entry.entry_id, cx).unwrap().path;
+                    let abs_entry_path = project
+                        .worktree_for_id(entry.worktree_id, cx).unwrap()
+                        .read(cx)
+                        .absolutize(&entry_path)
+                        .to_string_lossy()
+                        .to_string();
+                    ClipboardItem::new_string(abs_entry_path)
+                })
+                .collect();
 
-            cx.write_file_to_clipboard(ClipboardItem::new_string(abs_entry_path));
+            cx.write_file_to_clipboard(items);
 
             self.clipboard = Some(ClipboardEntry::Copied(entries));
             cx.notify();

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -2576,15 +2576,15 @@ impl ProjectPanel {
             let project = self.project.read(cx);
             let items: Vec<ClipboardItem> = entries
                 .iter()
-                .map(|entry| {
-                    let entry_path = project.path_for_entry(entry.entry_id, cx).unwrap().path;
+                .filter_map(|entry| {
+                    let entry_path = project.path_for_entry(entry.entry_id, cx)?.path;
                     let abs_entry_path = project
-                        .worktree_for_id(entry.worktree_id, cx).unwrap()
+                        .worktree_for_id(entry.worktree_id, cx)?
                         .read(cx)
                         .absolutize(&entry_path)
                         .to_string_lossy()
                         .to_string();
-                    ClipboardItem::new_string(abs_entry_path)
+                    Some(ClipboardItem::new_string(abs_entry_path))
                 })
                 .collect();
 


### PR DESCRIPTION
Fix copy file issue on x11 mentioned in this issue https://github.com/zed-industries/zed/issues/29026.

Release Notes:
- Fixed file copying across different apps on x11 window system.
