### PR TITLE
remote: Support building x86_64-linux-musl proxy in nix-darwin

### DIFF
--- a/crates/remote/src/transport.rs
+++ b/crates/remote/src/transport.rs
@@ -206,30 +206,22 @@ async fn build_remote_server_from_source(
         )
         .await?;
     } else {
-        let which = cx
-            .background_spawn(async move { which::which("zig") })
-            .await;
-
-        if which.is_err() {
-            #[cfg(not(target_os = "windows"))]
-            {
-                anyhow::bail!(
-                    "zig not found on $PATH, install zig (see https://ziglang.org/learn/getting-started or use zigup)"
-                )
-            }
-            #[cfg(target_os = "windows")]
-            {
-                anyhow::bail!(
-                    "zig not found on $PATH, install zig (use `winget install -e --id zig.zig` or see https://ziglang.org/learn/getting-started or use zigup)"
-                )
-            }
+        if which("zig", cx).await?.is_none() {
+            anyhow::bail!(if cfg!(not(windows)) {
+                "zig not found on $PATH, install zig (see https://ziglang.org/learn/getting-started or use zigup)"
+            } else {
+                "zig not found on $PATH, install zig (use `winget install -e --id zig.zig` or see https://ziglang.org/learn/getting-started or use zigup)"
+            });
         }
 
-        if build_remote_server.contains("noinstall") {
-            delegate.set_status(Some("Adding rustup target for cross-compilation"), cx);
-            log::info!("adding rustup target");
-            run_cmd(Command::new("rustup").args(["target", "add"]).arg(&triple)).await?;
+        let rustup = which("rustup", cx)
+            .await?
+            .context("rustup not found on $PATH, install rustup (see https://rustup.rs/)")?;
+        delegate.set_status(Some("Adding rustup target for cross-compilation"), cx);
+        log::info!("adding rustup target");
+        run_cmd(Command::new(rustup).args(["target", "add"]).arg(&triple)).await?;
 
+        if which("cargo-zigbuild", cx).await?.is_none() {
             delegate.set_status(Some("Installing cargo-zigbuild for cross-compilation"), cx);
             log::info!("installing cargo-zigbuild");
             run_cmd(Command::new("cargo").args(["install", "--locked", "cargo-zigbuild"])).await?;
@@ -276,7 +268,9 @@ async fn build_remote_server_from_source(
         #[cfg(target_os = "windows")]
         {
             // On Windows, we use 7z to compress the binary
-            let seven_zip = which::which("7z.exe").context("7z.exe not found on $PATH, install it (e.g. with `winget install -e --id 7zip.7zip`) or, if you don't want this behaviour, set $env:ZED_BUILD_REMOTE_SERVER=\"nocompress\"")?;
+            let seven_zip = which("7z.exe",cx)
+                .await?
+                .context("7z.exe not found on $PATH, install it (e.g. with `winget install -e --id 7zip.7zip`) or, if you don't want this behaviour, set $env:ZED_BUILD_REMOTE_SERVER=\"nocompress\"")?;
             let gz_path = format!("target/remote_server/{}/debug/remote_server.gz", triple);
             if smol::fs::metadata(&gz_path).await.is_ok() {
                 smol::fs::remove_file(&gz_path).await?;
@@ -298,4 +292,23 @@ async fn build_remote_server_from_source(
     };
 
     Ok(Some(path))
+}
+
+#[cfg(debug_assertions)]
+async fn which(
+    binary_name: impl AsRef<str>,
+    cx: &mut AsyncApp,
+) -> Result<Option<std::path::PathBuf>> {
+    let binary_name = binary_name.as_ref().to_string();
+    let binary_name_cloned = binary_name.clone();
+    let res = cx
+        .background_spawn(async move { which::which(binary_name_cloned) })
+        .await;
+    match res {
+        Ok(path) => Ok(Some(path)),
+        Err(which::Error::CannotFindBinaryPath) => Ok(None),
+        Err(err) => Err(anyhow::anyhow!(
+            "Failed to run 'which' to find the binary '{binary_name}': {err}"
+        )),
+    }
 }

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -6,6 +6,7 @@
   zed-editor,
 
   rust-analyzer,
+  rustup,
   cargo-nextest,
   cargo-hakari,
   cargo-machete,
@@ -19,6 +20,7 @@
   inputsFrom = [ zed-editor ];
   packages = [
     rust-analyzer
+    rustup
     cargo-nextest
     cargo-hakari
     cargo-machete
@@ -56,7 +58,6 @@
         ];
       };
       PROTOC = "${protobuf}/bin/protoc";
-      ZED_BUILD_REMOTE_SERVER = "noinstall";
       ZED_ZSTD_MUSL_LIB = "${pkgsCross.musl64.pkgsStatic.zstd.out}/lib";
     };
 }

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,6 +1,7 @@
 {
   mkShell,
   makeFontsConf,
+  pkgsCross,
 
   zed-editor,
 
@@ -8,9 +9,11 @@
   cargo-nextest,
   cargo-hakari,
   cargo-machete,
+  cargo-zigbuild,
   nixfmt-rfc-style,
   protobuf,
   nodejs_22,
+  zig,
 }:
 (mkShell.override { inherit (zed-editor) stdenv; }) {
   inputsFrom = [ zed-editor ];
@@ -19,6 +22,7 @@
     cargo-nextest
     cargo-hakari
     cargo-machete
+    cargo-zigbuild
     nixfmt-rfc-style
     # TODO: package protobuf-language-server for editing zed.proto
     # TODO: add other tools used in our scripts
@@ -26,6 +30,7 @@
     # `build.nix` adds this to the `zed-editor` wrapper (see `postFixup`)
     # we'll just put it on `$PATH`:
     nodejs_22
+    zig
   ];
 
   env =
@@ -51,5 +56,7 @@
         ];
       };
       PROTOC = "${protobuf}/bin/protoc";
+      ZED_BUILD_REMOTE_SERVER = "noinstall";
+      ZED_ZSTD_MUSL_LIB = "${pkgsCross.musl64.pkgsStatic.zstd.out}/lib";
     };
 }


### PR DESCRIPTION
Thanks to this change I can ssh into a linux box from macOS running nix-darwin :tada: This change adds two things to our remote server build process:
1. If `ZED_BUILD_REMOTE_SERVER` contains `noinstall`, the process will skip adding a rustup target and install `cargo-zigbuild` - we assume you would have already done that.
2. If `ZED_BUILD_REMOTE_SERVER` contains `musl` and `ZED_ZSTD_MUSL_LIB` is set, we will pass its value (the path) to `cargo-zigbuild` as `-C link-arg=-L{path}`.

Release Notes:

- N/A
