### PR TITLE
collab: Add 'Copy channel notes link' to right click menu on channels

### DIFF
--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -1265,6 +1265,13 @@ impl CollabPanel {
                     window.handler_for(&this, move |this, _, cx| {
                         this.copy_channel_link(channel_id, cx)
                     }),
+                )
+                .entry(
+                    "Copy Channel Notes Link",
+                    None,
+                    window.handler_for(&this, move |this, _, cx| {
+                        this.copy_channel_notes_link(channel_id, cx)
+                    }),
                 );
 
             let mut has_destructive_actions = false;
@@ -2217,6 +2224,15 @@ impl CollabPanel {
             return;
         };
         let item = ClipboardItem::new_string(channel.link(cx));
+        cx.write_to_clipboard(item)
+    }
+
+    fn copy_channel_notes_link(&mut self, channel_id: ChannelId, cx: &mut Context<Self>) {
+        let channel_store = self.channel_store.read(cx);
+        let Some(channel) = channel_store.channel_for_id(channel_id) else {
+            return;
+        };
+        let item = ClipboardItem::new_string(channel.notes_link(None, cx));
         cx.write_to_clipboard(item)
     }
 


### PR DESCRIPTION
Release Notes:

- Added a "Copy Channel Notes Link" action to right-click menu of Zed channels.
