### PR TITLE
gpui: Add a timeout to `#[gpui::test]` tests

### DIFF
--- a/crates/extension/src/extension_builder.rs
+++ b/crates/extension/src/extension_builder.rs
@@ -411,6 +411,8 @@ impl ExtensionBuilder {
         let mut clang_path = wasi_sdk_dir.clone();
         clang_path.extend(["bin", &format!("clang{}", env::consts::EXE_SUFFIX)]);
 
+        log::info!("downloading wasi-sdk to {}", wasi_sdk_dir.display());
+
         if fs::metadata(&clang_path).is_ok_and(|metadata| metadata.is_file()) {
             return Ok(clang_path);
         }
@@ -431,9 +433,11 @@ impl ExtensionBuilder {
         });
         let tar = Archive::new(body);
 
+        log::info!("un-tarring wasi-sdk to {}", wasi_sdk_dir.display());
         tar.unpack(&tar_out_dir)
             .await
             .context("failed to unpack wasi-sdk archive")?;
+        log::info!("finished downloading wasi-sdk");
 
         let inner_dir = fs::read_dir(&tar_out_dir)?
             .next()

--- a/crates/extension_host/src/extension_store_test.rs
+++ b/crates/extension_host/src/extension_store_test.rs
@@ -529,10 +529,6 @@ async fn test_extension_store(cx: &mut TestAppContext) {
     });
 }
 
-// todo(windows)
-// Disable this test on Windows for now. Because this test hangs at
-// `let fake_server = fake_servers.next().await.unwrap();`.
-// Reenable this test when we figure out why.
 #[gpui::test]
 async fn test_extension_store_with_test_extension(cx: &mut TestAppContext) {
     init_test(cx);

--- a/crates/extension_host/src/extension_store_test.rs
+++ b/crates/extension_host/src/extension_store_test.rs
@@ -31,7 +31,8 @@ use util::test::TempTree;
 #[cfg(test)]
 #[ctor::ctor]
 fn init_logger() {
-    zlog::init_test();
+    // show info logs while we debug the extension_store tests hanging.
+    zlog::init_test_with("info");
 }
 
 #[gpui::test]

--- a/crates/zlog/src/zlog.rs
+++ b/crates/zlog/src/zlog.rs
@@ -10,22 +10,28 @@ pub use sink::{flush, init_output_file, init_output_stderr, init_output_stdout};
 pub const SCOPE_DEPTH_MAX: usize = 4;
 
 pub fn init() {
-    if let Err(err) = try_init() {
+    if let Err(err) = try_init(None) {
         log::error!("{err}");
         eprintln!("{err}");
     }
 }
 
-pub fn try_init() -> anyhow::Result<()> {
+pub fn try_init(filter: Option<String>) -> anyhow::Result<()> {
     log::set_logger(&ZLOG)?;
     log::set_max_level(log::LevelFilter::max());
-    process_env();
+    process_env(filter);
     filter::refresh_from_settings(&std::collections::HashMap::default());
     Ok(())
 }
 
 pub fn init_test() {
-    if get_env_config().is_some() && try_init().is_ok() {
+    if get_env_config().is_some() && try_init(None).is_ok() {
+        init_output_stdout();
+    }
+}
+
+pub fn init_test_with(filter: &str) {
+    if try_init(Some(filter.to_owned())).is_ok() {
         init_output_stdout();
     }
 }
@@ -36,8 +42,8 @@ fn get_env_config() -> Option<String> {
         .ok()
 }
 
-pub fn process_env() {
-    let Some(env_config) = get_env_config() else {
+pub fn process_env(filter: Option<String>) {
+    let Some(env_config) = get_env_config().or(filter) else {
         return;
     };
     match env_config::parse(&env_config) {


### PR DESCRIPTION
This adds a general timeout to gpui test fixtures to prevent CI getting stuck for an hour and then getting killed through the CI timeout.

Release Notes:

- N/A *or* Added/Fixed/Improved ...


Co-authored-by: Conrad Irwin <conrad@zed.dev>
Co-authored-by: Ben Kunkle <ben@zed.dev>
