### PR TITLE
Don't upload symbols to DO anymore

### DIFF
--- a/script/bundle-linux
+++ b/script/bundle-linux
@@ -101,25 +101,9 @@ else
 fi
 
 # Strip debug symbols and save them for upload to DigitalOcean
-objcopy --only-keep-debug "${target_dir}/${target_triple}/release/zed" "${target_dir}/${target_triple}/release/zed.dbg"
-objcopy --only-keep-debug "${target_dir}/${remote_server_triple}/release/remote_server" "${target_dir}/${remote_server_triple}/release/remote_server.dbg"
 objcopy --strip-debug "${target_dir}/${target_triple}/release/zed"
 objcopy --strip-debug "${target_dir}/${target_triple}/release/cli"
 objcopy --strip-debug "${target_dir}/${remote_server_triple}/release/remote_server"
-
-gzip -f "${target_dir}/${target_triple}/release/zed.dbg"
-gzip -f "${target_dir}/${remote_server_triple}/release/remote_server.dbg"
-
-if [[ -n "${DIGITALOCEAN_SPACES_SECRET_KEY:-}" && -n "${DIGITALOCEAN_SPACES_ACCESS_KEY:-}" ]]; then
-    upload_to_blob_store_public \
-        "zed-debug-symbols" \
-        "${target_dir}/${target_triple}/release/zed.dbg.gz" \
-        "$channel/zed-$version-${target_triple}.dbg.gz"
-    upload_to_blob_store_public \
-        "zed-debug-symbols" \
-        "${target_dir}/${remote_server_triple}/release/remote_server.dbg.gz" \
-        "$channel/remote_server-$version-${remote_server_triple}.dbg.gz"
-fi
 
 # Ensure that remote_server does not depend on libssl nor libcrypto, as we got rid of these deps.
 if ldd "${target_dir}/${remote_server_triple}/release/remote_server" | grep -q 'libcrypto\|libssl'; then

--- a/script/bundle-mac
+++ b/script/bundle-mac
@@ -193,31 +193,6 @@ function prepare_binaries() {
     local architecture=$1
     local app_path=$2
 
-    echo "Unpacking dSYMs for $architecture"
-    exe_path="target/${architecture}/${target_dir}/Zed"
-    if ! dsymutil --flat "${exe_path}" 2> target/dsymutil.log; then
-        echo "dsymutil failed"
-        cat target/dsymutil.log
-        exit 1
-    fi
-    uuid=$(dwarfdump --uuid "${exe_path}" | cut -d ' ' -f 2 | tr 'A-F' 'a-f')
-    version="$(cargo metadata --no-deps --manifest-path crates/zed/Cargo.toml --offline --format-version=1 | jq -r '.packages | map(select(.name == "zed"))[0].version')"
-    if [ "$channel" == "nightly" ]; then
-        version="$version-$(git rev-parse --short HEAD)"
-    fi
-
-    echo "Removing existing gzipped dSYMs for $architecture"
-    rm -f target/${architecture}/${target_dir}/Zed.dwarf.gz
-
-    echo "Gzipping dSYMs for $architecture"
-    gzip -kf target/${architecture}/${target_dir}/Zed.dwarf
-
-    echo "Uploading dSYMs${architecture} for $architecture to by-uuid/${uuid}.dwarf.gz"
-    upload_to_blob_store_public \
-        "zed-debug-symbols" \
-        target/${architecture}/${target_dir}/Zed.dwarf.gz \
-        "by-uuid/${uuid}.dwarf.gz"
-
     cp target/${architecture}/${target_dir}/zed "${app_path}/Contents/MacOS/zed"
     cp target/${architecture}/${target_dir}/cli "${app_path}/Contents/MacOS/cli"
 }

--- a/script/bundle-windows.ps1
+++ b/script/bundle-windows.ps1
@@ -5,7 +5,6 @@ Param(
     [Parameter()][string]$Name
 )
 
-. "$PSScriptRoot/lib/blob-store.ps1"
 . "$PSScriptRoot/lib/workspace.ps1"
 
 # https://stackoverflow.com/questions/57949031/powershell-script-stops-if-program-fails-like-bash-set-o-errexit
@@ -293,7 +292,6 @@ DownloadConpty
 CollectFiles
 BuildInstaller
 
-UploadToBlobStorePublic -BucketName "zed-debug-symbols" -FileToUpload $debugArchive -BlobStoreKey $debugStoreKey
 UploadToSentry
 
 if ($buildSuccess) {

--- a/script/install-mold
+++ b/script/install-mold
@@ -12,12 +12,10 @@
 
 set -euo pipefail
 
-MOLD_VERSION="${MOLD_VERSION:-${1:-}}"
+MOLD_VERSION="2.34.0"
+
 if [ "$(uname -s)" != "Linux" ]; then
     echo "Error: This script is intended for Linux systems only."
-    exit 1
-elif [ -z "$MOLD_VERSION" ]; then
-    echo "Usage: $0 2.34.0"
     exit 1
 elif [ -e /usr/local/bin/mold ]; then
     echo "Warning: existing mold found at /usr/local/bin/mold. Skipping installation."


### PR DESCRIPTION
Sentry now symbolicates stack traces, no need to make our builds slower

Release Notes:

- N/A
