### PR TITLE
git_ui: Dismiss pickers only on active window

### DIFF
--- a/crates/git_ui/src/branch_picker.rs
+++ b/crates/git_ui/src/branch_picker.rs
@@ -152,12 +152,9 @@ impl BranchList {
         let delegate = BranchListDelegate::new(repository, style);
         let picker = cx.new(|cx| Picker::uniform_list(delegate, window, cx));
 
-        let _subscription =
-            cx.subscribe_in(&picker, window, |_, _, _: &DismissEvent, window, cx| {
-                if window.is_window_active() {
-                    cx.emit(DismissEvent);
-                }
-            });
+        let _subscription = cx.subscribe(&picker, |_, _, _, cx| {
+            cx.emit(DismissEvent);
+        });
 
         Self {
             picker,

--- a/crates/git_ui/src/branch_picker.rs
+++ b/crates/git_ui/src/branch_picker.rs
@@ -151,9 +151,12 @@ impl BranchList {
 
         let delegate = BranchListDelegate::new(repository, style);
         let picker = cx.new(|cx| Picker::uniform_list(delegate, window, cx));
+        let focus_handle = picker.focus_handle(cx);
 
-        let _subscription = cx.subscribe(&picker, |_, _, _, cx| {
-            cx.emit(DismissEvent);
+        let _subscription = cx.on_focus_out(&focus_handle, window,  |_, _, window, cx| {
+            if window.is_window_active() {
+                cx.emit(DismissEvent);
+            }
         });
 
         Self {

--- a/crates/git_ui/src/branch_picker.rs
+++ b/crates/git_ui/src/branch_picker.rs
@@ -151,13 +151,13 @@ impl BranchList {
 
         let delegate = BranchListDelegate::new(repository, style);
         let picker = cx.new(|cx| Picker::uniform_list(delegate, window, cx));
-        let focus_handle = picker.focus_handle(cx);
 
-        let _subscription = cx.on_focus_out(&focus_handle, window,  |_, _, window, cx| {
-            if window.is_window_active() {
-                cx.emit(DismissEvent);
-            }
-        });
+        let _subscription =
+            cx.subscribe_in(&picker, window, |_, _, _: &DismissEvent, window, cx| {
+                if window.is_window_active() {
+                    cx.emit(DismissEvent);
+                }
+            });
 
         Self {
             picker,

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -501,7 +501,7 @@ impl<D: PickerDelegate> Picker<D> {
     }
 
     pub fn cancel(&mut self, _: &menu::Cancel, window: &mut Window, cx: &mut Context<Self>) {
-        if self.delegate.should_dismiss() {
+        if self.delegate.should_dismiss() && window.is_window_active() {
             self.delegate.dismissed(window, cx);
             cx.emit(DismissEvent);
         }

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -501,7 +501,7 @@ impl<D: PickerDelegate> Picker<D> {
     }
 
     pub fn cancel(&mut self, _: &menu::Cancel, window: &mut Window, cx: &mut Context<Self>) {
-        if self.delegate.should_dismiss() && window.is_window_active() {
+        if self.delegate.should_dismiss() {
             self.delegate.dismissed(window, cx);
             cx.emit(DismissEvent);
         }
@@ -598,7 +598,7 @@ impl<D: PickerDelegate> Picker<D> {
                 self.update_matches(query, window, cx);
             }
             editor::EditorEvent::Blurred => {
-                if self.is_modal {
+                if self.is_modal && window.is_window_active() {
                     self.cancel(&menu::Cancel, window, cx);
                 }
             }
@@ -610,7 +610,9 @@ impl<D: PickerDelegate> Picker<D> {
         let Head::Empty(_) = &self.head else {
             panic!("unexpected call");
         };
-        self.cancel(&menu::Cancel, window, cx);
+        if window.is_window_active() {
+            self.cancel(&menu::Cancel, window, cx);
+        }
     }
 
     pub fn refresh_placeholder(&mut self, window: &mut Window, cx: &mut App) {


### PR DESCRIPTION
Small QOL improvement for branch picker to only dismiss when focus lost in active window.
This can benefit those who need to switch windows mid branch creation to fetch correct jira ticket number or etc.

Added `window.is_active_window()` guard in `picker.rs`  -> `cancel` event

Release Notes:
- (Let's Git Together) Fixed a behavior where pickers would automatically close upon the window becoming inactive.