### PR TITLE
remote: 60 second timeout on initial connection

### DIFF
--- a/crates/remote/src/remote_client.rs
+++ b/crates/remote/src/remote_client.rs
@@ -87,6 +87,7 @@ pub trait RemoteClientDelegate: Send + Sync {
 const MAX_MISSED_HEARTBEATS: usize = 5;
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
 const HEARTBEAT_TIMEOUT: Duration = Duration::from_secs(5);
+const INITIAL_CONNECTION_TIMEOUT: Duration = Duration::from_secs(60);
 
 const MAX_RECONNECT_ATTEMPTS: usize = 3;
 
@@ -350,7 +351,7 @@ impl RemoteClient {
 
                 let ready = client
                     .wait_for_remote_started()
-                    .with_timeout(HEARTBEAT_TIMEOUT, cx.background_executor())
+                    .with_timeout(INITIAL_CONNECTION_TIMEOUT, cx.background_executor())
                     .await;
                 match ready {
                     Ok(Some(_)) => {}


### PR DESCRIPTION
Closes #41316

Release Notes:

- Fixes #41316 

> This keeps the 5 second heartbeat behavior for after the connection is made