### PR TITLE
Always delete OpenConsole.exe on Windows uninstall

### DIFF
--- a/crates/zed/resources/windows/zed.iss
+++ b/crates/zed/resources/windows/zed.iss
@@ -49,6 +49,10 @@ Name: "simplifiedChinese"; MessagesFile: "{#ResourcesDir}\messages\Default.zh-cn
 ; Delete logs
 Type: filesandordirs; Name: "{app}\tools"
 Type: filesandordirs; Name: "{app}\updates"
+; Delete newer files which may not have been added by the initial installation
+Type: filesandordirs; Name: "{app}\x64"
+Type: filesandordirs; Name: "{app}\arm64"
+
 
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked


### PR DESCRIPTION
By default, the uninstaller will only delete files that were written by the original installer. When users upgrade Zed, these new OpenConsole.exe files will have been written by auto_upgrade_helper, not the installer. Force them to be deleted on uninstall, so they do not hang around.

Release Notes:

- N/A
