### PR TITLE
editor: Fix calculate relative line number panic

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -3181,7 +3181,7 @@ impl EditorElement {
             i += 1;
         }
         delta = 1;
-        i = head_idx.min(buffer_rows.len() as u32 - 1);
+        i = head_idx.min(buffer_rows.len().saturating_sub(1) as u32);
         while i > 0 && buffer_rows[i as usize].buffer_row.is_none() && !count_wrapped_lines {
             i -= 1;
         }


### PR DESCRIPTION
### Reproduction steps

1. Turn on relative line numbers
2. Start a debugging session and hit an active debug line
3. minimize Zed so the editor element with the active debug line has zero visible rows

#### Before 
https://github.com/user-attachments/assets/57cc7a4d-478d-481a-8b70-f14c879bd858
#### After 
https://github.com/user-attachments/assets/19614104-f9aa-4b76-886b-1ad4a5985403

Release Notes:

- debugger: Fix a panic that could occur when minimizing Zed
