### PR TITLE
agent_ui: Don't show root project in path prefix in @-mention menu

### DIFF
--- a/crates/agent_ui/src/acp/completion_provider.rs
+++ b/crates/agent_ui/src/acp/completion_provider.rs
@@ -570,7 +570,7 @@ impl ContextPickerCompletionProvider {
             .unwrap_or_default();
         let workspace = workspace.read(cx);
         let project = workspace.project().read(cx);
-        let include_root_name = project.worktrees(cx).count() > 1;
+        let include_root_name = workspace.visible_worktrees(cx).count() > 1;
 
         if let Some(agent_panel) = workspace.panel::<AgentPanel>(cx)
             && let Some(thread) = agent_panel.read(cx).active_agent_thread(cx)

--- a/crates/agent_ui/src/acp/completion_provider.rs
+++ b/crates/agent_ui/src/acp/completion_provider.rs
@@ -570,6 +570,7 @@ impl ContextPickerCompletionProvider {
             .unwrap_or_default();
         let workspace = workspace.read(cx);
         let project = workspace.project().read(cx);
+        let include_root_name = project.worktrees(cx).count() > 1;
 
         if let Some(agent_panel) = workspace.panel::<AgentPanel>(cx)
             && let Some(thread) = agent_panel.read(cx).active_agent_thread(cx)
@@ -595,8 +596,12 @@ impl ContextPickerCompletionProvider {
                 .filter_map(|(project_path, _)| {
                     project
                         .worktree_for_id(project_path.worktree_id, cx)
-                        .map(|_worktree| {
-                            let path_prefix = RelPath::empty().into();
+                        .map(|worktree| {
+                            let path_prefix = if include_root_name {
+                                worktree.read(cx).root_name().into()
+                            } else {
+                                RelPath::empty().into()
+                            };
                             Match::File(FileMatch {
                                 mat: fuzzy::PathMatch {
                                     score: 1.,

--- a/crates/agent_ui/src/acp/message_editor.rs
+++ b/crates/agent_ui/src/acp/message_editor.rs
@@ -2179,10 +2179,10 @@ mod tests {
             assert_eq!(
                 current_completion_labels(editor),
                 &[
-                    format!("eight.txt dir{slash}b{slash}"),
-                    format!("seven.txt dir{slash}b{slash}"),
-                    format!("six.txt dir{slash}b{slash}"),
-                    format!("five.txt dir{slash}b{slash}"),
+                    format!("eight.txt b{slash}"),
+                    format!("seven.txt b{slash}"),
+                    format!("six.txt b{slash}"),
+                    format!("five.txt b{slash}"),
                 ]
             );
             editor.set_text("", window, cx);
@@ -2210,10 +2210,10 @@ mod tests {
             assert_eq!(
                 current_completion_labels(editor),
                 &[
-                    format!("eight.txt dir{slash}b{slash}"),
-                    format!("seven.txt dir{slash}b{slash}"),
-                    format!("six.txt dir{slash}b{slash}"),
-                    format!("five.txt dir{slash}b{slash}"),
+                    format!("eight.txt b{slash}"),
+                    format!("seven.txt b{slash}"),
+                    format!("six.txt b{slash}"),
+                    format!("five.txt b{slash}"),
                     "Files & Directories".into(),
                     "Symbols".into(),
                     "Threads".into(),
@@ -2246,7 +2246,7 @@ mod tests {
             assert!(editor.has_visible_completions_menu());
             assert_eq!(
                 current_completion_labels(editor),
-                vec![format!("one.txt dir{slash}a{slash}")]
+                vec![format!("one.txt a{slash}")]
             );
         });
 
@@ -2516,7 +2516,7 @@ mod tests {
                 format!("Lorem [@one.txt]({url_one})  Ipsum [@eight.txt]({url_eight}) [@MySymbol]({}) @file x.png", symbol.to_uri())
             );
             assert!(editor.has_visible_completions_menu());
-            assert_eq!(current_completion_labels(editor), &[format!("x.png dir{slash}")]);
+            assert_eq!(current_completion_labels(editor), &[format!("x.png ")]);
         });
 
         editor.update_in(&mut cx, |editor, window, cx| {
@@ -2558,7 +2558,7 @@ mod tests {
                         format!("Lorem [@one.txt]({url_one})  Ipsum [@eight.txt]({url_eight}) [@MySymbol]({}) @file x.png", symbol.to_uri())
                     );
                     assert!(editor.has_visible_completions_menu());
-                    assert_eq!(current_completion_labels(editor), &[format!("x.png dir{slash}")]);
+                    assert_eq!(current_completion_labels(editor), &[format!("x.png ")]);
                 });
 
         editor.update_in(&mut cx, |editor, window, cx| {

--- a/crates/agent_ui/src/acp/message_editor.rs
+++ b/crates/agent_ui/src/acp/message_editor.rs
@@ -2516,7 +2516,7 @@ mod tests {
                 format!("Lorem [@one.txt]({url_one})  Ipsum [@eight.txt]({url_eight}) [@MySymbol]({}) @file x.png", symbol.to_uri())
             );
             assert!(editor.has_visible_completions_menu());
-            assert_eq!(current_completion_labels(editor), &[format!("x.png ")]);
+            assert_eq!(current_completion_labels(editor), &["x.png "]);
         });
 
         editor.update_in(&mut cx, |editor, window, cx| {
@@ -2558,7 +2558,7 @@ mod tests {
                         format!("Lorem [@one.txt]({url_one})  Ipsum [@eight.txt]({url_eight}) [@MySymbol]({}) @file x.png", symbol.to_uri())
                     );
                     assert!(editor.has_visible_completions_menu());
-                    assert_eq!(current_completion_labels(editor), &[format!("x.png ")]);
+                    assert_eq!(current_completion_labels(editor), &["x.png "]);
                 });
 
         editor.update_in(&mut cx, |editor, window, cx| {

--- a/crates/agent_ui/src/context_picker.rs
+++ b/crates/agent_ui/src/context_picker.rs
@@ -662,7 +662,7 @@ pub(crate) fn recent_context_picker_entries(
     let mut recent = Vec::with_capacity(6);
     let workspace = workspace.read(cx);
     let project = workspace.project().read(cx);
-    let include_root_name = project.worktrees(cx).count() > 1;
+    let include_root_name = workspace.visible_worktrees(cx).count() > 1;
 
     recent.extend(
         workspace

--- a/crates/agent_ui/src/context_picker.rs
+++ b/crates/agent_ui/src/context_picker.rs
@@ -675,9 +675,9 @@ pub(crate) fn recent_context_picker_entries(
             .filter_map(|(project_path, _)| {
                 project
                     .worktree_for_id(project_path.worktree_id, cx)
-                    .map(|worktree| RecentEntry::File {
+                    .map(|_worktree| RecentEntry::File {
                         project_path,
-                        path_prefix: worktree.read(cx).root_name().into(),
+                        path_prefix: RelPath::empty().into(),
                     })
             }),
     );

--- a/crates/agent_ui/src/context_picker.rs
+++ b/crates/agent_ui/src/context_picker.rs
@@ -662,6 +662,7 @@ pub(crate) fn recent_context_picker_entries(
     let mut recent = Vec::with_capacity(6);
     let workspace = workspace.read(cx);
     let project = workspace.project().read(cx);
+    let include_root_name = project.worktrees(cx).count() > 1;
 
     recent.extend(
         workspace
@@ -675,9 +676,16 @@ pub(crate) fn recent_context_picker_entries(
             .filter_map(|(project_path, _)| {
                 project
                     .worktree_for_id(project_path.worktree_id, cx)
-                    .map(|_worktree| RecentEntry::File {
-                        project_path,
-                        path_prefix: RelPath::empty().into(),
+                    .map(|worktree| {
+                        let path_prefix = if include_root_name {
+                            worktree.read(cx).root_name().into()
+                        } else {
+                            RelPath::empty().into()
+                        };
+                        RecentEntry::File {
+                            project_path,
+                            path_prefix,
+                        }
                     })
             }),
     );

--- a/crates/agent_ui/src/context_picker/completion_provider.rs
+++ b/crates/agent_ui/src/context_picker/completion_provider.rs
@@ -1320,10 +1320,10 @@ mod tests {
             assert_eq!(
                 current_completion_labels(editor),
                 &[
-                    format!("seven.txt dir{slash}b{slash}"),
-                    format!("six.txt dir{slash}b{slash}"),
-                    format!("five.txt dir{slash}b{slash}"),
-                    format!("four.txt dir{slash}a{slash}"),
+                    format!("seven.txt b{slash}"),
+                    format!("six.txt b{slash}"),
+                    format!("five.txt b{slash}"),
+                    format!("four.txt a{slash}"),
                     "Files & Directories".into(),
                     "Symbols".into(),
                     "Fetch".into()
@@ -1355,7 +1355,7 @@ mod tests {
             assert!(editor.has_visible_completions_menu());
             assert_eq!(
                 current_completion_labels(editor),
-                vec![format!("one.txt dir{slash}a{slash}")]
+                vec![format!("one.txt a{slash}")]
             );
         });
 
@@ -1367,12 +1367,12 @@ mod tests {
         editor.update(&mut cx, |editor, cx| {
             assert_eq!(
                 editor.text(cx),
-                format!("Lorem [@one.txt](@file:dir{slash}a{slash}one.txt) ")
+                format!("Lorem [@one.txt](@file:a{slash}one.txt) ")
             );
             assert!(!editor.has_visible_completions_menu());
             assert_eq!(
                 fold_ranges(editor, cx),
-                vec![Point::new(0, 6)..Point::new(0, 37)]
+                vec![Point::new(0, 6)..Point::new(0, 33)]
             );
         });
 
@@ -1381,12 +1381,12 @@ mod tests {
         editor.update(&mut cx, |editor, cx| {
             assert_eq!(
                 editor.text(cx),
-                format!("Lorem [@one.txt](@file:dir{slash}a{slash}one.txt)  ")
+                format!("Lorem [@one.txt](@file:a{slash}one.txt)  ")
             );
             assert!(!editor.has_visible_completions_menu());
             assert_eq!(
                 fold_ranges(editor, cx),
-                vec![Point::new(0, 6)..Point::new(0, 37)]
+                vec![Point::new(0, 6)..Point::new(0, 33)]
             );
         });
 
@@ -1395,12 +1395,12 @@ mod tests {
         editor.update(&mut cx, |editor, cx| {
             assert_eq!(
                 editor.text(cx),
-                format!("Lorem [@one.txt](@file:dir{slash}a{slash}one.txt)  Ipsum "),
+                format!("Lorem [@one.txt](@file:a{slash}one.txt)  Ipsum "),
             );
             assert!(!editor.has_visible_completions_menu());
             assert_eq!(
                 fold_ranges(editor, cx),
-                vec![Point::new(0, 6)..Point::new(0, 37)]
+                vec![Point::new(0, 6)..Point::new(0, 33)]
             );
         });
 
@@ -1409,12 +1409,12 @@ mod tests {
         editor.update(&mut cx, |editor, cx| {
             assert_eq!(
                 editor.text(cx),
-                format!("Lorem [@one.txt](@file:dir{slash}a{slash}one.txt)  Ipsum @file "),
+                format!("Lorem [@one.txt](@file:a{slash}one.txt)  Ipsum @file "),
             );
             assert!(editor.has_visible_completions_menu());
             assert_eq!(
                 fold_ranges(editor, cx),
-                vec![Point::new(0, 6)..Point::new(0, 37)]
+                vec![Point::new(0, 6)..Point::new(0, 33)]
             );
         });
 
@@ -1427,14 +1427,14 @@ mod tests {
         editor.update(&mut cx, |editor, cx| {
             assert_eq!(
                 editor.text(cx),
-                format!("Lorem [@one.txt](@file:dir{slash}a{slash}one.txt)  Ipsum [@seven.txt](@file:dir{slash}b{slash}seven.txt) ")
+                format!("Lorem [@one.txt](@file:a{slash}one.txt)  Ipsum [@seven.txt](@file:b{slash}seven.txt) ")
             );
             assert!(!editor.has_visible_completions_menu());
             assert_eq!(
                 fold_ranges(editor, cx),
                 vec![
-                    Point::new(0, 6)..Point::new(0, 37),
-                    Point::new(0, 45)..Point::new(0, 80)
+                    Point::new(0, 6)..Point::new(0, 33),
+                    Point::new(0, 41)..Point::new(0, 72)
                 ]
             );
         });
@@ -1444,14 +1444,14 @@ mod tests {
         editor.update(&mut cx, |editor, cx| {
             assert_eq!(
                 editor.text(cx),
-                format!("Lorem [@one.txt](@file:dir{slash}a{slash}one.txt)  Ipsum [@seven.txt](@file:dir{slash}b{slash}seven.txt) \n@")
+                format!("Lorem [@one.txt](@file:a{slash}one.txt)  Ipsum [@seven.txt](@file:b{slash}seven.txt) \n@")
             );
             assert!(editor.has_visible_completions_menu());
             assert_eq!(
                 fold_ranges(editor, cx),
                 vec![
-                    Point::new(0, 6)..Point::new(0, 37),
-                    Point::new(0, 45)..Point::new(0, 80)
+                    Point::new(0, 6)..Point::new(0, 33),
+                    Point::new(0, 41)..Point::new(0, 72)
                 ]
             );
         });
@@ -1465,15 +1465,15 @@ mod tests {
         editor.update(&mut cx, |editor, cx| {
             assert_eq!(
                 editor.text(cx),
-                format!("Lorem [@one.txt](@file:dir{slash}a{slash}one.txt)  Ipsum [@seven.txt](@file:dir{slash}b{slash}seven.txt) \n[@six.txt](@file:dir{slash}b{slash}six.txt) ")
+                format!("Lorem [@one.txt](@file:a{slash}one.txt)  Ipsum [@seven.txt](@file:b{slash}seven.txt) \n[@six.txt](@file:b{slash}six.txt) ")
             );
             assert!(!editor.has_visible_completions_menu());
             assert_eq!(
                 fold_ranges(editor, cx),
                 vec![
-                    Point::new(0, 6)..Point::new(0, 37),
-                    Point::new(0, 45)..Point::new(0, 80),
-                    Point::new(1, 0)..Point::new(1, 31)
+                    Point::new(0, 6)..Point::new(0, 33),
+                    Point::new(0, 41)..Point::new(0, 72),
+                    Point::new(1, 0)..Point::new(1, 27)
                 ]
             );
         });

--- a/crates/agent_ui/src/context_picker/file_context_picker.rs
+++ b/crates/agent_ui/src/context_picker/file_context_picker.rs
@@ -197,17 +197,29 @@ pub(crate) fn search_files(
     if query.is_empty() {
         let workspace = workspace.read(cx);
         let project = workspace.project().read(cx);
+        let worktree_count = project.worktrees(cx).count();
+        let include_root_name = worktree_count > 1;
+        
         let recent_matches = workspace
             .recent_navigation_history(Some(10), cx)
             .into_iter()
             .filter_map(|(project_path, _)| {
+                let path_prefix = if include_root_name {
+                    project
+                        .worktree_for_id(project_path.worktree_id, cx)
+                        .map(|wt| wt.read(cx).root_name().into())
+                        .unwrap_or_else(|| RelPath::empty().into())
+                } else {
+                    RelPath::empty().into()
+                };
+                
                 Some(FileMatch {
                     mat: PathMatch {
                         score: 0.,
                         positions: Vec::new(),
                         worktree_id: project_path.worktree_id.to_usize(),
                         path: project_path.path,
-                        path_prefix: RelPath::empty().into(),
+                        path_prefix,
                         distance_to_relative_ancestor: 0,
                         is_dir: false,
                     },
@@ -217,13 +229,18 @@ pub(crate) fn search_files(
 
         let file_matches = project.worktrees(cx).flat_map(|worktree| {
             let worktree = worktree.read(cx);
+            let path_prefix: Arc<RelPath> = if include_root_name {
+                worktree.root_name().into()
+            } else {
+                RelPath::empty().into()
+            };
             worktree.entries(false, 0).map(move |entry| FileMatch {
                 mat: PathMatch {
                     score: 0.,
                     positions: Vec::new(),
                     worktree_id: worktree.id().to_usize(),
                     path: entry.path.clone(),
-                    path_prefix: RelPath::empty().into(),
+                    path_prefix: path_prefix.clone(),
                     distance_to_relative_ancestor: 0,
                     is_dir: entry.is_dir(),
                 },
@@ -234,6 +251,7 @@ pub(crate) fn search_files(
         Task::ready(recent_matches.chain(file_matches).collect())
     } else {
         let worktrees = workspace.read(cx).visible_worktrees(cx).collect::<Vec<_>>();
+        let include_root_name = worktrees.len() > 1;
         let candidate_sets = worktrees
             .into_iter()
             .map(|worktree| {
@@ -242,7 +260,7 @@ pub(crate) fn search_files(
                 PathMatchCandidateSet {
                     snapshot: worktree.snapshot(),
                     include_ignored: worktree.root_entry().is_some_and(|entry| entry.is_ignored),
-                    include_root_name: true,
+                    include_root_name,
                     candidates: project::Candidates::Entries,
                 }
             })

--- a/crates/agent_ui/src/context_picker/file_context_picker.rs
+++ b/crates/agent_ui/src/context_picker/file_context_picker.rs
@@ -199,11 +199,11 @@ pub(crate) fn search_files(
         let project = workspace.project().read(cx);
         let worktree_count = project.worktrees(cx).count();
         let include_root_name = worktree_count > 1;
-        
+
         let recent_matches = workspace
             .recent_navigation_history(Some(10), cx)
             .into_iter()
-            .filter_map(|(project_path, _)| {
+            .map(|(project_path, _)| {
                 let path_prefix = if include_root_name {
                     project
                         .worktree_for_id(project_path.worktree_id, cx)
@@ -212,8 +212,8 @@ pub(crate) fn search_files(
                 } else {
                     RelPath::empty().into()
                 };
-                
-                Some(FileMatch {
+
+                FileMatch {
                     mat: PathMatch {
                         score: 0.,
                         positions: Vec::new(),
@@ -224,7 +224,7 @@ pub(crate) fn search_files(
                         is_dir: false,
                     },
                     is_recent: true,
-                })
+                }
             });
 
         let file_matches = project.worktrees(cx).flat_map(|worktree| {


### PR DESCRIPTION
This PR hides the worktree root name from the path prefix displayed when you @-mention a file or directory in the agent panel. Given the tight UI real state we have, I believe that having the project name in there is redundant—the project you're in is already displayed in the title bar. Not only it was the very first word you'd see after the file's name, but it also made the path longer than it needs to. A bit of a design clean up here :)

(PS: We still show the project name if there are more than one in the same workspace.)

Release Notes:

- N/A
