### PR TITLE
Clock in Status and Title Bar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16170,6 +16170,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "status_clock"
+version = "0.1.0"
+dependencies = [
+ "gpui",
+ "indoc",
+ "language",
+ "menu",
+ "project",
+ "rope",
+ "settings",
+ "theme",
+ "time",
+ "ui",
+ "util",
+ "workspace",
+ "zed_actions",
+]
+
+[[package]]
 name = "stop-words"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -21222,6 +21241,7 @@ dependencies = [
  "smol",
  "snippet_provider",
  "snippets_ui",
+ "status_clock",
  "supermaven",
  "svg_preview",
  "sysinfo 0.37.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17474,6 +17474,7 @@ dependencies = [
  "serde",
  "settings",
  "smallvec",
+ "status_clock",
  "story",
  "telemetry",
  "theme",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,6 +157,7 @@ members = [
     "crates/snippets_ui",
     "crates/sqlez",
     "crates/sqlez_macros",
+    "crates/status_clock",
     "crates/story",
     "crates/storybook",
     "crates/streaming_diff",
@@ -389,6 +390,7 @@ snippet_provider = { path = "crates/snippet_provider" }
 snippets_ui = { path = "crates/snippets_ui" }
 sqlez = { path = "crates/sqlez" }
 sqlez_macros = { path = "crates/sqlez_macros" }
+status_clock = { path = "crates/status_clock" }
 story = { path = "crates/story" }
 storybook = { path = "crates/storybook" }
 streaming_diff = { path = "crates/streaming_diff" }
@@ -663,6 +665,7 @@ time = { version = "0.3", features = [
     "serde",
     "serde-well-known",
     "formatting",
+    "local-offset"
 ] }
 tiny_http = "0.8"
 tokio = { version = "1" }

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1361,7 +1361,9 @@
     // Where to display the clock.
     "position": "status_bar",
     // Whether to display hours using a 12 or 24-hour clock.
-    "use_12_hour_clock": false
+    "use_12_hour_clock": false,
+    // Offset of the clock from Utc.
+    "offset": ""
   },
   // Settings specific to the terminal
   "terminal": {

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1354,6 +1354,15 @@
     // Whether to show active line endings button in the status bar.
     "line_endings_button": false
   },
+  // Clock related settings.
+  "clock": {
+    // Whether to show the clock.
+    "show": false,
+    // Where to display the clock.
+    "position": "status_bar",
+    // Whether to display hours using a 12 or 24-hour clock.
+    "use_12_hour_clock": false
+  },
   // Settings specific to the terminal
   "terminal": {
     // What shell to use when opening a terminal. May take 3 values:

--- a/crates/settings/src/settings_content.rs
+++ b/crates/settings/src/settings_content.rs
@@ -61,6 +61,7 @@ pub struct SettingsContent {
     pub tabs: Option<ItemSettingsContent>,
     pub tab_bar: Option<TabBarSettingsContent>,
     pub status_bar: Option<StatusBarSettingsContent>,
+    pub clock: Option<ClockSettingsContent>,
 
     pub preview_tabs: Option<PreviewTabsSettingsContent>,
 

--- a/crates/settings/src/settings_content/workspace.rs
+++ b/crates/settings/src/settings_content/workspace.rs
@@ -405,6 +405,10 @@ pub struct ClockSettingsContent {
     ///
     /// Default: false
     pub use_12_hour_clock: Option<bool>,
+    /// Offset of the clock from Utc. Example: -2:00
+    ///
+    /// Default: "" -> local system offset
+    pub offset: Option<String>,
 }
 
 #[skip_serializing_none]

--- a/crates/settings/src/settings_content/workspace.rs
+++ b/crates/settings/src/settings_content/workspace.rs
@@ -369,6 +369,19 @@ pub struct TabBarSettingsContent {
 
 #[skip_serializing_none]
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema, MergeFrom, Debug, PartialEq, Eq)]
+pub struct ClockSettingsContent {
+    /// Whether to show the clock.
+    ///
+    /// Default: false
+    pub show: Option<bool>,
+    /// Whether to display hours using a 12 or 24-hour clock.
+    ///
+    /// Default: false
+    pub use_12_hour_clock: Option<bool>,
+}
+
+#[skip_serializing_none]
+#[derive(Clone, Default, Serialize, Deserialize, JsonSchema, MergeFrom, Debug, PartialEq, Eq)]
 pub struct StatusBarSettingsContent {
     /// Whether to show the status bar.
     ///
@@ -387,6 +400,8 @@ pub struct StatusBarSettingsContent {
     ///
     /// Default: false
     pub line_endings_button: Option<bool>,
+    /// Settings for the clock in the status bar.
+    pub clock: Option<ClockSettingsContent>,
 }
 
 #[derive(

--- a/crates/settings/src/settings_content/workspace.rs
+++ b/crates/settings/src/settings_content/workspace.rs
@@ -367,6 +367,29 @@ pub struct TabBarSettingsContent {
     pub show_tab_bar_buttons: Option<bool>,
 }
 
+#[derive(
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Default,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    MergeFrom,
+    Debug,
+    strum::VariantArray,
+    strum::VariantNames,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum ClockLocation {
+    /// Show in the TitleBar.
+    TitleBar,
+    /// Show in the StatusBar.
+    #[default]
+    StatusBar,
+}
+
 #[skip_serializing_none]
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema, MergeFrom, Debug, PartialEq, Eq)]
 pub struct ClockSettingsContent {
@@ -374,6 +397,10 @@ pub struct ClockSettingsContent {
     ///
     /// Default: false
     pub show: Option<bool>,
+    /// Where to display the clock.
+    ///
+    /// Default: StatusBar
+    pub position: Option<ClockLocation>,
     /// Whether to display hours using a 12 or 24-hour clock.
     ///
     /// Default: false
@@ -400,8 +427,6 @@ pub struct StatusBarSettingsContent {
     ///
     /// Default: false
     pub line_endings_button: Option<bool>,
-    /// Settings for the clock in the status bar.
-    pub clock: Option<ClockSettingsContent>,
 }
 
 #[derive(

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -205,6 +205,7 @@ impl VsCodeSettings {
             repl: None,
             server_url: None,
             session: None,
+            clock: None,
             status_bar: self.status_bar_settings_content(),
             tab_bar: self.tab_bar_settings_content(),
             tabs: self.item_settings_content(),
@@ -636,7 +637,6 @@ impl VsCodeSettings {
             active_language_button: None,
             cursor_position_button: None,
             line_endings_button: None,
-            clock: None,
         })
     }
 

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -636,6 +636,7 @@ impl VsCodeSettings {
             active_language_button: None,
             cursor_position_button: None,
             line_endings_button: None,
+            clock: None,
         })
     }
 

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -2777,6 +2777,52 @@ pub(crate) fn settings_data(cx: &App) -> Vec<SettingsPage> {
                     metadata: None,
                     files: USER,
                 }),
+                SettingsPageItem::SectionHeader("Clock"),
+                SettingsPageItem::SettingItem(SettingItem {
+                    title: "Show Clock",
+                    description: "Whether to show the clock.",
+                    field: Box::new(SettingField {
+                        json_path: Some("clock.show"),
+                        pick: |settings_content| {
+                            settings_content.clock.as_ref()?.show.as_ref()
+                        },
+                        write: |settings_content, value| {
+                            settings_content.clock.get_or_insert_default().show = value;
+                        },
+                    }),
+                    metadata: None,
+                    files: USER,
+                }),
+                SettingsPageItem::SettingItem(SettingItem {
+                    title: "Clock Position",
+                    description: "Where to display the clock.",
+                    field: Box::new(SettingField {
+                        json_path: Some("clock.position"),
+                        pick: |settings_content| {
+                            settings_content.clock.as_ref()?.position.as_ref()
+                        },
+                        write: |settings_content, value| {
+                            settings_content.clock.get_or_insert_default().position = value;
+                        },
+                    }),
+                    metadata: None,
+                    files: USER,
+                }),
+                SettingsPageItem::SettingItem(SettingItem {
+                    title: "Use 12 hour clock",
+                    description: "Whether to display hours using a 12 or 24-hour clock.",
+                    field: Box::new(SettingField {
+                        json_path: Some("clock.use_12_hour_clock"),
+                        pick: |settings_content| {
+                            settings_content.clock.as_ref()?.use_12_hour_clock.as_ref()
+                        },
+                        write: |settings_content, value| {
+                            settings_content.clock.get_or_insert_default().use_12_hour_clock = value;
+                        },
+                    }),
+                    metadata: None,
+                    files: USER,
+                }),
                 SettingsPageItem::SectionHeader("Title Bar"),
                 SettingsPageItem::SettingItem(SettingItem {
                     title: "Show Branch Icon",

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -2777,52 +2777,6 @@ pub(crate) fn settings_data(cx: &App) -> Vec<SettingsPage> {
                     metadata: None,
                     files: USER,
                 }),
-                SettingsPageItem::SectionHeader("Clock"),
-                SettingsPageItem::SettingItem(SettingItem {
-                    title: "Show Clock",
-                    description: "Whether to show the clock.",
-                    field: Box::new(SettingField {
-                        json_path: Some("clock.show"),
-                        pick: |settings_content| {
-                            settings_content.clock.as_ref()?.show.as_ref()
-                        },
-                        write: |settings_content, value| {
-                            settings_content.clock.get_or_insert_default().show = value;
-                        },
-                    }),
-                    metadata: None,
-                    files: USER,
-                }),
-                SettingsPageItem::SettingItem(SettingItem {
-                    title: "Clock Position",
-                    description: "Where to display the clock.",
-                    field: Box::new(SettingField {
-                        json_path: Some("clock.position"),
-                        pick: |settings_content| {
-                            settings_content.clock.as_ref()?.position.as_ref()
-                        },
-                        write: |settings_content, value| {
-                            settings_content.clock.get_or_insert_default().position = value;
-                        },
-                    }),
-                    metadata: None,
-                    files: USER,
-                }),
-                SettingsPageItem::SettingItem(SettingItem {
-                    title: "Use 12 hour clock",
-                    description: "Whether to display hours using a 12 or 24-hour clock.",
-                    field: Box::new(SettingField {
-                        json_path: Some("clock.use_12_hour_clock"),
-                        pick: |settings_content| {
-                            settings_content.clock.as_ref()?.use_12_hour_clock.as_ref()
-                        },
-                        write: |settings_content, value| {
-                            settings_content.clock.get_or_insert_default().use_12_hour_clock = value;
-                        },
-                    }),
-                    metadata: None,
-                    files: USER,
-                }),
                 SettingsPageItem::SectionHeader("Title Bar"),
                 SettingsPageItem::SettingItem(SettingItem {
                     title: "Show Branch Icon",
@@ -3362,6 +3316,67 @@ pub(crate) fn settings_data(cx: &App) -> Vec<SettingsPage> {
                         },
                         write: |settings_content, value| {
                             settings_content.workspace.pane_split_direction_horizontal = value;
+                        },
+                    }),
+                    metadata: None,
+                    files: USER,
+                }),
+                SettingsPageItem::SectionHeader("Clock"),
+                SettingsPageItem::SettingItem(SettingItem {
+                    title: "Show Clock",
+                    description: "Whether to show the clock.",
+                    field: Box::new(SettingField {
+                        json_path: Some("clock.show"),
+                        pick: |settings_content| {
+                            settings_content.clock.as_ref()?.show.as_ref()
+                        },
+                        write: |settings_content, value| {
+                            settings_content.clock.get_or_insert_default().show = value;
+                        },
+                    }),
+                    metadata: None,
+                    files: USER,
+                }),
+                SettingsPageItem::SettingItem(SettingItem {
+                    title: "Clock Position",
+                    description: "Where to display the clock.",
+                    field: Box::new(SettingField {
+                        json_path: Some("clock.position"),
+                        pick: |settings_content| {
+                            settings_content.clock.as_ref()?.position.as_ref()
+                        },
+                        write: |settings_content, value| {
+                            settings_content.clock.get_or_insert_default().position = value;
+                        },
+                    }),
+                    metadata: None,
+                    files: USER,
+                }),
+                SettingsPageItem::SettingItem(SettingItem {
+                    title: "Use 12 hour clock",
+                    description: "Whether to display hours using a 12 or 24-hour clock.",
+                    field: Box::new(SettingField {
+                        json_path: Some("clock.use_12_hour_clock"),
+                        pick: |settings_content| {
+                            settings_content.clock.as_ref()?.use_12_hour_clock.as_ref()
+                        },
+                        write: |settings_content, value| {
+                            settings_content.clock.get_or_insert_default().use_12_hour_clock = value;
+                        },
+                    }),
+                    metadata: None,
+                    files: USER,
+                }),
+                SettingsPageItem::SettingItem(SettingItem {
+                    title: "Utc offset",
+                    description: "Offset of the clock from Utc. Example: -2:00",
+                    field: Box::new(SettingField {
+                        json_path: Some("clock.offset"),
+                        pick: |settings_content| {
+                            settings_content.clock.as_ref()?.offset.as_ref()
+                        },
+                        write: |settings_content, value| {
+                            settings_content.clock.get_or_insert_default().offset = value;
                         },
                     }),
                     metadata: None,

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -415,6 +415,7 @@ fn init_renderers(cx: &mut App) {
         .add_basic_renderer::<settings::SaturatingBool>(render_toggle_button)
         .add_basic_renderer::<settings::CursorShape>(render_dropdown)
         .add_basic_renderer::<settings::RestoreOnStartupBehavior>(render_dropdown)
+        .add_basic_renderer::<settings::ClockLocation>(render_dropdown)
         .add_basic_renderer::<settings::BottomDockLayout>(render_dropdown)
         .add_basic_renderer::<settings::OnLastWindowClosed>(render_dropdown)
         .add_basic_renderer::<settings::CloseWindowWhenNoItems>(render_dropdown)

--- a/crates/status_clock/Cargo.toml
+++ b/crates/status_clock/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "status_clock"
+version = "0.1.0"
+edition.workspace = true
+publish.workspace = true
+license = "GPL-3.0-or-later"
+
+[lints]
+workspace = true
+
+[lib]
+path = "src/clock.rs"
+doctest = false
+
+[dependencies]
+gpui.workspace = true
+settings.workspace = true
+time.workspace = true
+theme.workspace = true
+ui.workspace = true
+util.workspace = true
+workspace.workspace = true
+zed_actions.workspace = true
+
+[dev-dependencies]
+gpui = { workspace = true, features = ["test-support"] }
+indoc.workspace = true
+language = { workspace = true, features = ["test-support"] }
+menu.workspace = true
+project = { workspace = true, features = ["test-support"] }
+rope.workspace = true
+workspace = { workspace = true, features = ["test-support"] }

--- a/crates/status_clock/src/clock.rs
+++ b/crates/status_clock/src/clock.rs
@@ -1,0 +1,112 @@
+use gpui::{App, AppContext, Entity, Styled, Subscription, Task, WeakEntity};
+use settings::Settings;
+use std::time::Duration;
+use ui::{
+    BorrowAppContext, Button, ButtonCommon, Clickable, Context, FluentBuilder, IntoElement,
+    LabelSize, ParentElement, Render, Tooltip, Window, div,
+};
+use util::ResultExt;
+use workspace::{StatusBarSettings, StatusItemView, Workspace, item::ItemHandle};
+
+pub struct Clock {
+    update_time: Task<()>,
+    _observe_active_editor: Option<Subscription>,
+}
+
+impl Clock {
+    pub fn new() -> Self {
+        Self {
+            update_time: Task::ready(()),
+            _observe_active_editor: None,
+        }
+    }
+
+    fn update_time(&mut self, cx: &mut Context<Self>) {
+        // cx.background_spawn(async {
+
+        // });
+
+        self.update_time = cx.spawn(async move |clock, cx| {
+            cx.background_executor()
+                .timer(std::time::Duration::from_secs(60))
+                .await;
+            cx.update(|cx| {
+                cx.notify(clock.entity_id());
+            })
+            .log_err();
+        });
+    }
+}
+
+impl Render for Clock {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let clock = &StatusBarSettings::get_global(cx).clock;
+        if !clock.show {
+            return div().hidden();
+        }
+
+        // struct CurrentTime(time::OffsetDateTime);
+        // cx.observe_window_activation(window, |clock, window, cx| {
+
+        // });
+        // cx.observe_global::<CurrentTime>(|clock, cx| {
+        //     let time: CurrentTime = cx.global();
+        // });
+
+        let time = time::OffsetDateTime::now_local()
+            .log_err()
+            .unwrap_or_else(|| time::OffsetDateTime::now_utc());
+        use time::format_description::{
+            BorrowedFormatItem, Component,
+            modifier::{Hour, Minute, Padding, Period, Second},
+        };
+
+        let mut hour = Hour::default();
+        hour.is_12_hour_clock = clock.use_12_hour_clock;
+        let mut period = Period::default();
+        period.is_uppercase = true;
+
+        let end = if clock.use_12_hour_clock {
+            BorrowedFormatItem::Compound(&[
+                BorrowedFormatItem::Literal(b" "),
+                BorrowedFormatItem::Component(Component::Period(period)),
+            ])
+        } else {
+            BorrowedFormatItem::Literal(&[])
+        };
+        let format = [
+            BorrowedFormatItem::Component(Component::Hour(hour)),
+            BorrowedFormatItem::Literal(b":"),
+            BorrowedFormatItem::Component(Component::Minute(Minute::default())),
+            end,
+        ];
+        let text = time.format(&format[..]).unwrap();
+
+        self.update_time(cx);
+
+        div().child(
+            Button::new("clock", text)
+                .label_size(LabelSize::Small)
+                .on_click(|_event, window, cx| {
+                    window.dispatch_action(Box::new(zed_actions::OpenSettings), cx)
+                })
+                .tooltip(move |_window, cx| {
+                    Tooltip::for_action(
+                        "Open Settings and search for clock",
+                        &zed_actions::OpenSettings,
+                        cx,
+                    )
+                }),
+        )
+    }
+}
+
+impl StatusItemView for Clock {
+    fn set_active_pane_item(
+        &mut self,
+        _active_pane_item: Option<&dyn ItemHandle>,
+        _window: &mut Window,
+        _cx: &mut Context<Self>,
+    ) {
+    }
+}

--- a/crates/status_clock/src/clock.rs
+++ b/crates/status_clock/src/clock.rs
@@ -1,12 +1,11 @@
 use gpui::{App, AppContext, Entity, Styled, Subscription, Task, WeakEntity};
 use settings::Settings;
-use std::time::Duration;
 use ui::{
     BorrowAppContext, Button, ButtonCommon, Clickable, Context, FluentBuilder, IntoElement,
     LabelSize, ParentElement, Render, Tooltip, Window, div,
 };
 use util::ResultExt;
-use workspace::{StatusBarSettings, StatusItemView, Workspace, item::ItemHandle};
+use workspace::{ClockSettings, StatusItemView, Workspace, item::ItemHandle};
 
 pub struct Clock {
     update_time: Task<()>,
@@ -40,18 +39,10 @@ impl Clock {
 
 impl Render for Clock {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let clock = &StatusBarSettings::get_global(cx).clock;
+        let clock = ClockSettings::get_global(cx);
         if !clock.show {
             return div().hidden();
         }
-
-        // struct CurrentTime(time::OffsetDateTime);
-        // cx.observe_window_activation(window, |clock, window, cx| {
-
-        // });
-        // cx.observe_global::<CurrentTime>(|clock, cx| {
-        //     let time: CurrentTime = cx.global();
-        // });
 
         let time = time::OffsetDateTime::now_local()
             .log_err()
@@ -81,6 +72,14 @@ impl Render for Clock {
             end,
         ];
         let text = time.format(&format[..]).unwrap();
+
+        // struct CurrentTime(time::OffsetDateTime);
+        // cx.observe_window_activation(window, |clock, window, cx| {
+
+        // });
+        // cx.observe_global::<CurrentTime>(|clock, cx| {
+        //     let time: CurrentTime = cx.global();
+        // });
 
         self.update_time(cx);
 

--- a/crates/title_bar/Cargo.toml
+++ b/crates/title_bar/Cargo.toml
@@ -43,6 +43,7 @@ schemars.workspace = true
 serde.workspace = true
 settings.workspace = true
 smallvec.workspace = true
+status_clock.workspace = true
 story = { workspace = true, optional = true }
 telemetry.workspace = true
 theme.workspace = true

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -182,6 +182,16 @@ impl Render for TitleBar {
             children.push(self.banner.clone().into_any_element())
         }
 
+        if matches!(
+            workspace::ClockSettings::get_global(cx).position,
+            settings::ClockLocation::TitleBar
+        ) {
+            children.push(
+                cx.new(|_| status_clock::Clock::title_bar(self.workspace.clone()))
+                    .into_any_element(),
+            );
+        }
+
         let status = self.client.status();
         let status = &*status.borrow();
         let user = self.user_store.read(cx).current_user();

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -121,8 +121,8 @@ use util::{
 };
 use uuid::Uuid;
 pub use workspace_settings::{
-    AutosaveSetting, BottomDockLayout, RestoreOnStartupBehavior, StatusBarSettings, TabBarSettings,
-    WorkspaceSettings,
+    AutosaveSetting, BottomDockLayout, ClockSettings, RestoreOnStartupBehavior, StatusBarSettings,
+    TabBarSettings, WorkspaceSettings,
 };
 use zed_actions::{Spawn, feedback::FileBugReport};
 
@@ -533,6 +533,7 @@ pub fn init_settings(cx: &mut App) {
     PreviewTabsSettings::register(cx);
     TabBarSettings::register(cx);
     StatusBarSettings::register(cx);
+    ClockSettings::register(cx);
 }
 
 fn prompt_and_open_paths(app_state: Arc<AppState>, options: PathPromptOptions, cx: &mut App) {

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -126,6 +126,7 @@ pub struct ClockSettings {
     pub show: bool,
     pub position: ClockLocation,
     pub use_12_hour_clock: bool,
+    pub offset: String,
 }
 
 impl Settings for ClockSettings {
@@ -135,6 +136,7 @@ impl Settings for ClockSettings {
             show: clock.show.unwrap(),
             position: clock.position.unwrap(),
             use_12_hour_clock: clock.use_12_hour_clock.unwrap(),
+            offset: clock.offset.unwrap(),
         }
     }
 }

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -122,21 +122,33 @@ impl Settings for TabBarSettings {
 }
 
 #[derive(Deserialize)]
+pub struct ClockSettings {
+    pub show: bool,
+    pub use_12_hour_clock: bool,
+}
+
+#[derive(Deserialize)]
 pub struct StatusBarSettings {
     pub show: bool,
     pub active_language_button: bool,
     pub cursor_position_button: bool,
     pub line_endings_button: bool,
+    pub clock: ClockSettings,
 }
 
 impl Settings for StatusBarSettings {
     fn from_settings(content: &settings::SettingsContent) -> Self {
         let status_bar = content.status_bar.clone().unwrap();
+        let clock = status_bar.clock.clone().unwrap_or_default();
         StatusBarSettings {
             show: status_bar.show.unwrap(),
             active_language_button: status_bar.active_language_button.unwrap(),
             cursor_position_button: status_bar.cursor_position_button.unwrap(),
             line_endings_button: status_bar.line_endings_button.unwrap(),
+            clock: ClockSettings {
+                show: clock.show.unwrap_or(false),
+                use_12_hour_clock: clock.use_12_hour_clock.unwrap_or(false),
+            },
         }
     }
 }

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -8,7 +8,7 @@ pub use settings::{
     BottomDockLayout, PaneSplitDirectionHorizontal, PaneSplitDirectionVertical,
     RestoreOnStartupBehavior,
 };
-use settings::{InactiveOpacity, Settings};
+use settings::{ClockLocation, InactiveOpacity, Settings};
 
 pub struct WorkspaceSettings {
     pub active_pane_modifiers: ActivePanelModifiers,
@@ -124,7 +124,19 @@ impl Settings for TabBarSettings {
 #[derive(Deserialize)]
 pub struct ClockSettings {
     pub show: bool,
+    pub position: ClockLocation,
     pub use_12_hour_clock: bool,
+}
+
+impl Settings for ClockSettings {
+    fn from_settings(content: &settings::SettingsContent) -> Self {
+        let clock = content.clock.clone().unwrap();
+        ClockSettings {
+            show: clock.show.unwrap(),
+            position: clock.position.unwrap(),
+            use_12_hour_clock: clock.use_12_hour_clock.unwrap(),
+        }
+    }
 }
 
 #[derive(Deserialize)]
@@ -133,22 +145,16 @@ pub struct StatusBarSettings {
     pub active_language_button: bool,
     pub cursor_position_button: bool,
     pub line_endings_button: bool,
-    pub clock: ClockSettings,
 }
 
 impl Settings for StatusBarSettings {
     fn from_settings(content: &settings::SettingsContent) -> Self {
         let status_bar = content.status_bar.clone().unwrap();
-        let clock = status_bar.clock.clone().unwrap_or_default();
         StatusBarSettings {
             show: status_bar.show.unwrap(),
             active_language_button: status_bar.active_language_button.unwrap(),
             cursor_position_button: status_bar.cursor_position_button.unwrap(),
             line_endings_button: status_bar.line_endings_button.unwrap(),
-            clock: ClockSettings {
-                show: clock.show.unwrap_or(false),
-                use_12_hour_clock: clock.use_12_hour_clock.unwrap_or(false),
-            },
         }
     }
 }

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -127,6 +127,7 @@ session.workspace = true
 settings.workspace = true
 settings_profile_selector.workspace = true
 settings_ui.workspace = true
+status_clock.workspace = true
 shellexpand.workspace = true
 smol.workspace = true
 snippet_provider.workspace = true

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -424,6 +424,7 @@ pub fn initialize_workspace(
 
         let cursor_position =
             cx.new(|_| go_to_line::cursor_position::CursorPosition::new(workspace));
+        let clock = cx.new(|_| status_clock::Clock::new());
         let line_ending_indicator =
             cx.new(|_| line_ending_selector::LineEndingIndicator::default());
         workspace.status_bar().update(cx, |status_bar, cx| {
@@ -432,6 +433,7 @@ pub fn initialize_workspace(
             status_bar.add_left_item(diagnostic_summary, window, cx);
             status_bar.add_left_item(activity_indicator, window, cx);
             status_bar.add_right_item(edit_prediction_button, window, cx);
+            status_bar.add_right_item(clock, window, cx);
             status_bar.add_right_item(active_buffer_language, window, cx);
             status_bar.add_right_item(active_toolchain_language, window, cx);
             status_bar.add_right_item(line_ending_indicator, window, cx);

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -424,7 +424,7 @@ pub fn initialize_workspace(
 
         let cursor_position =
             cx.new(|_| go_to_line::cursor_position::CursorPosition::new(workspace));
-        let clock = cx.new(|_| status_clock::Clock::new(workspace));
+        let clock = cx.new(|_| status_clock::Clock::status_bar(workspace));
         let line_ending_indicator =
             cx.new(|_| line_ending_selector::LineEndingIndicator::default());
         workspace.status_bar().update(cx, |status_bar, cx| {

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -424,7 +424,7 @@ pub fn initialize_workspace(
 
         let cursor_position =
             cx.new(|_| go_to_line::cursor_position::CursorPosition::new(workspace));
-        let clock = cx.new(|_| status_clock::Clock::new());
+        let clock = cx.new(|_| status_clock::Clock::new(workspace));
         let line_ending_indicator =
             cx.new(|_| line_ending_selector::LineEndingIndicator::default());
         workspace.status_bar().update(cx, |status_bar, cx| {


### PR DESCRIPTION
I have been using a simple extension in VSCode to show the current time, so I don't forget the time while coding. A good sleep schedule is quite important, but wanting to fix that one bug or Todo is not helping. 
I would have implemented this as an extension, but I don't know if changing the UI from extensions is planned or not.

The clock can be toggled, switched between 24 and 12 Hours and displayed in the Status or Title bar.
UTC offset is also configurable, but local offset will be used by default. If the format of this offset is wrong, an error notification will be shown.
These clock settings are also integrated into the settings editor, under Window & Layout. I tried to implement custom UI for the offset, but it was very ugly, so I used String for now.

I haven't yet implemented actions to toggle the clock, it's position or the 12 Hours display.
Maybe I could also add a setting to adjust the size of the clock.

Release Notes:

- Add clock to status or title bar