### PR TITLE
lsp: Fix workspace diagnostics when registered statically

### DIFF
--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -10840,19 +10840,16 @@ impl LspStore {
             .capabilities()
             .diagnostic_provider
             .and_then(|provider| {
-                let workspace_refresher = lsp_workspace_diagnostics_refresh(
-                    None,
-                    provider.clone(),
-                    language_server.clone(),
-                    cx,
-                )?;
                 local
                     .language_server_dynamic_registrations
                     .entry(server_id)
                     .or_default()
                     .diagnostics
                     .entry(None)
-                    .or_insert(provider);
+                    .or_insert(provider.clone());
+                let workspace_refresher =
+                    lsp_workspace_diagnostics_refresh(None, provider, language_server.clone(), cx)?;
+
                 Some((None, workspace_refresher))
             })
             .into_iter()


### PR DESCRIPTION
Closes #41379

Release Notes:

- Fixed diagnostics for Ruff and Biome
