### PR TITLE
Adjust Windows fusion manifests

### DIFF
--- a/crates/auto_update_helper/manifest.xml
+++ b/crates/auto_update_helper/manifest.xml
@@ -1,16 +1,32 @@
-<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
-    <asmv3:application>
-        <asmv3:windowsSettings>
-            <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+    <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+        <security>
+            <requestedPrivileges>
+                <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+            </requestedPrivileges>
+        </security>
+    </trustInfo>
+    <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+        <application>
+            <!-- Windows 10 -->
+            <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+        </application>
+    </compatibility>
+    <application xmlns="urn:schemas-microsoft-com:asm.v3">
+        <windowsSettings>
+            <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
             <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
-        </asmv3:windowsSettings>
-    </asmv3:application>
+        </windowsSettings>
+    </application>
     <dependency>
         <dependentAssembly>
-            <assemblyIdentity type='win32'
+            <assemblyIdentity
+                type='win32'
                 name='Microsoft.Windows.Common-Controls'
-                version='6.0.0.0' processorArchitecture='*'
-                publicKeyToken='6595b64144ccf1df' />
+                version='6.0.0.0'
+                processorArchitecture='*'
+                publicKeyToken='6595b64144ccf1df'
+            />
         </dependentAssembly>
     </dependency>
 </assembly>

--- a/crates/gpui/resources/windows/gpui.manifest.xml
+++ b/crates/gpui/resources/windows/gpui.manifest.xml
@@ -1,16 +1,32 @@
-<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
-    <asmv3:application>
-        <asmv3:windowsSettings>
-            <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+    <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+        <security>
+            <requestedPrivileges>
+                <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+            </requestedPrivileges>
+        </security>
+    </trustInfo>
+    <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+        <application>
+            <!-- Windows 10 -->
+            <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+        </application>
+    </compatibility>
+    <application xmlns="urn:schemas-microsoft-com:asm.v3">
+        <windowsSettings>
+            <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
             <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
-        </asmv3:windowsSettings>
-    </asmv3:application>
+        </windowsSettings>
+    </application>
     <dependency>
         <dependentAssembly>
-            <assemblyIdentity type='win32'
+            <assemblyIdentity
+                type='win32'
                 name='Microsoft.Windows.Common-Controls'
-                version='6.0.0.0' processorArchitecture='*'
-                publicKeyToken='6595b64144ccf1df' />
+                version='6.0.0.0'
+                processorArchitecture='*'
+                publicKeyToken='6595b64144ccf1df'
+            />
         </dependentAssembly>
     </dependency>
 </assembly>


### PR DESCRIPTION
- Declare UAC support. This will prevent Windows from flagging `auto_update_helper.exe` as a legacy setup program that needs to run as administrator.
- Declare support for Windows 10. This will stop Windows from applying various application compatibility profiles.

The UAC policy is not really appropriate to apply to all GPUI applications (e.g. an installer written in GPUI may want to declare itself as `requireAdministrator` instead of `asInvoker`). I tried splitting this into a Zed.exe-only manifest and enabling manifest file merging, but I ran out of my time-box. We can fix this later if this is flagged by GPUI users.

Release Notes:

- N/A