### PR TITLE
Update docs to use == instead of =

### DIFF
--- a/docs/src/key-bindings.md
+++ b/docs/src/key-bindings.md
@@ -139,13 +139,13 @@ Context expressions can contain the following syntax:
 For example:
 
 - `"context": "Editor"` - matches any editor (including inline inputs)
-- `"context": "Editor && mode=full"` - matches the main editors used for editing code
+- `"context": "Editor && mode == full"` - matches the main editors used for editing code
 - `"context": "!Editor && !Terminal"` - matches anywhere except where an Editor or Terminal is focused
-- `"context": "os=macos > Editor"` - matches any editor on macOS.
+- `"context": "os == macos > Editor"` - matches any editor on macOS.
 
 It's worth noting that attributes are only available on the node they are defined on. This means that if you want to (for example) only enable a keybinding when the debugger is stopped in vim normal mode, you need to do `debugger_stopped > vim_mode == normal`.
 
-> Note: Before Zed v0.197.x, the `!` operator only looked at one node at a time, and `>` meant "parent" not "ancestor". This meant that `!Editor` would match the context `Workspace > Pane > Editor`, because (confusingly) the Pane matches `!Editor`, and that `os=macos > Editor` did not match the context `Workspace > Pane > Editor` because of the intermediate `Pane` node.
+> Note: Before Zed v0.197.x, the `!` operator only looked at one node at a time, and `>` meant "parent" not "ancestor". This meant that `!Editor` would match the context `Workspace > Pane > Editor`, because (confusingly) the Pane matches `!Editor`, and that `os == macos > Editor` did not match the context `Workspace > Pane > Editor` because of the intermediate `Pane` node.
 
 If you're using Vim mode, we have information on how [vim modes influence the context](./vim.md#contexts). Helix mode is built on top of Vim mode and uses the same contexts.
 


### PR DESCRIPTION
Closes #41219

Release Notes:

- Updated docs to use `==` instead of `=` in keymap context.

Hopefully I'm not mistaken here, but I think the docs have a bug in them