### PR TITLE
Action to Cycle through dock panels

### DIFF
--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -637,6 +637,59 @@ impl Dock {
         self.panel_entries.len()
     }
 
+    pub fn next_enabled_panel(&self, cx: &App) -> Option<usize> {
+        let panel_count = self.panel_entries.len();
+        if panel_count == 0 {
+            return None;
+        }
+
+        let start_index = if let Some(current) = self.active_panel_index {
+            (current + 1) % panel_count
+        } else {
+            0
+        };
+
+        for i in 0..panel_count {
+            let panel_index = (start_index + i) % panel_count;
+            if self.panel_entries[panel_index].panel.enabled(cx) {
+                return Some(panel_index);
+            }
+        }
+
+        None
+    }
+
+    pub fn previous_enabled_panel(&self, cx: &App) -> Option<usize> {
+        let panel_count = self.panel_entries.len();
+        if panel_count == 0 {
+            return None;
+        }
+
+        let start_index = if let Some(current) = self.active_panel_index {
+            if current == 0 {
+                panel_count - 1
+            } else {
+                current - 1
+            }
+        } else {
+            panel_count - 1
+        };
+
+        for i in 0..panel_count {
+            let panel_index = if start_index >= i {
+                start_index - i
+            } else {
+                panel_count - (i - start_index)
+            };
+
+            if self.panel_entries[panel_index].panel.enabled(cx) {
+                return Some(panel_index);
+            }
+        }
+
+        None
+    }
+
     pub fn activate_panel(&mut self, panel_ix: usize, window: &mut Window, cx: &mut Context<Self>) {
         if Some(panel_ix) != self.active_panel_index {
             if let Some(active_panel) = self.active_panel_entry() {


### PR DESCRIPTION
#40697 

this seems like a cool idea.
I have a somewhat working version here. but i'm running into some edge cases, wondering if you guys have any thoughts about what would be the best way to handle them.

-------------
`workspace::ActivateNextDockPanel` and `workspace::ActivatePreviousDockPanel` cycle through the panels in a dock similar to `pane::ActivateNextItem` and `pane::ActivatePreviousItem`.

- the Notification Panel is causing a problem. when the focus "moves" to the notification panel, if there are no active notifications, it dismisses the focus and the focus moves back to the editor. which breaks the user's ability to continue cycling through the dock panels.


- there are two settings that revolve around whether or not a panel is "visible" there is a setting to enable/disable a panel, but it looks like the Agent panel is actually the only panel that implements this the rest just default to true. and it is possible to "hide" the button for a panel in the bottom bar so that the panel does not have it's own icon. 

My initial thought was that this cycling action should only scroll through the panels that have visible buttons in the toolbar, it felt a little disorienting to cycle through panels that did not have a visible indicator in the ui. and I also think it would be great to give the user a bit of control over which panels to cycle through. I had a mostly working version by checking if the panel `icon.is_some()` because this returns the UI button setting; however the Terminal Panel has an issue. it is the only panel that calls `is_enabled` inside of `icon()` and `is_enabled` tries to read the workspace so it was panicking, since the action is trying to update the workspace during the read.

i like the idea of having the cycle action only include buttons that are visible, we need a different method? to determine the button setting, like `show_icon` ? instead of just checking this setting inside the `icon` method, then `show_icon` could be used to filter the panels while cycling.

- or

create a new method and setting specifically for this action?
`panel.skip_during_cycling` or something where we can set a default for each panel (we could use this to hide the notification panel while cycling as an easy fix) and then we can allow the user to override this for each panel to their preferences?

if this is something you guys are interested in let me know what you think.