### PR TITLE
gpui: Fix GPUI prompts from bleeding clicks into lower windows

### DIFF
--- a/crates/gpui/src/window/prompts.rs
+++ b/crates/gpui/src/window/prompts.rs
@@ -142,6 +142,7 @@ impl Render for FallbackPromptRenderer {
                     .id(ix)
                     .on_click(cx.listener(move |_, _, _, cx| {
                         cx.emit(PromptResponse(ix));
+                        cx.stop_propagation();
                     }))
             }));
 


### PR DESCRIPTION
Closes #41180 

When using the fallback prompt renderer (default on Wayland), clicks would bleed through into underlying windows. When the click happens to hit a button that creates a prompt, it drops the `RenderablePromptHandle` which is contained within `Window`, causing the `Receiver` which returns the index of the clicked `PromptButton` to return `Err(Canceled)` even though a button was pressed.

This bug appears in the GPUI `window.rs` example, which can be ran using `cargo run -p gpui --example window`. MacOS has a native `PromptRenderer` and thus needs additional code to be adjusted to be able to reproduce the issue.

Release Notes:

- N/A *or* Added/Fixed/Improved ...
