### PR TITLE
Document Go hard tabs in default settings

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1700,6 +1700,7 @@
       "preferred_line_length": 72
     },
     "Go": {
+      "hard_tabs": true,
       "code_actions_on_format": {
         "source.organizeImports": true
       },


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/40876

This is already present in the code but missing from the default settings, which is confusing.

Release Notes:

- N/A
