### PR TITLE
vim: Only focus when associated editor is also focused

### DIFF
--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -944,9 +944,11 @@ impl Vim {
             change_list::register(editor, cx);
             digraph::register(editor, cx);
 
-            cx.defer_in(window, |vim, window, cx| {
-                vim.focused(false, window, cx);
-            })
+            if editor.is_focused(window) {
+                cx.defer_in(window, |vim, window, cx| {
+                    vim.focused(false, window, cx);
+                })
+            }
         })
     }
 


### PR DESCRIPTION
Update `Vim::activate` to ensure that the `Vim.focused` method is only called if the associated editor is also focused.

This ensures that the `VimEvent::Focused` event is only emitted when the editor is actually focused, preventing a bug where, after starting Zed, Vim's mode indicator would show that the mode was `Insert` even though it was in `Normal` mode in the main editor.

Closes #41353 

Release Notes:

- Fixed vim's mode being shown as `Inserted` right after opening Zed
