### PR TITLE
zeta2: Improve context search performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21702,6 +21702,7 @@ dependencies = [
  "ordered-float 2.10.1",
  "pretty_assertions",
  "project",
+ "regex-syntax",
  "serde",
  "serde_json",
  "settings",

--- a/crates/zeta2/src/related_excerpts.rs
+++ b/crates/zeta2/src/related_excerpts.rs
@@ -79,8 +79,6 @@ const SEARCH_TOOL_NAME: &str = "search";
 #[derive(Clone, Deserialize, Serialize, JsonSchema)]
 pub struct SearchToolInput {
     /// An array of queries to run for gathering context relevant to the next prediction
-    ///
-    /// For the best performance, combine queries for the same glob into one regex pattern.
     #[schemars(length(max = 5))]
     pub queries: Box<[SearchToolQuery]>,
 }

--- a/crates/zeta2/src/related_excerpts.rs
+++ b/crates/zeta2/src/related_excerpts.rs
@@ -523,6 +523,17 @@ pub fn find_related_excerpts<'a>(
                 }
             }
 
+            if let Some(debug_tx) = &debug_tx {
+                debug_tx
+                    .unbounded_send(ZetaDebugInfo::SearchResultsFiltered(
+                        ZetaContextRetrievalDebugInfo {
+                            project: project.clone(),
+                            timestamp: Instant::now(),
+                        },
+                    ))
+                    .ok();
+            }
+
             if selected_ranges.is_empty() {
                 log::trace!("context gathering selected no ranges")
             }

--- a/crates/zeta2/src/zeta2.rs
+++ b/crates/zeta2/src/zeta2.rs
@@ -138,6 +138,7 @@ pub enum ZetaDebugInfo {
     ContextRetrievalStarted(ZetaContextRetrievalDebugInfo),
     SearchQueriesGenerated(ZetaSearchQueryDebugInfo),
     SearchQueriesExecuted(ZetaContextRetrievalDebugInfo),
+    SearchResultsFiltered(ZetaContextRetrievalDebugInfo),
     ContextRetrievalFinished(ZetaContextRetrievalDebugInfo),
     EditPredicted(ZetaEditPredictionDebugInfo),
 }

--- a/crates/zeta2_tools/Cargo.toml
+++ b/crates/zeta2_tools/Cargo.toml
@@ -30,6 +30,7 @@ project.workspace = true
 serde.workspace = true
 telemetry.workspace = true
 text.workspace = true
+regex-syntax = "0.8.8"
 ui.workspace = true
 ui_input.workspace = true
 util.workspace = true

--- a/crates/zeta2_tools/src/zeta2_context_view.rs
+++ b/crates/zeta2_tools/src/zeta2_context_view.rs
@@ -20,12 +20,11 @@ use project::Project;
 use text::OffsetRangeExt;
 use ui::{
     ButtonCommon, Clickable, Color, Disableable, FluentBuilder as _, Icon, IconButton, IconName,
-    IconSize, InteractiveElement, IntoElement, ListItem, StyledTypography, div, h_flex, v_flex,
+    IconSize, InteractiveElement, IntoElement, ListHeader, ListItem, StyledTypography, div, h_flex,
+    v_flex,
 };
 use workspace::{Item, ItemHandle as _};
-use zeta2::{
-    SearchToolQuery, Zeta, ZetaContextRetrievalDebugInfo, ZetaDebugInfo, ZetaSearchQueryDebugInfo,
-};
+use zeta2::{Zeta, ZetaContextRetrievalDebugInfo, ZetaDebugInfo, ZetaSearchQueryDebugInfo};
 
 pub struct Zeta2ContextView {
     empty_focus_handle: FocusHandle,
@@ -37,14 +36,20 @@ pub struct Zeta2ContextView {
 }
 
 #[derive(Debug)]
-pub struct RetrievalRun {
+struct RetrievalRun {
     editor: Entity<Editor>,
-    search_queries: Vec<SearchToolQuery>,
+    search_queries: Vec<GlobQueries>,
     started_at: Instant,
     search_results_generated_at: Option<Instant>,
     search_results_executed_at: Option<Instant>,
     search_results_filtered_at: Option<Instant>,
     finished_at: Option<Instant>,
+}
+
+#[derive(Debug)]
+struct GlobQueries {
+    glob: String,
+    alternations: Vec<String>,
 }
 
 actions!(
@@ -209,7 +214,23 @@ impl Zeta2ContextView {
         };
 
         run.search_results_generated_at = Some(info.timestamp);
-        run.search_queries = info.queries;
+        run.search_queries = info
+            .queries
+            .into_iter()
+            .map(|query| {
+                let mut regex_parser = regex_syntax::ast::parse::Parser::new();
+
+                GlobQueries {
+                    glob: query.glob,
+                    alternations: match regex_parser.parse(&query.regex) {
+                        Ok(regex_syntax::ast::Ast::Alternation(ref alt)) => {
+                            alt.asts.iter().map(|ast| ast.to_string()).collect()
+                        }
+                        _ => vec![query.regex],
+                    },
+                }
+            })
+            .collect();
         cx.notify();
     }
 
@@ -276,28 +297,37 @@ impl Zeta2ContextView {
         let run = &self.runs[self.current_ix];
 
         h_flex()
+            .p_2()
             .w_full()
             .font_buffer(cx)
             .text_xs()
             .border_t_1()
+            .gap_2()
             .child(
-                v_flex()
-                    .h_full()
-                    .flex_1()
-                    .children(run.search_queries.iter().enumerate().map(|(ix, query)| {
-                        ListItem::new(ix)
-                            .start_slot(
-                                Icon::new(IconName::MagnifyingGlass)
-                                    .color(Color::Muted)
-                                    .size(IconSize::Small),
-                            )
-                            .child(query.regex.clone())
-                    })),
+                v_flex().h_full().flex_1().children(
+                    run.search_queries
+                        .iter()
+                        .enumerate()
+                        .flat_map(|(ix, query)| {
+                            std::iter::once(ListHeader::new(query.glob.clone()).into_any_element())
+                                .chain(query.alternations.iter().enumerate().map(
+                                    move |(alt_ix, alt)| {
+                                        ListItem::new(ix * 100 + alt_ix)
+                                            .start_slot(
+                                                Icon::new(IconName::MagnifyingGlass)
+                                                    .color(Color::Muted)
+                                                    .size(IconSize::Small),
+                                            )
+                                            .child(alt.clone())
+                                            .into_any_element()
+                                    },
+                                ))
+                        }),
+                ),
             )
             .child(
                 v_flex()
                     .h_full()
-                    .pr_2()
                     .text_align(TextAlign::Right)
                     .child(
                         h_flex()


### PR DESCRIPTION
We'll now perform all searches from the context model concurrently, and combine queries for the same glob into one reducing the total number of project searches.

For better readability, the debug context view now displays each top-level regex alternation individually, grouped by its corresponding glob:

<img width="1592" height="672" alt="CleanShot 2025-10-29 at 19 56 03@2x" src="https://github.com/user-attachments/assets/f6e8408e-09d6-4e27-ba11-a739a772aa12" />

(This is with Claude so slow inference is expected)

Release Notes:

- N/A 
