### PR TITLE
docs: Fix Codestral section title in edit prediction page

### DIFF
--- a/docs/src/ai/edit-prediction.md
+++ b/docs/src/ai/edit-prediction.md
@@ -314,7 +314,7 @@ To use Supermaven as your provider, set this within `settings.json`:
 
 You should be able to sign-in to Supermaven by clicking on the Supermaven icon in the status bar and following the setup instructions.
 
-### Configuring Supermaven {#supermaven}
+### Codestral {#supermaven}
 
 To use Mistral's Codestral as your provider, start by going to the the Agent Panel settings view by running the {#action agent::OpenSettings} action.
 Look for the Mistral item and add a Codestral API key in the corresponding text input.

--- a/docs/src/ai/edit-prediction.md
+++ b/docs/src/ai/edit-prediction.md
@@ -314,7 +314,7 @@ To use Supermaven as your provider, set this within `settings.json`:
 
 You should be able to sign-in to Supermaven by clicking on the Supermaven icon in the status bar and following the setup instructions.
 
-### Codestral {#supermaven}
+### Codestral {#codestral}
 
 To use Mistral's Codestral as your provider, start by going to the the Agent Panel settings view by running the {#action agent::OpenSettings} action.
 Look for the Mistral item and add a Codestral API key in the corresponding text input.


### PR DESCRIPTION
Follow up to https://github.com/zed-industries/zed/pull/41507 as I realized I didn't change the title for this section.

Release Notes:

- N/A
