### PR TITLE
Full text search for agent history

### DIFF
--- a/crates/agent/src/db.rs
+++ b/crates/agent/src/db.rs
@@ -241,7 +241,7 @@ impl Column for DataType {
     }
 }
 
-pub(crate) struct ThreadsDatabase {
+pub struct ThreadsDatabase {
     executor: BackgroundExecutor,
     connection: Arc<Mutex<Connection>>,
 }
@@ -304,12 +304,69 @@ impl ThreadsDatabase {
         "})?()
         .map_err(|e| anyhow!("Failed to create threads table: {}", e))?;
 
+        // Create FTS5 virtual table for full text search
+        connection.exec(indoc! {"
+            CREATE VIRTUAL TABLE IF NOT EXISTS threads_fts USING fts5(
+                id UNINDEXED,
+                title,
+                content
+            )
+        "})?()
+        .map_err(|e| anyhow!("Failed to create threads_fts table: {}", e))?;
+
         let db = Self {
             executor,
             connection: Arc::new(Mutex::new(connection)),
         };
 
         Ok(db)
+    }
+
+    fn extract_text_content(thread: &DbThread) -> String {
+        let mut content = String::new();
+
+        for message in &thread.messages {
+            match message {
+                crate::Message::User(user_msg) => {
+                    for msg_content in &user_msg.content {
+                        match msg_content {
+                            UserMessageContent::Text(text) => {
+                                content.push_str(text);
+                                content.push(' ');
+                            }
+                            UserMessageContent::Mention { .. } => {
+                                // Skip mentions for full text search
+                            }
+                            UserMessageContent::Image(_) => {
+                                // Skip images for full text search
+                            }
+                        }
+                    }
+                }
+                crate::Message::Agent(agent_msg) => {
+                    for msg_content in &agent_msg.content {
+                        match msg_content {
+                            AgentMessageContent::Text(text) => {
+                                content.push_str(text);
+                                content.push(' ');
+                            }
+                            AgentMessageContent::Thinking { text, .. } => {
+                                content.push_str(text);
+                                content.push(' ');
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                crate::Message::Resume => {
+                    // Skip resume messages for full text search.
+                    // Resume messages are a marker used to indicate the conversation should continue
+                    // from where it left off. They are not real user content and should not be indexed.
+                }
+            }
+        }
+
+        content
     }
 
     fn save_thread_sync(
@@ -328,6 +385,7 @@ impl ThreadsDatabase {
 
         let title = thread.title.to_string();
         let updated_at = thread.updated_at.to_rfc3339();
+        let text_content = Self::extract_text_content(&thread);
         let json_data = serde_json::to_string(&SerializedThread {
             thread,
             version: DbThread::VERSION,
@@ -335,17 +393,51 @@ impl ThreadsDatabase {
 
         let connection = connection.lock();
 
-        let compressed = zstd::encode_all(json_data.as_bytes(), COMPRESSION_LEVEL)?;
-        let data_type = DataType::Zstd;
-        let data = compressed;
+        // Begin explicit transaction for atomicity
+        connection.exec("BEGIN IMMEDIATE")?()
+            .map_err(|e| anyhow!("Failed to begin transaction: {}", e))?;
 
-        let mut insert = connection.exec_bound::<(Arc<str>, String, String, DataType, Vec<u8>)>(indoc! {"
-            INSERT OR REPLACE INTO threads (id, summary, updated_at, data_type, data) VALUES (?, ?, ?, ?, ?)
-        "})?;
+        // Helper to rollback on error
+        let result = (|| -> Result<()> {
+            let compressed = zstd::encode_all(json_data.as_bytes(), COMPRESSION_LEVEL)?;
+            let data_type = DataType::Zstd;
+            let data = compressed;
 
-        insert((id.0, title, updated_at, data_type, data))?;
+            let mut insert = connection.exec_bound::<(Arc<str>, String, String, DataType, Vec<u8>)>(indoc! {"
+                INSERT OR REPLACE INTO threads (id, summary, updated_at, data_type, data) VALUES (?, ?, ?, ?, ?)
+            "})?;
 
-        Ok(())
+            insert((id.0.clone(), title.clone(), updated_at, data_type, data))?;
+
+            // Update FTS5 index with extracted text content
+            // FTS5 doesn't support traditional UPDATE statements for content changes
+            // DELETE and INSERT is the recommended approach
+            let mut delete_fts = connection.exec_bound::<Arc<str>>(indoc! {"
+                DELETE FROM threads_fts WHERE id = ?
+            "})?;
+            delete_fts(id.0.clone())?;
+
+            let mut insert_fts = connection.exec_bound::<(Arc<str>, String, String)>(indoc! {"
+                INSERT INTO threads_fts (id, title, content) VALUES (?, ?, ?)
+            "})?;
+            insert_fts((id.0, title, text_content))?;
+
+            Ok(())
+        })();
+
+        // Commit or rollback based on result
+        match result {
+            Ok(()) => {
+                connection.exec("COMMIT")?()
+                    .map_err(|e| anyhow!("Failed to commit transaction: {}", e))?;
+                Ok(())
+            }
+            Err(e) => {
+                // Attempt to rollback, but return the original error
+                let _ = connection.exec("ROLLBACK")?();
+                Err(e)
+            }
+        }
     }
 
     pub fn list_threads(&self) -> Task<Result<Vec<DbThreadMetadata>>> {
@@ -413,13 +505,268 @@ impl ThreadsDatabase {
         self.executor.spawn(async move {
             let connection = connection.lock();
 
+            // Delete from main table
             let mut delete = connection.exec_bound::<Arc<str>>(indoc! {"
                 DELETE FROM threads WHERE id = ?
             "})?;
+            delete(id.0.clone())?;
 
-            delete(id.0)?;
+            // Delete from FTS5 index
+            let mut delete_fts = connection.exec_bound::<Arc<str>>(indoc! {"
+                DELETE FROM threads_fts WHERE id = ?
+            "})?;
+            delete_fts(id.0)?;
 
             Ok(())
         })
+    }
+
+    pub fn search_threads(&self, query: String) -> Task<Result<Vec<DbThreadMetadata>>> {
+        let connection = self.connection.clone();
+
+        self.executor.spawn(async move {
+            let connection = connection.lock();
+
+            // Use FTS5 MATCH query to search both title and content
+            let mut select =
+                connection.select_bound::<String, (Arc<str>, String, String)>(indoc! {"
+                SELECT t.id, t.summary, t.updated_at
+                FROM threads t
+                INNER JOIN threads_fts fts ON t.id = fts.id
+                WHERE threads_fts MATCH ?
+                ORDER BY rank, t.updated_at DESC
+            "})?;
+
+            let rows = select(query)?;
+            let mut threads = Vec::new();
+
+            for (id, summary, updated_at) in rows {
+                threads.push(DbThreadMetadata {
+                    id: acp::SessionId(id),
+                    title: summary.into(),
+                    updated_at: DateTime::parse_from_rfc3339(&updated_at)?.with_timezone(&Utc),
+                });
+            }
+
+            Ok(threads)
+        })
+    }
+
+    /// Rebuilds the full text search index for all threads.
+    /// This is useful for migrating existing threads after enabling FTS.
+    pub fn rebuild_search_index(&self) -> Task<Result<usize>> {
+        let connection = self.connection.clone();
+
+        self.executor.spawn(async move {
+            // Get all threads
+            let rows = {
+                let connection_guard = connection.lock();
+                let mut select = connection_guard
+                    .select_bound::<(), (Arc<str>, DataType, Vec<u8>)>(indoc! {"
+                    SELECT id, data_type, data FROM threads
+                "})?;
+                select(())?
+            };
+
+            let mut indexed_count = 0;
+
+            for (id, data_type, data) in rows {
+                // Decompress and parse thread
+                let json_data = match data_type {
+                    DataType::Zstd => {
+                        let decompressed = zstd::decode_all(&data[..])?;
+                        String::from_utf8(decompressed)?
+                    }
+                    DataType::Json => String::from_utf8(data)?,
+                };
+
+                let thread = DbThread::from_json(json_data.as_bytes())?;
+                let title = thread.title.to_string();
+                let text_content = Self::extract_text_content(&thread);
+
+                // Update FTS index
+                {
+                    let connection_guard = connection.lock();
+
+                    let mut delete_fts = connection_guard.exec_bound::<Arc<str>>(indoc! {"
+                        DELETE FROM threads_fts WHERE id = ?
+                    "})?;
+                    delete_fts(id.clone())?;
+
+                    let mut insert_fts = connection_guard
+                        .exec_bound::<(Arc<str>, String, String)>(indoc! {"
+                        INSERT INTO threads_fts (id, title, content) VALUES (?, ?, ?)
+                    "})?;
+                    insert_fts((id, title, text_content))?;
+                }
+
+                indexed_count += 1;
+            }
+
+            Ok(indexed_count)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui::TestAppContext;
+
+    #[gpui::test]
+    async fn test_full_text_search(cx: &mut TestAppContext) {
+        let db = ThreadsDatabase::new(cx.executor()).unwrap();
+
+        // Create test threads with different content
+        let thread1 = DbThread {
+            title: "First Thread".into(),
+            messages: vec![
+                crate::Message::User(UserMessage {
+                    id: UserMessageId::new(),
+                    content: vec![UserMessageContent::Text(
+                        "How do I implement Rust async?".into(),
+                    )],
+                }),
+                crate::Message::Agent(AgentMessage {
+                    content: vec![AgentMessageContent::Text(
+                        "To implement async in Rust, you use async/await syntax.".into(),
+                    )],
+                    tool_results: IndexMap::default(),
+                }),
+            ],
+            updated_at: Utc::now(),
+            detailed_summary: None,
+            initial_project_snapshot: None,
+            cumulative_token_usage: Default::default(),
+            request_token_usage: HashMap::default(),
+            model: None,
+            completion_mode: None,
+            profile: None,
+        };
+
+        let thread2 = DbThread {
+            title: "Second Thread".into(),
+            messages: vec![
+                crate::Message::User(UserMessage {
+                    id: UserMessageId::new(),
+                    content: vec![UserMessageContent::Text(
+                        "What are the best Python frameworks?".into(),
+                    )],
+                }),
+                crate::Message::Agent(AgentMessage {
+                    content: vec![AgentMessageContent::Text(
+                        "Django and Flask are popular Python web frameworks.".into(),
+                    )],
+                    tool_results: IndexMap::default(),
+                }),
+            ],
+            updated_at: Utc::now(),
+            detailed_summary: None,
+            initial_project_snapshot: None,
+            cumulative_token_usage: Default::default(),
+            request_token_usage: HashMap::default(),
+            model: None,
+            completion_mode: None,
+            profile: None,
+        };
+
+        // Save threads
+        let id1 = acp::SessionId(Arc::from("test-thread-1"));
+        let id2 = acp::SessionId(Arc::from("test-thread-2"));
+
+        db.save_thread(id1.clone(), thread1).await.unwrap();
+        db.save_thread(id2.clone(), thread2).await.unwrap();
+
+        // Search for "Rust" - should find thread1
+        let results = db.search_threads("Rust".to_string()).await.unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].id, id1);
+
+        // Search for "Python" - should find thread2
+        let results = db.search_threads("Python".to_string()).await.unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].id, id2);
+
+        // Search for "frameworks" - should find thread2
+        let results = db.search_threads("frameworks".to_string()).await.unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].id, id2);
+
+        // Search for "async" - should find thread1 (searching content, not just title)
+        let results = db.search_threads("async".to_string()).await.unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].id, id1);
+
+        // Clean up
+        db.delete_thread(id1).await.unwrap();
+        db.delete_thread(id2).await.unwrap();
+    }
+
+    #[gpui::test]
+    async fn test_rebuild_search_index(cx: &mut TestAppContext) {
+        let db = ThreadsDatabase::new(cx.executor()).unwrap();
+
+        // Create a thread
+        let thread = DbThread {
+            title: "Migration Test".into(),
+            messages: vec![
+                crate::Message::User(UserMessage {
+                    id: UserMessageId::new(),
+                    content: vec![UserMessageContent::Text(
+                        "This thread needs to be indexed".into(),
+                    )],
+                }),
+                crate::Message::Agent(AgentMessage {
+                    content: vec![AgentMessageContent::Text(
+                        "Response with unique keyword xyzabc123".into(),
+                    )],
+                    tool_results: IndexMap::default(),
+                }),
+            ],
+            updated_at: Utc::now(),
+            detailed_summary: None,
+            initial_project_snapshot: None,
+            cumulative_token_usage: Default::default(),
+            request_token_usage: HashMap::default(),
+            model: None,
+            completion_mode: None,
+            profile: None,
+        };
+
+        let id = acp::SessionId(Arc::from("migration-test-thread"));
+
+        // Save the thread (this will index it)
+        db.save_thread(id.clone(), thread).await.unwrap();
+
+        // Manually clear the FTS index to simulate old data
+        {
+            let connection = db.connection.lock();
+            let mut delete = connection
+                .exec_bound::<Arc<str>>(indoc! {"
+                DELETE FROM threads_fts WHERE id = ?
+            "})
+                .unwrap();
+            delete(id.0.clone()).unwrap();
+        }
+
+        // Verify thread is not searchable
+        let results = db.search_threads("xyzabc123".to_string()).await.unwrap();
+        assert_eq!(
+            results.len(),
+            0,
+            "Thread should not be found before rebuild"
+        );
+
+        // Rebuild the index
+        let count = db.rebuild_search_index().await.unwrap();
+        assert_eq!(count, 1, "Should have indexed 1 thread");
+
+        // Verify thread is now searchable
+        let results = db.search_threads("xyzabc123".to_string()).await.unwrap();
+        assert_eq!(results.len(), 1, "Thread should be found after rebuild");
+        assert_eq!(results[0].id, id);
+
+        // Clean up
+        db.delete_thread(id).await.unwrap();
     }
 }


### PR DESCRIPTION
This PR implements full text search for the threads database providing the ability for users to search the entire agent history, not only the title.

The implementation uses SQLite's FTS5 (Full Text Search 5) extension. A new virtual table `threads_fts` was added to the database.

The FTS index is automatically maintained during database operations:

1. Save/Update Thread: When `save_thread()` is called
2. Delete Thread: When `delete_thread()` is called:

A background task to build the FTS index for existing threads provides a one-time migration to index exsting threads.

This PR was authored by Claude in Zed. I hope you find it to be acceptable quality.

