### PR TITLE
languages: Add ignore keyword for gomod

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17898,7 +17898,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-gomod"
 version = "1.1.1"
-source = "git+https://github.com/camdencheek/tree-sitter-go-mod?rev=6efb59652d30e0e9cd5f3b3a669afd6f1a926d3c#6efb59652d30e0e9cd5f3b3a669afd6f1a926d3c"
+source = "git+https://github.com/camdencheek/tree-sitter-go-mod?rev=2e886870578eeba1927a2dc4bd2e2b3f598c5f9a#2e886870578eeba1927a2dc4bd2e2b3f598c5f9a"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -672,7 +672,7 @@ tree-sitter-elixir = "0.3"
 tree-sitter-embedded-template = "0.23.0"
 tree-sitter-gitcommit = { git = "https://github.com/zed-industries/tree-sitter-git-commit", rev = "88309716a69dd13ab83443721ba6e0b491d37ee9" }
 tree-sitter-go = "0.23"
-tree-sitter-go-mod = { git = "https://github.com/camdencheek/tree-sitter-go-mod", rev = "6efb59652d30e0e9cd5f3b3a669afd6f1a926d3c", package = "tree-sitter-gomod" }
+tree-sitter-go-mod = { git = "https://github.com/camdencheek/tree-sitter-go-mod", rev = "2e886870578eeba1927a2dc4bd2e2b3f598c5f9a", package = "tree-sitter-gomod" }
 tree-sitter-gowork = { git = "https://github.com/zed-industries/tree-sitter-go-work", rev = "acb0617bf7f4fda02c6217676cc64acb89536dc7" }
 tree-sitter-heex = { git = "https://github.com/zed-industries/tree-sitter-heex", rev = "1dd45142fbb05562e35b2040c6129c9bca346592" }
 tree-sitter-html = "0.23"

--- a/crates/languages/src/gomod/highlights.scm
+++ b/crates/languages/src/gomod/highlights.scm
@@ -7,6 +7,7 @@
   "exclude"
   "retract"
   "module"
+  "ignore"
 ] @keyword
 
 "=>" @operator

--- a/crates/languages/src/gomod/structure.scm
+++ b/crates/languages/src/gomod/structure.scm
@@ -27,3 +27,9 @@
   ("(") @structure.open
   (")") @structure.close
 )
+
+(ignore_directive
+  "ignore" @structure.anchor
+  ("(") @structure.open
+  (")") @structure.close
+)


### PR DESCRIPTION
go 1.25 introduce ignore directive in go.mod to specify directories the go command should ignore.

ref: https://tip.golang.org/doc/go1.25#go-command


Release Notes:

- Added syntax highlighting support for the new [`ignore` directive](https://tip.golang.org/doc/go1.25#go-command) in `go.mod` files