### PR TITLE
Language: Fix minor C++ completion label formatting issue

### DIFF
--- a/crates/languages/src/c.rs
+++ b/crates/languages/src/c.rs
@@ -166,13 +166,24 @@ impl super::LspAdapter for CLspAdapter {
             None => "",
         };
 
-        let label = completion
+        let mut label = completion
             .label
             .strip_prefix('•')
             .unwrap_or(&completion.label)
             .trim()
-            .to_owned()
-            + label_detail;
+            .to_owned();
+
+        if !label_detail.is_empty() {
+            let should_add_space = match completion.kind {
+                Some(lsp::CompletionItemKind::FUNCTION | lsp::CompletionItemKind::METHOD) => false,
+                _ => true,
+            };
+
+            if should_add_space && !label.ends_with(' ') && !label_detail.starts_with(' ') {
+                label.push(' ');
+            }
+            label.push_str(label_detail);
+        }
 
         match completion.kind {
             Some(lsp::CompletionItemKind::FIELD) if completion.detail.is_some() => {


### PR DESCRIPTION
Closes #39515

**Details:**
- Improved logic for formatting completion labels, as some (such as `namespace`) were missing space characters.
- Added extra logic as per stale PR #39533 [comment](https://github.com/zed-industries/zed/pull/39533#issuecomment-3368549433) ensuring that cases where extra spaces are not necessary (such as functions) are not affected
	- I will note, I was not able to figure out how to fix the coloring of `namespace` within completion labels as mentioned in that comment, if someone would provide me with direction I would be happy to look into that too.

Previous:
<img width="812" height="530" alt="previous" src="https://github.com/user-attachments/assets/b38f1590-ca2d-489d-9dcb-2d478eb6ed03" />

Fixed:
<img width="812" height="530" alt="fixed" src="https://github.com/user-attachments/assets/020b151d-e5d9-467e-99c1-5b0cab057169" />


Release Notes:

- Fixed minor issue where some `clangd` labels would be missing a space in formatting
