### PR TITLE
vim: Improve pasting while in replace mode

### DIFF
--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -2270,4 +2270,19 @@ mod test {
             assert_eq!(workspace.active_pane().read(cx).active_item_index(), 1);
         });
     }
+
+    #[gpui::test]
+    async fn test_paste_on_replace(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+
+        cx.set_state(indoc! {"ˇ123"}, Mode::Replace);
+        cx.write_to_clipboard(gpui::ClipboardItem::new_string("456".to_string()));
+        cx.dispatch_action(editor::actions::Paste);
+        cx.assert_state(indoc! {"45ˇ6"}, Mode::Replace);
+
+        cx.set_state(indoc! {"ˇ123"}, Mode::Replace);
+        cx.write_to_clipboard(gpui::ClipboardItem::new_string("4567".to_string()));
+        cx.dispatch_action(editor::actions::Paste);
+        cx.assert_state(indoc! {"ˇ123"}, Mode::Replace);
+    }
 }

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -640,6 +640,16 @@ impl Vim {
                 vim.switch_mode(Mode::Normal, false, window, cx)
             });
 
+            Vim::action(editor, cx, |vim, _: &editor::actions::Paste, window, cx| {
+                // TODO!: Update this to actually call `vim.paste`?
+                // What should the action's fields be in that case?
+                if let Some(editor) = vim.editor() {
+                    editor.update(cx, |editor, cx| {
+                        editor.paste(&editor::actions::Paste, window, cx)
+                    });
+                }
+            });
+
             Vim::action(editor, cx, |vim, _: &SwitchToInsertMode, window, cx| {
                 vim.switch_mode(Mode::Insert, false, window, cx)
             });


### PR DESCRIPTION
- Update `vim::normal::Vim.normal_replace` to work with more than one
  character
- Add `vim::replace::Vim.paste_replace` to handle pasting the 
  clipboard's contents while in replace mode
- Update vim's handling of the `editor::actions::Paste` action so that
  the `paste_replace` method is called when vim is in replace mode,
  otherwise it'll just call the regular `editor::Editor.paste` method

Closes #41378 

Release Notes:

- Improved pasting while in Vim's Replace mode, ensuring that the Zed replaces the same number of characters as the length of the contents being pasted
