### PR TITLE
terminal: Properly kill child process on terminal exit

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -2241,7 +2241,8 @@ unsafe fn append_text_to_term(term: &mut Term<ZedListener>, text_lines: &[&str])
 
 impl Drop for Terminal {
     fn drop(&mut self) {
-        if let TerminalType::Pty { pty_tx, .. } = &self.terminal_type {
+        if let TerminalType::Pty { pty_tx, info } = &mut self.terminal_type {
+            info.kill_current_process();
             pty_tx.0.send(Msg::Shutdown).ok();
         }
     }


### PR DESCRIPTION
Unblocks https://github.com/zed-industries/zed/pull/41216

Release Notes:

- Fixed terminal processes occasionally leaking

Co-authored-by: Jakub Konka <kubkon@jakubkonka.com>
