### PR TITLE
Fix missing highlight for macro_invocation bang

### DIFF
--- a/crates/languages/src/rust/highlights.scm
+++ b/crates/languages/src/rust/highlights.scm
@@ -41,6 +41,9 @@
       name: (identifier) @function.special)
   ])
 
+(macro_invocation
+  "!" @function.special)
+
 (macro_definition
   name: (identifier) @function.special.definition)
 


### PR DESCRIPTION
(Not sure if this was left out on purpose, but this makes things feel a bit more consistent since [VS Code parses bang mark as part of the macro name](https://github.com/microsoft/vscode/blob/main/extensions/rust/syntaxes/rust.tmLanguage.json#L889-L905))


Release Notes:
- Added the missing highlight for the bang mark in macro invocations.


| **Before** | **After** |
| :---: | :---: |
| <img width="684" height="222" alt="before" src="https://github.com/user-attachments/assets/ae71eda3-76b5-4547-b2df-4e437a07abf5" /> | <img width="646" height="236" alt="fixed" src="https://github.com/user-attachments/assets/500deda5-d6d8-439c-8824-65c2fb0a5daa" /> |


