### PR TITLE
debugger: Get rid of initialize_args in php debugger setup docs

### DIFF
--- a/docs/src/languages/php.md
+++ b/docs/src/languages/php.md
@@ -71,9 +71,7 @@ Zed’s PHP extension provides a debug adapter for PHP and Xdebug. The adapter n
     "label": "PHP: Listen to Xdebug",
     "adapter": "Xdebug",
     "request": "launch",
-    "initialize_args": {
-      "port": 9003
-    }
+    "port": 9003
   },
   {
     "label": "PHP: Debug this test",


### PR DESCRIPTION
Related to issue: #40887

`initialize_args` was deprecated a while ago, this PR updates our PHP docs to reflect that

Release Notes:

- N/A
