### PR TITLE
Helix mode search and selection improvements

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -422,6 +422,12 @@
     }
   },
   {
+    "context": "vim_mode == helix_select && !menu",
+    "bindings": {
+      "escape": "vim::SwitchToHelixNormalMode"
+    }
+  },
+  {
     "context": "(vim_mode == helix_normal || vim_mode == helix_select) && !menu",
     "bindings": {
       // Movement

--- a/crates/agent_ui/src/text_thread_editor.rs
+++ b/crates/agent_ui/src/text_thread_editor.rs
@@ -2591,11 +2591,12 @@ impl SearchableItem for TextThreadEditor {
         &mut self,
         index: usize,
         matches: &[Self::Match],
+        collapse: bool,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         self.editor.update(cx, |editor, cx| {
-            editor.activate_match(index, matches, window, cx);
+            editor.activate_match(index, matches, collapse, window, cx);
         });
     }
 

--- a/crates/debugger_tools/src/dap_log.rs
+++ b/crates/debugger_tools/src/dap_log.rs
@@ -1029,11 +1029,13 @@ impl SearchableItem for DapLogView {
         &mut self,
         index: usize,
         matches: &[Self::Match],
+        collapse: bool,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.editor
-            .update(cx, |e, cx| e.activate_match(index, matches, window, cx))
+        self.editor.update(cx, |e, cx| {
+            e.activate_match(index, matches, collapse, window, cx)
+        })
     }
 
     fn select_matches(

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -1587,11 +1587,12 @@ impl SearchableItem for Editor {
         &mut self,
         index: usize,
         matches: &[Range<Anchor>],
+        collapse: bool,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         self.unfold_ranges(&[matches[index].clone()], false, true, cx);
-        let range = self.range_for_match(&matches[index]);
+        let range = self.range_for_match(&matches[index], collapse);
         self.change_selections(Default::default(), window, cx, |s| {
             s.select_ranges([range]);
         })

--- a/crates/language_tools/src/lsp_log_view.rs
+++ b/crates/language_tools/src/lsp_log_view.rs
@@ -812,11 +812,13 @@ impl SearchableItem for LspLogView {
         &mut self,
         index: usize,
         matches: &[Self::Match],
+        collapse: bool,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.editor
-            .update(cx, |e, cx| e.activate_match(index, matches, window, cx))
+        self.editor.update(cx, |e, cx| {
+            e.activate_match(index, matches, collapse, window, cx)
+        })
     }
 
     fn select_matches(

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -10,8 +10,9 @@ use any_vec::AnyVec;
 use anyhow::Context as _;
 use collections::HashMap;
 use editor::{
-    DisplayPoint, Editor, EditorSettings,
+    DisplayPoint, Editor, EditorSettings, VimFlavor,
     actions::{Backtab, Tab},
+    vim_flavor,
 };
 use futures::channel::oneshot;
 use gpui::{
@@ -825,7 +826,8 @@ impl BufferSearchBar {
                 .searchable_items_with_matches
                 .get(&active_searchable_item.downgrade())
         {
-            active_searchable_item.activate_match(match_ix, matches, window, cx)
+            let collapse = editor::vim_flavor(cx) == Some(VimFlavor::Vim);
+            active_searchable_item.activate_match(match_ix, matches, collapse, window, cx)
         }
     }
 
@@ -970,7 +972,8 @@ impl BufferSearchBar {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.select_match(Direction::Next, 1, window, cx);
+        let collapse = vim_flavor(cx) == Some(VimFlavor::Vim);
+        self.select_match(Direction::Next, 1, collapse, window, cx);
     }
 
     fn select_prev_match(
@@ -979,7 +982,8 @@ impl BufferSearchBar {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.select_match(Direction::Prev, 1, window, cx);
+        let collapse = vim_flavor(cx) == Some(VimFlavor::Vim);
+        self.select_match(Direction::Prev, 1, collapse, window, cx);
     }
 
     pub fn select_all_matches(
@@ -1004,6 +1008,7 @@ impl BufferSearchBar {
         &mut self,
         direction: Direction,
         count: usize,
+        collapse: bool,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
@@ -1026,7 +1031,7 @@ impl BufferSearchBar {
                 .match_index_for_direction(matches, index, direction, count, window, cx);
 
             searchable_item.update_matches(matches, window, cx);
-            searchable_item.activate_match(new_match_index, matches, window, cx);
+            searchable_item.activate_match(new_match_index, matches, collapse, window, cx);
         }
     }
 
@@ -1040,7 +1045,8 @@ impl BufferSearchBar {
                 return;
             }
             searchable_item.update_matches(matches, window, cx);
-            searchable_item.activate_match(0, matches, window, cx);
+            let collapse = vim_flavor(cx) == Some(VimFlavor::Vim);
+            searchable_item.activate_match(0, matches, collapse, window, cx);
         }
     }
 
@@ -1055,7 +1061,8 @@ impl BufferSearchBar {
             }
             let new_match_index = matches.len() - 1;
             searchable_item.update_matches(matches, window, cx);
-            searchable_item.activate_match(new_match_index, matches, window, cx);
+            let collapse = vim_flavor(cx) == Some(VimFlavor::Vim);
+            searchable_item.activate_match(new_match_index, matches, collapse, window, cx);
         }
     }
 

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -1447,6 +1447,7 @@ impl SearchableItem for TerminalView {
         &mut self,
         index: usize,
         _: &[Self::Match],
+        _collapse: bool,
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {

--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -1279,6 +1279,24 @@ mod test {
     }
 
     #[gpui::test]
+    async fn test_exit_visual_mode(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+
+        cx.set_state("ˇone two", Mode::Normal);
+        cx.simulate_keystrokes("v w");
+        cx.assert_state("«one tˇ»wo", Mode::Visual);
+        cx.simulate_keystrokes("escape");
+        cx.assert_state("one ˇtwo", Mode::Normal);
+
+        cx.enable_helix();
+        cx.set_state("ˇone two", Mode::HelixNormal);
+        cx.simulate_keystrokes("v w");
+        cx.assert_state("«one ˇ»two", Mode::HelixSelect);
+        cx.simulate_keystrokes("escape");
+        cx.assert_state("«one ˇ»two", Mode::HelixNormal);
+    }
+
+    #[gpui::test]
     async fn test_helix_select_regex(cx: &mut gpui::TestAppContext) {
         let mut cx = VimTestContext::new(cx, true).await;
         cx.enable_helix();

--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -450,7 +450,7 @@ impl Vim {
                         prior_selections,
                         prior_operator: self.operator_stack.last().cloned(),
                         prior_mode: self.mode,
-                        helix_select: true,
+                        is_helix_regex_search: true,
                     }
                 });
             }
@@ -1315,9 +1315,10 @@ mod test {
         cx.simulate_keystrokes("enter");
         cx.assert_state("«oneˇ» two «oneˇ»", Mode::HelixNormal);
 
-        cx.set_state("ˇone two one", Mode::HelixNormal);
-        cx.simulate_keystrokes("s o n e enter");
-        cx.assert_state("ˇone two one", Mode::HelixNormal);
+        // TODO: change "search_in_selection" to not perform any search when in helix select mode with no selection
+        // cx.set_state("ˇstuff one two one", Mode::HelixNormal);
+        // cx.simulate_keystrokes("s o n e enter");
+        // cx.assert_state("ˇstuff one two one", Mode::HelixNormal);
     }
 
     #[gpui::test]
@@ -1354,10 +1355,7 @@ mod test {
         cx.simulate_keystrokes("/ o n e");
         cx.simulate_keystrokes("enter");
         cx.simulate_keystrokes("n n");
-        cx.assert_state(
-            "«hˇ»ello two «oneˇ» two «oneˇ» two «oneˇ»",
-            Mode::HelixSelect,
-        );
+        cx.assert_state("ˇhello two «oneˇ» two «oneˇ» two «oneˇ»", Mode::HelixSelect);
     }
 
     #[gpui::test]

--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -1321,6 +1321,46 @@ mod test {
     }
 
     #[gpui::test]
+    async fn test_helix_select_next_match(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+
+        cx.set_state("ˇhello two one two one two one", Mode::Visual);
+        cx.simulate_keystrokes("/ o n e");
+        cx.simulate_keystrokes("enter");
+        cx.simulate_keystrokes("n n");
+        cx.assert_state("«hello two one two one two oˇ»ne", Mode::Visual);
+
+        cx.set_state("ˇhello two one two one two one", Mode::Normal);
+        cx.simulate_keystrokes("/ o n e");
+        cx.simulate_keystrokes("enter");
+        cx.simulate_keystrokes("n n");
+        cx.assert_state("hello two one two one two ˇone", Mode::Normal);
+
+        cx.set_state("ˇhello two one two one two one", Mode::Normal);
+        cx.simulate_keystrokes("/ o n e");
+        cx.simulate_keystrokes("enter");
+        cx.simulate_keystrokes("n g n g n");
+        cx.assert_state("hello two one two «one two oneˇ»", Mode::Visual);
+
+        cx.enable_helix();
+
+        cx.set_state("ˇhello two one two one two one", Mode::HelixNormal);
+        cx.simulate_keystrokes("/ o n e");
+        cx.simulate_keystrokes("enter");
+        cx.simulate_keystrokes("n n");
+        cx.assert_state("hello two one two one two «oneˇ»", Mode::HelixNormal);
+
+        cx.set_state("ˇhello two one two one two one", Mode::HelixSelect);
+        cx.simulate_keystrokes("/ o n e");
+        cx.simulate_keystrokes("enter");
+        cx.simulate_keystrokes("n n");
+        cx.assert_state(
+            "«hˇ»ello two «oneˇ» two «oneˇ» two «oneˇ»",
+            Mode::HelixSelect,
+        );
+    }
+
+    #[gpui::test]
     async fn test_helix_substitute(cx: &mut gpui::TestAppContext) {
         let mut cx = VimTestContext::new(cx, true).await;
 

--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -673,7 +673,8 @@ pub fn register(editor: &mut Editor, cx: &mut Context<Vim>) {
 impl Vim {
     pub(crate) fn search_motion(&mut self, m: Motion, window: &mut Window, cx: &mut Context<Self>) {
         if let Motion::ZedSearchResult {
-            prior_selections, ..
+            prior_selections,
+            new_selections: _new_selections,
         } = &m
         {
             match self.mode {
@@ -692,11 +693,20 @@ impl Vim {
                     }
                 }
 
-                Mode::HelixNormal | Mode::HelixSelect => {}
+                Mode::HelixNormal => {}
+                Mode::HelixSelect => {}
             }
         }
 
-        self.motion(m, window, cx)
+        self.motion(m, window, cx);
+
+        // if self.mode == Mode::HelixNormal {
+        //     self.update_editor(cx, |_, editor, cx| {
+        //         editor.change_selections(Default::default(), window, cx, |s| {
+        //             s.select_ranges(new_selections.iter().cloned())
+        //         });
+        //     });
+        // }
     }
 
     pub(crate) fn motion(&mut self, motion: Motion, window: &mut Window, cx: &mut Context<Self>) {

--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -672,41 +672,40 @@ pub fn register(editor: &mut Editor, cx: &mut Context<Vim>) {
 
 impl Vim {
     pub(crate) fn search_motion(&mut self, m: Motion, window: &mut Window, cx: &mut Context<Self>) {
-        if let Motion::ZedSearchResult {
+        let Motion::ZedSearchResult {
             prior_selections,
-            new_selections: _new_selections,
+            new_selections,
         } = &m
-        {
-            match self.mode {
-                Mode::Visual | Mode::VisualLine | Mode::VisualBlock => {
-                    if !prior_selections.is_empty() {
-                        self.update_editor(cx, |_, editor, cx| {
-                            editor.change_selections(Default::default(), window, cx, |s| {
-                                s.select_ranges(prior_selections.iter().cloned())
-                            })
-                        });
-                    }
-                }
-                Mode::Normal | Mode::Replace | Mode::Insert => {
-                    if self.active_operator().is_none() {
-                        return;
-                    }
-                }
+        else {
+            return;
+        };
 
-                Mode::HelixNormal => {}
-                Mode::HelixSelect => {}
+        match self.mode {
+            Mode::Visual | Mode::VisualLine | Mode::VisualBlock => {
+                if !prior_selections.is_empty() {
+                    self.update_editor(cx, |_, editor, cx| {
+                        editor.change_selections(Default::default(), window, cx, |s| {
+                            s.select_ranges(prior_selections.iter().cloned());
+                        });
+                    });
+                }
+                self.motion(m, window, cx);
+            }
+            Mode::Normal | Mode::Replace | Mode::Insert => {
+                if self.active_operator().is_some() {
+                    self.motion(m, window, cx);
+                }
+            }
+
+            Mode::HelixNormal => {}
+            Mode::HelixSelect => {
+                self.update_editor(cx, |_, editor, cx| {
+                    editor.change_selections(Default::default(), window, cx, |s| {
+                        s.select_ranges(prior_selections.iter().chain(new_selections).cloned());
+                    });
+                });
             }
         }
-
-        self.motion(m, window, cx);
-
-        // if self.mode == Mode::HelixNormal {
-        //     self.update_editor(cx, |_, editor, cx| {
-        //         editor.change_selections(Default::default(), window, cx, |s| {
-        //             s.select_ranges(new_selections.iter().cloned())
-        //         });
-        //     });
-        // }
     }
 
     pub(crate) fn motion(&mut self, motion: Motion, window: &mut Window, cx: &mut Context<Self>) {

--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -66,11 +66,15 @@ impl Display for Mode {
 }
 
 impl Mode {
-    pub fn is_visual(&self) -> bool {
+    pub fn is_visual(self) -> bool {
         match self {
             Self::Visual | Self::VisualLine | Self::VisualBlock | Self::HelixSelect => true,
             Self::Normal | Self::Insert | Self::Replace | Self::HelixNormal => false,
         }
+    }
+
+    pub fn is_helix(self) -> bool {
+        matches!(self, Mode::HelixNormal | Mode::HelixSelect)
     }
 }
 
@@ -990,7 +994,7 @@ pub struct SearchState {
     pub prior_selections: Vec<Range<Anchor>>,
     pub prior_operator: Option<Operator>,
     pub prior_mode: Mode,
-    pub helix_select: bool,
+    pub is_helix_regex_search: bool,
 }
 
 impl Operator {

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -669,7 +669,7 @@ impl Vim {
                 editor,
                 cx,
                 |vim, _: &SwitchToHelixNormalMode, window, cx| {
-                    vim.switch_mode(Mode::HelixNormal, false, window, cx)
+                    vim.switch_mode(Mode::HelixNormal, true, window, cx)
                 },
             );
             Vim::action(editor, cx, |_, _: &PushForcedMotion, _, cx| {

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -953,7 +953,6 @@ impl Vim {
     fn deactivate(editor: &mut Editor, cx: &mut Context<Editor>) {
         editor.set_cursor_shape(CursorShape::Bar, cx);
         editor.set_clip_at_line_ends(false, cx);
-        editor.set_collapse_matches(false);
         editor.set_input_enabled(true);
         editor.set_autoindent(true);
         editor.selections.set_line_mode(false);
@@ -1929,7 +1928,6 @@ impl Vim {
         self.update_editor(cx, |vim, editor, cx| {
             editor.set_cursor_shape(vim.cursor_shape(cx), cx);
             editor.set_clip_at_line_ends(vim.clip_at_line_ends(), cx);
-            editor.set_collapse_matches(true);
             editor.set_input_enabled(vim.editor_input_enabled());
             editor.set_autoindent(vim.should_autoindent());
             editor

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -847,9 +847,6 @@ impl Vim {
         let mut start_selection = 0usize;
         let mut end_selection = 0usize;
 
-        self.update_editor(cx, |_, editor, _| {
-            editor.set_collapse_matches(false);
-        });
         if vim_is_normal {
             pane.update(cx, |pane, cx| {
                 if let Some(search_bar) = pane.toolbar().read(cx).item_of_type::<BufferSearchBar>()
@@ -860,7 +857,7 @@ impl Vim {
                         }
                         // without update_match_index there is a bug when the cursor is before the first match
                         search_bar.update_match_index(window, cx);
-                        search_bar.select_match(direction.opposite(), 1, window, cx);
+                        search_bar.select_match(direction.opposite(), 1, false, window, cx);
                     });
                 }
             });
@@ -878,7 +875,7 @@ impl Vim {
             if let Some(search_bar) = pane.toolbar().read(cx).item_of_type::<BufferSearchBar>() {
                 search_bar.update(cx, |search_bar, cx| {
                     search_bar.update_match_index(window, cx);
-                    search_bar.select_match(direction, count, window, cx);
+                    search_bar.select_match(direction, count, false, window, cx);
                     match_exists = search_bar.match_exists(window, cx);
                 });
             }
@@ -905,7 +902,6 @@ impl Vim {
             editor.change_selections(Default::default(), window, cx, |s| {
                 s.select_ranges([start_selection..end_selection]);
             });
-            editor.set_collapse_matches(true);
         });
 
         match self.maybe_pop_operator() {

--- a/crates/workspace/src/searchable.rs
+++ b/crates/workspace/src/searchable.rs
@@ -104,6 +104,7 @@ pub trait SearchableItem: Item + EventEmitter<SearchEvent> {
         &mut self,
         index: usize,
         matches: &[Self::Match],
+        collapse: bool,
         window: &mut Window,
         cx: &mut Context<Self>,
     );
@@ -184,6 +185,7 @@ pub trait SearchableItemHandle: ItemHandle {
         &self,
         index: usize,
         matches: &AnyVec<dyn Send>,
+        collapse: bool,
         window: &mut Window,
         cx: &mut App,
     );
@@ -274,12 +276,13 @@ impl<T: SearchableItem> SearchableItemHandle for Entity<T> {
         &self,
         index: usize,
         matches: &AnyVec<dyn Send>,
+        collapse: bool,
         window: &mut Window,
         cx: &mut App,
     ) {
         let matches = matches.downcast_ref().unwrap();
         self.update(cx, |this, cx| {
-            this.activate_match(index, matches.as_slice(), window, cx)
+            this.activate_match(index, matches.as_slice(), collapse, window, cx)
         });
     }
 


### PR DESCRIPTION
Closes #41125
Closes #41164

This PR removes the out-of-band tracking of whether selection ranges should be compacted to the start of the range. That's useful for things like `SelectNextMatch` in vim, but it turns out not to be as universal when using vim mode as the original authors had thought, so we'd have to do silly hacks like turning that setting on and off between certain motions to get the correct behavior both for vim and helix modes.

Now you have to explicitly pass a `collapse` flag into the helpers having to do with buffer search selection matching, and we've migrated the relevant APIs to use that.

We also discovered a false positive in the helix tests around `s` used without a selection. In helix this doesn't do anything, but because of the semantics of our "search selected lines" flag, in zed it simply acts like `/`. We've disabled this test for now because the more faithful behavior doesn't seem necessarily more useful.

Release Notes:

- Fixed `SwitchToHelixNormalMode` to keep selection when hitting escape from select mode, and bound it to `escape` in helix select mode by default.
- Improved the behavior of `vim::MoveToNextMatch` and `search::SelectNextMatch` (as well as their `previous` counterparts) when using helix mode. When enabled, the latter now creates multiple selections using multicursor, unlike in vim where it simply deselects the current match and selects the next one.