### PR TITLE
agent_ui: Prevent mode selector tooltip from going off-screen

### DIFF
--- a/crates/agent_ui/src/acp/mode_selector.rs
+++ b/crates/agent_ui/src/acp/mode_selector.rs
@@ -1,8 +1,10 @@
 use acp_thread::AgentSessionModes;
 use agent_client_protocol as acp;
 use agent_servers::AgentServer;
+use agent_settings::AgentSettings;
 use fs::Fs;
 use gpui::{Context, Entity, FocusHandle, WeakEntity, Window, prelude::*};
+use settings::Settings as _;
 use std::{rc::Rc, sync::Arc};
 use ui::{
     Button, ContextMenu, ContextMenuEntry, DocumentationEdge, DocumentationSide, KeyBinding,
@@ -84,6 +86,14 @@ impl ModeSelector {
             let current_mode = self.connection.current_mode();
             let default_mode = self.agent_server.default_mode(cx);
 
+            let settings = AgentSettings::get_global(cx);
+            let side = match settings.dock {
+                settings::DockPosition::Left => DocumentationSide::Right,
+                settings::DockPosition::Bottom | settings::DockPosition::Right => {
+                    DocumentationSide::Left
+                }
+            };
+
             for mode in all_modes {
                 let is_selected = &mode.id == &current_mode;
                 let is_default = Some(&mode.id) == default_mode.as_ref();
@@ -91,7 +101,7 @@ impl ModeSelector {
                     .toggleable(IconPosition::End, is_selected);
 
                 let entry = if let Some(description) = &mode.description {
-                    entry.documentation_aside(DocumentationSide::Left, DocumentationEdge::Bottom, {
+                    entry.documentation_aside(side, DocumentationEdge::Bottom, {
                         let description = description.clone();
 
                         move |cx| {


### PR DESCRIPTION
Closes #41458 

Dynamically position mode selector tooltip to prevent clipping.

Position tooltip on the right when panel is docked left, otherwise on the left. This ensures the tooltip remains visible regardless of panel position.

**Note:** The tooltip currently vertically aligns with the bottom of the menu rather than individual items. Would be great if it can be aligned with the option it explains. But this doesn't seem trivial to me to implement and not sure if it's important enough atm? 

Before: 
<img width="431" height="248" alt="Screenshot 2025-10-30 at 22 21 09" src="https://github.com/user-attachments/assets/073f5440-b1bf-420b-b12f-558928b627f1" />

After:
<img width="632" height="158" alt="Screenshot 2025-10-30 at 17 26 52" src="https://github.com/user-attachments/assets/e999e390-bf23-435e-9df0-3126dbc14ecb" />
<img width="685" height="175" alt="Screenshot 2025-10-30 at 17 27 15" src="https://github.com/user-attachments/assets/84efca94-7920-474b-bcf8-062c7b59a812" />


Release Notes:

- Improved the agent panel's mode selector by preventing it to go off-screen in case the panel is docked to the left.

