### PR TITLE
settings_ui: Settings link improvements

### DIFF
--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -4500,7 +4500,7 @@ pub(crate) fn settings_data(cx: &App) -> Vec<SettingsPage> {
                                     title: "Program",
                                     description: "The shell program to use.",
                                     field: Box::new(SettingField {
-                                        json_path: Some("terminal.shell.program"),
+                                        json_path: Some("terminal.shell"),  
                                         pick: |settings_content| {
                                             match settings_content.terminal.as_ref()?.project.shell.as_ref() {
                                                 Some(settings::Shell::Program(program)) => Some(program),

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -18,13 +18,13 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use settings::{Settings, SettingsContent, SettingsStore};
 use std::{
-    any::{Any, TypeId, type_name},
+    any::{type_name, Any, TypeId},
     cell::RefCell,
     collections::HashMap,
     num::{NonZero, NonZeroU32},
     ops::Range,
     rc::Rc,
-    sync::{Arc, LazyLock, RwLock},
+    sync::{atomic::AtomicI32, Arc, LazyLock, RwLock},
 };
 use title_bar::platform_title_bar::PlatformTitleBar;
 use ui::{
@@ -915,7 +915,6 @@ fn render_settings_item(
 
     h_flex()
         .id(setting_item.title)
-
         .relative()
         .min_w_0()
         .justify_between()

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -853,10 +853,13 @@ fn handle_open_request(request: OpenRequest, app_state: Arc<AppState>, cx: &mut 
                 // languages.$(language).tab_size
                 // [ languages $(language) tab_size]
                 workspace::with_active_or_new_workspace(cx, |_workspace, window, cx| {
-                    window.dispatch_action(
-                        Box::new(zed_actions::OpenSettingsAt { path: setting_path }),
-                        cx,
-                    );
+                    match setting_path {
+                        None => window.dispatch_action(Box::new(zed_actions::OpenSettings), cx),
+                        Some(setting_path) => window.dispatch_action(
+                            Box::new(zed_actions::OpenSettingsAt { path: setting_path }),
+                            cx,
+                        ),
+                    }
                 });
             }
         }

--- a/crates/zed/src/zed/open_listener.rs
+++ b/crates/zed/src/zed/open_listener.rs
@@ -47,7 +47,10 @@ pub enum OpenRequestKind {
     AgentPanel,
     DockMenuAction { index: usize },
     BuiltinJsonSchema { schema_path: String },
-    Setting { setting_path: String },
+    Setting { 
+        // None just opens settings without navigating to a specific path
+        setting_path: Option<String> ,
+    },
 }
 
 impl OpenRequest {
@@ -94,9 +97,14 @@ impl OpenRequest {
                 this.kind = Some(OpenRequestKind::BuiltinJsonSchema {
                     schema_path: schema_path.to_string(),
                 });
-            } else if let Some(setting_path) = url.strip_prefix("zed://settings/") {
+            } else if url == "zed://settings" || url == "zed://settings/"  {
                 this.kind = Some(OpenRequestKind::Setting {
-                    setting_path: setting_path.to_string(),
+                    setting_path: None
+                });
+            }
+            else if let Some(setting_path) = url.strip_prefix("zed://settings/") {
+                this.kind = Some(OpenRequestKind::Setting {
+                    setting_path: Some(setting_path.to_string()),
                 });
             } else if url.starts_with("ssh://") {
                 this.parse_ssh_file_path(&url, cx)?


### PR DESCRIPTION
Two improvements to the settings UI link feature:
- "copy link" button
- set the search to `#foo.bar`, which will filter settings items with `foo.bar` in the path

Co-authored-by: Ben Kunkle <ben@zed.dev>Closes #ISSUE

Release Notes:

- N/A *or* Added/Fixed/Improved ...
