### PR TITLE
Add support for closing window tabs with middle mouse click

### DIFF
--- a/crates/title_bar/src/system_window_tabs.rs
+++ b/crates/title_bar/src/system_window_tabs.rs
@@ -227,6 +227,15 @@ impl SystemWindowTabs {
                     window.activate_window();
                 });
             })
+            .on_mouse_up(MouseButton::Middle, move |_, window, cx| {
+                if item.handle.window_id() == window.window_handle().window_id() {
+                    window.dispatch_action(Box::new(CloseWindow), cx);
+                } else {
+                    let _ = item.handle.update(cx, |_, window, cx| {
+                        window.dispatch_action(Box::new(CloseWindow), cx);
+                    });
+                }
+            })
             .child(label)
             .map(|this| match show_close_button {
                 ShowCloseButton::Hidden => this,


### PR DESCRIPTION
This change adds support for closing a system window tabs by pressing the middle mouse button.
It improves tab management UX by matching common tab behavior.

Release Notes:

- Added support for closing system window tabs with middle mouse click.