### PR TITLE
project_search: Add button to collapse/expand all excerpts

### DIFF
--- a/assets/icons/chevron_down_up.svg
+++ b/assets/icons/chevron_down_up.svg
@@ -1,0 +1,4 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11.3335 13.3333L8.00017 10L4.66685 13.3333" stroke="black" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M11.3335 2.66669L8.00017 6.00002L4.66685 2.66669" stroke="black" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -407,6 +407,7 @@
     "bindings": {
       "escape": "project_search::ToggleFocus",
       "shift-find": "search::FocusSearch",
+      "shift-enter": "project_search::ToggleAllSearchResults",
       "ctrl-shift-f": "search::FocusSearch",
       "ctrl-shift-h": "search::ToggleReplace",
       "alt-ctrl-g": "search::ToggleRegex",
@@ -479,6 +480,7 @@
       "alt-w": "search::ToggleWholeWord",
       "alt-find": "project_search::ToggleFilters",
       "alt-ctrl-f": "project_search::ToggleFilters",
+      "shift-enter": "project_search::ToggleAllSearchResults",
       "ctrl-alt-shift-r": "search::ToggleRegex",
       "ctrl-alt-shift-x": "search::ToggleRegex",
       "alt-r": "search::ToggleRegex",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -468,6 +468,7 @@
     "bindings": {
       "escape": "project_search::ToggleFocus",
       "cmd-shift-j": "project_search::ToggleFilters",
+      "shift-enter": "project_search::ToggleAllSearchResults",
       "cmd-shift-f": "search::FocusSearch",
       "cmd-shift-h": "search::ToggleReplace",
       "alt-cmd-g": "search::ToggleRegex",
@@ -496,6 +497,7 @@
     "bindings": {
       "escape": "project_search::ToggleFocus",
       "cmd-shift-j": "project_search::ToggleFilters",
+      "shift-enter": "project_search::ToggleAllSearchResults",
       "cmd-shift-h": "search::ToggleReplace",
       "alt-cmd-g": "search::ToggleRegex",
       "alt-cmd-x": "search::ToggleRegex"

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -488,6 +488,7 @@
       "alt-c": "search::ToggleCaseSensitive",
       "alt-w": "search::ToggleWholeWord",
       "alt-f": "project_search::ToggleFilters",
+      "shift-enter": "project_search::ToggleAllSearchResults",
       "alt-r": "search::ToggleRegex",
       // "ctrl-shift-alt-x": "search::ToggleRegex",
       "ctrl-k shift-enter": "pane::TogglePinTab"

--- a/crates/breadcrumbs/src/breadcrumbs.rs
+++ b/crates/breadcrumbs/src/breadcrumbs.rs
@@ -100,13 +100,21 @@ impl Render for Breadcrumbs {
 
         let breadcrumbs_stack = h_flex().gap_1().children(breadcrumbs);
 
+        let prefix_element = active_item.breadcrumb_prefix(window, cx);
+
+        let breadcrumbs = if let Some(prefix) = prefix_element {
+            h_flex().gap_1p5().child(prefix).child(breadcrumbs_stack)
+        } else {
+            breadcrumbs_stack
+        };
+
         match active_item
             .downcast::<Editor>()
             .map(|editor| editor.downgrade())
         {
             Some(editor) => element.child(
                 ButtonLike::new("toggle outline view")
-                    .child(breadcrumbs_stack)
+                    .child(breadcrumbs)
                     .style(ButtonStyle::Transparent)
                     .on_click({
                         let editor = editor.clone();
@@ -141,7 +149,7 @@ impl Render for Breadcrumbs {
                 // Match the height and padding of the `ButtonLike` in the other arm.
                 .h(rems_from_px(22.))
                 .pl_1()
-                .child(breadcrumbs_stack),
+                .child(breadcrumbs),
         }
     }
 }

--- a/crates/icons/src/icons.rs
+++ b/crates/icons/src/icons.rs
@@ -53,6 +53,7 @@ pub enum IconName {
     Check,
     CheckDouble,
     ChevronDown,
+    ChevronDownUp,
     ChevronLeft,
     ChevronRight,
     ChevronUp,

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -2009,6 +2009,52 @@ impl Render for ProjectSearchBar {
             })
             .unwrap_or_else(|| "0/0".to_string());
 
+        let query_focus = search.query_editor.focus_handle(cx);
+
+        let toggle_all_excerpts_button = h_flex()
+            .h_full()
+            .ml_neg_1()
+            .mr_2()
+            .pr_1()
+            .border_r_1()
+            .border_color(theme_colors.border_variant)
+            .child({
+                let is_collapsed = self
+                    .active_project_search
+                    .as_ref()
+                    .map(|search| search.read(cx).results_collapsed)
+                    .unwrap_or(false);
+                let (icon, tooltip_label) = if is_collapsed {
+                    (IconName::ChevronUpDown, "Expand All Search Results")
+                } else {
+                    (IconName::ChevronDownUp, "Collapse All Search Results")
+                };
+                let query_focus = query_focus.clone();
+
+                IconButton::new("project-search-collapse-expand", icon)
+                    .shape(IconButtonShape::Square)
+                    .icon_size(IconSize::Small)
+                    .tooltip(move |_, cx| {
+                        Tooltip::for_action_in(
+                            tooltip_label,
+                            &ToggleAllSearchResults,
+                            &query_focus,
+                            cx,
+                        )
+                    })
+                    .on_click(cx.listener(|this, _, window, cx| {
+                        if let Some(search) = this.active_project_search.as_ref() {
+                            search.update(cx, |search, cx| {
+                                search.toggle_all_search_results(
+                                    &ToggleAllSearchResults,
+                                    window,
+                                    cx,
+                                );
+                            });
+                        }
+                    }))
+            });
+
         let query_column = input_base_styles(InputPanel::Query)
             .on_action(cx.listener(|this, action, window, cx| this.confirm(action, window, cx)))
             .on_action(cx.listener(|this, action, window, cx| {
@@ -2017,6 +2063,7 @@ impl Render for ProjectSearchBar {
             .on_action(
                 cx.listener(|this, action, window, cx| this.next_history_query(action, window, cx)),
             )
+            .child(toggle_all_excerpts_button)
             .child(render_text_input(&search.query_editor, color_override, cx))
             .child(
                 h_flex()
@@ -2038,57 +2085,11 @@ impl Render for ProjectSearchBar {
                     )),
             );
 
-        let query_focus = search.query_editor.focus_handle(cx);
-
         let matches_column = h_flex()
             .ml_1()
             .pl_1p5()
             .border_l_1()
             .border_color(theme_colors.border_variant)
-            .child(
-                div()
-                    .pr_1p5()
-                    .mr_1p5()
-                    .border_r_1()
-                    .border_color(theme_colors.border_variant)
-                    .child({
-                        let is_collapsed = self
-                            .active_project_search
-                            .as_ref()
-                            .map(|search| search.read(cx).results_collapsed)
-                            .unwrap_or(false);
-
-                        let (icon, tooltip_label) = if is_collapsed {
-                            (IconName::ChevronUpDown, "Expand All Search Results")
-                        } else {
-                            (IconName::ChevronDownUp, "Collapse All Search Results")
-                        };
-
-                        let query_focus = query_focus.clone();
-
-                        IconButton::new("project-search-collapse-expand", icon)
-                            .shape(IconButtonShape::Square)
-                            .tooltip(move |_, cx| {
-                                Tooltip::for_action_in(
-                                    tooltip_label,
-                                    &ToggleAllSearchResults,
-                                    &query_focus,
-                                    cx,
-                                )
-                            })
-                            .on_click(cx.listener(|this, _, window, cx| {
-                                if let Some(search) = this.active_project_search.as_ref() {
-                                    search.update(cx, |search, cx| {
-                                        search.toggle_all_search_results(
-                                            &ToggleAllSearchResults,
-                                            window,
-                                            cx,
-                                        );
-                                    });
-                                }
-                            }))
-                    }),
-            )
             .child(render_action_button(
                 "project-search-nav-button",
                 IconName::ChevronLeft,

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -2032,6 +2032,7 @@ impl Render for ProjectSearchBar {
                 let query_focus = query_focus.clone();
 
                 IconButton::new("project-search-collapse-expand", icon)
+                    .disabled(search.active_match_index.is_none())
                     .shape(IconButtonShape::Square)
                     .icon_size(IconSize::Small)
                     .tooltip(move |_, cx| {

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -36,9 +36,7 @@ use std::{
     pin::pin,
     sync::Arc,
 };
-use ui::{
-    Divider, IconButtonShape, KeyBinding, Toggleable, Tooltip, prelude::*, utils::SearchInputWidth,
-};
+use ui::{IconButtonShape, KeyBinding, Toggleable, Tooltip, prelude::*, utils::SearchInputWidth};
 use util::{ResultExt as _, paths::PathMatcher, rel_path::RelPath};
 use workspace::{
     DeploySearch, ItemNavHistory, NewSearch, ToolbarItemEvent, ToolbarItemLocation,

--- a/crates/search/src/search_bar.rs
+++ b/crates/search/src/search_bar.rs
@@ -46,7 +46,6 @@ pub(crate) fn input_base_styles(border_color: Hsla, map: impl FnOnce(Div) -> Div
         .h_8()
         .pl_2()
         .pr_1()
-        .py_1()
         .border_1()
         .border_color(border_color)
         .rounded_md()

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -296,6 +296,15 @@ pub trait Item: Focusable + EventEmitter<Self::Event> + Render + Sized {
         None
     }
 
+    /// Returns optional elements to render to the left of the breadcrumb.
+    fn breadcrumb_prefix(
+        &self,
+        _window: &mut Window,
+        _cx: &mut Context<Self>,
+    ) -> Option<gpui::AnyElement> {
+        None
+    }
+
     fn added_to_workspace(
         &mut self,
         _workspace: &mut Workspace,
@@ -479,6 +488,7 @@ pub trait ItemHandle: 'static + Send {
     fn to_searchable_item_handle(&self, cx: &App) -> Option<Box<dyn SearchableItemHandle>>;
     fn breadcrumb_location(&self, cx: &App) -> ToolbarItemLocation;
     fn breadcrumbs(&self, theme: &Theme, cx: &App) -> Option<Vec<BreadcrumbText>>;
+    fn breadcrumb_prefix(&self, window: &mut Window, cx: &mut App) -> Option<gpui::AnyElement>;
     fn show_toolbar(&self, cx: &App) -> bool;
     fn pixel_position_of_cursor(&self, cx: &App) -> Option<Point<Pixels>>;
     fn downgrade_item(&self) -> Box<dyn WeakItemHandle>;
@@ -977,6 +987,10 @@ impl<T: Item> ItemHandle for Entity<T> {
 
     fn breadcrumbs(&self, theme: &Theme, cx: &App) -> Option<Vec<BreadcrumbText>> {
         self.read(cx).breadcrumbs(theme, cx)
+    }
+
+    fn breadcrumb_prefix(&self, window: &mut Window, cx: &mut App) -> Option<gpui::AnyElement> {
+        self.update(cx, |item, cx| item.breadcrumb_prefix(window, cx))
     }
 
     fn show_toolbar(&self, cx: &App) -> bool {


### PR DESCRIPTION
<img width="500" height="834" alt="Screenshot 2025-11-03 at 12  59@2x" src="https://github.com/user-attachments/assets/15c5e1fc-2291-41b4-9eec-a8cfa5a446c7" />

Releases Note:

- Added a button that allows to expand/collapse all project search excerpts at once.