### PR TITLE
settings: Change "remove trailing whitespace on save" to default false for Markdown

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1755,6 +1755,7 @@
     "Markdown": {
       "format_on_save": "off",
       "use_on_type_format": false,
+      "remove_trailing_whitespace_on_save": false,
       "allow_rewrap": "anywhere",
       "soft_wrap": "editor_width",
       "prettier": {


### PR DESCRIPTION
Closes #ISSUE: reported on X by user. 

Release Notes:

- Made it so that the default value for the  "remove trailing whitespace on save" setting in Markdown is false, to fix cases where the removed trailing whitespace had syntactic meaning
