### PR TITLE
Move @punctuation.delimiter before @operator capture

### DIFF
--- a/crates/languages/src/typescript/highlights.scm
+++ b/crates/languages/src/typescript/highlights.scm
@@ -122,6 +122,15 @@
 ; Tokens
 
 [
+  ";"
+  "?."
+  "."
+  ","
+  ":"
+  "?"
+] @punctuation.delimiter
+
+[
   "..."
   "-"
   "--"
@@ -178,15 +187,6 @@
     ":"
   ] @operator
 )
-
-[
-  ";"
-  "?."
-  "."
-  ","
-  ":"
-  "?"
-] @punctuation.delimiter
 
 [
   "("


### PR DESCRIPTION
Closes #41593

From what I understand the order of captures inside tree-sitter query files matters, and the last capture will win. `?` and `:` are captured by both `@operator` and `@punctuation.delimiter`.So in order for the ternary operator to win it should live after `@punctuation.delimiter`.

Before:
<img width="298" height="32" alt="Screenshot 2025-10-31 at 17 41 21" src="https://github.com/user-attachments/assets/af376e52-88be-4f62-9e2b-a106731f8145" />


After:
<img width="303" height="39" alt="Screenshot 2025-10-31 at 17 41 33" src="https://github.com/user-attachments/assets/9a754ae9-0521-4c70-9adb-90a562404ce8" />


Release Notes:

- Fixed an issue where the ternary operator symbols in TypeScript would not be highlighted as operators.
