### PR TITLE
Fix categorization of agent server extensions

### DIFF
--- a/crates/extension_cli/src/main.rs
+++ b/crates/extension_cli/src/main.rs
@@ -145,6 +145,10 @@ fn extension_provides(manifest: &ExtensionManifest) -> BTreeSet<ExtensionProvide
         provides.insert(ExtensionProvides::ContextServers);
     }
 
+    if !manifest.agent_servers.is_empty() {
+        provides.insert(ExtensionProvides::AgentServers);
+    }
+
     if manifest.snippets.is_some() {
         provides.insert(ExtensionProvides::Snippets);
     }


### PR DESCRIPTION
We missed making extensions that provide agent servers fill the `provides` field with `agent-servers`, and thus, filtering for this type of extension in both the app and site wouldn't return anything.

Release Notes:

- N/A
