### PR TITLE
remote: Fix incorrect default repository selection when using remote

### DIFF
--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -1281,7 +1281,7 @@ impl GitStore {
                     .push(cx.subscribe(&repo, Self::on_repository_event));
                 self._subscriptions
                     .push(cx.subscribe(&repo, Self::on_jobs_updated));
-                self.repositories.insert(id, repo.clone());
+                self.repositories.insert(id, repo);
                 cx.emit(GitStoreEvent::RepositoryAdded);
                 self.active_repo_id.get_or_insert_with(|| {
                     cx.emit(GitStoreEvent::ActiveRepositoryChanged(Some(id)));

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -1225,7 +1225,6 @@ impl GitStore {
         cx: &mut Context<Self>,
     ) {
         let mut removed_ids = Vec::new();
-        let mut first_new_repo = true;
         for update in updated_git_repositories.iter() {
             if let Some((id, existing)) = self.repositories.iter().find(|(_, repo)| {
                 let existing_work_directory_abs_path =
@@ -1267,12 +1266,11 @@ impl GitStore {
                         git_store,
                         cx,
                     );
-                    // trigger an empty `UpdateRepository` to ensure remote active_repo_id is set correctly
-                    if first_new_repo && let Some(updates_tx) = updates_tx.as_ref() {
+                    if let Some(updates_tx) = updates_tx.as_ref() {
+                        // trigger an empty `UpdateRepository` to ensure remote active_repo_id is set correctly
                         updates_tx
                             .unbounded_send(DownstreamUpdate::UpdateRepository(repo.snapshot()))
                             .ok();
-                        first_new_repo = false;
                     }
                     repo.schedule_scan(updates_tx.clone(), cx);
                     repo

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -1255,7 +1255,7 @@ impl GitStore {
                 let id = RepositoryId(next_repository_id.fetch_add(1, atomic::Ordering::Release));
                 let git_store = cx.weak_entity();
                 let repo = cx.new(|cx| {
-                    let mut repo = Repository::local(
+                    Repository::local(
                         id,
                         work_directory_abs_path.clone(),
                         dot_git_abs_path.clone(),
@@ -1265,15 +1265,20 @@ impl GitStore {
                         fs.clone(),
                         git_store,
                         cx,
-                    );
-                    repo.schedule_scan(updates_tx.clone(), cx);
-                    repo
+                    )
                 });
                 self._subscriptions
                     .push(cx.subscribe(&repo, Self::on_repository_event));
                 self._subscriptions
                     .push(cx.subscribe(&repo, Self::on_jobs_updated));
-                self.repositories.insert(id, repo);
+                self.repositories.insert(id, repo.clone());
+                if let Some(updates_tx) = updates_tx.as_ref() {
+                    updates_tx
+                        .unbounded_send(DownstreamUpdate::UpdateRepository(
+                            repo.read(cx).snapshot().clone(),
+                        ))
+                        .ok();
+                }
                 cx.emit(GitStoreEvent::RepositoryAdded);
                 self.active_repo_id.get_or_insert_with(|| {
                     cx.emit(GitStoreEvent::ActiveRepositoryChanged(Some(id)));


### PR DESCRIPTION
If I understand this correctly: The `active_repo_id` uses `get_or_insert_with`, which makes it dependent on the `RepositoryAdded` event sequence. To ensure correct initialization of the `active_repo_id` on the remote side, the first local `RepositoryAdded` event must synchronously send an `UpdateRepository` to `updates_tx`.

Closes #30694

Release Notes:

- Fixed incorrect default repository selection when using remote (let's git together)