### PR TITLE
Use `herb` language server as a formatter for `HTML+ERB` files

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1719,6 +1719,13 @@
         "allowed": true
       }
     },
+    "HTML+ERB": {
+      "formatter": {
+        "language_server": {
+          "name": "herb"
+        }
+      }
+    },
     "Java": {
       "prettier": {
         "allowed": true,


### PR DESCRIPTION
Hi, this pull request configures the `herb` language server as a formatter for HTML+ERB files.
[herb](https://herb-tools.dev/) is a language server for parsing HTML+ERB files and is enabled by default in the Ruby extension. Without this configuration, the tailwind language server is used for formatting ERB files, but it does not support formatting. I believe it should be safe to add this config option to the default settings. Please let me know if there is another way to do this. Thanks!

Release Notes:

- N/A
