### PR TITLE
git: Add notification to git clone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,7 @@ dependencies = [
  "auto_update",
  "editor",
  "extension_host",
+ "fs",
  "futures 0.3.31",
  "gpui",
  "language",

--- a/crates/activity_indicator/Cargo.toml
+++ b/crates/activity_indicator/Cargo.toml
@@ -17,6 +17,7 @@ anyhow.workspace = true
 auto_update.workspace = true
 editor.workspace = true
 extension_host.workspace = true
+fs.workspace = true
 futures.workspace = true
 gpui.workspace = true
 language.workspace = true

--- a/crates/activity_indicator/src/activity_indicator.rs
+++ b/crates/activity_indicator/src/activity_indicator.rs
@@ -51,6 +51,7 @@ pub struct ActivityIndicator {
     project: Entity<Project>,
     auto_updater: Option<Entity<AutoUpdater>>,
     context_menu_handle: PopoverMenuHandle<ContextMenu>,
+    fs_jobs: Vec<fs::JobInfo>,
 }
 
 #[derive(Debug)]
@@ -92,6 +93,27 @@ impl ActivityIndicator {
                             name,
                             status: LanguageServerStatusUpdate::Binary(binary_status),
                         });
+                        cx.notify();
+                    })?;
+                }
+                anyhow::Ok(())
+            })
+            .detach();
+
+            // Handle fs job events
+            let mut job_events = fs::subscribe_to_job_events();
+            cx.spawn(async move |this, cx| {
+                while let Some(job_event) = job_events.next().await {
+                    this.update(cx, |this: &mut ActivityIndicator, cx| {
+                        match job_event {
+                            fs::JobEvent::Started { info } => {
+                                this.fs_jobs.retain(|j| j.id != info.id);
+                                this.fs_jobs.push(info);
+                            }
+                            fs::JobEvent::Completed { id } => {
+                                this.fs_jobs.retain(|j| j.id != id);
+                            }
+                        }
                         cx.notify();
                     })?;
                 }
@@ -201,7 +223,8 @@ impl ActivityIndicator {
                 statuses: Vec::new(),
                 project: project.clone(),
                 auto_updater,
-                context_menu_handle: Default::default(),
+                context_menu_handle: PopoverMenuHandle::default(),
+                fs_jobs: Vec::new(),
             }
         });
 
@@ -433,20 +456,20 @@ impl ActivityIndicator {
         }
 
         // Show any long-running fs command
-        if let Some(fs_job_info) = self.project.read(cx).fs().current_job()
-            && Instant::now() - fs_job_info.start >= GIT_OPERATION_DELAY
-        {
-            return Some(Content {
-                icon: Some(
-                    Icon::new(IconName::ArrowCircle)
-                        .size(IconSize::Small)
-                        .with_rotate_animation(2)
-                        .into_any_element(),
-                ),
-                message: fs_job_info.message.into(),
-                on_click: None,
-                tooltip_message: None,
-            });
+        for fs_job in &self.fs_jobs {
+            if Instant::now().duration_since(fs_job.start) >= GIT_OPERATION_DELAY {
+                return Some(Content {
+                    icon: Some(
+                        Icon::new(IconName::ArrowCircle)
+                            .size(IconSize::Small)
+                            .with_rotate_animation(2)
+                            .into_any_element(),
+                    ),
+                    message: fs_job.message.clone().into(),
+                    on_click: None,
+                    tooltip_message: None,
+                });
+            }
         }
 
         // Show any language server installation info.

--- a/crates/activity_indicator/src/activity_indicator.rs
+++ b/crates/activity_indicator/src/activity_indicator.rs
@@ -100,8 +100,8 @@ impl ActivityIndicator {
             })
             .detach();
 
-            // Handle fs job events
-            let mut job_events = fs::subscribe_to_job_events();
+            let fs = project.read(cx).fs().clone();
+            let mut job_events = fs.subscribe_to_jobs();
             cx.spawn(async move |this, cx| {
                 while let Some(job_event) = job_events.next().await {
                     this.update(cx, |this: &mut ActivityIndicator, cx| {

--- a/crates/activity_indicator/src/activity_indicator.rs
+++ b/crates/activity_indicator/src/activity_indicator.rs
@@ -432,6 +432,23 @@ impl ActivityIndicator {
             });
         }
 
+        // Show any long-running fs command
+        if let Some(fs_job_info) = self.project.read(cx).fs().current_job()
+            && Instant::now() - fs_job_info.start >= GIT_OPERATION_DELAY
+        {
+            return Some(Content {
+                icon: Some(
+                    Icon::new(IconName::ArrowCircle)
+                        .size(IconSize::Small)
+                        .with_rotate_animation(2)
+                        .into_any_element(),
+                ),
+                message: fs_job_info.message.into(),
+                on_click: None,
+                tooltip_message: None,
+            });
+        }
+
         // Show any language server installation info.
         let mut downloading = SmallVec::<[_; 3]>::new();
         let mut checking_for_update = SmallVec::<[_; 3]>::new();

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -1069,9 +1069,6 @@ pub struct FakeFs {
     // Use an unfair lock to ensure tests are deterministic.
     state: Arc<Mutex<FakeFsState>>,
     executor: gpui::BackgroundExecutor,
-    active_jobs: Arc<Mutex<HashMap<JobId, JobInfo>>>,
-    #[allow(dead_code)]
-    next_job_id: Arc<AtomicUsize>,
 }
 
 #[cfg(any(test, feature = "test-support"))]
@@ -1353,8 +1350,6 @@ impl FakeFs {
         let this = Arc::new_cyclic(|this| Self {
             this: this.clone(),
             executor: executor.clone(),
-            active_jobs: Arc::new(Mutex::new(HashMap::new())),
-            next_job_id: Arc::new(AtomicUsize::new(0)),
             state: Arc::new(Mutex::new(FakeFsState {
                 root: FakeFsEntry::Dir {
                     inode: 0,
@@ -2628,7 +2623,7 @@ impl Fs for FakeFs {
     }
 
     fn current_job(&self) -> Option<JobInfo> {
-        self.active_jobs.lock().values().next().cloned()
+        None
     }
 
     #[cfg(any(test, feature = "test-support"))]

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -69,7 +69,9 @@ use cloud_llm_client::CompletionIntent;
 use workspace::{
     Workspace,
     dock::{DockPosition, Panel, PanelEvent},
-    notifications::{DetachAndPromptErr, ErrorMessagePrompt, NotificationId},
+    notifications::{
+        DetachAndPromptErr, ErrorMessagePrompt, NotificationFrame, NotificationId, SuppressEvent,
+    },
 };
 
 actions!(
@@ -2023,7 +2025,27 @@ impl GitPanel {
 
             let fs = this.read_with(cx, |this, _| this.fs.clone()).ok()?;
 
-            let prompt_answer = match fs.git_clone(&repo, path.as_path()).await {
+            let notification_id = NotificationId::unique::<GitCloneNotification>();
+            workspace
+                .update(cx, {
+                    let repo_name = repo_name.clone();
+                    |workspace, cx| {
+                        workspace.show_notification(notification_id.clone(), cx, |cx| {
+                            cx.new(|cx| GitCloneNotification::new(repo_name, cx))
+                        });
+                    }
+                })
+                .ok()?;
+
+            let clone_result = fs.git_clone(&repo, path.as_path()).await;
+
+            workspace
+                .update(cx, |workspace, cx| {
+                    workspace.dismiss_notification(&notification_id, cx);
+                })
+                .ok();
+
+            let prompt_answer = match clone_result {
                 Ok(_) => cx.update(|window, cx| {
                     window.prompt(
                         PromptLevel::Info,
@@ -4450,6 +4472,67 @@ impl Panel for GitPanel {
 }
 
 impl PanelHeader for GitPanel {}
+
+struct GitCloneNotification {
+    repo_name: SharedString,
+    focus_handle: FocusHandle,
+}
+
+impl GitCloneNotification {
+    fn new(repo_name: String, cx: &mut Context<Self>) -> Self {
+        Self {
+            repo_name: repo_name.into(),
+            focus_handle: cx.focus_handle(),
+        }
+    }
+}
+
+impl EventEmitter<DismissEvent> for GitCloneNotification {}
+
+impl EventEmitter<SuppressEvent> for GitCloneNotification {}
+
+impl Focusable for GitCloneNotification {
+    fn focus_handle(&self, _cx: &App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+impl workspace::notifications::Notification for GitCloneNotification {}
+
+impl Render for GitCloneNotification {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        NotificationFrame::new()
+            .with_title(Some("Cloning Repository"))
+            .show_suppress_button(false)
+            .on_close(cx.listener(|_, _, _, cx| {
+                cx.emit(DismissEvent);
+            }))
+            .with_content(
+                v_flex()
+                    .gap_1()
+                    .child(
+                        h_flex()
+                            .gap_2()
+                            .items_center()
+                            .child(
+                                Icon::new(IconName::ArrowCircle)
+                                    .size(ui::IconSize::Small)
+                                    .color(Color::Accent)
+                                    .with_rotate_animation(2),
+                            )
+                            .child(
+                                Label::new(format!("Cloning \"{}\"", self.repo_name))
+                                    .size(ui::LabelSize::Default),
+                            ),
+                    )
+                    .child(
+                        Label::new("Please wait while the repository is being cloned...")
+                            .size(ui::LabelSize::Small)
+                            .color(Color::Muted),
+                    ),
+            )
+    }
+}
 
 struct GitPanelMessageTooltip {
     commit_tooltip: Option<Entity<CommitTooltip>>,


### PR DESCRIPTION
Adds a simple notification when cloning a repo using the integrated git clone on Zed. Before this, the user had no feedback after starting the cloning action. 

Demo:

https://github.com/user-attachments/assets/72fcdf1b-fc99-4fe5-8db2-7c30b170f12f

Not sure about that icon I'm using for the animation, but that can be easily changed. 

Release Notes:

- Added notification when cloning a repo from zed