### PR TITLE
ruby: Add `herb` for `HTML+ERB` files

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1719,6 +1719,9 @@
         "allowed": true
       }
     },
+    "HTML+ERB": {
+      "language_servers": ["herb", "..."]
+    },
     "Java": {
       "prettier": {
         "allowed": true,


### PR DESCRIPTION
Hi, this pull request adds the `herb` language server for HTML+ERB files.
[herb](https://herb-tools.dev/) is a language server for parsing HTML+ERB files and is enabled by default in the Ruby extension. Without declaring `herb` explicitly, the tailwind language server is used for formatting ERB files, but it does not support formatting. I believe it should be safe to add this config option to the default settings. Please let me know if there is another way to do this. Thanks!

See my previous attempt [here](https://github.com/zed-industries/zed/pull/41707).

Release Notes:

- N/A
