### PR TITLE
windows: Fix click bleeding through collab follow 

### DIFF
--- a/crates/title_bar/src/collab.rs
+++ b/crates/title_bar/src/collab.rs
@@ -220,6 +220,8 @@ impl TitleBar {
                                 .on_click({
                                     let peer_id = collaborator.peer_id;
                                     cx.listener(move |this, _, window, cx| {
+                                        cx.stop_propagation();
+
                                         this.workspace
                                             .update(cx, |workspace, cx| {
                                                 if is_following {


### PR DESCRIPTION
On Windows, clicking on a collab user icon in the title bar would minimize/expand Zed because the click would bleed through to the title bar. This PR fixes this by stopping propagation.

#### Before (On MacOS with double clicks to mimic the same behavior)
https://github.com/user-attachments/assets/5a91f7ff-265a-4575-aa23-00b8d30daeed
#### After (On MacOS with double clicks to mimic the same behavior)
https://github.com/user-attachments/assets/e9fcb98f-4855-4f21-8926-2d306d256f1c

Release Notes:

- Windows: Fix clicking on user icon in title bar to follow minimizing/expanding Zed
