### PR TITLE
settings_ui: Close settings window after opening settings.json

### DIFF
--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -2087,6 +2087,7 @@ impl SettingsWindow {
                     .style(ButtonStyle::OutlinedGhost)
                     .on_click(cx.listener(|this, _, window, cx| {
                         this.open_current_settings_file(window, cx);
+                        window.remove_window();
                     })),
             )
     }


### PR DESCRIPTION
Closing the settings window after clicking `Edit in settings.json` makes sense to me as the settings pop up blocks the settings.json file, so I always need to close the setting window.

[Screencast_20251102_001900.webm](https://github.com/user-attachments/assets/29e6d5d4-b5e6-46c2-a7a3-cfb1130e0022)

I am not sure where to add tests for this, it seems like all of the tests in the `settings_ui` crate are unrelated. Any advice would be greatly appreciated.

Release Notes:

- N/A