### PR TITLE
vim: Make each vim repeat its own transaction

### DIFF
--- a/crates/vim/src/test.rs
+++ b/crates/vim/src/test.rs
@@ -2365,3 +2365,19 @@ async fn test_wrap_selections_in_tag_line_mode(cx: &mut gpui::TestAppContext) {
         Mode::VisualLine,
     );
 }
+
+#[gpui::test]
+async fn test_repeat_grouping_41735(cx: &mut gpui::TestAppContext) {
+    let mut cx = NeovimBackedTestContext::new(cx).await;
+
+    // typically transaction gropuing is disabled in tests, but here we need to test it.
+    cx.update_buffer(|buffer, _cx| buffer.set_group_interval(Duration::from_millis(300)));
+
+    cx.set_shared_state("ˇ").await;
+
+    cx.simulate_shared_keystrokes("i a escape").await;
+    cx.simulate_shared_keystrokes(". . .").await;
+    cx.shared_state().await.assert_eq("ˇaaaa");
+    cx.simulate_shared_keystrokes("u").await;
+    cx.shared_state().await.assert_eq("ˇaaa");
+}

--- a/crates/vim/test_data/test_repeat_grouping_41735.json
+++ b/crates/vim/test_data/test_repeat_grouping_41735.json
@@ -1,0 +1,10 @@
+{"Put":{"state":"ˇ"}}
+{"Key":"i"}
+{"Key":"a"}
+{"Key":"escape"}
+{"Key":"."}
+{"Key":"."}
+{"Key":"."}
+{"Get":{"state":"ˇaaaa","mode":"Normal"}}
+{"Key":"u"}
+{"Get":{"state":"ˇaaa","mode":"Normal"}}


### PR DESCRIPTION
Release Notes:

- Pressing `u` after multiple `.` in rapid succession will now only undo the latest repeat instead of all repeats.