### PR TITLE
Support GitLab and self-hosted GitLab avatars in git blame

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7078,6 +7078,7 @@ dependencies = [
  "serde_json",
  "settings",
  "url",
+ "urlencoding",
  "util",
 ]
 

--- a/crates/git_hosting_providers/Cargo.toml
+++ b/crates/git_hosting_providers/Cargo.toml
@@ -23,6 +23,7 @@ serde.workspace = true
 serde_json.workspace = true
 settings.workspace = true
 url.workspace = true
+urlencoding.workspace = true
 util.workspace = true
 
 [dev-dependencies]

--- a/crates/git_hosting_providers/src/providers/gitlab.rs
+++ b/crates/git_hosting_providers/src/providers/gitlab.rs
@@ -1,6 +1,11 @@
-use std::str::FromStr;
+use std::{str::FromStr, sync::Arc};
 
-use anyhow::{Result, bail};
+use anyhow::{Context as _, Result, bail};
+use async_trait::async_trait;
+use futures::AsyncReadExt;
+use gpui::SharedString;
+use http_client::{AsyncBody, HttpClient, HttpRequestExt, Request};
+use serde::Deserialize;
 use url::Url;
 
 use git::{
@@ -9,6 +14,16 @@ use git::{
 };
 
 use crate::get_host_from_git_remote_url;
+
+#[derive(Debug, Deserialize)]
+struct CommitDetails {
+    author_email: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct AvatarInfo {
+    avatar_url: String,
+}
 
 #[derive(Debug)]
 pub struct Gitlab {
@@ -46,8 +61,79 @@ impl Gitlab {
             Url::parse(&format!("https://{}", host))?,
         ))
     }
+
+    async fn fetch_gitlab_commit_author(
+        &self,
+        repo_owner: &str,
+        repo: &str,
+        commit: &str,
+        client: &Arc<dyn HttpClient>,
+    ) -> Result<Option<AvatarInfo>> {
+        let Some(host) = self.base_url.host_str() else {
+            bail!("failed to get host from gitlab base url");
+        };
+        let project_path = format!("{}/{}", repo_owner, repo);
+        let project_path_encoded = urlencoding::encode(&project_path);
+        let url = format!(
+            "https://{host}/api/v4/projects/{project_path_encoded}/repository/commits/{commit}"
+        );
+
+        let request = Request::get(&url)
+            .header("Content-Type", "application/json")
+            .follow_redirects(http_client::RedirectPolicy::FollowAll);
+
+        let mut response = client
+            .send(request.body(AsyncBody::default())?)
+            .await
+            .with_context(|| format!("error fetching GitLab commit details at {:?}", url))?;
+
+        let mut body = Vec::new();
+        response.body_mut().read_to_end(&mut body).await?;
+
+        if response.status().is_client_error() {
+            let text = String::from_utf8_lossy(body.as_slice());
+            bail!(
+                "status error {}, response: {text:?}",
+                response.status().as_u16()
+            );
+        }
+
+        let body_str = std::str::from_utf8(&body)?;
+
+        let author_email = serde_json::from_str::<CommitDetails>(body_str)
+            .map(|commit| commit.author_email)
+            .context("failed to deserialize GitLab commit details")?;
+
+        let avatar_info_url = format!("https://{host}/api/v4/avatar?email={author_email}");
+
+        let request = Request::get(&avatar_info_url)
+            .header("Content-Type", "application/json")
+            .follow_redirects(http_client::RedirectPolicy::FollowAll);
+
+        let mut response = client
+            .send(request.body(AsyncBody::default())?)
+            .await
+            .with_context(|| format!("error fetching GitLab avatar info at {:?}", url))?;
+
+        let mut body = Vec::new();
+        response.body_mut().read_to_end(&mut body).await?;
+
+        if response.status().is_client_error() {
+            let text = String::from_utf8_lossy(body.as_slice());
+            bail!(
+                "status error {}, response: {text:?}",
+                response.status().as_u16()
+            );
+        }
+
+        let body_str = std::str::from_utf8(&body)?;
+
+        serde_json::from_str::<Option<AvatarInfo>>(body_str)
+            .context("failed to deserialize GitLab avatar info")
+    }
 }
 
+#[async_trait]
 impl GitHostingProvider for Gitlab {
     fn name(&self) -> String {
         self.name.clone()
@@ -58,7 +144,7 @@ impl GitHostingProvider for Gitlab {
     }
 
     fn supports_avatars(&self) -> bool {
-        false
+        true
     }
 
     fn format_line_number(&self, line: u32) -> String {
@@ -122,6 +208,35 @@ impl GitHostingProvider for Gitlab {
         );
         permalink
     }
+
+    async fn commit_author_avatar_url(
+        &self,
+        repo_owner: &str,
+        repo: &str,
+        commit: SharedString,
+        http_client: Arc<dyn HttpClient>,
+    ) -> Result<Option<Url>> {
+        let commit = commit.to_string();
+        let avatar_url = self
+            .fetch_gitlab_commit_author(repo_owner, repo, &commit, &http_client)
+            .await?
+            .map(|author| -> Result<Url, url::ParseError> {
+                let mut url = Url::parse(&author.avatar_url)?;
+                if let Some(host) = url.host_str() {
+                    let size_query = if host.contains("gravatar") || host.contains("libravatar") {
+                        Some("s=128")
+                    } else if host.contains("gitlab") {
+                        Some("width=128")
+                    } else {
+                        None
+                    };
+                    url.set_query(size_query);
+                }
+                Ok(url)
+            })
+            .transpose()?;
+        Ok(avatar_url)
+    }
 }
 
 #[cfg(test)]
@@ -134,8 +249,8 @@ mod tests {
     #[test]
     fn test_invalid_self_hosted_remote_url() {
         let remote_url = "https://gitlab.com/zed-industries/zed.git";
-        let github = Gitlab::from_remote_url(remote_url);
-        assert!(github.is_err());
+        let gitlab = Gitlab::from_remote_url(remote_url);
+        assert!(gitlab.is_err());
     }
 
     #[test]

--- a/crates/git_hosting_providers/src/providers/gitlab.rs
+++ b/crates/git_hosting_providers/src/providers/gitlab.rs
@@ -225,7 +225,11 @@ impl GitHostingProvider for Gitlab {
                 if let Some(host) = url.host_str() {
                     let size_query = if host.contains("gravatar") || host.contains("libravatar") {
                         Some("s=128")
-                    } else if host.contains("gitlab") {
+                    } else if self
+                        .base_url
+                        .host_str()
+                        .is_some_and(|base_host| host.contains(base_host))
+                    {
                         Some("width=128")
                     } else {
                         None


### PR DESCRIPTION
Part of #11043.

Release Notes:

- Added Support for showing GitLab and self-hosted GitLab avatars in git blame
- (Let's Git Together)
