### PR TITLE
ui: Fix popover menu not restoring focus to the previously focused element

### DIFF
--- a/crates/ui/src/components/popover_menu.rs
+++ b/crates/ui/src/components/popover_menu.rs
@@ -270,11 +270,11 @@ fn show_menu<M: ManagedView>(
     window: &mut Window,
     cx: &mut App,
 ) {
+    let previous_focus_handle = window.focused(cx);
     let Some(new_menu) = (builder)(window, cx) else {
         return;
     };
     let menu2 = menu.clone();
-    let previous_focus_handle = window.focused(cx);
 
     window
         .subscribe(&new_menu, cx, move |modal, _: &DismissEvent, window, cx| {


### PR DESCRIPTION
Closes #26548

Here's a before/after comparison:

https://github.com/user-attachments/assets/21d49db7-28bb-4fe2-bdaf-e86b6400ae7a

Release Notes:

- Fixed popover menus not restoring focus to the previously focused element