### PR TITLE
ruby: Disable Ruby LSP for ERB files

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1719,6 +1719,9 @@
         "allowed": true
       }
     },
+    "HTML+ERB": {
+      "language_servers": ["herb", "!ruby-lsp", "..."]
+    },
     "Java": {
       "prettier": {
         "allowed": true,
@@ -1740,6 +1743,9 @@
       "prettier": {
         "allowed": true
       }
+    },
+    "JS+ERB": {
+      "language_servers": ["!ruby-lsp", "..."]
     },
     "Kotlin": {
       "language_servers": ["!kotlin-language-server", "kotlin-lsp", "..."]
@@ -1844,6 +1850,9 @@
       "prettier": {
         "allowed": true
       }
+    },
+    "YAML+ERB": {
+      "language_servers": ["!ruby-lsp", "..."]
     },
     "Zig": {
       "language_servers": ["zls", "..."]


### PR DESCRIPTION
The Ruby extension uses the `solargraph`
language server by default for Ruby files.
However, when a user opens any ERB file,
the extension automatically starts the Ruby LSP.
This affects developers because
they do not expect the Ruby LSP to be running.

Closes https://github.com/zed-extensions/ruby/issues/172

Release Notes:

- N/A
