### PR TITLE
agent_ui: Improve the "go to file" affordance in the edit bar

### DIFF
--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -3631,6 +3631,7 @@ impl AcpThreadView {
             .child(
                 h_flex()
                     .id("edits-container")
+                    .cursor_pointer()
                     .gap_1()
                     .child(Disclosure::new("edits-disclosure", expanded))
                     .map(|this| {
@@ -3770,6 +3771,7 @@ impl AcpThreadView {
                     Label::new(name.to_string())
                         .size(LabelSize::XSmall)
                         .buffer_font(cx)
+                        .ml_1p5()
                 });
 
                 let file_icon = FileIcons::get_icon(path.as_std_path(), cx)
@@ -3801,14 +3803,22 @@ impl AcpThreadView {
                     })
                     .child(
                         h_flex()
-                            .relative()
                             .id(("file-name", index))
+                            .relative()
+                            .cursor_pointer()
                             .pr_8()
-                            .gap_1p5()
                             .w_full()
                             .overflow_x_scroll()
-                            .child(file_icon)
-                            .child(h_flex().gap_0p5().children(file_name).children(file_path))
+                            .child(
+                                h_flex()
+                                    .pr_0p5()
+                                    .gap_0p5()
+                                    .hover(|s| s.bg(cx.theme().colors().element_hover))
+                                    .rounded_xs()
+                                    .child(file_icon)
+                                    .children(file_name)
+                                    .children(file_path),
+                            )
                             .child(
                                 div()
                                     .absolute()
@@ -3819,6 +3829,7 @@ impl AcpThreadView {
                                     .right_0()
                                     .bg(overlay_gradient),
                             )
+                            .tooltip(Tooltip::text("Go to File"))
                             .on_click({
                                 let buffer = buffer.clone();
                                 cx.listener(move |this, _, window, cx| {

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -3803,21 +3803,29 @@ impl AcpThreadView {
                     })
                     .child(
                         h_flex()
-                            .id(("file-name", index))
+                            .id(("file-name-row", index))
                             .relative()
-                            .cursor_pointer()
                             .pr_8()
                             .w_full()
                             .overflow_x_scroll()
                             .child(
                                 h_flex()
+                                    .id(("file-name-path", index))
+                                    .cursor_pointer()
                                     .pr_0p5()
                                     .gap_0p5()
                                     .hover(|s| s.bg(cx.theme().colors().element_hover))
                                     .rounded_xs()
                                     .child(file_icon)
                                     .children(file_name)
-                                    .children(file_path),
+                                    .children(file_path)
+                                    .tooltip(Tooltip::text("Go to File"))
+                                    .on_click({
+                                        let buffer = buffer.clone();
+                                        cx.listener(move |this, _, window, cx| {
+                                            this.open_edited_buffer(&buffer, window, cx);
+                                        })
+                                    }),
                             )
                             .child(
                                 div()
@@ -3828,14 +3836,7 @@ impl AcpThreadView {
                                     .bottom_0()
                                     .right_0()
                                     .bg(overlay_gradient),
-                            )
-                            .tooltip(Tooltip::text("Go to File"))
-                            .on_click({
-                                let buffer = buffer.clone();
-                                cx.listener(move |this, _, window, cx| {
-                                    this.open_edited_buffer(&buffer, window, cx);
-                                })
-                            }),
+                            ),
                     )
                     .child(
                         h_flex()


### PR DESCRIPTION
This PR makes it clearer that you can click on the file path to open the corresponding file in the agent panel's "edit bar", which is the element that shows up in the panel as soon as agent-made edits happen.

Release Notes:

- agent panel: Improved the "go to file" affordance in the edit bar.
