### PR TITLE
settings ui: Fix dropdown menu items not correctly showing the active value

### DIFF
--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -889,7 +889,7 @@ impl SettingsPageItem {
                             .px_8()
                             .child(discriminant_element.when(has_sub_fields, |this| this.pb_4())),
                     )
-                    .when(!has_sub_fields, |this| {
+                    .when(!has_sub_fields && !is_last, |this| {
                         this.child(h_flex().px_8().child(Divider::horizontal()))
                     });
 

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -3453,37 +3453,35 @@ where
         } else {
             current_value_label.to_string()
         },
-        window.use_state(cx, |window, cx| {
-            ContextMenu::new(window, cx, move |mut menu, _, _| {
-                for (&value, &label) in std::iter::zip(variants(), labels()) {
-                    let file = file.clone();
-                    menu = menu.toggleable_entry(
-                        if should_do_titlecase {
-                            label.to_title_case()
-                        } else {
-                            label.to_string()
-                        },
-                        value == current_value,
-                        IconPosition::End,
-                        None,
-                        move |_, cx| {
-                            if value == current_value {
-                                return;
-                            }
-                            update_settings_file(
-                                file.clone(),
-                                field.json_path,
-                                cx,
-                                move |settings, _cx| {
-                                    (field.write)(settings, Some(value));
-                                },
-                            )
-                            .log_err(); // todo(settings_ui) don't log err
-                        },
-                    );
-                }
-                menu
-            })
+        ContextMenu::build(window, cx, move |mut menu, _, _| {
+            for (&value, &label) in std::iter::zip(variants(), labels()) {
+                let file = file.clone();
+                menu = menu.toggleable_entry(
+                    if should_do_titlecase {
+                        label.to_title_case()
+                    } else {
+                        label.to_string()
+                    },
+                    value == current_value,
+                    IconPosition::End,
+                    None,
+                    move |_, cx| {
+                        if value == current_value {
+                            return;
+                        }
+                        update_settings_file(
+                            file.clone(),
+                            field.json_path,
+                            cx,
+                            move |settings, _cx| {
+                                (field.write)(settings, Some(value));
+                            },
+                        )
+                        .log_err(); // todo(settings_ui) don't log err
+                    },
+                );
+            }
+            menu
         }),
     )
     .tab_index(0)


### PR DESCRIPTION
There was a bug in the settings UI dropdown where the menu item marked as active—through the check icon—wouldn't be the actual selected value, as per verified from the button trigger itself. Turns out that the fix was unwrapping it from `window.use_state` to allow the `current_value` to update between multiple renders, which wasn't happening before given that its value was persisting.

Release Notes:

- settings UI: Fixed a bug where the item marked as selected (evident though the check icon) in a given dropdown wouldn't be the actual selected value.
