### PR TITLE
docs: Mark macOS 26.x as being supported

### DIFF
--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -50,6 +50,7 @@ Zed supports the follow macOS releases:
 
 | Version       | Codename | Apple Status   | Zed Status          |
 | ------------- | -------- | -------------- | ------------------- |
+| macOS 26.x    | Tahoe    | Supported      | Supported           |
 | macOS 15.x    | Sequoia  | Supported      | Supported           |
 | macOS 14.x    | Sonoma   | Supported      | Supported           |
 | macOS 13.x    | Ventura  | Supported      | Supported           |


### PR DESCRIPTION
Add "Tahoe" to list of supported macOS versions.

Closes #ISSUE

Release Notes:

- N/A 
