### PR TITLE
feat: add Stakpak agent server extension

### DIFF
--- a/STAKPAK_ZED_EXTENSION_GUIDE.md
+++ b/STAKPAK_ZED_EXTENSION_GUIDE.md
@@ -1,0 +1,376 @@
+# Stakpak Zed Agent Server Extension - Implementation Guide
+
+## Overview
+
+This document provides a complete guide for integrating Stakpak as an Agent Server Extension in Zed Editor using the new Agent Server Extensions feature (PR going live this week).
+
+## What is Stakpak?
+
+Stakpak is a terminal-native DevOps Agent built in Rust that specializes in:
+- Infrastructure code generation (Terraform, Kubernetes, Dockerfile, GitHub Actions)
+- DevOps operations with enterprise-grade security (mTLS, secret redaction)
+- Real-time progress streaming for long-running operations
+- Documentation research and semantic code search
+
+**Key Feature**: Stakpak already implements the Agent Client Protocol (ACP) via the `stakpak acp` command.
+
+- **Repository**: https://github.com/stakpak/agent
+- **License**: Apache-2.0
+- **Latest Releases**: Available at https://github.com/stakpak/agent/releases
+
+## Zed Agent Server Extensions
+
+Agent Server Extensions allow packaging ACP-compliant agents for easy distribution through Zed's extension system. The new feature (documented in [PR ea273e738d3e4eada4a4741aa8d6431ca7cc3d44](https://github.com/zed-industries/zed/blob/ea273e738d3e4eada4a4741aa8d6431ca7cc3d44/docs/src/extensions/agent-servers.md)) enables:
+
+- **Automatic binary distribution** across platforms (macOS, Linux, Windows)
+- **Version management** with archive downloads and caching
+- **Security verification** via SHA-256 hashes
+- **Easy installation** for end users (no manual configuration)
+
+## Implementation Steps
+
+### Step 1: Create Extension Repository
+
+Create a new GitHub repository named `stakpak-zed-extension` with this structure:
+
+```
+stakpak-zed-extension/
+├── extension.toml          # Main configuration file
+├── icon.svg               # Stakpak logo (16x16, monochrome)
+├── LICENSE                # Apache-2.0 or MIT
+└── README.md              # User documentation
+```
+
+### Step 2: Create `extension.toml`
+
+This is the core configuration file that tells Zed how to download and run Stakpak:
+
+```toml
+id = "stakpak"
+name = "Stakpak Agent"
+version = "0.1.0"
+schema_version = 1
+authors = ["Stakpak Team <team@stakpak.dev>"]
+description = "Enterprise-grade DevOps agent with security features and infrastructure code generation"
+repository = "https://github.com/stakpak/stakpak-zed-extension"
+
+[agent_servers.stakpak]
+name = "Stakpak"
+icon = "icon.svg"
+
+# Environment variables (if needed)
+[agent_servers.stakpak.env]
+# STAKPAK_LOG_LEVEL = "info"  # Optional: Add if you want to control logging
+
+# macOS ARM64 (M1/M2/M3/M4 Macs)
+[agent_servers.stakpak.targets.darwin-aarch64]
+archive = "https://github.com/stakpak/agent/releases/download/v0.2.66/stakpak-aarch64-apple-darwin.tar.gz"
+cmd = "./stakpak"
+args = ["acp"]
+sha256 = "REPLACE_WITH_ACTUAL_SHA256"
+
+# macOS x86_64 (Intel Macs)
+[agent_servers.stakpak.targets.darwin-x86_64]
+archive = "https://github.com/stakpak/agent/releases/download/v0.2.66/stakpak-x86_64-apple-darwin.tar.gz"
+cmd = "./stakpak"
+args = ["acp"]
+sha256 = "REPLACE_WITH_ACTUAL_SHA256"
+
+# Linux x86_64
+[agent_servers.stakpak.targets.linux-x86_64]
+archive = "https://github.com/stakpak/agent/releases/download/v0.2.66/stakpak-x86_64-unknown-linux-gnu.tar.gz"
+cmd = "./stakpak"
+args = ["acp"]
+sha256 = "REPLACE_WITH_ACTUAL_SHA256"
+
+# Windows x86_64
+[agent_servers.stakpak.targets.windows-x86_64]
+archive = "https://github.com/stakpak/agent/releases/download/v0.2.66/stakpak-x86_64-pc-windows-msvc.zip"
+cmd = "./stakpak.exe"
+args = ["acp"]
+sha256 = "REPLACE_WITH_ACTUAL_SHA256"
+```
+
+**Important Notes:**
+- Replace version `v0.2.66` with the latest version from releases
+- Update URLs to match actual release asset names (check https://github.com/stakpak/agent/releases/latest)
+- The `args = ["acp"]` tells Stakpak to start in ACP server mode
+- SHA-256 hashes must be generated for each archive (see below)
+
+### Step 3: Generate SHA-256 Hashes
+
+For each binary archive, generate and verify SHA-256 hashes:
+
+**On macOS/Linux:**
+```bash
+# Download each archive
+curl -LO https://github.com/stakpak/agent/releases/download/v0.2.66/stakpak-aarch64-apple-darwin.tar.gz
+
+# Generate SHA-256
+shasum -a 256 stakpak-aarch64-apple-darwin.tar.gz
+```
+
+**On Windows:**
+```bash
+# Download archive
+curl -LO https://github.com/stakpak/agent/releases/download/v0.2.66/stakpak-x86_64-pc-windows-msvc.zip
+
+# Generate SHA-256
+certutil -hashfile stakpak-x86_64-pc-windows-msvc.zip SHA256
+```
+
+Alternatively, GitHub sometimes provides checksums in release notes or a separate checksums file.
+
+### Step 4: Create Icon (Optional but Recommended)
+
+Create a monochrome SVG icon following Zed's guidelines:
+- **Size**: 16x16 bounding box
+- **Padding**: 1-2 pixels
+- **Style**: Monochrome only (no gradients)
+- **Format**: Clean SVG (process through [SVGOMG](https://jakearchibald.github.io/svgomg/))
+- **Opacity**: Can use opacity for visual layering
+
+Save as `icon.svg` in the extension root.
+
+### Step 5: Create README.md
+
+```markdown
+# Stakpak Agent for Zed
+
+Enterprise-grade DevOps agent with security features and infrastructure code generation capabilities.
+
+## Features
+
+- 🔒 **Security Hardened**: mTLS encryption, dynamic secret redaction, privacy mode
+- 🛠️ **DevOps Optimized**: Async task management, real-time progress streaming
+- 🧠 **Adaptive Intelligence**: Rule books, persistent knowledge, subagents
+- 📦 **IaC Generation**: Terraform, Kubernetes, Dockerfile, GitHub Actions
+
+## Usage
+
+1. Install the Stakpak extension in Zed
+2. Get an API key from [stakpak.dev](https://stakpak.dev)
+3. Set environment variable: `export STAKPAK_API_KEY=<your-key>`
+4. Open Agent Panel in Zed and select "Stakpak"
+
+## Authentication
+
+Stakpak requires an API key. Get one for free (no card required):
+1. Visit [stakpak.dev](https://stakpak.dev)
+2. Click "Login" → "Create API Key"
+3. Set `STAKPAK_API_KEY` environment variable
+
+## Links
+
+- [Stakpak Documentation](https://stakpak.dev)
+- [GitHub Repository](https://github.com/stakpak/agent)
+- [Agent Client Protocol](https://agentclientprotocol.com)
+
+## License
+
+Apache-2.0
+```
+
+### Step 6: Add LICENSE File
+
+Copy the Apache-2.0 license from the main Stakpak repository or use MIT license.
+
+### Step 7: Test Locally
+
+1. **Build/clone your extension locally**
+2. **In Zed Editor:**
+   - Open Command Palette (`Cmd+Shift+P` / `Ctrl+Shift+P`)
+   - Run `zed: install dev extension`
+   - Select your extension directory
+3. **Test the agent:**
+   - Open Agent Panel
+   - Select "Stakpak" from the agent list
+   - Verify it downloads, extracts, and launches correctly
+   - Test basic functionality (send a message, check responses)
+4. **Debug if needed:**
+   - Check Zed logs for errors
+   - Verify archive URLs are correct
+   - Confirm SHA-256 hashes match
+   - Test the command locally: `stakpak acp`
+
+### Step 8: Submit to Zed Extensions
+
+Once tested and working:
+
+1. **Fork** `zed-industries/extensions` repository
+   ```bash
+   # On GitHub, click Fork button
+   git clone https://github.com/YOUR_USERNAME/extensions.git
+   cd extensions
+   ```
+
+2. **Add your extension as a submodule**
+   ```bash
+   git submodule add https://github.com/stakpak/stakpak-zed-extension.git extensions/stakpak
+   git add extensions/stakpak
+   ```
+
+3. **Update `extensions.toml`** in the repository root
+   ```toml
+   [stakpak]
+   submodule = "extensions/stakpak"
+   version = "0.1.0"
+   ```
+
+4. **Sort extensions** (if sort script exists)
+   ```bash
+   pnpm sort-extensions  # Or npm run sort-extensions
+   ```
+
+5. **Commit and push**
+   ```bash
+   git commit -m "Add Stakpak agent server extension"
+   git push origin main
+   ```
+
+6. **Open Pull Request** to `zed-industries/extensions`
+
+### Step 9: PR Description
+
+Use this template when submitting your PR:
+
+```markdown
+# Add Stakpak Agent Server Extension
+
+This PR adds Stakpak as an agent server extension for Zed, leveraging the new Agent Server Extensions feature.
+
+## About Stakpak
+
+Stakpak is an enterprise-grade DevOps agent built in Rust with:
+- Agent Client Protocol (ACP) support
+- Security features (mTLS, secret redaction, privacy mode)
+- Infrastructure code generation (Terraform, Kubernetes, Dockerfile, GitHub Actions)
+- Real-time task management and progress streaming
+- Documentation research and semantic search
+
+**Repository**: https://github.com/stakpak/agent (362⭐, Apache-2.0)
+
+## What's Included
+
+- ✅ Agent server configuration for all platforms (macOS ARM/Intel, Linux, Windows)
+- ✅ SHA-256 hashes for security verification
+- ✅ Monochrome SVG icon following design guidelines
+- ✅ Apache-2.0 license
+- ✅ Comprehensive README with setup instructions
+
+## Testing
+
+- [x] Tested locally using `zed: install dev extension`
+- [x] Verified agent launches correctly on macOS ARM64
+- [x] Confirmed ACP communication works end-to-end
+- [x] Tested infrastructure code generation features
+- [x] Validated authentication flow with API key
+
+## Technical Details
+
+- **ACP Command**: `stakpak acp`
+- **Authentication**: Requires `STAKPAK_API_KEY` environment variable (free, no card required)
+- **Binaries**: Pre-built releases from GitHub with verified checksums
+- **Protocol**: Implements Agent Client Protocol v1.0
+
+## Links
+
+- Extension Repository: https://github.com/stakpak/stakpak-zed-extension
+- Stakpak Main Repository: https://github.com/stakpak/agent
+- Stakpak Website: https://stakpak.dev
+- ACP Specification: https://agentclientprotocol.com
+```
+
+## Key Requirements Checklist
+
+Before submitting, ensure:
+
+- [ ] `extension.toml` has all required fields (id, name, version, schema_version, authors, description, repository)
+- [ ] Agent servers configured for all 4 platforms (darwin-aarch64, darwin-x86_64, linux-x86_64, windows-x86_64)
+- [ ] Archive URLs point to valid GitHub releases
+- [ ] SHA-256 hashes are correct for each archive
+- [ ] `cmd` field points to the binary (with .exe for Windows)
+- [ ] `args = ["acp"]` starts Stakpak in ACP server mode
+- [ ] Icon is monochrome SVG, 16x16, optimized
+- [ ] LICENSE file exists (Apache-2.0 or MIT)
+- [ ] README.md includes usage instructions and authentication setup
+- [ ] Tested locally in Zed before submitting
+- [ ] Extension repo is public on GitHub
+
+## Authentication Considerations
+
+Stakpak requires an API key for operation. In your README and PR description, clearly document:
+
+1. **How to get an API key** (free at stakpak.dev, no card required)
+2. **How to set it**: `export STAKPAK_API_KEY=<key>`
+3. **Alternative**: Users can also run `stakpak login --api-key $STAKPAK_API_KEY` to save it to config
+
+Consider adding to `extension.toml`:
+```toml
+[agent_servers.stakpak.env]
+# Users should set STAKPAK_API_KEY in their shell environment
+# Get your free API key at: https://stakpak.dev
+```
+
+## Next Steps
+
+1. ✅ Verify latest Stakpak release version and binary naming convention
+2. ✅ Download binaries and generate SHA-256 hashes
+3. ✅ Create `stakpak-zed-extension` repository on GitHub
+4. ✅ Add all files (extension.toml, icon.svg, LICENSE, README.md)
+5. ✅ Test locally in Zed
+6. ✅ Fork `zed-industries/extensions`
+7. ✅ Add as submodule and update extensions.toml
+8. ✅ Submit PR with detailed description
+9. ✅ Wait for review and approval from Zed team
+
+## Timeline
+
+- **Now**: Agent Server Extensions PR is going live this week
+- **After PR merge**: You can submit Stakpak extension immediately
+- **Review time**: Typically 1-2 weeks for extension approval
+- **After approval**: Stakpak will appear in Zed's extension marketplace
+
+## Technical Architecture
+
+```
+Zed Editor
+    ↓
+Extension System (loads extension.toml)
+    ↓
+Downloads archive for user's platform
+    ↓
+Extracts to cache directory
+    ↓
+Runs: stakpak acp
+    ↓
+ACP Server starts (listens on stdio)
+    ↓
+Zed communicates via Agent Client Protocol
+    ↓
+User interacts through Zed's Agent Panel
+```
+
+## Resources
+
+- **Zed Agent Server Extensions Docs**: https://github.com/zed-industries/zed/blob/ea273e738d3e4eada4a4741aa8d6431ca7cc3d44/docs/src/extensions/agent-servers.md
+- **Zed Extensions Repository**: https://github.com/zed-industries/extensions
+- **Zed Extension Development Docs**: https://zed.dev/docs/extensions
+- **Agent Client Protocol**: https://agentclientprotocol.com
+- **Stakpak Repository**: https://github.com/stakpak/agent
+- **Stakpak Website**: https://stakpak.dev
+
+## Questions or Issues?
+
+If you encounter any issues during implementation:
+1. Check Zed's extension development docs
+2. Look at existing agent server extensions for reference
+3. Open an issue in the Zed repository for extension-related questions
+4. Reach out to Stakpak team for agent-specific issues
+
+---
+
+**Document Version**: 1.0  
+**Last Updated**: November 2, 2025  
+**Author**: Generated for Stakpak Zed Extension integration
+

--- a/extensions/stakpak/LICENSE-APACHE
+++ b/extensions/stakpak/LICENSE-APACHE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Support. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2025 Stakpak Team
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/extensions/stakpak/README.md
+++ b/extensions/stakpak/README.md
@@ -1,0 +1,113 @@
+# Stakpak Agent for Zed
+
+Enterprise-grade DevOps agent with security features and infrastructure code generation capabilities.
+
+## Features
+
+- 🔒 **Security Hardened**: mTLS encryption, dynamic secret redaction, privacy mode
+- 🛠️ **DevOps Optimized**: Async task management, real-time progress streaming
+- 🧠 **Adaptive Intelligence**: Rule books, persistent knowledge, subagents
+- 📦 **IaC Generation**: Terraform, Kubernetes, Dockerfile, GitHub Actions
+
+## Installation
+
+1. Open Zed Editor
+2. Open the Command Palette (`Cmd+Shift+P` on macOS or `Ctrl+Shift+P` on Windows/Linux)
+3. Search for "zed: extensions"
+4. Search for "Stakpak Agent" in the extensions list
+5. Click "Install"
+
+The extension will automatically download the appropriate Stakpak binary for your platform.
+
+## Usage
+
+1. Get an API key from [stakpak.dev](https://stakpak.dev)
+2. Set environment variable: `export STAKPAK_API_KEY=<your-key>`
+3. Restart Zed (or start it from a terminal with the environment variable set)
+4. Open Agent Panel in Zed
+5. Select "Stakpak" from the agent list
+6. Start interacting with the agent
+
+## Authentication
+
+Stakpak requires an API key to function. Getting one is free and requires no credit card:
+
+1. Visit [stakpak.dev](https://stakpak.dev)
+2. Click "Login" → "Create API Key"
+3. Copy your API key
+4. Set the environment variable:
+   ```bash
+   # Add to your shell profile (~/.zshrc, ~/.bashrc, etc.)
+   export STAKPAK_API_KEY=your_api_key_here
+   ```
+5. Restart your terminal and Zed
+
+Alternatively, you can use the Stakpak CLI to save the API key:
+```bash
+stakpak login --api-key $STAKPAK_API_KEY
+```
+
+## Supported Platforms
+
+- macOS (Apple Silicon and Intel)
+- Linux (x86_64)
+- Windows (x86_64)
+
+## Capabilities
+
+Stakpak agent excels at:
+
+- **Infrastructure Code Generation**: Generate Terraform, Kubernetes manifests, Dockerfiles, and GitHub Actions workflows
+- **DevOps Operations**: Execute complex DevOps tasks with built-in error handling and retries
+- **Documentation Research**: Search and analyze documentation with semantic understanding
+- **Code Analysis**: Perform semantic code search and analysis
+- **Security**: All operations are performed with mTLS encryption and automatic secret redaction
+
+## Links
+
+- [Stakpak Website](https://stakpak.dev)
+- [Stakpak GitHub Repository](https://github.com/stakpak/agent)
+- [Agent Client Protocol](https://agentclientprotocol.com)
+- [Extension Repository](https://github.com/stakpak/stakpak-zed-extension)
+
+## Troubleshooting
+
+### Agent not connecting
+
+1. Verify your API key is set correctly:
+   ```bash
+   echo $STAKPAK_API_KEY
+   ```
+2. Make sure Zed was started from a terminal with the environment variable set
+3. Check Zed logs for any error messages
+
+### Binary download issues
+
+If the extension fails to download the binary, you can manually install Stakpak:
+
+```bash
+# macOS (ARM64)
+curl -LO https://github.com/stakpak/agent/releases/download/v0.2.66/stakpak-darwin-aarch64.tar.gz
+tar -xzf stakpak-darwin-aarch64.tar.gz
+sudo mv stakpak /usr/local/bin/
+
+# Verify installation
+stakpak --version
+```
+
+Then configure Zed to use the system-installed binary (see Zed extension settings).
+
+## Support
+
+For issues, questions, or feature requests:
+
+- Extension issues: [stakpak-zed-extension issues](https://github.com/stakpak/stakpak-zed-extension/issues)
+- Stakpak agent issues: [agent issues](https://github.com/stakpak/agent/issues)
+- General questions: [stakpak.dev](https://stakpak.dev)
+
+## License
+
+Apache-2.0
+
+Copyright (c) 2025 Stakpak Team
+

--- a/extensions/stakpak/extension.toml
+++ b/extensions/stakpak/extension.toml
@@ -1,0 +1,44 @@
+id = "stakpak"
+name = "Stakpak Agent"
+version = "0.1.0"
+schema_version = 1
+authors = ["Stakpak Team <contact@stakpak.dev>"]
+description = "Open-source Agent in Rust. Built with enterprise-grade security for tough DevOps tasks."
+repository = "https://github.com/stakpak/agent"
+
+[agent_servers.stakpak]
+name = "Stakpak"
+icon = "icon.svg"
+
+# Environment variables (optional)
+[agent_servers.stakpak.env]
+# STAKPAK_LOG_LEVEL = "info"  # Optional: Add if you want to control logging
+
+# macOS ARM64 (M1/M2/M3/M4 Macs)
+[agent_servers.stakpak.targets.darwin-aarch64]
+archive = "https://github.com/stakpak/agent/releases/download/v0.2.66/stakpak-darwin-aarch64.tar.gz"
+cmd = "./stakpak"
+args = ["acp"]
+sha256 = "bd7c27d39bea6c344e3ef038606079c283870b3b9ca9f29bd000c1a4987453c3"
+
+# macOS x86_64 (Intel Macs)
+[agent_servers.stakpak.targets.darwin-x86_64]
+archive = "https://github.com/stakpak/agent/releases/download/v0.2.66/stakpak-darwin-x86_64.tar.gz"
+cmd = "./stakpak"
+args = ["acp"]
+sha256 = "30dc49c9c337cd03f691bc21e4e64e24c0de3220da3e7203a05232eb246331d8"
+
+# Linux x86_64
+[agent_servers.stakpak.targets.linux-x86_64]
+archive = "https://github.com/stakpak/agent/releases/download/v0.2.66/stakpak-linux-x86_64.tar.gz"
+cmd = "./stakpak"
+args = ["acp"]
+sha256 = "8210bd81321b2792e8fdde37ff26b1dc65b17c4dfac9b01fda4c07f9b51a3c45"
+
+# Windows x86_64
+[agent_servers.stakpak.targets.windows-x86_64]
+archive = "https://github.com/stakpak/agent/releases/download/v0.2.66/stakpak-windows-x86_64.zip"
+cmd = "./stakpak.exe"
+args = ["acp"]
+sha256 = "2c8d493a63703b18e68ebb0e7a70537b392de4f31b31179a50794cac19ab1277"
+

--- a/extensions/stakpak/icon.svg
+++ b/extensions/stakpak/icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <path fill="currentColor" d="M6.53 4.412h5.883v3.587H9.471v3.588H3.588V7.999H6.53Z"/>
+</svg>


### PR DESCRIPTION
Add complete Zed extension for Stakpak DevOps agent with Agent Client Protocol (ACP) support.

Features:
- Extension configuration for all platforms (macOS ARM64/Intel, Linux, Windows)
- Binary downloads from GitHub releases (v0.2.66)
- SHA-256 hash verification for security
- Monochrome SVG icon for theme compatibility
- Comprehensive README with installation and authentication instructions
- Apache-2.0 license

The extension enables users to interact with Stakpak's infrastructure code generation,
DevOps operations, and semantic search capabilities directly from Zed's Agent Panel.