### PR TITLE
Support Gitee avatars in git blame

### DIFF
--- a/crates/git_hosting_providers/src/providers/gitee.rs
+++ b/crates/git_hosting_providers/src/providers/gitee.rs
@@ -1,5 +1,11 @@
-use std::str::FromStr;
+use std::{str::FromStr, sync::Arc};
 
+use anyhow::{Context as _, Result, bail};
+use async_trait::async_trait;
+use futures::AsyncReadExt;
+use gpui::SharedString;
+use http_client::{AsyncBody, HttpClient, HttpRequestExt, Request};
+use serde::Deserialize;
 use url::Url;
 
 use git::{
@@ -9,6 +15,55 @@ use git::{
 
 pub struct Gitee;
 
+#[derive(Debug, Deserialize)]
+struct CommitDetails {
+    author: Option<Author>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Author {
+    avatar_url: String,
+}
+
+impl Gitee {
+    async fn fetch_gitee_commit_author(
+        &self,
+        repo_owner: &str,
+        repo: &str,
+        commit: &str,
+        client: &Arc<dyn HttpClient>,
+    ) -> Result<Option<Author>> {
+        let url = format!("https://gitee.com/api/v5/repos/{repo_owner}/{repo}/commits/{commit}");
+
+        let request = Request::get(&url)
+            .header("Content-Type", "application/json")
+            .follow_redirects(http_client::RedirectPolicy::FollowAll);
+
+        let mut response = client
+            .send(request.body(AsyncBody::default())?)
+            .await
+            .with_context(|| format!("error fetching Gitee commit details at {:?}", url))?;
+
+        let mut body = Vec::new();
+        response.body_mut().read_to_end(&mut body).await?;
+
+        if response.status().is_client_error() {
+            let text = String::from_utf8_lossy(body.as_slice());
+            bail!(
+                "status error {}, response: {text:?}",
+                response.status().as_u16()
+            );
+        }
+
+        let body_str = std::str::from_utf8(&body)?;
+
+        serde_json::from_str::<CommitDetails>(body_str)
+            .map(|commit| commit.author)
+            .context("failed to deserialize Gitee commit details")
+    }
+}
+
+#[async_trait]
 impl GitHostingProvider for Gitee {
     fn name(&self) -> String {
         "Gitee".to_string()
@@ -19,7 +74,7 @@ impl GitHostingProvider for Gitee {
     }
 
     fn supports_avatars(&self) -> bool {
-        false
+        true
     }
 
     fn format_line_number(&self, line: u32) -> String {
@@ -79,6 +134,26 @@ impl GitHostingProvider for Gitee {
                 .as_deref(),
         );
         permalink
+    }
+
+    async fn commit_author_avatar_url(
+        &self,
+        repo_owner: &str,
+        repo: &str,
+        commit: SharedString,
+        http_client: Arc<dyn HttpClient>,
+    ) -> Result<Option<Url>> {
+        let commit = commit.to_string();
+        let avatar_url = self
+            .fetch_gitee_commit_author(repo_owner, repo, &commit, &http_client)
+            .await?
+            .map(|author| -> Result<Url, url::ParseError> {
+                let mut url = Url::parse(&author.avatar_url)?;
+                url.set_query(Some("size=128"));
+                Ok(url)
+            })
+            .transpose()?;
+        Ok(avatar_url)
     }
 }
 

--- a/crates/git_hosting_providers/src/providers/gitee.rs
+++ b/crates/git_hosting_providers/src/providers/gitee.rs
@@ -149,7 +149,7 @@ impl GitHostingProvider for Gitee {
             .await?
             .map(|author| -> Result<Url, url::ParseError> {
                 let mut url = Url::parse(&author.avatar_url)?;
-                url.set_query(Some("size=128"));
+                url.set_query(Some("width=128"));
                 Ok(url)
             })
             .transpose()?;


### PR DESCRIPTION
Part of https://github.com/zed-industries/zed/issues/11043.

<img width="3596" height="1894" alt="CleanShot 2025-11-03 at 10 39 08@2x" src="https://github.com/user-attachments/assets/68d16c32-fd23-4f54-9973-6cbda9685a8f" />


Release Notes:

- Added Support for showing Gitee avatars in git blame
- Let's Git Together
