### PR TITLE
Fix racy inlay hints queries

### DIFF
--- a/crates/collab/src/tests/editor_tests.rs
+++ b/crates/collab/src/tests/editor_tests.rs
@@ -39,6 +39,7 @@ use std::{
         Arc,
         atomic::{self, AtomicBool, AtomicUsize},
     },
+    time::Duration,
 };
 use text::Point;
 use util::{path, rel_path::rel_path, uri};
@@ -1817,14 +1818,7 @@ async fn test_mutual_editor_inlay_hint_cache_update(
                 settings.project.all_languages.defaults.inlay_hints =
                     Some(InlayHintSettingsContent {
                         enabled: Some(true),
-                        show_value_hints: Some(true),
-                        edit_debounce_ms: Some(0),
-                        scroll_debounce_ms: Some(0),
-                        show_type_hints: Some(true),
-                        show_parameter_hints: Some(false),
-                        show_other_hints: Some(true),
-                        show_background: Some(false),
-                        toggle_on_modifiers_press: None,
+                        ..InlayHintSettingsContent::default()
                     })
             });
         });
@@ -1834,15 +1828,8 @@ async fn test_mutual_editor_inlay_hint_cache_update(
             store.update_user_settings(cx, |settings| {
                 settings.project.all_languages.defaults.inlay_hints =
                     Some(InlayHintSettingsContent {
-                        show_value_hints: Some(true),
                         enabled: Some(true),
-                        edit_debounce_ms: Some(0),
-                        scroll_debounce_ms: Some(0),
-                        show_type_hints: Some(true),
-                        show_parameter_hints: Some(false),
-                        show_other_hints: Some(true),
-                        show_background: Some(false),
-                        toggle_on_modifiers_press: None,
+                        ..InlayHintSettingsContent::default()
                     })
             });
         });
@@ -1935,6 +1922,7 @@ async fn test_mutual_editor_inlay_hint_cache_update(
     });
     let fake_language_server = fake_language_servers.next().await.unwrap();
     let editor_a = file_a.await.unwrap().downcast::<Editor>().unwrap();
+    executor.advance_clock(Duration::from_millis(100));
     executor.run_until_parked();
 
     let initial_edit = edits_made.load(atomic::Ordering::Acquire);
@@ -1955,6 +1943,7 @@ async fn test_mutual_editor_inlay_hint_cache_update(
         .downcast::<Editor>()
         .unwrap();
 
+    executor.advance_clock(Duration::from_millis(100));
     executor.run_until_parked();
     editor_b.update(cx_b, |editor, cx| {
         assert_eq!(
@@ -1973,6 +1962,7 @@ async fn test_mutual_editor_inlay_hint_cache_update(
     });
     cx_b.focus(&editor_b);
 
+    executor.advance_clock(Duration::from_secs(1));
     executor.run_until_parked();
     editor_a.update(cx_a, |editor, cx| {
         assert_eq!(
@@ -1996,6 +1986,7 @@ async fn test_mutual_editor_inlay_hint_cache_update(
     });
     cx_a.focus(&editor_a);
 
+    executor.advance_clock(Duration::from_secs(1));
     executor.run_until_parked();
     editor_a.update(cx_a, |editor, cx| {
         assert_eq!(
@@ -2017,6 +2008,7 @@ async fn test_mutual_editor_inlay_hint_cache_update(
         .into_response()
         .expect("inlay refresh request failed");
 
+    executor.advance_clock(Duration::from_secs(1));
     executor.run_until_parked();
     editor_a.update(cx_a, |editor, cx| {
         assert_eq!(

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1833,9 +1833,15 @@ impl Editor {
                     project::Event::RefreshCodeLens => {
                         // we always query lens with actions, without storing them, always refreshing them
                     }
-                    project::Event::RefreshInlayHints(server_id) => {
+                    project::Event::RefreshInlayHints {
+                        server_id,
+                        request_id,
+                    } => {
                         editor.refresh_inlay_hints(
-                            InlayHintRefreshReason::RefreshRequested(*server_id),
+                            InlayHintRefreshReason::RefreshRequested {
+                                server_id: *server_id,
+                                request_id: *request_id,
+                            },
                             cx,
                         );
                     }

--- a/crates/editor/src/inlays.rs
+++ b/crates/editor/src/inlays.rs
@@ -150,16 +150,6 @@ impl Editor {
                 inlay_hints.added_hints.remove(id_to_remove);
             }
         }
-        let a = to_insert
-            .iter()
-            .map(|inlay| (inlay.id, inlay.text().to_string()))
-            .collect::<Vec<_>>();
-        dbg!((
-            self.buffer.read(cx).is_singleton(),
-            "splice_inlays",
-            &to_remove,
-            a,
-        ));
         self.display_map.update(cx, |display_map, cx| {
             display_map.splice_inlays(to_remove, to_insert, cx)
         });

--- a/crates/editor/src/inlays.rs
+++ b/crates/editor/src/inlays.rs
@@ -150,6 +150,16 @@ impl Editor {
                 inlay_hints.added_hints.remove(id_to_remove);
             }
         }
+        let a = to_insert
+            .iter()
+            .map(|inlay| (inlay.id, inlay.text().to_string()))
+            .collect::<Vec<_>>();
+        dbg!((
+            self.buffer.read(cx).is_singleton(),
+            "splice_inlays",
+            &to_remove,
+            a,
+        ));
         self.display_map.update(cx, |display_map, cx| {
             display_map.splice_inlays(to_remove, to_insert, cx)
         });

--- a/crates/editor/src/inlays/inlay_hints.rs
+++ b/crates/editor/src/inlays/inlay_hints.rs
@@ -370,6 +370,12 @@ impl Editor {
             let Some(buffer) = multi_buffer.read(cx).buffer(buffer_id) else {
                 continue;
             };
+            dbg!((
+                self.buffer.read(cx).is_singleton(),
+                buffer.read(cx).file().map(|f| f.path()),
+                invalidate_cache,
+                ignore_previous_fetches,
+            ));
             let fetched_tasks = inlay_hints.hint_chunk_fetched.entry(buffer_id).or_default();
             if visible_excerpts
                 .buffer_version

--- a/crates/editor/src/inlays/inlay_hints.rs
+++ b/crates/editor/src/inlays/inlay_hints.rs
@@ -369,6 +369,12 @@ impl Editor {
                 continue;
             };
 
+            dbg!((
+                self.buffer.read(cx).is_singleton(),
+                buffer.read(cx).file().map(|f| f.path()),
+                invalidate_cache,
+                ignore_previous_fetches,
+            ));
             let (fetched_for_version, fetched_chunks) = inlay_hints
                 .hint_chunk_fetching
                 .entry(buffer_id)

--- a/crates/editor/src/inlays/inlay_hints.rs
+++ b/crates/editor/src/inlays/inlay_hints.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::hash_map,
     ops::{ControlFlow, Range},
     time::Duration,
 };
@@ -49,8 +48,8 @@ pub struct LspInlayHintData {
     allowed_hint_kinds: HashSet<Option<InlayHintKind>>,
     invalidate_debounce: Option<Duration>,
     append_debounce: Option<Duration>,
-    hint_refresh_tasks: HashMap<BufferId, HashMap<Vec<Range<BufferRow>>, Vec<Task<()>>>>,
-    hint_chunk_fetched: HashMap<BufferId, (Global, HashSet<Range<BufferRow>>)>,
+    hint_refresh_tasks: HashMap<BufferId, Vec<Task<()>>>,
+    hint_chunk_fetching: HashMap<BufferId, (Global, HashSet<Range<BufferRow>>)>,
     invalidate_hints_for_buffers: HashSet<BufferId>,
     pub added_hints: HashMap<InlayId, Option<InlayHintKind>>,
 }
@@ -63,7 +62,7 @@ impl LspInlayHintData {
             enabled_in_settings: settings.enabled,
             hint_refresh_tasks: HashMap::default(),
             added_hints: HashMap::default(),
-            hint_chunk_fetched: HashMap::default(),
+            hint_chunk_fetching: HashMap::default(),
             invalidate_hints_for_buffers: HashSet::default(),
             invalidate_debounce: debounce_value(settings.edit_debounce_ms),
             append_debounce: debounce_value(settings.scroll_debounce_ms),
@@ -99,9 +98,8 @@ impl LspInlayHintData {
 
     pub fn clear(&mut self) {
         self.hint_refresh_tasks.clear();
-        self.hint_chunk_fetched.clear();
+        self.hint_chunk_fetching.clear();
         self.added_hints.clear();
-        self.invalidate_hints_for_buffers.clear();
     }
 
     /// Checks inlay hint settings for enabled hint kinds and general enabled state.
@@ -199,7 +197,7 @@ impl LspInlayHintData {
     ) {
         for buffer_id in removed_buffer_ids {
             self.hint_refresh_tasks.remove(buffer_id);
-            self.hint_chunk_fetched.remove(buffer_id);
+            self.hint_chunk_fetching.remove(buffer_id);
         }
     }
 }
@@ -370,54 +368,45 @@ impl Editor {
             let Some(buffer) = multi_buffer.read(cx).buffer(buffer_id) else {
                 continue;
             };
-            dbg!((
-                self.buffer.read(cx).is_singleton(),
-                buffer.read(cx).file().map(|f| f.path()),
-                invalidate_cache,
-                ignore_previous_fetches,
-            ));
-            let fetched_tasks = inlay_hints.hint_chunk_fetched.entry(buffer_id).or_default();
+
+            let (fetched_for_version, fetched_chunks) = inlay_hints
+                .hint_chunk_fetching
+                .entry(buffer_id)
+                .or_default();
             if visible_excerpts
                 .buffer_version
-                .changed_since(&fetched_tasks.0)
+                .changed_since(fetched_for_version)
             {
-                fetched_tasks.1.clear();
-                fetched_tasks.0 = visible_excerpts.buffer_version.clone();
+                *fetched_for_version = visible_excerpts.buffer_version.clone();
+                fetched_chunks.clear();
                 inlay_hints.hint_refresh_tasks.remove(&buffer_id);
             }
 
-            let applicable_chunks =
-                semantics_provider.applicable_inlay_chunks(&buffer, &visible_excerpts.ranges, cx);
+            let known_chunks = if ignore_previous_fetches {
+                None
+            } else {
+                Some((fetched_for_version.clone(), fetched_chunks.clone()))
+            };
 
-            match inlay_hints
+            let mut applicable_chunks =
+                semantics_provider.applicable_inlay_chunks(&buffer, &visible_excerpts.ranges, cx);
+            applicable_chunks.retain(|chunk| fetched_chunks.insert(chunk.clone()));
+            if applicable_chunks.is_empty() && !ignore_previous_fetches {
+                continue;
+            }
+            inlay_hints
                 .hint_refresh_tasks
                 .entry(buffer_id)
                 .or_default()
-                .entry(applicable_chunks)
-            {
-                hash_map::Entry::Occupied(mut o) => {
-                    if invalidate_cache.should_invalidate() || ignore_previous_fetches {
-                        o.get_mut().push(spawn_editor_hints_refresh(
-                            buffer_id,
-                            invalidate_cache,
-                            ignore_previous_fetches,
-                            debounce,
-                            visible_excerpts,
-                            cx,
-                        ));
-                    }
-                }
-                hash_map::Entry::Vacant(v) => {
-                    v.insert(Vec::new()).push(spawn_editor_hints_refresh(
-                        buffer_id,
-                        invalidate_cache,
-                        ignore_previous_fetches,
-                        debounce,
-                        visible_excerpts,
-                        cx,
-                    ));
-                }
-            }
+                .push(spawn_editor_hints_refresh(
+                    buffer_id,
+                    invalidate_cache,
+                    debounce,
+                    visible_excerpts,
+                    known_chunks,
+                    applicable_chunks,
+                    cx,
+                ));
         }
     }
 
@@ -724,44 +713,29 @@ impl Editor {
     fn inlay_hints_for_buffer(
         &mut self,
         invalidate_cache: InvalidationStrategy,
-        ignore_previous_fetches: bool,
         buffer_excerpts: VisibleExcerpts,
+        known_chunks: Option<(Global, HashSet<Range<BufferRow>>)>,
         cx: &mut Context<Self>,
     ) -> Option<Vec<Task<(Range<BufferRow>, anyhow::Result<CacheInlayHints>)>>> {
         let semantics_provider = self.semantics_provider()?;
-        let inlay_hints = self.inlay_hints.as_mut()?;
-        let buffer_id = buffer_excerpts.buffer.read(cx).remote_id();
 
         let new_hint_tasks = semantics_provider
             .inlay_hints(
                 invalidate_cache,
                 buffer_excerpts.buffer,
                 buffer_excerpts.ranges,
-                inlay_hints
-                    .hint_chunk_fetched
-                    .get(&buffer_id)
-                    .filter(|_| !ignore_previous_fetches && !invalidate_cache.should_invalidate())
-                    .cloned(),
+                known_chunks,
                 cx,
             )
             .unwrap_or_default();
 
-        let (known_version, known_chunks) =
-            inlay_hints.hint_chunk_fetched.entry(buffer_id).or_default();
-        if buffer_excerpts.buffer_version.changed_since(known_version) {
-            known_chunks.clear();
-            *known_version = buffer_excerpts.buffer_version;
-        }
-
-        let mut hint_tasks = Vec::new();
+        let mut hint_tasks = None;
         for (row_range, new_hints_task) in new_hint_tasks {
-            let inserted = known_chunks.insert(row_range.clone());
-            if inserted || ignore_previous_fetches || invalidate_cache.should_invalidate() {
-                hint_tasks.push(cx.spawn(async move |_, _| (row_range, new_hints_task.await)));
-            }
+            hint_tasks
+                .get_or_insert_with(Vec::new)
+                .push(cx.spawn(async move |_, _| (row_range, new_hints_task.await)));
         }
-
-        Some(hint_tasks)
+        hint_tasks
     }
 
     fn apply_fetched_hints(
@@ -799,20 +773,28 @@ impl Editor {
         let excerpts = self.buffer.read(cx).excerpt_ids();
         let hints_to_insert = new_hints
             .into_iter()
-            .filter_map(|(chunk_range, hints_result)| match hints_result {
-                Ok(new_hints) => Some(new_hints),
-                Err(e) => {
-                    log::error!(
-                        "Failed to query inlays for buffer row range {chunk_range:?}, {e:#}"
-                    );
-                    if let Some((for_version, chunks_fetched)) =
-                        inlay_hints.hint_chunk_fetched.get_mut(&buffer_id)
-                    {
-                        if for_version == &query_version {
-                            chunks_fetched.remove(&chunk_range);
+            .filter_map(|(chunk_range, hints_result)| {
+                let chunks_fetched = inlay_hints.hint_chunk_fetching.get_mut(&buffer_id);
+                match hints_result {
+                    Ok(new_hints) => {
+                        if new_hints.is_empty() {
+                            if let Some((_, chunks_fetched)) = chunks_fetched {
+                                chunks_fetched.remove(&chunk_range);
+                            }
                         }
+                        Some(new_hints)
                     }
-                    None
+                    Err(e) => {
+                        log::error!(
+                            "Failed to query inlays for buffer row range {chunk_range:?}, {e:#}"
+                        );
+                        if let Some((for_version, chunks_fetched)) = chunks_fetched {
+                            if for_version == &query_version {
+                                chunks_fetched.remove(&chunk_range);
+                            }
+                        }
+                        None
+                    }
                 }
             })
             .flat_map(|hints| hints.into_values())
@@ -862,9 +844,10 @@ struct VisibleExcerpts {
 fn spawn_editor_hints_refresh(
     buffer_id: BufferId,
     invalidate_cache: InvalidationStrategy,
-    ignore_previous_fetches: bool,
     debounce: Option<Duration>,
     buffer_excerpts: VisibleExcerpts,
+    known_chunks: Option<(Global, HashSet<Range<BufferRow>>)>,
+    applicable_chunks: Vec<Range<BufferRow>>,
     cx: &mut Context<'_, Editor>,
 ) -> Task<()> {
     cx.spawn(async move |editor, cx| {
@@ -875,12 +858,7 @@ fn spawn_editor_hints_refresh(
         let query_version = buffer_excerpts.buffer_version.clone();
         let Some(hint_tasks) = editor
             .update(cx, |editor, cx| {
-                editor.inlay_hints_for_buffer(
-                    invalidate_cache,
-                    ignore_previous_fetches,
-                    buffer_excerpts,
-                    cx,
-                )
+                editor.inlay_hints_for_buffer(invalidate_cache, buffer_excerpts, known_chunks, cx)
             })
             .ok()
         else {
@@ -888,6 +866,19 @@ fn spawn_editor_hints_refresh(
         };
         let hint_tasks = hint_tasks.unwrap_or_default();
         if hint_tasks.is_empty() {
+            editor
+                .update(cx, |editor, _| {
+                    if let Some((_, hint_chunk_fetching)) = editor
+                        .inlay_hints
+                        .as_mut()
+                        .and_then(|inlay_hints| inlay_hints.hint_chunk_fetching.get_mut(&buffer_id))
+                    {
+                        for applicable_chunks in &applicable_chunks {
+                            hint_chunk_fetching.remove(applicable_chunks);
+                        }
+                    }
+                })
+                .ok();
             return;
         }
         let new_hints = join_all(hint_tasks).await;
@@ -1964,15 +1955,8 @@ pub mod tests {
     async fn test_large_buffer_inlay_requests_split(cx: &mut gpui::TestAppContext) {
         init_test(cx, |settings| {
             settings.defaults.inlay_hints = Some(InlayHintSettingsContent {
-                show_value_hints: Some(true),
                 enabled: Some(true),
-                edit_debounce_ms: Some(0),
-                scroll_debounce_ms: Some(0),
-                show_type_hints: Some(true),
-                show_parameter_hints: Some(true),
-                show_other_hints: Some(true),
-                show_background: Some(false),
-                toggle_on_modifiers_press: None,
+                ..InlayHintSettingsContent::default()
             })
         });
 
@@ -2050,6 +2034,7 @@ pub mod tests {
             cx.add_window(|window, cx| Editor::for_buffer(buffer, Some(project), window, cx));
         cx.executor().run_until_parked();
         let _fake_server = fake_servers.next().await.unwrap();
+        cx.executor().advance_clock(Duration::from_millis(100));
         cx.executor().run_until_parked();
 
         let ranges = lsp_request_ranges
@@ -2135,6 +2120,7 @@ pub mod tests {
                 );
             })
             .unwrap();
+        cx.executor().advance_clock(Duration::from_millis(100));
         cx.executor().run_until_parked();
         editor.update(cx, |_, _, _| {
             let ranges = lsp_request_ranges
@@ -2151,6 +2137,7 @@ pub mod tests {
                 editor.handle_input("++++more text++++", window, cx);
             })
             .unwrap();
+        cx.executor().advance_clock(Duration::from_secs(1));
         cx.executor().run_until_parked();
         editor.update(cx, |editor, _window, cx| {
             let mut ranges = lsp_request_ranges.lock().drain(..).collect::<Vec<_>>();
@@ -4028,7 +4015,7 @@ let c = 3;"#
         let mut all_fetched_hints = Vec::new();
         for buffer in editor.buffer.read(cx).all_buffers() {
             lsp_store.update(cx, |lsp_store, cx| {
-                let hints = &lsp_store.latest_lsp_data(&buffer, cx).inlay_hints();
+                let hints = lsp_store.latest_lsp_data(&buffer, cx).inlay_hints();
                 all_cached_labels.extend(hints.all_cached_hints().into_iter().map(|hint| {
                     let mut label = hint.text().to_string();
                     if hint.padding_left {

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -6665,6 +6665,12 @@ impl LspStore {
 
         let last_chunk_number = existing_inlay_hints.buffer_chunks_len() - 1;
 
+        dbg!((
+            buffer.read(cx).file().map(|f| f.path()),
+            invalidate,
+            &applicable_chunks,
+            lsp_refresh_requested,
+        ));
         for row_chunk in applicable_chunks {
             match (
                 existing_inlay_hints
@@ -6720,10 +6726,20 @@ impl LspStore {
             }
         }
 
-        if hint_fetch_tasks.is_empty()
-            && ranges_to_query
-                .as_ref()
-                .is_none_or(|ranges| ranges.is_empty())
+        let o = cached_inlay_hints
+            .iter()
+            .flatten()
+            .flat_map(|a| a.1.iter())
+            .flat_map(|(_, a)| a.iter())
+            .map(|(id, hint)| (*id, hint.text().to_string()))
+            .collect::<Vec<_>>();
+        dbg!(o);
+        if dbg!(hint_fetch_tasks.is_empty())
+            && dbg!(
+                ranges_to_query
+                    .as_ref()
+                    .is_none_or(|ranges| ranges.is_empty())
+            )
             && let Some(cached_inlay_hints) = cached_inlay_hints
         {
             cached_inlay_hints
@@ -6731,7 +6747,7 @@ impl LspStore {
                 .map(|(row_chunk, hints)| (row_chunk, Task::ready(Ok(hints))))
                 .collect()
         } else {
-            for (chunk, range_to_query) in ranges_to_query.into_iter().flatten() {
+            for (chunk, range_to_query) in dbg!(ranges_to_query).into_iter().flatten() {
                 let next_hint_id = next_hint_id.clone();
                 let buffer = buffer.clone();
                 let new_inlay_hints = cx
@@ -6769,6 +6785,13 @@ impl LspStore {
                                                     })
                                                     .collect::<Vec<_>>();
                                                 if update_cache {
+                                                    let n = new_hints
+                                                        .iter()
+                                                        .map(|(id, hint)| {
+                                                            (*id, hint.text().to_string())
+                                                        })
+                                                        .collect::<Vec<_>>();
+                                                    dbg!(n);
                                                     lsp_data.inlay_hints.insert_new_hints(
                                                         chunk,
                                                         server_id,

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -6636,14 +6636,16 @@ impl LspStore {
         cx: &mut Context<Self>,
     ) -> HashMap<Range<BufferRow>, Task<Result<CacheInlayHints>>> {
         let buffer_snapshot = buffer.read(cx).snapshot();
+        let next_hint_id = self.next_hint_id.clone();
+        let lsp_data = self.latest_lsp_data(&buffer, cx);
+        let mut lsp_refresh_requested = false;
         let for_server = if let InvalidationStrategy::RefreshRequested(server_id) = invalidate {
+            lsp_data.inlay_hints.invalidate_for_server(server_id);
+            lsp_refresh_requested = true;
             Some(server_id)
         } else {
             None
         };
-        let invalidate_cache = invalidate.should_invalidate();
-        let next_hint_id = self.next_hint_id.clone();
-        let lsp_data = self.latest_lsp_data(&buffer, cx);
         let existing_inlay_hints = &mut lsp_data.inlay_hints;
         let known_chunks = known_chunks
             .filter(|(known_version, _)| !lsp_data.buffer_version.changed_since(known_version))
@@ -6651,8 +6653,8 @@ impl LspStore {
             .unwrap_or_default();
 
         let mut hint_fetch_tasks = Vec::new();
-        let mut cached_inlay_hints = HashMap::default();
-        let mut ranges_to_query = Vec::new();
+        let mut cached_inlay_hints = None;
+        let mut ranges_to_query = None;
         let applicable_chunks = existing_inlay_hints
             .applicable_chunks(ranges.as_slice())
             .filter(|chunk| !known_chunks.contains(&(chunk.start..chunk.end)))
@@ -6667,12 +6669,12 @@ impl LspStore {
             match (
                 existing_inlay_hints
                     .cached_hints(&row_chunk)
-                    .filter(|_| !invalidate_cache)
+                    .filter(|_| !lsp_refresh_requested)
                     .cloned(),
                 existing_inlay_hints
                     .fetched_hints(&row_chunk)
                     .as_ref()
-                    .filter(|_| !invalidate_cache)
+                    .filter(|_| !lsp_refresh_requested)
                     .cloned(),
             ) {
                 (None, None) => {
@@ -6681,19 +6683,18 @@ impl LspStore {
                     } else {
                         Point::new(row_chunk.end, 0)
                     };
-                    ranges_to_query.push((
+                    ranges_to_query.get_or_insert_with(Vec::new).push((
                         row_chunk,
                         buffer_snapshot.anchor_before(Point::new(row_chunk.start, 0))
                             ..buffer_snapshot.anchor_after(end),
                     ));
                 }
-                (None, Some(fetched_hints)) => {
-                    hint_fetch_tasks.push((row_chunk, fetched_hints.clone()))
-                }
+                (None, Some(fetched_hints)) => hint_fetch_tasks.push((row_chunk, fetched_hints)),
                 (Some(cached_hints), None) => {
                     for (server_id, cached_hints) in cached_hints {
                         if for_server.is_none_or(|for_server| for_server == server_id) {
                             cached_inlay_hints
+                                .get_or_insert_with(HashMap::default)
                                 .entry(row_chunk.start..row_chunk.end)
                                 .or_insert_with(HashMap::default)
                                 .entry(server_id)
@@ -6703,10 +6704,11 @@ impl LspStore {
                     }
                 }
                 (Some(cached_hints), Some(fetched_hints)) => {
-                    hint_fetch_tasks.push((row_chunk, fetched_hints.clone()));
+                    hint_fetch_tasks.push((row_chunk, fetched_hints));
                     for (server_id, cached_hints) in cached_hints {
                         if for_server.is_none_or(|for_server| for_server == server_id) {
                             cached_inlay_hints
+                                .get_or_insert_with(HashMap::default)
                                 .entry(row_chunk.start..row_chunk.end)
                                 .or_insert_with(HashMap::default)
                                 .entry(server_id)
@@ -6718,18 +6720,18 @@ impl LspStore {
             }
         }
 
-        let cached_chunk_data = cached_inlay_hints
-            .into_iter()
-            .map(|(row_chunk, hints)| (row_chunk, Task::ready(Ok(hints))))
-            .collect();
-        if hint_fetch_tasks.is_empty() && ranges_to_query.is_empty() {
-            cached_chunk_data
+        if hint_fetch_tasks.is_empty()
+            && ranges_to_query
+                .as_ref()
+                .is_none_or(|ranges| ranges.is_empty())
+            && let Some(cached_inlay_hints) = cached_inlay_hints
+        {
+            cached_inlay_hints
+                .into_iter()
+                .map(|(row_chunk, hints)| (row_chunk, Task::ready(Ok(hints))))
+                .collect()
         } else {
-            if invalidate_cache {
-                lsp_data.inlay_hints.clear();
-            }
-
-            for (chunk, range_to_query) in ranges_to_query {
+            for (chunk, range_to_query) in ranges_to_query.into_iter().flatten() {
                 let next_hint_id = next_hint_id.clone();
                 let buffer = buffer.clone();
                 let new_inlay_hints = cx
@@ -6745,31 +6747,38 @@ impl LspStore {
                                     let update_cache = !lsp_data
                                         .buffer_version
                                         .changed_since(&buffer.read(cx).version());
-                                    new_hints_by_server
-                                        .into_iter()
-                                        .map(|(server_id, new_hints)| {
-                                            let new_hints = new_hints
-                                                .into_iter()
-                                                .map(|new_hint| {
-                                                    (
-                                                        InlayId::Hint(next_hint_id.fetch_add(
-                                                            1,
-                                                            atomic::Ordering::AcqRel,
-                                                        )),
-                                                        new_hint,
-                                                    )
-                                                })
-                                                .collect::<Vec<_>>();
-                                            if update_cache {
-                                                lsp_data.inlay_hints.insert_new_hints(
-                                                    chunk,
-                                                    server_id,
-                                                    new_hints.clone(),
-                                                );
-                                            }
-                                            (server_id, new_hints)
-                                        })
-                                        .collect()
+                                    if new_hints_by_server.is_empty() {
+                                        if update_cache {
+                                            lsp_data.inlay_hints.invalidate_for_chunk(chunk);
+                                        }
+                                        HashMap::default()
+                                    } else {
+                                        new_hints_by_server
+                                            .into_iter()
+                                            .map(|(server_id, new_hints)| {
+                                                let new_hints = new_hints
+                                                    .into_iter()
+                                                    .map(|new_hint| {
+                                                        (
+                                                            InlayId::Hint(next_hint_id.fetch_add(
+                                                                1,
+                                                                atomic::Ordering::AcqRel,
+                                                            )),
+                                                            new_hint,
+                                                        )
+                                                    })
+                                                    .collect::<Vec<_>>();
+                                                if update_cache {
+                                                    lsp_data.inlay_hints.insert_new_hints(
+                                                        chunk,
+                                                        server_id,
+                                                        new_hints.clone(),
+                                                    );
+                                                }
+                                                (server_id, new_hints)
+                                            })
+                                            .collect()
+                                    }
                                 })
                             })
                             .map_err(Arc::new)
@@ -6781,22 +6790,25 @@ impl LspStore {
                 hint_fetch_tasks.push((chunk, new_inlay_hints));
             }
 
-            let mut combined_data = cached_chunk_data;
-            combined_data.extend(hint_fetch_tasks.into_iter().map(|(chunk, hints_fetch)| {
-                (
-                    chunk.start..chunk.end,
-                    cx.spawn(async move |_, _| {
-                        hints_fetch.await.map_err(|e| {
-                            if e.error_code() != ErrorCode::Internal {
-                                anyhow!(e.error_code())
-                            } else {
-                                anyhow!("{e:#}")
-                            }
-                        })
-                    }),
-                )
-            }));
-            combined_data
+            cached_inlay_hints
+                .unwrap_or_default()
+                .into_iter()
+                .map(|(row_chunk, hints)| (row_chunk, Task::ready(Ok(hints))))
+                .chain(hint_fetch_tasks.into_iter().map(|(chunk, hints_fetch)| {
+                    (
+                        chunk.start..chunk.end,
+                        cx.spawn(async move |_, _| {
+                            hints_fetch.await.map_err(|e| {
+                                if e.error_code() != ErrorCode::Internal {
+                                    anyhow!(e.error_code())
+                                } else {
+                                    anyhow!("{e:#}")
+                                }
+                            })
+                        }),
+                    )
+                }))
+                .collect()
         }
     }
 
@@ -10972,7 +10984,6 @@ impl LspStore {
             language_server.name(),
             Some(key.worktree_id),
         ));
-        cx.emit(LspStoreEvent::RefreshInlayHints(server_id));
 
         let server_capabilities = language_server.capabilities();
         if let Some((downstream_client, project_id)) = self.downstream_client.as_ref() {

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -337,7 +337,10 @@ pub enum Event {
     HostReshared,
     Reshared,
     Rejoined,
-    RefreshInlayHints(LanguageServerId),
+    RefreshInlayHints {
+        server_id: LanguageServerId,
+        request_id: Option<usize>,
+    },
     RefreshCodeLens,
     RevealInProjectPanel(ProjectEntryId),
     SnippetEdit(BufferId, Vec<(lsp::Range, Snippet)>),
@@ -3074,9 +3077,13 @@ impl Project {
                     return;
                 };
             }
-            LspStoreEvent::RefreshInlayHints(server_id) => {
-                cx.emit(Event::RefreshInlayHints(*server_id))
-            }
+            LspStoreEvent::RefreshInlayHints {
+                server_id,
+                request_id,
+            } => cx.emit(Event::RefreshInlayHints {
+                server_id: *server_id,
+                request_id: *request_id,
+            }),
             LspStoreEvent::RefreshCodeLens => cx.emit(Event::RefreshCodeLens),
             LspStoreEvent::LanguageServerPrompt(prompt) => {
                 cx.emit(Event::LanguageServerPrompt(prompt.clone()))

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -1817,13 +1817,6 @@ async fn test_disk_based_diagnostics_progress(cx: &mut gpui::TestAppContext) {
         .await;
     assert_eq!(
         events.next().await.unwrap(),
-        Event::RefreshInlayHints {
-            server_id: fake_server.server.server_id(),
-            request_id: None,
-        }
-    );
-    assert_eq!(
-        events.next().await.unwrap(),
         Event::DiskBasedDiagnosticsStarted {
             language_server_id: LanguageServerId(0),
         }
@@ -1959,13 +1952,6 @@ async fn test_restarting_server_with_diagnostics_running(cx: &mut gpui::TestAppC
             fake_server.server.name(),
             Some(worktree_id)
         )
-    );
-    assert_eq!(
-        events.next().await.unwrap(),
-        Event::RefreshInlayHints {
-            server_id: fake_server.server.server_id(),
-            request_id: None,
-        }
     );
     fake_server.start_progress(progress_token).await;
     assert_eq!(

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -1817,7 +1817,10 @@ async fn test_disk_based_diagnostics_progress(cx: &mut gpui::TestAppContext) {
         .await;
     assert_eq!(
         events.next().await.unwrap(),
-        Event::RefreshInlayHints(fake_server.server.server_id())
+        Event::RefreshInlayHints {
+            server_id: fake_server.server.server_id(),
+            request_id: None,
+        }
     );
     assert_eq!(
         events.next().await.unwrap(),
@@ -1959,7 +1962,10 @@ async fn test_restarting_server_with_diagnostics_running(cx: &mut gpui::TestAppC
     );
     assert_eq!(
         events.next().await.unwrap(),
-        Event::RefreshInlayHints(fake_server.server.server_id())
+        Event::RefreshInlayHints {
+            server_id: fake_server.server.server_id(),
+            request_id: None,
+        }
     );
     fake_server.start_progress(progress_token).await;
     assert_eq!(

--- a/crates/proto/proto/lsp.proto
+++ b/crates/proto/proto/lsp.proto
@@ -466,6 +466,7 @@ message ResolveInlayHintResponse {
 message RefreshInlayHints {
     uint64 project_id = 1;
     uint64 server_id = 2;
+    optional uint64 request_id = 3;
 }
 
 message CodeLens {

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -4412,16 +4412,16 @@ pub mod tests {
             );
         });
         project.update(cx, |_, cx| {
-            cx.emit(project::Event::RefreshInlayHints(
-                fake_server.server.server_id(),
-            ));
+            cx.emit(project::Event::RefreshInlayHints {
+                server_id: fake_server.server.server_id(),
+                request_id: Some(1),
+            });
         });
         cx.executor().advance_clock(Duration::from_secs(1));
         cx.executor().run_until_parked();
         assert_eq!(
             requests_count.load(atomic::Ordering::Acquire),
-            // TODO kb should be 5
-            6,
+            5,
             "After a simulated server refresh request, we should have sent another request",
         );
 
@@ -4430,8 +4430,7 @@ pub mod tests {
         cx.executor().run_until_parked();
         assert_eq!(
             requests_count.load(atomic::Ordering::Acquire),
-            // TODO kb should be 5
-            6,
+            5,
             "New project search should reuse the cached hints",
         );
         search_view

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -4320,7 +4320,7 @@ pub mod tests {
 
         // Can do the 2nd search without any panics
         perform_search(search_view, "let ", cx);
-        cx.executor().advance_clock(Duration::from_millis(100));
+        cx.executor().advance_clock(Duration::from_secs(1));
         cx.executor().run_until_parked();
         search_view
             .update(cx, |search_view, _, cx| {
@@ -4386,8 +4386,7 @@ pub mod tests {
         });
         assert_eq!(
             requests_count.load(atomic::Ordering::Acquire),
-            // TODO kb this is wrong, should be 3
-            4,
+            3,
             "We have edited the buffer and should send a new request",
         );
 
@@ -4402,8 +4401,7 @@ pub mod tests {
         cx.executor().run_until_parked();
         assert_eq!(
             requests_count.load(atomic::Ordering::Acquire),
-            // TODO kb this is wrong, should be 4
-            6,
+            4,
             "We have edited the buffer again and should send a new request again",
         );
         singleton_editor.update(cx, |editor, cx| {
@@ -4419,7 +4417,7 @@ pub mod tests {
         cx.executor().run_until_parked();
         assert_eq!(
             requests_count.load(atomic::Ordering::Acquire),
-            6,
+            4,
             "New project search should reuse the cached hints",
         );
         search_view


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/40183

Release Notes:

- (Preview only) Fixed inlay hints duplicating when multiple editors are open for the same buffer
