### PR TITLE
Show modal hover for one-off tasks

### DIFF
--- a/crates/tasks_ui/src/modal.rs
+++ b/crates/tasks_ui/src/modal.rs
@@ -448,11 +448,12 @@ impl PickerDelegate for TasksModalDelegate {
         let template = resolved_task.original_task();
         let display_label = resolved_task.display_label();
 
-        let mut tooltip_label_text = if display_label != &template.label {
-            resolved_task.resolved_label.clone()
-        } else {
-            String::new()
-        };
+        let mut tooltip_label_text =
+            if display_label != &template.label || source_kind == &TaskSourceKind::UserInput {
+                resolved_task.resolved_label.clone()
+            } else {
+                String::new()
+            };
 
         if resolved_task.resolved.command_label != resolved_task.resolved_label {
             if !tooltip_label_text.trim().is_empty() {


### PR DESCRIPTION
Before, one-off commands did not show anything on hover at all, now they show their command:

<img width="657" height="527" alt="after" src="https://github.com/user-attachments/assets/d43292ca-9101-4a6a-b689-828277e8cfeb" />

Release Notes:

- Show modal hover for one-off tasks
