### PR TITLE
Fix bug with uninstalled agent extensions

### DIFF
--- a/crates/project/src/agent_server_store.rs
+++ b/crates/project/src/agent_server_store.rs
@@ -136,7 +136,7 @@ impl EventEmitter<AgentServersUpdated> for AgentServerStore {}
 #[cfg(test)]
 mod ext_agent_tests {
     use super::*;
-    use std::fmt::Write as _;
+    use std::{collections::HashSet, fmt::Write as _};
 
     // Helper to build a store in Collab mode so we can mutate internal maps without
     // needing to spin up a full project environment.

--- a/crates/project/src/agent_server_store.rs
+++ b/crates/project/src/agent_server_store.rs
@@ -250,6 +250,8 @@ impl AgentServerStore {
                 self.agent_icons.remove(name);
                 false
             } else {
+                // Keep the hardcoded external agents that don't come from extensions
+                // (In the future we may move these over to being extensions too.)
                 true
             }
         });

--- a/crates/project/src/agent_server_store.rs
+++ b/crates/project/src/agent_server_store.rs
@@ -246,11 +246,11 @@ impl AgentServerStore {
         // Remove all extension-provided agents
         // (They will be re-added below if they're in the currently installed extensions)
         self.external_agents.retain(|name, agent| {
-            if agent.downcast_mut::<LocalExtensionArchiveAgent>().is_none() {
-                true
-            } else {
+            if agent.downcast_mut::<LocalExtensionArchiveAgent>().is_some() {
                 self.agent_icons.remove(name);
                 false
+            } else {
+                true
             }
         });
 

--- a/crates/project/src/agent_server_store.rs
+++ b/crates/project/src/agent_server_store.rs
@@ -1,6 +1,7 @@
 use std::{
     any::Any,
     borrow::Borrow,
+    collections::HashSet,
     path::{Path, PathBuf},
     str::FromStr as _,
     sync::Arc,
@@ -136,7 +137,7 @@ impl EventEmitter<AgentServersUpdated> for AgentServerStore {}
 #[cfg(test)]
 mod ext_agent_tests {
     use super::*;
-    use std::{collections::HashSet, fmt::Write as _};
+    use std::fmt::Write as _;
 
     // Helper to build a store in Collab mode so we can mutate internal maps without
     // needing to spin up a full project environment.

--- a/crates/project/src/agent_server_store.rs
+++ b/crates/project/src/agent_server_store.rs
@@ -243,8 +243,8 @@ impl AgentServerStore {
         // Collect manifests first so we can iterate twice
         let manifests: Vec<_> = manifests.into_iter().collect();
 
-        // Remove all extension-provided agents (LocalExtensionArchiveAgent)
-        // They will be re-added below if they're in the currently installed extensions
+        // Remove all extension-provided agents
+        // (They will be re-added below if they're in the currently installed extensions)
         let keys_to_remove: Vec<_> = self
             .external_agents
             .iter_mut()

--- a/crates/project/src/agent_server_store.rs
+++ b/crates/project/src/agent_server_store.rs
@@ -245,21 +245,14 @@ impl AgentServerStore {
 
         // Remove all extension-provided agents
         // (They will be re-added below if they're in the currently installed extensions)
-        let keys_to_remove: Vec<_> = self
-            .external_agents
-            .iter_mut()
-            .filter_map(|(name, agent)| {
-                if agent.downcast_mut::<LocalExtensionArchiveAgent>().is_some() {
-                    Some(name.clone())
-                } else {
-                    None
-                }
-            })
-            .collect();
-        for key in &keys_to_remove {
-            self.external_agents.remove(key);
-            self.agent_icons.remove(key);
-        }
+        self.external_agents.retain(|name, agent| {
+            if agent.downcast_mut::<LocalExtensionArchiveAgent>().is_none() {
+                true
+            } else {
+                self.agent_icons.remove(name);
+                false
+            }
+        });
 
         // Insert agent servers from extension manifests
         match &self.state {

--- a/crates/project/src/agent_server_store.rs
+++ b/crates/project/src/agent_server_store.rs
@@ -1,7 +1,6 @@
 use std::{
     any::Any,
     borrow::Borrow,
-    collections::HashSet,
     path::{Path, PathBuf},
     str::FromStr as _,
     sync::Arc,


### PR DESCRIPTION
Previously, uninstalled agent extensions didn't immediately disappear from the menu. Now, they do!

Release Notes:

- After uninstalling an Agent Server Extension, the agent's icon now disappears from the menu immediately (instead of after next Zed restart)