### PR TITLE
file_finder: Fix duplicate "open this dictionary" entries

### DIFF
--- a/crates/file_finder/src/open_path_prompt.rs
+++ b/crates/file_finder/src/open_path_prompt.rs
@@ -399,7 +399,12 @@ impl PickerDelegate for OpenPathDelegate {
                             }
                     })
                     .unwrap_or(false);
-                if should_prepend_with_current_dir {
+
+                let current_dir_in_new_entries = new_entries
+                    .iter()
+                    .any(|entry| &entry.path.string == current_dir);
+
+                if should_prepend_with_current_dir && !current_dir_in_new_entries {
                     new_entries.insert(
                         0,
                         CandidateInfo {


### PR DESCRIPTION

Release Notes:

- Fixed an issue when adding a Python virtual environment that may cause duplicate "open this dictionary" entries

- Trigger condition:
Type `C:\`, delete `\`, then repeatedly add `\`.

-Video

bug:
https://github.com/user-attachments/assets/f68008bb-9138-4451-a842-25b58574493b

fix:
https://github.com/user-attachments/assets/2913b8c2-adee-4275-af7e-e055fd78915f

