### PR TITLE
gpui: Use DWM API for backdrop effects and add Mica/Mica Alt support

### DIFF
--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -1392,7 +1392,7 @@ pub enum WindowBackgroundAppearance {
     /// The Mica backdrop material, supported on Windows 11.
     MicaBackdrop,
     /// The Mica Alt backdrop material, supported on Windows 11.
-    MicaAltBackdrop
+    MicaAltBackdrop,
 }
 
 /// The options that can be configured for a file dialog prompt

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -1389,24 +1389,9 @@ pub enum WindowBackgroundAppearance {
     ///
     /// Not always supported.
     Blurred,
-    /// The Mica backdrop material used in Windows 11.
-    ///
-    /// This effect blends the window background with the desktop wallpaper
-    /// to produce a soft, tinted translucency that subtly tracks wallpaper
-    /// movement. It’s designed to provide depth and visual hierarchy while
-    /// remaining performance-friendly.
-    ///
-    /// Only available on Windows 11 (build ≥ 22000) and supported for
-    /// top-level windows.
+    /// The Mica backdrop material, supported on Windows 11.
     MicaBackdrop,
-    /// The Mica Alt (or Tabbed Mica) backdrop material used in Windows 11.
-    ///
-    /// A variant of Mica optimized for use in tabbed or layered interfaces.
-    /// It has a slightly stronger tint and reduced opacity to help distinguish
-    /// stacked surfaces such as document tabs or panels.
-    ///
-    /// Only available on Windows 11 (build ≥ 22621) and supported for
-    /// top-level windows.
+    /// The Mica Alt backdrop material, supported on Windows 11.
     MicaAltBackdrop
 }
 

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -1389,6 +1389,25 @@ pub enum WindowBackgroundAppearance {
     ///
     /// Not always supported.
     Blurred,
+    /// The Mica backdrop material used in Windows 11.
+    ///
+    /// This effect blends the window background with the desktop wallpaper
+    /// to produce a soft, tinted translucency that subtly tracks wallpaper
+    /// movement. It’s designed to provide depth and visual hierarchy while
+    /// remaining performance-friendly.
+    ///
+    /// Only available on Windows 11 (build ≥ 22000) and supported for
+    /// top-level windows.
+    MicaBackdrop,
+    /// The Mica Alt (or Tabbed Mica) backdrop material used in Windows 11.
+    ///
+    /// A variant of Mica optimized for use in tabbed or layered interfaces.
+    /// It has a slightly stronger tint and reduced opacity to help distinguish
+    /// stacked surfaces such as document tabs or panels.
+    ///
+    /// Only available on Windows 11 (build ≥ 22621) and supported for
+    /// top-level windows.
+    MicaAltBackdrop
 }
 
 /// The options that can be configured for a file dialog prompt

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -18,8 +18,8 @@ use smallvec::SmallVec;
 use windows::{
     Win32::{
         Foundation::*,
-        Graphics::Gdi::*,
         Graphics::Dwm::*,
+        Graphics::Gdi::*,
         System::{Com::*, LibraryLoader::*, Ole::*, SystemServices::*},
         UI::{Controls::*, HiDpi::*, Input::KeyboardAndMouse::*, Shell::*, WindowsAndMessaging::*},
     },
@@ -782,10 +782,10 @@ impl PlatformWindow for WindowsWindow {
             }
             WindowBackgroundAppearance::Transparent => {
                 set_window_composition_attribute(hwnd, None, 2);
-            },
+            }
             WindowBackgroundAppearance::Blurred => {
                 set_window_composition_attribute(hwnd, Some((0, 0, 0, 0)), 4);
-            },
+            }
             WindowBackgroundAppearance::MicaBackdrop => {
                 // DWMSBT_MAINWINDOW => MicaBase
                 dwm_set_window_composition_attribute(hwnd, 2);
@@ -1340,13 +1340,13 @@ fn retrieve_window_placement(
 fn dwm_set_window_composition_attribute(hwnd: HWND, backdrop_type: u32) {
     let mut version = unsafe { std::mem::zeroed() };
     let status = unsafe { windows::Wdk::System::SystemServices::RtlGetVersion(&mut version) };
-    
+
     // DWMWA_SYSTEMBACKDROP_TYPE is available only on version 22621 or later
     // using SetWindowCompositionAttributeType as a fallback
     if !status.is_ok() || version.dwBuildNumber < 22621 {
         return;
     }
-    
+
     unsafe {
         let result = DwmSetWindowAttribute(
             hwnd,
@@ -1364,11 +1364,11 @@ fn dwm_set_window_composition_attribute(hwnd: HWND, backdrop_type: u32) {
 fn set_window_composition_attribute(hwnd: HWND, color: Option<Color>, state: u32) {
     let mut version = unsafe { std::mem::zeroed() };
     let status = unsafe { windows::Wdk::System::SystemServices::RtlGetVersion(&mut version) };
-    
+
     if !status.is_ok() || version.dwBuildNumber < 17763 {
         return;
     }
-    
+
     unsafe {
         type SetWindowCompositionAttributeType =
             unsafe extern "system" fn(HWND, *mut WINDOWCOMPOSITIONATTRIBDATA) -> BOOL;


### PR DESCRIPTION
This PR updates window background rendering to use the **official DWM backdrop API** (`DwmSetWindowAttribute`) instead of the legacy `SetWindowCompositionAttribute`.
It also adds **Mica** and **Mica Alt** options to `WindowBackgroundAppearance` for native Windows 11 effects.

### Motivation

Enables modern, stable, and GPU-accelerated backdrops consistent with Windows 11’s Fluent Design.
Removes reliance on undocumented APIs while maintaining backward compatibility with older Windows versions.

### Changes

* Added `MicaBackdrop` and `MicaAltBackdrop` variants.
* Switched to DWM API for applying backdrop effects.
* Verified fallback behavior on Windows 10.

### Release Notes:

- Added `WindowBackgroundAppearance::MicaBackdrop` and `WindowBackgroundAppearance::MicaAltBackdrop` for Windows 11 Mica and Mica Alt window backdrops. 

### Screenshots

- `WindowBackgroundAppearance::Blurred`
<img width="553" height="354" alt="image" src="https://github.com/user-attachments/assets/57c9c25d-9412-4141-94b5-00000cc0b1ec" />

- `WindowBackgroundAppearance::MicaBackdrop`
<img width="553" height="354" alt="image" src="https://github.com/user-attachments/assets/019f541c-3335-4c9e-b026-71f5a1786534" />

- `WindowBackgroundAppearance::MicaAltBackdrop`
<img width="553" height="354" alt="image" src="https://github.com/user-attachments/assets/5128d600-c94d-4c89-b81a-8b842fe1337a" />

