### PR TITLE
gpui: Add 'Nearest' scrolling strategy to 'UniformList'

### DIFF
--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -460,8 +460,13 @@ impl CompletionsMenu {
         cx: &mut Context<Editor>,
     ) {
         if self.selected_item != match_index {
+            let strategy = if match_index > self.selected_item {
+                ScrollStrategy::Bottom
+            } else {
+                ScrollStrategy::Top
+            };
             self.selected_item = match_index;
-            self.handle_selection_changed(provider, window, cx);
+            self.handle_selection_changed(provider, window, cx, strategy);
         }
     }
 
@@ -486,9 +491,10 @@ impl CompletionsMenu {
         provider: Option<&dyn CompletionProvider>,
         window: &mut Window,
         cx: &mut Context<Editor>,
+        strategy: ScrollStrategy,
     ) {
         self.scroll_handle
-            .scroll_to_item(self.selected_item, ScrollStrategy::Top);
+            .scroll_to_item(self.selected_item, strategy);
         if let Some(provider) = provider {
             let entries = self.entries.borrow();
             let entry = if self.selected_item < entries.len() {
@@ -1124,7 +1130,7 @@ impl CompletionsMenu {
     ) {
         *self.entries.borrow_mut() = matches.into_boxed_slice();
         self.selected_item = 0;
-        self.handle_selection_changed(provider.as_deref(), window, cx);
+        self.handle_selection_changed(provider.as_deref(), window, cx, ScrollStrategy::Top);
     }
 
     pub fn sort_string_matches(

--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -488,7 +488,7 @@ impl CompletionsMenu {
         cx: &mut Context<Editor>,
     ) {
         self.scroll_handle
-            .scroll_to_item(self.selected_item, ScrollStrategy::Top);
+            .scroll_to_item(self.selected_item, ScrollStrategy::Nearest);
         if let Some(provider) = provider {
             let entries = self.entries.borrow();
             let entry = if self.selected_item < entries.len() {

--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -460,13 +460,8 @@ impl CompletionsMenu {
         cx: &mut Context<Editor>,
     ) {
         if self.selected_item != match_index {
-            let strategy = if match_index > self.selected_item {
-                ScrollStrategy::Bottom
-            } else {
-                ScrollStrategy::Top
-            };
             self.selected_item = match_index;
-            self.handle_selection_changed(provider, window, cx, strategy);
+            self.handle_selection_changed(provider, window, cx);
         }
     }
 
@@ -491,10 +486,9 @@ impl CompletionsMenu {
         provider: Option<&dyn CompletionProvider>,
         window: &mut Window,
         cx: &mut Context<Editor>,
-        strategy: ScrollStrategy,
     ) {
         self.scroll_handle
-            .scroll_to_item(self.selected_item, strategy);
+            .scroll_to_item(self.selected_item, ScrollStrategy::Top);
         if let Some(provider) = provider {
             let entries = self.entries.borrow();
             let entry = if self.selected_item < entries.len() {
@@ -1130,7 +1124,7 @@ impl CompletionsMenu {
     ) {
         *self.entries.borrow_mut() = matches.into_boxed_slice();
         self.selected_item = 0;
-        self.handle_selection_changed(provider.as_deref(), window, cx, ScrollStrategy::Top);
+        self.handle_selection_changed(provider.as_deref(), window, cx);
     }
 
     pub fn sort_string_matches(

--- a/crates/gpui/src/elements/uniform_list.rs
+++ b/crates/gpui/src/elements/uniform_list.rs
@@ -433,8 +433,7 @@ impl Element for UniformList {
                                         .max(Pixels::ZERO);
                                 }
                                 ScrollStrategy::Bottom => {
-                                    updated_scroll_offset.y = -(item_bottom - list_height
-                                        + offset_pixels)
+                                    updated_scroll_offset.y = -(item_bottom - list_height)
                                         .max(Pixels::ZERO)
                                         .min(content_height - list_height)
                                         .max(Pixels::ZERO);

--- a/crates/gpui/src/elements/uniform_list.rs
+++ b/crates/gpui/src/elements/uniform_list.rs
@@ -402,23 +402,18 @@ impl Element for UniformList {
                         let item_bottom = item_top + item_height;
                         let scroll_top = -updated_scroll_offset.y;
                         let offset_pixels = item_height * deferred_scroll.offset;
-                        let mut scrolled_to_top = false;
 
-                        if item_top < scroll_top + offset_pixels {
-                            scrolled_to_top = true;
-                            // todo: using the padding here is wrong - this only works well for few scenarios
-                            updated_scroll_offset.y = -item_top + padding.top + offset_pixels;
+                        let scroll_strategy = if deferred_scroll.scroll_strict {
+                            Some(deferred_scroll.strategy)
+                        } else if item_top < scroll_top + offset_pixels {
+                            Some(ScrollStrategy::Top)
                         } else if item_bottom > scroll_top + list_height {
-                            scrolled_to_top = true;
-                            updated_scroll_offset.y = -(item_bottom - list_height);
-                        }
-
-                        if deferred_scroll.scroll_strict
-                            || (scrolled_to_top
-                                && (item_top < scroll_top + offset_pixels
-                                    || item_bottom > scroll_top + list_height))
-                        {
-                            match deferred_scroll.strategy {
+                            Some(ScrollStrategy::Bottom)
+                        } else {
+                            None
+                        };
+                        if let Some(scroll_strategy) = scroll_strategy {
+                            match scroll_strategy {
                                 ScrollStrategy::Top => {
                                     updated_scroll_offset.y = -(item_top - offset_pixels)
                                         .max(Pixels::ZERO)

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -709,7 +709,7 @@ impl<D: PickerDelegate> Picker<D> {
         match &mut self.element_container {
             ElementContainer::List(state) => state.scroll_to_reveal_item(ix),
             ElementContainer::UniformList(scroll_handle) => {
-                scroll_handle.scroll_to_item(ix, ScrollStrategy::Top)
+                scroll_handle.scroll_to_item(ix, ScrollStrategy::Nearest)
             }
         }
     }


### PR DESCRIPTION
This PR introduces `Nearest` scrolling strategy to `UniformList`. This is now used in completions menu and the picker to choose the appropriate scrolling strategy depending on movement direction. Previously, selecting the next element after the last visible item caused the menu to scroll with `ScrollStrategy::Top`, which scrolled the whole page and placed the next element at the top. This behavior is inconsistent, because using `ScrollStrategy::Top` when moving up only scrolls one element, not the whole page.

https://github.com/user-attachments/assets/ccfb238f-8f76-4a18-a18d-bbcb63340c5a

The solution is to introduce the `Nearest` scrolling strategy which will internally choose the scrolling strategy depending on whether the new selected item is below or above currently visible items. This ensures a single-item scroll regardless of movement direction.

https://github.com/user-attachments/assets/8502efb8-e2c0-4ab1-bd8d-93103841a9c4


I also noticed that some functions in the file have different logic depending on `y_flipped`. This appears related to reversing the order of elements in the list when the completion menu appears above the cursor. This was a feature suggested in #11200 and implemented in #23446. It looks like this feature was reverted in #27765 and there currently seem to be no way to have `y_flipped` to be set to `true`. 

My understanding is that the opposite scroll strategy should be used if `y_flipped`, but since there is no way to enable this feature to test it and I don't know if the feature is ever going to be reintroduced I decided not to include it in this PR.


Release Notes:

- gpui: Add 'Nearest' scrolling strategy to 'UniformList'
