### PR TITLE
ruby: Add note about enabling Ruby LSP for ERB files

### DIFF
--- a/docs/src/languages/ruby.md
+++ b/docs/src/languages/ruby.md
@@ -71,6 +71,18 @@ To switch to `ruby-lsp`, add the following to your `settings.json`:
   "languages": {
     "Ruby": {
       "language_servers": ["ruby-lsp", "!solargraph", "!rubocop", "..."]
+    },
+    // Enable herb and ruby-lsp for *.html.erb files
+    "HTML+ERB": {
+      "language_servers": ["herb", "ruby-lsp", "..."]
+    },
+    // Enable ruby-lsp for *.js.erb files
+    "JS+ERB": {
+      "language_servers": ["ruby-lsp", "..."]
+    },
+    // Enable ruby-lsp for *.yaml.erb files
+    "YAML+ERB": {
+      "language_servers": ["ruby-lsp", "..."]
     }
   }
 }


### PR DESCRIPTION
Hi, this is a follow-up change for https://github.com/zed-industries/zed/pull/41754 I think it important to keep existing things working. So add notes to the Ruby extension doc about enabling Ruby LSP for ERB files as well. Thanks!

Release Notes:

- N/A
