### PR TITLE
agent: History and recent conversations persistence per workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,6 +202,7 @@ dependencies = [
  "uuid",
  "watch",
  "web_search",
+ "workspace",
  "worktree",
  "zed_env_vars",
  "zlog",

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -71,6 +71,7 @@ util.workspace = true
 uuid.workspace = true
 watch.workspace = true
 web_search.workspace = true
+workspace.workspace = true
 zed_env_vars.workspace = true
 zstd.workspace = true
 

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -1269,7 +1269,8 @@ mod internal_tests {
         let project = Project::test(fs.clone(), [], cx).await;
         let text_thread_store =
             cx.new(|cx| assistant_text_thread::TextThreadStore::fake(project.clone(), cx));
-        let history_store = cx.new(|cx| HistoryStore::new(text_thread_store, cx));
+        let history_store =
+            cx.new(|cx| HistoryStore::new(text_thread_store, HistoryScope::global(), cx));
         let agent = NativeAgent::new(
             project.clone(),
             history_store,
@@ -1331,7 +1332,8 @@ mod internal_tests {
         let project = Project::test(fs.clone(), [], cx).await;
         let text_thread_store =
             cx.new(|cx| assistant_text_thread::TextThreadStore::fake(project.clone(), cx));
-        let history_store = cx.new(|cx| HistoryStore::new(text_thread_store, cx));
+        let history_store =
+            cx.new(|cx| HistoryStore::new(text_thread_store, HistoryScope::global(), cx));
         let connection = NativeAgentConnection(
             NativeAgent::new(
                 project.clone(),
@@ -1407,7 +1409,8 @@ mod internal_tests {
 
         let text_thread_store =
             cx.new(|cx| assistant_text_thread::TextThreadStore::fake(project.clone(), cx));
-        let history_store = cx.new(|cx| HistoryStore::new(text_thread_store, cx));
+        let history_store =
+            cx.new(|cx| HistoryStore::new(text_thread_store, HistoryScope::global(), cx));
 
         // Create the agent and connection
         let agent = NativeAgent::new(
@@ -1480,7 +1483,8 @@ mod internal_tests {
         let project = Project::test(fs.clone(), [path!("/a").as_ref()], cx).await;
         let text_thread_store =
             cx.new(|cx| assistant_text_thread::TextThreadStore::fake(project.clone(), cx));
-        let history_store = cx.new(|cx| HistoryStore::new(text_thread_store, cx));
+        let history_store =
+            cx.new(|cx| HistoryStore::new(text_thread_store, HistoryScope::global(), cx));
         let agent = NativeAgent::new(
             project.clone(),
             history_store.clone(),

--- a/crates/agent/src/native_agent_server.rs
+++ b/crates/agent/src/native_agent_server.rs
@@ -118,7 +118,9 @@ mod tests {
             let history = cx.update(|cx| {
                 let text_thread_store =
                     cx.new(move |cx| TextThreadStore::fake(project.clone(), cx));
-                cx.new(move |cx| HistoryStore::new(text_thread_store, cx))
+                cx.new(move |cx| {
+                    HistoryStore::new(text_thread_store, crate::HistoryScope::global(), cx)
+                })
             });
 
             NativeAgentServer::new(fs.clone(), history)

--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -1872,7 +1872,8 @@ async fn test_agent_connection(cx: &mut TestAppContext) {
     let cwd = Path::new("/test");
     let text_thread_store =
         cx.new(|cx| assistant_text_thread::TextThreadStore::fake(project.clone(), cx));
-    let history_store = cx.new(|cx| HistoryStore::new(text_thread_store, cx));
+    let history_store =
+        cx.new(|cx| HistoryStore::new(text_thread_store, HistoryScope::global(), cx));
 
     // Create agent and connection
     let agent = NativeAgent::new(

--- a/crates/agent_ui/src/acp/entry_view_state.rs
+++ b/crates/agent_ui/src/acp/entry_view_state.rs
@@ -399,7 +399,7 @@ mod tests {
     use std::{path::Path, rc::Rc};
 
     use acp_thread::{AgentConnection, StubAgentConnection};
-    use agent::HistoryStore;
+    use agent::{HistoryScope, HistoryStore};
     use agent_client_protocol as acp;
     use agent_settings::AgentSettings;
     use assistant_text_thread::TextThreadStore;
@@ -467,7 +467,8 @@ mod tests {
         });
 
         let text_thread_store = cx.new(|cx| TextThreadStore::fake(project.clone(), cx));
-        let history_store = cx.new(|cx| HistoryStore::new(text_thread_store, cx));
+        let history_store =
+            cx.new(|cx| HistoryStore::new(text_thread_store, HistoryScope::global(), cx));
 
         let view_state = cx.new(|_cx| {
             EntryViewState::new(

--- a/crates/agent_ui/src/acp/message_editor.rs
+++ b/crates/agent_ui/src/acp/message_editor.rs
@@ -1607,7 +1607,7 @@ mod tests {
     use std::{cell::RefCell, ops::Range, path::Path, rc::Rc, sync::Arc};
 
     use acp_thread::MentionUri;
-    use agent::{HistoryStore, outline};
+    use agent::{HistoryScope, HistoryStore, outline};
     use agent_client_protocol as acp;
     use assistant_text_thread::TextThreadStore;
     use editor::{AnchorRangeExt as _, Editor, EditorMode};
@@ -1642,7 +1642,8 @@ mod tests {
             cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
 
         let text_thread_store = cx.new(|cx| TextThreadStore::fake(project.clone(), cx));
-        let history_store = cx.new(|cx| HistoryStore::new(text_thread_store, cx));
+        let history_store =
+            cx.new(|cx| HistoryStore::new(text_thread_store, HistoryScope::global(), cx));
 
         let message_editor = cx.update(|window, cx| {
             cx.new(|cx| {
@@ -1747,7 +1748,8 @@ mod tests {
 
         let project = Project::test(fs.clone(), ["/test".as_ref()], cx).await;
         let text_thread_store = cx.new(|cx| TextThreadStore::fake(project.clone(), cx));
-        let history_store = cx.new(|cx| HistoryStore::new(text_thread_store, cx));
+        let history_store =
+            cx.new(|cx| HistoryStore::new(text_thread_store, HistoryScope::global(), cx));
         let prompt_capabilities = Rc::new(RefCell::new(acp::PromptCapabilities::default()));
         // Start with no available commands - simulating Claude which doesn't support slash commands
         let available_commands = Rc::new(RefCell::new(vec![]));
@@ -1911,8 +1913,10 @@ mod tests {
         let mut cx = VisualTestContext::from_window(*window, cx);
 
         let text_thread_store = cx.new(|cx| TextThreadStore::fake(project.clone(), cx));
-        let history_store = cx.new(|cx| HistoryStore::new(text_thread_store, cx));
+        let history_store =
+            cx.new(|cx| HistoryStore::new(text_thread_store, HistoryScope::global(), cx));
         let prompt_capabilities = Rc::new(RefCell::new(acp::PromptCapabilities::default()));
+
         let available_commands = Rc::new(RefCell::new(vec![
             acp::AvailableCommand {
                 name: "quick-math".to_string(),
@@ -2151,7 +2155,8 @@ mod tests {
         }
 
         let text_thread_store = cx.new(|cx| TextThreadStore::fake(project.clone(), cx));
-        let history_store = cx.new(|cx| HistoryStore::new(text_thread_store, cx));
+        let history_store =
+            cx.new(|cx| HistoryStore::new(text_thread_store, HistoryScope::global(), cx));
         let prompt_capabilities = Rc::new(RefCell::new(acp::PromptCapabilities::default()));
 
         let (message_editor, editor) = workspace.update_in(&mut cx, |workspace, window, cx| {
@@ -2687,7 +2692,8 @@ mod tests {
             cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
 
         let text_thread_store = cx.new(|cx| TextThreadStore::fake(project.clone(), cx));
-        let history_store = cx.new(|cx| HistoryStore::new(text_thread_store, cx));
+        let history_store =
+            cx.new(|cx| HistoryStore::new(text_thread_store, HistoryScope::global(), cx));
 
         let message_editor = cx.update(|window, cx| {
             cx.new(|cx| {
@@ -2776,7 +2782,8 @@ mod tests {
             cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
 
         let text_thread_store = cx.new(|cx| TextThreadStore::fake(project.clone(), cx));
-        let history_store = cx.new(|cx| HistoryStore::new(text_thread_store, cx));
+        let history_store =
+            cx.new(|cx| HistoryStore::new(text_thread_store, HistoryScope::global(), cx));
 
         // Create a thread metadata to insert as summary
         let thread_metadata = agent::DbThreadMetadata {
@@ -2852,7 +2859,8 @@ mod tests {
             cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
 
         let text_thread_store = cx.new(|cx| TextThreadStore::fake(project.clone(), cx));
-        let history_store = cx.new(|cx| HistoryStore::new(text_thread_store, cx));
+        let history_store =
+            cx.new(|cx| HistoryStore::new(text_thread_store, HistoryScope::global(), cx));
 
         let message_editor = cx.update(|window, cx| {
             cx.new(|cx| {
@@ -2962,7 +2970,8 @@ mod tests {
         });
 
         let text_thread_store = cx.new(|cx| TextThreadStore::fake(project.clone(), cx));
-        let history_store = cx.new(|cx| HistoryStore::new(text_thread_store, cx));
+        let history_store =
+            cx.new(|cx| HistoryStore::new(text_thread_store, HistoryScope::global(), cx));
 
         // Create a new `MessageEditor`. The `EditorMode::full()` has to be used
         // to ensure we have a fixed viewport, so we can eventually actually

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -5764,6 +5764,7 @@ fn terminal_command_markdown_style(window: &Window, cx: &App) -> MarkdownStyle {
 #[cfg(test)]
 pub(crate) mod tests {
     use acp_thread::StubAgentConnection;
+    use agent::HistoryScope;
     use agent_client_protocol::SessionId;
     use assistant_text_thread::TextThreadStore;
     use editor::EditorSettings;
@@ -6031,8 +6032,9 @@ pub(crate) mod tests {
 
         let text_thread_store =
             cx.update(|_window, cx| cx.new(|cx| TextThreadStore::fake(project.clone(), cx)));
-        let history_store =
-            cx.update(|_window, cx| cx.new(|cx| HistoryStore::new(text_thread_store, cx)));
+        let history_store = cx.update(|_window, cx| {
+            cx.new(|cx| HistoryStore::new(text_thread_store, HistoryScope::global(), cx))
+        });
 
         let thread_view = cx.update(|window, cx| {
             cx.new(|cx| {
@@ -6306,8 +6308,9 @@ pub(crate) mod tests {
 
         let text_thread_store =
             cx.update(|_window, cx| cx.new(|cx| TextThreadStore::fake(project.clone(), cx)));
-        let history_store =
-            cx.update(|_window, cx| cx.new(|cx| HistoryStore::new(text_thread_store, cx)));
+        let history_store = cx.update(|_window, cx| {
+            cx.new(|cx| HistoryStore::new(text_thread_store, HistoryScope::global(), cx))
+        });
 
         let connection = Rc::new(StubAgentConnection::new());
         let thread_view = cx.update(|window, cx| {


### PR DESCRIPTION
Release Notes:

- Introduce HistoryScope to persist recent agent history using workspace-specific keys.
- Derive history scope from workspace metadata in the agent panel and reuse it across views.
- Update unit tests to account for the scoped history store behavior.