### PR TITLE
file_finder: Add ability to prioritize paths

### DIFF
--- a/crates/file_finder/src/file_finder_settings.rs
+++ b/crates/file_finder/src/file_finder_settings.rs
@@ -2,12 +2,13 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::Settings;
 
-#[derive(Deserialize, Debug, Clone, Copy, PartialEq)]
+#[derive(Deserialize, Debug, Clone, PartialEq)]
 pub struct FileFinderSettings {
     pub file_icons: bool,
     pub modal_max_width: FileFinderWidth,
     pub skip_focus_for_active_in_search: bool,
     pub include_ignored: Option<bool>,
+    pub priorities: Vec<String>,
 }
 
 impl Settings for FileFinderSettings {
@@ -23,6 +24,7 @@ impl Settings for FileFinderSettings {
                 settings::IncludeIgnoredContent::Indexed => Some(false),
                 settings::IncludeIgnoredContent::Smart => None,
             },
+            priorities: file_finder.path_priorities.clone().unwrap_or_default(),
         }
     }
 }

--- a/crates/file_finder/src/file_finder_tests.rs
+++ b/crates/file_finder/src/file_finder_tests.rs
@@ -1933,7 +1933,7 @@ async fn test_setting_auto_select_first_and_select_active_file(cx: &mut TestAppC
     let app_state = init_test(cx);
 
     cx.update(|cx| {
-        let settings = *FileFinderSettings::get_global(cx);
+        let settings = FileFinderSettings::get_global(cx).clone();
 
         FileFinderSettings::override_global(
             FileFinderSettings {

--- a/crates/file_finder/src/open_path_prompt.rs
+++ b/crates/file_finder/src/open_path_prompt.rs
@@ -711,9 +711,7 @@ impl PickerDelegate for OpenPathDelegate {
 
         match &self.directory_state {
             DirectoryState::List { parent_path, .. } => {
-                let (label, indices) = if is_current_dir_candidate {
-                    ("open this directory".to_string(), vec![])
-                } else if *parent_path == self.prompt_root {
+                let (label, indices) = if *parent_path == self.prompt_root {
                     match_positions.iter_mut().for_each(|position| {
                         *position += self.prompt_root.len();
                     });
@@ -721,6 +719,8 @@ impl PickerDelegate for OpenPathDelegate {
                         format!("{}{}", self.prompt_root, candidate.path.string),
                         match_positions,
                     )
+                } else if is_current_dir_candidate {
+                    ("open this directory".to_string(), vec![])
                 } else {
                     (candidate.path.string, match_positions)
                 };

--- a/crates/settings/src/settings_content.rs
+++ b/crates/settings/src/settings_content.rs
@@ -613,6 +613,11 @@ pub struct FileFinderSettingsContent {
     ///
     /// Default: Smart
     pub include_ignored: Option<IncludeIgnoredContent>,
+    /// Priorities for paths of files inside file finder results.
+    /// Listed in descending order.
+    ///
+    /// Default: []
+    pub path_priorities: Option<Vec<String>>,
 }
 
 #[derive(


### PR DESCRIPTION
There are no related issues as I know, although I thought about opening one myself. Later decided to just implement it myself.

Release Notes:

Add the `path_priorities` setting to File Finder related settings. It allows users in monorepos to specify paths of their projects and reliably see files from these directories on the top from withing the cmd+p search.


Right now this PR is just a POC as I want to hear your opinions on the implementation first. 
Missing:
1. new test cases
2. this setting should be read from workspace settings
3. I would like to add some visual indication of this feature, but don't know how yet