### PR TITLE
assistant_slash_commands: Fix AI text thread path display bugs on Windows and all platforms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -835,7 +835,6 @@ dependencies = [
  "fs",
  "futures 0.3.31",
  "fuzzy",
- "globset",
  "gpui",
  "html_to_markdown",
  "http_client",

--- a/crates/assistant_slash_commands/Cargo.toml
+++ b/crates/assistant_slash_commands/Cargo.toml
@@ -22,7 +22,6 @@ feature_flags.workspace = true
 fs.workspace = true
 futures.workspace = true
 fuzzy.workspace = true
-globset.workspace = true
 gpui.workspace = true
 html_to_markdown.workspace = true
 http_client.workspace = true


### PR DESCRIPTION
## Fix incorrect directory path folding in slash command file collection

**Description:**
This PR fixes a bug in the `collect_files` function where the directory folding logic (used to compact chains like `.github/workflows`) failed to reset its state when traversing out of a folded branch.

**The Issue:**
The `folded_directory_names` accumulator was persisting across loop iterations. If the traversal moved from a folded directory (e.g., `.github/workflows`) to a sibling directory (e.g., `.zed`), the sibling would incorrectly inherit the prefix of the previously folded path, resulting in incorrect paths like `.github/.zed`.

**The Fix:**
*   Introduced `folded_directory_path` to track the specific path currently being folded.
*   Added a check to reset `folded_directory_names` whenever the traversal encounters an entry that is not a child of the currently folded path.
*   Ensured state is cleared immediately after a folded directory is rendered.

**Release Notes:**
- Fixed an issue where using slash commands to collect files would sometimes display incorrect directory paths (e.g., showing `.github/.zed` instead of `.zed`) when adjacent directories were automatically folded.