### PR TITLE
Fix pinned tab causing resize loop on adjacent tab

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -3081,13 +3081,6 @@ impl Pane {
         let unpinned_tabs = tab_items.split_off(self.pinned_tab_count);
         let pinned_tabs = tab_items;
 
-        // Avoid flickering when max_offset is very small (< 2px).
-        // The border adds 1-2px which can push max_offset back to 0, creating a loop.
-        let max_scroll = self.tab_bar_scroll_handle.max_offset().width;
-        let current_offset = self.tab_bar_scroll_handle.offset().x;
-        let is_scrollable = max_scroll > px(2.0);
-        let is_scrolled = current_offset < px(0.);
-
         TabBar::new("tab_bar")
             .when(
                 self.display_nav_history_buttons.unwrap_or_default(),
@@ -3109,6 +3102,12 @@ impl Pane {
                 }
             })
             .children(pinned_tabs.len().ne(&0).then(|| {
+                let max_scroll = self.tab_bar_scroll_handle.max_offset().width;
+                // We need to check both because offset returns delta values even when the scroll handle is not scrollable
+                let is_scrolled = self.tab_bar_scroll_handle.offset().x < px(0.);
+                // Avoid flickering when max_offset is very small (< 2px).
+                // The border adds 1-2px which can push max_offset back to 0, creating a loop.
+                let is_scrollable = max_scroll > px(2.0);
                 let has_active_unpinned_tab = self.active_item_index >= self.pinned_tab_count;
                 h_flex()
                     .children(pinned_tabs)


### PR DESCRIPTION
Closes #41467 

My first PR in Zed, any guidance or tips are appreciated.

This fixes the flickering/resize loop that occurred on the tab immediately to the right of a pinned tab.

Removed the conditional border on the pinned tabs container. The border was a visual indicator to show when unpinned tabs were scrolled, but it wasn't essential and was causing the layout thrashing.

Release Notes:

- Fixed