### PR TITLE
Show inlay label parts' tooltips if those are present and hovered

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1310,7 +1310,14 @@ impl EditorElement {
                 hover_at(editor, Some(anchor), window, cx);
                 Self::update_visible_cursor(editor, point, position_map, window, cx);
             } else {
-                hover_at(editor, None, window, cx);
+                editor.update_inlay_link_and_hover_points(
+                    &position_map.snapshot,
+                    point_for_position,
+                    modifiers.secondary(),
+                    modifiers.shift,
+                    window,
+                    cx,
+                );
             }
         } else {
             editor.hide_hovered_link(cx);


### PR DESCRIPTION
Part of https://github.com/zed-industries/zed/issues/33715

https://github.com/user-attachments/assets/d2d6f47d-3974-4c8c-aab9-9046891186bf

Unlike VSCode that does more advanced hovering, this one only works for inlays with tooltip LSP data in them.

Release Notes:

- Started to show inlay label parts' tooltips when they are hovered