### PR TITLE
Tidy up `Edit in json` footer entries

### DIFF
--- a/crates/debugger_ui/src/new_process_modal.rs
+++ b/crates/debugger_ui/src/new_process_modal.rs
@@ -697,6 +697,7 @@ impl Render for NewProcessModal {
                     .justify_between()
                     .border_t_1()
                     .border_color(cx.theme().colors().border_variant);
+                let secondary_action = menu::SecondaryConfirm.boxed_clone();
                 match self.mode {
                     NewProcessMode::Launch => el.child(
                         container
@@ -706,6 +707,7 @@ impl Render for NewProcessModal {
                                         .on_click(cx.listener(|this, _, window, cx| {
                                             this.save_debug_scenario(window, cx);
                                         }))
+                                        .key_binding(KeyBinding::for_action(&*secondary_action, cx))
                                         .disabled(
                                             self.debugger.is_none()
                                                 || self
@@ -749,7 +751,6 @@ impl Render for NewProcessModal {
                         container
                             .child(div().child({
                                 Button::new("edit-attach-task", "Edit in debug.json")
-                                    .label_size(LabelSize::Small)
                                     .key_binding(KeyBinding::for_action(&*secondary_action, cx))
                                     .on_click(move |_, window, cx| {
                                         window.dispatch_action(secondary_action.boxed_clone(), cx)
@@ -1192,7 +1193,7 @@ impl PickerDelegate for DebugDelegate {
     }
 
     fn placeholder_text(&self, _window: &mut Window, _cx: &mut App) -> std::sync::Arc<str> {
-        "Find a debug task, or debug a command.".into()
+        "Find a debug task, or debug a command".into()
     }
 
     fn update_matches(
@@ -1453,18 +1454,17 @@ impl PickerDelegate for DebugDelegate {
             .child({
                 let action = menu::SecondaryConfirm.boxed_clone();
                 if self.matches.is_empty() {
-                    Button::new("edit-debug-json", "Edit debug.json")
-                        .label_size(LabelSize::Small)
-                        .on_click(cx.listener(|_picker, _, window, cx| {
+                    Button::new("edit-debug-json", "Edit debug.json").on_click(cx.listener(
+                        |_picker, _, window, cx| {
                             window.dispatch_action(
                                 zed_actions::OpenProjectDebugTasks.boxed_clone(),
                                 cx,
                             );
                             cx.emit(DismissEvent);
-                        }))
+                        },
+                    ))
                 } else {
                     Button::new("edit-debug-task", "Edit in debug.json")
-                        .label_size(LabelSize::Small)
                         .key_binding(KeyBinding::for_action(&*action, cx))
                         .on_click(move |_, window, cx| {
                             window.dispatch_action(action.boxed_clone(), cx)

--- a/crates/ui/src/components/button/button.rs
+++ b/crates/ui/src/components/button/button.rs
@@ -285,6 +285,10 @@ impl Disableable for Button {
     /// This results in a button that is disabled and does not respond to click events.
     fn disabled(mut self, disabled: bool) -> Self {
         self.base = self.base.disabled(disabled);
+        self.key_binding = self
+            .key_binding
+            .take()
+            .map(|binding| binding.disabled(disabled));
         self
     }
 }


### PR DESCRIPTION
Before:
<img width="350" height="109" alt="before" src="https://github.com/user-attachments/assets/d5d3e6bd-3a65-4d7d-8585-1e4d8f72997f" />

After:
<img width="310" height="103" alt="after" src="https://github.com/user-attachments/assets/40137084-7323-4a79-b95b-a020c418646b" />

* All items got a keybinding label
* All items were made of a non-small size, to match the text size in the right button
* Keybindings are rendered as disabled for disabled buttons

Release Notes:

- N/A 