### PR TITLE
Add vim/emacs modeline support

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1166,6 +1166,12 @@
   "hard_tabs": false,
   // How many columns a tab should occupy.
   "tab_size": 4,
+  // Number of lines to search for modelines at the beginning and end of files.
+  // Modelines contain editor directives (e.g., vim/emacs settings) that configure
+  // the editor behavior for specific files.
+  //
+  // A value of 0 disables modelines support.
+  "modeline_lines": 5,
   // What debuggers are preferred by default for all languages.
   "debuggers": [],
   // Control what info is collected by Zed.

--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -2094,6 +2094,7 @@ impl AcpThread {
 
                     let settings = language::language_settings::language_settings(
                         buffer.language().map(|l| l.name()),
+                        buffer.modeline(),
                         buffer.file(),
                         cx,
                     );

--- a/crates/acp_thread/src/diff.rs
+++ b/crates/acp_thread/src/diff.rs
@@ -373,6 +373,7 @@ async fn build_buffer_diff(
                 old_text_rope,
                 buffer.language().cloned(),
                 language_registry,
+                buffer.modeline().cloned(),
                 cx,
             )
         })?

--- a/crates/agent/src/tools/edit_file_tool.rs
+++ b/crates/agent/src/tools/edit_file_tool.rs
@@ -387,6 +387,7 @@ impl AgentTool for EditFileTool {
                 .read_with(cx, |buffer, cx| {
                     let settings = language_settings::language_settings(
                         buffer.language().map(|l| l.name()),
+                        buffer.modeline(),
                         buffer.file(),
                         cx,
                     );

--- a/crates/buffer_diff/src/buffer_diff.rs
+++ b/crates/buffer_diff/src/buffer_diff.rs
@@ -193,8 +193,13 @@ impl BufferDiffSnapshot {
         if let Some(text) = &base_text {
             let base_text_rope = Rope::from(text.as_str());
             base_text_pair = Some((text.clone(), base_text_rope.clone()));
-            let snapshot =
-                language::Buffer::build_snapshot(base_text_rope, language, language_registry, cx);
+            let snapshot = language::Buffer::build_snapshot(
+                base_text_rope,
+                language,
+                language_registry,
+                None,
+                cx,
+            );
             base_text_snapshot = cx.background_spawn(snapshot);
             base_text_exists = true;
         } else {

--- a/crates/collab/src/tests/remote_editing_collaboration_tests.rs
+++ b/crates/collab/src/tests/remote_editing_collaboration_tests.rs
@@ -165,8 +165,9 @@ async fn test_sharing_an_ssh_remote_project(
 
     cx_b.read(|cx| {
         let file = buffer_b.read(cx).file();
+        let modeline = buffer_b.read(cx).modeline();
         assert_eq!(
-            language_settings(Some("Rust".into()), file, cx).language_servers,
+            language_settings(Some("Rust".into()), modeline, file, cx).language_servers,
             ["override-rust-analyzer".to_string()]
         )
     });

--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -964,6 +964,7 @@ impl Copilot {
         let position = position.to_point_utf16(buffer);
         let settings = language_settings(
             buffer.language_at(position).map(|l| l.name()),
+            buffer.modeline(),
             buffer.file(),
             cx,
         );

--- a/crates/debugger_ui/src/new_process_modal.rs
+++ b/crates/debugger_ui/src/new_process_modal.rs
@@ -1306,9 +1306,10 @@ impl PickerDelegate for DebugDelegate {
         };
         let file = location.buffer.read(cx).file();
         let language = location.buffer.read(cx).language();
+        let modeline = location.buffer.read(cx).modeline();
         let language_name = language.as_ref().map(|l| l.name());
         let Some(adapter): Option<DebugAdapterName> =
-            language::language_settings::language_settings(language_name, file, cx)
+            language::language_settings::language_settings(language_name, modeline, file, cx)
                 .debuggers
                 .first()
                 .map(SharedString::from)

--- a/crates/edit_prediction_button/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_button/src/edit_prediction_button.rs
@@ -563,7 +563,7 @@ impl EditPredictionButton {
         let language_state = self.language.as_ref().map(|language| {
             (
                 language.clone(),
-                language_settings::language_settings(Some(language.name()), None, cx)
+                language_settings::language_settings(Some(language.name()), None, None, cx)
                     .show_edit_predictions,
             )
         });

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -600,7 +600,8 @@ impl DisplayMap {
             .and_then(|buffer| buffer.language())
             .map(|l| l.name());
         let file = buffer.and_then(|buffer| buffer.file());
-        language_settings(language, file, cx).tab_size
+        let modeline = buffer.and_then(|buffer| buffer.modeline());
+        language_settings(language, modeline, file, cx).tab_size
     }
 
     #[cfg(test)]

--- a/crates/editor/src/indent_guides.rs
+++ b/crates/editor/src/indent_guides.rs
@@ -39,6 +39,7 @@ impl Editor {
             if let Some(buffer) = self.buffer().read(cx).as_singleton() {
                 language_settings(
                     buffer.read(cx).language().map(|l| l.name()),
+                    buffer.read(cx).modeline(),
                     buffer.read(cx).file(),
                     cx,
                 )

--- a/crates/editor/src/inlays/inlay_hints.rs
+++ b/crates/editor/src/inlays/inlay_hints.rs
@@ -9,7 +9,7 @@ use futures::future::join_all;
 use gpui::{App, Entity, Task};
 use language::{
     BufferRow,
-    language_settings::{InlayHintKind, InlayHintSettings, language_settings},
+    language_settings::{InlayHintKind, InlayHintSettings},
 };
 use lsp::LanguageServerId;
 use multi_buffer::{Anchor, ExcerptId, MultiBufferSnapshot};
@@ -35,9 +35,7 @@ pub fn inlay_hint_settings(
     snapshot: &MultiBufferSnapshot,
     cx: &mut Context<Editor>,
 ) -> InlayHintSettings {
-    let file = snapshot.file_at(location);
-    let language = snapshot.language_at(location).map(|l| l.name());
-    language_settings(language, file, cx).inlay_hints
+    snapshot.language_settings_at(location, cx).inlay_hints
 }
 
 #[derive(Debug)]

--- a/crates/editor/src/jsx_tag_auto_close.rs
+++ b/crates/editor/src/jsx_tag_auto_close.rs
@@ -318,6 +318,7 @@ pub(crate) fn refresh_enabled_in_any_buffer(
 
             let buffer = buffer.read(cx);
             let snapshot = buffer.snapshot();
+            let modeline = buffer.modeline();
             for syntax_layer in snapshot.syntax_layers() {
                 let language = syntax_layer.language;
                 if language.config().jsx_tag_auto_close.is_none() {
@@ -325,6 +326,7 @@ pub(crate) fn refresh_enabled_in_any_buffer(
                 }
                 let language_settings = language::language_settings::language_settings(
                     Some(language.name()),
+                    modeline,
                     snapshot.file(),
                     cx,
                 );

--- a/crates/extension_host/src/wasm_host/wit/since_v0_1_0.rs
+++ b/crates/extension_host/src/wasm_host/wit/since_v0_1_0.rs
@@ -440,6 +440,7 @@ impl ExtensionImports for WasmState {
                         let settings = AllLanguageSettings::get(location, cx).language(
                             location,
                             key.as_ref(),
+                            None,
                             cx,
                         );
                         Ok(serde_json::to_string(&settings::LanguageSettings {

--- a/crates/extension_host/src/wasm_host/wit/since_v0_6_0.rs
+++ b/crates/extension_host/src/wasm_host/wit/since_v0_6_0.rs
@@ -933,6 +933,7 @@ impl ExtensionImports for WasmState {
                         let settings = AllLanguageSettings::get(location, cx).language(
                             location,
                             key.as_ref(),
+                            None,
                             cx,
                         );
                         Ok(serde_json::to_string(&settings::LanguageSettings {

--- a/crates/git_ui/src/commit_view.rs
+++ b/crates/git_ui/src/commit_view.rs
@@ -379,6 +379,7 @@ async fn build_buffer_diff(
                 old_text.as_deref().unwrap_or("").into(),
                 buffer.language().cloned(),
                 Some(language_registry.clone()),
+                buffer.modeline().cloned(),
                 cx,
             )
         })?

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -12,6 +12,7 @@ mod highlight_map;
 mod language_registry;
 pub mod language_settings;
 mod manifest;
+mod modeline;
 mod outline;
 pub mod proto;
 mod syntax_map;

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -12,7 +12,7 @@ mod highlight_map;
 mod language_registry;
 pub mod language_settings;
 mod manifest;
-mod modeline;
+pub mod modeline;
 mod outline;
 pub mod proto;
 mod syntax_map;
@@ -37,6 +37,7 @@ pub use language_registry::{
 };
 use lsp::{CodeActionKind, InitializeParams, LanguageServerBinary, LanguageServerBinaryOptions};
 pub use manifest::{ManifestDelegate, ManifestName, ManifestProvider, ManifestQuery};
+pub use modeline::{ModelineSettings, parse_modeline};
 use parking_lot::Mutex;
 use regex::Regex;
 use schemars::{JsonSchema, SchemaGenerator, json_schema};

--- a/crates/language/src/modeline.rs
+++ b/crates/language/src/modeline.rs
@@ -1,0 +1,838 @@
+use regex::Regex;
+use std::{num::NonZeroU32, sync::LazyLock};
+
+/// The settings extracted from an emacs/vim modelines.
+///
+/// The parsing tries to best match the modeline directives and
+/// variables to Zed, matching LanguageSettings fields.
+///
+/// It is not exhaustive, but covers the most common settings.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ModelineSettings {
+    /// The zed language name from the modeline.
+    pub language: Option<String>,
+    /// How many columns a tab should occupy.
+    pub tab_size: Option<NonZeroU32>,
+    /// Whether to indent lines using tab characters, as opposed to multiple
+    /// spaces.
+    pub hard_tabs: Option<bool>,
+    /// The number of bytes that comprise the indentation.
+    pub indent_size: Option<NonZeroU32>,
+    /// Whether to auto-indent lines
+    pub auto_indent: Option<bool>,
+    /// The column at which to soft-wrap lines, for buffers where soft-wrap
+    /// is enabled.
+    pub preferred_line_length: Option<NonZeroU32>,
+    /// Coding/encoding specification.
+    pub encoding: Option<String>,
+
+    /// Extra and unknown variables.
+    pub emacs_extra_variables: Vec<(String, String)>,
+    pub vim_extra_variables: Vec<(String, String)>,
+}
+
+impl ModelineSettings {
+    fn has_settings(&self) -> bool {
+        self != &Self::default()
+    }
+}
+
+/// Parse modelines from file content.
+///
+/// Supports:
+/// - Emacs modelines: -*- mode: rust; tab-width: 4; indent-tabs-mode: nil; -*- and "Local Variables"
+/// - Vim modelines: vim: set ft=rust ts=4 sw=4 et:
+pub fn parse_modeline(first_lines: &[&str], last_lines: &[&str]) -> Option<ModelineSettings> {
+    let mut settings = ModelineSettings::default();
+
+    parse_modelines(first_lines, &mut settings);
+
+    // Parse Emacs Local Variables in last lines
+    parse_emacs_local_variables(last_lines, &mut settings);
+
+    // Also check for vim modelines in last lines if we don't have settings yet
+    if !settings.has_settings() {
+        parse_vim_modelines(last_lines, &mut settings);
+    }
+
+    Some(settings).filter(|s| s.has_settings())
+}
+
+fn parse_modelines(modelines: &[&str], settings: &mut ModelineSettings) {
+    for line in modelines {
+        parse_emacs_modeline(line, settings);
+        // if emacs is set, do not check for vim modelines
+        if settings.has_settings() {
+            return;
+        }
+    }
+
+    parse_vim_modelines(modelines, settings);
+}
+
+static EMACS_MODELINE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"-\*-\s*(.+?)\s*-\*-").expect("valid regex"));
+
+/// Parse Emacs-style modelines
+/// Format: -*- mode: rust; tab-width: 4; indent-tabs-mode: nil; -*-
+/// See Emacs (set-auto-mode)
+fn parse_emacs_modeline(line: &str, settings: &mut ModelineSettings) {
+    let Some(captures) = EMACS_MODELINE_RE.captures(line) else {
+        return;
+    };
+    let Some(modeline_content) = captures.get(1).map(|m| m.as_str()) else {
+        return;
+    };
+    for part in modeline_content.split(';') {
+        parse_emacs_key_value(part, settings, true);
+    }
+}
+
+/// Parse Emacs-style Local Variables block
+///
+/// Emacs supports a "Local Variables" block at the end of files:
+/// ```text
+/// /* Local Variables: */
+/// /* mode: c */
+/// /* tab-width: 4 */
+/// /* End: */
+/// ```
+///
+/// Emacs related code is hack-local-variables--find-variables in
+/// https://cgit.git.savannah.gnu.org/cgit/emacs.git/tree/lisp/files.el#n4346
+fn parse_emacs_local_variables(lines: &[&str], settings: &mut ModelineSettings) {
+    let Some((i, prefix, suffix)) = lines.iter().enumerate().find_map(|(i, line)| {
+        line.find("Local Variables:")
+            .map(|prefix_len| (i, &line[..prefix_len], &line[prefix_len + 16..]))
+    }) else {
+        return;
+    };
+
+    let mut concat = None;
+    let mut i = i + 1;
+    loop {
+        let Some(line) = lines.get(i) else {
+            return;
+        };
+        let Some(line) = line.strip_prefix(prefix) else {
+            return;
+        };
+        let Some(line) = line.strip_suffix(suffix) else {
+            return;
+        };
+        let mut line = line.trim();
+        let mut line_bs = None;
+        if let Some(line) = line.strip_suffix('\\') {
+            if concat.is_none() {
+                concat = Some(String::new());
+            }
+            line_bs = Some(line);
+        }
+        if let Some(c) = &mut concat {
+            if let Some(line) = line_bs {
+                c.push_str(line);
+                i += 1;
+                continue;
+            } else {
+                c.push_str(line);
+                line = concat.as_ref().unwrap();
+            }
+        }
+        if line == "End:" {
+            return;
+        }
+        parse_emacs_key_value(line, settings, false);
+        concat = None;
+        i += 1;
+    }
+}
+
+fn parse_emacs_key_value(part: &str, settings: &mut ModelineSettings, bare: bool) {
+    let part = part.trim();
+    if part.is_empty() {
+        return;
+    }
+
+    if let Some((key, value)) = part.split_once(':') {
+        let key = key.trim();
+        let value = value.trim();
+
+        match key.to_lowercase().as_str() {
+            "mode" => {
+                settings.language = Some(modeline_language_to_zed(value));
+            }
+            "c-basic-offset" | "python-indent-offset" => {
+                if let Ok(size) = value.parse::<NonZeroU32>() {
+                    settings.indent_size = Some(size);
+                }
+            }
+            "fill-column" => {
+                if let Ok(size) = value.parse::<NonZeroU32>() {
+                    settings.preferred_line_length = Some(size);
+                }
+            }
+            "tab-width" => {
+                if let Ok(size) = value.parse::<NonZeroU32>() {
+                    settings.tab_size = Some(size);
+                }
+            }
+            "indent-tabs-mode" => {
+                settings.hard_tabs = Some(value != "nil");
+            }
+            "coding" => {
+                settings.encoding = Some(value.to_string());
+            }
+            "electric-indent-mode" => {
+                settings.auto_indent = Some(value != "nil");
+            }
+            key => settings
+                .emacs_extra_variables
+                .push((key.to_string(), value.to_string())),
+        }
+    } else if bare {
+        // Handle bare mode specification (e.g., -*- rust -*-)
+        settings.language = Some(modeline_language_to_zed(part));
+    }
+}
+
+fn parse_vim_modelines(modelines: &[&str], settings: &mut ModelineSettings) {
+    for line in modelines {
+        parse_vim_modeline(line, settings);
+    }
+}
+
+static VIM_MODELINE_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new(|| {
+    [
+        // Second form: [text{white}]{vi:vim:Vim:}[white]se[t] {options}:[text]
+        // Allow escaped colons in options: match non-colon chars or backslash followed by any char
+        // Only include ex: here if it's not at start of line
+        r"(?:(?:^|\s)(vi|vim|Vim):(?:\s*)se(?:t)?\s+((?:[^\\:]|\\.)*):|(?:\s)(ex):(?:\s*)se(?:t)?\s+((?:[^\\:]|\\.)*))",
+        // First form: [text{white}]{vi:vim:}[white]{options}
+        // Note: ex: at start of line is ignored (spec says it could be short for "example:")
+        r"(?:(?:^|\s+)(vi|vim):(?:\s*(.+))|(?:\s+)(ex):(?:\s*(.+)))",
+    ]
+        .iter()
+        .map(|pattern| Regex::new(pattern).expect("valid regex"))
+        .collect()
+});
+
+/// Parse Vim-style modelines
+/// Supports both forms:
+/// 1. First form: vi:noai:sw=3 ts=6
+/// 2. Second form: vim: set ft=rust ts=4 sw=4 et:
+fn parse_vim_modeline(line: &str, settings: &mut ModelineSettings) {
+    for re in VIM_MODELINE_PATTERNS.iter() {
+        if let Some(captures) = re.captures(line) {
+            if let Some(options) = captures.get(2).or_else(|| captures.get(4)) {
+                parse_vim_settings(options.as_str().trim(), settings);
+                break;
+            }
+        }
+    }
+}
+
+fn parse_vim_settings(content: &str, settings: &mut ModelineSettings) {
+    fn split_colon_unescape(input: &str) -> Vec<String> {
+        let mut split = Vec::new();
+        let mut str = String::new();
+        let mut chars = input.chars().peekable();
+        while let Some(c) = chars.next() {
+            if c == '\\' {
+                match chars.next() {
+                    Some(escaped_char) => str.push(escaped_char),
+                    None => str.push('\\'),
+                }
+            } else if c == ':' {
+                split.push(std::mem::take(&mut str));
+            } else {
+                str.push(c);
+            }
+        }
+        split.push(str);
+        split
+    }
+
+    let parts = split_colon_unescape(content);
+    for colon_part in parts {
+        let colon_part = colon_part.trim();
+        if colon_part.is_empty() {
+            continue;
+        }
+
+        // Each colon part might contain space-separated options
+        let space_parts: Vec<&str> = colon_part.split_whitespace().collect();
+        for part in space_parts {
+            let part = part.trim();
+            if part.is_empty() {
+                continue;
+            }
+
+            if let Some((key, value)) = part.split_once('=') {
+                match key {
+                    "ft" | "filetype" => {
+                        settings.language = Some(modeline_language_to_zed(value));
+                    }
+                    "ts" | "tabstop" => {
+                        if let Ok(size) = value.parse::<NonZeroU32>() {
+                            settings.tab_size = Some(size);
+                        } else {
+                            // Store invalid values as extra variables
+                            settings
+                                .vim_extra_variables
+                                .push((key.to_string(), value.to_string()));
+                        }
+                    }
+                    "sw" | "shiftwidth" => {
+                        if let Ok(size) = value.parse::<NonZeroU32>() {
+                            settings.indent_size = Some(size);
+                        } else {
+                            // Store invalid values as extra variables
+                            settings
+                                .vim_extra_variables
+                                .push((key.to_string(), value.to_string()));
+                        }
+                    }
+                    "tw" | "textwidth" => {
+                        if let Ok(size) = value.parse::<NonZeroU32>() {
+                            settings.preferred_line_length = Some(size);
+                        } else {
+                            // Store invalid values as extra variables
+                            settings
+                                .vim_extra_variables
+                                .push((key.to_string(), value.to_string()));
+                        }
+                    }
+                    "fileencoding" | "encoding" | "enc" => {
+                        settings.encoding = Some(value.to_string());
+                    }
+                    _ => {
+                        settings
+                            .vim_extra_variables
+                            .push((key.to_string(), value.to_string()));
+                    }
+                }
+            } else {
+                match part {
+                    "ai" | "autoindent" => {
+                        settings.auto_indent = Some(true);
+                    }
+                    "noai" | "noautoindent" => {
+                        settings.auto_indent = Some(false);
+                    }
+                    "et" | "expandtab" => {
+                        settings.hard_tabs = Some(false);
+                    }
+                    "noet" | "noexpandtab" => {
+                        settings.hard_tabs = Some(true);
+                    }
+                    "set" => {
+                        // Ignore the "set" keyword itself
+                    }
+                    _ => {
+                        settings
+                            .vim_extra_variables
+                            .push((part.to_string(), "true".to_string()));
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Normalize language names from modelines to Zed language names
+///
+/// It may make sense to move the mapping somewhere else and allow further customization.
+fn modeline_language_to_zed(name: &str) -> String {
+    let name = name.trim().to_lowercase();
+
+    match name.as_str() {
+        "c" => "C".to_string(),
+        "c++" | "cxx" => "C++".to_string(),
+        "css" => "CSS".to_string(),
+        "bash" | "fish" | "sh" | "shell" | "zsh" => "Shell Script".to_string(),
+        "go" | "golang" => "Go".to_string(),
+        "html" | "htm" => "HTML".to_string(),
+        "javascript" | "js" => "JavaScript".to_string(),
+        "json" => "JSON".to_string(),
+        "jsonc" => "JSONC".to_string(),
+        "makefile" => "Make".to_string(),
+        "markdown" | "md" => "Markdown".to_string(),
+        "meson" => "Meson".to_string(),
+        "perl" | "pl" => "Perl".to_string(),
+        "python" | "py" => "Python".to_string(),
+        "ruby" | "rb" => "Ruby".to_string(),
+        "rust" | "rs" => "Rust".to_string(),
+        "rst" => "reST".to_string(),
+        "scheme" => "Scheme".to_string(),
+        "latex" | "tex" => "LaTeX".to_string(),
+        "text" | "txt" => "Plain Text".to_string(),
+        "typescript" | "ts" => "TypeScript".to_string(),
+        "xml" => "XML".to_string(),
+        "yaml" => "YAML".to_string(),
+        _ => name,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indoc::indoc;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_no_modeline() {
+        let content = "This is just regular content\nwith no modeline";
+        assert!(parse_modeline(&[content], &[content]).is_none());
+    }
+
+    #[test]
+    fn test_emacs_bare_mode() {
+        let content = "/* -*- rust -*- */";
+        let settings = parse_modeline(&[content], &[]).unwrap();
+        assert_eq!(
+            settings,
+            ModelineSettings {
+                language: Some("Rust".to_string()),
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn test_emacs_modeline_parsing() {
+        let content = "/* -*- mode: rust; tab-width: 4; indent-tabs-mode: nil; -*- */";
+        let settings = parse_modeline(&[content], &[]).unwrap();
+        assert_eq!(
+            settings,
+            ModelineSettings {
+                language: Some("Rust".to_string()),
+                tab_size: Some(NonZeroU32::new(4).unwrap()),
+                hard_tabs: Some(false),
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn test_emacs_last_line_parsing() {
+        let content = indoc! {r#"
+        # Local Variables:
+        # compile-command: "cc foo.c -Dfoo=bar -Dhack=whatever \
+        #   -Dmumble=blaah"
+        # End:
+        "#}
+        .lines()
+        .collect::<Vec<_>>();
+        let settings = parse_modeline(&[], &content).unwrap();
+        assert_eq!(
+            settings,
+            ModelineSettings {
+                emacs_extra_variables: vec![(
+                    "compile-command".to_string(),
+                    "\"cc foo.c -Dfoo=bar -Dhack=whatever -Dmumble=blaah\"".to_string()
+                ),],
+                ..Default::default()
+            }
+        );
+
+        let content = indoc! {"
+            foo
+            /* Local Variables: */
+            /* eval: (font-lock-mode -1) */
+            /* mode: old-c */
+            /* mode: c */
+            /* End: */
+            /* mode: ignored */
+        "}
+        .lines()
+        .collect::<Vec<_>>();
+        let settings = parse_modeline(&[], &content).unwrap();
+        assert_eq!(
+            settings,
+            ModelineSettings {
+                language: Some("C".to_string()),
+                emacs_extra_variables: vec![(
+                    "eval".to_string(),
+                    "(font-lock-mode -1)".to_string()
+                ),],
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn test_vim_modeline_parsing() {
+        // Test second form (set format)
+        let content = "// vim: set ft=rust ts=4 sw=4 et:";
+        let settings = parse_modeline(&[content], &[]).unwrap();
+        assert_eq!(
+            settings,
+            ModelineSettings {
+                language: Some("Rust".to_string()),
+                tab_size: Some(NonZeroU32::new(4).unwrap()),
+                hard_tabs: Some(false),
+                indent_size: Some(NonZeroU32::new(4).unwrap()),
+                ..Default::default()
+            }
+        );
+
+        // Test first form (colon-separated)
+        let content = "vi:noai:sw=3:ts=6";
+        let settings = parse_modeline(&[content], &[]).unwrap();
+        assert_eq!(
+            settings,
+            ModelineSettings {
+                tab_size: Some(NonZeroU32::new(6).unwrap()),
+                auto_indent: Some(false),
+                indent_size: Some(NonZeroU32::new(3).unwrap()),
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn test_vim_modeline_first_form() {
+        // Examples from vim specification: vi:noai:sw=3 ts=6
+        let content = "   vi:noai:sw=3 ts=6 ";
+        let settings = parse_modeline(&[content], &[]).unwrap();
+        assert_eq!(
+            settings,
+            ModelineSettings {
+                tab_size: Some(NonZeroU32::new(6).unwrap()),
+                auto_indent: Some(false),
+                indent_size: Some(NonZeroU32::new(3).unwrap()),
+                ..Default::default()
+            }
+        );
+
+        // Test with filetype
+        let content = "vim:ft=python:ts=8:noet";
+        let settings = parse_modeline(&[content], &[]).unwrap();
+        assert_eq!(
+            settings,
+            ModelineSettings {
+                language: Some("Python".to_string()),
+                tab_size: Some(NonZeroU32::new(8).unwrap()),
+                hard_tabs: Some(true),
+                ..Default::default()
+            }
+        );
+
+        // Test 'ex:' format
+        let content = "   ex:ft=javascript:et:sw=2";
+        let settings = parse_modeline(&[content], &[]).unwrap();
+        assert_eq!(
+            settings,
+            ModelineSettings {
+                language: Some("JavaScript".to_string()),
+                hard_tabs: Some(false),
+                indent_size: Some(NonZeroU32::new(2).unwrap()),
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn test_vim_modeline_second_form() {
+        // Examples from vim specification: /* vim: set ai tw=75: */
+        let content = "/* vim: set ai tw=75: */";
+        let settings = parse_modeline(&[content], &[]).unwrap();
+        assert_eq!(
+            settings,
+            ModelineSettings {
+                auto_indent: Some(true),
+                preferred_line_length: Some(NonZeroU32::new(75).unwrap()),
+                ..Default::default()
+            }
+        );
+
+        // Test with 'Vim:' (capital V)
+        let content = "/* Vim: set ai tw=75: */";
+        let settings = parse_modeline(&[content], &[]).unwrap();
+        assert_eq!(
+            settings,
+            ModelineSettings {
+                auto_indent: Some(true),
+                preferred_line_length: Some(NonZeroU32::new(75).unwrap()),
+                ..Default::default()
+            }
+        );
+
+        // Test 'se' shorthand
+        let content = "// vi: se ft=c ts=4:";
+        let settings = parse_modeline(&[content], &[]).unwrap();
+        assert_eq!(
+            settings,
+            ModelineSettings {
+                language: Some("C".to_string()),
+                tab_size: Some(NonZeroU32::new(4).unwrap()),
+                ..Default::default()
+            }
+        );
+
+        // Test complex modeline with encoding
+        let content = "# vim: set ft=python ts=4 sw=4 et encoding=utf-8:";
+        let settings = parse_modeline(&[content], &[]).unwrap();
+        assert_eq!(
+            settings,
+            ModelineSettings {
+                language: Some("Python".to_string()),
+                tab_size: Some(NonZeroU32::new(4).unwrap()),
+                hard_tabs: Some(false),
+                indent_size: Some(NonZeroU32::new(4).unwrap()),
+                encoding: Some("utf-8".to_string()),
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn test_vim_modeline_edge_cases() {
+        // Test modeline at start of line (compatibility with version 3.0)
+        let content = "vi:ts=2:et";
+        let settings = parse_modeline(&[content], &[]).unwrap();
+        assert_eq!(
+            settings,
+            ModelineSettings {
+                tab_size: Some(NonZeroU32::new(2).unwrap()),
+                hard_tabs: Some(false),
+                ..Default::default()
+            }
+        );
+
+        // Test vim at start of line
+        let content = "vim:ft=rust:noet";
+        let settings = parse_modeline(&[content], &[]).unwrap();
+        assert_eq!(
+            settings,
+            ModelineSettings {
+                language: Some("Rust".to_string()),
+                hard_tabs: Some(true),
+                ..Default::default()
+            }
+        );
+
+        // Test that 'ex:' at start of line is ignored (as per spec)
+        let content = "ex:ft=ignored";
+        assert!(parse_modeline(&[content], &[]).is_none());
+
+        // Test mixed boolean flags
+        let content = "vim: set wrap noet ts=8:";
+        let settings = parse_modeline(&[content], &[]).unwrap();
+        assert_eq!(
+            settings,
+            ModelineSettings {
+                tab_size: Some(NonZeroU32::new(8).unwrap()),
+                hard_tabs: Some(true),
+                vim_extra_variables: vec![("wrap".to_string(), "true".to_string())],
+                ..Default::default()
+            }
+        );
+    }
+
+    #[test]
+    fn test_vim_modeline_invalid_cases() {
+        // Test malformed options are ignored gracefully
+        let content = "vim: set ts=invalid ft=rust:";
+        let settings = parse_modeline(&[content], &[]).unwrap();
+        assert_eq!(
+            settings,
+            ModelineSettings {
+                language: Some("Rust".to_string()),
+                vim_extra_variables: vec![("ts".to_string(), "invalid".to_string())],
+                ..Default::default()
+            }
+        );
+
+        // Test empty modeline content - this should still work as there might be options
+        let content = "vim: set :";
+        // This should return None because there are no actual options
+        let result = parse_modeline(&[content], &[]);
+        assert!(result.is_none(), "Expected None but got: {:?}", result);
+
+        // Test modeline without proper format
+        let content = "not a modeline";
+        assert!(parse_modeline(&[content], &[]).is_none());
+
+        // Test word that looks like modeline but isn't
+        let content = "example: this could be confused with ex:";
+        assert!(parse_modeline(&[content], &[]).is_none());
+    }
+
+    #[test]
+    fn test_vim_language_mapping() {
+        // Test vim-specific language mappings
+        let content = "vim: set ft=sh:";
+        let settings = parse_modeline(&[content], &[]).unwrap();
+        assert_eq!(settings.language, Some("Shell Script".to_string()));
+
+        let content = "vim: set ft=golang:";
+        let settings = parse_modeline(&[content], &[]).unwrap();
+        assert_eq!(settings.language, Some("Go".to_string()));
+
+        let content = "vim: set filetype=js:";
+        let settings = parse_modeline(&[content], &[]).unwrap();
+        assert_eq!(settings.language, Some("JavaScript".to_string()));
+    }
+
+    #[test]
+    fn test_vim_extra_variables() {
+        // Test that unknown vim options are stored as extra variables
+        let content = "vim: set foldmethod=marker conceallevel=2 custom=value:";
+        let settings = parse_modeline(&[content], &[]).unwrap();
+
+        assert!(
+            settings
+                .vim_extra_variables
+                .contains(&("foldmethod".to_string(), "marker".to_string()))
+        );
+        assert!(
+            settings
+                .vim_extra_variables
+                .contains(&("conceallevel".to_string(), "2".to_string()))
+        );
+        assert!(
+            settings
+                .vim_extra_variables
+                .contains(&("custom".to_string(), "value".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_modeline_position() {
+        // Test modeline in first lines
+        let first_lines = ["#!/bin/bash", "# vim: set ft=bash ts=4:"];
+        let settings = parse_modeline(&first_lines, &[]).unwrap();
+        assert_eq!(settings.language, Some("Shell Script".to_string()));
+
+        // Test modeline in last lines
+        let last_lines = ["", "/* vim: set ft=c: */"];
+        let settings = parse_modeline(&[], &last_lines).unwrap();
+        assert_eq!(settings.language, Some("C".to_string()));
+
+        // Test no modeline found
+        let content = ["regular content", "no modeline here"];
+        assert!(parse_modeline(&content, &content).is_none());
+    }
+
+    #[test]
+    fn test_vim_modeline_version_checks() {
+        // Note: Current implementation doesn't support version checks yet
+        // These are tests for future implementation based on vim spec
+
+        // Test version-specific modelines (currently ignored in our implementation)
+        let content = "/* vim700: set foldmethod=marker */";
+        // Should be ignored for now since we don't support version checks
+        assert!(parse_modeline(&[content], &[]).is_none());
+
+        let content = "/* vim>702: set cole=2: */";
+        // Should be ignored for now since we don't support version checks
+        assert!(parse_modeline(&[content], &[]).is_none());
+    }
+
+    #[test]
+    fn test_vim_modeline_colon_escaping() {
+        // Test colon escaping as mentioned in vim spec
+
+        // According to vim spec: "if you want to include a ':' in a set command precede it with a '\'"
+        let content = r#"/* vim: set fdm=expr fde=getline(v\:lnum)=~'{'?'>1'\:'1': */"#;
+
+        let result = parse_modeline(&[content], &[]).unwrap();
+
+        // The modeline should parse fdm=expr and fde=getline(v:lnum)=~'{'?'>1':'1'
+        // as extra variables since they're not recognized settings
+        assert_eq!(result.vim_extra_variables.len(), 2);
+        assert_eq!(result.vim_extra_variables[0], ("fdm".to_string(), "expr".to_string()));
+        assert_eq!(result.vim_extra_variables[1], ("fde".to_string(), "getline(v:lnum)=~'{'?'>1':'1'".to_string()));
+    }
+
+    #[test]
+    fn test_vim_modeline_whitespace_requirements() {
+        // Test whitespace requirements from vim spec
+
+        // Valid: whitespace before vi/vim/ex
+        let content = "  vim: set ft=rust:";
+        assert!(parse_modeline(&[content], &[]).is_some());
+
+        // Valid: tab before vi/vim/ex
+        let content = "\tvim: set ft=rust:";
+        assert!(parse_modeline(&[content], &[]).is_some());
+
+        // Valid: vi/vim at start of line (compatibility)
+        let content = "vim: set ft=rust:";
+        assert!(parse_modeline(&[content], &[]).is_some());
+
+        // Invalid: ex at start of line should be ignored
+        let content = "ex: set ft=rust:";
+        assert!(parse_modeline(&[content], &[]).is_none());
+
+        // Valid: ex with whitespace before
+        let content = " ex: set ft=rust:";
+        assert!(parse_modeline(&[content], &[]).is_some());
+    }
+
+    #[test]
+    fn test_vim_modeline_comprehensive_examples() {
+        // Real-world examples from vim documentation and common usage
+
+        // Python example
+        let content = "# vim: set expandtab tabstop=4 shiftwidth=4 softtabstop=4:";
+        let settings = parse_modeline(&[content], &[]).unwrap();
+        assert_eq!(settings.hard_tabs, Some(false));
+        assert_eq!(settings.tab_size, Some(NonZeroU32::new(4).unwrap()));
+
+        // C example with multiple options
+        let content = "/* vim: set ts=8 sw=8 noet ai cindent: */";
+        let settings = parse_modeline(&[content], &[]).unwrap();
+        assert_eq!(settings.tab_size, Some(NonZeroU32::new(8).unwrap()));
+        assert_eq!(settings.hard_tabs, Some(true));
+        assert!(
+            settings
+                .vim_extra_variables
+                .contains(&("cindent".to_string(), "true".to_string()))
+        );
+
+        // Shell script example
+        let content = "# vi: set ft=sh ts=2 sw=2 et:";
+        let settings = parse_modeline(&[content], &[]).unwrap();
+        assert_eq!(settings.language, Some("Shell Script".to_string()));
+        assert_eq!(settings.tab_size, Some(NonZeroU32::new(2).unwrap()));
+        assert_eq!(settings.hard_tabs, Some(false));
+
+        // First form colon-separated
+        let content = "vim:ft=xml:ts=2:sw=2:et";
+        let settings = parse_modeline(&[content], &[]).unwrap();
+        assert_eq!(settings.language, Some("XML".to_string()));
+        assert_eq!(settings.tab_size, Some(NonZeroU32::new(2).unwrap()));
+        assert_eq!(settings.hard_tabs, Some(false));
+    }
+
+    #[test]
+    fn test_combined_emacs_vim_detection() {
+        // Test that both emacs and vim modelines can be detected in the same file
+
+        let first_lines = [
+            "#!/usr/bin/env python3",
+            "# -*- coding: utf-8 -*-",
+            "# vim: set ft=python ts=4 sw=4 et:",
+        ];
+
+        // Should find the emacs modeline first (with coding)
+        let settings = parse_modeline(&first_lines, &[]).unwrap();
+        assert_eq!(settings.encoding, Some("utf-8".to_string()));
+
+        // Test vim-only content
+        let vim_only = ["# vim: set ft=python ts=4 sw=4 et:"];
+        let settings = parse_modeline(&vim_only, &[]).unwrap();
+        assert_eq!(settings.language, Some("Python".to_string()));
+        assert_eq!(settings.tab_size, Some(NonZeroU32::new(4).unwrap()));
+        assert_eq!(settings.hard_tabs, Some(false));
+    }
+
+    #[test]
+    fn test_language_normalization() {
+        assert_eq!(modeline_language_to_zed("c++"), "C++");
+        assert_eq!(modeline_language_to_zed("js"), "JavaScript");
+        assert_eq!(modeline_language_to_zed("unknown"), "unknown");
+    }
+}

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -825,7 +825,7 @@ impl ContextProvider for PythonContextProvider {
 
 fn selected_test_runner(location: Option<&Arc<dyn language::File>>, cx: &App) -> TestRunner {
     const TEST_RUNNER_VARIABLE: &str = "TEST_RUNNER";
-    language_settings(Some(LanguageName::new("Python")), location, cx)
+    language_settings(Some(LanguageName::new("Python")), None, location, cx)
         .tasks
         .variables
         .get(TEST_RUNNER_VARIABLE)

--- a/crates/languages/src/rust.rs
+++ b/crates/languages/src/rust.rs
@@ -703,7 +703,7 @@ impl ContextProvider for RustContextProvider {
         const DEFAULT_RUN_NAME_STR: &str = "RUST_DEFAULT_PACKAGE_RUN";
         const CUSTOM_TARGET_DIR: &str = "RUST_TARGET_DIR";
 
-        let language_sets = language_settings(Some("Rust".into()), file.as_ref(), cx);
+        let language_sets = language_settings(Some("Rust".into()), None, file.as_ref(), cx);
         let package_to_run = language_sets
             .tasks
             .variables

--- a/crates/languages/src/yaml.rs
+++ b/crates/languages/src/yaml.rs
@@ -146,7 +146,7 @@ impl LspAdapter for YamlLspAdapter {
 
         let tab_size = cx.update(|cx| {
             AllLanguageSettings::get(Some(location), cx)
-                .language(Some(location), Some(&"YAML".into()), cx)
+                .language(Some(location), Some(&"YAML".into()), None, cx)
                 .tab_size
         })?;
 

--- a/crates/prettier/src/prettier.rs
+++ b/crates/prettier/src/prettier.rs
@@ -330,7 +330,7 @@ impl Prettier {
                 let params = buffer
                     .update(cx, |buffer, cx| {
                         let buffer_language = buffer.language();
-                        let language_settings = language_settings(buffer_language.map(|l| l.name()), buffer.file(), cx);
+                        let language_settings = language_settings(buffer_language.map(|l| l.name()), buffer.modeline(), buffer.file(), cx);
                         let prettier_settings = &language_settings.prettier;
                         anyhow::ensure!(
                             prettier_settings.allowed,

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -2873,7 +2873,13 @@ impl LspCommand for OnTypeFormatting {
 
         let options = buffer.update(&mut cx, |buffer, cx| {
             lsp_formatting_options(
-                language_settings(buffer.language().map(|l| l.name()), buffer.file(), cx).as_ref(),
+                language_settings(
+                    buffer.language().map(|l| l.name()),
+                    buffer.modeline(),
+                    buffer.file(),
+                    cx,
+                )
+                .as_ref(),
             )
         })?;
 

--- a/crates/project/src/manifest_tree/server_tree.rs
+++ b/crates/project/src/manifest_tree/server_tree.rs
@@ -245,6 +245,7 @@ impl LanguageServerTree {
         let settings = AllLanguageSettings::get(Some(settings_location), cx).language(
             Some(settings_location),
             Some(language_name),
+            None,
             cx,
         );
         if !settings.enable_language_server {

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -214,7 +214,7 @@ async fn test_editorconfig_support(cx: &mut gpui::TestAppContext) {
                 .block(file_language)
                 .expect("Failed to get file language");
             let file = file as _;
-            language_settings(Some(file_language.name()), Some(&file), cx).into_owned()
+            language_settings(Some(file_language.name()), None, Some(&file), cx).into_owned()
         };
 
         let settings_a = settings_for("a.rs");
@@ -372,12 +372,12 @@ async fn test_managing_project_specific_settings(cx: &mut gpui::TestAppContext) 
                 tree.entry_for_path(rel_path("a/a.rs")).unwrap().clone(),
                 worktree.clone(),
             ) as _;
-            let settings_a = language_settings(None, Some(&file_a), cx);
+            let settings_a = language_settings(None, None, Some(&file_a), cx);
             let file_b = File::for_entry(
                 tree.entry_for_path(rel_path("b/b.rs")).unwrap().clone(),
                 worktree.clone(),
             ) as _;
-            let settings_b = language_settings(None, Some(&file_b), cx);
+            let settings_b = language_settings(None, None, Some(&file_b), cx);
 
             assert_eq!(settings_a.tab_size.get(), 8);
             assert_eq!(settings_b.tab_size.get(), 2);

--- a/crates/project/src/task_inventory.rs
+++ b/crates/project/src/task_inventory.rs
@@ -302,12 +302,12 @@ impl Inventory {
         let last_scheduled_scenarios = self.last_scheduled_scenarios.iter().cloned().collect();
 
         let adapter = task_contexts.location().and_then(|location| {
-            let (file, language) = {
+            let (file, language, modeline) = {
                 let buffer = location.buffer.read(cx);
-                (buffer.file(), buffer.language())
+                (buffer.file(), buffer.language(), buffer.modeline())
             };
             let language_name = language.as_ref().map(|l| l.name());
-            let adapter = language_settings(language_name, file, cx)
+            let adapter = language_settings(language_name, modeline, file, cx)
                 .debuggers
                 .first()
                 .map(SharedString::from)
@@ -394,7 +394,7 @@ impl Inventory {
         });
         let language_tasks = language
             .filter(|language| {
-                language_settings(Some(language.name()), file.as_ref(), cx)
+                language_settings(Some(language.name()), None, file.as_ref(), cx)
                     .tasks
                     .enabled
             })
@@ -478,7 +478,7 @@ impl Inventory {
         let global_tasks = self.global_templates_from_settings().collect::<Vec<_>>();
         let associated_tasks = language
             .filter(|language| {
-                language_settings(Some(language.name()), file.as_ref(), cx)
+                language_settings(Some(language.name()), None, file.as_ref(), cx)
                     .tasks
                     .enabled
             })

--- a/crates/remote_server/src/remote_editing_tests.rs
+++ b/crates/remote_server/src/remote_editing_tests.rs
@@ -277,7 +277,7 @@ async fn test_remote_settings(cx: &mut TestAppContext, server_cx: &mut TestAppCo
     server_cx.read(|cx| {
         assert_eq!(
             AllLanguageSettings::get_global(cx)
-                .language(None, Some(&"Rust".into()), cx)
+                .language(None, Some(&"Rust".into()), None, cx)
                 .language_servers,
             ["from-local-settings"],
             "User language settings should be synchronized with the server settings"
@@ -298,7 +298,7 @@ async fn test_remote_settings(cx: &mut TestAppContext, server_cx: &mut TestAppCo
     server_cx.read(|cx| {
         assert_eq!(
             AllLanguageSettings::get_global(cx)
-                .language(None, Some(&"Rust".into()), cx)
+                .language(None, Some(&"Rust".into()), None, cx)
                 .language_servers,
             ["from-server-settings".to_string()],
             "Server language settings should take precedence over the user settings"
@@ -358,7 +358,7 @@ async fn test_remote_settings(cx: &mut TestAppContext, server_cx: &mut TestAppCo
                 }),
                 cx
             )
-            .language(None, Some(&"Rust".into()), cx)
+            .language(None, Some(&"Rust".into()), None, cx)
             .language_servers,
             ["override-rust-analyzer".to_string()]
         )
@@ -366,8 +366,9 @@ async fn test_remote_settings(cx: &mut TestAppContext, server_cx: &mut TestAppCo
 
     cx.read(|cx| {
         let file = buffer.read(cx).file();
+        let modeline = buffer.read(cx).modeline();
         assert_eq!(
-            language_settings(Some("Rust".into()), file, cx).language_servers,
+            language_settings(Some("Rust".into()), modeline, file, cx).language_servers,
             ["override-rust-analyzer".to_string()]
         )
     });
@@ -471,8 +472,9 @@ async fn test_remote_lsp(cx: &mut TestAppContext, server_cx: &mut TestAppContext
 
     cx.read(|cx| {
         let file = buffer.read(cx).file();
+        let modeline = buffer.read(cx).modeline();
         assert_eq!(
-            language_settings(Some("Rust".into()), file, cx).language_servers,
+            language_settings(Some("Rust".into()), modeline, file, cx).language_servers,
             ["rust-analyzer".to_string()]
         )
     });

--- a/crates/settings/src/settings_content.rs
+++ b/crates/settings/src/settings_content.rs
@@ -161,6 +161,13 @@ pub struct SettingsContent {
 
     /// Settings related to Vim mode in Zed.
     pub vim: Option<VimSettingsContent>,
+
+    /// Number of lines to search for modelines at the beginning and end of files.
+    /// Modelines contain editor directives (e.g., vim/emacs settings) that configure
+    /// the editor behavior for specific files.
+    ///
+    /// Default: 5
+    pub modeline_lines: Option<usize>,
 }
 
 impl SettingsContent {

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -215,6 +215,7 @@ impl VsCodeSettings {
             vim: None,
             vim_mode: None,
             workspace: self.workspace_settings_content(),
+            modeline_lines: None,
         }
     }
 

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -6937,6 +6937,22 @@ fn language_settings_data() -> Vec<SettingsPageItem> {
                 metadata: None,
                 files: USER,
             }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Vim/Emacs Modeline Support",
+                description: "Number of lines to search for modelines (set to 0 to disable).",
+                field: Box::new(SettingField {
+                    json_path: Some("modeline_lines"),
+                    pick: |settings_content| {
+                        settings_content.modeline_lines.as_ref()
+                    },
+                    write: |settings_content, value| {
+                        settings_content.modeline_lines = value;
+
+                    },
+                }),
+                metadata: None,
+                files: USER | PROJECT,
+            }),
         ]);
     }
     items


### PR DESCRIPTION
Many editors such as vim and emacs support "modelines", a comment at the beginning of the file that allows the file type to be explicitly specified along with per-file specific settings

- The amount of configurations, style and settings mapping cannot be handled in one go, so this opens up a lot of potential improvements.
- I left out the possiblity to have "zed" specific modelines for now, but this could be potentially interesting.
- Mapping the mode or filetype to zed language names isn't obvious either. We may want to make it configurable.

This is my first contribution to zed, be kind. I struggled a bit to find the right place to add those settings. I use a similar approach as done with editorconfig (merge_with_editorconfig). There might be better ways.

Closes #4762

Release Notes:

- Add basic emacs/vim modeline support.
