### PR TITLE
util: Add missing quotes in shell env capturing on windows

### DIFF
--- a/crates/util/src/shell_env.rs
+++ b/crates/util/src/shell_env.rs
@@ -177,7 +177,7 @@ async fn capture_windows(
                 .args([
                     "-c",
                     &format!(
-                        "cd '{}'; {}{} --printenv",
+                        "cd '{}'; {}'{}' --printenv",
                         directory.display(),
                         shell_kind
                             .command_prefix()
@@ -206,7 +206,7 @@ async fn capture_windows(
                 .args([
                     "/c",
                     &format!(
-                        "cd '{}'; {} --printenv",
+                        "cd '{}'; '{}' --printenv",
                         directory.display(),
                         zed_path.display()
                     ),


### PR DESCRIPTION

Release Notes:

- Fixed shell env capturing failing if zed is installed on a path with whitespace in it