### PR TITLE
file_finder: Display duplicated file in file finder history

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -344,7 +344,7 @@ pub enum Event {
     RevealInProjectPanel(ProjectEntryId),
     SnippetEdit(BufferId, Vec<(lsp::Range, Snippet)>),
     ExpandedAllForEntry(WorktreeId, ProjectEntryId),
-    EntryRenamed(ProjectTransaction),
+    EntryRenamed(ProjectTransaction, ProjectPath, PathBuf),
     AgentLocationChanged,
 }
 
@@ -2248,7 +2248,11 @@ impl Project {
 
             project
                 .update(cx, |_, cx| {
-                    cx.emit(Event::EntryRenamed(transaction));
+                    cx.emit(Event::EntryRenamed(
+                        transaction,
+                        new_path.clone(),
+                        new_abs_path.clone(),
+                    ));
                 })
                 .ok();
 

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -2007,7 +2007,7 @@ async fn test_create_duplicate_items(cx: &mut gpui::TestAppContext) {
         "/src",
         json!({
             "test": {
-                "first.rs": "// First Rust file",
+                "first.txt": "// First Txt file",
                 "second.rs": "// Second Rust file",
                 "third.rs": "// Third Rust file",
             }
@@ -2106,7 +2106,7 @@ async fn test_create_duplicate_items(cx: &mut gpui::TestAppContext) {
             "v src",
             "    v test",
             "          [EDITOR: '']  <== selected",
-            "          first.rs",
+            "          first.txt",
             "          second.rs",
             "          third.rs"
         ]
@@ -2114,7 +2114,7 @@ async fn test_create_duplicate_items(cx: &mut gpui::TestAppContext) {
     panel.update_in(cx, |panel, window, cx| {
         panel
             .filename_editor
-            .update(cx, |editor, cx| editor.set_text("first.rs", window, cx));
+            .update(cx, |editor, cx| editor.set_text("first.txt", window, cx));
         assert!(
             panel.confirm_edit(true, window, cx).is_none(),
             "Should not allow to confirm on conflicting new file name"
@@ -2135,14 +2135,14 @@ async fn test_create_duplicate_items(cx: &mut gpui::TestAppContext) {
         &[
             "v src",
             "    v test  <== selected",
-            "          first.rs",
+            "          first.txt",
             "          second.rs",
             "          third.rs"
         ],
         "File list should be unchanged after failed file create confirmation"
     );
 
-    select_path(&panel, "src/test/first.rs", cx);
+    select_path(&panel, "src/test/first.txt", cx);
     panel.update_in(cx, |panel, window, cx| panel.confirm(&Confirm, window, cx));
     cx.executor().run_until_parked();
     assert_eq!(
@@ -2150,7 +2150,7 @@ async fn test_create_duplicate_items(cx: &mut gpui::TestAppContext) {
         &[
             "v src",
             "    v test",
-            "          first.rs  <== selected",
+            "          first.txt  <== selected",
             "          second.rs",
             "          third.rs"
         ],
@@ -2164,7 +2164,7 @@ async fn test_create_duplicate_items(cx: &mut gpui::TestAppContext) {
         &[
             "v src",
             "    v test",
-            "          [EDITOR: 'first.rs']  <== selected",
+            "          [EDITOR: 'first.txt']  <== selected",
             "          second.rs",
             "          third.rs"
         ]
@@ -2191,7 +2191,7 @@ async fn test_create_duplicate_items(cx: &mut gpui::TestAppContext) {
         &[
             "v src",
             "    v test",
-            "          first.rs  <== selected",
+            "          first.txt  <== selected",
             "          second.rs",
             "          third.rs"
         ],
@@ -2210,8 +2210,8 @@ async fn test_create_duplicate_items(cx: &mut gpui::TestAppContext) {
         &[
             "v src",
             "    v test",
-            "          first.rs",
-            "          [EDITOR: 'first copy.rs']  <== selected  <== marked",
+            "          first.txt",
+            "          [EDITOR: 'first copy.txt']  <== selected  <== marked",
             "          second.rs",
             "          third.rs"
         ],
@@ -2220,7 +2220,7 @@ async fn test_create_duplicate_items(cx: &mut gpui::TestAppContext) {
     let confirm = panel.update_in(cx, |panel, window, cx| {
         panel
             .filename_editor
-            .update(cx, |editor, cx| editor.set_text("fourth.rs", window, cx));
+            .update(cx, |editor, cx| editor.set_text("fourth.txt", window, cx));
         panel.confirm_edit(true, window, cx).unwrap()
     });
     confirm.await.unwrap();
@@ -2231,8 +2231,8 @@ async fn test_create_duplicate_items(cx: &mut gpui::TestAppContext) {
         &[
             "v src",
             "    v test",
-            "          first.rs",
-            "          fourth.rs  <== selected",
+            "          first.txt",
+            "          fourth.txt  <== selected",
             "          second.rs",
             "          third.rs"
         ],
@@ -2244,7 +2244,7 @@ async fn test_create_duplicate_items(cx: &mut gpui::TestAppContext) {
     });
     cx.executor().run_until_parked();
 
-    select_path(&panel, "src/test/first.rs", cx);
+    select_path(&panel, "src/test/first.txt", cx);
     panel.update_in(cx, |panel, window, cx| panel.open(&Open, window, cx));
     cx.executor().run_until_parked();
 
@@ -2253,8 +2253,8 @@ async fn test_create_duplicate_items(cx: &mut gpui::TestAppContext) {
             assert!(
                 this.recent_navigation_history_iter(cx)
                     .any(|(project_path, abs_path)| {
-                        project_path.path == Arc::from(rel_path("test/fourth.rs"))
-                            && abs_path == Some(PathBuf::from(path!("/src/test/fourth.rs")))
+                        project_path.path == Arc::from(rel_path("test/fourth.txt"))
+                            && abs_path == Some(PathBuf::from(path!("/src/test/fourth.txt")))
                     })
             );
         })

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -2467,6 +2467,125 @@ async fn test_create_duplicate_items_and_check_history(cx: &mut gpui::TestAppCon
 }
 
 #[gpui::test]
+async fn test_rename_item_and_check_history(cx: &mut gpui::TestAppContext) {
+    init_test_with_editor(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        "/src",
+        json!({
+            "test": {
+                "first.txt": "// First Txt file",
+                "second.txt": "// Second Txt file",
+                "third.txt": "// Third Txt file",
+            }
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), ["/src".as_ref()], cx).await;
+    let workspace = cx.add_window(|window, cx| Workspace::test_new(project.clone(), window, cx));
+    let cx = &mut VisualTestContext::from_window(*workspace, cx);
+    let panel = workspace
+        .update(cx, |workspace, window, cx| {
+            let panel = ProjectPanel::new(workspace, window, cx);
+            workspace.add_panel(panel.clone(), window, cx);
+            panel
+        })
+        .unwrap();
+    cx.run_until_parked();
+
+    select_path(&panel, "src", cx);
+    panel.update_in(cx, |panel, window, cx| panel.confirm(&Confirm, window, cx));
+    cx.executor().run_until_parked();
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, cx),
+        &[
+            //
+            "v src  <== selected",
+            "    > test"
+        ]
+    );
+
+    select_path(&panel, "src/test", cx);
+    panel.update_in(cx, |panel, window, cx| panel.confirm(&Confirm, window, cx));
+    cx.executor().run_until_parked();
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, cx),
+        &[
+            //
+            "v src",
+            "    > test  <== selected"
+        ]
+    );
+    panel.update_in(cx, |panel, window, cx| panel.new_file(&NewFile, window, cx));
+    cx.run_until_parked();
+    panel.update_in(cx, |panel, window, cx| {
+        assert!(panel.filename_editor.read(cx).is_focused(window));
+    });
+
+    select_path(&panel, "src/test/first.txt", cx);
+    panel.update_in(cx, |panel, window, cx| panel.open(&Open, window, cx));
+    cx.executor().run_until_parked();
+
+    panel.update_in(cx, |panel, window, cx| panel.rename(&Rename, window, cx));
+    cx.executor().run_until_parked();
+
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, cx),
+        &[
+            "v src",
+            "    v test",
+            "          [EDITOR: 'first.txt']  <== selected  <== marked",
+            "          second.txt",
+            "          third.txt"
+        ],
+    );
+
+    let confirm = panel.update_in(cx, |panel, window, cx| {
+        panel
+            .filename_editor
+            .update(cx, |editor, cx| editor.set_text("fourth.txt", window, cx));
+        panel.confirm_edit(true, window, cx).unwrap()
+    });
+    confirm.await.unwrap();
+    cx.executor().run_until_parked();
+
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, cx),
+        &[
+            "v src",
+            "    v test",
+            "          fourth.txt  <== selected",
+            "          second.txt",
+            "          third.txt"
+        ],
+        "File list should be different after rename confirmation"
+    );
+
+    panel.update_in(cx, |panel, window, cx| {
+        panel.update_visible_entries(None, false, false, window, cx);
+    });
+    cx.executor().run_until_parked();
+
+    select_path(&panel, "src/test/second.txt", cx);
+    panel.update_in(cx, |panel, window, cx| panel.open(&Open, window, cx));
+    cx.executor().run_until_parked();
+
+    workspace
+        .read_with(cx, |this, cx| {
+            assert!(
+                this.recent_navigation_history_iter(cx)
+                    .any(|(project_path, abs_path)| {
+                        project_path.path == Arc::from(rel_path("test/fourth.txt"))
+                            && abs_path == Some(PathBuf::from(path!("/src/test/fourth.txt")))
+                    })
+            );
+        })
+        .unwrap();
+}
+
+#[gpui::test]
 async fn test_select_git_entry(cx: &mut gpui::TestAppContext) {
     init_test_with_editor(cx);
 

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -2209,7 +2209,7 @@ async fn test_create_duplicate_items_and_check_history(cx: &mut gpui::TestAppCon
 
     let fs = FakeFs::new(cx.executor());
     fs.insert_tree(
-        path!("/src"),
+        "/src",
         json!({
             "test": {
                 "first.txt": "// First Txt file",

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -2466,7 +2466,11 @@ async fn test_create_duplicate_items_and_check_history(cx: &mut gpui::TestAppCon
         .unwrap();
 }
 
+// NOTE: This test is skipped on Windows, because on Windows,
+// when it triggers the lsp store it converts `/src/test/first.txt` into an uri
+// but it fails with message `"/src\\test\\first.txt" is not parseable as an URI`
 #[gpui::test]
+#[cfg_attr(target_os = "windows", ignore)]
 async fn test_rename_item_and_check_history(cx: &mut gpui::TestAppContext) {
     init_test_with_editor(cx);
 

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -2254,7 +2254,7 @@ async fn test_create_duplicate_items(cx: &mut gpui::TestAppContext) {
                 this.recent_navigation_history_iter(cx)
                     .any(|(project_path, abs_path)| {
                         project_path.path == Arc::from(rel_path("test/fourth.rs"))
-                            && abs_path == Some(PathBuf::from("/src/test/fourth.rs"))
+                            && abs_path == Some(PathBuf::from(path!("/src/test/fourth.rs")))
                     })
             );
         })

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -2197,8 +2197,6 @@ async fn test_create_duplicate_items(cx: &mut gpui::TestAppContext) {
         ],
         "File list should be unchanged after failed rename confirmation"
     );
-    panel.update_in(cx, |panel, window, cx| panel.open(&Open, window, cx));
-    cx.executor().run_until_parked();
 }
 
 // NOTE: This test is skipped on Windows, because on Windows,

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -2203,7 +2203,6 @@ async fn test_create_duplicate_items(cx: &mut gpui::TestAppContext) {
 // when it triggers the lsp store it converts `/src/test/first copy.txt` into an uri
 // but it fails with message `"/src\\test\\first copy.txt" is not parseable as an URI`
 #[gpui::test]
-#[cfg_attr(target_os = "windows", ignore)]
 async fn test_create_duplicate_items_and_check_history(cx: &mut gpui::TestAppContext) {
     init_test_with_editor(cx);
 

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -2203,6 +2203,7 @@ async fn test_create_duplicate_items(cx: &mut gpui::TestAppContext) {
 // when it triggers the lsp store it converts `/src/test/first copy.txt` into an uri
 // but it fails with message `"/src\\test\\first copy.txt" is not parseable as an URI`
 #[gpui::test]
+#[cfg_attr(target_os = "windows", ignore)]
 async fn test_create_duplicate_items_and_check_history(cx: &mut gpui::TestAppContext) {
     init_test_with_editor(cx);
 

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -2008,8 +2008,8 @@ async fn test_create_duplicate_items(cx: &mut gpui::TestAppContext) {
         json!({
             "test": {
                 "first.txt": "// First Txt file",
-                "second.rs": "// Second Rust file",
-                "third.rs": "// Third Rust file",
+                "second.txt": "// Second Txt file",
+                "third.txt": "// Third Txt file",
             }
         }),
     )
@@ -2107,8 +2107,8 @@ async fn test_create_duplicate_items(cx: &mut gpui::TestAppContext) {
             "    v test",
             "          [EDITOR: '']  <== selected",
             "          first.txt",
-            "          second.rs",
-            "          third.rs"
+            "          second.txt",
+            "          third.txt"
         ]
     );
     panel.update_in(cx, |panel, window, cx| {
@@ -2136,8 +2136,8 @@ async fn test_create_duplicate_items(cx: &mut gpui::TestAppContext) {
             "v src",
             "    v test  <== selected",
             "          first.txt",
-            "          second.rs",
-            "          third.rs"
+            "          second.txt",
+            "          third.txt"
         ],
         "File list should be unchanged after failed file create confirmation"
     );
@@ -2151,8 +2151,8 @@ async fn test_create_duplicate_items(cx: &mut gpui::TestAppContext) {
             "v src",
             "    v test",
             "          first.txt  <== selected",
-            "          second.rs",
-            "          third.rs"
+            "          second.txt",
+            "          third.txt"
         ],
     );
     panel.update_in(cx, |panel, window, cx| panel.rename(&Rename, window, cx));
@@ -2165,14 +2165,14 @@ async fn test_create_duplicate_items(cx: &mut gpui::TestAppContext) {
             "v src",
             "    v test",
             "          [EDITOR: 'first.txt']  <== selected",
-            "          second.rs",
-            "          third.rs"
+            "          second.txt",
+            "          third.txt"
         ]
     );
     panel.update_in(cx, |panel, window, cx| {
         panel
             .filename_editor
-            .update(cx, |editor, cx| editor.set_text("second.rs", window, cx));
+            .update(cx, |editor, cx| editor.set_text("second.txt", window, cx));
         assert!(
             panel.confirm_edit(true, window, cx).is_none(),
             "Should not allow to confirm on conflicting file rename"
@@ -2192,8 +2192,8 @@ async fn test_create_duplicate_items(cx: &mut gpui::TestAppContext) {
             "v src",
             "    v test",
             "          first.txt  <== selected",
-            "          second.rs",
-            "          third.rs"
+            "          second.txt",
+            "          third.txt"
         ],
         "File list should be unchanged after failed rename confirmation"
     );
@@ -2212,8 +2212,8 @@ async fn test_create_duplicate_items(cx: &mut gpui::TestAppContext) {
             "    v test",
             "          first.txt",
             "          [EDITOR: 'first copy.txt']  <== selected  <== marked",
-            "          second.rs",
-            "          third.rs"
+            "          second.txt",
+            "          third.txt"
         ],
     );
 
@@ -2233,8 +2233,8 @@ async fn test_create_duplicate_items(cx: &mut gpui::TestAppContext) {
             "    v test",
             "          first.txt",
             "          fourth.txt  <== selected",
-            "          second.rs",
-            "          third.rs"
+            "          second.txt",
+            "          third.txt"
         ],
         "File list should be different after rename confirmation"
     );

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -2209,7 +2209,7 @@ async fn test_create_duplicate_items_and_check_history(cx: &mut gpui::TestAppCon
 
     let fs = FakeFs::new(cx.executor());
     fs.insert_tree(
-        "/src",
+        path!("/src"),
         json!({
             "test": {
                 "first.txt": "// First Txt file",

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1123,7 +1123,6 @@ impl Pane {
                 false
             }
         });
-
         if let Some(existing_item_index) = existing_item_index {
             // If the item already exists, move it to the desired destination and activate it
 
@@ -4130,6 +4129,20 @@ impl NavHistory {
         state
             .closed_stack
             .retain(|entry| entry.item.id() != item_id);
+    }
+
+    pub fn rename_item(
+        &mut self,
+        item_id: EntityId,
+        project_path: ProjectPath,
+        abs_path: Option<PathBuf>,
+    ) {
+        let mut state = self.0.lock();
+        let path_for_item = state.paths_by_item.get_mut(&item_id);
+        if let Some(path_for_item) = path_for_item {
+            path_for_item.0 = project_path;
+            path_for_item.1 = abs_path;
+        }
     }
 
     pub fn path_for_item(&self, item_id: EntityId) -> Option<(ProjectPath, Option<PathBuf>)> {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -4300,6 +4300,10 @@ impl Workspace {
         cx.emit(Event::PaneRemoved);
     }
 
+    pub fn panes_mut(&mut self) -> &mut [Entity<Pane>] {
+        &mut self.panes
+    }
+
     pub fn panes(&self) -> &[Entity<Pane>] {
         &self.panes
     }


### PR DESCRIPTION
Closes #41850

When digging into this I figured out that basically what was going on is in the history of the file finder it doesn't update the name of the file duplicated because when you duplicate a file it's named automatically with `filename copy` and so this filename was added to the history but not updated so once you wanted to go back into this file it was not part of file finder displayed history anymore because this file doesn't exist anymore but the entity id remains the same.
I was also to reproduce this bug when just renaming a file.

Release Notes:

- Fixed: Display duplicated file in file finder history
