### PR TITLE
Shell out to real tar in extension builder (#41856) (cherry-pick)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5832,8 +5832,6 @@ name = "extension"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-compression",
- "async-tar",
  "async-trait",
  "collections",
  "dap",

--- a/crates/extension/Cargo.toml
+++ b/crates/extension/Cargo.toml
@@ -13,8 +13,6 @@ path = "src/extension.rs"
 
 [dependencies]
 anyhow.workspace = true
-async-compression.workspace = true
-async-tar.workspace = true
 async-trait.workspace = true
 collections.workspace = true
 dap.workspace = true


### PR DESCRIPTION
Cherry-pick of #41856
----
We see `test_extension_store_with_test_extension` hang in untarring the
WASI SDK some times.

In lieu of trying to debug the problem, let's try shelling out for now
in the hope that the test becomes more reliable.

There's a bit of risk here because we're using async-tar for other
things (but probably not 300Mb tar files...)

Assisted-By: Zed AI

Closes #ISSUE

Release Notes:

- N/A