### PR TITLE
editor: Jumping to diagnostics unfolds target locations

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -16081,7 +16081,12 @@ impl Editor {
         };
         let snapshot = self.snapshot(window, cx);
         if snapshot.intersects_fold(next_diagnostic.range.start) {
-            self.unfold_ranges(&[next_diagnostic.range.clone()], true, false, cx);
+            self.unfold_ranges(
+                std::slice::from_ref(&next_diagnostic.range),
+                true,
+                false,
+                cx,
+            );
         }
         self.change_selections(Default::default(), window, cx, |s| {
             s.select_ranges(vec![


### PR DESCRIPTION
Release Notes:

- Jumping to diagnostics no longer skips over folded regions. The folded region that contains a target diagnostic is now unfolded.
