### PR TITLE
AI: Fix Github Copilot edit predictions failing to start

### DIFF
--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -489,7 +489,11 @@ impl Copilot {
             let node_path = node_runtime.binary_path().await?;
             ensure_node_version_for_copilot(&node_path).await?;
 
-            let arguments: Vec<OsString> = vec![server_path.into(), "--stdio".into()];
+            let arguments: Vec<OsString> = vec![
+                "--experimental-sqlite".into(),
+                server_path.into(),
+                "--stdio".into(),
+            ];
             let binary = LanguageServerBinary {
                 path: node_path,
                 arguments,


### PR DESCRIPTION
Closes #41457 #41806 #41801

Copilot started using `node:sqlite` module which is an experimental feature between node v22-v23 (stable in v24). The fix was passing in the experimental flag when Zed starts the copilot LSP.

I tested this with v20.19.5 and v24.11.0. The fix got v20.19 working and didn't affect v24.11 which was already working.

Release Notes:

- AI: Fix Github Copilot edit predictions failing to start
