### PR TITLE
Fetch (just) enough refs in script/cherry-pick

### DIFF
--- a/script/cherry-pick
+++ b/script/cherry-pick
@@ -12,9 +12,8 @@ CHANNEL="$3"
 
 SHORT_SHA="${COMMIT_SHA:0:8}"
 NEW_BRANCH="cherry-pick-${BRANCH_NAME}-${SHORT_SHA}"
-git fetch origin
-git checkout "$BRANCH_NAME"
-git checkout -B "$NEW_BRANCH"
+git fetch --depth 2 origin +${COMMIT_SHA} ${BRANCH_NAME}
+git checkout --force "origin/$BRANCH_NAME" -B "$NEW_BRANCH"
 
 git cherry-pick "$COMMIT_SHA"
 


### PR DESCRIPTION
Before this change we'd download all the tagged commits, but none of their ancestors,
this was slow and made cherry-picking fail.

Release Notes:

- N/A
