### PR TITLE
inline assistant: Mention ability to add context with @ in the placeholder

### DIFF
--- a/crates/agent_ui/src/inline_prompt_editor.rs
+++ b/crates/agent_ui/src/inline_prompt_editor.rs
@@ -260,10 +260,10 @@ impl<T: 'static> PromptEditor<T> {
 
         let agent_panel_keybinding =
             ui::text_for_action(&zed_actions::assistant::ToggleFocus, window, cx)
-                .map(|keybinding| format!("{keybinding} to chat ― "))
+                .map(|keybinding| format!("{keybinding} to chat"))
                 .unwrap_or_default();
 
-        format!("{action}… ({agent_panel_keybinding}↓↑ for history)")
+        format!("{action}… ({agent_panel_keybinding} ― ↓↑ for history — @ to include context)")
     }
 
     pub fn prompt(&self, cx: &App) -> String {


### PR DESCRIPTION
This has been possible in the inline assistant for ages now and maybe you didn't know because we didn't say anything about it! This PR fixes that by including that you can @-mention context on it the same you can in the agent panel.

Release Notes:

- N/A
