### PR TITLE
git: Add cursor pointer on last commit to check changes

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -3618,43 +3618,43 @@ impl GitPanel {
                 .border_t_1()
                 .border_color(cx.theme().colors().border.opacity(0.8))
                 .child(
-                    div().overflow_hidden().line_clamp(1).child(
-                        div()
-                            .cursor_pointer()
-                            .id("commit-msg-hover")
-                            .on_click({
-                                let commit = commit.clone();
-                                let repo = active_repository.downgrade();
-                                move |_, window, cx| {
-                                    CommitView::open(
-                                        commit.sha.to_string(),
-                                        repo.clone(),
-                                        workspace.clone(),
-                                        None,
-                                        window,
-                                        cx,
-                                    );
-                                }
-                            })
-                            .hoverable_tooltip({
-                                let repo = active_repository.clone();
-                                move |window, cx| {
-                                    GitPanelMessageTooltip::new(
-                                        this.clone(),
-                                        commit.sha.clone(),
-                                        repo.clone(),
-                                        window,
-                                        cx,
-                                    )
-                                    .into()
-                                }
-                            })
-                            .child(
-                                Label::new(commit.subject.clone())
-                                    .size(LabelSize::Small)
-                                    .truncate(),
-                            ),
-                    ),
+                    div()
+                        .cursor_pointer()
+                        .overflow_hidden()
+                        .line_clamp(1)
+                        .child(
+                            Label::new(commit.subject.clone())
+                                .size(LabelSize::Small)
+                                .truncate(),
+                        )
+                        .id("commit-msg-hover")
+                        .on_click({
+                            let commit = commit.clone();
+                            let repo = active_repository.downgrade();
+                            move |_, window, cx| {
+                                CommitView::open(
+                                    commit.sha.to_string(),
+                                    repo.clone(),
+                                    workspace.clone(),
+                                    None,
+                                    window,
+                                    cx,
+                                );
+                            }
+                        })
+                        .hoverable_tooltip({
+                            let repo = active_repository.clone();
+                            move |window, cx| {
+                                GitPanelMessageTooltip::new(
+                                    this.clone(),
+                                    commit.sha.clone(),
+                                    repo.clone(),
+                                    window,
+                                    cx,
+                                )
+                                .into()
+                            }
+                        }),
                 )
                 .when(commit.has_parent, |this| {
                     let has_unstaged = self.has_unstaged_changes();

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -3618,43 +3618,43 @@ impl GitPanel {
                 .border_t_1()
                 .border_color(cx.theme().colors().border.opacity(0.8))
                 .child(
-                    div()
-                        .flex_grow()
-                        .overflow_hidden()
-                        .line_clamp(1)
-                        .child(
-                            Label::new(commit.subject.clone())
-                                .size(LabelSize::Small)
-                                .truncate(),
-                        )
-                        .id("commit-msg-hover")
-                        .on_click({
-                            let commit = commit.clone();
-                            let repo = active_repository.downgrade();
-                            move |_, window, cx| {
-                                CommitView::open(
-                                    commit.sha.to_string(),
-                                    repo.clone(),
-                                    workspace.clone(),
-                                    None,
-                                    window,
-                                    cx,
-                                );
-                            }
-                        })
-                        .hoverable_tooltip({
-                            let repo = active_repository.clone();
-                            move |window, cx| {
-                                GitPanelMessageTooltip::new(
-                                    this.clone(),
-                                    commit.sha.clone(),
-                                    repo.clone(),
-                                    window,
-                                    cx,
-                                )
-                                .into()
-                            }
-                        }),
+                    div().overflow_hidden().line_clamp(1).child(
+                        div()
+                            .cursor_pointer()
+                            .id("commit-msg-hover")
+                            .on_click({
+                                let commit = commit.clone();
+                                let repo = active_repository.downgrade();
+                                move |_, window, cx| {
+                                    CommitView::open(
+                                        commit.sha.to_string(),
+                                        repo.clone(),
+                                        workspace.clone(),
+                                        None,
+                                        window,
+                                        cx,
+                                    );
+                                }
+                            })
+                            .hoverable_tooltip({
+                                let repo = active_repository.clone();
+                                move |window, cx| {
+                                    GitPanelMessageTooltip::new(
+                                        this.clone(),
+                                        commit.sha.clone(),
+                                        repo.clone(),
+                                        window,
+                                        cx,
+                                    )
+                                    .into()
+                                }
+                            })
+                            .child(
+                                Label::new(commit.subject.clone())
+                                    .size(LabelSize::Small)
+                                    .truncate(),
+                            ),
+                    ),
                 )
                 .when(commit.has_parent, |this| {
                     let has_unstaged = self.has_unstaged_changes();


### PR DESCRIPTION
Release Notes:
-  Improved visual cue on git panel ui to check previous commit changes 

Before: 
<img width="1470" height="956" alt="Screenshot 2025-11-05 at 2 06 49 pm" src="https://github.com/user-attachments/assets/b8c54bb6-c8b8-4d36-a14f-71d725ed68f2" />

After:
<img width="1470" height="956" alt="Screenshot 2025-11-05 at 2 06 24 pm" src="https://github.com/user-attachments/assets/d8d96f9e-ceed-4c02-9f93-de9fd3dfcbf1" />
