### PR TITLE
gpui: Fix ellipsis not applying when line width is close to truncate width

### DIFF
--- a/crates/gpui/src/text_system/line_wrapper.rs
+++ b/crates/gpui/src/text_system/line_wrapper.rs
@@ -151,7 +151,7 @@ impl LineWrapper {
             let char_width = self.width_for_char(c);
             width += char_width;
 
-            if width.floor() > truncate_width {
+            if width > truncate_width {
                 let result =
                     SharedString::from(format!("{}{}", &line[..truncate_ix], truncation_suffix));
                 let mut runs = runs.to_vec();


### PR DESCRIPTION
When the width of the text (e.g. 102.8px) is close to the truncate width (e.g. 102px), the ellipsis don't apply due to the use of .floor().

This flooring behaviour seems incorrect and results in issues like the one in the attached screenshot

<img width="591" height="277" alt="image" src="https://github.com/user-attachments/assets/be20feec-50af-4922-ad6e-eaced3a8ae77" />