### PR TITLE
Work around codegen bug with GetKeyboardState

### DIFF
--- a/crates/gpui/src/interactive.rs
+++ b/crates/gpui/src/interactive.rs
@@ -26,10 +26,8 @@ pub struct KeyDownEvent {
     /// Whether the key is currently held down.
     pub is_held: bool,
 
-    /// Whether the modifiers are excessive for producing this character.
-    /// When false, the modifiers are essential for character input (e.g., AltGr),
-    /// and character input should be prioritized over keybindings.
-    /// When true, the modifiers are for keybindings (e.g., Ctrl+A).
+    /// Whether to prefer character input over keybindings for this keystroke.
+    /// In some cases, like AltGr on Windows, modifiers are significant for character input.
     pub prefer_character_input: bool,
 }
 

--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -1387,6 +1387,8 @@ fn should_prefer_character_input(vkey: VIRTUAL_KEY, scan_code: u16) -> bool {
         return false;
     }
 
+    // Workaround for some bug that makes the compiler think keyboard_state is still zeroed out
+    let keyboard_state = std::hint::black_box(keyboard_state);
     let ctrl_down = (keyboard_state[VK_CONTROL.0 as usize] & 0x80) != 0;
     let alt_down = (keyboard_state[VK_MENU.0 as usize] & 0x80) != 0;
     let win_down = (keyboard_state[VK_LWIN.0 as usize] & 0x80) != 0


### PR DESCRIPTION
Works around an issue, which can be reproduced in the following program:
```rs
use windows::Win32::UI::Input::KeyboardAndMouse::{GetKeyboardState, VK_CONTROL};

fn main() {
    let mut keyboard_state = [0u8; 256];
    unsafe {
        GetKeyboardState(&mut keyboard_state).unwrap();
    }

    let ctrl_down = (keyboard_state[VK_CONTROL.0 as usize] & 0x80) != 0;
    println!("Is Ctrl down: {ctrl_down}");
}
```

In debug mode, this program prints the correct answer. In release mode, it always prints false. The optimizer appears to think that `keyboard_state` isn't mutated and remains zeroed, and folds the `modifier_down` comparisons to `false`.

Release Notes:

- N/A
