### PR TITLE
gpui: Improve `Background` type

### DIFF
--- a/crates/gpui/src/platform/blade/blade_renderer.rs
+++ b/crates/gpui/src/platform/blade/blade_renderer.rs
@@ -3,8 +3,8 @@
 
 use super::{BladeAtlas, BladeContext};
 use crate::{
-    Background, Bounds, DevicePixels, GpuSpecs, MonochromeSprite, Path, Point, PolychromeSprite,
-    PrimitiveBatch, Quad, ScaledPixels, Scene, Shadow, Size, Underline,
+    BackgroundColor, Bounds, DevicePixels, GpuSpecs, MonochromeSprite, Path, Point,
+    PolychromeSprite, PrimitiveBatch, Quad, ScaledPixels, Scene, Shadow, Size, Underline,
     get_gamma_correction_ratios,
 };
 use blade_graphics as gpu;
@@ -119,7 +119,7 @@ struct PathSprite {
 struct PathRasterizationVertex {
     xy_position: Point<ScaledPixels>,
     st_position: Point<f32>,
-    color: Background,
+    color: BackgroundColor,
     bounds: Bounds<ScaledPixels>,
 }
 

--- a/crates/gpui/src/platform/blade/shaders.wgsl
+++ b/crates/gpui/src/platform/blade/shaders.wgsl
@@ -106,7 +106,7 @@ struct LinearColorStop {
     percentage: f32,
 }
 
-struct Background {
+struct BackgroundColor {
     // 0u is Solid
     // 1u is LinearGradient
     // 2u is PatternSlash
@@ -403,7 +403,7 @@ fn prepare_gradient_color(tag: u32, color_space: u32,
     return result;
 }
 
-fn gradient_color(background: Background, position: vec2<f32>, bounds: Bounds,
+fn gradient_color(background: BackgroundColor, position: vec2<f32>, bounds: Bounds,
     solid_color: vec4<f32>, color0: vec4<f32>, color1: vec4<f32>) -> vec4<f32> {
     var background_color = vec4<f32>(0.0);
 
@@ -483,7 +483,7 @@ struct Quad {
     border_style: u32,
     bounds: Bounds,
     content_mask: Bounds,
-    background: Background,
+    background: BackgroundColor,
     border_color: Hsla,
     corner_radii: Corners,
     border_widths: Edges,
@@ -986,7 +986,7 @@ fn fs_shadow(input: ShadowVarying) -> @location(0) vec4<f32> {
 struct PathRasterizationVertex {
     xy_position: vec2<f32>,
     st_position: vec2<f32>,
-    color: Background,
+    color: BackgroundColor,
     bounds: Bounds,
 }
 

--- a/crates/gpui/src/platform/mac/metal_renderer.rs
+++ b/crates/gpui/src/platform/mac/metal_renderer.rs
@@ -1,8 +1,8 @@
 use super::metal_atlas::MetalAtlas;
 use crate::{
-    AtlasTextureId, Background, Bounds, ContentMask, DevicePixels, MonochromeSprite, PaintSurface,
-    Path, Point, PolychromeSprite, PrimitiveBatch, Quad, ScaledPixels, Scene, Shadow, Size,
-    Surface, Underline, point, size,
+    AtlasTextureId, BackgroundColor, Bounds, ContentMask, DevicePixels, MonochromeSprite,
+    PaintSurface, Path, Point, PolychromeSprite, PrimitiveBatch, Quad, ScaledPixels, Scene, Shadow,
+    Size, Surface, Underline, point, size,
 };
 use anyhow::Result;
 use block::ConcreteBlock;
@@ -123,7 +123,7 @@ pub(crate) struct MetalRenderer {
 pub struct PathRasterizationVertex {
     pub xy_position: Point<ScaledPixels>,
     pub st_position: Point<f32>,
-    pub color: Background,
+    pub color: BackgroundColor,
     pub bounds: Bounds<ScaledPixels>,
 }
 

--- a/crates/gpui/src/platform/mac/shaders.metal
+++ b/crates/gpui/src/platform/mac/shaders.metal
@@ -34,7 +34,7 @@ float blur_along_x(float x, float y, float sigma, float corner,
                    float2 half_size);
 float4 over(float4 below, float4 above);
 float radians(float degrees);
-float4 fill_color(Background background, float2 position, Bounds_ScaledPixels bounds,
+float4 fill_color(BackgroundColor background, float2 position, Bounds_ScaledPixels bounds,
   float4 solid_color, float4 color0, float4 color1);
 
 struct GradientColor {
@@ -764,7 +764,7 @@ fragment float4 path_rasterization_fragment(
   float2 dy = dfdy(input.st_position);
 
   PathRasterizationVertex v = vertices[input.vertex_id];
-  Background background = v.color;
+  BackgroundColor background = v.color;
   Bounds_ScaledPixels path_bounds = v.bounds;
   float alpha;
   if (length(float2(dx.x, dy.x)) < 0.001) {
@@ -1164,7 +1164,7 @@ float2x2 rotate2d(float angle) {
     return float2x2(c, -s, s, c);
 }
 
-float4 fill_color(Background background,
+float4 fill_color(BackgroundColor background,
                       float2 position,
                       Bounds_ScaledPixels bounds,
                       float4 solid_color, float4 color0, float4 color1) {

--- a/crates/gpui/src/platform/windows/directx_renderer.rs
+++ b/crates/gpui/src/platform/windows/directx_renderer.rs
@@ -951,7 +951,7 @@ impl<T> PipelineState<T> {
 struct PathRasterizationSprite {
     xy_position: Point<ScaledPixels>,
     st_position: Point<f32>,
-    color: Background,
+    color: BackgroundColor,
     bounds: Bounds<ScaledPixels>,
 }
 

--- a/crates/gpui/src/platform/windows/shaders.hlsl
+++ b/crates/gpui/src/platform/windows/shaders.hlsl
@@ -41,7 +41,7 @@ struct LinearColorStop {
     float percentage;
 };
 
-struct Background {
+struct BackgroundColor {
     // 0u is Solid
     // 1u is LinearGradient
     // 2u is PatternSlash
@@ -328,7 +328,7 @@ float2x2 rotate2d(float angle) {
     return float2x2(c, -s, s, c);
 }
 
-float4 gradient_color(Background background,
+float4 gradient_color(BackgroundColor background,
                       float2 position,
                       Bounds bounds,
                       float4 solid_color, float4 color0, float4 color1) {
@@ -464,7 +464,7 @@ struct Quad {
     uint border_style;
     Bounds bounds;
     Bounds content_mask;
-    Background background;
+    BackgroundColor background;
     Hsla border_color;
     Corners corner_radii;
     Edges border_widths;
@@ -896,7 +896,7 @@ float4 shadow_fragment(ShadowFragmentInput input): SV_TARGET {
 struct PathRasterizationSprite {
     float2 xy_position;
     float2 st_position;
-    Background color;
+    BackgroundColor color;
     Bounds bounds;
 };
 
@@ -932,7 +932,7 @@ float4 path_rasterization_fragment(PathFragmentInput input): SV_Target {
     float2 dy = ddy(input.st_position);
     PathRasterizationSprite sprite = path_rasterization_sprites[input.vertex_id];
 
-    Background background = sprite.color;
+    BackgroundColor background = sprite.color;
     Bounds bounds = sprite.bounds;
 
     float alpha;

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -5,7 +5,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    AtlasTextureId, AtlasTile, Background, Bounds, ContentMask, Corners, Edges, Hsla, Pixels,
+    AtlasTextureId, AtlasTile, BackgroundColor, Bounds, ContentMask, Corners, Edges, Hsla, Pixels,
     Point, Radians, ScaledPixels, Size, bounds_tree::BoundsTree, point,
 };
 use std::{
@@ -455,7 +455,7 @@ pub(crate) struct Quad {
     pub border_style: BorderStyle,
     pub bounds: Bounds<ScaledPixels>,
     pub content_mask: ContentMask<ScaledPixels>,
-    pub background: Background,
+    pub background: BackgroundColor,
     pub border_color: Hsla,
     pub corner_radii: Corners<ScaledPixels>,
     pub border_widths: Edges<ScaledPixels>,
@@ -679,7 +679,7 @@ pub struct Path<P: Clone + Debug + Default + PartialEq> {
     pub(crate) bounds: Bounds<P>,
     pub(crate) content_mask: ContentMask<P>,
     pub(crate) vertices: Vec<PathVertex<P>>,
-    pub(crate) color: Background,
+    pub(crate) color: BackgroundColor,
     start: Point<P>,
     current: Point<P>,
     contour_count: usize,

--- a/crates/gpui/src/style.rs
+++ b/crates/gpui/src/style.rs
@@ -5,9 +5,9 @@ use std::{
 };
 
 use crate::{
-    AbsoluteLength, App, Background, BackgroundTag, BorderStyle, Bounds, ContentMask, Corners,
-    CornersRefinement, CursorStyle, DefiniteLength, DevicePixels, Edges, EdgesRefinement, Font,
-    FontFallbacks, FontFeatures, FontStyle, FontWeight, GridLocation, Hsla, Length, Pixels, Point,
+    AbsoluteLength, App, Background, BorderStyle, Bounds, ContentMask, Corners, CornersRefinement,
+    CursorStyle, DefiniteLength, DevicePixels, Edges, EdgesRefinement, Font, FontFallbacks,
+    FontFeatures, FontStyle, FontWeight, GridLocation, Hsla, Length, Pixels, Point,
     PointRefinement, Rgba, SharedString, Size, SizeRefinement, Styled, TextRun, Window, black, phi,
     point, quad, rems, size,
 };
@@ -626,25 +626,17 @@ impl Style {
 
         window.paint_shadows(bounds, corner_radii, &self.box_shadow);
 
-        let background_color = self.background.as_ref().and_then(Fill::color);
-        if background_color.is_some_and(|color| !color.is_transparent()) {
-            let mut border_color = match background_color {
-                Some(color) => match color.tag {
-                    BackgroundTag::Solid => color.solid,
-                    BackgroundTag::LinearGradient => color
-                        .colors
-                        .first()
-                        .map(|stop| stop.color)
-                        .unwrap_or_default(),
-                    BackgroundTag::PatternSlash => color.solid,
-                },
+        let background = self.background.as_ref().and_then(Fill::color);
+        if background.is_some_and(|background| !background.is_transparent()) {
+            let mut border_color = match background {
+                Some(color) => color.fill(),
                 None => Hsla::default(),
             };
             border_color.a = 0.;
             window.paint_quad(quad(
                 bounds,
                 corner_radii,
-                background_color.unwrap_or_default(),
+                background.unwrap_or_default(),
                 Edges::default(),
                 border_color,
                 self.border_style,

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -2,21 +2,22 @@
 use crate::Inspector;
 use crate::{
     Action, AnyDrag, AnyElement, AnyImageCache, AnyTooltip, AnyView, App, AppContext, Arena, Asset,
-    AsyncWindowContext, AvailableSpace, Background, BorderStyle, Bounds, BoxShadow, Capslock,
-    Context, Corners, CursorStyle, Decorations, DevicePixels, DispatchActionListener,
-    DispatchNodeId, DispatchTree, DisplayId, Edges, Effect, Entity, EntityId, EventEmitter,
-    FileDropEvent, FontId, Global, GlobalElementId, GlyphId, GpuSpecs, Hsla, InputHandler, IsZero,
-    KeyBinding, KeyContext, KeyDownEvent, KeyEvent, Keystroke, KeystrokeEvent, LayoutId,
-    LineLayoutIndex, Modifiers, ModifiersChangedEvent, MonochromeSprite, MouseButton, MouseEvent,
-    MouseMoveEvent, MouseUpEvent, Path, Pixels, PlatformAtlas, PlatformDisplay, PlatformInput,
-    PlatformInputHandler, PlatformWindow, Point, PolychromeSprite, PromptButton, PromptLevel, Quad,
-    Render, RenderGlyphParams, RenderImage, RenderImageParams, RenderSvgParams, Replay, ResizeEdge,
-    SMOOTH_SVG_SCALE_FACTOR, SUBPIXEL_VARIANTS_X, SUBPIXEL_VARIANTS_Y, ScaledPixels, Scene, Shadow,
-    SharedString, Size, StrikethroughStyle, Style, SubscriberSet, Subscription, SystemWindowTab,
-    SystemWindowTabController, TabStopMap, TaffyLayoutEngine, Task, TextStyle, TextStyleRefinement,
-    TransformationMatrix, Underline, UnderlineStyle, WindowAppearance, WindowBackgroundAppearance,
-    WindowBounds, WindowControls, WindowDecorations, WindowOptions, WindowParams, WindowTextSystem,
-    point, prelude::*, px, rems, size, transparent_black,
+    AsyncWindowContext, AvailableSpace, Background, BackgroundColor, BorderStyle, Bounds,
+    BoxShadow, Capslock, Context, Corners, CursorStyle, Decorations, DevicePixels,
+    DispatchActionListener, DispatchNodeId, DispatchTree, DisplayId, Edges, Effect, Entity,
+    EntityId, EventEmitter, FileDropEvent, FontId, Global, GlobalElementId, GlyphId, GpuSpecs,
+    Hsla, InputHandler, IsZero, KeyBinding, KeyContext, KeyDownEvent, KeyEvent, Keystroke,
+    KeystrokeEvent, LayoutId, LineLayoutIndex, Modifiers, ModifiersChangedEvent, MonochromeSprite,
+    MouseButton, MouseEvent, MouseMoveEvent, MouseUpEvent, Path, Pixels, PlatformAtlas,
+    PlatformDisplay, PlatformInput, PlatformInputHandler, PlatformWindow, Point, PolychromeSprite,
+    PromptButton, PromptLevel, Quad, Render, RenderGlyphParams, RenderImage, RenderImageParams,
+    RenderSvgParams, Replay, ResizeEdge, SMOOTH_SVG_SCALE_FACTOR, SUBPIXEL_VARIANTS_X,
+    SUBPIXEL_VARIANTS_Y, ScaledPixels, Scene, Shadow, SharedString, Size, StrikethroughStyle,
+    Style, SubscriberSet, Subscription, SystemWindowTab, SystemWindowTabController, TabStopMap,
+    TaffyLayoutEngine, Task, TextStyle, TextStyleRefinement, TransformationMatrix, Underline,
+    UnderlineStyle, WindowAppearance, WindowBackgroundAppearance, WindowBounds, WindowControls,
+    WindowDecorations, WindowOptions, WindowParams, WindowTextSystem, point, prelude::*, px, rems,
+    size, transparent_black,
 };
 use anyhow::{Context as _, Result, anyhow};
 use collections::{FxHashMap, FxHashSet};
@@ -2864,7 +2865,7 @@ impl Window {
             order: 0,
             bounds: quad.bounds.scale(scale_factor),
             content_mask: content_mask.scale(scale_factor),
-            background: quad.background.opacity(opacity),
+            background: BackgroundColor::from(quad.background.opacity(opacity)),
             border_color: quad.border_color.opacity(opacity),
             corner_radii: quad.corner_radii.scale(scale_factor),
             border_widths: quad.border_widths.scale(scale_factor),
@@ -2883,7 +2884,7 @@ impl Window {
         let opacity = self.element_opacity();
         path.content_mask = content_mask;
         let color: Background = color.into();
-        path.color = color.opacity(opacity);
+        path.color = BackgroundColor::from(color.opacity(opacity));
         self.next_frame
             .scene
             .insert_primitive(path.scale(scale_factor));


### PR DESCRIPTION
Release Notes:

- N/A

---

I was changed `Fill` to use `Background` since PR #20812.

But it's not inconvenient to retrieve the background color already set in the current style.

For example: I have use `StyleRefinement` a lot in GPUI Component, I may define a `style` for an element and `impl Styled for MyElement` for allows user to override the element default style.

In this case, I often need to get the `bg` of user sets to do something, e.g.: Adjust that color opacity to border use.

```rs
struct MyElement {
    style: StyleRefinement,
}

impl Styled for MyElement {
    fn style(&mut self) -> &mut StyleRefinement {
        &mut self.style
    }
}

fn render(...) {
    let bg_color = self.style.background;
    // Adjust bg_color ...

    div()
        .bg(default_color)
        .border_color(...)
        .map(|this| this.style().refine(&self.style))
}
```

- [x] Test macOS
- [x] Test Blade macOS
- [x] Test Windows