### PR TITLE
gpui: Fix busyloop on X disconnect

### DIFF
--- a/crates/gpui_linux/src/linux/x11/client.rs
+++ b/crates/gpui_linux/src/linux/x11/client.rs
@@ -602,6 +602,9 @@ impl X11Client {
                     Ok(None) => {
                         break;
                     }
+                    Err(err @ ConnectionError::IoError(..)) => {
+                        return Err(EventHandlerError::from(err));
+                    }
                     Err(err) => {
                         let err = handle_connection_error(err);
                         log::warn!("error while polling for X11 events: {err:?}");


### PR DESCRIPTION
When the connection to X is broken zed will go into an infinite loop and eat up 100% (of one core) of CPU; this change causes it to exit with an error instead.

I encountered this behavior while running zed in [Xephyr](https://freedesktop.org/wiki/Software/Xephyr/) for testing, though I do sometimes terminate my X server as a way to log out or attempt to recover from a (very) broken state, and I appreciate a graceful exit in those situations!

Exiting in case of X server disconnect is common practice in my observations, likely as the difficulty of recreating state stored server-side outweighs the potential utility in attempting to recover (if "reconnecting" to an X server is ever desired in regular usage, [Xpra](https://xpra.org/index.html) might be able to help!).


Release Notes:

- N/A
