### PR TITLE
Add helix keymap to delete without yanking

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -455,6 +455,7 @@
       "<": "vim::Outdent",
       "=": "vim::AutoIndent",
       "d": "vim::HelixDelete",
+      "alt-d": "editor::Delete", // Delete selection, without yanking
       "c": "vim::HelixSubstitute",
       "alt-c": "vim::HelixSubstituteNoYank",
 


### PR DESCRIPTION
Added previously missing keymap for helix deleting without yank. Action "editor::Delete" is mapped to "Ald-d" as in https://docs.helix-editor.com/master/keymap.html#changes

Release Notes:

- N/A