### PR TITLE
agent_ui: Reduce label repetitiveness on new thread menu

### DIFF
--- a/crates/agent_ui/src/agent_configuration.rs
+++ b/crates/agent_ui/src/agent_configuration.rs
@@ -1013,7 +1013,7 @@ impl AgentConfiguration {
                             .child(Divider::horizontal().color(DividerColor::BorderFaded))
                             .child(self.render_agent_server(
                                 AgentIcon::Name(IconName::AiOpenAi),
-                                "Codex",
+                                "Codex CLI",
                                 false,
                             ))
                             .child(Divider::horizontal().color(DividerColor::BorderFaded))

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1978,7 +1978,7 @@ impl AgentPanel {
                             .separator()
                             .header("External Agents")
                             .item(
-                                ContextMenuEntry::new("New Claude Code Thread")
+                                ContextMenuEntry::new("New Claude Code")
                                     .icon(IconName::AiClaude)
                                     .disabled(is_via_collab)
                                     .icon_color(Color::Muted)
@@ -2004,7 +2004,7 @@ impl AgentPanel {
                                     }),
                             )
                             .item(
-                                ContextMenuEntry::new("New Codex Thread")
+                                ContextMenuEntry::new("New Codex CLI")
                                     .icon(IconName::AiOpenAi)
                                     .disabled(is_via_collab)
                                     .icon_color(Color::Muted)
@@ -2030,7 +2030,7 @@ impl AgentPanel {
                                     }),
                             )
                             .item(
-                                ContextMenuEntry::new("New Gemini CLI Thread")
+                                ContextMenuEntry::new("New Gemini CLI")
                                     .icon(IconName::AiGemini)
                                     .icon_color(Color::Muted)
                                     .disabled(is_via_collab)
@@ -2074,7 +2074,7 @@ impl AgentPanel {
                                 for agent_name in agent_names {
                                     let icon_path = agent_server_store_read.agent_icon(&agent_name);
                                     let mut entry =
-                                        ContextMenuEntry::new(format!("New {} Thread", agent_name));
+                                        ContextMenuEntry::new(format!("New {}", agent_name));
                                     if let Some(icon_path) = icon_path {
                                         entry = entry.custom_icon_path(icon_path);
                                     } else {

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1880,7 +1880,12 @@ impl AgentPanel {
                 {
                     let focus_handle = focus_handle.clone();
                     move |_window, cx| {
-                        Tooltip::for_action_in("New…", &ToggleNewThreadMenu, &focus_handle, cx)
+                        Tooltip::for_action_in(
+                            "New Thread…",
+                            &ToggleNewThreadMenu,
+                            &focus_handle,
+                            cx,
+                        )
                     }
                 },
             )


### PR DESCRIPTION
Mostly just removing "thread" from all external agent menu items; I think we can do without it and it already becomes much better/cleaner.

Release Notes:

- N/A
