### PR TITLE
collab_ui: Show parents when searching channels

### DIFF
--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -645,7 +645,7 @@ impl CollabPanel {
                 executor.clone(),
             ));
 
-            let channel_ids_of_matches_or_parents = matches
+            let channel_ids_of_matches_or_parents: HashSet<_> = matches
                 .iter()
                 .flat_map(|mat| {
                     let match_channel = channels[mat.candidate_id];
@@ -656,7 +656,7 @@ impl CollabPanel {
                         .copied()
                         .chain(Some(match_channel.id))
                 })
-                .collect::<HashSet<_>>();
+                .collect();
 
             channels.retain(|chan| channel_ids_of_matches_or_parents.contains(&chan.id));
 


### PR DESCRIPTION
When searching through channels, it now shows all parents of the channel matches. This means that, if there are multiple channels with the same name (`notes` is very noticeable), you can now see *which* notes channel it's referring to.

Release Notes:

- N/A
