### PR TITLE
Enhance commit message generation with external agent support

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -2005,9 +2005,6 @@ impl GitPanel {
         }
     }
 
-    fn generate_commit_message_via_codex(&mut self, cx: &mut Context<Self>) {
-        self.generate_commit_message_via_agent_internal(Codex, cx);
-    }
 
     fn generate_commit_message_via_agent_internal<S>(&mut self, server: S, cx: &mut Context<Self>)
     where


### PR DESCRIPTION
This update introduces functionality to generate commit messages using external agents if the configured language model is unavailable or disabled. The `generate_commit_message` method now checks for available external agents and falls back to them when necessary. Additionally, new methods have been added to handle the connection and communication with these agents, improving the overall commit message generation process.

- Added support for generating commit messages via external agents (Codex, ClaudeCode, Gemini).
- Improved error handling and user feedback during the commit message generation process.

Not a rust expert by any chance, but this is a much loved feature by me and happy to make any changes needed after a review