### PR TITLE
Fix corrupted characters being inserted when Alt is pressed

### DIFF
--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -1370,7 +1370,7 @@ fn should_prefer_character_input(vkey: VIRTUAL_KEY, scan_code: u16) -> bool {
             scan_code as u32,
             Some(&keyboard_state),
             &mut buffer_c,
-            0x4,
+            0x5,
         )
     };
     if result_c < 0 {
@@ -1415,7 +1415,7 @@ fn should_prefer_character_input(vkey: VIRTUAL_KEY, scan_code: u16) -> bool {
             scan_code as u32,
             Some(&state_no_modifiers),
             &mut buffer_c_no_modifiers,
-            0x4,
+            0x5,
         )
     };
     if result_c_no_modifiers <= 0 {


### PR DESCRIPTION
The Alt+Numpad buffer that's maintained by the input stack is getting corrupted, leading to garbage characters being inserted on keystrokes like Alt+Up. Disable the automatic handling of Alt+Numpad for now until the cause of this corruption is understood. The Alt+Numpad input did not work anyway, so this does not regress anything.

Release Notes:

- windows: Fixed corrupted characters being inserted when Alt is pressed (preview only)
