### PR TITLE
Run ACP login from same cwd as agent server

### DIFF
--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -1679,7 +1679,10 @@ impl AcpThreadView {
             && let Some(login) = self.login.clone()
         {
             if let Some(workspace) = self.workspace.upgrade() {
-                Self::spawn_external_agent_login(login, workspace, false, window, cx)
+                let project = self.project.clone();
+                Self::spawn_external_agent_login(
+                    login, workspace, project, false, false, window, cx,
+                )
             } else {
                 Task::ready(Ok(()))
             }
@@ -1729,14 +1732,15 @@ impl AcpThreadView {
     fn spawn_external_agent_login(
         login: task::SpawnInTerminal,
         workspace: Entity<Workspace>,
+        project: Entity<Project>,
         previous_attempt: bool,
+        check_exit_code: bool,
         window: &mut Window,
         cx: &mut App,
     ) -> Task<Result<()>> {
         let Some(terminal_panel) = workspace.read(cx).panel::<TerminalPanel>(cx) else {
             return Task::ready(Ok(()));
         };
-        let project = workspace.read(cx).project().clone();
 
         window.spawn(cx, async move |cx| {
             let mut task = login.clone();

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -1773,7 +1773,7 @@ impl AcpThreadView {
             let terminal = terminal.await?;
 
             if check_exit_code {
-                // For extension-based auth: just wait for the process to exit and check exit code
+                // For extension-based auth, wait for the process to exit and check exit code
                 let exit_status = terminal
                     .read_with(cx, |terminal, cx| terminal.wait_for_completed_task(cx))?
                     .await;

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -1735,7 +1735,7 @@ impl AcpThreadView {
             if let Some(cmd) = &task.command {
                 // Have "node" command use Zed's managed Node runtime by default
                 if cmd == "node" {
-                    let resolved_node = project
+                    let resolved_node_runtime = project
                         .update(cx, |project, cx| {
                             let agent_server_store = project.agent_server_store().clone();
                             agent_server_store.update(cx, |store, cx| {
@@ -1745,9 +1745,9 @@ impl AcpThreadView {
                                     })
                                 })
                             })
-                        })?;
+                        });
 
-                    if let Some(resolve_task) = resolved_node {
+                    if let Ok(Some(resolve_task)) = resolved_node_runtime {
                         if let Ok(node_path) = resolve_task.await {
                             task.command = Some(node_path.to_string_lossy().to_string());
                         }

--- a/crates/extension/src/extension_manifest.rs
+++ b/crates/extension/src/extension_manifest.rs
@@ -173,6 +173,9 @@ pub struct AgentServerManifestEntry {
     /// cmd = "node"
     /// args = ["index.js", "--port", "3000"]
     /// ```
+    ///
+    /// Note: All commands are executed with the archive extraction directory as the
+    /// working directory.
     pub targets: HashMap<String, TargetConfig>,
 }
 

--- a/crates/extension/src/extension_manifest.rs
+++ b/crates/extension/src/extension_manifest.rs
@@ -175,7 +175,8 @@ pub struct AgentServerManifestEntry {
     /// ```
     ///
     /// Note: All commands are executed with the archive extraction directory as the
-    /// working directory.
+    /// working directory, so relative paths in args (like "index.js") will resolve
+    /// relative to the extracted archive contents.
     pub targets: HashMap<String, TargetConfig>,
 }
 

--- a/crates/project/src/agent_server_store.rs
+++ b/crates/project/src/agent_server_store.rs
@@ -1560,7 +1560,7 @@ impl ExternalAgentServer for LocalExtensionArchiveAgent {
                 env: Some(env),
             };
 
-            Ok((command, root_dir.to_string_lossy().into_owned(), None))
+            Ok((command, version_dir.to_string_lossy().into_owned(), None))
         })
     }
 

--- a/crates/project/src/agent_server_store.rs
+++ b/crates/project/src/agent_server_store.rs
@@ -438,6 +438,13 @@ impl AgentServerStore {
         cx.emit(AgentServersUpdated);
     }
 
+    pub fn node_runtime(&self) -> Option<NodeRuntime> {
+        match &self.state {
+            AgentServerStoreState::Local { node_runtime, .. } => Some(node_runtime.clone()),
+            _ => None,
+        }
+    }
+
     pub fn local(
         node_runtime: NodeRuntime,
         fs: Arc<dyn Fs>,

--- a/crates/project/src/agent_server_store.rs
+++ b/crates/project/src/agent_server_store.rs
@@ -1966,7 +1966,7 @@ mod extension_agent_tests {
         let agent = LocalExtensionArchiveAgent {
             fs: fs.clone(),
             http_client,
-            node_runtime: node_runtime.clone(),
+            node_runtime,
             project_environment,
             extension_id: Arc::from("test-ext"),
             agent_id: Arc::from("test-agent"),


### PR DESCRIPTION
This makes it possible to do login via things like `cmd: "node", args: ["my-node-file.js", "login"]`

Also, that command will now use Zed's managed `node` instance.

Release Notes:

- ACP extensions can now run terminal login commands using relative paths