### PR TITLE
Fix windows crash handler

### DIFF
--- a/crates/crashes/src/crashes.rs
+++ b/crates/crashes/src/crashes.rs
@@ -265,9 +265,10 @@ impl minidumper::ServerHandler for CrashServer {
             3 => {
                 let gpu_specs: system_specs::GpuSpecs =
                     bincode::deserialize(&buffer).expect("gpu specs");
-                self.active_gpu
-                    .set(gpu_specs)
-                    .expect("already set active gpu");
+                // we ignore the case where it was already set because this message is sent
+                // on each new window. in theory all zed windows should be using the same
+                // GPU so this is fine.
+                self.active_gpu.set(gpu_specs).ok()
             }
             _ => {
                 panic!("invalid message kind");

--- a/crates/crashes/src/crashes.rs
+++ b/crates/crashes/src/crashes.rs
@@ -268,7 +268,7 @@ impl minidumper::ServerHandler for CrashServer {
                 // we ignore the case where it was already set because this message is sent
                 // on each new window. in theory all zed windows should be using the same
                 // GPU so this is fine.
-                self.active_gpu.set(gpu_specs).ok()
+                self.active_gpu.set(gpu_specs).ok();
             }
             _ => {
                 panic!("invalid message kind");


### PR DESCRIPTION
Closes #41471

We were killing the crash handler when it received a second copy of any of the messages, but this GPU specs one is sent on each new window rather than once at startup. We could gate the sending to only happen once, but it's simpler to just allow multiple gpu specs messages.

Release Notes:

- N/A