### PR TITLE
Adjust terminal decorative character ranges to include missing Powerline characters

### DIFF
--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -1665,6 +1665,8 @@ mod tests {
         assert!(TerminalElement::is_decorative_character('\u{E0B2}')); // Powerline left triangle
         assert!(TerminalElement::is_decorative_character('\u{E0B4}')); // Powerline right half circle (the actual issue!)
         assert!(TerminalElement::is_decorative_character('\u{E0B6}')); // Powerline left half circle
+        assert!(TerminalElement::is_decorative_character('\u{E0CA}')); // Powerline mirrored ice waveform
+        assert!(TerminalElement::is_decorative_character('\u{E0D7}')); // Powerline left triangle inverted
 
         // Characters that should NOT be considered decorative
         assert!(!TerminalElement::is_decorative_character('A')); // Regular letter

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -537,9 +537,10 @@ impl TerminalElement {
 
             // Private Use Area - Powerline separator symbols only
             | 0xE0B0..=0xE0B7 // Powerline separators: triangles (E0B0-E0B3) and half circles (E0B4-E0B7)
-            | 0xE0B8..=0xE0BF // Additional Powerline separators: angles, flames, etc.
-            | 0xE0C0..=0xE0C8 // Powerline separators: pixelated triangles, curves
-            | 0xE0CC..=0xE0D4 // Powerline separators: rounded triangles, ice/lego style
+            | 0xE0B8..=0xE0BF // Powerline separators: corner triangles
+            | 0xE0C0..=0xE0CA // Powerline separators: flames (E0C0-E0C3), pixelated (E0C4-E0C7), and ice (E0C8 & E0CA)
+            | 0xE0CC..=0xE0D1 // Powerline separators: honeycombs (E0CC-E0CD) and lego (E0CE-E0D1)
+            | 0xE0D2..=0xE0D7 // Powerline separators: trapezoid (E0D2 & E0D4) and inverted triangles (E0D6-E0D7)
         )
     }
 


### PR DESCRIPTION
Closes #41975.

This change adjusts some of the ranges which were incorrectly labeled or excluded characters. The new ranges include three codepoints which are not assigned in Nerd Fonts. However, one of these codepoints were already included prior to this change. These codepoints are:

- U+E0C9, between the two ice separators
- U+E0D3, between the two trapezoid separators. The ranges prior to this PR already included this one.
- U+E0D5, between the trapezoid separators and the inverted triangle separators

I included these so as to not overcomplicate the ranges by cherry-picking the defined codepoints. That being said, if we're okay with this and an additional unassigned codepoint (U+E0CB, between ice separators and honeycomb separators) being included then a simple range from 0xE0B0 to 0xE0D7 nicely includes all of the Powerline characters.

I wasn't sure how to write tests for this so I just added two characters to the existing tests which were previously not covered lol. All of the Powerline characters can be seen [here](https://www.nerdfonts.com/cheat-sheet) by searching `nf-pl`.

Release Notes:

- Fixed certain Powerline characters incorrectly having terminal contrast adjustment applied.