### PR TITLE
ci: Correct workflow name for run_unit_evals

### DIFF
--- a/.github/workflows/run_unit_evals.yml
+++ b/.github/workflows/run_unit_evals.yml
@@ -1,6 +1,6 @@
-# Generated from xtask::workflows::run_agent_evals
+# Generated from xtask::workflows::run_unit_evals
 # Rebuild with `cargo xtask workflows`.
-name: run_agent_evals
+name: run_unit_evals
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: '0'

--- a/tooling/xtask/src/tasks/workflows/run_agent_evals.rs
+++ b/tooling/xtask/src/tasks/workflows/run_agent_evals.rs
@@ -57,7 +57,8 @@ fn agent_evals() -> NamedJob {
 pub(crate) fn run_unit_evals() -> Workflow {
     let unit_evals = unit_evals();
 
-    named::workflow()
+    Workflow::default()
+        .name("run_unit_evals".to_string())
         .on(Event::default()
             .schedule([
                 // GitHub might drop jobs at busy times, so we choose a random time in the middle of the night.


### PR DESCRIPTION
## Summary

This PR fixes a duplicate workflow name issue in GitHub Actions where the `run_unit_evals.yml` workflow was incorrectly named `run_agent_evals`, causing potential confusion with the actual `run_agent_evals.yml` workflow.

## Problem

The `.github/workflows/run_unit_evals.yml` file had its workflow name set to `run_agent_evals` instead of `run_unit_evals`. This occurred because both the `run_agent_evals()` and `run_unit_evals()` functions in `tooling/xtask/src/tasks/workflows/run_agent_evals.rs` were using the `named::workflow()` helper, which automatically derives the workflow name from the module name. Since both functions are in the same module, they both inherited the name `run_agent_evals`.

## Solution

- Modified `tooling/xtask/src/tasks/workflows/run_agent_evals.rs` to explicitly set the workflow name for `run_unit_evals` by using `Workflow::default().name("run_unit_evals".to_string())` instead of `named::workflow()`
- Regenerated workflow files using `cargo xtask workflows`
- The workflow file now correctly identifies itself as `run_unit_evals`

## Changes

- `.github/workflows/run_unit_evals.yml`: Updated workflow name from `run_agent_evals` to `run_unit_evals`
- `tooling/xtask/src/tasks/workflows/run_agent_evals.rs`: Explicitly set workflow name to prevent future confusion

## Testing

- Verified all workflow names are now unique across `.github/workflows/` directory
- Confirmed no compilation errors or warnings
- Validated YAML structure is correct

This ensures GitHub Actions can properly distinguish between the two workflows and prevents potential CI/CD issues.