### PR TITLE
Enable jemalloc allocator with "jemalloc" feature flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17315,6 +17315,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
 name = "time"
 version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -21259,6 +21279,7 @@ dependencies = [
  "theme",
  "theme_extension",
  "theme_selector",
+ "tikv-jemallocator",
  "time",
  "title_bar",
  "toolchain_selector",

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -167,6 +167,9 @@ zeta2.workspace = true
 zlog.workspace = true
 zlog_settings.workspace = true
 
+[target.'cfg(not(target_os = "windows"))'.dependencies]
+tikv-jemallocator = { version = "0.6.1", optional = true }
+
 [target.'cfg(target_os = "windows")'.dependencies]
 windows.workspace = true
 

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -55,9 +55,13 @@ use zed::{
 
 use crate::zed::{OpenRequestKind, eager_load_active_theme_and_icon_theme};
 
-#[cfg(feature = "mimalloc")]
+#[cfg(feature = "jemalloc")]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+#[cfg(all(feature = "tikv-jemallocator", not(target_os = "windows")))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 fn files_not_created_on_launch(errors: HashMap<io::ErrorKind, Vec<&Path>>) {
     let message = "Zed failed to launch";


### PR DESCRIPTION
I found that at least in linux, use jemalloc saves a lot of memory, although zed uses much lesser memory than vscode or other ides, but saves memory is a good thing, especially when use with rust-analyzer, less swap usage and better responsibility and faster cargo builds.

And Maybe not use system allocator to build bundles, it is much better in speed and memory usage no matter use mimalloc or jemalloc

Release Notes:

- N/A *or* Added/Fixed/Improved ...
