### PR TITLE
Fix scroll position restoration

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2298,6 +2298,15 @@ impl Editor {
                     if *local {
                         editor.hide_signature_help(cx, SignatureHelpHiddenBy::Escape);
                         editor.inline_blame_popover.take();
+                        let new_anchor = editor.scroll_manager.anchor();
+                        let snapshot = editor.snapshot(window, cx);
+                        editor.update_restoration_data(cx, move |data| {
+                            data.scroll_position = (
+                                new_anchor.top_row(snapshot.buffer_snapshot()),
+                                new_anchor.offset,
+                            );
+                        });
+
                         editor.post_scroll_update = cx.spawn_in(window, async move |editor, cx| {
                             cx.background_executor()
                                 .timer(Duration::from_millis(50))
@@ -2310,15 +2319,6 @@ impl Editor {
                                         InlayHintRefreshReason::NewLinesShown,
                                         cx,
                                     );
-
-                                    let new_anchor = editor.scroll_manager.anchor();
-                                    let snapshot = editor.snapshot(window, cx);
-                                    editor.update_restoration_data(cx, move |data| {
-                                        data.scroll_position = (
-                                            new_anchor.top_row(snapshot.buffer_snapshot()),
-                                            new_anchor.offset,
-                                        );
-                                    });
                                 })
                                 .ok();
                         });


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/42035
Scroll position needs to be stored immediately, otherwise editor close may not register that.

Release Notes:

- N/A 
