### PR TITLE
gpui: Improve line_wrapper truncation

### DIFF
--- a/crates/gpui/src/elements/text.rs
+++ b/crates/gpui/src/elements/text.rs
@@ -356,10 +356,7 @@ impl TextLayout {
                 let (truncate_width, truncation_suffix) =
                     if let Some(text_overflow) = text_style.text_overflow.clone() {
                         let width = known_dimensions.width.or(match available_space.width {
-                            crate::AvailableSpace::Definite(x) => match text_style.line_clamp {
-                                Some(max_lines) => Some(x * max_lines),
-                                None => Some(x),
-                            },
+                            crate::AvailableSpace::Definite(x) => Some(x),
                             _ => None,
                         });
 
@@ -377,14 +374,25 @@ impl TextLayout {
                     return text_layout.size.unwrap();
                 }
 
-                let mut line_wrapper = cx.text_system().line_wrapper(text_style.font(), font_size);
                 let (text, runs) = if let Some(truncate_width) = truncate_width {
-                    line_wrapper.truncate_line(
-                        text.clone(),
-                        truncate_width,
-                        &truncation_suffix,
-                        &runs,
-                    )
+                    let mut line_wrapper = cx.text_system().line_wrapper(text_style.font(), font_size);
+                    if let Some(wrap_width) = wrap_width && let Some(line_clamp) = text_style.line_clamp {
+                        line_wrapper.truncate_last_wrapped_line(
+                            text.clone(),
+                            truncate_width,
+                            &truncation_suffix,
+                            &runs,
+                            wrap_width,
+                            line_clamp
+                        )
+                    } else {
+                        line_wrapper.truncate_line(
+                            text.clone(),
+                            truncate_width,
+                            &truncation_suffix,
+                            &runs,
+                        )
+                    }
                 } else {
                     (text.clone(), Cow::Borrowed(&*runs))
                 };

--- a/crates/gpui/src/elements/text.rs
+++ b/crates/gpui/src/elements/text.rs
@@ -375,15 +375,18 @@ impl TextLayout {
                 }
 
                 let (text, runs) = if let Some(truncate_width) = truncate_width {
-                    let mut line_wrapper = cx.text_system().line_wrapper(text_style.font(), font_size);
-                    if let Some(wrap_width) = wrap_width && let Some(line_clamp) = text_style.line_clamp {
+                    let mut line_wrapper =
+                        cx.text_system().line_wrapper(text_style.font(), font_size);
+                    if let Some(wrap_width) = wrap_width
+                        && let Some(line_clamp) = text_style.line_clamp
+                    {
                         line_wrapper.truncate_last_wrapped_line(
                             text.clone(),
                             truncate_width,
                             &truncation_suffix,
                             &runs,
                             wrap_width,
-                            line_clamp
+                            line_clamp,
                         )
                     } else {
                         line_wrapper.truncate_line(

--- a/crates/gpui/src/text_system/line_wrapper.rs
+++ b/crates/gpui/src/text_system/line_wrapper.rs
@@ -166,7 +166,7 @@ impl LineWrapper {
         runs: &'a [TextRun],
     ) -> (SharedString, Cow<'a, [TextRun]>) {
         if let Some(truncate_ix) =
-            self.get_truncation_index(&*line, truncate_width, truncation_suffix)
+            self.get_truncation_index(&line, truncate_width, truncation_suffix)
         {
             let trimmed = line.trim_ascii_end();
             let result = if trimmed.len() <= truncate_ix {
@@ -201,7 +201,7 @@ impl LineWrapper {
             return self.truncate_line(line, truncate_width, truncation_suffix, runs);
         }
 
-        let fragment = [LineFragment::Text { text: &*line }];
+        let fragment = [LineFragment::Text { text: &line }];
 
         let Some(start_index) = self.wrap_line(&fragment, wrap_width).skip(lines - 2).next() else {
             return (line, Cow::Borrowed(runs));

--- a/crates/gpui/src/text_system/line_wrapper.rs
+++ b/crates/gpui/src/text_system/line_wrapper.rs
@@ -165,7 +165,9 @@ impl LineWrapper {
         truncation_suffix: &str,
         runs: &'a [TextRun],
     ) -> (SharedString, Cow<'a, [TextRun]>) {
-        if let Some(truncate_ix) = self.get_truncation_index(&*line, truncate_width, truncation_suffix) {
+        if let Some(truncate_ix) =
+            self.get_truncation_index(&*line, truncate_width, truncation_suffix)
+        {
             let trimmed = line.trim_ascii_end();
             let result = if trimmed.len() <= truncate_ix {
                 SharedString::new(trimmed)
@@ -201,20 +203,26 @@ impl LineWrapper {
 
         let fragment = [LineFragment::Text { text: &*line }];
 
-        let Some(start_index) = self.wrap_line(&fragment, wrap_width).skip(lines-2).next() else {
+        let Some(start_index) = self.wrap_line(&fragment, wrap_width).skip(lines - 2).next() else {
             return (line, Cow::Borrowed(runs));
         };
 
         let last_line = &line[start_index.ix..];
 
-        if let Some(truncate_ix) = self.get_truncation_index(last_line, truncate_width, truncation_suffix) {
+        if let Some(truncate_ix) =
+            self.get_truncation_index(last_line, truncate_width, truncation_suffix)
+        {
             let trimmed = line.trim_ascii_end();
-            let result = if trimmed.len() <= start_index.ix+truncate_ix {
+            let result = if trimmed.len() <= start_index.ix + truncate_ix {
                 SharedString::new(trimmed)
             } else if truncation_suffix.is_empty() {
-                SharedString::new(&line[..start_index.ix+truncate_ix])
+                SharedString::new(&line[..start_index.ix + truncate_ix])
             } else {
-                let string = format!("{}{}", &line[..start_index.ix+truncate_ix], truncation_suffix);
+                let string = format!(
+                    "{}{}",
+                    &line[..start_index.ix + truncate_ix],
+                    truncation_suffix
+                );
                 SharedString::from(string)
             };
 


### PR DESCRIPTION
Release Notes:
- Fixed gpui line wrapper truncation not occurring when line width is close to truncate width

Before:
<img width="197" height="64" alt="image" src="https://github.com/user-attachments/assets/f1bca030-d571-41f2-b067-8cc2cc89aab5" />

After:
<img width="202" height="32" alt="image" src="https://github.com/user-attachments/assets/a97ce1e1-6111-4f0a-bb6c-6538d6b1c256" />

- Fixed gpui line wrapper truncation not working correctly when used with line clamp

Before:
<img width="656" height="84" alt="image" src="https://github.com/user-attachments/assets/9f1241b5-3305-4b9c-9d83-4f74035f7942" />

After:
<img width="643" height="77" alt="image" src="https://github.com/user-attachments/assets/807fd296-8953-41a1-bce2-2b721d481409" />

- Improved gpui line wrapper truncation: it now skips whitespace, so ellipsis are placed next to words. If a line ends with whitespace, the whitespace can be truncated without applying the suffix.

Before:
<img width="202" height="32" alt="image" src="https://github.com/user-attachments/assets/a97ce1e1-6111-4f0a-bb6c-6538d6b1c256" />

After:
<img width="199" height="36" alt="image" src="https://github.com/user-attachments/assets/4eb6b85f-8c6c-476e-b49d-b91fd50c2d86" />

There are still some issues with text truncation/wrapping which I believe are due to subtle differences between the line wrapper and text layout systems. One of the differences I identified is that the line wrapper isn't kerning aware. Unfortunately, it seems like making it kerning aware would be a large refactor and if done naively could have a significant negative performance impact.

To hopefully mitigate any differences between the line wrapper and the text layout system, this PR adds a small bias to the truncation width of -0.25px. This isn't ideal, but it's better than the layout being incorrect.
