### PR TITLE
agent_ui: Make "add more agents" menu item take to extensions

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 use settings::{
     DefaultAgentView as DefaultView, LanguageModelProviderSetting, LanguageModelSelection,
 };
-use zed_actions::OpenBrowser;
+
 use zed_actions::agent::{OpenClaudeCodeOnboardingModal, ReauthenticateAgent};
 
 use crate::ui::{AcpOnboardingModal, ClaudeCodeOnboardingModal};
@@ -2131,12 +2131,20 @@ impl AgentPanel {
                                 menu
                             })
                             .separator()
-                            .link(
-                                "Add Other Agents",
-                                OpenBrowser {
-                                    url: zed_urls::external_agents_docs(cx),
-                                }
-                                .boxed_clone(),
+                            .item(
+                                ContextMenuEntry::new("Add More Agents")
+                                    .icon(IconName::Plus)
+                                    .icon_color(Color::Muted)
+                                    .handler({
+                                        move |window, cx| {
+                                            window.dispatch_action(Box::new(zed_actions::Extensions {
+                                                category_filter: Some(
+                                                    zed_actions::ExtensionCategoryFilter::AgentServers,
+                                                ),
+                                                id: None,
+                                            }), cx)
+                                        }
+                                    }),
                             )
                     }))
                 }


### PR DESCRIPTION
Now that agent servers are a thing, this is the primary and easiest way to quickly add more agents to Zed, without touching any settings JSON file. :)

Release Notes:

- N/A
