### PR TITLE
remote: Flush to stdin when writing to sftp

### DIFF
--- a/crates/remote/src/transport/ssh.rs
+++ b/crates/remote/src/transport/ssh.rs
@@ -850,7 +850,7 @@ impl SshRemoteConnection {
             if let Some(mut stdin) = child.stdin.take() {
                 use futures::AsyncWriteExt;
                 stdin.write_all(sftp_batch.as_bytes()).await?;
-                drop(stdin);
+                stdin.flush().await?;
             }
 
             let output = child.output().await?;


### PR DESCRIPTION
https://github.com/zed-industries/zed/issues/42027#issuecomment-3497210172

Release Notes:

- Fixed ssh remoting potentially  failing due to not flushing stdin to sftp
