### PR TITLE
Refresh outline panel on file renames

### DIFF
--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -5204,6 +5204,9 @@ fn subscribe_for_editor_events(
                         outline_panel.update_cached_entries(Some(UPDATE_DEBOUNCE), window, cx);
                     }
                 }
+                EditorEvent::TitleChanged => {
+                    outline_panel.update_fs_entries(editor.clone(), debounce, window, cx);
+                }
                 _ => {}
             }
         },


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/41877

Release Notes:

- Fixed outline panel not updating file headers on rename