### PR TITLE
Add refresh explorer button

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13057,6 +13057,7 @@ dependencies = [
  "gpui",
  "language",
  "menu",
+ "panel",
  "pretty_assertions",
  "project",
  "rayon",

--- a/crates/project_panel/Cargo.toml
+++ b/crates/project_panel/Cargo.toml
@@ -45,6 +45,7 @@ workspace.workspace = true
 language.workspace = true
 zed_actions.workspace = true
 telemetry.workspace = true
+panel.workspace = true
 
 [dev-dependencies]
 client = { workspace = true, features = ["test-support"] }


### PR DESCRIPTION
related issue #30851

While working, you may encounter instances where files that have been created or modified are slow to sync, or fail to sync at all.

VSCode provides a Refresh button to address this issue.

I wish Zed had a similar button.

<img width="524" height="275" alt="image" src="https://github.com/user-attachments/assets/28c5b916-8f39-4867-a1b3-226609c10de0" />


Release Notes:
- Add Refresh Explorer Button
