### PR TITLE
gpui: Remove all (unsound) `ManuallyDrop` usages, panic on device loss

### DIFF
--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -211,8 +211,8 @@ impl DirectWriteTextSystem {
         })))
     }
 
-    pub(crate) fn handle_gpu_lost(&self, directx_devices: &DirectXDevices) {
-        self.0.write().handle_gpu_lost(directx_devices);
+    pub(crate) fn handle_gpu_lost(&self, directx_devices: &DirectXDevices) -> Result<()> {
+        self.0.write().handle_gpu_lost(directx_devices)
     }
 }
 
@@ -1215,18 +1215,11 @@ impl DirectWriteState {
         result
     }
 
-    fn handle_gpu_lost(&mut self, directx_devices: &DirectXDevices) {
-        try_to_recover_from_device_lost(
-            || GPUState::new(directx_devices).context("Recreating GPU state for DirectWrite"),
-            |gpu_state| self.components.gpu_state = gpu_state,
-            || {
-                log::error!(
-                    "Failed to recreate GPU state for DirectWrite after multiple attempts."
-                );
-                // Do something here?
-                // At this point, the device loss is considered unrecoverable.
-            },
-        );
+    fn handle_gpu_lost(&mut self, directx_devices: &DirectXDevices) -> Result<()> {
+        try_to_recover_from_device_lost(|| {
+            GPUState::new(directx_devices).context("Recreating GPU state for DirectWrite")
+        })
+        .map(|gpu_state| self.components.gpu_state = gpu_state)
     }
 }
 

--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -1133,7 +1133,9 @@ impl WindowsWindowInner {
         let mut lock = self.state.borrow_mut();
         let devices = lparam.0 as *const DirectXDevices;
         let devices = unsafe { &*devices };
-        lock.renderer.handle_device_lost(&devices);
+        if let Err(err) = lock.renderer.handle_device_lost(&devices) {
+            panic!("Device lost: {err}");
+        }
         Some(0)
     }
 


### PR DESCRIPTION
Given that when we lose our devices unrecoverably we will panic anyways, might as well do so eagerly which makes it clearer.

Additionally this PR replaces all uses of `ManuallyDrop` with `Option`, as otherwise we need to do manual bookkeeping of what is and isn't initialized when we try to recover devices as we can bail out halfway while recovering. In other words, the code prior to this was fairly unsound due to freely using `ManuallyDrop::drop`.
 
Fixes ZED-1SS
 
Release Notes:

- N/A *or* Added/Fixed/Improved ...
