### PR TITLE
gpui: Fix `truncate_line` for multiple line clamp

### DIFF
--- a/crates/gpui/src/elements/text.rs
+++ b/crates/gpui/src/elements/text.rs
@@ -356,10 +356,7 @@ impl TextLayout {
                 let (truncate_width, truncation_suffix) =
                     if let Some(text_overflow) = text_style.text_overflow.clone() {
                         let width = known_dimensions.width.or(match available_space.width {
-                            crate::AvailableSpace::Definite(x) => match text_style.line_clamp {
-                                Some(max_lines) => Some(x * max_lines),
-                                None => Some(x),
-                            },
+                            crate::AvailableSpace::Definite(x) => Some(x),
                             _ => None,
                         });
 
@@ -382,6 +379,7 @@ impl TextLayout {
                     line_wrapper.truncate_line(
                         text.clone(),
                         truncate_width,
+                        text_style.line_clamp.unwrap_or(1),
                         &truncation_suffix,
                         &runs,
                     )

--- a/crates/gpui/src/text_system/line_wrapper.rs
+++ b/crates/gpui/src/text_system/line_wrapper.rs
@@ -132,10 +132,35 @@ impl LineWrapper {
     pub fn truncate_line<'a>(
         &mut self,
         line: SharedString,
-        truncate_width: Pixels,
+        wrap_width: Pixels,
+        line_clamp: usize,
         truncation_suffix: &str,
         runs: &'a [TextRun],
     ) -> (SharedString, Cow<'a, [TextRun]>) {
+        let mut truncate_width = wrap_width;
+        if line_clamp > 1 {
+            // For multiple lines, we need to account for the width
+            // by using `wrap_line` to calculate the actual width that
+            // wrapped of each line.
+            let mut ix = 0;
+            for _ in 0..line_clamp - 1 {
+                let fragment = &line[ix..];
+                let Some(boundary) = self
+                    .wrap_line(&[LineFragment::text(&fragment)], wrap_width)
+                    .next()
+                else {
+                    continue;
+                };
+
+                let line_width = fragment[..boundary.ix]
+                    .chars()
+                    .map(|c| self.width_for_char(c))
+                    .fold(px(0.0), |a, x| a + x);
+                ix = boundary.ix;
+                truncate_width += line_width;
+            }
+        }
+
         let mut width = px(0.);
         let mut suffix_width = truncation_suffix
             .chars()
@@ -191,7 +216,7 @@ impl LineWrapper {
     }
 
     #[inline(always)]
-    fn width_for_char(&mut self, c: char) -> Pixels {
+    pub(crate) fn width_for_char(&mut self, c: char) -> Pixels {
         if (c as u32) < 128 {
             if let Some(cached_width) = self.cached_ascii_char_widths[c as usize] {
                 cached_width
@@ -495,7 +520,7 @@ mod tests {
             let dummy_run_lens = vec![text.len()];
             let dummy_runs = generate_test_runs(&dummy_run_lens);
             let (result, dummy_runs) =
-                wrapper.truncate_line(text.into(), px(220.), ellipsis, &dummy_runs);
+                wrapper.truncate_line(text.into(), px(220.), 1, ellipsis, &dummy_runs);
             assert_eq!(result, expected);
             assert_eq!(dummy_runs.first().unwrap().len, result.len());
         }
@@ -534,7 +559,7 @@ mod tests {
         ) {
             let dummy_runs = generate_test_runs(run_lens);
             let (result, dummy_runs) =
-                wrapper.truncate_line(text.into(), line_width, "…", &dummy_runs);
+                wrapper.truncate_line(text.into(), line_width, 1, "…", &dummy_runs);
             assert_eq!(result, expected);
             for (run, result_len) in dummy_runs.iter().zip(result_run_len) {
                 assert_eq!(run.len, *result_len);


### PR DESCRIPTION
Release Notes:

- N/A

Ref #42092

This version to use `wrap_line` method to get correct previous wrapped lines width. So it will perfect to get the width.

## Before

<img width="267" height="473" alt="image" src="https://github.com/user-attachments/assets/5543e78d-fee0-4688-8ac2-c185cb76fd67" />

## After

https://github.com/user-attachments/assets/489e0a30-1cb7-4b0a-9301-41f5a0c5998e

## TODO

- [ ] macOS Test
