### PR TITLE
Fix ACP extension root dir

### DIFF
--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -538,14 +538,7 @@ impl AcpThreadView {
                 })
                 .log_err()
             } else {
-                let root_dir = if let Some(acp_agent) = connection
-                    .clone()
-                    .downcast::<agent_servers::AcpConnection>()
-                {
-                    acp_agent.root_dir().into()
-                } else {
-                    root_dir.unwrap_or(paths::home_dir().as_path().into())
-                };
+                let root_dir = root_dir.unwrap_or(paths::home_dir().as_path().into());
                 cx.update(|_, cx| {
                     connection
                         .clone()


### PR DESCRIPTION
Agents running in extensions need to have a root directory of the extension's dir for installation and authentication, but *not* for the conversation itself - otherwise the agent is running things like terminal commands in the wrong dir.

Release Notes:

- Fixed Agent Server extensions having the current working directory of the extension rather than the project
