### PR TITLE
Support relative paths in LSP & DAP binaries

### DIFF
--- a/crates/project/src/debugger/dap_store.rs
+++ b/crates/project/src/debugger/dap_store.rs
@@ -262,6 +262,7 @@ impl DapStore {
                 let user_installed_path = dap_settings.and_then(|s| match &s.binary {
                     DapBinary::Default => None,
                     DapBinary::Custom(binary) => {
+                        // if `binary` is absolute, `.join()` will keep it unmodified
                         Some(worktree.read(cx).abs_path().join(PathBuf::from(binary)))
                     }
                 });

--- a/crates/project/src/debugger/dap_store.rs
+++ b/crates/project/src/debugger/dap_store.rs
@@ -261,7 +261,9 @@ impl DapStore {
                     .get(&adapter.name());
                 let user_installed_path = dap_settings.and_then(|s| match &s.binary {
                     DapBinary::Default => None,
-                    DapBinary::Custom(binary) => Some(PathBuf::from(binary)),
+                    DapBinary::Custom(binary) => {
+                        Some(worktree.read(cx).abs_path().join(PathBuf::from(binary)))
+                    }
                 });
                 let user_args = dap_settings.map(|s| s.args.clone());
                 let user_env = dap_settings.map(|s| s.env.clone());

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -563,8 +563,8 @@ impl LocalLspStore {
         allow_binary_download: bool,
         cx: &mut App,
     ) -> Task<Result<LanguageServerBinary>> {
-        if let Some(settings) = settings.binary.as_ref()
-            && settings.path.is_some()
+        if let Some(settings) = &settings.binary
+            && let Some(path) = settings.path.as_ref().map(PathBuf::from)
         {
             let settings = settings.clone();
 
@@ -573,7 +573,7 @@ impl LocalLspStore {
                 env.extend(settings.env.unwrap_or_default());
 
                 Ok(LanguageServerBinary {
-                    path: PathBuf::from(&settings.path.unwrap()),
+                    path: delegate.worktree_root_path().join(path),
                     env: Some(env),
                     arguments: settings
                         .arguments

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -573,6 +573,7 @@ impl LocalLspStore {
                 env.extend(settings.env.unwrap_or_default());
 
                 Ok(LanguageServerBinary {
+                    // if `path` is absolute, `.join()` will keep it unmodified
                     path: delegate.worktree_root_path().join(path),
                     env: Some(env),
                     arguments: settings

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -1211,27 +1211,32 @@ async fn test_managing_language_servers(cx: &mut gpui::TestAppContext) {
 async fn test_language_server_relative_path(cx: &mut gpui::TestAppContext) {
     init_test(cx);
 
+    let rel_path = path!("relative_path/to/my_fake_lsp_binary.exe");
+    let settings_json_contents = format!(
+        r#"
+        {{
+            "languages": {{
+                "Rust": {{
+                    "language_servers": ["my_fake_lsp"]
+                }}
+            }},
+            "lsp": {{
+                "my_fake_lsp": {{
+                    "binary": {{
+                        "path": "{rel_path}",
+                    }}
+                }}
+            }},
+
+        }}"#
+    );
+
     let fs = FakeFs::new(cx.executor());
     fs.insert_tree(
         path!("/the-root"),
         json!({
             ".zed": {
-                "settings.json": r#"
-                {
-                    "languages": {
-                        "Rust": {
-                            "language_servers": ["my_fake_lsp"]
-                        }
-                    },
-                    "lsp": {
-                        "my_fake_lsp": {
-                            "binary": {
-                                "path": "relative_path/to/my_fake_lsp_binary.exe",
-                            }
-                        }
-                    },
-
-                }"#,
+                "settings.json": settings_json_contents,
             },
             "relative_path": {
                 "to": {

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -1211,32 +1211,27 @@ async fn test_managing_language_servers(cx: &mut gpui::TestAppContext) {
 async fn test_language_server_relative_path(cx: &mut gpui::TestAppContext) {
     init_test(cx);
 
-    let rel_path = path!("relative_path/to/my_fake_lsp_binary.exe");
-    let settings_json_contents = format!(
-        r#"
-        {{
-            "languages": {{
-                "Rust": {{
-                    "language_servers": ["my_fake_lsp"]
-                }}
-            }},
-            "lsp": {{
-                "my_fake_lsp": {{
-                    "binary": {{
-                        "path": "{rel_path}",
-                    }}
-                }}
-            }},
-
-        }}"#
-    );
+    let settings_json_contents = json!({
+        "languages": {
+            "Rust": {
+                "language_servers": ["my_fake_lsp"]
+            }
+        },
+        "lsp": {
+            "my_fake_lsp": {
+                "binary": {
+                    "path": path!("relative_path/to/my_fake_lsp_binary.exe").to_string(),
+                }
+            }
+        },
+    });
 
     let fs = FakeFs::new(cx.executor());
     fs.insert_tree(
         path!("/the-root"),
         json!({
             ".zed": {
-                "settings.json": settings_json_contents,
+                "settings.json": settings_json_contents.to_string(),
             },
             "relative_path": {
                 "to": {

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -2352,8 +2352,8 @@ impl Snapshot {
         self.entries_by_path.first()
     }
 
-    /// TODO: what's the difference between `root_dir` and `abs_path`?
-    /// is there any? if so, document it.
+    /// Returns `None` for a single file worktree, or `Some(self.abs_path())` if
+    /// it is a directory.
     pub fn root_dir(&self) -> Option<Arc<Path>> {
         self.root_entry()
             .filter(|entry| entry.is_dir())


### PR DESCRIPTION
Closes #41214

Release Notes:

- Added support for relative paths in LSP and DAP binaries
