### PR TITLE
Fix tab switcher close item using wrong pane

### DIFF
--- a/crates/tab_switcher/src/tab_switcher.rs
+++ b/crates/tab_switcher/src/tab_switcher.rs
@@ -537,7 +537,7 @@ impl TabSwitcherDelegate {
         let Some(tab_match) = self.matches.get(ix) else {
             return;
         };
-        let Some(pane) = self.pane.upgrade() else {
+        let Some(pane) = tab_match.pane.upgrade() else {
             return;
         };
         pane.update(cx, |pane, cx| {


### PR DESCRIPTION
Closes #40646

Release Notes:

- Fixed `tab_switcher::CloseSelectedItem` doing nothing on tab in inactive pane
