### PR TITLE
Use windows runner for publishing winget package

### DIFF
--- a/.github/workflows/after_release.yml
+++ b/.github/workflows/after_release.yml
@@ -48,7 +48,7 @@ jobs:
         webhook-url: ${{ secrets.DISCORD_WEBHOOK_RELEASE_NOTES }}
         content: ${{ steps.get-content.outputs.string }}
   publish_winget:
-    runs-on: self-32vcpu-windows-2022
+    runs-on: namespace-profile-2x4-ubuntu-2404
     steps:
     - id: set-package-name
       name: after_release::publish_winget::set_package_name

--- a/.github/workflows/after_release.yml
+++ b/.github/workflows/after_release.yml
@@ -48,7 +48,7 @@ jobs:
         webhook-url: ${{ secrets.DISCORD_WEBHOOK_RELEASE_NOTES }}
         content: ${{ steps.get-content.outputs.string }}
   publish_winget:
-    runs-on: namespace-profile-2x4-ubuntu-2404
+    runs-on: self-32vcpu-windows-2022
     steps:
     - id: set-package-name
       name: after_release::publish_winget::set_package_name

--- a/tooling/xtask/src/tasks/workflows/after_release.rs
+++ b/tooling/xtask/src/tasks/workflows/after_release.rs
@@ -116,7 +116,7 @@ fn publish_winget() -> NamedJob {
 
     named::job(
         Job::default()
-            .runs_on(runners::LINUX_SMALL)
+            .runs_on(runners::WINDOWS_DEFAULT)
             .add_step(set_package_name)
             .add_step(winget_releaser(&package_name)),
     )


### PR DESCRIPTION
Our new linux runners don't have powershell installed which causes the `release-winget` job to fail. This simply runs that step on windows instead.

Release Notes:

- N/A