### PR TITLE
git: Make long-running git staging snappy in git panel

### DIFF
--- a/crates/git/src/status.rs
+++ b/crates/git/src/status.rs
@@ -64,23 +64,23 @@ pub enum StageStatus {
 }
 
 impl StageStatus {
-    pub fn is_fully_staged(&self) -> bool {
+    pub const fn is_fully_staged(&self) -> bool {
         matches!(self, StageStatus::Staged)
     }
 
-    pub fn is_fully_unstaged(&self) -> bool {
+    pub const fn is_fully_unstaged(&self) -> bool {
         matches!(self, StageStatus::Unstaged)
     }
 
-    pub fn has_staged(&self) -> bool {
+    pub const fn has_staged(&self) -> bool {
         matches!(self, StageStatus::Staged | StageStatus::PartiallyStaged)
     }
 
-    pub fn has_unstaged(&self) -> bool {
+    pub const fn has_unstaged(&self) -> bool {
         matches!(self, StageStatus::Unstaged | StageStatus::PartiallyStaged)
     }
 
-    pub fn as_bool(self) -> Option<bool> {
+    pub const fn as_bool(self) -> Option<bool> {
         match self {
             StageStatus::Staged => Some(true),
             StageStatus::Unstaged => Some(false),

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1176,22 +1176,20 @@ impl GitPanel {
         let Some(active_repository) = self.active_repository.clone() else {
             return;
         };
-
-        let repository = active_repository.read(cx);
-        self.update_counts(repository);
-        cx.notify();
-
         cx.spawn({
             async move |this, cx| {
-                let result = cx
-                    .update(|cx| {
-                        active_repository.update(cx, |repo, cx| {
+                let result = this
+                    .update(cx, |this, cx| {
+                        let res = active_repository.update(cx, |repo, cx| {
                             if stage {
                                 repo.stage_all(cx)
                             } else {
                                 repo.unstage_all(cx)
                             }
-                        })
+                        });
+                        this.update_counts(active_repository.read(cx));
+                        cx.notify();
+                        res
                     })?
                     .await;
 

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1230,7 +1230,7 @@ impl GitPanel {
                 let stage = if active_repository
                     .read(cx)
                     .pending_ops_for_path(&status_entry.repo_path)
-                    .map(|ops| ops.staging())
+                    .map(|ops| ops.staging() || ops.staged())
                     .unwrap_or(status_entry.status.staging().has_staged())
                 {
                     if let Some(op) = self.bulk_staging.clone()

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1302,7 +1302,9 @@ impl GitPanel {
             entries: entries.clone(),
             finished: false,
         });
+
         let repository = active_repository.read(cx);
+        dbg!(&repository.snapshot().pending_ops_by_path);
         self.update_counts(repository);
         cx.notify();
 

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1049,7 +1049,7 @@ impl GitPanel {
                         cx,
                     )
                 })?
-                .await??;
+                .await?;
 
             let tasks: Vec<_> = cx.update(|cx| {
                 buffers

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1304,7 +1304,13 @@ impl GitPanel {
         });
 
         let repository = active_repository.read(cx);
-        dbg!(&repository.snapshot().pending_ops_by_path);
+        for entry in &entries {
+            println!(
+                "{:?} -> {:?}",
+                &entry.repo_path,
+                repository.snapshot().pending_ops_for_path(&entry.repo_path)
+            );
+        }
         self.update_counts(repository);
         cx.notify();
 

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -3963,7 +3963,7 @@ impl Repository {
     pub fn stage_all(&mut self, cx: &mut Context<Self>) -> Task<anyhow::Result<()>> {
         let to_stage = self
             .cached_status()
-            .filter(|entry| !entry.status.staging().is_fully_staged())
+            .filter(|entry| entry.status.staging().has_unstaged())
             .map(|entry| entry.repo_path)
             .collect();
         self.stage_entries(to_stage, cx)

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -344,7 +344,7 @@ pub struct GitJob {
 
 #[derive(PartialEq, Eq)]
 enum GitJobKey {
-    WriteIndex(RepoPath),
+    WriteIndex(Vec<RepoPath>),
     ReloadBufferDiffBases,
     RefreshStatuses,
     ReloadGitState,
@@ -3846,10 +3846,7 @@ impl Repository {
             .collect::<Vec<_>>()
             .join(" ");
         let status = format!("git add {paths}");
-        let job_key = match entries.len() {
-            1 => Some(GitJobKey::WriteIndex(entries[0].clone())),
-            _ => None,
-        };
+        let job_key = GitJobKey::WriteIndex(entries.clone());
 
         self.spawn_job_with_tracking(
             entries.clone(),
@@ -3862,7 +3859,7 @@ impl Repository {
 
                 this.update(cx, |this, _| {
                     this.send_keyed_job(
-                        job_key,
+                        Some(job_key),
                         Some(status.into()),
                         move |git_repo, _cx| async move {
                             match git_repo {
@@ -3911,10 +3908,7 @@ impl Repository {
             .collect::<Vec<_>>()
             .join(" ");
         let status = format!("git reset {paths}");
-        let job_key = match entries.len() {
-            1 => Some(GitJobKey::WriteIndex(entries[0].clone())),
-            _ => None,
-        };
+        let job_key = GitJobKey::WriteIndex(entries.clone());
 
         self.spawn_job_with_tracking(
             entries.clone(),
@@ -3927,7 +3921,7 @@ impl Repository {
 
                 this.update(cx, |this, _| {
                     this.send_keyed_job(
-                        job_key,
+                        Some(job_key),
                         Some(status.into()),
                         move |git_repo, _cx| async move {
                             match git_repo {
@@ -4409,7 +4403,7 @@ impl Repository {
         let this = cx.weak_entity();
         let git_store = self.git_store.clone();
         self.send_keyed_job(
-            Some(GitJobKey::WriteIndex(path.clone())),
+            Some(GitJobKey::WriteIndex(vec![path.clone()])),
             None,
             move |git_repo, mut cx| async move {
                 log::debug!(

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -3848,6 +3848,8 @@ impl Repository {
         let status = format!("git add {paths}");
         let job_key = GitJobKey::WriteIndex(entries.clone());
 
+        dbg!(self.pending_ops_for_path(&entries[0]));
+
         self.spawn_job_with_tracking(
             entries.clone(),
             pending_op::GitStatus::Staged,
@@ -5578,6 +5580,7 @@ async fn compute_snapshot(
         MergeDetails::load(&backend, &statuses_by_path, &prev_snapshot).await?;
     log::debug!("new merge details (changed={merge_heads_changed:?}): {merge_details:?}");
 
+    dbg!();
     let pending_ops_by_path = SumTree::from_iter(
         prev_snapshot.pending_ops_by_path.iter().filter_map(|ops| {
             let inner_ops: Vec<PendingOp> =

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -5256,7 +5256,7 @@ impl Repository {
         cx.spawn(async move |this, cx| {
             let job_status = match f(this.clone(), cx).await {
                 Ok(()) => pending_op::JobStatus::Finished,
-                Err(err) if err.is::<Canceled>() => pending_op::JobStatus::Canceled,
+                Err(err) if err.is::<Canceled>() => pending_op::JobStatus::Skipped,
                 Err(err) => return Err(err),
             };
 

--- a/crates/project/src/git_store/pending_op.rs
+++ b/crates/project/src/git_store/pending_op.rs
@@ -25,7 +25,7 @@ pub struct PendingOps {
     pub ops: Vec<PendingOp>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PendingOp {
     pub id: PendingOpId,
     pub git_status: GitStatus,

--- a/crates/project/src/git_store/pending_op.rs
+++ b/crates/project/src/git_store/pending_op.rs
@@ -13,9 +13,10 @@ pub enum GitStatus {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum JobStatus {
-    Started,
+    Running,
     Finished,
     Skipped,
+    Error,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -107,7 +108,7 @@ impl PendingOps {
     /// File is staged if the last job is finished and has status Staged.
     pub fn staged(&self) -> bool {
         if let Some(last) = self.ops.last() {
-            if last.git_status == GitStatus::Staged && last.finished() {
+            if last.git_status == GitStatus::Staged && last.job_status == JobStatus::Finished {
                 return true;
             }
         }
@@ -117,7 +118,7 @@ impl PendingOps {
     /// File is staged if the last job is not finished and has status Staged.
     pub fn staging(&self) -> bool {
         if let Some(last) = self.ops.last() {
-            if last.git_status == GitStatus::Staged && !last.finished() {
+            if last.git_status == GitStatus::Staged && last.job_status != JobStatus::Finished {
                 return true;
             }
         }
@@ -126,11 +127,15 @@ impl PendingOps {
 }
 
 impl PendingOp {
-    pub fn finished(&self) -> bool {
-        self.job_status == JobStatus::Finished
+    pub fn running(&self) -> bool {
+        self.job_status == JobStatus::Running
     }
 
-    pub fn finished_or_skipped(&self) -> bool {
-        self.job_status == JobStatus::Finished || self.job_status == JobStatus::Skipped
+    pub fn finished(&self) -> bool {
+        matches!(self.job_status, JobStatus::Finished | JobStatus::Skipped)
+    }
+
+    pub fn error(&self) -> bool {
+        self.job_status == JobStatus::Error
     }
 }

--- a/crates/project/src/git_store/pending_op.rs
+++ b/crates/project/src/git_store/pending_op.rs
@@ -34,7 +34,6 @@ pub struct PendingOp {
 
 #[derive(Clone, Debug)]
 pub struct PendingOpsSummary {
-    pub max_id: PendingOpId,
     pub staged_count: usize,
     pub staging_count: usize,
 }
@@ -49,7 +48,6 @@ impl Item for PendingOps {
         PathSummary {
             max_path: self.repo_path.0.clone(),
             item_summary: PendingOpsSummary {
-                max_id: self.ops.last().map(|op| op.id).unwrap_or_default(),
                 staged_count: self.staged() as usize,
                 staging_count: self.staging() as usize,
             },
@@ -60,14 +58,12 @@ impl Item for PendingOps {
 impl ContextLessSummary for PendingOpsSummary {
     fn zero() -> Self {
         Self {
-            max_id: PendingOpId::default(),
             staged_count: 0,
             staging_count: 0,
         }
     }
 
     fn add_summary(&mut self, summary: &Self) {
-        self.max_id = summary.max_id;
         self.staged_count += summary.staged_count;
         self.staging_count += summary.staging_count;
     }
@@ -101,6 +97,10 @@ impl PendingOps {
             repo_path: path.clone(),
             ops: Vec::new(),
         }
+    }
+
+    pub fn max_id(&self) -> PendingOpId {
+        self.ops.last().map(|op| op.id).unwrap_or_default()
     }
 
     pub fn op_by_id(&self, id: PendingOpId) -> Option<&PendingOp> {

--- a/crates/project/src/git_store/pending_op.rs
+++ b/crates/project/src/git_store/pending_op.rs
@@ -89,6 +89,12 @@ impl Add<u16> for PendingOpId {
     }
 }
 
+impl From<u16> for PendingOpId {
+    fn from(id: u16) -> Self {
+        Self(id)
+    }
+}
+
 impl PendingOps {
     pub fn new(path: &RepoPath) -> Self {
         Self {

--- a/crates/project/src/git_store/pending_op.rs
+++ b/crates/project/src/git_store/pending_op.rs
@@ -1,0 +1,99 @@
+use git::repository::RepoPath;
+use sum_tree::{ContextLessSummary, Dimension, Item, KeyedItem, NoSummary, SumTree};
+use worktree::{PathKey, PathSummary};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Status {
+    Staged,
+    Unstaged,
+    Reverted,
+    Unchanged,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PendingOp {
+    pub id: u16,
+    pub status: Status,
+    pub finished: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct PendingOpSummary {
+    pub max_id: u16,
+    pub staged_count: u32,
+    pub unstaged_count: u32,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PendingOps {
+    pub repo_path: RepoPath,
+    pub ops: SumTree<PendingOp>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct PendingOpId(u16);
+
+impl Item for PendingOps {
+    type Summary = PathSummary<NoSummary>;
+
+    fn summary(&self, _cx: ()) -> Self::Summary {
+        PathSummary {
+            max_path: self.repo_path.0.clone(),
+            item_summary: NoSummary,
+        }
+    }
+}
+
+impl KeyedItem for PendingOps {
+    type Key = PathKey;
+
+    fn key(&self) -> Self::Key {
+        PathKey(self.repo_path.0.clone())
+    }
+}
+
+impl Item for PendingOp {
+    type Summary = PendingOpSummary;
+
+    fn summary(&self, _cx: ()) -> Self::Summary {
+        PendingOpSummary {
+            max_id: self.id,
+            staged_count: (self.status == Status::Staged) as u32,
+            unstaged_count: (self.status == Status::Unstaged) as u32,
+        }
+    }
+}
+
+impl ContextLessSummary for PendingOpSummary {
+    fn zero() -> Self {
+        Self {
+            max_id: 0,
+            staged_count: 0,
+            unstaged_count: 0,
+        }
+    }
+
+    fn add_summary(&mut self, summary: &Self) {
+        self.max_id = summary.max_id;
+        self.staged_count += summary.staged_count;
+        self.unstaged_count += summary.unstaged_count;
+    }
+}
+
+impl KeyedItem for PendingOp {
+    type Key = PendingOpId;
+
+    fn key(&self) -> Self::Key {
+        PendingOpId(self.id)
+    }
+}
+
+impl Dimension<'_, PendingOpSummary> for PendingOpId {
+    fn zero(_cx: ()) -> Self {
+        Self(0)
+    }
+
+    fn add_summary(&mut self, summary: &PendingOpSummary, _cx: ()) {
+        self.0 = summary.max_id;
+    }
+}

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -50,6 +50,7 @@ use std::{
     sync::{Arc, OnceLock},
     task::Poll,
 };
+use sum_tree::SumTree;
 use task::{ResolvedTask, ShellKind, TaskContext};
 use unindent::Unindent as _;
 use util::{
@@ -8369,6 +8370,47 @@ async fn test_git_status_postprocessing(cx: &mut gpui::TestAppContext) {
     });
 }
 
+#[track_caller]
+/// We merge lhs into rhs.
+fn merge_pending_ops_snapshots<'a>(
+    source: Vec<pending_op::PendingOps>,
+    mut target: Vec<pending_op::PendingOps>,
+) -> Vec<pending_op::PendingOps> {
+    for s_ops in source {
+        if let Some(idx) = target.iter().zip(0..).find_map(|(ops, idx)| {
+            if ops.repo_path == s_ops.repo_path {
+                Some(idx)
+            } else {
+                None
+            }
+        }) {
+            let t_ops = &mut target[idx];
+            for s_op in s_ops.ops {
+                if let Some(op_idx) = t_ops
+                    .ops
+                    .iter()
+                    .zip(0..)
+                    .find_map(|(op, idx)| if op.id == s_op.id { Some(idx) } else { None })
+                {
+                    let t_op = &mut t_ops.ops[op_idx];
+                    match (s_op.job_status, t_op.job_status) {
+                        (pending_op::JobStatus::Running, _) => {}
+                        (s_st, pending_op::JobStatus::Running) => t_op.job_status = s_st,
+                        (s_st, t_st) if s_st == t_st => {}
+                        _ => unreachable!(),
+                    }
+                } else {
+                    t_ops.ops.push(s_op);
+                }
+            }
+            t_ops.ops.sort_by(|l, r| l.id.cmp(&r.id));
+        } else {
+            target.push(s_ops);
+        }
+    }
+    target
+}
+
 #[gpui::test]
 async fn test_repository_pending_ops_staging(
     executor: gpui::BackgroundExecutor,
@@ -8395,10 +8437,28 @@ async fn test_repository_pending_ops_staging(
     );
 
     let project = Project::test(fs.clone(), [path!("/root/my-repo").as_ref()], cx).await;
+    let pending_ops_all = Arc::new(Mutex::new(SumTree::default()));
+    project.update(cx, |project, cx| {
+        let pending_ops_all = pending_ops_all.clone();
+        cx.subscribe(project.git_store(), move |_, _, e, _| {
+            if let GitStoreEvent::RepositoryUpdated(
+                _,
+                RepositoryEvent::PendingOpsChanged { pending_ops },
+                _,
+            ) = e
+            {
+                let merged = merge_pending_ops_snapshots(
+                    pending_ops.items(()),
+                    pending_ops_all.lock().items(()),
+                );
+                *pending_ops_all.lock() = SumTree::from_iter(merged.into_iter(), ());
+            }
+        })
+        .detach();
+    });
     project
         .update(cx, |project, cx| project.git_scans_complete(cx))
         .await;
-    cx.run_until_parked();
 
     let repo = project.read_with(cx, |project, cx| {
         project.repositories(cx).values().next().unwrap().clone()
@@ -8457,6 +8517,43 @@ async fn test_repository_pending_ops_staging(
     assert_stage(repo_path("a.txt"), true).await;
     assert_stage(repo_path("a.txt"), false).await;
     assert_stage(repo_path("a.txt"), true).await;
+
+    cx.run_until_parked();
+
+    assert_eq!(
+        pending_ops_all
+            .lock()
+            .get(&worktree::PathKey(repo_path("a.txt").0), ())
+            .unwrap()
+            .ops,
+        vec![
+            pending_op::PendingOp {
+                id: 1u16.into(),
+                git_status: pending_op::GitStatus::Staged,
+                job_status: pending_op::JobStatus::Finished
+            },
+            pending_op::PendingOp {
+                id: 2u16.into(),
+                git_status: pending_op::GitStatus::Unstaged,
+                job_status: pending_op::JobStatus::Finished
+            },
+            pending_op::PendingOp {
+                id: 3u16.into(),
+                git_status: pending_op::GitStatus::Staged,
+                job_status: pending_op::JobStatus::Finished
+            },
+            pending_op::PendingOp {
+                id: 4u16.into(),
+                git_status: pending_op::GitStatus::Unstaged,
+                job_status: pending_op::JobStatus::Finished
+            },
+            pending_op::PendingOp {
+                id: 5u16.into(),
+                git_status: pending_op::GitStatus::Staged,
+                job_status: pending_op::JobStatus::Finished
+            }
+        ],
+    );
 }
 
 #[gpui::test]
@@ -8485,7 +8582,7 @@ async fn test_repository_pending_ops_long_running_staging(
     );
 
     let project = Project::test(fs.clone(), [path!("/root/my-repo").as_ref()], cx).await;
-    let pending_ops_all = Arc::new(Mutex::new(sum_tree::SumTree::default()));
+    let pending_ops_all = Arc::new(Mutex::new(SumTree::default()));
     project.update(cx, |project, cx| {
         let pending_ops_all = pending_ops_all.clone();
         cx.subscribe(project.git_store(), move |_, _, e, _| {
@@ -8495,11 +8592,11 @@ async fn test_repository_pending_ops_long_running_staging(
                 _,
             ) = e
             {
-                let edits = pending_ops
-                    .iter()
-                    .map(|ops| sum_tree::Edit::Insert(ops.clone()))
-                    .collect();
-                pending_ops_all.lock().edit(edits, ());
+                let merged = merge_pending_ops_snapshots(
+                    pending_ops.items(()),
+                    pending_ops_all.lock().items(()),
+                );
+                *pending_ops_all.lock() = SumTree::from_iter(merged.into_iter(), ());
             }
         })
         .detach();

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -8372,7 +8372,7 @@ async fn test_git_status_postprocessing(cx: &mut gpui::TestAppContext) {
 
 #[track_caller]
 /// We merge lhs into rhs.
-fn merge_pending_ops_snapshots<'a>(
+fn merge_pending_ops_snapshots(
     source: Vec<pending_op::PendingOps>,
     mut target: Vec<pending_op::PendingOps>,
 ) -> Vec<pending_op::PendingOps> {

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -8554,6 +8554,22 @@ async fn test_repository_pending_ops_staging(
             }
         ],
     );
+
+    repo.update(cx, |repo, _cx| {
+        let git_statuses = repo.cached_status().collect::<Vec<_>>();
+
+        assert_eq!(
+            git_statuses,
+            [StatusEntry {
+                repo_path: repo_path("a.txt"),
+                status: TrackedStatus {
+                    index_status: StatusCode::Added,
+                    worktree_status: StatusCode::Unmodified
+                }
+                .into(),
+            }]
+        );
+    });
 }
 
 #[gpui::test]
@@ -8644,6 +8660,22 @@ async fn test_repository_pending_ops_long_running_staging(
             }
         ],
     );
+
+    repo.update(cx, |repo, _cx| {
+        let git_statuses = repo.cached_status().collect::<Vec<_>>();
+
+        assert_eq!(
+            git_statuses,
+            [StatusEntry {
+                repo_path: repo_path("a.txt"),
+                status: TrackedStatus {
+                    index_status: StatusCode::Added,
+                    worktree_status: StatusCode::Unmodified
+                }
+                .into(),
+            }]
+        );
+    });
 }
 
 #[gpui::test]
@@ -8755,6 +8787,24 @@ async fn test_repository_pending_ops_stage_all(
             },
         ],
     );
+
+    repo.update(cx, |repo, _cx| {
+        let git_statuses = repo.cached_status().collect::<Vec<_>>();
+
+        assert_eq!(
+            git_statuses,
+            [
+                StatusEntry {
+                    repo_path: repo_path("a.txt"),
+                    status: FileStatus::Untracked,
+                },
+                StatusEntry {
+                    repo_path: repo_path("b.txt"),
+                    status: FileStatus::Untracked,
+                },
+            ]
+        );
+    });
 }
 
 #[gpui::test]


### PR DESCRIPTION
Previously, staging a large file in the git panel would block the UI items until that operation finished. This is due to the fact that staging is a git op that is locked globally by git (per repo) meaning only one op that is modifying the git index can run at any one time. In order to make the UI snappy while letting any pending git staging jobs to finish in the background, we track their progress via `PendingOps` indexed by git entry path. We have already had a concept of pending operations however they existed at the UI layer in the `GitPanel` abstraction. This PR moves and augments `PendingOps` into the model `Repository` in `git_store` which seems like a more natural place for tracking running git jobs/operations. Thanks to this, pending ops are now stored in a `SumTree` indexed by git entry path part of the `Repository` snapshot, which makes for efficient access from the UI.

Release Notes:

- Improved UI responsiveness when staging/unstaging large files in the git panel
