### PR TITLE
Small zeta cli fixes

### DIFF
--- a/crates/zeta_cli/src/example.rs
+++ b/crates/zeta_cli/src/example.rs
@@ -166,9 +166,7 @@ impl NamedExample {
                             REVISION_FIELD => {
                                 named.example.revision = value.trim().to_string();
                             }
-                            _ => {
-                                eprintln!("Warning: Unrecognized field `{field}`");
-                            }
+                            _ => {}
                         }
                     }
                 }
@@ -193,7 +191,6 @@ impl NamedExample {
                     } else if title.eq_ignore_ascii_case(EXPECTED_CONTEXT_HEADING) {
                         Section::ExpectedExcerpts
                     } else {
-                        eprintln!("Warning: Unrecognized section `{title:?}`");
                         Section::Other
                     };
                 }

--- a/crates/zeta_cli/src/predict.rs
+++ b/crates/zeta_cli/src/predict.rs
@@ -148,14 +148,6 @@ pub async fn zeta2_predict(
                     &request.local_prompt.unwrap_or_default(),
                 )?;
 
-                let response = request.response_rx.await?.0.map_err(|err| anyhow!(err))?;
-                prediction_finished_at = Some(Instant::now());
-
-                fs::write(
-                    LOGS_DIR.join("prediction_response.json"),
-                    &serde_json::to_string_pretty(&response).unwrap(),
-                )?;
-
                 for included_file in request.request.included_files {
                     let insertions = vec![(request.request.cursor_point, CURSOR_MARKER)];
                     result
@@ -177,6 +169,12 @@ pub async fn zeta2_predict(
                         &mut excerpts_text,
                     );
                 }
+
+                let response = request.response_rx.await?.0.map_err(|err| anyhow!(err))?;
+                let response = zeta2::text_from_response(response).unwrap_or_default();
+                prediction_finished_at = Some(Instant::now());
+                fs::write(LOGS_DIR.join("prediction_response.md"), &response)?;
+
                 break;
             }
         }


### PR DESCRIPTION
* Fix a panic that happened because we lost the `ContextRetrievalStarted` debug message, so we didn't assign `t0`.
* Write the edit prediction response log file as a markdown file containing the text, not a JSON file. We mostly always want the text content.

Release Notes:

- N/A
