### PR TITLE
workspace: Do not panic when the database is corruped

### DIFF
--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -791,12 +791,11 @@ impl WorkspaceDb {
                     remote_connection_id IS ?
                 LIMIT 1
             })
-            .map(|mut prepared_statement| {
+            .and_then(|mut prepared_statement| {
                 (prepared_statement)((
                     root_paths.serialize().paths,
                     remote_connection_id.map(|id| id.0 as i32),
                 ))
-                .unwrap()
             })
             .context("No workspaces found")
             .warn_on_err()


### PR DESCRIPTION
Fixes ZED-1NK

Release Notes:

- Fixed zed not starting when the database cannot be loaded
