### PR TITLE
agent_ui: Fix thread history item showing GMT time instead of local time on Windows

### DIFF
--- a/crates/agent_ui/src/acp/thread_history.rs
+++ b/crates/agent_ui/src/acp/thread_history.rs
@@ -673,7 +673,7 @@ impl EntryTimeFormat {
                 timezone,
                 time_format::TimestampFormat::EnhancedAbsolute,
             ),
-            EntryTimeFormat::TimeOnly => time_format::format_time(timestamp),
+            EntryTimeFormat::TimeOnly => time_format::format_time(timestamp.to_offset(timezone)),
         }
     }
 }


### PR DESCRIPTION
Closes #42178
Now it's consistent with the DateAndTime path which already does timezone conversion.

- **Future Work**
Happy to tackle the TODO in `time_format.rs` about implementing native Windows APIs for proper localized formatting (similar to macOS's `CFDateFormatter`) as a follow-up.

Release Notes:

- agent: Fixed the thread history item timestamp, which was being shown in GMT instead of in the user's local timezone on Windows.
