### PR TITLE
util: Fall back to `cmd` if we can't find powershell on the system

### DIFF
--- a/crates/util/src/shell.rs
+++ b/crates/util/src/shell.rs
@@ -199,7 +199,11 @@ pub fn get_windows_system_shell() -> String {
             .or_else(|| find_pwsh_in_programfiles(true, true))
             .or_else(find_pwsh_in_scoop)
             .map(|p| p.to_string_lossy().into_owned())
-            .unwrap_or("powershell.exe".to_string())
+            .inspect(|shell| log::info!("Found powershell in: {}", shell))
+            .unwrap_or_else(|| {
+                log::warn!("Powershell not found, falling back to `cmd`");
+                "cmd.exe".to_string()
+            })
     });
 
     (*SYSTEM_SHELL).clone()

--- a/crates/util/src/shell_env.rs
+++ b/crates/util/src/shell_env.rs
@@ -208,7 +208,6 @@ async fn capture_windows(
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),
     );
-    // "cmd" "/c" "cd \'C:\\Workspace\\salsa\\\'; \'C:\\Workspace\\zed\\zed\\target\\debug\\zed.exe\' --printenv"
     let env_output = String::from_utf8_lossy(&output.stdout);
 
     // Parse the JSON output from zed --printenv


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/42165

Release Notes:

- Fixed trying to use powershell for commands when its not installed on the system
