### PR TITLE
language_models: Add `auto_discover` setting for Ollama

### DIFF
--- a/crates/language_models/src/provider/ollama.rs
+++ b/crates/language_models/src/provider/ollama.rs
@@ -43,6 +43,7 @@ static API_KEY_ENV_VAR: LazyLock<EnvVar> = env_var!(API_KEY_ENV_VAR_NAME);
 #[derive(Default, Debug, Clone, PartialEq)]
 pub struct OllamaSettings {
     pub api_url: String,
+    pub auto_discover: bool,
     pub available_models: Vec<AvailableModel>,
 }
 
@@ -241,10 +242,13 @@ impl LanguageModelProvider for OllamaLanguageModelProvider {
 
     fn provided_models(&self, cx: &App) -> Vec<Arc<dyn LanguageModel>> {
         let mut models: HashMap<String, ollama::Model> = HashMap::new();
+        let settings = OllamaLanguageModelProvider::settings(cx);
 
         // Add models from the Ollama API
-        for model in self.state.read(cx).fetched_models.iter() {
-            models.insert(model.name.clone(), model.clone());
+        if settings.auto_discover {
+            for model in self.state.read(cx).fetched_models.iter() {
+                models.insert(model.name.clone(), model.clone());
+            }
         }
 
         // Override with available models from settings

--- a/crates/language_models/src/settings.rs
+++ b/crates/language_models/src/settings.rs
@@ -82,6 +82,7 @@ impl settings::Settings for AllLanguageModelSettings {
             },
             ollama: OllamaSettings {
                 api_url: ollama.api_url.unwrap(),
+                auto_discover: ollama.auto_discover.unwrap_or(true),
                 available_models: ollama.available_models.unwrap_or_default(),
             },
             open_router: OpenRouterSettings {

--- a/crates/settings/src/settings_content/language_model.rs
+++ b/crates/settings/src/settings_content/language_model.rs
@@ -92,6 +92,7 @@ pub enum BedrockAuthMethodContent {
 #[derive(Default, Clone, Debug, Serialize, Deserialize, PartialEq, JsonSchema, MergeFrom)]
 pub struct OllamaSettingsContent {
     pub api_url: Option<String>,
+    pub auto_discover: Option<bool>,
     pub available_models: Option<Vec<OllamaAvailableModel>>,
 }
 

--- a/docs/src/ai/llm-providers.md
+++ b/docs/src/ai/llm-providers.md
@@ -327,6 +327,33 @@ Download and install Ollama from [ollama.com/download](https://ollama.com/downlo
 
 3. In the Agent Panel, select one of the Ollama models using the model dropdown.
 
+#### Ollama Autodiscovery
+
+Zed will automatically discover models that Ollama has pulled. You can turn this off by setting
+the `auto_discover` field in the Ollama settings. If you do this, you should manually specify which
+models are available.
+
+```json [settings]
+{
+  "language_models": {
+    "ollama": {
+      "api_url": "http://localhost:11434",
+      "auto_discover": false,
+      "available_models": [
+        {
+          "name": "qwen2.5-coder",
+          "display_name": "qwen 2.5 coder",
+          "max_tokens": 32768,
+          "supports_tools": true,
+          "supports_thinking": true,
+          "supports_images": true
+        }
+      ]
+    }
+  }
+}
+```
+
 #### Ollama Context Length {#ollama-context}
 
 Zed has pre-configured maximum context lengths (`max_tokens`) to match the capabilities of common models.


### PR DESCRIPTION
First up: I'm sorry if this is a low quality PR, or if this feature isn't wanted. I implemented this because I'd like to have this behaviour. If you don't think that this is useful, feel free to close the PR without comment. :)

My idea is this: I love to pull random models with Ollama to try them. At the same time, not all of them are useful for coding, or some won't work out of the box with the context_length set. So, I'd like to change Zed's behaviour to not show me all models Ollama has, but to limit it to the ones that I configure manually. 

What I did is add an `auto_discover` field to the settings. The idea is that you can write a config like this:

```json
"language_models": {
    "ollama": {
      "api_url": "http://localhost:11434",
      "auto_discover": false,
      "available_models": [
        {
          "name": "qwen3:4b",
          "display_name": "Qwen3 4B 32K",
          "max_tokens": 32768,
          "supports_tools": true,
          "supports_thinking": true,
          "supports_images": true
        }
      ]
    }
  }
```

The `auto_discover: false` means that Zed won't pick up or show the language models that Ollama knows about, and will only show me the one I manually configured in `available_models`. That way, I can pull random models with Ollama, but in Zed I can only see the ones that I know work (because I've configured them).

The default for `auto_discover` (when it is not explicitly set) is `true`, meaning that the existing behaviour is preserved, and this is not a breaking change for configurations.

Release Notes:

- ollama: Added `auto_discover` setting to optionally limit visible models to only those manually configured in `available_models`

