### PR TITLE
gpui: Do not unwrap in `window_procedure`

### DIFF
--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -127,11 +127,17 @@ impl WindowsPlatform {
                 Some(HWND_MESSAGE),
                 None,
                 None,
-                Some(&context as *const _ as *const _),
+                Some(&raw const context as *const _),
             )
         };
-        let inner = context.inner.take().unwrap()?;
-        let dispatcher = context.dispatcher.take().unwrap();
+        let inner = context
+            .inner
+            .take()
+            .context("CreateWindowExW did not run correctly")??;
+        let dispatcher = context
+            .dispatcher
+            .take()
+            .context("CreateWindowExW did not run correctly")?;
         let handle = result?;
 
         let disable_direct_composition = std::env::var(DISABLE_DIRECT_COMPOSITION)
@@ -697,14 +703,24 @@ impl Platform for WindowsPlatform {
 impl WindowsPlatformInner {
     fn new(context: &mut PlatformWindowCreateContext) -> Result<Rc<Self>> {
         let state = RefCell::new(WindowsPlatformState::new(
-            context.directx_devices.take().unwrap(),
+            context
+                .directx_devices
+                .take()
+                .context("missing directx devices")?,
         ));
         Ok(Rc::new(Self {
             state,
             raw_window_handles: context.raw_window_handles.clone(),
-            dispatcher: context.dispatcher.as_ref().unwrap().clone(),
+            dispatcher: context
+                .dispatcher
+                .as_ref()
+                .context("missing dispatcher")?
+                .clone(),
             validation_number: context.validation_number,
-            main_receiver: context.main_receiver.take().unwrap(),
+            main_receiver: context
+                .main_receiver
+                .take()
+                .context("missing main receiver")?,
         }))
     }
 
@@ -1135,13 +1151,16 @@ unsafe extern "system" fn window_procedure(
     lparam: LPARAM,
 ) -> LRESULT {
     if msg == WM_NCCREATE {
-        let params = lparam.0 as *const CREATESTRUCTW;
-        let params = unsafe { &*params };
+        let params = unsafe { &*(lparam.0 as *const CREATESTRUCTW) };
         let creation_context = params.lpCreateParams as *mut PlatformWindowCreateContext;
         let creation_context = unsafe { &mut *creation_context };
 
+        let Some(main_sender) = creation_context.main_sender.take() else {
+            creation_context.inner = Some(Err(anyhow!("missing main sender")));
+            return LRESULT(0);
+        };
         creation_context.dispatcher = Some(Arc::new(WindowsDispatcher::new(
-            creation_context.main_sender.take().unwrap(),
+            main_sender,
             hwnd,
             creation_context.validation_number,
         )));

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -1167,8 +1167,7 @@ unsafe extern "system" fn window_procedure(
     lparam: LPARAM,
 ) -> LRESULT {
     if msg == WM_NCCREATE {
-        let window_params = lparam.0 as *const CREATESTRUCTW;
-        let window_params = unsafe { &*window_params };
+        let window_params = unsafe { &*(lparam.0 as *const CREATESTRUCTW) };
         let window_creation_context = window_params.lpCreateParams as *mut WindowCreateContext;
         let window_creation_context = unsafe { &mut *window_creation_context };
         return match WindowsWindowInner::new(window_creation_context, hwnd, window_params) {


### PR DESCRIPTION
Technically these should not be possible to hit, but sentry says otherwise. Turning these into errors should give us more information than the abort due to unwinding across ffi boundaries.

Fixes ZED-321

Release Notes:

- N/A *or* Added/Fixed/Improved ...
