### PR TITLE
Silence rust-analyzer startup errors

### DIFF
--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -2035,7 +2035,7 @@ impl LocalLspStore {
         cx: &mut AsyncApp,
     ) -> Result<Vec<(Range<Anchor>, Arc<str>)>> {
         let logger = zlog::scoped!("lsp_format");
-        zlog::info!(logger => "Formatting via LSP");
+        zlog::debug!(logger => "Formatting via LSP");
 
         let uri = file_path_to_lsp_url(abs_path)?;
         let text_document = lsp::TextDocumentIdentifier::new(uri);
@@ -8432,6 +8432,8 @@ impl LspStore {
             while let Some((server_id, response_result)) = response_results.next().await {
                 match response_result {
                     Ok(response) => responses.push((server_id, response)),
+                    // rust-analyzer likes to error with this when its still loading up
+                    Err(e) if e.to_string().ends_with("content modified") => (),
                     Err(e) => log::error!("Error handling response for request {request:?}: {e:#}"),
                 }
             }
@@ -12425,6 +12427,8 @@ impl LspStore {
                         let mut responses = Vec::new();
                         match server_task.await {
                             Ok(response) => responses.push((server_id, response)),
+                            // rust-analyzer likes to error with this when its still loading up
+                            Err(e) if e.to_string().ends_with("content modified") => (),
                             Err(e) => log::error!(
                                 "Error handling response for request {request:?}: {e:#}"
                             ),


### PR DESCRIPTION
When rust-analyzer is still loading the cargo project it tends to error out on most lsp requests with `content modified`. This pollutes our logs.

Release Notes:

- N/A *or* Added/Fixed/Improved ...
