### PR TITLE
Set override_redirect for PopUps

### DIFF
--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -427,6 +427,7 @@ impl X11WindowState {
             // https://stackoverflow.com/questions/43218127/x11-xlib-xcb-creating-a-window-requires-border-pixel-if-specifying-colormap-wh
             .border_pixel(visual_set.black_pixel)
             .colormap(colormap)
+            .override_redirect((params.kind == WindowKind::PopUp) as u32)
             .event_mask(
                 xproto::EventMask::EXPOSURE
                     | xproto::EventMask::STRUCTURE_NOTIFY


### PR DESCRIPTION
Currently on x11, gpui PopUp windows only rely on the "notification" type in order to indicate that they should spawn as floating window. Several window managers (leftwm in my case, but it also seems to be the case for dwm and ratpoison) do not this property into account thus not spawning them as float. On the other hand, using Floating instead of PopUp do make those windows spawn as floating, as these window manager do take into account the (older) "dialog" type.

The [freedekstop documentation](https://specifications.freedesktop.org/wm/1.5/ar01s05.html#id-1.6.7) does seem to suggest that these windows should also have the override redirect property :
> This property is typically used on override-redirect windows. 

Note that this also disables pretty much all interactions with the window manager (such as moving the window, resizing etc...)

Release Notes:

- Fix popup windows not spawning floating sometime on x11