### PR TITLE
debugger:  Truncate scope names to avoid text overlapping in variable list

### DIFF
--- a/crates/debugger_ui/src/session/running/variable_list.rs
+++ b/crates/debugger_ui/src/session/running/variable_list.rs
@@ -1404,6 +1404,7 @@ impl VariableList {
                         div()
                             .text_ui(cx)
                             .w_full()
+                            .truncate()
                             .when(self.disabled, |this| {
                                 this.text_color(Color::Disabled.color(cx))
                             })


### PR DESCRIPTION
Closes #41969

This was caused because scope names weren't being truncated unlike the other type of variable list entries. 

Release Notes:

- debugger: Fix bug where minimizing the width of the variable list would cause scope names to overlap
