### PR TITLE
bundle: Skip sentry upload for local install on macOS

### DIFF
--- a/script/bundle-mac
+++ b/script/bundle-mac
@@ -280,7 +280,9 @@ function sign_binary() {
 }
 
 function upload_debug_symbols() {
-    if [[ -n "${SENTRY_AUTH_TOKEN:-}" ]]; then
+    if [ "$local_install" = true ]; then
+        echo "local install; skipping sentry upload."
+    elif [[ -n "${SENTRY_AUTH_TOKEN:-}" ]]; then
         echo "Uploading zed debug symbols to sentry..."
         exe_path="target/${target_triple}/release/Zed"
         if ! dsymutil --flat "target/${target_triple}/${target_dir}/zed" 2> target/dsymutil.log; then


### PR DESCRIPTION
This is a follow up to #41482. When running `script/bundle-mac`, it will upload debug symbols to Sentry if you have a `$SENTRY_AUTH_TOKEN` set. I happen to have one set, so this script was trying to generate and upload those. Whoops! This change skips the upload entirely if you're running a local install.

Release Notes:

- N/A
