### PR TITLE
editor: Allow clicking on excerpts with alt key to open file path

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -4093,7 +4093,6 @@ impl EditorElement {
                             .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
                             .on_click(window.listener_for(&self.editor, {
                                 let buffer_id = for_excerpt.buffer_id;
-                                let jump_data = jump_data.clone();
                                 move |editor, e: &ClickEvent, window, cx| {
                                     if e.modifiers().alt {
                                         editor.open_excerpts_common(

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -4093,7 +4093,18 @@ impl EditorElement {
                             .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
                             .on_click(window.listener_for(&self.editor, {
                                 let buffer_id = for_excerpt.buffer_id;
-                                move |editor, _e: &ClickEvent, _window, cx| {
+                                let jump_data = jump_data.clone();
+                                move |editor, e: &ClickEvent, window, cx| {
+                                    if e.modifiers().alt {
+                                        editor.open_excerpts_common(
+                                            Some(jump_data.clone()),
+                                            e.modifiers().secondary(),
+                                            window,
+                                            cx,
+                                        );
+                                        return;
+                                    }
+
                                     if is_folded {
                                         editor.unfold_buffer(buffer_id, cx);
                                     } else {


### PR DESCRIPTION
#42021 Made clicking on an excerpt title toggle it. This PR brings back the old behavior if a user is pressing the Alt key when clicking on an excerpt title. 

Release Notes:

- N/A
