### PR TITLE
Search tab-switcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16903,7 +16903,6 @@ dependencies = [
  "serde",
  "serde_json",
  "settings",
- "smol",
  "theme",
  "ui",
  "util",

--- a/crates/tab_switcher/Cargo.toml
+++ b/crates/tab_switcher/Cargo.toml
@@ -23,7 +23,6 @@ project.workspace = true
 schemars.workspace = true
 serde.workspace = true
 settings.workspace = true
-smol.workspace = true
 ui.workspace = true
 util.workspace = true
 workspace.workspace = true


### PR DESCRIPTION


What?
----------
- Replace fuzzy search with contains-based filtering
- Store optional string_match and use highlighted labels
- Update placeholder to show Search all tabs… or Search tabs…
- Adjust tab item rendering to support highlighted matches
<img width="950" height="695" alt="Screenshot 2025-11-07 at 20 59 18" src="https://github.com/user-attachments/assets/f1b74b94-e9dd-456e-8348-e4d30c4e3d19" />



Why?
------------
I usually have many tabs open and I'd like to search for them from the `tab switcher:toggle`

Release notes
-------------
`tab switcher:toggle` now supports fuzzy search
