### PR TITLE
gpui: Increase app shutdown timeout for on_app_quit handlers

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -53,7 +53,7 @@ mod entity_map;
 mod test_context;
 
 /// The duration for which futures returned from [Context::on_app_quit] can run before the application fully quits.
-pub const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+pub const SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(100);
 
 /// Temporary(?) wrapper around [`RefCell<App>`] to help us debug any double borrows.
 /// Strongly consider removing after stabilization.

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -694,7 +694,7 @@ impl App {
     }
 
     /// Quit the application gracefully. Handlers registered with [`Context::on_app_quit`]
-    /// will be given up to 5 seconds to complete before exiting.
+    /// will be given up to `SHUTDOWN_TIMEOUT` to complete before exiting.
     pub fn shutdown(&mut self) {
         let mut futures = Vec::new();
 

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -53,7 +53,7 @@ mod entity_map;
 mod test_context;
 
 /// The duration for which futures returned from [Context::on_app_quit] can run before the application fully quits.
-pub const SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(100);
+pub const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Temporary(?) wrapper around [`RefCell<App>`] to help us debug any double borrows.
 /// Strongly consider removing after stabilization.
@@ -694,7 +694,7 @@ impl App {
     }
 
     /// Quit the application gracefully. Handlers registered with [`Context::on_app_quit`]
-    /// will be given 100ms to complete before exiting.
+    /// will be given up to 5 seconds to complete before exiting.
     pub fn shutdown(&mut self) {
         let mut futures = Vec::new();
 

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -47,9 +47,9 @@ const CONTENT_LEN_HEADER: &str = "Content-Length: ";
 
 pub const LSP_REQUEST_TIMEOUT: Duration = Duration::from_secs(60 * 2);
 #[cfg(target_os = "windows")]
-const SERVER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
-#[cfg(not(target_os = "windows"))]
 const SERVER_SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(100);
+#[cfg(not(target_os = "windows"))]
+const SERVER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 
 type NotificationHandler = Box<dyn Send + FnMut(Option<RequestId>, Value, &mut AsyncApp)>;
 type ResponseHandler = Box<dyn Send + FnOnce(Result<String, Error>)>;

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -46,7 +46,10 @@ const JSON_RPC_VERSION: &str = "2.0";
 const CONTENT_LEN_HEADER: &str = "Content-Length: ";
 
 pub const LSP_REQUEST_TIMEOUT: Duration = Duration::from_secs(60 * 2);
+#[cfg(target_os = "windows")]
 const SERVER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+#[cfg(not(target_os = "windows"))]
+const SERVER_SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(100);
 
 type NotificationHandler = Box<dyn Send + FnMut(Option<RequestId>, Value, &mut AsyncApp)>;
 type ResponseHandler = Box<dyn Send + FnOnce(Result<String, Error>)>;


### PR DESCRIPTION
Language servers can take up to 5s to finish their shutdown handshake, but gpui only waited 100ms before dropping on_app_quit futures. Bump SHUTDOWN_TIMEOUT to 5s (and update the doc comment) so LspStore’s quit hook has enough time to let LanguageServer::shutdown() reach its kill-on-timeout logic, preventing orphaned language server processes on Windows.

Closes https://github.com/zed-industries/zed/issues/42077

Release Notes:

- N/A