### PR TITLE
agent_ui: Always allow to include symbols

### DIFF
--- a/crates/agent_ui/src/acp/completion_provider.rs
+++ b/crates/agent_ui/src/acp/completion_provider.rs
@@ -646,16 +646,14 @@ impl ContextPickerCompletionProvider {
         cx: &mut App,
     ) -> Vec<ContextPickerEntry> {
         let embedded_context = self.prompt_capabilities.borrow().embedded_context;
-        let mut entries = if embedded_context {
-            vec![
-                ContextPickerEntry::Mode(ContextPickerMode::File),
-                ContextPickerEntry::Mode(ContextPickerMode::Symbol),
-                ContextPickerEntry::Mode(ContextPickerMode::Thread),
-            ]
-        } else {
-            // File is always available, but we don't need a mode entry
-            vec![]
-        };
+        let mut entries = vec![
+            ContextPickerEntry::Mode(ContextPickerMode::File),
+            ContextPickerEntry::Mode(ContextPickerMode::Symbol),
+        ];
+
+        if embedded_context {
+            entries.push(ContextPickerEntry::Mode(ContextPickerMode::Thread));
+        }
 
         let has_selection = workspace
             .read(cx)

--- a/crates/agent_ui/src/acp/message_editor.rs
+++ b/crates/agent_ui/src/acp/message_editor.rs
@@ -2205,6 +2205,8 @@ mod tests {
                     format!("seven.txt b{slash}"),
                     format!("six.txt b{slash}"),
                     format!("five.txt b{slash}"),
+                    "Files & Directories".into(),
+                    "Symbols".into()
                 ]
             );
             editor.set_text("", window, cx);


### PR DESCRIPTION
We can always include symbols, since we either include a ResourceLink to the symbol (when `PromptCapabilities::embedded_context = false`) or a Resource (when `PromptCapabilities::embedded_context = true`)

Release Notes:

- Fixed an issue where symbols could not be included when using specific ACP agents
