### PR TITLE
Slightly improve completion in settings.json (for lsp.<language-server>.)

### DIFF
--- a/crates/settings/src/settings_content/project.rs
+++ b/crates/settings/src/settings_content/project.rs
@@ -110,7 +110,7 @@ pub struct LspSettings {
     pub binary: Option<BinarySettings>,
     /// Options passed to the language server at startup.
     ///
-    /// Consult the documentation for the specific LSP to see what settings
+    /// Consult the documentation for the specific language server to see what settings
     /// are supported
     pub initialization_options: Option<serde_json::Value>,
     /// Language server settings

--- a/crates/settings/src/settings_content/project.rs
+++ b/crates/settings/src/settings_content/project.rs
@@ -108,7 +108,7 @@ pub struct WorktreeSettingsContent {
 #[serde(rename_all = "snake_case")]
 pub struct LspSettings {
     pub binary: Option<BinarySettings>,
-    /// Options passed to the language server at startup
+    /// Options passed to the language server at startup.
     ///
     /// Consult the documentation for the specific LSP to see what settings
     /// are supported

--- a/crates/settings/src/settings_content/project.rs
+++ b/crates/settings/src/settings_content/project.rs
@@ -108,7 +108,15 @@ pub struct WorktreeSettingsContent {
 #[serde(rename_all = "snake_case")]
 pub struct LspSettings {
     pub binary: Option<BinarySettings>,
+    /// Options passed to the language server at startup
+    ///
+    /// Consult the documentation for the specific LSP to see what settings
+    /// are supported
     pub initialization_options: Option<serde_json::Value>,
+    /// Language server settings
+    ///
+    /// Consult the documentation for the specific LSP to see what settings
+    /// are supported
     pub settings: Option<serde_json::Value>,
     /// If the server supports sending tasks over LSP extensions,
     /// this setting can be used to enable or disable them in Zed.

--- a/crates/settings/src/settings_content/project.rs
+++ b/crates/settings/src/settings_content/project.rs
@@ -26,6 +26,7 @@ pub struct ProjectSettingsContent {
     /// The following settings can be overridden for specific language servers:
     /// - initialization_options
     ///
+    ///
     /// To override settings for a language, add an entry for that language server's
     /// name to the lsp value.
     /// Default: null
@@ -110,13 +111,17 @@ pub struct LspSettings {
     pub binary: Option<BinarySettings>,
     /// Options passed to the language server at startup.
     ///
+    /// Ref: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initialize
+    ///
     /// Consult the documentation for the specific language server to see what settings
-    /// are supported
+    /// are supported.
     pub initialization_options: Option<serde_json::Value>,
-    /// Language server settings
+    /// Language server settings.
+    ///
+    /// Ref: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_configuration
     ///
     /// Consult the documentation for the specific LSP to see what settings
-    /// are supported
+    /// are supported.
     pub settings: Option<serde_json::Value>,
     /// If the server supports sending tasks over LSP extensions,
     /// this setting can be used to enable or disable them in Zed.


### PR DESCRIPTION
Document "any-typed" (`serde_json::Value`) "lsp" keys to include them in json-language-server completions.

The vscode-json-languageserver seems to skip generically typed keys when offering completion.

For this schema

```
    "LspSettings": {
        "type": "object",
        "properties": {
            ...
            "initialization_options": true,
            ...
         }
     }
```

"initialization_options" is not offered in the completion.

The effect is easy to verify by triggering completion inside:

```
    "lsp": {
        "basedpyright": {
           COMPLETE HERE
```

<img width="797" height="215" alt="image" src="https://github.com/user-attachments/assets/d1d1391c-d02c-4028-9888-8869f4d18b0f" />

By adding a documentation string the keys are offered even if they are generically typed:

<img width="809" height="238" alt="image" src="https://github.com/user-attachments/assets/9a072da9-961b-4e15-9aec-3d56933cbe67" />

---

Note: I did some cursory research of whether it's possible to make vscode-json-languageserver change behavior without success. IMO, not offering completions here is a bug (or at minimal should be configurable)

---

Release Notes:

- N/A
