### PR TITLE
Improve error messages on extension loading

### DIFF
--- a/crates/extension/src/extension_manifest.rs
+++ b/crates/extension/src/extension_manifest.rs
@@ -279,10 +279,7 @@ impl ExtensionManifest {
         } else {
             extension_manifest_path.set_extension("toml");
             let manifest_content = fs.load(&extension_manifest_path).await.with_context(|| {
-                format!(
-                    "failed to load {extension_name} extension.toml, {:?}",
-                    extension_manifest_path
-                )
+                format!("loading {extension_name} extension.toml, {extension_manifest_path:?}")
             })?;
             toml::from_str(&manifest_content).map_err(|err| {
                 anyhow!("Invalid extension.toml for extension {extension_name}:\n{err}")

--- a/crates/extension/src/extension_manifest.rs
+++ b/crates/extension/src/extension_manifest.rs
@@ -270,7 +270,7 @@ impl ExtensionManifest {
             let manifest_content = fs
                 .load(&extension_manifest_path)
                 .await
-                .with_context(|| format!("failed to load {extension_name} extension.json"))?;
+                .with_context(|| format!("failed to load {extension_name} extension.json, {:?}", extension_manifest_path))?;
             let manifest_json = serde_json::from_str::<OldExtensionManifest>(&manifest_content)
                 .with_context(|| {
                     format!("invalid extension.json for extension {extension_name}")
@@ -282,7 +282,7 @@ impl ExtensionManifest {
             let manifest_content = fs
                 .load(&extension_manifest_path)
                 .await
-                .with_context(|| format!("failed to load {extension_name} extension.toml"))?;
+                .with_context(|| format!("failed to load {extension_name} extension.toml, {:?}", extension_manifest_path))?;
             toml::from_str(&manifest_content).map_err(|err| {
                 anyhow!("Invalid extension.toml for extension {extension_name}:\n{err}")
             })

--- a/crates/extension/src/extension_manifest.rs
+++ b/crates/extension/src/extension_manifest.rs
@@ -267,10 +267,12 @@ impl ExtensionManifest {
 
         let mut extension_manifest_path = extension_dir.join("extension.json");
         if fs.is_file(&extension_manifest_path).await {
-            let manifest_content = fs
-                .load(&extension_manifest_path)
-                .await
-                .with_context(|| format!("failed to load {extension_name} extension.json, {:?}", extension_manifest_path))?;
+            let manifest_content = fs.load(&extension_manifest_path).await.with_context(|| {
+                format!(
+                    "failed to load {extension_name} extension.json, {:?}",
+                    extension_manifest_path
+                )
+            })?;
             let manifest_json = serde_json::from_str::<OldExtensionManifest>(&manifest_content)
                 .with_context(|| {
                     format!("invalid extension.json for extension {extension_name}")
@@ -279,10 +281,12 @@ impl ExtensionManifest {
             Ok(manifest_from_old_manifest(manifest_json, extension_name))
         } else {
             extension_manifest_path.set_extension("toml");
-            let manifest_content = fs
-                .load(&extension_manifest_path)
-                .await
-                .with_context(|| format!("failed to load {extension_name} extension.toml, {:?}", extension_manifest_path))?;
+            let manifest_content = fs.load(&extension_manifest_path).await.with_context(|| {
+                format!(
+                    "failed to load {extension_name} extension.toml, {:?}",
+                    extension_manifest_path
+                )
+            })?;
             toml::from_str(&manifest_content).map_err(|err| {
                 anyhow!("Invalid extension.toml for extension {extension_name}:\n{err}")
             })

--- a/crates/extension/src/extension_manifest.rs
+++ b/crates/extension/src/extension_manifest.rs
@@ -268,10 +268,7 @@ impl ExtensionManifest {
         let mut extension_manifest_path = extension_dir.join("extension.json");
         if fs.is_file(&extension_manifest_path).await {
             let manifest_content = fs.load(&extension_manifest_path).await.with_context(|| {
-                format!(
-                    "failed to load {extension_name} extension.json, {:?}",
-                    extension_manifest_path
-                )
+                format!("loading {extension_name} extension.json, {extension_manifest_path:?}")
             })?;
             let manifest_json = serde_json::from_str::<OldExtensionManifest>(&manifest_content)
                 .with_context(|| {

--- a/crates/extension_host/src/wasm_host.rs
+++ b/crates/extension_host/src/wasm_host.rs
@@ -759,11 +759,10 @@ impl WasmExtension {
     ) -> Result<Self> {
         let path = extension_dir.join("extension.wasm");
 
-        let mut wasm_file = wasm_host
-            .fs
-            .open_sync(&path)
-            .await
-            .context(format!("failed to open wasm file, path: {}", path.display()))?;
+        let mut wasm_file = wasm_host.fs.open_sync(&path).await.context(format!(
+            "failed to open wasm file, path: {}",
+            path.display()
+        ))?;
 
         let mut wasm_bytes = Vec::new();
         wasm_file

--- a/crates/extension_host/src/wasm_host.rs
+++ b/crates/extension_host/src/wasm_host.rs
@@ -759,20 +759,21 @@ impl WasmExtension {
     ) -> Result<Self> {
         let path = extension_dir.join("extension.wasm");
 
-        let mut wasm_file = wasm_host.fs.open_sync(&path).await.context(format!(
-            "failed to open wasm file, path: {}",
-            path.display()
-        ))?;
+        let mut wasm_file = wasm_host
+            .fs
+            .open_sync(&path)
+            .await
+            .context(format!("opening wasm file, path: {path:?}"))?;
 
         let mut wasm_bytes = Vec::new();
         wasm_file
             .read_to_end(&mut wasm_bytes)
-            .context(format!("failed to read wasm, path: {}", path.display()))?;
+            .context(format!("reading wasm file, path: {path:?}"))?;
 
         wasm_host
             .load_extension(wasm_bytes, manifest, cx)
             .await
-            .with_context(|| format!("failed to load wasm extension {}", manifest.id))
+            .with_context(|| format!("loading wasm extension: {}", manifest.id))
     }
 
     pub async fn call<T, Fn>(&self, f: Fn) -> Result<T>

--- a/crates/extension_host/src/wasm_host.rs
+++ b/crates/extension_host/src/wasm_host.rs
@@ -763,12 +763,12 @@ impl WasmExtension {
             .fs
             .open_sync(&path)
             .await
-            .context("failed to open wasm file")?;
+            .context(format!("failed to open wasm file, path: {}", path.display()))?;
 
         let mut wasm_bytes = Vec::new();
         wasm_file
             .read_to_end(&mut wasm_bytes)
-            .context("failed to read wasm")?;
+            .context(format!("failed to read wasm, path: {}", path.display()))?;
 
         wasm_host
             .load_extension(wasm_bytes, manifest, cx)


### PR DESCRIPTION
This pull request improves error message when extension loading goes wrong.

Before:

```
2025-11-08T21:16:02+08:00 ERROR [extension_host::extension_host] failed to load arkts extension.toml

Caused by:
    No such file or directory (os error 2)
```

Now:

```
2025-11-08T22:57:00+08:00 ERROR [extension_host::extension_host] failed to load arkts extension.toml, "/Users/user_name_placeholder/Library/Application Support/Zed/extensions/installed/arkts/extension.toml"

Caused by:
    No such file or directory (os error 2)

```

Release Notes:

- N/A