### PR TITLE
copilot: Add usage metrics to context menu

### DIFF
--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -29,7 +29,7 @@ use language_model::{
     StopReason, TokenUsage,
 };
 use settings::SettingsStore;
-use ui::{CommonAnimationExt, Divider, ProgressBar, prelude::*};
+use ui::{CommonAnimationExt, ProgressBar, prelude::*};
 use util::debug_panic;
 
 use crate::ui::ConfiguredApiCard;
@@ -1587,8 +1587,14 @@ impl Render for ConfigurationView {
                         || (usage.premium_interactions.overage_count > 0
                             && !usage.premium_interactions.overage_permitted);
 
-                    this.child(Divider::horizontal()).child(
+                    this.child(
                         v_flex()
+                            .mt_0p5()
+                            .p_2()
+                            .rounded_md()
+                            .border_1()
+                            .border_color(cx.theme().colors().border)
+                            .bg(cx.theme().colors().background)
                             .gap_2()
                             .child(
                                 Label::new("Usage")


### PR DESCRIPTION
Closes #ISSUE

Preview:

|Context menu|Settings panel|
|-|-|
|<img width="297" height="689" alt="image" src="https://github.com/user-attachments/assets/5e32cb1d-b3c0-49aa-832f-9ccac0636066" />|<img width="534" height="259" alt="image" src="https://github.com/user-attachments/assets/a9b21b2e-1045-41ce-9c2e-bc20170d3e67" />|

I also added the usage on GitHub Copilot settings, since users may not be using copilot as their edit prediction provider but they may still want to see the usage. 

Release Notes:

- Added usage stats to copilot context menu
- Added usage stats on GitHub Copilot settings
