### PR TITLE
agent: Improve `AddSelectionToThread` action display

### DIFF
--- a/crates/editor/src/mouse_context_menu.rs
+++ b/crates/editor/src/mouse_context_menu.rs
@@ -8,6 +8,8 @@ use crate::{
 };
 use gpui::prelude::FluentBuilder;
 use gpui::{Context, DismissEvent, Entity, Focusable as _, Pixels, Point, Subscription, Window};
+use project::DisableAiSettings;
+use settings::Settings;
 use std::ops::Range;
 use text::PointUtf16;
 use workspace::OpenInTerminal;
@@ -202,6 +204,7 @@ pub fn deploy_context_menu(
 
         let evaluate_selection = window.is_action_available(&EvaluateSelectedText, cx);
         let run_to_cursor = window.is_action_available(&RunToCursor, cx);
+        let disable_ai = DisableAiSettings::get_global(cx).disable_ai;
 
         ui::ContextMenu::build(window, cx, |menu, _window, _cx| {
             let builder = menu
@@ -234,7 +237,9 @@ pub fn deploy_context_menu(
                         quick_launch: false,
                     }),
                 )
-                .action("Add to Agent Thread", Box::new(AddSelectionToThread))
+                .when(!disable_ai && has_selections, |this| {
+                    this.action("Add to Agent Thread", Box::new(AddSelectionToThread))
+                })
                 .separator()
                 .action("Cut", Box::new(Cut))
                 .action("Copy", Box::new(Copy))

--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -2,7 +2,7 @@ use collab_ui::collab_panel;
 use gpui::{App, Menu, MenuItem, OsAction};
 use release_channel::ReleaseChannel;
 use terminal_view::terminal_panel;
-use zed_actions::{ToggleFocus as ToggleDebugPanel, agent::AddSelectionToThread, dev};
+use zed_actions::{ToggleFocus as ToggleDebugPanel, dev};
 
 pub fn app_menus(cx: &mut App) -> Vec<Menu> {
     use zed_actions::Quit;
@@ -218,8 +218,6 @@ pub fn app_menus(cx: &mut App) -> Vec<Menu> {
                 MenuItem::action("Move Line Up", editor::actions::MoveLineUp),
                 MenuItem::action("Move Line Down", editor::actions::MoveLineDown),
                 MenuItem::action("Duplicate Selection", editor::actions::DuplicateLineDown),
-                MenuItem::separator(),
-                MenuItem::action("Add to Agent Thread", AddSelectionToThread),
             ],
         },
         Menu {

--- a/crates/zed/src/zed/quick_action_bar.rs
+++ b/crates/zed/src/zed/quick_action_bar.rs
@@ -15,7 +15,7 @@ use gpui::{
     FocusHandle, Focusable, InteractiveElement, ParentElement, Render, Styled, Subscription,
     WeakEntity, Window, anchored, deferred, point,
 };
-use project::project_settings::DiagnosticSeverity;
+use project::{DisableAiSettings, project_settings::DiagnosticSeverity};
 use search::{BufferSearchBar, buffer_search};
 use settings::{Settings, SettingsStore};
 use ui::{
@@ -27,7 +27,7 @@ use workspace::item::ItemBufferKind;
 use workspace::{
     ToolbarItemEvent, ToolbarItemLocation, ToolbarItemView, Workspace, item::ItemHandle,
 };
-use zed_actions::{assistant::InlineAssist, outline::ToggleOutline};
+use zed_actions::{agent::AddSelectionToThread, assistant::InlineAssist, outline::ToggleOutline};
 
 const MAX_CODE_ACTION_MENU_LINES: u32 = 16;
 
@@ -241,7 +241,13 @@ impl Render for QuickActionBar {
                 .read(cx)
                 .snapshot(cx)
                 .has_diff_hunks();
+            let has_selection = editor.update(cx, |editor, cx| {
+                editor.has_non_empty_selection(&editor.display_snapshot(cx))
+            });
+
             let focus = editor.focus_handle(cx);
+
+            let disable_ai = DisableAiSettings::get_global(cx).disable_ai;
 
             PopoverMenu::new("editor-selections-dropdown")
                 .trigger_with_tooltip(
@@ -278,6 +284,13 @@ impl Render for QuickActionBar {
                                     skip_soft_wrap: true,
                                 }),
                             )
+                            .when(!disable_ai, |this| {
+                                this.separator().action_disabled_when(
+                                    !has_selection,
+                                    "Add to Agent Thread",
+                                    Box::new(AddSelectionToThread),
+                                )
+                            })
                             .separator()
                             .action("Go to Symbol", Box::new(ToggleOutline))
                             .action("Go to Line/Column", Box::new(ToggleGoToLine))


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/42276

This fixes the fact that the `AddSelectionToThread` action was visible when `disable_ai` was true, as well as it improves its display by making it either disabled or hidden when there are no selections in the editor. I also ended up removing it from the app menu simply because making it observe the `disable_ai` setting would be a bit more complex than I'd like at the moment, so figured that, given I'm also now adding it to the toolbar selection menu, we could do without it over there.

Release Notes:

- Fixed the `AddSelectionToThread` action showing up when `disable_ai` is true
- Improved the `AddSelectionToThread` action display by only making it available when there are selections in the editor
