### PR TITLE
ollama: Correct tool use for ollama 0.12.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10892,6 +10892,7 @@ dependencies = [
  "anyhow",
  "futures 0.3.31",
  "http_client",
+ "log",
  "schemars 1.0.4",
  "serde",
  "serde_json",

--- a/crates/language_models/src/provider/ollama.rs
+++ b/crates/language_models/src/provider/ollama.rs
@@ -581,7 +581,7 @@ fn map_to_language_model_completion_events(
                     if let Some(tool_call) = tool_calls.and_then(|v| v.into_iter().next()) {
                         // Directly access the struct fields
                         let function = tool_call.function; // Accessing the function field
-                        let tool_id = tool_call.id.clone().unwrap_or_else(|| {
+                        let tool_id = tool_call.id.unwrap_or_else(|| {
                             format!(
                                 "{}-{}",
                                 &function.name, // Assuming `function` has a `name` field

--- a/crates/language_models/src/provider/ollama.rs
+++ b/crates/language_models/src/provider/ollama.rs
@@ -387,7 +387,7 @@ impl OllamaLanguageModel {
                                         index: None,
                                         name: tool_use.name.to_string(),
                                         arguments: tool_use.input,
-                                    }
+                                    },
                                 });
                             }
                             _ => (),
@@ -581,20 +581,21 @@ fn map_to_language_model_completion_events(
                     if let Some(tool_call) = tool_calls.and_then(|v| v.into_iter().next()) {
                         // Directly access the struct fields
                         let function = tool_call.function; // Accessing the function field
-                        let tool_id = tool_call.id.clone().unwrap_or_else(|| format!(
-                            "{}-{}",
-                            &function.name, // Assuming `function` has a `name` field
-                            TOOL_CALL_COUNTER.fetch_add(1, Ordering::Relaxed)
-                        )); // Access id, handle Option
+                        let tool_id = tool_call.id.clone().unwrap_or_else(|| {
+                            format!(
+                                "{}-{}",
+                                &function.name, // Assuming `function` has a `name` field
+                                TOOL_CALL_COUNTER.fetch_add(1, Ordering::Relaxed)
+                            )
+                        }); // Access id, handle Option
 
-                        let event =
-                            LanguageModelCompletionEvent::ToolUse(LanguageModelToolUse {
-                                id: LanguageModelToolUseId::from(tool_id),
-                                name: Arc::from(function.name),
-                                raw_input: function.arguments.to_string(),
-                                input: function.arguments,
-                                is_input_complete: true,
-                            });
+                        let event = LanguageModelCompletionEvent::ToolUse(LanguageModelToolUse {
+                            id: LanguageModelToolUseId::from(tool_id),
+                            name: Arc::from(function.name),
+                            raw_input: function.arguments.to_string(),
+                            input: function.arguments,
+                            is_input_complete: true,
+                        });
                         events.push(Ok(event));
                         state.used_tools = true;
                     } else if !content.is_empty() {

--- a/crates/language_models/src/provider/ollama.rs
+++ b/crates/language_models/src/provider/ollama.rs
@@ -381,10 +381,14 @@ impl OllamaLanguageModel {
                                 thinking = Some(text)
                             }
                             MessageContent::ToolUse(tool_use) => {
-                                tool_calls.push(OllamaToolCall::Function(OllamaFunctionCall {
-                                    name: tool_use.name.to_string(),
-                                    arguments: tool_use.input,
-                                }));
+                                tool_calls.push(OllamaToolCall {
+                                    id: None,
+                                    function: OllamaFunctionCall {
+                                        index: None,
+                                        name: tool_use.name.to_string(),
+                                        arguments: tool_use.input,
+                                    }
+                                });
                             }
                             _ => (),
                         }
@@ -575,25 +579,24 @@ fn map_to_language_model_completion_events(
                     }
 
                     if let Some(tool_call) = tool_calls.and_then(|v| v.into_iter().next()) {
-                        match tool_call {
-                            OllamaToolCall::Function(function) => {
-                                let tool_id = format!(
-                                    "{}-{}",
-                                    &function.name,
-                                    TOOL_CALL_COUNTER.fetch_add(1, Ordering::Relaxed)
-                                );
-                                let event =
-                                    LanguageModelCompletionEvent::ToolUse(LanguageModelToolUse {
-                                        id: LanguageModelToolUseId::from(tool_id),
-                                        name: Arc::from(function.name),
-                                        raw_input: function.arguments.to_string(),
-                                        input: function.arguments,
-                                        is_input_complete: true,
-                                    });
-                                events.push(Ok(event));
-                                state.used_tools = true;
-                            }
-                        }
+                        // Directly access the struct fields
+                        let function = tool_call.function; // Accessing the function field
+                        let tool_id = tool_call.id.clone().unwrap_or_else(|| format!(
+                            "{}-{}",
+                            &function.name, // Assuming `function` has a `name` field
+                            TOOL_CALL_COUNTER.fetch_add(1, Ordering::Relaxed)
+                        )); // Access id, handle Option
+
+                        let event =
+                            LanguageModelCompletionEvent::ToolUse(LanguageModelToolUse {
+                                id: LanguageModelToolUseId::from(tool_id),
+                                name: Arc::from(function.name),
+                                raw_input: function.arguments.to_string(),
+                                input: function.arguments,
+                                is_input_complete: true,
+                            });
+                        events.push(Ok(event));
+                        state.used_tools = true;
                     } else if !content.is_empty() {
                         events.push(Ok(LanguageModelCompletionEvent::Text(content)));
                     }

--- a/crates/ollama/Cargo.toml
+++ b/crates/ollama/Cargo.toml
@@ -19,6 +19,7 @@ schemars = ["dep:schemars"]
 anyhow.workspace = true
 futures.workspace = true
 http_client.workspace = true
+log.workspace = true
 schemars = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/ollama/src/ollama.rs
+++ b/crates/ollama/src/ollama.rs
@@ -485,6 +485,38 @@ mod tests {
             "eval_duration": 302561917,
         });
 
+    #[test]
+    fn parse_tool_call_ollama_0_10_12() {
+        // Tool call response as of 2025-11: https://github.com/ollama/ollama/pull/12956
+        let response = serde_json::json!({
+            "model": "llama3.2:3b",
+            "created_at": "2025-04-28T20:02:02.140489Z",
+            "message": {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_f5kqwpjg",
+                        "function": {
+                            "index": 0,
+                            "name": "weather",
+                            "arguments": {
+                                "city": "london",
+                            }
+                        }
+                    }
+                ]
+            },
+            "done_reason": "stop",
+            "done": true,
+            "total_duration": 2758629166u64,
+            "load_duration": 1770059875,
+            "prompt_eval_count": 147,
+            "prompt_eval_duration": 684637583,
+            "eval_count": 16,
+            "eval_duration": 302561917,
+        });
+
         let result: ChatResponseDelta = serde_json::from_value(response).unwrap();
         match result.message {
             ChatMessage::Assistant {

--- a/crates/ollama/src/ollama.rs
+++ b/crates/ollama/src/ollama.rs
@@ -4,7 +4,6 @@ use http_client::{AsyncBody, HttpClient, HttpRequestExt, Method, Request as Http
 use serde::{Deserialize, Serialize};
 use serde_json::{Number, Value};
 pub use settings::KeepAlive;
-use log::info;
 
 pub const OLLAMA_API_URL: &str = "http://localhost:11434";
 
@@ -484,6 +483,21 @@ mod tests {
             "eval_count": 16,
             "eval_duration": 302561917,
         });
+
+        let result: ChatResponseDelta = serde_json::from_value(response).unwrap();
+        match result.message {
+            ChatMessage::Assistant {
+                content,
+                tool_calls,
+                images: _,
+                thinking,
+            } => {
+                assert!(content.is_empty());
+                assert!(tool_calls.is_some_and(|v| !v.is_empty()));
+                assert!(thinking.is_none());
+            }
+            _ => panic!("Deserialized wrong role"),
+        }
     }
 
     #[test]

--- a/crates/ollama/src/ollama.rs
+++ b/crates/ollama/src/ollama.rs
@@ -284,7 +284,10 @@ pub async fn stream_chat_completion(
     request: ChatRequest,
 ) -> Result<BoxStream<'static, Result<ChatResponseDelta>>> {
     let uri = format!("{api_url}/api/chat");
-    info!("Chat request: {:?}", serde_json::to_string(&request).unwrap());
+    log::info!(
+        "Chat request: {:?}",
+        serde_json::to_string(&request).unwrap()
+    );
     let request = HttpRequest::builder()
         .method(Method::POST)
         .uri(&uri)
@@ -293,9 +296,12 @@ pub async fn stream_chat_completion(
             builder.header("Authorization", format!("Bearer {api_key}"))
         })
         .body(AsyncBody::from(serde_json::to_string(&request)?))?;
-    info!("Sending request to Ollama: {}", uri);
+    log::info!("Sending request to Ollama: {}", uri);
     let mut response = client.send(request).await?;
-    info!("Received response from Ollama: status = {}", response.status());
+    log::info!(
+        "Received response from Ollama: status = {}",
+        response.status()
+    );
     if response.status().is_success() {
         let reader = BufReader::new(response.into_body());
 

--- a/crates/ollama/src/ollama.rs
+++ b/crates/ollama/src/ollama.rs
@@ -484,6 +484,7 @@ mod tests {
             "eval_count": 16,
             "eval_duration": 302561917,
         });
+    }
 
     #[test]
     fn parse_tool_call_ollama_0_10_12() {


### PR DESCRIPTION
Release Notes:

- Fixed ollama 0.12.10 tool use

Issue:

failure to execute tools (parse error)
```
2025-11-09T00:10:05+01:00 INFO  [ollama] Received line from Ollama: {"model":"qwen3:8b","created_at":"2025-11-08T23:10:05.993258464Z","message":{"role":"assist
ant","content":"","tool_calls":[{"id":"call_f5kqwpjg","function":{"index":0,"name":"find_path","arguments":{"glob":"*led*","offset":0}}}]},"done":false}       
2025-11-09T00:10:05+01:00 ERROR [ollama] Unable to parse chat response: Error("invalid value: map, expected map with a single key", line: 1, column: 229)      
2025-11-09T00:10:05+01:00 ERROR [agent::thread] Turn execution failed: invalid value: map, expected map with a single key at line 1 column 229                 
2025-11-09T00:10:05+01:00 ERROR [agent] Error in model response stream: invalid value: map, expected map with a single key at line 1 column 229
```

solution: change the structure to be able to parse the tool response:
add id to OllamaToolCall (and change from enum to struct)
add index to OllamaFunctionCall

environment: 
dockerized ollama: ollama/ollama
ollama/ollama                                           latest                                    d353379de60a   2 days ago      3.65GB

ollama --version
ollama version is 0.12.10

Zed 0.211.6 
394f56da42c9baa27f53714c486bccf5d95a8e3d

any tool supporting model

i dont expect you to merge this PR, this rust code might be too hacky, but it would be really great to get some logging for ollama in the future in case some model answers do not match expectations anymore. did not find any useful way to enable debugging output for the real agent conversation