### PR TITLE
install_cli: Add user admin check and local bin fallback for CLI installation

### DIFF
--- a/crates/install_cli/src/install_cli_binary.rs
+++ b/crates/install_cli/src/install_cli_binary.rs
@@ -16,45 +16,25 @@ actions!(
     ]
 );
 
-async fn add_path_to_zshrc() -> Result<bool> {
-    let home_dir = std::env::var("HOME").context("Failed to get HOME environment variable")?;
-    let zshrc_path = PathBuf::from(&home_dir).join(".zshrc");
-    let path_export = r#"export PATH="$HOME/.local/bin:$PATH""#;
-
-    // Read existing .zshrc content if it exists
-    let existing_content = smol::fs::read_to_string(&zshrc_path)
-        .await
-        .unwrap_or_default();
-
-    // Check if the PATH export already exists
-    if existing_content.contains(path_export) || existing_content.contains("$HOME/.local/bin") {
-        return Ok(false);
+async fn is_user_admin() -> bool {
+    let output = smol::process::Command::new("groups").output().await.ok();
+    if let Some(output) = output {
+        if output.status.success() {
+            let groups = String::from_utf8_lossy(&output.stdout);
+            return groups.split_whitespace().any(|g| g == "admin");
+        }
     }
-
-    // Append the PATH export to .zshrc
-    let new_content = if existing_content.is_empty() {
-        format!("{}\n", path_export)
-    } else if existing_content.ends_with('\n') {
-        format!("{}{}\n", existing_content, path_export)
-    } else {
-        format!("{}\n{}\n", existing_content, path_export)
-    };
-
-    smol::fs::write(&zshrc_path, new_content)
-        .await
-        .context("Failed to write to ~/.zshrc")?;
-
-    Ok(true)
+    false
 }
 
-async fn install_script(cx: &AsyncApp) -> Result<PathBuf> {
+async fn install_to_local_bin(cx: &AsyncApp) -> Result<PathBuf> {
     let cli_path = cx.update(|cx| cx.path_for_auxiliary_executable("cli"))??;
     let home_dir = std::env::var("HOME").context("Failed to get HOME environment variable")?;
-    let link_path = Path::new(&home_dir).join(".local/bin/zed");
-    let bin_dir_path = link_path.parent().unwrap();
+    let local_bin = PathBuf::from(home_dir).join(".local/bin");
+    let link_path = local_bin.join("zed");
 
     // Ensure ~/.local/bin directory exists
-    smol::fs::create_dir_all(&bin_dir_path)
+    smol::fs::create_dir_all(&local_bin)
         .await
         .context("Failed to create ~/.local/bin directory")?;
 
@@ -63,13 +43,80 @@ async fn install_script(cx: &AsyncApp) -> Result<PathBuf> {
         return Ok(link_path);
     }
 
-    // If the symlink is not there or is outdated, first try replacing it.
+    // Remove old symlink if exists
     smol::fs::remove_file(&link_path).await.log_err();
+
+    // Create new symlink
     smol::fs::unix::symlink(&cli_path, &link_path)
         .await
         .context("Failed to create symlink to ~/.local/bin/zed")?;
 
     Ok(link_path)
+}
+
+async fn install_to_system_bin(cx: &AsyncApp) -> Result<PathBuf> {
+    let cli_path = cx.update(|cx| cx.path_for_auxiliary_executable("cli"))??;
+    let link_path = Path::new("/usr/local/bin/zed");
+    let bin_dir_path = link_path.parent().unwrap();
+
+    // Don't re-create symlink if it points to the same CLI binary.
+    if smol::fs::read_link(link_path).await.ok().as_ref() == Some(&cli_path) {
+        return Ok(link_path.into());
+    }
+
+    // If the symlink is not there or is outdated, first try replacing it
+    // without escalating.
+    smol::fs::remove_file(link_path).await.log_err();
+    if smol::fs::unix::symlink(&cli_path, link_path)
+        .await
+        .log_err()
+        .is_some()
+    {
+        return Ok(link_path.into());
+    }
+
+    // The symlink could not be created, so use osascript with admin privileges
+    // to create it.
+    let status = smol::process::Command::new("/usr/bin/osascript")
+        .args([
+            "-e",
+            &format!(
+                "do shell script \" \
+                    mkdir -p \'{}\' && \
+                    ln -sf \'{}\' \'{}\' \
+                \" with administrator privileges",
+                bin_dir_path.to_string_lossy(),
+                cli_path.to_string_lossy(),
+                link_path.to_string_lossy(),
+            ),
+        ])
+        .stdout(smol::process::Stdio::inherit())
+        .stderr(smol::process::Stdio::inherit())
+        .output()
+        .await?
+        .status;
+
+    anyhow::ensure!(status.success(), "error running osascript");
+    Ok(link_path.into())
+}
+
+async fn install_script(cx: &AsyncApp) -> Result<PathBuf> {
+    let has_admin = is_user_admin().await;
+
+    if !has_admin {
+        return install_to_local_bin(cx).await;
+    }
+
+    match install_to_system_bin(cx).await {
+        Ok(path) => Ok(path),
+        Err(err) => {
+            eprintln!(
+                "Failed to install to system bin: {}. Falling back to local bin.",
+                err
+            );
+            install_to_local_bin(cx).await
+        }
+    }
 }
 
 pub fn install_cli_binary(window: &mut Window, cx: &mut Context<Workspace>) {
@@ -90,27 +137,28 @@ pub fn install_cli_binary(window: &mut Window, cx: &mut Context<Workspace>) {
             .await
             .context("error creating CLI symlink")?;
 
-        // Add PATH to ~/.zshrc
-        let added_to_zshrc = add_path_to_zshrc().await.unwrap_or(false);
-
         workspace.update_in(cx, |workspace, _, cx| {
             struct InstalledZedCli;
 
-            let shell_note = if added_to_zshrc {
-                "\n\nAdded ~/.local/bin to PATH in ~/.zshrc. If you use a different shell (bash, fish, etc.), please add the following to your shell config:\nexport PATH=\"$HOME/.local/bin:$PATH\""
+            let message = if path.starts_with("/usr/local/bin") {
+                format!(
+                    "Installed `zed` to {}. You can launch {} from your terminal.",
+                    path.to_string_lossy(),
+                    ReleaseChannel::global(cx).display_name()
+                )
             } else {
-                "\n\nIf you use a shell other than zsh, please add the following to your shell config:\nexport PATH=\"$HOME/.local/bin:$PATH\""
+                format!(
+                    "Installed `zed` to {}. Make sure {} is in your PATH to launch from your terminal.",
+                    path.to_string_lossy(),
+                    path.parent().unwrap().to_string_lossy()
+                )
             };
+
 
             workspace.show_toast(
                 Toast::new(
                     NotificationId::unique::<InstalledZedCli>(),
-                    format!(
-                        "Installed `zed` to {}. You can launch {} from your terminal.{}",
-                        path.to_string_lossy(),
-                        ReleaseChannel::global(cx).display_name(),
-                        shell_note
-                    ),
+                    message,
                 ),
                 cx,
             )


### PR DESCRIPTION
Closes #10065 

Release Notes:

- Add `admin` check and CLI installation without admin support for `Install CLI`
- Check if the user is in the `admin` group. If not, install CLI to `~/.local/bin`. If yes, attempt installation via `osascript`; if it fails, fall back to installing in `~/.local/bin`.
  Refer to the flowchart below for clarification:
  ```mermaid
  flowchart TB
      Start[Start: install_script] --> CheckAdmin{Check if user<br/>in admin group?}
      
      CheckAdmin -->|No Admin| InstallLocal1[Install to ~/.local/bin]
      CheckAdmin -->|Has Admin| InstallSystem[Try install to /usr/local/bin]
      
      InstallLocal1 --> Success1[✅ Return ~/.local/bin/zed]
      
      InstallSystem -->|Success| Success2[✅ Return /usr/local/bin/zed]
      InstallSystem -->|Failed| Fallback[Fallback to ~/.local/bin]
      
      Fallback --> Success3[✅ Return ~/.local/bin/zed]
      
      Success1 --> End[End]
      Success2 --> End
      Success3 --> End
      
      style CheckAdmin fill:#FDB863,stroke:#E08214,stroke-width:3px,color:#000
      style InstallLocal1 fill:#B2ABD2,stroke:#5E3C99,stroke-width:3px,color:#000
      style Fallback fill:#F4A582,stroke:#D6604D,stroke-width:3px,color:#000
      style Start fill:#B8E186,stroke:#4D9221,color:#000
      style End fill:#B8E186,stroke:#4D9221,color:#000
  ```

https://github.com/user-attachments/assets/5f01daa8-ec81-4b2a-a494-0ab0576c97bc


