### PR TITLE
vim: Handle literal $ in search replacements

### DIFF
--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -658,6 +658,7 @@ impl Replacement {
 mod test {
     use std::time::Duration;
 
+    use super::Replacement;
     use crate::{
         state::Mode,
         test::{NeovimBackedTestContext, VimTestContext},
@@ -670,6 +671,9 @@ mod test {
 
     #[gpui::test]
     async fn test_replace_literal_dollar(cx: &mut gpui::TestAppContext) {
+        let replacement = Replacement::parse("/\\$Base/\\$BaseNew/".chars().peekable()).unwrap();
+        assert_eq!(replacement.replacement, "$$BaseNew");
+
         let mut cx = NeovimBackedTestContext::new(cx).await;
         cx.set_shared_state(indoc! {
             "ˇ$Base one
@@ -678,9 +682,7 @@ mod test {
         })
         .await;
 
-        cx.simulate_shared_keystrokes(
-            ": % s / \\ shift-4 shift-b a s e / \\ shift-4 shift-b a s e shift-n e w / g",
-        )
+        cx.simulate_shared_keystrokes(": % s / \\ $ B a s e / \\ $ B a s e N e w / g")
         .await;
         cx.simulate_shared_keystrokes("enter").await;
 

--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -683,7 +683,7 @@ mod test {
         .await;
 
         cx.simulate_shared_keystrokes(": % s / \\ $ B a s e / \\ $ B a s e N e w / g")
-        .await;
+            .await;
         cx.simulate_shared_keystrokes("enter").await;
 
         cx.shared_state().await.assert_eq(indoc! {

--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -599,6 +599,10 @@ impl Replacement {
                 escaped = false;
                 if phase == 1 && c.is_ascii_digit() {
                     buffer.push('$')
+                } else if phase == 1 && c == '$' {
+                    buffer.push('$');
+                    buffer.push('$');
+                    continue;
                 // unescape escaped parens
                 } else if phase == 0 && (c == '(' || c == ')') {
                 } else if c != delimiter {
@@ -654,6 +658,7 @@ impl Replacement {
 mod test {
     use std::time::Duration;
 
+    use super::Replacement;
     use crate::{
         state::Mode,
         test::{NeovimBackedTestContext, VimTestContext},
@@ -663,6 +668,12 @@ mod test {
     use indoc::indoc;
     use search::BufferSearchBar;
     use settings::SettingsStore;
+
+    #[test]
+    fn replacement_parse_literal_dollar() {
+        let replacement = Replacement::parse("/\\$Base/\\$BaseNew/".chars().peekable()).unwrap();
+        assert_eq!(replacement.replacement, "$$BaseNew");
+    }
 
     #[gpui::test]
     async fn test_move_to_next(cx: &mut gpui::TestAppContext) {

--- a/crates/vim/test_data/test_replace_literal_dollar.json
+++ b/crates/vim/test_data/test_replace_literal_dollar.json
@@ -1,0 +1,25 @@
+{"Put":{"state":"ˇ$Base one\n$Base two\n$Base three"}}
+{"Key":":"}
+{"Key":"%"}
+{"Key":"s"}
+{"Key":"/"}
+{"Key":"\\"}
+{"Key":"$"}
+{"Key":"B"}
+{"Key":"a"}
+{"Key":"s"}
+{"Key":"e"}
+{"Key":"/"}
+{"Key":"\\"}
+{"Key":"$"}
+{"Key":"B"}
+{"Key":"a"}
+{"Key":"s"}
+{"Key":"e"}
+{"Key":"N"}
+{"Key":"e"}
+{"Key":"w"}
+{"Key":"/"}
+{"Key":"g"}
+{"Key":"enter"}
+{"Get":{"state":"$BaseNew one\n$BaseNew two\nˇ$BaseNew three","mode":"Normal"}}


### PR DESCRIPTION
Ensure the replacement parser treats \$ as $$ instead of falling through the generic escape path

Closes https://github.com/zed-industries/zed/issues/42292

Release Notes:

- Fixed vim search replacement parsing for literal dollar signs
