### PR TITLE
Fix unexpected lack of output when stdout is a pipe

### DIFF
--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -240,7 +240,7 @@ pub fn main() {
     }
 
     zlog::init();
-    if stdout_is_a_pty() {
+    if args.foreground {
         zlog::init_output_stdout();
     } else {
         let result = zlog::init_output_file(paths::log_file(), Some(paths::old_log_file()));
@@ -1304,10 +1304,11 @@ struct Args {
     #[arg(long, hide = true)]
     crash_handler: Option<PathBuf>,
 
-    /// Run zed in the foreground, only used on Windows, to match the behavior on macOS.
+    /// Print logs
+    ///
+    /// Called by CLI binary when --foreground is given
     #[arg(long)]
-    #[cfg(target_os = "windows")]
-    #[arg(hide = true)]
+    #[cfg_attr(debug_assertions, arg(default_value_t = true, hide = true))]
     foreground: bool,
 
     /// The dock action to perform. This is used on Windows only.

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -1306,7 +1306,7 @@ struct Args {
 
     /// Print logs
     ///
-    /// Called by CLI binary when --foreground is given
+    /// Set by CLI binary when running zed in the foreground
     #[arg(long)]
     #[cfg_attr(debug_assertions, arg(default_value_t = true, hide = true))]
     foreground: bool,


### PR DESCRIPTION
## Motivation

Writing log output conditionally on stdout.is_terminal() creates unexpected behavior when piping/redirecting stdout, for example for further filtering.

```sh
zed # plenty of output :) (so much one may want to use grep)
zed | grep ... # suddenly no output!
```

## Changes

- ~~b80f4d68a4e405dc8af73b179e294c4d9a6e0410 Adds a --log option which controls when logs are written to stdout and takes a filter argument.~~
- ~~daaeeb5e10fba4af386436e3ed62a0bba3d0e3b0 Tidy up -h/--help output a little;~~
  Moved to new PR: https://github.com/zed-industries/zed/pull/42496
- ~~cdd4a18ae9d1c222683578ca35e9c07ff52738bf Adds a --log option which controls when logs are written to stdout.~~
- 7893c9688f47915103e7a2928967e14905f34af7 Write logs to stdout when --foreground is set.

    To keep logs readily discoverable (and for convenience during development), I thought it would be nice to set --foreground automatically in debug builds. The way that manifests is as follows:

    - in release builds:
    if `--foreground` is set, log to stdout, otherwise log to paths::log_file()
    as before.

    - in debug builds:
    always log to stdout, and the `--foreground` option is hidden from `-h`/`--help`.

Release Notes:

- Fixed missing logs when stdout is a pipe
