### PR TITLE
agent_ui: Fix external agent icons in configuration view

### DIFF
--- a/crates/agent_ui/src/agent_configuration.rs
+++ b/crates/agent_ui/src/agent_configuration.rs
@@ -1047,7 +1047,7 @@ impl AgentConfiguration {
             AgentIcon::Name(icon_name) => Icon::new(icon_name)
                 .size(IconSize::Small)
                 .color(Color::Muted),
-            AgentIcon::Path(icon_path) => Icon::from_path(icon_path)
+            AgentIcon::Path(icon_path) => Icon::from_external_svg(icon_path)
                 .size(IconSize::Small)
                 .color(Color::Muted),
         };


### PR DESCRIPTION
This PR makes the icons for external agents in the configuration view use `from_external_svg` instead of `from_path`.

Release Notes:

- N/A
