### PR TITLE
Make it easy to point zeta2 at ollama

### DIFF
--- a/crates/cloud_llm_client/src/cloud_llm_client.rs
+++ b/crates/cloud_llm_client/src/cloud_llm_client.rs
@@ -183,13 +183,13 @@ pub struct PredictEditsGitInfo {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PredictEditsResponse {
-    pub request_id: Uuid,
+    pub request_id: String,
     pub output_excerpt: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AcceptEditPredictionBody {
-    pub request_id: Uuid,
+    pub request_id: String,
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Serialize, Deserialize)]

--- a/crates/zeta/src/zeta.rs
+++ b/crates/zeta/src/zeta.rs
@@ -652,7 +652,7 @@ impl Zeta {
                     .header(ZED_VERSION_HEADER_NAME, app_version.to_string())
                     .body(
                         serde_json::to_string(&AcceptEditPredictionBody {
-                            request_id: request_id.0,
+                            request_id: request_id.0.to_string(),
                         })?
                         .into(),
                     )?)
@@ -734,6 +734,8 @@ impl Zeta {
             else {
                 return anyhow::Ok(None);
             };
+
+            let request_id = Uuid::from_str(&request_id).context("failed to parse request id")?;
 
             let edit_preview = edit_preview.await;
 
@@ -2162,7 +2164,7 @@ mod tests {
                                 .status(200)
                                 .body(
                                     serde_json::to_string(&PredictEditsResponse {
-                                        request_id: Uuid::new_v4(),
+                                        request_id: Uuid::new_v4().to_string(),
                                         output_excerpt: completion_response.lock().clone(),
                                     })
                                     .unwrap()

--- a/crates/zeta2/src/prediction.rs
+++ b/crates/zeta2/src/prediction.rs
@@ -1,21 +1,14 @@
 use std::{ops::Range, sync::Arc};
 
-use gpui::{AsyncApp, Entity};
+use gpui::{AsyncApp, Entity, SharedString};
 use language::{Anchor, Buffer, BufferSnapshot, EditPreview, OffsetRangeExt, TextBufferSnapshot};
-use uuid::Uuid;
 
-#[derive(Copy, Clone, Default, Debug, PartialEq, Eq, Hash)]
-pub struct EditPredictionId(pub Uuid);
-
-impl Into<Uuid> for EditPredictionId {
-    fn into(self) -> Uuid {
-        self.0
-    }
-}
+#[derive(Clone, Default, Debug, PartialEq, Eq, Hash)]
+pub struct EditPredictionId(pub SharedString);
 
 impl From<EditPredictionId> for gpui::ElementId {
     fn from(value: EditPredictionId) -> Self {
-        gpui::ElementId::Uuid(value.0)
+        gpui::ElementId::Name(value.0)
     }
 }
 
@@ -149,7 +142,7 @@ mod tests {
             .await;
 
         let prediction = EditPrediction {
-            id: EditPredictionId(Uuid::new_v4()),
+            id: EditPredictionId("prediction-1".into()),
             edits,
             snapshot: cx.read(|cx| buffer.read(cx).snapshot()),
             buffer: buffer.clone(),


### PR DESCRIPTION
I wanted to be able to work offline, so I made it a little bit more convenient to point zeta2 at ollama.

* For zeta2, don't require that request ids be UUIDs
* Add an env var `ZED_ZETA2_OLLAMA` that sets the edit prediction URL and model id to work w/ ollama.

Release Notes:

- N/A
