### PR TITLE
Replace deprecated json.schemastore.org with www.schemastore.org

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://json.schemastore.org/github-issue-config.json
+# yaml-language-server: $schema=https://www.schemastore.org/github-issue-config.json
 blank_issues_enabled: false
 contact_links:
   - name: Feature Request

--- a/crates/json_schema_store/src/schemas/package.json
+++ b/crates/json_schema_store/src/schemas/package.json
@@ -1030,22 +1030,22 @@
       "$ref": "#"
     },
     "eslintConfig": {
-      "$ref": "https://json.schemastore.org/eslintrc.json"
+      "$ref": "https://www.schemastore.org/eslintrc.json"
     },
     "prettier": {
-      "$ref": "https://json.schemastore.org/prettierrc.json"
+      "$ref": "https://www.schemastore.org/prettierrc.json"
     },
     "stylelint": {
-      "$ref": "https://json.schemastore.org/stylelintrc.json"
+      "$ref": "https://www.schemastore.org/stylelintrc.json"
     },
     "ava": {
-      "$ref": "https://json.schemastore.org/ava.json"
+      "$ref": "https://www.schemastore.org/ava.json"
     },
     "release": {
-      "$ref": "https://json.schemastore.org/semantic-release.json"
+      "$ref": "https://www.schemastore.org/semantic-release.json"
     },
     "jscpd": {
-      "$ref": "https://json.schemastore.org/jscpd.json"
+      "$ref": "https://www.schemastore.org/jscpd.json"
     },
     "pnpm": {
       "description": "Defines pnpm specific configuration.",
@@ -1305,5 +1305,5 @@
       ]
     }
   ],
-  "$id": "https://json.schemastore.org/package.json"
+  "$id": "https://www.schemastore.org/package.json"
 }

--- a/crates/json_schema_store/src/schemas/tsconfig.json
+++ b/crates/json_schema_store/src/schemas/tsconfig.json
@@ -1466,7 +1466,7 @@
       }
     }
   },
-  "id": "https://json.schemastore.org/tsconfig",
+  "id": "https://www.schemastore.org/tsconfig",
   "title": "JSON schema for the TypeScript compiler's configuration file",
   "type": "object"
 }

--- a/docs/src/languages/deno.md
+++ b/docs/src/languages/deno.md
@@ -78,7 +78,7 @@ To get completions for `deno.json` or `package.json` you can add the following t
               "fileMatch": [
                 "package.json"
               ],
-              "url": "http://json.schemastore.org/package"
+              "url": "http://www.schemastore.org/package"
             }
           ]
         }

--- a/docs/src/languages/deno.md
+++ b/docs/src/languages/deno.md
@@ -78,7 +78,7 @@ To get completions for `deno.json` or `package.json` you can add the following t
               "fileMatch": [
                 "package.json"
               ],
-              "url": "http://www.schemastore.org/package"
+              "url": "https://www.schemastore.org/package"
             }
           ]
         }

--- a/docs/src/languages/yaml.md
+++ b/docs/src/languages/yaml.md
@@ -19,7 +19,7 @@ You can configure various [yaml-language-server settings](https://github.com/red
             "singleQuote": true
           },
           "schemas": {
-              "http://json.schemastore.org/composer": ["/*"],
+              "http://www.schemastore.org/composer": ["/*"],
               "../relative/path/schema.json": ["/config*.yaml"]
           }
         }
@@ -70,7 +70,7 @@ By default yaml-language-server will attempt to determine the correct schema for
 You can override any auto-detected schema via the `schemas` settings key (demonstrated above) or by providing an [inlined schema](https://github.com/redhat-developer/yaml-language-server#using-inlined-schema) reference via a modeline comment at the top of your yaml file:
 
 ```yaml
-# yaml-language-server: $schema=https://json.schemastore.org/github-action.json
+# yaml-language-server: $schema=https://www.schemastore.org/github-action.json
 name: Issue Assignment
 on:
   issues:

--- a/docs/src/languages/yaml.md
+++ b/docs/src/languages/yaml.md
@@ -19,7 +19,7 @@ You can configure various [yaml-language-server settings](https://github.com/red
             "singleQuote": true
           },
           "schemas": {
-              "http://www.schemastore.org/composer": ["/*"],
+              "https://getcomposer.org/schema.json": ["/*"],
               "../relative/path/schema.json": ["/config*.yaml"]
           }
         }


### PR DESCRIPTION
Release Notes:

- N/A

According to [microsoft/vscode#254689](https://github.com/microsoft/vscode/issues/254689),
the json.schemastore.org domain has been deprecated and should now use
www.schemastore.org (or schemastore.org) instead.

This PR updates all occurrences of the old domain within the Zed codebase,
including code, documentation, and configuration files.