### PR TITLE
Fix circular reference issue between EditPredictionButton and PopoverMenuHandle

### DIFF
--- a/crates/edit_prediction_button/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_button/src/edit_prediction_button.rs
@@ -383,7 +383,8 @@ impl Render for EditPredictionButton {
 
                 let mut popover_menu = PopoverMenu::new("zeta")
                     .menu(move |window, cx| {
-                        this.update(cx, |this, cx| this.build_zeta_context_menu(window, cx)).ok()
+                        this.update(cx, |this, cx| this.build_zeta_context_menu(window, cx))
+                            .ok()
                     })
                     .anchor(Corner::BottomRight)
                     .with_handle(self.popover_menu_handle.clone());

--- a/crates/edit_prediction_button/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_button/src/edit_prediction_button.rs
@@ -379,11 +379,11 @@ impl Render for EditPredictionButton {
                         })
                     });
 
-                let this = cx.entity();
+                let this = cx.weak_entity();
 
                 let mut popover_menu = PopoverMenu::new("zeta")
                     .menu(move |window, cx| {
-                        Some(this.update(cx, |this, cx| this.build_zeta_context_menu(window, cx)))
+                        this.update(cx, |this, cx| this.build_zeta_context_menu(window, cx)).ok()
                     })
                     .anchor(Corner::BottomRight)
                     .with_handle(self.popover_menu_handle.clone());


### PR DESCRIPTION
Closes #ISSUE

While working on issue #40906, I discovered that RemoteClient was not being released after the remote project closed.
Analysis revealed a circular reference between EditPredictionButton and PopoverMenuHandle.

Dependency Chain: RemoteClient → Project → ZetaEditPredictionProvider → EditPredictionButton ↔ PopoverMenuHandle

<img width="400" height="300" alt="image" src="https://github.com/user-attachments/assets/6b716c9b-6938-471a-b044-397314b729d4" />

a) EditPredictionButton hold the reference of PopoverMenuHandle 
https://github.com/zed-industries/zed/blob/5f8226457ee6e1346a224ae6b0329f014ea883f7/crates/zed/src/zed.rs#L386-L394

b) PopoverMenuHandle hold the reference of Fn which capture `Entity<EditPredictionButton>`
https://github.com/zed-industries/zed/blob/5fc54986c72f2863645302c5e6a99277f8c38cab/crates/edit_prediction_button/src/edit_prediction_button.rs#L382-L389

https://github.com/zed-industries/zed/blob/a9bc890497f1edaf4f177385cf96785de60e910c/crates/ui/src/components/popover_menu.rs#L376-L384


Release Notes:

- N/A
