### PR TITLE
Fix track file renames in git panel

### DIFF
--- a/crates/collab/src/db/queries/projects.rs
+++ b/crates/collab/src/db/queries/projects.rs
@@ -1005,6 +1005,7 @@ impl Database {
                         is_last_update: true,
                         merge_message: db_repository_entry.merge_message,
                         stash_entries: Vec::new(),
+                        renamed_paths: Default::default(),
                     });
                 }
             }

--- a/crates/collab/src/db/queries/rooms.rs
+++ b/crates/collab/src/db/queries/rooms.rs
@@ -796,6 +796,7 @@ impl Database {
                             is_last_update: true,
                             merge_message: db_repository.merge_message,
                             stash_entries: Vec::new(),
+                            renamed_paths: Default::default(),
                         });
                     }
                 }

--- a/crates/fs/src/fake_git_repo.rs
+++ b/crates/fs/src/fake_git_repo.rs
@@ -359,6 +359,7 @@ impl GitRepository for FakeGitRepository {
             entries.sort_by(|a, b| a.0.cmp(&b.0));
             anyhow::Ok(GitStatus {
                 entries: entries.into(),
+                renamed_paths: HashMap::default(),
             })
         });
         Task::ready(match result {

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -2045,7 +2045,7 @@ fn git_status_args(path_prefixes: &[RepoPath]) -> Vec<OsString> {
         OsString::from("status"),
         OsString::from("--porcelain=v1"),
         OsString::from("--untracked-files=all"),
-        OsString::from("--no-renames"),
+        OsString::from("--find-renames"),
         OsString::from("-z"),
     ];
     args.extend(

--- a/crates/git/src/status.rs
+++ b/crates/git/src/status.rs
@@ -451,11 +451,11 @@ impl FromStr for GitStatus {
             if entry.is_empty() {
                 continue;
             }
-            
+
             if !matches!(entry.get(2..3), Some(" ")) {
                 continue;
             }
-            
+
             let path_or_old_path = &entry[3..];
 
             if path_or_old_path.ends_with('/') {

--- a/crates/git/src/status.rs
+++ b/crates/git/src/status.rs
@@ -207,7 +207,8 @@ impl FileStatus {
         let FileStatus::Tracked(tracked) = self else {
             return false;
         };
-        tracked.index_status == StatusCode::Renamed || tracked.worktree_status == StatusCode::Renamed
+        tracked.index_status == StatusCode::Renamed
+            || tracked.worktree_status == StatusCode::Renamed
     }
 
     pub fn summary(self) -> GitSummary {
@@ -445,23 +446,23 @@ impl FromStr for GitStatus {
     fn from_str(s: &str) -> Result<Self> {
         let mut parts = s.split('\0').peekable();
         let mut entries = Vec::new();
-        
+
         while let Some(entry) = parts.next() {
             if entry.is_empty() {
                 continue;
             }
-            
+
             let sep = match entry.get(2..3) {
                 Some(s) if s == " " => s,
                 _ => continue,
             };
-            
+
             let path_or_old_path = &entry[3..];
-            
+
             if path_or_old_path.ends_with('/') {
                 continue;
             }
-            
+
             let status = match entry.as_bytes()[0..2].try_into() {
                 Ok(bytes) => match FileStatus::from_bytes(bytes).log_err() {
                     Some(s) => s,
@@ -469,7 +470,7 @@ impl FromStr for GitStatus {
                 },
                 Err(_) => continue,
             };
-            
+
             let path = if matches!(
                 status,
                 FileStatus::Tracked(TrackedStatus {
@@ -487,16 +488,16 @@ impl FromStr for GitStatus {
             } else {
                 path_or_old_path
             };
-            
+
             if path.ends_with('/') {
                 continue;
             }
-            
+
             let path = match RelPath::unix(path).log_err() {
                 Some(p) => RepoPath::from_rel_path(p),
                 None => continue,
             };
-            
+
             entries.push((path, status));
         }
         entries.sort_unstable_by(|(a, _), (b, _)| a.cmp(b));

--- a/crates/git/src/status.rs
+++ b/crates/git/src/status.rs
@@ -451,12 +451,11 @@ impl FromStr for GitStatus {
             if entry.is_empty() {
                 continue;
             }
-
-            let sep = match entry.get(2..3) {
-                Some(s) if s == " " => s,
-                _ => continue,
-            };
-
+            
+            if !matches!(entry.get(2..3), Some(" ")) {
+                continue;
+            }
+            
             let path_or_old_path = &entry[3..];
 
             if path_or_old_path.ends_with('/') {

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -3933,15 +3933,16 @@ impl GitPanel {
         let has_conflict = status.is_conflicted();
         let is_modified = status.is_modified();
         let is_deleted = status.is_deleted();
+        let is_renamed = status.is_renamed();
 
         let label_color = if status_style == StatusStyle::LabelColor {
             if has_conflict {
                 Color::VersionControlConflict
-            } else if is_modified {
-                Color::VersionControlModified
             } else if is_deleted {
                 // We don't want a bunch of red labels in the list
                 Color::Disabled
+            } else if is_renamed || is_modified {
+                Color::VersionControlModified
             } else {
                 Color::VersionControlAdded
             }

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -3925,6 +3925,20 @@ impl GitPanel {
         let path_style = self.project.read(cx).path_style(cx);
         let display_name = entry.display_name(path_style);
 
+        let active_repo = self
+            .project
+            .read(cx)
+            .active_repository(cx)
+            .expect("active repository must be set");
+        let repo = active_repo.read(cx);
+        let repo_snapshot = repo.snapshot();
+
+        let old_path = if entry.status.is_renamed() {
+            repo_snapshot.renamed_paths.get(&entry.repo_path)
+        } else {
+            None
+        };
+
         let selected = self.selected_entry == Some(ix);
         let marked = self.marked_entries.contains(&ix);
         let status_style = GitPanelSettings::get_global(cx).status_style;
@@ -3962,12 +3976,6 @@ impl GitPanel {
         let checkbox_id: ElementId =
             ElementId::Name(format!("entry_{}_{}_checkbox", display_name, ix).into());
 
-        let active_repo = self
-            .project
-            .read(cx)
-            .active_repository(cx)
-            .expect("active repository must be set");
-        let repo = active_repo.read(cx);
         // Checking for current staged/unstaged file status is a chained operation:
         // 1. first, we check for any pending operation recorded in repository
         // 2. if there are no pending ops either running or finished, we then ask the repository
@@ -4120,23 +4128,32 @@ impl GitPanel {
                     .items_center()
                     .flex_1()
                     // .overflow_hidden()
-                    .when_some(entry.parent_dir(path_style), |this, parent| {
-                        if !parent.is_empty() {
-                            this.child(
-                                self.entry_label(
-                                    format!("{parent}{}", path_style.separator()),
-                                    path_color,
-                                )
-                                .when(status.is_deleted(), |this| this.strikethrough()),
-                            )
-                        } else {
-                            this
-                        }
+                    .when_some(old_path.as_ref(), |this, old_path| {
+                        let new_display = old_path.display(path_style).to_string();
+                        let old_display = entry.repo_path.display(path_style).to_string();
+                        this.child(self.entry_label(old_display, Color::Muted).strikethrough())
+                            .child(self.entry_label(" → ", Color::Muted))
+                            .child(self.entry_label(new_display, label_color))
                     })
-                    .child(
-                        self.entry_label(display_name, label_color)
-                            .when(status.is_deleted(), |this| this.strikethrough()),
-                    ),
+                    .when(old_path.is_none(), |this| {
+                        this.when_some(entry.parent_dir(path_style), |this, parent| {
+                            if !parent.is_empty() {
+                                this.child(
+                                    self.entry_label(
+                                        format!("{parent}{}", path_style.separator()),
+                                        path_color,
+                                    )
+                                    .when(status.is_deleted(), |this| this.strikethrough()),
+                                )
+                            } else {
+                                this
+                            }
+                        })
+                        .child(
+                            self.entry_label(display_name, label_color)
+                                .when(status.is_deleted(), |this| this.strikethrough()),
+                        )
+                    }),
             )
             .into_any_element()
     }

--- a/crates/git_ui/src/git_ui.rs
+++ b/crates/git_ui/src/git_ui.rs
@@ -708,6 +708,11 @@ impl RenderOnce for GitStatusIcon {
                 IconName::SquareMinus,
                 cx.theme().colors().version_control_deleted,
             )
+        } else if status.is_renamed() {
+            (
+                IconName::ArrowRight,
+                cx.theme().colors().version_control_modified,
+            )
         } else if status.is_modified() {
             (
                 IconName::SquareDot,

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -256,6 +256,7 @@ pub struct RepositorySnapshot {
     pub id: RepositoryId,
     pub statuses_by_path: SumTree<StatusEntry>,
     pub pending_ops_by_path: SumTree<PendingOps>,
+    pub renamed_paths: HashMap<RepoPath, RepoPath>,
     pub work_directory_abs_path: Arc<Path>,
     pub path_style: PathStyle,
     pub branch: Option<Branch>,
@@ -3029,6 +3030,7 @@ impl RepositorySnapshot {
             id,
             statuses_by_path: Default::default(),
             pending_ops_by_path: Default::default(),
+            renamed_paths: HashMap::default(),
             work_directory_abs_path,
             branch: None,
             head_commit: None,
@@ -3069,6 +3071,11 @@ impl RepositorySnapshot {
                 .entries
                 .iter()
                 .map(stash_to_proto)
+                .collect(),
+            renamed_paths: self
+                .renamed_paths
+                .iter()
+                .map(|(new_path, old_path)| (new_path.to_proto(), old_path.to_proto()))
                 .collect(),
         }
     }
@@ -3138,6 +3145,11 @@ impl RepositorySnapshot {
                 .entries
                 .iter()
                 .map(stash_to_proto)
+                .collect(),
+            renamed_paths: self
+                .renamed_paths
+                .iter()
+                .map(|(new_path, old_path)| (new_path.to_proto(), old_path.to_proto()))
                 .collect(),
         }
     }
@@ -4934,6 +4946,17 @@ impl Repository {
         }
         self.snapshot.stash_entries = new_stash_entries;
 
+        self.snapshot.renamed_paths = update
+            .renamed_paths
+            .into_iter()
+            .filter_map(|(new_path_str, old_path_str)| {
+                Some((
+                    RepoPath::from_proto(&new_path_str).log_err()?,
+                    RepoPath::from_proto(&old_path_str).log_err()?,
+                ))
+            })
+            .collect();
+
         let edits = update
             .removed_statuses
             .into_iter()
@@ -5709,6 +5732,7 @@ async fn compute_snapshot(
         id,
         statuses_by_path,
         pending_ops_by_path,
+        renamed_paths: statuses.renamed_paths,
         work_directory_abs_path,
         path_style: prev_snapshot.path_style,
         scan_id: prev_snapshot.scan_id + 1,

--- a/crates/proto/proto/git.proto
+++ b/crates/proto/proto/git.proto
@@ -124,6 +124,7 @@ message UpdateRepository {
     optional GitCommitDetails head_commit_details = 11;
     optional string merge_message = 12;
     repeated StashEntry stash_entries = 13;
+    map<string, string> renamed_paths = 14;
 }
 
 message RemoveRepository {


### PR DESCRIPTION
Closes #30549

Release Notes:

- Fixed: Git renames now properly show as renamed files in the git panel instead of appearing as deleted + untracked files
<img width="351" height="132" alt="Screenshot 2025-11-10 at 17 39 44" src="https://github.com/user-attachments/assets/80e9c286-1abd-4498-a7d5-bd21633e6597" />
<img width="500" height="95" alt="Screenshot 2025-11-10 at 17 39 55" src="https://github.com/user-attachments/assets/e4c59796-df3a-4d12-96f4-e6706b13a32f" />

