### PR TITLE
agent_ui: Allow to configure a default model for profiles through modal

### DIFF
--- a/crates/agent_ui/src/agent_model_selector.rs
+++ b/crates/agent_ui/src/agent_model_selector.rs
@@ -47,6 +47,7 @@ impl AgentModelSelector {
                             }
                         }
                     },
+                    true, // Use popover styles for picker
                     window,
                     cx,
                 )

--- a/crates/agent_ui/src/language_model_selector.rs
+++ b/crates/agent_ui/src/language_model_selector.rs
@@ -19,14 +19,26 @@ pub type LanguageModelSelector = Picker<LanguageModelPickerDelegate>;
 pub fn language_model_selector(
     get_active_model: impl Fn(&App) -> Option<ConfiguredModel> + 'static,
     on_model_changed: impl Fn(Arc<dyn LanguageModel>, &mut App) + 'static,
+    popover_styles: bool,
     window: &mut Window,
     cx: &mut Context<LanguageModelSelector>,
 ) -> LanguageModelSelector {
-    let delegate = LanguageModelPickerDelegate::new(get_active_model, on_model_changed, window, cx);
-    Picker::list(delegate, window, cx)
-        .show_scrollbar(true)
-        .width(rems(20.))
-        .max_height(Some(rems(20.).into()))
+    let delegate = LanguageModelPickerDelegate::new(
+        get_active_model,
+        on_model_changed,
+        popover_styles,
+        window,
+        cx,
+    );
+
+    if popover_styles {
+        Picker::list(delegate, window, cx)
+            .show_scrollbar(true)
+            .width(rems(20.))
+            .max_height(Some(rems(20.).into()))
+    } else {
+        Picker::list(delegate, window, cx).show_scrollbar(true)
+    }
 }
 
 fn all_models(cx: &App) -> GroupedModels {
@@ -75,12 +87,14 @@ pub struct LanguageModelPickerDelegate {
     selected_index: usize,
     _authenticate_all_providers_task: Task<()>,
     _subscriptions: Vec<Subscription>,
+    popover_styles: bool,
 }
 
 impl LanguageModelPickerDelegate {
     fn new(
         get_active_model: impl Fn(&App) -> Option<ConfiguredModel> + 'static,
         on_model_changed: impl Fn(Arc<dyn LanguageModel>, &mut App) + 'static,
+        popover_styles: bool,
         window: &mut Window,
         cx: &mut Context<Picker<Self>>,
     ) -> Self {
@@ -113,6 +127,7 @@ impl LanguageModelPickerDelegate {
                     }
                 },
             )],
+            popover_styles,
         }
     }
 
@@ -530,6 +545,10 @@ impl PickerDelegate for LanguageModelPickerDelegate {
         _window: &mut Window,
         cx: &mut Context<Picker<Self>>,
     ) -> Option<gpui::AnyElement> {
+        if !self.popover_styles {
+            return None;
+        }
+
         Some(
             h_flex()
                 .w_full()

--- a/crates/agent_ui/src/text_thread_editor.rs
+++ b/crates/agent_ui/src/text_thread_editor.rs
@@ -314,6 +314,7 @@ impl TextThreadEditor {
                             )
                         });
                     },
+                    true, // Use popover styles for picker
                     window,
                     cx,
                 )


### PR DESCRIPTION
Follow-up to https://github.com/zed-industries/zed/pull/39220

This PR allows to configure a default model for a given profile through the profile management modal.

| Option In Picker | Model Selector |
|--------|--------|
| <img width="1172" height="538" alt="Screenshot 2025-11-10 at 12  24 2@2x" src="https://github.com/user-attachments/assets/33dfb6f1-f8fd-42f9-b824-3dab807094da" /> | <img width="1172" height="1120" alt="Screenshot 2025-11-10 at 12  24@2x" src="https://github.com/user-attachments/assets/50360b0a-fbb1-455e-9cf7-9fa987345038" /> | 

Release Notes:

- N/A
