### PR TITLE
typo: Use tips from proselint

### DIFF
--- a/docs/src/globs.md
+++ b/docs/src/globs.md
@@ -53,7 +53,7 @@ If instead you wanted to restrict yourself only to [Zed Language-Specific Docume
 
 ### Implicit Wildcards
 
-When using the "Include" / "Exclude" filters on a Project Search each glob is wrapped in implicit wildcards. For example to exclude any files with license in the path or filename from your search just type type `license` in the exclude box. Behind the scenes Zed transforms `license` to `**license**`. This means that files named `license.*`, `*.license` or inside a `license` subdirectory will all be filtered out. This enables users to easily filter for `*.ts` without having to remember to type `**/*.ts` every time.
+When using the "Include" / "Exclude" filters on a Project Search each glob is wrapped in implicit wildcards. For example to exclude any files with license in the path or filename from your search just type `license` in the exclude box. Behind the scenes Zed transforms `license` to `**license**`. This means that files named `license.*`, `*.license` or inside a `license` subdirectory will all be filtered out. This enables users to easily filter for `*.ts` without having to remember to type `**/*.ts` every time.
 
 Alternatively, if in your Zed settings you wanted a [`file_types`](./configuring-zed.md#file-types) override which only applied to a certain directory you must explicitly include the wildcard globs. For example, if you had a directory of template files with the `html` extension that you wanted to recognize as Jinja2 template you could use the following:
 

--- a/docs/src/languages/ocaml.md
+++ b/docs/src/languages/ocaml.md
@@ -33,4 +33,4 @@ Once you have the cli, simply from a terminal, navigate to your project and run
 zed .
 ```
 
-Voila! You should have Zed running with OCaml support, no additional setup required.
+Voilà! You should have Zed running with OCaml support, no additional setup required.


### PR DESCRIPTION
I ran [proselint](https://github.com/amperser/proselint) (recommended by cURL author [Daniel Stenberg](https://daniel.haxx.se/blog/2022/09/22/taking-curl-documentation-quality-up-one-more-notch/)) against all the `.md` files in the codebase to see if I could fix some easy typos.

The tool is noisier than I would like and picking up the overrides to the default config in a `.proselintrc.json` was much harder than I expected.

There's many other small nits [1] that I believe are best left to your docs czar whenever they want to consider incorporating a tool like this into big releases or CI, but these seemed like small wins for now to open a conversation about a tool like proselint. 

---

[1]: Such nits include
- incosistent 1 or 2 spaces
- "color" vs "colour"
- ab/use of `very` 
- awkward or superfluous phrasing.

Release Notes:

- N/A
