### PR TITLE
Ignore "Option as Meta" setting outside of macOS

### DIFF
--- a/crates/terminal/src/mappings/keys.rs
+++ b/crates/terminal/src/mappings/keys.rs
@@ -46,7 +46,7 @@ impl AlacModifiers {
 pub fn to_esc_str(
     keystroke: &Keystroke,
     mode: &TermMode,
-    alt_is_meta: bool,
+    option_as_meta: bool,
 ) -> Option<Cow<'static, str>> {
     let modifiers = AlacModifiers::new(keystroke);
 
@@ -218,7 +218,7 @@ pub fn to_esc_str(
         }
     }
 
-    if alt_is_meta {
+    if !cfg!(target_os = "macos") || option_as_meta {
         let is_alt_lowercase_ascii = modifiers == AlacModifiers::Alt && keystroke.key.is_ascii();
         let is_alt_uppercase_ascii =
             keystroke.modifiers.alt && keystroke.modifiers.shift && keystroke.key.is_ascii();

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -1490,14 +1490,14 @@ impl Terminal {
         }
     }
 
-    pub fn try_keystroke(&mut self, keystroke: &Keystroke, alt_is_meta: bool) -> bool {
+    pub fn try_keystroke(&mut self, keystroke: &Keystroke, option_as_meta: bool) -> bool {
         if self.vi_mode_enabled {
             self.vi_motion(keystroke);
             return true;
         }
 
         // Keep default terminal behavior
-        let esc = to_esc_str(keystroke, &self.last_content.mode, alt_is_meta);
+        let esc = to_esc_str(keystroke, &self.last_content.mode, option_as_meta);
         if let Some(esc) = esc {
             match esc {
                 Cow::Borrowed(string) => self.input(string.as_bytes()),


### PR DESCRIPTION
The "Option" key only exists on a Mac. On other operating systems, it is always expected that the Alt key generates escaped characters.

Fixes https://github.com/zed-industries/zed/issues/40583

Release Notes:

- N/A