### PR TITLE
fs: Handle io::ErrorKind::NotADirectory in fs::metadata

### DIFF
--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -719,9 +719,8 @@ impl Fs for RealFs {
         {
             Ok(metadata) => metadata,
             Err(err) => {
-                return match (err.kind(), err.raw_os_error()) {
-                    (io::ErrorKind::NotFound, _) => Ok(None),
-                    (io::ErrorKind::Other, Some(libc::ENOTDIR)) => Ok(None),
+                return match err.kind() {
+                    io::ErrorKind::NotFound | io::ErrorKind::NotADirectory => Ok(None),
                     _ => Err(anyhow::Error::new(err)),
                 };
             }


### PR DESCRIPTION
New error variants were stabilized in 1.83, and this might've led to us
mis-handling not-a-directory errors.

Co-authored-by: Dino <dino@zed.dev>

Release Notes:

- N/A
