### PR TITLE
zeta2 cli: Cache at LLM request level

### DIFF
--- a/crates/zeta2/Cargo.toml
+++ b/crates/zeta2/Cargo.toml
@@ -11,6 +11,9 @@ workspace = true
 [lib]
 path = "src/zeta2.rs"
 
+[features]
+llm-response-cache = []
+
 [dependencies]
 anyhow.workspace = true
 arrayvec.workspace = true

--- a/crates/zeta_cli/Cargo.toml
+++ b/crates/zeta_cli/Cargo.toml
@@ -54,7 +54,7 @@ toml.workspace = true
 util.workspace = true
 watch.workspace = true
 zeta.workspace = true
-zeta2.workspace = true
+zeta2 = { workspace = true, features = ["llm-response-cache"] }
 zlog.workspace = true
 
 [dev-dependencies]

--- a/crates/zeta_cli/src/evaluate.rs
+++ b/crates/zeta_cli/src/evaluate.rs
@@ -21,7 +21,7 @@ use crate::{
 pub struct EvaluateArguments {
     example_paths: Vec<PathBuf>,
     #[clap(long)]
-    re_run: bool,
+    skip_cache: bool,
     #[arg(long, value_enum, default_value_t = PromptFormat::default())]
     prompt_format: PromptFormat,
 }
@@ -37,7 +37,7 @@ pub async fn run_evaluate(
         cx.spawn(async move |cx| {
             run_evaluate_one(
                 &path,
-                args.re_run,
+                args.skip_cache,
                 args.prompt_format,
                 app_state.clone(),
                 cx,
@@ -61,13 +61,13 @@ pub async fn run_evaluate(
 
 pub async fn run_evaluate_one(
     example_path: &Path,
-    re_run: bool,
+    skip_cache: bool,
     prompt_format: PromptFormat,
     app_state: Arc<ZetaCliAppState>,
     cx: &mut AsyncApp,
 ) -> Result<EvaluationResult> {
     let example = NamedExample::load(&example_path).unwrap();
-    let predictions = zeta2_predict(example.clone(), re_run, prompt_format, &app_state, cx)
+    let predictions = zeta2_predict(example.clone(), skip_cache, prompt_format, &app_state, cx)
         .await
         .unwrap();
 

--- a/crates/zeta_cli/src/evaluate.rs
+++ b/crates/zeta_cli/src/evaluate.rs
@@ -1,5 +1,4 @@
 use std::{
-    fs,
     io::IsTerminal,
     path::{Path, PathBuf},
     sync::Arc,
@@ -12,9 +11,9 @@ use gpui::AsyncApp;
 use zeta2::udiff::DiffLine;
 
 use crate::{
+    PromptFormat,
     example::{Example, NamedExample},
     headless::ZetaCliAppState,
-    paths::CACHE_DIR,
     predict::{PredictionDetails, zeta2_predict},
 };
 
@@ -23,6 +22,8 @@ pub struct EvaluateArguments {
     example_paths: Vec<PathBuf>,
     #[clap(long)]
     re_run: bool,
+    #[arg(long, value_enum, default_value_t = PromptFormat::default())]
+    prompt_format: PromptFormat,
 }
 
 pub async fn run_evaluate(
@@ -33,7 +34,16 @@ pub async fn run_evaluate(
     let example_len = args.example_paths.len();
     let all_tasks = args.example_paths.into_iter().map(|path| {
         let app_state = app_state.clone();
-        cx.spawn(async move |cx| run_evaluate_one(&path, args.re_run, app_state.clone(), cx).await)
+        cx.spawn(async move |cx| {
+            run_evaluate_one(
+                &path,
+                args.re_run,
+                args.prompt_format,
+                app_state.clone(),
+                cx,
+            )
+            .await
+        })
     });
     let all_results = futures::future::try_join_all(all_tasks).await.unwrap();
 
@@ -52,34 +62,14 @@ pub async fn run_evaluate(
 pub async fn run_evaluate_one(
     example_path: &Path,
     re_run: bool,
+    prompt_format: PromptFormat,
     app_state: Arc<ZetaCliAppState>,
     cx: &mut AsyncApp,
 ) -> Result<EvaluationResult> {
     let example = NamedExample::load(&example_path).unwrap();
-    let example_cache_path = CACHE_DIR.join(&example_path.file_name().unwrap());
-
-    let predictions = if !re_run && example_cache_path.exists() {
-        let file_contents = fs::read_to_string(&example_cache_path)?;
-        let as_json = serde_json::from_str::<PredictionDetails>(&file_contents)?;
-        log::debug!(
-            "Loaded predictions from cache: {}",
-            example_cache_path.display()
-        );
-        as_json
-    } else {
-        zeta2_predict(example.clone(), Default::default(), &app_state, cx)
-            .await
-            .unwrap()
-    };
-
-    if !example_cache_path.exists() {
-        fs::create_dir_all(&*CACHE_DIR).unwrap();
-        fs::write(
-            example_cache_path,
-            serde_json::to_string(&predictions).unwrap(),
-        )
+    let predictions = zeta2_predict(example.clone(), re_run, prompt_format, &app_state, cx)
+        .await
         .unwrap();
-    }
 
     let evaluation_result = evaluate(&example.example, &predictions);
 

--- a/crates/zeta_cli/src/main.rs
+++ b/crates/zeta_cli/src/main.rs
@@ -158,7 +158,7 @@ fn syntax_args_to_options(
         }),
         max_diagnostic_bytes: zeta2_args.max_diagnostic_bytes,
         max_prompt_bytes: zeta2_args.max_prompt_bytes,
-        prompt_format: zeta2_args.prompt_format.clone().into(),
+        prompt_format: zeta2_args.prompt_format.into(),
         file_indexing_parallelism: zeta2_args.file_indexing_parallelism,
         buffer_change_grouping_interval: Duration::ZERO,
     }

--- a/crates/zeta_cli/src/main.rs
+++ b/crates/zeta_cli/src/main.rs
@@ -164,7 +164,7 @@ fn syntax_args_to_options(
     }
 }
 
-#[derive(clap::ValueEnum, Default, Debug, Clone)]
+#[derive(clap::ValueEnum, Default, Debug, Clone, Copy)]
 enum PromptFormat {
     MarkedExcerpt,
     LabeledSections,

--- a/crates/zeta_cli/src/paths.rs
+++ b/crates/zeta_cli/src/paths.rs
@@ -2,7 +2,7 @@ use std::{env, path::PathBuf, sync::LazyLock};
 
 static TARGET_DIR: LazyLock<PathBuf> = LazyLock::new(|| env::current_dir().unwrap().join("target"));
 pub static CACHE_DIR: LazyLock<PathBuf> =
-    LazyLock::new(|| TARGET_DIR.join("zeta-prediction-cache"));
+    LazyLock::new(|| TARGET_DIR.join("zeta-llm-response-cache"));
 pub static REPOS_DIR: LazyLock<PathBuf> = LazyLock::new(|| TARGET_DIR.join("zeta-repos"));
 pub static WORKTREES_DIR: LazyLock<PathBuf> = LazyLock::new(|| TARGET_DIR.join("zeta-worktrees"));
 pub static LOGS_DIR: LazyLock<PathBuf> = LazyLock::new(|| TARGET_DIR.join("zeta-logs"));

--- a/crates/zeta_cli/src/predict.rs
+++ b/crates/zeta_cli/src/predict.rs
@@ -5,6 +5,7 @@ use crate::paths::{CACHE_DIR, LOGS_DIR};
 use ::serde::Serialize;
 use anyhow::{Result, anyhow};
 use clap::Args;
+use gpui::http_client::Url;
 // use cloud_llm_client::predict_edits_v3::PromptFormat;
 use cloud_zeta2_prompt::{CURSOR_MARKER, write_codeblock};
 use futures::StreamExt as _;
@@ -18,6 +19,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
+use zeta2::LlmResponseCache;
 
 #[derive(Debug, Args)]
 pub struct PredictArguments {
@@ -27,7 +29,7 @@ pub struct PredictArguments {
     format: PredictionsOutputFormat,
     example_path: PathBuf,
     #[clap(long)]
-    re_run: bool,
+    skip_cache: bool,
 }
 
 #[derive(clap::ValueEnum, Debug, Clone)]
@@ -42,7 +44,7 @@ pub async fn run_zeta2_predict(
     cx: &mut AsyncApp,
 ) {
     let example = NamedExample::load(args.example_path).unwrap();
-    let result = zeta2_predict(example, args.re_run, args.prompt_format, &app_state, cx)
+    let result = zeta2_predict(example, args.skip_cache, args.prompt_format, &app_state, cx)
         .await
         .unwrap();
     result.write(args.format, std::io::stdout()).unwrap();
@@ -54,23 +56,11 @@ thread_local! {
 
 pub async fn zeta2_predict(
     example: NamedExample,
-    re_run: bool,
+    skip_cache: bool,
     prompt_format: PromptFormat,
     app_state: &Arc<ZetaCliAppState>,
     cx: &mut AsyncApp,
 ) -> Result<PredictionDetails> {
-    let example_cache_path = CACHE_DIR.join(&example.name);
-
-    if !re_run && example_cache_path.exists() {
-        let file_contents = fs::read_to_string(&example_cache_path)?;
-        log::debug!(
-            "Loaded predictions from cache: {}",
-            example_cache_path.display()
-        );
-        let result = serde_json::from_str::<PredictionDetails>(&file_contents)?;
-        return Ok(result);
-    }
-
     fs::create_dir_all(&*LOGS_DIR)?;
     let worktree_path = example.setup_worktree().await?;
 
@@ -109,6 +99,10 @@ pub async fn zeta2_predict(
         .await;
 
     let zeta = cx.update(|cx| zeta2::Zeta::global(&app_state.client, &app_state.user_store, cx))?;
+
+    zeta.update(cx, |zeta, _cx| {
+        zeta.with_llm_response_cache(Arc::new(Cache { skip_cache }));
+    })?;
 
     cx.subscribe(&buffer_store, {
         let project = project.clone();
@@ -245,10 +239,52 @@ pub async fn zeta2_predict(
         })
         .unwrap_or_default();
 
-    fs::create_dir_all(&*CACHE_DIR).unwrap();
-    fs::write(example_cache_path, serde_json::to_string(&result).unwrap()).unwrap();
-
     anyhow::Ok(result)
+}
+
+struct Cache {
+    skip_cache: bool,
+}
+
+impl Cache {
+    fn path(key: u64) -> PathBuf {
+        CACHE_DIR.join(format!("{key:x}.json"))
+    }
+}
+
+impl LlmResponseCache for Cache {
+    fn get_key(&self, url: &Url, body: &str) -> u64 {
+        use collections::FxHasher;
+        use std::hash::{Hash, Hasher};
+
+        let mut hasher = FxHasher::default();
+        url.hash(&mut hasher);
+        body.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    fn read_response(&self, key: u64) -> Option<String> {
+        let path = Cache::path(key);
+        if path.exists() {
+            if self.skip_cache {
+                log::info!("Skipping existing cached LLM response: {}", path.display());
+                None
+            } else {
+                log::info!("Using LLM response from cache: {}", path.display());
+                Some(fs::read_to_string(path).unwrap())
+            }
+        } else {
+            None
+        }
+    }
+
+    fn write_response(&self, key: u64, value: &str) {
+        fs::create_dir_all(&*CACHE_DIR).unwrap();
+
+        let path = Cache::path(key);
+        log::info!("Writing LLM response to cache: {}", path.display());
+        fs::write(path, value).unwrap();
+    }
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]


### PR DESCRIPTION
We'll now cache LLM responses at the request level (by hash of URL+contents) for both context and prediction. This way we don't need to worry about mistakenly using the cache when we change the prompt or its components.

Release Notes:

- N/A
