### PR TITLE
rust: Explicitly capture lifetime identifier

### DIFF
--- a/crates/languages/src/rust/highlights.scm
+++ b/crates/languages/src/rust/highlights.scm
@@ -195,7 +195,9 @@
 (unary_expression "!" @operator)
 operator: "/" @operator
 
-(lifetime) @lifetime
+(lifetime
+  "'" @lifetime
+  (identifier) @lifetime)
 
 (parameter (identifier) @variable.parameter)
 


### PR DESCRIPTION
Closes #42030

This matches what VSCode and basically also this capture does. However, the identifier capture was overridden by other captures, hence the need to be explicit here.

| Before | After | 
| - | - |
| <img width="930" height="346" alt="Bildschirmfoto 2025-11-10 um 17 56 28" src="https://github.com/user-attachments/assets/e938c863-0981-4368-ab0a-a01dd04cfb24" /> | <img width="930" height="346" alt="Bildschirmfoto 2025-11-10 um 17 54 35" src="https://github.com/user-attachments/assets/f3b74011-c75c-448a-819e-80e7e8684e92" /> | 


Release Notes:

- Improved lifetime highlighting in Rust using the `lifetime` capture.
