### PR TITLE
vim: Sort whole buffer when no range is specified

### DIFF
--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -2898,4 +2898,112 @@ mod test {
             );
         });
     }
+
+    #[gpui::test]
+    async fn test_sort_commands(cx: &mut TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+
+        cx.set_state(
+            indoc! {"
+                «hornet
+                quirrel
+                elderbug
+                cornifer
+                idaˇ»
+            "},
+            Mode::Visual,
+        );
+
+        cx.simulate_keystrokes(": sort");
+        cx.simulate_keystrokes("enter");
+
+        cx.assert_state(
+            indoc! {"
+                ˇcornifer
+                elderbug
+                hornet
+                ida
+                quirrel
+            "},
+            Mode::Normal,
+        );
+
+        // Assert that, by default, `:sort` takes case into consideration.
+        cx.set_state(
+            indoc! {"
+                «hornet
+                quirrel
+                Elderbug
+                cornifer
+                idaˇ»
+            "},
+            Mode::Visual,
+        );
+
+        cx.simulate_keystrokes(": sort");
+        cx.simulate_keystrokes("enter");
+
+        cx.assert_state(
+            indoc! {"
+                ˇElderbug
+                cornifer
+                hornet
+                ida
+                quirrel
+            "},
+            Mode::Normal,
+        );
+
+        // Assert that, if the `i` option is passed, `:sort` ignores case.
+        cx.set_state(
+            indoc! {"
+                «hornet
+                quirrel
+                Elderbug
+                cornifer
+                idaˇ»
+            "},
+            Mode::Visual,
+        );
+
+        cx.simulate_keystrokes(": sort space i");
+        cx.simulate_keystrokes("enter");
+
+        cx.assert_state(
+            indoc! {"
+                ˇcornifer
+                Elderbug
+                hornet
+                ida
+                quirrel
+            "},
+            Mode::Normal,
+        );
+
+        // When no range is provided, sorts the whole buffer.
+        cx.set_state(
+            indoc! {"
+                ˇhornet
+                quirrel
+                elderbug
+                cornifer
+                ida
+            "},
+            Mode::Normal,
+        );
+
+        cx.simulate_keystrokes(": sort");
+        cx.simulate_keystrokes("enter");
+
+        cx.assert_state(
+            indoc! {"
+                ˇcornifer
+                elderbug
+                hornet
+                ida
+                quirrel
+            "},
+            Mode::Normal,
+        );
+    }
 }

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -930,29 +930,6 @@ impl Vim {
                 },
             );
 
-            Vim::action(
-                editor,
-                cx,
-                |vim, action: &editor::actions::SortLinesCaseSensitive, window, cx| {
-                    vim.update_editor(cx, |_, editor, cx| {
-                        // If there's no selection in the editor, select the
-                        // whole buffer's content so as to sort the entire
-                        // buffer.
-                        let snapshot = editor.display_snapshot(cx);
-                        if !editor.has_non_empty_selection(&snapshot) {
-                            editor.select_all(&Default::default(), window, cx);
-                        }
-
-                        editor.sort_lines_case_sensitive(action, window, cx);
-
-                        // Reset selections after lines are sorted.
-                        editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
-                            s.select_ranges([Point::new(0, 0)..Point::new(0, 0)]);
-                        })
-                    });
-                },
-            );
-
             normal::register(editor, cx);
             insert::register(editor, cx);
             helix::register(editor, cx);

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -930,6 +930,29 @@ impl Vim {
                 },
             );
 
+            Vim::action(
+                editor,
+                cx,
+                |vim, action: &editor::actions::SortLinesCaseSensitive, window, cx| {
+                    vim.update_editor(cx, |_, editor, cx| {
+                        // If there's no selection in the editor, select the
+                        // whole buffer's content so as to sort the entire
+                        // buffer.
+                        let snapshot = editor.display_snapshot(cx);
+                        if !editor.has_non_empty_selection(&snapshot) {
+                            editor.select_all(&Default::default(), window, cx);
+                        }
+
+                        editor.sort_lines_case_sensitive(action, window, cx);
+
+                        // Reset selections after lines are sorted.
+                        editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
+                            s.select_ranges([Point::new(0, 0)..Point::new(0, 0)]);
+                        })
+                    });
+                },
+            );
+
             normal::register(editor, cx);
             insert::register(editor, cx);
             helix::register(editor, cx);


### PR DESCRIPTION
- Introduce a `default_range` field to `VimCommand`, to be optionally
  used when no range is specified for the command
- Update `VimCommand.parse` to take into consideration the
  `default_range`
- Introduce `CommandRange::buffer` to obtain the `CommandRange` which
  corresponds to the whole buffer
- Update the `VimCommand` definitions for both `sort` and `sort i` to
  default to the whole buffer when no range is specified

Closes #41750 

Release Notes:

- Improved vim's `:sort` command to sort the buffer's content when no selection is used
