### PR TITLE
editor: Fix action closing its own preview tab on subsequent runs (instead of reactivating it)

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -17234,7 +17234,9 @@ impl Editor {
 
             workspace.add_item_to_active_pane(item, preview_item_idx, true, window, cx);
 
-            if let Some(preview_item_id) = preview_item_id {
+            if let Some(preview_item_id) = preview_item_id
+                && preview_item_id != item_id
+            {
                 workspace.active_pane().update(cx, |pane, cx| {
                     pane.remove_item(preview_item_id, false, false, window, cx);
                 });


### PR DESCRIPTION
To reproduce:

1. Enable `enable_preview_from_code_navigation`
2. Select something in tab A
3. Run `editor: open selections in multibuffer`
4. Switch back to tab A
5. Repeat step 3

Instead of opening the previewed "Selections for tab A" tab it is closed silently.

I think this is a regression after cb439e672da47dcebfd3df2fac15da846152ac47

(I can write a release note, but perhaps too minor to be worth mentioning)

BTW: Is it preferred that I open an issue in addition to the PR?

---

Release Notes:

- N/A
