### PR TITLE
Avoid some models printing filenames in tool output

### DIFF
--- a/crates/agent/src/templates/create_file_prompt.hbs
+++ b/crates/agent/src/templates/create_file_prompt.hbs
@@ -6,6 +6,33 @@ The text you output will be saved verbatim as the content of the file.
 Tool calls have been disabled.
 Start your response with ```.
 
+IMPORTANT: Output ONLY the file content between the backticks. Do NOT include:
+- The file path or name (like "path/to/file.txt")
+- Any markdown formatting within the content
+- Any explanatory text before or after the backticks
+- Any nested code fences within your output
+
+<example>
+If asked to create a file with "hello" inside:
+
+CORRECT output:
+```
+hello
+```
+
+INCORRECT output (includes file path):
+```path/to/file.txt
+hello
+```
+
+INCORRECT output (nested code fences):
+```
+```
+hello
+```
+```
+</example>
+
 <file_path>
 {{path}}
 </file_path>

--- a/crates/agent/src/tools/edit_file_tool.rs
+++ b/crates/agent/src/tools/edit_file_tool.rs
@@ -44,8 +44,16 @@ pub struct EditFileToolInput {
     ///
     /// NEVER mention the file path in this description.
     ///
+    /// IMPORTANT: Do NOT include markdown code fences (```) or other markdown formatting in this description.
+    /// Just describe what should be done - another model will generate the actual content.
+    ///
     /// <example>Fix API endpoint URLs</example>
     /// <example>Update copyright year in `page_footer`</example>
+    /// <example>Create a Python script that prints hello world</example>
+    ///
+    /// INCORRECT examples (do not do this):
+    /// <example>Create a file with:\n```python\nprint('hello')\n```</example>
+    /// <example>Add this code:\n```\nif err:\n  return\n```</example>
     ///
     /// Make sure to include this field before all the others in the input object so that we can display it immediately.
     pub display_description: String,


### PR DESCRIPTION
Closes #34466
Closes #40386

Need to verify that this doesn't regress evals before merging!

Release Notes:

- Changed tool call descriptions to avoid some models printing filenames in tool output
