### PR TITLE
Concurrent Agent Chat with tabbed threads

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -244,6 +244,7 @@
       "ctrl-shift-j": "agent::ToggleNavigationMenu",
       "ctrl-alt-i": "agent::ToggleOptionsMenu",
       "ctrl-alt-shift-n": "agent::ToggleNewThreadMenu",
+      "ctrl-alt-e": "agent::EditTitle",
       "shift-alt-escape": "agent::ExpandMessageEditor",
       "ctrl->": "agent::AddSelectionToThread",
       "ctrl-alt-e": "agent::RemoveAllContext",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -283,6 +283,7 @@
       "cmd-shift-j": "agent::ToggleNavigationMenu",
       "cmd-alt-m": "agent::ToggleOptionsMenu",
       "cmd-alt-shift-n": "agent::ToggleNewThreadMenu",
+      "ctrl-alt-e": "agent::EditTitle",
       "shift-alt-escape": "agent::ExpandMessageEditor",
       "cmd->": "agent::AddSelectionToThread",
       "cmd-alt-e": "agent::RemoveAllContext",

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -245,6 +245,7 @@
       "ctrl-shift-j": "agent::ToggleNavigationMenu",
       "ctrl-alt-i": "agent::ToggleOptionsMenu",
       // "ctrl-shift-alt-n": "agent::ToggleNewThreadMenu",
+      "ctrl-alt-e": "agent::EditTitle",
       "shift-alt-escape": "agent::ExpandMessageEditor",
       "ctrl-shift-.": "agent::AddSelectionToThread",
       "shift-alt-e": "agent::RemoveAllContext",

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -827,6 +827,16 @@ impl AcpThreadView {
         }
     }
 
+    pub fn session_id(&self, cx: &App) -> Option<acp::SessionId> {
+        if let Some(thread) = self.thread() {
+            Some(thread.read(cx).session_id().clone())
+        } else {
+            self.resume_thread_metadata
+                .as_ref()
+                .map(|metadata| metadata.id.clone())
+        }
+    }
+
     pub fn mode_selector(&self) -> Option<&Entity<ModeSelector>> {
         match &self.thread_state {
             ThreadState::Ready { mode_selector, .. } => mode_selector.as_ref(),

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1711,7 +1711,15 @@ impl AgentPanel {
 
         match view {
             ActiveView::ExternalAgentThread { thread_view } => {
-                Label::new(thread_view.read(cx).title(cx))
+                let text = thread_view
+                    .read(cx)
+                    .title_editor()
+                    .as_ref()
+                    .map(|editor| editor.read(cx).text(cx))
+                    .filter(|text| !text.is_empty())
+                    .unwrap_or_else(|| thread_view.read(cx).title(cx).to_string());
+
+                Label::new(text)
                     .color(Color::Muted)
                     .truncate()
                     .into_any_element()

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -74,6 +74,8 @@ actions!(
         ExpandMessageEditor,
         /// Opens the conversation history view.
         OpenHistory,
+        /// Edits the current thread title.
+        EditTitle,
         /// Adds a context server to the configuration.
         AddContextServer,
         /// Removes the currently selected thread.


### PR DESCRIPTION
To improve agent-driven workflows in Zed, this PR introduces a tabbed Agent panel that lets users run multiple agent threads in parallel and switch between them without losing context or scroll position—eliminating blocking when one agent is busy and aligning the Agent panel’s ergonomics with the main editor. See detailed information in the discussion here https://github.com/zed-industries/zed/discussions/42381#discussion-9126763. 
Here is a short demo


https://github.com/user-attachments/assets/e2287e79-f959-4797-93c0-b95d7dcf5265


Release Notes:

- Automatically open a new tab whenever you start a new thread (with Zed native agent, external agents like CC, Codex ..) or load a historical chat from history.
- The tab bar will work as the same way as the normal tab bar in the main editor. It means you are having a cleaner chrome: Tab-bar controls auto-hide unless the Agent panel is focused, reclaiming horizontal space.
- Tabs track threads via session_id, so each tab remains bound to its underlying conversation (including historical resume).
- The tab title will be automatically shorten by maximum 20 characters to save more spaces when you have a long title for the inactive tabs (tool-tip shows full text). For the current active tab, it is still showing the full title.
- The History and Settings view will work exactly as previous.
- You can edit the tab title by clicking the "Edit Title" in the options drop down menu "...", and the agent panel will show the original title editor on the top. Then you can modify the title, confirm, cancel/go back as you want, plus a new keybinding (EditTitle) added to the default keymaps (Linux/Windows/Mac).

