### PR TITLE
collab: Drop `channel_messages` table and its dependents

### DIFF
--- a/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
+++ b/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
@@ -291,29 +291,6 @@ CREATE TABLE IF NOT EXISTS "channel_chat_participants" (
 
 CREATE INDEX "index_channel_chat_participants_on_channel_id" ON "channel_chat_participants" ("channel_id");
 
-CREATE TABLE IF NOT EXISTS "channel_messages" (
-    "id" INTEGER PRIMARY KEY AUTOINCREMENT,
-    "channel_id" INTEGER NOT NULL REFERENCES channels (id) ON DELETE CASCADE,
-    "sender_id" INTEGER NOT NULL REFERENCES users (id),
-    "body" TEXT NOT NULL,
-    "sent_at" TIMESTAMP,
-    "edited_at" TIMESTAMP,
-    "nonce" BLOB NOT NULL,
-    "reply_to_message_id" INTEGER DEFAULT NULL
-);
-
-CREATE INDEX "index_channel_messages_on_channel_id" ON "channel_messages" ("channel_id");
-
-CREATE UNIQUE INDEX "index_channel_messages_on_sender_id_nonce" ON "channel_messages" ("sender_id", "nonce");
-
-CREATE TABLE "channel_message_mentions" (
-    "message_id" INTEGER NOT NULL REFERENCES channel_messages (id) ON DELETE CASCADE,
-    "start_offset" INTEGER NOT NULL,
-    "end_offset" INTEGER NOT NULL,
-    "user_id" INTEGER NOT NULL REFERENCES users (id) ON DELETE CASCADE,
-    PRIMARY KEY (message_id, start_offset)
-);
-
 CREATE TABLE "channel_members" (
     "id" INTEGER PRIMARY KEY AUTOINCREMENT,
     "channel_id" INTEGER NOT NULL REFERENCES channels (id) ON DELETE CASCADE,
@@ -407,15 +384,6 @@ CREATE TABLE "observed_buffer_edits" (
 );
 
 CREATE UNIQUE INDEX "index_observed_buffers_user_and_buffer_id" ON "observed_buffer_edits" ("user_id", "buffer_id");
-
-CREATE TABLE IF NOT EXISTS "observed_channel_messages" (
-    "user_id" INTEGER NOT NULL REFERENCES users (id) ON DELETE CASCADE,
-    "channel_id" INTEGER NOT NULL REFERENCES channels (id) ON DELETE CASCADE,
-    "channel_message_id" INTEGER NOT NULL,
-    PRIMARY KEY (user_id, channel_id)
-);
-
-CREATE UNIQUE INDEX "index_observed_channel_messages_user_and_channel_id" ON "observed_channel_messages" ("user_id", "channel_id");
 
 CREATE TABLE "notification_kinds" (
     "id" INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/crates/collab/migrations/20251110214057_drop_channel_messages.sql
+++ b/crates/collab/migrations/20251110214057_drop_channel_messages.sql
@@ -1,0 +1,3 @@
+drop table observed_channel_messages;
+drop table channel_message_mentions;
+drop table channel_messages;


### PR DESCRIPTION
This PR drops the `channel_messages` table and its dependents—`channel_message_mentions` and `observed_channel_messages`—as they are no longer used.

Release Notes:

- N/A
