### PR TITLE
docs: Fix broken links in docs with lychee

### DIFF
--- a/docs/src/ai/llm-providers.md
+++ b/docs/src/ai/llm-providers.md
@@ -587,7 +587,7 @@ These routing controls let you fine‑tune cost, capability, and reliability tra
 
 ### Vercel v0 {#vercel-v0}
 
-[Vercel v0](https://vercel.com/docs/v0/api) is an expert model for generating full-stack apps, with framework-aware completions optimized for modern stacks like Next.js and Vercel.
+[Vercel v0](https://v0.app/docs/api/model) is an expert model for generating full-stack apps, with framework-aware completions optimized for modern stacks like Next.js and Vercel.
 It supports text and image inputs and provides fast streaming responses.
 
 The v0 models are [OpenAI-compatible models](/#openai-api-compatible), but Vercel is listed as first-class provider in the panel's settings view.

--- a/docs/src/development/release-notes.md
+++ b/docs/src/development/release-notes.md
@@ -10,7 +10,7 @@ Release Notes:
 - N/A _or_ Added/Fixed/Improved ...
 ```
 
-On Wednesdays, we run a [`get-preview-channel-changes`](https://github.com/zed-industries/zed/blob/main/script/get-preview-channel-changes) script that scrapes `Release Notes` lines from pull requests landing in preview, as documented in our [Release](https://zed.dev/docs/development/releases) docs.
+On Wednesdays, we run a [`get-preview-channel-changes`](https://github.com/zed-industries/zed/blob/main/script/get-preview-channel-changes) script that scrapes `Release Notes` lines from pull requests landing in preview, as documented in our [Release](https://zed.dev/docs/development/release-notes) docs.
 
 The script outputs everything below the `Release Notes` line, including additional data such as the pull request author (if not a Zed team member) and a link to the pull request.
 If you use `N/A`, the script skips your pull request entirely.

--- a/docs/src/uninstall.md
+++ b/docs/src/uninstall.md
@@ -110,4 +110,4 @@ If you encounter issues during uninstallation:
 - **Linux**: If the uninstall script fails, check the error message and consider manual removal of the directories listed above.
 - **All platforms**: If you want to start fresh while keeping Zed installed, you can delete the configuration directories instead of uninstalling the application entirely.
 
-For additional help, see our [Linux-specific documentation](./linux.md) or visit the [Zed community](https://zed.dev/community).
+For additional help, see our [Linux-specific documentation](./linux.md) or visit the [Zed community](https://zed.dev/community-links).


### PR DESCRIPTION
Lychee is a [Rust based](https://lychee.cli.rs) async parallel link checker.

I ran it against the codebase to suss out stale links and fixed those up.

There's currently 2 remaining cases that I don't know how to resolve:

1. https://flathub.org/apps/dev.zed.Zed - nginx is giving a 502 bad gateway
2. https://github.com/zed-industries/zed/actions/workflows/ci.yml/badge.svg - I don't want to mess with the CI pipeline in this PR.

Once again, I'll punt to the Docs Czar to see if this gets incorporated into CI later.

---

## Running `lychee` locally:

```
cargo binstall -y lychee
lychee .
```

---
Release Notes:

- N/A
