### PR TITLE
vim: Add vim mode in Command Palette

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -983,7 +983,7 @@
     }
   },
   {
-    "context": "Editor && mode == auto_height && VimControl",
+    "context": "Editor && (mode == auto_height || mode == single_line) && VimControl",
     "bindings": {
       // TODO: Implement search
       "/": null,

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -348,6 +348,12 @@
     }
   },
   {
+    "context": "mode == single_line && vim_mode == insert",
+    "bindings": {
+      "shift-escape": "vim::SwitchToNormalMode"
+    }
+  },
+  {
     "context": "vim_mode == insert",
     "bindings": {
       "ctrl-c": "vim::NormalBefore",
@@ -385,6 +391,12 @@
       "ctrl-u": "vim::ScrollUp",
       "ctrl-e": "vim::LineDown",
       "ctrl-y": "vim::LineUp"
+    }
+  },
+  {
+    "context": "mode == single_line && vim_mode == insert",
+    "bindings": {
+      "escape": "menu::Cancel"
     }
   },
   {

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -348,12 +348,6 @@
     }
   },
   {
-    "context": "mode == single_line && vim_mode == insert",
-    "bindings": {
-      "shift-escape": "vim::SwitchToNormalMode"
-    }
-  },
-  {
     "context": "vim_mode == insert",
     "bindings": {
       "ctrl-c": "vim::NormalBefore",
@@ -385,18 +379,19 @@
     }
   },
   {
+    "context": "mode == single_line && vim_mode == insert",
+    "bindings": {
+      "shift-escape": "vim::SwitchToNormalMode",
+      "escape": "menu::Cancel"
+    }
+  },
+  {
     "context": "showing_completions",
     "bindings": {
       "ctrl-d": "vim::ScrollDown",
       "ctrl-u": "vim::ScrollUp",
       "ctrl-e": "vim::LineDown",
       "ctrl-y": "vim::LineUp"
-    }
-  },
-  {
-    "context": "mode == single_line && vim_mode == insert",
-    "bindings": {
-      "escape": "menu::Cancel"
     }
   },
   {

--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -276,6 +276,10 @@ impl CommandPaletteDelegate {
 impl PickerDelegate for CommandPaletteDelegate {
     type ListItem = ListItem;
 
+    fn use_modal_editing(&self) -> bool {
+        true
+    }
+
     fn placeholder_text(&self, _window: &mut Window, _cx: &mut App) -> Arc<str> {
         "Execute a command...".into()
     }

--- a/crates/picker/src/head.rs
+++ b/crates/picker/src/head.rs
@@ -15,6 +15,7 @@ pub(crate) enum Head {
 
 impl Head {
     pub fn editor<V: 'static>(
+        use_modal_editing: bool,
         placeholder_text: Arc<str>,
         edit_handler: impl FnMut(&mut V, &Entity<Editor>, &EditorEvent, &mut Window, &mut Context<V>)
         + 'static,
@@ -24,6 +25,7 @@ impl Head {
         let editor = cx.new(|cx| {
             let mut editor = Editor::single_line(window, cx);
             editor.set_placeholder_text(placeholder_text.as_ref(), window, cx);
+            editor.set_use_modal_editing(use_modal_editing);
             editor
         });
         cx.subscribe_in(&editor, window, edit_handler).detach();

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -86,6 +86,10 @@ pub enum PickerEditorPosition {
 pub trait PickerDelegate: Sized + 'static {
     type ListItem: IntoElement;
 
+    fn use_modal_editing(&self) -> bool {
+        false
+    }
+
     fn match_count(&self) -> usize;
     fn selected_index(&self) -> usize;
     fn separators_after_indices(&self) -> Vec<usize> {
@@ -254,6 +258,7 @@ impl<D: PickerDelegate> Picker<D> {
     /// If `PickerDelegate::render_match` can return items with different heights, use `Picker::list`.
     pub fn uniform_list(delegate: D, window: &mut Window, cx: &mut Context<Self>) -> Self {
         let head = Head::editor(
+            delegate.use_modal_editing(),
             delegate.placeholder_text(window, cx),
             Self::on_input_editor_event,
             window,
@@ -289,6 +294,7 @@ impl<D: PickerDelegate> Picker<D> {
     /// If `PickerDelegate::render_match` only returns items with the same height, use `Picker::uniform_list` as its implementation is optimized for that.
     pub fn list(delegate: D, window: &mut Window, cx: &mut Context<Self>) -> Self {
         let head = Head::editor(
+            delegate.use_modal_editing(),
             delegate.placeholder_text(window, cx),
             Self::on_input_editor_event,
             window,


### PR DESCRIPTION

in Command Palette:

`escape` Cancel
`shift-escape` Switch To NormalMode

https://github.com/user-attachments/assets/2c4eb1bd-d671-4cbc-831e-0742cfd1d22e

This is just experimental, if the team can accept it, it can be extended to any single-line editing

Release Notes:

- Added Vim mode in Command Palette
