### PR TITLE
vim: Fix change surround adding unwanted spaces with quotes

### DIFF
--- a/crates/vim/src/surrounds.rs
+++ b/crates/vim/src/surrounds.rs
@@ -327,7 +327,7 @@ impl Vim {
                                     while let Some((next_ch, _)) = reverse_chars_and_offsets.next()
                                         && (next_ch.to_string() == " "
                                             && forward_end
-                                                .map_or(true, |open_end| start > open_end))
+                                                .map_or(true, |open_end| start >= open_end))
                                         && close_str.len() < edit_len - 1
                                     {
                                         start -= 1;

--- a/crates/vim/src/surrounds.rs
+++ b/crates/vim/src/surrounds.rs
@@ -327,7 +327,7 @@ impl Vim {
                                     while let Some((next_ch, _)) = reverse_chars_and_offsets.next()
                                         && (next_ch.to_string() == " "
                                             && forward_end
-                                                .map_or(true, |open_end| start >= open_end))
+                                                .map_or(true, |open_end| start > open_end))
                                         && close_str.len() < edit_len - 1
                                     {
                                         start -= 1;
@@ -1252,7 +1252,7 @@ mod test {
         cx.assert_state(
             indoc! {"
             fn test_surround() {
-                'ˇ '
+                ˇ' '
             };"},
             Mode::Normal,
         );


### PR DESCRIPTION
Update `Vim.change_surround` in order to ensure that there's no
overlapping edits by keeping track of where the open string range ends
and ensuring that the closing string range start does not go lower than
the open string range end.

Closes #42316 

Release Notes:

- Fix vim's change surrounds `cs` inserting spaces with quotes by preventing overlapping edits