### PR TITLE
auto_update: Ignore dir removal errors on windows

### DIFF
--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -905,26 +905,15 @@ async fn install_release_macos(
 
 #[cfg(target_os = "windows")]
 async fn cleanup_windows() -> Result<()> {
-    use util::ResultExt;
-
     let parent = std::env::current_exe()?
         .parent()
         .context("No parent dir for Zed.exe")?
         .to_owned();
 
     // keep in sync with crates/auto_update_helper/src/updater.rs
-    smol::fs::remove_dir(parent.join("updates"))
-        .await
-        .context("failed to remove updates dir")
-        .log_err();
-    smol::fs::remove_dir(parent.join("install"))
-        .await
-        .context("failed to remove install dir")
-        .log_err();
-    smol::fs::remove_dir(parent.join("old"))
-        .await
-        .context("failed to remove old version dir")
-        .log_err();
+    _ = smol::fs::remove_dir(parent.join("updates")).await;
+    _ = smol::fs::remove_dir(parent.join("install")).await;
+    _ = smol::fs::remove_dir(parent.join("old")).await;
 
     Ok(())
 }

--- a/crates/auto_update_helper/src/updater.rs
+++ b/crates/auto_update_helper/src/updater.rs
@@ -1,6 +1,6 @@
 use std::{
-    cell::LazyCell,
     path::Path,
+    sync::LazyLock,
     time::{Duration, Instant},
 };
 
@@ -13,8 +13,8 @@ use windows::Win32::{
 use crate::windows_impl::WM_JOB_UPDATED;
 
 pub(crate) struct Job {
-    pub apply: Box<dyn Fn(&Path) -> Result<()>>,
-    pub rollback: Box<dyn Fn(&Path) -> Result<()>>,
+    pub apply: Box<dyn Fn(&Path) -> Result<()> + Send + Sync>,
+    pub rollback: Box<dyn Fn(&Path) -> Result<()> + Send + Sync>,
 }
 
 impl Job {
@@ -154,10 +154,8 @@ impl Job {
     }
 }
 
-// app is single threaded
 #[cfg(not(test))]
-#[allow(clippy::declare_interior_mutable_const)]
-pub(crate) const JOBS: LazyCell<[Job; 22]> = LazyCell::new(|| {
+pub(crate) static JOBS: LazyLock<[Job; 22]> = LazyLock::new(|| {
     fn p(value: &str) -> &Path {
         Path::new(value)
     }
@@ -206,10 +204,8 @@ pub(crate) const JOBS: LazyCell<[Job; 22]> = LazyCell::new(|| {
     ]
 });
 
-// app is single threaded
 #[cfg(test)]
-#[allow(clippy::declare_interior_mutable_const)]
-pub(crate) const JOBS: LazyCell<[Job; 9]> = LazyCell::new(|| {
+pub(crate) static JOBS: LazyLock<[Job; 9]> = LazyLock::new(|| {
     fn p(value: &str) -> &Path {
         Path::new(value)
     }


### PR DESCRIPTION
The auto update helper already removes these when successful, so these will always fail in the common case.

Additional replaces a mutable const with a static as otherwise we'll rebuild the job list on every access

Release Notes:

- N/A *or* Added/Fixed/Improved ...
