### PR TITLE
Fix search wrap detection when search_wrap is false

### DIFF
--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -1023,16 +1023,17 @@ impl BufferSearchBar {
                 .get(&searchable_item.downgrade())
                 .filter(|matches| !matches.is_empty())
         {
-            // If 'wrapscan' is disabled, searches do not wrap around the end of the file.
+            let new_match_index = searchable_item
+                .match_index_for_direction(matches, index, direction, count, window, cx);
+
+            // If 'search_wrap' is disabled, searches do not wrap around the file.
             if !EditorSettings::get_global(cx).search_wrap
-                && ((direction == Direction::Next && index + count >= matches.len())
-                    || (direction == Direction::Prev && index < count))
+                && ((direction == Direction::Next && new_match_index < index)
+                    || (direction == Direction::Prev && new_match_index > index))
             {
                 crate::show_no_more_matches(window, cx);
                 return;
             }
-            let new_match_index = searchable_item
-                .match_index_for_direction(matches, index, direction, count, window, cx);
 
             searchable_item.update_matches(matches, window, cx);
             searchable_item.activate_match(new_match_index, matches, collapse, window, cx);


### PR DESCRIPTION
Reproduce the original bug:
1. Search for text that has a single match in the buffer
2. Press ESC
3. Move cursor above the search match
4. Press F3 to find next match. It doesn't find the match but shows "No more matches". Alternatively you can press Ctrl-f to open the search again, and press Enter to search for the same string. It also shows "No more matches".

The bug also happens when there are more than one matches, and the cursor is between the second-to-last and last match.

This patch changes `select_match()` to always call `searchable_item.match_index_for_direction()` and then check whether the `new_match_index` is before or after the current `index` to detect wrapping.

Release Notes:

- Fix search wrap detection when search_wrap is false