### PR TITLE
docs: Fix typo in `configuring-zed.md`

### DIFF
--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -213,7 +213,7 @@ Note: This setting has no effect in Vim mode, as rewrap is already allowed every
 ## Auto Install extensions
 
 - Description: Define extensions to be autoinstalled or never be installed.
-- Setting: `auto_install_extension`
+- Setting: `auto_install_extensions`
 - Default: `{ "html": true }`
 
 **Options**


### PR DESCRIPTION
Fix a minor typo in the setting key: `auto_install_extension` should be `auto_install_extensions`.

Release Notes:

- N/A
