### PR TITLE
settings: Skip terminal env vars with substitutions in vscode import

### DIFF
--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -350,8 +350,7 @@ impl AutoUpdater {
 
     pub fn start_polling(&self, cx: &mut Context<Self>) -> Task<Result<()>> {
         cx.spawn(async move |this, cx| {
-            #[cfg(target_os = "windows")]
-            {
+            if cfg!(target_os = "windows") {
                 use util::ResultExt;
 
                 cleanup_windows()
@@ -903,7 +902,6 @@ async fn install_release_macos(
     Ok(None)
 }
 
-#[cfg(target_os = "windows")]
 async fn cleanup_windows() -> Result<()> {
     use util::ResultExt;
 

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -753,7 +753,13 @@ impl VsCodeSettings {
         let env = self
             .read_value(&format!("terminal.integrated.env.{platform}"))
             .and_then(|v| v.as_object())
-            .map(|v| v.iter().map(|(k, v)| (k.clone(), v.to_string())).collect());
+            .map(|v| {
+                v.iter()
+                    .map(|(k, v)| (k.clone(), v.to_string()))
+                    // zed does not support substitutions, so this can break env vars
+                    .filter(|(_, v)| !v.contains('$'))
+                    .collect()
+            });
 
         ProjectTerminalSettingsContent {
             // TODO: handle arguments

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -1386,7 +1386,15 @@ impl Terminal {
     /// (This is a no-op for display-only terminals.)
     fn write_to_pty(&self, input: impl Into<Cow<'static, [u8]>>) {
         if let TerminalType::Pty { pty_tx, .. } = &self.terminal_type {
-            pty_tx.notify(input.into());
+            let input = input.into();
+            if log::log_enabled!(log::Level::Debug) {
+                if let Ok(str) = str::from_utf8(&input) {
+                    log::debug!("Writing to PTY: {:?}", str);
+                } else {
+                    log::debug!("Writing to PTY: {:?}", input);
+                }
+            }
+            pty_tx.notify(input);
         }
     }
 


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/40547

Release Notes:

- Fixed vscode import creating faulty terminal env vars in terminal settings
