### PR TITLE
collab: Drop `embeddings` table

### DIFF
--- a/crates/collab/migrations/20251111161644_drop_embeddings.sql
+++ b/crates/collab/migrations/20251111161644_drop_embeddings.sql
@@ -1,0 +1,1 @@
+drop table embeddings;


### PR DESCRIPTION
This PR drops the `embeddings` table, as it is no longer used.

Release Notes:

- N/A