### PR TITLE
Send Code to Terminal (Interpreted language support)

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -35,6 +35,7 @@ mod persistence;
 mod rust_analyzer_ext;
 pub mod scroll;
 mod selections_collection;
+pub mod send_to_console;
 pub mod tasks;
 
 #[cfg(test)]

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -35,7 +35,6 @@ mod persistence;
 mod rust_analyzer_ext;
 pub mod scroll;
 mod selections_collection;
-pub mod send_to_console;
 pub mod tasks;
 
 #[cfg(test)]

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -6,6 +6,8 @@ pub(crate) mod mac_only_instance;
 mod migrate;
 mod open_listener;
 mod quick_action_bar;
+mod send_to_terminal;
+use send_to_terminal::send_to_terminal;
 #[cfg(target_os = "windows")]
 pub(crate) mod windows_only_instance;
 
@@ -18,7 +20,6 @@ use breadcrumbs::Breadcrumbs;
 use client::zed_urls;
 use collections::VecDeque;
 use debugger_ui::debugger_panel::DebugPanel;
-use editor::ToOffset;
 use editor::{Editor, MultiBuffer};
 use extension_host::ExtensionStore;
 use feature_flags::{FeatureFlagAppExt, PanicFeatureFlag};
@@ -78,7 +79,6 @@ use util::rel_path::RelPath;
 use util::{ResultExt, asset_str};
 use uuid::Uuid;
 use vim_mode_setting::VimModeSetting;
-use workspace::Panel;
 use workspace::notifications::{
     NotificationId, SuppressEvent, dismiss_app_notification, show_app_notification,
 };
@@ -271,109 +271,6 @@ pub fn init(cx: &mut App) {
                 window,
                 cx,
             );
-        });
-    });
-}
-
-fn send_to_terminal(cx: &mut App) {
-    with_active_or_new_workspace(cx, |workspace, window, cx| {
-        let Some(active_item) = workspace.active_item(cx) else {
-            return;
-        };
-
-        let Some(editor) = active_item.act_as::<editor::Editor>(cx) else {
-            return;
-        };
-
-        let buffer = editor.read(cx).buffer().read(cx).snapshot(cx);
-        let selection = editor.read(cx).selections.newest_anchor();
-        let selection_range = selection.start.to_offset(&buffer)..selection.end.to_offset(&buffer);
-
-        let (expression_text, expression_range) = if selection_range.is_empty() {
-            let cursor_offset = selection_range.start;
-            let cursor_point = buffer.offset_to_point(cursor_offset);
-
-            let line_range = buffer.point_to_offset(language::Point::new(cursor_point.row, 0))
-                ..buffer.point_to_offset(language::Point::new(cursor_point.row + 1, 0));
-            let line_text = buffer.text_for_range(line_range.clone()).collect::<String>();
-
-            let search_offset = if line_text.trim().is_empty() {
-                line_range.end
-            } else {
-                line_range.start
-            };
-
-            let mut range = search_offset..search_offset;
-            let mut found_valid_expression = false;
-
-            while let Some((node, new_range)) = buffer.syntax_ancestor(range.clone()) {
-                range = new_range;
-                if node.is_named() {
-                    let kind = node.kind();
-                    if kind.contains("call")
-                        || kind.contains("statement")
-                        || kind.contains("expression")
-                        || kind.contains("assignment")
-                        || kind == "binary_operator"
-                    {
-                        found_valid_expression = true;
-                        break;
-                    }
-                }
-            }
-
-            if !found_valid_expression {
-                range = search_offset..search_offset;
-                while let Some((node, new_range)) = buffer.syntax_ancestor(range.clone()) {
-                    range = new_range;
-                    if node.is_named() {
-                        break;
-                    }
-                }
-            }
-
-            if range.is_empty() {
-                (line_text, line_range)
-            } else {
-                (buffer.text_for_range(range.clone()).collect::<String>(), range)
-            }
-        } else {
-            (buffer.text_for_range(selection_range.clone()).collect::<String>(), selection_range)
-        };
-
-        let expression_text = expression_text.trim().to_string();
-
-        if expression_text.is_empty() {
-            return;
-        }
-
-        let Some(terminal_panel) = workspace.panel::<TerminalPanel>(cx) else {
-            return;
-        };
-
-        let Some(terminal_view) = terminal_panel.read(cx).pane().and_then(|pane| {
-            pane.read(cx)
-                .active_item()
-                .and_then(|item| item.downcast::<terminal_view::TerminalView>())
-        }) else {
-            return;
-        };
-
-        let command_with_newline = format!("{}\n", expression_text);
-        terminal_view.update(cx, |view, cx| {
-            view.terminal().update(cx, |terminal, _cx| {
-                terminal.input(command_with_newline.into_bytes());
-            });
-        });
-
-        let end_point = buffer.offset_to_point(expression_range.end);
-        let next_line_offset = buffer.point_to_offset(language::Point::new(end_point.row + 1, 0));
-        let anchor = buffer.anchor_after(next_line_offset);
-
-        editor.update(cx, |editor, cx| {
-            editor.change_selections(Default::default(), window, cx, |s| {
-                s.select_anchor_ranges([anchor..anchor]);
-            });
         });
     });
 }

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -18,6 +18,7 @@ use breadcrumbs::Breadcrumbs;
 use client::zed_urls;
 use collections::VecDeque;
 use debugger_ui::debugger_panel::DebugPanel;
+use editor::ToOffset;
 use editor::{Editor, MultiBuffer};
 use extension_host::ExtensionStore;
 use feature_flags::{FeatureFlagAppExt, PanicFeatureFlag};
@@ -77,6 +78,7 @@ use util::rel_path::RelPath;
 use util::{ResultExt, asset_str};
 use uuid::Uuid;
 use vim_mode_setting::VimModeSetting;
+use workspace::Panel;
 use workspace::notifications::{
     NotificationId, SuppressEvent, dismiss_app_notification, show_app_notification,
 };
@@ -97,6 +99,8 @@ use zed_actions::{
 actions!(
     zed,
     [
+        /// Sends the current expression to the active terminal.
+        SendToTerminal,
         /// Opens the element inspector for debugging UI.
         DebugElements,
         /// Hides the application window.
@@ -232,6 +236,9 @@ pub fn init(cx: &mut App) {
             );
         });
     });
+    cx.on_action(|_: &SendToTerminal, cx| {
+        send_to_terminal(cx);
+    });
     cx.on_action(|_: &OpenDebugTasks, cx| {
         with_active_or_new_workspace(cx, |_, window, cx| {
             open_settings_file(
@@ -264,6 +271,109 @@ pub fn init(cx: &mut App) {
                 window,
                 cx,
             );
+        });
+    });
+}
+
+fn send_to_terminal(cx: &mut App) {
+    with_active_or_new_workspace(cx, |workspace, window, cx| {
+        let Some(active_item) = workspace.active_item(cx) else {
+            return;
+        };
+
+        let Some(editor) = active_item.act_as::<editor::Editor>(cx) else {
+            return;
+        };
+
+        let buffer = editor.read(cx).buffer().read(cx).snapshot(cx);
+        let selection = editor.read(cx).selections.newest_anchor();
+        let selection_range = selection.start.to_offset(&buffer)..selection.end.to_offset(&buffer);
+
+        let (expression_text, expression_range) = if selection_range.is_empty() {
+            let cursor_offset = selection_range.start;
+            let cursor_point = buffer.offset_to_point(cursor_offset);
+
+            let line_range = buffer.point_to_offset(language::Point::new(cursor_point.row, 0))
+                ..buffer.point_to_offset(language::Point::new(cursor_point.row + 1, 0));
+            let line_text = buffer.text_for_range(line_range.clone()).collect::<String>();
+
+            let search_offset = if line_text.trim().is_empty() {
+                line_range.end
+            } else {
+                line_range.start
+            };
+
+            let mut range = search_offset..search_offset;
+            let mut found_valid_expression = false;
+
+            while let Some((node, new_range)) = buffer.syntax_ancestor(range.clone()) {
+                range = new_range;
+                if node.is_named() {
+                    let kind = node.kind();
+                    if kind.contains("call")
+                        || kind.contains("statement")
+                        || kind.contains("expression")
+                        || kind.contains("assignment")
+                        || kind == "binary_operator"
+                    {
+                        found_valid_expression = true;
+                        break;
+                    }
+                }
+            }
+
+            if !found_valid_expression {
+                range = search_offset..search_offset;
+                while let Some((node, new_range)) = buffer.syntax_ancestor(range.clone()) {
+                    range = new_range;
+                    if node.is_named() {
+                        break;
+                    }
+                }
+            }
+
+            if range.is_empty() {
+                (line_text, line_range)
+            } else {
+                (buffer.text_for_range(range.clone()).collect::<String>(), range)
+            }
+        } else {
+            (buffer.text_for_range(selection_range.clone()).collect::<String>(), selection_range)
+        };
+
+        let expression_text = expression_text.trim().to_string();
+
+        if expression_text.is_empty() {
+            return;
+        }
+
+        let Some(terminal_panel) = workspace.panel::<TerminalPanel>(cx) else {
+            return;
+        };
+
+        let Some(terminal_view) = terminal_panel.read(cx).pane().and_then(|pane| {
+            pane.read(cx)
+                .active_item()
+                .and_then(|item| item.downcast::<terminal_view::TerminalView>())
+        }) else {
+            return;
+        };
+
+        let command_with_newline = format!("{}\n", expression_text);
+        terminal_view.update(cx, |view, cx| {
+            view.terminal().update(cx, |terminal, _cx| {
+                terminal.input(command_with_newline.into_bytes());
+            });
+        });
+
+        let end_point = buffer.offset_to_point(expression_range.end);
+        let next_line_offset = buffer.point_to_offset(language::Point::new(end_point.row + 1, 0));
+        let anchor = buffer.anchor_after(next_line_offset);
+
+        editor.update(cx, |editor, cx| {
+            editor.change_selections(Default::default(), window, cx, |s| {
+                s.select_anchor_ranges([anchor..anchor]);
+            });
         });
     });
 }

--- a/crates/zed/src/zed/send_to_terminal.rs
+++ b/crates/zed/src/zed/send_to_terminal.rs
@@ -117,3 +117,245 @@ pub(crate) fn send_to_terminal(cx: &mut App) {
         });
     });
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::zed::tests::init_test;
+    use editor::Editor;
+    use gpui::TestAppContext;
+    use language::tree_sitter_python;
+    use language::{Language, LanguageConfig, LanguageMatcher};
+    use project::Project;
+    use serde_json::json;
+    use std::{path::PathBuf, sync::Arc};
+    use util::path;
+    use workspace::{OpenOptions, OpenVisible, Workspace};
+
+    fn python_language() -> Arc<Language> {
+        Arc::new(Language::new(
+            LanguageConfig {
+                name: "Python".into(),
+                matcher: LanguageMatcher {
+                    path_suffixes: vec!["py".to_string()],
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            Some(tree_sitter_python::LANGUAGE.into()),
+        ))
+    }
+
+    #[gpui::test]
+    async fn test_send_to_terminal_finds_expression(cx: &mut TestAppContext) {
+        let app_state = init_test(cx);
+
+        app_state
+            .fs
+            .as_fake()
+            .insert_tree(
+                path!("/root"),
+                json!({
+                    "test.py": ""
+                }),
+            )
+            .await;
+
+        let project = Project::test(app_state.fs.clone(), [path!("/root").as_ref()], cx).await;
+        let python_lang = python_language();
+
+        project.update(cx, |project, _cx| {
+            project.languages().add(python_lang.clone());
+        });
+
+        let window = cx.add_window(|window, cx| Workspace::test_new(project.clone(), window, cx));
+
+        let _res = window
+            .update(cx, |workspace, window, cx| {
+                workspace.open_paths(
+                    vec![PathBuf::from(path!("/root/test.py"))],
+                    OpenOptions {
+                        visible: Some(OpenVisible::All),
+                        ..Default::default()
+                    },
+                    None,
+                    window,
+                    cx,
+                )
+            })
+            .unwrap();
+
+        cx.background_executor.run_until_parked();
+
+        let editor = window
+            .update(cx, |workspace, _, cx| {
+                workspace.active_item_as::<Editor>(cx).unwrap()
+            })
+            .unwrap();
+
+        let code = r#"
+            import pandas as pd
+
+            df = pd.read_csv("data.csv")
+            print(df.head())
+
+            df.describe()
+        "#;
+
+        window
+            .update(cx, |_, window, cx| {
+                editor.update(cx, |editor, cx| {
+                    editor.set_text(code, window, cx);
+                    editor.buffer().update(cx, |buffer, cx| {
+                        buffer.as_singleton().unwrap().update(cx, |buffer, cx| {
+                            buffer.set_language(Some(python_lang.clone()), cx);
+                        });
+                    });
+                })
+            })
+            .unwrap();
+
+        cx.background_executor.run_until_parked();
+
+        // Test 1: Cursor at start should find "import pandas as pd"
+        window
+            .update(cx, |_, window, cx| {
+                editor.update(cx, |editor, cx| {
+                    editor.change_selections(Default::default(), window, cx, |s| {
+                        s.select_ranges([0..0]);
+                    });
+                })
+            })
+            .unwrap();
+
+        let buffer_text = editor.update(cx, |editor, cx| {
+            editor.buffer().read(cx).snapshot(cx).text()
+        });
+
+        assert!(buffer_text.contains("import pandas as pd"));
+        assert!(buffer_text.contains("df.describe()"));
+
+        // Test 2: Cursor on function call line
+        let function_call_offset = buffer_text.find("print(df.head())").unwrap();
+        window
+            .update(cx, |_, window, cx| {
+                editor.update(cx, |editor, cx| {
+                    editor.change_selections(Default::default(), window, cx, |s| {
+                        s.select_ranges([function_call_offset..function_call_offset]);
+                    });
+                })
+            })
+            .unwrap();
+
+        let cursor_line = editor.update(cx, |editor, cx| {
+            let buffer = editor.buffer().read(cx).snapshot(cx);
+            let cursor_offset = editor.selections.newest_anchor().head().to_offset(&buffer);
+            let cursor_point = buffer.offset_to_point(cursor_offset);
+            let line_start = buffer.point_to_offset(language::Point::new(cursor_point.row, 0));
+            let line_end = buffer.point_to_offset(language::Point::new(cursor_point.row + 1, 0));
+            buffer
+                .text_for_range(line_start..line_end)
+                .collect::<String>()
+        });
+
+        assert!(cursor_line.contains("print(df.head())"));
+    }
+
+    #[gpui::test]
+    async fn test_send_to_terminal_cursor_movement(cx: &mut TestAppContext) {
+        let app_state = init_test(cx);
+
+        app_state
+            .fs
+            .as_fake()
+            .insert_tree(
+                path!("/root"),
+                json!({
+                    "test.py": ""
+                }),
+            )
+            .await;
+
+        let project = Project::test(app_state.fs.clone(), [path!("/root").as_ref()], cx).await;
+        let python_lang = python_language();
+
+        project.update(cx, |project, _cx| {
+            project.languages().add(python_lang.clone());
+        });
+
+        let window = cx.add_window(|window, cx| Workspace::test_new(project.clone(), window, cx));
+
+        let task = window
+            .update(cx, |workspace, window, cx| {
+                workspace.open_paths(
+                    vec![PathBuf::from(path!("/root/test.py"))],
+                    OpenOptions {
+                        visible: Some(OpenVisible::All),
+                        ..Default::default()
+                    },
+                    None,
+                    window,
+                    cx,
+                )
+            })
+            .unwrap();
+        task.await;
+
+        cx.background_executor.run_until_parked();
+
+        let editor = window
+            .update(cx, |workspace, _, cx| {
+                workspace.active_item_as::<Editor>(cx).unwrap()
+            })
+            .unwrap();
+
+        let code = r#"
+            print("line 1")
+            print("line 2")
+            print("line 3")
+        "#;
+
+        window
+            .update(cx, |_, window, cx| {
+                editor.update(cx, |editor, cx| {
+                    editor.set_text(code, window, cx);
+                    editor.buffer().update(cx, |buffer, cx| {
+                        buffer.as_singleton().unwrap().update(cx, |buffer, cx| {
+                            buffer.set_language(Some(python_lang.clone()), cx);
+                        });
+                    });
+                })
+            })
+            .unwrap();
+
+        cx.background_executor.run_until_parked();
+
+        // Place cursor on first line
+        window
+            .update(cx, |_, window, cx| {
+                editor.update(cx, |editor, cx| {
+                    editor.change_selections(Default::default(), window, cx, |s| {
+                        s.select_ranges([0..0]);
+                    });
+                })
+            })
+            .unwrap();
+
+        let initial_line = editor.update(cx, |editor, cx| {
+            let buffer = editor.buffer().read(cx).snapshot(cx);
+            let cursor_offset = editor.selections.newest_anchor().head().to_offset(&buffer);
+            buffer.offset_to_point(cursor_offset).row
+        });
+
+        assert_eq!(initial_line, 0);
+
+        // Verify the code is loaded correctly
+        let buffer_text = editor.update(cx, |editor, cx| {
+            editor.buffer().read(cx).snapshot(cx).text()
+        });
+
+        assert!(buffer_text.contains("line 1"));
+        assert!(buffer_text.contains("line 2"));
+        assert!(buffer_text.contains("line 3"));
+    }
+}

--- a/crates/zed/src/zed/send_to_terminal.rs
+++ b/crates/zed/src/zed/send_to_terminal.rs
@@ -1,0 +1,119 @@
+use crate::{
+    App,
+    zed::{TerminalPanel, with_active_or_new_workspace},
+};
+use editor::ToOffset;
+use workspace::Panel;
+
+pub(crate) fn send_to_terminal(cx: &mut App) {
+    with_active_or_new_workspace(cx, |workspace, window, cx| {
+        let Some(active_item) = workspace.active_item(cx) else {
+            return;
+        };
+
+        let Some(editor) = active_item.act_as::<editor::Editor>(cx) else {
+            return;
+        };
+
+        let buffer = editor.read(cx).buffer().read(cx).snapshot(cx);
+        let selection = editor.read(cx).selections.newest_anchor();
+        let selection_range = selection.start.to_offset(&buffer)..selection.end.to_offset(&buffer);
+
+        let (expression_text, expression_range) = if selection_range.is_empty() {
+            let cursor_offset = selection_range.start;
+            let cursor_point = buffer.offset_to_point(cursor_offset);
+
+            let line_range = buffer.point_to_offset(language::Point::new(cursor_point.row, 0))
+                ..buffer.point_to_offset(language::Point::new(cursor_point.row + 1, 0));
+            let line_text = buffer
+                .text_for_range(line_range.clone())
+                .collect::<String>();
+
+            let search_offset = if line_text.trim().is_empty() {
+                line_range.end
+            } else {
+                line_range.start
+            };
+
+            let mut range = search_offset..search_offset;
+            let mut found_valid_expression = false;
+
+            while let Some((node, new_range)) = buffer.syntax_ancestor(range.clone()) {
+                range = new_range;
+                if node.is_named() {
+                    let kind = node.kind();
+                    if kind.contains("call")
+                        || kind.contains("statement")
+                        || kind.contains("expression")
+                        || kind.contains("assignment")
+                        || kind == "binary_operator"
+                    {
+                        found_valid_expression = true;
+                        break;
+                    }
+                }
+            }
+
+            if !found_valid_expression {
+                range = search_offset..search_offset;
+                while let Some((node, new_range)) = buffer.syntax_ancestor(range.clone()) {
+                    range = new_range;
+                    if node.is_named() {
+                        break;
+                    }
+                }
+            }
+
+            if range.is_empty() {
+                (line_text, line_range)
+            } else {
+                (
+                    buffer.text_for_range(range.clone()).collect::<String>(),
+                    range,
+                )
+            }
+        } else {
+            (
+                buffer
+                    .text_for_range(selection_range.clone())
+                    .collect::<String>(),
+                selection_range,
+            )
+        };
+
+        let expression_text = expression_text.trim().to_string();
+
+        if expression_text.is_empty() {
+            return;
+        }
+
+        let Some(terminal_panel) = workspace.panel::<TerminalPanel>(cx) else {
+            return;
+        };
+
+        let Some(terminal_view) = terminal_panel.read(cx).pane().and_then(|pane| {
+            pane.read(cx)
+                .active_item()
+                .and_then(|item| item.downcast::<terminal_view::TerminalView>())
+        }) else {
+            return;
+        };
+
+        let command_with_newline = format!("{}\n", expression_text);
+        terminal_view.update(cx, |view, cx| {
+            view.terminal().update(cx, |terminal, _cx| {
+                terminal.input(command_with_newline.into_bytes());
+            });
+        });
+
+        let end_point = buffer.offset_to_point(expression_range.end);
+        let next_line_offset = buffer.point_to_offset(language::Point::new(end_point.row + 1, 0));
+        let anchor = buffer.anchor_after(next_line_offset);
+
+        editor.update(cx, |editor, cx| {
+            editor.change_selections(Default::default(), window, cx, |s| {
+                s.select_anchor_ranges([anchor..anchor]);
+            });
+        });
+    });
+}


### PR DESCRIPTION
This PR provides a new command `SendToTerminal` which uses the active LSP to capture the current expression, send it to the terminal, and continue the cursor movement. 

The intent of this PR is to provide "real" support for interpreted languages like R, Julia, and Python and mimic code execution and cursor navigation that one gets in IDEs like RStudio, Positron, and others. 

- Closes https://github.com/zed-industries/zed/issues/8344 (in spirit)
- Closes https://github.com/zed-industries/zed/discussions/8674
- Closes https://github.com/zed-industries/zed/issues/16102
- Closes https://github.com/zed-industries/zed/issues/12598

I don't think this is _perfect_ but I think it is much better than the status quo. I think, also, that this may be best handled by language-specific extensions. However, based on my understanading of the Language extension, it doesn't provide an entrypoint for performing such tasks

Release Notes:

- Adds new command `SendToTerminal` to send active expression to the active terminal supporting dynamic code execution of interpreted languages such as R, Python, Julia, and more.


## Python Example

![Screen Recording 2025-11-11 at 08 15 13](https://github.com/user-attachments/assets/118b1901-fae9-49d9-9613-cf5270210257)

## R example

![Screen Recording 2025-11-11 at 08 22 52](https://github.com/user-attachments/assets/49fb4dc1-a07c-4b97-9eae-f54b6ba9e2e3)

## Julia Example

![Screen Recording 2025-11-11 at 08 16 49](https://github.com/user-attachments/assets/e9338e11-ce33-467f-97ca-26c4ed3f1916)
