### PR TITLE
zeta eval: Improve determinism and debugging ergonomics

### DIFF
--- a/crates/cloud_zeta2_prompt/src/retrieval_prompt.rs
+++ b/crates/cloud_zeta2_prompt/src/retrieval_prompt.rs
@@ -44,7 +44,7 @@ pub struct SearchToolInput {
 }
 
 /// Search for relevant code by path, syntax hierarchy, and content.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Hash)]
 pub struct SearchToolQuery {
     /// 1. A glob pattern to match file paths in the codebase to search in.
     pub glob: String,

--- a/crates/zeta2/Cargo.toml
+++ b/crates/zeta2/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 path = "src/zeta2.rs"
 
 [features]
-llm-response-cache = []
+eval-support = []
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/zeta2/src/retrieval_search.rs
+++ b/crates/zeta2/src/retrieval_search.rs
@@ -80,7 +80,7 @@ pub async fn run_retrieval_searches(
             return Ok(results);
         }
 
-        Some((eval_cache, serde_json::to_string(&queries)?, key))
+        Some((eval_cache, serde_json::to_string_pretty(&queries)?, key))
     } else {
         None
     };
@@ -155,7 +155,11 @@ pub async fn run_retrieval_searches(
                     Some((path?.as_std_path().to_path_buf(), ranges))
                 })
                 .collect();
-            cache.write(key, &queries, &serde_json::to_string(&cached_results)?);
+            cache.write(
+                key,
+                &queries,
+                &serde_json::to_string_pretty(&cached_results)?,
+            );
         }
 
         for (buffer, ranges) in results.iter_mut() {

--- a/crates/zeta2/src/retrieval_search.rs
+++ b/crates/zeta2/src/retrieval_search.rs
@@ -1,4 +1,4 @@
-use std::{ops::Range, path::PathBuf, sync::Arc};
+use std::{collections::BTreeMap, ops::Range, path::PathBuf, sync::Arc};
 
 use anyhow::{Context as _, Result};
 use cloud_zeta2_prompt::retrieval_prompt::SearchToolQuery;
@@ -22,7 +22,7 @@ use workspace::item::Settings as _;
 
 use crate::EvalCache;
 
-type CachedSearchResults = HashMap<PathBuf, Vec<Range<usize>>>;
+type CachedSearchResults = BTreeMap<PathBuf, Vec<Range<usize>>>;
 
 pub async fn run_retrieval_searches(
     queries: Vec<SearchToolQuery>,

--- a/crates/zeta2/src/retrieval_search.rs
+++ b/crates/zeta2/src/retrieval_search.rs
@@ -147,10 +147,11 @@ pub async fn run_retrieval_searches(
                 .filter_map(|(buffer, ranges)| {
                     let snapshot = snapshots.get(&buffer.entity_id())?;
                     let path = snapshot.file().map(|f| f.path());
-                    let ranges = ranges
+                    let mut ranges = ranges
                         .iter()
                         .map(|range| range.to_offset(&snapshot))
                         .collect::<Vec<_>>();
+                    ranges.sort_unstable_by_key(|range| (range.start, range.end));
 
                     Some((path?.as_std_path().to_path_buf(), ranges))
                 })

--- a/crates/zeta2/src/retrieval_search.rs
+++ b/crates/zeta2/src/retrieval_search.rs
@@ -51,7 +51,7 @@ pub async fn run_retrieval_searches(
         })?;
 
         queries.hash(&mut hasher);
-        let key = (EvalCacheEntryKind::Search, hasher.finish());
+        let key = (EvalCacheEntryKind::SearchResults, hasher.finish());
 
         if let Some(cached_results) = eval_cache.read(key) {
             let file_results = serde_json::from_str::<CachedSearchResults>(&cached_results)

--- a/crates/zeta2/src/retrieval_search.rs
+++ b/crates/zeta2/src/retrieval_search.rs
@@ -1,6 +1,6 @@
-use std::ops::Range;
+use std::{ops::Range, path::PathBuf, sync::Arc};
 
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 use cloud_zeta2_prompt::retrieval_prompt::SearchToolQuery;
 use collections::HashMap;
 use futures::{
@@ -20,11 +20,71 @@ use util::{
 };
 use workspace::item::Settings as _;
 
+use crate::EvalCache;
+
+type CachedSearchResults = HashMap<PathBuf, Vec<Range<usize>>>;
+
 pub async fn run_retrieval_searches(
-    project: Entity<Project>,
     queries: Vec<SearchToolQuery>,
+    project: Entity<Project>,
+    #[cfg(feature = "eval-support")] eval_cache: Option<Arc<dyn EvalCache>>,
     cx: &mut AsyncApp,
 ) -> Result<HashMap<Entity<Buffer>, Vec<Range<Anchor>>>> {
+    #[cfg(feature = "eval-support")]
+    let cache = if let Some(eval_cache) = eval_cache {
+        use collections::FxHasher;
+        use std::hash::{Hash, Hasher};
+
+        use crate::EvalCacheEntryKind;
+
+        let mut hasher = FxHasher::default();
+        project.read_with(cx, |project, cx| {
+            let mut worktrees = project.worktrees(cx);
+            let Some(worktree) = worktrees.next() else {
+                panic!("Expected a single worktree in eval project. Found none.");
+            };
+            assert!(
+                worktrees.next().is_none(),
+                "Expected a single worktree in eval project. Found more than one."
+            );
+            worktree.read(cx).abs_path().hash(&mut hasher);
+        })?;
+
+        queries.hash(&mut hasher);
+        let key = (EvalCacheEntryKind::Search, hasher.finish());
+
+        if let Some(cached_results) = eval_cache.read(key) {
+            let file_results = serde_json::from_str::<CachedSearchResults>(&cached_results)
+                .context("Failed to deserialize cached search results")?;
+            let mut results = HashMap::default();
+
+            for (path, ranges) in file_results {
+                let buffer = project
+                    .update(cx, |project, cx| {
+                        // todo!
+                        let project_path = project.find_project_path(path, cx).unwrap();
+                        project.open_buffer(project_path, cx)
+                    })?
+                    .await?;
+                let snapshot = buffer.read_with(cx, |buffer, _| buffer.snapshot())?;
+                let mut ranges = ranges
+                    .into_iter()
+                    .map(|range| {
+                        snapshot.anchor_before(range.start)..snapshot.anchor_after(range.end)
+                    })
+                    .collect();
+                merge_anchor_ranges(&mut ranges, &snapshot);
+                results.insert(buffer, ranges);
+            }
+
+            return Ok(results);
+        }
+
+        Some((eval_cache, key))
+    } else {
+        None
+    };
+
     let (exclude_matcher, path_style) = project.update(cx, |project, cx| {
         let global_settings = WorktreeSettings::get_global(cx);
         let exclude_patterns = global_settings
@@ -58,6 +118,7 @@ pub async fn run_retrieval_searches(
     }
     drop(results_tx);
 
+    let cache = cache.clone();
     cx.background_spawn(async move {
         let mut results: HashMap<Entity<Buffer>, Vec<Range<Anchor>>> = HashMap::default();
         let mut snapshots = HashMap::default();
@@ -77,6 +138,24 @@ pub async fn run_retrieval_searches(
                 total_bytes += size;
                 existing.push(range);
             }
+        }
+
+        #[cfg(feature = "eval-support")]
+        if let Some((cache, key)) = cache {
+            let cached_results: CachedSearchResults = results
+                .iter()
+                .filter_map(|(buffer, ranges)| {
+                    let snapshot = snapshots.get(&buffer.entity_id())?;
+                    let path = snapshot.file().map(|f| f.path());
+                    let ranges = ranges
+                        .iter()
+                        .map(|range| range.to_offset(&snapshot))
+                        .collect::<Vec<_>>();
+
+                    Some((path?.as_std_path().to_path_buf(), ranges))
+                })
+                .collect();
+            cache.write(key, &serde_json::to_string(&cached_results)?);
         }
 
         for (buffer, ranges) in results.iter_mut() {
@@ -489,9 +568,10 @@ mod tests {
         expected_output: &str,
         cx: &mut TestAppContext,
     ) {
-        let results = run_retrieval_searches(project.clone(), vec![query], &mut cx.to_async())
-            .await
-            .unwrap();
+        let results =
+            run_retrieval_searches(vec![query], project.clone(), None, &mut cx.to_async())
+                .await
+                .unwrap();
 
         let mut results = results.into_iter().collect::<Vec<_>>();
         results.sort_by_key(|results| {

--- a/crates/zeta2/src/retrieval_search.rs
+++ b/crates/zeta2/src/retrieval_search.rs
@@ -61,7 +61,6 @@ pub async fn run_retrieval_searches(
             for (path, ranges) in file_results {
                 let buffer = project
                     .update(cx, |project, cx| {
-                        // todo!
                         let project_path = project.find_project_path(path, cx).unwrap();
                         project.open_buffer(project_path, cx)
                     })?

--- a/crates/zeta2/src/zeta2.rs
+++ b/crates/zeta2/src/zeta2.rs
@@ -736,9 +736,7 @@ impl Zeta {
 
         #[cfg(feature = "eval-support")]
         let parsed_fut = futures::future::join_all(
-            context_files
-                .iter()
-                .map(|(buffer, _)| buffer.read(cx).parsing_idle()),
+            context_files.keys().map(|buffer| buffer.read(cx).parsing_idle()),
         );
 
         let mut included_files = context_files

--- a/crates/zeta2/src/zeta2.rs
+++ b/crates/zeta2/src/zeta2.rs
@@ -736,7 +736,9 @@ impl Zeta {
 
         #[cfg(feature = "eval-support")]
         let parsed_fut = futures::future::join_all(
-            context_files.keys().map(|buffer| buffer.read(cx).parsing_idle()),
+            context_files
+                .keys()
+                .map(|buffer| buffer.read(cx).parsing_idle()),
         );
 
         let mut included_files = context_files

--- a/crates/zeta2/src/zeta2.rs
+++ b/crates/zeta2/src/zeta2.rs
@@ -1075,7 +1075,7 @@ impl Zeta {
 
             let mut hasher = FxHasher::default();
             url.hash(&mut hasher);
-            let request_str = serde_json::to_string(&request)?;
+            let request_str = serde_json::to_string_pretty(&request)?;
             request_str.hash(&mut hasher);
             let hash = hasher.finish();
 
@@ -1104,7 +1104,7 @@ impl Zeta {
 
         #[cfg(feature = "eval-support")]
         if let Some((cache, request, key)) = cache_key {
-            cache.write(key, &request, &serde_json::to_string(&response)?);
+            cache.write(key, &request, &serde_json::to_string_pretty(&response)?);
         }
 
         Ok((response, usage))

--- a/crates/zeta2/src/zeta2.rs
+++ b/crates/zeta2/src/zeta2.rs
@@ -754,6 +754,10 @@ impl Zeta {
             })
             .collect::<Vec<_>>();
 
+        included_files.sort_by(|(_, _, path_a, ranges_a), (_, _, path_b, ranges_b)| {
+            (path_a, ranges_a.len()).cmp(&(path_b, ranges_b.len()))
+        });
+
         #[cfg(feature = "eval-support")]
         let eval_cache = self.eval_cache.clone();
 

--- a/crates/zeta2/src/zeta2.rs
+++ b/crates/zeta2/src/zeta2.rs
@@ -132,15 +132,25 @@ pub struct Zeta {
     options: ZetaOptions,
     update_required: bool,
     debug_tx: Option<mpsc::UnboundedSender<ZetaDebugInfo>>,
-    #[cfg(feature = "llm-response-cache")]
-    llm_response_cache: Option<Arc<dyn LlmResponseCache>>,
+    #[cfg(feature = "eval-support")]
+    eval_cache: Option<Arc<dyn EvalCache>>,
 }
 
-#[cfg(feature = "llm-response-cache")]
-pub trait LlmResponseCache: Send + Sync {
-    fn get_key(&self, url: &gpui::http_client::Url, body: &str) -> u64;
-    fn read_response(&self, key: u64) -> Option<String>;
-    fn write_response(&self, key: u64, value: &str);
+#[cfg(feature = "eval-support")]
+pub type EvalCacheKey = (EvalCacheEntryKind, u64);
+
+#[cfg(feature = "eval-support")]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum EvalCacheEntryKind {
+    Search,
+    LlmResponse,
+    LlmRequest,
+}
+
+#[cfg(feature = "eval-support")]
+pub trait EvalCache: Send + Sync {
+    fn read(&self, key: EvalCacheKey) -> Option<String>;
+    fn write(&self, key: EvalCacheKey, value: &str);
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -369,14 +379,14 @@ impl Zeta {
             ),
             update_required: false,
             debug_tx: None,
-            #[cfg(feature = "llm-response-cache")]
-            llm_response_cache: None,
+            #[cfg(feature = "eval-support")]
+            eval_cache: None,
         }
     }
 
-    #[cfg(feature = "llm-response-cache")]
-    pub fn with_llm_response_cache(&mut self, cache: Arc<dyn LlmResponseCache>) {
-        self.llm_response_cache = Some(cache);
+    #[cfg(feature = "eval-support")]
+    pub fn with_eval_cache(&mut self, cache: Arc<dyn EvalCache>) {
+        self.eval_cache = Some(cache);
     }
 
     pub fn debug_info(&mut self) -> mpsc::UnboundedReceiver<ZetaDebugInfo> {
@@ -736,9 +746,19 @@ impl Zeta {
         // TODO data collection
         let can_collect_data = cx.is_staff();
 
-        let mut included_files = project_state
+        let empty_context_files = HashMap::default();
+        let context_files = project_state
             .and_then(|project_state| project_state.context.as_ref())
-            .unwrap_or(&HashMap::default())
+            .unwrap_or(&empty_context_files);
+
+        #[cfg(feature = "eval-support")]
+        let parsed_fut = futures::future::join_all(
+            context_files
+                .iter()
+                .map(|(buffer, _)| buffer.read(cx).parsing_idle()),
+        );
+
+        let mut included_files = context_files
             .iter()
             .filter_map(|(buffer_entity, ranges)| {
                 let buffer = buffer_entity.read(cx);
@@ -751,12 +771,15 @@ impl Zeta {
             })
             .collect::<Vec<_>>();
 
-        #[cfg(feature = "llm-response-cache")]
-        let llm_response_cache = self.llm_response_cache.clone();
+        #[cfg(feature = "eval-support")]
+        let eval_cache = self.eval_cache.clone();
 
         let request_task = cx.background_spawn({
             let active_buffer = active_buffer.clone();
             async move {
+                #[cfg(feature = "eval-support")]
+                parsed_fut.await;
+
                 let index_state = if let Some(index_state) = index_state {
                     Some(index_state.lock_owned().await)
                 } else {
@@ -819,17 +842,17 @@ impl Zeta {
 
                         let included_files = included_files
                             .iter()
-                            .map(|(_, buffer, path, ranges)| {
+                            .map(|(_, snapshot, path, ranges)| {
                                 let excerpts = merge_excerpts(
-                                    &buffer,
+                                    &snapshot,
                                     ranges.iter().map(|range| {
-                                        let point_range = range.to_point(&buffer);
+                                        let point_range = range.to_point(&snapshot);
                                         Line(point_range.start.row)..Line(point_range.end.row)
                                     }),
                                 );
                                 predict_edits_v3::IncludedFile {
                                     path: path.clone(),
-                                    max_row: Line(buffer.max_point().row),
+                                    max_row: Line(snapshot.max_point().row),
                                     excerpts,
                                 }
                             })
@@ -948,8 +971,8 @@ impl Zeta {
                     client,
                     llm_token,
                     app_version,
-                    #[cfg(feature = "llm-response-cache")]
-                    llm_response_cache,
+                    #[cfg(feature = "eval-support")]
+                    eval_cache,
                 )
                 .await;
                 let request_time = chrono::Utc::now() - before_request;
@@ -1049,9 +1072,7 @@ impl Zeta {
         client: Arc<Client>,
         llm_token: LlmApiToken,
         app_version: SemanticVersion,
-        #[cfg(feature = "llm-response-cache")] llm_response_cache: Option<
-            Arc<dyn LlmResponseCache>,
-        >,
+        #[cfg(feature = "eval-support")] eval_cache: Option<Arc<dyn EvalCache>>,
     ) -> Result<(open_ai::Response, Option<EditPredictionUsage>)> {
         let url = if let Some(predict_edits_url) = PREDICT_EDITS_URL.as_ref() {
             http_client::Url::parse(&predict_edits_url)?
@@ -1061,12 +1082,20 @@ impl Zeta {
                 .build_zed_llm_url("/predict_edits/raw", &[])?
         };
 
-        #[cfg(feature = "llm-response-cache")]
-        let cache_key = if let Some(cache) = llm_response_cache {
-            let request_json = serde_json::to_string(&request)?;
-            let key = cache.get_key(&url, &request_json);
+        #[cfg(feature = "eval-support")]
+        let cache_key = if let Some(cache) = eval_cache {
+            use collections::FxHasher;
+            use std::hash::{Hash, Hasher};
 
-            if let Some(response_str) = cache.read_response(key) {
+            let mut hasher = FxHasher::default();
+            url.hash(&mut hasher);
+            let request_str = serde_json::to_string(&request)?;
+            request_str.hash(&mut hasher);
+            let key = (EvalCacheEntryKind::LlmResponse, hasher.finish());
+
+            cache.write((EvalCacheEntryKind::LlmRequest, key.1), &request_str);
+
+            if let Some(response_str) = cache.read(key) {
                 return Ok((serde_json::from_str(&response_str)?, None));
             }
 
@@ -1088,9 +1117,9 @@ impl Zeta {
         )
         .await?;
 
-        #[cfg(feature = "llm-response-cache")]
+        #[cfg(feature = "eval-support")]
         if let Some((cache, key)) = cache_key {
-            cache.write_response(key, &serde_json::to_string(&response)?);
+            cache.write(key, &serde_json::to_string(&response)?);
         }
 
         Ok((response, usage))
@@ -1361,8 +1390,8 @@ impl Zeta {
             reasoning_effort: None,
         };
 
-        #[cfg(feature = "llm-response-cache")]
-        let llm_response_cache = self.llm_response_cache.clone();
+        #[cfg(feature = "eval-support")]
+        let eval_cache = self.eval_cache.clone();
 
         cx.spawn(async move |this, cx| {
             log::trace!("Sending search planning request");
@@ -1371,8 +1400,8 @@ impl Zeta {
                 client,
                 llm_token,
                 app_version,
-                #[cfg(feature = "llm-response-cache")]
-                llm_response_cache,
+                #[cfg(feature = "eval-support")]
+                eval_cache.clone(),
             )
             .await;
             let mut response = Self::handle_api_response(&this, response, cx)?;
@@ -1421,8 +1450,14 @@ impl Zeta {
 
             log::trace!("Running retrieval search: {queries:#?}");
 
-            let related_excerpts_result =
-                retrieval_search::run_retrieval_searches(project.clone(), queries, cx).await;
+            let related_excerpts_result = retrieval_search::run_retrieval_searches(
+                queries,
+                project.clone(),
+                #[cfg(feature = "eval-support")]
+                eval_cache,
+                cx,
+            )
+            .await;
 
             log::trace!("Search queries executed");
 

--- a/crates/zeta_cli/Cargo.toml
+++ b/crates/zeta_cli/Cargo.toml
@@ -54,7 +54,7 @@ toml.workspace = true
 util.workspace = true
 watch.workspace = true
 zeta.workspace = true
-zeta2 = { workspace = true, features = ["llm-response-cache"] }
+zeta2 = { workspace = true, features = ["eval-support"] }
 zlog.workspace = true
 
 [dev-dependencies]

--- a/crates/zeta_cli/src/evaluate.rs
+++ b/crates/zeta_cli/src/evaluate.rs
@@ -14,7 +14,7 @@ use crate::{
     PromptFormat,
     example::{Example, NamedExample},
     headless::ZetaCliAppState,
-    paths::{RUN_DIR, print_run_data_dir},
+    paths::print_run_data_dir,
     predict::{CacheMode, PredictionDetails, zeta2_predict},
 };
 

--- a/crates/zeta_cli/src/evaluate.rs
+++ b/crates/zeta_cli/src/evaluate.rs
@@ -14,18 +14,18 @@ use crate::{
     PromptFormat,
     example::{Example, NamedExample},
     headless::ZetaCliAppState,
-    predict::{PredictionDetails, zeta2_predict},
+    predict::{CacheMode, PredictionDetails, zeta2_predict},
 };
 
 #[derive(Debug, Args)]
 pub struct EvaluateArguments {
     example_paths: Vec<PathBuf>,
-    #[clap(long)]
-    skip_cache: bool,
     #[arg(long, value_enum, default_value_t = PromptFormat::default())]
     prompt_format: PromptFormat,
     #[arg(long)]
     use_expected_context: bool,
+    #[clap(long, value_enum, default_value_t = CacheMode::default())]
+    cache: CacheMode,
 }
 
 pub async fn run_evaluate(
@@ -39,9 +39,9 @@ pub async fn run_evaluate(
         cx.spawn(async move |cx| {
             run_evaluate_one(
                 &path,
-                args.skip_cache,
                 args.prompt_format,
                 args.use_expected_context,
+                args.cache,
                 app_state.clone(),
                 cx,
             )
@@ -64,18 +64,18 @@ pub async fn run_evaluate(
 
 pub async fn run_evaluate_one(
     example_path: &Path,
-    skip_cache: bool,
     prompt_format: PromptFormat,
     use_expected_context: bool,
+    cache_mode: CacheMode,
     app_state: Arc<ZetaCliAppState>,
     cx: &mut AsyncApp,
 ) -> Result<EvaluationResult> {
     let example = NamedExample::load(&example_path).unwrap();
     let predictions = zeta2_predict(
         example.clone(),
-        skip_cache,
         prompt_format,
         use_expected_context,
+        cache_mode,
         &app_state,
         cx,
     )

--- a/crates/zeta_cli/src/example.rs
+++ b/crates/zeta_cli/src/example.rs
@@ -398,7 +398,7 @@ impl NamedExample {
         Ok(worktree_path)
     }
 
-    fn file_name(&self) -> String {
+    pub fn file_name(&self) -> String {
         self.name
             .chars()
             .map(|c| {

--- a/crates/zeta_cli/src/main.rs
+++ b/crates/zeta_cli/src/main.rs
@@ -54,6 +54,7 @@ enum Command {
         #[arg(long, value_enum, default_value_t = ExampleFormat::Md)]
         output_format: ExampleFormat,
     },
+    Clean,
 }
 
 #[derive(Subcommand, Debug)]
@@ -470,6 +471,7 @@ fn main() {
                     let example = NamedExample::load(path).unwrap();
                     example.write(output_format, io::stdout()).unwrap();
                 }
+                Command::Clean => std::fs::remove_dir_all(&*crate::paths::TARGET_ZETA_DIR).unwrap(),
             };
 
             let _ = cx.update(|cx| cx.quit());

--- a/crates/zeta_cli/src/paths.rs
+++ b/crates/zeta_cli/src/paths.rs
@@ -1,8 +1,7 @@
 use std::{env, path::PathBuf, sync::LazyLock};
 
 static TARGET_DIR: LazyLock<PathBuf> = LazyLock::new(|| env::current_dir().unwrap().join("target"));
-pub static CACHE_DIR: LazyLock<PathBuf> =
-    LazyLock::new(|| TARGET_DIR.join("zeta-llm-response-cache"));
+pub static CACHE_DIR: LazyLock<PathBuf> = LazyLock::new(|| TARGET_DIR.join("zeta-eval-support"));
 pub static REPOS_DIR: LazyLock<PathBuf> = LazyLock::new(|| TARGET_DIR.join("zeta-repos"));
 pub static WORKTREES_DIR: LazyLock<PathBuf> = LazyLock::new(|| TARGET_DIR.join("zeta-worktrees"));
 pub static LOGS_DIR: LazyLock<PathBuf> = LazyLock::new(|| TARGET_DIR.join("zeta-logs"));

--- a/crates/zeta_cli/src/paths.rs
+++ b/crates/zeta_cli/src/paths.rs
@@ -1,10 +1,19 @@
 use std::{env, path::PathBuf, sync::LazyLock};
 
-static TARGET_DIR: LazyLock<PathBuf> = LazyLock::new(|| env::current_dir().unwrap().join("target"));
-pub static CACHE_DIR: LazyLock<PathBuf> = LazyLock::new(|| TARGET_DIR.join("zeta-eval-support"));
-pub static REPOS_DIR: LazyLock<PathBuf> = LazyLock::new(|| TARGET_DIR.join("zeta-repos"));
-pub static WORKTREES_DIR: LazyLock<PathBuf> = LazyLock::new(|| TARGET_DIR.join("zeta-worktrees"));
-pub static LOGS_DIR: LazyLock<PathBuf> = LazyLock::new(|| TARGET_DIR.join("zeta-logs"));
+pub static TARGET_ZETA_DIR: LazyLock<PathBuf> =
+    LazyLock::new(|| env::current_dir().unwrap().join("target/zeta"));
+pub static CACHE_DIR: LazyLock<PathBuf> = LazyLock::new(|| TARGET_ZETA_DIR.join("cache"));
+pub static REPOS_DIR: LazyLock<PathBuf> = LazyLock::new(|| TARGET_ZETA_DIR.join("repos"));
+pub static WORKTREES_DIR: LazyLock<PathBuf> = LazyLock::new(|| TARGET_ZETA_DIR.join("worktrees"));
+pub static RUN_DIR: LazyLock<PathBuf> = LazyLock::new(|| {
+    TARGET_ZETA_DIR
+        .join("runs")
+        .join(chrono::Local::now().format("%Y%m%d%H%M%S").to_string())
+});
+pub static LATEST_EXAMPLE_RUN_DIR: LazyLock<PathBuf> =
+    LazyLock::new(|| TARGET_ZETA_DIR.join("latest"));
+// todo! remove
+pub static LOGS_DIR: LazyLock<PathBuf> = LazyLock::new(|| TARGET_ZETA_DIR.join("zeta-logs"));
 pub static LOGS_SEARCH_PROMPT: LazyLock<PathBuf> =
     LazyLock::new(|| LOGS_DIR.join("search_prompt.md"));
 pub static LOGS_SEARCH_QUERIES: LazyLock<PathBuf> =

--- a/crates/zeta_cli/src/paths.rs
+++ b/crates/zeta_cli/src/paths.rs
@@ -8,17 +8,33 @@ pub static WORKTREES_DIR: LazyLock<PathBuf> = LazyLock::new(|| TARGET_ZETA_DIR.j
 pub static RUN_DIR: LazyLock<PathBuf> = LazyLock::new(|| {
     TARGET_ZETA_DIR
         .join("runs")
-        .join(chrono::Local::now().format("%Y%m%d%H%M%S").to_string())
+        .join(chrono::Local::now().format("%d-%m-%y-%H_%M_%S").to_string())
 });
 pub static LATEST_EXAMPLE_RUN_DIR: LazyLock<PathBuf> =
     LazyLock::new(|| TARGET_ZETA_DIR.join("latest"));
-// todo! remove
-pub static LOGS_DIR: LazyLock<PathBuf> = LazyLock::new(|| TARGET_ZETA_DIR.join("zeta-logs"));
-pub static LOGS_SEARCH_PROMPT: LazyLock<PathBuf> =
-    LazyLock::new(|| LOGS_DIR.join("search_prompt.md"));
-pub static LOGS_SEARCH_QUERIES: LazyLock<PathBuf> =
-    LazyLock::new(|| LOGS_DIR.join("search_queries.json"));
-pub static LOGS_PREDICTION_PROMPT: LazyLock<PathBuf> =
-    LazyLock::new(|| LOGS_DIR.join("prediction_prompt.md"));
-pub static LOGS_PREDICTION_RESPONSE: LazyLock<PathBuf> =
-    LazyLock::new(|| LOGS_DIR.join("prediction_response.md"));
+
+pub fn print_run_data_dir() {
+    println!("\n## Run Data\n");
+
+    let current_dir = std::env::current_dir().unwrap();
+    for file in std::fs::read_dir(&*RUN_DIR).unwrap() {
+        let file = file.unwrap();
+        if file.file_type().unwrap().is_dir() {
+            for file in std::fs::read_dir(file.path()).unwrap() {
+                let path = file.unwrap().path();
+                let path = path.strip_prefix(&current_dir).unwrap_or(&path);
+                println!(
+                    "- {}/\x1b[34m{}\x1b[0m",
+                    path.parent().unwrap().display(),
+                    path.file_name().unwrap().display(),
+                );
+            }
+        } else {
+            let path = file.path();
+            println!(
+                "- {} ",
+                path.strip_prefix(&current_dir).unwrap_or(&path).display()
+            );
+        }
+    }
+}


### PR DESCRIPTION
- Improves the determinism of the search step for better cache reusability
- Adds a `--cache force` mode that refuses to make any requests or searches that aren't cached
- The structure of the `zeta-*` directories under `target` has been rethought for convenience 

Release Notes:

- N/A 