### PR TITLE
Revert "gpui: Fix `RefCell already borrowed` in `WindowsPlatform::run`"

### DIFF
--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -487,12 +487,14 @@ impl WindowsWindowInner {
         let scale_factor = lock.scale_factor;
         let wheel_scroll_amount = match modifiers.shift {
             true => {
-                self.system_settings()
+                self.system_settings
+                    .borrow()
                     .mouse_wheel_settings
                     .wheel_scroll_chars
             }
             false => {
-                self.system_settings()
+                self.system_settings
+                    .borrow()
                     .mouse_wheel_settings
                     .wheel_scroll_lines
             }
@@ -539,7 +541,8 @@ impl WindowsWindowInner {
         };
         let scale_factor = lock.scale_factor;
         let wheel_scroll_chars = self
-            .system_settings()
+            .system_settings
+            .borrow()
             .mouse_wheel_settings
             .wheel_scroll_chars;
         drop(lock);
@@ -674,7 +677,8 @@ impl WindowsWindowInner {
         // used by Chrome. However, it may result in one row of pixels being obscured
         // in our client area. But as Chrome says, "there seems to be no better solution."
         if is_maximized
-            && let Some(ref taskbar_position) = self.system_settings().auto_hide_taskbar_position
+            && let Some(ref taskbar_position) =
+                self.system_settings.borrow().auto_hide_taskbar_position
         {
             // For the auto-hide taskbar, adjust in by 1 pixel on taskbar edge,
             // so the window isn't treated as a "fullscreen app", which would cause
@@ -1068,7 +1072,7 @@ impl WindowsWindowInner {
             lock.border_offset.update(handle).log_err();
             // system settings may emit a window message which wants to take the refcell lock, so drop it
             drop(lock);
-            self.system_settings_mut().update(display, wparam.0);
+            self.system_settings.borrow_mut().update(display, wparam.0);
         } else {
             self.handle_system_theme_changed(handle, lparam)?;
         };

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -63,7 +63,7 @@ pub(crate) struct WindowsWindowInner {
     hwnd: HWND,
     drop_target_helper: IDropTargetHelper,
     pub(crate) state: RefCell<WindowsWindowState>,
-    system_settings: RefCell<WindowsSystemSettings>,
+    pub(crate) system_settings: RefCell<WindowsSystemSettings>,
     pub(crate) handle: AnyWindowHandle,
     pub(crate) hide_title_bar: bool,
     pub(crate) is_movable: bool,
@@ -320,14 +320,6 @@ impl WindowsWindowInner {
             },
         }
         Ok(())
-    }
-
-    pub(crate) fn system_settings(&self) -> std::cell::Ref<'_, WindowsSystemSettings> {
-        self.system_settings.borrow()
-    }
-
-    pub(crate) fn system_settings_mut(&self) -> std::cell::RefMut<'_, WindowsSystemSettings> {
-        self.system_settings.borrow_mut()
     }
 }
 


### PR DESCRIPTION
Reverts zed-industries/zed#42440

There are invalid temporaries in here keeping the borrows alive for longer