### PR TITLE
Fix panic when opening an invalid URL

### DIFF
--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -651,9 +651,12 @@ impl Platform for MacPlatform {
 
     fn open_url(&self, url: &str) {
         unsafe {
-            let url = NSURL::alloc(nil)
-                .initWithString_(ns_string(url))
-                .autorelease();
+            let ns_url = NSURL::alloc(nil).initWithString_(ns_string(url));
+            if ns_url.is_null() {
+                log::error!("Failed to create NSURL from string: {}", url);
+                return;
+            }
+            let url = ns_url.autorelease();
             let workspace: id = msg_send![class!(NSWorkspace), sharedWorkspace];
             msg_send![workspace, openURL: url]
         }

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -734,14 +734,8 @@ fn register_actions(
                     cx.open_url(parsed_url.as_str());
                 }
                 Err(e) => {
-                    workspace.show_toast(
-                        Toast::new(
-                            NotificationId::unique::<OpenBrowser>(),
-                            format!("Opening this URL in a browser failed because the URL is invalid: {}", action.url),
-                        )
-                        .autohide(),
-                        cx,
-                    );
+                    workspace
+                        .show_error(&anyhow::anyhow!("Invalid URL '{}': {}", action.url, e), cx);
                 }
             }
         })

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -734,7 +734,6 @@ fn register_actions(
                     cx.open_url(parsed_url.as_str());
                 }
                 Err(e) => {
-                    log::error!("Failed to parse URL '{}': {}", action.url, e);
                     workspace.show_toast(
                         Toast::new(
                             NotificationId::unique::<OpenBrowser>(),

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -726,7 +726,7 @@ fn register_actions(
                 ..Default::default()
             })
         })
-        .register_action(|_, action: &OpenBrowser, _window, cx| {
+        .register_action(|workspace, action: &OpenBrowser, _window, cx| {
             // Parse and validate the URL to ensure it's properly formatted
             match url::Url::parse(&action.url) {
                 Ok(parsed_url) => {
@@ -735,6 +735,14 @@ fn register_actions(
                 }
                 Err(e) => {
                     log::error!("Failed to parse URL '{}': {}", action.url, e);
+                    workspace.show_toast(
+                        Toast::new(
+                            NotificationId::unique::<OpenBrowser>(),
+                            format!("Opening this URL in a browser failed because the URL is invalid: {}", action.url),
+                        )
+                        .autohide(),
+                        cx,
+                    );
                 }
             }
         })

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -737,7 +737,7 @@ fn register_actions(
                     log::error!("Failed to parse URL '{}': {}", action.url, e);
                     workspace.show_error(
                         &anyhow::anyhow!(
-                            "Opening this URL in a browser failed because the URL is invalid: {}",
+                            "Opening this URL in a browser failed because the URL is invalid: {}\n\nError was: {e}",
                             action.url
                         ),
                         cx,

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -734,8 +734,14 @@ fn register_actions(
                     cx.open_url(parsed_url.as_str());
                 }
                 Err(e) => {
-                    workspace
-                        .show_error(&anyhow::anyhow!("Invalid URL '{}': {}", action.url, e), cx);
+                    log::error!("Failed to parse URL '{}': {}", action.url, e);
+                    workspace.show_error(
+                        &anyhow::anyhow!(
+                            "Opening this URL in a browser failed because the URL is invalid: {}",
+                            action.url
+                        ),
+                        cx,
+                    );
                 }
             }
         })

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -726,7 +726,18 @@ fn register_actions(
                 ..Default::default()
             })
         })
-        .register_action(|_, action: &OpenBrowser, _window, cx| cx.open_url(&action.url))
+        .register_action(|_, action: &OpenBrowser, _window, cx| {
+            // Parse and validate the URL to ensure it's properly formatted
+            match url::Url::parse(&action.url) {
+                Ok(parsed_url) => {
+                    // Use the parsed URL's string representation which is properly escaped
+                    cx.open_url(parsed_url.as_str());
+                }
+                Err(e) => {
+                    log::error!("Failed to parse URL '{}': {}", action.url, e);
+                }
+            }
+        })
         .register_action(|workspace, _: &workspace::Open, window, cx| {
             telemetry::event!("Project Opened");
             let paths = workspace.prompt_for_open_path(

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -734,7 +734,6 @@ fn register_actions(
                     cx.open_url(parsed_url.as_str());
                 }
                 Err(e) => {
-                    log::error!("Failed to parse URL '{}': {}", action.url, e);
                     workspace.show_error(
                         &anyhow::anyhow!(
                             "Opening this URL in a browser failed because the URL is invalid: {}\n\nError was: {e}",


### PR DESCRIPTION
Now instead of a panic we see this:

<img width="511" height="132" alt="Screenshot 2025-11-11 at 3 47 25 PM" src="https://github.com/user-attachments/assets/48ba2f41-c5c0-4030-9331-0d3acfbf9461" />


Release Notes:

- Trying to open invalid URLs in a browser now shows an error instead of panicking
