### PR TITLE
Use `enterprise_uri` for settings when provided

### DIFF
--- a/crates/copilot/src/copilot_chat.rs
+++ b/crates/copilot/src/copilot_chat.rs
@@ -44,10 +44,6 @@ impl CopilotChatConfiguration {
         }
     }
 
-    pub fn settings_url(&self) -> String {
-        Self::parse_domain(enterprise_uri).unwrap_or_else(|| "https://github.com/settings/copilot".to_string())
-    }
-
     pub fn chat_completions_url_from_endpoint(&self, endpoint: &str) -> String {
         format!("{}/chat/completions", endpoint)
     }

--- a/crates/copilot/src/copilot_chat.rs
+++ b/crates/copilot/src/copilot_chat.rs
@@ -44,6 +44,15 @@ impl CopilotChatConfiguration {
         }
     }
 
+    pub fn settings_url(&self) -> String {
+        if let Some(enterprise_uri) = &self.enterprise_uri {
+            let domain = Self::parse_domain(enterprise_uri);
+            format!("https://{}/settings/copilot", domain)
+        } else {
+            "https://github.com/settings/copilot".to_string()
+        }
+    }
+
     pub fn chat_completions_url_from_endpoint(&self, endpoint: &str) -> String {
         format!("{}/chat/completions", endpoint)
     }

--- a/crates/copilot/src/copilot_chat.rs
+++ b/crates/copilot/src/copilot_chat.rs
@@ -47,7 +47,7 @@ impl CopilotChatConfiguration {
     pub fn settings_url(&self) -> String {
         if let Some(enterprise_uri) = &self.enterprise_uri {
             let domain = Self::parse_domain(enterprise_uri);
-            format!("https://{}/settings/copilot", domain)
+            format!("https://{domain}/settings/copilot")
         } else {
             "https://github.com/settings/copilot".to_string()
         }

--- a/crates/copilot/src/copilot_chat.rs
+++ b/crates/copilot/src/copilot_chat.rs
@@ -45,12 +45,7 @@ impl CopilotChatConfiguration {
     }
 
     pub fn settings_url(&self) -> String {
-        if let Some(enterprise_uri) = &self.enterprise_uri {
-            let domain = Self::parse_domain(enterprise_uri);
-            format!("https://{domain}/settings/copilot")
-        } else {
-            "https://github.com/settings/copilot".to_string()
-        }
+        Self::parse_domain(enterprise_uri).unwrap_or_else(|| "https://github.com/settings/copilot".to_string())
     }
 
     pub fn chat_completions_url_from_endpoint(&self, endpoint: &str) -> String {

--- a/crates/edit_prediction_button/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_button/src/edit_prediction_button.rs
@@ -846,10 +846,10 @@ impl EditPredictionButton {
                 .clone(),
         };
         let settings_url = match Self::parse_domain(enterprise_uri) {
-          Some(uri) => {
-            format!("{}/{COPILOT_SETTINGS_PATH}", uri.trim_end_matches('/'))
-          }
-          None => COPILOT_SETTINGS_URL.to_string(),
+            Some(uri) => {
+                format!("{}/{COPILOT_SETTINGS_PATH}", uri.trim_end_matches('/'))
+            }
+            None => COPILOT_SETTINGS_URL.to_string(),
         };
 
         ContextMenu::build(window, cx, |menu, window, cx| {

--- a/crates/edit_prediction_button/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_button/src/edit_prediction_button.rs
@@ -44,7 +44,7 @@ actions!(
 );
 
 const COPILOT_SETTINGS_PATH: &str = "/settings/copilot";
-const COPILOT_SETTINGS_URL: &str = "https://github.com/settings/copilot";
+const COPILOT_SETTINGS_URL: &str = concat!("https://github.com", "/settings/copilot");
 const PRIVACY_DOCS: &str = "https://zed.dev/docs/ai/privacy-and-security";
 
 struct CopilotErrorToast;

--- a/crates/edit_prediction_button/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_button/src/edit_prediction_button.rs
@@ -43,7 +43,6 @@ actions!(
     ]
 );
 
-const COPILOT_SETTINGS_URL: &str = "https://github.com/settings/copilot";
 const PRIVACY_DOCS: &str = "https://zed.dev/docs/ai/privacy-and-security";
 
 struct CopilotErrorToast;
@@ -836,6 +835,12 @@ impl EditPredictionButton {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Entity<ContextMenu> {
+        let all_language_settings = all_language_settings(None, cx);
+        let copilot_config = copilot::copilot_chat::CopilotChatConfiguration {
+            enterprise_uri: all_language_settings.edit_predictions.copilot.enterprise_uri.clone(),
+        };
+        let settings_url = copilot_config.settings_url();
+
         ContextMenu::build(window, cx, |menu, window, cx| {
             let menu = self.build_language_settings_menu(menu, window, cx);
             let menu =
@@ -845,7 +850,7 @@ impl EditPredictionButton {
                 .link(
                     "Go to Copilot Settings",
                     OpenBrowser {
-                        url: COPILOT_SETTINGS_URL.to_string(),
+                        url: settings_url,
                     }
                     .boxed_clone(),
                 )

--- a/crates/edit_prediction_button/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_button/src/edit_prediction_button.rs
@@ -1229,9 +1229,7 @@ mod tests {
     }
 
     #[gpui::test]
-    async fn test_copilot_settings_url_with_enterprise_uri_trailing_slash(
-        cx: &mut TestAppContext,
-    ) {
+    async fn test_copilot_settings_url_with_enterprise_uri_trailing_slash(cx: &mut TestAppContext) {
         cx.update(|cx| {
             let settings_store = SettingsStore::test(cx);
             cx.set_global(settings_store);

--- a/crates/edit_prediction_button/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_button/src/edit_prediction_button.rs
@@ -44,7 +44,7 @@ actions!(
 );
 
 const COPILOT_SETTINGS_PATH: &str = "/settings/copilot";
-const COPILOT_SETTINGS_URL: &str = concat!("https://github.com", COPILOT_SETTINGS_PATH);
+const COPILOT_SETTINGS_URL: &str = "https://github.com/settings/copilot";
 const PRIVACY_DOCS: &str = "https://zed.dev/docs/ai/privacy-and-security";
 
 struct CopilotErrorToast;

--- a/crates/edit_prediction_button/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_button/src/edit_prediction_button.rs
@@ -1193,3 +1193,28 @@ fn copilot_settings_url(enterprise_uri: Option<&str>) -> String {
         None => COPILOT_SETTINGS_URL.to_string(),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[gpui::test]
+    fn test_copilot_settings_url_with_enterprise_uri() {
+        let enterprise_uri = Some("https://my-company.ghe.com");
+        let url = copilot_settings_url(enterprise_uri);
+        assert_eq!(url, "https://my-company.ghe.com/settings/copilot");
+    }
+
+    #[gpui::test]
+    fn test_copilot_settings_url_with_enterprise_uri_trailing_slash() {
+        let enterprise_uri = Some("https://my-company.ghe.com/");
+        let url = copilot_settings_url(enterprise_uri);
+        assert_eq!(url, "https://my-company.ghe.com/settings/copilot");
+    }
+
+    #[gpui::test]
+    fn test_copilot_settings_url_without_enterprise_uri() {
+        let url = copilot_settings_url(None);
+        assert_eq!(url, "https://github.com/settings/copilot");
+    }
+}

--- a/crates/edit_prediction_button/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_button/src/edit_prediction_button.rs
@@ -43,6 +43,7 @@ actions!(
     ]
 );
 
+const COPILOT_SETTINGS_URL: &str = "https://github.com/settings/copilot";
 const PRIVACY_DOCS: &str = "https://zed.dev/docs/ai/privacy-and-security";
 
 struct CopilotErrorToast;
@@ -839,7 +840,7 @@ impl EditPredictionButton {
         let copilot_config = copilot::copilot_chat::CopilotChatConfiguration {
             enterprise_uri: all_language_settings.edit_predictions.copilot.enterprise_uri.clone(),
         };
-        let settings_url = Self::parse_domain(enterprise_uri).unwrap_or_else(|| "https://github.com/settings/copilot".to_string());
+        let settings_url = Self::parse_domain(enterprise_uri).unwrap_or_else(|| COPILOT_SETTINGS_URL.to_string());
 
         ContextMenu::build(window, cx, |menu, window, cx| {
             let menu = self.build_language_settings_menu(menu, window, cx);

--- a/crates/edit_prediction_button/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_button/src/edit_prediction_button.rs
@@ -839,7 +839,7 @@ impl EditPredictionButton {
         let copilot_config = copilot::copilot_chat::CopilotChatConfiguration {
             enterprise_uri: all_language_settings.edit_predictions.copilot.enterprise_uri.clone(),
         };
-        let settings_url = copilot_config.settings_url();
+        let settings_url = Self::parse_domain(enterprise_uri).unwrap_or_else(|| "https://github.com/settings/copilot".to_string());
 
         ContextMenu::build(window, cx, |menu, window, cx| {
             let menu = self.build_language_settings_menu(menu, window, cx);

--- a/crates/edit_prediction_button/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_button/src/edit_prediction_button.rs
@@ -837,17 +837,16 @@ impl EditPredictionButton {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Entity<ContextMenu> {
-        let all_language_settings = all_language_settings(None, cx);
-        let copilot_config = copilot::copilot_chat::CopilotChatConfiguration {
-            enterprise_uri: all_language_settings
-                .edit_predictions
-                .copilot
-                .enterprise_uri
-                .clone(),
-        };
-        let settings_url = copilot_settings_url(copilot_config.enterprise_uri.as_deref());
-
         ContextMenu::build(window, cx, |menu, window, cx| {
+            let all_language_settings = all_language_settings(None, cx);
+            let settings_url = copilot_settings_url(
+                all_language_settings
+                    .edit_predictions
+                    .copilot
+                    .enterprise_uri
+                    .as_deref(),
+            );
+
             let menu = self.build_language_settings_menu(menu, window, cx);
             let menu =
                 self.add_provider_switching_section(menu, EditPredictionProvider::Copilot, cx);

--- a/crates/edit_prediction_button/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_button/src/edit_prediction_button.rs
@@ -837,16 +837,17 @@ impl EditPredictionButton {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Entity<ContextMenu> {
-        ContextMenu::build(window, cx, |menu, window, cx| {
-            let all_language_settings = all_language_settings(None, cx);
-            let settings_url = copilot_settings_url(
-                all_language_settings
-                    .edit_predictions
-                    .copilot
-                    .enterprise_uri
-                    .as_deref(),
-            );
+        let all_language_settings = all_language_settings(None, cx);
+        let copilot_config = copilot::copilot_chat::CopilotChatConfiguration {
+            enterprise_uri: all_language_settings
+                .edit_predictions
+                .copilot
+                .enterprise_uri
+                .clone(),
+        };
+        let settings_url = copilot_settings_url(copilot_config.enterprise_uri.as_deref());
 
+        ContextMenu::build(window, cx, |menu, window, cx| {
             let menu = self.build_language_settings_menu(menu, window, cx);
             let menu =
                 self.add_provider_switching_section(menu, EditPredictionProvider::Copilot, cx);

--- a/crates/edit_prediction_button/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_button/src/edit_prediction_button.rs
@@ -845,7 +845,7 @@ impl EditPredictionButton {
                 .enterprise_uri
                 .clone(),
         };
-        let settings_url = match Self::parse_domain(enterprise_uri) {
+        let settings_url = match enterprise_uri {
             Some(uri) => {
                 format!("{}/{COPILOT_SETTINGS_PATH}", uri.trim_end_matches('/'))
             }

--- a/crates/edit_prediction_button/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_button/src/edit_prediction_button.rs
@@ -1197,24 +1197,88 @@ fn copilot_settings_url(enterprise_uri: Option<&str>) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use gpui::TestAppContext;
 
     #[gpui::test]
-    fn test_copilot_settings_url_with_enterprise_uri() {
-        let enterprise_uri = Some("https://my-company.ghe.com");
-        let url = copilot_settings_url(enterprise_uri);
+    async fn test_copilot_settings_url_with_enterprise_uri(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            let settings_store = SettingsStore::test(cx);
+            cx.set_global(settings_store);
+        });
+
+        cx.update_global(|settings_store: &mut SettingsStore, cx| {
+            settings_store
+                .set_user_settings(
+                    r#"{"edit_predictions":{"copilot":{"enterprise_uri":"https://my-company.ghe.com"}}}"#,
+                    cx,
+                )
+                .unwrap();
+        });
+
+        let url = cx.update(|cx| {
+            let all_language_settings = all_language_settings(None, cx);
+            copilot_settings_url(
+                all_language_settings
+                    .edit_predictions
+                    .copilot
+                    .enterprise_uri
+                    .as_deref(),
+            )
+        });
+
         assert_eq!(url, "https://my-company.ghe.com/settings/copilot");
     }
 
     #[gpui::test]
-    fn test_copilot_settings_url_with_enterprise_uri_trailing_slash() {
-        let enterprise_uri = Some("https://my-company.ghe.com/");
-        let url = copilot_settings_url(enterprise_uri);
+    async fn test_copilot_settings_url_with_enterprise_uri_trailing_slash(
+        cx: &mut TestAppContext,
+    ) {
+        cx.update(|cx| {
+            let settings_store = SettingsStore::test(cx);
+            cx.set_global(settings_store);
+        });
+
+        cx.update_global(|settings_store: &mut SettingsStore, cx| {
+            settings_store
+                .set_user_settings(
+                    r#"{"edit_predictions":{"copilot":{"enterprise_uri":"https://my-company.ghe.com/"}}}"#,
+                    cx,
+                )
+                .unwrap();
+        });
+
+        let url = cx.update(|cx| {
+            let all_language_settings = all_language_settings(None, cx);
+            copilot_settings_url(
+                all_language_settings
+                    .edit_predictions
+                    .copilot
+                    .enterprise_uri
+                    .as_deref(),
+            )
+        });
+
         assert_eq!(url, "https://my-company.ghe.com/settings/copilot");
     }
 
     #[gpui::test]
-    fn test_copilot_settings_url_without_enterprise_uri() {
-        let url = copilot_settings_url(None);
+    async fn test_copilot_settings_url_without_enterprise_uri(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            let settings_store = SettingsStore::test(cx);
+            cx.set_global(settings_store);
+        });
+
+        let url = cx.update(|cx| {
+            let all_language_settings = all_language_settings(None, cx);
+            copilot_settings_url(
+                all_language_settings
+                    .edit_predictions
+                    .copilot
+                    .enterprise_uri
+                    .as_deref(),
+            )
+        });
+
         assert_eq!(url, "https://github.com/settings/copilot");
     }
 }

--- a/crates/edit_prediction_button/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_button/src/edit_prediction_button.rs
@@ -845,12 +845,7 @@ impl EditPredictionButton {
                 .enterprise_uri
                 .clone(),
         };
-        let settings_url = match enterprise_uri {
-            Some(uri) => {
-                format!("{}/{COPILOT_SETTINGS_PATH}", uri.trim_end_matches('/'))
-            }
-            None => COPILOT_SETTINGS_URL.to_string(),
-        };
+        let settings_url = copilot_settings_url(copilot_config.enterprise_uri.as_deref());
 
         ContextMenu::build(window, cx, |menu, window, cx| {
             let menu = self.build_language_settings_menu(menu, window, cx);
@@ -1187,5 +1182,14 @@ fn toggle_edit_prediction_mode(fs: Arc<dyn Fs>, mode: EditPredictionsMode, cx: &
                     });
             }
         });
+    }
+}
+
+fn copilot_settings_url(enterprise_uri: Option<&str>) -> String {
+    match enterprise_uri {
+        Some(uri) => {
+            format!("{}{}", uri.trim_end_matches('/'), COPILOT_SETTINGS_PATH)
+        }
+        None => COPILOT_SETTINGS_URL.to_string(),
     }
 }


### PR DESCRIPTION
Closes #34945

Release Notes:

- Fixed `enterprise_uri` not being used for GitHub settings URL when provided
