### PR TITLE
zed: Enable line wrapping for cli help

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -482,7 +482,7 @@ cfg-if = "1.0.3"
 chrono = { version = "0.4", features = ["serde"] }
 ciborium = "0.2"
 circular-buffer = "1.0"
-clap = { version = "4.4", features = ["derive"] }
+clap = { version = "4.4", features = ["derive", "wrap_help"] }
 cocoa = "=0.26.0"
 cocoa-foundation = "=0.2.0"
 convert_case = "0.8.0"

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -1237,7 +1237,7 @@ pub fn stdout_is_a_pty() -> bool {
 }
 
 #[derive(Parser, Debug)]
-#[command(name = "zed", disable_version_flag = true)]
+#[command(name = "zed", disable_version_flag = true, max_term_width = 100)]
 struct Args {
     /// A sequence of space-separated paths or urls that you want to open.
     ///
@@ -1252,11 +1252,12 @@ struct Args {
     diff: Vec<String>,
 
     /// Sets a custom directory for all user data (e.g., database, extensions, logs).
+    ///
     /// This overrides the default platform-specific data directory location.
     /// On macOS, the default is `~/Library/Application Support/Zed`.
     /// On Linux/FreeBSD, the default is `$XDG_DATA_HOME/zed`.
     /// On Windows, the default is `%LOCALAPPDATA%\Zed`.
-    #[arg(long, value_name = "DIR")]
+    #[arg(long, value_name = "DIR", verbatim_doc_comment)]
     user_data_dir: Option<String>,
 
     /// The username and WSL distribution to use when opening paths. If not specified,
@@ -1276,8 +1277,11 @@ struct Args {
     #[arg(long)]
     dev_server_token: Option<String>,
 
-    /// Prints system specs. Useful for submitting issues on GitHub when encountering a bug
-    /// that prevents Zed from starting, so you can't run `zed: copy system specs to clipboard`
+    /// Prints system specs.
+    ///
+    /// Useful for submitting issues on GitHub when encountering a bug that
+    /// prevents Zed from starting, so you can't run `zed: copy system specs to
+    /// clipboard`
     #[arg(long)]
     system_specs: bool,
 


### PR DESCRIPTION
This enables clap's [wrap-help] feature and sets max_term_width to wrap after 100 columns (the value clap is planning to default to in clap-v5).

This commit also adds blank lines which cause clap to split longer doc comments into separate help (displayed for `-h`) and long_help (displayed for `--help`) messages, as per [doc-processing].

[wrap-help]: https://docs.rs/clap/4.5.49/clap/_features/index.html#optional-features
[doc-processing]: https://docs.rs/clap/4.5.49/clap/_derive/index.html#pre-processing

![before: some lines of help text stretch across the whole screen. after: all lines are wrapped at 100 columns, and some manual linebreaks are preserved where it makes sense (in particular, when listing the user-data-dir locations on each platform)](https://github.com/user-attachments/assets/359067b4-5ffb-4fe3-80bd-5e1062986417)


Release Notes:

- N/A
