### PR TITLE
docs: Update basedpyright settings examples

### DIFF
--- a/docs/src/languages/python.md
+++ b/docs/src/languages/python.md
@@ -128,9 +128,11 @@ You can use the following configuration:
   "lsp": {
     "basedpyright": {
       "settings": {
-        "analysis": {
+        "basedpyright.analysis": {
           "diagnosticMode": "workspace",
-          "inlayHints.callArgumentNames": false
+          "inlayHints": {
+            "callArgumentNames": false
+          }
         }
       }
     }


### PR DESCRIPTION
The [example](https://docs.basedpyright.com/latest/configuration/language-server-settings/#zed) on the official website of basedpyright is correct.

Release Notes:

- Update basedpyright settings examples