### PR TITLE
agent_ui: Fix scrolling in context server configuration modal

### DIFF
--- a/crates/agent_ui/src/agent_configuration/configure_context_server_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/configure_context_server_modal.rs
@@ -711,7 +711,7 @@ impl Render for ConfigureContextServerModal {
                         Section::new().child(
                             div()
                                 .id("modal-content")
-                                .max_h(rems(40.))
+                                .max_h(vh(0.7, window))
                                 .child(self.render_modal_description(window, cx))
                                 .child(self.render_modal_content(cx))
                                 .child(match &self.state {

--- a/crates/agent_ui/src/agent_configuration/configure_context_server_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/configure_context_server_modal.rs
@@ -253,7 +253,7 @@ pub struct ConfigureContextServerModal {
     source: ConfigurationSource,
     state: State,
     original_server_id: Option<ContextServerId>,
-    scroll_handle: Option<ScrollHandle>,
+    scroll_handle: ScrollHandle,
 }
 
 impl ConfigureContextServerModal {
@@ -363,7 +363,7 @@ impl ConfigureContextServerModal {
                         window,
                         cx,
                     ),
-                    scroll_handle: None,
+                    scroll_handle: ScrollHandle::new(),
                 })
             })
         })
@@ -683,15 +683,10 @@ impl ConfigureContextServerModal {
 
 impl Render for ConfigureContextServerModal {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        // Lazily initialize scroll handle only when rendering
-        if self.scroll_handle.is_none() {
-            self.scroll_handle = Some(ScrollHandle::new());
-        }
-        let scroll_handle = self.scroll_handle.as_ref().unwrap().clone();
-
+        let scroll_handle = self.scroll_handle.clone();
         div()
             .elevation_3(cx)
-            .max_w(rems(34.))
+            .w(rems(34.))
             .key_context("ConfigureContextServerModal")
             .on_action(
                 cx.listener(|this, _: &menu::Cancel, _window, cx| this.cancel(&menu::Cancel, cx)),

--- a/crates/agent_ui/src/agent_configuration/configure_context_server_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/configure_context_server_modal.rs
@@ -23,7 +23,8 @@ use project::{
 use settings::{Settings as _, update_settings_file};
 use theme::ThemeSettings;
 use ui::{
-    CommonAnimationExt, KeyBinding, Modal, ModalFooter, ModalHeader, Section, Tooltip, prelude::*,
+    CommonAnimationExt, KeyBinding, Modal, ModalFooter, ModalHeader, Section, Tooltip,
+    WithScrollbar, prelude::*,
 };
 use util::ResultExt as _;
 use workspace::{ModalView, Workspace};
@@ -513,10 +514,18 @@ impl ConfigureContextServerModal {
             div()
                 .pb_2()
                 .text_sm()
-                .child(MarkdownElement::new(
-                    installation_instructions.clone(),
-                    default_markdown_style(window, cx),
-                ))
+                .child(
+                    div()
+                        .id("installation_instructions")
+                        .max_h_96()
+                        .overflow_y_scroll()
+                        .track_scroll(&self.scroll_handle)
+                        .child(MarkdownElement::new(
+                            installation_instructions.clone(),
+                            default_markdown_style(window, cx),
+                        ))
+                )
+                .vertical_scrollbar_for(self.scroll_handle.clone(), window, cx)
                 .into_any_element()
         } else {
             Label::new(MODAL_DESCRIPTION)
@@ -698,7 +707,7 @@ impl Render for ConfigureContextServerModal {
                 this.focus_handle(cx).focus(window);
             }))
             .child(
-                Modal::new("configure-context-server", Some(self.scroll_handle.clone()))
+                Modal::new("configure-context-server", None)
                     .header(self.render_modal_header())
                     .section(
                         Section::new()

--- a/crates/agent_ui/src/agent_configuration/configure_context_server_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/configure_context_server_modal.rs
@@ -7,8 +7,8 @@ use anyhow::{Context as _, Result};
 use context_server::{ContextServerCommand, ContextServerId};
 use editor::{Editor, EditorElement, EditorStyle};
 use gpui::{
-    AsyncWindowContext, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable, ScrollHandle,
-    Task, TextStyle, TextStyleRefinement, UnderlineStyle, WeakEntity, prelude::*,
+    AsyncWindowContext, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable, Task,
+    TextStyle, TextStyleRefinement, UnderlineStyle, WeakEntity, prelude::*,
 };
 use language::{Language, LanguageRegistry};
 use markdown::{Markdown, MarkdownElement, MarkdownStyle};
@@ -252,7 +252,6 @@ pub struct ConfigureContextServerModal {
     source: ConfigurationSource,
     state: State,
     original_server_id: Option<ContextServerId>,
-    scroll_handle: ScrollHandle,
 }
 
 impl ConfigureContextServerModal {
@@ -362,7 +361,6 @@ impl ConfigureContextServerModal {
                         window,
                         cx,
                     ),
-                    scroll_handle: ScrollHandle::new(),
                 })
             })
         })
@@ -698,7 +696,7 @@ impl Render for ConfigureContextServerModal {
                 this.focus_handle(cx).focus(window);
             }))
             .child(
-                Modal::new("configure-context-server", Some(self.scroll_handle.clone()))
+                Modal::new("configure-context-server", None)
                     .header(self.render_modal_header())
                     .section(
                         Section::new()

--- a/crates/agent_ui/src/agent_configuration/configure_context_server_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/configure_context_server_modal.rs
@@ -23,8 +23,8 @@ use project::{
 use settings::{Settings as _, update_settings_file};
 use theme::ThemeSettings;
 use ui::{
-    CommonAnimationExt, KeyBinding, Modal, ModalFooter, ModalHeader, ScrollAxes, Scrollbars,
-    Section, Tooltip, WithScrollbar, prelude::*,
+    CommonAnimationExt, KeyBinding, Modal, ModalFooter, ModalHeader, Section, Tooltip,
+    WithScrollbar, prelude::*,
 };
 use util::ResultExt as _;
 use workspace::{ModalView, Workspace};
@@ -712,6 +712,8 @@ impl Render for ConfigureContextServerModal {
                             div()
                                 .id("modal-content")
                                 .max_h(vh(0.7, window))
+                                .overflow_y_scroll()
+                                .track_scroll(&scroll_handle)
                                 .child(self.render_modal_description(window, cx))
                                 .child(self.render_modal_content(cx))
                                 .child(match &self.state {
@@ -719,16 +721,7 @@ impl Render for ConfigureContextServerModal {
                                     State::Waiting => Self::render_waiting_for_context_server(),
                                     State::Error(error) => Self::render_modal_error(error.clone()),
                                 })
-                                .custom_scrollbars(
-                                    Scrollbars::new(ScrollAxes::Vertical)
-                                        .tracked_scroll_handle(scroll_handle)
-                                        .with_track_along(
-                                            ScrollAxes::Vertical,
-                                            cx.theme().colors().panel_background,
-                                        ),
-                                    window,
-                                    cx,
-                                ),
+                                .vertical_scrollbar_for(scroll_handle, window, cx),
                         ),
                     )
                     .footer(self.render_modal_footer(cx)),

--- a/crates/agent_ui/src/agent_configuration/configure_context_server_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/configure_context_server_modal.rs
@@ -7,8 +7,8 @@ use anyhow::{Context as _, Result};
 use context_server::{ContextServerCommand, ContextServerId};
 use editor::{Editor, EditorElement, EditorStyle};
 use gpui::{
-    AsyncWindowContext, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable, Task,
-    TextStyle, TextStyleRefinement, UnderlineStyle, WeakEntity, prelude::*,
+    AsyncWindowContext, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable, ScrollHandle,
+    Task, TextStyle, TextStyleRefinement, UnderlineStyle, WeakEntity, prelude::*,
 };
 use language::{Language, LanguageRegistry};
 use markdown::{Markdown, MarkdownElement, MarkdownStyle};
@@ -252,6 +252,7 @@ pub struct ConfigureContextServerModal {
     source: ConfigurationSource,
     state: State,
     original_server_id: Option<ContextServerId>,
+    scroll_handle: ScrollHandle,
 }
 
 impl ConfigureContextServerModal {
@@ -361,6 +362,7 @@ impl ConfigureContextServerModal {
                         window,
                         cx,
                     ),
+                    scroll_handle: ScrollHandle::new(),
                 })
             })
         })
@@ -696,7 +698,7 @@ impl Render for ConfigureContextServerModal {
                 this.focus_handle(cx).focus(window);
             }))
             .child(
-                Modal::new("configure-context-server", None)
+                Modal::new("configure-context-server", Some(self.scroll_handle.clone()))
                     .header(self.render_modal_header())
                     .section(
                         Section::new()

--- a/crates/agent_ui/src/agent_configuration/configure_context_server_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/configure_context_server_modal.rs
@@ -23,8 +23,7 @@ use project::{
 use settings::{Settings as _, update_settings_file};
 use theme::ThemeSettings;
 use ui::{
-    CommonAnimationExt, KeyBinding, Modal, ModalFooter, ModalHeader, Section, Tooltip,
-    WithScrollbar, prelude::*,
+    CommonAnimationExt, KeyBinding, Modal, ModalFooter, ModalHeader, Section, Tooltip, prelude::*,
 };
 use util::ResultExt as _;
 use workspace::{ModalView, Workspace};
@@ -514,18 +513,10 @@ impl ConfigureContextServerModal {
             div()
                 .pb_2()
                 .text_sm()
-                .child(
-                    div()
-                        .id("installation_instructions")
-                        .max_h_96()
-                        .overflow_y_scroll()
-                        .track_scroll(&self.scroll_handle)
-                        .child(MarkdownElement::new(
-                            installation_instructions.clone(),
-                            default_markdown_style(window, cx),
-                        ))
-                )
-                .vertical_scrollbar_for(self.scroll_handle.clone(), window, cx)
+                .child(MarkdownElement::new(
+                    installation_instructions.clone(),
+                    default_markdown_style(window, cx),
+                ))
                 .into_any_element()
         } else {
             Label::new(MODAL_DESCRIPTION)
@@ -707,7 +698,7 @@ impl Render for ConfigureContextServerModal {
                 this.focus_handle(cx).focus(window);
             }))
             .child(
-                Modal::new("configure-context-server", None)
+                Modal::new("configure-context-server", Some(self.scroll_handle.clone()))
                     .header(self.render_modal_header())
                     .section(
                         Section::new()

--- a/crates/agent_ui/src/agent_configuration/configure_context_server_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/configure_context_server_modal.rs
@@ -710,17 +710,25 @@ impl Render for ConfigureContextServerModal {
                     .section(
                         Section::new().child(
                             div()
-                                .id("modal-content")
-                                .max_h(vh(0.7, window))
-                                .overflow_y_scroll()
-                                .track_scroll(&scroll_handle)
-                                .child(self.render_modal_description(window, cx))
-                                .child(self.render_modal_content(cx))
-                                .child(match &self.state {
-                                    State::Idle => div(),
-                                    State::Waiting => Self::render_waiting_for_context_server(),
-                                    State::Error(error) => Self::render_modal_error(error.clone()),
-                                })
+                                .size_full()
+                                .child(
+                                    div()
+                                        .id("modal-content")
+                                        .max_h(vh(0.7, window))
+                                        .overflow_y_scroll()
+                                        .track_scroll(&scroll_handle)
+                                        .child(self.render_modal_description(window, cx))
+                                        .child(self.render_modal_content(cx))
+                                        .child(match &self.state {
+                                            State::Idle => div(),
+                                            State::Waiting => {
+                                                Self::render_waiting_for_context_server()
+                                            }
+                                            State::Error(error) => {
+                                                Self::render_modal_error(error.clone())
+                                            }
+                                        }),
+                                )
                                 .vertical_scrollbar_for(scroll_handle, window, cx),
                         ),
                     )

--- a/crates/agent_ui/src/agent_configuration/configure_context_server_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/configure_context_server_modal.rs
@@ -23,8 +23,8 @@ use project::{
 use settings::{Settings as _, update_settings_file};
 use theme::ThemeSettings;
 use ui::{
-    CommonAnimationExt, KeyBinding, Modal, ModalFooter, ModalHeader, Section, Tooltip,
-    WithScrollbar, prelude::*,
+    CommonAnimationExt, KeyBinding, Modal, ModalFooter, ModalHeader, ScrollAxes, Scrollbars,
+    Section, Tooltip, WithScrollbar, prelude::*,
 };
 use util::ResultExt as _;
 use workspace::{ModalView, Workspace};
@@ -691,7 +691,7 @@ impl Render for ConfigureContextServerModal {
 
         div()
             .elevation_3(cx)
-            .w(rems(34.))
+            .max_w(rems(34.))
             .key_context("ConfigureContextServerModal")
             .on_action(
                 cx.listener(|this, _: &menu::Cancel, _window, cx| this.cancel(&menu::Cancel, cx)),
@@ -712,8 +712,6 @@ impl Render for ConfigureContextServerModal {
                             div()
                                 .id("modal-content")
                                 .max_h(rems(40.))
-                                .overflow_y_scroll()
-                                .track_scroll(&scroll_handle)
                                 .child(self.render_modal_description(window, cx))
                                 .child(self.render_modal_content(cx))
                                 .child(match &self.state {
@@ -721,7 +719,16 @@ impl Render for ConfigureContextServerModal {
                                     State::Waiting => Self::render_waiting_for_context_server(),
                                     State::Error(error) => Self::render_modal_error(error.clone()),
                                 })
-                                .vertical_scrollbar_for(scroll_handle, window, cx),
+                                .custom_scrollbars(
+                                    Scrollbars::new(ScrollAxes::Vertical)
+                                        .tracked_scroll_handle(scroll_handle)
+                                        .with_track_along(
+                                            ScrollAxes::Vertical,
+                                            cx.theme().colors().panel_background,
+                                        ),
+                                    window,
+                                    cx,
+                                ),
                         ),
                     )
                     .footer(self.render_modal_footer(cx)),


### PR DESCRIPTION
## Summary

Fixes #42342

When installing a dev extension with long installation instructions, the configuration modal would overflow and users couldn't scroll to see the full content or interact with buttons at the bottom.

## Solution

This PR adds a `ScrollHandle` to the `ConfigureContextServerModal` and passes it to the `Modal` component, enabling the built-in modal scrolling capability. This ensures all content remains accessible regardless of length.

## Changes

- Added `ScrollHandle` import to the ui imports
- Added `scroll_handle: ScrollHandle` field to `ConfigureContextServerModal` struct  
- Initialize `scroll_handle` with `ScrollHandle::new()` when creating the modal
- Pass the scroll handle to `Modal::new()` instead of `None`

## Testing

- Built the changes locally
- Tested with extensions that have long installation instructions
- Verified scrolling works and all content is accessible
- Confirmed no regression for extensions with short descriptions

Release Notes:

- Fixed scrolling issue in extension configuration modal when installation instructions overflow the viewport