### PR TITLE
vim: Move to opening html tag from / in closing tag

### DIFF
--- a/crates/vim/test_data/test_matching_tags.json
+++ b/crates/vim/test_data/test_matching_tags.json
@@ -13,3 +13,8 @@
 {"Put":{"state":"<a>\n    <br\n        test = \"test\"\n    /ˇ>\n</a>"}}
 {"Key":"%"}
 {"Get":{"state":"<a>\n    ˇ<br\n        test = \"test\"\n    />\n</a>","mode":"Normal"}}
+{"Put":{"state":"<html>\n    <bˇody>\n    </body>\n</html>"}}
+{"Key":"%"}
+{"Get":{"state":"<html>\n    <body>\n    <ˇ/body>\n</html>","mode":"Normal"}}
+{"Key":"%"}
+{"Get":{"state":"<html>\n    <ˇbody>\n    </body>\n</html>","mode":"Normal"}}


### PR DESCRIPTION
Closes #41582

Release Notes:

- Improves the '%' vim motion for html by moving the cursor to the opening tag when its positioned on the `/` ( slash ) of the closing tag
