### PR TITLE
Stop thread on Restore Checkpoint

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -3989,7 +3989,7 @@ mod tests {
             "Should have 1 entry after restore (only the first user message)"
         );
 
-        // BUG REPRODUCTION: The terminal still exists after checkpoint restore
+        // The terminal should no longer exist after checkpoint restore
         let terminal_exists_after =
             thread.read_with(cx, |thread, _| thread.terminals.contains_key(&terminal_id));
 

--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -3997,21 +3997,5 @@ mod tests {
             !terminal_exists_after,
             "Terminal should have been removed after checkpoint restore"
         );
-
-        // Additionally, if the terminal still exists, it should at least be killed
-        if terminal_exists_after {
-            let terminal_killed = thread.read_with(cx, |thread, _cx| {
-                let terminal_entity = thread.terminals.get(&terminal_id).unwrap();
-                terminal_entity.read_with(cx, |term, _cx| {
-                    // Check if the underlying terminal task was killed
-                    // If output exists, the task completed; if None, it's still running
-                    term.output().is_some()
-                })
-            });
-            assert!(
-                terminal_killed,
-                "If terminal still exists, it should at least be killed (BUG: it's still running)"
-            );
-        }
     }
 }

--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -3996,7 +3996,7 @@ mod tests {
         // This assertion demonstrates the bug - it should be false but is true
         assert!(
             !terminal_exists_after,
-            "Terminal should be removed after checkpoint restore (BUG: it still exists)"
+            "Terminal should have been removed after checkpoint restore"
         );
 
         // Additionally, if the terminal still exists, it should at least be killed

--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -1898,25 +1898,9 @@ impl AcpThread {
             cx.update(|cx| truncate.run(id.clone(), cx))?.await?;
             this.update(cx, |this, cx| {
                 if let Some((ix, _)) = this.user_message_mut(&id) {
-                    // Collect all terminals from entries that will be removed
-                    let terminals_to_remove: Vec<acp::TerminalId> = this.entries[ix..]
-                        .iter()
-                        .flat_map(|entry| entry.terminals())
-                        .filter_map(|terminal| terminal.read(cx).id().clone().into())
-                        .collect();
-
                     let range = ix..this.entries.len();
                     this.entries.truncate(ix);
                     cx.emit(AcpThreadEvent::EntriesRemoved(range));
-
-                    // Kill and remove the terminals
-                    for terminal_id in terminals_to_remove {
-                        if let Some(terminal) = this.terminals.remove(&terminal_id) {
-                            terminal.update(cx, |terminal, cx| {
-                                terminal.kill(cx);
-                            });
-                        }
-                    }
                 }
                 this.action_log().update(cx, |action_log, cx| {
                     action_log.reject_all_edits(Some(telemetry), cx)

--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -3989,13 +3989,11 @@ mod tests {
             "Should have 1 entry after restore (only the first user message)"
         );
 
-        // The terminal should no longer exist after checkpoint restore
-        let terminal_exists_after =
-            thread.read_with(cx, |thread, _| thread.terminals.contains_key(&terminal_id));
-
-        assert!(
-            !terminal_exists_after,
-            "Terminal should have been removed after checkpoint restore"
+        // Verify no terminals are running after checkpoint restore
+        let terminal_count = thread.read_with(cx, |thread, _| thread.terminals.len());
+        assert_eq!(
+            terminal_count, 0,
+            "No terminals should be running after checkpoint restore"
         );
     }
 }

--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -3993,7 +3993,6 @@ mod tests {
         let terminal_exists_after =
             thread.read_with(cx, |thread, _| thread.terminals.contains_key(&terminal_id));
 
-        // This assertion demonstrates the bug - it should be false but is true
         assert!(
             !terminal_exists_after,
             "Terminal should have been removed after checkpoint restore"

--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -3912,7 +3912,7 @@ mod tests {
         });
 
         // Create a tool call entry that references this terminal
-        // This represents the AI agent requesting a terminal command
+        // This represents the agent requesting a terminal command
         thread.update(cx, |thread, cx| {
             thread
                 .handle_session_update(

--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -1898,9 +1898,25 @@ impl AcpThread {
             cx.update(|cx| truncate.run(id.clone(), cx))?.await?;
             this.update(cx, |this, cx| {
                 if let Some((ix, _)) = this.user_message_mut(&id) {
+                    // Collect all terminals from entries that will be removed
+                    let terminals_to_remove: Vec<acp::TerminalId> = this.entries[ix..]
+                        .iter()
+                        .flat_map(|entry| entry.terminals())
+                        .filter_map(|terminal| terminal.read(cx).id().clone().into())
+                        .collect();
+
                     let range = ix..this.entries.len();
                     this.entries.truncate(ix);
                     cx.emit(AcpThreadEvent::EntriesRemoved(range));
+
+                    // Kill and remove the terminals
+                    for terminal_id in terminals_to_remove {
+                        if let Some(terminal) = this.terminals.remove(&terminal_id) {
+                            terminal.update(cx, |terminal, cx| {
+                                terminal.kill(cx);
+                            });
+                        }
+                    }
                 }
                 this.action_log().update(cx, |action_log, cx| {
                     action_log.reject_all_edits(Some(telemetry), cx)


### PR DESCRIPTION
Closes #35142

In addition to cleaning up the terminals, also stops the conversation.

Release Notes:

- Restoring a checkpoint now stops the agent conversation.
