### PR TITLE
Implement vertical scrolling for extended keymap load error information

### DIFF
--- a/crates/workspace/src/notifications.rs
+++ b/crates/workspace/src/notifications.rs
@@ -593,9 +593,9 @@ pub mod simple_message_notification {
 
     use gpui::{
         AnyElement, DismissEvent, EventEmitter, FocusHandle, Focusable, ParentElement, Render,
-        SharedString, Styled,
+        ScrollHandle, SharedString, Styled,
     };
-    use ui::prelude::*;
+    use ui::{ScrollAxes, WithScrollbar, prelude::*};
 
     use crate::notifications::NotificationFrame;
 
@@ -617,6 +617,7 @@ pub mod simple_message_notification {
         show_close_button: bool,
         show_suppress_button: bool,
         title: Option<SharedString>,
+        scroll_handle: ScrollHandle,
     }
 
     impl Focusable for MessageNotification {
@@ -661,6 +662,7 @@ pub mod simple_message_notification {
                 show_suppress_button: true,
                 title: None,
                 focus_handle: cx.focus_handle(),
+                scroll_handle: ScrollHandle::new(),
             }
         }
 
@@ -779,10 +781,15 @@ pub mod simple_message_notification {
                 .with_title(self.title.clone())
                 .with_content(
                     div()
-                        .id("message-notification-content")
-                        .max_h(vh(0.8, window))
-                        .overflow_y_scroll()
-                        .child((self.build_content)(window, cx)),
+                        .child(
+                            div()
+                                .id("message-notification-content")
+                                .max_h(vh(0.6, window))
+                                .overflow_y_scroll()
+                                .track_scroll(&self.scroll_handle.clone())
+                                .child((self.build_content)(window, cx)),
+                        )
+                        .vertical_scrollbar_for(self.scroll_handle.clone(), window, cx),
                 )
                 .show_close_button(self.show_close_button)
                 .show_suppress_button(self.show_suppress_button)

--- a/crates/workspace/src/notifications.rs
+++ b/crates/workspace/src/notifications.rs
@@ -777,7 +777,13 @@ pub mod simple_message_notification {
         fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
             NotificationFrame::new()
                 .with_title(self.title.clone())
-                .with_content((self.build_content)(window, cx))
+                .with_content(
+                    div()
+                        .id("message-notification-content")
+                        .max_h(vh(0.8, window))
+                        .overflow_y_scroll()
+                        .child((self.build_content)(window, cx)),
+                )
                 .show_close_button(self.show_close_button)
                 .show_suppress_button(self.show_suppress_button)
                 .on_close(cx.listener(|_, suppress, _, cx| {

--- a/crates/workspace/src/notifications.rs
+++ b/crates/workspace/src/notifications.rs
@@ -595,7 +595,7 @@ pub mod simple_message_notification {
         AnyElement, DismissEvent, EventEmitter, FocusHandle, Focusable, ParentElement, Render,
         ScrollHandle, SharedString, Styled,
     };
-    use ui::{ScrollAxes, WithScrollbar, prelude::*};
+    use ui::{WithScrollbar, prelude::*};
 
     use crate::notifications::NotificationFrame;
 

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -1696,12 +1696,20 @@ fn show_markdown_app_notification<F>(
                     MessageNotification::new_from_builder(cx, move |window, cx| {
                         image_cache(retain_all("notification-cache"))
                             .text_xs()
-                            .child(markdown_preview::markdown_renderer::render_parsed_markdown(
-                                &parsed_markdown.clone(),
-                                Some(workspace_handle.clone()),
-                                window,
-                                cx,
-                            ))
+                            .child(
+                                div()
+                                    .id("parsed-markdown")
+                                    .max_h(vh(0.8, window))
+                                    .overflow_y_scroll()
+                                    .child(
+                                        markdown_preview::markdown_renderer::render_parsed_markdown(
+                                            &parsed_markdown.clone(),
+                                            Some(workspace_handle.clone()),
+                                            window,
+                                            cx,
+                                        ),
+                                    ),
+                            )
                             .into_any()
                     })
                     .primary_message(primary_button_message)

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -1696,20 +1696,12 @@ fn show_markdown_app_notification<F>(
                     MessageNotification::new_from_builder(cx, move |window, cx| {
                         image_cache(retain_all("notification-cache"))
                             .text_xs()
-                            .child(
-                                div()
-                                    .id("parsed-markdown")
-                                    .max_h(vh(0.8, window))
-                                    .overflow_y_scroll()
-                                    .child(
-                                        markdown_preview::markdown_renderer::render_parsed_markdown(
-                                            &parsed_markdown.clone(),
-                                            Some(workspace_handle.clone()),
-                                            window,
-                                            cx,
-                                        ),
-                                    ),
-                            )
+                            .child(markdown_preview::markdown_renderer::render_parsed_markdown(
+                                &parsed_markdown.clone(),
+                                Some(workspace_handle.clone()),
+                                window,
+                                cx,
+                            ))
                             .into_any()
                     })
                     .primary_message(primary_button_message)


### PR DESCRIPTION
This PR fix an issue where, if an error occurs while loading the keymap file during application startup, an excessively long error message would be truncated and not fully displayed.

Before:

<img width="1567" height="1056" alt="before" src="https://github.com/user-attachments/assets/ab80c204-b642-4e8f-aaf5-eae070ab01a2" />


After:

<img width="1567" height="1056" alt="image" src="https://github.com/user-attachments/assets/1b2ff2ce-3796-41d5-b145-dc7d69f04f11" />


Release Notes:

- N/A