### PR TITLE
git_panel: Fix FocusChanges does nothing with no entries

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -745,7 +745,7 @@ impl GitPanel {
     ) {
         self.select_first_entry_if_none(cx);
 
-        cx.focus_self(window);
+        self.focus_handle.focus(window);
         cx.notify();
     }
 


### PR DESCRIPTION
Closes #31155

Release Notes:

- Ensure `git_panel::FocusChanges` bypasses the panel’s `Focusable` logic and directly focuses the `ChangesList` handle so the command works even when the repository has no entries.
- Keep the `Focusable` behavior from the commit 45b126a (which routes empty panels to the commit editor) by handling this special-case action rather than regressing the default focus experience.