### PR TITLE
Add additional comment for context in TypeScript highlights

### DIFF
--- a/crates/languages/src/typescript/highlights.scm
+++ b/crates/languages/src/typescript/highlights.scm
@@ -9,6 +9,9 @@
 (type_identifier) @type
 (predefined_type) @type.builtin
 
+;; Enables ts-pretty-errors
+;; The Lsp returns "snippets" of typescript, which are not valid typescript in totality,
+;; but should still be highlighted
 ;; Highlights object literals by hijacking the statement_block pattern, but only if
 ;; the statement block follows an object literal pattern
 ((statement_block


### PR DESCRIPTION
This adds additional comments which were left out from #42494 by accident. Namely, it describes why we have additional custom highlighting in `highlights.scm` for the Typescript grammar.

Release Notes:

- N/A
