### PR TITLE
Improve `pane: reopen closed item` to not reopen closed preview tabs

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -4103,15 +4103,18 @@ impl NavHistory {
                 });
             }
             NavigationMode::ClosingItem => {
-                if state.closed_stack.len() >= MAX_NAVIGATION_HISTORY_LEN {
-                    state.closed_stack.pop_front();
+                dbg!(is_preview);
+                if !is_preview {
+                    if state.closed_stack.len() >= MAX_NAVIGATION_HISTORY_LEN {
+                        state.closed_stack.pop_front();
+                    }
+                    state.closed_stack.push_back(NavigationEntry {
+                        item,
+                        data: data.map(|data| Box::new(data) as Box<dyn Any + Send>),
+                        timestamp: state.next_timestamp.fetch_add(1, Ordering::SeqCst),
+                        is_preview,
+                    });
                 }
-                state.closed_stack.push_back(NavigationEntry {
-                    item,
-                    data: data.map(|data| Box::new(data) as Box<dyn Any + Send>),
-                    timestamp: state.next_timestamp.fetch_add(1, Ordering::SeqCst),
-                    is_preview,
-                });
             }
         }
         state.did_update(cx);

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -4102,19 +4102,17 @@ impl NavHistory {
                     is_preview,
                 });
             }
+            NavigationMode::ClosingItem if is_preview => return,
             NavigationMode::ClosingItem => {
-                dbg!(is_preview);
-                if !is_preview {
-                    if state.closed_stack.len() >= MAX_NAVIGATION_HISTORY_LEN {
-                        state.closed_stack.pop_front();
-                    }
-                    state.closed_stack.push_back(NavigationEntry {
-                        item,
-                        data: data.map(|data| Box::new(data) as Box<dyn Any + Send>),
-                        timestamp: state.next_timestamp.fetch_add(1, Ordering::SeqCst),
-                        is_preview,
-                    });
+                if state.closed_stack.len() >= MAX_NAVIGATION_HISTORY_LEN {
+                    state.closed_stack.pop_front();
                 }
+                state.closed_stack.push_back(NavigationEntry {
+                    item,
+                    data: data.map(|data| Box::new(data) as Box<dyn Any + Send>),
+                    timestamp: state.next_timestamp.fetch_add(1, Ordering::SeqCst),
+                    is_preview,
+                });
             }
         }
         state.did_update(cx);


### PR DESCRIPTION
Closes #42134

Release Notes:

- Improved `pane: reopen closed item` to not reopen closed preview tabs.
