### PR TITLE
zeta eval: `--repeat` flag

### DIFF
--- a/crates/zeta2/src/xml_edits.rs
+++ b/crates/zeta2/src/xml_edits.rs
@@ -79,7 +79,7 @@ fn resolve_new_text_old_text_in_buffer(
             }
         }
         offset.ok_or_else(|| {
-            #[cfg(debug_assertions)]
+            #[cfg(any(debug_assertions, feature = "eval-support"))]
             if let Some(closest_match) = closest_old_text_match(buffer, old_text) {
                 log::info!(
                     "Closest `old_text` match: {}",
@@ -102,7 +102,7 @@ fn resolve_new_text_old_text_in_buffer(
         }))
 }
 
-#[cfg(debug_assertions)]
+#[cfg(any(debug_assertions, feature = "eval-support"))]
 fn closest_old_text_match(buffer: &TextBufferSnapshot, old_text: &str) -> Option<String> {
     let buffer_text = buffer.text();
     let len = old_text.len();

--- a/crates/zeta_cli/src/evaluate.rs
+++ b/crates/zeta_cli/src/evaluate.rs
@@ -91,7 +91,7 @@ fn write_aggregated_scores(
 ) -> Result<()> {
     let mut successful = Vec::new();
     let mut failed_count = 0;
-    writeln!("## Errors\n")?;
+    writeln!(w, "## Errors\n")?;
     for result in all_results.iter().flatten() {
         match result {
             Ok(eval_result) => successful.push(eval_result),

--- a/crates/zeta_cli/src/example.rs
+++ b/crates/zeta_cli/src/example.rs
@@ -6,9 +6,10 @@ use std::{
     io::Write,
     mem,
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{Arc, OnceLock},
 };
 
+use crate::headless::ZetaCliAppState;
 use anyhow::{Context as _, Result, anyhow};
 use clap::ValueEnum;
 use cloud_zeta2_prompt::CURSOR_MARKER;
@@ -18,13 +19,14 @@ use futures::{
     AsyncWriteExt as _,
     lock::{Mutex, OwnedMutexGuard},
 };
-use gpui::{AsyncApp, Entity, http_client::Url};
+use futures::{FutureExt as _, future::Shared};
+use gpui::{AppContext as _, AsyncApp, Entity, Task, http_client::Url};
 use language::{Anchor, Buffer};
 use project::{Project, ProjectPath};
 use pulldown_cmark::CowStr;
 use serde::{Deserialize, Serialize};
 use util::{paths::PathStyle, rel_path::RelPath};
-use zeta2::udiff::OpenedBuffers;
+use zeta2::{Zeta, udiff::OpenedBuffers};
 
 use crate::paths::{REPOS_DIR, WORKTREES_DIR};
 
@@ -309,6 +311,82 @@ impl NamedExample {
             }
             ExampleFormat::Md => Ok(write!(out, "{}", self)?),
         }
+    }
+
+    pub async fn setup_project<'a>(
+        &'a self,
+        app_state: &Arc<ZetaCliAppState>,
+        repetitions: u16,
+        cx: &mut AsyncApp,
+    ) -> Result<(Entity<Project>, Vec<Entity<Zeta>>, OpenedBuffers<'a>)> {
+        let worktree_path = self.setup_worktree().await?;
+
+        static AUTHENTICATED: OnceLock<Shared<Task<()>>> = OnceLock::new();
+
+        AUTHENTICATED
+            .get_or_init(|| {
+                let client = app_state.client.clone();
+                cx.spawn(async move |cx| {
+                    client
+                        .sign_in_with_optional_connect(true, cx)
+                        .await
+                        .unwrap();
+                })
+                .shared()
+            })
+            .clone()
+            .await;
+
+        let project = cx.update(|cx| {
+            Project::local(
+                app_state.client.clone(),
+                app_state.node_runtime.clone(),
+                app_state.user_store.clone(),
+                app_state.languages.clone(),
+                app_state.fs.clone(),
+                None,
+                cx,
+            )
+        })?;
+
+        let worktree = project
+            .update(cx, |project, cx| {
+                project.create_worktree(&worktree_path, true, cx)
+            })?
+            .await?;
+        worktree
+            .read_with(cx, |worktree, _cx| {
+                worktree.as_local().unwrap().scan_complete()
+            })?
+            .await;
+
+        let buffer_store = project.read_with(cx, |project, _| project.buffer_store().clone())?;
+
+        let zetas = (0..repetitions)
+            .map(|_| {
+                let zeta = cx.new(|cx| {
+                    zeta2::Zeta::new(app_state.client.clone(), app_state.user_store.clone(), cx)
+                })?;
+
+                cx.subscribe(&buffer_store, {
+                    let project = project.clone();
+                    let zeta = zeta.clone();
+                    move |_, event, cx| match event {
+                        project::buffer_store::BufferStoreEvent::BufferAdded(buffer) => {
+                            zeta.update(cx, |zeta, cx| zeta.register_buffer(&buffer, &project, cx));
+                        }
+                        _ => {}
+                    }
+                })?
+                .detach();
+
+                anyhow::Ok(zeta)
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        let edited_buffers = self.apply_edit_history(&project, cx).await?;
+
+        anyhow::Ok((project, zetas, edited_buffers))
     }
 
     pub async fn setup_worktree(&self) -> Result<PathBuf> {

--- a/crates/zeta_cli/src/paths.rs
+++ b/crates/zeta_cli/src/paths.rs
@@ -15,6 +15,7 @@ pub static LATEST_EXAMPLE_RUN_DIR: LazyLock<PathBuf> =
 
 pub fn print_run_data_dir() {
     println!("\n## Run Data\n");
+    let mut files = Vec::new();
 
     let current_dir = std::env::current_dir().unwrap();
     for file in std::fs::read_dir(&*RUN_DIR).unwrap() {
@@ -23,18 +24,23 @@ pub fn print_run_data_dir() {
             for file in std::fs::read_dir(file.path()).unwrap() {
                 let path = file.unwrap().path();
                 let path = path.strip_prefix(&current_dir).unwrap_or(&path);
-                println!(
+                files.push(format!(
                     "- {}/\x1b[34m{}\x1b[0m",
                     path.parent().unwrap().display(),
                     path.file_name().unwrap().display(),
-                );
+                ));
             }
         } else {
             let path = file.path();
-            println!(
+            files.push(format!(
                 "- {} ",
                 path.strip_prefix(&current_dir).unwrap_or(&path).display()
-            );
+            ));
         }
+    }
+    files.sort();
+
+    for file in files {
+        println!("{}", file);
     }
 }

--- a/crates/zeta_cli/src/paths.rs
+++ b/crates/zeta_cli/src/paths.rs
@@ -13,14 +13,14 @@ pub static RUN_DIR: LazyLock<PathBuf> = LazyLock::new(|| {
 pub static LATEST_EXAMPLE_RUN_DIR: LazyLock<PathBuf> =
     LazyLock::new(|| TARGET_ZETA_DIR.join("latest"));
 
-pub fn print_run_data_dir() {
+pub fn print_run_data_dir(deep: bool) {
     println!("\n## Run Data\n");
     let mut files = Vec::new();
 
     let current_dir = std::env::current_dir().unwrap();
     for file in std::fs::read_dir(&*RUN_DIR).unwrap() {
         let file = file.unwrap();
-        if file.file_type().unwrap().is_dir() {
+        if file.file_type().unwrap().is_dir() && deep {
             for file in std::fs::read_dir(file.path()).unwrap() {
                 let path = file.unwrap().path();
                 let path = path.strip_prefix(&current_dir).unwrap_or(&path);
@@ -32,9 +32,11 @@ pub fn print_run_data_dir() {
             }
         } else {
             let path = file.path();
+            let path = path.strip_prefix(&current_dir).unwrap_or(&path);
             files.push(format!(
-                "- {} ",
-                path.strip_prefix(&current_dir).unwrap_or(&path).display()
+                "- {}/\x1b[34m{}\x1b[0m",
+                path.parent().unwrap().display(),
+                path.file_name().unwrap().display(),
             ));
         }
     }
@@ -43,4 +45,9 @@ pub fn print_run_data_dir() {
     for file in files {
         println!("{}", file);
     }
+
+    println!(
+        "\n💡 Tip of the day: {} always points to the latest run\n",
+        LATEST_EXAMPLE_RUN_DIR.display()
+    );
 }

--- a/crates/zeta_cli/src/predict.rs
+++ b/crates/zeta_cli/src/predict.rs
@@ -367,7 +367,7 @@ impl EvalCache for RunCache {
                 }
             };
             if use_cache {
-                log::trace!("Using cache entry: {}", path.display());
+                log::info!("Using cache entry: {}", path.display());
                 self.link_to_run(&key);
                 Some(fs::read_to_string(path).unwrap())
             } else {


### PR DESCRIPTION
Adds a `--repeat` flag to the zeta eval that runs each example as many times as specified. Also makes the output nicer in a few ways.

Release Notes:

- N/A 
