### PR TITLE
Make check-licenses script check that AGPL crates are not included in release binaries

### DIFF
--- a/script/check-licenses
+++ b/script/check-licenses
@@ -2,14 +2,16 @@
 
 set -euo pipefail
 
+AGPL_CRATES=("collab")
+RELEASE_CRATES=("cli" "remote_server" "zed")
+
 check_license () {
     local dir="$1"
     local allowed_licenses=()
-    local agpl_crates=("crates/collab")
 
     local is_agpl=false
-    for agpl_crate in "${agpl_crates[@]}"; do
-        if [[ "$dir" == "$agpl_crate" ]]; then
+    for agpl_crate in "${AGPL_CRATES[@]}"; do
+        if [[ "$dir" == "crates/$agpl_crate" ]]; then
             is_agpl=true
             break
         fi
@@ -30,7 +32,7 @@ check_license () {
         fi
     done
 
-    if [[ "$dir" == "crates/collab" ]]; then
+    if [[ "$is_agpl" == true ]]; then
         echo "Error: $dir does not contain a LICENSE-AGPL symlink"
     else
         echo "Error: $dir does not contain a LICENSE-GPL or LICENSE-APACHE symlink"
@@ -41,3 +43,20 @@ check_license () {
 git ls-files "**/*/Cargo.toml" | while read -r cargo_toml; do
    check_license "$(dirname "$cargo_toml")"
 done
+
+
+# Make sure the AGPL server crates are included in the release tarball.
+for release_crate in "${RELEASE_CRATES[@]}"; do
+    tree_output=$(cargo tree --package "$release_crate")
+    for agpl_crate in "${AGPL_CRATES[@]}"; do
+        # Look for lines that contain the crate name followed by " v" (version)
+        # This matches patterns like "├── collab v0.44.0"
+        if echo "$tree_output" | grep -E "(^|[^a-zA-Z_])${agpl_crate} v" > /dev/null; then
+            echo "Error: crate '${agpl_crate}' is AGPL and is a dependency of crate '${release_crate}'." >&2
+            echo "AGPL licensed code should not be used in the release distribution, only in servers." >&2
+            exit 1
+        fi
+    done
+done
+
+echo "check-licenses succeeded"

--- a/script/licenses/zed-licenses.toml
+++ b/script/licenses/zed-licenses.toml
@@ -1,5 +1,16 @@
 no-clearly-defined = true
 private = { ignore = true }
+# Licenses allowed in Zed's dependencies. AGPL should not be added to
+# this list as use of AGPL software is sometimes disallowed. When
+# adding to this list, please check the following open source license
+# policies:
+#
+# * https://opensource.google/documentation/reference/thirdparty/licenses
+#
+# The Zed project does have AGPL crates, but these are only involved
+# in servers and are not built into the binaries in the release
+# tarball. `script/check-licenses` checks that AGPL crates are not
+# involved in release binaries.
 accepted = [
     "Apache-2.0",
     "MIT",


### PR DESCRIPTION
See discussion in #24657.  Recalled that I had a stashed change for this, so polished it up

Release Notes:

- N/A