### PR TITLE
Update cargo.rs to allow debugging of integration test annotated with the ignore attribute

### DIFF
--- a/crates/project/src/debugger/locators/cargo.rs
+++ b/crates/project/src/debugger/locators/cargo.rs
@@ -148,6 +148,10 @@ impl DapLocator for CargoLocator {
             .first()
             .is_some_and(|arg| arg == "test" || arg == "t");
 
+        let is_ignored = build_config
+            .args
+            .contains(&"--include-ignored".to_owned());
+
         let executables = output
             .lines()
             .filter(|line| !line.trim().is_empty())
@@ -205,6 +209,9 @@ impl DapLocator for CargoLocator {
         let mut args: Vec<_> = test_name.into_iter().collect();
         if is_test {
             args.push("--nocapture".to_owned());
+            if is_ignored {
+                args.push("--include-ignored".to_owned());
+            }
         }
 
         Ok(DebugRequest::Launch(task::LaunchRequest {

--- a/crates/project/src/debugger/locators/cargo.rs
+++ b/crates/project/src/debugger/locators/cargo.rs
@@ -148,9 +148,7 @@ impl DapLocator for CargoLocator {
             .first()
             .is_some_and(|arg| arg == "test" || arg == "t");
 
-        let is_ignored = build_config
-            .args
-            .contains(&"--include-ignored".to_owned());
+        let is_ignored = build_config.args.contains(&"--include-ignored".to_owned());
 
         let executables = output
             .lines()


### PR DESCRIPTION
Address #40429

If an integration test is annotated with the ignore attribute, allow the "debug: Test" option of the debug scenario or Code Action to run with "--include-ignored"

Closes #40429

Release Notes:

- N/A

