### PR TITLE
Allow running concurrent unit evals

### DIFF
--- a/.github/workflows/run_unit_evals.yml
+++ b/.github/workflows/run_unit_evals.yml
@@ -65,5 +65,5 @@ jobs:
         rm -rf ./../.cargo
       shell: bash -euxo pipefail {0}
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.run_id }}
   cancel-in-progress: true

--- a/tooling/xtask/src/tasks/workflows/run_agent_evals.rs
+++ b/tooling/xtask/src/tasks/workflows/run_agent_evals.rs
@@ -41,7 +41,7 @@ pub(crate) fn run_unit_evals() -> Workflow {
                 .add_input(model_name.name, model_name.input())
                 .add_input(commit_sha.name, commit_sha.input()),
         ))
-        .concurrency(vars::one_workflow_per_non_main_branch())
+        .concurrency(vars::allow_concurrent_runs())
         .add_env(("CARGO_TERM_COLOR", "always"))
         .add_env(("CARGO_INCREMENTAL", 0))
         .add_env(("RUST_BACKTRACE", 1))

--- a/tooling/xtask/src/tasks/workflows/vars.rs
+++ b/tooling/xtask/src/tasks/workflows/vars.rs
@@ -81,6 +81,12 @@ pub(crate) fn one_workflow_per_non_main_branch() -> Concurrency {
         .cancel_in_progress(true)
 }
 
+pub(crate) fn allow_concurrent_runs() -> Concurrency {
+    Concurrency::default()
+        .group("${{ github.workflow }}-${{ github.ref_name }}-${{ github.run_id }}")
+        .cancel_in_progress(true)
+}
+
 // Represents a pattern to check for changed files and corresponding output variable
 pub(crate) struct PathCondition {
     pub name: &'static str,


### PR DESCRIPTION
Right now only one unit eval GitHub Action can be run at a time. This permits them to run concurrently.

Release Notes:

- N/A