### PR TITLE
diagnostics: Workaround weird panic in `update_path_excerpts`

### DIFF
--- a/crates/multi_buffer/src/path_key.rs
+++ b/crates/multi_buffer/src/path_key.rs
@@ -410,6 +410,8 @@ impl MultiBuffer {
         }
 
         self.insert_excerpts_with_ids_after(insert_after, buffer, to_insert, cx);
+        // todo(lw): There is a logic bug somewhere that causes the to_remove vector to be not ordered correctly
+        to_remove.sort_by_cached_key(|&id| snapshot.excerpt_locator_for_id(id));
         self.remove_excerpts(to_remove, cx);
         if excerpt_ids.is_empty() {
             self.excerpts_by_path.remove(&path);


### PR DESCRIPTION
Fixes ZED-36P

Patching this over for now until I can figure out the cause of this

Release Notes:

- Fixed panic in diagnostics pane
