### PR TITLE
editor: Improve multi-buffer header filename click to jump to the latest selection from that buffer - take 2

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -7806,12 +7806,12 @@ fn header_jump_data(
     latest_selection_anchors: &HashMap<BufferId, Anchor>,
 ) -> JumpData {
     let jump_target = if let Some(anchor) = latest_selection_anchors.get(&first_excerpt.buffer_id)
-        && let Some(excerpt) = snapshot.excerpt_before(anchor.excerpt_id)
+        && let Some(range) = snapshot.context_range_for_excerpt(anchor.excerpt_id)
     {
         JumpTargetInExcerptInput {
             id: anchor.excerpt_id,
             buffer: &first_excerpt.buffer,
-            excerpt_start_anchor: excerpt.start_anchor().text_anchor,
+            excerpt_start_anchor: range.start,
             jump_anchor: anchor.text_anchor,
         }
     } else {


### PR DESCRIPTION
Relands https://github.com/zed-industries/zed/pull/42480

Release Notes:

- Clicking the multi-buffer header file name or the "Open file" button now jumps to the most recent selection in that buffer, if one exists.

