### PR TITLE
ci: Fix `script/clear-target-dir-if-larger-than` post #41652

### DIFF
--- a/script/clear-target-dir-if-larger-than
+++ b/script/clear-target-dir-if-larger-than
@@ -21,5 +21,5 @@ echo "target directory size: ${current_size_gb}gb. max size: ${max_size_gb}gb"
 
 if [[ ${current_size_gb} -gt ${max_size_gb} ]]; then
     echo "clearing target directory"
-    rm -rf target
+    rm -rf target/* target/.*
 fi


### PR DESCRIPTION
Closes #ISSUE

The namespace runners mount the `target` directory to the cache drive, so `rm -rf target` would fail with `Device Busy`. Instead we now do `rm -rf target/* target/.*` to remove all files (including hidden files) from the `target` directory, without removing the target directory itself

Release Notes:

- N/A *or* Added/Fixed/Improved ...
