### PR TITLE
Add Windows path for extensions

### DIFF
--- a/docs/src/extensions/installing-extensions.md
+++ b/docs/src/extensions/installing-extensions.md
@@ -8,6 +8,7 @@ Here you can view the extensions that you currently have installed or search and
 
 - On macOS, extensions are installed in `~/Library/Application Support/Zed/extensions`.
 - On Linux, they are installed in either `$XDG_DATA_HOME/zed/extensions` or `~/.local/share/zed/extensions`.
+- On Windows, the directory is `%LOCALAPPDATA%\zed\extensions`.
 
 This directory contains two subdirectories:
 

--- a/docs/src/extensions/installing-extensions.md
+++ b/docs/src/extensions/installing-extensions.md
@@ -8,7 +8,7 @@ Here you can view the extensions that you currently have installed or search and
 
 - On macOS, extensions are installed in `~/Library/Application Support/Zed/extensions`.
 - On Linux, they are installed in either `$XDG_DATA_HOME/zed/extensions` or `~/.local/share/zed/extensions`.
-- On Windows, the directory is `%LOCALAPPDATA%\zed\extensions`.
+- On Windows, the directory is `%LOCALAPPDATA%\Zed\extensions`.
 
 This directory contains two subdirectories:
 


### PR DESCRIPTION
### Description

The `installing-extensions.md` guide was missing the directory path for the Windows platform. It currently only lists the paths for macOS and Linux. This PR adds the correct path for Windows users (`%LOCALAPPDATA%\zed\extensions`).

Release Notes:

- N/A

