### PR TITLE
lsp: Add Markdown Language Server Support

### DIFF
--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -22,6 +22,7 @@ mod c;
 mod css;
 mod go;
 mod json;
+mod markdown;
 mod package_json;
 mod python;
 mod rust;
@@ -105,7 +106,8 @@ pub fn init(languages: Arc<LanguageRegistry>, fs: Arc<dyn Fs>, node: NodeRuntime
         fs.clone(),
     ));
     let vtsls_adapter = Arc::new(vtsls::VtslsLspAdapter::new(node.clone(), fs.clone()));
-    let yaml_lsp_adapter = Arc::new(yaml::YamlLspAdapter::new(node));
+    let yaml_lsp_adapter = Arc::new(yaml::YamlLspAdapter::new(node.clone()));
+    let markdown_adapter = Arc::new(markdown::MarkdownLspAdapter::new(node));
 
     let built_in_languages = [
         LanguageInfo {
@@ -165,7 +167,7 @@ pub fn init(languages: Arc<LanguageRegistry>, fs: Arc<dyn Fs>, node: NodeRuntime
         },
         LanguageInfo {
             name: "markdown",
-            adapters: vec![],
+            adapters: vec![markdown_adapter],
             ..Default::default()
         },
         LanguageInfo {

--- a/crates/languages/src/markdown.rs
+++ b/crates/languages/src/markdown.rs
@@ -1,0 +1,209 @@
+use anyhow::{Result, ensure};
+use async_trait::async_trait;
+use gpui::AsyncApp;
+use language::{LanguageName, LspAdapter, LspAdapterDelegate, LspInstaller, Toolchain};
+use lsp::{LanguageServerBinary, LanguageServerName};
+use node_runtime::{NodeRuntime, VersionStrategy};
+use project::lsp_store::language_server_settings;
+use serde_json::{Value, json};
+use smol::{fs, io::AsyncWriteExt};
+use std::{
+    ffi::OsString,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+use util::{ResultExt, maybe, merge_json_value_into};
+
+const SERVER_SCRIPT_NAME: &str = "markdown-lsp-server.cjs";
+const SERVER_SCRIPT_SOURCE: &str = include_str!("markdown/markdown-lsp-server.cjs");
+
+fn server_arguments(server_path: &Path) -> Vec<OsString> {
+    vec![server_path.into(), OsString::from("--stdio")]
+}
+
+pub struct MarkdownLspAdapter {
+    node: NodeRuntime,
+}
+
+impl MarkdownLspAdapter {
+    pub fn new(node: NodeRuntime) -> Self {
+        Self { node }
+    }
+    const SERVER_NAME: LanguageServerName =
+        LanguageServerName::new_static("vscode-markdown-languageservice");
+    const PACKAGE_NAME: &'static str = "vscode-markdown-languageservice";
+
+    fn script_path(container_dir: &Path) -> PathBuf {
+        container_dir.join(SERVER_SCRIPT_NAME)
+    }
+}
+
+impl LspInstaller for MarkdownLspAdapter {
+    type BinaryVersion = String;
+
+    async fn fetch_latest_server_version(
+        &self,
+        _delegate: &dyn LspAdapterDelegate,
+        _allow_pre: bool,
+        _cx: &mut AsyncApp,
+    ) -> Result<String> {
+        self.node
+            .npm_package_latest_version(Self::PACKAGE_NAME)
+            .await
+    }
+
+    async fn check_if_user_installed(
+        &self,
+        delegate: &dyn LspAdapterDelegate,
+        _toolchain: Option<Toolchain>,
+        _cx: &AsyncApp,
+    ) -> Option<LanguageServerBinary> {
+        // No user-provided binary for this server; rely on managed install.
+        let _ = delegate; // silence unused warning
+        None
+    }
+
+    async fn fetch_server_binary(
+        &self,
+        latest_version: String,
+        container_dir: PathBuf,
+        _delegate: &dyn LspAdapterDelegate,
+    ) -> Result<LanguageServerBinary> {
+        // Ensure directory exists and write server script
+        fs::create_dir_all(&container_dir).await.ok();
+
+        self.node
+            .npm_install_packages(
+                &container_dir,
+                &[
+                    (Self::PACKAGE_NAME, latest_version.as_str()),
+                    ("vscode-languageserver", "latest"),
+                    ("vscode-languageserver-textdocument", "latest"),
+                    ("vscode-uri", "latest"),
+                    ("markdown-it", "latest"),
+                ],
+            )
+            .await?;
+
+        let script_path = Self::script_path(&container_dir);
+        let mut file = fs::File::create(&script_path).await?;
+        file.write_all(SERVER_SCRIPT_SOURCE.as_bytes()).await?;
+        // Not strictly needed for Node execution as argument, but try to chmod +x.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(&script_path).await?.permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(&script_path, perms).await?;
+        }
+
+        Ok(LanguageServerBinary {
+            path: self.node.binary_path().await?,
+            env: None,
+            arguments: server_arguments(&script_path),
+        })
+    }
+
+    async fn check_if_version_installed(
+        &self,
+        version: &String,
+        container_dir: &PathBuf,
+        _delegate: &dyn LspAdapterDelegate,
+    ) -> Option<LanguageServerBinary> {
+        let script_path = Self::script_path(container_dir);
+
+        let should_install = self
+            .node
+            .should_install_npm_package(
+                Self::PACKAGE_NAME,
+                &script_path,
+                container_dir,
+                VersionStrategy::Latest(version),
+            )
+            .await;
+
+        if should_install {
+            None
+        } else {
+            Some(LanguageServerBinary {
+                path: self.node.binary_path().await.ok()?,
+                env: None,
+                arguments: server_arguments(&script_path),
+            })
+        }
+    }
+
+    async fn cached_server_binary(
+        &self,
+        container_dir: PathBuf,
+        _delegate: &dyn LspAdapterDelegate,
+    ) -> Option<LanguageServerBinary> {
+        maybe!(async {
+            let script_path = Self::script_path(&container_dir);
+            ensure!(
+                script_path.exists(),
+                "missing executable in directory {:?}",
+                container_dir
+            );
+            Ok(LanguageServerBinary {
+                path: self.node.binary_path().await?,
+                env: None,
+                arguments: server_arguments(&script_path),
+            })
+        })
+        .await
+        .log_err()
+    }
+}
+
+#[async_trait(?Send)]
+impl LspAdapter for MarkdownLspAdapter {
+    fn name(&self) -> LanguageServerName {
+        Self::SERVER_NAME
+    }
+
+    async fn initialization_options(
+        self: Arc<Self>,
+        delegate: &Arc<dyn LspAdapterDelegate>,
+    ) -> Result<Option<serde_json::Value>> {
+        let _ = delegate; // not used here
+        // Default options passed to vscode-markdown-languageservice
+        let options = json!({
+          // Enable useful defaults
+          "includeWorkspaceHeaderCompletions": true,
+          "diagnostics": { "validateFileLinks": true }
+        });
+
+        Ok(Some(options))
+    }
+
+    fn language_ids(&self) -> collections::HashMap<LanguageName, String> {
+        [(LanguageName::new("Markdown"), "markdown".to_string())]
+            .into_iter()
+            .collect()
+    }
+
+    async fn workspace_configuration(
+        self: Arc<Self>,
+        delegate: &Arc<dyn LspAdapterDelegate>,
+        _toolchain: Option<Toolchain>,
+        cx: &mut AsyncApp,
+    ) -> Result<Value> {
+        // Defaults (same shape as initializationOptions), can be overridden by user settings
+        let mut options = json!({
+          "includeWorkspaceHeaderCompletions": true,
+          "diagnostics": { "validateFileLinks": true }
+        });
+
+        let user_overrides = cx.update(|cx| {
+            language_server_settings(delegate.as_ref(), &Self::SERVER_NAME, cx)
+                .and_then(|s| s.settings.clone())
+        })?;
+
+        if let Some(override_options) = user_overrides {
+            merge_json_value_into(override_options, &mut options);
+        }
+
+        Ok(options)
+    }
+}

--- a/crates/languages/src/markdown/markdown-lsp-server.cjs
+++ b/crates/languages/src/markdown/markdown-lsp-server.cjs
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+/*
+  Minimal LSP server wrapper around vscode-markdown-languageservice.
+  Runs over stdio and implements a subset of features commonly used in editors.
+*/
+const {
+  createConnection,
+  ProposedFeatures,
+  TextDocuments,
+  TextDocumentSyncKind,
+} = require('vscode-languageserver/node');
+const { Emitter } = require('vscode-languageserver-protocol');
+const { TextDocument } = require('vscode-languageserver-textdocument');
+const { URI } = require('vscode-uri');
+const mdls = require('vscode-markdown-languageservice');
+const MarkdownIt = require('markdown-it');
+const fs = require('fs');
+const path = require('path');
+
+const connection = createConnection(ProposedFeatures.all);
+const documents = new TextDocuments(TextDocument);
+
+// Workspace implementation for the markdown language service
+class Workspace {
+  constructor() {
+    this._docs = new Map();
+    this.workspaceFolders = [];
+    this.#onDidChangeMarkdownDocument = new Emitter();
+    this.onDidChangeMarkdownDocument = this.#onDidChangeMarkdownDocument.event;
+    this.#onDidCreateMarkdownDocument = new Emitter();
+    this.onDidCreateMarkdownDocument = this.#onDidCreateMarkdownDocument.event;
+    this.#onDidDeleteMarkdownDocument = new Emitter();
+    this.onDidDeleteMarkdownDocument = this.#onDidDeleteMarkdownDocument.event;
+  }
+  #onDidChangeMarkdownDocument;
+  #onDidCreateMarkdownDocument;
+  #onDidDeleteMarkdownDocument;
+
+  setFolders(folders) {
+    this.workspaceFolders = folders;
+  }
+  onOpen(doc) { this._docs.set(doc.uri, doc); }
+  onClose(uri) { this._docs.delete(uri); }
+  async getAllMarkdownDocuments() { return Array.from(this._docs.values()); }
+  hasMarkdownDocument(resource) { return this._docs.has(resource.toString()); }
+  async openMarkdownDocument(resource) {
+    const key = resource.toString();
+    const existing = this._docs.get(key);
+    if (existing) return existing;
+    try {
+      const text = await fs.promises.readFile(resource.fsPath, 'utf8');
+      const doc = TextDocument.create(resource.toString(), 'markdown', 1, text);
+      this._docs.set(key, doc);
+      this.#onDidCreateMarkdownDocument.fire(doc);
+      return doc;
+    } catch {
+      return undefined;
+    }
+  }
+  async stat(resource) {
+    try {
+      const st = await fs.promises.stat(resource.fsPath);
+      return { isDirectory: st.isDirectory() };
+    } catch {
+      return undefined;
+    }
+  }
+  async readDirectory(resource) {
+    try {
+      const entries = await fs.promises.readdir(resource.fsPath, { withFileTypes: true });
+      return entries.map(e => [e.name, { isDirectory: e.isDirectory() }]);
+    } catch {
+      return [];
+    }
+  }
+}
+
+const mdIt = MarkdownIt({ html: true });
+const parser = new (class {
+  constructor() { this.slugifier = mdls.githubSlugifier; }
+  async tokenize(document) { return mdIt.parse(document.getText(), {}); }
+})();
+
+const logger = { log: (_level, _title, _message, _data) => {} };
+const workspace = new Workspace();
+let serverOptions = {};
+let languageService = null;
+
+// Diagnostics options: default; can be overridden from initializationOptions
+let diagOptions = { validateFileLinks: true };
+
+documents.onDidOpen((change) => {
+  workspace.onOpen(change.document);
+  void validateTextDocument(change.document);
+});
+
+documents.onDidChangeContent((change) => {
+  workspace.onOpen(change.document);
+  void validateTextDocument(change.document);
+});
+
+documents.onDidClose((change) => {
+  workspace.onClose(change.document.uri);
+  connection.sendDiagnostics({ uri: change.document.uri, diagnostics: [] });
+});
+
+async function validateTextDocument(document) {
+  try {
+    if (!languageService) return;
+    const token = { isCancellationRequested: false, onCancellationRequested: () => ({ dispose(){} }) };
+    const diagnostics = await languageService.computeDiagnostics(document, diagOptions, token);
+    connection.sendDiagnostics({ uri: document.uri, diagnostics });
+  } catch (e) {
+    // Swallow diagnostics errors
+  }
+}
+
+connection.onInitialize((params) => {
+  serverOptions = params.initializationOptions || {};
+  languageService = mdls.createLanguageService({ workspace, parser, logger, ...serverOptions });
+  if (serverOptions.diagnostics) {
+    diagOptions = { ...diagOptions, ...serverOptions.diagnostics };
+  }
+  // Capture workspace folders from client
+  const folders = [];
+  if (Array.isArray(params.workspaceFolders)) {
+    for (const f of params.workspaceFolders) {
+      try { folders.push(URI.parse(f.uri)); } catch {}
+    }
+  } else if (params.rootUri) {
+    try { folders.push(URI.parse(params.rootUri)); } catch {}
+  }
+  workspace.setFolders(folders);
+  console.error(`[markdown-lsp] initialized with ${folders.length} workspace folder(s)`);
+  return {
+    capabilities: {
+      textDocumentSync: TextDocumentSyncKind.Incremental,
+      completionProvider: { resolveProvider: false },
+      definitionProvider: true,
+      referencesProvider: true,
+      documentSymbolProvider: true,
+      workspaceSymbolProvider: true,
+      foldingRangeProvider: true,
+      documentLinkProvider: { resolveProvider: true },
+      renameProvider: { prepareProvider: true },
+      codeActionProvider: true,
+      hoverProvider: true,
+      selectionRangeProvider: true,
+    }
+  };
+});
+
+connection.onShutdown(() => {
+  try { if (languageService) languageService.dispose(); } catch {}
+});
+
+connection.onDidChangeConfiguration((params) => {
+  try {
+    const wsOptions = params.settings || {};
+    serverOptions = { ...serverOptions, ...wsOptions };
+    if (wsOptions.diagnostics) {
+      diagOptions = { ...diagOptions, ...wsOptions.diagnostics };
+    }
+    if (languageService && typeof languageService.dispose === 'function') {
+      languageService.dispose();
+    }
+    languageService = mdls.createLanguageService({ workspace, parser, logger, ...serverOptions });
+  } catch (e) {
+    // ignore
+  }
+});
+
+connection.onCompletion(async (params) => {
+  const doc = documents.get(params.textDocument.uri);
+  if (!doc) return [];
+  const token = { isCancellationRequested: false, onCancellationRequested: () => ({ dispose(){} }) };
+  return languageService.getCompletionItems(doc, params.position, { includeWorkspaceHeaderCompletions: true }, token);
+});
+
+connection.onDefinition(async (params) => {
+  const doc = documents.get(params.textDocument.uri);
+  if (!doc) return null;
+  const token = { isCancellationRequested: false, onCancellationRequested: () => ({ dispose(){} }) };
+  return languageService.getDefinition(doc, params.position, token);
+});
+
+connection.onReferences(async (params) => {
+  const doc = documents.get(params.textDocument.uri);
+  if (!doc) return [];
+  const token = { isCancellationRequested: false, onCancellationRequested: () => ({ dispose(){} }) };
+  return languageService.getReferences(doc, params.position, params.context, token);
+});
+
+connection.onDocumentSymbol(async (params) => {
+  const doc = documents.get(params.textDocument.uri);
+  if (!doc) return [];
+  const token = { isCancellationRequested: false, onCancellationRequested: () => ({ dispose(){} }) };
+  return languageService.getDocumentSymbols(doc, { includeLinkDefinitions: true }, token);
+});
+
+connection.onDocumentLinks(async (params) => {
+  const doc = documents.get(params.textDocument.uri);
+  if (!doc) return [];
+  const token = { isCancellationRequested: false, onCancellationRequested: () => ({ dispose(){} }) };
+  const links = await languageService.getDocumentLinks(doc, token);
+  const resolved = await Promise.all(links.map(l => languageService.resolveDocumentLink(l, token).then(r => r ?? l)));
+  return resolved;
+});
+
+connection.onFoldingRanges(async (params) => {
+  const doc = documents.get(params.textDocument.uri);
+  if (!doc) return [];
+  const token = { isCancellationRequested: false, onCancellationRequested: () => ({ dispose(){} }) };
+  return languageService.getFoldingRanges(doc, token);
+});
+
+connection.onPrepareRename(async (params) => {
+  const doc = documents.get(params.textDocument.uri);
+  if (!doc) return null;
+  const token = { isCancellationRequested: false, onCancellationRequested: () => ({ dispose(){} }) };
+  return languageService.prepareRename(doc, params.position, token);
+});
+
+connection.onRenameRequest(async (params) => {
+  const doc = documents.get(params.textDocument.uri);
+  if (!doc) return null;
+  const token = { isCancellationRequested: false, onCancellationRequested: () => ({ dispose(){} }) };
+  return languageService.getRenameEdit(doc, params.position, params.newName, token);
+});
+
+connection.onHover(async (params) => {
+  const doc = documents.get(params.textDocument.uri);
+  if (!doc) return null;
+  const token = { isCancellationRequested: false, onCancellationRequested: () => ({ dispose(){} }) };
+  return languageService.getHover(doc, params.position, token);
+});
+
+connection.onSelectionRanges(async (params) => {
+  const doc = documents.get(params.textDocument.uri);
+  if (!doc) return [];
+  const token = { isCancellationRequested: false, onCancellationRequested: () => ({ dispose(){} }) };
+  return languageService.getSelectionRanges(doc, params.positions, token);
+});
+
+connection.onCodeAction(async (params) => {
+  const doc = documents.get(params.textDocument.uri);
+  if (!doc) return [];
+  const token = { isCancellationRequested: false, onCancellationRequested: () => ({ dispose(){} }) };
+  return languageService.getCodeActions(doc, params.range, params.context, token);
+});
+
+// Track open docs
+documents.listen(connection);
+connection.listen();


### PR DESCRIPTION
## Summary

Integrates `vscode-markdown-languageservice` to provide LSP features for Markdown files.

## Changes

- Added `markdown.rs` LSP adapter that wraps `vscode-markdown-languageservice` via Node.js
- Implemented Node-based LSP server script with workspace filesystem support
- Registered Markdown LSP in language registry with default settings
- Added support for:
  - Link/header navigation (go-to-definition, find references)
  - Workspace header completions
  - File link validation diagnostics
  - Document symbols, folding ranges, hover
  - Rename and code actions (e.g., extract to link definition)
  - Configuration via user settings


Related to #33484

**Screen recording**


https://github.com/user-attachments/assets/c84e37fd-a7d0-4bb5-a316-6f267bf20dd6


Release Notes:

- N/A *or* Added/Fixed/Improved ...
