### PR TITLE
gpui: Only time out multi-stroke bindings when current prefix matches

### DIFF
--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -6551,12 +6551,12 @@ async fn test_pane_split_left(cx: &mut TestAppContext) {
         assert!(workspace.items(cx).collect::<Vec<_>>().len() == 2);
     });
     cx.simulate_keystrokes("cmd-k");
-    // sleep for longer than the timeout in keyboard shortcut handling
-    // to verify that it doesn't fire in this case.
+    // Sleep past the historical timeout to ensure the multi-stroke binding
+    // still fires now that unambiguous prefixes no longer auto-expire.
     cx.executor().advance_clock(Duration::from_secs(2));
     cx.simulate_keystrokes("left");
     workspace.update(cx, |workspace, cx| {
-        assert!(workspace.items(cx).collect::<Vec<_>>().len() == 2);
+        assert!(workspace.items(cx).collect::<Vec<_>>().len() == 3);
     });
 }
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -21994,13 +21994,7 @@ impl Editor {
             .pending_input_keystrokes()
             .into_iter()
             .flatten()
-            .filter_map(|keystroke| {
-                if keystroke.modifiers.is_subset_of(&Modifiers::shift()) {
-                    keystroke.key_char.clone()
-                } else {
-                    None
-                }
-            })
+            .filter_map(|keystroke| keystroke.key_char.clone())
             .collect();
 
         if !self.input_enabled || self.read_only || !self.focus_handle.is_focused(window) {

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -3902,13 +3902,7 @@ impl Window {
 
             let text_input_requires_timeout = event
                 .downcast_ref::<KeyDownEvent>()
-                .filter(|key_down| {
-                    key_down.keystroke.key_char.is_some()
-                        && key_down
-                            .keystroke
-                            .modifiers
-                            .is_subset_of(&Modifiers::shift())
-                })
+                .filter(|key_down| key_down.keystroke.key_char.is_some())
                 .and_then(|_| self.platform_window.take_input_handler())
                 .map_or(false, |mut input_handler| {
                     let accepts = input_handler.accepts_text_input(self, cx);


### PR DESCRIPTION
Part One for Resolving #10910

### Summary
Typing prefix (partial keybinding) will behave like Vim. No timeout until you either finish the sequence or hit Escape, while ambiguous sequences still auto-resolve after 1s.

### Description
This follow-up tweaks the which-key system first part groundwork so our timeout behavior matches Vim’s expectations. Then we can implement the UI part in the next step (reference latest comments in https://github.com/zed-industries/zed/pull/34798)
- `DispatchResult` now reports when the current keystrokes are already a complete binding in the active context stack (`pending_has_binding`). We only start the 1s flush timer in that case. Pure prefixes or sequences that only match in other contexts—stay pending indefinitely, so leader-style combos like `space f g` no longer evaporate after a second.
- `Window::dispatch_key_event` cancels any prior timer before scheduling a new one and only spawns the background flush task when `pending_has_binding` is true. If there’s no matching binding, we keep the pending keystrokes and rely on an explicit Escape or more typing to resolve them.

Release Notes:

- Multi-stroke keybindings (like `cmd-k cmd-s`, or `g d` in vim mode) will no-longer time out waiting for input. Before this change Zed would wait at most 1s for the second keystroke. In the case where the start of the multi-stroke binding is itself a valid key action (or input text) then the 1s timeout will still apply.