### PR TITLE
Unify archive naming for Linux bundle and install scripts

### DIFF
--- a/script/bundle-linux
+++ b/script/bundle-linux
@@ -52,8 +52,6 @@ version="$(script/get-crate-version zed)"
 # Set RELEASE_VERSION so it's compiled into GPUI and it knows about the version.
 export RELEASE_VERSION="${version}"
 
-commit=$(git rev-parse HEAD | cut -c 1-7)
-
 version_info=$(rustc --version --verbose)
 host_line=$(echo "$version_info" | grep host)
 target_triple=${host_line#*: }
@@ -169,12 +167,16 @@ chmod +x "${zed_dir}/share/applications/zed$suffix.desktop"
 cp "assets/licenses.md" "${zed_dir}/licenses.md"
 
 # Create archive out of everything that's in the temp directory
-arch=$(uname -m)
-archive="zed-linux-${arch}.tar.gz"
+target="linux-$(uname -m)"
+commit=$(git rev-parse HEAD | cut -c 1-7)
+archive="zed-${target}.tar.gz"
+if  [[ "$ZED_CHANNEL" == "dev" ]]; then
+  archive="zed-${commit}-${target}.tar.gz"
+fi
 
 rm -rf "${archive}"
-remove_match="zed(-[a-zA-Z0-9]+)?-linux-$(uname -m)\.tar\.gz"
+remove_match="zed(-[a-zA-Z0-9]+)?-${target}\.tar\.gz"
 ls "${target_dir}/release" | grep -E ${remove_match} | xargs -d "\n" -I {} rm -f "${target_dir}/release/{}" || true
 tar -czvf "${target_dir}/release/$archive" -C ${temp_dir} "zed$suffix.app"
 
-gzip -f --stdout --best "${target_dir}/${remote_server_triple}/release/remote_server" > "${target_dir}/zed-remote-server-linux-${arch}.gz"
+gzip -f --stdout --best "${target_dir}/${remote_server_triple}/release/remote_server" > "${target_dir}/zed-remote-server-${target}.gz"

--- a/script/install-linux
+++ b/script/install-linux
@@ -17,10 +17,9 @@ script/bundle-linux
 
 target="linux-$(uname -m)"
 commit=$(git rev-parse HEAD | cut -c 1-7)
+archive="zed-${target}.tar.gz"
 if  [[ "$ZED_CHANNEL" == "dev" ]]; then
   archive="zed-${commit}-${target}.tar.gz"
-else
-  archive="zed-${target}.tar.gz"
 fi
 export ZED_BUNDLE_PATH="${CARGO_TARGET_DIR:-target}/release/${archive}"
 script/install.sh


### PR DESCRIPTION
There is no issue for this fix, I haven't found anything related to this change. Right now building zed locally is not working due to misalignment in naming of the archive between scripts. I have unified the logic behind naming to make it more obvious.
Before this fix build was breaking on [this](https://github.com/zed-industries/zed/blob/main/script/install.sh#L82) line of code.

Release Notes:

- N/A