### PR TITLE
markdown: Improve table display

### DIFF
--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -5907,7 +5907,6 @@ fn default_markdown_style(
         syntax: cx.theme().syntax().clone(),
         selection_background_color: colors.element_selection_background,
         code_block_overflow_x_scroll: true,
-        table_overflow_x_scroll: true,
         heading_level_styles: Some(HeadingLevelStyles {
             h1: Some(TextStyleRefinement {
                 font_size: Some(rems(1.15).into()),


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/36330
Closes https://github.com/zed-industries/zed/issues/35460

This PR improves how we display markdown tables by relying on grids rather than flexbox. Given this makes text inside each cell wrap, I ended up removing the `table_overflow_x_scroll` method, as it was 1) used only in the agent panel, and 2) arguably not the best approach as a whole, because as soon as you need to scroll a table, you probably need more elements to make it be really great.

One thing I'm slightly unsatisfied with, though, is the border situation. I added a half pixel border to the cell so they all sum up to 1px, but there are cases where there's a tiny space between rows and I don't quite know where that's coming from and how it happens. But I think it's a reasonable improvement overall. 

<img width="500" height="1248" alt="Screenshot 2025-11-13 at 7  05@2x" src="https://github.com/user-attachments/assets/182b2235-efeb-4a61-ada2-98262967355d" />

Release Notes:

- agent: Improved table rendering in the agent panel, ensuring cell text wraps, not going off-screen.
