### PR TITLE
client: Clear plan and usage information when signing out

### DIFF
--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -1518,7 +1518,6 @@ impl Client {
     pub async fn sign_out(self: &Arc<Self>, cx: &AsyncApp) {
         self.state.write().credentials = None;
         self.cloud_client.clear_credentials();
-
         self.disconnect(cx);
 
         if self.has_credentials(cx).await {

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -1518,6 +1518,7 @@ impl Client {
     pub async fn sign_out(self: &Arc<Self>, cx: &AsyncApp) {
         self.state.write().credentials = None;
         self.cloud_client.clear_credentials();
+
         self.disconnect(cx);
 
         if self.has_credentials(cx).await {

--- a/crates/client/src/user.rs
+++ b/crates/client/src/user.rs
@@ -267,6 +267,7 @@ impl UserStore {
                         Status::SignedOut => {
                             current_user_tx.send(None).await.ok();
                             this.update(cx, |this, cx| {
+                                this.clear_plan_and_usage();
                                 cx.emit(Event::PrivateUserInfoUpdated);
                                 cx.notify();
                                 this.clear_contacts()
@@ -777,6 +778,12 @@ impl UserStore {
     ) {
         self.edit_prediction_usage = Some(usage);
         cx.notify();
+    }
+
+    pub fn clear_plan_and_usage(&mut self) {
+        self.plan_info = None;
+        self.model_request_usage = None;
+        self.edit_prediction_usage = None;
     }
 
     fn update_authenticated_user(


### PR DESCRIPTION
This PR makes it so we clear the user's plan and usage information when they sign out.

Release Notes:

- Signing out will now clear the local cache containing the plan and usage information.
