### PR TITLE
zeta2: Add minimal prompt for fine-tuned models

### DIFF
--- a/crates/cloud_llm_client/src/predict_edits_v3.rs
+++ b/crates/cloud_llm_client/src/predict_edits_v3.rs
@@ -76,6 +76,8 @@ pub enum PromptFormat {
     OldTextNewText,
     /// Prompt format intended for use via zeta_cli
     OnlySnippets,
+    /// One-sentence instructions intended for use in fine-tuned models
+    MinimalPrompt,
 }
 
 impl PromptFormat {
@@ -102,6 +104,7 @@ impl std::fmt::Display for PromptFormat {
             PromptFormat::OnlySnippets => write!(f, "Only Snippets"),
             PromptFormat::NumLinesUniDiff => write!(f, "Numbered Lines / Unified Diff"),
             PromptFormat::OldTextNewText => write!(f, "Old Text / New Text"),
+            PromptFormat::MinimalPrompt => write!(f, "Minimal Prompt"),
         }
     }
 }

--- a/crates/cloud_llm_client/src/predict_edits_v3.rs
+++ b/crates/cloud_llm_client/src/predict_edits_v3.rs
@@ -76,8 +76,8 @@ pub enum PromptFormat {
     OldTextNewText,
     /// Prompt format intended for use via zeta_cli
     OnlySnippets,
-    /// One-sentence instructions intended for use in fine-tuned models
-    MinimalPrompt,
+    /// One-sentence instructions used in fine-tuned models
+    Minimal,
 }
 
 impl PromptFormat {
@@ -104,7 +104,7 @@ impl std::fmt::Display for PromptFormat {
             PromptFormat::OnlySnippets => write!(f, "Only Snippets"),
             PromptFormat::NumLinesUniDiff => write!(f, "Numbered Lines / Unified Diff"),
             PromptFormat::OldTextNewText => write!(f, "Old Text / New Text"),
-            PromptFormat::MinimalPrompt => write!(f, "Minimal Prompt"),
+            PromptFormat::Minimal => write!(f, "Minimal"),
         }
     }
 }

--- a/crates/cloud_zeta2_prompt/src/cloud_zeta2_prompt.rs
+++ b/crates/cloud_zeta2_prompt/src/cloud_zeta2_prompt.rs
@@ -186,7 +186,7 @@ pub fn build_prompt(
         ],
         PromptFormat::LabeledSections
         | PromptFormat::NumLinesUniDiff
-        | PromptFormat::MinimalPrompt
+        | PromptFormat::Minimal
         | PromptFormat::OldTextNewText => {
             vec![(request.cursor_point, CURSOR_MARKER)]
         }
@@ -199,13 +199,13 @@ pub fn build_prompt(
         PromptFormat::NumLinesUniDiff => NUMBERED_LINES_INSTRUCTIONS.to_string(),
         PromptFormat::OldTextNewText => XML_TAGS_INSTRUCTIONS.to_string(),
         PromptFormat::OnlySnippets => String::new(),
-        PromptFormat::MinimalPrompt => STUDENT_MODEL_INSTRUCTIONS.to_string(),
+        PromptFormat::Minimal => STUDENT_MODEL_INSTRUCTIONS.to_string(),
     };
 
     if request.events.is_empty() {
         prompt.push_str("(No edit history)\n\n");
     } else {
-        let edit_preamble = if request.prompt_format == PromptFormat::MinimalPrompt {
+        let edit_preamble = if request.prompt_format == PromptFormat::Minimal {
             "The following are the latest edits made by the user, from earlier to later.\n\n"
         } else {
             "Here are the latest edits made by the user, from earlier to later.\n\n"
@@ -215,7 +215,7 @@ pub fn build_prompt(
     }
 
     let excerpts_preamble = match request.prompt_format {
-        PromptFormat::MinimalPrompt => indoc! {"
+        PromptFormat::Minimal => indoc! {"
             # Part of the file under the cursor:
 
             (The cursor marker <|user_cursor|> indicates the current user cursor position.
@@ -254,10 +254,10 @@ pub fn build_prompt(
 
         let include_line_numbers = matches!(
             request.prompt_format,
-            PromptFormat::NumLinesUniDiff | PromptFormat::MinimalPrompt
+            PromptFormat::NumLinesUniDiff | PromptFormat::Minimal
         );
         for related_file in &request.included_files {
-            if request.prompt_format == PromptFormat::MinimalPrompt {
+            if request.prompt_format == PromptFormat::Minimal {
                 write_codeblock_with_filename(
                     &related_file.path,
                     &related_file.excerpts,
@@ -294,7 +294,7 @@ pub fn build_prompt(
         PromptFormat::OldTextNewText => {
             prompt.push_str(OLD_TEXT_NEW_TEXT_REMINDER);
         }
-        PromptFormat::MinimalPrompt => {
+        PromptFormat::Minimal => {
             prompt.push_str(MINIMAL_PROMPT_REMINDER);
         }
         _ => {}
@@ -744,7 +744,7 @@ impl<'a> SyntaxBasedPrompt<'a> {
                     PromptFormat::MarkedExcerpt
                     | PromptFormat::OnlySnippets
                     | PromptFormat::OldTextNewText
-                    | PromptFormat::MinimalPrompt
+                    | PromptFormat::Minimal
                     | PromptFormat::NumLinesUniDiff => {
                         if range.start.0 > 0 && !skipped_last_snippet {
                             output.push_str("…\n");

--- a/crates/cloud_zeta2_prompt/src/cloud_zeta2_prompt.rs
+++ b/crates/cloud_zeta2_prompt/src/cloud_zeta2_prompt.rs
@@ -86,6 +86,13 @@ const NUMBERED_LINES_INSTRUCTIONS: &str = indoc! {r#"
 
 "#};
 
+const STUDENT_MODEL_INSTRUCTIONS: &str = indoc! {r#"
+    You are a code completion assistant that analyzes edit history to identify and systematically complete incomplete refactorings or patterns across the entire codebase.
+
+    # Edit History:
+
+    "#};
+
 const UNIFIED_DIFF_REMINDER: &str = indoc! {"
     ---
 
@@ -99,6 +106,14 @@ const UNIFIED_DIFF_REMINDER: &str = indoc! {"
     Context and removed lines are used to match the target edit location, so make sure to include enough of them
     to uniquely identify it amongst all excerpts of code provided.
 "};
+
+const MINIMAL_PROMPT_REMINDER: &str = indoc! {"
+    ---
+
+    Please analyze the edit history and the files, then provide the unified diff for your predicted edits.
+    Do not include the cursor marker in your output.
+    If you're editing multiple files, be sure to reflect filename in the hunk's header.
+    "};
 
 const XML_TAGS_INSTRUCTIONS: &str = indoc! {r#"
     # Instructions
@@ -171,6 +186,7 @@ pub fn build_prompt(
         ],
         PromptFormat::LabeledSections
         | PromptFormat::NumLinesUniDiff
+        | PromptFormat::MinimalPrompt
         | PromptFormat::OldTextNewText => {
             vec![(request.cursor_point, CURSOR_MARKER)]
         }
@@ -183,28 +199,47 @@ pub fn build_prompt(
         PromptFormat::NumLinesUniDiff => NUMBERED_LINES_INSTRUCTIONS.to_string(),
         PromptFormat::OldTextNewText => XML_TAGS_INSTRUCTIONS.to_string(),
         PromptFormat::OnlySnippets => String::new(),
+        PromptFormat::MinimalPrompt => STUDENT_MODEL_INSTRUCTIONS.to_string(),
     };
 
     if request.events.is_empty() {
         prompt.push_str("(No edit history)\n\n");
     } else {
-        prompt.push_str("Here are the latest edits made by the user, from earlier to later.\n\n");
+        let edit_preamble = if request.prompt_format == PromptFormat::MinimalPrompt {
+            "The following are the latest edits made by the user, from earlier to later.\n\n"
+        } else {
+            "Here are the latest edits made by the user, from earlier to later.\n\n"
+        };
+        prompt.push_str(edit_preamble);
         push_events(&mut prompt, &request.events);
     }
 
-    prompt.push_str(indoc! {"
-        # Code Excerpts
+    let excerpts_preamble = match request.prompt_format {
+        PromptFormat::MinimalPrompt => indoc! {"
+            # Part of the file under the cursor:
 
-        The cursor marker <|user_cursor|> indicates the current user cursor position.
-        The file is in current state, edits from edit history have been applied.
-    "});
+            (The cursor marker <|user_cursor|> indicates the current user cursor position.
+            The file is in current state, edits from edit history has been applied.
+            We only show part of the file around the cursor.
+            You can only edit exactly this part of the file.
+            We prepend line numbers (e.g., `123|<actual line>`); they are not part of the file.)
+            "},
+        PromptFormat::NumLinesUniDiff => indoc! {"
+            # Code Excerpts
 
-    if request.prompt_format == PromptFormat::NumLinesUniDiff {
-        prompt.push_str(indoc! {"
+            The cursor marker <|user_cursor|> indicates the current user cursor position.
+            The file is in current state, edits from edit history have been applied.
             We prepend line numbers (e.g., `123|<actual line>`); they are not part of the file.
-        "});
-    }
+            "},
+        _ => indoc! {"
+            # Code Excerpts
 
+            The cursor marker <|user_cursor|> indicates the current user cursor position.
+            The file is in current state, edits from edit history have been applied.
+        "},
+    };
+
+    prompt.push_str(excerpts_preamble);
     prompt.push('\n');
 
     let mut section_labels = Default::default();
@@ -217,19 +252,38 @@ pub fn build_prompt(
             anyhow::bail!("PromptFormat::LabeledSections cannot be used with ContextMode::Llm");
         }
 
+        let include_line_numbers = matches!(
+            request.prompt_format,
+            PromptFormat::NumLinesUniDiff | PromptFormat::MinimalPrompt
+        );
         for related_file in &request.included_files {
-            write_codeblock(
-                &related_file.path,
-                &related_file.excerpts,
-                if related_file.path == request.excerpt_path {
-                    &insertions
-                } else {
-                    &[]
-                },
-                related_file.max_row,
-                request.prompt_format == PromptFormat::NumLinesUniDiff,
-                &mut prompt,
-            );
+            if request.prompt_format == PromptFormat::MinimalPrompt {
+                write_codeblock_with_filename(
+                    &related_file.path,
+                    &related_file.excerpts,
+                    if related_file.path == request.excerpt_path {
+                        &insertions
+                    } else {
+                        &[]
+                    },
+                    related_file.max_row,
+                    include_line_numbers,
+                    &mut prompt,
+                );
+            } else {
+                write_codeblock(
+                    &related_file.path,
+                    &related_file.excerpts,
+                    if related_file.path == request.excerpt_path {
+                        &insertions
+                    } else {
+                        &[]
+                    },
+                    related_file.max_row,
+                    include_line_numbers,
+                    &mut prompt,
+                );
+            }
         }
     }
 
@@ -239,6 +293,9 @@ pub fn build_prompt(
         }
         PromptFormat::OldTextNewText => {
             prompt.push_str(OLD_TEXT_NEW_TEXT_REMINDER);
+        }
+        PromptFormat::MinimalPrompt => {
+            prompt.push_str(MINIMAL_PROMPT_REMINDER);
         }
         _ => {}
     }
@@ -255,6 +312,27 @@ pub fn write_codeblock<'a>(
     output: &'a mut String,
 ) {
     writeln!(output, "`````{}", DiffPathFmt(path)).unwrap();
+
+    write_excerpts(
+        excerpts,
+        sorted_insertions,
+        file_line_count,
+        include_line_numbers,
+        output,
+    );
+    write!(output, "`````\n\n").unwrap();
+}
+
+fn write_codeblock_with_filename<'a>(
+    path: &Path,
+    excerpts: impl IntoIterator<Item = &'a Excerpt>,
+    sorted_insertions: &[(Point, &str)],
+    file_line_count: Line,
+    include_line_numbers: bool,
+    output: &'a mut String,
+) {
+    writeln!(output, "`````filename={}", DiffPathFmt(path)).unwrap();
+
     write_excerpts(
         excerpts,
         sorted_insertions,
@@ -666,6 +744,7 @@ impl<'a> SyntaxBasedPrompt<'a> {
                     PromptFormat::MarkedExcerpt
                     | PromptFormat::OnlySnippets
                     | PromptFormat::OldTextNewText
+                    | PromptFormat::MinimalPrompt
                     | PromptFormat::NumLinesUniDiff => {
                         if range.start.0 > 0 && !skipped_last_snippet {
                             output.push_str("…\n");

--- a/crates/zeta2/src/retrieval_search.rs
+++ b/crates/zeta2/src/retrieval_search.rs
@@ -571,10 +571,15 @@ mod tests {
         expected_output: &str,
         cx: &mut TestAppContext,
     ) {
-        let results =
-            run_retrieval_searches(vec![query], project.clone(), None, &mut cx.to_async())
-                .await
-                .unwrap();
+        let results = run_retrieval_searches(
+            vec![query],
+            project.clone(),
+            #[cfg(feature = "eval-support")]
+            None,
+            &mut cx.to_async(),
+        )
+        .await
+        .unwrap();
 
         let mut results = results.into_iter().collect::<Vec<_>>();
         results.sort_by_key(|results| {

--- a/crates/zeta2/src/udiff.rs
+++ b/crates/zeta2/src/udiff.rs
@@ -49,7 +49,7 @@ pub async fn parse_diff<'a>(
             DiffEvent::FileEnd { renamed_to } => {
                 let (buffer, _) = edited_buffer
                     .take()
-                    .expect("Got a FileEnd event before an Hunk event");
+                    .context("Got a FileEnd event before an Hunk event")?;
 
                 if renamed_to.is_some() {
                     anyhow::bail!("edit predictions cannot rename files");
@@ -133,7 +133,7 @@ pub async fn apply_diff<'a>(
             DiffEvent::FileEnd { renamed_to } => {
                 let (buffer, _) = current_file
                     .take()
-                    .expect("Got a FileEnd event before an Hunk event");
+                    .context("Got a FileEnd event before an Hunk event")?;
 
                 if let Some(renamed_to) = renamed_to {
                     project

--- a/crates/zeta2/src/zeta2.rs
+++ b/crates/zeta2/src/zeta2.rs
@@ -99,11 +99,13 @@ static CONTEXT_RETRIEVAL_MODEL_ID: LazyLock<String> = LazyLock::new(|| {
     })
 });
 static EDIT_PREDICTIONS_MODEL_ID: LazyLock<String> = LazyLock::new(|| {
-    env::var("ZED_ZETA2_EP_MODEL").unwrap_or(if *USE_OLLAMA {
-        "qwen3-coder:30b".to_string()
-    } else {
-        "yqvev8r3".to_string()
-    })
+    match env::var("ZED_ZETA2_EP_MODEL").as_deref() {
+        Ok("zeta2-exp") => "4w5n28vw", // Fine-tuned model @ Baseten
+        Ok(model) => model,
+        Err(_) if *USE_OLLAMA => "qwen3-coder:30b",
+        Err(_) => "yqvev8r3", // Vanilla qwen3-coder @ Baseten
+    }
+    .to_string()
 });
 static PREDICT_EDITS_URL: LazyLock<Option<String>> = LazyLock::new(|| {
     env::var("ZED_PREDICT_EDITS_URL").ok().or_else(|| {

--- a/crates/zeta2/src/zeta2.rs
+++ b/crates/zeta2/src/zeta2.rs
@@ -99,7 +99,7 @@ static CONTEXT_RETRIEVAL_MODEL_ID: LazyLock<String> = LazyLock::new(|| {
     })
 });
 static EDIT_PREDICTIONS_MODEL_ID: LazyLock<String> = LazyLock::new(|| {
-    match env::var("ZED_ZETA2_EP_MODEL").as_deref() {
+    match env::var("ZED_ZETA2_MODEL").as_deref() {
         Ok("zeta2-exp") => "4w5n28vw", // Fine-tuned model @ Baseten
         Ok(model) => model,
         Err(_) if *USE_OLLAMA => "qwen3-coder:30b",
@@ -1022,7 +1022,7 @@ impl Zeta {
                         // TODO: Implement parsing of multi-file diffs
                         crate::udiff::parse_diff(&output_text, get_buffer_from_context).await?
                     }
-                    PromptFormat::MinimalPrompt => {
+                    PromptFormat::Minimal => {
                         if output_text.contains("--- a/\n+++ b/\nNo edits") {
                             let edits = vec![];
                             (&active_snapshot, edits)

--- a/crates/zeta_cli/src/main.rs
+++ b/crates/zeta_cli/src/main.rs
@@ -175,7 +175,7 @@ enum PromptFormat {
     #[default]
     NumberedLines,
     OldTextNewText,
-    MinimalPrompt,
+    Minimal,
 }
 
 impl Into<predict_edits_v3::PromptFormat> for PromptFormat {
@@ -186,7 +186,7 @@ impl Into<predict_edits_v3::PromptFormat> for PromptFormat {
             Self::OnlySnippets => predict_edits_v3::PromptFormat::OnlySnippets,
             Self::NumberedLines => predict_edits_v3::PromptFormat::NumLinesUniDiff,
             Self::OldTextNewText => predict_edits_v3::PromptFormat::OldTextNewText,
-            Self::MinimalPrompt => predict_edits_v3::PromptFormat::MinimalPrompt,
+            Self::Minimal => predict_edits_v3::PromptFormat::Minimal,
         }
     }
 }

--- a/crates/zeta_cli/src/main.rs
+++ b/crates/zeta_cli/src/main.rs
@@ -175,6 +175,7 @@ enum PromptFormat {
     #[default]
     NumberedLines,
     OldTextNewText,
+    MinimalPrompt,
 }
 
 impl Into<predict_edits_v3::PromptFormat> for PromptFormat {
@@ -185,6 +186,7 @@ impl Into<predict_edits_v3::PromptFormat> for PromptFormat {
             Self::OnlySnippets => predict_edits_v3::PromptFormat::OnlySnippets,
             Self::NumberedLines => predict_edits_v3::PromptFormat::NumLinesUniDiff,
             Self::OldTextNewText => predict_edits_v3::PromptFormat::OldTextNewText,
+            Self::MinimalPrompt => predict_edits_v3::PromptFormat::MinimalPrompt,
         }
     }
 }

--- a/crates/zeta_cli/src/predict.rs
+++ b/crates/zeta_cli/src/predict.rs
@@ -126,7 +126,7 @@ pub async fn zeta2_predict(
         example_run_dir = example_run_dir.join(format!("{:03}", repetition_ix));
     }
     fs::create_dir_all(&example_run_dir)?;
-    if LATEST_EXAMPLE_RUN_DIR.exists() {
+    if LATEST_EXAMPLE_RUN_DIR.is_symlink() {
         fs::remove_file(&*LATEST_EXAMPLE_RUN_DIR)?;
     }
 


### PR DESCRIPTION
1. Add `--prompt-format=minimal` that matches single-sentence instructions used in fine-tuned models (specifically, in `1028-*` and `1029-*` models)

2. Use separate configs for agentic context search model and edit prediction model. This is useful when running a fine-tuned EP model, but we still want to run vanilla model for context retrieval.

3. `zeta2-exp` is a symlink to the same-named Baseten deployment. This model can be redeployed and updated without having to update the deployment id.

Release Notes:

- N/A
