### PR TITLE
quick fix: Circumvent staff-only collab connection

### DIFF
--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -653,8 +653,9 @@ impl TitleBar {
                 window
                     .spawn(cx, async move |cx| {
                         client
-                            .sign_in_with_optional_connect(true, cx)
+                            .connect(true, cx)
                             .await
+                            .into_response()
                             .notify_async_err(cx);
                     })
                     .detach();


### PR DESCRIPTION
Switch the title bar sign in button to use the same sign in method as the collab panel. This is only for illustration purposes.

Closes #ISSUE (No current issue; Discussion over email with Esther.)

Release Notes:

- N/A 
