### PR TITLE
Improve the location of pop-up windows

### DIFF
--- a/crates/workspace/src/window_utils.rs
+++ b/crates/workspace/src/window_utils.rs
@@ -1,0 +1,58 @@
+use gpui::{App, Bounds, DisplayId, Pixels, Size, WindowBounds, WindowHandle};
+
+/// Return the DisplayId of the monitor that contains the center of the given window handle.
+pub fn display_id_for_window_center<T: 'static>(
+    handle: &WindowHandle<T>,
+    cx: &mut App,
+) -> Option<DisplayId> {
+    handle
+        .update(cx, |_, window, cx| {
+            let center = window.bounds().center();
+            cx.displays()
+                .into_iter()
+                .find(|display| display.bounds().contains(&center))
+                .map(|display| display.id())
+        })
+        .ok()
+        .flatten()
+}
+
+/// Compute centered window bounds on the display containing the given window handle.
+pub fn centered_bounds_for_window_display<T: 'static>(
+    handle: &WindowHandle<T>,
+    size: Size<Pixels>,
+    cx: &mut App,
+) -> WindowBounds {
+    let display_id = display_id_for_window_center(handle, cx);
+    WindowBounds::Windowed(Bounds::centered(display_id, size, cx))
+}
+
+/// Compute centered window bounds on a given display id (or primary if None).
+pub fn centered_bounds_for_display_id(
+    display_id: Option<DisplayId>,
+    size: Size<Pixels>,
+    cx: &mut App,
+) -> WindowBounds {
+    WindowBounds::Windowed(Bounds::centered(display_id, size, cx))
+}
+
+/// Return the DisplayId for the currently active window (if any).
+pub fn active_display_id(cx: &mut App) -> Option<DisplayId> {
+    cx.active_window().and_then(|handle| {
+        handle
+            .update(cx, |_, window, cx| {
+                let center = window.bounds().center();
+                cx.displays()
+                    .into_iter()
+                    .find(|display| display.bounds().contains(&center))
+                    .map(|display| display.id())
+            })
+            .ok()
+            .flatten()
+    })
+}
+
+/// Compute centered window bounds on the display of the currently active window (if any).
+pub fn centered_bounds_for_active_display(size: Size<Pixels>, cx: &mut App) -> WindowBounds {
+    WindowBounds::Windowed(Bounds::centered(active_display_id(cx), size, cx))
+}

--- a/crates/workspace/src/window_utils.rs
+++ b/crates/workspace/src/window_utils.rs
@@ -17,16 +17,6 @@ pub fn display_id_for_window_center<T: 'static>(
         .flatten()
 }
 
-/// Compute centered window bounds on the display containing the given window handle.
-pub fn centered_bounds_for_window_display<T: 'static>(
-    handle: &WindowHandle<T>,
-    size: Size<Pixels>,
-    cx: &mut App,
-) -> WindowBounds {
-    let display_id = display_id_for_window_center(handle, cx);
-    WindowBounds::Windowed(Bounds::centered(display_id, size, cx))
-}
-
 /// Compute centered window bounds on a given display id (or primary if None).
 pub fn centered_bounds_for_display_id(
     display_id: Option<DisplayId>,
@@ -50,9 +40,4 @@ pub fn active_display_id(cx: &mut App) -> Option<DisplayId> {
             .ok()
             .flatten()
     })
-}
-
-/// Compute centered window bounds on the display of the currently active window (if any).
-pub fn centered_bounds_for_active_display(size: Size<Pixels>, cx: &mut App) -> WindowBounds {
-    WindowBounds::Windowed(Bounds::centered(active_display_id(cx), size, cx))
 }

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -15,6 +15,7 @@ pub mod tasks;
 mod theme_preview;
 mod toast_layer;
 mod toolbar;
+pub mod window_utils;
 mod workspace_settings;
 
 pub use crate::notifications::NotificationFrame;


### PR DESCRIPTION
Improve the location where settings and rule pop-ups appear. When the user has multiple monitors and the zed editor is not in the main window, the opened settings/rules pop-up window will always appear in the main monitor. This PR adjusts this behavior so that its pop-up window always appears in the monitor of the last focused ze editor pop-up window.

Release Notes:

- Improve the location of pop-up windows
