### PR TITLE
multi_buffer: Typed `MultiBufferOffset`

### DIFF
--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -6066,6 +6066,7 @@ pub(crate) mod tests {
     use acp_thread::StubAgentConnection;
     use agent_client_protocol::SessionId;
     use assistant_text_thread::TextThreadStore;
+    use editor::MultiBufferOffset;
     use fs::FakeFs;
     use gpui::{EventEmitter, SemanticVersion, TestAppContext, VisualTestContext};
     use project::Project;
@@ -7234,7 +7235,7 @@ pub(crate) mod tests {
                         Editor::for_buffer(buffer.clone(), Some(project.clone()), window, cx);
 
                     editor.change_selections(Default::default(), window, cx, |selections| {
-                        selections.select_ranges([8..15]);
+                        selections.select_ranges([MultiBufferOffset(8)..MultiBufferOffset(15)]);
                     });
 
                     editor
@@ -7296,7 +7297,7 @@ pub(crate) mod tests {
                         Editor::for_buffer(buffer.clone(), Some(project.clone()), window, cx);
 
                     editor.change_selections(Default::default(), window, cx, |selections| {
-                        selections.select_ranges([8..15]);
+                        selections.select_ranges([MultiBufferOffset(8)..MultiBufferOffset(15)]);
                     });
 
                     editor

--- a/crates/agent_ui/src/buffer_codegen.rs
+++ b/crates/agent_ui/src/buffer_codegen.rs
@@ -429,7 +429,12 @@ impl CodegenAlternative {
 
         let prompt = self
             .builder
-            .generate_inline_transformation_prompt(user_prompt, language_name, buffer, range)
+            .generate_inline_transformation_prompt(
+                user_prompt,
+                language_name,
+                buffer,
+                range.start.0..range.end.0,
+            )
             .context("generating content prompt")?;
 
         let context_task = self.context_store.as_ref().and_then(|context_store| {

--- a/crates/agent_ui/src/context_picker/completion_provider.rs
+++ b/crates/agent_ui/src/context_picker/completion_provider.rs
@@ -1082,7 +1082,7 @@ impl MentionCompletion {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use editor::AnchorRangeExt;
+    use editor::{AnchorRangeExt, MultiBufferOffset};
     use gpui::{EventEmitter, FocusHandle, Focusable, TestAppContext, VisualTestContext};
     use project::{Project, ProjectPath};
     use serde_json::json;
@@ -1677,7 +1677,7 @@ mod tests {
         editor.display_map.update(cx, |display_map, cx| {
             display_map
                 .snapshot(cx)
-                .folds_in_range(0..snapshot.len())
+                .folds_in_range(MultiBufferOffset(0)..snapshot.len())
                 .map(|fold| fold.range.to_point(&snapshot))
                 .collect()
         })

--- a/crates/agent_ui/src/inline_prompt_editor.rs
+++ b/crates/agent_ui/src/inline_prompt_editor.rs
@@ -2,7 +2,7 @@ use agent::HistoryStore;
 use collections::{HashMap, VecDeque};
 use editor::actions::Paste;
 use editor::display_map::{CreaseId, EditorMargins};
-use editor::{Addon, AnchorRangeExt as _};
+use editor::{Addon, AnchorRangeExt as _, MultiBufferOffset};
 use editor::{
     ContextMenuOptions, Editor, EditorElement, EditorEvent, EditorMode, EditorStyle, MultiBuffer,
     actions::{MoveDown, MoveUp},
@@ -1165,7 +1165,7 @@ impl GenerationMode {
 /// Stored information that can be used to resurrect a context crease when creating an editor for a past message.
 #[derive(Clone, Debug)]
 pub struct MessageCrease {
-    pub range: Range<usize>,
+    pub range: Range<MultiBufferOffset>,
     pub icon_path: SharedString,
     pub label: SharedString,
     /// None for a deserialized message, Some otherwise.

--- a/crates/agent_ui/src/text_thread_editor.rs
+++ b/crates/agent_ui/src/text_thread_editor.rs
@@ -9,8 +9,8 @@ use assistant_slash_commands::{DefaultSlashCommand, FileSlashCommand, selections
 use client::{proto, zed_urls};
 use collections::{BTreeSet, HashMap, HashSet, hash_map};
 use editor::{
-    Anchor, Editor, EditorEvent, MenuEditPredictionsPolicy, MultiBuffer, MultiBufferSnapshot,
-    RowExt, ToOffset as _, ToPoint,
+    Anchor, Editor, EditorEvent, MenuEditPredictionsPolicy, MultiBuffer, MultiBufferOffset,
+    MultiBufferSnapshot, RowExt, ToOffset as _, ToPoint,
     actions::{MoveToEndOfLine, Newline, ShowCompletions},
     display_map::{
         BlockPlacement, BlockProperties, BlockStyle, Crease, CreaseMetadata, CustomBlockId, FoldId,
@@ -390,7 +390,7 @@ impl TextThreadEditor {
                 let cursor = user_message
                     .start
                     .to_offset(self.text_thread.read(cx).buffer().read(cx));
-                cursor..cursor
+                MultiBufferOffset(cursor)..MultiBufferOffset(cursor)
             };
             self.editor.update(cx, |editor, cx| {
                 editor.change_selections(Default::default(), window, cx, |selections| {
@@ -431,7 +431,7 @@ impl TextThreadEditor {
         let cursors = self.cursors(cx);
         self.text_thread.update(cx, |text_thread, cx| {
             let messages = text_thread
-                .messages_for_offsets(cursors, cx)
+                .messages_for_offsets(cursors.into_iter().map(|cursor| cursor.0), cx)
                 .into_iter()
                 .map(|message| message.id)
                 .collect();
@@ -439,9 +439,11 @@ impl TextThreadEditor {
         });
     }
 
-    fn cursors(&self, cx: &mut App) -> Vec<usize> {
+    fn cursors(&self, cx: &mut App) -> Vec<MultiBufferOffset> {
         let selections = self.editor.update(cx, |editor, cx| {
-            editor.selections.all::<usize>(&editor.display_snapshot(cx))
+            editor
+                .selections
+                .all::<MultiBufferOffset>(&editor.display_snapshot(cx))
         });
         selections
             .into_iter()
@@ -1580,7 +1582,11 @@ impl TextThreadEditor {
     fn get_clipboard_contents(
         &mut self,
         cx: &mut Context<Self>,
-    ) -> (String, CopyMetadata, Vec<text::Selection<usize>>) {
+    ) -> (
+        String,
+        CopyMetadata,
+        Vec<text::Selection<MultiBufferOffset>>,
+    ) {
         let (mut selection, creases) = self.editor.update(cx, |editor, cx| {
             let mut selection = editor
                 .selections
@@ -1638,30 +1644,26 @@ impl TextThreadEditor {
 
         // If selection is empty, we want to copy the entire line
         if selection.range().is_empty() {
-            let snapshot = text_thread.buffer().read(cx).snapshot();
+            let snapshot = self.editor.read(cx).buffer().read(cx).snapshot(cx);
             let point = snapshot.offset_to_point(selection.range().start);
             selection.start = snapshot.point_to_offset(Point::new(point.row, 0));
             selection.end = snapshot
                 .point_to_offset(cmp::min(Point::new(point.row + 1, 0), snapshot.max_point()));
-            for chunk in text_thread
-                .buffer()
-                .read(cx)
-                .text_for_range(selection.range())
-            {
+            for chunk in snapshot.text_for_range(selection.range()) {
                 text.push_str(chunk);
             }
         } else {
             for message in text_thread.messages(cx) {
-                if message.offset_range.start >= selection.range().end {
+                if message.offset_range.start >= selection.range().end.0 {
                     break;
-                } else if message.offset_range.end >= selection.range().start {
-                    let range = cmp::max(message.offset_range.start, selection.range().start)
-                        ..cmp::min(message.offset_range.end, selection.range().end);
+                } else if message.offset_range.end >= selection.range().start.0 {
+                    let range = cmp::max(message.offset_range.start, selection.range().start.0)
+                        ..cmp::min(message.offset_range.end, selection.range().end.0);
                     if !range.is_empty() {
                         for chunk in text_thread.buffer().read(cx).text_for_range(range) {
                             text.push_str(chunk);
                         }
-                        if message.offset_range.end < selection.range().end {
+                        if message.offset_range.end < selection.range().end.0 {
                             text.push('\n');
                         }
                     }
@@ -1743,7 +1745,7 @@ impl TextThreadEditor {
             self.editor.update(cx, |editor, cx| {
                 let paste_position = editor
                     .selections
-                    .newest::<usize>(&editor.display_snapshot(cx))
+                    .newest::<MultiBufferOffset>(&editor.display_snapshot(cx))
                     .head();
                 editor.paste(action, window, cx);
 
@@ -1791,13 +1793,16 @@ impl TextThreadEditor {
                 editor.transact(window, cx, |editor, _window, cx| {
                     let edits = editor
                         .selections
-                        .all::<usize>(&editor.display_snapshot(cx))
+                        .all::<MultiBufferOffset>(&editor.display_snapshot(cx))
                         .into_iter()
                         .map(|selection| (selection.start..selection.end, "\n"));
                     editor.edit(edits, cx);
 
                     let snapshot = editor.buffer().read(cx).snapshot(cx);
-                    for selection in editor.selections.all::<usize>(&editor.display_snapshot(cx)) {
+                    for selection in editor
+                        .selections
+                        .all::<MultiBufferOffset>(&editor.display_snapshot(cx))
+                    {
                         image_positions.push(snapshot.anchor_before(selection.end));
                     }
                 });
@@ -1889,7 +1894,7 @@ impl TextThreadEditor {
                 let range = selection
                     .map(|endpoint| endpoint.to_offset(&buffer))
                     .range();
-                text_thread.split_message(range, cx);
+                text_thread.split_message(range.start.0..range.end.0, cx);
             }
         });
     }
@@ -2963,7 +2968,7 @@ pub fn make_lsp_adapter_delegate(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use editor::SelectionEffects;
+    use editor::{MultiBufferOffset, SelectionEffects};
     use fs::FakeFs;
     use gpui::{App, TestAppContext, VisualTestContext};
     use indoc::indoc;
@@ -3169,15 +3174,16 @@ mod tests {
         text_thread: &Entity<TextThread>,
         message_ix: usize,
         cx: &mut TestAppContext,
-    ) -> Range<usize> {
-        text_thread.update(cx, |text_thread, cx| {
+    ) -> Range<MultiBufferOffset> {
+        let range = text_thread.update(cx, |text_thread, cx| {
             text_thread
                 .messages(cx)
                 .nth(message_ix)
                 .unwrap()
                 .anchor_range
                 .to_offset(&text_thread.buffer().read(cx).snapshot())
-        })
+        });
+        MultiBufferOffset(range.start)..MultiBufferOffset(range.end)
     }
 
     fn assert_copy_paste_text_thread_editor<T: editor::ToOffset>(

--- a/crates/assistant_text_thread/src/text_thread.rs
+++ b/crates/assistant_text_thread/src/text_thread.rs
@@ -667,7 +667,7 @@ pub struct TextThread {
     buffer: Entity<Buffer>,
     pub(crate) parsed_slash_commands: Vec<ParsedSlashCommand>,
     invoked_slash_commands: HashMap<InvokedSlashCommandId, InvokedSlashCommand>,
-    edits_since_last_parse: language::Subscription,
+    edits_since_last_parse: language::Subscription<usize>,
     slash_commands: Arc<SlashCommandWorkingSet>,
     pub(crate) slash_command_output_sections: Vec<SlashCommandOutputSection<language::Anchor>>,
     thought_process_output_sections: Vec<ThoughtProcessOutputSection<language::Anchor>>,

--- a/crates/collab/src/tests/channel_buffer_tests.rs
+++ b/crates/collab/src/tests/channel_buffer_tests.rs
@@ -7,7 +7,7 @@ use channel::ACKNOWLEDGE_DEBOUNCE_INTERVAL;
 use client::{Collaborator, ParticipantIndex, UserId};
 use collab_ui::channel_view::ChannelView;
 use collections::HashMap;
-use editor::{Anchor, Editor, ToOffset};
+use editor::{Anchor, Editor, MultiBufferOffset, ToOffset};
 use futures::future;
 use gpui::{BackgroundExecutor, Context, Entity, TestAppContext, Window};
 use rpc::{RECEIVE_TIMEOUT, proto::PeerId};
@@ -180,7 +180,7 @@ async fn test_channel_notes_participant_indices(
         notes.editor.update(cx, |editor, cx| {
             editor.insert("a", window, cx);
             editor.change_selections(Default::default(), window, cx, |selections| {
-                selections.select_ranges(vec![0..1]);
+                selections.select_ranges(vec![MultiBufferOffset(0)..MultiBufferOffset(1)]);
             });
         });
     });
@@ -190,7 +190,7 @@ async fn test_channel_notes_participant_indices(
             editor.move_down(&Default::default(), window, cx);
             editor.insert("b", window, cx);
             editor.change_selections(Default::default(), window, cx, |selections| {
-                selections.select_ranges(vec![1..2]);
+                selections.select_ranges(vec![MultiBufferOffset(1)..MultiBufferOffset(2)]);
             });
         });
     });
@@ -200,7 +200,7 @@ async fn test_channel_notes_participant_indices(
             editor.move_down(&Default::default(), window, cx);
             editor.insert("c", window, cx);
             editor.change_selections(Default::default(), window, cx, |selections| {
-                selections.select_ranges(vec![2..3]);
+                selections.select_ranges(vec![MultiBufferOffset(2)..MultiBufferOffset(3)]);
             });
         });
     });
@@ -287,12 +287,12 @@ async fn test_channel_notes_participant_indices(
 
     editor_a.update_in(cx_a, |editor, window, cx| {
         editor.change_selections(Default::default(), window, cx, |selections| {
-            selections.select_ranges(vec![0..1]);
+            selections.select_ranges(vec![MultiBufferOffset(0)..MultiBufferOffset(1)]);
         });
     });
     editor_b.update_in(cx_b, |editor, window, cx| {
         editor.change_selections(Default::default(), window, cx, |selections| {
-            selections.select_ranges(vec![2..3]);
+            selections.select_ranges(vec![MultiBufferOffset(2)..MultiBufferOffset(3)]);
         });
     });
     executor.run_until_parked();
@@ -327,7 +327,7 @@ fn assert_remote_selections(
             let end = s.selection.end.to_offset(snapshot.buffer_snapshot());
             let user_id = collaborators.get(&peer_id).unwrap().user_id;
             let participant_index = hub.user_participant_indices(cx).get(&user_id).copied();
-            (participant_index, start..end)
+            (participant_index, start.0..end.0)
         })
         .collect::<Vec<_>>();
     assert_eq!(

--- a/crates/collab/src/tests/editor_tests.rs
+++ b/crates/collab/src/tests/editor_tests.rs
@@ -4,7 +4,8 @@ use crate::{
 };
 use call::ActiveCall;
 use editor::{
-    DocumentColorsRenderMode, Editor, FETCH_COLORS_DEBOUNCE_TIMEOUT, RowInfo, SelectionEffects,
+    DocumentColorsRenderMode, Editor, FETCH_COLORS_DEBOUNCE_TIMEOUT, MultiBufferOffset, RowInfo,
+    SelectionEffects,
     actions::{
         ConfirmCodeAction, ConfirmCompletion, ConfirmRename, ContextMenuFirst,
         ExpandMacroRecursively, MoveToEnd, Redo, Rename, SelectAll, ToggleCodeActions, Undo,
@@ -381,7 +382,7 @@ async fn test_collaborating_with_completion(cx_a: &mut TestAppContext, cx_b: &mu
     // Type a completion trigger character as the guest.
     editor_b.update_in(cx_b, |editor, window, cx| {
         editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
-            s.select_ranges([13..13])
+            s.select_ranges([MultiBufferOffset(13)..MultiBufferOffset(13)])
         });
         editor.handle_input(".", window, cx);
     });
@@ -503,7 +504,7 @@ async fn test_collaborating_with_completion(cx_a: &mut TestAppContext, cx_b: &mu
     // resolved
     editor_b.update_in(cx_b, |editor, window, cx| {
         editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
-            s.select_ranges([46..46])
+            s.select_ranges([MultiBufferOffset(46)..MultiBufferOffset(46)])
         });
         editor.handle_input("; a", window, cx);
         editor.handle_input(".", window, cx);
@@ -950,7 +951,7 @@ async fn test_collaborating_with_renames(cx_a: &mut TestAppContext, cx_b: &mut T
     // Move cursor to a location that can be renamed.
     let prepare_rename = editor_b.update_in(cx_b, |editor, window, cx| {
         editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
-            s.select_ranges([7..7])
+            s.select_ranges([MultiBufferOffset(7)..MultiBufferOffset(7)])
         });
         editor.rename(&Rename, window, cx).unwrap()
     });
@@ -977,17 +978,17 @@ async fn test_collaborating_with_renames(cx_a: &mut TestAppContext, cx_b: &mut T
         let buffer = editor.buffer().read(cx).snapshot(cx);
         assert_eq!(
             rename.range.start.to_offset(&buffer)..rename.range.end.to_offset(&buffer),
-            6..9
+            MultiBufferOffset(6)..MultiBufferOffset(9)
         );
         rename.editor.update(cx, |rename_editor, cx| {
-            let rename_selection = rename_editor.selections.newest::<usize>(&rename_editor.display_snapshot(cx));
+            let rename_selection = rename_editor.selections.newest::<MultiBufferOffset>(&rename_editor.display_snapshot(cx));
             assert_eq!(
                 rename_selection.range(),
-                0..3,
+                MultiBufferOffset(0)..MultiBufferOffset(3),
                 "Rename that was triggered from zero selection caret, should propose the whole word."
             );
             rename_editor.buffer().update(cx, |rename_buffer, cx| {
-                rename_buffer.edit([(0..3, "THREE")], None, cx);
+                rename_buffer.edit([(MultiBufferOffset(0)..MultiBufferOffset(3), "THREE")], None, cx);
             });
         });
     });
@@ -998,7 +999,7 @@ async fn test_collaborating_with_renames(cx_a: &mut TestAppContext, cx_b: &mut T
     });
     let prepare_rename = editor_b.update_in(cx_b, |editor, window, cx| {
         editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
-            s.select_ranges([7..8])
+            s.select_ranges([MultiBufferOffset(7)..MultiBufferOffset(8)])
         });
         editor.rename(&Rename, window, cx).unwrap()
     });
@@ -1025,16 +1026,16 @@ async fn test_collaborating_with_renames(cx_a: &mut TestAppContext, cx_b: &mut T
         let buffer = editor.buffer().read(cx).snapshot(cx);
         let lsp_rename_start = rename.range.start.to_offset(&buffer);
         let lsp_rename_end = rename.range.end.to_offset(&buffer);
-        assert_eq!(lsp_rename_start..lsp_rename_end, 6..9);
+        assert_eq!(lsp_rename_start..lsp_rename_end, MultiBufferOffset(6)..MultiBufferOffset(9));
         rename.editor.update(cx, |rename_editor, cx| {
-            let rename_selection = rename_editor.selections.newest::<usize>(&rename_editor.display_snapshot(cx));
+            let rename_selection = rename_editor.selections.newest::<MultiBufferOffset>(&rename_editor.display_snapshot(cx));
             assert_eq!(
                 rename_selection.range(),
-                1..2,
+                MultiBufferOffset(1)..MultiBufferOffset(2),
                 "Rename that was triggered from a selection, should have the same selection range in the rename proposal"
             );
             rename_editor.buffer().update(cx, |rename_buffer, cx| {
-                rename_buffer.edit([(0..lsp_rename_end - lsp_rename_start, "THREE")], None, cx);
+                rename_buffer.edit([(MultiBufferOffset(0)..MultiBufferOffset(lsp_rename_end - lsp_rename_start), "THREE")], None, cx);
             });
         });
     });
@@ -1237,7 +1238,7 @@ async fn test_slow_lsp_server(cx_a: &mut TestAppContext, cx_b: &mut TestAppConte
     // Move cursor to a location, this should trigger the code lens call.
     editor_b.update_in(cx_b, |editor, window, cx| {
         editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
-            s.select_ranges([7..7])
+            s.select_ranges([MultiBufferOffset(7)..MultiBufferOffset(7)])
         });
     });
     let () = request_started_rx.next().await.unwrap();
@@ -1259,7 +1260,7 @@ async fn test_slow_lsp_server(cx_a: &mut TestAppContext, cx_b: &mut TestAppConte
 
     editor_b.update_in(cx_b, |editor, window, cx| {
         editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
-            s.select_ranges([1..1])
+            s.select_ranges([MultiBufferOffset(1)..MultiBufferOffset(1)])
         });
     });
     let () = request_started_rx.next().await.unwrap();
@@ -1281,7 +1282,7 @@ async fn test_slow_lsp_server(cx_a: &mut TestAppContext, cx_b: &mut TestAppConte
 
     editor_b.update_in(cx_b, |editor, window, cx| {
         editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
-            s.select_ranges([2..2])
+            s.select_ranges([MultiBufferOffset(2)..MultiBufferOffset(2)])
         });
     });
     let () = request_started_rx.next().await.unwrap();
@@ -1719,7 +1720,7 @@ async fn test_on_input_format_from_host_to_guest(
     cx_a.focus(&editor_a);
     editor_a.update_in(cx_a, |editor, window, cx| {
         editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
-            s.select_ranges([13..13])
+            s.select_ranges([MultiBufferOffset(13)..MultiBufferOffset(13)])
         });
         editor.handle_input(">", window, cx);
     });
@@ -1828,7 +1829,7 @@ async fn test_on_input_format_from_guest_to_host(
     cx_b.focus(&editor_b);
     editor_b.update_in(cx_b, |editor, window, cx| {
         editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
-            s.select_ranges([13..13])
+            s.select_ranges([MultiBufferOffset(13)..MultiBufferOffset(13)])
         });
         editor.handle_input(":", window, cx);
     });
@@ -2056,7 +2057,7 @@ async fn test_mutual_editor_inlay_hint_cache_update(
     let after_client_edit = edits_made.fetch_add(1, atomic::Ordering::Release) + 1;
     editor_b.update_in(cx_b, |editor, window, cx| {
         editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
-            s.select_ranges([13..13].clone())
+            s.select_ranges([MultiBufferOffset(13)..MultiBufferOffset(13)].clone())
         });
         editor.handle_input(":", window, cx);
     });
@@ -2080,7 +2081,7 @@ async fn test_mutual_editor_inlay_hint_cache_update(
     let after_host_edit = edits_made.fetch_add(1, atomic::Ordering::Release) + 1;
     editor_a.update_in(cx_a, |editor, window, cx| {
         editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
-            s.select_ranges([13..13])
+            s.select_ranges([MultiBufferOffset(13)..MultiBufferOffset(13)])
         });
         editor.handle_input("a change to increment both buffers' versions", window, cx);
     });
@@ -2520,7 +2521,7 @@ async fn test_lsp_document_color(cx_a: &mut TestAppContext, cx_b: &mut TestAppCo
 
     editor_a.update_in(cx_a, |editor, window, cx| {
         editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
-            s.select_ranges([13..13].clone())
+            s.select_ranges([MultiBufferOffset(13)..MultiBufferOffset(13)].clone())
         });
         editor.handle_input(":", window, cx);
     });
@@ -2957,7 +2958,7 @@ async fn test_lsp_pull_diagnostics(
     editor_a_main.update(cx_a, |editor, cx| {
         let snapshot = editor.buffer().read(cx).snapshot(cx);
         let all_diagnostics = snapshot
-            .diagnostics_in_range(0..snapshot.len())
+            .diagnostics_in_range(MultiBufferOffset(0)..snapshot.len())
             .collect::<Vec<_>>();
         assert_eq!(
             all_diagnostics.len(),
@@ -3086,7 +3087,7 @@ async fn test_lsp_pull_diagnostics(
     editor_a_main.update(cx_a, |editor, cx| {
         let snapshot = editor.buffer().read(cx).snapshot(cx);
         let all_diagnostics = snapshot
-            .diagnostics_in_range(0..snapshot.len())
+            .diagnostics_in_range(MultiBufferOffset(0)..snapshot.len())
             .collect::<Vec<_>>();
         assert_eq!(
             all_diagnostics.len(),
@@ -3133,7 +3134,7 @@ async fn test_lsp_pull_diagnostics(
     editor_b_main.update(cx_b, |editor, cx| {
         let snapshot = editor.buffer().read(cx).snapshot(cx);
         let all_diagnostics = snapshot
-            .diagnostics_in_range(0..snapshot.len())
+            .diagnostics_in_range(MultiBufferOffset(0)..snapshot.len())
             .collect::<Vec<_>>();
         assert_eq!(
             all_diagnostics.len(),
@@ -3180,7 +3181,7 @@ async fn test_lsp_pull_diagnostics(
     editor_b_lib.update(cx_b, |editor, cx| {
         let snapshot = editor.buffer().read(cx).snapshot(cx);
         let all_diagnostics = snapshot
-            .diagnostics_in_range(0..snapshot.len())
+            .diagnostics_in_range(MultiBufferOffset(0)..snapshot.len())
             .collect::<Vec<_>>();
         let expected_messages = [
             expected_pull_diagnostic_lib_message,
@@ -3247,7 +3248,7 @@ async fn test_lsp_pull_diagnostics(
         editor_b_lib.update(cx_b, |editor, cx| {
             let snapshot = editor.buffer().read(cx).snapshot(cx);
             let all_diagnostics = snapshot
-                .diagnostics_in_range(0..snapshot.len())
+                .diagnostics_in_range(MultiBufferOffset(0)..snapshot.len())
                 .collect::<Vec<_>>();
             let expected_messages = [
                 expected_workspace_pull_diagnostics_lib_message,
@@ -3382,7 +3383,7 @@ async fn test_lsp_pull_diagnostics(
     editor_b_lib.update(cx_b, |editor, cx| {
         let snapshot = editor.buffer().read(cx).snapshot(cx);
         let all_diagnostics = snapshot
-            .diagnostics_in_range(0..snapshot.len())
+            .diagnostics_in_range(MultiBufferOffset(0)..snapshot.len())
             .collect::<Vec<_>>();
         let expected_messages = [
             expected_workspace_pull_diagnostics_lib_message,
@@ -3400,7 +3401,7 @@ async fn test_lsp_pull_diagnostics(
     editor_b_main.update(cx_b, |editor, cx| {
         let snapshot = editor.buffer().read(cx).snapshot(cx);
         let all_diagnostics = snapshot
-            .diagnostics_in_range(0..snapshot.len())
+            .diagnostics_in_range(MultiBufferOffset(0)..snapshot.len())
             .collect::<Vec<_>>();
         assert_eq!(all_diagnostics.len(), 2);
 
@@ -3419,7 +3420,7 @@ async fn test_lsp_pull_diagnostics(
     editor_a_main.update(cx_a, |editor, cx| {
         let snapshot = editor.buffer().read(cx).snapshot(cx);
         let all_diagnostics = snapshot
-            .diagnostics_in_range(0..snapshot.len())
+            .diagnostics_in_range(MultiBufferOffset(0)..snapshot.len())
             .collect::<Vec<_>>();
         assert_eq!(all_diagnostics.len(), 2);
         let expected_messages = [

--- a/crates/collab/src/tests/editor_tests.rs
+++ b/crates/collab/src/tests/editor_tests.rs
@@ -601,7 +601,7 @@ async fn test_collaborating_with_completion(cx_a: &mut TestAppContext, cx_b: &mu
     // Add another completion trigger to test the second language server
     editor_b.update_in(cx_b, |editor, window, cx| {
         editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
-            s.select_ranges([68..68])
+            s.select_ranges([MultiBufferOffset(68)..MultiBufferOffset(68)])
         });
         editor.handle_input("; b", window, cx);
         editor.handle_input(".", window, cx);

--- a/crates/collab/src/tests/following_tests.rs
+++ b/crates/collab/src/tests/following_tests.rs
@@ -6,7 +6,7 @@ use collab_ui::{
     channel_view::ChannelView,
     notifications::project_shared_notification::ProjectSharedNotification,
 };
-use editor::{Editor, MultiBuffer, PathKey, SelectionEffects};
+use editor::{Editor, MultiBuffer, MultiBufferOffset, PathKey, SelectionEffects};
 use gpui::{
     AppContext as _, BackgroundExecutor, BorrowAppContext, Entity, SharedString, TestAppContext,
     VisualContext, VisualTestContext, point,
@@ -124,7 +124,7 @@ async fn test_basic_following(
         editor.select_left(&Default::default(), window, cx);
         assert_eq!(
             editor.selections.ranges(&editor.display_snapshot(cx)),
-            vec![3..2]
+            vec![MultiBufferOffset(3)..MultiBufferOffset(2)]
         );
     });
     editor_a2.update_in(cx_a, |editor, window, cx| {
@@ -133,7 +133,7 @@ async fn test_basic_following(
         editor.select_left(&Default::default(), window, cx);
         assert_eq!(
             editor.selections.ranges(&editor.display_snapshot(cx)),
-            vec![2..1]
+            vec![MultiBufferOffset(2)..MultiBufferOffset(1)]
         );
     });
 
@@ -158,13 +158,13 @@ async fn test_basic_following(
         editor_b2.update(cx_b, |editor, cx| editor
             .selections
             .ranges(&editor.display_snapshot(cx))),
-        vec![2..1]
+        vec![MultiBufferOffset(2)..MultiBufferOffset(1)]
     );
     assert_eq!(
         editor_b1.update(cx_b, |editor, cx| editor
             .selections
             .ranges(&editor.display_snapshot(cx))),
-        vec![3..3]
+        vec![MultiBufferOffset(3)..MultiBufferOffset(3)]
     );
 
     executor.run_until_parked();
@@ -386,7 +386,10 @@ async fn test_basic_following(
     // Changes to client A's editor are reflected on client B.
     editor_a1.update_in(cx_a, |editor, window, cx| {
         editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
-            s.select_ranges([1..1, 2..2])
+            s.select_ranges([
+                MultiBufferOffset(1)..MultiBufferOffset(1),
+                MultiBufferOffset(2)..MultiBufferOffset(2),
+            ])
         });
     });
     executor.advance_clock(workspace::item::LEADER_UPDATE_THROTTLE);
@@ -396,7 +399,10 @@ async fn test_basic_following(
     editor_b1.update(cx_b, |editor, cx| {
         assert_eq!(
             editor.selections.ranges(&editor.display_snapshot(cx)),
-            &[1..1, 2..2]
+            &[
+                MultiBufferOffset(1)..MultiBufferOffset(1),
+                MultiBufferOffset(2)..MultiBufferOffset(2)
+            ]
         );
     });
 
@@ -408,7 +414,7 @@ async fn test_basic_following(
 
     editor_a1.update_in(cx_a, |editor, window, cx| {
         editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
-            s.select_ranges([3..3])
+            s.select_ranges([MultiBufferOffset(3)..MultiBufferOffset(3)])
         });
         editor.set_scroll_position(point(0., 100.), window, cx);
     });
@@ -417,7 +423,7 @@ async fn test_basic_following(
     editor_b1.update(cx_b, |editor, cx| {
         assert_eq!(
             editor.selections.ranges(&editor.display_snapshot(cx)),
-            &[3..3]
+            &[MultiBufferOffset(3)..MultiBufferOffset(3)]
         );
     });
 
@@ -1694,7 +1700,7 @@ async fn test_following_stops_on_unshare(cx_a: &mut TestAppContext, cx_b: &mut T
     // b should follow a to position 1
     editor_a.update_in(cx_a, |editor, window, cx| {
         editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
-            s.select_ranges([1..1])
+            s.select_ranges([MultiBufferOffset(1)..MultiBufferOffset(1)])
         })
     });
     cx_a.executor()
@@ -1703,7 +1709,7 @@ async fn test_following_stops_on_unshare(cx_a: &mut TestAppContext, cx_b: &mut T
     editor_b.update(cx_b, |editor, cx| {
         assert_eq!(
             editor.selections.ranges(&editor.display_snapshot(cx)),
-            vec![1..1]
+            vec![MultiBufferOffset(1)..MultiBufferOffset(1)]
         )
     });
 
@@ -1719,7 +1725,7 @@ async fn test_following_stops_on_unshare(cx_a: &mut TestAppContext, cx_b: &mut T
     // b should not follow a to position 2
     editor_a.update_in(cx_a, |editor, window, cx| {
         editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
-            s.select_ranges([2..2])
+            s.select_ranges([MultiBufferOffset(2)..MultiBufferOffset(2)])
         })
     });
     cx_a.executor()
@@ -1728,7 +1734,7 @@ async fn test_following_stops_on_unshare(cx_a: &mut TestAppContext, cx_b: &mut T
     editor_b.update(cx_b, |editor, cx| {
         assert_eq!(
             editor.selections.ranges(&editor.display_snapshot(cx)),
-            vec![1..1]
+            vec![MultiBufferOffset(1)..MultiBufferOffset(1)]
         )
     });
     cx_b.update(|_, cx| {
@@ -1829,7 +1835,7 @@ async fn test_following_into_excluded_file(
         editor.select_left(&Default::default(), window, cx);
         assert_eq!(
             editor.selections.ranges(&editor.display_snapshot(cx)),
-            vec![3..2]
+            vec![MultiBufferOffset(3)..MultiBufferOffset(2)]
         );
     });
     editor_for_excluded_a.update_in(cx_a, |editor, window, cx| {
@@ -1838,7 +1844,7 @@ async fn test_following_into_excluded_file(
         editor.select_left(&Default::default(), window, cx);
         assert_eq!(
             editor.selections.ranges(&editor.display_snapshot(cx)),
-            vec![18..17]
+            vec![MultiBufferOffset(18)..MultiBufferOffset(17)]
         );
     });
 
@@ -1864,7 +1870,7 @@ async fn test_following_into_excluded_file(
         editor_for_excluded_b.update(cx_b, |editor, cx| editor
             .selections
             .ranges(&editor.display_snapshot(cx))),
-        vec![18..17]
+        vec![MultiBufferOffset(18)..MultiBufferOffset(17)]
     );
 
     editor_for_excluded_a.update_in(cx_a, |editor, window, cx| {
@@ -2040,7 +2046,7 @@ async fn test_following_to_channel_notes_without_a_shared_project(
         notes.editor.update(cx, |editor, cx| {
             editor.insert("Hello from A.", window, cx);
             editor.change_selections(SelectionEffects::no_scroll(), window, cx, |selections| {
-                selections.select_ranges(vec![3..4]);
+                selections.select_ranges(vec![MultiBufferOffset(3)..MultiBufferOffset(4)]);
             });
         });
     });
@@ -2076,8 +2082,8 @@ async fn test_following_to_channel_notes_without_a_shared_project(
             assert_eq!(
                 editor
                     .selections
-                    .ranges::<usize>(&editor.display_snapshot(cx)),
-                &[3..4]
+                    .ranges::<MultiBufferOffset>(&editor.display_snapshot(cx)),
+                &[MultiBufferOffset(3)..MultiBufferOffset(4)]
             );
         })
     });

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -1496,7 +1496,7 @@ impl CollabPanel {
 
     fn reset_filter_editor_text(&mut self, window: &mut Window, cx: &mut Context<Self>) -> bool {
         self.filter_editor.update(cx, |editor, cx| {
-            if editor.buffer().read(cx).len(cx) > 0 {
+            if editor.buffer().read(cx).len(cx).0 > 0 {
                 editor.set_text("", window, cx);
                 true
             } else {

--- a/crates/copilot/src/copilot_completion_provider.rs
+++ b/crates/copilot/src/copilot_completion_provider.rs
@@ -270,7 +270,7 @@ fn common_prefix<T1: Iterator<Item = char>, T2: Iterator<Item = char>>(a: T1, b:
 mod tests {
     use super::*;
     use editor::{
-        Editor, ExcerptRange, MultiBuffer, SelectionEffects,
+        Editor, ExcerptRange, MultiBuffer, MultiBufferOffset, SelectionEffects,
         test::editor_lsp_test_context::EditorLspTestContext,
     };
     use fs::FakeFs;
@@ -1081,8 +1081,9 @@ mod tests {
             vec![complete_from_marker, replace_range_marker.clone()],
         );
 
+        let range = marked_ranges.remove(&replace_range_marker).unwrap()[0].clone();
         let replace_range =
-            cx.to_lsp_range(marked_ranges.remove(&replace_range_marker).unwrap()[0].clone());
+            cx.to_lsp_range(MultiBufferOffset(range.start)..MultiBufferOffset(range.end));
 
         let mut request =
             cx.set_request_handler::<lsp::request::Completion, _, _>(move |url, params, _| {

--- a/crates/debugger_ui/src/debugger_ui.rs
+++ b/crates/debugger_ui/src/debugger_ui.rs
@@ -1,7 +1,7 @@
 use std::any::TypeId;
 
 use debugger_panel::DebugPanel;
-use editor::Editor;
+use editor::{Editor, MultiBufferOffsetUtf16};
 use gpui::{Action, App, DispatchPhase, EntityInputHandler, actions};
 use new_process_modal::{NewProcessModal, NewProcessMode};
 use onboarding_modal::DebuggerOnboardingModal;
@@ -390,11 +390,14 @@ pub fn init(cx: &mut App) {
                             maybe!({
                                 let text = editor
                                     .update(cx, |editor, cx| {
+                                        let range = editor
+                                            .selections
+                                            .newest::<MultiBufferOffsetUtf16>(
+                                                &editor.display_snapshot(cx),
+                                            )
+                                            .range();
                                         editor.text_for_range(
-                                            editor
-                                                .selections
-                                                .newest(&editor.display_snapshot(cx))
-                                                .range(),
+                                            range.start.0.0..range.end.0.0,
                                             &mut None,
                                             window,
                                             cx,

--- a/crates/debugger_ui/src/session/running/console.rs
+++ b/crates/debugger_ui/src/session/running/console.rs
@@ -8,7 +8,7 @@ use collections::HashMap;
 use dap::{CompletionItem, CompletionItemType, OutputEvent};
 use editor::{
     Bias, CompletionProvider, Editor, EditorElement, EditorMode, EditorStyle, ExcerptId,
-    SizingBehavior,
+    MultiBufferOffset, SizingBehavior,
 };
 use fuzzy::StringMatchCandidate;
 use gpui::{
@@ -161,7 +161,9 @@ impl Console {
     ) -> Task<Result<()>> {
         self.console.update(cx, |_, cx| {
             cx.spawn_in(window, async move |console, cx| {
-                let mut len = console.update(cx, |this, cx| this.buffer().read(cx).len(cx))?;
+                let mut len = console
+                    .update(cx, |this, cx| this.buffer().read(cx).len(cx))?
+                    .0;
                 let (output, spans, background_spans) = cx
                     .background_spawn(async move {
                         let mut all_spans = Vec::new();
@@ -227,8 +229,8 @@ impl Console {
                     for (range, color) in spans {
                         let Some(color) = color else { continue };
                         let start_offset = range.start;
-                        let range =
-                            buffer.anchor_after(range.start)..buffer.anchor_before(range.end);
+                        let range = buffer.anchor_after(MultiBufferOffset(range.start))
+                            ..buffer.anchor_before(MultiBufferOffset(range.end));
                         let style = HighlightStyle {
                             color: Some(terminal_view::terminal_element::convert_color(
                                 &color,
@@ -247,8 +249,8 @@ impl Console {
                     for (range, color) in background_spans {
                         let Some(color) = color else { continue };
                         let start_offset = range.start;
-                        let range =
-                            buffer.anchor_after(range.start)..buffer.anchor_before(range.end);
+                        let range = buffer.anchor_after(MultiBufferOffset(range.start))
+                            ..buffer.anchor_before(MultiBufferOffset(range.end));
                         console.highlight_background_key::<ConsoleAnsiHighlight>(
                             start_offset,
                             &[range],
@@ -961,7 +963,7 @@ fn color_fetcher(color: ansi::Color) -> fn(&Theme) -> Hsla {
 mod tests {
     use super::*;
     use crate::tests::init_test;
-    use editor::test::editor_test_context::EditorTestContext;
+    use editor::{MultiBufferOffset, test::editor_test_context::EditorTestContext};
     use gpui::TestAppContext;
     use language::Point;
 
@@ -993,8 +995,8 @@ mod tests {
         cx.update_editor(|editor, _, cx| {
             editor.edit(
                 vec![(
-                    snapshot.offset_for_anchor(&replace_range.start)
-                        ..snapshot.offset_for_anchor(&replace_range.end),
+                    MultiBufferOffset(snapshot.offset_for_anchor(&replace_range.start))
+                        ..MultiBufferOffset(snapshot.offset_for_anchor(&replace_range.end)),
                     replacement,
                 )],
                 cx,

--- a/crates/diagnostics/src/diagnostics_tests.rs
+++ b/crates/diagnostics/src/diagnostics_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use collections::{HashMap, HashSet};
 use editor::{
-    DisplayPoint, EditorSettings, Inlay,
+    DisplayPoint, EditorSettings, Inlay, MultiBufferOffset,
     actions::{GoToDiagnostic, GoToPreviousDiagnostic, Hover, MoveToBeginning},
     display_map::DisplayRow,
     test::{
@@ -878,7 +878,8 @@ async fn test_random_diagnostics_with_inlays(cx: &mut TestAppContext, mut rng: S
                 diagnostics.editor.update(cx, |editor, cx| {
                     let snapshot = editor.snapshot(window, cx);
                     if !snapshot.buffer_snapshot().is_empty() {
-                        let position = rng.random_range(0..snapshot.buffer_snapshot().len());
+                        let position = rng
+                            .random_range(MultiBufferOffset(0)..snapshot.buffer_snapshot().len());
                         let position = snapshot.buffer_snapshot().clip_offset(position, Bias::Left);
                         log::info!(
                             "adding inlay at {position}/{}: {:?}",

--- a/crates/editor/benches/display_map.rs
+++ b/crates/editor/benches/display_map.rs
@@ -2,6 +2,7 @@ use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use editor::MultiBuffer;
 use gpui::TestDispatcher;
 use itertools::Itertools;
+use multi_buffer::MultiBufferOffset;
 use rand::{Rng, SeedableRng, rngs::StdRng};
 use std::num::NonZeroU32;
 use text::Bias;
@@ -24,7 +25,9 @@ fn to_tab_point_benchmark(c: &mut Criterion) {
         let (_, inlay_snapshot) = InlayMap::new(buffer_snapshot);
         let (_, fold_snapshot) = FoldMap::new(inlay_snapshot.clone());
         let fold_point = fold_snapshot.to_fold_point(
-            inlay_snapshot.to_point(InlayOffset(rng.random_range(0..length))),
+            inlay_snapshot.to_point(InlayOffset(
+                rng.random_range(MultiBufferOffset(0)..MultiBufferOffset(length)),
+            )),
             Bias::Left,
         );
         let (_, snapshot) = TabMap::new(fold_snapshot, NonZeroU32::new(4).unwrap());
@@ -69,7 +72,9 @@ fn to_fold_point_benchmark(c: &mut Criterion) {
         let (_, fold_snapshot) = FoldMap::new(inlay_snapshot.clone());
 
         let fold_point = fold_snapshot.to_fold_point(
-            inlay_snapshot.to_point(InlayOffset(rng.random_range(0..length))),
+            inlay_snapshot.to_point(InlayOffset(
+                rng.random_range(MultiBufferOffset(0)..MultiBufferOffset(length)),
+            )),
             Bias::Left,
         );
 

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -44,12 +44,10 @@ pub use invisibles::{is_invisible, replacement};
 
 use collections::{HashMap, HashSet};
 use gpui::{App, Context, Entity, Font, HighlightStyle, LineLayout, Pixels, UnderlineStyle};
-use language::{
-    OffsetUtf16, Point, Subscription as BufferSubscription, language_settings::language_settings,
-};
+use language::{Point, Subscription as BufferSubscription, language_settings::language_settings};
 use multi_buffer::{
-    Anchor, AnchorRangeExt, MultiBuffer, MultiBufferPoint, MultiBufferRow, MultiBufferSnapshot,
-    RowInfo, ToOffset, ToPoint,
+    Anchor, AnchorRangeExt, MultiBuffer, MultiBufferOffset, MultiBufferOffsetUtf16,
+    MultiBufferPoint, MultiBufferRow, MultiBufferSnapshot, RowInfo, ToOffset, ToPoint,
 };
 use project::InlayId;
 use project::project_settings::DiagnosticSeverity;
@@ -104,7 +102,7 @@ type InlayHighlights = TreeMap<TypeId, TreeMap<InlayId, (HighlightStyle, InlayHi
 pub struct DisplayMap {
     /// The buffer that we are displaying.
     buffer: Entity<MultiBuffer>,
-    buffer_subscription: BufferSubscription,
+    buffer_subscription: BufferSubscription<MultiBufferOffset>,
     /// Decides where the [`Inlay`]s should be displayed.
     inlay_map: InlayMap,
     /// Decides where the fold indicators should be and tracks parts of a source file that are currently folded.
@@ -198,7 +196,7 @@ impl DisplayMap {
     pub fn set_state(&mut self, other: &DisplaySnapshot, cx: &mut Context<Self>) {
         self.fold(
             other
-                .folds_in_range(0..other.buffer_snapshot().len())
+                .folds_in_range(MultiBufferOffset(0)..other.buffer_snapshot().len())
                 .map(|fold| {
                     Crease::simple(
                         fold.range.to_offset(other.buffer_snapshot()),
@@ -794,7 +792,7 @@ impl DisplaySnapshot {
     }
 
     pub fn is_empty(&self) -> bool {
-        self.buffer_snapshot().len() == 0
+        self.buffer_snapshot().len() == MultiBufferOffset(0)
     }
 
     pub fn row_infos(&self, start_row: DisplayRow) -> impl Iterator<Item = RowInfo> + '_ {
@@ -1133,7 +1131,10 @@ impl DisplaySnapshot {
         })
     }
 
-    pub fn buffer_chars_at(&self, mut offset: usize) -> impl Iterator<Item = (char, usize)> + '_ {
+    pub fn buffer_chars_at(
+        &self,
+        mut offset: MultiBufferOffset,
+    ) -> impl Iterator<Item = (char, MultiBufferOffset)> + '_ {
         self.buffer_snapshot().chars_at(offset).map(move |ch| {
             let ret = (ch, offset);
             offset += ch.len_utf8();
@@ -1143,8 +1144,8 @@ impl DisplaySnapshot {
 
     pub fn reverse_buffer_chars_at(
         &self,
-        mut offset: usize,
-    ) -> impl Iterator<Item = (char, usize)> + '_ {
+        mut offset: MultiBufferOffset,
+    ) -> impl Iterator<Item = (char, MultiBufferOffset)> + '_ {
         self.buffer_snapshot()
             .reversed_chars_at(offset)
             .map(move |ch| {
@@ -1526,7 +1527,7 @@ impl DisplayPoint {
         map.display_point_to_point(self, Bias::Left)
     }
 
-    pub fn to_offset(self, map: &DisplaySnapshot, bias: Bias) -> usize {
+    pub fn to_offset(self, map: &DisplaySnapshot, bias: Bias) -> MultiBufferOffset {
         let wrap_point = map.block_snapshot.to_wrap_point(self.0, bias);
         let tab_point = map.wrap_snapshot().to_tab_point(wrap_point);
         let fold_point = map.tab_snapshot().to_fold_point(tab_point, bias).0;
@@ -1536,13 +1537,13 @@ impl DisplayPoint {
     }
 }
 
-impl ToDisplayPoint for usize {
+impl ToDisplayPoint for MultiBufferOffset {
     fn to_display_point(&self, map: &DisplaySnapshot) -> DisplayPoint {
         map.point_to_display_point(self.to_point(map.buffer_snapshot()), Bias::Left)
     }
 }
 
-impl ToDisplayPoint for OffsetUtf16 {
+impl ToDisplayPoint for MultiBufferOffsetUtf16 {
     fn to_display_point(&self, map: &DisplaySnapshot) -> DisplayPoint {
         self.to_offset(map.buffer_snapshot()).to_display_point(map)
     }
@@ -1685,7 +1686,7 @@ pub mod tests {
                             let block_properties = (0..rng.random_range(1..=1))
                                 .map(|_| {
                                     let position = buffer.anchor_after(buffer.clip_offset(
-                                        rng.random_range(0..=buffer.len()),
+                                        rng.random_range(MultiBufferOffset(0)..=buffer.len()),
                                         Bias::Left,
                                     ));
 
@@ -1727,8 +1728,12 @@ pub mod tests {
                     for _ in 0..rng.random_range(1..=3) {
                         buffer.read_with(cx, |buffer, cx| {
                             let buffer = buffer.read(cx);
-                            let end = buffer.clip_offset(rng.random_range(0..=buffer.len()), Right);
-                            let start = buffer.clip_offset(rng.random_range(0..=end), Left);
+                            let end = buffer.clip_offset(
+                                rng.random_range(MultiBufferOffset(0)..=buffer.len()),
+                                Right,
+                            );
+                            let start = buffer
+                                .clip_offset(rng.random_range(MultiBufferOffset(0)..=end), Left);
                             ranges.push(start..end);
                         });
                     }
@@ -1954,7 +1959,7 @@ pub mod tests {
                 )
             );
 
-            let ix = snapshot.buffer_snapshot().text().find("seven").unwrap();
+            let ix = MultiBufferOffset(snapshot.buffer_snapshot().text().find("seven").unwrap());
             buffer.update(cx, |buffer, cx| {
                 buffer.edit([(ix..ix, "and ")], None, cx);
             });
@@ -2083,7 +2088,7 @@ pub mod tests {
                 &[],
                 vec![Inlay::edit_prediction(
                     0,
-                    buffer_snapshot.anchor_after(0),
+                    buffer_snapshot.anchor_after(MultiBufferOffset(0)),
                     "\n",
                 )],
                 cx,
@@ -2094,7 +2099,11 @@ pub mod tests {
         // Regression test: updating the display map does not crash when a
         // block is immediately followed by a multi-line inlay.
         buffer.update(cx, |buffer, cx| {
-            buffer.edit([(1..1, "b")], None, cx);
+            buffer.edit(
+                [(MultiBufferOffset(1)..MultiBufferOffset(1), "b")],
+                None,
+                cx,
+            );
         });
         map.update(cx, |m, cx| assert_eq!(m.snapshot(cx).text(), "\n\n\nab"));
     }
@@ -2694,6 +2703,7 @@ pub mod tests {
                 HighlightKey::Type(TypeId::of::<MyType>()),
                 highlighted_ranges
                     .into_iter()
+                    .map(|range| MultiBufferOffset(range.start)..MultiBufferOffset(range.end))
                     .map(|range| {
                         buffer_snapshot.anchor_before(range.start)
                             ..buffer_snapshot.anchor_before(range.end)

--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -11,8 +11,8 @@ use collections::{Bound, HashMap, HashSet};
 use gpui::{AnyElement, App, EntityId, Pixels, Window};
 use language::{Patch, Point};
 use multi_buffer::{
-    Anchor, ExcerptId, ExcerptInfo, MultiBuffer, MultiBufferRow, MultiBufferSnapshot, RowInfo,
-    ToOffset, ToPoint as _,
+    Anchor, ExcerptId, ExcerptInfo, MultiBuffer, MultiBufferOffset, MultiBufferRow,
+    MultiBufferSnapshot, RowInfo, ToOffset, ToPoint as _,
 };
 use parking_lot::Mutex;
 use std::{
@@ -1208,7 +1208,7 @@ impl BlockMapWriter<'_> {
 
     pub fn remove_intersecting_replace_blocks(
         &mut self,
-        ranges: impl IntoIterator<Item = Range<usize>>,
+        ranges: impl IntoIterator<Item = Range<MultiBufferOffset>>,
         inclusive: bool,
     ) {
         let wrap_snapshot = self.0.wrap_snapshot.borrow();
@@ -1283,7 +1283,7 @@ impl BlockMapWriter<'_> {
 
     fn blocks_intersecting_buffer_range(
         &self,
-        range: Range<usize>,
+        range: Range<MultiBufferOffset>,
         inclusive: bool,
     ) -> &[Arc<CustomBlock>] {
         if range.is_empty() && !inclusive {
@@ -3043,8 +3043,10 @@ mod tests {
                     let block_properties = (0..block_count)
                         .map(|_| {
                             let buffer = cx.update(|cx| buffer.read(cx).read(cx).clone());
-                            let offset =
-                                buffer.clip_offset(rng.random_range(0..=buffer.len()), Bias::Left);
+                            let offset = buffer.clip_offset(
+                                rng.random_range(MultiBufferOffset(0)..=buffer.len()),
+                                Bias::Left,
+                            );
                             let mut min_height = 0;
                             let placement = match rng.random_range(0..3) {
                                 0 => {
@@ -3244,7 +3246,7 @@ mod tests {
             // Note that this needs to be synced with the related section in BlockMap::sync
             expected_blocks.extend(block_map.header_and_footer_blocks(
                 &buffer_snapshot,
-                0..,
+                MultiBufferOffset(0)..,
                 &wraps_snapshot,
             ));
 

--- a/crates/editor/src/display_map/custom_highlights.rs
+++ b/crates/editor/src/display_map/custom_highlights.rs
@@ -1,7 +1,7 @@
 use collections::BTreeMap;
 use gpui::HighlightStyle;
 use language::Chunk;
-use multi_buffer::{MultiBufferChunks, MultiBufferSnapshot, ToOffset as _};
+use multi_buffer::{MultiBufferChunks, MultiBufferOffset, MultiBufferSnapshot, ToOffset as _};
 use std::{
     cmp,
     iter::{self, Peekable},
@@ -14,7 +14,7 @@ use crate::display_map::{HighlightKey, TextHighlights};
 pub struct CustomHighlightsChunks<'a> {
     buffer_chunks: MultiBufferChunks<'a>,
     buffer_chunk: Option<Chunk<'a>>,
-    offset: usize,
+    offset: MultiBufferOffset,
     multibuffer_snapshot: &'a MultiBufferSnapshot,
 
     highlight_endpoints: Peekable<vec::IntoIter<HighlightEndpoint>>,
@@ -24,14 +24,14 @@ pub struct CustomHighlightsChunks<'a> {
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 struct HighlightEndpoint {
-    offset: usize,
+    offset: MultiBufferOffset,
     tag: HighlightKey,
     style: Option<HighlightStyle>,
 }
 
 impl<'a> CustomHighlightsChunks<'a> {
     pub fn new(
-        range: Range<usize>,
+        range: Range<MultiBufferOffset>,
         language_aware: bool,
         text_highlights: Option<&'a TextHighlights>,
         multibuffer_snapshot: &'a MultiBufferSnapshot,
@@ -52,7 +52,7 @@ impl<'a> CustomHighlightsChunks<'a> {
         }
     }
 
-    pub fn seek(&mut self, new_range: Range<usize>) {
+    pub fn seek(&mut self, new_range: Range<MultiBufferOffset>) {
         self.highlight_endpoints =
             create_highlight_endpoints(&new_range, self.text_highlights, self.multibuffer_snapshot);
         self.offset = new_range.start;
@@ -63,7 +63,7 @@ impl<'a> CustomHighlightsChunks<'a> {
 }
 
 fn create_highlight_endpoints(
-    range: &Range<usize>,
+    range: &Range<MultiBufferOffset>,
     text_highlights: Option<&TextHighlights>,
     buffer: &MultiBufferSnapshot,
 ) -> iter::Peekable<vec::IntoIter<HighlightEndpoint>> {
@@ -117,7 +117,7 @@ impl<'a> Iterator for CustomHighlightsChunks<'a> {
     type Item = Chunk<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let mut next_highlight_endpoint = usize::MAX;
+        let mut next_highlight_endpoint = MultiBufferOffset(usize::MAX);
         while let Some(endpoint) = self.highlight_endpoints.peek().copied() {
             if endpoint.offset <= self.offset {
                 if let Some(style) = endpoint.style {
@@ -224,20 +224,22 @@ mod tests {
             let range_count = rng.random_range(1..10);
             let text = buffer_snapshot.text();
             for _ in 0..range_count {
-                if buffer_snapshot.len() == 0 {
+                if buffer_snapshot.len() == MultiBufferOffset(0) {
                     continue;
                 }
 
-                let mut start = rng.random_range(0..=buffer_snapshot.len().saturating_sub(10));
+                let mut start = rng.random_range(
+                    MultiBufferOffset(0)..=buffer_snapshot.len().saturating_sub_usize(10),
+                );
 
-                while !text.is_char_boundary(start) {
-                    start = start.saturating_sub(1);
+                while !text.is_char_boundary(start.0) {
+                    start = start.saturating_sub_usize(1);
                 }
 
-                let end_end = buffer_snapshot.len().min(start + 100);
+                let end_end = buffer_snapshot.len().min(start + 100usize);
                 let mut end = rng.random_range(start..=end_end);
-                while !text.is_char_boundary(end) {
-                    end = end.saturating_sub(1);
+                while !text.is_char_boundary(end.0) {
+                    end = end.saturating_sub_usize(1);
                 }
 
                 if start < end {
@@ -253,8 +255,12 @@ mod tests {
         }
 
         // Get all chunks and verify their bitmaps
-        let chunks =
-            CustomHighlightsChunks::new(0..buffer_snapshot.len(), false, None, &buffer_snapshot);
+        let chunks = CustomHighlightsChunks::new(
+            MultiBufferOffset(0)..buffer_snapshot.len(),
+            false,
+            None,
+            &buffer_snapshot,
+        );
 
         for chunk in chunks {
             let chunk_text = chunk.text;

--- a/crates/editor/src/display_map/inlay_map.rs
+++ b/crates/editor/src/display_map/inlay_map.rs
@@ -4,7 +4,10 @@ use crate::{
 };
 use collections::BTreeSet;
 use language::{Chunk, Edit, Point, TextSummary};
-use multi_buffer::{MultiBufferRow, MultiBufferRows, MultiBufferSnapshot, RowInfo, ToOffset};
+use multi_buffer::{
+    MBTextSummary, MultiBufferOffset, MultiBufferRow, MultiBufferRows, MultiBufferSnapshot,
+    RowInfo, ToOffset,
+};
 use project::InlayId;
 use std::{
     cmp,
@@ -42,7 +45,7 @@ impl std::ops::Deref for InlaySnapshot {
 
 #[derive(Clone, Debug)]
 enum Transform {
-    Isomorphic(TextSummary),
+    Isomorphic(MBTextSummary),
     Inlay(Inlay),
 }
 
@@ -56,8 +59,8 @@ impl sum_tree::Item for Transform {
                 output: *summary,
             },
             Transform::Inlay(inlay) => TransformSummary {
-                input: TextSummary::default(),
-                output: inlay.text().summary(),
+                input: MBTextSummary::default(),
+                output: MBTextSummary::from(inlay.text().summary()),
             },
         }
     }
@@ -65,8 +68,8 @@ impl sum_tree::Item for Transform {
 
 #[derive(Clone, Debug, Default)]
 struct TransformSummary {
-    input: TextSummary,
-    output: TextSummary,
+    input: MBTextSummary,
+    output: MBTextSummary,
 }
 
 impl sum_tree::ContextLessSummary for TransformSummary {
@@ -75,15 +78,15 @@ impl sum_tree::ContextLessSummary for TransformSummary {
     }
 
     fn add_summary(&mut self, other: &Self) {
-        self.input += &other.input;
-        self.output += &other.output;
+        self.input += other.input.clone();
+        self.output += other.output.clone();
     }
 }
 
 pub type InlayEdit = Edit<InlayOffset>;
 
 #[derive(Copy, Clone, Debug, Default, Eq, Ord, PartialOrd, PartialEq)]
-pub struct InlayOffset(pub usize);
+pub struct InlayOffset(pub MultiBufferOffset);
 
 impl Add for InlayOffset {
     type Output = Self;
@@ -94,10 +97,30 @@ impl Add for InlayOffset {
 }
 
 impl Sub for InlayOffset {
-    type Output = Self;
+    type Output = <MultiBufferOffset as Sub>::Output;
 
     fn sub(self, rhs: Self) -> Self::Output {
-        Self(self.0 - rhs.0)
+        self.0 - rhs.0
+    }
+}
+
+impl<T> SubAssign<T> for InlayOffset
+where
+    MultiBufferOffset: SubAssign<T>,
+{
+    fn sub_assign(&mut self, rhs: T) {
+        self.0 -= rhs;
+    }
+}
+
+impl<T> Add<T> for InlayOffset
+where
+    MultiBufferOffset: Add<T, Output = MultiBufferOffset>,
+{
+    type Output = Self;
+
+    fn add(self, rhs: T) -> Self::Output {
+        Self(self.0 + rhs)
     }
 }
 
@@ -107,9 +130,12 @@ impl AddAssign for InlayOffset {
     }
 }
 
-impl SubAssign for InlayOffset {
-    fn sub_assign(&mut self, rhs: Self) {
-        self.0 -= rhs.0;
+impl<T> AddAssign<T> for InlayOffset
+where
+    MultiBufferOffset: AddAssign<T>,
+{
+    fn add_assign(&mut self, rhs: T) {
+        self.0 += rhs;
     }
 }
 
@@ -119,7 +145,7 @@ impl<'a> sum_tree::Dimension<'a, TransformSummary> for InlayOffset {
     }
 
     fn add_summary(&mut self, summary: &'a TransformSummary, _: ()) {
-        self.0 += &summary.output.len;
+        self.0 += summary.output.len;
     }
 }
 
@@ -152,13 +178,13 @@ impl<'a> sum_tree::Dimension<'a, TransformSummary> for InlayPoint {
     }
 }
 
-impl<'a> sum_tree::Dimension<'a, TransformSummary> for usize {
+impl<'a> sum_tree::Dimension<'a, TransformSummary> for MultiBufferOffset {
     fn zero(_cx: ()) -> Self {
         Default::default()
     }
 
     fn add_summary(&mut self, summary: &'a TransformSummary, _: ()) {
-        *self += &summary.input.len;
+        *self += summary.input.len;
     }
 }
 
@@ -181,7 +207,7 @@ pub struct InlayBufferRows<'a> {
 }
 
 pub struct InlayChunks<'a> {
-    transforms: Cursor<'a, 'static, Transform, Dimensions<InlayOffset, usize>>,
+    transforms: Cursor<'a, 'static, Transform, Dimensions<InlayOffset, MultiBufferOffset>>,
     buffer_chunks: CustomHighlightsChunks<'a>,
     buffer_chunk: Option<Chunk<'a>>,
     inlay_chunks: Option<text::ChunkWithBitmaps<'a>>,
@@ -332,12 +358,12 @@ impl<'a> Iterator for InlayChunks<'a> {
                 let offset_in_inlay = self.output_offset - self.transforms.start().0;
                 if let Some((style, highlight)) = inlay_style_and_highlight {
                     let range = &highlight.range;
-                    if offset_in_inlay.0 < range.start {
-                        next_inlay_highlight_endpoint = range.start - offset_in_inlay.0;
-                    } else if offset_in_inlay.0 >= range.end {
+                    if offset_in_inlay < range.start {
+                        next_inlay_highlight_endpoint = range.start - offset_in_inlay;
+                    } else if offset_in_inlay >= range.end {
                         next_inlay_highlight_endpoint = usize::MAX;
                     } else {
-                        next_inlay_highlight_endpoint = range.end - offset_in_inlay.0;
+                        next_inlay_highlight_endpoint = range.end - offset_in_inlay;
                         highlight_style = highlight_style
                             .map(|highlight| highlight.highlight(*style))
                             .or_else(|| Some(*style));
@@ -350,7 +376,7 @@ impl<'a> Iterator for InlayChunks<'a> {
                     let start = offset_in_inlay;
                     let end = cmp::min(self.max_output_offset, self.transforms.end().0)
                         - self.transforms.start().0;
-                    let chunks = inlay.text().chunks_in_range(start.0..end.0);
+                    let chunks = inlay.text().chunks_in_range(start..end);
                     text::ChunkWithBitmaps(chunks)
                 });
                 let ChunkBitmaps {
@@ -488,7 +514,7 @@ impl InlayMap {
     pub fn sync(
         &mut self,
         buffer_snapshot: MultiBufferSnapshot,
-        mut buffer_edits: Vec<text::Edit<usize>>,
+        mut buffer_edits: Vec<text::Edit<MultiBufferOffset>>,
     ) -> (InlaySnapshot, Vec<InlayEdit>) {
         let snapshot = &mut self.snapshot;
 
@@ -519,7 +545,7 @@ impl InlayMap {
             let mut new_transforms = SumTree::default();
             let mut cursor = snapshot
                 .transforms
-                .cursor::<Dimensions<usize, InlayOffset>>(());
+                .cursor::<Dimensions<MultiBufferOffset, InlayOffset>>(());
             let mut buffer_edits_iter = buffer_edits.iter().peekable();
             while let Some(buffer_edit) = buffer_edits_iter.next() {
                 new_transforms.append(cursor.slice(&buffer_edit.old.start, Bias::Left), ());
@@ -531,11 +557,9 @@ impl InlayMap {
                 }
 
                 // Remove all the inlays and transforms contained by the edit.
-                let old_start =
-                    cursor.start().1 + InlayOffset(buffer_edit.old.start - cursor.start().0);
+                let old_start = cursor.start().1 + (buffer_edit.old.start - cursor.start().0);
                 cursor.seek(&buffer_edit.old.end, Bias::Right);
-                let old_end =
-                    cursor.start().1 + InlayOffset(buffer_edit.old.end - cursor.start().0);
+                let old_end = cursor.start().1 + (buffer_edit.old.end - cursor.start().0);
 
                 // Push the unchanged prefix.
                 let prefix_start = new_transforms.summary().input.len;
@@ -687,7 +711,10 @@ impl InlayMap {
         let snapshot = &mut self.snapshot;
         for i in 0..rng.random_range(1..=5) {
             if self.inlays.is_empty() || rng.random() {
-                let position = snapshot.buffer.random_byte_range(0, rng).start;
+                let position = snapshot
+                    .buffer
+                    .random_byte_range(MultiBufferOffset(0), rng)
+                    .start;
                 let bias = if rng.random() {
                     Bias::Left
                 } else {
@@ -740,9 +767,11 @@ impl InlayMap {
 
 impl InlaySnapshot {
     pub fn to_point(&self, offset: InlayOffset) -> InlayPoint {
-        let (start, _, item) = self
-            .transforms
-            .find::<Dimensions<InlayOffset, InlayPoint, usize>, _>((), &offset, Bias::Right);
+        let (start, _, item) = self.transforms.find::<Dimensions<
+            InlayOffset,
+            InlayPoint,
+            MultiBufferOffset,
+        >, _>((), &offset, Bias::Right);
         let overshoot = offset.0 - start.0.0;
         match item {
             Some(Transform::Isomorphic(_)) => {
@@ -801,22 +830,24 @@ impl InlaySnapshot {
             None => self.buffer.max_point(),
         }
     }
-    pub fn to_buffer_offset(&self, offset: InlayOffset) -> usize {
-        let (start, _, item) =
-            self.transforms
-                .find::<Dimensions<InlayOffset, usize>, _>((), &offset, Bias::Right);
+    pub fn to_buffer_offset(&self, offset: InlayOffset) -> MultiBufferOffset {
+        let (start, _, item) = self
+            .transforms
+            .find::<Dimensions<InlayOffset, MultiBufferOffset>, _>((), &offset, Bias::Right);
         match item {
             Some(Transform::Isomorphic(_)) => {
                 let overshoot = offset - start.0;
-                start.1 + overshoot.0
+                start.1 + overshoot
             }
             Some(Transform::Inlay(_)) => start.1,
             None => self.buffer.len(),
         }
     }
 
-    pub fn to_inlay_offset(&self, offset: usize) -> InlayOffset {
-        let mut cursor = self.transforms.cursor::<Dimensions<usize, InlayOffset>>(());
+    pub fn to_inlay_offset(&self, offset: MultiBufferOffset) -> InlayOffset {
+        let mut cursor = self
+            .transforms
+            .cursor::<Dimensions<MultiBufferOffset, InlayOffset>>(());
         cursor.seek(&offset, Bias::Left);
         loop {
             match cursor.item() {
@@ -973,14 +1004,16 @@ impl InlaySnapshot {
         }
     }
 
-    pub fn text_summary(&self) -> TextSummary {
+    pub fn text_summary(&self) -> MBTextSummary {
         self.transforms.summary().output
     }
 
-    pub fn text_summary_for_range(&self, range: Range<InlayOffset>) -> TextSummary {
-        let mut summary = TextSummary::default();
+    pub fn text_summary_for_range(&self, range: Range<InlayOffset>) -> MBTextSummary {
+        let mut summary = MBTextSummary::default();
 
-        let mut cursor = self.transforms.cursor::<Dimensions<InlayOffset, usize>>(());
+        let mut cursor = self
+            .transforms
+            .cursor::<Dimensions<InlayOffset, MultiBufferOffset>>(());
         cursor.seek(&range.start, Bias::Right);
 
         let overshoot = range.start.0 - cursor.start().0.0;
@@ -996,7 +1029,12 @@ impl InlaySnapshot {
             Some(Transform::Inlay(inlay)) => {
                 let suffix_start = overshoot;
                 let suffix_end = cmp::min(cursor.end().0, range.end).0 - cursor.start().0.0;
-                summary = inlay.text().cursor(suffix_start).summary(suffix_end);
+                summary = MBTextSummary::from(
+                    inlay
+                        .text()
+                        .cursor(suffix_start)
+                        .summary::<TextSummary>(suffix_end),
+                );
                 cursor.next();
             }
             None => {}
@@ -1014,7 +1052,7 @@ impl InlaySnapshot {
                     let prefix_end = prefix_start + overshoot;
                     summary += self
                         .buffer
-                        .text_summary_for_range::<TextSummary, _>(prefix_start..prefix_end);
+                        .text_summary_for_range::<MBTextSummary, _>(prefix_start..prefix_end);
                 }
                 Some(Transform::Inlay(inlay)) => {
                     let prefix_end = overshoot;
@@ -1070,7 +1108,9 @@ impl InlaySnapshot {
         language_aware: bool,
         highlights: Highlights<'a>,
     ) -> InlayChunks<'a> {
-        let mut cursor = self.transforms.cursor::<Dimensions<InlayOffset, usize>>(());
+        let mut cursor = self
+            .transforms
+            .cursor::<Dimensions<InlayOffset, MultiBufferOffset>>(());
         cursor.seek(&range.start, Bias::Right);
 
         let buffer_range = self.to_buffer_offset(range.start)..self.to_buffer_offset(range.end);
@@ -1122,8 +1162,8 @@ impl InlaySnapshot {
     }
 }
 
-fn push_isomorphic(sum_tree: &mut SumTree<Transform>, summary: TextSummary) {
-    if summary.len == 0 {
+fn push_isomorphic(sum_tree: &mut SumTree<Transform>, summary: MBTextSummary) {
+    if summary.len == MultiBufferOffset(0) {
         return;
     }
 
@@ -1279,7 +1319,10 @@ mod tests {
             &[],
             vec![Inlay::mock_hint(
                 post_inc(&mut next_inlay_id),
-                buffer.read(cx).snapshot(cx).anchor_after(3),
+                buffer
+                    .read(cx)
+                    .snapshot(cx)
+                    .anchor_after(MultiBufferOffset(3)),
                 "|123|",
             )],
         );
@@ -1335,7 +1378,15 @@ mod tests {
 
         // Edits before or after the inlay should not affect it.
         buffer.update(cx, |buffer, cx| {
-            buffer.edit([(2..3, "x"), (3..3, "y"), (4..4, "z")], None, cx)
+            buffer.edit(
+                [
+                    (MultiBufferOffset(2)..MultiBufferOffset(3), "x"),
+                    (MultiBufferOffset(3)..MultiBufferOffset(3), "y"),
+                    (MultiBufferOffset(4)..MultiBufferOffset(4), "z"),
+                ],
+                None,
+                cx,
+            )
         });
         let (inlay_snapshot, _) = inlay_map.sync(
             buffer.read(cx).snapshot(cx),
@@ -1344,7 +1395,13 @@ mod tests {
         assert_eq!(inlay_snapshot.text(), "abxy|123|dzefghi");
 
         // An edit surrounding the inlay should invalidate it.
-        buffer.update(cx, |buffer, cx| buffer.edit([(4..5, "D")], None, cx));
+        buffer.update(cx, |buffer, cx| {
+            buffer.edit(
+                [(MultiBufferOffset(4)..MultiBufferOffset(5), "D")],
+                None,
+                cx,
+            )
+        });
         let (inlay_snapshot, _) = inlay_map.sync(
             buffer.read(cx).snapshot(cx),
             buffer_edits.consume().into_inner(),
@@ -1356,12 +1413,18 @@ mod tests {
             vec![
                 Inlay::mock_hint(
                     post_inc(&mut next_inlay_id),
-                    buffer.read(cx).snapshot(cx).anchor_before(3),
+                    buffer
+                        .read(cx)
+                        .snapshot(cx)
+                        .anchor_before(MultiBufferOffset(3)),
                     "|123|",
                 ),
                 Inlay::edit_prediction(
                     post_inc(&mut next_inlay_id),
-                    buffer.read(cx).snapshot(cx).anchor_after(3),
+                    buffer
+                        .read(cx)
+                        .snapshot(cx)
+                        .anchor_after(MultiBufferOffset(3)),
                     "|456|",
                 ),
             ],
@@ -1369,7 +1432,13 @@ mod tests {
         assert_eq!(inlay_snapshot.text(), "abx|123||456|yDzefghi");
 
         // Edits ending where the inlay starts should not move it if it has a left bias.
-        buffer.update(cx, |buffer, cx| buffer.edit([(3..3, "JKL")], None, cx));
+        buffer.update(cx, |buffer, cx| {
+            buffer.edit(
+                [(MultiBufferOffset(3)..MultiBufferOffset(3), "JKL")],
+                None,
+                cx,
+            )
+        });
         let (inlay_snapshot, _) = inlay_map.sync(
             buffer.read(cx).snapshot(cx),
             buffer_edits.consume().into_inner(),
@@ -1571,17 +1640,26 @@ mod tests {
             vec![
                 Inlay::mock_hint(
                     post_inc(&mut next_inlay_id),
-                    buffer.read(cx).snapshot(cx).anchor_before(0),
+                    buffer
+                        .read(cx)
+                        .snapshot(cx)
+                        .anchor_before(MultiBufferOffset(0)),
                     "|123|\n",
                 ),
                 Inlay::mock_hint(
                     post_inc(&mut next_inlay_id),
-                    buffer.read(cx).snapshot(cx).anchor_before(4),
+                    buffer
+                        .read(cx)
+                        .snapshot(cx)
+                        .anchor_before(MultiBufferOffset(4)),
                     "|456|",
                 ),
                 Inlay::edit_prediction(
                     post_inc(&mut next_inlay_id),
-                    buffer.read(cx).snapshot(cx).anchor_before(7),
+                    buffer
+                        .read(cx)
+                        .snapshot(cx)
+                        .anchor_before(MultiBufferOffset(7)),
                     "\n|567|\n",
                 ),
             ],
@@ -1658,7 +1736,7 @@ mod tests {
                 .collect::<Vec<_>>();
             let mut expected_text = Rope::from(&buffer_snapshot.text());
             for (offset, inlay) in inlays.iter().rev() {
-                expected_text.replace(*offset..*offset, &inlay.text().to_string());
+                expected_text.replace(offset.0..offset.0, &inlay.text().to_string());
             }
             assert_eq!(inlay_snapshot.text(), expected_text.to_string());
 
@@ -1681,7 +1759,7 @@ mod tests {
             let mut text_highlights = TextHighlights::default();
             let text_highlight_count = rng.random_range(0_usize..10);
             let mut text_highlight_ranges = (0..text_highlight_count)
-                .map(|_| buffer_snapshot.random_byte_range(0, &mut rng))
+                .map(|_| buffer_snapshot.random_byte_range(MultiBufferOffset(0), &mut rng))
                 .collect::<Vec<_>>();
             text_highlight_ranges.sort_by_key(|range| (range.start, Reverse(range.end)));
             log::info!("highlighting text ranges {text_highlight_ranges:?}");
@@ -1744,12 +1822,13 @@ mod tests {
             }
 
             for _ in 0..5 {
-                let mut end = rng.random_range(0..=inlay_snapshot.len().0);
+                let mut end = rng.random_range(0..=inlay_snapshot.len().0.0);
                 end = expected_text.clip_offset(end, Bias::Right);
                 let mut start = rng.random_range(0..=end);
                 start = expected_text.clip_offset(start, Bias::Right);
 
-                let range = InlayOffset(start)..InlayOffset(end);
+                let range =
+                    InlayOffset(MultiBufferOffset(start))..InlayOffset(MultiBufferOffset(end));
                 log::info!("calling inlay_snapshot.chunks({range:?})");
                 let actual_text = inlay_snapshot
                     .chunks(
@@ -1771,25 +1850,27 @@ mod tests {
                 );
 
                 assert_eq!(
-                    inlay_snapshot.text_summary_for_range(InlayOffset(start)..InlayOffset(end)),
-                    expected_text.slice(start..end).summary()
+                    inlay_snapshot.text_summary_for_range(
+                        InlayOffset(MultiBufferOffset(start))..InlayOffset(MultiBufferOffset(end))
+                    ),
+                    MBTextSummary::from(expected_text.slice(start..end).summary())
                 );
             }
 
             for edit in inlay_edits {
                 prev_inlay_text.replace_range(
-                    edit.new.start.0..edit.new.start.0 + edit.old_len().0,
-                    &inlay_snapshot.text()[edit.new.start.0..edit.new.end.0],
+                    edit.new.start.0.0..edit.new.start.0.0 + edit.old_len(),
+                    &inlay_snapshot.text()[edit.new.start.0.0..edit.new.end.0.0],
                 );
             }
             assert_eq!(prev_inlay_text, inlay_snapshot.text());
 
             assert_eq!(expected_text.max_point(), inlay_snapshot.max_point().0);
-            assert_eq!(expected_text.len(), inlay_snapshot.len().0);
+            assert_eq!(expected_text.len(), inlay_snapshot.len().0.0);
 
             let mut buffer_point = Point::default();
             let mut inlay_point = inlay_snapshot.to_inlay_point(buffer_point);
-            let mut buffer_chars = buffer_snapshot.chars_at(0);
+            let mut buffer_chars = buffer_snapshot.chars_at(MultiBufferOffset(0));
             loop {
                 // Ensure conversion from buffer coordinates to inlay coordinates
                 // is consistent.
@@ -1930,7 +2011,7 @@ mod tests {
 
         // Get all chunks and verify their bitmaps
         let chunks = snapshot.chunks(
-            InlayOffset(0)..InlayOffset(snapshot.len().0),
+            InlayOffset(MultiBufferOffset(0))..snapshot.len(),
             false,
             Highlights::default(),
         );
@@ -2064,7 +2145,7 @@ mod tests {
         // Collect chunks - this previously would panic
         let chunks: Vec<_> = inlay_snapshot
             .chunks(
-                InlayOffset(0)..InlayOffset(inlay_snapshot.len().0),
+                InlayOffset(MultiBufferOffset(0))..inlay_snapshot.len(),
                 false,
                 highlights,
             )
@@ -2178,7 +2259,7 @@ mod tests {
 
             let chunks: Vec<_> = inlay_snapshot
                 .chunks(
-                    InlayOffset(0)..InlayOffset(inlay_snapshot.len().0),
+                    InlayOffset(MultiBufferOffset(0))..inlay_snapshot.len(),
                     false,
                     highlights,
                 )

--- a/crates/editor/src/display_map/inlay_map.rs
+++ b/crates/editor/src/display_map/inlay_map.rs
@@ -78,8 +78,8 @@ impl sum_tree::ContextLessSummary for TransformSummary {
     }
 
     fn add_summary(&mut self, other: &Self) {
-        self.input += other.input.clone();
-        self.output += other.output.clone();
+        self.input += other.input;
+        self.output += other.output;
     }
 }
 

--- a/crates/editor/src/display_map/tab_map.rs
+++ b/crates/editor/src/display_map/tab_map.rs
@@ -648,6 +648,7 @@ mod tests {
             inlay_map::InlayMap,
         },
     };
+    use multi_buffer::MultiBufferOffset;
     use rand::{Rng, prelude::StdRng};
     use util;
 
@@ -1156,7 +1157,7 @@ mod tests {
         let (_, inlay_snapshot) = InlayMap::new(buffer_snapshot);
         let (_, fold_snapshot) = FoldMap::new(inlay_snapshot);
         let chunks = fold_snapshot.chunks(
-            FoldOffset(0)..fold_snapshot.len(),
+            FoldOffset(MultiBufferOffset(0))..fold_snapshot.len(),
             false,
             Default::default(),
         );
@@ -1318,7 +1319,7 @@ mod tests {
         let (_, inlay_snapshot) = InlayMap::new(buffer_snapshot);
         let (_, fold_snapshot) = FoldMap::new(inlay_snapshot);
         let chunks = fold_snapshot.chunks(
-            FoldOffset(0)..fold_snapshot.len(),
+            FoldOffset(MultiBufferOffset(0))..fold_snapshot.len(),
             false,
             Default::default(),
         );

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1927,22 +1927,23 @@ impl Editor {
                         }
                     }
                     project::Event::SnippetEdit(id, snippet_edits) => {
-                        if let Some(buffer) = editor.buffer.read(cx).buffer(*id) {
+                        // todo(lw): Non singletons
+                        if let Some(buffer) = editor.buffer.read(cx).as_singleton() {
+                            let snapshot = buffer.read(cx).snapshot();
                             let focus_handle = editor.focus_handle(cx);
-                            if focus_handle.is_focused(window) {
-                                let snapshot = buffer.read(cx).snapshot();
+                            if snapshot.remote_id() == *id && focus_handle.is_focused(window) {
                                 for (range, snippet) in snippet_edits {
                                     let buffer_range =
                                         language::range_from_lsp(*range).to_offset(&snapshot);
-                                    todo!("transform buffer range to multibuffer range!");
-                                    // editor
-                                    //     .insert_snippet(
-                                    //         &[buffer_range],
-                                    //         snippet.clone(),
-                                    //         window,
-                                    //         cx,
-                                    //     )
-                                    //     .ok();
+                                    editor
+                                        .insert_snippet(
+                                            &[MultiBufferOffset(buffer_range.start)
+                                                ..MultiBufferOffset(buffer_range.end)],
+                                            snippet.clone(),
+                                            window,
+                                            cx,
+                                        )
+                                        .ok();
                                 }
                             }
                         }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -64,8 +64,9 @@ pub use items::MAX_TAB_TITLE_LEN;
 pub use lsp::CompletionContext;
 pub use lsp_ext::lsp_tasks;
 pub use multi_buffer::{
-    Anchor, AnchorRangeExt, ExcerptId, ExcerptRange, MBTextSummary, MultiBuffer, MultiBufferOffset,
-    MultiBufferOffsetUtf16, MultiBufferSnapshot, PathKey, RowInfo, ToOffset, ToPoint,
+    Anchor, AnchorRangeExt, BufferOffset, ExcerptId, ExcerptRange, MBTextSummary, MultiBuffer,
+    MultiBufferOffset, MultiBufferOffsetUtf16, MultiBufferSnapshot, PathKey, RowInfo, ToOffset,
+    ToPoint,
 };
 pub use text::Bias;
 
@@ -134,7 +135,6 @@ use lsp_colors::LspColorData;
 use markdown::Markdown;
 use mouse_context_menu::MouseContextMenu;
 use movement::TextLayoutDetails;
-use multi_buffer::BufferOffset;
 use multi_buffer::{
     ExcerptInfo, ExpandExcerptDirection, MultiBufferDiffHunk, MultiBufferPoint, MultiBufferRow,
 };

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -64,8 +64,8 @@ pub use items::MAX_TAB_TITLE_LEN;
 pub use lsp::CompletionContext;
 pub use lsp_ext::lsp_tasks;
 pub use multi_buffer::{
-    Anchor, AnchorRangeExt, ExcerptId, ExcerptRange, MultiBuffer, MultiBufferSnapshot, PathKey,
-    RowInfo, ToOffset, ToPoint,
+    Anchor, AnchorRangeExt, ExcerptId, ExcerptRange, MBTextSummary, MultiBuffer, MultiBufferOffset,
+    MultiBufferOffsetUtf16, MultiBufferSnapshot, PathKey, RowInfo, ToOffset, ToPoint,
 };
 pub use text::Bias;
 
@@ -134,7 +134,7 @@ use lsp_colors::LspColorData;
 use markdown::Markdown;
 use mouse_context_menu::MouseContextMenu;
 use movement::TextLayoutDetails;
-use multi_buffer::{BufferOffset, MultiBufferOffset, MultiBufferOffsetUtf16};
+use multi_buffer::BufferOffset;
 use multi_buffer::{
     ExcerptInfo, ExpandExcerptDirection, MultiBufferDiffHunk, MultiBufferPoint, MultiBufferRow,
 };

--- a/crates/editor/src/git/blame.rs
+++ b/crates/editor/src/git/blame.rs
@@ -67,7 +67,7 @@ impl<'a> sum_tree::Dimension<'a, GitBlameEntrySummary> for u32 {
 struct GitBlameBuffer {
     entries: SumTree<GitBlameEntry>,
     buffer_snapshot: BufferSnapshot,
-    buffer_edits: text::Subscription,
+    buffer_edits: text::Subscription<usize>,
     commit_details: HashMap<Oid, ParsedCommitMessage>,
 }
 

--- a/crates/editor/src/highlight_matching_bracket.rs
+++ b/crates/editor/src/highlight_matching_bracket.rs
@@ -1,6 +1,7 @@
 use crate::{Editor, RangeToAnchorExt};
 use gpui::{Context, HighlightStyle, Window};
 use language::CursorShape;
+use multi_buffer::MultiBufferOffset;
 use theme::ActiveTheme;
 
 enum MatchingBracketHighlight {}
@@ -15,7 +16,7 @@ impl Editor {
 
         let snapshot = self.snapshot(window, cx);
         let buffer_snapshot = snapshot.buffer_snapshot();
-        let newest_selection = self.selections.newest::<usize>(&snapshot);
+        let newest_selection = self.selections.newest::<MultiBufferOffset>(&snapshot);
         // Don't highlight brackets if the selection isn't empty
         if !newest_selection.is_empty() {
             return;

--- a/crates/editor/src/hover_links.rs
+++ b/crates/editor/src/hover_links.rs
@@ -738,6 +738,7 @@ mod tests {
     use gpui::Modifiers;
     use indoc::indoc;
     use lsp::request::{GotoDefinition, GotoTypeDefinition};
+    use multi_buffer::MultiBufferOffset;
     use settings::InlayHintSettingsContent;
     use util::{assert_set_eq, path};
     use workspace::item::Item;
@@ -1067,8 +1068,8 @@ mod tests {
             .clone();
         cx.update_editor(|editor, window, cx| {
             let snapshot = editor.buffer().read(cx).snapshot(cx);
-            let anchor_range = snapshot.anchor_before(selection_range.start)
-                ..snapshot.anchor_after(selection_range.end);
+            let anchor_range = snapshot.anchor_before(MultiBufferOffset(selection_range.start))
+                ..snapshot.anchor_after(MultiBufferOffset(selection_range.end));
             editor.change_selections(Default::default(), window, cx, |s| {
                 s.set_pending_anchor_range(anchor_range, crate::SelectMode::Character)
             });
@@ -1122,7 +1123,7 @@ mod tests {
                 }
             "})[0]
             .start;
-        let hint_position = cx.to_lsp(hint_start_offset);
+        let hint_position = cx.to_lsp(MultiBufferOffset(hint_start_offset));
         let target_range = cx.lsp_range(indoc! {"
                 struct «TestStruct»;
 
@@ -1179,8 +1180,8 @@ mod tests {
             .unwrap();
         let midpoint = cx.update_editor(|editor, window, cx| {
             let snapshot = editor.snapshot(window, cx);
-            let previous_valid = inlay_range.start.to_display_point(&snapshot);
-            let next_valid = inlay_range.end.to_display_point(&snapshot);
+            let previous_valid = MultiBufferOffset(inlay_range.start).to_display_point(&snapshot);
+            let next_valid = MultiBufferOffset(inlay_range.end).to_display_point(&snapshot);
             assert_eq!(previous_valid.row(), next_valid.row());
             assert!(previous_valid.column() < next_valid.column());
             DisplayPoint::new(
@@ -1203,7 +1204,7 @@ mod tests {
             let buffer_snapshot = editor.buffer().update(cx, |buffer, cx| buffer.snapshot(cx));
             let expected_highlight = InlayHighlight {
                 inlay: InlayId::Hint(0),
-                inlay_position: buffer_snapshot.anchor_after(inlay_range.start),
+                inlay_position: buffer_snapshot.anchor_after(MultiBufferOffset(inlay_range.start)),
                 range: 0..hint_label.len(),
             };
             assert_set_eq!(actual_highlights, vec![&expected_highlight]);

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -17,7 +17,7 @@ use itertools::Itertools;
 use language::{DiagnosticEntry, Language, LanguageRegistry};
 use lsp::DiagnosticSeverity;
 use markdown::{Markdown, MarkdownElement, MarkdownStyle};
-use multi_buffer::{ToOffset, ToPoint};
+use multi_buffer::{MultiBufferOffset, ToOffset, ToPoint};
 use project::{HoverBlock, HoverBlockKind, InlayHintLabelPart};
 use settings::Settings;
 use std::{borrow::Cow, cell::RefCell};
@@ -106,7 +106,7 @@ pub fn find_hovered_hint_part(
     hovered_offset: InlayOffset,
 ) -> Option<(InlayHintLabelPart, Range<InlayOffset>)> {
     if hovered_offset >= hint_start {
-        let mut hovered_character = (hovered_offset - hint_start).0;
+        let mut hovered_character = hovered_offset - hint_start;
         let mut part_start = hint_start;
         for part in label_parts {
             let part_len = part.value.chars().count();
@@ -316,12 +316,12 @@ fn show_hover(
             } else {
                 snapshot
                     .buffer_snapshot()
-                    .diagnostics_with_buffer_ids_in_range::<usize>(offset..offset)
+                    .diagnostics_with_buffer_ids_in_range::<MultiBufferOffset>(offset..offset)
                     .filter(|(_, diagnostic)| {
                         Some(diagnostic.diagnostic.group_id) != active_group_id
                     })
                     // Find the entry with the most specific range
-                    .min_by_key(|(_, entry)| entry.range.len())
+                    .min_by_key(|(_, entry)| entry.range.end - entry.range.start)
             };
 
             let diagnostic_popover = if let Some((buffer_id, local_diagnostic)) = local_diagnostic {
@@ -1633,7 +1633,7 @@ mod tests {
             }
         "})[0]
             .start;
-        let hint_position = cx.to_lsp(hint_start_offset);
+        let hint_position = cx.to_lsp(MultiBufferOffset(hint_start_offset));
         let new_type_target_range = cx.lsp_range(indoc! {"
             struct TestStruct;
 
@@ -1708,8 +1708,8 @@ mod tests {
             .unwrap();
         let new_type_hint_part_hover_position = cx.update_editor(|editor, window, cx| {
             let snapshot = editor.snapshot(window, cx);
-            let previous_valid = inlay_range.start.to_display_point(&snapshot);
-            let next_valid = inlay_range.end.to_display_point(&snapshot);
+            let previous_valid = MultiBufferOffset(inlay_range.start).to_display_point(&snapshot);
+            let next_valid = MultiBufferOffset(inlay_range.end).to_display_point(&snapshot);
             assert_eq!(previous_valid.row(), next_valid.row());
             assert!(previous_valid.column() < next_valid.column());
             let exact_unclipped = DisplayPoint::new(
@@ -1819,7 +1819,8 @@ mod tests {
                 popover.symbol_range,
                 RangeInEditor::Inlay(InlayHighlight {
                     inlay: InlayId::Hint(0),
-                    inlay_position: buffer_snapshot.anchor_after(inlay_range.start),
+                    inlay_position: buffer_snapshot
+                        .anchor_after(MultiBufferOffset(inlay_range.start)),
                     range: ": ".len()..": ".len() + new_type_label.len(),
                 }),
                 "Popover range should match the new type label part"
@@ -1832,8 +1833,8 @@ mod tests {
 
         let struct_hint_part_hover_position = cx.update_editor(|editor, window, cx| {
             let snapshot = editor.snapshot(window, cx);
-            let previous_valid = inlay_range.start.to_display_point(&snapshot);
-            let next_valid = inlay_range.end.to_display_point(&snapshot);
+            let previous_valid = MultiBufferOffset(inlay_range.start).to_display_point(&snapshot);
+            let next_valid = MultiBufferOffset(inlay_range.end).to_display_point(&snapshot);
             assert_eq!(previous_valid.row(), next_valid.row());
             assert!(previous_valid.column() < next_valid.column());
             let exact_unclipped = DisplayPoint::new(
@@ -1873,7 +1874,8 @@ mod tests {
                 popover.symbol_range,
                 RangeInEditor::Inlay(InlayHighlight {
                     inlay: InlayId::Hint(0),
-                    inlay_position: buffer_snapshot.anchor_after(inlay_range.start),
+                    inlay_position: buffer_snapshot
+                        .anchor_after(MultiBufferOffset(inlay_range.start)),
                     range: ": ".len() + new_type_label.len() + "<".len()
                         ..": ".len() + new_type_label.len() + "<".len() + struct_label.len(),
                 }),

--- a/crates/editor/src/inlays/inlay_hints.rs
+++ b/crates/editor/src/inlays/inlay_hints.rs
@@ -645,9 +645,9 @@ impl Editor {
                                         )
                                     {
                                         let highlight_start =
-                                            (part_range.start - hint_start).0 + extra_shift_left;
+                                            (part_range.start - hint_start) + extra_shift_left;
                                         let highlight_end =
-                                            (part_range.end - hint_start).0 + extra_shift_right;
+                                            (part_range.end - hint_start) + extra_shift_right;
                                         let highlight = InlayHighlight {
                                             inlay: hovered_hint.id,
                                             inlay_position: hovered_hint.position,
@@ -948,7 +948,7 @@ pub mod tests {
     use language::{Language, LanguageConfig, LanguageMatcher};
     use languages::rust_lang;
     use lsp::FakeLanguageServer;
-    use multi_buffer::MultiBuffer;
+    use multi_buffer::{MultiBuffer, MultiBufferOffset};
     use parking_lot::Mutex;
     use pretty_assertions::assert_eq;
     use project::{FakeFs, Project};
@@ -1029,7 +1029,7 @@ pub mod tests {
         editor
             .update(cx, |editor, window, cx| {
                 editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
-                    s.select_ranges([13..13])
+                    s.select_ranges([MultiBufferOffset(13)..MultiBufferOffset(13)])
                 });
                 editor.handle_input("some change", window, cx);
             })
@@ -1429,7 +1429,7 @@ pub mod tests {
         rs_editor
             .update(cx, |editor, window, cx| {
                 editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
-                    s.select_ranges([13..13])
+                    s.select_ranges([MultiBufferOffset(13)..MultiBufferOffset(13)])
                 });
                 editor.handle_input("some rs change", window, cx);
             })
@@ -1461,7 +1461,7 @@ pub mod tests {
         md_editor
             .update(cx, |editor, window, cx| {
                 editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
-                    s.select_ranges([13..13])
+                    s.select_ranges([MultiBufferOffset(13)..MultiBufferOffset(13)])
                 });
                 editor.handle_input("some md change", window, cx);
             })
@@ -1909,7 +1909,7 @@ pub mod tests {
             editor
                 .update(cx, |editor, window, cx| {
                     editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
-                        s.select_ranges([13..13])
+                        s.select_ranges([MultiBufferOffset(13)..MultiBufferOffset(13)])
                     });
                     editor.handle_input(change_after_opening, window, cx);
                 })
@@ -1955,7 +1955,7 @@ pub mod tests {
                 task_editor
                     .update(&mut cx, |editor, window, cx| {
                         editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
-                            s.select_ranges([13..13])
+                            s.select_ranges([MultiBufferOffset(13)..MultiBufferOffset(13)])
                         });
                         editor.handle_input(async_later_change, window, cx);
                     })
@@ -2706,7 +2706,7 @@ let c = 3;"#
             let mut editor =
                 Editor::for_multibuffer(multi_buffer, Some(project.clone()), window, cx);
             editor.change_selections(SelectionEffects::default(), window, cx, |s| {
-                s.select_ranges([0..0])
+                s.select_ranges([MultiBufferOffset(0)..MultiBufferOffset(0)])
             });
             editor
         });

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -21,6 +21,7 @@ use language::{
     SelectionGoal, proto::serialize_anchor as serialize_text_anchor,
 };
 use lsp::DiagnosticSeverity;
+use multi_buffer::MultiBufferOffset;
 use project::{
     Project, ProjectItem as _, ProjectPath, lsp_store::FormatTrigger,
     project_settings::ProjectSettings, search::SearchQuery,
@@ -1735,7 +1736,7 @@ impl SearchableItem for Editor {
             let mut ranges = Vec::new();
 
             let search_within_ranges = if search_within_ranges.is_empty() {
-                vec![buffer.anchor_before(0)..buffer.anchor_after(buffer.len())]
+                vec![buffer.anchor_before(MultiBufferOffset(0))..buffer.anchor_after(buffer.len())]
             } else {
                 search_within_ranges
             };
@@ -1746,7 +1747,10 @@ impl SearchableItem for Editor {
                 {
                     ranges.extend(
                         query
-                            .search(search_buffer, Some(search_range.clone()))
+                            .search(
+                                search_buffer,
+                                Some(search_range.start.0..search_range.end.0),
+                            )
                             .await
                             .into_iter()
                             .map(|match_range| {

--- a/crates/editor/src/jsx_tag_auto_close.rs
+++ b/crates/editor/src/jsx_tag_auto_close.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context as _, Result, anyhow};
 use collections::HashMap;
 use gpui::{Context, Entity, Window};
-use multi_buffer::{MultiBuffer, ToOffset};
+use multi_buffer::{BufferOffset, MultiBuffer, ToOffset};
 use std::ops::Range;
 use util::ResultExt as _;
 
@@ -546,9 +546,10 @@ pub(crate) fn handle_from(
                 if edit_range_offset.start != edit_range_offset.end {
                     continue;
                 }
-                if let Some(selection) =
-                    buffer_selection_map.get_mut(&(edit_range_offset.start, edit_range_offset.end))
-                {
+                if let Some(selection) = buffer_selection_map.get_mut(&(
+                    BufferOffset(edit_range_offset.start),
+                    BufferOffset(edit_range_offset.end),
+                )) {
                     if selection.0.head().bias() != text::Bias::Right
                         || selection.0.tail().bias() != text::Bias::Right
                     {
@@ -621,7 +622,7 @@ mod jsx_tag_autoclose_tests {
     use super::*;
     use gpui::{AppContext as _, TestAppContext};
     use languages::language;
-    use multi_buffer::ExcerptRange;
+    use multi_buffer::{ExcerptRange, MultiBufferOffset};
     use text::Selection;
 
     async fn test_setup(cx: &mut TestAppContext) -> EditorTestContext {
@@ -842,9 +843,9 @@ mod jsx_tag_autoclose_tests {
         cx.update_editor(|editor, window, cx| {
             editor.change_selections(SelectionEffects::no_scroll(), window, cx, |selections| {
                 selections.select(vec![
-                    Selection::from_offset(4),
-                    Selection::from_offset(9),
-                    Selection::from_offset(15),
+                    Selection::from_offset(MultiBufferOffset(4)),
+                    Selection::from_offset(MultiBufferOffset(9)),
+                    Selection::from_offset(MultiBufferOffset(15)),
                 ])
             })
         });

--- a/crates/editor/src/linked_editing_ranges.rs
+++ b/crates/editor/src/linked_editing_ranges.rs
@@ -1,6 +1,7 @@
 use collections::HashMap;
 use gpui::{AppContext, Context, Window};
 use itertools::Itertools;
+use multi_buffer::MultiBufferOffset;
 use std::{ops::Range, time::Duration};
 use text::{AnchorRangeExt, BufferId, ToPoint};
 use util::ResultExt;
@@ -60,7 +61,9 @@ pub(super) fn refresh_linked_ranges(
         editor
             .update(cx, |editor, cx| {
                 let display_snapshot = editor.display_snapshot(cx);
-                let selections = editor.selections.all::<usize>(&display_snapshot);
+                let selections = editor
+                    .selections
+                    .all::<MultiBufferOffset>(&display_snapshot);
                 let snapshot = display_snapshot.buffer_snapshot();
                 let buffer = editor.buffer.read(cx);
                 for selection in selections {

--- a/crates/editor/src/selections_collection.rs
+++ b/crates/editor/src/selections_collection.rs
@@ -124,7 +124,7 @@ impl SelectionsCollection {
         self.pending.as_ref().map(|pending| pending.mode.clone())
     }
 
-    pub fn all<'a, D>(&self, snapshot: &DisplaySnapshot) -> Vec<Selection<D>>
+    pub fn all<D>(&self, snapshot: &DisplaySnapshot) -> Vec<Selection<D>>
     where
         D: MultiBufferDimension + Sub + AddAssign<<D as Sub>::Output> + Ord,
     {
@@ -204,7 +204,7 @@ impl SelectionsCollection {
         }
     }
 
-    pub fn disjoint_in_range<'a, D>(
+    pub fn disjoint_in_range<D>(
         &self,
         range: Range<Anchor>,
         snapshot: &DisplaySnapshot,

--- a/crates/editor/src/selections_collection.rs
+++ b/crates/editor/src/selections_collection.rs
@@ -1,18 +1,18 @@
 use std::{
     cmp, fmt, iter, mem,
-    ops::{Deref, DerefMut, Range, Sub},
+    ops::{AddAssign, Deref, DerefMut, Range, Sub},
     sync::Arc,
 };
 
 use collections::HashMap;
 use gpui::Pixels;
 use itertools::Itertools as _;
-use language::{Bias, Point, Selection, SelectionGoal, TextDimension};
+use language::{Bias, Point, Selection, SelectionGoal};
+use multi_buffer::{MultiBufferDimension, MultiBufferOffset};
 use util::post_inc;
 
 use crate::{
     Anchor, DisplayPoint, DisplayRow, ExcerptId, MultiBufferSnapshot, SelectMode, ToOffset,
-    ToPoint,
     display_map::{DisplaySnapshot, ToDisplayPoint},
     movement::TextLayoutDetails,
 };
@@ -97,7 +97,7 @@ impl SelectionsCollection {
         if self.pending.is_none() {
             self.disjoint_anchors_arc()
         } else {
-            let all_offset_selections = self.all::<usize>(snapshot);
+            let all_offset_selections = self.all::<MultiBufferOffset>(snapshot);
             all_offset_selections
                 .into_iter()
                 .map(|selection| selection_to_anchor_selection(selection, snapshot))
@@ -113,10 +113,10 @@ impl SelectionsCollection {
         self.pending.as_mut().map(|pending| &mut pending.selection)
     }
 
-    pub fn pending<D: TextDimension + Ord + Sub<D, Output = D>>(
-        &self,
-        snapshot: &DisplaySnapshot,
-    ) -> Option<Selection<D>> {
+    pub fn pending<D>(&self, snapshot: &DisplaySnapshot) -> Option<Selection<D>>
+    where
+        D: MultiBufferDimension + Sub + AddAssign<<D as Sub>::Output> + Ord,
+    {
         resolve_selections_wrapping_blocks(self.pending_anchor(), &snapshot).next()
     }
 
@@ -126,7 +126,7 @@ impl SelectionsCollection {
 
     pub fn all<'a, D>(&self, snapshot: &DisplaySnapshot) -> Vec<Selection<D>>
     where
-        D: 'a + TextDimension + Ord + Sub<D, Output = D>,
+        D: MultiBufferDimension + Sub + AddAssign<<D as Sub>::Output> + Ord,
     {
         let disjoint_anchors = &self.disjoint;
         let mut disjoint =
@@ -210,7 +210,7 @@ impl SelectionsCollection {
         snapshot: &DisplaySnapshot,
     ) -> Vec<Selection<D>>
     where
-        D: 'a + TextDimension + Ord + Sub<D, Output = D> + std::fmt::Debug,
+        D: MultiBufferDimension + Sub + AddAssign<<D as Sub>::Output> + Ord + std::fmt::Debug,
     {
         let start_ix = match self
             .disjoint
@@ -267,10 +267,10 @@ impl SelectionsCollection {
             .unwrap()
     }
 
-    pub fn newest<D: TextDimension + Ord + Sub<D, Output = D>>(
-        &self,
-        snapshot: &DisplaySnapshot,
-    ) -> Selection<D> {
+    pub fn newest<D>(&self, snapshot: &DisplaySnapshot) -> Selection<D>
+    where
+        D: MultiBufferDimension + Sub + AddAssign<<D as Sub>::Output> + Ord,
+    {
         resolve_selections_wrapping_blocks([self.newest_anchor()], &snapshot)
             .next()
             .unwrap()
@@ -290,10 +290,10 @@ impl SelectionsCollection {
             .unwrap()
     }
 
-    pub fn oldest<D: TextDimension + Ord + Sub<D, Output = D>>(
-        &self,
-        snapshot: &DisplaySnapshot,
-    ) -> Selection<D> {
+    pub fn oldest<D>(&self, snapshot: &DisplaySnapshot) -> Selection<D>
+    where
+        D: MultiBufferDimension + Sub + AddAssign<<D as Sub>::Output> + Ord,
+    {
         resolve_selections_wrapping_blocks([self.oldest_anchor()], &snapshot)
             .next()
             .unwrap()
@@ -306,27 +306,27 @@ impl SelectionsCollection {
             .unwrap_or_else(|| self.disjoint.first().cloned().unwrap())
     }
 
-    pub fn first<D: TextDimension + Ord + Sub<D, Output = D>>(
-        &self,
-        snapshot: &DisplaySnapshot,
-    ) -> Selection<D> {
+    pub fn first<D>(&self, snapshot: &DisplaySnapshot) -> Selection<D>
+    where
+        D: MultiBufferDimension + Sub + AddAssign<<D as Sub>::Output> + Ord,
+    {
         self.all(snapshot).first().unwrap().clone()
     }
 
-    pub fn last<D: TextDimension + Ord + Sub<D, Output = D>>(
-        &self,
-        snapshot: &DisplaySnapshot,
-    ) -> Selection<D> {
+    pub fn last<D>(&self, snapshot: &DisplaySnapshot) -> Selection<D>
+    where
+        D: MultiBufferDimension + Sub + AddAssign<<D as Sub>::Output> + Ord,
+    {
         self.all(snapshot).last().unwrap().clone()
     }
 
     /// Returns a list of (potentially backwards!) ranges representing the selections.
     /// Useful for test assertions, but prefer `.all()` instead.
     #[cfg(any(test, feature = "test-support"))]
-    pub fn ranges<D: TextDimension + Ord + Sub<D, Output = D>>(
-        &self,
-        snapshot: &DisplaySnapshot,
-    ) -> Vec<Range<D>> {
+    pub fn ranges<D>(&self, snapshot: &DisplaySnapshot) -> Vec<Range<D>>
+    where
+        D: MultiBufferDimension + Sub + AddAssign<<D as Sub>::Output> + Ord,
+    {
         self.all::<D>(snapshot)
             .iter()
             .map(|s| {
@@ -509,7 +509,7 @@ impl<'snap, 'a> MutableSelectionsCollection<'snap, 'a> {
         };
 
         if filtered_selections.is_empty() {
-            let default_anchor = self.snapshot.anchor_before(0);
+            let default_anchor = self.snapshot.anchor_before(MultiBufferOffset(0));
             self.collection.disjoint = Arc::from([Selection {
                 id: post_inc(&mut self.collection.next_selection_id),
                 start: default_anchor,
@@ -590,7 +590,7 @@ impl<'snap, 'a> MutableSelectionsCollection<'snap, 'a> {
 
     pub fn insert_range<T>(&mut self, range: Range<T>)
     where
-        T: 'a + ToOffset + ToPoint + TextDimension + Ord + Sub<T, Output = T> + std::marker::Copy,
+        T: ToOffset,
     {
         let display_map = self.display_snapshot();
         let mut selections = self.collection.all(&display_map);
@@ -656,7 +656,8 @@ impl<'snap, 'a> MutableSelectionsCollection<'snap, 'a> {
     pub fn select_anchors(&mut self, selections: Vec<Selection<Anchor>>) {
         let map = self.display_snapshot();
         let resolved_selections =
-            resolve_selections_wrapping_blocks::<usize, _>(&selections, &map).collect::<Vec<_>>();
+            resolve_selections_wrapping_blocks::<MultiBufferOffset, _>(&selections, &map)
+                .collect::<Vec<_>>();
         self.select(resolved_selections);
     }
 
@@ -673,7 +674,7 @@ impl<'snap, 'a> MutableSelectionsCollection<'snap, 'a> {
 
     fn select_offset_ranges<I>(&mut self, ranges: I)
     where
-        I: IntoIterator<Item = Range<usize>>,
+        I: IntoIterator<Item = Range<MultiBufferOffset>>,
     {
         let selections = ranges
             .into_iter()
@@ -808,13 +809,13 @@ impl<'snap, 'a> MutableSelectionsCollection<'snap, 'a> {
 
     pub fn move_offsets_with(
         &mut self,
-        mut move_selection: impl FnMut(&MultiBufferSnapshot, &mut Selection<usize>),
+        mut move_selection: impl FnMut(&MultiBufferSnapshot, &mut Selection<MultiBufferOffset>),
     ) {
         let mut changed = false;
         let display_map = self.display_snapshot();
         let selections = self
             .collection
-            .all::<usize>(&display_map)
+            .all::<MultiBufferOffset>(&display_map)
             .into_iter()
             .map(|selection| {
                 let mut moved_selection = selection.clone();
@@ -938,7 +939,7 @@ impl<'snap, 'a> MutableSelectionsCollection<'snap, 'a> {
             let map = self.display_snapshot();
             let resolved_selections =
                 resolve_selections_wrapping_blocks(adjusted_disjoint.iter(), &map).collect();
-            self.select::<usize>(resolved_selections);
+            self.select::<MultiBufferOffset>(resolved_selections);
         }
 
         if let Some(pending) = pending.as_mut() {
@@ -981,7 +982,7 @@ impl DerefMut for MutableSelectionsCollection<'_, '_> {
 }
 
 fn selection_to_anchor_selection(
-    selection: Selection<usize>,
+    selection: Selection<MultiBufferOffset>,
     buffer: &MultiBufferSnapshot,
 ) -> Selection<Anchor> {
     let end_bias = if selection.start == selection.end {
@@ -1054,7 +1055,7 @@ fn resolve_selections_display<'a>(
     coalesce_selections(selections)
 }
 
-/// Resolves the passed in anchors to [`TextDimension`]s `D`
+/// Resolves the passed in anchors to [`MultiBufferDimension`]s `D`
 /// wrapping around blocks inbetween.
 ///
 /// # Panics
@@ -1065,7 +1066,7 @@ pub(crate) fn resolve_selections_wrapping_blocks<'a, D, I>(
     map: &'a DisplaySnapshot,
 ) -> impl 'a + Iterator<Item = Selection<D>>
 where
-    D: TextDimension + Ord + Sub<D, Output = D>,
+    D: MultiBufferDimension + Sub + AddAssign<<D as Sub>::Output> + Ord,
     I: 'a + IntoIterator<Item = &'a Selection<Anchor>>,
 {
     // Transforms `Anchor -> DisplayPoint -> Point -> DisplayPoint -> D`

--- a/crates/editor/src/signature_help.rs
+++ b/crates/editor/src/signature_help.rs
@@ -1,13 +1,13 @@
 use crate::actions::ShowSignatureHelp;
 use crate::hover_popover::open_markdown_url;
-use crate::{Editor, EditorSettings, ToggleAutoSignatureHelp, hover_markdown_style};
+use crate::{BufferOffset, Editor, EditorSettings, ToggleAutoSignatureHelp, hover_markdown_style};
 use gpui::{
     App, Context, Entity, HighlightStyle, MouseButton, ScrollHandle, Size, StyledText, Task,
     TextStyle, Window, combine_highlights,
 };
 use language::BufferSnapshot;
 use markdown::{Markdown, MarkdownElement};
-use multi_buffer::{Anchor, ToOffset};
+use multi_buffer::{Anchor, MultiBufferOffset, ToOffset};
 use settings::Settings;
 use std::ops::Range;
 use text::Rope;
@@ -82,7 +82,9 @@ impl Editor {
         if !(self.signature_help_state.is_shown() || self.auto_signature_help_enabled(cx)) {
             return false;
         }
-        let newest_selection = self.selections.newest::<usize>(&self.display_snapshot(cx));
+        let newest_selection = self
+            .selections
+            .newest::<MultiBufferOffset>(&self.display_snapshot(cx));
         let head = newest_selection.head();
 
         if !newest_selection.is_empty() && head != newest_selection.tail() {
@@ -92,14 +94,14 @@ impl Editor {
         }
 
         let buffer_snapshot = self.buffer().read(cx).snapshot(cx);
-        let bracket_range = |position: usize| match (position, position + 1) {
-            (0, b) if b <= buffer_snapshot.len() => 0..b,
-            (0, b) => 0..b - 1,
+        let bracket_range = |position: MultiBufferOffset| match (position, position + 1usize) {
+            (MultiBufferOffset(0), b) if b <= buffer_snapshot.len() => MultiBufferOffset(0)..b,
+            (MultiBufferOffset(0), b) => MultiBufferOffset(0)..b - 1,
             (a, b) if b <= buffer_snapshot.len() => a - 1..b,
             (a, b) => a - 1..b - 1,
         };
         let not_quote_like_brackets =
-            |buffer: &BufferSnapshot, start: Range<usize>, end: Range<usize>| {
+            |buffer: &BufferSnapshot, start: Range<BufferOffset>, end: Range<BufferOffset>| {
                 let text_start = buffer.text_for_range(start).collect::<String>();
                 let text_end = buffer.text_for_range(end).collect::<String>();
                 QUOTE_PAIRS

--- a/crates/editor/src/test/editor_lsp_test_context.rs
+++ b/crates/editor/src/test/editor_lsp_test_context.rs
@@ -7,6 +7,7 @@ use std::{
 
 use anyhow::Result;
 use language::{markdown_lang, rust_lang};
+use multi_buffer::MultiBufferOffset;
 use serde_json::json;
 
 use crate::{Editor, ToPoint};
@@ -333,50 +334,38 @@ impl EditorLspTestContext {
     #[track_caller]
     pub fn lsp_range(&mut self, marked_text: &str) -> lsp::Range {
         let ranges = self.ranges(marked_text);
-        self.to_lsp_range(ranges[0].clone())
+        self.to_lsp_range(MultiBufferOffset(ranges[0].start)..MultiBufferOffset(ranges[0].end))
     }
 
     #[expect(clippy::wrong_self_convention, reason = "This is test code")]
-    pub fn to_lsp_range(&mut self, range: Range<usize>) -> lsp::Range {
+    pub fn to_lsp_range(&mut self, range: Range<MultiBufferOffset>) -> lsp::Range {
+        use language::ToPointUtf16;
         let snapshot = self.update_editor(|editor, window, cx| editor.snapshot(window, cx));
         let start_point = range.start.to_point(&snapshot.buffer_snapshot());
         let end_point = range.end.to_point(&snapshot.buffer_snapshot());
 
         self.editor(|editor, _, cx| {
             let buffer = editor.buffer().read(cx);
-            let start = point_to_lsp(
-                buffer
-                    .point_to_buffer_offset(start_point, cx)
-                    .unwrap()
-                    .1
-                    .to_point_utf16(&buffer.read(cx)),
-            );
-            let end = point_to_lsp(
-                buffer
-                    .point_to_buffer_offset(end_point, cx)
-                    .unwrap()
-                    .1
-                    .to_point_utf16(&buffer.read(cx)),
-            );
-
+            let (start_buffer, start_offset) =
+                buffer.point_to_buffer_offset(start_point, cx).unwrap();
+            let start = point_to_lsp(start_offset.to_point_utf16(&start_buffer.read(cx)));
+            let (end_buffer, end_offset) = buffer.point_to_buffer_offset(end_point, cx).unwrap();
+            let end = point_to_lsp(end_offset.to_point_utf16(&end_buffer.read(cx)));
             lsp::Range { start, end }
         })
     }
 
     #[expect(clippy::wrong_self_convention, reason = "This is test code")]
-    pub fn to_lsp(&mut self, offset: usize) -> lsp::Position {
+    pub fn to_lsp(&mut self, offset: MultiBufferOffset) -> lsp::Position {
+        use language::ToPointUtf16;
+
         let snapshot = self.update_editor(|editor, window, cx| editor.snapshot(window, cx));
         let point = offset.to_point(&snapshot.buffer_snapshot());
 
         self.editor(|editor, _, cx| {
             let buffer = editor.buffer().read(cx);
-            point_to_lsp(
-                buffer
-                    .point_to_buffer_offset(point, cx)
-                    .unwrap()
-                    .1
-                    .to_point_utf16(&buffer.read(cx)),
-            )
+            let (buffer, offset) = buffer.point_to_buffer_offset(point, cx).unwrap();
+            point_to_lsp(offset.to_point_utf16(&buffer.read(cx)))
         })
     }
 

--- a/crates/editor/src/test/editor_test_context.rs
+++ b/crates/editor/src/test/editor_test_context.rs
@@ -13,7 +13,7 @@ use gpui::{
 };
 use itertools::Itertools;
 use language::{Buffer, BufferSnapshot, LanguageRegistry};
-use multi_buffer::{Anchor, ExcerptRange, MultiBufferRow};
+use multi_buffer::{Anchor, ExcerptRange, MultiBufferOffset, MultiBufferRow};
 use parking_lot::RwLock;
 use project::{FakeFs, Project};
 use std::{
@@ -267,7 +267,7 @@ impl EditorTestContext {
         let snapshot = self.editor.update_in(&mut self.cx, |editor, window, cx| {
             editor.snapshot(window, cx)
         });
-        ranges[0].start.to_display_point(&snapshot)
+        MultiBufferOffset(ranges[0].start).to_display_point(&snapshot)
     }
 
     pub fn pixel_position(&mut self, marked_text: &str) -> Point<Pixels> {
@@ -373,7 +373,11 @@ impl EditorTestContext {
         self.editor.update_in(&mut self.cx, |editor, window, cx| {
             editor.set_text(unmarked_text, window, cx);
             editor.change_selections(Default::default(), window, cx, |s| {
-                s.select_ranges(selection_ranges)
+                s.select_ranges(
+                    selection_ranges
+                        .into_iter()
+                        .map(|range| MultiBufferOffset(range.start)..MultiBufferOffset(range.end)),
+                )
             })
         });
         state_context
@@ -390,7 +394,11 @@ impl EditorTestContext {
         self.editor.update_in(&mut self.cx, |editor, window, cx| {
             assert_eq!(editor.text(cx), unmarked_text);
             editor.change_selections(Default::default(), window, cx, |s| {
-                s.select_ranges(selection_ranges)
+                s.select_ranges(
+                    selection_ranges
+                        .into_iter()
+                        .map(|range| MultiBufferOffset(range.start)..MultiBufferOffset(range.end)),
+                )
             })
         });
         state_context
@@ -576,6 +584,7 @@ impl EditorTestContext {
                 .unwrap_or_default()
                 .iter()
                 .map(|range| range.to_offset(&snapshot.buffer_snapshot()))
+                .map(|range| range.start.0..range.end.0)
                 .collect()
         });
         assert_set_eq!(actual_ranges, expected_ranges);
@@ -591,6 +600,7 @@ impl EditorTestContext {
             .unwrap_or_default()
             .into_iter()
             .map(|range| range.to_offset(&snapshot.buffer_snapshot()))
+            .map(|range| range.start.0..range.end.0)
             .collect();
         assert_set_eq!(actual_ranges, expected_ranges);
     }
@@ -608,14 +618,16 @@ impl EditorTestContext {
     fn editor_selections(&mut self) -> Vec<Range<usize>> {
         self.editor
             .update(&mut self.cx, |editor, cx| {
-                editor.selections.all::<usize>(&editor.display_snapshot(cx))
+                editor
+                    .selections
+                    .all::<MultiBufferOffset>(&editor.display_snapshot(cx))
             })
             .into_iter()
             .map(|s| {
                 if s.reversed {
-                    s.end..s.start
+                    s.end.0..s.start.0
                 } else {
-                    s.start..s.end
+                    s.start.0..s.end.0
                 }
             })
             .collect::<Vec<_>>()
@@ -711,7 +723,10 @@ pub fn assert_state_with_diff(
             snapshot.buffer_snapshot().clone(),
             editor
                 .selections
-                .ranges::<usize>(&snapshot.display_snapshot),
+                .ranges::<MultiBufferOffset>(&snapshot.display_snapshot)
+                .into_iter()
+                .map(|range| range.start.0..range.end.0)
+                .collect::<Vec<_>>(),
         )
     });
 

--- a/crates/git_ui/src/commit_view.rs
+++ b/crates/git_ui/src/commit_view.rs
@@ -1,6 +1,9 @@
 use anyhow::{Context as _, Result};
 use buffer_diff::{BufferDiff, BufferDiffSnapshot};
-use editor::{Editor, EditorEvent, MultiBuffer, SelectionEffects, multibuffer_context_lines};
+use editor::{
+    Editor, EditorEvent, MultiBuffer, MultiBufferOffset, SelectionEffects,
+    multibuffer_context_lines,
+};
 use git::repository::{CommitDetails, CommitDiff, RepoPath};
 use gpui::{
     Action, AnyElement, AnyView, App, AppContext as _, AsyncApp, AsyncWindowContext, Context,
@@ -187,7 +190,7 @@ impl CommitView {
             editor.update(cx, |editor, cx| {
                 editor.disable_header_for_buffer(metadata_buffer_id.unwrap(), cx);
                 editor.change_selections(SelectionEffects::no_scroll(), window, cx, |selections| {
-                    selections.select_ranges(vec![0..0]);
+                    selections.select_ranges(vec![MultiBufferOffset(0)..MultiBufferOffset(0)]);
                 });
             });
         }

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -13,7 +13,8 @@ use anyhow::Context as _;
 use askpass::AskPassDelegate;
 use db::kvp::KEY_VALUE_STORE;
 use editor::{
-    Direction, Editor, EditorElement, EditorMode, MultiBuffer, actions::ExpandAllDiffHunks,
+    Direction, Editor, EditorElement, EditorMode, MultiBuffer, MultiBufferOffset,
+    actions::ExpandAllDiffHunks,
 };
 use futures::StreamExt as _;
 use git::blame::ParsedCommitMessage;
@@ -1550,7 +1551,10 @@ impl GitPanel {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Option<String> {
-        let git_commit_language = self.commit_editor.read(cx).language_at(0, cx);
+        let git_commit_language = self
+            .commit_editor
+            .read(cx)
+            .language_at(MultiBufferOffset(0), cx);
         let message = self.commit_editor.read(cx).text(cx);
         if message.is_empty() {
             return self

--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -520,7 +520,8 @@ impl ProjectDiff {
             if was_empty {
                 editor.change_selections(SelectionEffects::no_scroll(), window, cx, |selections| {
                     // TODO select the very beginning (possibly inside a deletion)
-                    selections.select_ranges([0..0])
+                    selections
+                        .select_ranges([multi_buffer::Anchor::min()..multi_buffer::Anchor::min()])
                 });
             }
             if is_excerpt_newly_added

--- a/crates/git_ui/src/text_diff_view.rs
+++ b/crates/git_ui/src/text_diff_view.rs
@@ -446,7 +446,7 @@ impl Render for TextDiffView {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use editor::test::editor_test_context::assert_state_with_diff;
+    use editor::{MultiBufferOffset, test::editor_test_context::assert_state_with_diff};
     use gpui::{TestAppContext, VisualContext};
     use project::{FakeFs, Project};
     use serde_json::json;
@@ -691,7 +691,11 @@ mod tests {
             let (unmarked_text, selection_ranges) = marked_text_ranges(editor_text, false);
             editor.set_text(unmarked_text, window, cx);
             editor.change_selections(Default::default(), window, cx, |s| {
-                s.select_ranges(selection_ranges)
+                s.select_ranges(
+                    selection_ranges
+                        .into_iter()
+                        .map(|range| MultiBufferOffset(range.start)..MultiBufferOffset(range.end)),
+                )
             });
 
             editor

--- a/crates/go_to_line/src/cursor_position.rs
+++ b/crates/go_to_line/src/cursor_position.rs
@@ -1,4 +1,4 @@
-use editor::{Editor, EditorEvent, MultiBufferSnapshot};
+use editor::{Editor, EditorEvent, MBTextSummary, MultiBufferSnapshot};
 use gpui::{App, Entity, FocusHandle, Focusable, Styled, Subscription, Task, WeakEntity};
 use settings::{RegisterSetting, Settings};
 use std::{fmt::Write, num::NonZeroU32, time::Duration};
@@ -55,7 +55,7 @@ impl UserCaretPosition {
             let line_start = Point::new(selection_end.row, 0);
 
             let chars_to_last_position = snapshot
-                .text_summary_for_range::<text::TextSummary, _>(line_start..selection_end)
+                .text_summary_for_range::<MBTextSummary, _>(line_start..selection_end)
                 .chars as u32;
             (selection_end.row, chars_to_last_position)
         };
@@ -116,7 +116,7 @@ impl CursorPosition {
                                     for selection in editor.selections.all_adjusted(&snapshot) {
                                         let selection_summary = snapshot
                                             .buffer_snapshot()
-                                            .text_summary_for_range::<text::TextSummary, _>(
+                                            .text_summary_for_range::<MBTextSummary, _>(
                                             selection.start..selection.end,
                                         );
                                         cursor_position.selected_count.characters +=

--- a/crates/journal/src/journal.rs
+++ b/crates/journal/src/journal.rs
@@ -159,7 +159,7 @@ pub fn new_journal_entry(workspace: &Workspace, window: &mut Window, cx: &mut Ap
                         cx,
                         |s| s.select_ranges([len..len]),
                     );
-                    if len > 0 {
+                    if len.0 > 0 {
                         editor.insert("\n\n", window, cx);
                     }
                     editor.insert(&entry_heading, window, cx);

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -2083,7 +2083,7 @@ impl Buffer {
     }
 
     /// Gets a [`Subscription`] that tracks all of the changes to the buffer's text.
-    pub fn subscribe(&mut self) -> Subscription {
+    pub fn subscribe(&mut self) -> Subscription<usize> {
         self.text.subscribe()
     }
 

--- a/crates/language_tools/src/lsp_log_view.rs
+++ b/crates/language_tools/src/lsp_log_view.rs
@@ -1,6 +1,6 @@
 use collections::VecDeque;
 use copilot::Copilot;
-use editor::{Editor, EditorEvent, actions::MoveToEnd, scroll::Autoscroll};
+use editor::{Editor, EditorEvent, MultiBufferOffset, actions::MoveToEnd, scroll::Autoscroll};
 use gpui::{
     AnyView, App, Context, Corner, Entity, EventEmitter, FocusHandle, Focusable, IntoElement,
     ParentElement, Render, Styled, Subscription, Task, WeakEntity, Window, actions, div,
@@ -231,7 +231,7 @@ impl LspLogView {
                             let last_offset = editor.buffer().read(cx).len(cx);
                             let newest_cursor_is_at_end = editor
                                 .selections
-                                .newest::<usize>(&editor.display_snapshot(cx))
+                                .newest::<MultiBufferOffset>(&editor.display_snapshot(cx))
                                 .start
                                 >= last_offset;
                             editor.edit(

--- a/crates/language_tools/src/syntax_tree_view.rs
+++ b/crates/language_tools/src/syntax_tree_view.rs
@@ -1,5 +1,5 @@
 use command_palette_hooks::CommandPaletteFilter;
-use editor::{Anchor, Editor, ExcerptId, SelectionEffects, scroll::Autoscroll};
+use editor::{Anchor, Editor, ExcerptId, MultiBufferOffset, SelectionEffects, scroll::Autoscroll};
 use gpui::{
     App, AppContext as _, Context, Div, Entity, EntityId, EventEmitter, FocusHandle, Focusable,
     Hsla, InteractiveElement, IntoElement, MouseButton, MouseDownEvent, MouseMoveEvent,
@@ -254,7 +254,7 @@ impl SyntaxTreeView {
         let (buffer, range, excerpt_id) = editor_state.editor.update(cx, |editor, cx| {
             let selection_range = editor
                 .selections
-                .last::<usize>(&editor.display_snapshot(cx))
+                .last::<MultiBufferOffset>(&editor.display_snapshot(cx))
                 .range();
             let multi_buffer = editor.buffer().read(cx);
             let (buffer, range, excerpt_id) = snapshot
@@ -308,8 +308,8 @@ impl SyntaxTreeView {
         // Within the active layer, find the syntax node under the cursor,
         // and scroll to it.
         let mut cursor = layer.node().walk();
-        while cursor.goto_first_child_for_byte(range.start).is_some() {
-            if !range.is_empty() && cursor.node().end_byte() == range.start {
+        while cursor.goto_first_child_for_byte(range.start.0).is_some() {
+            if !range.is_empty() && cursor.node().end_byte() == range.start.0 {
                 cursor.goto_next_sibling();
             }
         }
@@ -317,7 +317,7 @@ impl SyntaxTreeView {
         // Ascend to the smallest ancestor that contains the range.
         loop {
             let node_range = cursor.node().byte_range();
-            if node_range.start <= range.start && node_range.end >= range.end {
+            if node_range.start <= range.start.0 && node_range.end >= range.end.0 {
                 break;
             }
             if !cursor.goto_parent() {

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -4,7 +4,7 @@ use std::{ops::Range, path::PathBuf};
 
 use anyhow::Result;
 use editor::scroll::Autoscroll;
-use editor::{Editor, EditorEvent, SelectionEffects};
+use editor::{Editor, EditorEvent, MultiBufferOffset, SelectionEffects};
 use gpui::{
     App, ClickEvent, Context, Entity, EventEmitter, FocusHandle, Focusable, InteractiveElement,
     IntoElement, IsZero, ListState, ParentElement, Render, RetainAllImageCache, Styled,
@@ -281,7 +281,7 @@ impl MarkdownPreviewView {
                         let selection_range = editor.update(cx, |editor, cx| {
                             editor
                                 .selections
-                                .last::<usize>(&editor.display_snapshot(cx))
+                                .last::<MultiBufferOffset>(&editor.display_snapshot(cx))
                                 .range()
                         });
                         this.selected_block = this.get_block_index_under_cursor(selection_range);
@@ -358,7 +358,7 @@ impl MarkdownPreviewView {
         &self,
         window: &mut Window,
         cx: &mut Context<Self>,
-        selection: Range<usize>,
+        selection: Range<MultiBufferOffset>,
     ) {
         if let Some(state) = &self.active_editor {
             state.editor.update(cx, |editor, cx| {
@@ -375,7 +375,7 @@ impl MarkdownPreviewView {
 
     /// The absolute path of the file that is currently being previewed.
     fn get_folder_for_active_editor(editor: &Editor, cx: &App) -> Option<PathBuf> {
-        if let Some(file) = editor.file_at(0, cx) {
+        if let Some(file) = editor.file_at(MultiBufferOffset(0), cx) {
             if let Some(file) = file.as_local() {
                 file.abs_path(cx).parent().map(|p| p.to_path_buf())
             } else {
@@ -386,9 +386,9 @@ impl MarkdownPreviewView {
         }
     }
 
-    fn get_block_index_under_cursor(&self, selection_range: Range<usize>) -> usize {
+    fn get_block_index_under_cursor(&self, selection_range: Range<MultiBufferOffset>) -> usize {
         let mut block_index = None;
-        let cursor = selection_range.start;
+        let cursor = selection_range.start.0;
 
         let mut last_end = 0;
         if let Some(content) = &self.contents {
@@ -524,7 +524,15 @@ impl Render for MarkdownPreviewView {
                                                         if e.checked() { "[x]" } else { "[ ]" };
 
                                                     editor.edit(
-                                                        vec![(e.source_range(), task_marker)],
+                                                        vec![(
+                                                            MultiBufferOffset(
+                                                                e.source_range().start,
+                                                            )
+                                                                ..MultiBufferOffset(
+                                                                    e.source_range().end,
+                                                                ),
+                                                            task_marker,
+                                                        )],
                                                         cx,
                                                     );
                                                 });
@@ -564,7 +572,8 @@ impl Render for MarkdownPreviewView {
                                             this.move_cursor_to_block(
                                                 window,
                                                 cx,
-                                                source_range.start..source_range.start,
+                                                MultiBufferOffset(source_range.start)
+                                                    ..MultiBufferOffset(source_range.start),
                                             );
                                         }
                                     },

--- a/crates/multi_buffer/src/anchor.rs
+++ b/crates/multi_buffer/src/anchor.rs
@@ -4,7 +4,7 @@ use super::{ExcerptId, MultiBufferSnapshot, ToOffset, ToPoint};
 use language::{Point, TextDimension};
 use std::{
     cmp::Ordering,
-    ops::{Range, Sub},
+    ops::{AddAssign, Range, Sub},
 };
 use sum_tree::Bias;
 use text::BufferId;
@@ -162,9 +162,9 @@ impl Anchor {
         *self
     }
 
-    pub fn summary<D>(&self, snapshot: &MultiBufferSnapshot) -> D
+    pub fn summary<D, R>(&self, snapshot: &MultiBufferSnapshot) -> D
     where
-        D: TextDimension + Ord + Sub<D, Output = D>,
+        D: TextDimension + Ord + Sub<D, Output = R> + AddAssign<R> + Default,
     {
         snapshot.summary_for_anchor(self)
     }

--- a/crates/multi_buffer/src/anchor.rs
+++ b/crates/multi_buffer/src/anchor.rs
@@ -1,7 +1,7 @@
-use crate::{MultiBufferOffset, MultiBufferOffsetUtf16};
+use crate::{MultiBufferDimension, MultiBufferOffset, MultiBufferOffsetUtf16};
 
 use super::{ExcerptId, MultiBufferSnapshot, ToOffset, ToPoint};
-use language::{Point, TextDimension};
+use language::Point;
 use std::{
     cmp::Ordering,
     ops::{AddAssign, Range, Sub},
@@ -162,9 +162,14 @@ impl Anchor {
         *self
     }
 
-    pub fn summary<D, R>(&self, snapshot: &MultiBufferSnapshot) -> D
+    pub fn summary<D>(&self, snapshot: &MultiBufferSnapshot) -> D
     where
-        D: TextDimension + Ord + Sub<D, Output = R> + AddAssign<R> + Default,
+        D: MultiBufferDimension
+            + Ord
+            + Sub<D, Output = D::TextDimension>
+            + AddAssign<D::TextDimension>
+            + Default,
+        D::TextDimension: Sub<Output = D::TextDimension> + Ord,
     {
         snapshot.summary_for_anchor(self)
     }

--- a/crates/multi_buffer/src/anchor.rs
+++ b/crates/multi_buffer/src/anchor.rs
@@ -237,6 +237,3 @@ impl AnchorRangeExt for Range<Anchor> {
         self.start.to_point(content)..self.end.to_point(content)
     }
 }
-
-#[derive(Clone, Copy, Eq, PartialEq, Debug, Hash, Ord, PartialOrd)]
-pub struct Offset(pub usize);

--- a/crates/multi_buffer/src/anchor.rs
+++ b/crates/multi_buffer/src/anchor.rs
@@ -166,9 +166,8 @@ impl Anchor {
     where
         D: MultiBufferDimension
             + Ord
-            + Sub<D, Output = D::TextDimension>
-            + AddAssign<D::TextDimension>
-            + Default,
+            + Sub<Output = D::TextDimension>
+            + AddAssign<D::TextDimension>,
         D::TextDimension: Sub<Output = D::TextDimension> + Ord,
     {
         snapshot.summary_for_anchor(self)

--- a/crates/multi_buffer/src/anchor.rs
+++ b/crates/multi_buffer/src/anchor.rs
@@ -1,5 +1,7 @@
+use crate::{MultiBufferOffset, MultiBufferOffsetUtf16};
+
 use super::{ExcerptId, MultiBufferSnapshot, ToOffset, ToPoint};
-use language::{OffsetUtf16, Point, TextDimension};
+use language::{Point, TextDimension};
 use std::{
     cmp::Ordering,
     ops::{Range, Sub},
@@ -182,10 +184,10 @@ impl Anchor {
 }
 
 impl ToOffset for Anchor {
-    fn to_offset(&self, snapshot: &MultiBufferSnapshot) -> usize {
+    fn to_offset(&self, snapshot: &MultiBufferSnapshot) -> MultiBufferOffset {
         self.summary(snapshot)
     }
-    fn to_offset_utf16(&self, snapshot: &MultiBufferSnapshot) -> OffsetUtf16 {
+    fn to_offset_utf16(&self, snapshot: &MultiBufferSnapshot) -> MultiBufferOffsetUtf16 {
         self.summary(snapshot)
     }
 }
@@ -203,7 +205,7 @@ pub trait AnchorRangeExt {
     fn cmp(&self, other: &Range<Anchor>, buffer: &MultiBufferSnapshot) -> Ordering;
     fn includes(&self, other: &Range<Anchor>, buffer: &MultiBufferSnapshot) -> bool;
     fn overlaps(&self, other: &Range<Anchor>, buffer: &MultiBufferSnapshot) -> bool;
-    fn to_offset(&self, content: &MultiBufferSnapshot) -> Range<usize>;
+    fn to_offset(&self, content: &MultiBufferSnapshot) -> Range<MultiBufferOffset>;
     fn to_point(&self, content: &MultiBufferSnapshot) -> Range<Point>;
 }
 
@@ -223,7 +225,7 @@ impl AnchorRangeExt for Range<Anchor> {
         self.end.cmp(&other.start, buffer).is_ge() && self.start.cmp(&other.end, buffer).is_le()
     }
 
-    fn to_offset(&self, content: &MultiBufferSnapshot) -> Range<usize> {
+    fn to_offset(&self, content: &MultiBufferSnapshot) -> Range<MultiBufferOffset> {
         self.start.to_offset(content)..self.end.to_offset(content)
     }
 

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -5451,7 +5451,7 @@ impl MultiBufferSnapshot {
     pub fn runnable_ranges(
         &self,
         range: Range<Anchor>,
-    ) -> impl Iterator<Item = language::RunnableRange> + '_ {
+    ) -> impl Iterator<Item = (Range<MultiBufferOffset>, language::RunnableRange)> + '_ {
         let range = range.start.to_offset(self)..range.end.to_offset(self);
         self.lift_buffer_metadata(range, move |buffer, range| {
             Some(
@@ -5464,10 +5464,7 @@ impl MultiBufferSnapshot {
                     .map(|runnable| (runnable.run_range.clone(), runnable)),
             )
         })
-        .map(|(run_range, runnable, _)| language::RunnableRange {
-            run_range: run_range.start.0..run_range.end.0,
-            ..runnable
-        })
+        .map(|(run_range, runnable, _)| (run_range, runnable))
     }
 
     pub fn line_indents(
@@ -5970,28 +5967,6 @@ impl MultiBufferSnapshot {
             return None;
         };
         Some((node, excerpt.map_range_from_buffer(node_range)))
-    }
-
-    pub fn syntax_next_sibling<T: ToOffset>(
-        &self,
-        range: Range<T>,
-    ) -> Option<tree_sitter::Node<'_>> {
-        let range = range.start.to_offset(self)..range.end.to_offset(self);
-        let mut excerpt = self.excerpt_containing(range.clone())?;
-        excerpt
-            .buffer()
-            .syntax_next_sibling(excerpt.map_range_to_buffer(range))
-    }
-
-    pub fn syntax_prev_sibling<T: ToOffset>(
-        &self,
-        range: Range<T>,
-    ) -> Option<tree_sitter::Node<'_>> {
-        let range = range.start.to_offset(self)..range.end.to_offset(self);
-        let mut excerpt = self.excerpt_containing(range.clone())?;
-        excerpt
-            .buffer()
-            .syntax_prev_sibling(excerpt.map_range_to_buffer(range))
     }
 
     pub fn outline(&self, theme: Option<&SyntaxTheme>) -> Option<Outline<Anchor>> {

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -669,7 +669,7 @@ pub struct MultiBufferExcerpt<'a> {
     diff_transforms:
         sum_tree::Cursor<'a, 'static, DiffTransform, DiffTransforms<MultiBufferOffset>>,
     offset: MultiBufferOffset,
-    // todo unsure about this
+    // todo unsure about this type
     excerpt_offset: MultiBufferOffset,
     buffer_offset: BufferOffset,
 }
@@ -6793,8 +6793,7 @@ impl<'a> MultiBufferExcerpt<'a> {
             log::warn!(
                 "Attempting to map a range from a buffer offset that starts before the current buffer offset"
             );
-            // return buffer_range;
-            todo!()
+            return self.offset..self.offset;
         }
         let overshoot = buffer_range.start - self.buffer_offset;
         let excerpt_offset = self.excerpt_offset + overshoot;
@@ -6804,8 +6803,7 @@ impl<'a> MultiBufferExcerpt<'a> {
             log::warn!(
                 "Attempting to map a range from a buffer offset that starts before the current buffer offset"
             );
-            // return buffer_range;
-            todo!()
+            return self.offset..self.offset;
         }
         let overshoot = excerpt_offset - self.diff_transforms.start().excerpt_dimension.0;
         let start = self.diff_transforms.start().output_dimension.0 + overshoot;

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -1855,7 +1855,7 @@ impl MultiBuffer {
             if let Some(excerpt) = excerpts.item()
                 && excerpt.locator == *locator
             {
-                let excerpt_start = excerpts.start().1.clone();
+                let excerpt_start = excerpts.start().1;
                 let excerpt_end = ExcerptDimension(excerpt_start.0 + excerpt.text_summary.lines);
 
                 diff_transforms.seek_forward(&excerpt_start, Bias::Left);
@@ -5195,7 +5195,7 @@ impl MultiBufferSnapshot {
             excerpt,
             offset: diff_transforms.start().output_dimension.0,
             buffer_offset: BufferOffset(excerpt.range.context.start.to_offset(&excerpt.buffer)),
-            excerpt_offset: excerpts.start().1.0.clone(),
+            excerpt_offset: excerpts.start().1.0,
             diff_transforms,
         })
     }
@@ -6108,7 +6108,7 @@ impl MultiBufferSnapshot {
             sought_exact = true;
         }
         if sought_exact {
-            let start = cursor.start().1.clone();
+            let start = cursor.start().1;
             let end = cursor.end().1;
             let mut diff_transforms = self
                 .diff_transforms
@@ -6161,7 +6161,7 @@ impl MultiBufferSnapshot {
         let region = cursor.region()?;
         let offset = region.range.start;
         let buffer_offset = start_excerpt.buffer_start_offset();
-        let excerpt_offset = cursor.excerpts.start().clone().0;
+        let excerpt_offset = cursor.excerpts.start().0;
         Some(MultiBufferExcerpt {
             diff_transforms: cursor.diff_transforms,
             excerpt: start_excerpt,
@@ -6770,7 +6770,7 @@ impl<'a> MultiBufferExcerpt<'a> {
     }
 
     fn map_offset_to_buffer_internal(&self, offset: MultiBufferOffset) -> BufferOffset {
-        let mut excerpt_offset = self.diff_transforms.start().excerpt_dimension.clone();
+        let mut excerpt_offset = self.diff_transforms.start().excerpt_dimension;
         if let Some(DiffTransform::BufferContent { .. }) = self.diff_transforms.item() {
             excerpt_offset.0 += offset - self.diff_transforms.start().output_dimension.0;
         };

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -347,12 +347,50 @@ impl AddAssign<DimensionPair<usize, Point>> for BufferOffset {
     }
 }
 
+impl language::ToPoint for BufferOffset {
+    fn to_point(&self, snapshot: &text::BufferSnapshot) -> Point {
+        self.0.to_point(snapshot)
+    }
+}
+
+impl language::ToPointUtf16 for BufferOffset {
+    fn to_point_utf16(&self, snapshot: &text::BufferSnapshot) -> PointUtf16 {
+        self.0.to_point_utf16(snapshot)
+    }
+}
+
+impl language::ToOffset for BufferOffset {
+    fn to_offset(&self, snapshot: &text::BufferSnapshot) -> usize {
+        self.0.to_offset(snapshot)
+    }
+}
+
+impl language::ToOffsetUtf16 for BufferOffset {
+    fn to_offset_utf16(&self, snapshot: &text::BufferSnapshot) -> OffsetUtf16 {
+        self.0.to_offset_utf16(snapshot)
+    }
+}
+
 #[derive(Copy, Clone, Debug, Default, Eq, Ord, PartialOrd, PartialEq)]
 pub struct MultiBufferOffsetUtf16(pub OffsetUtf16);
+
+impl ops::Add<usize> for MultiBufferOffsetUtf16 {
+    type Output = MultiBufferOffsetUtf16;
+
+    fn add(self, rhs: usize) -> Self::Output {
+        MultiBufferOffsetUtf16(OffsetUtf16(self.0.0 + rhs))
+    }
+}
 
 impl AddAssign<OffsetUtf16> for MultiBufferOffsetUtf16 {
     fn add_assign(&mut self, rhs: OffsetUtf16) {
         self.0 += rhs;
+    }
+}
+
+impl AddAssign<usize> for MultiBufferOffsetUtf16 {
+    fn add_assign(&mut self, rhs: usize) {
+        self.0.0 += rhs;
     }
 }
 
@@ -427,6 +465,14 @@ impl ops::AddAssign<usize> for MultiBufferOffset {
     }
 }
 
+impl ops::Add<isize> for MultiBufferOffset {
+    type Output = Self;
+
+    fn add(self, rhs: isize) -> Self::Output {
+        MultiBufferOffset((self.0 as isize + rhs) as usize)
+    }
+}
+
 impl ops::Add for MultiBufferOffset {
     type Output = Self;
 
@@ -438,12 +484,6 @@ impl ops::Add for MultiBufferOffset {
 impl ops::AddAssign<MultiBufferOffset> for MultiBufferOffset {
     fn add_assign(&mut self, other: MultiBufferOffset) {
         self.0 += other.0;
-    }
-}
-
-impl language::ToOffset for BufferOffset {
-    fn to_offset(&self, _: &text::BufferSnapshot) -> usize {
-        self.0
     }
 }
 
@@ -2429,7 +2469,7 @@ impl MultiBuffer {
             let start = snapshot.point_to_offset(Point::new(range.start.row, 0));
             let end = snapshot.point_to_offset(Point::new(range.end.row + 1, 0));
             let start = start.saturating_sub_usize(1);
-            let end = snapshot.len().min(end + 1);
+            let end = snapshot.len().min(end + 1usize);
             cursor.seek(&start, Bias::Right);
             while let Some(item) = cursor.item() {
                 if *cursor.start() >= end {

--- a/crates/multi_buffer/src/multi_buffer_tests.rs
+++ b/crates/multi_buffer/src/multi_buffer_tests.rs
@@ -3570,6 +3570,7 @@ fn assert_new_snapshot(
     let line_infos = new_snapshot
         .row_infos(MultiBufferRow(0))
         .collect::<Vec<_>>();
+    dbg!(&line_infos);
     let actual_diff = format_diff(&actual_text, &line_infos, &Default::default(), None);
     pretty_assertions::assert_eq!(actual_diff, expected_diff);
     check_edits(

--- a/crates/multi_buffer/src/multi_buffer_tests.rs
+++ b/crates/multi_buffer/src/multi_buffer_tests.rs
@@ -925,7 +925,7 @@ fn test_empty_diff_excerpt(cx: &mut TestAppContext) {
         .next()
         .unwrap();
 
-    assert_eq!(hunk.diff_base_byte_range.start, 0);
+    assert_eq!(hunk.diff_base_byte_range.start, BufferOffset(0));
 
     let buf2 = cx.new(|cx| Buffer::local("X", cx));
     multibuffer.update(cx, |multibuffer, cx| {

--- a/crates/multi_buffer/src/multi_buffer_tests.rs
+++ b/crates/multi_buffer/src/multi_buffer_tests.rs
@@ -386,7 +386,7 @@ fn test_diff_boundary_anchors(cx: &mut TestAppContext) {
         assert_eq!(after.to_point(&snapshot), Point::new(2, 0));
         assert_eq!(
             vec![Point::new(1, 0), Point::new(2, 0),],
-            snapshot.summaries_for_anchors::<Point, _>(&[before, after]),
+            snapshot.summaries_for_anchors::<Point, _, _>(&[before, after]),
         )
     })
 }
@@ -971,10 +971,30 @@ fn test_singleton_multibuffer_anchors(cx: &mut App) {
     assert_eq!(old_snapshot.text(), "abcd");
     assert_eq!(new_snapshot.text(), "XabcdY");
 
-    assert_eq!(old_snapshot.anchor_before(0).to_offset(&new_snapshot), 0);
-    assert_eq!(old_snapshot.anchor_after(0).to_offset(&new_snapshot), 1);
-    assert_eq!(old_snapshot.anchor_before(4).to_offset(&new_snapshot), 5);
-    assert_eq!(old_snapshot.anchor_after(4).to_offset(&new_snapshot), 6);
+    assert_eq!(
+        old_snapshot
+            .anchor_before(MultiBufferOffset(0))
+            .to_offset(&new_snapshot),
+        MultiBufferOffset(0)
+    );
+    assert_eq!(
+        old_snapshot
+            .anchor_after(MultiBufferOffset(0))
+            .to_offset(&new_snapshot),
+        MultiBufferOffset(1)
+    );
+    assert_eq!(
+        old_snapshot
+            .anchor_before(MultiBufferOffset(4))
+            .to_offset(&new_snapshot),
+        MultiBufferOffset(5)
+    );
+    assert_eq!(
+        old_snapshot
+            .anchor_after(MultiBufferOffset(4))
+            .to_offset(&new_snapshot),
+        MultiBufferOffset(6)
+    );
 }
 
 #[gpui::test]
@@ -989,12 +1009,28 @@ fn test_multibuffer_anchors(cx: &mut App) {
     });
     let old_snapshot = multibuffer.read(cx).snapshot(cx);
 
-    assert_eq!(old_snapshot.anchor_before(0).to_offset(&old_snapshot), 0);
-    assert_eq!(old_snapshot.anchor_after(0).to_offset(&old_snapshot), 0);
-    assert_eq!(Anchor::min().to_offset(&old_snapshot), 0);
-    assert_eq!(Anchor::min().to_offset(&old_snapshot), 0);
-    assert_eq!(Anchor::max().to_offset(&old_snapshot), 10);
-    assert_eq!(Anchor::max().to_offset(&old_snapshot), 10);
+    assert_eq!(
+        old_snapshot
+            .anchor_before(MultiBufferOffset(0))
+            .to_offset(&old_snapshot),
+        MultiBufferOffset(0)
+    );
+    assert_eq!(
+        old_snapshot
+            .anchor_after(MultiBufferOffset(0))
+            .to_offset(&old_snapshot),
+        MultiBufferOffset(0)
+    );
+    assert_eq!(Anchor::min().to_offset(&old_snapshot), MultiBufferOffset(0));
+    assert_eq!(Anchor::min().to_offset(&old_snapshot), MultiBufferOffset(0));
+    assert_eq!(
+        Anchor::max().to_offset(&old_snapshot),
+        MultiBufferOffset(10)
+    );
+    assert_eq!(
+        Anchor::max().to_offset(&old_snapshot),
+        MultiBufferOffset(10)
+    );
 
     buffer_1.update(cx, |buffer, cx| {
         buffer.edit([(0..0, "W")], None, cx);
@@ -1009,16 +1045,66 @@ fn test_multibuffer_anchors(cx: &mut App) {
     assert_eq!(old_snapshot.text(), "abcd\nefghi");
     assert_eq!(new_snapshot.text(), "WabcdX\nYefghiZ");
 
-    assert_eq!(old_snapshot.anchor_before(0).to_offset(&new_snapshot), 0);
-    assert_eq!(old_snapshot.anchor_after(0).to_offset(&new_snapshot), 1);
-    assert_eq!(old_snapshot.anchor_before(1).to_offset(&new_snapshot), 2);
-    assert_eq!(old_snapshot.anchor_after(1).to_offset(&new_snapshot), 2);
-    assert_eq!(old_snapshot.anchor_before(2).to_offset(&new_snapshot), 3);
-    assert_eq!(old_snapshot.anchor_after(2).to_offset(&new_snapshot), 3);
-    assert_eq!(old_snapshot.anchor_before(5).to_offset(&new_snapshot), 7);
-    assert_eq!(old_snapshot.anchor_after(5).to_offset(&new_snapshot), 8);
-    assert_eq!(old_snapshot.anchor_before(10).to_offset(&new_snapshot), 13);
-    assert_eq!(old_snapshot.anchor_after(10).to_offset(&new_snapshot), 14);
+    assert_eq!(
+        old_snapshot
+            .anchor_before(MultiBufferOffset(0))
+            .to_offset(&new_snapshot),
+        MultiBufferOffset(0)
+    );
+    assert_eq!(
+        old_snapshot
+            .anchor_after(MultiBufferOffset(0))
+            .to_offset(&new_snapshot),
+        MultiBufferOffset(1)
+    );
+    assert_eq!(
+        old_snapshot
+            .anchor_before(MultiBufferOffset(1))
+            .to_offset(&new_snapshot),
+        MultiBufferOffset(2)
+    );
+    assert_eq!(
+        old_snapshot
+            .anchor_after(MultiBufferOffset(1))
+            .to_offset(&new_snapshot),
+        MultiBufferOffset(3)
+    );
+    assert_eq!(
+        old_snapshot
+            .anchor_before(MultiBufferOffset(2))
+            .to_offset(&new_snapshot),
+        MultiBufferOffset(4)
+    );
+    assert_eq!(
+        old_snapshot
+            .anchor_after(MultiBufferOffset(2))
+            .to_offset(&new_snapshot),
+        MultiBufferOffset(5)
+    );
+    assert_eq!(
+        old_snapshot
+            .anchor_before(MultiBufferOffset(5))
+            .to_offset(&new_snapshot),
+        MultiBufferOffset(7)
+    );
+    assert_eq!(
+        old_snapshot
+            .anchor_after(MultiBufferOffset(5))
+            .to_offset(&new_snapshot),
+        MultiBufferOffset(8)
+    );
+    assert_eq!(
+        old_snapshot
+            .anchor_before(MultiBufferOffset(10))
+            .to_offset(&new_snapshot),
+        MultiBufferOffset(13)
+    );
+    assert_eq!(
+        old_snapshot
+            .anchor_after(MultiBufferOffset(10))
+            .to_offset(&new_snapshot),
+        MultiBufferOffset(14)
+    );
 }
 
 #[gpui::test]
@@ -1066,26 +1152,28 @@ fn test_resolving_anchors_after_replacing_their_excerpts(cx: &mut App) {
     // The current excerpts are from a different buffer, so we don't attempt to
     // resolve the old text anchor in the new buffer.
     assert_eq!(
-        snapshot_2.summary_for_anchor::<usize>(&snapshot_1.anchor_before(2)),
+        snapshot_2.summary_for_anchor::<usize, _>(&snapshot_1.anchor_before(MultiBufferOffset(2))),
         0
     );
     assert_eq!(
-        snapshot_2.summaries_for_anchors::<usize, _>(&[
-            snapshot_1.anchor_before(2),
-            snapshot_1.anchor_after(3)
+        snapshot_2.summaries_for_anchors::<usize, _, _>(&[
+            snapshot_1.anchor_before(MultiBufferOffset(2)),
+            snapshot_1.anchor_after(MultiBufferOffset(3))
         ]),
         vec![0, 0]
     );
 
     // Refresh anchors from the old snapshot. The return value indicates that both
     // anchors lost their original excerpt.
-    let refresh =
-        snapshot_2.refresh_anchors(&[snapshot_1.anchor_before(2), snapshot_1.anchor_after(3)]);
+    let refresh = snapshot_2.refresh_anchors(&[
+        snapshot_1.anchor_before(MultiBufferOffset(2)),
+        snapshot_1.anchor_after(MultiBufferOffset(3)),
+    ]);
     assert_eq!(
         refresh,
         &[
-            (0, snapshot_2.anchor_before(0), false),
-            (1, snapshot_2.anchor_after(0), false),
+            (0, snapshot_2.anchor_before(MultiBufferOffset(0)), false),
+            (1, snapshot_2.anchor_after(MultiBufferOffset(0)), false),
         ]
     );
 
@@ -1112,13 +1200,13 @@ fn test_resolving_anchors_after_replacing_their_excerpts(cx: &mut App) {
     // The third anchor can't be resolved, since its excerpt has been removed,
     // so it resolves to the same position as its predecessor.
     let anchors = [
-        snapshot_2.anchor_before(0),
-        snapshot_2.anchor_after(2),
-        snapshot_2.anchor_after(6),
-        snapshot_2.anchor_after(14),
+        snapshot_2.anchor_before(MultiBufferOffset(0)),
+        snapshot_2.anchor_after(MultiBufferOffset(2)),
+        snapshot_2.anchor_after(MultiBufferOffset(6)),
+        snapshot_2.anchor_after(MultiBufferOffset(14)),
     ];
     assert_eq!(
-        snapshot_3.summaries_for_anchors::<usize, _>(&anchors),
+        snapshot_3.summaries_for_anchors::<usize, _, _>(&anchors),
         &[0, 2, 9, 13]
     );
 
@@ -1128,7 +1216,7 @@ fn test_resolving_anchors_after_replacing_their_excerpts(cx: &mut App) {
         &[(0, true), (1, true), (2, true), (3, true)]
     );
     assert_eq!(
-        snapshot_3.summaries_for_anchors::<usize, _>(new_anchors.iter().map(|a| &a.1)),
+        snapshot_3.summaries_for_anchors::<usize, _, _>(new_anchors.iter().map(|a| &a.1)),
         &[0, 2, 7, 13]
     );
 }
@@ -1371,7 +1459,7 @@ fn test_basic_diff_hunks(cx: &mut TestAppContext) {
 
     assert_eq!(
         snapshot
-            .diff_hunks_in_range(0..snapshot.len())
+            .diff_hunks_in_range(MultiBufferOffset(0)..snapshot.len())
             .map(|hunk| hunk.row_range.start.0..hunk.row_range.end.0)
             .collect::<Vec<_>>(),
         &[0..4, 5..7]
@@ -2072,7 +2160,7 @@ fn test_diff_hunks_with_multiple_excerpts(cx: &mut TestAppContext) {
 
     assert_eq!(
         snapshot
-            .diff_hunks_in_range(0..snapshot.len())
+            .diff_hunks_in_range(MultiBufferOffset(0)..snapshot.len())
             .map(|hunk| hunk.row_range.start.0..hunk.row_range.end.0)
             .collect::<Vec<_>>(),
         &[0..1, 2..4, 5..7, 9..10, 12..13, 14..17]
@@ -2636,14 +2724,16 @@ async fn test_random_multibuffer(cx: &mut TestAppContext, mut rng: StdRng) {
             30..=39 if !reference.excerpts.is_empty() => {
                 let multibuffer =
                     multibuffer.read_with(cx, |multibuffer, cx| multibuffer.snapshot(cx));
-                let offset =
-                    multibuffer.clip_offset(rng.random_range(0..=multibuffer.len()), Bias::Left);
+                let offset = multibuffer.clip_offset(
+                    MultiBufferOffset(rng.random_range(0..=multibuffer.len().0)),
+                    Bias::Left,
+                );
                 let bias = if rng.random() {
                     Bias::Left
                 } else {
                     Bias::Right
                 };
-                log::info!("Creating anchor at {} with bias {:?}", offset, bias);
+                log::info!("Creating anchor at {} with bias {:?}", offset.0, bias);
                 anchors.push(multibuffer.anchor_at(offset, bias));
                 anchors.sort_by(|a, b| a.cmp(b, &multibuffer));
             }
@@ -2796,7 +2886,7 @@ async fn test_random_multibuffer(cx: &mut TestAppContext, mut rng: StdRng) {
         let snapshot = multibuffer.read_with(cx, |multibuffer, cx| multibuffer.snapshot(cx));
         let actual_text = snapshot.text();
         let actual_boundary_rows = snapshot
-            .excerpt_boundaries_in_range(0..)
+            .excerpt_boundaries_in_range(MultiBufferOffset(0)..)
             .map(|b| b.row)
             .collect::<HashSet<_>>();
         let actual_row_infos = snapshot.row_infos(MultiBufferRow(0)).collect::<Vec<_>>();
@@ -2874,9 +2964,14 @@ async fn test_random_multibuffer(cx: &mut TestAppContext, mut rng: StdRng) {
                 })
                 .collect::<HashMap<_, _>>()
         });
-        for i in 0..snapshot.len() {
-            let excerpt = snapshot.excerpt_containing(i..i).unwrap();
-            assert_eq!(excerpt.buffer_range(), reference_ranges[&excerpt.id()]);
+        for i in 0..snapshot.len().0 {
+            let excerpt = snapshot
+                .excerpt_containing(MultiBufferOffset(i)..MultiBufferOffset(i))
+                .unwrap();
+            assert_eq!(
+                excerpt.buffer_range().start.0..excerpt.buffer_range().end.0,
+                reference_ranges[&excerpt.id()]
+            );
         }
 
         assert_consistent_line_numbers(&snapshot);
@@ -2897,7 +2992,7 @@ async fn test_random_multibuffer(cx: &mut TestAppContext, mut rng: StdRng) {
             let start_ix = text_rope.clip_offset(rng.random_range(0..=end_ix), Bias::Left);
 
             let text_for_range = snapshot
-                .text_for_range(start_ix..end_ix)
+                .text_for_range(MultiBufferOffset(start_ix)..MultiBufferOffset(end_ix))
                 .collect::<String>();
             assert_eq!(
                 text_for_range,
@@ -2908,7 +3003,9 @@ async fn test_random_multibuffer(cx: &mut TestAppContext, mut rng: StdRng) {
 
             let expected_summary = TextSummary::from(&expected_text[start_ix..end_ix]);
             assert_eq!(
-                snapshot.text_summary_for_range::<TextSummary, _>(start_ix..end_ix),
+                snapshot.text_summary_for_range::<TextSummary, _>(
+                    MultiBufferOffset(start_ix)..MultiBufferOffset(end_ix)
+                ),
                 expected_summary,
                 "incorrect summary for range {:?}",
                 start_ix..end_ix
@@ -2916,12 +3013,12 @@ async fn test_random_multibuffer(cx: &mut TestAppContext, mut rng: StdRng) {
         }
 
         // Anchor resolution
-        let summaries = snapshot.summaries_for_anchors::<usize, _>(&anchors);
+        let summaries = snapshot.summaries_for_anchors::<usize, _, _>(&anchors);
         assert_eq!(anchors.len(), summaries.len());
         for (anchor, resolved_offset) in anchors.iter().zip(summaries) {
-            assert!(resolved_offset <= snapshot.len());
+            assert!(resolved_offset <= snapshot.len().0);
             assert_eq!(
-                snapshot.summary_for_anchor::<usize>(anchor),
+                snapshot.summary_for_anchor::<usize, _>(anchor),
                 resolved_offset,
                 "anchor: {:?}",
                 anchor
@@ -2931,7 +3028,9 @@ async fn test_random_multibuffer(cx: &mut TestAppContext, mut rng: StdRng) {
         for _ in 0..10 {
             let end_ix = text_rope.clip_offset(rng.random_range(0..=text_rope.len()), Bias::Right);
             assert_eq!(
-                snapshot.reversed_chars_at(end_ix).collect::<String>(),
+                snapshot
+                    .reversed_chars_at(MultiBufferOffset(end_ix))
+                    .collect::<String>(),
                 expected_text[..end_ix].chars().rev().collect::<String>(),
             );
         }
@@ -2941,7 +3040,7 @@ async fn test_random_multibuffer(cx: &mut TestAppContext, mut rng: StdRng) {
             let start_ix = rng.random_range(0..=end_ix);
             assert_eq!(
                 snapshot
-                    .bytes_in_range(start_ix..end_ix)
+                    .bytes_in_range(MultiBufferOffset(start_ix)..MultiBufferOffset(end_ix))
                     .flatten()
                     .copied()
                     .collect::<Vec<_>>(),
@@ -2964,7 +3063,9 @@ async fn test_random_multibuffer(cx: &mut TestAppContext, mut rng: StdRng) {
 
         let mut text = old_snapshot.text();
         for edit in edits {
-            let new_text: String = snapshot.text_for_range(edit.new.clone()).collect();
+            let new_text: String = snapshot
+                .text_for_range(MultiBufferOffset(edit.new.start)..MultiBufferOffset(edit.new.end))
+                .collect();
             text.replace_range(edit.new.start..edit.new.start + edit.old.len(), &new_text);
         }
         assert_eq!(text.to_string(), snapshot.text());
@@ -3038,7 +3139,11 @@ fn test_history(cx: &mut App) {
         // Edit buffer 1 through the multibuffer
         now += 2 * group_interval;
         multibuffer.start_transaction_at(now, cx);
-        multibuffer.edit([(2..2, "C")], None, cx);
+        multibuffer.edit(
+            [(MultiBufferOffset(2)..MultiBufferOffset(2), "C")],
+            None,
+            cx,
+        );
         multibuffer.end_transaction_at(now, cx);
         assert_eq!(multibuffer.read(cx).text(), "ABC1234\nAB5678");
 
@@ -3091,7 +3196,11 @@ fn test_history(cx: &mut App) {
         // Redo stack gets cleared after an edit.
         now += 2 * group_interval;
         multibuffer.start_transaction_at(now, cx);
-        multibuffer.edit([(0..0, "X")], None, cx);
+        multibuffer.edit(
+            [(MultiBufferOffset(0)..MultiBufferOffset(0), "X")],
+            None,
+            cx,
+        );
         multibuffer.end_transaction_at(now, cx);
         assert_eq!(multibuffer.read(cx).text(), "XABCD1234\nAB5678");
         multibuffer.redo(cx);
@@ -3278,11 +3387,11 @@ fn test_summaries_for_anchors(cx: &mut TestAppContext) {
     let id_2 = buffer_2.read_with(cx, |buffer, _| buffer.remote_id());
 
     let anchor_1 = Anchor::in_buffer(ids[0], id_1, text::Anchor::MIN);
-    let point_1 = snapshot.summaries_for_anchors::<Point, _>([&anchor_1])[0];
+    let point_1 = snapshot.summaries_for_anchors::<Point, _, _>([&anchor_1])[0];
     assert_eq!(point_1, Point::new(0, 0));
 
     let anchor_2 = Anchor::in_buffer(ids[1], id_2, text::Anchor::MIN);
-    let point_2 = snapshot.summaries_for_anchors::<Point, _>([&anchor_2])[0];
+    let point_2 = snapshot.summaries_for_anchors::<Point, _, _>([&anchor_2])[0];
     assert_eq!(point_2, Point::new(3, 0));
 }
 
@@ -3320,7 +3429,7 @@ fn test_trailing_deletion_without_newline(cx: &mut TestAppContext) {
     );
 
     assert_eq!(snapshot.max_point(), Point::new(2, 0));
-    assert_eq!(snapshot.len(), 8);
+    assert_eq!(snapshot.len().0, 8);
 
     assert_eq!(
         snapshot
@@ -3330,7 +3439,7 @@ fn test_trailing_deletion_without_newline(cx: &mut TestAppContext) {
     );
 
     let (_, translated_offset) = snapshot.point_to_buffer_offset(Point::new(2, 0)).unwrap();
-    assert_eq!(translated_offset, "one\n".len());
+    assert_eq!(translated_offset.0, "one\n".len());
     let (_, translated_point, _) = snapshot.point_to_buffer_point(Point::new(2, 0)).unwrap();
     assert_eq!(translated_point, Point::new(1, 0));
 
@@ -3371,7 +3480,7 @@ fn test_trailing_deletion_without_newline(cx: &mut TestAppContext) {
     let buffer_1_id = buffer_1.read_with(cx, |buffer_1, _| buffer_1.remote_id());
     let (buffer, translated_offset) = snapshot.point_to_buffer_offset(Point::new(2, 0)).unwrap();
     assert_eq!(buffer.remote_id(), buffer_1_id);
-    assert_eq!(translated_offset, "one\n".len());
+    assert_eq!(translated_offset.0, "one\n".len());
     let (buffer, translated_point, _) = snapshot.point_to_buffer_point(Point::new(2, 0)).unwrap();
     assert_eq!(buffer.remote_id(), buffer_1_id);
     assert_eq!(translated_point, Point::new(1, 0));
@@ -3491,8 +3600,8 @@ fn check_edits(
 fn assert_chunks_in_ranges(snapshot: &MultiBufferSnapshot) {
     let full_text = snapshot.text();
     for ix in 0..full_text.len() {
-        let mut chunks = snapshot.chunks(0..snapshot.len(), false);
-        chunks.seek(ix..snapshot.len());
+        let mut chunks = snapshot.chunks(MultiBufferOffset(0)..snapshot.len(), false);
+        chunks.seek(MultiBufferOffset(ix)..snapshot.len());
         let tail = chunks.map(|chunk| chunk.text).collect::<String>();
         assert_eq!(tail, &full_text[ix..], "seek to range: {:?}", ix..);
     }
@@ -3522,44 +3631,49 @@ fn assert_position_translation(snapshot: &MultiBufferSnapshot) {
     let mut offsets = Vec::new();
     let mut points = Vec::new();
     for offset in 0..=text.len() + 1 {
+        let offset = MultiBufferOffset(offset);
         let clipped_left = snapshot.clip_offset(offset, Bias::Left);
         let clipped_right = snapshot.clip_offset(offset, Bias::Right);
         assert_eq!(
-            clipped_left,
-            text.clip_offset(offset, Bias::Left),
+            clipped_left.0,
+            text.clip_offset(offset.0, Bias::Left),
             "clip_offset({offset:?}, Left)"
         );
         assert_eq!(
-            clipped_right,
-            text.clip_offset(offset, Bias::Right),
+            clipped_right.0,
+            text.clip_offset(offset.0, Bias::Right),
             "clip_offset({offset:?}, Right)"
         );
         assert_eq!(
             snapshot.offset_to_point(clipped_left),
-            text.offset_to_point(clipped_left),
-            "offset_to_point({clipped_left})"
+            text.offset_to_point(clipped_left.0),
+            "offset_to_point({})",
+            clipped_left.0
         );
         assert_eq!(
             snapshot.offset_to_point(clipped_right),
-            text.offset_to_point(clipped_right),
-            "offset_to_point({clipped_right})"
+            text.offset_to_point(clipped_right.0),
+            "offset_to_point({})",
+            clipped_right.0
         );
         let anchor_after = snapshot.anchor_after(clipped_left);
         assert_eq!(
             anchor_after.to_offset(snapshot),
             clipped_left,
-            "anchor_after({clipped_left}).to_offset {anchor_after:?}"
+            "anchor_after({}).to_offset {anchor_after:?}",
+            clipped_left.0
         );
         let anchor_before = snapshot.anchor_before(clipped_left);
         assert_eq!(
             anchor_before.to_offset(snapshot),
             clipped_left,
-            "anchor_before({clipped_left}).to_offset"
+            "anchor_before({}).to_offset",
+            clipped_left.0
         );
         left_anchors.push(anchor_before);
         right_anchors.push(anchor_after);
-        offsets.push(clipped_left);
-        points.push(text.offset_to_point(clipped_left));
+        offsets.push(clipped_left.0);
+        points.push(text.offset_to_point(clipped_left.0));
     }
 
     for row in 0..text.max_point().row {
@@ -3578,12 +3692,12 @@ fn assert_position_translation(snapshot: &MultiBufferSnapshot) {
                 "clip_point({point:?}, Right)"
             );
             assert_eq!(
-                snapshot.point_to_offset(clipped_left),
+                snapshot.point_to_offset(clipped_left).0,
                 text.point_to_offset(clipped_left),
                 "point_to_offset({clipped_left:?})"
             );
             assert_eq!(
-                snapshot.point_to_offset(clipped_right),
+                snapshot.point_to_offset(clipped_right).0,
                 text.point_to_offset(clipped_right),
                 "point_to_offset({clipped_right:?})"
             );
@@ -3591,22 +3705,22 @@ fn assert_position_translation(snapshot: &MultiBufferSnapshot) {
     }
 
     assert_eq!(
-        snapshot.summaries_for_anchors::<usize, _>(&left_anchors),
+        snapshot.summaries_for_anchors::<usize, _, _>(&left_anchors),
         offsets,
         "left_anchors <-> offsets"
     );
     assert_eq!(
-        snapshot.summaries_for_anchors::<Point, _>(&left_anchors),
+        snapshot.summaries_for_anchors::<Point, _, _>(&left_anchors),
         points,
         "left_anchors <-> points"
     );
     assert_eq!(
-        snapshot.summaries_for_anchors::<usize, _>(&right_anchors),
+        snapshot.summaries_for_anchors::<usize, _, _>(&right_anchors),
         offsets,
         "right_anchors <-> offsets"
     );
     assert_eq!(
-        snapshot.summaries_for_anchors::<Point, _>(&right_anchors),
+        snapshot.summaries_for_anchors::<Point, _, _>(&right_anchors),
         points,
         "right_anchors <-> points"
     );
@@ -3632,7 +3746,7 @@ fn assert_position_translation(snapshot: &MultiBufferSnapshot) {
     }
 
     if let Some((buffer, offset)) = snapshot.point_to_buffer_offset(snapshot.max_point()) {
-        assert!(offset <= buffer.len());
+        assert!(offset.0 <= buffer.len());
     }
     if let Some((buffer, point, _)) = snapshot.point_to_buffer_point(snapshot.max_point()) {
         assert!(point <= buffer.max_point());
@@ -3747,7 +3861,7 @@ fn test_random_chunk_bitmaps(cx: &mut App, mut rng: StdRng) {
 
     let snapshot = multibuffer.read(cx).snapshot(cx);
 
-    let chunks = snapshot.chunks(0..snapshot.len(), false);
+    let chunks = snapshot.chunks(MultiBufferOffset(0)..snapshot.len(), false);
 
     for chunk in chunks {
         let chunk_text = chunk.text;
@@ -3879,24 +3993,24 @@ fn test_random_chunk_bitmaps_with_diffs(cx: &mut App, mut rng: StdRng) {
 
             let mut ranges = Vec::new();
             for _ in 0..rng.random_range(1..5) {
-                if snapshot.len() == 0 {
+                if snapshot.len().0 == 0 {
                     break;
                 }
 
                 let diff_size = rng.random_range(5..1000);
-                let mut start = rng.random_range(0..snapshot.len());
+                let mut start = rng.random_range(0..snapshot.len().0);
 
                 while !text.is_char_boundary(start) {
                     start = start.saturating_sub(1);
                 }
 
-                let mut end = rng.random_range(start..snapshot.len().min(start + diff_size));
+                let mut end = rng.random_range(start..snapshot.len().0.min(start + diff_size));
 
                 while !text.is_char_boundary(end) {
                     end = end.saturating_add(1);
                 }
-                let start_anchor = snapshot.anchor_after(start);
-                let end_anchor = snapshot.anchor_before(end);
+                let start_anchor = snapshot.anchor_after(MultiBufferOffset(start));
+                let end_anchor = snapshot.anchor_before(MultiBufferOffset(end));
                 ranges.push(start_anchor..end_anchor);
             }
             multibuffer.expand_diff_hunks(ranges, cx);
@@ -3905,7 +4019,7 @@ fn test_random_chunk_bitmaps_with_diffs(cx: &mut App, mut rng: StdRng) {
 
     let snapshot = multibuffer.read(cx).snapshot(cx);
 
-    let chunks = snapshot.chunks(0..snapshot.len(), false);
+    let chunks = snapshot.chunks(MultiBufferOffset(0)..snapshot.len(), false);
 
     for chunk in chunks {
         let chunk_text = chunk.text;

--- a/crates/multi_buffer/src/transaction.rs
+++ b/crates/multi_buffer/src/transaction.rs
@@ -1,14 +1,14 @@
 use gpui::{App, Context, Entity};
-use language::{self, Buffer, TextDimension, TransactionId};
+use language::{self, Buffer, TransactionId};
 use std::{
     collections::HashMap,
-    ops::{Range, Sub},
+    ops::{AddAssign, Range, Sub},
     time::{Duration, Instant},
 };
 use sum_tree::Bias;
 use text::BufferId;
 
-use crate::BufferState;
+use crate::{BufferState, MultiBufferDimension};
 
 use super::{Event, ExcerptSummary, MultiBuffer};
 
@@ -320,7 +320,11 @@ impl MultiBuffer {
         cx: &App,
     ) -> Vec<Range<D>>
     where
-        D: TextDimension + Ord + Sub<D, Output = D>,
+        D: MultiBufferDimension
+            + Ord
+            + Sub<D, Output = D::TextDimension>
+            + for<'a> AddAssign<&'a D::TextDimension>,
+        D::TextDimension: PartialOrd + Sub<D::TextDimension, Output = D::TextDimension>,
     {
         let Some(transaction) = self.history.transaction(transaction_id) else {
             return Vec::new();
@@ -336,24 +340,34 @@ impl MultiBuffer {
             };
 
             let buffer = buffer_state.buffer.read(cx);
-            for range in buffer.edited_ranges_for_transaction_id::<D>(*buffer_transaction) {
+            for range in
+                buffer.edited_ranges_for_transaction_id::<D::TextDimension>(*buffer_transaction)
+            {
                 for excerpt_id in &buffer_state.excerpts {
                     cursor.seek(excerpt_id, Bias::Left);
                     if let Some(excerpt) = cursor.item()
                         && excerpt.locator == *excerpt_id
                     {
-                        let excerpt_buffer_start = excerpt.range.context.start.summary::<D>(buffer);
-                        let excerpt_buffer_end = excerpt.range.context.end.summary::<D>(buffer);
+                        let excerpt_buffer_start = excerpt
+                            .range
+                            .context
+                            .start
+                            .summary::<D::TextDimension>(buffer);
+                        let excerpt_buffer_end = excerpt
+                            .range
+                            .context
+                            .end
+                            .summary::<D::TextDimension>(buffer);
                         let excerpt_range = excerpt_buffer_start..excerpt_buffer_end;
                         if excerpt_range.contains(&range.start)
                             && excerpt_range.contains(&range.end)
                         {
-                            let excerpt_start = D::from_text_summary(&cursor.start().text);
+                            let excerpt_start = D::from_summary(&cursor.start().text);
 
                             let mut start = excerpt_start;
-                            start.add_assign(&(range.start - excerpt_buffer_start));
+                            start += &(range.start - excerpt_buffer_start);
                             let mut end = excerpt_start;
-                            end.add_assign(&(range.end - excerpt_buffer_start));
+                            end += &(range.end - excerpt_buffer_start);
 
                             ranges.push(start..end);
                             break;

--- a/crates/multi_buffer/src/transaction.rs
+++ b/crates/multi_buffer/src/transaction.rs
@@ -323,7 +323,7 @@ impl MultiBuffer {
         D: MultiBufferDimension
             + Ord
             + Sub<D, Output = D::TextDimension>
-            + for<'a> AddAssign<&'a D::TextDimension>,
+            + AddAssign<D::TextDimension>,
         D::TextDimension: PartialOrd + Sub<D::TextDimension, Output = D::TextDimension>,
     {
         let Some(transaction) = self.history.transaction(transaction_id) else {
@@ -365,9 +365,9 @@ impl MultiBuffer {
                             let excerpt_start = D::from_summary(&cursor.start().text);
 
                             let mut start = excerpt_start;
-                            start += &(range.start - excerpt_buffer_start);
+                            start += range.start - excerpt_buffer_start;
                             let mut end = excerpt_start;
-                            end += &(range.end - excerpt_buffer_start);
+                            end += range.end - excerpt_buffer_start;
 
                             ranges.push(start..end);
                             break;

--- a/crates/outline/src/outline.rs
+++ b/crates/outline/src/outline.rs
@@ -6,7 +6,7 @@ use std::{
 
 use editor::scroll::ScrollOffset;
 use editor::{Anchor, AnchorRangeExt, Editor, scroll::Autoscroll};
-use editor::{RowHighlightOptions, SelectionEffects};
+use editor::{MultiBufferOffset, RowHighlightOptions, SelectionEffects};
 use fuzzy::StringMatch;
 use gpui::{
     App, Context, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable, HighlightStyle,
@@ -247,7 +247,7 @@ impl PickerDelegate for OutlineViewDelegate {
                 let buffer = editor.buffer().read(cx).snapshot(cx);
                 let cursor_offset = editor
                     .selections
-                    .newest::<usize>(&editor.display_snapshot(cx))
+                    .newest::<MultiBufferOffset>(&editor.display_snapshot(cx))
                     .head();
                 (buffer, cursor_offset)
             });
@@ -259,8 +259,8 @@ impl PickerDelegate for OutlineViewDelegate {
                 .map(|(ix, item)| {
                     let range = item.range.to_offset(&buffer);
                     let distance_to_closest_endpoint = cmp::min(
-                        (range.start as isize - cursor_offset as isize).abs(),
-                        (range.end as isize - cursor_offset as isize).abs(),
+                        (range.start.0 as isize - cursor_offset.0 as isize).abs(),
+                        (range.end.0 as isize - cursor_offset.0 as isize).abs(),
                     );
                     let depth = if range.contains(&cursor_offset) {
                         Some(item.depth)

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -7,7 +7,7 @@ use collections::{BTreeSet, HashMap, hash_map};
 use command_palette_hooks::CommandPaletteFilter;
 use db::kvp::KEY_VALUE_STORE;
 use editor::{
-    Editor, EditorEvent,
+    Editor, EditorEvent, MultiBufferOffset,
     items::{
         entry_diagnostic_aware_icon_decoration_and_color,
         entry_diagnostic_aware_icon_name_and_color, entry_git_aware_label_color,
@@ -1925,7 +1925,9 @@ impl ProjectPanel {
                 self.filename_editor.update(cx, |editor, cx| {
                     editor.set_text(file_name, window, cx);
                     editor.change_selections(Default::default(), window, cx, |s| {
-                        s.select_ranges([selection])
+                        s.select_ranges([
+                            MultiBufferOffset(selection.start)..MultiBufferOffset(selection.end)
+                        ])
                     });
                 });
                 self.update_visible_entries(None, true, true, window, cx);

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use collections::HashSet;
+use editor::MultiBufferOffset;
 use gpui::{Empty, Entity, TestAppContext, VisualTestContext, WindowHandle};
 use pretty_assertions::assert_eq;
 use project::FakeFs;
@@ -658,7 +659,9 @@ async fn test_editing_files(cx: &mut gpui::TestAppContext) {
 
     let confirm = panel.update_in(cx, |panel, window, cx| {
         panel.filename_editor.update(cx, |editor, cx| {
-            let file_name_selections = editor.selections.all::<usize>(&editor.display_snapshot(cx));
+            let file_name_selections = editor
+                .selections
+                .all::<MultiBufferOffset>(&editor.display_snapshot(cx));
             assert_eq!(
                 file_name_selections.len(),
                 1,
@@ -666,12 +669,13 @@ async fn test_editing_files(cx: &mut gpui::TestAppContext) {
             );
             let file_name_selection = &file_name_selections[0];
             assert_eq!(
-                file_name_selection.start, 0,
+                file_name_selection.start,
+                MultiBufferOffset(0),
                 "Should select the file name from the start"
             );
             assert_eq!(
                 file_name_selection.end,
-                "another-filename".len(),
+                MultiBufferOffset("another-filename".len()),
                 "Should not select file extension"
             );
 
@@ -732,11 +736,11 @@ async fn test_editing_files(cx: &mut gpui::TestAppContext) {
 
     panel.update_in(cx, |panel, window, cx| {
             panel.filename_editor.update(cx, |editor, cx| {
-                let file_name_selections = editor.selections.all::<usize>(&editor.display_snapshot(cx));
+                let file_name_selections = editor.selections.all::<MultiBufferOffset>(&editor.display_snapshot(cx));
                 assert_eq!(file_name_selections.len(), 1, "File editing should have a single selection, but got: {file_name_selections:?}");
                 let file_name_selection = &file_name_selections[0];
-                assert_eq!(file_name_selection.start, 0, "Should select the file name from the start");
-                assert_eq!(file_name_selection.end, "a-different-filename.tar".len(), "Should not select file extension, but still may select anything up to the last dot..");
+                assert_eq!(file_name_selection.start, MultiBufferOffset(0), "Should select the file name from the start");
+                assert_eq!(file_name_selection.end, MultiBufferOffset("a-different-filename.tar".len()), "Should not select file extension, but still may select anything up to the last dot..");
 
             });
             panel.cancel(&menu::Cancel, window, cx)
@@ -1218,7 +1222,9 @@ async fn test_copy_paste(cx: &mut gpui::TestAppContext) {
 
     panel.update_in(cx, |panel, window, cx| {
         panel.filename_editor.update(cx, |editor, cx| {
-            let file_name_selections = editor.selections.all::<usize>(&editor.display_snapshot(cx));
+            let file_name_selections = editor
+                .selections
+                .all::<MultiBufferOffset>(&editor.display_snapshot(cx));
             assert_eq!(
                 file_name_selections.len(),
                 1,
@@ -1227,12 +1233,12 @@ async fn test_copy_paste(cx: &mut gpui::TestAppContext) {
             let file_name_selection = &file_name_selections[0];
             assert_eq!(
                 file_name_selection.start,
-                "one".len(),
+                MultiBufferOffset("one".len()),
                 "Should select the file name disambiguation after the original file name"
             );
             assert_eq!(
                 file_name_selection.end,
-                "one copy".len(),
+                MultiBufferOffset("one copy".len()),
                 "Should select the file name disambiguation until the extension"
             );
         });

--- a/crates/repl/src/repl_editor.rs
+++ b/crates/repl/src/repl_editor.rs
@@ -4,7 +4,7 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use anyhow::{Context as _, Result};
-use editor::Editor;
+use editor::{Editor, MultiBufferOffset};
 use gpui::{App, Entity, WeakEntity, Window, prelude::*};
 use language::{BufferSnapshot, Language, LanguageName, Point};
 use project::{ProjectItem as _, WorktreeId};
@@ -478,7 +478,9 @@ fn get_language(editor: WeakEntity<Editor>, cx: &mut App) -> Option<Arc<Language
     editor
         .update(cx, |editor, cx| {
             let display_snapshot = editor.display_snapshot(cx);
-            let selection = editor.selections.newest::<usize>(&display_snapshot);
+            let selection = editor
+                .selections
+                .newest::<MultiBufferOffset>(&display_snapshot);
             display_snapshot
                 .buffer_snapshot()
                 .language_at(selection.head())

--- a/crates/rope/src/offset_utf16.rs
+++ b/crates/rope/src/offset_utf16.rs
@@ -32,7 +32,6 @@ impl Sub for OffsetUtf16 {
     type Output = OffsetUtf16;
 
     fn sub(self, other: Self) -> Self::Output {
-        debug_assert!(other <= self);
         Self(self.0 - other.0)
     }
 }

--- a/crates/rope/src/rope.rs
+++ b/crates/rope/src/rope.rs
@@ -1549,21 +1549,6 @@ where
     }
 }
 
-impl<R, R2, K, V> ops::Add for DimensionPair<K, V>
-where
-    K: ops::Add<K, Output = R>,
-    V: ops::Add<V, Output = R2>,
-{
-    type Output = DimensionPair<R, R2>;
-
-    fn add(self, rhs: Self) -> Self::Output {
-        DimensionPair {
-            key: self.key + rhs.key,
-            value: self.value.zip(rhs.value).map(|(a, b)| a + b),
-        }
-    }
-}
-
 impl<R, R2, K, V> ops::AddAssign<DimensionPair<R, R2>> for DimensionPair<K, V>
 where
     K: ops::AddAssign<R>,
@@ -1571,15 +1556,13 @@ where
 {
     fn add_assign(&mut self, rhs: DimensionPair<R, R2>) {
         self.key += rhs.key;
-        self.value.as_mut().zip(rhs.value).map(|(a, b)| *a += b);
-    }
-}
-
-impl<D> std::ops::Add<DimensionPair<Point, D>> for Point {
-    type Output = Point;
-
-    fn add(self, rhs: DimensionPair<Point, D>) -> Self::Output {
-        self + rhs.key
+        if let Some(value) = &mut self.value {
+            if let Some(other_value) = rhs.value {
+                *value += other_value;
+            } else {
+                self.value.take();
+            }
+        }
     }
 }
 
@@ -1588,20 +1571,6 @@ impl<D> std::ops::AddAssign<DimensionPair<Point, D>> for Point {
         *self += rhs.key;
     }
 }
-
-// impl<R, K, V> ops::Sub<R> for DimensionPair<K, V>
-// where
-//     K: ops::Sub<R, Output = K>,
-// {
-//     type Output = Self;
-
-//     fn sub(self, rhs: R) -> Self::Output {
-//         Self {
-//             key: self.key - r,
-//             value: self.value,
-//         }
-//     }
-// }
 
 impl<K, V> cmp::Eq for DimensionPair<K, V> where K: cmp::Eq {}
 

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -10,7 +10,7 @@ use any_vec::AnyVec;
 use anyhow::Context as _;
 use collections::HashMap;
 use editor::{
-    DisplayPoint, Editor, EditorSettings,
+    DisplayPoint, Editor, EditorSettings, MultiBufferOffset,
     actions::{Backtab, Tab},
 };
 use futures::channel::oneshot;
@@ -868,7 +868,11 @@ impl BufferSearchBar {
                     .buffer()
                     .update(cx, |replacement_buffer, cx| {
                         let len = replacement_buffer.len(cx);
-                        replacement_buffer.edit([(0..len, replacement.unwrap())], None, cx);
+                        replacement_buffer.edit(
+                            [(MultiBufferOffset(0)..len, replacement.unwrap())],
+                            None,
+                            cx,
+                        );
                     });
             });
     }
@@ -892,7 +896,7 @@ impl BufferSearchBar {
             self.query_editor.update(cx, |query_editor, cx| {
                 query_editor.buffer().update(cx, |query_buffer, cx| {
                     let len = query_buffer.len(cx);
-                    query_buffer.edit([(0..len, query)], None, cx);
+                    query_buffer.edit([(MultiBufferOffset(0)..len, query)], None, cx);
                 });
             });
             self.set_search_options(options, cx);

--- a/crates/tasks_ui/src/tasks_ui.rs
+++ b/crates/tasks_ui/src/tasks_ui.rs
@@ -392,7 +392,7 @@ fn worktree_context(worktree_abs_path: &Path) -> TaskContext {
 mod tests {
     use std::{collections::HashMap, sync::Arc};
 
-    use editor::{Editor, SelectionEffects};
+    use editor::{Editor, MultiBufferOffset, SelectionEffects};
     use gpui::TestAppContext;
     use language::{Language, LanguageConfig};
     use project::{BasicContextProvider, FakeFs, Project, task_store::TaskStore};
@@ -539,7 +539,7 @@ mod tests {
         // And now, let's select an identifier.
         editor2.update_in(cx, |editor, window, cx| {
             editor.change_selections(SelectionEffects::no_scroll(), window, cx, |selections| {
-                selections.select_ranges([14..18])
+                selections.select_ranges([MultiBufferOffset(14)..MultiBufferOffset(18)])
             })
         });
 

--- a/crates/text/src/selection.rs
+++ b/crates/text/src/selection.rs
@@ -130,9 +130,15 @@ impl<T: Copy> Selection<T> {
     }
 }
 
-impl Selection<usize> {
+impl<T: std::ops::Sub + Copy> Selection<T> {
+    pub fn len(&self) -> <T as std::ops::Sub>::Output {
+        self.end - self.start
+    }
+}
+
+impl<T: Copy + Eq> Selection<T> {
     #[cfg(feature = "test-support")]
-    pub fn from_offset(offset: usize) -> Self {
+    pub fn from_offset(offset: T) -> Self {
         Selection {
             id: 0,
             start: offset,
@@ -142,7 +148,7 @@ impl Selection<usize> {
         }
     }
 
-    pub fn equals(&self, offset_range: &Range<usize>) -> bool {
+    pub fn equals(&self, offset_range: &Range<T>) -> bool {
         self.start == offset_range.start && self.end == offset_range.end
     }
 }

--- a/crates/text/src/text.rs
+++ b/crates/text/src/text.rs
@@ -54,7 +54,7 @@ pub struct Buffer {
     deferred_ops: OperationQueue<Operation>,
     deferred_replicas: HashSet<ReplicaId>,
     pub lamport_clock: clock::Lamport,
-    subscriptions: Topic,
+    subscriptions: Topic<usize>,
     edit_id_resolvers: HashMap<clock::Lamport, Vec<oneshot::Sender<()>>>,
     wait_for_version_txs: Vec<(clock::Global, oneshot::Sender<()>)>,
 }
@@ -1619,7 +1619,7 @@ impl Buffer {
         self.edited_ranges_for_edit_ids(&transaction.edit_ids)
     }
 
-    pub fn subscribe(&mut self) -> Subscription {
+    pub fn subscribe(&mut self) -> Subscription<usize> {
         self.subscriptions.subscribe()
     }
 

--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -6,8 +6,8 @@ mod select;
 
 use editor::display_map::DisplaySnapshot;
 use editor::{
-    DisplayPoint, Editor, EditorSettings, HideMouseCursorOrigin, SelectionEffects, ToOffset,
-    ToPoint, movement,
+    DisplayPoint, Editor, EditorSettings, HideMouseCursorOrigin, MultiBufferOffset,
+    SelectionEffects, ToOffset, ToPoint, movement,
 };
 use gpui::actions;
 use gpui::{Context, Window};
@@ -523,7 +523,7 @@ impl Vim {
                         ..range.end.to_offset(&display_map, Bias::Left);
 
                     if !byte_range.is_empty() {
-                        let replacement_text = text.repeat(byte_range.len());
+                        let replacement_text = text.repeat(byte_range.end - byte_range.start);
                         edits.push((byte_range, replacement_text));
                     }
                 }
@@ -620,7 +620,7 @@ impl Vim {
         self.update_editor(cx, |_, editor, cx| {
             let newest = editor
                 .selections
-                .newest::<usize>(&editor.display_snapshot(cx));
+                .newest::<MultiBufferOffset>(&editor.display_snapshot(cx));
             editor.change_selections(Default::default(), window, cx, |s| s.select(vec![newest]));
         });
     }

--- a/crates/vim/src/helix/duplicate.rs
+++ b/crates/vim/src/helix/duplicate.rs
@@ -1,6 +1,6 @@
 use std::ops::Range;
 
-use editor::{DisplayPoint, display_map::DisplaySnapshot};
+use editor::{DisplayPoint, MultiBufferOffset, display_map::DisplaySnapshot};
 use gpui::Context;
 use text::Bias;
 use ui::Window;
@@ -111,7 +111,7 @@ fn find_next_valid_duplicate_space(
 fn display_point_range_to_offset_range(
     range: &Range<DisplayPoint>,
     map: &DisplaySnapshot,
-) -> Range<usize> {
+) -> Range<MultiBufferOffset> {
     range.start.to_offset(map, Bias::Left)..range.end.to_offset(map, Bias::Right)
 }
 

--- a/crates/vim/src/helix/paste.rs
+++ b/crates/vim/src/helix/paste.rs
@@ -125,7 +125,7 @@ impl Vim {
                     s.select_ranges(new_selections.into_iter().map(|(anchor, len)| {
                         let offset = anchor.to_offset(&snapshot);
                         if action.before {
-                            offset.saturating_sub(len)..offset
+                            offset.saturating_sub_usize(len)..offset
                         } else {
                             offset..(offset + len)
                         }

--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -1,5 +1,5 @@
 use editor::{
-    Anchor, Bias, DisplayPoint, Editor, RowExt, ToOffset, ToPoint,
+    Anchor, Bias, BufferOffset, DisplayPoint, Editor, MultiBufferOffset, RowExt, ToOffset, ToPoint,
     display_map::{DisplayRow, DisplaySnapshot, FoldPoint, ToDisplayPoint},
     movement::{
         self, FindRange, TextLayoutDetails, find_boundary, find_preceding_boundary_display_point,
@@ -2143,7 +2143,7 @@ pub(crate) fn sentence_backwards(
             if start_of_next_sentence < start {
                 times = times.saturating_sub(1);
             }
-            if times == 0 || offset == 0 {
+            if times == 0 || offset.0 == 0 {
                 return map.clip_point(
                     start_of_next_sentence
                         .to_offset(&map.buffer_snapshot())
@@ -2207,7 +2207,7 @@ pub(crate) fn sentence_forwards(
     map.max_point()
 }
 
-fn next_non_blank(map: &DisplaySnapshot, start: usize) -> usize {
+fn next_non_blank(map: &DisplaySnapshot, start: MultiBufferOffset) -> MultiBufferOffset {
     for (c, o) in map.buffer_chars_at(start) {
         if c == '\n' || !c.is_whitespace() {
             return o;
@@ -2219,7 +2219,10 @@ fn next_non_blank(map: &DisplaySnapshot, start: usize) -> usize {
 
 // given the offset after a ., !, or ? find the start of the next sentence.
 // if this is not a sentence boundary, returns None.
-fn start_of_next_sentence(map: &DisplaySnapshot, end_of_sentence: usize) -> Option<usize> {
+fn start_of_next_sentence(
+    map: &DisplaySnapshot,
+    end_of_sentence: MultiBufferOffset,
+) -> Option<MultiBufferOffset> {
     let chars = map.buffer_chars_at(end_of_sentence);
     let mut seen_space = false;
 
@@ -2253,10 +2256,10 @@ fn go_to_line(map: &DisplaySnapshot, display_point: DisplayPoint, line: usize) -
             .clip_point(Point::new((line - 1) as u32, point.column), Bias::Left),
     );
     let buffer_range = excerpt.buffer_range();
-    if offset >= buffer_range.start && offset <= buffer_range.end {
+    if offset >= buffer_range.start.0 && offset <= buffer_range.end.0 {
         let point = map
             .buffer_snapshot()
-            .offset_to_point(excerpt.map_offset_from_buffer(offset));
+            .offset_to_point(excerpt.map_offset_from_buffer(BufferOffset(offset)));
         return map.clip_point(map.point_to_display_point(point, Bias::Left), Bias::Left);
     }
     let mut last_position = None;
@@ -2360,6 +2363,9 @@ fn matching_tag(map: &DisplaySnapshot, head: DisplayPoint) -> Option<DisplayPoin
 }
 
 fn matching(map: &DisplaySnapshot, display_point: DisplayPoint) -> DisplayPoint {
+    if !map.is_singleton() {
+        return display_point;
+    }
     // https://github.com/vim/vim/blob/1d87e11a1ef201b26ed87585fba70182ad0c468a/runtime/doc/motion.txt#L1200
     let display_point = map.clip_at_line_end(display_point);
     let point = display_point.to_point(map);
@@ -2375,9 +2381,10 @@ fn matching(map: &DisplaySnapshot, display_point: DisplayPoint) -> DisplayPoint 
     // Attempt to find the smallest enclosing bracket range that also contains
     // the offset, which only happens if the cursor is currently in a bracket.
     let range_filter = |_buffer: &language::BufferSnapshot,
-                        opening_range: Range<usize>,
-                        closing_range: Range<usize>| {
-        opening_range.contains(&offset) || closing_range.contains(&offset)
+                        opening_range: Range<BufferOffset>,
+                        closing_range: Range<BufferOffset>| {
+        opening_range.contains(&BufferOffset(offset.0))
+            || closing_range.contains(&BufferOffset(offset.0))
     };
 
     let bracket_ranges = snapshot
@@ -2840,7 +2847,7 @@ fn method_motion(
 
     for _ in 0..times {
         let point = map.display_point_to_point(display_point, Bias::Left);
-        let offset = point.to_offset(&map.buffer_snapshot());
+        let offset = point.to_offset(&map.buffer_snapshot()).0;
         let range = if direction == Direction::Prev {
             0..offset
         } else {
@@ -2869,7 +2876,7 @@ fn method_motion(
         } else {
             possibilities.min().unwrap_or(offset)
         };
-        let new_point = map.clip_point(dest.to_display_point(map), Bias::Left);
+        let new_point = map.clip_point(MultiBufferOffset(dest).to_display_point(map), Bias::Left);
         if new_point == display_point {
             break;
         }
@@ -2890,7 +2897,7 @@ fn comment_motion(
 
     for _ in 0..times {
         let point = map.display_point_to_point(display_point, Bias::Left);
-        let offset = point.to_offset(&map.buffer_snapshot());
+        let offset = point.to_offset(&map.buffer_snapshot()).0;
         let range = if direction == Direction::Prev {
             0..offset
         } else {
@@ -2923,7 +2930,7 @@ fn comment_motion(
         } else {
             possibilities.min().unwrap_or(offset)
         };
-        let new_point = map.clip_point(dest.to_display_point(map), Bias::Left);
+        let new_point = map.clip_point(MultiBufferOffset(dest).to_display_point(map), Bias::Left);
         if new_point == display_point {
             break;
         }
@@ -2946,7 +2953,7 @@ fn section_motion(
                 .display_point_to_point(display_point, Bias::Left)
                 .to_offset(&map.buffer_snapshot());
             let range = if direction == Direction::Prev {
-                0..offset
+                MultiBufferOffset(0)..offset
             } else {
                 offset..map.buffer_snapshot().len()
             };
@@ -2977,7 +2984,7 @@ fn section_motion(
                 let relevant = if is_start { range.start } else { range.end };
                 if direction == Direction::Prev && relevant < offset {
                     Some(relevant)
-                } else if direction == Direction::Next && relevant > offset + 1 {
+                } else if direction == Direction::Next && relevant > offset + 1usize {
                     Some(relevant)
                 } else {
                     None
@@ -2985,7 +2992,7 @@ fn section_motion(
             });
 
             let offset = if direction == Direction::Prev {
-                possibilities.max().unwrap_or(0)
+                possibilities.max().unwrap_or(MultiBufferOffset(0))
             } else {
                 possibilities.min().unwrap_or(map.buffer_snapshot().len())
             };

--- a/crates/vim/src/normal/increment.rs
+++ b/crates/vim/src/normal/increment.rs
@@ -211,9 +211,14 @@ fn find_target(
     let mut pre_char = String::new();
 
     // Backward scan to find the start of the number, but stop at start_offset
-    for ch in snapshot.reversed_chars_at(offset + if offset < snapshot.len() { 1 } else { 0 }) {
+    let next_offset = if offset < snapshot.len() {
+        offset + 1usize
+    } else {
+        offset
+    };
+    for ch in snapshot.reversed_chars_at(next_offset) {
         // Search boundaries
-        if offset == 0 || ch.is_whitespace() || (need_range && offset <= start_offset) {
+        if offset.0 == 0 || ch.is_whitespace() || (need_range && offset <= start_offset) {
             break;
         }
 

--- a/crates/vim/src/normal/paste.rs
+++ b/crates/vim/src/normal/paste.rs
@@ -1,4 +1,7 @@
-use editor::{DisplayPoint, RowExt, SelectionEffects, display_map::ToDisplayPoint, movement};
+use editor::{
+    DisplayPoint, MultiBufferOffset, RowExt, SelectionEffects, display_map::ToDisplayPoint,
+    movement,
+};
 use gpui::{Action, Context, Window};
 use language::{Bias, SelectionGoal};
 use schemars::JsonSchema;
@@ -174,7 +177,10 @@ impl Vim {
                     original_indent_columns.push(original_indent_column);
                 }
 
-                let cursor_offset = editor.selections.last::<usize>(&display_map).head();
+                let cursor_offset = editor
+                    .selections
+                    .last::<MultiBufferOffset>(&display_map)
+                    .head();
                 if editor
                     .buffer()
                     .read(cx)

--- a/crates/vim/src/object.rs
+++ b/crates/vim/src/object.rs
@@ -1126,11 +1126,11 @@ fn text_object(
         && !buffer_range.is_empty()
     {
         let buffer_range = BufferOffset(buffer_range.start)..BufferOffset(buffer_range.end);
-        let range = excerpt.map_range_from_buffer(buffer_range.clone());
+        let range = excerpt.map_range_from_buffer(buffer_range);
         return Some(range.start.to_display_point(map)..range.end.to_display_point(map));
     }
     let around_range = BufferOffset(around_range.start)..BufferOffset(around_range.end);
-    let buffer_range = excerpt.map_range_from_buffer(around_range.clone());
+    let buffer_range = excerpt.map_range_from_buffer(around_range);
     return Some(buffer_range.start.to_display_point(map)..buffer_range.end.to_display_point(map));
 }
 

--- a/crates/vim/src/object.rs
+++ b/crates/vim/src/object.rs
@@ -6,7 +6,7 @@ use crate::{
     state::{Mode, Operator},
 };
 use editor::{
-    Bias, DisplayPoint, Editor, ToOffset,
+    Bias, BufferOffset, DisplayPoint, Editor, MultiBufferOffset, ToOffset,
     display_map::{DisplaySnapshot, ToDisplayPoint},
     movement::{self, FindRange},
 };
@@ -81,8 +81,8 @@ pub struct CandidateRange {
 #[derive(Debug, Clone)]
 pub struct CandidateWithRanges {
     candidate: CandidateRange,
-    open_range: Range<usize>,
-    close_range: Range<usize>,
+    open_range: Range<MultiBufferOffset>,
+    close_range: Range<MultiBufferOffset>,
 }
 
 /// Selects text at the same indentation level.
@@ -120,7 +120,7 @@ struct CurlyBrackets {
     opening: bool,
 }
 
-fn cover_or_next<I: Iterator<Item = (Range<usize>, Range<usize>)>>(
+fn cover_or_next<I: Iterator<Item = (Range<MultiBufferOffset>, Range<MultiBufferOffset>)>>(
     candidates: Option<I>,
     caret: DisplayPoint,
     map: &DisplaySnapshot,
@@ -128,7 +128,7 @@ fn cover_or_next<I: Iterator<Item = (Range<usize>, Range<usize>)>>(
     let caret_offset = caret.to_offset(map, Bias::Left);
     let mut covering = vec![];
     let mut next_ones = vec![];
-    let snapshot = &map.buffer_snapshot();
+    let snapshot = map.buffer_snapshot();
 
     if let Some(ranges) = candidates {
         for (open_range, close_range) in ranges {
@@ -171,7 +171,7 @@ fn cover_or_next<I: Iterator<Item = (Range<usize>, Range<usize>)>>(
     if !next_ones.is_empty() {
         return next_ones.into_iter().min_by_key(|r| {
             let start = r.candidate.start.to_offset(map, Bias::Left);
-            (start as isize - caret_offset as isize).abs()
+            (start.0 as isize - caret_offset.0 as isize).abs()
         });
     }
 
@@ -181,8 +181,8 @@ fn cover_or_next<I: Iterator<Item = (Range<usize>, Range<usize>)>>(
 type DelimiterPredicate = dyn Fn(&BufferSnapshot, usize, usize) -> bool;
 
 struct DelimiterRange {
-    open: Range<usize>,
-    close: Range<usize>,
+    open: Range<MultiBufferOffset>,
+    close: Range<MultiBufferOffset>,
 }
 
 impl DelimiterRange {
@@ -221,14 +221,14 @@ fn find_mini_delimiters(
         .buffer_snapshot()
         .bracket_ranges(visible_line_range)
         .map(|ranges| {
-            ranges.filter_map(move |(open, close)| {
+            ranges.filter_map(|(open, close)| {
                 // Convert the ranges from multibuffer space to buffer space as
                 // that is what `is_valid_delimiter` expects, otherwise it might
                 // panic as the values might be out of bounds.
                 let buffer_open = excerpt.map_range_to_buffer(open.clone());
                 let buffer_close = excerpt.map_range_to_buffer(close.clone());
 
-                if is_valid_delimiter(buffer, buffer_open.start, buffer_close.start) {
+                if is_valid_delimiter(buffer, buffer_open.start.0, buffer_close.start.0) {
                     Some((open, close))
                 } else {
                     None
@@ -252,8 +252,12 @@ fn find_mini_delimiters(
 
     Some(
         DelimiterRange {
-            open: open_bracket,
-            close: close_bracket,
+            open: excerpt.map_range_from_buffer(
+                BufferOffset(open_bracket.start)..BufferOffset(open_bracket.end),
+            ),
+            close: excerpt.map_range_from_buffer(
+                BufferOffset(close_bracket.start)..BufferOffset(close_bracket.end),
+            ),
         }
         .to_display_range(map, around),
     )
@@ -899,7 +903,7 @@ pub fn surrounding_html_tag(
     // Find the most closest to current offset
     let mut cursor = buffer.syntax_layer_at(offset)?.node().walk();
     let mut last_child_node = cursor.node();
-    while cursor.goto_first_child_for_byte(offset).is_some() {
+    while cursor.goto_first_child_for_byte(offset.0).is_some() {
         last_child_node = cursor.node();
     }
 
@@ -916,10 +920,16 @@ pub fn surrounding_html_tag(
                     - range.start.to_offset(map, Bias::Left)
                     <= 1
                 {
-                    offset <= last_child.end_byte()
+                    offset.0 <= last_child.end_byte()
                 } else {
-                    range.start.to_offset(map, Bias::Left) >= first_child.start_byte()
-                        && range.end.to_offset(map, Bias::Left) <= last_child.start_byte() + 1
+                    excerpt
+                        .map_offset_to_buffer(range.start.to_offset(map, Bias::Left))
+                        .0
+                        >= first_child.start_byte()
+                        && excerpt
+                            .map_offset_to_buffer(range.end.to_offset(map, Bias::Left))
+                            .0
+                            <= last_child.start_byte() + 1
                 };
                 if open_tag.is_some() && open_tag == close_tag && is_valid {
                     let range = if around {
@@ -927,6 +937,7 @@ pub fn surrounding_html_tag(
                     } else {
                         first_child.byte_range().end..last_child.byte_range().start
                     };
+                    let range = BufferOffset(range.start)..BufferOffset(range.end);
                     if excerpt.contains_buffer_range(range.clone()) {
                         let result = excerpt.map_range_from_buffer(range);
                         return Some(
@@ -1093,7 +1104,8 @@ fn text_object(
         .collect();
     matches.sort_by_key(|r| r.end - r.start);
     if let Some(buffer_range) = matches.first() {
-        let range = excerpt.map_range_from_buffer(buffer_range.clone());
+        let buffer_range = BufferOffset(buffer_range.start)..BufferOffset(buffer_range.end);
+        let range = excerpt.map_range_from_buffer(buffer_range);
         return Some(range.start.to_display_point(map)..range.end.to_display_point(map));
     }
 
@@ -1113,9 +1125,11 @@ fn text_object(
     if let Some(buffer_range) = matches.first()
         && !buffer_range.is_empty()
     {
+        let buffer_range = BufferOffset(buffer_range.start)..BufferOffset(buffer_range.end);
         let range = excerpt.map_range_from_buffer(buffer_range.clone());
         return Some(range.start.to_display_point(map)..range.end.to_display_point(map));
     }
+    let around_range = BufferOffset(around_range.start)..BufferOffset(around_range.end);
     let buffer_range = excerpt.map_range_from_buffer(around_range.clone());
     return Some(buffer_range.start.to_display_point(map)..buffer_range.end.to_display_point(map));
 }
@@ -1134,9 +1148,9 @@ fn argument(
 
     fn comma_delimited_range_at(
         buffer: &BufferSnapshot,
-        mut offset: usize,
+        mut offset: BufferOffset,
         include_comma: bool,
-    ) -> Option<Range<usize>> {
+    ) -> Option<Range<BufferOffset>> {
         // Seek to the first non-whitespace character
         offset += buffer
             .chars_at(offset)
@@ -1151,7 +1165,7 @@ fn argument(
             }
 
             // If the cursor is outside the brackets, ignore them
-            if open.start == offset || close.end == offset {
+            if open.start == offset.0 || close.end == offset.0 {
                 return false;
             }
 
@@ -1167,7 +1181,7 @@ fn argument(
         let (open_bracket, close_bracket) =
             buffer.innermost_enclosing_bracket_ranges(offset..offset, Some(&bracket_filter))?;
 
-        let inner_bracket_range = open_bracket.end..close_bracket.start;
+        let inner_bracket_range = BufferOffset(open_bracket.end)..BufferOffset(close_bracket.start);
 
         let layer = buffer.syntax_layer_at(offset)?;
         let node = layer.node();
@@ -1186,7 +1200,7 @@ fn argument(
             parent_covers_bracket_range = covers_bracket_range;
 
             // Unable to find a child node with a parent that covers the bracket range, so no argument to select
-            cursor.goto_first_child_for_byte(offset)?;
+            cursor.goto_first_child_for_byte(offset.0)?;
         }
 
         let mut argument_node = cursor.node();
@@ -1256,7 +1270,7 @@ fn argument(
             }
         }
 
-        Some(start..end)
+        Some(BufferOffset(start)..BufferOffset(end))
     }
 
     let result = comma_delimited_range_at(buffer, excerpt.map_offset_to_buffer(offset), around)?;
@@ -1387,7 +1401,7 @@ fn is_possible_sentence_start(character: char) -> bool {
 const SENTENCE_END_PUNCTUATION: &[char] = &['.', '!', '?'];
 const SENTENCE_END_FILLERS: &[char] = &[')', ']', '"', '\''];
 const SENTENCE_END_WHITESPACE: &[char] = &[' ', '\t', '\n'];
-fn is_sentence_end(map: &DisplaySnapshot, offset: usize) -> bool {
+fn is_sentence_end(map: &DisplaySnapshot, offset: MultiBufferOffset) -> bool {
     let mut next_chars = map.buffer_chars_at(offset).peekable();
     if let Some((char, _)) = next_chars.next() {
         // We are at a double newline. This position is a sentence end.

--- a/crates/vim/src/surrounds.rs
+++ b/crates/vim/src/surrounds.rs
@@ -4,7 +4,7 @@ use crate::{
     object::{Object, surrounding_markers},
     state::Mode,
 };
-use editor::{Bias, movement};
+use editor::{Bias, MultiBufferOffset, movement};
 use gpui::{Context, Window};
 use language::BracketPair;
 
@@ -175,7 +175,7 @@ impl Vim {
                         while let Some((ch, offset)) = chars_and_offset.next() {
                             if ch.to_string() == pair.start {
                                 let start = offset;
-                                let mut end = start + 1;
+                                let mut end = start + 1usize;
                                 if surround
                                     && let Some((next_ch, _)) = chars_and_offset.peek()
                                     && next_ch.eq(&' ')
@@ -193,7 +193,7 @@ impl Vim {
                         while let Some((ch, offset)) = reverse_chars_and_offsets.next() {
                             if ch.to_string() == pair.end {
                                 let mut start = offset;
-                                let end = start + 1;
+                                let end = start + 1usize;
                                 if surround
                                     && let Some((next_ch, _)) = reverse_chars_and_offsets.peek()
                                     && next_ch.eq(&' ')
@@ -282,7 +282,7 @@ impl Vim {
                             // that the end replacement string does not exceed
                             // this value. Helpful when dealing with newlines.
                             let mut edit_len = 0;
-                            let mut open_range_end = 0;
+                            let mut open_range_end = MultiBufferOffset(0);
                             let mut chars_and_offset = display_map
                                 .buffer_chars_at(range.start.to_offset(&display_map, Bias::Left))
                                 .peekable();
@@ -291,7 +291,7 @@ impl Vim {
                                 if ch.to_string() == will_replace_pair.start {
                                     let mut open_str = pair.start.clone();
                                     let start = offset;
-                                    open_range_end = start + 1;
+                                    open_range_end = start + 1usize;
                                     while let Some((next_ch, _)) = chars_and_offset.next()
                                         && next_ch == ' '
                                     {
@@ -322,7 +322,7 @@ impl Vim {
                                 if ch.to_string() == will_replace_pair.end {
                                     let mut close_str = String::new();
                                     let mut start = offset;
-                                    let end = start + 1;
+                                    let end = start + 1usize;
                                     while let Some((next_ch, _)) = reverse_chars_and_offsets.next()
                                         && next_ch == ' '
                                         && close_str.len() < edit_len - 1

--- a/crates/vim/src/test.rs
+++ b/crates/vim/src/test.rs
@@ -7,7 +7,7 @@ use std::{sync::Arc, time::Duration};
 use collections::HashMap;
 use command_palette::CommandPalette;
 use editor::{
-    AnchorRangeExt, DisplayPoint, Editor, EditorMode, MultiBuffer,
+    AnchorRangeExt, DisplayPoint, Editor, EditorMode, MultiBuffer, MultiBufferOffset,
     actions::{DeleteLine, WrapSelectionsInTag},
     code_context_menus::CodeContextMenu,
     display_map::DisplayRow,
@@ -908,6 +908,9 @@ fn assert_pending_input(cx: &mut VimTestContext, expected: &str) {
                 .map(|highlight| highlight.to_offset(&snapshot.buffer_snapshot()))
                 .collect::<Vec<_>>(),
             ranges
+                .iter()
+                .map(|range| MultiBufferOffset(range.start)..MultiBufferOffset(range.end))
+                .collect::<Vec<_>>()
         )
     });
 }
@@ -967,7 +970,7 @@ async fn test_jk_delay(cx: &mut gpui::TestAppContext) {
                 .iter()
                 .map(|highlight| highlight.to_offset(&snapshot.buffer_snapshot()))
                 .collect::<Vec<_>>(),
-            vec![0..1]
+            vec![MultiBufferOffset(0)..MultiBufferOffset(1)]
         )
     });
     cx.executor().advance_clock(Duration::from_millis(500));

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -21,8 +21,8 @@ mod visual;
 
 use collections::HashMap;
 use editor::{
-    Anchor, Bias, Editor, EditorEvent, EditorSettings, HideMouseCursorOrigin, SelectionEffects,
-    ToPoint,
+    Anchor, Bias, Editor, EditorEvent, EditorSettings, HideMouseCursorOrigin, MultiBufferOffset,
+    SelectionEffects, ToPoint,
     actions::Paste,
     movement::{self, FindRange},
 };
@@ -1388,7 +1388,7 @@ impl Vim {
         let newest_selection_empty = editor.update(cx, |editor, cx| {
             editor
                 .selections
-                .newest::<usize>(&editor.display_snapshot(cx))
+                .newest::<MultiBufferOffset>(&editor.display_snapshot(cx))
                 .is_empty()
         });
         let editor = editor.read(cx);
@@ -1488,7 +1488,7 @@ impl Vim {
             let snapshot = &editor.snapshot(window, cx);
             let selection = editor
                 .selections
-                .newest::<usize>(&snapshot.display_snapshot);
+                .newest::<MultiBufferOffset>(&snapshot.display_snapshot);
 
             let snapshot = snapshot.buffer_snapshot();
             let (range, kind) =

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use collections::HashMap;
 use editor::{
-    Bias, DisplayPoint, Editor, SelectionEffects,
+    Bias, DisplayPoint, Editor, MultiBufferOffset, SelectionEffects,
     display_map::{DisplaySnapshot, ToDisplayPoint},
     movement,
 };
@@ -778,7 +778,7 @@ impl Vim {
                     {
                         let range = row_range.start.to_offset(&display_map, Bias::Right)
                             ..row_range.end.to_offset(&display_map, Bias::Right);
-                        let text = text.repeat(range.len());
+                        let text = text.repeat(range.end - range.start);
                         edits.push((range, text));
                     }
                 }
@@ -844,8 +844,8 @@ impl Vim {
             return;
         };
         let vim_is_normal = self.mode == Mode::Normal;
-        let mut start_selection = 0usize;
-        let mut end_selection = 0usize;
+        let mut start_selection = MultiBufferOffset(0);
+        let mut end_selection = MultiBufferOffset(0);
 
         self.update_editor(cx, |_, editor, _| {
             editor.set_collapse_matches(false);
@@ -868,7 +868,7 @@ impl Vim {
         self.update_editor(cx, |_, editor, cx| {
             let latest = editor
                 .selections
-                .newest::<usize>(&editor.display_snapshot(cx));
+                .newest::<MultiBufferOffset>(&editor.display_snapshot(cx));
             start_selection = latest.start;
             end_selection = latest.end;
         });
@@ -891,7 +891,7 @@ impl Vim {
         self.update_editor(cx, |_, editor, cx| {
             let latest = editor
                 .selections
-                .newest::<usize>(&editor.display_snapshot(cx));
+                .newest::<MultiBufferOffset>(&editor.display_snapshot(cx));
             if vim_is_normal {
                 start_selection = latest.start;
                 end_selection = latest.end;

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -2241,7 +2241,9 @@ mod tests {
     use super::*;
     use assets::Assets;
     use collections::HashSet;
-    use editor::{DisplayPoint, Editor, SelectionEffects, display_map::DisplayRow};
+    use editor::{
+        DisplayPoint, Editor, MultiBufferOffset, SelectionEffects, display_map::DisplayRow,
+    };
     use gpui::{
         Action, AnyWindowHandle, App, AssetSource, BorrowAppContext, SemanticVersion,
         TestAppContext, UpdateGlobal, VisualTestContext, WindowHandle, actions,
@@ -3508,7 +3510,11 @@ mod tests {
                     assert!(!editor.is_dirty(cx));
                     assert_eq!(editor.title(cx), "untitled");
                     assert!(Arc::ptr_eq(
-                        &editor.buffer().read(cx).language_at(0, cx).unwrap(),
+                        &editor
+                            .buffer()
+                            .read(cx)
+                            .language_at(MultiBufferOffset(0), cx)
+                            .unwrap(),
                         &languages::PLAIN_TEXT
                     ));
                     editor.handle_input("hi", window, cx);
@@ -3542,7 +3548,12 @@ mod tests {
                     assert!(!editor.is_dirty(cx));
                     assert_eq!(editor.title(cx), "the-new-name.rs");
                     assert_eq!(
-                        editor.buffer().read(cx).language_at(0, cx).unwrap().name(),
+                        editor
+                            .buffer()
+                            .read(cx)
+                            .language_at(MultiBufferOffset(0), cx)
+                            .unwrap()
+                            .name(),
                         "Rust".into()
                     );
                 });
@@ -3648,7 +3659,11 @@ mod tests {
             .update(cx, |_, window, cx| {
                 editor.update(cx, |editor, cx| {
                     assert!(Arc::ptr_eq(
-                        &editor.buffer().read(cx).language_at(0, cx).unwrap(),
+                        &editor
+                            .buffer()
+                            .read(cx)
+                            .language_at(MultiBufferOffset(0), cx)
+                            .unwrap(),
                         &languages::PLAIN_TEXT
                     ));
                     editor.handle_input("hi", window, cx);
@@ -3672,7 +3687,12 @@ mod tests {
                 editor.update(cx, |editor, cx| {
                     assert!(!editor.is_dirty(cx));
                     assert_eq!(
-                        editor.buffer().read(cx).language_at(0, cx).unwrap().name(),
+                        editor
+                            .buffer()
+                            .read(cx)
+                            .language_at(MultiBufferOffset(0), cx)
+                            .unwrap()
+                            .name(),
                         "Rust".into()
                     )
                 });


### PR DESCRIPTION
This PR introduces a new `MultiBufferOffset` new type wrapping size. The goal of this is to make it clear at the type level when we are interacting with offsets of a multi buffer versus offsets of a language / text buffer. This improves readability of things quite a bit by making it clear what kind of offsets one is working with while also reducing accidental bugs by using the wrong kin of offset for the wrong API.

This PR also uncovered two minor bugs due to that.

Does not yet introduce the MultiBufferPoint equivalent, that is for a follow up PR.

Release Notes:

- N/A *or* Added/Fixed/Improved ...
