### PR TITLE
Enhance color logic for phantom elements to improve visual distinction based on collision status

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -8400,9 +8400,11 @@ impl Editor {
                 (true, true) => ui::IconName::DebugDisabledLogBreakpoint,
             };
 
+            let color = cx.theme().colors();
+
             let color = if is_phantom {
                 if collides_with_existing {
-                    Color::Custom(cx.theme().colors().debugger_accent.opacity(0.5))
+                    Color::Custom(color.debugger_accent.blend(color.text.opacity(0.6)))
                 } else {
                     Color::Hint
                 }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -8401,7 +8401,11 @@ impl Editor {
             };
 
             let color = if is_phantom {
-                Color::Hint
+                if collides_with_existing {
+                    Color::Custom(cx.theme().colors().debugger_accent.opacity(0.5))
+                } else {
+                    Color::Hint
+                }
             } else if is_rejected {
                 Color::Disabled
             } else {


### PR DESCRIPTION
This change modifies the color assignment for phantom elements in the editor. If a phantom element collides with existing elements, it now uses a custom color based on the theme's debugger accent with reduced opacity. Otherwise, it defaults to the hint color.

BEFORE:
![20251114-0939-17 9919633](https://github.com/user-attachments/assets/4ec56f03-4708-4b35-b1ab-abdfd41c763e)

AFTER:
![20251114-0942-38 8596606](https://github.com/user-attachments/assets/6e9a98f1-a34d-4676-9dc6-b3e2b9f967bc)


Release Notes:

- Enhanced color logic for phantom elements to improve visual distinction based on collision status.

