### PR TITLE
util: Fix zip extraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1238,15 +1238,15 @@ dependencies = [
 
 [[package]]
 name = "async_zip"
-version = "0.0.17"
+version = "0.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b9f7252833d5ed4b00aa9604b563529dd5e11de9c23615de2dcdf91eb87b52"
+checksum = "0d8c50d65ce1b0e0cb65a785ff615f78860d7754290647d3b983208daa4f85e6"
 dependencies = [
  "async-compression",
  "crc32fast",
  "futures-lite 2.6.1",
  "pin-project",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -461,7 +461,7 @@ async-tar = "0.5.1"
 async-task = "4.7"
 async-trait = "0.1"
 async-tungstenite = "0.31.0"
-async_zip = { version = "0.0.17", features = ["deflate", "deflate64"] }
+async_zip = { version = "0.0.18", features = ["deflate", "deflate64"] }
 aws-config = { version = "1.6.1", features = ["behavior-version-latest"] }
 aws-credential-types = { version = "1.2.2", features = [
     "hardcoded-credentials",

--- a/crates/dap/src/adapters.rs
+++ b/crates/dap/src/adapters.rs
@@ -324,6 +324,7 @@ pub async fn download_adapter_from_github(
             extract_zip(&version_path, file)
                 .await
                 // we cannot check the status as some adapter include files with names that trigger `Illegal byte sequence`
+                .inspect_err(|e| log::warn!("ZIP extraction error: {}. Ignoring...", e))
                 .ok();
 
             util::fs::remove_matching(&adapter_path, |entry| {


### PR DESCRIPTION
I was trying to use Zed for Rust debugging on windows, but was getting this warning in debugger console: "Could not initialize Python interpreter - some features will be unavailable (e.g. debug visualizers)."
As the warning suggests this led to bad debugging experience where the variables were not visualized properly in the "Variables" panel.

After some investigation I found that the problem is that Zed silently failed to extract all files from the debug adapter package (https://github.com/vadimcn/codelldb/releases/download/v1.11.8/codelldb-win32-x64.vsix). Particularly `python-lldb` folder was missing, which caused the warning.
The error occurred here:
https://github.com/zed-industries/zed/blob/cf7c64d77f1806cdd34b3812bbf27681fb3cb905/crates/util/src/archive.rs#L47
And then gets ignored here:
https://github.com/zed-industries/zed/blob/cf7c64d77f1806cdd34b3812bbf27681fb3cb905/crates/dap/src/adapters.rs#L323-L326
The simple fix is to update `async_zip` crate to version 0.0.18 where this issue appears to be fixed. I also added logging instead of silently ignoring the error, as I believe that would have helped to catch it earlier.

To reproduce the original issue you can try to follow these steps:
0. (Optional) Remove/rename old codelldb adapter at `%localappdata%\Zed\debug_adapters\CodeLLDB`. Restart Zed.
1. Create a simple Rust project. Make sure you use gnu toolchain (target `x86_64-pc-windows-gnu`)
```rust
fn world() -> String {
    "world".into()
}

fn main() {
    let w = world();
    println!("hello {}", w);
}
```

2. Put a breakpoint on line 7 (`println`)
3. In the command palette choose "debugger: start" and then select "run *crate name*" 

Screenshot before the fix:

<img width="893" height="411" alt="image" src="https://github.com/user-attachments/assets/78097690-b55e-4989-bfa4-20452560f9fc" />


<details>
<summary>Console before the fix</summary>

```
Checking latest version of CodeLLDB...
Downloading from https://github.com/vadimcn/codelldb/releases/download/v1.11.8/codelldb-win32-x64.vsix...
Download complete
Could not initialize Python interpreter - some features will be unavailable (e.g. debug visualizers).
Console is in 'commands' mode, prefix expressions with '?'.
warning: (x86_64) D:\repro\target\x86_64-pc-windows-gnu\debug\repro.exe unable to locate separate debug file (dwo, dwp). Debugging will be degraded.
Launching: D:\repro\target\x86_64-pc-windows-gnu\debug\repro.exe
Launched process 13836 from 'D:\repro\target\x86_64-pc-windows-gnu\debug\repro.exe'
error: repro.exe [0x0000000000002074]: DIE has DW_AT_ranges(DW_FORM_sec_offset 0x000000000000001a) attribute, but range extraction failed (invalid range list offset 0x1a), please file a bug and attach the file at the start of this error message
error: repro.exe [0x000000000000208c]: DIE has DW_AT_ranges(DW_FORM_sec_offset 0x0000000000000025) attribute, but range extraction failed (invalid range list offset 0x25), please file a bug and attach the file at the start of this error message
error: repro.exe [0x00000000000020af]: DIE has DW_AT_ranges(DW_FORM_sec_offset 0x0000000000000030) attribute, but range extraction failed (invalid range list offset 0x30), please file a bug and attach the file at the start of this error message
error: repro.exe [0x00000000000020c4]: DIE has DW_AT_ranges(DW_FORM_sec_offset 0x000000000000003b) attribute, but range extraction failed (invalid range list offset 0x3b), please file a bug and attach the file at the start of this error message
error: repro.exe [0x00000000000020fc]: DIE has DW_AT_ranges(DW_FORM_sec_offset 0x0000000000000046) attribute, but range extraction failed (invalid range list offset 0x46), please file a bug and attach the file at the start of this error message
error: repro.exe [0x0000000000002130]: DIE has DW_AT_ranges(DW_FORM_sec_offset 0x0000000000000046) attribute, but range extraction failed (invalid range list offset 0x46), please file a bug and attach the file at the start of this error message
> ? w
< {...}
```
</details>

Screenshot after the fix:
<img width="634" height="295" alt="image" src="https://github.com/user-attachments/assets/67e36a64-97d2-406c-9216-7ac5b01f4101" />

<details>
<summary>Console after the fix</summary>

```
Checking latest version of CodeLLDB...
Downloading from https://github.com/vadimcn/codelldb/releases/download/v1.11.8/codelldb-win32-x64.vsix...
Download complete
Console is in 'commands' mode, prefix expressions with '?'.
Loading Rust formatters from C:\Users\Vasyl\.rustup\toolchains\1.91.1-x86_64-pc-windows-msvc\lib/rustlib/etc
warning: (x86_64) D:\repro\target\x86_64-pc-windows-gnu\debug\repro.exe unable to locate separate debug file (dwo, dwp). Debugging will be degraded.
Launching: D:\repro\target\x86_64-pc-windows-gnu\debug\repro.exe
Launched process 10364 from 'D:\repro\target\x86_64-pc-windows-gnu\debug\repro.exe'
error: repro.exe [0x0000000000002074]: DIE has DW_AT_ranges(DW_FORM_sec_offset 0x000000000000001a) attribute, but range extraction failed (invalid range list offset 0x1a), please file a bug and attach the file at the start of this error message
error: repro.exe [0x000000000000208c]: DIE has DW_AT_ranges(DW_FORM_sec_offset 0x0000000000000025) attribute, but range extraction failed (invalid range list offset 0x25), please file a bug and attach the file at the start of this error message
error: repro.exe [0x00000000000020af]: DIE has DW_AT_ranges(DW_FORM_sec_offset 0x0000000000000030) attribute, but range extraction failed (invalid range list offset 0x30), please file a bug and attach the file at the start of this error message
error: repro.exe [0x00000000000020c4]: DIE has DW_AT_ranges(DW_FORM_sec_offset 0x000000000000003b) attribute, but range extraction failed (invalid range list offset 0x3b), please file a bug and attach the file at the start of this error message
error: repro.exe [0x00000000000020fc]: DIE has DW_AT_ranges(DW_FORM_sec_offset 0x0000000000000046) attribute, but range extraction failed (invalid range list offset 0x46), please file a bug and attach the file at the start of this error message
error: repro.exe [0x0000000000002130]: DIE has DW_AT_ranges(DW_FORM_sec_offset 0x0000000000000046) attribute, but range extraction failed (invalid range list offset 0x46), please file a bug and attach the file at the start of this error message
> ? w
< "world"
```
</details>

This fixes #33753

Release Notes:

- debugger: Fixed CodeLLDB installation getting malformed due to ZIP unpacking bug.

