### PR TITLE
Add vertical tabs

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -18,3 +18,6 @@ rustflags = [
 
 [env]
 MACOSX_DEPLOYMENT_TARGET = "10.15.7"
+
+[net]
+git-fetch-with-cli = true

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -18,6 +18,3 @@ rustflags = [
 
 [env]
 MACOSX_DEPLOYMENT_TARGET = "10.15.7"
-
-[net]
-git-fetch-with-cli = true

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1029,7 +1029,9 @@
     // Whether or not to show the navigation history buttons.
     "show_nav_history_buttons": true,
     // Whether or not to show the tab bar buttons.
-    "show_tab_bar_buttons": true
+    "show_tab_bar_buttons": true,
+    // Orientation of the tab bar. One of: ["horizontal", "vertical"]
+    "orientation": "horizontal"
   },
   // Settings related to the editor's tabs
   "tabs": {

--- a/crates/settings/src/settings_content/workspace.rs
+++ b/crates/settings/src/settings_content/workspace.rs
@@ -350,6 +350,29 @@ pub enum RestoreOnStartupBehavior {
     LastSession,
 }
 
+#[derive(
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    Default,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    MergeFrom,
+    Debug,
+    strum::VariantArray,
+    strum::VariantNames,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum TabBarOrientation {
+    /// Display the tab bar above the pane content.
+    #[default]
+    Horizontal,
+    /// Display the tab bar alongside the pane content.
+    Vertical,
+}
+
 #[skip_serializing_none]
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema, MergeFrom, Debug, PartialEq)]
 pub struct TabBarSettingsContent {
@@ -365,6 +388,10 @@ pub struct TabBarSettingsContent {
     ///
     /// Default: true
     pub show_tab_bar_buttons: Option<bool>,
+    /// Orientation of the tab bar relative to the pane content.
+    ///
+    /// Default: "horizontal"
+    pub orientation: Option<TabBarOrientation>,
 }
 
 #[skip_serializing_none]

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -635,6 +635,7 @@ impl VsCodeSettings {
             show_tab_bar_buttons: self
                 .read_str("workbench.editor.editorActionsLocation")
                 .and_then(|str| if str == "hidden" { Some(false) } else { None }),
+            orientation: None,
         })
     }
 

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -2981,6 +2981,21 @@ pub(crate) fn settings_data(cx: &App) -> Vec<SettingsPage> {
                     files: USER,
                 }),
                 SettingsPageItem::SettingItem(SettingItem {
+                    title: "Tab Bar Orientation",
+                    description: "Lay out the tab bar horizontally above panes or vertically beside them.",
+                    field: Box::new(SettingField {
+                        json_path: Some("tab_bar.orientation"),
+                        pick: |settings_content| {
+                            settings_content.tab_bar.as_ref()?.orientation.as_ref()
+                        },
+                        write: |settings_content, value| {
+                            settings_content.tab_bar.get_or_insert_default().orientation = value;
+                        },
+                    }),
+                    metadata: None,
+                    files: USER,
+                }),
+                SettingsPageItem::SettingItem(SettingItem {
                     title: "Show Git Status In Tabs",
                     description: "Show the Git file status on a tab item.",
                     field: Box::new(SettingField {

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -503,6 +503,7 @@ fn init_renderers(cx: &mut App) {
         .add_basic_renderer::<settings::ShellDiscriminants>(render_dropdown)
         .add_basic_renderer::<settings::EditPredictionsMode>(render_dropdown)
         .add_basic_renderer::<settings::RelativeLineNumbers>(render_dropdown)
+        .add_basic_renderer::<settings::TabBarOrientation>(render_dropdown)
         // please semicolon stay on next line
         ;
 }

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -18,7 +18,7 @@ use gpui::{
 use itertools::Itertools;
 use project::{Fs, Project, ProjectEntryId};
 use search::{BufferSearchBar, buffer_search::DivRegistrar};
-use settings::{Settings, TerminalDockPosition};
+use settings::{Settings, TabBarOrientation, TerminalDockPosition};
 use task::{RevealStrategy, RevealTarget, Shell, ShellBuilder, SpawnInTerminal, TaskId};
 use terminal::{Terminal, terminal_settings::TerminalSettings};
 use ui::{
@@ -136,6 +136,7 @@ impl TerminalPanel {
     fn apply_tab_bar_buttons(&self, terminal_pane: &Entity<Pane>, cx: &mut Context<Self>) {
         let assistant_tab_bar_button = self.assistant_tab_bar_button.clone();
         terminal_pane.update(cx, |pane, cx| {
+            pane.set_tab_bar_orientation_override(Some(TabBarOrientation::Horizontal), cx);
             pane.set_render_tab_bar_buttons(cx, move |pane, window, cx| {
                 let split_context = pane
                     .active_item()
@@ -1111,6 +1112,7 @@ pub fn new_terminal_pane(
         pane.display_nav_history_buttons(None);
         pane.set_should_display_tab_bar(|_, _| true);
         pane.set_zoom_out_on_close(false);
+        pane.set_tab_bar_orientation_override(Some(TabBarOrientation::Horizontal), cx);
 
         let split_closure_terminal_panel = terminal_panel.downgrade();
         pane.set_can_split(Some(Arc::new(move |pane, dragged_item, _window, cx| {

--- a/crates/ui/src/components/tab.rs
+++ b/crates/ui/src/components/tab.rs
@@ -161,8 +161,7 @@ impl RenderOnce for Tab {
                     TabCloseSide::Start => (close_slot, indicator_slot),
                 };
 
-                base
-                    .h(Tab::container_height(cx))
+                base.h(Tab::container_height(cx))
                     .map(|this| match self.position {
                         TabPosition::First => {
                             if self.selected {
@@ -178,9 +177,15 @@ impl RenderOnce for Tab {
                                 this.pl_px().border_b_1().border_r_1()
                             }
                         }
-                        TabPosition::Middle(Ordering::Equal) => this.border_l_1().border_r_1().pb_px(),
-                        TabPosition::Middle(Ordering::Less) => this.border_l_1().pr_px().border_b_1(),
-                        TabPosition::Middle(Ordering::Greater) => this.border_r_1().pl_px().border_b_1(),
+                        TabPosition::Middle(Ordering::Equal) => {
+                            this.border_l_1().border_r_1().pb_px()
+                        }
+                        TabPosition::Middle(Ordering::Less) => {
+                            this.border_l_1().pr_px().border_b_1()
+                        }
+                        TabPosition::Middle(Ordering::Greater) => {
+                            this.border_r_1().pl_px().border_b_1()
+                        }
                     })
                     .child(
                         h_flex()
@@ -229,12 +234,7 @@ impl RenderOnce for Tab {
                         if let Some(slot) = indicator_content.take() {
                             row = row.child(build_indicator(slot));
                         }
-                        row = row.child(
-                            div()
-                                .flex_grow()
-                                .min_w_0()
-                                .children(self.children),
-                        );
+                        row = row.child(div().flex_grow().min_w_0().children(self.children));
                         if let Some(slot) = close_content.take() {
                             row = row.child(build_close(slot));
                         }
@@ -243,20 +243,14 @@ impl RenderOnce for Tab {
                         if let Some(slot) = close_content.take() {
                             row = row.child(build_close(slot));
                         }
-                        row = row.child(
-                            div()
-                                .flex_grow()
-                                .min_w_0()
-                                .children(self.children),
-                        );
+                        row = row.child(div().flex_grow().min_w_0().children(self.children));
                         if let Some(slot) = indicator_content.take() {
                             row = row.child(build_indicator(slot));
                         }
                     }
                 }
 
-                base
-                    .min_h(Tab::container_height(cx))
+                base.min_h(Tab::container_height(cx))
                     .w_full()
                     .border_b_1()
                     .child(row)

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -3061,7 +3061,6 @@ impl Pane {
             })
             .disabled(!self.can_navigate_forward())
             .tooltip({
-                let focus_handle = focus_handle.clone();
                 move |_window, cx| {
                     Tooltip::for_action_in("Go Forward", &GoForward, &focus_handle, cx)
                 }

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -21,7 +21,7 @@ use gpui::{
     DragMoveEvent, Empty, Entity, EntityId, EventEmitter, ExternalPaths, FocusHandle,
     FocusOutEvent, Focusable, KeyContext, MouseButton, MouseDownEvent, NavigationDirection, Pixels,
     Point, PromptLevel, Render, ScrollHandle, Subscription, Task, WeakEntity, WeakFocusHandle,
-    Window, actions, anchored, deferred, prelude::*, relative,
+    Window, actions, anchored, deferred, prelude::*,
 };
 use itertools::Itertools;
 use language::DiagnosticSeverity;

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -6,6 +6,7 @@ use serde::Deserialize;
 pub use settings::{
     AutosaveSetting, BottomDockLayout, InactiveOpacity, PaneSplitDirectionHorizontal,
     PaneSplitDirectionVertical, RegisterSetting, RestoreOnStartupBehavior, Settings,
+    TabBarOrientation,
 };
 
 #[derive(RegisterSetting)]
@@ -57,6 +58,7 @@ pub struct TabBarSettings {
     pub show: bool,
     pub show_nav_history_buttons: bool,
     pub show_tab_bar_buttons: bool,
+    pub orientation: TabBarOrientation,
 }
 
 impl Settings for WorkspaceSettings {
@@ -116,6 +118,7 @@ impl Settings for TabBarSettings {
             show: tab_bar.show.unwrap(),
             show_nav_history_buttons: tab_bar.show_nav_history_buttons.unwrap(),
             show_tab_bar_buttons: tab_bar.show_tab_bar_buttons.unwrap(),
+            orientation: tab_bar.orientation.unwrap_or_default(),
         }
     }
 }

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1257,7 +1257,8 @@ or
 "tab_bar": {
   "show": true,
   "show_nav_history_buttons": true,
-  "show_tab_bar_buttons": true
+  "show_tab_bar_buttons": true,
+  "orientation": "horizontal"
 }
 ```
 
@@ -1290,6 +1291,16 @@ or
 **Options**
 
 `boolean` values
+
+### Orientation
+
+- Description: Whether the tab bar is shown horizontally (above editor panes) or vertically (beside them).
+- Setting: `orientation`
+- Default: `"horizontal"`
+
+**Options**
+
+`"horizontal" | "vertical"`
 
 ## Editor Tabs
 

--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -304,7 +304,8 @@ TBD: Centered layout related settings
   "tab_bar": {
     "show": true,                     // Show/hide the tab bar
     "show_nav_history_buttons": true, // Show/hide history buttons on tab bar
-    "show_tab_bar_buttons": true      // Show hide buttons (new, split, zoom)
+    "show_tab_bar_buttons": true,     // Show hide buttons (new, split, zoom)
+    "orientation": "horizontal"      // Layout tabs horizontally or vertically
   },
   "tabs": {
     "git_status": false,              // Color to show git status


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/discussions/24006

Requested this feature a couple years ago. It didn't gain much traction for some reason (similar feature request on vscode has 618-ish upvotes — https://github.com/microsoft/vscode/issues/108264).

Vertical tabs is the only missing feature that's stopping me from using Zed. Thus I decided to implement it myself.

Release Notes:

- Added vertical tab support (configurable in settings): 
<img width="1512" height="745" alt="image" src="https://github.com/user-attachments/assets/9ace8b9d-c49a-4483-aca1-15bee711ef8f" />

