### PR TITLE
languages: Fix command used for Go subtests

### DIFF
--- a/crates/languages/src/go.rs
+++ b/crates/languages/src/go.rs
@@ -654,7 +654,7 @@ impl ContextProvider for GoContextProvider {
                     "-v".into(),
                     "-run".into(),
                     format!(
-                        "\\^{}\\$/\\^{}\\$",
+                        "'^{}$/^{}$'",
                         VariableName::Symbol.template_value(),
                         GO_SUBTEST_NAME_TASK_VARIABLE.template_value(),
                     ),


### PR DESCRIPTION
The command used to run go subtests was breaking if the test contained square brackets, for example:

```
go test . -v -run ^TestInventoryCheckout$/^\[test\]_test_checkout$
```

After a bit of testing it appears that the best way to actually resolve this in a way supported by `go test` is to wrap this command in quotes. As such, this commit updates the command to, considering the example above:

```
go test . -v -run '^TestInventoryCheckout$/^\[test\]_test_checkout$'
```

We also tested escape the square brackets, using `\\\[` instead of `\[`, but that would lead to a more complex change, so we opted for the simpler solution of wrapping the command in quotes.

Closes #42347 

Release Notes:

- Fixed command used to run Go subtests to ensure that escaped characters don't lead to a failure in finding tests to run
