### PR TITLE
gpui: Fix crashes when losing devices while resizing on windows

### DIFF
--- a/crates/gpui/src/platform/windows/directx_atlas.rs
+++ b/crates/gpui/src/platform/windows/directx_atlas.rs
@@ -234,11 +234,14 @@ impl DirectXAtlasState {
     }
 
     fn texture(&self, id: AtlasTextureId) -> &DirectXAtlasTexture {
-        let textures = match id.kind {
-            crate::AtlasTextureKind::Monochrome => &self.monochrome_textures,
-            crate::AtlasTextureKind::Polychrome => &self.polychrome_textures,
-        };
-        textures[id.index as usize].as_ref().unwrap()
+        match id.kind {
+            crate::AtlasTextureKind::Monochrome => &self.monochrome_textures[id.index as usize]
+                .as_ref()
+                .unwrap(),
+            crate::AtlasTextureKind::Polychrome => &self.polychrome_textures[id.index as usize]
+                .as_ref()
+                .unwrap(),
+        }
     }
 }
 

--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -201,8 +201,10 @@ impl WindowsWindowInner {
         let new_logical_size = device_size.to_pixels(scale_factor);
         let mut lock = self.state.borrow_mut();
         lock.logical_size = new_logical_size;
-        if should_resize_renderer {
-            lock.renderer.resize(device_size).log_err();
+        if should_resize_renderer && let Err(e) = lock.renderer.resize(device_size) {
+            log::error!("Failed to resize renderer, invalidating devices: {}", e);
+            lock.invalidate_devices
+                .store(true, std::sync::atomic::Ordering::Release);
         }
         if let Some(mut callback) = lock.callbacks.resize.take() {
             drop(lock);
@@ -1138,6 +1140,11 @@ impl WindowsWindowInner {
     #[inline]
     fn draw_window(&self, handle: HWND, force_render: bool) -> Option<isize> {
         let mut request_frame = self.state.borrow_mut().callbacks.request_frame.take()?;
+
+        // we are instructing gpui to force render a frame, this will
+        // re-populate all the gpu textures for us so we can resume drawing in
+        // case we disabled drawing earlier due to a device loss
+        self.state.borrow_mut().renderer.mark_drawable();
         request_frame(RequestFrameOptions {
             require_presentation: false,
             force_render,


### PR DESCRIPTION
Fixes ZED-1HC

Release Notes:

- Fixed Zed panicking when moving Zed windows over different screens associated with different gpu devices on windows
