### PR TITLE
Make wild the default linker on Linux

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -16,5 +16,13 @@ rustflags = [
     "target-feature=+crt-static", # This fixes the linking issue when compiling livekit on Windows
 ]
 
+[target.x86_64-unknown-linux-gnu]
+linker = "clang"
+rustflags = ["-C", "link-arg=--ld-path=wild"]
+
+[target.aarch64-unknown-linux-gnu]
+linker = "clang"
+rustflags = ["-C", "link-arg=--ld-path=wild"]
+
 [env]
 MACOSX_DEPLOYMENT_TARGET = "10.15.7"

--- a/script/install-wild
+++ b/script/install-wild
@@ -29,5 +29,4 @@ curl -fsSL --output - "$WILD_URL" \
     | $SUDO tar -C ${DEST_DIR} --strip-components=1 --no-overwrite-dir -xzf - \
     "${WILD_PACKAGE}/wild"
 
-cat <<EOF
-Wild is installed to ${DEST_DIR}/wild
+echo Wild is installed to ${DEST_DIR}/wild

--- a/script/install-wild
+++ b/script/install-wild
@@ -31,14 +31,3 @@ curl -fsSL --output - "$WILD_URL" \
 
 cat <<EOF
 Wild is installed to ${DEST_DIR}/wild
-
-To make it your default, add or merge these lines into your ~/.cargo/config.toml:
-
-[target.x86_64-unknown-linux-gnu]
-linker = "clang"
-rustflags = ["-C", "link-arg=--ld-path=wild"]
-
-[target.aarch64-unknown-linux-gnu]
-linker = "clang"
-rustflags = ["-C", "link-arg=--ld-path=wild"]
-EOF

--- a/script/linux
+++ b/script/linux
@@ -11,12 +11,14 @@ fi
 function finalize {
   # after packages install (curl, etc), get the rust toolchain
   which rustup > /dev/null 2>&1 || curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-  cat <<EOF
-Note: It's recommended to install and configure Wild or Mold for faster builds.
-      Run script/install-wild or script/install-mold.
+  # cat <<EOF
 
-Finished installing Linux dependencies with script/linux
-EOF
+  source script/install-wild
+# Note: It's recommended to install Wild for faster builds.
+#       Run script/install-wild.
+
+# Finished installing Linux dependencies with script/linux
+# EOF
 }
 
 # Ubuntu, Debian, Mint, Kali, Pop!_OS, Raspbian, etc.


### PR DESCRIPTION
It is significantly faster and no production ready. Still keeping it off in CI as its a relatively new linker.

We install it by default on linux now.

Closes #ISSUE

Release Notes:

- N/A *or* Added/Fixed/Improved ...
