### PR TITLE
Fix wild install script

### DIFF
--- a/script/install-wild
+++ b/script/install-wild
@@ -11,8 +11,8 @@ if [ "$(uname -s)" != "Linux" ]; then
 elif [ -z "$WILD_VERSION" ]; then
     echo "Usage: $0 [version]"
     exit 1
-elif which -s wild && wild --version | grep -Fq "$WILD_VERSION" ; then
-    echo "Warning: existing wild $WILD_VERSION found at $(which wild). Skipping installation."
+elif command -v wild >/dev/null 2>&1 && wild --version | grep -Fq "$WILD_VERSION" ; then
+    echo "Warning: existing wild $WILD_VERSION found at $(command -v wild). Skipping installation."
     exit 0
 fi
 


### PR DESCRIPTION
Use [`command`](https://www.gnu.org/software/bash/manual/bash.html#index-command) instead of `which` to check if `wild` is installed. 

Using `which` will result in an error being printed to stdout: 

```bash
./script/install-wild
which: invalid option -- 's'
/usr/local/bin/wild
Warning: existing wild 0.6.0 found at /usr/local/bin/wild. Skipping installation.
```

Release Notes:

- N/A
