### PR TITLE
Use ANSI codepage 1252 for RTF T&C

### DIFF
--- a/script/terms/terms.json
+++ b/script/terms/terms.json
@@ -3,7 +3,8 @@
         {
             "lang": "en-US",
             "type": "rtf",
-            "file": "terms.rtf"
+            "file": "terms.rtf",
+            "encoding": "windows-1252"
         }
     ]
 }


### PR DESCRIPTION
Fixes #40210

Cole and I previous tried UTF-8 encoding in #40423, but that didn't work.

`script/generate-terms-rtf` calls:
- `pandoc` to convert `legal/terms.md` to `script/terms/terms.html`, which preserves UTF-8 encoding
- `textutil` to convert `scripts/terms/terms.html` to `script/terms/terms.rtf`, which translates UTF-8 to ANSI codepage `windows-1252`. This is signified by `\rtf1\ansi\ansicpg1252` at the top of `script/terms/terms.rtf`

Ideally I'd like everything to use UTF-8, but as far as I can tell there's [no way](https://keith.github.io/xcode-man-pages/textutil.1.html) to configure `textutil` to use UTF-8 for RTF. `-encoding` doesn't help because the output file doesn't contain any non-ASCII characters. So instead we'll just tell `dmg-license` to use the weird non-UTF-8 encoding.

Release Notes:

- Fixed encoding error in terms & conditions displayed when installing
