### PR TITLE
Report automatically discarded zeta predictions 

### DIFF
--- a/crates/zed/src/zed/edit_prediction_registry.rs
+++ b/crates/zed/src/zed/edit_prediction_registry.rs
@@ -251,11 +251,12 @@ fn assign_edit_prediction_provider(
                             });
                         }
 
-                        let provider = cx.new(|_| {
+                        let provider = cx.new(|cx| {
                             zeta::ZetaEditPredictionProvider::new(
                                 zeta,
                                 project.clone(),
                                 singleton_buffer,
+                                cx,
                             )
                         });
                         editor.set_edit_prediction_provider(Some(provider), window, cx);

--- a/crates/zeta/src/zeta.rs
+++ b/crates/zeta/src/zeta.rs
@@ -1565,6 +1565,11 @@ impl edit_prediction::EditPredictionProvider for ZetaEditPredictionProvider {
                     let snapshot = buffer.read(cx).snapshot();
                     if new_completion.should_replace_completion(old_completion, &snapshot) {
                         this.zeta.update(cx, |zeta, cx| {
+                            zeta.discard_completion(
+                                old_compltion.completion.id,
+                                completion.was_shown,
+                                cx,
+                            );
                             zeta.completion_shown(&new_completion.completion, cx);
                         });
                         this.current_completion = Some(new_completion);


### PR DESCRIPTION
We weren't reporting predictions that were generated but never made it out of the provider, such as predictions that failed to interpolate, and those that are cancelled because another request completes before it.

Release Notes:

- N/A