### PR TITLE
git_ui: Fix tooltip overlaying context menu in git blame

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -6895,7 +6895,11 @@ impl Editor {
         }
     }
 
-    fn hide_blame_popover(&mut self, ignore_timeout: bool, cx: &mut Context<Self>) -> bool {
+    pub fn has_mouse_context_menu(&self) -> bool {
+        self.mouse_context_menu.is_some()
+    }
+
+    pub fn hide_blame_popover(&mut self, ignore_timeout: bool, cx: &mut Context<Self>) -> bool {
         self.inline_blame_popover_show_task.take();
         if let Some(state) = &mut self.inline_blame_popover {
             let hide_task = cx.spawn(async move |editor, cx| {

--- a/crates/git_ui/src/blame_ui.rs
+++ b/crates/git_ui/src/blame_ui.rs
@@ -85,6 +85,7 @@ impl BlameRenderer for GitBlameRenderer {
                         .on_mouse_down(MouseButton::Right, {
                             let blame_entry = blame_entry.clone();
                             let details = details.clone();
+                            let editor = editor.clone();
                             move |event, window, cx| {
                                 cx.stop_propagation();
 

--- a/crates/git_ui/src/blame_ui.rs
+++ b/crates/git_ui/src/blame_ui.rs
@@ -56,10 +56,6 @@ impl BlameRenderer for GitBlameRenderer {
             None
         };
 
-        // Split editor clones for different purposes to avoid borrow conflicts
-        let editor_for_mouse_down = editor.clone();
-        let editor_for_tooltip = editor;
-
         Some(
             div()
                 .mr_2()
@@ -92,7 +88,7 @@ impl BlameRenderer for GitBlameRenderer {
                                 deploy_blame_entry_context_menu(
                                     &blame_entry,
                                     details.as_ref(),
-                                    editor_for_mouse_down.clone(),
+                                    editor.clone(),
                                     event.position,
                                     window,
                                     cx,
@@ -115,23 +111,20 @@ impl BlameRenderer for GitBlameRenderer {
                                 )
                             }
                         })
-                        .when(
-                            !editor_for_tooltip.read(cx).has_mouse_context_menu(),
-                            |el| {
-                                el.hoverable_tooltip(move |_window, cx| {
-                                    cx.new(|cx| {
-                                        CommitTooltip::blame_entry(
-                                            &blame_entry,
-                                            details.clone(),
-                                            repository.clone(),
-                                            workspace.clone(),
-                                            cx,
-                                        )
-                                    })
-                                    .into()
+                        .when(!editor.read(cx).has_mouse_context_menu(), |el| {
+                            el.hoverable_tooltip(move |_window, cx| {
+                                cx.new(|cx| {
+                                    CommitTooltip::blame_entry(
+                                        &blame_entry,
+                                        details.clone(),
+                                        repository.clone(),
+                                        workspace.clone(),
+                                        cx,
+                                    )
                                 })
-                            },
-                        ),
+                                .into()
+                            })
+                        }),
                 )
                 .into_any(),
         )

--- a/crates/git_ui/src/blame_ui.rs
+++ b/crates/git_ui/src/blame_ui.rs
@@ -86,7 +86,6 @@ impl BlameRenderer for GitBlameRenderer {
                             let blame_entry = blame_entry.clone();
                             let details = details.clone();
                             move |event, window, cx| {
-                                // Prevent the right-click event from bubbling up to parent elements
                                 cx.stop_propagation();
 
                                 deploy_blame_entry_context_menu(


### PR DESCRIPTION
Closes #26949


## Summary

1. Split editor references to avoid borrow conflicts in event handlers
2. Check [has_mouse_context_menu()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) state directly in tooltip conditional instead of caching stale value
3. Restructured context menu deployment to ensure proper sequencing: hide popover → build menu → deploy menu → notify for re-render

**Screen recording**


https://github.com/user-attachments/assets/8a00f882-1c54-47b0-9211-4f28f8deb867



Release Notes:

- Fixed an issue where the context menu in the Git Blame view would be frequently overlapped by the commit information tooltip.
