### PR TITLE
Fix UTF-16 BE BOM detection

### DIFF
--- a/crates/encodings/src/encodings.rs
+++ b/crates/encodings/src/encodings.rs
@@ -194,7 +194,7 @@ impl EncodingOptions {
     fn detect(bytes: &[u8]) -> Option<Encoding> {
         if bytes.starts_with(&[0xFE, 0xFF]) {
             Some(Encoding {
-                encoding: UTF_8,
+                encoding: UTF_16BE,
                 with_bom: true,
             })
         } else if bytes.starts_with(&[0xFF, 0xFE]) {


### PR DESCRIPTION
 use UTF_16BE instead of UTF_8 when detecting [0xFE, 0xFF] BOM.
