### PR TITLE
editor: Add automatic markdown list continuation on newline and indent on tab

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1180,6 +1180,8 @@
   "extend_comment_on_newline": true,
   // Whether to continue markdown lists when pressing enter.
   "extend_list_on_newline": true,
+  // Whether to indent list items when pressing tab after a list marker.
+  "indent_list_on_tab": true,
   // Removes any lines containing only whitespace at the end of the file and
   // ensures just one newline at the end.
   "ensure_final_newline_on_save": true,

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1178,6 +1178,8 @@
   "remove_trailing_whitespace_on_save": true,
   // Whether to start a new line with a comment when a previous line is a comment as well.
   "extend_comment_on_newline": true,
+  // Whether to continue markdown lists when pressing enter.
+  "extend_list_on_newline": true,
   // Removes any lines containing only whitespace at the end of the file and
   // ensures just one newline at the end.
   "ensure_final_newline_on_save": true,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4883,10 +4883,7 @@ impl Editor {
                             NewlineConfig::UnindentCurrentLine { continuation } => {
                                 let row_start =
                                     buffer.point_to_offset(Point::new(start_point.row, 0));
-                                let tab_size = language_scope
-                                    .as_ref()
-                                    .map(|_| multi_buffer.language_settings(cx).tab_size)
-                                    .unwrap_or(NonZeroU32::new(4).unwrap());
+                                let tab_size = buffer.language_settings_at(start, cx).tab_size;
                                 let tab_size_indent = IndentSize::spaces(tab_size.get());
                                 let reduced_indent =
                                     existing_indent.with_delta(Ordering::Less, tab_size_indent);

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4890,7 +4890,7 @@ impl Editor {
                                 let mut new_text = String::new();
                                 new_text.extend(reduced_indent.chars());
                                 new_text.push_str(continuation);
-                                (row_start, new_text, false)
+                                (row_start, new_text, true)
                             }
                             NewlineConfig::Newline {
                                 additional_indent,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -10456,7 +10456,7 @@ impl Editor {
             if selection.is_empty() {
                 let cursor = selection.head();
                 let settings = buffer.language_settings_at(cursor, cx);
-                if settings.extend_list_on_newline {
+                if settings.indent_list_on_tab {
                     if let Some(language) = snapshot.language_scope_at(Point::new(cursor.row, 0)) {
                         if let Some(_) =
                             list_prefix_end_column(MultiBufferRow(cursor.row), &snapshot, &language)

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -23602,50 +23602,50 @@ fn list_delimiter_for_newline(
 
             return None;
         }
-    } else {
-        let candidate: String = snapshot
-            .chars_for_range(range.clone())
-            .skip(num_of_whitespaces)
-            .take(ORDERED_LIST_MAX_MARKER_LEN)
-            .collect();
+    }
 
-        for ordered_config in language.ordered_list() {
-            let regex = match Regex::new(&ordered_config.pattern) {
-                Ok(r) => r,
-                Err(_) => continue,
-            };
+    let candidate: String = snapshot
+        .chars_for_range(range.clone())
+        .skip(num_of_whitespaces)
+        .take(ORDERED_LIST_MAX_MARKER_LEN)
+        .collect();
 
-            if let Some(captures) = regex.captures(&candidate) {
-                let full_match = captures.get(0)?;
-                let marker_len = full_match.len();
-                let end_of_prefix = num_of_whitespaces + marker_len;
+    for ordered_config in language.ordered_list() {
+        let regex = match Regex::new(&ordered_config.pattern) {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
 
-                let has_content_after_marker = snapshot
-                    .chars_for_range(range.clone())
-                    .skip(end_of_prefix)
-                    .any(|c| !c.is_whitespace());
+        if let Some(captures) = regex.captures(&candidate) {
+            let full_match = captures.get(0)?;
+            let marker_len = full_match.len();
+            let end_of_prefix = num_of_whitespaces + marker_len;
 
-                if has_content_after_marker {
-                    let number: u32 = captures.get(1)?.as_str().parse().ok()?;
-                    let continuation = ordered_config
-                        .format
-                        .replace("{1}", &(number + 1).to_string());
-                    return Some(continuation.into());
-                }
+            let has_content_after_marker = snapshot
+                .chars_for_range(range.clone())
+                .skip(end_of_prefix)
+                .any(|c| !c.is_whitespace());
 
-                if start_point.column as usize == end_of_prefix {
-                    let continuation = ordered_config.format.replace("{1}", "1");
-                    if num_of_whitespaces == 0 {
-                        *newline_config = NewlineConfig::ClearCurrentLine;
-                    } else {
-                        *newline_config = NewlineConfig::UnindentCurrentLine {
-                            continuation: continuation.into(),
-                        };
-                    }
-                }
-
-                return None;
+            if has_content_after_marker {
+                let number: u32 = captures.get(1)?.as_str().parse().ok()?;
+                let continuation = ordered_config
+                    .format
+                    .replace("{1}", &(number + 1).to_string());
+                return Some(continuation.into());
             }
+
+            if start_point.column as usize == end_of_prefix {
+                let continuation = ordered_config.format.replace("{1}", "1");
+                if num_of_whitespaces == 0 {
+                    *newline_config = NewlineConfig::ClearCurrentLine;
+                } else {
+                    *newline_config = NewlineConfig::UnindentCurrentLine {
+                        continuation: continuation.into(),
+                    };
+                }
+            }
+
+            return None;
         }
     }
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -23596,12 +23596,13 @@ fn list_delimiter_for_newline(
             .max_by_key(|(prefix, _)| prefix.len())
         {
             let end_of_prefix = num_of_whitespaces + prefix.len();
+            let cursor_is_after_prefix = end_of_prefix <= start_point.column as usize;
             let has_content_after_marker = snapshot
                 .chars_for_range(range.clone())
                 .skip(end_of_prefix)
                 .any(|c| !c.is_whitespace());
 
-            if has_content_after_marker {
+            if has_content_after_marker && cursor_is_after_prefix {
                 return Some((*continuation).into());
             }
 
@@ -23635,13 +23636,14 @@ fn list_delimiter_for_newline(
             let full_match = captures.get(0)?;
             let marker_len = full_match.len();
             let end_of_prefix = num_of_whitespaces + marker_len;
+            let cursor_is_after_prefix = end_of_prefix <= start_point.column as usize;
 
             let has_content_after_marker = snapshot
                 .chars_for_range(range.clone())
                 .skip(end_of_prefix)
                 .any(|c| !c.is_whitespace());
 
-            if has_content_after_marker {
+            if has_content_after_marker && cursor_is_after_prefix {
                 let number: u32 = captures.get(1)?.as_str().parse().ok()?;
                 let continuation = ordered_config
                     .format

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -23598,7 +23598,7 @@ fn list_delimiter_for_newline(
             let end_of_prefix = num_of_whitespaces + prefix.len();
             let cursor_is_after_prefix = end_of_prefix <= start_point.column as usize;
             let has_content_after_marker = snapshot
-                .chars_for_range(range.clone())
+                .chars_for_range(range)
                 .skip(end_of_prefix)
                 .any(|c| !c.is_whitespace());
 
@@ -23639,7 +23639,7 @@ fn list_delimiter_for_newline(
             let cursor_is_after_prefix = end_of_prefix <= start_point.column as usize;
 
             let has_content_after_marker = snapshot
-                .chars_for_range(range.clone())
+                .chars_for_range(range)
                 .skip(end_of_prefix)
                 .any(|c| !c.is_whitespace());
 
@@ -23720,7 +23720,7 @@ fn list_prefix_end_column(
     }
 
     let candidate: String = snapshot
-        .chars_for_range(range.clone())
+        .chars_for_range(range)
         .skip(num_of_whitespaces)
         .take(ORDERED_LIST_MAX_MARKER_LEN)
         .collect();

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -29460,6 +29460,7 @@ async fn test_newline_task_list_continuation(cx: &mut TestAppContext) {
         - [ ] taskˇ
     "});
     cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
     cx.assert_editor_state(indoc! {"
         - [ ] task
         - [ ] ˇ
@@ -29470,6 +29471,7 @@ async fn test_newline_task_list_continuation(cx: &mut TestAppContext) {
         - [x] completed taskˇ
     "});
     cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
     cx.assert_editor_state(indoc! {"
         - [x] completed task
         - [ ] ˇ
@@ -29480,6 +29482,7 @@ async fn test_newline_task_list_continuation(cx: &mut TestAppContext) {
         - [ ] taˇsk
     "});
     cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
     cx.assert_editor_state(indoc! {"
         - [ ] ta
         - [ ] ˇsk
@@ -29490,6 +29493,7 @@ async fn test_newline_task_list_continuation(cx: &mut TestAppContext) {
         - [ ]  ˇ
     "});
     cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
     cx.assert_editor_state(
         indoc! {"
         - [ ]$$
@@ -29505,6 +29509,7 @@ async fn test_newline_task_list_continuation(cx: &mut TestAppContext) {
           - [ ] indentedˇ
     "});
     cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
     cx.assert_editor_state(indoc! {"
         - [ ] task
           - [ ] indented
@@ -29518,12 +29523,14 @@ async fn test_newline_task_list_continuation(cx: &mut TestAppContext) {
             - [ ] ˇ
     "});
     cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
     cx.assert_editor_state(indoc! {"
         - [ ] task
           - [ ] sub task
           - [ ] ˇ
     "});
     cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
 
     // Case 7: Adding newline with cursor right after prefix, removes marker
     cx.assert_editor_state(indoc! {"
@@ -29532,6 +29539,7 @@ async fn test_newline_task_list_continuation(cx: &mut TestAppContext) {
         - [ ] ˇ
     "});
     cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
     cx.assert_editor_state(indoc! {"
         - [ ] task
           - [ ] sub task
@@ -29554,6 +29562,7 @@ async fn test_newline_unordered_list_continuation(cx: &mut TestAppContext) {
         - itemˇ
     "});
     cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
     cx.assert_editor_state(indoc! {"
         - item
         - ˇ
@@ -29564,6 +29573,7 @@ async fn test_newline_unordered_list_continuation(cx: &mut TestAppContext) {
         * starred itemˇ
     "});
     cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
     cx.assert_editor_state(indoc! {"
         * starred item
         * ˇ
@@ -29573,6 +29583,7 @@ async fn test_newline_unordered_list_continuation(cx: &mut TestAppContext) {
         + plus itemˇ
     "});
     cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
     cx.assert_editor_state(indoc! {"
         + plus item
         + ˇ
@@ -29583,6 +29594,7 @@ async fn test_newline_unordered_list_continuation(cx: &mut TestAppContext) {
         - itˇem
     "});
     cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
     cx.assert_editor_state(indoc! {"
         - it
         - ˇem
@@ -29593,6 +29605,7 @@ async fn test_newline_unordered_list_continuation(cx: &mut TestAppContext) {
         -  ˇ
     "});
     cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
     cx.assert_editor_state(
         indoc! {"
         - $
@@ -29608,6 +29621,7 @@ async fn test_newline_unordered_list_continuation(cx: &mut TestAppContext) {
           - indentedˇ
     "});
     cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
     cx.assert_editor_state(indoc! {"
         - item
           - indented
@@ -29621,12 +29635,14 @@ async fn test_newline_unordered_list_continuation(cx: &mut TestAppContext) {
             - ˇ
     "});
     cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
     cx.assert_editor_state(indoc! {"
         - item
           - sub item
           - ˇ
     "});
     cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
 
     // Case 7: Adding newline with cursor right after marker, removes marker
     cx.assert_editor_state(indoc! {"
@@ -29635,6 +29651,7 @@ async fn test_newline_unordered_list_continuation(cx: &mut TestAppContext) {
         - ˇ
     "});
     cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
     cx.assert_editor_state(indoc! {"
         - item
           - sub item
@@ -29657,6 +29674,7 @@ async fn test_newline_ordered_list_continuation(cx: &mut TestAppContext) {
         1. first itemˇ
     "});
     cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
     cx.assert_editor_state(indoc! {"
         1. first item
         2. ˇ
@@ -29667,6 +29685,7 @@ async fn test_newline_ordered_list_continuation(cx: &mut TestAppContext) {
         10. tenth itemˇ
     "});
     cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
     cx.assert_editor_state(indoc! {"
         10. tenth item
         11. ˇ
@@ -29677,6 +29696,7 @@ async fn test_newline_ordered_list_continuation(cx: &mut TestAppContext) {
         1. itˇem
     "});
     cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
     cx.assert_editor_state(indoc! {"
         1. it
         2. ˇem
@@ -29687,6 +29707,7 @@ async fn test_newline_ordered_list_continuation(cx: &mut TestAppContext) {
         1.  ˇ
     "});
     cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
     cx.assert_editor_state(
         indoc! {"
         1. $
@@ -29702,6 +29723,7 @@ async fn test_newline_ordered_list_continuation(cx: &mut TestAppContext) {
           2. indentedˇ
     "});
     cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
     cx.assert_editor_state(indoc! {"
         1. item
           2. indented
@@ -29715,12 +29737,14 @@ async fn test_newline_ordered_list_continuation(cx: &mut TestAppContext) {
             3. ˇ
     "});
     cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
     cx.assert_editor_state(indoc! {"
         1. item
           2. sub item
           1. ˇ
     "});
     cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
 
     // Case 7: Adding newline with cursor right after marker, removes marker
     cx.assert_editor_state(indoc! {"
@@ -29729,10 +29753,38 @@ async fn test_newline_ordered_list_continuation(cx: &mut TestAppContext) {
         1. ˇ
     "});
     cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
     cx.assert_editor_state(indoc! {"
         1. item
           2. sub item
         ˇ
+    "});
+}
+
+#[gpui::test]
+async fn test_newline_should_not_autoindent_ordered_list(cx: &mut TestAppContext) {
+    init_test(cx, |settings| {
+        settings.defaults.tab_size = Some(2.try_into().unwrap());
+    });
+
+    let markdown_language = languages::language("markdown", tree_sitter_md::LANGUAGE.into());
+    let mut cx = EditorTestContext::new(cx).await;
+    cx.update_buffer(|buffer, cx| buffer.set_language(Some(markdown_language), cx));
+
+    // Case 1: Adding newline after (whitespace + marker + any non-whitespace) increments number
+    cx.set_state(indoc! {"
+        1. first item
+          1. sub first item
+          2. sub second item
+          3. ˇ
+    "});
+    cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
+    cx.assert_editor_state(indoc! {"
+        1. first item
+          1. sub first item
+          2. sub second item
+        1. ˇ
     "});
 }
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -25,8 +25,7 @@ use language::{
     BracketPairConfig,
     Capability::ReadWrite,
     DiagnosticSourceKind, FakeLspAdapter, IndentGuideSettings, LanguageConfig,
-    LanguageConfigOverride, LanguageMatcher, LanguageName, OrderedListConfig, Override, Point,
-    TaskListConfig,
+    LanguageConfigOverride, LanguageMatcher, LanguageName, Override, Point,
     language_settings::{
         CompletionSettingsContent, FormatterList, LanguageSettingsContent, LspInsertMode,
     },
@@ -29452,18 +29451,7 @@ async fn test_newline_task_list_continuation(cx: &mut TestAppContext) {
         settings.defaults.tab_size = Some(2.try_into().unwrap());
     });
 
-    let markdown_language = Arc::new(Language::new(
-        LanguageConfig {
-            name: "Markdown".into(),
-            task_list: Some(TaskListConfig {
-                prefixes: vec!["- [ ] ".into(), "- [x] ".into()],
-                continuation: "- [ ] ".into(),
-            }),
-            ..LanguageConfig::default()
-        },
-        None,
-    ));
-
+    let markdown_language = languages::language("markdown", tree_sitter_md::LANGUAGE.into());
     let mut cx = EditorTestContext::new(cx).await;
     cx.update_buffer(|buffer, cx| buffer.set_language(Some(markdown_language), cx));
 
@@ -29557,15 +29545,7 @@ async fn test_newline_unordered_list_continuation(cx: &mut TestAppContext) {
         settings.defaults.tab_size = Some(2.try_into().unwrap());
     });
 
-    let markdown_language = Arc::new(Language::new(
-        LanguageConfig {
-            name: "Markdown".into(),
-            unordered_list: vec!["- ".into(), "* ".into(), "+ ".into()],
-            ..LanguageConfig::default()
-        },
-        None,
-    ));
-
+    let markdown_language = languages::language("markdown", tree_sitter_md::LANGUAGE.into());
     let mut cx = EditorTestContext::new(cx).await;
     cx.update_buffer(|buffer, cx| buffer.set_language(Some(markdown_language), cx));
 
@@ -29668,18 +29648,7 @@ async fn test_newline_ordered_list_continuation(cx: &mut TestAppContext) {
         settings.defaults.tab_size = Some(2.try_into().unwrap());
     });
 
-    let markdown_language = Arc::new(Language::new(
-        LanguageConfig {
-            name: "Markdown".into(),
-            ordered_list: vec![OrderedListConfig {
-                pattern: r"(\d+)\. ".to_string(),
-                format: "{1}. ".to_string(),
-            }],
-            ..LanguageConfig::default()
-        },
-        None,
-    ));
-
+    let markdown_language = languages::language("markdown", tree_sitter_md::LANGUAGE.into());
     let mut cx = EditorTestContext::new(cx).await;
     cx.update_buffer(|buffer, cx| buffer.set_language(Some(markdown_language), cx));
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -29545,6 +29545,28 @@ async fn test_newline_task_list_continuation(cx: &mut TestAppContext) {
           - [ ] sub task
         ˇ
     "});
+
+    // Case 8: Cursor before or inside prefix does not add marker
+    cx.set_state(indoc! {"
+        ˇ- [ ] task
+    "});
+    cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
+    cx.assert_editor_state(indoc! {"
+
+        ˇ- [ ] task
+    "});
+
+    cx.set_state(indoc! {"
+        - [ˇ ] task
+    "});
+    cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
+    cx.assert_editor_state(indoc! {"
+        - [
+        ˇ
+        ] task
+    "});
 }
 
 #[gpui::test]
@@ -29657,6 +29679,27 @@ async fn test_newline_unordered_list_continuation(cx: &mut TestAppContext) {
           - sub item
         ˇ
     "});
+
+    // Case 8: Cursor before or inside prefix does not add marker
+    cx.set_state(indoc! {"
+        ˇ- item
+    "});
+    cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
+    cx.assert_editor_state(indoc! {"
+
+        ˇ- item
+    "});
+
+    cx.set_state(indoc! {"
+        -ˇ item
+    "});
+    cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
+    cx.assert_editor_state(indoc! {"
+        -
+        ˇitem
+    "});
 }
 
 #[gpui::test]
@@ -29758,6 +29801,27 @@ async fn test_newline_ordered_list_continuation(cx: &mut TestAppContext) {
         1. item
           2. sub item
         ˇ
+    "});
+
+    // Case 8: Cursor before or inside prefix does not add marker
+    cx.set_state(indoc! {"
+        ˇ1. item
+    "});
+    cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
+    cx.assert_editor_state(indoc! {"
+
+        ˇ1. item
+    "});
+
+    cx.set_state(indoc! {"
+        1ˇ. item
+    "});
+    cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
+    cx.assert_editor_state(indoc! {"
+        1
+        ˇ. item
     "});
 }
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -25,7 +25,7 @@ use language::{
     BracketPairConfig,
     Capability::ReadWrite,
     DiagnosticSourceKind, FakeLspAdapter, IndentGuideSettings, LanguageConfig,
-    LanguageConfigOverride, LanguageMatcher, LanguageName, Override, Point,
+    LanguageConfigOverride, LanguageMatcher, LanguageName, Override, Point, TaskListConfig,
     language_settings::{
         CompletionSettingsContent, FormatterList, LanguageSettingsContent, LspInsertMode,
     },
@@ -29447,11 +29447,17 @@ async fn test_find_references_single_case(cx: &mut TestAppContext) {
 
 #[gpui::test]
 async fn test_newline_task_list_continuation(cx: &mut TestAppContext) {
-    init_test(cx, |_| {});
+    init_test(cx, |settings| {
+        settings.defaults.tab_size = Some(2.try_into().unwrap());
+    });
 
     let markdown_language = Arc::new(Language::new(
         LanguageConfig {
             name: "Markdown".into(),
+            task_list: Some(TaskListConfig {
+                prefixes: vec!["- [ ] ".into(), "- [x] ".into()],
+                continuation: "- [ ] ".into(),
+            }),
             ..LanguageConfig::default()
         },
         None,
@@ -29495,21 +29501,16 @@ async fn test_newline_task_list_continuation(cx: &mut TestAppContext) {
         - [ ]  ˇ
     "});
     cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
-    cx.assert_editor_state(indoc! {"
-        - [ ]
+    cx.assert_editor_state(
+        indoc! {"
+        - [ ]$$
         ˇ
-    "});
+    "}
+        .replace("$", " ")
+        .as_str(),
+    );
 
-    // Case 5: Adding newline with cursor right after prefix, removes marker
-    cx.set_state(indoc! {"
-        - [ ] ˇ
-    "});
-    cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
-    cx.assert_editor_state(indoc! {"
-        ˇ
-    "});
-
-    // Case 6: Adding newline with content adds marker preserving indentation
+    // Case 5: Adding newline with content adds marker preserving indentation
     cx.set_state(indoc! {"
         - [ ] task
           - [ ] indentedˇ
@@ -29521,15 +29522,31 @@ async fn test_newline_task_list_continuation(cx: &mut TestAppContext) {
           - [ ] ˇ
     "});
 
-    // Case 7: Adding newline with cursor right after prefix, unindents
+    // Case 6: Adding newline with cursor right after prefix, unindents
     cx.set_state(indoc! {"
         - [ ] task
-          - [ ] ˇ
+          - [ ] sub task
+            - [ ] ˇ
     "});
     cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
     cx.assert_editor_state(indoc! {"
         - [ ] task
+          - [ ] sub task
+          - [ ] ˇ
+    "});
+    cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+
+    // Case 7: Adding newline with cursor right after prefix, removes marker
+    cx.assert_editor_state(indoc! {"
+        - [ ] task
+          - [ ] sub task
         - [ ] ˇ
+    "});
+    cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.assert_editor_state(indoc! {"
+        - [ ] task
+          - [ ] sub task
+        ˇ
     "});
 }
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -29619,11 +29619,11 @@ async fn test_newline_markdown_lists(cx: &mut TestAppContext) {
           2. ˇ
     "});
 
-    update_test_language_settings(cx.cx, |settings| {
+    update_test_language_settings(&mut cx.cx, |settings| {
         settings.defaults.extend_list_on_newline = Some(false);
     });
 
-    let mut cx = EditorTestContext::new(cx.cx).await;
+    let mut cx = EditorTestContext::new(&mut cx.cx).await;
     cx.update_buffer(|buffer, cx| {
         buffer.set_language(
             Some(Arc::new(Language::new(

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -29942,15 +29942,11 @@ async fn test_tab_list_indent(cx: &mut TestAppContext) {
     "};
     cx.assert_editor_state(expected);
 
-    // Case 8: Cursor at start of list item, moves the cursor when "extend_list_on_newline" is false
+    // Case 8: Cursor at start of list item, moves the cursor when "indent_list_on_tab" is false
     cx.update_editor(|_, _, cx| {
         SettingsStore::update_global(cx, |store, cx| {
             store.update_user_settings(cx, |settings| {
-                settings
-                    .project
-                    .all_languages
-                    .defaults
-                    .extend_list_on_newline = Some(false);
+                settings.project.all_languages.defaults.indent_list_on_tab = Some(false);
             });
         });
     });

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -29497,6 +29497,156 @@ async fn test_find_references_single_case(cx: &mut TestAppContext) {
     cx.assert_editor_state(after);
 }
 
+async fn test_newline_markdown_lists(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let markdown_language = Arc::new(Language::new(
+        LanguageConfig {
+            name: "Markdown".into(),
+            ..LanguageConfig::default()
+        },
+        None,
+    ));
+
+    let mut cx = EditorTestContext::new(cx).await;
+    cx.update_buffer(|buffer, cx| buffer.set_language(Some(markdown_language), cx));
+
+    cx.set_state(indoc! {"
+        - Item 1ˇ
+    "});
+    cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.assert_editor_state(indoc! {"
+        - Item 1
+        - ˇ
+    "});
+
+    cx.set_state(indoc! {"
+        * Item 1ˇ
+    "});
+    cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.assert_editor_state(indoc! {"
+        * Item 1
+        * ˇ
+    "});
+
+    cx.set_state(indoc! {"
+        + Item 1ˇ
+    "});
+    cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.assert_editor_state(indoc! {"
+        + Item 1
+        + ˇ
+    "});
+
+    cx.set_state(indoc! {"
+        1. Item 1ˇ
+    "});
+    cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.assert_editor_state(indoc! {"
+        1. Item 1
+        2. ˇ
+    "});
+
+    cx.set_state(indoc! {"
+        5. Item 5ˇ
+    "});
+    cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.assert_editor_state(indoc! {"
+        5. Item 5
+        6. ˇ
+    "});
+
+    cx.set_state(indoc! {"
+        - [ ] Unchecked taskˇ
+    "});
+    cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.assert_editor_state(indoc! {"
+        - [ ] Unchecked task
+        - [ ] ˇ
+    "});
+
+    cx.set_state(indoc! {"
+        - [x] Checked taskˇ
+    "});
+    cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.assert_editor_state(indoc! {"
+        - [x] Checked task
+        - [ ] ˇ
+    "});
+
+    cx.set_state(indoc! {"
+        - ˇ
+    "});
+    cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.assert_editor_state(indoc! {"
+
+        ˇ
+    "});
+
+    cx.set_state(indoc! {"
+        1. ˇ
+    "});
+    cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.assert_editor_state(indoc! {"
+
+        ˇ
+    "});
+
+    cx.set_state(indoc! {"
+        - [ ] ˇ
+    "});
+    cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.assert_editor_state(indoc! {"
+
+        ˇ
+    "});
+
+    cx.set_state(indoc! {"
+          - Indented itemˇ
+    "});
+    cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.assert_editor_state(indoc! {"
+          - Indented item
+          - ˇ
+    "});
+
+    cx.set_state(indoc! {"
+          1. Indented ordered itemˇ
+    "});
+    cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.assert_editor_state(indoc! {"
+          1. Indented ordered item
+          2. ˇ
+    "});
+
+    update_test_language_settings(cx.cx, |settings| {
+        settings.defaults.extend_list_on_newline = Some(false);
+    });
+
+    let mut cx = EditorTestContext::new(cx.cx).await;
+    cx.update_buffer(|buffer, cx| {
+        buffer.set_language(
+            Some(Arc::new(Language::new(
+                LanguageConfig {
+                    name: "Markdown".into(),
+                    ..LanguageConfig::default()
+                },
+                None,
+            ))),
+            cx,
+        )
+    });
+
+    cx.set_state(indoc! {"
+        - Item 1ˇ
+    "});
+    cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.assert_editor_state(indoc! {"
+        - Item 1
+        ˇ
+    "});
+}
+
 #[gpui::test]
 async fn test_local_worktree_trust(cx: &mut TestAppContext) {
     init_test(cx, |_| {});

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -122,6 +122,8 @@ pub struct LanguageSettings {
     pub whitespace_map: WhitespaceMap,
     /// Whether to start a new line with a comment when a previous line is a comment as well.
     pub extend_comment_on_newline: bool,
+    /// Whether to continue markdown lists when pressing enter.
+    pub extend_list_on_newline: bool,
     /// Inlay hint related settings.
     pub inlay_hints: InlayHintSettings,
     /// Whether to automatically close brackets.
@@ -567,6 +569,7 @@ impl settings::Settings for AllLanguageSettings {
                     tab: SharedString::new(whitespace_map.tab.unwrap().to_string()),
                 },
                 extend_comment_on_newline: settings.extend_comment_on_newline.unwrap(),
+                extend_list_on_newline: settings.extend_list_on_newline.unwrap(),
                 inlay_hints: InlayHintSettings {
                     enabled: inlay_hints.enabled.unwrap(),
                     show_value_hints: inlay_hints.show_value_hints.unwrap(),

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -124,6 +124,8 @@ pub struct LanguageSettings {
     pub extend_comment_on_newline: bool,
     /// Whether to continue markdown lists when pressing enter.
     pub extend_list_on_newline: bool,
+    /// Whether to indent list items when pressing tab after a list marker.
+    pub indent_list_on_tab: bool,
     /// Inlay hint related settings.
     pub inlay_hints: InlayHintSettings,
     /// Whether to automatically close brackets.
@@ -570,6 +572,7 @@ impl settings::Settings for AllLanguageSettings {
                 },
                 extend_comment_on_newline: settings.extend_comment_on_newline.unwrap(),
                 extend_list_on_newline: settings.extend_list_on_newline.unwrap(),
+                indent_list_on_tab: settings.indent_list_on_tab.unwrap(),
                 inlay_hints: InlayHintSettings {
                     enabled: inlay_hints.enabled.unwrap(),
                     show_value_hints: inlay_hints.show_value_hints.unwrap(),

--- a/crates/languages/src/markdown/config.toml
+++ b/crates/languages/src/markdown/config.toml
@@ -20,6 +20,9 @@ rewrap_prefixes = [
     ">\\s*",
     "[-*+]\\s+\\[[\\sx]\\]\\s+"
 ]
+unordered_list = ["- ", "* ", "+ "]
+ordered_list = [{ pattern = "(\\d+)\\. ", format = "{1}. " }]
+task_list = { prefixes = ["- [ ] ", "- [x] "], continuation = "- [ ] " }
 
 auto_indent_on_paste = false
 auto_indent_using_last_non_empty_line = false

--- a/crates/settings/src/settings_content/language.rs
+++ b/crates/settings/src/settings_content/language.rs
@@ -363,6 +363,10 @@ pub struct LanguageSettingsContent {
     ///
     /// Default: true
     pub extend_comment_on_newline: Option<bool>,
+    /// Whether to continue markdown lists when pressing enter.
+    ///
+    /// Default: true
+    pub extend_list_on_newline: Option<bool>,
     /// Inlay hint related settings.
     pub inlay_hints: Option<InlayHintSettingsContent>,
     /// Whether to automatically type closing characters for you. For example,

--- a/crates/settings/src/settings_content/language.rs
+++ b/crates/settings/src/settings_content/language.rs
@@ -367,6 +367,10 @@ pub struct LanguageSettingsContent {
     ///
     /// Default: true
     pub extend_list_on_newline: Option<bool>,
+    /// Whether to indent list items when pressing tab after a list marker.
+    ///
+    /// Default: true
+    pub indent_list_on_tab: Option<bool>,
     /// Inlay hint related settings.
     pub inlay_hints: Option<InlayHintSettingsContent>,
     /// Whether to automatically type closing characters for you. For example,

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -430,6 +430,7 @@ impl VsCodeSettings {
             enable_language_server: None,
             ensure_final_newline_on_save: self.read_bool("files.insertFinalNewline"),
             extend_comment_on_newline: None,
+            extend_list_on_newline: None,
             format_on_save: self.read_bool("editor.guides.formatOnSave").map(|b| {
                 if b {
                     FormatOnSave::On

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -431,6 +431,7 @@ impl VsCodeSettings {
             ensure_final_newline_on_save: self.read_bool("files.insertFinalNewline"),
             extend_comment_on_newline: None,
             extend_list_on_newline: None,
+            indent_list_on_tab: None,
             format_on_save: self.read_bool("editor.guides.formatOnSave").map(|b| {
                 if b {
                     FormatOnSave::On

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -2909,7 +2909,6 @@ Configuration object for defining settings profiles. Example:
 - Description:
   Preview tabs allow you to open files in preview mode, where they close automatically when you switch to another file unless you explicitly pin them. This is useful for quickly viewing files without cluttering your workspace. Preview tabs display their file names in italics. \
    There are several ways to convert a preview tab into a regular tab:
-
   - Double-clicking on the file
   - Double-clicking on the tab header
   - Using the {#action project_panel::OpenPermanent} action

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1587,8 +1587,18 @@ Positive `integer` value between 1 and 32. Values outside of this range will be 
 
 ## Extend List On Newline
 
-- Description: Whether to continue markdown lists (unordered, ordered, and task lists) when pressing Enter at the end of a list item. Pressing Enter on an empty list item will remove the marker and exit the list.
+- Description: Whether to continue lists when pressing Enter at the end of a list item. Supports unordered, ordered, and task lists. Pressing Enter on an empty list item removes the marker and exits the list.
 - Setting: `extend_list_on_newline`
+- Default: `true`
+
+**Options**
+
+`boolean` values
+
+## Indent List On Tab
+
+- Description: Whether to indent list items when pressing Tab on a line containing only a list marker. This enables quick creation of nested lists.
+- Setting: `indent_list_on_tab`
 - Default: `true`
 
 **Options**

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1585,6 +1585,16 @@ Positive `integer` value between 1 and 32. Values outside of this range will be 
 
 `boolean` values
 
+## Extend List On Newline
+
+- Description: Whether to continue markdown lists (unordered, ordered, and task lists) when pressing Enter at the end of a list item. Pressing Enter on an empty list item will remove the marker and exit the list.
+- Setting: `extend_list_on_newline`
+- Default: `true`
+
+**Options**
+
+`boolean` values
+
 ## Status Bar
 
 - Description: Control various elements in the status bar. Note that some items in the status bar have their own settings set elsewhere.

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -2909,6 +2909,7 @@ Configuration object for defining settings profiles. Example:
 - Description:
   Preview tabs allow you to open files in preview mode, where they close automatically when you switch to another file unless you explicitly pin them. This is useful for quickly viewing files without cluttering your workspace. Preview tabs display their file names in italics. \
    There are several ways to convert a preview tab into a regular tab:
+
   - Double-clicking on the file
   - Double-clicking on the tab header
   - Using the {#action project_panel::OpenPermanent} action

--- a/docs/src/languages/markdown.md
+++ b/docs/src/languages/markdown.md
@@ -35,13 +35,13 @@ Zed supports using Prettier to automatically re-format Markdown documents. You c
 
 ### List Continuation
 
-When you press Enter at the end of a markdown list item, Zed will automatically continue the list on the next line. This works for:
+Zed automatically continues lists when you press Enter at the end of a list item. Supported list types:
 
-- Unordered lists using `-`, `*`, or `+` markers
-- Ordered lists with auto-incrementing numbers
+- Unordered lists (`-`, `*`, or `+` markers)
+- Ordered lists (numbers are auto-incremented)
 - Task lists (`- [ ]` and `- [x]`)
 
-If you press Enter on an empty list item (just the marker with no content), the list marker will be removed and you'll exit the list.
+Pressing Enter on an empty list item removes the marker and exits the list.
 
 To disable this behavior:
 
@@ -49,6 +49,20 @@ To disable this behavior:
   "languages": {
     "Markdown": {
       "extend_list_on_newline": false
+    }
+  },
+```
+
+### List Indentation
+
+Zed indents list items when you press Tab while the cursor is on a line containing only a list marker. This allows you to quickly create nested lists.
+
+To disable this behavior:
+
+```json [settings]
+  "languages": {
+    "Markdown": {
+      "indent_list_on_tab": false
     }
   },
 ```

--- a/docs/src/languages/markdown.md
+++ b/docs/src/languages/markdown.md
@@ -33,6 +33,26 @@ Zed supports using Prettier to automatically re-format Markdown documents. You c
   },
 ```
 
+### List Continuation
+
+When you press Enter at the end of a markdown list item, Zed will automatically continue the list on the next line. This works for:
+
+- Unordered lists using `-`, `*`, or `+` markers
+- Ordered lists with auto-incrementing numbers
+- Task lists (`- [ ]` and `- [x]`)
+
+If you press Enter on an empty list item (just the marker with no content), the list marker will be removed and you'll exit the list.
+
+To disable this behavior:
+
+```json [settings]
+  "languages": {
+    "Markdown": {
+      "extend_list_on_newline": false
+    }
+  },
+```
+
 ### Trailing Whitespace
 
 By default Zed will remove trailing whitespace on save. If you rely on invisible trailing whitespace being converted to `<br />` in Markdown files you can disable this behavior with:


### PR DESCRIPTION
Closes #5089

Release notes:
- Markdown lists now continue automatically when you press Enter (unordered, ordered, and task lists). This can be configured with `extend_list_on_newline` (default: true).
- You can now indent list markers with Tab to quickly create nested lists. This can be configured with `indent_list_on_tab` (default: true).