### PR TITLE
Treat `.h++` files as C++

### DIFF
--- a/crates/languages/src/cpp/config.toml
+++ b/crates/languages/src/cpp/config.toml
@@ -1,6 +1,6 @@
 name = "C++"
 grammar = "cpp"
-path_suffixes = ["cc", "hh", "cpp", "h", "hpp", "cxx", "hxx", "c++", "ipp", "inl", "ino", "ixx", "cu", "cuh", "C", "H"]
+path_suffixes = ["cc", "hh", "cpp", "h", "hpp", "cxx", "hxx", "c++", "h++", "ipp", "inl", "ino", "ixx", "cu", "cuh", "C", "H"]
 line_comments = ["// ", "/// ", "//! "]
 decrease_indent_patterns = [
   { pattern = "^\\s*\\{.*\\}?\\s*$", valid_after = ["if", "for", "while", "do", "switch", "else"] },

--- a/crates/theme/src/icon_theme.rs
+++ b/crates/theme/src/icon_theme.rs
@@ -88,7 +88,7 @@ const FILE_SUFFIXES_BY_ICON_KEY: &[(&str, &[&str])] = &[
     ("coffeescript", &["coffee"]),
     (
         "cpp",
-        &["c++", "cc", "cpp", "cxx", "hh", "hpp", "hxx", "inl", "ixx"],
+        &["c++", "h++", "cc", "cpp", "cxx", "hh", "hpp", "hxx", "inl", "ixx"],
     ),
     ("crystal", &["cr", "ecr"]),
     ("csharp", &["cs"]),

--- a/crates/theme/src/icon_theme.rs
+++ b/crates/theme/src/icon_theme.rs
@@ -88,7 +88,9 @@ const FILE_SUFFIXES_BY_ICON_KEY: &[(&str, &[&str])] = &[
     ("coffeescript", &["coffee"]),
     (
         "cpp",
-        &["c++", "h++", "cc", "cpp", "cxx", "hh", "hpp", "hxx", "inl", "ixx"],
+        &[
+            "c++", "h++", "cc", "cpp", "cxx", "hh", "hpp", "hxx", "inl", "ixx",
+        ],
     ),
     ("crystal", &["cr", "ecr"]),
     ("csharp", &["cs"]),


### PR DESCRIPTION
Release Notes:

- `.h++` files are now treated as C++.
