### PR TITLE
http_client: Remove unused `HttpClient::type_name` method

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -2400,10 +2400,6 @@ impl HttpClient for NullHttpClient {
     fn proxy(&self) -> Option<&Url> {
         None
     }
-
-    fn type_name(&self) -> &'static str {
-        type_name::<Self>()
-    }
 }
 
 /// A mutable reference to an entity owned by GPUI

--- a/crates/http_client/src/http_client.rs
+++ b/crates/http_client/src/http_client.rs
@@ -14,9 +14,9 @@ use futures::{
 };
 use parking_lot::Mutex;
 use serde::Serialize;
+use std::sync::Arc;
 #[cfg(feature = "test-support")]
-use std::fmt;
-use std::{any::type_name, sync::Arc};
+use std::{any::type_name, fmt};
 pub use url::{Host, Url};
 
 #[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]

--- a/crates/http_client/src/http_client.rs
+++ b/crates/http_client/src/http_client.rs
@@ -59,8 +59,6 @@ impl HttpRequestExt for http::request::Builder {
 }
 
 pub trait HttpClient: 'static + Send + Sync {
-    fn type_name(&self) -> &'static str;
-
     fn user_agent(&self) -> Option<&HeaderValue>;
 
     fn send(
@@ -161,10 +159,6 @@ impl HttpClient for HttpClientWithProxy {
 
     fn proxy(&self) -> Option<&Url> {
         self.proxy.as_ref()
-    }
-
-    fn type_name(&self) -> &'static str {
-        self.client.type_name()
     }
 
     #[cfg(feature = "test-support")]
@@ -314,10 +308,6 @@ impl HttpClient for HttpClientWithUrl {
         self.client.proxy.as_ref()
     }
 
-    fn type_name(&self) -> &'static str {
-        self.client.type_name()
-    }
-
     #[cfg(feature = "test-support")]
     fn as_fake(&self) -> &FakeHttpClient {
         self.client.as_fake()
@@ -382,10 +372,6 @@ impl HttpClient for BlockedHttpClient {
 
     fn proxy(&self) -> Option<&Url> {
         None
-    }
-
-    fn type_name(&self) -> &'static str {
-        type_name::<Self>()
     }
 
     #[cfg(feature = "test-support")]
@@ -480,10 +466,6 @@ impl HttpClient for FakeHttpClient {
 
     fn proxy(&self) -> Option<&Url> {
         None
-    }
-
-    fn type_name(&self) -> &'static str {
-        type_name::<Self>()
     }
 
     fn as_fake(&self) -> &FakeHttpClient {

--- a/crates/http_client/src/http_client.rs
+++ b/crates/http_client/src/http_client.rs
@@ -176,17 +176,11 @@ impl HttpClient for HttpClientWithProxy {
 }
 
 /// An [`HttpClient`] that has a base URL.
+#[derive(Deref)]
 pub struct HttpClientWithUrl {
     base_url: Mutex<String>,
+    #[deref]
     client: HttpClientWithProxy,
-}
-
-impl std::ops::Deref for HttpClientWithUrl {
-    type Target = HttpClientWithProxy;
-
-    fn deref(&self) -> &Self::Target {
-        &self.client
-    }
 }
 
 impl HttpClientWithUrl {

--- a/crates/http_client/src/http_client.rs
+++ b/crates/http_client/src/http_client.rs
@@ -61,6 +61,8 @@ impl HttpRequestExt for http::request::Builder {
 pub trait HttpClient: 'static + Send + Sync {
     fn user_agent(&self) -> Option<&HeaderValue>;
 
+    fn proxy(&self) -> Option<&Url>;
+
     fn send(
         &self,
         req: http::Request<AsyncBody>,
@@ -103,8 +105,6 @@ pub trait HttpClient: 'static + Send + Sync {
             Err(e) => Box::pin(async move { Err(e.into()) }),
         }
     }
-
-    fn proxy(&self) -> Option<&Url>;
 
     #[cfg(feature = "test-support")]
     fn as_fake(&self) -> &FakeHttpClient {

--- a/crates/reqwest_client/src/reqwest_client.rs
+++ b/crates/reqwest_client/src/reqwest_client.rs
@@ -1,6 +1,6 @@
 use std::error::Error;
 use std::sync::{LazyLock, OnceLock};
-use std::{any::type_name, borrow::Cow, mem, pin::Pin, task::Poll, time::Duration};
+use std::{borrow::Cow, mem, pin::Pin, task::Poll, time::Duration};
 
 use anyhow::anyhow;
 use bytes::{BufMut, Bytes, BytesMut};
@@ -213,10 +213,6 @@ fn redact_error(mut error: reqwest::Error) -> reqwest::Error {
 impl http_client::HttpClient for ReqwestClient {
     fn proxy(&self) -> Option<&Url> {
         self.proxy.as_ref()
-    }
-
-    fn type_name(&self) -> &'static str {
-        type_name::<Self>()
     }
 
     fn user_agent(&self) -> Option<&HeaderValue> {


### PR DESCRIPTION
Closes #ISSUE

Remove unused method `HttpClient::type_name`. Looking at the PR from a year ago when it was added, it was never actually used for anything and seems like a prototyping artifact.

Other misc changes for the `http_client` crate include:

- Use `derive_more::Deref` for `HttpClientWithUrl` (already used for `HttpClientWithProxy`)
- Move `http_client::proxy()` higher up in the trait definition. (It was in between methods that have default implementations)

Release Notes:

- N/A *or* Added/Fixed/Improved ...
