### PR TITLE
project: Send LSP metadata to remote ServerInfo

### DIFF
--- a/crates/language_tools/src/lsp_log_view.rs
+++ b/crates/language_tools/src/lsp_log_view.rs
@@ -632,17 +632,24 @@ impl LspLogView {
                     .or_else(move || {
                         let capabilities =
                             lsp_store.lsp_server_capabilities.get(&server_id)?.clone();
-                        let name = lsp_store
-                            .language_server_statuses
-                            .get(&server_id)
-                            .map(|status| status.name.clone())?;
+                        let language_server_status =
+                            lsp_store.language_server_statuses.get(&server_id)?;
+
                         Some(ServerInfo {
                             id: server_id,
                             capabilities,
-                            binary: None,
-                            name,
-                            workspace_folders: Vec::new(),
-                            configuration: None,
+                            name: language_server_status.name.clone(),
+                            binary: language_server_status.binary.clone(),
+                            configuration: language_server_status.configuration.clone(),
+                            workspace_folders: language_server_status
+                                .workspace_folders
+                                .iter()
+                                .filter_map(|uri| {
+                                    uri.to_file_path()
+                                        .ok()
+                                        .map(|path| path.to_string_lossy().into_owned())
+                                })
+                                .collect::<Vec<_>>(),
                         })
                     })
             })

--- a/crates/language_tools/src/lsp_log_view.rs
+++ b/crates/language_tools/src/lsp_log_view.rs
@@ -344,7 +344,7 @@ impl LspLogView {
             BINARY = info.binary.as_ref().map_or_else(
                 || "Unknown".to_string(),
                 |binary| serde_json::to_string_pretty(binary)
-                    .unwrap_or_else(|e| format!("Failed to serialize binary info: {e}"))
+                    .unwrap_or_else(|e| format!("Failed to serialize binary info: {e:#}"))
             ),
             WORKSPACE_FOLDERS = info.workspace_folders.join(", "),
             CAPABILITIES = serde_json::to_string_pretty(&info.capabilities)

--- a/crates/language_tools/src/lsp_log_view.rs
+++ b/crates/language_tools/src/lsp_log_view.rs
@@ -12,7 +12,7 @@ use lsp::{
     TraceValue, notification::SetTrace,
 };
 use project::{
-    Project,
+    LanguageServerStatus, Project,
     lsp_store::{
         LanguageServerBinaryInfo,
         log_store::{self, Event, LanguageServerKind, LogKind, LogStore, Message},
@@ -339,17 +339,28 @@ impl LspLogView {
 * Capabilities: {CAPABILITIES}
 
 * Configuration: {CONFIGURATION}",
-            NAME = info.name,
+            NAME = info.status.name,
             ID = info.id,
-            BINARY = info.binary.as_ref().map_or_else(
+            BINARY = info.status.binary.as_ref().map_or_else(
                 || "Unknown".to_string(),
                 |binary| serde_json::to_string_pretty(binary)
                     .unwrap_or_else(|e| format!("Failed to serialize binary info: {e:#}"))
             ),
-            WORKSPACE_FOLDERS = info.workspace_folders.join(", "),
+            WORKSPACE_FOLDERS = info
+                .status
+                .workspace_folders
+                .iter()
+                .filter_map(|uri| {
+                    uri.to_file_path()
+                        .ok()
+                        .map(|path| path.to_string_lossy().into_owned())
+                })
+                .collect::<Vec<_>>()
+                .join(", "),
             CAPABILITIES = serde_json::to_string_pretty(&info.capabilities)
                 .unwrap_or_else(|e| format!("Failed to serialize capabilities: {e}")),
             CONFIGURATION = info
+                .status
                 .configuration
                 .map(|configuration| serde_json::to_string_pretty(&configuration))
                 .transpose()
@@ -636,24 +647,12 @@ impl LspLogView {
                     .or_else(move || {
                         let capabilities =
                             lsp_store.lsp_server_capabilities.get(&server_id)?.clone();
-                        let language_server_status =
-                            lsp_store.language_server_statuses.get(&server_id)?;
+                        let status = lsp_store.language_server_statuses.get(&server_id)?.clone();
 
                         Some(ServerInfo {
                             id: server_id,
                             capabilities,
-                            name: language_server_status.name.clone(),
-                            binary: language_server_status.binary.clone(),
-                            configuration: language_server_status.configuration.clone(),
-                            workspace_folders: language_server_status
-                                .workspace_folders
-                                .iter()
-                                .filter_map(|uri| {
-                                    uri.to_file_path()
-                                        .ok()
-                                        .map(|path| path.to_string_lossy().into_owned())
-                                })
-                                .collect::<Vec<_>>(),
+                            status,
                         })
                     })
             })
@@ -1326,10 +1325,7 @@ impl LspLogToolbarItemView {
 struct ServerInfo {
     id: LanguageServerId,
     capabilities: lsp::ServerCapabilities,
-    binary: Option<LanguageServerBinaryInfo>,
-    name: LanguageServerName,
-    workspace_folders: Vec<String>,
-    configuration: Option<serde_json::Value>,
+    status: LanguageServerStatus,
 }
 
 impl ServerInfo {
@@ -1337,27 +1333,25 @@ impl ServerInfo {
         Self {
             id: server.server_id(),
             capabilities: server.capabilities(),
-            binary: Some(LanguageServerBinaryInfo {
-                path: server.binary().path.to_string_lossy().into_owned(),
-                arguments: server
-                    .binary()
-                    .arguments
-                    .iter()
-                    .map(|arg| arg.to_string_lossy().into_owned())
-                    .collect(),
-                env: server.binary().env.clone(),
-            }),
-            name: server.name(),
-            workspace_folders: server
-                .workspace_folders()
-                .into_iter()
-                .filter_map(|path| {
-                    path.to_file_path()
-                        .ok()
-                        .map(|path| path.to_string_lossy().into_owned())
-                })
-                .collect::<Vec<_>>(),
-            configuration: Some(server.configuration().clone()),
+            status: LanguageServerStatus {
+                name: server.name(),
+                pending_work: Default::default(),
+                has_pending_diagnostic_updates: false,
+                progress_tokens: Default::default(),
+                worktree: None,
+                binary: Some(LanguageServerBinaryInfo {
+                    path: server.binary().path.to_string_lossy().into_owned(),
+                    arguments: server
+                        .binary()
+                        .arguments
+                        .iter()
+                        .map(|arg| arg.to_string_lossy().into_owned())
+                        .collect(),
+                    env: server.binary().env.clone(),
+                }),
+                configuration: Some(server.configuration().clone()),
+                workspace_folders: server.workspace_folders(),
+            },
         }
     }
 }

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -62,7 +62,7 @@ pub enum IoKind {
 
 /// Represents a launchable language server. This can either be a standalone binary or the path
 /// to a runtime with arguments to instruct it to launch the actual language server file.
-#[derive(Clone)]
+#[derive(Clone, Serialize)]
 pub struct LanguageServerBinary {
     pub path: PathBuf,
     pub arguments: Vec<OsString>,

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -62,7 +62,7 @@ pub enum IoKind {
 
 /// Represents a launchable language server. This can either be a standalone binary or the path
 /// to a runtime with arguments to instruct it to launch the actual language server file.
-#[derive(Clone, Serialize)]
+#[derive(Clone)]
 pub struct LanguageServerBinary {
     pub path: PathBuf,
     pub arguments: Vec<OsString>,

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -3543,12 +3543,6 @@ fn notify_server_capabilities_updated(server: &LanguageServer, cx: &mut Context<
                             .iter()
                             .map(|arg| arg.to_string_lossy().into_owned())
                             .collect(),
-                        env: server
-                            .binary()
-                            .env
-                            .clone()
-                            .map(|env| env.into_iter().collect())
-                            .unwrap_or_default(),
                     }),
                     configuration: serde_json::to_string(server.configuration()).ok(),
                     workspace_folders: server
@@ -3724,7 +3718,7 @@ pub struct LanguageServerStatus {
     pub name: LanguageServerName,
     pub pending_work: BTreeMap<ProgressToken, LanguageServerProgress>,
     pub has_pending_diagnostic_updates: bool,
-    progress_tokens: HashSet<ProgressToken>,
+    pub progress_tokens: HashSet<ProgressToken>,
     pub worktree: Option<WorktreeId>,
     pub binary: Option<LanguageServerBinaryInfo>,
     pub configuration: Option<Value>,

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -3535,13 +3535,21 @@ fn notify_server_capabilities_updated(server: &LanguageServer, cx: &mut Context<
             message: proto::update_language_server::Variant::MetadataUpdated(
                 proto::ServerMetadataUpdated {
                     capabilities: Some(capabilities),
-                    binary_path: Some(server.binary().path.to_string_lossy().to_string()),
-                    binary_args: server
-                        .binary()
-                        .arguments
-                        .iter()
-                        .map(|arg| arg.to_string_lossy().to_string())
-                        .collect(),
+                    binary: Some(proto::LanguageServerBinaryInfo {
+                        path: server.binary().path.to_string_lossy().into_owned(),
+                        arguments: server
+                            .binary()
+                            .arguments
+                            .iter()
+                            .map(|arg| arg.to_string_lossy().into_owned())
+                            .collect(),
+                        env: server
+                            .binary()
+                            .env
+                            .clone()
+                            .map(|env| env.into_iter().collect())
+                            .unwrap_or_default(),
+                    }),
                     configuration: serde_json::to_string(server.configuration()).ok(),
                     workspace_folders: server
                         .workspace_folders()
@@ -3705,13 +3713,20 @@ pub enum LspStoreEvent {
 }
 
 #[derive(Clone, Debug, Serialize)]
+pub struct LanguageServerBinaryInfo {
+    pub path: String,
+    pub arguments: Vec<String>,
+    pub env: Option<HashMap<String, String>>,
+}
+
+#[derive(Clone, Debug, Serialize)]
 pub struct LanguageServerStatus {
     pub name: LanguageServerName,
     pub pending_work: BTreeMap<ProgressToken, LanguageServerProgress>,
     pub has_pending_diagnostic_updates: bool,
     progress_tokens: HashSet<ProgressToken>,
     pub worktree: Option<WorktreeId>,
-    pub binary: Option<LanguageServerBinary>,
+    pub binary: Option<LanguageServerBinaryInfo>,
     pub configuration: Option<Value>,
     pub workspace_folders: BTreeSet<Uri>,
 }
@@ -11034,7 +11049,16 @@ impl LspStore {
                 has_pending_diagnostic_updates: false,
                 progress_tokens: Default::default(),
                 worktree: Some(key.worktree_id),
-                binary: Some(language_server.binary().clone()),
+                binary: Some(LanguageServerBinaryInfo {
+                    path: language_server.binary().path.to_string_lossy().into_owned(),
+                    arguments: language_server
+                        .binary()
+                        .arguments
+                        .iter()
+                        .map(|arg| arg.to_string_lossy().into_owned())
+                        .collect(),
+                    env: language_server.binary().env.clone(),
+                }),
                 configuration: Some(language_server.configuration().clone()),
                 workspace_folders: language_server.workspace_folders(),
             },

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -37,7 +37,7 @@ use dap::inline_value::{InlineValueLocation, VariableLookupKind, VariableScope};
 
 use crate::{
     git_store::GitStore,
-    lsp_store::{SymbolLocation, log_store::LogKind},
+    lsp_store::{LanguageServerBinaryInfo, SymbolLocation, log_store::LogKind},
     project_search::SearchResultsHandle,
 };
 pub use agent_server_store::{AgentServerStore, AgentServersUpdated, ExternalAgentServerName};
@@ -111,7 +111,6 @@ use snippet_provider::SnippetProvider;
 use std::{
     borrow::Cow,
     collections::BTreeMap,
-    ffi::OsString,
     ops::{Not as _, Range},
     path::{Path, PathBuf},
     pin::pin,
@@ -3127,15 +3126,11 @@ impl Project {
                                 .language_server_statuses
                                 .get_mut(language_server_id)
                             {
-                                if let Some(path) = &update.binary_path {
+                                if let Some(binary) = &update.binary {
                                     language_server_status.binary =
-                                        Some(lsp::LanguageServerBinary {
-                                            path: path.into(),
-                                            arguments: update
-                                                .binary_args
-                                                .iter()
-                                                .map(|arg| OsString::from(arg))
-                                                .collect(),
+                                        Some(LanguageServerBinaryInfo {
+                                            path: binary.path.clone(),
+                                            arguments: binary.arguments.clone(),
                                             env: None,
                                         });
                                 }

--- a/crates/proto/proto/lsp.proto
+++ b/crates/proto/proto/lsp.proto
@@ -618,7 +618,6 @@ message RegisteredForBuffer {
 message LanguageServerBinaryInfo {
     string path = 1;
     repeated string arguments = 2;
-    map<string, string> env = 3;
 }
 
 message ServerMetadataUpdated {

--- a/crates/proto/proto/lsp.proto
+++ b/crates/proto/proto/lsp.proto
@@ -617,6 +617,10 @@ message RegisteredForBuffer {
 
 message ServerMetadataUpdated {
     optional string capabilities = 1;
+    optional string binary_path = 2;
+    repeated string binary_args = 3;
+    optional string configuration = 4;
+    repeated string workspace_folders = 5;
 }
 
 message LanguageServerLog {

--- a/crates/proto/proto/lsp.proto
+++ b/crates/proto/proto/lsp.proto
@@ -615,12 +615,17 @@ message RegisteredForBuffer {
     uint64 buffer_id = 2;
 }
 
+message LanguageServerBinaryInfo {
+    string path = 1;
+    repeated string arguments = 2;
+    map<string, string> env = 3;
+}
+
 message ServerMetadataUpdated {
     optional string capabilities = 1;
-    optional string binary_path = 2;
-    repeated string binary_args = 3;
-    optional string configuration = 4;
-    repeated string workspace_folders = 5;
+    optional LanguageServerBinaryInfo binary = 2;
+    optional string configuration = 3;
+    repeated string workspace_folders = 4;
 }
 
 message LanguageServerLog {


### PR DESCRIPTION
Closes #39582

Release Notes:

- Fixed language server info not available in remote projects

Here's the before/after:

https://github.com/user-attachments/assets/1057faa5-82af-4975-abad-5e10e139fac1