### PR TITLE
project_panel: Fix preview tabs disabling focusing files after just one click in project panel

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -4698,7 +4698,7 @@ impl ProjectPanel {
                     } else {
                         let preview_tabs_enabled = PreviewTabsSettings::get_global(cx).enabled;
                         let click_count = event.click_count();
-                        let focus_opened_item = !preview_tabs_enabled || click_count > 1;
+                        let focus_opened_item = click_count > 1;
                         let allow_preview = preview_tabs_enabled && click_count == 1;
                         project_panel.open_entry(entry_id, focus_opened_item, allow_preview, cx);
                     }


### PR DESCRIPTION
Closes #41484

With preview tabs disabled, when you click once on a file in the project panel, rather than focusing on that file, zed will incorrectly focus on the text editor panel. This means if you click on a file to focus it, then follow up with a keybind like backspace to delete that file, it doesn't delete that file because the backspace goes through to the text editor instead.

Incorrect behaviour seen here:

https://github.com/user-attachments/assets/8c2dea90-bd90-4507-8ba6-344be348f151



Release Notes:

- Fixed improper UI focus behaviour in the project panel when preview tabs are disabled