### PR TITLE
editor: Fix block cursor offset when selecting text

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1097,6 +1097,8 @@ pub struct Editor {
     pending_rename: Option<RenameState>,
     searchable: bool,
     cursor_shape: CursorShape,
+    /// Whether the cursor is offset one character to the left when something is selected (needed for vim visual mode)
+    cursor_offset_on_selection: bool,
     current_line_highlight: Option<CurrentLineHighlight>,
     pub collapse_matches: bool,
     autoindent_mode: Option<AutoindentMode>,
@@ -2217,6 +2219,7 @@ impl Editor {
             cursor_shape: EditorSettings::get_global(cx)
                 .cursor_shape
                 .unwrap_or_default(),
+            cursor_offset_on_selection: false,
             current_line_highlight: None,
             autoindent_mode: Some(AutoindentMode::EachLine),
             collapse_matches: false,
@@ -3026,6 +3029,10 @@ impl Editor {
 
     pub fn cursor_shape(&self) -> CursorShape {
         self.cursor_shape
+    }
+
+    pub fn set_cursor_offset_on_selection(&mut self, set_cursor_offset_on_selection: bool) {
+        self.cursor_offset_on_selection = set_cursor_offset_on_selection;
     }
 
     pub fn set_current_line_highlight(

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1097,7 +1097,8 @@ pub struct Editor {
     pending_rename: Option<RenameState>,
     searchable: bool,
     cursor_shape: CursorShape,
-    /// Whether the cursor is offset one character to the left when something is selected (needed for vim visual mode)
+    /// Whether the cursor is offset one character to the left when something is
+    /// selected (needed for vim visual mode)
     cursor_offset_on_selection: bool,
     current_line_highlight: Option<CurrentLineHighlight>,
     pub collapse_matches: bool,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -11800,7 +11800,7 @@ mod tests {
 
         window
             .update(cx, |editor, window, cx| {
-                editor.cursor_shape = CursorShape::Block;
+                editor.cursor_offset_on_selection = true;
                 editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
                     s.select_ranges([
                         Point::new(0, 0)..Point::new(1, 0),

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -1160,6 +1160,10 @@ impl Vim {
         // Sync editor settings like clip mode
         self.sync_vim_settings(window, cx);
 
+        self.update_editor(cx, |_, editor, _| {
+            editor.set_cursor_offset_on_selection(mode.is_visual());
+        });
+
         if VimSettings::get_global(cx).toggle_relative_line_numbers
             && self.mode != self.last_mode
             && (self.mode == Mode::Insert || self.last_mode == Mode::Insert)

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -1160,10 +1160,6 @@ impl Vim {
         // Sync editor settings like clip mode
         self.sync_vim_settings(window, cx);
 
-        self.update_editor(cx, |_, editor, _| {
-            editor.set_cursor_offset_on_selection(mode.is_visual());
-        });
-
         if VimSettings::get_global(cx).toggle_relative_line_numbers
             && self.mode != self.last_mode
             && (self.mode == Mode::Insert || self.last_mode == Mode::Insert)
@@ -1946,6 +1942,7 @@ impl Vim {
             editor.set_collapse_matches(collapse_matches);
             editor.set_input_enabled(vim.editor_input_enabled());
             editor.set_autoindent(vim.should_autoindent());
+            editor.set_cursor_offset_on_selection(vim.mode.is_visual());
             editor
                 .selections
                 .set_line_mode(matches!(vim.mode, Mode::VisualLine));


### PR DESCRIPTION
Closes #36677 and #20121

### Problem

Vim visual mode and Helix selection mode both require the cursor to be on the last character of the selection. Until now, this was implemented by offsetting the cursor one character to the left whenever a block cursor is used. (Since the visual modes use a block cursor.)
https://github.com/zed-industries/zed/blob/1683052e6ce44d206e947c397917b2ab7617c0fe/crates/editor/src/element.rs#L153
However, this oversees the problem that **some users might want to use the block cursor without being in visual mode**. Meaning that the cursor is offset by one character to the left even though Vim/Helix mode isn't even activated.

### Solution

Since the Vim mode implementation is separate from the `editor` crate the solution is not as straightforward as just checking the current vim mode. Therefore this PR introduces a new `Editor` struct field called `cursor_offset_on_selection`. This field replaces the condition above and is set to `true` whenever the Vim mode is changed to a visual mode, and `false` otherwise.

If there is a better solution without having to add a new `Editor` field, let me know.

Release Notes:

- Fixes block and hollow cursor being offset when selecting text
