### PR TITLE
Jetbrains keymap updates

### DIFF
--- a/assets/keymaps/linux/jetbrains.json
+++ b/assets/keymaps/linux/jetbrains.json
@@ -1,16 +1,18 @@
 [
   {
     "bindings": {
-      "ctrl-alt-s": "zed::OpenSettingsFile",
+      "ctrl-alt-s": "zed::OpenSettings",
       "ctrl-{": "pane::ActivatePreviousItem",
       "ctrl-}": "pane::ActivateNextItem",
       "shift-escape": null, // Unmap workspace::zoom
+      "ctrl-~": "git::Branch",
       "ctrl-f2": "debugger::Stop",
       "f6": "debugger::Pause",
       "f7": "debugger::StepInto",
       "f8": "debugger::StepOver",
       "shift-f8": "debugger::StepOut",
       "f9": "debugger::Continue",
+      "shift-f9": "debugger::Start",
       "alt-shift-f9": "debugger::Start"
     }
   },
@@ -46,7 +48,7 @@
       "alt-f7": "editor::FindAllReferences",
       "ctrl-alt-f7": "editor::FindAllReferences",
       "ctrl-b": "editor::GoToDefinition", // Conflicts with workspace::ToggleLeftDock
-      "ctrl-alt-b": "editor::GoToDefinitionSplit", // Conflicts with workspace::ToggleRightDock
+      "ctrl-alt-b": "editor::GoToImplementation", // Conflicts with workspace::ToggleRightDock
       "ctrl-shift-b": "editor::GoToTypeDefinition",
       "ctrl-alt-shift-b": "editor::GoToTypeDefinitionSplit",
       "f2": "editor::GoToDiagnostic",
@@ -70,7 +72,11 @@
       "ctrl-r": ["buffer_search::Deploy", { "replace_enabled": true }],
       "ctrl-shift-n": "file_finder::Toggle",
       "ctrl-g": "go_to_line::Toggle",
-      "alt-enter": "editor::ToggleCodeActions"
+      "alt-enter": "editor::ToggleCodeActions",
+      "ctrl-space": "editor::ShowCompletions",
+      "ctrl-q": "editor::Hover",
+      "ctrl-p": "editor::ShowSignatureHelp",
+      "ctrl-\\": "assistant::InlineAssist"
     }
   },
   {
@@ -94,9 +100,13 @@
       "ctrl-shift-f12": "workspace::ToggleAllDocks",
       "ctrl-shift-r": ["pane::DeploySearch", { "replace_enabled": true }],
       "alt-shift-f10": "task::Spawn",
+      "shift-f10": "task::Spawn",
+      "ctrl-f5": "task::Rerun",
       "ctrl-e": "file_finder::Toggle",
-      // "ctrl-k": "git_panel::ToggleFocus", // bug: This should also focus commit editor
+      "ctrl-k": "git_panel::ToggleFocus", // bug: This should also focus commit editor
       "ctrl-shift-n": "file_finder::Toggle",
+      "ctrl-n": "project_symbols::Toggle",
+      "ctrl-alt-n": "file_finder::Toggle",
       "ctrl-shift-a": "command_palette::Toggle",
       "shift shift": "command_palette::Toggle",
       "ctrl-alt-shift-n": "project_symbols::Toggle",
@@ -133,7 +143,9 @@
     "context": "Pane",
     "bindings": {
       "ctrl-alt-left": "pane::GoBack",
-      "ctrl-alt-right": "pane::GoForward"
+      "ctrl-alt-right": "pane::GoForward",
+      "alt-left": "pane::ActivatePreviousItem",
+      "alt-right": "pane::ActivateNextItem"
     }
   },
   {
@@ -152,8 +164,6 @@
     "bindings": {
       "ctrl-shift-t": "workspace::NewTerminal",
       "alt-f12": "workspace::CloseActiveDock",
-      "alt-left": "pane::ActivatePreviousItem",
-      "alt-right": "pane::ActivateNextItem",
       "ctrl-up": "terminal::ScrollLineUp",
       "ctrl-down": "terminal::ScrollLineDown",
       "shift-pageup": "terminal::ScrollPageUp",

--- a/assets/keymaps/macos/jetbrains.json
+++ b/assets/keymaps/macos/jetbrains.json
@@ -5,12 +5,14 @@
       "cmd-}": "pane::ActivateNextItem",
       "cmd-0": "git_panel::ToggleFocus", // overrides `cmd-0` zoom reset
       "shift-escape": null, // Unmap workspace::zoom
+      "cmd-~": "git::Branch",
       "ctrl-f2": "debugger::Stop",
       "f6": "debugger::Pause",
       "f7": "debugger::StepInto",
       "f8": "debugger::StepOver",
       "shift-f8": "debugger::StepOut",
       "f9": "debugger::Continue",
+      "shift-f9": "debugger::Start",
       "alt-shift-f9": "debugger::Start"
     }
   },
@@ -45,7 +47,7 @@
       "alt-f7": "editor::FindAllReferences",
       "cmd-alt-f7": "editor::FindAllReferences",
       "cmd-b": "editor::GoToDefinition", // Conflicts with workspace::ToggleLeftDock
-      "cmd-alt-b": "editor::GoToDefinitionSplit",
+      "cmd-alt-b": "editor::GoToImplementation",
       "cmd-shift-b": "editor::GoToTypeDefinition",
       "cmd-alt-shift-b": "editor::GoToTypeDefinitionSplit",
       "f2": "editor::GoToDiagnostic",
@@ -68,7 +70,11 @@
       "cmd-r": ["buffer_search::Deploy", { "replace_enabled": true }],
       "cmd-shift-o": "file_finder::Toggle",
       "cmd-l": "go_to_line::Toggle",
-      "alt-enter": "editor::ToggleCodeActions"
+      "alt-enter": "editor::ToggleCodeActions",
+      "ctrl-space": "editor::ShowCompletions",
+      "cmd-j": "editor::Hover",
+      "cmd-p": "editor::ShowSignatureHelp",
+      "cmd-\\": "assistant::InlineAssist"
     }
   },
   {
@@ -96,9 +102,13 @@
       "cmd-shift-f12": "workspace::ToggleAllDocks",
       "cmd-shift-r": ["pane::DeploySearch", { "replace_enabled": true }],
       "ctrl-alt-r": "task::Spawn",
+      "shift-f10": "task::Spawn",
+      "cmd-f5": "task::Rerun",
       "cmd-e": "file_finder::Toggle",
-      // "cmd-k": "git_panel::ToggleFocus", // bug: This should also focus commit editor
+      "cmd-k": "git_panel::ToggleFocus", // bug: This should also focus commit editor
       "cmd-shift-o": "file_finder::Toggle",
+      "cmd-shift-n": "file_finder::Toggle",
+      "cmd-n": "project_symbols::Toggle",
       "cmd-shift-a": "command_palette::Toggle",
       "shift shift": "command_palette::Toggle",
       "cmd-alt-o": "project_symbols::Toggle", // JetBrains: Go to Symbol
@@ -135,7 +145,9 @@
     "context": "Pane",
     "bindings": {
       "cmd-alt-left": "pane::GoBack",
-      "cmd-alt-right": "pane::GoForward"
+      "cmd-alt-right": "pane::GoForward",
+      "alt-left": "pane::ActivatePreviousItem",
+      "alt-right": "pane::ActivateNextItem"
     }
   },
   {


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/14639

## Release Notes:

Various improvements to the Jetbrains keymap. Added various missing keyboard shortcuts that I use on a daily basis in Jetbrains, and changed a few which were present in the keymap but mapped to the wrong behavior.

### Added:
- Added various missing keybindings for Jetbrains keymap
  - `ctrl-n` → `project_symbols::Toggle`
  - `ctrl-alt-n` → `file_finder::Toggle` (open project files)
  - `ctrl-~` → `git::Branch`
  - `ctrl-\` → `assistant::InlineAssist`
  - `ctrl-space` → `editor::ShowCompletions`
  - `ctrl-q` → `editor::Hover`
  - `ctrl-p` → `editor::ShowSignatureHelp`
  - `ctrl-f5` → `task::Rerun`
  - `shift-f9` → `debugger::Start`
  - `shift-f10` → `task::Spawn`
- Added macOS equivalents for all of the above, however I only have a Linux machine so I have not tested the mac bindings. The binding are generally the same except `ctrl → cmd` with few exceptions.
  - `cmd-j` → `editor::Hover`

### Fixed:
- Several incorrectly mapped keybindings for the Jetbrains keymap
  - `ctrl-alt-s` → `editor::OpenSettings` (was `editor::OpenSettingsFile`)
  - `ctrl-alt-b` → `editor::GoToImplementation` (was `editor::GoToDefinitionSplit`)
  - `alt-left` → `pane::ActivatePreviousItem`
  - `alt-right` → `pane::ActivateNextItem`
- `ctrl-k` now opens the Git panel. I believe this was commented out because of a bug where focus is not given to the commit message text box, but imo the current behavior of not doing anything at all feels more confusing/frustrating to a Jetbrains user (projecting a little here, happy to revert).
