### PR TITLE
languages: Clean up invalid init calls after recent API changes

### DIFF
--- a/crates/languages/src/c.rs
+++ b/crates/languages/src/c.rs
@@ -432,7 +432,6 @@ mod tests {
         cx.update(|cx| {
             let test_settings = SettingsStore::test(cx);
             cx.set_global(test_settings);
-            language::init(cx);
             cx.update_global::<SettingsStore, _>(|store, cx| {
                 store.update_user_settings(cx, |s| {
                     s.project.all_languages.defaults.tab_size = NonZeroU32::new(2);

--- a/crates/languages/src/cpp.rs
+++ b/crates/languages/src/cpp.rs
@@ -11,7 +11,6 @@ mod tests {
         cx.update(|cx| {
             let test_settings = SettingsStore::test(cx);
             cx.set_global(test_settings);
-            language::init(cx);
             cx.update_global::<SettingsStore, _>(|store, cx| {
                 store.update_user_settings(cx, |s| {
                     s.project.all_languages.defaults.tab_size = NonZeroU32::new(2);
@@ -42,7 +41,6 @@ mod tests {
         cx.update(|cx| {
             let test_settings = SettingsStore::test(cx);
             cx.set_global(test_settings);
-            language::init(cx);
             cx.update_global::<SettingsStore, _>(|store, cx| {
                 store.update_user_settings(cx, |s| {
                     s.project.all_languages.defaults.tab_size = NonZeroU32::new(2);


### PR DESCRIPTION
Related to https://github.com/zed-industries/zed/pull/41670

Release Notes:

- Cleaned up invalid init calls after recent API changes in https://github.com/zed-industries/zed/pull/42238


