### PR TITLE
Reduce macro burden for rust-analyzer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -631,6 +631,7 @@ scap = { git = "https://github.com/zed-industries/scap", rev = "4afea48c3b002197
 schemars = { version = "1.0", features = ["indexmap2"] }
 semver = "1.0"
 serde = { version = "1.0.221", features = ["derive", "rc"] }
+serde_derive = "1.0.221"
 serde_json = { version = "1.0.144", features = ["preserve_order", "raw_value"] }
 serde_json_lenient = { version = "0.2", features = [
     "preserve_order",
@@ -724,6 +725,7 @@ yawc = "0.2.5"
 zeroize = "1.8"
 zstd = "0.11"
 
+
 [workspace.dependencies.windows]
 version = "0.61"
 features = [
@@ -792,6 +794,19 @@ codegen-units = 16
 codegen-units = 16
 
 [profile.dev.package]
+# proc-macros start
+gpui_macros = { opt-level = 3 }
+derive_refineable = { opt-level = 3 }
+settings_macros = { opt-level = 3 }
+sqlez_macros = { opt-level = 3, codegen-units = 1 }
+ui_macros = { opt-level = 3 }
+util_macros = { opt-level = 3 }
+serde_derive = { opt-level = 3 }
+quote = { opt-level = 3 }
+syn = { opt-level = 3 }
+proc-macro2 = { opt-level = 3 }
+# proc-macros end
+
 taffy = { opt-level = 3 }
 cranelift-codegen = { opt-level = 3 }
 cranelift-codegen-meta = { opt-level = 3 }
@@ -833,7 +848,6 @@ semantic_version = { codegen-units = 1 }
 session = { codegen-units = 1 }
 snippet = { codegen-units = 1 }
 snippets_ui = { codegen-units = 1 }
-sqlez_macros = { codegen-units = 1 }
 story = { codegen-units = 1 }
 supermaven_api = { codegen-units = 1 }
 telemetry_events = { codegen-units = 1 }

--- a/crates/gpui/src/styled.rs
+++ b/crates/gpui/src/styled.rs
@@ -13,8 +13,9 @@ const ELLIPSIS: SharedString = SharedString::new_static("…");
 
 /// A trait for elements that can be styled.
 /// Use this to opt-in to a utility CSS-like styling API.
+// gate on rust-analyzer so rust-analyzer never needs to expand this macro, it takes up to 10 seconds to expand due to inefficiencies in rust-analyzers proc-macro srv
 #[cfg_attr(
-    any(feature = "inspector", debug_assertions),
+    all(any(feature = "inspector", debug_assertions), not(rust_analyzer)),
     gpui_macros::derive_inspector_reflection
 )]
 pub trait Styled: Sized {

--- a/crates/gpui_macros/tests/derive_inspector_reflection.rs
+++ b/crates/gpui_macros/tests/derive_inspector_reflection.rs
@@ -1,8 +1,7 @@
 //! This code was generated using Zed Agent with Claude Opus 4.
 
-use gpui_macros::derive_inspector_reflection;
-
-#[derive_inspector_reflection]
+// gate on rust-analyzer so rust-analyzer never needs to expand this macro, it takes up to 10 seconds to expand due to inefficiencies in rust-analyzers proc-macro srv
+#[cfg_attr(not(rust_analyzer), gpui_macros::derive_inspector_reflection)]
 trait Transform: Clone {
     /// Doubles the value
     fn double(self) -> Self;

--- a/crates/ui/src/traits/styled_ext.rs
+++ b/crates/ui/src/traits/styled_ext.rs
@@ -18,7 +18,11 @@ fn elevated_borderless<E: Styled>(this: E, cx: &mut App, index: ElevationIndex) 
 }
 
 /// Extends [`gpui::Styled`] with Zed-specific styling methods.
-#[cfg_attr(debug_assertions, gpui_macros::derive_inspector_reflection)]
+// gate on rust-analyzer so rust-analyzer never needs to expand this macro, it takes up to 10 seconds to expand due to inefficiencies in rust-analyzers proc-macro srv
+#[cfg_attr(
+    all(debug_assertions, not(rust_analyzer)),
+    gpui_macros::derive_inspector_reflection
+)]
 pub trait StyledExt: Styled + Sized {
     /// Horizontally stacks elements.
     ///


### PR DESCRIPTION
This enables optimizations for our own proc-macros as well as some heavy hitters. Additionally this gates the `derive_inspector_reflection` to be skipped  for rust-analyzer as it currently slows down rust-analyzer way too much

Partial workaround for https://github.com/rust-lang/rust-analyzer/issues/21050

Release Notes:

- N/A *or* Added/Fixed/Improved ...
