### PR TITLE
Fix persistence of low severity diagnostics

### DIFF
--- a/crates/collab/src/tests/editor_tests.rs
+++ b/crates/collab/src/tests/editor_tests.rs
@@ -2945,6 +2945,8 @@ async fn test_lsp_pull_diagnostics(
                                     },
                             },
                         ),
+                        // TODO: This clears the pushed diagnostics and causes the next
+                        // editor_b_lib.update call's assertions to fail.
                         lsp::WorkspaceDocumentDiagnosticReport::Full(
                             lsp::WorkspaceFullDocumentDiagnosticReport {
                                 uri: lsp::Uri::from_file_path(path!("/a/lib.rs")).unwrap(),
@@ -3072,13 +3074,12 @@ async fn test_lsp_pull_diagnostics(
             .collect::<Vec<_>>();
         let expected_messages = [
             expected_pull_diagnostic_lib_message,
-            // TODO bug: the pushed diagnostics are not being sent to the client when they open the corresponding buffer.
-            // expected_push_diagnostic_lib_message,
+            expected_push_diagnostic_lib_message,
         ];
         assert_eq!(
             all_diagnostics.len(),
-            1,
-            "Expected pull diagnostics, but got: {all_diagnostics:?}"
+            2,
+            "Expected pull and push diagnostics, but got: {all_diagnostics:?}"
         );
         for diagnostic in all_diagnostics {
             assert!(
@@ -3139,13 +3140,12 @@ async fn test_lsp_pull_diagnostics(
                 .collect::<Vec<_>>();
             let expected_messages = [
                 expected_workspace_pull_diagnostics_lib_message,
-                // TODO bug: the pushed diagnostics are not being sent to the client when they open the corresponding buffer.
-                // expected_push_diagnostic_lib_message,
+                expected_push_diagnostic_lib_message,
             ];
             assert_eq!(
                 all_diagnostics.len(),
-                1,
-                "Expected pull diagnostics, but got: {all_diagnostics:?}"
+                2,
+                "Expected pull and push diagnostics, but got: {all_diagnostics:?}"
             );
             for diagnostic in all_diagnostics {
                 assert!(
@@ -3277,7 +3277,7 @@ async fn test_lsp_pull_diagnostics(
             expected_pull_diagnostic_lib_message,
             expected_push_diagnostic_lib_message,
         ];
-        assert_eq!(all_diagnostics.len(), 1);
+        assert_eq!(all_diagnostics.len(), 2);
         for diagnostic in &all_diagnostics {
             assert!(
                 expected_messages.contains(&diagnostic.diagnostic.message.as_str()),

--- a/crates/collab/src/tests/editor_tests.rs
+++ b/crates/collab/src/tests/editor_tests.rs
@@ -2945,8 +2945,6 @@ async fn test_lsp_pull_diagnostics(
                                     },
                             },
                         ),
-                        // TODO: This clears the pushed diagnostics and causes the next
-                        // editor_b_lib.update call's assertions to fail.
                         lsp::WorkspaceDocumentDiagnosticReport::Full(
                             lsp::WorkspaceFullDocumentDiagnosticReport {
                                 uri: lsp::Uri::from_file_path(path!("/a/lib.rs")).unwrap(),

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -8114,13 +8114,7 @@ impl LspStore {
                     )?;
 
                 update.diagnostics.diagnostics.extend(reused_diagnostics);
-            } else {
-                // Handle non-open buffers.
-                // TODO: This overlaps with `update_worktree_diagnostics`.
-                let local = match &mut self.mode {
-                    LspStoreMode::Local(local_lsp_store) => local_lsp_store,
-                    _ => anyhow::bail!("update_worktree_diagnostics called on remote"),
-                };
+            } else if let Some(local) = self.as_local_mut() {
                 let diagnostics_for_tree = local.diagnostics.entry(worktree_id).or_default();
                 let diagnostics_by_server_id = diagnostics_for_tree
                     .entry(project_path.path.clone())

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -8197,7 +8197,7 @@ impl LspStore {
             .unwrap_or_default();
 
         let new_summary = DiagnosticSummary::new(&diagnostics);
-        if new_summary.is_empty() {
+        if diagnostics.is_empty() {
             if let Some(diagnostics_by_server_id) = diagnostics_for_tree.get_mut(&path_in_worktree)
             {
                 if let Ok(ix) = diagnostics_by_server_id.binary_search_by_key(&server_id, |e| e.0) {


### PR DESCRIPTION
Closes #41935

It seems the issue was not related to the tag, but instead caused when all the diagnostics for a file are `DiagnosticSeverity` `Hint` and/or `Information`. In that case they are cleared because the summary only includes `Warning` and `Error`. 

I tested this following the steps in the issue for the local case, and updated some existing tests for the remote/collab case.

Release Notes:

- Fixed file diagnostics being cleared when none have severity >= warning

