### PR TITLE
zeta2: Output `bucketed_analysis.md`

### DIFF
--- a/crates/zeta_cli/src/evaluate.rs
+++ b/crates/zeta_cli/src/evaluate.rs
@@ -593,7 +593,7 @@ fn write_bucketed_analysis(
             });
     }
 
-    let mut sorted_buckets: Vec<_> = buckets.into_iter().map(|(_, bucket)| bucket).collect();
+    let mut sorted_buckets = buckets.into_values().collect::<Vec<_>>();
     sorted_buckets.sort_by(|a, b| match (a.is_correct, b.is_correct) {
         (true, false) => std::cmp::Ordering::Less,
         (false, true) => std::cmp::Ordering::Greater,


### PR DESCRIPTION
Closes #ISSUE

Makes it so that a file named `bucketed_analysis.md` is written to the runs directory after an eval is ran with > 1 repetitions. This file buckets the predictions made by the model by comparing the edits made so that seeing how many times different failure modes were encountered becomes much easier.

Release Notes:

- N/A *or* Added/Fixed/Improved ...
