### PR TITLE
vim: Change approach to fixing vim's temporary mode bug

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -3024,6 +3024,10 @@ impl Editor {
         range.clone()
     }
 
+    pub fn clip_at_line_ends(&mut self, cx: &mut Context<Self>) -> bool {
+        self.display_map.read(cx).clip_at_line_ends
+    }
+
     pub fn set_clip_at_line_ends(&mut self, clip: bool, cx: &mut Context<Self>) {
         if self.display_map.read(cx).clip_at_line_ends != clip {
             self.display_map

--- a/crates/vim/src/normal/scroll.rs
+++ b/crates/vim/src/normal/scroll.rs
@@ -96,7 +96,7 @@ impl Vim {
     ) {
         let amount = by(Vim::take_count(cx).map(|c| c as f32));
         Vim::take_forced_motion(cx);
-        self.exit_temporary_normal(None, window, cx);
+        self.exit_temporary_normal(window, cx);
         self.update_editor(cx, |_, editor, cx| {
             scroll_editor(editor, move_cursor, amount, window, cx)
         });

--- a/crates/vim/src/normal/yank.rs
+++ b/crates/vim/src/normal/yank.rs
@@ -59,7 +59,7 @@ impl Vim {
                 });
             });
         });
-        self.exit_temporary_normal(None, window, cx);
+        self.exit_temporary_normal(window, cx);
     }
 
     pub fn yank_object(
@@ -90,7 +90,7 @@ impl Vim {
                 });
             });
         });
-        self.exit_temporary_normal(None, window, cx);
+        self.exit_temporary_normal(window, cx);
     }
 
     pub fn yank_selections_content(


### PR DESCRIPTION
The `Vim.exit_temporary_normal` method had been updated (https://github.com/zed-industries/zed/pull/42742) to expect and `Option<&Motion>` that would then be used to determine whether to move the cursor right in case the motion was `Some(EndOfLine { ..})`. Unfortunately this meant that all callers now had to provide this argument, even if just `None`.

After merging those changes I remember that we could probably play around with `clip_at_line_ends` so this commit removes those intial changes in favor of updating the `vim::normal::Vim.move_cursor` method so that, if vim is in temporary mode and `EndOfLine` is used, it disables clipping at line ends so that the newline character can be selected.

Closes [#42278](https://github.com/zed-industries/zed/issues/42278)

Release Notes:

- N/A
