### PR TITLE
Fix stale edits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14034,6 +14034,7 @@ dependencies = [
  "paths",
  "pretty_assertions",
  "project",
+ "prompt_store",
  "proto",
  "rayon",
  "release_channel",

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -607,6 +607,8 @@ pub struct Thread {
     pub(crate) prompt_capabilities_rx: watch::Receiver<acp::PromptCapabilities>,
     pub(crate) project: Entity<Project>,
     pub(crate) action_log: Entity<ActionLog>,
+    /// Tracks the last time files were read by the agent, to detect external modifications
+    pub(crate) file_read_times: HashMap<PathBuf, fs::MTime>,
 }
 
 impl Thread {
@@ -665,6 +667,7 @@ impl Thread {
             prompt_capabilities_rx,
             project,
             action_log,
+            file_read_times: HashMap::default(),
         }
     }
 
@@ -860,6 +863,7 @@ impl Thread {
             updated_at: db_thread.updated_at,
             prompt_capabilities_tx,
             prompt_capabilities_rx,
+            file_read_times: HashMap::default(),
         }
     }
 

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1003,6 +1003,7 @@ impl Thread {
         self.add_tool(NowTool);
         self.add_tool(OpenTool::new(self.project.clone()));
         self.add_tool(ReadFileTool::new(
+            cx.weak_entity(),
             self.project.clone(),
             self.action_log.clone(),
         ));

--- a/crates/agent/src/tools/edit_file_tool.rs
+++ b/crates/agent/src/tools/edit_file_tool.rs
@@ -311,7 +311,7 @@ impl AgentTool for EditFileTool {
 
             // Check if the file has been modified since the agent last read it
             if let Some(abs_path) = abs_path.as_ref() {
-                let (last_read_mtime, current_mtime) = self.thread.update(cx, |thread, cx| {
+                let (last_read_mtime, current_mtime) = self.thread.update(cx, |thread, cx| -> Result<_> {
                     // Check for unsaved changes first - these indicate modifications we don't know about
                     if buffer.read(cx).is_dirty() {
                         anyhow::bail!(

--- a/crates/agent/src/tools/edit_file_tool.rs
+++ b/crates/agent/src/tools/edit_file_tool.rs
@@ -318,6 +318,16 @@ impl AgentTool for EditFileTool {
                     (last_read, current, dirty)
                 })?;
 
+                // Check for unsaved changes first - these indicate modifications we don't know about
+                if is_dirty {
+                    anyhow::bail!(
+                        "The file {} has unsaved changes. \
+                         Please read the file again to get the current state before editing it.",
+                        input.path.display()
+                    );
+                }
+
+                // Check if the file was modified on disk since we last read it
                 if let (Some(last_read), Some(current)) = (last_read_mtime, current_mtime) {
                     // MTime can be unreliable for comparisons, so our newtype intentionally
                     // doesn't support comparing them. If the mtime at all different
@@ -330,13 +340,6 @@ impl AgentTool for EditFileTool {
                             input.path.display()
                         );
                     }
-                } else if is_dirty {
-                    // If the buffer has unsaved changes, that also means it was modified.
-                    anyhow::bail!(
-                        "The file {} has unsaved changes. \
-                         Please read the file again to get the current state before editing it.",
-                        input.path.display()
-                    );
                 }
             }
 

--- a/crates/agent/src/tools/edit_file_tool.rs
+++ b/crates/agent/src/tools/edit_file_tool.rs
@@ -1960,7 +1960,9 @@ mod tests {
             });
 
             cx.executor().run_until_parked();
-            model.send_last_completion_stream_text_chunk("<old_text>original</old_text><new_text>modified</new_text>".to_string());
+            model.send_last_completion_stream_text_chunk(
+                "<old_text>original</old_text><new_text>modified</new_text>".to_string(),
+            );
             model.end_last_completion_stream();
 
             edit_task.await
@@ -1982,12 +1984,17 @@ mod tests {
             });
 
             cx.executor().run_until_parked();
-            model.send_last_completion_stream_text_chunk("<old_text>modified</old_text><new_text>further modified</new_text>".to_string());
+            model.send_last_completion_stream_text_chunk(
+                "<old_text>modified</old_text><new_text>further modified</new_text>".to_string(),
+            );
             model.end_last_completion_stream();
 
             edit_task.await
         };
-        assert!(edit_result.is_ok(), "Second consecutive edit should succeed");
+        assert!(
+            edit_result.is_ok(),
+            "Second consecutive edit should succeed"
+        );
     }
 
     #[gpui::test]

--- a/crates/agent/src/tools/edit_file_tool.rs
+++ b/crates/agent/src/tools/edit_file_tool.rs
@@ -324,7 +324,7 @@ impl AgentTool for EditFileTool {
                     let last_read = thread.file_read_times.get(abs_path).copied();
                     let current = buffer.read(cx).file().and_then(|file| file.disk_state().mtime());
                     Ok((last_read, current))
-                })?;
+                })??;
 
                 // Check if the file was modified on disk since we last read it
                 if let (Some(last_read), Some(current)) = (last_read_mtime, current_mtime) {

--- a/crates/agent/src/tools/edit_file_tool.rs
+++ b/crates/agent/src/tools/edit_file_tool.rs
@@ -312,20 +312,20 @@ impl AgentTool for EditFileTool {
             // Check if the file has been modified since the agent last read it
             if let Some(abs_path) = abs_path.as_ref() {
                 let (last_read_mtime, current_mtime, is_dirty) = self.thread.update(cx, |thread, cx| {
-                    let last_read = thread.file_read_times.get(abs_path).copied();
+                    // Check for unsaved changes first - these indicate modifications we don't know about
+                    if buffer.read(cx).is_dirty() {
+                        anyhow::bail!(
+                            "The file {} has unsaved changes. \
+                             Please read the file again to get the current state before editing it.",
+                            input.path.display()
+                        );
+                    }
+
                     let current = buffer.read(cx).file().and_then(|file| file.disk_state().mtime());
-                    let dirty = buffer.read(cx).is_dirty();
+                    let last_read = thread.file_read_times.get(abs_path).copied();
                     (last_read, current, dirty)
                 })?;
 
-                // Check for unsaved changes first - these indicate modifications we don't know about
-                if is_dirty {
-                    anyhow::bail!(
-                        "The file {} has unsaved changes. \
-                         Please read the file again to get the current state before editing it.",
-                        input.path.display()
-                    );
-                }
 
                 // Check if the file was modified on disk since we last read it
                 if let (Some(last_read), Some(current)) = (last_read_mtime, current_mtime) {

--- a/crates/agent/src/tools/edit_file_tool.rs
+++ b/crates/agent/src/tools/edit_file_tool.rs
@@ -323,7 +323,7 @@ impl AgentTool for EditFileTool {
 
                     let last_read = thread.file_read_times.get(abs_path).copied();
                     let current = buffer.read(cx).file().and_then(|file| file.disk_state().mtime());
-                    (last_read, current)
+                    Ok((last_read, current))
                 })?;
 
                 // Check if the file was modified on disk since we last read it

--- a/crates/agent/src/tools/edit_file_tool.rs
+++ b/crates/agent/src/tools/edit_file_tool.rs
@@ -321,9 +321,9 @@ impl AgentTool for EditFileTool {
                 // Check for unsaved changes first - these indicate modifications we don't know about
                 if is_dirty {
                     anyhow::bail!(
-                        "The file {} has unsaved changes. \
-                         Please read the file again to get the current state before editing it.",
-                        input.path.display()
+                        "This file cannot be written to because it has unsaved changes. \
+                         Please end the current conversation immediately by telling the user you want to write to this file (mention its path explicitly) but you can't write to it because it has unsaved changes. \
+                         Ask the user to save that buffer's changes and to inform you when it's ok to proceed."
                     );
                 }
 
@@ -2210,7 +2210,7 @@ mod tests {
         assert!(result.is_err(), "Edit should fail when buffer is dirty");
         let error_msg = result.unwrap_err().to_string();
         assert!(
-            error_msg.contains("has unsaved changes"),
+            error_msg.contains("cannot be written to because it has unsaved changes"),
             "Error should mention unsaved changes, got: {}",
             error_msg
         );

--- a/crates/agent/src/tools/edit_file_tool.rs
+++ b/crates/agent/src/tools/edit_file_tool.rs
@@ -2084,6 +2084,8 @@ mod tests {
             .update(cx, |buffer, cx| buffer.reload(cx))
             .await
             .unwrap();
+        
+        cx.executor().run_until_parked();
 
         // Try to edit - should fail because file was modified externally
         let result = cx

--- a/crates/agent/src/tools/edit_file_tool.rs
+++ b/crates/agent/src/tools/edit_file_tool.rs
@@ -311,7 +311,7 @@ impl AgentTool for EditFileTool {
 
             // Check if the file has been modified since the agent last read it
             if let Some(abs_path) = abs_path.as_ref() {
-                let (last_read_mtime, current_mtime, is_dirty) = self.thread.update(cx, |thread, cx| {
+                let (last_read_mtime, current_mtime) = self.thread.update(cx, |thread, cx| {
                     // Check for unsaved changes first - these indicate modifications we don't know about
                     if buffer.read(cx).is_dirty() {
                         anyhow::bail!(
@@ -321,11 +321,10 @@ impl AgentTool for EditFileTool {
                         );
                     }
 
-                    let current = buffer.read(cx).file().and_then(|file| file.disk_state().mtime());
                     let last_read = thread.file_read_times.get(abs_path).copied();
-                    (last_read, current, dirty)
+                    let current = buffer.read(cx).file().and_then(|file| file.disk_state().mtime());
+                    (last_read, current)
                 })?;
-
 
                 // Check if the file was modified on disk since we last read it
                 if let (Some(last_read), Some(current)) = (last_read_mtime, current_mtime) {
@@ -1889,7 +1888,6 @@ mod tests {
             cx.set_global(settings_store);
         });
     }
-}
 
     #[gpui::test]
     async fn test_consecutive_edits_work(cx: &mut TestAppContext) {
@@ -2201,3 +2199,4 @@ mod tests {
             error_msg
         );
     }
+}

--- a/crates/agent/src/tools/edit_file_tool.rs
+++ b/crates/agent/src/tools/edit_file_tool.rs
@@ -1962,13 +1962,17 @@ mod tests {
 
             cx.executor().run_until_parked();
             model.send_last_completion_stream_text_chunk(
-                "<old_text>original</old_text><new_text>modified</new_text>".to_string(),
+                "<old_text>original content</old_text><new_text>modified content</new_text>".to_string(),
             );
             model.end_last_completion_stream();
 
             edit_task.await
         };
-        assert!(edit_result.is_ok(), "First edit should succeed");
+        assert!(
+            edit_result.is_ok(),
+            "First edit should succeed, got error: {:?}",
+            edit_result.as_ref().err()
+        );
 
         // Second edit should also work because the edit updated the recorded read time
         let edit_result = {
@@ -1986,7 +1990,7 @@ mod tests {
 
             cx.executor().run_until_parked();
             model.send_last_completion_stream_text_chunk(
-                "<old_text>modified</old_text><new_text>further modified</new_text>".to_string(),
+                "<old_text>modified content</old_text><new_text>further modified content</new_text>".to_string(),
             );
             model.end_last_completion_stream();
 
@@ -1994,7 +1998,8 @@ mod tests {
         };
         assert!(
             edit_result.is_ok(),
-            "Second consecutive edit should succeed"
+            "Second consecutive edit should succeed, got error: {:?}",
+            edit_result.as_ref().err()
         );
     }
 

--- a/crates/agent/src/tools/edit_file_tool.rs
+++ b/crates/agent/src/tools/edit_file_tool.rs
@@ -1962,7 +1962,8 @@ mod tests {
 
             cx.executor().run_until_parked();
             model.send_last_completion_stream_text_chunk(
-                "<old_text>original content</old_text><new_text>modified content</new_text>".to_string(),
+                "<old_text>original content</old_text><new_text>modified content</new_text>"
+                    .to_string(),
             );
             model.end_last_completion_stream();
 
@@ -2084,7 +2085,7 @@ mod tests {
             .update(cx, |buffer, cx| buffer.reload(cx))
             .await
             .unwrap();
-        
+
         cx.executor().run_until_parked();
 
         // Try to edit - should fail because file was modified externally

--- a/crates/agent/src/tools/read_file_tool.rs
+++ b/crates/agent/src/tools/read_file_tool.rs
@@ -302,9 +302,12 @@ impl AgentTool for ReadFileTool {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::{ContextServerRegistry, Templates, Thread};
     use gpui::{AppContext, TestAppContext, UpdateGlobal as _};
     use language::{Language, LanguageConfig, LanguageMatcher, tree_sitter_rust};
+    use language_model::fake_provider::FakeLanguageModel;
     use project::{FakeFs, Project};
+    use prompt_store::ProjectContext;
     use serde_json::json;
     use settings::SettingsStore;
     use util::path;
@@ -317,7 +320,20 @@ mod test {
         fs.insert_tree(path!("/root"), json!({})).await;
         let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
         let action_log = cx.new(|_| ActionLog::new(project.clone()));
-        let tool = Arc::new(ReadFileTool::new(project, action_log));
+        let context_server_registry =
+            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
+        let model = Arc::new(FakeLanguageModel::default());
+        let thread = cx.new(|cx| {
+            Thread::new(
+                project.clone(),
+                cx.new(|_cx| ProjectContext::default()),
+                context_server_registry,
+                Templates::new(),
+                Some(model),
+                cx,
+            )
+        });
+        let tool = Arc::new(ReadFileTool::new(thread.downgrade(), project, action_log));
         let (event_stream, _) = ToolCallEventStream::test();
 
         let result = cx
@@ -350,7 +366,20 @@ mod test {
         .await;
         let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
         let action_log = cx.new(|_| ActionLog::new(project.clone()));
-        let tool = Arc::new(ReadFileTool::new(project, action_log));
+        let context_server_registry =
+            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
+        let model = Arc::new(FakeLanguageModel::default());
+        let thread = cx.new(|cx| {
+            Thread::new(
+                project.clone(),
+                cx.new(|_cx| ProjectContext::default()),
+                context_server_registry,
+                Templates::new(),
+                Some(model),
+                cx,
+            )
+        });
+        let tool = Arc::new(ReadFileTool::new(thread.downgrade(), project, action_log));
         let result = cx
             .update(|cx| {
                 let input = ReadFileToolInput {
@@ -380,7 +409,20 @@ mod test {
         let language_registry = project.read_with(cx, |project, _| project.languages().clone());
         language_registry.add(Arc::new(rust_lang()));
         let action_log = cx.new(|_| ActionLog::new(project.clone()));
-        let tool = Arc::new(ReadFileTool::new(project, action_log));
+        let context_server_registry =
+            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
+        let model = Arc::new(FakeLanguageModel::default());
+        let thread = cx.new(|cx| {
+            Thread::new(
+                project.clone(),
+                cx.new(|_cx| ProjectContext::default()),
+                context_server_registry,
+                Templates::new(),
+                Some(model),
+                cx,
+            )
+        });
+        let tool = Arc::new(ReadFileTool::new(thread.downgrade(), project, action_log));
         let result = cx
             .update(|cx| {
                 let input = ReadFileToolInput {
@@ -452,7 +494,20 @@ mod test {
         let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
 
         let action_log = cx.new(|_| ActionLog::new(project.clone()));
-        let tool = Arc::new(ReadFileTool::new(project, action_log));
+        let context_server_registry =
+            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
+        let model = Arc::new(FakeLanguageModel::default());
+        let thread = cx.new(|cx| {
+            Thread::new(
+                project.clone(),
+                cx.new(|_cx| ProjectContext::default()),
+                context_server_registry,
+                Templates::new(),
+                Some(model),
+                cx,
+            )
+        });
+        let tool = Arc::new(ReadFileTool::new(thread.downgrade(), project, action_log));
         let result = cx
             .update(|cx| {
                 let input = ReadFileToolInput {
@@ -480,7 +535,20 @@ mod test {
         .await;
         let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
         let action_log = cx.new(|_| ActionLog::new(project.clone()));
-        let tool = Arc::new(ReadFileTool::new(project, action_log));
+        let context_server_registry =
+            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
+        let model = Arc::new(FakeLanguageModel::default());
+        let thread = cx.new(|cx| {
+            Thread::new(
+                project.clone(),
+                cx.new(|_cx| ProjectContext::default()),
+                context_server_registry,
+                Templates::new(),
+                Some(model),
+                cx,
+            )
+        });
+        let tool = Arc::new(ReadFileTool::new(thread.downgrade(), project, action_log));
 
         // start_line of 0 should be treated as 1
         let result = cx
@@ -624,7 +692,20 @@ mod test {
 
         let project = Project::test(fs.clone(), [path!("/project_root").as_ref()], cx).await;
         let action_log = cx.new(|_| ActionLog::new(project.clone()));
-        let tool = Arc::new(ReadFileTool::new(project, action_log));
+        let context_server_registry =
+            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
+        let model = Arc::new(FakeLanguageModel::default());
+        let thread = cx.new(|cx| {
+            Thread::new(
+                project.clone(),
+                cx.new(|_cx| ProjectContext::default()),
+                context_server_registry,
+                Templates::new(),
+                Some(model),
+                cx,
+            )
+        });
+        let tool = Arc::new(ReadFileTool::new(thread.downgrade(), project, action_log));
 
         // Reading a file outside the project worktree should fail
         let result = cx
@@ -838,7 +919,24 @@ mod test {
         .await;
 
         let action_log = cx.new(|_| ActionLog::new(project.clone()));
-        let tool = Arc::new(ReadFileTool::new(project.clone(), action_log.clone()));
+        let context_server_registry =
+            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
+        let model = Arc::new(FakeLanguageModel::default());
+        let thread = cx.new(|cx| {
+            Thread::new(
+                project.clone(),
+                cx.new(|_cx| ProjectContext::default()),
+                context_server_registry,
+                Templates::new(),
+                Some(model),
+                cx,
+            )
+        });
+        let tool = Arc::new(ReadFileTool::new(
+            thread.downgrade(),
+            project.clone(),
+            action_log.clone(),
+        ));
 
         // Test reading allowed files in worktree1
         let result = cx

--- a/crates/agent/src/tools/read_file_tool.rs
+++ b/crates/agent/src/tools/read_file_tool.rs
@@ -310,6 +310,7 @@ mod test {
     use prompt_store::ProjectContext;
     use serde_json::json;
     use settings::SettingsStore;
+    use std::sync::Arc;
     use util::path;
 
     #[gpui::test]

--- a/crates/agent/src/tools/read_file_tool.rs
+++ b/crates/agent/src/tools/read_file_tool.rs
@@ -201,6 +201,17 @@ impl AgentTool for ReadFileTool {
                 anyhow::bail!("{file_path} not found");
             }
 
+            // Record the file read time and mtime
+            if let Some(mtime) = buffer.read_with(cx, |buffer, _| {
+                buffer.file().and_then(|file| file.disk_state().mtime())
+            })? {
+                self.thread
+                    .update(cx, |thread, _| {
+                        thread.file_read_times.insert(abs_path.to_path_buf(), mtime);
+                    })
+                    .ok();
+            }
+
             let mut anchor = None;
 
             // Check if specific line ranges are provided

--- a/crates/agent/src/tools/read_file_tool.rs
+++ b/crates/agent/src/tools/read_file_tool.rs
@@ -12,7 +12,7 @@ use settings::Settings;
 use std::sync::Arc;
 use util::markdown::MarkdownCodeBlock;
 
-use crate::{AgentTool, ToolCallEventStream, outline};
+use crate::{AgentTool, Thread, ToolCallEventStream, outline};
 
 /// Reads the content of the given file in the project.
 ///

--- a/crates/agent/src/tools/read_file_tool.rs
+++ b/crates/agent/src/tools/read_file_tool.rs
@@ -1,7 +1,7 @@
 use action_log::ActionLog;
 use agent_client_protocol::{self as acp, ToolCallUpdateFields};
 use anyhow::{Context as _, Result, anyhow};
-use gpui::{App, Entity, SharedString, Task};
+use gpui::{App, Entity, SharedString, Task, WeakEntity};
 use indoc::formatdoc;
 use language::Point;
 use language_model::{LanguageModelImage, LanguageModelToolResultContent};
@@ -42,13 +42,19 @@ pub struct ReadFileToolInput {
 }
 
 pub struct ReadFileTool {
+    thread: WeakEntity<Thread>,
     project: Entity<Project>,
     action_log: Entity<ActionLog>,
 }
 
 impl ReadFileTool {
-    pub fn new(project: Entity<Project>, action_log: Entity<ActionLog>) -> Self {
+    pub fn new(
+        thread: WeakEntity<Thread>,
+        project: Entity<Project>,
+        action_log: Entity<ActionLog>,
+    ) -> Self {
         Self {
+            thread,
             project,
             action_log,
         }

--- a/crates/remote_server/Cargo.toml
+++ b/crates/remote_server/Cargo.toml
@@ -94,6 +94,7 @@ project = { workspace = true, features = ["test-support"] }
 remote = { workspace = true, features = ["test-support"] }
 language_model = { workspace = true, features = ["test-support"] }
 lsp = { workspace = true, features = ["test-support"] }
+prompt_store.workspace = true
 unindent.workspace = true
 serde_json.workspace = true
 zlog.workspace = true


### PR DESCRIPTION
Closes #34069

<img width="532" height="880" alt="Screenshot 2025-11-17 at 11 14 19 AM" src="https://github.com/user-attachments/assets/abc50c32-d54d-4310-a6e6-83008db7ed81" />

<img width="525" height="863" alt="Screenshot 2025-11-17 at 12 22 50 PM" src="https://github.com/user-attachments/assets/15a69792-c2c7-4727-add9-c1f9baa5e665" />

Release Notes:

- Agent file edits now error if the file has changed since last read (allowing the agent to read changes and avoid overwriting changes made outside Zed)
