### PR TITLE
editor: Fix prepaint recursion when updating stale sizes

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -8794,10 +8794,22 @@ impl EditorElement {
 
 #[derive(Default)]
 pub struct EditorRequestLayoutState {
+    // We use prepaint depth to limit the number of times prepaint is
+    // called recursively. We need this so that we can update stale
+    // data for e.g. block heights in block map.
     prepaint_depth: Rc<Cell<usize>>,
 }
 
 impl EditorRequestLayoutState {
+    // Ideally we should have this number set to 2. Since the first prepaint calculates
+    // new heights for blocks, and the second one simply uses them without any resize.
+    //
+    // But, in some cases we might be introduced to a new custom block in the second prepaint
+    // phase and now we first need to calculate new height for this block, and subsequently
+    // call prepaint again.
+    //
+    // We still need to investigate the appearance of this block in the second prepaint.
+    // test_random_diagnostics_blocks fails if you set this to 2.
     const MAX_PREPAINT_DEPTH: usize = 3;
 
     fn increment_prepaint_depth(&self) -> EditorPrepaintGuard {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -8801,16 +8801,12 @@ pub struct EditorRequestLayoutState {
 }
 
 impl EditorRequestLayoutState {
-    // Ideally we should have this number set to 2. Since the first prepaint calculates
-    // new heights for blocks, and the second one simply uses them without any resize.
-    //
-    // But, in some cases we might be introduced to a new custom block in the second prepaint
-    // phase and now we first need to calculate new height for this block, and subsequently
-    // call prepaint again.
-    //
-    // We still need to investigate the appearance of this block in the second prepaint.
-    // test_random_diagnostics_blocks fails if you set this to 2.
-    const MAX_PREPAINT_DEPTH: usize = 3;
+    // In ideal conditions we only need one more subsequent prepaint call for resize to take effect.
+    // i.e. MAX_PREPAINT_DEPTH = 2, but since moving blocks inline (place_near), more lines from
+    // below get exposed, and we end up querying blocks for those lines too in subsequent renders.
+    // Setting MAX_PREPAINT_DEPTH = 3, passes all tests. Just to be on the safe side we set it to 5, so
+    // that subsequent shrinking does not lead to incorrect block placing.
+    const MAX_PREPAINT_DEPTH: usize = 5;
 
     fn increment_prepaint_depth(&self) -> EditorPrepaintGuard {
         let depth = self.prepaint_depth.get();

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -9448,7 +9448,7 @@ impl Element for EditorElement {
                                 cx,
                             );
                         } else {
-                            log::debug!(
+                            debug_panic!(
                                 "skipping recursive prepaint at max depth. renderer widths may be stale."
                             );
                         }
@@ -9562,7 +9562,7 @@ impl Element for EditorElement {
                                 cx,
                             );
                         } else {
-                            log::debug!(
+                            debug_panic!(
                                 "skipping recursive prepaint at max depth. block layout may be stale."
                             );
                         }


### PR DESCRIPTION
The bug is in the `place_near` logic, specifically the `!row_block_types.contains_key(&(row - 1))` check. The problem isn’t really that condition itself, but it’s that it relies on `row_block_types`, which does not take into account that upon block resizes, subsequent block start row moves up/down. Since `place_near` depends on this incorrect map, it ends up causing incorrect resize syncs to the block map, which then triggers more bad recursive calls. The reason it worked till now in most of the cases is that recursive resizes eventually lead to stabilizing it.

Before `place_near`, we never touched `row_block_types` during the first prepaint pass because we knew it was based on outdated heights. Once all heights are finalized, using it is fine.

The fix is to make sure `row_block_types` is accurate from the very first prepaint pass by keeping an offset whenever a block shrinks or expands. Now ideally it should take only one subsequent prepaint. But due to shrinking, new custom/diagnostics blocks might come into the view from below, which needs further prepaint calls for resolving. Right now, tests pass after 2 subsequent prepaint calls. Just to be safe, we have set it to 5.

<img width="500"  alt="image" src="https://github.com/user-attachments/assets/da3d32ff-5972-46d9-8597-b438e162552b" />

Release Notes:

- Fix issue where sometimes Zed used to experience freeze while working with inline diagnostics.
