### PR TITLE
editor: Fix hover items becoming stale after switching tabs

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -21999,6 +21999,8 @@ impl Editor {
             self.hide_context_menu(window, cx);
         }
         self.take_active_edit_prediction(cx);
+        self.set_gutter_hovered(false, cx);
+        self.gutter_breakpoint_indicator = (None, None);
         cx.emit(EditorEvent::Blurred);
         cx.notify();
     }

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -789,10 +789,14 @@ impl Item for Editor {
     fn deactivated(&mut self, _: &mut Window, cx: &mut Context<Self>) {
         let selection = self.selections.newest_anchor();
         self.push_to_nav_history(selection.head(), None, true, false, cx);
+        self.set_gutter_hovered(false, cx);
+        self.gutter_breakpoint_indicator = (None, None);
     }
 
     fn workspace_deactivated(&mut self, _: &mut Window, cx: &mut Context<Self>) {
         self.hide_hovered_link(cx);
+        self.set_gutter_hovered(false, cx);
+        self.gutter_breakpoint_indicator = (None, None);
     }
 
     fn is_dirty(&self, cx: &App) -> bool {


### PR DESCRIPTION
Closes #42073

**Summary**
The gutter breakpoint/debug indicator could remain visible after switching away from an editor tab and returning. Hover state (and the phantom breakpoint indicator debounce task) was not cleared on blur/deactivation, so the last hover-derived UI state was reused without a fresh mouse event.

**Changes made**
- On editor blur (`handle_blur`) and item/workspace deactivation (`items.rs`), explicitly:
  - Clear gutter hover: `set_gutter_hovered(false, cx)`
  - Reset phantom breakpoint indicator: `gutter_breakpoint_indicator = (None, None)`
- This ensures no lingering symbol when returning to the tab.

**Verification Steps**
1. Open a file with gutter enabled.
2. Hover gutter: breakpoint/debug indicator appears.
3. Switch to another tab.
4. Move mouse away (not hovering gutter anywhere).
5. Return to original tab.
6. Indicator should be gone immediately.

**Screen recording**

https://github.com/user-attachments/assets/d784e78a-21a4-44d2-884f-f1b49efdb4da



Release Notes:

- N/A *or* Added/Fixed/Improved ...
