### PR TITLE
Fix formatting in various files

### DIFF
--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -143,9 +143,11 @@ impl LanguageModelProvider for CopilotChatLanguageModelProvider {
         };
 
         let Some(copilot) = Copilot::global(cx) else {
-            return Task::ready( Err(anyhow!(
-                "Copilot must be enabled for Copilot Chat to work. Please enable Copilot and try again."
-            ).into()));
+            return Task::ready(Err(anyhow!(concat!(
+                "Copilot must be enabled for Copilot Chat to work. ",
+                "Please enable Copilot and try again."
+            ))
+            .into()));
         };
 
         let err = match copilot.read(cx).status() {

--- a/crates/languages/src/bash.rs
+++ b/crates/languages/src/bash.rs
@@ -44,7 +44,11 @@ mod tests {
 
             let expect_indents_to =
                 |buffer: &mut Buffer, cx: &mut Context<Buffer>, input: &str, expected: &str| {
-                    buffer.edit( [(0..buffer.len(), input)], Some(AutoindentMode::EachLine), cx, );
+                    buffer.edit(
+                        [(0..buffer.len(), input)],
+                        Some(AutoindentMode::EachLine),
+                        cx,
+                    );
                     assert_eq!(buffer.text(), expected);
                 };
 

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1653,21 +1653,24 @@ impl ProjectPanel {
 
             match new_entry {
                 Err(e) => {
-                    project_panel.update_in( cx, |project_panel, window, cx| {
-                        project_panel.marked_entries.clear();
-                        project_panel.update_visible_entries(None, false, false, window, cx);
-                    }).ok();
+                    project_panel
+                        .update_in(cx, |project_panel, window, cx| {
+                            project_panel.marked_entries.clear();
+                            project_panel.update_visible_entries(None, false, false, window, cx);
+                        })
+                        .ok();
                     Err(e)?;
                 }
                 Ok(CreatedEntry::Included(new_entry)) => {
-                    project_panel.update_in( cx, |project_panel, window, cx| {
+                    project_panel.update_in(cx, |project_panel, window, cx| {
                         if let Some(selection) = &mut project_panel.state.selection
-                            && selection.entry_id == edited_entry_id {
-                                selection.worktree_id = worktree_id;
-                                selection.entry_id = new_entry.id;
-                                project_panel.marked_entries.clear();
-                                project_panel.expand_to_selection(cx);
-                            }
+                            && selection.entry_id == edited_entry_id
+                        {
+                            selection.worktree_id = worktree_id;
+                            selection.entry_id = new_entry.id;
+                            project_panel.marked_entries.clear();
+                            project_panel.expand_to_selection(cx);
+                        }
                         project_panel.update_visible_entries(None, false, false, window, cx);
                         if is_new_entry && !is_dir {
                             let settings = ProjectPanelSettings::get_global(cx);
@@ -1688,7 +1691,14 @@ impl ProjectPanel {
                                 project_panel.project.update(cx, |_, cx| {
                                     cx.emit(project::Event::Toast {
                                         notification_id: "excluded-directory".into(),
-                                        message: format!("Created an excluded directory at {abs_path:?}.\nAlter `file_scan_exclusions` in the settings to show it in the panel")
+                                        message: format!(
+                                            concat!(
+                                                "Created an excluded directory at {:?}.\n",
+                                                "Alter `file_scan_exclusions` in the settings ",
+                                                "to show it in the panel"
+                                            ),
+                                            abs_path
+                                        ),
                                     })
                                 });
                                 None
@@ -1696,7 +1706,15 @@ impl ProjectPanel {
                                 project_panel
                                     .workspace
                                     .update(cx, |workspace, cx| {
-                                        workspace.open_abs_path(abs_path, OpenOptions { visible: Some(OpenVisible::All), ..Default::default() }, window, cx)
+                                        workspace.open_abs_path(
+                                            abs_path,
+                                            OpenOptions {
+                                                visible: Some(OpenVisible::All),
+                                                ..Default::default()
+                                            },
+                                            window,
+                                            cx,
+                                        )
                                     })
                                     .ok()
                             }
@@ -3600,32 +3618,44 @@ impl ProjectPanel {
         cx.spawn_in(window, async move |this, cx| {
             async move {
                 for (filename, original_path) in &paths_to_replace {
-                    let answer = cx.update(|window, cx| {
-                        window
-                            .prompt(
+                    let prompt_message = format!(
+                        concat!(
+                            "A file or folder with name {} ",
+                            "already exists in the destination folder. ",
+                            "Do you want to replace it?"
+                        ),
+                        filename
+                    );
+                    let answer = cx
+                        .update(|window, cx| {
+                            window.prompt(
                                 PromptLevel::Info,
-                                format!("A file or folder with name {filename} already exists in the destination folder. Do you want to replace it?").as_str(),
+                                &prompt_message,
                                 None,
                                 &["Replace", "Cancel"],
                                 cx,
                             )
-                    })?.await?;
+                        })?
+                        .await?;
 
                     if answer == 1
-                        && let Some(item_idx) = paths.iter().position(|p| p == original_path) {
-                            paths.remove(item_idx);
-                        }
+                        && let Some(item_idx) = paths.iter().position(|p| p == original_path)
+                    {
+                        paths.remove(item_idx);
+                    }
                 }
 
                 if paths.is_empty() {
                     return Ok(());
                 }
 
-                let task = worktree.update( cx, |worktree, cx| {
+                let task = worktree.update(cx, |worktree, cx| {
                     worktree.copy_external_entries(target_directory, paths, fs, cx)
                 })?;
 
-                let opened_entries = task.await.with_context(|| "failed to copy external paths")?;
+                let opened_entries = task
+                    .await
+                    .with_context(|| "failed to copy external paths")?;
                 this.update(cx, |this, cx| {
                     if open_file_after_drop && !opened_entries.is_empty() {
                         let settings = ProjectPanelSettings::get_global(cx);
@@ -3635,7 +3665,8 @@ impl ProjectPanel {
                     }
                 })
             }
-            .log_err().await
+            .log_err()
+            .await
         })
         .detach();
     }

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -7306,14 +7306,9 @@ pub fn join_channel(
 ) -> Task<Result<()>> {
     let active_call = ActiveCall::global(cx);
     cx.spawn(async move |cx| {
-        let result = join_channel_internal(
-            channel_id,
-            &app_state,
-            requesting_window,
-            &active_call,
-             cx,
-        )
-            .await;
+        let result =
+            join_channel_internal(channel_id, &app_state, requesting_window, &active_call, cx)
+                .await;
 
         // join channel succeeded, and opened a window
         if matches!(result, Ok(true)) {
@@ -7321,8 +7316,7 @@ pub fn join_channel(
         }
 
         // find an existing workspace to focus and show call controls
-        let mut active_window =
-            requesting_window.or_else(|| activate_any_workspace_window( cx));
+        let mut active_window = requesting_window.or_else(|| activate_any_workspace_window(cx));
         if active_window.is_none() {
             // no open workspaces, make one to show the error in (blergh)
             let (window_handle, _) = cx
@@ -7334,7 +7328,8 @@ pub fn join_channel(
             if result.is_ok() {
                 cx.update(|cx| {
                     cx.dispatch_action(&OpenChannelNotes);
-                }).log_err();
+                })
+                .log_err();
             }
 
             active_window = Some(window_handle);
@@ -7346,19 +7341,25 @@ pub fn join_channel(
                 active_window
                     .update(cx, |_, window, cx| {
                         let detail: SharedString = match err.error_code() {
-                            ErrorCode::SignedOut => {
-                                "Please sign in to continue.".into()
+                            ErrorCode::SignedOut => "Please sign in to continue.".into(),
+                            ErrorCode::UpgradeRequired => concat!(
+                                "Your are running an unsupported version of Zed. ",
+                                "Please update to continue."
+                            )
+                            .into(),
+                            ErrorCode::NoSuchChannel => concat!(
+                                "No matching channel was found. ",
+                                "Please check the link and try again."
+                            )
+                            .into(),
+                            ErrorCode::Forbidden => concat!(
+                                "This channel is private, and you do not have access. ",
+                                "Please ask someone to add you and try again."
+                            )
+                            .into(),
+                            ErrorCode::Disconnected => {
+                                "Please check your internet connection and try again.".into()
                             }
-                            ErrorCode::UpgradeRequired => {
-                                "Your are running an unsupported version of Zed. Please update to continue.".into()
-                            }
-                            ErrorCode::NoSuchChannel => {
-                                "No matching channel was found. Please check the link and try again.".into()
-                            }
-                            ErrorCode::Forbidden => {
-                                "This channel is private, and you do not have access. Please ask someone to add you and try again.".into()
-                            }
-                            ErrorCode::Disconnected => "Please check your internet connection and try again.".into(),
                             _ => format!("{}\n\nPlease try again.", err).into(),
                         };
                         window.prompt(
@@ -7366,7 +7367,8 @@ pub fn join_channel(
                             "Failed to join channel",
                             Some(&detail),
                             &["Ok"],
-                        cx)
+                            cx,
+                        )
                     })?
                     .await
                     .ok();


### PR DESCRIPTION
This fixes various issues where rustfmt failed to format code due to too long strings, most of which I stumbled across over the last week and some additonal ones I searched for whilst fixing the others.

Release Notes:

- N/A
