### PR TITLE
text: Temporarily remove `assert_char_boundary` panics

### DIFF
--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -3828,21 +3828,10 @@ impl MultiBufferSnapshot {
         {
             let main_buffer_position = cursor.main_buffer_position()?;
             let buffer_snapshot = &cursor.excerpt()?.buffer;
-            // remove this assert once we figure out the cause of the panics for #40453
-            buffer_snapshot
-                .text
-                .as_rope()
-                .assert_char_boundary(main_buffer_position);
             return Some((buffer_snapshot, main_buffer_position));
         } else if buffer_offset > region.buffer.len() {
             return None;
         }
-        // remove this assert once we figure out the cause of the panics for #40453
-        region
-            .buffer
-            .text
-            .as_rope()
-            .assert_char_boundary(buffer_offset);
         Some((region.buffer, buffer_offset))
     }
 

--- a/crates/text/src/text.rs
+++ b/crates/text/src/text.rs
@@ -2447,7 +2447,6 @@ impl BufferSnapshot {
             if offset > self.visible_text.len() {
                 panic!("offset {} is out of bounds", offset)
             }
-            self.visible_text.assert_char_boundary(offset);
             let (start, _, item) = self.fragments.find::<usize, _>(&None, &offset, bias);
             let fragment = item.unwrap();
             let overshoot = offset - start;


### PR DESCRIPTION
As discussed in the first responders meeting. We have collected a lot of backtraces from these, but it's not quite clear yet what causes this. Removing these should ideally make things a bit more stable even if we may run into panics later one when the faulty anchor is used still.

Release Notes:

- N/A *or* Added/Fixed/Improved ...
