### PR TITLE
agent_ui: Fix model name label truncation

### DIFF
--- a/crates/agent_ui/src/acp/model_selector.rs
+++ b/crates/agent_ui/src/acp/model_selector.rs
@@ -251,17 +251,17 @@ impl PickerDelegate for AcpModelPickerDelegate {
                                 .inset(true)
                                 .spacing(ListItemSpacing::Sparse)
                                 .toggle_state(selected)
-                                .start_slot::<Icon>(model_info.icon.map(|icon| {
-                                    Icon::new(icon)
-                                        .color(model_icon_color)
-                                        .size(IconSize::Small)
-                                }))
                                 .child(
                                     h_flex()
                                         .w_full()
-                                        .pl_0p5()
                                         .gap_1p5()
-                                        .w(px(240.))
+                                        .when_some(model_info.icon, |this, icon| {
+                                            this.child(
+                                                Icon::new(icon)
+                                                    .color(model_icon_color)
+                                                    .size(IconSize::Small)
+                                            )
+                                        })
                                         .child(Label::new(model_info.name.clone()).truncate()),
                                 )
                                 .end_slot(div().pr_3().when(is_selected, |this| {

--- a/crates/agent_ui/src/language_model_selector.rs
+++ b/crates/agent_ui/src/language_model_selector.rs
@@ -492,17 +492,15 @@ impl PickerDelegate for LanguageModelPickerDelegate {
                         .inset(true)
                         .spacing(ListItemSpacing::Sparse)
                         .toggle_state(selected)
-                        .start_slot(
-                            Icon::new(model_info.icon)
-                                .color(model_icon_color)
-                                .size(IconSize::Small),
-                        )
                         .child(
                             h_flex()
                                 .w_full()
-                                .pl_0p5()
                                 .gap_1p5()
-                                .w(px(240.))
+                                .child(
+                                    Icon::new(model_info.icon)
+                                        .color(model_icon_color)
+                                        .size(IconSize::Small),
+                                )
                                 .child(Label::new(model_info.model.name().0).truncate()),
                         )
                         .end_slot(div().pr_3().when(is_selected, |this| {


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/32739

Release Notes:

- agent: Fixed an issue where the label for model names wouldn't use all the available space in the model picker.
