### PR TITLE
collab: Add `external_id` column to `billing_customers` table

### DIFF
--- a/crates/collab/migrations/20251117215316_add_external_id_to_billing_customers.sql
+++ b/crates/collab/migrations/20251117215316_add_external_id_to_billing_customers.sql
@@ -1,0 +1,4 @@
+alter table billing_customers
+    add column external_id text;
+
+create unique index uix_billing_customers_on_external_id on billing_customers (external_id);


### PR DESCRIPTION
This PR adds an `external_id` column to the `billing_customers` table.

Release Notes:

- N/A
