### PR TITLE
For and await highlighting rust

### DIFF
--- a/crates/languages/src/rust/highlights.scm
+++ b/crates/languages/src/rust/highlights.scm
@@ -85,7 +85,6 @@
 [
   "as"
   "async"
-  "await"
   "const"
   "default"
   "dyn"
@@ -115,6 +114,7 @@
 ] @keyword
 
 [
+  "await"
   "break"
   "continue"
   "else"

--- a/crates/languages/src/rust/highlights.scm
+++ b/crates/languages/src/rust/highlights.scm
@@ -102,6 +102,7 @@
   "ref"
   "static"
   "struct"
+  "for"
   "trait"
   "type"
   "union"
@@ -117,7 +118,6 @@
   "break"
   "continue"
   "else"
-  "for"
   "if"
   "in"
   "loop"
@@ -126,6 +126,9 @@
   "while"
   "yield"
 ] @keyword.control
+
+(for_expression
+  ("for" @keyword.control))
 
 [
   (string_literal)


### PR DESCRIPTION
Closes #42922

Release Notes:

- Fixed Correctly highlighting the 'for' keyword in Rust as keyword.control only in for loops.
- Fixed Highlighting the 'await' keyword in Rust as keyword.control
