### PR TITLE
Add a github issue label to shoo the stalebot away

### DIFF
--- a/.github/workflows/community_close_stale_issues.yml
+++ b/.github/workflows/community_close_stale_issues.yml
@@ -26,3 +26,4 @@ jobs:
           ascending: true
           enable-statistics: true
           stale-issue-label: "stale"
+          exempt-issue-labels: "never stale"


### PR DESCRIPTION
Labeling an issue with "never stale" will keep the stalebot away; the bot can get annoying in some situations otherwise.

Release Notes:

- N/A
