### PR TITLE
multi_buffer: Sort existing excerpts by locator before merge

### DIFF
--- a/crates/fsevent/src/fsevent.rs
+++ b/crates/fsevent/src/fsevent.rs
@@ -1,6 +1,7 @@
 #![cfg(target_os = "macos")]
 
 use bitflags::bitflags;
+use core_foundation::runloop::CFRunLoopWakeUp;
 use fsevent_sys::{self as fs, core_foundation as cf};
 use parking_lot::Mutex;
 use std::{
@@ -259,6 +260,7 @@ impl Drop for Handle {
         if let Lifecycle::Running(run_loop) = *state {
             unsafe {
                 cf::CFRunLoopStop(run_loop);
+                CFRunLoopWakeUp(run_loop as _);
                 cf::CFRelease(run_loop)
             }
         }

--- a/crates/fsevent/src/fsevent.rs
+++ b/crates/fsevent/src/fsevent.rs
@@ -381,7 +381,12 @@ unsafe extern "C" {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{fs, sync::mpsc, thread, time::{Duration, Instant}};
+    use std::{
+        fs,
+        sync::mpsc,
+        thread,
+        time::{Duration, Instant},
+    };
 
     #[test]
     fn test_event_stream_simple() {

--- a/crates/fsevent/src/fsevent.rs
+++ b/crates/fsevent/src/fsevent.rs
@@ -246,6 +246,7 @@ impl EventStream {
     }
 }
 
+#[cfg(test)]
 impl Handle {
     fn lifecycle(&self) -> Arc<Mutex<Lifecycle>> {
         self.0.clone()

--- a/crates/multi_buffer/src/path_key.rs
+++ b/crates/multi_buffer/src/path_key.rs
@@ -283,11 +283,12 @@ impl MultiBuffer {
             .and_then(|(_, value)| value.last().copied())
             .unwrap_or(ExcerptId::min());
 
-        let existing = self
+        let mut existing = self
             .excerpts_by_path
             .get(&path)
             .cloned()
             .unwrap_or_default();
+        existing.sort_by_cached_key(|id| snapshot.excerpt_locator_for_id(*id).clone());
         let mut new_iter = new.into_iter().peekable();
         let mut existing_iter = existing.into_iter().peekable();
 

--- a/crates/multi_buffer/src/path_key.rs
+++ b/crates/multi_buffer/src/path_key.rs
@@ -288,6 +288,7 @@ impl MultiBuffer {
             .get(&path)
             .cloned()
             .unwrap_or_default();
+        let snapshot = self.snapshot(cx);
         existing.sort_by_cached_key(|id| snapshot.excerpt_locator_for_id(*id).clone());
         let mut new_iter = new.into_iter().peekable();
         let mut existing_iter = existing.into_iter().peekable();
@@ -296,7 +297,6 @@ impl MultiBuffer {
         let mut to_remove = Vec::new();
         let mut to_insert: Vec<(ExcerptId, ExcerptRange<Point>)> = Vec::new();
         let mut added_a_new_excerpt = false;
-        let snapshot = self.snapshot(cx);
 
         let mut next_excerpt_id =
             // is this right? What if we remove the last excerpt, then we might reallocate with a wrong mapping?


### PR DESCRIPTION
Sort excerpts retrieved from `excerpts_by_path` by their locator using the current snapshot. This ensures consistent ordering when comparing/merging with new excerpts via peekable iterators, likely to maintain positional integrity or deduplication correctness.

Closes 
https://github.com/zed-industries/zed/issues/42818

