### PR TITLE
project search: Skip loading of gitignored paths when their descendants will never match an inclusion/exclusion query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3670,6 +3670,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_format"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12754,6 +12774,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5da3b0203fd7ee5720aa0b5e790b591aa5d3f41c3ed2c34a3a393382198af2f7"
 
 [[package]]
+name = "pori"
+version = "0.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a63d338dec139f56dacc692ca63ad35a6be6a797442479b55acd611d79e906"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13069,6 +13098,7 @@ dependencies = [
  "url",
  "util",
  "watch",
+ "wax",
  "which 6.0.3",
  "worktree",
  "zeroize",
@@ -19518,6 +19548,21 @@ dependencies = [
  "parking_lot",
  "rand 0.9.2",
  "zlog",
+]
+
+[[package]]
+name = "wax"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d12a78aa0bab22d2f26ed1a96df7ab58e8a93506a3e20adb47c51a93b4e1357"
+dependencies = [
+ "const_format",
+ "itertools 0.11.0",
+ "nom 7.1.3",
+ "pori",
+ "regex",
+ "thiserror 1.0.69",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -721,6 +721,7 @@ wasmtime = { version = "29", default-features = false, features = [
     "parallel-compilation",
 ] }
 wasmtime-wasi = "29"
+wax = "0.6"
 which = "6.0.0"
 windows-core = "0.61"
 wit-component = "0.221"

--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -86,6 +86,7 @@ toml.workspace = true
 url.workspace = true
 util.workspace = true
 watch.workspace = true
+wax.workspace = true
 which.workspace = true
 worktree.workspace = true
 zeroize.workspace = true

--- a/crates/project/src/project_search.rs
+++ b/crates/project/src/project_search.rs
@@ -799,13 +799,13 @@ struct MatchingEntry {
 /// scanned based on include/exclude patterns of a search query (as include/exclude parameters may match paths inside it).
 /// It is kind-of doing an inverse of glob. Given a glob pattern like `src/**/` and a parent path like `src`, we need to decide whether the parent
 /// may contain glob hits.
-struct PathInclusionMatcher {
+pub(crate) struct PathInclusionMatcher {
     included: BTreeSet<PathBuf>,
     query: Arc<SearchQuery>,
 }
 
 impl PathInclusionMatcher {
-    fn new(query: Arc<SearchQuery>) -> Self {
+    pub(crate) fn new(query: Arc<SearchQuery>) -> Self {
         let mut included = BTreeSet::new();
         // To do an inverse glob match, we split each glob into it's prefix and the glob part.
         // For example, `src/**/*.rs` becomes `src/` and `**/*.rs`. The glob part gets dropped.
@@ -822,7 +822,7 @@ impl PathInclusionMatcher {
         Self { included, query }
     }
 
-    fn should_scan_gitignored_dir(
+    pub(crate) fn should_scan_gitignored_dir(
         &self,
         entry: &Entry,
         snapshot: &Snapshot,

--- a/crates/project/src/project_search.rs
+++ b/crates/project/src/project_search.rs
@@ -209,8 +209,6 @@ impl Search {
                         let (sorted_search_results_tx, sorted_search_results_rx) = unbounded();
 
                         let (input_paths_tx, input_paths_rx) = unbounded();
-                        // glob: src/rust/
-                        // path: src/
                         let tasks = vec![
                             cx.spawn(Self::provide_search_paths(
                                 std::mem::take(worktrees),

--- a/crates/project/src/project_search.rs
+++ b/crates/project/src/project_search.rs
@@ -799,13 +799,13 @@ struct MatchingEntry {
 /// scanned based on include/exclude patterns of a search query (as include/exclude parameters may match paths inside it).
 /// It is kind-of doing an inverse of glob. Given a glob pattern like `src/**/` and a parent path like `src`, we need to decide whether the parent
 /// may contain glob hits.
-pub(crate) struct PathInclusionMatcher {
+struct PathInclusionMatcher {
     included: BTreeSet<PathBuf>,
     query: Arc<SearchQuery>,
 }
 
 impl PathInclusionMatcher {
-    pub(crate) fn new(query: Arc<SearchQuery>) -> Self {
+    fn new(query: Arc<SearchQuery>) -> Self {
         let mut included = BTreeSet::new();
         // To do an inverse glob match, we split each glob into it's prefix and the glob part.
         // For example, `src/**/*.rs` becomes `src/` and `**/*.rs`. The glob part gets dropped.
@@ -822,7 +822,7 @@ impl PathInclusionMatcher {
         Self { included, query }
     }
 
-    pub(crate) fn should_scan_gitignored_dir(
+    fn should_scan_gitignored_dir(
         &self,
         entry: &Entry,
         snapshot: &Snapshot,
@@ -898,5 +898,125 @@ impl PathInclusionMatcher {
         } else {
             false
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fs::FakeFs;
+    use serde_json::json;
+    use settings::Settings;
+    use util::{
+        path,
+        paths::{PathMatcher, PathStyle},
+        rel_path::RelPath,
+    };
+    use worktree::{Entry, EntryKind, WorktreeSettings};
+
+    use crate::{
+        Project, project_search::PathInclusionMatcher, project_tests::init_test,
+        search::SearchQuery,
+    };
+
+    #[gpui::test]
+    async fn test_path_inclusion_matcher(cx: &mut gpui::TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.background_executor.clone());
+        fs.insert_tree(
+            "/root",
+            json!({
+                ".gitignore": "src/data/\n",
+                "src": {
+                    "data": {
+                        "main.csv": "field_1,field_2,field_3",
+                    },
+                    "lib": {
+                        "main.txt": "Are you familiar with fields?",
+                    },
+                },
+            }),
+        )
+        .await;
+
+        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
+        let worktree = project.update(cx, |project, cx| project.worktrees(cx).next().unwrap());
+        let (worktree_settings, worktree_snapshot) = worktree.update(cx, |worktree, cx| {
+            let settings_location = worktree.settings_location(cx);
+            return (
+                WorktreeSettings::get(Some(settings_location), cx).clone(),
+                worktree.snapshot(),
+            );
+        });
+
+        // Manually create a test entry for the gitignored directory since it won't
+        // be loaded by the worktree
+        let entry = Entry {
+            id: ProjectEntryId::from_proto(1),
+            kind: EntryKind::UnloadedDir,
+            path: Arc::from(RelPath::unix(Path::new("src/data")).unwrap()),
+            inode: 0,
+            mtime: None,
+            canonical_path: None,
+            is_ignored: true,
+            is_hidden: false,
+            is_always_included: false,
+            is_external: false,
+            is_private: false,
+            size: 0,
+            char_bag: Default::default(),
+            is_fifo: false,
+        };
+
+        // 1. Test searching for `field`, including ignored files without any
+        // inclusion and exclusion filters.
+        let include_ignored = true;
+        let files_to_include = PathMatcher::default();
+        let files_to_exclude = PathMatcher::default();
+        let match_full_paths = false;
+        let search_query = SearchQuery::text(
+            "field",
+            false,
+            false,
+            include_ignored,
+            files_to_include,
+            files_to_exclude,
+            match_full_paths,
+            None,
+        )
+        .unwrap();
+
+        let path_matcher = PathInclusionMatcher::new(Arc::new(search_query));
+        assert!(path_matcher.should_scan_gitignored_dir(
+            &entry,
+            &worktree_snapshot,
+            &worktree_settings
+        ));
+
+        // 2. Test searching for `field`, including ignored files but updating
+        // `files_to_include` to only include files under `src/lib`.
+        let include_ignored = true;
+        let files_to_include = PathMatcher::new(vec!["src/lib"], PathStyle::Posix).unwrap();
+        let files_to_exclude = PathMatcher::default();
+        let match_full_paths = false;
+        let search_query = SearchQuery::text(
+            "field",
+            false,
+            false,
+            include_ignored,
+            files_to_include,
+            files_to_exclude,
+            match_full_paths,
+            None,
+        )
+        .unwrap();
+
+        let path_matcher = PathInclusionMatcher::new(Arc::new(search_query));
+        assert!(!path_matcher.should_scan_gitignored_dir(
+            &entry,
+            &worktree_snapshot,
+            &worktree_settings
+        ));
     }
 }

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -3,7 +3,6 @@
 use crate::{
     Event,
     git_store::{GitStoreEvent, RepositoryEvent, StatusEntry, pending_op},
-    project_search::PathInclusionMatcher,
     task_inventory::TaskContexts,
     task_store::TaskSettingsLocation,
     *,
@@ -15,7 +14,6 @@ use buffer_diff::{
 };
 use fs::FakeFs;
 use futures::{StreamExt, future};
-use fuzzy::CharBag;
 use git::{
     GitHostingProviderRegistry,
     repository::{RepoPath, repo_path},
@@ -62,7 +60,7 @@ use util::{
     test::{TempTree, marked_text_offsets},
     uri,
 };
-use worktree::{Entry, EntryKind, WorktreeModelHandle as _};
+use worktree::WorktreeModelHandle as _;
 
 #[gpui::test]
 async fn test_block_via_channel(cx: &mut gpui::TestAppContext) {
@@ -10846,105 +10844,4 @@ async fn test_git_worktree_remove(cx: &mut gpui::TestAppContext) {
             .map(|r| r.read(cx).work_directory_abs_path.clone())
     });
     assert!(active_repo_path.is_none());
-}
-
-#[gpui::test]
-async fn test_path_inclusion_matcher(cx: &mut gpui::TestAppContext) {
-    init_test(cx);
-
-    let fs = FakeFs::new(cx.background_executor.clone());
-    fs.insert_tree(
-        "/root",
-        json!({
-            ".gitignore": "src/data/\n",
-            "src": {
-                "data": {
-                    "main.csv": "field_1,field_2,field_3",
-                },
-                "lib": {
-                    "main.txt": "Are you familiar with fields?",
-                },
-            },
-        }),
-    )
-    .await;
-
-    let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
-    let worktree = project.update(cx, |project, cx| project.worktrees(cx).next().unwrap());
-    let (worktree_settings, worktree_snapshot) = worktree.update(cx, |worktree, cx| {
-        let settings_location = worktree.settings_location(cx);
-        return (
-            WorktreeSettings::get(Some(settings_location), cx).clone(),
-            worktree.snapshot(),
-        );
-    });
-
-    // Manually create a test entry for the gitignored directory since it won't
-    // be loaded by the worktree
-    let entry = Entry {
-        id: ProjectEntryId::from_proto(1),
-        kind: EntryKind::UnloadedDir,
-        path: Arc::from(RelPath::unix(Path::new("src/data")).unwrap()),
-        inode: 0,
-        mtime: None,
-        canonical_path: None,
-        is_ignored: true,
-        is_hidden: false,
-        is_always_included: false,
-        is_external: false,
-        is_private: false,
-        size: 0,
-        char_bag: CharBag::default(),
-        is_fifo: false,
-    };
-
-    // 1. Test searching for `field`, including ignored files without any
-    // inclusion and exclusion filters.
-    let include_ignored = true;
-    let files_to_include = PathMatcher::default();
-    let files_to_exclude = PathMatcher::default();
-    let match_full_paths = false;
-    let search_query = SearchQuery::text(
-        "field",
-        false,
-        false,
-        include_ignored,
-        files_to_include,
-        files_to_exclude,
-        match_full_paths,
-        None,
-    )
-    .unwrap();
-
-    let path_matcher = PathInclusionMatcher::new(Arc::new(search_query));
-    assert!(path_matcher.should_scan_gitignored_dir(
-        &entry,
-        &worktree_snapshot,
-        &worktree_settings
-    ));
-
-    // 2. Test searching for `field`, including ignored files but updating
-    // `files_to_include` to only include files under `src/lib`.
-    let include_ignored = true;
-    let files_to_include = PathMatcher::new(vec!["src/lib"], PathStyle::Posix).unwrap();
-    let files_to_exclude = PathMatcher::default();
-    let match_full_paths = false;
-    let search_query = SearchQuery::text(
-        "field",
-        false,
-        false,
-        include_ignored,
-        files_to_include,
-        files_to_exclude,
-        match_full_paths,
-        None,
-    )
-    .unwrap();
-
-    let path_matcher = PathInclusionMatcher::new(Arc::new(search_query));
-    assert!(!path_matcher.should_scan_gitignored_dir(
-        &entry,
-        &worktree_snapshot,
-        &worktree_settings
-    ));
 }

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -3,6 +3,7 @@
 use crate::{
     Event,
     git_store::{GitStoreEvent, RepositoryEvent, StatusEntry, pending_op},
+    project_search::PathInclusionMatcher,
     task_inventory::TaskContexts,
     task_store::TaskSettingsLocation,
     *,
@@ -14,6 +15,7 @@ use buffer_diff::{
 };
 use fs::FakeFs;
 use futures::{StreamExt, future};
+use fuzzy::CharBag;
 use git::{
     GitHostingProviderRegistry,
     repository::{RepoPath, repo_path},
@@ -60,7 +62,7 @@ use util::{
     test::{TempTree, marked_text_offsets},
     uri,
 };
-use worktree::WorktreeModelHandle as _;
+use worktree::{Entry, EntryKind, WorktreeModelHandle as _};
 
 #[gpui::test]
 async fn test_block_via_channel(cx: &mut gpui::TestAppContext) {
@@ -10844,4 +10846,105 @@ async fn test_git_worktree_remove(cx: &mut gpui::TestAppContext) {
             .map(|r| r.read(cx).work_directory_abs_path.clone())
     });
     assert!(active_repo_path.is_none());
+}
+
+#[gpui::test]
+async fn test_path_inclusion_matcher(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.background_executor.clone());
+    fs.insert_tree(
+        "/root",
+        json!({
+            ".gitignore": "src/data/\n",
+            "src": {
+                "data": {
+                    "main.csv": "field_1,field_2,field_3",
+                },
+                "lib": {
+                    "main.txt": "Are you familiar with fields?",
+                },
+            },
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
+    let worktree = project.update(cx, |project, cx| project.worktrees(cx).next().unwrap());
+    let (worktree_settings, worktree_snapshot) = worktree.update(cx, |worktree, cx| {
+        let settings_location = worktree.settings_location(cx);
+        return (
+            WorktreeSettings::get(Some(settings_location), cx).clone(),
+            worktree.snapshot(),
+        );
+    });
+
+    // Manually create a test entry for the gitignored directory since it won't
+    // be loaded by the worktree
+    let entry = Entry {
+        id: ProjectEntryId::from_proto(1),
+        kind: EntryKind::UnloadedDir,
+        path: Arc::from(RelPath::unix(Path::new("src/data")).unwrap()),
+        inode: 0,
+        mtime: None,
+        canonical_path: None,
+        is_ignored: true,
+        is_hidden: false,
+        is_always_included: false,
+        is_external: false,
+        is_private: false,
+        size: 0,
+        char_bag: CharBag::default(),
+        is_fifo: false,
+    };
+
+    // 1. Test searching for `field`, including ignored files without any
+    // inclusion and exclusion filters.
+    let include_ignored = true;
+    let files_to_include = PathMatcher::default();
+    let files_to_exclude = PathMatcher::default();
+    let match_full_paths = false;
+    let search_query = SearchQuery::text(
+        "field",
+        false,
+        false,
+        include_ignored,
+        files_to_include,
+        files_to_exclude,
+        match_full_paths,
+        None,
+    )
+    .unwrap();
+
+    let path_matcher = PathInclusionMatcher::new(Arc::new(search_query));
+    assert!(path_matcher.should_scan_gitignored_dir(
+        &entry,
+        &worktree_snapshot,
+        &worktree_settings
+    ));
+
+    // 2. Test searching for `field`, including ignored files but updating
+    // `files_to_include` to only include files under `src/lib`.
+    let include_ignored = true;
+    let files_to_include = PathMatcher::new(vec!["src/lib"], PathStyle::Posix).unwrap();
+    let files_to_exclude = PathMatcher::default();
+    let match_full_paths = false;
+    let search_query = SearchQuery::text(
+        "field",
+        false,
+        false,
+        include_ignored,
+        files_to_include,
+        files_to_exclude,
+        match_full_paths,
+        None,
+    )
+    .unwrap();
+
+    let path_matcher = PathInclusionMatcher::new(Arc::new(search_query));
+    assert!(!path_matcher.should_scan_gitignored_dir(
+        &entry,
+        &worktree_snapshot,
+        &worktree_settings
+    ));
 }


### PR DESCRIPTION
Co-authored-by: dino <dinojoaocosta@gmail.com>

Related-to: #38799

Release Notes:

- Improved project search performance with "Also search files ignored by configuration" combined with file inclusion/exclusion queries.
