### PR TITLE
vim: Fix snapshot out of bounds indexing

### DIFF
--- a/crates/vim/src/normal/increment.rs
+++ b/crates/vim/src/normal/increment.rs
@@ -211,7 +211,7 @@ fn find_target(
     let mut pre_char = String::new();
 
     // Backward scan to find the start of the number, but stop at start_offset
-    for ch in snapshot.reversed_chars_at(offset + 1) {
+    for ch in snapshot.reversed_chars_at(offset + if offset < snapshot.len() { 1 } else { 0 }) {
         // Search boundaries
         if offset == 0 || ch.is_whitespace() || (need_range && offset <= start_offset) {
             break;


### PR DESCRIPTION
Fixes ZED-38X

Release Notes:

- N/A
