### PR TITLE
Revert "git: Remove JobStatus from PendingOp in favour of in-flight pruning (#42955) (cherry-pick to preview)"

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -2629,7 +2629,7 @@ impl GitPanel {
                 && pending
                     .ops
                     .iter()
-                    .any(|op| op.git_status == pending_op::GitStatus::Reverted && op.finished)
+                    .any(|op| op.git_status == pending_op::GitStatus::Reverted && op.finished())
             {
                 continue;
             }


### PR DESCRIPTION
Reverts zed-industries/zed#42957