### PR TITLE
Disable phpactor by default on windows

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -2059,6 +2059,18 @@
   "dev": {
     // "theme": "Andromeda"
   },
+  // Settings overrides to use when using linux
+  "linux": {},
+  // Settings overrides to use when using macos
+  "macos": {},
+  // Settings overrides to use when using windows
+  "windows": {
+    "languages": {
+      "PHP": {
+        "language_servers": ["intelephense", "!phpactor", "..."]
+      }
+    }
+  },
   // Whether to show full labels in line indicator or short ones
   //
   // Values:


### PR DESCRIPTION
We install phpactor by default, but on windows it doesn't work out of the box (see [here](https://github.com/phpactor/phpactor/discussions/2579) for details). For now we'll default to using intelephense, but in the future we'd like to switch back if phpactor lands windows support given that it's open source.

Release Notes:

- N/A