### PR TITLE
Increase error verbosity

### DIFF
--- a/crates/onboarding/src/onboarding.rs
+++ b/crates/onboarding/src/onboarding.rs
@@ -449,7 +449,7 @@ pub async fn handle_import_vscode_settings(
         match settings::VsCodeSettings::load_user_settings(source, fs.clone()).await {
             Ok(vscode_settings) => vscode_settings,
             Err(err) => {
-                zlog::error!("{err}");
+                zlog::error!("{err:?}");
                 let _ = cx.prompt(
                     gpui::PromptLevel::Info,
                     &format!("Could not find or load a {source} settings file"),


### PR DESCRIPTION
Closes #42288

This will actually print the parsing error that prevented the vscode settings file from being loaded which should make it easier for users to self help when they have an invalid config.

Release Notes:

- N/A
