### PR TITLE
vim: Fix paste action for visual modes

### DIFF
--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -3,7 +3,7 @@ mod convert;
 mod delete;
 mod increment;
 pub(crate) mod mark;
-mod paste;
+pub(crate) mod paste;
 pub(crate) mod repeat;
 mod scroll;
 pub(crate) mod search;

--- a/crates/vim/src/normal/paste.rs
+++ b/crates/vim/src/normal/paste.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 /// Pastes text from the specified register at the cursor position.
-#[derive(Clone, Deserialize, JsonSchema, PartialEq, Action)]
+#[derive(Clone, Default, Deserialize, JsonSchema, PartialEq, Action)]
 #[action(namespace = vim)]
 #[serde(deny_unknown_fields)]
 pub struct Paste {

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -19,6 +19,7 @@ mod state;
 mod surrounds;
 mod visual;
 
+use crate::normal::paste::Paste as VimPaste;
 use collections::HashMap;
 use editor::{
     Anchor, Bias, Editor, EditorEvent, EditorSettings, HideMouseCursorOrigin, SelectionEffects,
@@ -922,6 +923,9 @@ impl Vim {
                 cx,
                 |vim, _: &editor::actions::Paste, window, cx| match vim.mode {
                     Mode::Replace => vim.paste_replace(window, cx),
+                    Mode::Visual | Mode::VisualLine | Mode::VisualBlock => {
+                        vim.paste(&VimPaste::default(), window, cx);
+                    }
                     _ => {
                         vim.update_editor(cx, |_, editor, cx| editor.paste(&Paste, window, cx));
                     }


### PR DESCRIPTION
Closes #41810 

Release Notes:

- Fixed paste not working correctly in vim visual modes

