### PR TITLE
git_ui: Fix tracked files inconsistency

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -2654,9 +2654,10 @@ impl GitPanel {
         self.stash_entries = repo.cached_stash();
 
         for entry in repo.cached_status() {
-            // Skip files that are outside the worktree boundaries
-            // to maintain consistency with the uncommitted changes view
-            if repo.repo_path_to_project_path(&entry.repo_path, cx).is_none() {
+            if repo
+                .repo_path_to_project_path(&entry.repo_path, cx)
+                .is_none()
+            {
                 continue;
             }
 

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -5107,11 +5107,6 @@ mod tests {
                     status: StatusCode::Modified.worktree(),
                     staging: StageStatus::Unstaged,
                 }),
-                GitListEntry::Status(GitStatusEntry {
-                    repo_path: repo_path("crates/util/util.rs"),
-                    status: StatusCode::Modified.worktree(),
-                    staging: StageStatus::Unstaged,
-                },),
             ],
         );
 
@@ -5132,11 +5127,6 @@ mod tests {
                     status: StatusCode::Modified.worktree(),
                     staging: StageStatus::Unstaged,
                 }),
-                GitListEntry::Status(GitStatusEntry {
-                    repo_path: repo_path("crates/util/util.rs"),
-                    status: StatusCode::Modified.worktree(),
-                    staging: StageStatus::Unstaged,
-                },),
             ],
         );
     }

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -2654,6 +2654,12 @@ impl GitPanel {
         self.stash_entries = repo.cached_stash();
 
         for entry in repo.cached_status() {
+            // Skip files that are outside the worktree boundaries
+            // to maintain consistency with the uncommitted changes view
+            if repo.repo_path_to_project_path(&entry.repo_path, cx).is_none() {
+                continue;
+            }
+
             let is_conflict = repo.had_conflict_on_last_merge_head_change(&entry.repo_path);
             let is_new = entry.status.is_created();
             let staging = entry.status.staging();


### PR DESCRIPTION
Fixes #29670

Release Notes:
- Fixed inconsistency where the git panel showed all repository files when Zed was launched from a subdirectory, while the uncommitted changes view correctly filtered to worktree files only.

Changes:
- Added filtering in git_panel.rs to skip entries outside worktree boundaries by checking if repo_path_to_project_path() returns None.
- Updated test `test_entry_worktree_paths` to only expect changes within workspace folder.
