### PR TITLE
editor: Go to test

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1601,6 +1601,16 @@
     "Markdown": [".rules", ".cursorrules", ".windsurfrules", ".clinerules"],
     "Shell Script": [".env.*"]
   },
+  // Patterns for navigating between source and test files.
+  // Use `{}` as a placeholder for the captured part of the path.
+  // Define both directions to enable navigation from source to test and back.
+  "go_to_test": {
+    "patterns": {
+      // Elixir
+      "lib/{}.ex": "test/{}_test.exs",
+      "test/{}_test.exs": "lib/{}.ex"
+    }
+  },
   // Settings for which version of Node.js and NPM to use when installing
   // language servers and Copilot.
   //

--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -526,6 +526,8 @@ actions!(
         GoToImplementationSplit,
         /// Goes to the next change in the file.
         GoToNextChange,
+        /// Goes to the corresponding test file for the current file.
+        GoToTest,
         /// Goes to the parent module of the current file.
         GoToParentModule,
         /// Goes to the previous change in the file.

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -1,5 +1,6 @@
 use core::num;
 
+use collections::HashMap;
 use gpui::App;
 use language::CursorShape;
 use project::project_settings::DiagnosticSeverity;
@@ -49,6 +50,7 @@ pub struct EditorSettings {
     pub show_signature_help_after_edits: bool,
     pub go_to_definition_fallback: GoToDefinitionFallback,
     pub jupyter: Jupyter,
+    pub go_to_test: GoToTest,
     pub hide_mouse: Option<HideMouseMode>,
     pub snippet_sort_order: SnippetSortOrder,
     pub diagnostics_max_severity: Option<DiagnosticSeverity>,
@@ -69,6 +71,12 @@ pub struct Jupyter {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct StickyScroll {
     pub enabled: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GoToTest {
+    /// Patterns for navigating between source and test files.
+    pub patterns: HashMap<String, String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -273,6 +281,9 @@ impl Settings for EditorSettings {
             go_to_definition_fallback: editor.go_to_definition_fallback.unwrap(),
             jupyter: Jupyter {
                 enabled: editor.jupyter.unwrap().enabled.unwrap(),
+            },
+            go_to_test: GoToTest {
+                patterns: editor.go_to_test.unwrap().patterns.unwrap(),
             },
             hide_mouse: editor.hide_mouse,
             snippet_sort_order: editor.snippet_sort_order.unwrap(),

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -421,6 +421,9 @@ impl EditorElement {
                 .detach_and_log_err(cx);
         });
         register_action(editor, window, |editor, action, window, cx| {
+            editor.go_to_test(action, window, cx).detach_and_log_err(cx);
+        });
+        register_action(editor, window, |editor, action, window, cx| {
             editor
                 .go_to_type_definition(action, window, cx)
                 .detach_and_log_err(cx);

--- a/crates/settings/src/settings_content/editor.rs
+++ b/crates/settings/src/settings_content/editor.rs
@@ -203,6 +203,9 @@ pub struct EditorSettingsContent {
     ///
     /// Default: [`DocumentColorsRenderMode::Inlay`]
     pub lsp_document_colors: Option<DocumentColorsRenderMode>,
+
+    /// Go to test related settings
+    pub go_to_test: Option<GoToTestContent>,
     /// When to show the scrollbar in the completion menu.
     /// This setting can take four values:
     ///
@@ -799,6 +802,18 @@ pub struct DragAndDropSelectionContent {
     ///
     /// Default: 300
     pub delay: Option<DelayMs>,
+}
+
+/// Patterns for navigating between source and test files.
+#[skip_serializing_none]
+#[derive(Clone, Default, Debug, Serialize, Deserialize, JsonSchema, MergeFrom, PartialEq, Eq)]
+pub struct GoToTestContent {
+    /// Patterns for navigating between source and test files.
+    /// Use `{}` as a placeholder for the captured part of the path.
+    /// Define both directions to enable navigation from source to test and back.
+    ///
+    /// Default: `{"lib/{}.ex": "test/{}_test.exs", "test/{}_test.exs": "lib/{}.ex"}`
+    pub patterns: Option<HashMap<String, String>>,
 }
 
 /// When to show the minimap in the editor.

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -264,6 +264,7 @@ impl VsCodeSettings {
             hover_popover_enabled: self.read_bool("editor.hover.enabled"),
             inline_code_actions: None,
             jupyter: None,
+            go_to_test: None,
             lsp_document_colors: None,
             lsp_highlight_debounce: None,
             middle_click_paste: None,


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/discussions/40859

I am an earlier Neovim user, and I have gotten used to having a shortcut for jumping from the source file to the test file and back again. Then I have a single shortcut to jump between the two, so I don't have to search. For me this is super helpful in big Elixir projects, since the source and test files are in completely different directories, but always relative to each other. I also frequently jump between source and test files.

I don't know how many languages that have this kind of pattern, but I know there is at least something similar in Ruby, but they have two different patterns depending on which test tool they are using.

Seems like the person that opened the issue uses Typescript, so might be some similar patterns there?

Release Notes:

- Added new action (editor: Go to test) for jumping between source files and test files.

![Go to test](https://github.com/user-attachments/assets/9e7b084a-8f7c-4eb2-9635-0075002eeab4)