### PR TITLE
Allow running zeta evals against sweep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21866,6 +21866,7 @@ dependencies = [
  "shellexpand 2.1.2",
  "smol",
  "soa-rs",
+ "sweep_ai",
  "terminal_view",
  "toml 0.8.23",
  "util",

--- a/crates/sweep_ai/src/sweep_ai.rs
+++ b/crates/sweep_ai/src/sweep_ai.rs
@@ -11,7 +11,7 @@ use http_client::{AsyncBody, Method};
 use language::{
     Anchor, Buffer, BufferSnapshot, EditPreview, Point, ToOffset as _, ToPoint, text_diff,
 };
-use project::Project;
+use project::{Project, ProjectPath};
 use release_channel::{AppCommitSha, AppVersion};
 use std::collections::{VecDeque, hash_map};
 use std::fmt::{self, Display};
@@ -48,11 +48,11 @@ impl Global for SweepAiGlobal {}
 
 #[derive(Clone)]
 pub struct EditPrediction {
-    id: EditPredictionId,
-    path: Arc<Path>,
-    edits: Arc<[(Range<Anchor>, Arc<str>)]>,
-    snapshot: BufferSnapshot,
-    edit_preview: EditPreview,
+    pub id: EditPredictionId,
+    pub path: Arc<Path>,
+    pub edits: Arc<[(Range<Anchor>, Arc<str>)]>,
+    pub snapshot: BufferSnapshot,
+    pub edit_preview: EditPreview,
 }
 
 impl EditPrediction {
@@ -195,8 +195,8 @@ impl SweepAi {
 
     pub fn request_completion(
         &mut self,
-        workspace: &WeakEntity<Workspace>,
         project: &Entity<Project>,
+        recent_buffers: impl Iterator<Item = ProjectPath>,
         active_buffer: &Entity<Buffer>,
         position: language::Anchor,
         cx: &mut Context<Self>,
@@ -223,26 +223,17 @@ impl SweepAi {
         let events = project_state.events.clone();
         let http_client = cx.http_client();
 
-        let Some(recent_buffers) = workspace
-            .read_with(cx, |workspace, cx| {
-                workspace
-                    .recent_navigation_history_iter(cx)
-                    .filter_map(|(project_path, _)| {
-                        let buffer = project.read(cx).get_open_buffer(&project_path, cx)?;
-
-                        if active_buffer == &buffer {
-                            None
-                        } else {
-                            Some(buffer.read(cx).snapshot())
-                        }
-                    })
-                    .take(3)
-                    .collect::<Vec<_>>()
+        let recent_buffer_snapshots = recent_buffers
+            .filter_map(|project_path| {
+                let buffer = project.read(cx).get_open_buffer(&project_path, cx)?;
+                if active_buffer == &buffer {
+                    None
+                } else {
+                    Some(buffer.read(cx).snapshot())
+                }
             })
-            .log_err()
-        else {
-            return Task::ready(Ok(None));
-        };
+            .take(3)
+            .collect::<Vec<_>>();
 
         let result = cx.background_spawn({
             let full_path = full_path.clone();
@@ -255,7 +246,7 @@ impl SweepAi {
                     writeln!(&mut recent_changes, "{event}")?;
                 }
 
-                let file_chunks = recent_buffers
+                let file_chunks = recent_buffer_snapshots
                     .into_iter()
                     .map(|snapshot| {
                         let end_point = language::Point::new(30, 0).min(snapshot.max_point());
@@ -623,8 +614,23 @@ impl edit_prediction::EditPredictionProvider for SweepAiEditPredictionProvider {
 
             let completion_request = this.update(cx, |this, cx| {
                 this.last_request_timestamp = Instant::now();
+
                 this.sweep_ai.update(cx, |sweep_ai, cx| {
-                    sweep_ai.request_completion(&workspace, &project, &buffer, position, cx)
+                    let Some(recent_buffers) = workspace
+                        .read_with(cx, |workspace, cx| {
+                            workspace.recent_navigation_history_iter(cx)
+                        })
+                        .log_err()
+                    else {
+                        return Task::ready(Ok(None));
+                    };
+                    sweep_ai.request_completion(
+                        &project,
+                        recent_buffers.map(move |(project_path, _)| project_path),
+                        &buffer,
+                        position,
+                        cx,
+                    )
                 })
             });
 

--- a/crates/sweep_ai/src/sweep_ai.rs
+++ b/crates/sweep_ai/src/sweep_ai.rs
@@ -110,7 +110,7 @@ impl SweepAi {
         }
     }
 
-    fn new(cx: &mut Context<Self>) -> Self {
+    pub fn new(cx: &mut Context<Self>) -> Self {
         Self {
             api_token: std::env::var("SWEEP_AI_TOKEN").ok(),
             projects: HashMap::default(),

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1845,7 +1845,7 @@ impl Workspace {
     pub fn recent_navigation_history_iter(
         &self,
         cx: &App,
-    ) -> impl Iterator<Item = (ProjectPath, Option<PathBuf>)> {
+    ) -> impl Iterator<Item = (ProjectPath, Option<PathBuf>)> + use<> {
         let mut abs_paths_opened: HashMap<PathBuf, HashSet<ProjectPath>> = HashMap::default();
         let mut history: HashMap<ProjectPath, (Option<PathBuf>, usize)> = HashMap::default();
 

--- a/crates/zeta2/src/zeta2.rs
+++ b/crates/zeta2/src/zeta2.rs
@@ -50,7 +50,7 @@ pub mod udiff;
 mod xml_edits;
 
 use crate::assemble_excerpts::assemble_excerpts;
-use crate::prediction::EditPrediction;
+pub use crate::prediction::EditPrediction;
 pub use crate::prediction::EditPredictionId;
 pub use provider::ZetaEditPredictionProvider;
 
@@ -325,6 +325,14 @@ impl Event {
                     })
                 }
             }
+        }
+    }
+
+    pub fn project_path(&self, cx: &App) -> Option<project::ProjectPath> {
+        match self {
+            Event::BufferChange { new_snapshot, .. } => new_snapshot
+                .file()
+                .map(|f| project::ProjectPath::from_file(f.as_ref(), cx)),
         }
     }
 }

--- a/crates/zeta2/src/zeta2.rs
+++ b/crates/zeta2/src/zeta2.rs
@@ -409,7 +409,10 @@ impl Zeta {
         }
     }
 
-    pub fn history_for_project(&self, project: &Entity<Project>) -> impl Iterator<Item = &Event> {
+    pub fn history_for_project(
+        &self,
+        project: &Entity<Project>,
+    ) -> impl DoubleEndedIterator<Item = &Event> {
         self.projects
             .get(&project.entity_id())
             .map(|project| project.events.iter())

--- a/crates/zeta_cli/Cargo.toml
+++ b/crates/zeta_cli/Cargo.toml
@@ -49,6 +49,7 @@ settings.workspace = true
 shellexpand.workspace = true
 smol.workspace = true
 soa-rs = "0.8.1"
+sweep_ai.workspace = true
 terminal_view.workspace = true
 toml.workspace = true
 util.workspace = true

--- a/crates/zeta_cli/src/evaluate.rs
+++ b/crates/zeta_cli/src/evaluate.rs
@@ -14,7 +14,7 @@ use util::ResultExt as _;
 use zeta2::{Zeta, udiff::DiffLine};
 
 use crate::{
-    PromptFormat,
+    PromptFormat, Zeta2Args,
     example::{Example, NamedExample},
     headless::ZetaCliAppState,
     paths::print_run_data_dir,
@@ -24,8 +24,8 @@ use crate::{
 #[derive(Debug, Args)]
 pub struct EvaluateArguments {
     example_paths: Vec<PathBuf>,
-    #[arg(long, value_enum, default_value_t = PromptFormat::default())]
-    prompt_format: PromptFormat,
+    #[clap(flatten)]
+    zeta2_args: Zeta2Args,
     #[arg(long)]
     use_expected_context: bool,
     #[clap(long, value_enum, default_value_t = CacheMode::default())]
@@ -74,7 +74,7 @@ pub async fn run_evaluate(
                         repetition_ix,
                         project,
                         zeta,
-                        args.prompt_format,
+                        args.zeta2_args.prompt_format,
                         args.use_expected_context,
                         !args.skip_prediction,
                         args.cache,

--- a/crates/zeta_cli/src/evaluate.rs
+++ b/crates/zeta_cli/src/evaluate.rs
@@ -8,15 +8,16 @@ use anyhow::Result;
 use collections::HashSet;
 use gpui::{AsyncApp, Entity};
 use project::Project;
+use sweep_ai::SweepAi;
 use util::ResultExt as _;
 use zeta2::{Zeta, udiff::DiffLine};
 
 use crate::{
-    EvaluateArguments, PredictionOptions,
+    EvaluateArguments, PredictionOptions, PredictionProvider,
     example::{Example, NamedExample},
     headless::ZetaCliAppState,
     paths::print_run_data_dir,
-    predict::{PredictionDetails, perform_predict},
+    predict::{PredictionDetails, perform_predict, setup_sweep, setup_zeta},
 };
 
 #[derive(Debug)]
@@ -42,35 +43,49 @@ pub async fn run_evaluate(
         let example = NamedExample::load(&path).expect("Failed to load example");
 
         cx.spawn(async move |cx| {
-            let (project, zetas, _edited_buffers) = example
-                .setup_project(&app_state, args.repetitions, cx)
-                .await
-                .unwrap();
+            let project = example.setup_project(&app_state, cx).await.unwrap();
 
-            let tasks = zetas
-                .into_iter()
-                .enumerate()
-                .map(move |(repetition_ix, zeta)| {
-                    let repetition_ix = (args.repetitions > 1).then(|| repetition_ix as u16);
-                    let example = example.clone();
-                    let project = project.clone();
-                    let options = options.clone();
+            let providers = (0..args.repetitions)
+                .map(|_| {
+                    (
+                        setup_zeta(&project, &app_state, cx).unwrap(),
+                        if matches!(args.options.provider, PredictionProvider::Sweep) {
+                            Some(setup_sweep(&project, cx).unwrap())
+                        } else {
+                            None
+                        },
+                    )
+                })
+                .collect::<Vec<_>>();
 
-                    cx.spawn(async move |cx| {
-                        let name = example.name.clone();
-                        run_evaluate_one(
-                            example,
-                            repetition_ix,
-                            project,
-                            zeta,
-                            options,
-                            !args.skip_prediction,
-                            cx,
-                        )
-                        .await
-                        .map_err(|err| (err, name, repetition_ix))
-                    })
-                });
+            let _edited_buffers = example.apply_edit_history(&project, cx).await.unwrap();
+
+            let tasks =
+                providers
+                    .into_iter()
+                    .enumerate()
+                    .map(move |(repetition_ix, (zeta, sweep))| {
+                        let repetition_ix = (args.repetitions > 1).then(|| repetition_ix as u16);
+                        let example = example.clone();
+                        let project = project.clone();
+                        let options = options.clone();
+
+                        cx.spawn(async move |cx| {
+                            let name = example.name.clone();
+                            run_evaluate_one(
+                                example,
+                                repetition_ix,
+                                project,
+                                zeta,
+                                sweep,
+                                options,
+                                !args.skip_prediction,
+                                cx,
+                            )
+                            .await
+                            .map_err(|err| (err, name, repetition_ix))
+                        })
+                    });
             futures::future::join_all(tasks).await
         })
     });
@@ -162,6 +177,7 @@ pub async fn run_evaluate_one(
     repetition_ix: Option<u16>,
     project: Entity<Project>,
     zeta: Entity<Zeta>,
+    sweep: Option<Entity<SweepAi>>,
     prediction_options: PredictionOptions,
     predict: bool,
     cx: &mut AsyncApp,
@@ -170,6 +186,7 @@ pub async fn run_evaluate_one(
         example.clone(),
         project,
         zeta,
+        sweep,
         repetition_ix,
         prediction_options,
         cx,

--- a/crates/zeta_cli/src/evaluate.rs
+++ b/crates/zeta_cli/src/evaluate.rs
@@ -1,12 +1,10 @@
 use std::{
     collections::{BTreeSet, HashMap},
     io::{IsTerminal, Write},
-    path::PathBuf,
     sync::Arc,
 };
 
 use anyhow::Result;
-use clap::Args;
 use collections::HashSet;
 use gpui::{AsyncApp, Entity};
 use project::Project;
@@ -14,27 +12,12 @@ use util::ResultExt as _;
 use zeta2::{Zeta, udiff::DiffLine};
 
 use crate::{
-    PromptFormat, Zeta2Args,
+    CacheMode, EvaluateArguments, PromptFormat,
     example::{Example, NamedExample},
     headless::ZetaCliAppState,
     paths::print_run_data_dir,
-    predict::{CacheMode, PredictionDetails, zeta2_predict},
+    predict::{PredictionDetails, perform_predict},
 };
-
-#[derive(Debug, Args)]
-pub struct EvaluateArguments {
-    example_paths: Vec<PathBuf>,
-    #[clap(flatten)]
-    zeta2_args: Zeta2Args,
-    #[arg(long)]
-    use_expected_context: bool,
-    #[clap(long, value_enum, default_value_t = CacheMode::default())]
-    cache: CacheMode,
-    #[clap(short, long, default_value_t = 1, alias = "repeat")]
-    repetitions: u16,
-    #[arg(long)]
-    skip_prediction: bool,
-}
 
 #[derive(Debug)]
 pub(crate) struct ExecutionData {
@@ -181,7 +164,7 @@ pub async fn run_evaluate_one(
     cache_mode: CacheMode,
     cx: &mut AsyncApp,
 ) -> Result<(EvaluationResult, ExecutionData)> {
-    let predict_result = zeta2_predict(
+    let predict_result = perform_predict(
         example.clone(),
         project,
         zeta,

--- a/crates/zeta_cli/src/example.rs
+++ b/crates/zeta_cli/src/example.rs
@@ -318,8 +318,8 @@ impl NamedExample {
         }
     }
 
-    pub async fn setup_project<'a>(
-        &'a self,
+    pub async fn setup_project(
+        &self,
         app_state: &Arc<ZetaCliAppState>,
         cx: &mut AsyncApp,
     ) -> Result<Entity<Project>> {

--- a/crates/zeta_cli/src/example.rs
+++ b/crates/zeta_cli/src/example.rs
@@ -20,13 +20,13 @@ use futures::{
     lock::{Mutex, OwnedMutexGuard},
 };
 use futures::{FutureExt as _, future::Shared};
-use gpui::{AppContext as _, AsyncApp, Entity, Task, http_client::Url};
+use gpui::{AsyncApp, Entity, Task, http_client::Url};
 use language::{Anchor, Buffer};
 use project::{Project, ProjectPath};
 use pulldown_cmark::CowStr;
 use serde::{Deserialize, Serialize};
 use util::{paths::PathStyle, rel_path::RelPath};
-use zeta2::{Zeta, udiff::OpenedBuffers};
+use zeta2::udiff::OpenedBuffers;
 
 use crate::paths::{REPOS_DIR, WORKTREES_DIR};
 
@@ -321,9 +321,8 @@ impl NamedExample {
     pub async fn setup_project<'a>(
         &'a self,
         app_state: &Arc<ZetaCliAppState>,
-        repetitions: u16,
         cx: &mut AsyncApp,
-    ) -> Result<(Entity<Project>, Vec<Entity<Zeta>>, OpenedBuffers<'a>)> {
+    ) -> Result<Entity<Project>> {
         let worktree_path = self.setup_worktree().await?;
 
         static AUTHENTICATED: OnceLock<Shared<Task<()>>> = OnceLock::new();
@@ -365,33 +364,7 @@ impl NamedExample {
             })?
             .await;
 
-        let buffer_store = project.read_with(cx, |project, _| project.buffer_store().clone())?;
-
-        let zetas = (0..repetitions)
-            .map(|_| {
-                let zeta = cx.new(|cx| {
-                    zeta2::Zeta::new(app_state.client.clone(), app_state.user_store.clone(), cx)
-                })?;
-
-                cx.subscribe(&buffer_store, {
-                    let project = project.clone();
-                    let zeta = zeta.clone();
-                    move |_, event, cx| match event {
-                        project::buffer_store::BufferStoreEvent::BufferAdded(buffer) => {
-                            zeta.update(cx, |zeta, cx| zeta.register_buffer(&buffer, &project, cx));
-                        }
-                        _ => {}
-                    }
-                })?
-                .detach();
-
-                anyhow::Ok(zeta)
-            })
-            .collect::<Result<Vec<_>>>()?;
-
-        let edited_buffers = self.apply_edit_history(&project, cx).await?;
-
-        anyhow::Ok((project, zetas, edited_buffers))
+        anyhow::Ok(project)
     }
 
     pub async fn setup_worktree(&self) -> Result<PathBuf> {

--- a/crates/zeta_cli/src/main.rs
+++ b/crates/zeta_cli/src/main.rs
@@ -73,7 +73,7 @@ struct ContextStatsArgs {
 #[derive(Debug, Args)]
 struct ContextArgs {
     #[arg(long)]
-    engine: ContextEngine,
+    provider: ContextProvider,
     #[arg(long)]
     worktree: PathBuf,
     #[arg(long)]
@@ -87,7 +87,7 @@ struct ContextArgs {
 }
 
 #[derive(clap::ValueEnum, Default, Debug, Clone, Copy)]
-enum ContextEngine {
+enum ContextProvider {
     Zeta1,
     #[default]
     Syntax,
@@ -132,6 +132,8 @@ pub struct PredictionOptions {
     use_expected_context: bool,
     #[clap(flatten)]
     zeta2: Zeta2Args,
+    #[clap(long)]
+    provider: PredictionProvider,
     #[clap(long, value_enum, default_value_t = CacheMode::default())]
     cache: CacheMode,
 }
@@ -490,15 +492,17 @@ fn main() {
                     println!("{}", result.unwrap());
                 }
                 Some(Command::Context(context_args)) => {
-                    let result = match context_args.engine {
-                        ContextEngine::Zeta1 => {
+                    let result = match context_args.provider {
+                        ContextProvider::Zeta1 => {
                             let context =
                                 zeta1_context(context_args, &app_state, cx).await.unwrap();
                             serde_json::to_string_pretty(&context.body).unwrap()
                         }
-                        ContextEngine::Syntax => zeta2_syntax_context(context_args, &app_state, cx)
-                            .await
-                            .unwrap(),
+                        ContextProvider::Syntax => {
+                            zeta2_syntax_context(context_args, &app_state, cx)
+                                .await
+                                .unwrap()
+                        }
                     };
                     println!("{}", result);
                 }

--- a/crates/zeta_cli/src/predict.rs
+++ b/crates/zeta_cli/src/predict.rs
@@ -138,94 +138,6 @@ pub async fn perform_predict(
     let (cursor_buffer, cursor_anchor) = example.cursor_position(&project, cx).await?;
 
     let result = Arc::new(Mutex::new(PredictionDetails::new(example_run_dir.clone())));
-    let mut debug_rx = zeta.update(cx, |zeta, _| zeta.debug_info())?;
-
-    let debug_task = cx.background_spawn({
-        let result = result.clone();
-        async move {
-            let mut start_time = None;
-            let mut search_queries_generated_at = None;
-            let mut search_queries_executed_at = None;
-            while let Some(event) = debug_rx.next().await {
-                match event {
-                    zeta2::ZetaDebugInfo::ContextRetrievalStarted(info) => {
-                        start_time = Some(info.timestamp);
-                        fs::write(
-                            example_run_dir.join("search_prompt.md"),
-                            &info.search_prompt,
-                        )?;
-                    }
-                    zeta2::ZetaDebugInfo::SearchQueriesGenerated(info) => {
-                        search_queries_generated_at = Some(info.timestamp);
-                        fs::write(
-                            example_run_dir.join("search_queries.json"),
-                            serde_json::to_string_pretty(&info.search_queries).unwrap(),
-                        )?;
-                    }
-                    zeta2::ZetaDebugInfo::SearchQueriesExecuted(info) => {
-                        search_queries_executed_at = Some(info.timestamp);
-                    }
-                    zeta2::ZetaDebugInfo::ContextRetrievalFinished(_info) => {}
-                    zeta2::ZetaDebugInfo::EditPredictionRequested(request) => {
-                        let prediction_started_at = Instant::now();
-                        start_time.get_or_insert(prediction_started_at);
-                        let prompt = request.local_prompt.unwrap_or_default();
-                        fs::write(example_run_dir.join("prediction_prompt.md"), &prompt)?;
-
-                        {
-                            let mut result = result.lock().unwrap();
-                            result.prompt_len = prompt.chars().count();
-
-                            for included_file in request.request.included_files {
-                                let insertions =
-                                    vec![(request.request.cursor_point, CURSOR_MARKER)];
-                                result.excerpts.extend(included_file.excerpts.iter().map(
-                                    |excerpt| ActualExcerpt {
-                                        path: included_file.path.components().skip(1).collect(),
-                                        text: String::from(excerpt.text.as_ref()),
-                                    },
-                                ));
-                                write_codeblock(
-                                    &included_file.path,
-                                    included_file.excerpts.iter(),
-                                    if included_file.path == request.request.excerpt_path {
-                                        &insertions
-                                    } else {
-                                        &[]
-                                    },
-                                    included_file.max_row,
-                                    false,
-                                    &mut result.excerpts_text,
-                                );
-                            }
-                        }
-
-                        let response = request.response_rx.await?.0.map_err(|err| anyhow!(err))?;
-                        let response = zeta2::text_from_response(response).unwrap_or_default();
-                        let prediction_finished_at = Instant::now();
-                        fs::write(example_run_dir.join("prediction_response.md"), &response)?;
-
-                        let mut result = result.lock().unwrap();
-                        result.generated_len = response.chars().count();
-
-                        if !options.use_expected_context {
-                            result.planning_search_time =
-                                Some(search_queries_generated_at.unwrap() - start_time.unwrap());
-                            result.running_search_time = Some(
-                                search_queries_executed_at.unwrap()
-                                    - search_queries_generated_at.unwrap(),
-                            );
-                        }
-                        result.prediction_time = prediction_finished_at - prediction_started_at;
-                        result.total_time = prediction_finished_at - start_time.unwrap();
-
-                        break;
-                    }
-                }
-            }
-            anyhow::Ok(())
-        }
-    });
 
     let prompt_format = options.zeta2.prompt_format;
 
@@ -235,61 +147,190 @@ pub async fn perform_predict(
         zeta.set_options(options);
     })?;
 
-    if options.use_expected_context {
-        let context_excerpts_tasks = example
-            .example
-            .expected_context
-            .iter()
-            .flat_map(|section| {
-                section.alternatives[0].excerpts.iter().map(|excerpt| {
-                    resolve_context_entry(project.clone(), excerpt.clone(), cx.clone())
-                })
-            })
-            .collect::<Vec<_>>();
-        let context_excerpts_vec = futures::future::try_join_all(context_excerpts_tasks).await?;
-
-        let mut context_excerpts = HashMap::default();
-        for (buffer, mut excerpts) in context_excerpts_vec {
-            context_excerpts
-                .entry(buffer)
-                .or_insert(Vec::new())
-                .append(&mut excerpts);
-        }
-
-        zeta.update(cx, |zeta, _cx| {
-            zeta.set_context(project.clone(), context_excerpts)
-        })?;
-    } else {
-        zeta.update(cx, |zeta, cx| {
-            zeta.refresh_context(project.clone(), cursor_buffer.clone(), cursor_anchor, cx)
-        })?
-        .await?;
-    }
-
     let prediction = match options.provider {
         crate::PredictionProvider::Zeta2 => {
-            zeta.update(cx, |zeta, cx| {
-                zeta.request_prediction(&project, &cursor_buffer, cursor_anchor, cx)
-            })?
-            .await?
+            let mut debug_rx = zeta.update(cx, |zeta, _| zeta.debug_info())?;
+
+            let debug_task = cx.background_spawn({
+                let result = result.clone();
+                async move {
+                    let mut start_time = None;
+                    let mut search_queries_generated_at = None;
+                    let mut search_queries_executed_at = None;
+                    while let Some(event) = debug_rx.next().await {
+                        match event {
+                            zeta2::ZetaDebugInfo::ContextRetrievalStarted(info) => {
+                                start_time = Some(info.timestamp);
+                                fs::write(
+                                    example_run_dir.join("search_prompt.md"),
+                                    &info.search_prompt,
+                                )?;
+                            }
+                            zeta2::ZetaDebugInfo::SearchQueriesGenerated(info) => {
+                                search_queries_generated_at = Some(info.timestamp);
+                                fs::write(
+                                    example_run_dir.join("search_queries.json"),
+                                    serde_json::to_string_pretty(&info.search_queries).unwrap(),
+                                )?;
+                            }
+                            zeta2::ZetaDebugInfo::SearchQueriesExecuted(info) => {
+                                search_queries_executed_at = Some(info.timestamp);
+                            }
+                            zeta2::ZetaDebugInfo::ContextRetrievalFinished(_info) => {}
+                            zeta2::ZetaDebugInfo::EditPredictionRequested(request) => {
+                                let prediction_started_at = Instant::now();
+                                start_time.get_or_insert(prediction_started_at);
+                                let prompt = request.local_prompt.unwrap_or_default();
+                                fs::write(example_run_dir.join("prediction_prompt.md"), &prompt)?;
+
+                                {
+                                    let mut result = result.lock().unwrap();
+                                    result.prompt_len = prompt.chars().count();
+
+                                    for included_file in request.request.included_files {
+                                        let insertions =
+                                            vec![(request.request.cursor_point, CURSOR_MARKER)];
+                                        result.excerpts.extend(included_file.excerpts.iter().map(
+                                            |excerpt| {
+                                                ActualExcerpt {
+                                                    path: included_file
+                                                        .path
+                                                        .components()
+                                                        .skip(1)
+                                                        .collect(),
+                                                    text: String::from(excerpt.text.as_ref()),
+                                                }
+                                            },
+                                        ));
+                                        write_codeblock(
+                                            &included_file.path,
+                                            included_file.excerpts.iter(),
+                                            if included_file.path == request.request.excerpt_path {
+                                                &insertions
+                                            } else {
+                                                &[]
+                                            },
+                                            included_file.max_row,
+                                            false,
+                                            &mut result.excerpts_text,
+                                        );
+                                    }
+                                }
+
+                                let response =
+                                    request.response_rx.await?.0.map_err(|err| anyhow!(err))?;
+                                let response =
+                                    zeta2::text_from_response(response).unwrap_or_default();
+                                let prediction_finished_at = Instant::now();
+                                fs::write(
+                                    example_run_dir.join("prediction_response.md"),
+                                    &response,
+                                )?;
+
+                                let mut result = result.lock().unwrap();
+                                result.generated_len = response.chars().count();
+
+                                if !options.use_expected_context {
+                                    result.planning_search_time = Some(
+                                        search_queries_generated_at.unwrap() - start_time.unwrap(),
+                                    );
+                                    result.running_search_time = Some(
+                                        search_queries_executed_at.unwrap()
+                                            - search_queries_generated_at.unwrap(),
+                                    );
+                                }
+                                result.prediction_time =
+                                    prediction_finished_at - prediction_started_at;
+                                result.total_time = prediction_finished_at - start_time.unwrap();
+
+                                break;
+                            }
+                        }
+                    }
+                    anyhow::Ok(())
+                }
+            });
+
+            if options.use_expected_context {
+                let context_excerpts_tasks = example
+                    .example
+                    .expected_context
+                    .iter()
+                    .flat_map(|section| {
+                        section.alternatives[0].excerpts.iter().map(|excerpt| {
+                            resolve_context_entry(project.clone(), excerpt.clone(), cx.clone())
+                        })
+                    })
+                    .collect::<Vec<_>>();
+                let context_excerpts_vec =
+                    futures::future::try_join_all(context_excerpts_tasks).await?;
+
+                let mut context_excerpts = HashMap::default();
+                for (buffer, mut excerpts) in context_excerpts_vec {
+                    context_excerpts
+                        .entry(buffer)
+                        .or_insert(Vec::new())
+                        .append(&mut excerpts);
+                }
+
+                zeta.update(cx, |zeta, _cx| {
+                    zeta.set_context(project.clone(), context_excerpts)
+                })?;
+            } else {
+                zeta.update(cx, |zeta, cx| {
+                    zeta.refresh_context(project.clone(), cursor_buffer.clone(), cursor_anchor, cx)
+                })?
+                .await?;
+            }
+
+            let prediction = zeta
+                .update(cx, |zeta, cx| {
+                    zeta.request_prediction(&project, &cursor_buffer, cursor_anchor, cx)
+                })?
+                .await?
+                .map(|prediction| (prediction.buffer, prediction.snapshot, prediction.edits));
+
+            debug_task.await?;
+
+            prediction
         }
-        crate::PredictionProvider::Sweep => sweep.unwrap().update(cx, |sweep, cx| {
-            todo!("use sweep");
-        })?,
+        crate::PredictionProvider::Sweep => {
+            sweep
+                .unwrap()
+                .update(cx, |sweep, cx| {
+                    // todo! these should be sorted by timestamp
+                    let recent_buffers = zeta
+                        .read(cx)
+                        .history_for_project(&project)
+                        .filter_map(|event| event.project_path(cx))
+                        .collect::<Box<[_]>>();
+                    sweep.request_completion(
+                        &project,
+                        recent_buffers.into_iter(),
+                        &cursor_buffer,
+                        cursor_anchor,
+                        cx,
+                    )
+                })?
+                .await?
+                .map(
+                    |sweep_ai::EditPrediction {
+                         edits, snapshot, ..
+                     }| { (cursor_buffer.clone(), snapshot, edits) },
+                )
+        }
     };
 
-    debug_task.await?;
-
     let mut result = Arc::into_inner(result).unwrap().into_inner().unwrap();
+
     result.diff = prediction
-        .map(|prediction| {
-            let old_text = prediction.snapshot.text();
-            let new_text = prediction
-                .buffer
+        .map(|(buffer, snapshot, edits)| {
+            let old_text = snapshot.text();
+            let new_text = buffer
                 .update(cx, |buffer, cx| {
                     let branch = buffer.branch(cx);
                     branch.update(cx, |branch, cx| {
-                        branch.edit(prediction.edits.iter().cloned(), None, cx);
+                        branch.edit(edits.iter().cloned(), None, cx);
                         branch.text()
                     })
                 })

--- a/crates/zeta_cli/src/predict.rs
+++ b/crates/zeta_cli/src/predict.rs
@@ -1,7 +1,7 @@
-use crate::PromptFormat;
 use crate::example::{ActualExcerpt, ExpectedExcerpt, NamedExample};
 use crate::headless::ZetaCliAppState;
 use crate::paths::{CACHE_DIR, LATEST_EXAMPLE_RUN_DIR, RUN_DIR, print_run_data_dir};
+use crate::{PromptFormat, Zeta2Args};
 use ::serde::Serialize;
 use anyhow::{Context, Result, anyhow};
 use clap::{Args, ValueEnum};
@@ -23,8 +23,8 @@ use zeta2::{EvalCache, EvalCacheEntryKind, EvalCacheKey, Zeta};
 
 #[derive(Debug, Args)]
 pub struct PredictArguments {
-    #[arg(long, value_enum, default_value_t = PromptFormat::default())]
-    prompt_format: PromptFormat,
+    #[clap(flatten)]
+    options: Zeta2Args,
     #[arg(long)]
     use_expected_context: bool,
     #[clap(long, short, value_enum, default_value_t = PredictionsOutputFormat::Md)]
@@ -89,7 +89,7 @@ pub async fn run_zeta2_predict(
         project,
         zetas.remove(0),
         None,
-        args.prompt_format,
+        args.options.prompt_format,
         args.use_expected_context,
         args.cache,
         cx,


### PR DESCRIPTION
This PR restructures the subcommands in `zeta-cli`, so that the prediction engine (currently `zeta1` vs `zeta2`) is no longer the highest order subcommand. Instead, there is just one layer of subcommands: `eval`, `predict`, `context`, etc. Within these commands, there are flags for using `zeta1`, `zeta2`, and now `sweep`.

Release Notes:

- N/A
