### PR TITLE
Bump fsevent tests timeout to 30s on CI

### DIFF
--- a/crates/fsevent/src/fsevent.rs
+++ b/crates/fsevent/src/fsevent.rs
@@ -500,12 +500,17 @@ mod tests {
     }
 
     fn flush_historical_events() {
-        thread::sleep(timeout());
+        let timeout = if std::env::var("CI").is_ok() {
+            Duration::from_secs(2)
+        } else {
+            Duration::from_millis(500)
+        };
+        thread::sleep(timeout);
     }
 
     fn timeout() -> Duration {
         if std::env::var("CI").is_ok() {
-            Duration::from_secs(4)
+            Duration::from_secs(30)
         } else {
             Duration::from_millis(500)
         }


### PR DESCRIPTION
Refs #42960 

I managed to reproduce the flakiness locally with a timeout of 500ms. Bumping the timeout to 4s locally solved the issue, so I suspect the flakiness just has to do with how busy the fsevent subsystem is at any given moment. This pull request uses a very long timeout on CI to ensure we eventually get the event we're expecting.

Release Notes:

- N/A
