### PR TITLE
vim: Disable IME in normal mode on Windows

### DIFF
--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -553,6 +553,9 @@ pub(crate) trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
 
     fn update_ime_position(&self, _bounds: Bounds<Pixels>);
 
+    fn enable_ime(&self) {}
+    fn disable_ime(&self) {}
+
     #[cfg(any(test, feature = "test-support"))]
     fn as_test(&mut self) -> Option<&mut TestWindow> {
         None

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -927,8 +927,6 @@ impl PlatformWindow for WindowsWindow {
         let hwnd = self.0.hwnd;
         unsafe {
             use std::ptr;
-            eprintln!("disable_ime called");
-
             ImmAssociateContext(hwnd, HIMC(ptr::null_mut()));
         }
     }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -4746,6 +4746,16 @@ impl Window {
     pub fn set_modifiers(&mut self, modifiers: Modifiers) {
         self.modifiers = modifiers;
     }
+
+    /// Enable IME input.
+    pub fn enable_ime(&self) {
+        self.platform_window.enable_ime();
+    }
+
+    /// Disable IME input.
+    pub fn disable_ime(&self) {
+        self.platform_window.disable_ime();
+    }
 }
 
 // #[derive(Clone, Copy, Eq, PartialEq, Hash)]

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -1136,6 +1136,18 @@ impl Vim {
         self.operator_stack.clear();
         self.selected_register.take();
         self.cancel_running_command(window, cx);
+
+        #[cfg(target_os = "windows")]
+        {
+            if last_mode == Mode::Insert && mode != Mode::Insert {
+                // disable IME when leaving Insert mode
+                window.disable_ime();
+            } else if mode == Mode::Insert && last_mode != Mode::Insert {
+                // enable IME when entering Insert mode
+                window.enable_ime();
+            }
+        }
+
         if mode == Mode::Normal || mode != last_mode {
             self.current_tx.take();
             self.current_anchor.take();


### PR DESCRIPTION
## Summary

Automatically disables IME (Input Method Editor) when exiting Vim Insert mode on Windows.

Fixes the issue where Japanese IME input would appear in Normal mode.

Related discussion: #42444 (user reported similar issues with Chinese IME)

## Changes

- Added `enable_ime()` and `disable_ime()` methods to `PlatformWindow` trait
- Implemented IME context preservation in Windows platform layer
- Vim mode switching now controls IME state on Windows

## Behavior

### Before
- IME remains active in Normal mode
- Pressing movement keys (j, k, h, l) triggers IME conversion candidates
- This causes unintended character input such as "っj", "っk", "っh", "っl" to appear in the editor instead of executing Vim commands
- Users must disable IME manually


### After
- **Insert mode**: IME enabled, previous state preserved
- **Normal mode**: IME automatically disabled
- **Return to Insert mode**: IME re-enabled with previous state

## Testing

Tested manually on Windows 11 with Japanese IME:
- [x] IME disabled when exited Insert mode pressing ESC
- [x] IME re-enabled when pressing `i` (Insert mode)
- [x] IME state (on/off) preserved across mode switches
- [x] No ghost input or candidate window issues

---

Release Notes:

- N/A