### PR TITLE
gpui: Restore last window close behavior on macOS

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -1410,7 +1410,7 @@ impl App {
                 let quit_on_empty = match cx.quit_mode {
                     QuitMode::Explicit => false,
                     QuitMode::LastWindowClosed => true,
-                    QuitMode::Default => !cfg!(macos),
+                    QuitMode::Default => cfg!(not(target_os = "macos")),
                 };
 
                 if quit_on_empty && cx.windows.is_empty() {


### PR DESCRIPTION
Follow-up to https://github.com/zed-industries/zed/pull/42391

Release Notes:

- Fixed an issue where Zed did not respect the `on_last_window_closed` setting on macOS
