### PR TITLE
git: Move pending ops container out of snapshot

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -2713,14 +2713,8 @@ impl GitPanel {
                         self.single_staged_entry = single_staged_entry;
                     }
                 }
-            } else if repo
-                .pending_ops_by_path
-                .summary()
-                .item_summary
-                .staging_count
-                == 1
-            {
-                self.single_staged_entry = repo.pending_ops_by_path.iter().find_map(|ops| {
+            } else if repo.pending_ops_summary().item_summary.staging_count == 1 {
+                self.single_staged_entry = repo.pending_ops().find_map(|ops| {
                     if ops.staging() {
                         repo.status_for_path(&ops.repo_path)
                             .map(|status| GitStatusEntry {

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -8611,7 +8611,7 @@ async fn test_repository_pending_ops_staging(
 
     // Ensure we have no pending ops for any of the untracked files
     repo.read_with(cx, |repo, _cx| {
-        assert!(repo.pending_ops_by_path.is_empty());
+        assert!(repo.pending_ops().next().is_none());
     });
 
     let mut id = 1u16;


### PR DESCRIPTION
This also fixes staging checkbox flickering.

Release Notes:

- Fixed staging checkbox flickering sporadically in the Git panel.
