### PR TITLE
gpui: Implement GPU device loss recovery for Linux X11

### DIFF
--- a/crates/gpui/src/platform/blade/blade_atlas.rs
+++ b/crates/gpui/src/platform/blade/blade_atlas.rs
@@ -61,6 +61,24 @@ impl BladeAtlas {
         self.0.lock().destroy();
     }
 
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    pub(crate) fn handle_device_lost(&self) {
+        let mut lock = self.0.lock();
+        lock.storage = BladeAtlasStorage::default();
+        lock.tiles_by_key.clear();
+    }
+
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    pub(crate) fn update_gpu_context(&self, new_gpu: &Arc<gpu::Context>) {
+        let mut lock = self.0.lock();
+        lock.gpu = Arc::clone(new_gpu);
+        lock.upload_belt = BufferBelt::new(BufferBeltDescriptor {
+            memory: gpu::Memory::Upload,
+            min_chunk_size: 0x10000,
+            alignment: 64,
+        });
+    }
+
     pub fn before_frame(&self, gpu_encoder: &mut gpu::CommandEncoder) {
         let mut lock = self.0.lock();
         lock.flush(gpu_encoder);

--- a/crates/gpui/src/platform/blade/blade_atlas.rs
+++ b/crates/gpui/src/platform/blade/blade_atlas.rs
@@ -64,8 +64,7 @@ impl BladeAtlas {
     #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     pub(crate) fn handle_device_lost(&self) {
         let mut lock = self.0.lock();
-        let gpu = Arc::clone(&lock.gpu);
-        lock.storage.clear_and_reuse(&gpu);
+        lock.storage.clear_without_destroy();
         lock.tiles_by_key.clear();
         lock.initializations.clear();
         lock.uploads.clear();
@@ -328,14 +327,10 @@ impl BladeAtlasStorage {
         }
     }
 
-    fn clear_and_reuse(&mut self, gpu: &gpu::Context) {
-        for mut texture in self.monochrome_textures.textures.drain(..).flatten() {
-            texture.destroy(gpu);
-        }
-        for mut texture in self.polychrome_textures.textures.drain(..).flatten() {
-            texture.destroy(gpu);
-        }
-
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+    fn clear_without_destroy(&mut self) {
+        self.monochrome_textures.textures.clear();
+        self.polychrome_textures.textures.clear();
         self.monochrome_textures.free_list.clear();
         self.polychrome_textures.free_list.clear();
     }

--- a/crates/gpui/src/platform/blade/blade_renderer.rs
+++ b/crates/gpui/src/platform/blade/blade_renderer.rs
@@ -653,7 +653,6 @@ impl BladeRenderer {
     }
 
     #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
-    /// Used to recover from GPU hangs caused by suspend/resume or driver issues.
     pub fn recreate_after_device_loss<
         I: raw_window_handle::HasWindowHandle + raw_window_handle::HasDisplayHandle,
     >(
@@ -839,7 +838,9 @@ impl BladeRenderer {
                     texture_id,
                     sprites,
                 } => {
-                    let tex_info = self.atlas.get_texture_info(texture_id);
+                    let Some(tex_info) = self.atlas.get_texture_info(texture_id) else {
+                        continue;
+                    };
                     let instance_buf =
                         unsafe { self.instance_belt.alloc_typed(sprites, &self.gpu) };
                     let mut encoder = pass.with(&self.pipelines.mono_sprites);
@@ -862,7 +863,9 @@ impl BladeRenderer {
                     texture_id,
                     sprites,
                 } => {
-                    let tex_info = self.atlas.get_texture_info(texture_id);
+                    let Some(tex_info) = self.atlas.get_texture_info(texture_id) else {
+                        continue;
+                    };
                     let instance_buf =
                         unsafe { self.instance_belt.alloc_typed(sprites, &self.gpu) };
                     let mut encoder = pass.with(&self.pipelines.poly_sprites);

--- a/crates/gpui/src/platform/blade/blade_renderer.rs
+++ b/crates/gpui/src/platform/blade/blade_renderer.rs
@@ -963,8 +963,15 @@ impl BladeRenderer {
             })) {
                 Ok(sp) => sp,
                 Err(e) => {
-                    log::error!("GPU submit panicked - device lost: {:?}", e);
-                    return Err(anyhow::anyhow!("GPU device crashed during submit"));
+                    let msg = if let Some(s) = e.downcast_ref::<String>() {
+                        s.as_str()
+                    } else if let Some(s) = e.downcast_ref::<&str>() {
+                        *s
+                    } else {
+                        "unknown panic"
+                    };
+                    log::error!("GPU crash: {}", msg);
+                    return Err(anyhow::anyhow!("GPU device crashed during submit: {}", msg));
                 }
             }
         };

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -9,6 +9,7 @@ use std::{
 use blade_graphics as gpu;
 use collections::HashMap;
 use futures::channel::oneshot::Receiver;
+use util::ResultExt;
 
 use raw_window_handle as rwh;
 use wayland_backend::client::ObjectId;
@@ -1213,7 +1214,7 @@ impl PlatformWindow for WaylandWindow {
 
     fn draw(&self, scene: &Scene) {
         let mut state = self.borrow_mut();
-        state.renderer.draw(scene);
+        state.renderer.draw(scene).log_err();
     }
 
     fn completed_frame(&self) {

--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -789,6 +789,16 @@ impl X11Client {
                 let [atom, arg1, arg2, arg3, arg4] = event.data.as_data32();
                 let mut state = self.0.borrow_mut();
 
+                if event.type_ == state.atoms._GPUI_FORCE_UPDATE_WINDOW {
+                    window.mark_renderer_drawable();
+                    drop(state);
+                    window.refresh(RequestFrameOptions {
+                        force_render: true,
+                        require_presentation: false,
+                    });
+                    return None;
+                }
+
                 if atom == state.atoms.WM_DELETE_WINDOW {
                     // window "x" button clicked by user
                     if window.should_close() {

--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -226,6 +226,12 @@ impl X11ClientStatePtr {
         self.0.upgrade().map(X11Client)
     }
 
+    pub(crate) fn update_gpu_context(&self, context: BladeContext) {
+        if let Some(client) = self.get_client() {
+            client.0.borrow_mut().gpu_context = context;
+        }
+    }
+
     pub fn drop_window(&self, x_window: u32) {
         let Some(client) = self.get_client() else {
             return;

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -901,7 +901,11 @@ impl X11Window {
         };
         state
             .renderer
-            .recreate_after_device_loss(&new_context, &raw_window)
+            .recreate_after_device_loss(&new_context, &raw_window)?;
+
+        state.client.update_gpu_context(new_context);
+
+        Ok(())
     }
 
     fn send_force_update(&self, force_update_atom: xproto::Atom) {

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -1471,6 +1471,9 @@ impl PlatformWindow for MacWindow {
 
     fn draw(&self, scene: &crate::Scene) {
         let mut this = self.0.lock();
+        #[cfg(feature = "macos-blade")]
+        this.renderer.draw(scene).log_err();
+        #[cfg(not(feature = "macos-blade"))]
         this.renderer.draw(scene);
     }
 


### PR DESCRIPTION
Closes #32318
Closes #27751 
Partial fix for #23288 (X11 only, not Wayland)


Release Notes:

- Fixed Zed hanging with 100% CPU usage after resuming from sleep on Linux X11 with NVIDIA GPUs

