### PR TITLE
Fix panic in the git panel when toggling `sort_by_path`

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -373,6 +373,7 @@ impl GitPanel {
                 let is_sort_by_path = GitPanelSettings::get_global(cx).sort_by_path;
                 if is_sort_by_path != was_sort_by_path {
                     this.entries.clear();
+                    this.bulk_staging.take();
                     this.update_visible_entries(window, cx);
                 }
                 was_sort_by_path = is_sort_by_path


### PR DESCRIPTION
We call `entry_by_path` on the `bulk_staging` anchor entry at the beginning of `update_visible_entries`, but in the codepath where `sort_by_path` is toggled on or off, we clear entries without clearing `bulk_staging` or counts, causing that `entry_by_path` to do an out of bounds index. Fixed by clearing `bulk_staging` as well.

Release Notes:

- N/A