### PR TITLE
Stop the buggy stalebot for now

### DIFF
--- a/.github/workflows/community_close_stale_issues.yml
+++ b/.github/workflows/community_close_stale_issues.yml
@@ -1,7 +1,7 @@
 name: "Close Stale Issues"
 on:
   schedule:
-    - cron: "0 7,9,11 * * 3"
+    - cron: "0 8 31 DEC *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Delay the stalebot runs until the end of the year since it's currently broken and comments on all the issues including feature requests. Bad bot. Allegedly this bug will soon be gone https://github.com/actions/stale/issues/1302  but it's too much work protecting issues from the bot until then.

Release Notes:

- N/A
