### PR TITLE
Use fixed calloop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2617,26 +2617,24 @@ dependencies = [
 
 [[package]]
 name = "calloop"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
+version = "0.14.3"
+source = "git+https://github.com/zed-industries/calloop#eb6b4fd17b9af5ecc226546bdd04185391b3e265"
 dependencies = [
  "bitflags 2.9.4",
- "log",
  "polling",
- "rustix 0.38.44",
+ "rustix 1.1.2",
  "slab",
- "thiserror 1.0.69",
+ "tracing",
 ]
 
 [[package]]
 name = "calloop-wayland-source"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
+checksum = "138efcf0940a02ebf0cc8d1eff41a1682a46b431630f4c52450d6265876021fa"
 dependencies = [
  "calloop",
- "rustix 0.38.44",
+ "rustix 1.1.2",
  "wayland-backend",
  "wayland-client",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -784,6 +784,7 @@ features = [
 notify = { git = "https://github.com/zed-industries/notify.git", rev = "b4588b2e5aee68f4c0e100f140e808cbce7b1419" }
 notify-types = { git = "https://github.com/zed-industries/notify.git", rev = "b4588b2e5aee68f4c0e100f140e808cbce7b1419" }
 windows-capture = { git = "https://github.com/zed-industries/windows-capture.git", rev = "f0d6c1b6691db75461b732f6d5ff56eed002eeb9" }
+calloop = { git = "https://github.com/zed-industries/calloop" }
 
 [profile.dev]
 split-debuginfo = "unpacked"

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -192,7 +192,7 @@ filedescriptor = { version = "0.8.2", optional = true }
 open = { version = "5.2.0", optional = true }
 
 # Wayland
-calloop-wayland-source = { version = "0.3.0", optional = true }
+calloop-wayland-source = { version = "0.4.1", optional = true }
 wayland-backend = { version = "0.3.3", features = [
     "client_system",
     "dlopen",

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -187,7 +187,7 @@ font-kit = { git = "https://github.com/zed-industries/font-kit", rev = "11052312
     "source-fontconfig-dlopen",
 ], optional = true }
 
-calloop = { version = "0.13.0" }
+calloop = { version = "0.14.3" }
 filedescriptor = { version = "0.8.2", optional = true }
 open = { version = "5.2.0", optional = true }
 


### PR DESCRIPTION
Calloop (used by our linux executor) was running all futures regardless of how long they take. Unfortunaly some of our futures are rather busy and take a while (>10ms).

Running all of them froze the editor for multiple seconds or even minutes when opening a large project diff (git reset HEAD~2000 in chromium for example).

Closes #ISSUE

Release Notes:

- N/A
