### PR TITLE
project_panel: Remove `cmd-opt-.` binding for hiding hidden files

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -43,8 +43,7 @@
       "f11": "zed::ToggleFullScreen",
       "ctrl-alt-z": "edit_prediction::RateCompletions",
       "ctrl-alt-shift-i": "edit_prediction::ToggleMenu",
-      "ctrl-alt-l": "lsp_tool::ToggleMenu",
-      "ctrl-alt-.": "project_panel::ToggleHideHidden"
+      "ctrl-alt-l": "lsp_tool::ToggleMenu"
     }
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -49,8 +49,7 @@
       "ctrl-cmd-f": "zed::ToggleFullScreen",
       "ctrl-cmd-z": "edit_prediction::RateCompletions",
       "ctrl-cmd-i": "edit_prediction::ToggleMenu",
-      "ctrl-cmd-l": "lsp_tool::ToggleMenu",
-      "cmd-alt-.": "project_panel::ToggleHideHidden"
+      "ctrl-cmd-l": "lsp_tool::ToggleMenu"
     }
   },
   {

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -41,8 +41,7 @@
       "shift-f11": "debugger::StepOut",
       "f11": "zed::ToggleFullScreen",
       "ctrl-shift-i": "edit_prediction::ToggleMenu",
-      "shift-alt-l": "lsp_tool::ToggleMenu",
-      "ctrl-alt-.": "project_panel::ToggleHideHidden"
+      "shift-alt-l": "lsp_tool::ToggleMenu"
     }
   },
   {


### PR DESCRIPTION
Lots of folks were accidentally clicking this. Even though it’s the default in macOS Finder, it’s a good idea to not have it as the default for us.

Release Notes:

- Removed the default `cmd-opt-.` binding for toggling hidden files in the Project Panel so it’s harder to hide them by accident.
