### PR TITLE
Passthrough env to npm subcommands when using the system node runtime

### DIFF
--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -414,7 +414,6 @@ impl ManagedNodeRuntime {
 
         let valid = if fs::metadata(&node_binary).await.is_ok() {
             let result = util::command::new_smol_command(&node_binary)
-                .env_clear()
                 .env(NODE_CA_CERTS_ENV_VAR, node_ca_certs)
                 .arg(npm_file)
                 .arg("--version")
@@ -701,7 +700,6 @@ impl NodeRuntimeTrait for SystemNodeRuntime {
         let mut command = util::command::new_smol_command(self.npm.clone());
         let path = path_with_node_binary_prepended(&self.node).unwrap_or_default();
         command
-            .env_clear()
             .env("PATH", path)
             .env(NODE_CA_CERTS_ENV_VAR, node_ca_certs)
             .arg(subcommand)


### PR DESCRIPTION
Closes #39448
Closes #37866

This PR expands the env-clearing fix from #42587 to include the SystemNodeRuntime, which covers Node.js installations managed by Mise. When running under the system runtime, npm subcommands were still launched with a cleared environment, preventing variables such as MISE_DATA_DIR from reaching the shim or the mise binary itself. As a result, Mise finds the npm binary in the default MISE_DATA_DIR, consistent with the behavior described in https://github.com/zed-industries/zed/issues/39448#issuecomment-3433644569.

This change ensures that environment variables are passed through for npm subcommands when using the system Node runtime, restoring expected behavior for Mise-managed Node installations. This also fixes cases where envs are used by npm itself.

Release Notes:

- Enable environment passthrough for npm subcommands
