### PR TITLE
Allow styling the container of markdown elements

### DIFF
--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -893,7 +893,6 @@ impl InfoPopover {
                 *keyboard_grace = false;
                 cx.stop_propagation();
             })
-            .p_2()
             .when_some(self.parsed_content.clone(), |this, markdown| {
                 this.child(
                     div()
@@ -909,7 +908,8 @@ impl InfoPopover {
                                     copy_button_on_hover: false,
                                     border: false,
                                 })
-                                .on_url_click(open_markdown_url),
+                                .on_url_click(open_markdown_url)
+                                .p_2(),
                         ),
                 )
                 .custom_scrollbars(


### PR DESCRIPTION
Closes #43033

Release Notes:

- FIxed an issue where the padding on info popovers would overlay text when the content was scrollable.
