### PR TITLE
Debug a test annotated with the ignore attribute if the test name partially matches another test

### DIFF
--- a/crates/project/src/debugger/locators/cargo.rs
+++ b/crates/project/src/debugger/locators/cargo.rs
@@ -206,6 +206,7 @@ impl DapLocator for CargoLocator {
             args.push("--nocapture".to_owned());
             if is_ignored {
                 args.push("--include-ignored".to_owned());
+                args.push("--exact".to_owned());
             }
         }
 


### PR DESCRIPTION
Related: #42574
If an integration test is annotated with the ignore attribute, allow the "debug: Test" option of the debug scenario or Code Action to run with the "--include-ignored" and "--exact" arguments.  Inclusion of "--exact" covers the case where more that one test shares a base name.  For example, consider two tests named "test_no_ace_in_middle_of_straight" and "test_no_ace_in_middle_of_straight_flush."  Without the "--exact" argument both tests would run if a user attempts to debug "test_no_ace_in_middle_of_straight".

Release Notes:

- Improved "debug test" experience in Rust with ignored tests.

