### PR TITLE
Add CollapseAllEntries keybinding to project_panel

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -866,6 +866,7 @@
     "context": "ProjectPanel",
     "bindings": {
       "left": "project_panel::CollapseSelectedEntry",
+      "ctrl-left": "project_panel::CollapseAllEntries",
       "right": "project_panel::ExpandSelectedEntry",
       "new": "project_panel::NewFile",
       "ctrl-n": "project_panel::NewFile",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -936,6 +936,7 @@
     "use_key_equivalents": true,
     "bindings": {
       "left": "project_panel::CollapseSelectedEntry",
+      "cmd-left": "project_panel::CollapseAllEntries",
       "right": "project_panel::ExpandSelectedEntry",
       "cmd-n": "project_panel::NewFile",
       "cmd-d": "project_panel::Duplicate",

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -880,6 +880,7 @@
     "use_key_equivalents": true,
     "bindings": {
       "left": "project_panel::CollapseSelectedEntry",
+      "ctrl-left": "project_panel::CollapseAllEntries",
       "right": "project_panel::ExpandSelectedEntry",
       "ctrl-n": "project_panel::NewFile",
       "alt-n": "project_panel::NewDirectory",


### PR DESCRIPTION
Motivated by user feature requests

* https://github.com/zed-industries/zed/issues/6880
* https://discord.com/channels/869392257814519848/1439453067119562793

In analogy with VSCode functionality, we're adding a keybinding to the project panel.

This is particularly for useful for large monorepos.

Release Notes:

- Keybinding added for `CollapseAllEntries` when in the `ProjectPanel`.
