### PR TITLE
google_ai: Update Gemini models

### DIFF
--- a/crates/google_ai/src/google_ai.rs
+++ b/crates/google_ai/src/google_ai.rs
@@ -492,12 +492,12 @@ pub enum Model {
     #[serde(rename = "gemini-2.0-flash")]
     Gemini20Flash,
     #[serde(
-        rename = "gemini-2.5-flash-lite-latest",
+        rename = "gemini-2.5-flash-lite",
         alias = "gemini-2.5-flash-lite-preview-06-17"
     )]
     Gemini25FlashLite,
     #[serde(
-        rename = "gemini-2.5-flash-latest",
+        rename = "gemini-2.5-flash",
         alias = "gemini-2.0-flash-thinking-exp",
         alias = "gemini-2.5-flash-preview-04-17",
         alias = "gemini-2.5-flash-preview-05-20",
@@ -537,8 +537,8 @@ impl Model {
         match self {
             Self::Gemini20FlashLite => "gemini-2.0-flash-lite",
             Self::Gemini20Flash => "gemini-2.0-flash",
-            Self::Gemini25FlashLite => "gemini-2.5-flash-lite-latest",
-            Self::Gemini25Flash => "gemini-2.5-flash-latest",
+            Self::Gemini25FlashLite => "gemini-2.5-flash-lite",
+            Self::Gemini25Flash => "gemini-2.5-flash",
             Self::Gemini25Pro => "gemini-2.5-pro",
             Self::Gemini3ProPreview => "gemini-3-pro-preview",
             Self::Custom { name, .. } => name,
@@ -548,8 +548,8 @@ impl Model {
         match self {
             Self::Gemini20FlashLite => "gemini-2.0-flash-lite",
             Self::Gemini20Flash => "gemini-2.0-flash",
-            Self::Gemini25FlashLite => "gemini-2.5-flash-lite-latest",
-            Self::Gemini25Flash => "gemini-2.5-flash-latest",
+            Self::Gemini25FlashLite => "gemini-2.5-flash-lite",
+            Self::Gemini25Flash => "gemini-2.5-flash",
             Self::Gemini25Pro => "gemini-2.5-pro",
             Self::Gemini3ProPreview => "gemini-3-pro-preview",
             Self::Custom { name, .. } => name,

--- a/crates/google_ai/src/google_ai.rs
+++ b/crates/google_ai/src/google_ai.rs
@@ -485,15 +485,9 @@ impl<'de> Deserialize<'de> for ModelName {
 #[derive(Clone, Default, Debug, Deserialize, Serialize, PartialEq, Eq, strum::EnumIter)]
 pub enum Model {
     #[serde(
-        rename = "gemini-2.0-flash-lite",
-        alias = "gemini-2.0-flash-lite-preview"
-    )]
-    Gemini20FlashLite,
-    #[serde(rename = "gemini-2.0-flash")]
-    Gemini20Flash,
-    #[serde(
         rename = "gemini-2.5-flash-lite",
-        alias = "gemini-2.5-flash-lite-preview-06-17"
+        alias = "gemini-2.5-flash-lite-preview-06-17",
+        alias = "gemini-2.0-flash-lite-preview"
     )]
     Gemini25FlashLite,
     #[serde(
@@ -501,7 +495,8 @@ pub enum Model {
         alias = "gemini-2.0-flash-thinking-exp",
         alias = "gemini-2.5-flash-preview-04-17",
         alias = "gemini-2.5-flash-preview-05-20",
-        alias = "gemini-2.5-flash-preview-latest"
+        alias = "gemini-2.5-flash-preview-latest",
+        alias = "gemini-2.0-flash"
     )]
     #[default]
     Gemini25Flash,
@@ -535,8 +530,6 @@ impl Model {
 
     pub fn id(&self) -> &str {
         match self {
-            Self::Gemini20FlashLite => "gemini-2.0-flash-lite",
-            Self::Gemini20Flash => "gemini-2.0-flash",
             Self::Gemini25FlashLite => "gemini-2.5-flash-lite",
             Self::Gemini25Flash => "gemini-2.5-flash",
             Self::Gemini25Pro => "gemini-2.5-pro",
@@ -546,8 +539,6 @@ impl Model {
     }
     pub fn request_id(&self) -> &str {
         match self {
-            Self::Gemini20FlashLite => "gemini-2.0-flash-lite",
-            Self::Gemini20Flash => "gemini-2.0-flash",
             Self::Gemini25FlashLite => "gemini-2.5-flash-lite",
             Self::Gemini25Flash => "gemini-2.5-flash",
             Self::Gemini25Pro => "gemini-2.5-pro",
@@ -558,8 +549,6 @@ impl Model {
 
     pub fn display_name(&self) -> &str {
         match self {
-            Self::Gemini20FlashLite => "Gemini 2.0 Flash-Lite",
-            Self::Gemini20Flash => "Gemini 2.0 Flash",
             Self::Gemini25FlashLite => "Gemini 2.5 Flash-Lite",
             Self::Gemini25Flash => "Gemini 2.5 Flash",
             Self::Gemini25Pro => "Gemini 2.5 Pro",
@@ -572,8 +561,6 @@ impl Model {
 
     pub fn max_token_count(&self) -> u64 {
         match self {
-            Self::Gemini20FlashLite => 1_048_576,
-            Self::Gemini20Flash => 1_048_576,
             Self::Gemini25FlashLite => 1_048_576,
             Self::Gemini25Flash => 1_048_576,
             Self::Gemini25Pro => 1_048_576,
@@ -584,8 +571,6 @@ impl Model {
 
     pub fn max_output_tokens(&self) -> Option<u64> {
         match self {
-            Model::Gemini20FlashLite => Some(8_192),
-            Model::Gemini20Flash => Some(8_192),
             Model::Gemini25FlashLite => Some(65_536),
             Model::Gemini25Flash => Some(65_536),
             Model::Gemini25Pro => Some(65_536),
@@ -604,7 +589,6 @@ impl Model {
 
     pub fn mode(&self) -> GoogleModelMode {
         match self {
-            Self::Gemini20FlashLite | Self::Gemini20Flash => GoogleModelMode::Default,
             Self::Gemini25FlashLite
             | Self::Gemini25Flash
             | Self::Gemini25Pro

--- a/crates/google_ai/src/google_ai.rs
+++ b/crates/google_ai/src/google_ai.rs
@@ -511,7 +511,7 @@ pub enum Model {
     )]
     Gemini25Pro,
     #[serde(rename = "gemini-3-pro-preview")]
-    Gemini3ProPreview,
+    Gemini3Pro,
     #[serde(rename = "custom")]
     Custom {
         name: String,
@@ -533,7 +533,7 @@ impl Model {
             Self::Gemini25FlashLite => "gemini-2.5-flash-lite",
             Self::Gemini25Flash => "gemini-2.5-flash",
             Self::Gemini25Pro => "gemini-2.5-pro",
-            Self::Gemini3ProPreview => "gemini-3-pro-preview",
+            Self::Gemini3Pro => "gemini-3-pro-preview",
             Self::Custom { name, .. } => name,
         }
     }
@@ -542,7 +542,7 @@ impl Model {
             Self::Gemini25FlashLite => "gemini-2.5-flash-lite",
             Self::Gemini25Flash => "gemini-2.5-flash",
             Self::Gemini25Pro => "gemini-2.5-pro",
-            Self::Gemini3ProPreview => "gemini-3-pro-preview",
+            Self::Gemini3Pro => "gemini-3-pro-preview",
             Self::Custom { name, .. } => name,
         }
     }
@@ -552,7 +552,7 @@ impl Model {
             Self::Gemini25FlashLite => "Gemini 2.5 Flash-Lite",
             Self::Gemini25Flash => "Gemini 2.5 Flash",
             Self::Gemini25Pro => "Gemini 2.5 Pro",
-            Self::Gemini3ProPreview => "Gemini 3 Pro",
+            Self::Gemini3Pro => "Gemini 3 Pro",
             Self::Custom {
                 name, display_name, ..
             } => display_name.as_ref().unwrap_or(name),
@@ -564,7 +564,7 @@ impl Model {
             Self::Gemini25FlashLite => 1_048_576,
             Self::Gemini25Flash => 1_048_576,
             Self::Gemini25Pro => 1_048_576,
-            Self::Gemini3ProPreview => 1_048_576,
+            Self::Gemini3Pro => 1_048_576,
             Self::Custom { max_tokens, .. } => *max_tokens,
         }
     }
@@ -574,7 +574,7 @@ impl Model {
             Model::Gemini25FlashLite => Some(65_536),
             Model::Gemini25Flash => Some(65_536),
             Model::Gemini25Pro => Some(65_536),
-            Model::Gemini3ProPreview => Some(65_536),
+            Model::Gemini3Pro => Some(65_536),
             Model::Custom { .. } => None,
         }
     }
@@ -592,7 +592,7 @@ impl Model {
             Self::Gemini25FlashLite
             | Self::Gemini25Flash
             | Self::Gemini25Pro
-            | Self::Gemini3ProPreview => {
+            | Self::Gemini3Pro => {
                 GoogleModelMode::Thinking {
                     // By default these models are set to "auto", so we preserve that behavior
                     // but indicate they are capable of thinking mode

--- a/crates/google_ai/src/google_ai.rs
+++ b/crates/google_ai/src/google_ai.rs
@@ -492,12 +492,12 @@ pub enum Model {
     #[serde(rename = "gemini-2.0-flash")]
     Gemini20Flash,
     #[serde(
-        rename = "gemini-2.5-flash-lite-preview",
+        rename = "gemini-2.5-flash-lite-latest",
         alias = "gemini-2.5-flash-lite-preview-06-17"
     )]
-    Gemini25FlashLitePreview,
+    Gemini25FlashLite,
     #[serde(
-        rename = "gemini-2.5-flash",
+        rename = "gemini-2.5-flash-latest",
         alias = "gemini-2.0-flash-thinking-exp",
         alias = "gemini-2.5-flash-preview-04-17",
         alias = "gemini-2.5-flash-preview-05-20",
@@ -537,8 +537,8 @@ impl Model {
         match self {
             Self::Gemini20FlashLite => "gemini-2.0-flash-lite",
             Self::Gemini20Flash => "gemini-2.0-flash",
-            Self::Gemini25FlashLitePreview => "gemini-2.5-flash-lite-preview",
-            Self::Gemini25Flash => "gemini-2.5-flash",
+            Self::Gemini25FlashLite => "gemini-2.5-flash-lite-latest",
+            Self::Gemini25Flash => "gemini-2.5-flash-latest",
             Self::Gemini25Pro => "gemini-2.5-pro",
             Self::Gemini3ProPreview => "gemini-3-pro-preview",
             Self::Custom { name, .. } => name,
@@ -548,8 +548,8 @@ impl Model {
         match self {
             Self::Gemini20FlashLite => "gemini-2.0-flash-lite",
             Self::Gemini20Flash => "gemini-2.0-flash",
-            Self::Gemini25FlashLitePreview => "gemini-2.5-flash-lite-preview-06-17",
-            Self::Gemini25Flash => "gemini-2.5-flash",
+            Self::Gemini25FlashLite => "gemini-2.5-flash-lite-latest",
+            Self::Gemini25Flash => "gemini-2.5-flash-latest",
             Self::Gemini25Pro => "gemini-2.5-pro",
             Self::Gemini3ProPreview => "gemini-3-pro-preview",
             Self::Custom { name, .. } => name,
@@ -560,7 +560,7 @@ impl Model {
         match self {
             Self::Gemini20FlashLite => "Gemini 2.0 Flash-Lite",
             Self::Gemini20Flash => "Gemini 2.0 Flash",
-            Self::Gemini25FlashLitePreview => "Gemini 2.5 Flash-Lite Preview",
+            Self::Gemini25FlashLite => "Gemini 2.5 Flash-Lite",
             Self::Gemini25Flash => "Gemini 2.5 Flash",
             Self::Gemini25Pro => "Gemini 2.5 Pro",
             Self::Gemini3ProPreview => "Gemini 3 Pro",
@@ -574,7 +574,7 @@ impl Model {
         match self {
             Self::Gemini20FlashLite => 1_048_576,
             Self::Gemini20Flash => 1_048_576,
-            Self::Gemini25FlashLitePreview => 1_000_000,
+            Self::Gemini25FlashLite => 1_048_576,
             Self::Gemini25Flash => 1_048_576,
             Self::Gemini25Pro => 1_048_576,
             Self::Gemini3ProPreview => 1_048_576,
@@ -586,7 +586,7 @@ impl Model {
         match self {
             Model::Gemini20FlashLite => Some(8_192),
             Model::Gemini20Flash => Some(8_192),
-            Model::Gemini25FlashLitePreview => Some(64_000),
+            Model::Gemini25FlashLite => Some(65_536),
             Model::Gemini25Flash => Some(65_536),
             Model::Gemini25Pro => Some(65_536),
             Model::Gemini3ProPreview => Some(65_536),
@@ -606,7 +606,7 @@ impl Model {
         match self {
             Self::Gemini20FlashLite
             | Self::Gemini20Flash => GoogleModelMode::Default,
-            Self::Gemini25FlashLitePreview
+            Self::Gemini25FlashLite
             | Self::Gemini25Flash
             | Self::Gemini25Pro
             | Self::Gemini3ProPreview => {

--- a/crates/google_ai/src/google_ai.rs
+++ b/crates/google_ai/src/google_ai.rs
@@ -530,7 +530,7 @@ pub enum Model {
 
 impl Model {
     pub fn default_fast() -> Self {
-        Self::Gemini20FlashLite
+        Self::Gemini25FlashLite
     }
 
     pub fn id(&self) -> &str {

--- a/crates/google_ai/src/google_ai.rs
+++ b/crates/google_ai/src/google_ai.rs
@@ -484,12 +484,6 @@ impl<'de> Deserialize<'de> for ModelName {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Clone, Default, Debug, Deserialize, Serialize, PartialEq, Eq, strum::EnumIter)]
 pub enum Model {
-    #[serde(rename = "gemini-1.5-pro")]
-    Gemini15Pro,
-    #[serde(rename = "gemini-1.5-flash-8b")]
-    Gemini15Flash8b,
-    #[serde(rename = "gemini-1.5-flash")]
-    Gemini15Flash,
     #[serde(
         rename = "gemini-2.0-flash-lite",
         alias = "gemini-2.0-flash-lite-preview"
@@ -541,9 +535,6 @@ impl Model {
 
     pub fn id(&self) -> &str {
         match self {
-            Self::Gemini15Pro => "gemini-1.5-pro",
-            Self::Gemini15Flash8b => "gemini-1.5-flash-8b",
-            Self::Gemini15Flash => "gemini-1.5-flash",
             Self::Gemini20FlashLite => "gemini-2.0-flash-lite",
             Self::Gemini20Flash => "gemini-2.0-flash",
             Self::Gemini25FlashLitePreview => "gemini-2.5-flash-lite-preview",
@@ -555,9 +546,6 @@ impl Model {
     }
     pub fn request_id(&self) -> &str {
         match self {
-            Self::Gemini15Pro => "gemini-1.5-pro",
-            Self::Gemini15Flash8b => "gemini-1.5-flash-8b",
-            Self::Gemini15Flash => "gemini-1.5-flash",
             Self::Gemini20FlashLite => "gemini-2.0-flash-lite",
             Self::Gemini20Flash => "gemini-2.0-flash",
             Self::Gemini25FlashLitePreview => "gemini-2.5-flash-lite-preview-06-17",
@@ -570,9 +558,6 @@ impl Model {
 
     pub fn display_name(&self) -> &str {
         match self {
-            Self::Gemini15Pro => "Gemini 1.5 Pro",
-            Self::Gemini15Flash8b => "Gemini 1.5 Flash-8b",
-            Self::Gemini15Flash => "Gemini 1.5 Flash",
             Self::Gemini20FlashLite => "Gemini 2.0 Flash-Lite",
             Self::Gemini20Flash => "Gemini 2.0 Flash",
             Self::Gemini25FlashLitePreview => "Gemini 2.5 Flash-Lite Preview",
@@ -587,9 +572,6 @@ impl Model {
 
     pub fn max_token_count(&self) -> u64 {
         match self {
-            Self::Gemini15Pro => 2_097_152,
-            Self::Gemini15Flash8b => 1_048_576,
-            Self::Gemini15Flash => 1_048_576,
             Self::Gemini20FlashLite => 1_048_576,
             Self::Gemini20Flash => 1_048_576,
             Self::Gemini25FlashLitePreview => 1_000_000,
@@ -602,9 +584,6 @@ impl Model {
 
     pub fn max_output_tokens(&self) -> Option<u64> {
         match self {
-            Model::Gemini15Pro => Some(8_192),
-            Model::Gemini15Flash8b => Some(8_192),
-            Model::Gemini15Flash => Some(8_192),
             Model::Gemini20FlashLite => Some(8_192),
             Model::Gemini20Flash => Some(8_192),
             Model::Gemini25FlashLitePreview => Some(64_000),
@@ -625,10 +604,7 @@ impl Model {
 
     pub fn mode(&self) -> GoogleModelMode {
         match self {
-            Self::Gemini15Pro
-            | Self::Gemini15Flash8b
-            | Self::Gemini15Flash
-            | Self::Gemini20FlashLite
+            Self::Gemini20FlashLite
             | Self::Gemini20Flash => GoogleModelMode::Default,
             Self::Gemini25FlashLitePreview
             | Self::Gemini25Flash

--- a/crates/google_ai/src/google_ai.rs
+++ b/crates/google_ai/src/google_ai.rs
@@ -604,8 +604,7 @@ impl Model {
 
     pub fn mode(&self) -> GoogleModelMode {
         match self {
-            Self::Gemini20FlashLite
-            | Self::Gemini20Flash => GoogleModelMode::Default,
+            Self::Gemini20FlashLite | Self::Gemini20Flash => GoogleModelMode::Default,
             Self::Gemini25FlashLite
             | Self::Gemini25Flash
             | Self::Gemini25Pro


### PR DESCRIPTION
Closes #43040

Release Notes:

- Remove the end-of-support Gemini 1.5 model from the options.
- Remove the older Gemini 2.0 model from the options.
  - Please let me know if you think it's better to keep it, as it is still a usable model.
- Update the incorrect amounts for some input/output tokens.
- Update the default model to Gemini 2.5 Flash-Lite.
- Rename variant `Gemini3ProPreview` to `Gemini3Pro`

When this PR is merged, users will be able to select the following Gemini models.

- 2.5 Flash
- 2.5 Flash-Lite
- 2.5 Pro
- 3 Pro
