### PR TITLE
git: Support project-level git.inline_blame settings 

### DIFF
--- a/crates/collab/src/tests/editor_tests.rs
+++ b/crates/collab/src/tests/editor_tests.rs
@@ -3482,14 +3482,16 @@ async fn test_git_blame_is_forwarded(cx_a: &mut TestAppContext, cx_b: &mut TestA
     cx_a.update(|cx| {
         SettingsStore::update_global(cx, |store, cx| {
             store.update_user_settings(cx, |settings| {
-                settings.git.get_or_insert_default().inline_blame = inline_blame_off_settings;
+                settings.git.get_or_insert_default().project.inline_blame =
+                    inline_blame_off_settings;
             });
         });
     });
     cx_b.update(|cx| {
         SettingsStore::update_global(cx, |store, cx| {
             store.update_user_settings(cx, |settings| {
-                settings.git.get_or_insert_default().inline_blame = inline_blame_off_settings;
+                settings.git.get_or_insert_default().project.inline_blame =
+                    inline_blame_off_settings;
             });
         });
     });

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -162,7 +162,9 @@ use project::{
         CacheInlayHints, CompletionDocumentation, FormatTrigger, LspFormatTarget,
         OpenLspBufferHandle,
     },
-    project_settings::{DiagnosticSeverity, GoToDiagnosticSeverityFilter, ProjectSettings},
+    project_settings::{
+        DiagnosticSeverity, GitSettings, GoToDiagnosticSeverityFilter, ProjectSettings,
+    },
 };
 use rand::seq::SliceRandom;
 use regex::Regex;
@@ -2330,8 +2332,7 @@ impl Editor {
             show_git_blame_inline: false,
             show_selection_menu: None,
             show_git_blame_inline_delay_task: None,
-            git_blame_inline_enabled: full_mode
-                && ProjectSettings::get_global(cx).git.inline_blame.enabled,
+            git_blame_inline_enabled: full_mode && GitSettings::get_global(cx).inline_blame.enabled,
             render_diff_hunk_controls: Arc::new(render_diff_hunk_controls),
             buffer_serialization: is_minimap.not().then(|| {
                 BufferSerialization::new(
@@ -6923,7 +6924,7 @@ impl Editor {
     }
 
     fn start_inline_blame_timer(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        if let Some(delay) = ProjectSettings::get_global(cx).git.inline_blame_delay() {
+        if let Some(delay) = self.git_settings(cx).inline_blame_delay() {
             self.show_git_blame_inline = false;
 
             self.show_git_blame_inline_delay_task =
@@ -20950,6 +20951,10 @@ impl Editor {
         None
     }
 
+    pub fn git_settings(&self, cx: &App) -> GitSettings {
+        GitSettings::get(self.settings_location(cx), cx).clone()
+    }
+
     pub fn git_blame_inline_enabled(&self) -> bool {
         self.git_blame_inline_enabled
     }
@@ -21023,11 +21028,7 @@ impl Editor {
     ) {
         self.start_git_blame(user_triggered, window, cx);
 
-        if ProjectSettings::get_global(cx)
-            .git
-            .inline_blame_delay()
-            .is_some()
-        {
+        if self.git_settings(cx).inline_blame_delay().is_some() {
             self.start_inline_blame_timer(window, cx);
         } else {
             self.show_git_blame_inline = true
@@ -22320,7 +22321,7 @@ impl Editor {
 
         if self.mode.is_full() {
             let show_inline_diagnostics = project_settings.diagnostics.inline.enabled;
-            let inline_blame_enabled = project_settings.git.inline_blame.enabled;
+            let inline_blame_enabled = self.git_settings(cx).inline_blame.enabled;
             if self.show_inline_diagnostics != show_inline_diagnostics {
                 self.show_inline_diagnostics = show_inline_diagnostics;
                 self.refresh_inline_diagnostics(false, window, cx);
@@ -22362,6 +22363,17 @@ impl Editor {
         }
 
         cx.notify();
+    }
+
+    fn settings_location<'a>(&self, cx: &'a App) -> Option<SettingsLocation<'a>> {
+        let location = self.buffer().read(cx).as_singleton().and_then(|buffer| {
+            let buffer = buffer.read(cx);
+            buffer.file().map(|file| SettingsLocation {
+                worktree_id: file.worktree_id(cx),
+                path: file.path().as_ref(),
+            })
+        });
+        location
     }
 
     pub fn set_searchable(&mut self, searchable: bool) {
@@ -25275,7 +25287,7 @@ impl EditorSnapshot {
         {
             let show_git_gutter = self.show_git_diff_gutter.unwrap_or_else(|| {
                 matches!(
-                    ProjectSettings::get_global(cx).git.git_gutter,
+                    GitSettings::get_global(cx).git_gutter,
                     GitGutterSetting::TrackedFiles
                 )
             });

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -20952,7 +20952,7 @@ impl Editor {
     }
 
     pub fn git_settings(&self, cx: &App) -> GitSettings {
-        GitSettings::get(self.settings_location(cx), cx).clone()
+        *GitSettings::get(self.settings_location(cx), cx)
     }
 
     pub fn git_blame_inline_enabled(&self) -> bool {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -62,6 +62,7 @@ use edit_prediction_types::EditPredictionGranularity;
 use project::{
     Entry, ProjectPath,
     debugger::breakpoint_store::{Breakpoint, BreakpointSessionState},
+    project_settings::GitSettings,
     project_settings::ProjectSettings,
 };
 use settings::{
@@ -2212,7 +2213,7 @@ impl EditorElement {
             .display_diff_hunks_for_rows(display_rows, folded_buffers)
             .map(|hunk| (hunk, None))
             .collect::<Vec<_>>();
-        let git_gutter_setting = ProjectSettings::get_global(cx).git.git_gutter;
+        let git_gutter_setting = GitSettings::get_global(cx).git_gutter;
         if let GitGutterSetting::TrackedFiles = git_gutter_setting {
             for (hunk, hitbox) in &mut display_hunks {
                 if matches!(hunk, DisplayDiffHunk::Unfolded { .. }) {
@@ -2570,10 +2571,11 @@ impl EditorElement {
 
         let editor = self.editor.read(cx);
         let blame = editor.blame.clone()?;
+        let git_settings = editor.git_settings(cx);
         let padding = {
             const INLINE_ACCEPT_SUGGESTION_EM_WIDTHS: f32 = 14.;
 
-            let mut padding = ProjectSettings::get_global(cx).git.inline_blame.padding as f32;
+            let mut padding = git_settings.inline_blame.padding as f32;
 
             if let Some(edit_prediction) = editor.active_edit_prediction.as_ref()
                 && let EditPrediction::Edit {
@@ -2612,7 +2614,7 @@ impl EditorElement {
 
             let min_column_in_pixels = column_pixels(
                 &self.style,
-                ProjectSettings::get_global(cx).git.inline_blame.min_column as usize,
+                git_settings.inline_blame.min_column as usize,
                 window,
             );
             let min_start = Pixels::from(
@@ -6498,7 +6500,7 @@ impl EditorElement {
             .show_git_diff_gutter
             .unwrap_or_else(|| {
                 matches!(
-                    ProjectSettings::get_global(cx).git.git_gutter,
+                    GitSettings::get_global(cx).git_gutter,
                     GitGutterSetting::TrackedFiles
                 )
             });
@@ -7881,7 +7883,7 @@ impl EditorElement {
     fn diff_hunk_hollow(status: DiffHunkStatus, cx: &mut App) -> bool {
         let unstaged = status.has_secondary_hunk();
         let unstaged_hollow = matches!(
-            ProjectSettings::get_global(cx).git.hunk_style,
+            GitSettings::get_global(cx).hunk_style,
             GitHunkStyleSetting::UnstagedHollow
         );
 
@@ -9845,8 +9847,7 @@ impl Element for EditorElement {
                                 .flatten()?;
                             let mut element = render_inline_blame_entry(blame_entry, style, cx)?;
                             let inline_blame_padding =
-                                ProjectSettings::get_global(cx).git.inline_blame.padding as f32
-                                    * em_advance;
+                                editor.git_settings(cx).inline_blame.padding as f32 * em_advance;
                             Some(
                                 element
                                     .layout_as_root(AvailableSpace::min_size(), window, cx)

--- a/crates/git_ui/src/blame_ui.rs
+++ b/crates/git_ui/src/blame_ui.rs
@@ -9,7 +9,7 @@ use gpui::{
     TextStyleRefinement, UnderlineStyle, WeakEntity, prelude::*,
 };
 use markdown::{Markdown, MarkdownElement};
-use project::{git_store::Repository, project_settings::ProjectSettings};
+use project::{git_store::Repository, project_settings::GitSettings};
 use settings::Settings as _;
 use theme::ThemeSettings;
 use time::OffsetDateTime;
@@ -43,7 +43,7 @@ impl BlameRenderer for GitBlameRenderer {
         let author_name = blame_entry.author.as_deref().unwrap_or("<no name>");
         let name = util::truncate_and_trailoff(author_name, GIT_BLAME_MAX_AUTHOR_CHARS_DISPLAYED);
 
-        let avatar = if ProjectSettings::get_global(cx).git.blame.show_avatar {
+        let avatar = if GitSettings::get_global(cx).blame.show_avatar {
             Some(
                 CommitAvatar::new(
                     &blame_entry.sha.to_string().into(),
@@ -137,10 +137,7 @@ impl BlameRenderer for GitBlameRenderer {
     ) -> Option<AnyElement> {
         let relative_timestamp = blame_entry_relative_timestamp(&blame_entry);
         let author = blame_entry.author.as_deref().unwrap_or_default();
-        let summary_enabled = ProjectSettings::get_global(cx)
-            .git
-            .inline_blame
-            .show_commit_summary;
+        let summary_enabled = GitSettings::get_global(cx).inline_blame.show_commit_summary;
 
         let text = match blame_entry.summary.as_ref() {
             Some(summary) if summary_enabled => {

--- a/crates/git_ui/src/branch_picker.rs
+++ b/crates/git_ui/src/branch_picker.rs
@@ -12,7 +12,7 @@ use gpui::{
 };
 use picker::{Picker, PickerDelegate, PickerEditorPosition};
 use project::git_store::Repository;
-use project::project_settings::ProjectSettings;
+use project::project_settings::GitSettings;
 use settings::Settings;
 use std::sync::Arc;
 use time::OffsetDateTime;
@@ -963,8 +963,7 @@ impl PickerDelegate for BranchListDelegate {
                                                     }
                                                     Entry::Branch { .. } => {
                                                         let show_author_name =
-                                                            ProjectSettings::get_global(cx)
-                                                                .git
+                                                            GitSettings::get_global(cx)
                                                                 .branch_picker
                                                                 .show_author_name;
 

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -56,7 +56,7 @@ use panel::{
 use project::{
     Fs, Project, ProjectPath,
     git_store::{GitStoreEvent, Repository, RepositoryEvent, RepositoryId, pending_op},
-    project_settings::{GitPathStyle, ProjectSettings},
+    project_settings::{GitPathStyle, GitSettings},
 };
 use prompt_store::{BuiltInPrompt, PromptId, PromptStore, RULES_FILE_NAMES};
 use serde::{Deserialize, Serialize};
@@ -4897,7 +4897,7 @@ impl GitPanel {
     ) -> AnyElement {
         let tree_view = GitPanelSettings::get_global(cx).tree_view;
         let path_style = self.project.read(cx).path_style(cx);
-        let git_path_style = ProjectSettings::get_global(cx).git.path_style;
+        let git_path_style = GitSettings::get_global(cx).path_style;
         let display_name = entry.display_name(path_style);
 
         let selected = self.selected_entry == Some(ix);

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -101,7 +101,7 @@ pub use manifest_tree::ManifestProvidersStore;
 use node_runtime::NodeRuntime;
 use parking_lot::Mutex;
 pub use prettier_store::PrettierStore;
-use project_settings::{ProjectSettings, SettingsObserver, SettingsObserverEvent};
+use project_settings::{GitSettings, SettingsObserver, SettingsObserverEvent};
 use remote::{RemoteClient, RemoteConnectionOptions};
 use rpc::{
     AnyProtoClient, ErrorCode,
@@ -3474,8 +3474,8 @@ impl Project {
     ) {
         self.buffers_needing_diff.insert(buffer.downgrade());
         let first_insertion = self.buffers_needing_diff.len() == 1;
-        let settings = ProjectSettings::get_global(cx);
-        let delay = settings.git.gutter_debounce;
+        let settings = GitSettings::get_global(cx);
+        let delay = settings.gutter_debounce;
 
         if delay == 0 {
             if first_insertion {

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -447,9 +447,9 @@ impl GitSettings {
 
 impl settings::Settings for GitSettings {
     fn from_settings(content: &settings::SettingsContent) -> Self {
-        let user_content = content.git.clone().unwrap();
+        let user_content = content.git.unwrap();
         // Note: we allow a subset of "git" settings in the project files.
-        let mut project_content = user_content.project.clone();
+        let mut project_content = user_content.project;
         project_content.merge_from_option(content.project.git.as_ref());
         GitSettings {
             enabled: GitEnabledSettings {

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -453,7 +453,11 @@ impl settings::Settings for GitSettings {
         project_content.merge_from_option(content.project.git.as_ref());
         GitSettings {
             enabled: GitEnabledSettings {
-                status: user_content.enabled.as_ref().unwrap().is_git_status_enabled(),
+                status: user_content
+                    .enabled
+                    .as_ref()
+                    .unwrap()
+                    .is_git_status_enabled(),
                 diff: user_content.enabled.as_ref().unwrap().is_git_diff_enabled(),
             },
             git_gutter: user_content.git_gutter.unwrap(),

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -481,6 +481,7 @@ impl settings::Settings for GitSettings {
                 }
             },
             hunk_style: user_content.hunk_style.unwrap(),
+            path_style: user_content.path_style.unwrap().into(),
         }
     }
 }

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -21,7 +21,8 @@ pub use settings::DirenvSettings;
 pub use settings::LspSettings;
 use settings::{
     DapSettingsContent, InvalidSettingsError, LocalSettingsKind, RegisterSetting, Settings,
-    SettingsLocation, SettingsStore, parse_json_with_comments, watch_config_file,
+    SettingsLocation, SettingsStore, merge_from::MergeFrom, parse_json_with_comments,
+    watch_config_file,
 };
 use std::{cell::OnceCell, collections::BTreeMap, path::PathBuf, sync::Arc, time::Duration};
 use task::{DebugTaskFile, TaskTemplates, VsCodeDebugTaskFile, VsCodeTaskFile};
@@ -64,9 +65,6 @@ pub struct ProjectSettings {
 
     /// Configuration for Diagnostics-related features.
     pub diagnostics: DiagnosticsSettings,
-
-    /// Configuration for Git-related features
-    pub git: GitSettings,
 
     /// Configuration for Node-related features
     pub node: NodeBinarySettings,
@@ -339,7 +337,7 @@ impl GoToDiagnosticSeverityFilter {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, RegisterSetting)]
 pub struct GitSettings {
     /// Whether or not git integration is enabled.
     ///
@@ -447,6 +445,46 @@ impl GitSettings {
     }
 }
 
+impl settings::Settings for GitSettings {
+    fn from_settings(content: &settings::SettingsContent) -> Self {
+        let user_content = content.git.clone().unwrap();
+        // Note: we allow a subset of "git" settings in the project files.
+        let mut project_content = user_content.project.clone();
+        project_content.merge_from_option(content.project.git.as_ref());
+        GitSettings {
+            enabled: GitEnabledSettings {
+                status: user_content.enabled.as_ref().unwrap().is_git_status_enabled(),
+                diff: user_content.enabled.as_ref().unwrap().is_git_diff_enabled(),
+            },
+            git_gutter: user_content.git_gutter.unwrap(),
+            gutter_debounce: user_content.gutter_debounce.unwrap_or_default(),
+            inline_blame: {
+                let inline = project_content.inline_blame.unwrap_or_default();
+                InlineBlameSettings {
+                    enabled: inline.enabled.unwrap(),
+                    delay_ms: inline.delay_ms.unwrap(),
+                    padding: inline.padding.unwrap(),
+                    min_column: inline.min_column.unwrap(),
+                    show_commit_summary: inline.show_commit_summary.unwrap(),
+                }
+            },
+            blame: {
+                let blame = user_content.blame.unwrap();
+                BlameSettings {
+                    show_avatar: blame.show_avatar.unwrap(),
+                }
+            },
+            branch_picker: {
+                let branch_picker = user_content.branch_picker.unwrap();
+                BranchPickerSettings {
+                    show_author_name: branch_picker.show_author_name.unwrap(),
+                }
+            },
+            hunk_style: user_content.hunk_style.unwrap(),
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct BranchPickerSettings {
@@ -525,43 +563,6 @@ impl Settings for ProjectSettings {
         let diagnostics = content.diagnostics.as_ref().unwrap();
         let lsp_pull_diagnostics = diagnostics.lsp_pull_diagnostics.as_ref().unwrap();
         let inline_diagnostics = diagnostics.inline.as_ref().unwrap();
-
-        let git = content.git.as_ref().unwrap();
-        let git_enabled = {
-            GitEnabledSettings {
-                status: git.enabled.as_ref().unwrap().is_git_status_enabled(),
-                diff: git.enabled.as_ref().unwrap().is_git_diff_enabled(),
-            }
-        };
-        let git_settings = GitSettings {
-            enabled: git_enabled,
-            git_gutter: git.git_gutter.unwrap(),
-            gutter_debounce: git.gutter_debounce.unwrap_or_default(),
-            inline_blame: {
-                let inline = git.inline_blame.unwrap();
-                InlineBlameSettings {
-                    enabled: inline.enabled.unwrap(),
-                    delay_ms: inline.delay_ms.unwrap(),
-                    padding: inline.padding.unwrap(),
-                    min_column: inline.min_column.unwrap(),
-                    show_commit_summary: inline.show_commit_summary.unwrap(),
-                }
-            },
-            blame: {
-                let blame = git.blame.unwrap();
-                BlameSettings {
-                    show_avatar: blame.show_avatar.unwrap(),
-                }
-            },
-            branch_picker: {
-                let branch_picker = git.branch_picker.unwrap();
-                BranchPickerSettings {
-                    show_author_name: branch_picker.show_author_name.unwrap(),
-                }
-            },
-            hunk_style: git.hunk_style.unwrap(),
-            path_style: git.path_style.unwrap().into(),
-        };
         Self {
             context_servers: project
                 .context_servers
@@ -605,7 +606,6 @@ impl Settings for ProjectSettings {
                     max_severity: inline_diagnostics.max_severity.map(Into::into),
                 },
             },
-            git: git_settings,
             node: content.node.clone().unwrap().into(),
             load_direnv: project.load_direnv.clone().unwrap(),
             session: SessionSettings {

--- a/crates/settings/src/settings_content/project.rs
+++ b/crates/settings/src/settings_content/project.rs
@@ -327,6 +327,8 @@ pub struct ProjectGitSettings {
 #[with_fallible_options]
 #[derive(Copy, Clone, Debug, PartialEq, Default, Serialize, Deserialize, JsonSchema, MergeFrom)]
 pub struct GitSettings {
+    #[serde(flatten)]
+    pub project: ProjectGitSettings,
     /// Whether or not to enable git integration.
     ///
     /// Default: true

--- a/crates/settings/src/settings_content/project.rs
+++ b/crates/settings/src/settings_content/project.rs
@@ -70,7 +70,6 @@ pub struct ProjectSettingsContent {
     pub git_hosting_providers: Option<ExtendingVec<GitHostingProviderConfig>>,
 
     /// Git-related settings.
-    #[serde(default)]
     pub git: Option<ProjectGitSettings>,
 }
 

--- a/crates/settings/src/settings_content/project.rs
+++ b/crates/settings/src/settings_content/project.rs
@@ -68,6 +68,10 @@ pub struct ProjectSettingsContent {
 
     /// The list of custom Git hosting providers.
     pub git_hosting_providers: Option<ExtendingVec<GitHostingProviderConfig>>,
+
+    /// Git-related settings.
+    #[serde(default)]
+    pub git: Option<ProjectGitSettings>,
 }
 
 #[with_fallible_options]
@@ -312,6 +316,15 @@ impl std::fmt::Debug for ContextServerCommand {
     }
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Default, Serialize, Deserialize, JsonSchema, MergeFrom)]
+pub struct ProjectGitSettings {
+    /// Whether or not to show git blame data inline in
+    /// the currently focused line.
+    ///
+    /// Default: on
+    pub inline_blame: Option<InlineBlameSettings>,
+}
+
 #[with_fallible_options]
 #[derive(Copy, Clone, Debug, PartialEq, Default, Serialize, Deserialize, JsonSchema, MergeFrom)]
 pub struct GitSettings {
@@ -328,11 +341,6 @@ pub struct GitSettings {
     ///
     /// Default: 0
     pub gutter_debounce: Option<u64>,
-    /// Whether or not to show git blame data inline in
-    /// the currently focused line.
-    ///
-    /// Default: on
-    pub inline_blame: Option<InlineBlameSettings>,
     /// Git blame settings.
     pub blame: Option<BlameSettings>,
     /// Which information to show in the branch picker.

--- a/crates/settings/src/settings_store.rs
+++ b/crates/settings/src/settings_store.rs
@@ -1920,6 +1920,7 @@ mod tests {
             current
                 .git
                 .get_or_insert_default()
+                .project
                 .inline_blame
                 .get_or_insert_default()
                 .enabled = Some(true);

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -407,6 +407,7 @@ impl VsCodeSettings {
             load_direnv: None,
             slash_commands: None,
             git_hosting_providers: None,
+            git: None,
         }
     }
 
@@ -551,10 +552,13 @@ impl VsCodeSettings {
     fn git_settings_content(&self) -> Option<GitSettings> {
         let inline_blame = self.read_bool("git.blame.editorDecoration.enabled")?;
         skip_default(GitSettings {
-            inline_blame: Some(InlineBlameSettings {
-                enabled: Some(inline_blame),
+            project: ProjectGitSettings {
+                inline_blame: Some(InlineBlameSettings {
+                    enabled: Some(inline_blame),
+                    ..Default::default()
+                }),
                 ..Default::default()
-            }),
+            },
             ..Default::default()
         })
     }

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -557,7 +557,6 @@ impl VsCodeSettings {
                     enabled: Some(inline_blame),
                     ..Default::default()
                 }),
-                ..Default::default()
             },
             ..Default::default()
         })

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -6199,6 +6199,7 @@ fn version_control_page() -> SettingsPage {
                         settings_content
                             .git
                             .get_or_insert_default()
+                            .project
                             .inline_blame
                             .get_or_insert_default()
                             .enabled = value;
@@ -6223,6 +6224,7 @@ fn version_control_page() -> SettingsPage {
                         settings_content
                             .git
                             .get_or_insert_default()
+                            .project
                             .inline_blame
                             .get_or_insert_default()
                             .delay_ms = value;
@@ -6247,6 +6249,7 @@ fn version_control_page() -> SettingsPage {
                         settings_content
                             .git
                             .get_or_insert_default()
+                            .project
                             .inline_blame
                             .get_or_insert_default()
                             .padding = value;
@@ -6271,6 +6274,7 @@ fn version_control_page() -> SettingsPage {
                         settings_content
                             .git
                             .get_or_insert_default()
+                            .project
                             .inline_blame
                             .get_or_insert_default()
                             .min_column = value;
@@ -6295,6 +6299,7 @@ fn version_control_page() -> SettingsPage {
                         settings_content
                             .git
                             .get_or_insert_default()
+                            .project
                             .inline_blame
                             .get_or_insert_default()
                             .show_commit_summary = value;

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -6189,13 +6189,11 @@ fn version_control_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("git.inline_blame.enabled"),
                     pick: |settings_content| {
-                        settings_content
-                            .git
-                            .as_ref()?
-                            .inline_blame
-                            .as_ref()?
-                            .enabled
-                            .as_ref()
+                        git_settings_field(settings_content, |git| {
+                            git.inline_blame
+                                .as_ref()
+                                .and_then(|inline_blame| inline_blame.enabled.as_ref())
+                        })
                     },
                     write: |settings_content, value| {
                         settings_content
@@ -6207,7 +6205,7 @@ fn version_control_page() -> SettingsPage {
                     },
                 }),
                 metadata: None,
-                files: USER,
+                files: USER | PROJECT,
             }),
             SettingsPageItem::SettingItem(SettingItem {
                 title: "Delay",
@@ -6215,13 +6213,11 @@ fn version_control_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("git.inline_blame.delay_ms"),
                     pick: |settings_content| {
-                        settings_content
-                            .git
-                            .as_ref()?
-                            .inline_blame
-                            .as_ref()?
-                            .delay_ms
-                            .as_ref()
+                        git_settings_field(settings_content, |git| {
+                            git.inline_blame
+                                .as_ref()
+                                .and_then(|inline_blame| inline_blame.delay_ms.as_ref())
+                        })
                     },
                     write: |settings_content, value| {
                         settings_content
@@ -6233,7 +6229,7 @@ fn version_control_page() -> SettingsPage {
                     },
                 }),
                 metadata: None,
-                files: USER,
+                files: USER | PROJECT,
             }),
             SettingsPageItem::SettingItem(SettingItem {
                 title: "Padding",
@@ -6241,13 +6237,11 @@ fn version_control_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("git.inline_blame.padding"),
                     pick: |settings_content| {
-                        settings_content
-                            .git
-                            .as_ref()?
-                            .inline_blame
-                            .as_ref()?
-                            .padding
-                            .as_ref()
+                        git_settings_field(settings_content, |git| {
+                            git.inline_blame
+                                .as_ref()
+                                .and_then(|inline_blame| inline_blame.padding.as_ref())
+                        })
                     },
                     write: |settings_content, value| {
                         settings_content
@@ -6259,7 +6253,7 @@ fn version_control_page() -> SettingsPage {
                     },
                 }),
                 metadata: None,
-                files: USER,
+                files: USER | PROJECT,
             }),
             SettingsPageItem::SettingItem(SettingItem {
                 title: "Minimum Column",
@@ -6267,13 +6261,11 @@ fn version_control_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("git.inline_blame.min_column"),
                     pick: |settings_content| {
-                        settings_content
-                            .git
-                            .as_ref()?
-                            .inline_blame
-                            .as_ref()?
-                            .min_column
-                            .as_ref()
+                        git_settings_field(settings_content, |git| {
+                            git.inline_blame
+                                .as_ref()
+                                .and_then(|inline_blame| inline_blame.min_column.as_ref())
+                        })
                     },
                     write: |settings_content, value| {
                         settings_content
@@ -6285,7 +6277,7 @@ fn version_control_page() -> SettingsPage {
                     },
                 }),
                 metadata: None,
-                files: USER,
+                files: USER | PROJECT,
             }),
             SettingsPageItem::SettingItem(SettingItem {
                 title: "Show Commit Summary",
@@ -6293,13 +6285,11 @@ fn version_control_page() -> SettingsPage {
                 field: Box::new(SettingField {
                     json_path: Some("git.inline_blame.show_commit_summary"),
                     pick: |settings_content| {
-                        settings_content
-                            .git
-                            .as_ref()?
-                            .inline_blame
-                            .as_ref()?
-                            .show_commit_summary
-                            .as_ref()
+                        git_settings_field(settings_content, |git| {
+                            git.inline_blame
+                                .as_ref()
+                                .and_then(|inline_blame| inline_blame.show_commit_summary.as_ref())
+                        })
                     },
                     write: |settings_content, value| {
                         settings_content
@@ -6311,7 +6301,7 @@ fn version_control_page() -> SettingsPage {
                     },
                 }),
                 metadata: None,
-                files: USER,
+                files: USER | PROJECT,
             }),
         ]
     }
@@ -8535,6 +8525,20 @@ fn edit_prediction_language_settings_section() -> [SettingsPageItem; 4] {
             files: USER | PROJECT,
         }),
     ]
+}
+
+fn git_settings_field<T>(
+    settings_content: &SettingsContent,
+    get: fn(&settings::ProjectGitSettings) -> Option<&T>,
+) -> Option<&T> {
+    if let Some(value) = settings_content.project.git.as_ref().and_then(get) {
+        return Some(value);
+    }
+    settings_content
+        .git
+        .as_ref()
+        .map(|git| &git.project)
+        .and_then(get)
 }
 
 fn show_scrollbar_or_editor(


### PR DESCRIPTION
Closes #13547

We've limited the `git blame` command's thread usage, and following the issue discussion, we've added a project-level `git.inline_blame` setting to allow users to configure it for each project.

https://github.com/user-attachments/assets/5ff239f7-1cc6-4180-9f3b-35c96b76a0eb

Release Notes:

- Added support for configuring the git.inline_blame setting at the project level



