### PR TITLE
Git/commit multibuffer nav to current

### DIFF
--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -873,6 +873,14 @@
     }
   },
   {
+    "context": "GitCommit > Editor || GitStash > Editor",
+    "use_key_equivalents": true,
+    "bindings": {
+      "alt-shift-enter": ["editor::OpenExcerpts", { "target": "open_current" }],
+      "alt-cmd-shift-enter": ["editor::OpenExcerptsSplit", { "target": "open_current" }]
+    }
+  },
+  {
     "context": "PromptEditor",
     "use_key_equivalents": true,
     "bindings": {

--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -636,13 +636,13 @@ actions!(
         /// Opens excerpts in a split pane.
         OpenExcerptsSplit,
         /// Specific to `CommitDiff` and `StashDiff` views, opens excerts at head if file wasn't moved or deleted
-        OpenHeadExcerpt,
+        OpenHeadExcerpts,
         /// Specific to `CommitDiff` and `StashDiff` views, opens excerts at head in a split pane if it exists
-        OpenHeadExcerptSplit,
+        OpenHeadExcerptsSplit,
         /// Specific to `CommitDiff` view, opens excerts before changes were commited
-        OpenParentExcerpt,
+        OpenParentExcerpts,
         /// Specific to `CommitDiff` view, opens excerts before changes were commited in a split pane
-        OpenParentExcerptSplit,
+        OpenParentExcerptsSplit,
         /// Opens the proposed changes editor.
         OpenProposedChangesEditor,
         /// Opens documentation for the symbol at cursor.

--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -635,6 +635,14 @@ actions!(
         OpenExcerpts,
         /// Opens excerpts in a split pane.
         OpenExcerptsSplit,
+        /// Specific to `CommitDiff` and `StashDiff` views, opens excerts at head if file wasn't moved or deleted
+        OpenHeadExcerpt,
+        /// Specific to `CommitDiff` and `StashDiff` views, opens excerts at head in a split pane if it exists
+        OpenHeadExcerptSplit,
+        /// Specific to `CommitDiff` view, opens excerts before changes were commited
+        OpenParentExcerpt,
+        /// Specific to `CommitDiff` view, opens excerts before changes were commited in a split pane
+        OpenParentExcerptSplit,
         /// Opens the proposed changes editor.
         OpenProposedChangesEditor,
         /// Opens documentation for the symbol at cursor.

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -6,10 +6,10 @@ use crate::{
     EditDisplayMode, EditPrediction, Editor, EditorMode, EditorSettings, EditorSnapshot,
     EditorStyle, FILE_HEADER_HEIGHT, FocusedBlock, GutterDimensions, HalfPageDown, HalfPageUp,
     HandleInput, HoveredCursor, InlayHintRefreshReason, JumpData, LineDown, LineHighlight, LineUp,
-    MAX_LINE_LEN, MINIMAP_FONT_SIZE, MULTI_BUFFER_EXCERPT_HEADER_HEIGHT, OpenExcerpts, PageDown,
-    PageUp, PhantomBreakpointIndicator, Point, RowExt, RowRangeExt, SelectPhase,
-    SelectedTextHighlight, Selection, SelectionDragState, SelectionEffects, SizingBehavior,
-    SoftWrap, StickyHeaderExcerpt, ToPoint, ToggleFold, ToggleFoldAll,
+    MAX_LINE_LEN, MINIMAP_FONT_SIZE, MULTI_BUFFER_EXCERPT_HEADER_HEIGHT, OpenExcerptHistoric,
+    OpenExcerpts, PageDown, PageUp, PhantomBreakpointIndicator, Point, RowExt, RowRangeExt,
+    SelectPhase, SelectedTextHighlight, Selection, SelectionDragState, SelectionEffects,
+    SizingBehavior, SoftWrap, StickyHeaderExcerpt, ToPoint, ToggleFold, ToggleFoldAll,
     code_context_menus::{CodeActionsMenu, MENU_ASIDE_MAX_WIDTH, MENU_ASIDE_MIN_WIDTH, MENU_GAP},
     display_map::{
         Block, BlockContext, BlockStyle, ChunkRendererId, DisplaySnapshot, EditorMargins,
@@ -751,13 +751,15 @@ impl EditorElement {
                             )
                             .row;
                         let line_offset_from_top = display_row - scroll_position_row as u32;
-                        // if double click is made without alt, open the corresponding excerp
+                        // if double click is made without alt, open the corresponding excerpt
+
                         editor.open_excerpts_common(
                             Some(JumpData::MultiBufferRow {
                                 row: MultiBufferRow(multi_buffer_row),
                                 line_offset_from_top,
                             }),
                             false,
+                            &OpenExcerpts::default(),
                             window,
                             cx,
                         );
@@ -794,6 +796,7 @@ impl EditorElement {
                         line_offset_from_top,
                     }),
                     modifiers.alt,
+                    &OpenExcerpts::default(),
                     window,
                     cx,
                 );
@@ -3943,6 +3946,31 @@ impl EditorElement {
             .unwrap_or_default();
         let file = for_excerpt.buffer.file();
         let can_open_excerpts = Editor::can_open_excerpts_in_file(file);
+        // Check if this is a non-local file (like GitBlob) that also exists in the project
+        // todo! complete this
+        let can_handle_commit_diff_action = window.is_action_available(&OpenExcerptHistoric, cx);
+
+        // todo! complete this
+        let (is_historical_commit, can_open_current) = (true, true);
+        // file.get_git_info() -> [Committed(commit_id), Uncommited, None]
+        // file.get_commit_id() -> Option<String>
+
+        // file
+        // .map(|file| {
+        //     let is_non_local = !file.is_local(); // not collab file
+        //     let exists_in_project = editor
+        //         .project
+        //         .as_ref()
+        //         .and_then(|project| {
+        //             let worktree =
+        //                 project.read(cx).worktree_for_id(file.worktree_id(cx), cx)?;
+        //             let entry = worktree.read(cx).entry_for_path(file.path())?;
+        //             Some(entry)
+        //         })
+        //         .is_some();
+        //     (is_non_local, is_non_local && exists_in_project)
+        // })
+        // .unwrap_or((false, false));
         let path_style = file.map(|file| file.path_style(cx));
         let relative_path = for_excerpt.buffer.resolve_file_path(include_root, cx);
         let (parent_path, filename) = if let Some(path) = &relative_path {
@@ -3957,6 +3985,7 @@ impl EditorElement {
         };
         let focus_handle = editor.focus_handle(cx);
         let colors = cx.theme().colors();
+        let open_current_action = OpenExcerpts;
 
         let header = div()
             .p_1()
@@ -4108,6 +4137,7 @@ impl EditorElement {
                                                     editor.open_excerpts_common(
                                                         Some(jump_data.clone()),
                                                         e.modifiers().secondary(),
+                                                        &OpenExcerpts::default(),
                                                         window,
                                                         cx,
                                                     );
@@ -4131,7 +4161,7 @@ impl EditorElement {
                                         Button::new("open-file-button", "Open File")
                                             .style(ButtonStyle::OutlinedGhost)
                                             .key_binding(KeyBinding::for_action_in(
-                                                &OpenExcerpts,
+                                                &OpenExcerpts::default(),
                                                 &focus_handle,
                                                 cx,
                                             ))
@@ -4141,11 +4171,43 @@ impl EditorElement {
                                                     editor.open_excerpts_common(
                                                         Some(jump_data.clone()),
                                                         e.modifiers().secondary(),
+                                                        &OpenExcerpts::default(),
                                                         window,
                                                         cx,
                                                     );
                                                 }
                                             })),
+                                    )
+                                    .when(
+                                        can_open_current && can_handle_commit_diff_action,
+                                        |el| {
+                                            el.child(
+                                                ButtonLike::new("open-file-button")
+                                                    .style(ButtonStyle::OutlinedGhost)
+                                                    .child(
+                                                        h_flex()
+                                                            .gap_2p5()
+                                                            .child(Label::new("Open current"))
+                                                            .child(KeyBinding::for_action_in(
+                                                                &open_current_action,
+                                                                &focus_handle,
+                                                                cx,
+                                                            )),
+                                                    )
+                                                    .on_click(window.listener_for(&self.editor, {
+                                                        let jump_data = jump_data.clone();
+                                                        move |editor, e: &ClickEvent, window, cx| {
+                                                            editor.open_excerpts_common(
+                                                                Some(jump_data.clone()),
+                                                                e.modifiers().secondary(),
+                                                                &open_current_action,
+                                                                window,
+                                                                cx,
+                                                            );
+                                                        }
+                                                    })),
+                                            )
+                                        },
                                     )
                                 },
                             )
@@ -4157,6 +4219,7 @@ impl EditorElement {
                                         editor.open_excerpts_common(
                                             Some(jump_data.clone()),
                                             e.modifiers().secondary(),
+                                            &OpenExcerpts::default(),
                                             window,
                                             cx,
                                         );

--- a/crates/git_ui/src/commit_view.rs
+++ b/crates/git_ui/src/commit_view.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context as _, Result};
 use buffer_diff::{BufferDiff, BufferDiffSnapshot};
-use editor::actions::OpenExcerptHistoric;
+use editor::actions::OpenParentExcerpts;
 use editor::display_map::{BlockPlacement, BlockProperties, BlockStyle};
 use editor::{
     Editor, EditorEvent, ExcerptId, ExcerptRange, MultiBuffer, multibuffer_context_lines,
@@ -1016,7 +1016,7 @@ impl Render for CommitView {
             .size_full()
             // editor can check if this action is via the window.is_action_avaliable
             // if it is we can handle it here
-            .on_action(|_: &OpenExcerptHistoric, window, cx| {
+            .on_action(|_: &OpenParentExcerpts, _window, _cx| {
                 dbg!("Action is hit");
             })
             .bg(cx.theme().colors().editor_background)

--- a/crates/git_ui/src/commit_view.rs
+++ b/crates/git_ui/src/commit_view.rs
@@ -1007,7 +1007,11 @@ impl Render for CommitView {
         let is_stash = self.stash.is_some();
 
         v_flex()
+            .id("commit-view")
             .key_context(if is_stash { "StashDiff" } else { "CommitDiff" })
+            // todo!
+            // add your action listerners here
+            // .on_action()
             .size_full()
             .bg(cx.theme().colors().editor_background)
             .child(self.render_header(window, cx))

--- a/crates/git_ui/src/commit_view.rs
+++ b/crates/git_ui/src/commit_view.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context as _, Result};
 use buffer_diff::{BufferDiff, BufferDiffSnapshot};
+use editor::actions::OpenExcerptHistoric;
 use editor::display_map::{BlockPlacement, BlockProperties, BlockStyle};
 use editor::{
     Editor, EditorEvent, ExcerptId, ExcerptRange, MultiBuffer, multibuffer_context_lines,
@@ -1013,6 +1014,11 @@ impl Render for CommitView {
             // add your action listerners here
             // .on_action()
             .size_full()
+            // editor can check if this action is via the window.is_action_avaliable
+            // if it is we can handle it here
+            .on_action(|_: &OpenExcerptHistoric, window, cx| {
+                dbg!("Action is hit");
+            })
             .bg(cx.theme().colors().editor_background)
             .child(self.render_header(window, cx))
             .child(div().flex_grow().child(self.editor.clone()))

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1959,7 +1959,7 @@ impl Window {
     }
 
     /// Determine whether the given action is available along the dispatch path to the currently focused element.
-    pub fn is_action_available(&self, action: &dyn Action, cx: &mut App) -> bool {
+    pub fn is_action_available(&self, action: &dyn Action, cx: &App) -> bool {
         let node_id =
             self.focus_node_id_in_rendered_frame(self.focused(cx).map(|handle| handle.id));
         self.rendered_frame


### PR DESCRIPTION
Closes [#40851](https://github.com/zed-industries/zed/issues/40851)

Depends on: https://github.com/zed-industries/zed/pull/42558

Release Notes:

- Added: Ability for open except to open the current file
