### PR TITLE
extensions: Add `-` as linked edit character for HTML

### DIFF
--- a/extensions/html/languages/html/config.toml
+++ b/extensions/html/languages/html/config.toml
@@ -14,3 +14,6 @@ brackets = [
 ]
 completion_query_characters = ["-"]
 prettier_parser_name = "html"
+
+[overrides.default]
+linked_edit_characters = ["-"]

--- a/extensions/html/languages/html/overrides.scm
+++ b/extensions/html/languages/html/overrides.scm
@@ -1,2 +1,7 @@
 (comment) @comment
 (quoted_attribute_value) @string
+
+[
+  (start_tag)
+  (end_tag)
+] @default


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/43060

Fixed issue where typing in custom HTML tag would not complete subsequent end tag for - character.

Release Notes:

- N/A
