### PR TITLE
Add `git commit --cleanup=strip/--cleanup=whitespace` option

### DIFF
--- a/crates/git_ui/src/commit_modal.rs
+++ b/crates/git_ui/src/commit_modal.rs
@@ -1,6 +1,5 @@
 use crate::branch_picker::{self, BranchList};
 use crate::git_panel::{GitPanel, commit_message_editor};
-use git::repository::CommitOptions;
 use git::{Amend, Commit, GenerateCommitMessage, Signoff};
 use panel::{panel_button, panel_editor_style};
 use project::DisableAiSettings;
@@ -439,10 +438,8 @@ impl CommitModal {
                             telemetry::event!("Git Committed", source = "Git Modal");
                             this.git_panel.update(cx, |git_panel, cx| {
                                 git_panel.commit_changes(
-                                    CommitOptions {
-                                        amend: is_amend_pending,
-                                        signoff: is_signoff_enabled,
-                                    },
+                                    is_amend_pending,
+                                    is_signoff_enabled,
                                     window,
                                     cx,
                                 )
@@ -498,14 +495,7 @@ impl CommitModal {
         }
         telemetry::event!("Git Committed", source = "Git Modal");
         self.git_panel.update(cx, |git_panel, cx| {
-            git_panel.commit_changes(
-                CommitOptions {
-                    amend: false,
-                    signoff: git_panel.signoff_enabled(),
-                },
-                window,
-                cx,
-            )
+            git_panel.commit_changes(false, git_panel.signoff_enabled(), window, cx)
         });
         cx.emit(DismissEvent);
     }
@@ -530,14 +520,7 @@ impl CommitModal {
             telemetry::event!("Git Amended", source = "Git Modal");
             self.git_panel.update(cx, |git_panel, cx| {
                 git_panel.set_amend_pending(false, cx);
-                git_panel.commit_changes(
-                    CommitOptions {
-                        amend: true,
-                        signoff: git_panel.signoff_enabled(),
-                    },
-                    window,
-                    cx,
-                );
+                git_panel.commit_changes(true, git_panel.signoff_enabled(), window, cx);
             });
             cx.emit(DismissEvent);
         }

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -4,6 +4,7 @@ use context_server::ContextServerCommand;
 use dap::adapters::DebugAdapterName;
 use fs::Fs;
 use futures::StreamExt as _;
+use git::repository::CommitMessageCleanup;
 use gpui::{AsyncApp, BorrowAppContext, Context, Entity, EventEmitter, Subscription, Task};
 use lsp::LanguageServerName;
 use paths::{
@@ -352,6 +353,10 @@ pub struct GitSettings {
     ///
     /// Default: file_name_first
     pub path_style: GitPathStyle,
+    /// How commit cleanup is handled in the commit message.
+    ///
+    /// Default: strip
+    pub commit_cleanup: CommitMessageCleanup,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Default)]
@@ -522,6 +527,10 @@ impl Settings for ProjectSettings {
             },
             hunk_style: git.hunk_style.unwrap(),
             path_style: git.path_style.unwrap().into(),
+            commit_cleanup: match git.commit_cleanup.unwrap_or_default() {
+                settings::CommitMessageCleanup::Strip => CommitMessageCleanup::Strip,
+                settings::CommitMessageCleanup::Whitespace => CommitMessageCleanup::Whitespace,
+            },
         };
         Self {
             context_servers: project

--- a/crates/settings/src/settings_content/project.rs
+++ b/crates/settings/src/settings_content/project.rs
@@ -315,6 +315,10 @@ pub struct GitSettings {
     ///
     /// Default: file_name_first
     pub path_style: Option<GitPathStyle>,
+    /// How to cleanup a git commit message.
+    ///
+    /// Default: strip
+    pub commit_cleanup: Option<CommitMessageCleanup>,
 }
 
 #[derive(
@@ -430,6 +434,26 @@ pub enum GitPathStyle {
     FileNameFirst,
     /// Show full path first
     FilePathFirst,
+}
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Default,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    MergeFrom,
+    strum::VariantArray,
+    strum::VariantNames,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum CommitMessageCleanup {
+    #[default]
+    Strip,
+    Whitespace,
 }
 
 #[skip_serializing_none]


### PR DESCRIPTION
TODO: There's a related issue somewhere
TODO: Add tests

Added a new enum to handle the `strip` and `whitespace` settings that are found in `man git` - this can be extended to handle other cases should people want to add them.

This PR needed to consider the local git settings *not* overriding the __remote__ git settings, which is why it doesn't mess with the `git_proto.rs` protobuf definitions.

Release Notes:

- N/A *or* Added/Fixed/Improved ...
