### PR TITLE
ui: Display path in active tabs

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1078,7 +1078,12 @@
     //    "errors"
     // 3. Mark files with errors and warnings:
     //    "all"
-    "show_diagnostics": "off"
+    "show_diagnostics": "off",
+    // Whether to show the path for the active tab in each pane.
+    // When enabled, the active tab in each pane will display the
+    // path from the worktree root (or absolute path for files outside
+    // the worktree) instead of just the filename.
+    "active_tab_path": false
   },
   // Settings related to preview tabs.
   "preview_tabs": {

--- a/crates/settings/src/settings_content/workspace.rs
+++ b/crates/settings/src/settings_content/workspace.rs
@@ -140,6 +140,13 @@ pub struct ItemSettingsContent {
     ///
     /// Default: false
     pub show_close_button: Option<ShowCloseButton>,
+    /// Whether to show the path for the active tab.
+    /// When enabled, the active tab will display the path from the worktree root
+    /// (or absolute path for files outside the worktree) instead of just the filename,
+    /// and the description will be hidden.
+    ///
+    /// Default: false
+    pub active_tab_path: Option<bool>,
 }
 
 #[skip_serializing_none]

--- a/crates/settings/src/settings_store.rs
+++ b/crates/settings/src/settings_store.rs
@@ -1726,6 +1726,25 @@ mod tests {
 
         check_settings_update(
             &mut store,
+            r#""#.unindent(),
+            |settings| {
+                settings.tabs = Some(ItemSettingsContent {
+                    active_tab_path: Some(true),
+                    ..Default::default()
+                })
+            },
+            r#"{
+              "tabs": {
+                "active_tab_path": true
+              }
+            }
+            "#
+            .unindent(),
+            cx,
+        );
+
+        check_settings_update(
+            &mut store,
             r#"{
             }
             "#

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -611,6 +611,7 @@ impl VsCodeSettings {
                         ShowCloseButton::Hidden
                     }
                 }),
+            active_tab_path: None,
         })
     }
 

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -3120,6 +3120,24 @@ pub(crate) fn settings_data(cx: &App) -> Vec<SettingsPage> {
                     metadata: None,
                     files: USER,
                 }),
+                SettingsPageItem::SettingItem(SettingItem {
+                    title: "Show Path For Active Tab",
+                    description: "Show the path from the worktree root (or absolute path for files outside the worktree) for the active tab in each pane.",
+                    field: Box::new(SettingField {
+                        json_path: Some("tabs.active_tab_path"),
+                        pick: |settings_content| {
+                            settings_content.tabs.as_ref()?.active_tab_path.as_ref()
+                        },
+                        write: |settings_content, value| {
+                            settings_content
+                                .tabs
+                                .get_or_insert_default()
+                                .active_tab_path = value;
+                        },
+                    }),
+                    metadata: None,
+                    files: USER,
+                }),
                 SettingsPageItem::SectionHeader("Preview Tabs"),
                 SettingsPageItem::SettingItem(SettingItem {
                     title: "Preview Tabs Enabled",

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -59,6 +59,7 @@ pub struct ItemSettings {
     pub file_icons: bool,
     pub show_diagnostics: ShowDiagnostics,
     pub show_close_button: ShowCloseButton,
+    pub active_tab_path: bool,
 }
 
 #[derive(RegisterSetting)]
@@ -78,6 +79,7 @@ impl Settings for ItemSettings {
             file_icons: tabs.file_icons.unwrap(),
             show_diagnostics: tabs.show_diagnostics.unwrap(),
             show_close_button: tabs.show_close_button.unwrap(),
+            active_tab_path: tabs.active_tab_path.unwrap(),
         }
     }
 }


### PR DESCRIPTION
Adds a new `tabs.active_tab_path` setting that displays the complete file path for the active tab in each pane, instead of just the filename.

## Motivation

I want to see the full path of the file I'm currently working on. Breadcrumbs provide this, but I find horizontal breadcrumbs don't work for me - they duplicate the filename and add visual noise. And now that Zed has sticky scrolling (which I love), breadcrumbs feel redundant and take up precious vertical space.

This feature provides a cleaner alternative by showing the complete path directly in active tabs in each pane.

## Behavior

- Added `tabs.active_tab_path` setting (default: `false`)
- When enabled, active tabs display the complete path instead of just the
   filename
- Files in worktree display a relative path to the worktree root: `crates/editor/src/items.rs` 
- Files outside worktree display an absolute path: `/Users/name/file.txt`
- Description (parent directory hint) is hidden for active tabs when enabled
- Inactive tabs continue showing filename + description as normal
- Setting available in both JSON settings and Settings UI

## Usage

Users can enable this feature in their settings:

```json
{
  "tabs": {
    "active_tab_path": true
  }
}
```

Or via the Settings UI toggle: **"Show Path For Active Tab"**

## Screenshots

### Active tab in worktree

#### Default
<img width="979" height="396" alt="Screenshot 2025-11-20 at 1 19 16 PM" src="https://github.com/user-attachments/assets/85b56c26-b838-4b7a-addc-59ccb80af515" />


#### Setting Enabled
The active tab's full relative path is displayed.

<img width="981" height="400" alt="Screenshot 2025-11-20 at 1 16 03 PM" src="https://github.com/user-attachments/assets/1d214835-324e-44c6-b3ac-b5610666dc84" />

### Active tab in worktree that matches filename of another tab

#### Default

<img width="979" height="475" alt="Screenshot 2025-11-20 at 1 41 21 PM" src="https://github.com/user-attachments/assets/f1c1cecc-beea-4259-98ba-8e0c2f45fe5c" />

#### Setting Enabled
The active tab's full relative path is displayed with no need for the parent path to the right of it.

<img width="980" height="473" alt="Screenshot 2025-11-20 at 1 40 58 PM" src="https://github.com/user-attachments/assets/aee91a02-f2c3-4289-be1c-c89337036cc4" />

### Active tab outside worktree

#### Default
<img width="979" height="422" alt="Screenshot 2025-11-20 at 1 45 30 PM" src="https://github.com/user-attachments/assets/7b5990fe-ca57-4f7f-b56b-6d2f4bf871cd" />

#### Setting Enabled
The active tab's absolute path is displayed.

<img width="980" height="425" alt="Screenshot 2025-11-20 at 1 45 00 PM" src="https://github.com/user-attachments/assets/cc9ab3fe-64a8-44ce-b65f-f25824b8b55f" />

---

Release Notes:

- Added `tabs.active_tab_path` setting to display the complete file path for active tabs instead of just the filename.
