### PR TITLE
gpui: #[inline] some trivial functions

### DIFF
--- a/crates/gpui/src/app/async_context.rs
+++ b/crates/gpui/src/app/async_context.rs
@@ -296,8 +296,8 @@ impl AsyncWindowContext {
 
     /// A convenience method for [`Window::on_next_frame`].
     pub fn on_next_frame(&mut self, f: impl FnOnce(&mut Window, &mut App) + 'static) {
-        self.window
-            .update(self, |_, window, _| window.on_next_frame(f))
+        self.app
+            .update_window(self.window, |_, window, _| window.on_next_frame(f))
             .ok();
     }
 
@@ -306,8 +306,8 @@ impl AsyncWindowContext {
         &mut self,
         read: impl FnOnce(&G, &Window, &App) -> R,
     ) -> Result<R> {
-        self.window
-            .update(self, |_, window, cx| read(cx.global(), window, cx))
+        self.app
+            .update_window(self.window, |_, window, cx| read(cx.global(), window, cx))
     }
 
     /// A convenience method for [`App::update_global`](BorrowAppContext::update_global).
@@ -319,7 +319,7 @@ impl AsyncWindowContext {
     where
         G: Global,
     {
-        self.window.update(self, |_, window, cx| {
+        self.app.update_window(self.window, |_, window, cx| {
             cx.update_global(|global, cx| update(global, window, cx))
         })
     }
@@ -350,8 +350,8 @@ impl AsyncWindowContext {
     where
         T: Clone + Into<PromptButton>,
     {
-        self.window
-            .update(self, |_, window, cx| {
+        self.app
+            .update_window(self.window, |_, window, cx| {
                 window.prompt(level, message, detail, answers, cx)
             })
             .unwrap_or_else(|_| oneshot::channel().1)
@@ -365,11 +365,13 @@ impl AppContext for AsyncWindowContext {
     where
         T: 'static,
     {
-        self.window.update(self, |_, _, cx| cx.new(build_entity))
+        self.app
+            .update_window(self.window, |_, _, cx| cx.new(build_entity))
     }
 
     fn reserve_entity<T: 'static>(&mut self) -> Result<Reservation<T>> {
-        self.window.update(self, |_, _, cx| cx.reserve_entity())
+        self.app
+            .update_window(self.window, |_, _, cx| cx.reserve_entity())
     }
 
     fn insert_entity<T: 'static>(
@@ -377,8 +379,9 @@ impl AppContext for AsyncWindowContext {
         reservation: Reservation<T>,
         build_entity: impl FnOnce(&mut Context<T>) -> T,
     ) -> Self::Result<Entity<T>> {
-        self.window
-            .update(self, |_, _, cx| cx.insert_entity(reservation, build_entity))
+        self.app.update_window(self.window, |_, _, cx| {
+            cx.insert_entity(reservation, build_entity)
+        })
     }
 
     fn update_entity<T: 'static, R>(
@@ -386,8 +389,8 @@ impl AppContext for AsyncWindowContext {
         handle: &Entity<T>,
         update: impl FnOnce(&mut T, &mut Context<T>) -> R,
     ) -> Result<R> {
-        self.window
-            .update(self, |_, _, cx| cx.update_entity(handle, update))
+        self.app
+            .update_window(self.window, |_, _, cx| cx.update_entity(handle, update))
     }
 
     fn as_mut<'a, T>(&'a mut self, _: &Entity<T>) -> Self::Result<super::GpuiBorrow<'a, T>>
@@ -452,8 +455,9 @@ impl VisualContext for AsyncWindowContext {
         &mut self,
         build_entity: impl FnOnce(&mut Window, &mut Context<T>) -> T,
     ) -> Self::Result<Entity<T>> {
-        self.window
-            .update(self, |_, window, cx| cx.new(|cx| build_entity(window, cx)))
+        self.app.update_window(self.window, |_, window, cx| {
+            cx.new(|cx| build_entity(window, cx))
+        })
     }
 
     fn update_window_entity<T: 'static, R>(
@@ -461,7 +465,7 @@ impl VisualContext for AsyncWindowContext {
         view: &Entity<T>,
         update: impl FnOnce(&mut T, &mut Window, &mut Context<T>) -> R,
     ) -> Self::Result<R> {
-        self.window.update(self, |_, window, cx| {
+        self.app.update_window(self.window, |_, window, cx| {
             view.update(cx, |entity, cx| update(entity, window, cx))
         })
     }
@@ -473,15 +477,16 @@ impl VisualContext for AsyncWindowContext {
     where
         V: 'static + Render,
     {
-        self.window
-            .update(self, |_, window, cx| window.replace_root(cx, build_view))
+        self.app.update_window(self.window, |_, window, cx| {
+            window.replace_root(cx, build_view)
+        })
     }
 
     fn focus<V>(&mut self, view: &Entity<V>) -> Self::Result<()>
     where
         V: Focusable,
     {
-        self.window.update(self, |_, window, cx| {
+        self.app.update_window(self.window, |_, window, cx| {
             view.read(cx).focus_handle(cx).focus(window);
         })
     }

--- a/crates/gpui/src/app/context.rs
+++ b/crates/gpui/src/app/context.rs
@@ -736,14 +736,17 @@ impl<T> Context<'_, T> {
 impl<T> AppContext for Context<'_, T> {
     type Result<U> = U;
 
+    #[inline]
     fn new<U: 'static>(&mut self, build_entity: impl FnOnce(&mut Context<U>) -> U) -> Entity<U> {
         self.app.new(build_entity)
     }
 
+    #[inline]
     fn reserve_entity<U: 'static>(&mut self) -> Reservation<U> {
         self.app.reserve_entity()
     }
 
+    #[inline]
     fn insert_entity<U: 'static>(
         &mut self,
         reservation: Reservation<U>,
@@ -752,6 +755,7 @@ impl<T> AppContext for Context<'_, T> {
         self.app.insert_entity(reservation, build_entity)
     }
 
+    #[inline]
     fn update_entity<U: 'static, R>(
         &mut self,
         handle: &Entity<U>,
@@ -760,6 +764,7 @@ impl<T> AppContext for Context<'_, T> {
         self.app.update_entity(handle, update)
     }
 
+    #[inline]
     fn as_mut<'a, E>(&'a mut self, handle: &Entity<E>) -> Self::Result<super::GpuiBorrow<'a, E>>
     where
         E: 'static,
@@ -767,6 +772,7 @@ impl<T> AppContext for Context<'_, T> {
         self.app.as_mut(handle)
     }
 
+    #[inline]
     fn read_entity<U, R>(
         &self,
         handle: &Entity<U>,
@@ -778,6 +784,7 @@ impl<T> AppContext for Context<'_, T> {
         self.app.read_entity(handle, read)
     }
 
+    #[inline]
     fn update_window<R, F>(&mut self, window: AnyWindowHandle, update: F) -> Result<R>
     where
         F: FnOnce(AnyView, &mut Window, &mut App) -> R,
@@ -785,6 +792,7 @@ impl<T> AppContext for Context<'_, T> {
         self.app.update_window(window, update)
     }
 
+    #[inline]
     fn read_window<U, R>(
         &self,
         window: &WindowHandle<U>,
@@ -796,6 +804,7 @@ impl<T> AppContext for Context<'_, T> {
         self.app.read_window(window, read)
     }
 
+    #[inline]
     fn background_spawn<R>(&self, future: impl Future<Output = R> + Send + 'static) -> Task<R>
     where
         R: Send + 'static,
@@ -803,6 +812,7 @@ impl<T> AppContext for Context<'_, T> {
         self.app.background_executor.spawn(future)
     }
 
+    #[inline]
     fn read_global<G, R>(&self, callback: impl FnOnce(&G, &App) -> R) -> Self::Result<R>
     where
         G: Global,

--- a/crates/gpui/src/app/entity_map.rs
+++ b/crates/gpui/src/app/entity_map.rs
@@ -244,11 +244,13 @@ impl AnyEntity {
     }
 
     /// Returns the id associated with this entity.
+    #[inline]
     pub fn entity_id(&self) -> EntityId {
         self.entity_id
     }
 
     /// Returns the [TypeId] associated with this entity.
+    #[inline]
     pub fn entity_type(&self) -> TypeId {
         self.entity_type
     }
@@ -332,18 +334,21 @@ impl Drop for AnyEntity {
 }
 
 impl<T> From<Entity<T>> for AnyEntity {
+    #[inline]
     fn from(entity: Entity<T>) -> Self {
         entity.any_entity
     }
 }
 
 impl Hash for AnyEntity {
+    #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.entity_id.hash(state);
     }
 }
 
 impl PartialEq for AnyEntity {
+    #[inline]
     fn eq(&self, other: &Self) -> bool {
         self.entity_id == other.entity_id
     }
@@ -352,12 +357,14 @@ impl PartialEq for AnyEntity {
 impl Eq for AnyEntity {}
 
 impl Ord for AnyEntity {
+    #[inline]
     fn cmp(&self, other: &Self) -> Ordering {
         self.entity_id.cmp(&other.entity_id)
     }
 }
 
 impl PartialOrd for AnyEntity {
+    #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
@@ -384,6 +391,7 @@ pub struct Entity<T> {
 impl<T> Sealed for Entity<T> {}
 
 impl<T: 'static> Entity<T> {
+    #[inline]
     fn new(id: EntityId, entity_map: Weak<RwLock<EntityRefCounts>>) -> Self
     where
         T: 'static,
@@ -395,11 +403,13 @@ impl<T: 'static> Entity<T> {
     }
 
     /// Get the entity ID associated with this entity
+    #[inline]
     pub fn entity_id(&self) -> EntityId {
         self.any_entity.entity_id
     }
 
     /// Downgrade this entity pointer to a non-retaining weak pointer
+    #[inline]
     pub fn downgrade(&self) -> WeakEntity<T> {
         WeakEntity {
             any_entity: self.any_entity.downgrade(),
@@ -408,16 +418,19 @@ impl<T: 'static> Entity<T> {
     }
 
     /// Convert this into a dynamically typed entity.
+    #[inline]
     pub fn into_any(self) -> AnyEntity {
         self.any_entity
     }
 
     /// Grab a reference to this entity from the context.
+    #[inline]
     pub fn read<'a>(&self, cx: &'a App) -> &'a T {
         cx.entities.read(self)
     }
 
     /// Read the entity referenced by this handle with the given function.
+    #[inline]
     pub fn read_with<R, C: AppContext>(
         &self,
         cx: &C,
@@ -427,6 +440,7 @@ impl<T: 'static> Entity<T> {
     }
 
     /// Updates the entity referenced by this handle with the given function.
+    #[inline]
     pub fn update<R, C: AppContext>(
         &self,
         cx: &mut C,
@@ -436,6 +450,7 @@ impl<T: 'static> Entity<T> {
     }
 
     /// Updates the entity referenced by this handle with the given function.
+    #[inline]
     pub fn as_mut<'a, C: AppContext>(&self, cx: &'a mut C) -> C::Result<GpuiBorrow<'a, T>> {
         cx.as_mut(self)
     }
@@ -451,6 +466,7 @@ impl<T: 'static> Entity<T> {
     /// Updates the entity referenced by this handle with the given function if
     /// the referenced entity still exists, within a visual context that has a window.
     /// Returns an error if the entity has been released.
+    #[inline]
     pub fn update_in<R, C: VisualContext>(
         &self,
         cx: &mut C,
@@ -461,6 +477,7 @@ impl<T: 'static> Entity<T> {
 }
 
 impl<T> Clone for Entity<T> {
+    #[inline]
     fn clone(&self) -> Self {
         Self {
             any_entity: self.any_entity.clone(),
@@ -479,12 +496,14 @@ impl<T> std::fmt::Debug for Entity<T> {
 }
 
 impl<T> Hash for Entity<T> {
+    #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.any_entity.hash(state);
     }
 }
 
 impl<T> PartialEq for Entity<T> {
+    #[inline]
     fn eq(&self, other: &Self) -> bool {
         self.any_entity == other.any_entity
     }
@@ -493,18 +512,21 @@ impl<T> PartialEq for Entity<T> {
 impl<T> Eq for Entity<T> {}
 
 impl<T> PartialEq<WeakEntity<T>> for Entity<T> {
+    #[inline]
     fn eq(&self, other: &WeakEntity<T>) -> bool {
         self.any_entity.entity_id() == other.entity_id()
     }
 }
 
 impl<T: 'static> Ord for Entity<T> {
+    #[inline]
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.entity_id().cmp(&other.entity_id())
     }
 }
 
 impl<T: 'static> PartialOrd for Entity<T> {
+    #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
@@ -520,6 +542,7 @@ pub struct AnyWeakEntity {
 
 impl AnyWeakEntity {
     /// Get the entity ID associated with this weak reference.
+    #[inline]
     pub fn entity_id(&self) -> EntityId {
         self.entity_id
     }
@@ -618,18 +641,21 @@ impl std::fmt::Debug for AnyWeakEntity {
 }
 
 impl<T> From<WeakEntity<T>> for AnyWeakEntity {
+    #[inline]
     fn from(entity: WeakEntity<T>) -> Self {
         entity.any_entity
     }
 }
 
 impl Hash for AnyWeakEntity {
+    #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.entity_id.hash(state);
     }
 }
 
 impl PartialEq for AnyWeakEntity {
+    #[inline]
     fn eq(&self, other: &Self) -> bool {
         self.entity_id == other.entity_id
     }
@@ -638,12 +664,14 @@ impl PartialEq for AnyWeakEntity {
 impl Eq for AnyWeakEntity {}
 
 impl Ord for AnyWeakEntity {
+    #[inline]
     fn cmp(&self, other: &Self) -> Ordering {
         self.entity_id.cmp(&other.entity_id)
     }
 }
 
 impl PartialOrd for AnyWeakEntity {
+    #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
@@ -740,6 +768,7 @@ impl<T: 'static> WeakEntity<T> {
     }
 
     /// Create a new weak entity that can never be upgraded.
+    #[inline]
     pub fn new_invalid() -> Self {
         Self {
             any_entity: AnyWeakEntity::new_invalid(),
@@ -749,12 +778,14 @@ impl<T: 'static> WeakEntity<T> {
 }
 
 impl<T> Hash for WeakEntity<T> {
+    #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.any_entity.hash(state);
     }
 }
 
 impl<T> PartialEq for WeakEntity<T> {
+    #[inline]
     fn eq(&self, other: &Self) -> bool {
         self.any_entity == other.any_entity
     }
@@ -763,18 +794,21 @@ impl<T> PartialEq for WeakEntity<T> {
 impl<T> Eq for WeakEntity<T> {}
 
 impl<T> PartialEq<Entity<T>> for WeakEntity<T> {
+    #[inline]
     fn eq(&self, other: &Entity<T>) -> bool {
         self.entity_id() == other.any_entity.entity_id()
     }
 }
 
 impl<T: 'static> Ord for WeakEntity<T> {
+    #[inline]
     fn cmp(&self, other: &Self) -> Ordering {
         self.entity_id().cmp(&other.entity_id())
     }
 }
 
 impl<T: 'static> PartialOrd for WeakEntity<T> {
+    #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }

--- a/crates/text/src/text.rs
+++ b/crates/text/src/text.rs
@@ -3129,13 +3129,13 @@ pub trait ToOffset {
 }
 
 impl ToOffset for Point {
+    #[inline]
     fn to_offset(&self, snapshot: &BufferSnapshot) -> usize {
         snapshot.point_to_offset(*self)
     }
 }
 
 impl ToOffset for usize {
-    #[track_caller]
     fn to_offset(&self, snapshot: &BufferSnapshot) -> usize {
         assert!(
             *self <= snapshot.len(),
@@ -3148,24 +3148,28 @@ impl ToOffset for usize {
 }
 
 impl ToOffset for Anchor {
+    #[inline]
     fn to_offset(&self, snapshot: &BufferSnapshot) -> usize {
         snapshot.summary_for_anchor(self)
     }
 }
 
 impl<T: ToOffset> ToOffset for &T {
+    #[inline]
     fn to_offset(&self, content: &BufferSnapshot) -> usize {
         (*self).to_offset(content)
     }
 }
 
 impl ToOffset for PointUtf16 {
+    #[inline]
     fn to_offset(&self, snapshot: &BufferSnapshot) -> usize {
         snapshot.point_utf16_to_offset(*self)
     }
 }
 
 impl ToOffset for Unclipped<PointUtf16> {
+    #[inline]
     fn to_offset(&self, snapshot: &BufferSnapshot) -> usize {
         snapshot.unclipped_point_utf16_to_offset(*self)
     }
@@ -3176,24 +3180,28 @@ pub trait ToPoint {
 }
 
 impl ToPoint for Anchor {
+    #[inline]
     fn to_point(&self, snapshot: &BufferSnapshot) -> Point {
         snapshot.summary_for_anchor(self)
     }
 }
 
 impl ToPoint for usize {
+    #[inline]
     fn to_point(&self, snapshot: &BufferSnapshot) -> Point {
         snapshot.offset_to_point(*self)
     }
 }
 
 impl ToPoint for Point {
+    #[inline]
     fn to_point(&self, _: &BufferSnapshot) -> Point {
         *self
     }
 }
 
 impl ToPoint for Unclipped<PointUtf16> {
+    #[inline]
     fn to_point(&self, snapshot: &BufferSnapshot) -> Point {
         snapshot.unclipped_point_utf16_to_point(*self)
     }
@@ -3204,24 +3212,28 @@ pub trait ToPointUtf16 {
 }
 
 impl ToPointUtf16 for Anchor {
+    #[inline]
     fn to_point_utf16(&self, snapshot: &BufferSnapshot) -> PointUtf16 {
         snapshot.summary_for_anchor(self)
     }
 }
 
 impl ToPointUtf16 for usize {
+    #[inline]
     fn to_point_utf16(&self, snapshot: &BufferSnapshot) -> PointUtf16 {
         snapshot.offset_to_point_utf16(*self)
     }
 }
 
 impl ToPointUtf16 for PointUtf16 {
+    #[inline]
     fn to_point_utf16(&self, _: &BufferSnapshot) -> PointUtf16 {
         *self
     }
 }
 
 impl ToPointUtf16 for Point {
+    #[inline]
     fn to_point_utf16(&self, snapshot: &BufferSnapshot) -> PointUtf16 {
         snapshot.point_to_point_utf16(*self)
     }
@@ -3232,18 +3244,21 @@ pub trait ToOffsetUtf16 {
 }
 
 impl ToOffsetUtf16 for Anchor {
+    #[inline]
     fn to_offset_utf16(&self, snapshot: &BufferSnapshot) -> OffsetUtf16 {
         snapshot.summary_for_anchor(self)
     }
 }
 
 impl ToOffsetUtf16 for usize {
+    #[inline]
     fn to_offset_utf16(&self, snapshot: &BufferSnapshot) -> OffsetUtf16 {
         snapshot.offset_to_offset_utf16(*self)
     }
 }
 
 impl ToOffsetUtf16 for OffsetUtf16 {
+    #[inline]
     fn to_offset_utf16(&self, _snapshot: &BufferSnapshot) -> OffsetUtf16 {
         *self
     }
@@ -3254,24 +3269,28 @@ pub trait FromAnchor {
 }
 
 impl FromAnchor for Anchor {
+    #[inline]
     fn from_anchor(anchor: &Anchor, _snapshot: &BufferSnapshot) -> Self {
         *anchor
     }
 }
 
 impl FromAnchor for Point {
+    #[inline]
     fn from_anchor(anchor: &Anchor, snapshot: &BufferSnapshot) -> Self {
         snapshot.summary_for_anchor(anchor)
     }
 }
 
 impl FromAnchor for PointUtf16 {
+    #[inline]
     fn from_anchor(anchor: &Anchor, snapshot: &BufferSnapshot) -> Self {
         snapshot.summary_for_anchor(anchor)
     }
 }
 
 impl FromAnchor for usize {
+    #[inline]
     fn from_anchor(anchor: &Anchor, snapshot: &BufferSnapshot) -> Self {
         snapshot.summary_for_anchor(anchor)
     }


### PR DESCRIPTION
These appear in a lot of stacktraces (especially on windows) despite them being plain forwarding calls.

Also removes some intermediate calls within gpui that will only turn into more unnecessary compiler work.

Release Notes:

- N/A *or* Added/Fixed/Improved ...
