### PR TITLE
Fix `connect.host` setting being ignored by debugpy

### DIFF
--- a/crates/dap_adapters/src/python.rs
+++ b/crates/dap_adapters/src/python.rs
@@ -368,6 +368,9 @@ impl PythonDebugAdapter {
                 bail!("Cannot have two different ports in debug configuration")
             }
 
+            if let Some(hostname) = config_host {
+                tcp_connection.host = Some(hostname.parse().context("hostname must be IPv4")?);
+            }
             tcp_connection.port = config_port;
             DebugpyLaunchMode::AttachWithConnect { host: config_host }
         } else {


### PR DESCRIPTION
Closes #42727

Unfortunately we can only support IPv4 addresses right now because `TcpArguments` only supports an IPv4 address. I'm not sure how difficult it would be to lift this limitation.

Release Notes:

- Fixed `connect.host` setting being ignored by debugpy
