### PR TITLE
rope: Use SIMD in `Chunk::push_str` to create byte masks faster

### DIFF
--- a/crates/rope/src/rope.rs
+++ b/crates/rope/src/rope.rs
@@ -1,3 +1,4 @@
+#![feature(portable_simd)]
 mod chunk;
 mod offset_utf16;
 mod point;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.91.1"
+channel = "nightly"
 profile = "minimal"
 components = [ "rustfmt", "clippy" ]
 targets = [


### PR DESCRIPTION
Improves the performance of rope's Chunk::push_str using SIMD.

Zed's Rope Bitmaps make it much faster to search through a Rope more quickly, with the trade-off that Bitmaps need to be generated ahead of time (in `Chunk::push_str`).

I modified `Chunk::push_str`'s Bitmap code to loop over each *byte* instead of each *codepoint*, but that wasn't enough for Rust to optimize the loop, so I created a version that explicitly tells Rust how to to use SIMD instructions.

On my computer this improves the performance of the push by approximately 50%.
(`cd crates/rope && cargo bench`)
```
push/4096               time:   [42.499 µs 42.522 µs 42.552 µs]
                        thrpt:  [91.800 MiB/s 91.864 MiB/s 91.913 MiB/s]
                 change:
                        time:   [-55.021% -54.961% -54.904%] (p = 0.00 < 0.05)
                        thrpt:  [+121.75% +122.03% +122.33%]
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  7 (7.00%) high mild
  4 (4.00%) high severe

push/65536              time:   [315.91 µs 318.51 µs 321.42 µs]
                        thrpt:  [194.45 MiB/s 196.23 MiB/s 197.84 MiB/s]
                 change:
                        time:   [-50.450% -49.954% -49.430%] (p = 0.00 < 0.05)
                        thrpt:  [+97.745% +99.815% +101.82%]
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild
```

Concerns:
* This code uses `std::simd` which is currently only available in nightly Rust.
* The code is now more confusing than the non-simd version, although not by too much.
* I've chosen a width of 64 somewhat arbitrarily as it's the maximum size `std::simd` provides, but it's possible that other widths could be better.
* Rope's tests may use u16 sized bitmasks which might not cover the SIMD code

Release Notes:

- N/A