### PR TITLE
Fix casing in comments in `default.json`

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -2068,11 +2068,11 @@
   "dev": {
     // "theme": "Andromeda"
   },
-  // Settings overrides to use when using linux
+  // Settings overrides to use when using Linux.
   "linux": {},
-  // Settings overrides to use when using macos
+  // Settings overrides to use when using macOS.
   "macos": {},
-  // Settings overrides to use when using windows
+  // Settings overrides to use when using Windows.
   "windows": {
     "languages": {
       "PHP": {


### PR DESCRIPTION
This PR fixes the casing of the operating system names in the language-specific sections of `default.json`.

This files serves as documentation for users (since it can be viewed through `zed: open default settings`), so we should make sure it is tidy.

Release Notes:

- N/A
