### PR TITLE
Disable fsevents tests

### DIFF
--- a/crates/fsevent/src/fsevent.rs
+++ b/crates/fsevent/src/fsevent.rs
@@ -372,7 +372,9 @@ unsafe extern "C" {
     pub fn FSEventsGetCurrentEventId() -> u64;
 }
 
-#[cfg(test)]
+// These tests are disabled by default because they seem to be unresolvably flaky.
+// Feel free to bring them back to help test this code
+#[cfg(false)]
 mod tests {
     use super::*;
     use std::{fs, sync::mpsc, thread, time::Duration};


### PR DESCRIPTION
They're flakier than phyllo dough, and not nearly as delicious

Release Notes:

- N/A
