### PR TITLE
zed: Allocate more rayon threads depending on available parallelism

### DIFF
--- a/crates/remote_server/src/unix.rs
+++ b/crates/remote_server/src/unix.rs
@@ -373,7 +373,7 @@ pub fn execute_run(
     let listeners = ServerListeners::new(stdin_socket, stdout_socket, stderr_socket)?;
 
     rayon::ThreadPoolBuilder::new()
-        .num_threads(4)
+        .num_threads(std::thread::available_parallelism().map_or(1, |n| n.get().div_ceil(2)))
         .stack_size(10 * 1024 * 1024)
         .thread_name(|ix| format!("RayonWorker{}", ix))
         .build_global()

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -265,7 +265,7 @@ pub fn main() {
     }
 
     rayon::ThreadPoolBuilder::new()
-        .num_threads(4)
+        .num_threads(std::thread::available_parallelism().map_or(1, |n| n.get().div_ceil(2)))
         .stack_size(10 * 1024 * 1024)
         .thread_name(|ix| format!("RayonWorker{}", ix))
         .build_global()


### PR DESCRIPTION
While zed itself is not a heavy user of rayon, wasmtime is, especially for compilation. This change is similar to the rayon default but we halve the number of threads still so we don't spawn too many threads overall.

Release Notes:

- N/A *or* Added/Fixed/Improved ...
