### PR TITLE
docs: Fix small typo in docs for Snippets

### DIFF
--- a/docs/src/snippets.md
+++ b/docs/src/snippets.md
@@ -35,7 +35,7 @@ To create JSX snippets you have to use `javascript.json` snippets file, instead 
 
 ## Known Limitations
 
-- Only the first prefix is used when an list of prefixes is passed in.
+- Only the first prefix is used when a list of prefixes is passed in.
 - Currently only the `json` snippet file format is supported, even though the `simple-completion-language-server` supports both `json` and `toml` file formats.
 
 ## See also


### PR DESCRIPTION
Happened to notice this typo while going through the docs.

Release Notes:

- N/A

---

💖