### PR TITLE
git: Show renamed files with arrow icon in Git panel

### DIFF
--- a/crates/collab/src/db.rs
+++ b/crates/collab/src/db.rs
@@ -742,6 +742,7 @@ fn db_status_to_proto(
         status: Some(proto::GitFileStatus {
             variant: Some(variant),
         }),
+        old_path: None,
     })
 }
 

--- a/crates/fs/src/fake_git_repo.rs
+++ b/crates/fs/src/fake_git_repo.rs
@@ -52,6 +52,8 @@ pub struct FakeGitRepositoryState {
     pub branches: HashSet<String>,
     pub simulated_index_write_error_message: Option<String>,
     pub refs: HashMap<String, String>,
+    /// Maps new_path -> old_path for renamed files
+    pub renamed_paths: HashMap<RepoPath, RepoPath>,
 }
 
 impl FakeGitRepositoryState {
@@ -68,6 +70,7 @@ impl FakeGitRepositoryState {
             refs: HashMap::from_iter([("HEAD".into(), "abc".into())]),
             merge_base_contents: Default::default(),
             oids: Default::default(),
+            renamed_paths: Default::default(),
         }
     }
 }
@@ -359,7 +362,7 @@ impl GitRepository for FakeGitRepository {
             entries.sort_by(|a, b| a.0.cmp(&b.0));
             anyhow::Ok(GitStatus {
                 entries: entries.into(),
-                renamed_paths: HashMap::default(),
+                renamed_paths: state.renamed_paths.clone(),
             })
         });
         Task::ready(match result {

--- a/crates/fs/src/fake_git_repo.rs
+++ b/crates/fs/src/fake_git_repo.rs
@@ -359,6 +359,7 @@ impl GitRepository for FakeGitRepository {
             entries.sort_by(|a, b| a.0.cmp(&b.0));
             anyhow::Ok(GitStatus {
                 entries: entries.into(),
+                renamed_paths: HashMap::default(),
             })
         });
         Task::ready(match result {

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -1853,6 +1853,20 @@ impl FakeFs {
         .unwrap();
     }
 
+    /// Set renamed paths for a git repository.
+    /// Maps new_path -> old_path for renamed files.
+    pub fn set_renamed_paths_for_repo(&self, dot_git: &Path, renames: &[(&str, &str)]) {
+        self.with_git_state(dot_git, true, |state| {
+            state.renamed_paths.clear();
+            for (new_path, old_path) in renames {
+                state
+                    .renamed_paths
+                    .insert(repo_path(new_path), repo_path(old_path));
+            }
+        })
+        .unwrap();
+    }
+
     /// Put the given git repository into a state with the given status,
     /// by mutating the head, index, and unmerged state.
     pub fn set_status_for_repo(&self, dot_git: &Path, statuses: &[(&str, FileStatus)]) {

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -2045,7 +2045,7 @@ fn git_status_args(path_prefixes: &[RepoPath]) -> Vec<OsString> {
         OsString::from("status"),
         OsString::from("--porcelain=v1"),
         OsString::from("--untracked-files=all"),
-        OsString::from("--no-renames"),
+        OsString::from("--find-renames"),
         OsString::from("-z"),
     ];
     args.extend(

--- a/crates/git/src/status.rs
+++ b/crates/git/src/status.rs
@@ -481,7 +481,9 @@ impl FromStr for GitStatus {
                     }
                     let new_path = RepoPath::from_rel_path(RelPath::unix(path).log_err()?);
                     let old_path = RepoPath::from_rel_path(RelPath::unix(old_path_str).log_err()?);
-                    renamed_paths.borrow_mut().insert(new_path.clone(), old_path);
+                    renamed_paths
+                        .borrow_mut()
+                        .insert(new_path.clone(), old_path);
                     skip_indices.borrow_mut().insert(i + 1);
                     Some((new_path, status))
                 } else {
@@ -644,11 +646,16 @@ mod tests {
         assert!(entries[2].1.is_modified());
 
         // Check renamed file
-        assert_eq!(entries[3].0, RepoPath::new("project/new/renamed.rs").unwrap());
+        assert_eq!(
+            entries[3].0,
+            RepoPath::new("project/new/renamed.rs").unwrap()
+        );
 
         // Check renamed_paths map contains the old path
         assert_eq!(
-            output.renamed_paths.get(&RepoPath::new("project/new/renamed.rs").unwrap()),
+            output
+                .renamed_paths
+                .get(&RepoPath::new("project/new/renamed.rs").unwrap()),
             Some(&RepoPath::new("project/old/renamed.rs").unwrap())
         );
     }
@@ -666,11 +673,15 @@ mod tests {
 
         // Check renamed_paths map contains both renames
         assert_eq!(
-            output.renamed_paths.get(&RepoPath::new("src/new_file1.rs").unwrap()),
+            output
+                .renamed_paths
+                .get(&RepoPath::new("src/new_file1.rs").unwrap()),
             Some(&RepoPath::new("src/old_file1.rs").unwrap())
         );
         assert_eq!(
-            output.renamed_paths.get(&RepoPath::new("src/new_file2.rs").unwrap()),
+            output
+                .renamed_paths
+                .get(&RepoPath::new("src/new_file2.rs").unwrap()),
             Some(&RepoPath::new("src/old_file2.rs").unwrap())
         );
         assert_eq!(output.renamed_paths.len(), 2);
@@ -690,11 +701,15 @@ mod tests {
 
         // Check renamed_paths map contains both copies (we track copies the same way as renames)
         assert_eq!(
-            output.renamed_paths.get(&RepoPath::new("src/copy1.rs").unwrap()),
+            output
+                .renamed_paths
+                .get(&RepoPath::new("src/copy1.rs").unwrap()),
             Some(&RepoPath::new("src/original1.rs").unwrap())
         );
         assert_eq!(
-            output.renamed_paths.get(&RepoPath::new("src/copy2.rs").unwrap()),
+            output
+                .renamed_paths
+                .get(&RepoPath::new("src/copy2.rs").unwrap()),
             Some(&RepoPath::new("src/original2.rs").unwrap())
         );
         assert_eq!(output.renamed_paths.len(), 2);

--- a/crates/git/src/status.rs
+++ b/crates/git/src/status.rs
@@ -168,6 +168,17 @@ impl FileStatus {
             || self.is_deleted()
             || self.is_untracked()
             || self.is_conflicted()
+            || self.is_renamed()
+    }
+
+    pub fn is_renamed(self) -> bool {
+        match self {
+            FileStatus::Tracked(tracked) => matches!(
+                (tracked.index_status, tracked.worktree_status),
+                (StatusCode::Renamed, _) | (_, StatusCode::Renamed)
+            ),
+            _ => false,
+        }
     }
 
     pub fn is_modified(self) -> bool {

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -256,6 +256,7 @@ pub struct GitStatusEntry {
     pub(crate) repo_path: RepoPath,
     pub(crate) status: FileStatus,
     pub(crate) staging: StageStatus,
+    pub(crate) old_path: Option<RepoPath>,
 }
 
 impl GitStatusEntry {
@@ -2826,6 +2827,7 @@ impl GitPanel {
                 repo_path: entry.repo_path.clone(),
                 status: entry.status,
                 staging,
+                old_path: entry.old_path.clone(),
             };
 
             if staging.has_staged() {
@@ -2876,6 +2878,7 @@ impl GitPanel {
                                 repo_path: ops.repo_path.clone(),
                                 status: status.status,
                                 staging: StageStatus::Staged,
+                                old_path: status.old_path.clone(),
                             })
                     } else {
                         None
@@ -4296,7 +4299,13 @@ impl GitPanel {
                             }),
                     ),
             )
-            .child(git_status_icon(status))
+            .child(if entry.old_path.is_some() {
+                Icon::new(IconName::ArrowRight)
+                    .color(Color::Custom(cx.theme().colors().version_control_modified))
+                    .into_any_element()
+            } else {
+                git_status_icon(status).into_any_element()
+            })
             .child(
                 h_flex()
                     .items_center()
@@ -4312,7 +4321,14 @@ impl GitPanel {
                             git_path_style,
                             status.is_deleted(),
                         )
-                    })),
+                    }))
+                    .when_some(entry.old_path.as_ref(), |this, old_path| {
+                        this.child(
+                            Label::new(format!(" ← {}", old_path.display(path_style)))
+                                .size(LabelSize::Small)
+                                .color(Color::Muted),
+                        )
+                    }),
             )
             .into_any_element()
     }
@@ -5273,11 +5289,13 @@ mod tests {
                     repo_path: repo_path("crates/gpui/gpui.rs"),
                     status: StatusCode::Modified.worktree(),
                     staging: StageStatus::Unstaged,
+                    old_path: None,
                 }),
                 GitListEntry::Status(GitStatusEntry {
                     repo_path: repo_path("crates/util/util.rs"),
                     status: StatusCode::Modified.worktree(),
                     staging: StageStatus::Unstaged,
+                    old_path: None,
                 },),
             ],
         );
@@ -5298,11 +5316,13 @@ mod tests {
                     repo_path: repo_path("crates/gpui/gpui.rs"),
                     status: StatusCode::Modified.worktree(),
                     staging: StageStatus::Unstaged,
+                    old_path: None,
                 }),
                 GitListEntry::Status(GitStatusEntry {
                     repo_path: repo_path("crates/util/util.rs"),
                     status: StatusCode::Modified.worktree(),
                     staging: StageStatus::Unstaged,
+                    old_path: None,
                 },),
             ],
         );

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -2878,7 +2878,7 @@ impl GitPanel {
                                 repo_path: ops.repo_path.clone(),
                                 status: status.status,
                                 staging: StageStatus::Staged,
-                                old_path: status.old_path.clone(),
+                                old_path: status.old_path,
                             })
                     } else {
                         None

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -221,7 +221,11 @@ impl TryFrom<proto::StatusEntry> for StatusEntry {
         let repo_path = RepoPath::from_proto(&value.repo_path).context("invalid repo path")?;
         let status = status_from_proto(value.simple_status, value.status)?;
         let old_path = value.old_path.and_then(|p| RepoPath::from_proto(&p).ok());
-        Ok(Self { repo_path, status, old_path })
+        Ok(Self {
+            repo_path,
+            status,
+            old_path,
+        })
     }
 }
 

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -8373,14 +8373,17 @@ async fn test_git_repository_status(cx: &mut gpui::TestAppContext) {
                 StatusEntry {
                     repo_path: repo_path("a.txt"),
                     status: StatusCode::Modified.worktree(),
+                    old_path: None,
                 },
                 StatusEntry {
                     repo_path: repo_path("b.txt"),
                     status: FileStatus::Untracked,
+                    old_path: None,
                 },
                 StatusEntry {
                     repo_path: repo_path("d.txt"),
                     status: StatusCode::Deleted.worktree(),
+                    old_path: None,
                 },
             ]
         );
@@ -8402,18 +8405,22 @@ async fn test_git_repository_status(cx: &mut gpui::TestAppContext) {
                 StatusEntry {
                     repo_path: repo_path("a.txt"),
                     status: StatusCode::Modified.worktree(),
+                    old_path: None,
                 },
                 StatusEntry {
                     repo_path: repo_path("b.txt"),
                     status: FileStatus::Untracked,
+                    old_path: None,
                 },
                 StatusEntry {
                     repo_path: repo_path("c.txt"),
                     status: StatusCode::Modified.worktree(),
+                    old_path: None,
                 },
                 StatusEntry {
                     repo_path: repo_path("d.txt"),
                     status: StatusCode::Deleted.worktree(),
+                    old_path: None,
                 },
             ]
         );
@@ -8447,6 +8454,7 @@ async fn test_git_repository_status(cx: &mut gpui::TestAppContext) {
             [StatusEntry {
                 repo_path: repo_path("a.txt"),
                 status: StatusCode::Deleted.worktree(),
+                old_path: None,
             }]
         );
     });
@@ -8510,6 +8518,7 @@ async fn test_git_status_postprocessing(cx: &mut gpui::TestAppContext) {
                     worktree_status: StatusCode::Added
                 }
                 .into(),
+                old_path: None,
             }]
         )
     });
@@ -8712,6 +8721,7 @@ async fn test_repository_pending_ops_staging(
                     worktree_status: StatusCode::Unmodified
                 }
                 .into(),
+                old_path: None,
             }]
         );
     });
@@ -8818,6 +8828,7 @@ async fn test_repository_pending_ops_long_running_staging(
                     worktree_status: StatusCode::Unmodified
                 }
                 .into(),
+                old_path: None,
             }]
         );
     });
@@ -8942,10 +8953,12 @@ async fn test_repository_pending_ops_stage_all(
                 StatusEntry {
                     repo_path: repo_path("a.txt"),
                     status: FileStatus::Untracked,
+                    old_path: None,
                 },
                 StatusEntry {
                     repo_path: repo_path("b.txt"),
                     status: FileStatus::Untracked,
+                    old_path: None,
                 },
             ]
         );

--- a/crates/proto/proto/git.proto
+++ b/crates/proto/proto/git.proto
@@ -290,6 +290,7 @@ message StatusEntry {
     // Can be removed once collab's min version is >=0.171.0.
     GitStatus simple_status = 2;
     GitFileStatus status = 3;
+    optional string old_path = 4;
 }
 
 message StashEntry {


### PR DESCRIPTION
## Closes #43089

This PR improves the Git panel to properly handle renamed files:

1. **Display renamed files with arrow icon** - Instead of showing separate deleted/added entries, renamed files now appear with an arrow icon (→) and their original path.

2. **Show correct diff for renamed files** - When viewing a staged renamed file's diff, the content is now correctly loaded from the original path in HEAD, not the new path (which doesn't exist in HEAD).

## Release Notes:

  - Rename detection uses git's default 50% similarity threshold
  - Works for both `git mv` and manual renames that meet similarity threshold
  - Also supports copied files (shown the same way as renames)
  - Arrow icon uses the theme's `version_control_modified` color
  - Original path displays in muted color to avoid visual clutter
  - Viewing diff of renamed files now correctly shows changes from original file

## Screenshot:
<img width="756" height="300" alt="2025-11-21_21-25-01" src="https://github.com/user-attachments/assets/7cbb5721-e453-4678-a7f3-8a219c160f99" />

<img width="2192" height="552" alt="image" src="https://github.com/user-attachments/assets/1f5e8c7a-52ef-4e30-91b8-a888e884a20a" />
