### PR TITLE
project: Support env-configured custom agent servers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13035,6 +13035,7 @@ dependencies = [
  "settings",
  "sha2",
  "shellexpand 2.1.2",
+ "shlex",
  "smallvec",
  "smol",
  "snippet",

--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -73,6 +73,7 @@ serde_json.workspace = true
 settings.workspace = true
 sha2.workspace = true
 shellexpand.workspace = true
+shlex.workspace = true
 smallvec.workspace = true
 smol.workspace = true
 snippet.workspace = true

--- a/crates/project/src/agent_server_store.rs
+++ b/crates/project/src/agent_server_store.rs
@@ -149,10 +149,7 @@ impl EventEmitter<AgentServersUpdated> for AgentServerStore {}
 #[cfg(test)]
 mod ext_agent_tests {
     use super::*;
-    use std::{
-        collections::HashSet,
-        fmt::Write as _,
-    };
+    use std::{collections::HashSet, fmt::Write as _};
 
     // Helper to build a store in Collab mode so we can mutate internal maps without
     // needing to spin up a full project environment.

--- a/crates/project/src/agent_server_store.rs
+++ b/crates/project/src/agent_server_store.rs
@@ -149,7 +149,10 @@ impl EventEmitter<AgentServersUpdated> for AgentServerStore {}
 #[cfg(test)]
 mod ext_agent_tests {
     use super::*;
-    use std::{collections::HashSet, fmt::Write as _};
+    use std::{
+        collections::HashSet,
+        fmt::Write as _,
+    };
 
     // Helper to build a store in Collab mode so we can mutate internal maps without
     // needing to spin up a full project environment.
@@ -199,7 +202,7 @@ mod ext_agent_tests {
 
     #[test]
     fn env_agent_server_config_parses() {
-        let mut map = HashMap::new();
+        let mut map: HashMap<String, String> = HashMap::with_hasher(Default::default());
         map.insert(
             "ZED_AGENT_SERVER_BIN".to_string(),
             "~/bin/my-agent".to_string(),

--- a/crates/project/src/agent_server_store.rs
+++ b/crates/project/src/agent_server_store.rs
@@ -203,9 +203,11 @@ mod ext_agent_tests {
         let old_args = env::var("ZED_AGENT_SERVER_ARGS").ok();
         let old_name = env::var("ZED_AGENT_SERVER_NAME").ok();
 
-        env::set_var("ZED_AGENT_SERVER_BIN", "~/bin/my-agent");
-        env::set_var("ZED_AGENT_SERVER_ARGS", "--foo bar");
-        env::set_var("ZED_AGENT_SERVER_NAME", "local-env-agent");
+        unsafe {
+            env::set_var("ZED_AGENT_SERVER_BIN", "~/bin/my-agent");
+            env::set_var("ZED_AGENT_SERVER_ARGS", "--foo bar");
+            env::set_var("ZED_AGENT_SERVER_NAME", "local-env-agent");
+        }
 
         let cfg = env_agent_server_config().expect("env agent server present");
         assert_eq!(cfg.0.to_string(), "local-env-agent");
@@ -213,17 +215,19 @@ mod ext_agent_tests {
         assert_eq!(cfg.1.args, vec!["--foo", "bar"]);
 
         // Restore environment
-        match old_bin {
-            Some(v) => env::set_var("ZED_AGENT_SERVER_BIN", v),
-            None => env::remove_var("ZED_AGENT_SERVER_BIN"),
-        }
-        match old_args {
-            Some(v) => env::set_var("ZED_AGENT_SERVER_ARGS", v),
-            None => env::remove_var("ZED_AGENT_SERVER_ARGS"),
-        }
-        match old_name {
-            Some(v) => env::set_var("ZED_AGENT_SERVER_NAME", v),
-            None => env::remove_var("ZED_AGENT_SERVER_NAME"),
+        unsafe {
+            match old_bin {
+                Some(v) => env::set_var("ZED_AGENT_SERVER_BIN", v),
+                None => env::remove_var("ZED_AGENT_SERVER_BIN"),
+            }
+            match old_args {
+                Some(v) => env::set_var("ZED_AGENT_SERVER_ARGS", v),
+                None => env::remove_var("ZED_AGENT_SERVER_ARGS"),
+            }
+            match old_name {
+                Some(v) => env::set_var("ZED_AGENT_SERVER_NAME", v),
+                None => env::remove_var("ZED_AGENT_SERVER_NAME"),
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
Add environment-driven registration for a custom agent server. If `ZED_AGENT_SERVER_BIN` is set, Zed registers a local agent server alongside built-ins. Optional envs: `ZED_AGENT_SERVER_ARGS` (shlex-parsed) and `ZED_AGENT_SERVER_NAME` (label). Tilde expansion is supported.

## Motivation
- Faster local/internal agent workflows without editing settings or packaging an extension
- Point Zed at an existing ACP-compatible agent binary with minimal setup
- Keep built-ins untouched; opt-in via env vars

## Testing
- cargo clippy -p project --all-targets --all-features -- -D warnings (local)
- cargo test -p project env_agent_server_config_parses (local)

Release Notes:

- Added environment-driven registration for a custom agent server via ZED_AGENT_SERVER_BIN/ARGS/NAME so users can point Zed at a local ACP-compatible binary without editing settings.
