### PR TITLE
agent: Disable git pager to avoid hangs

### DIFF
--- a/crates/acp_thread/src/terminal.rs
+++ b/crates/acp_thread/src/terminal.rs
@@ -195,8 +195,10 @@ pub async fn create_terminal_entity(
         Default::default()
     };
 
-    // Disables paging for `git` and hopefully other commands
+    // Disable pagers so agent/terminal commands don't hang behind interactive UIs
     env.insert("PAGER".into(), "".into());
+    // Override user core.pager (e.g. delta) which Git prefers over PAGER
+    env.insert("GIT_PAGER".into(), "cat".into());
     env.extend(env_vars);
 
     // Use remote shell or default system shell, as appropriate


### PR DESCRIPTION
- Set PAGER='' and GIT_PAGER=cat for agent/terminal commands so pager configs (e.g. delta) don't hang tool output\n\nFixes #42943

Release Notes:
- Prevent git pager configs from hanging agent/terminal git commands by forcing PAGER and GIT_PAGER off.