### PR TITLE
git: Collapse nested paths before refreshing statuses

### DIFF
--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -2691,6 +2691,16 @@ impl GitStore {
                         continue;
                     }
                     path_was_used[ix] = true;
+
+                    // Collapse nested paths so we only request a status refresh at the
+                    // shallowest level needed (important when scanning large trees).
+                    if entry
+                        .last()
+                        .is_some_and(|last_path: &RepoPath| repo_path.starts_with(last_path))
+                    {
+                        continue;
+                    }
+
                     entry.push(repo_path);
                 }
             }


### PR DESCRIPTION
- When background scanning reports many paths for the same repo, collapse nested paths so we only refresh git status at the shallowest level.
- Cuts repeated git status processes when opening huge directories (e.g. ~/), addressing runaway git spawns/CPU.
- Fixes #35780.

Release Notes:
- Reduce redundant git status invocations when scanning large trees by collapsing nested paths, mitigating runaway git processes for huge directories.