### PR TITLE
askpass: Fix double command ampersand in powershell script

### DIFF
--- a/crates/askpass/src/askpass.rs
+++ b/crates/askpass/src/askpass.rs
@@ -375,7 +375,7 @@ fn generate_askpass_script(
     Ok(format!(
         r#"
         $ErrorActionPreference = 'Stop';
-        ($args -join [char]0) | & {askpass_program} --askpass={askpass_socket} 2> $null
+        ($args -join [char]0) | {askpass_program} --askpass={askpass_socket} 2> $null
         "#,
     ))
 }


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/42618 / https://github.com/zed-industries/zed/issues/43109

Release Notes:

- N/A 
