### PR TITLE
zed: Support opening welcome page on startup

### DIFF
--- a/crates/onboarding/src/onboarding.rs
+++ b/crates/onboarding/src/onboarding.rs
@@ -420,15 +420,15 @@ pub fn go_to_welcome_page(cx: &mut App) {
                 }
             }
 
-            if let Some(entity_id) = onboarding_id {
-                pane.remove_item(entity_id, false, false, window, cx);
-            }
-
             if let Some(idx) = welcome_page_idx {
                 pane.activate_item(idx, true, true, window, cx);
             } else {
                 let item = Box::new(WelcomePage::new(window, cx));
                 pane.add_item(item, true, true, onboarding_idx, window, cx);
+            }
+
+            if let Some(entity_id) = onboarding_id {
+                pane.remove_item(entity_id, false, false, window, cx);
             }
         });
     });

--- a/crates/settings/src/settings_content/workspace.rs
+++ b/crates/settings/src/settings_content/workspace.rs
@@ -367,6 +367,8 @@ impl CloseWindowWhenNoItems {
 pub enum RestoreOnStartupBehavior {
     /// Always start with an empty editor
     None,
+    /// Always start on the welcome page
+    WelcomePage,
     /// Restore the workspace that was closed last.
     LastWorkspace,
     /// Restore all workspaces that were open when quitting Zed.

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -1187,14 +1187,11 @@ pub(crate) async fn open_serialized_workspace(
     }
 
     if error_count > 0 {
-        let message = if error_count == 1 {
-            "Failed to restore 1 workspace. Check logs for details.".to_string()
-        } else {
-            format!(
-                "Failed to restore {} workspaces. Check logs for details.",
-                error_count
-            )
-        };
+        let message = format!(
+            "Failed to restore {} workspace{}. Check logs for details.",
+            error_count,
+            if error_count == 1 { "" } else { "s" }
+        );
 
         // Try to find an active workspace to show the toast
         let toast_shown = cx

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -10,7 +10,6 @@ use collab_ui::channel_view::ChannelView;
 use collections::HashMap;
 use crashes::InitCrashHandler;
 use db::kvp::{GLOBAL_KEY_VALUE_STORE, KEY_VALUE_STORE};
-use editor::Editor;
 use extension::ExtensionHostProxy;
 use fs::{Fs, RealFs};
 use futures::{StreamExt, channel::oneshot, future};

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -1229,57 +1229,24 @@ pub(crate) async fn restorable_workspace_locations(
     cx: &mut AsyncApp,
     app_state: &Arc<AppState>,
 ) -> Option<Vec<(SerializedWorkspaceLocation, PathList)>> {
-    let mut restore_behavior = cx
+    let restore_behavior = cx
         .update(|cx| WorkspaceSettings::get(None, cx).restore_on_startup)
         .ok()?;
 
-    let session_handle = app_state.session.clone();
-    let (last_session_id, last_session_window_stack) = cx
-        .update(|cx| {
-            let session = session_handle.read(cx);
-
-            (
-                session.last_session_id().map(|id| id.to_string()),
-                session.last_session_window_stack(),
-            )
-        })
-        .ok()?;
-
-    if last_session_id.is_none()
-        && matches!(
-            restore_behavior,
-            workspace::RestoreOnStartupBehavior::LastSession
-        )
-    {
-        restore_behavior = workspace::RestoreOnStartupBehavior::LastWorkspace;
-    }
-
     match restore_behavior {
-        workspace::RestoreOnStartupBehavior::LastWorkspace => {
+        settings::RestoreOnStartupBehavior::LastSession => {
+            if let Some(locations) = get_last_session_workspaces(&app_state, cx) {
+                Some(locations)
+            } else {
+                workspace::last_opened_workspace_location()
+                    .await
+                    .map(|location| vec![location])
+            }
+        }
+        settings::RestoreOnStartupBehavior::LastWorkspace => {
             workspace::last_opened_workspace_location()
                 .await
                 .map(|location| vec![location])
-        }
-        workspace::RestoreOnStartupBehavior::LastSession => {
-            if let Some(last_session_id) = last_session_id {
-                let ordered = last_session_window_stack.is_some();
-
-                let mut locations = workspace::last_session_workspace_locations(
-                    &last_session_id,
-                    last_session_window_stack,
-                )
-                .filter(|locations| !locations.is_empty());
-
-                // Since last_session_window_order returns the windows ordered front-to-back
-                // we need to open the window that was frontmost last.
-                if ordered && let Some(locations) = locations.as_mut() {
-                    locations.reverse();
-                }
-
-                locations
-            } else {
-                None
-            }
         }
         _ => None,
     }

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -10,6 +10,7 @@ use collab_ui::channel_view::ChannelView;
 use collections::HashMap;
 use crashes::InitCrashHandler;
 use db::kvp::{GLOBAL_KEY_VALUE_STORE, KEY_VALUE_STORE};
+use editor::Editor;
 use extension::ExtensionHostProxy;
 use fs::{Fs, RealFs};
 use futures::{StreamExt, channel::oneshot, future};


### PR DESCRIPTION
Closes #40100 #43158

I saw a great suggestion in #43158 of reusing the welcome page as an option when opening Zed. Preferably we would have  a dedicated startup page at some later point in time that could highlight other useful features such as remoting (or add it to the welcome page?).

Currently still on the todo list:

- [ ] Think about removing `Return to Setup` from welcome screen conditionally (feedback appreciated)
- [ ] Consider whether Welcome Page should be the default, a setting, used as a fallback or something else entirely, it likely should not be under "what to restore from a previous session"
- [ ] Docs

The PR will likely be decently large, I'm willing to pair with someone to get it merged

<img width="1509" height="842" alt="image" src="https://github.com/user-attachments/assets/5ca204da-675c-4e39-adad-08bfca07ee0f" />
<img width="1296" height="372" alt="image" src="https://github.com/user-attachments/assets/88a6f86b-8551-4867-b210-20d613075b28" />

Release Notes:

- New setting to open a welcome page when launching Zed
