### PR TITLE
Update JavaScript default language server

### DIFF
--- a/docs/src/languages/javascript.md
+++ b/docs/src/languages/javascript.md
@@ -3,7 +3,8 @@
 JavaScript support is available natively in Zed.
 
 - Tree-sitter: [tree-sitter/tree-sitter-javascript](https://github.com/tree-sitter/tree-sitter-javascript)
-- Language Server: [typescript-language-server/typescript-language-server](https://github.com/typescript-language-server/typescript-language-server)
+- Language Server: [yioneko/vtsls](https://github.com/yioneko/vtsls)
+- Alternate Language Server: [typescript-language-server/typescript-language-server](https://github.com/typescript-language-server/typescript-language-server)
 - Debug Adapter: [vscode-js-debug](https://github.com/microsoft/vscode-js-debug)
 
 ## Code formatting


### PR DESCRIPTION
As stated in [TypeScript Language Server documentation](https://zed.dev/docs/languages/typescript#language-servers), JavaScript uses `vtsls` as the default language server.

Release Notes:

- N/A
