### PR TITLE
Improve Go language struct completion

### DIFF
--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -254,6 +254,17 @@ impl CachedLspAdapter {
         self.adapter.diagnostic_message_to_markdown(message)
     }
 
+    pub async fn preprocess_completions(
+        &self,
+        completion_items: &mut [lsp::CompletionItem],
+        buffer: &BufferSnapshot,
+        position: PointUtf16,
+    ) {
+        self.adapter
+            .preprocess_completions(completion_items, buffer, position)
+            .await
+    }
+
     pub async fn process_completions(&self, completion_items: &mut [lsp::CompletionItem]) {
         self.adapter.process_completions(completion_items).await
     }
@@ -336,6 +347,15 @@ pub trait LspAdapter: 'static + Send + Sync + DynLspInstaller {
     /// for the unnecessary diagnostics, so do not underline them.
     fn underline_diagnostic(&self, _diagnostic: &lsp::Diagnostic) -> bool {
         true
+    }
+
+    /// Pre-processes completions provided by the language server.
+    async fn preprocess_completions(
+        &self,
+        _: &mut [lsp::CompletionItem],
+        _: &BufferSnapshot,
+        _: PointUtf16,
+    ) {
     }
 
     /// Post-processes completions provided by the language server.

--- a/crates/languages/src/go.rs
+++ b/crates/languages/src/go.rs
@@ -6,7 +6,7 @@ use gpui::{App, AsyncApp, Task};
 use http_client::github::latest_github_release;
 pub use language::*;
 use language::{LanguageToolchainStore, LspAdapterDelegate, LspInstaller};
-use lsp::{CompletionItemKind, LanguageServerBinary, LanguageServerName, Position};
+use lsp::{CompletionItemKind, LanguageServerBinary, LanguageServerName};
 
 use regex::Regex;
 use serde_json::json;
@@ -214,7 +214,7 @@ impl LspAdapter for GoLspAdapter {
     ) {
         // Go back to the position the last character was written in.
         // Otherwise, we sometimes get 'block' for the new position.
-        let position = PointUtf16::new(position.row, position.column-1);
+        let position = PointUtf16::new(position.row, position.column - 1);
 
         let offset = buffer.point_utf16_to_offset(position);
         let mut inside_type_context = false;
@@ -227,7 +227,7 @@ impl LspAdapter for GoLspAdapter {
             let mut node = layer.node().descendant_for_byte_range(offset, offset);
 
             if node.is_none() {
-                return
+                return;
             }
 
             while let Some(n) = node {
@@ -248,7 +248,7 @@ impl LspAdapter for GoLspAdapter {
                     }
                     "block" => {
                         break;
-                    },
+                    }
                     _ => {}
                 }
                 node = n.parent();

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -2234,6 +2234,11 @@ impl LspCommand for GetCompletions {
             .and_then(|list| list.item_defaults.clone())
             .map(Arc::new);
 
+        let buffer_snapshot = buffer.read_with(&cx, |buffer, _| buffer.snapshot())?;
+        language_server_adapter
+            .preprocess_completions(&mut completions, &buffer_snapshot, self.position)
+            .await;
+
         let mut completion_edits = Vec::new();
         buffer.update(&mut cx, |buffer, _cx| {
             let snapshot = buffer.snapshot();


### PR DESCRIPTION
This PR improves the completion of structs in Go by conditionally including `{}` based on the buffer position. It follows the behavior of Jetbrains Goland.

A small example:

https://github.com/user-attachments/assets/b9046527-1de3-4e9c-a9d0-59dce69b3aad

More examples:

<img width="796" height="810" alt="CleanShot 2025-11-22 at 13 42 45@2x" src="https://github.com/user-attachments/assets/43b9330a-27f0-49ba-b24a-3ca951415041" />

> The last example is also inline with Jetbrains Goland, and I didn't find an obvious way to improve upon it.

I'm not a Rust dev, so any input on improving the code is highly appreciated! :)

Release Notes:

- Added smart `{}` placement on Go struct completions.
