### PR TITLE
Properly check for success on xdg-portal open URI

### DIFF
--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -651,7 +651,12 @@ pub(super) fn open_uri_internal(
                     .await
                     .and_then(|e| e.response())
                 {
-                    Ok(()) => return,
+                    Ok(request) => {
+                        match request.response() {
+                            Ok(_) => return,
+                            Err(e) => log::error!("Portal request failed or was cancelled: {}", e),
+                        }
+                    }
                     Err(e) => log::error!("Failed to open with dbus: {}", e),
                 }
 

--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -651,12 +651,10 @@ pub(super) fn open_uri_internal(
                     .await
                     .and_then(|e| e.response())
                 {
-                    Ok(request) => {
-                        match request.response() {
-                            Ok(_) => return,
-                            Err(e) => log::error!("Portal request failed or was cancelled: {}", e),
-                        }
-                    }
+                    Ok(request) => match request.response() {
+                        Ok(_) => return,
+                        Err(e) => log::error!("Portal request failed or was cancelled: {}", e),
+                    },
                     Err(e) => log::error!("Failed to open with dbus: {}", e),
                 }
 


### PR DESCRIPTION
Ensure we properly make sure opening the uri actually worked to ensure we always fallback if it does not.

Release Notes:

Fixed: When opening URIs on Linux (e.g. on Sign in) properly fallback to xdg-open in case the xdg portal failed. The fallback existed already, but was not always triggered as some errors had been ignored.