### PR TITLE
docs: Fix minor typo in docker.md

### DIFF
--- a/docs/src/languages/docker.md
+++ b/docs/src/languages/docker.md
@@ -10,7 +10,7 @@ Docker `compose.yaml` language support in Zed is provided by the [Docker Compose
 
 ## Dockerfile
 
-`Dockerfile` language support in Zed is provided by the [Dockerfile extension](https://github.com/d1y/dockerfile.zed). Please issues to: [https://github.com/d1y/dockerfile.zed/issues](https://github.com/d1y/dockerfile.zed/issues).
+`Dockerfile` language support in Zed is provided by the [Dockerfile extension](https://github.com/d1y/dockerfile.zed). Please report issues to: [https://github.com/d1y/dockerfile.zed/issues](https://github.com/d1y/dockerfile.zed/issues).
 
 - Tree-sitter: [camdencheek/tree-sitter-dockerfile](https://github.com/camdencheek/tree-sitter-dockerfile)
 - Language Server: [rcjsuen/dockerfile-language-server](https://github.com/rcjsuen/dockerfile-language-server)


### PR DESCRIPTION
Updated wording (added a missing word) for reporting issues in Dockerfile extension documentation.

Closes #ISSUE N/A

Release Notes:

- N/A 
