### PR TITLE
Allow opening git commit view via URI scheme 

### DIFF
--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -880,6 +880,52 @@ fn handle_open_request(request: OpenRequest, app_state: Arc<AppState>, cx: &mut 
                 })
                 .detach_and_log_err(cx);
             }
+            OpenRequestKind::GitCommit { path, sha } => {
+                cx.spawn(async move |cx| {
+                    // Open workspace using the path, which will route to the correct window
+                    let workspace = if path.is_empty() || request.open_paths.is_empty() {
+                        // No path specified, use any active workspace
+                        workspace::get_any_active_workspace(app_state, cx.clone()).await?
+                    } else {
+                        // Use the normal open_paths flow which does smart workspace routing
+                        let paths_with_position =
+                            derive_paths_with_position(app_state.fs.as_ref(), request.open_paths)
+                                .await;
+                        let (workspace, _results) = open_paths_with_positions(
+                            &paths_with_position,
+                            &[],
+                            app_state,
+                            workspace::OpenOptions::default(),
+                            cx,
+                        )
+                        .await?;
+                        workspace
+                    };
+
+                    let _ = workspace
+                        .update(cx, |workspace, window, cx| {
+                            let Some(repo) = workspace.project().read(cx).active_repository(cx)
+                            else {
+                                log::error!("no active repository found for commit view");
+                                return Err(anyhow::anyhow!("no active repository found"));
+                            };
+
+                            git_ui::commit_view::CommitView::open(
+                                sha,
+                                repo.downgrade(),
+                                workspace.weak_handle(),
+                                None,
+                                None,
+                                window,
+                                cx,
+                            );
+                            Ok(())
+                        })
+                        .log_err();
+                    anyhow::Ok(())
+                })
+                .detach_and_log_err(cx);
+            }
         }
 
         return;

--- a/crates/zed/src/zed/open_listener.rs
+++ b/crates/zed/src/zed/open_listener.rs
@@ -145,7 +145,7 @@ impl OpenRequest {
             .context("invalid git commit url: missing repo query parameter")?
             .to_string();
 
-        self.open_paths.push(repo.clone());
+        self.open_paths.push(repo);
 
         self.kind = Some(OpenRequestKind::GitCommit {
             sha: sha.to_string(),


### PR DESCRIPTION
Add support for `zed://git/commit/<path-to-repo>#<sha>` (**EDIT:** now changed to `zed://git/commit/<sha>?repo=<path>`) URI scheme to access the git commit view

implement parsing and handling of git commit URIs to navigate directly to commit views from external links. the main use case for me is to use OSC8 hyperlinks to link from a git sha into zed. this allows me e.g. to easily navigate from a terminal into zed

**questions**

- is this URI scheme appropriate? it was the first one i thought of, but wondering if `?ref=<some sha>` might make more sense – the git/commit namespace was also an equally arbitrary choice

<details>
<summary>video demo showing navigation from zed's built in terminal</summary>

https://github.com/user-attachments/assets/18ad7e64-6b39-44b2-a440-1a9eb71cd212
</details>

<details>
<summary>video demo showing navigation from ghostty to zed's commit view</summary>

https://github.com/user-attachments/assets/1825e753-523f-4f98-b59c-7188ae2f5f19

</details>



Release Notes:

- Added support for `zed://git/commit/<sha>?repo=<path>` URI scheme to access the git commit view
