### PR TITLE
git: Keep lines that start with # in the commit message

### DIFF
--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -1648,7 +1648,7 @@ impl GitRepository for RealGitRepository {
                 .envs(env.iter())
                 .args(["commit", "--quiet", "-m"])
                 .arg(&message.to_string())
-                .arg("--cleanup=strip")
+                .arg("--cleanup=verbatim")
                 .arg("--no-verify")
                 .stdout(smol::process::Stdio::piped())
                 .stderr(smol::process::Stdio::piped());


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/26643

Release Notes:

- Fixed keep lines that start with # in the commit message