### PR TITLE
Add global search keybinding from helix

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -517,6 +517,7 @@
       "space c": "editor::ToggleComments",
       "space p": "editor::Paste",
       "space y": "editor::Copy",
+      "space /": "pane::DeploySearch",
 
       // Other
       ":": "command_palette::Toggle",


### PR DESCRIPTION
In helix, `space /` activates a global search picker, so I think that it should be the same in zed's helix mode.

Release Notes:

- Added helix's `space /` keybinding to open a global search menu to zed's helix mode