### PR TITLE
Use buffer language when formatting with Prettier

### DIFF
--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -18995,7 +18995,7 @@ async fn test_document_format_with_prettier_explicit_language(cx: &mut TestAppCo
         .await;
     assert_eq!(
         editor.update(cx, |editor, cx| editor.text(cx)),
-        buffer_text.to_string() + prettier_format_suffix,
+        buffer_text.to_string() + prettier_format_suffix + "\ntypescript",
         "Test prettier formatting was not applied to the original buffer text",
     );
 
@@ -19012,9 +19012,14 @@ async fn test_document_format_with_prettier_explicit_language(cx: &mut TestAppCo
         )
     });
     format.await.unwrap();
+
     assert_eq!(
         editor.update(cx, |editor, cx| editor.text(cx)),
-        buffer_text.to_string() + prettier_format_suffix + "\n" + prettier_format_suffix,
+        buffer_text.to_string()
+            + prettier_format_suffix
+            + "\ntypescript\n"
+            + prettier_format_suffix
+            + "\ntypescript",
         "Autoformatting (via test prettier) was not applied to the original buffer text",
     );
 }

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -18922,6 +18922,104 @@ async fn test_document_format_with_prettier(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_document_format_with_prettier_explicit_language(cx: &mut TestAppContext) {
+    init_test(cx, |settings| {
+        settings.defaults.formatter = Some(FormatterList::Single(Formatter::Prettier))
+    });
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_file(path!("/file.settings"), Default::default())
+        .await;
+
+    let project = Project::test(fs, [path!("/file.settings").as_ref()], cx).await;
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+
+    let ts_lang = Arc::new(Language::new(
+        LanguageConfig {
+            name: "TypeScript".into(),
+            matcher: LanguageMatcher {
+                path_suffixes: vec!["ts".to_string()],
+                ..LanguageMatcher::default()
+            },
+            prettier_parser_name: Some("typescript".to_string()),
+            ..LanguageConfig::default()
+        },
+        Some(tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into()),
+    ));
+
+    language_registry.add(ts_lang.clone());
+
+    update_test_language_settings(cx, |settings| {
+        settings.defaults.prettier.get_or_insert_default().allowed = Some(true);
+    });
+
+    let test_plugin = "test_plugin";
+    let _ = language_registry.register_fake_lsp(
+        "TypeScript",
+        FakeLspAdapter {
+            prettier_plugins: vec![test_plugin],
+            ..Default::default()
+        },
+    );
+
+    let prettier_format_suffix = project::TEST_PRETTIER_FORMAT_SUFFIX;
+    let buffer = project
+        .update(cx, |project, cx| {
+            project.open_local_buffer(path!("/file.settings"), cx)
+        })
+        .await
+        .unwrap();
+
+    project.update(cx, |project, cx| {
+        project.set_language_for_buffer(&buffer, ts_lang, cx)
+    });
+
+    let buffer_text = "one\ntwo\nthree\n";
+    let buffer = cx.new(|cx| MultiBuffer::singleton(buffer, cx));
+    let (editor, cx) = cx.add_window_view(|window, cx| build_editor(buffer, window, cx));
+    editor.update_in(cx, |editor, window, cx| {
+        editor.set_text(buffer_text, window, cx)
+    });
+
+    editor
+        .update_in(cx, |editor, window, cx| {
+            editor.perform_format(
+                project.clone(),
+                FormatTrigger::Manual,
+                FormatTarget::Buffers(editor.buffer().read(cx).all_buffers()),
+                window,
+                cx,
+            )
+        })
+        .unwrap()
+        .await;
+    assert_eq!(
+        editor.update(cx, |editor, cx| editor.text(cx)),
+        buffer_text.to_string() + prettier_format_suffix,
+        "Test prettier formatting was not applied to the original buffer text",
+    );
+
+    update_test_language_settings(cx, |settings| {
+        settings.defaults.formatter = Some(FormatterList::default())
+    });
+    let format = editor.update_in(cx, |editor, window, cx| {
+        editor.perform_format(
+            project.clone(),
+            FormatTrigger::Manual,
+            FormatTarget::Buffers(editor.buffer().read(cx).all_buffers()),
+            window,
+            cx,
+        )
+    });
+    format.await.unwrap();
+    assert_eq!(
+        editor.update(cx, |editor, cx| editor.text(cx)),
+        buffer_text.to_string() + prettier_format_suffix + "\n" + prettier_format_suffix,
+        "Autoformatting (via test prettier) was not applied to the original buffer text",
+    );
+}
+
+#[gpui::test]
 async fn test_addition_reverts(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
     let mut cx = EditorLspTestContext::new_rust(lsp::ServerCapabilities::default(), cx).await;

--- a/crates/prettier/src/prettier.rs
+++ b/crates/prettier/src/prettier.rs
@@ -345,150 +345,150 @@ impl Prettier {
         ignore_dir: Option<PathBuf>,
         cx: &mut AsyncApp,
     ) -> anyhow::Result<Diff> {
+        let params = buffer
+            .update(cx, |buffer, cx| {
+                let buffer_language = buffer.language();
+                let language_settings = language_settings(buffer_language.map(|l| l.name()), buffer.file(), cx);
+                let prettier_settings = &language_settings.prettier;
+                anyhow::ensure!(
+                    prettier_settings.allowed,
+                    "Cannot format: prettier is not allowed for language {buffer_language:?}"
+                );
+                let prettier_node_modules = self.prettier_dir().join("node_modules");
+                anyhow::ensure!(
+                    prettier_node_modules.is_dir(),
+                    "Prettier node_modules dir does not exist: {prettier_node_modules:?}"
+                );
+                let plugin_name_into_path = |plugin_name: &str| {
+                    let prettier_plugin_dir = prettier_node_modules.join(plugin_name);
+                    [
+                        prettier_plugin_dir.join("dist").join("index.mjs"),
+                        prettier_plugin_dir.join("dist").join("index.js"),
+                        prettier_plugin_dir.join("dist").join("plugin.js"),
+                        prettier_plugin_dir.join("src").join("plugin.js"),
+                        prettier_plugin_dir.join("lib").join("index.js"),
+                        prettier_plugin_dir.join("index.mjs"),
+                        prettier_plugin_dir.join("index.js"),
+                        prettier_plugin_dir.join("plugin.js"),
+                        // this one is for @prettier/plugin-php
+                        prettier_plugin_dir.join("standalone.js"),
+                        // this one is for prettier-plugin-latex
+                        prettier_plugin_dir.join("dist").join("prettier-plugin-latex.js"),
+                        prettier_plugin_dir,
+                    ]
+                    .into_iter()
+                    .find(|possible_plugin_path| possible_plugin_path.is_file())
+                };
+
+                // Tailwind plugin requires being added last
+                // https://github.com/tailwindlabs/prettier-plugin-tailwindcss#compatibility-with-other-prettier-plugins
+                let mut add_tailwind_back = false;
+
+                let mut located_plugins = prettier_settings.plugins.iter()
+                    .filter(|plugin_name| {
+                        if plugin_name.as_str() == TAILWIND_PRETTIER_PLUGIN_PACKAGE_NAME {
+                            add_tailwind_back = true;
+                            false
+                        } else {
+                            true
+                        }
+                    })
+                    .map(|plugin_name| {
+                        let plugin_path = plugin_name_into_path(plugin_name);
+                        (plugin_name.clone(), plugin_path)
+                    })
+                    .collect::<Vec<_>>();
+                if add_tailwind_back {
+                    located_plugins.push((
+                        TAILWIND_PRETTIER_PLUGIN_PACKAGE_NAME.to_owned(),
+                        plugin_name_into_path(TAILWIND_PRETTIER_PLUGIN_PACKAGE_NAME),
+                    ));
+                }
+
+                let prettier_options = if self.is_default() {
+                    let mut options = prettier_settings.options.clone();
+                    if !options.contains_key("tabWidth") {
+                        options.insert(
+                            "tabWidth".to_string(),
+                            serde_json::Value::Number(serde_json::Number::from(
+                                language_settings.tab_size.get(),
+                            )),
+                        );
+                    }
+                    if !options.contains_key("printWidth") {
+                        options.insert(
+                            "printWidth".to_string(),
+                            serde_json::Value::Number(serde_json::Number::from(
+                                language_settings.preferred_line_length,
+                            )),
+                        );
+                    }
+                    if !options.contains_key("useTabs") {
+                        options.insert(
+                            "useTabs".to_string(),
+                            serde_json::Value::Bool(language_settings.hard_tabs),
+                        );
+                    }
+                    Some(options)
+                } else {
+                    None
+                };
+
+                let plugins = located_plugins
+                    .into_iter()
+                    .filter_map(|(plugin_name, located_plugin_path)| {
+                        match located_plugin_path {
+                            Some(path) => Some(path),
+                            None => {
+                                log::error!("Have not found plugin path for {plugin_name:?} inside {prettier_node_modules:?}");
+                                None
+                            }
+                        }
+                    })
+                    .collect();
+
+                let prettier_parser = if buffer_path.is_none() {
+                    let parser = prettier_settings.parser.as_deref().or_else(|| buffer_language.and_then(|language| language.prettier_parser_name()));
+                    if parser.is_none() {
+                        log::error!("Formatting unsaved file with prettier failed. No prettier parser configured for language {buffer_language:?}");
+                        anyhow::bail!("Cannot determine prettier parser for unsaved file");
+                    }
+                    parser
+                } else if let (Some(buffer_language), Some(buffer_path)) = (buffer_language, &buffer_path)
+                    && buffer_path.extension().is_some_and(|extension| !buffer_language.config().matcher.path_suffixes.contains(&extension.to_string_lossy().into_owned())) {
+                        buffer_language.prettier_parser_name()
+                } else {
+                    prettier_settings.parser.as_deref()
+                };
+
+                let ignore_path = ignore_dir.and_then(|dir| {
+                    let ignore_file = dir.join(".prettierignore");
+                    ignore_file.is_file().then_some(ignore_file)
+                });
+
+                log::debug!(
+                    "Formatting file {:?} with prettier, plugins :{:?}, options: {:?}, ignore_path: {:?}",
+                    buffer.file().map(|f| f.full_path(cx)),
+                    plugins,
+                    prettier_options,
+                    ignore_path,
+                );
+
+                anyhow::Ok(FormatParams {
+                    text: buffer.text(),
+                    options: FormatOptions {
+                        parser: prettier_parser.map(ToOwned::to_owned),
+                        plugins,
+                        path: buffer_path,
+                        prettier_options,
+                        ignore_path,
+                    },
+                })
+            })?
+            .context("building prettier request")?;
+
         match self {
             Self::Real(local) => {
-                let params = buffer
-                    .update(cx, |buffer, cx| {
-                        let buffer_language = buffer.language();
-                        let language_settings = language_settings(buffer_language.map(|l| l.name()), buffer.file(), cx);
-                        let prettier_settings = &language_settings.prettier;
-                        anyhow::ensure!(
-                            prettier_settings.allowed,
-                            "Cannot format: prettier is not allowed for language {buffer_language:?}"
-                        );
-                        let prettier_node_modules = self.prettier_dir().join("node_modules");
-                        anyhow::ensure!(
-                            prettier_node_modules.is_dir(),
-                            "Prettier node_modules dir does not exist: {prettier_node_modules:?}"
-                        );
-                        let plugin_name_into_path = |plugin_name: &str| {
-                            let prettier_plugin_dir = prettier_node_modules.join(plugin_name);
-                            [
-                                prettier_plugin_dir.join("dist").join("index.mjs"),
-                                prettier_plugin_dir.join("dist").join("index.js"),
-                                prettier_plugin_dir.join("dist").join("plugin.js"),
-                                prettier_plugin_dir.join("src").join("plugin.js"),
-                                prettier_plugin_dir.join("lib").join("index.js"),
-                                prettier_plugin_dir.join("index.mjs"),
-                                prettier_plugin_dir.join("index.js"),
-                                prettier_plugin_dir.join("plugin.js"),
-                                // this one is for @prettier/plugin-php
-                                prettier_plugin_dir.join("standalone.js"),
-                                // this one is for prettier-plugin-latex
-                                prettier_plugin_dir.join("dist").join("prettier-plugin-latex.js"),
-                                prettier_plugin_dir,
-                            ]
-                            .into_iter()
-                            .find(|possible_plugin_path| possible_plugin_path.is_file())
-                        };
-
-                        // Tailwind plugin requires being added last
-                        // https://github.com/tailwindlabs/prettier-plugin-tailwindcss#compatibility-with-other-prettier-plugins
-                        let mut add_tailwind_back = false;
-
-                        let mut located_plugins = prettier_settings.plugins.iter()
-                            .filter(|plugin_name| {
-                                if plugin_name.as_str() == TAILWIND_PRETTIER_PLUGIN_PACKAGE_NAME {
-                                    add_tailwind_back = true;
-                                    false
-                                } else {
-                                    true
-                                }
-                            })
-                            .map(|plugin_name| {
-                                let plugin_path = plugin_name_into_path(plugin_name);
-                                (plugin_name.clone(), plugin_path)
-                            })
-                            .collect::<Vec<_>>();
-                        if add_tailwind_back {
-                            located_plugins.push((
-                                TAILWIND_PRETTIER_PLUGIN_PACKAGE_NAME.to_owned(),
-                                plugin_name_into_path(TAILWIND_PRETTIER_PLUGIN_PACKAGE_NAME),
-                            ));
-                        }
-
-                        let prettier_options = if self.is_default() {
-                            let mut options = prettier_settings.options.clone();
-                            if !options.contains_key("tabWidth") {
-                                options.insert(
-                                    "tabWidth".to_string(),
-                                    serde_json::Value::Number(serde_json::Number::from(
-                                        language_settings.tab_size.get(),
-                                    )),
-                                );
-                            }
-                            if !options.contains_key("printWidth") {
-                                options.insert(
-                                    "printWidth".to_string(),
-                                    serde_json::Value::Number(serde_json::Number::from(
-                                        language_settings.preferred_line_length,
-                                    )),
-                                );
-                            }
-                            if !options.contains_key("useTabs") {
-                                options.insert(
-                                    "useTabs".to_string(),
-                                    serde_json::Value::Bool(language_settings.hard_tabs),
-                                );
-                            }
-                            Some(options)
-                        } else {
-                            None
-                        };
-
-                        let plugins = located_plugins
-                            .into_iter()
-                            .filter_map(|(plugin_name, located_plugin_path)| {
-                                match located_plugin_path {
-                                    Some(path) => Some(path),
-                                    None => {
-                                        log::error!("Have not found plugin path for {plugin_name:?} inside {prettier_node_modules:?}");
-                                        None
-                                    }
-                                }
-                            })
-                            .collect();
-
-                        let prettier_parser = if buffer_path.is_none() {
-                            let parser = prettier_settings.parser.as_deref().or_else(|| buffer_language.and_then(|language| language.prettier_parser_name()));
-                            if parser.is_none() {
-                                log::error!("Formatting unsaved file with prettier failed. No prettier parser configured for language {buffer_language:?}");
-                                anyhow::bail!("Cannot determine prettier parser for unsaved file");
-                            }
-                            parser
-                        } else if let (Some(buffer_language), Some(buffer_path)) = (buffer_language, &buffer_path)
-                            && buffer_path.extension().is_some_and(|extension| !buffer_language.config().matcher.path_suffixes.contains(&extension.to_string_lossy().into_owned())) {
-                                buffer_language.prettier_parser_name()
-                        } else {
-                            prettier_settings.parser.as_deref()
-                        };
-
-                        let ignore_path = ignore_dir.and_then(|dir| {
-                            let ignore_file = dir.join(".prettierignore");
-                            ignore_file.is_file().then_some(ignore_file)
-                        });
-
-                        log::debug!(
-                            "Formatting file {:?} with prettier, plugins :{:?}, options: {:?}, ignore_path: {:?}",
-                            buffer.file().map(|f| f.full_path(cx)),
-                            plugins,
-                            prettier_options,
-                            ignore_path,
-                        );
-
-                        anyhow::Ok(FormatParams {
-                            text: buffer.text(),
-                            options: FormatOptions {
-                                parser: prettier_parser.map(ToOwned::to_owned),
-                                plugins,
-                                path: buffer_path,
-                                prettier_options,
-                                ignore_path,
-                            },
-                        })
-                    })?
-                    .context("building prettier request")?;
-
                 let response = local
                     .server
                     .request::<Format>(params)
@@ -507,7 +507,12 @@ impl Prettier {
                     {
                         Some("rust") => anyhow::bail!("prettier does not support Rust"),
                         Some(_other) => {
-                            let formatted_text = buffer.text() + FORMAT_SUFFIX;
+                            let mut formatted_text = buffer.text() + FORMAT_SUFFIX;
+
+                            if let Some(parser) = params.options.parser {
+                                formatted_text = format!("{}\n{}", formatted_text, parser.as_str());
+                            }
+
                             Ok(buffer.diff(formatted_text, cx))
                         }
                         None => panic!("Should not format buffer without a language with prettier"),


### PR DESCRIPTION
Set `prettier_parser` explicitly if the file extension for the buffer does not match a known one for the current language

Release Notes:

- N/A
