### PR TITLE
agent_ui: Make thread markdown editable

### DIFF
--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -4775,7 +4775,7 @@ impl AcpThreadView {
             buffer.update(cx, |buffer, cx| {
                 buffer.set_text(markdown, cx);
                 buffer.set_language(Some(markdown_language), cx);
-                buffer.set_capability(language::Capability::ReadOnly, cx);
+                buffer.set_capability(language::Capability::ReadWrite, cx);
             })?;
 
             workspace.update_in(cx, |workspace, window, cx| {


### PR DESCRIPTION
This PR makes the thread markdown editable. This refers to the "open thread as markdown" feature, where you previously could only read. One benefit of this move is that it makes a bit more obvious that you can `cmd-s` to save the markdown, allowing you to store the content of a given thread. You could already do this before, but due to it being editable now, you see the tab with a dirty indicator, which communicates that better.

Release Notes:

- agent: Made the thread markdown editable.
