### PR TITLE
docs: Better wording for `terminal.working_directory` setting

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1441,7 +1441,7 @@
     "default_height": 320,
     // What working directory to use when launching the terminal.
     // May take 4 values:
-    // 1. Use the current file's project directory.  Will Fallback to the
+    // 1. Use the current file's project directory. Fallback to the
     //    first project directory strategy if unsuccessful
     //      "working_directory": "current_project_directory"
     // 2. Use the first project in this workspace's directory

--- a/crates/settings/src/settings_content/terminal.rs
+++ b/crates/settings/src/settings_content/terminal.rs
@@ -225,7 +225,8 @@ pub enum WorkingDirectory {
     /// Use the current file's project directory. Fallback to the
     /// first project directory strategy if unsuccessful.
     CurrentProjectDirectory,
-    /// Use the first project in this workspace's directory.
+    /// Use the first project in this workspace's directory. Fallback to using
+    /// this platform's home directory.
     FirstProjectDirectory,
     /// Always use this platform's home directory (if it can be found).
     AlwaysHome,

--- a/crates/settings/src/settings_content/terminal.rs
+++ b/crates/settings/src/settings_content/terminal.rs
@@ -222,7 +222,7 @@ pub enum Shell {
 #[strum_discriminants(derive(strum::VariantArray, strum::VariantNames, strum::FromRepr))]
 #[serde(rename_all = "snake_case")]
 pub enum WorkingDirectory {
-    /// Use the current file's project directory.  Will Fallback to the
+    /// Use the current file's project directory. Fallback to the
     /// first project directory strategy if unsuccessful.
     CurrentProjectDirectory,
     /// Use the first project in this workspace's directory.

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -4091,7 +4091,7 @@ Example command to set the title: `echo -e "\e]2;New Title\007";`
 }
 ```
 
-3. Always use this platform's home directory, if we can find it.
+3. Always use this platform's home directory if it can be found.
 
 ```json [settings]
 {

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -4071,7 +4071,7 @@ Example command to set the title: `echo -e "\e]2;New Title\007";`
 
 **Options**
 
-1. Use the current file's project directory. Will Fallback to the first project directory strategy if unsuccessful
+1. Use the current file's project directory. Fallback to the first project directory strategy if unsuccessful.
 
 ```json [settings]
 {
@@ -4081,7 +4081,7 @@ Example command to set the title: `echo -e "\e]2;New Title\007";`
 }
 ```
 
-2. Use the first project in this workspace's directory. Will fallback to using this platform's home directory.
+2. Use the first project in this workspace's directory. Fallback to using this platform's home directory.
 
 ```json [settings]
 {
@@ -4091,7 +4091,7 @@ Example command to set the title: `echo -e "\e]2;New Title\007";`
 }
 ```
 
-3. Always use this platform's home directory (if we can find it)
+3. Always use this platform's home directory, if we can find it.
 
 ```json [settings]
 {


### PR DESCRIPTION
Initially this was just going to be a minor docs fix, but then I wondered if we could improve the copy in the editor as well.

Release Notes:

- N/A
