### PR TITLE
util: Fix invalid powershell redirection syntax used in uni shell env capture

### DIFF
--- a/crates/util/src/shell_env.rs
+++ b/crates/util/src/shell_env.rs
@@ -55,6 +55,7 @@ async fn capture_unix(
         // xonsh doesn't support redirecting to stdin, and control sequences are printed to
         // stdout on startup
         ShellKind::Xonsh => (FD_STDERR, "o>e".to_string()),
+        ShellKind::PowerShell => (FD_STDIN, format!(">{}", FD_STDIN)),
         _ => (FD_STDIN, format!(">&{}", FD_STDIN)), // `>&0`
     };
 


### PR DESCRIPTION


Closes  https://github.com/zed-industries/zed/issues/42869

Release Notes:

- Fixed shell env sourcing not working with powershell on unix systems