### PR TITLE
Add each panel to the workspace as soon as it's ready

### DIFF
--- a/crates/collab/src/tests/following_tests.rs
+++ b/crates/collab/src/tests/following_tests.rs
@@ -529,7 +529,7 @@ async fn test_basic_following(
         });
 
         // Client B activates a panel, and the previously-opened screen-sharing item gets activated.
-        let panel = cx_b.new(|cx| TestPanel::new(DockPosition::Left, cx));
+        let panel = cx_b.new(|cx| TestPanel::new(DockPosition::Left, 100, cx));
         workspace_b.update_in(cx_b, |workspace, window, cx| {
             workspace.add_panel(panel, window, cx);
             workspace.toggle_panel_focus::<TestPanel>(window, cx);

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -560,7 +560,16 @@ impl Dock {
             .binary_search_by_key(&panel.read(cx).activation_priority(), |entry| {
                 entry.panel.activation_priority(cx)
             }) {
-            Ok(ix) => ix,
+            Ok(ix) => {
+                if cfg!(debug_assertions) {
+                    panic!(
+                        "Panels `{}` and `{}` have the same activation priority. Each panel must have a unique priority so the status bar order is deterministic.",
+                        T::panel_key(),
+                        self.panel_entries[ix].panel.panel_key()
+                    );
+                }
+                ix
+            }
             Err(ix) => ix,
         };
         if let Some(active_index) = self.active_panel_index.as_mut()

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -1003,19 +1003,21 @@ pub mod test {
         pub active: bool,
         pub focus_handle: FocusHandle,
         pub size: Pixels,
+        pub activation_priority: u32,
     }
     actions!(test_only, [ToggleTestPanel]);
 
     impl EventEmitter<PanelEvent> for TestPanel {}
 
     impl TestPanel {
-        pub fn new(position: DockPosition, cx: &mut App) -> Self {
+        pub fn new(position: DockPosition, activation_priority: u32, cx: &mut App) -> Self {
             Self {
                 position,
                 zoomed: false,
                 active: false,
                 focus_handle: cx.focus_handle(),
                 size: px(300.),
+                activation_priority,
             }
         }
     }
@@ -1081,7 +1083,7 @@ pub mod test {
         }
 
         fn activation_priority(&self) -> u32 {
-            100
+            self.activation_priority
         }
     }
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -9176,7 +9176,7 @@ mod tests {
             cx.add_window_view(|window, cx| Workspace::test_new(project, window, cx));
 
         let panel = workspace.update_in(cx, |workspace, window, cx| {
-            let panel = cx.new(|cx| TestPanel::new(DockPosition::Right, cx));
+            let panel = cx.new(|cx| TestPanel::new(DockPosition::Right, 100, cx));
             workspace.add_panel(panel.clone(), window, cx);
 
             workspace
@@ -9409,10 +9409,10 @@ mod tests {
 
         // Open two docks (left and right) with one panel each
         let (left_panel, right_panel) = workspace.update_in(cx, |workspace, window, cx| {
-            let left_panel = cx.new(|cx| TestPanel::new(DockPosition::Left, cx));
+            let left_panel = cx.new(|cx| TestPanel::new(DockPosition::Left, 100, cx));
             workspace.add_panel(left_panel.clone(), window, cx);
 
-            let right_panel = cx.new(|cx| TestPanel::new(DockPosition::Right, cx));
+            let right_panel = cx.new(|cx| TestPanel::new(DockPosition::Right, 101, cx));
             workspace.add_panel(right_panel.clone(), window, cx);
 
             workspace.toggle_dock(DockPosition::Left, window, cx);
@@ -9840,10 +9840,10 @@ mod tests {
             cx.add_window_view(|window, cx| Workspace::test_new(project, window, cx));
 
         let (panel_1, panel_2) = workspace.update_in(cx, |workspace, window, cx| {
-            let panel_1 = cx.new(|cx| TestPanel::new(DockPosition::Left, cx));
+            let panel_1 = cx.new(|cx| TestPanel::new(DockPosition::Left, 100, cx));
             workspace.add_panel(panel_1.clone(), window, cx);
             workspace.toggle_dock(DockPosition::Left, window, cx);
-            let panel_2 = cx.new(|cx| TestPanel::new(DockPosition::Right, cx));
+            let panel_2 = cx.new(|cx| TestPanel::new(DockPosition::Right, 101, cx));
             workspace.add_panel(panel_2.clone(), window, cx);
             workspace.toggle_dock(DockPosition::Right, window, cx);
 
@@ -10750,7 +10750,7 @@ mod tests {
         // Add a new panel to the right dock, opening the dock and setting the
         // focus to the new panel.
         let panel = workspace.update_in(cx, |workspace, window, cx| {
-            let panel = cx.new(|cx| TestPanel::new(DockPosition::Right, cx));
+            let panel = cx.new(|cx| TestPanel::new(DockPosition::Right, 100, cx));
             workspace.add_panel(panel.clone(), window, cx);
 
             workspace


### PR DESCRIPTION
We'll now add panels to the workspace as soon as they're ready rather than waiting for all the rest to complete. We should strive to make all panels fast, but given that their load tasks are fallible and do IO, this approach seems more resilient.

Additionally, we'll now start loading the agent panel at the same time as the rest.

Release Notes:

- workspace: Add panels as soon as they are ready