### PR TITLE
Disable `phptools` language server by default for PHP

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1889,7 +1889,7 @@
       }
     },
     "PHP": {
-      "language_servers": ["phpactor", "!intelephense", "..."],
+      "language_servers": ["phpactor", "!intelephense", "!phptools", "..."],
       "prettier": {
         "allowed": true,
         "plugins": ["@prettier/plugin-php"],
@@ -2138,7 +2138,7 @@
   "windows": {
     "languages": {
       "PHP": {
-        "language_servers": ["intelephense", "!phpactor", "..."]
+        "language_servers": ["intelephense", "!phpactor", "!phptools", "..."]
       }
     }
   },


### PR DESCRIPTION
This PR makes it so we disable the `phptools` language server by default for PHP.

The default language server is `phpactor` on macOS and Linux and `intelephense` on Windows (as `phpactor` does not support Windows), so we don't want to run `phptools` as well.

Release Notes:

- Disabled the `phptools` language server by default for PHP.
