### PR TITLE
Keep single default PHP language server

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1889,7 +1889,7 @@
       }
     },
     "PHP": {
-      "language_servers": ["phpactor", "!intelephense", "..."],
+      "language_servers": ["phpactor", "!intelephense", "!phptools", "..."],
       "prettier": {
         "allowed": true,
         "plugins": ["@prettier/plugin-php"],
@@ -2138,7 +2138,7 @@
   "windows": {
     "languages": {
       "PHP": {
-        "language_servers": ["intelephense", "!phpactor", "..."]
+        "language_servers": ["intelephense", "!phpactor", "!phptools", "..."]
       }
     }
   },

--- a/docs/src/configuring-languages.md
+++ b/docs/src/configuring-languages.md
@@ -123,7 +123,7 @@ You can specify your preference using the `language_servers` setting:
 ```json [settings]
   "languages": {
     "PHP": {
-      "language_servers": ["intelephense", "!phpactor", "..."]
+      "language_servers": ["intelephense", "!phpactor", "!phptools", "..."]
     }
   }
 ```

--- a/docs/src/languages/php.md
+++ b/docs/src/languages/php.md
@@ -35,7 +35,7 @@ To switch to `intelephense`, add the following to your `settings.json`:
 {
   "languages": {
     "PHP": {
-      "language_servers": ["intelephense", "!phpactor", "..."]
+      "language_servers": ["intelephense", "!phpactor", "!phptools", "..."]
     }
   }
 }


### PR DESCRIPTION
https://github.com/zed-extensions/php/blob/9a119b18eeb247072964a19ce46fab54bbd1bb30/extension.toml provides 3 language servers for `php`, so `...` will always include all 3 if those are not excluded or included explicitly.

Change the configs and docs so, that only one php language server is used.

Release Notes:

- N/A
