### PR TITLE
gpui: Fix incorrect text wrap when line end has spaces

### DIFF
--- a/crates/gpui/src/text_system/line_wrapper.rs
+++ b/crates/gpui/src/text_system/line_wrapper.rs
@@ -58,19 +58,27 @@ impl LineWrapper {
                             continue;
                         }
 
+                        let mut candidate = false;
                         if Self::is_word_char(c) {
                             if prev_c == ' ' && c != ' ' && first_non_whitespace_ix.is_some() {
-                                last_candidate_ix = ix;
-                                last_candidate_width = width;
+                                candidate = true;
                             }
                         } else {
-                            if c == ' ' || first_non_whitespace_ix.is_some() {
-                                // 1. For english, the space to as a splitter to wrap, e.g.: `Hello world `,
-                                // 2. For CJK, may not be space separated, e.g.: `Hello world你好世界`,
-                                // when `ix` is `你`, we can also need to wrap here.
-                                last_candidate_ix = ix;
-                                last_candidate_width = width;
+                            if c != ' ' && first_non_whitespace_ix.is_some() {
+                                // For CJK, may not be space separated, e.g.: `Hello world你好世界`,
+                                // when `ix` is `你`, we can wrap here.
+                                candidate = true;
+                            } else if c == ' ' && prev_c != ' ' && first_non_whitespace_ix.is_some()
+                            {
+                                // For continue spaces, we can wrap at the space
+                                // if the previous character is not a space.
+                                candidate = true;
                             }
+                        }
+
+                        if candidate {
+                            last_candidate_ix = ix;
+                            last_candidate_width = width;
                         }
 
                         if c != ' ' && first_non_whitespace_ix.is_none() {

--- a/crates/gpui/src/text_system/line_wrapper.rs
+++ b/crates/gpui/src/text_system/line_wrapper.rs
@@ -65,7 +65,7 @@ impl LineWrapper {
                             }
                         } else {
                             if c == ' ' || first_non_whitespace_ix.is_some() {
-                                // 1. For english, the space to as a spliter to wrap, e.g.: `Hello world `,
+                                // 1. For english, the space to as a splitter to wrap, e.g.: `Hello world `,
                                 // 2. For CJK, may not be space separated, e.g.: `Hello world你好世界`,
                                 // when `ix` is `你`, we can also need to wrap here.
                                 last_candidate_ix = ix;

--- a/crates/gpui/src/text_system/line_wrapper.rs
+++ b/crates/gpui/src/text_system/line_wrapper.rs
@@ -80,7 +80,6 @@ impl LineWrapper {
                             if candidate {
                                 last_candidate_ix = ix;
                                 last_candidate_width = width;
-                                dbg!(c);
                             }
                         }
 
@@ -108,8 +107,6 @@ impl LineWrapper {
                         element_width
                     }
                 };
-
-                dbg!(&item_width);
 
                 width += item_width;
                 if width > wrap_width && ix > last_wrap_ix {

--- a/crates/gpui/src/text_system/line_wrapper.rs
+++ b/crates/gpui/src/text_system/line_wrapper.rs
@@ -417,14 +417,15 @@ mod tests {
         assert_eq!(
             wrapper
                 .wrap_line(
-                    &[LineFragment::text("aa bbb cccc ddddd eeee         ")],
+                    &[LineFragment::text("aa bbb cccc ddddd eeeeee    ")],
                     px(72.)
                 )
                 .collect::<Vec<_>>(),
             &[
                 Boundary::new(7, 0),
                 Boundary::new(12, 0),
-                Boundary::new(18, 0)
+                Boundary::new(18, 0),
+                Boundary::new(25, 0),
             ]
         );
 
@@ -460,11 +461,7 @@ mod tests {
                     px(72.)
                 )
                 .collect::<Vec<_>>(),
-            &[
-                Boundary::new(5, 0),
-                Boundary::new(9, 0),
-                Boundary::new(11, 0)
-            ],
+            &[Boundary::new(5, 0), Boundary::new(10, 0)],
         );
 
         // Test with element at the beginning and text afterward

--- a/crates/gpui/src/text_system/line_wrapper.rs
+++ b/crates/gpui/src/text_system/line_wrapper.rs
@@ -53,7 +53,6 @@ impl LineWrapper {
                 let ix = index;
                 index += candidate.len_utf8();
                 let mut new_prev_c = prev_c;
-
                 let item_width = match candidate {
                     WrapBoundaryCandidate::Char { character: c } => {
                         if c == '\n' {

--- a/crates/gpui/src/text_system/line_wrapper.rs
+++ b/crates/gpui/src/text_system/line_wrapper.rs
@@ -47,17 +47,12 @@ impl LineWrapper {
 
         let mut candidates = fragments
             .iter()
-            .flat_map(move |fragment| fragment.wrap_boundary_candidates())
-            .peekable();
+            .flat_map(move |fragment| fragment.wrap_boundary_candidates());
         iter::from_fn(move || {
-            while let Some(candidate) = candidates.next() {
+            for candidate in candidates.by_ref() {
                 let ix = index;
                 index += candidate.len_utf8();
                 let mut new_prev_c = prev_c;
-                let next_c = candidates.peek().map(|c| match c {
-                    WrapBoundaryCandidate::Char { character: c } => *c,
-                    WrapBoundaryCandidate::Element { .. } => '\0',
-                });
 
                 let item_width = match candidate {
                     WrapBoundaryCandidate::Char { character: c } => {

--- a/crates/gpui/src/text_system/line_wrapper.rs
+++ b/crates/gpui/src/text_system/line_wrapper.rs
@@ -64,8 +64,10 @@ impl LineWrapper {
                                 last_candidate_width = width;
                             }
                         } else {
-                            // CJK may not be space separated, e.g.: `Hello world你好世界`
-                            if c != ' ' && first_non_whitespace_ix.is_some() {
+                            if c == ' ' || first_non_whitespace_ix.is_some() {
+                                // 1. For english, the space to as a spliter to wrap, e.g.: `Hello world `,
+                                // 2. For CJK, may not be space separated, e.g.: `Hello world你好世界`,
+                                // when `ix` is `你`, we can also need to wrap here.
                                 last_candidate_ix = ix;
                                 last_candidate_width = width;
                             }


### PR DESCRIPTION
Release Notes:

- Fixed incorrect text wrap when line end has spaces.

<img width="713" height="792" alt="image" src="https://github.com/user-attachments/assets/9f2d47c9-5563-4b64-9c7c-536eae9553b1" />

Resize details after change:

https://github.com/user-attachments/assets/f5f2791b-6288-4ae2-af4c-31bf4b4431b6


---

I have also tested CJK content by run `text_wrapper` example and Zed, they are correct.

### How to test

Use this text and enable soft wrap in Zed, and resize window.

> NOTE: In this text, last have a lot of space.

```
    GPUI is still in active development as we work on the Zed code editor,                   and is still pre-1.0.                           There will often be breaking changes between versions. You'll also need to use the latest version of stable Rust and be on macOS or Linux.                                                                                                                       
```



