### PR TITLE
miniprofiler_ui: Improve MiniProfiler to use uniform list

### DIFF
--- a/crates/gpui/src/elements/uniform_list.rs
+++ b/crates/gpui/src/elements/uniform_list.rs
@@ -11,7 +11,7 @@ use crate::{
     StyleRefinement, Styled, Window, point, size,
 };
 use smallvec::SmallVec;
-use std::{cell::RefCell, cmp, ops::Range, rc::Rc};
+use std::{cell::RefCell, cmp, ops::Range, rc::Rc, usize};
 
 use super::ListHorizontalSizingBehavior;
 
@@ -234,6 +234,11 @@ impl UniformListScrollHandle {
         } else {
             false
         }
+    }
+
+    /// Scroll to the bottom of the list.
+    pub fn scroll_to_bottom(&self) {
+        self.scroll_to_item(usize::MAX, ScrollStrategy::Bottom);
     }
 }
 

--- a/crates/miniprofiler_ui/src/miniprofiler_ui.rs
+++ b/crates/miniprofiler_ui/src/miniprofiler_ui.rs
@@ -129,12 +129,12 @@ impl ProfilerWindow {
                     .get_current_thread_timings();
 
                 this.update(cx, |this: &mut ProfilerWindow, cx| {
-                    this.data = DataMode::Realtime(Some(data));
                     let max_offset = this.scroll_handle.max_offset();
                     if !this.autoscroll {
                         let scroll_offset = this.scroll_handle.offset();
                         this.autoscroll = -scroll_offset.y >= (max_offset.height - px(24.));
                     }
+                    this.data = DataMode::Realtime(Some(data));
 
                     if this.autoscroll {
                         this.scroll_handle

--- a/crates/miniprofiler_ui/src/miniprofiler_ui.rs
+++ b/crates/miniprofiler_ui/src/miniprofiler_ui.rs
@@ -239,12 +239,11 @@ impl Render for ProfilerWindow {
             .id("profiler")
             .w_full()
             .h_full()
-            .gap_2()
             .bg(cx.theme().colors().surface_background)
             .text_color(cx.theme().colors().text)
             .child(
                 h_flex()
-                    .py_3()
+                    .py_2()
                     .px_4()
                     .w_full()
                     .justify_between()

--- a/crates/miniprofiler_ui/src/miniprofiler_ui.rs
+++ b/crates/miniprofiler_ui/src/miniprofiler_ui.rs
@@ -217,7 +217,7 @@ impl ProfilerWindow {
                     .min_w(px(60.0))
                     .flex_shrink_0()
                     .text_right()
-                    .child(format!("{:.1}ms", time_ms)),
+                    .child(format!("{:.1} ms", time_ms)),
             )
     }
 }

--- a/crates/miniprofiler_ui/src/miniprofiler_ui.rs
+++ b/crates/miniprofiler_ui/src/miniprofiler_ui.rs
@@ -214,7 +214,7 @@ impl ProfilerWindow {
             )
             .child(
                 div()
-                    .min_w(px(60.0))
+                    .min_w(px(70.))
                     .flex_shrink_0()
                     .text_right()
                     .child(format!("{:.1} ms", time_ms)),

--- a/crates/miniprofiler_ui/src/miniprofiler_ui.rs
+++ b/crates/miniprofiler_ui/src/miniprofiler_ui.rs
@@ -327,20 +327,26 @@ impl Render for ProfilerWindow {
                             ),
                     )
                     .child(
-                        Checkbox::new("autoscroll", self.autoscroll.into())
-                            .label("Auto Scroll")
-                            .on_click(cx.listener(|this, checked: &ToggleState, _window, cx| {
-                                this.autoscroll = checked.selected();
-                                cx.notify();
-                            })),
-                    )
-                    .child(
-                        Checkbox::new("include-self", self.include_self_timings)
-                            .label("Include profiler timings")
-                            .on_click(cx.listener(|this, checked, _window, cx| {
-                                this.include_self_timings = *checked;
-                                cx.notify();
-                            })),
+                        h_flex()
+                            .gap_3()
+                            .child(
+                                Checkbox::new("autoscroll", self.autoscroll.into())
+                                    .label("Auto Scroll")
+                                    .on_click(cx.listener(
+                                        |this, checked: &ToggleState, _window, cx| {
+                                            this.autoscroll = checked.selected();
+                                            cx.notify();
+                                        },
+                                    )),
+                            )
+                            .child(
+                                Checkbox::new("include-self", self.include_self_timings)
+                                    .label("Include profiler timings")
+                                    .on_click(cx.listener(|this, checked, _window, cx| {
+                                        this.include_self_timings = *checked;
+                                        cx.notify();
+                                    })),
+                            ),
                     ),
             )
             .when_some(self.get_timings(), |div, e| {

--- a/crates/miniprofiler_ui/src/miniprofiler_ui.rs
+++ b/crates/miniprofiler_ui/src/miniprofiler_ui.rs
@@ -130,10 +130,8 @@ impl ProfilerWindow {
 
                 this.update(cx, |this: &mut ProfilerWindow, cx| {
                     let max_offset = this.scroll_handle.max_offset();
-                    if !this.autoscroll {
-                        let scroll_offset = this.scroll_handle.offset();
-                        this.autoscroll = -scroll_offset.y >= (max_offset.height - px(24.));
-                    }
+                    let scroll_offset = this.scroll_handle.offset();
+                    this.autoscroll = -scroll_offset.y >= (max_offset.height - px(24.));
                     this.data = DataMode::Realtime(Some(data));
 
                     if this.autoscroll {


### PR DESCRIPTION
Release Notes:

- N/A

---

- Apply uniform_list for timing list for performance.
- Add paddings for window.
- Add space to `ms`, before: `100ms` after `100 ms`.

## Before 

<img width="1392" height="860" alt="image" src="https://github.com/user-attachments/assets/9706a96f-7093-4d4f-832f-306948a9b17b" />

## After 

<img width="1392" height="864" alt="image" src="https://github.com/user-attachments/assets/38df1b71-15e7-4101-b0c9-ecdcdb7752d7" />
