### PR TITLE
acp: Only pass enabled MCP servers to agent

### DIFF
--- a/crates/project/src/context_server_store.rs
+++ b/crates/project/src/context_server_store.rs
@@ -199,12 +199,12 @@ impl ContextServerStore {
         )
     }
 
-    /// Returns all configured context server ids, regardless of enabled state.
+    /// Returns all configured context server ids, excluding the ones that are disabled
     pub fn configured_server_ids(&self) -> Vec<ContextServerId> {
         self.context_server_settings
-            .keys()
-            .cloned()
-            .map(ContextServerId)
+            .iter()
+            .filter(|(_, settings)| settings.enabled())
+            .map(|(id, _)| ContextServerId(*id))
             .collect()
     }
 

--- a/crates/project/src/context_server_store.rs
+++ b/crates/project/src/context_server_store.rs
@@ -204,7 +204,7 @@ impl ContextServerStore {
         self.context_server_settings
             .iter()
             .filter(|(_, settings)| settings.enabled())
-            .map(|(id, _)| ContextServerId(*id))
+            .map(|(id, _)| ContextServerId(id.clone()))
             .collect()
     }
 


### PR DESCRIPTION
Release Notes:

- Fix an issue where ACP agents would start MCP servers that were disabled in Zed
