### PR TITLE
languages: Recognize .clang-format as YAML

### DIFF
--- a/crates/languages/src/yaml/config.toml
+++ b/crates/languages/src/yaml/config.toml
@@ -1,6 +1,6 @@
 name = "YAML"
 grammar = "yaml"
-path_suffixes = ["yml", "yaml", "pixi.lock"]
+path_suffixes = ["yml", "yaml", "pixi.lock", "clang-format"]
 line_comments = ["# "]
 autoclose_before = ",]}"
 brackets = [

--- a/docs/src/languages/c.md
+++ b/docs/src/languages/c.md
@@ -27,9 +27,10 @@ By default clang and gcc will recognize `*.C` and `*.H` (uppercase extensions) a
 
 ## Formatting
 
-By default Zed will use the `clangd` language server for formatting C code. The Clangd is the same as the `clang-format` CLI tool. To configure this you can add a `.clang-format` file. For example:
+By default Zed will use the `clangd` language server for formatting C code like the `clang-format` CLI tool. To configure this you can add a `.clang-format` file. For example:
 
 ```yaml
+# yaml-language-server: $schema=https://json.schemastore.org/clang-format-21.x.json
 ---
 BasedOnStyle: GNU
 IndentWidth: 2


### PR DESCRIPTION
Clang-Format uses uses a YAML config file format.

Use YAML language by default for `.clang-format` and `_clang-format` filenames. ([source](https://clang.llvm.org/docs/ClangFormatStyleOptions.html))
Add `#yaml-language-server: $schema` to `.clang-format` example in C language docs.

Release Notes:

- Added support for identifying. `.clang-format` files as YAML by default
