### PR TITLE
editor: Fix package version completion partial accept and improve sorting

### DIFF
--- a/crates/editor/src/code_completion_tests.rs
+++ b/crates/editor/src/code_completion_tests.rs
@@ -277,8 +277,10 @@ async fn test_semver_label_sort_by_latest_version(cx: &mut TestAppContext) {
     assert_eq!(matches[10].string, "10.4.20+20210327");
     assert_eq!(matches[11].string, "10.4.20");
     assert_eq!(matches[12].string, "10.4.20-beta.1");
-    assert_eq!(matches[13].string, "10.4.12");
-    assert_eq!(matches[14].string, "10.4.2");
+    // TODO: we still need to figure how to handle case where
+    // we might want to prefer sort_text over sort_positions and sort_score
+    assert_eq!(matches[13].string, "10.4.2");
+    assert_eq!(matches[14].string, "10.4.12");
 }
 
 async fn test_for_each_prefix<F>(

--- a/crates/editor/src/code_completion_tests.rs
+++ b/crates/editor/src/code_completion_tests.rs
@@ -241,7 +241,7 @@ async fn test_fuzzy_over_sort_positions(cx: &mut TestAppContext) {
 
 #[gpui::test]
 async fn test_semver_label_sort_by_latest_version(cx: &mut TestAppContext) {
-    let versions = [
+    let mut versions = [
         "10.4.112",
         "10.4.22",
         "10.4.2",
@@ -256,7 +256,15 @@ async fn test_semver_label_sort_by_latest_version(cx: &mut TestAppContext) {
         "10.4.21+build.123",
         "10.4.20+20210327",
     ];
-
+    versions.sort_by(|a, b| {
+        match (
+            semver::Version::parse(a).ok(),
+            semver::Version::parse(b).ok(),
+        ) {
+            (Some(a_ver), Some(b_ver)) => b_ver.cmp(&a_ver),
+            _ => std::cmp::Ordering::Equal,
+        }
+    });
     let completions: Vec<_> = versions
         .iter()
         .enumerate()

--- a/crates/editor/src/code_completion_tests.rs
+++ b/crates/editor/src/code_completion_tests.rs
@@ -242,6 +242,7 @@ async fn test_fuzzy_over_sort_positions(cx: &mut TestAppContext) {
 #[gpui::test]
 async fn test_semver_label_sort_by_latest_version(cx: &mut TestAppContext) {
     let completions = vec![
+        CompletionBuilder::new("10.4.112", None, "00000000", None),
         CompletionBuilder::new("10.4.22", None, "00000001", None),
         CompletionBuilder::new("10.4.2", None, "00000015", None),
         CompletionBuilder::new("10.4.20", None, "00000012", None),
@@ -249,38 +250,30 @@ async fn test_semver_label_sort_by_latest_version(cx: &mut TestAppContext) {
         CompletionBuilder::new("10.4.12", None, "00000014", None),
         // Pre-release versions
         CompletionBuilder::new("10.4.22-alpha", None, "00000007", None),
-        CompletionBuilder::new("10.4.22-alpha.1", None, "00000006", None),
-        CompletionBuilder::new("10.4.22-alpha.2", None, "00000005", None),
-        CompletionBuilder::new("10.4.22-beta", None, "00000004", None),
         CompletionBuilder::new("10.4.22-beta.1", None, "00000003", None),
         CompletionBuilder::new("10.4.22-rc.1", None, "00000002", None),
-        CompletionBuilder::new("10.4.20-beta.1", None, "00000013", None),
         // Build metadata versions
         CompletionBuilder::new("10.4.21+build.123", None, "00000009", None),
-        CompletionBuilder::new("10.4.21+build.456", None, "00000008", None),
         CompletionBuilder::new("10.4.20+20210327", None, "00000011", None),
     ];
 
-    let matches = filter_and_sort_matches("2", &completions, SnippetSortOrder::default(), cx).await;
+    let matches =
+        filter_and_sort_matches("10.4.2", &completions, SnippetSortOrder::default(), cx).await;
 
+    // Exact match comes first
+    assert_eq!(matches[0].string, "10.4.2");
+    // Ordered by recency
+    assert_eq!(matches[1].string, "10.4.112");
+    assert_eq!(matches[2].string, "10.4.22");
     // Within pre-releases: rc.1 > beta.1 > beta > alpha.2 > alpha.1 > alpha
-    assert_eq!(matches[0].string, "10.4.22");
-    assert_eq!(matches[1].string, "10.4.22-rc.1");
-    assert_eq!(matches[2].string, "10.4.22-beta.1");
-    assert_eq!(matches[3].string, "10.4.22-beta");
-    assert_eq!(matches[4].string, "10.4.22-alpha.2");
-    assert_eq!(matches[5].string, "10.4.22-alpha.1");
-    assert_eq!(matches[6].string, "10.4.22-alpha");
-    assert_eq!(matches[7].string, "10.4.21+build.456");
-    assert_eq!(matches[8].string, "10.4.21+build.123");
-    assert_eq!(matches[9].string, "10.4.21");
-    assert_eq!(matches[10].string, "10.4.20+20210327");
-    assert_eq!(matches[11].string, "10.4.20");
-    assert_eq!(matches[12].string, "10.4.20-beta.1");
-    // TODO: we still need to figure how to handle case where
-    // we might want to prefer sort_text over sort_positions and sort_score
-    assert_eq!(matches[13].string, "10.4.2");
-    assert_eq!(matches[14].string, "10.4.12");
+    assert_eq!(matches[3].string, "10.4.22-rc.1");
+    assert_eq!(matches[4].string, "10.4.22-beta.1");
+    assert_eq!(matches[8].string, "10.4.22-alpha");
+    assert_eq!(matches[10].string, "10.4.21+build.123");
+    assert_eq!(matches[11].string, "10.4.21");
+    assert_eq!(matches[12].string, "10.4.20+20210327");
+    assert_eq!(matches[13].string, "10.4.20");
+    assert_eq!(matches[15].string, "10.4.12");
 }
 
 async fn test_for_each_prefix<F>(

--- a/crates/editor/src/code_completion_tests.rs
+++ b/crates/editor/src/code_completion_tests.rs
@@ -284,8 +284,13 @@ async fn test_semver_label_sort_by_latest_version(cx: &mut TestAppContext) {
         "10.4.12",
         "10.4.2",
     ];
+    for (match_item, expected) in matches.iter().zip(expected_versions.iter()) {
+        assert_eq!(match_item.string.as_ref() as &str, *expected);
+    }
 
     // Case 2: User types major, minor and patch version
+    let matches =
+        filter_and_sort_matches("10.4.2", &completions, SnippetSortOrder::default(), cx).await;
     let expected_versions = [
         // Exact version comes first
         "10.4.2",
@@ -304,6 +309,9 @@ async fn test_semver_label_sort_by_latest_version(cx: &mut TestAppContext) {
         "10.4.12",
         "10.4.112",
     ];
+    for (match_item, expected) in matches.iter().zip(expected_versions.iter()) {
+        assert_eq!(match_item.string.as_ref() as &str, *expected);
+    }
 }
 
 async fn test_for_each_prefix<F>(

--- a/crates/editor/src/code_completion_tests.rs
+++ b/crates/editor/src/code_completion_tests.rs
@@ -267,10 +267,10 @@ async fn test_semver_label_sort_by_latest_version(cx: &mut TestAppContext) {
         })
         .collect();
 
-    // Case 1: User types just major and minor version
+    // Case 1: User types just the major and minor version
     let matches =
         filter_and_sort_matches("10.4.", &completions, SnippetSortOrder::default(), cx).await;
-    // Versions are ordered by recency
+    // Versions are ordered by recency (latest first)
     let expected_versions = [
         "10.4.112",
         "10.4.22",
@@ -288,13 +288,13 @@ async fn test_semver_label_sort_by_latest_version(cx: &mut TestAppContext) {
         assert_eq!(match_item.string.as_ref() as &str, *expected);
     }
 
-    // Case 2: User types major, minor and patch version
+    // Case 2: User types the major, minor, and patch version
     let matches =
         filter_and_sort_matches("10.4.2", &completions, SnippetSortOrder::default(), cx).await;
     let expected_versions = [
-        // Exact version comes first
+        // Exact match comes first
         "10.4.2",
-        // Ordered by recency with exact major, minor and patch versions
+        // Ordered by recency with exact major, minor, and patch versions
         "10.4.22",
         "10.4.22-rc.1",
         "10.4.22-beta.1",
@@ -303,9 +303,9 @@ async fn test_semver_label_sort_by_latest_version(cx: &mut TestAppContext) {
         "10.4.21",
         "10.4.20+20210327",
         "10.4.20",
-        // Versions with non exact patch version are ordered by fuzzy score
-        // Higher fuzzy score than 112 patch version since 2, comes before than
-        // of 112 version
+        // Versions with non-exact patch versions are ordered by fuzzy score
+        // Higher fuzzy score than 112 patch version since "2" appears before "1"
+        // in "12", making it rank higher than "112"
         "10.4.12",
         "10.4.112",
     ];

--- a/crates/editor/src/code_completion_tests.rs
+++ b/crates/editor/src/code_completion_tests.rs
@@ -243,22 +243,22 @@ async fn test_fuzzy_over_sort_positions(cx: &mut TestAppContext) {
 async fn test_semver_label_sort_by_latest_version(cx: &mut TestAppContext) {
     let completions = vec![
         CompletionBuilder::new("10.4.22", None, "00000001", None),
-        CompletionBuilder::new("10.4.2", None, None, None),
-        CompletionBuilder::new("10.4.20", None, None, None),
-        CompletionBuilder::new("10.4.21", None, None, None),
-        CompletionBuilder::new("10.4.12", None, None, None),
+        CompletionBuilder::new("10.4.2", None, "00000015", None),
+        CompletionBuilder::new("10.4.20", None, "00000012", None),
+        CompletionBuilder::new("10.4.21", None, "00000010", None),
+        CompletionBuilder::new("10.4.12", None, "00000014", None),
         // Pre-release versions
-        CompletionBuilder::new("10.4.22-alpha", None, None, None),
-        CompletionBuilder::new("10.4.22-alpha.1", None, None, None),
-        CompletionBuilder::new("10.4.22-alpha.2", None, None, None),
-        CompletionBuilder::new("10.4.22-beta", None, None, None),
-        CompletionBuilder::new("10.4.22-beta.1", None, None, None),
-        CompletionBuilder::new("10.4.22-rc.1", None, None, None),
-        CompletionBuilder::new("10.4.20-beta.1", None, None, None),
+        CompletionBuilder::new("10.4.22-alpha", None, "00000007", None),
+        CompletionBuilder::new("10.4.22-alpha.1", None, "00000006", None),
+        CompletionBuilder::new("10.4.22-alpha.2", None, "00000005", None),
+        CompletionBuilder::new("10.4.22-beta", None, "00000004", None),
+        CompletionBuilder::new("10.4.22-beta.1", None, "00000003", None),
+        CompletionBuilder::new("10.4.22-rc.1", None, "00000002", None),
+        CompletionBuilder::new("10.4.20-beta.1", None, "00000013", None),
         // Build metadata versions
-        CompletionBuilder::new("10.4.21+build.123", None, None, None),
-        CompletionBuilder::new("10.4.21+build.456", None, None, None),
-        CompletionBuilder::new("10.4.20+20210327", None, None, None),
+        CompletionBuilder::new("10.4.21+build.123", None, "00000009", None),
+        CompletionBuilder::new("10.4.21+build.456", None, "00000008", None),
+        CompletionBuilder::new("10.4.20+20210327", None, "00000011", None),
     ];
 
     let matches = filter_and_sort_matches("2", &completions, SnippetSortOrder::default(), cx).await;

--- a/crates/fuzzy/src/matcher.rs
+++ b/crates/fuzzy/src/matcher.rs
@@ -264,7 +264,10 @@ impl<'a> Matcher<'a> {
 
                     if last == '/' {
                         char_score = 0.9;
-                    } else if (last == '-' || last == '_' || last == ' ' || last.is_numeric())
+                    } else if (last == '-'
+                        || last == '_'
+                        || last == ' '
+                        || (last.is_numeric() && !curr.is_numeric()))
                         || (last.is_lowercase() && curr.is_uppercase())
                     {
                         char_score = 0.8;
@@ -595,5 +598,26 @@ mod tests {
                 )
             })
             .collect()
+    }
+
+    #[test]
+    fn test_numeric_boundary_preserved_for_non_numeric() {
+        let paths = vec!["imgpng", "img2png"];
+        let results = match_single_path_query("p", false, &paths);
+        assert_eq!(
+            results[0].0, "img2png",
+            "A number should act as a boundary for non-numeric character"
+        );
+    }
+
+    #[test]
+    fn test_numeric_boundary_ignored_for_digits() {
+        let paths = vec!["v10", "v.0"];
+        let results = match_single_path_query("0", false, &paths);
+        // v.0 wins over v10 here since the previous character of 0 is a dot
+        assert_eq!(
+            results[0].0, "v.0",
+            "A number should not act as a boundary for other numbers"
+        );
     }
 }

--- a/crates/fuzzy/src/matcher.rs
+++ b/crates/fuzzy/src/matcher.rs
@@ -264,10 +264,7 @@ impl<'a> Matcher<'a> {
 
                     if last == '/' {
                         char_score = 0.9;
-                    } else if (last == '-'
-                        || last == '_'
-                        || last == ' '
-                        || (last.is_numeric() && !curr.is_numeric()))
+                    } else if (last == '-' || last == '_' || last == ' ' || last.is_numeric())
                         || (last.is_lowercase() && curr.is_uppercase())
                     {
                         char_score = 0.8;
@@ -598,26 +595,5 @@ mod tests {
                 )
             })
             .collect()
-    }
-
-    #[test]
-    fn test_numeric_boundary_preserved_for_non_numeric() {
-        let paths = vec!["imgpng", "img2png"];
-        let results = match_single_path_query("p", false, &paths);
-        assert_eq!(
-            results[0].0, "img2png",
-            "A number should act as a boundary for non-numeric character"
-        );
-    }
-
-    #[test]
-    fn test_numeric_boundary_ignored_for_digits() {
-        let paths = vec!["v10", "v.0"];
-        let results = match_single_path_query("0", false, &paths);
-        // v.0 wins over v10 here since the previous character of 0 is a dot
-        assert_eq!(
-            results[0].0, "v.0",
-            "A number should not act as a boundary for other numbers"
-        );
     }
 }

--- a/crates/languages/src/json/config.toml
+++ b/crates/languages/src/json/config.toml
@@ -11,5 +11,6 @@ brackets = [
 tab_size = 2
 prettier_parser_name = "json"
 debuggers = ["JavaScript"]
+
 [overrides.string]
-completion_query_characters = [":", " "]
+completion_query_characters = [":", " ", "."]


### PR DESCRIPTION
Closes #41723

This PR fixes an issue with accepting partial semver completions by including `.` in the completion query. This makes the editor treat the entire version string as the query, instead of breaking segment at last `.` .

This PR also adds a test for sorting semver completions. The actual sorting fix is handled in the `package-version-server` by having it provide `sort_text`. More: https://github.com/zed-industries/package-version-server/pull/10

<img width="600" alt="image" src="https://github.com/user-attachments/assets/7657912f-c6da-4e05-956b-1c044918304f" />

Release Notes:

- Fixed an issue where accepting a completion for a semver version in package.json would append the suggestion to the existing text instead of replacing it.
- Improved the sorting of semver completions in package.json so the latest versions appear at the top.