### PR TITLE
Preserve whitespaces in commit messages

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -12290,6 +12290,22 @@ impl Editor {
         self.rewrap_impl(RewrapOptions::default(), cx)
     }
 
+    pub fn commit_rewrap(&mut self, _: &Rewrap, _: &mut Window, cx: &mut Context<Self>) {
+        self.hide_mouse_cursor(HideMouseCursorOrigin::TypingAction, cx);
+        if self.mode.is_single_line() {
+            cx.propagate();
+            return;
+        }
+
+        self.rewrap_impl(
+            RewrapOptions {
+                override_language_settings: false,
+                preserve_existing_whitespace: true,
+            },
+            cx,
+        );
+    }
+
     pub fn rewrap_impl(&mut self, options: RewrapOptions, cx: &mut Context<Self>) {
         let buffer = self.buffer.read(cx).snapshot(cx);
         let selections = self.selections.all::<Point>(&self.display_snapshot(cx));

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1634,7 +1634,7 @@ impl GitPanel {
         let editor = cx.new(|cx| Editor::for_buffer(buffer, None, window, cx));
         let wrapped_message = editor.update(cx, |editor, cx| {
             editor.select_all(&Default::default(), window, cx);
-            editor.rewrap(&Default::default(), window, cx);
+            editor.commit_rewrap(&Default::default(), window, cx);
             editor.text(cx)
         });
         if wrapped_message.trim().is_empty() {


### PR DESCRIPTION
Closes #42476 

Release Notes:

Preserve Whitespace in Git Commit Messages

**What Changed:**
- Modified commit message rewrapping behavior to preserve existing whitespace formatting
- Added new `commit_rewrap` method to the Editor that maintains intentional spacing in commit messages

**Technical Details:**
- Introduced `commit_rewrap()` method in `editor.rs` with `preserve_existing_whitespace: true` option
- Updated Git panel to use `commit_rewrap()` instead of standard `rewrap()` when formatting commit messages
- This ensures that deliberate formatting choices (like blank lines, indentation, and spacing) in commit messages are
maintained during the rewrap operation

**Impact:**
- Users can now format their commit messages with intentional whitespace without it being removed during the rewrap process
- Improves commit message readability and preserves structured formatting (e.g., bullet points, paragraphs, code blocks)

**Files Modified:**
- `crates/editor/src/editor.rs` - Added `commit_rewrap()` method
- `crates/git_ui/src/git_panel.rs` - Updated to use new rewrap method
