### PR TITLE
Redact sensitive environment variables in LSP Logs: Server Info

### DIFF
--- a/crates/language_tools/src/lsp_log_view.rs
+++ b/crates/language_tools/src/lsp_log_view.rs
@@ -340,10 +340,11 @@ impl LspLogView {
 * Configuration: {CONFIGURATION}",
             NAME = info.status.name,
             ID = info.id,
-            BINARY = info.status.binary.as_ref().map_or_else(
-                || "Unknown".to_string(),
-                |binary| format!("{:#?}", binary)
-            ),
+            BINARY = info
+                .status
+                .binary
+                .as_ref()
+                .map_or_else(|| "Unknown".to_string(), |binary| format!("{:#?}", binary)),
             WORKSPACE_FOLDERS = info
                 .status
                 .workspace_folders

--- a/crates/language_tools/src/lsp_log_view.rs
+++ b/crates/language_tools/src/lsp_log_view.rs
@@ -342,8 +342,7 @@ impl LspLogView {
             ID = info.id,
             BINARY = info.status.binary.as_ref().map_or_else(
                 || "Unknown".to_string(),
-                |binary| serde_json::to_string_pretty(binary)
-                    .unwrap_or_else(|e| format!("Failed to serialize binary info: {e:#}"))
+                |binary| format!("{:#?}", binary)
             ),
             WORKSPACE_FOLDERS = info
                 .status


### PR DESCRIPTION
Follow-up to: 
- https://github.com/zed-industries/zed/pull/43436
- https://github.com/zed-industries/zed/pull/42831

The changes in #42831 resulted in a regression where environment variables in the Server Info view were no longer redact. The changes in #43436 were insufficient as I was still seeing sensitive values in Nightly e6fe95b4f2f676c7fc4a5f951ba7c721e7d22e8a (which includes #43436).

CC: @SomeoneToIgnore (Hi! 👋 Thanks for keeping this redaction functionality alive)

Release Notes:

- N/A
