### PR TITLE
Add missing update of last_prediction_refresh

### DIFF
--- a/crates/zeta/src/zeta.rs
+++ b/crates/zeta/src/zeta.rs
@@ -1126,7 +1126,6 @@ impl Zeta {
         zeta_project.next_pending_prediction_id += 1;
         let last_request = zeta_project.last_prediction_refresh;
 
-        // TODO report cancelled requests like in zeta1
         let task = cx.spawn(async move |this, cx| {
             if let Some((last_entity, last_timestamp)) = last_request
                 && throttle_entity == last_entity
@@ -1135,6 +1134,12 @@ impl Zeta {
             {
                 cx.background_executor().timer(timeout).await;
             }
+
+            this.update(cx, |this, cx| {
+                this.get_or_init_zeta_project(&project, cx)
+                    .last_prediction_refresh = Some((throttle_entity, Instant::now()));
+            })
+            .ok();
 
             let edit_prediction_id = do_refresh(this.clone(), cx).await.log_err().flatten();
 


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/zed-industries/zed/pull/43284 where edit predictions stopped being throttled at all 😬 

Release Notes:

- N/A
