### PR TITLE
agent: Add auto_summarize_on_token_limit setting for infinite agent continuation

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1020,7 +1020,13 @@
     // Minimum number of lines to display in the agent message editor.
     //
     // Default: 4
-    "message_editor_min_lines": 4
+    "message_editor_min_lines": 4,
+    // Whether to automatically start a new thread from summary when token usage reaches 90%.
+    // This allows the agent to continue working indefinitely without manual intervention,
+    // transitioning smoothly before hitting the hard token limit.
+    //
+    // Default: false
+    "auto_summarize_on_token_limit": false
   },
   // Whether the screen sharing icon is shown in the os status bar.
   "show_call_status_icon": true,

--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -45,6 +45,7 @@ pub struct AgentSettings {
     pub expand_terminal_card: bool,
     pub use_modifier_to_send: bool,
     pub message_editor_min_lines: usize,
+    pub auto_summarize_on_token_limit: bool,
 }
 
 impl AgentSettings {
@@ -177,6 +178,7 @@ impl Settings for AgentSettings {
             expand_terminal_card: agent.expand_terminal_card.unwrap(),
             use_modifier_to_send: agent.use_modifier_to_send.unwrap(),
             message_editor_min_lines: agent.message_editor_min_lines.unwrap(),
+            auto_summarize_on_token_limit: agent.auto_summarize_on_token_limit.unwrap(),
         }
     }
 }

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -142,6 +142,10 @@ pub struct NewExternalAgentThread {
 #[serde(deny_unknown_fields)]
 pub struct NewNativeAgentThreadFromSummary {
     from_session_id: agent_client_protocol::SessionId,
+    /// Whether to automatically send the message after the thread is created.
+    /// This is used when auto-summarizing on token limit.
+    #[serde(default)]
+    pub auto_send: bool,
 }
 
 // TODO unify this with AgentType
@@ -468,6 +472,7 @@ mod tests {
             expand_terminal_card: true,
             use_modifier_to_send: true,
             message_editor_min_lines: 1,
+            auto_summarize_on_token_limit: false,
         };
 
         cx.update(|cx| {

--- a/crates/settings/src/settings_content/agent.rs
+++ b/crates/settings/src/settings_content/agent.rs
@@ -106,6 +106,12 @@ pub struct AgentSettingsContent {
     ///
     /// Default: 4
     pub message_editor_min_lines: Option<usize>,
+    /// Whether to automatically start a new thread from summary when token usage reaches 90%.
+    /// This allows the agent to continue working indefinitely without manual intervention,
+    /// transitioning smoothly before hitting the hard token limit.
+    ///
+    /// Default: false
+    pub auto_summarize_on_token_limit: Option<bool>,
 }
 
 impl AgentSettingsContent {


### PR DESCRIPTION
## Summary

This PR adds a new setting `auto_summarize_on_token_limit` that allows the agent to automatically continue in a new thread when token usage reaches 90%.

## Problem

Currently, when the agent reaches the token limit during a conversation, users must manually click "Start New Thread" to continue. This interrupts the workflow and requires user intervention for long-running agent tasks.

## Solution

Added a new setting that, when enabled:
1. Detects when token usage reaches 90% (triggered after the agent stops responding)
2. Automatically creates a new thread with a summary reference to the old thread  
3. Automatically sends the message to kick off the new thread

The 90% threshold ensures the agent has room to complete its current response before transitioning smoothly to the new thread.

## Usage

Add to your settings:
```json
{
  "agent": {
    "auto_summarize_on_token_limit": true
  }
}
```

## Files Changed

- `crates/settings/src/settings_content/agent.rs` - Added setting definition
- `crates/agent_settings/src/agent_settings.rs` - Added setting field and initialization
- `assets/settings/default.json` - Added default value (false)
- `crates/agent_ui/src/agent_ui.rs` - Added `auto_send` field to `NewNativeAgentThreadFromSummary` action
- `crates/agent_ui/src/agent_panel.rs` - Added `auto_send` parameter to `external_thread()`
- `crates/agent_ui/src/acp/thread_view.rs` - Implemented auto-summarize logic on thread stop

## Testing

Manual testing recommended:
1. Enable the setting
2. Start a long conversation that approaches the token limit
3. Verify that at ~90% usage, a new thread is automatically created with the summary

---

*This feature allows the agent to theoretically continue indefinitely without user intervention.*

## Release Notes

- Added `auto_summarize_on_token_limit` setting that automatically continues agent conversations in a new thread when token usage reaches 90%, allowing the agent to work indefinitely without manual intervention.