### PR TITLE
Always display terminal cursor when blinking is disabled

### DIFF
--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -649,9 +649,10 @@ impl TerminalView {
         // When focused, check blinking settings and blink manager state
         match TerminalSettings::get_global(cx).blinking {
             TerminalBlink::Off => true,
-            TerminalBlink::On | TerminalBlink::TerminalControlled => {
-                self.blink_manager.read(cx).visible()
+            TerminalBlink::TerminalControlled => {
+                !self.blinking_terminal_enabled || self.blink_manager.read(cx).visible()
             }
+            TerminalBlink::On => self.blink_manager.read(cx).visible(),
         }
     }
 


### PR DESCRIPTION
Fixes an issue where the terminal cursor wouldn't always be displayed in the default `blink: "terminal_controlled"` mode unless the terminal requested cursor blinking. 

Release Notes:

- N/A
