### PR TITLE
terminal: Update search match highlights on resize

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -992,6 +992,9 @@ impl Terminal {
                 }
 
                 term.resize(new_bounds);
+                if !self.matches.is_empty() {
+                    cx.emit(Event::Wakeup);
+                }
             }
             InternalEvent::Clear => {
                 trace!("Clearing");

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -992,6 +992,9 @@ impl Terminal {
                 }
 
                 term.resize(new_bounds);
+                // If there are matches we need to emit a wake up event to
+                // invalidate the matches and recalculate their locations
+                // in the new terminal layout
                 if !self.matches.is_empty() {
                     cx.emit(Event::Wakeup);
                 }


### PR DESCRIPTION
Before this PR, the terminal would highlight incorrect locations after resizing while there were active search highlights/matches. The fix for this is emitting a wake up event which invalidates the search matches and forces the terminal to recalculate the match highlight positions. 

Release Notes:

- terminal: Fix bug where search match highlights wouldn't update their position when resizing the terminal.
