### PR TITLE
markdown: Fix rendering of inline HTML <code> tags

### DIFF
--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -1202,6 +1202,15 @@ impl Element for MarkdownElement {
                     builder.push_text(html, range.clone());
                 }
                 MarkdownEvent::InlineHtml => {
+                    let html = &parsed_markdown.source[range.clone()];
+                    if html.eq_ignore_ascii_case("<code>") {
+                        builder.push_text_style(self.style.inline_code.clone());
+                        continue;
+                    }
+                    if html.eq_ignore_ascii_case("</code>") {
+                        builder.pop_text_style();
+                        continue;
+                    }
                     builder.push_text(&parsed_markdown.source[range.clone()], range.clone());
                 }
                 MarkdownEvent::Rule => {

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -1203,11 +1203,11 @@ impl Element for MarkdownElement {
                 }
                 MarkdownEvent::InlineHtml => {
                     let html = &parsed_markdown.source[range.clone()];
-                    if html.eq_ignore_ascii_case("<code>") {
+                    if html.starts_with("<code>") {
                         builder.push_text_style(self.style.inline_code.clone());
                         continue;
                     }
-                    if html.eq_ignore_ascii_case("</code>") {
+                    if html.trim_end().starts_with("</code>") {
                         builder.pop_text_style();
                         continue;
                     }


### PR DESCRIPTION
Added support for rendering HTML `<code> `tags inside Markdown content. Previously, these tags were ignored by the renderer and displayed as raw text (inside LSP hover documentation).

Closes: #43166 

Release Notes:
- Fixed styling of `<code>` HTML tags in Markdown popovers.

Before:
<img width="445" height="145" alt="image" src="https://github.com/user-attachments/assets/67c4f864-1fa7-46a9-bb25-8b07a335355d" />
After:
<img width="699" height="257" alt="image" src="https://github.com/user-attachments/assets/8d784a75-28be-43cd-80b4-3aad8babb65b" />
