### PR TITLE
Exclude tracked files from gitignore status

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,17 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(/opt/homebrew/bin/cargo check -p worktree)",
+      "Bash(export PATH=\"$HOME/.cargo/bin:$PATH:/usr/bin:/bin\")",
+      "Bash(cargo check:*)",
+      "Bash(cargo test:*)",
+      "Bash(/opt/homebrew/bin/cargo test:*)",
+      "Bash(echo $HOME/.cargo/bin/cargo)",
+      "Bash($HOME/.cargo/bin/cargo test:*)",
+      "Bash(~/.cargo/bin/cargo test:*)",
+      "Bash(RUST_LOG=trace ~/.cargo/bin/cargo test:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/crates/worktree/src/ignore.rs
+++ b/crates/worktree/src/ignore.rs
@@ -121,5 +121,4 @@ impl IgnoreStack {
             },
         }
     }
-
 }

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -64,7 +64,9 @@ use std::{
 use sum_tree::{Bias, Dimensions, Edit, KeyedItem, SeekTarget, SumTree, Summary, TreeMap, TreeSet};
 use text::{LineEnding, Rope};
 use util::{
-    ResultExt, command::new_smol_command, debug_panic, maybe,
+    ResultExt,
+    command::new_smol_command,
+    debug_panic, maybe,
     paths::{PathMatcher, PathStyle, SanitizedPath, home_dir},
     rel_path::RelPath,
 };
@@ -2994,7 +2996,8 @@ impl BackgroundScannerState {
 
         // Fetch and store tracked files for this repository
         let tracked_files = get_tracked_files(&work_directory_abs_path).await;
-        self.snapshot.tracked_files_by_repo_root
+        self.snapshot
+            .tracked_files_by_repo_root
             .insert(work_directory_abs_path.into(), Arc::new(tracked_files));
 
         log::trace!("inserting new local git repository");

--- a/crates/worktree/src/worktree_tests.rs
+++ b/crates/worktree/src/worktree_tests.rs
@@ -2290,8 +2290,12 @@ async fn test_tracked_files_not_ignored(cx: &mut TestAppContext) {
 
     // Add .gitignore and tracked.txt to git (force add tracked.txt since it matches ignore pattern)
     let mut index = repo.index().expect("Failed to get index");
-    index.add_path(Path::new(".gitignore")).expect("Failed to add .gitignore");
-    index.add_path(Path::new("tracked.txt")).expect("Failed to add tracked.txt");
+    index
+        .add_path(Path::new(".gitignore"))
+        .expect("Failed to add .gitignore");
+    index
+        .add_path(Path::new("tracked.txt"))
+        .expect("Failed to add tracked.txt");
     index.write().expect("Failed to write index");
 
     // Commit the tracked files


### PR DESCRIPTION
Fixes #23224

## Problem
When a `.gitignore` file contains `*` (ignore all), Zed incorrectly treats ALL files as ignored, including files explicitly tracked by git (added via `git add -f`). This causes:
- Tracked files to be grayed out in the project panel
- `auto_reveal_entries` to not work for tracked files
- Git status indicators to not display for tracked files

## Solution
Modified the ignore stack logic to check if files are tracked by git before marking them as ignored. Git-tracked files should never be treated as ignored, matching git's actual behavior where `.gitignore` only affects untracked files.

## Changes
- Added `tracked_paths` field to `IgnoreStack` struct
- Modified `is_abs_path_ignored()` to check if a file is tracked before returning true
- Added `get_tracked_files()` function that runs `git ls-files` to get tracked files
- Added test `test_tracked_files_not_ignored` to verify the fix

## Testing
Tested with a repo containing `.gitignore` with `*` and force-added tracked files - tracked files now display normally while untracked files are correctly grayed out.