### PR TITLE
gpui: Unify `track_scroll` method to receive a reference type

### DIFF
--- a/crates/acp_tools/src/acp_tools.rs
+++ b/crates/acp_tools/src/acp_tools.rs
@@ -528,7 +528,7 @@ impl Render for AcpTools {
                                 .with_sizing_behavior(gpui::ListSizingBehavior::Auto)
                                 .size_full(),
                             )
-                            .vertical_scrollbar_for(connection.list_state.clone(), window, cx)
+                            .vertical_scrollbar_for(&connection.list_state, window, cx)
                             .into_any()
                     }
                 }

--- a/crates/agent_ui/src/acp/thread_history.rs
+++ b/crates/agent_ui/src/acp/thread_history.rs
@@ -502,14 +502,10 @@ impl Render for AcpThreadHistory {
                         )
                         .p_1()
                         .pr_4()
-                        .track_scroll(self.scroll_handle.clone())
+                        .track_scroll(&self.scroll_handle)
                         .flex_grow(),
                     )
-                    .vertical_scrollbar_for(
-                        self.scroll_handle.clone(),
-                        window,
-                        cx,
-                    )
+                    .vertical_scrollbar_for(&self.scroll_handle, window, cx)
                 }
             })
     }

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -5896,7 +5896,7 @@ impl Render for AcpThreadView {
                             .flex_grow()
                             .into_any(),
                         )
-                        .vertical_scrollbar_for(self.list_state.clone(), window, cx)
+                        .vertical_scrollbar_for(&self.list_state, window, cx)
                         .into_any()
                     } else {
                         this.child(self.render_recent_history(cx)).into_any()

--- a/crates/agent_ui/src/agent_configuration.rs
+++ b/crates/agent_ui/src/agent_configuration.rs
@@ -1209,7 +1209,7 @@ impl Render for AgentConfiguration {
                             .child(self.render_context_servers_section(window, cx))
                             .child(self.render_provider_configuration_section(cx)),
                     )
-                    .vertical_scrollbar_for(self.scroll_handle.clone(), window, cx),
+                    .vertical_scrollbar_for(&self.scroll_handle, window, cx),
             )
     }
 }

--- a/crates/agent_ui/src/agent_configuration/add_llm_provider_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/add_llm_provider_modal.rs
@@ -516,7 +516,7 @@ impl Render for AddLlmProviderModal {
                     .child(
                         div()
                             .size_full()
-                            .vertical_scrollbar_for(self.scroll_handle.clone(), window, cx)
+                            .vertical_scrollbar_for(&self.scroll_handle, window, cx)
                             .child(
                                 v_flex()
                                     .id("modal_content")

--- a/crates/agent_ui/src/agent_configuration/configure_context_server_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/configure_context_server_modal.rs
@@ -821,7 +821,6 @@ impl ConfigureContextServerModal {
 
 impl Render for ConfigureContextServerModal {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let scroll_handle = self.scroll_handle.clone();
         div()
             .elevation_3(cx)
             .w(rems(34.))
@@ -849,7 +848,7 @@ impl Render for ConfigureContextServerModal {
                                         .id("modal-content")
                                         .max_h(vh(0.7, window))
                                         .overflow_y_scroll()
-                                        .track_scroll(&scroll_handle)
+                                        .track_scroll(&self.scroll_handle)
                                         .child(self.render_modal_description(window, cx))
                                         .child(self.render_modal_content(cx))
                                         .child(match &self.state {
@@ -862,7 +861,7 @@ impl Render for ConfigureContextServerModal {
                                             }
                                         }),
                                 )
-                                .vertical_scrollbar_for(scroll_handle, window, cx),
+                                .vertical_scrollbar_for(&self.scroll_handle, window, cx),
                         ),
                     )
                     .footer(self.render_modal_footer(cx)),

--- a/crates/agent_ui/src/agent_configuration/configure_context_server_tools_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/configure_context_server_tools_modal.rs
@@ -138,7 +138,7 @@ impl ConfigureContextServerToolsModal {
                         items
                     })),
             )
-            .vertical_scrollbar_for(self.scroll_handle.clone(), window, cx)
+            .vertical_scrollbar_for(&self.scroll_handle, window, cx)
             .into_any_element()
     }
 }

--- a/crates/debugger_ui/src/session/running/breakpoint_list.rs
+++ b/crates/debugger_ui/src/session/running/breakpoint_list.rs
@@ -575,7 +575,7 @@ impl BreakpointList {
         )
         .with_horizontal_sizing_behavior(gpui::ListHorizontalSizingBehavior::Unconstrained)
         .with_width_from_item(self.max_width_index)
-        .track_scroll(self.scroll_handle.clone())
+        .track_scroll(&self.scroll_handle)
         .flex_1()
     }
 
@@ -776,7 +776,7 @@ impl Render for BreakpointList {
             .child(self.render_list(cx))
             .custom_scrollbars(
                 ui::Scrollbars::new(ScrollAxes::Both)
-                    .tracked_scroll_handle(self.scroll_handle.clone())
+                    .tracked_scroll_handle(&self.scroll_handle)
                     .with_track_along(ScrollAxes::Both, cx.theme().colors().panel_background)
                     .tracked_entity(cx.entity_id()),
                 window,

--- a/crates/debugger_ui/src/session/running/memory_view.rs
+++ b/crates/debugger_ui/src/session/running/memory_view.rs
@@ -229,7 +229,7 @@ impl MemoryView {
                 rows
             },
         )
-        .track_scroll(view_state.scroll_handle)
+        .track_scroll(&view_state.scroll_handle)
         .with_horizontal_sizing_behavior(ListHorizontalSizingBehavior::Unconstrained)
         .on_scroll_wheel(cx.listener(|this, evt: &ScrollWheelEvent, window, _| {
             let mut view_state = this.view_state();
@@ -921,7 +921,7 @@ impl Render for MemoryView {
                     }))
                     .custom_scrollbars(
                         ui::Scrollbars::new(ui::ScrollAxes::Both)
-                            .tracked_scroll_handle(self.view_state_handle.clone())
+                            .tracked_scroll_handle(&self.view_state_handle)
                             .with_track_along(
                                 ui::ScrollAxes::Both,
                                 cx.theme().colors().panel_background,

--- a/crates/debugger_ui/src/session/running/module_list.rs
+++ b/crates/debugger_ui/src/session/running/module_list.rs
@@ -253,7 +253,7 @@ impl ModuleList {
                 range.map(|ix| this.render_entry(ix, cx)).collect()
             }),
         )
-        .track_scroll(self.scroll_handle.clone())
+        .track_scroll(&self.scroll_handle)
         .size_full()
     }
 }
@@ -279,6 +279,6 @@ impl Render for ModuleList {
             .size_full()
             .p_1()
             .child(self.render_list(window, cx))
-            .vertical_scrollbar_for(self.scroll_handle.clone(), window, cx)
+            .vertical_scrollbar_for(&self.scroll_handle, window, cx)
     }
 }

--- a/crates/debugger_ui/src/session/running/stack_frame_list.rs
+++ b/crates/debugger_ui/src/session/running/stack_frame_list.rs
@@ -913,7 +913,7 @@ impl Render for StackFrameList {
                 )
             })
             .child(self.render_list(window, cx))
-            .vertical_scrollbar_for(self.list_state.clone(), window, cx)
+            .vertical_scrollbar_for(&self.list_state, window, cx)
     }
 }
 

--- a/crates/debugger_ui/src/session/running/variable_list.rs
+++ b/crates/debugger_ui/src/session/running/variable_list.rs
@@ -1557,7 +1557,7 @@ impl Render for VariableList {
                         this.render_entries(range, window, cx)
                     }),
                 )
-                .track_scroll(self.list_handle.clone())
+                .track_scroll(&self.list_handle)
                 .with_width_from_item(self.max_width_index)
                 .with_sizing_behavior(gpui::ListSizingBehavior::Auto)
                 .with_horizontal_sizing_behavior(gpui::ListHorizontalSizingBehavior::Unconstrained)
@@ -1574,10 +1574,10 @@ impl Render for VariableList {
                 )
                 .with_priority(1)
             }))
-            // .vertical_scrollbar_for(self.list_handle.clone(), window, cx)
+            // .vertical_scrollbar_for(&self.list_handle, window, cx)
             .custom_scrollbars(
                 ui::Scrollbars::new(ScrollAxes::Both)
-                    .tracked_scroll_handle(self.list_handle.clone())
+                    .tracked_scroll_handle(&self.list_handle)
                     .with_track_along(ScrollAxes::Both, cx.theme().colors().panel_background)
                     .tracked_entity(cx.entity_id()),
                 window,

--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -933,7 +933,7 @@ impl CompletionsMenu {
         )
         .occlude()
         .max_h(max_height_in_lines as f32 * window.line_height())
-        .track_scroll(self.scroll_handle.clone())
+        .track_scroll(&self.scroll_handle)
         .with_sizing_behavior(ListSizingBehavior::Infer)
         .map(|this| {
             if self.display_options.dynamic_width {
@@ -948,7 +948,7 @@ impl CompletionsMenu {
                 div().child(list).custom_scrollbars(
                     Scrollbars::for_settings::<CompletionMenuScrollBarSetting>()
                         .show_along(ScrollAxes::Vertical)
-                        .tracked_scroll_handle(self.scroll_handle.clone()),
+                        .tracked_scroll_handle(&self.scroll_handle),
                     window,
                     cx,
                 ),
@@ -1599,7 +1599,7 @@ impl CodeActionsMenu {
         )
         .occlude()
         .max_h(max_height_in_lines as f32 * window.line_height())
-        .track_scroll(self.scroll_handle.clone())
+        .track_scroll(&self.scroll_handle)
         .with_width_from_item(
             self.actions
                 .iter()

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -914,7 +914,7 @@ impl InfoPopover {
                 )
                 .custom_scrollbars(
                     Scrollbars::for_settings::<EditorSettings>()
-                        .tracked_scroll_handle(self.scroll_handle.clone()),
+                        .tracked_scroll_handle(&self.scroll_handle),
                     window,
                     cx,
                 )
@@ -1012,7 +1012,7 @@ impl DiagnosticPopover {
                     )
                     .custom_scrollbars(
                         Scrollbars::for_settings::<EditorSettings>()
-                            .tracked_scroll_handle(self.scroll_handle.clone()),
+                            .tracked_scroll_handle(&self.scroll_handle),
                         window,
                         cx,
                     ),

--- a/crates/editor/src/signature_help.rs
+++ b/crates/editor/src/signature_help.rs
@@ -391,7 +391,7 @@ impl SignatureHelpPopover {
                             )
                     }),
             )
-            .vertical_scrollbar_for(self.scroll_handle.clone(), window, cx);
+            .vertical_scrollbar_for(&self.scroll_handle, window, cx);
 
         let controls = if self.signatures.len() > 1 {
             let prev_button = IconButton::new("signature_help_prev", IconName::ChevronUp)

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -1704,12 +1704,12 @@ impl Render for ExtensionsPage {
                 if count == 0 {
                     this.child(self.render_empty_state(cx)).into_any_element()
                 } else {
-                    let scroll_handle = self.list.clone();
+                    let scroll_handle = &self.list;
                     this.child(
                         uniform_list("entries", count, cx.processor(Self::render_extensions))
                             .flex_grow()
                             .pb_4()
-                            .track_scroll(scroll_handle.clone()),
+                            .track_scroll(scroll_handle),
                     )
                     .vertical_scrollbar_for(scroll_handle, window, cx)
                     .into_any_element()

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -3939,7 +3939,7 @@ impl GitPanel {
                             ListHorizontalSizingBehavior::Unconstrained,
                         )
                         .with_width_from_item(self.max_width_item_index)
-                        .track_scroll(self.scroll_handle.clone()),
+                        .track_scroll(&self.scroll_handle),
                     )
                     .on_mouse_down(
                         MouseButton::Right,
@@ -3949,7 +3949,7 @@ impl GitPanel {
                     )
                     .custom_scrollbars(
                         Scrollbars::for_settings::<GitPanelSettings>()
-                            .tracked_scroll_handle(self.scroll_handle.clone())
+                            .tracked_scroll_handle(&self.scroll_handle)
                             .with_track_along(
                                 ScrollAxes::Horizontal,
                                 cx.theme().colors().panel_background,

--- a/crates/gpui/examples/data_table.rs
+++ b/crates/gpui/examples/data_table.rs
@@ -438,7 +438,7 @@ impl Render for DataTable {
                                     }),
                                 )
                                 .size_full()
-                                .track_scroll(self.scroll_handle.clone()),
+                                .track_scroll(&self.scroll_handle),
                             )
                             .child(self.render_scrollbar(window, cx)),
                     ),

--- a/crates/gpui/src/elements/uniform_list.rs
+++ b/crates/gpui/src/elements/uniform_list.rs
@@ -668,9 +668,9 @@ impl UniformList {
     }
 
     /// Track and render scroll state of this list with reference to the given scroll handle.
-    pub fn track_scroll(mut self, handle: UniformListScrollHandle) -> Self {
+    pub fn track_scroll(mut self, handle: &UniformListScrollHandle) -> Self {
         self.interactivity.tracked_scroll_handle = Some(handle.0.borrow().base_handle.clone());
-        self.scroll_handle = Some(handle);
+        self.scroll_handle = Some(handle.clone());
         self
     }
 
@@ -780,7 +780,7 @@ mod test {
                                     .collect()
                             }),
                         )
-                        .track_scroll(self.scroll_handle.clone())
+                        .track_scroll(&self.scroll_handle)
                         .h(px(200.0)),
                     )
             }

--- a/crates/language_tools/src/syntax_tree_view.rs
+++ b/crates/language_tools/src/syntax_tree_view.rs
@@ -507,11 +507,11 @@ impl Render for SyntaxTreeView {
                             }),
                         )
                         .size_full()
-                        .track_scroll(self.list_scroll_handle.clone())
+                        .track_scroll(&self.list_scroll_handle)
                         .text_bg(cx.theme().colors().background)
                         .into_any_element(),
                     )
-                    .vertical_scrollbar_for(self.list_scroll_handle.clone(), window, cx)
+                    .vertical_scrollbar_for(&self.list_scroll_handle, window, cx)
                     .into_any_element()
                 } else {
                     let inner_content = v_flex()

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -889,7 +889,7 @@ impl Element for MarkdownElement {
                                     {
                                         let scrollbars = Scrollbars::new(ScrollAxes::Horizontal)
                                             .id(("markdown-code-block-scrollbar", range.start))
-                                            .tracked_scroll_handle(scroll_handle.clone())
+                                            .tracked_scroll_handle(scroll_handle)
                                             .with_track_along(
                                                 ScrollAxes::Horizontal,
                                                 cx.theme().colors().editor_background,

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -611,6 +611,6 @@ impl Render for MarkdownPreviewView {
                     .size_full(),
                 )
             }))
-            .vertical_scrollbar_for(self.list_state.clone(), window, cx)
+            .vertical_scrollbar_for(&self.list_state, window, cx)
     }
 }

--- a/crates/miniprofiler_ui/src/miniprofiler_ui.rs
+++ b/crates/miniprofiler_ui/src/miniprofiler_ui.rs
@@ -400,10 +400,10 @@ impl Render for ProfilerWindow {
                                 this.autoscroll = false;
                                 cx.notify();
                             }))
-                            .track_scroll(self.scroll_handle.clone())
+                            .track_scroll(&self.scroll_handle)
                             .size_full(),
                         )
-                        .vertical_scrollbar_for(self.scroll_handle.clone(), window, cx),
+                        .vertical_scrollbar_for(&self.scroll_handle, window, cx),
                 )
             })
     }

--- a/crates/onboarding/src/onboarding.rs
+++ b/crates/onboarding/src/onboarding.rs
@@ -350,7 +350,7 @@ impl Render for Onboarding {
                             .child(self.render_page(cx))
                             .track_scroll(&self.scroll_handle),
                     )
-                    .vertical_scrollbar_for(self.scroll_handle.clone(), window, cx),
+                    .vertical_scrollbar_for(&self.scroll_handle, window, cx),
             )
     }
 }

--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -4654,7 +4654,7 @@ impl OutlinePanel {
                 .with_sizing_behavior(ListSizingBehavior::Infer)
                 .with_horizontal_sizing_behavior(ListHorizontalSizingBehavior::Unconstrained)
                 .with_width_from_item(self.max_width_item_index)
-                .track_scroll(self.scroll_handle.clone())
+                .track_scroll(&self.scroll_handle)
                 .when(show_indent_guides, |list| {
                     list.with_decoration(
                         ui::indent_guides(px(indent_size), IndentGuideColors::panel(cx))
@@ -4707,7 +4707,7 @@ impl OutlinePanel {
                 .child(list_contents.size_full().flex_shrink())
                 .custom_scrollbars(
                     Scrollbars::for_settings::<OutlinePanelSettings>()
-                        .tracked_scroll_handle(self.scroll_handle.clone())
+                        .tracked_scroll_handle(&self.scroll_handle.clone())
                         .with_track_along(
                             ScrollAxes::Horizontal,
                             cx.theme().colors().panel_background,

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -780,7 +780,7 @@ impl<D: PickerDelegate> Picker<D> {
             })
             .flex_grow()
             .py_1()
-            .track_scroll(scroll_handle.clone())
+            .track_scroll(&scroll_handle)
             .into_any_element(),
             ElementContainer::List(state) => list(
                 state.clone(),
@@ -866,12 +866,12 @@ impl<D: PickerDelegate> Render for Picker<D> {
 
                             this.map(|this| match &self.element_container {
                                 ElementContainer::List(state) => this.custom_scrollbars(
-                                    base_scrollbar_config.tracked_scroll_handle(state.clone()),
+                                    base_scrollbar_config.tracked_scroll_handle(state),
                                     window,
                                     cx,
                                 ),
                                 ElementContainer::UniformList(state) => this.custom_scrollbars(
-                                    base_scrollbar_config.tracked_scroll_handle(state.clone()),
+                                    base_scrollbar_config.tracked_scroll_handle(state),
                                     window,
                                     cx,
                                 ),

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -5765,7 +5765,7 @@ impl Render for ProjectPanel {
                                 ListHorizontalSizingBehavior::Unconstrained,
                             )
                             .with_width_from_item(self.state.max_width_item_index)
-                            .track_scroll(self.scroll_handle.clone()),
+                            .track_scroll(&self.scroll_handle),
                         )
                         .child(
                             div()
@@ -5908,7 +5908,7 @@ impl Render for ProjectPanel {
                 )
                 .custom_scrollbars(
                     Scrollbars::for_settings::<ProjectPanelSettings>()
-                        .tracked_scroll_handle(self.scroll_handle.clone())
+                        .tracked_scroll_handle(&self.scroll_handle)
                         .with_track_along(
                             ScrollAxes::Horizontal,
                             cx.theme().colors().panel_background,

--- a/crates/recent_projects/src/remote_servers.rs
+++ b/crates/recent_projects/src/remote_servers.rs
@@ -2160,7 +2160,7 @@ impl RemoteServerProjects {
                             )
                             .size_full(),
                         )
-                        .vertical_scrollbar_for(state.scroll_handle, window, cx),
+                        .vertical_scrollbar_for(&state.scroll_handle, window, cx),
                 ),
             )
             .into_any_element()

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -2452,9 +2452,9 @@ impl SettingsWindow {
                             }),
                         )
                         .size_full()
-                        .track_scroll(self.navbar_scroll_handle.clone()),
+                        .track_scroll(&self.navbar_scroll_handle),
                     )
-                    .vertical_scrollbar_for(self.navbar_scroll_handle.clone(), window, cx),
+                    .vertical_scrollbar_for(&self.navbar_scroll_handle, window, cx),
             )
             .child(
                 h_flex()
@@ -3009,10 +3009,10 @@ impl SettingsWindow {
                 window.focus_prev();
             }))
             .when(sub_page_stack().is_empty(), |this| {
-                this.vertical_scrollbar_for(self.list_state.clone(), window, cx)
+                this.vertical_scrollbar_for(&self.list_state, window, cx)
             })
             .when(!sub_page_stack().is_empty(), |this| {
-                this.vertical_scrollbar_for(self.sub_page_scroll_handle.clone(), window, cx)
+                this.vertical_scrollbar_for(&self.sub_page_scroll_handle, window, cx)
             })
             .track_focus(&self.content_focus_handle.focus_handle(cx))
             .pt_6()

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -1118,7 +1118,7 @@ impl Render for TerminalView {
                                     ScrollAxes::Vertical,
                                     cx.theme().colors().editor_background,
                                 )
-                                .tracked_scroll_handle(self.scroll_handle.clone()),
+                                .tracked_scroll_handle(&self.scroll_handle),
                             window,
                             cx,
                         )

--- a/crates/ui/src/components/data_table.rs
+++ b/crates/ui/src/components/data_table.rs
@@ -872,7 +872,7 @@ impl<const COLS: usize> RenderOnce for Table<COLS> {
                                 interaction_state.as_ref(),
                                 |this, state| {
                                     this.track_scroll(
-                                        state.read_with(cx, |s, _| s.scroll_handle.clone()),
+                                        &state.read_with(cx, |s, _| s.scroll_handle.clone()),
                                     )
                                 },
                             ),
@@ -906,7 +906,7 @@ impl<const COLS: usize> RenderOnce for Table<COLS> {
                         .unwrap_or_else(|| Scrollbars::new(super::ScrollAxes::Both));
                     content
                         .custom_scrollbars(
-                            scrollbars.tracked_scroll_handle(state.read(cx).scroll_handle.clone()),
+                            scrollbars.tracked_scroll_handle(&state.read(cx).scroll_handle),
                             window,
                             cx,
                         )

--- a/crates/ui/src/components/scrollbar.rs
+++ b/crates/ui/src/components/scrollbar.rs
@@ -150,9 +150,9 @@ pub trait WithScrollbar: Sized {
     // }
 
     #[track_caller]
-    fn vertical_scrollbar_for<ScrollHandle: ScrollableHandle>(
+    fn vertical_scrollbar_for<ScrollHandle: ScrollableHandle + Clone>(
         self,
-        scroll_handle: ScrollHandle,
+        scroll_handle: &ScrollHandle,
         window: &mut Window,
         cx: &mut App,
     ) -> Self::Output {
@@ -441,7 +441,7 @@ impl<ScrollHandle: ScrollableHandle> Scrollbars<ScrollHandle> {
 
     pub fn tracked_scroll_handle<TrackedHandle: ScrollableHandle>(
         self,
-        tracked_scroll_handle: TrackedHandle,
+        tracked_scroll_handle: &TrackedHandle,
     ) -> Scrollbars<TrackedHandle> {
         let Self {
             id,
@@ -454,7 +454,7 @@ impl<ScrollHandle: ScrollableHandle> Scrollbars<ScrollHandle> {
         } = self;
 
         Scrollbars {
-            scrollable_handle: Handle::Tracked(tracked_scroll_handle),
+            scrollable_handle: Handle::Tracked(tracked_scroll_handle.clone()),
             id,
             tracked_entity: tracked_entity_id,
             visibility,
@@ -968,7 +968,7 @@ impl ScrollableHandle for ScrollHandle {
     }
 }
 
-pub trait ScrollableHandle: 'static + Any + Sized {
+pub trait ScrollableHandle: 'static + Any + Sized + Clone {
     fn max_offset(&self) -> Size<Pixels>;
     fn set_offset(&self, point: Point<Pixels>);
     fn offset(&self) -> Point<Pixels>;

--- a/crates/ui/src/components/tab_bar.rs
+++ b/crates/ui/src/components/tab_bar.rs
@@ -24,8 +24,8 @@ impl TabBar {
         }
     }
 
-    pub fn track_scroll(mut self, scroll_handle: ScrollHandle) -> Self {
-        self.scroll_handle = Some(scroll_handle);
+    pub fn track_scroll(mut self, scroll_handle: &ScrollHandle) -> Self {
+        self.scroll_handle = Some(scroll_handle.clone());
         self
     }
 

--- a/crates/zed/src/zed/component_preview.rs
+++ b/crates/zed/src/zed/component_preview.rs
@@ -627,7 +627,7 @@ impl Render for ComponentPreview {
                                     .collect()
                             }),
                         )
-                        .track_scroll(self.nav_scroll_handle.clone())
+                        .track_scroll(&self.nav_scroll_handle)
                         .p_2p5()
                         .w(px(231.)) // Matches perfectly with the size of the "Component Preview" tab, if that's the first one in the pane
                         .h_full()


### PR DESCRIPTION
Release Notes:

- N/A

This PR to change the `track_scroll` method to receive a reference type like the [Div#track_scroll](https://docs.rs/gpui/latest/gpui/trait.StatefulInteractiveElement.html#method.track_scroll), [Div#track_focus](https://docs.rs/gpui/latest/gpui/trait.InteractiveElement.html#method.track_focus).


```diff
- .track_scroll(self.scroll_handle.clone())
+ .track_scroll(&self.scroll_handle)

- .vertical_scrollbar_for(self.scroll_handle.clone(), window, cx)
+ .vertical_scrollbar_for(&self.scroll_handle, window, cx)
```

https://github.com/zed-industries/zed/blob/56a2f9cfcf0c6a3c38f596b58002953763cd890f/crates/gpui/src/elements/div.rs#L1088-L1093

https://github.com/zed-industries/zed/blob/56a2f9cfcf0c6a3c38f596b58002953763cd890f/crates/gpui/src/elements/div.rs#L613-L620