### PR TITLE
editor: Fix vertical scroll margin not accounting for file header height

### DIFF
--- a/crates/editor/src/scroll/actions.rs
+++ b/crates/editor/src/scroll/actions.rs
@@ -71,14 +71,20 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Editor>,
     ) {
+        let display_snapshot = self.display_snapshot(cx);
         let scroll_margin_rows = self.vertical_scroll_margin() as u32;
         let new_screen_top = self
             .selections
-            .newest_display(&self.display_snapshot(cx))
+            .newest_display(&display_snapshot)
             .head()
             .row()
             .0;
-        let new_screen_top = new_screen_top.saturating_sub(scroll_margin_rows);
+        let header_offset = display_snapshot
+            .buffer_snapshot()
+            .show_headers()
+            .then(|| display_snapshot.buffer_header_height())
+            .unwrap_or(0);
+        let new_screen_top = new_screen_top.saturating_sub(scroll_margin_rows + header_offset);
         self.set_scroll_top_row(DisplayRow(new_screen_top), window, cx);
     }
 


### PR DESCRIPTION
Closes #43178

Release Notes:

- Fixed vertical scroll margin not accounting for file header height

Here's the before/after:

With `{ "vertical_scroll_margin": 0 }` in `~/.config/zed/settings.json`

https://github.com/user-attachments/assets/418c6d7f-de0f-4da6-a038-69927b1b8b88

