### PR TITLE
editor: Do not show scroll thumb if page fits

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -10712,9 +10712,9 @@ impl ScrollbarLayout {
         show_thumb: bool,
         axis: ScrollbarAxis,
     ) -> Self {
-        let text_units_per_page = f64::from(viewport_size / glyph_space);
+        let text_units_per_page = viewport_size.to_f64() / glyph_space.to_f64();
         let visible_range = scroll_position..scroll_position + text_units_per_page;
-        let total_text_units = scroll_range / f64::from(glyph_space);
+        let total_text_units = scroll_range / glyph_space.to_f64();
 
         let thumb_percentage = text_units_per_page / total_text_units;
         let thumb_size = Pixels::from(ScrollOffset::from(track_length) * thumb_percentage)


### PR DESCRIPTION
Follow-up to https://github.com/zed-industries/zed/pull/39367

Release Notes:

- Fixed a small issue where a scrollbar would sometimes show in the editor although the content fix exactly on screen.
