### PR TITLE
languages: Recognize .clangd as YAML

### DIFF
--- a/crates/languages/src/yaml/config.toml
+++ b/crates/languages/src/yaml/config.toml
@@ -1,6 +1,6 @@
 name = "YAML"
 grammar = "yaml"
-path_suffixes = ["yml", "yaml", "pixi.lock", "clang-format"]
+path_suffixes = ["yml", "yaml", "pixi.lock", "clang-format", "clangd"]
 line_comments = ["# "]
 autoclose_before = ",]}"
 brackets = [

--- a/docs/src/languages/c.md
+++ b/docs/src/languages/c.md
@@ -11,6 +11,7 @@ C support is available natively in Zed.
 Clangd out of the box assumes mixed C++/C projects. If you have a C-only project you may wish to instruct clangd to treat all files as C using the `-xc` flag. To do this, create a `.clangd` file in the root of your project with the following:
 
 ```yaml
+# yaml-language-server: $schema=https://json.schemastore.org/clangd.json
 CompileFlags:
   Add: [-xc]
 ```

--- a/docs/src/languages/cpp.md
+++ b/docs/src/languages/cpp.md
@@ -78,6 +78,7 @@ You can pass any number of arguments to clangd. To see a full set of available o
 By default Zed will use the `clangd` language server for formatting C++ code. The Clangd is the same as the `clang-format` CLI tool. To configure this you can add a `.clang-format` file. For example:
 
 ```yaml
+# yaml-language-server: $schema=https://json.schemastore.org/clang-format-21.x.json
 ---
 BasedOnStyle: LLVM
 IndentWidth: 4
@@ -106,7 +107,8 @@ You can trigger formatting via {#kb editor::Format} or the `editor: format` acti
 
 In the root of your project, it is generally common to create a `.clangd` file to set extra configuration.
 
-```text
+```yaml
+# yaml-language-server: $schema=https://json.schemastore.org/clangd.json
 CompileFlags:
   Add:
     - "--include-directory=/path/to/include"


### PR DESCRIPTION
Follow-up to: https://github.com/zed-industries/zed/pull/43469

Thanks @WeetHet for [the idea]([WeetHet](https://github.com/WeetHet)).

Release Notes:

- Added support for identifying. .clangd files as YAML by default