### PR TITLE
buffer_search: Fix replace buttons not working if search bar is not focused

### DIFF
--- a/crates/search/src/search_bar.rs
+++ b/crates/search/src/search_bar.rs
@@ -29,7 +29,7 @@ pub(super) fn render_action_button(
             if !focus_handle.is_focused(window) {
                 window.focus(&focus_handle);
             }
-            window.dispatch_action(action.boxed_clone(), cx)
+            window.dispatch_action(action.boxed_clone(), cx);
         }
     })
     .tooltip(move |_window, cx| Tooltip::for_action_in(tooltip, action, &focus_handle, cx))


### PR DESCRIPTION
Update the way that both
`search::buffer_search::BufferSearchBar.replace_next` and `search::buffer_search::BufferSearchBar.replace_all` are registered as listeners, so that we don't require the replacement editor to be focused in order for these listeners to be active, only requiring the replacement mode to be active in the buffer search bar.

This means that, even if the user is focused on the buffer editor, if the "Replace Next Match" or "Replace All Matches" buttons are clicked, the replacement will be performed.

Closes #42471 

Release Notes:

- Fixed issue with buffer search bar where the replacement buttons ("Replace Next Match" & "Replace All Matches") wouldn't work if search bar was not focused
