### PR TITLE
checkbox: Fix showing cursor pointer for edge of the checkbox when it's disabled

### DIFF
--- a/crates/ui/src/components/toggle.rs
+++ b/crates/ui/src/components/toggle.rs
@@ -247,7 +247,13 @@ impl RenderOnce for Checkbox {
 
         h_flex()
             .id(self.id)
-            .cursor_pointer()
+            .map(|this| {
+                if self.disabled {
+                    this.cursor_not_allowed()
+                } else {
+                    this.cursor_pointer()
+                }
+            })
             .gap(DynamicSpacing::Base06.rems(cx))
             .child(checkbox)
             .when_some(


### PR DESCRIPTION
This PR fixes that you saw the cursor pointer for disabled checkbox. This is only for the edge of the checkbox component, because we didn't check for the disabled case.

**Before**

https://github.com/user-attachments/assets/cfebad01-533b-4515-b8d9-4bcb839eaec4

**After**

https://github.com/user-attachments/assets/969600de-081b-42df-a288-ca3db5758d12

Release Notes:

- N/A
