### PR TITLE
edit prediction: Report early-rejected predictions and fix cancel bug

### DIFF
--- a/crates/cloud_llm_client/src/cloud_llm_client.rs
+++ b/crates/cloud_llm_client/src/cloud_llm_client.rs
@@ -200,7 +200,7 @@ pub struct RejectEditPredictionsBody {
     pub rejections: Vec<EditPredictionRejection>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct EditPredictionRejection {
     pub request_id: String,
     pub was_shown: bool,

--- a/crates/cloud_llm_client/src/cloud_llm_client.rs
+++ b/crates/cloud_llm_client/src/cloud_llm_client.rs
@@ -203,7 +203,26 @@ pub struct RejectEditPredictionsBody {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct EditPredictionRejection {
     pub request_id: String,
+    #[serde(default)]
+    pub reason: EditPredictionRejectReason,
     pub was_shown: bool,
+}
+
+#[derive(Default, Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+pub enum EditPredictionRejectReason {
+    /// New requests were triggered before this one completed
+    Canceled,
+    /// No edits returned
+    Empty,
+    /// Edits returned, but none remained after interpolation
+    InterpolatedEmpty,
+    /// The new prediction was preferred over the current one
+    Replaced,
+    /// The current prediction was preferred over the new one
+    CurrentPreferred,
+    /// The current prediction was discarded
+    #[default]
+    Discarded,
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Serialize, Deserialize)]

--- a/crates/zeta/src/provider.rs
+++ b/crates/zeta/src/provider.rs
@@ -1,6 +1,7 @@
 use std::{cmp, sync::Arc, time::Duration};
 
 use client::{Client, UserStore};
+use cloud_llm_client::EditPredictionRejectReason;
 use edit_prediction::{DataCollectionState, Direction, EditPredictionProvider};
 use gpui::{App, Entity, prelude::*};
 use language::ToPoint as _;
@@ -132,7 +133,11 @@ impl EditPredictionProvider for ZetaEditPredictionProvider {
 
     fn discard(&mut self, cx: &mut Context<Self>) {
         self.zeta.update(cx, |zeta, cx| {
-            zeta.discard_current_prediction(&self.project, cx);
+            zeta.reject_current_prediction(
+                EditPredictionRejectReason::Discarded,
+                &self.project,
+                cx,
+            );
         });
     }
 
@@ -169,7 +174,11 @@ impl EditPredictionProvider for ZetaEditPredictionProvider {
 
         let Some(edits) = prediction.interpolate(&snapshot) else {
             self.zeta.update(cx, |zeta, cx| {
-                zeta.discard_current_prediction(&self.project, cx);
+                zeta.reject_current_prediction(
+                    EditPredictionRejectReason::InterpolatedEmpty,
+                    &self.project,
+                    cx,
+                );
             });
             return None;
         };

--- a/crates/zeta/src/sweep_ai.rs
+++ b/crates/zeta/src/sweep_ai.rs
@@ -18,7 +18,7 @@ use std::{
     time::Instant,
 };
 
-use crate::{EditPrediction, EditPredictionId, EditPredictionInputs};
+use crate::{EditPredictionId, EditPredictionInputs, prediction::EditPredictionResult};
 
 const SWEEP_API_URL: &str = "https://autocomplete.sweep.dev/backend/next_edit_autocomplete";
 
@@ -45,7 +45,7 @@ impl SweepAi {
         recent_paths: &VecDeque<ProjectPath>,
         diagnostic_search_range: Range<Point>,
         cx: &mut App,
-    ) -> Task<Result<Option<EditPrediction>>> {
+    ) -> Task<Result<Option<EditPredictionResult>>> {
         let debug_info = self.debug_info.clone();
         let Some(api_token) = self.api_token.clone() else {
             return Task::ready(Ok(None));
@@ -242,8 +242,8 @@ impl SweepAi {
 
         cx.spawn(async move |cx| {
             let (id, edits, old_snapshot, response_received_at, inputs) = result.await?;
-            anyhow::Ok(
-                EditPrediction::new(
+            anyhow::Ok(Some(
+                EditPredictionResult::new(
                     EditPredictionId(id.into()),
                     &buffer,
                     &old_snapshot,
@@ -254,7 +254,7 @@ impl SweepAi {
                     cx,
                 )
                 .await,
-            )
+            ))
         })
     }
 }

--- a/crates/zeta/src/zeta.rs
+++ b/crates/zeta/src/zeta.rs
@@ -3,9 +3,9 @@ use arrayvec::ArrayVec;
 use client::{Client, EditPredictionUsage, UserStore};
 use cloud_llm_client::predict_edits_v3::{self, Event, PromptFormat, Signature};
 use cloud_llm_client::{
-    AcceptEditPredictionBody, EXPIRED_LLM_TOKEN_HEADER_NAME, EditPredictionRejection,
-    MAX_EDIT_PREDICTION_REJECTIONS_PER_REQUEST, MINIMUM_REQUIRED_VERSION_HEADER_NAME,
-    RejectEditPredictionsBody, ZED_VERSION_HEADER_NAME,
+    AcceptEditPredictionBody, EXPIRED_LLM_TOKEN_HEADER_NAME, EditPredictionRejectReason,
+    EditPredictionRejection, MAX_EDIT_PREDICTION_REJECTIONS_PER_REQUEST,
+    MINIMUM_REQUIRED_VERSION_HEADER_NAME, RejectEditPredictionsBody, ZED_VERSION_HEADER_NAME,
 };
 use cloud_zeta2_prompt::retrieval_prompt::{SearchToolInput, SearchToolQuery};
 use cloud_zeta2_prompt::{CURSOR_MARKER, DEFAULT_MAX_PROMPT_BYTES};
@@ -74,6 +74,7 @@ use crate::onboarding_modal::ZedPredictModal;
 pub use crate::prediction::EditPrediction;
 pub use crate::prediction::EditPredictionId;
 pub use crate::prediction::EditPredictionInputs;
+use crate::prediction::EditPredictionResult;
 use crate::rate_prediction_modal::{
     NextEdit, PreviousEdit, RatePredictionsModal, ThumbsDownActivePrediction,
     ThumbsUpActivePrediction,
@@ -324,7 +325,12 @@ impl ZetaProject {
             };
 
             this.update(cx, |this, cx| {
-                this.discard_prediction(prediction_id, false, cx);
+                this.reject_prediction(
+                    prediction_id,
+                    EditPredictionRejectReason::Canceled,
+                    false,
+                    cx,
+                );
             })
             .ok();
         })
@@ -371,7 +377,7 @@ impl CurrentEditPrediction {
         {
             let (old_range, old_text) = &old_edits[0];
             let (new_range, new_text) = &new_edits[0];
-            new_range == old_range && new_text.starts_with(old_text.as_ref())
+            dbg!(new_range == old_range) && dbg!(new_text.starts_with(old_text.as_ref()))
         } else {
             true
         }
@@ -937,11 +943,16 @@ impl Zeta {
         })
     }
 
-    fn discard_current_prediction(&mut self, project: &Entity<Project>, cx: &mut Context<Self>) {
+    fn reject_current_prediction(
+        &mut self,
+        reason: EditPredictionRejectReason,
+        project: &Entity<Project>,
+        cx: &mut Context<Self>,
+    ) {
         if let Some(project_state) = self.projects.get_mut(&project.entity_id()) {
             project_state.pending_predictions.clear();
             if let Some(prediction) = project_state.current_prediction.take() {
-                self.discard_prediction(prediction.prediction.id, prediction.was_shown, cx);
+                self.reject_prediction(prediction.prediction.id, reason, prediction.was_shown, cx);
             }
         };
     }
@@ -962,14 +973,16 @@ impl Zeta {
         }
     }
 
-    fn discard_prediction(
+    fn reject_prediction(
         &mut self,
         prediction_id: EditPredictionId,
+        reason: EditPredictionRejectReason,
         was_shown: bool,
         cx: &mut Context<Self>,
     ) {
         self.rejected_predictions.push(EditPredictionRejection {
             request_id: prediction_id.to_string(),
+            reason,
             was_shown,
         });
 
@@ -977,10 +990,10 @@ impl Zeta {
             self.rejected_predictions.len() >= MAX_EDIT_PREDICTION_REJECTIONS_PER_REQUEST;
         let reject_tx = self.reject_predictions_tx.clone();
         self.reject_predictions_debounce_task = Some(cx.spawn(async move |_this, cx| {
-            const DISCARD_COMPLETIONS_DEBOUNCE: Duration = Duration::from_secs(15);
+            const REJECT_REQUEST_DEBOUNCE: Duration = Duration::from_secs(15);
             if !reached_request_limit {
                 cx.background_executor()
-                    .timer(DISCARD_COMPLETIONS_DEBOUNCE)
+                    .timer(REJECT_REQUEST_DEBOUNCE)
                     .await;
             }
             reject_tx.unbounded_send(()).log_err();
@@ -1010,36 +1023,15 @@ impl Zeta {
                 return Task::ready(anyhow::Ok(None));
             };
 
-            let project = project.clone();
-            cx.spawn(async move |cx| {
-                if let Some(prediction) = request_task.await? {
-                    this.update(cx, |this, cx| {
-                        let project_state = this
-                            .projects
-                            .get_mut(&project.entity_id())
-                            .context("Project not found")?;
-
-                        let new_prediction = CurrentEditPrediction {
-                            requested_by: PredictionRequestedBy::Buffer(buffer.entity_id()),
-                            prediction: prediction,
-                            was_shown: false,
-                        };
-
-                        if project_state
-                            .current_prediction
-                            .as_ref()
-                            .is_none_or(|old_prediction| {
-                                new_prediction.should_replace_prediction(&old_prediction, cx)
-                            })
-                        {
-                            anyhow::Ok(Some(new_prediction))
-                        } else {
-                            anyhow::Ok(None)
-                        }
-                    })?
-                } else {
-                    Ok(None)
-                }
+            cx.spawn(async move |_cx| {
+                request_task.await.map(|prediction_result| {
+                    prediction_result.map(|prediction_result| {
+                        (
+                            prediction_result,
+                            PredictionRequestedBy::Buffer(buffer.entity_id()),
+                        )
+                    })
+                })
             })
         })
     }
@@ -1089,7 +1081,7 @@ impl Zeta {
                     return anyhow::Ok(None);
                 };
 
-                let Some(prediction) = this
+                let Some(prediction_result) = this
                     .update(cx, |this, cx| {
                         this.request_prediction(&project, &jump_buffer, jump_position, cx)
                     })?
@@ -1099,19 +1091,21 @@ impl Zeta {
                 };
 
                 this.update(cx, |this, cx| {
-                    if this
-                        .get_or_init_zeta_project(&project, cx)
-                        .current_prediction
-                        .is_none()
-                    {
-                        Some(CurrentEditPrediction {
-                            requested_by: PredictionRequestedBy::DiagnosticsUpdate,
-                            prediction,
-                            was_shown: false,
-                        })
-                    } else {
-                        None
-                    }
+                    Some((
+                        if this
+                            .get_or_init_zeta_project(&project, cx)
+                            .current_prediction
+                            .is_none()
+                        {
+                            prediction_result
+                        } else {
+                            EditPredictionResult {
+                                id: prediction_result.id,
+                                prediction: Err(EditPredictionRejectReason::CurrentPreferred),
+                            }
+                        },
+                        PredictionRequestedBy::DiagnosticsUpdate,
+                    ))
                 })
             })
         });
@@ -1130,7 +1124,8 @@ impl Zeta {
         do_refresh: impl FnOnce(
             WeakEntity<Self>,
             &mut AsyncApp,
-        ) -> Task<Result<Option<CurrentEditPrediction>>>
+        )
+            -> Task<Result<Option<(EditPredictionResult, PredictionRequestedBy)>>>
         + 'static,
     ) {
         let zeta_project = self.get_or_init_zeta_project(&project, cx);
@@ -1165,21 +1160,69 @@ impl Zeta {
                 return None;
             }
 
-            let new_prediction = do_refresh(this.clone(), cx).await.log_err().flatten();
-            let new_prediction_id = new_prediction
+            let new_prediction_result = do_refresh(this.clone(), cx).await.log_err().flatten();
+            let new_prediction_id = new_prediction_result
                 .as_ref()
-                .map(|prediction| prediction.prediction.id.clone());
+                .map(|(prediction, _)| prediction.id.clone());
 
             // When a prediction completes, remove it from the pending list, and cancel
             // any pending predictions that were enqueued before it.
             this.update(cx, |this, cx| {
                 let zeta_project = this.get_or_init_zeta_project(&project, cx);
 
-                if !zeta_project
+                let is_cancelled = zeta_project
                     .cancelled_predictions
-                    .remove(&pending_prediction_id)
+                    .remove(&pending_prediction_id);
+
+                let new_current_prediction = if !is_cancelled
+                    && let Some((prediction_result, requested_by)) = new_prediction_result
                 {
-                    zeta_project.current_prediction = new_prediction;
+                    match prediction_result.prediction {
+                        Ok(prediction) => {
+                            let new_prediction = CurrentEditPrediction {
+                                requested_by,
+                                prediction,
+                                was_shown: false,
+                            };
+
+                            if let Some(current_prediction) =
+                                zeta_project.current_prediction.as_ref()
+                            {
+                                if new_prediction.should_replace_prediction(&current_prediction, cx)
+                                {
+                                    this.reject_current_prediction(
+                                        EditPredictionRejectReason::Replaced,
+                                        &project,
+                                        cx,
+                                    );
+
+                                    Some(new_prediction)
+                                } else {
+                                    this.reject_prediction(
+                                        new_prediction.prediction.id,
+                                        EditPredictionRejectReason::CurrentPreferred,
+                                        false,
+                                        cx,
+                                    );
+                                    None
+                                }
+                            } else {
+                                Some(new_prediction)
+                            }
+                        }
+                        Err(reject_reason) => {
+                            this.reject_prediction(prediction_result.id, reject_reason, false, cx);
+                            None
+                        }
+                    }
+                } else {
+                    None
+                };
+
+                let zeta_project = this.get_or_init_zeta_project(&project, cx);
+
+                if let Some(new_prediction) = new_current_prediction {
+                    zeta_project.current_prediction = Some(new_prediction);
                 }
 
                 let mut pending_predictions = mem::take(&mut zeta_project.pending_predictions);
@@ -1222,7 +1265,7 @@ impl Zeta {
         active_buffer: &Entity<Buffer>,
         position: language::Anchor,
         cx: &mut Context<Self>,
-    ) -> Task<Result<Option<EditPrediction>>> {
+    ) -> Task<Result<Option<EditPredictionResult>>> {
         self.request_prediction_internal(
             project.clone(),
             active_buffer.clone(),
@@ -1239,7 +1282,7 @@ impl Zeta {
         position: language::Anchor,
         allow_jump: bool,
         cx: &mut Context<Self>,
-    ) -> Task<Result<Option<EditPrediction>>> {
+    ) -> Task<Result<Option<EditPredictionResult>>> {
         const DIAGNOSTIC_LINES_RANGE: u32 = 20;
 
         self.get_or_init_zeta_project(&project, cx);
@@ -1285,9 +1328,7 @@ impl Zeta {
         };
 
         cx.spawn(async move |this, cx| {
-            let prediction = task
-                .await?
-                .filter(|prediction| !prediction.edits.is_empty());
+            let prediction = task.await?;
 
             if prediction.is_none() && allow_jump {
                 let cursor_point = position.to_point(&snapshot);
@@ -1409,7 +1450,7 @@ impl Zeta {
         position: language::Anchor,
         events: Vec<Arc<Event>>,
         cx: &mut Context<Self>,
-    ) -> Task<Result<Option<EditPrediction>>> {
+    ) -> Task<Result<Option<EditPredictionResult>>> {
         let project_state = self.projects.get(&project.entity_id());
 
         let index_state = project_state.and_then(|state| {
@@ -1706,7 +1747,7 @@ impl Zeta {
                 let (res, usage) = response?;
                 let request_id = EditPredictionId(res.id.clone().into());
                 let Some(mut output_text) = text_from_response(res) else {
-                    return Ok((None, usage));
+                    return Ok((Some((request_id, None)), usage));
                 };
 
                 if output_text.contains(CURSOR_MARKER) {
@@ -1764,11 +1805,13 @@ impl Zeta {
                 anyhow::Ok((
                     Some((
                         request_id,
-                        inputs,
-                        edited_buffer,
-                        edited_buffer_snapshot.clone(),
-                        edits,
-                        received_response_at,
+                        Some((
+                            inputs,
+                            edited_buffer,
+                            edited_buffer_snapshot.clone(),
+                            edits,
+                            received_response_at,
+                        )),
                     )),
                     usage,
                 ))
@@ -1777,30 +1820,40 @@ impl Zeta {
 
         cx.spawn({
             async move |this, cx| {
+                let Some((id, prediction)) =
+                    Self::handle_api_response(&this, request_task.await, cx)?
+                else {
+                    return Ok(None);
+                };
+
                 let Some((
-                    id,
                     inputs,
                     edited_buffer,
                     edited_buffer_snapshot,
                     edits,
                     received_response_at,
-                )) = Self::handle_api_response(&this, request_task.await, cx)?
+                )) = prediction
                 else {
-                    return Ok(None);
+                    return Ok(Some(EditPredictionResult {
+                        id,
+                        prediction: Err(EditPredictionRejectReason::Empty),
+                    }));
                 };
 
                 // TODO telemetry: duration, etc
-                Ok(EditPrediction::new(
-                    id,
-                    &edited_buffer,
-                    &edited_buffer_snapshot,
-                    edits.into(),
-                    buffer_snapshotted_at,
-                    received_response_at,
-                    inputs,
-                    cx,
-                )
-                .await)
+                Ok(Some(
+                    EditPredictionResult::new(
+                        id,
+                        &edited_buffer,
+                        &edited_buffer_snapshot,
+                        edits.into(),
+                        buffer_snapshotted_at,
+                        received_response_at,
+                        inputs,
+                        cx,
+                    )
+                    .await,
+                ))
             }
         })
     }
@@ -2823,7 +2876,9 @@ mod tests {
 
     use client::UserStore;
     use clock::FakeSystemClock;
-    use cloud_llm_client::{EditPredictionRejection, RejectEditPredictionsBody};
+    use cloud_llm_client::{
+        EditPredictionRejectReason, EditPredictionRejection, RejectEditPredictionsBody,
+    };
     use cloud_zeta2_prompt::retrieval_prompt::{SearchToolInput, SearchToolQuery};
     use futures::{
         AsyncReadExt, StreamExt,
@@ -2947,7 +3002,7 @@ mod tests {
         refresh_task.await.unwrap();
 
         zeta.update(cx, |zeta, cx| {
-            zeta.discard_current_prediction(&project, cx);
+            zeta.reject_current_prediction(EditPredictionRejectReason::Discarded, &project, cx);
         });
 
         // Prediction for another file
@@ -3047,7 +3102,7 @@ mod tests {
             "}))
             .unwrap();
 
-        let prediction = prediction_task.await.unwrap().unwrap();
+        let prediction = prediction_task.await.unwrap().unwrap().prediction.unwrap();
 
         assert_eq!(prediction.edits.len(), 1);
         assert_eq!(
@@ -3121,7 +3176,7 @@ mod tests {
             "#}))
             .unwrap();
 
-        let prediction = prediction_task.await.unwrap().unwrap();
+        let prediction = prediction_task.await.unwrap().unwrap().prediction.unwrap();
 
         assert_eq!(prediction.edits.len(), 1);
         assert_eq!(
@@ -3129,6 +3184,70 @@ mod tests {
             language::Point::new(1, 3)
         );
         assert_eq!(prediction.edits[0].1.as_ref(), " are you?");
+    }
+
+    #[gpui::test]
+    async fn test_empty_prediction(cx: &mut TestAppContext) {
+        let (zeta, mut requests) = init_test(cx);
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            "/root",
+            json!({
+                "foo.md":  "Hello!\nHow\nBye\n"
+            }),
+        )
+        .await;
+        let project = Project::test(fs, vec![path!("/root").as_ref()], cx).await;
+
+        let buffer = project
+            .update(cx, |project, cx| {
+                let path = project.find_project_path(path!("root/foo.md"), cx).unwrap();
+                project.open_buffer(path, cx)
+            })
+            .await
+            .unwrap();
+        let snapshot = buffer.read_with(cx, |buffer, _cx| buffer.snapshot());
+        let position = snapshot.anchor_before(language::Point::new(1, 3));
+
+        zeta.update(cx, |zeta, cx| {
+            zeta.refresh_prediction_from_buffer(project.clone(), buffer.clone(), position, cx);
+        });
+
+        const NO_OP_DIFF: &str = indoc! { r"
+            --- a/root/foo.md
+            +++ b/root/foo.md
+            @@ ... @@
+             Hello!
+            -How
+            +How
+             Bye
+        "};
+
+        let (_, respond_tx) = requests.predict.next().await.unwrap();
+        let response = model_response(NO_OP_DIFF);
+        let id = response.id.clone();
+        respond_tx.send(response).unwrap();
+
+        cx.run_until_parked();
+
+        zeta.read_with(cx, |zeta, cx| {
+            assert!(
+                zeta.current_prediction_for_buffer(&buffer, &project, cx)
+                    .is_none()
+            );
+        });
+
+        // second is reported as rejected
+        let (reject_request, _) = requests.reject.next().await.unwrap();
+
+        assert_eq!(
+            &reject_request.rejections,
+            &[EditPredictionRejection {
+                request_id: id,
+                reason: EditPredictionRejectReason::Empty,
+                was_shown: false
+            }]
+        );
     }
 
     const SIMPLE_DIFF: &str = indoc! { r"
@@ -3221,6 +3340,176 @@ mod tests {
             &reject_request.rejections,
             &[EditPredictionRejection {
                 request_id: first_id,
+                reason: EditPredictionRejectReason::Canceled,
+                was_shown: false
+            }]
+        );
+    }
+
+    #[gpui::test]
+    async fn test_replace_current(cx: &mut TestAppContext) {
+        let (zeta, mut requests) = init_test(cx);
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            "/root",
+            json!({
+                "foo.md":  "Hello!\nHow\nBye\n"
+            }),
+        )
+        .await;
+        let project = Project::test(fs, vec![path!("/root").as_ref()], cx).await;
+
+        let buffer = project
+            .update(cx, |project, cx| {
+                let path = project.find_project_path(path!("root/foo.md"), cx).unwrap();
+                project.open_buffer(path, cx)
+            })
+            .await
+            .unwrap();
+        let snapshot = buffer.read_with(cx, |buffer, _cx| buffer.snapshot());
+        let position = snapshot.anchor_before(language::Point::new(1, 3));
+
+        zeta.update(cx, |zeta, cx| {
+            zeta.refresh_prediction_from_buffer(project.clone(), buffer.clone(), position, cx);
+        });
+
+        let (_, respond_tx) = requests.predict.next().await.unwrap();
+        let first_response = model_response(SIMPLE_DIFF);
+        let first_id = first_response.id.clone();
+        respond_tx.send(first_response).unwrap();
+
+        cx.run_until_parked();
+
+        zeta.read_with(cx, |zeta, cx| {
+            assert_eq!(
+                zeta.current_prediction_for_buffer(&buffer, &project, cx)
+                    .unwrap()
+                    .id
+                    .0,
+                first_id
+            );
+        });
+
+        // a second request is triggered
+        zeta.update(cx, |zeta, cx| {
+            zeta.refresh_prediction_from_buffer(project.clone(), buffer.clone(), position, cx);
+        });
+
+        let (_, respond_tx) = requests.predict.next().await.unwrap();
+        let second_response = model_response(SIMPLE_DIFF);
+        let second_id = second_response.id.clone();
+        respond_tx.send(second_response).unwrap();
+
+        cx.run_until_parked();
+
+        zeta.read_with(cx, |zeta, cx| {
+            // second replaces first
+            assert_eq!(
+                zeta.current_prediction_for_buffer(&buffer, &project, cx)
+                    .unwrap()
+                    .id
+                    .0,
+                second_id
+            );
+        });
+
+        // first is reported as replaced
+        let (reject_request, _) = requests.reject.next().await.unwrap();
+
+        assert_eq!(
+            &reject_request.rejections,
+            &[EditPredictionRejection {
+                request_id: first_id,
+                reason: EditPredictionRejectReason::Replaced,
+                was_shown: false
+            }]
+        );
+    }
+
+    #[gpui::test]
+    async fn test_current_preferred(cx: &mut TestAppContext) {
+        let (zeta, mut requests) = init_test(cx);
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            "/root",
+            json!({
+                "foo.md":  "Hello!\nHow\nBye\n"
+            }),
+        )
+        .await;
+        let project = Project::test(fs, vec![path!("/root").as_ref()], cx).await;
+
+        let buffer = project
+            .update(cx, |project, cx| {
+                let path = project.find_project_path(path!("root/foo.md"), cx).unwrap();
+                project.open_buffer(path, cx)
+            })
+            .await
+            .unwrap();
+        let snapshot = buffer.read_with(cx, |buffer, _cx| buffer.snapshot());
+        let position = snapshot.anchor_before(language::Point::new(1, 3));
+
+        zeta.update(cx, |zeta, cx| {
+            zeta.refresh_prediction_from_buffer(project.clone(), buffer.clone(), position, cx);
+        });
+
+        let (_, respond_tx) = requests.predict.next().await.unwrap();
+        let first_response = model_response(SIMPLE_DIFF);
+        let first_id = first_response.id.clone();
+        respond_tx.send(first_response).unwrap();
+
+        cx.run_until_parked();
+
+        zeta.read_with(cx, |zeta, cx| {
+            assert_eq!(
+                zeta.current_prediction_for_buffer(&buffer, &project, cx)
+                    .unwrap()
+                    .id
+                    .0,
+                first_id
+            );
+        });
+
+        // a second request is triggered
+        zeta.update(cx, |zeta, cx| {
+            zeta.refresh_prediction_from_buffer(project.clone(), buffer.clone(), position, cx);
+        });
+
+        let (_, respond_tx) = requests.predict.next().await.unwrap();
+        // worse than current prediction
+        let second_response = model_response(indoc! { r"
+            --- a/root/foo.md
+            +++ b/root/foo.md
+            @@ ... @@
+             Hello!
+            -How
+            +How are
+             Bye
+        "});
+        let second_id = second_response.id.clone();
+        respond_tx.send(second_response).unwrap();
+
+        cx.run_until_parked();
+
+        zeta.read_with(cx, |zeta, cx| {
+            // first is preferred over second
+            assert_eq!(
+                zeta.current_prediction_for_buffer(&buffer, &project, cx)
+                    .unwrap()
+                    .id
+                    .0,
+                first_id
+            );
+        });
+
+        // second is reported as rejected
+        let (reject_request, _) = requests.reject.next().await.unwrap();
+
+        assert_eq!(
+            &reject_request.rejections,
+            &[EditPredictionRejection {
+                request_id: second_id,
+                reason: EditPredictionRejectReason::CurrentPreferred,
                 was_shown: false
             }]
         );
@@ -3282,7 +3571,7 @@ mod tests {
         let (_, respond_third) = requests.predict.next().await.unwrap();
 
         let first_response = model_response(SIMPLE_DIFF);
-        let first_response_id = first_response.id.clone();
+        let first_id = first_response.id.clone();
         respond_first.send(first_response).unwrap();
 
         cx.run_until_parked();
@@ -3294,7 +3583,7 @@ mod tests {
                     .unwrap()
                     .id
                     .0,
-                first_response_id
+                first_id
             );
         });
 
@@ -3311,7 +3600,7 @@ mod tests {
                     .unwrap()
                     .id
                     .0,
-                first_response_id
+                first_id
             );
         });
 
@@ -3339,10 +3628,18 @@ mod tests {
 
         assert_eq!(
             &reject_request.rejections,
-            &[EditPredictionRejection {
-                request_id: cancelled_id,
-                was_shown: false
-            }]
+            &[
+                EditPredictionRejection {
+                    request_id: cancelled_id,
+                    reason: EditPredictionRejectReason::Canceled,
+                    was_shown: false
+                },
+                EditPredictionRejection {
+                    request_id: first_id,
+                    reason: EditPredictionRejectReason::Replaced,
+                    was_shown: false
+                }
+            ]
         );
     }
 

--- a/crates/zeta/src/zeta.rs
+++ b/crates/zeta/src/zeta.rs
@@ -377,7 +377,7 @@ impl CurrentEditPrediction {
         {
             let (old_range, old_text) = &old_edits[0];
             let (new_range, new_text) = &new_edits[0];
-            dbg!(new_range == old_range) && dbg!(new_text.starts_with(old_text.as_ref()))
+            new_range == old_range && new_text.starts_with(old_text.as_ref())
         } else {
             true
         }

--- a/crates/zeta/src/zeta.rs
+++ b/crates/zeta/src/zeta.rs
@@ -506,7 +506,7 @@ impl Zeta {
         let (reject_tx, mut reject_rx) = mpsc::unbounded();
         cx.spawn(async move |this, cx| {
             while let Some(()) = reject_rx.next().await {
-                this.update(cx, |this, cx| this.reject_edit_predictions(cx))?
+                this.update(cx, |this, cx| this.flush_rejected_predictions(cx))?
                     .await
                     .log_err();
             }
@@ -895,7 +895,7 @@ impl Zeta {
         .detach_and_log_err(cx);
     }
 
-    fn reject_edit_predictions(&mut self, cx: &mut Context<Self>) -> Task<Result<()>> {
+    fn flush_rejected_predictions(&mut self, cx: &mut Context<Self>) -> Task<Result<()>> {
         match self.edit_prediction_model {
             ZetaEditPredictionModel::Zeta1 | ZetaEditPredictionModel::Zeta2 => {}
             ZetaEditPredictionModel::Sweep => return Task::ready(anyhow::Ok(())),

--- a/crates/zeta/src/zeta_tests.rs
+++ b/crates/zeta/src/zeta_tests.rs
@@ -538,7 +538,7 @@ async fn run_edit_prediction(
     let prediction_task = zeta.update(cx, |zeta, cx| {
         zeta.request_prediction(&project, buffer, cursor, cx)
     });
-    prediction_task.await.unwrap().unwrap()
+    prediction_task.await.unwrap().unwrap().prediction.unwrap()
 }
 
 async fn make_test_zeta(

--- a/crates/zeta_cli/src/predict.rs
+++ b/crates/zeta_cli/src/predict.rs
@@ -235,7 +235,10 @@ pub async fn perform_predict(
     let mut result = Arc::into_inner(result).unwrap().into_inner().unwrap();
 
     result.diff = prediction
-        .and_then(|prediction| prediction.edit_preview.as_unified_diff(&prediction.edits))
+        .and_then(|prediction| {
+            let prediction = prediction.prediction.ok()?;
+            prediction.edit_preview.as_unified_diff(&prediction.edits)
+        })
         .unwrap_or_default();
 
     anyhow::Ok(result)


### PR DESCRIPTION
Many prediction requests end up being rejected early without ever being set as the current prediction. Before this change, those cases weren’t reported as rejections because the `request_prediction_with_*` functions simply returned `Ok(None)`.

With this update, whenever we get a successful response from the provider, we will return at least the `id`, allowing it to be properly reported. The request now also includes a “reject reason,” since the different variants carry distinct implications for prediction quality.

All of these scenarios are now covered by tests. While adding them, I also found and fixed a bug where some cancelled predictions were incorrectly being set as the current one.

Release Notes:

- N/A
