### PR TITLE
edit prediction: Request trigger

### DIFF
--- a/crates/cloud_llm_client/src/cloud_llm_client.rs
+++ b/crates/cloud_llm_client/src/cloud_llm_client.rs
@@ -169,6 +169,17 @@ pub struct PredictEditsBody {
     /// Info about the git repository state, only present when can_collect_data is true.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub git_info: Option<PredictEditsGitInfo>,
+    /// The trigger for this request.
+    #[serde(default)]
+    pub trigger: PredictEditsRequestTrigger,
+}
+
+#[derive(Default, Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum PredictEditsRequestTrigger {
+    Diagnostics,
+    Cli,
+    #[default]
+    Other,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/cloud_llm_client/src/predict_edits_v3.rs
+++ b/crates/cloud_llm_client/src/predict_edits_v3.rs
@@ -9,7 +9,7 @@ use std::{
 use strum::EnumIter;
 use uuid::Uuid;
 
-use crate::PredictEditsGitInfo;
+use crate::{PredictEditsGitInfo, PredictEditsRequestTrigger};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PlanContextRetrievalRequest {
@@ -53,6 +53,8 @@ pub struct PredictEditsRequest {
     pub prompt_max_bytes: Option<usize>,
     #[serde(default)]
     pub prompt_format: PromptFormat,
+    #[serde(default)]
+    pub trigger: PredictEditsRequestTrigger,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/zeta/src/zeta1.rs
+++ b/crates/zeta/src/zeta1.rs
@@ -8,7 +8,8 @@ use crate::{
 };
 use anyhow::{Context as _, Result};
 use cloud_llm_client::{
-    PredictEditsBody, PredictEditsGitInfo, PredictEditsResponse, predict_edits_v3::Event,
+    PredictEditsBody, PredictEditsGitInfo, PredictEditsRequestTrigger, PredictEditsResponse,
+    predict_edits_v3::Event,
 };
 use gpui::{App, AppContext as _, AsyncApp, Context, Entity, SharedString, Task};
 use input_excerpt::excerpt_for_cursor_position;
@@ -35,6 +36,7 @@ pub(crate) fn request_prediction_with_zeta1(
     snapshot: BufferSnapshot,
     position: language::Anchor,
     events: Vec<Arc<Event>>,
+    trigger: PredictEditsRequestTrigger,
     cx: &mut Context<Zeta>,
 ) -> Task<Result<Option<EditPredictionResult>>> {
     let buffer = buffer.clone();
@@ -70,6 +72,7 @@ pub(crate) fn request_prediction_with_zeta1(
         &snapshot,
         cursor_point,
         prompt_for_events,
+        trigger,
         cx,
     );
 
@@ -402,6 +405,7 @@ pub fn gather_context(
     snapshot: &BufferSnapshot,
     cursor_point: language::Point,
     prompt_for_events: impl FnOnce() -> (String, usize) + Send + 'static,
+    trigger: PredictEditsRequestTrigger,
     cx: &App,
 ) -> Task<Result<GatherContextOutput>> {
     cx.background_spawn({
@@ -425,6 +429,7 @@ pub fn gather_context(
                 git_info: None,
                 outline: None,
                 speculated_output: None,
+                trigger,
             };
 
             Ok(GatherContextOutput {

--- a/crates/zeta/src/zeta_tests.rs
+++ b/crates/zeta/src/zeta_tests.rs
@@ -536,7 +536,7 @@ async fn run_edit_prediction(
     zeta.update(cx, |zeta, cx| zeta.register_buffer(buffer, &project, cx));
     cx.background_executor.run_until_parked();
     let prediction_task = zeta.update(cx, |zeta, cx| {
-        zeta.request_prediction(&project, buffer, cursor, cx)
+        zeta.request_prediction(&project, buffer, cursor, Default::default(), cx)
     });
     prediction_task.await.unwrap().unwrap().prediction.unwrap()
 }

--- a/crates/zeta_cli/src/main.rs
+++ b/crates/zeta_cli/src/main.rs
@@ -454,6 +454,7 @@ async fn zeta1_context(
             &snapshot,
             clipped_cursor,
             prompt_for_events,
+            cloud_llm_client::PredictEditsRequestTrigger::Cli,
             cx,
         )
     })?

--- a/crates/zeta_cli/src/predict.rs
+++ b/crates/zeta_cli/src/predict.rs
@@ -226,7 +226,13 @@ pub async fn perform_predict(
 
     let prediction = zeta
         .update(cx, |zeta, cx| {
-            zeta.request_prediction(&project, &cursor_buffer, cursor_anchor, cx)
+            zeta.request_prediction(
+                &project,
+                &cursor_buffer,
+                cursor_anchor,
+                cloud_llm_client::PredictEditsRequestTrigger::Cli,
+                cx,
+            )
         })?
         .await?;
 


### PR DESCRIPTION
Adds a `trigger` field to the zeta1/zeta2 prediction requests so that we can distinguish between editor, diagnostic, and zeta-cli requests.

Release Notes:

- N/A
