### PR TITLE
auto-update: Fix auto-update loop with non-nightly channels

### DIFF
--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -717,9 +717,12 @@ impl AutoUpdater {
     }
 
     fn check_if_fetched_version_is_newer_non_nightly(
-        installed_version: Version,
+        mut installed_version: Version,
         fetched_version: Version,
     ) -> Result<Option<VersionCheckType>> {
+        // For non-nightly releases, ignore build and pre-release fields as they're not provided by our endpoints right now.
+        installed_version.build = semver::BuildMetadata::EMPTY;
+        installed_version.pre = semver::Prerelease::EMPTY;
         let should_download = fetched_version > installed_version;
         let newer_version = should_download.then(|| VersionCheckType::Semantic(fetched_version));
         Ok(newer_version)


### PR DESCRIPTION
There are 2 factors:
1. The Preview channel endpoint does not propagate versions with build identifier (which we oh-so-conveniently store in pre-release field of semver).
2. Preview build, once fetched, sees it's version *with* build identifier (as that's baked into the binary).
3. Auto update logic treats versions with pre-release version as less than versions without pre-release version.

This in turn makes any Preview client see itself as versioned like 0.214.4-123+asdf1234455311, whereas the latest version on the endpoint is 0.214.4. Thus, the endpoint version is always more recent than the client version, causing an update loop.

The fix is to ignore build identifier when comparing versions of non-nightly channels. This should still let us introduce changes to auto-update behavior in minor releases in the future.

Closes #43584

Release Notes:

- (Preview only): Fixed an update loop with latest Preview update.
