### PR TITLE
Update Gemini25FlashLitePreview to latest preview

### DIFF
--- a/crates/google_ai/src/google_ai.rs
+++ b/crates/google_ai/src/google_ai.rs
@@ -499,7 +499,7 @@ pub enum Model {
     Gemini20Flash,
     #[serde(
         rename = "gemini-2.5-flash-lite-preview",
-        alias = "gemini-2.5-flash-lite-preview-06-17"
+        alias = "gemini-2.5-flash-lite-preview-09-2025"
     )]
     Gemini25FlashLitePreview,
     #[serde(


### PR DESCRIPTION
Closes #43040

Release Notes:
Fixed: Updated Gemini 2.5 Flash Lite Preview to the latest model, to fix the 404 error.

Additional Notes: