### PR TITLE
git: Add debug logs

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -12327,6 +12327,10 @@ impl Editor {
                     let (comment_prefix, rewrap_prefix) = if let Some(language_scope) =
                         &language_scope
                     {
+                        log::info!(
+                            "language_scope with {:?} rewrap_prefixes",
+                            language_scope.rewrap_prefixes().len()
+                        );
                         let indent_end = Point::new(row, indent.len);
                         let line_end = Point::new(row, buffer.line_len(MultiBufferRow(row)));
                         let line_text_after_indent = buffer

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -3758,6 +3758,10 @@ impl Repository {
 
             if let Some(language_registry) = language_registry {
                 let git_commit_language = language_registry.language_for_name("Git Commit").await?;
+                log::info!(
+                    "Loaded 'Git Commit' Language with {} rewrap_prefixes",
+                    git_commit_language.config().rewrap_prefixes.len()
+                );
                 buffer.update(cx, |buffer, cx| {
                     buffer.set_language(Some(git_commit_language), cx);
                 })?;


### PR DESCRIPTION
DEMO-ONLY
Add debug logs to show `rewrap_prefixes` of the Git Commit language becomes empty when the Git Firefly extension is installed.

Closes #42476

Release Notes:

- N/A *or* Added/Fixed/Improved ...
