### PR TITLE
macos: Add missing file access entitlements

### DIFF
--- a/crates/zed/resources/zed.entitlements
+++ b/crates/zed/resources/zed.entitlements
@@ -22,5 +22,9 @@
 	<true/>
 	<key>com.apple.security.personal-information.photos-library</key>
 	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+	<key>com.apple.security.files.downloads.read-write</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Adds `com.apple.security.files.user-selected.read-write` and `com.apple.security.files.downloads.read-write` to zed.entitlements.

This resolves an issue where the integrated terminal could not access external drives or user-selected files on macOS, even when "Full Disk Access" was granted. These entitlements are required for the application to properly inherit file access permissions.

Release Notes:

- Resolves an issue where the integrated terminal could not access external drives or user-selected files on macOS.
