### PR TITLE
remote: Do not include prerelease and build meta in asset queries

### DIFF
--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -510,7 +510,9 @@ impl AutoUpdater {
             (None, None, None)
         };
 
-        let version = if let Some(version) = version {
+        let version = if let Some(mut version) = version {
+            version.pre = semver::Prerelease::EMPTY;
+            version.build = semver::BuildMetadata::EMPTY;
             version.to_string()
         } else {
             "latest".to_string()


### PR DESCRIPTION
Closes #43580

Release Notes:

- (Preview only) Fixed failures to fetch remoting server (needed to run remoting).
