### PR TITLE
Feat/md preview copy

### DIFF
--- a/crates/markdown_preview/src/markdown_elements.rs
+++ b/crates/markdown_preview/src/markdown_elements.rs
@@ -41,6 +41,13 @@ impl ParsedMarkdownElement {
         matches!(self, Self::ListItem(_))
     }
 
+    /// Returns the plain text content of this element.
+    pub fn plain_text(&self) -> String {
+        let mut output = String::new();
+        self.append_plain_text(&mut output);
+        output
+    }
+
     pub fn append_plain_text(&self, output: &mut String) {
         match self {
             Self::Heading(heading) => {

--- a/crates/markdown_preview/src/markdown_preview.rs
+++ b/crates/markdown_preview/src/markdown_preview.rs
@@ -19,7 +19,9 @@ actions!(
         /// Opens a markdown preview in a split pane.
         OpenPreviewToTheSide,
         /// Opens a following markdown preview that syncs with the editor.
-        OpenFollowingPreview
+        OpenFollowingPreview,
+        /// Copies all markdown content as plain text to clipboard.
+        CopyAll
     ]
 );
 

--- a/crates/markdown_preview/src/markdown_preview.rs
+++ b/crates/markdown_preview/src/markdown_preview.rs
@@ -21,9 +21,71 @@ actions!(
         /// Opens a following markdown preview that syncs with the editor.
         OpenFollowingPreview,
         /// Copies all markdown content as plain text to clipboard.
-        CopyAll
+        CopyAll,
     ]
 );
+
+/// A position within the markdown preview content.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct MarkdownPosition {
+    /// The index of the block containing this position.
+    pub block_index: usize,
+    /// The character offset within the block's plain text content.
+    pub char_offset: usize,
+}
+
+impl MarkdownPosition {
+    pub fn new(block_index: usize, char_offset: usize) -> Self {
+        Self {
+            block_index,
+            char_offset,
+        }
+    }
+}
+
+/// The current text selection state in the markdown preview.
+#[derive(Clone, Debug)]
+pub struct SelectionState {
+    /// Where the selection started (the anchor point).
+    pub anchor: MarkdownPosition,
+    /// The current end of the selection (moves during drag).
+    pub head: MarkdownPosition,
+}
+
+impl SelectionState {
+    pub fn new(anchor: MarkdownPosition) -> Self {
+        Self {
+            anchor,
+            head: anchor,
+        }
+    }
+
+    /// Returns the start and end of the selection in document order.
+    pub fn ordered(&self) -> (MarkdownPosition, MarkdownPosition) {
+        if self.anchor <= self.head {
+            (self.anchor, self.head)
+        } else {
+            (self.head, self.anchor)
+        }
+    }
+
+    /// Returns true if the selection is empty (anchor equals head).
+    pub fn is_empty(&self) -> bool {
+        self.anchor == self.head
+    }
+}
+
+/// The phase of the selection process.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum SelectionPhase {
+    /// No selection is in progress.
+    #[default]
+    None,
+    /// User is actively selecting (mouse is down and dragging).
+    Selecting,
+    /// Selection is complete (mouse was released).
+    Ended,
+}
 
 pub fn init(cx: &mut App) {
     cx.observe_new(|workspace: &mut Workspace, window, cx| {

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -721,9 +721,20 @@ impl Render for MarkdownPreviewView {
                     .on_mouse_down(
                         MouseButton::Left,
                         cx.listener(|this, event: &MouseDownEvent, _window, cx| {
-                            // Clear existing selection when starting a new one
-                            this.selection = None;
-                            this.start_selection(event.position, cx);
+                            if event.modifiers.shift && this.selection.is_some() {
+                                // Shift+click extends the existing selection
+                                if let Some(pos) = this.position_from_point(event.position) {
+                                    if let Some(selection) = &mut this.selection {
+                                        selection.head = pos;
+                                        this.selection_phase = SelectionPhase::Selecting;
+                                        cx.notify();
+                                    }
+                                }
+                            } else {
+                                // Clear existing selection and start a new one
+                                this.selection = None;
+                                this.start_selection(event.position, cx);
+                            }
                         }),
                     )
                     .on_mouse_up(

--- a/crates/markdown_preview/src/markdown_renderer.rs
+++ b/crates/markdown_preview/src/markdown_renderer.rs
@@ -1,10 +1,10 @@
+use crate::SelectionState;
 use crate::markdown_elements::{
     HeadingLevel, Image, Link, MarkdownParagraph, MarkdownParagraphChunk, ParsedMarkdown,
     ParsedMarkdownBlockQuote, ParsedMarkdownCodeBlock, ParsedMarkdownElement,
     ParsedMarkdownHeading, ParsedMarkdownListItem, ParsedMarkdownListItemType, ParsedMarkdownTable,
     ParsedMarkdownTableAlignment, ParsedMarkdownTableRow,
 };
-use crate::SelectionState;
 use fs::normalize_path;
 use gpui::{
     AbsoluteLength, AnyElement, App, AppContext as _, ClipboardItem, Context, Div, Element,
@@ -738,8 +738,8 @@ fn render_markdown_code_block(
         base_highlights
     };
 
-    let body =
-        StyledText::new(parsed.contents.clone()).with_default_highlights(&cx.buffer_text_style, all_highlights);
+    let body = StyledText::new(parsed.contents.clone())
+        .with_default_highlights(&cx.buffer_text_style, all_highlights);
 
     let copy_block_button = IconButton::new("copy-code", IconName::Copy)
         .icon_size(IconSize::Small)
@@ -793,9 +793,7 @@ fn render_markdown_text(parsed_new: &MarkdownParagraph, cx: &mut RenderContext) 
         .iter()
         .map(|chunk| match chunk {
             MarkdownParagraphChunk::Text(text) => text.contents.len(),
-            MarkdownParagraphChunk::Image(image) => {
-                image.alt_text.as_ref().map_or(0, |t| t.len())
-            }
+            MarkdownParagraphChunk::Image(image) => image.alt_text.as_ref().map_or(0, |t| t.len()),
         })
         .sum();
 
@@ -874,7 +872,8 @@ fn render_markdown_text(parsed_new: &MarkdownParagraph, cx: &mut RenderContext) 
 
                 // Combine base highlights with selection highlight
                 let highlights: Vec<_> = if let Some(selection_hl) = selection_highlight {
-                    gpui::combine_highlights(base_highlights, std::iter::once(selection_hl)).collect()
+                    gpui::combine_highlights(base_highlights, std::iter::once(selection_hl))
+                        .collect()
                 } else {
                     base_highlights
                 };


### PR DESCRIPTION
Closes #43614 for feature request #28447 

Release Notes:

- Copy All button in Markdown Preview pane

<img width="183" height="126" alt="Screenshot 2025-11-26 at 5 42 54 PM" src="https://github.com/user-attachments/assets/86f47210-6e2a-4495-a7de-0dad1e09de75" />

- Select with mouse, CMD/CTRL+C to copy

<img width="1579" height="901" alt="Screenshot 2025-11-26 at 5 43 53 PM" src="https://github.com/user-attachments/assets/a989feeb-a395-42fd-a127-552618cfc3b7" />

- Shift+click to add selection

- Handles edge case issue when selection ranges could land in the middle of multi-byte UTF-8 characters (like emojis or non-ASCII text). I added a find_char_boundary helper function that ensures all selection highlight ranges fall on valid character boundaries. This prevents the panic when StyledText::with_default_highlights validates that the range ends fall on character boundaries.
