### PR TITLE
markdown_preview: Add "Copy All" button

### DIFF
--- a/crates/markdown_preview/src/markdown_elements.rs
+++ b/crates/markdown_preview/src/markdown_elements.rs
@@ -41,6 +41,13 @@ impl ParsedMarkdownElement {
         matches!(self, Self::ListItem(_))
     }
 
+    /// Returns the plain text content of this element.
+    pub fn plain_text(&self) -> String {
+        let mut output = String::new();
+        self.append_plain_text(&mut output);
+        output
+    }
+
     pub fn append_plain_text(&self, output: &mut String) {
         match self {
             Self::Heading(heading) => {

--- a/crates/markdown_preview/src/markdown_preview.rs
+++ b/crates/markdown_preview/src/markdown_preview.rs
@@ -19,7 +19,9 @@ actions!(
         /// Opens a markdown preview in a split pane.
         OpenPreviewToTheSide,
         /// Opens a following markdown preview that syncs with the editor.
-        OpenFollowingPreview
+        OpenFollowingPreview,
+        /// Copies all markdown content as plain text to clipboard.
+        CopyAll
     ]
 );
 

--- a/crates/markdown_preview/src/markdown_preview.rs
+++ b/crates/markdown_preview/src/markdown_preview.rs
@@ -21,9 +21,71 @@ actions!(
         /// Opens a following markdown preview that syncs with the editor.
         OpenFollowingPreview,
         /// Copies all markdown content as plain text to clipboard.
-        CopyAll
+        CopyAll,
     ]
 );
+
+/// A position within the markdown preview content.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct MarkdownPosition {
+    /// The index of the block containing this position.
+    pub block_index: usize,
+    /// The character offset within the block's plain text content.
+    pub char_offset: usize,
+}
+
+impl MarkdownPosition {
+    pub fn new(block_index: usize, char_offset: usize) -> Self {
+        Self {
+            block_index,
+            char_offset,
+        }
+    }
+}
+
+/// The current text selection state in the markdown preview.
+#[derive(Clone, Debug)]
+pub struct SelectionState {
+    /// Where the selection started (the anchor point).
+    pub anchor: MarkdownPosition,
+    /// The current end of the selection (moves during drag).
+    pub head: MarkdownPosition,
+}
+
+impl SelectionState {
+    pub fn new(anchor: MarkdownPosition) -> Self {
+        Self {
+            anchor,
+            head: anchor,
+        }
+    }
+
+    /// Returns the start and end of the selection in document order.
+    pub fn ordered(&self) -> (MarkdownPosition, MarkdownPosition) {
+        if self.anchor <= self.head {
+            (self.anchor, self.head)
+        } else {
+            (self.head, self.anchor)
+        }
+    }
+
+    /// Returns true if the selection is empty (anchor equals head).
+    pub fn is_empty(&self) -> bool {
+        self.anchor == self.head
+    }
+}
+
+/// The phase of the selection process.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum SelectionPhase {
+    /// No selection is in progress.
+    #[default]
+    None,
+    /// User is actively selecting (mouse is down and dragging).
+    Selecting,
+    /// Selection is complete (mouse was released).
+    Ended,
+}
 
 pub fn init(cx: &mut App) {
     cx.observe_new(|workspace: &mut Workspace, window, cx| {

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -22,7 +22,8 @@ use crate::markdown_elements::ParsedMarkdownElement;
 use crate::markdown_renderer::CheckboxClickedEvent;
 use crate::{
     CopyAll, MarkdownPosition, MovePageDown, MovePageUp, OpenFollowingPreview, OpenPreview,
-    OpenPreviewToTheSide, SelectionPhase, SelectionState, markdown_elements::ParsedMarkdown,
+    OpenPreviewToTheSide, SelectionPhase, SelectionState,
+    markdown_elements::ParsedMarkdown,
     markdown_parser::parse_markdown,
     markdown_renderer::{RenderContext, render_markdown_block},
 };
@@ -512,7 +513,8 @@ impl MarkdownPreviewView {
                     // and horizontal position. This is a rough estimate since we don't have
                     // access to the actual text layout.
                     let relative_y = (point.y - bounds.top()) / bounds.size.height;
-                    let relative_x = ((point.x - bounds.left()) / bounds.size.width).clamp(0.0, 1.0);
+                    let relative_x =
+                        ((point.x - bounds.left()) / bounds.size.width).clamp(0.0, 1.0);
 
                     // Count approximate lines in the text
                     let line_count = plain_text.lines().count().max(1);
@@ -532,7 +534,10 @@ impl MarkdownPreviewView {
                         char_offset += line.len() + 1; // +1 for newline
                     }
 
-                    return Some(MarkdownPosition::new(block_index, char_offset.min(text_len)));
+                    return Some(MarkdownPosition::new(
+                        block_index,
+                        char_offset.min(text_len),
+                    ));
                 }
             }
         }
@@ -721,9 +726,20 @@ impl Render for MarkdownPreviewView {
                     .on_mouse_down(
                         MouseButton::Left,
                         cx.listener(|this, event: &MouseDownEvent, _window, cx| {
-                            // Clear existing selection when starting a new one
-                            this.selection = None;
-                            this.start_selection(event.position, cx);
+                            if event.modifiers.shift && this.selection.is_some() {
+                                // Shift+click extends the existing selection
+                                if let Some(pos) = this.position_from_point(event.position) {
+                                    if let Some(selection) = &mut this.selection {
+                                        selection.head = pos;
+                                        this.selection_phase = SelectionPhase::Selecting;
+                                        cx.notify();
+                                    }
+                                }
+                            } else {
+                                // Clear existing selection and start a new one
+                                this.selection = None;
+                                this.start_selection(event.position, cx);
+                            }
                         }),
                     )
                     .on_mouse_up(
@@ -741,112 +757,112 @@ impl Render for MarkdownPreviewView {
                         list(
                             self.list_state.clone(),
                             cx.processor(|this, ix, window, cx| {
-                            let Some(contents) = &this.contents else {
-                                return div().into_any();
-                            };
+                                let Some(contents) = &this.contents else {
+                                    return div().into_any();
+                                };
 
-                            let mut render_cx =
-                                RenderContext::new(Some(this.workspace.clone()), window, cx)
-                                    .with_selection(this.selection.clone())
-                                    .with_checkbox_clicked_callback(cx.listener(
-                                        move |this, e: &CheckboxClickedEvent, window, cx| {
-                                            if let Some(editor) = this
-                                                .active_editor
-                                                .as_ref()
-                                                .map(|s| s.editor.clone())
-                                            {
-                                                editor.update(cx, |editor, cx| {
-                                                    let task_marker =
-                                                        if e.checked() { "[x]" } else { "[ ]" };
+                                let mut render_cx =
+                                    RenderContext::new(Some(this.workspace.clone()), window, cx)
+                                        .with_selection(this.selection.clone())
+                                        .with_checkbox_clicked_callback(cx.listener(
+                                            move |this, e: &CheckboxClickedEvent, window, cx| {
+                                                if let Some(editor) = this
+                                                    .active_editor
+                                                    .as_ref()
+                                                    .map(|s| s.editor.clone())
+                                                {
+                                                    editor.update(cx, |editor, cx| {
+                                                        let task_marker =
+                                                            if e.checked() { "[x]" } else { "[ ]" };
 
-                                                    editor.edit(
-                                                        vec![(
-                                                            MultiBufferOffset(
-                                                                e.source_range().start,
-                                                            )
-                                                                ..MultiBufferOffset(
-                                                                    e.source_range().end,
-                                                                ),
-                                                            task_marker,
-                                                        )],
-                                                        cx,
+                                                        editor.edit(
+                                                            vec![(
+                                                                MultiBufferOffset(
+                                                                    e.source_range().start,
+                                                                )
+                                                                    ..MultiBufferOffset(
+                                                                        e.source_range().end,
+                                                                    ),
+                                                                task_marker,
+                                                            )],
+                                                            cx,
+                                                        );
+                                                    });
+                                                    this.parse_markdown_from_active_editor(
+                                                        false, window, cx,
                                                     );
-                                                });
-                                                this.parse_markdown_from_active_editor(
-                                                    false, window, cx,
+                                                    cx.notify();
+                                                }
+                                            },
+                                        ));
+
+                                render_cx.set_current_block_index(ix);
+                                let block = contents.children.get(ix).unwrap();
+                                let rendered_block = render_markdown_block(block, &mut render_cx);
+
+                                let should_apply_padding = Self::should_apply_padding_between(
+                                    block,
+                                    contents.children.get(ix + 1),
+                                );
+
+                                div()
+                                    .id(ix)
+                                    .when(should_apply_padding, |this| {
+                                        this.pb(render_cx.scaled_rems(0.75))
+                                    })
+                                    .group("markdown-block")
+                                    .on_click(cx.listener(
+                                        move |this, event: &ClickEvent, window, cx| {
+                                            if event.click_count() == 2
+                                                && let Some(source_range) = this
+                                                    .contents
+                                                    .as_ref()
+                                                    .and_then(|c| c.children.get(ix))
+                                                    .and_then(|block: &ParsedMarkdownElement| {
+                                                        block.source_range()
+                                                    })
+                                            {
+                                                this.move_cursor_to_block(
+                                                    window,
+                                                    cx,
+                                                    MultiBufferOffset(source_range.start)
+                                                        ..MultiBufferOffset(source_range.start),
                                                 );
-                                                cx.notify();
                                             }
                                         },
-                                    ));
+                                    ))
+                                    .map(move |container| {
+                                        let indicator = div()
+                                            .h_full()
+                                            .w(px(4.0))
+                                            .when(ix == this.selected_block, |this| {
+                                                this.bg(cx.theme().colors().border)
+                                            })
+                                            .group_hover("markdown-block", |s| {
+                                                if ix == this.selected_block {
+                                                    s
+                                                } else {
+                                                    s.bg(cx.theme().colors().border_variant)
+                                                }
+                                            })
+                                            .rounded_xs();
 
-                            render_cx.set_current_block_index(ix);
-                            let block = contents.children.get(ix).unwrap();
-                            let rendered_block = render_markdown_block(block, &mut render_cx);
-
-                            let should_apply_padding = Self::should_apply_padding_between(
-                                block,
-                                contents.children.get(ix + 1),
-                            );
-
-                            div()
-                                .id(ix)
-                                .when(should_apply_padding, |this| {
-                                    this.pb(render_cx.scaled_rems(0.75))
-                                })
-                                .group("markdown-block")
-                                .on_click(cx.listener(
-                                    move |this, event: &ClickEvent, window, cx| {
-                                        if event.click_count() == 2
-                                            && let Some(source_range) = this
-                                                .contents
-                                                .as_ref()
-                                                .and_then(|c| c.children.get(ix))
-                                                .and_then(|block: &ParsedMarkdownElement| {
-                                                    block.source_range()
-                                                })
-                                        {
-                                            this.move_cursor_to_block(
-                                                window,
-                                                cx,
-                                                MultiBufferOffset(source_range.start)
-                                                    ..MultiBufferOffset(source_range.start),
-                                            );
-                                        }
-                                    },
-                                ))
-                                .map(move |container| {
-                                    let indicator = div()
-                                        .h_full()
-                                        .w(px(4.0))
-                                        .when(ix == this.selected_block, |this| {
-                                            this.bg(cx.theme().colors().border)
-                                        })
-                                        .group_hover("markdown-block", |s| {
-                                            if ix == this.selected_block {
-                                                s
-                                            } else {
-                                                s.bg(cx.theme().colors().border_variant)
-                                            }
-                                        })
-                                        .rounded_xs();
-
-                                    container.child(
-                                        div()
-                                            .relative()
-                                            .child(
-                                                div()
-                                                    .pl(render_cx.scaled_rems(1.0))
-                                                    .child(rendered_block),
-                                            )
-                                            .child(indicator.absolute().left_0().top_0()),
-                                    )
-                                })
-                                .into_any()
-                        }),
-                    )
-                    .size_full(),
-                ),
+                                        container.child(
+                                            div()
+                                                .relative()
+                                                .child(
+                                                    div()
+                                                        .pl(render_cx.scaled_rems(1.0))
+                                                        .child(rendered_block),
+                                                )
+                                                .child(indicator.absolute().left_0().top_0()),
+                                        )
+                                    })
+                                    .into_any()
+                            }),
+                        )
+                        .size_full(),
+                    ),
             )
             .vertical_scrollbar_for(&self.list_state, window, cx)
     }

--- a/crates/markdown_preview/src/markdown_renderer.rs
+++ b/crates/markdown_preview/src/markdown_renderer.rs
@@ -1,10 +1,10 @@
+use crate::SelectionState;
 use crate::markdown_elements::{
     HeadingLevel, Image, Link, MarkdownParagraph, MarkdownParagraphChunk, ParsedMarkdown,
     ParsedMarkdownBlockQuote, ParsedMarkdownCodeBlock, ParsedMarkdownElement,
     ParsedMarkdownHeading, ParsedMarkdownListItem, ParsedMarkdownListItemType, ParsedMarkdownTable,
     ParsedMarkdownTableAlignment, ParsedMarkdownTableRow,
 };
-use crate::SelectionState;
 use fs::normalize_path;
 use gpui::{
     AbsoluteLength, AnyElement, App, AppContext as _, ClipboardItem, Context, Div, Element,
@@ -738,8 +738,8 @@ fn render_markdown_code_block(
         base_highlights
     };
 
-    let body =
-        StyledText::new(parsed.contents.clone()).with_default_highlights(&cx.buffer_text_style, all_highlights);
+    let body = StyledText::new(parsed.contents.clone())
+        .with_default_highlights(&cx.buffer_text_style, all_highlights);
 
     let copy_block_button = IconButton::new("copy-code", IconName::Copy)
         .icon_size(IconSize::Small)
@@ -793,9 +793,7 @@ fn render_markdown_text(parsed_new: &MarkdownParagraph, cx: &mut RenderContext) 
         .iter()
         .map(|chunk| match chunk {
             MarkdownParagraphChunk::Text(text) => text.contents.len(),
-            MarkdownParagraphChunk::Image(image) => {
-                image.alt_text.as_ref().map_or(0, |t| t.len())
-            }
+            MarkdownParagraphChunk::Image(image) => image.alt_text.as_ref().map_or(0, |t| t.len()),
         })
         .sum();
 
@@ -874,7 +872,8 @@ fn render_markdown_text(parsed_new: &MarkdownParagraph, cx: &mut RenderContext) 
 
                 // Combine base highlights with selection highlight
                 let highlights: Vec<_> = if let Some(selection_hl) = selection_highlight {
-                    gpui::combine_highlights(base_highlights, std::iter::once(selection_hl)).collect()
+                    gpui::combine_highlights(base_highlights, std::iter::once(selection_hl))
+                        .collect()
                 } else {
                     base_highlights
                 };


### PR DESCRIPTION
Closes #43614 for feature request #28447

Release Notes:

- Copy All button in Markdown Preview pane

<img width="366" height="252" alt="image" src="https://github.com/user-attachments/assets/c56ba3f8-c71f-45c8-9855-a1551ff77044" />

- Select with mouse, CMD/CTRL+C to copy

<img width="3158" height="1802" alt="image" src="https://github.com/user-attachments/assets/f3002693-4c11-4b6f-841c-e0800a175acf" />

- Shift+click to add selection

- Handles edge case issue when selection ranges could land in the middle of multi-byte UTF-8 characters (like emojis or non-ASCII text). I added a find_char_boundary helper function that ensures all selection highlight ranges fall on valid character boundaries. This prevents the panic when StyledText::with_default_highlights validates that the range ends fall on character boundaries.