### PR TITLE
Add infrastructure and Zed action for HTML clipboard for all platforms

### DIFF
--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -418,6 +418,8 @@ actions!(
         CopyFileLocation,
         /// Copies the highlighted text as JSON.
         CopyHighlightJson,
+        /// Copies selected text with syntax highlighting as HTML for rich text pasting.
+        CopyWithSyntaxHighlighting,
         /// Copies the current file name to the clipboard.
         CopyFileName,
         /// Copies the file name without extension to the clipboard.

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -105,8 +105,8 @@ use gpui::{
     AvailableSpace, Background, Bounds, ClickEvent, ClipboardEntry, ClipboardItem, Context,
     DispatchPhase, Edges, Entity, EntityInputHandler, EventEmitter, FocusHandle, FocusOutEvent,
     Focusable, FontId, FontWeight, Global, HighlightStyle, Hsla, KeyContext, Modifiers,
-    MouseButton, MouseDownEvent, MouseMoveEvent, PaintQuad, ParentElement, Pixels, Render,
-    Rgba, ScrollHandle, SharedString, Size, Stateful, Styled, Subscription, Task, TextStyle,
+    MouseButton, MouseDownEvent, MouseMoveEvent, PaintQuad, ParentElement, Pixels, Render, Rgba,
+    ScrollHandle, SharedString, Size, Stateful, Styled, Subscription, Task, TextStyle,
     TextStyleRefinement, UTF16Selection, UnderlineStyle, UniformListScrollHandle, WeakEntity,
     WeakFocusHandle, Window, div, point, prelude::*, pulsating_between, px, relative, size,
 };

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -491,6 +491,7 @@ impl EditorElement {
         register_action(editor, window, Editor::copy_file_name);
         register_action(editor, window, Editor::copy_file_name_without_extension);
         register_action(editor, window, Editor::copy_highlight_json);
+        register_action(editor, window, Editor::copy_with_syntax_highlighting);
         register_action(editor, window, Editor::copy_permalink_to_line);
         register_action(editor, window, Editor::open_permalink_to_line);
         register_action(editor, window, Editor::copy_file_location);

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -1594,6 +1594,7 @@ impl ClipboardItem {
             entries: vec![ClipboardEntry::String(ClipboardString {
                 text,
                 metadata: Some(metadata),
+                html: None,
             })],
         }
     }
@@ -1603,6 +1604,15 @@ impl ClipboardItem {
         Self {
             entries: vec![ClipboardEntry::String(
                 ClipboardString::new(text).with_json_metadata(metadata),
+            )],
+        }
+    }
+
+    /// Create a new ClipboardItem::String with the given text and HTML representation
+    pub fn new_string_with_html(text: String, html: String) -> Self {
+        Self {
+            entries: vec![ClipboardEntry::String(
+                ClipboardString::new(text).with_html(html),
             )],
         }
     }
@@ -1620,7 +1630,7 @@ impl ClipboardItem {
         let mut answer = String::new();
 
         for entry in self.entries.iter() {
-            if let ClipboardEntry::String(ClipboardString { text, metadata: _ }) = entry {
+            if let ClipboardEntry::String(ClipboardString { text, .. }) = entry {
                 answer.push_str(text);
             }
         }
@@ -1886,6 +1896,7 @@ impl Image {
 pub struct ClipboardString {
     pub(crate) text: String,
     pub(crate) metadata: Option<String>,
+    pub(crate) html: Option<String>,
 }
 
 impl ClipboardString {
@@ -1894,6 +1905,7 @@ impl ClipboardString {
         Self {
             text,
             metadata: None,
+            html: None,
         }
     }
 
@@ -1901,6 +1913,13 @@ impl ClipboardString {
     /// after serializing it as JSON.
     pub fn with_json_metadata<T: Serialize>(mut self, metadata: T) -> Self {
         self.metadata = Some(serde_json::to_string(&metadata).unwrap());
+        self
+    }
+
+    /// Return a new clipboard item with HTML content for rich text pasting.
+    /// When present, platforms will write both plain text and HTML to the clipboard.
+    pub fn with_html(mut self, html: String) -> Self {
+        self.html = Some(html);
         self
     }
 
@@ -1912,6 +1931,11 @@ impl ClipboardString {
     /// Get the owned text of the clipboard string
     pub fn into_text(self) -> String {
         self.text
+    }
+
+    /// Get the HTML content of the clipboard string, if present
+    pub fn html(&self) -> Option<&String> {
+        self.html.as_ref()
     }
 
     /// Get the metadata of the clipboard string, formatted as JSON
@@ -1937,6 +1961,7 @@ impl From<String> for ClipboardString {
         Self {
             text: value,
             metadata: None,
+            html: None,
         }
     }
 }

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -864,11 +864,23 @@ impl LinuxClient for WaylandClient {
             return;
         };
         if state.mouse_focused_window.is_some() || state.keyboard_focused_window.is_some() {
+            // Check if any entry has HTML content
+            let has_html = item.entries().iter().any(|entry| {
+                if let crate::ClipboardEntry::String(s) = entry {
+                    s.html.is_some()
+                } else {
+                    false
+                }
+            });
+
             state.clipboard.set(item);
             let serial = state.serial_tracker.get(SerialKind::KeyPress);
             let data_source = data_device_manager.create_data_source(&state.globals.qh, ());
             for mime_type in TEXT_MIME_TYPES {
                 data_source.offer(mime_type.to_string());
+            }
+            if has_html {
+                data_source.offer("text/html".to_string());
             }
             data_source.offer(state.clipboard.self_mime());
             data_device.set_selection(Some(&data_source), serial);

--- a/crates/gpui/src/platform/linux/x11/clipboard.rs
+++ b/crates/gpui/src/platform/linux/x11/clipboard.rs
@@ -76,7 +76,7 @@ x11rb::atom_manager! {
         TEXT,
         TEXT_MIME_UNKNOWN: b"text/plain",
 
-        // HTML: b"text/html",
+        HTML_MIME: b"text/html",
         // URI_LIST: b"text/uri-list",
 
         PNG__MIME: ImageFormat::mime_type(ImageFormat::Png ).as_bytes(),
@@ -986,6 +986,26 @@ impl Clipboard {
             bytes: message.into_owned().into_bytes(),
             format: self.inner.atoms.UTF8_STRING,
         }];
+        self.inner.write(data, selection, wait)
+    }
+
+    pub(crate) fn set_text_with_html(
+        &self,
+        text: Cow<'_, str>,
+        html: Cow<'_, str>,
+        selection: ClipboardKind,
+        wait: WaitConfig,
+    ) -> Result<()> {
+        let data = vec![
+            ClipboardData {
+                bytes: text.into_owned().into_bytes(),
+                format: self.inner.atoms.UTF8_STRING,
+            },
+            ClipboardData {
+                bytes: html.into_owned().into_bytes(),
+                format: self.inner.atoms.HTML_MIME,
+            },
+        ];
         self.inner.write(data, selection, wait)
     }
 

--- a/crates/zeta/src/zeta.rs
+++ b/crates/zeta/src/zeta.rs
@@ -2025,7 +2025,9 @@ impl Zeta {
 
                 let mut body = Vec::new();
                 response.body_mut().read_to_end(&mut body).await?;
-                return Ok((serde_json::from_slice(&body)?, usage));
+                // Treat empty responses as null (allows deserializing to () for endpoints that return no body)
+                let body_to_parse: &[u8] = if body.is_empty() { b"null" } else { &body };
+                return Ok((serde_json::from_slice(body_to_parse)?, usage));
             } else if !did_retry
                 && response
                     .headers()


### PR DESCRIPTION
Closes #17584 by providing both infrastructure and action

Release Notes:
1. HTML Clipboard infrastructure
- ClipboardItem::new_string_with_html(plain_text, html)
- Platform support for macOS, Windows, Linux (X11 + Wayland)
- UTF-8 encoding handled correctly
2. New Zed action `editor: copy with syntax highlighting`

Copies headings, bold, italics, ul/li lists, emojis, etc! Users can copy code with syntax colors preserved for pasting into:
- Google Docs, Notion, Confluence
- Email clients (Gmail, Outlook)
- Presentations (Keynote, PowerPoint, Slides)
- Blog posts / documentation

Supports my other PR for copying markdown preview contents #43619 for the feature request #28447 (which will need a follow-up commit upon merge). Did not commit the test Copy All button for markdown preview in this PR; left it for the previous dedicated PR.

Example using the new action (pasted into Docs):

<img width="715" height="603" alt="Screenshot 2025-11-26 at 9 25 17 PM" src="https://github.com/user-attachments/assets/a75df4df-87ba-4c31-a1da-e96728343c3d" />

Also supports future development, such as:

1. **Terminal: Copy with ANSI Colors**
Terminal output often has meaningful colors (errors in red, success in green, etc.). Could preserve those when copying.

2. **Diff View**
Copy diffs with the red (removed) / green (added) highlighting preserved - useful for code reviews, documentation.

3. **Diagnostics Panel**
Copy compiler errors or warnings with their formatting (error type coloring, file paths, etc.)

4. **Search Results**
Copy search results with the matched text highlighted.

5. **Assistant/Chat Panel**
Copy AI responses with code blocks properly formatted and syntax highlighted.