### PR TITLE
Add local agent tracking and agent sync backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ xcuserdata/
 # Don't commit any secrets to the repo.
 .env
 .env.secret.toml
+/thoughts/

--- a/crates/agent/src/agent_activity.rs
+++ b/crates/agent/src/agent_activity.rs
@@ -1,0 +1,125 @@
+use gpui::{Context, EventEmitter, SharedString};
+use language_model::LanguageModel;
+use std::sync::Arc;
+
+/// Tracks the activity status of an AI agent for collaborative features.
+/// This entity emits `ActivityStatusChanged` events when the agent's state changes.
+pub struct AgentActivityTracker {
+    status: AgentActivityStatus,
+    agent_type: Option<SharedString>,
+    prompt_summary: Option<SharedString>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub enum AgentActivityStatus {
+    #[default]
+    Idle,
+    Active,
+}
+
+/// Event emitted when the agent's activity status changes.
+/// Subscribers can listen for these events to react to agent state changes.
+#[derive(Clone, Debug)]
+pub struct ActivityStatusChanged {
+    pub status: AgentActivityStatus,
+    pub agent_type: Option<SharedString>,
+    pub prompt_summary: Option<SharedString>,
+}
+
+impl EventEmitter<ActivityStatusChanged> for AgentActivityTracker {}
+
+impl AgentActivityTracker {
+    /// Creates a new activity tracker in the idle state.
+    pub fn new() -> Self {
+        Self {
+            status: AgentActivityStatus::Idle,
+            agent_type: None,
+            prompt_summary: None,
+        }
+    }
+
+    /// Sets the tracker to active state and records the agent type from the model.
+    /// Emits an `ActivityStatusChanged` event and notifies GPUI.
+    pub fn set_active(&mut self, model: &Arc<dyn LanguageModel>, cx: &mut Context<Self>) {
+        self.status = AgentActivityStatus::Active;
+        self.agent_type = Some(SharedString::from(model.upstream_provider_name().0.clone()));
+
+        cx.emit(ActivityStatusChanged {
+            status: self.status.clone(),
+            agent_type: self.agent_type.clone(),
+            prompt_summary: self.prompt_summary.clone(),
+        });
+        cx.notify();
+    }
+
+    /// Sets the tracker to idle state.
+    /// Emits an `ActivityStatusChanged` event and notifies GPUI.
+    pub fn set_idle(&mut self, cx: &mut Context<Self>) {
+        self.status = AgentActivityStatus::Idle;
+        self.agent_type = None;
+
+        cx.emit(ActivityStatusChanged {
+            status: self.status.clone(),
+            agent_type: self.agent_type.clone(),
+            prompt_summary: self.prompt_summary.clone(),
+        });
+        cx.notify();
+    }
+
+    /// Sets the agent type independently (useful for initialization).
+    pub fn set_agent_type(&mut self, agent_type: SharedString) {
+        self.agent_type = Some(agent_type);
+    }
+
+    /// Returns the current activity status.
+    pub fn status(&self) -> &AgentActivityStatus {
+        &self.status
+    }
+
+    /// Returns the current agent type (e.g., "Anthropic", "OpenAI").
+    pub fn agent_type(&self) -> Option<&SharedString> {
+        self.agent_type.as_ref()
+    }
+
+    /// Returns the current prompt summary (for future use).
+    pub fn prompt_summary(&self) -> Option<&SharedString> {
+        self.prompt_summary.as_ref()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui::TestAppContext;
+
+    #[gpui::test]
+    async fn test_activity_tracker_state_transitions(cx: &mut TestAppContext) {
+        let tracker = cx.new(|_| AgentActivityTracker::new());
+
+        // Initial state should be idle
+        tracker.read_with(cx, |tracker, _| {
+            assert_eq!(*tracker.status(), AgentActivityStatus::Idle);
+            assert!(tracker.agent_type().is_none());
+        });
+
+        // Set active with a model
+        let model = Arc::new(language_model::FakeLanguageModel::default());
+        tracker.update(cx, |tracker, cx| {
+            tracker.set_active(&model, cx);
+        });
+
+        tracker.read_with(cx, |tracker, _| {
+            assert_eq!(*tracker.status(), AgentActivityStatus::Active);
+            assert!(tracker.agent_type().is_some());
+        });
+
+        // Set back to idle
+        tracker.update(cx, |tracker, cx| {
+            tracker.set_idle(cx);
+        });
+
+        tracker.read_with(cx, |tracker, _| {
+            assert_eq!(*tracker.status(), AgentActivityStatus::Idle);
+        });
+    }
+}

--- a/crates/call/src/call_impl/participant.rs
+++ b/crates/call/src/call_impl/participant.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context as _, Result};
 use client::{ParticipantIndex, User, proto};
 use collections::HashMap;
-use gpui::WeakEntity;
+use gpui::{SharedString, WeakEntity};
 use livekit_client::AudioStream;
 use project::Project;
 use std::sync::Arc;
@@ -38,6 +38,7 @@ pub struct LocalParticipant {
     pub projects: Vec<proto::ParticipantProject>,
     pub active_project: Option<WeakEntity<Project>>,
     pub role: proto::ChannelRole,
+    pub agent_activity: Option<AgentActivity>,
 }
 
 impl LocalParticipant {
@@ -60,6 +61,7 @@ pub struct RemoteParticipant {
     pub speaking: bool,
     pub video_tracks: HashMap<TrackSid, RemoteVideoTrack>,
     pub audio_tracks: HashMap<TrackSid, (RemoteAudioTrack, AudioStream)>,
+    pub agent_activity: Option<AgentActivity>,
 }
 
 impl RemoteParticipant {
@@ -73,4 +75,17 @@ impl RemoteParticipant {
             proto::ChannelRole::Admin | proto::ChannelRole::Member
         )
     }
+}
+
+#[derive(Clone, Debug)]
+pub struct AgentActivity {
+    pub agent_type: SharedString,
+    pub status: AgentActivityStatus,
+    pub prompt_summary: Option<SharedString>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum AgentActivityStatus {
+    Idle,
+    Active,
 }

--- a/crates/call/src/call_impl/room.rs
+++ b/crates/call/src/call_impl/room.rs
@@ -62,6 +62,13 @@ pub enum Event {
     RoomLeft {
         channel_id: Option<ChannelId>,
     },
+    ParticipantAgentActivityChanged {
+        peer_id: proto::PeerId,
+    },
+    AgentDocChanged {
+        user_id: u64,
+        path: String,
+    },
 }
 
 pub struct Room {
@@ -826,6 +833,7 @@ impl Room {
                                     speaking: false,
                                     video_tracks: Default::default(),
                                     audio_tracks: Default::default(),
+                                    agent_activity: None,
                                 },
                             );
 

--- a/crates/proto/proto/ai.proto
+++ b/crates/proto/proto/ai.proto
@@ -218,3 +218,27 @@ message NewExternalAgentVersionAvailable {
     string name = 2;
     string version = 3;
 }
+
+// Agent activity sync for collaborative sessions
+enum AgentActivityStatus {
+    AgentIdle = 0;
+    AgentActive = 1;
+}
+
+message AgentActivity {
+    uint64 user_id = 1;
+    string agent_type = 2;  // "Anthropic", "OpenAI", "Google AI", "xAI"
+    AgentActivityStatus status = 3;
+    optional string prompt_summary = 4;
+}
+
+message UpdateAgentActivity {
+    uint64 room_id = 1;
+    AgentActivity activity = 2;
+}
+
+message AgentDocChanged {
+    uint64 room_id = 1;
+    uint64 user_id = 2;
+    string path = 3;  // relative path within .agent-docs/
+}

--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -439,7 +439,10 @@ message Envelope {
 
         ExternalExtensionAgentsUpdated external_extension_agents_updated = 394;
 
-        RunGitHook run_git_hook = 395; // current max
+        RunGitHook run_git_hook = 395;
+
+        UpdateAgentActivity update_agent_activity = 396;
+        AgentDocChanged agent_doc_changed = 397; // current max
     }
 
     reserved 87 to 88;

--- a/crates/proto/src/proto.rs
+++ b/crates/proto/src/proto.rs
@@ -338,7 +338,9 @@ messages!(
     (RemoteStarted, Background),
     (GitGetWorktrees, Background),
     (GitWorktreesResponse, Background),
-    (GitCreateWorktree, Background)
+    (GitCreateWorktree, Background),
+    (UpdateAgentActivity, Foreground),
+    (AgentDocChanged, Foreground)
 );
 
 request_messages!(


### PR DESCRIPTION
## Summary
This PR implements Phase 1 of agent activity synchronization for collaborative sessions, establishing the protocol foundation for broadcasting AI agent status across room participants.

## Changes
- Add proto message definitions for agent activity (AgentActivityStatus, AgentActivity, UpdateAgentActivity, AgentDocChanged)
- Register messages in Envelope (fields 396-397) with Foreground priority
- Extend LocalParticipant and RemoteParticipant to track agent activity state
- Add room events for agent activity changes (ParticipantAgentActivityChanged, AgentDocChanged)

## Design Decisions
- Messages use **Foreground priority** (time-sensitive, user-facing updates)
- `agent_type` is a **string** to accommodate future providers without proto changes
- `prompt_summary` is **optional** (may not always be available)
- Both messages include `room_id` for room-scoped routing
- Follows existing patterns from UpdateParticipantLocation and RoomUpdated

## Implementation Plan
- ✅ **Phase 1** (this PR): Data structures & proto messages
- 🔜 **Phase 2**: Message handlers & broadcast logic
- 🔜 **Phase 3**: UI integration for displaying agent activity
- 🔜 **Phase 4**: Agent document synchronization

## Testing
- ✅ Clippy passes with no warnings
- ✅ Compiles cleanly for proto and call crates

## Related
- Research doc: [Agent Sync Phase 1 Proto Integration](https://github.com/amanyrath/zed/blob/add_agent_sync/thoughts/shared/research/2025-11-26-agent-sync-phase1-proto-integration.md)