### PR TITLE
Agent to Agent awareness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ xcuserdata/
 # Don't commit any secrets to the repo.
 .env
 .env.secret.toml
+/thoughts/

--- a/crates/agent/src/agent_activity.rs
+++ b/crates/agent/src/agent_activity.rs
@@ -1,0 +1,125 @@
+use gpui::{Context, EventEmitter, SharedString};
+use language_model::LanguageModel;
+use std::sync::Arc;
+
+/// Tracks the activity status of an AI agent for collaborative features.
+/// This entity emits `ActivityStatusChanged` events when the agent's state changes.
+pub struct AgentActivityTracker {
+    status: AgentActivityStatus,
+    agent_type: Option<SharedString>,
+    prompt_summary: Option<SharedString>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub enum AgentActivityStatus {
+    #[default]
+    Idle,
+    Active,
+}
+
+/// Event emitted when the agent's activity status changes.
+/// Subscribers can listen for these events to react to agent state changes.
+#[derive(Clone, Debug)]
+pub struct ActivityStatusChanged {
+    pub status: AgentActivityStatus,
+    pub agent_type: Option<SharedString>,
+    pub prompt_summary: Option<SharedString>,
+}
+
+impl EventEmitter<ActivityStatusChanged> for AgentActivityTracker {}
+
+impl AgentActivityTracker {
+    /// Creates a new activity tracker in the idle state.
+    pub fn new() -> Self {
+        Self {
+            status: AgentActivityStatus::Idle,
+            agent_type: None,
+            prompt_summary: None,
+        }
+    }
+
+    /// Sets the tracker to active state and records the agent type from the model.
+    /// Emits an `ActivityStatusChanged` event and notifies GPUI.
+    pub fn set_active(&mut self, model: &Arc<dyn LanguageModel>, cx: &mut Context<Self>) {
+        self.status = AgentActivityStatus::Active;
+        self.agent_type = Some(SharedString::from(model.upstream_provider_name().0.clone()));
+
+        cx.emit(ActivityStatusChanged {
+            status: self.status.clone(),
+            agent_type: self.agent_type.clone(),
+            prompt_summary: self.prompt_summary.clone(),
+        });
+        cx.notify();
+    }
+
+    /// Sets the tracker to idle state.
+    /// Emits an `ActivityStatusChanged` event and notifies GPUI.
+    pub fn set_idle(&mut self, cx: &mut Context<Self>) {
+        self.status = AgentActivityStatus::Idle;
+        self.agent_type = None;
+
+        cx.emit(ActivityStatusChanged {
+            status: self.status.clone(),
+            agent_type: self.agent_type.clone(),
+            prompt_summary: self.prompt_summary.clone(),
+        });
+        cx.notify();
+    }
+
+    /// Sets the agent type independently (useful for initialization).
+    pub fn set_agent_type(&mut self, agent_type: SharedString) {
+        self.agent_type = Some(agent_type);
+    }
+
+    /// Returns the current activity status.
+    pub fn status(&self) -> &AgentActivityStatus {
+        &self.status
+    }
+
+    /// Returns the current agent type (e.g., "Anthropic", "OpenAI").
+    pub fn agent_type(&self) -> Option<&SharedString> {
+        self.agent_type.as_ref()
+    }
+
+    /// Returns the current prompt summary (for future use).
+    pub fn prompt_summary(&self) -> Option<&SharedString> {
+        self.prompt_summary.as_ref()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui::TestAppContext;
+
+    #[gpui::test]
+    async fn test_activity_tracker_state_transitions(cx: &mut TestAppContext) {
+        let tracker = cx.new(|_| AgentActivityTracker::new());
+
+        // Initial state should be idle
+        tracker.read_with(cx, |tracker, _| {
+            assert_eq!(*tracker.status(), AgentActivityStatus::Idle);
+            assert!(tracker.agent_type().is_none());
+        });
+
+        // Set active with a model
+        let model = Arc::new(language_model::FakeLanguageModel::default());
+        tracker.update(cx, |tracker, cx| {
+            tracker.set_active(&model, cx);
+        });
+
+        tracker.read_with(cx, |tracker, _| {
+            assert_eq!(*tracker.status(), AgentActivityStatus::Active);
+            assert!(tracker.agent_type().is_some());
+        });
+
+        // Set back to idle
+        tracker.update(cx, |tracker, cx| {
+            tracker.set_idle(cx);
+        });
+
+        tracker.read_with(cx, |tracker, _| {
+            assert_eq!(*tracker.status(), AgentActivityStatus::Idle);
+        });
+    }
+}

--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -813,15 +813,18 @@ async fn test_send_after_tool_use_limit(cx: &mut TestAppContext) {
 }
 
 async fn expect_tool_call(events: &mut UnboundedReceiver<Result<ThreadEvent>>) -> acp::ToolCall {
-    let event = events
-        .next()
-        .await
-        .expect("no tool call authorization event received")
-        .unwrap();
-    match event {
-        ThreadEvent::ToolCall(tool_call) => tool_call,
-        event => {
-            panic!("Unexpected event {event:?}");
+    loop {
+        let event = events
+            .next()
+            .await
+            .expect("no tool call event received")
+            .unwrap();
+        match event {
+            ThreadEvent::ActivityChanged { .. } => continue,
+            ThreadEvent::ToolCall(tool_call) => return tool_call,
+            event => {
+                panic!("Unexpected event {event:?}");
+            }
         }
     }
 }
@@ -829,15 +832,18 @@ async fn expect_tool_call(events: &mut UnboundedReceiver<Result<ThreadEvent>>) -
 async fn expect_tool_call_update_fields(
     events: &mut UnboundedReceiver<Result<ThreadEvent>>,
 ) -> acp::ToolCallUpdate {
-    let event = events
-        .next()
-        .await
-        .expect("no tool call authorization event received")
-        .unwrap();
-    match event {
-        ThreadEvent::ToolCallUpdate(acp_thread::ToolCallUpdate::UpdateFields(update)) => update,
-        event => {
-            panic!("Unexpected event {event:?}");
+    loop {
+        let event = events
+            .next()
+            .await
+            .expect("no tool call update event received")
+            .unwrap();
+        match event {
+            ThreadEvent::ActivityChanged { .. } => continue,
+            ThreadEvent::ToolCallUpdate(acp_thread::ToolCallUpdate::UpdateFields(update)) => return update,
+            event => {
+                panic!("Unexpected event {event:?}");
+            }
         }
     }
 }

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -5,8 +5,10 @@ use acp_thread::{
 };
 use acp_thread::{AgentConnection, Plan};
 use action_log::{ActionLog, ActionLogTelemetry};
-use agent::{DbThreadMetadata, HistoryEntry, HistoryEntryId, HistoryStore, NativeAgentServer};
+use agent::{ActivityStatusChanged, DbThreadMetadata, HistoryEntry, HistoryEntryId, HistoryStore, NativeAgentConnection, NativeAgentServer};
 use agent_client_protocol::{self as acp, PromptCapabilities};
+use call::ActiveCall;
+use client::proto;
 use agent_servers::{AgentServer, AgentServerDelegate};
 use agent_settings::{AgentProfileId, AgentSettings, CompletionMode};
 use anyhow::{Result, anyhow};
@@ -646,6 +648,74 @@ impl AcpThreadView {
                             } else {
                                 None
                             };
+
+                        // Subscribe to agent activity changes for room broadcasting
+                        if let Some(native_connection) = agent
+                            .read(cx)
+                            .connection()
+                            .downcast_ref::<NativeAgentConnection>()
+                        {
+                            let activity_tracker = native_connection.activity_tracker(cx);
+                            let client = client::Client::global(cx).clone();
+
+                            // Send initial state if already active
+                            activity_tracker.update(cx, |tracker, _| {
+                                if *tracker.status() == agent::AgentActivityStatus::Active {
+                                    if let Some(room) = ActiveCall::try_global(cx)
+                                        .and_then(|call| call.read(cx).room().cloned())
+                                    {
+                                        if let Some(user_id) = client.user_id() {
+                                            let proto_activity = proto::AgentActivity {
+                                                user_id,
+                                                agent_type: tracker.agent_type()
+                                                    .map(|s| s.to_string())
+                                                    .unwrap_or_default(),
+                                                status: proto::AgentActivityStatus::AgentActive as i32,
+                                                prompt_summary: tracker.prompt_summary()
+                                                    .map(|s| s.to_string()),
+                                            };
+                                            room.update(cx, |room, cx| {
+                                                room.update_agent_activity(proto_activity, cx).log_err();
+                                            });
+                                        }
+                                    }
+                                }
+                            });
+
+                            subscriptions.push(cx.subscribe(
+                                &activity_tracker,
+                                move |_this, _tracker, event: &ActivityStatusChanged, cx| {
+                                    // Broadcast activity to room participants
+                                    let room = match ActiveCall::try_global(cx)
+                                        .and_then(|call| call.read(cx).room().cloned())
+                                    {
+                                        Some(room) => room,
+                                        None => return,
+                                    };
+
+                                    let Some(user_id) = client.user_id() else {
+                                        return;
+                                    };
+
+                                    let proto_activity = proto::AgentActivity {
+                                        user_id,
+                                        agent_type: event.agent_type.as_ref()
+                                            .map(|s| s.to_string())
+                                            .unwrap_or_default(),
+                                        status: match event.status {
+                                            agent::AgentActivityStatus::Active => proto::AgentActivityStatus::AgentActive as i32,
+                                            agent::AgentActivityStatus::Idle => proto::AgentActivityStatus::AgentIdle as i32,
+                                        },
+                                        prompt_summary: event.prompt_summary.as_ref()
+                                            .map(|s| s.to_string()),
+                                    };
+
+                                    room.update(cx, |room, cx| {
+                                        room.update_agent_activity(proto_activity, cx).log_err();
+                                    });
+                                }
+                            ));
+                        }
 
                         this.thread_state = ThreadState::Ready {
                             thread,

--- a/crates/call/src/call_impl/participant.rs
+++ b/crates/call/src/call_impl/participant.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context as _, Result};
 use client::{ParticipantIndex, User, proto};
 use collections::HashMap;
-use gpui::WeakEntity;
+use gpui::{SharedString, WeakEntity};
 use livekit_client::AudioStream;
 use project::Project;
 use std::sync::Arc;
@@ -38,6 +38,7 @@ pub struct LocalParticipant {
     pub projects: Vec<proto::ParticipantProject>,
     pub active_project: Option<WeakEntity<Project>>,
     pub role: proto::ChannelRole,
+    pub agent_activity: Option<AgentActivity>,
 }
 
 impl LocalParticipant {
@@ -60,6 +61,7 @@ pub struct RemoteParticipant {
     pub speaking: bool,
     pub video_tracks: HashMap<TrackSid, RemoteVideoTrack>,
     pub audio_tracks: HashMap<TrackSid, (RemoteAudioTrack, AudioStream)>,
+    pub agent_activity: Option<AgentActivity>,
 }
 
 impl RemoteParticipant {
@@ -73,4 +75,17 @@ impl RemoteParticipant {
             proto::ChannelRole::Admin | proto::ChannelRole::Member
         )
     }
+}
+
+#[derive(Clone, Debug)]
+pub struct AgentActivity {
+    pub agent_type: SharedString,
+    pub status: AgentActivityStatus,
+    pub prompt_summary: Option<SharedString>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum AgentActivityStatus {
+    Idle,
+    Active,
 }

--- a/crates/call/src/call_impl/room.rs
+++ b/crates/call/src/call_impl/room.rs
@@ -62,6 +62,13 @@ pub enum Event {
     RoomLeft {
         channel_id: Option<ChannelId>,
     },
+    ParticipantAgentActivityChanged {
+        peer_id: proto::PeerId,
+    },
+    AgentDocChanged {
+        user_id: u64,
+        path: String,
+    },
 }
 
 pub struct Room {
@@ -826,6 +833,7 @@ impl Room {
                                     speaking: false,
                                     video_tracks: Default::default(),
                                     audio_tracks: Default::default(),
+                                    agent_activity: None,
                                 },
                             );
 

--- a/crates/proto/proto/ai.proto
+++ b/crates/proto/proto/ai.proto
@@ -218,3 +218,27 @@ message NewExternalAgentVersionAvailable {
     string name = 2;
     string version = 3;
 }
+
+// Agent activity sync for collaborative sessions
+enum AgentActivityStatus {
+    AgentIdle = 0;
+    AgentActive = 1;
+}
+
+message AgentActivity {
+    uint64 user_id = 1;
+    string agent_type = 2;  // "Anthropic", "OpenAI", "Google AI", "xAI"
+    AgentActivityStatus status = 3;
+    optional string prompt_summary = 4;
+}
+
+message UpdateAgentActivity {
+    uint64 room_id = 1;
+    AgentActivity activity = 2;
+}
+
+message AgentDocChanged {
+    uint64 room_id = 1;
+    uint64 user_id = 2;
+    string path = 3;  // relative path within .agent-docs/
+}

--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -439,7 +439,10 @@ message Envelope {
 
         ExternalExtensionAgentsUpdated external_extension_agents_updated = 394;
 
-        RunGitHook run_git_hook = 395; // current max
+        RunGitHook run_git_hook = 395;
+
+        UpdateAgentActivity update_agent_activity = 396;
+        AgentDocChanged agent_doc_changed = 397; // current max
     }
 
     reserved 87 to 88;

--- a/crates/proto/src/proto.rs
+++ b/crates/proto/src/proto.rs
@@ -338,7 +338,9 @@ messages!(
     (RemoteStarted, Background),
     (GitGetWorktrees, Background),
     (GitWorktreesResponse, Background),
-    (GitCreateWorktree, Background)
+    (GitCreateWorktree, Background),
+    (UpdateAgentActivity, Foreground),
+    (AgentDocChanged, Foreground)
 );
 
 request_messages!(


### PR DESCRIPTION
# Agent Sync MVP Implementation Plan

**Status**: Phase 3 Complete ✓ - Ready for Phase 4

## Overview

Enable agent-to-agent awareness in Zed's collaborative editing environment. When multiple users collaborate in a shared project, each user's AI agent should be aware of what other agents are doing: their status, what they were prompted to do, and what documents they've created.

## Implementation Status

### ✅ Phase 1: Proto Messages & Data Structures (COMPLETE)
- Proto messages defined in `ai.proto` and registered in `zed.proto`
- Data structures added to `participant.rs` and `room.rs`
- Events defined for agent activity changes
- Proto crate compiles and passes clippy

### ✅ Phase 2: Local Agent Activity Tracking (COMPLETE)
- `AgentActivityTracker` entity created with GPUI event emission
- Integrated with agent lifecycle via `ThreadEvent::ActivityChanged`
- Agent type tracking and state management implemented
- All agent tests pass, no clippy warnings

### ✅ Phase 3: Room Broadcasting (COMPLETE)
- Server-side handlers implemented in `collab/src/rpc.rs`
- Client-side message handlers implemented in `room.rs`
- Activity tracker subscription added in `AcpThreadView`
- Initial state sync when joining room with active agent
- Agent activity broadcasts to all room participants via RPC

### 🔄 Next: Phase 4 - Agent-Docs Write Detection
Need to detect when the local agent writes to `.agent-docs/` and broadcast notification.

### Environment Notes
- Full build requires: `cmake` and Xcode command line tools
- Install with: `brew install cmake && xcode-select --install`
- Proto changes are complete and verified
- Agent activity tracking is complete and tested

## Current State Analysis

### Existing Infrastructure We Can Leverage

1. **Room-based presence system** (`crates/call/src/call_impl/room.rs`)
   - `RemoteParticipant` struct tracks users with location, projects, role
   - `RoomUpdated` broadcasts presence changes to all participants
   - UI renders participants in collab panel

2. **Agent thread system** (`crates/agent/src/thread.rs`)
   - `Thread` manages agent execution lifecycle
   - `ThreadEvent` stream captures all activity (prompts, tool calls, completions)
   - `thread.model()?.upstream_provider_name()` gives agent type ("Anthropic", "OpenAI", etc.)
   - `thread.summarization_model` exists for generating summaries

3. **RPC infrastructure** (`crates/proto/`, `crates/collab/src/rpc.rs`)
   - Well-established patterns for adding new message types
   - `ai.proto` already has agent-related messages

4. **Worktree sync** (`crates/worktree/`, `crates/project/`)
   - Shared projects already sync file changes via CRDT
   - Files in `.agent-docs/` would sync automatically

### Key Discoveries
- Agent type accessible via `thread.model()?.upstream_provider_name()` at `crates/agent/src/thread.rs:932`
- Thread events flow through `handle_thread_events()` at `crates/agent/src/agent.rs:766`
- Room broadcasts via `room_updated()` at `crates/collab/src/rpc.rs:3917`
- Collab panel renders participants at `crates/collab_ui/src/collab_panel.rs:943`

## Desired End State

After this plan is complete:

1. When User A's agent starts working, User B sees "User A's Agent (Anthropic) - Active" in the collab panel
2. User B can hover to see a summary of what User A prompted their agent to do
3. When User A's agent writes to `.agent-docs/`, User B's agent is notified and can read the file
4. All state is ephemeral - cleared when users leave the room

### Verification
- Two users in a shared project, each with an agent panel open
- User A prompts their agent → User B's collab panel shows agent activity within 1-2 seconds
- User A's agent writes `.agent-docs/notes.md` → User B's agent receives notification
- User A leaves room → User B's collab panel clears User A's agent activity

## What We're NOT Doing

- Persisting agent activity to database (ephemeral only)
- Agent-to-agent direct communication or coordination
- Automatic conflict resolution when agents edit same files
- Injecting other agents' context automatically (just notification)
- Supporting agents outside of shared project rooms

## Implementation Approach

We extend the existing room presence system with agent activity state. Agent writes to `.agent-docs/` leverage worktree sync (already works) plus a lightweight notification layer.

---

## Phase 1: Proto Messages & Data Structures

### Overview
Define the protocol messages and client-side data structures for agent activity.

### Changes Required

#### 1. Proto Message Definitions
**File**: `crates/proto/proto/ai.proto`
**Changes**: Add agent activity messages at end of file

```protobuf
// Agent activity sync for collaborative sessions
enum AgentActivityStatus {
    AgentIdle = 0;
    AgentActive = 1;
}

message AgentActivity {
    uint64 user_id = 1;
    string agent_type = 2;  // "Anthropic", "OpenAI", "Google AI", "xAI"
    AgentActivityStatus status = 3;
    optional string prompt_summary = 4;
}

message UpdateAgentActivity {
    uint64 room_id = 1;
    AgentActivity activity = 2;
}

message AgentDocChanged {
    uint64 room_id = 1;
    uint64 user_id = 2;
    string path = 3;  // relative path within .agent-docs/
}
```

#### 2. Register Messages in Envelope
**File**: `crates/proto/proto/zed.proto`
**Changes**: Add to `Envelope` oneof payload (find next available field numbers)

```protobuf
UpdateAgentActivity update_agent_activity = XXX;
AgentDocChanged agent_doc_changed = XXX;
```

#### 3. Register Messages in Rust
**File**: `crates/proto/src/proto.rs`
**Changes**: Add to `messages!` macro

```rust
(UpdateAgentActivity, Foreground),
(AgentDocChanged, Foreground),
```

#### 4. Extend RemoteParticipant
**File**: `crates/call/src/call_impl/participant.rs`
**Changes**: Add agent activity field to `RemoteParticipant`

```rust
pub struct RemoteParticipant {
    // ... existing fields ...
    pub agent_activity: Option<AgentActivity>,
}

#[derive(Clone, Debug)]
pub struct AgentActivity {
    pub agent_type: SharedString,
    pub status: AgentActivityStatus,
    pub prompt_summary: Option<SharedString>,
}

#[derive(Clone, Debug, PartialEq)]
pub enum AgentActivityStatus {
    Idle,
    Active,
}
```

#### 5. Add Room Event for Agent Activity
**File**: `crates/call/src/call_impl/room.rs`
**Changes**: Add event variant

```rust
pub enum Event {
    // ... existing variants ...
    ParticipantAgentActivityChanged { peer_id: proto::PeerId },
}
```

### Success Criteria

#### Automated Verification
- [x] Proto compiles: `cargo build -p proto`
- [x] Call crate compiles: `cargo build -p call` (requires cmake + Xcode tools)
- [x] No clippy warnings: `./script/clippy -p proto`

#### Manual Verification
- [x] N/A - no user-visible changes yet

### Implementation Notes
**Files Modified:**
- `crates/proto/proto/ai.proto`: Added `AgentActivityStatus`, `AgentActivity`, `UpdateAgentActivity`, `AgentDocChanged` messages
- `crates/proto/proto/zed.proto`: Registered messages in Envelope (fields 396, 397)
- `crates/proto/src/proto.rs`: Added message registrations in `messages!` macro
- `crates/call/src/call_impl/participant.rs`: Added `AgentActivity`, `AgentActivityStatus` types; extended `RemoteParticipant` with `agent_activity: Option<AgentActivity>`
- `crates/call/src/call_impl/room.rs`: Added `ParticipantAgentActivityChanged` and `AgentDocChanged` to Event enum; initialized `agent_activity: None` in RemoteParticipant creation

---

## Phase 2: Local Agent Activity Tracking

### Overview
Track agent activity locally and emit events when it changes. Includes prompt summarization.

### Changes Required

#### 1. Create AgentActivityTracker
**File**: `crates/agent/src/agent_activity.rs` (new file)
**Changes**: Create tracker struct

```rust
use gpui::{Entity, Context, SharedString, Task};
use language_model::LanguageModel;
use std::sync::Arc;

pub struct AgentActivityTracker {
    status: AgentActivityStatus,
    agent_type: Option<SharedString>,
    prompt_summary: Option<SharedString>,
    pending_summarization: Option<Task<()>>,
}

#[derive(Clone, Debug, PartialEq)]
pub enum AgentActivityStatus {
    Idle,
    Active,
}

impl AgentActivityTracker {
    pub fn new() -> Self {
        Self {
            status: AgentActivityStatus::Idle,
            agent_type: None,
            prompt_summary: None,
            pending_summarization: None,
        }
    }

    pub fn set_active(&mut self, model: &Arc<dyn LanguageModel>, cx: &mut Context<Self>) {
        self.status = AgentActivityStatus::Active;
        self.agent_type = Some(model.upstream_provider_name().0.clone());
        cx.notify();
    }

    pub fn set_idle(&mut self, cx: &mut Context<Self>) {
        self.status = AgentActivityStatus::Idle;
        self.pending_summarization = None;
        cx.notify();
    }

    pub fn summarize_prompt(
        &mut self,
        prompt: String,
        summarization_model: Arc<dyn LanguageModel>,
        cx: &mut Context<Self>,
    ) {
        let task = cx.spawn(async move |this, mut cx| {
            let summary = Self::generate_summary(prompt, summarization_model).await;
            this.update(&mut cx, |this, cx| {
                if let Ok(summary) = summary {
                    this.prompt_summary = Some(summary.into());
                    cx.notify();
                }
            }).ok();
        });
        self.pending_summarization = Some(task);
    }

    async fn generate_summary(
        prompt: String,
        model: Arc<dyn LanguageModel>,
    ) -> anyhow::Result<String> {
        // Truncate very long prompts before summarizing
        let truncated = if prompt.len() > 2000 {
            format!("{}...", &prompt[..2000])
        } else {
            prompt
        };

        let request = language_model::LanguageModelRequest {
            messages: vec![language_model::LanguageModelRequestMessage {
                role: language_model::Role::User,
                content: vec![language_model::MessageContent::Text(format!(
                    "Summarize this prompt in one short sentence (max 100 chars). Just the summary, no preamble:\n\n{}",
                    truncated
                ))],
                cache: false,
            }],
            tools: vec![],
            stop: vec![],
            temperature: Some(0.0),
        };

        let mut response = String::new();
        let mut stream = model.stream_completion(request, &[])?;
        while let Some(event) = stream.next().await {
            if let language_model::LanguageModelCompletionEvent::Text(text) = event? {
                response.push_str(&text);
            }
        }

        // Truncate summary if model went over
        Ok(if response.len() > 100 {
            format!("{}...", &response[..97])
        } else {
            response
        })
    }

    pub fn activity(&self) -> Option<proto::AgentActivity> {
        let agent_type = self.agent_type.as_ref()?;
        Some(proto::AgentActivity {
            user_id: 0, // Filled in by caller
            agent_type: agent_type.to_string(),
            status: match self.status {
                AgentActivityStatus::Active => proto::AgentActivityStatus::AgentActive as i32,
                AgentActivityStatus::Idle => proto::AgentActivityStatus::AgentIdle as i32,
            },
            prompt_summary: self.prompt_summary.as_ref().map(|s| s.to_string()),
        })
    }
}
```

#### 2. Add Module Declaration
**File**: `crates/agent/src/agent.rs`
**Changes**: Add module and integrate tracker

```rust
mod agent_activity;
pub use agent_activity::{AgentActivityTracker, AgentActivityStatus};
```

#### 3. Hook Into Thread Lifecycle
**File**: `crates/agent/src/thread.rs`
**Changes**: Emit activity events at key points

In `run_turn()` (around line 1175):
```rust
// At start of turn, before spawning task:
cx.emit(ThreadEvent::ActivityChanged { active: true });
```

In `run_turn_internal()` completion (around line 1294):
```rust
// When turn completes:
cx.emit(ThreadEvent::ActivityChanged { active: false });
```

#### 4. Add ThreadEvent Variant
**File**: `crates/agent/src/thread.rs`
**Changes**: Add to ThreadEvent enum

```rust
pub enum ThreadEvent {
    // ... existing variants ...
    ActivityChanged { active: bool },
}
```

#### 5. Handle Activity Events in NativeAgent
**File**: `crates/agent/src/agent.rs`
**Changes**: In `handle_thread_events()`, capture activity changes and forward to tracker

```rust
ThreadEvent::ActivityChanged { active } => {
    // Forward to activity tracker (implementation depends on how tracker is owned)
}
```

### Success Criteria

#### Automated Verification
- [x] Agent crate compiles: `cargo build -p agent`
- [x] Agent tests pass: `cargo test -p agent`
- [x] No clippy warnings: `./script/clippy`

#### Manual Verification
- [x] N/A - no user-visible changes yet

### Implementation Notes
**Files Modified:**
- `crates/agent/src/agent_activity.rs` (new file): Created `AgentActivityTracker` with `AgentActivityStatus` enum and `ActivityStatusChanged` event emitter
- `crates/agent/src/agent.rs`: Added module declaration; added `activity_tracker: Entity<AgentActivityTracker>` to `NativeAgent`; exposed `activity_tracker()` getter; updated `run_turn` and `handle_thread_events` to pass activity tracker
- `crates/agent/src/thread.rs`: Extended `ThreadEvent` enum with `ActivityChanged { active: bool, agent_type: Option<SharedString> }`; added `send_activity_changed` method to `ThreadEventStream`; emit activity events at turn start/end
- `crates/agent/src/tests/mod.rs`: Updated `expect_tool_call` and `expect_tool_call_update_fields` helper functions to skip `ActivityChanged` events

---

## Phase 3: Room Broadcasting

### Overview
Broadcast agent activity changes to room participants and receive updates from others.

### Changes Required

#### 1. Register Server Handler
**File**: `crates/collab/src/rpc.rs`
**Changes**: Add message handler in `Server::new()`

```rust
server
    .add_message_handler(update_agent_activity)
    .add_message_handler(agent_doc_changed)
```

#### 2. Implement Server Handlers
**File**: `crates/collab/src/rpc.rs`
**Changes**: Add handler functions

```rust
async fn update_agent_activity(
    message: proto::UpdateAgentActivity,
    session: MessageContext,
) -> Result<()> {
    let room_id = RoomId::from_proto(message.room_id);
    let connection_pool = session.connection_pool().await;

    // Get all participants in the room except sender
    let room = session.db().await.get_room(room_id).await?;
    for participant in room.participants {
        if participant.peer_id != Some(session.connection_id.into()) {
            if let Some(peer_id) = participant.peer_id {
                session.peer.send(
                    peer_id.into(),
                    proto::UpdateAgentActivity {
                        room_id: message.room_id,
                        activity: message.activity.clone(),
                    },
                )?;
            }
        }
    }

    Ok(())
}

async fn agent_doc_changed(
    message: proto::AgentDocChanged,
    session: MessageContext,
) -> Result<()> {
    let room_id = RoomId::from_proto(message.room_id);

    // Broadcast to all participants except sender
    let room = session.db().await.get_room(room_id).await?;
    for participant in room.participants {
        if participant.peer_id != Some(session.connection_id.into()) {
            if let Some(peer_id) = participant.peer_id {
                session.peer.send(
                    peer_id.into(),
                    proto::AgentDocChanged {
                        room_id: message.room_id,
                        user_id: message.user_id,
                        path: message.path.clone(),
                    },
                )?;
            }
        }
    }

    Ok(())
}
```

#### 3. Client-Side: Send Activity Updates
**File**: `crates/call/src/call_impl/room.rs`
**Changes**: Add method to send activity updates

```rust
pub fn update_agent_activity(
    &self,
    activity: proto::AgentActivity,
    cx: &App,
) -> Result<()> {
    self.client.send(proto::UpdateAgentActivity {
        room_id: self.id,
        activity: Some(activity),
    })
}
```

#### 4. Client-Side: Receive Activity Updates
**File**: `crates/call/src/call_impl/room.rs`
**Changes**: Register handler in `Room::new()` and implement

```rust
// In Room::new(), add subscription:
client.add_message_handler(cx.weak_entity(), Self::handle_agent_activity_update)

// Handler implementation:
async fn handle_agent_activity_update(
    this: Entity<Self>,
    envelope: TypedEnvelope<proto::UpdateAgentActivity>,
    _: Arc<Client>,
    cx: &mut AsyncApp,
) -> Result<()> {
    this.update(cx, |this, cx| {
        if let Some(activity) = envelope.payload.activity {
            let user_id = activity.user_id;
            if let Some(participant) = this.remote_participants.values_mut()
                .find(|p| p.user.id == user_id)
            {
                participant.agent_activity = Some(AgentActivity {
                    agent_type: activity.agent_type.into(),
                    status: if activity.status == proto::AgentActivityStatus::AgentActive as i32 {
                        AgentActivityStatus::Active
                    } else {
                        AgentActivityStatus::Idle
                    },
                    prompt_summary: activity.prompt_summary.map(|s| s.into()),
                });
                cx.emit(Event::ParticipantAgentActivityChanged {
                    peer_id: participant.peer_id,
                });
            }
        }
    })?;
    Ok(())
}
```

#### 5. Client-Side: Handle AgentDocChanged
**File**: `crates/call/src/call_impl/room.rs`
**Changes**: Similar pattern for doc notifications

```rust
// Register handler
client.add_message_handler(cx.weak_entity(), Self::handle_agent_doc_changed)

// Emit event for agent to consume
pub enum Event {
    // ... existing ...
    AgentDocChanged { user_id: u64, path: String },
}

async fn handle_agent_doc_changed(
    this: Entity<Self>,
    envelope: TypedEnvelope<proto::AgentDocChanged>,
    _: Arc<Client>,
    cx: &mut AsyncApp,
) -> Result<()> {
    this.update(cx, |this, cx| {
        cx.emit(Event::AgentDocChanged {
            user_id: envelope.payload.user_id,
            path: envelope.payload.path,
        });
    })?;
    Ok(())
}
```

### Success Criteria

#### Automated Verification
- [x] Collab crate compiles: `cargo build -p collab`
- [x] Call crate compiles: `cargo build -p call`
- [x] Agent UI crate compiles: `cargo build -p agent_ui`
- [x] No clippy warnings: `./script/clippy`

#### Manual Verification
- [ ] Two users in a shared project with active call
- [ ] User A prompts their agent → User B receives activity update
- [ ] Activity update includes agent type, status, and prompt summary
- [ ] User A's agent completes → User B receives idle status update
- [ ] User A leaves room → activity updates stop broadcasting

### Implementation Notes
**Files Modified:**
- `crates/agent/src/agent.rs`: Added `activity_tracker()` method to `NativeAgentConnection` to expose the activity tracker
- `crates/agent_ui/src/acp/thread_view.rs`: Added subscription to `ActivityStatusChanged` events in `AcpThreadView::initial_state()`; broadcasts activity to room via `room.update_agent_activity()`; sends initial state when joining room with already-active agent
- `crates/collab/src/rpc.rs`: Server-side handlers already implemented (lines 2624-2665)
- `crates/call/src/call_impl/room.rs`: Client-side handlers already implemented (lines 664-705, 1278-1287)

---

## Phase 4: Agent-Docs Write Detection

### Overview
Detect when the local agent writes to `.agent-docs/` and broadcast notification.

### Changes Required

#### 1. Watch for Agent-Docs Writes
**File**: `crates/agent/src/action_log.rs`
**Changes**: Detect writes to `.agent-docs/` path

```rust
// In track_buffer_internal or similar, check if path is in .agent-docs/
fn is_agent_doc_path(path: &Path) -> bool {
    path.components().any(|c| c.as_os_str() == ".agent-docs")
}

// When buffer is saved and path matches, emit event
```

#### 2. Emit AgentDocWritten Event
**File**: `crates/agent/src/thread.rs` or `agent.rs`
**Changes**: Add event type and emission

```rust
pub enum AgentEvent {
    ActivityChanged { ... },
    DocWritten { path: PathBuf },
}
```

#### 3. Connect to Room Broadcast
**File**: `crates/agent/src/agent.rs` or integration point
**Changes**: When `DocWritten` event fires, call `room.send_agent_doc_changed()`

```rust
// In the component that owns both agent and room access:
if let AgentEvent::DocWritten { path } = event {
    if let Some(room) = active_call.read(cx).room() {
        room.update(cx, |room, cx| {
            let relative_path = path.strip_prefix(&project_root)
                .unwrap_or(&path)
                .to_string_lossy()
                .to_string();
            room.send_agent_doc_changed(relative_path, cx);
        });
    }
}
```

### Success Criteria

#### Automated Verification
- [ ] Agent crate compiles: `cargo build -p agent`
- [ ] Agent tests pass: `cargo test -p agent`
- [ ] No clippy warnings: `./script/clippy`

#### Manual Verification
- [ ] N/A - UI feedback not implemented yet

---

## Phase 5: Collab Panel UI

### Overview
Display agent activity in the collab panel alongside user presence.

### Changes Required

#### 1. Subscribe to Agent Activity Events
**File**: `crates/collab_ui/src/collab_panel.rs`
**Changes**: In room subscription, handle `ParticipantAgentActivityChanged`

```rust
// In existing room observation code:
Event::ParticipantAgentActivityChanged { .. } => {
    this.update_entries(false, cx);
}
```

#### 2. Update Participant Rendering
**File**: `crates/collab_ui/src/collab_panel.rs`
**Changes**: Modify `render_call_participant()` to show agent activity

```rust
fn render_call_participant(
    &self,
    user: &Arc<User>,
    peer_id: Option<PeerId>,
    is_pending: bool,
    role: proto::ChannelRole,
    agent_activity: Option<&AgentActivity>,
    cx: &mut Context<Self>,
) -> impl IntoElement {
    let has_active_agent = agent_activity
        .map(|a| a.status == AgentActivityStatus::Active)
        .unwrap_or(false);

    let agent_label = agent_activity.and_then(|a| {
        if a.status == AgentActivityStatus::Active {
            Some(format!("{} Agent", a.agent_type))
        } else {
            None
        }
    });

    let prompt_tooltip = agent_activity
        .and_then(|a| a.prompt_summary.clone());

    ListItem::new(user.github_login.clone())
        .start_slot(Avatar::new(user.avatar_uri.clone()))
        .child(render_participant_name_and_handle(user))
        .end_slot(
            h_flex()
                .gap_1()
                .when_some(agent_label, |this, label| {
                    this.child(
                        Label::new(label)
                            .size(LabelSize::Small)
                            .color(Color::Success)
                            .when_some(prompt_tooltip, |this, tooltip| {
                                this.tooltip(move |_cx| Tooltip::text(tooltip.clone()))
                            })
                    )
                })
                // ... existing end slot content ...
        )
}
```

#### 3. Pass Agent Activity to Renderer
**File**: `crates/collab_ui/src/collab_panel.rs`
**Changes**: In `render_entry()`, extract agent activity from participant

```rust
ListEntry::CallParticipant { user, peer_id, is_pending, role } => {
    let agent_activity = peer_id.and_then(|pid| {
        room.read(cx).remote_participants().get(&pid)
            .and_then(|p| p.agent_activity.as_ref())
    });

    self.render_call_participant(user, *peer_id, *is_pending, *role, agent_activity, cx)
}
```

### Success Criteria

#### Automated Verification
- [ ] Collab UI crate compiles: `cargo build -p collab_ui`
- [ ] No clippy warnings: `./script/clippy`

#### Manual Verification
- [ ] Two users join a shared project room
- [ ] User A opens agent panel and sends a prompt
- [ ] User B sees "Anthropic Agent" label appear next to User A in collab panel within 2 seconds
- [ ] User B hovers over label and sees prompt summary tooltip
- [ ] User A's agent completes → label disappears or changes to idle state
- [ ] User A leaves room → all agent activity for User A clears

---

## Phase 6: Integration Testing

### Overview
Add integration tests for the room broadcasting functionality.

### Changes Required

#### 1. Add Agent Activity Broadcast Test
**File**: `crates/collab/src/tests/agent_sync_tests.rs` (new file)
**Changes**: Create test module

```rust
use crate::tests::TestServer;
use gpui::TestAppContext;

#[gpui::test]
async fn test_agent_activity_broadcast(
    cx_a: &mut TestAppContext,
    cx_b: &mut TestAppContext,
) {
    let server = TestServer::start(cx_a.executor()).await;
    let client_a = server.create_client(cx_a, "user_a").await;
    let client_b = server.create_client(cx_b, "user_b").await;

    // Both join a room
    let room_a = client_a.create_room(cx_a).await;
    client_b.join_room(room_a.id(), cx_b).await;

    // User A sends agent activity update
    room_a.update(cx_a, |room, cx| {
        room.update_agent_activity(proto::AgentActivity {
            user_id: client_a.user_id(),
            agent_type: "Anthropic".into(),
            status: proto::AgentActivityStatus::AgentActive as i32,
            prompt_summary: Some("Analyzing code".into()),
        }, cx).unwrap();
    });

    // Verify User B receives it
    cx_b.executor().run_until_parked();

    let room_b = client_b.room().unwrap();
    room_b.read_with(cx_b, |room, _| {
        let participant = room.remote_participants()
            .values()
            .find(|p| p.user.id == client_a.user_id())
            .unwrap();

        let activity = participant.agent_activity.as_ref().unwrap();
        assert_eq!(activity.agent_type.as_ref(), "Anthropic");
        assert_eq!(activity.status, AgentActivityStatus::Active);
        assert_eq!(activity.prompt_summary.as_deref(), Some("Analyzing code"));
    });
}

#[gpui::test]
async fn test_agent_doc_changed_notification(
    cx_a: &mut TestAppContext,
    cx_b: &mut TestAppContext,
) {
    // Similar setup...
    // Verify AgentDocChanged broadcasts correctly
}
```

#### 2. Register Test Module
**File**: `crates/collab/src/tests.rs`
**Changes**: Add module

```rust
mod agent_sync_tests;
```

### Success Criteria

#### Automated Verification
- [ ] Integration tests pass: `cargo test -p collab test_agent_activity_broadcast`
- [ ] Integration tests pass: `cargo test -p collab test_agent_doc_changed_notification`
- [ ] All collab tests pass: `cargo test -p collab`

#### Manual Verification
- [ ] N/A - tests are the verification

---

## Testing Strategy

### Unit Tests
- `AgentActivityTracker` state transitions
- Proto message serialization round-trips
- Path detection for `.agent-docs/` folder

### Integration Tests
- Two-client room with agent activity broadcast (Phase 6)
- Agent doc changed notification propagation
- Activity cleared on room leave

### Manual Testing Steps
1. Start two Zed instances with different users
2. Create shared project and have both join
3. User A opens agent panel, sends prompt to Claude
4. Verify User B sees activity in collab panel
5. User A's agent writes to `.agent-docs/analysis.md`
6. Verify User B's agent (if running) could be notified
7. User A leaves room - verify activity clears for User B

## Performance Considerations

- Prompt summarization is async and non-blocking
- Activity updates are lightweight (small proto messages)
- Doc change notifications don't include file content (just path)
- Worktree sync handles actual file transfer

## Migration Notes

N/A - new feature with no existing data to migrate.

## References

- Research doc: `thoughts/shared/research/2025-11-25-agent-sync-infrastructure.md`
- Research doc: `thoughts/shared/research/2025-01-24-ai-first-feature-infrastructure.md`
- Room presence implementation: `crates/call/src/call_impl/room.rs:643`
- Agent thread implementation: `crates/agent/src/thread.rs`
- RPC patterns: `crates/collab/src/rpc.rs`
