### PR TITLE
project: Make individual DAP settings optional

### DIFF
--- a/crates/project/src/debugger/dap_store.rs
+++ b/crates/project/src/debugger/dap_store.rs
@@ -266,8 +266,8 @@ impl DapStore {
                         Some(worktree.read(cx).resolve_executable_path(path))
                     }
                 });
-                let user_args = dap_settings.map(|s| s.args.clone());
-                let user_env = dap_settings.map(|s| s.env.clone());
+                let user_args = dap_settings.and_then(|s| s.args.clone());
+                let user_env = dap_settings.and_then(|s| s.env.clone());
 
                 let delegate = self.delegate(worktree, console, cx);
 

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -1207,8 +1207,8 @@ pub fn local_settings_kind_to_proto(kind: LocalSettingsKind) -> proto::LocalSett
 #[derive(Debug, Clone)]
 pub struct DapSettings {
     pub binary: DapBinary,
-    pub args: Vec<String>,
-    pub env: HashMap<String, String>,
+    pub args: Option<Vec<String>>,
+    pub env: Option<HashMap<String, String>>,
 }
 
 impl From<DapSettingsContent> for DapSettings {
@@ -1217,8 +1217,8 @@ impl From<DapSettingsContent> for DapSettings {
             binary: content
                 .binary
                 .map_or_else(|| DapBinary::Default, |binary| DapBinary::Custom(binary)),
-            args: content.args.unwrap_or_default(),
-            env: content.env.unwrap_or_default(),
+            args: content.args,
+            env: content.env,
         }
     }
 }


### PR DESCRIPTION
Currently, when overriding e.g a `binary` in dap settings, one have to override all settings, including `args` as it otherwise set it to empty string.

E.g this config will set `args` and `env` to their empty states, like empty string and empty map:
```json
{
  "dap": {
    "Delve": {
      "binary": "/path/to/binary"
    }
  }
}
```

This PR changes so that it is instead possible to only override a single field. This is useful e.g on nixos where you don't want (or cant let) zed download binaries for you, but you want to use the default args, such as in Delve, you want zed to configure it with a random listening port.

Release Notes:

- Improved dap settings so that it is possible to override individual fields, such as `binary`
