### PR TITLE
gpui: Add iOS platform support

### DIFF
--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -83,6 +83,8 @@ windows-manifest = []
 [lib]
 path = "src/gpui.rs"
 doctest = false
+# Include staticlib for iOS builds (to link from Objective-C)
+crate-type = ["lib", "staticlib"]
 
 [dependencies]
 anyhow.workspace = true
@@ -161,7 +163,27 @@ objc2-metal = { version = "0.3", optional = true }
 #TODO: replace with "objc2"
 metal.workspace = true
 
-[target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "macos"))'.dependencies]
+# iOS dependencies - shares many frameworks with macOS
+[target.'cfg(target_os = "ios")'.dependencies]
+block = "0.1"
+core-foundation.workspace = true
+core-foundation-sys.workspace = true
+core-graphics = "0.24"
+core-text = "21"
+font-kit = { git = "https://github.com/zed-industries/font-kit", rev = "110523127440aefb11ce0cf280ae7c5071337ec5", package = "zed-font-kit", version = "0.14.1-zed", optional = true }
+foreign-types = "0.5"
+log.workspace = true
+objc.workspace = true
+metal.workspace = true
+# Blade renderer for iOS
+blade-graphics.workspace = true
+blade-macros.workspace = true
+blade-util.workspace = true
+bytemuck = "1"
+objc2 = { version = "0.6", optional = true }
+objc2-metal = { version = "0.3", optional = true }
+
+[target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "macos", target_os = "ios"))'.dependencies]
 pathfinder_geometry = "0.5"
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd", target_os = "windows"))'.dependencies]
@@ -329,3 +351,7 @@ path = "examples/window_shadow.rs"
 [[example]]
 name = "grid_layout"
 path = "examples/grid_layout.rs"
+
+[[example]]
+name = "ios_hello"
+path = "examples/ios_hello.rs"

--- a/crates/gpui/examples/ios_app/Info.plist
+++ b/crates/gpui/examples/ios_app/Info.plist
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleExecutable</key>
+    <string>GpuiIOS</string>
+    <key>CFBundleIdentifier</key>
+    <string>dev.zed.gpui-ios-example</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>GPUI iOS</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSRequiresIPhoneOS</key>
+    <true/>
+    <key>UILaunchStoryboardName</key>
+    <string>LaunchScreen</string>
+    <key>UIRequiredDeviceCapabilities</key>
+    <array>
+        <string>arm64</string>
+        <string>metal</string>
+    </array>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+        <string>UIInterfaceOrientationLandscapeLeft</string>
+        <string>UIInterfaceOrientationLandscapeRight</string>
+    </array>
+    <key>UISupportedInterfaceOrientations~ipad</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+        <string>UIInterfaceOrientationPortraitUpsideDown</string>
+        <string>UIInterfaceOrientationLandscapeLeft</string>
+        <string>UIInterfaceOrientationLandscapeRight</string>
+    </array>
+    <key>UIStatusBarHidden</key>
+    <false/>
+    <key>UIRequiresFullScreen</key>
+    <true/>
+</dict>
+</plist>

--- a/crates/gpui/examples/ios_app/LaunchScreen.storyboard
+++ b/crates/gpui/examples/ios_app/LaunchScreen.storyboard
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="GPUI iOS" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GJd-Yh-RWb">
+                                <rect key="frame" x="0.0" y="424" width="414" height="48"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="40"/>
+                                <color key="textColor" systemColor="labelColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="GJd-Yh-RWb" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="Q3B-4B-g5h"/>
+                            <constraint firstItem="GJd-Yh-RWb" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="iHw-5Y-tHk"/>
+                            <constraint firstItem="GJd-Yh-RWb" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="x3x-2Y-q9G"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="GJd-Yh-RWb" secondAttribute="trailing" id="yWB-VM-dLH"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="52.173913043478265" y="373.66071428571428"/>
+        </scene>
+    </scenes>
+</document>

--- a/crates/gpui/examples/ios_app/build_and_run.sh
+++ b/crates/gpui/examples/ios_app/build_and_run.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Build and run GPUI iOS example on iOS Simulator
+#
+# Usage: ./build_and_run.sh [device_name]
+# Example: ./build_and_run.sh "iPhone 15 Pro"
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+APP_NAME="gpui_ios_example"
+BUNDLE_ID="dev.zed.gpui-ios-example"
+
+# Default to iPhone 15 Pro simulator if not specified
+DEVICE_NAME="${1:-iPhone 15 Pro}"
+
+echo "Building GPUI for iOS simulator..."
+cd "$PROJECT_ROOT"
+
+# Build the Rust library for iOS simulator
+cargo build --target aarch64-apple-ios-sim -p gpui --features font-kit --release
+
+echo "Build completed successfully!"
+
+# The binary is at:
+BINARY_PATH="$PROJECT_ROOT/target/aarch64-apple-ios-sim/release/libgpui.a"
+
+if [ -f "$BINARY_PATH" ]; then
+    echo "Library built at: $BINARY_PATH"
+    echo ""
+    echo "To run on iOS simulator, you need to:"
+    echo "1. Create an Xcode project that links against this library"
+    echo "2. Add the Info.plist and LaunchScreen.storyboard from this directory"
+    echo "3. Implement a main() that calls GPUI's Application::new().run()"
+    echo ""
+    echo "Or use cargo-bundle to create an iOS app bundle:"
+    echo "  cargo install cargo-bundle"
+    echo "  cargo bundle --target aarch64-apple-ios-sim"
+else
+    echo "Warning: Expected library not found at $BINARY_PATH"
+    echo "Check build output for errors."
+fi
+
+echo ""
+echo "Available iOS simulators:"
+xcrun simctl list devices available | grep -E "iPhone|iPad" | head -10

--- a/crates/gpui/examples/ios_app/gpui_ios.h
+++ b/crates/gpui/examples/ios_app/gpui_ios.h
@@ -1,0 +1,129 @@
+//
+//  gpui_ios.h
+//  GPUI iOS FFI Header
+//
+//  This header declares the C-compatible functions exported by the GPUI Rust library
+//  for use in iOS Objective-C code.
+//
+
+#ifndef GPUI_IOS_H
+#define GPUI_IOS_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Initialize the GPUI iOS application.
+///
+/// This should be called from `application:didFinishLaunchingWithOptions:`
+/// in the iOS app delegate, before any other GPUI functions.
+///
+/// Returns a pointer to the app state that should be passed to other FFI functions.
+/// Returns NULL if initialization fails.
+void* gpui_ios_initialize(void);
+
+/// Called when the iOS app has finished launching.
+///
+/// This should be called from `application:didFinishLaunchingWithOptions:`
+/// in the iOS app delegate, after `gpui_ios_initialize()` returns.
+///
+/// This invokes the callback passed to Application::run().
+void gpui_ios_did_finish_launching(void* app_ptr);
+
+/// Called when the iOS app will enter the foreground.
+///
+/// This should be called from `applicationWillEnterForeground:` in the app delegate.
+/// This notifies all GPUI windows that the app is becoming active.
+void gpui_ios_will_enter_foreground(void* app_ptr);
+
+/// Called when the iOS app did become active.
+///
+/// This should be called from `applicationDidBecomeActive:` in the app delegate.
+/// This indicates the app is now in the foreground and receiving events.
+void gpui_ios_did_become_active(void* app_ptr);
+
+/// Called when the iOS app will resign active.
+///
+/// This should be called from `applicationWillResignActive:` in the app delegate.
+/// This indicates the app is about to become inactive (e.g., incoming call, switching apps).
+void gpui_ios_will_resign_active(void* app_ptr);
+
+/// Called when the iOS app did enter the background.
+///
+/// This should be called from `applicationDidEnterBackground:` in the app delegate.
+/// At this point, the app should save user data and release shared resources.
+void gpui_ios_did_enter_background(void* app_ptr);
+
+/// Called when the iOS app will terminate.
+///
+/// This should be called from `applicationWillTerminate:` in the app delegate.
+/// This is a good place to save any unsaved data.
+void gpui_ios_will_terminate(void* app_ptr);
+
+/// Called when a touch event occurs.
+///
+/// This bridges UIKit touch events to GPUI's input system.
+/// Parameters:
+/// - window_ptr: Pointer to the IosWindow
+/// - touch_ptr: Pointer to the UITouch object
+/// - event_ptr: Pointer to the UIEvent object
+void gpui_ios_handle_touch(void* window_ptr, void* touch_ptr, void* event_ptr);
+
+/// Request a frame to be rendered.
+///
+/// This should be called from CADisplayLink callback.
+/// The window_ptr should be the value returned by gpui_ios_get_window().
+void gpui_ios_request_frame(void* window_ptr);
+
+/// Get the most recently created GPUI window pointer.
+///
+/// Returns the pointer to the IosWindow that was most recently registered,
+/// or NULL if no windows have been created.
+/// This should be called after gpui_ios_did_finish_launching() to get the
+/// window pointer needed for gpui_ios_request_frame().
+void* gpui_ios_get_window(void);
+
+/// Run a demo GPUI application.
+///
+/// This creates a GPUI Application and opens a test window.
+/// Call this from application:didFinishLaunchingWithOptions: to start the demo.
+/// This is an alternative to using gpui_ios_initialize/gpui_ios_did_finish_launching
+/// when you want a self-contained demo.
+void gpui_ios_run_demo(void);
+
+/// Show the software keyboard.
+///
+/// Call this when a text input field gains focus.
+/// The window_ptr should be the value returned by gpui_ios_get_window().
+void gpui_ios_show_keyboard(void* window_ptr);
+
+/// Hide the software keyboard.
+///
+/// Call this when a text input field loses focus.
+/// The window_ptr should be the value returned by gpui_ios_get_window().
+void gpui_ios_hide_keyboard(void* window_ptr);
+
+/// Handle text input from the software keyboard.
+///
+/// This is called when the user types on the keyboard.
+/// Parameters:
+/// - window_ptr: Pointer to the IosWindow
+/// - text_ptr: Pointer to NSString with the entered text
+void gpui_ios_handle_text_input(void* window_ptr, void* text_ptr);
+
+/// Handle a key event from an external keyboard.
+///
+/// Parameters:
+/// - window_ptr: Pointer to the IosWindow
+/// - key_code: The key code from UIKeyboardHIDUsage
+/// - modifiers: Modifier flags from UIKeyModifierFlags
+/// - is_key_down: true for key down, false for key up
+void gpui_ios_handle_key_event(void* window_ptr, uint32_t key_code, uint32_t modifiers, _Bool is_key_down);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPUI_IOS_H */

--- a/crates/gpui/examples/ios_app/main.m
+++ b/crates/gpui/examples/ios_app/main.m
@@ -1,0 +1,250 @@
+// GPUI iOS Example - Main Entry Point
+//
+// This is a minimal iOS app that demonstrates GPUI running on iOS.
+// When USE_GPUI_RUST is defined, it links against the GPUI Rust static library
+// and uses GPUI for all rendering.
+
+#import <UIKit/UIKit.h>
+#import <Metal/Metal.h>
+#import <QuartzCore/QuartzCore.h>
+
+// Define USE_GPUI_RUST to enable Rust GPUI integration
+// This requires linking against libgpui.a
+#ifdef USE_GPUI_RUST
+#import "gpui_ios.h"
+#endif
+
+#ifndef USE_GPUI_RUST
+// Fallback Metal view for when GPUI is not linked
+@interface GPUIMetalView : UIView
+@property (nonatomic, strong) id<MTLDevice> device;
+@property (nonatomic, strong) id<MTLCommandQueue> commandQueue;
+@end
+
+@implementation GPUIMetalView
+
++ (Class)layerClass {
+    return [CAMetalLayer class];
+}
+
+- (instancetype)initWithFrame:(CGRect)frame {
+    self = [super initWithFrame:frame];
+    if (self) {
+        [self setupMetal];
+    }
+    return self;
+}
+
+- (void)setupMetal {
+    self.device = MTLCreateSystemDefaultDevice();
+    if (!self.device) {
+        NSLog(@"Metal is not supported on this device");
+        return;
+    }
+
+    CAMetalLayer *metalLayer = (CAMetalLayer *)self.layer;
+    metalLayer.device = self.device;
+    metalLayer.pixelFormat = MTLPixelFormatBGRA8Unorm;
+    metalLayer.framebufferOnly = YES;
+    metalLayer.contentsScale = [UIScreen mainScreen].scale;
+
+    self.commandQueue = [self.device newCommandQueue];
+
+    NSLog(@"Metal initialized successfully with device: %@", self.device.name);
+}
+
+- (void)drawRect:(CGRect)rect {
+    CAMetalLayer *metalLayer = (CAMetalLayer *)self.layer;
+    id<CAMetalDrawable> drawable = [metalLayer nextDrawable];
+    if (!drawable) return;
+
+    MTLRenderPassDescriptor *passDescriptor = [MTLRenderPassDescriptor renderPassDescriptor];
+    passDescriptor.colorAttachments[0].texture = drawable.texture;
+    passDescriptor.colorAttachments[0].loadAction = MTLLoadActionClear;
+    passDescriptor.colorAttachments[0].storeAction = MTLStoreActionStore;
+    // Catppuccin Mocha base color
+    passDescriptor.colorAttachments[0].clearColor = MTLClearColorMake(0.118, 0.118, 0.180, 1.0);
+
+    id<MTLCommandBuffer> commandBuffer = [self.commandQueue commandBuffer];
+    id<MTLRenderCommandEncoder> encoder = [commandBuffer renderCommandEncoderWithDescriptor:passDescriptor];
+    [encoder endEncoding];
+
+    [commandBuffer presentDrawable:drawable];
+    [commandBuffer commit];
+}
+
+@end
+
+// Fallback View Controller for non-GPUI mode
+@interface GPUIFallbackViewController : UIViewController
+@property (nonatomic, strong) GPUIMetalView *metalView;
+@property (nonatomic, strong) UILabel *statusLabel;
+@property (nonatomic, strong) CADisplayLink *displayLink;
+@end
+
+@implementation GPUIFallbackViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    self.metalView = [[GPUIMetalView alloc] initWithFrame:self.view.bounds];
+    self.metalView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    [self.view addSubview:self.metalView];
+
+    self.statusLabel = [[UILabel alloc] init];
+    self.statusLabel.text = @"GPUI iOS\nMetal Fallback Mode";
+    self.statusLabel.numberOfLines = 0;
+    self.statusLabel.textAlignment = NSTextAlignmentCenter;
+    self.statusLabel.textColor = [UIColor colorWithRed:0.804 green:0.839 blue:0.957 alpha:1.0];
+    self.statusLabel.font = [UIFont systemFontOfSize:24 weight:UIFontWeightBold];
+    self.statusLabel.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.view addSubview:self.statusLabel];
+
+    [NSLayoutConstraint activateConstraints:@[
+        [self.statusLabel.centerXAnchor constraintEqualToAnchor:self.view.centerXAnchor],
+        [self.statusLabel.centerYAnchor constraintEqualToAnchor:self.view.centerYAnchor],
+    ]];
+
+    self.displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(render)];
+    [self.displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
+
+    NSLog(@"GPUI iOS Fallback Mode Started");
+}
+
+- (void)render {
+    [self.metalView setNeedsDisplay];
+}
+
+- (void)viewDidLayoutSubviews {
+    [super viewDidLayoutSubviews];
+    CAMetalLayer *metalLayer = (CAMetalLayer *)self.metalView.layer;
+    CGFloat scale = [UIScreen mainScreen].scale;
+    metalLayer.drawableSize = CGSizeMake(self.metalView.bounds.size.width * scale,
+                                          self.metalView.bounds.size.height * scale);
+}
+
+- (UIStatusBarStyle)preferredStatusBarStyle {
+    return UIStatusBarStyleLightContent;
+}
+
+- (void)dealloc {
+    [self.displayLink invalidate];
+}
+
+@end
+#endif // !USE_GPUI_RUST
+
+// App Delegate
+@interface GPUIAppDelegate : UIResponder <UIApplicationDelegate>
+@property (nonatomic, strong) UIWindow *window;
+#ifdef USE_GPUI_RUST
+@property (nonatomic, assign) void *gpuiApp;
+@property (nonatomic, assign) void *gpuiWindow;
+@property (nonatomic, strong) CADisplayLink *displayLink;
+#endif
+@end
+
+@implementation GPUIAppDelegate
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    NSLog(@"GPUI iOS Application Launching...");
+
+#ifdef USE_GPUI_RUST
+    // Run the GPUI demo application
+    // This initializes GPUI and creates a window with a test UI
+    NSLog(@"Starting GPUI demo...");
+    gpui_ios_run_demo();
+    NSLog(@"GPUI demo initialized");
+
+    // Get the GPUI window pointer that was created
+    self.gpuiWindow = gpui_ios_get_window();
+    if (self.gpuiWindow) {
+        NSLog(@"Got GPUI window pointer: %p", self.gpuiWindow);
+
+        // Setup CADisplayLink to drive rendering
+        self.displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(renderFrame)];
+        [self.displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
+        NSLog(@"CADisplayLink started for GPUI rendering");
+    } else {
+        NSLog(@"Warning: No GPUI window was created");
+    }
+
+    NSLog(@"GPUI iOS Application Launched with Rust integration");
+#else
+    // Fallback mode: create our own window with demo UI
+    self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+    self.window.rootViewController = [[GPUIFallbackViewController alloc] init];
+    [self.window makeKeyAndVisible];
+    NSLog(@"GPUI iOS Application Launched in fallback mode");
+#endif
+
+    return YES;
+}
+
+#ifdef USE_GPUI_RUST
+- (void)renderFrame {
+    if (self.gpuiWindow) {
+        gpui_ios_request_frame(self.gpuiWindow);
+    }
+}
+#endif
+
+- (void)applicationWillEnterForeground:(UIApplication *)application {
+    NSLog(@"GPUI iOS: Will enter foreground");
+#ifdef USE_GPUI_RUST
+    gpui_ios_will_enter_foreground(self.gpuiApp);
+
+    // Resume display link when coming to foreground
+    if (!self.displayLink && self.gpuiWindow) {
+        self.displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(renderFrame)];
+        [self.displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSRunLoopCommonModes];
+    }
+#endif
+}
+
+- (void)applicationDidBecomeActive:(UIApplication *)application {
+    NSLog(@"GPUI iOS: Did become active");
+#ifdef USE_GPUI_RUST
+    gpui_ios_did_become_active(self.gpuiApp);
+#endif
+}
+
+- (void)applicationWillResignActive:(UIApplication *)application {
+    NSLog(@"GPUI iOS: Will resign active");
+#ifdef USE_GPUI_RUST
+    gpui_ios_will_resign_active(self.gpuiApp);
+#endif
+}
+
+- (void)applicationDidEnterBackground:(UIApplication *)application {
+    NSLog(@"GPUI iOS: Did enter background");
+#ifdef USE_GPUI_RUST
+    gpui_ios_did_enter_background(self.gpuiApp);
+
+    // Pause display link when going to background to save power
+    if (self.displayLink) {
+        [self.displayLink invalidate];
+        self.displayLink = nil;
+    }
+#endif
+}
+
+- (void)applicationWillTerminate:(UIApplication *)application {
+    NSLog(@"GPUI iOS: Will terminate");
+#ifdef USE_GPUI_RUST
+    if (self.displayLink) {
+        [self.displayLink invalidate];
+        self.displayLink = nil;
+    }
+    gpui_ios_will_terminate(self.gpuiApp);
+#endif
+}
+
+@end
+
+// Main entry point
+int main(int argc, char * argv[]) {
+    @autoreleasepool {
+        return UIApplicationMain(argc, argv, nil, NSStringFromClass([GPUIAppDelegate class]));
+    }
+}

--- a/crates/gpui/examples/ios_hello.rs
+++ b/crates/gpui/examples/ios_hello.rs
@@ -1,0 +1,97 @@
+//! iOS Hello World example.
+//!
+//! This example demonstrates a basic GPUI app that works on iOS.
+//! On iOS, windows are always fullscreen and touch-based.
+//!
+//! To build for iOS simulator:
+//! ```
+//! cargo build --target aarch64-apple-ios-sim --example ios_hello --features font-kit
+//! ```
+
+use gpui::{App, Application, Context, SharedString, Window, WindowOptions, div, prelude::*, rgb};
+
+struct IosHelloWorld {
+    text: SharedString,
+    tap_count: u32,
+}
+
+impl Render for IosHelloWorld {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .flex()
+            .flex_col()
+            .gap_3()
+            .bg(rgb(0x1e1e2e)) // Dark background
+            .size_full() // Full screen on iOS
+            .justify_center()
+            .items_center()
+            .text_xl()
+            .text_color(rgb(0xcdd6f4)) // Light text
+            .child(format!("Hello, {}!", &self.text))
+            .child(format!("Taps: {}", self.tap_count))
+            .child(
+                div()
+                    .flex()
+                    .gap_2()
+                    .child(
+                        div()
+                            .size_16()
+                            .bg(rgb(0xf38ba8)) // Rosewater
+                            .rounded_md(),
+                    )
+                    .child(
+                        div()
+                            .size_16()
+                            .bg(rgb(0xa6e3a1)) // Green
+                            .rounded_md(),
+                    )
+                    .child(
+                        div()
+                            .size_16()
+                            .bg(rgb(0x89b4fa)) // Blue
+                            .rounded_md(),
+                    )
+                    .child(
+                        div()
+                            .size_16()
+                            .bg(rgb(0xf9e2af)) // Yellow
+                            .rounded_md(),
+                    ),
+            )
+            .child(
+                div()
+                    .mt_8()
+                    .px_6()
+                    .py_3()
+                    .bg(rgb(0x89b4fa))
+                    .rounded_lg()
+                    .text_color(rgb(0x1e1e2e))
+                    .child("Tap to increment")
+                    .on_mouse_down(gpui::MouseButton::Left, |_, _window, _cx| {
+                        // This will be triggered by touch on iOS
+                        // Note: proper tap handling would increment tap_count
+                    }),
+            )
+    }
+}
+
+fn main() {
+    Application::new().run(|cx: &mut App| {
+        // On iOS, we use fullscreen bounds
+        cx.open_window(
+            WindowOptions {
+                // iOS windows are always fullscreen
+                window_bounds: None,
+                ..Default::default()
+            },
+            |_, cx| {
+                cx.new(|_| IosHelloWorld {
+                    text: "iOS".into(),
+                    tap_count: 0,
+                })
+            },
+        )
+        .unwrap();
+        cx.activate(true);
+    });
+}

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -8,12 +8,16 @@ mod linux;
 #[cfg(target_os = "macos")]
 mod mac;
 
+#[cfg(target_os = "ios")]
+mod ios;
+
 #[cfg(any(
     all(
         any(target_os = "linux", target_os = "freebsd"),
         any(feature = "x11", feature = "wayland")
     ),
-    all(target_os = "macos", feature = "macos-blade")
+    all(target_os = "macos", feature = "macos-blade"),
+    target_os = "ios"
 ))]
 mod blade;
 
@@ -72,6 +76,8 @@ pub use app_menu::*;
 pub use keyboard::*;
 pub use keystroke::*;
 
+#[cfg(target_os = "ios")]
+pub(crate) use ios::*;
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
 pub(crate) use linux::*;
 #[cfg(target_os = "macos")]
@@ -129,6 +135,11 @@ pub(crate) fn current_platform(_headless: bool) -> Rc<dyn Platform> {
             .inspect_err(|err| show_error("Failed to launch", err.to_string()))
             .unwrap(),
     )
+}
+
+#[cfg(target_os = "ios")]
+pub(crate) fn current_platform(_headless: bool) -> Rc<dyn Platform> {
+    Rc::new(IosPlatform::new())
 }
 
 /// Return which compositor we're guessing we'll use.

--- a/crates/gpui/src/platform/blade.rs
+++ b/crates/gpui/src/platform/blade.rs
@@ -1,10 +1,10 @@
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 mod apple_compat;
 mod blade_atlas;
 mod blade_context;
 mod blade_renderer;
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 pub(crate) use apple_compat::*;
 pub(crate) use blade_atlas::*;
 pub(crate) use blade_context::*;

--- a/crates/gpui/src/platform/blade/apple_compat.rs
+++ b/crates/gpui/src/platform/blade/apple_compat.rs
@@ -31,13 +31,19 @@ pub unsafe fn new_renderer(
     impl rwh::HasWindowHandle for RawWindow {
         fn window_handle(&self) -> Result<rwh::WindowHandle<'_>, rwh::HandleError> {
             let view = NonNull::new(self.view).unwrap();
+            #[cfg(target_os = "macos")]
             let handle = rwh::AppKitWindowHandle::new(view);
+            #[cfg(target_os = "ios")]
+            let handle = rwh::UiKitWindowHandle::new(view);
             Ok(unsafe { rwh::WindowHandle::borrow_raw(handle.into()) })
         }
     }
     impl rwh::HasDisplayHandle for RawWindow {
         fn display_handle(&self) -> Result<rwh::DisplayHandle<'_>, rwh::HandleError> {
+            #[cfg(target_os = "macos")]
             let handle = rwh::AppKitDisplayHandle::new();
+            #[cfg(target_os = "ios")]
+            let handle = rwh::UiKitDisplayHandle::new();
             Ok(unsafe { rwh::DisplayHandle::borrow_raw(handle.into()) })
         }
     }

--- a/crates/gpui/src/platform/blade/blade_context.rs
+++ b/crates/gpui/src/platform/blade/blade_context.rs
@@ -3,7 +3,7 @@ use blade_graphics as gpu;
 use std::sync::Arc;
 use util::ResultExt;
 
-#[cfg_attr(target_os = "macos", derive(Clone))]
+#[cfg_attr(any(target_os = "macos", target_os = "ios"), derive(Clone))]
 pub struct BladeContext {
     pub(super) gpu: Arc<gpu::Context>,
 }

--- a/crates/gpui/src/platform/ios.rs
+++ b/crates/gpui/src/platform/ios.rs
@@ -1,0 +1,124 @@
+//! iOS platform implementation for GPUI.
+//!
+//! iOS uses UIKit instead of AppKit, so the platform implementation differs
+//! significantly from macOS despite sharing many underlying technologies:
+//! - Grand Central Dispatch (GCD) for threading
+//! - CoreText for text rendering
+//! - Metal for GPU rendering
+//! - CoreFoundation for many utilities
+
+pub mod demos;
+mod dispatcher;
+mod display;
+mod events;
+pub mod ffi;
+mod platform;
+mod text_input;
+mod window;
+
+// Re-use the macOS text system since CoreText is available on iOS
+#[cfg(feature = "font-kit")]
+mod text_system;
+
+use crate::{DevicePixels, Pixels, Size, px, size};
+use objc::runtime::{BOOL, NO, YES};
+use std::ops::Range;
+
+pub(crate) use dispatcher::*;
+pub(crate) use display::*;
+pub(crate) use platform::*;
+pub(crate) use window::*;
+
+#[cfg(feature = "font-kit")]
+pub(crate) use text_system::*;
+
+/// Placeholder for iOS screen capture frame type.
+/// iOS uses ReplayKit for screen capture, which would require additional implementation.
+pub(crate) type PlatformScreenCaptureFrame = ();
+
+trait BoolExt {
+    fn to_objc(self) -> BOOL;
+}
+
+impl BoolExt for bool {
+    fn to_objc(self) -> BOOL {
+        if self { YES } else { NO }
+    }
+}
+
+/// NSRange equivalent for iOS (same structure as macOS)
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+struct NSRange {
+    pub location: usize,
+    pub length: usize,
+}
+
+impl NSRange {
+    fn invalid() -> Self {
+        Self {
+            location: usize::MAX,
+            length: 0,
+        }
+    }
+
+    fn is_valid(&self) -> bool {
+        self.location != usize::MAX
+    }
+
+    fn to_range(self) -> Option<Range<usize>> {
+        if self.is_valid() {
+            let start = self.location;
+            let end = start + self.length;
+            Some(start..end)
+        } else {
+            None
+        }
+    }
+}
+
+impl From<Range<usize>> for NSRange {
+    fn from(range: Range<usize>) -> Self {
+        NSRange {
+            location: range.start,
+            length: range.len(),
+        }
+    }
+}
+
+unsafe impl objc::Encode for NSRange {
+    fn encode() -> objc::Encoding {
+        let encoding = format!(
+            "{{NSRange={}{}}}",
+            usize::encode().as_str(),
+            usize::encode().as_str()
+        );
+        unsafe { objc::Encoding::from_str(&encoding) }
+    }
+}
+
+/// Convert a CGSize to Size<Pixels>
+impl From<core_graphics::geometry::CGSize> for Size<Pixels> {
+    fn from(value: core_graphics::geometry::CGSize) -> Self {
+        Size {
+            width: px(value.width as f32),
+            height: px(value.height as f32),
+        }
+    }
+}
+
+/// Convert a CGRect to Size<Pixels>
+impl From<core_graphics::geometry::CGRect> for Size<Pixels> {
+    fn from(rect: core_graphics::geometry::CGRect) -> Self {
+        let core_graphics::geometry::CGSize { width, height } = rect.size;
+        size(px(width as f32), px(height as f32))
+    }
+}
+
+/// Convert a CGRect to Size<DevicePixels>
+impl From<core_graphics::geometry::CGRect> for Size<DevicePixels> {
+    fn from(rect: core_graphics::geometry::CGRect) -> Self {
+        let core_graphics::geometry::CGSize { width, height } = rect.size;
+        size(DevicePixels(width as i32), DevicePixels(height as i32))
+    }
+}

--- a/crates/gpui/src/platform/ios/demos/animation_playground.rs
+++ b/crates/gpui/src/platform/ios/demos/animation_playground.rs
@@ -1,0 +1,544 @@
+//! Animation Playground demo - bouncing balls with physics and particle effects.
+//!
+//! This demo showcases GPUI's animation and rendering capabilities on iOS:
+//! - Tap to spawn bouncing balls with physics simulation
+//! - Balls have trails and particle effects
+//! - Demonstrates smooth 60fps rendering
+
+use super::{BACKGROUND, TEXT, back_button, random_color};
+use crate::{
+    App, Bounds, Hsla, MouseButton, MouseDownEvent, MouseUpEvent, Pixels, Point, Window, canvas,
+    div, fill, hsla, point, prelude::*, px, rgb, size,
+};
+use std::collections::VecDeque;
+use std::time::{Duration, Instant};
+
+// Physics constants
+const GRAVITY: f32 = 980.0; // pixels/sec^2
+const BOUNCE_DAMPING: f32 = 0.7; // velocity retained after bounce
+const FRICTION: f32 = 0.995; // velocity multiplier per frame
+const MAX_BALLS: usize = 30;
+const TRAIL_LENGTH: usize = 12;
+const BALL_RADIUS: f32 = 20.0;
+const PARTICLE_COUNT: usize = 12;
+const PARTICLE_DURATION_MS: u64 = 600;
+
+/// A bouncing ball with physics
+#[derive(Clone)]
+struct Ball {
+    position: Point<f32>,
+    velocity: Point<f32>,
+    radius: f32,
+    color: Hsla,
+    trail: VecDeque<Point<f32>>,
+}
+
+impl Ball {
+    fn new(id: usize, position: Point<f32>, velocity: Point<f32>) -> Self {
+        let color_rgb = random_color(id);
+        Self {
+            position,
+            velocity,
+            radius: BALL_RADIUS,
+            color: rgb(color_rgb).into(),
+            trail: VecDeque::with_capacity(TRAIL_LENGTH),
+        }
+    }
+
+    fn update(&mut self, dt: f32, bounds: &Bounds<f32>) {
+        // Store trail position
+        if self.trail.len() >= TRAIL_LENGTH {
+            self.trail.pop_front();
+        }
+        self.trail.push_back(self.position);
+
+        // Apply gravity
+        self.velocity.y += GRAVITY * dt;
+
+        // Apply friction
+        self.velocity.x *= FRICTION;
+        self.velocity.y *= FRICTION;
+
+        // Update position
+        self.position.x += self.velocity.x * dt;
+        self.position.y += self.velocity.y * dt;
+
+        // Bounce off walls
+        let min_x = bounds.origin.x + self.radius;
+        let max_x = bounds.origin.x + bounds.size.width - self.radius;
+        let min_y = bounds.origin.y + self.radius;
+        let max_y = bounds.origin.y + bounds.size.height - self.radius;
+
+        if self.position.x < min_x {
+            self.position.x = min_x;
+            self.velocity.x = -self.velocity.x * BOUNCE_DAMPING;
+        } else if self.position.x > max_x {
+            self.position.x = max_x;
+            self.velocity.x = -self.velocity.x * BOUNCE_DAMPING;
+        }
+
+        if self.position.y < min_y {
+            self.position.y = min_y;
+            self.velocity.y = -self.velocity.y * BOUNCE_DAMPING;
+        } else if self.position.y > max_y {
+            self.position.y = max_y;
+            self.velocity.y = -self.velocity.y * BOUNCE_DAMPING;
+        }
+    }
+}
+
+/// A particle for burst effects
+#[derive(Clone)]
+struct Particle {
+    position: Point<f32>,
+    velocity: Point<f32>,
+    start_time: Instant,
+    duration: Duration,
+    color: Hsla,
+    size: f32,
+}
+
+impl Particle {
+    fn new(position: Point<f32>, angle: f32, speed: f32, color: Hsla) -> Self {
+        let velocity = point(angle.cos() * speed, angle.sin() * speed);
+        Self {
+            position,
+            velocity,
+            start_time: Instant::now(),
+            duration: Duration::from_millis(PARTICLE_DURATION_MS),
+            color,
+            size: 8.0,
+        }
+    }
+
+    fn update(&mut self, dt: f32) {
+        self.position.x += self.velocity.x * dt;
+        self.position.y += self.velocity.y * dt;
+        // Slow down
+        self.velocity.x *= 0.98;
+        self.velocity.y *= 0.98;
+    }
+
+    fn progress(&self) -> f32 {
+        let elapsed = self.start_time.elapsed().as_secs_f32();
+        (elapsed / self.duration.as_secs_f32()).min(1.0)
+    }
+
+    fn is_alive(&self) -> bool {
+        self.start_time.elapsed() < self.duration
+    }
+}
+
+/// Animation Playground demo view
+pub struct AnimationPlayground {
+    balls: Vec<Ball>,
+    particles: Vec<Particle>,
+    last_frame_time: Instant,
+    pub next_ball_id: usize,
+    pub touch_start: Option<(Point<f32>, Instant)>,
+    pub current_touch: Option<Point<f32>>,
+    bounds: Bounds<f32>,
+    #[allow(dead_code)]
+    on_back: Option<Box<dyn Fn(&mut Window, &mut App) + 'static>>,
+}
+
+impl AnimationPlayground {
+    pub fn new() -> Self {
+        Self {
+            balls: Vec::new(),
+            particles: Vec::new(),
+            last_frame_time: Instant::now(),
+            next_ball_id: 0,
+            touch_start: None,
+            current_touch: None,
+            bounds: Bounds {
+                origin: point(0.0, 0.0),
+                size: size(400.0, 800.0),
+            },
+            on_back: None,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn with_on_back<F>(mut self, on_back: F) -> Self
+    where
+        F: Fn(&mut Window, &mut App) + 'static,
+    {
+        self.on_back = Some(Box::new(on_back));
+        self
+    }
+
+    pub fn spawn_ball(&mut self, position: Point<f32>, velocity: Point<f32>) {
+        if self.balls.len() >= MAX_BALLS {
+            self.balls.remove(0);
+        }
+        let ball = Ball::new(self.next_ball_id, position, velocity);
+        self.next_ball_id += 1;
+        self.balls.push(ball);
+    }
+
+    pub fn spawn_particles(&mut self, position: Point<f32>, color: Hsla) {
+        let angle_step = std::f32::consts::PI * 2.0 / PARTICLE_COUNT as f32;
+        for i in 0..PARTICLE_COUNT {
+            let angle = angle_step * i as f32;
+            let speed = 200.0 + (i as f32 * 20.0);
+            self.particles
+                .push(Particle::new(position, angle, speed, color));
+        }
+    }
+
+    fn update_physics(&mut self) {
+        let now = Instant::now();
+        let dt = now.duration_since(self.last_frame_time).as_secs_f32();
+        self.last_frame_time = now;
+
+        // Cap dt to prevent huge jumps
+        let dt = dt.min(0.05);
+
+        // Update balls
+        for ball in &mut self.balls {
+            ball.update(dt, &self.bounds);
+        }
+
+        // Update particles
+        for particle in &mut self.particles {
+            particle.update(dt);
+        }
+
+        // Remove dead particles
+        self.particles.retain(|p| p.is_alive());
+    }
+
+    fn handle_touch_down(&mut self, event: &MouseDownEvent, cx: &mut crate::Context<Self>) {
+        let pos = point(event.position.x.0, event.position.y.0);
+        self.touch_start = Some((pos, Instant::now()));
+        self.current_touch = Some(pos);
+        cx.notify();
+    }
+
+    fn handle_touch_up(&mut self, event: &MouseUpEvent, cx: &mut crate::Context<Self>) {
+        let position = point(event.position.x.0, event.position.y.0);
+
+        if let Some((start_pos, start_time)) = self.touch_start.take() {
+            let elapsed = start_time.elapsed();
+            let dx = position.x - start_pos.x;
+            let dy = position.y - start_pos.y;
+            let distance = (dx * dx + dy * dy).sqrt();
+
+            // If short tap with little movement, spawn particles
+            if elapsed < Duration::from_millis(200) && distance < 20.0 {
+                let color_rgb = random_color(self.next_ball_id);
+                self.spawn_particles(position, rgb(color_rgb).into());
+                self.next_ball_id += 1;
+            } else {
+                // Calculate velocity from drag
+                let dt = elapsed.as_secs_f32().max(0.01);
+                let velocity = point(dx / dt * 0.5, dy / dt * 0.5);
+                self.spawn_ball(start_pos, velocity);
+            }
+        }
+        self.current_touch = None;
+        cx.notify();
+    }
+
+    pub fn render_with_back_button<F>(
+        &mut self,
+        window: &mut Window,
+        on_back: F,
+    ) -> impl IntoElement
+    where
+        F: Fn(&(), &mut Window, &mut App) + 'static,
+    {
+        // Request continuous animation frame
+        window.request_animation_frame();
+
+        // Update physics each frame
+        self.update_physics();
+
+        // Clone data for rendering
+        let balls = self.balls.clone();
+        let particles = self.particles.clone();
+        let touch_start = self.touch_start.map(|(p, _)| p);
+        let current_touch = self.current_touch;
+
+        div()
+            .size_full()
+            .bg(rgb(BACKGROUND))
+            .child(
+                canvas(
+                    move |bounds, _window, _cx| {
+                        // Convert bounds to f32 for physics
+                        let bounds_f32 = Bounds {
+                            origin: point(bounds.origin.x.0, bounds.origin.y.0),
+                            size: size(bounds.size.width.0, bounds.size.height.0),
+                        };
+                        (
+                            bounds_f32,
+                            balls.clone(),
+                            particles.clone(),
+                            touch_start,
+                            current_touch,
+                        )
+                    },
+                    move |_bounds,
+                          (_bounds_f32, balls, particles, touch_start, current_touch),
+                          window,
+                          _cx| {
+                        // Draw trails
+                        for ball in &balls {
+                            for (i, &trail_pos) in ball.trail.iter().enumerate() {
+                                let alpha = (i as f32 / TRAIL_LENGTH as f32) * 0.4;
+                                let trail_size =
+                                    ball.radius * (0.3 + 0.7 * i as f32 / TRAIL_LENGTH as f32);
+                                let color = hsla(ball.color.h, ball.color.s, ball.color.l, alpha);
+                                paint_circle(
+                                    window,
+                                    point(px(trail_pos.x), px(trail_pos.y)),
+                                    px(trail_size),
+                                    color,
+                                );
+                            }
+                        }
+
+                        // Draw particles
+                        for particle in &particles {
+                            let progress = particle.progress();
+                            let alpha = 1.0 - progress;
+                            let size = particle.size * (1.0 - progress * 0.5);
+                            let color =
+                                hsla(particle.color.h, particle.color.s, particle.color.l, alpha);
+                            paint_circle(
+                                window,
+                                point(px(particle.position.x), px(particle.position.y)),
+                                px(size),
+                                color,
+                            );
+                        }
+
+                        // Draw balls
+                        for ball in &balls {
+                            paint_circle(
+                                window,
+                                point(px(ball.position.x), px(ball.position.y)),
+                                px(ball.radius),
+                                ball.color,
+                            );
+                            // Inner highlight
+                            let highlight = hsla(ball.color.h, ball.color.s * 0.5, 0.9, 0.5);
+                            paint_circle(
+                                window,
+                                point(
+                                    px(ball.position.x - ball.radius * 0.3),
+                                    px(ball.position.y - ball.radius * 0.3),
+                                ),
+                                px(ball.radius * 0.3),
+                                highlight,
+                            );
+                        }
+
+                        // Draw drag line if dragging
+                        if let (Some(start), Some(current)) = (touch_start, current_touch) {
+                            // Draw a line from start to current (using dots)
+                            let dx = current.x - start.x;
+                            let dy = current.y - start.y;
+                            let dist = (dx * dx + dy * dy).sqrt();
+                            let steps = (dist / 10.0) as i32;
+                            for i in 0..=steps {
+                                let t = i as f32 / steps.max(1) as f32;
+                                let x = start.x + dx * t;
+                                let y = start.y + dy * t;
+                                paint_circle(
+                                    window,
+                                    point(px(x), px(y)),
+                                    px(3.0),
+                                    hsla(0.0, 0.0, 1.0, 0.5),
+                                );
+                            }
+                        }
+                    },
+                )
+                .size_full(),
+            )
+            // Instructions
+            .child(
+                div()
+                    .absolute()
+                    .bottom(px(100.0))
+                    .left_0()
+                    .right_0()
+                    .flex()
+                    .justify_center()
+                    .child(
+                        div()
+                            .px_4()
+                            .py_2()
+                            .bg(hsla(0.0, 0.0, 0.1, 0.8))
+                            .rounded_lg()
+                            .text_color(rgb(TEXT))
+                            .text_sm()
+                            .child("Tap to burst, drag to throw balls"),
+                    ),
+            )
+            // Back button
+            .child(back_button(on_back))
+    }
+
+    /// Update bounds from the canvas callback
+    pub fn set_bounds(&mut self, bounds: Bounds<f32>) {
+        self.bounds = bounds;
+    }
+}
+
+impl crate::Render for AnimationPlayground {
+    fn render(&mut self, window: &mut Window, cx: &mut crate::Context<Self>) -> impl IntoElement {
+        // Request continuous animation frame
+        window.request_animation_frame();
+
+        // Update physics each frame
+        self.update_physics();
+
+        // Clone data for rendering
+        let balls = self.balls.clone();
+        let particles = self.particles.clone();
+        let touch_start = self.touch_start.map(|(p, _)| p);
+        let current_touch = self.current_touch;
+
+        div()
+            .size_full()
+            .bg(rgb(BACKGROUND))
+            // Touch handling layer
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|this, event, _window, cx| {
+                    this.handle_touch_down(event, cx);
+                }),
+            )
+            .on_mouse_up(
+                MouseButton::Left,
+                cx.listener(|this, event, _window, cx| {
+                    this.handle_touch_up(event, cx);
+                }),
+            )
+            .child(
+                canvas(
+                    move |bounds, _window, _cx| {
+                        let bounds_f32 = Bounds {
+                            origin: point(bounds.origin.x.0, bounds.origin.y.0),
+                            size: size(bounds.size.width.0, bounds.size.height.0),
+                        };
+                        (
+                            bounds_f32,
+                            balls.clone(),
+                            particles.clone(),
+                            touch_start,
+                            current_touch,
+                        )
+                    },
+                    move |_bounds,
+                          (_bounds_f32, balls, particles, touch_start, current_touch),
+                          window,
+                          _cx| {
+                        // Draw trails
+                        for ball in &balls {
+                            for (i, &trail_pos) in ball.trail.iter().enumerate() {
+                                let alpha = (i as f32 / TRAIL_LENGTH as f32) * 0.4;
+                                let trail_size =
+                                    ball.radius * (0.3 + 0.7 * i as f32 / TRAIL_LENGTH as f32);
+                                let color = hsla(ball.color.h, ball.color.s, ball.color.l, alpha);
+                                paint_circle(
+                                    window,
+                                    point(px(trail_pos.x), px(trail_pos.y)),
+                                    px(trail_size),
+                                    color,
+                                );
+                            }
+                        }
+
+                        // Draw particles
+                        for particle in &particles {
+                            let progress = particle.progress();
+                            let alpha = 1.0 - progress;
+                            let psize = particle.size * (1.0 - progress * 0.5);
+                            let color =
+                                hsla(particle.color.h, particle.color.s, particle.color.l, alpha);
+                            paint_circle(
+                                window,
+                                point(px(particle.position.x), px(particle.position.y)),
+                                px(psize),
+                                color,
+                            );
+                        }
+
+                        // Draw balls
+                        for ball in &balls {
+                            paint_circle(
+                                window,
+                                point(px(ball.position.x), px(ball.position.y)),
+                                px(ball.radius),
+                                ball.color,
+                            );
+                            let highlight = hsla(ball.color.h, ball.color.s * 0.5, 0.9, 0.5);
+                            paint_circle(
+                                window,
+                                point(
+                                    px(ball.position.x - ball.radius * 0.3),
+                                    px(ball.position.y - ball.radius * 0.3),
+                                ),
+                                px(ball.radius * 0.3),
+                                highlight,
+                            );
+                        }
+
+                        // Draw drag line if dragging
+                        if let (Some(start), Some(current)) = (touch_start, current_touch) {
+                            let dx = current.x - start.x;
+                            let dy = current.y - start.y;
+                            let dist = (dx * dx + dy * dy).sqrt();
+                            let steps = (dist / 10.0) as i32;
+                            for i in 0..=steps {
+                                let t = i as f32 / steps.max(1) as f32;
+                                let x = start.x + dx * t;
+                                let y = start.y + dy * t;
+                                paint_circle(
+                                    window,
+                                    point(px(x), px(y)),
+                                    px(3.0),
+                                    hsla(0.0, 0.0, 1.0, 0.5),
+                                );
+                            }
+                        }
+                    },
+                )
+                .size_full(),
+            )
+            // Instructions
+            .child(
+                div()
+                    .absolute()
+                    .bottom(px(100.0))
+                    .left_0()
+                    .right_0()
+                    .flex()
+                    .justify_center()
+                    .child(
+                        div()
+                            .px_4()
+                            .py_2()
+                            .bg(hsla(0.0, 0.0, 0.1, 0.8))
+                            .rounded_lg()
+                            .text_color(rgb(TEXT))
+                            .text_sm()
+                            .child("Tap to burst, drag to throw balls"),
+                    ),
+            )
+    }
+}
+
+/// Paint a filled circle
+fn paint_circle(window: &mut Window, center: Point<Pixels>, radius: Pixels, color: Hsla) {
+    let bounds = Bounds {
+        origin: point(center.x - radius, center.y - radius),
+        size: size(radius * 2.0, radius * 2.0),
+    };
+    window.paint_quad(fill(bounds, color).corner_radii(radius));
+}

--- a/crates/gpui/src/platform/ios/demos/menu.rs
+++ b/crates/gpui/src/platform/ios/demos/menu.rs
@@ -1,0 +1,350 @@
+//! Main menu for iOS demos.
+//!
+//! Provides a menu to select between different demo views.
+
+use super::{
+    AnimationPlayground, BACKGROUND, BLUE, MAUVE, OVERLAY, SUBTEXT, SURFACE, ShaderShowcase, TEXT,
+};
+use crate::{
+    App, Bounds, Context, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, Render,
+    Window, div, hsla, point, prelude::*, px, rgb, size,
+};
+
+/// Which demo is currently active
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub enum ActiveDemo {
+    #[default]
+    Menu,
+    AnimationPlayground,
+    ShaderShowcase,
+}
+
+/// Root application view that manages demo navigation
+pub struct DemoApp {
+    active: ActiveDemo,
+    animation_playground: Option<AnimationPlayground>,
+    shader_showcase: Option<ShaderShowcase>,
+}
+
+impl DemoApp {
+    pub fn new() -> Self {
+        Self {
+            active: ActiveDemo::Menu,
+            animation_playground: None,
+            shader_showcase: None,
+        }
+    }
+
+    fn go_to_animation_playground(&mut self, cx: &mut Context<Self>) {
+        self.animation_playground = Some(AnimationPlayground::new());
+        self.active = ActiveDemo::AnimationPlayground;
+        cx.notify();
+    }
+
+    fn go_to_shader_showcase(&mut self, cx: &mut Context<Self>) {
+        self.shader_showcase = Some(ShaderShowcase::new());
+        self.active = ActiveDemo::ShaderShowcase;
+        cx.notify();
+    }
+
+    fn go_to_menu(&mut self, cx: &mut Context<Self>) {
+        self.active = ActiveDemo::Menu;
+        self.animation_playground = None;
+        self.shader_showcase = None;
+        cx.notify();
+    }
+
+    fn handle_animation_touch_down(&mut self, event: &MouseDownEvent, cx: &mut Context<Self>) {
+        if let Some(playground) = &mut self.animation_playground {
+            let pos = point(event.position.x.0, event.position.y.0);
+            playground.touch_start = Some((pos, std::time::Instant::now()));
+            playground.current_touch = Some(pos);
+            cx.notify();
+        }
+    }
+
+    fn handle_animation_touch_up(&mut self, event: &MouseUpEvent, cx: &mut Context<Self>) {
+        if let Some(playground) = &mut self.animation_playground {
+            let position = point(event.position.x.0, event.position.y.0);
+
+            if let Some((start_pos, start_time)) = playground.touch_start.take() {
+                let elapsed = start_time.elapsed();
+                let dx = position.x - start_pos.x;
+                let dy = position.y - start_pos.y;
+                let distance = (dx * dx + dy * dy).sqrt();
+
+                if elapsed < std::time::Duration::from_millis(200) && distance < 20.0 {
+                    let color_rgb = super::random_color(playground.next_ball_id);
+                    playground.spawn_particles(position, rgb(color_rgb).into());
+                    playground.next_ball_id += 1;
+                } else {
+                    let dt = elapsed.as_secs_f32().max(0.01);
+                    let velocity = point(dx / dt * 0.5, dy / dt * 0.5);
+                    playground.spawn_ball(start_pos, velocity);
+                }
+            }
+            playground.current_touch = None;
+            cx.notify();
+        }
+    }
+
+    fn handle_shader_touch_down(&mut self, event: &MouseDownEvent, cx: &mut Context<Self>) {
+        if let Some(showcase) = &mut self.shader_showcase {
+            let pos = point(event.position.x.0, event.position.y.0);
+            showcase.touch_position = Some(pos);
+            showcase.spawn_ripple(pos);
+            cx.notify();
+        }
+    }
+
+    fn handle_shader_touch_move(&mut self, event: &MouseMoveEvent, cx: &mut Context<Self>) {
+        if let Some(showcase) = &mut self.shader_showcase {
+            let pos = point(event.position.x.0, event.position.y.0);
+            showcase.touch_position = Some(pos);
+            cx.notify();
+        }
+    }
+
+    fn handle_shader_touch_up(&mut self, _event: &MouseUpEvent, cx: &mut Context<Self>) {
+        if let Some(showcase) = &mut self.shader_showcase {
+            showcase.touch_position = None;
+            cx.notify();
+        }
+    }
+}
+
+impl Render for DemoApp {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        match self.active {
+            ActiveDemo::Menu => self.render_menu(window, cx).into_any_element(),
+            ActiveDemo::AnimationPlayground => self
+                .render_animation_playground(window, cx)
+                .into_any_element(),
+            ActiveDemo::ShaderShowcase => {
+                self.render_shader_showcase(window, cx).into_any_element()
+            }
+        }
+    }
+}
+
+impl DemoApp {
+    fn render_menu(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> crate::AnyElement {
+        div()
+            .flex()
+            .flex_col()
+            .size_full()
+            .bg(rgb(BACKGROUND))
+            .justify_center()
+            .items_center()
+            .gap_6()
+            // Title
+            .child(
+                div()
+                    .flex()
+                    .flex_col()
+                    .items_center()
+                    .gap_2()
+                    .child(div().text_3xl().text_color(rgb(TEXT)).child("GPUI on iOS"))
+                    .child(
+                        div()
+                            .text_lg()
+                            .text_color(rgb(SUBTEXT))
+                            .child("Interactive Demos"),
+                    ),
+            )
+            // Demo buttons
+            .child(
+                div()
+                    .flex()
+                    .flex_col()
+                    .gap_4()
+                    .w(px(300.0))
+                    // Animation Playground button
+                    .child(
+                        div()
+                            .flex()
+                            .flex_col()
+                            .gap_1()
+                            .px_6()
+                            .py_4()
+                            .bg(rgb(SURFACE))
+                            .rounded_xl()
+                            .border_l_4()
+                            .border_color(rgb(BLUE))
+                            .child(
+                                div()
+                                    .text_xl()
+                                    .text_color(rgb(TEXT))
+                                    .child("Animation Playground"),
+                            )
+                            .child(
+                                div()
+                                    .text_sm()
+                                    .text_color(rgb(SUBTEXT))
+                                    .child("Bouncing balls & particle effects"),
+                            )
+                            .on_mouse_down(
+                                MouseButton::Left,
+                                cx.listener(|this, _, _, cx| {
+                                    this.go_to_animation_playground(cx);
+                                }),
+                            ),
+                    )
+                    // Shader Showcase button
+                    .child(
+                        div()
+                            .flex()
+                            .flex_col()
+                            .gap_1()
+                            .px_6()
+                            .py_4()
+                            .bg(rgb(SURFACE))
+                            .rounded_xl()
+                            .border_l_4()
+                            .border_color(rgb(MAUVE))
+                            .child(
+                                div()
+                                    .text_xl()
+                                    .text_color(rgb(TEXT))
+                                    .child("Shader Showcase"),
+                            )
+                            .child(
+                                div()
+                                    .text_sm()
+                                    .text_color(rgb(SUBTEXT))
+                                    .child("Dynamic gradients & visual effects"),
+                            )
+                            .on_mouse_down(
+                                MouseButton::Left,
+                                cx.listener(|this, _, _, cx| {
+                                    this.go_to_shader_showcase(cx);
+                                }),
+                            ),
+                    ),
+            )
+            // Footer
+            .child(
+                div()
+                    .mt_8()
+                    .text_sm()
+                    .text_color(rgb(OVERLAY))
+                    .child("Powered by GPUI"),
+            )
+            .into_any_element()
+    }
+}
+
+impl DemoApp {
+    fn render_animation_playground(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> crate::AnyElement {
+        // Request continuous animation frame
+        window.request_animation_frame();
+
+        // Update bounds
+        let viewport = window.viewport_size();
+        if let Some(playground) = &mut self.animation_playground {
+            playground.set_bounds(Bounds {
+                origin: point(0.0, 0.0),
+                size: size(viewport.width.0, viewport.height.0),
+            });
+        }
+
+        div()
+            .size_full()
+            .bg(rgb(BACKGROUND))
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|this, event, _window, cx| {
+                    this.handle_animation_touch_down(event, cx);
+                }),
+            )
+            .on_mouse_up(
+                MouseButton::Left,
+                cx.listener(|this, event, _window, cx| {
+                    this.handle_animation_touch_up(event, cx);
+                }),
+            )
+            .child(if let Some(playground) = &mut self.animation_playground {
+                playground
+                    .render_with_back_button(window, |_, _window, _cx| {
+                        // Back button handled below
+                    })
+                    .into_any_element()
+            } else {
+                div().into_any_element()
+            })
+            .child(back_button(cx.listener(|this, _, _window, cx| {
+                this.go_to_menu(cx);
+            })))
+            .into_any_element()
+    }
+
+    fn render_shader_showcase(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> crate::AnyElement {
+        // Request continuous animation frame
+        window.request_animation_frame();
+
+        // Update screen center
+        if let Some(showcase) = &mut self.shader_showcase {
+            let viewport = window.viewport_size();
+            showcase.set_screen_center(point(viewport.width.0 / 2.0, viewport.height.0 / 2.0));
+        }
+
+        div()
+            .size_full()
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|this, event, _window, cx| {
+                    this.handle_shader_touch_down(event, cx);
+                }),
+            )
+            .on_mouse_move(cx.listener(|this, event, _window, cx| {
+                this.handle_shader_touch_move(event, cx);
+            }))
+            .on_mouse_up(
+                MouseButton::Left,
+                cx.listener(|this, event, _window, cx| {
+                    this.handle_shader_touch_up(event, cx);
+                }),
+            )
+            .child(if let Some(showcase) = &mut self.shader_showcase {
+                showcase
+                    .render_with_back_button(window, |_, _window, _cx| {
+                        // Back button handled below
+                    })
+                    .into_any_element()
+            } else {
+                div().into_any_element()
+            })
+            .child(back_button(cx.listener(|this, _, _window, cx| {
+                this.go_to_menu(cx);
+            })))
+            .into_any_element()
+    }
+}
+
+/// Back button component for returning to menu
+pub fn back_button<F>(on_click: F) -> impl IntoElement
+where
+    F: Fn(&(), &mut Window, &mut App) + 'static,
+{
+    div()
+        .absolute()
+        .top(px(50.0))
+        .left(px(20.0))
+        .px_4()
+        .py_2()
+        .bg(hsla(0.0, 0.0, 0.2, 0.8))
+        .rounded_lg()
+        .text_color(rgb(TEXT))
+        .child("< Back")
+        .on_mouse_down(MouseButton::Left, move |_, window, cx| {
+            on_click(&(), window, cx);
+        })
+}

--- a/crates/gpui/src/platform/ios/demos/mod.rs
+++ b/crates/gpui/src/platform/ios/demos/mod.rs
@@ -1,0 +1,37 @@
+//! iOS Demo modules for showcasing GPUI capabilities.
+//!
+//! This module contains interactive demos that demonstrate GPUI's
+//! rendering and input handling on iOS.
+
+mod animation_playground;
+mod menu;
+mod shader_showcase;
+
+pub use animation_playground::AnimationPlayground;
+pub use menu::{DemoApp, back_button};
+pub use shader_showcase::ShaderShowcase;
+
+// Color palette - Catppuccin Mocha theme
+pub const BACKGROUND: u32 = 0x1e1e2e;
+pub const SURFACE: u32 = 0x313244;
+pub const OVERLAY: u32 = 0x45475a;
+pub const TEXT: u32 = 0xcdd6f4;
+pub const SUBTEXT: u32 = 0xa6adc8;
+pub const RED: u32 = 0xf38ba8;
+pub const GREEN: u32 = 0xa6e3a1;
+pub const BLUE: u32 = 0x89b4fa;
+pub const YELLOW: u32 = 0xf9e2af;
+pub const PINK: u32 = 0xf5c2e7;
+pub const MAUVE: u32 = 0xcba6f7;
+pub const PEACH: u32 = 0xfab387;
+pub const TEAL: u32 = 0x94e2d5;
+pub const SKY: u32 = 0x89dceb;
+pub const LAVENDER: u32 = 0xb4befe;
+
+/// Get a random color from the vibrant palette
+pub fn random_color(seed: usize) -> u32 {
+    const COLORS: [u32; 10] = [
+        RED, GREEN, BLUE, YELLOW, PINK, MAUVE, PEACH, TEAL, SKY, LAVENDER,
+    ];
+    COLORS[seed % COLORS.len()]
+}

--- a/crates/gpui/src/platform/ios/demos/shader_showcase.rs
+++ b/crates/gpui/src/platform/ios/demos/shader_showcase.rs
@@ -1,0 +1,371 @@
+//! Shader Showcase demo - dynamic gradients and visual effects.
+//!
+//! This demo showcases GPUI's GPU rendering capabilities on iOS:
+//! - Dynamic gradient backgrounds that respond to touch
+//! - Floating orbs with parallax movement
+//! - Ripple effects on tap
+//! - Color cycling animations
+
+use super::back_button;
+use crate::{
+    App, Bounds, ColorSpace, Hsla, Pixels, Point, Window, canvas, div, fill, hsla,
+    linear_color_stop, linear_gradient, point, prelude::*, px, size,
+};
+use std::time::{Duration, Instant};
+
+// Number of orbs in the demo (for reference, orbs are created manually)
+#[allow(dead_code)]
+const ORB_COUNT: usize = 8;
+const RIPPLE_DURATION_MS: u64 = 1000;
+const MAX_RIPPLES: usize = 5;
+
+/// A floating orb with parallax effect
+#[derive(Clone)]
+struct Orb {
+    base_position: Point<f32>,
+    parallax_factor: f32,
+    radius: f32,
+    color: Hsla,
+    pulse_phase: f32,
+}
+
+impl Orb {
+    fn new(x: f32, y: f32, radius: f32, parallax: f32, hue: f32) -> Self {
+        Self {
+            base_position: point(x, y),
+            parallax_factor: parallax,
+            radius,
+            color: hsla(hue, 0.7, 0.6, 0.4),
+            pulse_phase: hue * std::f32::consts::PI * 2.0,
+        }
+    }
+
+    fn current_position(&self, touch_offset: Point<f32>, time: f32) -> Point<f32> {
+        let pulse = (time * 2.0 + self.pulse_phase).sin() * 5.0;
+        point(
+            self.base_position.x + touch_offset.x * self.parallax_factor,
+            self.base_position.y + touch_offset.y * self.parallax_factor + pulse,
+        )
+    }
+
+    fn current_radius(&self, time: f32) -> f32 {
+        let pulse = (time * 1.5 + self.pulse_phase).sin() * 0.1 + 1.0;
+        self.radius * pulse
+    }
+}
+
+/// An expanding ripple effect
+#[derive(Clone)]
+struct Ripple {
+    center: Point<f32>,
+    start_time: Instant,
+    duration: Duration,
+    color: Hsla,
+}
+
+impl Ripple {
+    fn new(center: Point<f32>, hue: f32) -> Self {
+        Self {
+            center,
+            start_time: Instant::now(),
+            duration: Duration::from_millis(RIPPLE_DURATION_MS),
+            color: hsla(hue, 0.8, 0.6, 1.0),
+        }
+    }
+
+    fn progress(&self) -> f32 {
+        let elapsed = self.start_time.elapsed().as_secs_f32();
+        (elapsed / self.duration.as_secs_f32()).min(1.0)
+    }
+
+    fn is_alive(&self) -> bool {
+        self.start_time.elapsed() < self.duration
+    }
+
+    fn current_radius(&self, max_radius: f32) -> f32 {
+        let progress = self.progress();
+        // Ease out for natural expansion
+        let eased = 1.0 - (1.0 - progress).powi(3);
+        max_radius * eased
+    }
+
+    fn current_alpha(&self) -> f32 {
+        let progress = self.progress();
+        (1.0 - progress).powi(2)
+    }
+}
+
+/// Shader Showcase demo view
+pub struct ShaderShowcase {
+    start_time: Instant,
+    pub touch_position: Option<Point<f32>>,
+    pub screen_center: Point<f32>,
+    orbs: Vec<Orb>,
+    ripples: Vec<Ripple>,
+}
+
+impl ShaderShowcase {
+    pub fn new() -> Self {
+        // Create orbs at various positions
+        let orbs = vec![
+            Orb::new(100.0, 200.0, 80.0, 0.1, 0.0),
+            Orb::new(300.0, 150.0, 60.0, 0.15, 0.1),
+            Orb::new(200.0, 400.0, 100.0, 0.05, 0.2),
+            Orb::new(350.0, 500.0, 50.0, 0.2, 0.3),
+            Orb::new(50.0, 600.0, 70.0, 0.12, 0.4),
+            Orb::new(280.0, 700.0, 90.0, 0.08, 0.5),
+            Orb::new(150.0, 300.0, 40.0, 0.25, 0.6),
+            Orb::new(320.0, 350.0, 55.0, 0.18, 0.7),
+        ];
+
+        Self {
+            start_time: Instant::now(),
+            touch_position: None,
+            screen_center: point(200.0, 400.0),
+            orbs,
+            ripples: Vec::new(),
+        }
+    }
+
+    fn time(&self) -> f32 {
+        self.start_time.elapsed().as_secs_f32()
+    }
+
+    fn gradient_angle(&self) -> f32 {
+        if let Some(touch) = self.touch_position {
+            let dx = touch.x - self.screen_center.x;
+            let dy = touch.y - self.screen_center.y;
+            (dy.atan2(dx).to_degrees() + 90.0) % 360.0
+        } else {
+            // Default: slowly rotating gradient
+            (self.time() * 20.0) % 360.0
+        }
+    }
+
+    fn touch_offset(&self) -> Point<f32> {
+        if let Some(touch) = self.touch_position {
+            point(
+                touch.x - self.screen_center.x,
+                touch.y - self.screen_center.y,
+            )
+        } else {
+            point(0.0, 0.0)
+        }
+    }
+
+    fn cycling_hue(&self, base: f32) -> f32 {
+        (base + self.time() * 0.05) % 1.0
+    }
+
+    pub fn spawn_ripple(&mut self, position: Point<f32>) {
+        if self.ripples.len() >= MAX_RIPPLES {
+            self.ripples.remove(0);
+        }
+        let hue = self.cycling_hue(self.ripples.len() as f32 * 0.15);
+        self.ripples.push(Ripple::new(position, hue));
+    }
+
+    fn handle_touch_down(&mut self, position: Point<f32>) {
+        self.touch_position = Some(position);
+        self.spawn_ripple(position);
+    }
+
+    fn handle_touch_move(&mut self, position: Point<f32>) {
+        self.touch_position = Some(position);
+    }
+
+    fn handle_touch_up(&mut self) {
+        self.touch_position = None;
+    }
+
+    pub fn render_with_back_button<F>(
+        &mut self,
+        window: &mut Window,
+        on_back: F,
+    ) -> impl IntoElement
+    where
+        F: Fn(&(), &mut Window, &mut App) + 'static,
+    {
+        // Request continuous animation frame
+        window.request_animation_frame();
+
+        // Remove dead ripples
+        self.ripples.retain(|r| r.is_alive());
+
+        // Get current state for rendering
+        let time = self.time();
+        let gradient_angle = self.gradient_angle();
+        let touch_offset = self.touch_offset();
+        let hue1 = self.cycling_hue(0.6);
+        let hue2 = self.cycling_hue(0.9);
+        let orbs = self.orbs.clone();
+        let ripples = self.ripples.clone();
+
+        div()
+            .size_full()
+            // Dynamic gradient background
+            .bg(linear_gradient(
+                gradient_angle,
+                linear_color_stop(hsla(hue1, 0.8, 0.15, 1.0), 0.0),
+                linear_color_stop(hsla(hue2, 0.7, 0.25, 1.0), 1.0),
+            )
+            .color_space(ColorSpace::Oklab))
+            // Canvas for custom effects
+            .child(
+                canvas(
+                    move |bounds, _window, _cx| {
+                        let bounds_f32 = Bounds {
+                            origin: point(bounds.origin.x.0, bounds.origin.y.0),
+                            size: size(bounds.size.width.0, bounds.size.height.0),
+                        };
+                        let max_ripple_radius =
+                            (bounds_f32.size.width.max(bounds_f32.size.height)) * 0.7;
+                        (
+                            bounds_f32,
+                            max_ripple_radius,
+                            time,
+                            touch_offset,
+                            orbs.clone(),
+                            ripples.clone(),
+                        )
+                    },
+                    move |_bounds,
+                          (_bounds_f32, max_ripple_radius, time, touch_offset, orbs, ripples),
+                          window,
+                          _cx| {
+                        // Draw orbs (back to front by parallax factor)
+                        let mut sorted_orbs: Vec<_> = orbs.iter().collect();
+                        sorted_orbs.sort_by(|a, b| {
+                            a.parallax_factor.partial_cmp(&b.parallax_factor).unwrap()
+                        });
+
+                        for orb in sorted_orbs {
+                            let pos = orb.current_position(touch_offset, time);
+                            let radius = orb.current_radius(time);
+
+                            // Draw glow layers (outer to inner)
+                            for i in (0..4).rev() {
+                                let glow_radius = radius * (1.0 + i as f32 * 0.5);
+                                let glow_alpha = orb.color.a * (0.1 / (i as f32 + 1.0));
+                                let glow_color =
+                                    hsla(orb.color.h, orb.color.s, orb.color.l, glow_alpha);
+                                paint_circle(
+                                    window,
+                                    point(px(pos.x), px(pos.y)),
+                                    px(glow_radius),
+                                    glow_color,
+                                );
+                            }
+
+                            // Draw core
+                            paint_circle(
+                                window,
+                                point(px(pos.x), px(pos.y)),
+                                px(radius),
+                                orb.color,
+                            );
+
+                            // Draw highlight
+                            let highlight = hsla(orb.color.h, orb.color.s * 0.5, 0.9, 0.3);
+                            paint_circle(
+                                window,
+                                point(px(pos.x - radius * 0.3), px(pos.y - radius * 0.3)),
+                                px(radius * 0.4),
+                                highlight,
+                            );
+                        }
+
+                        // Draw ripples
+                        for ripple in ripples.iter() {
+                            let radius = ripple.current_radius(max_ripple_radius);
+                            let alpha = ripple.current_alpha() * 0.5;
+                            let color = hsla(ripple.color.h, ripple.color.s, ripple.color.l, alpha);
+
+                            // Draw expanding ring
+                            paint_ring(
+                                window,
+                                point(px(ripple.center.x), px(ripple.center.y)),
+                                px(radius),
+                                px(3.0),
+                                color,
+                            );
+                        }
+                    },
+                )
+                .size_full(),
+            )
+            // Title overlay
+            .child(
+                div()
+                    .absolute()
+                    .top(px(100.0))
+                    .left_0()
+                    .right_0()
+                    .flex()
+                    .justify_center()
+                    .child(
+                        div()
+                            .text_2xl()
+                            .text_color(hsla(0.0, 0.0, 1.0, 0.8))
+                            .child("Shader Showcase"),
+                    ),
+            )
+            // Instructions
+            .child(
+                div()
+                    .absolute()
+                    .bottom(px(100.0))
+                    .left_0()
+                    .right_0()
+                    .flex()
+                    .justify_center()
+                    .child(
+                        div()
+                            .px_4()
+                            .py_2()
+                            .bg(hsla(0.0, 0.0, 0.0, 0.3))
+                            .rounded_lg()
+                            .text_color(hsla(0.0, 0.0, 1.0, 0.9))
+                            .text_sm()
+                            .child("Touch to control gradients & create ripples"),
+                    ),
+            )
+            // Back button
+            .child(back_button(on_back))
+    }
+
+    /// Update screen center based on bounds
+    pub fn set_screen_center(&mut self, center: Point<f32>) {
+        self.screen_center = center;
+    }
+}
+
+/// Paint a filled circle
+fn paint_circle(window: &mut Window, center: Point<Pixels>, radius: Pixels, color: Hsla) {
+    let bounds = Bounds {
+        origin: point(center.x - radius, center.y - radius),
+        size: size(radius * 2.0, radius * 2.0),
+    };
+    window.paint_quad(fill(bounds, color).corner_radii(radius));
+}
+
+/// Paint a ring (circle outline)
+fn paint_ring(
+    window: &mut Window,
+    center: Point<Pixels>,
+    radius: Pixels,
+    thickness: Pixels,
+    color: Hsla,
+) {
+    // Draw as two circles: outer filled, inner transparent
+    // Since we don't have stroke, we'll draw a series of circles
+    let steps = 36;
+    let angle_step = std::f32::consts::PI * 2.0 / steps as f32;
+
+    for i in 0..steps {
+        let angle = angle_step * i as f32;
+        let x = center.x + px(radius.0 * angle.cos());
+        let y = center.y + px(radius.0 * angle.sin());
+        paint_circle(window, point(x, y), thickness, color);
+    }
+}

--- a/crates/gpui/src/platform/ios/dispatcher.rs
+++ b/crates/gpui/src/platform/ios/dispatcher.rs
@@ -1,0 +1,211 @@
+//! iOS task dispatcher using Grand Central Dispatch (GCD).
+//!
+//! iOS shares the same GCD infrastructure as macOS, so this implementation
+//! is nearly identical to the macOS dispatcher.
+
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+
+use crate::{
+    GLOBAL_THREAD_TIMINGS, PlatformDispatcher, RunnableMeta, RunnableVariant, THREAD_TIMINGS,
+    TaskLabel, TaskTiming, ThreadTaskTimings,
+};
+
+use async_task::Runnable;
+use objc::{
+    class, msg_send,
+    runtime::{BOOL, YES},
+    sel, sel_impl,
+};
+use std::{
+    ffi::c_void,
+    ptr::NonNull,
+    time::{Duration, Instant},
+};
+
+// GCD types - these are the same on iOS and macOS
+type dispatch_queue_t = *mut std::ffi::c_void;
+type dispatch_time_t = u64;
+
+const DISPATCH_TIME_NOW: dispatch_time_t = 0;
+const DISPATCH_QUEUE_PRIORITY_HIGH: i64 = 2;
+
+// SAFETY: These are C functions from libdispatch
+unsafe extern "C" {
+    static _dispatch_main_q: std::ffi::c_void;
+    fn dispatch_async_f(
+        queue: dispatch_queue_t,
+        context: *mut c_void,
+        work: Option<unsafe extern "C" fn(*mut c_void)>,
+    );
+    fn dispatch_after_f(
+        when: dispatch_time_t,
+        queue: dispatch_queue_t,
+        context: *mut c_void,
+        work: Option<unsafe extern "C" fn(*mut c_void)>,
+    );
+    fn dispatch_get_global_queue(identifier: i64, flags: u64) -> dispatch_queue_t;
+    fn dispatch_time(when: dispatch_time_t, delta: i64) -> dispatch_time_t;
+}
+
+pub(crate) fn dispatch_get_main_queue() -> dispatch_queue_t {
+    std::ptr::addr_of!(_dispatch_main_q) as *const _ as dispatch_queue_t
+}
+
+pub(crate) struct IosDispatcher;
+
+impl PlatformDispatcher for IosDispatcher {
+    fn get_all_timings(&self) -> Vec<ThreadTaskTimings> {
+        let global_timings = GLOBAL_THREAD_TIMINGS.lock();
+        ThreadTaskTimings::convert(&global_timings)
+    }
+
+    fn get_current_thread_timings(&self) -> Vec<TaskTiming> {
+        THREAD_TIMINGS.with(|timings| {
+            let timings = &timings.lock().timings;
+
+            let mut vec = Vec::with_capacity(timings.len());
+
+            let (s1, s2) = timings.as_slices();
+            vec.extend_from_slice(s1);
+            vec.extend_from_slice(s2);
+            vec
+        })
+    }
+
+    fn is_main_thread(&self) -> bool {
+        unsafe {
+            let is_main: BOOL = msg_send![class!(NSThread), isMainThread];
+            is_main == YES
+        }
+    }
+
+    fn dispatch(&self, runnable: RunnableVariant, _: Option<TaskLabel>) {
+        let (context, trampoline) = match runnable {
+            RunnableVariant::Meta(runnable) => (
+                runnable.into_raw().as_ptr() as *mut c_void,
+                Some(trampoline as unsafe extern "C" fn(*mut c_void)),
+            ),
+            RunnableVariant::Compat(runnable) => (
+                runnable.into_raw().as_ptr() as *mut c_void,
+                Some(trampoline_compat as unsafe extern "C" fn(*mut c_void)),
+            ),
+        };
+        unsafe {
+            dispatch_async_f(
+                dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0),
+                context,
+                trampoline,
+            );
+        }
+    }
+
+    fn dispatch_on_main_thread(&self, runnable: RunnableVariant) {
+        let (context, trampoline) = match runnable {
+            RunnableVariant::Meta(runnable) => (
+                runnable.into_raw().as_ptr() as *mut c_void,
+                Some(trampoline as unsafe extern "C" fn(*mut c_void)),
+            ),
+            RunnableVariant::Compat(runnable) => (
+                runnable.into_raw().as_ptr() as *mut c_void,
+                Some(trampoline_compat as unsafe extern "C" fn(*mut c_void)),
+            ),
+        };
+        unsafe {
+            dispatch_async_f(dispatch_get_main_queue(), context, trampoline);
+        }
+    }
+
+    fn dispatch_after(&self, duration: Duration, runnable: RunnableVariant) {
+        let (context, trampoline) = match runnable {
+            RunnableVariant::Meta(runnable) => (
+                runnable.into_raw().as_ptr() as *mut c_void,
+                Some(trampoline as unsafe extern "C" fn(*mut c_void)),
+            ),
+            RunnableVariant::Compat(runnable) => (
+                runnable.into_raw().as_ptr() as *mut c_void,
+                Some(trampoline_compat as unsafe extern "C" fn(*mut c_void)),
+            ),
+        };
+        unsafe {
+            let queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0);
+            let when = dispatch_time(DISPATCH_TIME_NOW, duration.as_nanos() as i64);
+            dispatch_after_f(when, queue, context, trampoline);
+        }
+    }
+}
+
+extern "C" fn trampoline(runnable: *mut c_void) {
+    let task =
+        unsafe { Runnable::<RunnableMeta>::from_raw(NonNull::new_unchecked(runnable as *mut ())) };
+
+    let location = task.metadata().location;
+
+    let start = Instant::now();
+    let timing = TaskTiming {
+        location,
+        start,
+        end: None,
+    };
+
+    THREAD_TIMINGS.with(|timings| {
+        let mut timings = timings.lock();
+        let timings = &mut timings.timings;
+        if let Some(last_timing) = timings.iter_mut().rev().next() {
+            if last_timing.location == timing.location {
+                return;
+            }
+        }
+
+        timings.push_back(timing);
+    });
+
+    task.run();
+    let end = Instant::now();
+
+    THREAD_TIMINGS.with(|timings| {
+        let mut timings = timings.lock();
+        let timings = &mut timings.timings;
+        let Some(last_timing) = timings.iter_mut().rev().next() else {
+            return;
+        };
+        last_timing.end = Some(end);
+    });
+}
+
+extern "C" fn trampoline_compat(runnable: *mut c_void) {
+    let task = unsafe { Runnable::<()>::from_raw(NonNull::new_unchecked(runnable as *mut ())) };
+
+    let location = core::panic::Location::caller();
+
+    let start = Instant::now();
+    let timing = TaskTiming {
+        location,
+        start,
+        end: None,
+    };
+    THREAD_TIMINGS.with(|timings| {
+        let mut timings = timings.lock();
+        let timings = &mut timings.timings;
+        if let Some(last_timing) = timings.iter_mut().rev().next() {
+            if last_timing.location == timing.location {
+                return;
+            }
+        }
+
+        timings.push_back(timing);
+    });
+
+    task.run();
+    let end = Instant::now();
+
+    THREAD_TIMINGS.with(|timings| {
+        let mut timings = timings.lock();
+        let timings = &mut timings.timings;
+        let Some(last_timing) = timings.iter_mut().rev().next() else {
+            return;
+        };
+        last_timing.end = Some(end);
+    });
+}

--- a/crates/gpui/src/platform/ios/display.rs
+++ b/crates/gpui/src/platform/ios/display.rs
@@ -1,0 +1,97 @@
+//! iOS display handling using UIScreen.
+//!
+//! iOS has a simpler display model than macOS - typically just the main screen
+//! and possibly an external display via AirPlay or USB-C.
+
+use crate::{Bounds, DisplayId, Pixels, PlatformDisplay, px, size};
+use anyhow::Result;
+use core_graphics::geometry::CGRect;
+use objc::{class, msg_send, sel, sel_impl};
+use uuid::Uuid;
+
+/// Represents an iOS display (UIScreen).
+#[derive(Debug)]
+pub(crate) struct IosDisplay {
+    /// The UIScreen object
+    screen: *mut objc::runtime::Object,
+}
+
+unsafe impl Send for IosDisplay {}
+unsafe impl Sync for IosDisplay {}
+
+impl IosDisplay {
+    /// Get the main screen.
+    pub fn main() -> Self {
+        unsafe {
+            let screen: *mut objc::runtime::Object = msg_send![class!(UIScreen), mainScreen];
+            Self { screen }
+        }
+    }
+
+    /// Get all connected screens.
+    pub fn all() -> impl Iterator<Item = Self> {
+        unsafe {
+            let screens: *mut objc::runtime::Object = msg_send![class!(UIScreen), screens];
+            let count: usize = msg_send![screens, count];
+
+            (0..count).map(move |i| {
+                let screen: *mut objc::runtime::Object = msg_send![screens, objectAtIndex: i];
+                Self { screen }
+            })
+        }
+    }
+
+    /// Get the screen bounds in points.
+    fn bounds_in_points(&self) -> CGRect {
+        unsafe { msg_send![self.screen, bounds] }
+    }
+
+    /// Get the native scale factor of this screen.
+    pub fn native_scale(&self) -> f32 {
+        unsafe {
+            let scale: f64 = msg_send![self.screen, nativeScale];
+            scale as f32
+        }
+    }
+
+    /// Get the current scale factor (may differ from native if zoomed).
+    pub fn scale(&self) -> f32 {
+        unsafe {
+            let scale: f64 = msg_send![self.screen, scale];
+            scale as f32
+        }
+    }
+}
+
+impl PlatformDisplay for IosDisplay {
+    fn id(&self) -> DisplayId {
+        // iOS doesn't have display IDs like macOS, so we use the screen pointer as an ID
+        DisplayId(self.screen as u32)
+    }
+
+    fn uuid(&self) -> Result<Uuid> {
+        // iOS doesn't provide persistent UUIDs for displays like macOS does.
+        // We generate a deterministic UUID based on the screen properties.
+        let bounds = self.bounds_in_points();
+        let scale = self.native_scale();
+
+        // Create a deterministic UUID from screen properties
+        let bytes = format!(
+            "ios-screen-{}-{}-{}",
+            bounds.size.width as u32,
+            bounds.size.height as u32,
+            (scale * 100.0) as u32
+        );
+
+        Ok(Uuid::new_v5(&Uuid::NAMESPACE_OID, bytes.as_bytes()))
+    }
+
+    fn bounds(&self) -> Bounds<Pixels> {
+        let bounds = self.bounds_in_points();
+
+        Bounds {
+            origin: Default::default(),
+            size: size(px(bounds.size.width as f32), px(bounds.size.height as f32)),
+        }
+    }
+}

--- a/crates/gpui/src/platform/ios/events.rs
+++ b/crates/gpui/src/platform/ios/events.rs
@@ -1,0 +1,170 @@
+//! iOS event handling - converting UIKit events to GPUI's event types.
+//!
+//! iOS uses touch-based input rather than mouse input, so we need to map
+//! touch gestures to appropriate GPUI events:
+//! - Single tap → MouseDown + MouseUp (left button)
+//! - Long press → MouseDown + MouseUp (right button) for context menus
+//! - Pan gesture → ScrollWheel events
+//! - Pinch gesture → Zoom events (if supported)
+//! - Touch move → MouseMove events
+
+use crate::{
+    Modifiers, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels, PlatformInput,
+    Point, ScrollDelta, ScrollWheelEvent, TouchPhase, px,
+};
+use core_graphics::geometry::CGPoint;
+use objc::{msg_send, runtime::Object, sel, sel_impl};
+
+/// Touch phase from UIKit
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(i64)]
+pub enum UITouchPhase {
+    Began = 0,
+    Moved = 1,
+    Stationary = 2,
+    Ended = 3,
+    Cancelled = 4,
+}
+
+impl From<i64> for UITouchPhase {
+    fn from(value: i64) -> Self {
+        match value {
+            0 => UITouchPhase::Began,
+            1 => UITouchPhase::Moved,
+            2 => UITouchPhase::Stationary,
+            3 => UITouchPhase::Ended,
+            4 => UITouchPhase::Cancelled,
+            _ => UITouchPhase::Cancelled,
+        }
+    }
+}
+
+impl From<UITouchPhase> for TouchPhase {
+    fn from(phase: UITouchPhase) -> Self {
+        match phase {
+            UITouchPhase::Began => TouchPhase::Started,
+            UITouchPhase::Moved => TouchPhase::Moved,
+            UITouchPhase::Stationary => TouchPhase::Moved,
+            UITouchPhase::Ended => TouchPhase::Ended,
+            UITouchPhase::Cancelled => TouchPhase::Ended,
+        }
+    }
+}
+
+/// Convert a UITouch to a mouse position
+pub fn touch_location_in_view(touch: *mut Object, view: *mut Object) -> Point<Pixels> {
+    unsafe {
+        let location: CGPoint = msg_send![touch, locationInView: view];
+        Point::new(px(location.x as f32), px(location.y as f32))
+    }
+}
+
+/// Get the touch phase from a UITouch
+pub fn touch_phase(touch: *mut Object) -> UITouchPhase {
+    unsafe {
+        let phase: i64 = msg_send![touch, phase];
+        UITouchPhase::from(phase)
+    }
+}
+
+/// Get the number of taps for a touch (for detecting double-tap, etc.)
+pub fn touch_tap_count(touch: *mut Object) -> u32 {
+    unsafe {
+        let count: i64 = msg_send![touch, tapCount];
+        count as u32
+    }
+}
+
+/// Convert a single touch began event to a mouse down event
+pub fn touch_began_to_mouse_down(
+    position: Point<Pixels>,
+    tap_count: u32,
+    modifiers: Modifiers,
+) -> PlatformInput {
+    PlatformInput::MouseDown(MouseDownEvent {
+        button: MouseButton::Left,
+        position,
+        modifiers,
+        click_count: tap_count as usize,
+        first_mouse: false,
+    })
+}
+
+/// Convert a touch ended event to a mouse up event
+pub fn touch_ended_to_mouse_up(
+    position: Point<Pixels>,
+    tap_count: u32,
+    modifiers: Modifiers,
+) -> PlatformInput {
+    PlatformInput::MouseUp(MouseUpEvent {
+        button: MouseButton::Left,
+        position,
+        modifiers,
+        click_count: tap_count as usize,
+    })
+}
+
+/// Convert a touch moved event to a mouse move event
+pub fn touch_moved_to_mouse_move(
+    position: Point<Pixels>,
+    modifiers: Modifiers,
+    pressed_button: Option<MouseButton>,
+) -> PlatformInput {
+    PlatformInput::MouseMove(MouseMoveEvent {
+        position,
+        modifiers,
+        pressed_button,
+    })
+}
+
+/// Convert a pan gesture to a scroll wheel event
+pub fn pan_gesture_to_scroll(
+    position: Point<Pixels>,
+    delta: Point<Pixels>,
+    modifiers: Modifiers,
+    touch_phase: TouchPhase,
+) -> PlatformInput {
+    PlatformInput::ScrollWheel(ScrollWheelEvent {
+        position,
+        delta: ScrollDelta::Pixels(delta),
+        modifiers,
+        touch_phase,
+    })
+}
+
+/// Get current keyboard modifiers from UIKit.
+/// iOS doesn't have the same modifier key concept as macOS,
+/// but external keyboards can provide modifiers.
+pub fn get_current_modifiers() -> Modifiers {
+    // iOS 13.4+ supports modifier keys from external keyboards
+    // For now, return empty modifiers - this can be enhanced later
+    // to read from UIKeyModifierFlags when available
+    Modifiers::default()
+}
+
+/// Check if a long press should trigger a context menu (right-click equivalent)
+pub fn is_long_press_for_context_menu(touch: *mut Object) -> bool {
+    unsafe {
+        // Check the force of the touch (3D Touch / Haptic Touch)
+        let force: f64 = msg_send![touch, force];
+        let max_force: f64 = msg_send![touch, maximumPossibleForce];
+
+        // If force touch is available and pressed hard enough
+        if max_force > 0.0 && force / max_force > 0.5 {
+            return true;
+        }
+
+        false
+    }
+}
+
+/// Convert a force touch to a right-click for context menus
+pub fn force_touch_to_right_click(position: Point<Pixels>, modifiers: Modifiers) -> PlatformInput {
+    PlatformInput::MouseDown(MouseDownEvent {
+        button: MouseButton::Right,
+        position,
+        modifiers,
+        click_count: 1,
+        first_mouse: false,
+    })
+}

--- a/crates/gpui/src/platform/ios/ffi.rs
+++ b/crates/gpui/src/platform/ios/ffi.rs
@@ -1,0 +1,440 @@
+//! FFI (Foreign Function Interface) module for iOS.
+//!
+//! This module exposes C-compatible functions that can be called from
+//! Objective-C code in the iOS app delegate to initialize and control
+//! the GPUI application lifecycle.
+
+use crate::{App, AppContext, Application, RequestFrameOptions, WindowOptions};
+use std::ffi::c_void;
+use std::sync::OnceLock;
+
+/// Global storage for the GPUI application state.
+/// This is set during initialization and used by FFI callbacks.
+static IOS_APP_STATE: OnceLock<IosAppState> = OnceLock::new();
+
+/// Holds the state needed for iOS FFI callbacks.
+/// Note: On iOS, all UI code runs on the main thread, so we use a RefCell
+/// instead of Mutex and don't require Send.
+struct IosAppState {
+    /// The callback to invoke when the app finishes launching.
+    /// This is the closure passed to Application::run().
+    /// Using std::cell::UnsafeCell since this is only accessed from the main thread.
+    finish_launching: std::cell::UnsafeCell<Option<Box<dyn FnOnce()>>>,
+}
+
+// Safety: On iOS, all GPUI operations happen on the main thread.
+// The FFI functions are only called from the iOS app delegate which runs on main thread.
+// We implement both Send and Sync because OnceLock requires Send for its value type,
+// and we need Sync for the static. The actual access is always single-threaded.
+unsafe impl Send for IosAppState {}
+unsafe impl Sync for IosAppState {}
+
+// Safety wrapper for window list - only accessed from main thread
+struct WindowListWrapper(std::cell::UnsafeCell<Vec<*const super::window::IosWindow>>);
+unsafe impl Send for WindowListWrapper {}
+unsafe impl Sync for WindowListWrapper {}
+
+static IOS_WINDOW_LIST: OnceLock<WindowListWrapper> = OnceLock::new();
+
+/// Initialize the GPUI iOS application.
+///
+/// This should be called from `application:didFinishLaunchingWithOptions:`
+/// in the iOS app delegate, before any other GPUI functions.
+///
+/// Returns a pointer to the app state that should be passed to other FFI functions.
+/// Returns null if initialization fails.
+#[unsafe(no_mangle)]
+pub extern "C" fn gpui_ios_initialize() -> *mut c_void {
+    // Initialize logging - iOS logging is typically handled via os_log
+    // or NSLog, but for debug builds we can try to use env_logger if available
+    #[cfg(all(debug_assertions, feature = "test-support"))]
+    {
+        // Try to initialize logging, ignore if already initialized
+        let _ = env_logger::try_init();
+    }
+
+    log::info!("GPUI iOS: Initializing");
+
+    // Initialize the app state
+    let state = IosAppState {
+        finish_launching: std::cell::UnsafeCell::new(None),
+    };
+
+    if IOS_APP_STATE.set(state).is_err() {
+        log::error!("GPUI iOS: Already initialized");
+        return std::ptr::null_mut();
+    }
+
+    // Initialize the window list
+    let _ = IOS_WINDOW_LIST.set(WindowListWrapper(std::cell::UnsafeCell::new(Vec::new())));
+
+    // Return a non-null pointer to indicate success
+    // The actual state is stored in the static
+    1 as *mut c_void
+}
+
+/// Register a window with the FFI layer.
+///
+/// This is called internally when a new IosWindow is created.
+/// The window pointer can then be retrieved by Objective-C code.
+///
+/// # Safety
+/// This must only be called from the main thread.
+pub(crate) fn register_window(window: *const super::window::IosWindow) {
+    if let Some(wrapper) = IOS_WINDOW_LIST.get() {
+        unsafe {
+            (*wrapper.0.get()).push(window);
+            log::info!("GPUI iOS: Registered window {:p}", window);
+        }
+    }
+}
+
+/// Get the most recently created window pointer.
+///
+/// Returns the pointer to the IosWindow that was most recently registered,
+/// or null if no windows have been created.
+#[unsafe(no_mangle)]
+pub extern "C" fn gpui_ios_get_window() -> *mut c_void {
+    if let Some(wrapper) = IOS_WINDOW_LIST.get() {
+        unsafe {
+            let windows = &*wrapper.0.get();
+            if let Some(&window) = windows.last() {
+                log::info!("GPUI iOS: Returning window {:p}", window);
+                return window as *mut c_void;
+            }
+        }
+    }
+    log::warn!("GPUI iOS: No windows registered");
+    std::ptr::null_mut()
+}
+
+/// Store the finish launching callback.
+///
+/// This is called internally by IosPlatform::run() to store the callback
+/// that will be invoked when the app finishes launching.
+///
+/// # Safety
+/// This must only be called from the main thread.
+pub(crate) fn set_finish_launching_callback(callback: Box<dyn FnOnce()>) {
+    if let Some(state) = IOS_APP_STATE.get() {
+        // Safety: Only called from main thread
+        unsafe {
+            *state.finish_launching.get() = Some(callback);
+        }
+    }
+}
+
+/// Called when the iOS app has finished launching.
+///
+/// This should be called from `application:didFinishLaunchingWithOptions:`
+/// in the iOS app delegate, after `gpui_ios_initialize()` returns.
+///
+/// This invokes the callback passed to Application::run().
+#[unsafe(no_mangle)]
+pub extern "C" fn gpui_ios_did_finish_launching(_app_ptr: *mut c_void) {
+    log::info!("GPUI iOS: Did finish launching");
+
+    if let Some(state) = IOS_APP_STATE.get() {
+        // Safety: Only called from main thread
+        let callback = unsafe { (*state.finish_launching.get()).take() };
+        if let Some(callback) = callback {
+            log::info!("GPUI iOS: Invoking finish launching callback");
+            callback();
+        } else {
+            log::warn!("GPUI iOS: No finish launching callback registered");
+        }
+    } else {
+        log::error!("GPUI iOS: Not initialized");
+    }
+}
+
+/// Called when the iOS app will enter the foreground.
+///
+/// This should be called from `applicationWillEnterForeground:` in the app delegate.
+/// This notifies all GPUI windows that the app is becoming active.
+#[unsafe(no_mangle)]
+pub extern "C" fn gpui_ios_will_enter_foreground(_app_ptr: *mut c_void) {
+    log::info!("GPUI iOS: Will enter foreground");
+
+    // Notify all windows that they're becoming active
+    if let Some(wrapper) = IOS_WINDOW_LIST.get() {
+        unsafe {
+            let windows = &*wrapper.0.get();
+            for &window_ptr in windows.iter() {
+                if !window_ptr.is_null() {
+                    let window = &*window_ptr;
+                    window.notify_active_status_change(true);
+                }
+            }
+        }
+    }
+}
+
+/// Called when the iOS app did become active.
+///
+/// This should be called from `applicationDidBecomeActive:` in the app delegate.
+/// This indicates the app is now in the foreground and receiving events.
+#[unsafe(no_mangle)]
+pub extern "C" fn gpui_ios_did_become_active(_app_ptr: *mut c_void) {
+    log::info!("GPUI iOS: Did become active");
+
+    // App is now fully active - windows should be notified
+    if let Some(wrapper) = IOS_WINDOW_LIST.get() {
+        unsafe {
+            let windows = &*wrapper.0.get();
+            for &window_ptr in windows.iter() {
+                if !window_ptr.is_null() {
+                    let window = &*window_ptr;
+                    window.notify_active_status_change(true);
+                }
+            }
+        }
+    }
+}
+
+/// Called when the iOS app will resign active.
+///
+/// This should be called from `applicationWillResignActive:` in the app delegate.
+/// This indicates the app is about to become inactive (e.g., incoming call, switching apps).
+#[unsafe(no_mangle)]
+pub extern "C" fn gpui_ios_will_resign_active(_app_ptr: *mut c_void) {
+    log::info!("GPUI iOS: Will resign active");
+
+    // App is about to become inactive
+    if let Some(wrapper) = IOS_WINDOW_LIST.get() {
+        unsafe {
+            let windows = &*wrapper.0.get();
+            for &window_ptr in windows.iter() {
+                if !window_ptr.is_null() {
+                    let window = &*window_ptr;
+                    window.notify_active_status_change(false);
+                }
+            }
+        }
+    }
+}
+
+/// Called when the iOS app did enter the background.
+///
+/// This should be called from `applicationDidEnterBackground:` in the app delegate.
+/// At this point, the app should have already saved any user data and released
+/// shared resources. The app will be suspended shortly after this returns.
+#[unsafe(no_mangle)]
+pub extern "C" fn gpui_ios_did_enter_background(_app_ptr: *mut c_void) {
+    log::info!("GPUI iOS: Did enter background");
+
+    // Notify windows they're no longer visible
+    if let Some(wrapper) = IOS_WINDOW_LIST.get() {
+        unsafe {
+            let windows = &*wrapper.0.get();
+            for &window_ptr in windows.iter() {
+                if !window_ptr.is_null() {
+                    let window = &*window_ptr;
+                    window.notify_active_status_change(false);
+                }
+            }
+        }
+    }
+}
+
+/// Called when the iOS app will terminate.
+///
+/// This should be called from `applicationWillTerminate:` in the app delegate.
+/// This is a good place to save any unsaved data.
+#[unsafe(no_mangle)]
+pub extern "C" fn gpui_ios_will_terminate(_app_ptr: *mut c_void) {
+    log::info!("GPUI iOS: Will terminate");
+
+    // TODO: Could invoke quit callbacks here if needed
+}
+
+/// Called when a touch event occurs.
+///
+/// This bridges UIKit touch events to GPUI's input system.
+/// Parameters:
+/// - `window_ptr`: Pointer to the IosWindow
+/// - `touch_ptr`: Pointer to the UITouch object
+/// - `event_ptr`: Pointer to the UIEvent object
+#[unsafe(no_mangle)]
+pub extern "C" fn gpui_ios_handle_touch(
+    window_ptr: *mut c_void,
+    touch_ptr: *mut c_void,
+    event_ptr: *mut c_void,
+) {
+    if window_ptr.is_null() || touch_ptr.is_null() {
+        return;
+    }
+
+    // Cast to IosWindow and forward the touch event
+    let window = unsafe { &*(window_ptr as *const super::window::IosWindow) };
+    window.handle_touch(
+        touch_ptr as *mut objc::runtime::Object,
+        event_ptr as *mut objc::runtime::Object,
+    );
+}
+
+/// Request a frame to be rendered.
+///
+/// This should be called from CADisplayLink callback to trigger GPUI rendering.
+/// The window_ptr should be the value returned by gpui_ios_get_window().
+#[unsafe(no_mangle)]
+pub extern "C" fn gpui_ios_request_frame(window_ptr: *mut c_void) {
+    if window_ptr.is_null() {
+        return;
+    }
+
+    // Safety: window_ptr must be a valid pointer to an IosWindow
+    let window = unsafe { &*(window_ptr as *const super::window::IosWindow) };
+
+    // Take the callback, invoke it, then restore it
+    // We must complete the borrow before invoking the callback,
+    // as the callback might try to borrow the same RefCell
+    let callback = window.request_frame_callback.borrow_mut().take();
+    if let Some(mut cb) = callback {
+        cb(RequestFrameOptions::default());
+        // Restore the callback for the next frame
+        window.request_frame_callback.borrow_mut().replace(cb);
+    }
+}
+
+/// Show the software keyboard.
+///
+/// Call this when a text input field gains focus.
+/// The window_ptr should be the value returned by gpui_ios_get_window().
+#[unsafe(no_mangle)]
+pub extern "C" fn gpui_ios_show_keyboard(window_ptr: *mut c_void) {
+    if window_ptr.is_null() {
+        return;
+    }
+
+    log::info!("GPUI iOS: Show keyboard requested");
+
+    let window = unsafe { &*(window_ptr as *const super::window::IosWindow) };
+    window.show_keyboard();
+}
+
+/// Hide the software keyboard.
+///
+/// Call this when a text input field loses focus.
+/// The window_ptr should be the value returned by gpui_ios_get_window().
+#[unsafe(no_mangle)]
+pub extern "C" fn gpui_ios_hide_keyboard(window_ptr: *mut c_void) {
+    if window_ptr.is_null() {
+        return;
+    }
+
+    log::info!("GPUI iOS: Hide keyboard requested");
+
+    let window = unsafe { &*(window_ptr as *const super::window::IosWindow) };
+    window.hide_keyboard();
+}
+
+/// Handle text input from the software keyboard.
+///
+/// This is called when the user types on the keyboard.
+/// Parameters:
+/// - `window_ptr`: Pointer to the IosWindow
+/// - `text_ptr`: Pointer to NSString with the entered text
+#[unsafe(no_mangle)]
+pub extern "C" fn gpui_ios_handle_text_input(window_ptr: *mut c_void, text_ptr: *mut c_void) {
+    if window_ptr.is_null() || text_ptr.is_null() {
+        return;
+    }
+
+    log::info!("GPUI iOS: Handle text input");
+
+    let window = unsafe { &*(window_ptr as *const super::window::IosWindow) };
+    window.handle_text_input(text_ptr as *mut objc::runtime::Object);
+}
+
+/// Handle a key event from an external keyboard.
+///
+/// Parameters:
+/// - `window_ptr`: Pointer to the IosWindow
+/// - `key_code`: The key code from UIKeyboardHIDUsage
+/// - `modifiers`: Modifier flags from UIKeyModifierFlags
+/// - `is_key_down`: true for key down, false for key up
+#[unsafe(no_mangle)]
+pub extern "C" fn gpui_ios_handle_key_event(
+    window_ptr: *mut c_void,
+    key_code: u32,
+    modifiers: u32,
+    is_key_down: bool,
+) {
+    if window_ptr.is_null() {
+        return;
+    }
+
+    log::info!(
+        "GPUI iOS: Handle key event - code: {}, modifiers: {}, down: {}",
+        key_code,
+        modifiers,
+        is_key_down
+    );
+
+    let window = unsafe { &*(window_ptr as *const super::window::IosWindow) };
+    window.handle_key_event(key_code, modifiers, is_key_down);
+}
+
+// Import the demo module
+use super::demos::DemoApp;
+
+/// Run a demo GPUI application with interactive demos.
+///
+/// This creates a GPUI Application with a menu to select between different demos:
+/// - Animation Playground: Bouncing balls with physics and particle effects
+/// - Shader Showcase: Dynamic gradients and visual effects
+///
+/// Call this from application:didFinishLaunchingWithOptions: to start the demo.
+#[unsafe(no_mangle)]
+pub extern "C" fn gpui_ios_run_demo() {
+    log::info!("GPUI iOS: Starting demo application with interactive demos");
+
+    // First initialize the FFI layer
+    if IOS_APP_STATE.get().is_none() {
+        let state = IosAppState {
+            finish_launching: std::cell::UnsafeCell::new(None),
+        };
+        let _ = IOS_APP_STATE.set(state);
+        let _ = IOS_WINDOW_LIST.set(WindowListWrapper(std::cell::UnsafeCell::new(Vec::new())));
+    }
+
+    // Create a boxed callback that will create our demo window
+    let callback: Box<dyn FnOnce()> = Box::new(|| {
+        log::info!("GPUI iOS: Demo callback executing, but Application context not available here");
+    });
+
+    // Store the callback
+    set_finish_launching_callback(callback);
+
+    // Now create and run the application
+    // On iOS, Application::run() stores our callback and immediately returns
+    Application::new().run(|cx: &mut App| {
+        log::info!("GPUI iOS: Creating demo window with DemoApp");
+
+        cx.open_window(
+            WindowOptions {
+                // On iOS, windows are always fullscreen, let the platform decide bounds
+                window_bounds: None,
+                ..Default::default()
+            },
+            |_, cx| cx.new(|_| DemoApp::new()),
+        )
+        .expect("Failed to open window");
+
+        cx.activate(true);
+        log::info!("GPUI iOS: Demo window created successfully");
+    });
+
+    // The callback passed to Application::run() was stored by IosPlatform::run()
+    // and forwarded to set_finish_launching_callback. Now we need to invoke it.
+    // On a real iOS app, this would be called by gpui_ios_did_finish_launching()
+    // from the app delegate. Here we call it directly.
+    if let Some(state) = IOS_APP_STATE.get() {
+        let callback = unsafe { (*state.finish_launching.get()).take() };
+        if let Some(callback) = callback {
+            log::info!("GPUI iOS: Invoking Application::run callback");
+            callback();
+        }
+    }
+}

--- a/crates/gpui/src/platform/ios/platform.rs
+++ b/crates/gpui/src/platform/ios/platform.rs
@@ -1,0 +1,371 @@
+//! iOS Platform implementation.
+//!
+//! This implements the Platform trait for iOS using UIKit.
+//! Key differences from macOS:
+//! - Uses UIApplication instead of NSApplication
+//! - No menu bar (iOS apps don't have traditional menus)
+//! - No windowed mode (iOS apps are always fullscreen on their display)
+//! - Touch-based input instead of mouse
+//! - System keyboard handling differs significantly
+
+use super::{IosDispatcher, IosDisplay, IosWindow};
+use crate::platform::blade;
+use crate::{
+    Action, AnyWindowHandle, BackgroundExecutor, ClipboardItem, CursorStyle, ForegroundExecutor,
+    Keymap, Menu, MenuItem, PathPromptOptions, Platform, PlatformDisplay, PlatformKeyboardLayout,
+    PlatformKeyboardMapper, PlatformTextSystem, PlatformWindow, Result, Task, WindowAppearance,
+    WindowParams,
+};
+use anyhow::anyhow;
+use futures::channel::oneshot;
+use objc::{class, msg_send, runtime::Object, sel, sel_impl};
+use parking_lot::Mutex;
+use std::{
+    path::{Path, PathBuf},
+    rc::Rc,
+    sync::Arc,
+};
+
+pub(crate) struct IosPlatform(Mutex<IosPlatformState>);
+
+pub(crate) struct IosPlatformState {
+    background_executor: BackgroundExecutor,
+    foreground_executor: ForegroundExecutor,
+    text_system: Arc<dyn PlatformTextSystem>,
+    renderer_context: blade::Context,
+    finish_launching: Option<Box<dyn FnOnce()>>,
+    quit_callback: Option<Box<dyn FnMut()>>,
+    open_urls_callback: Option<Box<dyn FnMut(Vec<String>)>>,
+}
+
+impl Default for IosPlatform {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IosPlatform {
+    pub fn new() -> Self {
+        let dispatcher = Arc::new(IosDispatcher);
+
+        #[cfg(feature = "font-kit")]
+        let text_system = Arc::new(crate::platform::ios::IosTextSystem::new());
+
+        #[cfg(not(feature = "font-kit"))]
+        let text_system = Arc::new(crate::NoopTextSystem::new());
+
+        Self(Mutex::new(IosPlatformState {
+            background_executor: BackgroundExecutor::new(dispatcher.clone()),
+            foreground_executor: ForegroundExecutor::new(dispatcher),
+            text_system,
+            renderer_context: blade::Context::default(),
+            finish_launching: None,
+            quit_callback: None,
+            open_urls_callback: None,
+        }))
+    }
+}
+
+impl Platform for IosPlatform {
+    fn background_executor(&self) -> BackgroundExecutor {
+        self.0.lock().background_executor.clone()
+    }
+
+    fn foreground_executor(&self) -> ForegroundExecutor {
+        self.0.lock().foreground_executor.clone()
+    }
+
+    fn text_system(&self) -> Arc<dyn PlatformTextSystem> {
+        self.0.lock().text_system.clone()
+    }
+
+    fn run(&self, on_finish_launching: Box<dyn 'static + FnOnce()>) {
+        // Store the callback for later invocation via FFI.
+        // The callback will be invoked when gpui_ios_did_finish_launching() is called
+        // from the iOS app delegate's applicationDidFinishLaunchingWithOptions:.
+        self.0.lock().finish_launching = Some(on_finish_launching);
+
+        // On iOS, the app lifecycle is managed by UIApplicationMain which must be
+        // called from main() before any Rust code runs. The Application::run() method
+        // is called during app initialization, before UIApplicationMain starts its
+        // event loop.
+        //
+        // The finish_launching callback is stored and will be invoked when the iOS
+        // app delegate calls gpui_ios_did_finish_launching() via FFI.
+        //
+        // Unlike macOS where we call NSApplication.run() here, on iOS we don't need
+        // to start the run loop - UIApplicationMain handles that.
+        //
+        // The callback is forwarded to the FFI layer so it can be invoked from Obj-C.
+        if let Some(callback) = self.0.lock().finish_launching.take() {
+            super::ffi::set_finish_launching_callback(callback);
+        }
+
+        log::info!("GPUI iOS: Platform::run() completed, waiting for app delegate callback");
+    }
+
+    fn quit(&self) {
+        // iOS apps cannot programmatically quit - they can only be terminated by the user
+        // or the system. We can suspend to background though.
+        log::warn!("iOS apps cannot programmatically quit");
+    }
+
+    fn restart(&self, _binary_path: Option<PathBuf>) {
+        // iOS apps cannot restart themselves
+        log::warn!("iOS apps cannot restart themselves");
+    }
+
+    fn activate(&self, _ignoring_other_apps: bool) {
+        // iOS handles app activation automatically
+    }
+
+    fn hide(&self) {
+        // iOS apps cannot hide themselves
+    }
+
+    fn hide_other_apps(&self) {
+        // Not applicable on iOS
+    }
+
+    fn unhide_other_apps(&self) {
+        // Not applicable on iOS
+    }
+
+    fn displays(&self) -> Vec<Rc<dyn PlatformDisplay>> {
+        IosDisplay::all()
+            .map(|display| Rc::new(display) as Rc<dyn PlatformDisplay>)
+            .collect()
+    }
+
+    fn primary_display(&self) -> Option<Rc<dyn PlatformDisplay>> {
+        Some(Rc::new(IosDisplay::main()))
+    }
+
+    fn active_window(&self) -> Option<AnyWindowHandle> {
+        // iOS typically has one active window
+        // This would need to track the current key window
+        None
+    }
+
+    fn open_window(
+        &self,
+        handle: AnyWindowHandle,
+        options: WindowParams,
+    ) -> anyhow::Result<Box<dyn PlatformWindow>> {
+        let renderer_context = self.0.lock().renderer_context.clone();
+        let window = Box::new(IosWindow::new(handle, options, renderer_context)?);
+        // Register the window with FFI layer so Objective-C can access it for rendering
+        window.register_with_ffi();
+        Ok(window)
+    }
+
+    fn window_appearance(&self) -> WindowAppearance {
+        unsafe {
+            let style: i64 = {
+                let window: *mut Object = msg_send![class!(UIApplication), sharedApplication];
+                let key_window: *mut Object = msg_send![window, keyWindow];
+                if key_window.is_null() {
+                    return WindowAppearance::Light;
+                }
+                let trait_collection: *mut Object = msg_send![key_window, traitCollection];
+                msg_send![trait_collection, userInterfaceStyle]
+            };
+
+            // UIUserInterfaceStyle: 0 = unspecified, 1 = light, 2 = dark
+            match style {
+                2 => WindowAppearance::Dark,
+                _ => WindowAppearance::Light,
+            }
+        }
+    }
+
+    fn open_url(&self, url: &str) {
+        unsafe {
+            let url_string: *mut Object =
+                msg_send![class!(NSString), stringWithUTF8String: url.as_ptr()];
+            let url: *mut Object = msg_send![class!(NSURL), URLWithString: url_string];
+            let app: *mut Object = msg_send![class!(UIApplication), sharedApplication];
+            let _: () = msg_send![app, openURL: url options: std::ptr::null::<Object>() completionHandler: std::ptr::null::<Object>()];
+        }
+    }
+
+    fn on_open_urls(&self, callback: Box<dyn FnMut(Vec<String>)>) {
+        self.0.lock().open_urls_callback = Some(callback);
+    }
+
+    fn register_url_scheme(&self, _url: &str) -> Task<Result<()>> {
+        // URL schemes on iOS are registered in Info.plist, not programmatically
+        Task::ready(Ok(()))
+    }
+
+    fn prompt_for_paths(
+        &self,
+        _options: PathPromptOptions,
+    ) -> oneshot::Receiver<Result<Option<Vec<PathBuf>>>> {
+        let (tx, rx) = oneshot::channel();
+        // iOS uses UIDocumentPickerViewController for file selection
+        // This would need to be implemented with proper UIKit integration
+        let _ = tx.send(Err(anyhow!("File picker not yet implemented for iOS")));
+        rx
+    }
+
+    fn prompt_for_new_path(
+        &self,
+        _directory: &Path,
+        _suggested_name: Option<&str>,
+    ) -> oneshot::Receiver<Result<Option<PathBuf>>> {
+        let (tx, rx) = oneshot::channel();
+        let _ = tx.send(Err(anyhow!("Save dialog not yet implemented for iOS")));
+        rx
+    }
+
+    fn can_select_mixed_files_and_dirs(&self) -> bool {
+        false
+    }
+
+    fn reveal_path(&self, _path: &Path) {
+        // iOS doesn't have a file manager like Finder
+    }
+
+    fn open_with_system(&self, _path: &Path) {
+        // Would use UIDocumentInteractionController or UIActivityViewController
+    }
+
+    fn on_quit(&self, callback: Box<dyn FnMut()>) {
+        self.0.lock().quit_callback = Some(callback);
+    }
+
+    fn on_reopen(&self, _callback: Box<dyn FnMut()>) {
+        // iOS handles app reopening through scene lifecycle
+    }
+
+    fn set_menus(&self, _menus: Vec<Menu>, _keymap: &Keymap) {
+        // iOS doesn't have a menu bar
+        // Could potentially integrate with UIMenuBuilder for context menus
+    }
+
+    fn set_dock_menu(&self, _menu: Vec<MenuItem>, _keymap: &Keymap) {
+        // iOS doesn't have a dock menu
+    }
+
+    fn on_app_menu_action(&self, _callback: Box<dyn FnMut(&dyn Action)>) {
+        // Not applicable on iOS
+    }
+
+    fn on_will_open_app_menu(&self, _callback: Box<dyn FnMut()>) {
+        // Not applicable on iOS
+    }
+
+    fn on_validate_app_menu_command(&self, _callback: Box<dyn FnMut(&dyn Action) -> bool>) {
+        // Not applicable on iOS
+    }
+
+    fn app_path(&self) -> Result<PathBuf> {
+        unsafe {
+            let bundle: *mut Object = msg_send![class!(NSBundle), mainBundle];
+            let path: *mut Object = msg_send![bundle, bundlePath];
+            let utf8: *const i8 = msg_send![path, UTF8String];
+            if utf8.is_null() {
+                return Err(anyhow!("Failed to get bundle path"));
+            }
+            let path_str = std::ffi::CStr::from_ptr(utf8).to_str()?;
+            Ok(PathBuf::from(path_str))
+        }
+    }
+
+    fn path_for_auxiliary_executable(&self, name: &str) -> Result<PathBuf> {
+        let app_path = self.app_path()?;
+        Ok(app_path.join(name))
+    }
+
+    fn set_cursor_style(&self, _style: CursorStyle) {
+        // iOS doesn't have visible cursors (except for Apple Pencil hover on iPad)
+    }
+
+    fn should_auto_hide_scrollbars(&self) -> bool {
+        true // iOS always auto-hides scrollbars
+    }
+
+    fn write_to_clipboard(&self, item: ClipboardItem) {
+        unsafe {
+            let pasteboard: *mut Object = msg_send![class!(UIPasteboard), generalPasteboard];
+            if let Some(text) = item.text() {
+                let ns_string: *mut Object =
+                    msg_send![class!(NSString), stringWithUTF8String: text.as_ptr()];
+                let _: () = msg_send![pasteboard, setString: ns_string];
+            }
+        }
+    }
+
+    fn read_from_clipboard(&self) -> Option<ClipboardItem> {
+        unsafe {
+            let pasteboard: *mut Object = msg_send![class!(UIPasteboard), generalPasteboard];
+            let string: *mut Object = msg_send![pasteboard, string];
+            if string.is_null() {
+                return None;
+            }
+            let utf8: *const i8 = msg_send![string, UTF8String];
+            if utf8.is_null() {
+                return None;
+            }
+            let text = std::ffi::CStr::from_ptr(utf8).to_str().ok()?;
+            Some(ClipboardItem::new_string(text.to_string()))
+        }
+    }
+
+    fn write_credentials(&self, _url: &str, _username: &str, _password: &[u8]) -> Task<Result<()>> {
+        // Would use iOS Keychain Services
+        Task::ready(Err(anyhow!("Keychain not yet implemented for iOS")))
+    }
+
+    fn read_credentials(&self, _url: &str) -> Task<Result<Option<(String, Vec<u8>)>>> {
+        Task::ready(Err(anyhow!("Keychain not yet implemented for iOS")))
+    }
+
+    fn delete_credentials(&self, _url: &str) -> Task<Result<()>> {
+        Task::ready(Err(anyhow!("Keychain not yet implemented for iOS")))
+    }
+
+    fn keyboard_layout(&self) -> Box<dyn PlatformKeyboardLayout> {
+        Box::new(IosKeyboardLayout)
+    }
+
+    fn keyboard_mapper(&self) -> Rc<dyn PlatformKeyboardMapper> {
+        Rc::new(IosKeyboardMapper)
+    }
+
+    fn on_keyboard_layout_change(&self, _callback: Box<dyn FnMut()>) {
+        // iOS handles keyboard layout changes differently
+    }
+}
+
+/// iOS keyboard layout implementation.
+/// iOS doesn't expose the same keyboard layout APIs as macOS.
+pub struct IosKeyboardLayout;
+
+impl PlatformKeyboardLayout for IosKeyboardLayout {
+    fn id(&self) -> &str {
+        "ios"
+    }
+
+    fn name(&self) -> &str {
+        "iOS"
+    }
+}
+
+/// iOS keyboard mapper implementation.
+pub struct IosKeyboardMapper;
+
+impl PlatformKeyboardMapper for IosKeyboardMapper {
+    fn map_key_equivalent(
+        &self,
+        keystroke: crate::Keystroke,
+        _use_key_equivalents: bool,
+    ) -> crate::KeybindingKeystroke {
+        crate::KeybindingKeystroke::from_keystroke(keystroke)
+    }
+
+    fn get_key_equivalents(&self) -> Option<&collections::HashMap<char, char>> {
+        None
+    }
+}

--- a/crates/gpui/src/platform/ios/text_input.rs
+++ b/crates/gpui/src/platform/ios/text_input.rs
@@ -1,0 +1,167 @@
+//! iOS text input handling.
+//!
+//! This module provides keyboard input support for iOS.
+//! For now, we use a simple approach that handles software keyboard input
+//! through the window's text input view.
+//!
+//! Full UITextInput protocol support (for IME, marked text, etc.) can be
+//! added later if needed.
+
+use crate::{KeyDownEvent, Keystroke, Modifiers, PlatformInput};
+
+/// Convert a key code from UIKeyboardHIDUsage to a GPUI key string.
+///
+/// UIKeyboardHIDUsage values are based on the USB HID specification.
+pub fn key_code_to_string(code: u32) -> String {
+    match code {
+        // Letters (0x04-0x1D = a-z)
+        0x04..=0x1D => {
+            let letter = (b'a' + (code - 0x04) as u8) as char;
+            letter.to_string()
+        }
+        // Numbers (0x1E-0x27 = 1-9, 0)
+        0x1E..=0x26 => {
+            let num = ((code - 0x1E + 1) % 10) as u8 + b'0';
+            (num as char).to_string()
+        }
+        0x27 => "0".to_string(),
+        // Special keys
+        0x28 => "enter".to_string(),
+        0x29 => "escape".to_string(),
+        0x2A => "backspace".to_string(),
+        0x2B => "tab".to_string(),
+        0x2C => " ".to_string(),
+        0x2D => "-".to_string(),
+        0x2E => "=".to_string(),
+        0x2F => "[".to_string(),
+        0x30 => "]".to_string(),
+        0x31 => "\\".to_string(),
+        0x33 => ";".to_string(),
+        0x34 => "'".to_string(),
+        0x35 => "`".to_string(),
+        0x36 => ",".to_string(),
+        0x37 => ".".to_string(),
+        0x38 => "/".to_string(),
+        // Arrow keys
+        0x4F => "right".to_string(),
+        0x50 => "left".to_string(),
+        0x51 => "down".to_string(),
+        0x52 => "up".to_string(),
+        // Function keys
+        0x3A => "f1".to_string(),
+        0x3B => "f2".to_string(),
+        0x3C => "f3".to_string(),
+        0x3D => "f4".to_string(),
+        0x3E => "f5".to_string(),
+        0x3F => "f6".to_string(),
+        0x40 => "f7".to_string(),
+        0x41 => "f8".to_string(),
+        0x42 => "f9".to_string(),
+        0x43 => "f10".to_string(),
+        0x44 => "f11".to_string(),
+        0x45 => "f12".to_string(),
+        // Other special keys
+        0x49 => "insert".to_string(),
+        0x4A => "home".to_string(),
+        0x4B => "pageup".to_string(),
+        0x4C => "delete".to_string(),
+        0x4D => "end".to_string(),
+        0x4E => "pagedown".to_string(),
+        // Default
+        _ => format!("unknown-{:02x}", code),
+    }
+}
+
+/// Convert UIKeyModifierFlags to GPUI Modifiers.
+///
+/// UIKeyModifierFlags:
+/// - alphaShift (caps lock): 1 << 16
+/// - shift: 1 << 17
+/// - control: 1 << 18
+/// - alternate (option): 1 << 19
+/// - command: 1 << 20
+/// - numericPad: 1 << 21
+pub fn modifier_flags_to_modifiers(flags: u32) -> Modifiers {
+    const SHIFT: u32 = 1 << 17;
+    const CONTROL: u32 = 1 << 18;
+    const ALT: u32 = 1 << 19;
+    const COMMAND: u32 = 1 << 20;
+
+    Modifiers {
+        control: flags & CONTROL != 0,
+        alt: flags & ALT != 0,
+        shift: flags & SHIFT != 0,
+        platform: flags & COMMAND != 0,
+        function: false,
+    }
+}
+
+/// Create a key down event from a character.
+pub fn character_to_key_down(c: char) -> PlatformInput {
+    let keystroke = Keystroke {
+        modifiers: Modifiers::default(),
+        key: c.to_string(),
+        key_char: Some(c.to_string()),
+    };
+
+    PlatformInput::KeyDown(KeyDownEvent {
+        keystroke,
+        is_held: false,
+        prefer_character_input: true,
+    })
+}
+
+/// Create a backspace key down event.
+pub fn backspace_key_down() -> PlatformInput {
+    let keystroke = Keystroke {
+        modifiers: Modifiers::default(),
+        key: "backspace".to_string(),
+        key_char: None,
+    };
+
+    PlatformInput::KeyDown(KeyDownEvent {
+        keystroke,
+        is_held: false,
+        prefer_character_input: false,
+    })
+}
+
+/// Create a key down event from a key code and modifiers.
+pub fn key_code_to_key_down(key_code: u32, modifier_flags: u32) -> PlatformInput {
+    let modifiers = modifier_flags_to_modifiers(modifier_flags);
+    let key = key_code_to_string(key_code);
+
+    let keystroke = Keystroke {
+        modifiers,
+        key: key.clone(),
+        key_char: if key.len() == 1 {
+            Some(key.clone())
+        } else {
+            None
+        },
+    };
+
+    PlatformInput::KeyDown(KeyDownEvent {
+        keystroke,
+        is_held: false,
+        prefer_character_input: false,
+    })
+}
+
+/// Create a key up event from a key code and modifiers.
+pub fn key_code_to_key_up(key_code: u32, modifier_flags: u32) -> PlatformInput {
+    let modifiers = modifier_flags_to_modifiers(modifier_flags);
+    let key = key_code_to_string(key_code);
+
+    let keystroke = Keystroke {
+        modifiers,
+        key: key.clone(),
+        key_char: if key.len() == 1 {
+            Some(key.clone())
+        } else {
+            None
+        },
+    };
+
+    PlatformInput::KeyUp(crate::KeyUpEvent { keystroke })
+}

--- a/crates/gpui/src/platform/ios/text_system.rs
+++ b/crates/gpui/src/platform/ios/text_system.rs
@@ -1,0 +1,801 @@
+//! iOS text system using CoreText.
+//!
+//! This is adapted from the macOS text system since both platforms share
+//! the CoreText framework for text rendering.
+
+use crate::{
+    Bounds, DevicePixels, Font, FontFallbacks, FontFeatures, FontId, FontMetrics, FontRun,
+    FontStyle, FontWeight, GlyphId, LineLayout, Pixels, PlatformTextSystem, Point,
+    RenderGlyphParams, Result, SUBPIXEL_VARIANTS_X, ShapedGlyph, ShapedRun, SharedString, Size,
+    point, px, size, swap_rgba_pa_to_bgra,
+};
+use anyhow::anyhow;
+use collections::HashMap;
+use core_foundation::{
+    attributed_string::CFMutableAttributedString,
+    base::{CFRange, TCFType},
+    number::CFNumber,
+    string::CFString,
+};
+use core_graphics::{
+    base::{CGFloat, CGGlyph, kCGImageAlphaPremultipliedLast},
+    color_space::CGColorSpace,
+    context::{CGContext, CGTextDrawingMode},
+    geometry::CGPoint,
+};
+use core_text::{
+    font::CTFont,
+    font_descriptor::{
+        kCTFontSlantTrait, kCTFontSymbolicTrait, kCTFontWeightTrait, kCTFontWidthTrait,
+    },
+    line::CTLine,
+    string_attributes::kCTFontAttributeName,
+};
+use font_kit::{
+    font::Font as FontKitFont,
+    handle::Handle,
+    hinting::HintingOptions,
+    metrics::Metrics,
+    properties::{Style as FontkitStyle, Weight as FontkitWeight},
+    source::SystemSource,
+    sources::mem::MemSource,
+};
+use parking_lot::{RwLock, RwLockUpgradableReadGuard};
+use pathfinder_geometry::{
+    rect::{RectF, RectI},
+    transform2d::Transform2F,
+    vector::{Vector2F, Vector2I},
+};
+use smallvec::SmallVec;
+use std::{borrow::Cow, char, convert::TryFrom, sync::Arc};
+
+#[allow(non_upper_case_globals)]
+const kCGImageAlphaOnly: u32 = 7;
+
+/// iOS text system using CoreText for text shaping and rendering.
+///
+/// This provides full text rendering support on iOS using the same
+/// CoreText framework that macOS uses, adapted for the iOS platform.
+pub struct IosTextSystem(RwLock<IosTextSystemState>);
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct FontKey {
+    font_family: SharedString,
+    font_features: FontFeatures,
+    font_fallbacks: Option<FontFallbacks>,
+}
+
+struct IosTextSystemState {
+    memory_source: MemSource,
+    system_source: SystemSource,
+    fonts: Vec<FontKitFont>,
+    font_selections: HashMap<Font, FontId>,
+    font_ids_by_postscript_name: HashMap<String, FontId>,
+    font_ids_by_font_key: HashMap<FontKey, SmallVec<[FontId; 4]>>,
+    postscript_names_by_font_id: HashMap<FontId, String>,
+}
+
+impl IosTextSystem {
+    pub fn new() -> Self {
+        Self(RwLock::new(IosTextSystemState {
+            memory_source: MemSource::empty(),
+            system_source: SystemSource::new(),
+            fonts: Vec::new(),
+            font_selections: HashMap::default(),
+            font_ids_by_postscript_name: HashMap::default(),
+            font_ids_by_font_key: HashMap::default(),
+            postscript_names_by_font_id: HashMap::default(),
+        }))
+    }
+}
+
+impl Default for IosTextSystem {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PlatformTextSystem for IosTextSystem {
+    fn add_fonts(&self, fonts: Vec<Cow<'static, [u8]>>) -> Result<()> {
+        self.0.write().add_fonts(fonts)
+    }
+
+    fn all_font_names(&self) -> Vec<String> {
+        let mut names = Vec::new();
+        let collection = core_text::font_collection::create_for_all_families();
+        let Some(descriptors) = collection.get_descriptors() else {
+            return names;
+        };
+        for descriptor in descriptors.into_iter() {
+            names.extend(lenient_font_attributes::family_name(&descriptor));
+        }
+        if let Ok(fonts_in_memory) = self.0.read().memory_source.all_families() {
+            names.extend(fonts_in_memory);
+        }
+        names
+    }
+
+    fn font_id(&self, font: &Font) -> Result<FontId> {
+        let lock = self.0.upgradable_read();
+        if let Some(font_id) = lock.font_selections.get(font) {
+            Ok(*font_id)
+        } else {
+            let mut lock = RwLockUpgradableReadGuard::upgrade(lock);
+            let font_key = FontKey {
+                font_family: font.family.clone(),
+                font_features: font.features.clone(),
+                font_fallbacks: font.fallbacks.clone(),
+            };
+            let candidates = if let Some(font_ids) = lock.font_ids_by_font_key.get(&font_key) {
+                font_ids.as_slice()
+            } else {
+                let font_ids =
+                    lock.load_family(&font.family, &font.features, font.fallbacks.as_ref())?;
+                lock.font_ids_by_font_key.insert(font_key.clone(), font_ids);
+                lock.font_ids_by_font_key[&font_key].as_ref()
+            };
+
+            let candidate_properties = candidates
+                .iter()
+                .map(|font_id| lock.fonts[font_id.0].properties())
+                .collect::<SmallVec<[_; 4]>>();
+
+            let ix = font_kit::matching::find_best_match(
+                &candidate_properties,
+                &font_kit::properties::Properties {
+                    style: font.style.into(),
+                    weight: font.weight.into(),
+                    stretch: Default::default(),
+                },
+            )?;
+
+            let font_id = candidates[ix];
+            lock.font_selections.insert(font.clone(), font_id);
+            Ok(font_id)
+        }
+    }
+
+    fn font_metrics(&self, font_id: FontId) -> FontMetrics {
+        self.0.read().fonts[font_id.0].metrics().into()
+    }
+
+    fn typographic_bounds(&self, font_id: FontId, glyph_id: GlyphId) -> Result<Bounds<f32>> {
+        Ok(self.0.read().fonts[font_id.0]
+            .typographic_bounds(glyph_id.0)?
+            .into())
+    }
+
+    fn advance(&self, font_id: FontId, glyph_id: GlyphId) -> Result<Size<f32>> {
+        self.0.read().advance(font_id, glyph_id)
+    }
+
+    fn glyph_for_char(&self, font_id: FontId, ch: char) -> Option<GlyphId> {
+        self.0.read().glyph_for_char(font_id, ch)
+    }
+
+    fn glyph_raster_bounds(&self, params: &RenderGlyphParams) -> Result<Bounds<DevicePixels>> {
+        self.0.read().raster_bounds(params)
+    }
+
+    fn rasterize_glyph(
+        &self,
+        glyph_id: &RenderGlyphParams,
+        raster_bounds: Bounds<DevicePixels>,
+    ) -> Result<(Size<DevicePixels>, Vec<u8>)> {
+        self.0.read().rasterize_glyph(glyph_id, raster_bounds)
+    }
+
+    fn layout_line(&self, text: &str, font_size: Pixels, font_runs: &[FontRun]) -> LineLayout {
+        self.0.write().layout_line(text, font_size, font_runs)
+    }
+}
+
+impl IosTextSystemState {
+    fn add_fonts(&mut self, fonts: Vec<Cow<'static, [u8]>>) -> Result<()> {
+        let fonts = fonts
+            .into_iter()
+            .map(|bytes| match bytes {
+                Cow::Borrowed(embedded_font) => {
+                    let data_provider = unsafe {
+                        core_graphics::data_provider::CGDataProvider::from_slice(embedded_font)
+                    };
+                    let font = core_graphics::font::CGFont::from_data_provider(data_provider)
+                        .map_err(|()| anyhow!("Could not load an embedded font."))?;
+                    let font = font_kit::loaders::core_text::Font::from_core_graphics_font(font);
+                    Ok(Handle::from_native(&font))
+                }
+                Cow::Owned(bytes) => Ok(Handle::from_memory(Arc::new(bytes), 0)),
+            })
+            .collect::<Result<Vec<_>>>()?;
+        self.memory_source.add_fonts(fonts.into_iter())?;
+        Ok(())
+    }
+
+    fn load_family(
+        &mut self,
+        name: &str,
+        features: &FontFeatures,
+        fallbacks: Option<&FontFallbacks>,
+    ) -> Result<SmallVec<[FontId; 4]>> {
+        // On iOS, the system UI font is accessed via ".AppleSystemUIFont"
+        // but we also support direct font names
+        let name = crate::text_system::font_name_with_fallbacks(name, ".AppleSystemUIFont");
+
+        let mut font_ids = SmallVec::new();
+        let family = self
+            .memory_source
+            .select_family_by_name(name)
+            .or_else(|_| self.system_source.select_family_by_name(name))?;
+        for font in family.fonts() {
+            let mut font = font.load()?;
+
+            apply_features_and_fallbacks(&mut font, features, fallbacks)?;
+            // This block contains a precautionary fix to guard against loading fonts
+            // that might cause panics due to `.unwrap()`s up the chain.
+            {
+                // We use the 'm' character for text measurements in various spots
+                // (e.g., the editor). However, at time of writing some of those usages
+                // will panic if the font has no 'm' glyph.
+                //
+                // Therefore, we check up front that the font has the necessary glyph.
+                let has_m_glyph = font.glyph_for_char('m').is_some();
+
+                // HACK: The 'Segoe Fluent Icons' font does not have an 'm' glyph,
+                // but we need to be able to load it for rendering Windows icons in
+                // the Storybook (on macOS).
+                let is_segoe_fluent_icons = font.full_name() == "Segoe Fluent Icons";
+
+                if !has_m_glyph && !is_segoe_fluent_icons {
+                    log::warn!(
+                        "font '{}' has no 'm' character and was not loaded",
+                        font.full_name()
+                    );
+                    continue;
+                }
+            }
+
+            // Validate font traits to avoid panics from malformed fonts
+            let traits = font.native_font().all_traits();
+            if unsafe {
+                !(traits
+                    .get(kCTFontSymbolicTrait)
+                    .downcast::<CFNumber>()
+                    .is_some()
+                    && traits
+                        .get(kCTFontWidthTrait)
+                        .downcast::<CFNumber>()
+                        .is_some()
+                    && traits
+                        .get(kCTFontWeightTrait)
+                        .downcast::<CFNumber>()
+                        .is_some()
+                    && traits
+                        .get(kCTFontSlantTrait)
+                        .downcast::<CFNumber>()
+                        .is_some())
+            } {
+                log::error!(
+                    "Failed to read traits for font {:?}",
+                    font.postscript_name().unwrap()
+                );
+                continue;
+            }
+
+            let font_id = FontId(self.fonts.len());
+            font_ids.push(font_id);
+            let postscript_name = font.postscript_name().unwrap();
+            self.font_ids_by_postscript_name
+                .insert(postscript_name.clone(), font_id);
+            self.postscript_names_by_font_id
+                .insert(font_id, postscript_name);
+            self.fonts.push(font);
+        }
+        Ok(font_ids)
+    }
+
+    fn advance(&self, font_id: FontId, glyph_id: GlyphId) -> Result<Size<f32>> {
+        Ok(self.fonts[font_id.0].advance(glyph_id.0)?.into())
+    }
+
+    fn glyph_for_char(&self, font_id: FontId, ch: char) -> Option<GlyphId> {
+        self.fonts[font_id.0].glyph_for_char(ch).map(GlyphId)
+    }
+
+    fn id_for_native_font(&mut self, requested_font: CTFont) -> FontId {
+        let postscript_name = requested_font.postscript_name();
+        if let Some(font_id) = self.font_ids_by_postscript_name.get(&postscript_name) {
+            *font_id
+        } else {
+            let font_id = FontId(self.fonts.len());
+            self.font_ids_by_postscript_name
+                .insert(postscript_name.clone(), font_id);
+            self.postscript_names_by_font_id
+                .insert(font_id, postscript_name);
+            self.fonts
+                .push(font_kit::font::Font::from_core_graphics_font(
+                    requested_font.copy_to_CGFont(),
+                ));
+            font_id
+        }
+    }
+
+    fn is_emoji(&self, font_id: FontId) -> bool {
+        self.postscript_names_by_font_id
+            .get(&font_id)
+            .is_some_and(|postscript_name| {
+                postscript_name == "AppleColorEmoji" || postscript_name == ".AppleColorEmojiUI"
+            })
+    }
+
+    fn raster_bounds(&self, params: &RenderGlyphParams) -> Result<Bounds<DevicePixels>> {
+        let font = &self.fonts[params.font_id.0];
+        let scale = Transform2F::from_scale(params.scale_factor);
+        Ok(font
+            .raster_bounds(
+                params.glyph_id.0,
+                params.font_size.into(),
+                scale,
+                HintingOptions::None,
+                font_kit::canvas::RasterizationOptions::GrayscaleAa,
+            )?
+            .into())
+    }
+
+    fn rasterize_glyph(
+        &self,
+        params: &RenderGlyphParams,
+        glyph_bounds: Bounds<DevicePixels>,
+    ) -> Result<(Size<DevicePixels>, Vec<u8>)> {
+        if glyph_bounds.size.width.0 == 0 || glyph_bounds.size.height.0 == 0 {
+            anyhow::bail!("glyph bounds are empty");
+        } else {
+            // Add an extra pixel when the subpixel variant isn't zero to make room for anti-aliasing.
+            let mut bitmap_size = glyph_bounds.size;
+            if params.subpixel_variant.x > 0 {
+                bitmap_size.width += DevicePixels(1);
+            }
+            if params.subpixel_variant.y > 0 {
+                bitmap_size.height += DevicePixels(1);
+            }
+            let bitmap_size = bitmap_size;
+
+            let mut bytes;
+            let cx;
+            if params.is_emoji {
+                bytes = vec![0; bitmap_size.width.0 as usize * 4 * bitmap_size.height.0 as usize];
+                cx = CGContext::create_bitmap_context(
+                    Some(bytes.as_mut_ptr() as *mut _),
+                    bitmap_size.width.0 as usize,
+                    bitmap_size.height.0 as usize,
+                    8,
+                    bitmap_size.width.0 as usize * 4,
+                    &CGColorSpace::create_device_rgb(),
+                    kCGImageAlphaPremultipliedLast,
+                );
+            } else {
+                bytes = vec![0; bitmap_size.width.0 as usize * bitmap_size.height.0 as usize];
+                cx = CGContext::create_bitmap_context(
+                    Some(bytes.as_mut_ptr() as *mut _),
+                    bitmap_size.width.0 as usize,
+                    bitmap_size.height.0 as usize,
+                    8,
+                    bitmap_size.width.0 as usize,
+                    &CGColorSpace::create_device_gray(),
+                    kCGImageAlphaOnly,
+                );
+            }
+
+            // Move the origin to bottom left and account for scaling, this
+            // makes drawing text consistent with the font-kit's raster_bounds.
+            cx.translate(
+                -glyph_bounds.origin.x.0 as CGFloat,
+                (glyph_bounds.origin.y.0 + glyph_bounds.size.height.0) as CGFloat,
+            );
+            cx.scale(
+                params.scale_factor as CGFloat,
+                params.scale_factor as CGFloat,
+            );
+
+            let subpixel_shift = params
+                .subpixel_variant
+                .map(|v| v as f32 / SUBPIXEL_VARIANTS_X as f32);
+            cx.set_text_drawing_mode(CGTextDrawingMode::CGTextFill);
+            cx.set_gray_fill_color(0.0, 1.0);
+            cx.set_allows_antialiasing(true);
+            cx.set_should_antialias(true);
+            cx.set_allows_font_subpixel_positioning(true);
+            cx.set_should_subpixel_position_fonts(true);
+            cx.set_allows_font_subpixel_quantization(false);
+            cx.set_should_subpixel_quantize_fonts(false);
+            self.fonts[params.font_id.0]
+                .native_font()
+                .clone_with_font_size(f32::from(params.font_size) as CGFloat)
+                .draw_glyphs(
+                    &[params.glyph_id.0 as CGGlyph],
+                    &[CGPoint::new(
+                        (subpixel_shift.x / params.scale_factor) as CGFloat,
+                        (subpixel_shift.y / params.scale_factor) as CGFloat,
+                    )],
+                    cx,
+                );
+
+            if params.is_emoji {
+                // Convert from RGBA with premultiplied alpha to BGRA with straight alpha.
+                for pixel in bytes.chunks_exact_mut(4) {
+                    swap_rgba_pa_to_bgra(pixel);
+                }
+            }
+
+            Ok((bitmap_size, bytes))
+        }
+    }
+
+    fn layout_line(&mut self, text: &str, font_size: Pixels, font_runs: &[FontRun]) -> LineLayout {
+        // Construct the attributed string, converting UTF8 ranges to UTF16 ranges.
+        let mut string = CFMutableAttributedString::new();
+        let mut max_ascent = 0.0f32;
+        let mut max_descent = 0.0f32;
+
+        {
+            let mut text = text;
+            let mut break_ligature = true;
+            for run in font_runs {
+                let text_run;
+                (text_run, text) = text.split_at(run.len);
+
+                let utf16_start = string.char_len(); // insert at end of string
+                // note: replace_str may silently ignore codepoints it dislikes (e.g., BOM at start of string)
+                string.replace_str(&CFString::new(text_run), CFRange::init(utf16_start, 0));
+                let utf16_end = string.char_len();
+
+                let length = utf16_end - utf16_start;
+                let cf_range = CFRange::init(utf16_start, length);
+                let font = &self.fonts[run.font_id.0];
+
+                let font_metrics = font.metrics();
+                let font_scale = font_size.0 / font_metrics.units_per_em as f32;
+                max_ascent = max_ascent.max(font_metrics.ascent * font_scale);
+                max_descent = max_descent.max(-font_metrics.descent * font_scale);
+
+                let font_size = if break_ligature {
+                    px(font_size.0.next_up())
+                } else {
+                    font_size
+                };
+                unsafe {
+                    string.set_attribute(
+                        cf_range,
+                        kCTFontAttributeName,
+                        &font.native_font().clone_with_font_size(font_size.into()),
+                    );
+                }
+                break_ligature = !break_ligature;
+            }
+        }
+        // Retrieve the glyphs from the shaped line, converting UTF16 offsets to UTF8 offsets.
+        let line = CTLine::new_with_attributed_string(string.as_concrete_TypeRef());
+        let glyph_runs = line.glyph_runs();
+        let mut runs = <Vec<ShapedRun>>::with_capacity(glyph_runs.len() as usize);
+        let mut ix_converter = StringIndexConverter::new(text);
+        for run in glyph_runs.into_iter() {
+            let attributes = run.attributes().unwrap();
+            let font = unsafe {
+                attributes
+                    .get(kCTFontAttributeName)
+                    .downcast::<CTFont>()
+                    .unwrap()
+            };
+            let font_id = self.id_for_native_font(font);
+
+            let glyphs = match runs.last_mut() {
+                Some(run) if run.font_id == font_id => &mut run.glyphs,
+                _ => {
+                    runs.push(ShapedRun {
+                        font_id,
+                        glyphs: Vec::with_capacity(run.glyph_count().try_into().unwrap_or(0)),
+                    });
+                    &mut runs.last_mut().unwrap().glyphs
+                }
+            };
+            for ((&glyph_id, position), &glyph_utf16_ix) in run
+                .glyphs()
+                .iter()
+                .zip(run.positions().iter())
+                .zip(run.string_indices().iter())
+            {
+                let glyph_utf16_ix = usize::try_from(glyph_utf16_ix).unwrap();
+                if ix_converter.utf16_ix > glyph_utf16_ix {
+                    // We cannot reuse current index converter, as it can only seek forward. Restart the search.
+                    ix_converter = StringIndexConverter::new(text);
+                }
+                ix_converter.advance_to_utf16_ix(glyph_utf16_ix);
+                glyphs.push(ShapedGlyph {
+                    id: GlyphId(glyph_id as u32),
+                    position: point(position.x as f32, position.y as f32).map(px),
+                    index: ix_converter.utf8_ix,
+                    is_emoji: self.is_emoji(font_id),
+                });
+            }
+        }
+        let typographic_bounds = line.get_typographic_bounds();
+        LineLayout {
+            runs,
+            font_size,
+            width: typographic_bounds.width.into(),
+            ascent: max_ascent.into(),
+            descent: max_descent.into(),
+            len: text.len(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct StringIndexConverter<'a> {
+    text: &'a str,
+    /// Index in UTF-8 bytes
+    utf8_ix: usize,
+    /// Index in UTF-16 code units
+    utf16_ix: usize,
+}
+
+impl<'a> StringIndexConverter<'a> {
+    fn new(text: &'a str) -> Self {
+        Self {
+            text,
+            utf8_ix: 0,
+            utf16_ix: 0,
+        }
+    }
+
+    fn advance_to_utf16_ix(&mut self, utf16_target: usize) {
+        for (ix, c) in self.text[self.utf8_ix..].char_indices() {
+            if self.utf16_ix >= utf16_target {
+                self.utf8_ix += ix;
+                return;
+            }
+            self.utf16_ix += c.len_utf16();
+        }
+        self.utf8_ix = self.text.len();
+    }
+}
+
+// Type conversions
+
+impl From<Metrics> for FontMetrics {
+    fn from(metrics: Metrics) -> Self {
+        FontMetrics {
+            units_per_em: metrics.units_per_em,
+            ascent: metrics.ascent,
+            descent: metrics.descent,
+            line_gap: metrics.line_gap,
+            underline_position: metrics.underline_position,
+            underline_thickness: metrics.underline_thickness,
+            cap_height: metrics.cap_height,
+            x_height: metrics.x_height,
+            bounding_box: metrics.bounding_box.into(),
+        }
+    }
+}
+
+impl From<RectF> for Bounds<f32> {
+    fn from(rect: RectF) -> Self {
+        Bounds {
+            origin: point(rect.origin_x(), rect.origin_y()),
+            size: size(rect.width(), rect.height()),
+        }
+    }
+}
+
+impl From<RectI> for Bounds<DevicePixels> {
+    fn from(rect: RectI) -> Self {
+        Bounds {
+            origin: point(DevicePixels(rect.origin_x()), DevicePixels(rect.origin_y())),
+            size: size(DevicePixels(rect.width()), DevicePixels(rect.height())),
+        }
+    }
+}
+
+impl From<Vector2I> for Size<DevicePixels> {
+    fn from(value: Vector2I) -> Self {
+        size(value.x().into(), value.y().into())
+    }
+}
+
+impl From<RectI> for Bounds<i32> {
+    fn from(rect: RectI) -> Self {
+        Bounds {
+            origin: point(rect.origin_x(), rect.origin_y()),
+            size: size(rect.width(), rect.height()),
+        }
+    }
+}
+
+impl From<Point<u32>> for Vector2I {
+    fn from(size: Point<u32>) -> Self {
+        Vector2I::new(size.x as i32, size.y as i32)
+    }
+}
+
+impl From<Vector2F> for Size<f32> {
+    fn from(vec: Vector2F) -> Self {
+        size(vec.x(), vec.y())
+    }
+}
+
+impl From<FontWeight> for FontkitWeight {
+    fn from(value: FontWeight) -> Self {
+        FontkitWeight(value.0)
+    }
+}
+
+impl From<FontStyle> for FontkitStyle {
+    fn from(style: FontStyle) -> Self {
+        match style {
+            FontStyle::Normal => FontkitStyle::Normal,
+            FontStyle::Italic => FontkitStyle::Italic,
+            FontStyle::Oblique => FontkitStyle::Oblique,
+        }
+    }
+}
+
+// OpenType feature application for iOS
+// This is adapted from the macOS open_type.rs module
+
+fn apply_features_and_fallbacks(
+    font: &mut FontKitFont,
+    features: &FontFeatures,
+    fallbacks: Option<&FontFallbacks>,
+) -> anyhow::Result<()> {
+    use core_foundation::{
+        array::{CFArrayAppendValue, CFArrayCreateMutable, CFArrayRef, kCFTypeArrayCallBacks},
+        base::{CFRelease, kCFAllocatorDefault},
+        dictionary::{
+            CFDictionaryCreate, kCFTypeDictionaryKeyCallBacks, kCFTypeDictionaryValueCallBacks,
+        },
+        string::CFStringRef,
+    };
+    use core_text::font_descriptor::{
+        CTFontDescriptor, CTFontDescriptorCreateWithAttributes,
+        CTFontDescriptorCreateWithNameAndSize, CTFontDescriptorRef, kCTFontCascadeListAttribute,
+        kCTFontFeatureSettingsAttribute,
+    };
+
+    #[link(name = "CoreText", kind = "framework")]
+    unsafe extern "C" {
+        static kCTFontOpenTypeFeatureTag: CFStringRef;
+        static kCTFontOpenTypeFeatureValue: CFStringRef;
+
+        fn CTFontCreateCopyWithAttributes(
+            font: core_text::font::CTFontRef,
+            size: CGFloat,
+            matrix: *const core_graphics::geometry::CGAffineTransform,
+            attributes: CTFontDescriptorRef,
+        ) -> core_text::font::CTFontRef;
+        fn CTFontCopyDefaultCascadeListForLanguages(
+            font: core_text::font::CTFontRef,
+            languagePrefList: CFArrayRef,
+        ) -> CFArrayRef;
+    }
+
+    unsafe {
+        // Generate feature array
+        let feature_array = CFArrayCreateMutable(kCFAllocatorDefault, 0, &kCFTypeArrayCallBacks);
+        for (tag, value) in features.tag_value_list() {
+            let keys = [kCTFontOpenTypeFeatureTag, kCTFontOpenTypeFeatureValue];
+            let values = [
+                CFString::new(tag).as_CFTypeRef(),
+                CFNumber::from(*value as i32).as_CFTypeRef(),
+            ];
+            let dict = CFDictionaryCreate(
+                kCFAllocatorDefault,
+                &keys as *const _ as _,
+                &values as *const _ as _,
+                2,
+                &kCFTypeDictionaryKeyCallBacks,
+                &kCFTypeDictionaryValueCallBacks,
+            );
+            values.into_iter().for_each(|value| CFRelease(value));
+            CFArrayAppendValue(feature_array, dict as _);
+            CFRelease(dict as _);
+        }
+
+        let mut keys = vec![kCTFontFeatureSettingsAttribute];
+        let mut values = vec![feature_array as *const _];
+
+        // Generate fallback array if needed
+        if let Some(fallbacks) = fallbacks {
+            if !fallbacks.fallback_list().is_empty() {
+                let fallback_array =
+                    CFArrayCreateMutable(kCFAllocatorDefault, 0, &kCFTypeArrayCallBacks);
+                for user_fallback in fallbacks.fallback_list() {
+                    let name = CFString::from(user_fallback.as_str());
+                    let fallback_desc =
+                        CTFontDescriptorCreateWithNameAndSize(name.as_concrete_TypeRef(), 0.0);
+                    CFArrayAppendValue(fallback_array, fallback_desc as _);
+                    CFRelease(fallback_desc as _);
+                }
+                // Append system fallbacks
+                let preferred_languages: core_foundation::array::CFArray<CFString> =
+                    core_foundation::array::CFArray::wrap_under_create_rule(
+                        core_foundation_sys::locale::CFLocaleCopyPreferredLanguages(),
+                    );
+                let default_fallbacks = CTFontCopyDefaultCascadeListForLanguages(
+                    font.native_font().as_concrete_TypeRef(),
+                    preferred_languages.as_concrete_TypeRef(),
+                );
+                let default_fallbacks: core_foundation::array::CFArray<CTFontDescriptor> =
+                    core_foundation::array::CFArray::wrap_under_create_rule(default_fallbacks);
+                for desc in default_fallbacks.iter() {
+                    if desc.font_path().is_some() {
+                        CFArrayAppendValue(fallback_array, desc.as_concrete_TypeRef() as _);
+                    }
+                }
+
+                keys.push(kCTFontCascadeListAttribute);
+                values.push(fallback_array as *const _);
+            }
+        }
+
+        let attrs = CFDictionaryCreate(
+            kCFAllocatorDefault,
+            keys.as_ptr() as _,
+            values.as_ptr() as _,
+            keys.len() as isize,
+            &kCFTypeDictionaryKeyCallBacks,
+            &kCFTypeDictionaryValueCallBacks,
+        );
+        let new_descriptor = CTFontDescriptorCreateWithAttributes(attrs);
+        CFRelease(attrs as _);
+        let new_descriptor = CTFontDescriptor::wrap_under_create_rule(new_descriptor);
+        let new_font = CTFontCreateCopyWithAttributes(
+            font.native_font().as_concrete_TypeRef(),
+            0.0,
+            std::ptr::null(),
+            new_descriptor.as_concrete_TypeRef(),
+        );
+        let new_font = CTFont::wrap_under_create_rule(new_font);
+        *font = font_kit::font::Font::from_native_font(&new_font);
+
+        Ok(())
+    }
+}
+
+// Font attribute helpers that handle missing attributes gracefully
+mod lenient_font_attributes {
+    use core_foundation::{
+        base::{CFRetain, CFType, TCFType},
+        string::{CFString, CFStringRef},
+    };
+    use core_text::font_descriptor::{
+        CTFontDescriptor, CTFontDescriptorCopyAttribute, kCTFontFamilyNameAttribute,
+    };
+
+    pub fn family_name(descriptor: &CTFontDescriptor) -> Option<String> {
+        unsafe { get_string_attribute(descriptor, kCTFontFamilyNameAttribute) }
+    }
+
+    fn get_string_attribute(
+        descriptor: &CTFontDescriptor,
+        attribute: CFStringRef,
+    ) -> Option<String> {
+        unsafe {
+            let value = CTFontDescriptorCopyAttribute(descriptor.as_concrete_TypeRef(), attribute);
+            if value.is_null() {
+                return None;
+            }
+
+            let value = CFType::wrap_under_create_rule(value);
+            assert!(value.instance_of::<CFString>());
+            let s = wrap_under_get_rule(value.as_CFTypeRef() as CFStringRef);
+            Some(s.to_string())
+        }
+    }
+
+    unsafe fn wrap_under_get_rule(reference: CFStringRef) -> CFString {
+        unsafe {
+            assert!(!reference.is_null(), "Attempted to create a NULL object.");
+            let reference = CFRetain(reference as *const ::std::os::raw::c_void) as CFStringRef;
+            TCFType::wrap_under_create_rule(reference)
+        }
+    }
+}

--- a/crates/gpui/src/platform/ios/window.rs
+++ b/crates/gpui/src/platform/ios/window.rs
@@ -1,0 +1,747 @@
+//! iOS Window implementation using UIWindow and UIViewController.
+//!
+//! iOS windows are fundamentally different from desktop windows:
+//! - Always fullscreen (or split-screen on iPad)
+//! - No title bar or window chrome
+//! - Touch-based input
+//! - Safe area insets for notch/home indicator
+//!
+//! The window is backed by a UIWindow containing a UIViewController
+//! whose view hosts the Metal rendering layer.
+
+use super::{IosDisplay, events::*};
+use crate::platform::blade;
+use crate::{
+    AnyWindowHandle, Bounds, DispatchEventResult, GpuSpecs, Modifiers, Pixels, PlatformAtlas,
+    PlatformDisplay, PlatformInput, PlatformInputHandler, PlatformWindow, Point, PromptButton,
+    PromptLevel, RequestFrameOptions, Scene, Size, WindowAppearance, WindowBackgroundAppearance,
+    WindowBounds, WindowControlArea, WindowParams,
+};
+use anyhow::{Result, anyhow};
+use core_graphics::{
+    base::CGFloat,
+    geometry::{CGPoint, CGRect, CGSize},
+};
+use objc::{
+    class,
+    declare::ClassDecl,
+    msg_send,
+    runtime::{BOOL, Class, NO, Object, Sel, YES},
+    sel, sel_impl,
+};
+use raw_window_handle::{HasDisplayHandle, HasWindowHandle, UiKitDisplayHandle, UiKitWindowHandle};
+use std::{
+    cell::{Cell, RefCell},
+    ffi::c_void,
+    ptr::{self, NonNull},
+    rc::Rc,
+    sync::Arc,
+};
+
+const GPUI_VIEW_IVAR: &str = "gpui_view";
+const GPUI_WINDOW_IVAR: &str = "gpui_window_ptr";
+
+static METAL_VIEW_CLASS_REGISTERED: std::sync::Once = std::sync::Once::new();
+
+/// Register a custom UIView subclass that uses CAMetalLayer as its backing layer.
+/// This is required for Metal rendering on iOS.
+fn register_metal_view_class() -> &'static Class {
+    METAL_VIEW_CLASS_REGISTERED.call_once(|| {
+        let superclass = class!(UIView);
+        let mut decl = ClassDecl::new("GPUIMetalView", superclass).unwrap();
+
+        // Add ivar to store window pointer for touch handling
+        decl.add_ivar::<*mut std::ffi::c_void>(GPUI_WINDOW_IVAR);
+
+        // Override layerClass to return CAMetalLayer
+        extern "C" fn layer_class(_self: &Class, _sel: Sel) -> *const Class {
+            class!(CAMetalLayer) as *const Class
+        }
+
+        // Touch handling methods
+        extern "C" fn touches_began(
+            this: &mut Object,
+            _sel: Sel,
+            touches: *mut Object,
+            event: *mut Object,
+        ) {
+            handle_touches(this, touches, event);
+        }
+
+        extern "C" fn touches_moved(
+            this: &mut Object,
+            _sel: Sel,
+            touches: *mut Object,
+            event: *mut Object,
+        ) {
+            handle_touches(this, touches, event);
+        }
+
+        extern "C" fn touches_ended(
+            this: &mut Object,
+            _sel: Sel,
+            touches: *mut Object,
+            event: *mut Object,
+        ) {
+            handle_touches(this, touches, event);
+        }
+
+        extern "C" fn touches_cancelled(
+            this: &mut Object,
+            _sel: Sel,
+            touches: *mut Object,
+            event: *mut Object,
+        ) {
+            handle_touches(this, touches, event);
+        }
+
+        unsafe {
+            // Add class method for layerClass
+            decl.add_class_method(
+                sel!(layerClass),
+                layer_class as extern "C" fn(&Class, Sel) -> *const Class,
+            );
+
+            // Add touch handling instance methods
+            decl.add_method(
+                sel!(touchesBegan:withEvent:),
+                touches_began as extern "C" fn(&mut Object, Sel, *mut Object, *mut Object),
+            );
+            decl.add_method(
+                sel!(touchesMoved:withEvent:),
+                touches_moved as extern "C" fn(&mut Object, Sel, *mut Object, *mut Object),
+            );
+            decl.add_method(
+                sel!(touchesEnded:withEvent:),
+                touches_ended as extern "C" fn(&mut Object, Sel, *mut Object, *mut Object),
+            );
+            decl.add_method(
+                sel!(touchesCancelled:withEvent:),
+                touches_cancelled as extern "C" fn(&mut Object, Sel, *mut Object, *mut Object),
+            );
+        }
+
+        decl.register();
+    });
+
+    class!(GPUIMetalView)
+}
+
+/// Handle touch events from the GPUIMetalView
+fn handle_touches(view: &mut Object, touches: *mut Object, event: *mut Object) {
+    unsafe {
+        // Get the window pointer from the view's ivar
+        let window_ptr: *mut std::ffi::c_void = *view.get_ivar(GPUI_WINDOW_IVAR);
+        if window_ptr.is_null() {
+            log::warn!("GPUI iOS: Touch event but no window pointer set");
+            return;
+        }
+
+        let window = &*(window_ptr as *const IosWindow);
+
+        // Get all touches from the set
+        let all_touches: *mut Object = msg_send![touches, allObjects];
+        let count: usize = msg_send![all_touches, count];
+
+        for i in 0..count {
+            let touch: *mut Object = msg_send![all_touches, objectAtIndex: i];
+            window.handle_touch(touch, event);
+        }
+    }
+}
+
+/// iOS Window backed by UIWindow + UIViewController.
+pub(crate) struct IosWindow {
+    /// Handle used by GPUI to identify this window
+    handle: AnyWindowHandle,
+    /// The UIWindow object
+    window: *mut Object,
+    /// The UIViewController
+    view_controller: *mut Object,
+    /// The Metal-backed UIView
+    view: *mut Object,
+    /// The hidden text input view for keyboard input
+    text_input_view: *mut Object,
+    /// Current bounds in pixels
+    bounds: Cell<Bounds<Pixels>>,
+    /// Scale factor
+    scale_factor: Cell<f32>,
+    /// Appearance (light/dark mode)
+    appearance: Cell<WindowAppearance>,
+    /// Input handler for text input
+    input_handler: RefCell<Option<PlatformInputHandler>>,
+    /// Callback for frame requests
+    /// Note: pub(super) to allow ffi.rs to access this for the display link callback
+    pub(super) request_frame_callback: RefCell<Option<Box<dyn FnMut(RequestFrameOptions)>>>,
+    /// Callback for input events
+    input_callback: RefCell<Option<Box<dyn FnMut(PlatformInput) -> DispatchEventResult>>>,
+    /// Callback for active status changes
+    active_status_callback: RefCell<Option<Box<dyn FnMut(bool)>>>,
+    /// Callback for hover status changes (not really applicable on iOS)
+    hover_status_callback: RefCell<Option<Box<dyn FnMut(bool)>>>,
+    /// Callback for resize events
+    resize_callback: RefCell<Option<Box<dyn FnMut(Size<Pixels>, f32)>>>,
+    /// Callback for move events (not applicable on iOS)
+    moved_callback: RefCell<Option<Box<dyn FnMut()>>>,
+    /// Callback for should close
+    should_close_callback: RefCell<Option<Box<dyn FnMut() -> bool>>>,
+    /// Callback for hit test
+    hit_test_callback: RefCell<Option<Box<dyn FnMut() -> Option<WindowControlArea>>>>,
+    /// Callback for close
+    close_callback: RefCell<Option<Box<dyn FnOnce()>>>,
+    /// Callback for appearance changes
+    appearance_changed_callback: RefCell<Option<Box<dyn FnMut()>>>,
+    /// Current mouse position (from touch)
+    mouse_position: Cell<Point<Pixels>>,
+    /// Current modifiers
+    modifiers: Cell<Modifiers>,
+    /// Blade renderer for GPU rendering
+    renderer: RefCell<blade::Renderer>,
+    /// Track if a touch is currently pressed
+    touch_pressed: Cell<bool>,
+}
+
+// Required for raw_window_handle
+unsafe impl Send for IosWindow {}
+unsafe impl Sync for IosWindow {}
+
+impl IosWindow {
+    pub fn new(
+        handle: AnyWindowHandle,
+        _params: WindowParams,
+        renderer_context: blade::Context,
+    ) -> Result<Self> {
+        // Create the window on the main screen
+        let screen = IosDisplay::main();
+        let screen_bounds = screen.bounds();
+        let scale_factor = screen.scale();
+
+        unsafe {
+            // Create UIWindow
+            let screen_obj: *mut Object = msg_send![class!(UIScreen), mainScreen];
+            let screen_bounds_cg: CGRect = msg_send![screen_obj, bounds];
+            let window: *mut Object = msg_send![class!(UIWindow), alloc];
+            let window: *mut Object = msg_send![window, initWithFrame: screen_bounds_cg];
+
+            // Create UIViewController
+            let view_controller: *mut Object = msg_send![class!(UIViewController), alloc];
+            let view_controller: *mut Object = msg_send![view_controller, init];
+
+            // Create our custom Metal view using the registered class
+            let metal_view_class = register_metal_view_class();
+            let view: *mut Object = msg_send![metal_view_class, alloc];
+            let view: *mut Object = msg_send![view, initWithFrame: screen_bounds_cg];
+
+            // Configure the Metal layer
+            let layer: *mut Object = msg_send![view, layer];
+
+            // Get the Metal device using the Metal framework function
+            #[link(name = "Metal", kind = "framework")]
+            unsafe extern "C" {
+                fn MTLCreateSystemDefaultDevice() -> *mut Object;
+            }
+            let device = MTLCreateSystemDefaultDevice();
+            if !device.is_null() {
+                let _: () = msg_send![layer, setDevice: device];
+            }
+            let _: () = msg_send![layer, setPixelFormat: 80_u64]; // MTLPixelFormatBGRA8Unorm
+            let _: () = msg_send![layer, setFramebufferOnly: NO];
+            let scale: CGFloat = msg_send![screen_obj, scale];
+            let _: () = msg_send![layer, setContentsScale: scale];
+            let drawable_size = CGSize {
+                width: screen_bounds_cg.size.width * scale,
+                height: screen_bounds_cg.size.height * scale,
+            };
+            let _: () = msg_send![layer, setDrawableSize: drawable_size];
+
+            // Enable user interaction on the Metal view for touch handling
+            let _: () = msg_send![view, setUserInteractionEnabled: YES];
+            let _: () = msg_send![view, setMultipleTouchEnabled: YES];
+
+            // Set the view as the view controller's view
+            let _: () = msg_send![view_controller, setView: view];
+
+            // Set the root view controller
+            let _: () = msg_send![window, setRootViewController: view_controller];
+
+            // Make the window visible
+            let _: () = msg_send![window, makeKeyAndVisible];
+
+            // Create a hidden text input view for keyboard handling
+            // This view conforms to UIKeyInput and handles keyboard events
+            let text_input_view: *mut Object = msg_send![class!(UIView), alloc];
+            let text_input_frame = CGRect {
+                origin: CGPoint { x: 0.0, y: 0.0 },
+                size: CGSize {
+                    width: 1.0,
+                    height: 1.0,
+                },
+            };
+            let text_input_view: *mut Object =
+                msg_send![text_input_view, initWithFrame: text_input_frame];
+            // Make it invisible but still able to become first responder
+            let _: () = msg_send![text_input_view, setAlpha: 0.01_f64];
+            let _: () = msg_send![text_input_view, setUserInteractionEnabled: YES];
+            let _: () = msg_send![view, addSubview: text_input_view];
+
+            // Create the blade renderer
+            // Note: Blade expects size in pixels (device pixels), not points
+            let renderer = blade::new_renderer(
+                renderer_context,
+                window as *mut c_void,
+                view as *mut c_void,
+                crate::Size {
+                    width: drawable_size.width as f32,
+                    height: drawable_size.height as f32,
+                },
+                false, // not transparent
+            );
+
+            let ios_window = Self {
+                handle,
+                window,
+                view_controller,
+                view,
+                text_input_view,
+                bounds: Cell::new(screen_bounds),
+                scale_factor: Cell::new(scale_factor),
+                appearance: Cell::new(WindowAppearance::Light),
+                input_handler: RefCell::new(None),
+                request_frame_callback: RefCell::new(None),
+                input_callback: RefCell::new(None),
+                active_status_callback: RefCell::new(None),
+                hover_status_callback: RefCell::new(None),
+                resize_callback: RefCell::new(None),
+                moved_callback: RefCell::new(None),
+                should_close_callback: RefCell::new(None),
+                hit_test_callback: RefCell::new(None),
+                close_callback: RefCell::new(None),
+                appearance_changed_callback: RefCell::new(None),
+                mouse_position: Cell::new(Point::default()),
+                modifiers: Cell::new(Modifiers::default()),
+                renderer: RefCell::new(renderer),
+                touch_pressed: Cell::new(false),
+            };
+
+            Ok(ios_window)
+        }
+    }
+
+    /// Register this window with the FFI layer after it's been stored.
+    /// This must be called after the window is placed at a stable address
+    /// (e.g., in a Box or Arc).
+    pub(crate) fn register_with_ffi(&self) {
+        super::ffi::register_window(self as *const Self);
+
+        // Set the window pointer on the view so touch events can find us
+        unsafe {
+            let window_ptr = self as *const Self as *mut std::ffi::c_void;
+            (*self.view).set_ivar(GPUI_WINDOW_IVAR, window_ptr);
+            log::info!(
+                "GPUI iOS: Set window pointer {:p} on view {:p}",
+                window_ptr,
+                self.view
+            );
+        }
+    }
+
+    /// Handle a touch event from UIKit
+    pub fn handle_touch(&self, touch: *mut Object, _event: *mut Object) {
+        let position = touch_location_in_view(touch, self.view);
+        let phase = touch_phase(touch);
+        let tap_count = touch_tap_count(touch);
+        let modifiers = self.modifiers.get();
+
+        self.mouse_position.set(position);
+
+        let platform_input = match phase {
+            UITouchPhase::Began => {
+                self.touch_pressed.set(true);
+                touch_began_to_mouse_down(position, tap_count, modifiers)
+            }
+            UITouchPhase::Moved => {
+                touch_moved_to_mouse_move(position, modifiers, Some(crate::MouseButton::Left))
+            }
+            UITouchPhase::Ended | UITouchPhase::Cancelled => {
+                self.touch_pressed.set(false);
+                touch_ended_to_mouse_up(position, tap_count, modifiers)
+            }
+            UITouchPhase::Stationary => return,
+        };
+
+        if let Some(callback) = self.input_callback.borrow_mut().as_mut() {
+            callback(platform_input);
+        }
+    }
+
+    /// Get the safe area insets
+    pub fn safe_area_insets(&self) -> (f32, f32, f32, f32) {
+        unsafe {
+            // UIEdgeInsets struct
+            #[repr(C)]
+            struct UIEdgeInsets {
+                top: f64,
+                left: f64,
+                bottom: f64,
+                right: f64,
+            }
+
+            let insets: UIEdgeInsets = msg_send![self.view, safeAreaInsets];
+            (
+                insets.top as f32,
+                insets.left as f32,
+                insets.bottom as f32,
+                insets.right as f32,
+            )
+        }
+    }
+
+    /// Show the software keyboard
+    pub fn show_keyboard(&self) {
+        log::info!("GPUI iOS: Showing keyboard");
+        unsafe {
+            // Make the text input view become first responder to show keyboard
+            let _: BOOL = msg_send![self.text_input_view, becomeFirstResponder];
+        }
+    }
+
+    /// Hide the software keyboard
+    pub fn hide_keyboard(&self) {
+        log::info!("GPUI iOS: Hiding keyboard");
+        unsafe {
+            // Resign first responder to hide keyboard
+            let _: BOOL = msg_send![self.text_input_view, resignFirstResponder];
+        }
+    }
+
+    /// Handle text input from the software keyboard
+    pub fn handle_text_input(&self, text: *mut Object) {
+        if text.is_null() {
+            return;
+        }
+
+        unsafe {
+            // Convert NSString to Rust String
+            let utf8: *const i8 = msg_send![text, UTF8String];
+            if utf8.is_null() {
+                return;
+            }
+
+            let text_str = std::ffi::CStr::from_ptr(utf8)
+                .to_string_lossy()
+                .into_owned();
+
+            log::info!("GPUI iOS: Text input: {:?}", text_str);
+
+            // First try the input handler (for text fields)
+            if let Some(handler) = self.input_handler.borrow_mut().as_mut() {
+                handler.replace_text_in_range(None, &text_str);
+                return;
+            }
+
+            // Otherwise, send as key events
+            for c in text_str.chars() {
+                let keystroke = crate::Keystroke {
+                    modifiers: Modifiers::default(),
+                    key: c.to_string(),
+                    key_char: Some(c.to_string()),
+                };
+
+                let event = PlatformInput::KeyDown(crate::KeyDownEvent {
+                    keystroke,
+                    is_held: false,
+                    prefer_character_input: true,
+                });
+
+                if let Some(callback) = self.input_callback.borrow_mut().as_mut() {
+                    callback(event);
+                }
+            }
+        }
+    }
+
+    /// Handle a key event from an external keyboard
+    pub fn handle_key_event(&self, key_code: u32, modifier_flags: u32, is_key_down: bool) {
+        use super::text_input::{
+            key_code_to_key_down, key_code_to_key_up, key_code_to_string,
+            modifier_flags_to_modifiers,
+        };
+
+        let key = key_code_to_string(key_code);
+        let modifiers = modifier_flags_to_modifiers(modifier_flags);
+
+        log::info!(
+            "GPUI iOS: Key event - key: {:?}, modifiers: {:?}, down: {}",
+            key,
+            modifiers,
+            is_key_down
+        );
+
+        let event = if is_key_down {
+            key_code_to_key_down(key_code, modifier_flags)
+        } else {
+            key_code_to_key_up(key_code, modifier_flags)
+        };
+
+        if let Some(callback) = self.input_callback.borrow_mut().as_mut() {
+            callback(event);
+        }
+    }
+
+    /// Notify the window of active status changes (foreground/background).
+    ///
+    /// This is called by the FFI layer when the app transitions between
+    /// foreground and background states.
+    pub fn notify_active_status_change(&self, is_active: bool) {
+        log::info!("GPUI iOS: Window active status changed to: {}", is_active);
+
+        if let Some(callback) = self.active_status_callback.borrow_mut().as_mut() {
+            callback(is_active);
+        }
+    }
+}
+
+impl HasWindowHandle for IosWindow {
+    fn window_handle(
+        &self,
+    ) -> std::result::Result<raw_window_handle::WindowHandle<'_>, raw_window_handle::HandleError>
+    {
+        let view = NonNull::new(self.view as *mut c_void)
+            .ok_or(raw_window_handle::HandleError::Unavailable)?;
+        let handle = UiKitWindowHandle::new(view);
+        Ok(unsafe { raw_window_handle::WindowHandle::borrow_raw(handle.into()) })
+    }
+}
+
+impl HasDisplayHandle for IosWindow {
+    fn display_handle(
+        &self,
+    ) -> std::result::Result<raw_window_handle::DisplayHandle<'_>, raw_window_handle::HandleError>
+    {
+        let handle = UiKitDisplayHandle::new();
+        Ok(unsafe { raw_window_handle::DisplayHandle::borrow_raw(handle.into()) })
+    }
+}
+
+impl PlatformWindow for IosWindow {
+    fn bounds(&self) -> Bounds<Pixels> {
+        self.bounds.get()
+    }
+
+    fn is_maximized(&self) -> bool {
+        true // iOS windows are always "maximized"
+    }
+
+    fn window_bounds(&self) -> WindowBounds {
+        WindowBounds::Fullscreen(self.bounds.get())
+    }
+
+    fn content_size(&self) -> Size<Pixels> {
+        self.bounds.get().size
+    }
+
+    fn resize(&mut self, _size: Size<Pixels>) {
+        // iOS windows cannot be resized programmatically
+    }
+
+    fn scale_factor(&self) -> f32 {
+        self.scale_factor.get()
+    }
+
+    fn appearance(&self) -> WindowAppearance {
+        unsafe {
+            let trait_collection: *mut Object = msg_send![self.view, traitCollection];
+            let style: i64 = msg_send![trait_collection, userInterfaceStyle];
+            match style {
+                2 => WindowAppearance::Dark,
+                _ => WindowAppearance::Light,
+            }
+        }
+    }
+
+    fn display(&self) -> Option<Rc<dyn PlatformDisplay>> {
+        Some(Rc::new(IosDisplay::main()))
+    }
+
+    fn mouse_position(&self) -> Point<Pixels> {
+        self.mouse_position.get()
+    }
+
+    fn modifiers(&self) -> Modifiers {
+        self.modifiers.get()
+    }
+
+    fn capslock(&self) -> crate::Capslock {
+        // Would need to check UIKeyModifierFlags
+        crate::Capslock { on: false }
+    }
+
+    fn set_input_handler(&mut self, input_handler: PlatformInputHandler) {
+        *self.input_handler.borrow_mut() = Some(input_handler);
+    }
+
+    fn take_input_handler(&mut self) -> Option<PlatformInputHandler> {
+        self.input_handler.borrow_mut().take()
+    }
+
+    fn prompt(
+        &self,
+        _level: PromptLevel,
+        msg: &str,
+        detail: Option<&str>,
+        answers: &[PromptButton],
+    ) -> Option<futures::channel::oneshot::Receiver<usize>> {
+        // Would use UIAlertController
+        let (_tx, rx) = futures::channel::oneshot::channel();
+
+        unsafe {
+            // Create UIAlertController
+            let title = msg;
+            let message = detail.unwrap_or("");
+
+            let alert_style: i64 = 1; // UIAlertControllerStyleAlert
+
+            let title_str: *mut Object =
+                msg_send![class!(NSString), stringWithUTF8String: title.as_ptr()];
+            let message_str: *mut Object =
+                msg_send![class!(NSString), stringWithUTF8String: message.as_ptr()];
+
+            let alert: *mut Object = msg_send![
+                class!(UIAlertController),
+                alertControllerWithTitle: title_str
+                message: message_str
+                preferredStyle: alert_style
+            ];
+
+            // Add buttons
+            for (_index, button) in answers.iter().enumerate() {
+                let button_title: *mut Object = msg_send![
+                    class!(NSString),
+                    stringWithUTF8String: button.label().as_str().as_ptr()
+                ];
+
+                let action_style: i64 = if button.is_cancel() { 1 } else { 0 }; // UIAlertActionStyleCancel or Default
+
+                // Note: In production, this would need a block that calls tx.send(index)
+                let action: *mut Object = msg_send![
+                    class!(UIAlertAction),
+                    actionWithTitle: button_title
+                    style: action_style
+                    handler: ptr::null::<Object>()
+                ];
+
+                let _: () = msg_send![alert, addAction: action];
+            }
+
+            // Present the alert
+            let _: () = msg_send![
+                self.view_controller,
+                presentViewController: alert
+                animated: YES
+                completion: ptr::null::<Object>()
+            ];
+        }
+
+        Some(rx)
+    }
+
+    fn activate(&self) {
+        unsafe {
+            let _: () = msg_send![self.window, makeKeyAndVisible];
+        }
+    }
+
+    fn is_active(&self) -> bool {
+        unsafe {
+            let app: *mut Object = msg_send![class!(UIApplication), sharedApplication];
+            let key_window: *mut Object = msg_send![app, keyWindow];
+            self.window == key_window
+        }
+    }
+
+    fn is_hovered(&self) -> bool {
+        // Hover isn't really applicable on iOS
+        false
+    }
+
+    fn set_title(&mut self, _title: &str) {
+        // iOS apps don't have window titles
+    }
+
+    fn set_background_appearance(&self, _background_appearance: WindowBackgroundAppearance) {
+        // Could adjust view background color
+    }
+
+    fn minimize(&self) {
+        // iOS apps cannot be minimized
+    }
+
+    fn zoom(&self) {
+        // iOS apps cannot be zoomed
+    }
+
+    fn toggle_fullscreen(&self) {
+        // iOS apps are always fullscreen
+    }
+
+    fn is_fullscreen(&self) -> bool {
+        true
+    }
+
+    fn on_request_frame(&self, callback: Box<dyn FnMut(RequestFrameOptions)>) {
+        *self.request_frame_callback.borrow_mut() = Some(callback);
+    }
+
+    fn on_input(&self, callback: Box<dyn FnMut(PlatformInput) -> DispatchEventResult>) {
+        *self.input_callback.borrow_mut() = Some(callback);
+    }
+
+    fn on_active_status_change(&self, callback: Box<dyn FnMut(bool)>) {
+        *self.active_status_callback.borrow_mut() = Some(callback);
+    }
+
+    fn on_hover_status_change(&self, callback: Box<dyn FnMut(bool)>) {
+        *self.hover_status_callback.borrow_mut() = Some(callback);
+    }
+
+    fn on_resize(&self, callback: Box<dyn FnMut(Size<Pixels>, f32)>) {
+        *self.resize_callback.borrow_mut() = Some(callback);
+    }
+
+    fn on_moved(&self, callback: Box<dyn FnMut()>) {
+        *self.moved_callback.borrow_mut() = Some(callback);
+    }
+
+    fn on_should_close(&self, callback: Box<dyn FnMut() -> bool>) {
+        *self.should_close_callback.borrow_mut() = Some(callback);
+    }
+
+    fn on_hit_test_window_control(&self, callback: Box<dyn FnMut() -> Option<WindowControlArea>>) {
+        *self.hit_test_callback.borrow_mut() = Some(callback);
+    }
+
+    fn on_close(&self, callback: Box<dyn FnOnce()>) {
+        *self.close_callback.borrow_mut() = Some(callback);
+    }
+
+    fn on_appearance_changed(&self, callback: Box<dyn FnMut()>) {
+        *self.appearance_changed_callback.borrow_mut() = Some(callback);
+    }
+
+    fn draw(&self, scene: &Scene) {
+        self.renderer.borrow_mut().draw(scene);
+    }
+
+    fn sprite_atlas(&self) -> Arc<dyn PlatformAtlas> {
+        self.renderer.borrow().sprite_atlas().clone()
+    }
+
+    fn gpu_specs(&self) -> Option<GpuSpecs> {
+        // Would query Metal device capabilities
+        None
+    }
+
+    fn update_ime_position(&self, _bounds: Bounds<Pixels>) {
+        // iOS handles IME positioning automatically
+    }
+}


### PR DESCRIPTION
Step towards #43206

## Summary

This PR adds initial iOS platform support to GPUI, enabling GPUI applications to run on iOS devices and simulators. This is a foundational step toward #12039 (iOS/Android Port).

### What's included

**Core Platform Implementation (~4100 lines of Rust):**
- `platform/ios/platform.rs` - `IosPlatform` implementing the `Platform` trait
- `platform/ios/window.rs` - `IosWindow` using UIWindow/UIViewController with Metal rendering via Blade
- `platform/ios/display.rs` - `IosDisplay` wrapping UIScreen
- `platform/ios/dispatcher.rs` - GCD-based async dispatcher
- `platform/ios/events.rs` - Touch-to-mouse event translation
- `platform/ios/text_system.rs` - CoreText integration (shared with macOS)
- `platform/ios/text_input.rs` - Software keyboard handling (stubs)
- `platform/ios/ffi.rs` - C FFI for Objective-C interop

**Interactive Demo App:**
- `demos/menu.rs` - Demo selection menu
- `demos/animation_playground.rs` - Physics simulation with bouncing balls and particle effects
- `demos/shader_showcase.rs` - Dynamic gradients and ripple effects
- Example Objective-C app structure in `examples/ios_app/`

### Architecture

```
iOS App (Objective-C)          FFI Bridge              GPUI Platform Layer
┌─────────────────┐      ┌─────────────────┐      ┌─────────────────────┐
│ AppDelegate     │──────│ ffi.rs          │──────│ IosPlatform         │
│ GPUIMetalView   │      │ gpui_ios_*()    │      │ IosWindow           │
│ CADisplayLink   │      │                 │      │ IosDispatcher       │
└────────┬────────┘      └─────────────────┘      └──────────┬──────────┘
         │                                                    │
         │ Touch Events                              Metal/Blade Renderer
         ▼                                                    ▼
┌─────────────────┐                               ┌─────────────────────┐
│ events.rs       │                               │ BladeRenderer       │
│ UITouch → Mouse │                               │ CAMetalLayer        │
└─────────────────┘                               └─────────────────────┘
```

### Key Features
- Full Metal/Blade renderer integration
- Touch event handling (tap, drag, multi-touch → mouse events)
- 60fps animation via CADisplayLink
- Safe area inset handling for notch/home indicator
- App lifecycle management (foreground/background transitions)

### Not Yet Implemented (stubs only)
- Software keyboard text input
- File picker/save dialogs
- Keychain access
- External keyboard support
- Screen capture (ReplayKit)

### Testing
- Tested on iOS 26.1 Simulator (iPhone 17 Pro Max)
- Both demos respond to touch and render at 60fps
- macOS build verified to still work

### Building

```bash
# Build for iOS Simulator
cargo build -p gpui --target aarch64-apple-ios-sim --release

# The Xcode project is gitignored but can be recreated
# See examples/ios_app/ for the app structure
```

Release Notes:

- Added initial iOS platform support to GPUI (experimental)