### PR TITLE
release_version: Do not use prerelease field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1380,6 +1380,7 @@ dependencies = [
  "http_client",
  "markdown_preview",
  "release_channel",
+ "semver",
  "serde",
  "serde_json",
  "smol",

--- a/crates/auto_update_ui/Cargo.toml
+++ b/crates/auto_update_ui/Cargo.toml
@@ -20,6 +20,7 @@ gpui.workspace = true
 http_client.workspace = true
 markdown_preview.workspace = true
 release_channel.workspace = true
+semver.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 smol.workspace = true

--- a/crates/auto_update_ui/src/auto_update_ui.rs
+++ b/crates/auto_update_ui/src/auto_update_ui.rs
@@ -148,7 +148,9 @@ pub fn notify_if_app_was_updated(cx: &mut App) {
         let should_show_notification = should_show_notification.await?;
         if should_show_notification {
             cx.update(|cx| {
-                let version = updater.read(cx).current_version();
+                let mut version = updater.read(cx).current_version();
+                version.build = semver::BuildMetadata::EMPTY;
+                version.pre = semver::Prerelease::EMPTY;
                 let app_name = ReleaseChannel::global(cx).display_name();
                 show_app_notification(
                     NotificationId::unique::<UpdateNotification>(),

--- a/crates/release_channel/src/lib.rs
+++ b/crates/release_channel/src/lib.rs
@@ -90,11 +90,19 @@ impl AppVersion {
         } else {
             pkg_version.parse().expect("invalid version in Cargo.toml")
         };
+        let mut pre = String::from(RELEASE_CHANNEL.dev_name());
+
         if let Some(build_id) = build_id {
-            version.pre = semver::Prerelease::new(&build_id).expect("Invalid build identifier");
+            pre.push('.');
+            pre.push_str(&build_id);
         }
+
         if let Some(sha) = commit_sha {
-            version.build = semver::BuildMetadata::new(&sha.0).expect("Invalid build metadata");
+            pre.push('.');
+            pre.push_str(&sha.0);
+        }
+        if let Ok(build) = semver::BuildMetadata::new(&pre) {
+            version.build = build;
         }
 
         version


### PR DESCRIPTION
- **release_channel: Do not use prerelease channel for build id**
Prerelease channel specifiers always compare as less than to non-prerelease, which led to 2 auto-update bugs fixed in https://github.com/zed-industries/zed/pull/43595 and https://github.com/zed-industries/zed/pull/43611.
We'll use a dot-delimited build specifiers in form: release-channel.build_number.sha1 instead
- **auto_update: Do not display full build metadata in update notification**

Release Notes:

- N/A
