### PR TITLE
language: Allow support for ESLint working directories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9012,6 +9012,7 @@ dependencies = [
  "chrono",
  "collections",
  "futures 0.3.31",
+ "globset",
  "gpui",
  "http_client",
  "itertools 0.14.0",

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -36,7 +36,9 @@ use http_client::HttpClient;
 pub use language_registry::{
     LanguageName, LanguageServerStatusUpdate, LoadedLanguage, ServerHealth,
 };
-use lsp::{CodeActionKind, InitializeParams, LanguageServerBinary, LanguageServerBinaryOptions};
+use lsp::{
+    CodeActionKind, InitializeParams, LanguageServerBinary, LanguageServerBinaryOptions, Uri,
+};
 pub use manifest::{ManifestDelegate, ManifestName, ManifestProvider, ManifestQuery};
 use parking_lot::Mutex;
 use regex::Regex;
@@ -406,6 +408,7 @@ pub trait LspAdapter: 'static + Send + Sync + DynLspInstaller {
         self: Arc<Self>,
         _: &Arc<dyn LspAdapterDelegate>,
         _: Option<Toolchain>,
+        _: Option<Uri>,
         _cx: &mut AsyncApp,
     ) -> Result<Value> {
         Ok(serde_json::json!({}))

--- a/crates/language_extension/src/extension_lsp_adapter.rs
+++ b/crates/language_extension/src/extension_lsp_adapter.rs
@@ -14,7 +14,7 @@ use language::{
 };
 use lsp::{
     CodeActionKind, LanguageServerBinary, LanguageServerBinaryOptions, LanguageServerName,
-    LanguageServerSelector,
+    LanguageServerSelector, Uri,
 };
 use serde::Serialize;
 use serde_json::Value;
@@ -282,6 +282,7 @@ impl LspAdapter for ExtensionLspAdapter {
         self: Arc<Self>,
         delegate: &Arc<dyn LspAdapterDelegate>,
         _: Option<Toolchain>,
+        _: Option<Uri>,
         _cx: &mut AsyncApp,
     ) -> Result<Value> {
         let delegate = Arc::new(WorktreeDelegateAdapter(delegate.clone())) as _;

--- a/crates/languages/Cargo.toml
+++ b/crates/languages/Cargo.toml
@@ -42,6 +42,7 @@ async-trait.workspace = true
 chrono.workspace = true
 collections.workspace = true
 futures.workspace = true
+globset.workspace = true
 gpui.workspace = true
 http_client.workspace = true
 json_schema_store.workspace = true

--- a/crates/languages/src/css.rs
+++ b/crates/languages/src/css.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use gpui::AsyncApp;
 use language::{LspAdapter, LspAdapterDelegate, LspInstaller, Toolchain};
-use lsp::{LanguageServerBinary, LanguageServerName};
+use lsp::{LanguageServerBinary, LanguageServerName, Uri};
 use node_runtime::{NodeRuntime, VersionStrategy};
 use project::lsp_store::language_server_settings;
 use serde_json::json;
@@ -142,6 +142,7 @@ impl LspAdapter for CssLspAdapter {
         self: Arc<Self>,
         delegate: &Arc<dyn LspAdapterDelegate>,
         _: Option<Toolchain>,
+        _: Option<Uri>,
         cx: &mut AsyncApp,
     ) -> Result<serde_json::Value> {
         let mut default_config = json!({

--- a/crates/languages/src/eslint.rs
+++ b/crates/languages/src/eslint.rs
@@ -470,107 +470,233 @@ mod tests {
 
     #[test]
     fn test_match_glob_pattern() {
-        let pattern = "/test/*/";
-        let file_path = Path::new("/test/foo/bar/file.txt");
-        let matched = match_glob_pattern(pattern, file_path);
-        assert_eq!(matched, Some("/test/foo/".to_string()));
+        #[cfg(not(windows))]
+        {
+            let pattern = "/test/*/";
+            let file_path = Path::new("/test/foo/bar/file.txt");
+            let matched = match_glob_pattern(pattern, file_path);
+            assert_eq!(matched, Some("/test/foo/".to_string()));
+        }
+        #[cfg(windows)]
+        {
+            let pattern = "C:\\test\\*\\";
+            let file_path = Path::new("C:\\test\\foo\\bar\\file.txt");
+            let matched = match_glob_pattern(pattern, file_path);
+            assert_eq!(matched, Some("C:\\test\\foo\\".to_string()));
+        }
     }
 
     #[test]
     fn test_match_glob_pattern_globstar() {
-        let pattern = "/workspace/**/src/";
-        let file_path = Path::new("/workspace/packages/core/src/index.ts");
-        let matched = match_glob_pattern(pattern, file_path);
-        assert_eq!(matched, Some("/workspace/packages/core/src/".to_string()));
+        #[cfg(not(windows))]
+        {
+            let pattern = "/workspace/**/src/";
+            let file_path = Path::new("/workspace/packages/core/src/index.ts");
+            let matched = match_glob_pattern(pattern, file_path);
+            assert_eq!(matched, Some("/workspace/packages/core/src/".to_string()));
+        }
+        #[cfg(windows)]
+        {
+            let pattern = "C:\\workspace\\**\\src\\";
+            let file_path = Path::new("C:\\workspace\\packages\\core\\src\\index.ts");
+            let matched = match_glob_pattern(pattern, file_path);
+            assert_eq!(
+                matched,
+                Some("C:\\workspace\\packages\\core\\src\\".to_string())
+            );
+        }
     }
 
     #[test]
     fn test_match_glob_pattern_no_match() {
-        let pattern = "/other/*/";
-        let file_path = Path::new("/test/foo/bar/file.txt");
-        let matched = match_glob_pattern(pattern, file_path);
-        assert_eq!(matched, None);
+        #[cfg(not(windows))]
+        {
+            let pattern = "/other/*/";
+            let file_path = Path::new("/test/foo/bar/file.txt");
+            let matched = match_glob_pattern(pattern, file_path);
+            assert_eq!(matched, None);
+        }
+        #[cfg(windows)]
+        {
+            let pattern = "C:\\other\\*\\";
+            let file_path = Path::new("C:\\test\\foo\\bar\\file.txt");
+            let matched = match_glob_pattern(pattern, file_path);
+            assert_eq!(matched, None);
+        }
     }
 
     #[test]
     fn test_working_directory_string() {
-        let uri = make_uri("/workspace/packages/foo/src/file.ts");
-        let working_directories = vec![WorkingDirectory::String("packages/foo".to_string())];
-        let workspace_folder = PathBuf::from("/workspace");
+        #[cfg(not(windows))]
+        {
+            let uri = make_uri("/workspace/packages/foo/src/file.ts");
+            let working_directories = vec![WorkingDirectory::String("packages/foo".to_string())];
+            let workspace_folder = PathBuf::from("/workspace");
 
-        let result = determine_working_directory(uri, working_directories, workspace_folder);
-        assert_directory_result(result, "/workspace/packages/foo/", false);
+            let result = determine_working_directory(uri, working_directories, workspace_folder);
+            assert_directory_result(result, "/workspace/packages/foo/", false);
+        }
+        #[cfg(windows)]
+        {
+            let uri = make_uri("C:\\workspace\\packages\\foo\\src\\file.ts");
+            let working_directories = vec![WorkingDirectory::String("packages\\foo".to_string())];
+            let workspace_folder = PathBuf::from("C:\\workspace");
+
+            let result = determine_working_directory(uri, working_directories, workspace_folder);
+            assert_directory_result(result, "C:\\workspace\\packages\\foo\\", false);
+        }
     }
 
     #[test]
     fn test_working_directory_absolute_path() {
-        let uri = make_uri("/workspace/packages/foo/src/file.ts");
-        let working_directories = vec![WorkingDirectory::String(
-            "/workspace/packages/foo".to_string(),
-        )];
-        let workspace_folder = PathBuf::from("/workspace");
+        #[cfg(not(windows))]
+        {
+            let uri = make_uri("/workspace/packages/foo/src/file.ts");
+            let working_directories = vec![WorkingDirectory::String(
+                "/workspace/packages/foo".to_string(),
+            )];
+            let workspace_folder = PathBuf::from("/workspace");
 
-        let result = determine_working_directory(uri, working_directories, workspace_folder);
-        assert_directory_result(result, "/workspace/packages/foo/", false);
+            let result = determine_working_directory(uri, working_directories, workspace_folder);
+            assert_directory_result(result, "/workspace/packages/foo/", false);
+        }
+        #[cfg(windows)]
+        {
+            let uri = make_uri("C:\\workspace\\packages\\foo\\src\\file.ts");
+            let working_directories = vec![WorkingDirectory::String(
+                "C:\\workspace\\packages\\foo".to_string(),
+            )];
+            let workspace_folder = PathBuf::from("C:\\workspace");
+
+            let result = determine_working_directory(uri, working_directories, workspace_folder);
+            assert_directory_result(result, "C:\\workspace\\packages\\foo\\", false);
+        }
     }
 
     #[test]
     fn test_working_directory_directory_item() {
-        let uri = make_uri("/workspace/packages/foo/src/file.ts");
-        let working_directories = vec![WorkingDirectory::DirectoryItem(DirectoryItem {
-            directory: "packages/foo".to_string(),
-            not_cwd: Some(true),
-        })];
-        let workspace_folder = PathBuf::from("/workspace");
+        #[cfg(not(windows))]
+        {
+            let uri = make_uri("/workspace/packages/foo/src/file.ts");
+            let working_directories = vec![WorkingDirectory::DirectoryItem(DirectoryItem {
+                directory: "packages/foo".to_string(),
+                not_cwd: Some(true),
+            })];
+            let workspace_folder = PathBuf::from("/workspace");
 
-        let result = determine_working_directory(uri, working_directories, workspace_folder);
-        assert_directory_result(result, "/workspace/packages/foo/", true);
+            let result = determine_working_directory(uri, working_directories, workspace_folder);
+            assert_directory_result(result, "/workspace/packages/foo/", true);
+        }
+        #[cfg(windows)]
+        {
+            let uri = make_uri("C:\\workspace\\packages\\foo\\src\\file.ts");
+            let working_directories = vec![WorkingDirectory::DirectoryItem(DirectoryItem {
+                directory: "packages\\foo".to_string(),
+                not_cwd: Some(true),
+            })];
+            let workspace_folder = PathBuf::from("C:\\workspace");
+
+            let result = determine_working_directory(uri, working_directories, workspace_folder);
+            assert_directory_result(result, "C:\\workspace\\packages\\foo\\", true);
+        }
     }
 
     #[test]
     fn test_working_directory_legacy_item() {
-        let uri = make_uri("/workspace/packages/foo/src/file.ts");
-        let working_directories =
-            vec![WorkingDirectory::LegacyDirectoryItem(LegacyDirectoryItem {
-                directory: "packages/foo".to_string(),
-                change_process_cwd: false,
-            })];
-        let workspace_folder = PathBuf::from("/workspace");
+        #[cfg(not(windows))]
+        {
+            let uri = make_uri("/workspace/packages/foo/src/file.ts");
+            let working_directories =
+                vec![WorkingDirectory::LegacyDirectoryItem(LegacyDirectoryItem {
+                    directory: "packages/foo".to_string(),
+                    change_process_cwd: false,
+                })];
+            let workspace_folder = PathBuf::from("/workspace");
 
-        let result = determine_working_directory(uri, working_directories, workspace_folder);
-        assert_directory_result(result, "/workspace/packages/foo/", true);
+            let result = determine_working_directory(uri, working_directories, workspace_folder);
+            assert_directory_result(result, "/workspace/packages/foo/", true);
+        }
+        #[cfg(windows)]
+        {
+            let uri = make_uri("C:\\workspace\\packages\\foo\\src\\file.ts");
+            let working_directories =
+                vec![WorkingDirectory::LegacyDirectoryItem(LegacyDirectoryItem {
+                    directory: "packages\\foo".to_string(),
+                    change_process_cwd: false,
+                })];
+            let workspace_folder = PathBuf::from("C:\\workspace");
+
+            let result = determine_working_directory(uri, working_directories, workspace_folder);
+            assert_directory_result(result, "C:\\workspace\\packages\\foo\\", true);
+        }
     }
 
     #[test]
     fn test_working_directory_pattern_item() {
-        let uri = make_uri("/workspace/packages/foo/src/file.ts");
-        let working_directories = vec![WorkingDirectory::PatternItem(PatternItem {
-            pattern: "packages/*/".to_string(),
-            not_cwd: Some(false),
-        })];
-        let workspace_folder = PathBuf::from("/workspace");
+        #[cfg(not(windows))]
+        {
+            let uri = make_uri("/workspace/packages/foo/src/file.ts");
+            let working_directories = vec![WorkingDirectory::PatternItem(PatternItem {
+                pattern: "packages/*/".to_string(),
+                not_cwd: Some(false),
+            })];
+            let workspace_folder = PathBuf::from("/workspace");
 
-        let result = determine_working_directory(uri, working_directories, workspace_folder);
-        assert_directory_result(result, "/workspace/packages/foo/", false);
+            let result = determine_working_directory(uri, working_directories, workspace_folder);
+            assert_directory_result(result, "/workspace/packages/foo/", false);
+        }
+        #[cfg(windows)]
+        {
+            let uri = make_uri("C:\\workspace\\packages\\foo\\src\\file.ts");
+            let working_directories = vec![WorkingDirectory::PatternItem(PatternItem {
+                pattern: "packages\\*\\".to_string(),
+                not_cwd: Some(false),
+            })];
+            let workspace_folder = PathBuf::from("C:\\workspace");
+
+            let result = determine_working_directory(uri, working_directories, workspace_folder);
+            assert_directory_result(result, "C:\\workspace\\packages\\foo\\", false);
+        }
     }
 
     #[test]
     fn test_working_directory_multiple_patterns() {
-        let uri = make_uri("/workspace/apps/web/src/file.ts");
-        let working_directories = vec![
-            WorkingDirectory::PatternItem(PatternItem {
-                pattern: "packages/*/".to_string(),
-                not_cwd: None,
-            }),
-            WorkingDirectory::PatternItem(PatternItem {
-                pattern: "apps/*/".to_string(),
-                not_cwd: None,
-            }),
-        ];
-        let workspace_folder = PathBuf::from("/workspace");
+        #[cfg(not(windows))]
+        {
+            let uri = make_uri("/workspace/apps/web/src/file.ts");
+            let working_directories = vec![
+                WorkingDirectory::PatternItem(PatternItem {
+                    pattern: "packages/*/".to_string(),
+                    not_cwd: None,
+                }),
+                WorkingDirectory::PatternItem(PatternItem {
+                    pattern: "apps/*/".to_string(),
+                    not_cwd: None,
+                }),
+            ];
+            let workspace_folder = PathBuf::from("/workspace");
 
-        let result = determine_working_directory(uri, working_directories, workspace_folder);
-        assert_directory_result(result, "/workspace/apps/web/", false);
+            let result = determine_working_directory(uri, working_directories, workspace_folder);
+            assert_directory_result(result, "/workspace/apps/web/", false);
+        }
+        #[cfg(windows)]
+        {
+            let uri = make_uri("C:\\workspace\\apps\\web\\src\\file.ts");
+            let working_directories = vec![
+                WorkingDirectory::PatternItem(PatternItem {
+                    pattern: "packages\\*\\".to_string(),
+                    not_cwd: None,
+                }),
+                WorkingDirectory::PatternItem(PatternItem {
+                    pattern: "apps\\*\\".to_string(),
+                    not_cwd: None,
+                }),
+            ];
+            let workspace_folder = PathBuf::from("C:\\workspace");
+
+            let result = determine_working_directory(uri, working_directories, workspace_folder);
+            assert_directory_result(result, "C:\\workspace\\apps\\web\\", false);
+        }
     }
 
     fn make_uri(path: &str) -> Uri {

--- a/crates/languages/src/eslint.rs
+++ b/crates/languages/src/eslint.rs
@@ -1,0 +1,248 @@
+use anyhow::{Context as _, Result};
+use async_trait::async_trait;
+use gpui::AsyncApp;
+use http_client::{
+    github::{AssetKind, GitHubLspBinaryVersion, build_asset_url},
+    github_download::download_server_binary,
+};
+use language::{LspAdapter, LspAdapterDelegate, LspInstaller, Toolchain};
+use lsp::{CodeActionKind, LanguageServerBinary, LanguageServerName};
+use node_runtime::NodeRuntime;
+use project::lsp_store::language_server_settings;
+use serde_json::{Value, json};
+use smol::{fs, stream::StreamExt};
+use std::{
+    ffi::OsString,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+use util::fs::remove_matching;
+use util::merge_json_value_into;
+
+fn eslint_server_binary_arguments(server_path: &Path) -> Vec<OsString> {
+    vec![
+        "--max-old-space-size=8192".into(),
+        server_path.into(),
+        "--stdio".into(),
+    ]
+}
+
+pub struct EsLintLspAdapter {
+    node: NodeRuntime,
+}
+
+impl EsLintLspAdapter {
+    const CURRENT_VERSION: &'static str = "2.4.4";
+    const CURRENT_VERSION_TAG_NAME: &'static str = "release/2.4.4";
+
+    #[cfg(not(windows))]
+    const GITHUB_ASSET_KIND: AssetKind = AssetKind::TarGz;
+    #[cfg(windows)]
+    const GITHUB_ASSET_KIND: AssetKind = AssetKind::Zip;
+
+    const SERVER_PATH: &'static str = "vscode-eslint/server/out/eslintServer.js";
+    const SERVER_NAME: LanguageServerName = LanguageServerName::new_static("eslint");
+
+    const FLAT_CONFIG_FILE_NAMES: &'static [&'static str] = &[
+        "eslint.config.js",
+        "eslint.config.mjs",
+        "eslint.config.cjs",
+        "eslint.config.ts",
+        "eslint.config.cts",
+        "eslint.config.mts",
+    ];
+
+    pub fn new(node: NodeRuntime) -> Self {
+        EsLintLspAdapter { node }
+    }
+
+    fn build_destination_path(container_dir: &Path) -> PathBuf {
+        container_dir.join(format!("vscode-eslint-{}", Self::CURRENT_VERSION))
+    }
+}
+
+impl LspInstaller for EsLintLspAdapter {
+    type BinaryVersion = GitHubLspBinaryVersion;
+
+    async fn fetch_latest_server_version(
+        &self,
+        _delegate: &dyn LspAdapterDelegate,
+        _: bool,
+        _: &mut AsyncApp,
+    ) -> Result<GitHubLspBinaryVersion> {
+        let url = build_asset_url(
+            "zed-industries/vscode-eslint",
+            Self::CURRENT_VERSION_TAG_NAME,
+            Self::GITHUB_ASSET_KIND,
+        )?;
+
+        Ok(GitHubLspBinaryVersion {
+            name: Self::CURRENT_VERSION.into(),
+            digest: None,
+            url,
+        })
+    }
+
+    async fn fetch_server_binary(
+        &self,
+        version: GitHubLspBinaryVersion,
+        container_dir: PathBuf,
+        delegate: &dyn LspAdapterDelegate,
+    ) -> Result<LanguageServerBinary> {
+        let destination_path = Self::build_destination_path(&container_dir);
+        let server_path = destination_path.join(Self::SERVER_PATH);
+
+        if fs::metadata(&server_path).await.is_err() {
+            remove_matching(&container_dir, |_| true).await;
+
+            download_server_binary(
+                &*delegate.http_client(),
+                &version.url,
+                None,
+                &destination_path,
+                Self::GITHUB_ASSET_KIND,
+            )
+            .await?;
+
+            let mut dir = fs::read_dir(&destination_path).await?;
+            let first = dir.next().await.context("missing first file")??;
+            let repo_root = destination_path.join("vscode-eslint");
+            fs::rename(first.path(), &repo_root).await?;
+
+            #[cfg(target_os = "windows")]
+            {
+                handle_symlink(
+                    repo_root.join("$shared"),
+                    repo_root.join("client").join("src").join("shared"),
+                )
+                .await?;
+                handle_symlink(
+                    repo_root.join("$shared"),
+                    repo_root.join("server").join("src").join("shared"),
+                )
+                .await?;
+            }
+
+            self.node
+                .run_npm_subcommand(&repo_root, "install", &[])
+                .await?;
+
+            self.node
+                .run_npm_subcommand(&repo_root, "run-script", &["compile"])
+                .await?;
+        }
+
+        Ok(LanguageServerBinary {
+            path: self.node.binary_path().await?,
+            env: None,
+            arguments: eslint_server_binary_arguments(&server_path),
+        })
+    }
+
+    async fn cached_server_binary(
+        &self,
+        container_dir: PathBuf,
+        _: &dyn LspAdapterDelegate,
+    ) -> Option<LanguageServerBinary> {
+        let server_path =
+            Self::build_destination_path(&container_dir).join(EsLintLspAdapter::SERVER_PATH);
+        Some(LanguageServerBinary {
+            path: self.node.binary_path().await.ok()?,
+            env: None,
+            arguments: eslint_server_binary_arguments(&server_path),
+        })
+    }
+}
+
+#[async_trait(?Send)]
+impl LspAdapter for EsLintLspAdapter {
+    fn code_action_kinds(&self) -> Option<Vec<CodeActionKind>> {
+        Some(vec![
+            CodeActionKind::QUICKFIX,
+            CodeActionKind::new("source.fixAll.eslint"),
+        ])
+    }
+
+    async fn workspace_configuration(
+        self: Arc<Self>,
+        delegate: &Arc<dyn LspAdapterDelegate>,
+        _: Option<Toolchain>,
+        cx: &mut AsyncApp,
+    ) -> Result<Value> {
+        let workspace_root = delegate.worktree_root_path();
+        let use_flat_config = Self::FLAT_CONFIG_FILE_NAMES
+            .iter()
+            .any(|file| workspace_root.join(file).is_file());
+
+        let mut default_workspace_configuration = json!({
+            "validate": "on",
+            "rulesCustomizations": [],
+            "run": "onType",
+            "nodePath": null,
+            "workingDirectory": {
+                "mode": "auto"
+            },
+            "workspaceFolder": {
+                "uri": workspace_root,
+                "name": workspace_root.file_name()
+                    .unwrap_or(workspace_root.as_os_str())
+                    .to_string_lossy(),
+            },
+            "problems": {},
+            "codeActionOnSave": {
+                // We enable this, but without also configuring code_actions_on_format
+                // in the Zed configuration, it doesn't have an effect.
+                "enable": true,
+            },
+            "codeAction": {
+                "disableRuleComment": {
+                    "enable": true,
+                    "location": "separateLine",
+                },
+                "showDocumentation": {
+                    "enable": true
+                }
+            },
+            "experimental": {
+                "useFlatConfig": use_flat_config,
+            }
+        });
+
+        let override_options = cx.update(|cx| {
+            language_server_settings(delegate.as_ref(), &Self::SERVER_NAME, cx)
+                .and_then(|s| s.settings.clone())
+        })?;
+
+        if let Some(override_options) = override_options {
+            merge_json_value_into(override_options, &mut default_workspace_configuration);
+        }
+
+        Ok(json!({
+            "": default_workspace_configuration
+        }))
+    }
+
+    fn name(&self) -> LanguageServerName {
+        Self::SERVER_NAME
+    }
+}
+
+#[cfg(target_os = "windows")]
+async fn handle_symlink(src_dir: PathBuf, dest_dir: PathBuf) -> Result<()> {
+    anyhow::ensure!(
+        fs::metadata(&src_dir).await.is_ok(),
+        "Directory {src_dir:?} is not present"
+    );
+    if fs::metadata(&dest_dir).await.is_ok() {
+        fs::remove_file(&dest_dir).await?;
+    }
+    fs::create_dir_all(&dest_dir).await?;
+    let mut entries = fs::read_dir(&src_dir).await?;
+    while let Some(entry) = entries.try_next().await? {
+        let entry_path = entry.path();
+        let entry_name = entry.file_name();
+        let dest_path = dest_dir.join(&entry_name);
+        fs::copy(&entry_path, &dest_path).await?;
+    }
+    Ok(())
+}

--- a/crates/languages/src/eslint.rs
+++ b/crates/languages/src/eslint.rs
@@ -271,8 +271,8 @@ impl LspAdapter for EsLintLspAdapter {
     }
 }
 
-/// Normalizes path separators to the platform's native format.
-/// Converts both Unix (/) and Windows (\) separators to the platform's MAIN_SEPARATOR.
+/// On Windows, converts Unix-style separators (/) to Windows-style (\).
+/// On Unix, returns the path unchanged
 fn normalize_path_separators(path: &str) -> String {
     #[cfg(windows)]
     {
@@ -280,7 +280,7 @@ fn normalize_path_separators(path: &str) -> String {
     }
     #[cfg(not(windows))]
     {
-        path.replace('\\', "/")
+        path.to_string()
     }
 }
 

--- a/crates/languages/src/eslint.rs
+++ b/crates/languages/src/eslint.rs
@@ -6,7 +6,7 @@ use http_client::{
     github_download::download_server_binary,
 };
 use language::{LspAdapter, LspAdapterDelegate, LspInstaller, Toolchain};
-use lsp::{CodeActionKind, LanguageServerBinary, LanguageServerName};
+use lsp::{CodeActionKind, LanguageServerBinary, LanguageServerName, Uri};
 use node_runtime::NodeRuntime;
 use project::lsp_store::language_server_settings;
 use serde_json::{Value, json};
@@ -167,6 +167,7 @@ impl LspAdapter for EsLintLspAdapter {
         self: Arc<Self>,
         delegate: &Arc<dyn LspAdapterDelegate>,
         _: Option<Toolchain>,
+        _: Option<Uri>,
         cx: &mut AsyncApp,
     ) -> Result<Value> {
         let workspace_root = delegate.worktree_root_path();

--- a/crates/languages/src/eslint.rs
+++ b/crates/languages/src/eslint.rs
@@ -254,8 +254,6 @@ impl LspAdapter for EsLintLspAdapter {
                     determine_working_directory(uri, wd, worktree_root.to_owned())
                 });
 
-            dbg!(&working_directory);
-
             if let Some(working_directory) = working_directory
                 && let Some(wd) = default_workspace_configuration.get_mut("workingDirectory")
             {

--- a/crates/languages/src/eslint.rs
+++ b/crates/languages/src/eslint.rs
@@ -470,237 +470,161 @@ mod tests {
 
     #[test]
     fn test_match_glob_pattern() {
-        #[cfg(not(windows))]
-        {
-            let pattern = "/test/*/";
-            let file_path = Path::new("/test/foo/bar/file.txt");
-            let matched = match_glob_pattern(pattern, file_path);
-            assert_eq!(matched, Some("/test/foo/".to_string()));
-        }
-        #[cfg(windows)]
-        {
-            let pattern = "C:\\test\\*\\";
-            let file_path = Path::new("C:\\test\\foo\\bar\\file.txt");
-            let matched = match_glob_pattern(pattern, file_path);
-            assert_eq!(matched, Some("C:\\test\\foo\\".to_string()));
-        }
+        let pattern = unix_path_to_platform("/test/*/");
+        let file_path = PathBuf::from(unix_path_to_platform("/test/foo/bar/file.txt"));
+        let matched = match_glob_pattern(&pattern, &file_path);
+        assert_eq!(matched, Some(unix_path_to_platform("/test/foo/")));
     }
 
     #[test]
     fn test_match_glob_pattern_globstar() {
-        #[cfg(not(windows))]
-        {
-            let pattern = "/workspace/**/src/";
-            let file_path = Path::new("/workspace/packages/core/src/index.ts");
-            let matched = match_glob_pattern(pattern, file_path);
-            assert_eq!(matched, Some("/workspace/packages/core/src/".to_string()));
-        }
-        #[cfg(windows)]
-        {
-            let pattern = "C:\\workspace\\**\\src\\";
-            let file_path = Path::new("C:\\workspace\\packages\\core\\src\\index.ts");
-            let matched = match_glob_pattern(pattern, file_path);
-            assert_eq!(
-                matched,
-                Some("C:\\workspace\\packages\\core\\src\\".to_string())
-            );
-        }
+        let pattern = unix_path_to_platform("/workspace/**/src/");
+        let file_path = PathBuf::from(unix_path_to_platform(
+            "/workspace/packages/core/src/index.ts",
+        ));
+        let matched = match_glob_pattern(&pattern, &file_path);
+        assert_eq!(
+            matched,
+            Some(unix_path_to_platform("/workspace/packages/core/src/"))
+        );
     }
 
     #[test]
     fn test_match_glob_pattern_no_match() {
-        #[cfg(not(windows))]
-        {
-            let pattern = "/other/*/";
-            let file_path = Path::new("/test/foo/bar/file.txt");
-            let matched = match_glob_pattern(pattern, file_path);
-            assert_eq!(matched, None);
-        }
-        #[cfg(windows)]
-        {
-            let pattern = "C:\\other\\*\\";
-            let file_path = Path::new("C:\\test\\foo\\bar\\file.txt");
-            let matched = match_glob_pattern(pattern, file_path);
-            assert_eq!(matched, None);
-        }
+        let pattern = unix_path_to_platform("/other/*/");
+        let file_path = PathBuf::from(unix_path_to_platform("/test/foo/bar/file.txt"));
+        let matched = match_glob_pattern(&pattern, &file_path);
+        assert_eq!(matched, None);
     }
 
     #[test]
     fn test_working_directory_string() {
-        #[cfg(not(windows))]
-        {
-            let uri = make_uri("/workspace/packages/foo/src/file.ts");
-            let working_directories = vec![WorkingDirectory::String("packages/foo".to_string())];
-            let workspace_folder = PathBuf::from("/workspace");
+        let uri = make_uri("/workspace/packages/foo/src/file.ts");
+        let working_directories = vec![WorkingDirectory::String(unix_path_to_platform(
+            "packages/foo",
+        ))];
+        let workspace_folder = PathBuf::from(unix_path_to_platform("/workspace"));
 
-            let result = determine_working_directory(uri, working_directories, workspace_folder);
-            assert_directory_result(result, "/workspace/packages/foo/", false);
-        }
-        #[cfg(windows)]
-        {
-            let uri = make_uri("C:\\workspace\\packages\\foo\\src\\file.ts");
-            let working_directories = vec![WorkingDirectory::String("packages\\foo".to_string())];
-            let workspace_folder = PathBuf::from("C:\\workspace");
-
-            let result = determine_working_directory(uri, working_directories, workspace_folder);
-            assert_directory_result(result, "C:\\workspace\\packages\\foo\\", false);
-        }
+        let result = determine_working_directory(uri, working_directories, workspace_folder);
+        assert_directory_result(
+            result,
+            &unix_path_to_platform("/workspace/packages/foo/"),
+            false,
+        );
     }
 
     #[test]
     fn test_working_directory_absolute_path() {
-        #[cfg(not(windows))]
-        {
-            let uri = make_uri("/workspace/packages/foo/src/file.ts");
-            let working_directories = vec![WorkingDirectory::String(
-                "/workspace/packages/foo".to_string(),
-            )];
-            let workspace_folder = PathBuf::from("/workspace");
+        let uri = make_uri("/workspace/packages/foo/src/file.ts");
+        let working_directories = vec![WorkingDirectory::String(unix_path_to_platform(
+            "/workspace/packages/foo",
+        ))];
+        let workspace_folder = PathBuf::from(unix_path_to_platform("/workspace"));
 
-            let result = determine_working_directory(uri, working_directories, workspace_folder);
-            assert_directory_result(result, "/workspace/packages/foo/", false);
-        }
-        #[cfg(windows)]
-        {
-            let uri = make_uri("C:\\workspace\\packages\\foo\\src\\file.ts");
-            let working_directories = vec![WorkingDirectory::String(
-                "C:\\workspace\\packages\\foo".to_string(),
-            )];
-            let workspace_folder = PathBuf::from("C:\\workspace");
-
-            let result = determine_working_directory(uri, working_directories, workspace_folder);
-            assert_directory_result(result, "C:\\workspace\\packages\\foo\\", false);
-        }
+        let result = determine_working_directory(uri, working_directories, workspace_folder);
+        assert_directory_result(
+            result,
+            &unix_path_to_platform("/workspace/packages/foo/"),
+            false,
+        );
     }
 
     #[test]
     fn test_working_directory_directory_item() {
-        #[cfg(not(windows))]
-        {
-            let uri = make_uri("/workspace/packages/foo/src/file.ts");
-            let working_directories = vec![WorkingDirectory::DirectoryItem(DirectoryItem {
-                directory: "packages/foo".to_string(),
-                not_cwd: Some(true),
-            })];
-            let workspace_folder = PathBuf::from("/workspace");
+        let uri = make_uri("/workspace/packages/foo/src/file.ts");
+        let working_directories = vec![WorkingDirectory::DirectoryItem(DirectoryItem {
+            directory: unix_path_to_platform("packages/foo"),
+            not_cwd: Some(true),
+        })];
+        let workspace_folder = PathBuf::from(unix_path_to_platform("/workspace"));
 
-            let result = determine_working_directory(uri, working_directories, workspace_folder);
-            assert_directory_result(result, "/workspace/packages/foo/", true);
-        }
-        #[cfg(windows)]
-        {
-            let uri = make_uri("C:\\workspace\\packages\\foo\\src\\file.ts");
-            let working_directories = vec![WorkingDirectory::DirectoryItem(DirectoryItem {
-                directory: "packages\\foo".to_string(),
-                not_cwd: Some(true),
-            })];
-            let workspace_folder = PathBuf::from("C:\\workspace");
-
-            let result = determine_working_directory(uri, working_directories, workspace_folder);
-            assert_directory_result(result, "C:\\workspace\\packages\\foo\\", true);
-        }
+        let result = determine_working_directory(uri, working_directories, workspace_folder);
+        assert_directory_result(
+            result,
+            &unix_path_to_platform("/workspace/packages/foo/"),
+            true,
+        );
     }
 
     #[test]
     fn test_working_directory_legacy_item() {
-        #[cfg(not(windows))]
-        {
-            let uri = make_uri("/workspace/packages/foo/src/file.ts");
-            let working_directories =
-                vec![WorkingDirectory::LegacyDirectoryItem(LegacyDirectoryItem {
-                    directory: "packages/foo".to_string(),
-                    change_process_cwd: false,
-                })];
-            let workspace_folder = PathBuf::from("/workspace");
+        let uri = make_uri("/workspace/packages/foo/src/file.ts");
+        let working_directories =
+            vec![WorkingDirectory::LegacyDirectoryItem(LegacyDirectoryItem {
+                directory: unix_path_to_platform("packages/foo"),
+                change_process_cwd: false,
+            })];
+        let workspace_folder = PathBuf::from(unix_path_to_platform("/workspace"));
 
-            let result = determine_working_directory(uri, working_directories, workspace_folder);
-            assert_directory_result(result, "/workspace/packages/foo/", true);
-        }
-        #[cfg(windows)]
-        {
-            let uri = make_uri("C:\\workspace\\packages\\foo\\src\\file.ts");
-            let working_directories =
-                vec![WorkingDirectory::LegacyDirectoryItem(LegacyDirectoryItem {
-                    directory: "packages\\foo".to_string(),
-                    change_process_cwd: false,
-                })];
-            let workspace_folder = PathBuf::from("C:\\workspace");
-
-            let result = determine_working_directory(uri, working_directories, workspace_folder);
-            assert_directory_result(result, "C:\\workspace\\packages\\foo\\", true);
-        }
+        let result = determine_working_directory(uri, working_directories, workspace_folder);
+        assert_directory_result(
+            result,
+            &unix_path_to_platform("/workspace/packages/foo/"),
+            true,
+        );
     }
 
     #[test]
     fn test_working_directory_pattern_item() {
-        #[cfg(not(windows))]
-        {
-            let uri = make_uri("/workspace/packages/foo/src/file.ts");
-            let working_directories = vec![WorkingDirectory::PatternItem(PatternItem {
-                pattern: "packages/*/".to_string(),
-                not_cwd: Some(false),
-            })];
-            let workspace_folder = PathBuf::from("/workspace");
+        let uri = make_uri("/workspace/packages/foo/src/file.ts");
+        let working_directories = vec![WorkingDirectory::PatternItem(PatternItem {
+            pattern: unix_path_to_platform("packages/*/"),
+            not_cwd: Some(false),
+        })];
+        let workspace_folder = PathBuf::from(unix_path_to_platform("/workspace"));
 
-            let result = determine_working_directory(uri, working_directories, workspace_folder);
-            assert_directory_result(result, "/workspace/packages/foo/", false);
-        }
-        #[cfg(windows)]
-        {
-            let uri = make_uri("C:\\workspace\\packages\\foo\\src\\file.ts");
-            let working_directories = vec![WorkingDirectory::PatternItem(PatternItem {
-                pattern: "packages\\*\\".to_string(),
-                not_cwd: Some(false),
-            })];
-            let workspace_folder = PathBuf::from("C:\\workspace");
-
-            let result = determine_working_directory(uri, working_directories, workspace_folder);
-            assert_directory_result(result, "C:\\workspace\\packages\\foo\\", false);
-        }
+        let result = determine_working_directory(uri, working_directories, workspace_folder);
+        assert_directory_result(
+            result,
+            &unix_path_to_platform("/workspace/packages/foo/"),
+            false,
+        );
     }
 
     #[test]
     fn test_working_directory_multiple_patterns() {
-        #[cfg(not(windows))]
-        {
-            let uri = make_uri("/workspace/apps/web/src/file.ts");
-            let working_directories = vec![
-                WorkingDirectory::PatternItem(PatternItem {
-                    pattern: "packages/*/".to_string(),
-                    not_cwd: None,
-                }),
-                WorkingDirectory::PatternItem(PatternItem {
-                    pattern: "apps/*/".to_string(),
-                    not_cwd: None,
-                }),
-            ];
-            let workspace_folder = PathBuf::from("/workspace");
+        let uri = make_uri("/workspace/apps/web/src/file.ts");
+        let working_directories = vec![
+            WorkingDirectory::PatternItem(PatternItem {
+                pattern: unix_path_to_platform("packages/*/"),
+                not_cwd: None,
+            }),
+            WorkingDirectory::PatternItem(PatternItem {
+                pattern: unix_path_to_platform("apps/*/"),
+                not_cwd: None,
+            }),
+        ];
+        let workspace_folder = PathBuf::from(unix_path_to_platform("/workspace"));
 
-            let result = determine_working_directory(uri, working_directories, workspace_folder);
-            assert_directory_result(result, "/workspace/apps/web/", false);
-        }
+        let result = determine_working_directory(uri, working_directories, workspace_folder);
+        assert_directory_result(
+            result,
+            &unix_path_to_platform("/workspace/apps/web/"),
+            false,
+        );
+    }
+
+    /// Converts a Unix-style path to a platform-specific path.
+    /// On Windows, converts "/workspace/foo/bar" to "C:\workspace\foo\bar"
+    /// On Unix, returns the path unchanged.
+    fn unix_path_to_platform(path: &str) -> String {
         #[cfg(windows)]
         {
-            let uri = make_uri("C:\\workspace\\apps\\web\\src\\file.ts");
-            let working_directories = vec![
-                WorkingDirectory::PatternItem(PatternItem {
-                    pattern: "packages\\*\\".to_string(),
-                    not_cwd: None,
-                }),
-                WorkingDirectory::PatternItem(PatternItem {
-                    pattern: "apps\\*\\".to_string(),
-                    not_cwd: None,
-                }),
-            ];
-            let workspace_folder = PathBuf::from("C:\\workspace");
-
-            let result = determine_working_directory(uri, working_directories, workspace_folder);
-            assert_directory_result(result, "C:\\workspace\\apps\\web\\", false);
+            if path.starts_with('/') {
+                format!("C:{}", path.replace('/', "\\"))
+            } else {
+                path.replace('/', "\\")
+            }
+        }
+        #[cfg(not(windows))]
+        {
+            path.to_string()
         }
     }
 
     fn make_uri(path: &str) -> Uri {
-        Uri::from_file_path(path).unwrap()
+        let platform_path = unix_path_to_platform(path);
+        Uri::from_file_path(&platform_path).unwrap()
     }
 
     fn assert_directory_result(

--- a/crates/languages/src/json.rs
+++ b/crates/languages/src/json.rs
@@ -10,7 +10,7 @@ use language::{
     ContextProvider, LanguageName, LocalFile as _, LspAdapter, LspAdapterDelegate, LspInstaller,
     Toolchain,
 };
-use lsp::{LanguageServerBinary, LanguageServerName};
+use lsp::{LanguageServerBinary, LanguageServerName, Uri};
 use node_runtime::{NodeRuntime, VersionStrategy};
 use project::lsp_store::language_server_settings;
 use serde_json::{Value, json};
@@ -251,6 +251,7 @@ impl LspAdapter for JsonLspAdapter {
         self: Arc<Self>,
         delegate: &Arc<dyn LspAdapterDelegate>,
         _: Option<Toolchain>,
+        _: Option<Uri>,
         cx: &mut AsyncApp,
     ) -> Result<Value> {
         let mut config = cx.update(|cx| {

--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -21,6 +21,7 @@ mod bash;
 mod c;
 mod cpp;
 mod css;
+mod eslint;
 mod go;
 mod json;
 mod package_json;
@@ -84,7 +85,7 @@ pub fn init(languages: Arc<LanguageRegistry>, fs: Arc<dyn Fs>, node: NodeRuntime
 
     let c_lsp_adapter = Arc::new(c::CLspAdapter);
     let css_lsp_adapter = Arc::new(css::CssLspAdapter::new(node.clone()));
-    let eslint_adapter = Arc::new(typescript::EsLintLspAdapter::new(node.clone()));
+    let eslint_adapter = Arc::new(eslint::EsLintLspAdapter::new(node.clone()));
     let go_context_provider = Arc::new(go::GoContextProvider);
     let go_lsp_adapter = Arc::new(go::GoLspAdapter);
     let json_context_provider = Arc::new(JsonTaskProvider);

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -10,8 +10,8 @@ use language::{ContextLocation, LanguageToolchainStore, LspInstaller};
 use language::{ContextProvider, LspAdapter, LspAdapterDelegate};
 use language::{LanguageName, ManifestName, ManifestProvider, ManifestQuery};
 use language::{Toolchain, ToolchainList, ToolchainLister, ToolchainMetadata};
-use lsp::LanguageServerBinary;
 use lsp::LanguageServerName;
+use lsp::{LanguageServerBinary, Uri};
 use node_runtime::{NodeRuntime, VersionStrategy};
 use pet_core::Configuration;
 use pet_core::os_environment::Environment;
@@ -206,6 +206,7 @@ impl LspAdapter for TyLspAdapter {
         self: Arc<Self>,
         delegate: &Arc<dyn LspAdapterDelegate>,
         toolchain: Option<Toolchain>,
+        _: Option<Uri>,
         cx: &mut AsyncApp,
     ) -> Result<Value> {
         let mut ret = cx
@@ -517,6 +518,7 @@ impl LspAdapter for PyrightLspAdapter {
         self: Arc<Self>,
         adapter: &Arc<dyn LspAdapterDelegate>,
         toolchain: Option<Toolchain>,
+        _: Option<Uri>,
         cx: &mut AsyncApp,
     ) -> Result<Value> {
         cx.update(move |cx| {
@@ -1593,6 +1595,7 @@ impl LspAdapter for PyLspAdapter {
         self: Arc<Self>,
         adapter: &Arc<dyn LspAdapterDelegate>,
         toolchain: Option<Toolchain>,
+        _: Option<Uri>,
         cx: &mut AsyncApp,
     ) -> Result<Value> {
         cx.update(move |cx| {
@@ -1884,6 +1887,7 @@ impl LspAdapter for BasedPyrightLspAdapter {
         self: Arc<Self>,
         adapter: &Arc<dyn LspAdapterDelegate>,
         toolchain: Option<Toolchain>,
+        _: Option<Uri>,
         cx: &mut AsyncApp,
     ) -> Result<Value> {
         cx.update(move |cx| {

--- a/crates/languages/src/tailwind.rs
+++ b/crates/languages/src/tailwind.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use collections::HashMap;
 use gpui::AsyncApp;
 use language::{LanguageName, LspAdapter, LspAdapterDelegate, LspInstaller, Toolchain};
-use lsp::{LanguageServerBinary, LanguageServerName};
+use lsp::{LanguageServerBinary, LanguageServerName, Uri};
 use node_runtime::{NodeRuntime, VersionStrategy};
 use project::lsp_store::language_server_settings;
 use serde_json::{Value, json};
@@ -154,6 +154,7 @@ impl LspAdapter for TailwindLspAdapter {
         self: Arc<Self>,
         delegate: &Arc<dyn LspAdapterDelegate>,
         _: Option<Toolchain>,
+        _: Option<Uri>,
         cx: &mut AsyncApp,
     ) -> Result<Value> {
         let mut tailwind_user_settings = cx.update(|cx| {

--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -9,7 +9,7 @@ use language::{
     ContextLocation, ContextProvider, File, LanguageName, LanguageToolchainStore, LspAdapter,
     LspAdapterDelegate, LspInstaller, Toolchain,
 };
-use lsp::{CodeActionKind, LanguageServerBinary, LanguageServerName};
+use lsp::{CodeActionKind, LanguageServerBinary, LanguageServerName, Uri};
 use node_runtime::{NodeRuntime, VersionStrategy};
 use project::{Fs, lsp_store::language_server_settings};
 use serde_json::{Value, json};
@@ -801,9 +801,9 @@ impl LspAdapter for TypeScriptLspAdapter {
 
     async fn workspace_configuration(
         self: Arc<Self>,
-
         delegate: &Arc<dyn LspAdapterDelegate>,
         _: Option<Toolchain>,
+        _: Option<Uri>,
         cx: &mut AsyncApp,
     ) -> Result<Value> {
         let override_options = cx.update(|cx| {

--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -4,8 +4,6 @@ use chrono::{DateTime, Local};
 use collections::HashMap;
 use futures::future::join_all;
 use gpui::{App, AppContext, AsyncApp, Task};
-use http_client::github::{AssetKind, GitHubLspBinaryVersion, build_asset_url};
-use http_client::github_download::download_server_binary;
 use itertools::Itertools as _;
 use language::{
     ContextLocation, ContextProvider, File, LanguageName, LanguageToolchainStore, LspAdapter,
@@ -15,7 +13,7 @@ use lsp::{CodeActionKind, LanguageServerBinary, LanguageServerName};
 use node_runtime::{NodeRuntime, VersionStrategy};
 use project::{Fs, lsp_store::language_server_settings};
 use serde_json::{Value, json};
-use smol::{fs, lock::RwLock, stream::StreamExt};
+use smol::lock::RwLock;
 use std::{
     borrow::Cow,
     ffi::OsString,
@@ -23,8 +21,8 @@ use std::{
     sync::{Arc, LazyLock},
 };
 use task::{TaskTemplate, TaskTemplates, VariableName};
-use util::{ResultExt, fs::remove_matching, maybe};
-use util::{merge_json_value_into, rel_path::RelPath};
+use util::rel_path::RelPath;
+use util::{ResultExt, maybe};
 
 use crate::{PackageJson, PackageJsonData};
 
@@ -589,14 +587,6 @@ fn typescript_server_binary_arguments(server_path: &Path) -> Vec<OsString> {
     vec![server_path.into(), "--stdio".into()]
 }
 
-fn eslint_server_binary_arguments(server_path: &Path) -> Vec<OsString> {
-    vec![
-        "--max-old-space-size=8192".into(),
-        server_path.into(),
-        "--stdio".into(),
-    ]
-}
-
 fn replace_test_name_parameters(test_name: &str) -> String {
     static PATTERN: LazyLock<regex::Regex> =
         LazyLock::new(|| regex::Regex::new(r"(\$([A-Za-z0-9_\.]+|[\#])|%[psdifjo#\$%])").unwrap());
@@ -864,226 +854,6 @@ async fn get_cached_ts_server_binary(
     })
     .await
     .log_err()
-}
-
-pub struct EsLintLspAdapter {
-    node: NodeRuntime,
-}
-
-impl EsLintLspAdapter {
-    const CURRENT_VERSION: &'static str = "2.4.4";
-    const CURRENT_VERSION_TAG_NAME: &'static str = "release/2.4.4";
-
-    #[cfg(not(windows))]
-    const GITHUB_ASSET_KIND: AssetKind = AssetKind::TarGz;
-    #[cfg(windows)]
-    const GITHUB_ASSET_KIND: AssetKind = AssetKind::Zip;
-
-    const SERVER_PATH: &'static str = "vscode-eslint/server/out/eslintServer.js";
-    const SERVER_NAME: LanguageServerName = LanguageServerName::new_static("eslint");
-
-    const FLAT_CONFIG_FILE_NAMES: &'static [&'static str] = &[
-        "eslint.config.js",
-        "eslint.config.mjs",
-        "eslint.config.cjs",
-        "eslint.config.ts",
-        "eslint.config.cts",
-        "eslint.config.mts",
-    ];
-
-    pub fn new(node: NodeRuntime) -> Self {
-        EsLintLspAdapter { node }
-    }
-
-    fn build_destination_path(container_dir: &Path) -> PathBuf {
-        container_dir.join(format!("vscode-eslint-{}", Self::CURRENT_VERSION))
-    }
-}
-
-impl LspInstaller for EsLintLspAdapter {
-    type BinaryVersion = GitHubLspBinaryVersion;
-
-    async fn fetch_latest_server_version(
-        &self,
-        _delegate: &dyn LspAdapterDelegate,
-        _: bool,
-        _: &mut AsyncApp,
-    ) -> Result<GitHubLspBinaryVersion> {
-        let url = build_asset_url(
-            "zed-industries/vscode-eslint",
-            Self::CURRENT_VERSION_TAG_NAME,
-            Self::GITHUB_ASSET_KIND,
-        )?;
-
-        Ok(GitHubLspBinaryVersion {
-            name: Self::CURRENT_VERSION.into(),
-            digest: None,
-            url,
-        })
-    }
-
-    async fn fetch_server_binary(
-        &self,
-        version: GitHubLspBinaryVersion,
-        container_dir: PathBuf,
-        delegate: &dyn LspAdapterDelegate,
-    ) -> Result<LanguageServerBinary> {
-        let destination_path = Self::build_destination_path(&container_dir);
-        let server_path = destination_path.join(Self::SERVER_PATH);
-
-        if fs::metadata(&server_path).await.is_err() {
-            remove_matching(&container_dir, |_| true).await;
-
-            download_server_binary(
-                &*delegate.http_client(),
-                &version.url,
-                None,
-                &destination_path,
-                Self::GITHUB_ASSET_KIND,
-            )
-            .await?;
-
-            let mut dir = fs::read_dir(&destination_path).await?;
-            let first = dir.next().await.context("missing first file")??;
-            let repo_root = destination_path.join("vscode-eslint");
-            fs::rename(first.path(), &repo_root).await?;
-
-            #[cfg(target_os = "windows")]
-            {
-                handle_symlink(
-                    repo_root.join("$shared"),
-                    repo_root.join("client").join("src").join("shared"),
-                )
-                .await?;
-                handle_symlink(
-                    repo_root.join("$shared"),
-                    repo_root.join("server").join("src").join("shared"),
-                )
-                .await?;
-            }
-
-            self.node
-                .run_npm_subcommand(&repo_root, "install", &[])
-                .await?;
-
-            self.node
-                .run_npm_subcommand(&repo_root, "run-script", &["compile"])
-                .await?;
-        }
-
-        Ok(LanguageServerBinary {
-            path: self.node.binary_path().await?,
-            env: None,
-            arguments: eslint_server_binary_arguments(&server_path),
-        })
-    }
-
-    async fn cached_server_binary(
-        &self,
-        container_dir: PathBuf,
-        _: &dyn LspAdapterDelegate,
-    ) -> Option<LanguageServerBinary> {
-        let server_path =
-            Self::build_destination_path(&container_dir).join(EsLintLspAdapter::SERVER_PATH);
-        Some(LanguageServerBinary {
-            path: self.node.binary_path().await.ok()?,
-            env: None,
-            arguments: eslint_server_binary_arguments(&server_path),
-        })
-    }
-}
-
-#[async_trait(?Send)]
-impl LspAdapter for EsLintLspAdapter {
-    fn code_action_kinds(&self) -> Option<Vec<CodeActionKind>> {
-        Some(vec![
-            CodeActionKind::QUICKFIX,
-            CodeActionKind::new("source.fixAll.eslint"),
-        ])
-    }
-
-    async fn workspace_configuration(
-        self: Arc<Self>,
-        delegate: &Arc<dyn LspAdapterDelegate>,
-        _: Option<Toolchain>,
-        cx: &mut AsyncApp,
-    ) -> Result<Value> {
-        let workspace_root = delegate.worktree_root_path();
-        let use_flat_config = Self::FLAT_CONFIG_FILE_NAMES
-            .iter()
-            .any(|file| workspace_root.join(file).is_file());
-
-        let mut default_workspace_configuration = json!({
-            "validate": "on",
-            "rulesCustomizations": [],
-            "run": "onType",
-            "nodePath": null,
-            "workingDirectory": {
-                "mode": "auto"
-            },
-            "workspaceFolder": {
-                "uri": workspace_root,
-                "name": workspace_root.file_name()
-                    .unwrap_or(workspace_root.as_os_str())
-                    .to_string_lossy(),
-            },
-            "problems": {},
-            "codeActionOnSave": {
-                // We enable this, but without also configuring code_actions_on_format
-                // in the Zed configuration, it doesn't have an effect.
-                "enable": true,
-            },
-            "codeAction": {
-                "disableRuleComment": {
-                    "enable": true,
-                    "location": "separateLine",
-                },
-                "showDocumentation": {
-                    "enable": true
-                }
-            },
-            "experimental": {
-                "useFlatConfig": use_flat_config,
-            }
-        });
-
-        let override_options = cx.update(|cx| {
-            language_server_settings(delegate.as_ref(), &Self::SERVER_NAME, cx)
-                .and_then(|s| s.settings.clone())
-        })?;
-
-        if let Some(override_options) = override_options {
-            merge_json_value_into(override_options, &mut default_workspace_configuration);
-        }
-
-        Ok(json!({
-            "": default_workspace_configuration
-        }))
-    }
-
-    fn name(&self) -> LanguageServerName {
-        Self::SERVER_NAME
-    }
-}
-
-#[cfg(target_os = "windows")]
-async fn handle_symlink(src_dir: PathBuf, dest_dir: PathBuf) -> Result<()> {
-    anyhow::ensure!(
-        fs::metadata(&src_dir).await.is_ok(),
-        "Directory {src_dir:?} is not present"
-    );
-    if fs::metadata(&dest_dir).await.is_ok() {
-        fs::remove_file(&dest_dir).await?;
-    }
-    fs::create_dir_all(&dest_dir).await?;
-    let mut entries = fs::read_dir(&src_dir).await?;
-    while let Some(entry) = entries.try_next().await? {
-        let entry_path = entry.path();
-        let entry_name = entry.file_name();
-        let dest_path = dest_dir.join(&entry_name);
-        fs::copy(&entry_path, &dest_path).await?;
-    }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/languages/src/vtsls.rs
+++ b/crates/languages/src/vtsls.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use collections::HashMap;
 use gpui::AsyncApp;
 use language::{LanguageName, LspAdapter, LspAdapterDelegate, LspInstaller, Toolchain};
-use lsp::{CodeActionKind, LanguageServerBinary, LanguageServerName};
+use lsp::{CodeActionKind, LanguageServerBinary, LanguageServerName, Uri};
 use node_runtime::{NodeRuntime, VersionStrategy};
 use project::{Fs, lsp_store::language_server_settings};
 use regex::Regex;
@@ -228,6 +228,7 @@ impl LspAdapter for VtslsLspAdapter {
         self: Arc<Self>,
         delegate: &Arc<dyn LspAdapterDelegate>,
         _: Option<Toolchain>,
+        _: Option<Uri>,
         cx: &mut AsyncApp,
     ) -> Result<Value> {
         let tsdk_path = self.tsdk_path(delegate).await;

--- a/crates/languages/src/yaml.rs
+++ b/crates/languages/src/yaml.rs
@@ -4,7 +4,7 @@ use gpui::AsyncApp;
 use language::{
     LspAdapter, LspAdapterDelegate, LspInstaller, Toolchain, language_settings::AllLanguageSettings,
 };
-use lsp::{LanguageServerBinary, LanguageServerName};
+use lsp::{LanguageServerBinary, LanguageServerName, Uri};
 use node_runtime::{NodeRuntime, VersionStrategy};
 use project::lsp_store::language_server_settings;
 use serde_json::Value;
@@ -132,9 +132,9 @@ impl LspAdapter for YamlLspAdapter {
 
     async fn workspace_configuration(
         self: Arc<Self>,
-
         delegate: &Arc<dyn LspAdapterDelegate>,
         _: Option<Toolchain>,
+        _: Option<Uri>,
         cx: &mut AsyncApp,
     ) -> Result<Value> {
         let location = SettingsLocation {

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -13633,7 +13633,7 @@ pub fn language_server_settings<'a>(
     )
 }
 
-pub(crate) fn language_server_settings_for<'a>(
+pub fn language_server_settings_for<'a>(
     location: SettingsLocation<'a>,
     language: &LanguageServerName,
     cx: &'a App,

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -436,6 +436,7 @@ impl LocalLspStore {
                         adapter.adapter.clone(),
                         &delegate,
                         toolchain,
+                        None,
                         cx,
                     )
                     .await?;
@@ -725,7 +726,7 @@ impl LocalLspStore {
                         for item in &params.items {
                             let scope_uri = item.scope_uri.clone();
                             let std::collections::btree_map::Entry::Vacant(new_scope_uri) =
-                                scope_uri_to_workspace_config.entry(scope_uri)
+                                scope_uri_to_workspace_config.entry(scope_uri.clone())
                             else {
                                 // We've already queried workspace configuration of this URI.
                                 continue;
@@ -734,6 +735,7 @@ impl LocalLspStore {
                                 adapter.clone(),
                                 &delegate,
                                 toolchain_for_id.clone(),
+                                scope_uri,
                                 &mut cx,
                             )
                             .await?;
@@ -3537,11 +3539,12 @@ impl LocalLspStore {
         adapter: Arc<dyn LspAdapter>,
         delegate: &Arc<dyn LspAdapterDelegate>,
         toolchain: Option<Toolchain>,
+        requested_uri: Option<Uri>,
         cx: &mut AsyncApp,
     ) -> Result<serde_json::Value> {
         let mut workspace_config = adapter
             .clone()
-            .workspace_configuration(delegate, toolchain, cx)
+            .workspace_configuration(delegate, toolchain, requested_uri, cx)
             .await?;
 
         for other_adapter in delegate.registered_lsp_adapters() {
@@ -7973,6 +7976,7 @@ impl LspStore {
                                                 adapter.adapter.clone(),
                                                 &delegate,
                                                 toolchain,
+                                                None,
                                                 cx,
                                             )
                                             .await


### PR DESCRIPTION
Closes #9648 #9755

Release Notes:

- Added way to configure ESLint's working directories in settings. For example: `{"lsp":{"eslint":{"settings":{"workingDirectories":["./client","./server"]}}}}`