### PR TITLE
gpui: Give windows message loop processing chances when we overload the main thread with tasks

### DIFF
--- a/crates/gpui/src/platform/windows/dispatcher.rs
+++ b/crates/gpui/src/platform/windows/dispatcher.rs
@@ -25,7 +25,7 @@ pub(crate) struct WindowsDispatcher {
     pub(crate) wake_posted: AtomicBool,
     main_sender: Sender<RunnableVariant>,
     main_thread_id: ThreadId,
-    platform_window_handle: SafeHwnd,
+    pub(crate) platform_window_handle: SafeHwnd,
     validation_number: usize,
 }
 


### PR DESCRIPTION
This reduces hangs on windows when we have many tasks queued up on the main thread that yield a lot.

Release Notes:

- Reduced hangs on windows in some situations
