### PR TITLE
sweep: Set `use_bytes` flag

### DIFF
--- a/crates/zeta/src/sweep_ai.rs
+++ b/crates/zeta/src/sweep_ai.rs
@@ -164,6 +164,7 @@ impl SweepAi {
                 file_chunks,
                 retrieval_chunks: vec![],
                 recent_user_actions: vec![],
+                use_bytes: true,
                 // TODO
                 privacy_mode_enabled: false,
             };
@@ -275,6 +276,7 @@ struct AutocompleteRequest {
     pub multiple_suggestions: bool,
     pub privacy_mode_enabled: bool,
     pub changes_above_cursor: bool,
+    pub use_bytes: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]


### PR DESCRIPTION
Without this new flag, the Sweep API will actually produce a combination of UTF-16 and char indices, leading to incorrect edit positions.

Release Notes:

- N/A 
