### PR TITLE
askpass: Use double quotes for script name in helper command

### DIFF
--- a/crates/askpass/src/askpass.rs
+++ b/crates/askpass/src/askpass.rs
@@ -257,7 +257,7 @@ impl PasswordProxy {
         // todo(shell): There might be no powershell on the system
         #[cfg(target_os = "windows")]
         let askpass_helper = format!(
-            "powershell.exe -ExecutionPolicy Bypass -File '{}'",
+            "powershell.exe -ExecutionPolicy Bypass -File \"{}\"",
             askpass_script_path.display()
         );
 


### PR DESCRIPTION
Replace single quotes with double quotes when referencing the askpass script name in the helper command. The Windows command processor (cmd.exe) requires double quotes for proper string handling, as single quotes are treated as literal characters.

Error I get when trying to open remote project:
<img width="396" height="390" alt="image" src="https://github.com/user-attachments/assets/1538ee10-8efc-4f80-a867-b367908091b6" />

```
Zed Nightly 0.216.0 
c2281779af56bd52c829ccd31aae4eb82b682ebc
0.216.0+nightly.1965.c2281779af56bd52c829ccd31aae4eb82b682ebc
```

Release Notes:

- N/A