### PR TITLE
diffs: AST based syntax diffing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -914,6 +914,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ast_diff"
+version = "0.1.0"
+dependencies = [
+ "bumpalo",
+ "hashbrown 0.15.5",
+ "log",
+ "pretty_assertions",
+ "radix-heap",
+ "rustc-hash 2.1.1",
+ "smallvec",
+ "strsim",
+ "tree-sitter",
+ "tree-sitter-json",
+ "tree-sitter-python",
+ "tree-sitter-rust",
+ "tree-sitter-typescript",
+ "wu-diff",
+]
+
+[[package]]
 name = "async-attributes"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8767,6 +8787,7 @@ name = "language"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "ast_diff",
  "async-trait",
  "clock",
  "collections",
@@ -13544,6 +13565,12 @@ name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "radix-heap"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ffec9df464013295b499298811e6a3de31bf8128092135826517db12dee601"
 
 [[package]]
 name = "rand"
@@ -20829,6 +20856,12 @@ name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "wu-diff"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e3e6735fcde06432870db8dc9d7e3ab1b93727c14eaef329969426299f28893"
 
 [[package]]
 name = "wyz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/action_log",
     "crates/activity_indicator",
     "crates/agent",
+    "crates/ast_diff",
     "crates/agent_servers",
     "crates/agent_settings",
     "crates/agent_ui",
@@ -247,6 +248,7 @@ ai_onboarding = { path = "crates/ai_onboarding" }
 anthropic = { path = "crates/anthropic" }
 askpass = { path = "crates/askpass" }
 assets = { path = "crates/assets" }
+ast_diff = { path = "crates/ast_diff" }
 assistant_text_thread = { path = "crates/assistant_text_thread" }
 assistant_slash_command = { path = "crates/assistant_slash_command" }
 assistant_slash_commands = { path = "crates/assistant_slash_commands" }

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1216,6 +1216,15 @@
   //
   // Default: true
   "word_diff_enabled": true,
+  // Whether to use AST-aware syntax diffing for word highlights.
+  //
+  // When enabled and a language grammar is available, uses tree-sitter
+  // to parse and diff syntax trees for more accurate change detection.
+  // Falls back to token-based word diffing if syntax diffing fails or
+  // the language doesn't have a grammar.
+  //
+  // Default: false
+  "syntax_diff_enabled": false,
   // Control what info is collected by Zed.
   "telemetry": {
     // Send debug info like crash reports.

--- a/crates/ast_diff/Cargo.toml
+++ b/crates/ast_diff/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "ast_diff"
+version = "0.1.0"
+edition.workspace = true
+publish = false
+license = "GPL-3.0-or-later"
+
+[lints]
+workspace = true
+
+[lib]
+path = "src/ast_diff.rs"
+
+[dependencies]
+bumpalo = "3.16"
+radix-heap = "0.4"
+smallvec.workspace = true
+rustc-hash.workspace = true
+hashbrown.workspace = true
+strsim.workspace = true
+log.workspace = true
+tree-sitter.workspace = true
+wu-diff = "0.1"
+
+[dev-dependencies]
+pretty_assertions = "1.0"
+tree-sitter-json.workspace = true
+tree-sitter-rust.workspace = true
+tree-sitter-python.workspace = true
+tree-sitter-typescript.workspace = true

--- a/crates/ast_diff/LICENSE-GPL
+++ b/crates/ast_diff/LICENSE-GPL
@@ -1,0 +1,1 @@
+../../LICENSE-GPL

--- a/crates/ast_diff/src/ast_diff.rs
+++ b/crates/ast_diff/src/ast_diff.rs
@@ -1,0 +1,1173 @@
+//! AST-aware diffing for syntax trees, extracted and adapted from
+//! [difftastic](https://github.com/Wilfred/difftastic).
+
+mod builder;
+mod changes;
+mod config;
+mod dijkstra;
+mod graph;
+mod hash;
+mod lcs_diff;
+mod sliders;
+mod stack;
+mod syntax;
+mod unchanged;
+
+pub use builder::build_syntax;
+pub use changes::{ChangeKind, ChangeMap};
+pub use config::{DefaultConfig, LanguageDiffConfig, SyntaxDiffConfig};
+pub use dijkstra::ExceededGraphLimit;
+pub use sliders::SliderPreference;
+pub use syntax::{init_all_info, AtomKind, StringKind, Syntax, SyntaxId};
+
+use bumpalo::Bump;
+use std::{fmt, ops::Range};
+use tree_sitter::Tree;
+
+/// Default graph limit (10 million vertices).
+pub const DEFAULT_GRAPH_LIMIT: usize = 10_000_000;
+
+/// Error types for syntax diffing.
+#[derive(Debug)]
+pub enum DiffError {
+    /// The diff graph exceeded the configured limit.
+    ExceededGraphLimit,
+}
+
+impl fmt::Display for DiffError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DiffError::ExceededGraphLimit => {
+                write!(f, "Diff graph exceeded configured vertex limit")
+            }
+        }
+    }
+}
+
+impl std::error::Error for DiffError {}
+
+impl From<ExceededGraphLimit> for DiffError {
+    fn from(_: ExceededGraphLimit) -> Self {
+        DiffError::ExceededGraphLimit
+    }
+}
+
+/// Options for syntax diffing.
+#[derive(Debug, Clone)]
+pub struct DiffOptions {
+    /// Maximum number of graph vertices before falling back to text diff.
+    pub graph_limit: usize,
+    /// Preference for slider fixing (inner vs outer delimiters).
+    pub slider_preference: SliderPreference,
+}
+
+impl Default for DiffOptions {
+    fn default() -> Self {
+        Self {
+            graph_limit: DEFAULT_GRAPH_LIMIT,
+            slider_preference: SliderPreference::PreferInner,
+        }
+    }
+}
+
+/// The type of change detected for a syntax element.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SyntaxChangeKind {
+    /// The node is unchanged.
+    Unchanged,
+    /// The node is novel (added or removed).
+    Novel,
+    /// A comment was replaced with another comment.
+    ReplacedComment,
+    /// A string was replaced with another string.
+    ReplacedString,
+}
+
+/// A change detected during syntax diffing.
+#[derive(Debug, Clone)]
+pub struct SyntaxChange {
+    /// The type of change.
+    pub kind: SyntaxChangeKind,
+    /// The byte range in the LHS text that changed (None if added).
+    pub lhs_byte_range: Option<Range<usize>>,
+    /// The byte range in the RHS text that changed (None if removed).
+    pub rhs_byte_range: Option<Range<usize>>,
+}
+
+/// Compute a syntax-aware diff between two tree-sitter trees.
+///
+/// Returns `DiffError::ExceededGraphLimit` if the diff graph exceeds the
+/// configured limit. Callers should fall back to text-based diffing in this case.
+pub fn diff_syntax(
+    lhs_tree: &Tree,
+    lhs_text: &str,
+    rhs_tree: &Tree,
+    rhs_text: &str,
+    config: &dyn SyntaxDiffConfig,
+    options: &DiffOptions,
+) -> Result<(Vec<Range<usize>>, Vec<Range<usize>>), DiffError> {
+    let arena = Bump::new();
+
+    let lhs_roots = build_syntax(&arena, lhs_tree, lhs_text, config);
+    let rhs_roots = build_syntax(&arena, rhs_tree, rhs_text, config);
+
+    diff_syntax_roots(&lhs_roots, &rhs_roots, options).map_err(Into::into)
+}
+
+/// Compute a syntax-aware diff between two syntax trees.
+pub fn diff_syntax_roots<'a>(
+    lhs_roots: &[&'a Syntax<'a>],
+    rhs_roots: &[&'a Syntax<'a>],
+    options: &DiffOptions,
+) -> Result<(Vec<Range<usize>>, Vec<Range<usize>>), ExceededGraphLimit> {
+    init_all_info(lhs_roots, rhs_roots);
+
+    let mut change_map = ChangeMap::default();
+    let nodes_to_diff = unchanged::mark_unchanged(lhs_roots, rhs_roots, &mut change_map);
+
+    for (lhs_nodes, rhs_nodes) in nodes_to_diff {
+        dijkstra::mark_syntax(
+            lhs_nodes.first().copied(),
+            rhs_nodes.first().copied(),
+            &mut change_map,
+            options.graph_limit,
+        )?;
+    }
+
+    sliders::fix_all_sliders(options.slider_preference, lhs_roots, &mut change_map);
+    sliders::fix_all_sliders(options.slider_preference, rhs_roots, &mut change_map);
+
+    let lhs_ranges = collect_novel_ranges(lhs_roots, &change_map);
+    let rhs_ranges = collect_novel_ranges(rhs_roots, &change_map);
+
+    Ok((lhs_ranges, rhs_ranges))
+}
+
+fn collect_novel_ranges<'a>(
+    nodes: &[&'a Syntax<'a>],
+    change_map: &ChangeMap<'a>,
+) -> Vec<Range<usize>> {
+    let mut ranges = Vec::new();
+    collect_novel_ranges_recursive(nodes, change_map, &mut ranges);
+
+    if ranges.is_empty() {
+        return ranges;
+    }
+    
+    ranges.sort_by_key(|r| r.start);
+    let mut merged = vec![ranges[0].clone()];
+    
+    for range in ranges.into_iter().skip(1) {
+        let last = merged.last_mut().unwrap();
+        if range.start <= last.end {
+            last.end = last.end.max(range.end);
+        } else {
+            merged.push(range);
+        }
+    }
+    
+    merged
+}
+
+fn collect_novel_ranges_recursive<'a>(
+    nodes: &[&'a Syntax<'a>],
+    change_map: &ChangeMap<'a>,
+    ranges: &mut Vec<Range<usize>>,
+) {
+    for node in nodes {
+        match change_map.get(node) {
+            Some(ChangeKind::Novel) => {
+                ranges.push(node.byte_range());
+            }
+            Some(ChangeKind::ReplacedComment(_, _)) | Some(ChangeKind::ReplacedString(_, _)) => {
+                ranges.push(node.byte_range());
+            }
+            Some(ChangeKind::Unchanged(_)) => {
+                if let Syntax::List { children, .. } = node {
+                    collect_novel_ranges_recursive(children, change_map, ranges);
+                }
+            }
+            None => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bumpalo::Bump;
+
+    fn make_atom<'a>(arena: &'a Bump, content: &str, start: usize) -> &'a Syntax<'a> {
+        Syntax::new_atom(
+            arena,
+            start..start + content.len(),
+            content.to_string(),
+            AtomKind::Normal,
+        )
+    }
+
+    #[test]
+    fn test_identical_atoms() {
+        let arena = Bump::new();
+        
+        let lhs = make_atom(&arena, "foo", 0);
+        let rhs = make_atom(&arena, "foo", 0);
+        
+        let (lhs_ranges, rhs_ranges) = diff_syntax_roots(
+            &[lhs],
+            &[rhs],
+            &DiffOptions::default(),
+        ).unwrap();
+        
+        assert!(lhs_ranges.is_empty(), "Expected no changes on LHS");
+        assert!(rhs_ranges.is_empty(), "Expected no changes on RHS");
+    }
+
+    #[test]
+    fn test_different_atoms() {
+        let arena = Bump::new();
+        
+        let lhs = make_atom(&arena, "foo", 0);
+        let rhs = make_atom(&arena, "bar", 0);
+        
+        let (lhs_ranges, rhs_ranges) = diff_syntax_roots(
+            &[lhs],
+            &[rhs],
+            &DiffOptions::default(),
+        ).unwrap();
+        
+        assert_eq!(lhs_ranges.len(), 1, "Expected one change on LHS");
+        assert_eq!(rhs_ranges.len(), 1, "Expected one change on RHS");
+        assert_eq!(lhs_ranges[0], 0..3);
+        assert_eq!(rhs_ranges[0], 0..3);
+    }
+
+    #[test]
+    fn test_added_node() {
+        let arena = Bump::new();
+        
+        let lhs = [make_atom(&arena, "a", 0)];
+        let rhs = [
+            make_atom(&arena, "a", 0),
+            make_atom(&arena, "b", 2),
+        ];
+        
+        let (lhs_ranges, rhs_ranges) = diff_syntax_roots(
+            &lhs,
+            &rhs,
+            &DiffOptions::default(),
+        ).unwrap();
+        
+        assert!(lhs_ranges.is_empty(), "Expected no changes on LHS");
+        assert_eq!(rhs_ranges.len(), 1, "Expected one addition on RHS");
+        assert_eq!(rhs_ranges[0], 2..3);
+    }
+
+    #[test]
+    fn test_list_with_unchanged_delimiters() {
+        let arena = Bump::new();
+        
+        let lhs_child = make_atom(&arena, "old", 1);
+        let lhs = Syntax::new_list(
+            &arena,
+            "(",
+            0..1,
+            vec![lhs_child],
+            ")",
+            4..5,
+        );
+        
+        let rhs_child = make_atom(&arena, "new", 1);
+        let rhs = Syntax::new_list(
+            &arena,
+            "(",
+            0..1,
+            vec![rhs_child],
+            ")",
+            4..5,
+        );
+        
+        let (lhs_ranges, rhs_ranges) = diff_syntax_roots(
+            &[lhs],
+            &[rhs],
+            &DiffOptions::default(),
+        ).unwrap();
+        
+        assert_eq!(lhs_ranges.len(), 1);
+        assert_eq!(rhs_ranges.len(), 1);
+        assert_eq!(lhs_ranges[0], 1..4);
+        assert_eq!(rhs_ranges[0], 1..4);
+    }
+
+    fn parse_json(source: &str) -> tree_sitter::Tree {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_json::LANGUAGE.into())
+            .expect("Error loading JSON grammar");
+        parser.parse(source, None).expect("Failed to parse")
+    }
+
+    #[test]
+    fn test_integration_identical_json() {
+        let arena = Bump::new();
+        let config = DefaultConfig::default();
+        let source = r#"{"key": "value"}"#;
+        
+        let tree = parse_json(source);
+        let lhs_nodes = build_syntax(&arena, &tree, source, &config);
+        let rhs_nodes = build_syntax(&arena, &tree, source, &config);
+        
+        let (lhs_ranges, rhs_ranges) = diff_syntax_roots(
+            &lhs_nodes,
+            &rhs_nodes,
+            &DiffOptions::default(),
+        ).unwrap();
+        
+        assert!(lhs_ranges.is_empty(), "Expected no changes for identical JSON");
+        assert!(rhs_ranges.is_empty(), "Expected no changes for identical JSON");
+    }
+
+    #[test]
+    fn test_integration_different_json_values() {
+        let arena = Bump::new();
+        let config = DefaultConfig::default();
+        
+        let lhs_source = r#"{"key": "old"}"#;
+        let rhs_source = r#"{"key": "new"}"#;
+        
+        let lhs_tree = parse_json(lhs_source);
+        let rhs_tree = parse_json(rhs_source);
+        
+        let lhs_nodes = build_syntax(&arena, &lhs_tree, lhs_source, &config);
+        let rhs_nodes = build_syntax(&arena, &rhs_tree, rhs_source, &config);
+        
+        let (lhs_ranges, rhs_ranges) = diff_syntax_roots(
+            &lhs_nodes,
+            &rhs_nodes,
+            &DiffOptions::default(),
+        ).unwrap();
+        
+        // Should detect that the string value changed
+        assert!(!lhs_ranges.is_empty(), "Expected changes on LHS");
+        assert!(!rhs_ranges.is_empty(), "Expected changes on RHS");
+    }
+
+    #[test]
+    fn test_integration_added_json_field() {
+        let arena = Bump::new();
+        let config = DefaultConfig::default();
+        
+        let lhs_source = r#"{"a": 1}"#;
+        let rhs_source = r#"{"a": 1, "b": 2}"#;
+        
+        let lhs_tree = parse_json(lhs_source);
+        let rhs_tree = parse_json(rhs_source);
+        
+        let lhs_nodes = build_syntax(&arena, &lhs_tree, lhs_source, &config);
+        let rhs_nodes = build_syntax(&arena, &rhs_tree, rhs_source, &config);
+        
+        let (lhs_ranges, rhs_ranges) = diff_syntax_roots(
+            &lhs_nodes,
+            &rhs_nodes,
+            &DiffOptions::default(),
+        ).unwrap();
+        
+        // LHS should have no changes, RHS should have the added field
+        assert!(lhs_ranges.is_empty(), "Expected no changes on LHS for added field");
+        assert!(!rhs_ranges.is_empty(), "Expected additions on RHS");
+    }
+
+    #[test]
+    fn test_integration_removed_json_field() {
+        let arena = Bump::new();
+        let config = DefaultConfig::default();
+        
+        let lhs_source = r#"{"a": 1, "b": 2}"#;
+        let rhs_source = r#"{"a": 1}"#;
+        
+        let lhs_tree = parse_json(lhs_source);
+        let rhs_tree = parse_json(rhs_source);
+        
+        let lhs_nodes = build_syntax(&arena, &lhs_tree, lhs_source, &config);
+        let rhs_nodes = build_syntax(&arena, &rhs_tree, rhs_source, &config);
+        
+        let (lhs_ranges, rhs_ranges) = diff_syntax_roots(
+            &lhs_nodes,
+            &rhs_nodes,
+            &DiffOptions::default(),
+        ).unwrap();
+        
+        // LHS should have the removed field, RHS should have no changes
+        assert!(!lhs_ranges.is_empty(), "Expected removals on LHS");
+        assert!(rhs_ranges.is_empty(), "Expected no changes on RHS for removed field");
+    }
+
+    #[test]
+    fn test_integration_nested_json_change() {
+        let arena = Bump::new();
+        let config = DefaultConfig::default();
+        
+        let lhs_source = r#"{"outer": {"inner": "old"}}"#;
+        let rhs_source = r#"{"outer": {"inner": "new"}}"#;
+        
+        let lhs_tree = parse_json(lhs_source);
+        let rhs_tree = parse_json(rhs_source);
+        
+        let lhs_nodes = build_syntax(&arena, &lhs_tree, lhs_source, &config);
+        let rhs_nodes = build_syntax(&arena, &rhs_tree, rhs_source, &config);
+        
+        let (lhs_ranges, rhs_ranges) = diff_syntax_roots(
+            &lhs_nodes,
+            &rhs_nodes,
+            &DiffOptions::default(),
+        ).unwrap();
+        
+        // Should detect the nested change
+        assert!(!lhs_ranges.is_empty(), "Expected changes on LHS");
+        assert!(!rhs_ranges.is_empty(), "Expected changes on RHS");
+    }
+
+    #[test]
+    fn test_diff_syntax_high_level_api() {
+        let config = DefaultConfig::default();
+        
+        let lhs_source = r#"{"key": "old"}"#;
+        let rhs_source = r#"{"key": "new"}"#;
+        
+        let lhs_tree = parse_json(lhs_source);
+        let rhs_tree = parse_json(rhs_source);
+        
+        let (lhs_ranges, rhs_ranges) = diff_syntax(
+            &lhs_tree,
+            lhs_source,
+            &rhs_tree,
+            rhs_source,
+            &config,
+            &DiffOptions::default(),
+        ).unwrap();
+        
+        assert!(!lhs_ranges.is_empty(), "Expected changes on LHS");
+        assert!(!rhs_ranges.is_empty(), "Expected changes on RHS");
+    }
+
+    #[test]
+    fn test_diff_syntax_identical() {
+        let config = DefaultConfig::default();
+        let source = r#"[1, 2, 3]"#;
+        
+        let tree = parse_json(source);
+        
+        let (lhs_ranges, rhs_ranges) = diff_syntax(
+            &tree,
+            source,
+            &tree,
+            source,
+            &config,
+            &DiffOptions::default(),
+        ).unwrap();
+        
+        assert!(lhs_ranges.is_empty(), "Expected no changes for identical input");
+        assert!(rhs_ranges.is_empty(), "Expected no changes for identical input");
+    }
+
+    #[test]
+    fn test_empty_vs_nonempty() {
+        let arena = Bump::new();
+        
+        let lhs: Vec<&Syntax> = vec![];
+        let rhs = vec![make_atom(&arena, "x", 0)];
+        
+        let (lhs_ranges, rhs_ranges) = diff_syntax_roots(
+            &lhs,
+            &rhs,
+            &DiffOptions::default(),
+        ).unwrap();
+        
+        assert!(lhs_ranges.is_empty(), "Expected no changes on empty LHS");
+        assert_eq!(rhs_ranges.len(), 1, "Expected one addition on RHS");
+    }
+
+    #[test]
+    fn test_nonempty_vs_empty() {
+        let arena = Bump::new();
+        
+        let lhs = vec![make_atom(&arena, "x", 0)];
+        let rhs: Vec<&Syntax> = vec![];
+        
+        let (lhs_ranges, rhs_ranges) = diff_syntax_roots(
+            &lhs,
+            &rhs,
+            &DiffOptions::default(),
+        ).unwrap();
+        
+        assert_eq!(lhs_ranges.len(), 1, "Expected one removal on LHS");
+        assert!(rhs_ranges.is_empty(), "Expected no changes on empty RHS");
+    }
+
+    #[test]
+    fn test_both_empty() {
+        let lhs: Vec<&Syntax> = vec![];
+        let rhs: Vec<&Syntax> = vec![];
+        
+        let (lhs_ranges, rhs_ranges) = diff_syntax_roots(
+            &lhs,
+            &rhs,
+            &DiffOptions::default(),
+        ).unwrap();
+        
+        assert!(lhs_ranges.is_empty());
+        assert!(rhs_ranges.is_empty());
+    }
+
+    #[test]
+    fn test_graph_limit_exceeded() {
+        let arena = Bump::new();
+        
+        let lhs = make_atom(&arena, "a", 0);
+        let rhs = make_atom(&arena, "b", 0);
+        
+        let options = DiffOptions {
+            graph_limit: 1,
+            ..Default::default()
+        };
+        
+        let result = diff_syntax_roots(&[lhs], &[rhs], &options);
+        
+        assert!(result.is_err(), "Expected graph limit error with limit of 1");
+    }
+
+    #[test]
+    fn test_diff_error_display() {
+        let err = DiffError::ExceededGraphLimit;
+        let msg = format!("{}", err);
+        assert!(msg.contains("limit"), "Error message should mention limit");
+    }
+
+    #[test]
+    fn test_syntax_change_kind() {
+        assert_eq!(SyntaxChangeKind::Novel, SyntaxChangeKind::Novel);
+        assert_ne!(SyntaxChangeKind::Novel, SyntaxChangeKind::Unchanged);
+    }
+
+    #[test]
+    fn test_deep_nesting() {
+        let config = DefaultConfig::default();
+        
+        let lhs_source = r#"{"a": {"b": {"c": {"d": 1}}}}"#;
+        let rhs_source = r#"{"a": {"b": {"c": {"d": 2}}}}"#;
+        
+        let lhs_tree = parse_json(lhs_source);
+        let rhs_tree = parse_json(rhs_source);
+        
+        let (lhs_ranges, rhs_ranges) = diff_syntax(
+            &lhs_tree,
+            lhs_source,
+            &rhs_tree,
+            rhs_source,
+            &config,
+            &DiffOptions::default(),
+        ).unwrap();
+        
+        assert!(!lhs_ranges.is_empty(), "Expected changes detected in deeply nested structure");
+        assert!(!rhs_ranges.is_empty(), "Expected changes detected in deeply nested structure");
+    }
+
+    #[test]
+    fn test_multiple_changes() {
+        let config = DefaultConfig::default();
+        
+        let lhs_source = r#"{"a": 1, "b": 2, "c": 3}"#;
+        let rhs_source = r#"{"a": 9, "b": 2, "c": 8}"#;
+        
+        let lhs_tree = parse_json(lhs_source);
+        let rhs_tree = parse_json(rhs_source);
+        
+        let (lhs_ranges, rhs_ranges) = diff_syntax(
+            &lhs_tree,
+            lhs_source,
+            &rhs_tree,
+            rhs_source,
+            &config,
+            &DiffOptions::default(),
+        ).unwrap();
+        
+        assert!(!lhs_ranges.is_empty(), "Expected changes on LHS");
+        assert!(!rhs_ranges.is_empty(), "Expected changes on RHS");
+    }
+}
+
+#[cfg(test)]
+mod integration_tests {
+    use super::*;
+    use crate::LanguageDiffConfig;
+
+    fn parse_rust(source: &str) -> tree_sitter::Tree {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .expect("Error loading Rust grammar");
+        parser.parse(source, None).expect("Failed to parse Rust")
+    }
+
+    fn parse_python(source: &str) -> tree_sitter::Tree {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_python::LANGUAGE.into())
+            .expect("Error loading Python grammar");
+        parser.parse(source, None).expect("Failed to parse Python")
+    }
+
+    fn parse_typescript(source: &str) -> tree_sitter::Tree {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into())
+            .expect("Error loading TypeScript grammar");
+        parser.parse(source, None).expect("Failed to parse TypeScript")
+    }
+
+    fn rust_config() -> LanguageDiffConfig {
+        LanguageDiffConfig::new(vec![
+            ("{".to_string(), "}".to_string()),
+            ("[".to_string(), "]".to_string()),
+            ("(".to_string(), ")".to_string()),
+            ("<".to_string(), ">".to_string()),
+        ])
+    }
+
+    fn python_config() -> LanguageDiffConfig {
+        LanguageDiffConfig::new(vec![
+            ("{".to_string(), "}".to_string()),
+            ("[".to_string(), "]".to_string()),
+            ("(".to_string(), ")".to_string()),
+        ])
+    }
+
+    fn typescript_config() -> LanguageDiffConfig {
+        LanguageDiffConfig::new(vec![
+            ("{".to_string(), "}".to_string()),
+            ("[".to_string(), "]".to_string()),
+            ("(".to_string(), ")".to_string()),
+            ("<".to_string(), ">".to_string()),
+        ])
+    }
+
+    #[test]
+    fn test_rust_function_body_change() {
+        let old_source = r#"fn main() {
+    let x = 1;
+    println!("{}", x);
+}"#;
+        let new_source = r#"fn main() {
+    let x = 2;
+    println!("{}", x);
+}"#;
+
+        let old_tree = parse_rust(old_source);
+        let new_tree = parse_rust(new_source);
+        let config = rust_config();
+
+        let (old_ranges, new_ranges) = diff_syntax(
+            &old_tree,
+            old_source,
+            &new_tree,
+            new_source,
+            &config,
+            &DiffOptions::default(),
+        )
+        .unwrap();
+
+        assert!(!old_ranges.is_empty(), "Expected changes in old source");
+        assert!(!new_ranges.is_empty(), "Expected changes in new source");
+
+        let old_changed = &old_source[old_ranges[0].clone()];
+        let new_changed = &new_source[new_ranges[0].clone()];
+        assert!(
+            old_changed.contains("1") || old_source.contains("1"),
+            "Old change should involve '1'"
+        );
+        assert!(
+            new_changed.contains("2") || new_source.contains("2"),
+            "New change should involve '2'"
+        );
+    }
+
+    #[test]
+    fn test_rust_identical_code() {
+        let source = r#"fn hello(name: &str) -> String {
+    format!("Hello, {}!", name)
+}"#;
+
+        let tree = parse_rust(source);
+        let config = rust_config();
+
+        let (old_ranges, new_ranges) = diff_syntax(
+            &tree,
+            source,
+            &tree,
+            source,
+            &config,
+            &DiffOptions::default(),
+        )
+        .unwrap();
+
+        assert!(old_ranges.is_empty(), "Expected no changes for identical Rust code");
+        assert!(new_ranges.is_empty(), "Expected no changes for identical Rust code");
+    }
+
+    #[test]
+    fn test_rust_added_function() {
+        let old_source = r#"fn one() {}"#;
+        let new_source = r#"fn one() {}
+fn two() {}"#;
+
+        let old_tree = parse_rust(old_source);
+        let new_tree = parse_rust(new_source);
+        let config = rust_config();
+
+        let (old_ranges, new_ranges) = diff_syntax(
+            &old_tree,
+            old_source,
+            &new_tree,
+            new_source,
+            &config,
+            &DiffOptions::default(),
+        )
+        .unwrap();
+
+        assert!(
+            old_ranges.is_empty(),
+            "Expected no changes on old side when adding function"
+        );
+        assert!(!new_ranges.is_empty(), "Expected additions on new side");
+    }
+
+    #[test]
+    fn test_rust_struct_field_change() {
+        let old_source = r#"struct Point {
+    x: i32,
+    y: i32,
+}"#;
+        let new_source = r#"struct Point {
+    x: f64,
+    y: f64,
+}"#;
+
+        let old_tree = parse_rust(old_source);
+        let new_tree = parse_rust(new_source);
+        let config = rust_config();
+
+        let (old_ranges, new_ranges) = diff_syntax(
+            &old_tree,
+            old_source,
+            &new_tree,
+            new_source,
+            &config,
+            &DiffOptions::default(),
+        )
+        .unwrap();
+
+        assert!(!old_ranges.is_empty(), "Expected changes for type modification");
+        assert!(!new_ranges.is_empty(), "Expected changes for type modification");
+    }
+
+    #[test]
+    fn test_python_function_body_change() {
+        let old_source = r#"def greet(name):
+    return "Hello, " + name"#;
+        let new_source = r#"def greet(name):
+    return "Hi, " + name"#;
+
+        let old_tree = parse_python(old_source);
+        let new_tree = parse_python(new_source);
+        let config = python_config();
+
+        let (old_ranges, new_ranges) = diff_syntax(
+            &old_tree,
+            old_source,
+            &new_tree,
+            new_source,
+            &config,
+            &DiffOptions::default(),
+        )
+        .unwrap();
+
+        assert!(!old_ranges.is_empty(), "Expected changes in Python function");
+        assert!(!new_ranges.is_empty(), "Expected changes in Python function");
+    }
+
+    #[test]
+    fn test_python_identical_code() {
+        let source = r#"def add(a, b):
+    return a + b"#;
+
+        let tree = parse_python(source);
+        let config = python_config();
+
+        let (old_ranges, new_ranges) = diff_syntax(
+            &tree,
+            source,
+            &tree,
+            source,
+            &config,
+            &DiffOptions::default(),
+        )
+        .unwrap();
+
+        assert!(old_ranges.is_empty(), "Expected no changes for identical Python code");
+        assert!(new_ranges.is_empty(), "Expected no changes for identical Python code");
+    }
+
+    #[test]
+    fn test_python_class_method_change() {
+        let old_source = r#"class Calculator:
+    def add(self, a, b):
+        return a + b"#;
+        let new_source = r#"class Calculator:
+    def add(self, a, b):
+        return a - b"#;
+
+        let old_tree = parse_python(old_source);
+        let new_tree = parse_python(new_source);
+        let config = python_config();
+
+        let (old_ranges, new_ranges) = diff_syntax(
+            &old_tree,
+            old_source,
+            &new_tree,
+            new_source,
+            &config,
+            &DiffOptions::default(),
+        )
+        .unwrap();
+
+        assert!(!old_ranges.is_empty(), "Expected changes in class method");
+        assert!(!new_ranges.is_empty(), "Expected changes in class method");
+    }
+
+    #[test]
+    fn test_typescript_interface_change() {
+        let old_source = r#"interface User {
+    name: string;
+    age: number;
+}"#;
+        let new_source = r#"interface User {
+    name: string;
+    age: number;
+    email: string;
+}"#;
+
+        let old_tree = parse_typescript(old_source);
+        let new_tree = parse_typescript(new_source);
+        let config = typescript_config();
+
+        let (old_ranges, new_ranges) = diff_syntax(
+            &old_tree,
+            old_source,
+            &new_tree,
+            new_source,
+            &config,
+            &DiffOptions::default(),
+        )
+        .unwrap();
+
+        assert!(old_ranges.is_empty(), "Expected no changes on old side when adding field");
+        assert!(!new_ranges.is_empty(), "Expected additions for new field");
+    }
+
+    #[test]
+    fn test_typescript_identical_code() {
+        let source = r#"function greet(name: string): string {
+    return `Hello, ${name}!`;
+}"#;
+
+        let tree = parse_typescript(source);
+        let config = typescript_config();
+
+        let (old_ranges, new_ranges) = diff_syntax(
+            &tree,
+            source,
+            &tree,
+            source,
+            &config,
+            &DiffOptions::default(),
+        )
+        .unwrap();
+
+        assert!(
+            old_ranges.is_empty(),
+            "Expected no changes for identical TypeScript code"
+        );
+        assert!(
+            new_ranges.is_empty(),
+            "Expected no changes for identical TypeScript code"
+        );
+    }
+
+    #[test]
+    fn test_typescript_function_signature_change() {
+        let old_source = r#"function process(data: string): void {
+    console.log(data);
+}"#;
+        let new_source = r#"function process(data: number): void {
+    console.log(data);
+}"#;
+
+        let old_tree = parse_typescript(old_source);
+        let new_tree = parse_typescript(new_source);
+        let config = typescript_config();
+
+        let (old_ranges, new_ranges) = diff_syntax(
+            &old_tree,
+            old_source,
+            &new_tree,
+            new_source,
+            &config,
+            &DiffOptions::default(),
+        )
+        .unwrap();
+
+        assert!(!old_ranges.is_empty(), "Expected changes for type change");
+        assert!(!new_ranges.is_empty(), "Expected changes for type change");
+    }
+
+    #[test]
+    fn test_default_config_vs_language_config() {
+        let source = r#"{"key": "value"}"#;
+
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_json::LANGUAGE.into())
+            .expect("Error loading JSON grammar");
+        let tree = parser.parse(source, None).expect("Failed to parse");
+
+        let default_config = DefaultConfig::default();
+        let language_config = LanguageDiffConfig::new(vec![
+            ("{".to_string(), "}".to_string()),
+            ("[".to_string(), "]".to_string()),
+        ]);
+
+        let (default_lhs, default_rhs) = diff_syntax(
+            &tree,
+            source,
+            &tree,
+            source,
+            &default_config,
+            &DiffOptions::default(),
+        )
+        .unwrap();
+
+        let (lang_lhs, lang_rhs) = diff_syntax(
+            &tree,
+            source,
+            &tree,
+            source,
+            &language_config,
+            &DiffOptions::default(),
+        )
+        .unwrap();
+
+        assert_eq!(default_lhs, lang_lhs, "Both configs should produce same result for identical input");
+        assert_eq!(default_rhs, lang_rhs, "Both configs should produce same result for identical input");
+    }
+
+    #[test]
+    fn test_language_config_delimiter_recognition() {
+        let old_source = r#"fn test() {
+    let arr = [1, 2, 3];
+}"#;
+        let new_source = r#"fn test() {
+    let arr = [1, 2, 3, 4];
+}"#;
+
+        let old_tree = parse_rust(old_source);
+        let new_tree = parse_rust(new_source);
+
+        let config_with_brackets = LanguageDiffConfig::new(vec![
+            ("{".to_string(), "}".to_string()),
+            ("[".to_string(), "]".to_string()),
+            ("(".to_string(), ")".to_string()),
+        ]);
+
+        let config_without_brackets = LanguageDiffConfig::new(vec![
+            ("{".to_string(), "}".to_string()),
+            ("(".to_string(), ")".to_string()),
+        ]);
+
+        let (with_lhs, with_rhs) = diff_syntax(
+            &old_tree,
+            old_source,
+            &new_tree,
+            new_source,
+            &config_with_brackets,
+            &DiffOptions::default(),
+        )
+        .unwrap();
+
+        let (without_lhs, without_rhs) = diff_syntax(
+            &old_tree,
+            old_source,
+            &new_tree,
+            new_source,
+            &config_without_brackets,
+            &DiffOptions::default(),
+        )
+        .unwrap();
+
+        assert!(!with_lhs.is_empty() || !with_rhs.is_empty(), "Both configs should detect changes");
+        assert!(
+            !without_lhs.is_empty() || !without_rhs.is_empty(),
+            "Both configs should detect changes"
+        );
+    }
+
+    #[test]
+    fn test_comment_handling_across_languages() {
+        let rust_old = "// old comment\nfn main() {}";
+        let rust_new = "// new comment\nfn main() {}";
+
+        let old_tree = parse_rust(rust_old);
+        let new_tree = parse_rust(rust_new);
+        let config = rust_config();
+
+        let (old_ranges, new_ranges) = diff_syntax(
+            &old_tree,
+            rust_old,
+            &new_tree,
+            rust_new,
+            &config,
+            &DiffOptions::default(),
+        )
+        .unwrap();
+
+        assert!(
+            !old_ranges.is_empty() || !new_ranges.is_empty(),
+            "Should detect comment change"
+        );
+    }
+
+    #[test]
+    fn test_string_literal_handling() {
+        let old_source = r#"let msg = "hello";"#;
+        let new_source = r#"let msg = "world";"#;
+
+        let old_tree = parse_rust(old_source);
+        let new_tree = parse_rust(new_source);
+        let config = rust_config();
+
+        let (old_ranges, new_ranges) = diff_syntax(
+            &old_tree,
+            old_source,
+            &new_tree,
+            new_source,
+            &config,
+            &DiffOptions::default(),
+        )
+        .unwrap();
+
+        assert!(!old_ranges.is_empty(), "Should detect string change");
+        assert!(!new_ranges.is_empty(), "Should detect string change");
+    }
+
+    #[test]
+    fn test_nested_structure_preservation() {
+        let old_source = r#"fn outer() {
+    fn inner() {
+        let x = 1;
+    }
+}"#;
+        let new_source = r#"fn outer() {
+    fn inner() {
+        let x = 2;
+    }
+}"#;
+
+        let old_tree = parse_rust(old_source);
+        let new_tree = parse_rust(new_source);
+        let config = rust_config();
+
+        let (old_ranges, new_ranges) = diff_syntax(
+            &old_tree,
+            old_source,
+            &new_tree,
+            new_source,
+            &config,
+            &DiffOptions::default(),
+        )
+        .unwrap();
+
+        assert!(!old_ranges.is_empty(), "Should detect nested change");
+        assert!(!new_ranges.is_empty(), "Should detect nested change");
+        assert!(
+            old_ranges.len() <= 2,
+            "Should have minimal changed ranges, not explode entire structure"
+        );
+    }
+
+    #[test]
+    fn test_whitespace_only_changes() {
+        let old_source = "fn main() { let x = 1; }";
+        let new_source = "fn main() {\n    let x = 1;\n}";
+
+        let old_tree = parse_rust(old_source);
+        let new_tree = parse_rust(new_source);
+        let config = rust_config();
+
+        let result = diff_syntax(
+            &old_tree,
+            old_source,
+            &new_tree,
+            new_source,
+            &config,
+            &DiffOptions::default(),
+        );
+
+        assert!(result.is_ok(), "Should handle whitespace-only changes gracefully");
+    }
+
+    #[test]
+    fn test_large_file_graph_limit() {
+        let mut large_source = String::new();
+        for i in 0..100 {
+            large_source.push_str(&format!("fn func_{}() {{ let x = {}; }}\n", i, i));
+        }
+
+        let tree = parse_rust(&large_source);
+        let config = rust_config();
+
+        let options = DiffOptions {
+            graph_limit: 100,
+            ..Default::default()
+        };
+
+        let result = diff_syntax(&tree, &large_source, &tree, &large_source, &config, &options);
+
+        assert!(result.is_ok(), "Identical large files should not exceed graph limit");
+    }
+
+    #[test]
+    fn test_completely_different_files() {
+        let old_source = r#"fn old_function() {
+    println!("old");
+}"#;
+        let new_source = r#"struct NewStruct {
+    field: i32,
+}"#;
+
+        let old_tree = parse_rust(old_source);
+        let new_tree = parse_rust(new_source);
+        let config = rust_config();
+
+        let (old_ranges, new_ranges) = diff_syntax(
+            &old_tree,
+            old_source,
+            &new_tree,
+            new_source,
+            &config,
+            &DiffOptions::default(),
+        )
+        .unwrap();
+
+        assert!(!old_ranges.is_empty(), "Should detect all old content as changed");
+        assert!(!new_ranges.is_empty(), "Should detect all new content as novel");
+    }
+}

--- a/crates/ast_diff/src/builder.rs
+++ b/crates/ast_diff/src/builder.rs
@@ -1,0 +1,402 @@
+//! Build `Syntax` trees from tree-sitter parse trees.
+
+use bumpalo::Bump;
+use tree_sitter::{Tree, TreeCursor};
+
+use crate::config::SyntaxDiffConfig;
+use crate::syntax::{AtomKind, StringKind, Syntax};
+
+pub fn build_syntax<'a>(
+    arena: &'a Bump,
+    tree: &Tree,
+    source: &str,
+    config: &dyn SyntaxDiffConfig,
+) -> Vec<&'a Syntax<'a>> {
+    let root = tree.root_node();
+
+    log::trace!(
+        "Building syntax tree from root node: kind={}, children={}, range={:?}",
+        root.kind(),
+        root.child_count(),
+        root.byte_range()
+    );
+
+    let mut cursor = root.walk();
+    cursor.goto_first_child();
+
+    let result = all_syntaxes_from_cursor(arena, source, &mut cursor, config);
+
+    log::trace!("Built {} root-level syntax nodes", result.len());
+
+    result
+}
+
+fn all_syntaxes_from_cursor<'a>(
+    arena: &'a Bump,
+    source: &str,
+    cursor: &mut TreeCursor,
+    config: &dyn SyntaxDiffConfig,
+) -> Vec<&'a Syntax<'a>> {
+    let mut nodes = Vec::new();
+
+    loop {
+        if let Some(syntax) = syntax_from_cursor(arena, source, cursor, config) {
+            nodes.push(syntax);
+        }
+
+        if !cursor.goto_next_sibling() {
+            break;
+        }
+    }
+
+    nodes
+}
+
+fn syntax_from_cursor<'a>(
+    arena: &'a Bump,
+    source: &str,
+    cursor: &mut TreeCursor,
+    config: &dyn SyntaxDiffConfig,
+) -> Option<&'a Syntax<'a>> {
+    let node = cursor.node();
+
+    if node.byte_range().is_empty() {
+        return None;
+    }
+
+    let node_kind = node.kind();
+    let child_count = node.child_count();
+
+    if config.is_atom_node(node_kind) {
+        log::trace!(
+            "Node '{}' forced to atom by config (children={})",
+            node_kind,
+            child_count
+        );
+        return Some(atom_from_cursor(arena, source, cursor, config));
+    }
+
+    if config.is_comment(node_kind) || config.is_string(node_kind) {
+        log::trace!(
+            "Node '{}' treated as atom (comment/string heuristic, children={})",
+            node_kind,
+            child_count
+        );
+        return Some(atom_from_cursor(arena, source, cursor, config));
+    }
+
+    if child_count > 0 {
+        return Some(list_from_cursor(arena, source, cursor, config));
+    }
+
+    Some(atom_from_cursor(arena, source, cursor, config))
+}
+
+fn atom_from_cursor<'a>(
+    arena: &'a Bump,
+    source: &str,
+    cursor: &mut TreeCursor,
+    config: &dyn SyntaxDiffConfig,
+) -> &'a Syntax<'a> {
+    let node = cursor.node();
+    let byte_range = node.byte_range();
+    let content = source.get(byte_range.clone()).unwrap_or("").to_string();
+    let kind = determine_atom_kind(node.kind(), config);
+
+    Syntax::new_atom(arena, byte_range, content, kind)
+}
+
+fn determine_atom_kind(node_kind: &str, config: &dyn SyntaxDiffConfig) -> AtomKind {
+    if node_kind == "ERROR" {
+        return AtomKind::TreeSitterError;
+    }
+
+    if config.is_comment(node_kind) {
+        return AtomKind::Comment;
+    }
+
+    if config.is_string(node_kind) {
+        return AtomKind::String(StringKind::StringLiteral);
+    }
+
+    if config.is_keyword(node_kind) {
+        return AtomKind::Keyword;
+    }
+
+    if config.is_type(node_kind) {
+        return AtomKind::Type;
+    }
+
+    AtomKind::Normal
+}
+
+fn child_tokens<'a>(source: &'a str, cursor: &mut TreeCursor) -> Vec<Option<&'a str>> {
+    let mut tokens = Vec::new();
+    let node = cursor.node();
+
+    let mut child_cursor = node.walk();
+    if child_cursor.goto_first_child() {
+        loop {
+            let child = child_cursor.node();
+            let text = source.get(child.byte_range());
+            tokens.push(text);
+
+            if !child_cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+
+    tokens
+}
+
+fn find_delim_positions(
+    source: &str,
+    cursor: &mut TreeCursor,
+    config: &dyn SyntaxDiffConfig,
+) -> Option<(usize, usize)> {
+    let tokens = child_tokens(source, cursor);
+
+    for (i, token) in tokens.iter().enumerate() {
+        if let Some(token_text) = token {
+            if let Some(close_delim) = config.get_matching_delimiter(token_text) {
+                for (j, close_token) in tokens.iter().enumerate().skip(i + 1) {
+                    if let Some(close_text) = close_token {
+                        if *close_text == close_delim {
+                            return Some((i, j));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    None
+}
+
+fn list_from_cursor<'a>(
+    arena: &'a Bump,
+    source: &str,
+    cursor: &mut TreeCursor,
+    config: &dyn SyntaxDiffConfig,
+) -> &'a Syntax<'a> {
+    let root_node = cursor.node();
+    let root_range = root_node.byte_range();
+
+    let outer_open_content = "";
+    let outer_open_range = root_range.start..root_range.start;
+    let outer_close_content = "";
+    let outer_close_range = root_range.end..root_range.end;
+
+    let (open_idx, close_idx) = match find_delim_positions(source, cursor, config) {
+        Some((i, j)) => (i as isize, j as isize),
+        None => (-1, root_node.child_count() as isize),
+    };
+
+    let mut inner_open_content = outer_open_content;
+    let mut inner_open_range = outer_open_range.clone();
+    let mut inner_close_content = outer_close_content;
+    let mut inner_close_range = outer_close_range.clone();
+
+    let mut before_delim = Vec::new();
+    let mut between_delim = Vec::new();
+    let mut after_delim = Vec::new();
+
+    cursor.goto_first_child();
+    let mut node_i: isize = 0;
+
+    loop {
+        let child_node = cursor.node();
+
+        if node_i < open_idx {
+            if let Some(syntax) = syntax_from_cursor(arena, source, cursor, config) {
+                before_delim.push(syntax);
+            }
+        } else if node_i == open_idx {
+            let range = child_node.byte_range();
+            inner_open_content = source.get(range.clone()).unwrap_or("");
+            inner_open_range = range;
+        } else if node_i < close_idx {
+            if let Some(syntax) = syntax_from_cursor(arena, source, cursor, config) {
+                between_delim.push(syntax);
+            }
+        } else if node_i == close_idx {
+            let range = child_node.byte_range();
+            inner_close_content = source.get(range.clone()).unwrap_or("");
+            inner_close_range = range;
+        } else {
+            if let Some(syntax) = syntax_from_cursor(arena, source, cursor, config) {
+                after_delim.push(syntax);
+            }
+        }
+
+        if !cursor.goto_next_sibling() {
+            break;
+        }
+        node_i += 1;
+    }
+    cursor.goto_parent();
+
+    let inner_list = Syntax::new_list(
+        arena,
+        inner_open_content,
+        inner_open_range,
+        between_delim,
+        inner_close_content,
+        inner_close_range,
+    );
+
+    if before_delim.is_empty() && after_delim.is_empty() {
+        inner_list
+    } else {
+        let mut children = before_delim;
+        children.push(inner_list);
+        children.append(&mut after_delim);
+
+        Syntax::new_list(
+            arena,
+            outer_open_content,
+            outer_open_range,
+            children,
+            outer_close_content,
+            outer_close_range,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::DefaultConfig;
+
+    fn parse_json(source: &str) -> Tree {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_json::LANGUAGE.into())
+            .expect("Error loading JSON grammar");
+        parser.parse(source, None).expect("Failed to parse")
+    }
+
+    #[test]
+    fn test_build_simple_atom() {
+        let arena = Bump::new();
+        let source = "42";
+        let tree = parse_json(source);
+        let config = DefaultConfig::default();
+
+        let roots = build_syntax(&arena, &tree, source, &config);
+
+        assert_eq!(roots.len(), 1);
+        match roots[0] {
+            Syntax::Atom { content, .. } => {
+                assert_eq!(content, "42");
+            }
+            _ => panic!("Expected atom"),
+        }
+    }
+
+    #[test]
+    fn test_build_string_literal() {
+        let arena = Bump::new();
+        let source = r#""hello""#;
+        let tree = parse_json(source);
+        let config = DefaultConfig::default();
+
+        let roots = build_syntax(&arena, &tree, source, &config);
+
+        assert_eq!(roots.len(), 1);
+        match roots[0] {
+            Syntax::Atom { content, kind, .. } => {
+                assert_eq!(content, r#""hello""#);
+                assert!(matches!(kind, AtomKind::String(_)));
+            }
+            _ => panic!("Expected atom"),
+        }
+    }
+
+    #[test]
+    fn test_build_array() {
+        let arena = Bump::new();
+        let source = "[1, 2, 3]";
+        let tree = parse_json(source);
+        let config = DefaultConfig::default();
+
+        let roots = build_syntax(&arena, &tree, source, &config);
+
+        assert_eq!(roots.len(), 1);
+        match roots[0] {
+            Syntax::List {
+                open_content,
+                close_content,
+                children,
+                ..
+            } => {
+                assert_eq!(open_content, "[");
+                assert_eq!(close_content, "]");
+                // Should have 3 numbers (commas might be separate nodes depending on grammar)
+                assert!(!children.is_empty());
+            }
+            _ => panic!("Expected list"),
+        }
+    }
+
+    #[test]
+    fn test_build_object() {
+        let arena = Bump::new();
+        let source = r#"{"key": "value"}"#;
+        let tree = parse_json(source);
+        let config = DefaultConfig::default();
+
+        let roots = build_syntax(&arena, &tree, source, &config);
+
+        assert_eq!(roots.len(), 1);
+        match roots[0] {
+            Syntax::List {
+                open_content,
+                close_content,
+                ..
+            } => {
+                assert_eq!(open_content, "{");
+                assert_eq!(close_content, "}");
+            }
+            _ => panic!("Expected list"),
+        }
+    }
+
+    #[test]
+    fn test_build_nested_structure() {
+        let arena = Bump::new();
+        let source = r#"{"items": [1, 2]}"#;
+        let tree = parse_json(source);
+        let config = DefaultConfig::default();
+
+        let roots = build_syntax(&arena, &tree, source, &config);
+
+        assert_eq!(roots.len(), 1);
+
+        fn count_nodes(node: &Syntax) -> usize {
+            match node {
+                Syntax::Atom { .. } => 1,
+                Syntax::List { children, .. } => {
+                    1 + children.iter().map(|c| count_nodes(c)).sum::<usize>()
+                }
+            }
+        }
+
+        // Should have multiple nodes in the tree
+        let total = count_nodes(roots[0]);
+        assert!(total > 1, "Expected nested structure, got {} nodes", total);
+    }
+
+    #[test]
+    fn test_empty_source() {
+        let arena = Bump::new();
+        let source = "";
+        let tree = parse_json(source);
+        let config = DefaultConfig::default();
+
+        let roots = build_syntax(&arena, &tree, source, &config);
+
+        assert!(roots.is_empty());
+    }
+}

--- a/crates/ast_diff/src/changes.rs
+++ b/crates/ast_diff/src/changes.rs
@@ -1,0 +1,89 @@
+use crate::{
+    hash::DftHashMap,
+    syntax::{Syntax, SyntaxId},
+};
+
+#[derive(PartialEq, Eq, Clone, Copy)]
+pub enum ChangeKind<'a> {
+    Unchanged(&'a Syntax<'a>),
+    ReplacedComment(&'a Syntax<'a>, &'a Syntax<'a>),
+    ReplacedString(&'a Syntax<'a>, &'a Syntax<'a>),
+    Novel,
+}
+
+impl std::fmt::Debug for ChangeKind<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let desc = match self {
+            ChangeKind::Unchanged(node) => format!("Unchanged(ID: {})", node.id()),
+            ChangeKind::ReplacedComment(lhs_node, rhs_node)
+            | ChangeKind::ReplacedString(lhs_node, rhs_node) => {
+                let change_kind = if matches!(self, ChangeKind::ReplacedComment(_, _)) {
+                    "ReplacedComment"
+                } else {
+                    "ReplacedString"
+                };
+
+                format!(
+                    "{}(lhs ID: {}, rhs ID: {})",
+                    change_kind,
+                    lhs_node.id(),
+                    rhs_node.id()
+                )
+            }
+            ChangeKind::Novel => "Novel".to_owned(),
+        };
+        f.write_str(&desc)
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct ChangeMap<'a> {
+    changes: DftHashMap<SyntaxId, ChangeKind<'a>>,
+}
+
+impl<'a> ChangeMap<'a> {
+    pub fn insert(&mut self, node: &'a Syntax<'a>, ck: ChangeKind<'a>) {
+        self.changes.insert(node.id(), ck);
+    }
+
+    pub fn get(&self, node: &Syntax<'a>) -> Option<ChangeKind<'a>> {
+        self.changes.get(&node.id()).copied()
+    }
+}
+
+pub fn insert_deep_unchanged<'a>(
+    node: &'a Syntax<'a>,
+    opposite_node: &'a Syntax<'a>,
+    change_map: &mut ChangeMap<'a>,
+) {
+    change_map.insert(node, ChangeKind::Unchanged(opposite_node));
+
+    match (node, opposite_node) {
+        (
+            Syntax::List {
+                children: node_children,
+                ..
+            },
+            Syntax::List {
+                children: opposite_children,
+                ..
+            },
+        ) => {
+            for (child, opposite_child) in node_children.iter().zip(opposite_children) {
+                insert_deep_unchanged(child, opposite_child, change_map);
+            }
+        }
+        (Syntax::Atom { .. }, Syntax::Atom { .. }) => {}
+        _ => unreachable!("Unchanged nodes should be both lists, or both atoms"),
+    }
+}
+
+pub fn insert_deep_novel<'a>(node: &'a Syntax<'a>, change_map: &mut ChangeMap<'a>) {
+    change_map.insert(node, ChangeKind::Novel);
+
+    if let Syntax::List { children, .. } = node {
+        for child in children.iter() {
+            insert_deep_novel(child, change_map);
+        }
+    }
+}

--- a/crates/ast_diff/src/config.rs
+++ b/crates/ast_diff/src/config.rs
@@ -238,8 +238,8 @@ mod tests {
 
     #[test]
     fn test_language_diff_config_with_additional_atoms() {
-        let config = LanguageDiffConfig::new(vec![])
-            .with_additional_atoms(["custom_node".to_string()]);
+        let config =
+            LanguageDiffConfig::new(vec![]).with_additional_atoms(["custom_node".to_string()]);
 
         assert!(config.is_atom_node("custom_node"));
         // Should still have default atoms
@@ -248,8 +248,7 @@ mod tests {
 
     #[test]
     fn test_language_diff_config_with_custom_atoms() {
-        let config = LanguageDiffConfig::new(vec![])
-            .with_atom_nodes(["only_this".to_string()]);
+        let config = LanguageDiffConfig::new(vec![]).with_atom_nodes(["only_this".to_string()]);
 
         assert!(config.is_atom_node("only_this"));
         // Should NOT have default atoms

--- a/crates/ast_diff/src/config.rs
+++ b/crates/ast_diff/src/config.rs
@@ -1,0 +1,453 @@
+//! Configuration for syntax-aware diffing.
+
+use std::borrow::Cow;
+use std::collections::HashSet;
+
+/// Configuration for syntax-aware diffing of a specific language.
+pub trait SyntaxDiffConfig {
+    /// Returns true if the given node kind should be treated as an atom
+    /// (not have its children diffed individually).
+    fn is_atom_node(&self, node_kind: &str) -> bool;
+
+    /// Returns true if the given text is a delimiter (either open or close).
+    fn is_delimiter(&self, text: &str) -> bool;
+
+    /// Returns the matching close delimiter for an open delimiter.
+    ///
+    /// Returns `None` if the given string is not an open delimiter.
+    fn get_matching_delimiter<'a>(&'a self, open: &str) -> Option<&'a str>;
+
+    /// Returns true if the text is an open delimiter.
+    fn is_open_delimiter(&self, text: &str) -> bool;
+
+    /// Returns true if the text is a close delimiter.
+    fn is_close_delimiter(&self, text: &str) -> bool;
+
+    fn is_comment(&self, node_kind: &str) -> bool {
+        let kind_lower = node_kind.to_lowercase();
+        kind_lower.contains("comment")
+    }
+
+    fn is_string(&self, node_kind: &str) -> bool {
+        let kind_lower = node_kind.to_lowercase();
+        kind_lower.contains("string")
+    }
+
+    fn is_keyword(&self, node_kind: &str) -> bool {
+        let _ = node_kind;
+        false
+    }
+
+    fn is_type(&self, node_kind: &str) -> bool {
+        let kind_lower = node_kind.to_lowercase();
+        kind_lower.contains("type") && !kind_lower.contains("identifier")
+    }
+}
+
+/// Default configuration that works reasonably well for most languages.
+#[derive(Debug, Clone)]
+pub struct DefaultConfig {
+    atom_nodes: HashSet<&'static str>,
+    delimiter_tokens: Vec<(&'static str, &'static str)>,
+}
+
+impl Default for DefaultConfig {
+    fn default() -> Self {
+        let atom_nodes: HashSet<&'static str> = [
+            "string",
+            "string_literal",
+            "string_content",
+            "raw_string_literal",
+            "interpreted_string_literal",
+            "template_string",
+            "comment",
+            "line_comment",
+            "block_comment",
+            "doc_comment",
+            "number",
+            "integer",
+            "integer_literal",
+            "float",
+            "float_literal",
+            "char",
+            "char_literal",
+            "character_literal",
+            "regex",
+            "regex_literal",
+            "ERROR",
+        ]
+        .into_iter()
+        .collect();
+
+        let delimiter_tokens = vec![("(", ")"), ("{", "}"), ("[", "]"), ("<", ">")];
+
+        Self {
+            atom_nodes,
+            delimiter_tokens,
+        }
+    }
+}
+
+impl SyntaxDiffConfig for DefaultConfig {
+    fn is_atom_node(&self, node_kind: &str) -> bool {
+        self.atom_nodes.contains(node_kind)
+    }
+
+    fn is_delimiter(&self, text: &str) -> bool {
+        self.delimiter_tokens
+            .iter()
+            .any(|(start, end)| *start == text || *end == text)
+    }
+
+    fn get_matching_delimiter<'a>(&'a self, open: &str) -> Option<&'a str> {
+        self.delimiter_tokens
+            .iter()
+            .find(|(start, _)| *start == open)
+            .map(|(_, end)| *end)
+    }
+
+    fn is_open_delimiter(&self, text: &str) -> bool {
+        self.delimiter_tokens
+            .iter()
+            .any(|(start, _)| *start == text)
+    }
+
+    fn is_close_delimiter(&self, text: &str) -> bool {
+        self.delimiter_tokens.iter().any(|(_, end)| *end == text)
+    }
+}
+
+impl DefaultConfig {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_additional_atoms(mut self, atoms: impl IntoIterator<Item = &'static str>) -> Self {
+        self.atom_nodes.extend(atoms);
+        self
+    }
+
+    pub fn with_additional_delimiters(
+        mut self,
+        delimiters: impl IntoIterator<Item = (&'static str, &'static str)>,
+    ) -> Self {
+        self.delimiter_tokens.extend(delimiters);
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_config_has_common_atoms() {
+        let config = DefaultConfig::default();
+
+        assert!(config.is_atom_node("string_literal"));
+        assert!(config.is_atom_node("comment"));
+        assert!(config.is_atom_node("line_comment"));
+        assert!(config.is_atom_node("number"));
+    }
+
+    #[test]
+    fn test_default_config_has_common_delimiters() {
+        let config = DefaultConfig::default();
+
+        assert!(config.is_delimiter("("));
+        assert!(config.is_delimiter(")"));
+        assert!(config.is_delimiter("{"));
+        assert!(config.is_delimiter("}"));
+        assert!(config.is_delimiter("["));
+        assert!(config.is_delimiter("]"));
+    }
+
+    #[test]
+    fn test_is_comment() {
+        let config = DefaultConfig::default();
+
+        assert!(config.is_comment("comment"));
+        assert!(config.is_comment("line_comment"));
+        assert!(config.is_comment("block_comment"));
+        assert!(!config.is_comment("identifier"));
+    }
+
+    #[test]
+    fn test_is_string() {
+        let config = DefaultConfig::default();
+
+        assert!(config.is_string("string"));
+        assert!(config.is_string("string_literal"));
+        assert!(config.is_string("raw_string"));
+        assert!(!config.is_string("identifier"));
+    }
+
+    #[test]
+    fn test_with_additional_atoms() {
+        let config = DefaultConfig::default().with_additional_atoms(["custom_atom"]);
+        assert!(config.is_atom_node("custom_atom"));
+    }
+
+    #[test]
+    fn test_with_additional_delimiters() {
+        let config = DefaultConfig::default().with_additional_delimiters([("<", ">")]);
+        assert!(config.is_delimiter("<"));
+        assert!(config.is_delimiter(">"));
+    }
+
+    #[test]
+    fn test_language_diff_config_creation() {
+        let delimiters = vec![
+            ("{".to_string(), "}".to_string()),
+            ("(".to_string(), ")".to_string()),
+        ];
+        let config = LanguageDiffConfig::new(delimiters);
+
+        assert!(config.is_open_delimiter("{"));
+        assert!(config.is_close_delimiter("}"));
+        assert!(config.is_open_delimiter("("));
+        assert!(config.is_close_delimiter(")"));
+        assert!(!config.is_delimiter("["));
+    }
+
+    #[test]
+    fn test_language_diff_config_matching_delimiter() {
+        let delimiters = vec![
+            ("{".to_string(), "}".to_string()),
+            ("[".to_string(), "]".to_string()),
+        ];
+        let config = LanguageDiffConfig::new(delimiters);
+
+        assert_eq!(config.get_matching_delimiter("{"), Some("}"));
+        assert_eq!(config.get_matching_delimiter("["), Some("]"));
+        assert_eq!(config.get_matching_delimiter("("), None);
+    }
+
+    #[test]
+    fn test_language_diff_config_atom_nodes() {
+        let config = LanguageDiffConfig::new(vec![]);
+
+        // Default atom nodes should include common types
+        assert!(config.is_atom_node("string"));
+        assert!(config.is_atom_node("comment"));
+        assert!(config.is_atom_node("number"));
+        assert!(config.is_atom_node("line_comment"));
+        assert!(config.is_atom_node("string_literal"));
+        assert!(!config.is_atom_node("identifier"));
+    }
+
+    #[test]
+    fn test_language_diff_config_with_additional_atoms() {
+        let config = LanguageDiffConfig::new(vec![])
+            .with_additional_atoms(["custom_node".to_string()]);
+
+        assert!(config.is_atom_node("custom_node"));
+        // Should still have default atoms
+        assert!(config.is_atom_node("string"));
+    }
+
+    #[test]
+    fn test_language_diff_config_with_custom_atoms() {
+        let config = LanguageDiffConfig::new(vec![])
+            .with_atom_nodes(["only_this".to_string()]);
+
+        assert!(config.is_atom_node("only_this"));
+        // Should NOT have default atoms
+        assert!(!config.is_atom_node("string"));
+    }
+
+    #[test]
+    fn test_language_diff_config_comment_detection() {
+        let config = LanguageDiffConfig::new(vec![]);
+
+        assert!(config.is_comment("comment"));
+        assert!(config.is_comment("line_comment"));
+        assert!(config.is_comment("block_comment"));
+        assert!(!config.is_comment("identifier"));
+    }
+
+    #[test]
+    fn test_language_diff_config_string_detection() {
+        let config = LanguageDiffConfig::new(vec![]);
+
+        assert!(config.is_string("string"));
+        assert!(config.is_string("string_literal"));
+        assert!(config.is_string("template_string"));
+        assert!(!config.is_string("identifier"));
+    }
+
+    #[test]
+    fn test_rust_style_delimiters() {
+        let delimiters = vec![
+            ("{".to_string(), "}".to_string()),
+            ("[".to_string(), "]".to_string()),
+            ("(".to_string(), ")".to_string()),
+            ("<".to_string(), ">".to_string()),
+            ("r#\"".to_string(), "\"#".to_string()),
+        ];
+        let config = LanguageDiffConfig::new(delimiters);
+
+        assert!(config.is_open_delimiter("{"));
+        assert!(config.is_close_delimiter("}"));
+        assert!(config.is_open_delimiter("<"));
+        assert!(config.is_close_delimiter(">"));
+        assert!(config.is_open_delimiter("r#\""));
+        assert!(config.is_close_delimiter("\"#"));
+
+        assert_eq!(config.get_matching_delimiter("{"), Some("}"));
+        assert_eq!(config.get_matching_delimiter("r#\""), Some("\"#"));
+    }
+
+    #[test]
+    fn test_typescript_style_delimiters() {
+        let delimiters = vec![
+            ("{".to_string(), "}".to_string()),
+            ("[".to_string(), "]".to_string()),
+            ("(".to_string(), ")".to_string()),
+            ("<".to_string(), ">".to_string()),
+            ("\"".to_string(), "\"".to_string()),
+            ("'".to_string(), "'".to_string()),
+            ("`".to_string(), "`".to_string()),
+        ];
+        let config = LanguageDiffConfig::new(delimiters);
+
+        assert!(config.is_open_delimiter("{"));
+        assert!(config.is_close_delimiter("}"));
+        assert!(config.is_delimiter("\"")); // Both open and close
+        assert!(config.is_delimiter("'")); // Both open and close
+        assert!(config.is_delimiter("`")); // Template string
+    }
+
+    #[test]
+    fn test_python_style_delimiters() {
+        let delimiters = vec![
+            ("{".to_string(), "}".to_string()),
+            ("[".to_string(), "]".to_string()),
+            ("(".to_string(), ")".to_string()),
+            ("\"".to_string(), "\"".to_string()),
+            ("'".to_string(), "'".to_string()),
+            ("\"\"\"".to_string(), "\"\"\"".to_string()),
+            ("'''".to_string(), "'''".to_string()),
+        ];
+        let config = LanguageDiffConfig::new(delimiters);
+
+        assert!(config.is_open_delimiter("{"));
+        assert!(config.is_open_delimiter("\"\"\""));
+        assert!(config.is_close_delimiter("\"\"\""));
+        assert_eq!(config.get_matching_delimiter("\"\"\""), Some("\"\"\""));
+    }
+
+    #[test]
+    fn test_empty_delimiter_list() {
+        let config = LanguageDiffConfig::new(vec![]);
+
+        assert!(!config.is_delimiter("{"));
+        assert!(!config.is_delimiter("}"));
+        assert_eq!(config.get_matching_delimiter("{"), None);
+    }
+
+    #[test]
+    fn test_config_preserves_delimiter_order() {
+        let delimiters = vec![
+            ("A".to_string(), "a".to_string()),
+            ("B".to_string(), "b".to_string()),
+            ("C".to_string(), "c".to_string()),
+        ];
+        let config = LanguageDiffConfig::new(delimiters);
+
+        assert_eq!(config.get_matching_delimiter("A"), Some("a"));
+        assert_eq!(config.get_matching_delimiter("B"), Some("b"));
+        assert_eq!(config.get_matching_delimiter("C"), Some("c"));
+    }
+}
+
+/// Language-specific diff configuration.
+#[derive(Debug, Clone)]
+pub struct LanguageDiffConfig {
+    delimiter_tokens: Vec<(String, String)>,
+    atom_nodes: HashSet<Cow<'static, str>>,
+}
+
+impl LanguageDiffConfig {
+    pub fn new(delimiters: Vec<(String, String)>) -> Self {
+        Self {
+            delimiter_tokens: delimiters,
+            atom_nodes: default_atom_nodes(),
+        }
+    }
+
+    pub fn with_atom_nodes(mut self, atoms: impl IntoIterator<Item = String>) -> Self {
+        self.atom_nodes = atoms.into_iter().map(Cow::Owned).collect();
+        self
+    }
+
+    pub fn with_additional_atoms(mut self, atoms: impl IntoIterator<Item = String>) -> Self {
+        self.atom_nodes.extend(atoms.into_iter().map(Cow::Owned));
+        self
+    }
+
+    pub fn delimiter_tokens_list(&self) -> &[(String, String)] {
+        &self.delimiter_tokens
+    }
+
+    pub fn forced_atom_nodes_list(&self) -> Vec<&str> {
+        self.atom_nodes.iter().map(|s| s.as_ref()).collect()
+    }
+}
+
+impl SyntaxDiffConfig for LanguageDiffConfig {
+    fn is_atom_node(&self, node_kind: &str) -> bool {
+        self.atom_nodes.iter().any(|s| s.as_ref() == node_kind)
+    }
+
+    fn is_delimiter(&self, text: &str) -> bool {
+        self.delimiter_tokens
+            .iter()
+            .any(|(start, end)| start == text || end == text)
+    }
+
+    fn get_matching_delimiter<'a>(&'a self, open: &str) -> Option<&'a str> {
+        self.delimiter_tokens
+            .iter()
+            .find(|(start, _)| start == open)
+            .map(|(_, end)| end.as_str())
+    }
+
+    fn is_open_delimiter(&self, text: &str) -> bool {
+        self.delimiter_tokens.iter().any(|(start, _)| start == text)
+    }
+
+    fn is_close_delimiter(&self, text: &str) -> bool {
+        self.delimiter_tokens.iter().any(|(_, end)| end == text)
+    }
+}
+
+fn default_atom_nodes() -> HashSet<Cow<'static, str>> {
+    [
+        "string",
+        "string_literal",
+        "string_content",
+        "raw_string_literal",
+        "interpreted_string_literal",
+        "template_string",
+        "string_fragment",
+        "comment",
+        "line_comment",
+        "block_comment",
+        "doc_comment",
+        "number",
+        "integer",
+        "integer_literal",
+        "float",
+        "float_literal",
+        "char",
+        "char_literal",
+        "character_literal",
+        "regex",
+        "regex_literal",
+        "ERROR",
+    ]
+    .into_iter()
+    .map(Cow::Borrowed)
+    .collect()
+}

--- a/crates/ast_diff/src/dijkstra.rs
+++ b/crates/ast_diff/src/dijkstra.rs
@@ -1,0 +1,212 @@
+use std::cmp::Reverse;
+
+use bumpalo::Bump;
+use radix_heap::RadixHeapMap;
+
+use crate::{
+    changes::ChangeMap,
+    graph::{populate_change_map, set_neighbours, Edge, Vertex},
+    hash::DftHashMap,
+    syntax::Syntax,
+};
+
+#[derive(Debug)]
+pub struct ExceededGraphLimit;
+
+fn shortest_vertex_path<'s, 'v>(
+    start: &'v Vertex<'s, 'v>,
+    vertex_arena: &'v Bump,
+    size_hint: usize,
+    graph_limit: usize,
+) -> Result<Vec<&'v Vertex<'s, 'v>>, ExceededGraphLimit> {
+    // RadixHeapMap is a max-heap, so wrap with Reverse to get min-heap behavior.
+    let mut heap: RadixHeapMap<Reverse<_>, &'v Vertex<'s, 'v>> = RadixHeapMap::new();
+
+    heap.push(Reverse(0), start);
+
+    let mut seen = DftHashMap::default();
+    seen.reserve(size_hint);
+
+    let end: &'v Vertex<'s, 'v> = loop {
+        match heap.pop() {
+            Some((Reverse(distance), current)) => {
+                if current.is_end() {
+                    break current;
+                }
+
+                set_neighbours(current, vertex_arena, &mut seen);
+                for neighbour in *current
+                    .neighbours
+                    .borrow()
+                    .as_ref()
+                    .expect("Neighbours should be set before traversal")
+                {
+                    let (edge, next) = neighbour;
+                    let distance_to_next = distance + edge.cost();
+
+                    let found_shorter_route = match next.predecessor.get() {
+                        Some((prev_shortest, _)) => distance_to_next < prev_shortest,
+                        None => true,
+                    };
+
+                    if found_shorter_route {
+                        next.predecessor.replace(Some((distance_to_next, current)));
+                        heap.push(Reverse(distance_to_next), next);
+                    }
+                }
+
+                if seen.len() > graph_limit {
+                    log::info!(
+                        "Reached graph limit, arena consumed {} bytes",
+                        vertex_arena.allocated_bytes(),
+                    );
+                    return Err(ExceededGraphLimit);
+                }
+            }
+            None => panic!("Ran out of graph nodes before reaching end"),
+        }
+    };
+
+    log::info!(
+        "Saw {} vertices (a Vertex is {} bytes), arena consumed {} bytes, with {} vertices left on heap.",
+        seen.len(),
+        std::mem::size_of::<Vertex>(),
+        vertex_arena.allocated_bytes(),
+        heap.len(),
+    );
+
+    let mut current = Some((0, end));
+    let mut vertex_route: Vec<&'v Vertex<'s, 'v>> = vec![];
+    while let Some((_, node)) = current {
+        vertex_route.push(node);
+        current = node.predecessor.get();
+    }
+
+    vertex_route.reverse();
+    Ok(vertex_route)
+}
+
+fn shortest_path_with_edges<'s, 'v>(
+    route: &[&'v Vertex<'s, 'v>],
+) -> Vec<(Edge, &'v Vertex<'s, 'v>)> {
+    let mut prev = route.first().expect("Expected non-empty route");
+
+    let mut cost = 0;
+    let mut res = vec![];
+
+    for vertex in route.iter().skip(1) {
+        let edge = edge_between(prev, vertex);
+        res.push((edge, *prev));
+        cost += edge.cost();
+
+        prev = vertex;
+    }
+    log::debug!("Found a path of {} with cost {}.", route.len(), cost);
+
+    res
+}
+
+fn shortest_path<'s, 'v>(
+    start: Vertex<'s, 'v>,
+    vertex_arena: &'v Bump,
+    size_hint: usize,
+    graph_limit: usize,
+) -> Result<Vec<(Edge, &'v Vertex<'s, 'v>)>, ExceededGraphLimit> {
+    let start: &'v Vertex<'s, 'v> = vertex_arena.alloc(start);
+    let vertex_path = shortest_vertex_path(start, vertex_arena, size_hint, graph_limit)?;
+    Ok(shortest_path_with_edges(&vertex_path))
+}
+
+fn edge_between<'s, 'v>(before: &Vertex<'s, 'v>, after: &Vertex<'s, 'v>) -> Edge {
+    assert_ne!(before, after);
+
+    let mut shortest_edge: Option<Edge> = None;
+    if let Some(neighbours) = &*before.neighbours.borrow() {
+        for neighbour in *neighbours {
+            let (edge, next) = *neighbour;
+            // If there are multiple edges that can take us to `next`,
+            // prefer the shortest.
+            if *next == *after {
+                let is_shorter = match shortest_edge {
+                    Some(prev_edge) => edge.cost() < prev_edge.cost(),
+                    None => true,
+                };
+
+                if is_shorter {
+                    shortest_edge = Some(edge);
+                }
+            }
+        }
+    }
+
+    if let Some(edge) = shortest_edge {
+        return edge;
+    }
+
+    panic!(
+        "Expected a route between the two vertices {:#?} and {:#?}",
+        before, after
+    );
+}
+
+fn node_count(root: Option<&Syntax>) -> u32 {
+    let iter = std::iter::successors(root, |node| node.next_sibling());
+
+    iter.map(|node| match node {
+        Syntax::List {
+            num_descendants, ..
+        } => *num_descendants,
+        Syntax::Atom { .. } => 1,
+    })
+    .sum::<u32>()
+}
+
+fn tree_count(root: Option<&Syntax>) -> u32 {
+    std::iter::successors(root, |node| node.next_sibling()).count() as _
+}
+
+pub(crate) fn mark_syntax<'a>(
+    lhs_syntax: Option<&'a Syntax<'a>>,
+    rhs_syntax: Option<&'a Syntax<'a>>,
+    change_map: &mut ChangeMap<'a>,
+    graph_limit: usize,
+) -> Result<(), ExceededGraphLimit> {
+    let lhs_node_count = node_count(lhs_syntax) as usize;
+    let rhs_node_count = node_count(rhs_syntax) as usize;
+    log::info!(
+        "LHS nodes: {} ({} toplevel), RHS nodes: {} ({} toplevel)",
+        lhs_node_count,
+        tree_count(lhs_syntax),
+        rhs_node_count,
+        tree_count(rhs_syntax),
+    );
+
+    let size_hint = std::cmp::min(lhs_node_count * rhs_node_count, graph_limit);
+
+    let start = Vertex::new(lhs_syntax, rhs_syntax);
+    let vertex_arena = Bump::new();
+
+    let route = shortest_path(start, &vertex_arena, size_hint, graph_limit)?;
+
+    log::debug!(
+        "Initial 5 items on path: {:#?}",
+        route
+            .iter()
+            .map(|(edge, v)| {
+                format!(
+                    "{:20} {:20} --- {:3} {:?}",
+                    v.lhs_syntax
+                        .map_or_else(|| "None".into(), Syntax::dbg_content),
+                    v.rhs_syntax
+                        .map_or_else(|| "None".into(), Syntax::dbg_content),
+                    edge.cost(),
+                    edge,
+                )
+            })
+            .take(5)
+            .collect::<Vec<_>>()
+    );
+
+    populate_change_map(&route, change_map);
+    Ok(())
+}

--- a/crates/ast_diff/src/dijkstra.rs
+++ b/crates/ast_diff/src/dijkstra.rs
@@ -5,7 +5,7 @@ use radix_heap::RadixHeapMap;
 
 use crate::{
     changes::ChangeMap,
-    graph::{populate_change_map, set_neighbours, Edge, Vertex},
+    graph::{Edge, Vertex, populate_change_map, set_neighbours},
     hash::DftHashMap,
     syntax::Syntax,
 };

--- a/crates/ast_diff/src/graph.rs
+++ b/crates/ast_diff/src/graph.rs
@@ -9,12 +9,12 @@ use std::{
 
 use bumpalo::Bump;
 use hashbrown::hash_map::RawEntryMut;
-use smallvec::{smallvec, SmallVec};
+use smallvec::{SmallVec, smallvec};
 use strsim::normalized_levenshtein;
 
 use self::Edge::*;
 use crate::{
-    changes::{insert_deep_unchanged, ChangeKind, ChangeMap},
+    changes::{ChangeKind, ChangeMap, insert_deep_unchanged},
     hash::DftHashMap,
     stack::Stack,
     syntax::{AtomKind, Syntax, SyntaxId},
@@ -185,7 +185,9 @@ fn try_pop_lhs<'s, 'v>(
         Some(EnteredDelimiter::PopEither((lhs_delims, rhs_delims))) => match lhs_delims.peek() {
             Some(lhs_delim) => {
                 let mut entered = entered.pop().expect("Delimiter stack should be non-empty");
-                let new_lhs_delims = lhs_delims.pop().expect("LHS delimiter stack should be non-empty");
+                let new_lhs_delims = lhs_delims
+                    .pop()
+                    .expect("LHS delimiter stack should be non-empty");
 
                 if !new_lhs_delims.is_empty() || !rhs_delims.is_empty() {
                     entered = entered.push(
@@ -210,7 +212,9 @@ fn try_pop_rhs<'s, 'v>(
         Some(EnteredDelimiter::PopEither((lhs_delims, rhs_delims))) => match rhs_delims.peek() {
             Some(rhs_delim) => {
                 let mut entered = entered.pop().expect("Delimiter stack should be non-empty");
-                let new_rhs_delims = rhs_delims.pop().expect("RHS delimiter stack should be non-empty");
+                let new_rhs_delims = rhs_delims
+                    .pop()
+                    .expect("RHS delimiter stack should be non-empty");
 
                 if !lhs_delims.is_empty() || !new_rhs_delims.is_empty() {
                     entered = entered.push(
@@ -237,7 +241,10 @@ fn push_lhs_delimiter<'s, 'v>(
             .pop()
             .expect("Delimiter stack should be non-empty")
             .push(
-                EnteredDelimiter::PopEither((lhs_delims.push(delimiter, alloc), rhs_delims.clone())),
+                EnteredDelimiter::PopEither((
+                    lhs_delims.push(delimiter, alloc),
+                    rhs_delims.clone(),
+                )),
                 alloc,
             ),
         _ => entered.push(
@@ -257,7 +264,10 @@ fn push_rhs_delimiter<'s, 'v>(
             .pop()
             .expect("Delimiter stack should be non-empty")
             .push(
-                EnteredDelimiter::PopEither((lhs_delims.clone(), rhs_delims.push(delimiter, alloc))),
+                EnteredDelimiter::PopEither((
+                    lhs_delims.clone(),
+                    rhs_delims.push(delimiter, alloc),
+                )),
                 alloc,
             ),
         _ => entered.push(

--- a/crates/ast_diff/src/graph.rs
+++ b/crates/ast_diff/src/graph.rs
@@ -1,0 +1,790 @@
+//! A graph representation for computing tree diffs.
+
+use std::{
+    cell::{Cell, RefCell},
+    cmp::min,
+    fmt,
+    hash::{Hash, Hasher},
+};
+
+use bumpalo::Bump;
+use hashbrown::hash_map::RawEntryMut;
+use smallvec::{smallvec, SmallVec};
+use strsim::normalized_levenshtein;
+
+use self::Edge::*;
+use crate::{
+    changes::{insert_deep_unchanged, ChangeKind, ChangeMap},
+    hash::DftHashMap,
+    stack::Stack,
+    syntax::{AtomKind, Syntax, SyntaxId},
+};
+
+/// A vertex in a directed acyclic graph that represents a diff.
+///
+/// Each vertex represents two pointers: one to the next unmatched LHS
+/// syntax, and one to the next unmatched RHS syntax.
+///
+/// For example, suppose we have `X A` on the LHS and `A` on the
+/// RHS. Our start vertex looks like this.
+///
+/// ```text
+/// LHS: X A     RHS: A
+///      ^            ^
+/// ```
+///
+/// From this vertex, we could take [`Edge::NovelAtomLHS`], bringing
+/// us to this vertex.
+///
+/// ```text
+/// LHS: X A     RHS: A
+///        ^          ^
+/// ```
+///
+/// Alternatively, we could take the [`Edge::NovelAtomRHS`], bringing us
+/// to this vertex.
+///
+/// ```text
+/// LHS: X A     RHS: A
+///      ^              ^
+/// ```
+///
+/// Vertices are arena allocated (the 'v lifetime) and have references
+/// to syntax nodes (the 's lifetime).
+#[derive(Debug, Clone)]
+pub(crate) struct Vertex<'s, 'v> {
+    pub(crate) neighbours: RefCell<Option<&'v [(Edge, &'v Vertex<'s, 'v>)]>>,
+    pub(crate) predecessor: Cell<Option<(u32, &'v Vertex<'s, 'v>)>>,
+    pub(crate) lhs_syntax: Option<&'s Syntax<'s>>,
+    pub(crate) rhs_syntax: Option<&'s Syntax<'s>>,
+    parents: Stack<'v, EnteredDelimiter<'s, 'v>>,
+    lhs_parent_id: Option<SyntaxId>,
+    rhs_parent_id: Option<SyntaxId>,
+}
+
+impl PartialEq for Vertex<'_, '_> {
+    fn eq(&self, other: &Self) -> bool {
+        // Strictly speaking, we should compare the whole
+        // EnteredDelimiter stack, not just the immediate
+        // parents. By taking the immediate parent, we have
+        // vertices with different stacks that are 'equal'.
+        //
+        // This makes the graph traversal path dependent: the
+        // first vertex we see 'wins', and we use it for deciding
+        // how we can pop.
+        //
+        // In practice this seems to work well. The first vertex
+        // has the lowest cost, so has the most PopBoth
+        // occurrences, which is the best outcome.
+        //
+        // Handling this properly would require considering many
+        // more vertices to be distinct, exponentially increasing
+        // the graph size relative to tree depth.
+        let b0 = match (self.lhs_syntax, other.lhs_syntax) {
+            (Some(s0), Some(s1)) => s0.id() == s1.id(),
+            (None, None) => self.lhs_parent_id == other.lhs_parent_id,
+            _ => false,
+        };
+        let b1 = match (self.rhs_syntax, other.rhs_syntax) {
+            (Some(s0), Some(s1)) => s0.id() == s1.id(),
+            (None, None) => self.rhs_parent_id == other.rhs_parent_id,
+            _ => false,
+        };
+        // We do want to distinguish whether we can pop each side
+        // independently though. Without this, if we find a case
+        // where we can pop sides together, we don't consider the
+        // case where we get a better diff by popping each side
+        // separately.
+        let b2 = can_pop_either_parent(&self.parents) == can_pop_either_parent(&other.parents);
+
+        b0 && b1 && b2
+    }
+}
+impl Eq for Vertex<'_, '_> {}
+
+impl Hash for Vertex<'_, '_> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.lhs_syntax.map(|node| node.id()).hash(state);
+        self.rhs_syntax.map(|node| node.id()).hash(state);
+
+        self.lhs_parent_id.hash(state);
+        self.rhs_parent_id.hash(state);
+        can_pop_either_parent(&self.parents).hash(state);
+    }
+}
+
+/// Tracks entering syntax List nodes.
+#[derive(Clone, PartialEq)]
+enum EnteredDelimiter<'s, 'v> {
+    /// If we've entered the LHS or RHS separately, we can pop either
+    /// side independently.
+    ///
+    /// Assumes that at least one stack is non-empty.
+    PopEither((Stack<'v, &'s Syntax<'s>>, Stack<'v, &'s Syntax<'s>>)),
+    /// If we've entered the LHS and RHS together, we must pop both
+    /// sides together too. Otherwise we'd consider the following case to have no changes.
+    ///
+    /// ```text
+    /// Old: (a b c)
+    /// New: (a b) c
+    /// ```
+    PopBoth((&'s Syntax<'s>, &'s Syntax<'s>)),
+}
+
+impl fmt::Debug for EnteredDelimiter<'_, '_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let desc = match self {
+            Self::PopEither((lhs_delims, rhs_delims)) => {
+                format!(
+                    "PopEither(lhs count: {}, rhs count: {})",
+                    lhs_delims.size(),
+                    rhs_delims.size()
+                )
+            }
+            Self::PopBoth(_) => "PopBoth".to_owned(),
+        };
+        f.write_str(&desc)
+    }
+}
+
+fn push_both_delimiters<'s, 'v>(
+    entered: &Stack<'v, EnteredDelimiter<'s, 'v>>,
+    lhs_delim: &'s Syntax<'s>,
+    rhs_delim: &'s Syntax<'s>,
+    alloc: &'v Bump,
+) -> Stack<'v, EnteredDelimiter<'s, 'v>> {
+    entered.push(EnteredDelimiter::PopBoth((lhs_delim, rhs_delim)), alloc)
+}
+
+fn can_pop_either_parent(entered: &Stack<EnteredDelimiter>) -> bool {
+    matches!(entered.peek(), Some(EnteredDelimiter::PopEither(_)))
+}
+
+fn try_pop_both<'s, 'v>(
+    entered: &Stack<'v, EnteredDelimiter<'s, 'v>>,
+) -> Option<(
+    &'s Syntax<'s>,
+    &'s Syntax<'s>,
+    Stack<'v, EnteredDelimiter<'s, 'v>>,
+)> {
+    match entered.peek() {
+        Some(EnteredDelimiter::PopBoth((lhs_delim, rhs_delim))) => Some((
+            lhs_delim,
+            rhs_delim,
+            entered.pop().expect("Delimiter stack should be non-empty"),
+        )),
+        _ => None,
+    }
+}
+
+fn try_pop_lhs<'s, 'v>(
+    entered: &Stack<'v, EnteredDelimiter<'s, 'v>>,
+    alloc: &'v Bump,
+) -> Option<(&'s Syntax<'s>, Stack<'v, EnteredDelimiter<'s, 'v>>)> {
+    match entered.peek() {
+        Some(EnteredDelimiter::PopEither((lhs_delims, rhs_delims))) => match lhs_delims.peek() {
+            Some(lhs_delim) => {
+                let mut entered = entered.pop().expect("Delimiter stack should be non-empty");
+                let new_lhs_delims = lhs_delims.pop().expect("LHS delimiter stack should be non-empty");
+
+                if !new_lhs_delims.is_empty() || !rhs_delims.is_empty() {
+                    entered = entered.push(
+                        EnteredDelimiter::PopEither((new_lhs_delims, rhs_delims.clone())),
+                        alloc,
+                    );
+                }
+
+                Some((lhs_delim, entered))
+            }
+            None => None,
+        },
+        _ => None,
+    }
+}
+
+fn try_pop_rhs<'s, 'v>(
+    entered: &Stack<'v, EnteredDelimiter<'s, 'v>>,
+    alloc: &'v Bump,
+) -> Option<(&'s Syntax<'s>, Stack<'v, EnteredDelimiter<'s, 'v>>)> {
+    match entered.peek() {
+        Some(EnteredDelimiter::PopEither((lhs_delims, rhs_delims))) => match rhs_delims.peek() {
+            Some(rhs_delim) => {
+                let mut entered = entered.pop().expect("Delimiter stack should be non-empty");
+                let new_rhs_delims = rhs_delims.pop().expect("RHS delimiter stack should be non-empty");
+
+                if !lhs_delims.is_empty() || !new_rhs_delims.is_empty() {
+                    entered = entered.push(
+                        EnteredDelimiter::PopEither((lhs_delims.clone(), new_rhs_delims)),
+                        alloc,
+                    );
+                }
+
+                Some((rhs_delim, entered))
+            }
+            None => None,
+        },
+        _ => None,
+    }
+}
+
+fn push_lhs_delimiter<'s, 'v>(
+    entered: &Stack<'v, EnteredDelimiter<'s, 'v>>,
+    delimiter: &'s Syntax<'s>,
+    alloc: &'v Bump,
+) -> Stack<'v, EnteredDelimiter<'s, 'v>> {
+    match entered.peek() {
+        Some(EnteredDelimiter::PopEither((lhs_delims, rhs_delims))) => entered
+            .pop()
+            .expect("Delimiter stack should be non-empty")
+            .push(
+                EnteredDelimiter::PopEither((lhs_delims.push(delimiter, alloc), rhs_delims.clone())),
+                alloc,
+            ),
+        _ => entered.push(
+            EnteredDelimiter::PopEither((Stack::new().push(delimiter, alloc), Stack::new())),
+            alloc,
+        ),
+    }
+}
+
+fn push_rhs_delimiter<'s, 'v>(
+    entered: &Stack<'v, EnteredDelimiter<'s, 'v>>,
+    delimiter: &'s Syntax<'s>,
+    alloc: &'v Bump,
+) -> Stack<'v, EnteredDelimiter<'s, 'v>> {
+    match entered.peek() {
+        Some(EnteredDelimiter::PopEither((lhs_delims, rhs_delims))) => entered
+            .pop()
+            .expect("Delimiter stack should be non-empty")
+            .push(
+                EnteredDelimiter::PopEither((lhs_delims.clone(), rhs_delims.push(delimiter, alloc))),
+                alloc,
+            ),
+        _ => entered.push(
+            EnteredDelimiter::PopEither((Stack::new(), Stack::new().push(delimiter, alloc))),
+            alloc,
+        ),
+    }
+}
+
+impl<'s, 'v> Vertex<'s, 'v> {
+    pub(crate) fn is_end(&self) -> bool {
+        self.lhs_syntax.is_none() && self.rhs_syntax.is_none() && self.parents.is_empty()
+    }
+
+    pub(crate) fn new(
+        lhs_syntax: Option<&'s Syntax<'s>>,
+        rhs_syntax: Option<&'s Syntax<'s>>,
+    ) -> Self {
+        let parents = Stack::new();
+        Vertex {
+            neighbours: RefCell::new(None),
+            predecessor: Cell::new(None),
+            lhs_syntax,
+            rhs_syntax,
+            parents,
+            lhs_parent_id: None,
+            rhs_parent_id: None,
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub(crate) enum Edge {
+    UnchangedNode {
+        depth_difference: u32,
+        probably_punctuation: bool,
+    },
+    EnterUnchangedDelimiter {
+        depth_difference: u32,
+    },
+    ReplacedComment {
+        levenshtein_pct: u8,
+    },
+    ReplacedString {
+        levenshtein_pct: u8,
+    },
+    NovelAtomLHS {},
+    NovelAtomRHS {},
+    EnterNovelDelimiterLHS {},
+    EnterNovelDelimiterRHS {},
+}
+
+impl Edge {
+    pub(crate) fn cost(self) -> u32 {
+        match self {
+            UnchangedNode {
+                depth_difference,
+                probably_punctuation,
+            } => {
+                let base = min(40, depth_difference + 1);
+                // Penalize punctuation matches so we prefer matching variable names.
+                base + if probably_punctuation { 200 } else { 0 }
+            }
+            EnterUnchangedDelimiter { depth_difference } => 100 + min(40, depth_difference),
+            NovelAtomLHS {} | NovelAtomRHS {} => 300,
+            EnterNovelDelimiterLHS { .. } | EnterNovelDelimiterRHS { .. } => 300,
+            // Must be less than 2 * 300 since this replaces two novel edges.
+            ReplacedComment { levenshtein_pct } | ReplacedString { levenshtein_pct } => {
+                500 + u32::from(100 - levenshtein_pct)
+            }
+        }
+    }
+}
+
+fn allocate_if_new<'s, 'v>(
+    v: Vertex<'s, 'v>,
+    alloc: &'v Bump,
+    seen: &mut DftHashMap<&Vertex<'s, 'v>, SmallVec<[&'v Vertex<'s, 'v>; 2]>>,
+) -> &'v Vertex<'s, 'v> {
+    match seen.raw_entry_mut().from_key(&v) {
+        RawEntryMut::Occupied(mut occupied) => {
+            let existing = occupied.get_mut();
+
+            if let Some(allocated) = existing.last() {
+                if existing.len() >= 2 {
+                    return allocated;
+                }
+            }
+
+            for existing_node in existing.iter() {
+                if existing_node.parents == v.parents {
+                    return existing_node;
+                }
+            }
+
+            let allocated = alloc.alloc(v);
+            existing.push(allocated);
+            allocated
+        }
+        RawEntryMut::Vacant(vacant) => {
+            let allocated = alloc.alloc(v);
+            let existing: SmallVec<[&'v Vertex<'s, 'v>; 2]> = smallvec![&*allocated];
+            vacant.insert(allocated, existing);
+            allocated
+        }
+    }
+}
+
+fn looks_like_punctuation(node: &Syntax) -> bool {
+    match node {
+        Syntax::Atom { content, .. } => content == "," || content == ";" || content == ".",
+        _ => false,
+    }
+}
+
+fn pop_all_parents<'s, 'v>(
+    lhs_node: Option<&'s Syntax<'s>>,
+    rhs_node: Option<&'s Syntax<'s>>,
+    lhs_parent_id: Option<SyntaxId>,
+    rhs_parent_id: Option<SyntaxId>,
+    parents: &Stack<'v, EnteredDelimiter<'s, 'v>>,
+    alloc: &'v Bump,
+) -> (
+    Option<&'s Syntax<'s>>,
+    Option<&'s Syntax<'s>>,
+    Option<SyntaxId>,
+    Option<SyntaxId>,
+    Stack<'v, EnteredDelimiter<'s, 'v>>,
+) {
+    let mut lhs_node = lhs_node;
+    let mut rhs_node = rhs_node;
+    let mut lhs_parent_id = lhs_parent_id;
+    let mut rhs_parent_id = rhs_parent_id;
+    let mut parents = parents.clone();
+
+    loop {
+        if lhs_node.is_none() {
+            if let Some((lhs_parent, parents_next)) = try_pop_lhs(&parents, alloc) {
+                lhs_node = lhs_parent.next_sibling();
+                lhs_parent_id = lhs_parent.parent().map(Syntax::id);
+                parents = parents_next;
+                continue;
+            }
+        }
+
+        if rhs_node.is_none() {
+            if let Some((rhs_parent, parents_next)) = try_pop_rhs(&parents, alloc) {
+                rhs_node = rhs_parent.next_sibling();
+                rhs_parent_id = rhs_parent.parent().map(Syntax::id);
+                parents = parents_next;
+                continue;
+            }
+        }
+
+        if lhs_node.is_none() && rhs_node.is_none() {
+            if let Some((lhs_parent, rhs_parent, parents_next)) = try_pop_both(&parents) {
+                lhs_node = lhs_parent.next_sibling();
+                rhs_node = rhs_parent.next_sibling();
+                lhs_parent_id = lhs_parent.parent().map(Syntax::id);
+                rhs_parent_id = rhs_parent.parent().map(Syntax::id);
+                parents = parents_next;
+                continue;
+            }
+        }
+
+        break;
+    }
+
+    (lhs_node, rhs_node, lhs_parent_id, rhs_parent_id, parents)
+}
+
+pub(crate) fn set_neighbours<'s, 'v>(
+    v: &Vertex<'s, 'v>,
+    alloc: &'v Bump,
+    seen: &mut DftHashMap<&Vertex<'s, 'v>, SmallVec<[&'v Vertex<'s, 'v>; 2]>>,
+) {
+    if v.neighbours.borrow().is_some() {
+        return;
+    }
+
+    let mut neighbours: Vec<(Edge, &Vertex)> = Vec::with_capacity(7);
+
+    if let (Some(lhs_syntax), Some(rhs_syntax)) = (&v.lhs_syntax, &v.rhs_syntax) {
+        if lhs_syntax == rhs_syntax {
+            let depth_difference = (lhs_syntax.num_ancestors() as i32
+                - rhs_syntax.num_ancestors() as i32)
+                .unsigned_abs();
+
+            let probably_punctuation = looks_like_punctuation(lhs_syntax);
+
+            let (lhs_syntax, rhs_syntax, lhs_parent_id, rhs_parent_id, parents) = pop_all_parents(
+                lhs_syntax.next_sibling(),
+                rhs_syntax.next_sibling(),
+                v.lhs_parent_id,
+                v.rhs_parent_id,
+                &v.parents,
+                alloc,
+            );
+
+            neighbours.push((
+                UnchangedNode {
+                    depth_difference,
+                    probably_punctuation,
+                },
+                allocate_if_new(
+                    Vertex {
+                        neighbours: RefCell::new(None),
+                        predecessor: Cell::new(None),
+                        lhs_syntax,
+                        rhs_syntax,
+                        parents,
+                        lhs_parent_id,
+                        rhs_parent_id,
+                    },
+                    alloc,
+                    seen,
+                ),
+            ));
+        }
+
+        if let (
+            Syntax::List {
+                open_content: lhs_open_content,
+                close_content: lhs_close_content,
+                children: lhs_children,
+                ..
+            },
+            Syntax::List {
+                open_content: rhs_open_content,
+                close_content: rhs_close_content,
+                children: rhs_children,
+                ..
+            },
+        ) = (lhs_syntax, rhs_syntax)
+        {
+            if lhs_open_content == rhs_open_content && lhs_close_content == rhs_close_content {
+                let lhs_next = lhs_children.first().copied();
+                let rhs_next = rhs_children.first().copied();
+
+                let parents_next = push_both_delimiters(&v.parents, lhs_syntax, rhs_syntax, alloc);
+
+                let depth_difference = (lhs_syntax.num_ancestors() as i32
+                    - rhs_syntax.num_ancestors() as i32)
+                    .unsigned_abs();
+
+                let (lhs_syntax, rhs_syntax, lhs_parent_id, rhs_parent_id, parents) =
+                    pop_all_parents(
+                        lhs_next,
+                        rhs_next,
+                        Some(lhs_syntax.id()),
+                        Some(rhs_syntax.id()),
+                        &parents_next,
+                        alloc,
+                    );
+
+                neighbours.push((
+                    EnterUnchangedDelimiter { depth_difference },
+                    allocate_if_new(
+                        Vertex {
+                            neighbours: RefCell::new(None),
+                            predecessor: Cell::new(None),
+                            lhs_syntax,
+                            rhs_syntax,
+                            parents,
+                            lhs_parent_id,
+                            rhs_parent_id,
+                        },
+                        alloc,
+                        seen,
+                    ),
+                ));
+            }
+        }
+
+        if let (
+            Syntax::Atom {
+                content: lhs_content,
+                kind: lhs_kind @ AtomKind::Comment | lhs_kind @ AtomKind::String(_),
+                ..
+            },
+            Syntax::Atom {
+                content: rhs_content,
+                kind: rhs_kind @ AtomKind::Comment | rhs_kind @ AtomKind::String(_),
+                ..
+            },
+        ) = (lhs_syntax, rhs_syntax)
+        {
+            if lhs_kind == rhs_kind && lhs_content != rhs_content {
+                let levenshtein_pct =
+                    (normalized_levenshtein(lhs_content, rhs_content) * 100.0).round() as u8;
+                let edge = if lhs_kind == &AtomKind::Comment {
+                    ReplacedComment { levenshtein_pct }
+                } else {
+                    ReplacedString { levenshtein_pct }
+                };
+
+                let (lhs_syntax, rhs_syntax, lhs_parent_id, rhs_parent_id, parents) =
+                    pop_all_parents(
+                        lhs_syntax.next_sibling(),
+                        rhs_syntax.next_sibling(),
+                        v.lhs_parent_id,
+                        v.rhs_parent_id,
+                        &v.parents,
+                        alloc,
+                    );
+                neighbours.push((
+                    edge,
+                    allocate_if_new(
+                        Vertex {
+                            neighbours: RefCell::new(None),
+                            predecessor: Cell::new(None),
+                            lhs_syntax,
+                            rhs_syntax,
+                            parents,
+                            lhs_parent_id,
+                            rhs_parent_id,
+                        },
+                        alloc,
+                        seen,
+                    ),
+                ));
+            }
+        }
+    }
+
+    if let Some(lhs_syntax) = &v.lhs_syntax {
+        match lhs_syntax {
+            Syntax::Atom { .. } => {
+                let (lhs_syntax, rhs_syntax, lhs_parent_id, rhs_parent_id, parents) =
+                    pop_all_parents(
+                        lhs_syntax.next_sibling(),
+                        v.rhs_syntax,
+                        v.lhs_parent_id,
+                        v.rhs_parent_id,
+                        &v.parents,
+                        alloc,
+                    );
+
+                neighbours.push((
+                    NovelAtomLHS {},
+                    allocate_if_new(
+                        Vertex {
+                            neighbours: RefCell::new(None),
+                            predecessor: Cell::new(None),
+                            lhs_syntax,
+                            rhs_syntax,
+                            parents,
+                            lhs_parent_id,
+                            rhs_parent_id,
+                        },
+                        alloc,
+                        seen,
+                    ),
+                ));
+            }
+            Syntax::List { children, .. } => {
+                let lhs_next = children.first().copied();
+
+                let parents_next = push_lhs_delimiter(&v.parents, lhs_syntax, alloc);
+
+                let (lhs_syntax, rhs_syntax, lhs_parent_id, rhs_parent_id, parents) =
+                    pop_all_parents(
+                        lhs_next,
+                        v.rhs_syntax,
+                        Some(lhs_syntax.id()),
+                        v.rhs_parent_id,
+                        &parents_next,
+                        alloc,
+                    );
+
+                neighbours.push((
+                    EnterNovelDelimiterLHS {},
+                    allocate_if_new(
+                        Vertex {
+                            neighbours: RefCell::new(None),
+                            predecessor: Cell::new(None),
+                            lhs_syntax,
+                            rhs_syntax,
+                            parents,
+                            lhs_parent_id,
+                            rhs_parent_id,
+                        },
+                        alloc,
+                        seen,
+                    ),
+                ));
+            }
+        }
+    }
+
+    if let Some(rhs_syntax) = &v.rhs_syntax {
+        match rhs_syntax {
+            Syntax::Atom { .. } => {
+                let (lhs_syntax, rhs_syntax, lhs_parent_id, rhs_parent_id, parents) =
+                    pop_all_parents(
+                        v.lhs_syntax,
+                        rhs_syntax.next_sibling(),
+                        v.lhs_parent_id,
+                        v.rhs_parent_id,
+                        &v.parents,
+                        alloc,
+                    );
+
+                neighbours.push((
+                    NovelAtomRHS {},
+                    allocate_if_new(
+                        Vertex {
+                            neighbours: RefCell::new(None),
+                            predecessor: Cell::new(None),
+                            lhs_syntax,
+                            rhs_syntax,
+                            parents,
+                            lhs_parent_id,
+                            rhs_parent_id,
+                        },
+                        alloc,
+                        seen,
+                    ),
+                ));
+            }
+            Syntax::List { children, .. } => {
+                let rhs_next = children.first().copied();
+                let parents_next = push_rhs_delimiter(&v.parents, rhs_syntax, alloc);
+
+                let (lhs_syntax, rhs_syntax, lhs_parent_id, rhs_parent_id, parents) =
+                    pop_all_parents(
+                        v.lhs_syntax,
+                        rhs_next,
+                        v.lhs_parent_id,
+                        Some(rhs_syntax.id()),
+                        &parents_next,
+                        alloc,
+                    );
+
+                neighbours.push((
+                    EnterNovelDelimiterRHS {},
+                    allocate_if_new(
+                        Vertex {
+                            neighbours: RefCell::new(None),
+                            predecessor: Cell::new(None),
+                            lhs_syntax,
+                            rhs_syntax,
+                            parents,
+                            lhs_parent_id,
+                            rhs_parent_id,
+                        },
+                        alloc,
+                        seen,
+                    ),
+                ));
+            }
+        }
+    }
+    assert!(
+        !neighbours.is_empty(),
+        "Must always find some next steps if node is not the end"
+    );
+
+    v.neighbours
+        .replace(Some(alloc.alloc_slice_copy(neighbours.as_slice())));
+}
+
+pub(crate) fn populate_change_map<'s, 'v>(
+    route: &[(Edge, &'v Vertex<'s, 'v>)],
+    change_map: &mut ChangeMap<'s>,
+) {
+    for (e, v) in route {
+        match e {
+            UnchangedNode { .. } => {
+                // No change on this node or its children.
+                let lhs = v
+                    .lhs_syntax
+                    .expect("Both syntaxes should be present for this edge");
+                let rhs = v
+                    .rhs_syntax
+                    .expect("Both syntaxes should be present for this edge");
+
+                insert_deep_unchanged(lhs, rhs, change_map);
+                insert_deep_unchanged(rhs, lhs, change_map);
+            }
+            EnterUnchangedDelimiter { .. } => {
+                // No change on the outer delimiter, but children may
+                // have changed.
+                let lhs = v
+                    .lhs_syntax
+                    .expect("Both syntaxes should be present for this edge");
+                let rhs = v
+                    .rhs_syntax
+                    .expect("Both syntaxes should be present for this edge");
+                change_map.insert(lhs, ChangeKind::Unchanged(rhs));
+                change_map.insert(rhs, ChangeKind::Unchanged(lhs));
+            }
+            ReplacedComment { levenshtein_pct } | ReplacedString { levenshtein_pct } => {
+                let lhs = v
+                    .lhs_syntax
+                    .expect("Both syntaxes should be present for this edge");
+                let rhs = v
+                    .rhs_syntax
+                    .expect("Both syntaxes should be present for this edge");
+                let change_kind = |first, second| {
+                    if matches!(e, ReplacedComment { .. }) {
+                        ChangeKind::ReplacedComment(first, second)
+                    } else {
+                        ChangeKind::ReplacedString(first, second)
+                    }
+                };
+
+                if *levenshtein_pct > 20 {
+                    change_map.insert(lhs, change_kind(lhs, rhs));
+                    change_map.insert(rhs, change_kind(rhs, lhs));
+                } else {
+                    change_map.insert(lhs, ChangeKind::Novel);
+                    change_map.insert(rhs, ChangeKind::Novel);
+                }
+            }
+            NovelAtomLHS { .. } | EnterNovelDelimiterLHS { .. } => {
+                let lhs = v
+                    .lhs_syntax
+                    .expect("LHS syntax should be present for this edge");
+                change_map.insert(lhs, ChangeKind::Novel);
+            }
+            NovelAtomRHS { .. } | EnterNovelDelimiterRHS { .. } => {
+                let rhs = v
+                    .rhs_syntax
+                    .expect("RHS syntax should be present for this edge");
+                change_map.insert(rhs, ChangeKind::Novel);
+            }
+        }
+    }
+}

--- a/crates/ast_diff/src/hash.rs
+++ b/crates/ast_diff/src/hash.rs
@@ -1,0 +1,16 @@
+use std::hash::BuildHasherDefault;
+
+use rustc_hash::{FxHashSet, FxHasher};
+
+/// A fast hashmap with no hash DoS protection. This is used in
+/// extremely hot code.
+///
+/// Wrapping FxHasher (the fastest hash algorithm in benchmarks) in a
+/// hashbrown::HashMap rather than std HashMap is a little faster, and
+/// it also allows us to use the entry_ref API which is unavailable in
+/// stable Rust.
+pub(crate) type DftHashMap<K, V> = hashbrown::HashMap<K, V, BuildHasherDefault<FxHasher>>;
+
+/// A fast hash set with no hash DoS protection. This is a simple
+/// alias, but added for consistency with `DftHashMap`.
+pub(crate) type DftHashSet<V> = FxHashSet<V>;

--- a/crates/ast_diff/src/lcs_diff.rs
+++ b/crates/ast_diff/src/lcs_diff.rs
@@ -1,0 +1,151 @@
+use std::hash::Hash;
+
+use crate::hash::DftHashMap;
+
+#[derive(Debug, PartialEq)]
+pub(crate) enum DiffResult<T> {
+    Left(T),
+    Both(T, T),
+    Right(T),
+}
+
+pub(crate) fn slice<'a, T: PartialEq + Clone>(
+    lhs: &'a [T],
+    rhs: &'a [T],
+) -> Vec<DiffResult<&'a T>> {
+    wu_diff::diff(lhs, rhs)
+        .into_iter()
+        .map(|result| match result {
+            wu_diff::DiffResult::Removed(r) => DiffResult::Left(
+                &lhs[r
+                    .old_index
+                    .expect("Index should be present for this diff variant")],
+            ),
+            wu_diff::DiffResult::Common(c) => {
+                let lhs_id = c
+                    .old_index
+                    .expect("Index should be present for this diff variant");
+                let rhs_id = c
+                    .new_index
+                    .expect("Index should be present for this diff variant");
+                DiffResult::Both(&lhs[lhs_id], &rhs[rhs_id])
+            }
+            wu_diff::DiffResult::Added(a) => DiffResult::Right(
+                &rhs[a
+                    .new_index
+                    .expect("Index should be present for this diff variant")],
+            ),
+        })
+        .collect::<Vec<_>>()
+}
+
+#[allow(dead_code)]
+pub(crate) fn slice_by_hash<'a, T: Eq + Hash>(
+    lhs: &'a [T],
+    rhs: &'a [T],
+) -> Vec<DiffResult<&'a T>> {
+    //
+    // This is the decorate-sort-undecorate pattern, or Schwartzian
+    // transform, for diffing.
+    let mut value_ids: DftHashMap<&T, u32> = DftHashMap::default();
+    let mut id_values: DftHashMap<u32, &T> = DftHashMap::default();
+
+    let mut lhs_ids = Vec::with_capacity(lhs.len());
+    for value in lhs {
+        let id: u32 = match value_ids.get(value) {
+            Some(id) => *id,
+            None => {
+                let new_id = value_ids.len() as u32;
+                value_ids.insert(value, new_id);
+                id_values.insert(new_id, value);
+                new_id
+            }
+        };
+        lhs_ids.push(id);
+    }
+
+    let mut rhs_ids = Vec::with_capacity(rhs.len());
+    for value in rhs {
+        let id = match value_ids.get(value) {
+            Some(id) => *id,
+            None => {
+                let new_id = value_ids.len() as u32;
+                value_ids.insert(value, new_id);
+                id_values.insert(new_id, value);
+                new_id
+            }
+        };
+        rhs_ids.push(id);
+    }
+
+    slice(&lhs_ids[..], &rhs_ids[..])
+        .into_iter()
+        .map(|result| match result {
+            DiffResult::Left(id) => {
+                DiffResult::Left(*id_values.get(id).expect("ID should be present in map"))
+            }
+            DiffResult::Both(lhs_id, rhs_id) => DiffResult::Both(
+                *id_values
+                    .get(lhs_id)
+                    .expect("ID should be present in map"),
+                *id_values
+                    .get(rhs_id)
+                    .expect("ID should be present in map"),
+            ),
+            DiffResult::Right(id) => {
+                DiffResult::Right(*id_values.get(id).expect("ID should be present in map"))
+            }
+        })
+        .collect::<Vec<_>>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_slice_same_items() {
+        let diff_items = slice(&["a", "b"], &["a", "b"]);
+        assert_eq!(
+            diff_items,
+            vec![DiffResult::Both(&"a", &"a"), DiffResult::Both(&"b", &"b")]
+        );
+    }
+
+    #[test]
+    fn test_slice_different_items() {
+        let diff_items = slice(&["a", "b"], &["c", "d"]);
+        assert_eq!(
+            diff_items,
+            vec![
+                DiffResult::Left(&"a"),
+                DiffResult::Left(&"b"),
+                DiffResult::Right(&"c"),
+                DiffResult::Right(&"d"),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_slice_by_hash_same_items() {
+        let diff_items = slice_by_hash(&["a", "b"], &["a", "b"]);
+        assert_eq!(
+            diff_items,
+            vec![DiffResult::Both(&"a", &"a"), DiffResult::Both(&"b", &"b")]
+        );
+    }
+
+    #[test]
+    fn test_slice_by_hash_different_items() {
+        let diff_items = slice_by_hash(&["a", "b"], &["c", "d"]);
+        assert_eq!(
+            diff_items,
+            vec![
+                DiffResult::Left(&"a"),
+                DiffResult::Left(&"b"),
+                DiffResult::Right(&"c"),
+                DiffResult::Right(&"d"),
+            ]
+        );
+    }
+}

--- a/crates/ast_diff/src/lcs_diff.rs
+++ b/crates/ast_diff/src/lcs_diff.rs
@@ -85,12 +85,8 @@ pub(crate) fn slice_by_hash<'a, T: Eq + Hash>(
                 DiffResult::Left(*id_values.get(id).expect("ID should be present in map"))
             }
             DiffResult::Both(lhs_id, rhs_id) => DiffResult::Both(
-                *id_values
-                    .get(lhs_id)
-                    .expect("ID should be present in map"),
-                *id_values
-                    .get(rhs_id)
-                    .expect("ID should be present in map"),
+                *id_values.get(lhs_id).expect("ID should be present in map"),
+                *id_values.get(rhs_id).expect("ID should be present in map"),
             ),
             DiffResult::Right(id) => {
                 DiffResult::Right(*id_values.get(id).expect("ID should be present in map"))

--- a/crates/ast_diff/src/sliders.rs
+++ b/crates/ast_diff/src/sliders.rs
@@ -34,7 +34,7 @@
 //! for a thorough discussion.
 
 use crate::{
-    changes::{insert_deep_novel, insert_deep_unchanged, ChangeKind::*, ChangeMap},
+    changes::{ChangeKind::*, ChangeMap, insert_deep_novel, insert_deep_unchanged},
     syntax::Syntax::{self, *},
 };
 

--- a/crates/ast_diff/src/sliders.rs
+++ b/crates/ast_diff/src/sliders.rs
@@ -1,0 +1,491 @@
+//! Prefer contiguous novel nodes on the same line.
+//!
+//! A slider takes the following form:
+//!
+//! Old:
+//!
+//! ```text
+//! A B
+//! C D
+//! ```
+//!
+//! New:
+//!
+//! ```text
+//! A B
+//! A B
+//! C D
+//! ```
+//!
+//! It would be correct, but ugly, to show the following diff:
+//!
+//! ```text
+//! A +B+
+//! +A+ B
+//! C D
+//! ```
+//!
+//! This module fixes these cases. It identifies situations where we
+//! can change which item is marked as novel (e.g. either `B` in the
+//! example above) whilst still showing a valid, minimal diff.
+//!
+//! A similar problem exists with line-oriented diffs, see
+//! [diff-slider-tools](https://github.com/mhagger/diff-slider-tools)
+//! for a thorough discussion.
+
+use crate::{
+    changes::{insert_deep_novel, insert_deep_unchanged, ChangeKind::*, ChangeMap},
+    syntax::Syntax::{self, *},
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SliderPreference {
+    PreferOuter,
+    #[default]
+    PreferInner,
+}
+
+pub(crate) fn fix_all_sliders<'a>(
+    preference: SliderPreference,
+    nodes: &[&'a Syntax<'a>],
+    change_map: &mut ChangeMap<'a>,
+) {
+    // TODO: fix sliders that require more than two steps.
+    fix_all_sliders_one_step(nodes, change_map);
+    fix_all_sliders_one_step(nodes, change_map);
+
+    fix_all_nested_sliders(preference, nodes, change_map);
+}
+
+fn fix_all_sliders_one_step<'a>(nodes: &[&'a Syntax<'a>], change_map: &mut ChangeMap<'a>) {
+    for node in nodes {
+        if let List { children, .. } = node {
+            fix_all_sliders_one_step(children, change_map);
+        }
+    }
+    fix_sliders(nodes, change_map);
+}
+
+fn fix_all_nested_sliders<'a>(
+    preference: SliderPreference,
+    nodes: &[&'a Syntax<'a>],
+    change_map: &mut ChangeMap<'a>,
+) {
+    let prefer_outer = preference == SliderPreference::PreferOuter;
+    for node in nodes {
+        if prefer_outer {
+            fix_nested_slider_prefer_outer(node, change_map);
+        } else {
+            fix_nested_slider_prefer_inner(node, change_map);
+        }
+    }
+}
+
+fn fix_nested_slider_prefer_outer<'a>(node: &'a Syntax<'a>, change_map: &mut ChangeMap<'a>) {
+    if let List { children, .. } = node {
+        match change_map
+            .get(node)
+            .expect("Changes should be set before slider correction")
+        {
+            Unchanged(_) => {
+                let mut candidates = vec![];
+                unchanged_descendants_for_outer_slider(children, &mut candidates, change_map);
+
+                if let [candidate] = candidates[..] {
+                    if matches!(candidate, List { .. })
+                        && matches!(change_map.get(candidate), Some(Novel))
+                    {
+                        push_unchanged_to_descendant(node, candidate, change_map);
+                    }
+                }
+            }
+            ReplacedComment(_, _) | ReplacedString(_, _) | Novel => {}
+        }
+
+        for child in children {
+            fix_nested_slider_prefer_outer(child, change_map);
+        }
+    }
+}
+
+fn fix_nested_slider_prefer_inner<'a>(node: &'a Syntax<'a>, change_map: &mut ChangeMap<'a>) {
+    if let List { children, .. } = node {
+        match change_map
+            .get(node)
+            .expect("Changes should be set before slider correction")
+        {
+            Unchanged(_) => {}
+            ReplacedComment(_, _) | ReplacedString(_, _) => {}
+            Novel => {
+                let mut found_unchanged = vec![];
+                unchanged_descendants(children, &mut found_unchanged, change_map);
+
+                if let [List { .. }] = found_unchanged[..] {
+                    push_unchanged_to_ancestor(node, found_unchanged[0], change_map);
+                }
+            }
+        }
+
+        for child in children {
+            fix_nested_slider_prefer_inner(child, change_map);
+        }
+    }
+}
+
+fn unchanged_descendants<'a>(
+    nodes: &[&'a Syntax<'a>],
+    found: &mut Vec<&'a Syntax<'a>>,
+    change_map: &ChangeMap<'a>,
+) {
+    if found.len() > 1 {
+        return;
+    }
+
+    for node in nodes {
+        match change_map.get(node).expect("Node changes should be set") {
+            Unchanged(_) => {
+                found.push(node);
+            }
+            Novel | ReplacedComment(_, _) | ReplacedString(_, _) => {
+                if let List { children, .. } = node {
+                    unchanged_descendants(children, found, change_map);
+                }
+            }
+        }
+    }
+}
+
+fn unchanged_descendants_for_outer_slider<'a>(
+    nodes: &[&'a Syntax<'a>],
+    found: &mut Vec<&'a Syntax<'a>>,
+    change_map: &ChangeMap<'a>,
+) {
+    if found.len() > 1 {
+        return;
+    }
+
+    for node in nodes {
+        let is_unchanged = matches!(change_map.get(node), Some(Unchanged(_)));
+
+        match node {
+            Atom { .. } => {
+                if is_unchanged {
+                    // Sliding requires a single list, so an unchanged atom means we can't slide.
+                    found.push(node);
+                    break;
+                }
+            }
+            List { children, .. } => {
+                if is_unchanged {
+                    // Can't slide unchanged delimiters.
+                    found.push(node);
+                    break;
+                } else {
+                    let has_unchanged_children = children
+                        .iter()
+                        .any(|node| matches!(change_map.get(node), Some(Unchanged(_))));
+                    if has_unchanged_children {
+                        found.push(node);
+                    } else {
+                        unchanged_descendants_for_outer_slider(children, found, change_map);
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn push_unchanged_to_descendant<'a>(
+    root: &'a Syntax<'a>,
+    inner: &'a Syntax<'a>,
+    change_map: &mut ChangeMap<'a>,
+) {
+    let root_change = change_map
+        .get(root)
+        .expect("Changes should be set before slider correction");
+
+    let delimiters_match = match (root, inner) {
+        (
+            List {
+                open_content: root_open,
+                close_content: root_close,
+                ..
+            },
+            List {
+                open_content: inner_open,
+                close_content: inner_close,
+                ..
+            },
+        ) => root_open == inner_open && root_close == inner_close,
+        _ => false,
+    };
+
+    if delimiters_match {
+        change_map.insert(root, Novel);
+        change_map.insert(inner, root_change);
+    }
+}
+
+fn push_unchanged_to_ancestor<'a>(
+    root: &'a Syntax<'a>,
+    inner: &'a Syntax<'a>,
+    change_map: &mut ChangeMap<'a>,
+) {
+    let inner_change = change_map.get(inner).expect("Node changes should be set");
+
+    let delimiters_match = match (root, inner) {
+        (
+            List {
+                open_content: root_open,
+                close_content: root_close,
+                ..
+            },
+            List {
+                open_content: inner_open,
+                close_content: inner_close,
+                ..
+            },
+        ) => root_open == inner_open && root_close == inner_close,
+        _ => false,
+    };
+
+    if delimiters_match {
+        change_map.insert(root, inner_change);
+        change_map.insert(inner, Novel);
+    }
+}
+
+fn fix_sliders<'a>(nodes: &[&'a Syntax<'a>], change_map: &mut ChangeMap<'a>) {
+    for (region_start, region_end) in novel_regions_after_unchanged(nodes, change_map) {
+        slide_to_prev_node(nodes, change_map, region_start, region_end);
+    }
+    for (region_start, region_end) in novel_regions_before_unchanged(nodes, change_map) {
+        slide_to_next_node(nodes, change_map, region_start, region_end);
+    }
+}
+
+fn novel_regions_after_unchanged<'a>(
+    nodes: &[&'a Syntax<'a>],
+    change_map: &ChangeMap<'a>,
+) -> Vec<(usize, usize)> {
+    let mut regions: Vec<Vec<usize>> = vec![];
+    let mut region: Option<Vec<usize>> = None;
+
+    for (i, node) in nodes.iter().enumerate() {
+        let change = change_map.get(node).expect("Node changes should be set");
+
+        match change {
+            Unchanged(_) => {
+                if let Some(region) = region {
+                    regions.push(region);
+                }
+                region = Some(vec![]);
+            }
+            Novel => {
+                if let Some(mut r) = region {
+                    r.push(i);
+                    region = Some(r);
+                }
+            }
+            ReplacedComment(_, _) | ReplacedString(_, _) => {
+                if let Some(region) = region {
+                    regions.push(region);
+                }
+                region = None;
+            }
+        }
+    }
+
+    if let Some(region) = region {
+        regions.push(region);
+    }
+
+    regions
+        .into_iter()
+        .filter(|r| !r.is_empty())
+        .map(|r| {
+            (
+                *r.first().expect("Region should be non-empty after filter"),
+                *r.last().expect("Region should be non-empty after filter"),
+            )
+        })
+        .collect()
+}
+
+fn novel_regions_before_unchanged<'a>(
+    nodes: &[&'a Syntax<'a>],
+    change_map: &ChangeMap<'a>,
+) -> Vec<(usize, usize)> {
+    let mut regions: Vec<Vec<usize>> = vec![];
+    let mut region: Option<Vec<usize>> = None;
+
+    for (i, node) in nodes.iter().enumerate() {
+        let change = change_map.get(node).expect("Node changes should be set");
+
+        match change {
+            Unchanged(_) => {
+                if let Some(region) = region {
+                    regions.push(region);
+                }
+                region = None;
+            }
+            Novel => {
+                let mut r = region.unwrap_or_default();
+                r.push(i);
+                region = Some(r);
+            }
+            ReplacedComment(_, _) | ReplacedString(_, _) => {
+                region = None;
+            }
+        }
+    }
+
+    if let Some(region) = region {
+        regions.push(region);
+    }
+
+    regions
+        .into_iter()
+        .filter(|r| !r.is_empty())
+        .map(|r| {
+            (
+                *r.first().expect("Region should be non-empty after filter"),
+                *r.last().expect("Region should be non-empty after filter"),
+            )
+        })
+        .collect()
+}
+
+fn is_novel_deep<'a>(node: &Syntax<'a>, change_map: &ChangeMap<'a>) -> bool {
+    match node {
+        List { children, .. } => {
+            if !matches!(change_map.get(node), Some(Novel)) {
+                return false;
+            }
+            for child in children {
+                if !is_novel_deep(child, change_map) {
+                    return false;
+                }
+            }
+
+            true
+        }
+        Atom { .. } => matches!(change_map.get(node), Some(Novel)),
+    }
+}
+
+fn slide_to_prev_node<'a>(
+    nodes: &[&'a Syntax<'a>],
+    change_map: &mut ChangeMap<'a>,
+    start_idx: usize,
+    end_idx: usize,
+) {
+    if start_idx == 0 {
+        return;
+    }
+    if start_idx == end_idx {
+        return;
+    }
+
+    let start_node = nodes[start_idx];
+    let last_node = nodes[end_idx];
+    let before_start_node = nodes[start_idx - 1];
+    let before_last_node = nodes[end_idx - 1];
+
+    if before_start_node.content_id() != last_node.content_id() {
+        return;
+    }
+
+    let distance_to_before_start = distance_between(before_start_node, start_node);
+    let distance_to_last = distance_between(before_last_node, last_node);
+
+    if distance_to_before_start <= distance_to_last {
+        let opposite = match change_map
+            .get(before_start_node)
+            .expect("Node changes should be set")
+        {
+            Unchanged(n) => {
+                if before_start_node.content_id() != n.content_id() {
+                    return;
+                }
+                n
+            }
+            _ => {
+                return;
+            }
+        };
+
+        for node in &nodes[start_idx..=end_idx] {
+            if !is_novel_deep(node, change_map) {
+                return;
+            }
+        }
+
+        insert_deep_novel(before_start_node, change_map);
+        insert_deep_unchanged(last_node, opposite, change_map);
+        insert_deep_unchanged(opposite, last_node, change_map);
+    }
+}
+
+fn slide_to_next_node<'a>(
+    nodes: &[&'a Syntax<'a>],
+    change_map: &mut ChangeMap<'a>,
+    start_idx: usize,
+    end_idx: usize,
+) {
+    if end_idx == nodes.len() - 1 {
+        return;
+    }
+    if start_idx == end_idx {
+        return;
+    }
+
+    let start_node = nodes[start_idx];
+    let last_node = nodes[end_idx];
+    let after_start_node = nodes[start_idx + 1];
+    let after_last_node = nodes[end_idx + 1];
+
+    if after_last_node.content_id() != start_node.content_id() {
+        return;
+    }
+
+    let distance_to_start = distance_between(start_node, after_start_node);
+    let distance_to_after_last = distance_between(last_node, after_last_node);
+
+    if distance_to_after_last < distance_to_start {
+        let opposite = match change_map
+            .get(after_last_node)
+            .expect("Node changes should be set")
+        {
+            Unchanged(n) => {
+                if after_last_node.content_id() != n.content_id() {
+                    return;
+                }
+                n
+            }
+            _ => {
+                return;
+            }
+        };
+        for node in &nodes[start_idx..=end_idx] {
+            if !is_novel_deep(node, change_map) {
+                return;
+            }
+        }
+
+        insert_deep_unchanged(start_node, opposite, change_map);
+        insert_deep_unchanged(opposite, start_node, change_map);
+        insert_deep_novel(after_last_node, change_map);
+    }
+}
+
+fn distance_between(prev: &Syntax, next: &Syntax) -> (usize, usize) {
+    let prev_end = prev.byte_range().end;
+    let next_start = next.byte_range().start;
+
+    if next_start > prev_end {
+        (next_start - prev_end, 0)
+    } else {
+        (0, 0)
+    }
+}

--- a/crates/ast_diff/src/stack.rs
+++ b/crates/ast_diff/src/stack.rs
@@ -1,0 +1,47 @@
+use bumpalo::Bump;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct Node<'b, T> {
+    val: T,
+    next: Option<&'b Node<'b, T>>,
+}
+
+/// A persistent stack.
+///
+/// This is similar to `Stack` from the rpds crate, but it's faster
+/// and uses less memory.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct Stack<'b, T> {
+    head: Option<&'b Node<'b, T>>,
+}
+
+impl<'b, T> Stack<'b, T> {
+    pub(crate) fn new() -> Self {
+        Self { head: None }
+    }
+
+    pub(crate) fn peek(&self) -> Option<&T> {
+        self.head.map(|n| &n.val)
+    }
+
+    pub(crate) fn pop(&self) -> Option<Self> {
+        self.head.map(|n| Self { head: n.next })
+    }
+
+    pub(crate) fn push(&self, v: T, alloc: &'b Bump) -> Self {
+        Self {
+            head: Some(alloc.alloc(Node {
+                val: v,
+                next: self.head,
+            })),
+        }
+    }
+
+    pub(crate) fn size(&self) -> usize {
+        std::iter::successors(self.head, |&n| n.next).count()
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.head.is_none()
+    }
+}

--- a/crates/ast_diff/src/syntax.rs
+++ b/crates/ast_diff/src/syntax.rs
@@ -1,12 +1,6 @@
 //! Syntax tree definitions with change metadata.
 
-use std::{
-    cell::Cell,
-    fmt,
-    hash::Hash,
-    num::NonZeroU32,
-    ops::Range,
-};
+use std::{cell::Cell, fmt, hash::Hash, num::NonZeroU32, ops::Range};
 
 use bumpalo::Bump;
 

--- a/crates/ast_diff/src/syntax.rs
+++ b/crates/ast_diff/src/syntax.rs
@@ -1,0 +1,489 @@
+//! Syntax tree definitions with change metadata.
+
+use std::{
+    cell::Cell,
+    fmt,
+    hash::Hash,
+    num::NonZeroU32,
+    ops::Range,
+};
+
+use bumpalo::Bump;
+
+use crate::hash::DftHashMap;
+
+/// A unique identifier for a syntax node.
+pub type SyntaxId = NonZeroU32;
+
+/// A content-based identifier for comparing syntax nodes.
+pub type ContentId = u32;
+
+/// Fields that are common to both `Syntax::List` and `Syntax::Atom`.
+pub struct SyntaxInfo<'a> {
+    /// The previous node with the same parent as this one.
+    previous_sibling: Cell<Option<&'a Syntax<'a>>>,
+    /// The next node with the same parent as this one.
+    next_sibling: Cell<Option<&'a Syntax<'a>>>,
+    /// The syntax node that occurs before this one, in a depth-first
+    /// tree traversal.
+    prev: Cell<Option<&'a Syntax<'a>>>,
+    /// The parent syntax node, if present.
+    parent: Cell<Option<&'a Syntax<'a>>>,
+    /// The number of nodes that are ancestors of this one.
+    num_ancestors: Cell<u32>,
+    pub(crate) num_after: Cell<usize>,
+    /// A number that uniquely identifies this syntax node.
+    unique_id: Cell<SyntaxId>,
+    /// A number that uniquely identifies the content of this syntax
+    /// node. This may be the same as nodes on the other side of the
+    /// diff, or nodes at different positions.
+    ///
+    /// Values are sequential, not hashes. Collisions never occur.
+    content_id: Cell<ContentId>,
+    /// Is this the only node with this content? Ignores nodes on the
+    /// other side.
+    content_is_unique: Cell<bool>,
+}
+
+impl<'a> SyntaxInfo<'a> {
+    pub(crate) fn new() -> Self {
+        Self {
+            previous_sibling: Cell::new(None),
+            next_sibling: Cell::new(None),
+            prev: Cell::new(None),
+            parent: Cell::new(None),
+            num_ancestors: Cell::new(0),
+            num_after: Cell::new(0),
+            unique_id: Cell::new(NonZeroU32::new(u32::MAX).unwrap()),
+            content_id: Cell::new(0),
+            content_is_unique: Cell::new(false),
+        }
+    }
+}
+
+impl Default for SyntaxInfo<'_> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Different types of strings. We want to diff these the same way,
+/// but highlight them differently.
+#[derive(PartialEq, Eq, Debug, Clone, Copy, Hash)]
+pub enum StringKind {
+    /// A string literal, such as `"foo"`.
+    StringLiteral,
+    /// Plain text, such as the content of `<p>foo</p>`.
+    Text,
+}
+
+/// The kind of an atom node.
+#[derive(PartialEq, Eq, Debug, Clone, Copy, Hash)]
+pub enum AtomKind {
+    /// The kind of this atom when we don't know anything else about
+    /// it. This is typically a variable, e.g. `foo`, or a literal
+    /// `123`. Note that string literals have a separate kind.
+    Normal,
+    /// A string literal or text content.
+    String(StringKind),
+    /// A type name.
+    Type,
+    /// A comment.
+    Comment,
+    /// A keyword.
+    Keyword,
+    /// A tree-sitter error node.
+    TreeSitterError,
+}
+
+/// A syntax node in the diff tree.
+///
+/// Syntax trees are built from tree-sitter parse trees and simplified
+/// into a List/Atom representation that's easier to diff.
+pub enum Syntax<'a> {
+    /// A list node with delimiters and children.
+    List {
+        info: SyntaxInfo<'a>,
+        /// Byte range of the opening delimiter.
+        open_position: Range<usize>,
+        /// Content of the opening delimiter (e.g., "(", "{", "[").
+        open_content: String,
+        /// Child syntax nodes.
+        children: Vec<&'a Syntax<'a>>,
+        /// Byte range of the closing delimiter.
+        close_position: Range<usize>,
+        /// Content of the closing delimiter (e.g., ")", "}", "]").
+        close_content: String,
+        /// Total number of descendant nodes.
+        num_descendants: u32,
+    },
+    /// An atom node (leaf) such as an identifier, literal, or comment.
+    Atom {
+        info: SyntaxInfo<'a>,
+        /// Byte range of this atom.
+        position: Range<usize>,
+        /// Text content of the atom.
+        content: String,
+        /// The kind of atom.
+        kind: AtomKind,
+    },
+}
+
+impl<'a> fmt::Debug for Syntax<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Syntax::List {
+                open_content,
+                open_position,
+                children,
+                close_content,
+                close_position,
+                ..
+            } => f
+                .debug_struct(&format!(
+                    "List id:{} content_id:{}",
+                    self.id(),
+                    self.content_id()
+                ))
+                .field("open_content", &open_content)
+                .field("open_position", &open_position)
+                .field("children", &children)
+                .field("close_content", &close_content)
+                .field("close_position", &close_position)
+                .finish(),
+            Syntax::Atom {
+                content,
+                position,
+                kind,
+                ..
+            } => f
+                .debug_struct(&format!(
+                    "Atom id:{} content_id:{}",
+                    self.id(),
+                    self.content_id()
+                ))
+                .field("content", &content)
+                .field("position", &position)
+                .field("kind", &kind)
+                .finish(),
+        }
+    }
+}
+
+impl<'a> Syntax<'a> {
+    pub fn new_list(
+        arena: &'a Bump,
+        open_content: &str,
+        open_position: Range<usize>,
+        children: Vec<&'a Self>,
+        close_content: &str,
+        close_position: Range<usize>,
+    ) -> &'a Self {
+        // Skip empty atoms: they aren't displayed, so there's no
+        // point making our syntax tree bigger.
+        let children = children
+            .into_iter()
+            .filter(|n| match n {
+                Syntax::List { .. } => true,
+                Syntax::Atom { content, .. } => !content.is_empty(),
+            })
+            .collect::<Vec<_>>();
+
+        // Don't bother creating a list if we have no open/close and
+        // there's only one child.
+        if children.len() == 1 && open_content.is_empty() && close_content.is_empty() {
+            return children[0];
+        }
+
+        let mut num_descendants = 0;
+        for child in &children {
+            num_descendants += match child {
+                Syntax::List {
+                    num_descendants, ..
+                } => *num_descendants + 1,
+                Syntax::Atom { .. } => 1,
+            };
+        }
+
+        arena.alloc(Syntax::List {
+            info: SyntaxInfo::default(),
+            open_position,
+            open_content: open_content.into(),
+            close_content: close_content.into(),
+            close_position,
+            children,
+            num_descendants,
+        })
+    }
+
+    pub fn new_atom(
+        arena: &'a Bump,
+        position: Range<usize>,
+        mut content: String,
+        kind: AtomKind,
+    ) -> &'a Self {
+        // If content ends with \r on CRLF files, discard it.
+        if content.ends_with('\r') {
+            content.pop();
+        }
+
+        // If content ends with newline, discard it.
+        if content.ends_with('\n') {
+            content.pop();
+        }
+
+        arena.alloc(Syntax::Atom {
+            info: SyntaxInfo::default(),
+            position,
+            content,
+            kind,
+        })
+    }
+
+    pub(crate) fn info(&self) -> &SyntaxInfo<'a> {
+        match self {
+            Syntax::List { info, .. } | Syntax::Atom { info, .. } => info,
+        }
+    }
+
+    pub fn parent(&self) -> Option<&'a Self> {
+        self.info().parent.get()
+    }
+
+    pub fn next_sibling(&self) -> Option<&'a Self> {
+        self.info().next_sibling.get()
+    }
+
+    pub fn id(&self) -> SyntaxId {
+        self.info().unique_id.get()
+    }
+
+    pub fn content_id(&self) -> ContentId {
+        self.info().content_id.get()
+    }
+
+    pub fn content_is_unique(&self) -> bool {
+        self.info().content_is_unique.get()
+    }
+
+    pub fn num_ancestors(&self) -> u32 {
+        self.info().num_ancestors.get()
+    }
+
+    pub fn byte_range(&self) -> Range<usize> {
+        match self {
+            Syntax::List {
+                open_position,
+                close_position,
+                ..
+            } => open_position.start..close_position.end,
+            Syntax::Atom { position, .. } => position.clone(),
+        }
+    }
+
+    pub fn dbg_content(&self) -> String {
+        match self {
+            Syntax::List {
+                open_content,
+                close_content,
+                open_position,
+                ..
+            } => {
+                format!(
+                    "byte:{} {} ... {}",
+                    open_position.start, open_content, close_content
+                )
+            }
+            Syntax::Atom {
+                content, position, ..
+            } => {
+                format!("byte:{} {}", position.start, content)
+            }
+        }
+    }
+}
+
+impl PartialEq for Syntax<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        debug_assert!(self.content_id() > 0);
+        debug_assert!(other.content_id() > 0);
+        self.content_id() == other.content_id()
+    }
+}
+
+impl<'a> Eq for Syntax<'a> {}
+
+pub fn init_all_info<'a>(lhs_roots: &[&'a Syntax<'a>], rhs_roots: &[&'a Syntax<'a>]) {
+    init_info(lhs_roots, rhs_roots);
+    init_next_prev(lhs_roots);
+    init_next_prev(rhs_roots);
+}
+
+fn init_info<'a>(lhs_roots: &[&'a Syntax<'a>], rhs_roots: &[&'a Syntax<'a>]) {
+    let mut id = NonZeroU32::new(1).unwrap();
+    init_info_on_side(lhs_roots, &mut id);
+    init_info_on_side(rhs_roots, &mut id);
+
+    let mut existing = DftHashMap::default();
+    set_content_id(lhs_roots, &mut existing);
+    set_content_id(rhs_roots, &mut existing);
+
+    set_content_is_unique(lhs_roots);
+    set_content_is_unique(rhs_roots);
+}
+
+type ContentKey = (Option<String>, Option<String>, Vec<u32>, bool, bool);
+
+fn set_content_id(nodes: &[&Syntax], existing: &mut DftHashMap<ContentKey, u32>) {
+    for node in nodes {
+        let key: ContentKey = match node {
+            Syntax::List {
+                open_content,
+                close_content,
+                children,
+                ..
+            } => {
+                // Recurse first, so children all have their content_id set.
+                set_content_id(children, existing);
+
+                let children_content_ids: Vec<_> =
+                    children.iter().map(|c| c.info().content_id.get()).collect();
+
+                (
+                    Some(open_content.clone()),
+                    Some(close_content.clone()),
+                    children_content_ids,
+                    true,
+                    true,
+                )
+            }
+            Syntax::Atom { content, kind, .. } => {
+                let is_comment = *kind == AtomKind::Comment;
+                (Some(content.clone()), None, vec![], false, is_comment)
+            }
+        };
+
+        // Ensure the ID is always greater than zero, so we can
+        // distinguish an uninitialised SyntaxInfo value.
+        let next_id = existing.len() as u32 + 1;
+        let content_id = existing.entry(key).or_insert(next_id);
+        node.info().content_id.set(*content_id);
+    }
+}
+
+fn set_num_after(nodes: &[&Syntax], parent_num_after: usize) {
+    for (i, node) in nodes.iter().enumerate() {
+        let num_after = parent_num_after + nodes.len() - 1 - i;
+        node.info().num_after.set(num_after);
+
+        if let Syntax::List { children, .. } = node {
+            set_num_after(children, num_after);
+        }
+    }
+}
+
+pub(crate) fn init_next_prev<'a>(roots: &[&'a Syntax<'a>]) {
+    set_prev_sibling(roots);
+    set_next_sibling(roots);
+    set_prev(roots, None);
+}
+
+fn init_info_on_side<'a>(roots: &[&'a Syntax<'a>], next_id: &mut SyntaxId) {
+    set_parent(roots, None);
+    set_num_ancestors(roots, 0);
+    set_num_after(roots, 0);
+    set_unique_id(roots, next_id);
+}
+
+fn set_unique_id(nodes: &[&Syntax], next_id: &mut SyntaxId) {
+    for node in nodes {
+        node.info().unique_id.set(*next_id);
+        *next_id = NonZeroU32::new(u32::from(*next_id) + 1)
+            .expect("Should not have more than u32::MAX nodes");
+        if let Syntax::List { children, .. } = node {
+            set_unique_id(children, next_id);
+        }
+    }
+}
+
+fn find_nodes_with_unique_content(nodes: &[&Syntax], counts: &mut DftHashMap<ContentId, usize>) {
+    for node in nodes {
+        *counts.entry(node.content_id()).or_insert(0) += 1;
+        if let Syntax::List { children, .. } = node {
+            find_nodes_with_unique_content(children, counts);
+        }
+    }
+}
+
+fn set_content_is_unique_from_counts(nodes: &[&Syntax], counts: &DftHashMap<ContentId, usize>) {
+    for node in nodes {
+        let count = counts
+            .get(&node.content_id())
+            .expect("Count should be present");
+        node.info().content_is_unique.set(*count == 1);
+
+        if let Syntax::List { children, .. } = node {
+            set_content_is_unique_from_counts(children, counts);
+        }
+    }
+}
+
+fn set_content_is_unique(nodes: &[&Syntax]) {
+    let mut counts = DftHashMap::default();
+    find_nodes_with_unique_content(nodes, &mut counts);
+    set_content_is_unique_from_counts(nodes, &counts);
+}
+
+fn set_prev_sibling<'a>(nodes: &[&'a Syntax<'a>]) {
+    let mut prev = None;
+
+    for node in nodes {
+        node.info().previous_sibling.set(prev);
+        prev = Some(*node);
+
+        if let Syntax::List { children, .. } = node {
+            set_prev_sibling(children);
+        }
+    }
+}
+
+fn set_next_sibling<'a>(nodes: &[&'a Syntax<'a>]) {
+    for (i, node) in nodes.iter().enumerate() {
+        let sibling = nodes.get(i + 1).copied();
+        node.info().next_sibling.set(sibling);
+
+        if let Syntax::List { children, .. } = node {
+            set_next_sibling(children);
+        }
+    }
+}
+
+fn set_prev<'a>(nodes: &[&'a Syntax<'a>], parent: Option<&'a Syntax<'a>>) {
+    for (i, node) in nodes.iter().enumerate() {
+        let node_prev = if i == 0 { parent } else { Some(nodes[i - 1]) };
+
+        node.info().prev.set(node_prev);
+        if let Syntax::List { children, .. } = node {
+            set_prev(children, Some(*node));
+        }
+    }
+}
+
+fn set_parent<'a>(nodes: &[&'a Syntax<'a>], parent: Option<&'a Syntax<'a>>) {
+    for node in nodes {
+        node.info().parent.set(parent);
+        if let Syntax::List { children, .. } = node {
+            set_parent(children, Some(*node));
+        }
+    }
+}
+
+fn set_num_ancestors(nodes: &[&Syntax], num_ancestors: u32) {
+    for node in nodes {
+        node.info().num_ancestors.set(num_ancestors);
+
+        if let Syntax::List { children, .. } = node {
+            set_num_ancestors(children, num_ancestors + 1);
+        }
+    }
+}

--- a/crates/ast_diff/src/unchanged.rs
+++ b/crates/ast_diff/src/unchanged.rs
@@ -1,0 +1,412 @@
+use std::hash::Hash;
+
+use crate::changes::{insert_deep_unchanged, ChangeKind, ChangeMap};
+use crate::hash::DftHashSet;
+use crate::lcs_diff;
+use crate::syntax::{ContentId, Syntax};
+
+const TINY_TREE_THRESHOLD: u32 = 10;
+const MOSTLY_UNCHANGED_MIN_COMMON_CHILDREN: usize = 4;
+
+pub(crate) fn mark_unchanged<'a>(
+    lhs_nodes: &[&'a Syntax<'a>],
+    rhs_nodes: &[&'a Syntax<'a>],
+    change_map: &mut ChangeMap<'a>,
+) -> Vec<(Vec<&'a Syntax<'a>>, Vec<&'a Syntax<'a>>)> {
+    let (_, lhs_nodes, rhs_nodes) = shrink_unchanged_at_ends(lhs_nodes, rhs_nodes, change_map);
+
+    let mut nodes_to_diff = vec![];
+    for (lhs_nodes, rhs_nodes) in split_mostly_unchanged_toplevel(&lhs_nodes, &rhs_nodes) {
+        let (_, lhs_nodes, rhs_nodes) =
+            shrink_unchanged_at_ends(&lhs_nodes, &rhs_nodes, change_map);
+        nodes_to_diff.extend(split_unchanged(&lhs_nodes, &rhs_nodes, change_map));
+    }
+
+    nodes_to_diff
+}
+
+#[derive(Debug)]
+enum ChangeState {
+    UnchangedDelimiter,
+    UnchangedNode,
+    PossiblyChanged,
+}
+
+fn split_unchanged<'a>(
+    lhs_nodes: &[&'a Syntax<'a>],
+    rhs_nodes: &[&'a Syntax<'a>],
+    change_map: &mut ChangeMap<'a>,
+) -> Vec<(Vec<&'a Syntax<'a>>, Vec<&'a Syntax<'a>>)> {
+    let size_threshold = if let Ok(env_threshold) = std::env::var("DFT_TINY_THRESHOLD") {
+        env_threshold
+            .parse::<u32>()
+            .ok()
+            .unwrap_or(TINY_TREE_THRESHOLD)
+    } else {
+        TINY_TREE_THRESHOLD
+    };
+
+    let mut res: Vec<(Vec<&'a Syntax<'a>>, Vec<&'a Syntax<'a>>)> = vec![];
+    for (cs, lhs_section_nodes, rhs_section_nodes) in
+        split_unchanged_toplevel(lhs_nodes, rhs_nodes, size_threshold)
+    {
+        match cs {
+            ChangeState::UnchangedDelimiter => {
+                assert_eq!(lhs_section_nodes.len(), rhs_section_nodes.len());
+                for (lhs_section_node, rhs_section_node) in
+                    lhs_section_nodes.iter().zip(rhs_section_nodes.iter())
+                {
+                    change_map.insert(lhs_section_node, ChangeKind::Unchanged(rhs_section_node));
+                    change_map.insert(rhs_section_node, ChangeKind::Unchanged(lhs_section_node));
+                }
+            }
+            ChangeState::UnchangedNode => {
+                assert_eq!(lhs_section_nodes.len(), rhs_section_nodes.len());
+                for (lhs_section_node, rhs_section_node) in
+                    lhs_section_nodes.iter().zip(rhs_section_nodes.iter())
+                {
+                    insert_deep_unchanged(lhs_section_node, rhs_section_node, change_map);
+                    insert_deep_unchanged(rhs_section_node, lhs_section_node, change_map);
+                }
+            }
+            ChangeState::PossiblyChanged => {
+                res.push((lhs_section_nodes, rhs_section_nodes));
+            }
+        }
+    }
+
+    res
+}
+
+fn split_unchanged_singleton_list<'a>(
+    lhs_nodes: &[&'a Syntax<'a>],
+    rhs_nodes: &[&'a Syntax<'a>],
+    size_threshold: u32,
+) -> Vec<(ChangeState, Vec<&'a Syntax<'a>>, Vec<&'a Syntax<'a>>)> {
+    let mut res: Vec<(ChangeState, Vec<&'a Syntax<'a>>, Vec<&'a Syntax<'a>>)> = vec![];
+    match as_singleton_list_children(lhs_nodes, rhs_nodes) {
+        Some((lhs_children, rhs_children)) => {
+            let mut split_children =
+                split_unchanged_toplevel(&lhs_children, &rhs_children, size_threshold);
+            if split_children.len() > 1 {
+                res.push((
+                    ChangeState::UnchangedDelimiter,
+                    lhs_nodes.to_vec(),
+                    rhs_nodes.to_vec(),
+                ));
+                // Managed to further split.
+                res.append(&mut split_children);
+            } else {
+                // Did not split further. Keep the outer list, so we can use
+                // its delimiter when doing the tree diff.
+                res.push((
+                    ChangeState::PossiblyChanged,
+                    lhs_nodes.to_vec(),
+                    rhs_nodes.to_vec(),
+                ));
+            }
+        }
+        None => {
+            res.push((
+                ChangeState::PossiblyChanged,
+                lhs_nodes.to_vec(),
+                rhs_nodes.to_vec(),
+            ));
+        }
+    }
+
+    res
+}
+
+fn find_unique_content_ids(node: &Syntax, unique_ids: &mut DftHashSet<ContentId>) {
+    if node.content_is_unique() {
+        unique_ids.insert(node.content_id());
+    }
+    if let Syntax::List { children, .. } = node {
+        for child in children {
+            find_unique_content_ids(child, unique_ids);
+        }
+    }
+}
+
+fn find_all_unique_content_ids(node: &Syntax) -> DftHashSet<u32> {
+    let mut unique_ids = DftHashSet::default();
+    find_unique_content_ids(node, &mut unique_ids);
+    unique_ids
+}
+
+fn count_unique_subtrees(node: &Syntax, opposite_unique_ids: &DftHashSet<u32>) -> usize {
+    if node.content_is_unique() && opposite_unique_ids.contains(&node.content_id()) {
+        // Ignore children as soon as find a unique node, to avoid
+        // overcounting.
+        return 1;
+    }
+
+    if let Syntax::List { children, .. } = node {
+        return children
+            .iter()
+            .map(|child| count_unique_subtrees(child, opposite_unique_ids))
+            .sum();
+    }
+
+    0
+}
+
+fn count_common_unique(lhs: &Syntax, rhs: &Syntax) -> usize {
+    let rhs_unique_ids = find_all_unique_content_ids(rhs);
+    count_unique_subtrees(lhs, &rhs_unique_ids)
+}
+
+fn is_mostly_unchanged_list(lhs: &Syntax, rhs: &Syntax) -> bool {
+    match (lhs, rhs) {
+        (Syntax::List { .. }, Syntax::List { .. }) => {
+            count_common_unique(lhs, rhs) >= MOSTLY_UNCHANGED_MIN_COMMON_CHILDREN
+        }
+        _ => false,
+    }
+}
+
+fn split_mostly_unchanged_toplevel<'a>(
+    lhs_nodes: &[&'a Syntax<'a>],
+    rhs_nodes: &[&'a Syntax<'a>],
+) -> Vec<(Vec<&'a Syntax<'a>>, Vec<&'a Syntax<'a>>)> {
+    let mut lhs_nodes = lhs_nodes;
+    let mut rhs_nodes = rhs_nodes;
+
+    let mut leading: Vec<(Vec<&'a Syntax<'a>>, Vec<&'a Syntax<'a>>)> = vec![];
+    while let (Some(lhs), Some(rhs)) = (lhs_nodes.first(), rhs_nodes.first()) {
+        if is_mostly_unchanged_list(lhs, rhs) {
+            leading.push((vec![lhs], vec![rhs]));
+
+            lhs_nodes = &lhs_nodes[1..];
+            rhs_nodes = &rhs_nodes[1..];
+        } else {
+            break;
+        }
+    }
+
+    let mut trailing: Vec<(Vec<&'a Syntax<'a>>, Vec<&'a Syntax<'a>>)> = vec![];
+    while let (Some(lhs), Some(rhs)) = (lhs_nodes.last(), rhs_nodes.last()) {
+        if is_mostly_unchanged_list(lhs, rhs) {
+            trailing.push((vec![lhs], vec![rhs]));
+
+            lhs_nodes = &lhs_nodes[..lhs_nodes.len() - 1];
+            rhs_nodes = &rhs_nodes[..rhs_nodes.len() - 1];
+        } else {
+            break;
+        }
+    }
+
+    let mut res: Vec<(Vec<&'a Syntax<'a>>, Vec<&'a Syntax<'a>>)> = vec![];
+    res.extend_from_slice(&leading[..]);
+
+    if !lhs_nodes.is_empty() || !rhs_nodes.is_empty() {
+        res.push((Vec::from(lhs_nodes), Vec::from(rhs_nodes)));
+    }
+
+    res.extend(trailing.into_iter().rev());
+
+    res
+}
+
+fn split_unchanged_toplevel<'a>(
+    lhs_nodes: &[&'a Syntax<'a>],
+    rhs_nodes: &[&'a Syntax<'a>],
+    size_threshold: u32,
+) -> Vec<(ChangeState, Vec<&'a Syntax<'a>>, Vec<&'a Syntax<'a>>)> {
+    let lhs_node_ids = lhs_nodes
+        .iter()
+        .map(|n| EqOnFirstItem(n.content_id(), *n))
+        .collect::<Vec<_>>();
+    let rhs_node_ids = rhs_nodes
+        .iter()
+        .map(|n| EqOnFirstItem(n.content_id(), *n))
+        .collect::<Vec<_>>();
+
+    let mut res: Vec<(ChangeState, Vec<&'a Syntax<'a>>, Vec<&'a Syntax<'a>>)> = vec![];
+    let mut section_lhs_nodes = vec![];
+    let mut section_rhs_nodes = vec![];
+
+    for diff_res in lcs_diff::slice(&lhs_node_ids, &rhs_node_ids) {
+        match diff_res {
+            lcs_diff::DiffResult::Both(lhs, rhs) => {
+                let lhs_node = lhs.1;
+                let rhs_node = rhs.1;
+
+                let tiny_node = match lhs_node {
+                    Syntax::List {
+                        num_descendants, ..
+                    } => *num_descendants < size_threshold,
+                    Syntax::Atom { .. } => true,
+                };
+
+                if tiny_node {
+                    section_lhs_nodes.push(lhs_node);
+                    section_rhs_nodes.push(rhs_node);
+                } else {
+                    if !section_lhs_nodes.is_empty() || !section_rhs_nodes.is_empty() {
+                        res.extend(split_unchanged_singleton_list(
+                            &section_lhs_nodes,
+                            &section_rhs_nodes,
+                            size_threshold,
+                        ));
+                        section_lhs_nodes = vec![];
+                        section_rhs_nodes = vec![];
+                    }
+
+                    res.push((ChangeState::UnchangedNode, vec![lhs_node], vec![rhs_node]));
+                }
+            }
+            lcs_diff::DiffResult::Left(lhs) => {
+                section_lhs_nodes.push(lhs.1);
+            }
+            lcs_diff::DiffResult::Right(rhs) => {
+                section_rhs_nodes.push(rhs.1);
+            }
+        }
+    }
+
+    if !section_lhs_nodes.is_empty() || !section_rhs_nodes.is_empty() {
+        res.extend(split_unchanged_singleton_list(
+            &section_lhs_nodes,
+            &section_rhs_nodes,
+            size_threshold,
+        ));
+    }
+
+    res
+}
+
+#[derive(Debug, Clone)]
+struct EqOnFirstItem<X, Y>(X, Y);
+
+impl<X: Eq, Y> PartialEq for EqOnFirstItem<X, Y> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+impl<X: Eq, Y> Eq for EqOnFirstItem<X, Y> {}
+
+impl<X: Eq + PartialOrd, Y> PartialOrd for EqOnFirstItem<X, Y> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.0.partial_cmp(&other.0)
+    }
+}
+
+impl<X: Eq + Ord, Y> Ord for EqOnFirstItem<X, Y> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
+impl<X: Hash, Y> Hash for EqOnFirstItem<X, Y> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
+    }
+}
+
+fn as_singleton_list_children<'a>(
+    lhs_nodes: &[&'a Syntax<'a>],
+    rhs_nodes: &[&'a Syntax<'a>],
+) -> Option<(Vec<&'a Syntax<'a>>, Vec<&'a Syntax<'a>>)> {
+    if let (
+        [Syntax::List {
+            open_content: lhs_open,
+            children: lhs_children,
+            close_content: lhs_close,
+            ..
+        }],
+        [Syntax::List {
+            open_content: rhs_open,
+            children: rhs_children,
+            close_content: rhs_close,
+            ..
+        }],
+    ) = (lhs_nodes, rhs_nodes)
+    {
+        if lhs_open == rhs_open && lhs_close == rhs_close {
+            return Some((lhs_children.clone(), rhs_children.clone()));
+        }
+    }
+
+    None
+}
+
+fn shrink_unchanged_delimiters<'a>(
+    lhs_nodes: &[&'a Syntax<'a>],
+    rhs_nodes: &[&'a Syntax<'a>],
+    change_map: &mut ChangeMap<'a>,
+) -> (bool, Vec<&'a Syntax<'a>>, Vec<&'a Syntax<'a>>) {
+    if let (
+        [Syntax::List {
+            open_content: lhs_open,
+            children: lhs_children,
+            close_content: lhs_close,
+            ..
+        }],
+        [Syntax::List {
+            open_content: rhs_open,
+            children: rhs_children,
+            close_content: rhs_close,
+            ..
+        }],
+    ) = (lhs_nodes, rhs_nodes)
+    {
+        if lhs_open == rhs_open && lhs_close == rhs_close {
+            let (changed_later, lhs_shrunk_nodes, rhs_shrunk_nodes) =
+                shrink_unchanged_at_ends(lhs_children, rhs_children, change_map);
+            if changed_later {
+                change_map.insert(lhs_nodes[0], ChangeKind::Unchanged(rhs_nodes[0]));
+                change_map.insert(rhs_nodes[0], ChangeKind::Unchanged(lhs_nodes[0]));
+
+                return (true, lhs_shrunk_nodes, rhs_shrunk_nodes);
+            }
+        }
+    }
+
+    (false, Vec::from(lhs_nodes), Vec::from(rhs_nodes))
+}
+
+fn shrink_unchanged_at_ends<'a>(
+    lhs_nodes: &[&'a Syntax<'a>],
+    rhs_nodes: &[&'a Syntax<'a>],
+    change_map: &mut ChangeMap<'a>,
+) -> (bool, Vec<&'a Syntax<'a>>, Vec<&'a Syntax<'a>>) {
+    let mut lhs_nodes = lhs_nodes;
+    let mut rhs_nodes = rhs_nodes;
+
+    let mut changed = false;
+    while let (Some(lhs_node), Some(rhs_node)) = (lhs_nodes.first(), rhs_nodes.first()) {
+        if lhs_node.content_id() == rhs_node.content_id() {
+            insert_deep_unchanged(lhs_node, rhs_node, change_map);
+            insert_deep_unchanged(rhs_node, lhs_node, change_map);
+
+            changed = true;
+            lhs_nodes = &lhs_nodes[1..];
+            rhs_nodes = &rhs_nodes[1..];
+        } else {
+            break;
+        }
+    }
+
+    while let (Some(lhs_node), Some(rhs_node)) = (lhs_nodes.last(), rhs_nodes.last()) {
+        if lhs_node.content_id() == rhs_node.content_id() {
+            insert_deep_unchanged(lhs_node, rhs_node, change_map);
+            insert_deep_unchanged(rhs_node, lhs_node, change_map);
+
+            changed = true;
+            lhs_nodes = &lhs_nodes[..lhs_nodes.len() - 1];
+            rhs_nodes = &rhs_nodes[..rhs_nodes.len() - 1];
+        } else {
+            break;
+        }
+    }
+
+    if lhs_nodes.len() == 1 && rhs_nodes.len() == 1 {
+        let (changed_later, lhs_nodes, rhs_nodes) =
+            shrink_unchanged_delimiters(lhs_nodes, rhs_nodes, change_map);
+        (changed || changed_later, lhs_nodes, rhs_nodes)
+    } else {
+        (changed, Vec::from(lhs_nodes), Vec::from(rhs_nodes))
+    }
+}

--- a/crates/ast_diff/src/unchanged.rs
+++ b/crates/ast_diff/src/unchanged.rs
@@ -1,6 +1,6 @@
 use std::hash::Hash;
 
-use crate::changes::{insert_deep_unchanged, ChangeKind, ChangeMap};
+use crate::changes::{ChangeKind, ChangeMap, insert_deep_unchanged};
 use crate::hash::DftHashSet;
 use crate::lcs_diff;
 use crate::syntax::{ContentId, Syntax};
@@ -310,18 +310,22 @@ fn as_singleton_list_children<'a>(
     rhs_nodes: &[&'a Syntax<'a>],
 ) -> Option<(Vec<&'a Syntax<'a>>, Vec<&'a Syntax<'a>>)> {
     if let (
-        [Syntax::List {
-            open_content: lhs_open,
-            children: lhs_children,
-            close_content: lhs_close,
-            ..
-        }],
-        [Syntax::List {
-            open_content: rhs_open,
-            children: rhs_children,
-            close_content: rhs_close,
-            ..
-        }],
+        [
+            Syntax::List {
+                open_content: lhs_open,
+                children: lhs_children,
+                close_content: lhs_close,
+                ..
+            },
+        ],
+        [
+            Syntax::List {
+                open_content: rhs_open,
+                children: rhs_children,
+                close_content: rhs_close,
+                ..
+            },
+        ],
     ) = (lhs_nodes, rhs_nodes)
     {
         if lhs_open == rhs_open && lhs_close == rhs_close {
@@ -338,18 +342,22 @@ fn shrink_unchanged_delimiters<'a>(
     change_map: &mut ChangeMap<'a>,
 ) -> (bool, Vec<&'a Syntax<'a>>, Vec<&'a Syntax<'a>>) {
     if let (
-        [Syntax::List {
-            open_content: lhs_open,
-            children: lhs_children,
-            close_content: lhs_close,
-            ..
-        }],
-        [Syntax::List {
-            open_content: rhs_open,
-            children: rhs_children,
-            close_content: rhs_close,
-            ..
-        }],
+        [
+            Syntax::List {
+                open_content: lhs_open,
+                children: lhs_children,
+                close_content: lhs_close,
+                ..
+            },
+        ],
+        [
+            Syntax::List {
+                open_content: rhs_open,
+                children: rhs_children,
+                close_content: rhs_close,
+                ..
+            },
+        ],
     ) = (lhs_nodes, rhs_nodes)
     {
         if lhs_open == rhs_open && lhs_close == rhs_close {

--- a/crates/language/Cargo.toml
+++ b/crates/language/Cargo.toml
@@ -70,6 +70,7 @@ util.workspace = true
 watch.workspace = true
 zlog.workspace = true
 diffy = "0.4.2"
+ast_diff.workspace = true
 
 [dev-dependencies]
 collections = { workspace = true, features = ["test-support"] }

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -160,6 +160,15 @@ pub struct LanguageSettings {
     ///
     /// Default: `true`
     pub word_diff_enabled: bool,
+    /// Whether to use AST-aware syntax diffing for word highlights.
+    ///
+    /// When enabled and a language grammar is available, uses tree-sitter
+    /// to parse and diff syntax trees for more accurate change detection.
+    /// Falls back to token-based word diffing if syntax diffing fails or
+    /// the language doesn't have a grammar.
+    ///
+    /// Default: `false`
+    pub syntax_diff_enabled: bool,
     /// Whether to use tree-sitter bracket queries to detect and colorize the brackets in the editor.
     pub colorize_brackets: bool,
 }
@@ -603,6 +612,7 @@ impl settings::Settings for AllLanguageSettings {
                 },
                 debuggers: settings.debuggers.unwrap(),
                 word_diff_enabled: settings.word_diff_enabled.unwrap(),
+                syntax_diff_enabled: settings.syntax_diff_enabled.unwrap(),
             }
         }
 

--- a/crates/language/src/text_diff.rs
+++ b/crates/language/src/text_diff.rs
@@ -1,4 +1,4 @@
-use crate::{with_parser, CharClassifier, CharKind, CharScopeContext, LanguageScope};
+use crate::{CharClassifier, CharKind, CharScopeContext, LanguageScope, with_parser};
 use anyhow::{Context, anyhow};
 use ast_diff::DiffOptions as AstDiffOptions;
 use imara_diff::{
@@ -125,8 +125,14 @@ fn syntax_diff_ranges(
         config.forced_atom_nodes_list(),
     );
 
-    let result =
-        ast_diff::diff_syntax(&old_tree, old_text, &new_tree, new_text, &config, &ast_options);
+    let result = ast_diff::diff_syntax(
+        &old_tree,
+        old_text,
+        &new_tree,
+        new_text,
+        &config,
+        &ast_options,
+    );
 
     match &result {
         Ok((lhs, rhs)) => {

--- a/crates/multi_buffer/src/multi_buffer_tests.rs
+++ b/crates/multi_buffer/src/multi_buffer_tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use buffer_diff::{DiffHunkStatus, DiffHunkStatusKind};
-use gpui::{App, BorrowAppContext, TestAppContext};
+use gpui::{App, TestAppContext};
 use indoc::indoc;
 use language::{Buffer, Rope};
 use parking_lot::RwLock;

--- a/crates/settings/src/settings_content/language.rs
+++ b/crates/settings/src/settings_content/language.rs
@@ -425,6 +425,15 @@ pub struct LanguageSettingsContent {
     ///
     /// Default: true
     pub word_diff_enabled: Option<bool>,
+    /// Whether to use AST-aware syntax diffing for word highlights.
+    ///
+    /// When enabled and a language grammar is available, uses tree-sitter
+    /// to parse and diff syntax trees for more accurate change detection.
+    /// Falls back to token-based word diffing if syntax diffing fails or
+    /// the language doesn't have a grammar.
+    ///
+    /// Default: false
+    pub syntax_diff_enabled: Option<bool>,
     /// Whether to use tree-sitter bracket queries to detect and colorize the brackets in the editor.
     ///
     /// Default: false

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -491,6 +491,7 @@ impl VsCodeSettings {
                         .collect()
                 }),
             word_diff_enabled: None,
+            syntax_diff_enabled: None,
         }
     }
 


### PR DESCRIPTION
Closes #9721

Release Notes:

- Added syntax based diffing for git & agent diffs

### Built in language git diff
<img width="1280" height="280" alt="image" src="https://github.com/user-attachments/assets/90c6eae4-1584-410a-9035-934cacd65b0c" />

### Built in language agent diff

<img width="1280" height="280" alt="image" src="https://github.com/user-attachments/assets/847f03cf-659b-4da6-ae1c-fe0a3301bb16" />

### Extension based language diff

<img width="1606" height="482" alt="image" src="https://github.com/user-attachments/assets/ab732eb1-282c-4474-9cfa-ad58534f4574" />

