### PR TITLE
git_ui: Introduce explicit yield points for project diff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7129,6 +7129,7 @@ dependencies = [
  "serde",
  "serde_json",
  "settings",
+ "smol",
  "strum 0.27.2",
  "telemetry",
  "theme",

--- a/crates/git_ui/Cargo.toml
+++ b/crates/git_ui/Cargo.toml
@@ -50,6 +50,7 @@ schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 settings.workspace = true
+smol.workspace = true
 strum.workspace = true
 telemetry.workspace = true
 theme.workspace = true


### PR DESCRIPTION
These are long running foreground tasks that tend to not have pending await points, meaning once we start executing them they will never reschedule themselves, starving the foreground thread.

Release Notes:

- Improved git project diff responsiveness
