### PR TITLE
Use test db for command palette under vim tests

### DIFF
--- a/crates/command_palette/Cargo.toml
+++ b/crates/command_palette/Cargo.toml
@@ -8,6 +8,9 @@ license = "GPL-3.0-or-later"
 [lints]
 workspace = true
 
+[features]
+test-support = ["db/test-support"]
+
 [lib]
 path = "src/command_palette.rs"
 doctest = false

--- a/crates/vim/Cargo.toml
+++ b/crates/vim/Cargo.toml
@@ -55,7 +55,7 @@ zed_actions.workspace = true
 
 [dev-dependencies]
 assets.workspace = true
-command_palette.workspace = true
+command_palette = { workspace = true, features = ["test-support"] }
 editor = { workspace = true, features = ["test-support"] }
 git_ui.workspace = true
 gpui = { workspace = true, features = ["test-support"] }


### PR DESCRIPTION
When running vim tests, the command palette code wasn't using the test database. This PR fixes that by adding a `test-support` feature to the `command_palette` crate which in turn enables the `test-support` flag on the `db` crate.

Release Notes:

- N/A 
