### PR TITLE
Fix slow rebuild time for dev extensions with grammar compilation

### DIFF
--- a/crates/extension/src/extension_builder.rs
+++ b/crates/extension/src/extension_builder.rs
@@ -52,6 +52,7 @@ pub struct ExtensionBuilder {
 
 pub struct CompileExtensionOptions {
     pub release: bool,
+    pub dev_extension: bool,
 }
 
 #[derive(Deserialize)]

--- a/crates/extension/src/extension_builder.rs
+++ b/crates/extension/src/extension_builder.rs
@@ -79,7 +79,7 @@ impl ExtensionBuilder {
         extension_manifest: &mut ExtensionManifest,
         options: CompileExtensionOptions,
     ) -> Result<()> {
-        let dev_extension = options.dev_extension.clone();
+        let dev_extension = options.dev_extension;
 
         populate_defaults(extension_manifest, extension_dir)?;
 
@@ -251,8 +251,8 @@ impl ExtensionBuilder {
     ) -> Result<()> {
         let clang_path = self.install_wasi_sdk_if_needed().await?;
 
-        let mut grammar_repo_dir = self.get_grammar_repo_dir(extension_dir, grammar_name);
-        let mut grammar_wasm_path = self.get_grammar_wasm_path(&grammar_repo_dir);
+        let grammar_repo_dir = self.get_grammar_repo_dir(extension_dir, grammar_name);
+        let grammar_wasm_path = self.get_grammar_wasm_path(&grammar_repo_dir);
 
         log::info!("checking out {grammar_name} parser");
         self.checkout_repo(

--- a/crates/extension_cli/src/main.rs
+++ b/crates/extension_cli/src/main.rs
@@ -70,7 +70,10 @@ async fn main() -> Result<()> {
         .compile_extension(
             &extension_path,
             &mut manifest,
-            CompileExtensionOptions { release: true },
+            CompileExtensionOptions {
+                release: true,
+                dev_extension: false,
+            },
         )
         .await
         .context("failed to compile extension")?;

--- a/crates/extension_host/benches/extension_compilation_benchmark.rs
+++ b/crates/extension_host/benches/extension_compilation_benchmark.rs
@@ -72,7 +72,10 @@ fn wasm_bytes(cx: &TestAppContext, manifest: &mut ExtensionManifest) -> Vec<u8> 
         .block(extension_builder.compile_extension(
             &path,
             manifest,
-            CompileExtensionOptions { release: true },
+            CompileExtensionOptions {
+                release: true,
+                dev_extension: false,
+            },
         ))
         .unwrap();
     std::fs::read(path.join("extension.wasm")).unwrap()

--- a/crates/extension_host/src/extension_host.rs
+++ b/crates/extension_host/src/extension_host.rs
@@ -985,7 +985,10 @@ impl ExtensionStore {
                         .compile_extension(
                             &extension_source_path,
                             &mut extension_manifest,
-                            CompileExtensionOptions { release: false },
+                            CompileExtensionOptions {
+                                release: false,
+                                dev_extension: true,
+                            },
                         )
                         .await
                 }
@@ -1047,7 +1050,10 @@ impl ExtensionStore {
                 .compile_extension(
                     &path,
                     &mut manifest,
-                    CompileExtensionOptions { release: true },
+                    CompileExtensionOptions {
+                        release: true,
+                        dev_extension: true,
+                    },
                 )
                 .await
         });


### PR DESCRIPTION
This is a proposal hotfix for the discussion [#43685](https://github.com/zed-industries/zed/discussions/43685)

Release Notes:

- When installing or rebuilding a dev extension, the compiling of grammars is skipped, if the compiled grammars are already present on the file system.

What it's solving:

When trying to fix the zed extension [zed-cfml](https://github.com/cfmleditor/zed-cfml) that uses the [tree-sitter-cfml](https://github.com/cfmleditor/tree-sitter-cfml) grammar, I came across build times around 2 minutes when installing the extension locally as a dev extension. After reading trough the code, I realized `crates/extension/src/extension_builder.rs:compile_grammar()` is called, despite having already compiled. I assume this makes sense for deploying extension, but in the local development process, it's slowing the developer experience a lot.

How it's solving:

- Extended the `CompileExtensionOptions` with a new boolean flag `dev_extension` that is only set to true when invoking either `install_dev_extension()` or `rebuild_dev_extension()`.
- If `dev_extension` is set to true, it checks, wether the compiled wasm is present on the file system.
- If the compiled wasm is present, the compiling step is skipped.
- This ensures that the process for normal extension stays the same.

Changes in Developer Experience:

Faster installation and rebuild times for dev extension at the cost of having to manually delete the desired foo_grammar.wasm in the extension's folder.
Note: This is already the case when changing the grammar's commit/rev, the developer will have to manually delete the grammars/foo_grammar/ folder.

Changes in UI:
- N/A