### PR TITLE
Update typos to 1.40.0

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -84,7 +84,7 @@ jobs:
       run: ./script/check-keymaps
       shell: bash -euxo pipefail {0}
     - name: run_tests::check_style::check_for_typos
-      uses: crate-ci/typos@80c8a4945eec0f6d464eaf9e65ed98ef085283d1
+      uses: crate-ci/typos@2d0ce569feab1f8752f1dde43cc2f2aa53236e06
       with:
         config: ./typos.toml
     - name: steps::cargo_fmt

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -596,7 +596,7 @@ pub enum HitboxBehavior {
     /// ```
     ///
     /// This has effects beyond event handling - any use of hitbox checking, such as hover
-    /// styles and tooltops. These other behaviors are the main point of this mechanism. An
+    /// styles and tooltips. These other behaviors are the main point of this mechanism. An
     /// alternative might be to not affect mouse event handling - but this would allow
     /// inconsistent UI where clicks and moves interact with elements that are not considered to
     /// be hovered.
@@ -624,7 +624,7 @@ pub enum HitboxBehavior {
     /// desired, then a `cx.stop_propagation()` handler like the one above can be used.
     ///
     /// This has effects beyond event handling - this affects any use of `is_hovered`, such as
-    /// hover styles and tooltops. These other behaviors are the main point of this mechanism.
+    /// hover styles and tooltips. These other behaviors are the main point of this mechanism.
     /// An alternative might be to not affect mouse event handling - but this would allow
     /// inconsistent UI where clicks and moves interact with elements that are not considered to
     /// be hovered.

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -9733,7 +9733,7 @@ async fn test_ignored_dirs_events(cx: &mut gpui::TestAppContext) {
             ("project/target/debug/deps".to_string(), PathChange::Added),
             ("project/target/debug/deps".to_string(), PathChange::Removed),
         ],
-        "Due to `debug` directory being tracket, it should get updates for entries inside it.
+        "Due to `debug` directory being tracked, it should get updates for entries inside it.
         No updates for more nested directories should happen as those are ignored",
     );
 }

--- a/crates/settings/src/merge_from.rs
+++ b/crates/settings/src/merge_from.rs
@@ -1,6 +1,6 @@
 /// Trait for recursively merging settings structures.
 ///
-/// When Zed starts it loads settinsg from `default.json` to initialize
+/// When Zed starts it loads settings from `default.json` to initialize
 /// everything. These may be further refined by loading the user's settings,
 /// and any settings profiles; and then further refined by loading any
 /// local project settings.

--- a/tooling/xtask/src/tasks/workflows/run_tests.rs
+++ b/tooling/xtask/src/tasks/workflows/run_tests.rs
@@ -226,8 +226,8 @@ fn check_style() -> NamedJob {
         named::uses(
             "crate-ci",
             "typos",
-            "80c8a4945eec0f6d464eaf9e65ed98ef085283d1",
-        ) // v1.38.1
+            "2d0ce569feab1f8752f1dde43cc2f2aa53236e06",
+        ) // v1.40.0
         .with(("config", "./typos.toml"))
     }
     named::job(


### PR DESCRIPTION
Noticed we had a few typos that weren't caught by the version we were using

Release Notes:

- N/A
