### PR TITLE
python: Add SQL syntax highlighting

### DIFF
--- a/crates/languages/src/python/injections.scm
+++ b/crates/languages/src/python/injections.scm
@@ -1,3 +1,43 @@
 ((comment) @injection.content
  (#set! injection.language "comment")
 )
+
+; SQL -----------------------------------------------------------------------------
+; common functions ex: spark.sql("SELECT * FROM tbl")
+(call
+    [
+        (attribute attribute: (identifier) @function_name)
+        (identifier) @function_name
+    ]
+    (#match? @function_name "(?i:sql|read_sql|read_sql_query)")
+    arguments: (argument_list
+        (string
+            (string_content) @injection.content (#set! injection.language "sql")
+        )
+    )
+)
+
+; sqlalchemy ex: from sqlalchemy import text; text("SELECT * FROM tbl")
+(call
+    function: (identifier) @function_name
+    (#match? @function_name "(?i:text)")
+    arguments: (argument_list
+        (string
+            (string_content) @injection.content (#set! injection.language "sql")
+        )
+    )
+)
+
+; string variables
+((comment) @comment
+    .
+    (expression_statement
+        (assignment
+            right: (string
+                (string_content) @injection.content
+            )
+        )
+    )
+    (#match? @comment "^(#|#\\s+)(?i:sql)\\s*$")
+    (#set! injection.language "sql")
+)

--- a/crates/languages/src/python/injections.scm
+++ b/crates/languages/src/python/injections.scm
@@ -9,7 +9,7 @@
         (attribute attribute: (identifier) @function_name)
         (identifier) @function_name
     ]
-    (#match? @function_name "(?i:sql|read_sql|read_sql_query)")
+    (#match? @function_name "(?i:sql|read_sql|read_sql_query|execute)")
     arguments: (argument_list
         (string
             (string_content) @injection.content (#set! injection.language "sql")

--- a/crates/languages/src/python/injections.scm
+++ b/crates/languages/src/python/injections.scm
@@ -9,7 +9,7 @@
         (attribute attribute: (identifier) @function_name)
         (identifier) @function_name
     ]
-    (#match? @function_name "(?i:sql|read_sql|read_sql_query|execute)")
+    (#match? @function_name "^(?i:sql|read_sql|read_sql_query|execute)$")
     arguments: (argument_list
         (string
             (string_content) @injection.content (#set! injection.language "sql")

--- a/crates/languages/src/python/injections.scm
+++ b/crates/languages/src/python/injections.scm
@@ -20,7 +20,7 @@
 ; sqlalchemy ex: from sqlalchemy import text; text("SELECT * FROM tbl")
 (call
     function: (identifier) @function_name
-    (#match? @function_name "(?i:text)")
+    (#match? @function_name "^(?i:text)$")
     arguments: (argument_list
         (string
             (string_content) @injection.content (#set! injection.language "sql")

--- a/crates/languages/src/python/injections.scm
+++ b/crates/languages/src/python/injections.scm
@@ -3,41 +3,32 @@
 )
 
 ; SQL -----------------------------------------------------------------------------
-; common functions ex: spark.sql("SELECT * FROM tbl")
-(call
+(
     [
-        (attribute attribute: (identifier) @function_name)
-        (identifier) @function_name
+        ; function calls
+        (call
+            [
+                (attribute attribute: (identifier) @function_name)
+                (identifier) @function_name
+            ]
+            arguments: (argument_list
+                (comment) @comment
+                (string
+                    (string_content) @injection.content
+                )
+        ))
+
+        ; string variables
+        ((comment) @comment
+            .
+            (expression_statement
+                (assignment
+                    right: (string
+                        (string_content) @injection.content
+                    )
+                )
+        ))
     ]
-    (#match? @function_name "^(?i:sql|read_sql|read_sql_query|execute)$")
-    arguments: (argument_list
-        (string
-            (string_content) @injection.content (#set! injection.language "sql")
-        )
-    )
-)
-
-; sqlalchemy ex: from sqlalchemy import text; text("SELECT * FROM tbl")
-(call
-    function: (identifier) @function_name
-    (#match? @function_name "^(?i:text)$")
-    arguments: (argument_list
-        (string
-            (string_content) @injection.content (#set! injection.language "sql")
-        )
-    )
-)
-
-; string variables
-((comment) @comment
-    .
-    (expression_statement
-        (assignment
-            right: (string
-                (string_content) @injection.content
-            )
-        )
-    )
     (#match? @comment "^(#|#\\s+)(?i:sql)\\s*$")
     (#set! injection.language "sql")
 )

--- a/docs/src/languages/python.md
+++ b/docs/src/languages/python.md
@@ -258,6 +258,25 @@ quote-style = "single"
 
 For more details, refer to the Ruff documentation about [configuration files](https://docs.astral.sh/ruff/configuration/) and [language server settings](https://docs.astral.sh/ruff/editors/settings/), and the [list of options](https://docs.astral.sh/ruff/settings/).
 
+### Embedded Language Highlighting
+
+Zed supports syntax highlighting for code embedded in Python strings by adding a comment with the language name.
+
+```python
+# sql
+query = "SELECT * FROM users"
+
+#sql
+query = """
+    SELECT *
+    FROM users
+"""
+
+result = func( #sql
+    "SELECT * FROM users"
+)
+```
+
 ## Debugging
 
 Zed supports Python debugging through the `debugpy` adapter. You can start with no configuration or define custom launch profiles in `.zed/debug.json`.


### PR DESCRIPTION
Release Notes: 

- Added support for SQL syntax highlighting in Python files

## Summary

I am a data engineer who spends a lot of time writing SQL in Python files using Zed. This PR adds support for SQL syntax highlighting with common libraries (like pyspark, polars, pandas) and string variables (prefixed with a `# sql` comment). I referenced [#37605](https://github.com/zed-industries/zed/pull/37605) for this implementation to keep the comment prefix consistent.

## Examples
<img width="738" height="990" alt="image" src="https://github.com/user-attachments/assets/48a859da-c477-490d-be73-ca70d8e47cc9" />
