### PR TITLE
docs: Reduce load flicker

### DIFF
--- a/docs/theme/index.hbs
+++ b/docs/theme/index.hbs
@@ -3,6 +3,13 @@
     <head>
         <!-- Book generated using mdBook -->
         <meta charset="UTF-8">
+        <meta name="view-transition" content="same-origin">
+        <style>
+            ::view-transition-old(root),
+            ::view-transition-new(root) {
+                animation-duration: 0.15s;
+            }
+        </style>
         <!-- Theme initialization - must run before any CSS loads to prevent flicker -->
         <script>
             (function() {


### PR DESCRIPTION
Follow up to https://github.com/zed-industries/zed/pull/43758.

This PR uses view transition animations to reduce the page flickering when navigating between one and the other. Pretty cool CSS-only solution.

Release Notes:

- N/A
