### PR TITLE
go: Fix language injections

### DIFF
--- a/crates/languages/src/go/injections.scm
+++ b/crates/languages/src/go/injections.scm
@@ -23,61 +23,54 @@
 		; var, const or short declaration of raw or interpreted string literal
 		((comment) @comment
             value: (expression_list
-            (interpreted_string_literal
-                (interpreted_string_literal_content) @injection.content
-            )
-        ))
-
-		((comment) @comment
-            value: (expression_list
-            (raw_string_literal
-                (raw_string_literal_content) @injection.content
-            )
+            [
+                (interpreted_string_literal
+                    (interpreted_string_literal_content) @injection.content
+                )
+                (raw_string_literal
+                    (raw_string_literal_content) @injection.content
+                )
+            ]
         ))
 
 		; := assignment
     	((comment) @comment
             right: (expression_list
-            (interpreted_string_literal
-                (interpreted_string_literal_content) @injection.content
-            )
+            [
+                (interpreted_string_literal
+                    (interpreted_string_literal_content) @injection.content
+                )
+                (raw_string_literal
+                    (raw_string_literal_content) @injection.content
+                )
+            ]
         ))
-
-		((comment) @comment
-            right: (expression_list
-            (raw_string_literal
-                (raw_string_literal_content) @injection.content
-            )
-        ))
-
 
         ; when passing as a literal element (to struct field eg.)
         ((comment) @comment
             value: (literal_element
-            (interpreted_string_literal
-                (interpreted_string_literal_content) @injection.content
-            )
-        ))
-
-		((comment) @comment
-            value: (literal_element
-            (raw_string_literal
-                (raw_string_literal_content) @injection.content
-            )
+            [
+                (interpreted_string_literal
+                    (interpreted_string_literal_content) @injection.content
+                )
+                (raw_string_literal
+                    (raw_string_literal_content) @injection.content
+                )
+            ]
         ))
 
 		; when passing as a function parameter
         ((comment) @comment
-       	(interpreted_string_literal
-           	(interpreted_string_literal_content) @injection.content
-        ))
-
-        ((comment) @comment
-       	(raw_string_literal
-           	(raw_string_literal_content) @injection.content
-        ))
+        [
+           	(interpreted_string_literal
+               	(interpreted_string_literal_content) @injection.content
+            )
+            (raw_string_literal
+               	(raw_string_literal_content) @injection.content
+            )
+        ]
+        )
     ]
-
     (#match? @comment "^\\/\\*\\s*sql\\s*\\*\\/") ; /* sql */ or /*sql*/
     (#set! injection.language "sql")
 )

--- a/crates/languages/src/go/injections.scm
+++ b/crates/languages/src/go/injections.scm
@@ -22,31 +22,60 @@
 	[
 		; var, const or short declaration of raw or interpreted string literal
 		((comment) @comment
-  		.
-    	(expression_list
-     	[
-      		(interpreted_string_literal)
-        	(raw_string_literal)
-        ] @injection.content
+            value: (expression_list
+            (interpreted_string_literal
+                (interpreted_string_literal_content) @injection.content
+            )
         ))
+
+		((comment) @comment
+            value: (expression_list
+            (raw_string_literal
+                (raw_string_literal_content) @injection.content
+            )
+        ))
+
+		; := assignment
+    	((comment) @comment
+            right: (expression_list
+            (interpreted_string_literal
+                (interpreted_string_literal_content) @injection.content
+            )
+        ))
+
+		((comment) @comment
+            right: (expression_list
+            (raw_string_literal
+                (raw_string_literal_content) @injection.content
+            )
+        ))
+
 
         ; when passing as a literal element (to struct field eg.)
-		((comment) @comment
-        .
-        (literal_element
-        [
-        	(interpreted_string_literal)
-        	(raw_string_literal)
-        ] @injection.content
+        ((comment) @comment
+            value: (literal_element
+            (interpreted_string_literal
+                (interpreted_string_literal_content) @injection.content
+            )
         ))
 
-        ; when passing as a function parameter
+		((comment) @comment
+            value: (literal_element
+            (raw_string_literal
+                (raw_string_literal_content) @injection.content
+            )
+        ))
+
+		; when passing as a function parameter
         ((comment) @comment
-        .
-        [
-        	(interpreted_string_literal)
-        	(raw_string_literal)
-        ] @injection.content)
+       	(interpreted_string_literal
+           	(interpreted_string_literal_content) @injection.content
+        ))
+
+        ((comment) @comment
+       	(raw_string_literal
+           	(raw_string_literal_content) @injection.content
+        ))
     ]
 
     (#match? @comment "^\\/\\*\\s*sql\\s*\\*\\/") ; /* sql */ or /*sql*/

--- a/crates/languages/src/go/injections.scm
+++ b/crates/languages/src/go/injections.scm
@@ -19,9 +19,11 @@
 
 ; INJECT SQL
 (
-	[
-		; var, const or short declaration of raw or interpreted string literal
-		((comment) @comment
+    [
+        (const_spec
+            name: (identifier)
+            "="
+            (comment) @_comment
             value: (expression_list
             [
                 (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
@@ -29,41 +31,10 @@
             ]
         ))
 
-		; := assignment
-    	((comment) @comment
-            right: (expression_list
-            [
-                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
-                (raw_string_literal (raw_string_literal_content) @injection.content)
-            ]
-        ))
-
-        ; when passing as a literal element (to struct field eg.)
-        ((comment) @comment
-            value: (literal_element
-            [
-                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
-                (raw_string_literal (raw_string_literal_content) @injection.content)
-            ]
-        ))
-
-		; when passing as a function parameter
-        ((comment) @comment
-        [
-           	(interpreted_string_literal (interpreted_string_literal_content) @injection.content)
-            (raw_string_literal (raw_string_literal_content) @injection.content)
-        ]
-        )
-    ]
-    (#match? @comment "^\\/\\*\\s*sql\\s*\\*\\/") ; /* sql */ or /*sql*/
-    (#set! injection.language "sql")
-)
-
-; INJECT JSON
-(
-	[
-		; var, const or short declaration of raw or interpreted string literal
-		((comment) @comment
+        (var_spec
+            name: (identifier)
+            "="
+            (comment) @_comment
             value: (expression_list
             [
                 (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
@@ -71,17 +42,29 @@
             ]
         ))
 
-		; := assignment
-       	((comment) @comment
-            right: (expression_list
+        (assignment_statement
+        left: (expression_list)
+        "="
+        (comment) @_comment
+        right: (expression_list
             [
                 (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
                 (raw_string_literal (raw_string_literal_content) @injection.content)
             ]
         ))
 
-        ; when passing as a literal element (to struct field eg.)
-        ((comment) @comment
+        (short_var_declaration
+        left: (expression_list)
+        ":="
+        (comment) @_comment
+        right: (expression_list
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
+        ))
+
+        ((comment) @_comment
             value: (literal_element
             [
                 (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
@@ -89,24 +72,92 @@
             ]
         ))
 
-        ; when passing as a function parameter
-        ((comment) @comment
+        (argument_list
+            (comment) @_comment
             [
                	(interpreted_string_literal (interpreted_string_literal_content) @injection.content)
                 (raw_string_literal (raw_string_literal_content) @injection.content)
             ]
         )
     ]
+  (#match? @_comment "^\\/\\*\\s*sql\\s*\\*\\/$")
+  (#set! injection.language "sql")
+)
 
-    (#match? @comment "^\\/\\*\\s*json\\s*\\*\\/") ; /* json */ or /*json*/
+; INJECT JSON
+(
+    [
+        (const_spec
+            name: (identifier)
+            "="
+            (comment) @_comment
+            value: (expression_list
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
+        ))
+
+        (var_spec
+            name: (identifier)
+            "="
+            (comment) @_comment
+            value: (expression_list
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
+        ))
+
+        (assignment_statement
+        left: (expression_list)
+        "="
+        (comment) @_comment
+        right: (expression_list
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
+        ))
+
+        (short_var_declaration
+        left: (expression_list)
+        ":="
+        (comment) @_comment
+        right: (expression_list
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
+        ))
+
+        ((comment) @_comment
+            value: (literal_element
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
+        ))
+
+        (argument_list
+            (comment) @_comment
+            [
+               	(interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
+        )
+    ]
+    (#match? @_comment "^\\/\\*\\s*json\\s*\\*\\/") ; /* json */ or /*json*/
     (#set! injection.language "json")
 )
 
 ; INJECT YAML
 (
-	[
-		; var, const or short declaration of raw or interpreted string literal
-		((comment) @comment
+    [
+        (const_spec
+            name: (identifier)
+            "="
+            (comment) @_comment
             value: (expression_list
             [
                 (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
@@ -114,42 +165,66 @@
             ]
         ))
 
-       	((comment) @comment
-            right: (expression_list
+        (var_spec
+            name: (identifier)
+            "="
+            (comment) @_comment
+            value: (expression_list
             [
                 (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
                 (raw_string_literal (raw_string_literal_content) @injection.content)
             ]
         ))
 
+        (assignment_statement
+        left: (expression_list)
+        "="
+        (comment) @_comment
+        right: (expression_list
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
+        ))
 
-        ; when passing as a literal element (to struct field eg.)
-        ((comment) @comment
+        (short_var_declaration
+        left: (expression_list)
+        ":="
+        (comment) @_comment
+        right: (expression_list
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
+        ))
+
+        ((comment) @_comment
             value: (literal_element
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
+        ))
+
+        (argument_list
+            (comment) @_comment
             [
                	(interpreted_string_literal (interpreted_string_literal_content) @injection.content)
                 (raw_string_literal (raw_string_literal_content) @injection.content)
             ]
-        ))
-
-        ; when passing as a function parameter
-        ((comment) @comment
-            [
-                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
-                (raw_string_literal (raw_string_literal_content) @injection.content)
-            ]
         )
     ]
-
-    (#match? @comment "^\\/\\*\\s*yaml\\s*\\*\\/") ; /* yaml */ or /*yaml*/
+    (#match? @_comment "^\\/\\*\\s*yaml\\s*\\*\\/") ; /* yaml */ or /*yaml*/
     (#set! injection.language "yaml")
 )
 
-; INJECT XML
+; ; INJECT XML
 (
     [
-		; var, const or short declaration of raw or interpreted string literal
-		((comment) @comment
+        (const_spec
+            name: (identifier)
+            "="
+            (comment) @_comment
             value: (expression_list
             [
                 (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
@@ -157,17 +232,40 @@
             ]
         ))
 
-		; := assignment
-       	((comment) @comment
-            right: (expression_list
+        (var_spec
+            name: (identifier)
+            "="
+            (comment) @_comment
+            value: (expression_list
             [
                 (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
                 (raw_string_literal (raw_string_literal_content) @injection.content)
             ]
         ))
 
-        ; when passing as a literal element (to struct field eg.)
-        ((comment) @comment
+        (assignment_statement
+        left: (expression_list)
+        "="
+        (comment) @_comment
+        right: (expression_list
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
+        ))
+
+        (short_var_declaration
+        left: (expression_list)
+        ":="
+        (comment) @_comment
+        right: (expression_list
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
+        ))
+
+        ((comment) @_comment
             value: (literal_element
             [
                 (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
@@ -175,23 +273,25 @@
             ]
         ))
 
-		; when passing as a function parameter
-           ((comment) @comment
-           [
-              	(interpreted_string_literal (interpreted_string_literal_content) @injection.content)
-               (raw_string_literal (raw_string_literal_content) @injection.content)
-           ]
-           )
-       ]
-    (#match? @comment "^\\/\\*\\s*xml\\s*\\*\\/") ; /* xml */ or /*xml*/
+        (argument_list
+            (comment) @_comment
+            [
+               	(interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
+        )
+    ]
+    (#match? @_comment "^\\/\\*\\s*xml\\s*\\*\\/") ; /* xml */ or /*xml*/
     (#set! injection.language "xml")
 )
 
 ; INJECT HTML
 (
-	[
-		; var, const or short declaration of raw or interpreted string literal
-		((comment) @comment
+    [
+        (const_spec
+            name: (identifier)
+            "="
+            (comment) @_comment
             value: (expression_list
             [
                 (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
@@ -199,17 +299,40 @@
             ]
         ))
 
-		; := assignment
-    	((comment) @comment
-            right: (expression_list
+        (var_spec
+            name: (identifier)
+            "="
+            (comment) @_comment
+            value: (expression_list
             [
                 (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
                 (raw_string_literal (raw_string_literal_content) @injection.content)
             ]
         ))
 
-        ; when passing as a literal element (to struct field eg.)
-        ((comment) @comment
+        (assignment_statement
+        left: (expression_list)
+        "="
+        (comment) @_comment
+        right: (expression_list
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
+        ))
+
+        (short_var_declaration
+        left: (expression_list)
+        ":="
+        (comment) @_comment
+        right: (expression_list
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
+        ))
+
+        ((comment) @_comment
             value: (literal_element
             [
                 (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
@@ -217,23 +340,25 @@
             ]
         ))
 
-		; when passing as a function parameter
-        ((comment) @comment
+        (argument_list
+            (comment) @_comment
             [
                	(interpreted_string_literal (interpreted_string_literal_content) @injection.content)
                 (raw_string_literal (raw_string_literal_content) @injection.content)
             ]
         )
     ]
-    (#match? @comment "^\\/\\*\\s*html\\s*\\*\\/") ; /* html */ or /*html*/
+    (#match? @_comment "^\\/\\*\\s*html\\s*\\*\\/") ; /* html */ or /*html*/
     (#set! injection.language "html")
 )
 
 ; INJECT JS
 (
-	[
-		; var, const or short declaration of raw or interpreted string literal
-		((comment) @comment
+    [
+        (const_spec
+            name: (identifier)
+            "="
+            (comment) @_comment
             value: (expression_list
             [
                 (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
@@ -241,17 +366,40 @@
             ]
         ))
 
-		; := assignment
-    	((comment) @comment
-            right: (expression_list
+        (var_spec
+            name: (identifier)
+            "="
+            (comment) @_comment
+            value: (expression_list
             [
                 (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
                 (raw_string_literal (raw_string_literal_content) @injection.content)
             ]
         ))
 
-        ; when passing as a literal element (to struct field eg.)
-        ((comment) @comment
+        (assignment_statement
+        left: (expression_list)
+        "="
+        (comment) @_comment
+        right: (expression_list
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
+        ))
+
+        (short_var_declaration
+        left: (expression_list)
+        ":="
+        (comment) @_comment
+        right: (expression_list
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
+        ))
+
+        ((comment) @_comment
             value: (literal_element
             [
                 (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
@@ -259,24 +407,26 @@
             ]
         ))
 
-		; when passing as a function parameter
-        ((comment) @comment
+        (argument_list
+            (comment) @_comment
             [
                	(interpreted_string_literal (interpreted_string_literal_content) @injection.content)
                 (raw_string_literal (raw_string_literal_content) @injection.content)
             ]
         )
     ]
-    (#match? @comment "^\\/\\*\\s*js\\s*\\*\\/") ; /* js */ or /*js*/
+    (#match? @_comment "^\\/\\*\\s*js\\s*\\*\\/") ; /* js */ or /*js*/
     (#set! injection.language "javascript")
 )
 
 
 ; INJECT CSS
 (
-	[
-		; var, const or short declaration of raw or interpreted string literal
-		((comment) @comment
+    [
+        (const_spec
+            name: (identifier)
+            "="
+            (comment) @_comment
             value: (expression_list
             [
                 (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
@@ -284,17 +434,40 @@
             ]
         ))
 
-		; := assignment
-    	((comment) @comment
-            right: (expression_list
+        (var_spec
+            name: (identifier)
+            "="
+            (comment) @_comment
+            value: (expression_list
             [
                 (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
                 (raw_string_literal (raw_string_literal_content) @injection.content)
             ]
         ))
 
-        ; when passing as a literal element (to struct field eg.)
-        ((comment) @comment
+        (assignment_statement
+        left: (expression_list)
+        "="
+        (comment) @_comment
+        right: (expression_list
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
+        ))
+
+        (short_var_declaration
+        left: (expression_list)
+        ":="
+        (comment) @_comment
+        right: (expression_list
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
+        ))
+
+        ((comment) @_comment
             value: (literal_element
             [
                 (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
@@ -302,24 +475,26 @@
             ]
         ))
 
-		; when passing as a function parameter
-        ((comment) @comment
+        (argument_list
+            (comment) @_comment
             [
                	(interpreted_string_literal (interpreted_string_literal_content) @injection.content)
                 (raw_string_literal (raw_string_literal_content) @injection.content)
             ]
         )
     ]
-    (#match? @comment "^\\/\\*\\s*css\\s*\\*\\/") ; /* css */ or /*css*/
+    (#match? @_comment "^\\/\\*\\s*css\\s*\\*\\/") ; /* css */ or /*css*/
     (#set! injection.language "css")
 )
 
 
 ; INJECT LUA
 (
-	[
-		; var, const or short declaration of raw or interpreted string literal
-		((comment) @comment
+    [
+        (const_spec
+            name: (identifier)
+            "="
+            (comment) @_comment
             value: (expression_list
             [
                 (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
@@ -327,17 +502,40 @@
             ]
         ))
 
-		; := assignment
-    	((comment) @comment
-            right: (expression_list
+        (var_spec
+            name: (identifier)
+            "="
+            (comment) @_comment
+            value: (expression_list
             [
                 (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
                 (raw_string_literal (raw_string_literal_content) @injection.content)
             ]
         ))
 
-        ; when passing as a literal element (to struct field eg.)
-        ((comment) @comment
+        (assignment_statement
+        left: (expression_list)
+        "="
+        (comment) @_comment
+        right: (expression_list
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
+        ))
+
+        (short_var_declaration
+        left: (expression_list)
+        ":="
+        (comment) @_comment
+        right: (expression_list
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
+        ))
+
+        ((comment) @_comment
             value: (literal_element
             [
                 (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
@@ -345,23 +543,25 @@
             ]
         ))
 
-		; when passing as a function parameter
-        ((comment) @comment
+        (argument_list
+            (comment) @_comment
             [
                	(interpreted_string_literal (interpreted_string_literal_content) @injection.content)
                 (raw_string_literal (raw_string_literal_content) @injection.content)
             ]
         )
     ]
-    (#match? @comment "^\\/\\*\\s*lua\\s*\\*\\/") ; /* lua */ or /*lua*/
+    (#match? @_comment "^\\/\\*\\s*lua\\s*\\*\\/") ; /* lua */ or /*lua*/
     (#set! injection.language "lua")
 )
 
 ; INJECT BASH
 (
-	[
-		; var, const or short declaration of raw or interpreted string literal
-		((comment) @comment
+    [
+        (const_spec
+            name: (identifier)
+            "="
+            (comment) @_comment
             value: (expression_list
             [
                 (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
@@ -369,17 +569,40 @@
             ]
         ))
 
-		; := assignment
-    	((comment) @comment
-            right: (expression_list
+        (var_spec
+            name: (identifier)
+            "="
+            (comment) @_comment
+            value: (expression_list
             [
                 (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
                 (raw_string_literal (raw_string_literal_content) @injection.content)
             ]
         ))
 
-        ; when passing as a literal element (to struct field eg.)
-        ((comment) @comment
+        (assignment_statement
+        left: (expression_list)
+        "="
+        (comment) @_comment
+        right: (expression_list
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
+        ))
+
+        (short_var_declaration
+        left: (expression_list)
+        ":="
+        (comment) @_comment
+        right: (expression_list
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
+        ))
+
+        ((comment) @_comment
             value: (literal_element
             [
                 (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
@@ -387,23 +610,25 @@
             ]
         ))
 
-		; when passing as a function parameter
-        ((comment) @comment
+        (argument_list
+            (comment) @_comment
             [
                	(interpreted_string_literal (interpreted_string_literal_content) @injection.content)
                 (raw_string_literal (raw_string_literal_content) @injection.content)
             ]
         )
     ]
-    (#match? @comment "^\\/\\*\\s*bash\\s*\\*\\/") ; /* bash */ or /*bash*/
+    (#match? @_comment "^\\/\\*\\s*bash\\s*\\*\\/") ; /* bash */ or /*bash*/
     (#set! injection.language "bash")
 )
 
 ; INJECT CSV
 (
-	[
-		; var, const or short declaration of raw or interpreted string literal
-		((comment) @comment
+    [
+        (const_spec
+            name: (identifier)
+            "="
+            (comment) @_comment
             value: (expression_list
             [
                 (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
@@ -411,17 +636,40 @@
             ]
         ))
 
-		; := assignment
-    	((comment) @comment
-            right: (expression_list
+        (var_spec
+            name: (identifier)
+            "="
+            (comment) @_comment
+            value: (expression_list
             [
                 (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
                 (raw_string_literal (raw_string_literal_content) @injection.content)
             ]
         ))
 
-        ; when passing as a literal element (to struct field eg.)
-        ((comment) @comment
+        (assignment_statement
+        left: (expression_list)
+        "="
+        (comment) @_comment
+        right: (expression_list
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
+        ))
+
+        (short_var_declaration
+        left: (expression_list)
+        ":="
+        (comment) @_comment
+        right: (expression_list
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
+        ))
+
+        ((comment) @_comment
             value: (literal_element
             [
                 (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
@@ -429,14 +677,14 @@
             ]
         ))
 
-		; when passing as a function parameter
-        ((comment) @comment
+        (argument_list
+            (comment) @_comment
             [
                	(interpreted_string_literal (interpreted_string_literal_content) @injection.content)
                 (raw_string_literal (raw_string_literal_content) @injection.content)
             ]
         )
     ]
-    (#match? @comment "^\\/\\*\\s*csv\\s*\\*\\/") ; /* csv */ or /*csv */
+    (#match? @_comment "^\\/\\*\\s*csv\\s*\\*\\/") ; /* csv */ or /*csv */
     (#set! injection.language "csv")
 )

--- a/crates/languages/src/go/injections.scm
+++ b/crates/languages/src/go/injections.scm
@@ -64,21 +64,26 @@
             ]
         ))
 
-        ((comment) @_comment
+        (composite_literal
+            body: (literal_value
+            (keyed_element
+            (comment) @_comment
             value: (literal_element
             [
                 (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
                 (raw_string_literal (raw_string_literal_content) @injection.content)
             ]
-        ))
+        ))))
 
-        (argument_list
+        (expression_statement
+            (call_expression
+            (argument_list
             (comment) @_comment
             [
                	(interpreted_string_literal (interpreted_string_literal_content) @injection.content)
                 (raw_string_literal (raw_string_literal_content) @injection.content)
             ]
-        )
+        )))
     ]
   (#match? @_comment "^\\/\\*\\s*sql\\s*\\*\\/$")
   (#set! injection.language "sql")
@@ -131,21 +136,26 @@
             ]
         ))
 
-        ((comment) @_comment
+        (composite_literal
+            body: (literal_value
+            (keyed_element
+            (comment) @_comment
             value: (literal_element
             [
                 (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
                 (raw_string_literal (raw_string_literal_content) @injection.content)
             ]
-        ))
+        ))))
 
-        (argument_list
+        (expression_statement
+            (call_expression
+            (argument_list
             (comment) @_comment
             [
                	(interpreted_string_literal (interpreted_string_literal_content) @injection.content)
                 (raw_string_literal (raw_string_literal_content) @injection.content)
             ]
-        )
+        )))
     ]
     (#match? @_comment "^\\/\\*\\s*json\\s*\\*\\/") ; /* json */ or /*json*/
     (#set! injection.language "json")
@@ -198,27 +208,32 @@
             ]
         ))
 
-        ((comment) @_comment
+        (composite_literal
+            body: (literal_value
+            (keyed_element
+            (comment) @_comment
             value: (literal_element
             [
                 (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
                 (raw_string_literal (raw_string_literal_content) @injection.content)
             ]
-        ))
+        ))))
 
-        (argument_list
+        (expression_statement
+            (call_expression
+            (argument_list
             (comment) @_comment
             [
                	(interpreted_string_literal (interpreted_string_literal_content) @injection.content)
                 (raw_string_literal (raw_string_literal_content) @injection.content)
             ]
-        )
+        )))
     ]
     (#match? @_comment "^\\/\\*\\s*yaml\\s*\\*\\/") ; /* yaml */ or /*yaml*/
     (#set! injection.language "yaml")
 )
 
-; ; INJECT XML
+; INJECT XML
 (
     [
         (const_spec
@@ -265,21 +280,26 @@
             ]
         ))
 
-        ((comment) @_comment
+        (composite_literal
+            body: (literal_value
+            (keyed_element
+            (comment) @_comment
             value: (literal_element
             [
                 (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
                 (raw_string_literal (raw_string_literal_content) @injection.content)
             ]
-        ))
+        ))))
 
-        (argument_list
+        (expression_statement
+            (call_expression
+            (argument_list
             (comment) @_comment
             [
                	(interpreted_string_literal (interpreted_string_literal_content) @injection.content)
                 (raw_string_literal (raw_string_literal_content) @injection.content)
             ]
-        )
+        )))
     ]
     (#match? @_comment "^\\/\\*\\s*xml\\s*\\*\\/") ; /* xml */ or /*xml*/
     (#set! injection.language "xml")
@@ -332,21 +352,26 @@
             ]
         ))
 
-        ((comment) @_comment
+        (composite_literal
+            body: (literal_value
+            (keyed_element
+            (comment) @_comment
             value: (literal_element
             [
                 (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
                 (raw_string_literal (raw_string_literal_content) @injection.content)
             ]
-        ))
+        ))))
 
-        (argument_list
+        (expression_statement
+            (call_expression
+            (argument_list
             (comment) @_comment
             [
                	(interpreted_string_literal (interpreted_string_literal_content) @injection.content)
                 (raw_string_literal (raw_string_literal_content) @injection.content)
             ]
-        )
+        )))
     ]
     (#match? @_comment "^\\/\\*\\s*html\\s*\\*\\/") ; /* html */ or /*html*/
     (#set! injection.language "html")
@@ -399,21 +424,26 @@
             ]
         ))
 
-        ((comment) @_comment
+        (composite_literal
+            body: (literal_value
+            (keyed_element
+            (comment) @_comment
             value: (literal_element
             [
                 (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
                 (raw_string_literal (raw_string_literal_content) @injection.content)
             ]
-        ))
+        ))))
 
-        (argument_list
+        (expression_statement
+            (call_expression
+            (argument_list
             (comment) @_comment
             [
                	(interpreted_string_literal (interpreted_string_literal_content) @injection.content)
                 (raw_string_literal (raw_string_literal_content) @injection.content)
             ]
-        )
+        )))
     ]
     (#match? @_comment "^\\/\\*\\s*js\\s*\\*\\/") ; /* js */ or /*js*/
     (#set! injection.language "javascript")
@@ -467,21 +497,26 @@
             ]
         ))
 
-        ((comment) @_comment
+        (composite_literal
+            body: (literal_value
+            (keyed_element
+            (comment) @_comment
             value: (literal_element
             [
                 (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
                 (raw_string_literal (raw_string_literal_content) @injection.content)
             ]
-        ))
+        ))))
 
-        (argument_list
+        (expression_statement
+            (call_expression
+            (argument_list
             (comment) @_comment
             [
                	(interpreted_string_literal (interpreted_string_literal_content) @injection.content)
                 (raw_string_literal (raw_string_literal_content) @injection.content)
             ]
-        )
+        )))
     ]
     (#match? @_comment "^\\/\\*\\s*css\\s*\\*\\/") ; /* css */ or /*css*/
     (#set! injection.language "css")
@@ -535,21 +570,26 @@
             ]
         ))
 
-        ((comment) @_comment
+        (composite_literal
+            body: (literal_value
+            (keyed_element
+            (comment) @_comment
             value: (literal_element
             [
                 (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
                 (raw_string_literal (raw_string_literal_content) @injection.content)
             ]
-        ))
+        ))))
 
-        (argument_list
+        (expression_statement
+            (call_expression
+            (argument_list
             (comment) @_comment
             [
                	(interpreted_string_literal (interpreted_string_literal_content) @injection.content)
                 (raw_string_literal (raw_string_literal_content) @injection.content)
             ]
-        )
+        )))
     ]
     (#match? @_comment "^\\/\\*\\s*lua\\s*\\*\\/") ; /* lua */ or /*lua*/
     (#set! injection.language "lua")
@@ -602,21 +642,26 @@
             ]
         ))
 
-        ((comment) @_comment
+        (composite_literal
+            body: (literal_value
+            (keyed_element
+            (comment) @_comment
             value: (literal_element
             [
                 (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
                 (raw_string_literal (raw_string_literal_content) @injection.content)
             ]
-        ))
+        ))))
 
-        (argument_list
+        (expression_statement
+            (call_expression
+            (argument_list
             (comment) @_comment
             [
                	(interpreted_string_literal (interpreted_string_literal_content) @injection.content)
                 (raw_string_literal (raw_string_literal_content) @injection.content)
             ]
-        )
+        )))
     ]
     (#match? @_comment "^\\/\\*\\s*bash\\s*\\*\\/") ; /* bash */ or /*bash*/
     (#set! injection.language "bash")

--- a/crates/languages/src/go/injections.scm
+++ b/crates/languages/src/go/injections.scm
@@ -24,12 +24,8 @@
 		((comment) @comment
             value: (expression_list
             [
-                (interpreted_string_literal
-                    (interpreted_string_literal_content) @injection.content
-                )
-                (raw_string_literal
-                    (raw_string_literal_content) @injection.content
-                )
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
             ]
         ))
 
@@ -37,12 +33,8 @@
     	((comment) @comment
             right: (expression_list
             [
-                (interpreted_string_literal
-                    (interpreted_string_literal_content) @injection.content
-                )
-                (raw_string_literal
-                    (raw_string_literal_content) @injection.content
-                )
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
             ]
         ))
 
@@ -50,24 +42,16 @@
         ((comment) @comment
             value: (literal_element
             [
-                (interpreted_string_literal
-                    (interpreted_string_literal_content) @injection.content
-                )
-                (raw_string_literal
-                    (raw_string_literal_content) @injection.content
-                )
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
             ]
         ))
 
 		; when passing as a function parameter
         ((comment) @comment
         [
-           	(interpreted_string_literal
-               	(interpreted_string_literal_content) @injection.content
-            )
-            (raw_string_literal
-               	(raw_string_literal_content) @injection.content
-            )
+           	(interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+            (raw_string_literal (raw_string_literal_content) @injection.content)
         ]
         )
     ]
@@ -80,31 +64,38 @@
 	[
 		; var, const or short declaration of raw or interpreted string literal
 		((comment) @comment
-  		.
-    	(expression_list
-     	[
-      		(interpreted_string_literal)
-        	(raw_string_literal)
-        ] @injection.content
+            value: (expression_list
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
+        ))
+
+		; := assignment
+       	((comment) @comment
+            right: (expression_list
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
         ))
 
         ; when passing as a literal element (to struct field eg.)
-		((comment) @comment
-        .
-        (literal_element
-        [
-        	(interpreted_string_literal)
-        	(raw_string_literal)
-        ] @injection.content
+        ((comment) @comment
+            value: (literal_element
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
         ))
 
         ; when passing as a function parameter
         ((comment) @comment
-        .
-        [
-        	(interpreted_string_literal)
-        	(raw_string_literal)
-        ] @injection.content)
+            [
+               	(interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
+        )
     ]
 
     (#match? @comment "^\\/\\*\\s*json\\s*\\*\\/") ; /* json */ or /*json*/
@@ -116,31 +107,38 @@
 	[
 		; var, const or short declaration of raw or interpreted string literal
 		((comment) @comment
-  		.
-    	(expression_list
-     	[
-      		(interpreted_string_literal)
-        	(raw_string_literal)
-        ] @injection.content
+            value: (expression_list
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
         ))
 
+       	((comment) @comment
+            right: (expression_list
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
+        ))
+
+
         ; when passing as a literal element (to struct field eg.)
-		((comment) @comment
-        .
-        (literal_element
-        [
-        	(interpreted_string_literal)
-        	(raw_string_literal)
-        ] @injection.content
+        ((comment) @comment
+            value: (literal_element
+            [
+               	(interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
         ))
 
         ; when passing as a function parameter
         ((comment) @comment
-        .
-        [
-        	(interpreted_string_literal)
-        	(raw_string_literal)
-        ] @injection.content)
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
+        )
     ]
 
     (#match? @comment "^\\/\\*\\s*yaml\\s*\\*\\/") ; /* yaml */ or /*yaml*/
@@ -149,36 +147,42 @@
 
 ; INJECT XML
 (
-	[
+    [
 		; var, const or short declaration of raw or interpreted string literal
 		((comment) @comment
-  		.
-    	(expression_list
-     	[
-      		(interpreted_string_literal)
-        	(raw_string_literal)
-        ] @injection.content
+            value: (expression_list
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
+        ))
+
+		; := assignment
+       	((comment) @comment
+            right: (expression_list
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
         ))
 
         ; when passing as a literal element (to struct field eg.)
-		((comment) @comment
-        .
-        (literal_element
-        [
-        	(interpreted_string_literal)
-        	(raw_string_literal)
-        ] @injection.content
+        ((comment) @comment
+            value: (literal_element
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
         ))
 
-        ; when passing as a function parameter
-        ((comment) @comment
-        .
-        [
-        	(interpreted_string_literal)
-        	(raw_string_literal)
-        ] @injection.content)
-    ]
-
+		; when passing as a function parameter
+           ((comment) @comment
+           [
+              	(interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+               (raw_string_literal (raw_string_literal_content) @injection.content)
+           ]
+           )
+       ]
     (#match? @comment "^\\/\\*\\s*xml\\s*\\*\\/") ; /* xml */ or /*xml*/
     (#set! injection.language "xml")
 )
@@ -188,33 +192,39 @@
 	[
 		; var, const or short declaration of raw or interpreted string literal
 		((comment) @comment
-  		.
-    	(expression_list
-     	[
-      		(interpreted_string_literal)
-        	(raw_string_literal)
-        ] @injection.content
+            value: (expression_list
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
+        ))
+
+		; := assignment
+    	((comment) @comment
+            right: (expression_list
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
         ))
 
         ; when passing as a literal element (to struct field eg.)
-		((comment) @comment
-        .
-        (literal_element
-        [
-        	(interpreted_string_literal)
-        	(raw_string_literal)
-        ] @injection.content
+        ((comment) @comment
+            value: (literal_element
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
         ))
 
-        ; when passing as a function parameter
+		; when passing as a function parameter
         ((comment) @comment
-        .
-        [
-        	(interpreted_string_literal)
-        	(raw_string_literal)
-        ] @injection.content)
+            [
+               	(interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
+        )
     ]
-
     (#match? @comment "^\\/\\*\\s*html\\s*\\*\\/") ; /* html */ or /*html*/
     (#set! injection.language "html")
 )
@@ -224,105 +234,125 @@
 	[
 		; var, const or short declaration of raw or interpreted string literal
 		((comment) @comment
-  		.
-    	(expression_list
-     	[
-      		(interpreted_string_literal)
-        	(raw_string_literal)
-        ] @injection.content
+            value: (expression_list
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
+        ))
+
+		; := assignment
+    	((comment) @comment
+            right: (expression_list
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
         ))
 
         ; when passing as a literal element (to struct field eg.)
-		((comment) @comment
-        .
-        (literal_element
-        [
-        	(interpreted_string_literal)
-        	(raw_string_literal)
-        ] @injection.content
+        ((comment) @comment
+            value: (literal_element
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
         ))
 
-        ; when passing as a function parameter
+		; when passing as a function parameter
         ((comment) @comment
-        .
-        [
-        	(interpreted_string_literal)
-        	(raw_string_literal)
-        ] @injection.content)
+            [
+               	(interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
+        )
     ]
-
     (#match? @comment "^\\/\\*\\s*js\\s*\\*\\/") ; /* js */ or /*js*/
     (#set! injection.language "javascript")
 )
+
 
 ; INJECT CSS
 (
 	[
 		; var, const or short declaration of raw or interpreted string literal
 		((comment) @comment
-  		.
-    	(expression_list
-     	[
-      		(interpreted_string_literal)
-        	(raw_string_literal)
-        ] @injection.content
+            value: (expression_list
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
+        ))
+
+		; := assignment
+    	((comment) @comment
+            right: (expression_list
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
         ))
 
         ; when passing as a literal element (to struct field eg.)
-		((comment) @comment
-        .
-        (literal_element
-        [
-        	(interpreted_string_literal)
-        	(raw_string_literal)
-        ] @injection.content
+        ((comment) @comment
+            value: (literal_element
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
         ))
 
-        ; when passing as a function parameter
+		; when passing as a function parameter
         ((comment) @comment
-        .
-        [
-        	(interpreted_string_literal)
-        	(raw_string_literal)
-        ] @injection.content)
+            [
+               	(interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
+        )
     ]
-
     (#match? @comment "^\\/\\*\\s*css\\s*\\*\\/") ; /* css */ or /*css*/
     (#set! injection.language "css")
 )
+
 
 ; INJECT LUA
 (
 	[
 		; var, const or short declaration of raw or interpreted string literal
 		((comment) @comment
-  		.
-    	(expression_list
-     	[
-      		(interpreted_string_literal)
-        	(raw_string_literal)
-        ] @injection.content
+            value: (expression_list
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
+        ))
+
+		; := assignment
+    	((comment) @comment
+            right: (expression_list
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
         ))
 
         ; when passing as a literal element (to struct field eg.)
-		((comment) @comment
-        .
-        (literal_element
-        [
-        	(interpreted_string_literal)
-        	(raw_string_literal)
-        ] @injection.content
+        ((comment) @comment
+            value: (literal_element
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
         ))
 
-        ; when passing as a function parameter
+		; when passing as a function parameter
         ((comment) @comment
-        .
-        [
-        	(interpreted_string_literal)
-        	(raw_string_literal)
-        ] @injection.content)
+            [
+               	(interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
+        )
     ]
-
     (#match? @comment "^\\/\\*\\s*lua\\s*\\*\\/") ; /* lua */ or /*lua*/
     (#set! injection.language "lua")
 )
@@ -332,33 +362,39 @@
 	[
 		; var, const or short declaration of raw or interpreted string literal
 		((comment) @comment
-  		.
-    	(expression_list
-     	[
-      		(interpreted_string_literal)
-        	(raw_string_literal)
-        ] @injection.content
+            value: (expression_list
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
+        ))
+
+		; := assignment
+    	((comment) @comment
+            right: (expression_list
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
         ))
 
         ; when passing as a literal element (to struct field eg.)
-		((comment) @comment
-        .
-        (literal_element
-        [
-        	(interpreted_string_literal)
-        	(raw_string_literal)
-        ] @injection.content
+        ((comment) @comment
+            value: (literal_element
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
         ))
 
-        ; when passing as a function parameter
+		; when passing as a function parameter
         ((comment) @comment
-        .
-        [
-        	(interpreted_string_literal)
-        	(raw_string_literal)
-        ] @injection.content)
+            [
+               	(interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
+        )
     ]
-
     (#match? @comment "^\\/\\*\\s*bash\\s*\\*\\/") ; /* bash */ or /*bash*/
     (#set! injection.language "bash")
 )
@@ -368,33 +404,39 @@
 	[
 		; var, const or short declaration of raw or interpreted string literal
 		((comment) @comment
-  		.
-    	(expression_list
-     	[
-      		(interpreted_string_literal)
-        	(raw_string_literal)
-        ] @injection.content
+            value: (expression_list
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
+        ))
+
+		; := assignment
+    	((comment) @comment
+            right: (expression_list
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
         ))
 
         ; when passing as a literal element (to struct field eg.)
-		((comment) @comment
-        .
-        (literal_element
-        [
-        	(interpreted_string_literal)
-        	(raw_string_literal)
-        ] @injection.content
+        ((comment) @comment
+            value: (literal_element
+            [
+                (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
         ))
 
-        ; when passing as a function parameter
+		; when passing as a function parameter
         ((comment) @comment
-        .
-        [
-        	(interpreted_string_literal)
-        	(raw_string_literal)
-        ] @injection.content)
+            [
+               	(interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+                (raw_string_literal (raw_string_literal_content) @injection.content)
+            ]
+        )
     ]
-
-    (#match? @comment "^\\/\\*\\s*csv\\s*\\*\\/") ; /* csv */ or /*csv*/
+    (#match? @comment "^\\/\\*\\s*csv\\s*\\*\\/") ; /* csv */ or /*csv */
     (#set! injection.language "csv")
 )


### PR DESCRIPTION
Closes #43730


## Summary
This modifies the existing injections.scm file for go by adding more specific prefix queries and *_content nodes to the existing `raw_string_literal` and `interpreted_string_literal` sections

<details><summary>This PR</summary>

<img width="567" height="784" alt="image" src="https://github.com/user-attachments/assets/bfe8c64e-1dc2-470c-9f85-2c664a6c5a15" />
<img width="383" height="909" alt="image" src="https://github.com/user-attachments/assets/9349af8c-22d3-4c9b-a435-a73719f17ba3" />
<img width="572" height="800" alt="image" src="https://github.com/user-attachments/assets/939ada3b-1440-443b-8492-0eb61a7ee90f" />

</details>

<details><summary>Current Release (0.214.7)</summary>

<img width="569" height="777" alt="image" src="https://github.com/user-attachments/assets/e6fffe77-e4c6-48e3-9c6d-a140298225c5" />
<img width="381" height="896" alt="image" src="https://github.com/user-attachments/assets/bf107950-c33a-4603-90d3-2304bef0a4af" />
<img width="574" height="798" alt="image" src="https://github.com/user-attachments/assets/2c5e43e5-f101-4722-8f58-6b176ba950ca" />

</details>

<details><summary>Code</summary>

```go
func test_sql() {
	// const assignment
	const _ = /* sql */ "SELECT * FROM users"
	const _ = /* sql */ `SELECT id, name FROM products`

	// var assignment
	var _ = /* sql */ `SELECT id, name FROM products`
	var _ = /* sql */ "SELECT id, name FROM products"

	// := assignment
	test := /* sql */ "SELECT * FROM users"
	test2 := /* sql */ `SELECT * FROM users`
	println(test)
	println(test2)

	// = assignment
	_ = /* sql */ "SELECT * FROM users WHERE id = 1"
	_ = /* sql */ `SELECT * FROM users WHERE id = 1`

	// literal elements
	_ = testStruct{Field: /* sql */ "SELECT * FROM users"}
	_ = testStruct{Field: /* sql */ `SELECT * FROM users`}

	testFunc(/* sql */ "SELECT * FROM users")
	testFunc(/* sql */ `SELECT * FROM users`)

	const backtickString = /* sql */ `SELECT * FROM users;`
	const quotedString = /* sql */ "SELECT * FROM users;"

	const backtickStringNoHighlight = `SELECT * FROM users;`
	const quotedStringNoHighlight = "SELECT * FROM users;"
}

func test_yaml() {
	// const assignment
	const _ = /* yaml */ `
settings:
  enabled: true
  port: 8080
`

	// := assignment
	test := /* yaml */ `
settings:
  enabled: true
  port: 8080
`

	println(test)

	// = assignment
	_ = /* yaml */ `
settings:
  enabled: true
  port: 8080
`

	// literal elements in a struct
	_ = testStruct{Field: /* yaml */ `
settings:
  test: 1234
  port: 8080
`}

	// function argument
	testFunc(/* yaml */ `
settings:
  enabled: true
  port: 8080
`)
}

func test_css() {
	// const assignment
	const _ = /* css */ "body { margin: 0; }"
	const _ = /* css */ `body { margin: 0; }`

	const cssCodes = /* css */ `
h1 {
  color: #333;
}
`

	// := assignment
	test := /* css */ "body { margin: 0; }"
	println(test)

	// = assignment
	_ = /* css */ "body { margin: 0; }"
	_ = /* css */ `body { margin: 0; }`

	// literal elements
	_ = testStruct{Field: /* css */ "body { margin: 0; }"}
	_ = testStruct{Field: /* css */ `body { margin: 0; }`}

	testFunc(/* css */ "body { margin: 0; }")
	testFunc(/* css */ `body { margin: 0; }`)

	const backtickString = /* css */ `body { margin: 0; }`
	const quotedString = /* css */ "body { margin: 0; }"

	const backtickStringNoHighlight = `body { margin: 0; }`
	const quotedStringNoHighlight = "body { margin: 0; }"
}
```

</details>

Release Notes:

- Greatly improved the quality of comment-directed language injections in Go