### PR TITLE
buffer_diff: Fix git gutter incorrectly showing for ignored files

### DIFF
--- a/crates/buffer_diff/src/buffer_diff.rs
+++ b/crates/buffer_diff/src/buffer_diff.rs
@@ -1235,7 +1235,7 @@ impl DiffHunk {
     pub fn is_created_file(&self) -> bool {
         self.diff_base_byte_range == (0..0)
             && self.buffer_range.start.is_min()
-            && self.buffer_range.end.is_min()
+            && self.buffer_range.end.is_max()
     }
 
     pub fn status(&self) -> DiffHunkStatus {


### PR DESCRIPTION
Closes #43734
Closes #43698

Release Notes:

- Fixed git gutter incorrectly showing up for ignored files.