### PR TITLE
ssh: Fix connection failure to remote server when login shell prints anything

### DIFF
--- a/crates/remote/src/transport/ssh.rs
+++ b/crates/remote/src/transport/ssh.rs
@@ -1060,8 +1060,7 @@ impl SshSocket {
 
         // The outputs of initialization scripts may not end with new line, so os may become like
         // "Welcome to Ubuntu 20.04.4 LTSLinux". We just check the ending here.
-        let os = os.trim_end();
-        let os = match os {
+        let os = match os.trim_end() {
             o if o.ends_with("Darwin") => "macos",
             o if o.ends_with("Linux") => "linux",
             _ => anyhow::bail!(

--- a/crates/remote/src/transport/ssh.rs
+++ b/crates/remote/src/transport/ssh.rs
@@ -1064,8 +1064,8 @@ impl SshSocket {
             o if o.ends_with("Darwin") => "macos",
             o if o.ends_with("Linux") => "linux",
             _ => anyhow::bail!(
-                    "Prebuilt remote servers are not yet available for {os:?}. See https://zed.dev/docs/remote-development"
-                )
+                "Prebuilt remote servers are not yet available for {os:?}. See https://zed.dev/docs/remote-development"
+            ),
         };
 
         // exclude armv5,6,7 as they are 32-bit.

--- a/crates/remote/src/transport/ssh.rs
+++ b/crates/remote/src/transport/ssh.rs
@@ -1060,7 +1060,7 @@ impl SshSocket {
             _ => anyhow::bail!("unknown uname: {uname:?}"),
         };
 
-        // The junk infor before the uname output may look lke "Welcome to Ubuntu 20.04.4 LTS"
+        // The junk info before the uname output may look like "Welcome to Ubuntu 20.04.4 LTS"
         // and doesn't have a trailing newline, so os may become like "LTSLinux". We just check
         // the ending here.
         let os = match os {


### PR DESCRIPTION
Closes #43599

Release Notes:

- ssh remote: Fixed that remote project fail to start when remote user's login shell
prints contents. The remote server's os type and arch type are decided by running
command 'uname -sm'. But if the login shell prints something  else before the 
output of 'uname -sm', it will pollute the result of 'uname -sm'. 
