### PR TITLE
extensions: Pass protobuf-language-server settings and initialization_options to the LSP

### DIFF
--- a/extensions/proto/src/proto.rs
+++ b/extensions/proto/src/proto.rs
@@ -59,6 +59,30 @@ impl zed::Extension for ProtobufExtension {
             env: Default::default(),
         })
     }
+
+    fn language_server_workspace_configuration(
+        &mut self,
+        server_id: &zed::LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<Option<zed::serde_json::Value>> {
+        let settings = LspSettings::for_worktree(server_id.as_ref(), worktree)
+            .ok()
+            .and_then(|lsp_settings| lsp_settings.settings)
+            .unwrap_or_default();
+        Ok(Some(settings))
+    }
+
+    fn language_server_initialization_options(
+        &mut self,
+        server_id: &zed::LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<Option<zed_extension_api::serde_json::Value>> {
+        let initialization_options = LspSettings::for_worktree(server_id.as_ref(), worktree)
+            .ok()
+            .and_then(|lsp_settings| lsp_settings.initialization_options)
+            .unwrap_or_default();
+        Ok(Some(initialization_options))
+    }
 }
 
 zed::register_extension!(ProtobufExtension);

--- a/extensions/proto/src/proto.rs
+++ b/extensions/proto/src/proto.rs
@@ -67,9 +67,8 @@ impl zed::Extension for ProtobufExtension {
     ) -> Result<Option<zed::serde_json::Value>> {
         let settings = LspSettings::for_worktree(server_id.as_ref(), worktree)
             .ok()
-            .and_then(|lsp_settings| lsp_settings.settings)
-            .unwrap_or_default();
-        Ok(Some(settings))
+            .and_then(|lsp_settings| lsp_settings.settings);
+        Ok(settings)
     }
 
     fn language_server_initialization_options(
@@ -79,9 +78,8 @@ impl zed::Extension for ProtobufExtension {
     ) -> Result<Option<zed_extension_api::serde_json::Value>> {
         let initialization_options = LspSettings::for_worktree(server_id.as_ref(), worktree)
             .ok()
-            .and_then(|lsp_settings| lsp_settings.initialization_options)
-            .unwrap_or_default();
-        Ok(Some(initialization_options))
+            .and_then(|lsp_settings| lsp_settings.initialization_options);
+        Ok(initialization_options)
     }
 }
 


### PR DESCRIPTION
pass protobuf-language-server settings and initialization_options to the protobuf-language-server

Closes #43786

Release Notes:

- N/A
