### PR TITLE
agent_ui: Fix delete icon event in history panel

### DIFF
--- a/crates/agent_ui/src/acp/thread_history.rs
+++ b/crates/agent_ui/src/acp/thread_history.rs
@@ -446,9 +446,10 @@ impl AcpThreadHistory {
                                 .tooltip(move |_window, cx| {
                                     Tooltip::for_action("Delete", &RemoveSelectedThread, cx)
                                 })
-                                .on_click(
-                                    cx.listener(move |this, _, _, cx| this.remove_thread(ix, cx)),
-                                ),
+                                .on_click(cx.listener(move |this, _, _, cx| {
+                                    this.remove_thread(ix, cx);
+                                    cx.stop_propagation()
+                                })),
                         )
                     } else {
                         None


### PR DESCRIPTION
Summary

Fixed the thread deletion issue by:

1. Click handler conflict between the trash icon and the main ListItem
2. Added `cx.stop_propagation()` to prevent the click event from bubbling up to the parent ListItem's click handler
3. Followed the established `cx.stop_propagation()` pattern used throughout the codebase

Now when you click the trash icon to delete a thread:
- ✅ The thread deletion happens immediately on the first click
- ✅ No race condition between deletion and activation
- ✅ No double-clicking required

The fix is minimal, follows established patterns, and addresses the exact root cause of the issue.

- Stop event propagation in thread removal handler

Release Notes:

- agent: Improved delete thread action in the history view by preventing it from also triggering the thread activation.