### PR TITLE
Respect vertical placement offset for glyphs

### DIFF
--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -1515,7 +1515,7 @@ impl IDWriteTextRenderer_Impl for TextRenderer_Impl {
                     id,
                     position: point(
                         px(context.width + glyph_offsets[this_glyph_idx].advanceOffset),
-                        px(0.0),
+                        px(-glyph_offsets[this_glyph_idx].ascenderOffset),
                     ),
                     index: context.index_converter.utf8_ix,
                     is_emoji,

--- a/crates/gpui/src/text_system/line.rs
+++ b/crates/gpui/src/text_system/line.rs
@@ -369,16 +369,17 @@ fn paint_line(
 
                 let content_mask = window.content_mask();
                 if max_glyph_bounds.intersects(&content_mask.bounds) {
+                    let vertical_offset = point(px(0.0), glyph.position.y);
                     if glyph.is_emoji {
                         window.paint_emoji(
-                            glyph_origin + baseline_offset,
+                            glyph_origin + baseline_offset + vertical_offset,
                             run.font_id,
                             glyph.id,
                             layout.font_size,
                         )?;
                     } else {
                         window.paint_glyph(
-                            glyph_origin + baseline_offset,
+                            glyph_origin + baseline_offset + vertical_offset,
                             run.font_id,
                             glyph.id,
                             layout.font_size,


### PR DESCRIPTION
Before:
<img width="41" height="45" alt="image" src="https://github.com/user-attachments/assets/0f8b1d0e-b0cf-483c-aa2d-77aadd90503c" />

After:
<img width="34" height="50" alt="image" src="https://github.com/user-attachments/assets/fa3eb842-2d1b-49b1-9c37-ebe6e11b37eb" />



Release Notes:

- N/A