### PR TITLE
gpui: Reset mouse scroll state on FocusOut to prevent large jumps

### DIFF
--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -944,6 +944,8 @@ impl X11Client {
                 let window = self.get_window(event.event)?;
                 window.set_active(false);
                 let mut state = self.0.borrow_mut();
+                // Set last scroll values to `None` so that a large delta isn't created if scrolling is done outside the window (the valuator is global)
+                reset_all_pointer_device_scroll_positions(&mut state.pointer_device_states);
                 state.keyboard_focused_window = None;
                 if let Some(compose_state) = state.compose_state.as_mut() {
                     compose_state.reset();


### PR DESCRIPTION
This fixes an X11 scrolling issue where Zed may jump by a large amount due to the scroll valuator state not being reset when the window loses focus. If you Alt-Tab away from Zed, scroll in another application, then return, the first scroll event in Zed applies the entire accumulated delta instead of a single step.

The missing FocusOut reset was originally identified in issue #34901.

Resetting scroll positions on FocusOut matches the behavior already implemented in the XinputLeave handler and prevents this jump.

Closes #34901
Closes #40538

Release Notes:

- Fixed an X11 issue where Alt-Tabbing to another application, scrolling, and returning to Zed could cause the next scroll event to jump by a large amount.
