### PR TITLE
journal: Added possibility to define path, and filename for the journal file

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1399,6 +1399,8 @@
   "journal": {
     // The path of the directory where journal entries are stored
     "path": "~",
+    // What name to use for folders and journal files.
+    "date_format": "%Y/%m/%d.md",
     // What format to display the hours in
     // May take 2 values:
     // 1. hour12

--- a/crates/settings/src/settings_content.rs
+++ b/crates/settings/src/settings_content.rs
@@ -725,6 +725,10 @@ pub struct JournalSettingsContent {
     ///
     /// Default: `~`
     pub path: Option<String>,
+    /// Date format for journal entries.
+    ///
+    /// Default: `%Y/%m/%d.md`
+    pub date_format: Option<String>,
     /// What format to display the hours in.
     ///
     /// Default: hour12


### PR DESCRIPTION
Uses the chronos crate, and file path is formated using DateTime::format.

 - If this is interesting I can add the tests.

Closes Discussion #43845

Release Notes:

- Added date_path configuration for journal files.
