### PR TITLE
gpui: Translate Wayland touch events to mouse events

### DIFF
--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -78,6 +78,9 @@ x11 = [
 screen-capture = [
     "scap",
 ]
+wayland-touch-to-mouse-translation = [
+    "wayland",
+]
 windows-manifest = []
 
 [lib]

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -2451,12 +2451,19 @@ impl Dispatch<wl_touch::WlTouch, ()> for WaylandClientStatePtr {
                     let Some(window) = window.upgrade() else {
                         continue;
                     };
+
+                    // Touch events don't have enter/leave, which is how
+                    // `first_mouse` is determined for mouse events. Pass
+                    // `false` to mark all events as non-focusing (i.e. they
+                    // perform an action, not just change focus).
+                    let first_mouse = false;
+
                     window.handle_input(PlatformInput::MouseDown(MouseDownEvent {
                         button: MouseButton::Left,
                         position,
                         modifiers,
                         click_count: 1,
-                        first_mouse: true,
+                        first_mouse,
                     }));
 
                     window.handle_input(PlatformInput::MouseUp(MouseUpEvent {

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -1419,7 +1419,9 @@ impl Dispatch<wl_seat::WlSeat, ()> for WaylandClientStatePtr {
 
                 state.wl_pointer = Some(pointer);
             }
-            if capabilities.contains(wl_seat::Capability::Touch) {
+            if cfg!(feature = "wayland-touch-to-mouse-translation")
+                && capabilities.contains(wl_seat::Capability::Touch)
+            {
                 if let Some(p) = state.wl_touch.replace(seat.get_touch(qh, ())) {
                     p.release();
                 }
@@ -2416,6 +2418,10 @@ impl Dispatch<wl_touch::WlTouch, ()> for WaylandClientStatePtr {
         _: &Connection,
         _: &QueueHandle<Self>,
     ) {
+        if !cfg!(feature = "wayland-touch-to-mouse-translation") {
+            return;
+        }
+
         let mut client = this.get_client();
         let mut state = client.borrow_mut();
 

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -277,6 +277,20 @@ pub struct WaylandWindowStatePtr {
     callbacks: Rc<RefCell<Callbacks>>,
 }
 
+#[derive(Clone)]
+pub struct WaylandWindowStateWeakPtr {
+    state: std::rc::Weak<RefCell<WaylandWindowState>>,
+    callbacks: std::rc::Weak<RefCell<Callbacks>>,
+}
+
+impl WaylandWindowStateWeakPtr {
+    pub fn upgrade(&self) -> Option<WaylandWindowStatePtr> {
+        let state = self.state.upgrade()?;
+        let callbacks = self.callbacks.upgrade()?;
+        Some(WaylandWindowStatePtr { state, callbacks })
+    }
+}
+
 impl WaylandWindowState {
     pub(crate) fn new(
         handle: AnyWindowHandle,
@@ -487,6 +501,13 @@ impl WaylandWindow {
 impl WaylandWindowStatePtr {
     pub fn handle(&self) -> AnyWindowHandle {
         self.state.borrow().handle
+    }
+
+    pub fn weak(&self) -> WaylandWindowStateWeakPtr {
+        WaylandWindowStateWeakPtr {
+            state: Rc::downgrade(&self.state),
+            callbacks: Rc::downgrade(&self.callbacks),
+        }
     }
 
     pub fn surface(&self) -> wl_surface::WlSurface {

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -70,6 +70,7 @@ gpui = { workspace = true, features = [
     "x11",
     "font-kit",
     "windows-manifest",
+    "wayland-touch-to-mouse-translation",
 ] }
 gpui_tokio.workspace = true
 rayon.workspace = true


### PR DESCRIPTION
First step towards #13698
Alternative to #40139 and #34675


#40139 didn't work on my machine due to the way it handled the [`Window` for touch events](https://github.com/zed-industries/zed/pull/40139#discussion_r2573244164).  It also made a few decisions that I don't agree with as someone who often uses a touchscreen when reading code. Namely:
- Restricting scrolling to two-finger touch (most editors allow scrolling with one-finger, suppressing clicks when a drag is detected).
- Implementing pinch-to-zoom, which isn't good UX when you can't translate the viewport to keep the content under the users fingers consistent.

Obviously, it would be ideal to add `on_touch_down` and friends, maybe emitting mouse up/down/click events when those methods aren't called, but that would require a lot of design work. Unless someone enfranchised takes it upon themselves to start that process, Zed will remain unresponsive on touch screens without hacks like this PR.

The goal is to be simple enough to get upstreamed quickly while providing a good foundation for proper touch/gesture handling. It:
- emits `Mouse{Up,Down}` events when the screen is tapped.  (just like #40139)
- emits `ScrollWheel` events when a finger is dragged across the screen.
- tracks multiple touches, but only emits scroll events for the earliest touch.
- allows simultaneous tapping and scrolling.
- hides this translation behind a feature flag (enabled by the `zed` crate).
- doesn't have pinch-to-zoom. 
- doesn't have long press to right click.

Single finger scroll conflicts with things like drag and drop and moving the minimap, but provides the best UX for the most common use-case for touch gestures: browsing code.

Currently , this PR stores a weak version of `WaylandWindowStatePtr` for each active touch, so touches don't keep a window alive and are silently dropped if it goes out of scope. This is probably overkill. I don't really know the lifecycle of a Wayland window in Zed, or if a single Zed instance uses multiple Wayland windows at once. However, it seemed like the most bulletproof solution.

Release Notes:

- Initial support for touch input on Wayland (tap-to-left-click and and drag-to-scroll)
s