### PR TITLE
Fix for debugging Go subtests

### DIFF
--- a/crates/languages/src/go.rs
+++ b/crates/languages/src/go.rs
@@ -23,7 +23,7 @@ use std::{
         atomic::{AtomicBool, Ordering::SeqCst},
     },
 };
-use task::{TaskTemplate, TaskTemplates, TaskVariables, VariableName};
+use task::{TaskTemplate, TaskTemplates, TaskVariables, VariableName, quote_arg};
 use util::{ResultExt, fs::remove_matching, maybe};
 
 fn server_binary_arguments() -> Vec<OsString> {
@@ -563,11 +563,11 @@ impl ContextProvider for GoContextProvider {
                     "test".into(),
                     "-v".into(),
                     "-run".into(),
-                    format!(
-                        "\\^Test{}\\$/\\^{}\\$",
+                    quote_arg(&format!(
+                        "^Test{}$/^{}$",
                         GO_SUITE_NAME_TASK_VARIABLE.template_value(),
                         VariableName::Symbol.template_value(),
-                    ),
+                    )),
                 ],
                 cwd: package_cwd.clone(),
                 tags: vec!["go-testify-suite".to_owned()],
@@ -585,11 +585,11 @@ impl ContextProvider for GoContextProvider {
                     "test".into(),
                     "-v".into(),
                     "-run".into(),
-                    format!(
-                        "\\^{}\\$/\\^{}\\$",
+                    quote_arg(&format!(
+                        "^{}$/^{}$",
                         VariableName::Symbol.template_value(),
                         GO_TABLE_TEST_CASE_NAME_TASK_VARIABLE.template_value(),
-                    ),
+                    )),
                 ],
                 cwd: package_cwd.clone(),
                 tags: vec!["go-table-test-case".to_owned()],
@@ -605,7 +605,7 @@ impl ContextProvider for GoContextProvider {
                 args: vec![
                     "test".into(),
                     "-run".into(),
-                    format!("\\^{}\\$", VariableName::Symbol.template_value(),),
+                    quote_arg(&format!("^{}$", VariableName::Symbol.template_value(),)),
                 ],
                 tags: vec!["go-test".to_owned()],
                 cwd: package_cwd.clone(),
@@ -621,7 +621,7 @@ impl ContextProvider for GoContextProvider {
                 args: vec![
                     "test".into(),
                     "-run".into(),
-                    format!("\\^{}\\$", VariableName::Symbol.template_value(),),
+                    quote_arg(&format!("^{}$", VariableName::Symbol.template_value(),)),
                 ],
                 tags: vec!["go-example".to_owned()],
                 cwd: package_cwd.clone(),
@@ -653,11 +653,11 @@ impl ContextProvider for GoContextProvider {
                     "test".into(),
                     "-v".into(),
                     "-run".into(),
-                    format!(
-                        "'^{}$/^{}$'",
+                    quote_arg(&format!(
+                        "^{}$/^{}$",
                         VariableName::Symbol.template_value(),
                         GO_SUBTEST_NAME_TASK_VARIABLE.template_value(),
-                    ),
+                    )),
                 ],
                 cwd: package_cwd.clone(),
                 tags: vec!["go-subtest".to_owned()],
@@ -675,7 +675,7 @@ impl ContextProvider for GoContextProvider {
                     "-benchmem".into(),
                     "-run='^$'".into(),
                     "-bench".into(),
-                    format!("\\^{}\\$", VariableName::Symbol.template_value()),
+                    quote_arg(&format!("^{}$", VariableName::Symbol.template_value())),
                 ],
                 cwd: package_cwd.clone(),
                 tags: vec!["go-benchmark".to_owned()],
@@ -692,7 +692,7 @@ impl ContextProvider for GoContextProvider {
                     "test".into(),
                     "-fuzz=Fuzz".into(),
                     "-run".into(),
-                    format!("\\^{}\\$", VariableName::Symbol.template_value(),),
+                    quote_arg(&format!("^{}$", VariableName::Symbol.template_value())),
                 ],
                 tags: vec!["go-fuzz".to_owned()],
                 cwd: package_cwd.clone(),

--- a/crates/project/src/debugger/locators/go.rs
+++ b/crates/project/src/debugger/locators/go.rs
@@ -367,7 +367,7 @@ mod tests {
                 "-tags".to_string(),
                 "integration,unit".to_string(),
                 "-run".to_string(),
-                "Foo".to_string(),
+                "'^TestFoo$/^subtest_for_Konstantin'\\''s_case$'".to_string(),
                 ".".to_string(),
             ],
             ..Default::default()
@@ -388,7 +388,7 @@ mod tests {
                 build_flags: vec!["-tags".to_string(), "integration,unit".to_string(),],
                 args: vec![
                     "-test.run".to_string(),
-                    "Foo".to_string(),
+                    "^TestFoo$/^subtest_for_Konstantin's_case$".to_string(),
                     "-test.v".to_string()
                 ],
                 env: HashMap::default(),

--- a/crates/project/src/debugger/locators/go.rs
+++ b/crates/project/src/debugger/locators/go.rs
@@ -4,7 +4,7 @@ use collections::HashMap;
 use dap::{DapLocator, DebugRequest, adapters::DebugAdapterName};
 use gpui::SharedString;
 use serde::{Deserialize, Serialize};
-use task::{DebugScenario, SpawnInTerminal, TaskTemplate};
+use task::{DebugScenario, SpawnInTerminal, TaskTemplate, unquote_arg};
 
 pub(crate) struct GoLocator;
 
@@ -98,6 +98,10 @@ impl DapLocator for GoLocator {
         if build_config.command != "go" {
             return None;
         }
+
+        // Given a "test" or "run" Go command, parse its arguments and build a corresponding
+        // DAP command to be sent to Delve.
+
         let go_action = build_config.args.first()?;
 
         match go_action.as_str() {
@@ -114,29 +118,9 @@ impl DapLocator for GoLocator {
 
                 for arg in build_config.args.iter().skip(1) {
                     if all_args_are_test || next_arg_is_test {
-                        // HACK: tasks assume that they are run in a shell context,
-                        // so the -run regex has escaped specials. Delve correctly
-                        // handles escaping, so we undo that here.
-                        if let Some((left, right)) = arg.split_once("/")
-                            && left.starts_with("\\^")
-                            && left.ends_with("\\$")
-                            && right.starts_with("\\^")
-                            && right.ends_with("\\$")
-                        {
-                            let mut left = left[1..left.len() - 2].to_string();
-                            left.push('$');
-
-                            let mut right = right[1..right.len() - 2].to_string();
-                            right.push('$');
-
-                            args.push(format!("{left}/{right}"));
-                        } else if arg.starts_with("\\^") && arg.ends_with("\\$") {
-                            let mut arg = arg[1..arg.len() - 2].to_string();
-                            arg.push('$');
-                            args.push(arg);
-                        } else {
-                            args.push(arg.clone());
-                        }
+                        // Test name regexes were quoted to run in a shell context.
+                        // Let's unquote them using the reverse algorithm
+                        args.push(unquote_arg(arg));
                         next_arg_is_test = false;
                     } else if next_arg_is_build {
                         build_flags.push(arg.clone());

--- a/crates/task/src/task.rs
+++ b/crates/task/src/task.rs
@@ -22,8 +22,8 @@ pub use debug_format::{
     Request, TcpArgumentsTemplate, ZedDebugConfig,
 };
 pub use task_template::{
-    DebugArgsRequest, HideStrategy, RevealStrategy, TaskTemplate, TaskTemplates,
-    substitute_variables_in_map, substitute_variables_in_str,
+    DebugArgsRequest, HideStrategy, RevealStrategy, TaskTemplate, TaskTemplates, quote_arg,
+    substitute_variables_in_map, substitute_variables_in_str, unquote_arg,
 };
 pub use util::shell::{Shell, ShellKind};
 pub use util::shell_builder::ShellBuilder;

--- a/crates/task/src/task_template.rs
+++ b/crates/task/src/task_template.rs
@@ -428,6 +428,7 @@ fn substitute_all_template_variables_in_map(
     Some(new_map)
 }
 
+// Finish the old single-quoted sequence, add "\'", start a new single-quoted sequence
 const SINGLE_QUOTE_QUOTED_IN_SINGLE_QUOTED_STRING: &str = "'\\''";
 
 /// Quotes an argument (e.g. a test name) for use in a shell command.

--- a/crates/task/src/task_template.rs
+++ b/crates/task/src/task_template.rs
@@ -27,6 +27,8 @@ pub struct TaskTemplate {
     /// Executable command to spawn.
     pub command: String,
     /// Arguments to the command.
+    /// If they contain shell-unsafe characters ('$' etc), they should be escaped.
+    /// See `quote_arg` and unquote_arg`.
     #[serde(default)]
     pub args: Vec<String>,
     /// Env overrides for the command, will be appended to the terminal's environment from the settings.
@@ -424,6 +426,36 @@ fn substitute_all_template_variables_in_map(
         new_map.insert(new_key, new_value);
     }
     Some(new_map)
+}
+
+const SINGLE_QUOTE_QUOTED_IN_SINGLE_QUOTED_STRING: &str = "'\\''";
+
+/// Quotes an argument (e.g. a test name) for use in a shell command.
+/// Using the single-quote technique described in https://stackoverflow.com/a/20053121:
+/// `It's a "string"` => `'It'\''s a "string"'`
+pub fn quote_arg(name: &str) -> String {
+    let mut quoted = "'".to_string();
+    for c in name.chars() {
+        if c == '\'' {
+            quoted.push_str(SINGLE_QUOTE_QUOTED_IN_SINGLE_QUOTED_STRING);
+        } else {
+            quoted.push(c);
+        }
+    }
+    quoted.push('\'');
+    quoted
+}
+
+/// Unquotes an argument previously quoted via `quote_arg`.
+pub fn unquote_arg(name: &str) -> String {
+    if name.starts_with('\'') && name.ends_with('\'') {
+        return name[1..name.len() - 1].replace(SINGLE_QUOTE_QUOTED_IN_SINGLE_QUOTED_STRING, "'");
+    }
+    // If this condition above not true, it's suspicious, since this function should be called only
+    // on strings that are known to be quoted.
+    // However, it should be safe to fall back to the original string (the result of this function
+    // is supposed to be "unsafe" for raw shell usage anyway).
+    name.to_string()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/43847

The problem is the quote fix https://github.com/zed-industries/zed/pull/42734 was:
- inconsistent with the rest of the quoting code
- out of sync with the unquoting code added in https://github.com/zed-industries/zed/pull/32221

Release Notes:
- use consistent quoting for test name regexes in Go commands
- ensure the quoting is correctly reverted when generating Delve DAP commands