### PR TITLE
gpui: Further fix extraction of font runs from text runs

### DIFF
--- a/crates/gpui/src/text_system.rs
+++ b/crates/gpui/src/text_system.rs
@@ -550,7 +550,6 @@ impl WindowTextSystem {
         force_width: Option<Pixels>,
     ) -> Arc<LineLayout> {
         let mut last_run = None::<&TextRun>;
-        let mut last_font: Option<FontId> = None;
         let mut font_runs = self.font_runs_pool.lock().pop().unwrap_or_default();
         font_runs.clear();
 
@@ -568,14 +567,13 @@ impl WindowTextSystem {
                 true
             };
 
+            let font_id = self.resolve_font(&run.font);
             if let Some(font_run) = font_runs.last_mut()
-                && Some(font_run.font_id) == last_font
+                && font_id == font_run.font_id
                 && !decoration_changed
             {
                 font_run.len += run.len;
             } else {
-                let font_id = self.resolve_font(&run.font);
-                last_font = Some(font_id);
                 font_runs.push(FontRun {
                     len: run.len,
                     font_id,


### PR DESCRIPTION
After #39928, if a font's weight changes between text runs without other decoration changing, the earlier weight continues to be used for the subsequent run(s).

PR #40840 fixes this in shape_text, but similar code exists also in layout_text. The latter is used for text in the editor view itself, so the issue continues to appear when using a highlighting theme with varied font weights.

Fix the issue by applying the same fix in layout_text.

Closes #42297

Release Notes:

- Fixed incorrect font weights in editor view when using a highlighting theme with varying font weights
