### PR TITLE
terminal_view: Fix selection columns not being clamped correctly for rendering

### DIFF
--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -1275,7 +1275,7 @@ impl Element for TerminalElement {
                     }
 
                     for (relative_highlighted_range, color) in
-                        layout.relative_highlighted_ranges.iter()
+&                        layout.relative_highlighted_ranges
                     {
                         if let Some((start_y, highlighted_range_lines)) =
                             to_highlighted_range_lines(relative_highlighted_range, layout, origin)
@@ -1542,11 +1542,13 @@ fn to_highlighted_range_lines(
     }
 
     let clamped_start_line = unclamped_start.line.0.max(0) as usize;
+
     let clamped_end_line = unclamped_end
         .line
         .0
         .min(layout.dimensions.num_lines() as i32) as usize;
-    //Convert the start of the range to pixels
+
+    // Convert the start of the range to pixels
     let start_y = origin.y + clamped_start_line as f32 * layout.dimensions.line_height;
 
     // Step 3. Expand ranges that cross lines into a collection of single-line ranges.
@@ -1556,10 +1558,11 @@ fn to_highlighted_range_lines(
         let mut line_start = 0;
         let mut line_end = layout.dimensions.columns();
 
-        if line == clamped_start_line {
+        if line == clamped_start_line && unclamped_start.line.0 >= 0 {
             line_start = unclamped_start.column.0;
         }
-        if line == clamped_end_line {
+        if line == clamped_end_line && unclamped_end.line.0 <= layout.dimensions.num_lines() as i32
+        {
             line_end = unclamped_end.column.0 + 1; // +1 for inclusive
         }
 


### PR DESCRIPTION

Before:

https://github.com/user-attachments/assets/3be4d451-81a6-430b-bc36-d91f4cd44c9b

After:

https://github.com/user-attachments/assets/6d64bf0c-5bd1-45be-b9d8-20118e5a25e6



Release Notes:

- Fixed rendered selections in the terminal view not being clamped to the line start/ends correctly
