### PR TITLE
util: Move `PathMatcher` over to `RelPath`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15116,6 +15116,7 @@ dependencies = [
  "editor",
  "futures 0.3.31",
  "gpui",
+ "itertools 0.14.0",
  "language",
  "lsp",
  "menu",

--- a/crates/agent/src/tools/find_path_tool.rs
+++ b/crates/agent/src/tools/find_path_tool.rs
@@ -177,7 +177,7 @@ fn search_paths(glob: &str, project: Entity<Project>, cx: &mut App) -> Task<Resu
         let mut results = Vec::new();
         for snapshot in snapshots {
             for entry in snapshot.entries(false, 0) {
-                if path_matcher.is_match(snapshot.root_name().join(&entry.path).as_std_path()) {
+                if path_matcher.is_match(&snapshot.root_name().join(&entry.path)) {
                     results.push(snapshot.absolutize(&entry.path));
                 }
             }

--- a/crates/agent/src/tools/grep_tool.rs
+++ b/crates/agent/src/tools/grep_tool.rs
@@ -145,8 +145,7 @@ impl AgentTool for GrepTool {
             let exclude_patterns = global_settings
                 .file_scan_exclusions
                 .sources()
-                .iter()
-                .chain(global_settings.private_files.sources().iter());
+                .chain(global_settings.private_files.sources());
 
             match PathMatcher::new(exclude_patterns, path_style) {
                 Ok(matcher) => matcher,

--- a/crates/search/Cargo.toml
+++ b/crates/search/Cargo.toml
@@ -42,6 +42,7 @@ util.workspace = true
 util_macros.workspace = true
 workspace.workspace = true
 zed_actions.workspace = true
+itertools.workspace = true
 
 [dev-dependencies]
 client = { workspace = true, features = ["test-support"] }

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -21,6 +21,7 @@ use gpui::{
     Global, Hsla, InteractiveElement, IntoElement, KeyContext, ParentElement, Point, Render,
     SharedString, Styled, Subscription, Task, UpdateGlobal, WeakEntity, Window, actions, div,
 };
+use itertools::Itertools;
 use language::{Buffer, Language};
 use menu::Confirm;
 use project::{

--- a/crates/util/src/rel_path.rs
+++ b/crates/util/src/rel_path.rs
@@ -27,7 +27,7 @@ pub struct RelPath(str);
 /// relative and normalized.
 ///
 /// This type is to [`RelPath`] as [`std::path::PathBuf`] is to [`std::path::Path`]
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct RelPathBuf(String);
 
 impl RelPath {
@@ -228,7 +228,8 @@ impl RelPath {
     pub fn display(&self, style: PathStyle) -> Cow<'_, str> {
         match style {
             PathStyle::Posix => Cow::Borrowed(&self.0),
-            PathStyle::Windows => Cow::Owned(self.0.replace('/', "\\")),
+            PathStyle::Windows if self.0.contains('/') => Cow::Owned(self.0.replace('/', "\\")),
+            PathStyle::Windows => Cow::Borrowed(&self.0),
         }
     }
 
@@ -338,6 +339,12 @@ impl Into<Arc<RelPath>> for RelPathBuf {
 impl AsRef<RelPath> for RelPathBuf {
     fn as_ref(&self) -> &RelPath {
         self.as_rel_path()
+    }
+}
+
+impl AsRef<RelPath> for RelPath {
+    fn as_ref(&self) -> &RelPath {
+        self
     }
 }
 

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -5509,7 +5509,7 @@ impl TryFrom<(&CharBag, &PathMatcher, proto::Entry)> for Entry {
         let path =
             RelPath::from_proto(&entry.path).context("invalid relative path in proto message")?;
         let char_bag = char_bag_for_path(*root_char_bag, &path);
-        let is_always_included = always_included.is_match(path.as_std_path());
+        let is_always_included = always_included.is_match(&path);
         Ok(Entry {
             id: ProjectEntryId::from_proto(entry.id),
             kind,

--- a/crates/worktree/src/worktree_settings.rs
+++ b/crates/worktree/src/worktree_settings.rs
@@ -25,25 +25,25 @@ pub struct WorktreeSettings {
 impl WorktreeSettings {
     pub fn is_path_private(&self, path: &RelPath) -> bool {
         path.ancestors()
-            .any(|ancestor| self.private_files.is_match(ancestor.as_std_path()))
+            .any(|ancestor| self.private_files.is_match(ancestor))
     }
 
     pub fn is_path_excluded(&self, path: &RelPath) -> bool {
         path.ancestors()
-            .any(|ancestor| self.file_scan_exclusions.is_match(ancestor.as_std_path()))
+            .any(|ancestor| self.file_scan_exclusions.is_match(ancestor))
     }
 
     pub fn is_path_always_included(&self, path: &RelPath, is_dir: bool) -> bool {
         if is_dir {
-            self.parent_dir_scan_inclusions.is_match(path.as_std_path())
+            self.parent_dir_scan_inclusions.is_match(path)
         } else {
-            self.file_scan_inclusions.is_match(path.as_std_path())
+            self.file_scan_inclusions.is_match(path)
         }
     }
 
     pub fn is_path_hidden(&self, path: &RelPath) -> bool {
         path.ancestors()
-            .any(|ancestor| self.hidden_files.is_match(ancestor.as_std_path()))
+            .any(|ancestor| self.hidden_files.is_match(ancestor))
     }
 }
 

--- a/crates/zeta/src/retrieval_search.rs
+++ b/crates/zeta/src/retrieval_search.rs
@@ -87,8 +87,7 @@ pub async fn run_retrieval_searches(
         let exclude_patterns = global_settings
             .file_scan_exclusions
             .sources()
-            .iter()
-            .chain(global_settings.private_files.sources().iter());
+            .chain(global_settings.private_files.sources());
         let path_style = project.path_style(cx);
         anyhow::Ok((PathMatcher::new(exclude_patterns, path_style)?, path_style))
     })??;


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/40688 Closes https://github.com/zed-industries/zed/issues/41242

Release Notes:

- Fixed project search not working correctly on remotes where the host and remote path styles differ
