### PR TITLE
rust: Nicer snippet completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9039,6 +9039,7 @@ dependencies = [
  "serde_json",
  "serde_json_lenient",
  "settings",
+ "smallvec",
  "smol",
  "snippet",
  "task",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9040,6 +9040,7 @@ dependencies = [
  "serde_json_lenient",
  "settings",
  "smol",
+ "snippet",
  "task",
  "terminal",
  "text",

--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -835,36 +835,38 @@ impl CompletionsMenu {
                                     FontWeight::BOLD.into(),
                                 )
                             }),
-                            styled_runs_for_code_label(&completion.label, &style.syntax).map(
-                                |(range, mut highlight)| {
-                                    // Ignore font weight for syntax highlighting, as we'll use it
-                                    // for fuzzy matches.
-                                    highlight.font_weight = None;
-                                    if completion
-                                        .source
-                                        .lsp_completion(false)
-                                        .and_then(|lsp_completion| {
-                                            match (lsp_completion.deprecated, &lsp_completion.tags)
-                                            {
-                                                (Some(true), _) => Some(true),
-                                                (_, Some(tags)) => Some(
-                                                    tags.contains(&CompletionItemTag::DEPRECATED),
-                                                ),
-                                                _ => None,
+                            styled_runs_for_code_label(
+                                &completion.label,
+                                &style.syntax,
+                                &style.local_player,
+                            )
+                            .map(|(range, mut highlight)| {
+                                // Ignore font weight for syntax highlighting, as we'll use it
+                                // for fuzzy matches.
+                                highlight.font_weight = None;
+                                if completion
+                                    .source
+                                    .lsp_completion(false)
+                                    .and_then(|lsp_completion| {
+                                        match (lsp_completion.deprecated, &lsp_completion.tags) {
+                                            (Some(true), _) => Some(true),
+                                            (_, Some(tags)) => {
+                                                Some(tags.contains(&CompletionItemTag::DEPRECATED))
                                             }
-                                        })
-                                        .unwrap_or(false)
-                                    {
-                                        highlight.strikethrough = Some(StrikethroughStyle {
-                                            thickness: 1.0.into(),
-                                            ..Default::default()
-                                        });
-                                        highlight.color = Some(cx.theme().colors().text_muted);
-                                    }
+                                            _ => None,
+                                        }
+                                    })
+                                    .unwrap_or(false)
+                                {
+                                    highlight.strikethrough = Some(StrikethroughStyle {
+                                        thickness: 1.0.into(),
+                                        ..Default::default()
+                                    });
+                                    highlight.color = Some(cx.theme().colors().text_muted);
+                                }
 
-                                    (range, highlight)
-                                },
-                            ),
+                                (range, highlight)
+                            }),
                         );
 
                         let completion_label = StyledText::new(completion.label.text.clone())

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -24908,6 +24908,7 @@ pub fn diagnostic_style(severity: lsp::DiagnosticSeverity, colors: &StatusColors
 pub fn styled_runs_for_code_label<'a>(
     label: &'a CodeLabel,
     syntax_theme: &'a theme::SyntaxTheme,
+    local_player: &'a theme::PlayerColor,
 ) -> impl 'a + Iterator<Item = (Range<usize>, HighlightStyle)> {
     let fade_out = HighlightStyle {
         fade_out: Some(0.35),
@@ -24920,7 +24921,17 @@ pub fn styled_runs_for_code_label<'a>(
         .iter()
         .enumerate()
         .flat_map(move |(ix, (range, highlight_id))| {
-            let style = if let Some(style) = highlight_id.style(syntax_theme) {
+            let style = if *highlight_id == language::HighlightId::TABSTOP_INSERT_ID {
+                HighlightStyle {
+                    color: Some(local_player.cursor),
+                    ..Default::default()
+                }
+            } else if *highlight_id == language::HighlightId::TABSTOP_REPLACE_ID {
+                HighlightStyle {
+                    background_color: Some(local_player.selection),
+                    ..Default::default()
+                }
+            } else if let Some(style) = highlight_id.style(syntax_theme) {
                 style
             } else {
                 return Default::default();

--- a/crates/language/src/highlight_map.rs
+++ b/crates/language/src/highlight_map.rs
@@ -51,6 +51,9 @@ impl HighlightMap {
 }
 
 impl HighlightId {
+    pub const TABSTOP_INSERT_ID: HighlightId = HighlightId(u32::MAX - 1);
+    pub const TABSTOP_REPLACE_ID: HighlightId = HighlightId(u32::MAX - 2);
+
     pub(crate) fn is_default(&self) -> bool {
         *self == DEFAULT_SYNTAX_HIGHLIGHT_ID
     }

--- a/crates/languages/Cargo.toml
+++ b/crates/languages/Cargo.toml
@@ -44,8 +44,8 @@ collections.workspace = true
 futures.workspace = true
 gpui.workspace = true
 http_client.workspace = true
-json_schema_store.workspace = true
 itertools.workspace = true
+json_schema_store.workspace = true
 language.workspace = true
 log.workspace = true
 lsp.workspace = true
@@ -67,7 +67,7 @@ serde_json.workspace = true
 serde_json_lenient.workspace = true
 settings.workspace = true
 smol.workspace = true
-url.workspace = true
+snippet.workspace = true
 task.workspace = true
 terminal.workspace = true
 theme.workspace = true
@@ -90,6 +90,7 @@ tree-sitter-regex = { workspace = true, optional = true }
 tree-sitter-rust = { workspace = true, optional = true }
 tree-sitter-typescript = { workspace = true, optional = true }
 tree-sitter-yaml = { workspace = true, optional = true }
+url.workspace = true
 util.workspace = true
 
 [dev-dependencies]

--- a/crates/languages/Cargo.toml
+++ b/crates/languages/Cargo.toml
@@ -66,6 +66,7 @@ serde.workspace = true
 serde_json.workspace = true
 serde_json_lenient.workspace = true
 settings.workspace = true
+smallvec.workspace = true
 smol.workspace = true
 snippet.workspace = true
 task.workspace = true

--- a/crates/languages/src/rust.rs
+++ b/crates/languages/src/rust.rs
@@ -1461,6 +1461,63 @@ mod tests {
                 vec![(0..11, HighlightId(3)), (13..19, HighlightId(0))],
             ))
         );
+
+        // Snippet with insert tabstop (empty placeholder)
+        assert_eq!(
+            adapter
+                .label_for_completion(
+                    &lsp::CompletionItem {
+                        kind: Some(lsp::CompletionItemKind::SNIPPET),
+                        label: "println!".to_string(),
+                        insert_text_format: Some(lsp::InsertTextFormat::SNIPPET),
+                        text_edit: Some(lsp::CompletionTextEdit::Edit(lsp::TextEdit {
+                            range: lsp::Range::default(),
+                            new_text: "println!(\"$1\", $2)$0".to_string(),
+                        })),
+                        ..Default::default()
+                    },
+                    &language,
+                )
+                .await,
+            Some(CodeLabel::new(
+                "println!(\"…\", …)".to_string(),
+                0..8,
+                vec![
+                    (10..13, HighlightId::TABSTOP_INSERT_ID),
+                    (16..19, HighlightId::TABSTOP_INSERT_ID),
+                    (0..7, HighlightId(2)),
+                    (7..8, HighlightId(2)),
+                ],
+            ))
+        );
+
+        // Snippet with replace tabstop (placeholder with default text)
+        assert_eq!(
+            adapter
+                .label_for_completion(
+                    &lsp::CompletionItem {
+                        kind: Some(lsp::CompletionItemKind::SNIPPET),
+                        label: "vec!".to_string(),
+                        insert_text_format: Some(lsp::InsertTextFormat::SNIPPET),
+                        text_edit: Some(lsp::CompletionTextEdit::Edit(lsp::TextEdit {
+                            range: lsp::Range::default(),
+                            new_text: "vec![${1:elem}]$0".to_string(),
+                        })),
+                        ..Default::default()
+                    },
+                    &language,
+                )
+                .await,
+            Some(CodeLabel::new(
+                "vec![elem]".to_string(),
+                0..4,
+                vec![
+                    (5..9, HighlightId::TABSTOP_REPLACE_ID),
+                    (0..3, HighlightId(2)),
+                    (3..4, HighlightId(2)),
+                ],
+            ))
+        );
     }
 
     #[gpui::test]

--- a/crates/languages/src/rust.rs
+++ b/crates/languages/src/rust.rs
@@ -1518,6 +1518,64 @@ mod tests {
                 ],
             ))
         );
+
+        // Snippet with tabstop appearing more than once
+        assert_eq!(
+            adapter
+                .label_for_completion(
+                    &lsp::CompletionItem {
+                        kind: Some(lsp::CompletionItemKind::SNIPPET),
+                        label: "if let".to_string(),
+                        insert_text_format: Some(lsp::InsertTextFormat::SNIPPET),
+                        text_edit: Some(lsp::CompletionTextEdit::Edit(lsp::TextEdit {
+                            range: lsp::Range::default(),
+                            new_text: "if let ${1:pat} = $1 {\n    $0\n}".to_string(),
+                        })),
+                        ..Default::default()
+                    },
+                    &language,
+                )
+                .await,
+            Some(CodeLabel::new(
+                "if let pat = … {\n    \n}".to_string(),
+                0..6,
+                vec![
+                    (7..10, HighlightId::TABSTOP_REPLACE_ID),
+                    (13..16, HighlightId::TABSTOP_INSERT_ID),
+                    (0..2, HighlightId(1)),
+                    (3..6, HighlightId(1)),
+                ],
+            ))
+        );
+
+        // Snippet with tabstops not in left-to-right order
+        assert_eq!(
+            adapter
+                .label_for_completion(
+                    &lsp::CompletionItem {
+                        kind: Some(lsp::CompletionItemKind::SNIPPET),
+                        label: "for".to_string(),
+                        insert_text_format: Some(lsp::InsertTextFormat::SNIPPET),
+                        text_edit: Some(lsp::CompletionTextEdit::Edit(lsp::TextEdit {
+                            range: lsp::Range::default(),
+                            new_text: "for ${2:item} in ${1:iter} {\n    $0\n}".to_string(),
+                        })),
+                        ..Default::default()
+                    },
+                    &language,
+                )
+                .await,
+            Some(CodeLabel::new(
+                "for item in iter {\n    \n}".to_string(),
+                0..3,
+                vec![
+                    (4..8, HighlightId::TABSTOP_REPLACE_ID),
+                    (12..16, HighlightId::TABSTOP_REPLACE_ID),
+                    (0..3, HighlightId(1)),
+                    (9..11, HighlightId(1)),
+                ],
+            ))
+        );
     }
 
     #[gpui::test]

--- a/crates/project_symbols/src/project_symbols.rs
+++ b/crates/project_symbols/src/project_symbols.rs
@@ -224,7 +224,9 @@ impl PickerDelegate for ProjectSymbolsDelegate {
         let path_style = self.project.read(cx).path_style(cx);
         let string_match = &self.matches.get(ix)?;
         let symbol = &self.symbols.get(string_match.candidate_id)?;
-        let syntax_runs = styled_runs_for_code_label(&symbol.label, cx.theme().syntax());
+        let theme = cx.theme();
+        let local_player = theme.players().local();
+        let syntax_runs = styled_runs_for_code_label(&symbol.label, theme.syntax(), &local_player);
 
         let path = match &symbol.path {
             SymbolLocation::InProject(project_path) => {


### PR DESCRIPTION
At some point, rust-analyzer started including the snippet expression for some completions in the description field, but that can look like a bug:

<img width="1570" height="578" alt="CleanShot 2025-11-27 at 20 39 49@2x" src="https://github.com/user-attachments/assets/5a87c9fe-c0a8-472f-8d83-3bc9e9e00bbc"></img>


In these cases, we will now inline the tab stops as an ellipsis character:

<img width="1544" height="428" alt="CleanShot 2025-12-01 at 10 01 18@2x" src="https://github.com/user-attachments/assets/4c550891-4545-47cd-a295-a5eb07e78e92"></img>

You may also notice that we now syntax highlight the pattern closer to what it looks like after accepted.

Alternatively, when the tab stop isn't just one position, it gets highlighted as a selection since that's what it would do when accepted:

<img width="1558" height="314" alt="CleanShot 2025-12-01 at 10 04 37@2x" src="https://github.com/user-attachments/assets/ce630ab2-da22-4072-a996-7b71ba21637d" />


Release Notes:

- rust: Display completion tab stops inline rather than as a raw LSP snippet expression
