### PR TITLE
Fix attach to process in Go debugger

### DIFF
--- a/crates/dap_adapters/src/go.rs
+++ b/crates/dap_adapters/src/go.rs
@@ -366,7 +366,7 @@ impl DebugAdapter for GoDebugAdapter {
             dap::DebugRequest::Attach(attach_config) => {
                 json!({
                     "request": "attach",
-                    "mode": "debug",
+                    "mode": "local",
                     "processId": attach_config.process_id,
                 })
             }


### PR DESCRIPTION
Release Notes:

- Fixed the behavior of the attach to process feature for the Golang debugger.

**Step to reprorduce:**
1. Build and run golang binary
2. In Zed open debugger
3. Go to Attach tab
4. Select the binary you just built from the list
**Actual result:** 
```
Tried to launch debugger with: {
  "request": "attach",
  "mode": "debug",
  "processId": 74702,
  "stopOnEntry": false,
  "cwd": "/path/to/the/current/working/directory"
}
error: Failed to attach: invalid debug configuration - unsupported 'mode' attribute "debug" 
```

**Expected result:** The debugger can attach to the process.


According to the [Delve documentation](https://github.com/go-delve/delve/tree/master/Documentation/api/dap#launch-and-attach-configurations) `attach` request supports `local` and `remote` values only
