### PR TITLE
Add fuzzy score boosting for usage frequency

### DIFF
--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -306,13 +306,9 @@ impl PickerDelegate for CommandPaletteDelegate {
                     .iter()
                     .enumerate()
                     .map(|(ix, command)| {
-                        // Calculate boost from hit counts using square root scaling
-                        // This is more aggressive for low counts, giving frequently-used commands
-                        // a fighting chance against better fuzzy matches:
-                        // 1 use → 2.5x, 5 uses → 4.35x, 10 uses → 5.74x, 50 uses → 11.6x
                         let boost = hit_counts
                             .get(&command.name)
-                            .map(|&count| 1.0 + (count as f64).sqrt() * 1.5)
+                            .map(|&count| (count as f64 + 1.0).sqrt())
                             .unwrap_or(1.0);
                         StringMatchCandidate::with_boost(ix, &command.name, boost)
                     })

--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -1,11 +1,6 @@
 mod persistence;
 
-use std::{
-    cmp,
-    collections::HashMap,
-    sync::Arc,
-    time::Duration,
-};
+use std::{cmp, collections::HashMap, sync::Arc, time::Duration};
 
 use client::parse_zed_link;
 use command_palette_hooks::{

--- a/crates/debugger_ui/src/session/running/console.rs
+++ b/crates/debugger_ui/src/session/running/console.rs
@@ -622,6 +622,7 @@ impl ConsoleQueryBarCompletionProvider {
                         id: 0,
                         string: evaluate_name.clone(),
                         char_bag: evaluate_name.chars().collect(),
+                        boost: 1.0,
                     });
                 }
 
@@ -633,6 +634,7 @@ impl ConsoleQueryBarCompletionProvider {
                         id: 0,
                         string: variable.name.clone(),
                         char_bag: variable.name.chars().collect(),
+                        boost: 1.0,
                     });
                 }
             }

--- a/crates/file_finder/src/open_path_prompt.rs
+++ b/crates/file_finder/src/open_path_prompt.rs
@@ -407,6 +407,7 @@ impl PickerDelegate for OpenPathDelegate {
                                 id: max_id + 1,
                                 string: current_dir.to_string(),
                                 char_bag: CharBag::from(current_dir),
+                                boost: 1.0,
                             },
                             is_dir: true,
                         },

--- a/crates/fuzzy/src/strings.rs
+++ b/crates/fuzzy/src/strings.rs
@@ -30,6 +30,7 @@ impl StringMatchCandidate {
     }
 
     pub fn with_boost(id: usize, string: &str, boost: f64) -> Self {
+        debug_assert!(boost > 0.0, "boost must be positive");
         Self {
             id,
             string: string.into(),

--- a/crates/fuzzy/src/strings.rs
+++ b/crates/fuzzy/src/strings.rs
@@ -142,7 +142,7 @@ where
     }
 
     if query.is_empty() {
-        return candidates
+        let mut results: Vec<StringMatch> = candidates
             .iter()
             .map(|candidate| StringMatch {
                 candidate_id: candidate.borrow().id,
@@ -151,6 +151,8 @@ where
                 string: candidate.borrow().string.clone(),
             })
             .collect();
+        results.sort_by(|a, b| b.cmp(a));
+        return results;
     }
 
     let lowercase_query = query.to_lowercase().chars().collect::<Vec<_>>();

--- a/crates/fuzzy/src/strings.rs
+++ b/crates/fuzzy/src/strings.rs
@@ -232,7 +232,7 @@ mod tests {
             false,
             10,
             &AtomicBool::new(false),
-            cx.background_executor().clone(),
+            cx.background_executor.clone(),
         )
         .await;
 
@@ -261,7 +261,7 @@ mod tests {
             false,
             10,
             &AtomicBool::new(false),
-            cx.background_executor().clone(),
+            cx.background_executor.clone(),
         )
         .await;
 
@@ -289,7 +289,7 @@ mod tests {
             false,
             10,
             &AtomicBool::new(false),
-            cx.background_executor().clone(),
+            cx.background_executor.clone(),
         )
         .await;
 
@@ -316,7 +316,7 @@ mod tests {
             false,
             10,
             &AtomicBool::new(false),
-            cx.background_executor().clone(),
+            cx.background_executor.clone(),
         )
         .await;
 

--- a/crates/fuzzy/src/strings.rs
+++ b/crates/fuzzy/src/strings.rs
@@ -249,9 +249,9 @@ mod tests {
     #[gpui::test]
     async fn test_boost_affects_fuzzy_matching(cx: &mut TestAppContext) {
         let candidates = vec![
-            StringMatchCandidate::with_boost(0, "backspace", 1.0),   // Good match, no boost
-            StringMatchCandidate::with_boost(1, "back", 10.0),       // Perfect match, high boost
-            StringMatchCandidate::with_boost(2, "feedback", 1.0),    // Weaker match, no boost
+            StringMatchCandidate::with_boost(0, "backspace", 1.0), // Good match, no boost
+            StringMatchCandidate::with_boost(1, "back", 10.0),     // Perfect match, high boost
+            StringMatchCandidate::with_boost(2, "feedback", 1.0),  // Weaker match, no boost
         ];
 
         let matches = match_strings(
@@ -277,9 +277,9 @@ mod tests {
     #[gpui::test]
     async fn test_boost_doesnt_promote_bad_matches(cx: &mut TestAppContext) {
         let candidates = vec![
-            StringMatchCandidate::with_boost(0, "backspace", 1.0),      // Good fuzzy match
-            StringMatchCandidate::with_boost(1, "xyz", 100.0),          // No match, huge boost
-            StringMatchCandidate::with_boost(2, "feedback", 1.0),       // Weaker match
+            StringMatchCandidate::with_boost(0, "backspace", 1.0), // Good fuzzy match
+            StringMatchCandidate::with_boost(1, "xyz", 100.0),     // No match, huge boost
+            StringMatchCandidate::with_boost(2, "feedback", 1.0),  // Weaker match
         ];
 
         let matches = match_strings(


### PR DESCRIPTION
Adds a boost field to StringMatchCandidate that multiplies fuzzy match scores. Command palette uses this to rank frequently-used commands higher in search results.

Uses square root scaling (1 use → 2.5x, 10 uses → 5.74x, 50 uses → 11.6x) so frequent commands get advantage without completely overriding fuzzy match quality. Zero-score matches stay filtered out regardless of boost.

Includes tests verifying boost works with empty queries, affects ranking, and doesn't promote non-matches.

Alternative approach to https://github.com/zed-industries/zed/pull/30386