### PR TITLE
Docs README.md small fixes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -72,9 +72,9 @@ Templates are just functions that modify the source of the docs pages (usually w
 
 ## Postprocessor
 
-A postprocessor is implemented as a sub-command of `docs_preprocessor` that wraps the builtin `html` renderer and applies post-processing to the `html` files, to add support for page-specific title and meta description values.
+A postprocessor is implemented as a sub-command of `docs_preprocessor` that wraps the built-in `html` renderer and applies post-processing to the `html` files, to add support for page-specific title and meta description values.
 
-An example of the syntax can be found in `git.md`, as well as below
+An example of the syntax can be found in `git.md`, as well as below:
 
 ```md
 ---
@@ -85,7 +85,7 @@ description: A page-specific description
 # Editor
 ```
 
-The above will be transformed into (with non-relevant tags removed)
+The above code will be transformed into (with non-relevant tags removed):
 
 ```html
 <head>
@@ -97,7 +97,7 @@ The above will be transformed into (with non-relevant tags removed)
 </body>
 ```
 
-If no front-matter is provided, or If one or both keys aren't provided, the title and description will be set based on the `default-title` and `default-description` keys in `book.toml` respectively.
+If no front matter is provided, or if one or both keys aren't provided, the `title` and `description` will be set based on the `default-title` and `default-description` keys in `book.toml` respectively.
 
 ### Implementation details
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,8 +22,7 @@ cd docs && pnpm dlx prettier@3.5.0 . --write && cd ..
 
 We have a custom mdBook preprocessor for interfacing with our crates (`crates/docs_preprocessor`).
 
-If for some reason you need to bypass the docs preprocessor, you can comment out `[preprocessor.zed_docs_preprocessor]
-` from the `book.toml`.
+If for some reason you need to bypass the docs preprocessor, you can comment out `[preprocessor.zed_docs_preprocessor]` from the `book.toml`.
 
 ## Images and videos
 
@@ -33,7 +32,7 @@ Putting binary assets such as images in the Git repository will bloat the reposi
 
 ## Internal notes:
 
-- We have a Cloudflare router called `docs-proxy` that intercepts requests to `zed.dev/docs` and forwards them to the "docs" in Cloudflare Pages project.
+- We have a Cloudflare router called `docs-proxy` that intercepts requests to `zed.dev/docs` and forwards them to the "docs" Cloudflare Pages project.
 - The CI uploads a new version to the Cloudflare Pages project from `.github/workflows/deploy_docs.yml` on every push to `main`.
 
 ### Table of Contents
@@ -44,7 +43,7 @@ Since all this preprocessor does is generate the static assets, we don't need to
 
 ## Referencing Keybindings and Actions
 
-When referencing keybindings or actions, use the following formats.
+When referencing keybindings or actions, use the following formats:
 
 ### Keybindings
 
@@ -62,7 +61,8 @@ This will render a human-readable version of the action name, e.g., "zed: open s
 
 ### Creating New Templates
 
-Templates are functions that modify the source of the docs pages (usually with a regex match and replace). You can see how the actions and keybindings are templated in `crates/docs_preprocessor/src/main.rs` for reference on how to create new templates.
+Templates are functions that modify the source of the docs pages (usually with a regex match and replace).
+You can see how the actions and keybindings are templated in `crates/docs_preprocessor/src/main.rs` for reference on how to create new templates.
 
 ### References
 
@@ -101,7 +101,8 @@ If no front matter is provided, or if one or both keys aren't provided, the `tit
 
 ### Implementation details
 
-Unfortunately, mdBook does not support post-processing like it does pre-processing, and only supports defining one description to put in the `meta` tag per book rather than per file. So in order to apply post-processing (necessary to modify the HTML `head` tags) the global book description is set to a marker value `#description#` and the HTML renderer is replaced with a sub-command of `docs_preprocessor` that wraps the built-in HTML renderer and applies post-processing to the HTML files, replacing the marker value and the `<title>(.*)</title>` with the contents of the front matter if there is one.
+Unfortunately, mdBook does not support post-processing like it does pre-processing, and only supports defining one description to put in the `meta` tag per book rather than per file.
+So in order to apply post-processing (necessary to modify the HTML `head` tags) the global book description is set to a marker value `#description#` and the HTML renderer is replaced with a sub-command of `docs_preprocessor` that wraps the built-in HTML renderer and applies post-processing to the HTML files, replacing the marker value and the `<title>(.*)</title>` with the contents of the front matter if there is one.
 
 ### Known limitations
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -105,7 +105,7 @@ Unfortunately, mdBook does not support post-processing like it does pre-processi
 
 ### Known limitations
 
-The front matter parsing is extremely simple, which avoids needing to take on an additional dependency, or implement full yaml parsing.
+The front matter parsing is extremely simple, which avoids needing to take on an additional dependency, or implement full YAML parsing.
 
 - Double quotes and multi-line values are not supported, i.e. Keys and values must be entirely on the same line, with no double quotes around the value.
 
@@ -119,7 +119,7 @@ title: Some
 ---
 ```
 
-And neither will:
+neither this:
 
 ```md
 ---
@@ -127,6 +127,5 @@ title: "Some title"
 ---
 ```
 
-- The front matter must be at the top of the file, with only white-space preceding it
-
-- The contents of the title and description will not be html-escaped. They should be simple ascii text with no unicode or emoji characters
+- The front matter must be at the top of the file, with only white-space preceding it.
+- The contents of the title and description will not be html-escaped. They should be simple ascii text with no unicode or emoji characters.

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ cd docs && pnpm dlx prettier@3.5.0 . --write && cd ..
 
 ## Preprocessor
 
-We have a custom mdbook preprocessor for interfacing with our crates (`crates/docs_preprocessor`).
+We have a custom mdBook preprocessor for interfacing with our crates (`crates/docs_preprocessor`).
 
 If for some reason you need to bypass the docs preprocessor, you can comment out `[preprocessor.zed_docs_preprocessor]
 ` from the `book.toml`.
@@ -101,7 +101,7 @@ If no front matter is provided, or if one or both keys aren't provided, the `tit
 
 ### Implementation details
 
-Unfortunately, `mdbook` does not support post-processing like it does pre-processing, and only supports defining one description to put in the meta tag per book rather than per file. So in order to apply post-processing (necessary to modify the html head tags) the global book description is set to a marker value `#description#` and the html renderer is replaced with a sub-command of `docs_preprocessor` that wraps the builtin `html` renderer and applies post-processing to the `html` files, replacing the marker value and the `<title>(.*)</title>` with the contents of the front-matter if there is one.
+Unfortunately, mdBook does not support post-processing like it does pre-processing, and only supports defining one description to put in the meta tag per book rather than per file. So in order to apply post-processing (necessary to modify the html head tags) the global book description is set to a marker value `#description#` and the html renderer is replaced with a sub-command of `docs_preprocessor` that wraps the builtin `html` renderer and applies post-processing to the `html` files, replacing the marker value and the `<title>(.*)</title>` with the contents of the front-matter if there is one.
 
 ### Known limitations
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -72,7 +72,7 @@ Templates are just functions that modify the source of the docs pages (usually w
 
 ## Postprocessor
 
-A postprocessor is implemented as a sub-command of `docs_preprocessor` that wraps the built-in `html` renderer and applies post-processing to the `html` files, to add support for page-specific title and meta description values.
+A postprocessor is implemented as a sub-command of `docs_preprocessor` that wraps the built-in HTML renderer and applies post-processing to the HTML files, to add support for page-specific `title` and `meta` description values.
 
 An example of the syntax can be found in `git.md`, as well as below:
 
@@ -101,11 +101,11 @@ If no front matter is provided, or if one or both keys aren't provided, the `tit
 
 ### Implementation details
 
-Unfortunately, mdBook does not support post-processing like it does pre-processing, and only supports defining one description to put in the meta tag per book rather than per file. So in order to apply post-processing (necessary to modify the html head tags) the global book description is set to a marker value `#description#` and the html renderer is replaced with a sub-command of `docs_preprocessor` that wraps the builtin `html` renderer and applies post-processing to the `html` files, replacing the marker value and the `<title>(.*)</title>` with the contents of the front-matter if there is one.
+Unfortunately, mdBook does not support post-processing like it does pre-processing, and only supports defining one description to put in the `meta` tag per book rather than per file. So in order to apply post-processing (necessary to modify the HTML `head` tags) the global book description is set to a marker value `#description#` and the HTML renderer is replaced with a sub-command of `docs_preprocessor` that wraps the built-in HTML renderer and applies post-processing to the HTML files, replacing the marker value and the `<title>(.*)</title>` with the contents of the front matter if there is one.
 
 ### Known limitations
 
-The front-matter parsing is extremely simple, which avoids needing to take on an additional dependency, or implement full yaml parsing.
+The front matter parsing is extremely simple, which avoids needing to take on an additional dependency, or implement full yaml parsing.
 
 - Double quotes and multi-line values are not supported, i.e. Keys and values must be entirely on the same line, with no double quotes around the value.
 
@@ -127,6 +127,6 @@ title: "Some title"
 ---
 ```
 
-- The front-matter must be at the top of the file, with only white-space preceding it
+- The front matter must be at the top of the file, with only white-space preceding it
 
 - The contents of the title and description will not be html-escaped. They should be simple ascii text with no unicode or emoji characters

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,8 +33,8 @@ Putting binary assets such as images in the Git repository will bloat the reposi
 
 ## Internal notes:
 
-- We have a Cloudflare router called `docs-proxy` that intercepts requests to `zed.dev/docs` and forwards them to the "docs" Cloudflare Pages project.
-- CI uploads a new version to the Pages project from `.github/workflows/deploy_docs.yml` on every push to `main`.
+- We have a Cloudflare router called `docs-proxy` that intercepts requests to `zed.dev/docs` and forwards them to the "docs" in Cloudflare Pages project.
+- The CI uploads a new version to the Cloudflare Pages project from `.github/workflows/deploy_docs.yml` on every push to `main`.
 
 ### Table of Contents
 
@@ -44,17 +44,17 @@ Since all this preprocessor does is generate the static assets, we don't need to
 
 ## Referencing Keybindings and Actions
 
-When referencing keybindings or actions, use the following formats:
+When referencing keybindings or actions, use the following formats.
 
-### Keybindings:
+### Keybindings
 
 `{#kb scope::Action}` - e.g., `{#kb zed::OpenSettings}`.
 
-This will output a code element like: `<code>Cmd+,|Ctrl+,</code>`. We then use a client-side plugin to show the actual keybinding based on the user's platform.
+This will output a code element like: `<code>Cmd + , | Ctrl + ,</code>`. We then use a client-side plugin to show the actual keybinding based on the user's platform.
 
 By using the action name, we can ensure that the keybinding is always up-to-date rather than hardcoding the keybinding.
 
-### Actions:
+### Actions
 
 `{#action scope::Action}` - e.g., `{#action zed::OpenSettings}`.
 
@@ -62,7 +62,7 @@ This will render a human-readable version of the action name, e.g., "zed: open s
 
 ### Creating New Templates
 
-Templates are just functions that modify the source of the docs pages (usually with a regex match & replace). You can see how the actions and keybindings are templated in `crates/docs_preprocessor/src/main.rs` for reference on how to create new templates.
+Templates are functions that modify the source of the docs pages (usually with a regex match and replace). You can see how the actions and keybindings are templated in `crates/docs_preprocessor/src/main.rs` for reference on how to create new templates.
 
 ### References
 
@@ -72,7 +72,7 @@ Templates are just functions that modify the source of the docs pages (usually w
 
 ## Postprocessor
 
-A postprocessor is implemented as a sub-command of `docs_preprocessor` that wraps the built-in HTML renderer and applies post-processing to the HTML files, to add support for page-specific `title` and `meta` description values.
+A postprocessor is implemented as a sub-command of `docs_preprocessor` that wraps the built-in HTML renderer and applies post-processing to the HTML files, to add support for page-specific title and `meta` tag description values.
 
 An example of the syntax can be found in `git.md`, as well as below:
 
@@ -128,4 +128,4 @@ title: "Some title"
 ```
 
 - The front matter must be at the top of the file, with only white-space preceding it.
-- The contents of the title and description will not be html-escaped. They should be simple ascii text with no unicode or emoji characters.
+- The contents of the `title` and `description` will not be HTML escaped. They should be simple ASCII text with no unicode or emoji characters.

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@ cd docs && pnpm dlx prettier@3.5.0 . --write && cd ..
 We have a custom mdbook preprocessor for interfacing with our crates (`crates/docs_preprocessor`).
 
 If for some reason you need to bypass the docs preprocessor, you can comment out `[preprocessor.zed_docs_preprocessor]
-` from the `book.toml`.:
+` from the `book.toml`.
 
 ## Images and videos
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -66,9 +66,9 @@ Templates are just functions that modify the source of the docs pages (usually w
 
 ### References
 
-- Template Trait: crates/docs_preprocessor/src/templates.rs
-- Example template: crates/docs_preprocessor/src/templates/keybinding.rs
-- Client-side plugins: docs/theme/plugins.js
+- Template Trait: `crates/docs_preprocessor/src/templates.rs`
+- Example template: `crates/docs_preprocessor/src/templates/keybinding.rs`
+- Client-side plugins: `docs/theme/plugins.js`
 
 ## Postprocessor
 


### PR DESCRIPTION
Correct punctuation marks, style keywords in Markdown so it rendered correctly (e.g. HTML tags, paths), capitalize abbreviations (HTML, YAML, ASCII), fix typos for consistency (e.g. mdBook).

Release Notes:

- N/A
