### PR TITLE
Suppress a backtrace in extension error logging

### DIFF
--- a/crates/extension_host/src/extension_host.rs
+++ b/crates/extension_host/src/extension_host.rs
@@ -1376,7 +1376,11 @@ impl ExtensionStore {
                         wasm_extensions.push((extension.manifest.clone(), wasm_extension))
                     }
                     Err(e) => {
-                        log::error!("Failed to load extension: {e:#}");
+                        log::error!(
+                            "Failed to load extension: {}, {:#}",
+                            extension.manifest.id,
+                            e
+                        );
                         this.update(cx, |_, cx| {
                             cx.emit(Event::ExtensionFailedToLoad(extension.manifest.id.clone()))
                         })

--- a/crates/extension_host/src/headless_host.rs
+++ b/crates/extension_host/src/headless_host.rs
@@ -96,7 +96,7 @@ impl HeadlessExtensionStore {
 
             for extension in to_load {
                 if let Err(e) = Self::load_extension(this.clone(), extension.clone(), cx).await {
-                    log::info!("failed to load extension: {}, {:?}", extension.id, e);
+                    log::info!("failed to load extension: {}, {:#}", extension.id, e);
                     missing.push(extension)
                 } else if extension.dev {
                     missing.push(extension)


### PR DESCRIPTION
One less redundant backtrace in the logs:

<img width="2032" height="1161" alt="backtrace" src="https://github.com/user-attachments/assets/f03192b4-1b9c-4fa1-809d-9e826452f711" />

Release Notes:

- N/A 
