### PR TITLE
zeta: Smaller reject batches

### DIFF
--- a/crates/zeta/src/zeta.rs
+++ b/crates/zeta/src/zeta.rs
@@ -988,7 +988,7 @@ impl Zeta {
         });
 
         let reached_request_limit =
-            self.rejected_predictions.len() >= MAX_EDIT_PREDICTION_REJECTIONS_PER_REQUEST;
+            self.rejected_predictions.len() >= MAX_EDIT_PREDICTION_REJECTIONS_PER_REQUEST / 2;
         let reject_tx = self.reject_predictions_tx.clone();
         self.reject_predictions_debounce_task = Some(cx.spawn(async move |_this, cx| {
             const REJECT_REQUEST_DEBOUNCE: Duration = Duration::from_secs(15);


### PR DESCRIPTION
We were allowing the client to build up to `MAX_EDIT_PREDICTION_REJECTIONS_PER_REQUEST`. We'll now attempt to flush the rejections when we reach half max.

Release Notes:

- N/A
