### PR TITLE
edit prediction: Do not attempt to gather context for non-zeta2 models

### DIFF
--- a/crates/zeta/src/zeta.rs
+++ b/crates/zeta/src/zeta.rs
@@ -2058,6 +2058,10 @@ impl Zeta {
         cursor_position: language::Anchor,
         cx: &mut Context<Self>,
     ) {
+        if !matches!(self.edit_prediction_model, ZetaEditPredictionModel::Zeta2) {
+            return;
+        }
+
         if !matches!(&self.options().context, ContextMode::Agentic { .. }) {
             return;
         }


### PR DESCRIPTION
We were running the LLM-based context gathering for zeta1 and sweep which don't use it.

Release Notes:

- N/A
