### PR TITLE
ci: Always run nextest for extensions

### DIFF
--- a/.github/workflows/extension_tests.yml
+++ b/.github/workflows/extension_tests.yml
@@ -7,12 +7,7 @@ env:
   CARGO_INCREMENTAL: '0'
   ZED_EXTENSION_CLI_SHA: 7cfce605704d41ca247e3f84804bf323f6c6caaf
 on:
-  workflow_call:
-    inputs:
-      run_tests:
-        description: Whether the workflow should run rust tests
-        required: true
-        type: boolean
+  workflow_call: {}
 jobs:
   orchestrate:
     if: (github.repository_owner == 'zed-industries' || github.repository_owner == 'zed-extensions')
@@ -73,12 +68,12 @@ jobs:
       run: cargo clippy --release --all-targets --all-features -- --deny warnings
       shell: bash -euxo pipefail {0}
     - name: steps::cargo_install_nextest
-      if: inputs.run_tests
       uses: taiki-e/install-action@nextest
     - name: steps::cargo_nextest
-      if: inputs.run_tests
       run: cargo nextest run --workspace --no-fail-fast
       shell: bash -euxo pipefail {0}
+      env:
+        NEXTEST_NO_TESTS: warn
     timeout-minutes: 3
   check_extension:
     needs:

--- a/tooling/xtask/src/tasks/workflows/extension_tests.rs
+++ b/tooling/xtask/src/tasks/workflows/extension_tests.rs
@@ -8,7 +8,6 @@ use crate::tasks::workflows::{
     vars::{PathCondition, StepOutput, one_workflow_per_non_main_branch},
 };
 
-const RUN_TESTS_INPUT: &str = "run_tests";
 pub(crate) const ZED_EXTENSION_CLI_SHA: &str = "7cfce605704d41ca247e3f84804bf323f6c6caaf";
 
 // This is used by various extensions repos in the zed-extensions org to run automated tests.
@@ -27,17 +26,7 @@ pub(crate) fn extension_tests() -> Workflow {
     let tests_pass = tests_pass(&jobs);
 
     named::workflow()
-        .add_event(
-            Event::default().workflow_call(WorkflowCall::default().add_input(
-                RUN_TESTS_INPUT,
-                WorkflowCallInput {
-                    description: "Whether the workflow should run rust tests".into(),
-                    required: true,
-                    input_type: "boolean".into(),
-                    default: None,
-                },
-            )),
-        )
+        .add_event(Event::default().workflow_call(WorkflowCall::default()))
         .concurrency(one_workflow_per_non_main_branch())
         .add_env(("CARGO_TERM_COLOR", "always"))
         .add_env(("RUST_BACKTRACE", 1))
@@ -65,13 +54,9 @@ fn check_rust() -> NamedJob {
         .add_step(steps::cache_rust_dependencies_namespace())
         .add_step(steps::cargo_fmt())
         .add_step(run_clippy())
+        .add_step(steps::cargo_install_nextest())
         .add_step(
-            steps::cargo_install_nextest()
-                .if_condition(Expression::new(format!("inputs.{RUN_TESTS_INPUT}"))),
-        )
-        .add_step(
-            steps::cargo_nextest(runners::Platform::Linux)
-                .if_condition(Expression::new(format!("inputs.{RUN_TESTS_INPUT}"))),
+            steps::cargo_nextest(runners::Platform::Linux).add_env(("NEXTEST_NO_TESTS", "warn")),
         );
 
     named::job(job)


### PR DESCRIPTION
This makes rolling this out across extensions a far bit easier and also safer, because we don't have to manually set `run_tests` for every extension (and never have to consider this when updating these).

Release Notes:

- N/A
