### PR TITLE
Add customization capabilities to which-key menu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19728,6 +19728,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "which_key"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "command_palette",
+ "gpui",
+ "schemars 1.0.1",
+ "serde",
+ "settings",
+ "theme",
+ "ui",
+ "workspace",
+ "workspace-hack",
+ "zed-util",
+]
+
+[[package]]
 name = "whoami"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -21337,6 +21354,7 @@ dependencies = [
  "web_search",
  "web_search_providers",
  "windows 0.61.3",
+ "which_key",
  "winresource",
  "workspace",
  "zed-reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19734,7 +19734,7 @@ dependencies = [
  "anyhow",
  "command_palette",
  "gpui",
- "schemars 1.0.4",
+ "schemars",
  "serde",
  "settings",
  "theme",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19731,10 +19731,8 @@ dependencies = [
 name = "which_key"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "command_palette",
  "gpui",
- "schemars",
  "serde",
  "settings",
  "theme",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19734,14 +19734,13 @@ dependencies = [
  "anyhow",
  "command_palette",
  "gpui",
- "schemars 1.0.1",
+ "schemars 1.0.4",
  "serde",
  "settings",
  "theme",
  "ui",
+ "util",
  "workspace",
- "workspace-hack",
- "zed-util",
 ]
 
 [[package]]
@@ -21353,8 +21352,8 @@ dependencies = [
  "watch",
  "web_search",
  "web_search_providers",
- "windows 0.61.3",
  "which_key",
+ "windows 0.61.3",
  "winresource",
  "workspace",
  "zed-reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,6 +191,7 @@ members = [
     "crates/vercel",
     "crates/vim",
     "crates/vim_mode_setting",
+    "crates/which_key",
     "crates/watch",
     "crates/web_search",
     "crates/web_search_providers",
@@ -421,6 +422,7 @@ util_macros = { path = "crates/util_macros" }
 vercel = { path = "crates/vercel" }
 vim = { path = "crates/vim" }
 vim_mode_setting = { path = "crates/vim_mode_setting" }
+which_key = { path = "crates/which_key" }
 
 watch = { path = "crates/watch" }
 web_search = { path = "crates/web_search" }

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -2107,6 +2107,13 @@
     // The shape can be one of the following: "block", "bar", "underline", "hollow".
     "cursor_shape": {}
   },
+  // Which-key popup settings
+  "which_key": {
+    // Whether to show the which-key popup when holding down key combinations.
+    "enabled": false,
+    // Delay in milliseconds before showing the which-key popup.
+    "delay_ms": 700
+  },
   // The server to connect to. If the environment variable
   // ZED_SERVER_URL is set, it will override this setting.
   "server_url": "https://zed.dev",

--- a/crates/collab/src/tests/test_server.rs
+++ b/crates/collab/src/tests/test_server.rs
@@ -352,7 +352,9 @@ impl TestServer {
             file_finder::init(cx);
             menu::init();
             cx.bind_keys(
-                settings::KeymapFile::load_asset_allow_partial_failure(os_keymap, cx).unwrap(),
+                settings::KeymapFile::load_asset_allow_partial_failure(os_keymap, cx)
+                    .unwrap()
+                    .key_bindings,
             );
             language_model::LanguageModelRegistry::test(cx);
             assistant_text_thread::init(client.clone(), cx);

--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -793,8 +793,9 @@ mod tests {
             go_to_line::init(cx);
             workspace::init(app_state.clone(), cx);
             init(cx);
-            cx.bind_keys(KeymapFile::load_panic_on_failure(
-                r#"[
+            cx.bind_keys(
+                KeymapFile::load_panic_on_failure(
+                    r#"[
                     {
                         "bindings": {
                             "cmd-n": "workspace::NewFile",
@@ -803,8 +804,10 @@ mod tests {
                         }
                     }
                 ]"#,
-                cx,
-            ));
+                    cx,
+                )
+                .key_bindings,
+            );
             app_state
         })
     }

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -22895,7 +22895,7 @@ async fn test_multi_buffer_navigation_with_folded_buffers(cx: &mut TestAppContex
             cx,
         )
         .unwrap();
-        cx.bind_keys(default_key_bindings);
+        cx.bind_keys(default_key_bindings.key_bindings);
     });
 
     let (editor, cx) = cx.add_window_view(|window, cx| {

--- a/crates/gpui/src/key_dispatch.rs
+++ b/crates/gpui/src/key_dispatch.rs
@@ -462,6 +462,17 @@ impl DispatchTree {
         (bindings, partial, context_stack)
     }
 
+    /// Find the bindings that can follow the current input sequence.
+    pub fn possible_next_bindings_for_input(
+        &self,
+        input: &[Keystroke],
+        context_stack: &[KeyContext],
+    ) -> Vec<KeyBinding> {
+        self.keymap
+            .borrow()
+            .possible_next_bindings_for_input(input, context_stack)
+    }
+
     /// dispatch_key processes the keystroke
     /// input should be set to the value of `pending` from the previous call to dispatch_key.
     /// This returns three instructions to the input handler:

--- a/crates/gpui/src/keymap.rs
+++ b/crates/gpui/src/keymap.rs
@@ -215,6 +215,41 @@ impl Keymap {
             Some(contexts.len())
         }
     }
+
+    /// Find the bindings that can follow the current input sequence.
+    pub fn possible_next_bindings_for_input(
+        &self,
+        input: &[Keystroke],
+        context_stack: &[KeyContext],
+    ) -> Vec<KeyBinding> {
+        let mut bindings = self
+            .bindings()
+            .enumerate()
+            .rev()
+            .filter_map(|(ix, binding)| {
+                let depth = self.binding_enabled(binding, context_stack)?;
+                let pending = binding.match_keystrokes(input);
+                match pending {
+                    None => None,
+                    Some(is_pending) => {
+                        if !is_pending || is_no_action(&*binding.action) {
+                            return None;
+                        }
+                        Some((depth, BindingIndex(ix), binding))
+                    }
+                }
+            })
+            .collect::<Vec<_>>();
+
+        bindings.sort_by(|(depth_a, ix_a, _), (depth_b, ix_b, _)| {
+            depth_b.cmp(depth_a).then(ix_b.cmp(ix_a))
+        });
+
+        bindings
+            .into_iter()
+            .map(|(_, _, binding)| binding.clone())
+            .collect::<Vec<_>>()
+    }
 }
 
 #[cfg(test)]

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -4423,6 +4423,13 @@ impl Window {
         dispatch_tree.highest_precedence_binding_for_action(action, &context_stack)
     }
 
+    /// Find the bindings that can follow the current input sequence for the current context stack.
+    pub fn possible_bindings_for_input(&self, input: &[Keystroke]) -> Vec<KeyBinding> {
+        self.rendered_frame
+            .dispatch_tree
+            .possible_next_bindings_for_input(input, &self.context_stack())
+    }
+
     fn context_stack_for_focus_handle(
         &self,
         focus_handle: &FocusHandle,

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -1593,7 +1593,7 @@ mod tests {
                 cx,
             )
             .unwrap();
-            cx.bind_keys(default_key_bindings);
+            cx.bind_keys(default_key_bindings.key_bindings);
             editor = Some(cx.new(|cx| Editor::for_buffer(buffer.clone(), None, window, cx)));
             let mut search_bar = BufferSearchBar::new(None, window, cx);
             search_bar.set_active_pane_item(Some(&editor.clone().unwrap()), window, cx);

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -27,7 +27,7 @@ pub use base_keymap_setting::*;
 pub use editable_setting_control::*;
 pub use keymap_file::{
     KeyBindingValidator, KeyBindingValidatorRegistration, KeybindSource, KeybindUpdateOperation,
-    KeybindUpdateTarget, KeymapFile, KeymapFileLoadResult,
+    KeybindUpdateTarget, KeymapFile, KeymapFileLoadResult, KeymapLabel, KeymapLabels, KeymapLoad,
 };
 pub use serde_helper::*;
 pub use settings_file::*;

--- a/crates/settings/src/settings_content.rs
+++ b/crates/settings/src/settings_content.rs
@@ -158,6 +158,9 @@ pub struct SettingsContent {
     /// Default: false
     pub disable_ai: Option<SaturatingBool>,
 
+    /// Settings for the which-key popup.
+    pub which_key: Option<WhichKeySettingsContent>,
+
     /// Settings related to Vim mode in Zed.
     pub vim: Option<VimSettingsContent>,
 }
@@ -952,6 +955,20 @@ pub struct ReplSettingsContent {
     ///
     /// Default: 128
     pub max_columns: Option<usize>,
+}
+
+/// Settings for configuring the which-key popup behaviour.
+#[skip_serializing_none]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, JsonSchema, MergeFrom)]
+pub struct WhichKeySettingsContent {
+    /// Whether to show the which-key popup when holding down key combinations
+    ///
+    /// Default: false
+    pub enabled: Option<bool>,
+    /// Delay in milliseconds before showing the which-key popup.
+    ///
+    /// Default: 700
+    pub delay_ms: Option<u64>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]

--- a/crates/settings/src/settings_content.rs
+++ b/crates/settings/src/settings_content.rs
@@ -958,7 +958,6 @@ pub struct ReplSettingsContent {
 }
 
 /// Settings for configuring the which-key popup behaviour.
-#[skip_serializing_none]
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, JsonSchema, MergeFrom)]
 pub struct WhichKeySettingsContent {
     /// Whether to show the which-key popup when holding down key combinations

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -215,6 +215,7 @@ impl VsCodeSettings {
             vim: None,
             vim_mode: None,
             workspace: self.workspace_settings_content(),
+            which_key: None,
         }
     }
 

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -1192,6 +1192,49 @@ pub(crate) fn settings_data(cx: &App) -> Vec<SettingsPage> {
                             }
                         }).collect(),
                     }),
+                    SettingsPageItem::SectionHeader("Which-key Menu"),
+                    SettingsPageItem::SettingItem(SettingItem {
+                        title: "Show Which-key Menu",
+                        description: "Display the which-key menu with matching bindings while a multi-stroke binding is pending.",
+                        field: Box::new(SettingField {
+                            json_path: Some("which_key.enabled"),
+                            pick: |settings_content| {
+                                settings_content
+                                    .which_key
+                                    .as_ref()
+                                    .and_then(|settings| settings.enabled.as_ref())
+                            },
+                            write: |settings_content, value| {
+                                settings_content
+                                    .which_key
+                                    .get_or_insert_default()
+                                    .enabled = value;
+                            },
+                        }),
+                        metadata: None,
+                        files: USER,
+                    }),
+                    SettingsPageItem::SettingItem(SettingItem {
+                        title: "Menu Delay",
+                        description: "Delay in milliseconds before the which-key menu appears.",
+                        field: Box::new(SettingField {
+                            json_path: Some("which_key.delay_ms"),
+                            pick: |settings_content| {
+                                settings_content
+                                    .which_key
+                                    .as_ref()
+                                    .and_then(|settings| settings.delay_ms.as_ref())
+                            },
+                            write: |settings_content, value| {
+                                settings_content
+                                    .which_key
+                                    .get_or_insert_default()
+                                    .delay_ms = value;
+                            },
+                        }),
+                        metadata: None,
+                        files: USER,
+                    }),
                     SettingsPageItem::SectionHeader("Multibuffer"),
                     SettingsPageItem::SettingItem(SettingItem {
                         title: "Double Click In Multibuffer",

--- a/crates/storybook/src/storybook.rs
+++ b/crates/storybook/src/storybook.rs
@@ -145,7 +145,7 @@ fn load_embedded_fonts(cx: &App) -> anyhow::Result<()> {
 }
 
 fn load_storybook_keymap(cx: &mut App) {
-    cx.bind_keys(KeymapFile::load_asset("keymaps/storybook.json", None, cx).unwrap());
+    cx.bind_keys(KeymapFile::load_asset("keymaps/storybook.json", None, cx).unwrap().key_bindings);
 }
 
 pub fn init(cx: &mut App) {

--- a/crates/vim/src/test/vim_test_context.rs
+++ b/crates/vim/src/test/vim_test_context.rs
@@ -96,15 +96,15 @@ impl VimTestContext {
         SettingsStore::update_global(cx, |store, cx| {
             store.update_user_settings(cx, |s| s.vim_mode = Some(enabled));
         });
-        let mut default_key_bindings = settings::KeymapFile::load_asset_allow_partial_failure(
+        let mut default_keymap = settings::KeymapFile::load_asset_allow_partial_failure(
             "keymaps/default-macos.json",
             cx,
         )
         .unwrap();
-        for key_binding in &mut default_key_bindings {
+        for key_binding in &mut default_keymap.key_bindings {
             key_binding.set_meta(settings::KeybindSource::Default.meta());
         }
-        cx.bind_keys(default_key_bindings);
+        cx.bind_keys(default_keymap.key_bindings);
         if enabled {
             let vim_key_bindings = settings::KeymapFile::load_asset(
                 "keymaps/vim.json",
@@ -112,7 +112,7 @@ impl VimTestContext {
                 cx,
             )
             .unwrap();
-            cx.bind_keys(vim_key_bindings);
+            cx.bind_keys(vim_key_bindings.key_bindings);
         }
     }
 

--- a/crates/which_key/Cargo.toml
+++ b/crates/which_key/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "which_key"
+version = "0.1.0"
+edition.workspace = true
+publish.workspace = true
+license = "GPL-3.0-or-later"
+
+[lints]
+workspace = true
+
+[lib]
+path = "src/which_key.rs"
+doctest = false
+
+[dependencies]
+anyhow.workspace = true
+command_palette.workspace = true
+gpui.workspace = true
+schemars.workspace = true
+serde.workspace = true
+settings.workspace = true
+theme.workspace = true
+ui.workspace = true
+util.workspace = true
+workspace.workspace = true
+workspace-hack.workspace = true

--- a/crates/which_key/Cargo.toml
+++ b/crates/which_key/Cargo.toml
@@ -13,10 +13,8 @@ path = "src/which_key.rs"
 doctest = false
 
 [dependencies]
-anyhow.workspace = true
 command_palette.workspace = true
 gpui.workspace = true
-schemars.workspace = true
 serde.workspace = true
 settings.workspace = true
 theme.workspace = true

--- a/crates/which_key/Cargo.toml
+++ b/crates/which_key/Cargo.toml
@@ -23,4 +23,3 @@ theme.workspace = true
 ui.workspace = true
 util.workspace = true
 workspace.workspace = true
-workspace-hack.workspace = true

--- a/crates/which_key/LICENSE-GPL
+++ b/crates/which_key/LICENSE-GPL
@@ -1,0 +1,1 @@
+../../LICENSE-GPL

--- a/crates/which_key/src/which_key.rs
+++ b/crates/which_key/src/which_key.rs
@@ -1,0 +1,98 @@
+//! Which-key support for Zed.
+
+mod which_key_modal;
+mod which_key_settings;
+
+use gpui::{App, Keystroke};
+use settings::Settings;
+use std::{sync::LazyLock, time::Duration};
+use util::ResultExt;
+use which_key_modal::WhichKeyModal;
+use which_key_settings::WhichKeySettings;
+use workspace::Workspace;
+
+pub fn init(cx: &mut App) {
+    WhichKeySettings::register(cx);
+
+    cx.observe_new(|_: &mut Workspace, window, cx| {
+        let Some(window) = window else {
+            return;
+        };
+        let mut timer = None;
+        cx.observe_pending_input(window, move |workspace, window, cx| {
+            if window.pending_input_keystrokes().is_none() {
+                if let Some(modal) = workspace.active_modal::<WhichKeyModal>(cx) {
+                    modal.update(cx, |modal, cx| modal.dismiss(cx));
+                };
+                timer.take();
+                return;
+            }
+
+            let which_key_settings = WhichKeySettings::get_global(cx);
+            if !which_key_settings.enabled {
+                return;
+            }
+
+            let delay_ms = which_key_settings.delay_ms;
+
+            timer.replace(cx.spawn_in(window, async move |workspace_handle, cx| {
+                cx.background_executor()
+                    .timer(Duration::from_millis(delay_ms))
+                    .await;
+                workspace_handle
+                    .update_in(cx, |workspace, window, cx| {
+                        if workspace.active_modal::<WhichKeyModal>(cx).is_some() {
+                            return;
+                        };
+
+                        workspace.toggle_modal(window, cx, |window, cx| {
+                            WhichKeyModal::new(workspace_handle.clone(), window, cx)
+                        });
+                    })
+                    .log_err();
+            }));
+        })
+        .detach();
+    })
+    .detach();
+}
+
+// Hard-coded list of keystrokes to filter out from which-key display
+pub static FILTERED_KEYSTROKES: LazyLock<Vec<Vec<Keystroke>>> = LazyLock::new(|| {
+    [
+        // Modifiers on normal vim commands
+        "g h",
+        "g j",
+        "g k",
+        "g l",
+        "g $",
+        "g ^",
+        // Duplicate keys with "ctrl" held, e.g. "ctrl-w ctrl-a" is duplicate of "ctrl-w a"
+        "ctrl-w ctrl-a",
+        "ctrl-w ctrl-c",
+        "ctrl-w ctrl-h",
+        "ctrl-w ctrl-j",
+        "ctrl-w ctrl-k",
+        "ctrl-w ctrl-l",
+        "ctrl-w ctrl-n",
+        "ctrl-w ctrl-o",
+        "ctrl-w ctrl-p",
+        "ctrl-w ctrl-q",
+        "ctrl-w ctrl-s",
+        "ctrl-w ctrl-v",
+        "ctrl-w ctrl-w",
+        "ctrl-w ctrl-]",
+        "ctrl-w ctrl-shift-w",
+        "ctrl-w ctrl-g t",
+        "ctrl-w ctrl-g shift-t",
+    ]
+    .iter()
+    .filter_map(|s| {
+        let keystrokes: Result<Vec<_>, _> = s
+            .split(' ')
+            .map(|keystroke_str| Keystroke::parse(keystroke_str))
+            .collect();
+        keystrokes.ok()
+    })
+    .collect()
+});

--- a/crates/which_key/src/which_key.rs
+++ b/crates/which_key/src/which_key.rs
@@ -1,9 +1,11 @@
 //! Which-key support for Zed.
 
+mod which_key_labels;
 mod which_key_modal;
 mod which_key_settings;
 
 use gpui::{App, Keystroke};
+use settings::KeymapLabels;
 use settings::Settings;
 use std::{sync::LazyLock, time::Duration};
 use util::ResultExt;
@@ -13,6 +15,7 @@ use workspace::Workspace;
 
 pub fn init(cx: &mut App) {
     WhichKeySettings::register(cx);
+    which_key_labels::register(cx);
 
     cx.observe_new(|_: &mut Workspace, window, cx| {
         let Some(window) = window else {
@@ -55,6 +58,10 @@ pub fn init(cx: &mut App) {
         .detach();
     })
     .detach();
+}
+
+pub fn set_keymap_labels(cx: &mut App, labels: KeymapLabels) {
+    which_key_labels::set_labels(cx, labels);
 }
 
 // Hard-coded list of keystrokes to filter out from which-key display

--- a/crates/which_key/src/which_key_labels.rs
+++ b/crates/which_key/src/which_key_labels.rs
@@ -1,0 +1,114 @@
+use gpui::{App, BorrowAppContext, Global};
+use settings::KeymapLabels;
+
+#[derive(Default)]
+struct GlobalKeymapLabels(KeymapLabels);
+
+impl Global for GlobalKeymapLabels {}
+
+pub fn register(cx: &mut App) {
+    if !cx.has_global::<GlobalKeymapLabels>() {
+        cx.set_global(GlobalKeymapLabels::default());
+    }
+}
+
+pub fn set_labels(cx: &mut App, labels: KeymapLabels) {
+    if cx.has_global::<GlobalKeymapLabels>() {
+        cx.update_global(|global: &mut GlobalKeymapLabels, _| global.0 = labels);
+    } else {
+        cx.set_global(GlobalKeymapLabels(labels));
+    }
+}
+
+pub fn labels(cx: &mut App) -> KeymapLabels {
+    cx.try_global::<GlobalKeymapLabels>()
+        .map(|global| global.0.clone())
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui::{
+        DummyKeyboardMapper, KeyBindingContextPredicate, KeyContext, KeybindingKeystroke, Keystroke,
+    };
+    use ui::SharedString;
+
+    fn parse_keystrokes(keystrokes: &str) -> Vec<KeybindingKeystroke> {
+        keystrokes
+            .split_whitespace()
+            .map(|source| {
+                KeybindingKeystroke::new_with_mapper(
+                    Keystroke::parse(source).unwrap(),
+                    false,
+                    &DummyKeyboardMapper,
+                )
+            })
+            .collect()
+    }
+
+    fn make_label(
+        keystrokes: &str,
+        label: impl Into<SharedString>,
+        context: Option<&str>,
+    ) -> settings::KeymapLabel {
+        settings::KeymapLabel {
+            keystrokes: parse_keystrokes(keystrokes).into(),
+            label: label.into(),
+            context_predicate: context
+                .map(|ctx| KeyBindingContextPredicate::parse(ctx).unwrap().into()),
+            meta: None,
+        }
+    }
+
+    #[test]
+    fn resolves_binding_label_with_precedence() {
+        let mut default_labels = KeymapLabels::default();
+        default_labels.binding_labels.push(make_label(
+            "ctrl-w d",
+            "Go to definition (split)",
+            Some("VimControl"),
+        ));
+
+        let mut user_labels = KeymapLabels::default();
+        user_labels.binding_labels.push(make_label(
+            "ctrl-w d",
+            "Definition in split",
+            Some("VimControl"),
+        ));
+
+        let mut merged = KeymapLabels::default();
+        merged.merge(default_labels);
+        merged.merge(user_labels);
+
+        let context_stack = vec![KeyContext::parse("VimControl").unwrap()];
+        let keystrokes = parse_keystrokes("ctrl-w d");
+
+        assert_eq!(
+            merged
+                .resolve_binding_label(&keystrokes, &context_stack)
+                .as_ref()
+                .map(|s| s.as_ref()),
+            Some("Definition in split")
+        );
+    }
+
+    #[test]
+    fn resolves_group_label_for_prefix() {
+        let mut labels = KeymapLabels::default();
+        labels
+            .group_labels
+            .push(make_label("ctrl-w", "Window & panes", Some("VimControl")));
+
+        let context_stack = vec![KeyContext::parse("VimControl").unwrap()];
+        let keystrokes = parse_keystrokes("ctrl-w");
+
+        assert_eq!(
+            labels
+                .resolve_group_label(&keystrokes, &context_stack)
+                .as_ref()
+                .map(|s| s.as_ref()),
+            Some("Window & panes")
+        );
+    }
+}

--- a/crates/which_key/src/which_key_modal.rs
+++ b/crates/which_key/src/which_key_modal.rs
@@ -340,7 +340,7 @@ impl Render for WhichKeyModal {
                             div()
                                 .h(list_container_height)
                                 .child(rows.h(list_container_height))
-                                .vertical_scrollbar_for(self.scroll_handle.clone(), window, cx),
+                                .vertical_scrollbar_for(&self.scroll_handle, window, cx),
                         )
                     }),
             )

--- a/crates/which_key/src/which_key_modal.rs
+++ b/crates/which_key/src/which_key_modal.rs
@@ -1,0 +1,393 @@
+//! Modal implementation for the which-key display.
+
+use gpui::{
+    App, AvailableSpace, Context, DismissEvent, EventEmitter, FocusHandle, Focusable, FontWeight,
+    Keystroke, Subscription, WeakEntity, Window, size,
+};
+use settings::Settings;
+use std::collections::HashMap;
+use theme::ThemeSettings;
+use ui::{DynamicSpacing, prelude::*, text_for_keystrokes};
+use workspace::{ModalView, Workspace};
+
+use crate::FILTERED_KEYSTROKES;
+
+pub struct WhichKeyModal {
+    workspace: WeakEntity<Workspace>,
+    focus_handle: FocusHandle,
+    bindings: Vec<(SharedString, SharedString)>,
+    pending_keys: SharedString,
+    _pending_input_subscription: Subscription,
+    _focus_out_subscription: Subscription,
+}
+
+impl WhichKeyModal {
+    pub fn new(
+        workspace: WeakEntity<Workspace>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        // Keep focus where it currently is
+        let focus_handle = window.focused(cx).unwrap_or(cx.focus_handle());
+
+        let handle = cx.weak_entity();
+        let mut this = Self {
+            workspace: workspace.clone(),
+            focus_handle: focus_handle.clone(),
+            bindings: Vec::new(),
+            pending_keys: SharedString::new_static(""),
+            _pending_input_subscription: cx.observe_pending_input(
+                window,
+                |this: &mut Self, window, cx| {
+                    this.update_pending_keys(window, cx);
+                },
+            ),
+            _focus_out_subscription: window.on_focus_out(&focus_handle, cx, move |_, _, cx| {
+                handle.update(cx, |_, cx| cx.emit(DismissEvent)).ok();
+            }),
+        };
+        this.update_pending_keys(window, cx);
+        this
+    }
+
+    pub fn dismiss(&self, cx: &mut Context<Self>) {
+        cx.emit(DismissEvent)
+    }
+
+    fn update_pending_keys(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(pending_keys) = window.pending_input_keystrokes() else {
+            cx.emit(DismissEvent);
+            return;
+        };
+        let bindings = window.possible_bindings_for_input(pending_keys);
+
+        let mut binding_data = bindings
+            .iter()
+            .map(|binding| {
+                // Map to keystrokes
+                (
+                    binding
+                        .keystrokes()
+                        .iter()
+                        .map(|k| k.inner().to_owned())
+                        .collect::<Vec<_>>(),
+                    binding.action(),
+                )
+            })
+            .filter(|(keystrokes, _action)| {
+                // Check if this binding matches any filtered keystroke pattern
+                !FILTERED_KEYSTROKES.iter().any(|filtered| {
+                    keystrokes.len() >= filtered.len()
+                        && keystrokes[..filtered.len()] == filtered[..]
+                })
+            })
+            .map(|(keystrokes, action)| {
+                // Map to remaining keystrokes and action name
+                let remaining_keystrokes = keystrokes[pending_keys.len()..].to_vec();
+                let action_name: SharedString =
+                    command_palette::humanize_action_name(action.name()).into();
+                (remaining_keystrokes, action_name)
+            })
+            .collect();
+
+        binding_data = group_bindings(binding_data);
+
+        // Sort bindings from shortest to longest, with groups last
+        // Using stable sort to preserve relative order of equal elements
+        binding_data.sort_by(|(keystrokes_a, action_a), (keystrokes_b, action_b)| {
+            // Groups (actions starting with "+") should go last
+            let is_group_a = action_a.starts_with('+');
+            let is_group_b = action_b.starts_with('+');
+
+            // First, separate groups from non-groups
+            let group_cmp = is_group_a.cmp(&is_group_b);
+            if group_cmp != std::cmp::Ordering::Equal {
+                return group_cmp;
+            }
+
+            // Then sort by keystroke count
+            let keystroke_cmp = keystrokes_a.len().cmp(&keystrokes_b.len());
+            if keystroke_cmp != std::cmp::Ordering::Equal {
+                return keystroke_cmp;
+            }
+
+            // Finally sort by text length, then lexicographically for full stability
+            let text_a = text_for_keystrokes(keystrokes_a, cx);
+            let text_b = text_for_keystrokes(keystrokes_b, cx);
+            let text_len_cmp = text_a.len().cmp(&text_b.len());
+            if text_len_cmp != std::cmp::Ordering::Equal {
+                return text_len_cmp;
+            }
+            text_a.cmp(&text_b)
+        });
+        binding_data.dedup();
+        self.pending_keys = text_for_keystrokes(&pending_keys, cx).into();
+        self.bindings = binding_data
+            .into_iter()
+            .map(|(keystrokes, action)| (text_for_keystrokes(&keystrokes, cx).into(), action))
+            .collect();
+    }
+}
+
+impl Render for WhichKeyModal {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let ui_font_size = ThemeSettings::get_global(cx).ui_font_size(cx);
+        let status_bar_height = DynamicSpacing::Base08.px(cx) * 2.0 + ui_font_size;
+
+        let is_zoomed = self
+            .workspace
+            .read_with(cx, |workspace, _cx| workspace.zoomed_item().is_some())
+            .unwrap_or(false);
+
+        // Get dock widths and bottom dock height for dynamic padding
+        // If workspace is zoomed, ignore panel padding and render at bottom of buffer
+        let (left_margin, right_margin) = if let Ok(margins) =
+            self.workspace.read_with(cx, |workspace, cx| {
+                if is_zoomed {
+                    return (Pixels::ZERO, Pixels::ZERO);
+                }
+
+                let left_width = workspace
+                    .left_dock()
+                    .read(cx)
+                    .active_panel_size(window, cx)
+                    .unwrap_or_default();
+                let right_width = workspace
+                    .right_dock()
+                    .read(cx)
+                    .active_panel_size(window, cx)
+                    .unwrap_or_default();
+
+                (left_width, right_width)
+            }) {
+            margins
+        } else {
+            (Pixels::ZERO, Pixels::ZERO)
+        };
+
+        let column_gap = DynamicSpacing::Base32.px(cx); // Gap between columns
+        let row_gap = DynamicSpacing::Base04.px(cx); // Gap between rows
+        let content_gap = DynamicSpacing::Base08.px(cx); // Gap between current pending keystroke and grid of keys+actions
+        let margin = DynamicSpacing::Base08.px(cx); // Margin around the panel
+        let padding = DynamicSpacing::Base16.px(cx); // Padding inside the panel
+
+        // Calculate column width based on UI font size (as maximum)
+        let max_column_width = ui_font_size * 125.0;
+
+        // Calculate actual column width based on largest binding element
+        let largest_binding = self
+            .bindings
+            .iter()
+            .max_by_key(|(remaining_keystrokes, action_name)| {
+                remaining_keystrokes.len() + action_name.len()
+            })
+            .map(|(remaining_keystrokes, action_name)| {
+                create_aligned_binding_element(
+                    remaining_keystrokes.clone(),
+                    action_name.clone(),
+                    None,
+                )
+                .into_any_element()
+                .layout_as_root(AvailableSpace::min_size(), window, cx)
+            })
+            .unwrap_or(size(Pixels::ZERO, Pixels::ZERO));
+
+        // Final width of the columns
+        let column_width = largest_binding.width.min(max_column_width);
+
+        // Calculate available width (window width minus padding)
+        let window_width = largest_binding.width.min(max_column_width);
+        let available_width =
+            window_width - (left_margin + right_margin + (margin * 2.0) + (padding * 2.0));
+
+        // Calculate number of columns that can fit
+        let columns = ((available_width + column_gap) / (column_width + column_gap))
+            .floor()
+            .max(1.0) as usize;
+
+        // Calculate rows per column
+        let total_items = self.bindings.len();
+        let rows_per_column = (total_items + columns - 1).div_ceil(columns);
+
+        // Create columns
+        let mut column_elements = Vec::new();
+        for col in 0..columns {
+            let start_idx = col * rows_per_column;
+            let end_idx = ((col + 1) * rows_per_column).min(total_items);
+
+            if start_idx >= total_items {
+                break;
+            }
+
+            let column_items = &self.bindings[start_idx..end_idx];
+
+            // Find the longest_keystroke text width for this column
+            let column_longest_keystroke_width = column_items
+                .iter()
+                .max_by_key(|(remaining_keystrokes, _)| {
+                    (
+                        remaining_keystrokes.len(),
+                        remaining_keystrokes.ends_with(|c| c == 'm' || c == 'w'),
+                    )
+                })
+                .map(|(remaining_keystrokes, _)| {
+                    Label::new(remaining_keystrokes.clone())
+                        .into_any_element()
+                        .layout_as_root(AvailableSpace::min_size(), window, cx)
+                        .width
+                        + px(10.)
+                });
+
+            let column = v_flex().gap(row_gap).children(column_items.iter().map(
+                |(remaining_keystrokes, action_name)| {
+                    create_aligned_binding_element(
+                        remaining_keystrokes.clone(),
+                        action_name.clone(),
+                        column_longest_keystroke_width,
+                    )
+                },
+            ));
+
+            column_elements.push(column);
+        }
+
+        // Calculate real size of 1 row
+        let row_height = largest_binding.height;
+
+        // Calculate height
+        let base_height = (padding * 2) /* Container padding */
+            + (row_height) /* Pending keys */
+            + content_gap; /* Pending keys gap */
+        let total_height = base_height
+            + (rows_per_column * row_height) /* Rows */
+            + ((rows_per_column - 1) * row_gap); /* Rows gap */
+
+        // Calculate minimum height (to show ~2.5 rows, using 2.15 as the last row spills over in the margin)
+        let minimum_rows = (rows_per_column as f32).min(2.15);
+        let minimum_height = base_height
+            + (minimum_rows * row_height) /* Rows */
+            + ((minimum_rows - 1.0) * row_gap); /* Rows gap */
+
+        let cursor_position = self
+            .workspace
+            .read_with(cx, |workspace, cx| {
+                workspace
+                    .active_item(cx)
+                    .and_then(|item| item.pixel_position_of_cursor(cx))
+            })
+            .unwrap_or(None);
+
+        let panel_bottom_y = status_bar_height + margin;
+
+        // Adjust height to avoid covering cursor
+        let adjusted_height = if let Some(cursor_pos) = cursor_position {
+            let cursor_padding = (ThemeSettings::get_global(cx).buffer_font_size(cx)
+                * ThemeSettings::get_global(cx).line_height())
+                + margin;
+            let window_height = window.viewport_size().height;
+            // Calculate available space from cursor to bottom of panel
+            let available_space = window_height - panel_bottom_y - cursor_pos.y - cursor_padding;
+            if available_space > px(0.0) {
+                total_height.min(available_space).max(minimum_height)
+            } else {
+                total_height
+            }
+        } else {
+            total_height
+        };
+
+        div()
+            .id("which-key-buffer-panel-scroll")
+            .occlude()
+            .absolute()
+            .bottom(panel_bottom_y)
+            .left(left_margin + margin)
+            .right(right_margin + margin)
+            .elevation_3(cx)
+            .p(padding)
+            .overflow_y_scroll()
+            .h(adjusted_height)
+            .child(
+                v_flex()
+                    .gap(content_gap)
+                    .child(Label::new(self.pending_keys.clone()).weight(FontWeight::BOLD))
+                    .child(
+                        h_flex()
+                            .gap(column_gap)
+                            .items_start()
+                            .children(column_elements),
+                    ),
+            )
+    }
+}
+
+impl EventEmitter<DismissEvent> for WhichKeyModal {}
+
+impl Focusable for WhichKeyModal {
+    fn focus_handle(&self, _cx: &App) -> gpui::FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+impl ModalView for WhichKeyModal {
+    fn render_bare(&self) -> bool {
+        true
+    }
+}
+
+fn group_bindings(
+    binding_data: Vec<(Vec<Keystroke>, SharedString)>,
+) -> Vec<(Vec<Keystroke>, SharedString)> {
+    let mut groups: HashMap<Option<Keystroke>, Vec<(Vec<Keystroke>, SharedString)>> =
+        HashMap::new();
+
+    // Group bindings by their first keystroke
+    for (remaining_keystrokes, action_name) in binding_data {
+        let first_key = remaining_keystrokes.first().cloned();
+        groups
+            .entry(first_key)
+            .or_default()
+            .push((remaining_keystrokes, action_name));
+    }
+
+    let mut result = Vec::new();
+
+    for (first_key, mut group_bindings) in groups {
+        // Remove duplicates within each group
+        group_bindings.dedup_by_key(|(keystrokes, _)| keystrokes.clone());
+
+        if group_bindings.len() > 1 && first_key.is_some() {
+            // This is a group - create a single entry with just the first keystroke
+            let first_keystroke = vec![first_key.unwrap()];
+            let count = group_bindings.len();
+            result.push((first_keystroke, format!("+{} keybinds", count).into()));
+        } else {
+            // Not a group or empty keystrokes - add all bindings as-is
+            result.append(&mut group_bindings);
+        }
+    }
+
+    result
+}
+
+fn create_aligned_binding_element(
+    keystrokes: SharedString,
+    action_name: SharedString,
+    keystroke_width: Option<Pixels>,
+) -> impl IntoElement {
+    let keystroke = div()
+        .when_some(keystroke_width, |div, width| div.w(width))
+        .child(Label::new(keystrokes).color({
+            if action_name.starts_with('+') {
+                Color::Success
+            } else {
+                Color::Accent
+            }
+        }))
+        .text_align(gpui::TextAlign::Right);
+
+    h_flex().items_center().gap_1p5().children([
+        keystroke.into_any_element(),
+        Label::new(action_name).truncate().into_any_element(),
+    ])
+}

--- a/crates/which_key/src/which_key_modal.rs
+++ b/crates/which_key/src/which_key_modal.rs
@@ -37,7 +37,7 @@ impl WhichKeyModal {
 
         let handle = cx.weak_entity();
         let mut this = Self {
-            _workspace: workspace.clone(),
+            _workspace: workspace,
             focus_handle: focus_handle.clone(),
             scroll_handle: ScrollHandle::new(),
             bindings: Vec::new(),

--- a/crates/which_key/src/which_key_settings.rs
+++ b/crates/which_key/src/which_key_settings.rs
@@ -1,0 +1,33 @@
+use serde::Deserialize;
+use settings::{Settings, SettingsContent, SettingsKey, WhichKeySettingsContent};
+
+#[derive(Deserialize)]
+pub struct WhichKeySettings {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default = "default_delay_ms")]
+    pub delay_ms: u64,
+}
+
+fn default_delay_ms() -> u64 {
+    700
+}
+
+impl Settings for WhichKeySettings {
+    fn from_settings(content: &SettingsContent) -> Self {
+        let which_key: WhichKeySettingsContent = content.which_key.clone().unwrap_or_default();
+
+        Self {
+            enabled: which_key.enabled.unwrap_or(false),
+            delay_ms: which_key.delay_ms.unwrap_or_else(default_delay_ms),
+        }
+    }
+
+    fn import_from_vscode(_vscode: &settings::VsCodeSettings, _current: &mut SettingsContent) {
+        // No equivalent setting in VScode
+    }
+}
+
+impl SettingsKey for WhichKeySettings {
+    const KEY: Option<&'static str> = Some("which_key");
+}

--- a/crates/which_key/src/which_key_settings.rs
+++ b/crates/which_key/src/which_key_settings.rs
@@ -1,33 +1,18 @@
-use serde::Deserialize;
-use settings::{Settings, SettingsContent, SettingsKey, WhichKeySettingsContent};
+use settings::{RegisterSetting, Settings, SettingsContent, WhichKeySettingsContent};
 
-#[derive(Deserialize)]
+#[derive(Debug, Clone, Copy, RegisterSetting)]
 pub struct WhichKeySettings {
-    #[serde(default)]
     pub enabled: bool,
-    #[serde(default = "default_delay_ms")]
     pub delay_ms: u64,
-}
-
-fn default_delay_ms() -> u64 {
-    700
 }
 
 impl Settings for WhichKeySettings {
     fn from_settings(content: &SettingsContent) -> Self {
-        let which_key: WhichKeySettingsContent = content.which_key.clone().unwrap_or_default();
+        let which_key: &WhichKeySettingsContent = content.which_key.as_ref().unwrap();
 
         Self {
-            enabled: which_key.enabled.unwrap_or(false),
-            delay_ms: which_key.delay_ms.unwrap_or_else(default_delay_ms),
+            enabled: which_key.enabled.unwrap(),
+            delay_ms: which_key.delay_ms.unwrap(),
         }
     }
-
-    fn import_from_vscode(_vscode: &settings::VsCodeSettings, _current: &mut SettingsContent) {
-        // No equivalent setting in VScode
-    }
-}
-
-impl SettingsKey for WhichKeySettings {
-    const KEY: Option<&'static str> = Some("which_key");
 }

--- a/crates/workspace/src/modal_layer.rs
+++ b/crates/workspace/src/modal_layer.rs
@@ -22,12 +22,17 @@ pub trait ModalView: ManagedView {
     fn fade_out_background(&self) -> bool {
         false
     }
+
+    fn render_bare(&self) -> bool {
+        false
+    }
 }
 
 trait ModalViewHandle {
     fn on_before_dismiss(&mut self, window: &mut Window, cx: &mut App) -> DismissDecision;
     fn view(&self) -> AnyView;
     fn fade_out_background(&self, cx: &mut App) -> bool;
+    fn render_bare(&self, cx: &mut App) -> bool;
 }
 
 impl<V: ModalView> ModalViewHandle for Entity<V> {
@@ -41,6 +46,10 @@ impl<V: ModalView> ModalViewHandle for Entity<V> {
 
     fn fade_out_background(&self, cx: &mut App) -> bool {
         self.read(cx).fade_out_background()
+    }
+
+    fn render_bare(&self, cx: &mut App) -> bool {
+        self.read(cx).render_bare()
     }
 }
 
@@ -167,8 +176,12 @@ impl ModalLayer {
 impl Render for ModalLayer {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let Some(active_modal) = &self.active_modal else {
-            return div();
+            return div().into_any_element();
         };
+
+        if active_modal.modal.render_bare(cx) {
+            return active_modal.modal.view().into_any_element();
+        }
 
         div()
             .occlude()
@@ -204,5 +217,6 @@ impl Render for ModalLayer {
                             }),
                     ),
             )
+            .into_any_element()
     }
 }

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -157,6 +157,7 @@ vim_mode_setting.workspace = true
 watch.workspace = true
 web_search.workspace = true
 web_search_providers.workspace = true
+which_key.workspace = true
 workspace.workspace = true
 zed_actions.workspace = true
 zed_env_vars.workspace = true

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -637,6 +637,7 @@ pub fn main() {
         inspector_ui::init(app_state.clone(), cx);
         json_schema_store::init(cx);
         miniprofiler_ui::init(*STARTUP_TIME.get().unwrap(), cx);
+        which_key::init(cx);
 
         cx.observe_global::<SettingsStore>({
             let http = app_state.client.http_client();


### PR DESCRIPTION
Closes #10910

Support parsing extra fields "binding_labels" and "group_labels" under each context stack in _keymap.json_

Release Notes:

- Added customization capability to which-key menu to enabling renaming action name and prefix of the group of actions.
