### PR TITLE
extension_ci: Use more robust bash syntax for `bump_extension_version`

### DIFF
--- a/.github/workflows/extension_bump.yml
+++ b/.github/workflows/extension_bump.yml
@@ -114,15 +114,12 @@ jobs:
       run: |
         OLD_VERSION="${{ needs.check_bump_needed.outputs.current_version }}"
 
-        if [[ -f "extension.toml" ]]; then
-            EXTENSION_TOML="extension.toml"
-        fi
-
+        BUMP_FILES=("extension.toml")
         if [[ -f "Cargo.toml" ]]; then
-            CARGO_TOML="Cargo.toml"
+            BUMP_FILES+=("Cargo.toml")
         fi
 
-        bump2version --verbose --current-version "$OLD_VERSION" --no-configured-files ${{ inputs.bump-type }} "$EXTENSION_TOML" "$CARGO_TOML"
+        bump2version --verbose --current-version "$OLD_VERSION" --no-configured-files ${{ inputs.bump-type }} "${BUMP_FILES[@]}"
 
         if [[ -f "Cargo.toml" ]]; then
             cargo update --workspace

--- a/tooling/xtask/src/tasks/workflows/extension_bump.rs
+++ b/tooling/xtask/src/tasks/workflows/extension_bump.rs
@@ -242,15 +242,12 @@ fn bump_version(current_version: &JobOutput, bump_type: &WorkflowInput) -> (Step
         indoc! {r#"
             OLD_VERSION="{}"
 
-            if [[ -f "extension.toml" ]]; then
-                EXTENSION_TOML="extension.toml"
-            fi
-
+            BUMP_FILES=("extension.toml")
             if [[ -f "Cargo.toml" ]]; then
-                CARGO_TOML="Cargo.toml"
+                BUMP_FILES+=("Cargo.toml")
             fi
 
-            bump2version --verbose --current-version "$OLD_VERSION" --no-configured-files {} "$EXTENSION_TOML" "$CARGO_TOML"
+            bump2version --verbose --current-version "$OLD_VERSION" --no-configured-files {} "${{BUMP_FILES[@]}}"
 
             if [[ -f "Cargo.toml" ]]; then
                 cargo update --workspace


### PR DESCRIPTION
Also does some more cleanup here and there.

Release Notes:

- N/A