### PR TITLE
ci: Supply `github_token` to `bufbuild_setup_action`

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -520,6 +520,7 @@ jobs:
       uses: bufbuild/buf-setup-action@v1
       with:
         version: v1.29.0
+        github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: run_tests::check_postgres_and_protobuf_migrations::bufbuild_breaking_action
       uses: bufbuild/buf-breaking-action@v1
       with:

--- a/tooling/xtask/src/tasks/workflows/run_tests.rs
+++ b/tooling/xtask/src/tasks/workflows/run_tests.rs
@@ -7,7 +7,7 @@ use crate::tasks::workflows::{
     nix_build::build_nix,
     runners::Arch,
     steps::{BASH_SHELL, CommonJobConditions, repository_owner_guard_expression},
-    vars::PathCondition,
+    vars::{self, PathCondition},
 };
 
 use super::{
@@ -353,7 +353,9 @@ pub(crate) fn check_postgres_and_protobuf_migrations() -> NamedJob {
     }
 
     fn bufbuild_setup_action() -> Step<Use> {
-        named::uses("bufbuild", "buf-setup-action", "v1").add_with(("version", "v1.29.0"))
+        named::uses("bufbuild", "buf-setup-action", "v1")
+            .add_with(("version", "v1.29.0"))
+            .add_with(("github_token", vars::GITHUB_TOKEN))
     }
 
     fn bufbuild_breaking_action() -> Step<Use> {


### PR DESCRIPTION
This should hopefully resolve errors like https://github.com/zed-industries/zed/actions/runs/19839788214/job/56845583441

Release Notes:

- N/A
