### PR TITLE
Fix regression in closing project diff

### DIFF
--- a/crates/editor/src/split.rs
+++ b/crates/editor/src/split.rs
@@ -243,20 +243,25 @@ impl Render for SplittableEditor {
         window: &mut ui::Window,
         cx: &mut ui::Context<Self>,
     ) -> impl ui::IntoElement {
-        let Some(active) = self.panes.panes().into_iter().next() else {
-            return div().into_any_element();
+        let inner = if self.secondary.is_none() {
+            self.primary_editor.clone().into_any_element()
+        } else if let Some(active) = self.panes.panes().into_iter().next() {
+            self.panes
+                .render(
+                    None,
+                    &ActivePaneDecorator::new(active, &self.workspace),
+                    window,
+                    cx,
+                )
+                .into_any_element()
+        } else {
+            div().into_any_element()
         };
         div()
             .id("splittable-editor")
             .on_action(cx.listener(Self::split))
             .on_action(cx.listener(Self::unsplit))
             .size_full()
-            .child(self.panes.render(
-                None,
-                &ActivePaneDecorator::new(active, &self.workspace),
-                window,
-                cx,
-            ))
-            .into_any_element()
+            .child(inner)
     }
 }


### PR DESCRIPTION
Follow-up to #43586--when the diff is not split, just render the primary editor. Otherwise the child `Pane` intercepts `CloseActiveItem`. (This is still a bug for the actual split diff, but just fixing the user-visible regression for now.)

Release Notes:

- N/A