### PR TITLE
vim: Fix gj block

### DIFF
--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -2938,11 +2938,12 @@ impl InlayHints {
 
         let position = buffer_handle.read_with(cx, |buffer, _| {
             let position = buffer.clip_point_utf16(point_from_lsp(lsp_hint.position), Bias::Left);
-            if kind == Some(InlayHintKind::Parameter) {
-                buffer.anchor_before(position)
-            } else {
-                buffer.anchor_after(position)
-            }
+            // if kind == Some(InlayHintKind::Parameter) {
+            //     buffer.anchor_before(position)
+            // } else {
+            //     buffer.anchor_after(position)
+            // }
+            buffer.anchor_before(position)
         })?;
         let label = Self::lsp_inlay_label_to_project(lsp_hint.label, server_id)
             .await


### PR DESCRIPTION
The method to reproduce this is as follows: 
Open a Python file, then enable inlay-hint and reduce the width until a character is pushed to the next line. Then try gj, and it will be prevented from moving to the next line.

This is my test code:
```python
####################


def func1(a, b) -> int:
    return a + b


def func2(a, b):
    return a + b


if __name__ == "__main__":
    func2(1, 2)
    aa = func1(1, 4)
    print(aa)
```

Before and after repair comparison


https://github.com/user-attachments/assets/5fa051c7-b081-413c-a2d7-8fe6e0cda823


Release Notes:

- Fix gj block
