### PR TITLE
Add Tailwind CSS support for Gleam

### DIFF
--- a/crates/languages/src/tailwind.rs
+++ b/crates/languages/src/tailwind.rs
@@ -176,6 +176,7 @@ impl LspAdapter for TailwindLspAdapter {
         HashMap::from_iter([
             (LanguageName::new("Astro"), "astro".to_string()),
             (LanguageName::new("HTML"), "html".to_string()),
+            (LanguageName::new("Gleam"), "html".to_string()),
             (LanguageName::new("CSS"), "css".to_string()),
             (LanguageName::new("JavaScript"), "javascript".to_string()),
             (LanguageName::new("TypeScript"), "typescript".to_string()),

--- a/docs/src/languages/tailwindcss.md
+++ b/docs/src/languages/tailwindcss.md
@@ -28,6 +28,7 @@ Languages which can be used with Tailwind CSS in Zed:
 - [Astro](./astro.md)
 - [CSS](./css.md)
 - [ERB](./ruby.md)
+- [Gleam](./gleam.md)
 - [HEEx](./elixir.md#heex)
 - [HTML](./html.md)
 - [TypeScript](./typescript.md)


### PR DESCRIPTION
Currently, Zed does not provide suggestions and validations for Gleam, as it is only available for languages specified in `tailwind.rs`. This pull-request adds Gleam to that list of languages.

After this, if Tailwind is configured to work with Gleam, suggestions and validation appear correctly.

Even after this change, Tailwind will not be able to detect and give suggestions in Gleam directly. Below is the config required for Tailwind classes to be detected in all Gleam strings.


<details><summary>Zed Config for Tailwind detection in Gleam</summary>
<p>

```
{
  "languages": {
    "Gleam": {
      "language_servers": [
        "gleam",
        "tailwindcss-language-server"
      ]
    }
  },
  "lsp": {
    "tailwindcss-language-server": {
      "settings": {
        "experimental": {
          "classRegex": [
            "\"([^\"]*)\""
          ]
        }
      }
    }
  }
}
```

The `classRegex` will match all Gleam strings, making it work seamlessly with Lustre templates and plain string literals.

</p>
</details> 

Release Notes:

- Added support for Tailwind suggestions and validations for the [Gleam programming language](https://gleam.run/).