### PR TITLE
git_ui: Fix utf8 panic in `compress_commit_diff`

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1950,7 +1950,7 @@ impl GitPanel {
             .lines()
             .map(|line| {
                 if line.len() > 256 {
-                    format!("{}...[truncated]\n", &line[..256])
+                    format!("{}...[truncated]\n", &line[..line.floor_char_boundary(256)])
                 } else {
                     format!("{}\n", line)
                 }
@@ -5910,7 +5910,7 @@ mod tests {
 
     #[test]
     fn test_compress_diff_truncate_long_lines() {
-        let long_line = "a".repeat(300);
+        let long_line = "🦀".repeat(300);
         let diff = indoc::formatdoc! {"
             --- a/file.txt
             +++ b/file.txt


### PR DESCRIPTION
Fixes ZED-3QG

Release Notes:

- N/A *or* Added/Fixed/Improved ...
