### PR TITLE
git: Use UI font in commit and blame popovers

### DIFF
--- a/crates/git_ui/src/blame_ui.rs
+++ b/crates/git_ui/src/blame_ui.rs
@@ -198,9 +198,6 @@ impl BlameRenderer for GitBlameRenderer {
         let link_color = cx.theme().colors().text_accent;
         let markdown_style = {
             let mut style = hover_markdown_style(window, cx);
-            if let Some(code_block) = &style.code_block.text {
-                style.base_text_style.refine(code_block);
-            }
             style.link.refine(&TextStyleRefinement {
                 color: Some(link_color),
                 underline: Some(UnderlineStyle {

--- a/crates/git_ui/src/commit_tooltip.rs
+++ b/crates/git_ui/src/commit_tooltip.rs
@@ -197,10 +197,7 @@ impl Render for CommitTooltip {
             time_format::TimestampFormat::MediumAbsolute,
         );
         let markdown_style = {
-            let mut style = hover_markdown_style(window, cx);
-            if let Some(code_block) = &style.code_block.text {
-                style.base_text_style.refine(code_block);
-            }
+            let style = hover_markdown_style(window, cx);
             style
         };
 


### PR DESCRIPTION
Closes #30353

Release Notes:

- Fixed: Hover tooltips in git commit and blame popovers now consistently use the UI font
