### PR TITLE
languages: Initialize Tailwind's options with `includeLanguages`

### DIFF
--- a/crates/languages/src/tailwind.rs
+++ b/crates/languages/src/tailwind.rs
@@ -140,7 +140,7 @@ impl LspAdapter for TailwindLspAdapter {
     ) -> Result<Option<serde_json::Value>> {
         Ok(Some(json!({
             "provideFormatter": true,
-            "userLanguages": {
+            "includeLanguages": {
                 "html": "html",
                 "css": "css",
                 "javascript": "javascript",

--- a/crates/languages/src/tailwind.rs
+++ b/crates/languages/src/tailwind.rs
@@ -140,13 +140,7 @@ impl LspAdapter for TailwindLspAdapter {
     ) -> Result<Option<serde_json::Value>> {
         Ok(Some(json!({
             "provideFormatter": true,
-            "includeLanguages": {
-                "html": "html",
-                "css": "css",
-                "javascript": "javascript",
-                "typescript": "typescript",
-                "typescriptreact": "typescriptreact",
-            },
+
         })))
     }
 
@@ -167,8 +161,18 @@ impl LspAdapter for TailwindLspAdapter {
             tailwind_user_settings["emmetCompletions"] = Value::Bool(true);
         }
 
+        if tailwind_user_settings.get("includeLanguages").is_none() {
+            tailwind_user_settings["includeLanguages"] = json!({
+                "html": "html",
+                "css": "css",
+                "javascript": "javascript",
+                "typescript": "typescript",
+                "typescriptreact": "typescriptreact",
+            });
+        }
+
         Ok(json!({
-            "tailwindCSS": tailwind_user_settings,
+            "tailwindCSS": tailwind_user_settings
         }))
     }
 

--- a/crates/languages/src/tailwind.rs
+++ b/crates/languages/src/tailwind.rs
@@ -140,7 +140,6 @@ impl LspAdapter for TailwindLspAdapter {
     ) -> Result<Option<serde_json::Value>> {
         Ok(Some(json!({
             "provideFormatter": true,
-
         })))
     }
 


### PR DESCRIPTION
Since [this PR](https://github.com/tailwindlabs/tailwindcss-intellisense/pull/1014), the `tailwindCSS.userLanguages` option has been deprecated, and it is recommended to use `tailwindCSS.includeLanguages` instead. Using `tailwindCSS.userLanguages` triggers the warning shown below in the `tailwindcss-language-server` logs.

<img width="634" height="259" alt="tailwindcss-language-server (kron) Server Logs v" src="https://github.com/user-attachments/assets/763551ad-f41a-4756-9d7d-dfb7df45cc5c" />

Release Notes:

- Fixed a warning indicating the deprecation of `tailwindCSS.userLanguages` by initializing the options with `tailwindCSS.includeLanguages`.
