### PR TITLE
lsp: Send client process ID in LSP initialize request

### DIFF
--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -667,7 +667,7 @@ impl LanguageServer {
 
         #[allow(deprecated)]
         InitializeParams {
-            process_id: None,
+            process_id: Some(std::process::id()),
             root_path: None,
             root_uri: Some(self.root_uri.clone()),
             initialization_options: None,


### PR DESCRIPTION
Per the [LSP specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initializeParams), the client should send its process ID to the language server so the server can monitor the client process and shut itself down if the client exits unexpectedly.

Release Notes:

- N/A
