### PR TITLE
collab: Add action to copy room id

### DIFF
--- a/crates/call/src/call_impl/room.rs
+++ b/crates/call/src/call_impl/room.rs
@@ -524,6 +524,16 @@ impl Room {
         self.id
     }
 
+    pub fn room_id(&self) -> impl Future<Output = Option<String>> + 'static {
+        let room = self.live_kit.as_ref().map(|lk| lk.room.clone());
+        async move {
+            let room = room?;
+            let sid = room.sid().await;
+            let name = room.name();
+            Some(format!("{} (sid: {sid})", name))
+        }
+    }
+
     pub fn status(&self) -> RoomStatus {
         self.status
     }

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -37,7 +37,7 @@ use ui::{
 };
 use util::{ResultExt, TryFutureExt, maybe};
 use workspace::{
-    Deafen, LeaveCall, Mute, OpenChannelNotes, ScreenShare, ShareProject, Workspace,
+    CopyRoomId, Deafen, LeaveCall, Mute, OpenChannelNotes, ScreenShare, ShareProject, Workspace,
     dock::{DockPosition, Panel, PanelEvent},
     notifications::{DetachAndPromptErr, NotifyResultExt},
 };
@@ -127,6 +127,31 @@ pub fn init(cx: &mut App) {
         });
         workspace.register_action(|_, _: &LeaveCall, window, cx| {
             CollabPanel::leave_call(window, cx);
+        });
+        workspace.register_action(|workspace, _: &CopyRoomId, window, cx| {
+            use workspace::notifications::{NotificationId, NotifyTaskExt as _};
+
+            struct RoomIdCopiedToast;
+
+            if let Some(room) = ActiveCall::global(cx).read(cx).room() {
+                let romo_id_fut = room.read(cx).room_id();
+                cx.spawn(async move |workspace, cx| {
+                    let room_id = romo_id_fut.await.context("Failed to get livekit room")?;
+                    workspace.update(cx, |workspace, cx| {
+                        cx.write_to_clipboard(ClipboardItem::new_string(room_id));
+                        workspace.show_toast(
+                            workspace::Toast::new(
+                                NotificationId::unique::<RoomIdCopiedToast>(),
+                                "Room ID copied to clipboard",
+                            ),
+                            cx,
+                        );
+                    })
+                })
+                .detach_and_notify_err(window, cx);
+            } else {
+                workspace.show_error(&"No active call. Join one first.", cx);
+            }
         });
         workspace.register_action(|workspace, _: &ShareProject, window, cx| {
             let project = workspace.project().clone();

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -143,14 +143,15 @@ pub fn init(cx: &mut App) {
                             workspace::Toast::new(
                                 NotificationId::unique::<RoomIdCopiedToast>(),
                                 "Room ID copied to clipboard",
-                            ),
+                            )
+                            .autohide(),
                             cx,
                         );
                     })
                 })
                 .detach_and_notify_err(window, cx);
             } else {
-                workspace.show_error(&"No active call. Join one first.", cx);
+                workspace.show_error(&"There’s no active call; join one first.", cx);
             }
         });
         workspace.register_action(|workspace, _: &ShareProject, window, cx| {

--- a/crates/livekit_client/src/livekit_client.rs
+++ b/crates/livekit_client/src/livekit_client.rs
@@ -98,6 +98,14 @@ impl Room {
         self.room.connection_state()
     }
 
+    pub fn name(&self) -> String {
+        self.room.name()
+    }
+
+    pub async fn sid(&self) -> String {
+        self.room.sid().await.to_string()
+    }
+
     pub async fn publish_local_microphone_track(
         &self,
         user_name: String,

--- a/crates/livekit_client/src/test.rs
+++ b/crates/livekit_client/src/test.rs
@@ -714,6 +714,14 @@ impl Room {
         self.0.lock().token.clone()
     }
 
+    pub fn name(&self) -> String {
+        "test_room".to_string()
+    }
+
+    pub async fn sid(&self) -> String {
+        "RM_test_session".to_string()
+    }
+
     pub fn play_remote_audio_track(
         &self,
         _track: &RemoteAudioTrack,

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -7236,7 +7236,9 @@ actions!(
         /// Shares the current project with collaborators.
         ShareProject,
         /// Shares your screen with collaborators.
-        ScreenShare
+        ScreenShare,
+        /// Copies the current room name and session id for debugging purposes.
+        CopyRoomId,
     ]
 );
 actions!(


### PR DESCRIPTION
Adds a `collab: copy room id` action which copies the live kit room name and session ID to the clipboard.

Release Notes:

- N/A
