### PR TITLE
Pin cargo-about to 0.8.2

### DIFF
--- a/script/generate-licenses
+++ b/script/generate-licenses
@@ -28,10 +28,10 @@ echo -n "" >"$OUTPUT_FILE"
 } >>"$OUTPUT_FILE"
 
 if ! cargo about --version | grep "cargo-about $CARGO_ABOUT_VERSION" &>/dev/null; then
-    echo "Installing cargo-about@^$CARGO_ABOUT_VERSION..."
-    cargo install "cargo-about@^$CARGO_ABOUT_VERSION"
+    echo "Installing cargo-about@$CARGO_ABOUT_VERSION..."
+    cargo install "cargo-about@$CARGO_ABOUT_VERSION"
 else
-    echo "cargo-about@^$CARGO_ABOUT_VERSION is already installed."
+    echo "cargo-about@$CARGO_ABOUT_VERSION is already installed."
 fi
 
 echo "Generating cargo licenses"

--- a/script/generate-licenses
+++ b/script/generate-licenses
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-CARGO_ABOUT_VERSION="0.8"
+CARGO_ABOUT_VERSION="0.8.2"
 OUTPUT_FILE="${1:-$(pwd)/assets/licenses.md}"
 TEMPLATE_FILE="script/licenses/template.md.hbs"
 

--- a/script/generate-licenses-csv
+++ b/script/generate-licenses-csv
@@ -7,10 +7,10 @@ OUTPUT_FILE="${1:-$(pwd)/assets/licenses.csv}"
 TEMPLATE_FILE="script/licenses/template.csv.hbs"
 
 if ! cargo about --version | grep "cargo-about $CARGO_ABOUT_VERSION" 2>&1 > /dev/null; then
-  echo "Installing cargo-about@^$CARGO_ABOUT_VERSION..."
-  cargo install "cargo-about@^$CARGO_ABOUT_VERSION"
+  echo "Installing cargo-about@$CARGO_ABOUT_VERSION..."
+  cargo install "cargo-about@$CARGO_ABOUT_VERSION"
 else
-  echo "cargo-about@^$CARGO_ABOUT_VERSION is already installed."
+  echo "cargo-about@$CARGO_ABOUT_VERSION is already installed."
 fi
 
 echo "Generating cargo licenses"

--- a/script/generate-licenses-csv
+++ b/script/generate-licenses-csv
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-CARGO_ABOUT_VERSION="0.8"
+CARGO_ABOUT_VERSION="0.8.2"
 OUTPUT_FILE="${1:-$(pwd)/assets/licenses.csv}"
 TEMPLATE_FILE="script/licenses/template.csv.hbs"
 

--- a/script/generate-licenses.ps1
+++ b/script/generate-licenses.ps1
@@ -1,4 +1,4 @@
-$CARGO_ABOUT_VERSION="0.8"
+$CARGO_ABOUT_VERSION="0.8.2"
 $outputFile=$args[0] ? $args[0] : "$(Get-Location)/assets/licenses.md"
 $templateFile="script/licenses/template.md.hbs"
 

--- a/script/generate-licenses.ps1
+++ b/script/generate-licenses.ps1
@@ -14,10 +14,10 @@ New-Item -Path "$outputFile" -ItemType File -Value "" -Force
 
 $versionOutput = cargo about --version
 if (-not ($versionOutput -match "cargo-about $CARGO_ABOUT_VERSION")) {
-    Write-Host "Installing cargo-about@^$CARGO_ABOUT_VERSION..."
-    cargo install "cargo-about@^$CARGO_ABOUT_VERSION"
+    Write-Host "Installing cargo-about@$CARGO_ABOUT_VERSION..."
+    cargo install "cargo-about@$CARGO_ABOUT_VERSION"
 } else {
-    Write-Host "cargo-about@^$CARGO_ABOUT_VERSION" is already installed
+    Write-Host "cargo-about@$CARGO_ABOUT_VERSION" is already installed
 }
 
 Write-Host "Generating cargo licenses"


### PR DESCRIPTION
cargo-about@0.8.3 doesn't seem to like our license identifiers. Pinning to 0.8.2 for now.

Release Notes:

- N/A 
