### PR TITLE
zed: Promote comment to a doc comment

### DIFF
--- a/crates/zed/src/zed/open_listener.rs
+++ b/crates/zed/src/zed/open_listener.rs
@@ -54,7 +54,7 @@ pub enum OpenRequestKind {
         schema_path: String,
     },
     Setting {
-        // None just opens settings without navigating to a specific path
+        /// `None` opens settings without navigating to a specific path.
         setting_path: Option<String>,
     },
 }


### PR DESCRIPTION
This PR promotes a line comment above a variant member to a doc comment, so that the docs show up on hover.

Release Notes:

- N/A
