### PR TITLE
cli: Enable `--add` option for development builds on macOS

### DIFF
--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -318,6 +318,12 @@ fn main() {
 
     let (open_listener, mut open_rx) = OpenListener::new();
 
+    // Listen for CLI connections via Unix socket
+    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    let socket_bind_failed = crate::zed::listen_for_cli_connections(open_listener.clone()).is_err();
+    #[cfg(target_os = "macos")]
+    crate::zed::listen_for_cli_connections(open_listener.clone()).log_err();
+
     let failed_single_instance_check = if *zed_env_vars::ZED_STATELESS
         || *release_channel::RELEASE_CHANNEL == ReleaseChannel::Dev
     {
@@ -325,7 +331,7 @@ fn main() {
     } else {
         #[cfg(any(target_os = "linux", target_os = "freebsd"))]
         {
-            crate::zed::listen_for_cli_connections(open_listener.clone()).is_err()
+            socket_bind_failed
         }
 
         #[cfg(target_os = "windows")]

--- a/crates/zed/src/zed/open_listener.rs
+++ b/crates/zed/src/zed/open_listener.rs
@@ -248,7 +248,7 @@ impl OpenListener {
     }
 }
 
-#[cfg(any(target_os = "linux", target_os = "freebsd"))]
+#[cfg(unix)]
 pub fn listen_for_cli_connections(opener: OpenListener) -> Result<()> {
     use release_channel::RELEASE_CHANNEL_NAME;
     use std::os::unix::net::UnixDatagram;


### PR DESCRIPTION
When running Zed from a development build (via `--zed ./target/release/zed`), the `--add` CLI option didn't work because the CLI currently would always spawn a new process instead of connecting to an existing instance.

This change extends the Unix socket IPC mechanism (already used on Linux) to macOS, allowing the CLI to connect to a running development build of Zed.

Written with Claude.

Closes #ISSUE

Release Notes:

- Enabled `--add` CLI option for development builds on macOS