### PR TITLE
Make highlighting of C preprocessing directive same as C++

### DIFF
--- a/crates/languages/src/c/highlights.scm
+++ b/crates/languages/src/c/highlights.scm
@@ -36,7 +36,7 @@
   "#ifndef"
   "#include"
   (preproc_directive)
-] @keyword
+] @keyword.directive
 
 [
   "="


### PR DESCRIPTION
Small fix for consistency between C and C++ highlighting. Related to https://github.com/zed-industries/zed/issues/9461

Release Notes:

- Change syntax highlighting for preprocessing directive in C so it can be configured with `keyword.directive` instead of being treated as other `keyword`. The behavior should be like the C++ one now.

<img width="953" height="343" alt="圖片" src="https://github.com/user-attachments/assets/6b45d2cc-323d-44ba-995f-d77996757669" />
