### PR TITLE
language: Remove old unused `HTML/ERB` language ID

### DIFF
--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -283,7 +283,6 @@ pub fn init(languages: Arc<LanguageRegistry>, fs: Arc<dyn Fs>, node: NodeRuntime
         "CSS",
         "ERB",
         "HTML+ERB",
-        "HTML/ERB",
         "HEEX",
         "HTML",
         "JavaScript",

--- a/crates/languages/src/tailwind.rs
+++ b/crates/languages/src/tailwind.rs
@@ -186,7 +186,6 @@ impl LspAdapter for TailwindLspAdapter {
             (LanguageName::new("HEEX"), "phoenix-heex".to_string()),
             (LanguageName::new("ERB"), "erb".to_string()),
             (LanguageName::new("HTML+ERB"), "erb".to_string()),
-            (LanguageName::new("HTML/ERB"), "erb".to_string()),
             (LanguageName::new("PHP"), "php".to_string()),
             (LanguageName::new("Vue.js"), "vue".to_string()),
         ])


### PR DESCRIPTION
The `HTML/ERB` language was renamed
to `HTML+ERB` in https://github.com/zed-industries/zed/pull/40000 We can remove the old name safely now.

Release Notes:

- N/A
