### PR TITLE
gpui: Make HTTP client optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -305,7 +305,7 @@ git_hosting_providers = { path = "crates/git_hosting_providers" }
 git_ui = { path = "crates/git_ui" }
 go_to_line = { path = "crates/go_to_line" }
 google_ai = { path = "crates/google_ai" }
-gpui = { path = "crates/gpui", default-features = false }
+gpui = { path = "crates/gpui", default-features = false, features = ["http-client"] }
 gpui_macros = { path = "crates/gpui_macros" }
 gpui_tokio = { path = "crates/gpui_tokio" }
 html_to_markdown = { path = "crates/html_to_markdown" }

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -17,7 +17,7 @@ categories = ["gui"]
 workspace = true
 
 [features]
-default = ["font-kit", "wayland", "x11", "windows-manifest"]
+default = ["font-kit", "wayland", "x11", "windows-manifest", "http-client"]
 test-support = [
     "leak-detection",
     "collections/test-support",
@@ -79,6 +79,7 @@ screen-capture = [
     "scap",
 ]
 windows-manifest = []
+http-client = ["http_client/client"]
 
 [lib]
 path = "src/gpui.rs"

--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -129,10 +129,16 @@ impl TestAppContext {
         let foreground_executor = ForegroundExecutor::new(arc_dispatcher);
         let platform = TestPlatform::new(background_executor.clone(), foreground_executor.clone());
         let asset_source = Arc::new(());
+        #[cfg(feature = "http-client")]
         let http_client = http_client::FakeHttpClient::with_404_response();
         let text_system = Arc::new(TextSystem::new(platform.text_system()));
 
-        let mut app = App::new_app(platform.clone(), asset_source, http_client);
+        let mut app = App::new_app(
+            platform.clone(),
+            asset_source,
+            #[cfg(feature = "http-client")]
+            http_client,
+        );
         app.borrow_mut().mode = GpuiMode::test();
 
         Self {

--- a/crates/http_client/Cargo.toml
+++ b/crates/http_client/Cargo.toml
@@ -10,10 +10,11 @@ description = "A HTTP client library for Zed and GPUI"
 workspace = true
 
 [features]
+client = ["dep:reqwest"]
 test-support = []
 
 [lib]
-path = "src/http_client.rs"
+path = "src/lib.rs"
 doctest = true
 
 [dependencies]
@@ -28,7 +29,7 @@ http-body.workspace = true
 http.workspace = true
 log.workspace = true
 parking_lot.workspace = true
-reqwest.workspace = true
+reqwest = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
 serde_urlencoded.workspace = true

--- a/crates/http_client/src/http_client.rs
+++ b/crates/http_client/src/http_client.rs
@@ -1,23 +1,19 @@
-mod async_body;
-pub mod github;
-pub mod github_download;
+use std::sync::Arc;
+#[cfg(feature = "test-support")]
+use std::{any::type_name, fmt};
 
-pub use anyhow::{Result, anyhow};
-pub use async_body::{AsyncBody, Inner};
+use anyhow::{Result, anyhow};
 use derive_more::Deref;
-use http::HeaderValue;
-pub use http::{self, Method, Request, Response, StatusCode, Uri, request::Builder};
-
 use futures::{
     FutureExt as _,
     future::{self, BoxFuture},
 };
+use http::{HeaderValue, Method, Request, Response, request::Builder};
 use parking_lot::Mutex;
 use serde::Serialize;
-use std::sync::Arc;
-#[cfg(feature = "test-support")]
-use std::{any::type_name, fmt};
-pub use url::{Host, Url};
+use url::Url;
+
+use crate::AsyncBody;
 
 #[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
 pub enum RedirectPolicy {

--- a/crates/http_client/src/lib.rs
+++ b/crates/http_client/src/lib.rs
@@ -1,0 +1,17 @@
+#[cfg(feature = "client")]
+mod async_body;
+#[cfg(feature = "client")]
+pub mod github;
+#[cfg(feature = "client")]
+pub mod github_download;
+#[cfg(feature = "client")]
+mod http_client;
+
+pub use anyhow::{Result, anyhow};
+pub use http::{self, Method, Request, Response, StatusCode, Uri, request::Builder};
+pub use url::{Host, Url};
+
+#[cfg(feature = "client")]
+pub use crate::async_body::{AsyncBody, Inner};
+#[cfg(feature = "client")]
+pub use crate::http_client::*;

--- a/crates/supermaven_api/Cargo.toml
+++ b/crates/supermaven_api/Cargo.toml
@@ -15,7 +15,7 @@ doctest = false
 [dependencies]
 anyhow.workspace = true
 futures.workspace = true
-http_client.workspace = true
+http_client = { workspace = true, features = ["client"] }
 paths.workspace = true
 serde.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION
Make the Http client optional as a feature.

The `http_client` crate pulls in `tokio`, which is kinda heavy to compile, and not all apps need the ability to fetch, so I make this an optional feature.

Release Notes:

- N/A
