### PR TITLE
Add option to show tab bar inside title bar

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -439,7 +439,10 @@
     // Whether to show the sign in button in the titlebar.
     "show_sign_in": true,
     // Whether to show the menus in the titlebar.
-    "show_menus": false
+    "show_menus": false,
+    // Whether to show the tab bar in the title bar.
+    /// Need to restart for changes to apply
+    "show_tab_bar": false
   },
   "audio": {
     // Opt into the new audio system.

--- a/crates/inspector_ui/src/inspector.rs
+++ b/crates/inspector_ui/src/inspector.rs
@@ -57,7 +57,7 @@ fn render_inspector(
     let ui_font = theme::setup_ui_font(window, cx);
     let colors = cx.theme().colors();
     let inspector_id = inspector.active_element_id();
-    let toolbar_height = PlatformTitleBar::height(window);
+    let toolbar_height = PlatformTitleBar::height(window, None);
 
     v_flex()
         .size_full()

--- a/crates/settings/src/settings_content.rs
+++ b/crates/settings/src/settings_content.rs
@@ -290,6 +290,11 @@ pub struct TitleBarSettingsContent {
     ///
     /// Default: false
     pub show_menus: Option<bool>,
+    /// Whether to show the tab bar in the title bar.
+    /// Need to restart for changes to apply
+    ///
+    /// Default: false
+    pub show_tab_bar: Option<bool>,
 }
 
 /// Configuration of audio in Zed.

--- a/crates/title_bar/src/collab.rs
+++ b/crates/title_bar/src/collab.rs
@@ -155,7 +155,6 @@ impl TitleBar {
 
         h_flex()
             .id("collaborator-list")
-            .w_full()
             .gap_1()
             .overflow_x_scroll()
             .when_some(

--- a/crates/title_bar/src/platform_title_bar.rs
+++ b/crates/title_bar/src/platform_title_bar.rs
@@ -46,7 +46,7 @@ impl PlatformTitleBar {
     }
 
     #[cfg(target_os = "windows")]
-    pub fn height(window: &mut Window, cx: Option<&mut Context<Self>>) -> Pixels {
+    pub fn height(_window: &mut Window, cx: Option<&mut Context<Self>>) -> Pixels {
         if let Some(cx) = cx
             && TitleBarSettings::get_global(cx).show_tab_bar
         {

--- a/crates/title_bar/src/title_bar_settings.rs
+++ b/crates/title_bar/src/title_bar_settings.rs
@@ -9,6 +9,7 @@ pub struct TitleBarSettings {
     pub show_project_items: bool,
     pub show_sign_in: bool,
     pub show_menus: bool,
+    pub show_tab_bar: bool,
 }
 
 impl Settings for TitleBarSettings {
@@ -22,6 +23,7 @@ impl Settings for TitleBarSettings {
             show_project_items: content.show_project_items.unwrap(),
             show_sign_in: content.show_sign_in.unwrap(),
             show_menus: content.show_menus.unwrap(),
+            show_tab_bar: content.show_tab_bar.unwrap(),
         }
     }
 }

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -373,7 +373,7 @@ pub struct Pane {
             &mut Context<Pane>,
         ) -> (Option<AnyElement>, Option<AnyElement>),
     >,
-    render_tab_bar: Rc<dyn Fn(&mut Pane, &mut Window, &mut Context<Pane>) -> AnyElement>,
+    pub render_tab_bar: Rc<dyn Fn(&mut Pane, &mut Window, &mut Context<Pane>) -> AnyElement>,
     show_tab_bar_buttons: bool,
     max_tabs: Option<NonZeroUsize>,
     use_max_tabs: bool,
@@ -3019,7 +3019,7 @@ impl Pane {
             })
     }
 
-    fn render_tab_bar(&mut self, window: &mut Window, cx: &mut Context<Pane>) -> AnyElement {
+    pub fn render_tab_bar(&mut self, window: &mut Window, cx: &mut Context<Pane>) -> AnyElement {
         let focus_handle = self.focus_handle.clone();
         let navigate_backward = IconButton::new("navigate_backward", IconName::ArrowLeft)
             .icon_size(IconSize::Small)

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -4266,7 +4266,8 @@ Run the {#action theme_selector::Toggle} action in the command palette to see a 
   "show_onboarding_banner": true,
   "show_user_picture": true,
   "show_sign_in": true,
-  "show_menus": false
+  "show_menus": false,
+  "show_tab_bar": false
 }
 ```
 

--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -119,7 +119,8 @@ To disable this behavior use:
     "show_onboarding_banner": true, // Show/hide onboarding banners
     "show_user_picture": true,      // Show/hide user avatar
     "show_sign_in": true,           // Show/hide sign-in button
-    "show_menus": false             // Show/hide menus
+    "show_menus": false,            // Show/hide menus
+    "show_tab_bar": false           // Show/hide tab bar on titlebar
   },
 ```
 


### PR DESCRIPTION
Added new setting `title_bar.show_tab_bar` (default: `false`)

When enabled, regular tab bar is hidden and tabs are rendered in title bar. 
Only tabs from the current active pane are shown. 
On macOS, window is made non-movable when tabs are in the title bar to prevent conflicts with drag interactions and requires **application restart** (notification shown to users)

Note: Tested on macOS only

 Demo

https://github.com/user-attachments/assets/2bdf5075-41bd-4c1a-ab3f-5f4250cdc720


Release Notes:

- Added title_bar.show_tab_bar setting to display tab bar inside the title bar
  (https://github.com/zed-industries/zed/issues/5066)
