### PR TITLE
git: Add tree view support to Git Panel

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -870,6 +870,10 @@
     //
     // Default: false
     "collapse_untracked_diff": false,
+    /// Whether to show entries with tree or flat view in the panel
+    ///
+    /// Default: false
+    "tree_view": false,
     "scrollbar": {
       // When to show the scrollbar in the git panel.
       //

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1432,7 +1432,7 @@ impl GitPanel {
                         if let Some(op) = self.bulk_staging.clone()
                             && op.anchor == status_entry.repo_path
                         {
-                            clear_anchor = Some(op.anchor.clone());
+                            clear_anchor = Some(op.anchor);
                         }
                         false
                     } else {
@@ -1447,7 +1447,7 @@ impl GitPanel {
                         if let Some(op) = self.bulk_staging.clone()
                             && op.anchor == status_entry.entry.repo_path
                         {
-                            clear_anchor = Some(op.anchor.clone());
+                            clear_anchor = Some(op.anchor);
                         }
                         false
                     } else {
@@ -3438,7 +3438,7 @@ impl GitPanel {
         flattened
     }
 
-    fn compact_directory_chain<'a>(mut node: &'a TreeNode) -> (&'a TreeNode, SharedString) {
+    fn compact_directory_chain(mut node: &TreeNode) -> (&TreeNode, SharedString) {
         let mut parts = vec![node.name.clone()];
         while node.files.is_empty() && node.children.len() == 1 {
             let Some(child) = node.children.values().next() else {
@@ -4381,7 +4381,6 @@ impl GitPanel {
                                         cx.entity(),
                                         |this, range, _window, _cx| {
                                             range
-                                                .clone()
                                                 .map(|ix| match this.entries.get(ix) {
                                                     Some(GitListEntry::Directory(dir)) => dir.depth,
                                                     Some(GitListEntry::TreeStatus(status)) => {

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -3259,23 +3259,16 @@ impl GitPanel {
         self.tracked_staged_count = 0;
         self.entry_count = 0;
 
-        for git_status in repo.cached_status() {
-            let staging = git_status.status.staging();
-
-            let entry = GitStatusEntry {
-                repo_path: git_status.repo_path.clone(),
-                status: git_status.status,
-                staging,
-            };
+        for status_entry in self.entries.iter().filter_map(|entry| entry.status_entry()) {
             self.entry_count += 1;
+            let is_staging_or_staged = self.is_entry_staged(status_entry, repo);
 
-            let is_staging_or_staged = self.is_entry_staged(&entry, repo);
-            if repo.had_conflict_on_last_merge_head_change(&entry.repo_path) {
+            if repo.had_conflict_on_last_merge_head_change(&status_entry.repo_path) {
                 self.conflicted_count += 1;
                 if is_staging_or_staged {
                     self.conflicted_staged_count += 1;
                 }
-            } else if entry.status.is_created() {
+            } else if status_entry.status.is_created() {
                 self.new_count += 1;
                 if is_staging_or_staged {
                     self.new_staged_count += 1;

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -173,9 +173,9 @@ fn git_panel_context_menu(
             .separator()
             .entry(
                 if state.tree_view {
-                    "Tree View"
-                } else {
                     "Flat View"
+                } else {
+                    "Tree View"
                 },
                 Some(Box::new(ToggleTreeView)),
                 move |window, cx| window.dispatch_action(Box::new(ToggleTreeView), cx),

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -180,15 +180,17 @@ fn git_panel_context_menu(
                 Some(Box::new(ToggleTreeView)),
                 move |window, cx| window.dispatch_action(Box::new(ToggleTreeView), cx),
             )
-            .entry(
-                if state.sort_by_path {
-                    "Sort by Status"
-                } else {
-                    "Sort by Path"
-                },
-                Some(Box::new(ToggleSortByPath)),
-                move |window, cx| window.dispatch_action(Box::new(ToggleSortByPath), cx),
-            )
+            .when(!state.tree_view, |this| {
+                this.entry(
+                    if state.sort_by_path {
+                        "Sort by Status"
+                    } else {
+                        "Sort by Path"
+                    },
+                    Some(Box::new(ToggleSortByPath)),
+                    move |window, cx| window.dispatch_action(Box::new(ToggleSortByPath), cx),
+                )
+            })
     })
 }
 

--- a/crates/git_ui/src/git_panel_settings.rs
+++ b/crates/git_ui/src/git_panel_settings.rs
@@ -24,6 +24,7 @@ pub struct GitPanelSettings {
     pub fallback_branch_name: String,
     pub sort_by_path: bool,
     pub collapse_untracked_diff: bool,
+    pub tree_view: bool,
 }
 
 impl ScrollbarVisibility for GitPanelSettings {
@@ -56,6 +57,7 @@ impl Settings for GitPanelSettings {
             fallback_branch_name: git_panel.fallback_branch_name.unwrap(),
             sort_by_path: git_panel.sort_by_path.unwrap(),
             collapse_untracked_diff: git_panel.collapse_untracked_diff.unwrap(),
+            tree_view: git_panel.tree_view.unwrap(),
         }
     }
 }

--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -644,9 +644,10 @@ impl ProjectDiff {
 }
 
 fn sort_prefix(repo: &Repository, repo_path: &RepoPath, status: FileStatus, cx: &App) -> u64 {
-    // todo! we probably want tree view to only be sorted by tracked sort prefix
-    // ask Anthony more about this
-    if GitPanelSettings::get_global(cx).sort_by_path {
+    let settings = GitPanelSettings::get_global(cx);
+
+    // Tree view can only sort by path
+    if settings.sort_by_path || settings.tree_view {
         TRACKED_SORT_PREFIX
     } else if repo.had_conflict_on_last_merge_head_change(repo_path) {
         CONFLICT_SORT_PREFIX

--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -644,6 +644,8 @@ impl ProjectDiff {
 }
 
 fn sort_prefix(repo: &Repository, repo_path: &RepoPath, status: FileStatus, cx: &App) -> u64 {
+    // todo! we probably want tree view to only be sorted by tracked sort prefix
+    // ask Anthony more about this
     if GitPanelSettings::get_global(cx).sort_by_path {
         TRACKED_SORT_PREFIX
     } else if repo.had_conflict_on_last_merge_head_change(repo_path) {

--- a/crates/settings/src/settings_content.rs
+++ b/crates/settings/src/settings_content.rs
@@ -511,6 +511,11 @@ pub struct GitPanelSettingsContent {
     ///
     /// Default: false
     pub collapse_untracked_diff: Option<bool>,
+
+    /// Whether to show entries with tree or flat view in the panel
+    ///
+    /// Default: false
+    pub tree_view: Option<bool>,
 }
 
 #[derive(

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -4315,6 +4315,24 @@ pub(crate) fn settings_data(cx: &App) -> Vec<SettingsPage> {
                     files: USER,
                 }),
                 SettingsPageItem::SettingItem(SettingItem {
+                    title: "Tree View",
+                    description: "Enable to show entries in tree view list, disable to show in flat view list.",
+                    field: Box::new(SettingField {
+                        json_path: Some("git_panel.tree_view"),
+                        pick: |settings_content| {
+                            settings_content.git_panel.as_ref()?.tree_view.as_ref()
+                        },
+                        write: |settings_content, value| {
+                            settings_content
+                                .git_panel
+                                .get_or_insert_default()
+                                .tree_view = value;
+                        },
+                    }),
+                    metadata: None,
+                    files: USER,
+                }),
+                SettingsPageItem::SettingItem(SettingItem {
                     title: "Scroll Bar",
                     description: "How and when the scrollbar should be displayed.",
                     field: Box::new(SettingField {


### PR DESCRIPTION
Closes #35803

This PR adds tree view support to the git panel UI as an additional setting and moves git entry checkboxes to the right.  Tree view only supports sorting by paths behavior since sorting by status can become noisy, due to having to duplicate directories that have entries with different statuses.

### Tree vs Flat View
<img width="358" height="250" alt="image" src="https://github.com/user-attachments/assets/c6b95d57-12fc-4c5e-8537-ee129963e50c" />
<img width="362" height="152" alt="image" src="https://github.com/user-attachments/assets/0a69e00f-3878-4807-ae45-65e2d54174fc" />


#### Architecture changes

Before this PR, `GitPanel::entries` represented all entries and all visible entries because both sets were equal to one another. However, this equality isn't true for tree view, because entries can be collapsed. To fix this, `TreeState` was added as a logical indices field that is used to filter out non-visible entries. A benefit of this field is that it could be used in the future to implement searching in the GitPanel.

Another significant thing this PR changed was adding a HashMap field `entries_by_indices` on `GitPanel`. We did this because `entry_by_path` used binary search, which becomes overly complicated to implement for tree view. The performance of this function matters because it's a hot code path, so a linear search wasn't ideal either. The solution was using a hash map to improve time complexity from O(log n) to O(1), where n is the count of entries. 

#### Follow-ups
In the future, we could use `ui::ListItem` to render entries in the tree view to improve UI consistency. 
 
Release Notes:

- Added tree view for Git panel. Users are able to switch between Flat and Tree view in Git panel.
