### PR TITLE
Prefer to disable options over hiding (git panel entry context menu)

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -4004,28 +4004,21 @@ impl GitPanel {
             "Restore File"
         };
         let context_menu = ContextMenu::build(window, cx, |context_menu, _, _| {
-            let mut context_menu = context_menu
+            let is_created = entry.status.is_created();
+            context_menu
                 .context(self.focus_handle.clone())
                 .action(stage_title, ToggleStaged.boxed_clone())
-                .action(restore_title, git::RestoreFile::default().boxed_clone());
-
-            if entry.status.is_created() {
-                context_menu =
-                    context_menu.action("Add to .gitignore", git::AddToGitignore.boxed_clone())
-            }
-
-            context_menu = context_menu
+                .action(restore_title, git::RestoreFile::default().boxed_clone())
+                .action_disabled_when(
+                    !is_created,
+                    "Add to .gitignore",
+                    git::AddToGitignore.boxed_clone(),
+                )
                 .separator()
                 .action("Open Diff", Confirm.boxed_clone())
-                .action("Open File", SecondaryConfirm.boxed_clone());
-
-            if !entry.status.is_created() {
-                context_menu = context_menu
-                    .separator()
-                    .action("File History", Box::new(git::FileHistory));
-            }
-
-            context_menu
+                .action("Open File", SecondaryConfirm.boxed_clone())
+                .separator()
+                .action_disabled_when(is_created, "File History", Box::new(git::FileHistory))
         });
         self.selected_entry = Some(ix);
         self.set_context_menu(context_menu, position, window, cx);


### PR DESCRIPTION
When adding the File History option here, I used the pattern to hide the option, since that's what another option was already doing here, but I see other menus in the git panel (`...`) that use disabling over hiding, which is what I think is a nicer experience (allows you to learn of actions, the full range of actions is always visible, don't have to worry about how multiple hidden items might interact in various configurations, etc).

<img width="336" height="241" alt="SCR-20251203-pnpy" src="https://github.com/user-attachments/assets/0da90b9a-c230-4ce3-87b9-553ffb83604f" />

<img width="332" height="265" alt="SCR-20251203-pobg" src="https://github.com/user-attachments/assets/5da95c7d-faa9-4f0f-a069-f1d099f952b9" />


In general, I think it would be good to move to being more consistent with disabling over hiding - there are other places in the app that are hiding - some might be valid, but others might just choices made on a whim.

Release Notes:

- N/A
