### PR TITLE
git: Don't call `git2::Repository::find_remote` for every blamed buffer

### DIFF
--- a/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
+++ b/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
@@ -121,6 +121,8 @@ CREATE TABLE "project_repositories" (
     "merge_message" VARCHAR,
     "branch_summary" VARCHAR,
     "head_commit_details" VARCHAR,
+    "remote_upstream_url" VARCHAR,
+    "remote_origin_url" VARCHAR,
     PRIMARY KEY (project_id, id)
 );
 

--- a/crates/collab/migrations/20251203234258_add_remote_urls_to_project_repositories.sql
+++ b/crates/collab/migrations/20251203234258_add_remote_urls_to_project_repositories.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "project_repositories" ADD COLUMN "remote_upstream_url" VARCHAR;
+ALTER TABLE "project_repositories" ADD COLUMN "remote_origin_url" VARCHAR;

--- a/crates/collab/src/db/queries/projects.rs
+++ b/crates/collab/src/db/queries/projects.rs
@@ -362,6 +362,8 @@ impl Database {
                                 entry_ids: ActiveValue::set("[]".into()),
                                 head_commit_details: ActiveValue::set(None),
                                 merge_message: ActiveValue::set(None),
+                                remote_upstream_url: ActiveValue::set(None),
+                                remote_origin_url: ActiveValue::set(None),
                             }
                         }),
                     )
@@ -511,6 +513,8 @@ impl Database {
                     serde_json::to_string(&update.current_merge_conflicts).unwrap(),
                 )),
                 merge_message: ActiveValue::set(update.merge_message.clone()),
+                remote_upstream_url: ActiveValue::set(update.remote_upstream_url.clone()),
+                remote_origin_url: ActiveValue::set(update.remote_origin_url.clone()),
             })
             .on_conflict(
                 OnConflict::columns([
@@ -1005,6 +1009,8 @@ impl Database {
                         is_last_update: true,
                         merge_message: db_repository_entry.merge_message,
                         stash_entries: Vec::new(),
+                        remote_upstream_url: db_repository_entry.remote_upstream_url.clone(),
+                        remote_origin_url: db_repository_entry.remote_origin_url.clone(),
                     });
                 }
             }

--- a/crates/collab/src/db/queries/rooms.rs
+++ b/crates/collab/src/db/queries/rooms.rs
@@ -796,6 +796,8 @@ impl Database {
                             is_last_update: true,
                             merge_message: db_repository.merge_message,
                             stash_entries: Vec::new(),
+                            remote_upstream_url: db_repository.remote_upstream_url.clone(),
+                            remote_origin_url: db_repository.remote_origin_url.clone(),
                         });
                     }
                 }

--- a/crates/collab/src/db/tables/project_repository.rs
+++ b/crates/collab/src/db/tables/project_repository.rs
@@ -22,6 +22,8 @@ pub struct Model {
     pub branch_summary: Option<String>,
     // A JSON object representing the current Head commit values
     pub head_commit_details: Option<String>,
+    pub remote_upstream_url: Option<String>,
+    pub remote_origin_url: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/collab/src/tests/editor_tests.rs
+++ b/crates/collab/src/tests/editor_tests.rs
@@ -3518,7 +3518,6 @@ async fn test_git_blame_is_forwarded(cx_a: &mut TestAppContext, cx_b: &mut TestA
         .into_iter()
         .map(|(sha, message)| (sha.parse().unwrap(), message.into()))
         .collect(),
-        remote_url: Some("git@github.com:zed-industries/zed.git".to_string()),
     };
     client_a.fs().set_blame_for_repo(
         Path::new(path!("/my-repo/.git")),

--- a/crates/collab/src/tests/editor_tests.rs
+++ b/crates/collab/src/tests/editor_tests.rs
@@ -3602,10 +3602,6 @@ async fn test_git_blame_is_forwarded(cx_a: &mut TestAppContext, cx_b: &mut TestA
             for (idx, (buffer, entry)) in entries.iter().flatten().enumerate() {
                 let details = blame.details_for_entry(*buffer, entry).unwrap();
                 assert_eq!(details.message, format!("message for idx-{}", idx));
-                assert_eq!(
-                    details.permalink.unwrap().to_string(),
-                    format!("https://github.com/zed-industries/zed/commit/{}", entry.sha)
-                );
             }
         });
     });

--- a/crates/git/src/blame.rs
+++ b/crates/git/src/blame.rs
@@ -19,7 +19,6 @@ pub use git2 as libgit;
 pub struct Blame {
     pub entries: Vec<BlameEntry>,
     pub messages: HashMap<Oid, String>,
-    pub remote_url: Option<String>,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -36,7 +35,6 @@ impl Blame {
         working_directory: &Path,
         path: &RepoPath,
         content: &Rope,
-        remote_url: Option<String>,
     ) -> Result<Self> {
         let output = run_git_blame(git_binary, working_directory, path, content).await?;
         let mut entries = parse_git_blame(&output)?;
@@ -53,11 +51,7 @@ impl Blame {
             .await
             .context("failed to get commit messages")?;
 
-        Ok(Self {
-            entries,
-            messages,
-            remote_url,
-        })
+        Ok(Self { entries, messages })
     }
 }
 

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -1473,28 +1473,17 @@ impl GitRepository for RealGitRepository {
         let git_binary_path = self.any_git_binary_path.clone();
         let executor = self.executor.clone();
 
-        async move {
-            let remote_url = if let Some(remote_url) = self.remote_url("upstream").await {
-                Some(remote_url)
-            } else if let Some(remote_url) = self.remote_url("origin").await {
-                Some(remote_url)
-            } else {
-                None
-            };
-            executor
-                .spawn(async move {
-                    crate::blame::Blame::for_path(
-                        &git_binary_path,
-                        &working_directory?,
-                        &path,
-                        &content,
-                        remote_url,
-                    )
-                    .await
-                })
+        executor
+            .spawn(async move {
+                crate::blame::Blame::for_path(
+                    &git_binary_path,
+                    &working_directory?,
+                    &path,
+                    &content,
+                )
                 .await
-        }
-        .boxed()
+            })
+            .boxed()
     }
 
     fn file_history(&self, path: RepoPath) -> BoxFuture<'_, Result<FileHistory>> {

--- a/crates/proto/proto/git.proto
+++ b/crates/proto/proto/git.proto
@@ -124,6 +124,8 @@ message UpdateRepository {
     optional GitCommitDetails head_commit_details = 11;
     optional string merge_message = 12;
     repeated StashEntry stash_entries = 13;
+    optional string remote_upstream_url = 14;
+    optional string remote_origin_url = 15;
 }
 
 message RemoveRepository {
@@ -487,8 +489,8 @@ message BlameBufferResponse {
     message BlameResponse {
         repeated BlameEntry entries = 1;
         repeated CommitMessage messages = 2;
-        optional string remote_url = 4;
         reserved 3;
+        reserved 4;
     }
 
     optional BlameResponse blame_response = 5;


### PR DESCRIPTION
We already store the remote URLs for `origin` and `upstream` in the `RepositorySnapshot`, so just use that data. Follow-up to #44092.

Release Notes:

- N/A