### PR TITLE
linux: Spawn at least two background threads

### DIFF
--- a/crates/gpui/src/platform/linux/dispatcher.rs
+++ b/crates/gpui/src/platform/linux/dispatcher.rs
@@ -26,12 +26,13 @@ pub(crate) struct LinuxDispatcher {
     main_thread_id: thread::ThreadId,
 }
 
+const MIN_THREADS: usize = 2;
+
 impl LinuxDispatcher {
     pub fn new(main_sender: Sender<RunnableVariant>) -> Self {
         let (background_sender, background_receiver) = flume::unbounded::<RunnableVariant>();
-        let thread_count = std::thread::available_parallelism()
-            .map(|i| i.get())
-            .unwrap_or(1);
+        let thread_count =
+            std::thread::available_parallelism().map_or(MIN_THREADS, |i| i.get().max(MIN_THREADS));
 
         let mut background_threads = (0..thread_count)
             .map(|i| {


### PR DESCRIPTION
Related to https://github.com/zed-industries/zed/pull/44109, https://github.com/zed-industries/zed/issues/43884, https://github.com/zed-industries/zed/issues/43809. 

In the Linux dispatcher, we create one background thread per CPU, but when a single core is available, having a single background thread significantly hinders the perceived performance of Zed. This is particularly helpful when SSH remoting to low-resource servers.

We may want to bump this to more than two threads actually, but I wanted to be conservative, and this seems to make a big difference already.

Release Notes:

- N/A
