### PR TITLE
Reduce priority of Windows thread pool work items

### DIFF
--- a/crates/gpui/src/platform/windows/dispatcher.rs
+++ b/crates/gpui/src/platform/windows/dispatcher.rs
@@ -7,9 +7,7 @@ use std::{
 use flume::Sender;
 use util::ResultExt;
 use windows::{
-    System::Threading::{
-        ThreadPool, ThreadPoolTimer, TimerElapsedHandler, WorkItemHandler, WorkItemPriority,
-    },
+    System::Threading::{ThreadPool, ThreadPoolTimer, TimerElapsedHandler, WorkItemHandler},
     Win32::{
         Foundation::{LPARAM, WPARAM},
         UI::WindowsAndMessaging::PostMessageW,
@@ -55,7 +53,7 @@ impl WindowsDispatcher {
                 Ok(())
             })
         };
-        ThreadPool::RunWithPriorityAsync(&handler, WorkItemPriority::High).log_err();
+        ThreadPool::RunAsync(&handler).log_err();
     }
 
     fn dispatch_on_threadpool_after(&self, runnable: RunnableVariant, duration: Duration) {


### PR DESCRIPTION
`WorkItemPriority::High` will enqueue the work items to threads with higher-than-normal priority. If the work items are very intensive, this can cause the system to become unresponsive. It's not clear what this gets us, so let's avoid the responsiveness issue by deleting this.

Release Notes:

- N/A
