### PR TITLE
remote: Recognize WSL interop to open browser for codex web login

### DIFF
--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -1723,6 +1723,10 @@ impl ProtoClient for Client {
     fn is_via_collab(&self) -> bool {
         true
     }
+
+    fn has_wsl_interop(&self) -> bool {
+        false
+    }
 }
 
 /// prefix for the zed:// url scheme

--- a/crates/remote/Cargo.toml
+++ b/crates/remote/Cargo.toml
@@ -43,7 +43,6 @@ urlencoding.workspace = true
 util.workspace = true
 which.workspace = true
 
-
 [dev-dependencies]
 gpui = { workspace = true, features = ["test-support"] }
 fs = { workspace = true, features = ["test-support"] }

--- a/crates/remote/src/transport.rs
+++ b/crates/remote/src/transport.rs
@@ -131,11 +131,7 @@ async fn build_remote_server_from_source(
     let build_remote_server =
         std::env::var("ZED_BUILD_REMOTE_SERVER").unwrap_or("nocompress".into());
 
-    if build_remote_server == "false"
-        || build_remote_server == "no"
-        || build_remote_server == "off"
-        || build_remote_server == "0"
-    {
+    if let "false" | "no" | "off" | "0" = &*build_remote_server {
         return Ok(None);
     }
 

--- a/crates/remote/src/transport/ssh.rs
+++ b/crates/remote/src/transport/ssh.rs
@@ -394,6 +394,10 @@ impl RemoteConnection for SshRemoteConnection {
     fn path_style(&self) -> PathStyle {
         self.ssh_path_style
     }
+
+    fn has_wsl_interop(&self) -> bool {
+        false
+    }
 }
 
 impl SshRemoteConnection {

--- a/crates/rpc/src/proto_client.rs
+++ b/crates/rpc/src/proto_client.rs
@@ -59,6 +59,7 @@ pub trait ProtoClient: Send + Sync {
     fn message_handler_set(&self) -> &parking_lot::Mutex<ProtoMessageHandlerSet>;
 
     fn is_via_collab(&self) -> bool;
+    fn has_wsl_interop(&self) -> bool;
 }
 
 #[derive(Default)]
@@ -509,6 +510,10 @@ impl AnyProtoClient {
                 handle: entity.downgrade().into(),
             },
         );
+    }
+
+    pub fn has_wsl_interop(&self) -> bool {
+        self.0.client.has_wsl_interop()
     }
 }
 


### PR DESCRIPTION
Closes #41521

Release Notes:

- Fixed codex web login not working on wsl remotes if no browser is installed
