### PR TITLE
feat(agent): add allowed_paths setting for file access outside project

### DIFF
--- a/crates/acp_thread/src/connection.rs
+++ b/crates/acp_thread/src/connection.rs
@@ -346,6 +346,7 @@ mod test_support {
                         embedded_context: true,
                         meta: None,
                     }),
+                    Vec::new(),
                     cx,
                 )
             });

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -320,6 +320,7 @@ impl NativeAgent {
                 action_log.clone(),
                 session_id.clone(),
                 prompt_capabilities_rx,
+                Vec::new(),
                 cx,
             )
         });

--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -36,6 +36,7 @@ pub struct AcpConnection {
     agent_capabilities: acp::AgentCapabilities,
     default_mode: Option<acp::SessionModeId>,
     root_dir: PathBuf,
+    allowed_paths: Vec<PathBuf>,
     // NB: Don't move this into the wait_task, since we need to ensure the process is
     // killed on drop (setting kill_on_drop on the command seems to not always work).
     child: smol::process::Child,
@@ -57,6 +58,7 @@ pub async fn connect(
     command: AgentServerCommand,
     root_dir: &Path,
     default_mode: Option<acp::SessionModeId>,
+    allowed_paths: Vec<PathBuf>,
     is_remote: bool,
     cx: &mut AsyncApp,
 ) -> Result<Rc<dyn AgentConnection>> {
@@ -66,6 +68,7 @@ pub async fn connect(
         command.clone(),
         root_dir,
         default_mode,
+        allowed_paths,
         is_remote,
         cx,
     )
@@ -82,6 +85,7 @@ impl AcpConnection {
         command: AgentServerCommand,
         root_dir: &Path,
         default_mode: Option<acp::SessionModeId>,
+        allowed_paths: Vec<PathBuf>,
         is_remote: bool,
         cx: &mut AsyncApp,
     ) -> Result<Self> {
@@ -201,6 +205,7 @@ impl AcpConnection {
         Ok(Self {
             auth_methods: response.auth_methods,
             root_dir: root_dir.to_owned(),
+            allowed_paths,
             connection,
             server_name,
             telemetry_id,
@@ -348,6 +353,7 @@ impl AgentConnection for AcpConnection {
 
             let session_id = response.session_id;
             let action_log = cx.new(|_| ActionLog::new(project.clone()))?;
+            let allowed_paths = self.allowed_paths.clone();
             let thread = cx.new(|cx| {
                 AcpThread::new(
                     self.server_name.clone(),
@@ -357,6 +363,7 @@ impl AgentConnection for AcpConnection {
                     session_id.clone(),
                     // ACP doesn't currently support per-session prompt capabilities or changing capabilities dynamically.
                     watch::Receiver::constant(self.agent_capabilities.prompt_capabilities.clone()),
+                    allowed_paths,
                     cx,
                 )
             })?;

--- a/crates/agent_servers/src/claude.rs
+++ b/crates/agent_servers/src/claude.rs
@@ -68,6 +68,14 @@ impl AgentServer for ClaudeCode {
         let store = delegate.store.downgrade();
         let extra_env = load_proxy_env(cx);
         let default_mode = self.default_mode(cx);
+        let allowed_paths = cx.read_global(|settings: &SettingsStore, _| {
+            settings
+                .get::<AllAgentServersSettings>(None)
+                .claude
+                .as_ref()
+                .map(|s| s.allowed_paths.clone())
+                .unwrap_or_default()
+        });
 
         cx.spawn(async move |cx| {
             let (command, root_dir, login) = store
@@ -90,6 +98,7 @@ impl AgentServer for ClaudeCode {
                 command,
                 root_dir.as_ref(),
                 default_mode,
+                allowed_paths,
                 is_remote,
                 cx,
             )

--- a/crates/agent_servers/src/codex.rs
+++ b/crates/agent_servers/src/codex.rs
@@ -69,6 +69,14 @@ impl AgentServer for Codex {
         let store = delegate.store.downgrade();
         let extra_env = load_proxy_env(cx);
         let default_mode = self.default_mode(cx);
+        let allowed_paths = cx.read_global(|settings: &SettingsStore, _| {
+            settings
+                .get::<AllAgentServersSettings>(None)
+                .codex
+                .as_ref()
+                .map(|s| s.allowed_paths.clone())
+                .unwrap_or_default()
+        });
 
         cx.spawn(async move |cx| {
             let (command, root_dir, login) = store
@@ -92,6 +100,7 @@ impl AgentServer for Codex {
                 command,
                 root_dir.as_ref(),
                 default_mode,
+                allowed_paths,
                 is_remote,
                 cx,
             )

--- a/crates/agent_servers/src/custom.rs
+++ b/crates/agent_servers/src/custom.rs
@@ -73,6 +73,14 @@ impl crate::AgentServer for CustomAgentServer {
         let default_mode = self.default_mode(cx);
         let store = delegate.store.downgrade();
         let extra_env = load_proxy_env(cx);
+        let allowed_paths = cx.read_global(|settings: &SettingsStore, _| {
+            settings
+                .get::<AllAgentServersSettings>(None)
+                .custom
+                .get(&self.name())
+                .map(|s| s.allowed_paths.clone())
+                .unwrap_or_default()
+        });
 
         cx.spawn(async move |cx| {
             let (command, root_dir, login) = store
@@ -97,6 +105,7 @@ impl crate::AgentServer for CustomAgentServer {
                 command,
                 root_dir.as_ref(),
                 default_mode,
+                allowed_paths,
                 is_remote,
                 cx,
             )

--- a/crates/agent_servers/src/e2e_tests.rs
+++ b/crates/agent_servers/src/e2e_tests.rs
@@ -476,6 +476,7 @@ pub async fn init_test(cx: &mut TestAppContext) -> Arc<FakeFs> {
                     env: None,
                     ignore_system_version: None,
                     default_mode: None,
+                    allowed_paths: Vec::new(),
                 }),
                 gemini: Some(crate::gemini::tests::local_command().into()),
                 codex: Some(BuiltinAgentServerSettings {
@@ -484,6 +485,7 @@ pub async fn init_test(cx: &mut TestAppContext) -> Arc<FakeFs> {
                     env: None,
                     ignore_system_version: None,
                     default_mode: None,
+                    allowed_paths: Vec::new(),
                 }),
                 custom: collections::HashMap::default(),
             },

--- a/crates/agent_servers/src/gemini.rs
+++ b/crates/agent_servers/src/gemini.rs
@@ -4,9 +4,10 @@ use std::{any::Any, path::Path};
 use crate::{AgentServer, AgentServerDelegate, load_proxy_env};
 use acp_thread::AgentConnection;
 use anyhow::{Context as _, Result};
-use gpui::{App, SharedString, Task};
+use gpui::{App, AppContext as _, SharedString, Task};
 use language_models::provider::google::GoogleLanguageModelProvider;
-use project::agent_server_store::GEMINI_NAME;
+use project::agent_server_store::{AllAgentServersSettings, GEMINI_NAME};
+use settings::SettingsStore;
 
 #[derive(Clone)]
 pub struct Gemini;
@@ -37,6 +38,14 @@ impl AgentServer for Gemini {
         let store = delegate.store.downgrade();
         let mut extra_env = load_proxy_env(cx);
         let default_mode = self.default_mode(cx);
+        let allowed_paths = cx.read_global(|settings: &SettingsStore, _| {
+            settings
+                .get::<AllAgentServersSettings>(None)
+                .gemini
+                .as_ref()
+                .map(|s| s.allowed_paths.clone())
+                .unwrap_or_default()
+        });
 
         cx.spawn(async move |cx| {
             extra_env.insert("SURFACE".to_owned(), "zed".to_owned());
@@ -69,6 +78,7 @@ impl AgentServer for Gemini {
                 command,
                 root_dir.as_ref(),
                 default_mode,
+                allowed_paths,
                 is_remote,
                 cx,
             )

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -6413,6 +6413,7 @@ pub(crate) mod tests {
                         embedded_context: true,
                         meta: None,
                     }),
+                    Vec::new(),
                     cx,
                 )
             })))
@@ -6477,6 +6478,7 @@ pub(crate) mod tests {
                         embedded_context: true,
                         meta: None,
                     }),
+                    Vec::new(),
                     cx,
                 )
             })))

--- a/crates/agent_ui/src/agent_configuration.rs
+++ b/crates/agent_ui/src/agent_configuration.rs
@@ -1226,6 +1226,7 @@ async fn open_new_agent_servers_entry_in_settings_editor(
                                 args: vec![],
                                 env: Some(HashMap::default()),
                                 default_mode: None,
+                                allowed_paths: None,
                             },
                         );
                 }

--- a/crates/project/src/agent_server_store.rs
+++ b/crates/project/src/agent_server_store.rs
@@ -1632,6 +1632,7 @@ pub struct BuiltinAgentServerSettings {
     pub env: Option<HashMap<String, String>>,
     pub ignore_system_version: Option<bool>,
     pub default_mode: Option<String>,
+    pub allowed_paths: Vec<PathBuf>,
 }
 
 impl BuiltinAgentServerSettings {
@@ -1654,6 +1655,12 @@ impl From<settings::BuiltinAgentServerSettings> for BuiltinAgentServerSettings {
             env: value.env,
             ignore_system_version: value.ignore_system_version,
             default_mode: value.default_mode,
+            allowed_paths: value
+                .allowed_paths
+                .unwrap_or_default()
+                .into_iter()
+                .map(|p| PathBuf::from(shellexpand::tilde(&p.to_string_lossy()).as_ref()))
+                .collect(),
         }
     }
 }
@@ -1664,7 +1671,9 @@ impl From<AgentServerCommand> for BuiltinAgentServerSettings {
             path: Some(value.path),
             args: Some(value.args),
             env: value.env,
-            ..Default::default()
+            ignore_system_version: None,
+            default_mode: None,
+            allowed_paths: Vec::new(),
         }
     }
 }
@@ -1678,6 +1687,7 @@ pub struct CustomAgentServerSettings {
     ///
     /// Default: None
     pub default_mode: Option<String>,
+    pub allowed_paths: Vec<PathBuf>,
 }
 
 impl From<settings::CustomAgentServerSettings> for CustomAgentServerSettings {
@@ -1689,6 +1699,12 @@ impl From<settings::CustomAgentServerSettings> for CustomAgentServerSettings {
                 env: value.env,
             },
             default_mode: value.default_mode,
+            allowed_paths: value
+                .allowed_paths
+                .unwrap_or_default()
+                .into_iter()
+                .map(|p| PathBuf::from(shellexpand::tilde(&p.to_string_lossy()).as_ref()))
+                .collect(),
         }
     }
 }
@@ -2006,6 +2022,7 @@ mod extension_agent_tests {
             env: None,
             ignore_system_version: None,
             default_mode: None,
+            allowed_paths: None,
         };
 
         let BuiltinAgentServerSettings { path, .. } = settings.into();
@@ -2021,6 +2038,7 @@ mod extension_agent_tests {
             args: vec!["serve".into()],
             env: None,
             default_mode: None,
+            allowed_paths: None,
         };
 
         let CustomAgentServerSettings {

--- a/crates/settings/src/settings_content/agent.rs
+++ b/crates/settings/src/settings_content/agent.rs
@@ -332,6 +332,15 @@ pub struct BuiltinAgentServerSettings {
     ///
     /// Default: None
     pub default_mode: Option<String>,
+    /// Additional paths outside the project that this agent can read and write.
+    ///
+    /// Each path acts as a prefix - specifying "~/.claude" allows access to
+    /// "~/.claude/plans", "~/.claude/configs", etc.
+    /// More specific paths restrict access: "~/.claude/plans" only allows
+    /// that folder and its subfolders.
+    ///
+    /// Default: []
+    pub allowed_paths: Option<Vec<PathBuf>>,
 }
 
 #[skip_serializing_none]
@@ -348,4 +357,13 @@ pub struct CustomAgentServerSettings {
     ///
     /// Default: None
     pub default_mode: Option<String>,
+    /// Additional paths outside the project that this agent can read and write.
+    ///
+    /// Each path acts as a prefix - specifying "~/.claude" allows access to
+    /// "~/.claude/plans", "~/.claude/configs", etc.
+    /// More specific paths restrict access: "~/.claude/plans" only allows
+    /// that folder and its subfolders.
+    ///
+    /// Default: []
+    pub allowed_paths: Option<Vec<PathBuf>>,
 }


### PR DESCRIPTION
This PR resolves an issue that happens with claude code when trying to use their plan mode: The agent sometimes can write to `~/.claude/plans` and sometimes cant. This PR adds a new setting that allows users to enable access to folders outside of the projects directory.

```json
  "agent_servers": {
    "claude": {
      "allowed_paths": ["~/.claude"]
    }
  }
```

I also added tests for folders that are allowed outside of project, for those that arent, and for those that have similar names (/open and /open_backup).

I explicitly added the checks after the inital check for the worktree/project access.

Would be happy for any feedback.

Closes #37620 (partially)

Release Notes:

- Added `allowed_paths` setting to external agents to permit claude code to write plans.
