### PR TITLE
gpui: Fix division by zero crash

### DIFF
--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -1419,7 +1419,7 @@ impl Dispatch<wl_keyboard::WlKeyboard, ()> for WaylandClientStatePtr {
                         state.repeat.current_keycode = Some(keycode);
 
                         let rate = state.repeat.characters_per_second;
-                        let repeat_interval = Duration::from_secs(1) / rate;
+                        let repeat_interval = Duration::from_secs(1) / rate.max(1);
                         let id = state.repeat.current_id;
                         state
                             .loop_handle


### PR DESCRIPTION
Closes #44148

the existing rate == 0 check inside the timer callback already handles disabling repeat - it just drops the timer immediately. So the fix prevents the crash while preserving correct behavior. This is my first contribution, so if it is not the right solution all feedback is appreciated

Release Notes:

- Linux (Wayland): Fixed a crash that could occur when `characters_per_second` was zero
