### PR TITLE
agent: Add allowed_paths setting for file access outside project (Claude Code planning issue)

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -32,7 +32,12 @@ use std::ops::Range;
 use std::process::ExitStatus;
 use std::rc::Rc;
 use std::time::{Duration, Instant};
-use std::{fmt::Display, mem, path::PathBuf, sync::Arc};
+use std::{
+    fmt::Display,
+    mem,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 use ui::App;
 use util::{ResultExt, get_default_system_shell_preferring_bash, paths::PathStyle};
 use uuid::Uuid;
@@ -838,6 +843,7 @@ pub struct AcpThread {
     terminals: HashMap<acp::TerminalId, Entity<Terminal>>,
     pending_terminal_output: HashMap<acp::TerminalId, Vec<Vec<u8>>>,
     pending_terminal_exit: HashMap<acp::TerminalId, acp::TerminalExitStatus>,
+    allowed_paths: Vec<PathBuf>,
 }
 
 impl From<&AcpThread> for ActionLogTelemetry {
@@ -1039,6 +1045,7 @@ impl AcpThread {
         action_log: Entity<ActionLog>,
         session_id: acp::SessionId,
         mut prompt_capabilities_rx: watch::Receiver<acp::PromptCapabilities>,
+        allowed_paths: Vec<PathBuf>,
         cx: &mut Context<Self>,
     ) -> Self {
         let prompt_capabilities = prompt_capabilities_rx.borrow().clone();
@@ -1068,11 +1075,18 @@ impl AcpThread {
             terminals: HashMap::default(),
             pending_terminal_output: HashMap::default(),
             pending_terminal_exit: HashMap::default(),
+            allowed_paths,
         }
     }
 
     pub fn prompt_capabilities(&self) -> acp::PromptCapabilities {
         self.prompt_capabilities.clone()
+    }
+
+    pub fn is_path_allowed(&self, path: &Path) -> bool {
+        self.allowed_paths
+            .iter()
+            .any(|allowed| path.starts_with(allowed))
     }
 
     pub fn connection(&self) -> &Rc<dyn AgentConnection> {
@@ -2022,17 +2036,23 @@ impl AcpThread {
         let project = self.project.clone();
         let action_log = self.action_log.clone();
         cx.spawn(async move |this, cx| {
-            let load = project
-                .update(cx, |project, cx| {
-                    let path = project
-                        .project_path_for_absolute_path(&path, cx)
-                        .ok_or_else(|| {
-                            acp::Error::resource_not_found(Some(path.display().to_string()))
-                        })?;
-                    Ok(project.open_buffer(path, cx))
-                })
-                .map_err(|e| acp::Error::internal_error().data(e.to_string()))
-                .flatten()?;
+            let project_path = project.read_with(cx, |project, cx| {
+                project.project_path_for_absolute_path(&path, cx)
+            })?;
+
+            let load = if let Some(project_path) = project_path {
+                project.update(cx, |project, cx| project.open_buffer(project_path, cx))?
+            } else {
+                let is_allowed_outside_project =
+                    this.read_with(cx, |this, _| this.is_path_allowed(&path))?;
+                if !is_allowed_outside_project {
+                    return Err(acp::Error::resource_not_found(Some(format!(
+                        "Path {} is outside the project and not in allowed_paths",
+                        path.display()
+                    ))));
+                }
+                project.update(cx, |project, cx| project.open_local_buffer(&path, cx))?
+            };
 
             let buffer = load.await?;
 
@@ -2097,13 +2117,29 @@ impl AcpThread {
         let project = self.project.clone();
         let action_log = self.action_log.clone();
         cx.spawn(async move |this, cx| {
-            let load = project.update(cx, |project, cx| {
-                let path = project
-                    .project_path_for_absolute_path(&path, cx)
-                    .context("invalid path")?;
-                anyhow::Ok(project.open_buffer(path, cx))
-            });
-            let buffer = load??.await?;
+            let project_path = project.read_with(cx, |project, cx| {
+                project.project_path_for_absolute_path(&path, cx)
+            })?;
+
+            let buffer = if let Some(project_path) = project_path {
+                project
+                    .update(cx, |project, cx| project.open_buffer(project_path, cx))?
+                    .await?
+            } else {
+                let is_allowed_outside_project =
+                    this.read_with(cx, |this, _| this.is_path_allowed(&path))?;
+                if !is_allowed_outside_project {
+                    return Err(acp::Error::resource_not_found(Some(format!(
+                        "Path {} is outside the project and not in allowed_paths",
+                        path.display()
+                    )))
+                    .into());
+                }
+
+                project
+                    .update(cx, |project, cx| project.open_local_buffer(&path, cx))?
+                    .await?
+            };
             let snapshot = this.update(cx, |this, cx| {
                 this.shared_buffers
                     .get(&buffer)
@@ -2938,6 +2974,268 @@ mod tests {
     }
 
     #[gpui::test]
+    async fn test_allowed_paths_empty_only_project_accessible(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            path!("/"),
+            json!({
+                "project": {
+                    "file.txt": "project content"
+                },
+                "external": {
+                    "file.txt": "external content"
+                }
+            }),
+        )
+        .await;
+
+        let project = Project::test(fs.clone(), [], cx).await;
+        project
+            .update(cx, |project, cx| {
+                project.find_or_create_worktree(path!("/project"), true, cx)
+            })
+            .await
+            .unwrap();
+
+        let connection = Rc::new(FakeAgentConnection::new());
+
+        let thread = cx
+            .update(|cx| connection.new_thread(project, Path::new(path!("/project")), cx))
+            .await
+            .unwrap();
+
+        let content = thread
+            .update(cx, |thread, cx| {
+                thread.read_text_file(path!("/project/file.txt").into(), None, None, false, cx)
+            })
+            .await
+            .unwrap();
+        assert_eq!(content, "project content");
+
+        let err = thread
+            .update(cx, |thread, cx| {
+                thread.read_text_file(path!("/external/file.txt").into(), None, None, false, cx)
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(err.code, acp::ErrorCode::RESOURCE_NOT_FOUND.code);
+    }
+
+    #[gpui::test]
+    async fn test_allowed_paths_claude_folder_accessible(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            path!("/"),
+            json!({
+                "project": {
+                    "file.txt": "project content"
+                },
+                "home": {
+                    ".claude": {
+                        "plans": {
+                            "plan.md": "# My Plan"
+                        }
+                    }
+                }
+            }),
+        )
+        .await;
+
+        let project = Project::test(fs.clone(), [], cx).await;
+        project
+            .update(cx, |project, cx| {
+                project.find_or_create_worktree(path!("/project"), true, cx)
+            })
+            .await
+            .unwrap();
+
+        let connection = Rc::new(
+            FakeAgentConnection::new().with_allowed_paths(vec![path!("/home/.claude").into()]),
+        );
+
+        let thread = cx
+            .update(|cx| connection.new_thread(project, Path::new(path!("/project")), cx))
+            .await
+            .unwrap();
+
+        let content = thread
+            .update(cx, |thread, cx| {
+                thread.read_text_file(path!("/project/file.txt").into(), None, None, false, cx)
+            })
+            .await
+            .unwrap();
+        assert_eq!(content, "project content");
+
+        let content = thread
+            .update(cx, |thread, cx| {
+                thread.read_text_file(
+                    path!("/home/.claude/plans/plan.md").into(),
+                    None,
+                    None,
+                    false,
+                    cx,
+                )
+            })
+            .await
+            .unwrap();
+        assert_eq!(content, "# My Plan");
+    }
+
+    #[gpui::test]
+    async fn test_allowed_paths_prefix_restriction(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            path!("/"),
+            json!({
+                "project": {
+                    "file.txt": "project content"
+                },
+                "home": {
+                    ".claude": {
+                        "open": {
+                            "test.txt": "open content"
+                        },
+                        "closed": {
+                            "test.txt": "closed content"
+                        }
+                    }
+                }
+            }),
+        )
+        .await;
+
+        let project = Project::test(fs.clone(), [], cx).await;
+        project
+            .update(cx, |project, cx| {
+                project.find_or_create_worktree(path!("/project"), true, cx)
+            })
+            .await
+            .unwrap();
+
+        let connection = Rc::new(
+            FakeAgentConnection::new().with_allowed_paths(vec![path!("/home/.claude/open").into()]),
+        );
+
+        let thread = cx
+            .update(|cx| connection.new_thread(project, Path::new(path!("/project")), cx))
+            .await
+            .unwrap();
+
+        let content = thread
+            .update(cx, |thread, cx| {
+                thread.read_text_file(path!("/project/file.txt").into(), None, None, false, cx)
+            })
+            .await
+            .unwrap();
+        assert_eq!(content, "project content");
+
+        let content = thread
+            .update(cx, |thread, cx| {
+                thread.read_text_file(
+                    path!("/home/.claude/open/test.txt").into(),
+                    None,
+                    None,
+                    false,
+                    cx,
+                )
+            })
+            .await
+            .unwrap();
+        assert_eq!(content, "open content");
+
+        let err = thread
+            .update(cx, |thread, cx| {
+                thread.read_text_file(
+                    path!("/home/.claude/closed/test.txt").into(),
+                    None,
+                    None,
+                    false,
+                    cx,
+                )
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(err.code, acp::ErrorCode::RESOURCE_NOT_FOUND.code);
+    }
+
+    #[gpui::test]
+    async fn test_allowed_paths_same_start_directory_bypass_prevented(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            path!("/"),
+            json!({
+                "project": {
+                    "file.txt": "project content"
+                },
+                "home": {
+                    ".claude": {
+                        "open": {
+                            "test.txt": "open content"
+                        },
+                        "open_backup": {
+                            "test.txt": "backup content"
+                        }
+                    }
+                }
+            }),
+        )
+        .await;
+
+        let project = Project::test(fs.clone(), [], cx).await;
+        project
+            .update(cx, |project, cx| {
+                project.find_or_create_worktree(path!("/project"), true, cx)
+            })
+            .await
+            .unwrap();
+
+        let connection = Rc::new(
+            FakeAgentConnection::new().with_allowed_paths(vec![path!("/home/.claude/open").into()]),
+        );
+
+        let thread = cx
+            .update(|cx| connection.new_thread(project, Path::new(path!("/project")), cx))
+            .await
+            .unwrap();
+
+        let content = thread
+            .update(cx, |thread, cx| {
+                thread.read_text_file(
+                    path!("/home/.claude/open/test.txt").into(),
+                    None,
+                    None,
+                    false,
+                    cx,
+                )
+            })
+            .await
+            .unwrap();
+        assert_eq!(content, "open content");
+
+        let err = thread
+            .update(cx, |thread, cx| {
+                thread.read_text_file(
+                    path!("/home/.claude/open_backup/test.txt").into(),
+                    None,
+                    None,
+                    false,
+                    cx,
+                )
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(err.code, acp::ErrorCode::RESOURCE_NOT_FOUND.code);
+    }
+
+    #[gpui::test]
     async fn test_succeeding_canceled_toolcall(cx: &mut TestAppContext) {
         init_test(cx);
 
@@ -3518,6 +3816,7 @@ mod tests {
     #[derive(Clone, Default)]
     struct FakeAgentConnection {
         auth_methods: Vec<acp::AuthMethod>,
+        allowed_paths: Vec<PathBuf>,
         sessions: Arc<parking_lot::Mutex<HashMap<acp::SessionId, WeakEntity<AcpThread>>>>,
         on_user_message: Option<
             Rc<
@@ -3535,6 +3834,7 @@ mod tests {
         fn new() -> Self {
             Self {
                 auth_methods: Vec::new(),
+                allowed_paths: Vec::new(),
                 on_user_message: None,
                 sessions: Arc::default(),
             }
@@ -3543,6 +3843,11 @@ mod tests {
         #[expect(unused)]
         fn with_auth_methods(mut self, auth_methods: Vec<acp::AuthMethod>) -> Self {
             self.auth_methods = auth_methods;
+            self
+        }
+
+        fn with_allowed_paths(mut self, allowed_paths: Vec<PathBuf>) -> Self {
+            self.allowed_paths = allowed_paths;
             self
         }
 
@@ -3583,6 +3888,7 @@ mod tests {
                     .collect::<String>(),
             );
             let action_log = cx.new(|_| ActionLog::new(project.clone()));
+            let allowed_paths = self.allowed_paths.clone();
             let thread = cx.new(|cx| {
                 AcpThread::new(
                     "Test",
@@ -3596,6 +3902,7 @@ mod tests {
                             .audio(true)
                             .embedded_context(true),
                     ),
+                    allowed_paths,
                     cx,
                 )
             });

--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -3027,7 +3027,7 @@ mod tests {
             })
             .await
             .unwrap_err();
-        assert_eq!(err.code, acp::ErrorCode::RESOURCE_NOT_FOUND.code);
+        assert_eq!(err.code, acp::ErrorCode::ResourceNotFound);
     }
 
     #[gpui::test]
@@ -3168,7 +3168,7 @@ mod tests {
             })
             .await
             .unwrap_err();
-        assert_eq!(err.code, acp::ErrorCode::RESOURCE_NOT_FOUND.code);
+        assert_eq!(err.code, acp::ErrorCode::ResourceNotFound);
     }
 
     #[gpui::test]
@@ -3239,7 +3239,7 @@ mod tests {
             })
             .await
             .unwrap_err();
-        assert_eq!(err.code, acp::ErrorCode::RESOURCE_NOT_FOUND.code);
+        assert_eq!(err.code, acp::ErrorCode::ResourceNotFound);
     }
 
     #[gpui::test]
@@ -3310,7 +3310,7 @@ mod tests {
             })
             .await
             .unwrap_err();
-        assert_eq!(err.code, acp::ErrorCode::RESOURCE_NOT_FOUND.code);
+        assert_eq!(err.code, acp::ErrorCode::ResourceNotFound);
     }
 
     #[gpui::test]

--- a/crates/acp_thread/src/connection.rs
+++ b/crates/acp_thread/src/connection.rs
@@ -351,6 +351,7 @@ mod test_support {
                             .audio(true)
                             .embedded_context(true),
                     ),
+                    Vec::new(),
                     cx,
                 )
             });

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -318,6 +318,7 @@ impl NativeAgent {
                 action_log.clone(),
                 session_id.clone(),
                 prompt_capabilities_rx,
+                Vec::new(),
                 cx,
             )
         });

--- a/crates/agent_servers/src/claude.rs
+++ b/crates/agent_servers/src/claude.rs
@@ -85,6 +85,14 @@ impl AgentServer for ClaudeCode {
         let extra_env = load_proxy_env(cx);
         let default_mode = self.default_mode(cx);
         let default_model = self.default_model(cx);
+        let allowed_paths = cx.read_global(|settings: &SettingsStore, _| {
+            settings
+                .get::<AllAgentServersSettings>(None)
+                .claude
+                .as_ref()
+                .map(|s| s.allowed_paths.clone())
+                .unwrap_or_default()
+        });
 
         cx.spawn(async move |cx| {
             let (command, root_dir, login) = store
@@ -107,6 +115,7 @@ impl AgentServer for ClaudeCode {
                 root_dir.as_ref(),
                 default_mode,
                 default_model,
+                allowed_paths,
                 is_remote,
                 cx,
             )

--- a/crates/agent_servers/src/codex.rs
+++ b/crates/agent_servers/src/codex.rs
@@ -86,6 +86,14 @@ impl AgentServer for Codex {
         let extra_env = load_proxy_env(cx);
         let default_mode = self.default_mode(cx);
         let default_model = self.default_model(cx);
+        let allowed_paths = cx.read_global(|settings: &SettingsStore, _| {
+            settings
+                .get::<AllAgentServersSettings>(None)
+                .codex
+                .as_ref()
+                .map(|s| s.allowed_paths.clone())
+                .unwrap_or_default()
+        });
 
         cx.spawn(async move |cx| {
             let (command, root_dir, login) = store
@@ -109,6 +117,7 @@ impl AgentServer for Codex {
                 root_dir.as_ref(),
                 default_mode,
                 default_model,
+                allowed_paths,
                 is_remote,
                 cx,
             )

--- a/crates/agent_servers/src/e2e_tests.rs
+++ b/crates/agent_servers/src/e2e_tests.rs
@@ -460,6 +460,7 @@ pub async fn init_test(cx: &mut TestAppContext) -> Arc<FakeFs> {
                     ignore_system_version: None,
                     default_mode: None,
                     default_model: None,
+                    allowed_paths: Vec::new(),
                 }),
                 gemini: Some(crate::gemini::tests::local_command().into()),
                 codex: Some(BuiltinAgentServerSettings {
@@ -469,6 +470,7 @@ pub async fn init_test(cx: &mut TestAppContext) -> Arc<FakeFs> {
                     ignore_system_version: None,
                     default_mode: None,
                     default_model: None,
+                    allowed_paths: Vec::new(),
                 }),
                 custom: collections::HashMap::default(),
             },

--- a/crates/agent_servers/src/gemini.rs
+++ b/crates/agent_servers/src/gemini.rs
@@ -4,9 +4,10 @@ use std::{any::Any, path::Path};
 use crate::{AgentServer, AgentServerDelegate, load_proxy_env};
 use acp_thread::AgentConnection;
 use anyhow::{Context as _, Result};
-use gpui::{App, SharedString, Task};
+use gpui::{App, AppContext as _, SharedString, Task};
 use language_models::provider::google::GoogleLanguageModelProvider;
-use project::agent_server_store::GEMINI_NAME;
+use project::agent_server_store::{AllAgentServersSettings, GEMINI_NAME};
+use settings::SettingsStore;
 
 #[derive(Clone)]
 pub struct Gemini;
@@ -33,6 +34,14 @@ impl AgentServer for Gemini {
         let mut extra_env = load_proxy_env(cx);
         let default_mode = self.default_mode(cx);
         let default_model = self.default_model(cx);
+        let allowed_paths = cx.read_global(|settings: &SettingsStore, _| {
+            settings
+                .get::<AllAgentServersSettings>(None)
+                .gemini
+                .as_ref()
+                .map(|s| s.allowed_paths.clone())
+                .unwrap_or_default()
+        });
 
         cx.spawn(async move |cx| {
             extra_env.insert("SURFACE".to_owned(), "zed".to_owned());
@@ -65,6 +74,7 @@ impl AgentServer for Gemini {
                 root_dir.as_ref(),
                 default_mode,
                 default_model,
+                allowed_paths,
                 is_remote,
                 cx,
             )

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -6522,6 +6522,7 @@ pub(crate) mod tests {
                             .audio(true)
                             .embedded_context(true),
                     ),
+                    Vec::new(),
                     cx,
                 )
             })))
@@ -6586,6 +6587,7 @@ pub(crate) mod tests {
                             .audio(true)
                             .embedded_context(true),
                     ),
+                    Vec::new(),
                     cx,
                 )
             })))

--- a/crates/agent_ui/src/agent_configuration.rs
+++ b/crates/agent_ui/src/agent_configuration.rs
@@ -1365,6 +1365,7 @@ async fn open_new_agent_servers_entry_in_settings_editor(
                                 env: Some(HashMap::default()),
                                 default_mode: None,
                                 default_model: None,
+                                allowed_paths: None,
                             },
                         );
                 }

--- a/crates/project/src/agent_server_store.rs
+++ b/crates/project/src/agent_server_store.rs
@@ -1931,6 +1931,11 @@ pub enum CustomAgentServerSettings {
         /// Default: None
         default_model: Option<String>,
         /// Additional paths outside the project that this agent can read and write.
+        ///
+        /// Example:
+        ///   - ~/.claude/plans
+        ///
+        /// Default: None
         allowed_paths: Vec<PathBuf>,
     },
     Extension {

--- a/crates/settings/src/settings_content/agent.rs
+++ b/crates/settings/src/settings_content/agent.rs
@@ -337,6 +337,15 @@ pub struct BuiltinAgentServerSettings {
     ///
     /// Default: None
     pub default_model: Option<String>,
+    /// Additional paths outside the project that this agent can read and write.
+    ///
+    /// Each path acts as a prefix - specifying "~/.claude" allows access to
+    /// "~/.claude/plans", "~/.claude/configs", etc.
+    /// More specific paths restrict access: "~/.claude/plans" only allows
+    /// that folder and its subfolders.
+    ///
+    /// Default: []
+    pub allowed_paths: Option<Vec<PathBuf>>,
 }
 
 #[with_fallible_options]
@@ -361,6 +370,15 @@ pub enum CustomAgentServerSettings {
         ///
         /// Default: None
         default_model: Option<String>,
+        /// Additional paths outside the project that this agent can read and write.
+        ///
+        /// Each path acts as a prefix - specifying "~/.claude" allows access to
+        /// "~/.claude/plans", "~/.claude/configs", etc.
+        /// More specific paths restrict access: "~/.claude/plans" only allows
+        /// that folder and its subfolders.
+        ///
+        /// Default: []
+        allowed_paths: Option<Vec<PathBuf>>,
     },
     Extension {
         /// The default mode to use for this agent.
@@ -375,5 +393,14 @@ pub enum CustomAgentServerSettings {
         ///
         /// Default: None
         default_model: Option<String>,
+        /// Additional paths outside the project that this agent can read and write.
+        ///
+        /// Each path acts as a prefix - specifying "~/.claude" allows access to
+        /// "~/.claude/plans", "~/.claude/configs", etc.
+        /// More specific paths restrict access: "~/.claude/plans" only allows
+        /// that folder and its subfolders.
+        ///
+        /// Default: []
+        allowed_paths: Option<Vec<PathBuf>>,
     },
 }


### PR DESCRIPTION
This PR resolves an issue that happens with claude code when trying to use their plan mode: The agent sometimes can write to `~/.claude/plans` and sometimes cant (using echo or cat vs the write tool). It also tries all the time to create the .claude folder again.

I tried to steer it with prompting but that was not really reliable, so I thought this could be added as a setting.

 This PR adds a new setting that allows users to enable access to folders outside of the projects directory.

Config: 
```json
  "agent_servers": {
    "claude": {
      "allowed_paths": ["~/.claude"]
    }
  }
```

This works for EVERY external agent, CC, Gemini, Codex etc, but the current most obvious case would be CC.

I also added tests for folders that are allowed outside of project, for those that arent, and for those that have similar names (/open and /open_backup).
It also checks for normalized paths, e.g. `~/.claude/../../` should be erroring (also addes test for that). I found that there was already a util func for that, so thats being used.

I explicitly added the checks after the inital check for the worktree/project access.

Would be happy for any feedback.

Closes #37620 (partially)
Closes #44221

Release Notes:

- Added `allowed_paths` setting to external agents to permit claude code to write plans.
