### PR TITLE
git_ui: Fix indent guides not showing for file buffers in the commit view

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1079,6 +1079,7 @@ pub struct Editor {
     show_breakpoints: Option<bool>,
     show_wrap_guides: Option<bool>,
     show_indent_guides: Option<bool>,
+    buffers_with_disabled_indent_guides: HashSet<BufferId>,
     highlight_order: usize,
     highlighted_rows: HashMap<TypeId, Vec<RowHighlight>>,
     background_highlights: HashMap<HighlightKey, BackgroundHighlight>,
@@ -2204,6 +2205,7 @@ impl Editor {
             show_breakpoints: None,
             show_wrap_guides: None,
             show_indent_guides,
+            buffers_with_disabled_indent_guides: HashSet::default(),
             highlight_order: 0,
             highlighted_rows: HashMap::default(),
             background_highlights: HashMap::default(),
@@ -20090,9 +20092,18 @@ impl Editor {
         self.show_indent_guides
     }
 
-    pub fn disable_indent_guides(&mut self) -> Option<bool> {
-        self.show_indent_guides = Some(false);
-        self.show_indent_guides
+    pub fn disable_indent_guides_for_buffer(
+        &mut self,
+        buffer_id: BufferId,
+        cx: &mut Context<Self>,
+    ) {
+        self.buffers_with_disabled_indent_guides.insert(buffer_id);
+        cx.notify();
+    }
+
+    pub fn has_indent_guides_disabled_for_buffer(&self, buffer_id: BufferId) -> bool {
+        self.buffers_with_disabled_indent_guides
+            .contains(&buffer_id)
     }
 
     pub fn toggle_line_numbers(

--- a/crates/editor/src/indent_guides.rs
+++ b/crates/editor/src/indent_guides.rs
@@ -181,6 +181,10 @@ pub fn indent_guides_in_range(
         .buffer_snapshot()
         .indent_guides_in_range(start_anchor..end_anchor, ignore_disabled_for_language, cx)
         .filter(|indent_guide| {
+            if editor.has_indent_guides_disabled_for_buffer(indent_guide.buffer_id) {
+                return false;
+            }
+
             if editor.is_buffer_folded(indent_guide.buffer_id, cx) {
                 return false;
             }

--- a/crates/git_ui/src/commit_view.rs
+++ b/crates/git_ui/src/commit_view.rs
@@ -150,7 +150,6 @@ impl CommitView {
                 Editor::for_multibuffer(multibuffer.clone(), Some(project.clone()), window, cx);
 
             editor.disable_inline_diagnostics();
-            editor.disable_indent_guides();
             editor.set_expand_all_diff_hunks(cx);
 
             editor
@@ -259,6 +258,8 @@ impl CommitView {
 
                 this.editor.update(cx, |editor, cx| {
                     editor.disable_header_for_buffer(message_buffer.read(cx).remote_id(), cx);
+                    editor
+                        .disable_indent_guides_for_buffer(message_buffer.read(cx).remote_id(), cx);
 
                     editor.insert_blocks(
                         [BlockProperties {


### PR DESCRIPTION
Follow up to https://github.com/zed-industries/zed/pull/44162 where my strategy for not displaying the indent guides only in the commit message was wrong given I ended up... disabling indent guides for all the buffers. This PR adds a new method to the editor where we can disable it for a specific buffer ID following the pattern of `disable_header_for_buffer`.

Release Notes:

- N/A
