### PR TITLE
macos: Reset exception ports for shell-spawned processes

### DIFF
--- a/crates/util/src/command.rs
+++ b/crates/util/src/command.rs
@@ -58,7 +58,7 @@ pub fn new_smol_command(program: impl AsRef<OsStr>) -> smol::process::Command {
 }
 
 #[cfg(target_os = "macos")]
-fn reset_exception_ports() {
+pub fn reset_exception_ports() {
     use mach2::exception_types::{
         EXC_MASK_ALL, EXCEPTION_DEFAULT, exception_behavior_t, exception_mask_t,
     };

--- a/crates/util/src/util.rs
+++ b/crates/util/src/util.rs
@@ -390,6 +390,8 @@ pub fn set_pre_exec_to_start_new_session(
         use std::os::unix::process::CommandExt;
         command.pre_exec(|| {
             libc::setsid();
+            #[cfg(target_os = "macos")]
+            crate::command::reset_exception_ports();
             Ok(())
         });
     };


### PR DESCRIPTION
## Summary

Follow-up to #40716. This applies the same `reset_exception_ports()` fix to `set_pre_exec_to_start_new_session()`, which is used by shell environment capture, terminal spawning, and DAP transport.

### Root Cause

After more debugging, I finally figured out what was causing the issue on my machine. Here's what was happening:

1. Zed spawns a login shell (zsh) to capture environment variables
2. A pipe is created: reader in Zed, writer mapped to fd 0 in zsh
3. zsh sources `.zshrc` → loads oh-my-zsh → runs poetry plugin
4. Poetry plugin runs `poetry completions zsh &|` in background
5. Poetry inherits fd 0 (the pipe's write end) from zsh
6. zsh finishes `zed --printenv` and exits
7. Poetry still holds fd 0 open
8. Zed's `reader.read_to_end()` blocks waiting for all writers to close
9. Poetry hangs (likely due to inherited crash handler exception ports interfering with its normal operation)
10. Pipe stays open → Zed stuck → no more processes spawn (including LSPs)

I confirmed this by killing the hanging `poetry` process, which immediately unblocked Zed and allowed LSPs to start. However, this workaround was needed every time I started Zed.

While poetry was the culprit in my case, this can affect any shell configuration that spawns background processes during initialization (oh-my-zsh plugins, direnv, asdf, nvm, etc.).

Fixes #36754

## Test plan

- [x] Build with `ZED_GENERATE_MINIDUMPS=true` to force crash handler initialization
- [x] Verify crash handler logs appear ("spawning crash handler process", "crash handler registered")  
- [x] Confirm LSPs start correctly with shell plugins that spawn background processes

Release Notes:

- Fixed an issue on macOS where LSPs could fail to start when shell plugins spawn background processes during environment capture.