### PR TITLE
lsp: Format RPC messages in language server logs

### DIFF
--- a/crates/project/src/lsp_store/log_store.rs
+++ b/crates/project/src/lsp_store/log_store.rs
@@ -553,9 +553,13 @@ impl LogStore {
             rpc_log_lines.pop_front();
         }
 
+        let message = serde_json::from_str::<serde_json::Value>(message)
+            .and_then(|value| serde_json::to_string_pretty(&value))
+            .unwrap_or_else(|_| message.trim().to_owned());
+
         if store_logs {
             rpc_log_lines.push_back(RpcMessage {
-                message: message.trim().to_owned(),
+                message: message.clone(),
             });
         }
 
@@ -563,7 +567,7 @@ impl LogStore {
             Event::NewServerLogEntry {
                 id: language_server_id,
                 kind: LanguageServerLogType::Rpc { received },
-                text: message.to_owned(),
+                text: message,
             },
             cx,
         );


### PR DESCRIPTION
Closes #44182

Release Notes:

- Improved readability of RPC messages in language server logs

<table>
  <tr>
    <td>Before</td>
    <td>After</td>
  </tr>
  <tr>
    <td><img width="400" alt="Screenshot 2025-12-05 at 18 30 32" src="https://github.com/user-attachments/assets/e6e64b60-b057-4930-979a-e1bc5688b561" /></td>
    <td><img width="400" alt="Screenshot 2025-12-05 at 18 26 39" src="https://github.com/user-attachments/assets/971c8f3c-b6b8-4206-9abc-42eed70d95a5" /></td>
  </tr>
</table>