### PR TITLE
remoting: Server download connect timeout

### DIFF
--- a/crates/remote/src/transport/ssh.rs
+++ b/crates/remote/src/transport/ssh.rs
@@ -706,9 +706,11 @@ impl SshRemoteConnection {
                         self.ssh_shell_kind,
                         "wget",
                         &[
-                            url,
                             "--connect-timeout",
                             CONNECT_TIMEOUT_SECS,
+                            "--tries",
+                            "1",
+                            url,
                             "-O",
                             &tmp_path_gz.display(self.path_style()),
                         ],

--- a/crates/remote/src/transport/ssh.rs
+++ b/crates/remote/src/transport/ssh.rs
@@ -668,6 +668,8 @@ impl SshRemoteConnection {
 
         delegate.set_status(Some("Downloading remote development server on host"), cx);
 
+        const CONNECT_TIMEOUT_SECS: &str = "10";
+
         match self
             .socket
             .run_command(
@@ -676,6 +678,8 @@ impl SshRemoteConnection {
                 &[
                     "-f",
                     "-L",
+                    "--connect-timeout",
+                    CONNECT_TIMEOUT_SECS,
                     url,
                     "-o",
                     &tmp_path_gz.display(self.path_style()),
@@ -701,7 +705,13 @@ impl SshRemoteConnection {
                     .run_command(
                         self.ssh_shell_kind,
                         "wget",
-                        &[url, "-O", &tmp_path_gz.display(self.path_style())],
+                        &[
+                            url,
+                            "--connect-timeout",
+                            CONNECT_TIMEOUT_SECS,
+                            "-O",
+                            &tmp_path_gz.display(self.path_style()),
+                        ],
                         true,
                     )
                     .await


### PR DESCRIPTION
Sometimes machines are configured to drop outbound packets (rather than reject connections). In these cases, curl/wget just hang causing our download step to never complete. This PR adds a timeout of 10s for the connection (not the whole download), so that in situations like this we can fallback to our client-side download eventually.

Related to but doesn't fully fix: https://github.com/zed-industries/zed/issues/43694 and https://github.com/zed-industries/zed/issues/43718

Release Notes:

- remote: Add 10s connect timeout for server download