### PR TITLE
git_ui: Fix history view label truncation

### DIFF
--- a/crates/git_ui/src/file_history_view.rs
+++ b/crates/git_ui/src/file_history_view.rs
@@ -267,15 +267,18 @@ impl FileHistoryView {
                     .child(self.render_commit_avatar(&entry.sha, window, cx))
                     .child(
                         h_flex()
+                            .min_w_0()
                             .w_full()
                             .justify_between()
                             .child(
                                 h_flex()
                                     .gap_1()
+                                    .flex_1()
                                     .child(
                                         Label::new(entry.author_name.clone())
                                             .size(LabelSize::Small)
-                                            .color(Color::Default),
+                                            .color(Color::Default)
+                                            .truncate(),
                                     )
                                     .child(
                                         Label::new(&entry.subject)
@@ -285,9 +288,11 @@ impl FileHistoryView {
                                     ),
                             )
                             .child(
-                                Label::new(relative_timestamp)
-                                    .size(LabelSize::Small)
-                                    .color(Color::Muted),
+                                h_flex().flex_none().child(
+                                    Label::new(relative_timestamp)
+                                        .size(LabelSize::Small)
+                                        .color(Color::Muted),
+                                ),
                             ),
                     ),
             )

--- a/crates/git_ui/src/file_history_view.rs
+++ b/crates/git_ui/src/file_history_view.rs
@@ -272,8 +272,9 @@ impl FileHistoryView {
                             .justify_between()
                             .child(
                                 h_flex()
+                                    .min_w_0()
+                                    .w_full()
                                     .gap_1()
-                                    .flex_1()
                                     .child(
                                         Label::new(entry.author_name.clone())
                                             .size(LabelSize::Small)


### PR DESCRIPTION
There's still a weird problem happening where the labels (and the label on the tab, too, for what is worth) flicker as the file history view gets smaller. I suspect that problem is related to something else—potentially the truncation algorithm or focus management—so I'm not solving it here.

<img width="500" height="1948" alt="Screenshot 2025-12-05 at 11  24@2x" src="https://github.com/user-attachments/assets/25715725-e2cb-475a-bdab-f506bb75475f" />

Release Notes:

- N/A
