### PR TITLE
markdown_preview: Remove unnecessary vec allocation

### DIFF
--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -524,7 +524,7 @@ impl Render for MarkdownPreviewView {
                                                         if e.checked() { "[x]" } else { "[ ]" };
 
                                                     editor.edit(
-                                                        vec![(
+                                                        [(
                                                             MultiBufferOffset(
                                                                 e.source_range().start,
                                                             )


### PR DESCRIPTION
Instead of allocating a one-element vec on the heap, we can just use an array here (since `Editor::edit` accepts anything that implements `IntoIterator`).

I haven't checked if there are more instances that can be simplified, just accidentally stumbled upon this when working on something else in the markdown preview crate.

Release Notes:

- N/A