### PR TITLE
Fix persistence for single-file worktrees

### DIFF
--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -1359,11 +1359,11 @@ impl WorkspaceDb {
             // If a local workspace points to WSL, this check will cause us to wait for the
             // WSL VM and file server to boot up. This can block for many seconds.
             // Supported scenarios use remote workspaces.
-            if !has_wsl_path
-                && paths.paths().iter().all(|path| path.exists())
-                && paths.paths().iter().any(|path| path.is_dir())
-            {
-                result.push((id, SerializedWorkspaceLocation::Local, paths));
+            if !has_wsl_path && paths.paths().iter().all(|path| path.exists()) {
+                // Only show directories in recent projects
+                if paths.paths().iter().any(|path| path.is_dir()) {
+                    result.push((id, SerializedWorkspaceLocation::Local, paths));
+                }
             } else {
                 delete_tasks.push(self.delete_workspace_by_id(id));
             }


### PR DESCRIPTION
We were just deleting them before

Co-Authored-By: Matthew Chisolm <mchisolm0@gmail.com>

Closes #24228

Release Notes:

- Fixed restoring window location for single-file worktrees
