### PR TITLE
Put tracy dependency behind feature tracy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -699,7 +699,6 @@ tree-sitter-rust = "0.24"
 tree-sitter-typescript = { git = "https://github.com/zed-industries/tree-sitter-typescript", rev = "e2c53597d6a5d9cf7bbe8dccde576fe1e46c5899" } # https://github.com/tree-sitter/tree-sitter-typescript/pull/347
 tree-sitter-yaml = { git = "https://github.com/zed-industries/tree-sitter-yaml", rev = "baff0b51c64ef6a1fb1f8390f3ad6015b83ec13a" }
 tracing = "0.1.40"
-tracing-tracy = "0.11.4"
 unicase = "2.6"
 unicode-script = "0.5.7"
 unicode-segmentation = "1.10"

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -10,6 +10,9 @@ authors = ["Zed Team <hi@zed.dev>"]
 [lints]
 workspace = true
 
+[features]
+tracy = ["ztracing/tracy"]
+
 [[bin]]
 name = "zed"
 path = "src/zed-main.rs"

--- a/crates/ztracing/Cargo.toml
+++ b/crates/ztracing/Cargo.toml
@@ -8,10 +8,13 @@ license = "GPL-3.0-or-later"
 [lints]
 workspace = true
 
+[features]
+tracy = ["tracing-tracy"]
+
 [dependencies]
 tracing.workspace = true
 
 tracing-subscriber = "0.3.22"
-tracing-tracy = { workspace = true, features = ["enable", "ondemand"] }
+tracing-tracy = { version = "0.11.4", optional = true, features = ["enable", "ondemand"] }
 
 ztracing_macro.workspace = true

--- a/docs/src/performance.md
+++ b/docs/src/performance.md
@@ -28,7 +28,7 @@ fn should_appear_in_profile(kitty: Cat) {
 }
 ```
 
-Then either compile Zed with `ZTRACING=1 cargo r --release`. The release build is optional but highly recommended as like every program Zeds performance characteristics change dramatically with optimizations. You do not want to chase slowdowns that do not exist in release.
+Then either compile Zed with `ZTRACING=1 cargo r --features tracy --release`. The release build is optional but highly recommended as like every program Zeds performance characteristics change dramatically with optimizations. You do not want to chase slowdowns that do not exist in release.
 
 ## One time Setup/Building the profiler:
 


### PR DESCRIPTION
It broke CI, now it no longer does :tada: Proper fix followes after the weekend.

Release Notes:

- N/A
