### PR TITLE
agent ui: Fix clicks on the notification sometimes not being triggered

### DIFF
--- a/crates/agent_ui/src/ui/agent_notification.rs
+++ b/crates/agent_ui/src/ui/agent_notification.rs
@@ -106,9 +106,6 @@ impl Render for AgentNotification {
             .font(ui_font)
             .border_color(cx.theme().colors().border)
             .rounded_xl()
-            .on_click(cx.listener(|_, _, _, cx| {
-                cx.emit(AgentNotificationEvent::Accepted);
-            }))
             .child(
                 h_flex()
                     .items_start()


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/43292

We were seeing clicks on the "View Panel" and "Dismiss" buttons sometimes not being triggered. I believe this was happening because the overall parent also had an on_click, which due to this being a popup window, was causing conflicts with the buttons' on click handlers. This should hopefully fix that issue.

Release Notes:

- agent: Fixed an issue where clicking on the agent notification buttons would sometimes not trigger their actions.
