### PR TITLE
editor: Use Tree-sitter scopes to calculate quote autoclose

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4372,10 +4372,11 @@ impl Editor {
                                             })
                                             .unwrap_or(true);
 
-                                        let adjacent_point =
-                                            Point::new(point.row, point.column + 1);
                                         let is_delimiter = snapshot
-                                            .language_scope_at(adjacent_point)
+                                            .language_scope_at(Point::new(
+                                                point.row,
+                                                point.column + 1,
+                                            ))
                                             .and_then(|scope| {
                                                 scope
                                                     .brackets()

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4343,21 +4343,19 @@ impl Editor {
                                 && bracket_pair.start.len() == 1
                             {
                                 let target = bracket_pair.start.chars().next().unwrap();
+                                let mut byte_offset = 0u32;
                                 let current_line_count = snapshot
                                     .reversed_chars_at(selection.start)
                                     .take_while(|&c| c != '\n')
-                                    .enumerate()
-                                    .filter(|(offset, c)| {
+                                    .filter(|c| {
+                                        byte_offset += c.len_utf8() as u32;
                                         if *c != target {
                                             return false;
                                         }
 
                                         let point = Point::new(
                                             selection.start.row,
-                                            selection
-                                                .start
-                                                .column
-                                                .saturating_sub(*offset as u32 + 1),
+                                            selection.start.column.saturating_sub(byte_offset),
                                         );
 
                                         let is_enabled = snapshot

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -10846,6 +10846,27 @@ async fn test_autoclose_quotes_with_scope_awareness(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_autoclose_quotes_with_multibyte_characters(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+    let language = languages::language("python", tree_sitter_python::LANGUAGE.into());
+    cx.update_buffer(|buffer, cx| buffer.set_language(Some(language), cx));
+
+    cx.set_state(indoc! {r#"
+        def main():
+            items = ["🎉", ˇ]
+    "#});
+    cx.update_editor(|editor, window, cx| {
+        editor.handle_input("\"", window, cx);
+    });
+    cx.assert_editor_state(indoc! {r#"
+        def main():
+            items = ["🎉", "ˇ"]
+    "#});
+}
+
+#[gpui::test]
 async fn test_surround_with_pair(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -10758,7 +10758,7 @@ async fn test_autoclose_with_overrides(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
-async fn test_autoclose_quotes_same_line_with_scope_awareness(cx: &mut TestAppContext) {
+async fn test_autoclose_quotes_with_scope_awareness(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 
     let mut cx = EditorTestContext::new(cx).await;
@@ -10829,6 +10829,19 @@ async fn test_autoclose_quotes_same_line_with_scope_awareness(cx: &mut TestAppCo
     cx.assert_editor_state(indoc! {r#"
         def main():
             items = ['"""', "'''''", "ˇ"]
+    "#});
+    cx.update_editor(|editor, window, cx| {
+        editor.move_right(&MoveRight, window, cx);
+    });
+    cx.update_editor(|editor, window, cx| {
+        editor.handle_input(", ", window, cx);
+    });
+    cx.update_editor(|editor, window, cx| {
+        editor.handle_input("'", window, cx);
+    });
+    cx.assert_editor_state(indoc! {r#"
+        def main():
+            items = ['"""', "'''''", "", 'ˇ']
     "#});
 }
 


### PR DESCRIPTION
Closes #44233

Release Notes:

- Fixed quote autoclose incorrectly counting quotes inside strings
