### PR TITLE
zlog: Fix dynamic mod path filtering

### DIFF
--- a/crates/zlog/src/filter.rs
+++ b/crates/zlog/src/filter.rs
@@ -5,7 +5,7 @@ use std::sync::{
     atomic::{AtomicU8, Ordering},
 };
 
-use crate::{SCOPE_DEPTH_MAX, SCOPE_STRING_SEP_STR, Scope, ScopeAlloc, env_config, private};
+use crate::{SCOPE_DEPTH_MAX, SCOPE_STRING_SEP_STR, ScopeAlloc, ScopeRef, env_config, private};
 
 use log;
 
@@ -59,7 +59,11 @@ pub fn is_possibly_enabled_level(level: log::Level) -> bool {
     level as u8 <= LEVEL_ENABLED_MAX_CONFIG.load(Ordering::Acquire)
 }
 
-pub fn is_scope_enabled(scope: &Scope, module_path: Option<&str>, level: log::Level) -> bool {
+pub fn is_scope_enabled(
+    scope: &ScopeRef<'_>,
+    module_path: Option<&str>,
+    level: log::Level,
+) -> bool {
     // TODO: is_always_allowed_level that checks against LEVEL_ENABLED_MIN_CONFIG
     if !is_possibly_enabled_level(level) {
         // [FAST PATH]
@@ -401,6 +405,7 @@ impl ScopeMap {
 mod tests {
     use log::LevelFilter;
 
+    use crate::Scope;
     use crate::private::scope_new;
 
     use super::*;

--- a/crates/zlog/src/sink.rs
+++ b/crates/zlog/src/sink.rs
@@ -8,7 +8,7 @@ use std::{
     },
 };
 
-use crate::{SCOPE_STRING_SEP_CHAR, Scope};
+use crate::{SCOPE_STRING_SEP_CHAR, ScopeRef};
 
 // ANSI color escape codes for log levels
 const ANSI_RESET: &str = "\x1b[0m";
@@ -35,7 +35,7 @@ static SINK_FILE_SIZE_BYTES: AtomicU64 = AtomicU64::new(0);
 const SINK_FILE_SIZE_BYTES_MAX: u64 = 1024 * 1024; // 1 MB
 
 pub struct Record<'a> {
-    pub scope: Scope,
+    pub scope: ScopeRef<'a>,
     pub level: log::Level,
     pub message: &'a std::fmt::Arguments<'a>,
     pub module_path: Option<&'a str>,
@@ -208,7 +208,7 @@ pub fn flush() {
 }
 
 struct SourceFmt<'a> {
-    scope: Scope,
+    scope: ScopeRef<'a>,
     module_path: Option<&'a str>,
     line: Option<u32>,
     ansi: bool,


### PR DESCRIPTION
Closes #ISSUE

Release Notes:

- Linux: cleaned up noisy logs from `zbus` 
