### PR TITLE
debugger: Get stack frame list working with historic snapshot feature

### DIFF
--- a/crates/debugger_ui/src/session/running/loaded_source_list.rs
+++ b/crates/debugger_ui/src/session/running/loaded_source_list.rs
@@ -17,7 +17,9 @@ impl LoadedSourceList {
         let list = ListState::new(0, gpui::ListAlignment::Top, px(1000.));
 
         let _subscription = cx.subscribe(&session, |this, _, event, cx| match event {
-            SessionEvent::Stopped(_) | SessionEvent::LoadedSources => {
+            SessionEvent::Stopped(_)
+            | SessionEvent::SnapshotSelectionChanged
+            | SessionEvent::LoadedSources => {
                 this.invalidate = true;
                 cx.notify();
             }

--- a/crates/debugger_ui/src/session/running/loaded_source_list.rs
+++ b/crates/debugger_ui/src/session/running/loaded_source_list.rs
@@ -18,7 +18,7 @@ impl LoadedSourceList {
 
         let _subscription = cx.subscribe(&session, |this, _, event, cx| match event {
             SessionEvent::Stopped(_)
-            | SessionEvent::SnapshotSelectionChanged
+            | SessionEvent::HistoricSnapshotSelected
             | SessionEvent::LoadedSources => {
                 this.invalidate = true;
                 cx.notify();

--- a/crates/debugger_ui/src/session/running/module_list.rs
+++ b/crates/debugger_ui/src/session/running/module_list.rs
@@ -33,7 +33,7 @@ impl ModuleList {
 
         let _subscription = cx.subscribe(&session, |this, _, event, cx| match event {
             SessionEvent::Stopped(_)
-            | SessionEvent::SnapshotSelectionChanged
+            | SessionEvent::HistoricSnapshotSelected
             | SessionEvent::Modules => {
                 if this._rebuild_task.is_some() {
                     this.schedule_rebuild(cx);

--- a/crates/debugger_ui/src/session/running/module_list.rs
+++ b/crates/debugger_ui/src/session/running/module_list.rs
@@ -32,7 +32,9 @@ impl ModuleList {
         let focus_handle = cx.focus_handle();
 
         let _subscription = cx.subscribe(&session, |this, _, event, cx| match event {
-            SessionEvent::Stopped(_) | SessionEvent::Modules => {
+            SessionEvent::Stopped(_)
+            | SessionEvent::SnapshotSelectionChanged
+            | SessionEvent::Modules => {
                 if this._rebuild_task.is_some() {
                     this.schedule_rebuild(cx);
                 }

--- a/crates/debugger_ui/src/session/running/stack_frame_list.rs
+++ b/crates/debugger_ui/src/session/running/stack_frame_list.rs
@@ -99,7 +99,7 @@ impl StackFrameList {
                 }
                 SessionEvent::Stopped(..)
                 | SessionEvent::StackTrace
-                | SessionEvent::SnapshotSelectionChanged => {
+                | SessionEvent::HistoricSnapshotSelected => {
                     this.schedule_refresh(true, window, cx);
                 }
                 _ => {}

--- a/crates/debugger_ui/src/session/running/stack_frame_list.rs
+++ b/crates/debugger_ui/src/session/running/stack_frame_list.rs
@@ -97,7 +97,9 @@ impl StackFrameList {
                 SessionEvent::Threads => {
                     this.schedule_refresh(false, window, cx);
                 }
-                SessionEvent::Stopped(..) | SessionEvent::StackTrace => {
+                SessionEvent::Stopped(..)
+                | SessionEvent::StackTrace
+                | SessionEvent::SnapshotSelectionChanged => {
                     this.schedule_refresh(true, window, cx);
                 }
                 _ => {}

--- a/crates/debugger_ui/src/session/running/variable_list.rs
+++ b/crates/debugger_ui/src/session/running/variable_list.rs
@@ -217,7 +217,7 @@ impl VariableList {
         let _subscriptions = vec![
             cx.subscribe(&stack_frame_list, Self::handle_stack_frame_list_events),
             cx.subscribe(&session, |this, _, event, cx| match event {
-                SessionEvent::SnapshotSelectionChanged => {
+                SessionEvent::HistoricSnapshotSelected => {
                     this.selection.take();
                     this.edited_path.take();
                     this.selected_stack_frame_id.take();

--- a/crates/debugger_ui/src/session/running/variable_list.rs
+++ b/crates/debugger_ui/src/session/running/variable_list.rs
@@ -217,6 +217,12 @@ impl VariableList {
         let _subscriptions = vec![
             cx.subscribe(&stack_frame_list, Self::handle_stack_frame_list_events),
             cx.subscribe(&session, |this, _, event, cx| match event {
+                SessionEvent::SnapshotSelectionChanged => {
+                    this.selection.take();
+                    this.edited_path.take();
+                    this.selected_stack_frame_id.take();
+                    this.build_entries(cx);
+                }
                 SessionEvent::Stopped(_) => {
                     this.selection.take();
                     this.edited_path.take();
@@ -225,7 +231,6 @@ impl VariableList {
                 SessionEvent::Variables | SessionEvent::Watchers => {
                     this.build_entries(cx);
                 }
-
                 _ => {}
             }),
             cx.on_focus_out(&focus_handle, window, |this, _, _, cx| {

--- a/crates/project/src/debugger/session.rs
+++ b/crates/project/src/debugger/session.rs
@@ -808,7 +808,7 @@ pub enum SessionEvent {
     },
     DataBreakpointInfo,
     ConsoleOutput,
-    SnapshotSelectionChanged,
+    HistoricSnapshotSelected,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -1448,7 +1448,7 @@ impl Session {
         self.selected_snapshot_index = ix;
 
         if ix.is_some() {
-            cx.emit(SessionEvent::SnapshotSelectionChanged);
+            cx.emit(SessionEvent::HistoricSnapshotSelected);
         }
 
         cx.notify();
@@ -1669,16 +1669,10 @@ impl Session {
             );
         }
 
-        if self.selected_snapshot_index.is_some() {
-            return;
-        }
-
-        if self.is_session_terminated {
-            return;
-        }
-
-        if !self.active_snapshot.thread_states.any_stopped_thread()
-            && request.type_id() != TypeId::of::<ThreadsCommand>()
+        if (!self.active_snapshot.thread_states.any_stopped_thread()
+            && request.type_id() != TypeId::of::<ThreadsCommand>())
+            || self.selected_snapshot_index.is_some()
+            || self.is_session_terminated
         {
             return;
         }

--- a/crates/project/src/debugger/session.rs
+++ b/crates/project/src/debugger/session.rs
@@ -808,6 +808,7 @@ pub enum SessionEvent {
     },
     DataBreakpointInfo,
     ConsoleOutput,
+    SnapshotSelectionChanged,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -1447,7 +1448,7 @@ impl Session {
         self.selected_snapshot_index = ix;
 
         if ix.is_some() {
-            cx.emit(SessionEvent::Stopped(None));
+            cx.emit(SessionEvent::SnapshotSelectionChanged);
         }
 
         cx.notify();
@@ -2505,7 +2506,7 @@ impl Session {
             );
         }
 
-        match self.active_snapshot.threads.get(&thread_id) {
+        match self.session_state().threads.get(&thread_id) {
             Some(thread) => {
                 if let Some(error) = &thread.stack_frames_error {
                     Err(anyhow!(error.to_string()))


### PR DESCRIPTION
This PR fixes an issue where the stack frame list would not update when viewing a historic snapshot. 
We now also show the right active debug line based on the currently selected history.

https://github.com/user-attachments/assets/baccd078-23ed-4db3-9959-f83dc2be8309

Release Notes:

- N/A
