### PR TITLE
docs: Document implemented `clangd` extensions

### DIFF
--- a/docs/src/languages/cpp.md
+++ b/docs/src/languages/cpp.md
@@ -156,3 +156,15 @@ You can use CodeLLDB or GDB to debug native binaries. (Make sure that your build
   }
 ]
 ```
+
+## Extensions
+
+Zed implements several clangd [extensions](https://clangd.llvm.org/extensions) to enhance the support for C/C++ development.
+
+### Switch Between Source and Header File
+
+You can instantly jump between a source file and its corresponding header file using a dedicated command.
+
+### Inactive Code Highlighting
+
+Zed visually dims code that is inactive due to preprocessor directives (such as code within an `#if 0` block). This makes it easy to distinguish between active and compiled-out code, helping you better understand the current compilation state of your files.

--- a/docs/src/languages/cpp.md
+++ b/docs/src/languages/cpp.md
@@ -157,14 +157,25 @@ You can use CodeLLDB or GDB to debug native binaries. (Make sure that your build
 ]
 ```
 
-## Extensions
+## Protocol Extensions
 
-Zed implements several `clangd` [extensions](https://clangd.llvm.org/extensions) to enhance the support for C/C++ development.
+Zed currently implements the following `clangd` [extensions](https://clangd.llvm.org/extensions):
 
-### Switch Between Source and Header File
+### Inactive Regions
 
-You can instantly jump between a source file and its corresponding header file using a dedicated command.
+Automatically dims inactive sections of code due to preprocessor directives, such as `#if`, `#ifdef`, or `#ifndef` blocks that evaluate to false.
 
-### Inactive Code Highlighting
+### Switch Between Source and Header Files
 
-Zed visually dims code that is inactive due to preprocessor directives (such as code within an `#if 0` block). This makes it easy to distinguish between active and compiled-out code, helping you better understand the current compilation state of your files.
+Allows switching between corresponding C++ source files (e.g., `.cpp`) and header files (e.g., `.h`).
+by running the command {#action editor::SwitchSourceHeader} from the command palette or by setting
+a keybinding for the `editor::SwitchSourceHeader` action.
+
+```json [settings]
+{
+  "context": "Editor",
+  "bindings": {
+    "alt-enter": "editor::SwitchSourceHeader"
+  }
+}
+```

--- a/docs/src/languages/cpp.md
+++ b/docs/src/languages/cpp.md
@@ -159,7 +159,7 @@ You can use CodeLLDB or GDB to debug native binaries. (Make sure that your build
 
 ## Extensions
 
-Zed implements several clangd [extensions](https://clangd.llvm.org/extensions) to enhance the support for C/C++ development.
+Zed implements several `clangd` [extensions](https://clangd.llvm.org/extensions) to enhance the support for C/C++ development.
 
 ### Switch Between Source and Header File
 


### PR DESCRIPTION
Zed currently doesn’t support all protocol extensions implemented by `clangd`, but it does support two:

- `textDocument/inactiveRegion`
- `textDocument/switchSourceHeader`

Release Notes:

- N/A
