### PR TITLE
docs: Point to the right URL for Astro LSP

### DIFF
--- a/docs/src/languages/astro.md
+++ b/docs/src/languages/astro.md
@@ -3,7 +3,7 @@
 Astro support is available through the [Astro extension](https://github.com/zed-extensions/astro).
 
 - Tree-sitter: [virchau13/tree-sitter-astro](https://github.com/virchau13/tree-sitter-astro)
-- Language Server: [withastro/language-tools](https://github.com/withastro/language-tools)
+- Language Server: [withastro/language-tools](https://github.com/withastro/astro/tree/main/packages/language-tools)
 
 <!--
 TBD: Documentation Astro usage / configuration

--- a/docs/src/languages/astro.md
+++ b/docs/src/languages/astro.md
@@ -3,7 +3,7 @@
 Astro support is available through the [Astro extension](https://github.com/zed-extensions/astro).
 
 - Tree-sitter: [virchau13/tree-sitter-astro](https://github.com/virchau13/tree-sitter-astro)
-- Language Server: [withastro/language-tools](https://github.com/withastro/astro/tree/main/packages/language-tools)
+- Language Server: [withastro/language-tools](https://github.com/withastro/astro/tree/main/packages/language-tools/language-server)
 
 <!--
 TBD: Documentation Astro usage / configuration


### PR DESCRIPTION
The original URL points to a deprecated repo.

Release Notes:

- N/A
