### PR TITLE
editor: Add action to run rust-analyzer flycheck on the current file

### DIFF
--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -667,6 +667,8 @@ actions!(
         Rewrap,
         /// Runs flycheck diagnostics.
         RunFlycheck,
+        /// Runs flycheck diagnostics only on the current files workspace.
+        RunFlycheckCurrentFile,
         /// Scrolls the cursor to the bottom of the viewport.
         ScrollCursorBottom,
         /// Scrolls the cursor to the center of the viewport.


### PR DESCRIPTION
by default it would always send `"textDocument": null`, if your rust-analyzer config disabled workspace checking this caused flycheck to do nothing

Release Notes:

- N/A *or* Added/Fixed/Improved ...
