### PR TITLE
Add project settings schema to schema_generator CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14213,6 +14213,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "settings",
  "theme",
 ]
 

--- a/crates/schema_generator/Cargo.toml
+++ b/crates/schema_generator/Cargo.toml
@@ -15,4 +15,5 @@ env_logger.workspace = true
 schemars = { workspace = true, features = ["indexmap2"] }
 serde.workspace = true
 serde_json.workspace = true
+settings.workspace = true
 theme.workspace = true

--- a/crates/schema_generator/src/main.rs
+++ b/crates/schema_generator/src/main.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use clap::{Parser, ValueEnum};
 use schemars::schema_for;
+use settings::ProjectSettingsContent;
 use theme::{IconThemeFamilyContent, ThemeFamilyContent};
 
 #[derive(Parser, Debug)]
@@ -14,6 +15,7 @@ pub struct Args {
 pub enum SchemaType {
     Theme,
     IconTheme,
+    Project,
 }
 
 fn main() -> Result<()> {
@@ -28,6 +30,10 @@ fn main() -> Result<()> {
         }
         SchemaType::IconTheme => {
             let schema = schema_for!(IconThemeFamilyContent);
+            println!("{}", serde_json::to_string_pretty(&schema)?);
+        }
+        SchemaType::Project => {
+            let schema = schema_for!(ProjectSettingsContent);
             println!("{}", serde_json::to_string_pretty(&schema)?);
         }
     }


### PR DESCRIPTION
Release Notes:

- Added project settings schema to the schema_generator CLI. This allows for exporting the project settings schema as JSON for use in other tools. 
