### PR TITLE
Add stash list view to Git Panel

### DIFF
--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -991,6 +991,16 @@
     }
   },
   {
+    "context": "GitPanel && StashList",
+    "use_key_equivalents": true,
+    "bindings": {
+      "up": "git_panel::SelectPrevStash",
+      "down": "git_panel::SelectNextStash",
+      "enter": "menu::Confirm",
+      "escape": "git_panel::ToggleFocus"
+    }
+  },
+  {
     "context": "GitPanel && CommitEditor",
     "use_key_equivalents": true,
     "bindings": {

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -921,6 +921,16 @@
     }
   },
   {
+    "context": "GitPanel && StashList",
+    "use_key_equivalents": true,
+    "bindings": {
+      "up": "git_panel::SelectPrevStash",
+      "down": "git_panel::SelectNextStash",
+      "enter": "menu::Confirm",
+      "escape": "git_panel::ToggleFocus"
+    }
+  },
+  {
     "context": "GitPanel && CommitEditor",
     "use_key_equivalents": true,
     "bindings": {

--- a/crates/git_ui/src/stash_picker.rs
+++ b/crates/git_ui/src/stash_picker.rs
@@ -281,7 +281,7 @@ impl StashListDelegate {
 
         cx.spawn(async move |_, cx| {
             repo.update(cx, |repo, cx| repo.stash_pop(Some(stash_index), cx))?
-                .await?;
+                .await??;
             Ok(())
         })
         .detach_and_prompt_err("Failed to pop stash", window, cx, |e, _, _| {


### PR DESCRIPTION
  Closes #N/A

  Add a stash list view to the Git Panel, allowing users to browse and manage stashes directly from the UI.

  Features:
  - Tab switching between Changes and Stash views
  - Stash list showing index, message, branch, and timestamp
  - File preview for selected stash with resizable height
  - Apply, Pop, and Drop operations with helpful conflict error messages
  - Keyboard navigation (up/down) in the stash list
  - Stash tab only appears when stashes exist

  [Screencast](https://drive.google.com/file/d/1RBgYahHSC1hyXZ-RUsl6qLV5TfG6d7-N/view?usp=sharing)

  Release Notes:

  - Added stash list view to Git Panel with Apply, Pop, and Drop operations