### PR TITLE
debugger: Fix UI would not update when you select the `Current State` option

### DIFF
--- a/crates/project/src/debugger/session.rs
+++ b/crates/project/src/debugger/session.rs
@@ -1454,11 +1454,7 @@ impl Session {
         }
 
         self.selected_snapshot_index = ix;
-
-        if ix.is_some() {
-            cx.emit(SessionEvent::HistoricSnapshotSelected);
-        }
-
+        cx.emit(SessionEvent::HistoricSnapshotSelected);
         cx.notify();
     }
 


### PR DESCRIPTION
This PR fixes that the `Current State` option inside the history dropdown does not updating the UI. This was because we didn't send the `SessionEvent::HistoricSnapshotSelected` event in the reset case. This was just a mistake.

**After**

https://github.com/user-attachments/assets/6df5f990-fd66-4c6b-9633-f85b422fb95a

cc @Anthony-Eid

Release Notes:

- N/A
