### PR TITLE
languages: Check whether to update `typescript-language-server`

### DIFF
--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -720,7 +720,7 @@ impl LspInstaller for TypeScriptLspAdapter {
                         latest_version.typescript_version.as_str(),
                     ),
                     (
-                        "typescript-language-server",
+                        Self::SERVER_PACKAGE_NAME,
                         latest_version.server_version.as_str(),
                     ),
                 ],

--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -599,14 +599,19 @@ pub struct TypeScriptLspAdapter {
 }
 
 impl TypeScriptLspAdapter {
-    const OLD_SERVER_PATH: &'static str = "node_modules/typescript-language-server/lib/cli.js";
-    const NEW_SERVER_PATH: &'static str = "node_modules/typescript-language-server/lib/cli.mjs";
-    const SERVER_NAME: LanguageServerName =
-        LanguageServerName::new_static("typescript-language-server");
+    const OLD_SERVER_PATH: &str = "node_modules/typescript-language-server/lib/cli.js";
+    const NEW_SERVER_PATH: &str = "node_modules/typescript-language-server/lib/cli.mjs";
+
     const PACKAGE_NAME: &str = "typescript";
+    const SERVER_PACKAGE_NAME: &str = "typescript-language-server";
+
+    const SERVER_NAME: LanguageServerName =
+        LanguageServerName::new_static(Self::SERVER_PACKAGE_NAME);
+
     pub fn new(node: NodeRuntime, fs: Arc<dyn Fs>) -> Self {
         TypeScriptLspAdapter { fs, node }
     }
+
     async fn tsdk_path(&self, adapter: &Arc<dyn LspAdapterDelegate>) -> Option<&'static str> {
         let is_yarn = adapter
             .read_text_file(RelPath::unix(".yarn/sdks/typescript/lib/typescript.js").unwrap())
@@ -646,10 +651,13 @@ impl LspInstaller for TypeScriptLspAdapter {
         _: &mut AsyncApp,
     ) -> Result<TypeScriptVersions> {
         Ok(TypeScriptVersions {
-            typescript_version: self.node.npm_package_latest_version("typescript").await?,
+            typescript_version: self
+                .node
+                .npm_package_latest_version(Self::PACKAGE_NAME)
+                .await?,
             server_version: self
                 .node
-                .npm_package_latest_version("typescript-language-server")
+                .npm_package_latest_version(Self::SERVER_PACKAGE_NAME)
                 .await?,
         })
     }
@@ -662,7 +670,7 @@ impl LspInstaller for TypeScriptLspAdapter {
     ) -> Option<LanguageServerBinary> {
         let server_path = container_dir.join(Self::NEW_SERVER_PATH);
 
-        let should_install_language_server = self
+        let should_install_package = self
             .node
             .should_install_npm_package(
                 Self::PACKAGE_NAME,
@@ -672,7 +680,17 @@ impl LspInstaller for TypeScriptLspAdapter {
             )
             .await;
 
-        if should_install_language_server {
+        let should_install_server = self
+            .node
+            .should_install_npm_package(
+                Self::SERVER_PACKAGE_NAME,
+                &server_path,
+                container_dir,
+                VersionStrategy::Latest(version.server_version.as_str()),
+            )
+            .await;
+
+        if should_install_package || should_install_server {
             None
         } else {
             Some(LanguageServerBinary {

--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -670,7 +670,7 @@ impl LspInstaller for TypeScriptLspAdapter {
     ) -> Option<LanguageServerBinary> {
         let server_path = container_dir.join(Self::NEW_SERVER_PATH);
 
-        let should_install_package = self
+        if self
             .node
             .should_install_npm_package(
                 Self::PACKAGE_NAME,
@@ -678,9 +678,12 @@ impl LspInstaller for TypeScriptLspAdapter {
                 container_dir,
                 VersionStrategy::Latest(version.typescript_version.as_str()),
             )
-            .await;
+            .await
+        {
+            return None;
+        }
 
-        let should_install_server = self
+        if self
             .node
             .should_install_npm_package(
                 Self::SERVER_PACKAGE_NAME,
@@ -688,17 +691,16 @@ impl LspInstaller for TypeScriptLspAdapter {
                 container_dir,
                 VersionStrategy::Latest(version.server_version.as_str()),
             )
-            .await;
-
-        if should_install_package || should_install_server {
-            None
-        } else {
-            Some(LanguageServerBinary {
-                path: self.node.binary_path().await.ok()?,
-                env: None,
-                arguments: typescript_server_binary_arguments(&server_path),
-            })
+            .await
+        {
+            return None;
         }
+
+        Some(LanguageServerBinary {
+            path: self.node.binary_path().await.ok()?,
+            env: None,
+            arguments: typescript_server_binary_arguments(&server_path),
+        })
     }
 
     async fn fetch_server_binary(


### PR DESCRIPTION
Closes #43155

Adds a missing check to also update packages when the `typescript-language-server` package is outdated. 

I created a new `SERVER_PACKAGE_NAME ` constant so that the package name isn't coupled to the language server name inside of Zed.

Release Notes:

- Fixed the typescript language server falling out of date
