### PR TITLE
Add file_preview_modes to settings to control whether files open in preview or editor

### DIFF
--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -250,6 +250,12 @@ impl MarkdownPreviewView {
         }
     }
 
+    pub fn active_editor(&self) -> Option<Entity<Editor>> {
+        self.active_editor
+            .as_ref()
+            .map(|state| state.editor.clone())
+    }
+
     pub fn is_markdown_file<V>(editor: &Entity<Editor>, cx: &mut Context<V>) -> bool {
         let buffer = editor.read(cx).buffer().read(cx);
         if let Some(buffer) = buffer.as_singleton()

--- a/crates/settings/src/settings_content/workspace.rs
+++ b/crates/settings/src/settings_content/workspace.rs
@@ -112,6 +112,47 @@ pub struct WorkspaceSettingsContent {
     /// What draws window decorations/titlebar, the client application (Zed) or display server
     /// Default: client
     pub window_decorations: Option<WindowDecorations>,
+    /// Rules for automatic file preview modes.
+    /// Rules are evaluated in order; first match wins.
+    ///
+    /// Example:
+    /// ```json
+    /// "file_preview_modes": [
+    ///   {"filter": "README.md", "mode": "preview_only"},
+    ///   {"filter": "docs/**/*.md", "mode": "preview_and_editor"}
+    /// ]
+    /// ```
+    pub file_preview_modes: Option<Vec<FilePreviewModeRule>>,
+}
+
+/// Configuration for automatic file preview modes based on file patterns
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct FilePreviewModeRule {
+    /// Glob pattern for matching files
+    /// Examples: "*.md", "docs/**/*.md", "README.md"
+    pub filter: String,
+
+    /// Preview mode to apply
+    /// - "preview_only": Show only preview (markdown/SVG)
+    /// - "preview_and_editor": Show both preview and editor side-by-side
+    #[serde(default = "default_preview_mode")]
+    pub mode: PreviewMode,
+}
+
+/// Mode for displaying file previews
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum PreviewMode {
+    /// Show only the preview view
+    PreviewOnly,
+
+    /// Show both preview and editor in split panes
+    #[default]
+    PreviewAndEditor,
+}
+
+fn default_preview_mode() -> PreviewMode {
+    PreviewMode::PreviewAndEditor
 }
 
 #[with_fallible_options]

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -861,6 +861,7 @@ impl VsCodeSettings {
                 }
             }),
             zoomed_padding: None,
+            file_preview_modes: None,
         }
     }
 

--- a/crates/svg_preview/src/svg_preview.rs
+++ b/crates/svg_preview/src/svg_preview.rs
@@ -1,5 +1,8 @@
-use gpui::{App, actions};
-use workspace::Workspace;
+use std::sync::Arc;
+
+use gpui::{App, Context, Window, actions};
+use language::LanguageRegistry;
+use workspace::{ItemHandle, PreviewFactory, Workspace, register_preview_factory};
 
 pub mod svg_preview_view;
 
@@ -16,6 +19,9 @@ actions!(
 );
 
 pub fn init(cx: &mut App) {
+    // Register the preview factory
+    register_preview_factory(Arc::new(SvgPreviewFactory), cx);
+
     cx.observe_new(|workspace: &mut Workspace, window, cx| {
         let Some(window) = window else {
             return;
@@ -23,4 +29,47 @@ pub fn init(cx: &mut App) {
         crate::svg_preview_view::SvgPreviewView::register(workspace, window, cx);
     })
     .detach();
+}
+
+struct SvgPreviewFactory;
+
+impl PreviewFactory for SvgPreviewFactory {
+    fn can_preview_extension(&self, extension: &str) -> bool {
+        extension.eq_ignore_ascii_case("svg")
+    }
+
+    fn can_preview(&self, item: &dyn ItemHandle, cx: &App) -> bool {
+        // Check if the item has an SVG file extension
+        let mut can_preview = false;
+        item.for_each_project_item(cx, &mut |_, project_item| {
+            if let Some(path) = project_item.project_path(cx) {
+                if let Some(extension) = path.path.extension() {
+                    can_preview = extension.eq_ignore_ascii_case("svg");
+                }
+            }
+        });
+        can_preview
+    }
+
+    fn create_preview(
+        &self,
+        item: Box<dyn ItemHandle>,
+        _language_registry: Arc<language::LanguageRegistry>,
+        window: &mut Window,
+        cx: &mut Context<Workspace>,
+    ) -> Box<dyn ItemHandle> {
+        use svg_preview_view::{SvgPreviewMode, SvgPreviewView};
+
+        // Get the MultiBuffer from the item using act_as
+        // This works because Editor implements act_as for MultiBuffer
+        let buffer = item
+            .act_as::<multi_buffer::MultiBuffer>(cx)
+            .expect("Item should be able to provide a MultiBuffer");
+
+        let workspace = cx.entity().downgrade();
+
+        let preview = SvgPreviewView::new(SvgPreviewMode::Default, buffer, workspace, window, cx);
+
+        Box::new(preview)
+    }
 }

--- a/crates/svg_preview/src/svg_preview_view.rs
+++ b/crates/svg_preview/src/svg_preview_view.rs
@@ -190,6 +190,10 @@ impl SvgPreviewView {
         )
     }
 
+    pub fn buffer(&self) -> Option<&Entity<Buffer>> {
+        self.buffer.as_ref()
+    }
+
     pub fn is_svg_file(buffer: &Entity<MultiBuffer>, cx: &App) -> bool {
         buffer
             .read(cx)

--- a/crates/workspace/src/open_editor.rs
+++ b/crates/workspace/src/open_editor.rs
@@ -1,0 +1,79 @@
+use std::sync::Arc;
+
+use gpui::{App, Global, Window};
+
+use crate::{ItemHandle, Workspace};
+
+pub fn init(cx: &mut App) {
+    cx.observe_new(|workspace: &mut Workspace, _window, _cx| {
+        workspace.register_action(|workspace, _: &crate::OpenEditor, window, cx| {
+            if let Some(active_item) = workspace.active_item(cx) {
+                if let Some(source_item) =
+                    get_source_item_from_preview(active_item.as_ref(), window, cx)
+                {
+                    // Open the source item using the standard workspace flow
+                    workspace.add_item_to_active_pane(source_item, None, true, window, cx);
+                }
+            }
+        });
+    })
+    .detach();
+}
+
+/// Registry for extracting source items from preview items.
+#[derive(Clone, Default)]
+pub struct PreviewSourceRegistry {
+    extractors: Vec<Arc<dyn PreviewSourceExtractor>>,
+}
+
+impl Global for PreviewSourceRegistry {}
+
+impl PreviewSourceRegistry {
+    pub fn register(&mut self, extractor: Arc<dyn PreviewSourceExtractor>) {
+        self.extractors.push(extractor);
+    }
+
+    pub fn get_source_item(
+        &self,
+        item: &dyn ItemHandle,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> Option<Box<dyn ItemHandle>> {
+        let extractors = self.extractors.clone();
+        for extractor in extractors {
+            if let Some(source) = extractor.extract_source(item, window, cx) {
+                return Some(source);
+            }
+        }
+        None
+    }
+}
+
+/// Trait for extracting source items from preview items.
+pub trait PreviewSourceExtractor: Send + Sync {
+    /// Attempts to extract the source item from a preview.
+    /// Returns None if this extractor doesn't handle this preview type.
+    fn extract_source(
+        &self,
+        item: &dyn ItemHandle,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> Option<Box<dyn ItemHandle>>;
+}
+
+/// Register a preview source extractor globally.
+pub fn register_preview_source_extractor(extractor: Arc<dyn PreviewSourceExtractor>, cx: &mut App) {
+    cx.default_global::<PreviewSourceRegistry>()
+        .register(extractor);
+}
+
+/// Attempts to extract the source item (editor/buffer) from a preview item.
+/// Returns None if the item is not a preview or if extraction fails.
+fn get_source_item_from_preview(
+    item: &dyn ItemHandle,
+    window: &mut Window,
+    cx: &mut App,
+) -> Option<Box<dyn ItemHandle>> {
+    let registry = cx.try_global::<PreviewSourceRegistry>()?.clone();
+    registry.get_source_item(item, window, cx)
+}

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -3859,9 +3859,9 @@ impl Workspace {
             pane.open_item(
                 project_entry_id,
                 project_path,
-                false,
+                focus_item,
                 allow_preview,
-                false,
+                activate,
                 None,
                 window,
                 cx,
@@ -3889,9 +3889,6 @@ impl Workspace {
             if let Some(item) = pane.active_item() {
                 let index = pane.index_for_item(item.as_ref()).unwrap();
                 pane.activate_item(index, activate, focus_item, window, cx);
-                if focus_item {
-                    pane.focus_active_item(window, cx)
-                };
             }
         });
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -4,6 +4,7 @@ pub mod invalid_item_view;
 pub mod item;
 mod modal_layer;
 pub mod notifications;
+mod open_editor;
 pub mod pane;
 pub mod pane_group;
 mod path_list;
@@ -58,6 +59,9 @@ use node_runtime::NodeRuntime;
 use notifications::{
     DetachAndPromptErr, Notifications, dismiss_app_notification,
     simple_message_notification::MessageNotification,
+};
+pub use open_editor::{
+    PreviewSourceExtractor, PreviewSourceRegistry, register_preview_source_extractor,
 };
 pub use pane::*;
 pub use pane_group::{
@@ -231,6 +235,8 @@ actions!(
         NewWindow,
         /// Opens a file or directory.
         Open,
+        /// Opens the source editor for the current preview.
+        OpenEditor,
         /// Opens multiple files.
         OpenFiles,
         /// Opens the current location in terminal.
@@ -568,6 +574,7 @@ pub fn init(app_state: Arc<AppState>, cx: &mut App) {
     theme_preview::init(cx);
     toast_layer::init(cx);
     history_manager::init(cx);
+    open_editor::init(cx);
 
     cx.on_action(|_: &CloseWindow, cx| Workspace::close_global(cx));
     cx.on_action(|_: &Reload, cx| reload(cx));

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -3777,7 +3777,7 @@ impl Workspace {
         &mut self,
         pane: WeakEntity<Pane>,
         project_entry_id: Option<ProjectEntryId>,
-        project_path: ProjectPath,
+        _project_path: ProjectPath,
         build_item: WorkspaceItemBuilder,
         focus_item: bool,
         allow_preview: bool,

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -3736,7 +3736,9 @@ impl Workspace {
         // Check rules in order (first match wins)
         let path_style = self.project.read(cx).path_style(cx);
         for rule in &settings.file_preview_modes {
-            let matcher = util::paths::PathMatcher::new(&[rule.filter.clone()], path_style).ok()?;
+            let matcher =
+                util::paths::PathMatcher::new(std::slice::from_ref(&rule.filter), path_style)
+                    .ok()?;
 
             if matcher.is_match(&path.path) {
                 return Some(rule.mode);

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -4,8 +4,9 @@ use crate::DockPosition;
 use collections::HashMap;
 use serde::Deserialize;
 pub use settings::{
-    AutosaveSetting, BottomDockLayout, InactiveOpacity, PaneSplitDirectionHorizontal,
-    PaneSplitDirectionVertical, RegisterSetting, RestoreOnStartupBehavior, Settings,
+    AutosaveSetting, BottomDockLayout, FilePreviewModeRule, InactiveOpacity,
+    PaneSplitDirectionHorizontal, PaneSplitDirectionVertical, RegisterSetting,
+    RestoreOnStartupBehavior, Settings,
 };
 
 #[derive(RegisterSetting)]
@@ -32,6 +33,7 @@ pub struct WorkspaceSettings {
     pub use_system_window_tabs: bool,
     pub zoomed_padding: bool,
     pub window_decorations: settings::WindowDecorations,
+    pub file_preview_modes: Vec<FilePreviewModeRule>,
 }
 
 #[derive(Copy, Clone, PartialEq, Debug, Default)]
@@ -107,6 +109,7 @@ impl Settings for WorkspaceSettings {
             use_system_window_tabs: workspace.use_system_window_tabs.unwrap(),
             zoomed_padding: workspace.zoomed_padding.unwrap(),
             window_decorations: workspace.window_decorations.unwrap(),
+            file_preview_modes: workspace.file_preview_modes.clone().unwrap_or_default(),
         }
     }
 }


### PR DESCRIPTION
Closes #10966

Release Notes:
- Added settings to open .md and .svg as preview only or preview with editor

# Overview

Added to settings section:
```json
{
  "file_preview_modes": [
    { "filter": "README.md", "mode": "preview_only" },
    { "filter": "docs/**/*.md", "mode": "preview_and_editor" },
    { "filter": "*.svg", "mode": "preview_only" },
  ],
  ...
 }
``` 

that processed on file opening and for:
- preview_only - opens only preview with editor under the hood. with option to just to editor using command "Open editor"
- preview_and_editor - opens editor in current pane and preview to the right with preserving focus in editor.
