### PR TITLE
vim: Fix editor paste not using clipboard in visual mode

### DIFF
--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -924,6 +924,7 @@ impl Vim {
                 |vim, _: &editor::actions::Paste, window, cx| match vim.mode {
                     Mode::Replace => vim.paste_replace(window, cx),
                     Mode::Visual | Mode::VisualLine | Mode::VisualBlock => {
+                        vim.selected_register.replace('+');
                         vim.paste(&VimPaste::default(), window, cx);
                     }
                     _ => {


### PR DESCRIPTION
Closes #44178

Release Notes:

- Fixed editor paste not using clipboard when in Vim visual mode
