### PR TITLE
Update Recent Projects picker to show SSH host

### DIFF
--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -532,8 +532,8 @@ impl PickerDelegate for RecentProjectsDelegate {
             .unzip();
 
         let prefix = match &location {
-            SerializedWorkspaceLocation::Remote(RemoteConnectionOptions::Wsl(wsl)) => {
-                Some(SharedString::from(&wsl.distro_name))
+            SerializedWorkspaceLocation::Remote(options) => {
+                Some(SharedString::from(options.display_name()))
             }
             _ => None,
         };


### PR DESCRIPTION
**Problem addressed:**

Cannot distinguish an identical path on multiple remote hosts in the "Recent Projects" picker.

**Related work:**

- Issue #40358 (already closed) identified the issue in the "Expected Behavior" section for both WSL and SSH remotes.
- PR #40375 implemented WSL distro labels.

**Screenshots:**

Before:
<img width="485" height="98" alt="screenshot-sample-project-before" src="https://github.com/user-attachments/assets/182d907a-6f11-44aa-8ca5-8114f5551c93" />

After:
<img width="481" height="94" alt="screenshot-sample-project-after" src="https://github.com/user-attachments/assets/5f87ff12-6577-404e-9319-717f84b7d2e7" />

**Implementation notes:**

RemoteConnectionOptions::display_name() will be subject to exhaustiveness checking on RemoteConnectionOption variants.

Keeps the same UI approach as the WSL distro variants.

Release Notes:

- Improved Recent Projects picker: now displays SSH hostname with remotes.
