### PR TITLE
ui: Remove support for unnecessary Switch colors

### DIFF
--- a/crates/agent_ui/src/agent_configuration.rs
+++ b/crates/agent_ui/src/agent_configuration.rs
@@ -36,7 +36,7 @@ use settings::{Settings, SettingsStore, update_settings_file};
 use ui::{
     Button, ButtonStyle, Chip, CommonAnimationExt, ContextMenu, ContextMenuEntry, Disclosure,
     Divider, DividerColor, ElevationIndex, IconName, IconPosition, IconSize, Indicator, LabelSize,
-    PopoverMenu, Switch, SwitchColor, Tooltip, WithScrollbar, prelude::*,
+    PopoverMenu, Switch, Tooltip, WithScrollbar, prelude::*,
 };
 use util::ResultExt as _;
 use workspace::{Workspace, create_and_open_local_file};
@@ -879,7 +879,6 @@ impl AgentConfiguration {
                             .child(context_server_configuration_menu)
                             .child(
                             Switch::new("context-server-switch", is_running.into())
-                                .color(SwitchColor::Accent)
                                 .on_click({
                                     let context_server_manager = self.context_server_store.clone();
                                     let fs = self.fs.clone();

--- a/crates/debugger_ui/src/new_process_modal.rs
+++ b/crates/debugger_ui/src/new_process_modal.rs
@@ -881,7 +881,6 @@ impl ConfigureMode {
                     .label("Stop on Entry")
                     .label_position(SwitchLabelPosition::Start)
                     .label_size(LabelSize::Default)
-                    .color(ui::SwitchColor::Accent)
                     .on_click({
                         let this = cx.weak_entity();
                         move |state, _, cx| {

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -1472,8 +1472,7 @@ impl ExtensionsPage {
                                                             },
                                                         );
                                                     },
-                                                ))
-                                                .color(ui::SwitchColor::Accent),
+                                                )),
                                             ),
                                     ),
                             )

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -29,8 +29,8 @@ use std::{
 use title_bar::platform_title_bar::PlatformTitleBar;
 use ui::{
     Banner, ContextMenu, Divider, DividerColor, DropdownMenu, DropdownStyle, IconButtonShape,
-    KeyBinding, KeybindingHint, PopoverMenu, Switch, SwitchColor, Tooltip, TreeViewItem,
-    WithScrollbar, prelude::*,
+    KeyBinding, KeybindingHint, PopoverMenu, Switch, Tooltip, TreeViewItem, WithScrollbar,
+    prelude::*,
 };
 use ui_input::{NumberField, NumberFieldType};
 use util::{ResultExt as _, paths::PathStyle, rel_path::RelPath};
@@ -3501,7 +3501,6 @@ fn render_toggle_button<B: Into<bool> + From<bool> + Copy>(
 
     Switch::new("toggle_button", toggle_state)
         .tab_index(0_isize)
-        .color(SwitchColor::Accent)
         .on_click({
             move |state, _window, cx| {
                 telemetry::event!("Settings Change", setting = field.json_path, type = file.setting_type());

--- a/crates/ui/src/components/toggle.rs
+++ b/crates/ui/src/components/toggle.rs
@@ -280,7 +280,6 @@ impl RenderOnce for Checkbox {
 /// Defines the color for a switch component.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Default)]
 pub enum SwitchColor {
-    Default,
     #[default]
     Accent,
     Custom(Hsla),
@@ -296,12 +295,6 @@ impl SwitchColor {
         }
 
         match self {
-            SwitchColor::Default => {
-                let colors = cx.theme().colors();
-                let base_color = colors.text;
-                let bg_color = colors.element_background.blend(base_color.opacity(0.08));
-                (bg_color, colors.border_variant)
-            }
             SwitchColor::Accent => {
                 let status = cx.theme().status();
                 let colors = cx.theme().colors();
@@ -315,7 +308,6 @@ impl SwitchColor {
 impl From<SwitchColor> for Color {
     fn from(color: SwitchColor) -> Self {
         match color {
-            SwitchColor::Default => Color::Default,
             SwitchColor::Accent => Color::Accent,
             SwitchColor::Custom(_) => Color::Default,
         }
@@ -963,16 +955,8 @@ impl Component for Switch {
                         "Colors",
                         vec![
                             single_example(
-                                "Default",
-                                Switch::new("switch_default_style", ToggleState::Selected)
-                                    .color(SwitchColor::Default)
-                                    .on_click(|_, _, _cx| {})
-                                    .into_any_element(),
-                            ),
-                            single_example(
-                                "Accent",
+                                "Accent (Default)",
                                 Switch::new("switch_accent_style", ToggleState::Selected)
-                                    .color(SwitchColor::Accent)
                                     .on_click(|_, _, _cx| {})
                                     .into_any_element(),
                             ),

--- a/crates/ui/src/components/toggle.rs
+++ b/crates/ui/src/components/toggle.rs
@@ -280,12 +280,9 @@ impl RenderOnce for Checkbox {
 /// Defines the color for a switch component.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Default)]
 pub enum SwitchColor {
-    #[default]
     Default,
+    #[default]
     Accent,
-    Error,
-    Warning,
-    Success,
     Custom(Hsla),
 }
 
@@ -307,19 +304,8 @@ impl SwitchColor {
             }
             SwitchColor::Accent => {
                 let status = cx.theme().status();
-                (status.info.opacity(0.4), status.info.opacity(0.2))
-            }
-            SwitchColor::Error => {
-                let status = cx.theme().status();
-                (status.error.opacity(0.4), status.error.opacity(0.2))
-            }
-            SwitchColor::Warning => {
-                let status = cx.theme().status();
-                (status.warning.opacity(0.4), status.warning.opacity(0.2))
-            }
-            SwitchColor::Success => {
-                let status = cx.theme().status();
-                (status.success.opacity(0.4), status.success.opacity(0.2))
+                let colors = cx.theme().colors();
+                (status.info.opacity(0.4), colors.text_accent.opacity(0.2))
             }
             SwitchColor::Custom(color) => (*color, color.opacity(0.6)),
         }
@@ -331,9 +317,6 @@ impl From<SwitchColor> for Color {
         match color {
             SwitchColor::Default => Color::Default,
             SwitchColor::Accent => Color::Accent,
-            SwitchColor::Error => Color::Error,
-            SwitchColor::Warning => Color::Warning,
-            SwitchColor::Success => Color::Success,
             SwitchColor::Custom(_) => Color::Default,
         }
     }
@@ -990,27 +973,6 @@ impl Component for Switch {
                                 "Accent",
                                 Switch::new("switch_accent_style", ToggleState::Selected)
                                     .color(SwitchColor::Accent)
-                                    .on_click(|_, _, _cx| {})
-                                    .into_any_element(),
-                            ),
-                            single_example(
-                                "Error",
-                                Switch::new("switch_error_style", ToggleState::Selected)
-                                    .color(SwitchColor::Error)
-                                    .on_click(|_, _, _cx| {})
-                                    .into_any_element(),
-                            ),
-                            single_example(
-                                "Warning",
-                                Switch::new("switch_warning_style", ToggleState::Selected)
-                                    .color(SwitchColor::Warning)
-                                    .on_click(|_, _, _cx| {})
-                                    .into_any_element(),
-                            ),
-                            single_example(
-                                "Success",
-                                Switch::new("switch_success_style", ToggleState::Selected)
-                                    .color(SwitchColor::Success)
                                     .on_click(|_, _, _cx| {})
                                     .into_any_element(),
                             ),


### PR DESCRIPTION
This PR removes the default, error, warning, and success color variants from the `SwitchColor` enum. In the most YAGNI spirit, I think we'll probably never want to use these colors for the switch, so there's no reason to support them. And if we ever want to do it, we can re-add them. 

I also took the opportunity to change the default color to be "accent", which is _already_ what we use for all instances of this component, so there's no need to have to define it every time. This effectively makes the enum support only "accent" and "custom", which I think is okay for now if we ever need an escape hatch before committing to supporting new values.

Release Notes:

- N/A
