### PR TITLE
acp: Fix download path for Codex on ARM Windows

### DIFF
--- a/crates/project/src/agent_server_store.rs
+++ b/crates/project/src/agent_server_store.rs
@@ -1501,8 +1501,8 @@ fn get_platform_info() -> Option<(&'static str, &'static str, &'static str)> {
         return None;
     };
 
-    // Only Windows x86_64 uses .zip in release assets
-    let ext = if cfg!(target_os = "windows") && cfg!(target_arch = "x86_64") {
+    // Windows uses .zip in release assets
+    let ext = if cfg!(target_os = "windows") {
         "zip"
     } else {
         "tar.gz"


### PR DESCRIPTION
Both windows paths use .zip, not .tar.gz

Closes #44378

Release Notes:

- acp: Fix codex-acp download path for ARM Windows targets
