### PR TITLE
extension_api: Add support for xz compression format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3616,6 +3616,7 @@ dependencies = [
  "compression-core",
  "deflate64",
  "flate2",
+ "liblzma",
  "memchr",
 ]
 
@@ -9166,6 +9167,26 @@ checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "liblzma"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73c36d08cad03a3fbe2c4e7bb3a9e84c57e4ee4135ed0b065cade3d98480c648"
+dependencies = [
+ "liblzma-sys",
+]
+
+[[package]]
+name = "liblzma-sys"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01b9596486f6d60c3bbe644c0e1be1aa6ccc472ad630fe8927b456973d7cb736"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -447,7 +447,7 @@ anyhow = "1.0.86"
 arrayvec = { version = "0.7.4", features = ["serde"] }
 ashpd = { version = "0.11", default-features = false, features = ["async-std"] }
 async-compat = "0.2.1"
-async-compression = { version = "0.4", features = ["gzip", "futures-io"] }
+async-compression = { version = "0.4", features = ["gzip", "xz", "futures-io"] }
 async-dispatcher = "0.1"
 async-fs = "2.1"
 async-lock = "2.1"

--- a/crates/extension_api/wit/since_v0.8.0/extension.wit
+++ b/crates/extension_api/wit/since_v0.8.0/extension.wit
@@ -25,6 +25,8 @@ world extension {
         gzip,
         /// A gzipped tar archive (`.tar.gz`).
         gzip-tar,
+        /// A xz compressed archive (`.xz`)
+        xz,
         /// A ZIP file (`.zip`).
         zip,
         /// An uncompressed file.

--- a/crates/extension_host/src/wasm_host/wit/since_v0_1_0.rs
+++ b/crates/extension_host/src/wasm_host/wit/since_v0_1_0.rs
@@ -545,7 +545,7 @@ impl ExtensionImports for WasmState {
                     futures::pin_mut!(body);
                     self.host
                         .fs
-                        .extract_tar_file(&destination_path, Archive::new(body))
+                        .extract_archive(&destination_path, Archive::new(body))
                         .await?;
                 }
                 DownloadedFileType::Zip => {

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -100,7 +100,7 @@ pub trait Fs: Send + Sync {
         path: &Path,
         content: Pin<&mut (dyn AsyncRead + Send)>,
     ) -> Result<()>;
-    async fn extract_tar_file(
+    async fn extract_archive(
         &self,
         path: &Path,
         content: Archive<Pin<&mut (dyn AsyncRead + Send)>>,
@@ -550,7 +550,7 @@ impl Fs for RealFs {
         Ok(())
     }
 
-    async fn extract_tar_file(
+    async fn extract_archive(
         &self,
         path: &Path,
         content: Archive<Pin<&mut (dyn AsyncRead + Send)>>,
@@ -2340,7 +2340,7 @@ impl Fs for FakeFs {
         Ok(())
     }
 
-    async fn extract_tar_file(
+    async fn extract_archive(
         &self,
         path: &Path,
         content: Archive<Pin<&mut (dyn AsyncRead + Send)>>,


### PR DESCRIPTION
This allows extensions to download and uncompress xz archives via the `zed_extension_api::download_file` method

Release Notes:

- N/A
