### PR TITLE
extension_api: Update default trait implementations for language server settings

### DIFF
--- a/crates/extension_api/src/extension_api.rs
+++ b/crates/extension_api/src/extension_api.rs
@@ -6,6 +6,7 @@ pub mod settings;
 
 use core::fmt;
 
+use crate::settings::LspSettings;
 use wit::*;
 
 pub use serde_json;
@@ -85,19 +86,21 @@ pub trait Extension: Send + Sync {
     /// Returns the initialization options to pass to the specified language server.
     fn language_server_initialization_options(
         &mut self,
-        _language_server_id: &LanguageServerId,
-        _worktree: &Worktree,
+        language_server_id: &LanguageServerId,
+        worktree: &Worktree,
     ) -> Result<Option<serde_json::Value>> {
-        Ok(None)
+        LspSettings::for_worktree(language_server_id.as_ref(), worktree)
+            .map(|settings| settings.initialization_options.clone())
     }
 
     /// Returns the workspace configuration options to pass to the language server.
     fn language_server_workspace_configuration(
         &mut self,
-        _language_server_id: &LanguageServerId,
-        _worktree: &Worktree,
+        language_server_id: &LanguageServerId,
+        worktree: &Worktree,
     ) -> Result<Option<serde_json::Value>> {
-        Ok(None)
+        LspSettings::for_worktree(language_server_id.as_ref(), worktree)
+            .map(|settings| settings.settings.clone())
     }
 
     /// Returns the initialization options to pass to the other language server.

--- a/crates/extension_api/src/extension_api.rs
+++ b/crates/extension_api/src/extension_api.rs
@@ -90,7 +90,7 @@ pub trait Extension: Send + Sync {
         worktree: &Worktree,
     ) -> Result<Option<serde_json::Value>> {
         LspSettings::for_worktree(language_server_id.as_ref(), worktree)
-            .map(|settings| settings.initialization_options.clone())
+            .map(|settings| settings.initialization_options)
     }
 
     /// Returns the workspace configuration options to pass to the language server.
@@ -100,7 +100,7 @@ pub trait Extension: Send + Sync {
         worktree: &Worktree,
     ) -> Result<Option<serde_json::Value>> {
         LspSettings::for_worktree(language_server_id.as_ref(), worktree)
-            .map(|settings| settings.settings.clone())
+            .map(|settings| settings.settings)
     }
 
     /// Returns the initialization options to pass to the other language server.


### PR DESCRIPTION
With this change, language servers will have settings and initialization options propagated to them by default. This removes the need for authors to implement this manually whilst still giving the option to opt out of this behavior.

Release Notes:

- N/A
