### PR TITLE
nix: Fix nix build failure due to missing `protoc`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ xcuserdata/
 # Don't commit any secrets to the repo.
 .env
 .env.secret.toml
+
+# `nix build` output
+/result 

--- a/nix/build.nix
+++ b/nix/build.nix
@@ -177,6 +177,7 @@ let
         ZED_UPDATE_EXPLANATION = "Zed has been installed using Nix. Auto-updates have thus been disabled.";
         RELEASE_VERSION = version;
         LK_CUSTOM_WEBRTC = livekit-libwebrtc;
+        PROTOC="${protobuf}/bin/protoc";
 
         CARGO_PROFILE = profile;
         # need to handle some profiles specially https://github.com/rust-lang/cargo/issues/11053


### PR DESCRIPTION
Sets `$PROTOC` to prevent build failures in `proto` under nix

Release Notes:

- N/A 
