### PR TITLE
git: Use branch names for resolve conflict buttons

### DIFF
--- a/crates/git_ui/src/conflict_view.rs
+++ b/crates/git_ui/src/conflict_view.rs
@@ -372,7 +372,7 @@ fn render_conflict_buttons(
         .gap_1()
         .bg(cx.theme().colors().editor_background)
         .child(
-            Button::new("head", format!("Use {}", conflict.ours_name))
+            Button::new("head", format!("Use {}", conflict.ours_branch_name))
                 .label_size(LabelSize::Small)
                 .on_click({
                     let editor = editor.clone();
@@ -392,7 +392,7 @@ fn render_conflict_buttons(
                 }),
         )
         .child(
-            Button::new("origin", format!("Use {}", conflict.theirs_name))
+            Button::new("origin", format!("Use {}", conflict.theirs_branch_name))
                 .label_size(LabelSize::Small)
                 .on_click({
                     let editor = editor.clone();

--- a/crates/git_ui/src/conflict_view.rs
+++ b/crates/git_ui/src/conflict_view.rs
@@ -372,7 +372,7 @@ fn render_conflict_buttons(
         .gap_1()
         .bg(cx.theme().colors().editor_background)
         .child(
-            Button::new("head", "Use HEAD")
+            Button::new("head", format!("Use {}", conflict.ours_name))
                 .label_size(LabelSize::Small)
                 .on_click({
                     let editor = editor.clone();
@@ -392,7 +392,7 @@ fn render_conflict_buttons(
                 }),
         )
         .child(
-            Button::new("origin", "Use Origin")
+            Button::new("origin", format!("Use {}", conflict.theirs_name))
                 .label_size(LabelSize::Small)
                 .on_click({
                     let editor = editor.clone();

--- a/crates/project/src/git_store/conflict_set.rs
+++ b/crates/project/src/git_store/conflict_set.rs
@@ -245,7 +245,7 @@ impl ConflictSet {
                 conflicts.push(ConflictRegion {
                     ours_name: ours_branch_name
                         .take()
-                        .unwrap_or_else(|| SharedString::new_static("Head")),
+                        .unwrap_or_else(|| SharedString::new_static("HEAD")),
                     theirs_name: theirs_branch_name
                         .take()
                         .unwrap_or_else(|| SharedString::new_static("Origin")),


### PR DESCRIPTION
This makes merge conflict resolution clearer because we're now parsing the branch names from the conflict region instead of hardcoding HEAD and ORIGIN.

### Before
<img width="1157" height="1308" alt="image" src="https://github.com/user-attachments/assets/1fd72823-4650-48dd-b26a-77c66d21614d" />

### After
<img width="1440" height="1249" alt="Screenshot 2025-12-08 at 2 17 12 PM" src="https://github.com/user-attachments/assets/d23c219a-6128-4e2d-a8bc-3f128aa55272" />

Release Notes:

- git: Use branch names for git conflict buttons instead of HEAD and ORIGIN
