### PR TITLE
Fix LSP startup failure in secondary remote windows

### DIFF
--- a/crates/project/src/manifest_tree.rs
+++ b/crates/project/src/manifest_tree.rs
@@ -44,9 +44,21 @@ impl WorktreeRoots {
                 match event {
                     WorktreeEvent::UpdatedEntries(changes) => {
                         for (path, _, kind) in changes.iter() {
-                            if kind == &worktree::PathChange::Removed {
-                                let path = TriePath::from(path.as_ref());
-                                this.roots.remove(&path);
+                            match kind {
+                                worktree::PathChange::Removed => {
+                                    let path = TriePath::from(path.as_ref());
+                                    this.roots.remove(&path);
+                                }
+                                _ => {
+                                    if let Some(parent) = path.parent() {
+                                        if parent.is_empty() {
+                                            this.roots = RootPathTrie::new();
+                                        } else {
+                                            let parent = TriePath::from(parent);
+                                            this.roots.remove(&parent);
+                                        }
+                                    }
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Closes #43318 

Release Notes:
- Fixed LSP startup failure in secondary remote windows
  When opening a second window or worktree in a remote environment, a race condition often occurred where ManifestTree scanned for project roots (e.g., package.json, mix.exs) before the remote file system fully synced. This resulted in a "KnownAbsent" cache entry that permanently blocked LSP startup because the cache invalidation logic only listened for file removals, ignoring additions.
  
  This commit updates WorktreeRoots to invalidate the manifest cache when files are added or updated. This ensures that when the manifest file inevitably appears, Zed clears the stale KnownAbsent state, allowing the Language Server to discover the project root and start correctly.
  
  This fixes issues where:
  1. Extension-based LSPs (Elixir, PHP) failed to start entirely.
  2. Built-in LSPs (Rust, TS) started in a degraded "single-file" mode (showing "Unknown worktree").

