### PR TITLE
extension_cli: Properly populate manifest with snippet location

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5799,6 +5799,7 @@ dependencies = [
  "gpui",
  "heck 0.5.0",
  "http_client",
+ "indoc",
  "language",
  "log",
  "lsp",

--- a/crates/extension/Cargo.toml
+++ b/crates/extension/Cargo.toml
@@ -37,5 +37,8 @@ wasm-encoder.workspace = true
 wasmparser.workspace = true
 
 [dev-dependencies]
+fs = { workspace = true, "features" = ["test-support"] }
+gpui = { workspace = true, "features" = ["test-support"] }
+indoc.workspace = true
 pretty_assertions.workspace = true
 tempfile.workspace = true

--- a/crates/extension_cli/src/main.rs
+++ b/crates/extension_cli/src/main.rs
@@ -71,6 +71,7 @@ async fn main() -> Result<()> {
             &extension_path,
             &mut manifest,
             CompileExtensionOptions { release: true },
+            fs.clone(),
         )
         .await
         .context("failed to compile extension")?;

--- a/crates/extension_host/src/extension_host.rs
+++ b/crates/extension_host/src/extension_host.rs
@@ -980,12 +980,14 @@ impl ExtensionStore {
 
             cx.background_spawn({
                 let extension_source_path = extension_source_path.clone();
+                let fs = fs.clone();
                 async move {
                     builder
                         .compile_extension(
                             &extension_source_path,
                             &mut extension_manifest,
                             CompileExtensionOptions { release: false },
+                            fs,
                         )
                         .await
                 }
@@ -1042,12 +1044,13 @@ impl ExtensionStore {
 
         cx.notify();
         let compile = cx.background_spawn(async move {
-            let mut manifest = ExtensionManifest::load(fs, &path).await?;
+            let mut manifest = ExtensionManifest::load(fs.clone(), &path).await?;
             builder
                 .compile_extension(
                     &path,
                     &mut manifest,
                     CompileExtensionOptions { release: true },
+                    fs,
                 )
                 .await
         });


### PR DESCRIPTION
This fixes an issue where the snippet file location would not be the proper one for compiled extensions because it would be populated with an absolute path instead of a relative one in relation to the extension output directory. This caused the copy operation downstream to not do anything, because it copied the file to the location it already was (which was not the output directory for that extension).

Also adds some tests and pulls in the `Fs` so we do not have such issues with snippets a third time hopefully.

Release Notes:

- N/A