### PR TITLE
Disable OmniSharp by default for C# files

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1810,6 +1810,9 @@
         "allowed": false
       }
     },
+    "CSharp": {
+      "language_servers": ["roslyn", "!omnisharp", "..."]
+    },
     "CSS": {
       "prettier": {
         "allowed": true


### PR DESCRIPTION
In preparation for https://github.com/zed-extensions/csharp/pull/11. Do not merge before that PR is published.

Release Notes:

- Added support for Roslyn in C# files. Roslyn will now be the default language server for C#
