### PR TITLE
Fix telemetry for `collab::ToggleMute` and remove unregistered actions

### DIFF
--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -109,22 +109,8 @@ pub fn init(cx: &mut App) {
         });
         // TODO: make it possible to bind this one to a held key for push to talk?
         // how to make "toggle_on_modifiers_press" contextual?
-        workspace.register_action(|_, _: &Mute, window, cx| {
-            let room = ActiveCall::global(cx).read(cx).room().cloned();
-            if let Some(room) = room {
-                window.defer(cx, move |_window, cx| {
-                    room.update(cx, |room, cx| room.toggle_mute(cx))
-                });
-            }
-        });
-        workspace.register_action(|_, _: &Deafen, window, cx| {
-            let room = ActiveCall::global(cx).read(cx).room().cloned();
-            if let Some(room) = room {
-                window.defer(cx, move |_window, cx| {
-                    room.update(cx, |room, cx| room.toggle_deafen(cx))
-                });
-            }
-        });
+        workspace.register_action(|_, _: &Mute, _, cx| title_bar::collab::toggle_mute(cx));
+        workspace.register_action(|_, _: &Deafen, _, cx| title_bar::collab::toggle_deafen(cx));
         workspace.register_action(|_, _: &LeaveCall, window, cx| {
             CollabPanel::leave_call(window, cx);
         });

--- a/crates/title_bar/src/collab.rs
+++ b/crates/title_bar/src/collab.rs
@@ -8,7 +8,7 @@ use gpui::{
     AnyElement, Hsla, IntoElement, MouseButton, Path, ScreenCaptureSource, Styled, WeakEntity,
     canvas, point,
 };
-use gpui::{App, Task, Window, actions};
+use gpui::{App, Task, Window};
 use project::WorktreeSettings;
 use rpc::proto::{self};
 use settings::{Settings as _, SettingsLocation};
@@ -22,19 +22,7 @@ use workspace::notifications::DetachAndPromptErr;
 
 use crate::TitleBar;
 
-actions!(
-    collab,
-    [
-        /// Toggles screen sharing on or off.
-        ToggleScreenSharing,
-        /// Toggles microphone mute.
-        ToggleMute,
-        /// Toggles deafen mode (mute both microphone and speakers).
-        ToggleDeafen
-    ]
-);
-
-fn toggle_screen_sharing(
+pub fn toggle_screen_sharing(
     screen: anyhow::Result<Option<Rc<dyn ScreenCaptureSource>>>,
     window: &mut Window,
     cx: &mut App,
@@ -90,7 +78,7 @@ fn toggle_screen_sharing(
     toggle_screen_sharing.detach_and_prompt_err("Sharing Screen Failed", window, cx, |e, _, _| Some(format!("{:?}\n\nPlease check that you have given Zed permissions to record your screen in Settings.", e)));
 }
 
-fn toggle_mute(_: &ToggleMute, cx: &mut App) {
+pub fn toggle_mute(cx: &mut App) {
     let call = ActiveCall::global(cx).read(cx);
     if let Some(room) = call.room().cloned() {
         room.update(cx, |room, cx| {
@@ -110,7 +98,7 @@ fn toggle_mute(_: &ToggleMute, cx: &mut App) {
     }
 }
 
-fn toggle_deafen(_: &ToggleDeafen, cx: &mut App) {
+pub fn toggle_deafen(cx: &mut App) {
     if let Some(room) = ActiveCall::global(cx).read(cx).room().cloned() {
         room.update(cx, |room, cx| room.toggle_deafen(cx));
     }
@@ -458,9 +446,7 @@ impl TitleBar {
                 .icon_size(IconSize::Small)
                 .toggle_state(is_muted)
                 .selected_style(ButtonStyle::Tinted(TintColor::Error))
-                .on_click(move |_, _window, cx| {
-                    toggle_mute(&Default::default(), cx);
-                })
+                .on_click(move |_, _window, cx| toggle_mute(cx))
                 .into_any_element(),
             );
         }
@@ -497,7 +483,7 @@ impl TitleBar {
                     }
                 }
             })
-            .on_click(move |_, _, cx| toggle_deafen(&Default::default(), cx))
+            .on_click(move |_, _, cx| toggle_deafen(cx))
             .into_any_element(),
         );
 

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -1,5 +1,5 @@
 mod application_menu;
-mod collab;
+pub mod collab;
 mod onboarding_banner;
 pub mod platform_title_bar;
 mod platforms;


### PR DESCRIPTION
This PR removes the actions `collab::ToggleScreenSharing`, `collab::ToggleMute`, and `collab::ToggleDeafen`. They weren't actually registered to any behavior, so while it was possible to create a keybind bound to them, they never actually trigger. I spent ~30 minutes trying to figure out why I was getting this result for my `"f13": "collab::ToggleMute"` keybind in the keybind context menu:

<img width="485" height="174" alt="image" src="https://github.com/user-attachments/assets/23064c8f-fe8d-42e5-b94f-bd4b8a0cb3b5" />

(This really threw me for a loop because I was trying to use this as a known good case to compare against a _different_ action that wasn't working because I forgot to register it.)

As a side benefit, this enables telemetry for toggling mic mute via keybind.

Release Notes:

- Fixed telemetry for `collab::Mute`
- Removed unregistered actions `collab::ToggleMute`, `collab::ToggleDeafen`, and `collab::ToggleScreenshare`
  - The correctly-functioning actions `collab::Mute`, `collab::Deafen`, and `collab::ScreenShare` are recommended instead