### PR TITLE
proto: Add two language servers and change used grammar

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,4 +1,13 @@
 {
+  "lsp": {
+    "protols": {
+      "initialization_options": {
+        "include_paths": [
+          "crates/proto/proto"
+        ]
+      }
+    }
+  },
   "languages": {
     "Markdown": {
       "tab_size": 2,

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,13 +1,4 @@
 {
-  "lsp": {
-    "protols": {
-      "initialization_options": {
-        "include_paths": [
-          "crates/proto/proto"
-        ]
-      }
-    }
-  },
   "languages": {
     "Markdown": {
       "tab_size": 2,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20794,7 +20794,7 @@ dependencies = [
 name = "zed_proto"
 version = "0.2.3"
 dependencies = [
- "zed_extension_api 0.1.0",
+ "zed_extension_api 0.7.0",
 ]
 
 [[package]]

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1918,6 +1918,9 @@
       "allow_rewrap": "anywhere",
       "soft_wrap": "editor_width"
     },
+    "Proto": {
+      "language_servers": ["protols", "!protobuf-language-server", "..."]
+    },
     "Python": {
       "code_actions_on_format": {
         "source.organizeImports.ruff": true

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1919,7 +1919,7 @@
       "soft_wrap": "editor_width"
     },
     "Proto": {
-      "language_servers": ["protols", "!protobuf-language-server", "..."]
+      "language_servers": ["buf", "!protols", "!protobuf-language-server", "..."]
     },
     "Python": {
       "code_actions_on_format": {

--- a/extensions/proto/Cargo.toml
+++ b/extensions/proto/Cargo.toml
@@ -13,4 +13,4 @@ path = "src/proto.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.1.0"
+zed_extension_api = "0.7.0"

--- a/extensions/proto/extension.toml
+++ b/extensions/proto/extension.toml
@@ -10,6 +10,11 @@ repository = "https://github.com/zed-industries/zed"
 repository = "https://github.com/coder3101/tree-sitter-proto"
 commit = "a6caac94b5aa36b322b5b70040d5b67132f109d0"
 
+
+[language_servers.buf]
+name = "Buf"
+languages = ["Proto"]
+
 [language_servers.protobuf-language-server]
 name = "Protobuf Language Server"
 languages = ["Proto"]

--- a/extensions/proto/extension.toml
+++ b/extensions/proto/extension.toml
@@ -13,3 +13,7 @@ commit = "0848bd30a64be48772e15fbb9d5ba8c0cc5772ad"
 [language_servers.protobuf-language-server]
 name = "Protobuf Language Server"
 languages = ["Proto"]
+
+[language_servers.protols]
+name = "Protols"
+languages = ["Proto"]

--- a/extensions/proto/extension.toml
+++ b/extensions/proto/extension.toml
@@ -7,8 +7,8 @@ authors = ["Zed Industries <support@zed.dev>"]
 repository = "https://github.com/zed-industries/zed"
 
 [grammars.proto]
-repository = "https://github.com/zed-industries/tree-sitter-proto"
-commit = "0848bd30a64be48772e15fbb9d5ba8c0cc5772ad"
+repository = "https://github.com/coder3101/tree-sitter-proto"
+commit = "a6caac94b5aa36b322b5b70040d5b67132f109d0"
 
 [language_servers.protobuf-language-server]
 name = "Protobuf Language Server"

--- a/extensions/proto/src/language_servers.rs
+++ b/extensions/proto/src/language_servers.rs
@@ -1,5 +1,8 @@
+mod buf;
 mod protobuf_language_server;
 mod protols;
+mod util;
 
+pub(crate) use buf::*;
 pub(crate) use protobuf_language_server::*;
 pub(crate) use protols::*;

--- a/extensions/proto/src/language_servers.rs
+++ b/extensions/proto/src/language_servers.rs
@@ -1,0 +1,5 @@
+mod protobuf_language_server;
+mod protols;
+
+pub(crate) use protobuf_language_server::*;
+pub(crate) use protols::*;

--- a/extensions/proto/src/language_servers/buf.rs
+++ b/extensions/proto/src/language_servers/buf.rs
@@ -72,9 +72,7 @@ impl BufLsp {
             (Os::Windows, Architecture::Aarch64) => "Windows-arm64.exe",
             (Os::Windows, Architecture::X8664) => "Windows-x86_64.exe",
             _ => {
-                return Err(format!(
-                    "Platform and architecture not supported by buf CLI"
-                ));
+                return Err("Platform and architecture not supported by buf CLI".to_string());
             }
         };
 

--- a/extensions/proto/src/language_servers/protobuf_language_server.rs
+++ b/extensions/proto/src/language_servers/protobuf_language_server.rs
@@ -1,0 +1,52 @@
+use zed_extension_api::{self as zed, Result, settings::LspSettings};
+
+pub(crate) struct ProtobufLanguageServer {
+    cached_binary_path: Option<String>,
+}
+
+impl ProtobufLanguageServer {
+    pub(crate) const SERVER_NAME: &str = "protobuf-language-server";
+
+    pub(crate) fn new() -> Self {
+        ProtobufLanguageServer {
+            cached_binary_path: None,
+        }
+    }
+
+    pub(crate) fn language_server_binary(
+        &mut self,
+        worktree: &zed::Worktree,
+    ) -> Result<zed::Command> {
+        let binary_settings = LspSettings::for_worktree(Self::SERVER_NAME, worktree)
+            .ok()
+            .and_then(|lsp_settings| lsp_settings.binary);
+
+        let args = binary_settings
+            .as_ref()
+            .and_then(|binary_settings| binary_settings.arguments.clone())
+            .unwrap_or_else(|| vec!["-logs".into(), "".into()]);
+
+        if let Some(path) = binary_settings.and_then(|binary_settings| binary_settings.path) {
+            Ok(zed::Command {
+                command: path,
+                args,
+                env: Default::default(),
+            })
+        } else if let Some(path) = self.cached_binary_path.clone() {
+            Ok(zed::Command {
+                command: path,
+                args,
+                env: Default::default(),
+            })
+        } else if let Some(path) = worktree.which(Self::SERVER_NAME) {
+            self.cached_binary_path = Some(path.clone());
+            Ok(zed::Command {
+                command: path,
+                args,
+                env: Default::default(),
+            })
+        } else {
+            Err(format!("{} not found in PATH", Self::SERVER_NAME))
+        }
+    }
+}

--- a/extensions/proto/src/language_servers/protols.rs
+++ b/extensions/proto/src/language_servers/protols.rs
@@ -1,0 +1,121 @@
+use std::fs;
+
+use zed_extension_api::{
+    self as zed, Architecture, DownloadedFileType, GithubReleaseOptions, Os, Result,
+    settings::LspSettings,
+};
+
+pub(crate) struct ProtoLs {
+    cached_binary_path: Option<String>,
+}
+
+impl ProtoLs {
+    pub(crate) const SERVER_NAME: &str = "protols";
+
+    pub(crate) fn new() -> Self {
+        ProtoLs {
+            cached_binary_path: None,
+        }
+    }
+
+    pub(crate) fn language_server_binary(
+        &mut self,
+        worktree: &zed::Worktree,
+    ) -> Result<zed::Command> {
+        let binary_settings = LspSettings::for_worktree(Self::SERVER_NAME, worktree)
+            .ok()
+            .and_then(|lsp_settings| lsp_settings.binary);
+
+        let args = binary_settings
+            .as_ref()
+            .and_then(|binary_settings| binary_settings.arguments.clone())
+            .unwrap_or_default();
+
+        let env = worktree.shell_env();
+
+        if let Some(path) = binary_settings.and_then(|binary_settings| binary_settings.path) {
+            return Ok(zed::Command {
+                command: path,
+                args,
+                env,
+            });
+        } else if let Some(path) = self.cached_binary_path.clone() {
+            return Ok(zed::Command {
+                command: path,
+                args,
+                env,
+            });
+        } else if let Some(path) = worktree.which(Self::SERVER_NAME) {
+            self.cached_binary_path = Some(path.clone());
+            return Ok(zed::Command {
+                command: path,
+                args,
+                env,
+            });
+        }
+
+        let latest_release = zed::latest_github_release(
+            "coder3101/protols",
+            GithubReleaseOptions {
+                require_assets: true,
+                pre_release: false,
+            },
+        )?;
+
+        let (os, arch) = zed::current_platform();
+
+        let release_suffix = match (os, arch) {
+            (Os::Mac, Architecture::Aarch64) => "aarch64-apple-darwin.tar.gz",
+            (Os::Mac, Architecture::X8664) => "x86_64-apple-darwin.tar.gz",
+            (Os::Linux, Architecture::Aarch64) => "aarch64-unknown-linux-gnu.tar.gz",
+            (Os::Linux, Architecture::X8664) => "x86_64-unknown-linux-gnu.tar.gz",
+            (Os::Windows, Architecture::X8664) => "x86_64-pc-windows-msvc.zip",
+            _ => {
+                return Err(format!(
+                    "Platform and architecture not supported by Protols"
+                ));
+            }
+        };
+
+        let release_name = format!("protols-{release_suffix}");
+
+        let file_type = if os == Os::Windows {
+            DownloadedFileType::Zip
+        } else {
+            DownloadedFileType::GzipTar
+        };
+
+        let version_dir = format!("{}-{}", Self::SERVER_NAME, latest_release.version);
+        let binary_path = format!("{version_dir}/protols");
+
+        let download_target = latest_release
+            .assets
+            .into_iter()
+            .find(|asset| asset.name == release_name)
+            .ok_or_else(|| {
+                format!(
+                    "Could not find asset with name {} in Protols release",
+                    &release_name
+                )
+            })?;
+
+        zed::download_file(&download_target.download_url, &version_dir, file_type)?;
+
+        let entries =
+            fs::read_dir(".").map_err(|e| format!("failed to list working directory {e}"))?;
+        for entry in entries {
+            let entry = entry.map_err(|e| format!("failed to load directory entry {e}"))?;
+            if entry.file_name().to_str() != Some(&version_dir) {
+                fs::remove_dir_all(entry.path()).ok();
+            }
+        }
+
+        self.cached_binary_path = Some(binary_path.clone());
+
+        Ok(zed::Command {
+            command: binary_path,
+            args,
+            env,
+        })
+    }
+}

--- a/extensions/proto/src/language_servers/protols.rs
+++ b/extensions/proto/src/language_servers/protols.rs
@@ -71,9 +71,7 @@ impl ProtoLs {
             (Os::Linux, Architecture::X8664) => "x86_64-unknown-linux-gnu.tar.gz",
             (Os::Windows, Architecture::X8664) => "x86_64-pc-windows-msvc.zip",
             _ => {
-                return Err(format!(
-                    "Platform and architecture not supported by Protols"
-                ));
+                return Err("Platform and architecture not supported by Protols".to_string());
             }
         };
 

--- a/extensions/proto/src/language_servers/util.rs
+++ b/extensions/proto/src/language_servers/util.rs
@@ -1,0 +1,19 @@
+use std::fs;
+
+use zed_extension_api::Result;
+
+pub(super) fn remove_outdated_versions(
+    language_server_id: &'static str,
+    version_dir: &str,
+) -> Result<()> {
+    let entries = fs::read_dir(".").map_err(|e| format!("failed to list working directory {e}"))?;
+    for entry in entries {
+        let entry = entry.map_err(|e| format!("failed to load directory entry {e}"))?;
+        if entry.file_name().to_str().is_none_or(|file_name| {
+            file_name.starts_with(language_server_id) && file_name != version_dir
+        }) {
+            fs::remove_dir_all(entry.path()).ok();
+        }
+    }
+    Ok(())
+}

--- a/extensions/proto/src/proto.rs
+++ b/extensions/proto/src/proto.rs
@@ -1,12 +1,13 @@
 use zed_extension_api::{self as zed, Result, settings::LspSettings};
 
-use crate::language_servers::{ProtoLs, ProtobufLanguageServer};
+use crate::language_servers::{BufLsp, ProtoLs, ProtobufLanguageServer};
 
 mod language_servers;
 
 struct ProtobufExtension {
     protobuf_language_server: Option<ProtobufLanguageServer>,
     protols: Option<ProtoLs>,
+    buf_lsp: Option<BufLsp>,
 }
 
 impl zed::Extension for ProtobufExtension {
@@ -14,6 +15,7 @@ impl zed::Extension for ProtobufExtension {
         Self {
             protobuf_language_server: None,
             protols: None,
+            buf_lsp: None,
         }
     }
 
@@ -31,6 +33,11 @@ impl zed::Extension for ProtobufExtension {
             ProtoLs::SERVER_NAME => self
                 .protols
                 .get_or_insert_with(ProtoLs::new)
+                .language_server_binary(worktree),
+
+            BufLsp::SERVER_NAME => self
+                .buf_lsp
+                .get_or_insert_with(BufLsp::new)
                 .language_server_binary(worktree),
 
             _ => Err(format!("Unknown language server ID {}", language_server_id)),

--- a/typos.toml
+++ b/typos.toml
@@ -35,6 +35,8 @@ extend-exclude = [
     "crates/rpc/src/auth.rs",
     # glsl isn't recognized by this tool.
     "extensions/glsl/languages/glsl/",
+    # Protols is the name of the language server.
+    "extensions/proto/src/language_servers/protols.rs",
     # Windows likes its abbreviations.
     "crates/gpui/src/platform/windows/directx_renderer.rs",
     "crates/gpui/src/platform/windows/events.rs",

--- a/typos.toml
+++ b/typos.toml
@@ -36,6 +36,7 @@ extend-exclude = [
     # glsl isn't recognized by this tool.
     "extensions/glsl/languages/glsl/",
     # Protols is the name of the language server.
+    "extensions/proto/extension.toml",
     "extensions/proto/src/language_servers/protols.rs",
     # Windows likes its abbreviations.
     "crates/gpui/src/platform/windows/directx_renderer.rs",


### PR DESCRIPTION
Closes #43784
Closes #44375
Closes #21057

This PR updates the Proto extension to include support for two new language servers as well as an updated grammar for better highlighting.

Release Notes:

- Improved Proto support to work better out of the box.
