### PR TITLE
Avoid the cost of creating an anyhow error in RelPath::strip_prefix

### DIFF
--- a/crates/util/src/rel_path.rs
+++ b/crates/util/src/rel_path.rs
@@ -161,7 +161,7 @@ impl RelPath {
         false
     }
 
-    pub fn strip_prefix<'a>(&'a self, other: &Self) -> Result<&'a Self> {
+    pub fn strip_prefix<'a>(&'a self, other: &Self) -> Result<&'a Self, StripPrefixError> {
         if other.is_empty() {
             return Ok(self);
         }
@@ -172,7 +172,7 @@ impl RelPath {
                 return Ok(Self::empty());
             }
         }
-        Err(anyhow!("failed to strip prefix: {other:?} from {self:?}"))
+        Err(StripPrefixError)
     }
 
     pub fn len(&self) -> usize {
@@ -250,6 +250,9 @@ impl RelPath {
         Path::new(&self.0)
     }
 }
+
+#[derive(Debug)]
+pub struct StripPrefixError;
 
 impl ToOwned for RelPath {
     type Owned = RelPathBuf;


### PR DESCRIPTION
Release Notes:

- Fixed a performance bottleneck that could delay Zed's processing FS events for a long time in some cases.
