### PR TITLE
Add vim `friendly_mode_display` setting for nicer status labels

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -2123,7 +2123,11 @@
     // Specify the mode as the key and the shape as the value.
     // The mode can be one of the following: "normal", "replace", "insert", "visual".
     // The shape can be one of the following: "block", "bar", "underline", "hollow".
-    "cursor_shape": {}
+    "cursor_shape": {},
+    // Whether Vim status shows friendly mode indicator labels.
+    //
+    // Default: false
+    "friendly_mode_indicator": false
   },
   // The server to connect to. If the environment variable
   // ZED_SERVER_URL is set, it will override this setting.

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -2124,10 +2124,10 @@
     // The mode can be one of the following: "normal", "replace", "insert", "visual".
     // The shape can be one of the following: "block", "bar", "underline", "hollow".
     "cursor_shape": {},
-    // Whether Vim status shows friendly mode indicator labels.
+    // Whether to show friendly mode display.
     //
     // Default: false
-    "friendly_mode_indicator": false
+    "friendly_mode_display": false
   },
   // The server to connect to. If the environment variable
   // ZED_SERVER_URL is set, it will override this setting.

--- a/crates/settings/src/settings_content.rs
+++ b/crates/settings/src/settings_content.rs
@@ -673,10 +673,10 @@ pub struct VimSettingsContent {
     pub custom_digraphs: Option<HashMap<String, Arc<str>>>,
     pub highlight_on_yank_duration: Option<u64>,
     pub cursor_shape: Option<CursorShapeSettings>,
-    /// Whether to show friendly mode indicator labels in the Vim status.
+    /// Whether to show friendly mode display.
     ///
     /// Default: false
-    pub friendly_mode_indicator: Option<bool>,
+    pub friendly_mode_display: Option<bool>,
 }
 
 #[derive(Copy, Clone, Default, Serialize, Deserialize, JsonSchema, MergeFrom, PartialEq, Debug)]

--- a/crates/settings/src/settings_content.rs
+++ b/crates/settings/src/settings_content.rs
@@ -673,6 +673,10 @@ pub struct VimSettingsContent {
     pub custom_digraphs: Option<HashMap<String, Arc<str>>>,
     pub highlight_on_yank_duration: Option<u64>,
     pub cursor_shape: Option<CursorShapeSettings>,
+    /// Whether to show friendly mode indicator labels in the Vim status.
+    ///
+    /// Default: false
+    pub friendly_mode_indicator: Option<bool>,
 }
 
 #[derive(Copy, Clone, Default, Serialize, Deserialize, JsonSchema, MergeFrom, PartialEq, Debug)]

--- a/crates/vim/src/mode_indicator.rs
+++ b/crates/vim/src/mode_indicator.rs
@@ -145,26 +145,34 @@ impl Render for ModeIndicator {
             crate::state::Mode::HelixSelect => colors.vim_helix_select_background,
         };
 
+        let is_vim_mode = matches!(
+            mode,
+            crate::state::Mode::Normal
+                | crate::state::Mode::Insert
+                | crate::state::Mode::Replace
+                | crate::state::Mode::Visual
+                | crate::state::Mode::VisualLine
+                | crate::state::Mode::VisualBlock
+        );
+
         let (label, mode): (SharedString, Option<SharedString>) = if let Some(label) = status_label
         {
             (label, None)
-        } else if friendly_mode {
+        } else if friendly_mode && is_vim_mode {
             let mode_str = match mode {
-                crate::state::Mode::Normal => "Vim".to_string(),
-                crate::state::Mode::Insert => "Insert".to_string(),
-                crate::state::Mode::Replace => "Replace".to_string(),
-                crate::state::Mode::Visual => "Visual".to_string(),
-                crate::state::Mode::VisualLine => "Visual Line".to_string(),
-                crate::state::Mode::VisualBlock => "Visual Block".to_string(),
-                crate::state::Mode::HelixNormal | crate::state::Mode::HelixSelect => {
-                    mode.to_string()
-                }
+                crate::state::Mode::Normal => "Vim",
+                crate::state::Mode::Insert => "Insert",
+                crate::state::Mode::Replace => "Replace",
+                crate::state::Mode::Visual => "Visual",
+                crate::state::Mode::VisualLine => "Visual Line",
+                crate::state::Mode::VisualBlock => "Visual Block",
+                _ => unreachable!(),
             };
 
             let mode_str = if temp_mode {
                 format!("(insert) {}", mode_str)
             } else {
-                mode_str
+                mode_str.to_string()
             };
 
             let operators_description = self.friendly_operators_description(vim.clone(), cx);

--- a/crates/vim/src/mode_indicator.rs
+++ b/crates/vim/src/mode_indicator.rs
@@ -116,10 +116,21 @@ impl Render for ModeIndicator {
         {
             (label, None)
         } else {
+            let mode_str = match mode {
+                crate::state::Mode::Normal => "Vim",
+                crate::state::Mode::Insert => "Insert",
+                crate::state::Mode::Replace => "Replace",
+                crate::state::Mode::Visual => "Visual",
+                crate::state::Mode::VisualLine => "Visual Line",
+                crate::state::Mode::VisualBlock => "Visual Block",
+                crate::state::Mode::HelixNormal => "NORMAL",
+                crate::state::Mode::HelixSelect => "SELECT",
+            };
+
             let mode_str = if temp_mode {
-                format!("(insert) {}", mode)
+                format!("(insert) {}", mode_str)
             } else {
-                mode.to_string()
+                mode_str.to_string()
             };
 
             let current_operators_description = self.current_operators_description(vim.clone(), cx);
@@ -127,12 +138,7 @@ impl Render for ModeIndicator {
                 .pending_keys
                 .as_ref()
                 .unwrap_or(&current_operators_description);
-            let mode = if bg_color != system_transparent {
-                mode_str.into()
-            } else {
-                format!("-- {} --", mode_str).into()
-            };
-            (pending.into(), Some(mode))
+            (pending.into(), Some(mode_str.into()))
         };
         h_flex()
             .gap_1()

--- a/crates/vim/src/mode_indicator.rs
+++ b/crates/vim/src/mode_indicator.rs
@@ -150,10 +150,14 @@ impl Render for ModeIndicator {
             };
 
             let current_operators_description = self.current_operators_description(vim.clone(), cx);
-            let pending = self
-                .pending_keys
-                .as_ref()
-                .unwrap_or(&current_operators_description);
+
+            // Prefer vim's state when it has content, fall back to raw pending keystrokes
+            // for multi-key bindings like `gg`, `gU`, etc. that vim hasn't processed yet
+            let pending = if !current_operators_description.is_empty() {
+                current_operators_description
+            } else {
+                self.pending_keys.clone().unwrap_or_default()
+            };
 
             // Hide mode label when an operator is pending
             let show_mode = pending.is_empty();

--- a/crates/vim/src/mode_indicator.rs
+++ b/crates/vim/src/mode_indicator.rs
@@ -123,7 +123,7 @@ impl Render for ModeIndicator {
             return div().hidden().into_any_element();
         };
 
-        let friendly_mode = VimSettings::get_global(cx).friendly_mode_indicator;
+        let friendly_mode = VimSettings::get_global(cx).friendly_mode_display;
 
         let vim_readable = vim.read(cx);
         let status_label = vim_readable.status_label.clone();

--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -1038,6 +1038,31 @@ impl Operator {
         }
     }
 
+    pub fn status(&self) -> String {
+        fn make_visible(c: &str) -> &str {
+            match c {
+                "\n" => "enter",
+                "\t" => "tab",
+                " " => "space",
+                c => c,
+            }
+        }
+        match self {
+            Operator::Digraph {
+                first_char: Some(first_char),
+            } => format!("^K{}", make_visible(&first_char.to_string())),
+            Operator::Literal {
+                prefix: Some(prefix),
+            } => format!("^V{}", make_visible(prefix)),
+            Operator::AutoIndent => "=".to_string(),
+            Operator::ShellCommand => "=".to_string(),
+            Operator::HelixMatch => "m".to_string(),
+            Operator::HelixNext { .. } => "]".to_string(),
+            Operator::HelixPrevious { .. } => "[".to_string(),
+            _ => self.id().to_string(),
+        }
+    }
+
     pub fn friendly_status(&self) -> &'static str {
         match self {
             Operator::Change => "Change",

--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -1100,9 +1100,9 @@ impl Operator {
             Operator::ToggleComments => "Toggle comments",
             Operator::ReplaceWithRegister => "Replace with register",
             Operator::Exchange => "Exchange",
-            Operator::HelixMatch => "Match",
-            Operator::HelixNext { .. } => "Next",
-            Operator::HelixPrevious { .. } => "Previous",
+            Operator::HelixMatch | Operator::HelixNext { .. } | Operator::HelixPrevious { .. } => {
+                unreachable!()
+            }
         }
     }
 

--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -1038,28 +1038,46 @@ impl Operator {
         }
     }
 
-    pub fn status(&self) -> String {
-        fn make_visible(c: &str) -> &str {
-            match c {
-                "\n" => "enter",
-                "\t" => "tab",
-                " " => "space",
-                c => c,
-            }
-        }
+    pub fn friendly_status(&self) -> &'static str {
         match self {
-            Operator::Digraph {
-                first_char: Some(first_char),
-            } => format!("^K{}", make_visible(&first_char.to_string())),
-            Operator::Literal {
-                prefix: Some(prefix),
-            } => format!("^V{}", make_visible(prefix)),
-            Operator::AutoIndent => "=".to_string(),
-            Operator::ShellCommand => "=".to_string(),
-            Operator::HelixMatch => "m".to_string(),
-            Operator::HelixNext { .. } => "]".to_string(),
-            Operator::HelixPrevious { .. } => "[".to_string(),
-            _ => self.id().to_string(),
+            Operator::Change => "Change",
+            Operator::Delete => "Delete",
+            Operator::Yank => "Yank",
+            Operator::Replace => "Replace character",
+            Operator::Object { around: false } => "inner",
+            Operator::Object { around: true } => "around",
+            Operator::FindForward { before: false, .. } => "Find",
+            Operator::FindForward { before: true, .. } => "Till",
+            Operator::FindBackward { after: false, .. } => "Find back",
+            Operator::FindBackward { after: true, .. } => "Till back",
+            Operator::Sneak { .. } => "Sneak",
+            Operator::SneakBackward { .. } => "Sneak back",
+            Operator::AddSurrounds { .. } => "Add surround",
+            Operator::ChangeSurrounds { .. } => "Change surround",
+            Operator::DeleteSurrounds => "Delete surround",
+            Operator::Mark => "Mark",
+            Operator::Jump { .. } => "Jump to",
+            Operator::Indent => "Indent",
+            Operator::Outdent => "Outdent",
+            Operator::AutoIndent => "Auto indent",
+            Operator::Rewrap => "Rewrap",
+            Operator::ShellCommand => "Shell command",
+            Operator::Lowercase => "Lowercase",
+            Operator::Uppercase => "Uppercase",
+            Operator::OppositeCase => "Toggle case",
+            Operator::Rot13 => "ROT13",
+            Operator::Rot47 => "ROT47",
+            Operator::Digraph { .. } => "Digraph",
+            Operator::Literal { .. } => "Literal",
+            Operator::Register => "Register",
+            Operator::RecordRegister => "Record macro",
+            Operator::ReplayRegister => "Replay macro",
+            Operator::ToggleComments => "Toggle comments",
+            Operator::ReplaceWithRegister => "Replace with register",
+            Operator::Exchange => "Exchange",
+            Operator::HelixMatch => "Match",
+            Operator::HelixNext { .. } => "Next",
+            Operator::HelixPrevious { .. } => "Previous",
         }
     }
 

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -1962,7 +1962,7 @@ pub(crate) struct VimSettings {
     pub custom_digraphs: HashMap<String, Arc<str>>,
     pub highlight_on_yank_duration: u64,
     pub cursor_shape: CursorShapeSettings,
-    pub friendly_mode_indicator: bool,
+    pub friendly_mode_display: bool,
 }
 
 /// The settings for cursor shape.
@@ -2017,7 +2017,7 @@ impl Settings for VimSettings {
             custom_digraphs: vim.custom_digraphs.unwrap(),
             highlight_on_yank_duration: vim.highlight_on_yank_duration.unwrap(),
             cursor_shape: vim.cursor_shape.unwrap().into(),
-            friendly_mode_indicator: vim.friendly_mode_indicator.unwrap(),
+            friendly_mode_display: vim.friendly_mode_display.unwrap(),
         }
     }
 }

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -1954,7 +1954,7 @@ impl Vim {
 }
 
 #[derive(RegisterSetting)]
-struct VimSettings {
+pub(crate) struct VimSettings {
     pub default_mode: Mode,
     pub toggle_relative_line_numbers: bool,
     pub use_system_clipboard: settings::UseSystemClipboard,
@@ -1962,6 +1962,7 @@ struct VimSettings {
     pub custom_digraphs: HashMap<String, Arc<str>>,
     pub highlight_on_yank_duration: u64,
     pub cursor_shape: CursorShapeSettings,
+    pub friendly_mode_indicator: bool,
 }
 
 /// The settings for cursor shape.
@@ -2016,6 +2017,7 @@ impl Settings for VimSettings {
             custom_digraphs: vim.custom_digraphs.unwrap(),
             highlight_on_yank_duration: vim.highlight_on_yank_duration.unwrap(),
             cursor_shape: vim.cursor_shape.unwrap().into(),
+            friendly_mode_indicator: vim.friendly_mode_indicator.unwrap(),
         }
     }
 }

--- a/docs/src/vim.md
+++ b/docs/src/vim.md
@@ -569,7 +569,7 @@ You can change the following settings to modify vim mode's behavior:
 | toggle_relative_line_numbers | If `true`, line numbers are relative in normal mode and absolute in insert mode, giving you the best of both options.                                                                         | false         |
 | custom_digraphs              | An object that allows you to add custom digraphs. Read below for an example.                                                                                                                  | {}            |
 | highlight_on_yank_duration   | The duration of the highlight animation(in ms). Set to `0` to disable                                                                                                                         | 200           |
-| friendly_mode_display        | Whether to show friendly mode display.                                                                                                                                                         | false         |
+| friendly_mode_display        | Whether to show friendly mode display.                                                                                                                                                        | false         |
 
 Here's an example of adding a digraph for the zombie emoji. This allows you to type `ctrl-k f z` to insert a zombie emoji. You can add as many digraphs as you like.
 

--- a/docs/src/vim.md
+++ b/docs/src/vim.md
@@ -569,6 +569,7 @@ You can change the following settings to modify vim mode's behavior:
 | toggle_relative_line_numbers | If `true`, line numbers are relative in normal mode and absolute in insert mode, giving you the best of both options.                                                                         | false         |
 | custom_digraphs              | An object that allows you to add custom digraphs. Read below for an example.                                                                                                                  | {}            |
 | highlight_on_yank_duration   | The duration of the highlight animation(in ms). Set to `0` to disable                                                                                                                         | 200           |
+| friendly_mode_indicator      | Whether Vim status shows friendly mode indicator labels.                                                                                                                                       | false         |
 
 Here's an example of adding a digraph for the zombie emoji. This allows you to type `ctrl-k f z` to insert a zombie emoji. You can add as many digraphs as you like.
 
@@ -592,6 +593,7 @@ Here's an example of these settings changed:
     "use_smartcase_find": true,
     "toggle_relative_line_numbers": true,
     "highlight_on_yank_duration": 50,
+    "friendly_mode_indicator": true,
     "custom_digraphs": {
       "fz": "🧟‍♀️"
     }

--- a/docs/src/vim.md
+++ b/docs/src/vim.md
@@ -569,7 +569,7 @@ You can change the following settings to modify vim mode's behavior:
 | toggle_relative_line_numbers | If `true`, line numbers are relative in normal mode and absolute in insert mode, giving you the best of both options.                                                                         | false         |
 | custom_digraphs              | An object that allows you to add custom digraphs. Read below for an example.                                                                                                                  | {}            |
 | highlight_on_yank_duration   | The duration of the highlight animation(in ms). Set to `0` to disable                                                                                                                         | 200           |
-| friendly_mode_indicator      | Whether Vim status shows friendly mode indicator labels.                                                                                                                                       | false         |
+| friendly_mode_display        | Whether to show friendly mode display.                                                                                                                                                         | false         |
 
 Here's an example of adding a digraph for the zombie emoji. This allows you to type `ctrl-k f z` to insert a zombie emoji. You can add as many digraphs as you like.
 
@@ -593,7 +593,7 @@ Here's an example of these settings changed:
     "use_smartcase_find": true,
     "toggle_relative_line_numbers": true,
     "highlight_on_yank_duration": 50,
-    "friendly_mode_indicator": true,
+    "friendly_mode_display": true,
     "custom_digraphs": {
       "fz": "🧟‍♀️"
     }


### PR DESCRIPTION
Release Notes:

- Added `friendly_mode_display` vim setting to show descriptive vim status labels  instead of classic Vim shorthand notation
