### PR TITLE
git_ui: Hide breakpoints in commit views

### DIFF
--- a/crates/git_ui/src/commit_view.rs
+++ b/crates/git_ui/src/commit_view.rs
@@ -152,6 +152,7 @@ impl CommitView {
                 Editor::for_multibuffer(multibuffer.clone(), Some(project.clone()), window, cx);
 
             editor.disable_inline_diagnostics();
+            editor.set_show_breakpoints(false, cx);
             editor.set_expand_all_diff_hunks(cx);
 
             editor


### PR DESCRIPTION
Release Notes:

- Improved commit view to not show breakpoints on hover
