### PR TITLE
Add cross-window tab drag and drop capability

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -2021,6 +2021,44 @@ impl App {
         }
     }
 
+    /// Returns a reference to the value of the currently active drag operation,
+    /// if one exists and its value is of type `T`.
+    pub fn active_drag_value<T: 'static>(&self) -> Option<&T> {
+        self.active_drag
+            .as_ref()
+            .and_then(|drag| drag.value.downcast_ref::<T>())
+    }
+
+    /// Returns the cursor offset of the currently active drag operation, if one exists.
+    pub fn active_drag_cursor_offset(&self) -> Option<Point<Pixels>> {
+        self.active_drag.as_ref().map(|drag| drag.cursor_offset)
+    }
+
+    /// Clears the active drag if its value is of type `T`.
+    /// Returns `true` if the drag was cleared.
+    pub fn clear_active_drag_of_type<T: 'static>(&mut self) -> bool {
+        if self
+            .active_drag
+            .as_ref()
+            .is_some_and(|drag| drag.value.is::<T>())
+        {
+            self.active_drag = None;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Takes ownership of the currently active drag operation, if one exists.
+    pub fn take_active_drag(&mut self) -> Option<AnyDrag> {
+        self.active_drag.take()
+    }
+
+    /// Restores a previously taken drag operation as the active drag.
+    pub fn restore_active_drag(&mut self, drag: AnyDrag) {
+        self.active_drag = Some(drag);
+    }
+
     /// Sets the cursor style for the currently active drag operation.
     pub fn set_active_drag_cursor_style(
         &mut self,

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -465,6 +465,7 @@ pub(crate) trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     fn window_bounds(&self) -> WindowBounds;
     fn content_size(&self) -> Size<Pixels>;
     fn resize(&mut self, size: Size<Pixels>);
+    fn set_position(&mut self, position: Point<Pixels>);
     fn scale_factor(&self) -> f32;
     fn appearance(&self) -> WindowAppearance;
     fn display(&self) -> Option<Rc<dyn PlatformDisplay>>;
@@ -1244,6 +1245,7 @@ pub(crate) struct WindowParams {
     pub display_id: Option<DisplayId>,
 
     pub window_min_size: Option<Size<Pixels>>,
+    pub window_decorations: Option<WindowDecorations>,
     #[cfg(target_os = "macos")]
     pub tabbing_identifier: Option<String>,
 }

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -1245,6 +1245,7 @@ pub(crate) struct WindowParams {
     pub display_id: Option<DisplayId>,
 
     pub window_min_size: Option<Size<Pixels>>,
+    #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
     pub window_decorations: Option<WindowDecorations>,
     #[cfg(target_os = "macos")]
     pub tabbing_identifier: Option<String>,

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -1041,6 +1041,11 @@ impl PlatformWindow for WaylandWindow {
             .detach();
     }
 
+    fn set_position(&mut self, _position: Point<Pixels>) {
+        // Wayland does not allow clients to set their own window position.
+        // Window positioning is controlled by the compositor.
+    }
+
     fn scale_factor(&self) -> f32 {
         self.borrow().scale
     }

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -1226,9 +1226,9 @@ impl PlatformWindow for X11Window {
 
     fn set_position(&mut self, position: Point<Pixels>) {
         let state = self.0.state.borrow();
-        let position = position.to_device_pixels(state.scale_factor);
-        let x = position.x.0 as i32;
-        let y = position.y.0 as i32;
+        let scale_factor = state.scale_factor;
+        let x = (position.x.0 * scale_factor).round() as i32;
+        let y = (position.y.0 * scale_factor).round() as i32;
 
         check_reply(
             || format!("X11 ConfigureWindow failed. x: {}, y: {}", x, y),

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -1224,6 +1224,23 @@ impl PlatformWindow for X11Window {
         xcb_flush(&self.0.xcb);
     }
 
+    fn set_position(&mut self, position: Point<Pixels>) {
+        let state = self.0.state.borrow();
+        let position = position.to_device_pixels(state.scale_factor);
+        let x = position.x.0 as i32;
+        let y = position.y.0 as i32;
+
+        check_reply(
+            || format!("X11 ConfigureWindow failed. x: {}, y: {}", x, y),
+            self.0.xcb.configure_window(
+                self.0.x_window,
+                &xproto::ConfigureWindowAux::new().x(x).y(y),
+            ),
+        )
+        .log_err();
+        xcb_flush(&self.0.xcb);
+    }
+
     fn scale_factor(&self) -> f32 {
         self.0.state.borrow().scale_factor
     }

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -5,8 +5,9 @@ use crate::{
     MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels, PlatformAtlas, PlatformDisplay,
     PlatformInput, PlatformWindow, Point, PromptButton, PromptLevel, RequestFrameOptions,
     SharedString, Size, SystemWindowTab, Timer, WindowAppearance, WindowBackgroundAppearance,
-    WindowBounds, WindowControlArea, WindowKind, WindowParams, dispatch_get_main_queue,
-    dispatch_sys::dispatch_async_f, platform::PlatformInputHandler, point, px, size,
+    WindowBounds, WindowControlArea, WindowDecorations, WindowKind, WindowParams,
+    dispatch_get_main_queue, dispatch_sys::dispatch_async_f, platform::PlatformInputHandler, point,
+    px, size,
 };
 use block::ConcreteBlock;
 use cocoa::{
@@ -581,6 +582,7 @@ impl MacWindow {
             show,
             display_id,
             window_min_size,
+            window_decorations,
             tabbing_identifier,
         }: WindowParams,
         executor: ForegroundExecutor,
@@ -612,6 +614,8 @@ impl MacWindow {
                 if titlebar.appears_transparent {
                     style_mask |= NSWindowStyleMask::NSFullSizeContentViewWindowMask;
                 }
+            } else if window_decorations == Some(WindowDecorations::Client) {
+                style_mask = NSWindowStyleMask::NSBorderlessWindowMask;
             } else {
                 style_mask = NSWindowStyleMask::NSTitledWindowMask
                     | NSWindowStyleMask::NSFullSizeContentViewWindowMask;
@@ -977,6 +981,30 @@ impl PlatformWindow for MacWindow {
                         width: size.width.0 as f64,
                         height: size.height.0 as f64,
                     });
+                }
+            })
+            .detach();
+    }
+
+    fn set_position(&mut self, position: Point<Pixels>) {
+        let this = self.0.lock();
+        let window = this.native_window;
+        let screen_frame = unsafe {
+            let screen: id = msg_send![window, screen];
+            if screen.is_null() {
+                return;
+            }
+            NSScreen::frame(screen)
+        };
+        this.executor
+            .spawn(async move {
+                unsafe {
+                    let frame: NSRect = msg_send![window, frame];
+                    let new_origin = NSPoint {
+                        x: position.x.0 as f64,
+                        y: screen_frame.size.height - position.y.0 as f64 - frame.size.height,
+                    };
+                    window.setFrameOrigin_(new_origin);
                 }
             })
             .detach();

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -133,6 +133,11 @@ impl PlatformWindow for TestWindow {
         lock.bounds.size = size;
     }
 
+    fn set_position(&mut self, position: Point<Pixels>) {
+        let mut lock = self.0.lock();
+        lock.bounds.origin = position;
+    }
+
     fn scale_factor(&self) -> f32 {
         2.0
     }

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -577,6 +577,30 @@ impl PlatformWindow for WindowsWindow {
             .detach();
     }
 
+    fn set_position(&mut self, position: Point<Pixels>) {
+        let hwnd = self.0.hwnd;
+        let position = position.to_device_pixels(self.scale_factor());
+
+        self.0
+            .executor
+            .spawn(async move {
+                unsafe {
+                    SetWindowPos(
+                        hwnd,
+                        None,
+                        position.x.0,
+                        position.y.0,
+                        0,
+                        0,
+                        SWP_NOSIZE | SWP_NOZORDER,
+                    )
+                    .context("unable to set window position")
+                    .log_err();
+                }
+            })
+            .detach();
+    }
+
     fn scale_factor(&self) -> f32 {
         self.state.scale_factor.get()
     }

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -579,7 +579,9 @@ impl PlatformWindow for WindowsWindow {
 
     fn set_position(&mut self, position: Point<Pixels>) {
         let hwnd = self.0.hwnd;
-        let position = position.to_device_pixels(self.scale_factor());
+        let scale_factor = self.scale_factor();
+        let x = (position.x.0 * scale_factor).round() as i32;
+        let y = (position.y.0 * scale_factor).round() as i32;
 
         self.0
             .executor
@@ -588,8 +590,8 @@ impl PlatformWindow for WindowsWindow {
                     SetWindowPos(
                         hwnd,
                         None,
-                        position.x.0,
-                        position.y.0,
+                        x,
+                        y,
                         0,
                         0,
                         SWP_NOSIZE | SWP_NOZORDER,

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -587,17 +587,9 @@ impl PlatformWindow for WindowsWindow {
             .executor
             .spawn(async move {
                 unsafe {
-                    SetWindowPos(
-                        hwnd,
-                        None,
-                        x,
-                        y,
-                        0,
-                        0,
-                        SWP_NOSIZE | SWP_NOZORDER,
-                    )
-                    .context("unable to set window position")
-                    .log_err();
+                    SetWindowPos(hwnd, None, x, y, 0, 0, SWP_NOSIZE | SWP_NOZORDER)
+                        .context("unable to set window position")
+                        .log_err();
                 }
             })
             .detach();

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1040,6 +1040,7 @@ impl Window {
                 show,
                 display_id,
                 window_min_size,
+                window_decorations,
                 #[cfg(target_os = "macos")]
                 tabbing_identifier,
             },
@@ -1765,6 +1766,11 @@ impl Window {
     /// Set the content size of the window.
     pub fn resize(&mut self, size: Size<Pixels>) {
         self.platform_window.resize(size);
+    }
+
+    /// Set the position of the window on screen in pixels.
+    pub fn set_position(&mut self, position: Point<Pixels>) {
+        self.platform_window.set_position(position);
     }
 
     /// Returns whether or not the window is currently fullscreen

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -39,12 +39,14 @@ use futures::{
     future::{Shared, try_join_all},
 };
 use gpui::{
-    Action, AnyEntity, AnyView, AnyWeakView, App, AsyncApp, AsyncWindowContext, Bounds, Context,
-    CursorStyle, Decorations, DragMoveEvent, Entity, EntityId, EventEmitter, FocusHandle,
-    Focusable, Global, HitboxBehavior, Hsla, KeyContext, Keystroke, ManagedView, MouseButton,
-    PathPromptOptions, Point, PromptLevel, Render, ResizeEdge, Size, Stateful, Subscription,
-    SystemWindowTabController, Task, Tiling, WeakEntity, WindowBounds, WindowHandle, WindowId,
-    WindowOptions, actions, canvas, point, relative, size, transparent_black,
+    Action, AnyDrag, AnyEntity, AnyView, AnyWeakView, App, AsyncApp, AsyncWindowContext, Bounds,
+    Context, CursorStyle, Decorations, DispatchPhase, DragMoveEvent, Entity, EntityId,
+    EventEmitter, FocusHandle, Focusable, Global, HitboxBehavior, Hsla, KeyContext, Keystroke,
+    ManagedView, MouseButton, MouseMoveEvent, MouseUpEvent, PathPromptOptions, Pixels, Point,
+    PromptLevel, Render, ResizeEdge, SharedString, Size, Stateful, Subscription,
+    SystemWindowTabController, Task, Tiling, WeakEntity, WindowBackgroundAppearance, WindowBounds,
+    WindowDecorations, WindowHandle, WindowId, WindowKind, WindowOptions, actions, canvas, point,
+    px, relative, size, transparent_black,
 };
 pub use history_manager::*;
 pub use item::{
@@ -112,7 +114,7 @@ use task::{DebugScenario, SpawnInTerminal, TaskContext};
 use theme::{ActiveTheme, GlobalTheme, SystemAppearance, ThemeSettings};
 pub use toolbar::{Toolbar, ToolbarItemEvent, ToolbarItemLocation, ToolbarItemView};
 pub use ui;
-use ui::{Window, prelude::*};
+use ui::{Tab, Window, prelude::*};
 use util::{
     ResultExt, TryFutureExt,
     paths::{PathStyle, SanitizedPath},
@@ -131,6 +133,40 @@ use crate::persistence::{
     model::{DockData, DockStructure, SerializedItem, SerializedPane, SerializedPaneGroup},
 };
 use crate::{item::ItemBufferKind, notifications::NotificationId};
+
+pub struct DragPreviewPopup {
+    pub label: SharedString,
+    pub is_active: bool,
+}
+
+impl Render for DragPreviewPopup {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let ui_font = ThemeSettings::get_global(cx).ui_font.clone();
+        Tab::new("drag-preview")
+            .toggle_state(self.is_active)
+            .child(
+                Label::new(self.label.clone())
+                    .single_line()
+                    .color(if self.is_active {
+                        Color::Default
+                    } else {
+                        Color::Muted
+                    }),
+            )
+            .render(window, cx)
+            .font(ui_font)
+    }
+}
+
+#[derive(Default)]
+pub struct CrossWindowDragPreview {
+    pub popup_window: Option<gpui::AnyWindowHandle>,
+    pub source_window_id: Option<WindowId>,
+    pub last_position: Option<Point<Pixels>>,
+    pub stored_drag: Option<AnyDrag>,
+}
+
+impl Global for CrossWindowDragPreview {}
 
 pub const SERIALIZATION_THROTTLE_TIME: Duration = Duration::from_millis(200);
 
@@ -2635,6 +2671,109 @@ impl Workspace {
             .await?;
             Ok(())
         })
+    }
+
+    pub fn open_dragged_tab_in_new_window(
+        dragged_tab: &DraggedTab,
+        screen_position: Point<Pixels>,
+        source_window: &mut Window,
+        cx: &mut App,
+    ) -> bool {
+        let app_state = match AppState::try_global(cx).and_then(|weak| weak.upgrade()) {
+            Some(state) => state,
+            None => return false,
+        };
+
+        let item = dragged_tab.item.boxed_clone();
+        let item_id = item.item_id();
+        let source_pane = dragged_tab.pane.clone();
+
+        let source_workspace = source_pane.read(cx).workspace.clone();
+        let project = match source_workspace.upgrade() {
+            Some(ws) => ws.read(cx).project().clone(),
+            None => return false,
+        };
+
+        let source_window_id = source_window.window_handle().window_id();
+
+        let workspace_windows: Vec<WindowHandle<Workspace>> = cx
+            .windows()
+            .into_iter()
+            .filter_map(|window| window.downcast::<Workspace>())
+            .filter(|workspace_handle| workspace_handle.window_id() != source_window_id)
+            .collect();
+
+        let mut target_workspace = None;
+        for workspace_handle in workspace_windows {
+            let is_within_bounds = workspace_handle
+                .update(cx, |_, window, _| {
+                    let bounds = window.bounds();
+                    screen_position.x >= bounds.origin.x
+                        && screen_position.x <= bounds.origin.x + bounds.size.width
+                        && screen_position.y >= bounds.origin.y
+                        && screen_position.y <= bounds.origin.y + bounds.size.height
+                })
+                .unwrap_or(false);
+
+            if is_within_bounds {
+                target_workspace = Some(workspace_handle);
+                break;
+            }
+        }
+
+        source_pane.update(cx, |pane, cx| {
+            pane.remove_item(item_id, false, true, source_window, cx);
+        });
+
+        if let Some(target_workspace) = target_workspace {
+            target_workspace
+                .update(cx, |workspace, window, cx| {
+                    let pane = workspace.active_pane().clone();
+                    pane.update(cx, |pane, cx| {
+                        pane.add_item(item, true, true, None, window, cx);
+                    });
+                    window.activate_window();
+                })
+                .ok();
+            return true;
+        }
+
+        let window_size = Size {
+            width: px(800.),
+            height: px(600.),
+        };
+        let window_origin = Point {
+            x: screen_position.x - window_size.width / 2.0,
+            y: screen_position.y - px(20.),
+        };
+
+        let window_bounds = Bounds {
+            origin: window_origin,
+            size: window_size,
+        };
+
+        let mut options = (app_state.build_window_options)(None, cx);
+        options.window_bounds = Some(WindowBounds::Windowed(window_bounds));
+
+        let new_window = cx.open_window(options, move |window, cx| {
+            cx.new(|cx| Workspace::new(None, project, app_state, window, cx))
+        });
+
+        let Ok(new_window) = new_window else {
+            return false;
+        };
+
+        new_window
+            .update(cx, |workspace, window, cx| {
+                let pane = workspace.active_pane().clone();
+                pane.update(cx, |pane, cx| {
+                    pane.add_item(item, true, true, None, window, cx);
+                });
+                window.activate_window();
+            })
+            .ok();
+
+        true
     }
 
     #[allow(clippy::type_complexity)]
@@ -6760,7 +6899,224 @@ impl Render for Workspace {
                                                 }
                                             })
                                         },
-                                        |_, _, _, _| {},
+                                        |_, _, window, _cx| {
+                                            let viewport_size = window.viewport_size();
+                                            let window_bounds = window.bounds();
+                                            let window_id = window.window_handle().window_id();
+
+                                            window.on_mouse_event(
+                                                move |event: &MouseMoveEvent,
+                                                      phase,
+                                                      _window,
+                                                      cx| {
+                                                    if phase != DispatchPhase::Capture {
+                                                        return;
+                                                    }
+
+                                                    let drag_info: Option<(SharedString, bool, Point<Pixels>)> =
+                                                        cx.active_drag_value::<DraggedTab>().and_then(|dragged_tab| {
+                                                            cx.active_drag_cursor_offset().map(|cursor_offset| {
+                                                                let label = dragged_tab.item.tab_content_text(dragged_tab.detail, cx);
+                                                                let is_active = dragged_tab.is_active;
+                                                                (label, is_active, cursor_offset)
+                                                            })
+                                                        });
+
+                                                    let stored_drag_info: Option<(SharedString, bool, Point<Pixels>)> =
+                                                        cx.try_global::<CrossWindowDragPreview>()
+                                                            .and_then(|preview| preview.stored_drag.as_ref())
+                                                            .and_then(|drag| {
+                                                                drag.value.downcast_ref::<DraggedTab>().map(|dragged_tab| {
+                                                                    let label = dragged_tab.item.tab_content_text(dragged_tab.detail, cx);
+                                                                    let is_active = dragged_tab.is_active;
+                                                                    (label, is_active, drag.cursor_offset)
+                                                                })
+                                                            });
+
+                                                    let Some((label, is_active, cursor_offset)) = drag_info.or(stored_drag_info) else {
+                                                        if let Some(preview) = cx.try_global::<CrossWindowDragPreview>() {
+                                                            if let Some(popup) = preview.popup_window {
+                                                                popup.update(cx, |_, window, _| {
+                                                                    window.remove_window();
+                                                                }).ok();
+                                                            }
+                                                        }
+                                                        if cx.try_global::<CrossWindowDragPreview>().is_some() {
+                                                            let preview = cx.global_mut::<CrossWindowDragPreview>();
+                                                            preview.popup_window = None;
+                                                            preview.source_window_id = None;
+                                                            preview.last_position = None;
+                                                            preview.stored_drag = None;
+                                                        }
+                                                        return;
+                                                    };
+
+                                                    let pos = event.position;
+                                                    let is_outside = pos.x < px(0.)
+                                                        || pos.y < px(0.)
+                                                        || pos.x > viewport_size.width
+                                                        || pos.y > viewport_size.height;
+
+                                                    if is_outside {
+                                                        let screen_position = Point {
+                                                            x: window_bounds.origin.x + pos.x,
+                                                            y: window_bounds.origin.y + pos.y,
+                                                        };
+
+                                                        if cx.try_global::<CrossWindowDragPreview>().is_none() {
+                                                            cx.set_global(CrossWindowDragPreview::default());
+                                                        }
+
+                                                        let taken_drag = cx.take_active_drag();
+                                                        if let Some(drag) = taken_drag {
+                                                            let preview = cx.global_mut::<CrossWindowDragPreview>();
+                                                            preview.stored_drag = Some(drag);
+                                                        }
+
+                                                        let popup_origin = Point {
+                                                            x: screen_position.x - cursor_offset.x,
+                                                            y: screen_position.y - cursor_offset.y,
+                                                        };
+
+                                                        let preview = cx.global::<CrossWindowDragPreview>();
+                                                        let has_popup = preview.popup_window.is_some();
+                                                        let is_same_source = preview.source_window_id == Some(window_id);
+                                                        let popup_handle = preview.popup_window;
+
+                                                        if has_popup && is_same_source {
+                                                            if let Some(popup) = popup_handle {
+                                                                popup.update(cx, |_, window, _| {
+                                                                    window.set_position(popup_origin);
+                                                                }).ok();
+                                                            }
+                                                            let preview = cx.global_mut::<CrossWindowDragPreview>();
+                                                            preview.last_position = Some(screen_position);
+                                                        } else {
+                                                            if let Some(popup) = popup_handle {
+                                                                popup.update(cx, |_, window, _| {
+                                                                    window.remove_window();
+                                                                }).ok();
+                                                            }
+
+                                                            let estimated_width = px(label.len() as f32 * 8.0 + 60.0).max(px(80.));
+                                                            let tab_height = px(32.);
+                                                            let popup_bounds = Bounds {
+                                                                origin: popup_origin,
+                                                                size: size(estimated_width, tab_height),
+                                                            };
+
+                                                            let popup_result = cx.open_window(
+                                                                WindowOptions {
+                                                                    window_bounds: Some(WindowBounds::Windowed(popup_bounds)),
+                                                                    titlebar: None,
+                                                                    focus: false,
+                                                                    show: true,
+                                                                    kind: WindowKind::PopUp,
+                                                                    is_movable: false,
+                                                                    is_resizable: false,
+                                                                    window_background: WindowBackgroundAppearance::Transparent,
+                                                                    window_decorations: Some(WindowDecorations::Client),
+                                                                    ..Default::default()
+                                                                },
+                                                                move |_, cx| {
+                                                                    cx.new(|_| DragPreviewPopup { label, is_active })
+                                                                },
+                                                            );
+
+                                                            if let Ok(popup) = popup_result {
+                                                                let preview = cx.global_mut::<CrossWindowDragPreview>();
+                                                                preview.popup_window = Some(popup.into());
+                                                                preview.source_window_id = Some(window_id);
+                                                                preview.last_position = Some(screen_position);
+                                                            }
+                                                        }
+                                                    } else {
+                                                        if cx.try_global::<CrossWindowDragPreview>().is_some() {
+                                                            let preview = cx.global::<CrossWindowDragPreview>();
+                                                            if preview.source_window_id == Some(window_id) {
+                                                                if let Some(popup) = preview.popup_window {
+                                                                    popup.update(cx, |_, window, _| {
+                                                                        window.remove_window();
+                                                                    }).ok();
+                                                                }
+                                                                let preview = cx.global_mut::<CrossWindowDragPreview>();
+                                                                let stored = preview.stored_drag.take();
+                                                                preview.popup_window = None;
+                                                                preview.source_window_id = None;
+                                                                preview.last_position = None;
+                                                                if let Some(drag) = stored {
+                                                                    cx.restore_active_drag(drag);
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                },
+                                            );
+
+                                            window.on_mouse_event(
+                                                move |event: &MouseUpEvent,
+                                                      phase,
+                                                      window,
+                                                      cx| {
+                                                    if phase != DispatchPhase::Capture {
+                                                        return;
+                                                    }
+
+                                                    let stored_drag = cx.try_global::<CrossWindowDragPreview>()
+                                                        .and_then(|preview| preview.stored_drag.as_ref())
+                                                        .and_then(|drag| drag.value.downcast_ref::<DraggedTab>())
+                                                        .cloned();
+
+                                                    if let Some(preview) = cx.try_global::<CrossWindowDragPreview>() {
+                                                        if let Some(popup) = preview.popup_window {
+                                                            popup.update(cx, |_, window, _| {
+                                                                window.remove_window();
+                                                            }).ok();
+                                                        }
+                                                        let preview = cx.global_mut::<CrossWindowDragPreview>();
+                                                        preview.popup_window = None;
+                                                        preview.source_window_id = None;
+                                                        preview.last_position = None;
+                                                        preview.stored_drag = None;
+                                                    }
+
+                                                    let dragged_tab = cx.active_drag_value::<DraggedTab>()
+                                                        .cloned()
+                                                        .or(stored_drag);
+
+                                                    let Some(dragged_tab) = dragged_tab else {
+                                                        return;
+                                                    };
+
+                                                    let pos = event.position;
+                                                    let is_outside = pos.x < px(0.)
+                                                        || pos.y < px(0.)
+                                                        || pos.x > viewport_size.width
+                                                        || pos.y > viewport_size.height;
+
+                                                    if !is_outside {
+                                                        return;
+                                                    }
+
+                                                    let screen_position = Point {
+                                                        x: window_bounds.origin.x + pos.x,
+                                                        y: window_bounds.origin.y + pos.y,
+                                                    };
+
+                                                    cx.clear_active_drag_of_type::<DraggedTab>();
+
+                                                    Workspace::open_dragged_tab_in_new_window(
+                                                        &dragged_tab,
+                                                        screen_position,
+                                                        window,
+                                                        cx,
+                                                    );
+
+                                                    cx.stop_propagation();
+                                                    window.refresh();
+                                                },
+                                            );
+                                        },
                                     )
                                     .absolute()
                                     .size_full()
@@ -6807,6 +7163,29 @@ impl Render for Workspace {
                                         },
                                     ))
                                 })
+                                .drag_over::<DraggedTab>(|workspace_div, _, _, cx| {
+                                    workspace_div
+                                        .bg(cx.theme().colors().drop_target_background)
+                                        .border_4()
+                                        .border_color(cx.theme().colors().border_focused)
+                                })
+                                .on_drop(cx.listener(
+                                    |workspace, dragged_tab: &DraggedTab, window, cx| {
+                                        let item = dragged_tab.item.boxed_clone();
+                                        let item_id = item.item_id();
+                                        let source_pane = dragged_tab.pane.clone();
+
+                                        source_pane.update(cx, |pane, cx| {
+                                            pane.remove_item(item_id, false, true, window, cx);
+                                        });
+
+                                        let pane = workspace.active_pane().clone();
+                                        pane.update(cx, |pane, cx| {
+                                            pane.add_item(item, true, true, None, window, cx);
+                                        });
+                                        window.activate_window();
+                                    },
+                                ))
                                 .child({
                                     match bottom_dock_layout {
                                         BottomDockLayout::Full => div()


### PR DESCRIPTION
Closes #6722

Release Notes:

- Added cross-window tab drag and drop support. You can now drag tabs between different Zed windows or drop them outside a window to create a new window.

https://github.com/user-attachments/assets/107b8881-cbdb-4412-98be-b997516d18ec

