### PR TITLE
Revert "Improve TS/TSX/JS syntax highlighting for parameters, types, and punctuation"

### DIFF
--- a/crates/languages/src/javascript/highlights.scm
+++ b/crates/languages/src/javascript/highlights.scm
@@ -47,45 +47,10 @@
   left: (identifier) @function
   right: [(function_expression) (arrow_function)])
 
-; Parameters
-
-(required_parameter
-  (identifier) @variable.parameter)
-
-(required_parameter
-  (_
-    ([
-      (identifier)
-      (shorthand_property_identifier_pattern)
-    ]) @variable.parameter))
-
-(optional_parameter
-  (identifier) @variable.parameter)
-
-(optional_parameter
-  (_
-    ([
-      (identifier)
-      (shorthand_property_identifier_pattern)
-    ]) @variable.parameter))
-
-(catch_clause
-  parameter: (identifier) @variable.parameter)
-
-(index_signature
-  name: (identifier) @variable.parameter)
-
-(arrow_function
-  parameter: (identifier) @variable.parameter)
-
 ; Special identifiers
-;
-(class_declaration
-  (type_identifier) @type.class)
 
-(extends_clause
-  value: (identifier) @type.class)
-
+((identifier) @type
+ (#match? @type "^[A-Z]"))
 (type_identifier) @type
 (predefined_type) @type.builtin
 

--- a/crates/languages/src/jsdoc/highlights.scm
+++ b/crates/languages/src/jsdoc/highlights.scm
@@ -1,3 +1,2 @@
 (tag_name) @keyword.jsdoc
 (type) @type.jsdoc
-(identifier) @variable.jsdoc

--- a/crates/languages/src/tsx/highlights.scm
+++ b/crates/languages/src/tsx/highlights.scm
@@ -47,67 +47,12 @@
   left: (identifier) @function
   right: [(function_expression) (arrow_function)])
 
-; Parameters
-
-(required_parameter
-  (identifier) @variable.parameter)
-
-(required_parameter
-  (_
-    ([
-      (identifier)
-      (shorthand_property_identifier_pattern)
-    ]) @variable.parameter))
-
-(optional_parameter
-  (identifier) @variable.parameter)
-
-(optional_parameter
-  (_
-    ([
-      (identifier)
-      (shorthand_property_identifier_pattern)
-    ]) @variable.parameter))
-
-(catch_clause
-  parameter: (identifier) @variable.parameter)
-
-(index_signature
-  name: (identifier) @variable.parameter)
-
-(arrow_function
-  parameter: (identifier) @variable.parameter)
-
-(type_predicate
-  name: (identifier) @variable.parameter)
-
 ; Special identifiers
 
-(type_annotation) @type
+((identifier) @type
+ (#match? @type "^[A-Z]"))
 (type_identifier) @type
 (predefined_type) @type.builtin
-
-(type_alias_declaration
-  (type_identifier) @type)
-
-(type_alias_declaration
-  value: (_
-    (type_identifier) @type))
-
-(interface_declaration
-  (type_identifier) @type)
-
-(class_declaration
-  (type_identifier) @type.class)
-
-(extends_clause
-  value: (identifier) @type.class)
-
-(extends_type_clause
-  type: (type_identifier) @type)
-
-(implements_clause
-  (type_identifier) @type)
 
 ([
   (identifier)
@@ -286,41 +231,7 @@
   "<" @punctuation.bracket
   ">" @punctuation.bracket)
 
-(type_parameters
-  "<" @punctuation.bracket
-  ">" @punctuation.bracket)
-
 (decorator "@" @punctuation.special)
-
-(union_type
-  ("|") @punctuation.special)
-
-(intersection_type
-  ("&") @punctuation.special)
-
-(type_annotation
-  (":") @punctuation.special)
-
-(index_signature
-  (":") @punctuation.special)
-
-(type_predicate_annotation
-  (":") @punctuation.special)
-
-(public_field_definition
-  ("?") @punctuation.special)
-
-(property_signature
-  ("?") @punctuation.special)
-
-(method_signature
-  ("?") @punctuation.special)
-
-(optional_parameter
-  ([
-    "?"
-    ":"
-  ]) @punctuation.special)
 
 ; Keywords
 

--- a/crates/languages/src/typescript/highlights.scm
+++ b/crates/languages/src/typescript/highlights.scm
@@ -4,32 +4,10 @@
 
 ; Special identifiers
 
-(type_annotation) @type
-
+((identifier) @type
+ (#match? @type "^[A-Z]"))
 (type_identifier) @type
 (predefined_type) @type.builtin
-
-(type_alias_declaration
-  (type_identifier) @type)
-
-(type_alias_declaration
-  value: (_
-    (type_identifier) @type))
-
-(interface_declaration
-  (type_identifier) @type)
-
-(class_declaration
-  (type_identifier) @type.class)
-
-(extends_clause
-  value: (identifier) @type.class)
-
-(extends_type_clause
-  type: (type_identifier) @type)
-
-(implements_clause
-  (type_identifier) @type)
 
 ;; Enables ts-pretty-errors
 ;; The Lsp returns "snippets" of typescript, which are not valid typescript in totality,
@@ -135,40 +113,6 @@
   right: [(function_expression) (arrow_function)])
 
 (arrow_function) @function
-
-; Parameters
-
-(required_parameter
-  (identifier) @variable.parameter)
-
-(required_parameter
-  (_
-    ([
-      (identifier)
-      (shorthand_property_identifier_pattern)
-    ]) @variable.parameter))
-
-(optional_parameter
-  (identifier) @variable.parameter)
-
-(optional_parameter
-  (_
-    ([
-      (identifier)
-      (shorthand_property_identifier_pattern)
-    ]) @variable.parameter))
-
-(catch_clause
-  parameter: (identifier) @variable.parameter)
-
-(index_signature
-  name: (identifier) @variable.parameter)
-
-(arrow_function
-  parameter: (identifier) @variable.parameter)
-
-(type_predicate
-  name: (identifier) @variable.parameter)
 
 ; Literals
 
@@ -300,41 +244,7 @@
   "<" @punctuation.bracket
   ">" @punctuation.bracket)
 
-(type_parameters
-  "<" @punctuation.bracket
-  ">" @punctuation.bracket)
-
 (decorator "@" @punctuation.special)
-
-(union_type
-  ("|") @punctuation.special)
-
-(intersection_type
-  ("&") @punctuation.special)
-
-(type_annotation
-  (":") @punctuation.special)
-
-(index_signature
-  (":") @punctuation.special)
-
-(type_predicate_annotation
-  (":") @punctuation.special)
-
-(public_field_definition
-  ("?") @punctuation.special)
-
-(property_signature
-  ("?") @punctuation.special)
-
-(method_signature
-  ("?") @punctuation.special)
-
-(optional_parameter
-  ([
-    "?"
-    ":"
-  ]) @punctuation.special)
 
 ; Keywords
 


### PR DESCRIPTION
Reverts zed-industries/zed#43437

Internally we noticed some regression related to removed query for PascalCase identifiers. Reverting now to prevent this from going to preview, still planning to land this with the necessary fixes later.