### PR TITLE
repl: Add inverse jupytext setting

### DIFF
--- a/crates/repl/src/repl_settings.rs
+++ b/crates/repl/src/repl_settings.rs
@@ -1,4 +1,4 @@
-use settings::{RegisterSetting, Settings};
+use settings::{CellMarkerStyle, RegisterSetting, Settings};
 
 /// Settings for configuring REPL display and behavior.
 #[derive(Clone, Debug, RegisterSetting)]
@@ -13,6 +13,10 @@ pub struct ReplSettings {
     ///
     /// Default: 128
     pub max_columns: usize,
+    /// How cell markers are interpreted in source files.
+    ///
+    /// Default: Jupytext
+    pub cell_marker_style: CellMarkerStyle,
 }
 
 impl Settings for ReplSettings {
@@ -22,6 +26,7 @@ impl Settings for ReplSettings {
         Self {
             max_lines: repl.max_lines.unwrap(),
             max_columns: repl.max_columns.unwrap(),
+            cell_marker_style: repl.cell_marker_style.unwrap_or_default(),
         }
     }
 }

--- a/crates/settings/src/settings_content.rs
+++ b/crates/settings/src/settings_content.rs
@@ -938,9 +938,35 @@ pub struct SshPortForwardOption {
     pub remote_port: u16,
 }
 
+/// How cell markers are interpreted in source files.
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    MergeFrom,
+    PartialEq,
+    Eq,
+    strum::VariantArray,
+    strum::VariantNames,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum CellMarkerStyle {
+    /// Standard jupytext style: `# %%` marks the start of a cell.
+    /// The cell includes all code from the marker until the next marker or end of file.
+    #[default]
+    Jupytext,
+    /// Inverse jupytext style: `# $$` marks the end of a cell.
+    /// The cell includes all code from the previous marker (or start of file) up to and including the marker line.
+    InverseJupytext,
+}
+
 /// Settings for configuring REPL display and behavior.
 #[with_fallible_options]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema, MergeFrom)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, JsonSchema, MergeFrom)]
 pub struct ReplSettingsContent {
     /// Maximum number of lines to keep in REPL's scrollback buffer.
     /// Clamped with [4, 256] range.
@@ -952,6 +978,13 @@ pub struct ReplSettingsContent {
     ///
     /// Default: 128
     pub max_columns: Option<usize>,
+    /// How cell markers are interpreted in source files.
+    ///
+    /// - `jupytext`: Standard jupytext style where `# %%` marks the start of a cell
+    /// - `inverse_jupytext`: Inverse style where `# $$` marks the end of a cell
+    ///
+    /// Default: jupytext
+    pub cell_marker_style: Option<CellMarkerStyle>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]


### PR DESCRIPTION
Standard jupytext cell markers (`# %%`) mark the *start* of a cell. This creates friction during development because code naturally flows downward: you write code, then decide where the cell boundary should be. With standard jupytext, you have to scroll back up to insert a marker at the beginning of the section you just wrote.

This PR adds a REPL setting and parser for an alternative cell marker style called "inverse jupytext" that uses `# $$` to mark the *end* of a cell instead of the beginning. This matches the natural top-to-bottom flow of writing code: write code then add `# $$` at the end to close the cell.

Details:
write
```
x = 1
y = 2
print(x + y)
# $$

z = x * y
print(z)
# $$
```
with setting
```
{
  "repl": {
    "cell_marker_style": "inverse_jupytext"
  }
}
```
This is equivalent to if you had written
```
# %%
x = 1
y = 2
print(x + y)
# %%
z = x * y
print(z)
```

setting is set to
```
{
  "repl": {
    "cell_marker_style": "jupytext"
  }
}
```
by default. When one mode is enabled, markers from the other mode are treated as if they are just comments.

This feature is off by default.

Release Notes:

- Added option for inverse jupytext marker parsing
