### PR TITLE
editor: Improve performance of `create_highlight_endpoints`

### DIFF
--- a/crates/editor/src/display_map/custom_highlights.rs
+++ b/crates/editor/src/display_map/custom_highlights.rs
@@ -79,12 +79,15 @@ fn create_highlight_endpoints(
             let start_ix = ranges
                 .binary_search_by(|probe| probe.end.cmp(&start, buffer).then(cmp::Ordering::Less))
                 .unwrap_or_else(|i| i);
+            let end_ix = ranges[start_ix..]
+                .binary_search_by(|probe| {
+                    probe.start.cmp(&end, buffer).then(cmp::Ordering::Greater)
+                })
+                .unwrap_or_else(|i| i);
 
-            for range in &ranges[start_ix..] {
-                if range.start.cmp(&end, buffer).is_ge() {
-                    break;
-                }
+            highlight_endpoints.reserve(2 * end_ix);
 
+            for range in &ranges[start_ix..][..end_ix] {
                 let start = range.start.to_offset(buffer);
                 let end = range.end.to_offset(buffer);
                 if start == end {


### PR DESCRIPTION
We reallocate quite a bunch in this codepath even though we don't need to, we already roughly know what number of elements we are working with so we can reduce the required allocations to some degree. This also reduces the amount of anchor comparisons required.

Came up in profiling for https://github.com/zed-industries/zed/issues/44503

Release Notes:

- N/A *or* Added/Fixed/Improved ...
