### PR TITLE
Add terminal tab renaming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16513,6 +16513,7 @@ dependencies = [
  "itertools 0.14.0",
  "language",
  "log",
+ "menu",
  "pretty_assertions",
  "project",
  "rand 0.9.2",

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -2084,7 +2084,7 @@ impl Terminal {
     pub fn title(&self, truncate: bool) -> String {
         const MAX_CHARS: usize = 25;
 
-        if let Some(ref title_override) = self.title_override {
+        if let Some(title_override) = &self.title_override {
             return if truncate {
                 truncate_and_trailoff(title_override, MAX_CHARS)
             } else {

--- a/crates/terminal_view/Cargo.toml
+++ b/crates/terminal_view/Cargo.toml
@@ -29,6 +29,7 @@ gpui.workspace = true
 itertools.workspace = true
 language.workspace = true
 log.workspace = true
+menu.workspace = true
 pretty_assertions.workspace = true
 project.workspace = true
 regex.workspace = true

--- a/crates/terminal_view/src/persistence.rs
+++ b/crates/terminal_view/src/persistence.rs
@@ -484,14 +484,6 @@ impl TerminalDb {
     }
 
     query! {
-        pub fn get_working_directory(item_id: ItemId, workspace_id: WorkspaceId) -> Result<Option<PathBuf>> {
-            SELECT working_directory
-            FROM terminals
-            WHERE item_id = ? AND workspace_id = ?
-        }
-    }
-
-    query! {
         pub fn get_terminal(item_id: ItemId, workspace_id: WorkspaceId) -> Result<Option<(PathBuf, Option<String>)>> {
             SELECT working_directory, custom_name
             FROM terminals

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -8,13 +8,10 @@ mod terminal_slash_command;
 use assistant_slash_command::SlashCommandRegistry;
 use editor::{Editor, EditorSettings, actions::SelectAll, blink_manager::BlinkManager};
 use gpui::{
-    Action, AnyElement, App, Context, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable,
-    IntoElement, KeyContext, KeyDownEvent, Keystroke, MouseButton, MouseDownEvent, Pixels, Render,
-    ScrollWheelEvent, Styled, Subscription, Task, WeakEntity, Window, actions, anchored, deferred,
-    div,
-    Action, AnyElement, App, ClipboardEntry, DismissEvent, Entity, EventEmitter, FocusHandle,
-    Focusable, KeyContext, KeyDownEvent, Keystroke, MouseButton, MouseDownEvent, Pixels, Render,
-    ScrollWheelEvent, Styled, Subscription, Task, WeakEntity, actions, anchored, deferred, div,
+    Action, AnyElement, App, ClipboardEntry, Context, DismissEvent, Entity, EventEmitter,
+    FocusHandle, Focusable, IntoElement, KeyContext, KeyDownEvent, Keystroke, MouseButton,
+    MouseDownEvent, Pixels, Render, ScrollWheelEvent, Styled, Subscription, Task, WeakEntity,
+    Window, actions, anchored, deferred, div,
 };
 use menu::{Cancel, Confirm};
 use persistence::TERMINAL_DB;
@@ -459,7 +456,7 @@ impl TerminalView {
             cx.new(|cx| TerminalRenameEditor::new(editor, terminal_view, window, cx));
 
         let focus_handle = rename_editor.focus_handle(cx);
-        window.focus(&focus_handle);
+        window.focus(&focus_handle, cx);
 
         self.rename_editor = Some(rename_editor);
         cx.emit(ItemEvent::UpdateTab);
@@ -486,7 +483,7 @@ impl TerminalView {
                 });
             }
 
-            window.focus(&self.focus_handle);
+            window.focus(&self.focus_handle, cx);
             cx.emit(ItemEvent::UpdateTab);
             cx.notify();
         }
@@ -1151,7 +1148,7 @@ impl TerminalView {
 
     fn focus_in(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         if let Some(rename_editor) = &self.rename_editor {
-            window.focus(&rename_editor.focus_handle(cx));
+            window.focus(&rename_editor.focus_handle(cx), cx);
             return;
         }
 

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -46,9 +46,9 @@ use workspace::{
     CloseActiveItem, NewCenterTerminal, NewTerminal, ToolbarItemLocation, Workspace, WorkspaceId,
     delete_unloaded_items,
     item::{
-        BreadcrumbText, Item, ItemEvent, SerializableItem, TabContentParams, TabTooltipContent,
+        BreadcrumbText, Item, ItemEvent, SerializableItem, TabContentParams, TabContextMenuEntry,
+        TabTooltipContent,
     },
-    pane::RenameTab,
     register_serializable_item,
     searchable::{Direction, SearchEvent, SearchOptions, SearchableItem, SearchableItemHandle},
 };
@@ -90,6 +90,8 @@ pub struct SendKeystroke(String);
 actions!(
     terminal,
     [
+        /// Renames the current terminal tab.
+        RenameTerminal,
         /// Reruns the last executed task in the terminal.
         RerunTask
     ]
@@ -604,7 +606,7 @@ impl TerminalView {
         window.dispatch_action(Box::new(task), cx);
     }
 
-    fn rename_tab(&mut self, _: &RenameTab, window: &mut Window, cx: &mut Context<Self>) {
+    fn rename_terminal(&mut self, _: &RenameTerminal, window: &mut Window, cx: &mut Context<Self>) {
         self.start_rename(window, cx);
     }
 
@@ -1210,7 +1212,7 @@ impl Render for TerminalView {
             .on_action(cx.listener(TerminalView::show_character_palette))
             .on_action(cx.listener(TerminalView::select_all))
             .on_action(cx.listener(TerminalView::rerun_task))
-            .on_action(cx.listener(Self::rename_tab))
+            .on_action(cx.listener(Self::rename_terminal))
             .on_key_down(cx.listener(Self::key_down))
             .on_mouse_down(
                 MouseButton::Right,
@@ -1475,8 +1477,8 @@ impl Item for TerminalView {
         f(*event)
     }
 
-    fn supports_rename(&self) -> bool {
-        true
+    fn tab_context_menu_entries(&self, _window: &Window, _cx: &App) -> Vec<TabContextMenuEntry> {
+        vec![TabContextMenuEntry::new("Rename", RenameTerminal)]
     }
 }
 

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -351,6 +351,10 @@ pub trait Item: Focusable + EventEmitter<Self::Event> + Render + Sized {
     fn include_in_nav_history() -> bool {
         true
     }
+
+    fn supports_rename(&self) -> bool {
+        false
+    }
 }
 
 pub trait SerializableItem: Item {
@@ -519,6 +523,7 @@ pub trait ItemHandle: 'static + Send {
     fn preserve_preview(&self, cx: &App) -> bool;
     fn include_in_nav_history(&self) -> bool;
     fn relay_action(&self, action: Box<dyn Action>, window: &mut Window, cx: &mut App);
+    fn supports_rename(&self, cx: &App) -> bool;
     fn can_autosave(&self, cx: &App) -> bool {
         let is_deleted = self.project_entry_ids(cx).is_empty();
         self.is_dirty(cx) && !self.has_conflict(cx) && self.can_save(cx) && !is_deleted
@@ -1055,6 +1060,10 @@ impl<T: Item> ItemHandle for Entity<T> {
             this.focus_handle(cx).focus(window, cx);
             window.dispatch_action(action, cx);
         })
+    }
+
+    fn supports_rename(&self, cx: &App) -> bool {
+        self.read(cx).supports_rename()
     }
 }
 

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -218,6 +218,8 @@ actions!(
         JoinAll,
         /// Reopens the most recently closed item.
         ReopenClosedItem,
+        /// Renames the currently active tab.
+        RenameTab,
         /// Splits the pane to the left, cloning the current item.
         SplitLeft,
         /// Splits the pane upward, cloning the current item.
@@ -2642,6 +2644,7 @@ impl Pane {
         let indicator = render_item_indicator(item.boxed_clone(), cx);
         let tab_tooltip_content = item.tab_tooltip_content(cx);
         let item_id = item.item_id();
+        let supports_rename = item.supports_rename(cx);
         let is_first_item = ix == 0;
         let is_last_item = ix == self.items.len() - 1;
         let is_pinned = self.is_tab_pinned(ix);
@@ -2940,7 +2943,18 @@ impl Pane {
                                     pane.close_all_items(&close_all_items_action, window, cx)
                                         .detach_and_log_err(cx)
                                 }),
-                            );
+                            )
+                            .when(supports_rename, |menu| {
+                                menu.separator().entry(
+                                    "Rename",
+                                    Some(RenameTab.boxed_clone()),
+                                    window.handler_for(&pane, move |pane, window, cx| {
+                                        if let Some(item) = pane.items.get(ix).cloned() {
+                                            item.relay_action(RenameTab.boxed_clone(), window, cx);
+                                        }
+                                    }),
+                                )
+                            });
 
                         let pin_tab_entries = |menu: ContextMenu| {
                             menu.separator().map(|this| {


### PR DESCRIPTION
**Summary**
Allows users to rename terminal tabs for better organization.

This change introduces a rename tab functionality that enables users to customize the title of their terminal tabs. The new title is persisted and restored upon application restart.

**Features**
- New global action `pane: rename tab` when the terminal is focus
- New contextual action `Rename` at the right click on a terminal
- When the terminal is not renamed, we keep the override of the terminal title
- Emptying the title rename resets the title to its original state

https://github.com/user-attachments/assets/53600470-45eb-4b0a-8884-cb4bca31c70a

https://github.com/user-attachments/assets/f49ded93-bb2f-40b5-a738-153e28872e82

Release Notes:

- Added command to rename terminal title