### PR TITLE
docs: Add clarifying note about Vim subword motion

### DIFF
--- a/docs/src/vim.md
+++ b/docs/src/vim.md
@@ -205,6 +205,7 @@ These text objects implement the behavior of the [mini.ai](https://github.com/ec
 #### Choosing Between Approaches
 
 - Use **AnyQuotes/AnyBrackets** if you:
+
   - Prefer traditional Vim behavior
   - Want consistent character-based selection prioritizing innermost delimiters
   - Need behavior that closely matches vanilla Vim's text objects

--- a/docs/src/vim.md
+++ b/docs/src/vim.md
@@ -205,7 +205,6 @@ These text objects implement the behavior of the [mini.ai](https://github.com/ec
 #### Choosing Between Approaches
 
 - Use **AnyQuotes/AnyBrackets** if you:
-
   - Prefer traditional Vim behavior
   - Want consistent character-based selection prioritizing innermost delimiters
   - Need behavior that closely matches vanilla Vim's text objects
@@ -471,11 +470,11 @@ But you cannot use the same shortcuts to move between all the editor docks (the 
 }
 ```
 
-Subword motion, which allows you to navigate and select individual words in camelCase or snake_case, is not enabled by default. To enable it, add these bindings to your keymap. If you would like operations to remain unaffected (ex. `dw`), add ` && vim_mode != operator` to the `context` check.
+Subword motion, which allows you to navigate and select individual words in `camelCase` or `snake_case`, is not enabled by default. To enable it, add these bindings to your keymap.
 
 ```json [settings]
 {
-  "context": "VimControl && !menu",
+  "context": "VimControl && !menu && vim_mode != operator",
   "bindings": {
     "w": "vim::NextSubwordStart",
     "b": "vim::PreviousSubwordStart",
@@ -484,6 +483,9 @@ Subword motion, which allows you to navigate and select individual words in came
   }
 }
 ```
+
+> Note: Operations like `dw` remain unaffected. If you would like operations to
+> also use subword motion, remove `vim_mode != operator` from the `context`.
 
 Vim mode comes with shortcuts to surround the selection in normal mode (`ys`), but it doesn't have a shortcut to add surrounds in visual mode. By default, `shift-s` substitutes the selection (erases the text and enters insert mode). To use `shift-s` to add surrounds in visual mode, you can add the following object to your keymap.
 

--- a/docs/src/vim.md
+++ b/docs/src/vim.md
@@ -471,11 +471,11 @@ But you cannot use the same shortcuts to move between all the editor docks (the 
 }
 ```
 
-Subword motion, which allows you to navigate and select individual words in camelCase or snake_case, is not enabled by default. To enable it, add these bindings to your keymap.
+Subword motion, which allows you to navigate and select individual words in camelCase or snake_case, is not enabled by default. To enable it, add these bindings to your keymap. If you would like operations to remain unaffected (ex. `dw`), add ` && vim_mode != operator` to the `context` check.
 
 ```json [settings]
 {
-  "context": "VimControl && !menu && vim_mode != operator",
+  "context": "VimControl && !menu",
   "bindings": {
     "w": "vim::NextSubwordStart",
     "b": "vim::PreviousSubwordStart",


### PR DESCRIPTION
Clarify the docs regarding how operations are affected when subword motion in Vim is activated.

Ref: https://github.com/zed-industries/zed/issues/23344#issuecomment-3186025873.

Release Notes:

- N/A