### PR TITLE
commit view: Fix layout shift while loading commit

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1275,7 +1275,7 @@ pub struct GutterDimensions {
 }
 
 impl GutterDimensions {
-    pub fn default_with_margin(font_id: FontId, font_size: Pixels, cx: &App) -> Self {
+    fn default_with_margin(font_id: FontId, font_size: Pixels, cx: &App) -> Self {
         Self {
             margin: Self::default_gutter_margin(font_id, font_size, cx),
             ..Default::default()
@@ -20366,7 +20366,7 @@ impl Editor {
 
     pub fn style(&mut self, cx: &App) -> &EditorStyle {
         if self.style.is_none() {
-            self.style = Some(self.create_editor_style(cx));
+            self.style = Some(self.create_style(cx));
         }
         self.style.as_ref().unwrap()
     }
@@ -23171,7 +23171,7 @@ impl Editor {
         self.active_diagnostics == ActiveDiagnostic::All || !self.mode().is_full()
     }
 
-    fn create_editor_style(&self, cx: &App) -> EditorStyle {
+    fn create_style(&self, cx: &App) -> EditorStyle {
         let settings = ThemeSettings::get_global(cx);
 
         let mut text_style = match self.mode {
@@ -25024,7 +25024,7 @@ impl Focusable for Editor {
 
 impl Render for Editor {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        EditorElement::new(&cx.entity(), self.create_editor_style(cx))
+        EditorElement::new(&cx.entity(), self.create_style(cx))
     }
 }
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -2218,10 +2218,9 @@ async fn test_move_start_of_paragraph_end_of_paragraph(cx: &mut TestAppContext) 
     init_test(cx, |_| {});
     let mut cx = EditorTestContext::new(cx).await;
 
-    let line_height = cx.editor(|editor, window, _| {
+    let line_height = cx.update_editor(|editor, window, cx| {
         editor
-            .style()
-            .unwrap()
+            .style(cx)
             .text
             .line_height_in_pixels(window.rem_size())
     });
@@ -2334,10 +2333,9 @@ async fn test_move_start_of_paragraph_end_of_paragraph(cx: &mut TestAppContext) 
 async fn test_scroll_page_up_page_down(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
     let mut cx = EditorTestContext::new(cx).await;
-    let line_height = cx.editor(|editor, window, _| {
+    let line_height = cx.update_editor(|editor, window, cx| {
         editor
-            .style()
-            .unwrap()
+            .style(cx)
             .text
             .line_height_in_pixels(window.rem_size())
     });
@@ -2400,8 +2398,7 @@ async fn test_autoscroll(cx: &mut TestAppContext) {
     let line_height = cx.update_editor(|editor, window, cx| {
         editor.set_vertical_scroll_margin(2, cx);
         editor
-            .style()
-            .unwrap()
+            .style(cx)
             .text
             .line_height_in_pixels(window.rem_size())
     });
@@ -2480,10 +2477,9 @@ async fn test_move_page_up_page_down(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
     let mut cx = EditorTestContext::new(cx).await;
 
-    let line_height = cx.editor(|editor, window, _cx| {
+    let line_height = cx.update_editor(|editor, window, cx| {
         editor
-            .style()
-            .unwrap()
+            .style(cx)
             .text
             .line_height_in_pixels(window.rem_size())
     });
@@ -28311,7 +28307,8 @@ async fn test_sticky_scroll(cx: &mut TestAppContext) {
     let mut sticky_headers = |offset: ScrollOffset| {
         cx.update_editor(|e, window, cx| {
             e.scroll(gpui::Point { x: 0., y: offset }, None, window, cx);
-            EditorElement::sticky_headers(&e, &e.snapshot(window, cx), cx)
+            let style = e.style(cx).clone();
+            EditorElement::sticky_headers(&e, &e.snapshot(window, cx), &style, cx)
                 .into_iter()
                 .map(
                     |StickyHeader {
@@ -28365,10 +28362,9 @@ async fn test_scroll_by_clicking_sticky_header(cx: &mut TestAppContext) {
     });
     let mut cx = EditorTestContext::new(cx).await;
 
-    let line_height = cx.editor(|editor, window, _cx| {
+    let line_height = cx.update_editor(|editor, window, cx| {
         editor
-            .style()
-            .unwrap()
+            .style(cx)
             .text
             .line_height_in_pixels(window.rem_size())
     });

--- a/crates/editor/src/mouse_context_menu.rs
+++ b/crates/editor/src/mouse_context_menu.rs
@@ -59,7 +59,7 @@ impl MouseContextMenu {
                 x: editor.gutter_dimensions.width,
                 y: Pixels::ZERO,
             };
-        let source_position = editor.to_pixel_point(source, &editor_snapshot, window)?;
+        let source_position = editor.to_pixel_point(source, &editor_snapshot, window, cx)?;
         let menu_position = MenuPosition::PinnedToEditor {
             source,
             offset: position - (source_position + content_origin),

--- a/crates/editor/src/test/editor_test_context.rs
+++ b/crates/editor/src/test/editor_test_context.rs
@@ -283,8 +283,7 @@ impl EditorTestContext {
                 .head();
             let pixel_position = editor.pixel_position_of_newest_cursor.unwrap();
             let line_height = editor
-                .style()
-                .unwrap()
+                .style(cx)
                 .text
                 .line_height_in_pixels(window.rem_size());
             let snapshot = editor.snapshot(window, cx);

--- a/crates/git_ui/src/commit_view.rs
+++ b/crates/git_ui/src/commit_view.rs
@@ -169,64 +169,62 @@ impl CommitView {
         let commit_message = commit.message.clone();
 
         cx.spawn(async move |this, cx| {
-            for file in commit_diff.files {
-                let is_deleted = file.new_text.is_none();
-                let new_text = file.new_text.unwrap_or_default();
-                let old_text = file.old_text;
-                let worktree_id = repository_clone
-                    .update(cx, |repository, cx| {
-                        repository
-                            .repo_path_to_project_path(&file.path, cx)
-                            .map(|path| path.worktree_id)
-                            .or(first_worktree_id)
-                    })?
-                    .context("project has no worktrees")?;
-                let short_sha = commit_sha.get(0..7).unwrap_or(&commit_sha);
-                let file_name = file
-                    .path
-                    .file_name()
-                    .map(|name| name.to_string())
-                    .unwrap_or_else(|| file.path.display(PathStyle::Posix).to_string());
-                let display_name: Arc<str> =
-                    Arc::from(format!("{short_sha} - {file_name}").into_boxed_str());
+            let diff_file_tasks = commit_diff.files.into_iter().map(|file| {
+                let commit_sha = commit_sha.clone();
+                let repository_clone = repository_clone.clone();
+                let first_worktree_id = first_worktree_id.clone();
+                let language_registry = language_registry.clone();
+                cx.spawn(async move |cx| {
+                    let is_deleted = file.new_text.is_none();
+                    let new_text = file.new_text.unwrap_or_default();
+                    let old_text = file.old_text;
+                    let worktree_id = repository_clone
+                        .update(cx, |repository, cx| {
+                            repository
+                                .repo_path_to_project_path(&file.path, cx)
+                                .map(|path| path.worktree_id)
+                                .or(first_worktree_id)
+                        })?
+                        .context("project has no worktrees")?;
+                    let short_sha = commit_sha.get(0..7).unwrap_or(&commit_sha);
+                    let file_name = file
+                        .path
+                        .file_name()
+                        .map(|name| name.to_string())
+                        .unwrap_or_else(|| file.path.display(PathStyle::Posix).to_string());
+                    let display_name: Arc<str> =
+                        Arc::from(format!("{short_sha} - {file_name}").into_boxed_str());
 
-                let file = Arc::new(GitBlob {
-                    path: file.path.clone(),
-                    is_deleted,
-                    worktree_id,
-                    display_name,
-                }) as Arc<dyn language::File>;
+                    let file = Arc::new(GitBlob {
+                        path: file.path.clone(),
+                        is_deleted,
+                        worktree_id,
+                        display_name,
+                    }) as Arc<dyn language::File>;
 
-                let buffer = build_buffer(new_text, file, &language_registry, cx).await?;
-                let buffer_diff =
-                    build_buffer_diff(old_text, &buffer, &language_registry, cx).await?;
+                    let buffer = build_buffer(new_text, file, &language_registry, cx).await?;
+                    let buffer_diff =
+                        build_buffer_diff(old_text, &buffer, &language_registry, cx).await?;
 
-                this.update(cx, |this, cx| {
-                    this.multibuffer.update(cx, |multibuffer, cx| {
-                        let snapshot = buffer.read(cx).snapshot();
-                        let path = snapshot.file().unwrap().path().clone();
-                        let excerpt_ranges = {
-                            let mut hunks = buffer_diff.read(cx).hunks(&snapshot, cx).peekable();
-                            if hunks.peek().is_none() {
-                                vec![language::Point::zero()..snapshot.max_point()]
-                            } else {
-                                hunks
-                                    .map(|hunk| hunk.buffer_range.to_point(&snapshot))
-                                    .collect::<Vec<_>>()
-                            }
+                    let (path, excerpt_ranges) = buffer.read_with(cx, |buffer, cx| {
+                        let path = buffer.file().unwrap().path().clone();
+                        let mut hunks = buffer_diff.read(cx).hunks(&buffer, cx).peekable();
+                        let excerpt_ranges = if hunks.peek().is_none() {
+                            vec![language::Point::zero()..buffer.max_point()]
+                        } else {
+                            hunks
+                                .map(|hunk| hunk.buffer_range.to_point(&buffer))
+                                .collect::<Vec<_>>()
                         };
 
-                        let _is_newly_added = multibuffer.set_excerpts_for_path(
-                            PathKey::with_sort_prefix(FILE_NAMESPACE_SORT_PREFIX, path),
-                            buffer,
-                            excerpt_ranges,
-                            multibuffer_context_lines(cx),
-                            cx,
-                        );
-                        multibuffer.add_diff(buffer_diff, cx);
-                    });
-                })?;
-            }
+                        (path, excerpt_ranges)
+                    })?;
+
+                    anyhow::Ok((buffer, buffer_diff, path, excerpt_ranges))
+                })
+            });
+
+            let diff_files = futures::future::try_join_all(diff_file_tasks).await?;
 
             let message_buffer = cx.new(|cx| {
                 let mut buffer = Buffer::local(commit_message, cx);
@@ -236,6 +234,17 @@ impl CommitView {
 
             this.update(cx, |this, cx| {
                 this.multibuffer.update(cx, |multibuffer, cx| {
+                    for (buffer, buffer_diff, path, excerpt_ranges) in diff_files {
+                        let _is_newly_added = multibuffer.set_excerpts_for_path(
+                            PathKey::with_sort_prefix(FILE_NAMESPACE_SORT_PREFIX, path),
+                            buffer,
+                            excerpt_ranges,
+                            multibuffer_context_lines(cx),
+                            cx,
+                        );
+                        multibuffer.add_diff(buffer_diff, cx);
+                    }
+
                     let range = ExcerptRange {
                         context: Anchor::MIN..Anchor::MAX,
                         primary: Anchor::MIN..Anchor::MAX,

--- a/crates/git_ui/src/commit_view.rs
+++ b/crates/git_ui/src/commit_view.rs
@@ -426,14 +426,21 @@ impl CommitView {
             None
         };
 
+        let editor = self.editor.read(cx);
+        let gutter_width = editor.last_gutter_dimensions().full_width();
+        // hide elements until editor renders once
+        let loading = gutter_width < px(1.);
+
         h_flex()
             .border_b_1()
             .border_color(cx.theme().colors().border_variant)
+            .w_full()
             .child(
                 h_flex()
-                    .w(self.editor.read(cx).last_gutter_dimensions().full_width())
+                    .w(gutter_width)
                     .justify_center()
-                    .child(self.render_commit_avatar(&commit.sha, rems_from_px(48.), window, cx)),
+                    .child(self.render_commit_avatar(&commit.sha, rems_from_px(48.), window, cx))
+                    .when(loading, |this| this.opacity(0.)),
             )
             .child(
                 h_flex()
@@ -481,7 +488,8 @@ impl CommitView {
                             .icon_size(IconSize::Small)
                             .icon_position(IconPosition::Start)
                             .on_click(move |_, _, cx| cx.open_url(&url))
-                    })),
+                    }))
+                    .when(loading, |this| this.opacity(0.)),
             )
     }
 
@@ -1020,7 +1028,9 @@ impl Render for CommitView {
             .size_full()
             .bg(cx.theme().colors().editor_background)
             .child(self.render_header(window, cx))
-            .child(div().flex_grow().child(self.editor.clone()))
+            .when(!self.editor.read(cx).is_empty(cx), |this| {
+                this.child(div().flex_grow().child(self.editor.clone()))
+            })
     }
 }
 

--- a/crates/vim/src/normal/scroll.rs
+++ b/crates/vim/src/normal/scroll.rs
@@ -294,11 +294,10 @@ mod test {
     async fn test_scroll(cx: &mut gpui::TestAppContext) {
         let mut cx = VimTestContext::new(cx, true).await;
 
-        let (line_height, visible_line_count) = cx.editor(|editor, window, _cx| {
+        let (line_height, visible_line_count) = cx.update_editor(|editor, window, cx| {
             (
                 editor
-                    .style()
-                    .unwrap()
+                    .style(cx)
                     .text
                     .line_height_in_pixels(window.rem_size()),
                 editor.visible_line_count().unwrap(),

--- a/crates/vim/src/test.rs
+++ b/crates/vim/src/test.rs
@@ -2399,7 +2399,7 @@ async fn test_clipping_on_mode_change(cx: &mut gpui::TestAppContext) {
             .end;
         editor.last_bounds().unwrap().origin
             + editor
-                .display_to_pixel_point(current_head, &snapshot, window)
+                .display_to_pixel_point(current_head, &snapshot, window, cx)
                 .unwrap()
     });
     pixel_position.x += px(100.);

--- a/crates/vim/src/test/neovim_backed_test_context.rs
+++ b/crates/vim/src/test/neovim_backed_test_context.rs
@@ -304,11 +304,10 @@ impl NeovimBackedTestContext {
         self.neovim.set_option(&format!("scrolloff={}", 3)).await;
         // +2 to account for the vim command UI at the bottom.
         self.neovim.set_option(&format!("lines={}", rows + 2)).await;
-        let (line_height, visible_line_count) = self.editor(|editor, window, _cx| {
+        let (line_height, visible_line_count) = self.update_editor(|editor, window, cx| {
             (
                 editor
-                    .style()
-                    .unwrap()
+                    .style(cx)
                     .text
                     .line_height_in_pixels(window.rem_size()),
                 editor.visible_line_count().unwrap(),

--- a/crates/zed/src/zed/quick_action_bar.rs
+++ b/crates/zed/src/zed/quick_action_bar.rs
@@ -174,17 +174,13 @@ impl Render for QuickActionBar {
                     .as_ref()
                     .is_some_and(|menu| matches!(menu.origin(), ContextMenuOrigin::QuickActionBar))
             };
-            let code_action_element = if is_deployed {
-                editor.update(cx, |editor, cx| {
-                    if let Some(style) = editor.style() {
-                        editor.render_context_menu(style, MAX_CODE_ACTION_MENU_LINES, window, cx)
-                    } else {
-                        None
-                    }
+            let code_action_element = is_deployed
+                .then(|| {
+                    editor.update(cx, |editor, cx| {
+                        editor.render_context_menu(MAX_CODE_ACTION_MENU_LINES, window, cx)
+                    })
                 })
-            } else {
-                None
-            };
+                .flatten();
             v_flex()
                 .child(
                     IconButton::new("toggle_code_actions_icon", IconName::BoltOutlined)


### PR DESCRIPTION
Fixes a few cases where the commit view would layout shift as the diff loaded. This was caused by:
- Adding the commit message buffer after all the diff files
- Using the gutter dimensions from the last frame for the avatar spacing

Release Notes:

- commit view: Fix layout shift while loading commit
