### PR TITLE
git_ui: Always use latest commit message on amend

### DIFF
--- a/crates/fs/src/fake_git_repo.rs
+++ b/crates/fs/src/fake_git_repo.rs
@@ -200,6 +200,7 @@ impl GitRepository for FakeGitRepository {
         async {
             Ok(CommitDetails {
                 sha: commit.into(),
+                message: "initial commit".into(),
                 ..Default::default()
             })
         }
@@ -568,7 +569,7 @@ impl GitRepository for FakeGitRepository {
         _askpass: AskPassDelegate,
         _env: Arc<HashMap<String, String>>,
     ) -> BoxFuture<'_, Result<()>> {
-        unimplemented!()
+        async { Ok(()) }.boxed()
     }
 
     fn run_hook(
@@ -576,7 +577,7 @@ impl GitRepository for FakeGitRepository {
         _hook: RunHook,
         _env: Arc<HashMap<String, String>>,
     ) -> BoxFuture<'_, Result<()>> {
-        unimplemented!()
+        async { Ok(()) }.boxed()
     }
 
     fn push(

--- a/crates/git_ui/src/commit_modal.rs
+++ b/crates/git_ui/src/commit_modal.rs
@@ -492,52 +492,22 @@ impl CommitModal {
         }
     }
 
-    fn commit(&mut self, _: &git::Commit, window: &mut Window, cx: &mut Context<Self>) {
-        if self.git_panel.read(cx).amend_pending() {
-            return;
-        }
-        telemetry::event!("Git Committed", source = "Git Modal");
-        self.git_panel.update(cx, |git_panel, cx| {
-            git_panel.commit_changes(
-                CommitOptions {
-                    amend: false,
-                    signoff: git_panel.signoff_enabled(),
-                },
-                window,
-                cx,
-            )
-        });
-        cx.emit(DismissEvent);
-    }
-
-    fn amend(&mut self, _: &git::Amend, window: &mut Window, cx: &mut Context<Self>) {
+    fn on_commit(&mut self, _: &git::Commit, window: &mut Window, cx: &mut Context<Self>) {
         if self
             .git_panel
-            .read(cx)
-            .active_repository
-            .as_ref()
-            .and_then(|repo| repo.read(cx).head_commit.as_ref())
-            .is_none()
+            .update(cx, |git_panel, cx| git_panel.commit(window, cx))
         {
-            return;
+            telemetry::event!("Git Committed", source = "Git Modal");
+            cx.emit(DismissEvent);
         }
-        if !self.git_panel.read(cx).amend_pending() {
-            self.git_panel.update(cx, |git_panel, cx| {
-                git_panel.set_amend_pending(true, cx);
-                git_panel.load_last_commit_message(cx);
-            });
-        } else {
+    }
+
+    fn on_amend(&mut self, _: &git::Amend, window: &mut Window, cx: &mut Context<Self>) {
+        if self
+            .git_panel
+            .update(cx, |git_panel, cx| git_panel.amend(window, cx))
+        {
             telemetry::event!("Git Amended", source = "Git Modal");
-            self.git_panel.update(cx, |git_panel, cx| {
-                git_panel.commit_changes(
-                    CommitOptions {
-                        amend: true,
-                        signoff: git_panel.signoff_enabled(),
-                    },
-                    window,
-                    cx,
-                );
-            });
             cx.emit(DismissEvent);
         }
     }
@@ -563,8 +533,8 @@ impl Render for CommitModal {
             .id("commit-modal")
             .key_context("GitCommit")
             .on_action(cx.listener(Self::dismiss))
-            .on_action(cx.listener(Self::commit))
-            .on_action(cx.listener(Self::amend))
+            .on_action(cx.listener(Self::on_commit))
+            .on_action(cx.listener(Self::on_amend))
             .when(!DisableAiSettings::get_global(cx).disable_ai, |this| {
                 this.on_action(cx.listener(|this, _: &GenerateCommitMessage, _, cx| {
                     this.git_panel.update(cx, |panel, cx| {

--- a/crates/git_ui/src/commit_modal.rs
+++ b/crates/git_ui/src/commit_modal.rs
@@ -529,7 +529,6 @@ impl CommitModal {
         } else {
             telemetry::event!("Git Amended", source = "Git Modal");
             self.git_panel.update(cx, |git_panel, cx| {
-                git_panel.set_amend_pending(false, cx);
                 git_panel.commit_changes(
                     CommitOptions {
                         amend: true,

--- a/crates/git_ui/src/commit_modal.rs
+++ b/crates/git_ui/src/commit_modal.rs
@@ -139,7 +139,7 @@ impl CommitModal {
                             && !git_panel.amend_pending()
                         {
                             git_panel.set_amend_pending(true, cx);
-                            git_panel.load_last_commit_message_if_empty(cx);
+                            git_panel.load_last_commit_message(cx);
                         }
                     }
                     ForceMode::Commit => {
@@ -524,7 +524,7 @@ impl CommitModal {
         if !self.git_panel.read(cx).amend_pending() {
             self.git_panel.update(cx, |git_panel, cx| {
                 git_panel.set_amend_pending(true, cx);
-                git_panel.load_last_commit_message_if_empty(cx);
+                git_panel.load_last_commit_message(cx);
             });
         } else {
             telemetry::event!("Git Amended", source = "Git Modal");


### PR DESCRIPTION
Update the behavior of `git::Amend` to ensure that the latest head commit message, if available, is always loaded into the commit message editor, regardless of its state. The previous text, if any, is now also restored after the amend is finished.

- Update `FakeGitRepository.show` to include a message in the returned `CommitDetails` so we can assert that this specific commit message is set in the commit message editor.
- Add default implementation for `FakeGitRepository.commit` and `FakeGitRepository.run_hook` to ensure that tests are able to run and don't panic on `unimplemented!()`
- Refactor `GitPanel.load_last_commit_message_if_empty` to `GitPanel.load_last_commit_message`, ensuring that the head commit message is always loaded, regardless of whether the commit message editor is empty.
- Update `GitPanel.commit_changes` to ensure that the pending amend state is only updated if the editor managed to actually commit the changes. This also ensures that we don't restore the commit message editor's contents when amending a commit, before the amend is actually processed.
- Update `CommitModal.amend`, removing the call to `GitPanel.set_amend_pending` as that is now handled by the background task created in `GitPanel.commit_changes`.
- Split the `commit` and `amend` methods from the event handlers so that the methods can be called directly, as is now being done by `CommitModal.on_commit` and `CommitModal.on_amend`.

Release Notes:

- Updated the ‎`git: amend` command to always load the latest head commit message, and to restore any previously entered text in the commit message editor after the amend completes
