### PR TITLE
vim: Remove `ctrl-6` keybinding alias for `pane::AlternateFile`

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -180,7 +180,6 @@
       "ctrl-w g shift-d": "editor::GoToTypeDefinitionSplit",
       "ctrl-w space": "editor::OpenExcerptsSplit",
       "ctrl-w g space": "editor::OpenExcerptsSplit",
-      "ctrl-6": "pane::AlternateFile",
       "ctrl-^": "pane::AlternateFile",
       ".": "vim::Repeat"
     }


### PR DESCRIPTION
Closes #ISSUE

It seems that `ctrl-6` is used exclusively as an alias, as can be seen in the [linked section of the vim docs](https://vimhelp.org/editing.txt.html#CTRL-%5E) from the initial PR that added it. This however conflicts with the `ctrl-{n}` bindings for `pane::ActivateItem` on macOS, leading to confusing file selection when `ctrl-6` is pressed.

Release Notes:

- vim(BREAKING): Removed a keybinding conflict between the default macOS bindings for `pane::ActivateItem` and the `ctrl-6` alias for`pane::AlternateFile` which is primarily bound to `ctrl-^`. `ctrl-6` is no longer treated as an alias for `ctrl-^` in vim mode. If you'd like to restore `ctrl-6` as a binding for `pane::AlternateFile`, paste the following into your `keymap.json` file: 
```
  {
    "context": "VimControl && !menu",
    "bindings": {
      "ctrl-6": "pane::AlternateFile"
    }
  }
```
