### PR TITLE
Add keymap field to bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/10_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/10_bug_report.yml
@@ -77,6 +77,22 @@ body:
       required: false
   - type: textarea
     attributes:
+      label: Relevant Keymap
+      description: |
+        Open the command palette in Zed, then type “zed: open keymap file” and copy/paste the file's contents.
+      value: |
+        <details><summary>keymap.json</summary>
+
+        <!-- Paste your keymap file inside the code block. -->
+        ```json
+
+        ```
+
+        </details>
+    validations:
+      required: false
+  - type: textarea
+    attributes:
       label: (for AI issues) Model provider details
       placeholder: |
         - Provider: (Anthropic via ZedPro, Anthropic via API key, Copilot Chat, Mistral, OpenAI, etc.)


### PR DESCRIPTION
Update the issue template used for "Report a bug" to include a field specifically for the user's keymap file, as we've seen multiple cases where we end up asking the users for their custom keymap, to ensure that they're not overriding existing defaults.

Release Notes:

- N/A