### PR TITLE
Revert "Increase askpass timeout for git operations (#42946)"

### DIFF
--- a/crates/git/src/git.rs
+++ b/crates/git/src/git.rs
@@ -232,14 +232,12 @@ impl From<Oid> for usize {
 #[derive(Copy, Clone, Debug)]
 pub enum RunHook {
     PreCommit,
-    PrePush,
 }
 
 impl RunHook {
     pub fn as_str(&self) -> &str {
         match self {
             Self::PreCommit => "pre-commit",
-            Self::PrePush => "pre-push",
         }
     }
 
@@ -250,7 +248,6 @@ impl RunHook {
     pub fn from_proto(value: i32) -> Option<Self> {
         match value {
             0 => Some(Self::PreCommit),
-            1 => Some(Self::PrePush),
             _ => None,
         }
     }

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -4692,11 +4692,9 @@ impl Repository {
             });
 
         let this = cx.weak_entity();
-        let rx = self.run_hook(RunHook::PrePush, cx);
         self.send_job(
             Some(format!("git push {} {} {}", args, remote, branch).into()),
             move |git_repo, mut cx| async move {
-                rx.await??;
                 match git_repo {
                     RepositoryState::Local(LocalRepositoryState {
                         backend,

--- a/crates/proto/proto/git.proto
+++ b/crates/proto/proto/git.proto
@@ -580,6 +580,7 @@ message GitCreateWorktree {
 message RunGitHook {
     enum GitHook {
         PRE_COMMIT = 0;
+        reserved 1;
     }
 
     uint64 project_id = 1;

--- a/crates/proto/proto/git.proto
+++ b/crates/proto/proto/git.proto
@@ -580,7 +580,6 @@ message GitCreateWorktree {
 message RunGitHook {
     enum GitHook {
         PRE_COMMIT = 0;
-        PRE_PUSH = 1;
     }
 
     uint64 project_id = 1;


### PR DESCRIPTION
This reverts commit a74aac88c95738b1e1c95ac583b116a253920fbf.

cc @11happy, we need to do a bit more than just running `git hook pre-push` before pushing, as described [here](https://github.com/zed-industries/zed/pull/42946#issuecomment-3550570438). Right now this is also running the pre-push hook twice.

Release Notes:

- N/A