### PR TITLE
Add scrolling functionality to markdown preview mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18103,6 +18103,7 @@ dependencies = [
  "language",
  "log",
  "lsp",
+ "markdown_preview",
  "menu",
  "multi_buffer",
  "nvim-rs",

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -1190,7 +1190,11 @@
     "context": "MarkdownPreview",
     "bindings": {
       "pageup": "markdown::MovePageUp",
-      "pagedown": "markdown::MovePageDown"
+      "pagedown": "markdown::MovePageDown",
+      "up": "markdown::MoveUp",
+      "down": "markdown::MoveDown",
+      "alt-up": "markdown::MoveUpByItem",
+      "alt-down": "markdown::MoveDownByItem"
     }
   },
   {

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -1189,12 +1189,12 @@
   {
     "context": "MarkdownPreview",
     "bindings": {
-      "pageup": "markdown::MovePageUp",
-      "pagedown": "markdown::MovePageDown",
-      "up": "markdown::MoveUp",
-      "down": "markdown::MoveDown",
-      "alt-up": "markdown::MoveUpByItem",
-      "alt-down": "markdown::MoveDownByItem"
+      "pageup": "markdown::ScrollPageUp",
+      "pagedown": "markdown::ScrollPageDown",
+      "up": "markdown::ScrollUp",
+      "down": "markdown::ScrollDown",
+      "alt-up": "markdown::ScrollUpByItem",
+      "alt-down": "markdown::ScrollDownByItem"
     }
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -1295,7 +1295,9 @@
     "context": "MarkdownPreview",
     "bindings": {
       "pageup": "markdown::MovePageUp",
-      "pagedown": "markdown::MovePageDown"
+      "pagedown": "markdown::MovePageDown",
+      "down": "markdown::MoveDown",
+      "up": "markdown::MoveUp"
     }
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -1296,8 +1296,10 @@
     "bindings": {
       "pageup": "markdown::MovePageUp",
       "pagedown": "markdown::MovePageDown",
+      "up": "markdown::MoveUp",
       "down": "markdown::MoveDown",
-      "up": "markdown::MoveUp"
+      "alt-up": "markdown::MoveUpByItem",
+      "alt-down": "markdown::MoveDownByItem"
     }
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -1294,12 +1294,12 @@
   {
     "context": "MarkdownPreview",
     "bindings": {
-      "pageup": "markdown::MovePageUp",
-      "pagedown": "markdown::MovePageDown",
-      "up": "markdown::MoveUp",
-      "down": "markdown::MoveDown",
-      "alt-up": "markdown::MoveUpByItem",
-      "alt-down": "markdown::MoveDownByItem"
+      "pageup": "markdown::ScrollPageUp",
+      "pagedown": "markdown::ScrollPageDown",
+      "up": "markdown::ScrollUp",
+      "down": "markdown::ScrollDown",
+      "alt-up": "markdown::ScrollUpByItem",
+      "alt-down": "markdown::ScrollDownByItem"
     }
   },
   {

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -1218,12 +1218,12 @@
     "context": "MarkdownPreview",
     "use_key_equivalents": true,
     "bindings": {
-      "pageup": "markdown::MovePageUp",
-      "pagedown": "markdown::MovePageDown",
-      "up": "markdown::MoveUp",
-      "down": "markdown::MoveDown",
-      "alt-up": "markdown::MoveUpByItem",
-      "alt-down": "markdown::MoveDownByItem"
+      "pageup": "markdown::ScrollPageUp",
+      "pagedown": "markdown::ScrollPageDown",
+      "up": "markdown::ScrollUp",
+      "down": "markdown::ScrollDown",
+      "alt-up": "markdown::ScrollUpByItem",
+      "alt-down": "markdown::ScrollDownByItem"
     }
   },
   {

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -1219,7 +1219,11 @@
     "use_key_equivalents": true,
     "bindings": {
       "pageup": "markdown::MovePageUp",
-      "pagedown": "markdown::MovePageDown"
+      "pagedown": "markdown::MovePageDown",
+      "up": "markdown::MoveUp",
+      "down": "markdown::MoveDown",
+      "alt-up": "markdown::MoveUpByItem",
+      "alt-down": "markdown::MoveDownByItem"
     }
   },
   {

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -1043,5 +1043,14 @@
       "g g": "settings_editor::FocusFirstNavEntry",
       "shift-g": "settings_editor::FocusLastNavEntry"
     }
+  },
+  {
+    "context": "MarkdownPreview",
+    "bindings": {
+      "ctrl-u": "markdown::ScrollPageUp",
+      "ctrl-d": "markdown::ScrollPageDown",
+      "ctrl-y": "markdown::ScrollUp",
+      "ctrl-e": "markdown::ScrollDown"
+    }
   }
 ]

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -300,7 +300,7 @@ impl EditorElement {
         register_action(editor, window, Editor::scroll_cursor_bottom);
         register_action(editor, window, Editor::scroll_cursor_center_top_bottom);
         register_action(editor, window, |editor, _: &LineDown, window, cx| {
-            editor.scroll_screen(&ScrollAmount::Line(1.), window, cx)
+            editor.scroll_screen(&ScrollAmount::Line(1.), window, cx) // Could probably just start by making this the j/down command in markdown preview
         });
         register_action(editor, window, |editor, _: &LineUp, window, cx| {
             editor.scroll_screen(&ScrollAmount::Line(-1.), window, cx)

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -300,7 +300,7 @@ impl EditorElement {
         register_action(editor, window, Editor::scroll_cursor_bottom);
         register_action(editor, window, Editor::scroll_cursor_center_top_bottom);
         register_action(editor, window, |editor, _: &LineDown, window, cx| {
-            editor.scroll_screen(&ScrollAmount::Line(1.), window, cx) // Could probably just start by making this the j/down command in markdown preview
+            editor.scroll_screen(&ScrollAmount::Line(1.), window, cx)
         });
         register_action(editor, window, |editor, _: &LineUp, window, cx| {
             editor.scroll_screen(&ScrollAmount::Line(-1.), window, cx)

--- a/crates/markdown_preview/src/markdown_preview.rs
+++ b/crates/markdown_preview/src/markdown_preview.rs
@@ -11,8 +11,10 @@ actions!(
     markdown,
     [
         /// Scrolls up by one page in the markdown preview.
+        #[action(deprecated_aliases = ["markdown::MovePageUp"])]
         ScrollPageUp,
         /// Scrolls down by one page in the markdown preview.
+        #[action(deprecated_aliases = ["markdown::MovePageDown"])]
         ScrollPageDown,
         /// Scrolls up by approximately one visual line.
         ScrollUp,

--- a/crates/markdown_preview/src/markdown_preview.rs
+++ b/crates/markdown_preview/src/markdown_preview.rs
@@ -11,17 +11,17 @@ actions!(
     markdown,
     [
         /// Scrolls up by one page in the markdown preview.
-        MovePageUp,
+        ScrollPageUp,
         /// Scrolls down by one page in the markdown preview.
-        MovePageDown,
+        ScrollPageDown,
         /// Scrolls up by approximately one visual line.
-        MoveUp,
+        ScrollUp,
         /// Scrolls down by approximately one visual line.
-        MoveDown,
+        ScrollDown,
         /// Scrolls up by one markdown element in the markdown preview
-        MoveUpByItem,
+        ScrollUpByItem,
         /// Scrolls down by one markdown element in the markdown preview
-        MoveDownByItem,
+        ScrollDownByItem,
         /// Opens a markdown preview for the current file.
         OpenPreview,
         /// Opens a markdown preview in a split pane.

--- a/crates/markdown_preview/src/markdown_preview.rs
+++ b/crates/markdown_preview/src/markdown_preview.rs
@@ -18,6 +18,10 @@ actions!(
         MoveUp,
         /// Scrolls down by approximately one visual line.
         MoveDown,
+        /// Scrolls up by one markdown element in the markdown preview
+        MoveUpByItem,
+        /// Scrolls down by one markdown element in the markdown preview
+        MoveDownByItem,
         /// Opens a markdown preview for the current file.
         OpenPreview,
         /// Opens a markdown preview in a split pane.

--- a/crates/markdown_preview/src/markdown_preview.rs
+++ b/crates/markdown_preview/src/markdown_preview.rs
@@ -14,6 +14,10 @@ actions!(
         MovePageUp,
         /// Scrolls down by one page in the markdown preview.
         MovePageDown,
+        /// Scrolls up by approximately one visual line.
+        MoveUp,
+        /// Scrolls down by approximately one visual line.
+        MoveDown,
         /// Opens a markdown preview for the current file.
         OpenPreview,
         /// Opens a markdown preview in a split pane.

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -20,7 +20,7 @@ use workspace::{Pane, Workspace};
 
 use crate::markdown_elements::ParsedMarkdownElement;
 use crate::markdown_renderer::CheckboxClickedEvent;
-use crate::{MoveDown, MoveUp};
+use crate::{MoveDown, MoveDownByItem, MoveUp, MoveUpByItem};
 use crate::{
     MovePageDown, MovePageUp, OpenFollowingPreview, OpenPreview, OpenPreviewToTheSide,
     markdown_elements::ParsedMarkdown,
@@ -470,6 +470,32 @@ impl MarkdownPreviewView {
         }
         cx.notify();
     }
+
+    fn scroll_up_by_item(
+        &mut self,
+        _: &MoveUpByItem,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let scroll_top = self.list_state.logical_scroll_top();
+        if let Some(bounds) = self.list_state.bounds_for_item(scroll_top.item_ix) {
+            self.list_state.scroll_by(-bounds.size.height);
+        }
+        cx.notify();
+    }
+
+    fn scroll_down_by_item(
+        &mut self,
+        _: &MoveDownByItem,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let scroll_top = self.list_state.logical_scroll_top();
+        if let Some(bounds) = self.list_state.bounds_for_item(scroll_top.item_ix) {
+            self.list_state.scroll_by(bounds.size.height);
+        }
+        cx.notify();
+    }
 }
 
 impl Focusable for MarkdownPreviewView {
@@ -524,6 +550,8 @@ impl Render for MarkdownPreviewView {
             .on_action(cx.listener(MarkdownPreviewView::scroll_page_down))
             .on_action(cx.listener(MarkdownPreviewView::scroll_up))
             .on_action(cx.listener(MarkdownPreviewView::scroll_down))
+            .on_action(cx.listener(MarkdownPreviewView::scroll_up_by_item))
+            .on_action(cx.listener(MarkdownPreviewView::scroll_down_by_item))
             .size_full()
             .bg(cx.theme().colors().editor_background)
             .p_4()

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -20,13 +20,13 @@ use workspace::{Pane, Workspace};
 
 use crate::markdown_elements::ParsedMarkdownElement;
 use crate::markdown_renderer::CheckboxClickedEvent;
-use crate::{MoveDown, MoveDownByItem, MoveUp, MoveUpByItem};
 use crate::{
-    MovePageDown, MovePageUp, OpenFollowingPreview, OpenPreview, OpenPreviewToTheSide,
+    OpenFollowingPreview, OpenPreview, OpenPreviewToTheSide, ScrollPageDown, ScrollPageUp,
     markdown_elements::ParsedMarkdown,
     markdown_parser::parse_markdown,
     markdown_renderer::{RenderContext, render_markdown_block},
 };
+use crate::{ScrollDown, ScrollDownByItem, ScrollUp, ScrollUpByItem};
 
 const REPARSE_DEBOUNCE: Duration = Duration::from_millis(200);
 
@@ -427,7 +427,7 @@ impl MarkdownPreviewView {
         !(current_block.is_list_item() && next_block.map(|b| b.is_list_item()).unwrap_or(false))
     }
 
-    fn scroll_page_up(&mut self, _: &MovePageUp, _window: &mut Window, cx: &mut Context<Self>) {
+    fn scroll_page_up(&mut self, _: &ScrollPageUp, _window: &mut Window, cx: &mut Context<Self>) {
         let viewport_height = self.list_state.viewport_bounds().size.height;
         if viewport_height.is_zero() {
             return;
@@ -437,7 +437,12 @@ impl MarkdownPreviewView {
         cx.notify();
     }
 
-    fn scroll_page_down(&mut self, _: &MovePageDown, _window: &mut Window, cx: &mut Context<Self>) {
+    fn scroll_page_down(
+        &mut self,
+        _: &ScrollPageDown,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         let viewport_height = self.list_state.viewport_bounds().size.height;
         if viewport_height.is_zero() {
             return;
@@ -447,7 +452,7 @@ impl MarkdownPreviewView {
         cx.notify();
     }
 
-    fn scroll_up(&mut self, _: &MoveUp, window: &mut Window, cx: &mut Context<Self>) {
+    fn scroll_up(&mut self, _: &ScrollUp, window: &mut Window, cx: &mut Context<Self>) {
         let scroll_top = self.list_state.logical_scroll_top();
         if let Some(bounds) = self.list_state.bounds_for_item(scroll_top.item_ix) {
             let item_height = bounds.size.height;
@@ -459,7 +464,7 @@ impl MarkdownPreviewView {
         cx.notify();
     }
 
-    fn scroll_down(&mut self, _: &MoveDown, window: &mut Window, cx: &mut Context<Self>) {
+    fn scroll_down(&mut self, _: &ScrollDown, window: &mut Window, cx: &mut Context<Self>) {
         let scroll_top = self.list_state.logical_scroll_top();
         if let Some(bounds) = self.list_state.bounds_for_item(scroll_top.item_ix) {
             let item_height = bounds.size.height;
@@ -473,7 +478,7 @@ impl MarkdownPreviewView {
 
     fn scroll_up_by_item(
         &mut self,
-        _: &MoveUpByItem,
+        _: &ScrollUpByItem,
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
@@ -486,7 +491,7 @@ impl MarkdownPreviewView {
 
     fn scroll_down_by_item(
         &mut self,
-        _: &MoveDownByItem,
+        _: &ScrollDownByItem,
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {

--- a/crates/vim/Cargo.toml
+++ b/crates/vim/Cargo.toml
@@ -63,6 +63,7 @@ indoc.workspace = true
 language = { workspace = true, features = ["test-support"] }
 project = { workspace = true, features = ["test-support"] }
 lsp = { workspace = true, features = ["test-support"] }
+markdown_preview.workspace = true
 parking_lot.workspace = true
 project_panel.workspace = true
 release_channel.workspace = true

--- a/crates/vim/src/test/vim_test_context.rs
+++ b/crates/vim/src/test/vim_test_context.rs
@@ -28,6 +28,7 @@ impl VimTestContext {
             search::init(cx);
             theme::init(theme::LoadThemes::JustBase, cx);
             settings_ui::init(cx);
+            markdown_preview::init(cx);
         });
     }
 


### PR DESCRIPTION
Closes #21324

Adds four new commands:
- `markdown::MoveUp`, `markdown::MoveDown` - these scroll up and down in markdown preview mode, by no more than the height of a large headline.

- `markdown::MoveUpByItem`, and `markdown::MoveDownByItem` - these scroll up and down by the height of the item at the top of the markdown preview window. So headlines and large codeblocks, for instance, scroll further than individual paragraph lines.

Also attempts to create sensible defaults:
`down` -> `markdown::ScrollDown`
`up` -> `markdown::ScrollUp`
`alt-down` -> `markdown::ScrollDownByItem`
`alt-up` -> `markdown::ScrollUpByItem`

And in Vim:

`ctrl-u` -> `markdown::ScrollPageUp`
`ctrl-d` -> `markdown::ScrollPageDown`
`ctrl-e` -> `markdown::ScrollDown`
`ctrl-y` -> `markdown::ScrollUp`


Release Notes:

- Added commands `markdown::ScrollUp`, `markdown::ScrollDown`, `markdown::ScrollUpByItem`, and `markdown::ScrollDownByItem`
- Changed commands `markdown::MovePageUp` to `markdown::ScrollPageUp` and `markdown::MovePageDown` to `markdown::ScrollPageDown`
