### PR TITLE
edit_prediction: Fix predictions showing up when disabled

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -8134,6 +8134,10 @@ impl Editor {
         self.edit_prediction_settings =
             self.edit_prediction_settings_at_position(&buffer, cursor_buffer_position, cx);
 
+        if !self.should_show_edit_predictions() {
+            return None;
+        }
+
         self.edit_prediction_indent_conflict = multibuffer.is_line_whitespace_upto(cursor);
 
         if self.edit_prediction_indent_conflict {


### PR DESCRIPTION
There were some cases, especially when a jump would be triggered by a diagnostic, that we were still seeing the prediction.

Added a check before updating to double-check if predictions should be allowed in this buffer or not.

Release Notes:

- edit_prediction: Fix issue where predictions might be shown even when disabled.
