### PR TITLE
docs: Improve HTML LSP config examples

### DIFF
--- a/docs/src/languages/html.md
+++ b/docs/src/languages/html.md
@@ -59,12 +59,6 @@ You can customize various [formatting options](https://code.visualstudio.com/doc
             // Add an extra newline before <div> and <p>
             "extraLiners": "div,p"
           }
-        },
-        // workaround to prevent html lsp error about validproperties
-        "css": {
-          "lint": {
-            "validProperties": {}
-          }
         }
       }
     }

--- a/docs/src/languages/html.md
+++ b/docs/src/languages/html.md
@@ -25,6 +25,7 @@ You can disable `format_on_save` by adding the following to your Zed `settings.j
   "languages": {
     "HTML": {
       "format_on_save": "off",
+      "language_servers": ["vscode-html-language-server"],
     }
   }
 ```

--- a/docs/src/languages/html.md
+++ b/docs/src/languages/html.md
@@ -58,6 +58,12 @@ You can customize various [formatting options](https://code.visualstudio.com/doc
             // Add an extra newline before <div> and <p>
             "extraLiners": "div,p"
           }
+        },
+        // workaround to prevent html lsp error about validproperties
+        "css": {
+          "lint": {
+            "validProperties": {}
+          }
         }
       }
     }

--- a/docs/src/languages/html.md
+++ b/docs/src/languages/html.md
@@ -25,7 +25,6 @@ You can disable `format_on_save` by adding the following to your Zed `settings.j
   "languages": {
     "HTML": {
       "format_on_save": "off",
-      "language_servers": ["vscode-html-language-server"],
     }
   }
 ```
@@ -40,6 +39,7 @@ To use the `vscode-html-language-server` language server auto-formatting instead
   "languages": {
     "HTML": {
       "formatter": "language_server",
+      "language_servers": ["vscode-html-language-server"],
     }
   }
 ```

--- a/docs/src/languages/html.md
+++ b/docs/src/languages/html.md
@@ -39,7 +39,7 @@ To use the `vscode-html-language-server` language server auto-formatting instead
   "languages": {
     "HTML": {
       "formatter": "language_server",
-      "language_servers": ["vscode-html-language-server"],
+      "language_servers": ["vscode-html-language-server", "!prettier", "..."],
     }
   }
 ```


### PR DESCRIPTION
If you set `vscode-html-language-server` instead of `Prettier` for formatting HTML, code with style attributes or style tags might throw this error in the LSP logs: `Cannot read properties of null (reading 'validProperties')`. 

**Steps to recreate issue:**

1. In `settings.json`, set:
```json
  "languages": {
    "HTML": {
      "formatter": "language_server",
    }
  }
```
2. In an html file, set the attribute `style=""` for any element.
3. Go to "Language Servers" (Ctrl+Alt+L), view logs for `vscode-html-language-server` and search for `Error`

**Solution**
Use this config in `settings.json`:
```json
  "languages": {
    "HTML": {
      "formatter": "language_server"
    }
  },
  "lsp": {
    "vscode-html-language-server": {
      "settings": {
        // workaround to prevent html lsp error about validproperties
        "css": {
          "lint": {
            "validProperties": {}
          }
        }
      }
    }
  }
```

This is the most common workaround I found for this issue. Most of the solutions were for neovim using lua so this might be helpful for zed users. Based on this [nvim example](https://neovim.discourse.group/t/help-with-diagnostics-for-html-files/2682/2). I don't fully understand it so not sure if this belongs as the default config example in the docs or should be reported as a bug in the vscode lsp repo.

Not sure if I need to put any release notes for docs changes.

Release Notes:

- N/A
