### PR TITLE
language: Spawn language servers on background threads

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -631,7 +631,7 @@ shellexpand = "2.1.0"
 shlex = "1.3.0"
 simplelog = "0.12.2"
 slotmap = "1.0.6"
-smallvec = { version = "1.6", features = ["union"] }
+smallvec = { version = "1.6", features = ["union", "const_new"] }
 smol = "2.0"
 sqlformat = "0.2"
 stacksafe = "0.1"

--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -516,7 +516,8 @@ impl Copilot {
                 None,
                 Default::default(),
                 cx,
-            )?;
+            )
+            .await?;
 
             server
                 .on_notification::<StatusNotification, _>(|_, _| { /* Silence the notification */ })

--- a/crates/prettier/src/prettier.rs
+++ b/crates/prettier/src/prettier.rs
@@ -320,6 +320,7 @@ impl Prettier {
             Default::default(),
             &mut cx,
         )
+        .await
         .context("prettier server creation")?;
 
         let server = cx

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -422,6 +422,7 @@ impl LocalLspStore {
                     Some(pending_workspace_folders),
                     cx,
                 )
+                .await
             }
         });
 


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/39056

Leverages a new `await_on_background` API that spawns the future on the background but blocks the current task, allowing to borrow from the surrounding scope.

Release Notes:

- N/A *or* Added/Fixed/Improved ...
