### PR TITLE
gpui: Fix some memory leaks on macOS platform

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -14,6 +14,7 @@ disallowed-methods = [
     { path = "std::process::Command::stderr", reason = "`smol::process::Command::from()` does not preserve stdio configuration", replacement = "smol::process::Command::stderr" },
     { path = "serde_json::from_reader", reason = "Parsing from a buffer is much slower than first reading the buffer into a Vec/String, see https://github.com/serde-rs/json/issues/160#issuecomment-253446892. Use `serde_json::from_slice` instead." },
     { path = "serde_json_lenient::from_reader", reason = "Parsing from a buffer is much slower than first reading the buffer into a Vec/String, see https://github.com/serde-rs/json/issues/160#issuecomment-253446892, Use `serde_json_lenient::from_slice` instead." },
+    { path = "cocoa::foundation::NSString::alloc", reason = "NSString must be autoreleased to avoid memory leaks. Use `ns_string()` helper instead." },
 ]
 disallowed-types = [
     # { path = "std::collections::HashMap", replacement = "collections::HashMap" },

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -641,6 +641,8 @@ impl Fs for RealFs {
         use objc::{class, msg_send, sel, sel_impl};
 
         unsafe {
+            /// Allow NSString::alloc use here because it sets autorelease
+            #[allow(clippy::disallowed_methods)]
             unsafe fn ns_string(string: &str) -> id {
                 unsafe { NSString::alloc(nil).init_str(string).autorelease() }
             }

--- a/crates/gpui/src/platform/mac.rs
+++ b/crates/gpui/src/platform/mac.rs
@@ -135,6 +135,8 @@ unsafe impl objc::Encode for NSRange {
     }
 }
 
+/// Allow NSString::alloc use here because it sets autorelease
+#[allow(clippy::disallowed_methods)]
 unsafe fn ns_string(string: &str) -> id {
     unsafe { NSString::alloc(nil).init_str(string).autorelease() }
 }

--- a/crates/gpui/src/platform/mac/attributed_string.rs
+++ b/crates/gpui/src/platform/mac/attributed_string.rs
@@ -1,3 +1,4 @@
+use super::ns_string;
 use cocoa::base::id;
 use cocoa::foundation::NSRange;
 use objc::{class, msg_send, sel, sel_impl};
@@ -53,7 +54,7 @@ mod tests {
     use super::*;
     use cocoa::appkit::NSImage;
     use cocoa::base::nil;
-    use cocoa::foundation::{NSAutoreleasePool, NSString};
+    use cocoa::foundation::NSAutoreleasePool;
     #[test]
     #[ignore] // This was SIGSEGV-ing on CI but not locally; need to investigate https://github.com/zed-industries/zed/actions/runs/10362363230/job/28684225486?pr=15782#step:4:1348
     fn test_nsattributed_string() {
@@ -69,14 +70,14 @@ mod tests {
 
         unsafe {
             let image: id = msg_send![class!(NSImage), alloc];
-            image.initWithContentsOfFile_(NSString::alloc(nil).init_str("test.jpeg").autorelease());
+            image.initWithContentsOfFile_(ns_string("test.jpeg"));
             let _size = image.size();
 
-            let string = NSString::alloc(nil).init_str("Test String").autorelease();
+            let string = ns_string("Test String");
             let attr_string = NSMutableAttributedString::alloc(nil)
                 .init_attributed_string(string)
                 .autorelease();
-            let hello_string = NSString::alloc(nil).init_str("Hello World").autorelease();
+            let hello_string = ns_string("Hello World");
             let hello_attr_string = NSAttributedString::alloc(nil)
                 .init_attributed_string(hello_string)
                 .autorelease();
@@ -88,9 +89,7 @@ mod tests {
                 msg_send![class!(NSAttributedString), attributedStringWithAttachment: attachment];
             attr_string.appendAttributedString_(image_attr_string);
 
-            let another_string = NSString::alloc(nil)
-                .init_str("Another String")
-                .autorelease();
+            let another_string = ns_string("Another String");
             let another_attr_string = NSAttributedString::alloc(nil)
                 .init_attributed_string(another_string)
                 .autorelease();

--- a/crates/gpui/src/platform/mac/attributed_string.rs
+++ b/crates/gpui/src/platform/mac/attributed_string.rs
@@ -70,8 +70,12 @@ mod tests {
         impl NSTextAttachment for id {}
 
         unsafe {
-            let image: id = msg_send![class!(NSImage), alloc];
-            image.initWithContentsOfFile_(ns_string("test.jpeg"));
+            let image: id = {
+                let img: id = msg_send![class!(NSImage), alloc];
+                let img: id = msg_send![img, initWithContentsOfFile: ns_string("test.jpeg")];
+                let img: id = msg_send![img, autorelease];
+                img
+            };
             let _size = image.size();
 
             let string = ns_string("Test String");
@@ -84,7 +88,7 @@ mod tests {
                 .autorelease();
             attr_string.appendAttributedString_(hello_attr_string);
 
-            let attachment = NSTextAttachment::alloc(nil);
+            let attachment: id = msg_send![NSTextAttachment::alloc(nil), autorelease];
             let _: () = msg_send![attachment, setImage: image];
             let image_attr_string =
                 msg_send![class!(NSAttributedString), attributedStringWithAttachment: attachment];

--- a/crates/gpui/src/platform/mac/attributed_string.rs
+++ b/crates/gpui/src/platform/mac/attributed_string.rs
@@ -1,4 +1,3 @@
-use super::ns_string;
 use cocoa::base::id;
 use cocoa::foundation::NSRange;
 use objc::{class, msg_send, sel, sel_impl};
@@ -51,6 +50,8 @@ impl NSMutableAttributedString for id {}
 
 #[cfg(test)]
 mod tests {
+    use crate::platform::mac::ns_string;
+
     use super::*;
     use cocoa::appkit::NSImage;
     use cocoa::base::nil;

--- a/crates/gpui/src/platform/mac/attributed_string.rs
+++ b/crates/gpui/src/platform/mac/attributed_string.rs
@@ -53,7 +53,7 @@ mod tests {
     use super::*;
     use cocoa::appkit::NSImage;
     use cocoa::base::nil;
-    use cocoa::foundation::NSString;
+    use cocoa::foundation::{NSAutoreleasePool, NSString};
     #[test]
     #[ignore] // This was SIGSEGV-ing on CI but not locally; need to investigate https://github.com/zed-industries/zed/actions/runs/10362363230/job/28684225486?pr=15782#step:4:1348
     fn test_nsattributed_string() {
@@ -69,14 +69,17 @@ mod tests {
 
         unsafe {
             let image: id = msg_send![class!(NSImage), alloc];
-            image.initWithContentsOfFile_(NSString::alloc(nil).init_str("test.jpeg"));
+            image.initWithContentsOfFile_(NSString::alloc(nil).init_str("test.jpeg").autorelease());
             let _size = image.size();
 
-            let string = NSString::alloc(nil).init_str("Test String");
-            let attr_string = NSMutableAttributedString::alloc(nil).init_attributed_string(string);
-            let hello_string = NSString::alloc(nil).init_str("Hello World");
-            let hello_attr_string =
-                NSAttributedString::alloc(nil).init_attributed_string(hello_string);
+            let string = NSString::alloc(nil).init_str("Test String").autorelease();
+            let attr_string = NSMutableAttributedString::alloc(nil)
+                .init_attributed_string(string)
+                .autorelease();
+            let hello_string = NSString::alloc(nil).init_str("Hello World").autorelease();
+            let hello_attr_string = NSAttributedString::alloc(nil)
+                .init_attributed_string(hello_string)
+                .autorelease();
             attr_string.appendAttributedString_(hello_attr_string);
 
             let attachment = NSTextAttachment::alloc(nil);
@@ -85,9 +88,12 @@ mod tests {
                 msg_send![class!(NSAttributedString), attributedStringWithAttachment: attachment];
             attr_string.appendAttributedString_(image_attr_string);
 
-            let another_string = NSString::alloc(nil).init_str("Another String");
-            let another_attr_string =
-                NSAttributedString::alloc(nil).init_attributed_string(another_string);
+            let another_string = NSString::alloc(nil)
+                .init_str("Another String")
+                .autorelease();
+            let another_attr_string = NSAttributedString::alloc(nil)
+                .init_attributed_string(another_string)
+                .autorelease();
             attr_string.appendAttributedString_(another_attr_string);
 
             let _len: cocoa::foundation::NSUInteger = msg_send![attr_string, length];

--- a/crates/gpui/src/platform/mac/display.rs
+++ b/crates/gpui/src/platform/mac/display.rs
@@ -1,9 +1,10 @@
+use super::ns_string;
 use crate::{Bounds, DisplayId, Pixels, PlatformDisplay, point, px, size};
 use anyhow::Result;
 use cocoa::{
     appkit::NSScreen,
     base::{id, nil},
-    foundation::{NSArray, NSDictionary, NSString},
+    foundation::{NSArray, NSDictionary},
 };
 use core_foundation::uuid::{CFUUIDGetUUIDBytes, CFUUIDRef};
 use core_graphics::display::{CGDirectDisplayID, CGDisplayBounds, CGGetActiveDisplayList};
@@ -35,7 +36,7 @@ impl MacDisplay {
             let screens = NSScreen::screens(nil);
             let screen = cocoa::foundation::NSArray::objectAtIndex(screens, 0);
             let device_description = NSScreen::deviceDescription(screen);
-            let screen_number_key: id = NSString::alloc(nil).init_str("NSScreenNumber");
+            let screen_number_key: id = ns_string("NSScreenNumber");
             let screen_number = device_description.objectForKey_(screen_number_key);
             let screen_number: CGDirectDisplayID = msg_send![screen_number, unsignedIntegerValue];
             Self(screen_number)
@@ -150,7 +151,7 @@ impl MacDisplay {
     unsafe fn get_nsscreen(&self) -> id {
         let screens = unsafe { NSScreen::screens(nil) };
         let count = unsafe { NSArray::count(screens) };
-        let screen_number_key: id = unsafe { NSString::alloc(nil).init_str("NSScreenNumber") };
+        let screen_number_key: id = unsafe { ns_string("NSScreenNumber") };
 
         for i in 0..count {
             let screen = unsafe { NSArray::objectAtIndex(screens, i) };

--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -2,7 +2,7 @@ use super::{
     BoolExt, MacKeyboardLayout, MacKeyboardMapper,
     attributed_string::{NSAttributedString, NSMutableAttributedString},
     events::key_to_native,
-    renderer,
+    ns_string, renderer,
 };
 use crate::{
     Action, AnyWindowHandle, BackgroundExecutor, ClipboardEntry, ClipboardItem, ClipboardString,
@@ -1061,13 +1061,15 @@ impl Platform for MacPlatform {
                 let attributed_string = {
                     let mut buf = NSMutableAttributedString::alloc(nil)
                         // TODO can we skip this? Or at least part of it?
-                        .init_attributed_string(NSString::alloc(nil).init_str(""));
+                        .init_attributed_string(ns_string(""))
+                        .autorelease();
 
                     for entry in item.entries {
                         if let ClipboardEntry::String(ClipboardString { text, metadata: _ }) = entry
                         {
                             let to_append = NSAttributedString::alloc(nil)
-                                .init_attributed_string(NSString::alloc(nil).init_str(&text));
+                                .init_attributed_string(ns_string(&text))
+                                .autorelease();
 
                             buf.appendAttributedString_(to_append);
                         }
@@ -1541,10 +1543,6 @@ extern "C" fn handle_dock_menu(this: &mut Object, _: Sel, _: id) -> id {
             nil
         }
     }
-}
-
-unsafe fn ns_string(string: &str) -> id {
-    unsafe { NSString::alloc(nil).init_str(string).autorelease() }
 }
 
 unsafe fn ns_url_to_path(url: id) -> Result<PathBuf> {

--- a/crates/gpui/src/platform/mac/screen_capture.rs
+++ b/crates/gpui/src/platform/mac/screen_capture.rs
@@ -1,3 +1,4 @@
+use super::ns_string;
 use crate::{
     DevicePixels, ForegroundExecutor, SharedString, SourceMetadata,
     platform::{ScreenCaptureFrame, ScreenCaptureSource, ScreenCaptureStream},
@@ -7,7 +8,7 @@ use anyhow::{Result, anyhow};
 use block::ConcreteBlock;
 use cocoa::{
     base::{YES, id, nil},
-    foundation::{NSArray, NSString},
+    foundation::NSArray,
 };
 use collections::HashMap;
 use core_foundation::base::TCFType;
@@ -195,7 +196,7 @@ unsafe fn screen_id_to_human_label() -> HashMap<CGDirectDisplayID, ScreenMeta> {
     let screens: id = msg_send![class!(NSScreen), screens];
     let count: usize = msg_send![screens, count];
     let mut map = HashMap::default();
-    let screen_number_key = unsafe { NSString::alloc(nil).init_str("NSScreenNumber") };
+    let screen_number_key = unsafe { ns_string("NSScreenNumber") };
     for i in 0..count {
         let screen: id = msg_send![screens, objectAtIndex: i];
         let device_desc: id = msg_send![screen, deviceDescription];

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -781,9 +781,7 @@ impl MacWindow {
                     native_window.setAcceptsMouseMovedEvents_(YES);
 
                     if let Some(tabbing_identifier) = tabbing_identifier {
-                        let tabbing_id = NSString::alloc(nil)
-                            .init_str(tabbing_identifier.as_str())
-                            .autorelease();
+                        let tabbing_id = ns_string(tabbing_identifier.as_str());
                         let _: () = msg_send![native_window, setTabbingIdentifier: tabbing_id];
                     } else {
                         let _: () = msg_send![native_window, setTabbingIdentifier:nil];
@@ -906,12 +904,8 @@ impl MacWindow {
     pub fn get_user_tabbing_preference() -> Option<UserTabbingPreference> {
         unsafe {
             let defaults: id = NSUserDefaults::standardUserDefaults();
-            let domain = NSString::alloc(nil)
-                .init_str("NSGlobalDomain")
-                .autorelease();
-            let key = NSString::alloc(nil)
-                .init_str("AppleWindowTabbingMode")
-                .autorelease();
+            let domain = ns_string("NSGlobalDomain");
+            let key = ns_string("AppleWindowTabbingMode");
 
             let dict: id = msg_send![defaults, persistentDomainForName: domain];
             let value: id = if !dict.is_null() {
@@ -1039,9 +1033,7 @@ impl PlatformWindow for MacWindow {
             }
 
             if let Some(tabbing_identifier) = tabbing_identifier {
-                let tabbing_id = NSString::alloc(nil)
-                    .init_str(tabbing_identifier.as_str())
-                    .autorelease();
+                let tabbing_id = ns_string(tabbing_identifier.as_str());
                 let _: () = msg_send![native_window, setTabbingIdentifier: tabbing_id];
             } else {
                 let _: () = msg_send![native_window, setTabbingIdentifier:nil];
@@ -1067,12 +1059,8 @@ impl PlatformWindow for MacWindow {
                 return None;
             }
             let device_description: id = msg_send![screen, deviceDescription];
-            let screen_number: id = NSDictionary::valueForKey_(
-                device_description,
-                NSString::alloc(nil)
-                    .init_str("NSScreenNumber")
-                    .autorelease(),
-            );
+            let screen_number: id =
+                NSDictionary::valueForKey_(device_description, ns_string("NSScreenNumber"));
 
             let screen_number: u32 = msg_send![screen_number, unsignedIntValue];
 
@@ -1515,12 +1503,8 @@ impl PlatformWindow for MacWindow {
             .spawn(async move {
                 unsafe {
                     let defaults: id = NSUserDefaults::standardUserDefaults();
-                    let domain = NSString::alloc(nil)
-                        .init_str("NSGlobalDomain")
-                        .autorelease();
-                    let key = NSString::alloc(nil)
-                        .init_str("AppleActionOnDoubleClick")
-                        .autorelease();
+                    let domain = ns_string("NSGlobalDomain");
+                    let key = ns_string("AppleActionOnDoubleClick");
 
                     let dict: id = msg_send![defaults, persistentDomainForName: domain];
                     let action: id = if !dict.is_null() {
@@ -2522,9 +2506,7 @@ where
 unsafe fn display_id_for_screen(screen: id) -> CGDirectDisplayID {
     unsafe {
         let device_description = NSScreen::deviceDescription(screen);
-        let screen_number_key: id = NSString::alloc(nil)
-            .init_str("NSScreenNumber")
-            .autorelease();
+        let screen_number_key: id = ns_string("NSScreenNumber");
         let screen_number = device_description.objectForKey_(screen_number_key);
         let screen_number: NSUInteger = msg_send![screen_number, unsignedIntegerValue];
         screen_number as CGDirectDisplayID
@@ -2570,7 +2552,7 @@ unsafe fn remove_layer_background(layer: id) {
             // `description` reflects its name and some parameters. Currently `NSVisualEffectView`
             // uses a `CAFilter` named "colorSaturate". If one day they switch to `CIFilter`, the
             // `description` will still contain "Saturat" ("... inputSaturation = ...").
-            let test_string: id = NSString::alloc(nil).init_str("Saturat").autorelease();
+            let test_string: id = ns_string("Saturat");
             let count = NSArray::count(filters);
             for i in 0..count {
                 let description: id = msg_send![filters.objectAtIndex(i), description];

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -2081,9 +2081,7 @@ extern "C" fn window_did_change_key_status(this: &Object, selector: Sel, _: id) 
         .spawn(async move {
             let mut lock = window_state.as_ref().lock();
             if is_active {
-                unsafe {
-                    lock.move_traffic_light();
-                }
+                lock.move_traffic_light();
             }
 
             if let Some(mut callback) = lock.activate_callback.take() {

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -781,7 +781,9 @@ impl MacWindow {
                     native_window.setAcceptsMouseMovedEvents_(YES);
 
                     if let Some(tabbing_identifier) = tabbing_identifier {
-                        let tabbing_id = NSString::alloc(nil).init_str(tabbing_identifier.as_str());
+                        let tabbing_id = NSString::alloc(nil)
+                            .init_str(tabbing_identifier.as_str())
+                            .autorelease();
                         let _: () = msg_send![native_window, setTabbingIdentifier: tabbing_id];
                     } else {
                         let _: () = msg_send![native_window, setTabbingIdentifier:nil];
@@ -904,8 +906,12 @@ impl MacWindow {
     pub fn get_user_tabbing_preference() -> Option<UserTabbingPreference> {
         unsafe {
             let defaults: id = NSUserDefaults::standardUserDefaults();
-            let domain = NSString::alloc(nil).init_str("NSGlobalDomain");
-            let key = NSString::alloc(nil).init_str("AppleWindowTabbingMode");
+            let domain = NSString::alloc(nil)
+                .init_str("NSGlobalDomain")
+                .autorelease();
+            let key = NSString::alloc(nil)
+                .init_str("AppleWindowTabbingMode")
+                .autorelease();
 
             let dict: id = msg_send![defaults, persistentDomainForName: domain];
             let value: id = if !dict.is_null() {
@@ -1033,7 +1039,9 @@ impl PlatformWindow for MacWindow {
             }
 
             if let Some(tabbing_identifier) = tabbing_identifier {
-                let tabbing_id = NSString::alloc(nil).init_str(tabbing_identifier.as_str());
+                let tabbing_id = NSString::alloc(nil)
+                    .init_str(tabbing_identifier.as_str())
+                    .autorelease();
                 let _: () = msg_send![native_window, setTabbingIdentifier: tabbing_id];
             } else {
                 let _: () = msg_send![native_window, setTabbingIdentifier:nil];
@@ -1061,7 +1069,9 @@ impl PlatformWindow for MacWindow {
             let device_description: id = msg_send![screen, deviceDescription];
             let screen_number: id = NSDictionary::valueForKey_(
                 device_description,
-                NSString::alloc(nil).init_str("NSScreenNumber"),
+                NSString::alloc(nil)
+                    .init_str("NSScreenNumber")
+                    .autorelease(),
             );
 
             let screen_number: u32 = msg_send![screen_number, unsignedIntValue];
@@ -1505,8 +1515,12 @@ impl PlatformWindow for MacWindow {
             .spawn(async move {
                 unsafe {
                     let defaults: id = NSUserDefaults::standardUserDefaults();
-                    let domain = NSString::alloc(nil).init_str("NSGlobalDomain");
-                    let key = NSString::alloc(nil).init_str("AppleActionOnDoubleClick");
+                    let domain = NSString::alloc(nil)
+                        .init_str("NSGlobalDomain")
+                        .autorelease();
+                    let key = NSString::alloc(nil)
+                        .init_str("AppleActionOnDoubleClick")
+                        .autorelease();
 
                     let dict: id = msg_send![defaults, persistentDomainForName: domain];
                     let action: id = if !dict.is_null() {
@@ -2067,7 +2081,11 @@ extern "C" fn window_did_change_key_status(this: &Object, selector: Sel, _: id) 
         .spawn(async move {
             let mut lock = window_state.as_ref().lock();
             if is_active {
-                lock.move_traffic_light();
+                unsafe {
+                    let pool = NSAutoreleasePool::new(nil);
+                    lock.move_traffic_light();
+                    pool.drain();
+                }
             }
 
             if let Some(mut callback) = lock.activate_callback.take() {
@@ -2508,7 +2526,9 @@ where
 unsafe fn display_id_for_screen(screen: id) -> CGDirectDisplayID {
     unsafe {
         let device_description = NSScreen::deviceDescription(screen);
-        let screen_number_key: id = NSString::alloc(nil).init_str("NSScreenNumber");
+        let screen_number_key: id = NSString::alloc(nil)
+            .init_str("NSScreenNumber")
+            .autorelease();
         let screen_number = device_description.objectForKey_(screen_number_key);
         let screen_number: NSUInteger = msg_send![screen_number, unsignedIntegerValue];
         screen_number as CGDirectDisplayID

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -2082,9 +2082,7 @@ extern "C" fn window_did_change_key_status(this: &Object, selector: Sel, _: id) 
             let mut lock = window_state.as_ref().lock();
             if is_active {
                 unsafe {
-                    let pool = NSAutoreleasePool::new(nil);
                     lock.move_traffic_light();
-                    pool.drain();
                 }
             }
 


### PR DESCRIPTION
While profiling with instruments, I discovered that some of the strings allocated on the mac platform are never released, and the profiler marks them as leaks

<img width="1570" height="219" alt="image" src="https://github.com/user-attachments/assets/174e9293-5139-46ae-8757-c8989f3fc598" />


Release Notes:

- N/A
