### PR TITLE
gpui: Improve the tab stop example by demonstrating tab_group

### DIFF
--- a/crates/gpui/examples/tab_stop.rs
+++ b/crates/gpui/examples/tab_stop.rs
@@ -130,6 +130,50 @@ impl Render for Example {
                             })),
                     ),
             )
+            .child(
+                div()
+                    .id("group-1")
+                    .tab_index(6)
+                    .tab_group()
+                    .tab_stop(false)
+                    .child(
+                        button("group-1-button-1")
+                            .tab_index(1)
+                            .child("Tab index [6, 1]"),
+                    )
+                    .child(
+                        button("group-1-button-2")
+                            .tab_index(2)
+                            .child("Tab index [6, 2]"),
+                    )
+                    .child(
+                        button("group-1-button-3")
+                            .tab_index(3)
+                            .child("Tab index [6, 3]"),
+                    ),
+            )
+            .child(
+                div()
+                    .id("group-2")
+                    .tab_index(7)
+                    .tab_group()
+                    .tab_stop(false)
+                    .child(
+                        button("group-2-button-1")
+                            .tab_index(1)
+                            .child("Tab index [7, 1]"),
+                    )
+                    .child(
+                        button("group-2-button-2")
+                            .tab_index(2)
+                            .child("Tab index [7, 2]"),
+                    )
+                    .child(
+                        button("group-2-button-3")
+                            .tab_index(3)
+                            .child("Tab index [7, 3]"),
+                    ),
+            )
     }
 }
 


### PR DESCRIPTION
I've just enriched the existing tab_stop.rs example for GPUI with a demonstration of tab_group. I don't think tab groups existed when the original example was written.

(I didn't understand the behaviour for tab_group from the doccomments and the example was missing, so I think this is a productive PR)

Release Notes:

- N/A
