### PR TITLE
image viewer: Make image metadata not a button

### DIFF
--- a/crates/image_viewer/src/image_info.rs
+++ b/crates/image_viewer/src/image_info.rs
@@ -77,9 +77,7 @@ impl Render for ImageInfo {
             .to_string(),
         );
 
-        div().child(
-            Button::new("image-metadata", components.join(" • ")).label_size(LabelSize::Small),
-        )
+        div().child(Label::new(components.join(" • ")).size(LabelSize::Small))
     }
 }
 


### PR DESCRIPTION
Tiny thing I noticed; the image metadata showing on the status bar was previously a button, but given that nothing happens when you click it, it doesn't need to be one. Having hover, active, and all other states was confusing.

Release Notes:

- N/A
