### PR TITLE
gpui: Improve path rendering and bounds performance

### DIFF
--- a/crates/gpui/src/bounds_tree.rs
+++ b/crates/gpui/src/bounds_tree.rs
@@ -7,7 +7,7 @@ use std::{
 
 /// Maximum children per internal node (R-tree style branching factor).
 /// Higher values = shorter tree = fewer cache misses, but more work per node.
-const MAX_CHILDREN: usize = 4;
+const MAX_CHILDREN: usize = 12;
 
 /// A spatial tree optimized for finding maximum ordering among intersecting bounds.
 ///

--- a/crates/gpui/src/bounds_tree.rs
+++ b/crates/gpui/src/bounds_tree.rs
@@ -57,18 +57,18 @@ enum NodeKind {
     /// Internal node with children.
     Internal {
         /// Indices of child nodes (2 to MAX_CHILDREN).
-        children: ChildArray,
+        children: NodeChildren,
     },
 }
 
 /// Fixed-size array for child indices, avoiding heap allocation.
 #[derive(Debug, Clone)]
-struct ChildArray {
+struct NodeChildren {
     indices: [usize; MAX_CHILDREN],
     len: u8,
 }
 
-impl ChildArray {
+impl NodeChildren {
     fn new() -> Self {
         Self {
             indices: [0; MAX_CHILDREN],
@@ -216,7 +216,7 @@ where
             let root_bounds = self.nodes[root_idx].bounds.clone();
             let root_order = self.nodes[root_idx].max_order;
 
-            let mut children = ChildArray::new();
+            let mut children = NodeChildren::new();
             children.push(root_idx);
             children.push(new_leaf_idx);
 
@@ -273,7 +273,7 @@ where
                     let sibling_bounds = self.nodes[best_child_idx].bounds.clone();
                     let sibling_order = self.nodes[best_child_idx].max_order;
 
-                    let mut new_children = ChildArray::new();
+                    let mut new_children = NodeChildren::new();
                     new_children.push(best_child_idx);
                     new_children.push(new_leaf_idx);
 

--- a/crates/gpui/src/bounds_tree.rs
+++ b/crates/gpui/src/bounds_tree.rs
@@ -5,14 +5,90 @@ use std::{
     ops::{Add, Sub},
 };
 
+/// Maximum children per internal node (R-tree style branching factor).
+/// Higher values = shorter tree = fewer cache misses, but more work per node.
+const MAX_CHILDREN: usize = 4;
+
+/// A spatial tree optimized for finding maximum ordering among intersecting bounds.
+///
+/// This is an R-tree variant specifically designed for the use case of assigning
+/// z-order to overlapping UI elements. Key optimizations:
+/// - Tracks the leaf with global max ordering for O(1) fast-path queries
+/// - Uses higher branching factor (4) for lower tree height
+/// - Aggressive pruning during search based on max_order metadata
 #[derive(Debug)]
 pub(crate) struct BoundsTree<U>
 where
     U: Clone + Debug + Default + PartialEq,
 {
-    root: Option<usize>,
+    /// All nodes stored contiguously for cache efficiency.
     nodes: Vec<Node<U>>,
-    stack: Vec<usize>,
+    /// Index of the root node, if any.
+    root: Option<usize>,
+    /// Index of the leaf with the highest ordering (for fast-path lookups).
+    max_leaf: Option<usize>,
+    /// Reusable stack for tree traversal during insertion.
+    insert_path: Vec<usize>,
+    /// Reusable stack for search operations.
+    search_stack: Vec<usize>,
+}
+
+/// A node in the bounds tree.
+#[derive(Debug, Clone)]
+struct Node<U>
+where
+    U: Clone + Debug + Default + PartialEq,
+{
+    /// Bounding box containing this node and all descendants.
+    bounds: Bounds<U>,
+    /// Maximum ordering value in this subtree.
+    max_order: u32,
+    /// Node-specific data.
+    kind: NodeKind,
+}
+
+#[derive(Debug, Clone)]
+enum NodeKind {
+    /// Leaf node containing actual bounds data.
+    Leaf {
+        /// The ordering assigned to this bounds.
+        order: u32,
+    },
+    /// Internal node with children.
+    Internal {
+        /// Indices of child nodes (2 to MAX_CHILDREN).
+        children: ChildArray,
+    },
+}
+
+/// Fixed-size array for child indices, avoiding heap allocation.
+#[derive(Debug, Clone)]
+struct ChildArray {
+    indices: [usize; MAX_CHILDREN],
+    len: u8,
+}
+
+impl ChildArray {
+    fn new() -> Self {
+        Self {
+            indices: [0; MAX_CHILDREN],
+            len: 0,
+        }
+    }
+
+    fn push(&mut self, index: usize) {
+        debug_assert!((self.len as usize) < MAX_CHILDREN);
+        self.indices[self.len as usize] = index;
+        self.len += 1;
+    }
+
+    fn len(&self) -> usize {
+        self.len as usize
+    }
+
+    fn as_slice(&self) -> &[usize] {
+        &self.indices[..self.len as usize]
+    }
 }
 
 impl<U> BoundsTree<U>
@@ -26,158 +102,224 @@ where
         + Half
         + Default,
 {
+    /// Clears all nodes from the tree.
     pub fn clear(&mut self) {
-        self.root = None;
         self.nodes.clear();
-        self.stack.clear();
+        self.root = None;
+        self.max_leaf = None;
+        self.insert_path.clear();
+        self.search_stack.clear();
     }
 
+    /// Inserts bounds into the tree and returns its assigned ordering.
+    ///
+    /// The ordering is one greater than the maximum ordering of any
+    /// existing bounds that intersect with the new bounds.
     pub fn insert(&mut self, new_bounds: Bounds<U>) -> u32 {
-        // If the tree is empty, make the root the new leaf.
-        let Some(mut index) = self.root else {
-            let new_node = self.push_leaf(new_bounds, 1);
-            self.root = Some(new_node);
-            return 1;
+        // Find maximum ordering among intersecting bounds
+        let max_intersecting = self.find_max_ordering(&new_bounds);
+        let ordering = max_intersecting + 1;
+
+        // Insert the new leaf
+        let new_leaf_idx = self.insert_leaf(new_bounds, ordering);
+
+        // Update max_leaf tracking
+        self.max_leaf = match self.max_leaf {
+            None => Some(new_leaf_idx),
+            Some(old_idx) if self.nodes[old_idx].max_order < ordering => Some(new_leaf_idx),
+            some => some,
         };
-
-        // Search for the best place to add the new leaf based on heuristics.
-        let mut max_intersecting_ordering = 0;
-        while let Node::Internal {
-            left,
-            right,
-            bounds: node_bounds,
-            ..
-        } = &mut self.nodes[index]
-        {
-            let left = *left;
-            let right = *right;
-            *node_bounds = node_bounds.union(&new_bounds);
-            self.stack.push(index);
-
-            // Descend to the best-fit child, based on which one would increase
-            // the surface area the least. This attempts to keep the tree balanced
-            // in terms of surface area. If there is an intersection with the other child,
-            // add its keys to the intersections vector.
-            let left_cost = new_bounds.union(self.nodes[left].bounds()).half_perimeter();
-            let right_cost = new_bounds
-                .union(self.nodes[right].bounds())
-                .half_perimeter();
-            if left_cost < right_cost {
-                max_intersecting_ordering =
-                    self.find_max_ordering(right, &new_bounds, max_intersecting_ordering);
-                index = left;
-            } else {
-                max_intersecting_ordering =
-                    self.find_max_ordering(left, &new_bounds, max_intersecting_ordering);
-                index = right;
-            }
-        }
-
-        // We've found a leaf ('index' now refers to a leaf node).
-        // We'll insert a new parent node above the leaf and attach our new leaf to it.
-        let sibling = index;
-
-        // Check for collision with the located leaf node
-        let Node::Leaf {
-            bounds: sibling_bounds,
-            order: sibling_ordering,
-            ..
-        } = &self.nodes[index]
-        else {
-            unreachable!();
-        };
-        if sibling_bounds.intersects(&new_bounds) {
-            max_intersecting_ordering = cmp::max(max_intersecting_ordering, *sibling_ordering);
-        }
-
-        let ordering = max_intersecting_ordering + 1;
-        let new_node = self.push_leaf(new_bounds, ordering);
-        let new_parent = self.push_internal(sibling, new_node);
-
-        // If there was an old parent, we need to update its children indices.
-        if let Some(old_parent) = self.stack.last().copied() {
-            let Node::Internal { left, right, .. } = &mut self.nodes[old_parent] else {
-                unreachable!();
-            };
-
-            if *left == sibling {
-                *left = new_parent;
-            } else {
-                *right = new_parent;
-            }
-        } else {
-            // If the old parent was the root, the new parent is the new root.
-            self.root = Some(new_parent);
-        }
-
-        for node_index in self.stack.drain(..).rev() {
-            let Node::Internal {
-                max_order: max_ordering,
-                ..
-            } = &mut self.nodes[node_index]
-            else {
-                unreachable!()
-            };
-            if *max_ordering >= ordering {
-                break;
-            }
-            *max_ordering = ordering;
-        }
 
         ordering
     }
 
-    fn find_max_ordering(&self, index: usize, bounds: &Bounds<U>, mut max_ordering: u32) -> u32 {
-        match &self.nodes[index] {
-            Node::Leaf {
-                bounds: node_bounds,
-                order: ordering,
-                ..
-            } => {
-                if bounds.intersects(node_bounds) {
-                    max_ordering = cmp::max(*ordering, max_ordering);
-                }
+    /// Finds the maximum ordering among all bounds that intersect with the query.
+    fn find_max_ordering(&mut self, query: &Bounds<U>) -> u32 {
+        let Some(root_idx) = self.root else {
+            return 0;
+        };
+
+        // Fast path: check if the max-ordering leaf intersects
+        if let Some(max_idx) = self.max_leaf {
+            let max_node = &self.nodes[max_idx];
+            if query.intersects(&max_node.bounds) {
+                return max_node.max_order;
             }
-            Node::Internal {
-                left,
-                right,
-                bounds: node_bounds,
-                max_order: node_max_ordering,
-                ..
-            } => {
-                if bounds.intersects(node_bounds) && max_ordering < *node_max_ordering {
-                    let left_max_ordering = self.nodes[*left].max_ordering();
-                    let right_max_ordering = self.nodes[*right].max_ordering();
-                    if left_max_ordering > right_max_ordering {
-                        max_ordering = self.find_max_ordering(*left, bounds, max_ordering);
-                        max_ordering = self.find_max_ordering(*right, bounds, max_ordering);
-                    } else {
-                        max_ordering = self.find_max_ordering(*right, bounds, max_ordering);
-                        max_ordering = self.find_max_ordering(*left, bounds, max_ordering);
+        }
+
+        // Slow path: search the tree
+        self.search_stack.clear();
+        self.search_stack.push(root_idx);
+
+        let mut max_found = 0u32;
+
+        while let Some(node_idx) = self.search_stack.pop() {
+            let node = &self.nodes[node_idx];
+
+            // Pruning: skip if this subtree can't improve our result
+            if node.max_order <= max_found {
+                continue;
+            }
+
+            // Spatial pruning: skip if bounds don't intersect
+            if !query.intersects(&node.bounds) {
+                continue;
+            }
+
+            match &node.kind {
+                NodeKind::Leaf { order } => {
+                    max_found = cmp::max(max_found, *order);
+                }
+                NodeKind::Internal { children } => {
+                    // Add children to search stack, sorted by max_order ascending
+                    // so highest max_order is processed first (LIFO)
+                    let mut child_orders: [(u32, usize); MAX_CHILDREN] =
+                        [(0, 0); MAX_CHILDREN];
+                    let num_children = children.len();
+
+                    for (i, &child_idx) in children.as_slice().iter().enumerate() {
+                        child_orders[i] = (self.nodes[child_idx].max_order, child_idx);
+                    }
+
+                    // Sort by max_order (ascending, so highest is pushed last = popped first)
+                    child_orders[..num_children]
+                        .sort_unstable_by_key(|(max_order, _)| *max_order);
+
+                    for (child_max, child_idx) in &child_orders[..num_children] {
+                        if *child_max > max_found {
+                            self.search_stack.push(*child_idx);
+                        }
                     }
                 }
             }
         }
-        max_ordering
+
+        max_found
     }
 
-    fn push_leaf(&mut self, bounds: Bounds<U>, order: u32) -> usize {
-        self.nodes.push(Node::Leaf { bounds, order });
-        self.nodes.len() - 1
-    }
-
-    fn push_internal(&mut self, left: usize, right: usize) -> usize {
-        let left_node = &self.nodes[left];
-        let right_node = &self.nodes[right];
-        let new_bounds = left_node.bounds().union(right_node.bounds());
-        let max_ordering = cmp::max(left_node.max_ordering(), right_node.max_ordering());
-        self.nodes.push(Node::Internal {
-            bounds: new_bounds,
-            left,
-            right,
-            max_order: max_ordering,
+    /// Inserts a leaf node with the given bounds and ordering.
+    /// Returns the index of the new leaf.
+    fn insert_leaf(&mut self, bounds: Bounds<U>, order: u32) -> usize {
+        let new_leaf_idx = self.nodes.len();
+        self.nodes.push(Node {
+            bounds: bounds.clone(),
+            max_order: order,
+            kind: NodeKind::Leaf { order },
         });
-        self.nodes.len() - 1
+
+        let Some(root_idx) = self.root else {
+            // Tree is empty, new leaf becomes root
+            self.root = Some(new_leaf_idx);
+            return new_leaf_idx;
+        };
+
+        // If root is a leaf, create internal node with both
+        if matches!(self.nodes[root_idx].kind, NodeKind::Leaf { .. }) {
+            let root_bounds = self.nodes[root_idx].bounds.clone();
+            let root_order = self.nodes[root_idx].max_order;
+
+            let mut children = ChildArray::new();
+            children.push(root_idx);
+            children.push(new_leaf_idx);
+
+            let new_root_idx = self.nodes.len();
+            self.nodes.push(Node {
+                bounds: root_bounds.union(&bounds),
+                max_order: cmp::max(root_order, order),
+                kind: NodeKind::Internal { children },
+            });
+            self.root = Some(new_root_idx);
+            return new_leaf_idx;
+        }
+
+        // Descend to find the best internal node to insert into
+        self.insert_path.clear();
+        let mut current_idx = root_idx;
+
+        loop {
+            let current = &self.nodes[current_idx];
+            let NodeKind::Internal { children } = &current.kind else {
+                unreachable!("Should only traverse internal nodes");
+            };
+
+            // Find the best child to descend into
+            let mut best_child_idx = children.as_slice()[0];
+            let mut best_cost = bounds
+                .union(&self.nodes[best_child_idx].bounds)
+                .half_perimeter();
+
+            for &child_idx in &children.as_slice()[1..] {
+                let cost = bounds
+                    .union(&self.nodes[child_idx].bounds)
+                    .half_perimeter();
+                if cost < best_cost {
+                    best_cost = cost;
+                    best_child_idx = child_idx;
+                }
+            }
+
+            // Check if best child is a leaf or internal
+            if matches!(self.nodes[best_child_idx].kind, NodeKind::Leaf { .. }) {
+                // Best child is a leaf. Check if current node has room for another child.
+                if children.len() < MAX_CHILDREN {
+                    // Add new leaf directly to this node
+                    self.insert_path.push(current_idx);
+                    let node = &mut self.nodes[current_idx];
+                    if let NodeKind::Internal { children } = &mut node.kind {
+                        children.push(new_leaf_idx);
+                    }
+                    node.bounds = node.bounds.union(&bounds);
+                    node.max_order = cmp::max(node.max_order, order);
+                    break;
+                } else {
+                    // Node is full, create new internal with [best_leaf, new_leaf]
+                    self.insert_path.push(current_idx);
+                    let sibling_bounds = self.nodes[best_child_idx].bounds.clone();
+                    let sibling_order = self.nodes[best_child_idx].max_order;
+
+                    let mut new_children = ChildArray::new();
+                    new_children.push(best_child_idx);
+                    new_children.push(new_leaf_idx);
+
+                    let new_internal_idx = self.nodes.len();
+                    self.nodes.push(Node {
+                        bounds: sibling_bounds.union(&bounds),
+                        max_order: cmp::max(sibling_order, order),
+                        kind: NodeKind::Internal {
+                            children: new_children,
+                        },
+                    });
+
+                    // Replace the leaf with the new internal in parent
+                    let parent = &mut self.nodes[current_idx];
+                    if let NodeKind::Internal { children } = &mut parent.kind {
+                        let num_children = children.len();
+                        for child_ref in children.indices[..num_children].iter_mut() {
+                            if *child_ref == best_child_idx {
+                                *child_ref = new_internal_idx;
+                                break;
+                            }
+                        }
+                    }
+                    break;
+                }
+            } else {
+                // Best child is internal, continue descent
+                self.insert_path.push(current_idx);
+                current_idx = best_child_idx;
+            }
+        }
+
+        // Propagate bounds and max_order updates up the tree
+        for &node_idx in self.insert_path.iter().rev() {
+            let node = &mut self.nodes[node_idx];
+            node.bounds = node.bounds.union(&bounds);
+            if node.max_order < order {
+                node.max_order = order;
+            }
+        }
+
+        new_leaf_idx
     }
 }
 
@@ -187,50 +329,11 @@ where
 {
     fn default() -> Self {
         BoundsTree {
-            root: None,
             nodes: Vec::new(),
-            stack: Vec::new(),
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-enum Node<U>
-where
-    U: Clone + Debug + Default + PartialEq,
-{
-    Leaf {
-        bounds: Bounds<U>,
-        order: u32,
-    },
-    Internal {
-        left: usize,
-        right: usize,
-        bounds: Bounds<U>,
-        max_order: u32,
-    },
-}
-
-impl<U> Node<U>
-where
-    U: Clone + Debug + Default + PartialEq,
-{
-    fn bounds(&self) -> &Bounds<U> {
-        match self {
-            Node::Leaf { bounds, .. } => bounds,
-            Node::Internal { bounds, .. } => bounds,
-        }
-    }
-
-    fn max_ordering(&self) -> u32 {
-        match self {
-            Node::Leaf {
-                order: ordering, ..
-            } => *ordering,
-            Node::Internal {
-                max_order: max_ordering,
-                ..
-            } => *max_ordering,
+            root: None,
+            max_leaf: None,
+            insert_path: Vec::new(),
+            search_stack: Vec::new(),
         }
     }
 }

--- a/crates/gpui/src/bounds_tree.rs
+++ b/crates/gpui/src/bounds_tree.rs
@@ -173,8 +173,7 @@ where
                 NodeKind::Internal { children } => {
                     // Add children to search stack, sorted by max_order ascending
                     // so highest max_order is processed first (LIFO)
-                    let mut child_orders: [(u32, usize); MAX_CHILDREN] =
-                        [(0, 0); MAX_CHILDREN];
+                    let mut child_orders: [(u32, usize); MAX_CHILDREN] = [(0, 0); MAX_CHILDREN];
                     let num_children = children.len();
 
                     for (i, &child_idx) in children.as_slice().iter().enumerate() {
@@ -182,8 +181,7 @@ where
                     }
 
                     // Sort by max_order (ascending, so highest is pushed last = popped first)
-                    child_orders[..num_children]
-                        .sort_unstable_by_key(|(max_order, _)| *max_order);
+                    child_orders[..num_children].sort_unstable_by_key(|(max_order, _)| *max_order);
 
                     for (child_max, child_idx) in &child_orders[..num_children] {
                         if *child_max > max_found {
@@ -249,9 +247,7 @@ where
                 .half_perimeter();
 
             for &child_idx in &children.as_slice()[1..] {
-                let cost = bounds
-                    .union(&self.nodes[child_idx].bounds)
-                    .half_perimeter();
+                let cost = bounds.union(&self.nodes[child_idx].bounds).half_perimeter();
                 if cost < best_cost {
                     best_cost = cost;
                     best_child_idx = child_idx;

--- a/crates/gpui/src/bounds_tree.rs
+++ b/crates/gpui/src/bounds_tree.rs
@@ -172,7 +172,7 @@ where
                     max_found = cmp::max(max_found, *order);
                 }
                 NodeKind::Internal { children } => {
-                    // Children are maintained with heighest max_order at the end.
+                    // Children are maintained with highest max_order at the end.
                     // Push in forward order to highest (last) is popped first.
                     for &child_idx in children.as_slice() {
                         if self.nodes[child_idx].max_order > max_found {
@@ -307,7 +307,7 @@ where
                         children.indices[best_child_pos] = new_internal_idx;
 
                         // If new internal has highest max_order, swap it to the end
-                        // to mantain sorting invariant
+                        // to maintain sorting invariant
                         if new_internal_max > parent.max_order {
                             children.indices.swap(best_child_pos, children_len - 1);
                         }


### PR DESCRIPTION
On my macOS machine, the paths_bench example currently runs at about 40 fps in release mode. Profiling shows that at a 24 ms frame interval, roughly 6–9 ms are spent on the GPU (fragment work, which still needs optimization), while the remainder is CPU time. After more accurate profiling, the frame graph revealed that most of the CPU cost came from bounds tree insertion 

<img width="1061" height="327" alt="image" src="https://github.com/user-attachments/assets/d67915c6-70e3-4871-abca-897e40d5d469" />

The issue is that the existing tree structure performs poorly when many bounds are identical, which is exactly what happens in paths_bench.

The new implementation is a variant of an R-tree. I may experiment with an R*-tree variant later, but the current approach already addresses three major problems:

1. Fast path for max leaf (now O(1) for overlapping bounds)
Before: Every insertion walked the entire tree to find the maximum intersecting ordering.
After: The tree maintains a pointer to the leaf with the global maximum ordering, letting us test it immediately.

2. Higher branching factor
The tree now uses four children per node instead of two, which reduces height and improves traversal efficiency.

3. Better overall balancing
Node selection and splitting strategies produce a more stable and evenly distributed tree structure.

These changes reduce insertion complexity:

- Identical or fully overlapping bounds drop from O(n^2) to O(n)
- Mostly overlapping bounds drop from O(n^2) to O(n log n)
- Spatially distributed bounds keep similar asymptotic cost but benefit from reduced height
- Non-overlapping bounds also benefit from reduced height

And specific operations improve significantly:

- find_max_ordering: from O(n) to O(1) when the max leaf intersects, otherwise O(log n)
- insert_leaf: from O(n) for identical bounds to O(log4 n)
- Total cost for inserting n items: from O(n^2) worst-case to O(n) best-case and O(n log n) worst-case

In the paths_bench example, these changes produce a **100% performance improvement**, increasing the frame rate from 40 fps to 80 fps. With a few more optimizations, I believe we can push the example to around 120 fps.

Before:

<img width="319" height="327" alt="image" src="https://github.com/user-attachments/assets/d928ec39-0d0b-4583-a4a3-907cfccc21b1" />

After:

<img width="319" height="327" alt="image" src="https://github.com/user-attachments/assets/6dfc99cf-e024-4999-9d4b-fcf3181782f4" />


Release Notes:

- Improved path and rendering performance
