### PR TITLE
vim: Fix cursor position when moving up/down at buffer boundaries with goal column

### DIFF
--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -1555,6 +1555,12 @@ impl Sub<u32> for DisplayRow {
     }
 }
 
+impl PartialEq<u32> for DisplayRow {
+    fn eq(&self, &other: &u32) -> bool {
+        self.0 == other
+    }
+}
+
 impl DisplayPoint {
     pub fn new(row: DisplayRow, column: u32) -> Self {
         Self(BlockPoint(Point::new(row.0, column)))

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -9187,7 +9187,7 @@ impl Element for EditorElement {
                             .is_none_or(|info| info.buffer_row.is_none())
                     };
 
-                    let start_anchor = if start_row == Default::default() {
+                    let start_anchor = if start_row == 0 {
                         Anchor::min()
                     } else {
                         snapshot.buffer_snapshot().anchor_before(

--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -843,6 +843,7 @@ impl Motion {
             | Up { .. }
             | WrappingLeft
             | WrappingRight => false,
+
             EndOfDocument
             | EndOfParagraph
             | GoToPercentage
@@ -966,7 +967,7 @@ impl Motion {
             } => down_display(map, point, goal, times, text_layout_details),
             Up {
                 display_lines: false,
-            } => up_down_buffer_rows(map, point, goal, 0 - times as isize, text_layout_details),
+            } => up_down_buffer_rows(map, point, goal, -(times as isize), text_layout_details),
             Up {
                 display_lines: true,
             } => up_display(map, point, goal, times, text_layout_details),

--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -1532,6 +1532,12 @@ fn up_down_buffer_rows(
     mut times: isize,
     text_layout_details: &TextLayoutDetails,
 ) -> (DisplayPoint, SelectionGoal) {
+    // Return early if we're already on the first/last row of the buffer and
+    // trying to move further in that direction.
+    if (point.row() == 0 && times < 0) || (point.row() == map.max_point().row() && times > 0) {
+        return (point, goal);
+    }
+
     let bias = if times < 0 { Bias::Left } else { Bias::Right };
 
     while map.is_folded_buffer_header(point.row()) {


### PR DESCRIPTION
Fixes incorrect cursor positioning in Vim mode when attempting to move up on the first row or down on the last row of the buffer while a `SelectionGoal` is set.

Previously, when a vertical movement had set a goal column, attempting to move beyond the buffer boundaries would incorrectly reposition the cursor instead of staying in place.

Before:

https://github.com/user-attachments/assets/ceeb1104-860e-441c-a51f-e5a86666b4d3

After:

https://github.com/user-attachments/assets/6a5555ba-9e40-488b-a2bf-cacc70a61e42


Release Notes:

- Fixed vim mode incorrectly repositioning the cursor when pressing `k` on the first line or `j` on the last line after establishing a goal column 