### PR TITLE
Add Search Everywhere feature (JetBrains-style universal search)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14454,6 +14454,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "search_everywhere"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "collections",
+ "command_palette_hooks",
+ "ctor",
+ "editor",
+ "futures 0.3.31",
+ "fuzzy",
+ "gpui",
+ "language",
+ "log",
+ "parking_lot",
+ "picker",
+ "project",
+ "ui",
+ "util",
+ "workspace",
+]
+
+[[package]]
 name = "sec1"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -20563,6 +20585,7 @@ dependencies = [
  "reqwest_client",
  "rope",
  "search",
+ "search_everywhere",
  "semver",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,6 +147,7 @@ members = [
     "crates/rules_library",
     "crates/schema_generator",
     "crates/search",
+    "crates/search_everywhere",
     "crates/session",
     "crates/settings",
     "crates/settings_json",
@@ -373,6 +374,7 @@ rope = { path = "crates/rope" }
 rpc = { path = "crates/rpc" }
 rules_library = { path = "crates/rules_library" }
 search = { path = "crates/search" }
+search_everywhere = { path = "crates/search_everywhere" }
 session = { path = "crates/session" }
 settings = { path = "crates/settings" }
 settings_json = { path = "crates/settings_json" }

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -617,6 +617,7 @@
       "ctrl-alt-super-p": "settings_profile_selector::Toggle",
       "ctrl-t": "project_symbols::Toggle",
       "ctrl-p": "file_finder::Toggle",
+      "shift shift": "search_everywhere::Toggle",
       "ctrl-shift-tab": ["tab_switcher::Toggle", { "select_last": true }],
       "ctrl-tab": "tab_switcher::Toggle",
       "ctrl-e": "file_finder::Toggle",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -684,6 +684,7 @@
       "ctrl-alt-cmd-p": "settings_profile_selector::Toggle",
       "cmd-t": "project_symbols::Toggle",
       "cmd-p": "file_finder::Toggle",
+      "shift shift": "search_everywhere::Toggle",
       "ctrl-shift-tab": ["tab_switcher::Toggle", { "select_last": true }],
       "ctrl-tab": "tab_switcher::Toggle",
       "cmd-shift-p": "command_palette::Toggle",

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -609,6 +609,7 @@
       "ctrl-alt-super-p": "settings_profile_selector::Toggle",
       "ctrl-t": "project_symbols::Toggle",
       "ctrl-p": "file_finder::Toggle",
+      "shift shift": "search_everywhere::Toggle",
       "ctrl-shift-tab": ["tab_switcher::Toggle", { "select_last": true }],
       "ctrl-tab": "tab_switcher::Toggle",
       "ctrl-e": "file_finder::Toggle",

--- a/crates/search_everywhere/Cargo.toml
+++ b/crates/search_everywhere/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "search_everywhere"
+version = "0.1.0"
+edition.workspace = true
+publish.workspace = true
+license = "GPL-3.0-or-later"
+
+[lints]
+workspace = true
+
+[lib]
+path = "src/search_everywhere.rs"
+doctest = false
+
+[dependencies]
+anyhow.workspace = true
+collections.workspace = true
+command_palette_hooks.workspace = true
+editor.workspace = true
+futures.workspace = true
+fuzzy.workspace = true
+gpui.workspace = true
+language.workspace = true
+log.workspace = true
+parking_lot.workspace = true
+picker.workspace = true
+project.workspace = true
+ui.workspace = true
+util.workspace = true
+workspace.workspace = true
+
+[dev-dependencies]
+ctor.workspace = true
+editor = { workspace = true, features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }
+language = { workspace = true, features = ["test-support"] }
+picker = { workspace = true, features = ["test-support"] }
+workspace = { workspace = true, features = ["test-support"] }

--- a/crates/search_everywhere/LICENSE-GPL
+++ b/crates/search_everywhere/LICENSE-GPL
@@ -1,0 +1,1 @@
+../../LICENSE-GPL

--- a/crates/search_everywhere/src/actions.rs
+++ b/crates/search_everywhere/src/actions.rs
@@ -1,0 +1,136 @@
+use command_palette_hooks::CommandPaletteFilter;
+use fuzzy::{StringMatch, StringMatchCandidate};
+use gpui::{Action, SharedString, Task, Window};
+
+use crate::SearchEverywhereDelegate;
+use crate::providers::{SearchResult, SearchResultCategory};
+
+pub struct ActionProvider {
+    commands: Vec<Command>,
+}
+
+struct Command {
+    name: String,
+    action: Box<dyn Action>,
+}
+
+impl ActionProvider {
+    pub fn new<T: 'static>(window: &mut Window, cx: &mut gpui::Context<T>) -> Self {
+        let filter = CommandPaletteFilter::try_global(cx);
+
+        let commands = window
+            .available_actions(cx)
+            .into_iter()
+            .filter_map(|action| {
+                if filter.is_some_and(|filter| filter.is_hidden(&*action)) {
+                    return None;
+                }
+
+                Some(Command {
+                    name: humanize_action_name(action.name()),
+                    action,
+                })
+            })
+            .collect();
+
+        Self { commands }
+    }
+
+    pub fn search(
+        &self,
+        query: &str,
+        _window: &mut Window,
+        cx: &mut gpui::Context<picker::Picker<SearchEverywhereDelegate>>,
+    ) -> Task<Vec<(SearchResult, StringMatch)>> {
+        if query.is_empty() {
+            return Task::ready(Vec::new());
+        }
+
+        let candidates: Vec<StringMatchCandidate> = self
+            .commands
+            .iter()
+            .enumerate()
+            .map(|(id, c)| StringMatchCandidate::new(id, &c.name))
+            .collect();
+
+        let query = query.to_string();
+        let commands: Vec<_> = self
+            .commands
+            .iter()
+            .map(|c| (c.name.clone(), c.action.boxed_clone()))
+            .collect();
+
+        cx.spawn(async move |_, cx| {
+            let matches = fuzzy::match_strings(
+                &candidates,
+                &query,
+                true,
+                true,
+                100,
+                &Default::default(),
+                cx.background_executor().clone(),
+            )
+            .await;
+
+            matches
+                .into_iter()
+                .filter_map(|m| {
+                    let (name, action) = commands.get(m.candidate_id)?;
+
+                    let result = SearchResult {
+                        label: SharedString::from(name.clone()),
+                        detail: None,
+                        category: SearchResultCategory::Action,
+                        path: None,
+                        action: Some(action.boxed_clone()),
+                        symbol: None,
+                        document_symbol: None,
+                    };
+
+                    Some((result, m))
+                })
+                .collect()
+        })
+    }
+}
+
+fn humanize_action_name(name: &str) -> String {
+    let capacity = name.len() + name.chars().filter(|c| c.is_uppercase()).count();
+    let mut result = String::with_capacity(capacity);
+
+    for char in name.chars() {
+        if char == ':' {
+            if result.ends_with(':') {
+                result.push(' ');
+            } else {
+                result.push(':');
+            }
+        } else if char == '_' {
+            result.push(' ');
+        } else if char.is_uppercase() {
+            if !result.ends_with(' ') && !result.ends_with(':') {
+                result.push(' ');
+            }
+            result.extend(char.to_lowercase());
+        } else {
+            result.push(char);
+        }
+    }
+
+    let mut title_cased = String::with_capacity(result.len());
+    let mut should_capitalize = true;
+
+    for char in result.chars() {
+        if should_capitalize && char.is_alphabetic() {
+            title_cased.extend(char.to_uppercase());
+            should_capitalize = false;
+        } else {
+            title_cased.push(char);
+            if char == ' ' || char == ':' {
+                should_capitalize = true;
+            }
+        }
+    }
+
+    title_cased
+}

--- a/crates/search_everywhere/src/files.rs
+++ b/crates/search_everywhere/src/files.rs
@@ -1,0 +1,109 @@
+use fuzzy::{StringMatch, StringMatchCandidate};
+use gpui::{App, Entity, SharedString, Task};
+use project::{Project, ProjectPath, WorktreeId};
+
+use crate::SearchEverywhereDelegate;
+use crate::providers::{SearchResult, SearchResultCategory};
+
+pub struct FileProvider {
+    project: Entity<Project>,
+}
+
+impl FileProvider {
+    pub fn new(project: Entity<Project>, _cx: &App) -> Self {
+        Self { project }
+    }
+
+    pub fn search(
+        &self,
+        query: &str,
+        cx: &mut gpui::Context<picker::Picker<SearchEverywhereDelegate>>,
+    ) -> Task<Vec<(SearchResult, StringMatch)>> {
+        if query.is_empty() {
+            return Task::ready(Vec::new());
+        }
+
+        let project = self.project.clone();
+        let query = query.to_string();
+
+        cx.spawn(async move |_, cx| {
+            let Some(candidates) = cx
+                .update(|cx| {
+                    let project = project.read(cx);
+                    let worktrees = project.visible_worktrees(cx).collect::<Vec<_>>();
+
+                    let mut candidates = Vec::new();
+                    for worktree in worktrees {
+                        let worktree = worktree.read(cx);
+                        let worktree_id = worktree.id();
+
+                        for entry in worktree.files(false, 0) {
+                            let path = entry.path.as_unix_str().to_string();
+                            candidates.push(FileCandidate {
+                                path: path.clone(),
+                                worktree_id,
+                                project_path: ProjectPath {
+                                    worktree_id,
+                                    path: entry.path.clone(),
+                                },
+                            });
+                        }
+                    }
+                    candidates
+                })
+                .ok()
+            else {
+                return Vec::new();
+            };
+
+            let string_candidates: Vec<StringMatchCandidate> = candidates
+                .iter()
+                .enumerate()
+                .map(|(id, c)| StringMatchCandidate::new(id, &c.path))
+                .collect();
+
+            let matches = fuzzy::match_strings(
+                &string_candidates,
+                &query,
+                true,
+                true,
+                100,
+                &Default::default(),
+                cx.background_executor().clone(),
+            )
+            .await;
+
+            matches
+                .into_iter()
+                .filter_map(|m| {
+                    let candidate = candidates.get(m.candidate_id)?;
+                    let file_name = candidate
+                        .project_path
+                        .path
+                        .file_name()
+                        .map(|n| n.to_string())
+                        .unwrap_or_else(|| candidate.path.clone());
+
+                    let result = SearchResult {
+                        label: SharedString::from(file_name),
+                        detail: Some(SharedString::from(candidate.path.clone())),
+                        category: SearchResultCategory::File,
+                        path: Some(candidate.project_path.clone()),
+                        action: None,
+                        symbol: None,
+                        document_symbol: None,
+                    };
+
+                    Some((result, m))
+                })
+                .collect()
+        })
+    }
+}
+
+struct FileCandidate {
+    path: String,
+    #[allow(dead_code)]
+    worktree_id: WorktreeId,
+    project_path: ProjectPath,
+}

--- a/crates/search_everywhere/src/providers.rs
+++ b/crates/search_everywhere/src/providers.rs
@@ -1,0 +1,26 @@
+use gpui::{Action, Entity, SharedString};
+use language::{Anchor, Buffer};
+use project::{ProjectPath, Symbol};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SearchResultCategory {
+    File,
+    Symbol,
+    Action,
+}
+
+pub struct SearchResult {
+    pub label: SharedString,
+    pub detail: Option<SharedString>,
+    pub category: SearchResultCategory,
+    pub path: Option<ProjectPath>,
+    pub action: Option<Box<dyn Action>>,
+    pub symbol: Option<Symbol>,
+    pub document_symbol: Option<DocumentSymbolResult>,
+}
+
+#[derive(Clone)]
+pub struct DocumentSymbolResult {
+    pub buffer: Entity<Buffer>,
+    pub range: std::ops::Range<Anchor>,
+}

--- a/crates/search_everywhere/src/search_everywhere.rs
+++ b/crates/search_everywhere/src/search_everywhere.rs
@@ -1,0 +1,559 @@
+mod actions;
+mod files;
+mod providers;
+mod symbols;
+
+use std::sync::Arc;
+
+use actions::ActionProvider;
+use editor::{Bias, Editor, SelectionEffects, scroll::Autoscroll};
+use files::FileProvider;
+use fuzzy::StringMatch;
+use gpui::{
+    App, Context, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable, IntoElement,
+    ParentElement, Render, SharedString, Styled, Task, WeakEntity, Window, actions, rems,
+};
+use language::ToPoint;
+use picker::{Picker, PickerDelegate};
+use providers::{SearchResult, SearchResultCategory};
+use symbols::SymbolProvider;
+use ui::{
+    Divider, IconName, KeyBinding, ListItem, ListItemSpacing, ToggleButtonGroup,
+    ToggleButtonGroupStyle, ToggleButtonSimple, prelude::*,
+};
+use util::ResultExt;
+use workspace::{ModalView, Workspace};
+
+actions!(
+    search_everywhere,
+    [
+        /// Toggle the Search Everywhere modal.
+        Toggle,
+    ]
+);
+
+pub fn init(cx: &mut App) {
+    cx.observe_new(SearchEverywhere::register).detach();
+}
+
+impl ModalView for SearchEverywhere {}
+
+pub struct SearchEverywhere {
+    picker: Entity<Picker<SearchEverywhereDelegate>>,
+    active_tab: SearchTab,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SearchTab {
+    #[default]
+    All,
+    Files,
+    Symbols,
+    Actions,
+}
+
+impl SearchEverywhere {
+    fn register(
+        workspace: &mut Workspace,
+        _window: Option<&mut Window>,
+        _: &mut Context<Workspace>,
+    ) {
+        workspace.register_action(|workspace, _: &Toggle, window, cx| {
+            Self::toggle(workspace, window, cx);
+        });
+    }
+
+    pub fn toggle(workspace: &mut Workspace, window: &mut Window, cx: &mut Context<Workspace>) {
+        let Some(previous_focus_handle) = window.focused(cx) else {
+            return;
+        };
+
+        let project = workspace.project().clone();
+        let weak_workspace = cx.entity().downgrade();
+
+        workspace.toggle_modal(window, cx, move |window, cx| {
+            SearchEverywhere::new(weak_workspace, project, previous_focus_handle, window, cx)
+        });
+    }
+
+    fn new(
+        workspace: WeakEntity<Workspace>,
+        project: Entity<project::Project>,
+        previous_focus_handle: FocusHandle,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let weak_search_everywhere = cx.entity().downgrade();
+
+        let delegate = SearchEverywhereDelegate::new(
+            weak_search_everywhere,
+            workspace,
+            project,
+            previous_focus_handle,
+            window,
+            cx,
+        );
+
+        // Only start indexing if we don't have cached symbols already
+        if !delegate.symbol_provider.has_cached_symbols() {
+            delegate.symbol_provider.start_indexing(cx);
+        }
+
+        let picker = cx.new(|cx| Picker::uniform_list(delegate, window, cx));
+
+        Self {
+            picker,
+            active_tab: SearchTab::All,
+        }
+    }
+
+    fn set_active_tab(&mut self, tab: SearchTab, window: &mut Window, cx: &mut Context<Self>) {
+        self.active_tab = tab;
+        self.picker.update(cx, |picker, cx| {
+            picker.delegate.active_tab = tab;
+            picker.refresh(window, cx);
+        });
+        cx.notify();
+    }
+}
+
+impl EventEmitter<DismissEvent> for SearchEverywhere {}
+
+impl Focusable for SearchEverywhere {
+    fn focus_handle(&self, cx: &App) -> FocusHandle {
+        self.picker.focus_handle(cx)
+    }
+}
+
+impl Render for SearchEverywhere {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        v_flex()
+            .key_context("SearchEverywhere")
+            .w(rems(34.))
+            .child(self.picker.clone())
+    }
+}
+
+pub struct SearchEverywhereDelegate {
+    search_everywhere: WeakEntity<SearchEverywhere>,
+    workspace: WeakEntity<Workspace>,
+    project: Entity<project::Project>,
+    previous_focus_handle: FocusHandle,
+    active_tab: SearchTab,
+    matches: Vec<SearchResultMatch>,
+    selected_ix: usize,
+    is_loading: bool,
+    file_provider: FileProvider,
+    action_provider: ActionProvider,
+    symbol_provider: SymbolProvider,
+}
+
+struct SearchResultMatch {
+    result: SearchResult,
+    string_match: StringMatch,
+}
+
+impl SearchEverywhereDelegate {
+    fn new(
+        search_everywhere: WeakEntity<SearchEverywhere>,
+        workspace: WeakEntity<Workspace>,
+        project: Entity<project::Project>,
+        previous_focus_handle: FocusHandle,
+        window: &mut Window,
+        cx: &mut Context<SearchEverywhere>,
+    ) -> Self {
+        let file_provider = FileProvider::new(project.clone(), cx);
+        let action_provider = ActionProvider::new(window, cx);
+        let symbol_provider = SymbolProvider::new(project.clone());
+
+        Self {
+            search_everywhere,
+            workspace,
+            project,
+            previous_focus_handle,
+            active_tab: SearchTab::All,
+            matches: Vec::new(),
+            selected_ix: 0,
+            is_loading: false,
+            file_provider,
+            action_provider,
+            symbol_provider,
+        }
+    }
+
+    fn filter_matches_by_tab(&self, matches: Vec<SearchResultMatch>) -> Vec<SearchResultMatch> {
+        match self.active_tab {
+            SearchTab::All => matches,
+            SearchTab::Files => matches
+                .into_iter()
+                .filter(|m| m.result.category == SearchResultCategory::File)
+                .collect(),
+            SearchTab::Symbols => matches
+                .into_iter()
+                .filter(|m| m.result.category == SearchResultCategory::Symbol)
+                .collect(),
+            SearchTab::Actions => matches
+                .into_iter()
+                .filter(|m| m.result.category == SearchResultCategory::Action)
+                .collect(),
+        }
+    }
+}
+
+impl PickerDelegate for SearchEverywhereDelegate {
+    type ListItem = ListItem;
+
+    fn match_count(&self) -> usize {
+        self.matches.len()
+    }
+
+    fn selected_index(&self) -> usize {
+        self.selected_ix
+    }
+
+    fn set_selected_index(
+        &mut self,
+        ix: usize,
+        _window: &mut Window,
+        _cx: &mut Context<Picker<Self>>,
+    ) {
+        self.selected_ix = ix;
+    }
+
+    fn placeholder_text(&self, _window: &mut Window, _cx: &mut App) -> Arc<str> {
+        "Search everywhere...".into()
+    }
+
+    fn no_matches_text(&self, _window: &mut Window, _cx: &mut App) -> Option<SharedString> {
+        if self.symbol_provider.is_indexing() {
+            let progress = self.symbol_provider.indexing_progress_percent();
+            Some(SharedString::from(format!(
+                "Indexing project... {}%",
+                progress
+            )))
+        } else if self.is_loading {
+            Some("Searching...".into())
+        } else {
+            Some("No matches".into())
+        }
+    }
+
+    fn render_editor(
+        &self,
+        editor: &Entity<Editor>,
+        _window: &mut Window,
+        _cx: &mut Context<Picker<Self>>,
+    ) -> Div {
+        let selected_index = match self.active_tab {
+            SearchTab::All => 0,
+            SearchTab::Files => 1,
+            SearchTab::Symbols => 2,
+            SearchTab::Actions => 3,
+        };
+
+        let search_everywhere = self.search_everywhere.clone();
+
+        v_flex()
+            .child(
+                h_flex().px_2().py_1p5().child(
+                    ToggleButtonGroup::single_row(
+                        "search-everywhere-tabs",
+                        [
+                            ToggleButtonSimple::new("All", {
+                                let search_everywhere = search_everywhere.clone();
+                                move |_event, window, cx| {
+                                    search_everywhere
+                                        .update(cx, |this, cx| {
+                                            this.set_active_tab(SearchTab::All, window, cx);
+                                        })
+                                        .log_err();
+                                }
+                            }),
+                            ToggleButtonSimple::new("Files", {
+                                let search_everywhere = search_everywhere.clone();
+                                move |_event, window, cx| {
+                                    search_everywhere
+                                        .update(cx, |this, cx| {
+                                            this.set_active_tab(SearchTab::Files, window, cx);
+                                        })
+                                        .log_err();
+                                }
+                            }),
+                            ToggleButtonSimple::new("Symbols", {
+                                let search_everywhere = search_everywhere.clone();
+                                move |_event, window, cx| {
+                                    search_everywhere
+                                        .update(cx, |this, cx| {
+                                            this.set_active_tab(SearchTab::Symbols, window, cx);
+                                        })
+                                        .log_err();
+                                }
+                            }),
+                            ToggleButtonSimple::new("Actions", {
+                                move |_event, window, cx| {
+                                    search_everywhere
+                                        .update(cx, |this, cx| {
+                                            this.set_active_tab(SearchTab::Actions, window, cx);
+                                        })
+                                        .log_err();
+                                }
+                            }),
+                        ],
+                    )
+                    .style(ToggleButtonGroupStyle::Outlined)
+                    .selected_index(selected_index),
+                ),
+            )
+            .child(
+                h_flex()
+                    .overflow_hidden()
+                    .flex_none()
+                    .h_9()
+                    .px_2p5()
+                    .child(editor.clone()),
+            )
+            .child(Divider::horizontal())
+    }
+
+    fn update_matches(
+        &mut self,
+        query: String,
+        window: &mut Window,
+        cx: &mut Context<Picker<Self>>,
+    ) -> Task<()> {
+        self.is_loading = true;
+        cx.notify();
+
+        let file_results = self.file_provider.search(&query, cx);
+        let action_results = self.action_provider.search(&query, window, cx);
+        let symbol_results = self.symbol_provider.search(&query, cx);
+
+        cx.spawn_in(window, async move |picker, cx| {
+            let (file_matches, action_matches, symbol_matches) =
+                futures::join!(file_results, action_results, symbol_results);
+
+            let mut all_matches: Vec<SearchResultMatch> = Vec::new();
+
+            for (result, string_match) in file_matches {
+                all_matches.push(SearchResultMatch {
+                    result,
+                    string_match,
+                });
+            }
+
+            for (result, string_match) in action_matches {
+                all_matches.push(SearchResultMatch {
+                    result,
+                    string_match,
+                });
+            }
+
+            for (result, string_match) in symbol_matches {
+                all_matches.push(SearchResultMatch {
+                    result,
+                    string_match,
+                });
+            }
+
+            all_matches.sort_by(|a, b| {
+                b.string_match
+                    .score
+                    .partial_cmp(&a.string_match.score)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
+
+            picker
+                .update(cx, |picker, cx| {
+                    let filtered = picker.delegate.filter_matches_by_tab(all_matches);
+                    picker.delegate.matches = filtered;
+                    picker.delegate.selected_ix = 0;
+                    picker.delegate.is_loading = false;
+                    cx.notify();
+                })
+                .log_err();
+        })
+    }
+
+    fn confirm(&mut self, _secondary: bool, window: &mut Window, cx: &mut Context<Picker<Self>>) {
+        if self.matches.is_empty() {
+            self.dismissed(window, cx);
+            return;
+        }
+
+        let selected_ix = self.selected_ix;
+        if selected_ix >= self.matches.len() {
+            self.dismissed(window, cx);
+            return;
+        }
+
+        let selected_match = &self.matches[selected_ix];
+
+        match selected_match.result.category {
+            SearchResultCategory::File => {
+                if let Some(path) = &selected_match.result.path {
+                    let path = path.clone();
+                    if let Some(workspace) = self.workspace.upgrade() {
+                        workspace.update(cx, |workspace, cx| {
+                            workspace
+                                .open_path(path, None, true, window, cx)
+                                .detach_and_log_err(cx);
+                        });
+                    }
+                    window.focus(&self.previous_focus_handle);
+                    self.search_everywhere
+                        .update(cx, |_, cx| cx.emit(DismissEvent))
+                        .log_err();
+                }
+            }
+            SearchResultCategory::Action => {
+                if let Some(action) = &selected_match.result.action {
+                    let action = action.boxed_clone();
+                    window.focus(&self.previous_focus_handle);
+                    self.search_everywhere
+                        .update(cx, |_, cx| cx.emit(DismissEvent))
+                        .log_err();
+                    window.dispatch_action(action, cx);
+                }
+            }
+            SearchResultCategory::Symbol => {
+                if let Some(symbol) = &selected_match.result.symbol {
+                    let symbol = symbol.clone();
+                    let project = self.project.clone();
+                    let workspace = self.workspace.clone();
+                    let search_everywhere = self.search_everywhere.clone();
+
+                    let buffer = project.update(cx, |project, cx| {
+                        project.open_buffer_for_symbol(&symbol, cx)
+                    });
+
+                    cx.spawn_in(window, async move |_, cx| {
+                        let buffer = buffer.await?;
+                        workspace.update_in(cx, |workspace, window, cx| {
+                            let position = buffer
+                                .read(cx)
+                                .clip_point_utf16(symbol.range.start, Bias::Left);
+
+                            let editor = workspace.open_project_item::<Editor>(
+                                workspace.active_pane().clone(),
+                                buffer,
+                                true,
+                                true,
+                                true,
+                                true,
+                                window,
+                                cx,
+                            );
+
+                            editor.update(cx, |editor, cx| {
+                                editor.change_selections(
+                                    SelectionEffects::scroll(Autoscroll::center()),
+                                    window,
+                                    cx,
+                                    |s| s.select_ranges([position..position]),
+                                );
+                            });
+                        })?;
+                        search_everywhere
+                            .update(cx, |_, cx| cx.emit(DismissEvent))
+                            .log_err();
+                        anyhow::Ok(())
+                    })
+                    .detach_and_log_err(cx);
+                } else if let Some(doc_symbol) = &selected_match.result.document_symbol {
+                    let buffer = doc_symbol.buffer.clone();
+                    let range = doc_symbol.range.clone();
+                    let workspace = self.workspace.clone();
+                    let search_everywhere = self.search_everywhere.clone();
+
+                    if let Some(workspace) = workspace.upgrade() {
+                        workspace.update(cx, |workspace, cx| {
+                            // Convert anchor to point using buffer snapshot
+                            let point = {
+                                let buffer_snapshot = buffer.read(cx).snapshot();
+                                range.start.to_point(&buffer_snapshot)
+                            };
+
+                            let editor = workspace.open_project_item::<Editor>(
+                                workspace.active_pane().clone(),
+                                buffer,
+                                true,
+                                true,
+                                true,
+                                true,
+                                window,
+                                cx,
+                            );
+
+                            editor.update(cx, |editor, cx| {
+                                editor.change_selections(
+                                    SelectionEffects::scroll(Autoscroll::center()),
+                                    window,
+                                    cx,
+                                    |s| s.select_ranges([point..point]),
+                                );
+                            });
+                        });
+                    }
+
+                    search_everywhere
+                        .update(cx, |_, cx| cx.emit(DismissEvent))
+                        .log_err();
+                }
+            }
+        }
+    }
+
+    fn dismissed(&mut self, window: &mut Window, cx: &mut Context<Picker<Self>>) {
+        window.focus(&self.previous_focus_handle);
+        self.search_everywhere
+            .update(cx, |_, cx| cx.emit(DismissEvent))
+            .log_err();
+    }
+
+    fn render_match(
+        &self,
+        ix: usize,
+        selected: bool,
+        _window: &mut Window,
+        cx: &mut Context<Picker<Self>>,
+    ) -> Option<Self::ListItem> {
+        let search_match = self.matches.get(ix)?;
+        let result = &search_match.result;
+
+        let icon = match result.category {
+            SearchResultCategory::File => IconName::File,
+            SearchResultCategory::Symbol => IconName::Code,
+            SearchResultCategory::Action => IconName::BoltOutlined,
+        };
+
+        let keybinding = result
+            .action
+            .as_ref()
+            .map(|action| KeyBinding::for_action_in(&**action, &self.previous_focus_handle, cx));
+
+        Some(
+            ListItem::new(ix)
+                .inset(true)
+                .spacing(ListItemSpacing::Sparse)
+                .toggle_state(selected)
+                .start_slot(Icon::new(icon).color(Color::Muted))
+                .child(
+                    h_flex()
+                        .gap_2()
+                        .child(Label::new(result.label.clone()))
+                        .when_some(result.detail.clone(), |this, detail| {
+                            this.child(
+                                Label::new(detail)
+                                    .size(LabelSize::Small)
+                                    .color(Color::Muted),
+                            )
+                        }),
+                )
+                .end_slot(
+                    h_flex()
+                        .gap_2()
+                        .when_some(keybinding, |this, kb| this.child(kb)),
+                ),
+        )
+    }
+}

--- a/crates/search_everywhere/src/symbols.rs
+++ b/crates/search_everywhere/src/symbols.rs
@@ -1,0 +1,339 @@
+use std::sync::Arc;
+
+use collections::HashMap;
+use fuzzy::{StringMatch, StringMatchCandidate};
+use gpui::{App, Entity, EntityId, SharedString, Task as GpuiTask};
+use language::{Anchor, Buffer, OutlineItem};
+use parking_lot::Mutex;
+use project::{Project, Symbol};
+use util::ResultExt;
+
+use crate::SearchEverywhereDelegate;
+use crate::providers::{DocumentSymbolResult, SearchResult, SearchResultCategory};
+
+// Global cache for symbol providers, keyed by project entity ID
+static SYMBOL_CACHES: Mutex<Option<HashMap<EntityId, Arc<SymbolCache>>>> = Mutex::new(None);
+
+struct SymbolCache {
+    cached_symbols: Mutex<Vec<SymbolEntry>>,
+    is_indexing: Mutex<bool>,
+    indexing_progress: Mutex<(usize, usize)>,
+}
+
+pub struct SymbolProvider {
+    project: Entity<Project>,
+    cache: Arc<SymbolCache>,
+}
+
+#[derive(Clone)]
+pub enum SymbolEntry {
+    Workspace(Symbol),
+    Outline {
+        name: String,
+        path: String,
+        buffer: Entity<Buffer>,
+        range: std::ops::Range<Anchor>,
+    },
+}
+
+impl SymbolProvider {
+    pub fn new(project: Entity<Project>) -> Self {
+        let project_id = project.entity_id();
+
+        // Get or create the cache for this project
+        let cache = {
+            let mut caches = SYMBOL_CACHES.lock();
+            let caches = caches.get_or_insert_with(HashMap::default);
+            caches
+                .entry(project_id)
+                .or_insert_with(|| {
+                    Arc::new(SymbolCache {
+                        cached_symbols: Mutex::new(Vec::new()),
+                        is_indexing: Mutex::new(false),
+                        indexing_progress: Mutex::new((0, 0)),
+                    })
+                })
+                .clone()
+        };
+
+        Self { project, cache }
+    }
+
+    /// Start indexing all symbols in the project. Call this when the modal opens.
+    pub fn start_indexing(&self, cx: &mut App) {
+        // Don't start if already indexing
+        {
+            let mut is_indexing = self.cache.is_indexing.lock();
+            if *is_indexing {
+                return;
+            }
+            *is_indexing = true;
+        }
+
+        let project = self.project.clone();
+        let cache = self.cache.clone();
+
+        // Get all file paths from all worktrees (respects .gitignore)
+        let worktrees: Vec<_> = project.read(cx).visible_worktrees(cx).collect();
+
+        let mut paths_to_index: Vec<project::ProjectPath> = Vec::new();
+        for worktree in &worktrees {
+            let snapshot = worktree.read(cx).snapshot();
+            for entry in snapshot.files(false, 0) {
+                // Skip ignored files
+                if entry.is_ignored {
+                    continue;
+                }
+                paths_to_index.push(project::ProjectPath {
+                    worktree_id: snapshot.id(),
+                    path: entry.path.clone(),
+                });
+            }
+        }
+
+        log::info!(
+            "Search everywhere: starting to index {} files for symbols",
+            paths_to_index.len()
+        );
+
+        // Also try workspace symbols with empty query to get all symbols (if LSP supports it)
+        let workspace_symbols_task = project.update(cx, |project, cx| project.symbols("", cx));
+
+        // Initialize progress
+        {
+            let mut progress = cache.indexing_progress.lock();
+            *progress = (0, paths_to_index.len());
+        }
+
+        cx.spawn({
+            let project = project.clone();
+            async move |cx| {
+                let mut all_symbols: Vec<SymbolEntry> = Vec::new();
+
+                // Collect workspace symbols first (fast, if LSP supports it)
+                if let Some(symbols) = workspace_symbols_task.await.log_err() {
+                    log::info!(
+                        "Search everywhere: indexed {} workspace symbols",
+                        symbols.len()
+                    );
+                    for symbol in symbols {
+                        all_symbols.push(SymbolEntry::Workspace(symbol));
+                    }
+                }
+
+                // Now open each file and get outline items (Tree-sitter based, no LSP needed)
+                // Process in batches to avoid overwhelming the system
+                let batch_size = 50;
+                let total_files = paths_to_index.len();
+
+                for (batch_idx, paths_batch) in paths_to_index.chunks(batch_size).enumerate() {
+                    let mut batch_tasks: Vec<(
+                        String,
+                        GpuiTask<anyhow::Result<(Entity<Buffer>, Vec<OutlineItem<Anchor>>)>>,
+                    )> = Vec::new();
+
+                    for path in paths_batch {
+                        let path_string = path.path.as_unix_str().to_string();
+                        let path = path.clone();
+                        let project = project.clone();
+
+                        // Open buffer and get outline items
+                        let task = cx.update(|cx| {
+                            project.update(cx, |project, cx| {
+                                let open_task = project.open_buffer(path.clone(), cx);
+                                cx.spawn(async move |_weak_project, cx| {
+                                    let buffer = open_task.await?;
+                                    let outline_items = cx.update(|cx| {
+                                        let buffer_snapshot = buffer.read(cx).snapshot();
+                                        let outline = buffer_snapshot.outline(None);
+                                        outline.items
+                                    })?;
+                                    anyhow::Ok((buffer, outline_items))
+                                })
+                            })
+                        });
+
+                        if let Ok(task) = task {
+                            batch_tasks.push((path_string, task));
+                        }
+                    }
+
+                    // Wait for batch to complete
+                    for (file_path, task) in batch_tasks {
+                        match task.await {
+                            Ok((buffer, outline_items)) => {
+                                if !outline_items.is_empty() {
+                                    log::debug!(
+                                        "Search everywhere: got {} outline items from {}",
+                                        outline_items.len(),
+                                        file_path
+                                    );
+                                }
+                                for item in outline_items {
+                                    all_symbols.push(SymbolEntry::Outline {
+                                        name: item.text.clone(),
+                                        path: file_path.clone(),
+                                        buffer: buffer.clone(),
+                                        range: item.range.clone(),
+                                    });
+                                }
+                            }
+                            Err(e) => {
+                                log::debug!(
+                                    "Search everywhere: failed to get outline for {}: {}",
+                                    file_path,
+                                    e
+                                );
+                            }
+                        }
+                    }
+
+                    // Update progress
+                    let processed = ((batch_idx + 1) * batch_size).min(total_files);
+                    {
+                        let mut progress = cache.indexing_progress.lock();
+                        *progress = (processed, total_files);
+                    }
+
+                    if processed % 100 == 0 || processed >= total_files {
+                        log::info!(
+                            "Search everywhere: indexed {}/{} files ({}%), {} symbols so far",
+                            processed,
+                            total_files,
+                            (processed * 100) / total_files.max(1),
+                            all_symbols.len()
+                        );
+                    }
+
+                    // Update cache incrementally so results appear as we index
+                    {
+                        let mut symbols = cache.cached_symbols.lock();
+                        *symbols = all_symbols.clone();
+                    }
+                }
+
+                log::info!(
+                    "Search everywhere: indexing complete, {} total symbols",
+                    all_symbols.len()
+                );
+
+                // Final cache update
+                {
+                    let mut symbols = cache.cached_symbols.lock();
+                    *symbols = all_symbols;
+                }
+
+                // Mark indexing as complete
+                {
+                    let mut indexing = cache.is_indexing.lock();
+                    *indexing = false;
+                }
+
+                // Notify to refresh UI
+                cx.update(|_cx| {}).ok();
+            }
+        })
+        .detach();
+    }
+
+    pub fn is_indexing(&self) -> bool {
+        *self.cache.is_indexing.lock()
+    }
+
+    pub fn indexing_progress_percent(&self) -> usize {
+        let (processed, total) = *self.cache.indexing_progress.lock();
+        if total == 0 {
+            0
+        } else {
+            (processed * 100) / total
+        }
+    }
+
+    pub fn has_cached_symbols(&self) -> bool {
+        !self.cache.cached_symbols.lock().is_empty()
+    }
+
+    pub fn search(
+        &self,
+        query: &str,
+        cx: &mut gpui::Context<picker::Picker<SearchEverywhereDelegate>>,
+    ) -> GpuiTask<Vec<(SearchResult, StringMatch)>> {
+        if query.is_empty() {
+            return GpuiTask::ready(Vec::new());
+        }
+
+        let cached_symbols = self.cache.cached_symbols.lock().clone();
+        let query = query.to_string();
+
+        cx.spawn(async move |_, cx| {
+            if cached_symbols.is_empty() {
+                return Vec::new();
+            }
+
+            let candidates: Vec<StringMatchCandidate> = cached_symbols
+                .iter()
+                .enumerate()
+                .map(|(id, entry)| {
+                    let name = match entry {
+                        SymbolEntry::Workspace(s) => s.label.filter_text().to_string(),
+                        SymbolEntry::Outline { name, .. } => name.clone(),
+                    };
+                    StringMatchCandidate::new(id, &name)
+                })
+                .collect();
+
+            let matches = fuzzy::match_strings(
+                &candidates,
+                &query,
+                false,
+                true,
+                100,
+                &Default::default(),
+                cx.background_executor().clone(),
+            )
+            .await;
+
+            matches
+                .into_iter()
+                .filter_map(|m| {
+                    let entry = cached_symbols.get(m.candidate_id)?;
+
+                    let result = match entry {
+                        SymbolEntry::Workspace(symbol) => {
+                            let label = symbol.label.text.clone();
+                            let detail = symbol.label.filter_text().to_string();
+                            SearchResult {
+                                label: SharedString::from(label),
+                                detail: Some(SharedString::from(detail)),
+                                category: SearchResultCategory::Symbol,
+                                path: None,
+                                action: None,
+                                symbol: Some(symbol.clone()),
+                                document_symbol: None,
+                            }
+                        }
+                        SymbolEntry::Outline {
+                            name,
+                            path,
+                            buffer,
+                            range,
+                        } => SearchResult {
+                            label: SharedString::from(name.clone()),
+                            detail: Some(SharedString::from(path.clone())),
+                            category: SearchResultCategory::Symbol,
+                            path: None,
+                            action: None,
+                            symbol: None,
+                            document_symbol: Some(DocumentSymbolResult {
+                                buffer: buffer.clone(),
+                                range: range.clone(),
+                            }),
+                        },
+                    };
+
+                    Some((result, m))
+                })
+                .collect()
+        })
+    }
+}

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -124,6 +124,7 @@ reqwest.workspace = true
 reqwest_client.workspace = true
 rope.workspace = true
 search.workspace = true
+search_everywhere.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 session.workspace = true

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -613,6 +613,7 @@ pub fn main() {
 
         go_to_line::init(cx);
         file_finder::init(cx);
+        search_everywhere::init(cx);
         tab_switcher::init(cx);
         outline::init(cx);
         project_symbols::init(cx);

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -4769,6 +4769,7 @@ mod tests {
                 "repl",
                 "rules_library",
                 "search",
+                "search_everywhere",
                 "settings_editor",
                 "settings_profile_selector",
                 "snippets",


### PR DESCRIPTION
## Summary

Implements a unified "Search Everywhere" modal (similar to JetBrains' Shift+Shift) that allows users to search across files, symbols, and actions from a single interface.

- **File search** using fuzzy matching across all project files
- **Symbol search** using Tree-sitter outlines (works for all languages, not just LSP-supported ones)
- **Action search** from the command palette
- Tab filtering to narrow results (All, Files, Symbols, Actions)
- Project-wide symbol indexing with progress percentage indicator
- Global symbol cache persisted across modal open/close (avoids re-indexing)
- File path display for each symbol result
- Keyboard shortcut display for actions
- Respects .gitignore for file indexing

**Keybindings:**
- All platforms: `Shift Shift` (double-tap shift key)
- Custom keymap action: `search_everywhere::Toggle`

## Test Plan

- [ ] Open Search Everywhere with double shift
- [ ] Verify file search returns fuzzy-matched results
- [ ] Verify symbol search indexes project and shows progress %
- [ ] Verify symbols show file path in detail
- [ ] Verify actions show keyboard shortcuts
- [ ] Verify tab filtering works (All/Files/Symbols/Actions)
- [ ] Verify selecting a file opens it
- [ ] Verify selecting a symbol navigates to it
- [ ] Verify selecting an action executes it
- [ ] Close and reopen modal - verify cache persists (no re-indexing)

## Release Notes

- Added Search Everywhere feature (`Shift Shift` on all platforms): a unified search modal that combines file search, symbol search, and action search in one interface with tab filtering