### PR TITLE
assistant_slash_commands: Fix text threads not listing files on windows correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -835,7 +835,6 @@ dependencies = [
  "fs",
  "futures 0.3.31",
  "fuzzy",
- "globset",
  "gpui",
  "html_to_markdown",
  "http_client",

--- a/crates/assistant_slash_commands/Cargo.toml
+++ b/crates/assistant_slash_commands/Cargo.toml
@@ -22,7 +22,6 @@ feature_flags.workspace = true
 fs.workspace = true
 futures.workspace = true
 fuzzy.workspace = true
-globset.workspace = true
 gpui.workspace = true
 html_to_markdown.workspace = true
 http_client.workspace = true


### PR DESCRIPTION
This copy of the path matcher is broken since the relpath changes I believe. Swapping it out with the newer one makes it work again on windows. This copy of the matcher does a bunch of trailing slash checks, which will no longer do anything as rel paths do not store trailing slashes.

Closes https://github.com/zed-industries/zed/issues/41242

Release Notes:

- N/A *or* Added/Fixed/Improved ...
