### PR TITLE
git_ui: Fix commit and amend not working via keybinds in commit modal

### DIFF
--- a/crates/git_ui/src/commit_modal.rs
+++ b/crates/git_ui/src/commit_modal.rs
@@ -493,20 +493,19 @@ impl CommitModal {
     }
 
     fn on_commit(&mut self, _: &git::Commit, window: &mut Window, cx: &mut Context<Self>) {
-        if self
-            .git_panel
-            .update(cx, |git_panel, cx| git_panel.commit(window, cx))
-        {
+        println!("sdfsdf");
+        if self.git_panel.update(cx, |git_panel, cx| {
+            git_panel.commit(&self.commit_editor.focus_handle(cx), window, cx)
+        }) {
             telemetry::event!("Git Committed", source = "Git Modal");
             cx.emit(DismissEvent);
         }
     }
 
     fn on_amend(&mut self, _: &git::Amend, window: &mut Window, cx: &mut Context<Self>) {
-        if self
-            .git_panel
-            .update(cx, |git_panel, cx| git_panel.amend(window, cx))
-        {
+        if self.git_panel.update(cx, |git_panel, cx| {
+            git_panel.amend(&self.commit_editor.focus_handle(cx), window, cx)
+        }) {
             telemetry::event!("Git Amended", source = "Git Modal");
             cx.emit(DismissEvent);
         }

--- a/crates/git_ui/src/commit_modal.rs
+++ b/crates/git_ui/src/commit_modal.rs
@@ -493,7 +493,6 @@ impl CommitModal {
     }
 
     fn on_commit(&mut self, _: &git::Commit, window: &mut Window, cx: &mut Context<Self>) {
-        println!("sdfsdf");
         if self.git_panel.update(cx, |git_panel, cx| {
             git_panel.commit(&self.commit_editor.focus_handle(cx), window, cx)
         }) {

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1935,7 +1935,7 @@ impl GitPanel {
     }
 
     fn on_commit(&mut self, _: &git::Commit, window: &mut Window, cx: &mut Context<Self>) {
-        if self.commit(window, cx) {
+        if self.commit(&self.commit_editor.focus_handle(cx), window, cx) {
             telemetry::event!("Git Committed", source = "Git Panel");
         }
     }
@@ -1943,16 +1943,17 @@ impl GitPanel {
     /// Commits staged changes with the current commit message.
     ///
     /// Returns `true` if the commit was executed, `false` otherwise.
-    pub(crate) fn commit(&mut self, window: &mut Window, cx: &mut Context<Self>) -> bool {
+    pub(crate) fn commit(
+        &mut self,
+        commit_editor_focus_handle: &FocusHandle,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> bool {
         if self.amend_pending {
             return false;
         }
 
-        if self
-            .commit_editor
-            .focus_handle(cx)
-            .contains_focused(window, cx)
-        {
+        if commit_editor_focus_handle.contains_focused(window, cx) {
             self.commit_changes(
                 CommitOptions {
                     amend: false,
@@ -1969,7 +1970,7 @@ impl GitPanel {
     }
 
     fn on_amend(&mut self, _: &git::Amend, window: &mut Window, cx: &mut Context<Self>) {
-        if self.amend(window, cx) {
+        if self.amend(&self.commit_editor.focus_handle(cx), window, cx) {
             telemetry::event!("Git Amended", source = "Git Panel");
         }
     }
@@ -1979,12 +1980,13 @@ impl GitPanel {
     /// Uses a two-stage workflow where the first invocation loads the commit
     /// message for editing, second invocation performs the amend. Returns
     /// `true` if the amend was executed, `false` otherwise.
-    pub(crate) fn amend(&mut self, window: &mut Window, cx: &mut Context<Self>) -> bool {
-        if self
-            .commit_editor
-            .focus_handle(cx)
-            .contains_focused(window, cx)
-        {
+    pub(crate) fn amend(
+        &mut self,
+        commit_editor_focus_handle: &FocusHandle,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        if commit_editor_focus_handle.contains_focused(window, cx) {
             if self.head_commit(cx).is_some() {
                 if !self.amend_pending {
                     self.set_amend_pending(true, cx);


### PR DESCRIPTION
Closes #41567

We were using the git panel editor to check the focus where the commit modal has its only editor.

Release Notes:

- Fixed an issue where commit and amend actions wouldn’t trigger when using keybinds in the commit modal.