### PR TITLE
Move servers back from the background thread

### DIFF
--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -516,8 +516,7 @@ impl Copilot {
                 None,
                 Default::default(),
                 cx,
-            )
-            .await?;
+            )?;
 
             server
                 .on_notification::<StatusNotification, _>(|_, _| { /* Silence the notification */ })

--- a/crates/prettier/src/prettier.rs
+++ b/crates/prettier/src/prettier.rs
@@ -320,7 +320,6 @@ impl Prettier {
             Default::default(),
             &mut cx,
         )
-        .await
         .context("prettier server creation")?;
 
         let server = cx

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -425,7 +425,6 @@ impl LocalLspStore {
                     Some(pending_workspace_folders),
                     cx,
                 )
-                .await
             }
         });
 


### PR DESCRIPTION
Partial revert of https://github.com/zed-industries/zed/pull/44631

With this and `sccache` enabled, I get 
<img width="3456" height="1096" alt="image" src="https://github.com/user-attachments/assets/937760fb-8b53-49f8-ae63-4df1d31b292b" />

and r-a infinitely hangs waiting on this.

Release Notes:

- N/A
