### PR TITLE
remote: Remove unnecessary and incorrect single quote in `MasterProcess`

### DIFF
--- a/crates/remote/src/transport/ssh.rs
+++ b/crates/remote/src/transport/ssh.rs
@@ -116,7 +116,7 @@ impl MasterProcess {
             .args(additional_args)
             .args(args);
 
-        master_process.arg(format!("ControlPath='{}'", socket_path.display()));
+        master_process.arg(format!("ControlPath={}", socket_path.display()));
 
         let process = master_process.arg(&url).spawn()?;
 


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/43992

Release Notes:

- Fixed remoting not working on some linux and mac systems
