### PR TITLE
edit prediction cli: Progress output cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5201,7 +5201,6 @@ dependencies = [
  "wasmtime",
  "watch",
  "zeta_prompt",
- "zlog",
 ]
 
 [[package]]

--- a/crates/edit_prediction_cli/Cargo.toml
+++ b/crates/edit_prediction_cli/Cargo.toml
@@ -56,7 +56,6 @@ watch.workspace = true
 edit_prediction = { workspace = true, features = ["cli-support"] }
 wasmtime.workspace = true
 zeta_prompt.workspace = true
-zlog.workspace = true
 
 # Wasmtime is included as a dependency in order to enable the same
 # features that are enabled in Zed.

--- a/crates/edit_prediction_cli/src/format_prompt.rs
+++ b/crates/edit_prediction_cli/src/format_prompt.rs
@@ -18,12 +18,11 @@ pub async fn run_format_prompt(
     example: &mut Example,
     prompt_format: PromptFormat,
     app_state: Arc<EpAppState>,
-    progress: Arc<Progress>,
     mut cx: AsyncApp,
 ) {
-    run_context_retrieval(example, app_state.clone(), progress.clone(), cx.clone()).await;
+    run_context_retrieval(example, app_state.clone(), cx.clone()).await;
 
-    let _step_progress = progress.start(Step::FormatPrompt, &example.name);
+    let _step_progress = Progress::global().start(Step::FormatPrompt, &example.name);
 
     match prompt_format {
         PromptFormat::Teacher => {
@@ -35,7 +34,7 @@ pub async fn run_format_prompt(
             });
         }
         PromptFormat::Zeta2 => {
-            run_load_project(example, app_state, progress.clone(), cx.clone()).await;
+            run_load_project(example, app_state, cx.clone()).await;
 
             let ep_store = cx
                 .update(|cx| EditPredictionStore::try_global(cx).unwrap())

--- a/crates/edit_prediction_cli/src/load_project.rs
+++ b/crates/edit_prediction_cli/src/load_project.rs
@@ -25,17 +25,12 @@ use std::{
 use util::{paths::PathStyle, rel_path::RelPath};
 use zeta_prompt::CURSOR_MARKER;
 
-pub async fn run_load_project(
-    example: &mut Example,
-    app_state: Arc<EpAppState>,
-    progress: Arc<Progress>,
-    mut cx: AsyncApp,
-) {
+pub async fn run_load_project(example: &mut Example, app_state: Arc<EpAppState>, mut cx: AsyncApp) {
     if example.state.is_some() {
         return;
     }
 
-    let progress = progress.start(Step::LoadProject, &example.name);
+    let progress = Progress::global().start(Step::LoadProject, &example.name);
 
     let project = setup_project(example, &app_state, &progress, &mut cx).await;
 

--- a/crates/edit_prediction_cli/src/load_project.rs
+++ b/crates/edit_prediction_cli/src/load_project.rs
@@ -149,7 +149,7 @@ async fn cursor_position(
 async fn setup_project(
     example: &mut Example,
     app_state: &Arc<EpAppState>,
-    step_progress: &Arc<StepProgress>,
+    step_progress: &StepProgress,
     cx: &mut AsyncApp,
 ) -> Entity<Project> {
     let ep_store = cx
@@ -227,7 +227,7 @@ async fn setup_project(
     project
 }
 
-async fn setup_worktree(example: &Example, step_progress: &Arc<StepProgress>) -> PathBuf {
+async fn setup_worktree(example: &Example, step_progress: &StepProgress) -> PathBuf {
     let (repo_owner, repo_name) = example.repo_name().expect("failed to get repo name");
     let repo_dir = REPOS_DIR.join(repo_owner.as_ref()).join(repo_name.as_ref());
     let worktree_path = WORKTREES_DIR

--- a/crates/edit_prediction_cli/src/main.rs
+++ b/crates/edit_prediction_cli/src/main.rs
@@ -32,7 +32,7 @@ use crate::score::run_scoring;
 struct EpArgs {
     #[arg(long, default_value_t = false)]
     printenv: bool,
-    #[clap(long, default_value_t = 10)]
+    #[clap(long, default_value_t = 10, global = true)]
     max_parallelism: usize,
     #[command(subcommand)]
     command: Option<Command>,

--- a/crates/edit_prediction_cli/src/main.rs
+++ b/crates/edit_prediction_cli/src/main.rs
@@ -112,8 +112,6 @@ impl EpArgs {
 }
 
 fn main() {
-    let _ = zlog::try_init(Some("error".into()));
-    zlog::init_output_stderr();
     let args = EpArgs::parse();
 
     if args.printenv {
@@ -152,7 +150,7 @@ fn main() {
             };
 
             let total_examples = examples.len();
-            let progress = Progress::new(total_examples);
+            Progress::global().set_total_examples(total_examples);
 
             let mut grouped_examples = group_examples_by_repo(&mut examples);
             let example_batches = grouped_examples.chunks_mut(args.max_parallelism);
@@ -163,29 +161,16 @@ fn main() {
                         match &command {
                             Command::ParseExample => {}
                             Command::LoadProject => {
-                                run_load_project(
-                                    example,
-                                    app_state.clone(),
-                                    progress.clone(),
-                                    cx.clone(),
-                                )
-                                .await;
+                                run_load_project(example, app_state.clone(), cx.clone()).await;
                             }
                             Command::Context => {
-                                run_context_retrieval(
-                                    example,
-                                    app_state.clone(),
-                                    progress.clone(),
-                                    cx.clone(),
-                                )
-                                .await;
+                                run_context_retrieval(example, app_state.clone(), cx.clone()).await;
                             }
                             Command::FormatPrompt(args) => {
                                 run_format_prompt(
                                     example,
                                     args.prompt_format,
                                     app_state.clone(),
-                                    progress.clone(),
                                     cx.clone(),
                                 )
                                 .await;
@@ -196,7 +181,6 @@ fn main() {
                                     Some(args.provider),
                                     args.repetitions,
                                     app_state.clone(),
-                                    progress.clone(),
                                     cx.clone(),
                                 )
                                 .await;
@@ -205,14 +189,7 @@ fn main() {
                                 run_distill(example).await;
                             }
                             Command::Score(args) | Command::Eval(args) => {
-                                run_scoring(
-                                    example,
-                                    &args,
-                                    app_state.clone(),
-                                    progress.clone(),
-                                    cx.clone(),
-                                )
-                                .await;
+                                run_scoring(example, &args, app_state.clone(), cx.clone()).await;
                             }
                             Command::Clean => {
                                 unreachable!()
@@ -222,7 +199,7 @@ fn main() {
                 });
                 futures::future::join_all(futures).await;
             }
-            progress.clear();
+            Progress::global().clear();
 
             if args.output.is_some() || !matches!(command, Command::Eval(_)) {
                 write_examples(&examples, output.as_ref());

--- a/crates/edit_prediction_cli/src/retrieve_context.rs
+++ b/crates/edit_prediction_cli/src/retrieve_context.rs
@@ -25,7 +25,7 @@ pub async fn run_context_retrieval(
 
     run_load_project(example, app_state.clone(), progress.clone(), cx.clone()).await;
 
-    let step_progress = progress.start(Step::Context, &example.name);
+    let step_progress: Arc<StepProgress> = progress.start(Step::Context, &example.name).into();
 
     let state = example.state.as_ref().unwrap();
     let project = state.project.clone();

--- a/crates/edit_prediction_cli/src/retrieve_context.rs
+++ b/crates/edit_prediction_cli/src/retrieve_context.rs
@@ -16,16 +16,17 @@ use std::time::Duration;
 pub async fn run_context_retrieval(
     example: &mut Example,
     app_state: Arc<EpAppState>,
-    progress: Arc<Progress>,
     mut cx: AsyncApp,
 ) {
     if example.context.is_some() {
         return;
     }
 
-    run_load_project(example, app_state.clone(), progress.clone(), cx.clone()).await;
+    run_load_project(example, app_state.clone(), cx.clone()).await;
 
-    let step_progress: Arc<StepProgress> = progress.start(Step::Context, &example.name).into();
+    let step_progress: Arc<StepProgress> = Progress::global()
+        .start(Step::Context, &example.name)
+        .into();
 
     let state = example.state.as_ref().unwrap();
     let project = state.project.clone();

--- a/crates/edit_prediction_cli/src/score.rs
+++ b/crates/edit_prediction_cli/src/score.rs
@@ -14,7 +14,6 @@ pub async fn run_scoring(
     example: &mut Example,
     args: &PredictArgs,
     app_state: Arc<EpAppState>,
-    progress: Arc<Progress>,
     cx: AsyncApp,
 ) {
     run_prediction(
@@ -22,12 +21,11 @@ pub async fn run_scoring(
         Some(args.provider),
         args.repetitions,
         app_state,
-        progress.clone(),
         cx,
     )
     .await;
 
-    let _progress = progress.start(Step::Score, &example.name);
+    let _progress = Progress::global().start(Step::Score, &example.name);
 
     let expected_patch = parse_patch(&example.expected_patch);
 


### PR DESCRIPTION
- Limit status lines to 10 in case `max_parallelism` is specified with a grater value
- Handle logging gracefully rather than writing over it when clearing status lines

Release Notes:

- N/A 
