### PR TITLE
Add `keyword.import` capture to Python syntax highlighting

### DIFF
--- a/crates/languages/src/python/highlights.scm
+++ b/crates/languages/src/python/highlights.scm
@@ -245,7 +245,6 @@
 ] @keyword.operator
 
 [
-  "as"
   "assert"
   "async"
   "await"
@@ -260,10 +259,8 @@
   "exec"
   "finally"
   "for"
-  "from"
   "global"
   "if"
-  "import"
   "lambda"
   "nonlocal"
   "pass"
@@ -277,6 +274,14 @@
   "match"
   "case"
 ] @keyword
+
+[
+  "from"
+  "as"
+  "import"
+]
+@keyword.import
+
 
 ; Definition keywords def, class, async def, lambda
 [


### PR DESCRIPTION
Improve Python syntax highlighting with granular theme customization support. Related to #9461

Release Notes:

- Added support for 'keyword.import' in Python syntax highlighting.
- Users can now customize the color of 'import', 'from', and 'as' keywords via theme_overrides independently of other keywords.
<img width="613" height="258" alt="before" src="https://github.com/user-attachments/assets/955b5518-6b36-4775-909d-0964c8aea686" />
<img width="577" height="256" alt="after" src="https://github.com/user-attachments/assets/a6b2beed-96c0-456a-9043-6e25b10ef0f2" />
<img width="298" height="129" alt="keyword" src="https://github.com/user-attachments/assets/ddeda01f-01d1-4d48-8fe7-3a699eb816ef" />
