### PR TITLE
Add angled bracket highlighting for C++

### DIFF
--- a/crates/languages/src/cpp/brackets.scm
+++ b/crates/languages/src/cpp/brackets.scm
@@ -1,5 +1,6 @@
 ("(" @open ")" @close)
 ("[" @open "]" @close)
 ("{" @open "}" @close)
+("<" @open ">" @close)
 (("\"" @open "\"" @close) (#set! rainbow.exclude))
 (("'" @open "'" @close) (#set! rainbow.exclude))


### PR DESCRIPTION
Enables rainbow bracket highlighting for angle brackets (< >) in C++.

<img width="401" height="46" alt="image" src="https://github.com/user-attachments/assets/169afdaa-c8be-4b78-bf64-9cf08787eb47" />


Release Notes:

- Added rainbow bracket coloring for C++ angle brackets (`<>`)

