### PR TITLE
git_ui: Fix file history view doesn't be tracked focus

### DIFF
--- a/crates/git_ui/src/file_history_view.rs
+++ b/crates/git_ui/src/file_history_view.rs
@@ -380,6 +380,7 @@ impl Render for FileHistoryView {
         let entry_count = self.history.entries.len();
 
         v_flex()
+            .track_focus(&self.focus_handle)
             .size_full()
             .bg(cx.theme().colors().editor_background)
             .child(


### PR DESCRIPTION
Closes #44581

Release Notes:

- Fixed the file history view can't use any shortcut keys.