### PR TITLE
Fix dock panel button tooltip not dismissed when state changes via keyboard shortcut

### DIFF
--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -941,7 +941,14 @@ impl Render for PanelButtons {
                         .anchor(menu_anchor)
                         .attach(menu_attach)
                         .trigger(move |is_active, _window, _cx| {
-                            IconButton::new(name, icon)
+                            // Include active state in element ID to invalidate the cached
+                            // tooltip when panel state changes (e.g., via keyboard shortcut)
+                            let button_id = if is_active_button {
+                                ElementId::Name(format!("{}-active", name).into())
+                            } else {
+                                ElementId::Name(name.into())
+                            };
+                            IconButton::new(button_id, icon)
                                 .icon_size(IconSize::Small)
                                 .toggle_state(is_active_button)
                                 .on_click({

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -943,12 +943,7 @@ impl Render for PanelButtons {
                         .trigger(move |is_active, _window, _cx| {
                             // Include active state in element ID to invalidate the cached
                             // tooltip when panel state changes (e.g., via keyboard shortcut)
-                            let button_id = if is_active_button {
-                                ElementId::Name(format!("{}-active", name).into())
-                            } else {
-                                ElementId::Name(name.into())
-                            };
-                            IconButton::new(button_id, icon)
+                            IconButton::new((name, is_active_button as u64), icon)
                                 .icon_size(IconSize::Small)
                                 .toggle_state(is_active_button)
                                 .on_click({


### PR DESCRIPTION
Closes #44720

Release Notes:

- Fixed dock panel button tooltips not being dismissed when toggling panels via keyboard shortcut




**Problem:** When hovering over a dock panel button and using a keyboard shortcut to toggle the panel, the tooltip remains visible with stale content. This is inconsistent with mouse click behavior, where the tooltip is dismissed on mouse down.

**Solution:** Include the panel's active state in the button's element ID. When the state changes, the element ID changes (e.g., `"DebugPanel"` → `"DebugPanel-active"`), which causes GPUI to discard the old element state including the cached tooltip.

**Testing:** Manually verified:
1. Hover over a dock panel button, wait for tooltip
2. Press keyboard shortcut to toggle the panel
3. Tooltip is now dismissed (consistent with mouse click behavior)

https://github.com/user-attachments/assets/ed92fb6c-6c22-44e2-87e3-5461d35f7106
