### PR TITLE
ui: Improve focused border color consistency across panels

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -4813,7 +4813,7 @@ impl GitPanel {
             .items_center()
             .border_1()
             .when(selected && self.focus_handle.is_focused(window), |el| {
-                el.border_color(cx.theme().colors().border_focused)
+                el.border_color(cx.theme().colors().panel_focused_border)
             })
             .px(rems(0.75)) // ~12px
             .overflow_hidden()
@@ -4977,7 +4977,7 @@ impl GitPanel {
             .items_center()
             .border_1()
             .when(selected && self.focus_handle.is_focused(window), |el| {
-                el.border_color(cx.theme().colors().border_focused)
+                el.border_color(cx.theme().colors().panel_focused_border)
             })
             .px(rems(0.75))
             .overflow_hidden()

--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -2610,7 +2610,7 @@ impl OutlinePanel {
             })
             .when(
                 is_active && self.focus_handle.contains_focused(window, cx),
-                |div| div.border_color(Color::Selected.color(cx)),
+                |div| div.border_color(cx.theme().colors().panel_focused_border),
             )
     }
 


### PR DESCRIPTION
The issue is that we aren't consistent in using the same `panel_focus_border` color across zed. 
Might completely fix my issue: #44750 

For focused items in: 
- outline panel
- git panel

While these: 
- project panel
- keymap editor tab

Are actually using the panel_focused_border option. 

Not sure if this warrants a release note, feel free to adapt. 

Release Notes:

- N/A
