### PR TITLE
vim: Fix global mark overwriting inconsistency

### DIFF
--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -550,6 +550,10 @@ impl MarksState {
         let buffer = multibuffer.read(cx).as_singleton();
         let abs_path = buffer.as_ref().and_then(|b| self.path_for_buffer(b, cx));
 
+        if self.is_global_mark(&name) && self.global_marks.contains_key(&name) {
+            self.delete_mark(name.clone(), multibuffer, cx);
+        }
+
         let Some(abs_path) = abs_path else {
             self.multibuffer_marks
                 .entry(multibuffer.entity_id())
@@ -573,7 +577,7 @@ impl MarksState {
 
         let buffer_id = buffer.read(cx).remote_id();
         self.buffer_marks.entry(buffer_id).or_default().insert(
-            name,
+            name.clone(),
             anchors
                 .into_iter()
                 .map(|anchor| anchor.text_anchor)
@@ -581,6 +585,10 @@ impl MarksState {
         );
         if !self.watched_buffers.contains_key(&buffer_id) {
             self.watch_buffer(MarkLocation::Path(abs_path.clone()), &buffer, cx)
+        }
+        if self.is_global_mark(&name) {
+            self.global_marks
+                .insert(name, MarkLocation::Path(abs_path.clone()));
         }
         self.serialize_buffer_marks(abs_path, &buffer, cx)
     }


### PR DESCRIPTION
Closes #43963

This issue was caused by the global marks not being deleted. Previously marking the first file `m A`

<img width="1736" height="888" alt="Screenshot From 2025-12-13 01-37-55" src="https://github.com/user-attachments/assets/9e46747f-7bb3-4297-82d4-44a20ef9e91a" />

followed by marking the second file `m A`

<img width="1736" height="888" alt="Screenshot From 2025-12-13 01-37-42" src="https://github.com/user-attachments/assets/0d126b47-2c42-475f-826a-173c0d5a1156" />

and navigating back to the first file

<img width="1736" height="888" alt="Screenshot From 2025-12-13 01-37-30" src="https://github.com/user-attachments/assets/032fd0bd-ff71-4a12-987a-7f1743016f6d" />

shows that the mark still exists and was not properly deleted. After these changes the global mark in the original file is correctly overwritten.

Added regression test for this.

Release Notes:

- Fixed bug where overwriting global Vim marks was inconsistent
