### PR TITLE
editor: Add smooth cursor animation

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -200,6 +200,13 @@
   "use_system_prompts": true,
   // Whether the cursor blinks in the editor.
   "cursor_blink": true,
+  // Enable smooth cursor animation.
+  "smooth_caret": false,
+  // Cursor visual effects (particle animations).
+  // Available modes: "none", "sonicboom"
+  "cursor_vfx": {
+    "mode": "none"
+  },
   // Cursor shape for the default editor.
   //  1. A vertical bar
   //     "bar"

--- a/crates/editor/src/blink_manager.rs
+++ b/crates/editor/src/blink_manager.rs
@@ -1,7 +1,9 @@
 use gpui::Context;
 use settings::SettingsStore;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use ui::App;
+
+const SMOOTH_BLINK_FADE_DURATION_MS: f32 = 150.0;
 
 pub struct BlinkManager {
     blink_interval: Duration,
@@ -14,6 +16,14 @@ pub struct BlinkManager {
     enabled: bool,
     /// Whether the blinking is enabled in the settings.
     blink_enabled_in_settings: fn(&App) -> bool,
+    /// Whether smooth blink transitions are enabled.
+    smooth_blink_enabled: bool,
+    /// Current opacity for smooth blink transitions (0.0-1.0).
+    current_opacity: f32,
+    /// Target opacity for smooth blink transitions.
+    target_opacity: f32,
+    /// Last update time for smooth blink interpolation.
+    last_smooth_blink_update: Option<Instant>,
 }
 
 impl BlinkManager {
@@ -35,7 +45,43 @@ impl BlinkManager {
             visible: true,
             enabled: false,
             blink_enabled_in_settings,
+            smooth_blink_enabled: false,
+            current_opacity: 1.0,
+            target_opacity: 1.0,
+            last_smooth_blink_update: None,
         }
+    }
+
+    pub fn set_smooth_blink_enabled(&mut self, enabled: bool) {
+        self.smooth_blink_enabled = enabled;
+        self.current_opacity = if self.visible { 1.0 } else { 0.0 };
+        self.target_opacity = self.current_opacity;
+        self.last_smooth_blink_update = None;
+    }
+
+    pub fn opacity(&mut self, cx: &mut Context<Self>) -> f32 {
+        if !self.smooth_blink_enabled {
+            return if self.visible { 1.0 } else { 0.0 };
+        }
+
+        let now = Instant::now();
+        if let Some(last_update) = self.last_smooth_blink_update {
+            let dt_ms = now.duration_since(last_update).as_secs_f32() * 1000.0;
+            let blend_factor = (dt_ms / SMOOTH_BLINK_FADE_DURATION_MS).clamp(0.0, 1.0);
+
+            let new_opacity =
+                self.current_opacity + (self.target_opacity - self.current_opacity) * blend_factor;
+            if (new_opacity - self.current_opacity).abs() > 0.001 {
+                self.current_opacity = new_opacity;
+                cx.notify();
+            }
+        }
+        self.last_smooth_blink_update = Some(now);
+        self.current_opacity
+    }
+
+    pub fn is_smooth_blink_animating(&self) -> bool {
+        self.smooth_blink_enabled && (self.current_opacity - self.target_opacity).abs() > 0.01
     }
 
     fn next_blink_epoch(&mut self) -> usize {
@@ -43,8 +89,11 @@ impl BlinkManager {
         self.blink_epoch
     }
 
-    pub fn pause_blinking(&mut self, cx: &mut Context<Self>) {
+    /// Reset blink state after a logical cursor move.
+    /// Cursor becomes visible immediately and blinking resumes after a short pause.
+    pub fn cursor_moved(&mut self, cx: &mut Context<Self>) {
         self.show_cursor(cx);
+        self.blinking_paused = true;
 
         let epoch = self.next_blink_epoch();
         let interval = Duration::from_millis(500);
@@ -55,10 +104,22 @@ impl BlinkManager {
         .detach();
     }
 
+    pub fn pause_blinking(&mut self, cx: &mut Context<Self>) {
+        self.cursor_moved(cx);
+    }
+
     fn resume_cursor_blinking(&mut self, epoch: usize, cx: &mut Context<Self>) {
         if epoch == self.blink_epoch {
             self.blinking_paused = false;
-            self.blink_cursors(epoch, cx);
+            self.show_cursor(cx);
+            let interval = self.blink_interval;
+            cx.spawn(async move |this, cx| {
+                cx.background_executor().timer(interval).await;
+                if let Some(this) = this.upgrade() {
+                    this.update(cx, |this, cx| this.blink_cursors(epoch, cx));
+                }
+            })
+            .detach();
         }
     }
 
@@ -66,6 +127,7 @@ impl BlinkManager {
         if (self.blink_enabled_in_settings)(cx) {
             if epoch == self.blink_epoch && self.enabled && !self.blinking_paused {
                 self.visible = !self.visible;
+                self.target_opacity = if self.visible { 1.0 } else { 0.0 };
                 cx.notify();
 
                 let epoch = self.next_blink_epoch();
@@ -84,10 +146,13 @@ impl BlinkManager {
     }
 
     pub fn show_cursor(&mut self, cx: &mut Context<BlinkManager>) {
-        if !self.visible {
-            self.visible = true;
-            cx.notify();
+        self.visible = true;
+        self.target_opacity = 1.0;
+        if self.smooth_blink_enabled {
+            self.current_opacity = 1.0;
+            self.last_smooth_blink_update = None;
         }
+        cx.notify();
     }
 
     /// Enable the blinking of the cursor.
@@ -100,6 +165,7 @@ impl BlinkManager {
         // Set cursors as invisible and start blinking: this causes cursors
         // to be visible during the next render.
         self.visible = false;
+        self.target_opacity = 0.0;
         self.blink_cursors(self.blink_epoch, cx);
     }
 
@@ -107,9 +173,44 @@ impl BlinkManager {
     pub fn disable(&mut self, _cx: &mut Context<Self>) {
         self.visible = false;
         self.enabled = false;
+        self.target_opacity = 0.0;
+        if !self.smooth_blink_enabled {
+            self.current_opacity = 0.0;
+        }
     }
 
     pub fn visible(&self) -> bool {
         self.visible
+    }
+
+    pub fn should_render(&self) -> bool {
+        if self.smooth_blink_enabled {
+            self.visible || self.is_smooth_blink_animating()
+        } else {
+            self.visible
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpui::{AppContext, TestAppContext};
+
+    #[gpui::test]
+    async fn cursor_move_forces_cursor_visible_immediately(cx: &mut TestAppContext) {
+        let blink_manager =
+            cx.new(|cx| BlinkManager::new(Duration::from_millis(500), |_| true, cx));
+
+        blink_manager.update(cx, |blink_manager: &mut BlinkManager, cx| {
+            blink_manager.disable(cx);
+            blink_manager.set_smooth_blink_enabled(true);
+
+            assert_eq!(blink_manager.opacity(cx), 0.0);
+            blink_manager.cursor_moved(cx);
+            assert_eq!(blink_manager.opacity(cx), 1.0);
+            assert!(blink_manager.should_render());
+            assert!(!blink_manager.is_smooth_blink_animating());
+        });
     }
 }

--- a/crates/editor/src/cursor_vfx.rs
+++ b/crates/editor/src/cursor_vfx.rs
@@ -1,0 +1,237 @@
+use std::time::{Duration, Instant};
+
+use gpui::{Bounds, Hsla, Pixels, Point, Window, point, size};
+
+use crate::editor_settings::CursorVfx;
+
+/// Cursor visual effect mode.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub enum CursorVfxMode {
+    /// No visual effects
+    #[default]
+    None,
+    /// Burst effect at cursor stop point
+    Sonicboom,
+}
+
+const DEFAULT_OPACITY: f32 = 200.0;
+const DEFAULT_HIGHLIGHT_LIFETIME: f32 = 0.2;
+
+#[derive(Debug, Clone)]
+pub struct CursorVfxConfig {
+    pub mode: CursorVfxMode,
+    pub opacity: f32,
+    pub highlight_lifetime: Duration,
+}
+
+impl Default for CursorVfxConfig {
+    fn default() -> Self {
+        Self {
+            mode: CursorVfxMode::None,
+            opacity: DEFAULT_OPACITY,
+            highlight_lifetime: Duration::from_secs_f32(DEFAULT_HIGHLIGHT_LIFETIME),
+        }
+    }
+}
+
+impl CursorVfxConfig {
+    pub fn is_enabled(&self) -> bool {
+        self.mode != CursorVfxMode::None
+    }
+
+    pub fn from_runtime_settings(settings: &CursorVfx) -> Self {
+        Self {
+            mode: settings.mode,
+            ..Default::default()
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct HighlightEffect {
+    center: Point<Pixels>,
+    birth: Instant,
+    lifetime: Duration,
+    base_opacity: f32,
+    mode: CursorVfxMode,
+}
+
+impl HighlightEffect {
+    fn new(center: Point<Pixels>, lifetime: Duration, opacity: f32, mode: CursorVfxMode) -> Self {
+        Self {
+            center,
+            birth: Instant::now(),
+            lifetime,
+            base_opacity: opacity,
+            mode,
+        }
+    }
+
+    fn normalized_age(&self) -> f32 {
+        let lifetime_secs = self.lifetime.as_secs_f32();
+        if lifetime_secs == 0.0 {
+            return 1.0;
+        }
+        (self.birth.elapsed().as_secs_f32() / lifetime_secs).min(1.0)
+    }
+
+    fn is_alive(&self) -> bool {
+        self.birth.elapsed() < self.lifetime
+    }
+}
+
+#[derive(Debug)]
+pub struct CursorVfxSystem {
+    config: CursorVfxConfig,
+    highlights: Vec<HighlightEffect>,
+    last_pos: Option<Point<Pixels>>,
+    was_moving: bool,
+}
+
+impl CursorVfxSystem {
+    pub fn new(config: CursorVfxConfig) -> Self {
+        Self {
+            config,
+            highlights: Vec::with_capacity(10),
+            last_pos: None,
+            was_moving: false,
+        }
+    }
+
+    pub fn set_config(&mut self, config: CursorVfxConfig) {
+        self.config = config;
+        if !self.config.is_enabled() {
+            self.highlights.clear();
+        }
+    }
+
+    pub fn is_animating(&self) -> bool {
+        !self.highlights.is_empty()
+    }
+
+    pub fn update(&mut self, cursor_pos: Point<Pixels>) {
+        if !self.config.is_enabled() {
+            return;
+        }
+
+        self.highlights.retain(|h| h.is_alive());
+
+        if let Some(last) = self.last_pos {
+            let dx = f32::from(cursor_pos.x - last.x);
+            let dy = f32::from(cursor_pos.y - last.y);
+            let distance = (dx * dx + dy * dy).sqrt();
+
+            if distance > 1.0 {
+                self.was_moving = true;
+            } else if self.was_moving {
+                self.was_moving = false;
+                self.spawn_stop_effect(cursor_pos);
+            }
+        }
+
+        self.last_pos = Some(cursor_pos);
+    }
+
+    fn spawn_stop_effect(&mut self, pos: Point<Pixels>) {
+        if self.config.mode == CursorVfxMode::Sonicboom {
+            self.highlights.push(HighlightEffect::new(
+                pos,
+                self.config.highlight_lifetime,
+                self.config.opacity / 255.0,
+                self.config.mode,
+            ));
+        }
+    }
+
+    pub fn paint(&self, origin: Point<Pixels>, window: &mut Window, color: Hsla) {
+        if !self.config.is_enabled() {
+            return;
+        }
+
+        for highlight in &self.highlights {
+            let t = highlight.normalized_age();
+            let opacity = highlight.base_opacity * (1.0 - t);
+
+            if opacity > 0.01 && highlight.mode == CursorVfxMode::Sonicboom {
+                let c = Hsla {
+                    a: color.a * opacity,
+                    ..color
+                };
+                let radius = t * 30.0;
+                self.paint_burst(highlight.center, origin, radius, c, window);
+            }
+        }
+    }
+
+    fn paint_burst(
+        &self,
+        center: Point<Pixels>,
+        origin: Point<Pixels>,
+        radius: f32,
+        color: Hsla,
+        window: &mut Window,
+    ) {
+        let pos = point(center.x + origin.x, center.y + origin.y);
+        let num_rays = 8;
+        for i in 0..num_rays {
+            let angle = (i as f32 / num_rays as f32) * std::f32::consts::TAU;
+            let end_x = pos.x + Pixels::from(angle.cos() * radius);
+            let end_y = pos.y + Pixels::from(angle.sin() * radius);
+
+            let bounds = Bounds {
+                origin: point(
+                    (pos.x + end_x) / 2.0 - Pixels::from(1.0),
+                    (pos.y + end_y) / 2.0 - Pixels::from(1.0),
+                ),
+                size: size(Pixels::from(2.0), Pixels::from(2.0)),
+            };
+            window.paint_quad(gpui::fill(bounds, color));
+        }
+    }
+
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disabled_vfx_does_nothing() {
+        let config = CursorVfxConfig::default();
+        let mut vfx = CursorVfxSystem::new(config);
+
+        vfx.update(point(Pixels::from(100.0), Pixels::from(100.0)));
+        assert!(!vfx.is_animating());
+    }
+
+    #[test]
+    fn sonicboom_spawns_on_stop() {
+        let mut config = CursorVfxConfig::default();
+        config.mode = CursorVfxMode::Sonicboom;
+        let mut vfx = CursorVfxSystem::new(config);
+
+        vfx.update(point(Pixels::from(0.0), Pixels::from(0.0)));
+        vfx.update(point(Pixels::from(100.0), Pixels::from(0.0)));
+        assert!(!vfx.is_animating());
+
+        vfx.update(point(Pixels::from(100.0), Pixels::from(0.0)));
+        assert!(vfx.is_animating());
+    }
+
+    #[test]
+    fn highlights_expire() {
+        let mut config = CursorVfxConfig::default();
+        config.mode = CursorVfxMode::Sonicboom;
+        config.highlight_lifetime = Duration::from_millis(10);
+        let mut vfx = CursorVfxSystem::new(config);
+
+        vfx.update(point(Pixels::from(0.0), Pixels::from(0.0)));
+        vfx.update(point(Pixels::from(100.0), Pixels::from(0.0)));
+        vfx.update(point(Pixels::from(100.0), Pixels::from(0.0)));
+        assert!(vfx.is_animating());
+
+        std::thread::sleep(Duration::from_millis(20));
+        vfx.update(point(Pixels::from(100.0), Pixels::from(0.0)));
+        assert!(!vfx.is_animating());
+    }
+}

--- a/crates/editor/src/cursor_vfx.rs
+++ b/crates/editor/src/cursor_vfx.rs
@@ -188,7 +188,6 @@ impl CursorVfxSystem {
             window.paint_quad(gpui::fill(bounds, color));
         }
     }
-
 }
 
 #[cfg(test)]

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1173,7 +1173,8 @@ pub struct Editor {
     blink_manager: Entity<BlinkManager>,
     quad_cursor: Option<inertial_cursor::QuadCursor>,
     cursor_animation_ticker: inertial_cursor::CursorAnimationTicker,
-    cursor_animation_destination: Option<(DisplayPoint, Pixels, Pixels)>,
+    cursor_animation_callback_generation: u64,
+    active_cursor_animation_callback_generation: Option<u64>,
     cursor_vfx_system: Option<cursor_vfx::CursorVfxSystem>,
     show_cursor_names: bool,
     hovered_cursors: HashMap<HoveredCursor, Task<()>>,
@@ -2127,6 +2128,8 @@ impl Editor {
                 |cx| EditorSettings::get_global(cx).cursor_blink,
                 cx,
             );
+            blink_manager
+                .set_smooth_blink_enabled(EditorSettings::get_global(cx).smooth_caret.smooth_blink);
             if is_minimap {
                 blink_manager.disable(cx);
             }
@@ -2480,7 +2483,8 @@ impl Editor {
                 }
             },
             cursor_animation_ticker: inertial_cursor::CursorAnimationTicker::new(),
-            cursor_animation_destination: None,
+            cursor_animation_callback_generation: 0,
+            active_cursor_animation_callback_generation: None,
             cursor_vfx_system: {
                 let vfx_settings = &EditorSettings::get_global(cx).cursor_vfx;
                 let vfx_config = cursor_vfx::CursorVfxConfig::from_runtime_settings(vfx_settings);
@@ -3372,15 +3376,22 @@ impl Editor {
         self.quad_cursor.as_mut()
     }
 
-    pub fn set_cursor_animation_destination(
-        &mut self,
-        destination: Option<(DisplayPoint, Pixels, Pixels)>,
-    ) {
-        self.cursor_animation_destination = destination;
+    pub fn begin_cursor_animation_callback_cycle(&mut self) -> u64 {
+        self.cursor_animation_callback_generation =
+            self.cursor_animation_callback_generation.wrapping_add(1);
+        let generation = self.cursor_animation_callback_generation;
+        self.active_cursor_animation_callback_generation = Some(generation);
+        generation
     }
 
-    pub fn cursor_animation_destination(&self) -> Option<(DisplayPoint, Pixels, Pixels)> {
-        self.cursor_animation_destination
+    pub fn is_active_cursor_animation_generation(&self, generation: u64) -> bool {
+        self.active_cursor_animation_callback_generation == Some(generation)
+    }
+
+    pub fn end_cursor_animation_callback_cycle(&mut self, generation: u64) {
+        if self.active_cursor_animation_callback_generation == Some(generation) {
+            self.active_cursor_animation_callback_generation = None;
+        }
     }
 
     fn build_inertial_cursor_config(
@@ -3429,15 +3440,16 @@ impl Editor {
         let steps = ((dt_secs / inertial_cursor::MAX_ANIMATION_DT).ceil() as usize).max(1);
         let dt_per_step = dt_secs / steps as f32;
 
-        let mut still_animating = false;
-
         if let Some(cursor) = &mut self.quad_cursor {
             for _ in 0..steps {
-                if cursor.update_physics(dt_per_step) {
-                    still_animating = true;
-                }
+                cursor.update_physics(dt_per_step);
             }
         }
+
+        let still_animating = self
+            .quad_cursor
+            .as_ref()
+            .is_some_and(|cursor| cursor.is_animating());
 
         if !still_animating {
             self.cursor_animation_ticker.stop();
@@ -3769,7 +3781,11 @@ impl Editor {
             }
         }
 
-        self.blink_manager.update(cx, BlinkManager::pause_blinking);
+        if old_cursor_position != &new_cursor_position {
+            self.blink_manager.update(cx, BlinkManager::cursor_moved);
+        } else {
+            self.blink_manager.update(cx, BlinkManager::pause_blinking);
+        }
 
         if local && !self.suppress_selection_callback {
             if let Some(callback) = self.on_local_selections_changed.as_ref() {
@@ -23903,7 +23919,7 @@ impl Editor {
     }
 
     pub fn show_local_cursors(&self, window: &mut Window, cx: &mut App) -> bool {
-        (self.read_only(cx) || self.blink_manager.read(cx).visible())
+        (self.read_only(cx) || self.blink_manager.read(cx).should_render())
             && self.focus_handle.is_focused(window)
     }
 
@@ -24312,6 +24328,7 @@ impl Editor {
             // Handle smooth_caret settings changes
             let new_smooth_caret_config =
                 Self::build_inertial_cursor_config(&editor_settings.smooth_caret);
+            let smooth_blink_enabled = editor_settings.smooth_caret.smooth_blink;
             if new_smooth_caret_config.enabled {
                 if let Some(cursor) = &mut self.quad_cursor {
                     cursor.set_config(new_smooth_caret_config);
@@ -24339,6 +24356,11 @@ impl Editor {
             } else {
                 self.cursor_vfx_system = None;
             }
+
+            // Update smooth blink setting (after editor_settings is no longer used)
+            self.blink_manager.update(cx, |blink_manager, _cx| {
+                blink_manager.set_smooth_blink_enabled(smooth_blink_enabled);
+            });
         }
 
         if old_cursor_shape != self.cursor_shape {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -16,6 +16,7 @@ pub mod blink_manager;
 mod bracket_colorization;
 mod clangd_ext;
 pub mod code_context_menus;
+mod cursor_vfx;
 pub mod display_map;
 mod document_colors;
 mod document_symbols;
@@ -27,6 +28,7 @@ mod highlight_matching_bracket;
 mod hover_links;
 pub mod hover_popover;
 mod indent_guides;
+mod inertial_cursor;
 mod inlays;
 pub mod items;
 mod jsx_tag_auto_close;
@@ -54,15 +56,16 @@ mod signature_help;
 pub mod test;
 
 pub(crate) use actions::*;
+pub use cursor_vfx::{CursorVfxConfig, CursorVfxSystem};
 pub use display_map::{
     ChunkRenderer, ChunkRendererContext, DisplayPoint, FoldPlaceholder, HighlightKey,
     SemanticTokenHighlight,
 };
 pub use edit_prediction_types::Direction;
 pub use editor_settings::{
-    CompletionDetailAlignment, CurrentLineHighlight, DiffViewStyle, DocumentColorsRenderMode,
-    EditorSettings, HideMouseMode, ScrollBeyondLastLine, ScrollbarAxes, SearchSettings,
-    ShowMinimap,
+    CompletionDetailAlignment, CurrentLineHighlight, CursorVfx, DiffViewStyle, DocumentColorsRenderMode,
+    EditorSettings, HideMouseMode, ScrollBeyondLastLine, ScrollbarAxes, SearchSettings, ShowMinimap,
+    SmoothCaret,
 };
 pub use element::{
     CursorLayout, EditorElement, HighlightedRange, HighlightedRangeLine, PointForPosition,
@@ -70,6 +73,7 @@ pub use element::{
 };
 pub use git::blame::BlameRenderer;
 pub use hover_popover::hover_markdown_style;
+pub use inertial_cursor::{CursorAnimationTicker, InertialCursorConfig, QuadCursor};
 pub use inlays::Inlay;
 pub use items::MAX_TAB_TITLE_LEN;
 pub use lsp::CompletionContext;
@@ -1167,6 +1171,9 @@ pub struct Editor {
     completion_provider: Option<Rc<dyn CompletionProvider>>,
     collaboration_hub: Option<Box<dyn CollaborationHub>>,
     blink_manager: Entity<BlinkManager>,
+    quad_cursor: Option<inertial_cursor::QuadCursor>,
+    cursor_animation_ticker: inertial_cursor::CursorAnimationTicker,
+    cursor_vfx_system: Option<cursor_vfx::CursorVfxSystem>,
     show_cursor_names: bool,
     hovered_cursors: HashMap<HoveredCursor, Task<()>>,
     pub show_local_selections: bool,
@@ -2457,6 +2464,30 @@ impl Editor {
                 .cursor_shape
                 .unwrap_or_default(),
             cursor_offset_on_selection: false,
+            quad_cursor: {
+                let smooth_caret_settings = &EditorSettings::get_global(cx).smooth_caret;
+                let config = Self::build_inertial_cursor_config(smooth_caret_settings);
+                if config.enabled {
+                    Some(inertial_cursor::QuadCursor::new(
+                        config,
+                        gpui::point(gpui::Pixels::ZERO, gpui::Pixels::ZERO),
+                        10.0,
+                        20.0,
+                    ))
+                } else {
+                    None
+                }
+            },
+            cursor_animation_ticker: inertial_cursor::CursorAnimationTicker::new(),
+            cursor_vfx_system: {
+                let vfx_settings = &EditorSettings::get_global(cx).cursor_vfx;
+                let vfx_config = cursor_vfx::CursorVfxConfig::from_runtime_settings(vfx_settings);
+                if vfx_config.is_enabled() {
+                    Some(cursor_vfx::CursorVfxSystem::new(vfx_config))
+                } else {
+                    None
+                }
+            },
             current_line_highlight: None,
             autoindent_mode: Some(AutoindentMode::EachLine),
             collapse_matches: false,
@@ -2535,7 +2566,14 @@ impl Editor {
                         cx.observe(&multi_buffer, Self::on_buffer_changed),
                         cx.subscribe_in(&multi_buffer, window, Self::on_buffer_event),
                         cx.observe_in(&display_map, window, Self::on_display_map_changed),
-                        cx.observe(&blink_manager, |_, _, cx| cx.notify()),
+                        cx.observe(&blink_manager, |editor, _, cx| {
+                            // Skip blink notifications during smooth cursor animation
+                            // to avoid triggering full frame redraws that cause flickering
+                            if editor.is_cursor_animating() {
+                                return;
+                            }
+                            cx.notify()
+                        }),
                         cx.observe_global_in::<SettingsStore>(window, Self::settings_changed),
                         cx.observe_global_in::<GlobalTheme>(window, Self::theme_changed),
                         observe_buffer_font_size_adjustment(cx, |_, cx| cx.notify()),
@@ -3322,6 +3360,89 @@ impl Editor {
 
     pub fn set_cursor_offset_on_selection(&mut self, set_cursor_offset_on_selection: bool) {
         self.cursor_offset_on_selection = set_cursor_offset_on_selection;
+    }
+
+    pub fn quad_cursor(&self) -> Option<&inertial_cursor::QuadCursor> {
+        self.quad_cursor.as_ref()
+    }
+
+    pub fn quad_cursor_mut(&mut self) -> Option<&mut inertial_cursor::QuadCursor> {
+        self.quad_cursor.as_mut()
+    }
+
+    fn build_inertial_cursor_config(
+        settings: &editor_settings::SmoothCaret,
+    ) -> inertial_cursor::InertialCursorConfig {
+        inertial_cursor::InertialCursorConfig::from_settings(settings)
+    }
+
+    pub fn is_cursor_animating(&self) -> bool {
+        self.quad_cursor.as_ref().is_some_and(|c| c.is_animating())
+    }
+
+    pub fn update_quad_cursor_position(&mut self, pos: gpui::Point<gpui::Pixels>) {
+        if let Some(cursor) = &mut self.quad_cursor {
+            cursor.set_logical_pos(pos);
+        }
+    }
+
+    pub fn set_quad_cursor_cell_size(&mut self, width: f32, height: f32) {
+        if let Some(cursor) = &mut self.quad_cursor {
+            cursor.set_cell_size(width, height);
+        }
+    }
+
+    pub fn cursor_vfx_system(&self) -> Option<&cursor_vfx::CursorVfxSystem> {
+        self.cursor_vfx_system.as_ref()
+    }
+
+    pub fn cursor_vfx_system_mut(&mut self) -> Option<&mut cursor_vfx::CursorVfxSystem> {
+        self.cursor_vfx_system.as_mut()
+    }
+
+    pub fn tick_cursor_animations(&mut self) -> bool {
+        let now = std::time::Instant::now();
+
+        let quad_animating = self.quad_cursor.as_ref().is_some_and(|c| c.is_animating());
+
+        if !quad_animating {
+            self.cursor_animation_ticker.stop();
+            return false;
+        }
+
+        let dt = self.cursor_animation_ticker.tick(now);
+        let dt_secs = dt.as_secs_f32();
+
+        let steps = ((dt_secs / inertial_cursor::MAX_ANIMATION_DT).ceil() as usize).max(1);
+        let dt_per_step = dt_secs / steps as f32;
+
+        let mut still_animating = false;
+
+        if let Some(cursor) = &mut self.quad_cursor {
+            for _ in 0..steps {
+                if cursor.update_physics(dt_per_step) {
+                    still_animating = true;
+                }
+            }
+        }
+
+        if !still_animating {
+            self.cursor_animation_ticker.stop();
+        }
+
+        still_animating
+    }
+
+    pub fn update_cursor_vfx(&mut self, cursor_pos: gpui::Point<gpui::Pixels>) {
+        if let Some(vfx) = &mut self.cursor_vfx_system {
+            vfx.update(cursor_pos);
+        }
+    }
+
+    pub fn is_cursor_vfx_animating(&self) -> bool {
+        self.cursor_vfx_system
+            .as_ref()
+            .is_some_and(|vfx| vfx.is_animating())
     }
 
     pub fn set_current_line_highlight(
@@ -24174,6 +24295,37 @@ impl Editor {
             self.show_breadcrumbs = editor_settings.toolbar.breadcrumbs;
             self.cursor_shape = editor_settings.cursor_shape.unwrap_or_default();
             self.hide_mouse_mode = editor_settings.hide_mouse.unwrap_or_default();
+
+            // Handle smooth_caret settings changes
+            let new_smooth_caret_config =
+                Self::build_inertial_cursor_config(&editor_settings.smooth_caret);
+            if new_smooth_caret_config.enabled {
+                if let Some(cursor) = &mut self.quad_cursor {
+                    cursor.set_config(new_smooth_caret_config);
+                } else {
+                    self.quad_cursor = Some(inertial_cursor::QuadCursor::new(
+                        new_smooth_caret_config,
+                        gpui::point(gpui::Pixels::ZERO, gpui::Pixels::ZERO),
+                        10.0,
+                        20.0,
+                    ));
+                }
+            } else {
+                self.quad_cursor = None;
+            }
+
+            // Handle cursor_vfx settings changes
+            let vfx_config =
+                cursor_vfx::CursorVfxConfig::from_runtime_settings(&editor_settings.cursor_vfx);
+            if vfx_config.is_enabled() {
+                if let Some(vfx) = &mut self.cursor_vfx_system {
+                    vfx.set_config(vfx_config);
+                } else {
+                    self.cursor_vfx_system = Some(cursor_vfx::CursorVfxSystem::new(vfx_config));
+                }
+            } else {
+                self.cursor_vfx_system = None;
+            }
         }
 
         if old_cursor_shape != self.cursor_shape {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1173,6 +1173,7 @@ pub struct Editor {
     blink_manager: Entity<BlinkManager>,
     quad_cursor: Option<inertial_cursor::QuadCursor>,
     cursor_animation_ticker: inertial_cursor::CursorAnimationTicker,
+    cursor_animation_destination: Option<(DisplayPoint, Pixels, Pixels)>,
     cursor_vfx_system: Option<cursor_vfx::CursorVfxSystem>,
     show_cursor_names: bool,
     hovered_cursors: HashMap<HoveredCursor, Task<()>>,
@@ -2479,6 +2480,7 @@ impl Editor {
                 }
             },
             cursor_animation_ticker: inertial_cursor::CursorAnimationTicker::new(),
+            cursor_animation_destination: None,
             cursor_vfx_system: {
                 let vfx_settings = &EditorSettings::get_global(cx).cursor_vfx;
                 let vfx_config = cursor_vfx::CursorVfxConfig::from_runtime_settings(vfx_settings);
@@ -3368,6 +3370,17 @@ impl Editor {
 
     pub fn quad_cursor_mut(&mut self) -> Option<&mut inertial_cursor::QuadCursor> {
         self.quad_cursor.as_mut()
+    }
+
+    pub fn set_cursor_animation_destination(
+        &mut self,
+        destination: Option<(DisplayPoint, Pixels, Pixels)>,
+    ) {
+        self.cursor_animation_destination = destination;
+    }
+
+    pub fn cursor_animation_destination(&self) -> Option<(DisplayPoint, Pixels, Pixels)> {
+        self.cursor_animation_destination
     }
 
     fn build_inertial_cursor_config(

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -9,8 +9,13 @@ pub use settings::{
     MinimapThumb, MinimapThumbBorder, MultiCursorModifier, ScrollBeyondLastLine,
     ScrollbarDiagnostics, SeedQuerySetting, ShowMinimap, SnippetSortOrder,
 };
-use settings::{RegisterSetting, RelativeLineNumbers, Settings};
+use settings::{
+    CursorVfxContent, CursorVfxModeContent, RegisterSetting, RelativeLineNumbers, Settings,
+    SmoothCaretSetting,
+};
 use ui::scrollbars::{ScrollbarVisibility, ShowScrollbar};
+
+use crate::cursor_vfx::CursorVfxMode;
 
 /// Imports from the VSCode settings at
 /// https://code.visualstudio.com/docs/reference/default-settings
@@ -18,6 +23,8 @@ use ui::scrollbars::{ScrollbarVisibility, ShowScrollbar};
 pub struct EditorSettings {
     pub cursor_blink: bool,
     pub cursor_shape: Option<CursorShape>,
+    pub smooth_caret: SmoothCaret,
+    pub cursor_vfx: CursorVfx,
     pub current_line_highlight: CurrentLineHighlight,
     pub selection_highlight: bool,
     pub rounded_selection: bool,
@@ -179,6 +186,83 @@ pub struct SearchSettings {
     pub search_on_input: bool,
 }
 
+/// Runtime settings for smooth cursor animation.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct SmoothCaret {
+    /// Whether smooth cursor animation is enabled.
+    pub enabled: bool,
+    /// Animation duration for large jumps (search, goto) in milliseconds.
+    pub animation_time_ms: u64,
+    /// Animation duration for small moves (typing) in milliseconds.
+    pub short_animation_time_ms: u64,
+    /// Trail size controls cursor responsiveness vs smoothness (0.0-1.0).
+    pub trail_size: f32,
+    /// Whether to animate cursor during insert mode (typing).
+    pub animate_in_insert_mode: bool,
+}
+
+impl Default for SmoothCaret {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            animation_time_ms: 150,
+            short_animation_time_ms: 25,
+            trail_size: 1.0,
+            animate_in_insert_mode: true,
+        }
+    }
+}
+
+impl SmoothCaret {
+    /// Parse from the settings content, supporting both boolean and object forms.
+    pub fn from_setting(setting: Option<SmoothCaretSetting>) -> Self {
+        match setting {
+            Some(SmoothCaretSetting::Bool(enabled)) => Self {
+                enabled,
+                ..Self::default()
+            },
+            Some(SmoothCaretSetting::Config(config)) => Self {
+                enabled: config.enabled.unwrap_or(true),
+                animation_time_ms: config.animation_time_ms.unwrap_or(150),
+                short_animation_time_ms: config.short_animation_time_ms.unwrap_or(25),
+                trail_size: config.trail_size.unwrap_or(1.0).clamp(0.0, 1.0),
+                animate_in_insert_mode: config.animate_in_insert_mode.unwrap_or(true),
+            },
+            None => Self::default(),
+        }
+    }
+}
+
+/// Runtime settings for cursor visual effects.
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+pub struct CursorVfx {
+    pub mode: CursorVfxMode,
+}
+
+impl CursorVfx {
+    pub fn from_setting(setting: Option<CursorVfxContent>) -> Self {
+        Self {
+            mode: setting
+                .and_then(|c| c.mode)
+                .map(Into::into)
+                .unwrap_or(CursorVfxMode::None),
+        }
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.mode != CursorVfxMode::None
+    }
+}
+
+impl From<CursorVfxModeContent> for CursorVfxMode {
+    fn from(mode: CursorVfxModeContent) -> Self {
+        match mode {
+            CursorVfxModeContent::None => CursorVfxMode::None,
+            CursorVfxModeContent::Sonicboom => CursorVfxMode::Sonicboom,
+        }
+    }
+}
+
 impl EditorSettings {
     pub fn jupyter_enabled(cx: &App) -> bool {
         EditorSettings::get_global(cx).jupyter.enabled
@@ -205,6 +289,8 @@ impl Settings for EditorSettings {
         Self {
             cursor_blink: editor.cursor_blink.unwrap(),
             cursor_shape: editor.cursor_shape.map(Into::into),
+            smooth_caret: SmoothCaret::from_setting(editor.smooth_caret),
+            cursor_vfx: CursorVfx::from_setting(editor.cursor_vfx),
             current_line_highlight: editor.current_line_highlight.unwrap(),
             selection_highlight: editor.selection_highlight.unwrap(),
             rounded_selection: editor.rounded_selection.unwrap(),

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -199,6 +199,8 @@ pub struct SmoothCaret {
     pub trail_size: f32,
     /// Whether to animate cursor during insert mode (typing).
     pub animate_in_insert_mode: bool,
+    /// Whether to use smooth opacity transitions for cursor blinking.
+    pub smooth_blink: bool,
 }
 
 impl Default for SmoothCaret {
@@ -206,9 +208,10 @@ impl Default for SmoothCaret {
         Self {
             enabled: true,
             animation_time_ms: 150,
-            short_animation_time_ms: 25,
-            trail_size: 1.0,
+            short_animation_time_ms: 40,
+            trail_size: 0.7,
             animate_in_insert_mode: true,
+            smooth_blink: true,
         }
     }
 }
@@ -219,14 +222,16 @@ impl SmoothCaret {
         match setting {
             Some(SmoothCaretSetting::Bool(enabled)) => Self {
                 enabled,
+                smooth_blink: enabled,
                 ..Self::default()
             },
             Some(SmoothCaretSetting::Config(config)) => Self {
                 enabled: config.enabled.unwrap_or(true),
                 animation_time_ms: config.animation_time_ms.unwrap_or(150),
-                short_animation_time_ms: config.short_animation_time_ms.unwrap_or(25),
-                trail_size: config.trail_size.unwrap_or(1.0).clamp(0.0, 1.0),
+                short_animation_time_ms: config.short_animation_time_ms.unwrap_or(40),
+                trail_size: config.trail_size.unwrap_or(0.7).clamp(0.0, 1.0),
                 animate_in_insert_mode: config.animate_in_insert_mode.unwrap_or(true),
+                smooth_blink: config.smooth_blink.unwrap_or(true),
             },
             None => Self::default(),
         }

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1920,8 +1920,9 @@ impl EditorElement {
                             // Physics tick happens in animation callback only (prevents double-tick)
                             // Use interpolated positions for smooth rendering between physics ticks
                             let corners = quad.interpolated_corner_positions();
-                            let visual = quad.visual_pos();
-                            (visual.x, visual.y, Some(corners))
+                            let render_origin =
+                                quad_top_left_or_fallback(Some(corners), quad.visual_pos());
+                            (render_origin.x, render_origin.y, Some(corners))
                         } else {
                             (logical_x, logical_y, None)
                         }
@@ -2006,6 +2007,7 @@ impl EditorElement {
                             line_height: cursor.line_height,
                             block_width: cursor.block_width,
                             cursor_shape: cursor.shape,
+                            target_display_point: cursor_position,
                             block_text: cursor.block_text.clone(),
                             font: block_cursor_font.clone(),
                             font_size: cursor_row_layout.font_size,
@@ -11929,6 +11931,64 @@ fn resolve_block_cursor_grapheme(
     Some(normalize_block_cursor_grapheme(grapheme.as_ref()))
 }
 
+fn shape_block_cursor_text_for_point(
+    snapshot: &DisplaySnapshot,
+    target_point: DisplayPoint,
+    placeholder_text: Option<&str>,
+    font: &Font,
+    font_size: Pixels,
+    block_text_color: Hsla,
+    window: &mut Window,
+) -> Option<ShapedLine> {
+    let target_text = resolve_block_cursor_grapheme(snapshot, target_point).or_else(|| {
+        placeholder_text.and_then(|placeholder| {
+            placeholder
+                .graphemes(true)
+                .next()
+                .map(normalize_block_cursor_grapheme)
+        })
+    });
+
+    target_text.map(|text| {
+        let len = text.len();
+        window.text_system().shape_line(
+            text,
+            font_size,
+            &[TextRun {
+                len,
+                font: font.clone(),
+                color: block_text_color,
+                ..Default::default()
+            }],
+            None,
+        )
+    })
+}
+
+fn prefer_cached_block_cursor_text<T>(
+    cached_block_text: Option<T>,
+    fresh_block_text: Option<T>,
+) -> Option<T> {
+    cached_block_text.or(fresh_block_text)
+}
+
+fn quad_top_left_or_fallback(
+    quad_corners: Option<[gpui::Point<Pixels>; 4]>,
+    fallback_origin: gpui::Point<Pixels>,
+) -> gpui::Point<Pixels> {
+    quad_corners
+        .map(|corners| corners[0])
+        .unwrap_or(fallback_origin)
+}
+
+fn should_paint_block_cursor_destination_mask<T>(
+    cursor_animating: bool,
+    destination_pos: Option<gpui::Point<Pixels>>,
+    block_text: Option<&T>,
+) -> bool {
+    cursor_animating && destination_pos.is_some() && block_text.is_some()
+}
+
 #[derive(Debug)]
 pub struct IndentGuideLayout {
     origin: gpui::Point<Pixels>,
@@ -11972,6 +12032,8 @@ struct CursorAnimationState {
     line_height: Pixels,
     block_width: Pixels,
     cursor_shape: CursorShape,
+    /// Target display point captured at layout time.
+    target_display_point: DisplayPoint,
     /// Block text captured at layout time (character under cursor)
     block_text: Option<ShapedLine>,
     /// Font for shaping block_text
@@ -12005,86 +12067,78 @@ fn paint_cursor_animation_frame(state: CursorAnimationState, window: &mut Window
         cursor_or_vfx_animating,
         fresh_block_text,
         destination_pos,
-    ) =
-        state.editor.update(cx, |editor, cx| {
-            editor.tick_cursor_animations();
+    ) = state.editor.update(cx, |editor, cx| {
+        editor.tick_cursor_animations();
 
-            let (origin, quad_corners) = if let Some(quad) = editor.quad_cursor() {
-                let visual = quad.visual_pos();
-                (visual, Some(quad.interpolated_corner_positions()))
-            } else {
-                (state.cursor_pos, None)
-            };
+        let (origin, quad_corners) = if let Some(quad) = editor.quad_cursor() {
+            let corners = quad.interpolated_corner_positions();
+            (
+                quad_top_left_or_fallback(Some(corners), quad.visual_pos()),
+                Some(corners),
+            )
+        } else {
+            (state.cursor_pos, None)
+        };
 
-            editor.update_cursor_vfx(origin);
+        editor.update_cursor_vfx(origin);
 
-            let cursor_animating = editor.is_cursor_animating();
-            let cursor_or_vfx_animating = cursor_animating || editor.is_cursor_vfx_animating();
+        let cursor_animating = editor.is_cursor_animating();
+        let cursor_or_vfx_animating = cursor_animating || editor.is_cursor_vfx_animating();
 
-            let fresh_block_text =
-                if state.cursor_shape == CursorShape::Block && !state.is_target_redacted {
-                    let snapshot = editor.display_snapshot(cx);
-                    let target_point = editor.selections.newest_display(&snapshot).head();
-                    let target_text = resolve_block_cursor_grapheme(&snapshot, target_point)
-                        .or_else(|| {
-                            if snapshot.is_empty() {
-                                editor.placeholder_text(cx).and_then(|placeholder| {
-                                    placeholder
-                                        .graphemes(true)
-                                        .next()
-                                        .map(normalize_block_cursor_grapheme)
-                                })
-                            } else {
-                                None
-                            }
-                        });
-
-                    target_text.map(|text| {
-                        let len = text.len();
-                        window.text_system().shape_line(
-                            text,
-                            state.font_size,
-                            &[TextRun {
-                                len,
-                                font: state.font.clone(),
-                                color: state.block_text_color,
-                                ..Default::default()
-                            }],
-                            None,
-                        )
-                    })
+        let fresh_block_text =
+            if state.cursor_shape == CursorShape::Block && !state.is_target_redacted {
+                let snapshot = editor.display_snapshot(cx);
+                let placeholder_text = if snapshot.is_empty() {
+                    editor.placeholder_text(cx)
                 } else {
                     None
                 };
-
-            let destination_pos = if cursor_animating
-                && state.cursor_shape == CursorShape::Block
-                && !state.is_target_redacted
-            {
-                editor
-                    .quad_cursor()
-                    .map(|quad| quad.destination_pos())
-                    .or(Some(state.cursor_pos))
+                shape_block_cursor_text_for_point(
+                    &snapshot,
+                    state.target_display_point,
+                    placeholder_text.as_deref(),
+                    &state.font,
+                    state.font_size,
+                    state.block_text_color,
+                    window,
+                )
             } else {
                 None
             };
 
-            (
-                origin,
-                quad_corners,
-                cursor_animating,
-                cursor_or_vfx_animating,
-                fresh_block_text,
-                destination_pos,
-            )
-        });
+        let destination_pos = if cursor_animating
+            && state.cursor_shape == CursorShape::Block
+            && !state.is_target_redacted
+        {
+            editor
+                .quad_cursor()
+                .map(|quad| quad.destination_pos())
+                .or(Some(state.cursor_pos))
+        } else {
+            None
+        };
+
+        (
+            origin,
+            quad_corners,
+            cursor_animating,
+            cursor_or_vfx_animating,
+            fresh_block_text,
+            destination_pos,
+        )
+    });
 
     let blink_animating = state.blink_manager.read(cx).is_smooth_blink_animating();
     let still_animating = cursor_or_vfx_animating || blink_animating;
 
-    let block_text = fresh_block_text.or_else(|| state.block_text.clone());
+    let block_text = prefer_cached_block_cursor_text(state.block_text.clone(), fresh_block_text);
 
-    if cursor_animating && let Some(destination_pos) = destination_pos {
+    if should_paint_block_cursor_destination_mask(
+        cursor_animating,
+        destination_pos,
+        block_text.as_ref(),
+    ) && let Some(destination_pos) = destination_pos
+    {
         let destination_bounds = Bounds::new(
             state.content_origin + destination_pos,
             size(state.block_width, state.line_height),
@@ -12259,44 +12313,21 @@ impl CursorLayout {
             }
 
             if let Some(block_text) = &self.block_text {
-                let min_x = corners_with_offset
-                    .iter()
-                    .map(|c| c.x)
-                    .fold(Pixels::MAX, |a, b| a.min(b));
-                let max_x = corners_with_offset
-                    .iter()
-                    .map(|c| c.x)
-                    .fold(Pixels::MIN, |a, b| a.max(b));
-                let min_y = corners_with_offset
-                    .iter()
-                    .map(|c| c.y)
-                    .fold(Pixels::MAX, |a, b| a.min(b));
-                let max_y = corners_with_offset
-                    .iter()
-                    .map(|c| c.y)
-                    .fold(Pixels::MIN, |a, b| a.max(b));
-
-                let clip_bounds =
-                    Bounds::new(point(min_x, min_y), size(max_x - min_x, max_y - min_y));
-
-                window.with_content_mask(
-                    Some(ContentMask {
-                        bounds: clip_bounds,
-                    }),
-                    |window| {
-                        block_text
-                            .paint_with_opacity(
-                                self.origin + origin,
-                                self.line_height,
-                                TextAlign::Left,
-                                None,
-                                self.opacity,
-                                window,
-                                cx,
-                            )
-                            .log_err();
-                    },
+                let block_text_origin = quad_top_left_or_fallback(
+                    Some(corners_with_offset),
+                    self.origin + origin,
                 );
+                block_text
+                    .paint_with_opacity(
+                        block_text_origin,
+                        self.line_height,
+                        TextAlign::Left,
+                        None,
+                        self.opacity,
+                        window,
+                        cx,
+                    )
+                    .log_err();
             }
             return;
         }
@@ -13164,6 +13195,125 @@ mod tests {
         assert_eq!(
             state.active_rows.keys().cloned().collect::<Vec<_>>(),
             vec![DisplayRow(0), DisplayRow(3), DisplayRow(5), DisplayRow(6)]
+        );
+    }
+
+    #[gpui::test]
+    fn test_block_cursor_animation_text_uses_provided_target_point(cx: &mut TestAppContext) {
+        init_test(cx, |_| {});
+
+        let window = cx.add_window(|window, cx| {
+            let buffer = MultiBuffer::build_simple("ab", cx);
+            Editor::new(EditorMode::full(), buffer, None, window, cx)
+        });
+        let cx = &mut VisualTestContext::from_window(*window, cx);
+        window
+            .update(cx, |editor, window, cx| {
+                editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
+                    s.select_ranges([Point::new(0, 1)..Point::new(0, 1)]);
+                });
+
+                let snapshot = editor.display_snapshot(cx);
+                let newest_head = editor.selections.newest_display(&snapshot).head();
+                assert_eq!(newest_head, DisplayPoint::new(DisplayRow(0), 1));
+
+                let mut block_cursor_font = editor.style(cx).text.font();
+                block_cursor_font.features = editor.style(cx).text.font_features.clone();
+                let font_size = editor.style(cx).text.font_size.to_pixels(window.rem_size());
+
+                let target_left = DisplayPoint::new(DisplayRow(0), 0);
+                let target_right = DisplayPoint::new(DisplayRow(0), 1);
+                let left_text = shape_block_cursor_text_for_point(
+                    &snapshot,
+                    target_left,
+                    None,
+                    &block_cursor_font,
+                    font_size,
+                    Hsla::white(),
+                    window,
+                )
+                .map(|line| line.text.to_string());
+                let right_text = shape_block_cursor_text_for_point(
+                    &snapshot,
+                    target_right,
+                    None,
+                    &block_cursor_font,
+                    font_size,
+                    Hsla::white(),
+                    window,
+                )
+                .map(|line| line.text.to_string());
+
+                assert_eq!(left_text.as_deref(), Some("a"));
+                assert_eq!(right_text.as_deref(), Some("b"));
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn test_prefer_cached_block_cursor_text_prioritizes_cached_value() {
+        assert_eq!(prefer_cached_block_cursor_text(Some(1), Some(2)), Some(1));
+        assert_eq!(prefer_cached_block_cursor_text(Some(1), None), Some(1));
+        assert_eq!(
+            prefer_cached_block_cursor_text(None::<i32>, Some(2)),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn test_destination_mask_requires_block_text() {
+        let destination = Some(point(px(4.), px(2.)));
+
+        assert!(!should_paint_block_cursor_destination_mask::<u8>(
+            true,
+            destination,
+            None
+        ));
+        assert!(!should_paint_block_cursor_destination_mask(
+            false,
+            destination,
+            Some(&1u8)
+        ));
+        assert!(should_paint_block_cursor_destination_mask(
+            true,
+            destination,
+            Some(&1u8)
+        ));
+    }
+
+    #[test]
+    fn test_quad_top_left_or_fallback_prefers_quad_top_left() {
+        let fallback = point(px(10.), px(20.));
+        let quad_corners = Some([
+            point(px(1.), px(2.)),
+            point(px(3.), px(2.)),
+            point(px(3.), px(4.)),
+            point(px(1.), px(4.)),
+        ]);
+
+        assert_eq!(
+            quad_top_left_or_fallback(quad_corners, fallback),
+            point(px(1.), px(2.))
+        );
+        assert_eq!(
+            quad_top_left_or_fallback(None, fallback),
+            point(px(10.), px(20.))
+        );
+    }
+
+    #[test]
+    fn test_quad_block_text_origin_uses_top_left_corner() {
+        let fallback = point(px(80.), px(90.));
+        let quad_corners_with_offset = Some([
+            point(px(12.), px(14.)),
+            point(px(16.), px(15.)),
+            point(px(15.), px(22.)),
+            point(px(11.), px(21.)),
+        ]);
+
+        assert_eq!(
+            quad_top_left_or_fallback(quad_corners_with_offset, fallback),
+            point(px(12.), px(14.))
         );
     }
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1792,8 +1792,9 @@ impl EditorElement {
         let mut autoscroll_bounds = None;
         let mut cursor_vfx_pos = None;
         let mut animation_state = None;
+        let mut newest_cursor_index: Option<usize> = None;
         let editor_handle = self.editor.clone();
-        let cursor_layouts = self.editor.update(cx, |editor, cx| {
+        let mut cursor_layouts = self.editor.update(cx, |editor, cx| {
             let mut cursors = Vec::new();
 
             let show_local_cursors = editor.show_local_cursors(window, cx);
@@ -1997,6 +1998,7 @@ impl EditorElement {
                     });
                     cursor.layout(content_origin, cursor_name, window, cx);
                     if selection.is_newest {
+                        newest_cursor_index = Some(cursors.len());
                         animation_state = Some(CursorAnimationState {
                             generation: 0,
                             editor: editor_handle.clone(),
@@ -2013,6 +2015,7 @@ impl EditorElement {
                             font_size: cursor_row_layout.font_size,
                             block_text_color,
                             is_target_redacted,
+                            other_cursors: Vec::new(),
                         });
                     }
                     cursors.push(cursor);
@@ -2053,6 +2056,21 @@ impl EditorElement {
         // We register an animation callback to tick physics and paint the cursor
         // on top of the cached scene.
         if is_animating && let Some(mut state) = animation_state {
+            if let Some(newest_idx) = newest_cursor_index {
+                let mut other_cursors =
+                    Vec::with_capacity(cursor_layouts.len().saturating_sub(1));
+                let mut kept = Vec::new();
+                for (i, cursor) in cursor_layouts.into_iter().enumerate() {
+                    if i == newest_idx {
+                        kept.push(cursor);
+                    } else {
+                        other_cursors.push(cursor);
+                    }
+                }
+                cursor_layouts = kept;
+                state.other_cursors = other_cursors;
+            }
+
             let generation = self.editor.update(cx, |editor, _cx| {
                 editor.begin_cursor_animation_callback_cycle()
             });
@@ -12044,10 +12062,12 @@ struct CursorAnimationState {
     block_text_color: Hsla,
     /// Whether target position is in a redacted range
     is_target_redacted: bool,
+    /// Non-animated cursors from multi-selection that must be painted alongside the animated cursor.
+    other_cursors: Vec<CursorLayout>,
 }
 
 /// Paint one frame of cursor animation and re-register callback if still animating.
-fn paint_cursor_animation_frame(state: CursorAnimationState, window: &mut Window, cx: &mut App) {
+fn paint_cursor_animation_frame(mut state: CursorAnimationState, window: &mut Window, cx: &mut App) {
     if !state
         .editor
         .read(cx)
@@ -12161,6 +12181,11 @@ fn paint_cursor_animation_frame(state: CursorAnimationState, window: &mut Window
         cursor_name: None,
     };
     cursor.paint(state.content_origin, window, cx);
+
+    for other in &mut state.other_cursors {
+        other.opacity = blink_opacity;
+        other.paint(state.content_origin, window, cx);
+    }
 
     if let Some(vfx_system) = state.editor.read(cx).cursor_vfx_system() {
         vfx_system.paint(state.content_origin, window, state.cursor_color);

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2,19 +2,19 @@ use crate::{
     ActiveDiagnostic, BlockId, CURSORS_VISIBLE_FOR, ChunkRendererContext, ChunkReplacement,
     CodeActionSource, ColumnarMode, ConflictsOurs, ConflictsOursMarker, ConflictsOuter,
     ConflictsTheirs, ConflictsTheirsMarker, ContextMenuPlacement, CursorShape, CustomBlockId,
-    DisplayDiffHunk, DisplayPoint, DisplayRow, EditDisplayMode, EditPrediction, Editor, EditorMode,
-    EditorSettings, EditorSnapshot, EditorStyle, FILE_HEADER_HEIGHT, FocusedBlock,
-    GutterDimensions, HalfPageDown, HalfPageUp, HandleInput, HoveredCursor, InlayHintRefreshReason,
-    JumpData, LineDown, LineHighlight, LineUp, MAX_LINE_LEN, MINIMAP_FONT_SIZE,
-    MULTI_BUFFER_EXCERPT_HEADER_HEIGHT, OpenExcerpts, PageDown, PageUp, PhantomBreakpointIndicator,
-    PhantomDiffReviewIndicator, Point, RowExt, RowRangeExt, SelectPhase, Selection,
-    SelectionDragState, SelectionEffects, SizingBehavior, SoftWrap, StickyHeaderExcerpt, ToPoint,
-    ToggleFold, ToggleFoldAll,
+    DisplayDiffHunk, DisplayPoint, DisplayRow, DocumentHighlightRead, DocumentHighlightWrite,
+    EditDisplayMode, EditPrediction, Editor, EditorMode, EditorSettings, EditorSnapshot, EditorStyle,
+    FILE_HEADER_HEIGHT, FocusedBlock, GutterDimensions, HalfPageDown, HalfPageUp, HandleInput,
+    HoveredCursor, InlayHintRefreshReason, JumpData, LineDown, LineHighlight, LineUp, MAX_LINE_LEN,
+    MINIMAP_FONT_SIZE, MULTI_BUFFER_EXCERPT_HEADER_HEIGHT, OpenExcerpts, PageDown, PageUp,
+    PhantomBreakpointIndicator, PhantomDiffReviewIndicator, Point, RowExt, RowRangeExt, SelectPhase,
+    SelectedTextHighlight, Selection, SelectionDragState, SelectionEffects, SizingBehavior, SoftWrap,
+    StickyHeaderExcerpt, ToPoint, ToggleFold, ToggleFoldAll, blink_manager::BlinkManager,
     code_context_menus::{CodeActionsMenu, MENU_ASIDE_MAX_WIDTH, MENU_ASIDE_MIN_WIDTH, MENU_GAP},
     column_pixels,
     display_map::{
         Block, BlockContext, BlockStyle, ChunkRendererId, DisplaySnapshot, EditorMargins,
-        HighlightKey, HighlightedChunk, ToDisplayPoint,
+        HighlightKey, HighlightedChunk, ToDisplayPoint, is_invisible, replacement,
     },
     editor_settings::{
         CurrentLineHighlight, DocumentColorsRenderMode, DoubleClickInMultibuffer, Minimap,
@@ -1797,16 +1797,11 @@ impl EditorElement {
             let mut cursors = Vec::new();
 
             let show_local_cursors = editor.show_local_cursors(window, cx);
-            // When smooth cursor animation is enabled, disable blinking entirely.
-            // Blinking adds visual noise when cursor is already smoothly animating.
             let smooth_cursor_enabled = editor.quad_cursor().is_some();
-            let blink_opacity = if smooth_cursor_enabled {
-                1.0 // Always visible when smooth cursor is enabled
-            } else if editor.blink_manager.read(cx).visible() {
-                1.0
-            } else {
-                0.0
-            };
+            let is_editor_focused = editor.is_focused(window);
+            let blink_opacity = editor
+                .blink_manager
+                .update(cx, |blink_manager, cx| blink_manager.opacity(cx));
 
             for (player_color, selections) in selections {
                 for selection in selections {
@@ -1867,68 +1862,45 @@ impl EditorElement {
                         cx.theme().colors().editor_background
                     };
 
-                    if selection.cursor_shape == CursorShape::Block && !is_target_redacted {
-                        if let Some(text) = snapshot.grapheme_at(cursor_position).or_else(|| {
-                            if snapshot.is_empty() {
-                                snapshot.placeholder_text().and_then(|s| {
-                                    s.graphemes(true).next().map(|s| s.to_string().into())
-                                })
-                            } else {
-                                None
-                            }
-                        }) {
-                            let is_ascii_whitespace_only =
-                                text.as_ref().chars().all(|c| c.is_ascii_whitespace());
-                            let len = text.len();
-
-                            let shaped = window.text_system().shape_line(
-                                text,
-                                cursor_row_layout.font_size,
-                                &[TextRun {
-                                    len,
-                                    font: block_cursor_font.clone(),
-                                    color: block_text_color,
-                                    ..Default::default()
-                                }],
-                                None,
-                            );
-                            if !is_ascii_whitespace_only {
-                                block_width = block_width.max(shaped.width);
-                            }
-                            block_text = Some(shaped);
-                        }
+                    let block_text = if selection.cursor_shape == CursorShape::Block
+                        && !is_target_redacted
+                    {
+                        resolve_block_cursor_grapheme(&snapshot.display_snapshot, cursor_position)
+                            .or_else(|| {
+                                if snapshot.is_empty() {
+                                    snapshot
+                                        .placeholder_text()
+                                        .and_then(|text| text.graphemes(true).next().map(normalize_block_cursor_grapheme))
+                                } else {
+                                    None
+                                }
+                            })
+                            .map(|text| {
+                                let is_ascii_whitespace_only =
+                                    text.chars().all(|c| c.is_ascii_whitespace());
+                                let len = text.len();
+                                let shaped = window.text_system().shape_line(
+                                    text,
+                                    cursor_row_layout.font_size,
+                                    &[TextRun {
+                                        len,
+                                        font: block_cursor_font.clone(),
+                                        color: block_text_color,
+                                        ..Default::default()
+                                    }],
+                                    None,
+                                );
+                                if !is_ascii_whitespace_only {
+                                    block_width = block_width.max(shaped.width);
+                                }
+                                shaped
+                            })
+                    } else {
+                        None
+                    };
+                    if let Some(shaped) = &block_text {
+                        block_width = block_width.max(shaped.width);
                     }
-
-                    let block_text =
-                        if selection.cursor_shape == CursorShape::Block && !is_target_redacted {
-                            snapshot
-                                .grapheme_at(cursor_position)
-                                .or_else(|| {
-                                    if snapshot.is_empty() {
-                                        snapshot.placeholder_text().and_then(|s| {
-                                            s.graphemes(true).next().map(|s| s.to_string().into())
-                                        })
-                                    } else {
-                                        None
-                                    }
-                                })
-                                .map(|text| {
-                                    let len = text.len();
-                                    window.text_system().shape_line(
-                                        text,
-                                        cursor_row_layout.font_size,
-                                        &[TextRun {
-                                            len,
-                                            font: block_cursor_font.clone(),
-                                            color: block_text_color,
-                                            ..Default::default()
-                                        }],
-                                        None,
-                                    )
-                                })
-                        } else {
-                            None
-                        };
                     let block_cursor_font_size = cursor_row_layout.font_size;
 
                     let logical_x = cursor_character_x - scroll_pixel_position.x.into();
@@ -1939,33 +1911,22 @@ impl EditorElement {
                     // For the newest (primary) cursor, use inertial animation if enabled
                     // Order: 1) set target 2) tick physics 3) read position
                     // This ensures physics uses the NEW target, eliminating one-frame lag
-                    let (x, y, quad_corners, cursor_animating_for_opacity) = if selection.is_newest
-                    {
+                    let (x, y, quad_corners) = if selection.is_newest {
                         if let Some(quad) = editor.quad_cursor_mut() {
+                            quad.set_cell_size(block_width.into(), line_height.into());
+                            quad.set_shape(selection.cursor_shape);
                             // Set target position for animation
                             quad.set_logical_pos(point(logical_x, logical_y));
-                            quad.set_cell_size(block_width.into(), line_height.into());
                             // Physics tick happens in animation callback only (prevents double-tick)
                             // Use interpolated positions for smooth rendering between physics ticks
                             let corners = quad.interpolated_corner_positions();
                             let visual = quad.visual_pos();
-                            let cursor_animating = editor.is_cursor_animating();
-                            // Track destination position for block cursor to mask ghost character
-                            if cursor_animating && selection.cursor_shape == CursorShape::Block {
-                                editor.set_cursor_animation_destination(Some((
-                                    cursor_position,
-                                    cursor_character_x,
-                                    block_width,
-                                )));
-                            } else {
-                                editor.set_cursor_animation_destination(None);
-                            }
-                            (visual.x, visual.y, Some(corners), cursor_animating)
+                            (visual.x, visual.y, Some(corners))
                         } else {
-                            (logical_x, logical_y, None, false)
+                            (logical_x, logical_y, None)
                         }
                     } else {
-                        (logical_x, logical_y, None, false)
+                        (logical_x, logical_y, None)
                     };
 
                     if selection.is_newest {
@@ -2013,22 +1974,18 @@ impl EditorElement {
                         origin: point(x, y),
                         quad_corners,
                         line_height,
-                        // When smooth cursor is animating, animation callback handles this cursor.
-                        // Only suppress when animation is active to prevent flicker on animation end.
-                        // With smooth cursor disabled, use normal blink behavior.
-                        opacity: if selection.is_newest
-                            && quad_corners.is_some()
-                            && cursor_animating_for_opacity
-                        {
-                            0.0 // Animation callback handles this cursor
-                        } else if selection.is_local && smooth_cursor_enabled {
-                            1.0 // Smooth cursor at rest - always visible
-                        } else if selection.is_local {
-                            blink_opacity // Normal blink behavior
+                        opacity: if selection.is_local {
+                            blink_opacity // Includes smooth blink interpolation
                         } else {
                             1.0 // Remote cursors
                         },
-                        shape: selection.cursor_shape,
+                        // When editor is unfocused and smooth cursor is enabled, show hollow outline
+                        shape: if !is_editor_focused && smooth_cursor_enabled && selection.is_local
+                        {
+                            CursorShape::Hollow
+                        } else {
+                            selection.cursor_shape
+                        },
                         block_text,
                         cursor_name: None,
                     };
@@ -2040,7 +1997,9 @@ impl EditorElement {
                     cursor.layout(content_origin, cursor_name, window, cx);
                     if selection.is_newest {
                         animation_state = Some(CursorAnimationState {
+                            generation: 0,
                             editor: editor_handle.clone(),
+                            blink_manager: editor.blink_manager.clone(),
                             content_origin,
                             cursor_pos: point(x, y),
                             cursor_color: cursor.color,
@@ -2048,13 +2007,10 @@ impl EditorElement {
                             block_width: cursor.block_width,
                             cursor_shape: cursor.shape,
                             block_text: cursor.block_text.clone(),
-                            target_display_point: cursor_position,
-                            font: block_cursor_font,
-                            font_size: block_cursor_font_size,
+                            font: block_cursor_font.clone(),
+                            font_size: cursor_row_layout.font_size,
                             block_text_color,
                             is_target_redacted,
-                            scroll_position,
-                            scroll_pixel_position,
                         });
                     }
                     cursors.push(cursor);
@@ -2072,10 +2028,11 @@ impl EditorElement {
         // Note: tick_cursor_animations() handles physics with centralized frame pacing
         let cursor_vfx_pos = cursor_vfx_pos;
         let update_vfx_in_callback = animation_state.is_some();
-        let is_animating = self.editor.update(cx, move |editor, _cx| {
+        let is_animating = self.editor.update(cx, move |editor, cx| {
             let cursor_animating = editor.is_cursor_animating();
             let vfx_animating = editor.is_cursor_vfx_animating();
-            let is_animating = cursor_animating || vfx_animating;
+            let blink_animating = editor.blink_manager.read(cx).is_smooth_blink_animating();
+            let is_animating = cursor_animating || vfx_animating || blink_animating;
 
             // Update VFX system with cursor position from quad cursor
             if !(is_animating && update_vfx_in_callback) {
@@ -2093,15 +2050,16 @@ impl EditorElement {
         // This uses scene caching to skip full layout on animation frames.
         // We register an animation callback to tick physics and paint the cursor
         // on top of the cached scene.
-        if is_animating {
-            window.request_animation_only_frame();
+        if is_animating && let Some(mut state) = animation_state {
+            let generation = self.editor.update(cx, |editor, _cx| {
+                editor.begin_cursor_animation_callback_cycle()
+            });
+            state.generation = generation;
 
-            // Register animation callback with state that re-registers itself each frame
-            if let Some(state) = animation_state {
-                window.on_animation_frame(move |window, cx| {
-                    paint_cursor_animation_frame(state, window, cx);
-                });
-            }
+            window.request_animation_only_frame();
+            window.on_animation_frame(move |window, cx| {
+                paint_cursor_animation_frame(state, window, cx);
+            });
         }
 
         cursor_layouts
@@ -6599,7 +6557,6 @@ impl EditorElement {
                 self.paint_document_colors(layout, window);
                 self.paint_lines(&invisible_display_ranges, layout, window, cx);
                 self.paint_redactions(layout, window);
-                self.paint_block_cursor_destination_mask(layout, window, cx);
                 self.paint_cursors(layout, window, cx);
                 self.paint_inline_diagnostics(layout, window, cx);
                 self.paint_inline_blame(layout, window, cx);
@@ -6813,39 +6770,6 @@ impl EditorElement {
                 );
             }
         });
-    }
-
-    fn paint_block_cursor_destination_mask(
-        &self,
-        layout: &EditorLayout,
-        window: &mut Window,
-        cx: &mut App,
-    ) {
-        let Some((dest_point, dest_x, dest_width)) =
-            self.editor.read(cx).cursor_animation_destination()
-        else {
-            return;
-        };
-
-        let dest_row = dest_point.row();
-        if dest_row < layout.visible_display_row_range.start
-            || dest_row >= layout.visible_display_row_range.end
-        {
-            return;
-        }
-
-        let line_height = layout.position_map.line_height;
-
-        let y = layout.content_origin.y
-            + line_height * (dest_row.0 as f32 - layout.position_map.scroll_position.y as f32);
-        let x = layout.content_origin.x + dest_x
-            - Pixels::from(layout.position_map.scroll_pixel_position.x);
-
-        let bg_color = cx.theme().colors().editor_background;
-        window.paint_quad(fill(
-            Bounds::new(point(x, y), size(dest_width, line_height)),
-            bg_color,
-        ));
     }
 
     fn paint_document_colors(&self, layout: &mut EditorLayout, window: &mut Window) {
@@ -11979,6 +11903,32 @@ pub fn layout_line(
     .unwrap()
 }
 
+fn normalize_block_cursor_grapheme(grapheme: &str) -> SharedString {
+    if let Some(invisible) = grapheme.chars().next().filter(|&char| is_invisible(char)) {
+        replacement(invisible).unwrap_or(grapheme).to_owned().into()
+    } else if grapheme == "\n" {
+        " ".into()
+    } else {
+        grapheme.to_owned().into()
+    }
+}
+
+fn resolve_block_cursor_grapheme(
+    snapshot: &DisplaySnapshot,
+    point: DisplayPoint,
+) -> Option<SharedString> {
+    let grapheme = snapshot.grapheme_at(point).or_else(|| {
+        let clipped = snapshot.clip_point(point, Bias::Left);
+        if clipped != point {
+            snapshot.grapheme_at(clipped)
+        } else {
+            None
+        }
+    })?;
+
+    Some(normalize_block_cursor_grapheme(grapheme.as_ref()))
+}
+
 #[derive(Debug)]
 pub struct IndentGuideLayout {
     origin: gpui::Point<Pixels>,
@@ -12013,16 +11963,17 @@ pub struct CursorName {
 
 /// State for cursor animation callback that re-registers itself each frame.
 struct CursorAnimationState {
+    generation: u64,
     editor: Entity<Editor>,
+    blink_manager: Entity<BlinkManager>,
     content_origin: gpui::Point<Pixels>,
     cursor_pos: gpui::Point<Pixels>,
     cursor_color: Hsla,
     line_height: Pixels,
     block_width: Pixels,
     cursor_shape: CursorShape,
+    /// Block text captured at layout time (character under cursor)
     block_text: Option<ShapedLine>,
-    /// Target position for dynamic block_text lookup
-    target_display_point: DisplayPoint,
     /// Font for shaping block_text
     font: Font,
     /// Font size for shaping block_text
@@ -12031,13 +11982,30 @@ struct CursorAnimationState {
     block_text_color: Hsla,
     /// Whether target position is in a redacted range
     is_target_redacted: bool,
-    scroll_position: gpui::Point<ScrollOffset>,
-    scroll_pixel_position: gpui::Point<ScrollPixelOffset>,
 }
 
 /// Paint one frame of cursor animation and re-register callback if still animating.
 fn paint_cursor_animation_frame(state: CursorAnimationState, window: &mut Window, cx: &mut App) {
-    let (cursor_origin, cursor_corners, still_animating, fresh_block_text, destination_mask) =
+    if !state
+        .editor
+        .read(cx)
+        .is_active_cursor_animation_generation(state.generation)
+    {
+        return;
+    }
+
+    let blink_opacity = state
+        .blink_manager
+        .update(cx, |blink_manager, cx| blink_manager.opacity(cx));
+
+    let (
+        cursor_origin,
+        cursor_corners,
+        cursor_animating,
+        cursor_or_vfx_animating,
+        fresh_block_text,
+        destination_pos,
+    ) =
         state.editor.update(cx, |editor, cx| {
             editor.tick_cursor_animations();
 
@@ -12050,21 +12018,28 @@ fn paint_cursor_animation_frame(state: CursorAnimationState, window: &mut Window
 
             editor.update_cursor_vfx(origin);
 
-            let still_animating = editor.is_cursor_animating() || editor.is_cursor_vfx_animating();
+            let cursor_animating = editor.is_cursor_animating();
+            let cursor_or_vfx_animating = cursor_animating || editor.is_cursor_vfx_animating();
 
-            // Get fresh block_text based on CURRENT target position to fix:
-            // 1. Character "slip-through" when quickly moving cursor
-            // 2. Missing character when moving to a new line
             let fresh_block_text =
                 if state.cursor_shape == CursorShape::Block && !state.is_target_redacted {
-                    // Use current target from editor if available (handles rapid cursor movements)
-                    let target_point = editor
-                        .cursor_animation_destination()
-                        .map(|(dp, _, _)| dp)
-                        .unwrap_or(state.target_display_point);
-
                     let snapshot = editor.display_snapshot(cx);
-                    snapshot.grapheme_at(target_point).map(|text| {
+                    let target_point = editor.selections.newest_display(&snapshot).head();
+                    let target_text = resolve_block_cursor_grapheme(&snapshot, target_point)
+                        .or_else(|| {
+                            if snapshot.is_empty() {
+                                editor.placeholder_text(cx).and_then(|placeholder| {
+                                    placeholder
+                                        .graphemes(true)
+                                        .next()
+                                        .map(normalize_block_cursor_grapheme)
+                                })
+                            } else {
+                                None
+                            }
+                        });
+
+                    target_text.map(|text| {
                         let len = text.len();
                         window.text_system().shape_line(
                             text,
@@ -12082,40 +12057,43 @@ fn paint_cursor_animation_frame(state: CursorAnimationState, window: &mut Window
                     None
                 };
 
-            let destination_mask =
-                if state.cursor_shape == CursorShape::Block && !state.is_target_redacted {
-                    editor
-                        .cursor_animation_destination()
-                        .map(|(dest_point, dest_x, dest_width)| {
-                            let dest_row = dest_point.row();
-                            let y = state.content_origin.y
-                                + state.line_height
-                                    * (dest_row.0 as f32 - state.scroll_position.y as f32);
-                            let x = state.content_origin.x + dest_x
-                                - Pixels::from(state.scroll_pixel_position.x);
-
-                            Bounds::new(point(x, y), size(dest_width, state.line_height))
-                        })
-                } else {
-                    None
-                };
+            let destination_pos = if cursor_animating
+                && state.cursor_shape == CursorShape::Block
+                && !state.is_target_redacted
+            {
+                editor
+                    .quad_cursor()
+                    .map(|quad| quad.destination_pos())
+                    .or(Some(state.cursor_pos))
+            } else {
+                None
+            };
 
             (
                 origin,
                 quad_corners,
-                still_animating,
+                cursor_animating,
+                cursor_or_vfx_animating,
                 fresh_block_text,
-                destination_mask,
+                destination_pos,
             )
         });
 
-    if let Some(mask_bounds) = destination_mask {
-        let bg_color = cx.theme().colors().editor_background;
-        window.paint_quad(fill(mask_bounds, bg_color));
-    }
+    let blink_animating = state.blink_manager.read(cx).is_smooth_blink_animating();
+    let still_animating = cursor_or_vfx_animating || blink_animating;
 
-    // Use fresh block_text if available, otherwise fall back to stored value
     let block_text = fresh_block_text.or_else(|| state.block_text.clone());
+
+    if cursor_animating && let Some(destination_pos) = destination_pos {
+        let destination_bounds = Bounds::new(
+            state.content_origin + destination_pos,
+            size(state.block_width, state.line_height),
+        );
+        window.paint_quad(fill(
+            destination_bounds,
+            cx.theme().colors().editor_background,
+        ));
+    }
 
     let mut cursor = CursorLayout {
         origin: cursor_origin,
@@ -12123,7 +12101,7 @@ fn paint_cursor_animation_frame(state: CursorAnimationState, window: &mut Window
         block_width: state.block_width,
         line_height: state.line_height,
         color: state.cursor_color,
-        opacity: 1.0,
+        opacity: blink_opacity,
         shape: state.cursor_shape,
         block_text,
         cursor_name: None,
@@ -12134,6 +12112,14 @@ fn paint_cursor_animation_frame(state: CursorAnimationState, window: &mut Window
         vfx_system.paint(state.content_origin, window, state.cursor_color);
     }
 
+    if !state
+        .editor
+        .read(cx)
+        .is_active_cursor_animation_generation(state.generation)
+    {
+        return;
+    }
+
     if still_animating {
         window.request_animation_only_frame();
         window.on_animation_frame(move |window, cx| {
@@ -12141,7 +12127,7 @@ fn paint_cursor_animation_frame(state: CursorAnimationState, window: &mut Window
         });
     } else {
         state.editor.update(cx, |editor, cx| {
-            editor.set_cursor_animation_destination(None);
+            editor.end_cursor_animation_callback_cycle(state.generation);
             cx.notify();
         });
     }
@@ -12266,41 +12252,53 @@ impl CursorLayout {
                 gpui::Point::new(corners[3].x + origin.x, corners[3].y + origin.y),
             ];
 
-            // Check if corners form a parallelogram (not a rectangle)
-            // In a rectangle: top edge and bottom edge are parallel and equal length
-            // Deformation = how much the corners deviate from a perfect rectangle
-            let top_edge_x = f32::from(corners_with_offset[1].x - corners_with_offset[0].x);
-            let bottom_edge_x = f32::from(corners_with_offset[2].x - corners_with_offset[3].x);
-            let left_edge_y = f32::from(corners_with_offset[3].y - corners_with_offset[0].y);
-            let right_edge_y = f32::from(corners_with_offset[2].y - corners_with_offset[1].y);
+            self.paint_quad_corners(corners_with_offset, color, window);
 
-            // Measure skew: difference between parallel edges indicates parallelogram deformation
-            let horizontal_skew = (top_edge_x - bottom_edge_x).abs();
-            let vertical_skew = (left_edge_y - right_edge_y).abs();
-            let deformation =
-                (horizontal_skew * horizontal_skew + vertical_skew * vertical_skew).sqrt();
-
-            if deformation > 2.0 && !matches!(self.shape, CursorShape::Hollow) {
-                self.paint_quad_corners(corners_with_offset, color, window);
-
-                if let Some(name) = &mut self.cursor_name {
-                    name.paint(window, cx);
-                }
-
-                if let Some(block_text) = &self.block_text {
-                    block_text
-                        .paint(
-                            self.origin + origin,
-                            self.line_height,
-                            TextAlign::Left,
-                            None,
-                            window,
-                            cx,
-                        )
-                        .log_err();
-                }
-                return;
+            if let Some(name) = &mut self.cursor_name {
+                name.paint(window, cx);
             }
+
+            if let Some(block_text) = &self.block_text {
+                let min_x = corners_with_offset
+                    .iter()
+                    .map(|c| c.x)
+                    .fold(Pixels::MAX, |a, b| a.min(b));
+                let max_x = corners_with_offset
+                    .iter()
+                    .map(|c| c.x)
+                    .fold(Pixels::MIN, |a, b| a.max(b));
+                let min_y = corners_with_offset
+                    .iter()
+                    .map(|c| c.y)
+                    .fold(Pixels::MAX, |a, b| a.min(b));
+                let max_y = corners_with_offset
+                    .iter()
+                    .map(|c| c.y)
+                    .fold(Pixels::MIN, |a, b| a.max(b));
+
+                let clip_bounds =
+                    Bounds::new(point(min_x, min_y), size(max_x - min_x, max_y - min_y));
+
+                window.with_content_mask(
+                    Some(ContentMask {
+                        bounds: clip_bounds,
+                    }),
+                    |window| {
+                        block_text
+                            .paint_with_opacity(
+                                self.origin + origin,
+                                self.line_height,
+                                TextAlign::Left,
+                                None,
+                                self.opacity,
+                                window,
+                                cx,
+                            )
+                            .log_err();
+                    },
+                );
+            }
+            return;
         }
 
         // Normal cursor rendering
@@ -12318,11 +12316,12 @@ impl CursorLayout {
 
         if let Some(block_text) = &self.block_text {
             block_text
-                .paint(
+                .paint_with_opacity(
                     self.origin + origin,
                     self.line_height,
                     TextAlign::Left,
                     None,
+                    self.opacity,
                     window,
                     cx,
                 )
@@ -12380,8 +12379,17 @@ impl CursorLayout {
                 }
             }
             CursorShape::Hollow => {
-                // Hollow cursors don't support quad animation, fall back to head bounds
-                // This case is handled earlier in paint() but included for completeness
+                // Hollow: draw the deformed cursor outline as a stroked quad path.
+                let mut builder = gpui::PathBuilder::stroke(px(1.0));
+                builder.move_to(corners[0]); // top-left
+                builder.line_to(corners[1]); // top-right
+                builder.line_to(corners[2]); // bottom-right
+                builder.line_to(corners[3]); // bottom-left
+                builder.close();
+
+                if let Ok(path) = builder.build() {
+                    window.paint_path(path, color);
+                }
             }
         }
     }
@@ -13755,6 +13763,7 @@ mod tests {
     }
 
     #[test]
+    #[test]
     fn test_checkerboard_size() {
         // line height is smaller than target height, so we just return half the line height
         assert_eq!(EditorElement::checkerboard_size(10.0, 20.0), 5.0);
@@ -13814,5 +13823,32 @@ mod tests {
             calculate_wrap_width(SoftWrap::Bounded(200), px(400.0), em_width),
             Some(px(400.0)),
         );
+    }
+
+    #[test]
+    fn test_normalize_block_cursor_grapheme() {
+        assert_eq!(
+            normalize_block_cursor_grapheme("\n"),
+            SharedString::from(" ")
+        );
+        assert_eq!(
+            normalize_block_cursor_grapheme("a"),
+            SharedString::from("a")
+        );
+
+        if let Some(invisible_char) = ['\u{200B}', '\u{200C}', '\u{00A0}']
+            .into_iter()
+            .find(|character| is_invisible(*character))
+        {
+            let grapheme = invisible_char.to_string();
+            let expected = replacement(invisible_char)
+                .unwrap_or(grapheme.as_str())
+                .to_string();
+            assert_eq!(
+                normalize_block_cursor_grapheme(grapheme.as_str()),
+                SharedString::from(expected)
+            );
+        }
+    }
     }
 }

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1866,36 +1866,15 @@ impl EditorElement {
                     let block_text = if selection.cursor_shape == CursorShape::Block
                         && !is_target_redacted
                     {
-                        resolve_block_cursor_grapheme(&snapshot.display_snapshot, cursor_position)
-                            .or_else(|| {
-                                if snapshot.is_empty() {
-                                    snapshot
-                                        .placeholder_text()
-                                        .and_then(|text| text.graphemes(true).next().map(normalize_block_cursor_grapheme))
-                                } else {
-                                    None
-                                }
-                            })
-                            .map(|text| {
-                                let is_ascii_whitespace_only =
-                                    text.chars().all(|c| c.is_ascii_whitespace());
-                                let len = text.len();
-                                let shaped = window.text_system().shape_line(
-                                    text,
-                                    cursor_row_layout.font_size,
-                                    &[TextRun {
-                                        len,
-                                        font: block_cursor_font.clone(),
-                                        color: block_text_color,
-                                        ..Default::default()
-                                    }],
-                                    None,
-                                );
-                                if !is_ascii_whitespace_only {
-                                    block_width = block_width.max(shaped.width);
-                                }
-                                shaped
-                            })
+                        shape_block_cursor_text_for_point(
+                            &snapshot.display_snapshot,
+                            cursor_position,
+                            snapshot.placeholder_text().as_deref(),
+                            &block_cursor_font,
+                            cursor_row_layout.font_size,
+                            block_text_color,
+                            window,
+                        )
                     } else {
                         None
                     };
@@ -2057,8 +2036,7 @@ impl EditorElement {
         // on top of the cached scene.
         if is_animating && let Some(mut state) = animation_state {
             if let Some(newest_idx) = newest_cursor_index {
-                let mut other_cursors =
-                    Vec::with_capacity(cursor_layouts.len().saturating_sub(1));
+                let mut other_cursors = Vec::with_capacity(cursor_layouts.len().saturating_sub(1));
                 let mut kept = Vec::new();
                 for (i, cursor) in cursor_layouts.into_iter().enumerate() {
                     if i == newest_idx {
@@ -11983,13 +11961,6 @@ fn shape_block_cursor_text_for_point(
     })
 }
 
-fn prefer_cached_block_cursor_text<T>(
-    cached_block_text: Option<T>,
-    fresh_block_text: Option<T>,
-) -> Option<T> {
-    cached_block_text.or(fresh_block_text)
-}
-
 fn quad_top_left_or_fallback(
     quad_corners: Option<[gpui::Point<Pixels>; 4]>,
     fallback_origin: gpui::Point<Pixels>,
@@ -11997,14 +11968,6 @@ fn quad_top_left_or_fallback(
     quad_corners
         .map(|corners| corners[0])
         .unwrap_or(fallback_origin)
-}
-
-fn should_paint_block_cursor_destination_mask<T>(
-    cursor_animating: bool,
-    destination_pos: Option<gpui::Point<Pixels>>,
-    block_text: Option<&T>,
-) -> bool {
-    cursor_animating && destination_pos.is_some() && block_text.is_some()
 }
 
 #[derive(Debug)]
@@ -12067,7 +12030,11 @@ struct CursorAnimationState {
 }
 
 /// Paint one frame of cursor animation and re-register callback if still animating.
-fn paint_cursor_animation_frame(mut state: CursorAnimationState, window: &mut Window, cx: &mut App) {
+fn paint_cursor_animation_frame(
+    mut state: CursorAnimationState,
+    window: &mut Window,
+    cx: &mut App,
+) {
     if !state
         .editor
         .read(cx)
@@ -12105,26 +12072,28 @@ fn paint_cursor_animation_frame(mut state: CursorAnimationState, window: &mut Wi
         let cursor_animating = editor.is_cursor_animating();
         let cursor_or_vfx_animating = cursor_animating || editor.is_cursor_vfx_animating();
 
-        let fresh_block_text =
-            if state.cursor_shape == CursorShape::Block && !state.is_target_redacted {
-                let snapshot = editor.display_snapshot(cx);
-                let placeholder_text = if snapshot.is_empty() {
-                    editor.placeholder_text(cx)
-                } else {
-                    None
-                };
-                shape_block_cursor_text_for_point(
-                    &snapshot,
-                    state.target_display_point,
-                    placeholder_text.as_deref(),
-                    &state.font,
-                    state.font_size,
-                    state.block_text_color,
-                    window,
-                )
+        let fresh_block_text = if state.block_text.is_none()
+            && state.cursor_shape == CursorShape::Block
+            && !state.is_target_redacted
+        {
+            let snapshot = editor.display_snapshot(cx);
+            let placeholder_text = if snapshot.is_empty() {
+                editor.placeholder_text(cx)
             } else {
                 None
             };
+            shape_block_cursor_text_for_point(
+                &snapshot,
+                state.target_display_point,
+                placeholder_text.as_deref(),
+                &state.font,
+                state.font_size,
+                state.block_text_color,
+                window,
+            )
+        } else {
+            None
+        };
 
         let destination_pos = if cursor_animating
             && state.cursor_shape == CursorShape::Block
@@ -12133,7 +12102,7 @@ fn paint_cursor_animation_frame(mut state: CursorAnimationState, window: &mut Wi
             editor
                 .quad_cursor()
                 .map(|quad| quad.destination_pos())
-                .or(Some(state.cursor_pos))
+                .unwrap_or(state.cursor_pos)
         } else {
             None
         };
@@ -12151,13 +12120,12 @@ fn paint_cursor_animation_frame(mut state: CursorAnimationState, window: &mut Wi
     let blink_animating = state.blink_manager.read(cx).is_smooth_blink_animating();
     let still_animating = cursor_or_vfx_animating || blink_animating;
 
-    let block_text = prefer_cached_block_cursor_text(state.block_text.clone(), fresh_block_text);
+    let block_text = state.block_text.clone().or(fresh_block_text);
 
-    if should_paint_block_cursor_destination_mask(
-        cursor_animating,
-        destination_pos,
-        block_text.as_ref(),
-    ) && let Some(destination_pos) = destination_pos
+    if cursor_animating
+        && destination_pos.is_some()
+        && block_text.is_some()
+        && let Some(destination_pos) = destination_pos
     {
         let destination_bounds = Bounds::new(
             state.content_origin + destination_pos,
@@ -12337,10 +12305,8 @@ impl CursorLayout {
             }
 
             if let Some(block_text) = &self.block_text {
-                let block_text_origin = quad_top_left_or_fallback(
-                    Some(corners_with_offset),
-                    self.origin + origin,
-                );
+                let block_text_origin =
+                    quad_top_left_or_fallback(Some(corners_with_offset), self.origin + origin);
                 block_text
                     .paint_with_opacity(
                         block_text_origin,
@@ -13272,37 +13238,6 @@ mod tests {
                 assert_eq!(right_text.as_deref(), Some("b"));
             })
             .unwrap();
-    }
-
-    #[test]
-    fn test_prefer_cached_block_cursor_text_prioritizes_cached_value() {
-        assert_eq!(prefer_cached_block_cursor_text(Some(1), Some(2)), Some(1));
-        assert_eq!(prefer_cached_block_cursor_text(Some(1), None), Some(1));
-        assert_eq!(
-            prefer_cached_block_cursor_text(None::<i32>, Some(2)),
-            Some(2)
-        );
-    }
-
-    #[test]
-    fn test_destination_mask_requires_block_text() {
-        let destination = Some(point(px(4.), px(2.)));
-
-        assert!(!should_paint_block_cursor_destination_mask::<u8>(
-            true,
-            destination,
-            None
-        ));
-        assert!(!should_paint_block_cursor_destination_mask(
-            false,
-            destination,
-            Some(&1u8)
-        ));
-        assert!(should_paint_block_cursor_destination_mask(
-            true,
-            destination,
-            Some(&1u8)
-        ));
     }
 
     #[test]

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -41,15 +41,15 @@ use git::{Oid, blame::BlameEntry, commit::ParsedCommitMessage, status::FileStatu
 use gpui::{
     Action, Along, AnyElement, App, AppContext, AvailableSpace, Axis as ScrollbarAxis, BorderStyle,
     Bounds, ClickEvent, ClipboardItem, ContentMask, Context, Corner, Corners, CursorStyle,
-    DispatchPhase, Edges, Element, ElementInputHandler, Entity, Focusable as _, FontId, FontWeight,
-    GlobalElementId, Hitbox, HitboxBehavior, Hsla, InteractiveElement, IntoElement, IsZero,
-    KeybindingKeystroke, Length, Modifiers, ModifiersChangedEvent, MouseButton, MouseClickEvent,
-    MouseDownEvent, MouseMoveEvent, MousePressureEvent, MouseUpEvent, PaintQuad, ParentElement,
-    Pixels, PressureStage, ScrollDelta, ScrollHandle, ScrollWheelEvent, ShapedLine, SharedString,
-    Size, StatefulInteractiveElement, Style, Styled, StyledText, TextAlign, TextRun,
+    DispatchPhase, Edges, Element, ElementInputHandler, Entity, Focusable as _, Font, FontId,
+    FontWeight, GlobalElementId, Hitbox, HitboxBehavior, Hsla, InteractiveElement, IntoElement,
+    IsZero, KeybindingKeystroke, Length, Modifiers, ModifiersChangedEvent, MouseButton,
+    MouseClickEvent, MouseDownEvent, MouseMoveEvent, MousePressureEvent, MouseUpEvent, PaintQuad,
+    ParentElement, Pixels, PressureStage, ScrollDelta, ScrollHandle, ScrollWheelEvent, ShapedLine,
+    SharedString, Size, StatefulInteractiveElement, Style, Styled, StyledText, TextAlign, TextRun,
     TextStyleRefinement, WeakEntity, Window, anchored, checkerboard, deferred, div, fill,
-    linear_color_stop, linear_gradient, outline, point, px, quad, relative, size, solid_background,
-    transparent_black,
+    linear_color_stop, linear_gradient, outline, pattern_slash, point, px, quad, relative, rgba, size,
+    solid_background, transparent_black,
 };
 use itertools::Itertools;
 use language::{IndentGuideSettings, language_settings::ShowWhitespaceSetting};
@@ -1834,16 +1834,40 @@ impl EditorElement {
                     if cell_width == Pixels::ZERO {
                         cell_width = em_advance;
                     }
-
                     let mut block_width = cell_width;
                     let mut block_text = None;
 
-                    let is_cursor_in_redacted_range = redacted_ranges
+                    // Check if cursor is in a redacted range
+                    let is_target_redacted = redacted_ranges
                         .iter()
                         .any(|range| range.start <= cursor_position && cursor_position < range.end);
 
-                    if selection.cursor_shape == CursorShape::Block && !is_cursor_in_redacted_range
-                    {
+                    // Compute font and color for block cursor text - needed for animation state
+                    let mut block_cursor_font = cursor_row_layout
+                        .font_id_for_index(cursor_column)
+                        .and_then(|cursor_font_id| {
+                            window.text_system().get_font_for_id(cursor_font_id)
+                        })
+                        .unwrap_or(self.style.text.font());
+                    block_cursor_font.features = self.style.text.font_features.clone();
+
+                    // Invert the text color for the block cursor. Ensure that the text
+                    // color is opaque enough to be visible against the background color.
+                    //
+                    // 0.75 is an arbitrary threshold to determine if the background color is
+                    // opaque enough to use as a text color.
+                    //
+                    // TODO: In the future we should ensure themes have a `text_inverse` color.
+                    let block_text_color = if cx.theme().colors().editor_background.a < 0.75 {
+                        match cx.theme().appearance {
+                            Appearance::Dark => Hsla::black(),
+                            Appearance::Light => Hsla::white(),
+                        }
+                    } else {
+                        cx.theme().colors().editor_background
+                    };
+
+                    if selection.cursor_shape == CursorShape::Block && !is_target_redacted {
                         if let Some(text) = snapshot.grapheme_at(cursor_position).or_else(|| {
                             if snapshot.is_empty() {
                                 snapshot.placeholder_text().and_then(|s| {
@@ -1857,37 +1881,13 @@ impl EditorElement {
                                 text.as_ref().chars().all(|c| c.is_ascii_whitespace());
                             let len = text.len();
 
-                            let mut font = cursor_row_layout
-                                .font_id_for_index(cursor_column)
-                                .and_then(|cursor_font_id| {
-                                    window.text_system().get_font_for_id(cursor_font_id)
-                                })
-                                .unwrap_or(self.style.text.font());
-                            font.features = self.style.text.font_features.clone();
-
-                            // Invert the text color for the block cursor. Ensure that the text
-                            // color is opaque enough to be visible against the background color.
-                            //
-                            // 0.75 is an arbitrary threshold to determine if the background color is
-                            // opaque enough to use as a text color.
-                            //
-                            // TODO: In the future we should ensure themes have a `text_inverse` color.
-                            let color = if cx.theme().colors().editor_background.a < 0.75 {
-                                match cx.theme().appearance {
-                                    Appearance::Dark => Hsla::black(),
-                                    Appearance::Light => Hsla::white(),
-                                }
-                            } else {
-                                cx.theme().colors().editor_background
-                            };
-
                             let shaped = window.text_system().shape_line(
                                 text,
                                 cursor_row_layout.font_size,
                                 &[TextRun {
                                     len,
-                                    font,
-                                    color,
+                                    font: block_cursor_font.clone(),
+                                    color: block_text_color,
                                     ..Default::default()
                                 }],
                                 None,
@@ -1899,6 +1899,38 @@ impl EditorElement {
                         }
                     }
 
+                    let block_text =
+                        if selection.cursor_shape == CursorShape::Block && !is_target_redacted {
+                            snapshot
+                                .grapheme_at(cursor_position)
+                                .or_else(|| {
+                                    if snapshot.is_empty() {
+                                        snapshot.placeholder_text().and_then(|s| {
+                                            s.graphemes(true).next().map(|s| s.to_string().into())
+                                        })
+                                    } else {
+                                        None
+                                    }
+                                })
+                                .map(|text| {
+                                    let len = text.len();
+                                    window.text_system().shape_line(
+                                        text,
+                                        cursor_row_layout.font_size,
+                                        &[TextRun {
+                                            len,
+                                            font: block_cursor_font.clone(),
+                                            color: block_text_color,
+                                            ..Default::default()
+                                        }],
+                                        None,
+                                    )
+                                })
+                        } else {
+                            None
+                        };
+                    let block_cursor_font_size = cursor_row_layout.font_size;
+
                     let logical_x = cursor_character_x - scroll_pixel_position.x.into();
                     let logical_y: Pixels = ((cursor_position.row().as_f64() - scroll_position.y)
                         * ScrollPixelOffset::from(line_height))
@@ -1907,7 +1939,8 @@ impl EditorElement {
                     // For the newest (primary) cursor, use inertial animation if enabled
                     // Order: 1) set target 2) tick physics 3) read position
                     // This ensures physics uses the NEW target, eliminating one-frame lag
-                    let (x, y, quad_corners, cursor_animating_for_opacity) = if selection.is_newest {
+                    let (x, y, quad_corners, cursor_animating_for_opacity) = if selection.is_newest
+                    {
                         if let Some(quad) = editor.quad_cursor_mut() {
                             // Set target position for animation
                             quad.set_logical_pos(point(logical_x, logical_y));
@@ -1917,6 +1950,16 @@ impl EditorElement {
                             let corners = quad.interpolated_corner_positions();
                             let visual = quad.visual_pos();
                             let cursor_animating = editor.is_cursor_animating();
+                            // Track destination position for block cursor to mask ghost character
+                            if cursor_animating && selection.cursor_shape == CursorShape::Block {
+                                editor.set_cursor_animation_destination(Some((
+                                    cursor_position,
+                                    cursor_character_x,
+                                    block_width,
+                                )));
+                            } else {
+                                editor.set_cursor_animation_destination(None);
+                            }
                             (visual.x, visual.y, Some(corners), cursor_animating)
                         } else {
                             (logical_x, logical_y, None, false)
@@ -2005,6 +2048,13 @@ impl EditorElement {
                             block_width: cursor.block_width,
                             cursor_shape: cursor.shape,
                             block_text: cursor.block_text.clone(),
+                            target_display_point: cursor_position,
+                            font: block_cursor_font,
+                            font_size: block_cursor_font_size,
+                            block_text_color,
+                            is_target_redacted,
+                            scroll_position,
+                            scroll_pixel_position,
                         });
                     }
                     cursors.push(cursor);
@@ -6549,6 +6599,7 @@ impl EditorElement {
                 self.paint_document_colors(layout, window);
                 self.paint_lines(&invisible_display_ranges, layout, window, cx);
                 self.paint_redactions(layout, window);
+                self.paint_block_cursor_destination_mask(layout, window, cx);
                 self.paint_cursors(layout, window, cx);
                 self.paint_inline_diagnostics(layout, window, cx);
                 self.paint_inline_blame(layout, window, cx);
@@ -6764,6 +6815,39 @@ impl EditorElement {
         });
     }
 
+    fn paint_block_cursor_destination_mask(
+        &self,
+        layout: &EditorLayout,
+        window: &mut Window,
+        cx: &mut App,
+    ) {
+        let Some((dest_point, dest_x, dest_width)) =
+            self.editor.read(cx).cursor_animation_destination()
+        else {
+            return;
+        };
+
+        let dest_row = dest_point.row();
+        if dest_row < layout.visible_display_row_range.start
+            || dest_row >= layout.visible_display_row_range.end
+        {
+            return;
+        }
+
+        let line_height = layout.position_map.line_height;
+
+        let y = layout.content_origin.y
+            + line_height * (dest_row.0 as f32 - layout.position_map.scroll_position.y as f32);
+        let x = layout.content_origin.x + dest_x
+            - Pixels::from(layout.position_map.scroll_pixel_position.x);
+
+        let bg_color = cx.theme().colors().editor_background;
+        window.paint_quad(fill(
+            Bounds::new(point(x, y), size(dest_width, line_height)),
+            bg_color,
+        ));
+    }
+
     fn paint_document_colors(&self, layout: &mut EditorLayout, window: &mut Window) {
         let Some((colors_render_mode, image_colors)) = &layout.document_colors else {
             return;
@@ -6826,16 +6910,17 @@ impl EditorElement {
         // Paint cursor VFX particles if enabled
         if let Some(vfx_system) = self.editor.read(cx).cursor_vfx_system() {
             // Use the cursor color from the first visible cursor, or fallback to white
-            let cursor_color = layout
-                .visible_cursors
-                .first()
-                .map(|c| c.color)
-                .unwrap_or(gpui::Hsla {
-                    h: 0.0,
-                    s: 0.0,
-                    l: 1.0,
-                    a: 1.0,
-                });
+            let cursor_color =
+                layout
+                    .visible_cursors
+                    .first()
+                    .map(|c| c.color)
+                    .unwrap_or(gpui::Hsla {
+                        h: 0.0,
+                        s: 0.0,
+                        l: 1.0,
+                        a: 1.0,
+                    });
             vfx_system.paint(layout.content_origin, window, cursor_color);
         }
     }
@@ -11936,12 +12021,24 @@ struct CursorAnimationState {
     block_width: Pixels,
     cursor_shape: CursorShape,
     block_text: Option<ShapedLine>,
+    /// Target position for dynamic block_text lookup
+    target_display_point: DisplayPoint,
+    /// Font for shaping block_text
+    font: Font,
+    /// Font size for shaping block_text
+    font_size: Pixels,
+    /// Text color for block cursor (inverted background)
+    block_text_color: Hsla,
+    /// Whether target position is in a redacted range
+    is_target_redacted: bool,
+    scroll_position: gpui::Point<ScrollOffset>,
+    scroll_pixel_position: gpui::Point<ScrollPixelOffset>,
 }
 
 /// Paint one frame of cursor animation and re-register callback if still animating.
 fn paint_cursor_animation_frame(state: CursorAnimationState, window: &mut Window, cx: &mut App) {
-    let (cursor_origin, cursor_corners, still_animating) =
-        state.editor.update(cx, |editor, _cx| {
+    let (cursor_origin, cursor_corners, still_animating, fresh_block_text, destination_mask) =
+        state.editor.update(cx, |editor, cx| {
             editor.tick_cursor_animations();
 
             let (origin, quad_corners) = if let Some(quad) = editor.quad_cursor() {
@@ -11955,8 +12052,70 @@ fn paint_cursor_animation_frame(state: CursorAnimationState, window: &mut Window
 
             let still_animating = editor.is_cursor_animating() || editor.is_cursor_vfx_animating();
 
-            (origin, quad_corners, still_animating)
+            // Get fresh block_text based on CURRENT target position to fix:
+            // 1. Character "slip-through" when quickly moving cursor
+            // 2. Missing character when moving to a new line
+            let fresh_block_text =
+                if state.cursor_shape == CursorShape::Block && !state.is_target_redacted {
+                    // Use current target from editor if available (handles rapid cursor movements)
+                    let target_point = editor
+                        .cursor_animation_destination()
+                        .map(|(dp, _, _)| dp)
+                        .unwrap_or(state.target_display_point);
+
+                    let snapshot = editor.display_snapshot(cx);
+                    snapshot.grapheme_at(target_point).map(|text| {
+                        let len = text.len();
+                        window.text_system().shape_line(
+                            text,
+                            state.font_size,
+                            &[TextRun {
+                                len,
+                                font: state.font.clone(),
+                                color: state.block_text_color,
+                                ..Default::default()
+                            }],
+                            None,
+                        )
+                    })
+                } else {
+                    None
+                };
+
+            let destination_mask =
+                if state.cursor_shape == CursorShape::Block && !state.is_target_redacted {
+                    editor
+                        .cursor_animation_destination()
+                        .map(|(dest_point, dest_x, dest_width)| {
+                            let dest_row = dest_point.row();
+                            let y = state.content_origin.y
+                                + state.line_height
+                                    * (dest_row.0 as f32 - state.scroll_position.y as f32);
+                            let x = state.content_origin.x + dest_x
+                                - Pixels::from(state.scroll_pixel_position.x);
+
+                            Bounds::new(point(x, y), size(dest_width, state.line_height))
+                        })
+                } else {
+                    None
+                };
+
+            (
+                origin,
+                quad_corners,
+                still_animating,
+                fresh_block_text,
+                destination_mask,
+            )
         });
+
+    if let Some(mask_bounds) = destination_mask {
+        let bg_color = cx.theme().colors().editor_background;
+        window.paint_quad(fill(mask_bounds, bg_color));
+    }
+
+    // Use fresh block_text if available, otherwise fall back to stored value
+    let block_text = fresh_block_text.or_else(|| state.block_text.clone());
 
     let mut cursor = CursorLayout {
         origin: cursor_origin,
@@ -11966,7 +12125,7 @@ fn paint_cursor_animation_frame(state: CursorAnimationState, window: &mut Window
         color: state.cursor_color,
         opacity: 1.0,
         shape: state.cursor_shape,
-        block_text: state.block_text.clone(),
+        block_text,
         cursor_name: None,
     };
     cursor.paint(state.content_origin, window, cx);
@@ -11981,7 +12140,10 @@ fn paint_cursor_animation_frame(state: CursorAnimationState, window: &mut Window
             paint_cursor_animation_frame(state, window, cx);
         });
     } else {
-        state.editor.update(cx, |_, cx| cx.notify());
+        state.editor.update(cx, |editor, cx| {
+            editor.set_cursor_animation_destination(None);
+            cx.notify();
+        });
     }
 }
 
@@ -12127,7 +12289,14 @@ impl CursorLayout {
 
                 if let Some(block_text) = &self.block_text {
                     block_text
-                        .paint(self.origin + origin, self.line_height, TextAlign::Left, None, window, cx)
+                        .paint(
+                            self.origin + origin,
+                            self.line_height,
+                            TextAlign::Left,
+                            None,
+                            window,
+                            cx,
+                        )
                         .log_err();
                 }
                 return;

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -12183,7 +12183,6 @@ fn paint_cursor_animation_frame(mut state: CursorAnimationState, window: &mut Wi
     cursor.paint(state.content_origin, window, cx);
 
     for other in &mut state.other_cursors {
-        other.opacity = blink_opacity;
         other.paint(state.content_origin, window, cx);
     }
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1790,10 +1790,23 @@ impl EditorElement {
         cx: &mut App,
     ) -> Vec<CursorLayout> {
         let mut autoscroll_bounds = None;
+        let mut cursor_vfx_pos = None;
+        let mut animation_state = None;
+        let editor_handle = self.editor.clone();
         let cursor_layouts = self.editor.update(cx, |editor, cx| {
             let mut cursors = Vec::new();
 
             let show_local_cursors = editor.show_local_cursors(window, cx);
+            // When smooth cursor animation is enabled, disable blinking entirely.
+            // Blinking adds visual noise when cursor is already smoothly animating.
+            let smooth_cursor_enabled = editor.quad_cursor().is_some();
+            let blink_opacity = if smooth_cursor_enabled {
+                1.0 // Always visible when smooth cursor is enabled
+            } else if editor.blink_manager.read(cx).visible() {
+                1.0
+            } else {
+                0.0
+            };
 
             for (player_color, selections) in selections {
                 for selection in selections {
@@ -1886,10 +1899,36 @@ impl EditorElement {
                         }
                     }
 
-                    let x = cursor_character_x - scroll_pixel_position.x.into();
-                    let y = ((cursor_position.row().as_f64() - scroll_position.y)
+                    let logical_x = cursor_character_x - scroll_pixel_position.x.into();
+                    let logical_y: Pixels = ((cursor_position.row().as_f64() - scroll_position.y)
                         * ScrollPixelOffset::from(line_height))
                     .into();
+
+                    // For the newest (primary) cursor, use inertial animation if enabled
+                    // Order: 1) set target 2) tick physics 3) read position
+                    // This ensures physics uses the NEW target, eliminating one-frame lag
+                    let (x, y, quad_corners, cursor_animating_for_opacity) = if selection.is_newest {
+                        if let Some(quad) = editor.quad_cursor_mut() {
+                            // Set target position for animation
+                            quad.set_logical_pos(point(logical_x, logical_y));
+                            quad.set_cell_size(block_width.into(), line_height.into());
+                            // Physics tick happens in animation callback only (prevents double-tick)
+                            // Use interpolated positions for smooth rendering between physics ticks
+                            let corners = quad.interpolated_corner_positions();
+                            let visual = quad.visual_pos();
+                            let cursor_animating = editor.is_cursor_animating();
+                            (visual.x, visual.y, Some(corners), cursor_animating)
+                        } else {
+                            (logical_x, logical_y, None, false)
+                        }
+                    } else {
+                        (logical_x, logical_y, None, false)
+                    };
+
+                    if selection.is_newest {
+                        cursor_vfx_pos = Some(point(x, y));
+                    }
+
                     if selection.is_newest {
                         editor.pixel_position_of_newest_cursor = Some(point(
                             text_hitbox.origin.x + x + block_width / 2.,
@@ -1929,7 +1968,23 @@ impl EditorElement {
                         color: player_color.cursor,
                         block_width,
                         origin: point(x, y),
+                        quad_corners,
                         line_height,
+                        // When smooth cursor is animating, animation callback handles this cursor.
+                        // Only suppress when animation is active to prevent flicker on animation end.
+                        // With smooth cursor disabled, use normal blink behavior.
+                        opacity: if selection.is_newest
+                            && quad_corners.is_some()
+                            && cursor_animating_for_opacity
+                        {
+                            0.0 // Animation callback handles this cursor
+                        } else if selection.is_local && smooth_cursor_enabled {
+                            1.0 // Smooth cursor at rest - always visible
+                        } else if selection.is_local {
+                            blink_opacity // Normal blink behavior
+                        } else {
+                            1.0 // Remote cursors
+                        },
                         shape: selection.cursor_shape,
                         block_text,
                         cursor_name: None,
@@ -1940,6 +1995,18 @@ impl EditorElement {
                         is_top_row: cursor_position.row().0 == 0,
                     });
                     cursor.layout(content_origin, cursor_name, window, cx);
+                    if selection.is_newest {
+                        animation_state = Some(CursorAnimationState {
+                            editor: editor_handle.clone(),
+                            content_origin,
+                            cursor_pos: point(x, y),
+                            cursor_color: cursor.color,
+                            line_height: cursor.line_height,
+                            block_width: cursor.block_width,
+                            cursor_shape: cursor.shape,
+                            block_text: cursor.block_text.clone(),
+                        });
+                    }
                     cursors.push(cursor);
                 }
             }
@@ -1949,6 +2016,42 @@ impl EditorElement {
 
         if let Some(bounds) = autoscroll_bounds {
             window.request_autoscroll(bounds);
+        }
+
+        // Update VFX and request next frame if still animating
+        // Note: tick_cursor_animations() handles physics with centralized frame pacing
+        let cursor_vfx_pos = cursor_vfx_pos;
+        let update_vfx_in_callback = animation_state.is_some();
+        let is_animating = self.editor.update(cx, move |editor, _cx| {
+            let cursor_animating = editor.is_cursor_animating();
+            let vfx_animating = editor.is_cursor_vfx_animating();
+            let is_animating = cursor_animating || vfx_animating;
+
+            // Update VFX system with cursor position from quad cursor
+            if !(is_animating && update_vfx_in_callback) {
+                if let Some(quad) = editor.quad_cursor() {
+                    let pos = quad.visual_pos();
+                    editor.update_cursor_vfx(pos);
+                } else if let Some(pos) = cursor_vfx_pos {
+                    editor.update_cursor_vfx(pos);
+                }
+            }
+
+            is_animating
+        });
+        // Request animation-only frame for smooth cursor animation.
+        // This uses scene caching to skip full layout on animation frames.
+        // We register an animation callback to tick physics and paint the cursor
+        // on top of the cached scene.
+        if is_animating {
+            window.request_animation_only_frame();
+
+            // Register animation callback with state that re-registers itself each frame
+            if let Some(state) = animation_state {
+                window.on_animation_frame(move |window, cx| {
+                    paint_cursor_animation_frame(state, window, cx);
+                });
+            }
         }
 
         cursor_layouts
@@ -6704,8 +6807,36 @@ impl EditorElement {
     }
 
     fn paint_cursors(&mut self, layout: &mut EditorLayout, window: &mut Window, cx: &mut App) {
+        // Skip cursor painting during regular paint when animation is active.
+        // The animation callback will handle cursor painting to avoid
+        // the cursor being included in the cached scene.
+        let is_animating = {
+            let editor = self.editor.read(cx);
+            editor.is_cursor_animating() || editor.is_cursor_vfx_animating()
+        };
+
+        if is_animating {
+            return;
+        }
+
         for cursor in &mut layout.visible_cursors {
             cursor.paint(layout.content_origin, window, cx);
+        }
+
+        // Paint cursor VFX particles if enabled
+        if let Some(vfx_system) = self.editor.read(cx).cursor_vfx_system() {
+            // Use the cursor color from the first visible cursor, or fallback to white
+            let cursor_color = layout
+                .visible_cursors
+                .first()
+                .map(|c| c.color)
+                .unwrap_or(gpui::Hsla {
+                    h: 0.0,
+                    s: 0.0,
+                    l: 1.0,
+                    a: 1.0,
+                });
+            vfx_system.paint(layout.content_origin, window, cursor_color);
         }
     }
 
@@ -11775,9 +11906,14 @@ pub struct IndentGuideLayout {
 
 pub struct CursorLayout {
     origin: gpui::Point<Pixels>,
+    /// Four corner positions for quad animation.
+    /// Corners are in order: [top-left, top-right, bottom-right, bottom-left]
+    quad_corners: Option<[gpui::Point<Pixels>; 4]>,
     block_width: Pixels,
     line_height: Pixels,
     color: Hsla,
+    /// Opacity for smooth blink (0.0 = hidden, 1.0 = fully visible).
+    opacity: f32,
     shape: CursorShape,
     block_text: Option<ShapedLine>,
     cursor_name: Option<AnyElement>,
@@ -11788,6 +11924,65 @@ pub struct CursorName {
     string: SharedString,
     color: Hsla,
     is_top_row: bool,
+}
+
+/// State for cursor animation callback that re-registers itself each frame.
+struct CursorAnimationState {
+    editor: Entity<Editor>,
+    content_origin: gpui::Point<Pixels>,
+    cursor_pos: gpui::Point<Pixels>,
+    cursor_color: Hsla,
+    line_height: Pixels,
+    block_width: Pixels,
+    cursor_shape: CursorShape,
+    block_text: Option<ShapedLine>,
+}
+
+/// Paint one frame of cursor animation and re-register callback if still animating.
+fn paint_cursor_animation_frame(state: CursorAnimationState, window: &mut Window, cx: &mut App) {
+    let (cursor_origin, cursor_corners, still_animating) =
+        state.editor.update(cx, |editor, _cx| {
+            editor.tick_cursor_animations();
+
+            let (origin, quad_corners) = if let Some(quad) = editor.quad_cursor() {
+                let visual = quad.visual_pos();
+                (visual, Some(quad.interpolated_corner_positions()))
+            } else {
+                (state.cursor_pos, None)
+            };
+
+            editor.update_cursor_vfx(origin);
+
+            let still_animating = editor.is_cursor_animating() || editor.is_cursor_vfx_animating();
+
+            (origin, quad_corners, still_animating)
+        });
+
+    let mut cursor = CursorLayout {
+        origin: cursor_origin,
+        quad_corners: cursor_corners,
+        block_width: state.block_width,
+        line_height: state.line_height,
+        color: state.cursor_color,
+        opacity: 1.0,
+        shape: state.cursor_shape,
+        block_text: state.block_text.clone(),
+        cursor_name: None,
+    };
+    cursor.paint(state.content_origin, window, cx);
+
+    if let Some(vfx_system) = state.editor.read(cx).cursor_vfx_system() {
+        vfx_system.paint(state.content_origin, window, state.cursor_color);
+    }
+
+    if still_animating {
+        window.request_animation_only_frame();
+        window.on_animation_frame(move |window, cx| {
+            paint_cursor_animation_frame(state, window, cx);
+        });
+    } else {
+        state.editor.update(cx, |_, cx| cx.notify());
+    }
 }
 
 impl CursorLayout {
@@ -11801,13 +11996,26 @@ impl CursorLayout {
     ) -> CursorLayout {
         CursorLayout {
             origin,
+            quad_corners: None,
             block_width,
             line_height,
             color,
+            opacity: 1.0,
             shape,
             block_text,
             cursor_name: None,
         }
+    }
+
+    /// Corners should be in order: [top-left, top-right, bottom-right, bottom-left]
+    pub fn with_quad_corners(mut self, corners: Option<[gpui::Point<Pixels>; 4]>) -> Self {
+        self.quad_corners = corners;
+        self
+    }
+
+    pub fn with_opacity(mut self, opacity: f32) -> Self {
+        self.opacity = opacity;
+        self
     }
 
     pub fn bounding_rect(&self, origin: gpui::Point<Pixels>) -> Bounds<Pixels> {
@@ -11877,13 +12085,60 @@ impl CursorLayout {
     }
 
     pub fn paint(&mut self, origin: gpui::Point<Pixels>, window: &mut Window, cx: &mut App) {
-        let bounds = self.bounds(origin);
+        let color = Hsla {
+            a: self.color.a * self.opacity,
+            ..self.color
+        };
 
-        //Draw background or border quad
+        if self.opacity < 0.01 {
+            return;
+        }
+
+        let head_bounds = self.bounds(origin);
+
+        if let Some(corners) = self.quad_corners {
+            let corners_with_offset = [
+                gpui::Point::new(corners[0].x + origin.x, corners[0].y + origin.y),
+                gpui::Point::new(corners[1].x + origin.x, corners[1].y + origin.y),
+                gpui::Point::new(corners[2].x + origin.x, corners[2].y + origin.y),
+                gpui::Point::new(corners[3].x + origin.x, corners[3].y + origin.y),
+            ];
+
+            // Check if corners form a parallelogram (not a rectangle)
+            // In a rectangle: top edge and bottom edge are parallel and equal length
+            // Deformation = how much the corners deviate from a perfect rectangle
+            let top_edge_x = f32::from(corners_with_offset[1].x - corners_with_offset[0].x);
+            let bottom_edge_x = f32::from(corners_with_offset[2].x - corners_with_offset[3].x);
+            let left_edge_y = f32::from(corners_with_offset[3].y - corners_with_offset[0].y);
+            let right_edge_y = f32::from(corners_with_offset[2].y - corners_with_offset[1].y);
+
+            // Measure skew: difference between parallel edges indicates parallelogram deformation
+            let horizontal_skew = (top_edge_x - bottom_edge_x).abs();
+            let vertical_skew = (left_edge_y - right_edge_y).abs();
+            let deformation =
+                (horizontal_skew * horizontal_skew + vertical_skew * vertical_skew).sqrt();
+
+            if deformation > 2.0 && !matches!(self.shape, CursorShape::Hollow) {
+                self.paint_quad_corners(corners_with_offset, color, window);
+
+                if let Some(name) = &mut self.cursor_name {
+                    name.paint(window, cx);
+                }
+
+                if let Some(block_text) = &self.block_text {
+                    block_text
+                        .paint(self.origin + origin, self.line_height, TextAlign::Left, None, window, cx)
+                        .log_err();
+                }
+                return;
+            }
+        }
+
+        // Normal cursor rendering
         let cursor = if matches!(self.shape, CursorShape::Hollow) {
-            outline(bounds, self.color, BorderStyle::Solid)
+            outline(head_bounds, color, BorderStyle::Solid)
         } else {
-            fill(bounds, self.color)
+            fill(head_bounds, color)
         };
 
         if let Some(name) = &mut self.cursor_name {
@@ -11906,8 +12161,60 @@ impl CursorLayout {
         }
     }
 
-    pub fn shape(&self) -> CursorShape {
-        self.shape
+    /// Used for parallelogram deformation during movement.
+    fn paint_quad_corners(
+        &self,
+        corners: [gpui::Point<Pixels>; 4],
+        color: Hsla,
+        window: &mut Window,
+    ) {
+        match self.shape {
+            CursorShape::Bar => {
+                // Bar: only use left edge of quad (corners 0 and 3)
+                let bar_width = px(2.0);
+                let mut builder = gpui::PathBuilder::fill();
+                builder.move_to(corners[0]);
+                builder.line_to(point(corners[0].x + bar_width, corners[0].y));
+                builder.line_to(point(corners[3].x + bar_width, corners[3].y));
+                builder.line_to(corners[3]);
+                builder.close();
+
+                if let Ok(path) = builder.build() {
+                    window.paint_path(path, color);
+                }
+            }
+            CursorShape::Block => {
+                // Block: draw full parallelogram using all 4 corners
+                let mut builder = gpui::PathBuilder::fill();
+                builder.move_to(corners[0]); // top-left
+                builder.line_to(corners[1]); // top-right
+                builder.line_to(corners[2]); // bottom-right
+                builder.line_to(corners[3]); // bottom-left
+                builder.close();
+
+                if let Ok(path) = builder.build() {
+                    window.paint_path(path, color);
+                }
+            }
+            CursorShape::Underline => {
+                // Underline: use bottom edge of quad (corners 2 and 3)
+                let underline_height = px(2.0);
+                let mut builder = gpui::PathBuilder::fill();
+                builder.move_to(point(corners[3].x, corners[3].y - underline_height));
+                builder.line_to(point(corners[2].x, corners[2].y - underline_height));
+                builder.line_to(corners[2]);
+                builder.line_to(corners[3]);
+                builder.close();
+
+                if let Ok(path) = builder.build() {
+                    window.paint_path(path, color);
+                }
+            }
+            CursorShape::Hollow => {
+                // Hollow cursors don't support quad animation, fall back to head bounds
+                // This case is handled earlier in paint() but included for completeness
+            }
+        }
     }
 }
 

--- a/crates/editor/src/inertial_cursor.rs
+++ b/crates/editor/src/inertial_cursor.rs
@@ -1,0 +1,798 @@
+use std::time::{Duration, Instant};
+
+use gpui::{Pixels, Point, point};
+
+use crate::editor_settings::SmoothCaret;
+
+/// Maximum animation step to prevent large jumps (~8.3ms at 120Hz)
+/// This ensures smooth animation even when frames are skipped.
+pub const MAX_ANIMATION_DT: f32 = 1.0 / 120.0;
+
+/// Fixed timestep for physics simulation (120Hz).
+/// Physics always runs at this rate; rendering interpolates between states.
+const PHYSICS_DT: f32 = 1.0 / 120.0;
+
+/// Distance threshold (in pixels) above which cursor snaps immediately.
+/// Prevents excessive stretching during very large jumps (e.g., search, goto).
+const LARGE_JUMP_SNAP_THRESHOLD: f32 = 1000.0;
+
+/// Minimum animation time for corner animation.
+/// Allows near-instant snap for leading corners with high trail_size.
+const MIN_CORNER_ANIMATION_TIME: f32 = 0.001;
+
+/// Convergence threshold for spring animation.
+/// Only check position for convergence, not velocity.
+const SPRING_CONVERGENCE_THRESHOLD: f32 = 0.01;
+
+/// Simple frame pacing for cursor animations.
+/// Uses actual wall-clock delta for smooth, drift-free animation.
+///
+/// Usage:
+/// 1. Call `tick(now)` at the start of each frame to get dt
+/// 2. Pass that dt to cursor's `update_physics(dt)`
+/// 3. Call `stop()` when animation finishes
+#[derive(Debug, Clone)]
+pub struct CursorAnimationTicker {
+    /// Last tick timestamp for delta calculation.
+    last_tick: Option<Instant>,
+    /// Whether we're currently in an animation period.
+    is_animating: bool,
+}
+
+impl Default for CursorAnimationTicker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CursorAnimationTicker {
+    /// Maximum dt to prevent huge jumps (e.g., after sleep/tab switch).
+    /// Caps at ~20fps minimum.
+    const MAX_DT: Duration = Duration::from_millis(50);
+
+    /// Default dt for first frame (~120Hz).
+    const DEFAULT_FIRST_FRAME_DT: Duration = Duration::from_millis(8);
+
+    pub fn new() -> Self {
+        Self {
+            last_tick: None,
+            is_animating: false,
+        }
+    }
+
+    /// Get the time delta since last tick.
+    /// Returns actual wall-clock delta, capped to prevent huge jumps.
+    pub fn tick(&mut self, now: Instant) -> Duration {
+        let dt = match self.last_tick {
+            Some(last) => {
+                let elapsed = now.saturating_duration_since(last);
+                elapsed.min(Self::MAX_DT)
+            }
+            None => {
+                self.is_animating = true;
+                Self::DEFAULT_FIRST_FRAME_DT
+            }
+        };
+        self.last_tick = Some(now);
+        dt
+    }
+
+    pub fn stop(&mut self) {
+        self.is_animating = false;
+        self.last_tick = None;
+    }
+
+    pub fn is_animating(&self) -> bool {
+        self.is_animating
+    }
+}
+
+/// Single-axis critically damped spring animation.
+/// This is the core building block for smooth cursor movement.
+/// Based on GDC 2021 Math In Game Development Summit.
+#[derive(Debug, Clone, Copy)]
+pub struct SpringAnimation {
+    /// Current offset from target (converges to 0)
+    pub position: f32,
+    /// Current velocity
+    pub velocity: f32,
+}
+
+impl Default for SpringAnimation {
+    fn default() -> Self {
+        Self {
+            position: 0.0,
+            velocity: 0.0,
+        }
+    }
+}
+
+impl SpringAnimation {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Update the spring animation. Returns true if still animating.
+    /// Uses critically damped spring formula (zeta = 1.0).
+    /// Checks convergence only at the end, only checking position (not velocity).
+    pub fn update(&mut self, dt: f32, animation_length: f32) -> bool {
+        // If animation_length <= dt, reset immediately
+        if animation_length <= dt {
+            self.reset();
+            return false;
+        }
+
+        if self.position == 0.0 {
+            return false;
+        }
+
+        // omega = 4.0 / animation_length gives ~98% convergence in animation_length time
+        let omega = 4.0 / animation_length;
+
+        // Analytical solution for critically damped oscillator:
+        // x(t) = (a + b*t) * e^(-omega*t)
+        // where a = initial_offset, b = initial_velocity + a*omega
+        let a = self.position;
+        let b = a * omega + self.velocity;
+        let c = (-omega * dt).exp();
+
+        self.position = (a + b * dt) * c;
+        self.velocity = c * (-a * omega - b * dt * omega + b);
+
+        if self.position.abs() < SPRING_CONVERGENCE_THRESHOLD {
+            self.reset();
+            false
+        } else {
+            true
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.position = 0.0;
+        self.velocity = 0.0;
+    }
+
+    pub fn is_complete(&self) -> bool {
+        // Check both position and velocity to prevent oscillation at threshold
+        self.position.abs() < SPRING_CONVERGENCE_THRESHOLD
+            && self.velocity.abs() < 0.1
+    }
+}
+
+/// Configuration for inertial cursor animation.
+/// Uses QuadCorner animation (4 independent corners).
+#[derive(Debug, Clone, Copy)]
+pub struct InertialCursorConfig {
+    pub enabled: bool,
+    /// Animation duration for large jumps (in seconds).
+    pub animation_time: Duration,
+    /// Animation duration for small moves/typing (in seconds).
+    pub short_animation_time: Duration,
+    /// Trail effect size (0.0-1.0):
+    /// - 1.0 = Leading edge snaps instantly (minimum latency, maximum responsiveness)
+    /// - 0.5 = Balanced animation
+    /// - 0.0 = Full smooth animation (maximum smoothness, more perceived latency)
+    pub trail_size: f32,
+    /// Whether to animate cursor during insert mode (typing).
+    /// When false, cursor snaps instantly for short horizontal movements.
+    pub animate_in_insert_mode: bool,
+}
+
+impl InertialCursorConfig {
+    /// Create configuration from editor settings.
+    /// This allows full customization of animation parameters.
+    pub fn from_settings(settings: &SmoothCaret) -> Self {
+        if !settings.enabled {
+            return Self {
+                enabled: false,
+                animation_time: Duration::from_millis(0),
+                short_animation_time: Duration::from_millis(0),
+                trail_size: 0.0,
+                animate_in_insert_mode: true,
+            };
+        }
+
+        Self {
+            enabled: true,
+            animation_time: Duration::from_millis(settings.animation_time_ms),
+            short_animation_time: Duration::from_millis(settings.short_animation_time_ms),
+            trail_size: settings.trail_size.clamp(0.0, 1.0),
+            animate_in_insert_mode: settings.animate_in_insert_mode,
+        }
+    }
+}
+
+impl Default for InertialCursorConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            animation_time: Duration::from_millis(150),
+            short_animation_time: Duration::from_millis(25),
+            trail_size: 1.0,
+            animate_in_insert_mode: true,
+        }
+    }
+}
+
+/// 2D vector for internal animation calculations.
+/// Uses f32 for arithmetic, converts to/from gpui::Point<Pixels> at boundaries.
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct Vec2 {
+    pub x: f32,
+    pub y: f32,
+}
+
+impl Vec2 {
+    pub const ZERO: Vec2 = Vec2 { x: 0.0, y: 0.0 };
+
+    #[inline]
+    pub fn new(x: f32, y: f32) -> Self {
+        Self { x, y }
+    }
+
+    #[inline]
+    pub fn length(self) -> f32 {
+        (self.x * self.x + self.y * self.y).sqrt()
+    }
+
+    #[inline]
+    pub fn from_point(p: Point<Pixels>) -> Self {
+        Self {
+            x: f32::from(p.x),
+            y: f32::from(p.y),
+        }
+    }
+
+    #[inline]
+    pub fn to_point(self) -> Point<Pixels> {
+        point(Pixels::from(self.x), Pixels::from(self.y))
+    }
+}
+
+impl std::ops::Add for Vec2 {
+    type Output = Vec2;
+    #[inline]
+    fn add(self, rhs: Vec2) -> Vec2 {
+        Vec2::new(self.x + rhs.x, self.y + rhs.y)
+    }
+}
+
+impl std::ops::Sub for Vec2 {
+    type Output = Vec2;
+    #[inline]
+    fn sub(self, rhs: Vec2) -> Vec2 {
+        Vec2::new(self.x - rhs.x, self.y - rhs.y)
+    }
+}
+
+impl std::ops::Mul<f32> for Vec2 {
+    type Output = Vec2;
+    #[inline]
+    fn mul(self, rhs: f32) -> Vec2 {
+        Vec2::new(self.x * rhs, self.y * rhs)
+    }
+}
+
+impl std::ops::Div<f32> for Vec2 {
+    type Output = Vec2;
+    #[inline]
+    fn div(self, rhs: f32) -> Vec2 {
+        Vec2::new(self.x / rhs, self.y / rhs)
+    }
+}
+
+/// Single corner of the cursor quad with independent X/Y spring animation.
+/// Each corner animates at different speeds based on movement direction.
+/// Uses independent X/Y springs for more natural diagonal movement.
+///
+/// Architecture: `corner_destination` is recalculated EVERY frame with
+/// current `cursor_dimensions` and `center`. This ensures smooth animation even
+/// when cell size changes during animation.
+#[derive(Debug, Clone)]
+pub struct AnimatedCorner {
+    /// Independent X-axis spring animation
+    animation_x: SpringAnimation,
+    /// Independent Y-axis spring animation
+    animation_y: SpringAnimation,
+    /// Current position (computed from destination - spring offset)
+    current_position: Vec2,
+    /// Relative offset from cursor center (-0.5 to 0.5)
+    relative_position: Vec2,
+    /// Previous destination position for detecting changes (exact comparison)
+    previous_destination: Vec2,
+    /// Animation length for this corner (in seconds).
+    /// Set once per jump, stays constant throughout the animation.
+    /// animation_length is absolute, not a multiplier.
+    animation_length: f32,
+    /// Whether this is a short movement (typing) - used to reset velocity
+    is_short_movement: bool,
+}
+
+impl AnimatedCorner {
+    pub fn new(relative_x: f32, relative_y: f32) -> Self {
+        Self {
+            animation_x: SpringAnimation::new(),
+            animation_y: SpringAnimation::new(),
+            current_position: Vec2::ZERO,
+            relative_position: Vec2::new(relative_x, relative_y),
+            previous_destination: Vec2::new(-1000.0, -1000.0), // Impossible initial value for change detection
+            animation_length: 0.1, // Default 100ms, will be set properly on first jump
+            is_short_movement: false,
+        }
+    }
+
+    /// Calculate direction alignment for ranking.
+    /// Returns dot product of corner offset from center and movement direction.
+    pub fn calculate_alignment(&self, top_left: Vec2, cell_width: f32, cell_height: f32) -> f32 {
+        let corner_dest = Vec2::new(
+            top_left.x + self.relative_position.x * cell_width,
+            top_left.y + self.relative_position.y * cell_height,
+        );
+        let move_delta = corner_dest - self.current_position;
+        let distance = move_delta.length();
+
+        if distance > 0.001 {
+            let direction = Vec2::new(move_delta.x / distance, move_delta.y / distance);
+            // Use offset from center (0.5, 0.5) for corner direction
+            // This gives: (-0.5,-0.5), (0.5,-0.5), (0.5,0.5), (-0.5,0.5)
+            let offset_from_center = Vec2::new(
+                self.relative_position.x - 0.5,
+                self.relative_position.y - 0.5,
+            );
+            let rel_len = offset_from_center.length();
+            if rel_len > 0.001 {
+                let rel_norm = Vec2::new(
+                    offset_from_center.x / rel_len,
+                    offset_from_center.y / rel_len,
+                );
+                rel_norm.x * direction.x + rel_norm.y * direction.y
+            } else {
+                0.0
+            }
+        } else {
+            0.0
+        }
+    }
+
+    /// Set animation length for this corner.
+    /// Called once per position change. animation_length stays constant
+    /// for all frames of this animation.
+    /// `is_short` indicates a short movement (typing) where velocity should be reset.
+    pub fn jump(&mut self, animation_length: f32, is_short: bool) {
+        self.animation_length = animation_length.max(MIN_CORNER_ANIMATION_TIME);
+        self.is_short_movement = is_short;
+    }
+
+    /// Update corner animation with current parameters.
+    /// CRITICAL: cursor_dimensions and center are passed EVERY frame.
+    /// This ensures correct animation even when cell size changes.
+    ///
+    /// Returns true if still animating.
+    pub fn update(
+        &mut self,
+        cursor_dimensions: (f32, f32), // (cell_width, cell_height)
+        center: Vec2,
+        dt: f32,
+        immediate_movement: bool,
+    ) -> bool {
+        // Calculate corner destination with CURRENT dimensions
+        let corner_destination = Vec2::new(
+            center.x + self.relative_position.x * cursor_dimensions.0,
+            center.y + self.relative_position.y * cursor_dimensions.1,
+        );
+
+        // Exact comparison to detect position change
+        if corner_destination != self.previous_destination {
+            // Initialize spring with delta from current position to new destination
+            let delta = corner_destination - self.current_position;
+            self.animation_x.position = delta.x;
+            self.animation_y.position = delta.y;
+
+            // For short movements (typing), reset velocity to prevent accumulation
+            // and micro-jitter during rapid keystrokes. For navigation, preserve
+            // velocity for smooth chaining.
+            if self.is_short_movement {
+                self.animation_x.velocity = 0.0;
+                self.animation_y.velocity = 0.0;
+            }
+
+            self.previous_destination = corner_destination;
+        }
+
+        if immediate_movement {
+            self.current_position = corner_destination;
+            self.animation_x.reset();
+            self.animation_y.reset();
+            return false;
+        }
+
+        // Update springs with stored animation_length (constant for this animation)
+        let mut animating = self.animation_x.update(dt, self.animation_length);
+        animating |= self.animation_y.update(dt, self.animation_length);
+
+        self.current_position.x = corner_destination.x - self.animation_x.position;
+        self.current_position.y = corner_destination.y - self.animation_y.position;
+
+        animating
+    }
+
+    pub fn position(&self) -> Vec2 {
+        self.current_position
+    }
+
+    pub fn is_complete(&self) -> bool {
+        self.animation_x.is_complete() && self.animation_y.is_complete()
+    }
+
+    pub fn init_position(&mut self, center: Vec2, cell_width: f32, cell_height: f32) {
+        let pos = Vec2::new(
+            center.x + self.relative_position.x * cell_width,
+            center.y + self.relative_position.y * cell_height,
+        );
+        self.current_position = pos;
+        self.previous_destination = pos;
+        self.animation_x.reset();
+        self.animation_y.reset();
+    }
+}
+
+/// Four-corner cursor for parallelogram deformation.
+/// Each corner animates independently based on movement direction.
+/// Architecture: corner positions recalculated every frame with
+/// current cell dimensions.
+///
+/// Uses fixed-timestep physics (120Hz) with interpolation for smooth
+/// rendering at any frame rate.
+#[derive(Debug, Clone)]
+pub struct QuadCursor {
+    /// The 4 corners of the cursor quad (each with independent X/Y springs)
+    corners: [AnimatedCorner; 4],
+    /// Target position (center of cursor)
+    logical_center: Vec2,
+    /// Animation configuration
+    config: InertialCursorConfig,
+    /// Whether cursor jumped this frame (triggers animation_length calculation)
+    jumped: bool,
+    /// Current cell dimensions (set immediately, no animation)
+    cell_width: f32,
+    cell_height: f32,
+    /// Corner positions at last physics tick (for interpolation)
+    previous_corner_positions: [Vec2; 4],
+    /// Accumulated time for fixed-timestep physics
+    physics_accumulator: f32,
+}
+
+impl QuadCursor {
+    pub fn new(
+        config: InertialCursorConfig,
+        initial_pos: Point<Pixels>,
+        cell_width: f32,
+        cell_height: f32,
+    ) -> Self {
+        let top_left = Vec2::from_point(initial_pos);
+        // Corner offsets as fractions of cell size (top-left based: 0,0 to 1,1)
+        // This matches how Zed passes cursor position (top-left of cell)
+        // Order: Top-left, Top-right, Bottom-right, Bottom-left
+        let mut corners = [
+            AnimatedCorner::new(0.0, 0.0),
+            AnimatedCorner::new(1.0, 0.0),
+            AnimatedCorner::new(1.0, 1.0),
+            AnimatedCorner::new(0.0, 1.0),
+        ];
+
+        for corner in &mut corners {
+            corner.init_position(top_left, cell_width, cell_height);
+        }
+
+        // Initialize previous positions to current positions
+        let previous_corner_positions = [
+            corners[0].position(),
+            corners[1].position(),
+            corners[2].position(),
+            corners[3].position(),
+        ];
+
+        Self {
+            corners,
+            logical_center: top_left,
+            config,
+            jumped: false,
+            cell_width,
+            cell_height,
+            previous_corner_positions,
+            physics_accumulator: 0.0,
+        }
+    }
+
+    pub fn set_config(&mut self, config: InertialCursorConfig) {
+        self.config = config;
+        if !config.enabled {
+            self.snap_to_logical();
+        }
+    }
+
+    /// Set cell dimensions (immediate, no animation).
+    /// Corner positions are recalculated every frame with current dimensions,
+    /// so cell size changes are handled smoothly by the corner springs.
+    pub fn set_cell_size(&mut self, width: f32, height: f32) {
+        self.cell_width = width;
+        self.cell_height = height;
+    }
+
+    /// Set the logical (target) center position.
+    /// Only sets animation_length via jump(). Actual animation happens in update_physics().
+    pub fn set_logical_pos(&mut self, pos: Point<Pixels>) {
+        let old_center = self.logical_center;
+        self.logical_center = Vec2::from_point(pos);
+
+        if !self.config.enabled {
+            self.snap_to_logical();
+            return;
+        }
+
+        // Detect movement distance
+        let move_vec = self.logical_center - old_center;
+        let move_distance = move_vec.length();
+
+        // Skip if position hasn't changed
+        if move_distance < 0.001 {
+            return;
+        }
+
+        // Snap immediately for very large jumps to prevent excessive stretching
+        if move_distance > LARGE_JUMP_SNAP_THRESHOLD {
+            self.snap_to_logical();
+            return;
+        }
+
+        self.jumped = true;
+
+        // Short jump detection: horizontal movement <= 2 chars AND vertical ~= 0
+        let is_short_animation = if self.cell_width > 0.001 && self.cell_height > 0.001 {
+            let chars_x = (move_vec.x / self.cell_width).abs();
+            let chars_y = (move_vec.y / self.cell_height).abs();
+            // Use 0.1 threshold (10% of cell height) for sub-pixel tolerance
+            chars_x <= 2.001 && chars_y < 0.1
+        } else {
+            false
+        };
+
+        // Skip animation for short movements if animate_in_insert_mode is disabled
+        if !self.config.animate_in_insert_mode && is_short_animation {
+            self.snap_to_logical();
+            self.jumped = false;
+            return;
+        }
+
+        // Calculate animation_length for each corner
+        if is_short_animation {
+            // Short jump: uniform animation_length for ALL corners (straight line)
+            let anim_length = self.config.short_animation_time.as_secs_f32().max(0.001);
+            for corner in &mut self.corners {
+                corner.jump(anim_length, true);
+            }
+        } else {
+            // Long jump: rank-based trailing effect
+            // 1. Calculate alignment for each corner
+            let alignments: [(usize, f32); 4] = [
+                (
+                    0,
+                    self.corners[0].calculate_alignment(
+                        self.logical_center,
+                        self.cell_width,
+                        self.cell_height,
+                    ),
+                ),
+                (
+                    1,
+                    self.corners[1].calculate_alignment(
+                        self.logical_center,
+                        self.cell_width,
+                        self.cell_height,
+                    ),
+                ),
+                (
+                    2,
+                    self.corners[2].calculate_alignment(
+                        self.logical_center,
+                        self.cell_width,
+                        self.cell_height,
+                    ),
+                ),
+                (
+                    3,
+                    self.corners[3].calculate_alignment(
+                        self.logical_center,
+                        self.cell_width,
+                        self.cell_height,
+                    ),
+                ),
+            ];
+
+            // 2. Sort by alignment to assign ranks (0 = most trailing, 3 = most leading)
+            let mut sorted: [(usize, f32); 4] = alignments;
+            sorted.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+
+            // 3. Build rank lookup: ranks[corner_index] = rank (0-3)
+            let mut ranks = [0usize; 4];
+            for (rank, (idx, _)) in sorted.iter().enumerate() {
+                ranks[*idx] = rank;
+            }
+
+            // 4. Calculate animation_length based on rank (triangular trail)
+            let base_time = self.config.animation_time.as_secs_f32().max(0.001);
+            let trail_size = self.config.trail_size;
+            let leading_time = base_time * (1.0 - trail_size).clamp(0.0, 1.0);
+            let trailing_time = base_time;
+            let middle_time = (leading_time + trailing_time) / 2.0;
+
+            for (i, corner) in self.corners.iter_mut().enumerate() {
+                // Rank 2-3 both get leading speed
+                let anim_length = match ranks[i] {
+                    0 => trailing_time,    // Most trailing - slowest
+                    1 => middle_time,      // Middle corner - medium
+                    2..=3 => leading_time, // Leading corners - fastest
+                    _ => base_time,
+                };
+                corner.jump(anim_length, false);
+            }
+        }
+    }
+
+    pub fn visual_pos(&self) -> Point<Pixels> {
+        self.corners[0].position().to_point()
+    }
+
+    pub fn snap_to_logical(&mut self) {
+        for corner in &mut self.corners {
+            corner.init_position(self.logical_center, self.cell_width, self.cell_height);
+        }
+        // Reset interpolation state
+        for (i, corner) in self.corners.iter().enumerate() {
+            self.previous_corner_positions[i] = corner.position();
+        }
+        self.physics_accumulator = 0.0;
+    }
+
+    pub fn is_animating(&self) -> bool {
+        if !self.config.enabled {
+            return false;
+        }
+        // Include jumped flag: animation starts when set_logical_pos() is called,
+        // even before update_physics() processes it
+        self.jumped || self.corners.iter().any(|c| !c.is_complete())
+    }
+
+    /// Update physics with a given frame delta time.
+    /// Uses fixed-timestep simulation (120Hz) for deterministic behavior.
+    /// Returns `true` if still animating.
+    ///
+    /// CRITICAL architecture:
+    /// - Physics runs at fixed PHYSICS_DT (120Hz) for consistency
+    /// - Accumulates frame_dt and steps multiple times if needed
+    /// - Stores previous positions for interpolation
+    /// - Rendering uses interpolated_corner_positions() for smooth visuals
+    pub fn update_physics(&mut self, frame_dt: f32) -> bool {
+        self.physics_accumulator += frame_dt;
+
+        let mut still_animating = false;
+        let cursor_dimensions = (self.cell_width, self.cell_height);
+        let center = self.logical_center;
+        let immediate_movement = !self.config.enabled;
+
+        // Run fixed-timestep physics loop
+        while self.physics_accumulator >= PHYSICS_DT {
+            // Store previous positions BEFORE stepping physics
+            for (i, corner) in self.corners.iter().enumerate() {
+                self.previous_corner_positions[i] = corner.position();
+            }
+
+            // Step physics with fixed dt
+            for corner in &mut self.corners {
+                if corner.update(cursor_dimensions, center, PHYSICS_DT, immediate_movement) {
+                    still_animating = true;
+                }
+            }
+
+            self.physics_accumulator -= PHYSICS_DT;
+            self.jumped = false;
+        }
+
+        still_animating
+    }
+
+    /// Get interpolation alpha (0.0-1.0) for smooth rendering between physics ticks.
+    pub fn interpolation_alpha(&self) -> f32 {
+        (self.physics_accumulator / PHYSICS_DT).clamp(0.0, 1.0)
+    }
+
+    /// Get interpolated corner positions for rendering.
+    /// Lerps between previous and current physics states based on accumulated time.
+    /// This provides sub-pixel smooth animation at any frame rate.
+    pub fn interpolated_corner_positions(&self) -> [Point<Pixels>; 4] {
+        let alpha = self.interpolation_alpha();
+        std::array::from_fn(|i| {
+            let prev = self.previous_corner_positions[i];
+            let curr = self.corners[i].position();
+            // Linear interpolation
+            let x = prev.x + (curr.x - prev.x) * alpha;
+            let y = prev.y + (curr.y - prev.y) * alpha;
+            point(Pixels::from(x), Pixels::from(y))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quad_cursor_disabled_snaps_immediately() {
+        let config = InertialCursorConfig {
+            enabled: false,
+            ..Default::default()
+        };
+        let mut cursor = QuadCursor::new(
+            config,
+            point(Pixels::from(0.0), Pixels::from(0.0)),
+            10.0,
+            20.0,
+        );
+
+        cursor.set_logical_pos(point(Pixels::from(100.0), Pixels::from(0.0)));
+        let changed = cursor.update_physics(0.016); // 16ms delta time
+
+        let visual = cursor.visual_pos();
+        // With animation disabled, visual should snap to target (100.0)
+        assert_eq!(f32::from(visual.x), 100.0);
+        assert!(!changed, "Disabled cursor shouldn't animate");
+    }
+
+    #[test]
+    fn quad_cursor_converges_to_target() {
+        let mut cursor = QuadCursor::new(
+            InertialCursorConfig::default(),
+            point(Pixels::from(0.0), Pixels::from(0.0)),
+            10.0,
+            20.0,
+        );
+
+        cursor.set_logical_pos(point(Pixels::from(100.0), Pixels::from(0.0)));
+
+        // Simulate ~2 seconds of animation at 60fps
+        for _ in 0..120 {
+            cursor.update_physics(0.016); // 16ms delta time
+        }
+
+        let visual = cursor.visual_pos();
+        let x = f32::from(visual.x);
+        assert!(
+            (x - 100.0).abs() < 1.0,
+            "Expected cursor to be close to target, got x = {}",
+            x
+        );
+    }
+
+    #[test]
+    fn quad_cursor_is_animating_reflects_state() {
+        let mut cursor = QuadCursor::new(
+            InertialCursorConfig::default(),
+            point(Pixels::from(0.0), Pixels::from(0.0)),
+            10.0,
+            20.0,
+        );
+
+        // Initially at rest
+        assert!(!cursor.is_animating());
+
+        // Move to new position
+        cursor.set_logical_pos(point(Pixels::from(100.0), Pixels::from(0.0)));
+        assert!(cursor.is_animating());
+
+        // After convergence
+        for _ in 0..200 {
+            cursor.update_physics(0.016); // 16ms delta time
+        }
+        assert!(!cursor.is_animating());
+    }
+}

--- a/crates/editor/src/inertial_cursor.rs
+++ b/crates/editor/src/inertial_cursor.rs
@@ -1,6 +1,7 @@
 use std::time::{Duration, Instant};
 
 use gpui::{Pixels, Point, point};
+use language::CursorShape;
 
 use crate::editor_settings::SmoothCaret;
 
@@ -12,10 +13,6 @@ pub const MAX_ANIMATION_DT: f32 = 1.0 / 120.0;
 /// Physics always runs at this rate; rendering interpolates between states.
 const PHYSICS_DT: f32 = 1.0 / 120.0;
 
-/// Distance threshold (in pixels) above which cursor snaps immediately.
-/// Prevents excessive stretching during very large jumps (e.g., search, goto).
-const LARGE_JUMP_SNAP_THRESHOLD: f32 = 1000.0;
-
 /// Minimum animation time for corner animation.
 /// Allows near-instant snap for leading corners with high trail_size.
 const MIN_CORNER_ANIMATION_TIME: f32 = 0.001;
@@ -23,6 +20,10 @@ const MIN_CORNER_ANIMATION_TIME: f32 = 0.001;
 /// Convergence threshold for spring animation.
 /// Only check position for convergence, not velocity.
 const SPRING_CONVERGENCE_THRESHOLD: f32 = 0.01;
+
+const BAR_WIDTH: f32 = 2.0;
+const UNDERLINE_HEIGHT: f32 = 2.0;
+const SHORT_MOVE_VERTICAL_THRESHOLD: f32 = 0.001;
 
 /// Simple frame pacing for cursor animations.
 /// Uses actual wall-clock delta for smooth, drift-free animation.
@@ -122,7 +123,7 @@ impl SpringAnimation {
             return false;
         }
 
-        if self.position == 0.0 {
+        if self.position == 0.0 && self.velocity == 0.0 {
             return false;
         }
 
@@ -154,8 +155,7 @@ impl SpringAnimation {
 
     pub fn is_complete(&self) -> bool {
         // Check both position and velocity to prevent oscillation at threshold
-        self.position.abs() < SPRING_CONVERGENCE_THRESHOLD
-            && self.velocity.abs() < 0.1
+        self.position.abs() < SPRING_CONVERGENCE_THRESHOLD && self.velocity.abs() < 0.1
     }
 }
 
@@ -207,8 +207,8 @@ impl Default for InertialCursorConfig {
         Self {
             enabled: true,
             animation_time: Duration::from_millis(150),
-            short_animation_time: Duration::from_millis(25),
-            trail_size: 1.0,
+            short_animation_time: Duration::from_millis(40),
+            trail_size: 0.7,
             animate_in_insert_mode: true,
         }
     }
@@ -434,6 +434,10 @@ impl AnimatedCorner {
         self.animation_x.reset();
         self.animation_y.reset();
     }
+
+    pub fn set_relative_position(&mut self, relative_x: f32, relative_y: f32) {
+        self.relative_position = Vec2::new(relative_x, relative_y);
+    }
 }
 
 /// Four-corner cursor for parallelogram deformation.
@@ -519,6 +523,41 @@ impl QuadCursor {
         self.cell_height = height;
     }
 
+    pub fn set_shape(&mut self, shape: CursorShape) {
+        let bar_fraction = if self.cell_width > 0.0 {
+            (BAR_WIDTH / self.cell_width).clamp(0.0, 1.0)
+        } else {
+            1.0
+        };
+        let underline_fraction = if self.cell_height > 0.0 {
+            (UNDERLINE_HEIGHT / self.cell_height).clamp(0.0, 1.0)
+        } else {
+            1.0
+        };
+
+        let offsets = match shape {
+            CursorShape::Block | CursorShape::Hollow => {
+                [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)]
+            }
+            CursorShape::Bar => [
+                (0.0, 0.0),
+                (bar_fraction, 0.0),
+                (bar_fraction, 1.0),
+                (0.0, 1.0),
+            ],
+            CursorShape::Underline => [
+                (0.0, 1.0 - underline_fraction),
+                (1.0, 1.0 - underline_fraction),
+                (1.0, 1.0),
+                (0.0, 1.0),
+            ],
+        };
+
+        for (corner, (x, y)) in self.corners.iter_mut().zip(offsets) {
+            corner.set_relative_position(x, y);
+        }
+    }
+
     /// Set the logical (target) center position.
     /// Only sets animation_length via jump(). Actual animation happens in update_physics().
     pub fn set_logical_pos(&mut self, pos: Point<Pixels>) {
@@ -539,20 +578,13 @@ impl QuadCursor {
             return;
         }
 
-        // Snap immediately for very large jumps to prevent excessive stretching
-        if move_distance > LARGE_JUMP_SNAP_THRESHOLD {
-            self.snap_to_logical();
-            return;
-        }
-
         self.jumped = true;
 
         // Short jump detection: horizontal movement <= 2 chars AND vertical ~= 0
         let is_short_animation = if self.cell_width > 0.001 && self.cell_height > 0.001 {
             let chars_x = (move_vec.x / self.cell_width).abs();
             let chars_y = (move_vec.y / self.cell_height).abs();
-            // Use 0.1 threshold (10% of cell height) for sub-pixel tolerance
-            chars_x <= 2.001 && chars_y < 0.1
+            chars_x <= 2.001 && chars_y <= SHORT_MOVE_VERTICAL_THRESHOLD
         } else {
             false
         };
@@ -611,7 +643,16 @@ impl QuadCursor {
 
             // 2. Sort by alignment to assign ranks (0 = most trailing, 3 = most leading)
             let mut sorted: [(usize, f32); 4] = alignments;
-            sorted.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+            sorted.sort_by(|a, b| {
+                let ordering = match a.1.partial_cmp(&b.1) {
+                    Some(ordering) => ordering,
+                    None => {
+                        log::warn!("NaN detected in cursor corner alignment calculation");
+                        std::cmp::Ordering::Equal
+                    }
+                };
+                ordering.then_with(|| a.0.cmp(&b.0))
+            });
 
             // 3. Build rank lookup: ranks[corner_index] = rank (0-3)
             let mut ranks = [0usize; 4];
@@ -641,6 +682,11 @@ impl QuadCursor {
 
     pub fn visual_pos(&self) -> Point<Pixels> {
         self.corners[0].position().to_point()
+    }
+
+    /// Target position in pixels relative to content origin.
+    pub fn destination_pos(&self) -> Point<Pixels> {
+        self.logical_center.to_point()
     }
 
     pub fn snap_to_logical(&mut self) {
@@ -794,5 +840,76 @@ mod tests {
             cursor.update_physics(0.016); // 16ms delta time
         }
         assert!(!cursor.is_animating());
+    }
+
+    #[test]
+    fn quad_cursor_shape_mapping_updates_corners() {
+        let mut cursor = QuadCursor::new(
+            InertialCursorConfig::default(),
+            point(Pixels::from(0.0), Pixels::from(0.0)),
+            20.0,
+            20.0,
+        );
+
+        cursor.set_shape(CursorShape::Bar);
+        assert_eq!(cursor.corners[0].relative_position, Vec2::new(0.0, 0.0));
+        assert_eq!(cursor.corners[3].relative_position, Vec2::new(0.0, 1.0));
+        assert_eq!(cursor.corners[1].relative_position, Vec2::new(0.1, 0.0),);
+        assert_eq!(cursor.corners[2].relative_position, Vec2::new(0.1, 1.0),);
+
+        cursor.set_shape(CursorShape::Underline);
+        assert_eq!(cursor.corners[0].relative_position, Vec2::new(0.0, 0.9),);
+        assert_eq!(cursor.corners[1].relative_position, Vec2::new(1.0, 0.9),);
+        assert_eq!(cursor.corners[2].relative_position, Vec2::new(1.0, 1.0));
+        assert_eq!(cursor.corners[3].relative_position, Vec2::new(0.0, 1.0));
+    }
+
+    #[test]
+    fn large_jump_stays_animated() {
+        let mut cursor = QuadCursor::new(
+            InertialCursorConfig::default(),
+            point(Pixels::from(0.0), Pixels::from(0.0)),
+            10.0,
+            20.0,
+        );
+
+        cursor.set_logical_pos(point(Pixels::from(5_000.0), Pixels::from(0.0)));
+
+        let visual = cursor.visual_pos();
+        assert!(f32::from(visual.x) < 1.0);
+        assert!(cursor.is_animating());
+    }
+
+    #[test]
+    fn short_move_requires_near_zero_vertical_delta() {
+        let mut cursor = QuadCursor::new(
+            InertialCursorConfig::default(),
+            point(Pixels::from(0.0), Pixels::from(0.0)),
+            10.0,
+            20.0,
+        );
+
+        cursor.set_logical_pos(point(Pixels::from(20.0), Pixels::from(0.03 * 20.0)));
+        assert!(
+            cursor
+                .corners
+                .iter()
+                .all(|corner| !corner.is_short_movement)
+        );
+    }
+
+    #[test]
+    fn remains_animating_before_first_fixed_step() {
+        let mut cursor = QuadCursor::new(
+            InertialCursorConfig::default(),
+            point(Pixels::from(0.0), Pixels::from(0.0)),
+            10.0,
+            20.0,
+        );
+
+        cursor.set_logical_pos(point(Pixels::from(100.0), Pixels::from(0.0)));
+        let changed = cursor.update_physics(PHYSICS_DT * 0.5);
+        assert!(!changed);
+        assert!(cursor.is_animating());
     }
 }

--- a/crates/gpui/src/key_dispatch.rs
+++ b/crates/gpui/src/key_dispatch.rs
@@ -163,6 +163,10 @@ impl DispatchTree {
         self.nodes.len()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.nodes.is_empty()
+    }
+
     pub fn push_node(&mut self) -> DispatchNodeId {
         let parent = self.node_stack.last().copied();
         let node_id = DispatchNodeId(self.nodes.len());

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -529,7 +529,7 @@ pub(crate) trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     fn on_hit_test_window_control(&self, callback: Box<dyn FnMut() -> Option<WindowControlArea>>);
     fn on_close(&self, callback: Box<dyn FnOnce()>);
     fn on_appearance_changed(&self, callback: Box<dyn FnMut()>);
-    fn draw(&self, scene: &Scene);
+    fn draw(&self, scene: &Scene, overlay: Option<&Scene>);
     fn completed_frame(&self) {}
     fn sprite_atlas(&self) -> Arc<dyn PlatformAtlas>;
     fn is_subpixel_rendering_supported(&self) -> bool;

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -1305,9 +1305,9 @@ impl PlatformWindow for WaylandWindow {
         self.0.callbacks.borrow_mut().appearance_changed = Some(callback);
     }
 
-    fn draw(&self, scene: &Scene) {
+    fn draw(&self, scene: &Scene, overlay: Option<&Scene>) {
         let mut state = self.borrow_mut();
-        state.renderer.draw(scene);
+        state.renderer.draw(scene, overlay);
     }
 
     fn completed_frame(&self) {

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -1560,9 +1560,9 @@ impl PlatformWindow for X11Window {
         self.0.callbacks.borrow_mut().appearance_changed = Some(callback);
     }
 
-    fn draw(&self, scene: &Scene) {
+    fn draw(&self, scene: &Scene, overlay: Option<&Scene>) {
         let mut inner = self.0.state.borrow_mut();
-        inner.renderer.draw(scene);
+        inner.renderer.draw(scene, overlay);
     }
 
     fn sprite_atlas(&self) -> Arc<dyn PlatformAtlas> {

--- a/crates/gpui/src/platform/mac/metal_renderer.rs
+++ b/crates/gpui/src/platform/mac/metal_renderer.rs
@@ -367,7 +367,7 @@ impl MetalRenderer {
         // nothing to do
     }
 
-    pub fn draw(&mut self, scene: &Scene) {
+    pub fn draw(&mut self, scene: &Scene, overlay: Option<&Scene>) {
         let layer = self.layer.clone();
         let viewport_size = layer.drawable_size();
         let viewport_size: Size<DevicePixels> = size(
@@ -387,8 +387,13 @@ impl MetalRenderer {
         loop {
             let mut instance_buffer = self.instance_buffer_pool.lock().acquire(&self.device);
 
-            let command_buffer =
-                self.draw_primitives(scene, &mut instance_buffer, drawable, viewport_size);
+            let command_buffer = self.draw_primitives(
+                scene,
+                overlay,
+                &mut instance_buffer,
+                drawable,
+                viewport_size,
+            );
 
             match command_buffer {
                 Ok(command_buffer) => {
@@ -527,6 +532,7 @@ impl MetalRenderer {
     fn draw_primitives(
         &mut self,
         scene: &Scene,
+        overlay: Option<&Scene>,
         instance_buffer: &mut InstanceBuffer,
         drawable: &metal::MetalDrawableRef,
         viewport_size: Size<DevicePixels>,
@@ -546,7 +552,27 @@ impl MetalRenderer {
             },
         );
 
-        for batch in scene.batches() {
+        let overlay_counts = overlay.map(|scene| {
+            (
+                scene.paths.len(),
+                scene.shadows.len(),
+                scene.quads.len(),
+                scene.underlines.len(),
+                scene.monochrome_sprites.len(),
+                scene.polychrome_sprites.len(),
+                scene.surfaces.len(),
+            )
+        });
+        let totals = overlay_counts.unwrap_or_default();
+        let total_paths = scene.paths.len() + totals.0;
+        let total_shadows = scene.shadows.len() + totals.1;
+        let total_quads = scene.quads.len() + totals.2;
+        let total_underlines = scene.underlines.len() + totals.3;
+        let total_mono = scene.monochrome_sprites.len() + totals.4;
+        let total_poly = scene.polychrome_sprites.len() + totals.5;
+        let total_surfaces = scene.surfaces.len() + totals.6;
+
+        for batch in scene.batches_with_overlay(overlay) {
             let ok = match batch {
                 PrimitiveBatch::Shadows(range) => self.draw_shadows(
                     &scene.shadows[range],
@@ -633,13 +659,13 @@ impl MetalRenderer {
                 command_encoder.end_encoding();
                 anyhow::bail!(
                     "scene too large: {} paths, {} shadows, {} quads, {} underlines, {} mono, {} poly, {} surfaces",
-                    scene.paths.len(),
-                    scene.shadows.len(),
-                    scene.quads.len(),
-                    scene.underlines.len(),
-                    scene.monochrome_sprites.len(),
-                    scene.polychrome_sprites.len(),
-                    scene.surfaces.len(),
+                    total_paths,
+                    total_shadows,
+                    total_quads,
+                    total_underlines,
+                    total_mono,
+                    total_poly,
+                    total_surfaces,
                 );
             }
         }

--- a/crates/gpui/src/platform/mac/metal_renderer.rs
+++ b/crates/gpui/src/platform/mac/metal_renderer.rs
@@ -457,7 +457,7 @@ impl MetalRenderer {
             let mut instance_buffer = self.instance_buffer_pool.lock().acquire(&self.device);
 
             let command_buffer =
-                self.draw_primitives(scene, &mut instance_buffer, drawable, viewport_size);
+                self.draw_primitives(scene, None, &mut instance_buffer, drawable, viewport_size);
 
             match command_buffer {
                 Ok(command_buffer) => {

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -1532,9 +1532,9 @@ impl PlatformWindow for MacWindow {
         self.0.as_ref().lock().toggle_tab_bar_callback = Some(callback);
     }
 
-    fn draw(&self, scene: &crate::Scene) {
+    fn draw(&self, scene: &crate::Scene, overlay: Option<&crate::Scene>) {
         let mut this = self.0.lock();
-        this.renderer.draw(scene);
+        this.renderer.draw(scene, overlay);
     }
 
     fn sprite_atlas(&self) -> Arc<dyn PlatformAtlas> {

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -274,7 +274,7 @@ impl PlatformWindow for TestWindow {
 
     fn on_appearance_changed(&self, _callback: Box<dyn FnMut()>) {}
 
-    fn draw(&self, _scene: &crate::Scene) {}
+    fn draw(&self, _scene: &crate::Scene, _overlay: Option<&crate::Scene>) {}
 
     fn sprite_atlas(&self) -> sync::Arc<dyn crate::PlatformAtlas> {
         self.0.lock().sprite_atlas.clone()

--- a/crates/gpui/src/platform/windows/directx_renderer.rs
+++ b/crates/gpui/src/platform/windows/directx_renderer.rs
@@ -304,6 +304,7 @@ impl DirectXRenderer {
     pub(crate) fn draw(
         &mut self,
         scene: &Scene,
+        overlay: Option<&Scene>,
         background_appearance: WindowBackgroundAppearance,
     ) -> Result<()> {
         if self.skip_draws {
@@ -315,10 +316,9 @@ impl DirectXRenderer {
             WindowBackgroundAppearance::Opaque => [1.0f32; 4],
             _ => [0.0f32; 4],
         })?;
-
         self.upload_scene_buffers(scene)?;
 
-        for batch in scene.batches() {
+        for batch in scene.batches_with_overlay(overlay) {
             match batch {
                 PrimitiveBatch::Shadows(range) => self.draw_shadows(range.start, range.len()),
                 PrimitiveBatch::Quads(range) => self.draw_quads(range.start, range.len()),

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -915,11 +915,11 @@ impl PlatformWindow for WindowsWindow {
             .set(Some(callback));
     }
 
-    fn draw(&self, scene: &Scene) {
+    fn draw(&self, scene: &Scene, overlay: Option<&Scene>) {
         self.state
             .renderer
             .borrow_mut()
-            .draw(scene, self.state.background_appearance.get())
+            .draw(scene, overlay, self.state.background_appearance.get())
             .log_err();
     }
 

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -54,6 +54,10 @@ impl Scene {
         self.paint_operations.len()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.paint_operations.is_empty()
+    }
+
     pub fn push_layer(&mut self, bounds: Bounds<ScaledPixels>) {
         let order = self.primitive_bounds.insert(bounds);
         self.layer_stack.push(order);
@@ -171,6 +175,32 @@ impl Scene {
             surfaces_iter: self.surfaces.iter().peekable(),
         }
     }
+
+    pub(crate) fn batches_with_overlay<'a>(
+        &'a self,
+        overlay: Option<&'a Scene>,
+    ) -> impl Iterator<Item = PrimitiveBatch<'a>> + 'a {
+        self.batches()
+            .chain(overlay.into_iter().flat_map(|scene| scene.batches()))
+    }
+}
+
+impl Clone for Scene {
+    fn clone(&self) -> Self {
+        Scene {
+            paint_operations: self.paint_operations.clone(),
+            primitive_bounds: BoundsTree::default(), // Not needed for replay
+            layer_stack: self.layer_stack.clone(),
+            shadows: self.shadows.clone(),
+            quads: self.quads.clone(),
+            paths: self.paths.clone(),
+            underlines: self.underlines.clone(),
+            monochrome_sprites: self.monochrome_sprites.clone(),
+            polychrome_sprites: self.polychrome_sprites.clone(),
+            subpixel_sprites: self.subpixel_sprites.clone(),
+            surfaces: self.surfaces.clone(),
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Default)]
@@ -193,6 +223,7 @@ pub(crate) enum PrimitiveKind {
     Surface,
 }
 
+#[derive(Clone)]
 pub(crate) enum PaintOperation {
     Primitive(Primitive),
     StartLayer(Bounds<ScaledPixels>),

--- a/crates/gpui/src/text_system.rs
+++ b/crates/gpui/src/text_system.rs
@@ -572,6 +572,10 @@ impl WindowTextSystem {
         self.line_layout_cache.finish_frame()
     }
 
+    pub(crate) fn discard_frame(&self) {
+        self.line_layout_cache.discard_frame()
+    }
+
     /// Layout the given line of text, at the given font_size.
     /// Subsets of the line can be styled independently with the `runs` parameter.
     /// Generally, you should prefer to use [`Self::shape_line`] instead, which

--- a/crates/gpui/src/text_system/line.rs
+++ b/crates/gpui/src/text_system/line.rs
@@ -69,6 +69,20 @@ impl ShapedLine {
         window: &mut Window,
         cx: &mut App,
     ) -> Result<()> {
+        self.paint_with_opacity(origin, line_height, align, align_width, 1.0, window, cx)
+    }
+
+    /// Paint the line of text to the window with a specified opacity.
+    pub fn paint_with_opacity(
+        &self,
+        origin: Point<Pixels>,
+        line_height: Pixels,
+        align: TextAlign,
+        align_width: Option<Pixels>,
+        opacity: f32,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> Result<()> {
         paint_line(
             origin,
             &self.layout,
@@ -77,6 +91,7 @@ impl ShapedLine {
             align_width,
             &self.decoration_runs,
             &[],
+            opacity,
             window,
             cx,
         )?;
@@ -151,6 +166,7 @@ impl WrappedLine {
             align_width,
             &self.decoration_runs,
             &self.wrap_boundaries,
+            1.0,
             window,
             cx,
         )?;
@@ -197,6 +213,7 @@ fn paint_line(
     align_width: Option<Pixels>,
     decoration_runs: &[DecorationRun],
     wrap_boundaries: &[WrapBoundary],
+    opacity: f32,
     window: &mut Window,
     cx: &mut App,
 ) -> Result<()> {
@@ -374,6 +391,14 @@ fn paint_line(
                 let content_mask = window.content_mask();
                 if max_glyph_bounds.intersects(&content_mask.bounds) {
                     let vertical_offset = point(px(0.0), glyph.position.y);
+                    let final_color = if opacity < 1.0 {
+                        Hsla {
+                            a: color.a * opacity,
+                            ..color
+                        }
+                    } else {
+                        color
+                    };
                     if glyph.is_emoji {
                         window.paint_emoji(
                             glyph_origin + baseline_offset + vertical_offset,
@@ -387,7 +412,7 @@ fn paint_line(
                             run.font_id,
                             glyph.id,
                             layout.font_size,
-                            color,
+                            final_color,
                         )?;
                     }
                 }

--- a/crates/gpui/src/text_system/line_layout.rs
+++ b/crates/gpui/src/text_system/line_layout.rs
@@ -465,6 +465,14 @@ impl LineLayoutCache {
         curr_frame.used_wrapped_lines.clear();
     }
 
+    pub fn discard_frame(&self) {
+        let mut curr_frame = self.current_frame.write();
+        curr_frame.lines.clear();
+        curr_frame.wrapped_lines.clear();
+        curr_frame.used_lines.clear();
+        curr_frame.used_wrapped_lines.clear();
+    }
+
     pub fn layout_wrapped_line<Text>(
         &self,
         text: Text,

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -4269,18 +4269,6 @@ impl Window {
     }
 
     fn dispatch_key_event(&mut self, event: &dyn Any, cx: &mut App) {
-        // Skip dispatch if the tree hasn't been populated yet (before first frame)
-        if self.rendered_frame.dispatch_tree.is_empty() {
-            return;
-        }
-
-        if self.invalidator.is_dirty() {
-            self.draw(cx).clear();
-        }
-
-        let node_id = self.focus_node_id_in_rendered_frame(self.focus);
-        let dispatch_path = self.rendered_frame.dispatch_tree.dispatch_path(node_id);
-
         let mut keystroke: Option<Keystroke> = None;
 
         if let Some(event) = event.downcast_ref::<ModifiersChangedEvent>() {
@@ -4288,21 +4276,19 @@ impl Window {
                 && self.pending_modifier.modifiers.number_of_modifiers() == 1
                 && !self.pending_modifier.saw_keystroke
             {
-                let key = match self.pending_modifier.modifiers {
-                    modifiers if modifiers.shift => Some("shift"),
-                    modifiers if modifiers.control => Some("control"),
-                    modifiers if modifiers.alt => Some("alt"),
-                    modifiers if modifiers.platform => Some("platform"),
-                    modifiers if modifiers.function => Some("function"),
+                keystroke = match self.pending_modifier.modifiers {
+                    modifiers if modifiers.shift => Some("shift".to_string()),
+                    modifiers if modifiers.control => Some("control".to_string()),
+                    modifiers if modifiers.alt => Some("alt".to_string()),
+                    modifiers if modifiers.platform => Some("platform".to_string()),
+                    modifiers if modifiers.function => Some("function".to_string()),
                     _ => None,
-                };
-                if let Some(key) = key {
-                    keystroke = Some(Keystroke {
-                        key: key.to_string(),
-                        key_char: None,
-                        modifiers: Modifiers::default(),
-                    });
                 }
+                .map(|key| Keystroke {
+                    key,
+                    key_char: None,
+                    modifiers: Modifiers::default(),
+                });
             }
 
             if self.pending_modifier.modifiers.number_of_modifiers() == 0
@@ -4315,6 +4301,18 @@ impl Window {
             self.pending_modifier.saw_keystroke = true;
             keystroke = Some(key_down_event.keystroke.clone());
         }
+
+        // Skip dispatch if the tree hasn't been populated yet (before first frame)
+        if self.rendered_frame.dispatch_tree.is_empty() {
+            return;
+        }
+
+        if self.invalidator.is_dirty() {
+            self.draw(cx).clear();
+        }
+
+        let node_id = self.focus_node_id_in_rendered_frame(self.focus);
+        let dispatch_path = self.rendered_frame.dispatch_tree.dispatch_path(node_id);
 
         let Some(keystroke) = keystroke else {
             self.finish_dispatch_key_event(event, dispatch_path, self.context_stack(), cx);

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -731,6 +731,21 @@ pub(crate) struct DeferredDraw {
     paint_range: Range<PaintIndex>,
 }
 
+/// Cached scene data for animation-only frames.
+/// This allows fast re-rendering of animated elements without full layout.
+pub(crate) struct CachedScene {
+    /// Cache validity key - viewport size
+    viewport_size: Size<Pixels>,
+    /// Cache validity key - scale factor
+    scale_factor: f32,
+}
+
+impl CachedScene {
+    fn is_valid(&self, viewport_size: Size<Pixels>, scale_factor: f32) -> bool {
+        self.viewport_size == viewport_size && self.scale_factor == scale_factor
+    }
+}
+
 pub(crate) struct Frame {
     pub(crate) focus: Option<FocusId>,
     pub(crate) window_active: bool,
@@ -739,6 +754,7 @@ pub(crate) struct Frame {
     pub(crate) mouse_listeners: Vec<Option<AnyMouseListener>>,
     pub(crate) dispatch_tree: DispatchTree,
     pub(crate) scene: Scene,
+    pub(crate) overlay_scene: Scene,
     pub(crate) hitboxes: Vec<Hitbox>,
     pub(crate) window_control_hitboxes: Vec<(WindowControlArea, Hitbox)>,
     pub(crate) deferred_draws: Vec<DeferredDraw>,
@@ -785,6 +801,7 @@ impl Frame {
             mouse_listeners: Vec::new(),
             dispatch_tree,
             scene: Scene::default(),
+            overlay_scene: Scene::default(),
             hitboxes: Vec::new(),
             window_control_hitboxes: Vec::new(),
             deferred_draws: Vec::new(),
@@ -810,6 +827,7 @@ impl Frame {
         self.mouse_listeners.clear();
         self.dispatch_tree.clear();
         self.scene.clear();
+        self.overlay_scene.clear();
         self.input_handlers.clear();
         self.tooltip_requests.clear();
         self.cursor_styles.clear();
@@ -879,6 +897,7 @@ impl Frame {
         }
 
         self.scene.finish();
+        self.overlay_scene.finish();
     }
 }
 
@@ -886,6 +905,12 @@ impl Frame {
 enum InputModality {
     Mouse,
     Keyboard,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PaintTarget {
+    Base,
+    Overlay,
 }
 
 /// Holds the state for a specific window.
@@ -941,6 +966,10 @@ pub struct Window {
     pub(crate) input_rate_tracker: Rc<RefCell<InputRateTracker>>,
     last_input_modality: InputModality,
     pub(crate) refreshing: bool,
+    animation_frame_requested: bool,
+    animation_callbacks: Vec<Box<dyn FnOnce(&mut Window, &mut App) + 'static>>,
+    cached_scene: Option<CachedScene>,
+    paint_target: PaintTarget,
     pub(crate) activation_observers: SubscriberSet<(), AnyObserver>,
     pub(crate) focus: Option<FocusId>,
     focus_enabled: bool,
@@ -1424,6 +1453,10 @@ impl Window {
             input_rate_tracker,
             last_input_modality: InputModality::Mouse,
             refreshing: false,
+            animation_frame_requested: false,
+            animation_callbacks: Vec::new(),
+            cached_scene: None,
+            paint_target: PaintTarget::Base,
             activation_observers: SubscriberSet::new(),
             focus: None,
             focus_enabled: true,
@@ -1479,6 +1512,9 @@ impl ContentMask<Pixels> {
 
 impl Window {
     fn mark_view_dirty(&mut self, view_id: EntityId) {
+        // Invalidate scene cache when any view becomes dirty
+        self.cached_scene = None;
+
         // Mark ancestor views as dirty. If already in the `dirty_views` set, then all its ancestors
         // should already be dirty.
         for view_id in self
@@ -1543,6 +1579,8 @@ impl Window {
         if self.invalidator.not_drawing() {
             self.refreshing = true;
             self.invalidator.set_dirty(true);
+            // Invalidate scene cache on refresh
+            self.cached_scene = None;
         }
     }
 
@@ -1844,6 +1882,30 @@ impl Window {
         self.on_next_frame(move |_, cx| cx.notify(entity));
     }
 
+    /// Request an animation-only frame that skips layout and repaints only animated overlays.
+    /// Only animation callbacks will be executed to paint animated elements on top of the last full frame.
+    /// This is much cheaper than a full frame for continuous animations like cursor movement.
+    ///
+    /// If the cache is invalid or views are dirty, falls back to a full frame.
+    pub fn request_animation_only_frame(&self) {
+        self.on_next_frame(move |window, _cx| {
+            window.animation_frame_requested = true;
+            window.invalidator.set_dirty(true);
+        });
+    }
+
+    /// Register a callback to paint animated content during animation-only frames.
+    /// The callback receives the window and app context for painting.
+    /// Callbacks are executed after the cached scene is replayed.
+    ///
+    /// Note: Callbacks must only paint - they should not modify app state.
+    pub fn on_animation_frame<F>(&mut self, callback: F)
+    where
+        F: FnOnce(&mut Window, &mut App) + 'static,
+    {
+        self.animation_callbacks.push(Box::new(callback));
+    }
+
     /// Spawn the future returned by the given closure on the application thread pool.
     /// The closure is provided a handle to the current window and an `AsyncWindowContext` for
     /// use within your future.
@@ -1885,6 +1947,9 @@ impl Window {
         self.scale_factor = self.platform_window.scale_factor();
         self.viewport_size = self.platform_window.content_size();
         self.display_id = self.platform_window.display().map(|display| display.id());
+
+        // Invalidate scene cache when bounds change
+        self.cached_scene = None;
 
         self.refresh();
 
@@ -2170,30 +2235,74 @@ impl Window {
         debug_assert!(self.rendered_entity_stack.is_empty());
         self.invalidator.set_dirty(false);
         self.requested_autoscroll = None;
+        self.next_frame.overlay_scene.clear();
+        self.paint_target = PaintTarget::Base;
 
         // Restore the previously-used input handler.
         if let Some(input_handler) = self.platform_window.take_input_handler() {
             self.rendered_frame.input_handlers.push(Some(input_handler));
         }
+
+        // Determine if this is an animation-only frame
+        let can_use_animation_frame = self.animation_frame_requested
+            && self.dirty_views.is_empty()
+            && !self.refreshing
+            && !self.rendered_frame.dispatch_tree.is_empty()
+            && self
+                .cached_scene
+                .as_ref()
+                .map(|c| c.is_valid(self.viewport_size, self.scale_factor))
+                .unwrap_or(false);
+
+        let mut used_animation_frame = false;
         if !cx.mode.skip_drawing() {
-            self.draw_roots(cx);
+            if can_use_animation_frame {
+                // Animation-only frame: reuse base scene and paint overlay callbacks only
+                self.draw_animation_frame(cx);
+                used_animation_frame = true;
+            } else {
+                // Full frame: do normal layout + paint + cache the scene
+                self.draw_roots(cx);
+                self.cache_current_scene();
+
+                // Run animation callbacks AFTER caching so animated elements
+                // are painted into the overlay scene (not included in cache)
+                self.run_animation_callbacks(cx);
+            }
         }
+
+        // Reset animation frame state for next frame
+        self.animation_frame_requested = false;
+        // Note: animation_callbacks already consumed by run_animation_callbacks or draw_animation_frame
+
         self.dirty_views.clear();
         self.next_frame.window_active = self.active.get();
 
         // Register requested input handler with the platform window.
+        if used_animation_frame && self.next_frame.input_handlers.is_empty() {
+            self.next_frame
+                .input_handlers
+                .append(&mut self.rendered_frame.input_handlers);
+        }
         if let Some(input_handler) = self.next_frame.input_handlers.pop() {
             self.platform_window
                 .set_input_handler(input_handler.unwrap());
         }
 
         self.layout_engine.as_mut().unwrap().clear();
-        self.text_system().finish_frame();
+        if used_animation_frame {
+            self.text_system().discard_frame();
+        } else {
+            self.text_system().finish_frame();
+        }
         self.next_frame.finish(&mut self.rendered_frame);
 
         self.invalidator.set_phase(DrawPhase::Focus);
         let previous_focus_path = self.rendered_frame.focus_path();
         let previous_window_active = self.rendered_frame.window_active;
+        if used_animation_frame {
+            self.reuse_rendered_frame_state_for_animation();
+        }
         mem::swap(&mut self.rendered_frame, &mut self.next_frame);
         self.next_frame.clear();
         let current_focus_path = self.rendered_frame.focus_path();
@@ -2235,6 +2344,99 @@ impl Window {
         ArenaClearNeeded::new(&cx.element_arena)
     }
 
+    /// Cache the current scene for animation-only frames
+    fn cache_current_scene(&mut self) {
+        self.cached_scene = Some(CachedScene {
+            viewport_size: self.viewport_size,
+            scale_factor: self.scale_factor,
+        });
+    }
+
+    /// Draw an animation-only frame by running animation callbacks into the overlay scene.
+    fn draw_animation_frame(&mut self, cx: &mut App) {
+        self.next_frame.overlay_scene.clear();
+        self.run_animation_callbacks(cx);
+    }
+
+    fn reuse_rendered_frame_state_for_animation(&mut self) {
+        // Preserve hit-testing and input state when only repainting animations.
+        mem::swap(&mut self.next_frame.focus, &mut self.rendered_frame.focus);
+        mem::swap(
+            &mut self.next_frame.element_states,
+            &mut self.rendered_frame.element_states,
+        );
+        mem::swap(
+            &mut self.next_frame.accessed_element_states,
+            &mut self.rendered_frame.accessed_element_states,
+        );
+        mem::swap(
+            &mut self.next_frame.mouse_listeners,
+            &mut self.rendered_frame.mouse_listeners,
+        );
+        mem::swap(
+            &mut self.next_frame.dispatch_tree,
+            &mut self.rendered_frame.dispatch_tree,
+        );
+        mem::swap(&mut self.next_frame.hitboxes, &mut self.rendered_frame.hitboxes);
+        mem::swap(
+            &mut self.next_frame.window_control_hitboxes,
+            &mut self.rendered_frame.window_control_hitboxes,
+        );
+        mem::swap(
+            &mut self.next_frame.deferred_draws,
+            &mut self.rendered_frame.deferred_draws,
+        );
+        mem::swap(&mut self.next_frame.scene, &mut self.rendered_frame.scene);
+        mem::swap(
+            &mut self.next_frame.input_handlers,
+            &mut self.rendered_frame.input_handlers,
+        );
+        mem::swap(
+            &mut self.next_frame.tooltip_requests,
+            &mut self.rendered_frame.tooltip_requests,
+        );
+        mem::swap(
+            &mut self.next_frame.cursor_styles,
+            &mut self.rendered_frame.cursor_styles,
+        );
+        mem::swap(&mut self.next_frame.tab_stops, &mut self.rendered_frame.tab_stops);
+
+        #[cfg(any(test, feature = "test-support"))]
+        {
+            mem::swap(&mut self.next_frame.debug_bounds, &mut self.rendered_frame.debug_bounds);
+        }
+        #[cfg(any(feature = "inspector", debug_assertions))]
+        {
+            mem::swap(
+                &mut self.next_frame.next_inspector_instance_ids,
+                &mut self.rendered_frame.next_inspector_instance_ids,
+            );
+            mem::swap(
+                &mut self.next_frame.inspector_hitboxes,
+                &mut self.rendered_frame.inspector_hitboxes,
+            );
+        }
+    }
+
+    /// Execute animation callbacks to paint animated elements.
+    /// Used by both full frames (after caching) and animation-only frames.
+    fn run_animation_callbacks(&mut self, cx: &mut App) {
+        if self.animation_callbacks.is_empty() {
+            return;
+        }
+
+        // Set paint phase for animation callbacks
+        self.invalidator.set_phase(DrawPhase::Paint);
+
+        // Execute animation callbacks to paint animated elements into the overlay scene.
+        let callbacks = std::mem::take(&mut self.animation_callbacks);
+        self.with_paint_target(PaintTarget::Overlay, |window| {
+            for callback in callbacks {
+                callback(window, cx);
+            }
+        });
+    }
+
     fn record_entities_accessed(&mut self, cx: &mut App) {
         let mut entities_ref = cx.entities.accessed_entities.borrow_mut();
         let mut entities = mem::take(entities_ref.deref_mut());
@@ -2260,7 +2462,10 @@ impl Window {
 
     #[profiling::function]
     fn present(&self) {
-        self.platform_window.draw(&self.rendered_frame.scene);
+        let overlay = (!self.rendered_frame.overlay_scene.is_empty())
+            .then_some(&self.rendered_frame.overlay_scene);
+        self.platform_window
+            .draw(&self.rendered_frame.scene, overlay);
         self.needs_present.set(false);
         profiling::finish_frame!();
     }
@@ -3037,6 +3242,21 @@ impl Window {
         });
     }
 
+    fn active_scene_mut(&mut self) -> &mut Scene {
+        match self.paint_target {
+            PaintTarget::Base => &mut self.next_frame.scene,
+            PaintTarget::Overlay => &mut self.next_frame.overlay_scene,
+        }
+    }
+
+    fn with_paint_target<R>(&mut self, target: PaintTarget, f: impl FnOnce(&mut Self) -> R) -> R {
+        let previous = self.paint_target;
+        self.paint_target = target;
+        let result = f(self);
+        self.paint_target = previous;
+        result
+    }
+
     /// Creates a new painting layer for the specified bounds. A "layer" is a batch
     /// of geometry that are non-overlapping and have the same draw order. This is typically used
     /// for performance reasons.
@@ -3049,15 +3269,14 @@ impl Window {
         let content_mask = self.content_mask();
         let clipped_bounds = bounds.intersect(&content_mask.bounds);
         if !clipped_bounds.is_empty() {
-            self.next_frame
-                .scene
+            self.active_scene_mut()
                 .push_layer(clipped_bounds.scale(scale_factor));
         }
 
         let result = f(self);
 
         if !clipped_bounds.is_empty() {
-            self.next_frame.scene.pop_layer();
+            self.active_scene_mut().pop_layer();
         }
 
         result
@@ -3079,7 +3298,7 @@ impl Window {
         let opacity = self.element_opacity();
         for shadow in shadows {
             let shadow_bounds = (bounds + shadow.offset).dilate(shadow.spread_radius);
-            self.next_frame.scene.insert_primitive(Shadow {
+            self.active_scene_mut().insert_primitive(Shadow {
                 order: 0,
                 blur_radius: shadow.blur_radius.scale(scale_factor),
                 bounds: shadow_bounds.scale(scale_factor),
@@ -3105,7 +3324,7 @@ impl Window {
         let scale_factor = self.scale_factor();
         let content_mask = self.content_mask();
         let opacity = self.element_opacity();
-        self.next_frame.scene.insert_primitive(Quad {
+        self.active_scene_mut().insert_primitive(Quad {
             order: 0,
             bounds: quad.bounds.scale(scale_factor),
             content_mask: content_mask.scale(scale_factor),
@@ -3129,8 +3348,7 @@ impl Window {
         path.content_mask = content_mask;
         let color: Background = color.into();
         path.color = color.opacity(opacity);
-        self.next_frame
-            .scene
+        self.active_scene_mut()
             .insert_primitive(path.scale(scale_factor));
     }
 
@@ -3158,7 +3376,7 @@ impl Window {
         let content_mask = self.content_mask();
         let element_opacity = self.element_opacity();
 
-        self.next_frame.scene.insert_primitive(Underline {
+        self.active_scene_mut().insert_primitive(Underline {
             order: 0,
             pad: 0,
             bounds: bounds.scale(scale_factor),
@@ -3189,7 +3407,7 @@ impl Window {
         let content_mask = self.content_mask();
         let opacity = self.element_opacity();
 
-        self.next_frame.scene.insert_primitive(Underline {
+        self.active_scene_mut().insert_primitive(Underline {
             order: 0,
             pad: 0,
             bounds: bounds.scale(scale_factor),
@@ -3343,7 +3561,7 @@ impl Window {
             let content_mask = self.content_mask().scale(scale_factor);
             let opacity = self.element_opacity();
 
-            self.next_frame.scene.insert_primitive(PolychromeSprite {
+            self.active_scene_mut().insert_primitive(PolychromeSprite {
                 order: 0,
                 pad: 0,
                 grayscale: false,
@@ -3407,7 +3625,7 @@ impl Window {
                 .map(|value| ScaledPixels(value.0 as f32 / SMOOTH_SVG_SCALE_FACTOR)),
         };
 
-        self.next_frame.scene.insert_primitive(MonochromeSprite {
+        self.active_scene_mut().insert_primitive(MonochromeSprite {
             order: 0,
             pad: 0,
             bounds: svg_bounds
@@ -3459,7 +3677,7 @@ impl Window {
         let corner_radii = corner_radii.scale(scale_factor);
         let opacity = self.element_opacity();
 
-        self.next_frame.scene.insert_primitive(PolychromeSprite {
+        self.active_scene_mut().insert_primitive(PolychromeSprite {
             order: 0,
             pad: 0,
             grayscale,
@@ -3486,7 +3704,7 @@ impl Window {
         let scale_factor = self.scale_factor();
         let bounds = bounds.scale(scale_factor);
         let content_mask = self.content_mask().scale(scale_factor);
-        self.next_frame.scene.insert_primitive(PaintSurface {
+        self.active_scene_mut().insert_primitive(PaintSurface {
             order: 0,
             bounds,
             content_mask,
@@ -4042,6 +4260,11 @@ impl Window {
     }
 
     fn dispatch_key_event(&mut self, event: &dyn Any, cx: &mut App) {
+        // Skip dispatch if the tree hasn't been populated yet (before first frame)
+        if self.rendered_frame.dispatch_tree.is_empty() {
+            return;
+        }
+
         if self.invalidator.is_dirty() {
             self.draw(cx).clear();
         }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -3480,7 +3480,7 @@ impl Window {
             let content_mask = self.content_mask().scale(scale_factor);
 
             if subpixel_rendering {
-                self.next_frame.scene.insert_primitive(SubpixelSprite {
+                self.active_scene_mut().insert_primitive(SubpixelSprite {
                     order: 0,
                     pad: 0,
                     bounds,
@@ -3490,7 +3490,7 @@ impl Window {
                     transformation: TransformationMatrix::unit(),
                 });
             } else {
-                self.next_frame.scene.insert_primitive(MonochromeSprite {
+                self.active_scene_mut().insert_primitive(MonochromeSprite {
                     order: 0,
                     pad: 0,
                     bounds,

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -2377,7 +2377,10 @@ impl Window {
             &mut self.next_frame.dispatch_tree,
             &mut self.rendered_frame.dispatch_tree,
         );
-        mem::swap(&mut self.next_frame.hitboxes, &mut self.rendered_frame.hitboxes);
+        mem::swap(
+            &mut self.next_frame.hitboxes,
+            &mut self.rendered_frame.hitboxes,
+        );
         mem::swap(
             &mut self.next_frame.window_control_hitboxes,
             &mut self.rendered_frame.window_control_hitboxes,
@@ -2399,11 +2402,17 @@ impl Window {
             &mut self.next_frame.cursor_styles,
             &mut self.rendered_frame.cursor_styles,
         );
-        mem::swap(&mut self.next_frame.tab_stops, &mut self.rendered_frame.tab_stops);
+        mem::swap(
+            &mut self.next_frame.tab_stops,
+            &mut self.rendered_frame.tab_stops,
+        );
 
         #[cfg(any(test, feature = "test-support"))]
         {
-            mem::swap(&mut self.next_frame.debug_bounds, &mut self.rendered_frame.debug_bounds);
+            mem::swap(
+                &mut self.next_frame.debug_bounds,
+                &mut self.rendered_frame.debug_bounds,
+            );
         }
         #[cfg(any(feature = "inspector", debug_assertions))]
         {

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -301,6 +301,8 @@ impl VsCodeSettings {
             ),
             selection_highlight: self.read_bool("editor.selectionHighlight"),
             show_signature_help_after_edits: self.read_bool("editor.parameterHints.enabled"),
+            smooth_caret: None,
+            cursor_vfx: None,
             snippet_sort_order: None,
             toolbar: None,
             use_smartcase_search: self.read_bool("search.smartCase"),

--- a/crates/settings_content/src/editor.rs
+++ b/crates/settings_content/src/editor.rs
@@ -29,8 +29,8 @@ pub struct EditorSettingsContent {
     /// {
     ///   "enabled": true,
     ///   "animation_time_ms": 150,
-    ///   "short_animation_time_ms": 25,
-    ///   "trail_size": 1.0,
+    ///   "short_animation_time_ms": 40,
+    ///   "trail_size": 0.8,
     ///   "animate_in_insert_mode": true
     /// }
     /// ```
@@ -724,6 +724,8 @@ pub enum CursorShape {
 
 /// Detailed smooth cursor animation settings.
 /// Allows fine-grained control over cursor animation behavior.
+/// Recommended opt-in preset for Neovide-like motion:
+/// `{ "smooth_caret": { "enabled": true, "animation_time_ms": 150, "short_animation_time_ms": 40, "trail_size": 0.7, "animate_in_insert_mode": true, "smooth_blink": true }, "cursor_vfx": { "mode": "none" } }`
 #[with_fallible_options]
 #[derive(Clone, Default, Debug, Serialize, Deserialize, JsonSchema, MergeFrom, PartialEq)]
 pub struct SmoothCaretContent {
@@ -739,7 +741,7 @@ pub struct SmoothCaretContent {
 
     /// Animation duration for small moves (typing) in milliseconds.
     ///
-    /// Default: 25
+    /// Default: 40
     pub short_animation_time_ms: Option<u64>,
 
     /// Trail size controls cursor responsiveness vs smoothness:
@@ -747,7 +749,7 @@ pub struct SmoothCaretContent {
     /// - 0.5 = Balanced animation
     /// - 0.0 = Full smooth animation (maximum smoothness, more perceived latency)
     ///
-    /// Default: 1.0
+    /// Default: 0.7
     #[serde(serialize_with = "crate::serialize_optional_f32_with_two_decimal_places")]
     #[schemars(range(min = 0.0, max = 1.0))]
     pub trail_size: Option<f32>,
@@ -757,6 +759,12 @@ pub struct SmoothCaretContent {
     ///
     /// Default: true
     pub animate_in_insert_mode: Option<bool>,
+
+    /// Whether to use smooth opacity transitions for cursor blinking.
+    /// When enabled, cursor fades in/out smoothly instead of toggling on/off.
+    ///
+    /// Default: true
+    pub smooth_blink: Option<bool>,
 }
 
 /// Smooth cursor setting that supports both simple boolean and detailed configuration.

--- a/crates/settings_content/src/editor.rs
+++ b/crates/settings_content/src/editor.rs
@@ -22,6 +22,26 @@ pub struct EditorSettingsContent {
     ///
     /// Default: bar
     pub cursor_shape: Option<CursorShape>,
+    /// Smooth cursor animation settings.
+    /// Can be a boolean (true/false) for simple enable/disable,
+    /// or an object for detailed configuration:
+    /// ```json
+    /// {
+    ///   "enabled": true,
+    ///   "animation_time_ms": 150,
+    ///   "short_animation_time_ms": 25,
+    ///   "trail_size": 1.0,
+    ///   "animate_in_insert_mode": true
+    /// }
+    /// ```
+    ///
+    /// Default: false
+    pub smooth_caret: Option<SmoothCaretSetting>,
+    /// Cursor visual effects (particle animations).
+    /// Enables effects like particle trails when cursor moves.
+    ///
+    /// Default: mode is "none" (disabled)
+    pub cursor_vfx: Option<CursorVfxContent>,
     /// Determines when the mouse cursor should be hidden in an editor or input box.
     ///
     /// Default: on_typing_and_movement
@@ -700,6 +720,95 @@ pub enum CursorShape {
     Underline,
     /// A box drawn around the following character
     Hollow,
+}
+
+/// Detailed smooth cursor animation settings.
+/// Allows fine-grained control over cursor animation behavior.
+#[with_fallible_options]
+#[derive(Clone, Default, Debug, Serialize, Deserialize, JsonSchema, MergeFrom, PartialEq)]
+pub struct SmoothCaretContent {
+    /// Whether smooth cursor animation is enabled.
+    ///
+    /// Default: true
+    pub enabled: Option<bool>,
+
+    /// Animation duration for large jumps (search, goto) in milliseconds.
+    ///
+    /// Default: 150
+    pub animation_time_ms: Option<u64>,
+
+    /// Animation duration for small moves (typing) in milliseconds.
+    ///
+    /// Default: 25
+    pub short_animation_time_ms: Option<u64>,
+
+    /// Trail size controls cursor responsiveness vs smoothness:
+    /// - 1.0 = Leading edge snaps instantly (minimum latency, maximum responsiveness)
+    /// - 0.5 = Balanced animation
+    /// - 0.0 = Full smooth animation (maximum smoothness, more perceived latency)
+    ///
+    /// Default: 1.0
+    #[serde(serialize_with = "crate::serialize_optional_f32_with_two_decimal_places")]
+    #[schemars(range(min = 0.0, max = 1.0))]
+    pub trail_size: Option<f32>,
+
+    /// Whether to animate cursor during insert mode (typing).
+    /// When false, cursor snaps instantly for short horizontal movements.
+    ///
+    /// Default: true
+    pub animate_in_insert_mode: Option<bool>,
+}
+
+/// Smooth cursor setting that supports both simple boolean and detailed configuration.
+/// This enables backwards compatibility with existing `"smooth_caret": true/false` settings.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema, MergeFrom)]
+#[serde(untagged)]
+pub enum SmoothCaretSetting {
+    /// Simple boolean for backwards compatibility
+    Bool(bool),
+    /// Detailed configuration object
+    Config(SmoothCaretContent),
+}
+
+impl Default for SmoothCaretSetting {
+    fn default() -> Self {
+        SmoothCaretSetting::Bool(true)
+    }
+}
+
+/// Cursor visual effect mode for particle animations.
+/// Provides enhanced visual feedback during cursor movement.
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    JsonSchema,
+    MergeFrom,
+    strum::VariantArray,
+    strum::VariantNames,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum CursorVfxModeContent {
+    /// No visual effects
+    #[default]
+    None,
+    /// Burst effect at cursor stop point
+    Sonicboom,
+}
+
+/// Cursor visual effects settings.
+#[with_fallible_options]
+#[derive(Clone, Default, Debug, Serialize, Deserialize, JsonSchema, MergeFrom, PartialEq)]
+pub struct CursorVfxContent {
+    /// Visual effect mode. Set to "none" to disable effects, or "sonicboom" for burst effect.
+    ///
+    /// Default: none
+    pub mode: Option<CursorVfxModeContent>,
 }
 
 /// What to do when go to definition yields no results.

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -1035,7 +1035,7 @@ fn appearance_page() -> SettingsPage {
         ]
     }
 
-    fn cursor_section() -> [SettingsPageItem; 5] {
+    fn cursor_section() -> [SettingsPageItem; 7] {
         [
             SettingsPageItem::SectionHeader("Cursor"),
             SettingsPageItem::SettingItem(SettingItem {
@@ -1085,6 +1085,42 @@ fn appearance_page() -> SettingsPage {
                     pick: |settings_content| settings_content.editor.hide_mouse.as_ref(),
                     write: |settings_content, value| {
                         settings_content.editor.hide_mouse = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Smooth Cursor Animation",
+                description: "Enable smooth cursor movement animation.",
+                field: Box::new(SettingField {
+                    json_path: Some("smooth_caret"),
+                    pick: |settings_content| settings_content.editor.smooth_caret.as_ref(),
+                    write: |settings_content, value| {
+                        settings_content.editor.smooth_caret = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Cursor Effect",
+                description: "Visual effect when cursor stops moving.",
+                field: Box::new(SettingField {
+                    json_path: Some("cursor_vfx.mode"),
+                    pick: |settings_content| {
+                        settings_content
+                            .editor
+                            .cursor_vfx
+                            .as_ref()
+                            .and_then(|c| c.mode.as_ref())
+                    },
+                    write: |settings_content, value| {
+                        settings_content
+                            .editor
+                            .cursor_vfx
+                            .get_or_insert_default()
+                            .mode = value;
                     },
                 }),
                 metadata: None,

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -557,6 +557,8 @@ fn init_renderers(cx: &mut App) {
         .add_basic_renderer::<settings::DocumentSymbols>(render_dropdown)
         .add_basic_renderer::<settings::AudioInputDeviceName>(render_input_audio_device_dropdown)
         .add_basic_renderer::<settings::AudioOutputDeviceName>(render_output_audio_device_dropdown)
+        .add_basic_renderer::<settings::SmoothCaretSetting>(render_smooth_caret_toggle)
+        .add_basic_renderer::<settings::CursorVfxModeContent>(render_dropdown)
         // please semicolon stay on next line
         ;
 }
@@ -4037,6 +4039,51 @@ fn render_toggle_button<B: Into<bool> + From<bool> + Copy>(
                     (field.write)(settings, Some(state.into()));
                 })
                 .log_err(); // todo(settings_ui) don't log err
+            }
+        })
+        .into_any_element()
+}
+
+fn render_smooth_caret_toggle(
+    field: SettingField<settings::SmoothCaretSetting>,
+    file: SettingsUiFile,
+    _metadata: Option<&SettingsFieldMetadata>,
+    _window: &mut Window,
+    cx: &mut App,
+) -> AnyElement {
+    let (_, value) = SettingsStore::global(cx).get_value_from_file(file.to_settings(), field.pick);
+    let existing_value = value.cloned();
+
+    let is_enabled = existing_value.as_ref().map_or(false, |v| match v {
+        settings::SmoothCaretSetting::Bool(b) => *b,
+        settings::SmoothCaretSetting::Config(config) => config.enabled.unwrap_or(true),
+    });
+
+    let toggle_state = if is_enabled {
+        ToggleState::Selected
+    } else {
+        ToggleState::Unselected
+    };
+
+    Switch::new("toggle_button", toggle_state)
+        .tab_index(0_isize)
+        .on_click({
+            let existing_value = existing_value.clone();
+            move |state, window, cx| {
+                telemetry::event!("Settings Change", setting = field.json_path, type = file.setting_type());
+                let enabled = *state == ui::ToggleState::Selected;
+                let existing_value = existing_value.clone();
+                update_settings_file(file.clone(), field.json_path, window, cx, move |settings, _cx| {
+                    let setting = match existing_value {
+                        Some(settings::SmoothCaretSetting::Config(mut config)) => {
+                            config.enabled = Some(enabled);
+                            settings::SmoothCaretSetting::Config(config)
+                        }
+                        _ => settings::SmoothCaretSetting::Bool(enabled),
+                    };
+                    (field.write)(settings, Some(setting));
+                })
+                .log_err();
             }
         })
         .into_any_element()

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -4068,7 +4068,7 @@ fn render_smooth_caret_toggle(
     Switch::new("toggle_button", toggle_state)
         .tab_index(0_isize)
         .on_click({
-            let existing_value = existing_value.clone();
+
             move |state, window, cx| {
                 telemetry::event!("Settings Change", setting = field.json_path, type = file.setting_type());
                 let enabled = *state == ui::ToggleState::Selected;

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -1117,12 +1117,21 @@ impl Element for TerminalElement {
 
                 // Layout cursor. Rectangle is used for IME, so we should lay it out even
                 // if we don't end up showing it.
+                // Keep cursor visible when blinking is disabled or view is unfocused.
+                let blink_opacity = if self.cursor_visible
+                    || self.terminal_view.read(cx).blink_manager.read(cx).visible()
+                {
+                    1.0
+                } else {
+                    0.0
+                };
+
                 let cursor_point = DisplayCursor::from(cursor.point, display_offset);
                 let cursor_text = {
-                    let str_trxt = cursor_char.to_string();
-                    let len = str_trxt.len();
+                    let str_txt = cursor_char.to_string();
+                    let len = str_txt.len();
                     window.text_system().shape_line(
-                        str_trxt.into(),
+                        str_txt.into(),
                         text_style.font_size.to_pixels(window.rem_size()),
                         &[TextRun {
                             len,
@@ -1171,6 +1180,7 @@ impl Element for TerminalElement {
                             shape,
                             text,
                         )
+                        .with_opacity(blink_opacity)
                     })
                 };
 

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -1115,17 +1115,6 @@ impl Element for TerminalElement {
                     )
                 };
 
-                // Layout cursor. Rectangle is used for IME, so we should lay it out even
-                // if we don't end up showing it.
-                // Keep cursor visible when blinking is disabled or view is unfocused.
-                let blink_opacity = if self.cursor_visible
-                    || self.terminal_view.read(cx).blink_manager.read(cx).visible()
-                {
-                    1.0
-                } else {
-                    0.0
-                };
-
                 let cursor_point = DisplayCursor::from(cursor.point, display_offset);
                 let cursor_text = {
                     let str_txt = cursor_char.to_string();
@@ -1158,30 +1147,63 @@ impl Element for TerminalElement {
                         size: size(cursor_width.ceil(), dimensions.line_height),
                     });
 
+                let should_blink_cursor = self.terminal_view.read(cx).should_blink_cursor_for_mode(
+                    self.focused,
+                    mode,
+                    cx,
+                );
+
                 let cursor = if let AlacCursorShape::Hidden = cursor.shape {
                     None
-                } else {
+                } else if let Some(bounds) = ime_cursor_bounds {
                     let focused = self.focused;
-                    ime_cursor_bounds.map(move |bounds| {
-                        let (shape, text) = match cursor.shape {
-                            AlacCursorShape::Block if !focused => (CursorShape::Hollow, None),
-                            AlacCursorShape::Block => (CursorShape::Block, Some(cursor_text)),
-                            AlacCursorShape::Underline => (CursorShape::Underline, None),
-                            AlacCursorShape::Beam => (CursorShape::Bar, None),
-                            AlacCursorShape::HollowBlock => (CursorShape::Hollow, None),
-                            AlacCursorShape::Hidden => unreachable!(),
-                        };
+                    let (render_shape, physics_shape, text) = match cursor.shape {
+                        AlacCursorShape::Block if !focused => {
+                            (CursorShape::Hollow, CursorShape::Block, None)
+                        }
+                        AlacCursorShape::Block => {
+                            (CursorShape::Block, CursorShape::Block, Some(cursor_text))
+                        }
+                        AlacCursorShape::Underline => {
+                            (CursorShape::Underline, CursorShape::Underline, None)
+                        }
+                        AlacCursorShape::Beam => (CursorShape::Bar, CursorShape::Bar, None),
+                        AlacCursorShape::HollowBlock => {
+                            (CursorShape::Hollow, CursorShape::Hollow, None)
+                        }
+                        AlacCursorShape::Hidden => unreachable!(),
+                    };
 
+                    let (origin, quad_corners, opacity, is_animating) =
+                        self.terminal_view.update(cx, |terminal_view, cx| {
+                            terminal_view.next_cursor_frame(
+                                bounds.origin,
+                                bounds.size.width,
+                                bounds.size.height,
+                                physics_shape,
+                                self.cursor_visible,
+                                should_blink_cursor,
+                                cx,
+                            )
+                        });
+                    if is_animating {
+                        window.request_animation_frame();
+                    }
+
+                    Some(
                         CursorLayout::new(
-                            bounds.origin,
+                            origin,
                             bounds.size.width,
                             bounds.size.height,
                             theme.players().local().cursor,
-                            shape,
+                            render_shape,
                             text,
                         )
-                        .with_opacity(blink_opacity)
-                    })
+                        .with_quad_corners(quad_corners)
+                        .with_opacity(opacity),
+                    )
+                } else {
+                    None
                 };
 
                 let block_below_cursor_element = if let Some(block) = &self.block_below_cursor {

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -6,7 +6,10 @@ pub mod terminal_scrollbar;
 mod terminal_slash_command;
 
 use assistant_slash_command::SlashCommandRegistry;
-use editor::{Editor, EditorSettings, actions::SelectAll, blink_manager::BlinkManager};
+use editor::{
+    CursorAnimationTicker, Editor, EditorSettings, InertialCursorConfig, QuadCursor, actions::SelectAll,
+    blink_manager::BlinkManager,
+};
 use gpui::{
     Action, AnyElement, App, ClipboardEntry, DismissEvent, Entity, EventEmitter, FocusHandle,
     Focusable, KeyContext, KeyDownEvent, Keystroke, MouseButton, MouseDownEvent, Pixels, Point,
@@ -25,13 +28,13 @@ use std::{
     path::{Path, PathBuf},
     rc::Rc,
     sync::Arc,
-    time::Duration,
+    time::{Duration, Instant},
 };
 use task::TaskId;
 use terminal::{
     Clear, Copy, Event, HoveredWord, MaybeNavigationTarget, Paste, ScrollLineDown, ScrollLineUp,
-    ScrollPageDown, ScrollPageUp, ScrollToBottom, ScrollToTop, ShowCharacterPalette, TaskState,
-    TaskStatus, Terminal, TerminalBounds, ToggleViMode,
+    ScrollPageDown, ScrollPageUp, ScrollToBottom, ScrollToTop, ShowCharacterPalette, TaskStatus,
+    TaskState, Terminal, TerminalBounds, ToggleViMode,
     alacritty_terminal::{
         index::Point as AlacPoint,
         term::{TermMode, point_to_viewport, search::RegexSearch},
@@ -56,10 +59,9 @@ use workspace::{
         BreadcrumbText, Item, ItemEvent, SerializableItem, TabContentParams, TabTooltipContent,
     },
     register_serializable_item,
-    searchable::{
-        Direction, SearchEvent, SearchOptions, SearchToken, SearchableItem, SearchableItemHandle,
-    },
+    searchable::{Direction, SearchEvent, SearchOptions, SearchToken, SearchableItem, SearchableItemHandle},
 };
+use zed_actions::{agent::AddSelectionToThread, assistant::InlineAssist};
 use zed_actions::{agent::AddSelectionToThread, assistant::InlineAssist};
 
 struct ImeState {
@@ -67,6 +69,7 @@ struct ImeState {
 }
 
 const CURSOR_BLINK_INTERVAL: Duration = Duration::from_millis(500);
+const MAX_CURSOR_ANIMATION_DT: f32 = 1.0 / 120.0;
 
 /// Event to transmit the scroll from the element to the view
 #[derive(Clone, Debug, PartialEq)]
@@ -130,6 +133,9 @@ pub struct TerminalView {
     context_menu: Option<(Entity<ContextMenu>, Point<Pixels>, Subscription)>,
     cursor_shape: CursorShape,
     blink_manager: Entity<BlinkManager>,
+    quad_cursor: Option<QuadCursor>,
+    cursor_animation_ticker: CursorAnimationTicker,
+    last_cursor_origin: Option<gpui::Point<Pixels>>,
     mode: TerminalMode,
     blinking_terminal_enabled: bool,
     needs_serialize: bool,
@@ -244,6 +250,8 @@ impl TerminalView {
             },
         );
         let cursor_shape = TerminalSettings::get_global(cx).cursor_shape;
+        let smooth_caret_settings = EditorSettings::get_global(cx).smooth_caret;
+        let smooth_caret_config = InertialCursorConfig::from_settings(&smooth_caret_settings);
 
         let scroll_handle = TerminalScrollHandle::new(terminal.read(cx));
 
@@ -258,6 +266,9 @@ impl TerminalView {
                 },
                 cx,
             )
+        });
+        blink_manager.update(cx, |manager, _cx| {
+            manager.set_smooth_blink_enabled(smooth_caret_settings.smooth_blink);
         });
 
         let subscriptions = vec![
@@ -276,6 +287,16 @@ impl TerminalView {
             context_menu: None,
             cursor_shape,
             blink_manager,
+            quad_cursor: smooth_caret_config.enabled.then(|| {
+                QuadCursor::new(
+                    smooth_caret_config,
+                    gpui::point(Pixels::ZERO, Pixels::ZERO),
+                    10.0,
+                    20.0,
+                )
+            }),
+            cursor_animation_ticker: CursorAnimationTicker::new(),
+            last_cursor_origin: None,
             blinking_terminal_enabled: false,
             hover: None,
             hover_tooltip_update: Task::ready(()),
@@ -549,6 +570,8 @@ impl TerminalView {
 
     fn settings_changed(&mut self, cx: &mut Context<Self>) {
         let settings = TerminalSettings::get_global(cx);
+        let smooth_caret_settings = EditorSettings::get_global(cx).smooth_caret;
+        let smooth_caret_config = InertialCursorConfig::from_settings(&smooth_caret_settings);
         let breadcrumb_visibility_changed = self.show_breadcrumbs != settings.toolbar.breadcrumbs;
         self.show_breadcrumbs = settings.toolbar.breadcrumbs;
 
@@ -574,6 +597,26 @@ impl TerminalView {
                 BlinkManager::disable
             },
         );
+        self.blink_manager.update(cx, |manager, _cx| {
+            manager.set_smooth_blink_enabled(smooth_caret_settings.smooth_blink);
+        });
+
+        if smooth_caret_config.enabled {
+            if let Some(cursor) = &mut self.quad_cursor {
+                cursor.set_config(smooth_caret_config);
+            } else {
+                self.quad_cursor = Some(QuadCursor::new(
+                    smooth_caret_config,
+                    gpui::point(Pixels::ZERO, Pixels::ZERO),
+                    10.0,
+                    20.0,
+                ));
+            }
+        } else {
+            self.quad_cursor = None;
+            self.cursor_animation_ticker.stop();
+            self.last_cursor_origin = None;
+        }
 
         if breadcrumb_visibility_changed {
             cx.emit(ItemEvent::UpdateBreadcrumbs);
@@ -752,27 +795,125 @@ impl TerminalView {
         cx.notify();
     }
 
+    pub(crate) fn should_blink_cursor_for_mode(
+        &self,
+        focused: bool,
+        terminal_mode: TermMode,
+        cx: &App,
+    ) -> bool {
+        if !focused || terminal_mode.contains(TermMode::ALT_SCREEN) {
+            return false;
+        }
+
+        match TerminalSettings::get_global(cx).blinking {
+            TerminalBlink::Off => false,
+            TerminalBlink::On => true,
+            TerminalBlink::TerminalControlled => self.blinking_terminal_enabled,
+        }
+    }
+
     pub fn should_show_cursor(&self, focused: bool, cx: &mut Context<Self>) -> bool {
-        // Always show cursor when not focused or in special modes
-        if !focused
-            || self
-                .terminal
-                .read(cx)
-                .last_content
-                .mode
-                .contains(TermMode::ALT_SCREEN)
-        {
+        let terminal_mode = self.terminal.read(cx).last_content.mode;
+        if !focused || terminal_mode.contains(TermMode::ALT_SCREEN) {
             return true;
         }
 
-        // When focused, check blinking settings and blink manager state
-        match TerminalSettings::get_global(cx).blinking {
-            TerminalBlink::Off => true,
-            TerminalBlink::TerminalControlled => {
-                !self.blinking_terminal_enabled || self.blink_manager.read(cx).visible()
-            }
-            TerminalBlink::On => self.blink_manager.read(cx).visible(),
+        if self.should_blink_cursor_for_mode(focused, terminal_mode, cx) {
+            self.blink_manager.read(cx).should_render()
+        } else {
+            true
         }
+    }
+
+    fn tick_cursor_animations(&mut self) -> bool {
+        let now = Instant::now();
+        let quad_animating = self
+            .quad_cursor
+            .as_ref()
+            .is_some_and(|cursor| cursor.is_animating());
+        if !quad_animating {
+            self.cursor_animation_ticker.stop();
+            return false;
+        }
+
+        let dt = self.cursor_animation_ticker.tick(now);
+        let dt_secs = dt.as_secs_f32();
+        let steps = ((dt_secs / MAX_CURSOR_ANIMATION_DT).ceil() as usize).max(1);
+        let dt_per_step = dt_secs / steps as f32;
+
+        if let Some(cursor) = &mut self.quad_cursor {
+            for _ in 0..steps {
+                cursor.update_physics(dt_per_step);
+            }
+        }
+
+        let still_animating = self
+            .quad_cursor
+            .as_ref()
+            .is_some_and(|cursor| cursor.is_animating());
+        if !still_animating {
+            self.cursor_animation_ticker.stop();
+        }
+        still_animating
+    }
+
+    pub(crate) fn next_cursor_frame(
+        &mut self,
+        cursor_origin: gpui::Point<Pixels>,
+        block_width: Pixels,
+        line_height: Pixels,
+        cursor_shape: language::CursorShape,
+        should_show_cursor: bool,
+        should_blink_cursor: bool,
+        cx: &mut Context<Self>,
+    ) -> (
+        gpui::Point<Pixels>,
+        Option<[gpui::Point<Pixels>; 4]>,
+        f32,
+        bool,
+    ) {
+        if should_blink_cursor
+            && self.last_cursor_origin.is_some_and(|previous| previous != cursor_origin)
+        {
+            self.blink_manager.update(cx, BlinkManager::cursor_moved);
+        }
+        self.last_cursor_origin = Some(cursor_origin);
+
+        if let Some(cursor) = &mut self.quad_cursor {
+            cursor.set_cell_size(block_width.into(), line_height.into());
+            cursor.set_shape(cursor_shape);
+            cursor.set_logical_pos(cursor_origin);
+        }
+
+        let cursor_animating = self.tick_cursor_animations();
+        let (origin, quad_corners) = if let Some(cursor) = self.quad_cursor.as_ref() {
+            (
+                cursor.visual_pos(),
+                Some(cursor.interpolated_corner_positions()),
+            )
+        } else {
+            (cursor_origin, None)
+        };
+
+        let blink_opacity = self
+            .blink_manager
+            .update(cx, |manager, cx| manager.opacity(cx));
+        let opacity = if !should_show_cursor {
+            0.0
+        } else if should_blink_cursor {
+            blink_opacity
+        } else {
+            1.0
+        };
+        let blink_animating =
+            should_blink_cursor && self.blink_manager.read(cx).is_smooth_blink_animating();
+
+        (
+            origin,
+            quad_corners,
+            opacity,
+            cursor_animating || blink_animating,
+        )
     }
 
     pub fn pause_cursor_blinking(&mut self, _window: &mut Window, cx: &mut Context<Self>) {

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -578,6 +578,7 @@ impl TerminalView {
         if breadcrumb_visibility_changed {
             cx.emit(ItemEvent::UpdateBreadcrumbs);
         }
+
         cx.notify();
     }
 
@@ -1158,15 +1159,7 @@ impl TerminalView {
             terminal.focus_in();
         });
 
-        let should_blink = match TerminalSettings::get_global(cx).blinking {
-            TerminalBlink::Off => false,
-            TerminalBlink::On => true,
-            TerminalBlink::TerminalControlled => self.blinking_terminal_enabled,
-        };
-
-        if should_blink {
-            self.blink_manager.update(cx, BlinkManager::enable);
-        }
+        self.blink_manager.update(cx, BlinkManager::enable);
 
         window.invalidate_character_coordinates();
         cx.notify();


### PR DESCRIPTION
Implement Neovide-style smooth cursor movement for editor and terminal. The cursor smoothly animates to new positions using inertial physics.

Controlled by `smooth_caret` setting (true/false).

Closes https://github.com/zed-industries/zed/issues/4991

DEMO:

https://github.com/user-attachments/assets/3f58e4ec-490a-4322-a71b-495a9946d78d


Release Notes:

- Added smooth cursor animation for editor and terminal

Before merge:
- [ ] Fix wrong character render https://github.com/zed-industries/zed/pull/44770#issuecomment-3679462002