### PR TITLE
gpui: Implement depth testing on metal

### DIFF
--- a/crates/gpui/src/platform/mac/metal_renderer.rs
+++ b/crates/gpui/src/platform/mac/metal_renderer.rs
@@ -117,6 +117,8 @@ pub(crate) struct MetalRenderer {
     path_intermediate_texture: Option<metal::Texture>,
     path_intermediate_msaa_texture: Option<metal::Texture>,
     path_sample_count: u32,
+    depth_texture: Option<metal::Texture>,
+    depth_stencil_state: metal::DepthStencilState,
 }
 
 #[repr(C)]
@@ -264,6 +266,10 @@ impl MetalRenderer {
         let core_video_texture_cache =
             CVMetalTextureCache::new(None, device.clone(), None).unwrap();
 
+        let depth_stencil_descriptor = metal::DepthStencilDescriptor::new();
+        depth_stencil_descriptor.set_depth_compare_function(metal::MTLCompareFunction::LessEqual);
+        depth_stencil_descriptor.set_depth_write_enabled(true);
+
         Self {
             device,
             layer,
@@ -284,6 +290,8 @@ impl MetalRenderer {
             path_intermediate_texture: None,
             path_intermediate_msaa_texture: None,
             path_sample_count: PATH_SAMPLE_COUNT,
+            depth_texture: None,
+            depth_stencil_state: device.new_depth_stencil_state(&depth_stencil_descriptor),
         }
     }
 

--- a/crates/gpui/src/platform/mac/metal_renderer.rs
+++ b/crates/gpui/src/platform/mac/metal_renderer.rs
@@ -1196,6 +1196,7 @@ impl MetalRenderer {
                 ptr::write(
                     buffer_contents,
                     SurfaceBounds {
+                        order: surface.order,
                         bounds: surface.bounds,
                         content_mask: surface.content_mask.clone(),
                     },
@@ -1418,6 +1419,7 @@ pub struct PathSprite {
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[repr(C)]
 pub struct SurfaceBounds {
+    pub order: DrawOrder,
     pub bounds: Bounds<ScaledPixels>,
     pub content_mask: ContentMask<ScaledPixels>,
 }

--- a/crates/gpui/src/platform/mac/metal_renderer.rs
+++ b/crates/gpui/src/platform/mac/metal_renderer.rs
@@ -481,6 +481,9 @@ impl MetalRenderer {
             },
         );
 
+        // Where can we set this?
+        command_encoder.set_depth_stencil_state(&self.depth_stencil_state);
+
         for batch in scene.batches() {
             let ok = match batch {
                 PrimitiveBatch::Shadows(shadows) => self.draw_shadows(

--- a/crates/gpui/src/platform/mac/metal_renderer.rs
+++ b/crates/gpui/src/platform/mac/metal_renderer.rs
@@ -337,6 +337,7 @@ impl MetalRenderer {
             height: DevicePixels(size.height as i32),
         };
         self.update_path_intermediate_textures(device_pixels_size);
+        self.update_depth_texture(device_pixels_size);
     }
 
     fn update_depth_texture(&mut self, size: Size<DevicePixels>) {

--- a/crates/gpui/src/platform/mac/shaders.metal
+++ b/crates/gpui/src/platform/mac/shaders.metal
@@ -77,7 +77,7 @@ vertex QuadVertexOutput quad_vertex(uint unit_vertex_id [[vertex_id]],
   float2 unit_vertex = unit_vertices[unit_vertex_id];
   Quad quad = quads[quad_id];
   float4 device_position =
-      to_device_position_with_depth(unit_vertex, quad.bounds, viewport_size);
+      to_device_position_with_depth(unit_vertex, quad.bounds, viewport_size, quad.order);
   float4 clip_distance = distance_from_clip_rect(unit_vertex, quad.bounds,
                                                  quad.content_mask.bounds);
   float4 border_color = hsla_to_rgba(quad.border_color);

--- a/crates/gpui/src/platform/mac/shaders.metal
+++ b/crates/gpui/src/platform/mac/shaders.metal
@@ -77,7 +77,7 @@ vertex QuadVertexOutput quad_vertex(uint unit_vertex_id [[vertex_id]],
   float2 unit_vertex = unit_vertices[unit_vertex_id];
   Quad quad = quads[quad_id];
   float4 device_position =
-      to_device_position_with_depth(unit_vertex, quad.bounds, viewport_size, quad.order);
+      to_device_position_with_order(unit_vertex, quad.bounds, viewport_size, quad.order);
   float4 clip_distance = distance_from_clip_rect(unit_vertex, quad.bounds,
                                                  quad.content_mask.bounds);
   float4 border_color = hsla_to_rgba(quad.border_color);
@@ -481,7 +481,7 @@ vertex ShadowVertexOutput shadow_vertex(
   bounds.size.height += 2. * margin;
 
   float4 device_position =
-      to_device_position(unit_vertex, bounds, viewport_size);
+      to_device_position_with_order(unit_vertex, bounds, viewport_size, shadow.order);
   float4 clip_distance =
       distance_from_clip_rect(unit_vertex, bounds, shadow.content_mask.bounds);
   float4 color = hsla_to_rgba(shadow.color);
@@ -566,7 +566,7 @@ vertex UnderlineVertexOutput underline_vertex(
   float2 unit_vertex = unit_vertices[unit_vertex_id];
   Underline underline = underlines[underline_id];
   float4 device_position =
-      to_device_position(unit_vertex, underline.bounds, viewport_size);
+      to_device_position_with_order(unit_vertex, underline.bounds, viewport_size, underline.order);
   float4 clip_distance = distance_from_clip_rect(unit_vertex, underline.bounds,
                                                  underline.content_mask.bounds);
   float4 color = hsla_to_rgba(underline.color);
@@ -859,7 +859,7 @@ vertex SurfaceVertexOutput surface_vertex(
   float2 unit_vertex = unit_vertices[unit_vertex_id];
   SurfaceBounds surface = surfaces[surface_id];
   float4 device_position =
-      to_device_position(unit_vertex, surface.bounds, viewport_size);
+      to_device_position_with_order(unit_vertex, surface.bounds, viewport_size, surface.order);
   float4 clip_distance = distance_from_clip_rect(unit_vertex, surface.bounds,
                                                  surface.content_mask.bounds);
   // We are going to copy the whole texture, so the texture position corresponds


### PR DESCRIPTION
This PR partially addresses #8043 on macOS

Still a WIP

The current renderer relies on the painter’s algorithm for draw ordering, which results in significant overdraw. Large portions of the frame are shaded multiple times even though only the frontmost fragments are visible, increasing GPU and CPU usage

This change enables depth testing and adjusts rendering to rely on depth buffering rather than strict back-to-front ordering. This allows the GPU to discard occluded fragments earlier in the pipeline, reducing unnecessary work.

Ref: https://developer.apple.com/documentation/metal/calculating-primitive-visibility-using-depth-testing

Release Notes:

- Reduced gpu and battery usage due to overdrawing
