### PR TITLE
git: Fix file history view shows duplicate entries when clicking on `Load More`

### DIFF
--- a/crates/fs/src/fake_git_repo.rs
+++ b/crates/fs/src/fake_git_repo.rs
@@ -469,13 +469,13 @@ impl GitRepository for FakeGitRepository {
     }
 
     fn file_history(&self, path: RepoPath) -> BoxFuture<'_, Result<git::repository::FileHistory>> {
-        self.file_history_paginated(path, 0, None)
+        self.file_history_paginated(path, None, None)
     }
 
     fn file_history_paginated(
         &self,
         path: RepoPath,
-        _skip: usize,
+        _last_commit_hash: Option<SharedString>,
         _limit: Option<usize>,
     ) -> BoxFuture<'_, Result<git::repository::FileHistory>> {
         async move {

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -3127,6 +3127,151 @@ mod tests {
         )
     }
 
+    #[gpui::test]
+    async fn test_file_history_pagination_with_rename(cx: &mut TestAppContext) {
+        disable_git_global_config();
+
+        cx.executor().allow_parking();
+
+        let repo_dir = tempfile::tempdir().unwrap();
+        git2::Repository::init(repo_dir.path()).unwrap();
+
+        let repo = RealGitRepository::new(
+            &repo_dir.path().join(".git"),
+            None,
+            Some("git".into()),
+            cx.executor(),
+        )
+        .unwrap();
+
+        // Create commits with a file rename in the middle to trigger --follow behavior.
+        // The bug is that git log --follow --skip=N ignores the --skip flag.
+        let old_file_path = repo_dir.path().join("old_name.txt");
+        let new_file_path = repo_dir.path().join("new_name.txt");
+
+        // Create 30 commits with old filename
+        for i in 0..30 {
+            smol::fs::write(&old_file_path, format!("content version {}", i))
+                .await
+                .unwrap();
+
+            repo.stage_paths(
+                vec![repo_path("old_name.txt")],
+                Arc::new(HashMap::default()),
+            )
+            .await
+            .unwrap();
+
+            repo.commit(
+                format!("Commit {} (old name)", i).into(),
+                None,
+                CommitOptions::default(),
+                AskPassDelegate::new(&mut cx.to_async(), |_, _, _| {}),
+                Arc::new(checkpoint_author_envs()),
+            )
+            .await
+            .unwrap();
+        }
+
+        // Rename the file using git mv
+        smol::process::Command::new("git")
+            .current_dir(repo_dir.path())
+            .args(["mv", "old_name.txt", "new_name.txt"])
+            .output()
+            .await
+            .unwrap();
+
+        repo.commit(
+            "Rename old_name.txt to new_name.txt".into(),
+            None,
+            CommitOptions::default(),
+            AskPassDelegate::new(&mut cx.to_async(), |_, _, _| {}),
+            Arc::new(checkpoint_author_envs()),
+        )
+        .await
+        .unwrap();
+
+        // Create 30 more commits with new filename (total: 61 commits)
+        for i in 30..60 {
+            smol::fs::write(&new_file_path, format!("content version {}", i))
+                .await
+                .unwrap();
+
+            repo.stage_paths(
+                vec![repo_path("new_name.txt")],
+                Arc::new(HashMap::default()),
+            )
+            .await
+            .unwrap();
+
+            repo.commit(
+                format!("Commit {} (new name)", i).into(),
+                None,
+                CommitOptions::default(),
+                AskPassDelegate::new(&mut cx.to_async(), |_, _, _| {}),
+                Arc::new(checkpoint_author_envs()),
+            )
+            .await
+            .unwrap();
+        }
+
+        let total_commits = 61; // 30 old + 1 rename + 30 new
+
+        // Get first page (skip=0, limit=50)
+        let first_page = repo
+            .file_history_paginated(repo_path("new_name.txt"), 0, Some(50))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            first_page.entries.len(),
+            50,
+            "First page should have 50 entries"
+        );
+
+        // Get second page (skip=50, limit=50)
+        let second_page = repo
+            .file_history_paginated(repo_path("new_name.txt"), 50, Some(50))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            second_page.entries.len(),
+            11,
+            "Second page should have 11 entries (61 total - 50 from first page)"
+        );
+
+        // Verify no duplicates between pages by checking SHAs
+        let first_page_shas: std::collections::HashSet<_> =
+            first_page.entries.iter().map(|e| e.sha.clone()).collect();
+        let second_page_shas: std::collections::HashSet<_> =
+            second_page.entries.iter().map(|e| e.sha.clone()).collect();
+
+        let duplicates: Vec<_> = first_page_shas
+            .intersection(&second_page_shas)
+            .cloned()
+            .collect();
+
+        assert!(
+            duplicates.is_empty(),
+            "Found duplicate commits between pages: {:?}",
+            duplicates
+        );
+
+        // Also verify that all 61 unique commits are accounted for
+        let all_shas: std::collections::HashSet<_> = first_page_shas
+            .union(&second_page_shas)
+            .cloned()
+            .collect();
+
+        assert_eq!(
+            all_shas.len(),
+            total_commits,
+            "Should have {} unique commits total",
+            total_commits
+        );
+    }
+
     impl RealGitRepository {
         /// Force a Git garbage collection on the repository.
         fn gc(&self) -> BoxFuture<'_, Result<()>> {

--- a/crates/git_ui/src/file_history_view.rs
+++ b/crates/git_ui/src/file_history_view.rs
@@ -59,7 +59,7 @@ impl FileHistoryView {
         let file_history_task = git_store
             .update(cx, |git_store, cx| {
                 repo.upgrade().map(|repo| {
-                    git_store.file_history_paginated(&repo, path.clone(), 0, Some(PAGE_SIZE), cx)
+                    git_store.file_history_paginated(&repo, path.clone(), None, Some(PAGE_SIZE), cx)
                 })
             })
             .ok()
@@ -153,7 +153,7 @@ impl FileHistoryView {
         self.loading_more = true;
         cx.notify();
 
-        let current_count = self.history.entries.len();
+        let last_commit_hash = self.history.entries.last().map(|entry| entry.sha.clone());
         let path = self.history.path.clone();
         let git_store = self.git_store.clone();
         let repo = self.repository.clone();
@@ -166,7 +166,7 @@ impl FileHistoryView {
                         git_store.file_history_paginated(
                             &repo,
                             path,
-                            current_count,
+                            last_commit_hash,
                             Some(PAGE_SIZE),
                             cx,
                         )

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -1076,11 +1076,13 @@ impl GitStore {
         &self,
         repo: &Entity<Repository>,
         path: RepoPath,
-        skip: usize,
+        last_commit_hash: Option<SharedString>,
         limit: Option<usize>,
         cx: &mut App,
     ) -> Task<Result<git::repository::FileHistory>> {
-        let rx = repo.update(cx, |repo, _| repo.file_history_paginated(path, skip, limit));
+        let rx = repo.update(cx, |repo, _| {
+            repo.file_history_paginated(path, last_commit_hash, limit)
+        });
 
         cx.spawn(|_: &mut AsyncApp| async move { rx.await? })
     }
@@ -2388,12 +2390,12 @@ impl GitStore {
         let repository_id = RepositoryId::from_proto(envelope.payload.repository_id);
         let repository_handle = Self::repository_for_request(&this, repository_id, &mut cx)?;
         let path = RepoPath::from_proto(&envelope.payload.path)?;
-        let skip = envelope.payload.skip as usize;
+        let last_commit_hash = envelope.payload.last_commit_hash.map(|hash| hash.into());
         let limit = envelope.payload.limit.map(|l| l as usize);
 
         let file_history = repository_handle
             .update(&mut cx, |repository_handle, _| {
-                repository_handle.file_history_paginated(path, skip, limit)
+                repository_handle.file_history_paginated(path, last_commit_hash, limit)
             })?
             .await??;
 
@@ -4124,20 +4126,22 @@ impl Repository {
         &mut self,
         path: RepoPath,
     ) -> oneshot::Receiver<Result<git::repository::FileHistory>> {
-        self.file_history_paginated(path, 0, None)
+        self.file_history_paginated(path, None, None)
     }
 
     pub fn file_history_paginated(
         &mut self,
         path: RepoPath,
-        skip: usize,
+        last_commit_hash: Option<SharedString>,
         limit: Option<usize>,
     ) -> oneshot::Receiver<Result<git::repository::FileHistory>> {
         let id = self.id;
         self.send_job(None, move |git_repo, _cx| async move {
             match git_repo {
                 RepositoryState::Local(LocalRepositoryState { backend, .. }) => {
-                    backend.file_history_paginated(path, skip, limit).await
+                    backend
+                        .file_history_paginated(path, last_commit_hash, limit)
+                        .await
                 }
                 RepositoryState::Remote(RemoteRepositoryState { client, project_id }) => {
                     let response = client
@@ -4145,7 +4149,7 @@ impl Repository {
                             project_id: project_id.0,
                             repository_id: id.to_proto(),
                             path: path.to_proto(),
-                            skip: skip as u64,
+                            last_commit_hash: last_commit_hash.map(String::from),
                             limit: limit.map(|l| l as u64),
                         })
                         .await?;

--- a/crates/proto/proto/git.proto
+++ b/crates/proto/proto/git.proto
@@ -310,8 +310,9 @@ message GitFileHistory {
     reserved 2;
     uint64 repository_id = 3;
     string path = 4;
-    uint64 skip = 5;
+    reserved 5; // Deprecated
     optional uint64 limit = 6;
+    optional string last_commit_hash = 7;
 }
 
 message GitFileHistoryResponse {


### PR DESCRIPTION

This is because the git command parameter `--skip` doesn't work correctly if it's used with `--follow`.

So I use a cursor-based pagination approach (using commit hash + `^` notation) to reliably fetch the next page of file history.

Closes #44591

Release Notes:

- Fixed file history view shows duplicate entries when clicking on `Load More`.
