### PR TITLE
agent_ui: Fix fallback icon used for external agents

### DIFF
--- a/crates/agent_ui/src/agent_configuration.rs
+++ b/crates/agent_ui/src/agent_configuration.rs
@@ -975,7 +975,7 @@ impl AgentConfiguration {
                 let icon = if let Some(icon_path) = agent_server_store.agent_icon(&name) {
                     AgentIcon::Path(icon_path)
                 } else {
-                    AgentIcon::Name(IconName::Ai)
+                    AgentIcon::Name(IconName::Sparkle)
                 };
                 let display_name = agent_server_store
                     .agent_display_name(&name)
@@ -1137,6 +1137,7 @@ impl AgentConfiguration {
     ) -> impl IntoElement {
         let id = id.into();
         let display_name = display_name.into();
+
         let icon = match icon {
             AgentIcon::Name(icon_name) => Icon::new(icon_name)
                 .size(IconSize::Small)


### PR DESCRIPTION
When an external agent doesn't provide an icon, we were using different fallback icons in all the places we display icons (settings view, thread new menu, and the thread view toolbar itself).

Release Notes:

- N/A
