### PR TITLE
docs: Add learning rust section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,10 @@ Zed is made up of several smaller crates - let's go over those you're most likel
 - [`cli`](/crates/cli) is the CLI crate which invokes the Zed binary.
 - [`zed`](/crates/zed) is where all things come together, and the `main` entry point for Zed.
 
+## Learning Rust
+
+Zed is written primarily in rust. Coming from a different language like TypeScript or C++? It may be helpful to follow something like [rustlings](https://rustlings.rust-lang.org/) to see how rust is different.
+
 ## Packaging Zed
 
 Check our [notes for packaging Zed](https://zed.dev/docs/development/linux#notes-for-packaging-zed).

--- a/docs/src/development.md
+++ b/docs/src/development.md
@@ -10,6 +10,10 @@ If you'd like to develop collaboration features, additionally see:
 
 - [Local Collaboration](./development/local-collaboration.md)
 
+## Learning Rust
+
+Zed is written primarily in rust. Coming from a different language like TypeScript or C++? It may be helpful to follow something like [rustlings](https://rustlings.rust-lang.org/) to see how rust is different.
+
 ## Keychain access
 
 Zed stores secrets in the system keychain.


### PR DESCRIPTION
DEMO ONLY

It could be helpful to point new contributors to quickly learn how rust works.

Feel free to close this PR without explanation if it is not wanted. If you think it is helpful, I think we should probably only merge *one* of these commits, though, I am open to input.