### PR TITLE
workspace: Persist window values without project

### DIFF
--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -1258,7 +1258,7 @@ pub(crate) struct WindowParams {
 }
 
 /// Represents the status of how a window should be opened.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Deserialize, Serialize)]
 pub enum WindowBounds {
     /// Indicates that the window should open in a windowed state with the given bounds.
     Windowed(Bounds<Pixels>),

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -8554,10 +8554,7 @@ pub fn remote_workspace_position_from_db(
             let restorable_bounds = serialized_workspace
                 .as_ref()
                 .and_then(|workspace| Some((workspace.display?, workspace.window_bounds?)))
-                .or_else(|| {
-                    let (display, window_bounds) = DB.last_window().log_err()?;
-                    Some((display?, window_bounds?))
-                });
+                .or_else(|| persistence::read_no_project_window_bounds());
 
             if let Some((serialized_display, serialized_status)) = restorable_bounds {
                 (Some(serialized_status.0), Some(serialized_display))


### PR DESCRIPTION
Persist and restore window values (size, position, etc.) to the KV Store when there are no projects open.

Relates to Discussion https://github.com/zed-industries/zed/discussions/24228#discussioncomment-15224666

Release Notes:

- Added persistence for window size when no projects are open
