### PR TITLE
Fix linked editing not working with Vim commands

### DIFF
--- a/crates/editor/src/linked_editing_ranges.rs
+++ b/crates/editor/src/linked_editing_ranges.rs
@@ -3,7 +3,7 @@ use gpui::{AppContext, Context, Window};
 use itertools::Itertools;
 use multi_buffer::MultiBufferOffset;
 use std::{ops::Range, time::Duration};
-use text::{AnchorRangeExt, BufferId, ToPoint};
+use text::{AnchorRangeExt, BufferId, ToOffset, ToPoint};
 use util::ResultExt;
 
 use crate::Editor;
@@ -22,15 +22,15 @@ impl LinkedEditingRanges {
         snapshot: &text::BufferSnapshot,
     ) -> Option<&(Range<text::Anchor>, Vec<Range<text::Anchor>>)> {
         let ranges_for_buffer = self.0.get(&id)?;
-        let lower_bound = ranges_for_buffer
-            .partition_point(|(range, _)| range.start.cmp(&anchor.start, snapshot).is_le());
-        if lower_bound == 0 {
-            // None of the linked ranges contains `anchor`.
-            return None;
-        }
-        ranges_for_buffer
-            .get(lower_bound - 1)
-            .filter(|(range, _)| range.end.cmp(&anchor.end, snapshot).is_ge())
+        let anchor_start = anchor.start.to_offset(snapshot);
+        let anchor_end = anchor.end.to_offset(snapshot);
+
+        // Use offset-based comparison to handle collapsed ranges correctly
+        ranges_for_buffer.iter().find(|(range, _)| {
+            let range_start = range.start.to_offset(snapshot);
+            let range_end = range.end.to_offset(snapshot);
+            range_start <= anchor_start && range_end >= anchor_end
+        })
     }
     pub(super) fn is_empty(&self) -> bool {
         self.0.is_empty()
@@ -38,6 +38,24 @@ impl LinkedEditingRanges {
 
     pub(super) fn clear(&mut self) {
         self.0.clear();
+    }
+
+    pub(super) fn cursor_within_any_range(
+        &self,
+        buffer_id: BufferId,
+        cursor: text::Anchor,
+        snapshot: &text::BufferSnapshot,
+    ) -> bool {
+        let Some(ranges_for_buffer) = self.0.get(&buffer_id) else {
+            return false;
+        };
+
+        let cursor_offset = cursor.to_offset(snapshot);
+        ranges_for_buffer.iter().any(|(range, _)| {
+            let range_start = range.start.to_offset(snapshot);
+            let range_end = range.end.to_offset(snapshot);
+            range_start <= cursor_offset && range_end >= cursor_offset
+        })
     }
 }
 
@@ -144,28 +162,61 @@ pub(super) fn refresh_linked_ranges(
 
         editor
             .update(cx, |this, cx| {
-                this.linked_edit_ranges.0.clear();
                 if this.pending_rename.is_some() {
+                    this.linked_edit_ranges.0.clear();
                     return;
                 }
-                for (buffer_id, ranges) in highlights.into_iter().flatten() {
-                    this.linked_edit_ranges
-                        .0
-                        .entry(buffer_id)
-                        .or_default()
-                        .extend(ranges);
+
+                let has_new_ranges = highlights.iter().any(|h| h.is_some());
+
+                // Check if cursor is within any existing range - if so, preserve them
+                // even if LSP returns new (potentially incorrect) ranges
+                let cursor_in_existing_range = {
+                    let display_snapshot = this.display_snapshot(cx);
+                    let selections =
+                        this.selections.all::<MultiBufferOffset>(&display_snapshot);
+                    let snapshot = display_snapshot.buffer_snapshot();
+
+                    selections.iter().any(|selection| {
+                        let cursor = selection.head();
+                        let anchor = snapshot.anchor_before(cursor);
+                        anchor.text_anchor.buffer_id.is_some_and(|buffer_id| {
+                            this.buffer.read(cx).buffer(buffer_id).is_some_and(|buffer| {
+                                let buffer_snapshot = buffer.read(cx).snapshot();
+                                this.linked_edit_ranges.cursor_within_any_range(
+                                    buffer_id,
+                                    anchor.text_anchor,
+                                    &buffer_snapshot,
+                                )
+                            })
+                        })
+                    })
+                };
+
+                if has_new_ranges && !cursor_in_existing_range {
+                    this.linked_edit_ranges.0.clear();
+                    for (buffer_id, ranges) in highlights.into_iter().flatten() {
+                        this.linked_edit_ranges
+                            .0
+                            .entry(buffer_id)
+                            .or_default()
+                            .extend(ranges);
+                    }
+                    for (buffer_id, values) in this.linked_edit_ranges.0.iter_mut() {
+                        let Some(snapshot) = this
+                            .buffer
+                            .read(cx)
+                            .buffer(*buffer_id)
+                            .map(|buffer| buffer.read(cx).snapshot())
+                        else {
+                            continue;
+                        };
+                        values.sort_by(|lhs, rhs| lhs.0.cmp(&rhs.0, &snapshot));
+                    }
+                } else if !has_new_ranges && !cursor_in_existing_range {
+                    this.linked_edit_ranges.0.clear();
                 }
-                for (buffer_id, values) in this.linked_edit_ranges.0.iter_mut() {
-                    let Some(snapshot) = this
-                        .buffer
-                        .read(cx)
-                        .buffer(*buffer_id)
-                        .map(|buffer| buffer.read(cx).snapshot())
-                    else {
-                        continue;
-                    };
-                    values.sort_by(|lhs, rhs| lhs.0.cmp(&rhs.0, &snapshot));
-                }
+                // If cursor_in_existing_range is true, keep existing ranges
 
                 cx.notify();
             })

--- a/crates/vim/src/normal/substitute.rs
+++ b/crates/vim/src/normal/substitute.rs
@@ -1,6 +1,5 @@
 use editor::{Editor, SelectionEffects, movement};
 use gpui::{Context, Window, actions};
-use language::Point;
 
 use crate::{
     Mode, Vim,
@@ -94,12 +93,7 @@ impl Vim {
                     MotionKind::Exclusive
                 };
                 vim.copy_selections_content(editor, kind, window, cx);
-                let selections = editor
-                    .selections
-                    .all::<Point>(&editor.display_snapshot(cx))
-                    .into_iter();
-                let edits = selections.map(|selection| (selection.start..selection.end, ""));
-                editor.edit(edits, cx);
+                editor.insert("", window, cx);
             });
         });
         self.switch_mode(Mode::Insert, true, window, cx);


### PR DESCRIPTION
Closes #35941 

Release Notes:

- Fixed Vim commands not triggering linked editing for JSX/TSX/HTML tag renaming