### PR TITLE
Implement Sum trait for Pixels

### DIFF
--- a/crates/gpui/src/geometry.rs
+++ b/crates/gpui/src/geometry.rs
@@ -2648,6 +2648,18 @@ impl Debug for Pixels {
     }
 }
 
+impl std::iter::Sum for Pixels {
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+        iter.fold(Self::ZERO, |a, b| a + b)
+    }
+}
+
+impl<'a> std::iter::Sum<&'a Pixels> for Pixels {
+    fn sum<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
+        iter.fold(Self::ZERO, |a, b| a + *b)
+    }
+}
+
 impl TryFrom<&'_ str> for Pixels {
     type Error = anyhow::Error;
 


### PR DESCRIPTION
This adds implementations of `std::iter::Sum` for `Pixels`, allowing the use of `.sum()` on iterators of `Pixels` values.

### Changes
- Implement `Sum<Pixels>` for `Pixels` (owned values)
- Implement `Sum<&Pixels>` for `Pixels` (references)

This enables ergonomic patterns like:
```rust
let total: Pixels = pixel_values.iter().sum();
```