### PR TITLE
editor: Fix inlay hovers blinking in sync with cursors

### DIFF
--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -151,7 +151,7 @@ pub fn hover_at_inlay(
                 false
             })
         {
-            hide_hover(editor, cx);
+            return;
         }
 
         let hover_popover_delay = EditorSettings::get_global(cx).hover_popover_delay.0;


### PR DESCRIPTION
This change matches how normal hovers are handled (which early return with `None` in this branch)

Release Notes:

- Fixed hover boxes for inlays blinking in and out without movement when cursor blinking was enabled
