### PR TITLE
Stop spawning ACP/MCP servers with interactive shells

### DIFF
--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -89,7 +89,7 @@ impl AcpConnection {
         cx: &mut AsyncApp,
     ) -> Result<Self> {
         let shell = cx.update(|cx| TerminalSettings::get(None, cx).shell.clone())?;
-        let builder = ShellBuilder::new(&shell, cfg!(windows));
+        let builder = ShellBuilder::new(&shell, cfg!(windows)).non_interactive();
         let mut child =
             builder.build_command(Some(command.path.display().to_string()), &command.args);
         child

--- a/crates/context_server/src/transport/stdio_transport.rs
+++ b/crates/context_server/src/transport/stdio_transport.rs
@@ -32,7 +32,7 @@ impl StdioTransport {
         cx: &AsyncApp,
     ) -> Result<Self> {
         let shell = cx.update(|cx| TerminalSettings::get(None, cx).shell.clone())?;
-        let builder = ShellBuilder::new(&shell, cfg!(windows));
+        let builder = ShellBuilder::new(&shell, cfg!(windows)).non_interactive();
         let mut command =
             builder.build_command(Some(binary.executable.display().to_string()), &binary.args);
 


### PR DESCRIPTION
### Summary:
- Ensure the external agents with ACP servers start via non-interactive shells to prevent shell startup noise from corrupting JSON-RPC.
- Apply the same tweak to MCP stdio transports so remote context servers aren’t affected by prompts or greetings.

### Description:
Switch both ACP and MCP stdio launch paths to call `ShellBuilder::non_interactive()` before building the command. This removes `-i` on POSIX shells, suppressing prompt/title sequences that previously prefixed the first JSON line and caused `serde_json` parse failures. No functional regressions are expected: both code paths only need a shell for Windows/npm script compatibility, not for interactivity.

Release Notes:
- Fixed external agents that hung on “Loading…” when shell startup output broke JSON-RPC initialization.