### PR TITLE
terminal: Remove SHLVL from terminal environment to fix incorrect shell level

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -420,6 +420,10 @@ impl TerminalBuilder {
     ) -> Task<Result<TerminalBuilder>> {
         let version = release_channel::AppVersion::global(cx);
         let fut = async move {
+            // Remove SHLVL so the spawned shell initializes it to 1, matching
+            // the behavior of standalone terminal emulators like iTerm2/Kitty/Alacritty.
+            env.remove("SHLVL");
+
             // If the parent environment doesn't have a locale set
             // (As is the case when launched from a .app on MacOS),
             // and the Project doesn't have a locale set, then


### PR DESCRIPTION
Fixes #33958

## Problem

When opening a terminal in Zed, `SHLVL` incorrectly starts at 2 instead of 1. On `workspace: reload`, it increases by 2 instead of 1.

## Root Cause

1. Zed's `shell_env::capture()` spawns a login shell (`-l -i -c`) to capture the user's environment, which increments `SHLVL`
2. The captured `SHLVL` is passed through to the PTY options
3. When alacritty_terminal spawns the user's shell, it increments `SHLVL` again

Result: `SHLVL` = captured value + 1 = 2 (when launched from Finder)

## Solution

Remove `SHLVL` from the environment in `TerminalBuilder::new()` before passing it to alacritty_terminal. This allows the spawned shell to initialize `SHLVL` to 1 on its own, matching the behavior of standalone terminal emulators like iTerm2, Kitty, and Alacritty.

## Testing

- Launch Zed from Finder → open terminal → `echo $SHLVL` → should output `1`
- Launch Zed from shell → open terminal → `echo $SHLVL` → should output `1`
- `workspace: reload` → open terminal → `echo $SHLVL` → should remain `1`
- Tested with bash, zsh, fish

Release Notes:

- Fixed terminal `$SHLVL` starting at 2 instead of 1 ([#33958](https://github.com/zed-industries/zed/issues/33958))