### PR TITLE
git: Fix partially-staged paths not being accurately rendered

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1642,7 +1642,6 @@ impl GitPanel {
                     (goal_staged_state, entries)
                 }
                 GitListEntry::Directory(entry) => {
-                    // FIXME do the same thing here (maybe we should have a function)
                     let goal_staged_state =
                         self.toggle_state_for_directory(&entry, repo) != ToggleState::Selected;
                     let entries = self


### PR DESCRIPTION
Updates #44089 

- Restores the ability to have a partially staged/`Indeterminate` status for the git panel checkboxes
- Removes the `optimistic_staging` logic, since its stated purpose is served by the `PendingOps` system in the `GitStore` (which may have bugs, but we should fix them in the git store rather than adding another layer)

Release Notes:

- Fixed partially-staged files not being represented accurately in the git panel.