### PR TITLE
Inline assistant finishing touches

### DIFF
--- a/crates/agent_ui/src/buffer_codegen.rs
+++ b/crates/agent_ui/src/buffer_codegen.rs
@@ -396,7 +396,7 @@ impl CodegenAlternative {
         &self.last_equal_ranges
     }
 
-    fn use_streaming_tools(model: &dyn LanguageModel, cx: &App) -> bool {
+    pub fn use_streaming_tools(model: &dyn LanguageModel, cx: &App) -> bool {
         model.supports_streaming_tools()
             && cx.has_flag::<InlineAssistantUseToolFeatureFlag>()
             && AgentSettings::get_global(cx).inline_assistant_use_streaming_tools

--- a/crates/agent_ui/src/buffer_codegen.rs
+++ b/crates/agent_ui/src/buffer_codegen.rs
@@ -1171,9 +1171,6 @@ impl CodegenAlternative {
                         })
                     }
                     "failure_message" => {
-                        if !is_complete {
-                            return None;
-                        }
                         let Ok(mut input) =
                             serde_json::from_value::<FailureMessageInput>(tool_use.input)
                         else {

--- a/crates/agent_ui/src/buffer_codegen.rs
+++ b/crates/agent_ui/src/buffer_codegen.rs
@@ -1155,7 +1155,6 @@ impl CodegenAlternative {
             let chars_read_so_far = Arc::new(Mutex::new(0usize));
             let process_tool_use = move |tool_use: LanguageModelToolUse| -> Option<ToolUseOutput> {
                 let mut chars_read_so_far = chars_read_so_far.lock();
-                let is_complete = tool_use.is_input_complete;
                 match tool_use.name.as_ref() {
                     "rewrite_section" => {
                         let Ok(input) =

--- a/crates/agent_ui/src/inline_prompt_editor.rs
+++ b/crates/agent_ui/src/inline_prompt_editor.rs
@@ -33,7 +33,7 @@ use workspace::{Toast, Workspace};
 use zed_actions::agent::ToggleModelSelector;
 
 use crate::agent_model_selector::AgentModelSelector;
-use crate::buffer_codegen::BufferCodegen;
+use crate::buffer_codegen::{BufferCodegen, CodegenAlternative};
 use crate::completion_provider::{
     PromptCompletionProvider, PromptCompletionProviderDelegate, PromptContextType,
 };
@@ -585,12 +585,18 @@ impl<T: 'static> PromptEditor<T> {
             }
             CompletionState::Generated { completion_text } => {
                 let model_info = self.model_selector.read(cx).active_model(cx);
-                let model_id = {
+                let (model_id, use_streaming_tools) = {
                     let Some(configured_model) = model_info else {
                         self.toast("No configured model", None, cx);
                         return;
                     };
-                    configured_model.model.telemetry_id()
+                    (
+                        configured_model.model.telemetry_id(),
+                        CodegenAlternative::use_streaming_tools(
+                            configured_model.model.as_ref(),
+                            cx,
+                        ),
+                    )
                 };
 
                 let selected_text = match &self.mode {
@@ -616,6 +622,7 @@ impl<T: 'static> PromptEditor<T> {
                     prompt = prompt,
                     completion = completion_text,
                     selected_text = selected_text,
+                    use_streaming_tools
                 );
 
                 self.session_state.completion = CompletionState::Rated;
@@ -641,12 +648,18 @@ impl<T: 'static> PromptEditor<T> {
             }
             CompletionState::Generated { completion_text } => {
                 let model_info = self.model_selector.read(cx).active_model(cx);
-                let model_telemetry_id = {
+                let (model_telemetry_id, use_streaming_tools) = {
                     let Some(configured_model) = model_info else {
                         self.toast("No configured model", None, cx);
                         return;
                     };
-                    configured_model.model.telemetry_id()
+                    (
+                        configured_model.model.telemetry_id(),
+                        CodegenAlternative::use_streaming_tools(
+                            configured_model.model.as_ref(),
+                            cx,
+                        ),
+                    )
                 };
 
                 let selected_text = match &self.mode {
@@ -672,6 +685,7 @@ impl<T: 'static> PromptEditor<T> {
                     prompt = prompt,
                     completion = completion_text,
                     selected_text = selected_text,
+                    use_streaming_tools
                 );
 
                 self.session_state.completion = CompletionState::Rated;

--- a/crates/feature_flags/src/flags.rs
+++ b/crates/feature_flags/src/flags.rs
@@ -16,8 +16,4 @@ pub struct InlineAssistantUseToolFeatureFlag;
 
 impl FeatureFlag for InlineAssistantUseToolFeatureFlag {
     const NAME: &'static str = "inline-assistant-use-tool";
-
-    fn enabled_for_staff() -> bool {
-        true
-    }
 }

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -251,7 +251,8 @@ impl Markdown {
         self.autoscroll_request = None;
         self.pending_parse = None;
         self.should_reparse = false;
-        self.parsed_markdown = ParsedMarkdown::default();
+        // Don't clear parsed_markdown here - keep existing content visible until new parse completes
+
         self.parse(cx);
     }
 

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -252,7 +252,6 @@ impl Markdown {
         self.pending_parse = None;
         self.should_reparse = false;
         // Don't clear parsed_markdown here - keep existing content visible until new parse completes
-
         self.parse(cx);
     }
 


### PR DESCRIPTION
Tighten up evals, make assistant less talkative, get them passing a bit more, improve telemetry, stream in failure messages, and turn it on for staff.

Release Notes:

- N/A
