### PR TITLE
terminal: Redraw after vi motion key press

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -1450,13 +1450,8 @@ impl Terminal {
         };
 
         if let Some(motion) = motion {
-            let cursor = self.last_content.cursor.point;
-            let cursor_pos = Point {
-                x: cursor.column.0 as f32 * self.last_content.terminal_bounds.cell_width,
-                y: cursor.line.0 as f32 * self.last_content.terminal_bounds.line_height,
-            };
-            self.events
-                .push_back(InternalEvent::UpdateSelection(cursor_pos));
+            // Clear selection when moving in normal mode
+            self.events.push_back(InternalEvent::SetSelection(None));
             self.events.push_back(InternalEvent::ViMotion(motion));
             return;
         }

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -1001,6 +1001,9 @@ impl TerminalView {
             );
             if handled {
                 cx.stop_propagation();
+                if term.vi_mode_enabled() {
+                    cx.notify();
+                }
             }
         });
     }


### PR DESCRIPTION
Closes #44541

**Summary**
- notify the app when vi motion keys are pressed.
- Set selection to none during vi motions.

**Screen recording**

https://github.com/user-attachments/assets/d592e47f-56ec-4214-934d-86997e00fa70



Release Notes:

- N/A *or* Added/Fixed/Improved ...
