### PR TITLE
Revert "Add Doxygen injection into C and C++ comments"

### DIFF
--- a/crates/languages/src/c/injections.scm
+++ b/crates/languages/src/c/injections.scm
@@ -1,7 +1,6 @@
 ((comment) @injection.content
-  (#match? @injection.content "^(///|//!|/\\*\\*|/\\*!)(.*)")
-  (#set! injection.language "doxygen")
-  (#set! injection.include-children))
+ (#set! injection.language "comment")
+)
 
 (preproc_def
     value: (preproc_arg) @injection.content

--- a/crates/languages/src/cpp/injections.scm
+++ b/crates/languages/src/cpp/injections.scm
@@ -1,7 +1,6 @@
 ((comment) @injection.content
-  (#match? @injection.content "^(///|//!|/\\*\\*|/\\*!)(.*)")
-  (#set! injection.language "doxygen")
-  (#set! injection.include-children))
+ (#set! injection.language "comment")
+)
 
 (preproc_def
     value: (preproc_arg) @injection.content


### PR DESCRIPTION
Reverts zed-industries/zed#43581

Release notes:
- Fixed comment injections not working with C and C++.