### PR TITLE
Add trailing commas to all asset jsonc files following #43854

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -44,15 +44,15 @@
       "f11": "zed::ToggleFullScreen",
       "ctrl-alt-z": "edit_prediction::RatePredictions",
       "ctrl-alt-shift-i": "edit_prediction::ToggleMenu",
-      "ctrl-alt-l": "lsp_tool::ToggleMenu"
-    }
+      "ctrl-alt-l": "lsp_tool::ToggleMenu",
+    },
   },
   {
     "context": "Picker || menu",
     "bindings": {
       "up": "menu::SelectPrevious",
-      "down": "menu::SelectNext"
-    }
+      "down": "menu::SelectNext",
+    },
   },
   {
     "context": "Editor",
@@ -124,8 +124,8 @@
       "shift-f10": "editor::OpenContextMenu",
       "ctrl-alt-shift-e": "editor::ToggleEditPrediction",
       "f9": "editor::ToggleBreakpoint",
-      "shift-f9": "editor::EditLogBreakpoint"
-    }
+      "shift-f9": "editor::EditLogBreakpoint",
+    },
   },
   {
     "context": "Editor && mode == full",
@@ -144,44 +144,44 @@
       "ctrl-alt-e": "editor::SelectEnclosingSymbol",
       "ctrl-shift-backspace": "editor::GoToPreviousChange",
       "ctrl-shift-alt-backspace": "editor::GoToNextChange",
-      "alt-enter": "editor::OpenSelectionsInMultibuffer"
-    }
+      "alt-enter": "editor::OpenSelectionsInMultibuffer",
+    },
   },
   {
     "context": "Editor && mode == full && edit_prediction",
     "bindings": {
       "alt-]": "editor::NextEditPrediction",
-      "alt-[": "editor::PreviousEditPrediction"
-    }
+      "alt-[": "editor::PreviousEditPrediction",
+    },
   },
   {
     "context": "Editor && !edit_prediction",
     "bindings": {
-      "alt-\\": "editor::ShowEditPrediction"
-    }
+      "alt-\\": "editor::ShowEditPrediction",
+    },
   },
   {
     "context": "Editor && mode == auto_height",
     "bindings": {
       "ctrl-enter": "editor::Newline",
       "shift-enter": "editor::Newline",
-      "ctrl-shift-enter": "editor::NewlineBelow"
-    }
+      "ctrl-shift-enter": "editor::NewlineBelow",
+    },
   },
   {
     "context": "Markdown",
     "bindings": {
       "copy": "markdown::Copy",
       "ctrl-insert": "markdown::Copy",
-      "ctrl-c": "markdown::Copy"
-    }
+      "ctrl-c": "markdown::Copy",
+    },
   },
   {
     "context": "Editor && jupyter && !ContextEditor",
     "bindings": {
       "ctrl-shift-enter": "repl::Run",
-      "ctrl-alt-enter": "repl::RunInPlace"
-    }
+      "ctrl-alt-enter": "repl::RunInPlace",
+    },
   },
   {
     "context": "Editor && !agent_diff",
@@ -189,8 +189,8 @@
       "ctrl-k ctrl-r": "git::Restore",
       "ctrl-alt-y": "git::ToggleStaged",
       "alt-y": "git::StageAndNext",
-      "alt-shift-y": "git::UnstageAndNext"
-    }
+      "alt-shift-y": "git::UnstageAndNext",
+    },
   },
   {
     "context": "Editor && editor_agent_diff",
@@ -199,8 +199,8 @@
       "ctrl-n": "agent::Reject",
       "ctrl-shift-y": "agent::KeepAll",
       "ctrl-shift-n": "agent::RejectAll",
-      "shift-ctrl-r": "agent::OpenAgentDiff"
-    }
+      "shift-ctrl-r": "agent::OpenAgentDiff",
+    },
   },
   {
     "context": "AgentDiff",
@@ -208,8 +208,8 @@
       "ctrl-y": "agent::Keep",
       "ctrl-n": "agent::Reject",
       "ctrl-shift-y": "agent::KeepAll",
-      "ctrl-shift-n": "agent::RejectAll"
-    }
+      "ctrl-shift-n": "agent::RejectAll",
+    },
   },
   {
     "context": "ContextEditor > Editor",
@@ -225,8 +225,8 @@
       "ctrl-k c": "assistant::CopyCode",
       "ctrl-g": "search::SelectNextMatch",
       "ctrl-shift-g": "search::SelectPreviousMatch",
-      "ctrl-k l": "agent::OpenRulesLibrary"
-    }
+      "ctrl-k l": "agent::OpenRulesLibrary",
+    },
   },
   {
     "context": "AgentPanel",
@@ -250,37 +250,37 @@
       "alt-enter": "agent::ContinueWithBurnMode",
       "ctrl-y": "agent::AllowOnce",
       "ctrl-alt-y": "agent::AllowAlways",
-      "ctrl-alt-z": "agent::RejectOnce"
-    }
+      "ctrl-alt-z": "agent::RejectOnce",
+    },
   },
   {
     "context": "AgentPanel > NavigationMenu",
     "bindings": {
-      "shift-backspace": "agent::DeleteRecentlyOpenThread"
-    }
+      "shift-backspace": "agent::DeleteRecentlyOpenThread",
+    },
   },
   {
     "context": "AgentPanel > Markdown",
     "bindings": {
       "copy": "markdown::CopyAsMarkdown",
       "ctrl-insert": "markdown::CopyAsMarkdown",
-      "ctrl-c": "markdown::CopyAsMarkdown"
-    }
+      "ctrl-c": "markdown::CopyAsMarkdown",
+    },
   },
   {
     "context": "AgentPanel && text_thread",
     "bindings": {
       "ctrl-n": "agent::NewTextThread",
-      "ctrl-alt-t": "agent::NewThread"
-    }
+      "ctrl-alt-t": "agent::NewThread",
+    },
   },
   {
     "context": "AgentPanel && acp_thread",
     "use_key_equivalents": true,
     "bindings": {
       "ctrl-n": "agent::NewExternalAgentThread",
-      "ctrl-alt-t": "agent::NewThread"
-    }
+      "ctrl-alt-t": "agent::NewThread",
+    },
   },
   {
     "context": "MessageEditor && !Picker > Editor && !use_modifier_to_send",
@@ -290,8 +290,8 @@
       "ctrl-i": "agent::ToggleProfileSelector",
       "shift-ctrl-r": "agent::OpenAgentDiff",
       "ctrl-shift-y": "agent::KeepAll",
-      "ctrl-shift-n": "agent::RejectAll"
-    }
+      "ctrl-shift-n": "agent::RejectAll",
+    },
   },
   {
     "context": "MessageEditor && !Picker > Editor && use_modifier_to_send",
@@ -301,30 +301,30 @@
       "ctrl-i": "agent::ToggleProfileSelector",
       "shift-ctrl-r": "agent::OpenAgentDiff",
       "ctrl-shift-y": "agent::KeepAll",
-      "ctrl-shift-n": "agent::RejectAll"
-    }
+      "ctrl-shift-n": "agent::RejectAll",
+    },
   },
   {
     "context": "EditMessageEditor > Editor",
     "bindings": {
       "escape": "menu::Cancel",
       "enter": "menu::Confirm",
-      "alt-enter": "editor::Newline"
-    }
+      "alt-enter": "editor::Newline",
+    },
   },
   {
     "context": "AgentFeedbackMessageEditor > Editor",
     "bindings": {
       "escape": "menu::Cancel",
       "enter": "menu::Confirm",
-      "alt-enter": "editor::Newline"
-    }
+      "alt-enter": "editor::Newline",
+    },
   },
   {
     "context": "AcpThread > ModeSelector",
     "bindings": {
-      "ctrl-enter": "menu::Confirm"
-    }
+      "ctrl-enter": "menu::Confirm",
+    },
   },
   {
     "context": "AcpThread > Editor && !use_modifier_to_send",
@@ -333,8 +333,8 @@
       "enter": "agent::Chat",
       "shift-ctrl-r": "agent::OpenAgentDiff",
       "ctrl-shift-y": "agent::KeepAll",
-      "ctrl-shift-n": "agent::RejectAll"
-    }
+      "ctrl-shift-n": "agent::RejectAll",
+    },
   },
   {
     "context": "AcpThread > Editor && use_modifier_to_send",
@@ -344,14 +344,14 @@
       "shift-ctrl-r": "agent::OpenAgentDiff",
       "ctrl-shift-y": "agent::KeepAll",
       "ctrl-shift-n": "agent::RejectAll",
-      "shift-tab": "agent::CycleModeSelector"
-    }
+      "shift-tab": "agent::CycleModeSelector",
+    },
   },
   {
     "context": "ThreadHistory",
     "bindings": {
-      "backspace": "agent::RemoveSelectedThread"
-    }
+      "backspace": "agent::RemoveSelectedThread",
+    },
   },
   {
     "context": "RulesLibrary",
@@ -359,8 +359,8 @@
       "new": "rules_library::NewRule",
       "ctrl-n": "rules_library::NewRule",
       "ctrl-shift-s": "rules_library::ToggleDefaultRule",
-      "ctrl-w": "workspace::CloseWindow"
-    }
+      "ctrl-w": "workspace::CloseWindow",
+    },
   },
   {
     "context": "BufferSearchBar",
@@ -373,22 +373,22 @@
       "find": "search::FocusSearch",
       "ctrl-f": "search::FocusSearch",
       "ctrl-h": "search::ToggleReplace",
-      "ctrl-l": "search::ToggleSelection"
-    }
+      "ctrl-l": "search::ToggleSelection",
+    },
   },
   {
     "context": "BufferSearchBar && in_replace > Editor",
     "bindings": {
       "enter": "search::ReplaceNext",
-      "ctrl-enter": "search::ReplaceAll"
-    }
+      "ctrl-enter": "search::ReplaceAll",
+    },
   },
   {
     "context": "BufferSearchBar && !in_replace > Editor",
     "bindings": {
       "up": "search::PreviousHistoryQuery",
-      "down": "search::NextHistoryQuery"
-    }
+      "down": "search::NextHistoryQuery",
+    },
   },
   {
     "context": "ProjectSearchBar",
@@ -399,22 +399,22 @@
       "ctrl-shift-f": "search::FocusSearch",
       "ctrl-shift-h": "search::ToggleReplace",
       "alt-ctrl-g": "search::ToggleRegex",
-      "alt-ctrl-x": "search::ToggleRegex"
-    }
+      "alt-ctrl-x": "search::ToggleRegex",
+    },
   },
   {
     "context": "ProjectSearchBar > Editor",
     "bindings": {
       "up": "search::PreviousHistoryQuery",
-      "down": "search::NextHistoryQuery"
-    }
+      "down": "search::NextHistoryQuery",
+    },
   },
   {
     "context": "ProjectSearchBar && in_replace > Editor",
     "bindings": {
       "enter": "search::ReplaceNext",
-      "ctrl-alt-enter": "search::ReplaceAll"
-    }
+      "ctrl-alt-enter": "search::ReplaceAll",
+    },
   },
   {
     "context": "ProjectSearchView",
@@ -422,8 +422,8 @@
       "escape": "project_search::ToggleFocus",
       "ctrl-shift-h": "search::ToggleReplace",
       "alt-ctrl-g": "search::ToggleRegex",
-      "alt-ctrl-x": "search::ToggleRegex"
-    }
+      "alt-ctrl-x": "search::ToggleRegex",
+    },
   },
   {
     "context": "Pane",
@@ -472,8 +472,8 @@
       "ctrl-alt-shift-r": "search::ToggleRegex",
       "ctrl-alt-shift-x": "search::ToggleRegex",
       "alt-r": "search::ToggleRegex",
-      "ctrl-k shift-enter": "pane::TogglePinTab"
-    }
+      "ctrl-k shift-enter": "pane::TogglePinTab",
+    },
   },
   // Bindings from VS Code
   {
@@ -537,31 +537,31 @@
       "ctrl-\\": "pane::SplitRight",
       "ctrl-alt-shift-c": "editor::DisplayCursorNames",
       "alt-.": "editor::GoToHunk",
-      "alt-,": "editor::GoToPreviousHunk"
-    }
+      "alt-,": "editor::GoToPreviousHunk",
+    },
   },
   {
     "context": "Editor && extension == md",
     "use_key_equivalents": true,
     "bindings": {
       "ctrl-k v": "markdown::OpenPreviewToTheSide",
-      "ctrl-shift-v": "markdown::OpenPreview"
-    }
+      "ctrl-shift-v": "markdown::OpenPreview",
+    },
   },
   {
     "context": "Editor && extension == svg",
     "use_key_equivalents": true,
     "bindings": {
       "ctrl-k v": "svg::OpenPreviewToTheSide",
-      "ctrl-shift-v": "svg::OpenPreview"
-    }
+      "ctrl-shift-v": "svg::OpenPreview",
+    },
   },
   {
     "context": "Editor && mode == full",
     "bindings": {
       "ctrl-shift-o": "outline::Toggle",
-      "ctrl-g": "go_to_line::Toggle"
-    }
+      "ctrl-g": "go_to_line::Toggle",
+    },
   },
   {
     "context": "Workspace",
@@ -655,28 +655,28 @@
       // "foo-bar": ["task::Spawn", { "task_tag": "MyTag" }],
       "f5": "debugger::Rerun",
       "ctrl-f4": "workspace::CloseActiveDock",
-      "ctrl-w": "workspace::CloseActiveDock"
-    }
+      "ctrl-w": "workspace::CloseActiveDock",
+    },
   },
   {
     "context": "Workspace && debugger_running",
     "bindings": {
-      "f5": "zed::NoAction"
-    }
+      "f5": "zed::NoAction",
+    },
   },
   {
     "context": "Workspace && debugger_stopped",
     "bindings": {
-      "f5": "debugger::Continue"
-    }
+      "f5": "debugger::Continue",
+    },
   },
   {
     "context": "ApplicationMenu",
     "bindings": {
       "f10": "menu::Cancel",
       "left": "app_menu::ActivateMenuLeft",
-      "right": "app_menu::ActivateMenuRight"
-    }
+      "right": "app_menu::ActivateMenuRight",
+    },
   },
   // Bindings from Sublime Text
   {
@@ -694,8 +694,8 @@
       "ctrl-alt-shift-left": "editor::SelectToPreviousSubwordStart",
       "ctrl-alt-shift-b": "editor::SelectToPreviousSubwordStart",
       "ctrl-alt-shift-right": "editor::SelectToNextSubwordEnd",
-      "ctrl-alt-shift-f": "editor::SelectToNextSubwordEnd"
-    }
+      "ctrl-alt-shift-f": "editor::SelectToNextSubwordEnd",
+    },
   },
   // Bindings from Atom
   {
@@ -704,37 +704,37 @@
       "ctrl-k up": "pane::SplitUp",
       "ctrl-k down": "pane::SplitDown",
       "ctrl-k left": "pane::SplitLeft",
-      "ctrl-k right": "pane::SplitRight"
-    }
+      "ctrl-k right": "pane::SplitRight",
+    },
   },
   // Bindings that should be unified with bindings for more general actions
   {
     "context": "Editor && renaming",
     "bindings": {
-      "enter": "editor::ConfirmRename"
-    }
+      "enter": "editor::ConfirmRename",
+    },
   },
   {
     "context": "Editor && showing_completions",
     "bindings": {
       "enter": "editor::ConfirmCompletion",
       "shift-enter": "editor::ConfirmCompletionReplace",
-      "tab": "editor::ComposeCompletion"
-    }
+      "tab": "editor::ComposeCompletion",
+    },
   },
   {
     "context": "Editor && in_snippet && has_next_tabstop && !showing_completions",
     "use_key_equivalents": true,
     "bindings": {
-      "tab": "editor::NextSnippetTabstop"
-    }
+      "tab": "editor::NextSnippetTabstop",
+    },
   },
   {
     "context": "Editor && in_snippet && has_previous_tabstop && !showing_completions",
     "use_key_equivalents": true,
     "bindings": {
-      "shift-tab": "editor::PreviousSnippetTabstop"
-    }
+      "shift-tab": "editor::PreviousSnippetTabstop",
+    },
   },
   // Bindings for accepting edit predictions
   //
@@ -746,22 +746,22 @@
       "alt-tab": "editor::AcceptEditPrediction",
       "alt-l": "editor::AcceptEditPrediction",
       "tab": "editor::AcceptEditPrediction",
-      "alt-right": "editor::AcceptPartialEditPrediction"
-    }
+      "alt-right": "editor::AcceptPartialEditPrediction",
+    },
   },
   {
     "context": "Editor && edit_prediction_conflict",
     "bindings": {
       "alt-tab": "editor::AcceptEditPrediction",
       "alt-l": "editor::AcceptEditPrediction",
-      "alt-right": "editor::AcceptPartialEditPrediction"
-    }
+      "alt-right": "editor::AcceptPartialEditPrediction",
+    },
   },
   {
     "context": "Editor && showing_code_actions",
     "bindings": {
-      "enter": "editor::ConfirmCodeAction"
-    }
+      "enter": "editor::ConfirmCodeAction",
+    },
   },
   {
     "context": "Editor && (showing_code_actions || showing_completions)",
@@ -771,29 +771,29 @@
       "ctrl-n": "editor::ContextMenuNext",
       "down": "editor::ContextMenuNext",
       "pageup": "editor::ContextMenuFirst",
-      "pagedown": "editor::ContextMenuLast"
-    }
+      "pagedown": "editor::ContextMenuLast",
+    },
   },
   {
     "context": "Editor && showing_signature_help && !showing_completions",
     "bindings": {
       "up": "editor::SignatureHelpPrevious",
-      "down": "editor::SignatureHelpNext"
-    }
+      "down": "editor::SignatureHelpNext",
+    },
   },
   // Custom bindings
   {
     "bindings": {
       "ctrl-alt-shift-f": "workspace::FollowNextCollaborator",
       // Only available in debug builds: opens an element inspector for development.
-      "ctrl-alt-i": "dev::ToggleInspector"
-    }
+      "ctrl-alt-i": "dev::ToggleInspector",
+    },
   },
   {
     "context": "!Terminal",
     "bindings": {
-      "ctrl-shift-c": "collab_panel::ToggleFocus"
-    }
+      "ctrl-shift-c": "collab_panel::ToggleFocus",
+    },
   },
   {
     "context": "!ContextEditor > Editor && mode == full",
@@ -805,8 +805,8 @@
       "ctrl-f8": "editor::GoToHunk",
       "ctrl-shift-f8": "editor::GoToPreviousHunk",
       "ctrl-enter": "assistant::InlineAssist",
-      "ctrl-:": "editor::ToggleInlayHints"
-    }
+      "ctrl-:": "editor::ToggleInlayHints",
+    },
   },
   {
     "context": "PromptEditor",
@@ -814,8 +814,8 @@
       "ctrl-[": "agent::CyclePreviousInlineAssist",
       "ctrl-]": "agent::CycleNextInlineAssist",
       "ctrl-shift-enter": "inline_assistant::ThumbsUpResult",
-      "ctrl-shift-backspace": "inline_assistant::ThumbsDownResult"
-    }
+      "ctrl-shift-backspace": "inline_assistant::ThumbsDownResult",
+    },
   },
   {
     "context": "Prompt",
@@ -823,14 +823,14 @@
       "left": "menu::SelectPrevious",
       "right": "menu::SelectNext",
       "h": "menu::SelectPrevious",
-      "l": "menu::SelectNext"
-    }
+      "l": "menu::SelectNext",
+    },
   },
   {
     "context": "ProjectSearchBar && !in_replace",
     "bindings": {
-      "ctrl-enter": "project_search::SearchInNew"
-    }
+      "ctrl-enter": "project_search::SearchInNew",
+    },
   },
   {
     "context": "OutlinePanel && not_editing",
@@ -847,8 +847,8 @@
       "shift-down": "menu::SelectNext",
       "shift-up": "menu::SelectPrevious",
       "alt-enter": "editor::OpenExcerpts",
-      "ctrl-alt-enter": "editor::OpenExcerptsSplit"
-    }
+      "ctrl-alt-enter": "editor::OpenExcerptsSplit",
+    },
   },
   {
     "context": "ProjectPanel",
@@ -886,14 +886,14 @@
       "ctrl-alt-shift-f": "project_panel::NewSearchInDirectory",
       "shift-down": "menu::SelectNext",
       "shift-up": "menu::SelectPrevious",
-      "escape": "menu::Cancel"
-    }
+      "escape": "menu::Cancel",
+    },
   },
   {
     "context": "ProjectPanel && not_editing",
     "bindings": {
-      "space": "project_panel::Open"
-    }
+      "space": "project_panel::Open",
+    },
   },
   {
     "context": "GitPanel && ChangesList",
@@ -914,15 +914,15 @@
       "backspace": ["git::RestoreFile", { "skip_prompt": false }],
       "shift-delete": ["git::RestoreFile", { "skip_prompt": false }],
       "ctrl-backspace": ["git::RestoreFile", { "skip_prompt": false }],
-      "ctrl-delete": ["git::RestoreFile", { "skip_prompt": false }]
-    }
+      "ctrl-delete": ["git::RestoreFile", { "skip_prompt": false }],
+    },
   },
   {
     "context": "GitPanel && CommitEditor",
     "use_key_equivalents": true,
     "bindings": {
-      "escape": "git::Cancel"
-    }
+      "escape": "git::Cancel",
+    },
   },
   {
     "context": "GitCommit > Editor",
@@ -931,8 +931,8 @@
       "enter": "editor::Newline",
       "ctrl-enter": "git::Commit",
       "ctrl-shift-enter": "git::Amend",
-      "alt-l": "git::GenerateCommitMessage"
-    }
+      "alt-l": "git::GenerateCommitMessage",
+    },
   },
   {
     "context": "GitPanel",
@@ -948,8 +948,8 @@
       "ctrl-space": "git::StageAll",
       "ctrl-shift-space": "git::UnstageAll",
       "ctrl-enter": "git::Commit",
-      "ctrl-shift-enter": "git::Amend"
-    }
+      "ctrl-shift-enter": "git::Amend",
+    },
   },
   {
     "context": "GitDiff > Editor",
@@ -957,14 +957,14 @@
       "ctrl-enter": "git::Commit",
       "ctrl-shift-enter": "git::Amend",
       "ctrl-space": "git::StageAll",
-      "ctrl-shift-space": "git::UnstageAll"
-    }
+      "ctrl-shift-space": "git::UnstageAll",
+    },
   },
   {
     "context": "AskPass > Editor",
     "bindings": {
-      "enter": "menu::Confirm"
-    }
+      "enter": "menu::Confirm",
+    },
   },
   {
     "context": "CommitEditor > Editor",
@@ -976,16 +976,16 @@
       "ctrl-enter": "git::Commit",
       "ctrl-shift-enter": "git::Amend",
       "alt-up": "git_panel::FocusChanges",
-      "alt-l": "git::GenerateCommitMessage"
-    }
+      "alt-l": "git::GenerateCommitMessage",
+    },
   },
   {
     "context": "DebugPanel",
     "bindings": {
       "ctrl-t": "debugger::ToggleThreadPicker",
       "ctrl-i": "debugger::ToggleSessionPicker",
-      "shift-alt-escape": "debugger::ToggleExpandItem"
-    }
+      "shift-alt-escape": "debugger::ToggleExpandItem",
+    },
   },
   {
     "context": "VariableList",
@@ -997,8 +997,8 @@
       "ctrl-alt-c": "variable_list::CopyVariableName",
       "delete": "variable_list::RemoveWatch",
       "backspace": "variable_list::RemoveWatch",
-      "alt-enter": "variable_list::AddWatch"
-    }
+      "alt-enter": "variable_list::AddWatch",
+    },
   },
   {
     "context": "BreakpointList",
@@ -1006,35 +1006,35 @@
       "space": "debugger::ToggleEnableBreakpoint",
       "backspace": "debugger::UnsetBreakpoint",
       "left": "debugger::PreviousBreakpointProperty",
-      "right": "debugger::NextBreakpointProperty"
-    }
+      "right": "debugger::NextBreakpointProperty",
+    },
   },
   {
     "context": "CollabPanel && not_editing",
     "bindings": {
       "ctrl-backspace": "collab_panel::Remove",
-      "space": "menu::Confirm"
-    }
+      "space": "menu::Confirm",
+    },
   },
   {
     "context": "CollabPanel",
     "bindings": {
       "alt-up": "collab_panel::MoveChannelUp",
       "alt-down": "collab_panel::MoveChannelDown",
-      "alt-enter": "collab_panel::OpenSelectedChannelNotes"
-    }
+      "alt-enter": "collab_panel::OpenSelectedChannelNotes",
+    },
   },
   {
     "context": "(CollabPanel && editing) > Editor",
     "bindings": {
-      "space": "collab_panel::InsertSpace"
-    }
+      "space": "collab_panel::InsertSpace",
+    },
   },
   {
     "context": "ChannelModal",
     "bindings": {
-      "tab": "channel_modal::ToggleMode"
-    }
+      "tab": "channel_modal::ToggleMode",
+    },
   },
   {
     "context": "Picker > Editor",
@@ -1043,29 +1043,29 @@
       "up": "menu::SelectPrevious",
       "down": "menu::SelectNext",
       "tab": "picker::ConfirmCompletion",
-      "alt-enter": ["picker::ConfirmInput", { "secondary": false }]
-    }
+      "alt-enter": ["picker::ConfirmInput", { "secondary": false }],
+    },
   },
   {
     "context": "ChannelModal > Picker > Editor",
     "bindings": {
-      "tab": "channel_modal::ToggleMode"
-    }
+      "tab": "channel_modal::ToggleMode",
+    },
   },
   {
     "context": "ToolchainSelector",
     "use_key_equivalents": true,
     "bindings": {
-      "ctrl-shift-a": "toolchain::AddToolchain"
-    }
+      "ctrl-shift-a": "toolchain::AddToolchain",
+    },
   },
   {
     "context": "FileFinder || (FileFinder > Picker > Editor)",
     "bindings": {
       "ctrl-p": "file_finder::Toggle",
       "ctrl-shift-a": "file_finder::ToggleSplitMenu",
-      "ctrl-shift-i": "file_finder::ToggleFilterMenu"
-    }
+      "ctrl-shift-i": "file_finder::ToggleFilterMenu",
+    },
   },
   {
     "context": "FileFinder || (FileFinder > Picker > Editor) || (FileFinder > Picker > menu)",
@@ -1074,8 +1074,8 @@
       "ctrl-j": "pane::SplitDown",
       "ctrl-k": "pane::SplitUp",
       "ctrl-h": "pane::SplitLeft",
-      "ctrl-l": "pane::SplitRight"
-    }
+      "ctrl-l": "pane::SplitRight",
+    },
   },
   {
     "context": "TabSwitcher",
@@ -1083,15 +1083,15 @@
       "ctrl-shift-tab": "menu::SelectPrevious",
       "ctrl-up": "menu::SelectPrevious",
       "ctrl-down": "menu::SelectNext",
-      "ctrl-backspace": "tab_switcher::CloseSelectedItem"
-    }
+      "ctrl-backspace": "tab_switcher::CloseSelectedItem",
+    },
   },
   {
     "context": "StashList || (StashList > Picker > Editor)",
     "bindings": {
       "ctrl-shift-backspace": "stash_picker::DropStashItem",
-      "ctrl-shift-v": "stash_picker::ShowStashItem"
-    }
+      "ctrl-shift-v": "stash_picker::ShowStashItem",
+    },
   },
   {
     "context": "Terminal",
@@ -1136,58 +1136,58 @@
       "ctrl-shift-r": "terminal::RerunTask",
       "ctrl-alt-r": "terminal::RerunTask",
       "alt-t": "terminal::RerunTask",
-      "ctrl-shift-5": "pane::SplitRight"
-    }
+      "ctrl-shift-5": "pane::SplitRight",
+    },
   },
   {
     "context": "ZedPredictModal",
     "bindings": {
-      "escape": "menu::Cancel"
-    }
+      "escape": "menu::Cancel",
+    },
   },
   {
     "context": "ConfigureContextServerModal > Editor",
     "bindings": {
       "escape": "menu::Cancel",
       "enter": "editor::Newline",
-      "ctrl-enter": "menu::Confirm"
-    }
+      "ctrl-enter": "menu::Confirm",
+    },
   },
   {
     "context": "ContextServerToolsModal",
     "use_key_equivalents": true,
     "bindings": {
-      "escape": "menu::Cancel"
-    }
+      "escape": "menu::Cancel",
+    },
   },
   {
     "context": "OnboardingAiConfigurationModal",
     "use_key_equivalents": true,
     "bindings": {
-      "escape": "menu::Cancel"
-    }
+      "escape": "menu::Cancel",
+    },
   },
   {
     "context": "Diagnostics",
     "use_key_equivalents": true,
     "bindings": {
-      "ctrl-r": "diagnostics::ToggleDiagnosticsRefresh"
-    }
+      "ctrl-r": "diagnostics::ToggleDiagnosticsRefresh",
+    },
   },
   {
     "context": "DebugConsole > Editor",
     "use_key_equivalents": true,
     "bindings": {
       "enter": "menu::Confirm",
-      "alt-enter": "console::WatchExpression"
-    }
+      "alt-enter": "console::WatchExpression",
+    },
   },
   {
     "context": "RunModal",
     "bindings": {
       "ctrl-tab": "pane::ActivateNextItem",
-      "ctrl-shift-tab": "pane::ActivatePreviousItem"
-    }
+      "ctrl-shift-tab": "pane::ActivatePreviousItem",
+    },
   },
   {
     "context": "MarkdownPreview",
@@ -1197,8 +1197,8 @@
       "up": "markdown::ScrollUp",
       "down": "markdown::ScrollDown",
       "alt-up": "markdown::ScrollUpByItem",
-      "alt-down": "markdown::ScrollDownByItem"
-    }
+      "alt-down": "markdown::ScrollDownByItem",
+    },
   },
   {
     "context": "KeymapEditor",
@@ -1212,8 +1212,8 @@
       "alt-enter": "keymap_editor::CreateBinding",
       "ctrl-c": "keymap_editor::CopyAction",
       "ctrl-shift-c": "keymap_editor::CopyContext",
-      "ctrl-t": "keymap_editor::ShowMatchingKeybinds"
-    }
+      "ctrl-t": "keymap_editor::ShowMatchingKeybinds",
+    },
   },
   {
     "context": "KeystrokeInput",
@@ -1221,24 +1221,24 @@
     "bindings": {
       "enter": "keystroke_input::StartRecording",
       "escape escape escape": "keystroke_input::StopRecording",
-      "delete": "keystroke_input::ClearKeystrokes"
-    }
+      "delete": "keystroke_input::ClearKeystrokes",
+    },
   },
   {
     "context": "KeybindEditorModal",
     "use_key_equivalents": true,
     "bindings": {
       "ctrl-enter": "menu::Confirm",
-      "escape": "menu::Cancel"
-    }
+      "escape": "menu::Cancel",
+    },
   },
   {
     "context": "KeybindEditorModal > Editor",
     "use_key_equivalents": true,
     "bindings": {
       "up": "menu::SelectPrevious",
-      "down": "menu::SelectNext"
-    }
+      "down": "menu::SelectNext",
+    },
   },
   {
     "context": "Onboarding",
@@ -1250,8 +1250,8 @@
       "ctrl-0": ["zed::ResetUiFontSize", { "persist": false }],
       "ctrl-enter": "onboarding::Finish",
       "alt-shift-l": "onboarding::SignIn",
-      "alt-shift-a": "onboarding::OpenAccount"
-    }
+      "alt-shift-a": "onboarding::OpenAccount",
+    },
   },
   {
     "context": "Welcome",
@@ -1260,23 +1260,23 @@
       "ctrl-=": ["zed::IncreaseUiFontSize", { "persist": false }],
       "ctrl-+": ["zed::IncreaseUiFontSize", { "persist": false }],
       "ctrl--": ["zed::DecreaseUiFontSize", { "persist": false }],
-      "ctrl-0": ["zed::ResetUiFontSize", { "persist": false }]
-    }
+      "ctrl-0": ["zed::ResetUiFontSize", { "persist": false }],
+    },
   },
   {
     "context": "InvalidBuffer",
     "use_key_equivalents": true,
     "bindings": {
-      "ctrl-shift-enter": "workspace::OpenWithSystem"
-    }
+      "ctrl-shift-enter": "workspace::OpenWithSystem",
+    },
   },
   {
     "context": "GitWorktreeSelector || (GitWorktreeSelector > Picker > Editor)",
     "use_key_equivalents": true,
     "bindings": {
       "ctrl-shift-space": "git::WorktreeFromDefaultOnWindow",
-      "ctrl-space": "git::WorktreeFromDefault"
-    }
+      "ctrl-space": "git::WorktreeFromDefault",
+    },
   },
   {
     "context": "SettingsWindow",
@@ -1301,16 +1301,16 @@
       "ctrl-9": ["settings_editor::FocusFile", 8],
       "ctrl-0": ["settings_editor::FocusFile", 9],
       "ctrl-pageup": "settings_editor::FocusPreviousFile",
-      "ctrl-pagedown": "settings_editor::FocusNextFile"
-    }
+      "ctrl-pagedown": "settings_editor::FocusNextFile",
+    },
   },
   {
     "context": "StashDiff > Editor",
     "bindings": {
       "ctrl-space": "git::ApplyCurrentStash",
       "ctrl-shift-space": "git::PopCurrentStash",
-      "ctrl-shift-backspace": "git::DropCurrentStash"
-    }
+      "ctrl-shift-backspace": "git::DropCurrentStash",
+    },
   },
   {
     "context": "SettingsWindow > NavigationMenu",
@@ -1325,22 +1325,22 @@
       "pageup": "settings_editor::FocusPreviousRootNavEntry",
       "pagedown": "settings_editor::FocusNextRootNavEntry",
       "home": "settings_editor::FocusFirstNavEntry",
-      "end": "settings_editor::FocusLastNavEntry"
-    }
+      "end": "settings_editor::FocusLastNavEntry",
+    },
   },
   {
     "context": "EditPredictionContext > Editor",
     "bindings": {
       "alt-left": "dev::EditPredictionContextGoBack",
-      "alt-right": "dev::EditPredictionContextGoForward"
-    }
+      "alt-right": "dev::EditPredictionContextGoForward",
+    },
   },
   {
     "context": "GitBranchSelector || (GitBranchSelector > Picker > Editor)",
     "use_key_equivalents": true,
     "bindings": {
       "ctrl-shift-backspace": "branch_picker::DeleteBranch",
-      "ctrl-shift-i": "branch_picker::FilterRemotes"
-    }
-  }
+      "ctrl-shift-i": "branch_picker::FilterRemotes",
+    },
+  },
 ]

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -50,8 +50,8 @@
       "ctrl-cmd-z": "edit_prediction::RatePredictions",
       "ctrl-cmd-i": "edit_prediction::ToggleMenu",
       "ctrl-cmd-l": "lsp_tool::ToggleMenu",
-      "ctrl-cmd-c": "editor::DisplayCursorNames"
-    }
+      "ctrl-cmd-c": "editor::DisplayCursorNames",
+    },
   },
   {
     "context": "Editor",
@@ -148,8 +148,8 @@
       "shift-f9": "editor::EditLogBreakpoint",
       "ctrl-f12": "editor::GoToDeclaration",
       "alt-ctrl-f12": "editor::GoToDeclarationSplit",
-      "ctrl-cmd-e": "editor::ToggleEditPrediction"
-    }
+      "ctrl-cmd-e": "editor::ToggleEditPrediction",
+    },
   },
   {
     "context": "Editor && mode == full",
@@ -167,8 +167,8 @@
       "cmd->": "agent::AddSelectionToThread",
       "cmd-<": "assistant::InsertIntoEditor",
       "cmd-alt-e": "editor::SelectEnclosingSymbol",
-      "alt-enter": "editor::OpenSelectionsInMultibuffer"
-    }
+      "alt-enter": "editor::OpenSelectionsInMultibuffer",
+    },
   },
   {
     "context": "Editor && multibuffer",
@@ -177,23 +177,23 @@
       "cmd-up": "editor::MoveToStartOfExcerpt",
       "cmd-down": "editor::MoveToStartOfNextExcerpt",
       "cmd-shift-up": "editor::SelectToStartOfExcerpt",
-      "cmd-shift-down": "editor::SelectToStartOfNextExcerpt"
-    }
+      "cmd-shift-down": "editor::SelectToStartOfNextExcerpt",
+    },
   },
   {
     "context": "Editor && mode == full && edit_prediction",
     "use_key_equivalents": true,
     "bindings": {
       "alt-tab": "editor::NextEditPrediction",
-      "alt-shift-tab": "editor::PreviousEditPrediction"
-    }
+      "alt-shift-tab": "editor::PreviousEditPrediction",
+    },
   },
   {
     "context": "Editor && !edit_prediction",
     "use_key_equivalents": true,
     "bindings": {
-      "alt-tab": "editor::ShowEditPrediction"
-    }
+      "alt-tab": "editor::ShowEditPrediction",
+    },
   },
   {
     "context": "Editor && mode == auto_height",
@@ -201,23 +201,23 @@
     "bindings": {
       "ctrl-enter": "editor::Newline",
       "shift-enter": "editor::Newline",
-      "ctrl-shift-enter": "editor::NewlineBelow"
-    }
+      "ctrl-shift-enter": "editor::NewlineBelow",
+    },
   },
   {
     "context": "Markdown",
     "use_key_equivalents": true,
     "bindings": {
-      "cmd-c": "markdown::Copy"
-    }
+      "cmd-c": "markdown::Copy",
+    },
   },
   {
     "context": "Editor && jupyter && !ContextEditor",
     "use_key_equivalents": true,
     "bindings": {
       "ctrl-shift-enter": "repl::Run",
-      "ctrl-alt-enter": "repl::RunInPlace"
-    }
+      "ctrl-alt-enter": "repl::RunInPlace",
+    },
   },
   {
     "context": "Editor && !agent_diff && !AgentPanel",
@@ -226,8 +226,8 @@
       "cmd-alt-z": "git::Restore",
       "cmd-alt-y": "git::ToggleStaged",
       "cmd-y": "git::StageAndNext",
-      "cmd-shift-y": "git::UnstageAndNext"
-    }
+      "cmd-shift-y": "git::UnstageAndNext",
+    },
   },
   {
     "context": "AgentDiff",
@@ -236,8 +236,8 @@
       "cmd-y": "agent::Keep",
       "cmd-n": "agent::Reject",
       "cmd-shift-y": "agent::KeepAll",
-      "cmd-shift-n": "agent::RejectAll"
-    }
+      "cmd-shift-n": "agent::RejectAll",
+    },
   },
   {
     "context": "Editor && editor_agent_diff",
@@ -247,8 +247,8 @@
       "cmd-n": "agent::Reject",
       "cmd-shift-y": "agent::KeepAll",
       "cmd-shift-n": "agent::RejectAll",
-      "shift-ctrl-r": "agent::OpenAgentDiff"
-    }
+      "shift-ctrl-r": "agent::OpenAgentDiff",
+    },
   },
   {
     "context": "ContextEditor > Editor",
@@ -264,8 +264,8 @@
       "cmd-k c": "assistant::CopyCode",
       "cmd-g": "search::SelectNextMatch",
       "cmd-shift-g": "search::SelectPreviousMatch",
-      "cmd-k l": "agent::OpenRulesLibrary"
-    }
+      "cmd-k l": "agent::OpenRulesLibrary",
+    },
   },
   {
     "context": "AgentPanel",
@@ -290,37 +290,37 @@
       "alt-enter": "agent::ContinueWithBurnMode",
       "cmd-y": "agent::AllowOnce",
       "cmd-alt-y": "agent::AllowAlways",
-      "cmd-alt-z": "agent::RejectOnce"
-    }
+      "cmd-alt-z": "agent::RejectOnce",
+    },
   },
   {
     "context": "AgentPanel > NavigationMenu",
     "bindings": {
-      "shift-backspace": "agent::DeleteRecentlyOpenThread"
-    }
+      "shift-backspace": "agent::DeleteRecentlyOpenThread",
+    },
   },
   {
     "context": "AgentPanel > Markdown",
     "use_key_equivalents": true,
     "bindings": {
-      "cmd-c": "markdown::CopyAsMarkdown"
-    }
+      "cmd-c": "markdown::CopyAsMarkdown",
+    },
   },
   {
     "context": "AgentPanel && text_thread",
     "use_key_equivalents": true,
     "bindings": {
       "cmd-n": "agent::NewTextThread",
-      "cmd-alt-n": "agent::NewExternalAgentThread"
-    }
+      "cmd-alt-n": "agent::NewExternalAgentThread",
+    },
   },
   {
     "context": "AgentPanel && acp_thread",
     "use_key_equivalents": true,
     "bindings": {
       "cmd-n": "agent::NewExternalAgentThread",
-      "cmd-alt-t": "agent::NewThread"
-    }
+      "cmd-alt-t": "agent::NewThread",
+    },
   },
   {
     "context": "MessageEditor && !Picker > Editor && !use_modifier_to_send",
@@ -331,8 +331,8 @@
       "cmd-i": "agent::ToggleProfileSelector",
       "shift-ctrl-r": "agent::OpenAgentDiff",
       "cmd-shift-y": "agent::KeepAll",
-      "cmd-shift-n": "agent::RejectAll"
-    }
+      "cmd-shift-n": "agent::RejectAll",
+    },
   },
   {
     "context": "MessageEditor && !Picker > Editor && use_modifier_to_send",
@@ -343,8 +343,8 @@
       "cmd-i": "agent::ToggleProfileSelector",
       "shift-ctrl-r": "agent::OpenAgentDiff",
       "cmd-shift-y": "agent::KeepAll",
-      "cmd-shift-n": "agent::RejectAll"
-    }
+      "cmd-shift-n": "agent::RejectAll",
+    },
   },
   {
     "context": "EditMessageEditor > Editor",
@@ -352,8 +352,8 @@
     "bindings": {
       "escape": "menu::Cancel",
       "enter": "menu::Confirm",
-      "alt-enter": "editor::Newline"
-    }
+      "alt-enter": "editor::Newline",
+    },
   },
   {
     "context": "AgentFeedbackMessageEditor > Editor",
@@ -361,20 +361,20 @@
     "bindings": {
       "escape": "menu::Cancel",
       "enter": "menu::Confirm",
-      "alt-enter": "editor::Newline"
-    }
+      "alt-enter": "editor::Newline",
+    },
   },
   {
     "context": "AgentConfiguration",
     "bindings": {
-      "ctrl--": "pane::GoBack"
-    }
+      "ctrl--": "pane::GoBack",
+    },
   },
   {
     "context": "AcpThread > ModeSelector",
     "bindings": {
-      "cmd-enter": "menu::Confirm"
-    }
+      "cmd-enter": "menu::Confirm",
+    },
   },
   {
     "context": "AcpThread > Editor && !use_modifier_to_send",
@@ -384,8 +384,8 @@
       "shift-ctrl-r": "agent::OpenAgentDiff",
       "cmd-shift-y": "agent::KeepAll",
       "cmd-shift-n": "agent::RejectAll",
-      "shift-tab": "agent::CycleModeSelector"
-    }
+      "shift-tab": "agent::CycleModeSelector",
+    },
   },
   {
     "context": "AcpThread > Editor && use_modifier_to_send",
@@ -395,20 +395,20 @@
       "shift-ctrl-r": "agent::OpenAgentDiff",
       "cmd-shift-y": "agent::KeepAll",
       "cmd-shift-n": "agent::RejectAll",
-      "shift-tab": "agent::CycleModeSelector"
-    }
+      "shift-tab": "agent::CycleModeSelector",
+    },
   },
   {
     "context": "ThreadHistory",
     "bindings": {
-      "ctrl--": "pane::GoBack"
-    }
+      "ctrl--": "pane::GoBack",
+    },
   },
   {
     "context": "ThreadHistory > Editor",
     "bindings": {
-      "shift-backspace": "agent::RemoveSelectedThread"
-    }
+      "shift-backspace": "agent::RemoveSelectedThread",
+    },
   },
   {
     "context": "RulesLibrary",
@@ -416,8 +416,8 @@
     "bindings": {
       "cmd-n": "rules_library::NewRule",
       "cmd-shift-s": "rules_library::ToggleDefaultRule",
-      "cmd-w": "workspace::CloseWindow"
-    }
+      "cmd-w": "workspace::CloseWindow",
+    },
   },
   {
     "context": "BufferSearchBar",
@@ -431,24 +431,24 @@
       "cmd-f": "search::FocusSearch",
       "cmd-alt-f": "search::ToggleReplace",
       "cmd-alt-l": "search::ToggleSelection",
-      "cmd-shift-o": "outline::Toggle"
-    }
+      "cmd-shift-o": "outline::Toggle",
+    },
   },
   {
     "context": "BufferSearchBar && in_replace > Editor",
     "use_key_equivalents": true,
     "bindings": {
       "enter": "search::ReplaceNext",
-      "cmd-enter": "search::ReplaceAll"
-    }
+      "cmd-enter": "search::ReplaceAll",
+    },
   },
   {
     "context": "BufferSearchBar && !in_replace > Editor",
     "use_key_equivalents": true,
     "bindings": {
       "up": "search::PreviousHistoryQuery",
-      "down": "search::NextHistoryQuery"
-    }
+      "down": "search::NextHistoryQuery",
+    },
   },
   {
     "context": "ProjectSearchBar",
@@ -460,24 +460,24 @@
       "cmd-shift-f": "search::FocusSearch",
       "cmd-shift-h": "search::ToggleReplace",
       "alt-cmd-g": "search::ToggleRegex",
-      "alt-cmd-x": "search::ToggleRegex"
-    }
+      "alt-cmd-x": "search::ToggleRegex",
+    },
   },
   {
     "context": "ProjectSearchBar > Editor",
     "use_key_equivalents": true,
     "bindings": {
       "up": "search::PreviousHistoryQuery",
-      "down": "search::NextHistoryQuery"
-    }
+      "down": "search::NextHistoryQuery",
+    },
   },
   {
     "context": "ProjectSearchBar && in_replace > Editor",
     "use_key_equivalents": true,
     "bindings": {
       "enter": "search::ReplaceNext",
-      "cmd-enter": "search::ReplaceAll"
-    }
+      "cmd-enter": "search::ReplaceAll",
+    },
   },
   {
     "context": "ProjectSearchView",
@@ -488,8 +488,8 @@
       "shift-enter": "project_search::ToggleAllSearchResults",
       "cmd-shift-h": "search::ToggleReplace",
       "alt-cmd-g": "search::ToggleRegex",
-      "alt-cmd-x": "search::ToggleRegex"
-    }
+      "alt-cmd-x": "search::ToggleRegex",
+    },
   },
   {
     "context": "Pane",
@@ -519,8 +519,8 @@
       "alt-cmd-w": "search::ToggleWholeWord",
       "alt-cmd-f": "project_search::ToggleFilters",
       "alt-cmd-x": "search::ToggleRegex",
-      "cmd-k shift-enter": "pane::TogglePinTab"
-    }
+      "cmd-k shift-enter": "pane::TogglePinTab",
+    },
   },
   // Bindings from VS Code
   {
@@ -590,24 +590,24 @@
       "cmd-.": "editor::ToggleCodeActions",
       "cmd-k r": "editor::RevealInFileManager",
       "cmd-k p": "editor::CopyPath",
-      "cmd-\\": "pane::SplitRight"
-    }
+      "cmd-\\": "pane::SplitRight",
+    },
   },
   {
     "context": "Editor && extension == md",
     "use_key_equivalents": true,
     "bindings": {
       "cmd-k v": "markdown::OpenPreviewToTheSide",
-      "cmd-shift-v": "markdown::OpenPreview"
-    }
+      "cmd-shift-v": "markdown::OpenPreview",
+    },
   },
   {
     "context": "Editor && extension == svg",
     "use_key_equivalents": true,
     "bindings": {
       "cmd-k v": "svg::OpenPreviewToTheSide",
-      "cmd-shift-v": "svg::OpenPreview"
-    }
+      "cmd-shift-v": "svg::OpenPreview",
+    },
   },
   {
     "context": "Editor && mode == full",
@@ -616,8 +616,8 @@
       "cmd-shift-o": "outline::Toggle",
       "ctrl-g": "go_to_line::Toggle",
       "cmd-shift-backspace": "editor::GoToPreviousChange",
-      "cmd-shift-alt-backspace": "editor::GoToNextChange"
-    }
+      "cmd-shift-alt-backspace": "editor::GoToNextChange",
+    },
   },
   {
     "context": "Pane",
@@ -635,8 +635,8 @@
       "ctrl-0": "pane::ActivateLastItem",
       "ctrl--": "pane::GoBack",
       "ctrl-_": "pane::GoForward",
-      "cmd-shift-f": "pane::DeploySearch"
-    }
+      "cmd-shift-f": "pane::DeploySearch",
+    },
   },
   {
     "context": "Workspace",
@@ -707,8 +707,8 @@
       "cmd-k shift-down": "workspace::SwapPaneDown",
       "cmd-shift-x": "zed::Extensions",
       "f5": "debugger::Rerun",
-      "cmd-w": "workspace::CloseActiveDock"
-    }
+      "cmd-w": "workspace::CloseActiveDock",
+    },
   },
   {
     "context": "Workspace && !Terminal",
@@ -719,27 +719,27 @@
       // All task parameters are captured and unchanged between reruns by default.
       // Use the `"reevaluate_context"` parameter to control this.
       "cmd-alt-r": ["task::Rerun", { "reevaluate_context": false }],
-      "ctrl-alt-shift-r": ["task::Spawn", { "reveal_target": "center" }]
+      "ctrl-alt-shift-r": ["task::Spawn", { "reveal_target": "center" }],
       // also possible to spawn tasks by name:
       // "foo-bar": ["task::Spawn", { "task_name": "MyTask", "reveal_target": "dock" }]
       // or by tag:
       // "foo-bar": ["task::Spawn", { "task_tag": "MyTag" }],
-    }
+    },
   },
   {
     "context": "Workspace && debugger_running",
     "use_key_equivalents": true,
     "bindings": {
       "f5": "zed::NoAction",
-      "f11": "debugger::StepInto"
-    }
+      "f11": "debugger::StepInto",
+    },
   },
   {
     "context": "Workspace && debugger_stopped",
     "use_key_equivalents": true,
     "bindings": {
-      "f5": "debugger::Continue"
-    }
+      "f5": "debugger::Continue",
+    },
   },
   // Bindings from Sublime Text
   {
@@ -760,8 +760,8 @@
       "ctrl-alt-shift-left": "editor::SelectToPreviousSubwordStart",
       "ctrl-alt-shift-b": "editor::SelectToPreviousSubwordStart",
       "ctrl-alt-shift-right": "editor::SelectToNextSubwordEnd",
-      "ctrl-alt-shift-f": "editor::SelectToNextSubwordEnd"
-    }
+      "ctrl-alt-shift-f": "editor::SelectToNextSubwordEnd",
+    },
   },
   // Bindings from Atom
   {
@@ -771,16 +771,16 @@
       "cmd-k up": "pane::SplitUp",
       "cmd-k down": "pane::SplitDown",
       "cmd-k left": "pane::SplitLeft",
-      "cmd-k right": "pane::SplitRight"
-    }
+      "cmd-k right": "pane::SplitRight",
+    },
   },
   // Bindings that should be unified with bindings for more general actions
   {
     "context": "Editor && renaming",
     "use_key_equivalents": true,
     "bindings": {
-      "enter": "editor::ConfirmRename"
-    }
+      "enter": "editor::ConfirmRename",
+    },
   },
   {
     "context": "Editor && showing_completions",
@@ -788,45 +788,45 @@
     "bindings": {
       "enter": "editor::ConfirmCompletion",
       "shift-enter": "editor::ConfirmCompletionReplace",
-      "tab": "editor::ComposeCompletion"
-    }
+      "tab": "editor::ComposeCompletion",
+    },
   },
   {
     "context": "Editor && in_snippet && has_next_tabstop && !showing_completions",
     "use_key_equivalents": true,
     "bindings": {
-      "tab": "editor::NextSnippetTabstop"
-    }
+      "tab": "editor::NextSnippetTabstop",
+    },
   },
   {
     "context": "Editor && in_snippet && has_previous_tabstop && !showing_completions",
     "use_key_equivalents": true,
     "bindings": {
-      "shift-tab": "editor::PreviousSnippetTabstop"
-    }
+      "shift-tab": "editor::PreviousSnippetTabstop",
+    },
   },
   {
     "context": "Editor && edit_prediction",
     "bindings": {
       "alt-tab": "editor::AcceptEditPrediction",
       "tab": "editor::AcceptEditPrediction",
-      "ctrl-cmd-right": "editor::AcceptPartialEditPrediction"
-    }
+      "ctrl-cmd-right": "editor::AcceptPartialEditPrediction",
+    },
   },
   {
     "context": "Editor && edit_prediction_conflict",
     "use_key_equivalents": true,
     "bindings": {
       "alt-tab": "editor::AcceptEditPrediction",
-      "ctrl-cmd-right": "editor::AcceptPartialEditPrediction"
-    }
+      "ctrl-cmd-right": "editor::AcceptPartialEditPrediction",
+    },
   },
   {
     "context": "Editor && showing_code_actions",
     "use_key_equivalents": true,
     "bindings": {
-      "enter": "editor::ConfirmCodeAction"
-    }
+      "enter": "editor::ConfirmCodeAction",
+    },
   },
   {
     "context": "Editor && (showing_code_actions || showing_completions)",
@@ -837,15 +837,15 @@
       "down": "editor::ContextMenuNext",
       "ctrl-n": "editor::ContextMenuNext",
       "pageup": "editor::ContextMenuFirst",
-      "pagedown": "editor::ContextMenuLast"
-    }
+      "pagedown": "editor::ContextMenuLast",
+    },
   },
   {
     "context": "Editor && showing_signature_help && !showing_completions",
     "bindings": {
       "up": "editor::SignatureHelpPrevious",
-      "down": "editor::SignatureHelpNext"
-    }
+      "down": "editor::SignatureHelpNext",
+    },
   },
   // Custom bindings
   {
@@ -855,8 +855,8 @@
       // TODO: Move this to a dock open action
       "cmd-shift-c": "collab_panel::ToggleFocus",
       // Only available in debug builds: opens an element inspector for development.
-      "cmd-alt-i": "dev::ToggleInspector"
-    }
+      "cmd-alt-i": "dev::ToggleInspector",
+    },
   },
   {
     "context": "!ContextEditor > Editor && mode == full",
@@ -869,8 +869,8 @@
       "cmd-f8": "editor::GoToHunk",
       "cmd-shift-f8": "editor::GoToPreviousHunk",
       "ctrl-enter": "assistant::InlineAssist",
-      "ctrl-:": "editor::ToggleInlayHints"
-    }
+      "ctrl-:": "editor::ToggleInlayHints",
+    },
   },
   {
     "context": "PromptEditor",
@@ -880,8 +880,8 @@
       "ctrl-[": "agent::CyclePreviousInlineAssist",
       "ctrl-]": "agent::CycleNextInlineAssist",
       "cmd-shift-enter": "inline_assistant::ThumbsUpResult",
-      "cmd-shift-backspace": "inline_assistant::ThumbsDownResult"
-    }
+      "cmd-shift-backspace": "inline_assistant::ThumbsDownResult",
+    },
   },
   {
     "context": "Prompt",
@@ -890,15 +890,15 @@
       "left": "menu::SelectPrevious",
       "right": "menu::SelectNext",
       "h": "menu::SelectPrevious",
-      "l": "menu::SelectNext"
-    }
+      "l": "menu::SelectNext",
+    },
   },
   {
     "context": "ProjectSearchBar && !in_replace",
     "use_key_equivalents": true,
     "bindings": {
-      "cmd-enter": "project_search::SearchInNew"
-    }
+      "cmd-enter": "project_search::SearchInNew",
+    },
   },
   {
     "context": "OutlinePanel && not_editing",
@@ -914,8 +914,8 @@
       "shift-down": "menu::SelectNext",
       "shift-up": "menu::SelectPrevious",
       "alt-enter": "editor::OpenExcerpts",
-      "cmd-alt-enter": "editor::OpenExcerptsSplit"
-    }
+      "cmd-alt-enter": "editor::OpenExcerptsSplit",
+    },
   },
   {
     "context": "ProjectPanel",
@@ -945,15 +945,15 @@
       "cmd-alt-shift-f": "project_panel::NewSearchInDirectory",
       "shift-down": "menu::SelectNext",
       "shift-up": "menu::SelectPrevious",
-      "escape": "menu::Cancel"
-    }
+      "escape": "menu::Cancel",
+    },
   },
   {
     "context": "ProjectPanel && not_editing",
     "use_key_equivalents": true,
     "bindings": {
-      "space": "project_panel::Open"
-    }
+      "space": "project_panel::Open",
+    },
   },
   {
     "context": "VariableList",
@@ -966,8 +966,8 @@
       "cmd-alt-c": "variable_list::CopyVariableName",
       "delete": "variable_list::RemoveWatch",
       "backspace": "variable_list::RemoveWatch",
-      "alt-enter": "variable_list::AddWatch"
-    }
+      "alt-enter": "variable_list::AddWatch",
+    },
   },
   {
     "context": "GitPanel && ChangesList",
@@ -990,15 +990,15 @@
       "backspace": ["git::RestoreFile", { "skip_prompt": false }],
       "delete": ["git::RestoreFile", { "skip_prompt": false }],
       "cmd-backspace": ["git::RestoreFile", { "skip_prompt": true }],
-      "cmd-delete": ["git::RestoreFile", { "skip_prompt": true }]
-    }
+      "cmd-delete": ["git::RestoreFile", { "skip_prompt": true }],
+    },
   },
   {
     "context": "GitPanel && CommitEditor",
     "use_key_equivalents": true,
     "bindings": {
-      "escape": "git::Cancel"
-    }
+      "escape": "git::Cancel",
+    },
   },
   {
     "context": "GitDiff > Editor",
@@ -1007,8 +1007,8 @@
       "cmd-enter": "git::Commit",
       "cmd-shift-enter": "git::Amend",
       "cmd-ctrl-y": "git::StageAll",
-      "cmd-ctrl-shift-y": "git::UnstageAll"
-    }
+      "cmd-ctrl-shift-y": "git::UnstageAll",
+    },
   },
   {
     "context": "CommitEditor > Editor",
@@ -1021,8 +1021,8 @@
       "shift-tab": "git_panel::FocusChanges",
       "alt-up": "git_panel::FocusChanges",
       "shift-escape": "git::ExpandCommitEditor",
-      "alt-tab": "git::GenerateCommitMessage"
-    }
+      "alt-tab": "git::GenerateCommitMessage",
+    },
   },
   {
     "context": "GitPanel",
@@ -1039,8 +1039,8 @@
       "cmd-ctrl-y": "git::StageAll",
       "cmd-ctrl-shift-y": "git::UnstageAll",
       "cmd-enter": "git::Commit",
-      "cmd-shift-enter": "git::Amend"
-    }
+      "cmd-shift-enter": "git::Amend",
+    },
   },
   {
     "context": "GitCommit > Editor",
@@ -1050,16 +1050,16 @@
       "escape": "menu::Cancel",
       "cmd-enter": "git::Commit",
       "cmd-shift-enter": "git::Amend",
-      "alt-tab": "git::GenerateCommitMessage"
-    }
+      "alt-tab": "git::GenerateCommitMessage",
+    },
   },
   {
     "context": "DebugPanel",
     "bindings": {
       "cmd-t": "debugger::ToggleThreadPicker",
       "cmd-i": "debugger::ToggleSessionPicker",
-      "shift-alt-escape": "debugger::ToggleExpandItem"
-    }
+      "shift-alt-escape": "debugger::ToggleExpandItem",
+    },
   },
   {
     "context": "BreakpointList",
@@ -1067,16 +1067,16 @@
       "space": "debugger::ToggleEnableBreakpoint",
       "backspace": "debugger::UnsetBreakpoint",
       "left": "debugger::PreviousBreakpointProperty",
-      "right": "debugger::NextBreakpointProperty"
-    }
+      "right": "debugger::NextBreakpointProperty",
+    },
   },
   {
     "context": "CollabPanel && not_editing",
     "use_key_equivalents": true,
     "bindings": {
       "ctrl-backspace": "collab_panel::Remove",
-      "space": "menu::Confirm"
-    }
+      "space": "menu::Confirm",
+    },
   },
   {
     "context": "CollabPanel",
@@ -1084,22 +1084,22 @@
     "bindings": {
       "alt-up": "collab_panel::MoveChannelUp",
       "alt-down": "collab_panel::MoveChannelDown",
-      "alt-enter": "collab_panel::OpenSelectedChannelNotes"
-    }
+      "alt-enter": "collab_panel::OpenSelectedChannelNotes",
+    },
   },
   {
     "context": "(CollabPanel && editing) > Editor",
     "use_key_equivalents": true,
     "bindings": {
-      "space": "collab_panel::InsertSpace"
-    }
+      "space": "collab_panel::InsertSpace",
+    },
   },
   {
     "context": "ChannelModal",
     "use_key_equivalents": true,
     "bindings": {
-      "tab": "channel_modal::ToggleMode"
-    }
+      "tab": "channel_modal::ToggleMode",
+    },
   },
   {
     "context": "Picker > Editor",
@@ -1110,30 +1110,30 @@
       "down": "menu::SelectNext",
       "tab": "picker::ConfirmCompletion",
       "alt-enter": ["picker::ConfirmInput", { "secondary": false }],
-      "cmd-alt-enter": ["picker::ConfirmInput", { "secondary": true }]
-    }
+      "cmd-alt-enter": ["picker::ConfirmInput", { "secondary": true }],
+    },
   },
   {
     "context": "ChannelModal > Picker > Editor",
     "use_key_equivalents": true,
     "bindings": {
-      "tab": "channel_modal::ToggleMode"
-    }
+      "tab": "channel_modal::ToggleMode",
+    },
   },
   {
     "context": "ToolchainSelector",
     "use_key_equivalents": true,
     "bindings": {
-      "cmd-shift-a": "toolchain::AddToolchain"
-    }
+      "cmd-shift-a": "toolchain::AddToolchain",
+    },
   },
   {
     "context": "FileFinder || (FileFinder > Picker > Editor)",
     "use_key_equivalents": true,
     "bindings": {
       "cmd-shift-a": "file_finder::ToggleSplitMenu",
-      "cmd-shift-i": "file_finder::ToggleFilterMenu"
-    }
+      "cmd-shift-i": "file_finder::ToggleFilterMenu",
+    },
   },
   {
     "context": "FileFinder || (FileFinder > Picker > Editor) || (FileFinder > Picker > menu)",
@@ -1143,8 +1143,8 @@
       "cmd-j": "pane::SplitDown",
       "cmd-k": "pane::SplitUp",
       "cmd-h": "pane::SplitLeft",
-      "cmd-l": "pane::SplitRight"
-    }
+      "cmd-l": "pane::SplitRight",
+    },
   },
   {
     "context": "TabSwitcher",
@@ -1153,16 +1153,16 @@
       "ctrl-shift-tab": "menu::SelectPrevious",
       "ctrl-up": "menu::SelectPrevious",
       "ctrl-down": "menu::SelectNext",
-      "ctrl-backspace": "tab_switcher::CloseSelectedItem"
-    }
+      "ctrl-backspace": "tab_switcher::CloseSelectedItem",
+    },
   },
   {
     "context": "StashList || (StashList > Picker > Editor)",
     "use_key_equivalents": true,
     "bindings": {
       "ctrl-shift-backspace": "stash_picker::DropStashItem",
-      "ctrl-shift-v": "stash_picker::ShowStashItem"
-    }
+      "ctrl-shift-v": "stash_picker::ShowStashItem",
+    },
   },
   {
     "context": "Terminal",
@@ -1217,8 +1217,8 @@
       "ctrl-alt-left": "pane::SplitLeft",
       "ctrl-alt-right": "pane::SplitRight",
       "cmd-d": "pane::SplitRight",
-      "cmd-alt-r": "terminal::RerunTask"
-    }
+      "cmd-alt-r": "terminal::RerunTask",
+    },
   },
   {
     "context": "RatePredictionsModal",
@@ -1228,8 +1228,8 @@
       "cmd-shift-backspace": "zeta::ThumbsDownActivePrediction",
       "shift-down": "zeta::NextEdit",
       "shift-up": "zeta::PreviousEdit",
-      "right": "zeta::PreviewPrediction"
-    }
+      "right": "zeta::PreviewPrediction",
+    },
   },
   {
     "context": "RatePredictionsModal > Editor",
@@ -1237,15 +1237,15 @@
     "bindings": {
       "escape": "zeta::FocusPredictions",
       "cmd-shift-enter": "zeta::ThumbsUpActivePrediction",
-      "cmd-shift-backspace": "zeta::ThumbsDownActivePrediction"
-    }
+      "cmd-shift-backspace": "zeta::ThumbsDownActivePrediction",
+    },
   },
   {
     "context": "ZedPredictModal",
     "use_key_equivalents": true,
     "bindings": {
-      "escape": "menu::Cancel"
-    }
+      "escape": "menu::Cancel",
+    },
   },
   {
     "context": "ConfigureContextServerModal > Editor",
@@ -1253,45 +1253,45 @@
     "bindings": {
       "escape": "menu::Cancel",
       "enter": "editor::Newline",
-      "cmd-enter": "menu::Confirm"
-    }
+      "cmd-enter": "menu::Confirm",
+    },
   },
   {
     "context": "ContextServerToolsModal",
     "use_key_equivalents": true,
     "bindings": {
-      "escape": "menu::Cancel"
-    }
+      "escape": "menu::Cancel",
+    },
   },
   {
     "context": "OnboardingAiConfigurationModal",
     "use_key_equivalents": true,
     "bindings": {
-      "escape": "menu::Cancel"
-    }
+      "escape": "menu::Cancel",
+    },
   },
   {
     "context": "Diagnostics",
     "use_key_equivalents": true,
     "bindings": {
-      "ctrl-r": "diagnostics::ToggleDiagnosticsRefresh"
-    }
+      "ctrl-r": "diagnostics::ToggleDiagnosticsRefresh",
+    },
   },
   {
     "context": "DebugConsole > Editor",
     "use_key_equivalents": true,
     "bindings": {
       "enter": "menu::Confirm",
-      "alt-enter": "console::WatchExpression"
-    }
+      "alt-enter": "console::WatchExpression",
+    },
   },
   {
     "context": "RunModal",
     "use_key_equivalents": true,
     "bindings": {
       "ctrl-tab": "pane::ActivateNextItem",
-      "ctrl-shift-tab": "pane::ActivatePreviousItem"
-    }
+      "ctrl-shift-tab": "pane::ActivatePreviousItem",
+    },
   },
   {
     "context": "MarkdownPreview",
@@ -1301,8 +1301,8 @@
       "up": "markdown::ScrollUp",
       "down": "markdown::ScrollDown",
       "alt-up": "markdown::ScrollUpByItem",
-      "alt-down": "markdown::ScrollDownByItem"
-    }
+      "alt-down": "markdown::ScrollDownByItem",
+    },
   },
   {
     "context": "KeymapEditor",
@@ -1315,8 +1315,8 @@
       "alt-enter": "keymap_editor::CreateBinding",
       "cmd-c": "keymap_editor::CopyAction",
       "cmd-shift-c": "keymap_editor::CopyContext",
-      "cmd-t": "keymap_editor::ShowMatchingKeybinds"
-    }
+      "cmd-t": "keymap_editor::ShowMatchingKeybinds",
+    },
   },
   {
     "context": "KeystrokeInput",
@@ -1324,24 +1324,24 @@
     "bindings": {
       "enter": "keystroke_input::StartRecording",
       "escape escape escape": "keystroke_input::StopRecording",
-      "delete": "keystroke_input::ClearKeystrokes"
-    }
+      "delete": "keystroke_input::ClearKeystrokes",
+    },
   },
   {
     "context": "KeybindEditorModal",
     "use_key_equivalents": true,
     "bindings": {
       "cmd-enter": "menu::Confirm",
-      "escape": "menu::Cancel"
-    }
+      "escape": "menu::Cancel",
+    },
   },
   {
     "context": "KeybindEditorModal > Editor",
     "use_key_equivalents": true,
     "bindings": {
       "up": "menu::SelectPrevious",
-      "down": "menu::SelectNext"
-    }
+      "down": "menu::SelectNext",
+    },
   },
   {
     "context": "Onboarding",
@@ -1353,8 +1353,8 @@
       "cmd-0": ["zed::ResetUiFontSize", { "persist": false }],
       "cmd-enter": "onboarding::Finish",
       "alt-tab": "onboarding::SignIn",
-      "alt-shift-a": "onboarding::OpenAccount"
-    }
+      "alt-shift-a": "onboarding::OpenAccount",
+    },
   },
   {
     "context": "Welcome",
@@ -1363,23 +1363,23 @@
       "cmd-=": ["zed::IncreaseUiFontSize", { "persist": false }],
       "cmd-+": ["zed::IncreaseUiFontSize", { "persist": false }],
       "cmd--": ["zed::DecreaseUiFontSize", { "persist": false }],
-      "cmd-0": ["zed::ResetUiFontSize", { "persist": false }]
-    }
+      "cmd-0": ["zed::ResetUiFontSize", { "persist": false }],
+    },
   },
   {
     "context": "InvalidBuffer",
     "use_key_equivalents": true,
     "bindings": {
-      "ctrl-shift-enter": "workspace::OpenWithSystem"
-    }
+      "ctrl-shift-enter": "workspace::OpenWithSystem",
+    },
   },
   {
     "context": "GitWorktreeSelector || (GitWorktreeSelector > Picker > Editor)",
     "use_key_equivalents": true,
     "bindings": {
       "ctrl-shift-space": "git::WorktreeFromDefaultOnWindow",
-      "ctrl-space": "git::WorktreeFromDefault"
-    }
+      "ctrl-space": "git::WorktreeFromDefault",
+    },
   },
   {
     "context": "SettingsWindow",
@@ -1404,8 +1404,8 @@
       "ctrl-9": ["settings_editor::FocusFile", 8],
       "ctrl-0": ["settings_editor::FocusFile", 9],
       "cmd-{": "settings_editor::FocusPreviousFile",
-      "cmd-}": "settings_editor::FocusNextFile"
-    }
+      "cmd-}": "settings_editor::FocusNextFile",
+    },
   },
   {
     "context": "StashDiff > Editor",
@@ -1413,8 +1413,8 @@
     "bindings": {
       "ctrl-space": "git::ApplyCurrentStash",
       "ctrl-shift-space": "git::PopCurrentStash",
-      "ctrl-shift-backspace": "git::DropCurrentStash"
-    }
+      "ctrl-shift-backspace": "git::DropCurrentStash",
+    },
   },
   {
     "context": "SettingsWindow > NavigationMenu",
@@ -1429,22 +1429,22 @@
       "pageup": "settings_editor::FocusPreviousRootNavEntry",
       "pagedown": "settings_editor::FocusNextRootNavEntry",
       "home": "settings_editor::FocusFirstNavEntry",
-      "end": "settings_editor::FocusLastNavEntry"
-    }
+      "end": "settings_editor::FocusLastNavEntry",
+    },
   },
   {
     "context": "EditPredictionContext > Editor",
     "bindings": {
       "alt-left": "dev::EditPredictionContextGoBack",
-      "alt-right": "dev::EditPredictionContextGoForward"
-    }
+      "alt-right": "dev::EditPredictionContextGoForward",
+    },
   },
   {
     "context": "GitBranchSelector || (GitBranchSelector > Picker > Editor)",
     "use_key_equivalents": true,
     "bindings": {
       "cmd-shift-backspace": "branch_picker::DeleteBranch",
-      "cmd-shift-i": "branch_picker::FilterRemotes"
-    }
-  }
+      "cmd-shift-i": "branch_picker::FilterRemotes",
+    },
+  },
 ]

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -42,16 +42,16 @@
       "f11": "zed::ToggleFullScreen",
       "ctrl-shift-i": "edit_prediction::ToggleMenu",
       "shift-alt-l": "lsp_tool::ToggleMenu",
-      "ctrl-shift-alt-c": "editor::DisplayCursorNames"
-    }
+      "ctrl-shift-alt-c": "editor::DisplayCursorNames",
+    },
   },
   {
     "context": "Picker || menu",
     "use_key_equivalents": true,
     "bindings": {
       "up": "menu::SelectPrevious",
-      "down": "menu::SelectNext"
-    }
+      "down": "menu::SelectNext",
+    },
   },
   {
     "context": "Editor",
@@ -119,8 +119,8 @@
       "shift-f10": "editor::OpenContextMenu",
       "ctrl-alt-e": "editor::ToggleEditPrediction",
       "f9": "editor::ToggleBreakpoint",
-      "shift-f9": "editor::EditLogBreakpoint"
-    }
+      "shift-f9": "editor::EditLogBreakpoint",
+    },
   },
   {
     "context": "Editor && mode == full",
@@ -139,23 +139,23 @@
       "shift-alt-e": "editor::SelectEnclosingSymbol",
       "ctrl-shift-backspace": "editor::GoToPreviousChange",
       "ctrl-shift-alt-backspace": "editor::GoToNextChange",
-      "alt-enter": "editor::OpenSelectionsInMultibuffer"
-    }
+      "alt-enter": "editor::OpenSelectionsInMultibuffer",
+    },
   },
   {
     "context": "Editor && mode == full && edit_prediction",
     "use_key_equivalents": true,
     "bindings": {
       "alt-]": "editor::NextEditPrediction",
-      "alt-[": "editor::PreviousEditPrediction"
-    }
+      "alt-[": "editor::PreviousEditPrediction",
+    },
   },
   {
     "context": "Editor && !edit_prediction",
     "use_key_equivalents": true,
     "bindings": {
-      "alt-\\": "editor::ShowEditPrediction"
-    }
+      "alt-\\": "editor::ShowEditPrediction",
+    },
   },
   {
     "context": "Editor && mode == auto_height",
@@ -163,23 +163,23 @@
     "bindings": {
       "ctrl-enter": "editor::Newline",
       "shift-enter": "editor::Newline",
-      "ctrl-shift-enter": "editor::NewlineBelow"
-    }
+      "ctrl-shift-enter": "editor::NewlineBelow",
+    },
   },
   {
     "context": "Markdown",
     "use_key_equivalents": true,
     "bindings": {
-      "ctrl-c": "markdown::Copy"
-    }
+      "ctrl-c": "markdown::Copy",
+    },
   },
   {
     "context": "Editor && jupyter && !ContextEditor",
     "use_key_equivalents": true,
     "bindings": {
       "ctrl-shift-enter": "repl::Run",
-      "ctrl-alt-enter": "repl::RunInPlace"
-    }
+      "ctrl-alt-enter": "repl::RunInPlace",
+    },
   },
   {
     "context": "Editor && !agent_diff",
@@ -187,8 +187,8 @@
     "bindings": {
       "ctrl-k ctrl-r": "git::Restore",
       "alt-y": "git::StageAndNext",
-      "shift-alt-y": "git::UnstageAndNext"
-    }
+      "shift-alt-y": "git::UnstageAndNext",
+    },
   },
   {
     "context": "Editor && editor_agent_diff",
@@ -198,8 +198,8 @@
       "ctrl-n": "agent::Reject",
       "ctrl-shift-y": "agent::KeepAll",
       "ctrl-shift-n": "agent::RejectAll",
-      "ctrl-shift-r": "agent::OpenAgentDiff"
-    }
+      "ctrl-shift-r": "agent::OpenAgentDiff",
+    },
   },
   {
     "context": "AgentDiff",
@@ -208,8 +208,8 @@
       "ctrl-y": "agent::Keep",
       "ctrl-n": "agent::Reject",
       "ctrl-shift-y": "agent::KeepAll",
-      "ctrl-shift-n": "agent::RejectAll"
-    }
+      "ctrl-shift-n": "agent::RejectAll",
+    },
   },
   {
     "context": "ContextEditor > Editor",
@@ -225,8 +225,8 @@
       "ctrl-k c": "assistant::CopyCode",
       "ctrl-g": "search::SelectNextMatch",
       "ctrl-shift-g": "search::SelectPreviousMatch",
-      "ctrl-k l": "agent::OpenRulesLibrary"
-    }
+      "ctrl-k l": "agent::OpenRulesLibrary",
+    },
   },
   {
     "context": "AgentPanel",
@@ -251,38 +251,38 @@
       "alt-enter": "agent::ContinueWithBurnMode",
       "shift-alt-a": "agent::AllowOnce",
       "ctrl-alt-y": "agent::AllowAlways",
-      "shift-alt-z": "agent::RejectOnce"
-    }
+      "shift-alt-z": "agent::RejectOnce",
+    },
   },
   {
     "context": "AgentPanel > NavigationMenu",
     "use_key_equivalents": true,
     "bindings": {
-      "shift-backspace": "agent::DeleteRecentlyOpenThread"
-    }
+      "shift-backspace": "agent::DeleteRecentlyOpenThread",
+    },
   },
   {
     "context": "AgentPanel > Markdown",
     "use_key_equivalents": true,
     "bindings": {
-      "ctrl-c": "markdown::CopyAsMarkdown"
-    }
+      "ctrl-c": "markdown::CopyAsMarkdown",
+    },
   },
   {
     "context": "AgentPanel && text_thread",
     "use_key_equivalents": true,
     "bindings": {
       "ctrl-n": "agent::NewTextThread",
-      "ctrl-alt-t": "agent::NewThread"
-    }
+      "ctrl-alt-t": "agent::NewThread",
+    },
   },
   {
     "context": "AgentPanel && acp_thread",
     "use_key_equivalents": true,
     "bindings": {
       "ctrl-n": "agent::NewExternalAgentThread",
-      "ctrl-alt-t": "agent::NewThread"
-    }
+      "ctrl-alt-t": "agent::NewThread",
+    },
   },
   {
     "context": "MessageEditor && !Picker > Editor && !use_modifier_to_send",
@@ -293,8 +293,8 @@
       "ctrl-i": "agent::ToggleProfileSelector",
       "ctrl-shift-r": "agent::OpenAgentDiff",
       "ctrl-shift-y": "agent::KeepAll",
-      "ctrl-shift-n": "agent::RejectAll"
-    }
+      "ctrl-shift-n": "agent::RejectAll",
+    },
   },
   {
     "context": "MessageEditor && !Picker > Editor && use_modifier_to_send",
@@ -305,8 +305,8 @@
       "ctrl-i": "agent::ToggleProfileSelector",
       "ctrl-shift-r": "agent::OpenAgentDiff",
       "ctrl-shift-y": "agent::KeepAll",
-      "ctrl-shift-n": "agent::RejectAll"
-    }
+      "ctrl-shift-n": "agent::RejectAll",
+    },
   },
   {
     "context": "EditMessageEditor > Editor",
@@ -314,8 +314,8 @@
     "bindings": {
       "escape": "menu::Cancel",
       "enter": "menu::Confirm",
-      "alt-enter": "editor::Newline"
-    }
+      "alt-enter": "editor::Newline",
+    },
   },
   {
     "context": "AgentFeedbackMessageEditor > Editor",
@@ -323,14 +323,14 @@
     "bindings": {
       "escape": "menu::Cancel",
       "enter": "menu::Confirm",
-      "alt-enter": "editor::Newline"
-    }
+      "alt-enter": "editor::Newline",
+    },
   },
   {
     "context": "AcpThread > ModeSelector",
     "bindings": {
-      "ctrl-enter": "menu::Confirm"
-    }
+      "ctrl-enter": "menu::Confirm",
+    },
   },
   {
     "context": "AcpThread > Editor && !use_modifier_to_send",
@@ -340,8 +340,8 @@
       "ctrl-shift-r": "agent::OpenAgentDiff",
       "ctrl-shift-y": "agent::KeepAll",
       "ctrl-shift-n": "agent::RejectAll",
-      "shift-tab": "agent::CycleModeSelector"
-    }
+      "shift-tab": "agent::CycleModeSelector",
+    },
   },
   {
     "context": "AcpThread > Editor && use_modifier_to_send",
@@ -351,15 +351,15 @@
       "ctrl-shift-r": "agent::OpenAgentDiff",
       "ctrl-shift-y": "agent::KeepAll",
       "ctrl-shift-n": "agent::RejectAll",
-      "shift-tab": "agent::CycleModeSelector"
-    }
+      "shift-tab": "agent::CycleModeSelector",
+    },
   },
   {
     "context": "ThreadHistory",
     "use_key_equivalents": true,
     "bindings": {
-      "backspace": "agent::RemoveSelectedThread"
-    }
+      "backspace": "agent::RemoveSelectedThread",
+    },
   },
   {
     "context": "RulesLibrary",
@@ -367,8 +367,8 @@
     "bindings": {
       "ctrl-n": "rules_library::NewRule",
       "ctrl-shift-s": "rules_library::ToggleDefaultRule",
-      "ctrl-w": "workspace::CloseWindow"
-    }
+      "ctrl-w": "workspace::CloseWindow",
+    },
   },
   {
     "context": "BufferSearchBar",
@@ -381,24 +381,24 @@
       "alt-enter": "search::SelectAllMatches",
       "ctrl-f": "search::FocusSearch",
       "ctrl-h": "search::ToggleReplace",
-      "ctrl-l": "search::ToggleSelection"
-    }
+      "ctrl-l": "search::ToggleSelection",
+    },
   },
   {
     "context": "BufferSearchBar && in_replace > Editor",
     "use_key_equivalents": true,
     "bindings": {
       "enter": "search::ReplaceNext",
-      "ctrl-enter": "search::ReplaceAll"
-    }
+      "ctrl-enter": "search::ReplaceAll",
+    },
   },
   {
     "context": "BufferSearchBar && !in_replace > Editor",
     "use_key_equivalents": true,
     "bindings": {
       "up": "search::PreviousHistoryQuery",
-      "down": "search::NextHistoryQuery"
-    }
+      "down": "search::NextHistoryQuery",
+    },
   },
   {
     "context": "ProjectSearchBar",
@@ -407,24 +407,24 @@
       "escape": "project_search::ToggleFocus",
       "ctrl-shift-f": "search::FocusSearch",
       "ctrl-shift-h": "search::ToggleReplace",
-      "alt-r": "search::ToggleRegex" // vscode
-    }
+      "alt-r": "search::ToggleRegex", // vscode
+    },
   },
   {
     "context": "ProjectSearchBar > Editor",
     "use_key_equivalents": true,
     "bindings": {
       "up": "search::PreviousHistoryQuery",
-      "down": "search::NextHistoryQuery"
-    }
+      "down": "search::NextHistoryQuery",
+    },
   },
   {
     "context": "ProjectSearchBar && in_replace > Editor",
     "use_key_equivalents": true,
     "bindings": {
       "enter": "search::ReplaceNext",
-      "ctrl-alt-enter": "search::ReplaceAll"
-    }
+      "ctrl-alt-enter": "search::ReplaceAll",
+    },
   },
   {
     "context": "ProjectSearchView",
@@ -432,8 +432,8 @@
     "bindings": {
       "escape": "project_search::ToggleFocus",
       "ctrl-shift-h": "search::ToggleReplace",
-      "alt-r": "search::ToggleRegex" // vscode
-    }
+      "alt-r": "search::ToggleRegex", // vscode
+    },
   },
   {
     "context": "Pane",
@@ -480,8 +480,8 @@
       "shift-enter": "project_search::ToggleAllSearchResults",
       "alt-r": "search::ToggleRegex",
       // "ctrl-shift-alt-x": "search::ToggleRegex",
-      "ctrl-k shift-enter": "pane::TogglePinTab"
-    }
+      "ctrl-k shift-enter": "pane::TogglePinTab",
+    },
   },
   // Bindings from VS Code
   {
@@ -542,31 +542,31 @@
       "ctrl-\\": "pane::SplitRight",
       "alt-.": "editor::GoToHunk",
       "alt-,": "editor::GoToPreviousHunk",
-    }
+    },
   },
   {
     "context": "Editor && extension == md",
     "use_key_equivalents": true,
     "bindings": {
       "ctrl-k v": "markdown::OpenPreviewToTheSide",
-      "ctrl-shift-v": "markdown::OpenPreview"
-    }
+      "ctrl-shift-v": "markdown::OpenPreview",
+    },
   },
   {
     "context": "Editor && extension == svg",
     "use_key_equivalents": true,
     "bindings": {
       "ctrl-k v": "svg::OpenPreviewToTheSide",
-      "ctrl-shift-v": "svg::OpenPreview"
-    }
+      "ctrl-shift-v": "svg::OpenPreview",
+    },
   },
   {
     "context": "Editor && mode == full",
     "use_key_equivalents": true,
     "bindings": {
       "ctrl-shift-o": "outline::Toggle",
-      "ctrl-g": "go_to_line::Toggle"
-    }
+      "ctrl-g": "go_to_line::Toggle",
+    },
   },
   {
     "context": "Workspace",
@@ -650,22 +650,22 @@
       // "foo-bar": ["task::Spawn", { "task_tag": "MyTag" }],
       "f5": "debugger::Rerun",
       "ctrl-f4": "workspace::CloseActiveDock",
-      "ctrl-w": "workspace::CloseActiveDock"
-    }
+      "ctrl-w": "workspace::CloseActiveDock",
+    },
   },
   {
     "context": "Workspace && debugger_running",
     "use_key_equivalents": true,
     "bindings": {
-      "f5": "zed::NoAction"
-    }
+      "f5": "zed::NoAction",
+    },
   },
   {
     "context": "Workspace && debugger_stopped",
     "use_key_equivalents": true,
     "bindings": {
-      "f5": "debugger::Continue"
-    }
+      "f5": "debugger::Continue",
+    },
   },
   {
     "context": "ApplicationMenu",
@@ -673,8 +673,8 @@
     "bindings": {
       "f10": "menu::Cancel",
       "left": "app_menu::ActivateMenuLeft",
-      "right": "app_menu::ActivateMenuRight"
-    }
+      "right": "app_menu::ActivateMenuRight",
+    },
   },
   // Bindings from Sublime Text
   {
@@ -691,8 +691,8 @@
       "ctrl-alt-left": "editor::MoveToPreviousSubwordStart",
       "ctrl-alt-right": "editor::MoveToNextSubwordEnd",
       "ctrl-shift-alt-left": "editor::SelectToPreviousSubwordStart",
-      "ctrl-shift-alt-right": "editor::SelectToNextSubwordEnd"
-    }
+      "ctrl-shift-alt-right": "editor::SelectToNextSubwordEnd",
+    },
   },
   // Bindings from Atom
   {
@@ -702,16 +702,16 @@
       "ctrl-k up": "pane::SplitUp",
       "ctrl-k down": "pane::SplitDown",
       "ctrl-k left": "pane::SplitLeft",
-      "ctrl-k right": "pane::SplitRight"
-    }
+      "ctrl-k right": "pane::SplitRight",
+    },
   },
   // Bindings that should be unified with bindings for more general actions
   {
     "context": "Editor && renaming",
     "use_key_equivalents": true,
     "bindings": {
-      "enter": "editor::ConfirmRename"
-    }
+      "enter": "editor::ConfirmRename",
+    },
   },
   {
     "context": "Editor && showing_completions",
@@ -719,22 +719,22 @@
     "bindings": {
       "enter": "editor::ConfirmCompletion",
       "shift-enter": "editor::ConfirmCompletionReplace",
-      "tab": "editor::ComposeCompletion"
-    }
+      "tab": "editor::ComposeCompletion",
+    },
   },
   {
     "context": "Editor && in_snippet && has_next_tabstop && !showing_completions",
     "use_key_equivalents": true,
     "bindings": {
-      "tab": "editor::NextSnippetTabstop"
-    }
+      "tab": "editor::NextSnippetTabstop",
+    },
   },
   {
     "context": "Editor && in_snippet && has_previous_tabstop && !showing_completions",
     "use_key_equivalents": true,
     "bindings": {
-      "shift-tab": "editor::PreviousSnippetTabstop"
-    }
+      "shift-tab": "editor::PreviousSnippetTabstop",
+    },
   },
   // Bindings for accepting edit predictions
   //
@@ -747,8 +747,8 @@
       "alt-tab": "editor::AcceptEditPrediction",
       "alt-l": "editor::AcceptEditPrediction",
       "tab": "editor::AcceptEditPrediction",
-      "alt-right": "editor::AcceptPartialEditPrediction"
-    }
+      "alt-right": "editor::AcceptPartialEditPrediction",
+    },
   },
   {
     "context": "Editor && edit_prediction_conflict",
@@ -756,15 +756,15 @@
     "bindings": {
       "alt-tab": "editor::AcceptEditPrediction",
       "alt-l": "editor::AcceptEditPrediction",
-      "alt-right": "editor::AcceptPartialEditPrediction"
-    }
+      "alt-right": "editor::AcceptPartialEditPrediction",
+    },
   },
   {
     "context": "Editor && showing_code_actions",
     "use_key_equivalents": true,
     "bindings": {
-      "enter": "editor::ConfirmCodeAction"
-    }
+      "enter": "editor::ConfirmCodeAction",
+    },
   },
   {
     "context": "Editor && (showing_code_actions || showing_completions)",
@@ -775,16 +775,16 @@
       "ctrl-n": "editor::ContextMenuNext",
       "down": "editor::ContextMenuNext",
       "pageup": "editor::ContextMenuFirst",
-      "pagedown": "editor::ContextMenuLast"
-    }
+      "pagedown": "editor::ContextMenuLast",
+    },
   },
   {
     "context": "Editor && showing_signature_help && !showing_completions",
     "use_key_equivalents": true,
     "bindings": {
       "up": "editor::SignatureHelpPrevious",
-      "down": "editor::SignatureHelpNext"
-    }
+      "down": "editor::SignatureHelpNext",
+    },
   },
   // Custom bindings
   {
@@ -792,15 +792,15 @@
     "bindings": {
       "ctrl-shift-alt-f": "workspace::FollowNextCollaborator",
       // Only available in debug builds: opens an element inspector for development.
-      "shift-alt-i": "dev::ToggleInspector"
-    }
+      "shift-alt-i": "dev::ToggleInspector",
+    },
   },
   {
     "context": "!Terminal",
     "use_key_equivalents": true,
     "bindings": {
-      "ctrl-shift-c": "collab_panel::ToggleFocus"
-    }
+      "ctrl-shift-c": "collab_panel::ToggleFocus",
+    },
   },
   {
     "context": "!ContextEditor > Editor && mode == full",
@@ -813,8 +813,8 @@
       "ctrl-f8": "editor::GoToHunk",
       "ctrl-shift-f8": "editor::GoToPreviousHunk",
       "ctrl-enter": "assistant::InlineAssist",
-      "ctrl-shift-;": "editor::ToggleInlayHints"
-    }
+      "ctrl-shift-;": "editor::ToggleInlayHints",
+    },
   },
   {
     "context": "PromptEditor",
@@ -823,8 +823,8 @@
       "ctrl-[": "agent::CyclePreviousInlineAssist",
       "ctrl-]": "agent::CycleNextInlineAssist",
       "ctrl-shift-enter": "inline_assistant::ThumbsUpResult",
-      "ctrl-shift-delete": "inline_assistant::ThumbsDownResult"
-    }
+      "ctrl-shift-delete": "inline_assistant::ThumbsDownResult",
+    },
   },
   {
     "context": "Prompt",
@@ -833,15 +833,15 @@
       "left": "menu::SelectPrevious",
       "right": "menu::SelectNext",
       "h": "menu::SelectPrevious",
-      "l": "menu::SelectNext"
-    }
+      "l": "menu::SelectNext",
+    },
   },
   {
     "context": "ProjectSearchBar && !in_replace",
     "use_key_equivalents": true,
     "bindings": {
-      "ctrl-enter": "project_search::SearchInNew"
-    }
+      "ctrl-enter": "project_search::SearchInNew",
+    },
   },
   {
     "context": "OutlinePanel && not_editing",
@@ -856,8 +856,8 @@
       "shift-down": "menu::SelectNext",
       "shift-up": "menu::SelectPrevious",
       "alt-enter": "editor::OpenExcerpts",
-      "ctrl-alt-enter": "editor::OpenExcerptsSplit"
-    }
+      "ctrl-alt-enter": "editor::OpenExcerptsSplit",
+    },
   },
   {
     "context": "ProjectPanel",
@@ -888,15 +888,15 @@
       "ctrl-k ctrl-shift-f": "project_panel::NewSearchInDirectory",
       "shift-down": "menu::SelectNext",
       "shift-up": "menu::SelectPrevious",
-      "escape": "menu::Cancel"
-    }
+      "escape": "menu::Cancel",
+    },
   },
   {
     "context": "ProjectPanel && not_editing",
     "use_key_equivalents": true,
     "bindings": {
-      "space": "project_panel::Open"
-    }
+      "space": "project_panel::Open",
+    },
   },
   {
     "context": "GitPanel && ChangesList",
@@ -917,15 +917,15 @@
       "backspace": ["git::RestoreFile", { "skip_prompt": false }],
       "shift-delete": ["git::RestoreFile", { "skip_prompt": false }],
       "ctrl-backspace": ["git::RestoreFile", { "skip_prompt": false }],
-      "ctrl-delete": ["git::RestoreFile", { "skip_prompt": false }]
-    }
+      "ctrl-delete": ["git::RestoreFile", { "skip_prompt": false }],
+    },
   },
   {
     "context": "GitPanel && CommitEditor",
     "use_key_equivalents": true,
     "bindings": {
-      "escape": "git::Cancel"
-    }
+      "escape": "git::Cancel",
+    },
   },
   {
     "context": "GitCommit > Editor",
@@ -935,8 +935,8 @@
       "enter": "editor::Newline",
       "ctrl-enter": "git::Commit",
       "ctrl-shift-enter": "git::Amend",
-      "alt-l": "git::GenerateCommitMessage"
-    }
+      "alt-l": "git::GenerateCommitMessage",
+    },
   },
   {
     "context": "GitPanel",
@@ -953,8 +953,8 @@
       "ctrl-space": "git::StageAll",
       "ctrl-shift-space": "git::UnstageAll",
       "ctrl-enter": "git::Commit",
-      "ctrl-shift-enter": "git::Amend"
-    }
+      "ctrl-shift-enter": "git::Amend",
+    },
   },
   {
     "context": "GitDiff > Editor",
@@ -963,15 +963,15 @@
       "ctrl-enter": "git::Commit",
       "ctrl-shift-enter": "git::Amend",
       "ctrl-space": "git::StageAll",
-      "ctrl-shift-space": "git::UnstageAll"
-    }
+      "ctrl-shift-space": "git::UnstageAll",
+    },
   },
   {
     "context": "AskPass > Editor",
     "use_key_equivalents": true,
     "bindings": {
-      "enter": "menu::Confirm"
-    }
+      "enter": "menu::Confirm",
+    },
   },
   {
     "context": "CommitEditor > Editor",
@@ -984,8 +984,8 @@
       "ctrl-enter": "git::Commit",
       "ctrl-shift-enter": "git::Amend",
       "alt-up": "git_panel::FocusChanges",
-      "alt-l": "git::GenerateCommitMessage"
-    }
+      "alt-l": "git::GenerateCommitMessage",
+    },
   },
   {
     "context": "DebugPanel",
@@ -993,8 +993,8 @@
     "bindings": {
       "ctrl-t": "debugger::ToggleThreadPicker",
       "ctrl-i": "debugger::ToggleSessionPicker",
-      "shift-alt-escape": "debugger::ToggleExpandItem"
-    }
+      "shift-alt-escape": "debugger::ToggleExpandItem",
+    },
   },
   {
     "context": "VariableList",
@@ -1007,8 +1007,8 @@
       "ctrl-alt-c": "variable_list::CopyVariableName",
       "delete": "variable_list::RemoveWatch",
       "backspace": "variable_list::RemoveWatch",
-      "alt-enter": "variable_list::AddWatch"
-    }
+      "alt-enter": "variable_list::AddWatch",
+    },
   },
   {
     "context": "BreakpointList",
@@ -1017,16 +1017,16 @@
       "space": "debugger::ToggleEnableBreakpoint",
       "backspace": "debugger::UnsetBreakpoint",
       "left": "debugger::PreviousBreakpointProperty",
-      "right": "debugger::NextBreakpointProperty"
-    }
+      "right": "debugger::NextBreakpointProperty",
+    },
   },
   {
     "context": "CollabPanel && not_editing",
     "use_key_equivalents": true,
     "bindings": {
       "ctrl-backspace": "collab_panel::Remove",
-      "space": "menu::Confirm"
-    }
+      "space": "menu::Confirm",
+    },
   },
   {
     "context": "CollabPanel",
@@ -1034,22 +1034,22 @@
     "bindings": {
       "alt-up": "collab_panel::MoveChannelUp",
       "alt-down": "collab_panel::MoveChannelDown",
-      "alt-enter": "collab_panel::OpenSelectedChannelNotes"
-    }
+      "alt-enter": "collab_panel::OpenSelectedChannelNotes",
+    },
   },
   {
     "context": "(CollabPanel && editing) > Editor",
     "use_key_equivalents": true,
     "bindings": {
-      "space": "collab_panel::InsertSpace"
-    }
+      "space": "collab_panel::InsertSpace",
+    },
   },
   {
     "context": "ChannelModal",
     "use_key_equivalents": true,
     "bindings": {
-      "tab": "channel_modal::ToggleMode"
-    }
+      "tab": "channel_modal::ToggleMode",
+    },
   },
   {
     "context": "Picker > Editor",
@@ -1059,22 +1059,22 @@
       "up": "menu::SelectPrevious",
       "down": "menu::SelectNext",
       "tab": "picker::ConfirmCompletion",
-      "alt-enter": ["picker::ConfirmInput", { "secondary": false }]
-    }
+      "alt-enter": ["picker::ConfirmInput", { "secondary": false }],
+    },
   },
   {
     "context": "ChannelModal > Picker > Editor",
     "use_key_equivalents": true,
     "bindings": {
-      "tab": "channel_modal::ToggleMode"
-    }
+      "tab": "channel_modal::ToggleMode",
+    },
   },
   {
     "context": "ToolchainSelector",
     "use_key_equivalents": true,
     "bindings": {
-      "ctrl-shift-a": "toolchain::AddToolchain"
-    }
+      "ctrl-shift-a": "toolchain::AddToolchain",
+    },
   },
   {
     "context": "FileFinder || (FileFinder > Picker > Editor)",
@@ -1082,8 +1082,8 @@
     "bindings": {
       "ctrl-p": "file_finder::Toggle",
       "ctrl-shift-a": "file_finder::ToggleSplitMenu",
-      "ctrl-shift-i": "file_finder::ToggleFilterMenu"
-    }
+      "ctrl-shift-i": "file_finder::ToggleFilterMenu",
+    },
   },
   {
     "context": "FileFinder || (FileFinder > Picker > Editor) || (FileFinder > Picker > menu)",
@@ -1093,8 +1093,8 @@
       "ctrl-j": "pane::SplitDown",
       "ctrl-k": "pane::SplitUp",
       "ctrl-h": "pane::SplitLeft",
-      "ctrl-l": "pane::SplitRight"
-    }
+      "ctrl-l": "pane::SplitRight",
+    },
   },
   {
     "context": "TabSwitcher",
@@ -1103,16 +1103,16 @@
       "ctrl-shift-tab": "menu::SelectPrevious",
       "ctrl-up": "menu::SelectPrevious",
       "ctrl-down": "menu::SelectNext",
-      "ctrl-backspace": "tab_switcher::CloseSelectedItem"
-    }
+      "ctrl-backspace": "tab_switcher::CloseSelectedItem",
+    },
   },
   {
     "context": "StashList || (StashList > Picker > Editor)",
     "use_key_equivalents": true,
     "bindings": {
       "ctrl-shift-backspace": "stash_picker::DropStashItem",
-      "ctrl-shift-v": "stash_picker::ShowStashItem"
-    }
+      "ctrl-shift-v": "stash_picker::ShowStashItem",
+    },
   },
   {
     "context": "Terminal",
@@ -1159,21 +1159,21 @@
       "ctrl-shift-r": "terminal::RerunTask",
       "ctrl-alt-r": "terminal::RerunTask",
       "alt-t": "terminal::RerunTask",
-      "ctrl-shift-5": "pane::SplitRight"
-    }
+      "ctrl-shift-5": "pane::SplitRight",
+    },
   },
   {
     "context": "Terminal && selection",
     "bindings": {
-      "ctrl-c": "terminal::Copy"
-    }
+      "ctrl-c": "terminal::Copy",
+    },
   },
   {
     "context": "ZedPredictModal",
     "use_key_equivalents": true,
     "bindings": {
-      "escape": "menu::Cancel"
-    }
+      "escape": "menu::Cancel",
+    },
   },
   {
     "context": "ConfigureContextServerModal > Editor",
@@ -1181,45 +1181,45 @@
     "bindings": {
       "escape": "menu::Cancel",
       "enter": "editor::Newline",
-      "ctrl-enter": "menu::Confirm"
-    }
+      "ctrl-enter": "menu::Confirm",
+    },
   },
   {
     "context": "ContextServerToolsModal",
     "use_key_equivalents": true,
     "bindings": {
-      "escape": "menu::Cancel"
-    }
+      "escape": "menu::Cancel",
+    },
   },
   {
     "context": "OnboardingAiConfigurationModal",
     "use_key_equivalents": true,
     "bindings": {
-      "escape": "menu::Cancel"
-    }
+      "escape": "menu::Cancel",
+    },
   },
   {
     "context": "Diagnostics",
     "use_key_equivalents": true,
     "bindings": {
-      "ctrl-r": "diagnostics::ToggleDiagnosticsRefresh"
-    }
+      "ctrl-r": "diagnostics::ToggleDiagnosticsRefresh",
+    },
   },
   {
     "context": "DebugConsole > Editor",
     "use_key_equivalents": true,
     "bindings": {
       "enter": "menu::Confirm",
-      "alt-enter": "console::WatchExpression"
-    }
+      "alt-enter": "console::WatchExpression",
+    },
   },
   {
     "context": "RunModal",
     "use_key_equivalents": true,
     "bindings": {
       "ctrl-tab": "pane::ActivateNextItem",
-      "ctrl-shift-tab": "pane::ActivatePreviousItem"
-    }
+      "ctrl-shift-tab": "pane::ActivatePreviousItem",
+    },
   },
   {
     "context": "MarkdownPreview",
@@ -1230,8 +1230,8 @@
       "up": "markdown::ScrollUp",
       "down": "markdown::ScrollDown",
       "alt-up": "markdown::ScrollUpByItem",
-      "alt-down": "markdown::ScrollDownByItem"
-    }
+      "alt-down": "markdown::ScrollDownByItem",
+    },
   },
   {
     "context": "KeymapEditor",
@@ -1244,8 +1244,8 @@
       "alt-enter": "keymap_editor::CreateBinding",
       "ctrl-c": "keymap_editor::CopyAction",
       "ctrl-shift-c": "keymap_editor::CopyContext",
-      "ctrl-t": "keymap_editor::ShowMatchingKeybinds"
-    }
+      "ctrl-t": "keymap_editor::ShowMatchingKeybinds",
+    },
   },
   {
     "context": "KeystrokeInput",
@@ -1253,24 +1253,24 @@
     "bindings": {
       "enter": "keystroke_input::StartRecording",
       "escape escape escape": "keystroke_input::StopRecording",
-      "delete": "keystroke_input::ClearKeystrokes"
-    }
+      "delete": "keystroke_input::ClearKeystrokes",
+    },
   },
   {
     "context": "KeybindEditorModal",
     "use_key_equivalents": true,
     "bindings": {
       "ctrl-enter": "menu::Confirm",
-      "escape": "menu::Cancel"
-    }
+      "escape": "menu::Cancel",
+    },
   },
   {
     "context": "KeybindEditorModal > Editor",
     "use_key_equivalents": true,
     "bindings": {
       "up": "menu::SelectPrevious",
-      "down": "menu::SelectNext"
-    }
+      "down": "menu::SelectNext",
+    },
   },
   {
     "context": "Onboarding",
@@ -1282,8 +1282,8 @@
       "ctrl-0": ["zed::ResetUiFontSize", { "persist": false }],
       "ctrl-enter": "onboarding::Finish",
       "alt-shift-l": "onboarding::SignIn",
-      "shift-alt-a": "onboarding::OpenAccount"
-    }
+      "shift-alt-a": "onboarding::OpenAccount",
+    },
   },
   {
     "context": "Welcome",
@@ -1292,16 +1292,16 @@
       "ctrl-=": ["zed::IncreaseUiFontSize", { "persist": false }],
       "ctrl-+": ["zed::IncreaseUiFontSize", { "persist": false }],
       "ctrl--": ["zed::DecreaseUiFontSize", { "persist": false }],
-      "ctrl-0": ["zed::ResetUiFontSize", { "persist": false }]
-    }
+      "ctrl-0": ["zed::ResetUiFontSize", { "persist": false }],
+    },
   },
   {
     "context": "GitWorktreeSelector || (GitWorktreeSelector > Picker > Editor)",
     "use_key_equivalents": true,
     "bindings": {
       "ctrl-shift-space": "git::WorktreeFromDefaultOnWindow",
-      "ctrl-space": "git::WorktreeFromDefault"
-    }
+      "ctrl-space": "git::WorktreeFromDefault",
+    },
   },
   {
     "context": "SettingsWindow",
@@ -1326,8 +1326,8 @@
       "ctrl-9": ["settings_editor::FocusFile", 8],
       "ctrl-0": ["settings_editor::FocusFile", 9],
       "ctrl-pageup": "settings_editor::FocusPreviousFile",
-      "ctrl-pagedown": "settings_editor::FocusNextFile"
-    }
+      "ctrl-pagedown": "settings_editor::FocusNextFile",
+    },
   },
   {
     "context": "StashDiff > Editor",
@@ -1335,8 +1335,8 @@
     "bindings": {
       "ctrl-space": "git::ApplyCurrentStash",
       "ctrl-shift-space": "git::PopCurrentStash",
-      "ctrl-shift-backspace": "git::DropCurrentStash"
-    }
+      "ctrl-shift-backspace": "git::DropCurrentStash",
+    },
   },
   {
     "context": "SettingsWindow > NavigationMenu",
@@ -1351,22 +1351,22 @@
       "pageup": "settings_editor::FocusPreviousRootNavEntry",
       "pagedown": "settings_editor::FocusNextRootNavEntry",
       "home": "settings_editor::FocusFirstNavEntry",
-      "end": "settings_editor::FocusLastNavEntry"
-    }
+      "end": "settings_editor::FocusLastNavEntry",
+    },
   },
   {
     "context": "EditPredictionContext > Editor",
     "bindings": {
       "alt-left": "dev::EditPredictionContextGoBack",
-      "alt-right": "dev::EditPredictionContextGoForward"
-    }
+      "alt-right": "dev::EditPredictionContextGoForward",
+    },
   },
   {
     "context": "GitBranchSelector || (GitBranchSelector > Picker > Editor)",
     "use_key_equivalents": true,
     "bindings": {
       "ctrl-shift-backspace": "branch_picker::DeleteBranch",
-      "ctrl-shift-i": "branch_picker::FilterRemotes"
-    }
-  }
+      "ctrl-shift-i": "branch_picker::FilterRemotes",
+    },
+  },
 ]

--- a/assets/keymaps/initial.json
+++ b/assets/keymaps/initial.json
@@ -10,12 +10,12 @@
     "context": "Workspace",
     "bindings": {
       // "shift shift": "file_finder::Toggle"
-    }
+    },
   },
   {
     "context": "Editor && vim_mode == insert",
     "bindings": {
       // "j k": "vim::NormalBefore"
-    }
-  }
+    },
+  },
 ]

--- a/assets/keymaps/linux/atom.json
+++ b/assets/keymaps/linux/atom.json
@@ -4,15 +4,15 @@
     "bindings": {
       "ctrl-shift-f5": "workspace::Reload", // window:reload
       "ctrl-k ctrl-n": "workspace::ActivatePreviousPane", // window:focus-next-pane
-      "ctrl-k ctrl-p": "workspace::ActivateNextPane" // window:focus-previous-pane
-    }
+      "ctrl-k ctrl-p": "workspace::ActivateNextPane", // window:focus-previous-pane
+    },
   },
   {
     "context": "Editor",
     "bindings": {
       "ctrl-k ctrl-u": "editor::ConvertToUpperCase", // editor:upper-case
-      "ctrl-k ctrl-l": "editor::ConvertToLowerCase" // editor:lower-case
-    }
+      "ctrl-k ctrl-l": "editor::ConvertToLowerCase", // editor:lower-case
+    },
   },
   {
     "context": "Editor && mode == full",
@@ -32,8 +32,8 @@
       "ctrl-down": "editor::MoveLineDown", // editor:move-line-down
       "ctrl-\\": "workspace::ToggleLeftDock", // tree-view:toggle
       "ctrl-shift-m": "markdown::OpenPreviewToTheSide", // markdown-preview:toggle
-      "ctrl-r": "outline::Toggle" // symbols-view:toggle-project-symbols
-    }
+      "ctrl-r": "outline::Toggle", // symbols-view:toggle-project-symbols
+    },
   },
   {
     "context": "BufferSearchBar",
@@ -41,8 +41,8 @@
       "f3": ["editor::SelectNext", { "replace_newest": true }], // find-and-replace:find-next
       "shift-f3": ["editor::SelectPrevious", { "replace_newest": true }], //find-and-replace:find-previous
       "ctrl-f3": "search::SelectNextMatch", // find-and-replace:find-next-selected
-      "ctrl-shift-f3": "search::SelectPreviousMatch" // find-and-replace:find-previous-selected
-    }
+      "ctrl-shift-f3": "search::SelectPreviousMatch", // find-and-replace:find-previous-selected
+    },
   },
   {
     "context": "Workspace",
@@ -50,8 +50,8 @@
       "ctrl-\\": "workspace::ToggleLeftDock", // tree-view:toggle
       "ctrl-k ctrl-b": "workspace::ToggleLeftDock", // tree-view:toggle
       "ctrl-t": "file_finder::Toggle", // fuzzy-finder:toggle-file-finder
-      "ctrl-r": "project_symbols::Toggle" // symbols-view:toggle-project-symbols
-    }
+      "ctrl-r": "project_symbols::Toggle", // symbols-view:toggle-project-symbols
+    },
   },
   {
     "context": "Pane",
@@ -65,8 +65,8 @@
       "ctrl-6": ["pane::ActivateItem", 5], // tree-view:open-selected-entry-in-pane-6
       "ctrl-7": ["pane::ActivateItem", 6], // tree-view:open-selected-entry-in-pane-7
       "ctrl-8": ["pane::ActivateItem", 7], // tree-view:open-selected-entry-in-pane-8
-      "ctrl-9": ["pane::ActivateItem", 8] // tree-view:open-selected-entry-in-pane-9
-    }
+      "ctrl-9": ["pane::ActivateItem", 8], // tree-view:open-selected-entry-in-pane-9
+    },
   },
   {
     "context": "ProjectPanel",
@@ -75,8 +75,8 @@
       "backspace": ["project_panel::Trash", { "skip_prompt": false }],
       "ctrl-x": "project_panel::Cut", // tree-view:cut
       "ctrl-c": "project_panel::Copy", // tree-view:copy
-      "ctrl-v": "project_panel::Paste" // tree-view:paste
-    }
+      "ctrl-v": "project_panel::Paste", // tree-view:paste
+    },
   },
   {
     "context": "ProjectPanel && not_editing",
@@ -90,7 +90,7 @@
       "d": "project_panel::Duplicate", // tree-view:duplicate
       "home": "menu::SelectFirst", // core:move-to-top
       "end": "menu::SelectLast", // core:move-to-bottom
-      "shift-a": "project_panel::NewDirectory" // tree-view:add-folder
-    }
-  }
+      "shift-a": "project_panel::NewDirectory", // tree-view:add-folder
+    },
+  },
 ]

--- a/assets/keymaps/linux/cursor.json
+++ b/assets/keymaps/linux/cursor.json
@@ -8,8 +8,8 @@
       "ctrl-shift-i": "agent::ToggleFocus",
       "ctrl-l": "agent::ToggleFocus",
       "ctrl-shift-l": "agent::ToggleFocus",
-      "ctrl-shift-j": "agent::OpenSettings"
-    }
+      "ctrl-shift-j": "agent::OpenSettings",
+    },
   },
   {
     "context": "Editor && mode == full",
@@ -20,18 +20,18 @@
       "ctrl-shift-l": "agent::AddSelectionToThread", // In cursor uses "Ask" mode
       "ctrl-l": "agent::AddSelectionToThread", // In cursor uses "Agent" mode
       "ctrl-k": "assistant::InlineAssist",
-      "ctrl-shift-k": "assistant::InsertIntoEditor"
-    }
+      "ctrl-shift-k": "assistant::InsertIntoEditor",
+    },
   },
   {
     "context": "InlineAssistEditor",
     "use_key_equivalents": true,
     "bindings": {
-      "ctrl-shift-backspace": "editor::Cancel"
+      "ctrl-shift-backspace": "editor::Cancel",
       // "alt-enter": // Quick Question
       // "ctrl-shift-enter": // Full File Context
       // "ctrl-shift-k": // Toggle input focus (editor <> inline assist)
-    }
+    },
   },
   {
     "context": "AgentPanel || ContextEditor || (MessageEditor > Editor)",
@@ -47,7 +47,7 @@
       "ctrl-shift-backspace": "editor::Cancel",
       "ctrl-r": "agent::NewThread",
       "ctrl-shift-v": "editor::Paste",
-      "ctrl-shift-k": "assistant::InsertIntoEditor"
+      "ctrl-shift-k": "assistant::InsertIntoEditor",
       // "escape": "agent::ToggleFocus"
       ///// Enable when Zed supports multiple thread tabs
       // "ctrl-t": // new thread tab
@@ -56,28 +56,28 @@
       ///// Enable if Zed adds support for keyboard navigation of thread elements
       // "tab": // cycle to next message
       // "shift-tab": // cycle to previous message
-    }
+    },
   },
   {
     "context": "Editor && editor_agent_diff",
     "use_key_equivalents": true,
     "bindings": {
       "ctrl-enter": "agent::KeepAll",
-      "ctrl-backspace": "agent::RejectAll"
-    }
+      "ctrl-backspace": "agent::RejectAll",
+    },
   },
   {
     "context": "Editor && mode == full && edit_prediction",
     "use_key_equivalents": true,
     "bindings": {
-      "ctrl-right": "editor::AcceptPartialEditPrediction"
-    }
+      "ctrl-right": "editor::AcceptPartialEditPrediction",
+    },
   },
   {
     "context": "Terminal",
     "use_key_equivalents": true,
     "bindings": {
-      "ctrl-k": "assistant::InlineAssist"
-    }
-  }
+      "ctrl-k": "assistant::InlineAssist",
+    },
+  },
 ]

--- a/assets/keymaps/linux/emacs.json
+++ b/assets/keymaps/linux/emacs.json
@@ -5,8 +5,8 @@
 [
   {
     "bindings": {
-      "ctrl-g": "menu::Cancel"
-    }
+      "ctrl-g": "menu::Cancel",
+    },
   },
   {
     // Workaround to avoid falling back to default bindings.
@@ -18,8 +18,8 @@
       "ctrl-g": null, // currently activates `go_to_line::Toggle` when there is nothing to cancel
       "ctrl-x": null, // currently activates `editor::Cut` if no following key is pressed for 1 second
       "ctrl-p": null, // currently activates `file_finder::Toggle` when the cursor is on the first character of the buffer
-      "ctrl-n": null // currently activates `workspace::NewFile` when the cursor is on the last character of the buffer
-    }
+      "ctrl-n": null, // currently activates `workspace::NewFile` when the cursor is on the last character of the buffer
+    },
   },
   {
     "context": "Editor",
@@ -82,8 +82,8 @@
       "ctrl-s": "buffer_search::Deploy", // isearch-forward
       "ctrl-r": "buffer_search::Deploy", // isearch-backward
       "alt-^": "editor::JoinLines", // join-line
-      "alt-q": "editor::Rewrap" // fill-paragraph
-    }
+      "alt-q": "editor::Rewrap", // fill-paragraph
+    },
   },
   {
     "context": "Editor && selection_mode", // region selection
@@ -119,22 +119,22 @@
       "alt->": "editor::SelectToEnd",
       "ctrl-home": "editor::SelectToBeginning",
       "ctrl-end": "editor::SelectToEnd",
-      "ctrl-g": "editor::Cancel"
-    }
+      "ctrl-g": "editor::Cancel",
+    },
   },
   {
     "context": "Editor && (showing_code_actions || showing_completions)",
     "bindings": {
       "ctrl-p": "editor::ContextMenuPrevious",
-      "ctrl-n": "editor::ContextMenuNext"
-    }
+      "ctrl-n": "editor::ContextMenuNext",
+    },
   },
   {
     "context": "Editor && showing_signature_help && !showing_completions",
     "bindings": {
       "ctrl-p": "editor::SignatureHelpPrevious",
-      "ctrl-n": "editor::SignatureHelpNext"
-    }
+      "ctrl-n": "editor::SignatureHelpNext",
+    },
   },
   // Example setting for using emacs-style tab
   // (i.e. indent the current line / selection or perform symbol completion depending on context)
@@ -164,8 +164,8 @@
       "ctrl-x ctrl-f": "file_finder::Toggle", // find-file
       "ctrl-x ctrl-s": "workspace::Save", // save-buffer
       "ctrl-x ctrl-w": "workspace::SaveAs", // write-file
-      "ctrl-x s": "workspace::SaveAll" // save-some-buffers
-    }
+      "ctrl-x s": "workspace::SaveAll", // save-some-buffers
+    },
   },
   {
     // Workaround to enable using native emacs from the Zed terminal.
@@ -185,22 +185,22 @@
       "ctrl-x ctrl-f": null, // find-file
       "ctrl-x ctrl-s": null, // save-buffer
       "ctrl-x ctrl-w": null, // write-file
-      "ctrl-x s": null // save-some-buffers
-    }
+      "ctrl-x s": null, // save-some-buffers
+    },
   },
   {
     "context": "BufferSearchBar > Editor",
     "bindings": {
       "ctrl-s": "search::SelectNextMatch",
       "ctrl-r": "search::SelectPreviousMatch",
-      "ctrl-g": "buffer_search::Dismiss"
-    }
+      "ctrl-g": "buffer_search::Dismiss",
+    },
   },
   {
     "context": "Pane",
     "bindings": {
       "ctrl-alt-left": "pane::GoBack",
-      "ctrl-alt-right": "pane::GoForward"
-    }
-  }
+      "ctrl-alt-right": "pane::GoForward",
+    },
+  },
 ]

--- a/assets/keymaps/linux/jetbrains.json
+++ b/assets/keymaps/linux/jetbrains.json
@@ -13,8 +13,8 @@
       "shift-f8": "debugger::StepOut",
       "f9": "debugger::Continue",
       "shift-f9": "debugger::Start",
-      "alt-shift-f9": "debugger::Start"
-    }
+      "alt-shift-f9": "debugger::Start",
+    },
   },
   {
     "context": "Editor",
@@ -62,8 +62,8 @@
       "ctrl-shift-end": "editor::SelectToEnd",
       "ctrl-f8": "editor::ToggleBreakpoint",
       "ctrl-shift-f8": "editor::EditLogBreakpoint",
-      "ctrl-shift-u": "editor::ToggleCase"
-    }
+      "ctrl-shift-u": "editor::ToggleCase",
+    },
   },
   {
     "context": "Editor && mode == full",
@@ -76,14 +76,14 @@
       "ctrl-space": "editor::ShowCompletions",
       "ctrl-q": "editor::Hover",
       "ctrl-p": "editor::ShowSignatureHelp",
-      "ctrl-\\": "assistant::InlineAssist"
-    }
+      "ctrl-\\": "assistant::InlineAssist",
+    },
   },
   {
     "context": "BufferSearchBar",
     "bindings": {
-      "shift-enter": "search::SelectPreviousMatch"
-    }
+      "shift-enter": "search::SelectPreviousMatch",
+    },
   },
   {
     "context": "BufferSearchBar || ProjectSearchBar",
@@ -91,8 +91,8 @@
       "alt-c": "search::ToggleCaseSensitive",
       "alt-e": "search::ToggleSelection",
       "alt-x": "search::ToggleRegex",
-      "alt-w": "search::ToggleWholeWord"
-    }
+      "alt-w": "search::ToggleWholeWord",
+    },
   },
   {
     "context": "Workspace",
@@ -114,8 +114,8 @@
       "alt-1": "project_panel::ToggleFocus",
       "alt-5": "debug_panel::ToggleFocus",
       "alt-6": "diagnostics::Deploy",
-      "alt-7": "outline_panel::ToggleFocus"
-    }
+      "alt-7": "outline_panel::ToggleFocus",
+    },
   },
   {
     "context": "Pane", // this is to override the default Pane mappings to switch tabs
@@ -129,15 +129,15 @@
       "alt-7": "outline_panel::ToggleFocus",
       "alt-8": null, // Services (bottom dock)
       "alt-9": null, // Git History (bottom dock)
-      "alt-0": "git_panel::ToggleFocus"
-    }
+      "alt-0": "git_panel::ToggleFocus",
+    },
   },
   {
     "context": "Workspace || Editor",
     "bindings": {
       "alt-f12": "terminal_panel::Toggle",
-      "ctrl-shift-k": "git::Push"
-    }
+      "ctrl-shift-k": "git::Push",
+    },
   },
   {
     "context": "Pane",
@@ -145,8 +145,8 @@
       "ctrl-alt-left": "pane::GoBack",
       "ctrl-alt-right": "pane::GoForward",
       "alt-left": "pane::ActivatePreviousItem",
-      "alt-right": "pane::ActivateNextItem"
-    }
+      "alt-right": "pane::ActivateNextItem",
+    },
   },
   {
     "context": "ProjectPanel",
@@ -156,8 +156,8 @@
       "backspace": ["project_panel::Trash", { "skip_prompt": false }],
       "delete": ["project_panel::Trash", { "skip_prompt": false }],
       "shift-delete": ["project_panel::Delete", { "skip_prompt": false }],
-      "shift-f6": "project_panel::Rename"
-    }
+      "shift-f6": "project_panel::Rename",
+    },
   },
   {
     "context": "Terminal",
@@ -167,8 +167,8 @@
       "ctrl-up": "terminal::ScrollLineUp",
       "ctrl-down": "terminal::ScrollLineDown",
       "shift-pageup": "terminal::ScrollPageUp",
-      "shift-pagedown": "terminal::ScrollPageDown"
-    }
+      "shift-pagedown": "terminal::ScrollPageDown",
+    },
   },
   { "context": "GitPanel", "bindings": { "alt-0": "workspace::CloseActiveDock" } },
   { "context": "ProjectPanel", "bindings": { "alt-1": "workspace::CloseActiveDock" } },
@@ -179,7 +179,7 @@
     "context": "Dock || Workspace || OutlinePanel || ProjectPanel || CollabPanel || (Editor && mode == auto_height)",
     "bindings": {
       "escape": "editor::ToggleFocus",
-      "shift-escape": "workspace::CloseActiveDock"
-    }
-  }
+      "shift-escape": "workspace::CloseActiveDock",
+    },
+  },
 ]

--- a/assets/keymaps/linux/sublime_text.json
+++ b/assets/keymaps/linux/sublime_text.json
@@ -22,8 +22,8 @@
       "ctrl-^": ["workspace::MoveItemToPane", { "destination": 5 }],
       "ctrl-&": ["workspace::MoveItemToPane", { "destination": 6 }],
       "ctrl-*": ["workspace::MoveItemToPane", { "destination": 7 }],
-      "ctrl-(": ["workspace::MoveItemToPane", { "destination": 8 }]
-    }
+      "ctrl-(": ["workspace::MoveItemToPane", { "destination": 8 }],
+    },
   },
   {
     "context": "Editor",
@@ -55,20 +55,20 @@
       "alt-right": "editor::MoveToNextSubwordEnd",
       "alt-left": "editor::MoveToPreviousSubwordStart",
       "alt-shift-right": "editor::SelectToNextSubwordEnd",
-      "alt-shift-left": "editor::SelectToPreviousSubwordStart"
-    }
+      "alt-shift-left": "editor::SelectToPreviousSubwordStart",
+    },
   },
   {
     "context": "Editor && mode == full",
     "bindings": {
-      "ctrl-r": "outline::Toggle"
-    }
+      "ctrl-r": "outline::Toggle",
+    },
   },
   {
     "context": "Editor && !agent_diff",
     "bindings": {
-      "ctrl-k ctrl-z": "git::Restore"
-    }
+      "ctrl-k ctrl-z": "git::Restore",
+    },
   },
   {
     "context": "Pane",
@@ -83,15 +83,15 @@
       "alt-6": ["pane::ActivateItem", 5],
       "alt-7": ["pane::ActivateItem", 6],
       "alt-8": ["pane::ActivateItem", 7],
-      "alt-9": "pane::ActivateLastItem"
-    }
+      "alt-9": "pane::ActivateLastItem",
+    },
   },
   {
     "context": "Workspace",
     "bindings": {
       "ctrl-k ctrl-b": "workspace::ToggleLeftDock",
       // "ctrl-0": "project_panel::ToggleFocus", // normally resets zoom
-      "shift-ctrl-r": "project_symbols::Toggle"
-    }
-  }
+      "shift-ctrl-r": "project_symbols::Toggle",
+    },
+  },
 ]

--- a/assets/keymaps/macos/atom.json
+++ b/assets/keymaps/macos/atom.json
@@ -4,16 +4,16 @@
     "bindings": {
       "ctrl-alt-cmd-l": "workspace::Reload",
       "cmd-k cmd-p": "workspace::ActivatePreviousPane",
-      "cmd-k cmd-n": "workspace::ActivateNextPane"
-    }
+      "cmd-k cmd-n": "workspace::ActivateNextPane",
+    },
   },
   {
     "context": "Editor",
     "bindings": {
       "cmd-shift-backspace": "editor::DeleteToBeginningOfLine",
       "cmd-k cmd-u": "editor::ConvertToUpperCase",
-      "cmd-k cmd-l": "editor::ConvertToLowerCase"
-    }
+      "cmd-k cmd-l": "editor::ConvertToLowerCase",
+    },
   },
   {
     "context": "Editor && mode == full",
@@ -33,8 +33,8 @@
       "ctrl-cmd-down": "editor::MoveLineDown",
       "cmd-\\": "workspace::ToggleLeftDock",
       "ctrl-shift-m": "markdown::OpenPreviewToTheSide",
-      "cmd-r": "outline::Toggle"
-    }
+      "cmd-r": "outline::Toggle",
+    },
   },
   {
     "context": "BufferSearchBar",
@@ -42,8 +42,8 @@
       "cmd-g": ["editor::SelectNext", { "replace_newest": true }],
       "cmd-shift-g": ["editor::SelectPrevious", { "replace_newest": true }],
       "cmd-f3": "search::SelectNextMatch",
-      "cmd-shift-f3": "search::SelectPreviousMatch"
-    }
+      "cmd-shift-f3": "search::SelectPreviousMatch",
+    },
   },
   {
     "context": "Workspace",
@@ -51,8 +51,8 @@
       "cmd-\\": "workspace::ToggleLeftDock",
       "cmd-k cmd-b": "workspace::ToggleLeftDock",
       "cmd-t": "file_finder::Toggle",
-      "cmd-shift-r": "project_symbols::Toggle"
-    }
+      "cmd-shift-r": "project_symbols::Toggle",
+    },
   },
   {
     "context": "Pane",
@@ -67,8 +67,8 @@
       "cmd-6": ["pane::ActivateItem", 5],
       "cmd-7": ["pane::ActivateItem", 6],
       "cmd-8": ["pane::ActivateItem", 7],
-      "cmd-9": "pane::ActivateLastItem"
-    }
+      "cmd-9": "pane::ActivateLastItem",
+    },
   },
   {
     "context": "ProjectPanel",
@@ -77,8 +77,8 @@
       "backspace": ["project_panel::Trash", { "skip_prompt": false }],
       "cmd-x": "project_panel::Cut",
       "cmd-c": "project_panel::Copy",
-      "cmd-v": "project_panel::Paste"
-    }
+      "cmd-v": "project_panel::Paste",
+    },
   },
   {
     "context": "ProjectPanel && not_editing",
@@ -92,7 +92,7 @@
       "d": "project_panel::Duplicate",
       "home": "menu::SelectFirst",
       "end": "menu::SelectLast",
-      "shift-a": "project_panel::NewDirectory"
-    }
-  }
+      "shift-a": "project_panel::NewDirectory",
+    },
+  },
 ]

--- a/assets/keymaps/macos/cursor.json
+++ b/assets/keymaps/macos/cursor.json
@@ -8,8 +8,8 @@
       "cmd-shift-i": "agent::ToggleFocus",
       "cmd-l": "agent::ToggleFocus",
       "cmd-shift-l": "agent::ToggleFocus",
-      "cmd-shift-j": "agent::OpenSettings"
-    }
+      "cmd-shift-j": "agent::OpenSettings",
+    },
   },
   {
     "context": "Editor && mode == full",
@@ -20,19 +20,19 @@
       "cmd-shift-l": "agent::AddSelectionToThread", // In cursor uses "Ask" mode
       "cmd-l": "agent::AddSelectionToThread", // In cursor uses "Agent" mode
       "cmd-k": "assistant::InlineAssist",
-      "cmd-shift-k": "assistant::InsertIntoEditor"
-    }
+      "cmd-shift-k": "assistant::InsertIntoEditor",
+    },
   },
   {
     "context": "InlineAssistEditor",
     "use_key_equivalents": true,
     "bindings": {
       "cmd-shift-backspace": "editor::Cancel",
-      "cmd-enter": "menu::Confirm"
+      "cmd-enter": "menu::Confirm",
       // "alt-enter": // Quick Question
       // "cmd-shift-enter": // Full File Context
       // "cmd-shift-k": // Toggle input focus (editor <> inline assist)
-    }
+    },
   },
   {
     "context": "AgentPanel || ContextEditor || (MessageEditor > Editor)",
@@ -48,7 +48,7 @@
       "cmd-shift-backspace": "editor::Cancel",
       "cmd-r": "agent::NewThread",
       "cmd-shift-v": "editor::Paste",
-      "cmd-shift-k": "assistant::InsertIntoEditor"
+      "cmd-shift-k": "assistant::InsertIntoEditor",
       // "escape": "agent::ToggleFocus"
       ///// Enable when Zed supports multiple thread tabs
       // "cmd-t": // new thread tab
@@ -57,28 +57,28 @@
       ///// Enable if Zed adds support for keyboard navigation of thread elements
       // "tab": // cycle to next message
       // "shift-tab": // cycle to previous message
-    }
+    },
   },
   {
     "context": "Editor && editor_agent_diff",
     "use_key_equivalents": true,
     "bindings": {
       "cmd-enter": "agent::KeepAll",
-      "cmd-backspace": "agent::RejectAll"
-    }
+      "cmd-backspace": "agent::RejectAll",
+    },
   },
   {
     "context": "Editor && mode == full && edit_prediction",
     "use_key_equivalents": true,
     "bindings": {
-      "cmd-right": "editor::AcceptPartialEditPrediction"
-    }
+      "cmd-right": "editor::AcceptPartialEditPrediction",
+    },
   },
   {
     "context": "Terminal",
     "use_key_equivalents": true,
     "bindings": {
-      "cmd-k": "assistant::InlineAssist"
-    }
-  }
+      "cmd-k": "assistant::InlineAssist",
+    },
+  },
 ]

--- a/assets/keymaps/macos/emacs.json
+++ b/assets/keymaps/macos/emacs.json
@@ -6,8 +6,8 @@
   {
     "context": "!GitPanel",
     "bindings": {
-      "ctrl-g": "menu::Cancel"
-    }
+      "ctrl-g": "menu::Cancel",
+    },
   },
   {
     // Workaround to avoid falling back to default bindings.
@@ -15,8 +15,8 @@
     // NOTE: must be declared before the `Editor` override.
     "context": "Editor",
     "bindings": {
-      "ctrl-g": null // currently activates `go_to_line::Toggle` when there is nothing to cancel
-    }
+      "ctrl-g": null, // currently activates `go_to_line::Toggle` when there is nothing to cancel
+    },
   },
   {
     "context": "Editor",
@@ -79,8 +79,8 @@
       "ctrl-s": "buffer_search::Deploy", // isearch-forward
       "ctrl-r": "buffer_search::Deploy", // isearch-backward
       "alt-^": "editor::JoinLines", // join-line
-      "alt-q": "editor::Rewrap" // fill-paragraph
-    }
+      "alt-q": "editor::Rewrap", // fill-paragraph
+    },
   },
   {
     "context": "Editor && selection_mode", // region selection
@@ -116,22 +116,22 @@
       "alt->": "editor::SelectToEnd",
       "ctrl-home": "editor::SelectToBeginning",
       "ctrl-end": "editor::SelectToEnd",
-      "ctrl-g": "editor::Cancel"
-    }
+      "ctrl-g": "editor::Cancel",
+    },
   },
   {
     "context": "Editor && (showing_code_actions || showing_completions)",
     "bindings": {
       "ctrl-p": "editor::ContextMenuPrevious",
-      "ctrl-n": "editor::ContextMenuNext"
-    }
+      "ctrl-n": "editor::ContextMenuNext",
+    },
   },
   {
     "context": "Editor && showing_signature_help && !showing_completions",
     "bindings": {
       "ctrl-p": "editor::SignatureHelpPrevious",
-      "ctrl-n": "editor::SignatureHelpNext"
-    }
+      "ctrl-n": "editor::SignatureHelpNext",
+    },
   },
   // Example setting for using emacs-style tab
   // (i.e. indent the current line / selection or perform symbol completion depending on context)
@@ -161,8 +161,8 @@
       "ctrl-x ctrl-f": "file_finder::Toggle", // find-file
       "ctrl-x ctrl-s": "workspace::Save", // save-buffer
       "ctrl-x ctrl-w": "workspace::SaveAs", // write-file
-      "ctrl-x s": "workspace::SaveAll" // save-some-buffers
-    }
+      "ctrl-x s": "workspace::SaveAll", // save-some-buffers
+    },
   },
   {
     // Workaround to enable using native emacs from the Zed terminal.
@@ -182,22 +182,22 @@
       "ctrl-x ctrl-f": null, // find-file
       "ctrl-x ctrl-s": null, // save-buffer
       "ctrl-x ctrl-w": null, // write-file
-      "ctrl-x s": null // save-some-buffers
-    }
+      "ctrl-x s": null, // save-some-buffers
+    },
   },
   {
     "context": "BufferSearchBar > Editor",
     "bindings": {
       "ctrl-s": "search::SelectNextMatch",
       "ctrl-r": "search::SelectPreviousMatch",
-      "ctrl-g": "buffer_search::Dismiss"
-    }
+      "ctrl-g": "buffer_search::Dismiss",
+    },
   },
   {
     "context": "Pane",
     "bindings": {
       "ctrl-alt-left": "pane::GoBack",
-      "ctrl-alt-right": "pane::GoForward"
-    }
-  }
+      "ctrl-alt-right": "pane::GoForward",
+    },
+  },
 ]

--- a/assets/keymaps/macos/jetbrains.json
+++ b/assets/keymaps/macos/jetbrains.json
@@ -13,8 +13,8 @@
       "shift-f8": "debugger::StepOut",
       "f9": "debugger::Continue",
       "shift-f9": "debugger::Start",
-      "alt-shift-f9": "debugger::Start"
-    }
+      "alt-shift-f9": "debugger::Start",
+    },
   },
   {
     "context": "Editor",
@@ -60,8 +60,8 @@
       "cmd-shift-end": "editor::SelectToEnd",
       "ctrl-f8": "editor::ToggleBreakpoint",
       "ctrl-shift-f8": "editor::EditLogBreakpoint",
-      "cmd-shift-u": "editor::ToggleCase"
-    }
+      "cmd-shift-u": "editor::ToggleCase",
+    },
   },
   {
     "context": "Editor && mode == full",
@@ -74,14 +74,14 @@
       "ctrl-space": "editor::ShowCompletions",
       "cmd-j": "editor::Hover",
       "cmd-p": "editor::ShowSignatureHelp",
-      "cmd-\\": "assistant::InlineAssist"
-    }
+      "cmd-\\": "assistant::InlineAssist",
+    },
   },
   {
     "context": "BufferSearchBar",
     "bindings": {
-      "shift-enter": "search::SelectPreviousMatch"
-    }
+      "shift-enter": "search::SelectPreviousMatch",
+    },
   },
   {
     "context": "BufferSearchBar || ProjectSearchBar",
@@ -93,8 +93,8 @@
       "ctrl-alt-c": "search::ToggleCaseSensitive",
       "ctrl-alt-e": "search::ToggleSelection",
       "ctrl-alt-w": "search::ToggleWholeWord",
-      "ctrl-alt-x": "search::ToggleRegex"
-    }
+      "ctrl-alt-x": "search::ToggleRegex",
+    },
   },
   {
     "context": "Workspace",
@@ -116,8 +116,8 @@
       "cmd-1": "project_panel::ToggleFocus",
       "cmd-5": "debug_panel::ToggleFocus",
       "cmd-6": "diagnostics::Deploy",
-      "cmd-7": "outline_panel::ToggleFocus"
-    }
+      "cmd-7": "outline_panel::ToggleFocus",
+    },
   },
   {
     "context": "Pane", // this is to override the default Pane mappings to switch tabs
@@ -131,15 +131,15 @@
       "cmd-7": "outline_panel::ToggleFocus",
       "cmd-8": null, // Services (bottom dock)
       "cmd-9": null, // Git History (bottom dock)
-      "cmd-0": "git_panel::ToggleFocus"
-    }
+      "cmd-0": "git_panel::ToggleFocus",
+    },
   },
   {
     "context": "Workspace || Editor",
     "bindings": {
       "alt-f12": "terminal_panel::Toggle",
-      "cmd-shift-k": "git::Push"
-    }
+      "cmd-shift-k": "git::Push",
+    },
   },
   {
     "context": "Pane",
@@ -147,8 +147,8 @@
       "cmd-alt-left": "pane::GoBack",
       "cmd-alt-right": "pane::GoForward",
       "alt-left": "pane::ActivatePreviousItem",
-      "alt-right": "pane::ActivateNextItem"
-    }
+      "alt-right": "pane::ActivateNextItem",
+    },
   },
   {
     "context": "ProjectPanel",
@@ -159,8 +159,8 @@
       "backspace": ["project_panel::Trash", { "skip_prompt": false }],
       "delete": ["project_panel::Trash", { "skip_prompt": false }],
       "shift-delete": ["project_panel::Delete", { "skip_prompt": false }],
-      "shift-f6": "project_panel::Rename"
-    }
+      "shift-f6": "project_panel::Rename",
+    },
   },
   {
     "context": "Terminal",
@@ -170,8 +170,8 @@
       "cmd-up": "terminal::ScrollLineUp",
       "cmd-down": "terminal::ScrollLineDown",
       "shift-pageup": "terminal::ScrollPageUp",
-      "shift-pagedown": "terminal::ScrollPageDown"
-    }
+      "shift-pagedown": "terminal::ScrollPageDown",
+    },
   },
   { "context": "GitPanel", "bindings": { "cmd-0": "workspace::CloseActiveDock" } },
   { "context": "ProjectPanel", "bindings": { "cmd-1": "workspace::CloseActiveDock" } },
@@ -182,7 +182,7 @@
     "context": "Dock || Workspace || OutlinePanel || ProjectPanel || CollabPanel || (Editor && mode == auto_height)",
     "bindings": {
       "escape": "editor::ToggleFocus",
-      "shift-escape": "workspace::CloseActiveDock"
-    }
-  }
+      "shift-escape": "workspace::CloseActiveDock",
+    },
+  },
 ]

--- a/assets/keymaps/macos/sublime_text.json
+++ b/assets/keymaps/macos/sublime_text.json
@@ -22,8 +22,8 @@
       "ctrl-^": ["workspace::MoveItemToPane", { "destination": 5 }],
       "ctrl-&": ["workspace::MoveItemToPane", { "destination": 6 }],
       "ctrl-*": ["workspace::MoveItemToPane", { "destination": 7 }],
-      "ctrl-(": ["workspace::MoveItemToPane", { "destination": 8 }]
-    }
+      "ctrl-(": ["workspace::MoveItemToPane", { "destination": 8 }],
+    },
   },
   {
     "context": "Editor",
@@ -57,20 +57,20 @@
       "ctrl-right": "editor::MoveToNextSubwordEnd",
       "ctrl-left": "editor::MoveToPreviousSubwordStart",
       "ctrl-shift-right": "editor::SelectToNextSubwordEnd",
-      "ctrl-shift-left": "editor::SelectToPreviousSubwordStart"
-    }
+      "ctrl-shift-left": "editor::SelectToPreviousSubwordStart",
+    },
   },
   {
     "context": "Editor && mode == full",
     "bindings": {
-      "cmd-r": "outline::Toggle"
-    }
+      "cmd-r": "outline::Toggle",
+    },
   },
   {
     "context": "Editor && !agent_diff",
     "bindings": {
-      "cmd-k cmd-z": "git::Restore"
-    }
+      "cmd-k cmd-z": "git::Restore",
+    },
   },
   {
     "context": "Pane",
@@ -85,8 +85,8 @@
       "cmd-6": ["pane::ActivateItem", 5],
       "cmd-7": ["pane::ActivateItem", 6],
       "cmd-8": ["pane::ActivateItem", 7],
-      "cmd-9": "pane::ActivateLastItem"
-    }
+      "cmd-9": "pane::ActivateLastItem",
+    },
   },
   {
     "context": "Workspace",
@@ -95,7 +95,7 @@
       "cmd-t": "file_finder::Toggle",
       "shift-cmd-r": "project_symbols::Toggle",
       // Currently busted: https://github.com/zed-industries/feedback/issues/898
-      "ctrl-0": "project_panel::ToggleFocus"
-    }
-  }
+      "ctrl-0": "project_panel::ToggleFocus",
+    },
+  },
 ]

--- a/assets/keymaps/macos/textmate.json
+++ b/assets/keymaps/macos/textmate.json
@@ -2,8 +2,8 @@
   {
     "bindings": {
       "cmd-shift-o": "projects::OpenRecent",
-      "cmd-alt-tab": "project_panel::ToggleFocus"
-    }
+      "cmd-alt-tab": "project_panel::ToggleFocus",
+    },
   },
   {
     "context": "Editor && mode == full",
@@ -15,8 +15,8 @@
       "cmd-enter": "editor::NewlineBelow",
       "cmd-alt-enter": "editor::NewlineAbove",
       "cmd-shift-l": "editor::SelectLine",
-      "cmd-shift-t": "outline::Toggle"
-    }
+      "cmd-shift-t": "outline::Toggle",
+    },
   },
   {
     "context": "Editor",
@@ -41,30 +41,30 @@
       "ctrl-u": "editor::ConvertToUpperCase",
       "ctrl-shift-u": "editor::ConvertToLowerCase",
       "ctrl-alt-u": "editor::ConvertToUpperCamelCase",
-      "ctrl-_": "editor::ConvertToSnakeCase"
-    }
+      "ctrl-_": "editor::ConvertToSnakeCase",
+    },
   },
   {
     "context": "BufferSearchBar",
     "bindings": {
       "ctrl-s": "search::SelectNextMatch",
-      "ctrl-shift-s": "search::SelectPreviousMatch"
-    }
+      "ctrl-shift-s": "search::SelectPreviousMatch",
+    },
   },
   {
     "context": "Workspace",
     "bindings": {
       "cmd-alt-ctrl-d": "workspace::ToggleLeftDock",
       "cmd-t": "file_finder::Toggle",
-      "cmd-shift-t": "project_symbols::Toggle"
-    }
+      "cmd-shift-t": "project_symbols::Toggle",
+    },
   },
   {
     "context": "Pane",
     "bindings": {
       "alt-cmd-r": "search::ToggleRegex",
-      "ctrl-tab": "project_panel::ToggleFocus"
-    }
+      "ctrl-tab": "project_panel::ToggleFocus",
+    },
   },
   {
     "context": "ProjectPanel",
@@ -75,11 +75,11 @@
       "return": "project_panel::Rename",
       "cmd-c": "project_panel::Copy",
       "cmd-v": "project_panel::Paste",
-      "cmd-alt-c": "project_panel::CopyPath"
-    }
+      "cmd-alt-c": "project_panel::CopyPath",
+    },
   },
   {
     "context": "Dock",
-    "bindings": {}
-  }
+    "bindings": {},
+  },
 ]

--- a/assets/keymaps/storybook.json
+++ b/assets/keymaps/storybook.json
@@ -27,7 +27,7 @@
       "backspace": "editor::Backspace",
       "delete": "editor::Delete",
       "left": "editor::MoveLeft",
-      "right": "editor::MoveRight"
-    }
-  }
+      "right": "editor::MoveRight",
+    },
+  },
 ]

--- a/assets/settings/initial_debug_tasks.json
+++ b/assets/settings/initial_debug_tasks.json
@@ -8,7 +8,7 @@
     "adapter": "Debugpy",
     "program": "$ZED_FILE",
     "request": "launch",
-    "cwd": "$ZED_WORKTREE_ROOT"
+    "cwd": "$ZED_WORKTREE_ROOT",
   },
   {
     "label": "Debug active JavaScript file",
@@ -16,7 +16,7 @@
     "program": "$ZED_FILE",
     "request": "launch",
     "cwd": "$ZED_WORKTREE_ROOT",
-    "type": "pwa-node"
+    "type": "pwa-node",
   },
   {
     "label": "JavaScript debug terminal",
@@ -24,6 +24,6 @@
     "request": "launch",
     "cwd": "$ZED_WORKTREE_ROOT",
     "console": "integratedTerminal",
-    "type": "pwa-node"
-  }
+    "type": "pwa-node",
+  },
 ]

--- a/assets/settings/initial_server_settings.json
+++ b/assets/settings/initial_server_settings.json
@@ -3,5 +3,5 @@
 // For a full list of overridable settings, and general information on settings,
 // see the documentation: https://zed.dev/docs/configuring-zed#settings-files
 {
-  "lsp": {}
+  "lsp": {},
 }

--- a/assets/settings/initial_tasks.json
+++ b/assets/settings/initial_tasks.json
@@ -47,8 +47,8 @@
     // Whether to show the task line in the output of the spawned task, defaults to `true`.
     "show_summary": true,
     // Whether to show the command line in the output of the spawned task, defaults to `true`.
-    "show_command": true
+    "show_command": true,
     // Represents the tags for inline runnable indicators, or spawning multiple tasks at once.
     // "tags": []
-  }
+  },
 ]

--- a/assets/settings/initial_user_settings.json
+++ b/assets/settings/initial_user_settings.json
@@ -12,6 +12,6 @@
   "theme": {
     "mode": "system",
     "light": "One Light",
-    "dark": "One Dark"
-  }
+    "dark": "One Dark",
+  },
 }


### PR DESCRIPTION
Closes #ISSUE

Post #43854, we are advertising trailing comma support for our asset `jsonc` files to the JSON LSP. This results in it adding trailing commas on format of these files. This PR batch updates the formatting for these files, so they are not spuriously added as part of other PRs that happen to modify these files

Release Notes:

- N/A *or* Added/Fixed/Improved ...
