### PR TITLE
agent_ui_v2: Fix `set_position` not updating the position properly

### DIFF
--- a/crates/agent_ui_v2/src/agents_panel.rs
+++ b/crates/agent_ui_v2/src/agents_panel.rs
@@ -384,8 +384,7 @@ impl Panel for AgentsPanel {
         update_settings_file(self.fs.clone(), cx, move |settings, _| {
             settings.agent.get_or_insert_default().agents_panel_dock = Some(match position {
                 DockPosition::Left => settings::DockSide::Left,
-                DockPosition::Bottom => settings::DockSide::Right,
-                DockPosition::Right => settings::DockSide::Left,
+                DockPosition::Right | DockPosition::Bottom => settings::DockSide::Right,
             });
         });
         self.re_register_utility_pane(window, cx);


### PR DESCRIPTION
The panel could not be relocated using the right click menu because both valid positions mapped to `Left`

Release Notes:

- N/A