### PR TITLE
project_panel: Fix divider taking too much horizontal space

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -6050,9 +6050,9 @@ impl Render for ProjectPanel {
                     h_flex()
                         .w_1_2()
                         .gap_2()
-                        .child(Divider::horizontal())
+                        .child(div().flex_1().child(Divider::horizontal()))
                         .child(Label::new("or").size(LabelSize::XSmall).color(Color::Muted))
-                        .child(Divider::horizontal()),
+                        .child(div().flex_1().child(Divider::horizontal())),
                 )
                 .child(
                     Button::new("clone_repo", "Clone Repository")


### PR DESCRIPTION
Closes: #44917

While setting up the project for contribution, I noticed that the divider in the welcome dialog was rendering incorrectly on the `main` branch compared to the latest release.

**Current behaviour (`main` branch):**
<img width="796" height="690" alt="image" src="https://github.com/user-attachments/assets/3f7d6c73-14eb-47f3-ad83-4796f5f7be0f" />

**Expected behaviour (Release `0.216.1`):**
<img width="794" height="692" alt="image" src="https://github.com/user-attachments/assets/b67857dc-a03d-4e49-bb33-22fe0c83ac5d" />

---

After some investigation, it looks like the issue was introduced in #44505, specifically in [these changes](https://github.com/zed-industries/zed/pull/44505/changes#diff-4ea61133da5775f0d5d06e67a8dccc84e671c3d04db5f738f6ebfab3a4df0b01R147-R158), which caused the divider to take the full width instead of being properly constrained.

**PR result**:
<img width="666" height="574" alt="image" src="https://github.com/user-attachments/assets/e12b7778-b7cc-4855-b82e-3470dfe43365" />

Release Notes:

- Fixes -or- divider rendering incorrectly
