### PR TITLE
docs: Drop deprecated key from settings for Agent Panel

### DIFF
--- a/docs/src/git.md
+++ b/docs/src/git.md
@@ -145,7 +145,6 @@ You can specify your preferred model to use by providing a `commit_message_model
 ```json [settings]
 {
   "agent": {
-    "version": "2",
     "commit_message_model": {
       "provider": "anthropic",
       "model": "claude-3-5-haiku"


### PR DESCRIPTION
The `version` key was deprecated a while ago.

Release Notes:

- N/A
