### PR TITLE
docs: Update links to account page

### DIFF
--- a/docs/src/ai/billing.md
+++ b/docs/src/ai/billing.md
@@ -5,7 +5,7 @@ For invoice-based billing, a Business plan is required. Contact [sales@zed.dev](
 
 ## Billing Information {#settings}
 
-You can access billing information and settings at [zed.dev/account](https://zed.dev/account).
+You can access billing information and settings at [dashboard.zed.dev/account](https://dashboard.zed.dev/account).
 Most of the page embeds information from our invoicing/metering partner, Orb (we're planning on a more native experience soon!).
 
 ## Billing Cycles {#billing-cycles}
@@ -28,7 +28,7 @@ If payment of an invoice fails, Zed will block usage of our hosted models until 
 
 ## Invoice History {#invoice-history}
 
-You can access your invoice history by navigating to [zed.dev/account](https://zed.dev/account) and clicking `Invoice history` within the embedded Orb portal.
+You can access your invoice history by navigating to [dashboard.zed.dev/account](https://dashboard.zed.dev/account) and clicking `Invoice history` within the embedded Orb portal.
 
 If you require historical Stripe invoices, email [billing-support@zed.dev](mailto:billing-support@zed.dev)
 

--- a/docs/src/ai/plans-and-usage.md
+++ b/docs/src/ai/plans-and-usage.md
@@ -12,11 +12,11 @@ Usage of Zed's hosted models is measured on a token basis, converted to dollars 
 
 Zed Pro comes with $5 of monthly dollar credit. A trial of Zed Pro includes $20 of credit, usable for 14 days. Monthly included credit resets on your monthly billing date.
 
-To view your current usage, you can visit your account at [zed.dev/account](https://zed.dev/account). Information from our metering and billing provider, Orb, is embedded on that page.
+To view your current usage, you can visit your account at [dashboard.zed.dev/account](https://dashboard.zed.dev/account). Information from our metering and billing provider, Orb, is embedded on that page.
 
 ## Spend Limits {#usage-spend-limits}
 
-At the top of [the Account page](https://zed.dev/account), you'll find an input for `Maximum Token Spend`. The dollar amount here specifies your _monthly_ limit for spend on tokens, _not counting_ the $5/month included with your Pro subscription.
+At the top of [the Account page](https://dashboard.zed.dev/account), you'll find an input for `Maximum Token Spend`. The dollar amount here specifies your _monthly_ limit for spend on tokens, _not counting_ the $5/month included with your Pro subscription.
 
 The default value for all Pro users is $10, for a total monthly spend with Zed of $20 ($10 for your Pro subscription, $10 in incremental token spend). This can be set to $0 to limit your spend with Zed to exactly $10/month. If you adjust this limit _higher_ than $10 and consume more than $10 of incremental token spend, you'll be billed via [threshold billing](./billing.md#threshold-billing).
 


### PR DESCRIPTION
This PR updates the links to the account page to point to the Dashboard.

Release Notes:

- N/A
