### PR TITLE
Anchor scroll offsets so that entire diff hunks at viewport top become visible

### DIFF
--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -22234,6 +22234,44 @@ async fn test_toggle_deletion_hunk_at_start_of_file(
 }
 
 #[gpui::test]
+async fn test_expand_first_line_diff_hunk_keeps_deleted_lines_visible(
+    executor: BackgroundExecutor,
+    cx: &mut TestAppContext,
+) {
+    init_test(cx, |_| {});
+    let mut cx = EditorTestContext::new(cx).await;
+
+    cx.set_state("ˇnew\nsecond\nthird\n");
+    cx.set_head_text("old\nsecond\nthird\n");
+    executor.run_until_parked();
+
+    let hunk_range = cx.update_editor(|editor, window, cx| {
+        let snapshot = editor.snapshot(window, cx);
+        let hunks = editor
+            .diff_hunks_in_ranges(&[Anchor::min()..Anchor::max()], &snapshot.buffer_snapshot())
+            .collect::<Vec<_>>();
+        assert_eq!(hunks.len(), 1);
+
+        let excerpt_id = editor.buffer.read(cx).excerpt_ids()[0];
+        Anchor::range_in_buffer(excerpt_id, hunks[0].buffer_range.clone())
+    });
+
+    cx.update_editor(|editor, window, cx| {
+        editor.scroll(gpui::Point { x: 0., y: 0. }, None, window, cx);
+    });
+    executor.run_until_parked();
+    assert_eq!(cx.update_editor(|editor, _, cx| editor.scroll_position(cx)).y, 0.0);
+
+    cx.update_editor(|editor, _, cx| editor.toggle_single_diff_hunk(hunk_range, cx));
+    executor.run_until_parked();
+    cx.assert_state_with_diff("- old\n+ ˇnew\n  second\n  third\n".to_string());
+
+    // Expanding a diff hunk at the first line inserts deleted lines above the first buffer line.
+    // Keep the editor scrolled to the top so the full hunk remains visible.
+    assert_eq!(cx.update_editor(|editor, _, cx| editor.scroll_position(cx)).y, 0.0);
+}
+
+#[gpui::test]
 async fn test_display_diff_hunks(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/editor/src/scroll.rs
+++ b/crates/editor/src/scroll.rs
@@ -251,7 +251,11 @@ impl ScrollManager {
                 Bias::Left,
             )
             .to_point(map);
-        let top_anchor = map.buffer_snapshot().anchor_after(scroll_top_buffer_point);
+        // Anchor the scroll position to the *left* of the first visible buffer point.
+        //
+        // This prevents the viewport from shifting down when blocks (e.g. expanded diff hunk
+        // deletions) are inserted *above* the first buffer character in the file.
+        let top_anchor = map.buffer_snapshot().anchor_before(scroll_top_buffer_point);
 
         self.set_anchor(
             ScrollAnchor {


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/39258

Release Notes:

- Fixed a bug when expanding a diff hunk at the beginning of a file, where the deleted portion of the hunk would remain outside of the viewport.
