### PR TITLE
Remove CopyAsMarkdown

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -262,9 +262,9 @@
   {
     "context": "AgentPanel > Markdown",
     "bindings": {
-      "copy": "markdown::CopyAsMarkdown",
-      "ctrl-insert": "markdown::CopyAsMarkdown",
-      "ctrl-c": "markdown::CopyAsMarkdown",
+      "copy": "markdown::Copy",
+      "ctrl-insert": "markdown::Copy",
+      "ctrl-c": "markdown::Copy",
     },
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -303,7 +303,7 @@
     "context": "AgentPanel > Markdown",
     "use_key_equivalents": true,
     "bindings": {
-      "cmd-c": "markdown::CopyAsMarkdown",
+      "cmd-c": "markdown::Copy",
     },
   },
   {

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -265,7 +265,7 @@
     "context": "AgentPanel > Markdown",
     "use_key_equivalents": true,
     "bindings": {
-      "ctrl-c": "markdown::CopyAsMarkdown",
+      "ctrl-c": "markdown::Copy",
     },
   },
   {

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -149,8 +149,6 @@ actions!(
     [
         /// Copies the selected text to the clipboard.
         Copy,
-        /// Copies the selected text as markdown to the clipboard.
-        CopyAsMarkdown
     ]
 );
 
@@ -292,14 +290,6 @@ impl Markdown {
             return;
         }
         let text = text.text_for_range(self.selection.start..self.selection.end);
-        cx.write_to_clipboard(ClipboardItem::new_string(text));
-    }
-
-    fn copy_as_markdown(&self, _: &mut Window, cx: &mut Context<Self>) {
-        if self.selection.end <= self.selection.start {
-            return;
-        }
-        let text = self.source[self.selection.start..self.selection.end].to_string();
         cx.write_to_clipboard(ClipboardItem::new_string(text));
     }
 
@@ -1357,14 +1347,6 @@ impl Element for MarkdownElement {
                 let text = text.clone();
                 if phase == DispatchPhase::Bubble {
                     entity.update(cx, move |this, cx| this.copy(&text, window, cx))
-                }
-            }
-        });
-        window.on_action(std::any::TypeId::of::<crate::CopyAsMarkdown>(), {
-            let entity = self.markdown.clone();
-            move |_, phase, window, cx| {
-                if phase == DispatchPhase::Bubble {
-                    entity.update(cx, move |this, cx| this.copy_as_markdown(window, cx))
                 }
             }
         });


### PR DESCRIPTION
Copying rendered markdown doesn't reliably do anything sensible. If we copy text from the middle of a bold section, no formatting is copied. If we copy text at the end, the trailing bold delimiters are copied, resulting in gibberish markdown. Thus even fixing the associated issue (so that leading delimeters are reliably copied) won't consistently produce good results.

Also, as the user messages in the agent panel don't render markdown anyway, it seems the most likely use case for copying markdown is inapplicable.

Closes #42958 

Release Notes:

- N/A
