### PR TITLE
workspace: Persist window values without project 

### DIFF
--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -158,7 +158,7 @@ impl Column for SerializedWindowBounds {
 
 const DEFAULT_WINDOW_BOUNDS_KEY: &str = "default_window_bounds";
 
-pub fn read_default_window_bounds() -> Option<(Uuid, SerializedWindowBounds)> {
+pub fn read_default_window_bounds() -> Option<(Uuid, WindowBounds)> {
     let json_str = KEY_VALUE_STORE
         .read_kvp(DEFAULT_WINDOW_BOUNDS_KEY)
         .log_err()
@@ -166,14 +166,14 @@ pub fn read_default_window_bounds() -> Option<(Uuid, SerializedWindowBounds)> {
 
     let (display_uuid, persisted) =
         serde_json::from_str::<(Uuid, WindowBoundsJson)>(&json_str).ok()?;
-    Some((display_uuid, SerializedWindowBounds(persisted.into())))
+    Some((display_uuid, persisted.into()))
 }
 
 pub async fn write_default_window_bounds(
-    bounds: SerializedWindowBounds,
+    bounds: WindowBounds,
     display_uuid: Uuid,
 ) -> anyhow::Result<()> {
-    let persisted = WindowBoundsJson::from(bounds.0);
+    let persisted = WindowBoundsJson::from(bounds);
     let json_str = serde_json::to_string(&(display_uuid, persisted))?;
     KEY_VALUE_STORE
         .write_kvp(DEFAULT_WINDOW_BOUNDS_KEY.to_string(), json_str)

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -1484,24 +1484,6 @@ impl WorkspaceDb {
         }
     }
 
-    pub(crate) fn last_window(
-        &self,
-    ) -> anyhow::Result<(Option<Uuid>, Option<SerializedWindowBounds>)> {
-        let mut prepared_query =
-            self.select::<(Option<Uuid>, Option<SerializedWindowBounds>)>(sql!(
-                SELECT
-                display,
-                window_state, window_x, window_y, window_width, window_height
-                FROM workspaces
-                WHERE paths
-                IS NOT NULL
-                ORDER BY timestamp DESC
-                LIMIT 1
-            ))?;
-        let result = prepared_query()?;
-        Ok(result.into_iter().next().unwrap_or((None, None)))
-    }
-
     query! {
         pub async fn delete_workspace_by_id(id: WorkspaceId) -> Result<()> {
             DELETE FROM workspaces

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1442,7 +1442,7 @@ impl Workspace {
                             if !has_paths {
                                 cx.background_executor()
                                     .spawn(persistence::write_default_window_bounds(
-                                        SerializedWindowBounds((window_bounds)),
+                                        window_bounds,
                                         display_uuid,
                                     ))
                                     .detach_and_log_err(cx);
@@ -1458,7 +1458,7 @@ impl Workspace {
                             } else {
                                 cx.background_executor()
                                     .spawn(persistence::write_default_window_bounds(
-                                        SerializedWindowBounds(window_bounds),
+                                        window_bounds,
                                         display_uuid,
                                     ))
                                     .detach_and_log_err(cx);
@@ -1684,7 +1684,7 @@ impl Workspace {
                 } else if is_empty_workspace {
                     // Empty workspace - try to restore the last known no-project window bounds
                     if let Some((display, bounds)) = persistence::read_default_window_bounds() {
-                        (Some(bounds.0), Some(display))
+                        (Some(bounds), Some(display))
                     } else {
                         (None, None)
                     }
@@ -8708,11 +8708,13 @@ pub fn remote_workspace_position_from_db(
         } else {
             let restorable_bounds = serialized_workspace
                 .as_ref()
-                .and_then(|workspace| Some((workspace.display?, workspace.window_bounds?)))
+                .and_then(|workspace| {
+                    Some((workspace.display?, workspace.window_bounds.map(|b| b.0)?))
+                })
                 .or_else(|| persistence::read_default_window_bounds());
 
-            if let Some((serialized_display, serialized_status)) = restorable_bounds {
-                (Some(serialized_status.0), Some(serialized_display))
+            if let Some((serialized_display, serialized_bounds)) = restorable_bounds {
+                (Some(serialized_bounds), Some(serialized_display))
             } else {
                 (None, None)
             }

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1438,10 +1438,26 @@ impl Workspace {
                             && let Ok(display_uuid) = display.uuid()
                         {
                             let window_bounds = window.inner_window_bounds();
+                            let has_paths = !this.root_paths(cx).is_empty();
+                            if !has_paths {
+                                cx.background_executor()
+                                    .spawn(persistence::write_no_project_window_bounds(
+                                        SerializedWindowBounds((window_bounds)),
+                                        display_uuid,
+                                    ))
+                                    .detach_and_log_err(cx);
+                            }
                             if let Some(database_id) = workspace_id {
                                 cx.background_executor()
                                     .spawn(DB.set_window_open_status(
                                         database_id,
+                                        SerializedWindowBounds(window_bounds),
+                                        display_uuid,
+                                    ))
+                                    .detach_and_log_err(cx);
+                            } else {
+                                cx.background_executor()
+                                    .spawn(persistence::write_no_project_window_bounds(
                                         SerializedWindowBounds(window_bounds),
                                         display_uuid,
                                     ))
@@ -1652,6 +1668,7 @@ impl Workspace {
                 window
             } else {
                 let window_bounds_override = window_bounds_env_override();
+                let is_empty_workspace = project_paths.is_empty();
 
                 let (window_bounds, display) = if let Some(bounds) = window_bounds_override {
                     (Some(WindowBounds::Windowed(bounds)), None)
@@ -1660,6 +1677,13 @@ impl Workspace {
                     if let (Some(display), Some(bounds)) =
                         (workspace.display, workspace.window_bounds.as_ref())
                     {
+                        (Some(bounds.0), Some(display))
+                    } else {
+                        (None, None)
+                    }
+                } else if is_empty_workspace {
+                    // Empty workspace - try to restore the last known no-project window bounds
+                    if let Some((display, bounds)) = persistence::read_no_project_window_bounds() {
                         (Some(bounds.0), Some(display))
                     } else {
                         (None, None)
@@ -8685,10 +8709,7 @@ pub fn remote_workspace_position_from_db(
             let restorable_bounds = serialized_workspace
                 .as_ref()
                 .and_then(|workspace| Some((workspace.display?, workspace.window_bounds?)))
-                .or_else(|| {
-                    let (display, window_bounds) = DB.last_window().log_err()?;
-                    Some((display?, window_bounds?))
-                });
+                .or_else(|| persistence::read_no_project_window_bounds());
 
             if let Some((serialized_display, serialized_status)) = restorable_bounds {
                 (Some(serialized_status.0), Some(serialized_display))

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1441,7 +1441,7 @@ impl Workspace {
                             let has_paths = !this.root_paths(cx).is_empty();
                             if !has_paths {
                                 cx.background_executor()
-                                    .spawn(persistence::write_no_project_window_bounds(
+                                    .spawn(persistence::write_default_window_bounds(
                                         SerializedWindowBounds((window_bounds)),
                                         display_uuid,
                                     ))
@@ -1457,7 +1457,7 @@ impl Workspace {
                                     .detach_and_log_err(cx);
                             } else {
                                 cx.background_executor()
-                                    .spawn(persistence::write_no_project_window_bounds(
+                                    .spawn(persistence::write_default_window_bounds(
                                         SerializedWindowBounds(window_bounds),
                                         display_uuid,
                                     ))
@@ -1683,7 +1683,7 @@ impl Workspace {
                     }
                 } else if is_empty_workspace {
                     // Empty workspace - try to restore the last known no-project window bounds
-                    if let Some((display, bounds)) = persistence::read_no_project_window_bounds() {
+                    if let Some((display, bounds)) = persistence::read_default_window_bounds() {
                         (Some(bounds.0), Some(display))
                     } else {
                         (None, None)
@@ -8709,7 +8709,7 @@ pub fn remote_workspace_position_from_db(
             let restorable_bounds = serialized_workspace
                 .as_ref()
                 .and_then(|workspace| Some((workspace.display?, workspace.window_bounds?)))
-                .or_else(|| persistence::read_no_project_window_bounds());
+                .or_else(|| persistence::read_default_window_bounds());
 
             if let Some((serialized_display, serialized_status)) = restorable_bounds {
                 (Some(serialized_status.0), Some(serialized_display))


### PR DESCRIPTION
Persist and restore window values (size, position, etc.) to the KV Store when there are no projects open.

Relates to Discussion https://github.com/zed-industries/zed/discussions/24228#discussioncomment-15224666

Release Notes:

-  Added persistence for window size when no projects are open