### PR TITLE
Clean up screenshare

### DIFF
--- a/crates/workspace/src/shared_screen.rs
+++ b/crates/workspace/src/shared_screen.rs
@@ -42,6 +42,11 @@ impl SharedScreen {
         })
         .detach();
 
+        cx.observe_release(&room, |_, _, cx| {
+            cx.emit(Event::Close);
+        })
+        .detach();
+
         let view = cx.new(|cx| RemoteVideoTrackView::new(track.clone(), window, cx));
         cx.subscribe(&view, |_, _, ev, cx| match ev {
             call::RemoteVideoTrackViewEvent::Close => cx.emit(Event::Close),


### PR DESCRIPTION
Release Notes:

- Fixed a bug where screen-share tabs would persist after the sender (or receiver) had left the call.
