### PR TITLE
Add `incremental=true` to dev cargo profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -774,8 +774,7 @@ calloop = { git = "https://github.com/zed-industries/calloop" }
 
 [profile.dev]
 split-debuginfo = "unpacked"
-# https://github.com/rust-lang/cargo/issues/16104
-incremental = false
+incremental = true
 codegen-units = 16
 
 # mirror configuration for crates compiled for the build platform


### PR DESCRIPTION
Long story short, I noticed a setting inside root `Cargo.toml` that referenced [this issue](https://github.com/rust-lang/cargo/issues/16104) about `incremental=false` being a hacky workaround for spurious project rebuilds.

A PR closing this issue was merged about a month ago, so we _should_ be able to re-enable the setting without much issue.

Follow-up (albeit delayed) to [this PR](https://github.com/zed-industries/zed/pull/41015)

> [!NOTE]
> For reasons amounting to "need more RAM", I am unable to execute `cargo run` without the process `SIGKILL`-ing itself for lack of memory.
> Help from a Zed staff member to ensure that this does indeed not blow up the editor would be greatly appreciated.

Release Notes:

- N/A