### PR TITLE
Remove outdated `Cargo.toml` comment about `declare_interior_mutable_const`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -857,8 +857,6 @@ unexpected_cfgs = { level = "allow" }
 dbg_macro = "deny"
 todo = "deny"
 
-# This is not a style lint, see https://github.com/rust-lang/rust-clippy/pull/15454
-# Remove when the lint gets promoted to `suspicious`.
 declare_interior_mutable_const = "deny"
 
 redundant_clone = "deny"


### PR DESCRIPTION
Since the rule is no longer a `style` lint as of [mid-August](https://github.com/rust-lang/rust-clippy/pull/15454), the comment mentioning it not being one is outdated and should be removed.

> [!NOTE]
> I kept the severity at `error` for now to avoid rustling feathers.
> If `warn` is preferred, feel free to change it yourself or ask me to do it - it's only 1 line of code, after all.

Release Notes:

- N/A