### PR TITLE
collab: Add `copilot` name alias to the `GET /contributor` endpoint

### DIFF
--- a/crates/collab/src/api/contributors.rs
+++ b/crates/collab/src/api/contributors.rs
@@ -111,6 +111,9 @@ struct CopilotSweAgentBot;
 impl CopilotSweAgentBot {
     const LOGIN: &'static str = "copilot-swe-agent[bot]";
     const USER_ID: i32 = 198982749;
+    /// The alias of the GitHub copilot user. Although https://api.github.com/users/copilot
+    /// yields a 404, GitHub still refers to the copilot bot user as @Copilot in some cases.
+    const NAME_ALIAS: &'static str = "copilot";
 
     /// Returns the `created_at` timestamp for the Dependabot bot user.
     fn created_at() -> &'static NaiveDateTime {
@@ -125,7 +128,9 @@ impl CopilotSweAgentBot {
     /// Returns whether the given contributor selector corresponds to the Copilot bot user.
     fn is_copilot_bot(contributor: &ContributorSelector) -> bool {
         match contributor {
-            ContributorSelector::GitHubLogin { github_login } => github_login == Self::LOGIN,
+            ContributorSelector::GitHubLogin { github_login } => {
+                github_login == Self::LOGIN || github_login == Self::NAME_ALIAS
+            }
             ContributorSelector::GitHubUserId { github_user_id } => {
                 github_user_id == &Self::USER_ID
             }


### PR DESCRIPTION
Although the copilot bot integration is referred to by `copilot-swe-agent[bot]` (https://api.github.com/users/copilot-swe-agent[bot]), GitHub parses the copilot identity as @\copilot in some cases, e.g. https://github.com/zed-industries/zed/pull/44915#issuecomment-3657567754. This causes the CLA check to still fail despite Copilot being added to the CLA endpoint (and https://api.github.com/users/copilot returning a 404 for that very name..). 

This PR fixes this by also considering the name alias of Copilot for the `contributor` endpoint.

Release Notes:

- N/A
