### PR TITLE
tab_switcher: Fix missing preview on initial ctrl-shift-tab press

### DIFF
--- a/crates/tab_switcher/src/tab_switcher.rs
+++ b/crates/tab_switcher/src/tab_switcher.rs
@@ -529,7 +529,9 @@ impl TabSwitcherDelegate {
         }
 
         if self.select_last {
-            return self.matches.len() - 1;
+            let item_index = self.matches.len() - 1;
+            self.set_selected_index(item_index, window, cx);
+            return item_index;
         }
 
         // This only runs when initially opening the picker


### PR DESCRIPTION
Closes #44852

Release Notes:

- Fixed tab preview not showing up on initial ctrl-shift-tab press
