### PR TITLE
project: Sanitize single-line completions from trailing newlines

### DIFF
--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -13482,7 +13482,7 @@ impl From<lsp::Documentation> for CompletionDocumentation {
         match docs {
             lsp::Documentation::String(text) => {
                 if text.lines().count() <= 1 {
-                    CompletionDocumentation::SingleLine(text.into())
+                    CompletionDocumentation::SingleLine(text.trim().to_string().into())
                 } else {
                     CompletionDocumentation::MultiLinePlainText(text.into())
                 }

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -13491,7 +13491,7 @@ impl From<lsp::Documentation> for CompletionDocumentation {
             lsp::Documentation::MarkupContent(lsp::MarkupContent { kind, value }) => match kind {
                 lsp::MarkupKind::PlainText => {
                     if value.lines().count() <= 1 {
-                        CompletionDocumentation::SingleLine(value.into())
+                        CompletionDocumentation::SingleLine(text.trim().to_string().into())
                     } else {
                         CompletionDocumentation::MultiLinePlainText(value.into())
                     }

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -13491,7 +13491,7 @@ impl From<lsp::Documentation> for CompletionDocumentation {
             lsp::Documentation::MarkupContent(lsp::MarkupContent { kind, value }) => match kind {
                 lsp::MarkupKind::PlainText => {
                     if value.lines().count() <= 1 {
-                        CompletionDocumentation::SingleLine(text.trim().to_string().into())
+                        CompletionDocumentation::SingleLine(value.into())
                     } else {
                         CompletionDocumentation::MultiLinePlainText(value.into())
                     }
@@ -14073,5 +14073,23 @@ mod tests {
                 vec![(0..6, HighlightId(1))],
             )
         );
+    }
+
+    #[test]
+    fn test_trailing_newline_in_completion_documentation() {
+        let doc =
+            lsp::Documentation::String("Inappropriate argument value (of correct type).\n".to_string());
+        let completion_doc: CompletionDocumentation = doc.into();
+        assert!(
+            matches!(completion_doc, CompletionDocumentation::SingleLine(s) if s == "Inappropriate argument value (of correct type).")
+        );
+
+        let doc = lsp::Documentation::String("  some value  \n".to_string());
+        let completion_doc: CompletionDocumentation = doc.into();
+        assert!(matches!(
+            completion_doc,
+            CompletionDocumentation::SingleLine(s) if s == "some value"
+        ));
+
     }
 }

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -14077,8 +14077,9 @@ mod tests {
 
     #[test]
     fn test_trailing_newline_in_completion_documentation() {
-        let doc =
-            lsp::Documentation::String("Inappropriate argument value (of correct type).\n".to_string());
+        let doc = lsp::Documentation::String(
+            "Inappropriate argument value (of correct type).\n".to_string(),
+        );
         let completion_doc: CompletionDocumentation = doc.into();
         assert!(
             matches!(completion_doc, CompletionDocumentation::SingleLine(s) if s == "Inappropriate argument value (of correct type).")
@@ -14090,6 +14091,5 @@ mod tests {
             completion_doc,
             CompletionDocumentation::SingleLine(s) if s == "some value"
         ));
-
     }
 }


### PR DESCRIPTION
Closes #43991
trim documentation string to prevent completion overlap


previous
[Screencast from 2025-12-16 14-55-58.webm](https://github.com/user-attachments/assets/d7674d82-63b0-4a85-a90f-b5c5091e4a82)
after change
[Screencast from 2025-12-16 14-50-05.webm](https://github.com/user-attachments/assets/109c22b5-3fff-49c8-a2ec-b1af467d6320)
Release Notes:

- Fixed an issue where completions in the completion menu would span multiple lines.
