### PR TITLE
fix: updated cursor linux keymap to use new AcceptNextWordEditPrediction

### DIFF
--- a/assets/keymaps/linux/cursor.json
+++ b/assets/keymaps/linux/cursor.json
@@ -70,7 +70,8 @@
     "context": "Editor && mode == full && edit_prediction",
     "use_key_equivalents": true,
     "bindings": {
-      "ctrl-right": "editor::AcceptPartialEditPrediction",
+      "ctrl-right": "editor::AcceptNextWordEditPrediction",
+      "ctrl-down": "editor::AcceptNextLineEditPrediction",
     },
   },
   {


### PR DESCRIPTION
### Problem

PR #44411 replaced the `editor::AcceptPartialEditPrediction` action with `editor::AcceptNextLineEditPrediction` and `editor::AcceptNextWordEditPrediction`. However, the Linux cursor keymap wasn't updated to reflect this change, causing a panic on startup for Linux users.

### Solution

Updated the Linux keymap configuration to reference the new actions

Release Notes:

- N/A