### PR TITLE
gpui: Add grid repeat min content API

### DIFF
--- a/crates/gpui/src/style.rs
+++ b/crates/gpui/src/style.rs
@@ -264,6 +264,10 @@ pub struct Style {
     /// Equivalent to the Tailwind `grid-cols-<number>`
     pub grid_cols: Option<u16>,
 
+    /// The grid columns with min-content minimum sizing.
+    /// Unlike grid_cols, it won't shrink to width 0 in AvailableSpace::MinContent constraints.
+    pub grid_cols_min_content: Option<u16>,
+
     /// The row span of this element
     /// Equivalent to the Tailwind `grid-rows-<number>`
     pub grid_rows: Option<u16>,
@@ -771,6 +775,7 @@ impl Default for Style {
             opacity: None,
             grid_rows: None,
             grid_cols: None,
+            grid_cols_min_content: None,
             grid_location: None,
 
             #[cfg(debug_assertions)]

--- a/crates/gpui/src/styled.rs
+++ b/crates/gpui/src/styled.rs
@@ -670,6 +670,13 @@ pub trait Styled: Sized {
         self
     }
 
+    /// Sets the grid columns with min-content minimum sizing.
+    /// Unlike grid_cols, it won't shrink to width 0 in AvailableSpace::MinContent constraints.
+    fn grid_cols_min_content(mut self, cols: u16) -> Self {
+        self.style().grid_cols_min_content = Some(cols);
+        self
+    }
+
     /// Sets the grid rows of this element.
     fn grid_rows(mut self, rows: u16) -> Self {
         self.style().grid_rows = Some(rows);


### PR DESCRIPTION
Required for https://github.com/zed-industries/zed/pull/44712

We started using `grid` for Markdown tables instead of flex (https://github.com/zed-industries/zed/pull/42674). This resulted in tables having a width of 0 inside popovers, since popovers are laid out using `AvailableSpace::MinContent`.

One way to fix this is to lay out popovers using `MaxContent` instead. But that would affect all Markdown rendered in popovers and could change how popovers look, or regress things.

The other option is to fix it where the problem actually is: `repeat(count, vec![minmax(length(0.0), fr(1.0))])`. Since the minimum width here is `0`, laying things out with `MinContent` causes the Markdown table to shrink completely. What we want instead is for the minimum width to be the min-content size, but only for Markdown rendered inside popovers.

This PR does exactly that, without interfering with the `grid_cols` API, which intentionally follows a TailwindCSS-like convention. See https://github.com/zed-industries/zed/pull/44368 for context.

Release Notes:

- N/A
