### PR TITLE
acp_thread: Decode file:// mention paths so non-ASCII names render correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,7 @@ dependencies = [
  "terminal",
  "ui",
  "url",
+ "urlencoding",
  "util",
  "uuid",
  "watch",

--- a/crates/acp_thread/Cargo.toml
+++ b/crates/acp_thread/Cargo.toml
@@ -46,6 +46,7 @@ url.workspace = true
 util.workspace = true
 uuid.workspace = true
 watch.workspace = true
+urlencoding.workspace = true
 
 [dev-dependencies]
 env_logger.workspace = true


### PR DESCRIPTION
## Summary

This fixes a minor bug I found #44981 

- Fix percent-encoded filenames appearing in agent mentions after message submission.
- Decode file:// paths in MentionUri::parse using the existing urlencoding crate (already used elsewhere in the codebase).
- Add tests for non-ASCII file URIs.

## Screenshots

<img width="409" height="116" alt="image" src="https://github.com/user-attachments/assets/32ef033b-6232-47c5-80c7-d5247d5dae88" />

## Release Notes

- Fixed percent-encoded filenames appearing in agent message file mentions.