### PR TITLE
agent_ui: Search models only by name

### DIFF
--- a/crates/agent_ui/src/acp/model_selector.rs
+++ b/crates/agent_ui/src/acp/model_selector.rs
@@ -403,9 +403,7 @@ async fn fuzzy_search(
         let candidates = model_list
             .iter()
             .enumerate()
-            .map(|(ix, model)| {
-                StringMatchCandidate::new(ix, &format!("{}/{}", model.id, model.name))
-            })
+            .map(|(ix, model)| StringMatchCandidate::new(ix, model.name.as_ref()))
             .collect::<Vec<_>>();
         let mut matches = match_strings(
             &candidates,


### PR DESCRIPTION
We were previously matching the search on both model name and provider ID. In most cases, this would yield an okay result, but if you search for "Opus", for example, you'd see the Sonnet models in the search result, which was very confusing. This was because we were matching to both provider ID and model name. "Sonnet" and "Opus" share the same provider ID, so they both contain "Anthropic" as a prefix. Then, "Opus" contains the letter P, as well as Anthropic, thus the match.

Now, we're only matching by model name, which I think most of the time will yield more accurate results.

Release Notes:

- agent: Improved the model search quality in the model picker.
