### PR TITLE
ui: Fix Divider component growing unnecessarily

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -6050,9 +6050,9 @@ impl Render for ProjectPanel {
                     h_flex()
                         .w_1_2()
                         .gap_2()
-                        .child(div().flex_1().child(Divider::horizontal()))
+                        .child(Divider::horizontal())
                         .child(Label::new("or").size(LabelSize::XSmall).color(Color::Muted))
-                        .child(div().flex_1().child(Divider::horizontal())),
+                        .child(Divider::horizontal()),
                 )
                 .child(
                     Button::new("clone_repo", "Clone Repository")

--- a/crates/ui/src/components/divider.rs
+++ b/crates/ui/src/components/divider.rs
@@ -146,13 +146,11 @@ impl RenderOnce for Divider {
         let base = match self.direction {
             DividerDirection::Horizontal => div()
                 .min_w_0()
-                .flex_none()
                 .h_px()
                 .w_full()
                 .when(self.inset, |this| this.mx_1p5()),
             DividerDirection::Vertical => div()
                 .min_w_0()
-                .flex_none()
                 .w_px()
                 .h_full()
                 .when(self.inset, |this| this.my_1p5()),


### PR DESCRIPTION
I had previously added `flex_none` to the Divider and that caused it to grow beyond the container's width in some cases (project panel, agent panel's restore to check point button, etc.).

Release Notes:

- N/A
