### PR TITLE
collab: Update extensions filter to consider description

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3336,6 +3336,7 @@ dependencies = [
  "scrypt",
  "sea-orm",
  "sea-orm-macros",
+ "sea-query",
  "semver",
  "serde",
  "serde_json",
@@ -14427,6 +14428,7 @@ dependencies = [
  "inherent",
  "ordered-float 4.6.0",
  "rust_decimal",
+ "sea-query-derive",
  "serde_json",
  "time",
  "uuid",
@@ -14446,6 +14448,20 @@ dependencies = [
  "sqlx",
  "time",
  "uuid",
+]
+
+[[package]]
+name = "sea-query-derive"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bae0cbad6ab996955664982739354128c58d16e126114fe88c2a493642502aab"
+dependencies = [
+ "darling",
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "thiserror 2.0.17",
 ]
 
 [[package]]

--- a/crates/collab/Cargo.toml
+++ b/crates/collab/Cargo.toml
@@ -49,6 +49,7 @@ rpc.workspace = true
 scrypt = "0.11"
 # sea-orm and sea-orm-macros versions must match exactly.
 sea-orm = { version = "=1.1.10", features = ["sqlx-postgres", "postgres-array", "runtime-tokio-rustls", "with-uuid"] }
+sea-query = { version = "=0.32.7", features = ["backend-postgres"]}
 sea-orm-macros = "=1.1.10"
 semver.workspace = true
 serde.workspace = true


### PR DESCRIPTION
Update the condition built by `Database.get_extensions` in order to also apply the same `ILIKE` filter on the `extension_version.description` column so that, if provided, a search filter can match on either the extension's name or description.

The `backend-postgres` feature is also added to the `sea-query` crate so that we can access the `ilike` method, which would otherwise not be available even though we now we're running a Postgres database.

Closes #43079 

Release Notes:

- Improved search results in "Extensions" to also compare the extension's description to the provided search query