### PR TITLE
git: Allow customising commit message prompt from rules library

### DIFF
--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -414,10 +414,7 @@ impl NativeAgent {
                 .into_iter()
                 .flat_map(|(contents, prompt_metadata)| match contents {
                     Ok(contents) => Some(UserRulesContext {
-                        uuid: match prompt_metadata.id {
-                            prompt_store::PromptId::User { uuid } => uuid,
-                            prompt_store::PromptId::EditWorkflow => return None,
-                        },
+                        uuid: prompt_metadata.id.user_id()?,
                         title: prompt_metadata.title.map(|title| title.to_string()),
                         contents,
                     }),

--- a/crates/agent_ui/src/completion_provider.rs
+++ b/crates/agent_ui/src/completion_provider.rs
@@ -20,7 +20,7 @@ use project::{
     Completion, CompletionDisplayOptions, CompletionIntent, CompletionResponse,
     PathMatchCandidateSet, Project, ProjectPath, Symbol, WorktreeId,
 };
-use prompt_store::{PromptId, PromptStore, UserPromptId};
+use prompt_store::{PromptStore, UserPromptId};
 use rope::Point;
 use text::{Anchor, ToPoint as _};
 use ui::prelude::*;
@@ -1585,13 +1585,10 @@ pub(crate) fn search_rules(
                 if metadata.default {
                     None
                 } else {
-                    match metadata.id {
-                        PromptId::EditWorkflow => None,
-                        PromptId::User { uuid } => Some(RulesContextEntry {
-                            prompt_id: uuid,
-                            title: metadata.title?,
-                        }),
-                    }
+                    Some(RulesContextEntry {
+                        prompt_id: metadata.id.user_id()?,
+                        title: metadata.title?,
+                    })
                 }
             })
             .collect::<Vec<_>>()

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -57,7 +57,7 @@ use project::{
     git_store::{GitStoreEvent, Repository, RepositoryEvent, RepositoryId, pending_op},
     project_settings::{GitPathStyle, ProjectSettings},
 };
-use prompt_store::RULES_FILE_NAMES;
+use prompt_store::{PromptId, PromptStore, RULES_FILE_NAMES};
 use serde::{Deserialize, Serialize};
 use settings::{Settings, SettingsStore, StatusStyle};
 use std::future::Future;
@@ -2376,6 +2376,20 @@ impl GitPanel {
         }
     }
 
+    async fn load_commit_message_prompt(cx: &mut AsyncApp) -> String {
+        const DEFAULT_PROMPT: &str = include_str!("commit_message_prompt.txt");
+
+        let load = async {
+            let store = cx.update(|cx| PromptStore::global(cx)).ok()?.await.ok()?;
+            store
+                .update(cx, |s, cx| s.load(PromptId::CommitMessage, cx))
+                .ok()?
+                .await
+                .ok()
+        };
+        load.await.unwrap_or_else(|| DEFAULT_PROMPT.to_string())
+    }
+
     /// Generates a commit message using an LLM.
     pub fn generate_commit_message(&mut self, cx: &mut Context<Self>) {
         if !self.can_commit() || !AgentSettings::get_global(cx).enabled(cx) {
@@ -2441,13 +2455,13 @@ impl GitPanel {
 
                 let rules_content = Self::load_project_rules(&project, &repo_work_dir, &mut cx).await;
 
+                let prompt = Self::load_commit_message_prompt(&mut cx).await;
+
                 let subject = this.update(cx, |this, cx| {
                     this.commit_editor.read(cx).text(cx).lines().next().map(ToOwned::to_owned).unwrap_or_default()
                 })?;
 
                 let text_empty = subject.trim().is_empty();
-
-                const PROMPT: &str = include_str!("commit_message_prompt.txt");
 
                 let rules_section = match &rules_content {
                     Some(rules) => format!(
@@ -2464,7 +2478,7 @@ impl GitPanel {
                 };
 
                 let content = format!(
-                    "{PROMPT}{rules_section}{subject_section}\nHere are the changes in this commit:\n{diff_text}"
+                    "{prompt}{rules_section}{subject_section}\nHere are the changes in this commit:\n{diff_text}"
                 );
 
                 let request = LanguageModelRequest {

--- a/crates/prompt_store/src/prompt_store.rs
+++ b/crates/prompt_store/src/prompt_store.rs
@@ -85,20 +85,6 @@ impl PromptId {
         }
     }
 
-    pub fn can_delete(&self) -> bool {
-        match self {
-            Self::User { .. } => true,
-            Self::EditWorkflow | Self::CommitMessage => false,
-        }
-    }
-
-    pub fn can_rename(&self) -> bool {
-        match self {
-            Self::User { .. } => true,
-            Self::EditWorkflow | Self::CommitMessage => false,
-        }
-    }
-
     pub fn default_content(&self) -> Option<&'static str> {
         match self {
             Self::User { .. } | Self::EditWorkflow => None,
@@ -489,7 +475,7 @@ impl PromptStore {
     ) -> Task<Result<()>> {
         let mut cache = self.metadata_cache.write();
 
-        if !id.can_rename() {
+        if !id.can_edit() {
             title = cache
                 .metadata_by_id
                 .get(&id)


### PR DESCRIPTION
Closes #26823 

Release Notes:

- Added support for customizing the prompt used for generating commit message in the rules library
