### PR TITLE
Re-add save_file and restore_file_from_disk agent tools

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -972,6 +972,8 @@
           "now": true,
           "find_path": true,
           "read_file": true,
+          "restore_file_from_disk": true,
+          "save_file": true,
           "open": true,
           "grep": true,
           "terminal": true,

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -2,8 +2,8 @@ use crate::{
     ContextServerRegistry, CopyPathTool, CreateDirectoryTool, DbLanguageModel, DbThread,
     DeletePathTool, DiagnosticsTool, EditFileTool, FetchTool, FindPathTool, GrepTool,
     ListDirectoryTool, MovePathTool, NowTool, OpenTool, ProjectSnapshot, ReadFileTool,
-    SaveFileTool, SystemPromptTemplate, Template, Templates, TerminalTool, ThinkingTool,
-    WebSearchTool,
+    RestoreFileFromDiskTool, SaveFileTool, SystemPromptTemplate, Template, Templates, TerminalTool,
+    ThinkingTool, WebSearchTool,
 };
 use acp_thread::{MentionUri, UserMessageId};
 use action_log::ActionLog;
@@ -1004,6 +1004,7 @@ impl Thread {
             self.action_log.clone(),
         ));
         self.add_tool(SaveFileTool::new(self.project.clone()));
+        self.add_tool(RestoreFileFromDiskTool::new(self.project.clone()));
         self.add_tool(TerminalTool::new(self.project.clone(), environment));
         self.add_tool(ThinkingTool);
         self.add_tool(WebSearchTool);

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1969,6 +1969,12 @@ impl Thread {
         self.running_turn.as_ref()?.tools.get(name).cloned()
     }
 
+    pub fn has_tool(&self, name: &str) -> bool {
+        self.running_turn
+            .as_ref()
+            .is_some_and(|turn| turn.tools.contains_key(name))
+    }
+
     fn build_request_messages(
         &self,
         available_tools: Vec<SharedString>,

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -2,7 +2,8 @@ use crate::{
     ContextServerRegistry, CopyPathTool, CreateDirectoryTool, DbLanguageModel, DbThread,
     DeletePathTool, DiagnosticsTool, EditFileTool, FetchTool, FindPathTool, GrepTool,
     ListDirectoryTool, MovePathTool, NowTool, OpenTool, ProjectSnapshot, ReadFileTool,
-    SystemPromptTemplate, Template, Templates, TerminalTool, ThinkingTool, WebSearchTool,
+    SaveFileTool, SystemPromptTemplate, Template, Templates, TerminalTool, ThinkingTool,
+    WebSearchTool,
 };
 use acp_thread::{MentionUri, UserMessageId};
 use action_log::ActionLog;
@@ -1002,6 +1003,7 @@ impl Thread {
             self.project.clone(),
             self.action_log.clone(),
         ));
+        self.add_tool(SaveFileTool::new(self.project.clone()));
         self.add_tool(TerminalTool::new(self.project.clone(), environment));
         self.add_tool(ThinkingTool);
         self.add_tool(WebSearchTool);

--- a/crates/agent/src/tools.rs
+++ b/crates/agent/src/tools.rs
@@ -13,6 +13,7 @@ mod move_path_tool;
 mod now_tool;
 mod open_tool;
 mod read_file_tool;
+mod save_file_tool;
 
 mod terminal_tool;
 mod thinking_tool;
@@ -36,6 +37,7 @@ pub use move_path_tool::*;
 pub use now_tool::*;
 pub use open_tool::*;
 pub use read_file_tool::*;
+pub use save_file_tool::*;
 
 pub use terminal_tool::*;
 pub use thinking_tool::*;
@@ -92,6 +94,7 @@ tools! {
     NowTool,
     OpenTool,
     ReadFileTool,
+    SaveFileTool,
     TerminalTool,
     ThinkingTool,
     WebSearchTool,

--- a/crates/agent/src/tools.rs
+++ b/crates/agent/src/tools.rs
@@ -4,7 +4,6 @@ mod create_directory_tool;
 mod delete_path_tool;
 mod diagnostics_tool;
 mod edit_file_tool;
-
 mod fetch_tool;
 mod find_path_tool;
 mod grep_tool;
@@ -13,6 +12,7 @@ mod move_path_tool;
 mod now_tool;
 mod open_tool;
 mod read_file_tool;
+mod restore_file_from_disk_tool;
 mod save_file_tool;
 
 mod terminal_tool;
@@ -28,7 +28,6 @@ pub use create_directory_tool::*;
 pub use delete_path_tool::*;
 pub use diagnostics_tool::*;
 pub use edit_file_tool::*;
-
 pub use fetch_tool::*;
 pub use find_path_tool::*;
 pub use grep_tool::*;
@@ -37,6 +36,7 @@ pub use move_path_tool::*;
 pub use now_tool::*;
 pub use open_tool::*;
 pub use read_file_tool::*;
+pub use restore_file_from_disk_tool::*;
 pub use save_file_tool::*;
 
 pub use terminal_tool::*;
@@ -94,6 +94,7 @@ tools! {
     NowTool,
     OpenTool,
     ReadFileTool,
+    RestoreFileFromDiskTool,
     SaveFileTool,
     TerminalTool,
     ThinkingTool,

--- a/crates/agent/src/tools/edit_file_tool.rs
+++ b/crates/agent/src/tools/edit_file_tool.rs
@@ -316,9 +316,8 @@ impl AgentTool for EditFileTool {
                 // Check for unsaved changes first - these indicate modifications we don't know about
                 if is_dirty {
                     anyhow::bail!(
-                        "This file cannot be written to because it has unsaved changes. \
-                         Please end the current conversation immediately by telling the user you want to write to this file (mention its path explicitly) but you can't write to it because it has unsaved changes. \
-                         Ask the user to save that buffer's changes and to inform you when it's ok to proceed."
+                        "This file has unsaved changes. Ask the user if they would like you to save the file. \
+                         If they agree, use the save_file tool to save it, then retry this edit."
                     );
                 }
 

--- a/crates/agent/src/tools/edit_file_tool.rs
+++ b/crates/agent/src/tools/edit_file_tool.rs
@@ -347,7 +347,6 @@ impl AgentTool for EditFileTool {
                }
             });
 
-
             let old_snapshot = buffer.read_with(cx, |buffer, _cx| buffer.snapshot())?;
             let old_text = cx
                 .background_spawn({

--- a/crates/agent/src/tools/edit_file_tool.rs
+++ b/crates/agent/src/tools/edit_file_tool.rs
@@ -316,8 +316,9 @@ impl AgentTool for EditFileTool {
                 // Check for unsaved changes first - these indicate modifications we don't know about
                 if is_dirty {
                     anyhow::bail!(
-                        "This file has unsaved changes. Ask the user if they would like you to save the file. \
-                         If they agree, use the save_file tool to save it, then retry this edit."
+                        "This file has unsaved changes. Ask the user whether they want to keep or discard those changes. \
+                         If they want to keep them, ask for confirmation then use the save_file tool to save the file, then retry this edit. \
+                         If they want to discard them, ask for confirmation then use the restore_file_from_disk tool to restore the on-disk contents, then retry this edit."
                     );
                 }
 
@@ -2203,6 +2204,21 @@ mod tests {
         assert!(
             error_msg.contains("This file has unsaved changes."),
             "Error should mention unsaved changes, got: {}",
+            error_msg
+        );
+        assert!(
+            error_msg.contains("keep or discard"),
+            "Error should ask whether to keep or discard changes, got: {}",
+            error_msg
+        );
+        assert!(
+            error_msg.contains("save_file"),
+            "Error should reference save_file tool, got: {}",
+            error_msg
+        );
+        assert!(
+            error_msg.contains("restore_file_from_disk"),
+            "Error should reference restore_file_from_disk tool, got: {}",
             error_msg
         );
     }

--- a/crates/agent/src/tools/edit_file_tool.rs
+++ b/crates/agent/src/tools/edit_file_tool.rs
@@ -347,6 +347,23 @@ impl AgentTool for EditFileTool {
                    diff.update(&mut cx, |diff, cx| diff.finalize(cx)).ok();
                }
             });
+            let save_on_cancel = util::defer({
+                let buffer = buffer.clone();
+                let project = project.clone();
+                let mut cx = cx.clone();
+                move || {
+                    let is_dirty = buffer
+                        .read_with(&cx, |buffer, _| buffer.is_dirty())
+                        .unwrap_or(false);
+                    if is_dirty {
+                        if let Ok(task) = project.update(&mut cx, |project, cx| {
+                            project.save_buffer(buffer, cx)
+                        }) {
+                            task.detach();
+                        }
+                    }
+                }
+            });
 
             let old_snapshot = buffer.read_with(cx, |buffer, _cx| buffer.snapshot())?;
             let old_text = cx
@@ -439,6 +456,7 @@ impl AgentTool for EditFileTool {
                 format_task.await.log_err();
             }
 
+            save_on_cancel.abort();
             project
                 .update(cx, |project, cx| project.save_buffer(buffer.clone(), cx))?
                 .await?;
@@ -1783,6 +1801,102 @@ mod tests {
             cx.run_until_parked();
             diff.read_with(cx, |diff, _| assert!(matches!(diff, Diff::Finalized(_))));
         }
+    }
+
+    #[gpui::test]
+    async fn test_save_on_cancel(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = project::FakeFs::new(cx.executor());
+        fs.insert_tree(
+            "/root",
+            json!({
+                "test.txt": "original content"
+            }),
+        )
+        .await;
+        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
+        let context_server_registry =
+            cx.new(|cx| ContextServerRegistry::new(project.read(cx).context_server_store(), cx));
+        let model = Arc::new(FakeLanguageModel::default());
+        let thread = cx.new(|cx| {
+            Thread::new(
+                project.clone(),
+                cx.new(|_cx| ProjectContext::default()),
+                context_server_registry,
+                Templates::new(),
+                Some(model.clone()),
+                cx,
+            )
+        });
+        let languages = project.read_with(cx, |project, _| project.languages().clone());
+        let action_log = thread.read_with(cx, |thread, _| thread.action_log().clone());
+
+        let read_tool = Arc::new(crate::ReadFileTool::new(
+            thread.downgrade(),
+            project.clone(),
+            action_log,
+        ));
+        let edit_tool = Arc::new(EditFileTool::new(
+            project.clone(),
+            thread.downgrade(),
+            languages,
+            Templates::new(),
+        ));
+
+        // Read the file first to record the read time
+        cx.update(|cx| {
+            read_tool.clone().run(
+                crate::ReadFileToolInput {
+                    path: "root/test.txt".to_string(),
+                    start_line: None,
+                    end_line: None,
+                },
+                ToolCallEventStream::test().0,
+                cx,
+            )
+        })
+        .await
+        .unwrap();
+
+        // Start an edit task
+        let (stream_tx, mut stream_rx) = ToolCallEventStream::test();
+        let edit_task = cx.update(|cx| {
+            edit_tool.clone().run(
+                EditFileToolInput {
+                    display_description: "Edit file".into(),
+                    path: "root/test.txt".into(),
+                    mode: EditFileMode::Edit,
+                },
+                stream_tx,
+                cx,
+            )
+        });
+
+        // Wait for the diff to be created (tool has opened buffer and is ready)
+        stream_rx.expect_update_fields().await;
+        let _diff = stream_rx.expect_diff().await;
+
+        // Run until parked to ensure the LLM request has been started
+        cx.executor().run_until_parked();
+
+        // Send an edit chunk and let it be processed
+        model.send_last_completion_stream_text_chunk(
+            "<old_text>original content</old_text><new_text>modified content</new_text>"
+                .to_string(),
+        );
+        cx.executor().run_until_parked();
+
+        // Drop the task to simulate cancellation (before the model stream ends)
+        drop(edit_task);
+        cx.executor().run_until_parked();
+
+        // Verify the file was saved to disk with the modified content
+        let file_content = fs.load(path!("/root/test.txt").as_ref()).await.unwrap();
+        assert_eq!(
+            file_content, "modified content",
+            "File should be saved on cancel with the streamed content"
+        );
     }
 
     #[gpui::test]

--- a/crates/agent/src/tools/restore_file_from_disk_tool.rs
+++ b/crates/agent/src/tools/restore_file_from_disk_tool.rs
@@ -144,50 +144,34 @@ impl AgentTool for RestoreFileFromDiskTool {
             }
 
             let mut lines: Vec<String> = Vec::new();
+
             if !restored_paths.is_empty() {
-                lines.push(format!(
-                    "Restored {} file(s) from disk (discarded unsaved changes).",
-                    restored_paths.len()
-                ));
+                lines.push(format!("Restored {} file(s).", restored_paths.len()));
             }
             if !clean_paths.is_empty() {
-                lines.push(format!(
-                    "{} file(s) had no unsaved changes.",
-                    clean_paths.len()
-                ));
+                lines.push(format!("{} clean.", clean_paths.len()));
             }
+
             if !not_found_paths.is_empty() {
-                lines.push(format!(
-                    "{} path(s) were not found in the project:",
-                    not_found_paths.len()
-                ));
+                lines.push(format!("Not found ({}):", not_found_paths.len()));
                 for path in &not_found_paths {
                     lines.push(format!("- {}", path.display()));
                 }
             }
             if !open_errors.is_empty() {
-                lines.push(format!(
-                    "{} error(s) occurred while opening buffers:",
-                    open_errors.len()
-                ));
+                lines.push(format!("Open failed ({}):", open_errors.len()));
                 for (path, error) in &open_errors {
                     lines.push(format!("- {}: {}", path.display(), error));
                 }
             }
             if !dirty_check_errors.is_empty() {
-                lines.push(format!(
-                    "{} error(s) occurred while checking for unsaved changes:",
-                    dirty_check_errors.len()
-                ));
+                lines.push(format!("Dirty check failed ({}):", dirty_check_errors.len()));
                 for (path, error) in &dirty_check_errors {
                     lines.push(format!("- {}: {}", path.display(), error));
                 }
             }
             if !reload_errors.is_empty() {
-                lines.push(format!(
-                    "{} error(s) occurred while reloading buffers:",
-                    reload_errors.len()
-                ));
+                lines.push(format!("Reload failed ({}):", reload_errors.len()));
                 for error in &reload_errors {
                     lines.push(format!("- {}", error));
                 }
@@ -294,16 +278,16 @@ mod tests {
 
         // Output should mention restored + clean.
         assert!(
-            output.contains("Restored 1 file(s) from disk (discarded unsaved changes)."),
+            output.contains("Restored 1 file(s)."),
             "expected restored count line, got:\n{output}"
         );
         assert!(
-            output.contains("1 file(s) had no unsaved changes."),
+            output.contains("1 clean."),
             "expected clean count line, got:\n{output}"
         );
 
         // Effect: dirty buffer should be restored back to disk content and become clean.
-        let dirty_text = dirty_buffer.read_with(cx, |buffer, _| buffer.text().to_string());
+        let dirty_text = dirty_buffer.read_with(cx, |buffer, _| buffer.text());
         assert_eq!(
             dirty_text, "on disk: dirty\n",
             "dirty.txt buffer should be restored to disk contents"
@@ -318,7 +302,7 @@ mod tests {
         assert_eq!(disk_dirty, "on disk: dirty\n");
 
         // Sanity: clean buffer should remain clean and unchanged.
-        let clean_text = clean_buffer.read_with(cx, |buffer, _| buffer.text().to_string());
+        let clean_text = clean_buffer.read_with(cx, |buffer, _| buffer.text());
         assert_eq!(clean_text, "on disk: clean\n");
         assert!(
             !clean_buffer.read_with(cx, |buffer, _| buffer.is_dirty()),
@@ -352,7 +336,7 @@ mod tests {
             .await
             .unwrap();
         assert!(
-            output.contains("1 path(s) were not found in the project:"),
+            output.contains("Not found (1):"),
             "expected not-found header line, got:\n{output}"
         );
         assert!(

--- a/crates/agent/src/tools/restore_file_from_disk_tool.rs
+++ b/crates/agent/src/tools/restore_file_from_disk_tool.rs
@@ -165,7 +165,10 @@ impl AgentTool for RestoreFileFromDiskTool {
                 }
             }
             if !dirty_check_errors.is_empty() {
-                lines.push(format!("Dirty check failed ({}):", dirty_check_errors.len()));
+                lines.push(format!(
+                    "Dirty check failed ({}):",
+                    dirty_check_errors.len()
+                ));
                 for (path, error) in &dirty_check_errors {
                     lines.push(format!("- {}: {}", path.display(), error));
                 }

--- a/crates/agent/src/tools/restore_file_from_disk_tool.rs
+++ b/crates/agent/src/tools/restore_file_from_disk_tool.rs
@@ -1,0 +1,203 @@
+use agent_client_protocol as acp;
+use anyhow::Result;
+use collections::FxHashSet;
+use gpui::{App, Entity, SharedString, Task};
+use language::Buffer;
+use project::Project;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use crate::{AgentTool, ToolCallEventStream};
+
+/// Discards unsaved changes in open buffers by reloading file contents from disk.
+///
+/// Use this tool when:
+/// - You attempted to edit files but they have unsaved changes the user does not want to keep.
+/// - You want to reset files to the on-disk state before retrying an edit.
+///
+/// Only use this tool after asking the user for permission, because it will discard unsaved changes.
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct RestoreFileFromDiskToolInput {
+    /// The paths of the files to restore from disk.
+    pub paths: Vec<PathBuf>,
+}
+
+pub struct RestoreFileFromDiskTool {
+    project: Entity<Project>,
+}
+
+impl RestoreFileFromDiskTool {
+    pub fn new(project: Entity<Project>) -> Self {
+        Self { project }
+    }
+}
+
+impl AgentTool for RestoreFileFromDiskTool {
+    type Input = RestoreFileFromDiskToolInput;
+    type Output = String;
+
+    fn name() -> &'static str {
+        "restore_file_from_disk"
+    }
+
+    fn kind() -> acp::ToolKind {
+        acp::ToolKind::Other
+    }
+
+    fn initial_title(
+        &self,
+        input: Result<Self::Input, serde_json::Value>,
+        _cx: &mut App,
+    ) -> SharedString {
+        match input {
+            Ok(input) if input.paths.len() == 1 => "Restore file from disk".into(),
+            Ok(input) => format!("Restore {} files from disk", input.paths.len()).into(),
+            Err(_) => "Restore files from disk".into(),
+        }
+    }
+
+    fn run(
+        self: Arc<Self>,
+        input: Self::Input,
+        _event_stream: ToolCallEventStream,
+        cx: &mut App,
+    ) -> Task<Result<String>> {
+        let project = self.project.clone();
+        let input_paths = input.paths;
+
+        cx.spawn(async move |cx| {
+            let mut buffers_to_reload: FxHashSet<Entity<Buffer>> = FxHashSet::default();
+
+            let mut restored_paths: Vec<PathBuf> = Vec::new();
+            let mut clean_paths: Vec<PathBuf> = Vec::new();
+            let mut not_found_paths: Vec<PathBuf> = Vec::new();
+            let mut open_errors: Vec<(PathBuf, String)> = Vec::new();
+            let mut dirty_check_errors: Vec<(PathBuf, String)> = Vec::new();
+            let mut reload_errors: Vec<String> = Vec::new();
+
+            for path in input_paths {
+                let project_path =
+                    project.read_with(cx, |project, cx| project.find_project_path(&path, cx));
+
+                let project_path = match project_path {
+                    Ok(Some(project_path)) => project_path,
+                    Ok(None) => {
+                        not_found_paths.push(path);
+                        continue;
+                    }
+                    Err(error) => {
+                        open_errors.push((path, error.to_string()));
+                        continue;
+                    }
+                };
+
+                let open_buffer_task =
+                    project.update(cx, |project, cx| project.open_buffer(project_path, cx));
+
+                let buffer = match open_buffer_task {
+                    Ok(task) => match task.await {
+                        Ok(buffer) => buffer,
+                        Err(error) => {
+                            open_errors.push((path, error.to_string()));
+                            continue;
+                        }
+                    },
+                    Err(error) => {
+                        open_errors.push((path, error.to_string()));
+                        continue;
+                    }
+                };
+
+                let is_dirty = match buffer.read_with(cx, |buffer, _| buffer.is_dirty()) {
+                    Ok(is_dirty) => is_dirty,
+                    Err(error) => {
+                        dirty_check_errors.push((path, error.to_string()));
+                        continue;
+                    }
+                };
+
+                if is_dirty {
+                    buffers_to_reload.insert(buffer);
+                    restored_paths.push(path);
+                } else {
+                    clean_paths.push(path);
+                }
+            }
+
+            if !buffers_to_reload.is_empty() {
+                let reload_task = project.update(cx, |project, cx| {
+                    project.reload_buffers(buffers_to_reload, true, cx)
+                });
+
+                match reload_task {
+                    Ok(task) => {
+                        if let Err(error) = task.await {
+                            reload_errors.push(error.to_string());
+                        }
+                    }
+                    Err(error) => {
+                        reload_errors.push(error.to_string());
+                    }
+                }
+            }
+
+            let mut lines: Vec<String> = Vec::new();
+            if !restored_paths.is_empty() {
+                lines.push(format!(
+                    "Restored {} file(s) from disk (discarded unsaved changes).",
+                    restored_paths.len()
+                ));
+            }
+            if !clean_paths.is_empty() {
+                lines.push(format!(
+                    "{} file(s) had no unsaved changes.",
+                    clean_paths.len()
+                ));
+            }
+            if !not_found_paths.is_empty() {
+                lines.push(format!(
+                    "{} path(s) were not found in the project:",
+                    not_found_paths.len()
+                ));
+                for path in &not_found_paths {
+                    lines.push(format!("- {}", path.display()));
+                }
+            }
+            if !open_errors.is_empty() {
+                lines.push(format!(
+                    "{} error(s) occurred while opening buffers:",
+                    open_errors.len()
+                ));
+                for (path, error) in &open_errors {
+                    lines.push(format!("- {}: {}", path.display(), error));
+                }
+            }
+            if !dirty_check_errors.is_empty() {
+                lines.push(format!(
+                    "{} error(s) occurred while checking for unsaved changes:",
+                    dirty_check_errors.len()
+                ));
+                for (path, error) in &dirty_check_errors {
+                    lines.push(format!("- {}: {}", path.display(), error));
+                }
+            }
+            if !reload_errors.is_empty() {
+                lines.push(format!(
+                    "{} error(s) occurred while reloading buffers:",
+                    reload_errors.len()
+                ));
+                for error in &reload_errors {
+                    lines.push(format!("- {}", error));
+                }
+            }
+
+            if lines.is_empty() {
+                Ok("No paths provided.".to_string())
+            } else {
+                Ok(lines.join("\n"))
+            }
+        })
+    }
+}

--- a/crates/agent/src/tools/save_file_tool.rs
+++ b/crates/agent/src/tools/save_file_tool.rs
@@ -1,6 +1,8 @@
 use agent_client_protocol as acp;
-use anyhow::{Result, anyhow};
+use anyhow::Result;
+use collections::FxHashSet;
 use gpui::{App, Entity, SharedString, Task};
+use language::Buffer;
 use project::Project;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -9,14 +11,14 @@ use std::sync::Arc;
 
 use crate::{AgentTool, ToolCallEventStream};
 
-/// Saves a file that has unsaved changes.
+/// Saves files that have unsaved changes.
 ///
-/// Use this tool when you need to edit a file but it has unsaved changes that must be saved first.
+/// Use this tool when you need to edit files but they have unsaved changes that must be saved first.
 /// Only use this tool after asking the user for permission to save their unsaved changes.
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct SaveFileToolInput {
-    /// The path of the file to save.
-    pub path: PathBuf,
+    /// The paths of the files to save.
+    pub paths: Vec<PathBuf>,
 }
 
 pub struct SaveFileTool {
@@ -44,18 +46,12 @@ impl AgentTool for SaveFileTool {
     fn initial_title(
         &self,
         input: Result<Self::Input, serde_json::Value>,
-        cx: &mut App,
+        _cx: &mut App,
     ) -> SharedString {
-        if let Ok(input) = input
-            && let Some(project_path) = self.project.read(cx).find_project_path(&input.path, cx)
-            && let Some(path) = self
-                .project
-                .read(cx)
-                .short_full_path_for_project_path(&project_path, cx)
-        {
-            format!("Save file `{path}`").into()
-        } else {
-            "Save file".into()
+        match input {
+            Ok(input) if input.paths.len() == 1 => "Save file".into(),
+            Ok(input) => format!("Save {} files", input.paths.len()).into(),
+            Err(_) => "Save files".into(),
         }
     }
 
@@ -66,35 +62,287 @@ impl AgentTool for SaveFileTool {
         cx: &mut App,
     ) -> Task<Result<String>> {
         let project = self.project.clone();
-
-        let Some(project_path) = project.read(cx).find_project_path(&input.path, cx) else {
-            return Task::ready(Err(anyhow!(
-                "Path {} not found in project",
-                input.path.display()
-            )));
-        };
-
-        let open_buffer = project.update(cx, |project, cx| {
-            project.open_buffer(project_path.clone(), cx)
-        });
+        let input_paths = input.paths;
 
         cx.spawn(async move |cx| {
-            let buffer = open_buffer.await?;
+            let mut buffers_to_save: FxHashSet<Entity<Buffer>> = FxHashSet::default();
 
-            let is_dirty = buffer.read_with(cx, |buffer, _| buffer.is_dirty())?;
+            let mut saved_paths: Vec<PathBuf> = Vec::new();
+            let mut clean_paths: Vec<PathBuf> = Vec::new();
+            let mut not_found_paths: Vec<PathBuf> = Vec::new();
+            let mut open_errors: Vec<(PathBuf, String)> = Vec::new();
+            let mut dirty_check_errors: Vec<(PathBuf, String)> = Vec::new();
+            let mut save_errors: Vec<String> = Vec::new();
 
-            if !is_dirty {
-                return Ok(format!(
-                    "File {} has no unsaved changes.",
-                    input.path.display()
-                ));
+            for path in input_paths {
+                let project_path =
+                    project.read_with(cx, |project, cx| project.find_project_path(&path, cx));
+
+                let project_path = match project_path {
+                    Ok(Some(project_path)) => project_path,
+                    Ok(None) => {
+                        not_found_paths.push(path);
+                        continue;
+                    }
+                    Err(error) => {
+                        open_errors.push((path, error.to_string()));
+                        continue;
+                    }
+                };
+
+                let open_buffer_task =
+                    project.update(cx, |project, cx| project.open_buffer(project_path, cx));
+
+                let buffer = match open_buffer_task {
+                    Ok(task) => match task.await {
+                        Ok(buffer) => buffer,
+                        Err(error) => {
+                            open_errors.push((path, error.to_string()));
+                            continue;
+                        }
+                    },
+                    Err(error) => {
+                        open_errors.push((path, error.to_string()));
+                        continue;
+                    }
+                };
+
+                let is_dirty = match buffer.read_with(cx, |buffer, _| buffer.is_dirty()) {
+                    Ok(is_dirty) => is_dirty,
+                    Err(error) => {
+                        dirty_check_errors.push((path, error.to_string()));
+                        continue;
+                    }
+                };
+
+                if is_dirty {
+                    buffers_to_save.insert(buffer);
+                    saved_paths.push(path);
+                } else {
+                    clean_paths.push(path);
+                }
             }
 
-            project
-                .update(cx, |project, cx| project.save_buffer(buffer, cx))?
-                .await?;
+            // Save each buffer individually since there's no batch save API
+            for buffer in buffers_to_save {
+                let save_task = project.update(cx, |project, cx| project.save_buffer(buffer, cx));
 
-            Ok(format!("Saved {}.", input.path.display()))
+                match save_task {
+                    Ok(task) => {
+                        if let Err(error) = task.await {
+                            save_errors.push(error.to_string());
+                        }
+                    }
+                    Err(error) => {
+                        save_errors.push(error.to_string());
+                    }
+                }
+            }
+
+            let mut lines: Vec<String> = Vec::new();
+            if !saved_paths.is_empty() {
+                lines.push(format!("Saved {} file(s).", saved_paths.len()));
+            }
+            if !clean_paths.is_empty() {
+                lines.push(format!(
+                    "{} file(s) had no unsaved changes.",
+                    clean_paths.len()
+                ));
+            }
+            if !not_found_paths.is_empty() {
+                lines.push(format!(
+                    "{} path(s) were not found in the project:",
+                    not_found_paths.len()
+                ));
+                for path in &not_found_paths {
+                    lines.push(format!("- {}", path.display()));
+                }
+            }
+            if !open_errors.is_empty() {
+                lines.push(format!(
+                    "{} error(s) occurred while opening buffers:",
+                    open_errors.len()
+                ));
+                for (path, error) in &open_errors {
+                    lines.push(format!("- {}: {}", path.display(), error));
+                }
+            }
+            if !dirty_check_errors.is_empty() {
+                lines.push(format!(
+                    "{} error(s) occurred while checking for unsaved changes:",
+                    dirty_check_errors.len()
+                ));
+                for (path, error) in &dirty_check_errors {
+                    lines.push(format!("- {}: {}", path.display(), error));
+                }
+            }
+            if !save_errors.is_empty() {
+                lines.push(format!(
+                    "{} error(s) occurred while saving files:",
+                    save_errors.len()
+                ));
+                for error in &save_errors {
+                    lines.push(format!("- {}", error));
+                }
+            }
+
+            if lines.is_empty() {
+                Ok("No paths provided.".to_string())
+            } else {
+                Ok(lines.join("\n"))
+            }
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fs::Fs;
+    use gpui::TestAppContext;
+    use project::FakeFs;
+    use serde_json::json;
+    use settings::SettingsStore;
+    use util::path;
+
+    fn init_test(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            let settings_store = SettingsStore::test(cx);
+            cx.set_global(settings_store);
+        });
+    }
+
+    #[gpui::test]
+    async fn test_save_file_output_and_effects(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            "/root",
+            json!({
+                "dirty.txt": "on disk: dirty\n",
+                "clean.txt": "on disk: clean\n",
+            }),
+        )
+        .await;
+
+        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
+        let tool = Arc::new(SaveFileTool::new(project.clone()));
+
+        // Make dirty.txt dirty in-memory.
+        let dirty_project_path = project.read_with(cx, |project, cx| {
+            project
+                .find_project_path("root/dirty.txt", cx)
+                .expect("dirty.txt should exist in project")
+        });
+
+        let dirty_buffer = project
+            .update(cx, |project, cx| {
+                project.open_buffer(dirty_project_path, cx)
+            })
+            .await
+            .unwrap();
+        dirty_buffer.update(cx, |buffer, cx| {
+            buffer.edit([(0..buffer.len(), "in memory: dirty\n")], None, cx);
+        });
+        assert!(
+            dirty_buffer.read_with(cx, |buffer, _| buffer.is_dirty()),
+            "dirty.txt buffer should be dirty before save"
+        );
+
+        // Ensure clean.txt is opened but remains clean.
+        let clean_project_path = project.read_with(cx, |project, cx| {
+            project
+                .find_project_path("root/clean.txt", cx)
+                .expect("clean.txt should exist in project")
+        });
+
+        let clean_buffer = project
+            .update(cx, |project, cx| {
+                project.open_buffer(clean_project_path, cx)
+            })
+            .await
+            .unwrap();
+        assert!(
+            !clean_buffer.read_with(cx, |buffer, _| buffer.is_dirty()),
+            "clean.txt buffer should start clean"
+        );
+
+        let output = cx
+            .update(|cx| {
+                tool.clone().run(
+                    SaveFileToolInput {
+                        paths: vec![
+                            PathBuf::from("root/dirty.txt"),
+                            PathBuf::from("root/clean.txt"),
+                        ],
+                    },
+                    ToolCallEventStream::test().0,
+                    cx,
+                )
+            })
+            .await
+            .unwrap();
+
+        // Output should mention saved + clean.
+        assert!(
+            output.contains("Saved 1 file(s)."),
+            "expected saved count line, got:\n{output}"
+        );
+        assert!(
+            output.contains("1 file(s) had no unsaved changes."),
+            "expected clean count line, got:\n{output}"
+        );
+
+        // Effect: dirty buffer should now be clean and disk should have new content.
+        assert!(
+            !dirty_buffer.read_with(cx, |buffer, _| buffer.is_dirty()),
+            "dirty.txt buffer should not be dirty after save"
+        );
+
+        let disk_dirty = fs.load(path!("/root/dirty.txt").as_ref()).await.unwrap();
+        assert_eq!(
+            disk_dirty, "in memory: dirty\n",
+            "dirty.txt disk content should be updated"
+        );
+
+        // Sanity: clean buffer should remain clean and disk unchanged.
+        let disk_clean = fs.load(path!("/root/clean.txt").as_ref()).await.unwrap();
+        assert_eq!(disk_clean, "on disk: clean\n");
+
+        // Test empty paths case.
+        let output = cx
+            .update(|cx| {
+                tool.clone().run(
+                    SaveFileToolInput { paths: vec![] },
+                    ToolCallEventStream::test().0,
+                    cx,
+                )
+            })
+            .await
+            .unwrap();
+        assert_eq!(output, "No paths provided.");
+
+        // Test not-found path case.
+        let output = cx
+            .update(|cx| {
+                tool.clone().run(
+                    SaveFileToolInput {
+                        paths: vec![PathBuf::from("nonexistent/path.txt")],
+                    },
+                    ToolCallEventStream::test().0,
+                    cx,
+                )
+            })
+            .await
+            .unwrap();
+        assert!(
+            output.contains("1 path(s) were not found in the project:"),
+            "expected not-found header line, got:\n{output}"
+        );
+        assert!(
+            output.contains("- nonexistent/path.txt"),
+            "expected not-found path bullet, got:\n{output}"
+        );
     }
 }

--- a/crates/agent/src/tools/save_file_tool.rs
+++ b/crates/agent/src/tools/save_file_tool.rs
@@ -81,7 +81,7 @@ impl AgentTool for SaveFileTool {
         cx.spawn(async move |cx| {
             let buffer = open_buffer.await?;
 
-            let is_dirty = buffer.read_with(&cx, |buffer, _| buffer.is_dirty())?;
+            let is_dirty = buffer.read_with(cx, |buffer, _| buffer.is_dirty())?;
 
             if !is_dirty {
                 return Ok(format!(
@@ -91,7 +91,7 @@ impl AgentTool for SaveFileTool {
             }
 
             project
-                .update(&cx, |project, cx| project.save_buffer(buffer, cx))?
+                .update(cx, |project, cx| project.save_buffer(buffer, cx))?
                 .await?;
 
             Ok(format!("Saved {}.", input.path.display()))

--- a/crates/agent/src/tools/save_file_tool.rs
+++ b/crates/agent/src/tools/save_file_tool.rs
@@ -138,8 +138,7 @@ impl AgentTool for SaveFileTool {
                     }
                 };
 
-                let save_task =
-                    project.update(cx, |project, cx| project.save_buffer(buffer, cx));
+                let save_task = project.update(cx, |project, cx| project.save_buffer(buffer, cx));
 
                 match save_task {
                     Ok(task) => {
@@ -175,7 +174,10 @@ impl AgentTool for SaveFileTool {
                 }
             }
             if !dirty_check_errors.is_empty() {
-                lines.push(format!("Dirty check failed ({}):", dirty_check_errors.len()));
+                lines.push(format!(
+                    "Dirty check failed ({}):",
+                    dirty_check_errors.len()
+                ));
                 for (path, error) in &dirty_check_errors {
                     lines.push(format!("- {}: {}", path.display(), error));
                 }

--- a/crates/agent/src/tools/save_file_tool.rs
+++ b/crates/agent/src/tools/save_file_tool.rs
@@ -1,0 +1,100 @@
+use agent_client_protocol as acp;
+use anyhow::{Result, anyhow};
+use gpui::{App, Entity, SharedString, Task};
+use project::Project;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use crate::{AgentTool, ToolCallEventStream};
+
+/// Saves a file that has unsaved changes.
+///
+/// Use this tool when you need to edit a file but it has unsaved changes that must be saved first.
+/// Only use this tool after asking the user for permission to save their unsaved changes.
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct SaveFileToolInput {
+    /// The path of the file to save.
+    pub path: PathBuf,
+}
+
+pub struct SaveFileTool {
+    project: Entity<Project>,
+}
+
+impl SaveFileTool {
+    pub fn new(project: Entity<Project>) -> Self {
+        Self { project }
+    }
+}
+
+impl AgentTool for SaveFileTool {
+    type Input = SaveFileToolInput;
+    type Output = String;
+
+    fn name() -> &'static str {
+        "save_file"
+    }
+
+    fn kind() -> acp::ToolKind {
+        acp::ToolKind::Other
+    }
+
+    fn initial_title(
+        &self,
+        input: Result<Self::Input, serde_json::Value>,
+        cx: &mut App,
+    ) -> SharedString {
+        if let Ok(input) = input
+            && let Some(project_path) = self.project.read(cx).find_project_path(&input.path, cx)
+            && let Some(path) = self
+                .project
+                .read(cx)
+                .short_full_path_for_project_path(&project_path, cx)
+        {
+            format!("Save file `{path}`").into()
+        } else {
+            "Save file".into()
+        }
+    }
+
+    fn run(
+        self: Arc<Self>,
+        input: Self::Input,
+        _event_stream: ToolCallEventStream,
+        cx: &mut App,
+    ) -> Task<Result<String>> {
+        let project = self.project.clone();
+
+        let Some(project_path) = project.read(cx).find_project_path(&input.path, cx) else {
+            return Task::ready(Err(anyhow!(
+                "Path {} not found in project",
+                input.path.display()
+            )));
+        };
+
+        let open_buffer = project.update(cx, |project, cx| {
+            project.open_buffer(project_path.clone(), cx)
+        });
+
+        cx.spawn(async move |cx| {
+            let buffer = open_buffer.await?;
+
+            let is_dirty = buffer.read_with(&cx, |buffer, _| buffer.is_dirty())?;
+
+            if !is_dirty {
+                return Ok(format!(
+                    "File {} has no unsaved changes.",
+                    input.path.display()
+                ));
+            }
+
+            project
+                .update(&cx, |project, cx| project.save_buffer(buffer, cx))?
+                .await?;
+
+            Ok(format!("Saved {}.", input.path.display()))
+        })
+    }
+}


### PR DESCRIPTION
This re-introduces the `save_file` and `restore_file_from_disk` agent tools that were reverted in #44949.

I pushed that original PR without trying it just to get the build off my machine, but I had missed a step: the tools weren't added to the default profile settings in `default.json`, so they were never enabled even though the code was present.

## Changes

- Add `save_file` and `restore_file_from_disk` to the "write" profile in `default.json`
- Add `Thread::has_tool()` method to check tool availability at runtime
- Make `edit_file_tool`'s dirty buffer error message conditional on whether `save_file`/`restore_file_from_disk` tools are available (so the agent gets appropriate guidance based on what tools it actually has)
- Update test to match new conditional error message behavior

Release Notes:

- Added `save_file` and `restore_file_from_disk` agent tools to handle dirty buffers when editing files