### PR TITLE
helix: Map Zed's specific diff and git-related to goto mode

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -502,6 +502,11 @@
       "g p": "pane::ActivatePreviousItem",
       "shift-h": "pane::ActivatePreviousItem", // not a helix default
       "g .": "vim::HelixGotoLastModification",
+      "g o": "editor::ToggleSelectedDiffHunks", // Zed specific
+      "g shift-o": "git::ToggleStaged", // Zed specific
+      "g shift-r": "git::Restore", // Zed specific
+      "g u": "git::StageAndNext", // Zed specific
+      "g shift-u": "git::UnstageAndNext", // Zed specific
 
       // Window mode
       "space w v": "pane::SplitDown",


### PR DESCRIPTION
Until now, Helix-mode users would have to rely on Vim's `d *` behaviour which cannot be reliably replicated with Helix's default delete behaviour and so I believe that remapping this functionality to Helix's goto mode is a better fit.

Release Notes:

- Added custom mappings for Zed specific diff and git-related actions to Helix's goto mode: 
  * `g o` - toggle selected diff hunks
  * `g O` - toggle staged
  * `g R` - restore change
  * `g u` - stage and goto next diff hunk
  * `g U` - unstage and goto next diff hunk