### PR TITLE
languages: Detect `.bst` files as YAML

### DIFF
--- a/crates/languages/src/yaml/config.toml
+++ b/crates/languages/src/yaml/config.toml
@@ -1,6 +1,6 @@
 name = "YAML"
 grammar = "yaml"
-path_suffixes = ["yml", "yaml", "pixi.lock", "clang-format", "clangd"]
+path_suffixes = ["yml", "yaml", "pixi.lock", "clang-format", "clangd", "bst"]
 line_comments = ["# "]
 autoclose_before = ",]}"
 brackets = [


### PR DESCRIPTION
These files are used by the BuildStream build project: https://buildstream.build/index.html


Release Notes:

- Added recognition for .bst files as yaml.
