### PR TITLE
nix: Resolve 'hostPlatform' rename warning in dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,14 +37,14 @@
           rustToolchain = rustBin.fromRustupToolchainFile ./rust-toolchain.toml;
         };
     in
-    rec {
+    {
       packages = forAllSystems (pkgs: rec {
         default = mkZed pkgs;
         debug = default.override { profile = "dev"; };
       });
       devShells = forAllSystems (pkgs: {
         default = pkgs.callPackage ./nix/shell.nix {
-          zed-editor = packages.${pkgs.hostPlatform.system}.default;
+          zed-editor = mkZed pkgs;
         };
       });
       formatter = forAllSystems (pkgs: pkgs.nixfmt-rfc-style);


### PR DESCRIPTION
This PR fixes the warning from entering the nix development shell:
```
evaluation warning: 'hostPlatform' has been renamed to/replaced by 'stdenv.hostPlatform'
```

Decided to go with `zed-editor = mkZed pkgs;` instead of `zed-editor = packages.${pkgs.stdenv.hostPlatform.system}.default;`, because it is simpler and with my understanding it is logically equivalent (i.e. we are getting `packages.<system>.default` which we can see in the definition of packages is equal to `mkZed pkgs;`).

Release Notes:

- Resolves 'hostPlatform' rename warning in nix development shell
