### PR TITLE
git: Align checkboxes in git panel

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -4855,7 +4855,7 @@ impl GitPanel {
                     cx.stop_propagation();
                 },
             )
-            .child(name_row)
+            .child(name_row.overflow_x_hidden())
             .child(
                 div()
                     .id(checkbox_wrapper_id)
@@ -4998,7 +4998,7 @@ impl GitPanel {
                     this.toggle_directory(&key, window, cx);
                 })
             })
-            .child(name_row)
+            .child(name_row.overflow_x_hidden())
             .child(
                 div()
                     .id(checkbox_wrapper_id)


### PR DESCRIPTION
Before this fix checkboxes would overflow off the visible view which isn't ideal. This aligns the checkboxes by allowing the path name to overflow.

#### Before
<img width="135" height="159" alt="image" src="https://github.com/user-attachments/assets/1a9e4c64-0d7b-4a8d-870a-bb198cc7377a" />

#### After
<img width="148" height="165" alt="image" src="https://github.com/user-attachments/assets/c7cf7a7c-c765-4e2b-8968-b3affcaa8649" />

Release Notes:

- N/A