### PR TITLE
gpui: Fix macOS memory leaks

### DIFF
--- a/crates/gpui/src/platform/mac/open_type.rs
+++ b/crates/gpui/src/platform/mac/open_type.rs
@@ -52,6 +52,11 @@ pub fn apply_features_and_fallbacks(
             &kCFTypeDictionaryKeyCallBacks,
             &kCFTypeDictionaryValueCallBacks,
         );
+        
+        for value in &values {
+            CFRelease(*value as _);
+        }
+        
         let new_descriptor = CTFontDescriptorCreateWithAttributes(attrs);
         CFRelease(attrs as _);
         let new_descriptor = CTFontDescriptor::wrap_under_create_rule(new_descriptor);

--- a/crates/gpui/src/platform/mac/open_type.rs
+++ b/crates/gpui/src/platform/mac/open_type.rs
@@ -52,11 +52,11 @@ pub fn apply_features_and_fallbacks(
             &kCFTypeDictionaryKeyCallBacks,
             &kCFTypeDictionaryValueCallBacks,
         );
-        
+
         for value in &values {
             CFRelease(*value as _);
         }
-        
+
         let new_descriptor = CTFontDescriptorCreateWithAttributes(attrs);
         CFRelease(attrs as _);
         let new_descriptor = CTFontDescriptor::wrap_under_create_rule(new_descriptor);

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -1190,6 +1190,7 @@ impl PlatformWindow for MacWindow {
             let (done_tx, done_rx) = oneshot::channel();
             let done_tx = Cell::new(Some(done_tx));
             let block = ConcreteBlock::new(move |answer: NSInteger| {
+                let _: () = msg_send![alert, release];
                 if let Some(done_tx) = done_tx.take() {
                     let _ = done_tx.send(answer.try_into().unwrap());
                 }


### PR DESCRIPTION
The below memory leaks were caused by failing to release reference counted resources. I confirmed using instruments that my changes stopped the leaks from occurring.

- System prompts 
- Screen capturing 
- loading font families

There were also two memory leaks I found from some of our dependencies that I made PRs to fix
- https://github.com/RustAudio/coreaudio-rs/pull/147
- https://github.com/servo/core-foundation-rs/pull/746

Release Notes:

- N/A
