### PR TITLE
Fix editor hang when positioned above viewport

### DIFF
--- a/crates/editor/src/test.rs
+++ b/crates/editor/src/test.rs
@@ -176,11 +176,9 @@ pub fn block_content_for_tests(
 }
 
 pub fn editor_content_with_blocks(editor: &Entity<Editor>, cx: &mut VisualTestContext) -> String {
-    cx.draw(
-        gpui::Point::default(),
-        size(px(3000.0), px(3000.0)),
-        |_, _| editor.clone(),
-    );
+    let draw_size = size(px(3000.0), px(3000.0));
+    cx.simulate_resize(draw_size);
+    cx.draw(gpui::Point::default(), draw_size, |_, _| editor.clone());
     let (snapshot, mut lines, blocks) = editor.update_in(cx, |editor, window, cx| {
         let snapshot = editor.snapshot(window, cx);
         let text = editor.display_text(cx);


### PR DESCRIPTION
Fixes the hang introduced in #44995 (which was reverted in #45011) and re-enables the optimization.

## Background

PR #44995 introduced an optimization to skip rendering lines that are clipped by parent containers (e.g., when a large AutoHeight editor is inside a scrollable List). This significantly improved performance for large diffs in the Agent Panel.
However, #45011 reverted this change because it caused the main thread to hang for 100+ seconds in certain scenarios, requiring a force quit to recover.

## Root Cause
The original analysis in #45011 suggested that visible_bounds wasn’t being intersected properly, but that was incorrect—the intersection via with_content_mask works correctly. The actual bug: when an editor is positioned above the visible viewport (e.g., scrolled past in a List), the clipping calculation produces a start_row that exceeds max_row:

1. Editor’s bounds.origin.y becomes very negative (e.g., -10000px)
2. After intersection, visible_bounds.origin.y is at the viewport top (e.g., 0)
3. clipped_top_in_lines = (0 - (-10000)) / line_height = huge number
4. start_row = huge number, but end_row is clamped to max_row
5. This creates an invalid range where start_row > end_row

This caused two different failures depending on build mode:
- Debug mode: Panic from subtraction overflow in Range<DisplayRow>::len()
- Release mode: Integer wraparound causing blocks_in_range to enter an infinite loop (the 100+ second hang)

## Fix

Simply clamp start_row to max_row, ensuring the row range is always valid:

```rs
let start_row = cmp::min(
    DisplayRow((scroll_position.y + clipped_top_in_lines).floor() as u32),
    max_row,
);
```

## Testing
Added a regression test that draws an editor at y=-10000 to simulate an editor that’s been scrolled past in a List. This would panic in debug mode (and hang in release mode) before the fix.

Release Notes:
- Improved agent panel performance when rendering large diffs.