### PR TITLE
workspace: Don't debug display paths to users in trust popup

### DIFF
--- a/crates/workspace/src/security_modal.rs
+++ b/crates/workspace/src/security_modal.rs
@@ -265,8 +265,8 @@ impl SecurityModal {
                 }
             }
             1 => Some(Cow::Owned(format!(
-                "Trust all projects in the {:?} folder",
-                self.shorten_path(available_parents[0])
+                "Trust all projects in the {:} folder",
+                self.shorten_path(available_parents[0]).display()
             ))),
             _ => Some(Cow::Borrowed("Trust all projects in the parent folders")),
         }


### PR DESCRIPTION
On windows this will render two backslashes otherwise

Release Notes:

- N/A *or* Added/Fixed/Improved ...
