### PR TITLE
python: Fetch non pre-release versions of `ty`

### DIFF
--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -280,7 +280,7 @@ impl LspInstaller for TyLspAdapter {
         _: &mut AsyncApp,
     ) -> Result<Self::BinaryVersion> {
         let release =
-            latest_github_release("astral-sh/ty", true, true, delegate.http_client()).await?;
+            latest_github_release("astral-sh/ty", true, false, delegate.http_client()).await?;
         let (_, asset_name) = Self::build_asset_name()?;
         let asset = release
             .assets


### PR DESCRIPTION
0.0.2 is not a pre-release artifact unlike the previous one, so our version fetch ignored it.

Fixes https://github.com/zed-industries/zed/issues/45061

Release Notes:

- N/A *or* Added/Fixed/Improved ...
