### PR TITLE
vim: Attempt to fix flaky vim tests on windows

### DIFF
--- a/crates/vim/src/object.rs
+++ b/crates/vim/src/object.rs
@@ -2807,9 +2807,8 @@ mod test {
 
         for (keystrokes, initial_state, expected_state, expected_mode) in TEST_CASES {
             cx.set_state(initial_state, Mode::Normal);
-
+            cx.buffer(|buffer, _| buffer.parsing_idle()).await;
             cx.simulate_keystrokes(keystrokes);
-
             cx.assert_state(expected_state, *expected_mode);
         }
 
@@ -2830,9 +2829,8 @@ mod test {
 
         for (keystrokes, initial_state, mode) in INVALID_CASES {
             cx.set_state(initial_state, Mode::Normal);
-
+            cx.buffer(|buffer, _| buffer.parsing_idle()).await;
             cx.simulate_keystrokes(keystrokes);
-
             cx.assert_state(initial_state, *mode);
         }
     }
@@ -3185,9 +3183,8 @@ mod test {
 
         for (keystrokes, initial_state, expected_state, expected_mode) in TEST_CASES {
             cx.set_state(initial_state, Mode::Normal);
-
+            cx.buffer(|buffer, _| buffer.parsing_idle()).await;
             cx.simulate_keystrokes(keystrokes);
-
             cx.assert_state(expected_state, *expected_mode);
         }
 
@@ -3208,9 +3205,8 @@ mod test {
 
         for (keystrokes, initial_state, mode) in INVALID_CASES {
             cx.set_state(initial_state, Mode::Normal);
-
+            cx.buffer(|buffer, _| buffer.parsing_idle()).await;
             cx.simulate_keystrokes(keystrokes);
-
             cx.assert_state(initial_state, *mode);
         }
     }


### PR DESCRIPTION
Both `test_miniquotes_object` and `test_minibrackets_object` rely on tree-sitter parsing for `MultiBufferSnapshot.bracket_ranges` to find quote/bracket pairs. The `VimTestContext.set_state` call eventually triggers async tree-sitter parsing, but `run_until_parked` doesn't guarantee parsing completion.

We suspect this is what might be causing the flakiness on Windows, as the syntax might not yet be parsed when the
`VimTestContext.simulate_keystrokes` call is made, so there's no bracket pairs returned.

This commit adds an explicit await call on `Bufffer.parsing_idle` after each `VimTestContext.set_state` call, to ensure tree-sitter parsing completes before simulating keystrokes.

Release Notes:

- N/A
