### PR TITLE
agent_ui: Make tool call raw input visible

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -192,6 +192,7 @@ pub struct ToolCall {
     pub locations: Vec<acp::ToolCallLocation>,
     pub resolved_locations: Vec<Option<AgentLocation>>,
     pub raw_input: Option<serde_json::Value>,
+    pub raw_input_markdown: Option<Entity<Markdown>>,
     pub raw_output: Option<serde_json::Value>,
 }
 
@@ -222,6 +223,11 @@ impl ToolCall {
             }
         }
 
+        let raw_input_markdown = tool_call
+            .raw_input
+            .as_ref()
+            .and_then(|input| markdown_for_raw_output(input, &language_registry, cx));
+
         let result = Self {
             id: tool_call.tool_call_id,
             label: cx
@@ -232,6 +238,7 @@ impl ToolCall {
             resolved_locations: Vec::default(),
             status,
             raw_input: tool_call.raw_input,
+            raw_input_markdown,
             raw_output: tool_call.raw_output,
         };
         Ok(result)
@@ -307,6 +314,7 @@ impl ToolCall {
         }
 
         if let Some(raw_input) = raw_input {
+            self.raw_input_markdown = markdown_for_raw_output(&raw_input, &language_registry, cx);
             self.raw_input = Some(raw_input);
         }
 
@@ -1355,6 +1363,7 @@ impl AcpThread {
                     locations: Vec::new(),
                     resolved_locations: Vec::new(),
                     raw_input: None,
+                    raw_input_markdown: None,
                     raw_output: None,
                 };
                 self.push_entry(AgentThreadEntry::ToolCall(failed_tool_call), cx);

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -280,7 +280,6 @@ pub struct AcpThreadView {
     list_state: ListState,
     auth_task: Option<Task<()>>,
     expanded_tool_calls: HashSet<acp::ToolCallId>,
-    expanded_tool_call_inputs: HashSet<acp::ToolCallId>,
     expanded_thinking_blocks: HashSet<(usize, usize)>,
     edits_expanded: bool,
     plan_expanded: bool,
@@ -433,7 +432,6 @@ impl AcpThreadView {
             thread_feedback: Default::default(),
             auth_task: None,
             expanded_tool_calls: HashSet::default(),
-            expanded_tool_call_inputs: HashSet::default(),
             expanded_thinking_blocks: HashSet::default(),
             editing_message: None,
             edits_expanded: false,
@@ -2429,30 +2427,8 @@ impl AcpThreadView {
         let use_card_layout = needs_confirmation || is_edit || is_terminal_tool;
 
         let is_collapsible = !tool_call.content.is_empty() && !needs_confirmation;
-        let has_input = tool_call.raw_input.is_some();
-        let is_input_open = self.expanded_tool_call_inputs.contains(&tool_call.id);
 
         let is_open = needs_confirmation || self.expanded_tool_calls.contains(&tool_call.id);
-
-        let tool_input_display = if has_input && is_input_open {
-            Some(
-                v_flex()
-                    .w_full()
-                    .p_2()
-                    .bg(cx.theme().colors().editor_background)
-                    .child(
-                        div()
-                            .text_ui_sm(cx)
-                            .text_color(cx.theme().colors().text_muted)
-                            .child(
-                                serde_json::to_string_pretty(tool_call.raw_input.as_ref().unwrap())
-                                    .unwrap_or_else(|_| "{}".to_string()),
-                            ),
-                    ),
-            )
-        } else {
-            None
-        };
 
         let tool_output_display =
             if is_open {
@@ -2586,30 +2562,11 @@ impl AcpThreadView {
                                 window,
                                 cx,
                             ))
-                            .when(has_input || is_collapsible || failed_or_canceled, |this| {
+                            .when(is_collapsible || failed_or_canceled, |this| {
                                 this.child(
                                     h_flex()
                                         .px_1()
                                         .gap_px()
-                                        .when(has_input, |this| {
-                                            this.child(
-                                                Disclosure::new(("expand-input", entry_ix), is_input_open)
-                                                    .opened_icon(IconName::ChevronUp)
-                                                    .closed_icon(IconName::ChevronDown)
-                                                    .visible_on_hover(&card_header_id)
-                                                    .on_click(cx.listener({
-                                                        let id = tool_call.id.clone();
-                                                        move |this: &mut Self, _, _, cx: &mut Context<Self>| {
-                                                            if is_input_open {
-                                                                this.expanded_tool_call_inputs.remove(&id);
-                                                            } else {
-                                                                this.expanded_tool_call_inputs.insert(id.clone());
-                                                            }
-                                                            cx.notify();
-                                                        }
-                                                    })),
-                                            )
-                                        })
                                         .when(is_collapsible, |this| {
                                             this.child(
                                             Disclosure::new(("expand-output", entry_ix), is_open)
@@ -2641,7 +2598,6 @@ impl AcpThreadView {
                     )
                 }
             })
-            .children(tool_input_display)
             .children(tool_output_display)
     }
 

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -2445,23 +2445,8 @@ impl AcpThreadView {
                             .text_ui_sm(cx)
                             .text_color(cx.theme().colors().text_muted)
                             .child(
-                                MarkdownElement::new(
-                                    format!(
-                                        "```json\n{}\n```",
-                                        serde_json::to_string_pretty(
-                                            tool_call.raw_input.as_ref().unwrap()
-                                        )
-                                        .unwrap_or_else(|_| "{}".to_string())
-                                    ),
-                                    default_markdown_style(false, true, window, cx),
-                                )
-                                .code_block_renderer(
-                                    markdown::CodeBlockRenderer::Default {
-                                        copy_button: true,
-                                        copy_button_on_hover: true,
-                                        border: false,
-                                    },
-                                ),
+                                serde_json::to_string_pretty(tool_call.raw_input.as_ref().unwrap())
+                                    .unwrap_or_else(|_| "{}".to_string()),
                             ),
                     ),
             )
@@ -2622,8 +2607,7 @@ impl AcpThreadView {
                                                             }
                                                             cx.notify();
                                                         }
-                                                    }))
-                                                    .tooltip(|cx| Tooltip::text("Toggle Input", cx)),
+                                                    })),
                                             )
                                         })
                                         .when(is_collapsible, |this| {
@@ -2642,8 +2626,7 @@ impl AcpThreadView {
                                                         }
                                                         cx.notify();
                                                     }
-                                                }))
-                                                .tooltip(|cx| Tooltip::text("Toggle Output", cx)),
+                                                })),
                                         )
                                         })
                                         .when(failed_or_canceled, |this| {

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -2429,6 +2429,12 @@ impl AcpThreadView {
         let is_collapsible = !tool_call.content.is_empty() && !needs_confirmation;
 
         let is_open = needs_confirmation || self.expanded_tool_calls.contains(&tool_call.id);
+        let input_output_header = |label: SharedString| {
+            Label::new(label)
+                .size(LabelSize::XSmall)
+                .color(Color::Muted)
+                .buffer_font(cx)
+        };
 
         let tool_output_display =
             if is_open {
@@ -2470,7 +2476,25 @@ impl AcpThreadView {
                     | ToolCallStatus::Completed
                     | ToolCallStatus::Failed
                     | ToolCallStatus::Canceled => v_flex()
+                        .mt_1p5()
                         .w_full()
+                        .child(
+                            v_flex()
+                                .ml(rems(0.4))
+                                .px_3p5()
+                                .pb_1()
+                                .gap_1()
+                                .border_l_1()
+                                .border_color(self.tool_card_border_color(cx))
+                                .child(input_output_header("Raw Input".into()))
+                                .children(tool_call.raw_input_markdown.clone().map(|input| {
+                                    self.render_markdown(
+                                        input,
+                                        default_markdown_style(false, false, window, cx),
+                                    )
+                                }))
+                                .child(input_output_header("Output:".into())),
+                        )
                         .children(tool_call.content.iter().enumerate().map(
                             |(content_ix, content)| {
                                 div().child(self.render_tool_call_content(
@@ -2755,7 +2779,6 @@ impl AcpThreadView {
         let button_id = SharedString::from(format!("tool_output-{:?}", tool_call_id));
 
         v_flex()
-            .mt_1p5()
             .gap_2()
             .when(!card_layout, |this| {
                 this.ml(rems(0.4))


### PR DESCRIPTION
<img width="500" height="1246" alt="Screenshot 2025-12-17 at 9  28@2x" src="https://github.com/user-attachments/assets/eddb290d-d4d0-4ab8-94b3-bcc50ad07157" />

Release Notes:

- agent: Made tool calls' raw input visible in the agent UI.