### PR TITLE
Revert "Remove CopyAsMarkdown"

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -264,9 +264,9 @@
   {
     "context": "AgentPanel > Markdown",
     "bindings": {
-      "copy": "markdown::Copy",
-      "ctrl-insert": "markdown::Copy",
-      "ctrl-c": "markdown::Copy",
+      "copy": "markdown::CopyAsMarkdown",
+      "ctrl-insert": "markdown::CopyAsMarkdown",
+      "ctrl-c": "markdown::CopyAsMarkdown",
     },
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -306,7 +306,7 @@
     "context": "AgentPanel > Markdown",
     "use_key_equivalents": true,
     "bindings": {
-      "cmd-c": "markdown::Copy",
+      "cmd-c": "markdown::CopyAsMarkdown",
     },
   },
   {

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -267,7 +267,7 @@
     "context": "AgentPanel > Markdown",
     "use_key_equivalents": true,
     "bindings": {
-      "ctrl-c": "markdown::Copy",
+      "ctrl-c": "markdown::CopyAsMarkdown",
     },
   },
   {

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -151,6 +151,8 @@ actions!(
     [
         /// Copies the selected text to the clipboard.
         Copy,
+        /// Copies the selected text as markdown to the clipboard.
+        CopyAsMarkdown
     ]
 );
 
@@ -292,6 +294,14 @@ impl Markdown {
             return;
         }
         let text = text.text_for_range(self.selection.start..self.selection.end);
+        cx.write_to_clipboard(ClipboardItem::new_string(text));
+    }
+
+    fn copy_as_markdown(&self, _: &mut Window, cx: &mut Context<Self>) {
+        if self.selection.end <= self.selection.start {
+            return;
+        }
+        let text = self.source[self.selection.start..self.selection.end].to_string();
         cx.write_to_clipboard(ClipboardItem::new_string(text));
     }
 
@@ -1353,6 +1363,14 @@ impl Element for MarkdownElement {
                 let text = text.clone();
                 if phase == DispatchPhase::Bubble {
                     entity.update(cx, move |this, cx| this.copy(&text, window, cx))
+                }
+            }
+        });
+        window.on_action(std::any::TypeId::of::<crate::CopyAsMarkdown>(), {
+            let entity = self.markdown.clone();
+            move |_, phase, window, cx| {
+                if phase == DispatchPhase::Bubble {
+                    entity.update(cx, move |this, cx| this.copy_as_markdown(window, cx))
                 }
             }
         });


### PR DESCRIPTION
Reverts https://github.com/zed-industries/zed/pull/44933.

It turns out that if you're copying agent responses to paste it anywhere else that isn't the message editor (e.g., for a follow up prompt), getting Markdown formatting is helpful. However, with the revert, the underlying issue in https://github.com/zed-industries/zed/issues/42958 remains, so I'll reopen that issue, unfortunately.

Release Notes:

- N/A
