### PR TITLE
nightly: Temporarly delete commit message prompt from rules library

### DIFF
--- a/crates/prompt_store/src/prompt_store.rs
+++ b/crates/prompt_store/src/prompt_store.rs
@@ -199,24 +199,8 @@ impl PromptStore {
             let metadata = db_env.create_database(&mut txn, Some("metadata.v2"))?;
             let bodies = db_env.create_database(&mut txn, Some("bodies.v2"))?;
 
-            // Insert default commit message prompt if not present
-            if metadata.get(&txn, &PromptId::CommitMessage)?.is_none() {
-                metadata.put(
-                    &mut txn,
-                    &PromptId::CommitMessage,
-                    &PromptMetadata {
-                        id: PromptId::CommitMessage,
-                        title: Some("Git Commit Message".into()),
-                        default: false,
-                        saved_at: Utc::now(),
-                    },
-                )?;
-            }
-            if bodies.get(&txn, &PromptId::CommitMessage)?.is_none() {
-                let commit_message_prompt =
-                    include_str!("../../git_ui/src/commit_message_prompt.txt");
-                bodies.put(&mut txn, &PromptId::CommitMessage, commit_message_prompt)?;
-            }
+            metadata.delete(&mut txn, &PromptId::CommitMessage)?;
+            bodies.delete(&mut txn, &PromptId::CommitMessage)?;
 
             txn.commit()?;
 


### PR DESCRIPTION
Relevant for Nightly Users only, follow up to #45004.

<img width="630" height="87" alt="image" src="https://github.com/user-attachments/assets/8fce5722-fffe-4abb-aa68-27ebbaf892e1" />

In case you use Nightly this will break preview/stable since deserialisation will fail. Shipping this to Nightly so that staff does not run into this issue. We can revert this PR in the following days.
I'll make a follow up PR which only stores the prompt in the database in case you customise it.

Release Notes:

- N/A
