### PR TITLE
agent_ui: Fix double axis scroll in the edited files list

### DIFF
--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -4121,6 +4121,8 @@ impl AcpThreadView {
                                 .ml_1p5()
                         });
 
+                        let full_path = path.display(path_style).to_string();
+
                         let file_icon = FileIcons::get_icon(path.as_std_path(), cx)
                             .map(Icon::from_path)
                             .map(|icon| icon.color(Color::Muted).size(IconSize::Small))
@@ -4154,7 +4156,6 @@ impl AcpThreadView {
                                     .relative()
                                     .pr_8()
                                     .w_full()
-                                    .overflow_x_scroll()
                                     .child(
                                         h_flex()
                                             .id(("file-name-path", index))
@@ -4166,7 +4167,14 @@ impl AcpThreadView {
                                             .child(file_icon)
                                             .children(file_name)
                                             .children(file_path)
-                                            .tooltip(Tooltip::text("Go to File"))
+                                            .tooltip(move |_, cx| {
+                                                Tooltip::with_meta(
+                                                    "Go to File",
+                                                    None,
+                                                    full_path.clone(),
+                                                    cx,
+                                                )
+                                            })
                                             .on_click({
                                                 let buffer = buffer.clone();
                                                 cx.listener(move |this, _, window, cx| {


### PR DESCRIPTION
Previously, the list of edit files had a double axis scroll issue because the list itself scrolled vertically and each file row would scroll horizontally, causing a bad UX. The horizontal scroll intention was so that you could see the whole path, but I've included it in the tooltip in case it becomes obscured due to a small panel width.

<img width="500" height="666" alt="Screenshot 2025-12-17 at 11  24@2x" src="https://github.com/user-attachments/assets/ea87236d-f5c6-475a-bf66-1afae7a6ca05" />

Release Notes:

- N/A
