### PR TITLE
editor: Separate delimiters computation from the newline method

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -23390,7 +23390,7 @@ fn documentation_delimiter_for_newline(
         tab_size: len,
     } = language.documentation_comment()?;
     let is_within_block_comment = buffer
-        .language_scope_at(start_point.clone())
+        .language_scope_at(*start_point)
         .is_some_and(|scope| scope.override_name() == Some("comment"));
     if !is_within_block_comment {
         return None;


### PR DESCRIPTION
Some refactoring I ran into while working on automatic Markdown list continuation on newline.

This PR:
- Moves `comment_delimiter` and `documentation_delimiter` computation outside of newline method.
- Adds `NewlineFormatting`, which holds info about how newlines affect indentation and other formatting we need.
- Moves newline-specific methods into the new `NewlineFormatting` struct.

Release Notes:

- N/A
