### PR TITLE
Unify wording for discarding file changes in git panel

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1208,14 +1208,14 @@ impl GitPanel {
                 let prompt = window.prompt(
                     PromptLevel::Warning,
                     &format!(
-                        "Are you sure you want to restore {}?",
+                        "Are you sure you want to discard changes to {}?",
                         entry
                             .repo_path
                             .file_name()
                             .unwrap_or(entry.repo_path.display(path_style).as_ref()),
                     ),
                     None,
-                    &["Restore", "Cancel"],
+                    &["Discard Changes", "Cancel"],
                     cx,
                 );
                 cx.background_spawn(prompt)
@@ -4698,7 +4698,7 @@ impl GitPanel {
         let restore_title = if entry.status.is_created() {
             "Trash File"
         } else {
-            "Restore File"
+            "Discard Changes"
         };
         let context_menu = ContextMenu::build(window, cx, |context_menu, _, _| {
             let is_created = entry.status.is_created();


### PR DESCRIPTION
In the `...` menu, we use `Discard...`

<img width="390" height="317" alt="SCR-20251217-kbdh" src="https://github.com/user-attachments/assets/f88271a6-efab-48fb-bac1-2dacf4fad8f0" />

But in the context menu of each entry, we use "Restore..."

<img width="366" height="250" alt="SCR-20251217-kbcj" src="https://github.com/user-attachments/assets/6c10842b-80f4-4868-a655-2703cba6bd5e" />

This PR just makes this more consistent, by using "Discard..." in the second case.

Release Notes:

- Unified wording for discarding file changes in git panel
