### PR TITLE
agent_ui_v2: Fix broken LICENSE-GPL symlink pointing to itself

### DIFF
--- a/crates/agent_ui_v2/LICENSE-GPL
+++ b/crates/agent_ui_v2/LICENSE-GPL
@@ -1,1 +1,1 @@
-LICENSE-GPL
+../../LICENSE-GPL


### PR DESCRIPTION
Fix broken LICENSE-GPL symlink that was pointing to itself instead of the LICENSE-GPL file in the root of the repo.

It caused jujutsu to freak out and made it impossible to work with the repo using it without switching to raw git:

```
Internal error: Failed to check out commit 22d04a82b119882e7aed88fb422430367c4df5f9
Caused by:
1: Failed to validate path /Users/aqrln/git/zed/crates/agent_ui_v2/LICENSE-GPL
2: Too many levels of symbolic links (os error 62)
```

Release Notes:

- N/A
