### PR TITLE
Use less generic globs for JSONC to avoid overmatching

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1705,7 +1705,12 @@
   // }
   //
   "file_types": {
-    "JSONC": ["**/.zed/**/*.json", "**/zed/**/*.json", "**/Zed/**/*.json", "**/.vscode/**/*.json", "tsconfig*.json"],
+    "JSONC": [
+      "**/.zed/*.json",
+      "**/.vscode/**/*.json",
+      "**/{zed,Zed}/{settings,keymap,tasks,debug}.json",
+      "tsconfig*.json",
+    ],
     "Markdown": [".rules", ".cursorrules", ".windsurfrules", ".clinerules"],
     "Shell Script": [".env.*"],
   },


### PR DESCRIPTION
Otherwise, all *.json files under `zed` directory will be matched as JSONC, e.g `zed/crates/vim/test_data/test_a.json` which is not right. 
On top, `globset` considers that `zed/crates/vim/test_data/test_a.json` matches `**/zed/*.json` glob (!).

Release Notes:

- N/A