### PR TITLE
agent_ui: Remove unnecessary Arc allocation

### DIFF
--- a/crates/agent_ui/src/acp/model_selector.rs
+++ b/crates/agent_ui/src/acp/model_selector.rs
@@ -221,7 +221,7 @@ impl PickerDelegate for AcpModelPickerDelegate {
         cx: &mut Context<Picker<Self>>,
     ) -> Task<()> {
         let favorites = if self.selector.supports_favorites() {
-            Arc::new(AgentSettings::get_global(cx).favorite_model_ids())
+            AgentSettings::get_global(cx).favorite_model_ids()
         } else {
             Default::default()
         };
@@ -242,7 +242,7 @@ impl PickerDelegate for AcpModelPickerDelegate {
 
             this.update_in(cx, |this, window, cx| {
                 this.delegate.filtered_entries =
-                    info_list_to_picker_entries(filtered_models, favorites);
+                    info_list_to_picker_entries(filtered_models, &favorites);
                 // Finds the currently selected model in the list
                 let new_index = this
                     .delegate
@@ -406,7 +406,7 @@ impl PickerDelegate for AcpModelPickerDelegate {
 
 fn info_list_to_picker_entries(
     model_list: AgentModelList,
-    favorites: Arc<HashSet<ModelId>>,
+    favorites: &HashSet<ModelId>,
 ) -> Vec<AcpModelPickerEntry> {
     let mut entries = Vec::new();
 
@@ -572,13 +572,11 @@ mod tests {
         }
     }
 
-    fn create_favorites(models: Vec<&str>) -> Arc<HashSet<ModelId>> {
-        Arc::new(
-            models
-                .into_iter()
-                .map(|m| ModelId::new(m.to_string()))
-                .collect(),
-        )
+    fn create_favorites(models: Vec<&str>) -> HashSet<ModelId> {
+        models
+            .into_iter()
+            .map(|m| ModelId::new(m.to_string()))
+            .collect()
     }
 
     fn get_entry_model_ids(entries: &[AcpModelPickerEntry]) -> Vec<&str> {
@@ -609,7 +607,7 @@ mod tests {
         ]);
         let favorites = create_favorites(vec!["zed/gemini"]);
 
-        let entries = info_list_to_picker_entries(models, favorites);
+        let entries = info_list_to_picker_entries(models, &favorites);
 
         assert!(matches!(
             entries.first(),
@@ -625,7 +623,7 @@ mod tests {
         let models = create_model_list(vec![("zed", vec!["zed/claude", "zed/gemini"])]);
         let favorites = create_favorites(vec![]);
 
-        let entries = info_list_to_picker_entries(models, favorites);
+        let entries = info_list_to_picker_entries(models, &favorites);
 
         assert!(matches!(
             entries.first(),
@@ -641,7 +639,7 @@ mod tests {
         ]);
         let favorites = create_favorites(vec!["zed/claude"]);
 
-        let entries = info_list_to_picker_entries(models, favorites);
+        let entries = info_list_to_picker_entries(models, &favorites);
 
         for entry in &entries {
             if let AcpModelPickerEntry::Model(info, is_favorite) = entry {
@@ -662,7 +660,7 @@ mod tests {
         ]);
         let favorites = create_favorites(vec!["zed/gemini", "openai/gpt-5"]);
 
-        let entries = info_list_to_picker_entries(models, favorites);
+        let entries = info_list_to_picker_entries(models, &favorites);
         let model_ids = get_entry_model_ids(&entries);
 
         assert_eq!(model_ids[0], "zed/gemini");
@@ -683,7 +681,7 @@ mod tests {
 
         let favorites = create_favorites(vec!["zed/claude"]);
 
-        let entries = info_list_to_picker_entries(models, favorites);
+        let entries = info_list_to_picker_entries(models, &favorites);
         let labels = get_entry_labels(&entries);
 
         assert_eq!(
@@ -723,7 +721,7 @@ mod tests {
         ]);
         let favorites = create_favorites(vec!["zed/gemini"]);
 
-        let entries = info_list_to_picker_entries(models, favorites);
+        let entries = info_list_to_picker_entries(models, &favorites);
 
         assert!(matches!(
             entries.first(),


### PR DESCRIPTION
Follow up to https://github.com/zed-industries/zed/pull/44297.

Initial implementation in ce884443f1c38ca8da9edf9fbbb8e7fd579452cb used `Arc` to store the reference to the hash map inside the iterator while keeping the lifetime static. The code was later simplified in 5151b22e2ea37fb457cf4f88b88fe4f315306074 to build the list eagerly but the Arc was forgotten, although it became unnecessary.

cc @bennetbo

Release Notes:

- N/A
