### PR TITLE
markdown_preview: Support `file:line:column` navigation in links

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9682,6 +9682,7 @@ dependencies = [
  "linkify",
  "log",
  "markup5ever_rcdom",
+ "outline",
  "pretty_assertions",
  "pulldown-cmark 0.12.2",
  "settings",
@@ -9690,6 +9691,7 @@ dependencies = [
  "urlencoding",
  "util",
  "workspace",
+ "zed_actions",
 ]
 
 [[package]]

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -1312,6 +1312,7 @@
       "down": "markdown::ScrollDown",
       "alt-up": "markdown::ScrollUpByItem",
       "alt-down": "markdown::ScrollDownByItem",
+      "cmd-shift-o": "outline::Toggle",
     },
   },
   {

--- a/crates/markdown_preview/Cargo.toml
+++ b/crates/markdown_preview/Cargo.toml
@@ -26,6 +26,7 @@ language.workspace = true
 linkify.workspace = true
 log.workspace = true
 markup5ever_rcdom.workspace = true
+outline.workspace = true
 pretty_assertions.workspace = true
 pulldown-cmark.workspace = true
 settings.workspace = true
@@ -34,6 +35,7 @@ ui.workspace = true
 urlencoding.workspace = true
 util.workspace = true
 workspace.workspace = true
+zed_actions.workspace = true
 
 [dev-dependencies]
 editor = { workspace = true, features = ["test-support"] }

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -506,13 +506,12 @@ impl MarkdownPreviewView {
 
     fn toggle_outline(
         &mut self,
-        _: &ToggleOutline,
+        action: &ToggleOutline,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         if let Some(editor_state) = &self.active_editor {
-            let editor = editor_state.editor.clone();
-            outline::toggle(editor, &ToggleOutline, window, &mut *cx);
+            outline::toggle(editor_state.editor.clone(), action, window, cx);
         }
     }
 }


### PR DESCRIPTION
Add support for navigating to specific line and column positions when clicking markdown links with the :row:column suffix syntax.

Examples:
- [Go to line 42](./file.rs:42)
- [Go to line 42, column 10](./file.rs:42:10)

Changes:
- Simplified Link::Path to use PathWithPosition directly
- Parse :line:column suffix in Link::identify() using existing util
- Navigate to position after opening file in click handlers
- Both text links and image links support position navigation
- Display impl shows full path:row:column in tooltips

This follows Zed's existing convention used by CLI, terminal links, and file finder (PathWithPosition in util::paths).

Release Notes:

- Added support for navigating to specific line and column positions when clicking markdown links with the :row:column suffix syntax.