### PR TITLE
extension api: Make server id types constructible, to ease writing tests

### DIFF
--- a/crates/extension_api/src/extension_api.rs
+++ b/crates/extension_api/src/extension_api.rs
@@ -331,7 +331,6 @@ static mut EXTENSION: Option<Box<dyn Extension>> = None;
 pub static ZED_API_VERSION: [u8; 6] = *include_bytes!(concat!(env!("OUT_DIR"), "/version_bytes"));
 
 mod wit {
-
     wit_bindgen::generate!({
         skip: ["init-extension"],
         path: "./wit/since_v0.8.0",
@@ -524,6 +523,12 @@ impl wit::Guest for Component {
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
 pub struct LanguageServerId(String);
 
+impl LanguageServerId {
+    pub fn new(value: String) -> Self {
+        Self(value)
+    }
+}
+
 impl AsRef<str> for LanguageServerId {
     fn as_ref(&self) -> &str {
         &self.0
@@ -539,6 +544,12 @@ impl fmt::Display for LanguageServerId {
 /// The ID of a context server.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
 pub struct ContextServerId(String);
+
+impl ContextServerId {
+    pub fn new(value: String) -> Self {
+        Self(value)
+    }
+}
 
 impl AsRef<str> for ContextServerId {
     fn as_ref(&self) -> &str {


### PR DESCRIPTION
Currently, extensions cannot have tests that call methods like `label_for_symbol` and `label_for_completion`, because those methods take a `LanguageServerId`, and that type is opaque, and cannot be constructed outside of the `zed_extension_api` crate.

This PR makes it possible to construct those types from strings, so that it's more straightforward to write unit tests for these LSP adapter methods.

Release Notes:

- N/A
