### PR TITLE
terminal: Respect RevealStrategy::NoFocus and Never focus settings

### DIFF
--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -787,8 +787,7 @@ impl TerminalPanel {
                 }
 
                 pane.update(cx, |pane, cx| {
-                    let focus = pane.has_focus(window, cx)
-                        || matches!(reveal_strategy, RevealStrategy::Always);
+                    let focus = matches!(reveal_strategy, RevealStrategy::Always);
                     pane.add_item(terminal_view, true, focus, None, window, cx);
                 });
 
@@ -850,8 +849,7 @@ impl TerminalPanel {
                         }
 
                         pane.update(cx, |pane, cx| {
-                            let focus = pane.has_focus(window, cx)
-                                || matches!(reveal_strategy, RevealStrategy::Always);
+                            let focus = matches!(reveal_strategy, RevealStrategy::Always);
                             pane.add_item(terminal_view, true, focus, None, window, cx);
                         });
 


### PR DESCRIPTION
Closes #45179

## Summary

Fixes the focus behavior when creating terminals with `RevealStrategy::NoFocus` or `RevealStrategy::Never`. Previously, terminals would still receive focus if the terminal pane already had focus, contradicting the documented behavior.

## Changes

- **`add_terminal_task()`**: Changed focus logic to only focus when `RevealStrategy::Always`
- **`add_terminal_shell()`**: Same fix

The fix changes:
```rust
// Before
let focus = pane.has_focus(window, cx)
    || matches!(reveal_strategy, RevealStrategy::Always);

// After  
let focus = matches!(reveal_strategy, RevealStrategy::Always);
```

## Impact

This affects:
- Vim users running `:!command` (uses `NoFocus`)
- Debugger terminal spawning (uses `NoFocus`)
- Any programmatic terminal creation requesting background behavior

Release Notes:

- Fixed terminal focus behavior to respect `RevealStrategy::NoFocus` and `RevealStrategy::Never` settings when the terminal pane already has focus.