### PR TITLE
Restore generic modal closing on mouse click

### DIFF
--- a/crates/workspace/src/modal_layer.rs
+++ b/crates/workspace/src/modal_layer.rs
@@ -193,6 +193,12 @@ impl Render for ModalLayer {
                 background.fade_out(0.2);
                 this.bg(background)
             })
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|this, _, window, cx| {
+                    this.hide_modal(window, cx);
+                }),
+            )
             .child(
                 v_flex()
                     .h(px(0.0))


### PR DESCRIPTION
Was removed in https://github.com/zed-industries/zed/pull/44887/changes#diff-1de872be76a27a9d574a0b0acec4581797446e60743d23b3e7a5f15088fa7e61

Release Notes:

- (Preview only) Fixed certain modals not being dismissed on mouse click outside
