### PR TITLE
docs: Add note about conflicting global macOS shortcut

### DIFF
--- a/docs/src/completions.md
+++ b/docs/src/completions.md
@@ -15,6 +15,10 @@ When there is an appropriate language server available, Zed will provide complet
 
 You can manually trigger completions with `ctrl-space` or by triggering the `editor::ShowCompletions` action from the command palette.
 
+> Using `ctrl-space` in Zed requires disabling the macOS global shortcut.
+> Open **System Settings** > **Keyboard** > **Keyboard Shortcut**s >
+> **Input Sources** and uncheck **Select the previous input source**.
+
 For more information, see:
 
 - [Configuring Supported Languages](./configuring-languages.md)

--- a/docs/src/completions.md
+++ b/docs/src/completions.md
@@ -15,7 +15,7 @@ When there is an appropriate language server available, Zed will provide complet
 
 You can manually trigger completions with `ctrl-space` or by triggering the `editor::ShowCompletions` action from the command palette.
 
-> Using `ctrl-space` in Zed requires disabling the macOS global shortcut.
+> Note: Using `ctrl-space` in Zed requires disabling the macOS global shortcut.
 > Open **System Settings** > **Keyboard** > **Keyboard Shortcut**s >
 > **Input Sources** and uncheck **Select the previous input source**.
 


### PR DESCRIPTION
This is already noted in our `default-macos.json`, but was never surfaced in our docs for some reason. A user noted their LSP completions were not working because they were not aware of the conflicting global shortcut.

Ref: https://github.com/zed-industries/zed/issues/44970#issuecomment-3664118523

Release Notes:

- N/A
