### PR TITLE
gpui: Persist window bounds and display when detaching a workspace session

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -5673,12 +5673,24 @@ impl Workspace {
                     persistence::DB.save_workspace(serialized_workspace).await;
                 })
             }
-            WorkspaceLocation::DetachFromSession => window.spawn(cx, async move |_| {
-                persistence::DB
-                    .set_session_id(database_id, None)
-                    .await
-                    .log_err();
-            }),
+            WorkspaceLocation::DetachFromSession => {
+                let window_bounds = SerializedWindowBounds(window.window_bounds());
+                let display = window.display(cx).and_then(|d| d.uuid().ok());
+                window.spawn(cx, async move |_| {
+                    persistence::DB
+                        .set_window_open_status(
+                            database_id,
+                            window_bounds,
+                            display.unwrap_or_default(),
+                        )
+                        .await
+                        .log_err();
+                    persistence::DB
+                        .set_session_id(database_id, None)
+                        .await
+                        .log_err();
+                })
+            }
             WorkspaceLocation::None => Task::ready(()),
         }
     }


### PR DESCRIPTION
Closes #41246 #45092

Release Notes:

- N/A

**Root Cause**:
Empty local workspaces returned `DetachFromSession` from 
`serialize_workspace_location()`, and the `DetachFromSession` handler only cleared the session_id **without saving window bounds**.

**Fix Applied**:
Modified the `DetachFromSession` handler to save window bounds via `set_window_open_status()`:
```rust
WorkspaceLocation::DetachFromSession => {
    let window_bounds = SerializedWindowBounds(window.window_bounds());
    let display = window.display(cx).and_then(|d| d.uuid().ok());
    window.spawn(cx, async move |_| {
        persistence::DB
            .set_window_open_status(database_id, window_bounds, display.unwrap_or_default())
            .await.log_err();
        persistence::DB.set_session_id(database_id, None).await.log_err();
    })
}
```

**Recording**:

https://github.com/user-attachments/assets/2b6564d4-4e1b-40fe-943b-147296340aa7

