### PR TITLE
acp: Change default for gemini back to managed version

### DIFF
--- a/crates/project/src/agent_server_store.rs
+++ b/crates/project/src/agent_server_store.rs
@@ -460,7 +460,7 @@ impl AgentServerStore {
                     .gemini
                     .as_ref()
                     .and_then(|settings| settings.ignore_system_version)
-                    .unwrap_or(false),
+                    .unwrap_or(true),
             }),
         );
         self.external_agents.insert(


### PR DESCRIPTION
It seems we unintentionally changed the default behavior of if we use the gemini on the path in #40663

Changing this back so by default we use a managed version of the CLI so we can better control min versions and the like, but still allow people to override if they need to.

Release Notes:

- N/A
