### PR TITLE
thread_view: Clearer authentication states

### DIFF
--- a/crates/ui/src/components/callout.rs
+++ b/crates/ui/src/components/callout.rs
@@ -121,7 +121,7 @@ impl RenderOnce for Callout {
             Severity::Info => (
                 IconName::Info,
                 Color::Muted,
-                cx.theme().colors().panel_background.opacity(0.),
+                cx.theme().status().info_background.opacity(0.1),
             ),
             Severity::Success => (
                 IconName::Check,


### PR DESCRIPTION
Closes #44717

Sometimes, we show the user the agent's auth methods because we got an AuthRequired error.

However, there are also several ways a user can choose to re-enter the authentication flow even though they are still logged in.

This has caused some confusion with several users, where after logging in, they type /login again to see if anything changed, and they saw an "Authentication Required" warning.

So, I made a distinction in the UI if we go to this flow from a concrete error, or if not, made the language less error-like to help avoid confusion.

| Before | After |
|--------|--------|
| <img width="1154" height="446" alt="Screenshot 2025-12-18 at 10  54@2x" src="https://github.com/user-attachments/assets/9df0d59a-2d45-4bfc-ba85-359dd1a4c8ae" /> | <img width="1154" height="446" alt="Screenshot 2025-12-18 at 10  53@2x" src="https://github.com/user-attachments/assets/73a9fb45-4e6f-4594-8795-aaade35b2a72" /> | 


Release Notes:

- N/A
