### PR TITLE
open_ai: Add `xhigh` to list of supported reasoning effort values

### DIFF
--- a/crates/settings/src/settings_content/language_model.rs
+++ b/crates/settings/src/settings_content/language_model.rs
@@ -217,6 +217,7 @@ pub enum OpenAiReasoningEffort {
     Low,
     Medium,
     High,
+    Xhigh,
 }
 
 #[with_fallible_options]


### PR DESCRIPTION
According to the [docs](https://platform.openai.com/docs/api-reference/chat/create#chat_create-reasoning_effort), `xhigh` is a supported value for all models after `gpt-5.1-codex-max`. It doesn’t look like we have any special logic in place to check if the reasoning model supports that level of effort, so I expect the API to throw if we send that effort value to a non-compatible model.

Closes #45168.

Release Notes:

- Added `xhigh` to list of supported reasoning effort values for OpenAI LLMs
