### PR TITLE
Hide inline overlays when context menu is open

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -5417,6 +5417,12 @@ impl EditorElement {
                 .max(MIN_POPOVER_LINE_HEIGHT * line_height), // Apply minimum height of 4 lines
         );
 
+        // Don't show hover popovers when context menu is open to avoid overlap
+        let has_context_menu = self.editor.read(cx).mouse_context_menu.is_some();
+        if has_context_menu {
+            return;
+        }
+
         let hover_popovers = self.editor.update(cx, |editor, cx| {
             editor.hover_state.render(
                 snapshot,


### PR DESCRIPTION
Closes #23367 

**Summary**
- Prevents inline diagnostics, code actions, blame annotations, and hover popovers from overlapping with the right-click context menu by checking for `mouse_context_menu` presence before rendering these UI elements.

PS: Same behaviour is present in other editors like VS Code.


**Screen recording**

https://github.com/user-attachments/assets/8290412b-0f86-4985-8c70-13440686e530



Release Notes:

- N/A *or* Added/Fixed/Improved ...
