### PR TITLE
agent: Add stop sequence to prevent model from generating user messages

### DIFF
--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1964,7 +1964,7 @@ impl Thread {
             messages,
             tools,
             tool_choice: None,
-            stop: Vec::new(),
+            stop: vec!["## User".to_string()],
             temperature: AgentSettings::temperature_for_model(model, cx),
             thinking_allowed: true,
         };


### PR DESCRIPTION
## Summary
- Fixes an issue where the agent would occasionally "go haywire" by hallucinating user responses and then replying to its own fabricated messages.
- Adds `## User` as a stop sequence in the language model request to enforce proper turn-taking.

## Problem
Without a stop sequence, the language model would sometimes continue generating beyond its turn. The conversation history uses markdown headers (`## User`) to separate turns, so the model could predict that `## User` comes next, begin generating a user message itself, and then respond to it—creating a self-conversation loop.

This typically manifested as the agent producing output like:

> "I'll go ahead and run that command."
>
> '## User'
> Go ahead with that.
>
> "Okay, running the command now..."

...when the user had never sent the middle message.

The issue occurred most frequently with Gemini models and during documentation-editing tasks or related non-code-writing activities, rather than pure code editing.

## Solution
Add `"## User"` to the `stop` field of the `LanguageModelRequest`. This instructs the model to halt generation immediately if it begins producing that token sequence, preventing it from starting a user turn and ensuring control returns to the actual user.

```diff
# Example diff snippet (for visibility)
- stop: Vec::new(),
+ stop: vec!["## User".to_string()],
```
All supported providers (Gemini, OpenAI, etc.) handle stop sequences correctly, and this specific sequence is unlikely to appear legitimately in assistant responses.

## Testing
This is a low-risk, non-breaking change: adding a stop sequence is a standard, well-established technique for enforcing turn-taking in LLM conversations, and the sequence `"## User"` is unique to turn boundaries—it should never appear in legitimate assistant output.

The bug itself is intermittent and most reliably triggered with Gemini models during documentation-related tasks (rather than pure code editing), which makes systematic local testing token-expensive and time-consuming.

I have not yet run local tests with the change applied, but no regressions are expected.