### PR TITLE
workspace: Add `Pane::add_item_behind` for background tab creation

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1226,6 +1226,35 @@ impl Pane {
         )
     }
 
+    /// Adds an item to the pane without switching to its tab.
+    ///
+    /// Unlike `add_item`, this method adds the item in the background without
+    /// making it the active tab. The `activate_pane` parameter still controls
+    /// whether the pane itself becomes active.
+    pub fn add_item_behind(
+        &mut self,
+        item: Box<dyn ItemHandle>,
+        activate_pane: bool,
+        focus_item: bool,
+        destination_index: Option<usize>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(text) = item.telemetry_event_text(cx) {
+            telemetry::event!(text);
+        }
+
+        self.add_item_inner(
+            item,
+            activate_pane,
+            focus_item,
+            false,
+            destination_index,
+            window,
+            cx,
+        )
+    }
+
     pub fn items_len(&self) -> usize {
         self.items.len()
     }


### PR DESCRIPTION
## Summary

Adds `Pane::add_item_behind`, a companion to `add_item` that inserts an item without switching to its tab.

- `add_item` - adds item and switches to it (unchanged)
- `add_item_behind` - adds item without switching to it (new)

Closes #45279

## Motivation

The existing `add_item` method hardcodes tab activation to `true`, making it impossible for callers to add items in the background. This is needed for:

- Programmatic terminal creation via extensions
- Background task terminals (`RevealStrategy::Never`)
- Any workflow that needs to create tabs without disrupting the user's current focus

## Changes

- Added `Pane::add_item_behind` method in `crates/workspace/src/pane.rs`
- No changes to existing `add_item` behavior (backwards compatible)