### PR TITLE
danger: Deny conventional commits in PR titles

### DIFF
--- a/script/danger/dangerfile.ts
+++ b/script/danger/dangerfile.ts
@@ -6,6 +6,9 @@ prHygiene({
   rules: {
     // Don't enable this rule just yet, as it can have false positives.
     useImperativeMood: "off",
+    noConventionalCommits: {
+      bannedTypes: ["feat", "fix", "style", "refactor", "perf", "test", "chore", "build", "revert"],
+    },
   },
 });
 

--- a/script/danger/package.json
+++ b/script/danger/package.json
@@ -8,6 +8,6 @@
   },
   "devDependencies": {
     "danger": "13.0.4",
-    "danger-plugin-pr-hygiene": "0.6.1"
+    "danger-plugin-pr-hygiene": "0.7.0"
   }
 }

--- a/script/danger/pnpm-lock.yaml
+++ b/script/danger/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: 13.0.4
         version: 13.0.4
       danger-plugin-pr-hygiene:
-        specifier: 0.6.1
-        version: 0.6.1
+        specifier: 0.7.0
+        version: 0.7.0
 
 packages:
 
@@ -134,8 +134,8 @@ packages:
   core-js@3.45.1:
     resolution: {integrity: sha512-L4NPsJlCfZsPeXukyzHFlg/i7IIVwHSItR0wg0FLNqYClJ4MQYTYLbC7EkjKYRLZF2iof2MUgN0EGy7MdQFChg==}
 
-  danger-plugin-pr-hygiene@0.6.1:
-    resolution: {integrity: sha512-nb+iUQvirE3BlKXI1WoOND6sujyGzHar590mJm5tt4RLi65HXFaU5hqONxgDoWFujJNHYnXse9yaZdxnxEi4QA==}
+  danger-plugin-pr-hygiene@0.7.0:
+    resolution: {integrity: sha512-YDWhEodP0fg/t9YO3SxufWS9j1Rcxbig+1flTlUlojBDFiKQyVmaj8PIvnJxJItjHWTlNKI9wMSRq5vUql6zyA==}
 
   danger@13.0.4:
     resolution: {integrity: sha512-IAdQ5nSJyIs4zKj6AN35ixt2B0Ce3WZUm3IFe/CMnL/Op7wV7IGg4D348U0EKNaNPP58QgXbdSk9pM+IXP1QXg==}
@@ -573,7 +573,7 @@ snapshots:
 
   core-js@3.45.1: {}
 
-  danger-plugin-pr-hygiene@0.6.1: {}
+  danger-plugin-pr-hygiene@0.7.0: {}
 
   danger@13.0.4:
     dependencies:


### PR DESCRIPTION
This PR upgrades `danger-plugin-pr-hygiene` to v0.7.0 so that we can have Danger deny conventional commits in PR titles.

Release Notes:

- N/A
