### PR TITLE
git: Clean up integration settings schema

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1319,15 +1319,17 @@
   // Globs to match files that will be considered "hidden". These files can be hidden from the
   // project panel by toggling the "hide_hidden" setting.
   "hidden_files": ["**/.*"],
-  // Git gutter behavior configuration.
+  // Git integration settings.
   "git": {
-    // Global switch to enable or disable all git integration features.
-    // If set to true, disables all git integration features.
-    // If set to false, individual git integration features below will be independently enabled or disabled.
+    // Master switch to disable all git integration features.
+    // When true, all git features are disabled regardless of other settings.
+    // When false (default), individual features are controlled by their respective settings.
     "disable_git": false,
-    // Whether to enable git status tracking.
+    // Whether to show git status indicators (modified, added, deleted) in the
+    // project panel, outline panel, and tabs.
     "enable_status": true,
-    // Whether to enable git diff display.
+    // Whether to show git diff information, including gutter diff indicators
+    // and scrollbar diff markers.
     "enable_diff": true,
     // Control whether the git gutter is shown. May take 2 values:
     // 1. Show the gutter

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -64,10 +64,7 @@ use project::{
     debugger::breakpoint_store::{Breakpoint, BreakpointSessionState},
     project_settings::ProjectSettings,
 };
-use settings::{
-    GitGutterSetting, GitHunkStyleSetting, IndentGuideBackgroundColoring, IndentGuideColoring,
-    Settings,
-};
+use settings::{GitHunkStyleSetting, IndentGuideBackgroundColoring, IndentGuideColoring, Settings};
 use smallvec::{SmallVec, smallvec};
 use std::{
     any::TypeId,
@@ -2204,8 +2201,8 @@ impl EditorElement {
             .display_diff_hunks_for_rows(display_rows, folded_buffers)
             .map(|hunk| (hunk, None))
             .collect::<Vec<_>>();
-        let git_gutter_setting = ProjectSettings::get_global(cx).git.git_gutter;
-        if let GitGutterSetting::TrackedFiles = git_gutter_setting {
+        let git_settings = &ProjectSettings::get_global(cx).git;
+        if git_settings.is_gutter_enabled() {
             for (hunk, hitbox) in &mut display_hunks {
                 if matches!(hunk, DisplayDiffHunk::Unfolded { .. }) {
                     let hunk_bounds =
@@ -6469,12 +6466,7 @@ impl EditorElement {
             .position_map
             .snapshot
             .show_git_diff_gutter
-            .unwrap_or_else(|| {
-                matches!(
-                    ProjectSettings::get_global(cx).git.git_gutter,
-                    GitGutterSetting::TrackedFiles
-                )
-            });
+            .unwrap_or_else(|| ProjectSettings::get_global(cx).git.is_gutter_enabled());
         if show_git_gutter {
             Self::paint_gutter_diff_hunks(layout, window, cx)
         }

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -365,6 +365,27 @@ pub struct GitSettings {
     pub path_style: GitPathStyle,
 }
 
+impl GitSettings {
+    /// Returns whether git status indicators should be shown.
+    /// This includes status in the project panel, outline panel, and tabs.
+    pub fn is_status_enabled(&self) -> bool {
+        self.enabled.status
+    }
+
+    /// Returns whether git diff features should be shown.
+    /// This includes gutter diff indicators and scrollbar diff markers.
+    pub fn is_diff_enabled(&self) -> bool {
+        self.enabled.diff
+    }
+
+    /// Returns whether the git gutter should be shown.
+    /// This checks both the global diff setting and the gutter-specific setting.
+    pub fn is_gutter_enabled(&self) -> bool {
+        self.is_diff_enabled()
+            && matches!(self.git_gutter, settings::GitGutterSetting::TrackedFiles)
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 pub struct GitEnabledSettings {
     /// Whether git integration is enabled for showing git status.

--- a/crates/settings/src/settings_content/project.rs
+++ b/crates/settings/src/settings_content/project.rs
@@ -322,12 +322,28 @@ pub struct GitSettings {
     pub path_style: Option<GitPathStyle>,
 }
 
+/// Global controls for enabling or disabling git integration features.
+///
+/// These settings provide a centralized way to control git integration,
+/// rather than having to configure each feature individually.
 #[with_fallible_options]
 #[derive(Clone, Copy, Debug, PartialEq, Default, Serialize, Deserialize, JsonSchema, MergeFrom)]
 #[serde(rename_all = "snake_case")]
 pub struct GitEnabledSettings {
+    /// Master switch to disable all git integration features.
+    /// When true, all git features are disabled regardless of other settings.
+    ///
+    /// Default: false
     pub disable_git: Option<bool>,
+    /// Whether to show git status indicators (modified, added, deleted)
+    /// in the project panel, outline panel, and tabs.
+    ///
+    /// Default: true
     pub enable_status: Option<bool>,
+    /// Whether to show git diff information, including gutter diff
+    /// indicators and scrollbar diff markers.
+    ///
+    /// Default: true
     pub enable_diff: Option<bool>,
 }
 


### PR DESCRIPTION
Follow up on: 43326

Integrate git gutter diff hunks with the global git integration setting, which was previously missing.

I also simplify the settings schema by replacing three boolean fields (disable_git, enable_status, enable_diff) with a single enum: full, status_only, diff_only, or disabled.

Release Notes:

- git: Add git integration setting that allows disabling git support in Zed
- `git: { integration: "full" | "status_only" | "diff_only" | "disabled"}`
