### PR TITLE
Add zed::PopKey action

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -1097,4 +1097,10 @@
       "ctrl-e": "markdown::ScrollDown",
     },
   },
+  {
+    "context": "pending",
+    "bindings": {
+      "backspace": "zed::PopKey"
+    }
+  },
 ]

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -4098,6 +4098,27 @@ impl Window {
         self.pending_input.take();
     }
 
+    /// Removes the last pending keystroke from the pending input sequence.
+    /// Returns true if a keystroke was removed, false if there were no pending keystrokes.
+    pub fn pop_pending_keystroke(&mut self, cx: &mut App) -> bool {
+        let Some(pending) = self.pending_input.as_mut() else {
+            return false;
+        };
+
+        if pending.keystrokes.is_empty() {
+            return false;
+        }
+
+        pending.keystrokes.pop();
+
+        if pending.keystrokes.is_empty() {
+            self.pending_input.take();
+        }
+
+        self.pending_input_changed(cx);
+        true
+    }
+
     /// Returns the currently pending input keystrokes that might result in a multi-stroke key binding.
     pub fn pending_input_keystrokes(&self) -> Option<&[Keystroke]> {
         self.pending_input

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -130,6 +130,8 @@ actions!(
         TestPanic,
         /// Triggers a hard crash for debugging.
         TestCrash,
+        /// Removes the latest pending keystroke.
+        PopKey,
     ]
 );
 
@@ -815,6 +817,9 @@ fn register_actions(
         })
         .register_action(|_, _: &ToggleFullScreen, window, _| {
             window.toggle_fullscreen();
+        })
+        .register_action(|_, _: &PopKey, window, cx| {
+            window.pop_pending_keystroke(cx);
         })
         .register_action(|_, action: &OpenZedUrl, _, cx| {
             OpenListener::global(cx).open(RawOpenRequest {


### PR DESCRIPTION
@xipeng-jin and I thought this would be a nice followup to the which-key PR. We already have the `vim_mode == waiting` context, but I decided to handle this at a more general level since it should work for non-vim sequential keybindings.

Release Notes:

- Add `zed::PopKey` action to remove the latest pending keystroke. This allows you to navigate backwards in our new which-key UI.
