### PR TITLE
vim: Remember search settings

### DIFF
--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -930,6 +930,9 @@ impl BufferSearchBar {
             self.default_options = configured_options;
         }
 
+        // This isn't a normal setting; it's only applicable to vim search.
+        self.search_options.remove(SearchOptions::BACKWARDS);
+
         self.dismissed = false;
         self.adjust_query_regex_language(cx);
         handle.search_bar_visibility_changed(true, window, cx);


### PR DESCRIPTION
In particular, don't do anything special for REGEX or CASE_SENSITIVE; just let the regular settings handle that.

Don't let BACKWARDS stick around in the buffer search settings - otherwise if the last vim search is BACKWARDS, the next Ctrl+F search will be too.

Closes #21956

Release Notes:

- Fix issue where the first search (`cmd-f`) after using a backwards vim search (`shift-/`) would also be done backwards
