### PR TITLE
Allow project search to be efficiently cancelled

### DIFF
--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -5179,7 +5179,7 @@ async fn test_project_search(
 
     // Perform a search as the guest.
     let mut results = HashMap::default();
-    let search_rx = project_b.update(cx_b, |project, cx| {
+    let (search_rx, search_task) = project_b.update(cx_b, |project, cx| {
         project.search(
             SearchQuery::text(
                 "world",
@@ -5195,6 +5195,8 @@ async fn test_project_search(
             cx,
         )
     });
+    // Keep the search task alive while we drain the receiver; dropping it cancels the search.
+    let _search_task = search_task;
     while let Ok(result) = search_rx.recv().await {
         match result {
             SearchResult::Buffer { buffer, ranges } => {

--- a/crates/extension_host/src/wasm_host.rs
+++ b/crates/extension_host/src/wasm_host.rs
@@ -12,6 +12,7 @@ use extension::{
     WorktreeDelegate,
 };
 use fs::{Fs, normalize_path};
+use futures::AsyncReadExt;
 use futures::future::LocalBoxFuture;
 use futures::{
     Future, FutureExt, StreamExt as _,
@@ -763,13 +764,14 @@ impl WasmExtension {
 
         let mut wasm_file = wasm_host
             .fs
-            .open_sync(&path)
+            .open_read(&path)
             .await
             .context(format!("opening wasm file, path: {path:?}"))?;
 
         let mut wasm_bytes = Vec::new();
         wasm_file
             .read_to_end(&mut wasm_bytes)
+            .await
             .context(format!("reading wasm file, path: {path:?}"))?;
 
         wasm_host

--- a/crates/project/src/project_search.rs
+++ b/crates/project/src/project_search.rs
@@ -681,7 +681,7 @@ impl RequestHandler<'_> {
     }
 
     async fn handle_find_first_match(&self, mut entry: MatchingEntry) {
-        _ = (async move || -> anyhow::Result<()> {
+        _=maybe!(async move {
             let abs_path = entry.worktree_root.join(entry.path.path.as_std_path());
 
             let file = self
@@ -713,10 +713,8 @@ impl RequestHandler<'_> {
                 entry.should_scan_tx.send(entry.path).await?;
             }
 
-            Ok(())
-        })()
-        .await
-        .log_err();
+            anyhow::Ok(())
+        }).await;
     }
 
     async fn handle_scan_path(&self, req: InputPath) {

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -10400,7 +10400,10 @@ async fn search(
     query: SearchQuery,
     cx: &mut gpui::TestAppContext,
 ) -> Result<HashMap<String, Vec<Range<usize>>>> {
-    let search_rx = project.update(cx, |project, cx| project.search(query, cx));
+    let (search_rx, search_task) = project.update(cx, |project, cx| project.search(query, cx));
+    // Keep the search task alive while we drain the receiver; dropping it cancels the search.
+    let _search_task = search_task;
+
     let mut results = HashMap::default();
     while let Ok(search_result) = search_rx.recv().await {
         match search_result {

--- a/crates/project/src/search.rs
+++ b/crates/project/src/search.rs
@@ -328,7 +328,7 @@ impl SearchQuery {
 
     pub(crate) async fn detect(&self, mut reader: impl AsyncBufRead + Unpin) -> Result<bool> {
         let query_str = self.as_str();
-        let needle_len = query_str.as_bytes().len();
+        let needle_len = query_str.len();
         if needle_len == 0 {
             return Ok(false);
         }

--- a/crates/project_benchmarks/src/main.rs
+++ b/crates/project_benchmarks/src/main.rs
@@ -102,9 +102,11 @@ fn main() -> Result<(), anyhow::Error> {
                 println!("Starting a project search");
                 let timer = std::time::Instant::now();
                 let mut first_match = None;
-                let matches = project
+
+                let (matches, _search_task) = project
                     .update(cx, |this, cx| this.search(query, cx))
                     .unwrap();
+
                 let mut matched_files = 0;
                 let mut matched_chunks = 0;
                 while let Ok(match_result) = matches.recv().await {

--- a/crates/remote_server/src/headless_project.rs
+++ b/crates/remote_server/src/headless_project.rs
@@ -771,7 +771,7 @@ impl HeadlessProject {
             message.query.context("missing query field")?,
             PathStyle::local(),
         )?;
-        let results = this.update(&mut cx, |this, cx| {
+        let (results, search_task) = this.update(&mut cx, |this, cx| {
             project::Search::local(
                 this.fs.clone(),
                 this.buffer_store.clone(),
@@ -782,6 +782,10 @@ impl HeadlessProject {
             .into_handle(query, cx)
             .matching_buffers(cx)
         })?;
+
+        // Keep the search task alive while we drain the receiver; dropping it cancels the search.
+        // We intentionally do not detach it.
+        let _search_task = search_task;
 
         let mut response = proto::FindSearchCandidatesResponse {
             buffer_ids: Vec::new(),


### PR DESCRIPTION
Previously, cancelling did not really terminate the search computations, due to detaching the owning Task, and due to synchronous IO that was used to find candidate files.

Release Notes:

- Optimized cancellation of project search. Now, when closing a project search or changing the query while the search is running, work on the previous search will terminate more promptly.
