### PR TITLE
JetBrains keymap: Add escape key binding to cancel in auto_height mode

### DIFF
--- a/assets/keymaps/linux/jetbrains.json
+++ b/assets/keymaps/linux/jetbrains.json
@@ -178,10 +178,16 @@
   { "context": "Diagnostics > Editor", "bindings": { "alt-6": "pane::CloseActiveItem" } },
   { "context": "OutlinePanel", "bindings": { "alt-7": "workspace::CloseActiveDock" } },
   {
-    "context": "Dock || Workspace || OutlinePanel || ProjectPanel || CollabPanel || (Editor && mode == auto_height)",
+    "context": "Dock || Workspace || OutlinePanel || ProjectPanel || CollabPanel",
     "bindings": {
       "escape": "editor::ToggleFocus",
       "shift-escape": "workspace::CloseActiveDock",
+    },
+  },
+  {
+    "context": "Editor && mode == auto_height",
+    "bindings": {
+      "escape": "editor::Cancel",
     },
   },
 ]

--- a/assets/keymaps/macos/jetbrains.json
+++ b/assets/keymaps/macos/jetbrains.json
@@ -181,10 +181,16 @@
   { "context": "Diagnostics > Editor", "bindings": { "cmd-6": "pane::CloseActiveItem" } },
   { "context": "OutlinePanel", "bindings": { "cmd-7": "workspace::CloseActiveDock" } },
   {
-    "context": "Dock || Workspace || OutlinePanel || ProjectPanel || CollabPanel || (Editor && mode == auto_height)",
+    "context": "Dock || Workspace || OutlinePanel || ProjectPanel || CollabPanel",
     "bindings": {
       "escape": "editor::ToggleFocus",
       "shift-escape": "workspace::CloseActiveDock",
+    },
+  },
+  {
+    "context": "Editor && mode == auto_height",
+    "bindings": {
+      "escape": "editor::Cancel",
     },
   },
 ]


### PR DESCRIPTION
Closes [#45299](https://github.com/zed-industries/zed/issues/45299)

Release Notes:

- Fix Escape key does not cancel/dismiss inline assist with Jetbrains keymap

Recording:

https://github.com/user-attachments/assets/766a9954-2d32-4f43-b81d-acba1cb8e133

