### PR TITLE
gpui: Request user attention for agent notifications on Linux

### DIFF
--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -4888,8 +4888,9 @@ impl AcpThreadView {
             return;
         }
 
+        let caption: SharedString = caption.into();
         let settings = AgentSettings::get_global(cx);
-
+        let is_critical = matches!(icon, IconName::Warning);
         let window_is_inactive = !window.is_window_active();
         let panel_is_hidden = self
             .workspace
@@ -4897,30 +4898,27 @@ impl AcpThreadView {
             .map(|workspace| AgentPanel::is_hidden(&workspace, cx))
             .unwrap_or(true);
 
-        let should_notify = window_is_inactive || panel_is_hidden;
-
-        if !should_notify {
+        if !(window_is_inactive || panel_is_hidden) {
             return;
         }
+
+        window.request_user_attention(is_critical);
 
         // TODO: Change this once we have title summarization for external agents.
         let title = self.agent.name();
 
         match settings.notify_when_agent_waiting {
             NotifyWhenAgentWaiting::PrimaryScreen => {
-                if let Some(primary) = cx.primary_display() {
-                    self.pop_up(icon, caption.into(), title, window, primary, cx);
+                if let Some(screen) = cx.primary_display() {
+                    self.pop_up(icon, caption, title, window, screen, cx);
                 }
             }
             NotifyWhenAgentWaiting::AllScreens => {
-                let caption = caption.into();
                 for screen in cx.displays() {
                     self.pop_up(icon, caption.clone(), title.clone(), window, screen, cx);
                 }
             }
-            NotifyWhenAgentWaiting::Never => {
-                // Don't show anything
-            }
+            NotifyWhenAgentWaiting::Never => {}
         }
     }
 
@@ -4933,7 +4931,7 @@ impl AcpThreadView {
         screen: Rc<dyn PlatformDisplay>,
         cx: &mut Context<Self>,
     ) {
-        let options = AgentNotification::window_options(screen, cx);
+        let options = AgentNotification::window_options(screen.clone(), cx);
 
         let project_name = self.workspace.upgrade().and_then(|workspace| {
             workspace

--- a/crates/collab_ui/src/notifications/incoming_call_notification.rs
+++ b/crates/collab_ui/src/notifications/incoming_call_notification.rs
@@ -46,6 +46,11 @@ pub fn init(app_state: &Arc<AppState>, cx: &mut App) {
                             })
                             .unwrap();
                         notification_windows.push(window);
+                        if let Some(window) = notification_windows.last() {
+                            window
+                                .update(cx, |_, window, _| window.request_user_attention(true))
+                                .log_err();
+                        }
                     }
                 }
             }

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -481,6 +481,7 @@ pub(crate) trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
         answers: &[PromptButton],
     ) -> Option<oneshot::Receiver<usize>>;
     fn activate(&self);
+    fn request_user_attention(&self, is_critical: bool);
     fn is_active(&self) -> bool;
     fn is_hovered(&self) -> bool;
     fn set_title(&mut self, title: &str);

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -696,7 +696,22 @@ impl LinuxClient for WaylandClient {
     }
 
     fn primary_display(&self) -> Option<Rc<dyn PlatformDisplay>> {
-        None
+        let state = self.0.borrow();
+        let best = state.outputs.iter().min_by_key(|(_, output)| {
+            (
+                output.bounds.origin.x.0,
+                output.bounds.origin.y.0,
+                output.bounds.size.width.0,
+                output.bounds.size.height.0,
+            )
+        });
+        best.map(|(id, output)| {
+            Rc::new(WaylandDisplay {
+                id: id.clone(),
+                name: output.name.clone(),
+                bounds: output.bounds.to_pixels(output.scale as f32),
+            }) as Rc<dyn PlatformDisplay>
+        })
     }
 
     #[cfg(feature = "screen-capture")]

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -182,6 +182,8 @@ impl PlatformWindow for TestWindow {
         )
     }
 
+    fn request_user_attention(&self, _is_critical: bool) {}
+
     fn activate(&self) {
         self.0
             .lock()

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -4252,6 +4252,11 @@ impl Window {
         self.platform_window.activate();
     }
 
+    /// Request the platform to draw attention to this window without necessarily activating it.
+    pub fn request_user_attention(&self, is_critical: bool) {
+        self.platform_window.request_user_attention(is_critical);
+    }
+
     /// Minimize the current window at the platform level.
     pub fn minimize_window(&self) {
         self.platform_window.minimize();


### PR DESCRIPTION
Closes #43803

## Summary

- Add `request_user_attention(is_critical: bool)` API to request platform-level attention indicators
- Implement for platforms:
  - **X11**: Sets `_NET_WM_STATE_DEMANDS_ATTENTION` atom
  - **Wayland**: Uses `xdg_activation_v1` protocol to request attention
- Call `request_user_attention` when agent notifications are shown and the window is inactive
- Implement `primary_display()` for Wayland so notifications work with the "Primary Screen" setting

## Test

- [x] Verify notification window opens when agent requests input and Zed is not focused
- [x] Verify `_NET_WM_STATE_DEMANDS_ATTENTION` is set on X11 (via `xprop`)
- [x] Test on Wayland (GNOME, Hyprland, Sway)
- [x] Test on X11 (LeftWM)

Release Notes:

- N/A
