### PR TITLE
agent ui: Make some UI elements more consistent

### DIFF
--- a/crates/agent_ui/src/acp/mode_selector.rs
+++ b/crates/agent_ui/src/acp/mode_selector.rs
@@ -188,6 +188,17 @@ impl Render for ModeSelector {
                             .gap_1()
                             .child(
                                 h_flex()
+                                    .gap_2()
+                                    .justify_between()
+                                    .child(Label::new("Toggle Mode Menu"))
+                                    .child(KeyBinding::for_action_in(
+                                        &ToggleProfileSelector,
+                                        &focus_handle,
+                                        cx,
+                                    )),
+                            )
+                            .child(
+                                h_flex()
                                     .pb_1()
                                     .gap_2()
                                     .justify_between()
@@ -196,17 +207,6 @@ impl Render for ModeSelector {
                                     .child(Label::new("Cycle Through Modes"))
                                     .child(KeyBinding::for_action_in(
                                         &CycleModeSelector,
-                                        &focus_handle,
-                                        cx,
-                                    )),
-                            )
-                            .child(
-                                h_flex()
-                                    .gap_2()
-                                    .justify_between()
-                                    .child(Label::new("Toggle Mode Menu"))
-                                    .child(KeyBinding::for_action_in(
-                                        &ToggleProfileSelector,
                                         &focus_handle,
                                         cx,
                                     )),

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -2718,7 +2718,7 @@ impl AcpThreadView {
                             ..default_markdown_style(false, true, window, cx)
                         },
                     ))
-                    .tooltip(Tooltip::text("Jump to File"))
+                    .tooltip(Tooltip::text("Go to File"))
                     .on_click(cx.listener(move |this, _, window, cx| {
                         this.open_tool_call_location(entry_ix, 0, window, cx);
                     }))

--- a/crates/agent_ui/src/profile_selector.rs
+++ b/crates/agent_ui/src/profile_selector.rs
@@ -191,6 +191,9 @@ impl Render for ProfileSelector {
                     let container = || h_flex().gap_1().justify_between();
                     v_flex()
                         .gap_1()
+                        .child(container().child(Label::new("Toggle Profile Menu")).child(
+                            KeyBinding::for_action_in(&ToggleProfileSelector, &focus_handle, cx),
+                        ))
                         .child(
                             container()
                                 .pb_1()
@@ -203,9 +206,6 @@ impl Render for ProfileSelector {
                                     cx,
                                 )),
                         )
-                        .child(container().child(Label::new("Toggle Profile Menu")).child(
-                            KeyBinding::for_action_in(&ToggleProfileSelector, &focus_handle, cx),
-                        ))
                         .into_any()
                 }
             }),


### PR DESCRIPTION
- Both the mode, profile, and model selectors have the option to cycle through its options with a keybinding. In the tooltip that shows it, in some of them the "Cycle Through..." label was at the top, and in others at the bottom. Now it's all at the bottom.
- We used different language in different places for "going to a file". The tool call edit card's header said "_Jump_ to File" while the edit files list said "_Go_ to File". Now it's both "Go to File".

Release Notes:

- N/A
