### PR TITLE
vim: Make `vaf` include const for arrow functions in JS/TS/TSX

### DIFF
--- a/crates/editor/src/test/editor_lsp_test_context.rs
+++ b/crates/editor/src/test/editor_lsp_test_context.rs
@@ -319,6 +319,49 @@ impl EditorLspTestContext {
                   (jsx_opening_element) @start
                   (jsx_closing_element)? @end) @indent
                 "#})),
+            text_objects: Some(Cow::from(indoc! {r#"
+                (function_declaration
+                    body: (_
+                        "{"
+                        (_)* @function.inside
+                        "}")) @function.around
+
+                (method_definition
+                    body: (_
+                        "{"
+                        (_)* @function.inside
+                        "}")) @function.around
+
+                ; Arrow function in variable declaration - capture the full declaration
+                ([
+                    (lexical_declaration
+                        (variable_declarator
+                            value: (arrow_function
+                                body: (statement_block
+                                    "{"
+                                    (_)* @function.inside
+                                    "}"))))
+                    (variable_declaration
+                        (variable_declarator
+                            value: (arrow_function
+                                body: (statement_block
+                                    "{"
+                                    (_)* @function.inside
+                                    "}"))))
+                ]) @function.around
+
+                ([
+                    (lexical_declaration
+                        (variable_declarator
+                            value: (arrow_function)))
+                    (variable_declaration
+                        (variable_declarator
+                            value: (arrow_function)))
+                ]) @function.around
+
+                ; Catch-all for arrow functions in other contexts (callbacks, etc.)
+                (arrow_function) @function.around
+                "#})),
             ..Default::default()
         })
         .expect("Could not parse queries");

--- a/crates/editor/src/test/editor_lsp_test_context.rs
+++ b/crates/editor/src/test/editor_lsp_test_context.rs
@@ -205,6 +205,49 @@ impl EditorLspTestContext {
                 (_ "{" "}" @end) @indent
                 (_ "(" ")" @end) @indent
                 "#})),
+            text_objects: Some(Cow::from(indoc! {r#"
+                (function_declaration
+                    body: (_
+                        "{"
+                        (_)* @function.inside
+                        "}")) @function.around
+
+                (method_definition
+                    body: (_
+                        "{"
+                        (_)* @function.inside
+                        "}")) @function.around
+
+                ; Arrow function in variable declaration - capture the full declaration
+                ([
+                    (lexical_declaration
+                        (variable_declarator
+                            value: (arrow_function
+                                body: (statement_block
+                                    "{"
+                                    (_)* @function.inside
+                                    "}"))))
+                    (variable_declaration
+                        (variable_declarator
+                            value: (arrow_function
+                                body: (statement_block
+                                    "{"
+                                    (_)* @function.inside
+                                    "}"))))
+                ]) @function.around
+
+                ([
+                    (lexical_declaration
+                        (variable_declarator
+                            value: (arrow_function)))
+                    (variable_declaration
+                        (variable_declarator
+                            value: (arrow_function)))
+                ]) @function.around
+
+                ; Catch-all for arrow functions in other contexts (callbacks, etc.)
+                (arrow_function) @function.around
+                "#})),
             ..Default::default()
         })
         .expect("Could not parse queries");

--- a/crates/editor/src/test/editor_lsp_test_context.rs
+++ b/crates/editor/src/test/editor_lsp_test_context.rs
@@ -246,7 +246,7 @@ impl EditorLspTestContext {
                 ]) @function.around
 
                 ; Catch-all for arrow functions in other contexts (callbacks, etc.)
-                (arrow_function) @function.around
+                ((arrow_function) @function.around (#not-has-parent? @function.around variable_declarator))
                 "#})),
             ..Default::default()
         })
@@ -360,7 +360,7 @@ impl EditorLspTestContext {
                 ]) @function.around
 
                 ; Catch-all for arrow functions in other contexts (callbacks, etc.)
-                (arrow_function) @function.around
+                ((arrow_function) @function.around (#not-has-parent? @function.around variable_declarator))
                 "#})),
             ..Default::default()
         })

--- a/crates/languages/src/javascript/textobjects.scm
+++ b/crates/languages/src/javascript/textobjects.scm
@@ -24,6 +24,34 @@
         (_)* @function.inside
         "}")) @function.around
 
+; Arrow function in variable declaration - capture the full declaration
+([
+    (lexical_declaration
+        (variable_declarator
+            value: (arrow_function
+                body: (statement_block
+                    "{"
+                    (_)* @function.inside
+                    "}"))))
+    (variable_declaration
+        (variable_declarator
+            value: (arrow_function
+                body: (statement_block
+                    "{"
+                    (_)* @function.inside
+                    "}"))))
+]) @function.around
+
+([
+    (lexical_declaration
+        (variable_declarator
+            value: (arrow_function)))
+    (variable_declaration
+        (variable_declarator
+            value: (arrow_function)))
+]) @function.around
+
+; Catch-all for arrow functions in other contexts (callbacks, etc.)
 (arrow_function) @function.around
 
 (generator_function

--- a/crates/languages/src/javascript/textobjects.scm
+++ b/crates/languages/src/javascript/textobjects.scm
@@ -18,11 +18,12 @@
         (_)* @function.inside
         "}")) @function.around
 
-(arrow_function
+((arrow_function
     body: (statement_block
         "{"
         (_)* @function.inside
         "}")) @function.around
+ (#not-has-parent? @function.around variable_declarator))
 
 ; Arrow function in variable declaration - capture the full declaration
 ([
@@ -42,17 +43,22 @@
                     "}"))))
 ]) @function.around
 
+; Arrow function in variable declaration (captures body for expression-bodied arrows)
 ([
     (lexical_declaration
         (variable_declarator
-            value: (arrow_function)))
+            value: (arrow_function
+                body: (_) @function.inside)))
     (variable_declaration
         (variable_declarator
-            value: (arrow_function)))
+            value: (arrow_function
+                body: (_) @function.inside)))
 ]) @function.around
 
 ; Catch-all for arrow functions in other contexts (callbacks, etc.)
-(arrow_function) @function.around
+((arrow_function
+    body: (_) @function.inside) @function.around
+ (#not-has-parent? @function.around variable_declarator))
 
 (generator_function
     body: (_

--- a/crates/languages/src/tsx/textobjects.scm
+++ b/crates/languages/src/tsx/textobjects.scm
@@ -24,6 +24,34 @@
         (_)* @function.inside
         "}")) @function.around
 
+; Arrow function in variable declaration - capture the full declaration
+([
+    (lexical_declaration
+        (variable_declarator
+            value: (arrow_function
+                body: (statement_block
+                    "{"
+                    (_)* @function.inside
+                    "}"))))
+    (variable_declaration
+        (variable_declarator
+            value: (arrow_function
+                body: (statement_block
+                    "{"
+                    (_)* @function.inside
+                    "}"))))
+]) @function.around
+
+([
+    (lexical_declaration
+        (variable_declarator
+            value: (arrow_function)))
+    (variable_declaration
+        (variable_declarator
+            value: (arrow_function)))
+]) @function.around
+
+; Catch-all for arrow functions in other contexts (callbacks, etc.)
 (arrow_function) @function.around
 (function_signature) @function.around
 

--- a/crates/languages/src/tsx/textobjects.scm
+++ b/crates/languages/src/tsx/textobjects.scm
@@ -18,11 +18,12 @@
         (_)* @function.inside
         "}")) @function.around
 
-(arrow_function
+((arrow_function
     body: (statement_block
         "{"
         (_)* @function.inside
         "}")) @function.around
+ (#not-has-parent? @function.around variable_declarator))
 
 ; Arrow function in variable declaration - capture the full declaration
 ([
@@ -42,17 +43,22 @@
                     "}"))))
 ]) @function.around
 
+; Arrow function in variable declaration (expression body fallback)
 ([
     (lexical_declaration
         (variable_declarator
-            value: (arrow_function)))
+            value: (arrow_function
+                body: (_) @function.inside)))
     (variable_declaration
         (variable_declarator
-            value: (arrow_function)))
+            value: (arrow_function
+                body: (_) @function.inside)))
 ]) @function.around
 
 ; Catch-all for arrow functions in other contexts (callbacks, etc.)
-(arrow_function) @function.around
+((arrow_function
+    body: (_) @function.inside) @function.around
+ (#not-has-parent? @function.around variable_declarator))
 (function_signature) @function.around
 
 (generator_function

--- a/crates/languages/src/typescript/textobjects.scm
+++ b/crates/languages/src/typescript/textobjects.scm
@@ -24,6 +24,34 @@
         (_)* @function.inside
         "}")) @function.around
 
+; Arrow function in variable declaration - capture the full declaration
+([
+    (lexical_declaration
+        (variable_declarator
+            value: (arrow_function
+                body: (statement_block
+                    "{"
+                    (_)* @function.inside
+                    "}"))))
+    (variable_declaration
+        (variable_declarator
+            value: (arrow_function
+                body: (statement_block
+                    "{"
+                    (_)* @function.inside
+                    "}"))))
+]) @function.around
+
+([
+    (lexical_declaration
+        (variable_declarator
+            value: (arrow_function)))
+    (variable_declaration
+        (variable_declarator
+            value: (arrow_function)))
+]) @function.around
+
+; Catch-all for arrow functions in other contexts (callbacks, etc.)
 (arrow_function) @function.around
 (function_signature) @function.around
 

--- a/crates/languages/src/typescript/textobjects.scm
+++ b/crates/languages/src/typescript/textobjects.scm
@@ -18,11 +18,12 @@
         (_)* @function.inside
         "}")) @function.around
 
-(arrow_function
+((arrow_function
     body: (statement_block
         "{"
         (_)* @function.inside
         "}")) @function.around
+ (#not-has-parent? @function.around variable_declarator))
 
 ; Arrow function in variable declaration - capture the full declaration
 ([
@@ -42,17 +43,23 @@
                     "}"))))
 ]) @function.around
 
+; Arrow function in variable declaration - capture body as @function.inside
+; (for statement blocks, the more specific pattern above captures just the contents)
 ([
     (lexical_declaration
         (variable_declarator
-            value: (arrow_function)))
+            value: (arrow_function
+                body: (_) @function.inside)))
     (variable_declaration
         (variable_declarator
-            value: (arrow_function)))
+            value: (arrow_function
+                body: (_) @function.inside)))
 ]) @function.around
 
 ; Catch-all for arrow functions in other contexts (callbacks, etc.)
-(arrow_function) @function.around
+((arrow_function
+    body: (_) @function.inside) @function.around
+ (#not-has-parent? @function.around variable_declarator))
 (function_signature) @function.around
 
 (generator_function

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -522,12 +522,16 @@ impl Vim {
                                             selection.start = original_point.to_display_point(map)
                                         }
                                     } else {
-                                        selection.end = movement::saturating_right(
-                                            map,
-                                            original_point.to_display_point(map),
-                                        );
-                                        if original_point.column > 0 {
-                                            selection.reversed = true
+                                        let original_display_point =
+                                            original_point.to_display_point(map);
+                                        if selection.end <= original_display_point {
+                                            selection.end = movement::saturating_right(
+                                                map,
+                                                original_display_point,
+                                            );
+                                            if original_point.column > 0 {
+                                                selection.reversed = true
+                                            }
                                         }
                                     }
                                 }


### PR DESCRIPTION
Closes #24264

Release Notes:

- N/A *or* Added/Fixed/Improved ...
