### PR TITLE
editor: Strip trailing newlines from completion documentation

### DIFF
--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -893,7 +893,7 @@ impl CompletionsMenu {
                                     None
                                 } else {
                                     Some(
-                                        Label::new(text.clone())
+                                        Label::new(text.trim().to_string())
                                             .ml_4()
                                             .size(LabelSize::Small)
                                             .color(Color::Muted),


### PR DESCRIPTION
Closes #45337

Release Notes:

- Fixed broken completion menu layout caused by trailing newlines in ty documentation

<table>
  <tr>
    <td>Before</td>
    <td>After</td>
  </tr>
  <tr>
    <td>
      <img width="756" height="875" alt="before" src="https://github.com/user-attachments/assets/1d9da7d8-437a-4f03-8158-32ff1af9a428" />
    </td>
    <td>  
      <img width="755" height="875" alt="after" src="https://github.com/user-attachments/assets/dca31af3-e571-445a-b4a9-c300bb4c63fa" />
    </td>
  </tr>
</table>
