### PR TITLE
chore: Add worktree_benchmarks to cargo workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20265,6 +20265,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "worktree_benchmarks"
+version = "0.1.0"
+dependencies = [
+ "fs",
+ "gpui",
+ "settings",
+ "worktree",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,6 +198,7 @@ members = [
     "crates/web_search_providers",
     "crates/workspace",
     "crates/worktree",
+    "crates/worktree_benchmarks",
     "crates/x_ai",
     "crates/zed",
     "crates/zed_actions",

--- a/crates/worktree_benchmarks/src/main.rs
+++ b/crates/worktree_benchmarks/src/main.rs
@@ -27,6 +27,7 @@ fn main() {
                 true,
                 fs,
                 Arc::new(AtomicUsize::new(0)),
+                true,
                 cx,
             )
             .await

--- a/crates/worktree_benchmarks/src/main.rs
+++ b/crates/worktree_benchmarks/src/main.rs
@@ -5,8 +5,7 @@ use std::{
 
 use fs::RealFs;
 use gpui::Application;
-use settings::Settings;
-use worktree::{Worktree, WorktreeSettings};
+use worktree::Worktree;
 
 fn main() {
     let Some(worktree_root_path) = std::env::args().nth(1) else {


### PR DESCRIPTION
Idk why it was missing, but

Release Notes:

- N/A
