### PR TITLE
Fix title bar spacing when building on the macOS Tahoe SDK

### DIFF
--- a/crates/title_bar/build.rs
+++ b/crates/title_bar/build.rs
@@ -7,21 +7,22 @@ fn main() {
     {
         use std::process::Command;
 
-        let sdk_version = Command::new("xcrun")
+        let output = Command::new("xcrun")
             .args(["--sdk", "macosx", "--show-sdk-version"])
             .output()
-            .ok()
-            .and_then(|output| String::from_utf8(output.stdout).ok())
-            .map(|v| v.trim().to_string());
+            .unwrap();
 
-        if let Some(version) = sdk_version {
-            let major_version: Option<u32> = version.split('.').next().and_then(|v| v.parse().ok());
+        let sdk_version = String::from_utf8(output.stdout).unwrap();
+        let major_version: Option<u32> = sdk_version
+            .trim()
+            .split('.')
+            .next()
+            .and_then(|v| v.parse().ok());
 
-            if let Some(major) = major_version {
-                if major >= 26 {
-                    println!("cargo:rustc-cfg=macos_sdk_26");
-                }
-            }
+        if let Some(major) = major_version
+            && major >= 26
+        {
+            println!("cargo:rustc-cfg=macos_sdk_26");
         }
     }
 }

--- a/crates/title_bar/build.rs
+++ b/crates/title_bar/build.rs
@@ -1,0 +1,27 @@
+#![allow(clippy::disallowed_methods, reason = "build scripts are exempt")]
+
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(macos_sdk_26)");
+
+    #[cfg(target_os = "macos")]
+    {
+        use std::process::Command;
+
+        let sdk_version = Command::new("xcrun")
+            .args(["--sdk", "macosx", "--show-sdk-version"])
+            .output()
+            .ok()
+            .and_then(|output| String::from_utf8(output.stdout).ok())
+            .map(|v| v.trim().to_string());
+
+        if let Some(version) = sdk_version {
+            let major_version: Option<u32> = version.split('.').next().and_then(|v| v.parse().ok());
+
+            if let Some(major) = major_version {
+                if major >= 26 {
+                    println!("cargo:rustc-cfg=macos_sdk_26");
+                }
+            }
+        }
+    }
+}

--- a/crates/title_bar/src/platforms/platform_mac.rs
+++ b/crates/title_bar/src/platforms/platform_mac.rs
@@ -1,6 +1,10 @@
-/// Use pixels here instead of a rem-based size because the macOS traffic
-/// lights are a static size, and don't scale with the rest of the UI.
-///
-/// Magic number: There is one extra pixel of padding on the left side due to
-/// the 1px border around the window on macOS apps.
+// Use pixels here instead of a rem-based size because the macOS traffic
+// lights are a static size, and don't scale with the rest of the UI.
+//
+// Magic number: There is one extra pixel of padding on the left side due to
+// the 1px border around the window on macOS apps.
+#[cfg(macos_sdk_26)]
+pub const TRAFFIC_LIGHT_PADDING: f32 = 78.;
+
+#[cfg(not(macos_sdk_26))]
 pub const TRAFFIC_LIGHT_PADDING: f32 = 71.;

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -447,34 +447,38 @@ impl TitleBar {
             return None;
         }
 
-        Some(
-            Button::new("restricted_mode_trigger", "Restricted Mode")
-                .style(ButtonStyle::Tinted(TintColor::Warning))
-                .label_size(LabelSize::Small)
-                .color(Color::Warning)
-                .icon(IconName::Warning)
-                .icon_color(Color::Warning)
-                .icon_size(IconSize::Small)
-                .icon_position(IconPosition::Start)
-                .tooltip(|_, cx| {
-                    Tooltip::with_meta(
-                        "You're in Restricted Mode",
-                        Some(&ToggleWorktreeSecurity),
-                        "Mark this project as trusted and unlock all features",
-                        cx,
-                    )
+        let button = Button::new("restricted_mode_trigger", "Restricted Mode")
+            .style(ButtonStyle::Tinted(TintColor::Warning))
+            .label_size(LabelSize::Small)
+            .color(Color::Warning)
+            .icon(IconName::Warning)
+            .icon_color(Color::Warning)
+            .icon_size(IconSize::Small)
+            .icon_position(IconPosition::Start)
+            .tooltip(|_, cx| {
+                Tooltip::with_meta(
+                    "You're in Restricted Mode",
+                    Some(&ToggleWorktreeSecurity),
+                    "Mark this project as trusted and unlock all features",
+                    cx,
+                )
+            })
+            .on_click({
+                cx.listener(move |this, _, window, cx| {
+                    this.workspace
+                        .update(cx, |workspace, cx| {
+                            workspace.show_worktree_trust_security_modal(true, window, cx)
+                        })
+                        .log_err();
                 })
-                .on_click({
-                    cx.listener(move |this, _, window, cx| {
-                        this.workspace
-                            .update(cx, |workspace, cx| {
-                                workspace.show_worktree_trust_security_modal(true, window, cx)
-                            })
-                            .log_err();
-                    })
-                })
-                .into_any_element(),
-        )
+            });
+
+        if cfg!(macos_sdk_26) {
+            // Make up for Tahoe's traffic light buttons having less spacing around them
+            Some(div().child(button).ml_0p5().into_any_element())
+        } else {
+            Some(button.into_any_element())
+        }
     }
 
     pub fn render_project_host(&self, cx: &mut Context<Self>) -> Option<AnyElement> {


### PR DESCRIPTION
The size and spacing around the traffic light buttons changes after macOS SDK 26. Our official builds aren't using this SDK yet, but dev builds sometimes are and the official will in the future.

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img width="582" height="146" alt="CleanShot 2025-12-19 at 08 58 53@2x" src="https://github.com/user-attachments/assets/1a28d74a-98a3-49d0-98d6-ab05b0580665" />
</td>
<td>
<img width="610" height="156" alt="CleanShot 2025-12-19 at 08 57 02@2x" src="https://github.com/user-attachments/assets/7b7693b3-baa1-4d7e-9fc1-bd7a7bfacd36" />
</td>
</tr>
<tr>
<td>
<img width="532" height="154" alt="CleanShot 2025-12-19 at 08 59 40@2x" src="https://github.com/user-attachments/assets/df7f40e7-7576-44f2-9cf3-047a5d00bb4e" />
</td>
<td>
<img width="520" height="150" alt="CleanShot 2025-12-19 at 09 01 17@2x" src="https://github.com/user-attachments/assets/b0fbdeb6-1b1d-4e7a-95d0-3c78f0569df1" />
</td>
</tr>
</table>

Release Notes:

- N/A 
