### PR TITLE
Introduce Responses API for codex models & fix glob panic

### DIFF
--- a/crates/language_models/src/provider/vercel.rs
+++ b/crates/language_models/src/provider/vercel.rs
@@ -216,6 +216,7 @@ impl VercelLanguageModel {
                 &api_url,
                 &api_key,
                 request,
+                false, // Vercel AI SDK doesn't use codex models
             );
             let response = request.await?;
             Ok(response)

--- a/crates/language_models/src/provider/x_ai.rs
+++ b/crates/language_models/src/provider/x_ai.rs
@@ -225,6 +225,7 @@ impl XAiLanguageModel {
                 &api_url,
                 &api_key,
                 request,
+                false, // xAI doesn't use codex models
             );
             let response = request.await?;
             Ok(response)

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -263,6 +263,15 @@ impl Model {
     pub fn supports_prompt_cache_key(&self) -> bool {
         true
     }
+
+    /// Returns whether the model is a codex model that requires the Responses API.
+    ///
+    /// Codex models (those with "codex" in their name) use the Responses API
+    /// instead of the Chat Completions API.
+    pub fn is_codex_model(&self) -> bool {
+        let model_id = self.id();
+        model_id.contains("codex")
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -498,7 +507,172 @@ pub async fn stream_completion(
     api_url: &str,
     api_key: &str,
     request: Request,
+    is_codex: bool,
 ) -> Result<BoxStream<'static, Result<ResponseStreamEvent>>, RequestError> {
+    // Use Responses API for codex models, Chat Completions API for others
+    if is_codex {
+        let responses_request = responses::into_open_ai_responses(request);
+        let stream =
+            responses::stream_response(client, provider_name, api_url, api_key, responses_request)
+                .await
+                .map_err(|e| RequestError::Other(e))?;
+
+        // Convert Responses API events to Chat Completions format
+        return Ok(stream
+            .filter_map(|event| async move {
+                match event {
+                    Ok(responses::StreamEvent::OutputTextDelta { delta, .. }) => {
+                        if delta.is_empty() {
+                            None
+                        } else {
+                            Some(Ok(ResponseStreamEvent {
+                                choices: vec![ChoiceDelta {
+                                    index: 0,
+                                    delta: Some(ResponseMessageDelta {
+                                        role: None,
+                                        content: Some(delta),
+                                        tool_calls: None,
+                                    }),
+                                    finish_reason: None,
+                                }],
+                                usage: None,
+                            }))
+                        }
+                    }
+                    Ok(responses::StreamEvent::OutputItemDone { item, .. }) => {
+                        match item {
+                            responses::ResponseOutputItem::FunctionCall {
+                                call_id,
+                                name,
+                                arguments,
+                                ..
+                            } => {
+                                // Emit tool call as a chunk
+                                Some(Ok(ResponseStreamEvent {
+                                    choices: vec![ChoiceDelta {
+                                        index: 0,
+                                        delta: Some(ResponseMessageDelta {
+                                            role: None,
+                                            content: None,
+                                            tool_calls: Some(vec![ToolCallChunk {
+                                                index: 0,
+                                                id: Some(call_id),
+                                                function: Some(FunctionChunk {
+                                                    name: Some(name),
+                                                    arguments: Some(arguments),
+                                                }),
+                                            }]),
+                                        }),
+                                        finish_reason: Some("tool_calls".to_string()),
+                                    }],
+                                    usage: None,
+                                }))
+                            }
+                            responses::ResponseOutputItem::Reasoning { .. } => {
+                                // Reasoning items are handled by the event mapper
+                                None
+                            }
+                            responses::ResponseOutputItem::Message { .. } => {
+                                // Message completion is handled by Completed event
+                                None
+                            }
+                        }
+                    }
+                    Ok(responses::StreamEvent::Completed { response }) => {
+                        let usage = response.usage.map(|u| Usage {
+                            prompt_tokens: u.input_tokens.unwrap_or(0),
+                            completion_tokens: u.output_tokens.unwrap_or(0),
+                            total_tokens: u.total_tokens.unwrap_or(0),
+                        });
+
+                        // Check if we already sent a tool_calls finish_reason
+                        let has_tool_calls = response.output.iter().any(|item| {
+                            matches!(item, responses::ResponseOutputItem::FunctionCall { .. })
+                        });
+
+                        if has_tool_calls {
+                            // Only send usage update, finish_reason already sent
+                            if usage.is_some() {
+                                Some(Ok(ResponseStreamEvent {
+                                    choices: vec![ChoiceDelta {
+                                        index: 0,
+                                        delta: Some(ResponseMessageDelta {
+                                            role: None,
+                                            content: None,
+                                            tool_calls: None,
+                                        }),
+                                        finish_reason: None,
+                                    }],
+                                    usage,
+                                }))
+                            } else {
+                                None
+                            }
+                        } else {
+                            Some(Ok(ResponseStreamEvent {
+                                choices: vec![ChoiceDelta {
+                                    index: 0,
+                                    delta: Some(ResponseMessageDelta {
+                                        role: None,
+                                        content: None,
+                                        tool_calls: None,
+                                    }),
+                                    finish_reason: Some("stop".to_string()),
+                                }],
+                                usage,
+                            }))
+                        }
+                    }
+                    Ok(responses::StreamEvent::Incomplete { response }) => {
+                        let usage = response.usage.map(|u| Usage {
+                            prompt_tokens: u.input_tokens.unwrap_or(0),
+                            completion_tokens: u.output_tokens.unwrap_or(0),
+                            total_tokens: u.total_tokens.unwrap_or(0),
+                        });
+
+                        let finish_reason = response
+                            .incomplete_details
+                            .as_ref()
+                            .and_then(|details| details.reason.as_ref())
+                            .map(|reason| match reason {
+                                responses::IncompleteReason::MaxOutputTokens => "length",
+                                responses::IncompleteReason::ContentFilter => "content_filter",
+                            })
+                            .unwrap_or("stop");
+
+                        Some(Ok(ResponseStreamEvent {
+                            choices: vec![ChoiceDelta {
+                                index: 0,
+                                delta: Some(ResponseMessageDelta {
+                                    role: None,
+                                    content: None,
+                                    tool_calls: None,
+                                }),
+                                finish_reason: Some(finish_reason.to_string()),
+                            }],
+                            usage,
+                        }))
+                    }
+                    Ok(responses::StreamEvent::Failed { response }) => {
+                        if let Some(error) = response.error {
+                            Some(Err(anyhow!("Response failed: {}", error.message)))
+                        } else {
+                            Some(Err(anyhow!("Response failed with unknown error")))
+                        }
+                    }
+                    Ok(responses::StreamEvent::GenericError { error }) => {
+                        Some(Err(anyhow!("Response error: {}", error.message)))
+                    }
+                    // Pass through other events that don't need conversion
+                    Ok(responses::StreamEvent::Created { .. })
+                    | Ok(responses::StreamEvent::OutputItemAdded { .. })
+                    | Ok(responses::StreamEvent::Unknown) => None,
+                    Err(e) => Some(Err(e)),
+                }
+            })
+            .boxed());
+    }
+
     let uri = format!("{api_url}/chat/completions");
     let request_builder = HttpRequest::builder()
         .method(Method::POST)
@@ -622,5 +796,621 @@ pub fn embed<'a>(
         let response: OpenAiEmbeddingResponse =
             serde_json::from_str(&body).context("failed to parse OpenAI embedding response")?;
         Ok(response)
+    }
+}
+
+// OpenAI Responses API support for codex models
+pub mod responses {
+    use super::*;
+
+    #[derive(Serialize, Debug)]
+    pub struct Request {
+        pub model: String,
+        pub input: Vec<ResponseInputItem>,
+        #[serde(default)]
+        pub stream: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub temperature: Option<f32>,
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        pub tools: Vec<ToolDefinition>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub tool_choice: Option<ToolChoice>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub reasoning: Option<ReasoningConfig>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub include: Option<Vec<ResponseIncludable>>,
+    }
+
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    #[serde(rename_all = "snake_case")]
+    pub enum ResponseIncludable {
+        #[serde(rename = "reasoning.encrypted_content")]
+        ReasoningEncryptedContent,
+    }
+
+    #[derive(Serialize, Deserialize, Debug)]
+    #[serde(tag = "type", rename_all = "snake_case")]
+    pub enum ToolDefinition {
+        Function {
+            name: String,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            description: Option<String>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            parameters: Option<Value>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            strict: Option<bool>,
+        },
+    }
+
+    #[derive(Serialize, Deserialize, Debug)]
+    #[serde(rename_all = "lowercase")]
+    pub enum ToolChoice {
+        Auto,
+        Any,
+        None,
+        #[serde(untagged)]
+        Other(ToolDefinition),
+    }
+
+    #[derive(Serialize, Deserialize, Debug)]
+    #[serde(rename_all = "lowercase")]
+    pub enum ReasoningSummary {
+        Auto,
+        Concise,
+        Detailed,
+    }
+
+    #[derive(Serialize, Debug)]
+    pub struct ReasoningConfig {
+        pub effort: ReasoningEffort,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub summary: Option<ReasoningSummary>,
+    }
+
+    #[derive(Serialize, Deserialize, Debug, Clone, Default)]
+    #[serde(rename_all = "snake_case")]
+    pub enum ResponseImageDetail {
+        Low,
+        High,
+        #[default]
+        Auto,
+    }
+
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    #[serde(tag = "type", rename_all = "snake_case")]
+    pub enum ResponseInputContent {
+        InputText {
+            text: String,
+        },
+        OutputText {
+            text: String,
+        },
+        InputImage {
+            #[serde(skip_serializing_if = "Option::is_none")]
+            image_url: Option<String>,
+            #[serde(default)]
+            detail: ResponseImageDetail,
+        },
+    }
+
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    #[serde(rename_all = "snake_case")]
+    pub enum ItemStatus {
+        InProgress,
+        Completed,
+        Incomplete,
+    }
+
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    #[serde(untagged)]
+    pub enum ResponseFunctionOutput {
+        Text(String),
+        Content(Vec<ResponseInputContent>),
+    }
+
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    #[serde(tag = "type", rename_all = "snake_case")]
+    pub enum ResponseInputItem {
+        Message {
+            role: String,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            content: Option<Vec<ResponseInputContent>>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            status: Option<String>,
+        },
+        FunctionCall {
+            call_id: String,
+            name: String,
+            arguments: String,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            status: Option<ItemStatus>,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            thought_signature: Option<String>,
+        },
+        FunctionCallOutput {
+            call_id: String,
+            output: ResponseFunctionOutput,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            status: Option<ItemStatus>,
+        },
+        Reasoning {
+            #[serde(skip_serializing_if = "Option::is_none")]
+            id: Option<String>,
+            summary: Vec<ResponseReasoningItem>,
+            encrypted_content: String,
+        },
+    }
+
+    #[derive(Deserialize, Debug, Clone)]
+    #[serde(rename_all = "snake_case")]
+    pub enum IncompleteReason {
+        #[serde(rename = "max_output_tokens")]
+        MaxOutputTokens,
+        #[serde(rename = "content_filter")]
+        ContentFilter,
+    }
+
+    #[derive(Deserialize, Debug, Clone)]
+    pub struct IncompleteDetails {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub reason: Option<IncompleteReason>,
+    }
+
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct ResponseReasoningItem {
+        #[serde(rename = "type")]
+        pub kind: String,
+        pub text: String,
+    }
+
+    #[derive(Deserialize, Debug)]
+    #[serde(tag = "type")]
+    pub enum StreamEvent {
+        #[serde(rename = "error")]
+        GenericError { error: ResponseError },
+
+        #[serde(rename = "response.created")]
+        Created { response: Response },
+
+        #[serde(rename = "response.output_item.added")]
+        OutputItemAdded {
+            output_index: usize,
+            #[serde(default)]
+            sequence_number: Option<u64>,
+            item: ResponseOutputItem,
+        },
+
+        #[serde(rename = "response.output_text.delta")]
+        OutputTextDelta {
+            item_id: String,
+            output_index: usize,
+            delta: String,
+        },
+
+        #[serde(rename = "response.output_item.done")]
+        OutputItemDone {
+            output_index: usize,
+            #[serde(default)]
+            sequence_number: Option<u64>,
+            item: ResponseOutputItem,
+        },
+
+        #[serde(rename = "response.incomplete")]
+        Incomplete { response: Response },
+
+        #[serde(rename = "response.completed")]
+        Completed { response: Response },
+
+        #[serde(rename = "response.failed")]
+        Failed { response: Response },
+
+        #[serde(other)]
+        Unknown,
+    }
+
+    #[derive(Deserialize, Debug, Clone)]
+    pub struct ResponseError {
+        pub code: String,
+        pub message: String,
+    }
+
+    #[derive(Deserialize, Debug, Default, Clone)]
+    pub struct Response {
+        pub id: Option<String>,
+        pub status: Option<String>,
+        pub usage: Option<ResponseUsage>,
+        pub output: Vec<ResponseOutputItem>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub incomplete_details: Option<IncompleteDetails>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub error: Option<ResponseError>,
+    }
+
+    #[derive(Deserialize, Debug, Default, Clone)]
+    pub struct ResponseUsage {
+        pub input_tokens: Option<u64>,
+        pub output_tokens: Option<u64>,
+        pub total_tokens: Option<u64>,
+    }
+
+    #[derive(Deserialize, Debug, Clone)]
+    #[serde(tag = "type", rename_all = "snake_case")]
+    pub enum ResponseOutputItem {
+        Message {
+            id: String,
+            role: String,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            content: Option<Vec<ResponseOutputContent>>,
+        },
+        FunctionCall {
+            #[serde(skip_serializing_if = "Option::is_none")]
+            id: Option<String>,
+            call_id: String,
+            name: String,
+            arguments: String,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            status: Option<ItemStatus>,
+            #[serde(default, skip_serializing_if = "Option::is_none")]
+            thought_signature: Option<String>,
+        },
+        Reasoning {
+            id: String,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            summary: Option<Vec<ResponseReasoningItem>>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            encrypted_content: Option<String>,
+        },
+    }
+
+    #[derive(Deserialize, Debug, Clone)]
+    #[serde(tag = "type", rename_all = "snake_case")]
+    pub enum ResponseOutputContent {
+        OutputText { text: String },
+        Refusal { refusal: String },
+    }
+
+    pub async fn stream_response(
+        client: &dyn HttpClient,
+        provider: &str,
+        api_url: &str,
+        api_key: &str,
+        request: Request,
+    ) -> Result<BoxStream<'static, Result<StreamEvent>>> {
+        let uri = format!("{api_url}/responses");
+
+        let is_streaming = request.stream;
+        let json = serde_json::to_string(&request)?;
+        let request_builder = HttpRequest::builder()
+            .method(Method::POST)
+            .uri(uri)
+            .header("Content-Type", "application/json")
+            .header("Authorization", format!("Bearer {}", api_key.trim()))
+            .body(AsyncBody::from(json))?;
+
+        let mut response = client.send(request_builder).await?;
+
+        if !response.status().is_success() {
+            let mut body = String::new();
+            response.body_mut().read_to_string(&mut body).await?;
+
+            let headers = response.headers().clone();
+
+            return Err(RequestError::HttpResponseError {
+                provider: provider.to_string(),
+                status_code: response.status(),
+                body,
+                headers,
+            }
+            .into());
+        }
+
+        if is_streaming {
+            let reader = BufReader::new(response.into_body());
+            Ok(reader
+                .lines()
+                .filter_map(|line| async move {
+                    match line {
+                        Ok(line) => {
+                            let line = line.strip_prefix("data: ")?;
+                            if line.starts_with("[DONE]") || line.is_empty() {
+                                return None;
+                            }
+
+                            match serde_json::from_str::<StreamEvent>(line) {
+                                Ok(event) => Some(Ok(event)),
+                                Err(error) => {
+                                    log::error!(
+                                        "Failed to parse OpenAI responses stream event: `{}`\nResponse: `{}`",
+                                        error,
+                                        line,
+                                    );
+                                    Some(Err(anyhow!(error)))
+                                }
+                            }
+                        }
+                        Err(error) => Some(Err(anyhow!(error))),
+                    }
+                })
+                .boxed())
+        } else {
+            let mut body = String::new();
+            response.body_mut().read_to_string(&mut body).await?;
+
+            match serde_json::from_str::<Response>(&body) {
+                Ok(response) => {
+                    let events = vec![StreamEvent::Created {
+                        response: response.clone(),
+                    }];
+
+                    let mut all_events = events;
+                    for (output_index, item) in response.output.iter().enumerate() {
+                        all_events.push(StreamEvent::OutputItemAdded {
+                            output_index,
+                            sequence_number: None,
+                            item: item.clone(),
+                        });
+
+                        if let ResponseOutputItem::Message {
+                            id,
+                            content: Some(content),
+                            ..
+                        } = item
+                        {
+                            for part in content {
+                                if let ResponseOutputContent::OutputText { text } = part {
+                                    all_events.push(StreamEvent::OutputTextDelta {
+                                        item_id: id.clone(),
+                                        output_index,
+                                        delta: text.clone(),
+                                    });
+                                }
+                            }
+                        }
+
+                        all_events.push(StreamEvent::OutputItemDone {
+                            output_index,
+                            sequence_number: None,
+                            item: item.clone(),
+                        });
+                    }
+
+                    let final_event = if response.error.is_some() {
+                        StreamEvent::Failed { response }
+                    } else if response.incomplete_details.is_some() {
+                        StreamEvent::Incomplete { response }
+                    } else {
+                        StreamEvent::Completed { response }
+                    };
+                    all_events.push(final_event);
+
+                    Ok(futures::stream::iter(all_events.into_iter().map(Ok)).boxed())
+                }
+                Err(error) => {
+                    log::error!(
+                        "Failed to parse OpenAI non-streaming response: `{}`\nResponse: `{}`",
+                        error,
+                        body,
+                    );
+                    Err(anyhow!(error))
+                }
+            }
+        }
+    }
+
+    /// Convert a standard OpenAI request to a Responses API request.
+    pub fn into_open_ai_responses(request: super::Request) -> Request {
+        let super::Request {
+            model,
+            messages,
+            stream,
+            max_completion_tokens: _,
+            stop: _,
+            temperature,
+            tool_choice,
+            parallel_tool_calls: _,
+            tools,
+            prompt_cache_key: _,
+            reasoning_effort,
+        } = request;
+
+        let mut input_items: Vec<ResponseInputItem> = Vec::new();
+
+        for message in messages {
+            match message {
+                super::RequestMessage::User { content } => {
+                    let parts = match content {
+                        super::MessageContent::Plain(text) => {
+                            vec![ResponseInputContent::InputText { text }]
+                        }
+                        super::MessageContent::Multipart(parts) => parts
+                            .into_iter()
+                            .filter_map(|part| match part {
+                                super::MessagePart::Text { text } => {
+                                    Some(ResponseInputContent::InputText { text })
+                                }
+                                super::MessagePart::Image { image_url } => {
+                                    Some(ResponseInputContent::InputImage {
+                                        image_url: Some(image_url.url),
+                                        detail: match image_url.detail.as_deref() {
+                                            Some("low") => ResponseImageDetail::Low,
+                                            Some("high") => ResponseImageDetail::High,
+                                            _ => ResponseImageDetail::Auto,
+                                        },
+                                    })
+                                }
+                            })
+                            .collect(),
+                    };
+
+                    if !parts.is_empty() {
+                        input_items.push(ResponseInputItem::Message {
+                            role: "user".to_string(),
+                            content: Some(parts),
+                            status: None,
+                        });
+                    }
+                }
+
+                super::RequestMessage::Assistant {
+                    content,
+                    tool_calls,
+                } => {
+                    // Add tool calls first
+                    for call in tool_calls {
+                        let super::ToolCallContent::Function { function } = call.content;
+                        input_items.push(ResponseInputItem::FunctionCall {
+                            call_id: call.id,
+                            name: function.name,
+                            arguments: function.arguments,
+                            status: None,
+                            thought_signature: None,
+                        });
+                    }
+
+                    // Add message content
+                    let parts = match content {
+                        Some(super::MessageContent::Plain(text)) => {
+                            if !text.is_empty() {
+                                vec![ResponseInputContent::OutputText { text }]
+                            } else {
+                                vec![]
+                            }
+                        }
+                        Some(super::MessageContent::Multipart(parts)) => parts
+                            .into_iter()
+                            .filter_map(|part| match part {
+                                super::MessagePart::Text { text } => {
+                                    Some(ResponseInputContent::OutputText { text })
+                                }
+                                super::MessagePart::Image { .. } => {
+                                    Some(ResponseInputContent::OutputText {
+                                        text: "[image omitted]".to_string(),
+                                    })
+                                }
+                            })
+                            .collect(),
+                        None => vec![],
+                    };
+
+                    if !parts.is_empty() {
+                        input_items.push(ResponseInputItem::Message {
+                            role: "assistant".to_string(),
+                            content: Some(parts),
+                            status: Some("completed".to_string()),
+                        });
+                    }
+                }
+
+                super::RequestMessage::System { content } => {
+                    let parts = match content {
+                        super::MessageContent::Plain(text) => {
+                            vec![ResponseInputContent::InputText { text }]
+                        }
+                        super::MessageContent::Multipart(parts) => parts
+                            .into_iter()
+                            .filter_map(|part| match part {
+                                super::MessagePart::Text { text } => {
+                                    Some(ResponseInputContent::InputText { text })
+                                }
+                                super::MessagePart::Image { .. } => None,
+                            })
+                            .collect(),
+                    };
+
+                    if !parts.is_empty() {
+                        input_items.push(ResponseInputItem::Message {
+                            role: "system".to_string(),
+                            content: Some(parts),
+                            status: None,
+                        });
+                    }
+                }
+
+                super::RequestMessage::Tool {
+                    content,
+                    tool_call_id,
+                } => {
+                    let output = match content {
+                        super::MessageContent::Plain(text) => ResponseFunctionOutput::Text(text),
+                        super::MessageContent::Multipart(parts) => {
+                            let content_parts: Vec<ResponseInputContent> = parts
+                                .into_iter()
+                                .filter_map(|part| match part {
+                                    super::MessagePart::Text { text } => {
+                                        Some(ResponseInputContent::InputText { text })
+                                    }
+                                    super::MessagePart::Image { image_url } => {
+                                        Some(ResponseInputContent::InputImage {
+                                            image_url: Some(image_url.url),
+                                            detail: match image_url.detail.as_deref() {
+                                                Some("low") => ResponseImageDetail::Low,
+                                                Some("high") => ResponseImageDetail::High,
+                                                _ => ResponseImageDetail::Auto,
+                                            },
+                                        })
+                                    }
+                                })
+                                .collect();
+
+                            if content_parts.is_empty() {
+                                ResponseFunctionOutput::Text(String::new())
+                            } else {
+                                ResponseFunctionOutput::Content(content_parts)
+                            }
+                        }
+                    };
+
+                    input_items.push(ResponseInputItem::FunctionCallOutput {
+                        call_id: tool_call_id,
+                        output,
+                        status: None,
+                    });
+                }
+            }
+        }
+
+        let converted_tools: Vec<ToolDefinition> = tools
+            .into_iter()
+            .map(|tool| {
+                let super::ToolDefinition::Function { function } = tool;
+                ToolDefinition::Function {
+                    name: function.name,
+                    description: function.description,
+                    parameters: function.parameters,
+                    strict: None,
+                }
+            })
+            .collect();
+
+        let mapped_tool_choice = tool_choice.map(|choice| match choice {
+            super::ToolChoice::Auto => ToolChoice::Auto,
+            super::ToolChoice::Required => ToolChoice::Any,
+            super::ToolChoice::None => ToolChoice::None,
+            super::ToolChoice::Other(value) => {
+                let super::ToolDefinition::Function { function } = value;
+                ToolChoice::Other(ToolDefinition::Function {
+                    name: function.name,
+                    description: function.description,
+                    parameters: function.parameters,
+                    strict: None,
+                })
+            }
+        });
+
+        let reasoning_config = reasoning_effort.map(|effort| ReasoningConfig {
+            effort,
+            summary: None,
+        });
+
+        Request {
+            model,
+            input: input_items,
+            stream,
+            temperature,
+            tools: converted_tools,
+            tool_choice: mapped_tool_choice,
+            reasoning: reasoning_config,
+            include: Some(vec![ResponseIncludable::ReasoningEncryptedContent]),
+        }
     }
 }

--- a/crates/project/src/project_search.rs
+++ b/crates/project/src/project_search.rs
@@ -790,12 +790,13 @@ impl PathInclusionMatcher {
         // For example, `src/**/*.rs` becomes `src/` and `**/*.rs`. The glob part gets dropped.
         // Then, when checking whether a given directory should be scanned, we check whether it is a non-empty substring of any glob prefix.
         if query.filters_path() {
-            included.extend(
-                query
-                    .files_to_include()
-                    .sources()
-                    .flat_map(|glob| Some(wax::Glob::new(glob).ok()?.partition().0)),
-            );
+            included.extend(query.files_to_include().sources().flat_map(|glob| {
+                // Skip empty globs to avoid wax partition panic
+                if glob.trim().is_empty() {
+                    return None;
+                }
+                Some(wax::Glob::new(glob).ok()?.partition().0)
+            }));
         }
         Self { included, query }
     }


### PR DESCRIPTION
This pull request introduces support for the OpenAI Responses API when using codex models (including compatible providers such as Azure OpenAI), and also includes a fix to avoid a panic on empty glob patterns during project file searches.

### Changes in this PR

1. **Responses API Integration**  
   - Stream and map `responses/v1` events for codex models  
   - Properly handle function calls, errors, and completion events  
   - Supports both built-in OpenAI and openai-compatible providers

2. **Glob Panic Fix**  
   - Added defensive check to skip empty or whitespace-only glob patterns  
   - Prevents `wax::Glob::partition()` from panicking when given an empty pattern

### Verification Steps

- Rebuilt the editor with these changes and confirmed that codex-based tool calls now correctly invoke functions instead of timing out.  
- Tested file search tools (fuzzy finder, include patterns) with blank or empty filters to ensure no panics occur.

Please review the two commits for more details on implementation.