### PR TITLE
editor: Fix code actions menu hidden in Helix mode

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2362,6 +2362,8 @@ impl Editor {
                             if active {
                                 editor.show_mouse_cursor(cx);
                             }
+
+                            cx.notify();
                         }),
                     ]
                 })


### PR DESCRIPTION
Closes #ISSUE

Release Notes:

- Fixed: Code Actions Menu Invisible After `Alt+Tab`

## Problem

After switching away from Zed with Alt+Tab on Windows and returning, pressing `space+a` in Helix mode to open the code actions menu would create the menu but render it behind other UI elements, making it invisible to the user.

## Root Cause

When a window is reactivated after Alt+Tab, the `observe_window_activation` callback updates internal state (blink manager, mouse cursor) but doesn't call `cx.notify()` to inform GPUI that a re-render is needed. This leaves the rendering context in a stale state, causing subsequently opened UI elements like the code actions menu to have incorrect z-index ordering.

But I fount that use  `ctrl+.` (VSCode default keybinding) works correctly because:
1. Pressing `Ctrl` triggers `ModifiersChangedEvent`
2. This calls `handle_modifiers_changed()`
3. Which calls `update_edit_prediction_preview()`
4. Which eventually calls `cx.notify()`, refreshing the rendering state

However, `space+a` doesn't involve modifier keys, so no modifier event is triggered, and the stale rendering state persists.

And after I found it, I found if I pressed `alt` or `ctrl` before `space-a`, the Code-Actions can show correctly.

## Solution

Call `cx.notify()` in the `observe_window_activation` callback whenever the window activation state changes (both activating and deactivating). This ensures the editor's visual state is properly synchronized with GPUI's rendering system after window focus changes.

But I can't build zed to test it by myself, I just  guess the reason is this.  qwq
Or maybe my solution have some performance impact?