### PR TITLE
Fix sticky header scroll offset

### DIFF
--- a/crates/editor/src/scroll/autoscroll.rs
+++ b/crates/editor/src/scroll/autoscroll.rs
@@ -189,19 +189,16 @@ impl Editor {
 
         let style = self.style(cx).clone();
         let sticky_headers = self.sticky_headers(&style, cx).unwrap_or_default();
-        let visible_sticky_headers = dbg!(
-            sticky_headers
-                .iter()
-                .filter(|h| {
-                    let buffer_snapshot = display_map.buffer_snapshot();
-                    let buffer_range = h.range.start.to_point(buffer_snapshot)
-                        ..h.range.end.to_point(buffer_snapshot);
+        let visible_sticky_headers = sticky_headers
+            .iter()
+            .filter(|h| {
+                let buffer_snapshot = display_map.buffer_snapshot();
+                let buffer_range =
+                    h.range.start.to_point(buffer_snapshot)..h.range.end.to_point(buffer_snapshot);
 
-                    buffer_range.contains(&Point::new(target_top as u32, 0))
-                })
-                .count()
-        );
-        let header_count = sticky_headers.len();
+                buffer_range.contains(&Point::new(target_top as u32, 0))
+            })
+            .count();
 
         let margin = if matches!(self.mode, EditorMode::AutoHeight { .. }) {
             0.
@@ -235,8 +232,7 @@ impl Editor {
         let was_autoscrolled = match strategy {
             AutoscrollStrategy::Fit | AutoscrollStrategy::Newest => {
                 let margin = margin.min(self.scroll_manager.vertical_scroll_margin);
-                let target_top =
-                    dbg!((target_top - margin - dbg!(visible_sticky_headers) as f64).max(0.0));
+                let target_top = (target_top - margin - visible_sticky_headers as f64).max(0.0);
                 let target_bottom = target_bottom + margin;
                 let start_row = scroll_position.y;
                 let end_row = start_row + visible_lines;

--- a/crates/editor/src/scroll/autoscroll.rs
+++ b/crates/editor/src/scroll/autoscroll.rs
@@ -6,8 +6,7 @@ use crate::{
 use gpui::{Bounds, Context, Pixels, Window};
 use language::Point;
 use multi_buffer::{Anchor, ToPoint};
-use std::{cmp, ops::RangeBounds};
-use text::Bias;
+use std::cmp;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Autoscroll {


### PR DESCRIPTION
Closes #43319

Release Notes:

- Sticky headers no longer obscure the cursor when it moves.