### PR TITLE
ci: Fix Factory CLI installation URL

### DIFF
--- a/.github/workflows/docs_automation.yml
+++ b/.github/workflows/docs_automation.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install Droid CLI
         id: install-droid
         run: |
-          curl -fsSL https://cli.factory.ai/install.sh | bash
+          curl -fsSL https://app.factory.ai/cli | sh
           echo "${HOME}/.factory/bin" >> "$GITHUB_PATH"
           echo "DROID_BIN=${HOME}/.factory/bin/droid" >> "$GITHUB_ENV"
           # Verify installation


### PR DESCRIPTION
Change from cli.factory.ai/install.sh to app.factory.ai/cli per official Factory documentation.

Release Notes:

- N/A
