### PR TITLE
Beam Jump - Lightning Fast Vim style navigation

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -2280,6 +2280,7 @@
     "use_system_clipboard": "always",
     "use_smartcase_find": false,
     "gdefault": false,
+    "beam_jump": false,
     "highlight_on_yank_duration": 200,
     "custom_digraphs": {},
     // Cursor shape for each mode.

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -23135,7 +23135,14 @@ impl Editor {
         mut highlights: Vec<BeamJumpHighlight>,
         cx: &mut Context<Self>,
     ) {
-        highlights.sort_by_key(|highlight| highlight.range.start);
+        let highlights_are_sorted = highlights.windows(2).all(|adjacent_highlights| {
+            adjacent_highlights[0].range.start <= adjacent_highlights[1].range.start
+        });
+
+        if !highlights_are_sorted {
+            highlights.sort_by_key(|highlight| highlight.range.start);
+        }
+
         self.beam_jump_highlights = highlights;
         cx.notify();
     }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -744,6 +744,12 @@ type BackgroundHighlight = (
 );
 type GutterHighlight = (fn(&App) -> Hsla, Vec<Range<Anchor>>);
 
+#[derive(Clone, Debug)]
+pub struct BeamJumpHighlight {
+    pub range: Range<MultiBufferOffset>,
+    pub label: Option<SharedString>,
+}
+
 #[derive(Default)]
 struct ScrollbarMarkerState {
     scrollbar_size: Size<Pixels>,
@@ -1186,6 +1192,7 @@ pub struct Editor {
     highlighted_rows: HashMap<TypeId, Vec<RowHighlight>>,
     background_highlights: HashMap<HighlightKey, BackgroundHighlight>,
     gutter_highlights: HashMap<TypeId, GutterHighlight>,
+    beam_jump_highlights: Vec<BeamJumpHighlight>,
     scrollbar_marker_state: ScrollbarMarkerState,
     active_indent_guides_state: ActiveIndentGuidesState,
     nav_history: Option<ItemNavHistory>,
@@ -2378,6 +2385,7 @@ impl Editor {
             highlighted_rows: HashMap::default(),
             background_highlights: HashMap::default(),
             gutter_highlights: HashMap::default(),
+            beam_jump_highlights: Vec::new(),
             scrollbar_marker_state: ScrollbarMarkerState::default(),
             active_indent_guides_state: ActiveIndentGuidesState::default(),
             nav_history: None,
@@ -23120,6 +23128,40 @@ impl Editor {
 
     pub fn clear_search_within_ranges(&mut self, cx: &mut Context<Self>) {
         self.clear_background_highlights::<SearchWithinRange>(cx);
+    }
+
+    pub fn set_beam_jump_highlights(
+        &mut self,
+        mut highlights: Vec<BeamJumpHighlight>,
+        cx: &mut Context<Self>,
+    ) {
+        highlights.sort_by_key(|highlight| highlight.range.start);
+        self.beam_jump_highlights = highlights;
+        cx.notify();
+    }
+
+    pub fn clear_beam_jump_highlights(&mut self, cx: &mut Context<Self>) {
+        if !self.beam_jump_highlights.is_empty() {
+            self.beam_jump_highlights.clear();
+            cx.notify();
+        }
+    }
+
+    pub fn beam_jump_highlights_in_range(
+        &self,
+        range: Range<MultiBufferOffset>,
+    ) -> &[BeamJumpHighlight] {
+        if self.beam_jump_highlights.is_empty() {
+            return &[];
+        }
+
+        let start_ix = self
+            .beam_jump_highlights
+            .partition_point(|highlight| highlight.range.end <= range.start);
+        let end_ix = self
+            .beam_jump_highlights
+            .partition_point(|highlight| highlight.range.start < range.end);
+        &self.beam_jump_highlights[start_ix..end_ix]
     }
 
     pub fn highlight_background<T: 'static>(

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1983,11 +1983,14 @@ impl EditorElement {
         let visible_end_offset = DisplayPoint::new(visible_row_range.end, 0)
             .to_offset(&snapshot.display_snapshot, Bias::Right);
 
-        let highlights = self
-            .editor
-            .read(cx)
-            .beam_jump_highlights_in_range(visible_start_offset..visible_end_offset)
-            .to_vec();
+        let highlights = self.editor.read(cx).beam_jump_highlights.clone();
+        let highlights = highlights.as_slice();
+
+        let start_ix =
+            highlights.partition_point(|highlight| highlight.range.end <= visible_start_offset);
+        let end_ix =
+            highlights.partition_point(|highlight| highlight.range.start < visible_end_offset);
+        let highlights = &highlights[start_ix..end_ix];
         if highlights.is_empty() {
             return Vec::new();
         }

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1965,6 +1965,133 @@ impl EditorElement {
         cursor_layouts
     }
 
+    fn layout_beam_jump_cursors(
+        &self,
+        snapshot: &EditorSnapshot,
+        visible_row_range: Range<DisplayRow>,
+        line_layouts: &[LineWithInvisibles],
+        content_origin: gpui::Point<Pixels>,
+        scroll_position: gpui::Point<ScrollOffset>,
+        scroll_pixel_position: gpui::Point<ScrollPixelOffset>,
+        line_height: Pixels,
+        em_advance: Pixels,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> Vec<CursorLayout> {
+        let visible_start_offset = DisplayPoint::new(visible_row_range.start, 0)
+            .to_offset(&snapshot.display_snapshot, Bias::Left);
+        let visible_end_offset = DisplayPoint::new(visible_row_range.end, 0)
+            .to_offset(&snapshot.display_snapshot, Bias::Right);
+
+        let highlights = self
+            .editor
+            .read(cx)
+            .beam_jump_highlights_in_range(visible_start_offset..visible_end_offset)
+            .to_vec();
+        if highlights.is_empty() {
+            return Vec::new();
+        }
+
+        let color = cx.theme().players().local().cursor;
+        let label_text_color = self.style.background;
+        let mut cursors = Vec::new();
+
+        for highlight in highlights {
+            let start = highlight
+                .range
+                .start
+                .to_display_point(&snapshot.display_snapshot);
+            let end = highlight
+                .range
+                .end
+                .to_display_point(&snapshot.display_snapshot);
+
+            // For soft-wrapped ranges, render one outline per display row segment.
+            let mut row = start.row();
+            let last_row = end.row();
+            while row <= last_row {
+                let start_col = if row == start.row() {
+                    start.column()
+                } else {
+                    0
+                };
+                let end_col = if row == last_row {
+                    end.column()
+                } else {
+                    snapshot.display_snapshot.line_len(row)
+                };
+
+                if end_col <= start_col {
+                    if row == last_row {
+                        break;
+                    }
+                    row = row.next_row();
+                    continue;
+                }
+
+                if !visible_row_range.contains(&row) {
+                    if row == last_row {
+                        break;
+                    }
+                    row = row.next_row();
+                    continue;
+                }
+
+                let Some(cursor_row_layout) =
+                    line_layouts.get(row.minus(visible_row_range.start) as usize)
+                else {
+                    if row == last_row {
+                        break;
+                    }
+                    row = row.next_row();
+                    continue;
+                };
+                let start_x = cursor_row_layout.x_for_index(start_col as usize);
+                let end_x = cursor_row_layout.x_for_index(end_col as usize);
+                let mut block_width = end_x - start_x;
+                if block_width == Pixels::ZERO {
+                    block_width = em_advance;
+                }
+
+                let x = start_x - scroll_pixel_position.x.into();
+                let y = ((row.as_f64() - scroll_position.y) * ScrollPixelOffset::from(line_height))
+                    .into();
+                let mut cursor = CursorLayout::new(
+                    point(x, y),
+                    block_width,
+                    line_height,
+                    color,
+                    CursorShape::Hollow,
+                    None,
+                );
+
+                if let Some(label) = highlight.label.clone()
+                    && row == last_row
+                {
+                    cursor.layout(
+                        content_origin,
+                        Some(CursorName {
+                            string: label,
+                            color: label_text_color,
+                            is_top_row: row.0 == 0,
+                        }),
+                        window,
+                        cx,
+                    );
+                }
+
+                cursors.push(cursor);
+
+                if row == last_row {
+                    break;
+                }
+                row = row.next_row();
+            }
+        }
+
+        cursors
+    }
+
     fn layout_scrollbars(
         &self,
         snapshot: &EditorSnapshot,
@@ -10476,7 +10603,19 @@ impl Element for EditorElement {
                         .iter()
                         .any(|c| !visible_row_range.contains(&c.0.row()));
 
-                    let visible_cursors = self.layout_visible_cursors(
+                    let mut visible_cursors = self.layout_beam_jump_cursors(
+                        &snapshot,
+                        start_row..end_row,
+                        &line_layouts,
+                        content_origin,
+                        scroll_position,
+                        scroll_pixel_position,
+                        line_height,
+                        em_advance,
+                        window,
+                        cx,
+                    );
+                    visible_cursors.extend(self.layout_visible_cursors(
                         &snapshot,
                         &selections,
                         &row_block_types,
@@ -10493,7 +10632,7 @@ impl Element for EditorElement {
                         &redacted_ranges,
                         window,
                         cx,
-                    );
+                    ));
 
                     let scrollbars_layout = self.layout_scrollbars(
                         &snapshot,

--- a/crates/settings_content/src/settings_content.rs
+++ b/crates/settings_content/src/settings_content.rs
@@ -704,6 +704,7 @@ pub struct VimSettingsContent {
     /// When enabled, the `:substitute` command replaces all matches in a line
     /// by default. The 'g' flag then toggles this behavior.,
     pub gdefault: Option<bool>,
+    pub beam_jump: Option<bool>,
     pub custom_digraphs: Option<HashMap<String, Arc<str>>>,
     pub highlight_on_yank_duration: Option<u64>,
     pub cursor_shape: Option<CursorShapeSettings>,

--- a/crates/vim/src/beam_jump.rs
+++ b/crates/vim/src/beam_jump.rs
@@ -198,6 +198,7 @@ impl BeamJumpState {
         }
 
         self.extend_matches(ch, buffer);
+        self.retain_non_overlapping_matches_in_start_order();
 
         if self.labels.is_some() {
             self.retain_labels_for_matches();
@@ -357,6 +358,17 @@ impl BeamJumpState {
 
             m.end = new_end;
             true
+        });
+    }
+
+    fn retain_non_overlapping_matches_in_start_order(&mut self) {
+        let mut last_kept_end: Option<MultiBufferOffset> = None;
+        self.matches.retain(|m| {
+            let keep = last_kept_end.map_or(true, |end| m.start >= end);
+            if keep {
+                last_kept_end = Some(m.end);
+            }
+            keep
         });
     }
 

--- a/crates/vim/src/beam_jump.rs
+++ b/crates/vim/src/beam_jump.rs
@@ -142,6 +142,12 @@ impl BeamJumpState {
 
         self.push_pattern_char(ch, buffer);
 
+        debug_assert!(
+            self.matches
+                .iter()
+                .all(|m| m.start > self.cursor_offset || m.end <= self.cursor_offset)
+        );
+
         if self.pattern_len < 2 {
             return BeamJumpAction::Continue;
         }
@@ -308,7 +314,10 @@ impl BeamJumpState {
                 break;
             }
 
-            if offset != self.cursor_offset && is_character_match(target, ch, self.smartcase) {
+            if offset != self.cursor_offset
+                && !(offset < self.cursor_offset && self.cursor_offset < next)
+                && is_character_match(target, ch, self.smartcase)
+            {
                 matches.push(BeamJumpMatch {
                     start: offset,
                     end: next,
@@ -339,6 +348,10 @@ impl BeamJumpState {
             new_end += next_ch.len_utf8();
 
             if new_end > self.view_end {
+                return false;
+            }
+
+            if m.start < self.cursor_offset && self.cursor_offset < new_end {
                 return false;
             }
 

--- a/crates/vim/src/beam_jump.rs
+++ b/crates/vim/src/beam_jump.rs
@@ -1,0 +1,442 @@
+use std::ops::Range;
+
+use collections::{HashMap, HashSet};
+use editor::{MultiBufferOffset, MultiBufferSnapshot};
+use ui::SharedString;
+
+use crate::motion::{Motion, is_character_match};
+
+const BASE_LABEL_CHARS: &[char] = &[
+    'f', 'j', 'd', 'k', 's', 'l', 'a', 'g', 'h', 'r', 'u', 'e', 'i', 'o', 'w', 'm', 'n', 'c', 'v',
+    'x', 'z', 'p', 'q', 'y', 't', 'b',
+];
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum BeamJumpDirection {
+    Forward,
+    Backward,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct BeamJumpMatch {
+    pub(crate) start: MultiBufferOffset,
+    pub(crate) end: MultiBufferOffset,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct BeamJumpLabels {
+    pub(crate) label_len: usize,
+    pub(crate) units: Vec<char>,
+    pub(crate) label_buffer: String,
+    pub(crate) label_key_set: HashSet<char>,
+    pub(crate) label_by_start: HashMap<MultiBufferOffset, SharedString>,
+    pub(crate) start_by_label: HashMap<String, MultiBufferOffset>,
+    pub(crate) label_pool: Option<Vec<String>>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct BeamJumpState {
+    pub(crate) direction: BeamJumpDirection,
+    pub(crate) smartcase: bool,
+    pub(crate) search_start: MultiBufferOffset,
+    pub(crate) search_end: MultiBufferOffset,
+    pub(crate) previous_last_find: Option<Motion>,
+
+    pub(crate) pattern: String,
+    pub(crate) pattern_len: usize,
+
+    pub(crate) matches: Vec<BeamJumpMatch>,
+    pub(crate) labels: Option<BeamJumpLabels>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct BeamJumpJump {
+    pub(crate) direction: BeamJumpDirection,
+    pub(crate) pattern: String,
+    pub(crate) smartcase: bool,
+    pub(crate) count: usize,
+    pub(crate) search_range: Range<MultiBufferOffset>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum BeamJumpAction {
+    Continue,
+    Cancel,
+    PassThrough,
+    Jump(BeamJumpJump),
+}
+
+impl BeamJumpState {
+    pub(crate) fn new(
+        direction: BeamJumpDirection,
+        smartcase: bool,
+        search_start: MultiBufferOffset,
+        search_end: MultiBufferOffset,
+        previous_last_find: Option<Motion>,
+    ) -> Self {
+        Self {
+            direction,
+            smartcase,
+            search_start,
+            search_end,
+            previous_last_find,
+            pattern: String::new(),
+            pattern_len: 0,
+            matches: Vec::new(),
+            labels: None,
+        }
+    }
+
+    pub(crate) fn on_typed_char(
+        &mut self,
+        ch: char,
+        buffer: &MultiBufferSnapshot,
+    ) -> BeamJumpAction {
+        if self.pattern_len >= 2 && self.matches.len() > 1 {
+            if let Some(labels) = &mut self.labels {
+                if labels.label_key_set.contains(&ch) {
+                    labels.label_buffer.push(ch);
+                    if labels.label_buffer.len() >= labels.label_len {
+                        let label = std::mem::take(&mut labels.label_buffer);
+                        if let Some(&start) = labels.start_by_label.get(&label)
+                            && let Some(count) = self.count_for_start(start)
+                        {
+                            return BeamJumpAction::Jump(BeamJumpJump {
+                                direction: self.direction,
+                                pattern: self.pattern.clone(),
+                                smartcase: self.smartcase,
+                                count,
+                                search_range: self.search_start..self.search_end,
+                            });
+                        }
+
+                        return BeamJumpAction::Cancel;
+                    }
+
+                    return BeamJumpAction::Continue;
+                }
+
+                labels.label_buffer.clear();
+                if !self.can_extend_pattern_with(ch, buffer) {
+                    return BeamJumpAction::PassThrough;
+                }
+            }
+        }
+
+        self.push_pattern_char(ch, buffer);
+
+        if self.pattern_len < 2 {
+            return BeamJumpAction::Continue;
+        }
+
+        match self.matches.len() {
+            0 | 1 => BeamJumpAction::Jump(BeamJumpJump {
+                direction: self.direction,
+                pattern: self.pattern.clone(),
+                smartcase: self.smartcase,
+                count: 1,
+                search_range: self.search_start..self.search_end,
+            }),
+            _ => {
+                if self.labels.is_none() {
+                    self.labels = Some(self.assign_labels(buffer));
+                }
+
+                BeamJumpAction::Continue
+            }
+        }
+    }
+
+    fn push_pattern_char(&mut self, ch: char, buffer: &MultiBufferSnapshot) {
+        self.pattern.push(ch);
+        self.pattern_len += 1;
+
+        if self.pattern_len == 1 {
+            self.matches = self.scan_first_char(ch, buffer);
+            return;
+        }
+
+        self.extend_matches(ch, buffer);
+
+        if self.labels.is_some() {
+            self.retain_labels_for_matches();
+        }
+    }
+
+    fn can_extend_pattern_with(&self, ch: char, buffer: &MultiBufferSnapshot) -> bool {
+        self.matches.iter().any(|m| {
+            if m.end >= self.search_end {
+                return false;
+            }
+
+            let Some(next_ch) = buffer.chars_at(m.end).next() else {
+                return false;
+            };
+
+            is_character_match(ch, next_ch, self.smartcase)
+        })
+    }
+
+    fn scan_first_char(&self, target: char, buffer: &MultiBufferSnapshot) -> Vec<BeamJumpMatch> {
+        let mut matches = Vec::new();
+        let mut offset = self.search_start;
+        while offset < self.search_end {
+            let Some(ch) = buffer.chars_at(offset).next() else {
+                break;
+            };
+
+            let mut next = offset;
+            next += ch.len_utf8();
+
+            if next > self.search_end {
+                break;
+            }
+
+            if is_character_match(target, ch, self.smartcase) {
+                matches.push(BeamJumpMatch {
+                    start: offset,
+                    end: next,
+                });
+            }
+
+            offset = next;
+        }
+
+        matches
+    }
+
+    fn extend_matches(&mut self, target: char, buffer: &MultiBufferSnapshot) {
+        self.matches.retain_mut(|m| {
+            if m.end >= self.search_end {
+                return false;
+            }
+
+            let Some(next_ch) = buffer.chars_at(m.end).next() else {
+                return false;
+            };
+
+            if !is_character_match(target, next_ch, self.smartcase) {
+                return false;
+            }
+
+            let mut new_end = m.end;
+            new_end += next_ch.len_utf8();
+
+            if new_end > self.search_end {
+                return false;
+            }
+
+            m.end = new_end;
+            true
+        });
+    }
+
+    fn retain_labels_for_matches(&mut self) {
+        let matches = &self.matches;
+        let direction = self.direction;
+
+        let Some(labels) = &mut self.labels else {
+            return;
+        };
+
+        let starts: HashSet<MultiBufferOffset> = matches.iter().map(|m| m.start).collect();
+        labels
+            .label_by_start
+            .retain(|start, _| starts.contains(start));
+        labels
+            .start_by_label
+            .retain(|_, start| starts.contains(start));
+
+        Self::backfill_labels_for_matches(matches, direction, labels);
+
+        labels.label_key_set = labels
+            .label_by_start
+            .values()
+            .flat_map(|label| label.chars())
+            .collect();
+    }
+
+    fn backfill_labels_for_matches(
+        matches: &[BeamJumpMatch],
+        direction: BeamJumpDirection,
+        labels: &mut BeamJumpLabels,
+    ) {
+        let unit_count = labels.units.len();
+        let capacity = match labels.label_len {
+            1 => unit_count,
+            2 => unit_count.saturating_mul(unit_count),
+            _ => 0,
+        };
+        let desired_label_count = std::cmp::min(matches.len(), capacity);
+        if desired_label_count <= labels.label_by_start.len() {
+            return;
+        }
+
+        let label_pool = labels
+            .label_pool
+            .take()
+            .unwrap_or_else(|| generate_labels(&labels.units, labels.label_len, capacity));
+
+        let matches_in_order: Box<dyn Iterator<Item = &BeamJumpMatch>> = match direction {
+            BeamJumpDirection::Forward => Box::new(matches.iter()),
+            BeamJumpDirection::Backward => Box::new(matches.iter().rev()),
+        };
+
+        let mut label_index = 0;
+        for m in matches_in_order {
+            if labels.label_by_start.contains_key(&m.start) {
+                continue;
+            }
+
+            if labels.label_by_start.len() >= desired_label_count {
+                break;
+            }
+
+            let mut next_label = None;
+            while label_index < label_pool.len() {
+                let candidate = &label_pool[label_index];
+                label_index += 1;
+                if labels.start_by_label.contains_key(candidate.as_str()) {
+                    continue;
+                }
+                next_label = Some(candidate.clone());
+                break;
+            }
+
+            let Some(label) = next_label else {
+                break;
+            };
+
+            labels.start_by_label.insert(label.clone(), m.start);
+            labels
+                .label_by_start
+                .insert(m.start, SharedString::from(label));
+        }
+
+        labels.label_pool = Some(label_pool);
+    }
+
+    fn collect_extension_chars(&self, buffer: &MultiBufferSnapshot) -> HashSet<char> {
+        let mut extension_chars = HashSet::default();
+
+        for m in &self.matches {
+            if m.end >= self.search_end {
+                continue;
+            }
+
+            let classifier = buffer.char_classifier_at(m.end);
+            let mut offset = m.end;
+            for ch in buffer.chars_at(offset) {
+                let mut next = offset;
+                next += ch.len_utf8();
+                if next > self.search_end {
+                    break;
+                }
+
+                if !classifier.is_word(ch) {
+                    break;
+                }
+
+                let normalized = if self.smartcase {
+                    ch.to_ascii_lowercase()
+                } else {
+                    ch
+                };
+                if BASE_LABEL_CHARS.contains(&normalized) {
+                    extension_chars.insert(normalized);
+                    if extension_chars.len() == BASE_LABEL_CHARS.len() {
+                        return extension_chars;
+                    }
+                }
+
+                offset = next;
+            }
+        }
+
+        extension_chars
+    }
+
+    fn assign_labels(&self, buffer: &MultiBufferSnapshot) -> BeamJumpLabels {
+        let extension_chars = self.collect_extension_chars(buffer);
+
+        // Exclude chars that appear later in any matched word; ';' and ',' are reserved for navigation.
+        let safe_units: Vec<char> = BASE_LABEL_CHARS
+            .iter()
+            .copied()
+            .filter(|ch| *ch != ';' && *ch != ',' && !extension_chars.contains(ch))
+            .collect();
+
+        // If no safe units remain, capacity drops to 0 and labels stay hidden.
+        let label_len = select_label_len(self.matches.len(), safe_units.len());
+        let capacity = match label_len {
+            1 => safe_units.len(),
+            2 => safe_units.len().saturating_mul(safe_units.len()),
+            _ => 0,
+        };
+        let label_count = std::cmp::min(self.matches.len(), capacity);
+        let labels = generate_labels(&safe_units, label_len, label_count);
+
+        let mut label_by_start = HashMap::default();
+        let mut start_by_label = HashMap::default();
+        let mut label_key_set = HashSet::default();
+
+        let matches_in_order: Box<dyn Iterator<Item = &BeamJumpMatch>> = match self.direction {
+            BeamJumpDirection::Forward => Box::new(self.matches.iter()),
+            BeamJumpDirection::Backward => Box::new(self.matches.iter().rev()),
+        };
+
+        for (m, label) in matches_in_order.take(label_count).zip(labels) {
+            label_key_set.extend(label.chars());
+
+            start_by_label.insert(label.clone(), m.start);
+            label_by_start.insert(m.start, SharedString::from(label));
+        }
+
+        BeamJumpLabels {
+            label_len,
+            units: safe_units,
+            label_buffer: String::new(),
+            label_key_set,
+            label_by_start,
+            start_by_label,
+            label_pool: None,
+        }
+    }
+
+    fn count_for_start(&self, start: MultiBufferOffset) -> Option<usize> {
+        let pos = self.matches.iter().position(|m| m.start == start)?;
+        match self.direction {
+            BeamJumpDirection::Forward => Some(pos + 1),
+            BeamJumpDirection::Backward => Some(self.matches.len().saturating_sub(pos)),
+        }
+    }
+}
+
+fn select_label_len(match_count: usize, unit_count: usize) -> usize {
+    if match_count <= unit_count { 1 } else { 2 }
+}
+
+fn generate_labels(units: &[char], label_len: usize, count: usize) -> Vec<String> {
+    let mut labels = Vec::with_capacity(count);
+
+    match label_len {
+        1 => {
+            for &ch in units.iter().take(count) {
+                labels.push(ch.to_string());
+            }
+        }
+        2 => {
+            'outer: for &a in units {
+                for &b in units {
+                    labels.push(format!("{}{}", a, b));
+                    if labels.len() == count {
+                        break 'outer;
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+
+    labels
+}

--- a/crates/vim/src/test.rs
+++ b/crates/vim/src/test.rs
@@ -1782,6 +1782,101 @@ async fn test_beam_jump_labels_forward(cx: &mut gpui::TestAppContext) {
 
 #[perf]
 #[gpui::test]
+async fn test_beam_jump_filters_overlapping_viewport_matches(cx: &mut gpui::TestAppContext) {
+    let mut cx = VimTestContext::new(cx, true).await;
+    cx.update_global(|store: &mut SettingsStore, cx| {
+        store.update_user_settings(cx, |s| {
+            s.vim.get_or_insert_with(Default::default).beam_jump = Some(true);
+        });
+    });
+
+    cx.update(|_window, cx| {
+        cx.bind_keys([KeyBinding::new(
+            "s",
+            PushSneak { first_char: None },
+            Some("vim_mode == normal"),
+        )])
+    });
+
+    // Regression for overlapping matches (e.g. `aa` in `aaaaa`): viewport candidates must match the
+    // non-overlapping enumeration used by the counted Beam Jump motion.
+    cx.set_state("ˇaaaaa", Mode::Normal);
+    cx.simulate_keystrokes("s a a");
+    cx.assert_state("ˇaaaaa", Mode::Normal);
+
+    let highlights = cx.update_editor(|editor, window, cx| {
+        let snapshot = editor.snapshot(window, cx);
+        let len = snapshot.display_snapshot.buffer_snapshot().len();
+        editor
+            .beam_jump_highlights_in_range(MultiBufferOffset(0)..len)
+            .to_vec()
+    });
+
+    assert_eq!(
+        highlights.len(),
+        2,
+        "expected overlapping matches to be filtered out. {}",
+        cx.assertion_context()
+    );
+    assert!(
+        highlights.iter().all(|highlight| highlight.label.is_some()),
+        "expected labels to be visible once pattern length >= 2. {}",
+        cx.assertion_context()
+    );
+    assert!(
+        highlights[0].range.end <= highlights[1].range.start,
+        "expected non-overlapping matches in start order. {}",
+        cx.assertion_context()
+    );
+    assert_eq!(
+        highlights[0].range,
+        MultiBufferOffset(1)..MultiBufferOffset(3),
+        "unexpected first match. {}",
+        cx.assertion_context()
+    );
+    assert_eq!(
+        highlights[1].range,
+        MultiBufferOffset(3)..MultiBufferOffset(5),
+        "unexpected second match. {}",
+        cx.assertion_context()
+    );
+
+    let label = highlights[1]
+        .label
+        .clone()
+        .expect("missing label for second match");
+    let keystrokes = label.chars().map(|ch| ch.to_string()).join(" ");
+    cx.simulate_keystrokes(&keystrokes);
+
+    cx.assert_state("aaaˇaa", Mode::Normal);
+    assert_eq!(cx.active_operator(), None, "{}", cx.assertion_context());
+
+    // Jumping to the first match is still correct.
+    cx.set_state("ˇaaaaa", Mode::Normal);
+    cx.simulate_keystrokes("s a a");
+    cx.assert_state("ˇaaaaa", Mode::Normal);
+
+    let highlights = cx.update_editor(|editor, window, cx| {
+        let snapshot = editor.snapshot(window, cx);
+        let len = snapshot.display_snapshot.buffer_snapshot().len();
+        editor
+            .beam_jump_highlights_in_range(MultiBufferOffset(0)..len)
+            .to_vec()
+    });
+
+    let label = highlights[0]
+        .label
+        .clone()
+        .expect("missing label for first match");
+    let keystrokes = label.chars().map(|ch| ch.to_string()).join(" ");
+    cx.simulate_keystrokes(&keystrokes);
+
+    cx.assert_state("aˇaaaa", Mode::Normal);
+    assert_eq!(cx.active_operator(), None, "{}", cx.assertion_context());
+}
+
+#[perf]
+#[gpui::test]
 async fn test_beam_jump_viewport_range_includes_before_and_after_cursor(
     cx: &mut gpui::TestAppContext,
 ) {


### PR DESCRIPTION
Closes #14801
Closes #4930

### Summary

Beam Jump is a **viewport-first, directionless** “type-to-target” jump mode for Zed’s Vim mode that supports **arbitrary-length patterns** with **low-noise visuals** and **no surprising navigation while typing**.

### How to use

- Press `s` to enter Beam Jump (cursor stays put; mode is directionless).
- Type a pattern (any length):

  - **len == 1:** show hollow outlines for eligible 1-char matches in the **viewport** (no labels, no jump).
  - **len ≥ 2:**

    - `V > 1` (multiple viewport matches): show hollow outlines + **1 or 2 char labels**; type a label to jump.
    - `V == 1`: show a **single outline** (no label); press `Enter` to commit the jump.
    - `V == 0`: press **Enter** to run a **global forward find with wrap** (the only global navigation trigger).
    
- Cancel anytime with `Esc` / `Backspace` / `Tab` (consumed; no Vim action pass through).

### Key invariant / guarantees

- **Viewport-only matching while typing**; no implicit global navigation.
- **Cross-cursor matches are excluded**; for `len ≥ 2`, viewport candidates are **non-overlapping** (canonical set used for labels + jumps).
- Label keys are **collision-safe** (characters that could extend the pattern are excluded); `;` / `,` are **pattern characters** while active and are **never** label keys.
- **Non-text keys cancel + consume** (no accidental Vim command execution).
- After a successful jump, the full pattern is persisted for Vim repeat (`;` / `,` outside Beam Jump) behavior.

### Safety / UX

* If `pattern_len ≥ 1` and viewport has **zero matches**, an **idle-cancel timer (1.5s)** cleans up the session.
* If viewport bounds can’t be computed at entry, treat viewport matches as **always empty** (no whole-buffer fallback); `Enter` at `len ≥ 2` still performs the global forward find (wrap).


### Release Notes

- Added optional **Beam Jump** mode for Vim **Sneak** (`s`): **arbitrary-length pattern** input with **viewport-first** matching and minimal visual overlays.
- Introduced **labeled jumps** (1–2 characters) for multiple viewport matches; labels are designed to avoid conflicts with continued typing.
- Added **explicit commit behavior**: when a unique viewport match exists, press **`Enter`** to jump (no auto-jump while typing).
- Added **repeatable global navigation** via **Enter-triggered forward find with wrap** when there are no viewport matches (pattern length ≥ 2).
- Improved safety/cancellation: **Esc/Backspace/Tab/non-text keys cancel and are consumed**, preventing accidental Vim command passthrough during an active session.
- Added **idle auto-cancel (1.5s)** when no viewport matches exist, preventing lingering “ghost” sessions.

