### PR TITLE
Add '#' to word_characters in JSON/CSS config

### DIFF
--- a/crates/languages/src/css/config.toml
+++ b/crates/languages/src/css/config.toml
@@ -12,3 +12,4 @@ brackets = [
 completion_query_characters = ["-", "@"]
 block_comment = { start = "/*", prefix = "* ", end = "*/", tab_size = 1 }
 prettier_parser_name = "css"
+word_characters = ["#"]

--- a/crates/languages/src/json/config.toml
+++ b/crates/languages/src/json/config.toml
@@ -12,6 +12,7 @@ brackets = [
 tab_size = 2
 prettier_parser_name = "json"
 debuggers = ["JavaScript"]
+word_characters = ["#"]
 
 [overrides.string]
 completion_query_characters = [":", " ", "."]


### PR DESCRIPTION
Closes #44266

Release Notes:

- Added '#' characters as part of word when double-clicking text in `.json` and `.css` files
