### PR TITLE
settings ui: Change window kind from floating to normal

### DIFF
--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -602,7 +602,7 @@ pub fn open_settings_editor(
                 focus: true,
                 show: true,
                 is_movable: true,
-                kind: gpui::WindowKind::Floating,
+                kind: gpui::WindowKind::Normal,
                 window_background: cx.theme().window_background_appearance(),
                 app_id: Some(app_id.to_owned()),
                 window_decorations: Some(window_decorations),


### PR DESCRIPTION
#40291 made floating windows always stay on top, which made the settings ui window always on top of Zed. To maintain the old behavior, this PR changes the setting window to be a normal window.

Release Notes:

- N/A
