### PR TITLE
Revert "gpui: Enable direct-to-display optimization for metal"

### DIFF
--- a/crates/gpui/src/platform/mac/metal_renderer.rs
+++ b/crates/gpui/src/platform/mac/metal_renderer.rs
@@ -46,9 +46,9 @@ pub unsafe fn new_renderer(
     _native_window: *mut c_void,
     _native_view: *mut c_void,
     _bounds: crate::Size<f32>,
-    transparent: bool,
+    _transparent: bool,
 ) -> Renderer {
-    MetalRenderer::new(context, transparent)
+    MetalRenderer::new(context)
 }
 
 pub(crate) struct InstanceBufferPool {
@@ -128,7 +128,7 @@ pub struct PathRasterizationVertex {
 }
 
 impl MetalRenderer {
-    pub fn new(instance_buffer_pool: Arc<Mutex<InstanceBufferPool>>, transparent: bool) -> Self {
+    pub fn new(instance_buffer_pool: Arc<Mutex<InstanceBufferPool>>) -> Self {
         // Prefer low‐power integrated GPUs on Intel Mac. On Apple
         // Silicon, there is only ever one GPU, so this is equivalent to
         // `metal::Device::system_default()`.
@@ -152,13 +152,8 @@ impl MetalRenderer {
         let layer = metal::MetalLayer::new();
         layer.set_device(&device);
         layer.set_pixel_format(MTLPixelFormat::BGRA8Unorm);
-        // Support direct-to-display rendering if the window is not transparent
-        // https://developer.apple.com/documentation/metal/managing-your-game-window-for-metal-in-macos
-        layer.set_opaque(!transparent);
+        layer.set_opaque(false);
         layer.set_maximum_drawable_count(3);
-        // We already present at display sync with the display link
-        // This allows to use direct-to-display even in window mode
-        layer.set_display_sync_enabled(false);
         unsafe {
             let _: () = msg_send![&*layer, setAllowsNextDrawableTimeout: NO];
             let _: () = msg_send![&*layer, setNeedsDisplayOnBoundsChange: YES];
@@ -357,8 +352,8 @@ impl MetalRenderer {
         }
     }
 
-    pub fn update_transparency(&self, transparent: bool) {
-        self.layer.set_opaque(!transparent);
+    pub fn update_transparency(&self, _transparent: bool) {
+        // todo(mac)?
     }
 
     pub fn destroy(&self) {


### PR DESCRIPTION
Reverts zed-industries/zed#44334

From my testing, this PR introduced screen tearing, or some kind of strange visual artifact, when scrolling at medium speed on a large display.

Release notes:

- N/A