### PR TITLE
git: Add basic vim motions to git file history view

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -1097,4 +1097,13 @@
       "ctrl-e": "markdown::ScrollDown",
     },
   },
+  {
+    "context": "FileHistoryView",
+    "bindings": {
+      "j": "menu::SelectNext",
+      "k": "menu::SelectPrevious",
+      "g g": "menu::SelectFirst",
+      "shift-g": "menu::SelectLast",
+    },
+  },
 ]


### PR DESCRIPTION
Closes #ISSUE

Related discussion #44629 

Release Notes:

- Added simple `g g`, `G`, `j` and `k` motions for the file history view on vim mode. 