### PR TITLE
proto: Add `extend` keyword

### DIFF
--- a/extensions/proto/languages/proto/highlights.scm
+++ b/extensions/proto/languages/proto/highlights.scm
@@ -9,6 +9,7 @@
   "returns"
   "message"
   "enum"
+  "extend"
   "oneof"
   "repeated"
   "reserved"


### PR DESCRIPTION
Closes #45385

Release Notes:
- Add extend keyword to proto
