### PR TITLE
git: Stash push with custom message

### DIFF
--- a/crates/fs/src/fake_git_repo.rs
+++ b/crates/fs/src/fake_git_repo.rs
@@ -538,6 +538,7 @@ impl GitRepository for FakeGitRepository {
     fn stash_paths(
         &self,
         _paths: Vec<RepoPath>,
+        _message: Option<String>,
         _env: Arc<HashMap<String, String>>,
     ) -> BoxFuture<'_, Result<()>> {
         unimplemented!()

--- a/crates/git/src/git.rs
+++ b/crates/git/src/git.rs
@@ -85,6 +85,8 @@ actions!(
         Commit,
         /// Amends the last commit with staged changes.
         Amend,
+        /// Stash push with a custom message
+        StashPush,
         /// Enable the --signoff option.
         Signoff,
         /// Cancels the current git operation.
@@ -101,6 +103,8 @@ actions!(
         Clone,
         /// Adds a file to .gitignore.
         AddToGitignore,
+        /// Switch commit editor to stash
+        ToggleCommitMode
     ]
 );
 

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -543,6 +543,7 @@ pub trait GitRepository: Send + Sync {
     fn stash_paths(
         &self,
         paths: Vec<RepoPath>,
+        message: Option<String>,
         env: Arc<HashMap<String, String>>,
     ) -> BoxFuture<'_, Result<()>>;
 
@@ -1718,6 +1719,7 @@ impl GitRepository for RealGitRepository {
     fn stash_paths(
         &self,
         paths: Vec<RepoPath>,
+        message: Option<String>,
         env: Arc<HashMap<String, String>>,
     ) -> BoxFuture<'_, Result<()>> {
         let working_directory = self.working_directory();
@@ -1728,7 +1730,8 @@ impl GitRepository for RealGitRepository {
                 cmd.current_dir(&working_directory?)
                     .envs(env.iter())
                     .args(["stash", "push", "--quiet"])
-                    .arg("--include-untracked");
+                    .arg("--include-untracked")
+                    .args(message.iter().flat_map(|m| ["-m", m.as_str()]));
 
                 cmd.args(paths.iter().map(|p| p.as_unix_str()));
 

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1978,7 +1978,7 @@ impl GitPanel {
         cx.spawn({
             async move |this, cx| {
                 let stash_task = active_repository
-                    .update(cx, |repo, cx| repo.stash_all(cx))?
+                    .update(cx, |repo, cx| repo.stash_all(None, cx))?
                     .await;
                 this.update(cx, |this, cx| {
                     stash_task

--- a/crates/proto/proto/git.proto
+++ b/crates/proto/proto/git.proto
@@ -362,6 +362,7 @@ message Stash {
     uint64 project_id = 1;
     uint64 repository_id = 2;
     repeated string paths = 3;
+    optional string message = 4;
 }
 
 message StashPop {


### PR DESCRIPTION
Closes #ISSUE


This PR adds support for doing a `git stash` with a custom message using either the git commit modal or the editor available on the git panel. 

Preview:

<img width="751" height="442" alt="Pasted image (2)" src="https://github.com/user-attachments/assets/50bdd6cd-aba1-4724-adbb-616b901ae07d" />

<img width="367" height="261" alt="image" src="https://github.com/user-attachments/assets/43f1dbba-f928-4f0b-86e6-228d8b37d8ab" />

<img width="367" height="261" alt="image" src="https://github.com/user-attachments/assets/2608f02f-7092-4321-a4dd-c73ec40a59f9" />

Not sure about the UI stuff, but that can be changed :) 


Release Notes:

- Added support for git stash with custom message
