### PR TITLE
ci: Disable automated docs on pushes to `main`

### DIFF
--- a/.github/workflows/docs_automation.yml
+++ b/.github/workflows/docs_automation.yml
@@ -1,11 +1,11 @@
 name: Documentation Automation
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'crates/**'
-      - 'extensions/**'
+  # push:
+  #   branches: [main]
+  #   paths:
+  #     - 'crates/**'
+  #     - 'extensions/**'
   workflow_dispatch:
     inputs:
       pr_number:
@@ -29,7 +29,7 @@ jobs:
   docs-automation:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -77,7 +77,7 @@ jobs:
             echo "ref=$SHA" >> "$GITHUB_OUTPUT"
             git diff --name-only "${SHA}^" "$SHA" > /tmp/changed_files.txt || git diff --name-only HEAD~1 HEAD > /tmp/changed_files.txt
           fi
-          
+
           echo "Changed files:"
           cat /tmp/changed_files.txt
         env:
@@ -102,24 +102,24 @@ jobs:
         run: |
           CHANGED_FILES=$(tr '\n' ' ' < /tmp/changed_files.txt)
           echo "Analyzing changes in: $CHANGED_FILES"
-          
+
           # Build prompt with context
           cat > /tmp/phase3-prompt.md << 'EOF'
           $(cat .factory/prompts/docs-automation/phase3-analyze.md)
-          
+
           ## Context
-          
+
           ### Changed Files
           $CHANGED_FILES
-          
+
           ### Phase 2 Output
           $(cat /tmp/phase2-output.txt)
           EOF
-          
+
           "$DROID_BIN" exec \
             -m "$DROID_MODEL" \
             "$(cat .factory/prompts/docs-automation/phase3-analyze.md)
-            
+
             Changed files: $CHANGED_FILES" \
             > /tmp/phase3-output.md 2>&1 || true
           echo "Change analysis complete"
@@ -135,7 +135,7 @@ jobs:
             > /tmp/phase4-plan.md 2>&1 || true
           echo "Documentation plan complete"
           cat /tmp/phase4-plan.md
-          
+
           # Check if updates are required
           if grep -q "NO_UPDATES_REQUIRED" /tmp/phase4-plan.md; then
             echo "updates_required=false" >> "$GITHUB_OUTPUT"
@@ -163,10 +163,10 @@ jobs:
         run: |
           echo "Formatting documentation with Prettier..."
           cd docs && prettier --write src/
-          
+
           echo "Verifying Prettier formatting passes..."
           cd docs && prettier --check src/
-          
+
           echo "Prettier formatting complete"
 
       # Phase 6: Summarize Changes (Read-Only - default)
@@ -176,7 +176,7 @@ jobs:
         run: |
           # Get git diff of docs
           git diff docs/src/ > /tmp/docs-diff.txt || true
-          
+
           "$DROID_BIN" exec \
             -m "$DROID_MODEL" \
             -f .factory/prompts/docs-automation/phase6-summarize.md \
@@ -194,17 +194,17 @@ jobs:
             echo "No documentation changes detected"
             exit 0
           fi
-          
+
           # Configure git
           git config user.name "factory-droid[bot]"
           git config user.email "138933559+factory-droid[bot]@users.noreply.github.com"
-          
+
           # Daily batch branch - one branch per day, multiple commits accumulate
           BRANCH_NAME="docs/auto-update-$(date +%Y-%m-%d)"
-          
+
           # Stash local changes from phase 5
           git stash push -m "docs-automation-changes" -- docs/src/
-          
+
           # Check if branch already exists on remote
           if git ls-remote --exit-code --heads origin "$BRANCH_NAME" > /dev/null 2>&1; then
             echo "Branch $BRANCH_NAME exists, checking out and updating..."
@@ -214,10 +214,10 @@ jobs:
             echo "Creating new branch $BRANCH_NAME..."
             git checkout -b "$BRANCH_NAME"
           fi
-          
+
           # Apply stashed changes
           git stash pop || true
-          
+
           # Stage and commit
           git add docs/src/
           SUMMARY=$(head -50 < /tmp/phase6-summary.md)
@@ -228,13 +228,13 @@ jobs:
           Triggered by: ${{ steps.changed.outputs.source }} ${{ steps.changed.outputs.ref }}
 
           Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>"
-          
+
           # Push
           git push -u origin "$BRANCH_NAME"
-          
+
           # Check if PR already exists for this branch
           EXISTING_PR=$(gh pr list --head "$BRANCH_NAME" --json number --jq '.[0].number' || echo "")
-          
+
           if [ -n "$EXISTING_PR" ]; then
             echo "PR #$EXISTING_PR already exists for branch $BRANCH_NAME, updated with new commit"
           else
@@ -254,7 +254,7 @@ jobs:
         run: |
           echo "## Documentation Automation Summary" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          
+
           if [ "${{ steps.phase4.outputs.updates_required }}" == "false" ]; then
             echo "No documentation updates required for this change." >> "$GITHUB_STEP_SUMMARY"
           elif [ -f /tmp/phase6-summary.md ]; then


### PR DESCRIPTION
This PR disables the automated docs on pushes to `main`, as it is currently making CI red.

Release Notes:

- N/A
