### PR TITLE
Add support for subpixel text rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2187,8 +2187,7 @@ dependencies = [
 [[package]]
 name = "blade-graphics"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4deb8f595ce7f00dee3543ebf6fd9a20ea86fc421ab79600dac30876250bdae"
+source = "git+https://github.com/kvark/blade?rev=e3cf011ca18a6dfd907d1dedd93e85e21f005fe3#e3cf011ca18a6dfd907d1dedd93e85e21f005fe3"
 dependencies = [
  "ash",
  "ash-window",
@@ -2222,8 +2221,7 @@ dependencies = [
 [[package]]
 name = "blade-macros"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27142319e2f4c264581067eaccb9f80acccdde60d8b4bf57cc50cd3152f109ca"
+source = "git+https://github.com/kvark/blade?rev=e3cf011ca18a6dfd907d1dedd93e85e21f005fe3#e3cf011ca18a6dfd907d1dedd93e85e21f005fe3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2233,8 +2231,7 @@ dependencies = [
 [[package]]
 name = "blade-util"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a6be3a82c001ba7a17b6f8e413ede5d1004e6047213f8efaf0ffc15b5c4904c"
+source = "git+https://github.com/kvark/blade?rev=e3cf011ca18a6dfd907d1dedd93e85e21f005fe3#e3cf011ca18a6dfd907d1dedd93e85e21f005fe3"
 dependencies = [
  "blade-graphics",
  "bytemuck",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7392,6 +7392,7 @@ dependencies = [
  "stacksafe",
  "strum 0.27.2",
  "sum_tree",
+ "swash",
  "taffy",
  "thiserror 2.0.17",
  "unicode-segmentation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -473,9 +473,9 @@ backtrace = "0.3"
 base64 = "0.22"
 bincode = "1.2.1"
 bitflags = "2.6.0"
-blade-graphics = { version = "0.7.0" }
-blade-macros = { version = "0.3.0" }
-blade-util = { version = "0.3.0" }
+blade-graphics = { git = "https://github.com/kvark/blade", rev = "e3cf011ca18a6dfd907d1dedd93e85e21f005fe3" }
+blade-macros = { git = "https://github.com/kvark/blade", rev = "e3cf011ca18a6dfd907d1dedd93e85e21f005fe3" }
+blade-util = { git = "https://github.com/kvark/blade", rev = "e3cf011ca18a6dfd907d1dedd93e85e21f005fe3" }
 brotli = "8.0.2"
 bytes = "1.0"
 cargo_metadata = "0.19"

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -172,12 +172,12 @@
   // Whether to enable subpixel (ClearType-style) text rendering.
   // May take 3 values:
   //  1. Use platform default behavior:
-  //         "subpixel_text_rendering": "platform_default"
+  //         "use_subpixel_text_rendering": "platform_default"
   //  2. Always enable subpixel text rendering:
-  //         "subpixel_text_rendering": "yes"
-  //  3. Always disable subpixel text rendering:
-  //         "subpixel_text_rendering": "no"
-  "subpixel_text_rendering": "platform_default",
+  //         "use_subpixel_text_rendering": "always"
+  //  3. Never enable subpixel text rendering:
+  //         "use_subpixel_text_rendering": "never"
+  "use_subpixel_text_rendering": "platform_default",
   // Whether to show padding for zoomed panels.
   // When enabled, zoomed center panels (e.g. code editor) will have padding all around,
   // while zoomed bottom/left/right panels will have padding to the top/right/left (respectively).

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -169,15 +169,15 @@
   //  2. Always quit the application
   //         "on_last_window_closed": "quit_app",
   "on_last_window_closed": "platform_default",
-  // Whether to enable subpixel (ClearType-style) text rendering.
+  // The text rendering mode to use.
   // May take 3 values:
   //  1. Use platform default behavior:
-  //         "use_subpixel_text_rendering": "platform_default"
-  //  2. Always enable subpixel text rendering:
-  //         "use_subpixel_text_rendering": "always"
-  //  3. Never enable subpixel text rendering:
-  //         "use_subpixel_text_rendering": "never"
-  "use_subpixel_text_rendering": "platform_default",
+  //         "text_rendering_mode": "platform_default"
+  //  2. Use subpixel (ClearType-style) text rendering:
+  //         "text_rendering_mode": "subpixel"
+  //  3. Use grayscale text rendering:
+  //         "text_rendering_mode": "grayscale"
+  "text_rendering_mode": "platform_default",
   // Whether to show padding for zoomed panels.
   // When enabled, zoomed center panels (e.g. code editor) will have padding all around,
   // while zoomed bottom/left/right panels will have padding to the top/right/left (respectively).

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -169,6 +169,15 @@
   //  2. Always quit the application
   //         "on_last_window_closed": "quit_app",
   "on_last_window_closed": "platform_default",
+  // Whether to enable subpixel (ClearType-style) text rendering.
+  // May take 3 values:
+  //  1. Use platform default behavior:
+  //         "subpixel_text_rendering": "platform_default"
+  //  2. Always enable subpixel text rendering:
+  //         "subpixel_text_rendering": "yes"
+  //  3. Always disable subpixel text rendering:
+  //         "subpixel_text_rendering": "no"
+  "subpixel_text_rendering": "platform_default",
   // Whether to show padding for zoomed panels.
   // When enabled, zoomed center panels (e.g. code editor) will have padding all around,
   // while zoomed bottom/left/right panels will have padding to the top/right/left (respectively).

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -183,6 +183,7 @@ blade-macros = { workspace = true, optional = true }
 blade-util = { workspace = true, optional = true }
 bytemuck = { version = "1", optional = true }
 cosmic-text = { version = "0.14.0", optional = true }
+swash = { version = "0.2.6" }
 # WARNING: If you change this, you must also publish a new version of zed-font-kit to crates.io
 font-kit = { git = "https://github.com/zed-industries/font-kit", rev = "110523127440aefb11ce0cf280ae7c5071337ec5", package = "zed-font-kit", version = "0.14.1-zed", features = [
     "source-fontconfig-dlopen",

--- a/crates/gpui/build.rs
+++ b/crates/gpui/build.rs
@@ -297,6 +297,7 @@ mod windows {
             "path_sprite",
             "underline",
             "monochrome_sprite",
+            "subpixel_sprite",
             "polychrome_sprite",
         ];
 

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -1,6 +1,6 @@
 use std::{
     any::{TypeId, type_name},
-    cell::{BorrowMutError, Ref, RefCell, RefMut},
+    cell::{BorrowMutError, Cell, Ref, RefCell, RefMut},
     marker::PhantomData,
     mem,
     ops::{Deref, DerefMut},
@@ -41,8 +41,8 @@ use crate::{
     PlatformDisplay, PlatformKeyboardLayout, PlatformKeyboardMapper, Point, Priority,
     PromptBuilder, PromptButton, PromptHandle, PromptLevel, Render, RenderImage,
     RenderablePromptHandle, Reservation, ScreenCaptureSource, SharedString, SubscriberSet,
-    Subscription, SvgRenderer, Task, TextSystem, Window, WindowAppearance, WindowHandle, WindowId,
-    WindowInvalidator,
+    Subscription, SvgRenderer, Task, TextRenderingMode, TextSystem, Window, WindowAppearance,
+    WindowHandle, WindowId, WindowInvalidator,
     colors::{Colors, GlobalColors},
     current_platform, hash, init_app_menus,
 };
@@ -633,6 +633,7 @@ pub struct App {
     pub(crate) inspector_element_registry: InspectorElementRegistry,
     #[cfg(any(test, feature = "test-support", debug_assertions))]
     pub(crate) name: Option<&'static str>,
+    pub(crate) text_rendering_mode: Rc<Cell<TextRenderingMode>>,
     quit_mode: QuitMode,
     quitting: bool,
 }
@@ -662,6 +663,7 @@ impl App {
                 liveness: std::sync::Arc::new(()),
                 platform: platform.clone(),
                 text_system,
+                text_rendering_mode: Rc::new(Cell::new(TextRenderingMode::default())),
                 mode: GpuiMode::Production,
                 actions: Rc::new(ActionRegistry::default()),
                 flushing_effects: false,
@@ -1084,9 +1086,14 @@ impl App {
         self.platform.read_from_clipboard()
     }
 
-    /// Enables or disables subpixel rendering for the application.
-    pub fn set_subpixel_rendering_enabled(&mut self, enabled: Option<bool>) {
-        self.platform.set_subpixel_rendering_enabled(enabled);
+    /// Sets the text rendering mode for the application.
+    pub fn set_text_rendering_mode(&mut self, mode: TextRenderingMode) {
+        self.text_rendering_mode.set(mode);
+    }
+
+    /// Returns the current text rendering mode for the application.
+    pub fn text_rendering_mode(&self) -> TextRenderingMode {
+        self.text_rendering_mode.get()
     }
 
     /// Writes data to the platform clipboard.

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -1089,13 +1089,6 @@ impl App {
         self.platform.set_subpixel_rendering_enabled(enabled);
     }
 
-    /// Writes data to the primary selection buffer.
-    /// Only available on Linux.
-    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
-    pub fn write_to_primary(&self, item: ClipboardItem) {
-        self.platform.write_to_primary(item)
-    }
-
     /// Writes data to the platform clipboard.
     pub fn write_to_clipboard(&self, item: ClipboardItem) {
         self.platform.write_to_clipboard(item)

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -1084,6 +1084,18 @@ impl App {
         self.platform.read_from_clipboard()
     }
 
+    /// Enables or disables subpixel rendering for the application.
+    pub fn set_subpixel_rendering_enabled(&mut self, enabled: Option<bool>) {
+        self.platform.set_subpixel_rendering_enabled(enabled);
+    }
+
+    /// Writes data to the primary selection buffer.
+    /// Only available on Linux.
+    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    pub fn write_to_primary(&self, item: ClipboardItem) {
+        self.platform.write_to_primary(item)
+    }
+
     /// Writes data to the platform clipboard.
     pub fn write_to_clipboard(&self, item: ClipboardItem) {
         self.platform.write_to_clipboard(item)

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -822,6 +822,14 @@ impl AtlasKey {
                 if params.is_emoji {
                     AtlasTextureKind::Polychrome
                 } else {
+                    #[cfg(target_os = "windows")]
+                    if crate::ENABLE_SUBPIXEL_TEXT_RENDERING {
+                        AtlasTextureKind::Subpixel
+                    } else {
+                        AtlasTextureKind::Monochrome
+                    }
+
+                    #[cfg(not(target_os = "windows"))]
                     AtlasTextureKind::Monochrome
                 }
             }
@@ -922,6 +930,7 @@ pub(crate) struct AtlasTextureId {
 pub(crate) enum AtlasTextureKind {
     Monochrome = 0,
     Polychrome = 1,
+    Subpixel = 2,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -497,7 +497,7 @@ pub(crate) trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     fn activate(&self);
     fn is_active(&self) -> bool;
     fn is_hovered(&self) -> bool;
-    fn is_opaque(&self) -> bool;
+    fn background_appearance(&self) -> WindowBackgroundAppearance;
     fn set_title(&mut self, title: &str);
     fn set_background_appearance(&self, background_appearance: WindowBackgroundAppearance);
     fn minimize(&self);

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -282,6 +282,8 @@ pub(crate) trait Platform: 'static {
     fn keyboard_layout(&self) -> Box<dyn PlatformKeyboardLayout>;
     fn keyboard_mapper(&self) -> Rc<dyn PlatformKeyboardMapper>;
     fn on_keyboard_layout_change(&self, callback: Box<dyn FnMut()>);
+
+    fn set_subpixel_rendering_enabled(&self, _enabled: Option<bool>) {}
 }
 
 /// A handle to a platform's display, e.g. a monitor or laptop screen.
@@ -570,6 +572,10 @@ pub(crate) trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     fn as_test(&mut self) -> Option<&mut TestWindow> {
         None
     }
+
+    fn is_subpixel_rendering_enabled(&self) -> bool {
+        false
+    }
 }
 
 /// This type is public so that our test macro can generate and use it, but it should not
@@ -821,15 +827,9 @@ impl AtlasKey {
             AtlasKey::Glyph(params) => {
                 if params.is_emoji {
                     AtlasTextureKind::Polychrome
+                } else if params.subpixel_rendering {
+                    AtlasTextureKind::Subpixel
                 } else {
-                    #[cfg(target_os = "windows")]
-                    if crate::ENABLE_SUBPIXEL_TEXT_RENDERING {
-                        AtlasTextureKind::Subpixel
-                    } else {
-                        AtlasTextureKind::Monochrome
-                    }
-
-                    #[cfg(not(target_os = "windows"))]
                     AtlasTextureKind::Monochrome
                 }
             }

--- a/crates/gpui/src/platform/blade/blade_atlas.rs
+++ b/crates/gpui/src/platform/blade/blade_atlas.rs
@@ -162,9 +162,8 @@ impl BladeAtlasState {
                 format = gpu::TextureFormat::R8Unorm;
                 usage = gpu::TextureUsage::COPY | gpu::TextureUsage::RESOURCE;
             }
-
             AtlasTextureKind::Subpixel => {
-                format = gpu::TextureFormat::Rgba8Unorm;
+                format = gpu::TextureFormat::Bgra8Unorm;
                 usage = gpu::TextureUsage::COPY | gpu::TextureUsage::RESOURCE;
             }
             AtlasTextureKind::Polychrome => {

--- a/crates/gpui/src/platform/blade/blade_atlas.rs
+++ b/crates/gpui/src/platform/blade/blade_atlas.rs
@@ -162,6 +162,11 @@ impl BladeAtlasState {
                 format = gpu::TextureFormat::R8Unorm;
                 usage = gpu::TextureUsage::COPY | gpu::TextureUsage::RESOURCE;
             }
+
+            AtlasTextureKind::Subpixel => {
+                format = gpu::TextureFormat::Rgba8Unorm;
+                usage = gpu::TextureUsage::COPY | gpu::TextureUsage::RESOURCE;
+            }
             AtlasTextureKind::Polychrome => {
                 format = gpu::TextureFormat::Bgra8Unorm;
                 usage = gpu::TextureUsage::COPY | gpu::TextureUsage::RESOURCE;
@@ -263,6 +268,7 @@ impl BladeAtlasState {
 #[derive(Default)]
 struct BladeAtlasStorage {
     monochrome_textures: AtlasTextureList<BladeAtlasTexture>,
+    subpixel_textures: AtlasTextureList<BladeAtlasTexture>,
     polychrome_textures: AtlasTextureList<BladeAtlasTexture>,
 }
 
@@ -271,6 +277,7 @@ impl ops::Index<AtlasTextureKind> for BladeAtlasStorage {
     fn index(&self, kind: AtlasTextureKind) -> &Self::Output {
         match kind {
             crate::AtlasTextureKind::Monochrome => &self.monochrome_textures,
+            crate::AtlasTextureKind::Subpixel => &self.subpixel_textures,
             crate::AtlasTextureKind::Polychrome => &self.polychrome_textures,
         }
     }
@@ -280,6 +287,7 @@ impl ops::IndexMut<AtlasTextureKind> for BladeAtlasStorage {
     fn index_mut(&mut self, kind: AtlasTextureKind) -> &mut Self::Output {
         match kind {
             crate::AtlasTextureKind::Monochrome => &mut self.monochrome_textures,
+            crate::AtlasTextureKind::Subpixel => &mut self.subpixel_textures,
             crate::AtlasTextureKind::Polychrome => &mut self.polychrome_textures,
         }
     }
@@ -290,6 +298,7 @@ impl ops::Index<AtlasTextureId> for BladeAtlasStorage {
     fn index(&self, id: AtlasTextureId) -> &Self::Output {
         let textures = match id.kind {
             crate::AtlasTextureKind::Monochrome => &self.monochrome_textures,
+            crate::AtlasTextureKind::Subpixel => &self.subpixel_textures,
             crate::AtlasTextureKind::Polychrome => &self.polychrome_textures,
         };
         textures[id.index as usize].as_ref().unwrap()
@@ -299,6 +308,9 @@ impl ops::Index<AtlasTextureId> for BladeAtlasStorage {
 impl BladeAtlasStorage {
     fn destroy(&mut self, gpu: &gpu::Context) {
         for mut texture in self.monochrome_textures.drain().flatten() {
+            texture.destroy(gpu);
+        }
+        for mut texture in self.subpixel_textures.drain().flatten() {
             texture.destroy(gpu);
         }
         for mut texture in self.polychrome_textures.drain().flatten() {

--- a/crates/gpui/src/platform/blade/blade_context.rs
+++ b/crates/gpui/src/platform/blade/blade_context.rs
@@ -34,6 +34,10 @@ impl BladeContext {
         );
         Ok(Self { gpu })
     }
+
+    pub fn supports_dual_source_blending(&self) -> bool {
+        self.gpu.capabilities().dual_source_blending
+    }
 }
 
 fn parse_pci_id(id: &str) -> anyhow::Result<u32> {

--- a/crates/gpui/src/platform/blade/blade_context.rs
+++ b/crates/gpui/src/platform/blade/blade_context.rs
@@ -35,6 +35,7 @@ impl BladeContext {
         Ok(Self { gpu })
     }
 
+    #[allow(dead_code)]
     pub fn supports_dual_source_blending(&self) -> bool {
         self.gpu.capabilities().dual_source_blending
     }

--- a/crates/gpui/src/platform/blade/blade_renderer.rs
+++ b/crates/gpui/src/platform/blade/blade_renderer.rs
@@ -678,7 +678,7 @@ impl BladeRenderer {
         }
     }
 
-    pub fn draw(&mut self, scene: &Scene, opaque_background: bool) {
+    pub fn draw(&mut self, scene: &Scene) {
         self.command_encoder.start();
         self.atlas.before_frame(&mut self.command_encoder);
 
@@ -705,10 +705,10 @@ impl BladeRenderer {
             gpu::RenderTargetSet {
                 colors: &[gpu::RenderTarget {
                     view: frame.texture_view(),
-                    init_op: gpu::InitOp::Clear(if opaque_background {
-                        gpu::TextureColor::White
-                    } else {
+                    init_op: gpu::InitOp::Clear(if self.surface_config.transparent {
                         gpu::TextureColor::TransparentBlack
+                    } else {
+                        gpu::TextureColor::White
                     }),
                     finish_op: gpu::FinishOp::Store,
                 }],

--- a/crates/gpui/src/platform/blade/blade_renderer.rs
+++ b/crates/gpui/src/platform/blade/blade_renderer.rs
@@ -95,7 +95,7 @@ struct ShaderMonoSpritesData {
 struct ShaderSubpixelSpritesData {
     globals: GlobalParams,
     gamma_ratios: [f32; 4],
-    grayscale_enhanced_contrast: f32,
+    subpixel_enhanced_contrast: f32,
     t_sprite: gpu::TextureView,
     s_sprite: gpu::Sampler,
     b_subpixel_sprites: gpu::BufferPiece,
@@ -868,9 +868,9 @@ impl BladeRenderer {
                         &ShaderSubpixelSpritesData {
                             globals,
                             gamma_ratios: self.rendering_parameters.gamma_ratios,
-                            grayscale_enhanced_contrast: self
+                            subpixel_enhanced_contrast: self
                                 .rendering_parameters
-                                .grayscale_enhanced_contrast,
+                                .subpixel_enhanced_contrast,
                             t_sprite: tex_info.raw_view,
                             s_sprite: self.atlas_sampler,
                             b_subpixel_sprites: instance_buf,
@@ -1068,6 +1068,10 @@ struct RenderingParameters {
     // Allowed range: [0.0, ..), other values are clipped
     // Default: 1.0
     grayscale_enhanced_contrast: f32,
+    // Env var: ZED_FONTS_SUBPIXEL_ENHANCED_CONTRAST
+    // Allowed range: [0.0, ..), other values are clipped
+    // Default: 0.5
+    subpixel_enhanced_contrast: f32,
 }
 
 impl RenderingParameters {
@@ -1094,11 +1098,17 @@ impl RenderingParameters {
             .and_then(|v| v.parse().ok())
             .unwrap_or(1.0_f32)
             .max(0.0);
+        let subpixel_enhanced_contrast = env::var("ZED_FONTS_SUBPIXEL_ENHANCED_CONTRAST")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(0.5_f32)
+            .max(0.0);
 
         Self {
             path_sample_count,
             gamma_ratios,
             grayscale_enhanced_contrast,
+            subpixel_enhanced_contrast,
         }
     }
 }

--- a/crates/gpui/src/platform/blade/shaders.wgsl
+++ b/crates/gpui/src/platform/blade/shaders.wgsl
@@ -87,6 +87,7 @@ struct GlobalParams {
 var<uniform> globals: GlobalParams;
 var<uniform> gamma_ratios: vec4<f32>;
 var<uniform> grayscale_enhanced_contrast: f32;
+var<uniform> subpixel_enhanced_contrast: f32;
 var t_sprite: texture_2d<f32>;
 var s_sprite: sampler;
 
@@ -1336,8 +1337,8 @@ struct SubpixelSpriteOutput {
 }
 
 struct SubpixelSpriteFragmentOutput {
-    @location(0) @blend_src(0) color0: vec4<f32>,
-    @location(0) @blend_src(1) color1: vec4<f32>,
+    @location(0) @blend_src(0) foreground: vec4<f32>,
+    @location(0) @blend_src(1) alpha: vec4<f32>,
 }
 
 @vertex
@@ -1356,7 +1357,7 @@ fn vs_subpixel_sprite(@builtin(vertex_index) vertex_id: u32, @builtin(instance_i
 @fragment
 fn fs_subpixel_sprite(input: SubpixelSpriteOutput) -> SubpixelSpriteFragmentOutput {
     let sample = textureSample(t_sprite, s_sprite, input.tile_position).rgb;
-    let alpha_corrected = apply_contrast_and_gamma_correction3(sample, input.color.rgb, grayscale_enhanced_contrast, gamma_ratios);
+    let alpha_corrected = apply_contrast_and_gamma_correction3(sample, input.color.rgb, subpixel_enhanced_contrast, gamma_ratios);
 
     // Alpha clip after using the derivatives.
     if (any(input.clip_distances < vec4<f32>(0.0))) {
@@ -1364,7 +1365,7 @@ fn fs_subpixel_sprite(input: SubpixelSpriteOutput) -> SubpixelSpriteFragmentOutp
     }
 
     var out = SubpixelSpriteFragmentOutput();
-    out.color0 = vec4<f32>(input.color.rgb, 1.0);
-    out.color1 = vec4<f32>(input.color.a * alpha_corrected, 1.0);
+    out.foreground = vec4<f32>(input.color.rgb, 1.0);
+    out.alpha = vec4<f32>(input.color.a * alpha_corrected, 1.0);
     return out;
 }

--- a/crates/gpui/src/platform/blade/shaders.wgsl
+++ b/crates/gpui/src/platform/blade/shaders.wgsl
@@ -1,3 +1,4 @@
+enable dual_source_blending;
 /* Functions useful for debugging:
 
 // A heat map color for debugging (blue -> cyan -> green -> yellow -> red).
@@ -46,7 +47,17 @@ fn enhance_contrast(alpha: f32, k: f32) -> f32 {
     return alpha * (k + 1.0) / (alpha * k + 1.0);
 }
 
+fn enhance_contrast3(alpha: vec3<f32>, k: f32) -> vec3<f32> {
+    return alpha * (k + 1.0) / (alpha * k + 1.0);
+}
+
 fn apply_alpha_correction(a: f32, b: f32, g: vec4<f32>) -> f32 {
+    let brightness_adjustment = g.x * b + g.y;
+    let correction = brightness_adjustment * a + (g.z * b + g.w);
+    return a + a * (1.0 - a) * correction;
+}
+
+fn apply_alpha_correction3(a: vec3<f32>, b: vec3<f32>, g: vec4<f32>) -> vec3<f32> {
     let brightness_adjustment = g.x * b + g.y;
     let correction = brightness_adjustment * a + (g.z * b + g.w);
     return a + a * (1.0 - a) * correction;
@@ -58,6 +69,13 @@ fn apply_contrast_and_gamma_correction(sample: f32, color: vec3<f32>, enhanced_c
 
     let contrasted = enhance_contrast(sample, enhanced_contrast);
     return apply_alpha_correction(contrasted, brightness, gamma_ratios);
+}
+
+fn apply_contrast_and_gamma_correction3(sample: vec3<f32>, color: vec3<f32>, enhanced_contrast_factor: f32, gamma_ratios: vec4<f32>) -> vec3<f32> {
+    let enhanced_contrast = light_on_dark_contrast(enhanced_contrast_factor, color);
+
+    let contrasted = enhance_contrast3(sample, enhanced_contrast);
+    return apply_alpha_correction3(contrasted, color, gamma_ratios);
 }
 
 struct GlobalParams {
@@ -1190,7 +1208,6 @@ fn fs_mono_sprite(input: MonoSpriteVarying) -> @location(0) vec4<f32> {
         return vec4<f32>(0.0);
     }
 
-    // convert to srgb space as the rest of the code (output swapchain) expects that
     return blend_color(input.color, alpha_corrected);
 }
 
@@ -1296,4 +1313,58 @@ fn fs_surface(input: SurfaceVarying) -> @location(0) vec4<f32> {
         1.0);
 
     return ycbcr_to_RGB * y_cb_cr;
+}
+
+// --- subpixel sprites --- //
+
+struct SubpixelSprite {
+    order: u32,
+    pad: u32,
+    bounds: Bounds,
+    content_mask: Bounds,
+    color: Hsla,
+    tile: AtlasTile,
+    transformation: TransformationMatrix,
+}
+var<storage, read> b_subpixel_sprites: array<SubpixelSprite>;
+
+struct SubpixelSpriteOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) tile_position: vec2<f32>,
+    @location(1) @interpolate(flat) color: vec4<f32>,
+    @location(3) clip_distances: vec4<f32>,
+}
+
+struct SubpixelSpriteFragmentOutput {
+    @location(0) @blend_src(0) color0: vec4<f32>,
+    @location(0) @blend_src(1) color1: vec4<f32>,
+}
+
+@vertex
+fn vs_subpixel_sprite(@builtin(vertex_index) vertex_id: u32, @builtin(instance_index) instance_id: u32) -> SubpixelSpriteOutput {
+    let unit_vertex = vec2<f32>(f32(vertex_id & 1u), 0.5 * f32(vertex_id & 2u));
+    let sprite = b_subpixel_sprites[instance_id];
+
+    var out = SubpixelSpriteOutput();
+    out.position = to_device_position_transformed(unit_vertex, sprite.bounds, sprite.transformation);
+    out.tile_position = to_tile_position(unit_vertex, sprite.tile);
+    out.color = hsla_to_rgba(sprite.color);
+    out.clip_distances = distance_from_clip_rect_transformed(unit_vertex, sprite.bounds, sprite.content_mask, sprite.transformation);
+    return out;
+}
+
+@fragment
+fn fs_subpixel_sprite(input: SubpixelSpriteOutput) -> SubpixelSpriteFragmentOutput {
+    let sample = textureSample(t_sprite, s_sprite, input.tile_position).rgb;
+    let alpha_corrected = apply_contrast_and_gamma_correction3(sample, input.color.rgb, grayscale_enhanced_contrast, gamma_ratios);
+
+    // Alpha clip after using the derivatives.
+    if (any(input.clip_distances < vec4<f32>(0.0))) {
+        return SubpixelSpriteFragmentOutput(vec4<f32>(0.0), vec4<f32>(0.0));
+    }
+
+    var out = SubpixelSpriteFragmentOutput();
+    out.color0 = vec4<f32>(input.color.rgb, 1.0);
+    out.color1 = vec4<f32>(input.color.a * alpha_corrected, 1.0);
+    return out;
 }

--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -1,8 +1,6 @@
 use std::{
-    cell::Cell,
     env,
     path::{Path, PathBuf},
-    rc::Rc,
     sync::Arc,
 };
 #[cfg(any(feature = "wayland", feature = "x11"))]
@@ -147,7 +145,6 @@ pub(crate) struct LinuxCommon {
     pub(crate) callbacks: PlatformHandlers,
     pub(crate) signal: LoopSignal,
     pub(crate) menus: Vec<OwnedMenu>,
-    pub(crate) subpixel_render_enabled: Rc<Cell<Option<bool>>>,
 }
 
 impl LinuxCommon {
@@ -174,7 +171,6 @@ impl LinuxCommon {
             callbacks,
             signal,
             menus: Vec::new(),
-            subpixel_render_enabled: Rc::new(Cell::new(None)),
         };
 
         (common, main_receiver)
@@ -204,10 +200,6 @@ impl<P: LinuxClient + 'static> Platform for P {
 
     fn on_keyboard_layout_change(&self, callback: Box<dyn FnMut()>) {
         self.with_common(|common| common.callbacks.keyboard_layout_change = Some(callback));
-    }
-
-    fn set_subpixel_rendering_enabled(&self, enabled: Option<bool>) {
-        self.with_common(|common| common.subpixel_render_enabled.set(enabled));
     }
 
     fn run(&self, on_finish_launching: Box<dyn FnOnce()>) {

--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -1,6 +1,7 @@
 use std::{
     env,
     path::{Path, PathBuf},
+    rc::Rc,
     sync::Arc,
 };
 #[cfg(any(feature = "wayland", feature = "x11"))]

--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -1,4 +1,5 @@
 use std::{
+    cell::Cell,
     env,
     path::{Path, PathBuf},
     rc::Rc,
@@ -146,6 +147,7 @@ pub(crate) struct LinuxCommon {
     pub(crate) callbacks: PlatformHandlers,
     pub(crate) signal: LoopSignal,
     pub(crate) menus: Vec<OwnedMenu>,
+    pub(crate) subpixel_render_enabled: Rc<Cell<Option<bool>>>,
 }
 
 impl LinuxCommon {
@@ -172,6 +174,7 @@ impl LinuxCommon {
             callbacks,
             signal,
             menus: Vec::new(),
+            subpixel_render_enabled: Rc::new(Cell::new(None)),
         };
 
         (common, main_receiver)
@@ -201,6 +204,10 @@ impl<P: LinuxClient + 'static> Platform for P {
 
     fn on_keyboard_layout_change(&self, callback: Box<dyn FnMut()>) {
         self.with_common(|common| common.callbacks.keyboard_layout_change = Some(callback));
+    }
+
+    fn set_subpixel_rendering_enabled(&self, enabled: Option<bool>) {
+        self.with_common(|common| common.subpixel_render_enabled.set(enabled));
     }
 
     fn run(&self, on_finish_launching: Box<dyn FnOnce()>) {

--- a/crates/gpui/src/platform/linux/text_system.rs
+++ b/crates/gpui/src/platform/linux/text_system.rs
@@ -6,8 +6,8 @@ use crate::{
 use anyhow::{Context as _, Ok, Result};
 use collections::HashMap;
 use cosmic_text::{
-    Attrs, AttrsList, CacheKey, Family, Font as CosmicTextFont, FontFeatures as CosmicFontFeatures,
-    FontSystem, ShapeBuffer, ShapeLine, SwashCache,
+    Attrs, AttrsList, Family, Font as CosmicTextFont, FontFeatures as CosmicFontFeatures,
+    FontSystem, ShapeBuffer, ShapeLine,
 };
 
 use itertools::Itertools;
@@ -18,6 +18,10 @@ use pathfinder_geometry::{
 };
 use smallvec::SmallVec;
 use std::{borrow::Cow, sync::Arc};
+use swash::{
+    scale::{Render, ScaleContext, Source, StrikeWith},
+    zeno::{Format, Transform, Vector},
+};
 
 pub(crate) struct CosmicTextSystem(RwLock<CosmicTextSystemState>);
 
@@ -34,9 +38,9 @@ impl FontKey {
 }
 
 struct CosmicTextSystemState {
-    swash_cache: SwashCache,
     font_system: FontSystem,
     scratch: ShapeBuffer,
+    swash_scale_context: ScaleContext,
     /// Contains all already loaded fonts, including all faces. Indexed by `FontId`.
     loaded_fonts: Vec<LoadedFont>,
     /// Caches the `FontId`s associated with a specific family to avoid iterating the font database
@@ -57,8 +61,8 @@ impl CosmicTextSystem {
 
         Self(RwLock::new(CosmicTextSystemState {
             font_system,
-            swash_cache: SwashCache::new(),
             scratch: ShapeBuffer::default(),
+            swash_scale_context: ScaleContext::new(),
             loaded_fonts: Vec::new(),
             font_ids_by_family_cache: HashMap::default(),
         }))
@@ -273,26 +277,7 @@ impl CosmicTextSystemState {
     }
 
     fn raster_bounds(&mut self, params: &RenderGlyphParams) -> Result<Bounds<DevicePixels>> {
-        let font = &self.loaded_fonts[params.font_id.0].font;
-        let subpixel_shift = point(
-            params.subpixel_variant.x as f32 / SUBPIXEL_VARIANTS_X as f32 / params.scale_factor,
-            params.subpixel_variant.y as f32 / SUBPIXEL_VARIANTS_Y as f32 / params.scale_factor,
-        );
-        let image = self
-            .swash_cache
-            .get_image(
-                &mut self.font_system,
-                CacheKey::new(
-                    font.id(),
-                    params.glyph_id.0 as u16,
-                    (params.font_size * params.scale_factor).into(),
-                    (subpixel_shift.x, subpixel_shift.y.trunc()),
-                    cosmic_text::CacheKeyFlags::empty(),
-                )
-                .0,
-            )
-            .clone()
-            .with_context(|| format!("no image for {params:?} in font {font:?}"))?;
+        let image = self.render_glyph_image(params)?;
         Ok(Bounds {
             origin: point(image.placement.left.into(), (-image.placement.top).into()),
             size: size(image.placement.width.into(), image.placement.height.into()),
@@ -307,38 +292,72 @@ impl CosmicTextSystemState {
     ) -> Result<(Size<DevicePixels>, Vec<u8>)> {
         if glyph_bounds.size.width.0 == 0 || glyph_bounds.size.height.0 == 0 {
             anyhow::bail!("glyph bounds are empty");
-        } else {
-            let bitmap_size = glyph_bounds.size;
-            let font = &self.loaded_fonts[params.font_id.0].font;
-            let subpixel_shift = point(
-                params.subpixel_variant.x as f32 / SUBPIXEL_VARIANTS_X as f32 / params.scale_factor,
-                params.subpixel_variant.y as f32 / SUBPIXEL_VARIANTS_Y as f32 / params.scale_factor,
-            );
-            let mut image = self
-                .swash_cache
-                .get_image(
-                    &mut self.font_system,
-                    CacheKey::new(
-                        font.id(),
-                        params.glyph_id.0 as u16,
-                        (params.font_size * params.scale_factor).into(),
-                        (subpixel_shift.x, subpixel_shift.y.trunc()),
-                        cosmic_text::CacheKeyFlags::empty(),
-                    )
-                    .0,
-                )
-                .clone()
-                .with_context(|| format!("no image for {params:?} in font {font:?}"))?;
+        }
 
-            if params.is_emoji {
+        let mut image = self.render_glyph_image(params)?;
+        let bitmap_size = glyph_bounds.size;
+        match image.content {
+            swash::scale::image::Content::Color | swash::scale::image::Content::SubpixelMask => {
                 // Convert from RGBA to BGRA.
                 for pixel in image.data.chunks_exact_mut(4) {
                     pixel.swap(0, 2);
                 }
+                Ok((bitmap_size, image.data))
             }
-
-            Ok((bitmap_size, image.data))
+            swash::scale::image::Content::Mask => Ok((bitmap_size, image.data)),
         }
+    }
+
+    fn render_glyph_image(
+        &mut self,
+        params: &RenderGlyphParams,
+    ) -> Result<swash::scale::image::Image> {
+        let loaded_font = &self.loaded_fonts[params.font_id.0];
+        let font_ref = loaded_font.font.as_swash();
+        let pixel_size = params.font_size.0;
+
+        let subpixel_offset = Vector::new(
+            params.subpixel_variant.x as f32 / SUBPIXEL_VARIANTS_X as f32 / params.scale_factor,
+            params.subpixel_variant.y as f32 / SUBPIXEL_VARIANTS_Y as f32 / params.scale_factor,
+        );
+
+        let mut scaler = self
+            .swash_scale_context
+            .builder(font_ref)
+            .size(pixel_size)
+            .hint(true)
+            .build();
+
+        let sources: &[Source] = if params.is_emoji {
+            &[
+                Source::ColorOutline(0),
+                Source::ColorBitmap(StrikeWith::BestFit),
+                Source::Outline,
+            ]
+        } else {
+            &[Source::Outline]
+        };
+
+        let mut renderer = Render::new(sources);
+        renderer.transform(Some(Transform {
+            xx: params.scale_factor,
+            xy: 0.0,
+            yx: 0.0,
+            yy: params.scale_factor,
+            x: 0.0,
+            y: 0.0,
+        }));
+
+        if params.subpixel_rendering {
+            renderer.format(Format::Subpixel).offset(subpixel_offset);
+        } else {
+            renderer.format(Format::Alpha).offset(subpixel_offset);
+        }
+
+        let glyph_id: u16 = params.glyph_id.0.try_into()?;
+        renderer
+            .render(&mut scaler, glyph_id)
+            .with_context(|| format!("unable to render glyph via swash for {params:?}"))
     }
 
     /// This is used when cosmic_text has chosen a fallback font instead of using the requested

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -204,7 +204,7 @@ pub struct Output {
 pub(crate) struct WaylandClientState {
     serial_tracker: SerialTracker,
     globals: Globals,
-    gpu_context: BladeContext,
+    pub gpu_context: BladeContext,
     wl_seat: wl_seat::WlSeat, // TODO: Multi seat support
     wl_pointer: Option<wl_pointer::WlPointer>,
     wl_keyboard: Option<wl_keyboard::WlKeyboard>,
@@ -247,7 +247,7 @@ pub(crate) struct WaylandClientState {
     cursor: Cursor,
     pending_activation: Option<PendingActivation>,
     event_loop: Option<EventLoop<'static, WaylandClientStatePtr>>,
-    common: LinuxCommon,
+    pub common: LinuxCommon,
 }
 
 pub struct DragState {

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -1220,8 +1220,8 @@ impl PlatformWindow for WaylandWindow {
         update_window(state);
     }
 
-    fn is_opaque(&self) -> bool {
-        self.borrow().background_appearance == WindowBackgroundAppearance::Opaque
+    fn background_appearance(&self) -> WindowBackgroundAppearance {
+        self.borrow().background_appearance
     }
 
     fn is_subpixel_rendering_supported(&self) -> bool {

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -1220,18 +1220,14 @@ impl PlatformWindow for WaylandWindow {
         update_window(state);
     }
 
-    fn is_subpixel_rendering_enabled(&self) -> bool {
-        if self.borrow().background_appearance != WindowBackgroundAppearance::Opaque {
-            return false;
-        }
+    fn is_opaque(&self) -> bool {
+        self.borrow().background_appearance == WindowBackgroundAppearance::Opaque
+    }
 
+    fn is_subpixel_rendering_supported(&self) -> bool {
         let client = self.borrow().client.get_client();
         let state = client.borrow();
-        state
-            .common
-            .subpixel_render_enabled
-            .get()
-            .unwrap_or_else(|| state.gpu_context.supports_dual_source_blending())
+        state.gpu_context.supports_dual_source_blending()
     }
 
     fn minimize(&self) {

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -1307,8 +1307,7 @@ impl PlatformWindow for WaylandWindow {
 
     fn draw(&self, scene: &Scene) {
         let mut state = self.borrow_mut();
-        let opaque = state.background_appearance == WindowBackgroundAppearance::Opaque;
-        state.renderer.draw(scene, opaque);
+        state.renderer.draw(scene);
     }
 
     fn completed_frame(&self) {

--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -177,7 +177,7 @@ pub struct X11ClientState {
     pub(crate) last_location: Point<Pixels>,
     pub(crate) current_count: usize,
 
-    gpu_context: BladeContext,
+    pub(crate) gpu_context: BladeContext,
 
     pub(crate) scale_factor: f32,
 

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -1569,8 +1569,7 @@ impl PlatformWindow for X11Window {
 
     fn draw(&self, scene: &Scene) {
         let mut inner = self.0.state.borrow_mut();
-        let opaque = inner.background_appearance == WindowBackgroundAppearance::Opaque;
-        inner.renderer.draw(scene, opaque);
+        inner.renderer.draw(scene);
     }
 
     fn sprite_atlas(&self) -> Arc<dyn PlatformAtlas> {

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -1459,11 +1459,11 @@ impl PlatformWindow for X11Window {
         state.renderer.update_transparency(transparent);
     }
 
-    fn is_subpixel_rendering_enabled(&self) -> bool {
-        if self.0.state.borrow().background_appearance != WindowBackgroundAppearance::Opaque {
-            return false;
-        }
+    fn is_opaque(&self) -> bool {
+        self.0.state.borrow().background_appearance == WindowBackgroundAppearance::Opaque
+    }
 
+    fn is_subpixel_rendering_supported(&self) -> bool {
         self.0
             .state
             .borrow()
@@ -1472,11 +1472,7 @@ impl PlatformWindow for X11Window {
             .upgrade()
             .map(|ref_cell| {
                 let state = ref_cell.borrow();
-                state
-                    .common
-                    .subpixel_render_enabled
-                    .get()
-                    .unwrap_or_else(|| state.gpu_context.supports_dual_source_blending())
+                state.gpu_context.supports_dual_source_blending()
             })
             .unwrap_or_default()
     }

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -1459,8 +1459,8 @@ impl PlatformWindow for X11Window {
         state.renderer.update_transparency(transparent);
     }
 
-    fn is_opaque(&self) -> bool {
-        self.0.state.borrow().background_appearance == WindowBackgroundAppearance::Opaque
+    fn background_appearance(&self) -> WindowBackgroundAppearance {
+        self.0.state.borrow().background_appearance
     }
 
     fn is_subpixel_rendering_supported(&self) -> bool {

--- a/crates/gpui/src/platform/mac/metal_atlas.rs
+++ b/crates/gpui/src/platform/mac/metal_atlas.rs
@@ -66,6 +66,7 @@ impl PlatformAtlas for MetalAtlas {
         let textures = match id.kind {
             AtlasTextureKind::Monochrome => &mut lock.monochrome_textures,
             AtlasTextureKind::Polychrome => &mut lock.polychrome_textures,
+            AtlasTextureKind::Subpixel => unreachable!(),
         };
 
         let Some(texture_slot) = textures
@@ -99,6 +100,7 @@ impl MetalAtlasState {
             let textures = match texture_kind {
                 AtlasTextureKind::Monochrome => &mut self.monochrome_textures,
                 AtlasTextureKind::Polychrome => &mut self.polychrome_textures,
+                AtlasTextureKind::Subpixel => unreachable!(),
             };
 
             if let Some(tile) = textures
@@ -143,6 +145,7 @@ impl MetalAtlasState {
                 pixel_format = metal::MTLPixelFormat::BGRA8Unorm;
                 usage = metal::MTLTextureUsage::ShaderRead;
             }
+            AtlasTextureKind::Subpixel => unreachable!(),
         }
         texture_descriptor.set_pixel_format(pixel_format);
         texture_descriptor.set_usage(usage);
@@ -151,6 +154,7 @@ impl MetalAtlasState {
         let texture_list = match kind {
             AtlasTextureKind::Monochrome => &mut self.monochrome_textures,
             AtlasTextureKind::Polychrome => &mut self.polychrome_textures,
+            AtlasTextureKind::Subpixel => unreachable!(),
         };
 
         let index = texture_list.free_list.pop();
@@ -181,6 +185,7 @@ impl MetalAtlasState {
         let textures = match id.kind {
             crate::AtlasTextureKind::Monochrome => &self.monochrome_textures,
             crate::AtlasTextureKind::Polychrome => &self.polychrome_textures,
+            crate::AtlasTextureKind::Subpixel => unreachable!(),
         };
         textures[id.index as usize].as_ref().unwrap()
     }

--- a/crates/gpui/src/platform/mac/metal_renderer.rs
+++ b/crates/gpui/src/platform/mac/metal_renderer.rs
@@ -534,6 +534,7 @@ impl MetalRenderer {
                     viewport_size,
                     command_encoder,
                 ),
+                PrimitiveBatch::SubpixelSprites { .. } => unreachable!(),
             };
             if !ok {
                 command_encoder.end_encoding();

--- a/crates/gpui/src/platform/mac/text_system.rs
+++ b/crates/gpui/src/platform/mac/text_system.rs
@@ -2,7 +2,7 @@ use crate::{
     Bounds, DevicePixels, Font, FontFallbacks, FontFeatures, FontId, FontMetrics, FontRun,
     FontStyle, FontWeight, GlyphId, LineLayout, Pixels, PlatformTextSystem, Point,
     RenderGlyphParams, Result, SUBPIXEL_VARIANTS_X, ShapedGlyph, ShapedRun, SharedString, Size,
-    point, px, size, swap_rgba_pa_to_bgra,
+    TextRenderingMode, point, px, size, swap_rgba_pa_to_bgra,
 };
 use anyhow::anyhow;
 use cocoa::appkit::CGFloat;
@@ -203,6 +203,14 @@ impl PlatformTextSystem for MacTextSystem {
 
     fn layout_line(&self, text: &str, font_size: Pixels, font_runs: &[FontRun]) -> LineLayout {
         self.0.write().layout_line(text, font_size, font_runs)
+    }
+
+    fn recommended_rendering_mode(
+        &self,
+        _font_id: FontId,
+        _font_size: Pixels,
+    ) -> TextRenderingMode {
+        TextRenderingMode::Grayscale
     }
 }
 

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -398,6 +398,7 @@ struct MacWindowState {
     native_window: id,
     native_view: NonNull<Object>,
     blurred_view: Option<id>,
+    background_appearance: WindowBackgroundAppearance,
     display_link: Option<DisplayLink>,
     renderer: renderer::Renderer,
     request_frame_callback: Option<Box<dyn FnMut(RequestFrameOptions)>>,
@@ -702,6 +703,7 @@ impl MacWindow {
                 native_window,
                 native_view: NonNull::new_unchecked(native_view),
                 blurred_view: None,
+                background_appearance: WindowBackgroundAppearance::Opaque,
                 display_link: None,
                 renderer: renderer::new_renderer(
                     renderer_context,
@@ -1300,6 +1302,7 @@ impl PlatformWindow for MacWindow {
 
     fn set_background_appearance(&self, background_appearance: WindowBackgroundAppearance) {
         let mut this = self.0.as_ref().lock();
+        this.background_appearance = background_appearance;
 
         let opaque = background_appearance == WindowBackgroundAppearance::Opaque;
         this.renderer.update_transparency(!opaque);
@@ -1354,8 +1357,8 @@ impl PlatformWindow for MacWindow {
         }
     }
 
-    fn is_opaque(&self) -> bool {
-        self.0.as_ref().lock().renderer.layer().is_opaque()
+    fn background_appearance(&self) -> WindowBackgroundAppearance {
+        self.0.as_ref().lock().background_appearance
     }
 
     fn is_subpixel_rendering_supported(&self) -> bool {

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -1354,6 +1354,14 @@ impl PlatformWindow for MacWindow {
         }
     }
 
+    fn is_opaque(&self) -> bool {
+        self.borrow().renderer.layer().is_opaque()
+    }
+
+    fn is_subpixel_rendering_supported(&self) -> bool {
+        false
+    }
+
     fn set_edited(&mut self, edited: bool) {
         unsafe {
             let window = self.0.lock().native_window;

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -1355,7 +1355,7 @@ impl PlatformWindow for MacWindow {
     }
 
     fn is_opaque(&self) -> bool {
-        self.borrow().renderer.layer().is_opaque()
+        self.0.as_ref().lock().renderer.layer().is_opaque()
     }
 
     fn is_subpixel_rendering_supported(&self) -> bool {

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -199,6 +199,14 @@ impl PlatformWindow for TestWindow {
         false
     }
 
+    fn is_opaque(&self) -> bool {
+        true
+    }
+
+    fn is_subpixel_rendering_supported(&self) -> bool {
+        false
+    }
+
     fn set_title(&mut self, title: &str) {
         self.0.lock().title = Some(title.to_owned());
     }

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -199,8 +199,8 @@ impl PlatformWindow for TestWindow {
         false
     }
 
-    fn is_opaque(&self) -> bool {
-        true
+    fn background_appearance(&self) -> WindowBackgroundAppearance {
+        WindowBackgroundAppearance::Opaque
     }
 
     fn is_subpixel_rendering_supported(&self) -> bool {

--- a/crates/gpui/src/platform/windows/alpha_correction.hlsl
+++ b/crates/gpui/src/platform/windows/alpha_correction.hlsl
@@ -17,9 +17,19 @@ float enhance_contrast(float alpha, float k) {
     return alpha * (k + 1.0f) / (alpha * k + 1.0f);
 }
 
+float3 enhance_contrast3(float3 alpha, float k) {
+    return alpha * (k + 1.0f) / (alpha * k + 1.0f);
+}
+
 float apply_alpha_correction(float a, float b, float4 g) {
     float brightness_adjustment = g.x * b + g.y;
     float correction = brightness_adjustment * a + (g.z * b + g.w);
+    return a + a * (1.0f - a) * correction;
+}
+
+float3 apply_alpha_correction3(float3 a, float3 b, float4 g) {
+    float3 brightness_adjustment = g.x * b + g.y;
+    float3 correction = brightness_adjustment * a + (g.z * b + g.w);
     return a + a * (1.0f - a) * correction;
 }
 
@@ -29,4 +39,11 @@ float apply_contrast_and_gamma_correction(float sample, float3 color, float enha
 
     float contrasted = enhance_contrast(sample, enhanced_contrast);
     return apply_alpha_correction(contrasted, brightness, gamma_ratios);
+}
+
+float3 apply_contrast_and_gamma_correction3(float3 sample, float3 color, float enhanced_contrast_factor, float4 gamma_ratios) {
+    float enhanced_contrast = light_on_dark_contrast(enhanced_contrast_factor, color);
+
+    float3 contrasted = enhance_contrast3(sample, enhanced_contrast);
+    return apply_alpha_correction3(contrasted, color, gamma_ratios);
 }

--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -1,6 +1,5 @@
 use std::{borrow::Cow, sync::Arc};
 
-pub(crate) const ENABLE_SUBPIXEL_TEXT_RENDERING: bool = true;
 use ::util::ResultExt;
 use anyhow::{Context, Result};
 use collections::HashMap;
@@ -760,7 +759,7 @@ impl DirectWriteState {
             m => m,
         };
 
-        let antialias_mode = if ENABLE_SUBPIXEL_TEXT_RENDERING {
+        let antialias_mode = if params.subpixel_rendering {
             DWRITE_TEXT_ANTIALIAS_MODE_CLEARTYPE
         } else {
             DWRITE_TEXT_ANTIALIAS_MODE_GRAYSCALE
@@ -784,7 +783,7 @@ impl DirectWriteState {
     fn raster_bounds(&self, params: &RenderGlyphParams) -> Result<Bounds<DevicePixels>> {
         let glyph_analysis = self.create_glyph_run_analysis(params)?;
 
-        let texture_type = if ENABLE_SUBPIXEL_TEXT_RENDERING {
+        let texture_type = if params.subpixel_rendering {
             DWRITE_TEXTURE_CLEARTYPE_3x1
         } else {
             DWRITE_TEXTURE_ALIASED_1x1
@@ -852,7 +851,7 @@ impl DirectWriteState {
         params: &RenderGlyphParams,
         glyph_bounds: Bounds<DevicePixels>,
     ) -> Result<Vec<u8>> {
-        if !ENABLE_SUBPIXEL_TEXT_RENDERING {
+        if !params.subpixel_rendering {
             let mut bitmap_data =
                 vec![0u8; glyph_bounds.size.width.0 as usize * glyph_bounds.size.height.0 as usize];
 

--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -1141,6 +1141,7 @@ impl DirectWriteState {
         let crate::FontInfo {
             gamma_ratios,
             grayscale_enhanced_contrast,
+            ..
         } = DirectXRenderer::get_font_info();
 
         for layer in glyph_layers {

--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -915,10 +915,17 @@ impl DirectWriteState {
         for pixel_ix in (0..pixel_count).rev() {
             let src = pixel_ix * 3;
             let dst = pixel_ix * 4;
-            bitmap_data[dst] = bitmap_data[src];
-            bitmap_data[dst + 1] = bitmap_data[src + 1];
-            bitmap_data[dst + 2] = bitmap_data[src + 2];
-            bitmap_data[dst + 3] = 0;
+            (
+                bitmap_data[dst],
+                bitmap_data[dst + 1],
+                bitmap_data[dst + 2],
+                bitmap_data[dst + 3],
+            ) = (
+                bitmap_data[src],
+                bitmap_data[src + 1],
+                bitmap_data[src + 2],
+                0,
+            );
         }
 
         Ok(bitmap_data)

--- a/crates/gpui/src/platform/windows/directx_renderer.rs
+++ b/crates/gpui/src/platform/windows/directx_renderer.rs
@@ -1539,8 +1539,8 @@ pub(crate) mod shader_resources {
                     ShaderTarget::Fragment => MONOCHROME_SPRITE_FRAGMENT_BYTES,
                 },
                 ShaderModule::SubpixelSprite => match target {
-                    ShaderTarget::Vertex => MONOCHROME_SPRITE_VERTEX_BYTES,
-                    ShaderTarget::Fragment => MONOCHROME_SPRITE_SUBPIXEL_FRAGMENT_BYTES,
+                    ShaderTarget::Vertex => SUBPIXEL_SPRITE_VERTEX_BYTES,
+                    ShaderTarget::Fragment => SUBPIXEL_SPRITE_FRAGMENT_BYTES,
                 },
                 ShaderModule::PolychromeSprite => match target {
                     ShaderTarget::Vertex => POLYCHROME_SPRITE_VERTEX_BYTES,

--- a/crates/gpui/src/platform/windows/directx_renderer.rs
+++ b/crates/gpui/src/platform/windows/directx_renderer.rs
@@ -835,7 +835,7 @@ impl DirectXRenderPipelines {
             "subpixel_sprite_pipeline",
             ShaderModule::SubpixelSprite,
             512,
-            create_subpixel_blend_state(device)?,
+            create_blend_state_for_subpixel_rendering(device)?,
         )?;
         let poly_sprites = PipelineState::new(
             device,
@@ -1301,7 +1301,7 @@ fn create_blend_state(device: &ID3D11Device) -> Result<ID3D11BlendState> {
 }
 
 #[inline]
-fn create_subpixel_blend_state(device: &ID3D11Device) -> Result<ID3D11BlendState> {
+fn create_blend_state_for_subpixel_rendering(device: &ID3D11Device) -> Result<ID3D11BlendState> {
     let mut desc = D3D11_BLEND_DESC::default();
     desc.RenderTarget[0].BlendEnable = true.into();
     desc.RenderTarget[0].BlendOp = D3D11_BLEND_OP_ADD;

--- a/crates/gpui/src/platform/windows/directx_renderer.rs
+++ b/crates/gpui/src/platform/windows/directx_renderer.rs
@@ -1311,7 +1311,7 @@ fn create_blend_state_for_subpixel_rendering(device: &ID3D11Device) -> Result<ID
     // It does not make sense to draw transparent subpixel-rendered text, since it cannot be meaningfully alpha-blended onto anything else.
     desc.RenderTarget[0].SrcBlendAlpha = D3D11_BLEND_ONE;
     desc.RenderTarget[0].DestBlendAlpha = D3D11_BLEND_ZERO;
-    desc.RenderTarget[0].RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_ALL.0 as u8;
+    desc.RenderTarget[0].RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_ALL.0 as u8 & !D3D11_COLOR_WRITE_ENABLE_ALPHA.0 as u8;
 
     unsafe {
         let mut state = None;

--- a/crates/gpui/src/platform/windows/directx_renderer.rs
+++ b/crates/gpui/src/platform/windows/directx_renderer.rs
@@ -34,6 +34,7 @@ const PATH_MULTISAMPLE_COUNT: u32 = 4;
 pub(crate) struct FontInfo {
     pub gamma_ratios: [f32; 4],
     pub grayscale_enhanced_contrast: f32,
+    pub subpixel_enhanced_contrast: f32,
 }
 
 pub(crate) struct DirectXRenderer {
@@ -196,7 +197,7 @@ impl DirectXRenderer {
                 gamma_ratios: self.font_info.gamma_ratios,
                 viewport_size: [resources.viewport.Width, resources.viewport.Height],
                 grayscale_enhanced_contrast: self.font_info.grayscale_enhanced_contrast,
-                _pad: 0,
+                subpixel_enhanced_contrast: self.font_info.subpixel_enhanced_contrast,
             }],
         )?;
         unsafe {
@@ -708,6 +709,7 @@ impl DirectXRenderer {
             FontInfo {
                 gamma_ratios: get_gamma_correction_ratios(render_params.GetGamma()),
                 grayscale_enhanced_contrast: render_params.GetGrayscaleEnhancedContrast(),
+                subpixel_enhanced_contrast: render_params.GetEnhancedContrast(),
             }
         })
     }
@@ -927,7 +929,7 @@ struct GlobalParams {
     gamma_ratios: [f32; 4],
     viewport_size: [f32; 2],
     grayscale_enhanced_contrast: f32,
-    _pad: u32,
+    subpixel_enhanced_contrast: f32,
 }
 
 struct PipelineState<T> {
@@ -1311,7 +1313,8 @@ fn create_blend_state_for_subpixel_rendering(device: &ID3D11Device) -> Result<ID
     // It does not make sense to draw transparent subpixel-rendered text, since it cannot be meaningfully alpha-blended onto anything else.
     desc.RenderTarget[0].SrcBlendAlpha = D3D11_BLEND_ONE;
     desc.RenderTarget[0].DestBlendAlpha = D3D11_BLEND_ZERO;
-    desc.RenderTarget[0].RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_ALL.0 as u8 & !D3D11_COLOR_WRITE_ENABLE_ALPHA.0 as u8;
+    desc.RenderTarget[0].RenderTargetWriteMask =
+        D3D11_COLOR_WRITE_ENABLE_ALL.0 as u8 & !D3D11_COLOR_WRITE_ENABLE_ALPHA.0 as u8;
 
     unsafe {
         let mut state = None;

--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -44,7 +44,6 @@ pub(crate) struct WindowsPlatform {
     invalidate_devices: Arc<AtomicBool>,
     handle: HWND,
     disable_direct_composition: bool,
-    subpixel_render_enabled: Rc<Cell<Option<bool>>>,
 }
 
 struct WindowsPlatformInner {
@@ -170,7 +169,6 @@ impl WindowsPlatform {
             windows_version,
             drop_target_helper,
             invalidate_devices: Arc::new(AtomicBool::new(false)),
-            subpixel_render_enabled: Rc::new(Cell::new(None)),
         })
     }
 
@@ -205,7 +203,6 @@ impl WindowsPlatform {
             disable_direct_composition: self.disable_direct_composition,
             directx_devices: self.inner.state.directx_devices.borrow().clone().unwrap(),
             invalidate_devices: self.invalidate_devices.clone(),
-            subpixel_render_enabled: self.subpixel_render_enabled.clone(),
         }
     }
 
@@ -725,10 +722,6 @@ impl Platform for WindowsPlatform {
     ) -> Vec<SmallVec<[PathBuf; 2]>> {
         self.update_jump_list(menus, entries)
     }
-
-    fn set_subpixel_rendering_enabled(&self, enabled: Option<bool>) {
-        self.subpixel_render_enabled.set(enabled);
-    }
 }
 
 impl WindowsPlatformInner {
@@ -947,7 +940,6 @@ pub(crate) struct WindowCreationInfo {
     /// Flag to instruct the `VSyncProvider` thread to invalidate the directx devices
     /// as resizing them has failed, causing us to have lost at least the render target.
     pub(crate) invalidate_devices: Arc<AtomicBool>,
-    pub(crate) subpixel_render_enabled: Rc<Cell<Option<bool>>>,
 }
 
 struct PlatformWindowCreateContext {

--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -44,6 +44,7 @@ pub(crate) struct WindowsPlatform {
     invalidate_devices: Arc<AtomicBool>,
     handle: HWND,
     disable_direct_composition: bool,
+    subpixel_render_enabled: Rc<Cell<Option<bool>>>,
 }
 
 struct WindowsPlatformInner {
@@ -169,6 +170,7 @@ impl WindowsPlatform {
             windows_version,
             drop_target_helper,
             invalidate_devices: Arc::new(AtomicBool::new(false)),
+            subpixel_render_enabled: Rc::new(Cell::new(None)),
         })
     }
 
@@ -203,6 +205,7 @@ impl WindowsPlatform {
             disable_direct_composition: self.disable_direct_composition,
             directx_devices: self.inner.state.directx_devices.borrow().clone().unwrap(),
             invalidate_devices: self.invalidate_devices.clone(),
+            subpixel_render_enabled: self.subpixel_render_enabled.clone(),
         }
     }
 
@@ -722,6 +725,10 @@ impl Platform for WindowsPlatform {
     ) -> Vec<SmallVec<[PathBuf; 2]>> {
         self.update_jump_list(menus, entries)
     }
+
+    fn set_subpixel_rendering_enabled(&self, enabled: Option<bool>) {
+        self.subpixel_render_enabled.set(enabled);
+    }
 }
 
 impl WindowsPlatformInner {
@@ -940,6 +947,7 @@ pub(crate) struct WindowCreationInfo {
     /// Flag to instruct the `VSyncProvider` thread to invalidate the directx devices
     /// as resizing them has failed, causing us to have lost at least the render target.
     pub(crate) invalidate_devices: Arc<AtomicBool>,
+    pub(crate) subpixel_render_enabled: Rc<Cell<Option<bool>>>,
 }
 
 struct PlatformWindowCreateContext {

--- a/crates/gpui/src/platform/windows/shaders.hlsl
+++ b/crates/gpui/src/platform/windows/shaders.hlsl
@@ -4,15 +4,15 @@ cbuffer GlobalParams: register(b0) {
     float4 gamma_ratios;
     float2 global_viewport_size;
     float grayscale_enhanced_contrast;
-    uint _pad;
+    float subpixel_enhanced_contrast;
 };
 
 Texture2D<float4> t_sprite: register(t0);
 SamplerState s_sprite: register(s0);
 
-struct DualSourceColorOutput {
-    float4 color0 : SV_Target0;
-    float4 color1 : SV_Target1;
+struct SubpixelSpriteFragmentOutput {
+    float4 foreground : SV_Target0;
+    float4 alpha : SV_Target1;
 };
 
 struct Bounds {
@@ -1128,13 +1128,13 @@ MonochromeSpriteVertexOutput subpixel_sprite_vertex(uint vertex_id: SV_VertexID,
     return monochrome_sprite_vertex(vertex_id, sprite_id);
 }
 
-DualSourceColorOutput subpixel_sprite_fragment(MonochromeSpriteFragmentInput input) {
+SubpixelSpriteFragmentOutput subpixel_sprite_fragment(MonochromeSpriteFragmentInput input) {
     float3 sample = t_sprite.Sample(s_sprite, input.tile_position).rgb;
-    float3 alpha_corrected = apply_contrast_and_gamma_correction3(sample, input.color.rgb, grayscale_enhanced_contrast, gamma_ratios);
+    float3 alpha_corrected = apply_contrast_and_gamma_correction3(sample, input.color.rgb, subpixel_enhanced_contrast, gamma_ratios);
 
-    DualSourceColorOutput output;
-    output.color0 = float4(input.color.rgb, 1.0f);
-    output.color1 = float4(input.color.a * alpha_corrected, 1.0f);
+    SubpixelSpriteFragmentOutput output;
+    output.foreground = float4(input.color.rgb, 1.0f);
+    output.alpha = float4(input.color.a * alpha_corrected, 1.0f);
     return output;
 }
 

--- a/crates/gpui/src/platform/windows/system_settings.rs
+++ b/crates/gpui/src/platform/windows/system_settings.rs
@@ -7,8 +7,9 @@ use ::util::ResultExt;
 use windows::Win32::UI::{
     Shell::{ABM_GETSTATE, ABM_GETTASKBARPOS, ABS_AUTOHIDE, APPBARDATA, SHAppBarMessage},
     WindowsAndMessaging::{
-        SPI_GETWHEELSCROLLCHARS, SPI_GETWHEELSCROLLLINES, SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS,
-        SystemParametersInfoW,
+        FE_FONTSMOOTHINGCLEARTYPE, SPI_GETFONTSMOOTHINGTYPE, SPI_GETWHEELSCROLLCHARS,
+        SPI_GETWHEELSCROLLLINES, SPI_SETWORKAREA, SYSTEM_PARAMETERS_INFO_ACTION,
+        SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS, SystemParametersInfoW,
     },
 };
 
@@ -22,6 +23,7 @@ use super::WindowsDisplay;
 pub(crate) struct WindowsSystemSettings {
     pub(crate) mouse_wheel_settings: MouseWheelSettings,
     pub(crate) auto_hide_taskbar_position: Cell<Option<AutoHideTaskbarPosition>>,
+    pub(crate) subpixel_rendering: Cell<bool>,
 }
 
 #[derive(Default, Debug, Clone)]
@@ -39,19 +41,35 @@ impl WindowsSystemSettings {
         settings
     }
 
-    fn init(&self, display: WindowsDisplay) {
+    fn init(&mut self, display: WindowsDisplay) {
         self.mouse_wheel_settings.update();
         self.auto_hide_taskbar_position
             .set(AutoHideTaskbarPosition::new(display).log_err().flatten());
+        self.update_subpixel_rendering();
     }
 
     pub(crate) fn update(&self, display: WindowsDisplay, wparam: usize) {
-        match wparam {
-            // SPI_SETWORKAREA
-            47 => self.update_taskbar_position(display),
-            // SPI_GETWHEELSCROLLLINES, SPI_GETWHEELSCROLLCHARS
-            104 | 108 => self.update_mouse_wheel_settings(),
+        match SYSTEM_PARAMETERS_INFO_ACTION(wparam as u32) {
+            SPI_SETWORKAREA => self.update_taskbar_position(display),
+            SPI_GETWHEELSCROLLLINES | SPI_GETWHEELSCROLLCHARS => self.update_mouse_wheel_settings(),
+            SPI_GETFONTSMOOTHINGTYPE => self.update_subpixel_rendering(),
             _ => {}
+        }
+    }
+
+    fn update_subpixel_rendering(&self) {
+        let mut value = c_uint::default();
+        let result = unsafe {
+            SystemParametersInfoW(
+                SPI_GETFONTSMOOTHINGTYPE,
+                0,
+                Some((&mut value) as *mut c_uint as *mut c_void),
+                SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS::default(),
+            )
+        };
+        if result.log_err().is_some() {
+            self.subpixel_rendering
+                .set(value as u32 == FE_FONTSMOOTHINGCLEARTYPE);
         }
     }
 

--- a/crates/gpui/src/platform/windows/system_settings.rs
+++ b/crates/gpui/src/platform/windows/system_settings.rs
@@ -69,7 +69,7 @@ impl WindowsSystemSettings {
         };
         if result.log_err().is_some() {
             self.subpixel_rendering
-                .set(value as u32 == FE_FONTSMOOTHINGCLEARTYPE);
+                .set(value == FE_FONTSMOOTHINGCLEARTYPE);
         }
     }
 

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -790,8 +790,8 @@ impl PlatformWindow for WindowsWindow {
         self.state.hovered.get()
     }
 
-    fn is_opaque(&self) -> bool {
-        self.state.background_appearance.get() == WindowBackgroundAppearance::Opaque
+    fn background_appearance(&self) -> WindowBackgroundAppearance {
+        self.state.background_appearance.get()
     }
 
     fn is_subpixel_rendering_supported(&self) -> bool {

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -30,6 +30,7 @@ pub(crate) struct Scene {
     pub(crate) paths: Vec<Path<ScaledPixels>>,
     pub(crate) underlines: Vec<Underline>,
     pub(crate) monochrome_sprites: Vec<MonochromeSprite>,
+    pub(crate) subpixel_sprites: Vec<SubpixelSprite>,
     pub(crate) polychrome_sprites: Vec<PolychromeSprite>,
     pub(crate) surfaces: Vec<PaintSurface>,
 }
@@ -44,6 +45,7 @@ impl Scene {
         self.quads.clear();
         self.underlines.clear();
         self.monochrome_sprites.clear();
+        self.subpixel_sprites.clear();
         self.polychrome_sprites.clear();
         self.surfaces.clear();
     }
@@ -101,6 +103,10 @@ impl Scene {
                 sprite.order = order;
                 self.monochrome_sprites.push(sprite.clone());
             }
+            Primitive::SubpixelSprite(sprite) => {
+                sprite.order = order;
+                self.subpixel_sprites.push(sprite.clone());
+            }
             Primitive::PolychromeSprite(sprite) => {
                 sprite.order = order;
                 self.polychrome_sprites.push(sprite.clone());
@@ -131,6 +137,8 @@ impl Scene {
         self.underlines.sort_by_key(|underline| underline.order);
         self.monochrome_sprites
             .sort_by_key(|sprite| (sprite.order, sprite.tile.tile_id));
+        self.subpixel_sprites
+            .sort_by_key(|sprite| (sprite.order, sprite.tile.tile_id));
         self.polychrome_sprites
             .sort_by_key(|sprite| (sprite.order, sprite.tile.tile_id));
         self.surfaces.sort_by_key(|surface| surface.order);
@@ -160,6 +168,9 @@ impl Scene {
             monochrome_sprites: &self.monochrome_sprites,
             monochrome_sprites_start: 0,
             monochrome_sprites_iter: self.monochrome_sprites.iter().peekable(),
+            subpixel_sprites: &self.subpixel_sprites,
+            subpixel_sprites_start: 0,
+            subpixel_sprites_iter: self.subpixel_sprites.iter().peekable(),
             polychrome_sprites: &self.polychrome_sprites,
             polychrome_sprites_start: 0,
             polychrome_sprites_iter: self.polychrome_sprites.iter().peekable(),
@@ -185,6 +196,7 @@ pub(crate) enum PrimitiveKind {
     Path,
     Underline,
     MonochromeSprite,
+    SubpixelSprite,
     PolychromeSprite,
     Surface,
 }
@@ -202,6 +214,7 @@ pub(crate) enum Primitive {
     Path(Path<ScaledPixels>),
     Underline(Underline),
     MonochromeSprite(MonochromeSprite),
+    SubpixelSprite(SubpixelSprite),
     PolychromeSprite(PolychromeSprite),
     Surface(PaintSurface),
 }
@@ -214,6 +227,7 @@ impl Primitive {
             Primitive::Path(path) => &path.bounds,
             Primitive::Underline(underline) => &underline.bounds,
             Primitive::MonochromeSprite(sprite) => &sprite.bounds,
+            Primitive::SubpixelSprite(sprite) => &sprite.bounds,
             Primitive::PolychromeSprite(sprite) => &sprite.bounds,
             Primitive::Surface(surface) => &surface.bounds,
         }
@@ -226,6 +240,7 @@ impl Primitive {
             Primitive::Path(path) => &path.content_mask,
             Primitive::Underline(underline) => &underline.content_mask,
             Primitive::MonochromeSprite(sprite) => &sprite.content_mask,
+            Primitive::SubpixelSprite(sprite) => &sprite.content_mask,
             Primitive::PolychromeSprite(sprite) => &sprite.content_mask,
             Primitive::Surface(surface) => &surface.content_mask,
         }
@@ -255,6 +270,9 @@ struct BatchIterator<'a> {
     monochrome_sprites: &'a [MonochromeSprite],
     monochrome_sprites_start: usize,
     monochrome_sprites_iter: Peekable<slice::Iter<'a, MonochromeSprite>>,
+    subpixel_sprites: &'a [SubpixelSprite],
+    subpixel_sprites_start: usize,
+    subpixel_sprites_iter: Peekable<slice::Iter<'a, SubpixelSprite>>,
     polychrome_sprites: &'a [PolychromeSprite],
     polychrome_sprites_start: usize,
     polychrome_sprites_iter: Peekable<slice::Iter<'a, PolychromeSprite>>,
@@ -281,6 +299,10 @@ impl<'a> Iterator for BatchIterator<'a> {
             (
                 self.monochrome_sprites_iter.peek().map(|s| s.order),
                 PrimitiveKind::MonochromeSprite,
+            ),
+            (
+                self.subpixel_sprites_iter.peek().map(|s| s.order),
+                PrimitiveKind::SubpixelSprite,
             ),
             (
                 self.polychrome_sprites_iter.peek().map(|s| s.order),
@@ -383,6 +405,27 @@ impl<'a> Iterator for BatchIterator<'a> {
                     sprites: &self.monochrome_sprites[sprites_start..sprites_end],
                 })
             }
+            PrimitiveKind::SubpixelSprite => {
+                let texture_id = self.subpixel_sprites_iter.peek().unwrap().tile.texture_id;
+                let sprites_start = self.subpixel_sprites_start;
+                let mut sprites_end = sprites_start + 1;
+                self.subpixel_sprites_iter.next();
+                while self
+                    .subpixel_sprites_iter
+                    .next_if(|sprite| {
+                        (sprite.order, batch_kind) < max_order_and_kind
+                            && sprite.tile.texture_id == texture_id
+                    })
+                    .is_some()
+                {
+                    sprites_end += 1;
+                }
+                self.subpixel_sprites_start = sprites_end;
+                Some(PrimitiveBatch::SubpixelSprites {
+                    texture_id,
+                    sprites: &self.subpixel_sprites[sprites_start..sprites_end],
+                })
+            }
             PrimitiveKind::PolychromeSprite => {
                 let texture_id = self.polychrome_sprites_iter.peek().unwrap().tile.texture_id;
                 let sprites_start = self.polychrome_sprites_start;
@@ -440,6 +483,10 @@ pub(crate) enum PrimitiveBatch<'a> {
     MonochromeSprites {
         texture_id: AtlasTextureId,
         sprites: &'a [MonochromeSprite],
+    },
+    SubpixelSprites {
+        texture_id: AtlasTextureId,
+        sprites: &'a [SubpixelSprite],
     },
     PolychromeSprites {
         texture_id: AtlasTextureId,
@@ -631,6 +678,24 @@ pub(crate) struct MonochromeSprite {
 impl From<MonochromeSprite> for Primitive {
     fn from(sprite: MonochromeSprite) -> Self {
         Primitive::MonochromeSprite(sprite)
+    }
+}
+
+#[derive(Clone, Debug)]
+#[repr(C)]
+pub(crate) struct SubpixelSprite {
+    pub order: DrawOrder,
+    pub pad: u32, // align to 8 bytes
+    pub bounds: Bounds<ScaledPixels>,
+    pub content_mask: ContentMask<ScaledPixels>,
+    pub color: Hsla,
+    pub tile: AtlasTile,
+    pub transformation: TransformationMatrix,
+}
+
+impl From<SubpixelSprite> for Primitive {
+    fn from(sprite: SubpixelSprite) -> Self {
+        Primitive::SubpixelSprite(sprite)
     }
 }
 

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -470,7 +470,7 @@ impl<'a> Iterator for BatchIterator<'a> {
 #[derive(Debug)]
 #[cfg_attr(
     all(
-        any(target_os = "linux", target_os = "freebsd", target_os = "macos"),
+        any(target_os = "linux", target_os = "freebsd"),
         not(any(feature = "x11", feature = "wayland"))
     ),
     allow(dead_code)
@@ -484,6 +484,7 @@ pub(crate) enum PrimitiveBatch<'a> {
         texture_id: AtlasTextureId,
         sprites: &'a [MonochromeSprite],
     },
+    #[cfg_attr(target_os = "macos", allow(dead_code))]
     SubpixelSprites {
         texture_id: AtlasTextureId,
         sprites: &'a [SubpixelSprite],

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -470,7 +470,7 @@ impl<'a> Iterator for BatchIterator<'a> {
 #[derive(Debug)]
 #[cfg_attr(
     all(
-        any(target_os = "linux", target_os = "freebsd"),
+        any(target_os = "linux", target_os = "freebsd", target_os = "macos"),
         not(any(feature = "x11", feature = "wayland"))
     ),
     allow(dead_code)

--- a/crates/gpui/src/text_system.rs
+++ b/crates/gpui/src/text_system.rs
@@ -775,6 +775,7 @@ pub(crate) struct RenderGlyphParams {
     pub(crate) subpixel_variant: Point<u8>,
     pub(crate) scale_factor: f32,
     pub(crate) is_emoji: bool,
+    pub(crate) subpixel_rendering: bool,
 }
 
 impl Eq for RenderGlyphParams {}
@@ -787,6 +788,7 @@ impl Hash for RenderGlyphParams {
         self.subpixel_variant.hash(state);
         self.scale_factor.to_bits().hash(state);
         self.is_emoji.hash(state);
+        self.subpixel_rendering.hash(state);
     }
 }
 

--- a/crates/gpui/src/text_system.rs
+++ b/crates/gpui/src/text_system.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     Bounds, DevicePixels, Hsla, Pixels, PlatformTextSystem, Point, Result, SharedString, Size,
-    StrikethroughStyle, UnderlineStyle, px,
+    StrikethroughStyle, TextRenderingMode, UnderlineStyle, px,
 };
 use anyhow::{Context as _, anyhow};
 use collections::FxHashMap;
@@ -325,6 +325,17 @@ impl TextSystem {
         let raster_bounds = self.raster_bounds(params)?;
         self.platform_text_system
             .rasterize_glyph(params, raster_bounds)
+    }
+
+    /// Returns the text rendering mode recommended by the platform for the given font and size.
+    /// The return value will never be [`TextRenderingMode::PlatformDefault`].
+    pub(crate) fn recommended_rendering_mode(
+        &self,
+        font_id: FontId,
+        font_size: Pixels,
+    ) -> TextRenderingMode {
+        self.platform_text_system
+            .recommended_rendering_mode(font_id, font_size)
     }
 }
 

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -3144,15 +3144,44 @@ impl Window {
                 size: tile.bounds.size.map(Into::into),
             };
             let content_mask = self.content_mask().scale(scale_factor);
-            self.next_frame.scene.insert_primitive(MonochromeSprite {
-                order: 0,
-                pad: 0,
-                bounds,
-                content_mask,
-                color: color.opacity(element_opacity),
-                tile,
-                transformation: TransformationMatrix::unit(),
-            });
+
+            #[cfg(target_os = "windows")]
+            if true {
+                use crate::SubpixelSprite;
+
+                self.next_frame.scene.insert_primitive(SubpixelSprite {
+                    order: 0,
+                    pad: 0,
+                    bounds,
+                    content_mask,
+                    color: color.opacity(element_opacity),
+                    tile,
+                    transformation: TransformationMatrix::unit(),
+                });
+            } else {
+                self.next_frame.scene.insert_primitive(MonochromeSprite {
+                    order: 0,
+                    pad: 0,
+                    bounds,
+                    content_mask,
+                    color: color.opacity(element_opacity),
+                    tile,
+                    transformation: TransformationMatrix::unit(),
+                });
+            }
+
+            #[cfg(not(target_os = "windows"))]
+            {
+                self.next_frame.scene.insert_primitive(MonochromeSprite {
+                    order: 0,
+                    pad: 0,
+                    bounds,
+                    content_mask,
+                    color: color.opacity(element_opacity),
+                    tile,
+                    transformation: TransformationMatrix::unit(),
+                });
+            }
         }
         Ok(())
     }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -3175,7 +3175,7 @@ impl Window {
     }
 
     fn should_use_subpixel_rendering(&self, font_id: FontId, font_size: Pixels) -> bool {
-        if !self.platform_window.is_opaque() {
+        if self.platform_window.background_appearance() != WindowBackgroundAppearance::Opaque {
             return false;
         }
 

--- a/crates/settings/src/settings_content/workspace.rs
+++ b/crates/settings/src/settings_content/workspace.rs
@@ -18,7 +18,7 @@ pub struct WorkspaceSettingsContent {
     /// Whether to enable subpixel (ClearType-style) text rendering.
     ///
     /// Default: platform_default
-    pub subpixel_text_rendering: Option<SubpixelTextRendering>,
+    pub use_subpixel_text_rendering: Option<SubpixelTextRendering>,
     /// Layout mode for the bottom dock
     ///
     /// Default: contained
@@ -568,10 +568,10 @@ pub enum SubpixelTextRendering {
     /// Use platform default behavior.
     #[default]
     PlatformDefault,
-    /// Always enable subpixel (ClearType) text rendering.
-    Yes,
-    /// Always disable subpixel (ClearType) text rendering.
-    No,
+    /// Always enable subpixel text rendering.
+    Always,
+    /// Always disable subpixel text rendering.
+    Never,
 }
 
 impl OnLastWindowClosed {

--- a/crates/settings/src/settings_content/workspace.rs
+++ b/crates/settings/src/settings_content/workspace.rs
@@ -15,10 +15,10 @@ use crate::{
 pub struct WorkspaceSettingsContent {
     /// Active pane styling settings.
     pub active_pane_modifiers: Option<ActivePaneModifiers>,
-    /// Whether to enable subpixel (ClearType-style) text rendering.
+    /// The text rendering mode to use.
     ///
     /// Default: platform_default
-    pub use_subpixel_text_rendering: Option<SubpixelTextRendering>,
+    pub text_rendering_mode: Option<TextRenderingMode>,
     /// Layout mode for the bottom dock
     ///
     /// Default: contained
@@ -564,14 +564,14 @@ pub enum OnLastWindowClosed {
     strum::VariantNames,
 )]
 #[serde(rename_all = "snake_case")]
-pub enum SubpixelTextRendering {
+pub enum TextRenderingMode {
     /// Use platform default behavior.
     #[default]
     PlatformDefault,
-    /// Always enable subpixel text rendering.
-    Always,
-    /// Always disable subpixel text rendering.
-    Never,
+    /// Use subpixel (ClearType-style) text rendering.
+    Subpixel,
+    /// Use grayscale text rendering.
+    Grayscale,
 }
 
 impl OnLastWindowClosed {

--- a/crates/settings/src/settings_content/workspace.rs
+++ b/crates/settings/src/settings_content/workspace.rs
@@ -15,6 +15,10 @@ use crate::{
 pub struct WorkspaceSettingsContent {
     /// Active pane styling settings.
     pub active_pane_modifiers: Option<ActivePaneModifiers>,
+    /// Whether to enable subpixel (ClearType-style) text rendering.
+    ///
+    /// Default: platform_default
+    pub subpixel_text_rendering: Option<SubpixelTextRendering>,
     /// Layout mode for the bottom dock
     ///
     /// Default: contained
@@ -543,6 +547,31 @@ pub enum OnLastWindowClosed {
     PlatformDefault,
     /// Quit the application the last window is closed
     QuitApp,
+}
+
+#[derive(
+    Copy,
+    Clone,
+    Default,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    MergeFrom,
+    PartialEq,
+    Eq,
+    Debug,
+    strum::VariantArray,
+    strum::VariantNames,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum SubpixelTextRendering {
+    /// Use platform default behavior.
+    #[default]
+    PlatformDefault,
+    /// Always enable subpixel (ClearType) text rendering.
+    Yes,
+    /// Always disable subpixel (ClearType) text rendering.
+    No,
 }
 
 impl OnLastWindowClosed {

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -816,6 +816,7 @@ impl VsCodeSettings {
     fn workspace_settings_content(&self) -> WorkspaceSettingsContent {
         WorkspaceSettingsContent {
             active_pane_modifiers: self.active_pane_modifiers(),
+            subpixel_text_rendering: None,
             autosave: self.read_enum("files.autoSave", |s| match s {
                 "off" => Some(AutosaveSetting::Off),
                 "afterDelay" => Some(AutosaveSetting::AfterDelay {

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -816,7 +816,7 @@ impl VsCodeSettings {
     fn workspace_settings_content(&self) -> WorkspaceSettingsContent {
         WorkspaceSettingsContent {
             active_pane_modifiers: self.active_pane_modifiers(),
-            subpixel_text_rendering: None,
+            use_subpixel_text_rendering: None,
             autosave: self.read_enum("files.autoSave", |s| match s {
                 "off" => Some(AutosaveSetting::Off),
                 "afterDelay" => Some(AutosaveSetting::AfterDelay {

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -816,7 +816,7 @@ impl VsCodeSettings {
     fn workspace_settings_content(&self) -> WorkspaceSettingsContent {
         WorkspaceSettingsContent {
             active_pane_modifiers: self.active_pane_modifiers(),
-            use_subpixel_text_rendering: None,
+            text_rendering_mode: None,
             autosave: self.read_enum("files.autoSave", |s| match s {
                 "off" => Some(AutosaveSetting::Off),
                 "afterDelay" => Some(AutosaveSetting::AfterDelay {

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -890,6 +890,22 @@ pub(crate) fn settings_data(cx: &App) -> Vec<SettingsPage> {
                     metadata: None,
                     files: USER,
                 }),
+                SettingsPageItem::SectionHeader("Text Rendering"),
+                SettingsPageItem::SettingItem(SettingItem {
+                    title: "Use Subpixel Rendering",
+                    description: "Whether to use subpixel rendering for text.",
+                    field: Box::new(SettingField {
+                        json_path: Some("use_subpixel_text_rendering"),
+                        pick: |settings_content| {
+                            settings_content.workspace.use_subpixel_text_rendering.as_ref()
+                        },
+                        write: |settings_content, value| {
+                            settings_content.workspace.use_subpixel_text_rendering = value;
+                        },
+                    }),
+                    metadata: None,
+                    files: USER,
+                }),
                 SettingsPageItem::SectionHeader("Cursor"),
                 SettingsPageItem::SettingItem(SettingItem {
                     title: "Multi Cursor Modifier",
@@ -3488,21 +3504,6 @@ pub(crate) fn settings_data(cx: &App) -> Vec<SettingsPage> {
                         },
                         write: |settings_content, value| {
                             settings_content.workspace.window_decorations = value;
-                        },
-                    }),
-                    metadata: None,
-                    files: USER,
-                }),
-                SettingsPageItem::SettingItem(SettingItem {
-                    title: "Subpixel Text Rendering",
-                    description: "Whether to enable subpixel (ClearType-style) text rendering.",
-                    field: Box::new(SettingField {
-                        json_path: Some("subpixel_text_rendering"),
-                        pick: |settings_content| {
-                            settings_content.workspace.subpixel_text_rendering.as_ref()
-                        },
-                        write: |settings_content, value| {
-                            settings_content.workspace.subpixel_text_rendering = value;
                         },
                     }),
                     metadata: None,

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -3493,6 +3493,21 @@ pub(crate) fn settings_data(cx: &App) -> Vec<SettingsPage> {
                     metadata: None,
                     files: USER,
                 }),
+                SettingsPageItem::SettingItem(SettingItem {
+                    title: "Subpixel Text Rendering",
+                    description: "Whether to enable subpixel (ClearType-style) text rendering.",
+                    field: Box::new(SettingField {
+                        json_path: Some("subpixel_text_rendering"),
+                        pick: |settings_content| {
+                            settings_content.workspace.subpixel_text_rendering.as_ref()
+                        },
+                        write: |settings_content, value| {
+                            settings_content.workspace.subpixel_text_rendering = value;
+                        },
+                    }),
+                    metadata: None,
+                    files: USER,
+                }),
                 SettingsPageItem::SectionHeader("Pane Modifiers"),
                 SettingsPageItem::SettingItem(SettingItem {
                     title: "Inactive Opacity",

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -892,15 +892,15 @@ pub(crate) fn settings_data(cx: &App) -> Vec<SettingsPage> {
                 }),
                 SettingsPageItem::SectionHeader("Text Rendering"),
                 SettingsPageItem::SettingItem(SettingItem {
-                    title: "Use Subpixel Rendering",
-                    description: "Whether to use subpixel rendering for text.",
+                    title: "Text Rendering Mode",
+                    description: "The text rendering mode to use.",
                     field: Box::new(SettingField {
-                        json_path: Some("use_subpixel_text_rendering"),
+                        json_path: Some("text_rendering_mode"),
                         pick: |settings_content| {
-                            settings_content.workspace.use_subpixel_text_rendering.as_ref()
+                            settings_content.workspace.text_rendering_mode.as_ref()
                         },
                         write: |settings_content, value| {
-                            settings_content.workspace.use_subpixel_text_rendering = value;
+                            settings_content.workspace.text_rendering_mode = value;
                         },
                     }),
                     metadata: None,

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -436,6 +436,7 @@ fn init_renderers(cx: &mut App) {
         .add_basic_renderer::<settings::BottomDockLayout>(render_dropdown)
         .add_basic_renderer::<settings::OnLastWindowClosed>(render_dropdown)
         .add_basic_renderer::<settings::CloseWindowWhenNoItems>(render_dropdown)
+        .add_basic_renderer::<settings::SubpixelTextRendering>(render_dropdown)
         .add_basic_renderer::<settings::FontFamilyName>(render_font_picker)
         .add_basic_renderer::<settings::BaseKeymapContent>(render_dropdown)
         .add_basic_renderer::<settings::MultiCursorModifier>(render_dropdown)

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -436,7 +436,7 @@ fn init_renderers(cx: &mut App) {
         .add_basic_renderer::<settings::BottomDockLayout>(render_dropdown)
         .add_basic_renderer::<settings::OnLastWindowClosed>(render_dropdown)
         .add_basic_renderer::<settings::CloseWindowWhenNoItems>(render_dropdown)
-        .add_basic_renderer::<settings::SubpixelTextRendering>(render_dropdown)
+        .add_basic_renderer::<settings::TextRenderingMode>(render_dropdown)
         .add_basic_renderer::<settings::FontFamilyName>(render_font_picker)
         .add_basic_renderer::<settings::BaseKeymapContent>(render_dropdown)
         .add_basic_renderer::<settings::MultiCursorModifier>(render_dropdown)

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -27,7 +27,7 @@ pub struct WorkspaceSettings {
     pub max_tabs: Option<NonZeroUsize>,
     pub when_closing_with_no_tabs: settings::CloseWindowWhenNoItems,
     pub on_last_window_closed: settings::OnLastWindowClosed,
-    pub use_subpixel_text_rendering: settings::SubpixelTextRendering,
+    pub text_rendering_mode: settings::TextRenderingMode,
     pub resize_all_panels_in_dock: Vec<DockPosition>,
     pub close_on_file_delete: bool,
     pub use_system_window_tabs: bool,
@@ -97,7 +97,7 @@ impl Settings for WorkspaceSettings {
             max_tabs: workspace.max_tabs,
             when_closing_with_no_tabs: workspace.when_closing_with_no_tabs.unwrap(),
             on_last_window_closed: workspace.on_last_window_closed.unwrap(),
-            use_subpixel_text_rendering: workspace.use_subpixel_text_rendering.unwrap(),
+            text_rendering_mode: workspace.text_rendering_mode.unwrap(),
             resize_all_panels_in_dock: workspace
                 .resize_all_panels_in_dock
                 .clone()

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -27,6 +27,7 @@ pub struct WorkspaceSettings {
     pub max_tabs: Option<NonZeroUsize>,
     pub when_closing_with_no_tabs: settings::CloseWindowWhenNoItems,
     pub on_last_window_closed: settings::OnLastWindowClosed,
+    pub subpixel_text_rendering: settings::SubpixelTextRendering,
     pub resize_all_panels_in_dock: Vec<DockPosition>,
     pub close_on_file_delete: bool,
     pub use_system_window_tabs: bool,
@@ -96,6 +97,7 @@ impl Settings for WorkspaceSettings {
             max_tabs: workspace.max_tabs,
             when_closing_with_no_tabs: workspace.when_closing_with_no_tabs.unwrap(),
             on_last_window_closed: workspace.on_last_window_closed.unwrap(),
+            subpixel_text_rendering: workspace.subpixel_text_rendering.unwrap(),
             resize_all_panels_in_dock: workspace
                 .resize_all_panels_in_dock
                 .clone()

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -27,7 +27,7 @@ pub struct WorkspaceSettings {
     pub max_tabs: Option<NonZeroUsize>,
     pub when_closing_with_no_tabs: settings::CloseWindowWhenNoItems,
     pub on_last_window_closed: settings::OnLastWindowClosed,
-    pub subpixel_text_rendering: settings::SubpixelTextRendering,
+    pub use_subpixel_text_rendering: settings::SubpixelTextRendering,
     pub resize_all_panels_in_dock: Vec<DockPosition>,
     pub close_on_file_delete: bool,
     pub use_system_window_tabs: bool,
@@ -97,7 +97,7 @@ impl Settings for WorkspaceSettings {
             max_tabs: workspace.max_tabs,
             when_closing_with_no_tabs: workspace.when_closing_with_no_tabs.unwrap(),
             on_last_window_closed: workspace.on_last_window_closed.unwrap(),
-            subpixel_text_rendering: workspace.subpixel_text_rendering.unwrap(),
+            use_subpixel_text_rendering: workspace.use_subpixel_text_rendering.unwrap(),
             resize_all_panels_in_dock: workspace
                 .resize_all_panels_in_dock
                 .clone()

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -678,6 +678,13 @@ fn main() {
                         .ok();
                 }
 
+                let enabled = match WorkspaceSettings::get_global(cx).subpixel_text_rendering {
+                    settings::SubpixelTextRendering::PlatformDefault => None,
+                    settings::SubpixelTextRendering::Yes => Some(true),
+                    settings::SubpixelTextRendering::No => Some(false),
+                };
+                cx.set_subpixel_rendering_enabled(enabled);
+
                 let new_host = &client::ClientSettings::get_global(cx).server_url;
                 if &http.base_url() != new_host {
                     http.set_base_url(new_host);

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -678,11 +678,15 @@ fn main() {
                         .ok();
                 }
 
-                cx.set_subpixel_rendering_enabled(
-                    match WorkspaceSettings::get_global(cx).use_subpixel_text_rendering {
-                        settings::SubpixelTextRendering::PlatformDefault => None,
-                        settings::SubpixelTextRendering::Always => Some(true),
-                        settings::SubpixelTextRendering::Never => Some(false),
+                cx.set_text_rendering_mode(
+                    match WorkspaceSettings::get_global(cx).text_rendering_mode {
+                        settings::TextRenderingMode::PlatformDefault => {
+                            gpui::TextRenderingMode::PlatformDefault
+                        }
+                        settings::TextRenderingMode::Subpixel => gpui::TextRenderingMode::Subpixel,
+                        settings::TextRenderingMode::Grayscale => {
+                            gpui::TextRenderingMode::Grayscale
+                        }
                     },
                 );
 

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -678,12 +678,13 @@ fn main() {
                         .ok();
                 }
 
-                let enabled = match WorkspaceSettings::get_global(cx).subpixel_text_rendering {
-                    settings::SubpixelTextRendering::PlatformDefault => None,
-                    settings::SubpixelTextRendering::Yes => Some(true),
-                    settings::SubpixelTextRendering::No => Some(false),
-                };
-                cx.set_subpixel_rendering_enabled(enabled);
+                cx.set_subpixel_rendering_enabled(
+                    match WorkspaceSettings::get_global(cx).use_subpixel_text_rendering {
+                        settings::SubpixelTextRendering::PlatformDefault => None,
+                        settings::SubpixelTextRendering::Always => Some(true),
+                        settings::SubpixelTextRendering::Never => Some(false),
+                    },
+                );
 
                 let new_host = &client::ClientSettings::get_global(cx).server_url;
                 if &http.base_url() != new_host {


### PR DESCRIPTION
Subpixel text rendering is now implemented on Windows and Linux.

Comparison screenshots:

|Before|After|
| ------------- | ------------- |
| <img width="400" src="https://github.com/user-attachments/assets/9d720d2c-2ec4-4adf-a83f-7c2d81d30025" /> | <img width="400" src="https://github.com/user-attachments/assets/8fd7dc2a-8ca0-4f71-86cd-55460f568f7a" /> |


Release Notes:

- Added support for subpixel (ClearType-style) text rendering. This improves the legibility of text on standard DPI displays. Subpixel rendering is enabled by default on Windows and Linux and can be configured using the `text_rendering_mode` setting.
