### PR TITLE
Parse and render markdown mention links from pasted text

### DIFF
--- a/crates/agent_ui/src/mention_set.rs
+++ b/crates/agent_ui/src/mention_set.rs
@@ -131,7 +131,9 @@ impl MentionSet {
             MentionUri::Fetch { url } => self.confirm_mention_for_fetch(url, http_client, cx),
             MentionUri::Directory { .. } => Task::ready(Ok(Mention::Link)),
             MentionUri::Thread { id, .. } => self.confirm_mention_for_thread(id, cx),
-            MentionUri::TextThread { path, .. } => self.confirm_mention_for_text_thread(path, cx),
+            MentionUri::TextThread { .. } => {
+                Task::ready(Err(anyhow!("Text thread mentions are no longer supported")))
+            }
             MentionUri::File { abs_path } => {
                 self.confirm_mention_for_file(abs_path, supports_images, cx)
             }
@@ -141,6 +143,10 @@ impl MentionSet {
                 ..
             } => self.confirm_mention_for_symbol(abs_path, line_range, cx),
             MentionUri::Rule { id, .. } => self.confirm_mention_for_rule(id, cx),
+            MentionUri::Diagnostics {
+                include_errors,
+                include_warnings,
+            } => self.confirm_mention_for_diagnostics(include_errors, include_warnings, cx),
             MentionUri::PastedImage | MentionUri::Selection { .. } => {
                 Task::ready(Err(anyhow!("Unsupported mention URI type for paste")))
             }


### PR DESCRIPTION
Closes [#ISSUE](https://github.com/zed-industries/zed/issues/45408)

Release Notes:

- Fixed mention links from pasted text.

Recording:

https://github.com/user-attachments/assets/e0d55562-c9a4-4798-be41-af8b8cd1f5d7

