### PR TITLE
Ensure terminal commands are properly quoted by switching to `shell_builder.build`

### DIFF
--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -90,10 +90,7 @@ impl PackageJsonData {
                     "jest".to_owned(),
                     "--runInBand".to_owned(),
                     "--testNamePattern".to_owned(),
-                    format!(
-                        "\"{}\"",
-                        TYPESCRIPT_JEST_TEST_NAME_VARIABLE.template_value()
-                    ),
+                    TYPESCRIPT_JEST_TEST_NAME_VARIABLE.template_value(),
                     VariableName::File.template_value(),
                 ],
                 tags: vec![
@@ -135,10 +132,7 @@ impl PackageJsonData {
                     "run".to_owned(),
                     "--no-file-parallelism".to_owned(),
                     "--testNamePattern".to_owned(),
-                    format!(
-                        "\"{}\"",
-                        TYPESCRIPT_VITEST_TEST_NAME_VARIABLE.template_value()
-                    ),
+                    TYPESCRIPT_VITEST_TEST_NAME_VARIABLE.template_value(),
                     VariableName::File.template_value(),
                 ],
                 tags: vec![
@@ -176,7 +170,7 @@ impl PackageJsonData {
                     "--".to_owned(),
                     "mocha".to_owned(),
                     "--grep".to_owned(),
-                    format!("\"{}\"", VariableName::Symbol.template_value()),
+                    VariableName::Symbol.template_value(),
                     VariableName::File.template_value(),
                 ],
                 tags: vec![
@@ -240,7 +234,7 @@ impl PackageJsonData {
                 args: vec![
                     "test".to_owned(),
                     "--test-name-pattern".to_owned(),
-                    format!("\"{}\"", TYPESCRIPT_BUN_TEST_NAME_VARIABLE.template_value()),
+                    TYPESCRIPT_BUN_TEST_NAME_VARIABLE.template_value(),
                     VariableName::File.template_value(),
                 ],
                 tags: vec![
@@ -272,7 +266,7 @@ impl PackageJsonData {
                 args: vec![
                     "--test".to_owned(),
                     "--test-name-pattern".to_owned(),
-                    format!("\"{}\"", VariableName::Symbol.template_value()),
+                    VariableName::Symbol.template_value(),
                     VariableName::File.template_value(),
                 ],
                 tags: vec![

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -1136,7 +1136,7 @@ pub fn prepare_task_for_spawn(
 ) -> SpawnInTerminal {
     let builder = ShellBuilder::new(shell, is_windows);
     let command_label = builder.command_label(task.command.as_deref().unwrap_or(""));
-    let (command, args) = builder.build_no_quote(task.command.clone(), &task.args);
+    let (command, args) = builder.build(task.command.clone(), &task.args);
 
     SpawnInTerminal {
         command_label,
@@ -1928,8 +1928,9 @@ mod tests {
         cx.update(|cx| {
             SettingsStore::update_global(cx, |store, cx| {
                 store.update_user_settings(cx, |settings| {
-                    settings.terminal.get_or_insert_default().project.shell =
-                        Some(settings::Shell::Program("asdf".to_owned()));
+                    settings.terminal.get_or_insert_default().project.shell = Some(
+                        settings::Shell::Program("/nonexistent/path/to/shell".to_owned()),
+                    );
                 });
             });
         });

--- a/crates/util/src/shell.rs
+++ b/crates/util/src/shell.rs
@@ -1202,10 +1202,7 @@ mod tests {
     fn test_quote_preserving_variables_var_followed_by_dollar() {
         let shell_kind = ShellKind::Posix;
         // $VAR followed by lone $ - the $ becomes part of literal
-        assert_eq!(
-            shell_kind.quote_preserving_variables("$VAR$"),
-            "$VAR'$'"
-        );
+        assert_eq!(shell_kind.quote_preserving_variables("$VAR$"), "$VAR'$'");
         // $VAR followed by $suffix (another variable)
         assert_eq!(
             shell_kind.quote_preserving_variables("$VAR$SUFFIX"),

--- a/crates/util/src/shell_builder.rs
+++ b/crates/util/src/shell_builder.rs
@@ -307,4 +307,56 @@ mod test {
         assert_eq!(program, "fish");
         assert_eq!(args, vec!["-i", "-c", "echo oo"]);
     }
+
+    #[test]
+    fn quotes_file_paths_with_parentheses() {
+        // Test that file paths with parentheses (common in Next.js app router) are properly quoted
+        let shell = Shell::Program("bash".to_owned());
+        let shell_builder = ShellBuilder::new(&shell, false);
+
+        let (program, args) = shell_builder.build(
+            Some("bun".into()),
+            &[
+                "test".to_string(),
+                "./src/app/(public)/tests/fails.test.ts".to_string(),
+            ],
+        );
+
+        assert_eq!(program, "bash");
+        // The file path with parentheses should be quoted to prevent shell interpretation
+        assert_eq!(
+            args,
+            vec![
+                "-i",
+                "-c",
+                "bun test './src/app/(public)/tests/fails.test.ts'"
+            ]
+        );
+    }
+
+    #[test]
+    fn build_no_quote_does_not_quote_paths_with_parentheses() {
+        // This demonstrates the bug: build_no_quote doesn't quote paths with special characters
+        let shell = Shell::Program("bash".to_owned());
+        let shell_builder = ShellBuilder::new(&shell, false);
+
+        let (program, args) = shell_builder.build_no_quote(
+            Some("bun".into()),
+            &[
+                "test".to_string(),
+                "./src/app/(public)/tests/fails.test.ts".to_string(),
+            ],
+        );
+
+        assert_eq!(program, "bash");
+        // Without quoting, the parentheses will be interpreted by the shell as a subshell
+        assert_eq!(
+            args,
+            vec![
+                "-i",
+                "-c",
+                "bun test ./src/app/(public)/tests/fails.test.ts"
+            ]
+        );
+    }
 }

--- a/crates/util/src/shell_builder.rs
+++ b/crates/util/src/shell_builder.rs
@@ -367,10 +367,7 @@ mod test {
         );
 
         // Parens need quoting, but .ts after variable doesn't (no special chars)
-        assert_eq!(
-            args,
-            vec!["-i", "-c", "echo './app/(public)/'$ZED_FILE.ts"]
-        );
+        assert_eq!(args, vec!["-i", "-c", "echo './app/(public)/'$ZED_FILE.ts"]);
     }
 
     #[test]


### PR DESCRIPTION
Closes [#ISSUE](https://github.com/zed-industries/zed/issues/45258)

Release Notes:

- Fixed gutter test runner failure for paths containing "()"
