### PR TITLE
Ensure agent servers and built-in agents consistently use Zed's bundled Node.js

### DIFF
--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -9,8 +9,6 @@ use futures::io::BufReader;
 use project::Project;
 use project::agent_server_store::AgentServerCommand;
 use serde::Deserialize;
-use settings::Settings as _;
-use task::ShellBuilder;
 use util::ResultExt as _;
 
 use std::path::PathBuf;
@@ -23,7 +21,7 @@ use gpui::{App, AppContext as _, AsyncApp, Entity, SharedString, Task, WeakEntit
 
 use acp_thread::{AcpThread, AuthRequired, LoadError, TerminalProviderEvent};
 use terminal::TerminalBuilder;
-use terminal::terminal_settings::{AlternateScroll, CursorShape, TerminalSettings};
+use terminal::terminal_settings::{AlternateScroll, CursorShape};
 
 #[derive(Debug, Error)]
 #[error("Unsupported version")]
@@ -88,11 +86,13 @@ impl AcpConnection {
         is_remote: bool,
         cx: &mut AsyncApp,
     ) -> Result<Self> {
-        let shell = cx.update(|cx| TerminalSettings::get(None, cx).shell.clone())?;
-        let builder = ShellBuilder::new(&shell, cfg!(windows)).non_interactive();
-        let mut child =
-            builder.build_command(Some(command.path.display().to_string()), &command.args);
+        // Spawn the command directly without wrapping in a shell.
+        // This is critical for avoiding shell initialization scripts (like .zshenv)
+        // that may override PATH with version managers (asdf, nvm) pointing to
+        // incompatible node versions. See issue #45241.
+        let mut child = util::command::new_smol_command(&command.path);
         child
+            .args(&command.args)
             .envs(command.env.iter().flatten())
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())

--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -204,6 +204,16 @@ impl NodeRuntime {
         self.instance().await.binary_path()
     }
 
+    /// Returns the path to the managed (bundled) Node.js binary, bypassing system node selection.
+    /// This should be used for ACP agents and other components that require a consistent,
+    /// modern Node.js version regardless of project-level version managers (asdf, nvm, etc.).
+    /// See issue #45241.
+    pub async fn managed_binary_path(&self) -> Result<PathBuf> {
+        let http = self.0.lock().await.http.clone();
+        let instance = ManagedNodeRuntime::install_if_needed(&http).await?;
+        instance.binary_path()
+    }
+
     pub async fn run_npm_subcommand(
         &self,
         directory: Option<&Path>,


### PR DESCRIPTION
Closes [#ISSUE](https://github.com/zed-industries/zed/issues/45241)

Release Notes:

- Fixed node version selection for ACP agents

Root cause:

`NodeRuntime` was selecting `SystemNodeRuntime` (e.g., asdf shim). When invoked, asdf checks the project's .tool-versions and picks that node version - which was v10.x (doesn't support ES modules).

Recording:

https://github.com/user-attachments/assets/7639d4e4-eb16-4af7-9867-dff43664b1de
