### PR TITLE
Make `RealFs::metadata` not error on recursive/looped symlinks

### DIFF
--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -3520,4 +3520,28 @@ mod tests {
         assert!(!metadata.is_executable);
         // don't care about len or mtime on symlinks?
     }
+
+    #[gpui::test]
+    async fn test_realfs_symlink_loop_metadata(executor: BackgroundExecutor) {
+        let tempdir = TempDir::new().unwrap();
+        let path = tempdir.path();
+        let fs = RealFs {
+            bundled_git_binary_path: None,
+            executor,
+            next_job_id: Arc::new(AtomicUsize::new(0)),
+            job_event_subscribers: Arc::new(Mutex::new(Vec::new())),
+        };
+        let symlink_path = path.join("symlink");
+        smol::block_on(fs.create_symlink(&symlink_path, PathBuf::from("symlink"))).unwrap();
+        let metadata = fs
+            .metadata(&symlink_path)
+            .await
+            .expect("metadata call succeeds")
+            .expect("metadata returned");
+        assert!(metadata.is_symlink);
+        assert!(!metadata.is_dir);
+        assert!(!metadata.is_fifo);
+        assert!(!metadata.is_executable);
+        // don't care about len or mtime on symlinks?
+    }
 }

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -886,22 +886,25 @@ impl Fs for RealFs {
         let is_symlink = symlink_metadata.file_type().is_symlink();
         let metadata = if is_symlink {
             let path_buf = path.to_path_buf();
-            let path_exists = self
+            // Read target metadata, if the target exists
+            match self
                 .executor
-                .spawn(async move {
-                    path_buf
-                        .try_exists()
-                        .with_context(|| format!("checking existence for path {path_buf:?}"))
-                })
-                .await?;
-            if path_exists {
-                let path_buf = path.to_path_buf();
-                self.executor
-                    .spawn(async move { std::fs::metadata(path_buf) })
-                    .await
-                    .with_context(|| "accessing symlink for path {path}")?
-            } else {
-                symlink_metadata
+                .spawn(async move { std::fs::metadata(path_buf) })
+                .await
+            {
+                Ok(target_metadata) => target_metadata,
+                Err(err) => {
+                    if err.kind() != io::ErrorKind::NotFound {
+                        // TODO: Also FilesystemLoop when that's stable
+                        log::warn!(
+                            "Failed to read symlink target metadata for path {path:?}: {err}"
+                        );
+                    }
+                    // For a broken or recursive symlink, return the symlink metadata. (Or
+                    // as edge cases, a symlink into a directory we can't read, which is hard
+                    // to distinguish from just being broken.)
+                    symlink_metadata
+                }
             }
         } else {
             symlink_metadata

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -3501,6 +3501,7 @@ mod tests {
     }
 
     #[gpui::test]
+    #[cfg(unix)]
     async fn test_realfs_broken_symlink_metadata(executor: BackgroundExecutor) {
         let tempdir = TempDir::new().unwrap();
         let path = tempdir.path();
@@ -3525,6 +3526,7 @@ mod tests {
     }
 
     #[gpui::test]
+    #[cfg(unix)]
     async fn test_realfs_symlink_loop_metadata(executor: BackgroundExecutor) {
         let tempdir = TempDir::new().unwrap();
         let path = tempdir.path();


### PR DESCRIPTION
In the Zed tree, `crates/eval_utils/LICENSE-GPL` is a symlink to itself:

```
drwxrwxr-x   3 mbp mbp  4096 Dec 17 20:44 ./
drwxrwxr-x 209 mbp mbp 12288 Dec 17 20:44 ../
-rw-rw-r--   1 mbp mbp   286 Dec 17 20:44 Cargo.toml
lrwxrwxrwx   1 mbp mbp    11 Dec 17 20:44 LICENSE-GPL -> LICENSE-GPL
-rw-rw-r--   1 mbp mbp    45 Dec 17 20:44 README.md
drwxrwxr-x   2 mbp mbp  4096 Dec 17 20:44 src/
```

Zed currently treats that as an error reading the symlink, and as a result:

* the link doesn't appear in the tree at all (#25181)
* it emits errors to the log

The test about recursive symlinks fails without the fix.

This doesn't completely fix #25181, because the worktree crate also emits entries that it can't canonicalize. I'm not quite sure how to fix that yet, but adding tests and fixing one layer feels like a step forward?

Release Notes:

- N/A 