### PR TITLE
Trigger onTypeFormatting in `vim: insert line above/below`

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5403,7 +5403,7 @@ impl Editor {
         }
     }
 
-    fn trigger_on_type_formatting(
+    pub fn trigger_on_type_formatting(
         &self,
         input: String,
         window: &mut Window,

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -735,6 +735,9 @@ impl Vim {
                         (insert_point, SelectionGoal::None)
                     });
                 });
+                if let Some(format) = editor.trigger_on_type_formatting("\n".to_owned(), window, cx) {
+                    format.detach_and_log_err(cx);
+                }
             });
         });
     }
@@ -781,6 +784,9 @@ impl Vim {
                     });
                 });
                 editor.edit_with_autoindent(edits, cx);
+                if let Some(format) = editor.trigger_on_type_formatting("\n".to_owned(), window, cx) {
+                    format.detach_and_log_err(cx);
+                }
             });
         });
     }


### PR DESCRIPTION
like #44882 but for the vim commands

Release Notes:

- N/A *or* Added/Fixed/Improved ...
