### PR TITLE
debugger: Add Flutter hot reload and hot restart support

### DIFF
--- a/crates/dap/src/dap.rs
+++ b/crates/dap/src/dap.rs
@@ -1,6 +1,7 @@
 pub mod adapters;
 pub mod client;
 pub mod debugger_settings;
+pub mod flutter;
 pub mod inline_value;
 pub mod proto_conversions;
 mod registry;

--- a/crates/dap/src/flutter.rs
+++ b/crates/dap/src/flutter.rs
@@ -1,0 +1,81 @@
+//! Flutter-specific DAP custom requests.
+//!
+//! These requests are extensions to the standard Debug Adapter Protocol
+//! supported by Flutter's debug adapter. See:
+//! https://github.com/flutter/flutter/blob/master/packages/flutter_tools/lib/src/debug_adapters/README.md
+
+use dap_types::requests::Request;
+use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
+
+/// Hot reload request - injects updated source code into the running VM
+/// and rebuilds the widget tree without restarting the app.
+#[derive(Debug, Clone, Copy)]
+pub struct HotReload;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct HotReloadArguments {
+    /// The reason for the hot reload, typically "manual" or "save"
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct HotReloadResponse {}
+
+impl Request for HotReload {
+    type Arguments = HotReloadArguments;
+    type Response = HotReloadResponse;
+    const COMMAND: &'static str = "hotReload";
+}
+
+/// Hot restart request - updates code and performs a full restart
+/// (does not preserve state).
+#[derive(Debug, Clone, Copy)]
+pub struct HotRestart;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct HotRestartArguments {
+    /// The reason for the hot restart, typically "manual" or "save"
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct HotRestartResponse {}
+
+impl Request for HotRestart {
+    type Arguments = HotRestartArguments;
+    type Response = HotRestartResponse;
+    const COMMAND: &'static str = "hotRestart";
+}
+
+/// Call service request - invokes a VM service extension.
+/// Used for operations like debugDumpRenderTree, toggle debug painting, etc.
+#[derive(Debug, Clone, Copy)]
+pub struct CallService;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CallServiceArguments {
+    /// The service method to call (e.g., "ext.flutter.debugPaint")
+    pub method: String,
+    /// Optional parameters for the service call
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub params: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CallServiceResponse {
+    /// The result from the service call
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<serde_json::Value>,
+}
+
+impl Request for CallService {
+    type Arguments = CallServiceArguments;
+    type Response = CallServiceResponse;
+    const COMMAND: &'static str = "callService";
+}

--- a/crates/debugger_ui/src/session/running.rs
+++ b/crates/debugger_ui/src/session/running.rs
@@ -1715,6 +1715,20 @@ impl RunningState {
         });
     }
 
+    /// Flutter hot reload - injects updated code without restarting (preserves state).
+    pub fn flutter_hot_reload(&self, cx: &mut Context<Self>) {
+        self.session().update(cx, |state, cx| {
+            state.flutter_hot_reload(cx);
+        });
+    }
+
+    /// Flutter hot restart - updates code and performs full restart (loses state).
+    pub fn flutter_hot_restart(&self, cx: &mut Context<Self>) {
+        self.session().update(cx, |state, cx| {
+            state.flutter_hot_restart(cx);
+        });
+    }
+
     pub fn pause_thread(&self, cx: &mut Context<Self>) {
         let Some(thread_id) = self.thread_id else {
             return;

--- a/crates/project/src/debugger/dap_command.rs
+++ b/crates/project/src/debugger/dap_command.rs
@@ -1973,3 +1973,87 @@ impl LocalDapCommand for dap::WriteMemoryArguments {
         Ok(message)
     }
 }
+
+// Flutter-specific DAP commands
+
+/// Hot reload command - injects updated code into the running VM
+/// without restarting the app (preserves state).
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub(crate) struct FlutterHotReloadCommand {
+    /// Reason for the hot reload ("manual" or "save")
+    pub reason: Option<String>,
+}
+
+impl LocalDapCommand for FlutterHotReloadCommand {
+    type Response = ();
+    type DapRequest = dap::flutter::HotReload;
+
+    fn to_dap(&self) -> <Self::DapRequest as dap::requests::Request>::Arguments {
+        dap::flutter::HotReloadArguments {
+            reason: self.reason.clone(),
+        }
+    }
+
+    fn response_from_dap(
+        &self,
+        _message: <Self::DapRequest as dap::requests::Request>::Response,
+    ) -> Result<Self::Response> {
+        Ok(())
+    }
+}
+
+/// Hot restart command - updates code and performs a full restart
+/// (does not preserve state).
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub(crate) struct FlutterHotRestartCommand {
+    /// Reason for the hot restart ("manual" or "save")
+    pub reason: Option<String>,
+}
+
+impl LocalDapCommand for FlutterHotRestartCommand {
+    type Response = ();
+    type DapRequest = dap::flutter::HotRestart;
+
+    fn to_dap(&self) -> <Self::DapRequest as dap::requests::Request>::Arguments {
+        dap::flutter::HotRestartArguments {
+            reason: self.reason.clone(),
+        }
+    }
+
+    fn response_from_dap(
+        &self,
+        _message: <Self::DapRequest as dap::requests::Request>::Response,
+    ) -> Result<Self::Response> {
+        Ok(())
+    }
+}
+
+/// Call service command - invokes a VM service extension.
+/// Used for Flutter-specific operations like debug paint, performance overlay, etc.
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub(crate) struct FlutterCallServiceCommand {
+    /// The service method to call (e.g., "ext.flutter.debugPaint")
+    pub method: String,
+    /// Optional parameters for the service call
+    pub params: Option<serde_json::Value>,
+}
+
+impl LocalDapCommand for FlutterCallServiceCommand {
+    type Response = ();
+    type DapRequest = dap::flutter::CallService;
+
+    fn to_dap(&self) -> <Self::DapRequest as dap::requests::Request>::Arguments {
+        dap::flutter::CallServiceArguments {
+            method: self.method.clone(),
+            params: self.params.clone(),
+        }
+    }
+
+    fn response_from_dap(
+        &self,
+        _message: <Self::DapRequest as dap::requests::Request>::Response,
+    ) -> Result<Self::Response> {
+        // We ignore the result for now, just acknowledge the call succeeded
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary

Adds Hot Reload and Hot Restart actions for Flutter debug sessions. These appear as toolbar buttons when debugging Dart/Flutter applications and can be triggered via command palette.

- Add Flutter-specific DAP request types (`hotReload`, `hotRestart`, `callService`) in new `dap/src/flutter.rs` module
- Add `FlutterHotReloadCommand` and `FlutterHotRestartCommand` implementations in `dap_command.rs`
- Add `flutter_hot_reload()` and `flutter_hot_restart()` methods to `Session`
- Add `RunningState` bridge methods for UI integration
- Add toolbar buttons that appear conditionally when debugging Dart/Flutter adapters

## Motivation

This implements a commonly requested feature for Flutter developers. Currently, to hot reload during a debug session, users must switch to the terminal and press `r`. With this PR, hot reload/restart buttons appear in the debugger toolbar for Dart/Flutter sessions.

Closes #11107

## Screenshots

*Toolbar shows Hot Reload (⟳) and Hot Restart (↻) buttons when debugging a Flutter app*