### PR TITLE
Optimize project search by skipping excerpt boundary blocks and tracking total match count

### DIFF
--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -453,6 +453,12 @@ impl DisplayMap {
         &self.block_map.folded_buffers
     }
 
+    /// Sets whether to skip excerpt boundary block creation during sync.
+    /// This is a performance optimization for editors with many excerpts (like project search).
+    pub fn set_skip_excerpt_boundary_sync(&mut self, skip: bool) {
+        self.block_map.set_skip_excerpt_boundary_sync(skip);
+    }
+
     #[instrument(skip_all)]
     pub fn insert_creases(
         &mut self,


### PR DESCRIPTION
Closes [#ISSUE](https://github.com/zed-industries/zed/issues/43543)

Release Notes:

- Optimized project search to prevent UI hang

Note：
You can reproduce the issue by opening the Zed project and searching for 'task' or 'fn' in Project Search.
This PR fix the issue by:
1. Skip Excerpt Boundary Blocks in Project Search
2. Batch Match Range Updates

If the issue can still be reproduced, I'd be happy to continue investigating.