### PR TITLE
gpui(windows): Don't log incorrect errors on `SetActiveWindow` calls

### DIFF
--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -42,7 +42,7 @@ impl WindowsWindowInner {
         let handled = match msg {
             // eagerly activate the window, so calls to `active_window` will work correctly
             WM_MOUSEACTIVATE => {
-                unsafe { SetActiveWindow(handle).log_err() };
+                unsafe { SetActiveWindow(handle).ok() };
                 None
             }
             WM_ACTIVATE => self.handle_activate_msg(wparam),

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -740,8 +740,8 @@ impl PlatformWindow for WindowsWindow {
                         ShowWindowAsync(hwnd, SW_RESTORE).ok().log_err();
                     }
 
-                    SetActiveWindow(hwnd).log_err();
-                    SetFocus(Some(hwnd)).log_err();
+                    SetActiveWindow(hwnd).ok();
+                    SetFocus(Some(hwnd)).ok();
                 }
 
                 // premium ragebait by windows, this is needed because the window


### PR DESCRIPTION
The function returns the previous focus handle, which may be null if there is no previous focus. Unfortunately that also overlaps with the error return value, so winapi will hand us a error 0 back in those cases which we log ...


Release Notes:

- N/A *or* Added/Fixed/Improved ...
