### PR TITLE
Persist dock visibility and manage terminal panel lifecycle by explicitly creating terminals on open and closing when empty

### DIFF
--- a/crates/terminal_view/src/persistence.rs
+++ b/crates/terminal_view/src/persistence.rs
@@ -20,7 +20,7 @@ use workspace::{
 };
 
 use crate::{
-    TerminalView, default_working_directory,
+    TerminalView,
     terminal_panel::{TerminalPanel, new_terminal_pane},
 };
 
@@ -235,41 +235,11 @@ async fn deserialize_pane_group(
                 async move |cx| {
                     let new_items = new_items.await;
 
-                    let items = pane.update_in(cx, |pane, window, cx| {
+                    let _items = pane.update_in(cx, |pane, window, cx| {
                         populate_pane_items(pane, new_items, active_item, window, cx);
                         pane.set_pinned_count(pinned_count.min(pane.items_len()));
                         pane.items_len()
                     });
-                    // Avoid blank panes in splits
-                    if items.is_ok_and(|items| items == 0) {
-                        let working_directory = workspace
-                            .update(cx, |workspace, cx| default_working_directory(workspace, cx))
-                            .ok()
-                            .flatten();
-                        let terminal = project
-                            .update(cx, |project, cx| {
-                                project.create_terminal_shell(working_directory, cx)
-                            })
-                            .await
-                            .log_err();
-                        let Some(terminal) = terminal else {
-                            return;
-                        };
-                        pane.update_in(cx, |pane, window, cx| {
-                            let terminal_view = Box::new(cx.new(|cx| {
-                                TerminalView::new(
-                                    terminal,
-                                    workspace.clone(),
-                                    Some(workspace_id),
-                                    project.downgrade(),
-                                    window,
-                                    cx,
-                                )
-                            }));
-                            pane.add_item(terminal_view, true, false, None, window, cx);
-                        })
-                        .ok();
-                    }
                 }
             })
             .await;

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -60,17 +60,7 @@ pub fn init(cx: &mut App) {
             workspace.register_action(|workspace, _: &ToggleFocus, window, cx| {
                 if is_enabled_in_workspace(workspace, cx) {
                     workspace.toggle_panel_focus::<TerminalPanel>(window, cx);
-                    // Create a terminal if panel is empty when user explicitly opens it
-                    if let Some(panel) = workspace.panel::<TerminalPanel>(cx) {
-                        if panel.read(cx).has_no_terminals(cx) {
-                            panel.update(cx, |panel, cx| {
-                                let kind = default_working_directory(workspace, cx);
-                                panel
-                                    .add_terminal_shell(kind, RevealStrategy::Always, window, cx)
-                                    .detach_and_log_err(cx);
-                            });
-                        }
-                    }
+                    ensure_terminal_if_empty(workspace, window, cx);
                 }
             });
             workspace.register_action(|workspace, _: &Toggle, window, cx| {
@@ -79,28 +69,30 @@ pub fn init(cx: &mut App) {
                     if !did_focus {
                         workspace.close_panel::<TerminalPanel>(window, cx);
                     } else {
-                        // Create a terminal if panel is empty when user explicitly opens it
-                        if let Some(panel) = workspace.panel::<TerminalPanel>(cx) {
-                            if panel.read(cx).has_no_terminals(cx) {
-                                panel.update(cx, |panel, cx| {
-                                    let kind = default_working_directory(workspace, cx);
-                                    panel
-                                        .add_terminal_shell(
-                                            kind,
-                                            RevealStrategy::Always,
-                                            window,
-                                            cx,
-                                        )
-                                        .detach_and_log_err(cx);
-                                });
-                            }
-                        }
+                        ensure_terminal_if_empty(workspace, window, cx);
                     }
                 }
             });
         },
     )
     .detach();
+}
+
+fn ensure_terminal_if_empty(
+    workspace: &mut Workspace,
+    window: &mut Window,
+    cx: &mut Context<Workspace>,
+) {
+    if let Some(panel) = workspace.panel::<TerminalPanel>(cx) {
+        if panel.read(cx).has_no_terminals(cx) {
+            panel.update(cx, |panel, cx| {
+                let kind = default_working_directory(workspace, cx);
+                panel
+                    .add_terminal_shell(kind, RevealStrategy::Always, window, cx)
+                    .detach_and_log_err(cx);
+            });
+        }
+    }
 }
 
 pub struct TerminalPanel {
@@ -829,8 +821,8 @@ impl TerminalPanel {
     ) -> Task<Result<WeakEntity<Terminal>>> {
         let workspace = self.workspace.clone();
         let pane = self.active_pane.clone();
-        // Increment synchronously so that has_no_terminals() returns false
-        // before any deferred callbacks run (e.g., in set_active).
+        // Increment synchronously so that has_no_terminals() returns false immediately,
+        // preventing the dock from auto-closing before the terminal is added.
         self.pending_terminals_to_add += 1;
 
         cx.spawn_in(window, async move |terminal_panel, cx| {
@@ -974,6 +966,12 @@ impl TerminalPanel {
                     result
                 }
                 Err(error) => {
+                    terminal_panel
+                        .update(cx, |terminal_panel, _| {
+                            terminal_panel.pending_terminals_to_add =
+                                terminal_panel.pending_terminals_to_add.saturating_sub(1);
+                        })
+                        .ok();
                     pane.update_in(cx, |pane, window, cx| {
                         let focus = pane.has_focus(window, cx);
                         let failed_to_spawn = cx.new(|cx| FailedToSpawnTerminal {

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -60,12 +60,41 @@ pub fn init(cx: &mut App) {
             workspace.register_action(|workspace, _: &ToggleFocus, window, cx| {
                 if is_enabled_in_workspace(workspace, cx) {
                     workspace.toggle_panel_focus::<TerminalPanel>(window, cx);
+                    // Create a terminal if panel is empty when user explicitly opens it
+                    if let Some(panel) = workspace.panel::<TerminalPanel>(cx) {
+                        if panel.read(cx).has_no_terminals(cx) {
+                            panel.update(cx, |panel, cx| {
+                                let kind = default_working_directory(workspace, cx);
+                                panel
+                                    .add_terminal_shell(kind, RevealStrategy::Always, window, cx)
+                                    .detach_and_log_err(cx);
+                            });
+                        }
+                    }
                 }
             });
             workspace.register_action(|workspace, _: &Toggle, window, cx| {
                 if is_enabled_in_workspace(workspace, cx) {
-                    if !workspace.toggle_panel_focus::<TerminalPanel>(window, cx) {
+                    let did_focus = workspace.toggle_panel_focus::<TerminalPanel>(window, cx);
+                    if !did_focus {
                         workspace.close_panel::<TerminalPanel>(window, cx);
+                    } else {
+                        // Create a terminal if panel is empty when user explicitly opens it
+                        if let Some(panel) = workspace.panel::<TerminalPanel>(cx) {
+                            if panel.read(cx).has_no_terminals(cx) {
+                                panel.update(cx, |panel, cx| {
+                                    let kind = default_working_directory(workspace, cx);
+                                    panel
+                                        .add_terminal_shell(
+                                            kind,
+                                            RevealStrategy::Always,
+                                            window,
+                                            cx,
+                                        )
+                                        .detach_and_log_err(cx);
+                                });
+                            }
+                        }
                     }
                 }
             });
@@ -345,7 +374,13 @@ impl TerminalPanel {
     ) {
         match event {
             pane::Event::ActivateItem { .. } => self.serialize(cx),
-            pane::Event::RemovedItem { .. } => self.serialize(cx),
+            pane::Event::RemovedItem { .. } => {
+                self.serialize(cx);
+                // Close the dock when the last terminal is removed
+                if self.has_no_terminals(cx) {
+                    cx.emit(PanelEvent::Close);
+                }
+            }
             pane::Event::Remove { focus_on_pane } => {
                 let pane_count_before_removal = self.center.panes().len();
                 let _removal_result = self.center.remove(pane, cx);
@@ -793,14 +828,23 @@ impl TerminalPanel {
         cx: &mut Context<Self>,
     ) -> Task<Result<WeakEntity<Terminal>>> {
         let workspace = self.workspace.clone();
+        let pane = self.active_pane.clone();
+        // Increment synchronously so that has_no_terminals() returns false
+        // before any deferred callbacks run (e.g., in set_active).
+        self.pending_terminals_to_add += 1;
+
         cx.spawn_in(window, async move |terminal_panel, cx| {
             if workspace.update(cx, |workspace, cx| !is_enabled_in_workspace(workspace, cx))? {
+                // Decrement if we bailed early
+                terminal_panel
+                    .update(cx, |this, _| {
+                        this.pending_terminals_to_add =
+                            this.pending_terminals_to_add.saturating_sub(1);
+                    })
+                    .ok();
                 anyhow::bail!("terminal not yet supported for remote projects");
             }
-            let pane = terminal_panel.update(cx, |terminal_panel, _| {
-                terminal_panel.pending_terminals_to_add += 1;
-                terminal_panel.active_pane.clone()
-            })?;
+            let pane = pane;
             let project = workspace.read_with(cx, |workspace, _| workspace.project().clone())?;
             let terminal = project
                 .update(cx, |project, cx| project.create_terminal_task(task, cx))
@@ -1092,8 +1136,15 @@ impl TerminalPanel {
         })
     }
 
-    fn has_no_terminals(&self, cx: &App) -> bool {
-        self.active_pane.read(cx).items_len() == 0 && self.pending_terminals_to_add == 0
+    pub fn has_no_terminals(&self, cx: &App) -> bool {
+        // Check all panes in the center group, not just the active pane.
+        // This prevents incorrectly closing the dock when split panes still have terminals.
+        let all_panes_empty = self
+            .center
+            .panes()
+            .into_iter()
+            .all(|pane| pane.read(cx).items_len() == 0);
+        all_panes_empty && self.pending_terminals_to_add == 0
     }
 
     pub fn assistant_enabled(&self) -> bool {
@@ -1601,23 +1652,10 @@ impl Panel for TerminalPanel {
         cx.notify();
     }
 
-    fn set_active(&mut self, active: bool, window: &mut Window, cx: &mut Context<Self>) {
-        let old_active = self.active;
+    fn set_active(&mut self, active: bool, _window: &mut Window, _cx: &mut Context<Self>) {
+        // Just track active state. Terminal creation is handled by action handlers
+        // (Toggle/ToggleFocus) to avoid race conditions when tasks are spawned.
         self.active = active;
-        if !active || old_active == active || !self.has_no_terminals(cx) {
-            return;
-        }
-        cx.defer_in(window, |this, window, cx| {
-            let Ok(kind) = this
-                .workspace
-                .update(cx, |workspace, cx| default_working_directory(workspace, cx))
-            else {
-                return;
-            };
-
-            this.add_terminal_shell(kind, RevealStrategy::Always, window, cx)
-                .detach_and_log_err(cx)
-        })
     }
 
     fn icon_label(&self, _window: &Window, cx: &App) -> Option<String> {

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -252,7 +252,7 @@ impl From<&dyn PanelHandle> for AnyView {
     }
 }
 
-/// A container with a fixed [`DockPosition`] adjacent to a certain widown edge.
+/// A container with a fixed [`DockPosition`] adjacent to a certain window edge.
 /// Can contain multiple panels and show/hide itself with all contents.
 pub struct Dock {
     position: DockPosition,
@@ -681,6 +681,12 @@ impl Dock {
                             .is_some_and(|p| p.panel_id() == Entity::entity_id(panel))
                         {
                             this.set_open(false, window, cx);
+                            // Serialize workspace to persist dock visibility change
+                            workspace
+                                .update(cx, |workspace, cx| {
+                                    workspace.serialize_workspace(window, cx);
+                                })
+                                .ok();
                         }
                     }
                 },

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -4241,13 +4241,19 @@ impl Workspace {
         self.open_panel::<T>(window, cx);
     }
 
-    pub fn close_panel<T: Panel>(&self, window: &mut Window, cx: &mut Context<Self>) {
+    pub fn close_panel<T: Panel>(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let mut did_close = false;
         for dock in self.all_docks().iter() {
             dock.update(cx, |dock, cx| {
-                if dock.panel::<T>().is_some() {
-                    dock.set_open(false, window, cx)
+                if dock.panel::<T>().is_some() && dock.is_open() {
+                    dock.set_open(false, window, cx);
+                    did_close = true;
                 }
-            })
+            });
+        }
+        // Serialize workspace to persist dock visibility change
+        if did_close {
+            self.serialize_workspace(window, cx);
         }
     }
 


### PR DESCRIPTION
Closes [#ISSUE](https://github.com/zed-industries/zed/issues/45443)

Release Notes:

- Dock visibility now persists correctly
- No more extra terminal when spawning tasks
