### PR TITLE
linux: Name desktop file correctly during bundle

### DIFF
--- a/docs/src/linux.md
+++ b/docs/src/linux.md
@@ -91,7 +91,7 @@ ln -sf ~/.local/zed.app/bin/zed ~/.local/bin/zed
 If you'd like integration with an XDG-compatible desktop environment, you will also need to install the `.desktop` file:
 
 ```sh
-cp ~/.local/zed.app/share/applications/zed.desktop ~/.local/share/applications/dev.zed.Zed.desktop
+install -D ~/.local/zed.app/share/applications/dev.zed.Zed.desktop -t ~/.local/share/applications
 sed -i "s|Icon=zed|Icon=$HOME/.local/zed.app/share/icons/hicolor/512x512/apps/zed.png|g" ~/.local/share/applications/dev.zed.Zed.desktop
 sed -i "s|Exec=zed|Exec=$HOME/.local/zed.app/libexec/zed-editor|g" ~/.local/share/applications/dev.zed.Zed.desktop
 ```

--- a/script/bundle-linux
+++ b/script/bundle-linux
@@ -164,17 +164,21 @@ export APP_ICON="zed"
 export APP_ARGS="%U"
 if [[ "$channel" == "preview" ]]; then
   export APP_NAME="Zed Preview"
+  APP_ID="dev.zed.Zed-Preview"
 elif [[ "$channel" == "nightly" ]]; then
   export APP_NAME="Zed Nightly"
+  APP_ID="dev.zed.Zed-Nightly"
 elif [[ "$channel" == "dev" ]]; then
   export APP_NAME="Zed Devel"
+  APP_ID="dev.zed.Zed-Dev"
 else
   export APP_NAME="Zed"
+  APP_ID="dev.zed.Zed"
 fi
 
 mkdir -p "${zed_dir}/share/applications"
-envsubst < "crates/zed/resources/zed.desktop.in" > "${zed_dir}/share/applications/zed$suffix.desktop"
-chmod +x "${zed_dir}/share/applications/zed$suffix.desktop"
+envsubst < "crates/zed/resources/zed.desktop.in" > "${zed_dir}/share/applications/$APP_ID.desktop"
+chmod +x "${zed_dir}/share/applications/$APP_ID.desktop"
 
 # Copy generated licenses so they'll end up in archive too
 cp "assets/licenses.md" "${zed_dir}/licenses.md"

--- a/script/install.sh
+++ b/script/install.sh
@@ -91,26 +91,6 @@ linux() {
         suffix="-$channel"
     fi
 
-    appid=""
-    case "$channel" in
-      stable)
-        appid="dev.zed.Zed"
-        ;;
-      nightly)
-        appid="dev.zed.Zed-Nightly"
-        ;;
-      preview)
-        appid="dev.zed.Zed-Preview"
-        ;;
-      dev)
-        appid="dev.zed.Zed-Dev"
-        ;;
-      *)
-        echo "Unknown release channel: ${channel}. Using stable app ID."
-        appid="dev.zed.Zed"
-        ;;
-    esac
-
     # Unpack
     rm -rf "$HOME/.local/zed$suffix.app"
     mkdir -p "$HOME/.local/zed$suffix.app"
@@ -128,8 +108,9 @@ linux() {
     fi
 
     # Copy .desktop file
-    desktop_file_path="$HOME/.local/share/applications/${appid}.desktop"
-    cp "$HOME/.local/zed$suffix.app/share/applications/zed$suffix.desktop" "${desktop_file_path}"
+    desktop_file_path_now="$(find "$HOME/.local/zed$suffix.app/share/applications" -name "*.desktop")"
+    desktop_file_path="$HOME/.local/share/applications/$(basename "$desktop_file_path_now")"
+    cp "$desktop_file_path_now" "${desktop_file_path}"
     sed -i "s|Icon=zed|Icon=$HOME/.local/zed$suffix.app/share/icons/hicolor/512x512/apps/zed.png|g" "${desktop_file_path}"
     sed -i "s|Exec=zed|Exec=$HOME/.local/zed$suffix.app/bin/zed|g" "${desktop_file_path}"
 }

--- a/script/install.sh
+++ b/script/install.sh
@@ -93,19 +93,19 @@ linux() {
 
     appid=""
     case "$channel" in
-    stable)
+      stable)
         appid="dev.zed.Zed"
         ;;
-    nightly)
+      nightly)
         appid="dev.zed.Zed-Nightly"
         ;;
-    preview)
+      preview)
         appid="dev.zed.Zed-Preview"
         ;;
-    dev)
+      dev)
         appid="dev.zed.Zed-Dev"
         ;;
-    *)
+      *)
         echo "Unknown release channel: ${channel}. Using stable app ID."
         appid="dev.zed.Zed"
         ;;

--- a/script/install.sh
+++ b/script/install.sh
@@ -91,6 +91,26 @@ linux() {
         suffix="-$channel"
     fi
 
+    appid=""
+    case "$channel" in
+    stable)
+        appid="dev.zed.Zed"
+        ;;
+    nightly)
+        appid="dev.zed.Zed-Nightly"
+        ;;
+    preview)
+        appid="dev.zed.Zed-Preview"
+        ;;
+    dev)
+        appid="dev.zed.Zed-Dev"
+        ;;
+    *)
+        echo "Unknown release channel: ${channel}. Using stable app ID."
+        appid="dev.zed.Zed"
+        ;;
+    esac
+
     # Unpack
     rm -rf "$HOME/.local/zed$suffix.app"
     mkdir -p "$HOME/.local/zed$suffix.app"
@@ -108,9 +128,14 @@ linux() {
     fi
 
     # Copy .desktop file
-    desktop_file_path_now="$(find "$HOME/.local/zed$suffix.app/share/applications" -name "*.desktop")"
-    desktop_file_path="$HOME/.local/share/applications/$(basename "$desktop_file_path_now")"
-    cp "$desktop_file_path_now" "${desktop_file_path}"
+    desktop_file_path="$HOME/.local/share/applications/${appid}.desktop"
+    src_dir="$HOME/.local/zed$suffix.app/share/applications"
+    if [ -f "$src_dir/${appid}.desktop" ]; then
+        cp "$src_dir/${appid}.desktop" "${desktop_file_path}"
+    else
+        # Fallback for older tarballs
+        cp "$src_dir/zed$suffix.desktop" "${desktop_file_path}"
+    fi
     sed -i "s|Icon=zed|Icon=$HOME/.local/zed$suffix.app/share/icons/hicolor/512x512/apps/zed.png|g" "${desktop_file_path}"
     sed -i "s|Exec=zed|Exec=$HOME/.local/zed$suffix.app/bin/zed|g" "${desktop_file_path}"
 }


### PR DESCRIPTION
Closes #45507

There have been 5+ PRs attempting to fix Linux desktop icon association by adding `StartupWMClass` back to the `.desktop.in` template (#15763, #20644, #23459, #33019, #37962), all closed because `StartupWMClass` is an X11-specific key that GNOME happens to misuse on Wayland, and the correct fix per the FreeDesktop spec is to name the `.desktop` file to match the app's Wayland `app_id` / X11 `WM_CLASS`. Refer: https://github.com/zed-industries/zed/issues/12707#issuecomment-2168742761

The root cause is that `bundle-linux` was never updated to produce the correct filename in the tarball. The only consumers of the tarball's desktop file are `install.sh` and manual extractors. So this fix is for people who download the tarball and extract it without `install.sh`. The docs already tell them to rename, but as @wcbing points out, not everyone reads that carefully.

We are now making `bundle-linux` produce the correctly named desktop file from the start.

Release Notes:

- N/A
