### PR TITLE
nix: Use exact Rust 1.92.0 channel

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.92"
+channel = "1.92.0"
 profile = "minimal"
 components = [ "rustfmt", "clippy" ]
 targets = [


### PR DESCRIPTION
Using channel = "1.92" in rust-toolchain.toml caused fromRustupToolchainFile to resolve an incomplete toolchain, resulting in a non-executable cargo binary.

Pinning the exact patch version (1.92.0) resolves the issue.

Closes #45514

Release Notes:

- N/A 
