### PR TITLE
docs: Fix `download_file` documentation

### DIFF
--- a/docs/src/extensions/capabilities.md
+++ b/docs/src/extensions/capabilities.md
@@ -62,7 +62,7 @@ The `download_file` capability grants extensions the ability to download files u
 To allow any file to be downloaded:
 
 ```toml
-{ kind = "download_file", host = "github.com", path = ["**"] }
+{ kind = "download_file", host = "*", path = ["**"] }
 ```
 
 To allow any file to be downloaded from `github.com`:


### PR DESCRIPTION
Fix a small error in the docs for the extension capabilities

Release Notes:

- N/A
