### PR TITLE
Allow specifying ZED_VERSION with fallback to latest in `install.sh`

### DIFF
--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -36,6 +36,16 @@ For most Linux users, the easiest way to install Zed is through our installation
 curl -f https://zed.dev/install.sh | sh
 ```
 
+You can now optionally specify a **version** of Zed to install using the `ZED_VERSION` environment variable:
+
+```sh
+# Install the latest stable version (default)
+curl -f https://zed.dev/install.sh | sh
+
+# Install a specific version
+curl -f https://zed.dev/install.sh | ZED_VERSION=0.216.0 sh
+```
+
 If you'd like to help us test our new features, you can also install our preview build:
 
 ```sh

--- a/script/install.sh
+++ b/script/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 set -eu
 
-# Downloads the latest tarball from https://zed.dev/releases and unpacks it
+# Downloads the a tarball from https://zed.dev/releases and unpacks it
 # into ~/.local/. If you'd prefer to do this manually, instructions are at
 # https://zed.dev/docs/linux.
 
@@ -9,6 +9,7 @@ main() {
     platform="$(uname -s)"
     arch="$(uname -m)"
     channel="${ZED_CHANNEL:-stable}"
+    ZED_VERSION="${ZED_VERSION:-latest}"
     # Use TMPDIR if available (for environments with non-standard temp directories)
     if [ -n "${TMPDIR:-}" ] && [ -d "${TMPDIR}" ]; then
         temp="$(mktemp -d "$TMPDIR/zed-XXXXXX")"
@@ -81,8 +82,8 @@ linux() {
     if [ -n "${ZED_BUNDLE_PATH:-}" ]; then
         cp "$ZED_BUNDLE_PATH" "$temp/zed-linux-$arch.tar.gz"
     else
-        echo "Downloading Zed"
-        curl "https://cloud.zed.dev/releases/$channel/latest/download?asset=zed&arch=$arch&os=linux&source=install.sh" > "$temp/zed-linux-$arch.tar.gz"
+        echo "Downloading Zed version: $ZED_VERSION"
+        curl "https://cloud.zed.dev/releases/$channel/$ZED_VERSION/download?asset=zed&arch=$arch&os=linux&source=install.sh" > "$temp/zed-linux-$arch.tar.gz"
     fi
 
     suffix=""
@@ -134,8 +135,8 @@ linux() {
 }
 
 macos() {
-    echo "Downloading Zed"
-    curl "https://cloud.zed.dev/releases/$channel/latest/download?asset=zed&os=macos&arch=$arch&source=install.sh" > "$temp/Zed-$arch.dmg"
+    echo "Downloading Zed version: $ZED_VERSION"
+    curl "https://cloud.zed.dev/releases/$channel/$ZED_VERSION/download?asset=zed&os=macos&arch=$arch&source=install.sh" > "$temp/Zed-$arch.dmg"
     hdiutil attach -quiet "$temp/Zed-$arch.dmg" -mountpoint "$temp/mount"
     app="$(cd "$temp/mount/"; echo *.app)"
     echo "Installing $app"

--- a/script/install.sh
+++ b/script/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 set -eu
 
-# Downloads the a tarball from https://zed.dev/releases and unpacks it
+# Downloads the tarball from https://zed.dev/releases and unpacks it
 # into ~/.local/. If you'd prefer to do this manually, instructions are at
 # https://zed.dev/docs/linux.
 

--- a/script/install.sh
+++ b/script/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 set -eu
 
-# Downloads the tarball from https://zed.dev/releases and unpacks it
+# Downloads a tarball from https://zed.dev/releases and unpacks it
 # into ~/.local/. If you'd prefer to do this manually, instructions are at
 # https://zed.dev/docs/linux.
 


### PR DESCRIPTION
This PR updates the Linux install script to support installing a specific version of Zed via the
ZED_VERSION environment variable.

- If ZED_VERSION is set, that version will be downloaded.
- If ZED_VERSION is not set, the script defaults to the latest stable version, preserving
  existing behavior.
- Works for both Linux and macOS installs.
- Maintains compatibility with ZED_CHANNEL for preview builds.

This enhancement allows users to:
- Pin a specific Zed version for reproducible setups or CI workflows.
- Easily install older or known-good versions without manually downloading release assets.

Usage examples:
- Install latest stable (default):
  curl -f https://zed.dev/install.sh | sh
- Install specific version:
  curl -f https://zed.dev/install.sh | ZED_VERSION=0.216.0 sh
  
  Use this — it’s correct, concise, and clearly user-facing:

Release Notes

* **Added:** Support for installing a specific Zed version via the `ZED_VERSION` environment variable in the install script (defaults to `latest` when unset).