### PR TITLE
extension_ci: Use larger runners for extension bundling

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -25,6 +25,7 @@ self-hosted-runner:
     - namespace-profile-32x64-ubuntu-2204
     # Namespace Ubuntu 24.04 (like ubuntu-latest)
     - namespace-profile-2x4-ubuntu-2404
+    - namespace-profile-8x32-ubuntu-2404
     # Namespace Limited Preview
     - namespace-profile-8x16-ubuntu-2004-arm-m4
     - namespace-profile-8x32-ubuntu-2004-arm-m4

--- a/.github/workflows/extension_tests.yml
+++ b/.github/workflows/extension_tests.yml
@@ -51,7 +51,7 @@ jobs:
     needs:
     - orchestrate
     if: needs.orchestrate.outputs.check_rust == 'true'
-    runs-on: namespace-profile-16x32-ubuntu-2204
+    runs-on: namespace-profile-4x8-ubuntu-2204
     steps:
     - name: steps::checkout_repo
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -79,7 +79,7 @@ jobs:
     needs:
     - orchestrate
     if: needs.orchestrate.outputs.check_extension == 'true'
-    runs-on: namespace-profile-2x4-ubuntu-2404
+    runs-on: namespace-profile-8x32-ubuntu-2404
     steps:
     - name: steps::checkout_repo
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/tooling/xtask/src/tasks/workflows/extension_tests.rs
+++ b/tooling/xtask/src/tasks/workflows/extension_tests.rs
@@ -48,7 +48,7 @@ fn run_clippy() -> Step<Run> {
 fn check_rust() -> NamedJob {
     let job = Job::default()
         .with_repository_owner_guard()
-        .runs_on(runners::LINUX_DEFAULT)
+        .runs_on(runners::LINUX_MEDIUM)
         .timeout_minutes(3u32)
         .add_step(steps::checkout_repo())
         .add_step(steps::cache_rust_dependencies_namespace())
@@ -66,7 +66,7 @@ pub(crate) fn check_extension() -> NamedJob {
     let (cache_download, cache_hit) = cache_zed_extension_cli();
     let job = Job::default()
         .with_repository_owner_guard()
-        .runs_on(runners::LINUX_SMALL)
+        .runs_on(runners::LINUX_LARGE_RAM)
         .timeout_minutes(2u32)
         .add_step(steps::checkout_repo())
         .add_step(cache_download)

--- a/tooling/xtask/src/tasks/workflows/runners.rs
+++ b/tooling/xtask/src/tasks/workflows/runners.rs
@@ -8,6 +8,9 @@ pub const LINUX_MEDIUM: Runner = Runner("namespace-profile-4x8-ubuntu-2204");
 pub const LINUX_X86_BUNDLER: Runner = Runner("namespace-profile-32x64-ubuntu-2004");
 pub const LINUX_ARM_BUNDLER: Runner = Runner("namespace-profile-8x32-ubuntu-2004-arm-m4");
 
+// Larger Ubuntu runner with glibc 2.39 for extension bundling
+pub const LINUX_LARGE_RAM: Runner = Runner("namespace-profile-8x32-ubuntu-2404");
+
 pub const MAC_DEFAULT: Runner = Runner("self-mini-macos");
 pub const WINDOWS_DEFAULT: Runner = Runner("self-32vcpu-windows-2022");
 


### PR DESCRIPTION
`2x4` is not nearly enough for some of the grammars in use, hence change this to a larger runner.

Also, reduce the size for the Rust runners a bit, as they don't need to be quite as large for the amount of Rust code we have in extensions.

Release Notes:

- N/A