### PR TITLE
extension_ci: Specify needed permissions for jobs

### DIFF
--- a/.github/workflows/extension_bump.yml
+++ b/.github/workflows/extension_bump.yml
@@ -66,7 +66,7 @@ jobs:
     if: |-
       (github.repository_owner == 'zed-industries' || github.repository_owner == 'zed-extensions') &&
       (inputs.force-bump == 'true' || needs.check_bump_needed.outputs.needs_bump == 'true')
-    runs-on: namespace-profile-8x16-ubuntu-2204
+    runs-on: namespace-profile-2x4-ubuntu-2404
     steps:
     - id: generate-token
       name: extension_bump::generate_token
@@ -119,7 +119,7 @@ jobs:
     needs:
     - check_bump_needed
     if: (github.repository_owner == 'zed-industries' || github.repository_owner == 'zed-extensions') && github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.check_bump_needed.outputs.needs_bump == 'false'
-    runs-on: namespace-profile-8x16-ubuntu-2204
+    runs-on: namespace-profile-2x4-ubuntu-2404
     steps:
     - id: generate-token
       name: extension_bump::generate_token

--- a/.github/workflows/extension_release.yml
+++ b/.github/workflows/extension_release.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   create_release:
     if: (github.repository_owner == 'zed-industries' || github.repository_owner == 'zed-extensions')
-    runs-on: namespace-profile-8x16-ubuntu-2204
+    runs-on: namespace-profile-2x4-ubuntu-2404
     steps:
     - id: generate-token
       name: extension_bump::generate_token

--- a/.github/workflows/extension_tests.yml
+++ b/.github/workflows/extension_tests.yml
@@ -51,7 +51,7 @@ jobs:
     needs:
     - orchestrate
     if: needs.orchestrate.outputs.check_rust == 'true'
-    runs-on: namespace-profile-16x32-ubuntu-2204
+    runs-on: namespace-profile-4x8-ubuntu-2204
     steps:
     - name: steps::checkout_repo
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/extensions/workflows/bump_version.yml
+++ b/extensions/workflows/bump_version.yml
@@ -43,6 +43,7 @@ jobs:
     - determine_bump_type
     if: github.event.action != 'labeled' || needs.determine_bump_type.outputs.bump_type != 'patch'
     permissions:
+      actions: write
       contents: write
       issues: write
       pull-requests: write

--- a/extensions/workflows/bump_version.yml
+++ b/extensions/workflows/bump_version.yml
@@ -13,6 +13,7 @@ on:
   workflow_dispatch: {}
 jobs:
   determine_bump_type:
+    if: (github.repository_owner == 'zed-industries' || github.repository_owner == 'zed-extensions')
     runs-on: namespace-profile-2x4-ubuntu-2404
     permissions: {}
     steps:

--- a/extensions/workflows/bump_version.yml
+++ b/extensions/workflows/bump_version.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch: {}
 jobs:
   determine_bump_type:
-    runs-on: namespace-profile-16x32-ubuntu-2204
+    runs-on: namespace-profile-2x4-ubuntu-2404
     permissions: {}
     steps:
     - id: get-bump-type

--- a/extensions/workflows/bump_version.yml
+++ b/extensions/workflows/bump_version.yml
@@ -40,6 +40,10 @@ jobs:
     needs:
     - determine_bump_type
     if: github.event.action != 'labeled' || needs.determine_bump_type.outputs.bump_type != 'patch'
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     uses: zed-industries/zed/.github/workflows/extension_bump.yml@main
     secrets:
       app-id: ${{ secrets.ZED_ZIPPY_APP_ID }}

--- a/extensions/workflows/bump_version.yml
+++ b/extensions/workflows/bump_version.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   determine_bump_type:
     runs-on: namespace-profile-16x32-ubuntu-2204
+    permissions: {}
     steps:
     - id: get-bump-type
       name: extensions::bump_version::get_bump_type

--- a/extensions/workflows/release_version.yml
+++ b/extensions/workflows/release_version.yml
@@ -7,6 +7,9 @@ on:
     - v**
 jobs:
   call_release_version:
+    permissions:
+      contents: write
+      pull-requests: write
     uses: zed-industries/zed/.github/workflows/extension_release.yml@main
     secrets:
       app-id: ${{ secrets.ZED_ZIPPY_APP_ID }}

--- a/extensions/workflows/run_tests.yml
+++ b/extensions/workflows/run_tests.yml
@@ -10,6 +10,8 @@ on:
     - main
 jobs:
   call_extension_tests:
+    permissions:
+      contents: read
     uses: zed-industries/zed/.github/workflows/extension_tests.yml@main
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}pr

--- a/tooling/xtask/src/tasks/workflows/extension_bump.rs
+++ b/tooling/xtask/src/tasks/workflows/extension_bump.rs
@@ -107,7 +107,7 @@ fn create_version_label(
             "{DEFAULT_REPOSITORY_OWNER_GUARD} && github.event_name == 'push' && github.ref == 'refs/heads/main' && {} == 'false'",
             needs_bump.expr(),
         )))
-        .runs_on(runners::LINUX_LARGE)
+        .runs_on(runners::LINUX_SMALL)
         .timeout_minutes(1u32)
         .add_step(generate_token)
         .add_step(steps::checkout_repo())
@@ -190,7 +190,7 @@ fn bump_extension_version(
             force_bump.expr(),
             needs_bump.expr(),
         )))
-        .runs_on(runners::LINUX_LARGE)
+        .runs_on(runners::LINUX_SMALL)
         .timeout_minutes(1u32)
         .add_step(generate_token)
         .add_step(steps::checkout_repo())

--- a/tooling/xtask/src/tasks/workflows/extension_release.rs
+++ b/tooling/xtask/src/tasks/workflows/extension_release.rs
@@ -33,7 +33,7 @@ fn create_release(app_id: &WorkflowSecret, app_secret: &WorkflowSecret) -> Named
 
     let job = Job::default()
         .with_repository_owner_guard()
-        .runs_on(runners::LINUX_LARGE)
+        .runs_on(runners::LINUX_SMALL)
         .add_step(generate_token)
         .add_step(checkout_repo())
         .add_step(get_extension_id)

--- a/tooling/xtask/src/tasks/workflows/extension_tests.rs
+++ b/tooling/xtask/src/tasks/workflows/extension_tests.rs
@@ -48,7 +48,7 @@ fn run_clippy() -> Step<Run> {
 fn check_rust() -> NamedJob {
     let job = Job::default()
         .with_repository_owner_guard()
-        .runs_on(runners::LINUX_DEFAULT)
+        .runs_on(runners::LINUX_MEDIUM)
         .timeout_minutes(3u32)
         .add_step(steps::checkout_repo())
         .add_step(steps::cache_rust_dependencies_namespace())

--- a/tooling/xtask/src/tasks/workflows/extensions/bump_version.rs
+++ b/tooling/xtask/src/tasks/workflows/extensions/bump_version.rs
@@ -73,7 +73,7 @@ fn determine_bump_type() -> (NamedJob, StepOutput) {
     let (get_bump_type, output) = get_bump_type();
     let job = Job::default()
         .permissions(Permissions::default())
-        .runs_on(runners::LINUX_DEFAULT)
+        .runs_on(runners::LINUX_SMALL)
         .add_step(get_bump_type)
         .outputs([(output.name.to_owned(), output.to_string())]);
     (named::job(job), output)

--- a/tooling/xtask/src/tasks/workflows/extensions/bump_version.rs
+++ b/tooling/xtask/src/tasks/workflows/extensions/bump_version.rs
@@ -72,6 +72,7 @@ pub(crate) fn call_bump_version(
 fn determine_bump_type() -> (NamedJob, StepOutput) {
     let (get_bump_type, output) = get_bump_type();
     let job = Job::default()
+        .permissions(Permissions::default())
         .runs_on(runners::LINUX_DEFAULT)
         .add_step(get_bump_type)
         .outputs([(output.name.to_owned(), output.to_string())]);

--- a/tooling/xtask/src/tasks/workflows/extensions/bump_version.rs
+++ b/tooling/xtask/src/tasks/workflows/extensions/bump_version.rs
@@ -7,7 +7,7 @@ use indoc::indoc;
 
 use crate::tasks::workflows::{
     runners,
-    steps::{NamedJob, named},
+    steps::{CommonJobConditions, NamedJob, named},
     vars::{self, JobOutput, StepOutput, one_workflow_per_non_main_branch_and_token},
 };
 
@@ -72,6 +72,7 @@ pub(crate) fn call_bump_version(
 fn determine_bump_type() -> (NamedJob, StepOutput) {
     let (get_bump_type, output) = get_bump_type();
     let job = Job::default()
+        .with_repository_owner_guard()
         .permissions(Permissions::default())
         .runs_on(runners::LINUX_SMALL)
         .add_step(get_bump_type)

--- a/tooling/xtask/src/tasks/workflows/extensions/bump_version.rs
+++ b/tooling/xtask/src/tasks/workflows/extensions/bump_version.rs
@@ -1,6 +1,6 @@
 use gh_workflow::{
-    Event, Expression, Input, Job, PullRequest, PullRequestType, Push, Run, Step, UsesJob,
-    Workflow, WorkflowDispatch,
+    Event, Expression, Input, Job, Level, Permissions, PullRequest, PullRequestType, Push, Run,
+    Step, UsesJob, Workflow, WorkflowDispatch,
 };
 use indexmap::IndexMap;
 use indoc::indoc;
@@ -40,6 +40,12 @@ pub(crate) fn call_bump_version(
             "github.event.action != 'labeled' || {} != 'patch'",
             bump_type.expr()
         )))
+        .permissions(
+            Permissions::default()
+                .contents(Level::Write)
+                .issues(Level::Write)
+                .pull_requests(Level::Write),
+        )
         .uses(
             "zed-industries",
             "zed",

--- a/tooling/xtask/src/tasks/workflows/extensions/bump_version.rs
+++ b/tooling/xtask/src/tasks/workflows/extensions/bump_version.rs
@@ -44,7 +44,8 @@ pub(crate) fn call_bump_version(
             Permissions::default()
                 .contents(Level::Write)
                 .issues(Level::Write)
-                .pull_requests(Level::Write),
+                .pull_requests(Level::Write)
+                .actions(Level::Write),
         )
         .uses(
             "zed-industries",

--- a/tooling/xtask/src/tasks/workflows/extensions/release_version.rs
+++ b/tooling/xtask/src/tasks/workflows/extensions/release_version.rs
@@ -1,4 +1,4 @@
-use gh_workflow::{Event, Job, Push, UsesJob, Workflow};
+use gh_workflow::{Event, Job, Level, Permissions, Push, UsesJob, Workflow};
 
 use crate::tasks::workflows::{
     extensions::WithAppSecrets,
@@ -14,6 +14,11 @@ pub(crate) fn release_version() -> Workflow {
 
 pub(crate) fn call_release_version() -> NamedJob<UsesJob> {
     let job = Job::default()
+        .permissions(
+            Permissions::default()
+                .contents(Level::Write)
+                .pull_requests(Level::Write),
+        )
         .uses(
             "zed-industries",
             "zed",

--- a/tooling/xtask/src/tasks/workflows/extensions/run_tests.rs
+++ b/tooling/xtask/src/tasks/workflows/extensions/run_tests.rs
@@ -1,4 +1,4 @@
-use gh_workflow::{Event, Job, PullRequest, Push, UsesJob, Workflow};
+use gh_workflow::{Event, Job, Level, Permissions, PullRequest, Push, UsesJob, Workflow};
 
 use crate::tasks::workflows::{
     steps::{NamedJob, named},
@@ -16,12 +16,14 @@ pub(crate) fn run_tests() -> Workflow {
 }
 
 pub(crate) fn call_extension_tests() -> NamedJob<UsesJob> {
-    let job = Job::default().uses(
-        "zed-industries",
-        "zed",
-        ".github/workflows/extension_tests.yml",
-        "main",
-    );
+    let job = Job::default()
+        .permissions(Permissions::default().contents(Level::Read))
+        .uses(
+            "zed-industries",
+            "zed",
+            ".github/workflows/extension_tests.yml",
+            "main",
+        );
 
     named::job(job)
 }


### PR DESCRIPTION
GitHub flags these as security vulnerabilities. Hence, this PR specifies the needed permissions for the workflows used in the `zed-extensions` organization.

Release Notes:

- N/A