### PR TITLE
terminal: Prevent terminal cursor stretching by always using cell width

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1852,8 +1852,8 @@ impl EditorElement {
                                 None
                             }
                         }) {
-                            let is_whitespace_only =
-                                text.as_ref().chars().all(|c| c.is_whitespace());
+                            let is_ascii_whitespace_only =
+                                text.as_ref().chars().all(|c| c.is_ascii_whitespace());
                             let len = text.len();
 
                             let mut font = cursor_row_layout
@@ -1891,7 +1891,7 @@ impl EditorElement {
                                 }],
                                 None,
                             );
-                            if !is_whitespace_only {
+                            if !is_ascii_whitespace_only {
                                 block_width = block_width.max(shaped.width);
                             }
                             block_text = Some(shaped);

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1829,67 +1829,74 @@ impl EditorElement {
                     let cursor_next_x = cursor_row_layout.x_for_index(cursor_column + 1)
                         + cursor_row_layout
                             .alignment_offset(self.style.text.text_align, text_hitbox.size.width);
-                    let mut block_width = cursor_next_x - cursor_character_x;
-                    if block_width == Pixels::ZERO {
-                        block_width = em_advance;
+                    let mut cell_width = cursor_next_x - cursor_character_x;
+                    if cell_width == Pixels::ZERO {
+                        cell_width = em_advance;
                     }
-                    let block_text = if selection.cursor_shape == CursorShape::Block
-                        && !redacted_ranges.iter().any(|range| {
-                            range.start <= cursor_position && cursor_position < range.end
+
+                    let mut block_width = cell_width;
+                    let mut block_text = None;
+
+                    let is_cursor_in_redacted_range = redacted_ranges
+                        .iter()
+                        .any(|range| range.start <= cursor_position && cursor_position < range.end);
+
+                    if selection.cursor_shape == CursorShape::Block && !is_cursor_in_redacted_range
+                    {
+                        if let Some(text) = snapshot.grapheme_at(cursor_position).or_else(|| {
+                            if snapshot.is_empty() {
+                                snapshot.placeholder_text().and_then(|s| {
+                                    s.graphemes(true).next().map(|s| s.to_string().into())
+                                })
+                            } else {
+                                None
+                            }
                         }) {
-                        snapshot
-                            .grapheme_at(cursor_position)
-                            .or_else(|| {
-                                if snapshot.is_empty() {
-                                    snapshot.placeholder_text().and_then(|s| {
-                                        s.graphemes(true).next().map(|s| s.to_string().into())
-                                    })
-                                } else {
-                                    None
+                            let is_whitespace_only =
+                                text.as_ref().chars().all(|c| c.is_whitespace());
+                            let len = text.len();
+
+                            let mut font = cursor_row_layout
+                                .font_id_for_index(cursor_column)
+                                .and_then(|cursor_font_id| {
+                                    window.text_system().get_font_for_id(cursor_font_id)
+                                })
+                                .unwrap_or(self.style.text.font());
+                            font.features = self.style.text.font_features.clone();
+
+                            // Invert the text color for the block cursor. Ensure that the text
+                            // color is opaque enough to be visible against the background color.
+                            //
+                            // 0.75 is an arbitrary threshold to determine if the background color is
+                            // opaque enough to use as a text color.
+                            //
+                            // TODO: In the future we should ensure themes have a `text_inverse` color.
+                            let color = if cx.theme().colors().editor_background.a < 0.75 {
+                                match cx.theme().appearance {
+                                    Appearance::Dark => Hsla::black(),
+                                    Appearance::Light => Hsla::white(),
                                 }
-                            })
-                            .map(|text| {
-                                let len = text.len();
+                            } else {
+                                cx.theme().colors().editor_background
+                            };
 
-                                let mut font = cursor_row_layout
-                                    .font_id_for_index(cursor_column)
-                                    .and_then(|cursor_font_id| {
-                                        window.text_system().get_font_for_id(cursor_font_id)
-                                    })
-                                    .unwrap_or(self.style.text.font());
-                                font.features = self.style.text.font_features.clone();
-
-                                // Invert the text color for the block cursor. Ensure that the text
-                                // color is opaque enough to be visible against the background color.
-                                //
-                                // 0.75 is an arbitrary threshold to determine if the background color is
-                                // opaque enough to use as a text color.
-                                //
-                                // TODO: In the future we should ensure themes have a `text_inverse` color.
-                                let color = if cx.theme().colors().editor_background.a < 0.75 {
-                                    match cx.theme().appearance {
-                                        Appearance::Dark => Hsla::black(),
-                                        Appearance::Light => Hsla::white(),
-                                    }
-                                } else {
-                                    cx.theme().colors().editor_background
-                                };
-
-                                window.text_system().shape_line(
-                                    text,
-                                    cursor_row_layout.font_size,
-                                    &[TextRun {
-                                        len,
-                                        font,
-                                        color,
-                                        ..Default::default()
-                                    }],
-                                    None,
-                                )
-                            })
-                    } else {
-                        None
-                    };
+                            let shaped = window.text_system().shape_line(
+                                text,
+                                cursor_row_layout.font_size,
+                                &[TextRun {
+                                    len,
+                                    font,
+                                    color,
+                                    ..Default::default()
+                                }],
+                                None,
+                            );
+                            if !is_whitespace_only {
+                                block_width = block_width.max(shaped.width);
+                            }
+                            block_text = Some(shaped);
+                        }
+                    }
 
                     let x = cursor_character_x - scroll_pixel_position.x.into();
                     let y = ((cursor_position.row().as_f64() - scroll_position.y)

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -2342,18 +2342,4 @@ mod tests {
         assert_eq!(negative_filtered.first().unwrap().point.line, Line(-7));
         assert_eq!(negative_filtered.last().unwrap().point.line, Line(-4));
     }
-
-    #[test]
-    fn test_cursor_width_always_uses_cell_width() {
-        use gpui::px;
-
-        // The cursor should always use cell_width, regardless of the shaped text width.
-        // This prevents Tab characters or other wide-rendering characters from stretching the cursor.
-        let cell_width = px(10.0);
-
-        // For any text width, cursor width should always be cell_width
-        // Test this by verifying that we use cell_width directly, ignoring text fragment width
-        let cursor_width = cell_width; // This is what shape_cursor now returns
-        assert_eq!(cursor_width, px(10.0));
-    }
 }

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -56,6 +56,7 @@ pub struct LayoutState {
 }
 
 /// Helper struct for converting data between Alacritty's cursor points, and displayed cursor points.
+#[derive(Copy, Clone)]
 struct DisplayCursor {
     line: i32,
     col: usize,
@@ -504,14 +505,12 @@ impl TerminalElement {
     fn shape_cursor(
         cursor_point: DisplayCursor,
         size: TerminalBounds,
-        text_fragment: &ShapedLine,
+        _text_fragment: &ShapedLine,
     ) -> Option<(Point<Pixels>, Pixels)> {
         if cursor_point.line() < size.total_lines() as i32 {
-            let cursor_width = if text_fragment.width == Pixels::ZERO {
-                size.cell_width()
-            } else {
-                text_fragment.width
-            };
+            // Always use cell_width for cursor - the text shaping width can be too wide
+            // for certain characters like Tab, causing the cursor to stretch
+            let cursor_width = size.cell_width();
 
             // Cursor should always surround as much of the text as possible,
             // hence when on pixel boundaries round the origin down and the width up
@@ -2342,5 +2341,19 @@ mod tests {
         // Negative: lines -7, -6, -5, -4
         assert_eq!(negative_filtered.first().unwrap().point.line, Line(-7));
         assert_eq!(negative_filtered.last().unwrap().point.line, Line(-4));
+    }
+
+    #[test]
+    fn test_cursor_width_always_uses_cell_width() {
+        use gpui::px;
+
+        // The cursor should always use cell_width, regardless of the shaped text width.
+        // This prevents Tab characters or other wide-rendering characters from stretching the cursor.
+        let cell_width = px(10.0);
+
+        // For any text width, cursor width should always be cell_width
+        // Test this by verifying that we use cell_width directly, ignoring text fragment width
+        let cursor_width = cell_width; // This is what shape_cursor now returns
+        assert_eq!(cursor_width, px(10.0));
     }
 }

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -4,7 +4,7 @@ use gpui::{
     Element, ElementId, Entity, FocusHandle, Font, FontFeatures, FontStyle, FontWeight,
     GlobalElementId, HighlightStyle, Hitbox, Hsla, InputHandler, InteractiveElement, Interactivity,
     IntoElement, LayoutId, Length, ModifiersChangedEvent, MouseButton, MouseMoveEvent, Pixels,
-    Point, ShapedLine, StatefulInteractiveElement, StrikethroughStyle, Styled, TextRun, TextStyle,
+    Point, StatefulInteractiveElement, StrikethroughStyle, Styled, TextRun, TextStyle,
     UTF16Selection, UnderlineStyle, WeakEntity, WhiteSpace, Window, div, fill, point, px, relative,
     size,
 };
@@ -500,16 +500,12 @@ impl TerminalElement {
         (rects, batched_runs)
     }
 
-    /// Computes the cursor position and expected block width, may return a zero width if x_for_index returns
-    /// the same position for sequential indexes. Use em_width instead
+    /// Computes the cursor position and block width using the fixed cell width.
     fn shape_cursor(
         cursor_point: DisplayCursor,
         size: TerminalBounds,
-        _text_fragment: &ShapedLine,
     ) -> Option<(Point<Pixels>, Pixels)> {
         if cursor_point.line() < size.total_lines() as i32 {
-            // Always use cell_width for cursor - the text shaping width can be too wide
-            // for certain characters like Tab, causing the cursor to stretch
             let cursor_width = size.cell_width();
 
             // Cursor should always surround as much of the text as possible,
@@ -1148,7 +1144,7 @@ impl Element for TerminalElement {
                 };
 
                 let ime_cursor_bounds =
-                    TerminalElement::shape_cursor(cursor_point, dimensions, &cursor_text).map(
+                    TerminalElement::shape_cursor(cursor_point, dimensions).map(
                         |(cursor_position, block_width)| Bounds {
                             origin: cursor_position,
                             size: size(block_width, dimensions.line_height),

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -501,10 +501,7 @@ impl TerminalElement {
     }
 
     /// Computes the cursor position based on the cursor point and terminal dimensions.
-    fn cursor_position(
-        cursor_point: DisplayCursor,
-        size: TerminalBounds,
-    ) -> Option<Point<Pixels>> {
+    fn cursor_position(cursor_point: DisplayCursor, size: TerminalBounds) -> Option<Point<Pixels>> {
         if cursor_point.line() < size.total_lines() as i32 {
             // When on pixel boundaries round the origin down
             Some(point(
@@ -1146,13 +1143,11 @@ impl Element for TerminalElement {
                     cursor_text.width.max(dimensions.cell_width())
                 };
 
-                let ime_cursor_bounds =
-                    TerminalElement::cursor_position(cursor_point, dimensions).map(
-                        |cursor_position| Bounds {
-                            origin: cursor_position,
-                            size: size(cursor_width.ceil(), dimensions.line_height),
-                        },
-                    );
+                let ime_cursor_bounds = TerminalElement::cursor_position(cursor_point, dimensions)
+                    .map(|cursor_position| Bounds {
+                        origin: cursor_position,
+                        size: size(cursor_width.ceil(), dimensions.line_height),
+                    });
 
                 let cursor = if let AlacCursorShape::Hidden = cursor.shape {
                     None


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/8516

Release Notes:

- Prevent terminal cursor stretching by always using cell width.
