### PR TITLE
rust: Highlight enum variants as types

### DIFF
--- a/crates/languages/src/rust/highlights.scm
+++ b/crates/languages/src/rust/highlights.scm
@@ -57,6 +57,9 @@
 ((identifier) @constant
  (#match? @constant "^_*[A-Z][A-Z\\d_]*$"))
 
+; Ensure enum variants are highlighted correctly regardless of naming convention
+(enum_variant name: (identifier) @type)
+
 [
   "("
   ")"


### PR DESCRIPTION
Closes [#ISSUE](https://github.com/zed-industries/zed/issues/14489)

Release Notes:

- Fix Rust enum variants with no lower-case highlighted as constants

Screenshot:

<img width="401" height="280" alt="image" src="https://github.com/user-attachments/assets/cd67a576-3c41-452d-9c6b-b3c259cee556" />
