### PR TITLE
Make modal editing modes (Vim/Helix) and standard mutually exclusive

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -117,11 +117,11 @@
   // 2. Maps `Control` on Linux and Windows and to `Command` on MacOS:
   //    "cmd_or_ctrl" (alias: "cmd", "ctrl")
   "multi_cursor_modifier": "alt",
-  // Whether to enable vim modes and key bindings.
-  "vim_mode": false,
-  // Whether to enable helix mode and key bindings.
-  // Enabling this mode will automatically enable vim mode.
-  "helix_mode": false,
+  // Modal editing mode, one of:
+  // - "none": Standard editing mode
+  // - "vim": Enables Vim-style modal editing and key bindings
+  // - "helix": Enables Helix-style modal editing and key bindings
+  "modal_editing": "none",
   // Whether to show the informational hover box when moving the mouse
   // over symbols in the editor.
   "hover_popover_enabled": true,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2461,10 +2461,10 @@ impl Editor {
                     }
                 }
                 EditorEvent::Edited { .. } => {
-                    let vim_mode = vim_mode_setting::VimModeSetting::try_get(cx)
-                        .map(|vim_mode| vim_mode.0)
+                    let modal_editing_enabled = vim_mode_setting::ModalEditing::try_get(cx)
+                        .map(|m| m.is_enabled())
                         .unwrap_or(false);
-                    if !vim_mode {
+                    if !modal_editing_enabled {
                         let display_map = editor.display_snapshot(cx);
                         let selections = editor.selections.all_adjusted_display(&display_map);
                         let pop_state = editor
@@ -22557,8 +22557,8 @@ impl Editor {
             .and_then(|e| e.to_str())
             .map(|a| a.to_string()));
 
-        let vim_mode = vim_mode_setting::VimModeSetting::try_get(cx)
-            .map(|vim_mode| vim_mode.0)
+        let vim_mode = vim_mode_setting::ModalEditing::try_get(cx)
+            .map(|m| m.is_enabled())
             .unwrap_or(false);
 
         let edit_predictions_provider = all_language_settings(file, cx).edit_predictions.provider;

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -28,7 +28,7 @@ use ui::{
     ToggleButtonGroupSize, ToggleButtonGroupStyle, ToggleButtonSimple, Tooltip, WithScrollbar,
     prelude::*,
 };
-use vim_mode_setting::VimModeSetting;
+use vim_mode_setting::ModalEditing;
 use workspace::{
     Workspace,
     item::{Item, ItemEvent},
@@ -1452,7 +1452,7 @@ impl ExtensionsPage {
                                             .child(
                                                 Switch::new(
                                                     "enable-vim",
-                                                    if VimModeSetting::get_global(cx).0 {
+                                                    if ModalEditing::get_global(cx).is_vim() {
                                                         ui::ToggleState::Selected
                                                     } else {
                                                         ui::ToggleState::Unselected
@@ -1468,7 +1468,13 @@ impl ExtensionsPage {
                                                             selection,
                                                             cx,
                                                             |setting, value| {
-                                                                setting.vim_mode = Some(value)
+                                                                setting.modal_editing = Some(if value {
+                                                                    settings::ModalEditingContent::Vim
+                                                                } else {
+                                                                    settings::ModalEditingContent::None
+                                                                });
+                                                                setting.vim_mode = None;
+                                                                setting.helix_mode = None;
                                                             },
                                                         );
                                                     },

--- a/crates/settings/src/settings_content.rs
+++ b/crates/settings/src/settings_content.rs
@@ -100,9 +100,18 @@ pub struct SettingsContent {
 
     pub repl: Option<ReplSettingsContent>,
 
+    /// The modal editing mode to use.
+    ///
+    /// Options: "none", "vim", "helix"
+    ///
+    /// Default: none(Standar editind)
+    pub modal_editing: Option<ModalEditingContent>,
+
     /// Whether or not to enable Helix mode.
+    /// DEPRECATED: Use `modal_editing` instead.
     ///
     /// Default: false
+    #[serde(skip_serializing)]
     pub helix_mode: Option<bool>,
 
     pub journal: Option<JournalSettingsContent>,
@@ -146,8 +155,10 @@ pub struct SettingsContent {
     pub title_bar: Option<TitleBarSettingsContent>,
 
     /// Whether or not to enable Vim mode.
+    /// DEPRECATED: Use `modal_editing` instead.
     ///
     /// Default: false
+    #[serde(skip_serializing)]
     pub vim_mode: Option<bool>,
 
     // Settings related to calls in Zed
@@ -260,6 +271,37 @@ impl strum::VariantNames for BaseKeymapContent {
         "Cursor",
         "None",
     ];
+}
+
+/// Modal editing mode selection.
+///
+/// Default: None (standard editing)
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    MergeFrom,
+    PartialEq,
+    Eq,
+    Default,
+    strum::VariantArray,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum ModalEditingContent {
+    /// Standard editing mode
+    #[default]
+    None,
+    /// Vim-style modal editing
+    Vim,
+    /// Helix-style modal editing
+    Helix,
+}
+
+impl strum::VariantNames for ModalEditingContent {
+    const VARIANTS: &'static [&'static str] = &["None", "Vim", "Helix"];
 }
 
 #[with_fallible_options]

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -194,6 +194,7 @@ impl VsCodeSettings {
             line_indicator_format: None,
             log: None,
             message_editor: None,
+            modal_editing: None,
             node: self.node_binary_settings(),
             notification_panel: None,
             outline_panel: self.outline_panel_settings_content(),

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -1113,29 +1113,16 @@ pub(crate) fn settings_data(cx: &App) -> Vec<SettingsPage> {
                     files: USER,
                 }),
                 SettingsPageItem::SectionHeader("Modal Editing"),
-                // todo(settings_ui): Vim/Helix Mode should be apart of one type because it's undefined
-                // behavior to have them both enabled at the same time
                 SettingsPageItem::SettingItem(SettingItem {
-                    title: "Vim Mode",
-                    description: "Enable Vim mode and key bindings.",
+                    title: "Modal Editing",
+                    description: "Choose a modal editing mode: None for standard editing, Vim for Vim-style or Helix for Helix-style modal editing.",
                     field: Box::new(SettingField {
-                        json_path: Some("vim_mode"),
-                        pick: |settings_content| settings_content.vim_mode.as_ref(),
+                        json_path: Some("modal_editing"),
+                        pick: |settings_content| settings_content.modal_editing.as_ref(),
                         write: |settings_content, value| {
-                            settings_content.vim_mode = value;
-                        },
-                    }),
-                    metadata: None,
-                    files: USER,
-                }),
-                SettingsPageItem::SettingItem(SettingItem {
-                    title: "Helix Mode",
-                    description: "Enable Helix mode and key bindings.",
-                    field: Box::new(SettingField {
-                        json_path: Some("helix_mode"),
-                        pick: |settings_content| settings_content.helix_mode.as_ref(),
-                        write: |settings_content, value| {
-                            settings_content.helix_mode = value;
+                            settings_content.modal_editing = value;
+                            settings_content.vim_mode = None;
+                            settings_content.helix_mode = None;
                         },
                     }),
                     metadata: None,

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -438,6 +438,7 @@ fn init_renderers(cx: &mut App) {
         .add_basic_renderer::<settings::CloseWindowWhenNoItems>(render_dropdown)
         .add_basic_renderer::<settings::FontFamilyName>(render_font_picker)
         .add_basic_renderer::<settings::BaseKeymapContent>(render_dropdown)
+        .add_basic_renderer::<settings::ModalEditingContent>(render_dropdown)
         .add_basic_renderer::<settings::MultiCursorModifier>(render_dropdown)
         .add_basic_renderer::<settings::HideMouseMode>(render_dropdown)
         .add_basic_renderer::<settings::CurrentLineHighlight>(render_dropdown)

--- a/crates/vim/src/indent.rs
+++ b/crates/vim/src/indent.rs
@@ -6,7 +6,7 @@ use gpui::actions;
 use gpui::{Context, Window};
 use language::SelectionGoal;
 use settings::Settings;
-use vim_mode_setting::HelixModeSetting;
+use vim_mode_setting::ModalEditing;
 
 #[derive(PartialEq, Eq)]
 pub(crate) enum IndentDirection {
@@ -39,7 +39,7 @@ pub(crate) fn register(editor: &mut Editor, cx: &mut Context<Vim>) {
                 for _ in 0..count {
                     editor.indent(&Default::default(), window, cx);
                 }
-                if !HelixModeSetting::get_global(cx).0 {
+                if !ModalEditing::get_global(cx).is_helix() {
                     vim.restore_selection_cursors(editor, window, cx, original_positions);
                 }
             });
@@ -60,7 +60,7 @@ pub(crate) fn register(editor: &mut Editor, cx: &mut Context<Vim>) {
                 for _ in 0..count {
                     editor.outdent(&Default::default(), window, cx);
                 }
-                if !HelixModeSetting::get_global(cx).0 {
+                if !ModalEditing::get_global(cx).is_helix() {
                     vim.restore_selection_cursors(editor, window, cx, original_positions);
                 }
             });

--- a/crates/vim/src/insert.rs
+++ b/crates/vim/src/insert.rs
@@ -4,7 +4,7 @@ use gpui::{Action, Context, Window, actions};
 use language::SelectionGoal;
 use settings::Settings;
 use text::Point;
-use vim_mode_setting::HelixModeSetting;
+use vim_mode_setting::ModalEditing;
 use workspace::searchable::Direction;
 
 actions!(
@@ -50,7 +50,7 @@ impl Vim {
         if count <= 1 || Vim::globals(cx).dot_replaying {
             self.create_mark("^".into(), window, cx);
 
-            if HelixModeSetting::get_global(cx).0 {
+            if ModalEditing::get_global(cx).is_helix() {
                 self.update_editor(cx, |_, editor, cx| {
                     editor.dismiss_menus_and_popups(false, window, cx);
                 });

--- a/crates/vim/src/normal/paste.rs
+++ b/crates/vim/src/normal/paste.rs
@@ -8,7 +8,7 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use settings::Settings;
 use std::cmp;
-use vim_mode_setting::HelixModeSetting;
+use vim_mode_setting::ModalEditing;
 
 use crate::{
     Vim,
@@ -229,7 +229,7 @@ impl Vim {
             });
         });
 
-        if HelixModeSetting::get_global(cx).0 {
+        if ModalEditing::get_global(cx).is_helix() {
             self.switch_mode(Mode::HelixNormal, true, window, cx);
         } else {
             self.switch_mode(Mode::Normal, true, window, cx);

--- a/crates/vim/src/test/vim_test_context.rs
+++ b/crates/vim/src/test/vim_test_context.rs
@@ -96,7 +96,13 @@ impl VimTestContext {
 
     pub fn init_keybindings(enabled: bool, cx: &mut App) {
         SettingsStore::update_global(cx, |store, cx| {
-            store.update_user_settings(cx, |s| s.vim_mode = Some(enabled));
+            store.update_user_settings(cx, |s| {
+                s.modal_editing = Some(if enabled {
+                    settings::ModalEditingContent::Vim
+                } else {
+                    settings::ModalEditingContent::None
+                });
+            });
         });
         let mut default_key_bindings = settings::KeymapFile::load_asset_allow_partial_failure(
             "keymaps/default-macos.json",
@@ -165,7 +171,9 @@ impl VimTestContext {
     pub fn enable_vim(&mut self) {
         self.cx.update(|_, cx| {
             SettingsStore::update_global(cx, |store, cx| {
-                store.update_user_settings(cx, |s| s.vim_mode = Some(true));
+                store.update_user_settings(cx, |s| {
+                    s.modal_editing = Some(settings::ModalEditingContent::Vim);
+                });
             });
         })
     }
@@ -173,7 +181,9 @@ impl VimTestContext {
     pub fn disable_vim(&mut self) {
         self.cx.update(|_, cx| {
             SettingsStore::update_global(cx, |store, cx| {
-                store.update_user_settings(cx, |s| s.vim_mode = Some(false));
+                store.update_user_settings(cx, |s| {
+                    s.modal_editing = Some(settings::ModalEditingContent::None);
+                });
             });
         })
     }
@@ -181,7 +191,9 @@ impl VimTestContext {
     pub fn enable_helix(&mut self) {
         self.cx.update(|_, cx| {
             SettingsStore::update_global(cx, |store, cx| {
-                store.update_user_settings(cx, |s| s.helix_mode = Some(true));
+                store.update_user_settings(cx, |s| {
+                    s.modal_editing = Some(settings::ModalEditingContent::Helix);
+                });
             });
         })
     }

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -41,6 +41,7 @@ use normal::search::SearchSubmit;
 use object::Object;
 use schemars::JsonSchema;
 use serde::Deserialize;
+use settings::ModalEditingContent;
 use settings::RegisterSetting;
 pub use settings::{
     ModeContent, Settings, SettingsStore, UseSystemClipboard, update_settings_file,
@@ -50,8 +51,7 @@ use std::{mem, ops::Range, sync::Arc};
 use surrounds::SurroundsType;
 use theme::ThemeSettings;
 use ui::{IntoElement, SharedString, px};
-use vim_mode_setting::HelixModeSetting;
-use vim_mode_setting::VimModeSetting;
+use vim_mode_setting::ModalEditing;
 use workspace::{self, Pane, Workspace};
 
 use crate::{
@@ -275,23 +275,31 @@ pub fn init(cx: &mut App) {
     cx.observe_new(|workspace: &mut Workspace, _, _| {
         workspace.register_action(|workspace, _: &ToggleVimMode, _, cx| {
             let fs = workspace.app_state().fs.clone();
-            let currently_enabled = VimModeSetting::get_global(cx).0;
+            let current = ModalEditing::get_global(cx);
+            let new_mode = if current.is_vim() {
+                ModalEditingContent::None
+            } else {
+                ModalEditingContent::Vim
+            };
             update_settings_file(fs, cx, move |setting, _| {
-                setting.vim_mode = Some(!currently_enabled);
-                if let Some(helix_mode) = &mut setting.helix_mode {
-                    *helix_mode = false;
-                }
+                setting.modal_editing = Some(new_mode);
+                setting.vim_mode = None;
+                setting.helix_mode = None;
             })
         });
 
         workspace.register_action(|workspace, _: &ToggleHelixMode, _, cx| {
             let fs = workspace.app_state().fs.clone();
-            let currently_enabled = HelixModeSetting::get_global(cx).0;
+            let current = ModalEditing::get_global(cx);
+            let new_mode = if current.is_helix() {
+                ModalEditingContent::None
+            } else {
+                ModalEditingContent::Helix
+            };
             update_settings_file(fs, cx, move |setting, _| {
-                setting.helix_mode = Some(!currently_enabled);
-                if let Some(vim_mode) = &mut setting.vim_mode {
-                    *vim_mode = false;
-                }
+                setting.modal_editing = Some(new_mode);
+                setting.vim_mode = None;
+                setting.helix_mode = None;
             })
         });
 
@@ -536,7 +544,7 @@ impl Vim {
         let editor = cx.entity();
 
         let initial_vim_mode = VimSettings::get_global(cx).default_mode;
-        let (mode, last_mode) = if HelixModeSetting::get_global(cx).0 {
+        let (mode, last_mode) = if ModalEditing::get_global(cx).is_helix() {
             let initial_helix_mode = match initial_vim_mode {
                 Mode::Normal => Mode::HelixNormal,
                 Mode::Insert => Mode::Insert,
@@ -999,7 +1007,7 @@ impl Vim {
     }
 
     pub fn enabled(cx: &mut App) -> bool {
-        VimModeSetting::get_global(cx).0 || HelixModeSetting::get_global(cx).0
+        ModalEditing::get_global(cx).is_enabled()
     }
 
     /// Called whenever an keystroke is typed so vim can observe all actions
@@ -1170,7 +1178,7 @@ impl Vim {
                 editor.set_relative_line_number(Some(is_relative), cx)
             });
         }
-        if HelixModeSetting::get_global(cx).0 {
+        if ModalEditing::get_global(cx).is_helix() {
             if self.mode == Mode::Normal {
                 self.mode = Mode::HelixNormal
             } else if self.mode == Mode::Visual {
@@ -1939,7 +1947,7 @@ impl Vim {
         self.update_editor(cx, |vim, editor, cx| {
             editor.set_cursor_shape(vim.cursor_shape(cx), cx);
             editor.set_clip_at_line_ends(vim.clip_at_line_ends(), cx);
-            let collapse_matches = !HelixModeSetting::get_global(cx).0;
+            let collapse_matches = !ModalEditing::get_global(cx).is_helix();
             editor.set_collapse_matches(collapse_matches);
             editor.set_input_enabled(vim.editor_input_enabled());
             editor.set_autoindent(vim.should_autoindent());

--- a/crates/vim_mode_setting/src/vim_mode_setting.rs
+++ b/crates/vim_mode_setting/src/vim_mode_setting.rs
@@ -1,25 +1,107 @@
-//! Contains the [`VimModeSetting`] and [`HelixModeSetting`] used to enable/disable Vim and Helix modes.
+//! Contains the [`ModalEditing`] setting for modal editing modes (Vim/Helix).
 //!
-//! This is in its own crate as we want other crates to be able to enable or
-//! disable Vim/Helix modes without having to depend on the `vim` crate in its
-//! entirety.
+//! This is in its own crate to allow other crates to check modal editing mode
+//! without depending on the `vim` crate in its entirety.
 
+use settings::ModalEditingContent;
 use settings::{RegisterSetting, Settings, SettingsContent};
+use std::fmt::{Display, Formatter};
 
-#[derive(RegisterSetting)]
-pub struct VimModeSetting(pub bool);
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default, RegisterSetting)]
+pub enum ModalEditing {
+    /// Standard editing mode
+    #[default]
+    None,
+    /// Vim-style modal editing
+    Vim,
+    /// Helix-style modal editing
+    Helix,
+}
 
-impl Settings for VimModeSetting {
-    fn from_settings(content: &SettingsContent) -> Self {
-        Self(content.vim_mode.unwrap())
+impl From<ModalEditingContent> for ModalEditing {
+    fn from(value: ModalEditingContent) -> Self {
+        match value {
+            ModalEditingContent::None => Self::None,
+            ModalEditingContent::Vim => Self::Vim,
+            ModalEditingContent::Helix => Self::Helix,
+        }
     }
 }
 
+impl From<ModalEditing> for ModalEditingContent {
+    fn from(value: ModalEditing) -> Self {
+        match value {
+            ModalEditing::None => Self::None,
+            ModalEditing::Vim => Self::Vim,
+            ModalEditing::Helix => Self::Helix,
+        }
+    }
+}
+
+impl Display for ModalEditing {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ModalEditing::None => write!(f, "None"),
+            ModalEditing::Vim => write!(f, "Vim"),
+            ModalEditing::Helix => write!(f, "Helix"),
+        }
+    }
+}
+
+impl Settings for ModalEditing {
+    fn from_settings(content: &SettingsContent) -> Self {
+        if let Some(modal_editing) = content.modal_editing {
+            return modal_editing.into();
+        }
+
+        // Legacy fallback: check old boolean fields
+        {
+            if content.helix_mode.unwrap_or(false) {
+                return Self::Helix;
+            }
+            if content.vim_mode.unwrap_or(false) {
+                return Self::Vim;
+            }
+        }
+
+        Self::None
+    }
+}
+
+impl ModalEditing {
+    pub fn is_enabled(&self) -> bool {
+        *self != ModalEditing::None
+    }
+
+    pub fn is_vim(&self) -> bool {
+        *self == ModalEditing::Vim
+    }
+
+    pub fn is_helix(&self) -> bool {
+        *self == ModalEditing::Helix
+    }
+}
+
+#[deprecated(note = "Use ModalEditing instead")]
+#[derive(RegisterSetting)]
+pub struct VimModeSetting(pub bool);
+
+#[allow(deprecated)]
+impl Settings for VimModeSetting {
+    fn from_settings(content: &SettingsContent) -> Self {
+        let modal = ModalEditing::from_settings(content);
+        Self(modal == ModalEditing::Vim || modal == ModalEditing::Helix)
+    }
+}
+
+#[deprecated(note = "Use ModalEditing instead")]
 #[derive(RegisterSetting)]
 pub struct HelixModeSetting(pub bool);
 
+#[allow(deprecated)]
 impl Settings for HelixModeSetting {
     fn from_settings(content: &SettingsContent) -> Self {
-        Self(content.helix_mode.unwrap())
+        let modal = ModalEditing::from_settings(content);
+        Self(modal == ModalEditing::Helix)
     }
 }

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -77,7 +77,7 @@ use util::markdown::MarkdownString;
 use util::rel_path::RelPath;
 use util::{ResultExt, asset_str};
 use uuid::Uuid;
-use vim_mode_setting::VimModeSetting;
+use vim_mode_setting::ModalEditing;
 use workspace::notifications::{
     NotificationId, SuppressEvent, dismiss_app_notification, show_app_notification,
 };
@@ -1587,21 +1587,15 @@ pub fn handle_keymap_file_changes(
     let (base_keymap_tx, mut base_keymap_rx) = mpsc::unbounded();
     let (keyboard_layout_tx, mut keyboard_layout_rx) = mpsc::unbounded();
     let mut old_base_keymap = *BaseKeymap::get_global(cx);
-    let mut old_vim_enabled = VimModeSetting::get_global(cx).0;
-    let mut old_helix_enabled = vim_mode_setting::HelixModeSetting::get_global(cx).0;
+    let mut old_modal_editing = *ModalEditing::get_global(cx);
 
     cx.observe_global::<SettingsStore>(move |cx| {
         let new_base_keymap = *BaseKeymap::get_global(cx);
-        let new_vim_enabled = VimModeSetting::get_global(cx).0;
-        let new_helix_enabled = vim_mode_setting::HelixModeSetting::get_global(cx).0;
+        let new_modal_editing = *ModalEditing::get_global(cx);
 
-        if new_base_keymap != old_base_keymap
-            || new_vim_enabled != old_vim_enabled
-            || new_helix_enabled != old_helix_enabled
-        {
+        if new_base_keymap != old_base_keymap || new_modal_editing != old_modal_editing {
             old_base_keymap = new_base_keymap;
-            old_vim_enabled = new_vim_enabled;
-            old_helix_enabled = new_helix_enabled;
+            old_modal_editing = new_modal_editing;
 
             base_keymap_tx.unbounded_send(()).unwrap();
         }
@@ -1819,7 +1813,7 @@ pub fn load_default_keymap(cx: &mut App) {
         cx.bind_keys(KeymapFile::load_asset(asset_path, Some(KeybindSource::Base), cx).unwrap());
     }
 
-    if VimModeSetting::get_global(cx).0 || vim_mode_setting::HelixModeSetting::get_global(cx).0 {
+    if ModalEditing::get_global(cx).is_enabled() {
         cx.bind_keys(
             KeymapFile::load_asset(VIM_KEYMAP_PATH, Some(KeybindSource::Vim), cx).unwrap(),
         );

--- a/crates/zed/src/zed/quick_action_bar.rs
+++ b/crates/zed/src/zed/quick_action_bar.rs
@@ -22,7 +22,7 @@ use ui::{
     ButtonStyle, ContextMenu, ContextMenuEntry, DocumentationEdge, DocumentationSide, IconButton,
     IconName, IconSize, PopoverMenu, PopoverMenuHandle, Tooltip, prelude::*,
 };
-use vim_mode_setting::{HelixModeSetting, VimModeSetting};
+use vim_mode_setting::ModalEditing;
 use workspace::item::ItemBufferKind;
 use workspace::{
     ToolbarItemEvent, ToolbarItemLocation, ToolbarItemView, Workspace, item::ItemHandle,
@@ -315,8 +315,7 @@ impl Render for QuickActionBar {
         let editor_focus_handle = editor.focus_handle(cx);
         let editor = editor.downgrade();
         let editor_settings_dropdown = {
-            let vim_mode_enabled = VimModeSetting::get_global(cx).0;
-            let helix_mode_enabled = HelixModeSetting::get_global(cx).0;
+            let modal_editing = *ModalEditing::get_global(cx);
 
             PopoverMenu::new("editor-settings")
                 .trigger_with_tooltip(
@@ -585,29 +584,37 @@ impl Render for QuickActionBar {
                             menu = menu.separator();
 
                             menu = menu.toggleable_entry(
-                                "Vim Mode",
-                                vim_mode_enabled,
+                                "No Modal Editing",
+                                modal_editing == ModalEditing::None,
                                 IconPosition::Start,
                                 None,
                                 {
                                     move |window, cx| {
-                                        let new_value = !vim_mode_enabled;
-                                        VimModeSetting::override_global(VimModeSetting(new_value), cx);
-                                        HelixModeSetting::override_global(HelixModeSetting(false), cx);
+                                        ModalEditing::override_global(ModalEditing::None, cx);
+                                        window.refresh();
+                                    }
+                                },
+                            );
+                            menu = menu.toggleable_entry(
+                                "Vim Mode",
+                                modal_editing == ModalEditing::Vim,
+                                IconPosition::Start,
+                                None,
+                                {
+                                    move |window, cx| {
+                                        ModalEditing::override_global(ModalEditing::Vim, cx);
                                         window.refresh();
                                     }
                                 },
                             );
                             menu = menu.toggleable_entry(
                                 "Helix Mode",
-                                helix_mode_enabled,
+                                modal_editing == ModalEditing::Helix,
                                 IconPosition::Start,
                                 None,
                                 {
                                     move |window, cx| {
-                                        let new_value = !helix_mode_enabled;
-                                        HelixModeSetting::override_global(HelixModeSetting(new_value), cx);
-                                        VimModeSetting::override_global(VimModeSetting(false), cx);
+                                        ModalEditing::override_global(ModalEditing::Helix, cx);
                                         window.refresh();
                                     }
                                 }

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -39,7 +39,7 @@ This will create a `.zed` directory containing`.zed/settings.json`.
 
 Although most projects will only need one settings file at the root, you can add more local settings files for subdirectories as needed.
 Not all settings can be set in local files, just those that impact the behavior of the editor and language tooling.
-For example you can set `tab_size`, `formatter` etc. but not `theme`, `vim_mode` and similar.
+For example you can set `tab_size`, `formatter` etc. but not `theme`, `modal_editing` and similar.
 
 The syntax for configuration files is a super-set of JSON that allows `//` comments.
 
@@ -52,10 +52,10 @@ They are merged into the base configuration with settings from these keys taking
 ```json [settings]
 {
   "theme": "sunset",
-  "vim_mode": false,
+  "modal_editing": "none",
   "nightly": {
     "theme": "cave-light",
-    "vim_mode": true
+    "modal_editing": "vim"
   },
   "preview": {
     "theme": "zed-dark"
@@ -63,7 +63,7 @@ They are merged into the base configuration with settings from these keys taking
 }
 ```
 
-With this configuration, Stable keeps all base preferences, Preview switches to `zed-dark`, and Nightly enables Vim mode with a different theme.
+With this configuration, Stable keeps all base preferences, Preview switches to `zed-dark`, and Nightly enables Vim-style modal editing with a different theme.
 
 Changing settings in the Settings Editorwill always apply the change across all channels.
 
@@ -2302,15 +2302,37 @@ Example:
 
 `boolean` values
 
-## Helix Mode
+## Modal Editing
 
-- Description: Whether or not to enable Helix mode. Enabling `helix_mode` also enables `vim_mode`. See the [Helix documentation](./helix.md) for more details.
-- Setting: `helix_mode`
-- Default: `false`
+- Description: Selects the modal editing mode. See the [Vim documentation](./vim.md) and [Helix documentation](./helix.md) for more details.
+- Setting: `modal_editing`
+- Default: `"none"`
 
 **Options**
 
-`boolean` values
+1. Disable modal editing:
+
+```json [settings]
+{
+  "modal_editing": "none"
+}
+```
+
+2. Enable Vim-style modal editing:
+
+```json [settings]
+{
+  "modal_editing": "vim"
+}
+```
+
+3. Enable Helix-style modal editing:
+
+```json [settings]
+{
+  "modal_editing": "helix"
+}
+```
 
 ## Indent Guides
 
@@ -4395,12 +4417,6 @@ Run the {#action theme_selector::Toggle} action in the command palette to see a 
 - `show_sign_in`: Whether to show the sign in button in the titlebar
 - `show_menus`: Whether to show the menus in the titlebar
 
-## Vim
-
-- Description: Whether or not to enable vim mode.
-- Setting: `vim_mode`
-- Default: `false`
-
 ## When Closing With No Tabs
 
 - Description: Whether the window should be closed when using 'close active item' on a window with no tabs
@@ -5049,7 +5065,7 @@ To preview and enable a settings profile, open the command palette via {#kb comm
 
   "autosave": "on_focus_change",
   "format_on_save": "off",
-  "vim_mode": false,
+  "modal_editing": "none",
   "projects_online_by_default": true,
   "terminal": {
     "font_family": "FiraCode Nerd Font Mono",

--- a/docs/src/helix.md
+++ b/docs/src/helix.md
@@ -2,7 +2,7 @@
 
 _Work in progress! Not all Helix keybindings are implemented yet._
 
-Zed's Helix mode is an emulation layer that brings Helix-style keybindings and modal editing to Zed. It builds upon Zed's [Vim mode](./vim.md), so much of the core functionality is shared. Enabling `helix_mode` will also enable `vim_mode`.
+Zed's Helix mode is an emulation layer that brings Helix-style keybindings and modal editing to Zed. It builds upon Zed's [Vim mode](./vim.md), so much of the core functionality is shared. To enable Helix mode, set `"modal_editing": "helix"` in your settings.
 
 For a guide on Vim-related features that are also available in Helix mode, please refer to our [Vim mode documentation](./vim.md).
 

--- a/docs/src/key-bindings.md
+++ b/docs/src/key-bindings.md
@@ -18,7 +18,7 @@ We currently support:
 
 This setting can also be changed via the command palette through the `zed: toggle base keymap selector` action.
 
-You can also enable `vim_mode` or `helix_mode`, which add modal bindings.
+You can also use `modal_editing` to enable Vim or Helix-style modal bindings.
 For more information, see the documentation for [Vim mode](./vim.md) and [Helix mode](./helix.md).
 
 ## Keymap Editor

--- a/docs/src/vim.md
+++ b/docs/src/vim.md
@@ -41,7 +41,7 @@ If you missed this, you can toggle vim mode on or off anytime by opening the com
 >
 > ```json [settings]
 > {
->   "vim_mode": true
+>   "modal_editing": "vim"
 > }
 > ```
 


### PR DESCRIPTION
#42662, #38483

Release Notes:
  - Consolidate `vim_mode` and `helix_mode` into `modal_editing: "none" | "vim" | "helix"`
  - Update default.json and documentation to use new `modal_editing` setting
  - Legacy settings remain readable for backward compatibility

