### PR TITLE
Add support for automatic Markdown task list continuation when using uppercase X

### DIFF
--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -29602,6 +29602,17 @@ async fn test_newline_task_list_continuation(cx: &mut TestAppContext) {
         - [ ] ˇ
     "});
 
+    // Case 2.1: Works with uppercase checked marker too
+    cx.set_state(indoc! {"
+        - [X] completed taskˇ
+    "});
+    cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+    cx.wait_for_autoindent_applied().await;
+    cx.assert_editor_state(indoc! {"
+        - [X] completed task
+        - [ ] ˇ
+    "});
+
     // Case 3: Cursor position doesn't matter - content after marker is what counts
     cx.set_state(indoc! {"
         - [ ] taˇsk

--- a/crates/languages/src/markdown/config.toml
+++ b/crates/languages/src/markdown/config.toml
@@ -22,7 +22,7 @@ rewrap_prefixes = [
 ]
 unordered_list = ["- ", "* ", "+ "]
 ordered_list = [{ pattern = "(\\d+)\\. ", format = "{1}. " }]
-task_list = { prefixes = ["- [ ] ", "- [x] "], continuation = "- [ ] " }
+task_list = { prefixes = ["- [ ] ", "- [x] ", "- [X] "], continuation = "- [ ] " }
 
 auto_indent_on_paste = false
 auto_indent_using_last_non_empty_line = false


### PR DESCRIPTION
Release Notes:

- Added support for automatic Markdown task list continuation when using uppercase X
