### PR TITLE
Optimize startup CPU usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 **/venv
 **/.direnv
 *.wasm
+*.cwasm
 *.xcodeproj
 .DS_Store
 .blob_store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5968,6 +5968,7 @@ dependencies = [
  "futures 0.3.31",
  "gpui",
  "gpui_tokio",
+ "hex",
  "http_client",
  "language",
  "language_extension",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15332,7 +15332,6 @@ dependencies = [
  "log",
  "parking_lot",
  "smol",
- "sqlformat",
  "thread_local",
  "util",
  "uuid",

--- a/crates/edit_prediction/src/license_detection.rs
+++ b/crates/edit_prediction/src/license_detection.rs
@@ -736,6 +736,7 @@ mod tests {
             fs.clone(),
             Default::default(),
             true,
+            false,
             &mut cx.to_async(),
         )
         .await
@@ -760,6 +761,7 @@ mod tests {
             fs.clone(),
             Default::default(),
             true,
+            false,
             &mut cx.to_async(),
         )
         .await
@@ -819,6 +821,7 @@ mod tests {
             fs.clone(),
             Default::default(),
             true,
+            false,
             &mut cx.to_async(),
         )
         .await

--- a/crates/extension_host/Cargo.toml
+++ b/crates/extension_host/Cargo.toml
@@ -28,6 +28,7 @@ fs.workspace = true
 futures.workspace = true
 gpui.workspace = true
 gpui_tokio.workspace = true
+hex.workspace = true
 http_client.workspace = true
 language.workspace = true
 log.workspace = true

--- a/crates/extension_host/build.rs
+++ b/crates/extension_host/build.rs
@@ -3,7 +3,45 @@ use std::fs;
 use std::path::PathBuf;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    emit_wasmtime_version();
     copy_extension_api_rust_files()
+}
+
+/// Emit the wasmtime crate version as a compile-time environment variable.
+/// This allows us to use the version for cache invalidation without hardcoding.
+fn emit_wasmtime_version() {
+    // Try to read version from Cargo.lock
+    let cargo_lock_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .map(|p| p.join("Cargo.lock"));
+
+    if let Some(lock_path) = cargo_lock_path {
+        println!("cargo:rerun-if-changed={}", lock_path.display());
+        if let Ok(content) = fs::read_to_string(&lock_path) {
+            // Parse Cargo.lock to find wasmtime version
+            // Format: [[package]]\nname = "wasmtime"\nversion = "X.Y.Z"
+            let mut in_wasmtime = false;
+            for line in content.lines() {
+                if line.starts_with("name = \"wasmtime\"") {
+                    in_wasmtime = true;
+                } else if in_wasmtime && line.starts_with("version = ") {
+                    if let Some(version) = line
+                        .strip_prefix("version = \"")
+                        .and_then(|s| s.strip_suffix('"'))
+                    {
+                        println!("cargo:rustc-env=WASMTIME_VERSION={}", version);
+                        return;
+                    }
+                } else if line.starts_with("[[package]]") && in_wasmtime {
+                    break;
+                }
+            }
+        }
+    }
+
+    // Fallback if we can't parse Cargo.lock
+    println!("cargo:rustc-env=WASMTIME_VERSION=unknown");
 }
 
 /// rust-analyzer doesn't support include! for files from outside the crate.

--- a/crates/extension_host/build.rs
+++ b/crates/extension_host/build.rs
@@ -23,7 +23,7 @@ fn emit_wasmtime_version() {
             // Format: [[package]]\nname = "wasmtime"\nversion = "X.Y.Z"
             let mut in_wasmtime = false;
             for line in content.lines() {
-                if line.starts_with("name = \"wasmtime\"") {
+                if line.trim() == "name = \"wasmtime\"" {
                     in_wasmtime = true;
                 } else if in_wasmtime && line.starts_with("version = ") {
                     if let Some(version) = line

--- a/crates/extension_host/src/wasm_host.rs
+++ b/crates/extension_host/src/wasm_host.rs
@@ -697,6 +697,171 @@ impl WasmHost {
         })
     }
 
+    /// Load a pre-compiled WASM component without recompilation.
+    pub fn load_extension_from_component(
+        self: &Arc<Self>,
+        component: Component,
+        zed_api_version: semver::Version,
+        manifest: &Arc<ExtensionManifest>,
+        cx: &AsyncApp,
+    ) -> Task<Result<WasmExtension>> {
+        let this = self.clone();
+        let manifest = manifest.clone();
+        let executor = cx.background_executor().clone();
+        let load_extension_task = async move {
+            let mut store = wasmtime::Store::new(
+                &this.engine,
+                WasmState {
+                    ctx: this.build_wasi_ctx(&manifest).await?,
+                    manifest: manifest.clone(),
+                    table: ResourceTable::new(),
+                    host: this.clone(),
+                    capability_granter: CapabilityGranter::new(
+                        this.granted_capabilities.clone(),
+                        manifest.clone(),
+                    ),
+                },
+            );
+            store.set_epoch_deadline(1);
+            store.epoch_deadline_async_yield_and_update(1);
+
+            let mut extension = Extension::instantiate_async(
+                &executor,
+                &mut store,
+                this.release_channel,
+                zed_api_version.clone(),
+                &component,
+            )
+            .await?;
+
+            extension
+                .call_init_extension(&mut store)
+                .await
+                .context("failed to initialize wasm extension")?;
+
+            let (tx, mut rx) = mpsc::unbounded::<ExtensionCall>();
+            let extension_task = async move {
+                IS_WASM_THREAD.with(|v| v.store(true, Ordering::Release));
+                while let Some(call) = rx.next().await {
+                    (call)(&mut extension, &mut store).await;
+                }
+            };
+
+            anyhow::Ok((
+                extension_task,
+                manifest.clone(),
+                this.work_dir.join(manifest.id.as_ref()).into(),
+                tx,
+                zed_api_version,
+            ))
+        };
+        cx.spawn(async move |cx| {
+            let (extension_task, manifest, work_dir, tx, zed_api_version) =
+                cx.background_executor().spawn(load_extension_task).await?;
+            let task = Arc::new(gpui_tokio::Tokio::spawn(cx, extension_task)?);
+
+            Ok(WasmExtension {
+                manifest,
+                work_dir,
+                tx,
+                zed_api_version,
+                _task: task,
+            })
+        })
+    }
+
+    /// Load and compile a WASM extension, caching the compiled result to disk.
+    pub fn load_extension_and_cache(
+        self: &Arc<Self>,
+        wasm_bytes: Vec<u8>,
+        cwasm_path: &Path,
+        manifest: &Arc<ExtensionManifest>,
+        cx: &AsyncApp,
+    ) -> Task<Result<WasmExtension>> {
+        let this = self.clone();
+        let manifest = manifest.clone();
+        let executor = cx.background_executor().clone();
+        let cwasm_path = cwasm_path.to_path_buf();
+        let load_extension_task = async move {
+            let zed_api_version = parse_wasm_extension_version(&manifest.id, &wasm_bytes)?;
+
+            let component = Component::from_binary(&this.engine, &wasm_bytes)
+                .context("failed to compile wasm component")?;
+
+            // Serialize and cache the compiled component for next time (best effort)
+            if let Ok(serialized) = component.serialize() {
+                if let Err(err) = std::fs::write(&cwasm_path, &serialized) {
+                    log::debug!("Failed to cache compiled WASM extension: {}", err);
+                } else {
+                    log::debug!(
+                        "Cached compiled extension {} to {:?}",
+                        manifest.id,
+                        cwasm_path
+                    );
+                }
+            }
+
+            let mut store = wasmtime::Store::new(
+                &this.engine,
+                WasmState {
+                    ctx: this.build_wasi_ctx(&manifest).await?,
+                    manifest: manifest.clone(),
+                    table: ResourceTable::new(),
+                    host: this.clone(),
+                    capability_granter: CapabilityGranter::new(
+                        this.granted_capabilities.clone(),
+                        manifest.clone(),
+                    ),
+                },
+            );
+            store.set_epoch_deadline(1);
+            store.epoch_deadline_async_yield_and_update(1);
+
+            let mut extension = Extension::instantiate_async(
+                &executor,
+                &mut store,
+                this.release_channel,
+                zed_api_version.clone(),
+                &component,
+            )
+            .await?;
+
+            extension
+                .call_init_extension(&mut store)
+                .await
+                .context("failed to initialize wasm extension")?;
+
+            let (tx, mut rx) = mpsc::unbounded::<ExtensionCall>();
+            let extension_task = async move {
+                IS_WASM_THREAD.with(|v| v.store(true, Ordering::Release));
+                while let Some(call) = rx.next().await {
+                    (call)(&mut extension, &mut store).await;
+                }
+            };
+
+            anyhow::Ok((
+                extension_task,
+                manifest.clone(),
+                this.work_dir.join(manifest.id.as_ref()).into(),
+                tx,
+                zed_api_version,
+            ))
+        };
+        cx.spawn(async move |cx| {
+            let (extension_task, manifest, work_dir, tx, zed_api_version) =
+                cx.background_executor().spawn(load_extension_task).await?;
+            let task = Arc::new(gpui_tokio::Tokio::spawn(cx, extension_task)?);
+
+            Ok(WasmExtension {
+                manifest,
+                work_dir,
+                tx,
+                zed_api_version,
+                _task: task,
+            })
+        })
+    }
+
     async fn build_wasi_ctx(&self, manifest: &Arc<ExtensionManifest>) -> Result<wasi::WasiCtx> {
         let extension_work_dir = self.work_dir.join(manifest.id.as_ref());
         self.fs
@@ -778,23 +943,66 @@ impl WasmExtension {
         wasm_host: Arc<WasmHost>,
         cx: &AsyncApp,
     ) -> Result<Self> {
-        let path = extension_dir.join("extension.wasm");
+        let wasm_path = extension_dir.join("extension.wasm");
+        let cwasm_path = extension_dir.join("extension.cwasm");
 
+        // Always read WASM bytes to parse the zed_api_version
         let mut wasm_file = wasm_host
             .fs
-            .open_sync(&path)
+            .open_sync(&wasm_path)
             .await
-            .context(format!("opening wasm file, path: {path:?}"))?;
+            .context(format!("opening wasm file, path: {:?}", wasm_path))?;
 
         let mut wasm_bytes = Vec::new();
         wasm_file
             .read_to_end(&mut wasm_bytes)
-            .context(format!("reading wasm file, path: {path:?}"))?;
+            .context(format!("reading wasm file, path: {:?}", wasm_path))?;
 
-        wasm_host
-            .load_extension(wasm_bytes, manifest, cx)
+        let zed_api_version = parse_wasm_extension_version(&manifest.id, &wasm_bytes)?;
+
+        // Try to load pre-compiled module first
+        if let Ok(metadata) = std::fs::metadata(&cwasm_path) {
+            // Check if .cwasm is newer than .wasm (in case extension was updated)
+            let wasm_modified = std::fs::metadata(&wasm_path)
+                .and_then(|m| m.modified())
+                .ok();
+            let cwasm_modified = metadata.modified().ok();
+
+            let cwasm_is_valid = match (wasm_modified, cwasm_modified) {
+                (Some(wasm_time), Some(cwasm_time)) => cwasm_time >= wasm_time,
+                _ => true, // If we can't check timestamps, assume cwasm is valid
+            };
+
+            if cwasm_is_valid {
+                if let Ok(cwasm_bytes) = std::fs::read(&cwasm_path) {
+                    // Try to deserialize the pre-compiled module
+                    // SAFETY: We compiled this module ourselves with the same engine configuration
+                    if let Ok(component) =
+                        unsafe { Component::deserialize(&wasm_host.engine, &cwasm_bytes) }
+                    {
+                        log::debug!(
+                            "Loading pre-compiled extension {} from {:?}",
+                            manifest.id,
+                            cwasm_path
+                        );
+                        return wasm_host
+                            .load_extension_from_component(component, zed_api_version, manifest, cx)
+                            .await
+                            .with_context(|| {
+                                format!("loading pre-compiled wasm extension: {}", manifest.id)
+                            });
+                    }
+                }
+            }
+        }
+
+        // Compile and persist the module for next time
+        let result = wasm_host
+            .load_extension_and_cache(wasm_bytes, &cwasm_path, manifest, cx)
             .await
-            .with_context(|| format!("loading wasm extension: {}", manifest.id))
+            .with_context(|| format!("loading wasm extension: {}", manifest.id));
+
+        result
     }
 
     pub async fn call<T, Fn>(&self, f: Fn) -> Result<T>
@@ -891,31 +1099,81 @@ impl wasi::WasiView for WasmState {
 /// Since wasm modules have many similar elements, this can save us a lot of work at the
 /// cost of a small memory footprint. However, we don't want this to be unbounded, so we use
 /// a LFU/LRU cache to evict less used cache entries.
+///
+/// This cache also persists entries to disk to survive app restarts, avoiding expensive
+/// recompilation of WASM extensions on every startup.
 #[derive(Debug)]
 struct IncrementalCompilationCache {
-    cache: Cache<Vec<u8>, Vec<u8>>,
+    memory_cache: Cache<Vec<u8>, Vec<u8>>,
+    cache_dir: PathBuf,
 }
 
 impl IncrementalCompilationCache {
     fn new() -> Self {
-        let cache = Cache::builder()
+        let memory_cache = Cache::builder()
             // Cap this at 32 MB for now. Our extensions turn into roughly 512kb in the cache,
             // which means we could store 64 completely novel extensions in the cache, but in
             // practice we will more than that, which is more than enough for our use case.
             .max_capacity(32 * 1024 * 1024)
             .weigher(|k: &Vec<u8>, v: &Vec<u8>| (k.len() + v.len()).try_into().unwrap_or(u32::MAX))
             .build();
-        Self { cache }
+
+        // Include wasmtime version in cache path to invalidate on engine updates.
+        // WASMTIME_VERSION is set by build.rs from Cargo.lock.
+        let cache_dir =
+            paths::wasm_cache_dir().join(format!("wasmtime-{}", env!("WASMTIME_VERSION")));
+
+        // Create cache directory if it doesn't exist
+        if let Err(err) = std::fs::create_dir_all(&cache_dir) {
+            log::warn!("Failed to create WASM cache directory: {}", err);
+        }
+
+        Self {
+            memory_cache,
+            cache_dir,
+        }
+    }
+
+    fn cache_file_path(&self, key: &[u8]) -> PathBuf {
+        use std::fmt::Write;
+        // Use a hash of the key as the filename
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        std::hash::Hash::hash_slice(key, &mut hasher);
+        let hash = std::hash::Hasher::finish(&hasher);
+        let mut filename = String::with_capacity(16);
+        write!(&mut filename, "{:016x}.cache", hash).unwrap();
+        self.cache_dir.join(filename)
     }
 }
 
 impl CacheStore for IncrementalCompilationCache {
     fn get(&self, key: &[u8]) -> Option<Cow<'_, [u8]>> {
-        self.cache.get(key).map(|v| v.into())
+        // Check memory cache first
+        if let Some(value) = self.memory_cache.get(key) {
+            return Some(value.into());
+        }
+
+        // Check disk cache
+        let cache_file = self.cache_file_path(key);
+        if let Ok(data) = std::fs::read(&cache_file) {
+            // Populate memory cache for faster subsequent access
+            self.memory_cache.insert(key.to_vec(), data.clone());
+            return Some(data.into());
+        }
+
+        None
     }
 
     fn insert(&self, key: &[u8], value: Vec<u8>) -> bool {
-        self.cache.insert(key.to_vec(), value);
+        // Insert into memory cache
+        self.memory_cache.insert(key.to_vec(), value.clone());
+
+        // Persist to disk cache (best effort - don't fail if this doesn't work)
+        let cache_file = self.cache_file_path(key);
+        if let Err(err) = std::fs::write(&cache_file, &value) {
+            log::debug!("Failed to persist WASM cache entry to disk: {}", err);
+        }
+
         true
     }
 }

--- a/crates/extension_host/src/wasm_host.rs
+++ b/crates/extension_host/src/wasm_host.rs
@@ -956,7 +956,8 @@ impl WasmExtension {
         let wasm_path = extension_dir.join("extension.wasm");
         // Include wasmtime version to invalidate cache on engine updates.
         // Without this, Component::deserialize could load incompatible components.
-        let cwasm_path = extension_dir.join(format!("extension-{}.cwasm", env!("WASMTIME_VERSION")));
+        let cwasm_path =
+            extension_dir.join(format!("extension-{}.cwasm", env!("WASMTIME_VERSION")));
 
         // Always read WASM bytes to parse the zed_api_version
         let mut wasm_file = wasm_host
@@ -1111,8 +1112,6 @@ impl wasi::WasiView for WasmState {
     }
 }
 
-
-
 /// Wrapper around a mini-moka bounded cache for storing incremental compilation artifacts.
 /// Since wasm modules have many similar elements, this can save us a lot of work at the
 /// cost of a small memory footprint. However, we don't want this to be unbounded, so we use
@@ -1191,4 +1190,3 @@ impl CacheStore for IncrementalCompilationCache {
         true
     }
 }
-

--- a/crates/paths/src/paths.rs
+++ b/crates/paths/src/paths.rs
@@ -155,6 +155,14 @@ pub fn temp_dir() -> &'static PathBuf {
     })
 }
 
+/// Returns the path to the WASM compilation cache directory.
+///
+/// This is where compiled WASM modules are cached to avoid recompilation on startup.
+pub fn wasm_cache_dir() -> &'static PathBuf {
+    static WASM_CACHE_DIR: OnceLock<PathBuf> = OnceLock::new();
+    WASM_CACHE_DIR.get_or_init(|| temp_dir().join("wasm-cache"))
+}
+
 /// Returns the path to the hang traces directory.
 pub fn hang_traces_dir() -> &'static PathBuf {
     static LOGS_DIR: OnceLock<PathBuf> = OnceLock::new();

--- a/crates/project/src/worktree_store.rs
+++ b/crates/project/src/worktree_store.rs
@@ -1212,4 +1212,3 @@ mod tests {
         assert!(!should_defer_scanning(&home.join("AppData").join("Local")));
     }
 }
-

--- a/crates/project/src/worktree_store.rs
+++ b/crates/project/src/worktree_store.rs
@@ -81,12 +81,6 @@ fn should_defer_scanning(abs_path: &Path) -> bool {
     false
 }
 
-struct MatchingEntry {
-    worktree_root: Arc<Path>,
-    path: ProjectPath,
-    respond: oneshot::Sender<ProjectPath>,
-}
-
 enum WorktreeStoreState {
     Local {
         fs: Arc<dyn Fs>,

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -3488,9 +3488,14 @@ impl ProjectPanel {
                             hash_map::Entry::Occupied(e) => e.into_mut(),
                             hash_map::Entry::Vacant(e) => {
                                 // The first time a worktree's root entry becomes available,
-                                // mark that root entry as expanded.
+                                // mark that root entry as expanded (unless it's UnloadedDir).
                                 if let Some(entry) = worktree_snapshot.root_entry() {
-                                    e.insert(vec![entry.id]).as_slice()
+                                    if entry.kind == project::EntryKind::UnloadedDir {
+                                        // Don't auto-expand UnloadedDir roots - let user click to expand
+                                        e.insert(vec![]).as_slice()
+                                    } else {
+                                        e.insert(vec![entry.id]).as_slice()
+                                    }
                                 } else {
                                     &[]
                                 }

--- a/crates/remote_server/src/headless_project.rs
+++ b/crates/remote_server/src/headless_project.rs
@@ -474,6 +474,7 @@ impl HeadlessProject {
                     this.fs.clone(),
                     this.next_entry_id.clone(),
                     true,
+                    false,
                     &mut cx,
                 )
             })?

--- a/crates/sqlez/Cargo.toml
+++ b/crates/sqlez/Cargo.toml
@@ -17,7 +17,6 @@ libsqlite3-sys.workspace = true
 log.workspace = true
 parking_lot.workspace = true
 smol.workspace = true
-sqlformat.workspace = true
 thread_local = "1.1.4"
 util.workspace = true
 uuid.workspace = true

--- a/crates/worktree/src/worktree_tests.rs
+++ b/crates/worktree/src/worktree_tests.rs
@@ -47,6 +47,7 @@ async fn test_traversal(cx: &mut TestAppContext) {
         fs,
         Default::default(),
         true,
+        false,
         &mut cx.to_async(),
     )
     .await
@@ -112,6 +113,7 @@ async fn test_circular_symlinks(cx: &mut TestAppContext) {
         fs.clone(),
         Default::default(),
         true,
+        false,
         &mut cx.to_async(),
     )
     .await
@@ -212,6 +214,7 @@ async fn test_symlinks_pointing_outside(cx: &mut TestAppContext) {
         fs.clone(),
         Default::default(),
         true,
+        false,
         &mut cx.to_async(),
     )
     .await
@@ -363,6 +366,7 @@ async fn test_renaming_case_only(cx: &mut TestAppContext) {
         fs.clone(),
         Default::default(),
         true,
+        false,
         &mut cx.to_async(),
     )
     .await
@@ -441,6 +445,7 @@ async fn test_open_gitignored_files(cx: &mut TestAppContext) {
         fs.clone(),
         Default::default(),
         true,
+        false,
         &mut cx.to_async(),
     )
     .await
@@ -606,6 +611,7 @@ async fn test_dirs_no_longer_ignored(cx: &mut TestAppContext) {
         fs.clone(),
         Default::default(),
         true,
+        false,
         &mut cx.to_async(),
     )
     .await
@@ -707,6 +713,7 @@ async fn test_write_file(cx: &mut TestAppContext) {
         Arc::new(RealFs::new(None, cx.executor())),
         Default::default(),
         true,
+        false,
         &mut cx.to_async(),
     )
     .await
@@ -805,6 +812,7 @@ async fn test_file_scan_inclusions(cx: &mut TestAppContext) {
         Arc::new(RealFs::new(None, cx.executor())),
         Default::default(),
         true,
+        false,
         &mut cx.to_async(),
     )
     .await
@@ -871,6 +879,7 @@ async fn test_file_scan_exclusions_overrules_inclusions(cx: &mut TestAppContext)
         Arc::new(RealFs::new(None, cx.executor())),
         Default::default(),
         true,
+        false,
         &mut cx.to_async(),
     )
     .await
@@ -930,6 +939,7 @@ async fn test_file_scan_inclusions_reindexes_on_setting_change(cx: &mut TestAppC
         Arc::new(RealFs::new(None, cx.executor())),
         Default::default(),
         true,
+        false,
         &mut cx.to_async(),
     )
     .await
@@ -1016,6 +1026,7 @@ async fn test_file_scan_exclusions(cx: &mut TestAppContext) {
         Arc::new(RealFs::new(None, cx.executor())),
         Default::default(),
         true,
+        false,
         &mut cx.to_async(),
     )
     .await
@@ -1098,6 +1109,7 @@ async fn test_hidden_files(cx: &mut TestAppContext) {
         Arc::new(RealFs::new(None, cx.executor())),
         Default::default(),
         true,
+        false,
         &mut cx.to_async(),
     )
     .await
@@ -1209,6 +1221,7 @@ async fn test_fs_events_in_exclusions(cx: &mut TestAppContext) {
         Arc::new(RealFs::new(None, cx.executor())),
         Default::default(),
         true,
+        false,
         &mut cx.to_async(),
     )
     .await
@@ -1321,6 +1334,7 @@ async fn test_fs_events_in_dot_git_worktree(cx: &mut TestAppContext) {
         Arc::new(RealFs::new(None, cx.executor())),
         Default::default(),
         true,
+        false,
         &mut cx.to_async(),
     )
     .await
@@ -1360,6 +1374,7 @@ async fn test_create_directory_during_initial_scan(cx: &mut TestAppContext) {
         fs,
         Default::default(),
         true,
+        false,
         &mut cx.to_async(),
     )
     .await
@@ -1429,6 +1444,7 @@ async fn test_create_dir_all_on_create_entry(cx: &mut TestAppContext) {
         fs_fake,
         Default::default(),
         true,
+        false,
         &mut cx.to_async(),
     )
     .await
@@ -1471,6 +1487,7 @@ async fn test_create_dir_all_on_create_entry(cx: &mut TestAppContext) {
         fs_real,
         Default::default(),
         true,
+        false,
         &mut cx.to_async(),
     )
     .await
@@ -1580,6 +1597,7 @@ async fn test_create_file_in_expanded_gitignored_dir(cx: &mut TestAppContext) {
         fs.clone(),
         Default::default(),
         true,
+        false,
         &mut cx.to_async(),
     )
     .await
@@ -1676,6 +1694,7 @@ async fn test_fs_event_for_gitignored_dir_does_not_lose_contents(cx: &mut TestAp
         fs.clone(),
         Default::default(),
         true,
+        false,
         &mut cx.to_async(),
     )
     .await
@@ -1754,6 +1773,7 @@ async fn test_random_worktree_operations_during_initial_scan(
         fs.clone(),
         Default::default(),
         true,
+        false,
         &mut cx.to_async(),
     )
     .await
@@ -1845,6 +1865,7 @@ async fn test_random_worktree_changes(cx: &mut TestAppContext, mut rng: StdRng) 
         fs.clone(),
         Default::default(),
         true,
+        false,
         &mut cx.to_async(),
     )
     .await
@@ -1918,6 +1939,7 @@ async fn test_random_worktree_changes(cx: &mut TestAppContext, mut rng: StdRng) 
             fs.clone(),
             Default::default(),
             true,
+            false,
             &mut cx.to_async(),
         )
         .await
@@ -2238,6 +2260,7 @@ async fn test_private_single_file_worktree(cx: &mut TestAppContext) {
         fs.clone(),
         Default::default(),
         true,
+        false,
         &mut cx.to_async(),
     )
     .await
@@ -2271,6 +2294,7 @@ async fn test_repository_above_root(executor: BackgroundExecutor, cx: &mut TestA
         fs.clone(),
         Arc::default(),
         true,
+        false,
         &mut cx.to_async(),
     )
     .await
@@ -2349,6 +2373,7 @@ async fn test_global_gitignore(executor: BackgroundExecutor, cx: &mut TestAppCon
         fs.clone(),
         Arc::default(),
         true,
+        false,
         &mut cx.to_async(),
     )
     .await
@@ -2455,6 +2480,7 @@ async fn test_repo_exclude(executor: BackgroundExecutor, cx: &mut TestAppContext
         fs.clone(),
         Default::default(),
         true,
+        false,
         &mut cx.to_async(),
     )
     .await
@@ -2671,6 +2697,7 @@ async fn test_load_file_encoding(cx: &mut TestAppContext) {
         fs,
         Default::default(),
         true,
+        false,
         &mut cx.to_async(),
     )
     .await
@@ -2734,6 +2761,7 @@ async fn test_write_file_encoding(cx: &mut gpui::TestAppContext) {
         fs.clone(),
         Default::default(),
         true,
+        false,
         &mut cx.to_async(),
     )
     .await
@@ -2842,4 +2870,150 @@ async fn test_write_file_encoding(cx: &mut gpui::TestAppContext) {
             case.name, case.expected_bytes, bytes
         );
     }
+}
+
+#[gpui::test]
+async fn test_defer_initial_scan(cx: &mut TestAppContext) {
+    init_test(cx);
+    let fs = FakeFs::new(cx.background_executor.clone());
+    fs.insert_tree(
+        "/root",
+        json!({
+            "a": {
+                "a1.txt": "a1",
+                "a2": {
+                    "nested.txt": "nested"
+                }
+            },
+            "b": {
+                "b1.txt": "b1"
+            },
+            "c.txt": "c"
+        }),
+    )
+    .await;
+
+    // Create worktree with defer_initial_scan=true
+    let tree = Worktree::local(
+        Path::new("/root"),
+        true,
+        fs.clone(),
+        Default::default(),
+        true,
+        true, // defer_initial_scan = true
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+
+    cx.executor().run_until_parked();
+
+    // Initially, root should be UnloadedDir (not scanned)
+    tree.read_with(cx, |tree, _| {
+        let root = tree.entry_for_path(rel_path("")).unwrap();
+        assert_eq!(
+            root.kind,
+            EntryKind::UnloadedDir,
+            "Root should start as UnloadedDir when defer_initial_scan=true"
+        );
+
+        // No child entries should exist yet
+        assert_eq!(
+            tree.entries(true, 0).count(),
+            1,
+            "Only root entry should exist initially"
+        );
+    });
+
+    // Expand the root directory
+    tree.read_with(cx, |tree, _| {
+        tree.as_local()
+            .unwrap()
+            .refresh_entries_for_paths(vec![rel_path("").into()])
+    })
+    .recv()
+    .await;
+
+    // After expanding root, immediate children should be visible
+    // but subdirectories should still be UnloadedDir
+    tree.read_with(cx, |tree, _| {
+        let entries: Vec<_> = tree.entries(true, 0).collect();
+
+        // Should have root + a + b + c.txt
+        assert!(entries.len() >= 4, "Should have root and its children");
+
+        // Check that root is now Dir (not UnloadedDir)
+        let root = tree.entry_for_path(rel_path("")).unwrap();
+        assert_eq!(
+            root.kind,
+            EntryKind::Dir,
+            "Root should be Dir after expansion"
+        );
+
+        // Check that child directories are UnloadedDir (not recursively scanned)
+        if let Some(dir_a) = tree.entry_for_path(rel_path("a")) {
+            assert_eq!(
+                dir_a.kind,
+                EntryKind::UnloadedDir,
+                "Child directory 'a' should be UnloadedDir (not recursively scanned)"
+            );
+        }
+
+        if let Some(dir_b) = tree.entry_for_path(rel_path("b")) {
+            assert_eq!(
+                dir_b.kind,
+                EntryKind::UnloadedDir,
+                "Child directory 'b' should be UnloadedDir (not recursively scanned)"
+            );
+        }
+
+        // File should be present
+        assert!(
+            tree.entry_for_path(rel_path("c.txt")).is_some(),
+            "File c.txt should be visible"
+        );
+    });
+
+    // Expand directory 'a'
+    tree.read_with(cx, |tree, _| {
+        tree.as_local()
+            .unwrap()
+            .refresh_entries_for_paths(vec![rel_path("a").into()])
+    })
+    .recv()
+    .await;
+
+    // After expanding 'a', its contents should be visible
+    tree.read_with(cx, |tree, _| {
+        // 'a' should now be Dir
+        let dir_a = tree.entry_for_path(rel_path("a")).unwrap();
+        assert_eq!(
+            dir_a.kind,
+            EntryKind::Dir,
+            "'a' should be Dir after expansion"
+        );
+
+        // 'a/a1.txt' should be visible
+        assert!(
+            tree.entry_for_path(rel_path("a/a1.txt")).is_some(),
+            "a/a1.txt should be visible after expanding 'a'"
+        );
+
+        // 'a/a2' should still be UnloadedDir
+        if let Some(dir_a2) = tree.entry_for_path(rel_path("a/a2")) {
+            assert_eq!(
+                dir_a2.kind,
+                EntryKind::UnloadedDir,
+                "Nested directory 'a/a2' should still be UnloadedDir"
+            );
+        }
+
+        // 'b' should still be UnloadedDir (we didn't expand it)
+        let dir_b = tree.entry_for_path(rel_path("b")).unwrap();
+        assert_eq!(
+            dir_b.kind,
+            EntryKind::UnloadedDir,
+            "'b' should still be UnloadedDir"
+        );
+    });
 }

--- a/crates/worktree_benchmarks/src/main.rs
+++ b/crates/worktree_benchmarks/src/main.rs
@@ -27,6 +27,7 @@ fn main() {
                 fs,
                 Arc::new(AtomicUsize::new(0)),
                 true,
+                false,
                 cx,
             )
             .await


### PR DESCRIPTION
Release Notes:

- SQL Optimisation: Reduce CPU overhead during startup caused by re-formatting SQL migrations.
- Startup Cache Enhancements: provide a stable, persistent location for WASM compilation artefacts.
- WASM Compilation Optimisation: target the significant component of startup CPU bloat.
- On-demand directory scanning.`/` and `~` directories are set as deferred scanning directories, which should vastly reduce the CPU usage when opening them. 

Maybe on-demand directory scanning can be considered to set as a configuration. It can at least partially solve [#35780](https://github.com/zed-industries/zed/issues/35780) and completely solve [20913](https://github.com/zed-industries/zed/issues/20913)

Recording:

Before (`main` branch):

https://github.com/user-attachments/assets/afa58c6f-7d82-4a9b-9e56-508116876f72

After (this fix):

https://github.com/user-attachments/assets/011fd617-faec-4db4-9694-290b7d6190e9

