### PR TITLE
setting: Add `editor.select_word_as_node` setting for syntax node selection behavior

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -284,6 +284,8 @@
   // 4. Never show the scrollbar:
   //    "never" (default)
   "completion_menu_scrollbar": "never",
+  // Whether to select the word under the cursor when expanding the selection.
+  "select_word_as_node": true,
   // Show method signatures in the editor, when inside parentheses.
   "auto_signature_help": false,
   // Whether to show the signature help after completion or a bracket pair inserted.

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -15885,23 +15885,25 @@ impl Editor {
             .map(|selection| {
                 let old_range = selection.start..selection.end;
 
-                if let Some((node, _)) = buffer.syntax_ancestor(old_range.clone()) {
-                    // manually select word at selection
-                    if ["string_content", "inline"].contains(&node.kind()) {
-                        let (word_range, _) = buffer.surrounding_word(old_range.start, None);
-                        // ignore if word is already selected
-                        if !word_range.is_empty() && old_range != word_range {
-                            let (last_word_range, _) = buffer.surrounding_word(old_range.end, None);
-                            // only select word if start and end point belongs to same word
-                            if word_range == last_word_range {
-                                selected_larger_node = true;
-                                return Selection {
-                                    id: selection.id,
-                                    start: word_range.start,
-                                    end: word_range.end,
-                                    goal: SelectionGoal::None,
-                                    reversed: selection.reversed,
-                                };
+                if EditorSettings::get_global(cx).select_word_as_node {
+                    if let Some((node, _)) = buffer.syntax_ancestor(old_range.clone()) {
+                        // manually select word at selection
+                        if ["string_content", "inline"].contains(&node.kind()) {
+                            let (word_range, _) = buffer.surrounding_word(old_range.start, None);
+                            // ignore if word is already selected
+                            if !word_range.is_empty() && old_range != word_range {
+                                let (last_word_range, _) = buffer.surrounding_word(old_range.end, None);
+                                // only select word if start and end point belongs to same word
+                                if word_range == last_word_range {
+                                    selected_larger_node = true;
+                                    return Selection {
+                                        id: selection.id,
+                                        start: word_range.start,
+                                        end: word_range.end,
+                                        goal: SelectionGoal::None,
+                                        reversed: selection.reversed,
+                                    };
+                                }
                             }
                         }
                     }

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -57,6 +57,7 @@ pub struct EditorSettings {
     pub lsp_document_colors: DocumentColorsRenderMode,
     pub minimum_contrast_for_highlights: f32,
     pub completion_menu_scrollbar: ShowScrollbar,
+    pub select_word_as_node: bool,
 }
 #[derive(Debug, Clone)]
 pub struct Jupyter {
@@ -286,6 +287,7 @@ impl Settings for EditorSettings {
             lsp_document_colors: editor.lsp_document_colors.unwrap(),
             minimum_contrast_for_highlights: editor.minimum_contrast_for_highlights.unwrap().0,
             completion_menu_scrollbar: editor.completion_menu_scrollbar.map(Into::into).unwrap(),
+            select_word_as_node: editor.select_word_as_node.unwrap(),
         }
     }
 }

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -9679,6 +9679,66 @@ async fn test_select_larger_smaller_syntax_node_for_string(cx: &mut TestAppConte
 }
 
 #[gpui::test]
+async fn test_select_larger_syntax_node_disabled_word_selection(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let language = Arc::new(Language::new(
+        LanguageConfig::default(),
+        Some(tree_sitter_rust::LANGUAGE.into()),
+    ));
+
+    let text = r#"
+        fn fn_1() {
+            let var1 = "hello world";
+        }
+    "#
+    .unindent();
+
+    let buffer = cx.new(|cx| Buffer::local(text, cx).with_language(language, cx));
+    let buffer = cx.new(|cx| MultiBuffer::singleton(buffer, cx));
+    let (editor, cx) = cx.add_window_view(|window, cx| build_editor(buffer, window, cx));
+
+    editor
+        .condition::<crate::EditorEvent>(cx, |editor, cx| !editor.buffer.read(cx).is_parsing(cx))
+        .await;
+
+    // Disable word selection
+    update_test_editor_settings(cx, |settings| {
+        settings.select_word_as_node = Some(false);
+    });
+
+    editor.update_in(cx, |editor, window, cx| {
+        editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
+            s.select_display_ranges([
+                DisplayPoint::new(DisplayRow(1), 17)..DisplayPoint::new(DisplayRow(1), 17)
+            ]);
+        });
+    });
+    editor.update_in(cx, |editor, window, cx| {
+        assert_text_with_selections(
+            editor,
+            indoc! {r#"
+                fn fn_1() {
+                    let var1 = "hˇello world";
+                }
+            "#},
+            cx,
+        );
+        editor.select_larger_syntax_node(&SelectLargerSyntaxNode, window, cx);
+        // Should skip the "hello" word selection and go straight to the string content
+        assert_text_with_selections(
+            editor,
+            indoc! {r#"
+                fn fn_1() {
+                    let var1 = "«ˇhello world»";
+                }
+            "#},
+            cx,
+        );
+    });
+}
+
+#[gpui::test]
 async fn test_unwrap_syntax_nodes(cx: &mut gpui::TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/settings/src/settings_content/editor.rs
+++ b/crates/settings/src/settings_content/editor.rs
@@ -215,6 +215,11 @@ pub struct EditorSettingsContent {
     /// 4. Never show the scrollbar:
     ///    "never" (default)
     pub completion_menu_scrollbar: Option<ShowScrollbar>,
+
+    /// Whether to select the word under the cursor when expanding the selection.
+    ///
+    /// Default: true
+    pub select_word_as_node: Option<bool>,
 }
 
 #[derive(

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -302,6 +302,7 @@ impl VsCodeSettings {
             use_smartcase_search: self.read_bool("search.smartCase"),
             vertical_scroll_margin: self.read_f32("editor.cursorSurroundingLines"),
             completion_menu_scrollbar: None,
+            select_word_as_node: None,
         }
     }
 


### PR DESCRIPTION
This PR adds the `editor.select_word_as_node` setting (defaulting to `true`) to guard the behavior introduced in https://github.com/zed-industries/zed/pull/28864
.

The goal is to provide an opt-out for users who find this behavior unintuitive or counterproductive—particularly when they intend to select the actual syntax node rather than the word.

Note: This patch was generated with the assistance of Gemini.