### PR TITLE
markdown_preview: Fix inline HTML <img> tags not being rendered

### DIFF
--- a/crates/markdown_preview/src/markdown_parser.rs
+++ b/crates/markdown_preview/src/markdown_parser.rs
@@ -270,20 +270,21 @@ impl<'a> MarkdownParser<'a> {
                 }
 
                 Event::InlineHtml(html) => {
-                    let (_, html_range) = self.current().unwrap();
-                    let html_range = html_range.clone();
-
-                    if let Some(image) = self.extract_inline_html_image(&html, html_range) {
-                        if !text.is_empty() {
-                            let parsed_regions = MarkdownParagraphChunk::Text(ParsedMarkdownText {
-                                source_range: source_range.clone(),
-                                contents: mem::take(&mut text).into(),
-                                highlights: mem::take(&mut highlights),
-                                regions: mem::take(&mut regions),
-                            });
-                            markdown_text_like.push(parsed_regions);
+                    if let Some((_, html_range)) = self.current() {
+                        let html_range = html_range.clone();
+                        if let Some(image) = self.extract_inline_html_image(&html, html_range) {
+                            if !text.is_empty() {
+                                let parsed_regions =
+                                    MarkdownParagraphChunk::Text(ParsedMarkdownText {
+                                        source_range: source_range.clone(),
+                                        contents: mem::take(&mut text).into(),
+                                        highlights: mem::take(&mut highlights),
+                                        regions: mem::take(&mut regions),
+                                    });
+                                markdown_text_like.push(parsed_regions);
+                            }
+                            markdown_text_like.push(MarkdownParagraphChunk::Image(image));
                         }
-                        markdown_text_like.push(MarkdownParagraphChunk::Image(image));
                     }
                 }
 


### PR DESCRIPTION
Closes #38748

## Problem

The markdown preview was not rendering `<img>` tags unless there was a blank line before them. This caused images indented under list items to silently fail to display.

 **Example markdown that wasn't working:**

 ```md
- `Dock`: A UI element similar to a `Pane` which can be opened and hidden. There can be up to 3 docks open at a time, left right and below the center. A dock contains one or more `Panel`s not `Pane`s. (see image).
<img width="1921" height="1080" alt="image" src="https://github.com/user-attachments/assets/2cb1170e-2850-450d-89bb-73622b5d07b2" />

- `Project`: One or more `Worktree`s
```

The first image would not render, while an image with a blank line before it would work fine.

<img width="1504" height="327" alt="image" src="https://github.com/user-attachments/assets/bb7ced57-760e-4d5e-807d-b85427b4c3a1" />

## Solution

Updated the markdown parser to handle inline `<img>` tags that don't have a blank line before them.

<img width="1568" height="646" alt="image" src="https://github.com/user-attachments/assets/e948f89f-4a12-4c48-b22b-0ac0cb09f1e5" />

Release Notes:

- Fixed markdown preview not rendering <img> tags that don't have a blank line before them (https://github.com/zed-industries/zed/issues/38748)
