### PR TITLE
terminal: Fix fast scrolling during mouse mode

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -1988,7 +1988,9 @@ impl Terminal {
         let mouse_mode = self.mouse_mode(e.shift);
         let scroll_multiplier = if mouse_mode { 1. } else { scroll_multiplier };
 
-        if let Some(scroll_lines) = self.determine_scroll_lines(e, scroll_multiplier) {
+        if let Some(scroll_lines) = self.determine_scroll_lines(e, scroll_multiplier)
+            && scroll_lines != 0
+        {
             if mouse_mode {
                 let point = grid_point(
                     e.position - self.last_content.terminal_bounds.bounds.origin,
@@ -2009,7 +2011,7 @@ impl Terminal {
                 && !e.shift
             {
                 self.write_to_pty(alt_scroll(scroll_lines));
-            } else if scroll_lines != 0 {
+            } else {
                 let scroll = AlacScroll::Delta(scroll_lines);
 
                 self.events.push_back(InternalEvent::Scroll(scroll));


### PR DESCRIPTION
Closes #18930

### Summary
- Fix fast Macbook trackpad/mouse scrolling in terminal applications with mouse mode enabled

### The Problem
Scrolling with a trackpad in tmux, neovim, or any terminal app that enables mouse mode was too fast. A gentle swipe would send me through hundreds of lines, making these apps practically unusable in Zed's terminal.

### Root Cause
When the terminal is in mouse mode, we send escape sequences to report scroll events to the application. The bug was in `scroll_report()`:
https://github.com/zed-industries/zed/blob/ca478226677e5f7190a5d8933277522780faaaf7/crates/terminal/src/terminal.rs#L1983-L1988

That `max(scroll_lines, 1)` meant we'd send **at least 1 scroll event even when `scroll_lines` was 0**.
https://github.com/zed-industries/zed/blob/ca478226677e5f7190a5d8933277522780faaaf7/crates/terminal/src/mappings/mouse.rs#L96

On macOS, trackpad gestures fire many small pixel deltas due to scroll acceleration. Each tiny movement triggered a scroll event, even though we hadn't accumulated enough pixels for a full line yet. This is a known issue alacritty/alacritty#2869 - macOS sends fractional line deltas (like 0.1) instead of whole lines.

### The Fix
Don't send mouse reports when no full line has accumulated

This aligns with Alacritty's approach - accumulate partial scroll amounts and only report when complete lines are ready.
https://github.com/alacritty/alacritty/blob/6ee6e53ee3457c24137f117237b0ff1d84f6f836/alacritty/src/input/mod.rs#L700-L730

### Testing
Tested trackpad scrolling in:
- tmux (pane navigation, scrollback)
- neovim (buffer scrolling)
- opencode (TUI navigation)
All scroll smoothly now.

### Demo
The demo shows the behavior of the scrolling. I can go fast or I can go slow

https://github.com/user-attachments/assets/14bfc2f4-f286-4341-bf55-4ced894d63f9

Release Notes:

- Fixed trackpad scrolling being too fast in terminal applications with mouse mode enabled (tmux, neovim, opencode, etc.)