### PR TITLE
editor: Fix ctrl+drag/drop to duplicate selected text

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1020,6 +1020,10 @@ impl EditorElement {
             && hovered_link_modifier
             && mouse_down_hovered_link_modifier
             && text_hitbox.is_hovered(window)
+            && !matches!(
+                editor.selection_drag_state,
+                SelectionDragState::Dragging { .. }
+            )
         {
             let point = position_map.point_for_position(mouse_position);
             editor.handle_click_hovered_link(point, event.modifiers(), window, cx);


### PR DESCRIPTION
Holding control while dragging text to copy it was being blocked by link handling stopping the propogation of the mouse event; solution: don't handle link clicks when selection_drag_state is Dragging.

Issue found & fix tested on Linux (since the modifier key on mac is apparently different, the issue likely doesn't occur there, but I'm assuming it does apply to Windows).

I didn't see an issue open for it, and since I fixed it myself I'm unsure whether it needs one or if the PR is enough.

Release Notes:

- Fix an issue where Ctrl+drag to duplicate selected text on Linux and Windows when the selection is inside a link.