### PR TITLE
docs: Update casing of `Ty` to `ty`

### DIFF
--- a/docs/src/languages/python.md
+++ b/docs/src/languages/python.md
@@ -71,7 +71,7 @@ Zed provides several Python language servers out of the box. By default, [basedp
 
 Other built-in language servers are:
 
-- [Ty](https://docs.astral.sh/ty/)&mdash;Up-and-coming language server from Astral, built for speed.
+- [ty](https://docs.astral.sh/ty/)&mdash;Up-and-coming language server from Astral, built for speed.
 - [Pyright](https://github.com/microsoft/pyright)&mdash;The basis for basedpyright.
 - [PyLSP](https://github.com/python-lsp/python-lsp-server)&mdash;A plugin-based language server that integrates with tools like `pycodestyle`, `autopep8`, and `yapf`.
 
@@ -82,7 +82,7 @@ These are disabled by default, but can be enabled in your settings. For example:
   "languages": {
     "Python": {
       "language_servers": [
-        // Disable basedpyright and enable Ty, and otherwise
+        // Disable basedpyright and enable ty, and otherwise
         // use the default configuration.
         "ty",
         "!basedpyright",

--- a/docs/src/migrate/pycharm.md
+++ b/docs/src/migrate/pycharm.md
@@ -164,7 +164,7 @@ Zed uses the Language Server Protocol (LSP) for code intelligence. For Python, Z
 
 - **basedpyright** (default) — Fast type checking and completions
 - **Ruff** (default) — Linting and formatting
-- **Ty** — Up-and-coming language server from Astral, built for speed
+- **ty** — Up-and-coming language server from Astral, built for speed
 - **Pyright** — Microsoft's type checker
 - **PyLSP** — Plugin-based server with tool integrations
 


### PR DESCRIPTION
### Why?

Small nit I noticed when configuring `ty` from Zed docs, ty should always be stylized as lowercase.

See: https://github.com/astral-sh/ty?tab=readme-ov-file#how-should-i-stylize-ty

Release Notes:

- N/A
