### PR TITLE
git: Add "Stage All" and "Discard" buttons to Git panel headers and entries, visible on hover

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -4750,18 +4750,16 @@ impl GitPanel {
                                 .icon_size(IconSize::Small)
                                 .icon_color(Color::Muted)
                                 .tooltip(Tooltip::text(discard_tooltip))
-                                .on_click(cx.listener(move |this, _, window, cx| {
-                                    match section {
-                                        Section::New => {
-                                            this.clean_all(&TrashUntrackedFiles, window, cx);
-                                        }
-                                        _ => {
-                                            this.restore_tracked_files(
-                                                &RestoreTrackedFiles,
-                                                window,
-                                                cx,
-                                            );
-                                        }
+                                .on_click(cx.listener(move |this, _, window, cx| match section {
+                                    Section::New => {
+                                        this.clean_all(&TrashUntrackedFiles, window, cx);
+                                    }
+                                    _ => {
+                                        this.restore_tracked_files(
+                                            &RestoreTrackedFiles,
+                                            window,
+                                            cx,
+                                        );
                                     }
                                 })),
                         ),


### PR DESCRIPTION
Release Notes:

- Added 'Stage All' and 'Discard' button to Git panel headers and entries

Recording:


https://github.com/user-attachments/assets/20ca2041-4a7c-4a2c-8af4-9b040c55b2f7

