### PR TITLE
Add structured outline for Markdown

### DIFF
--- a/crates/languages/src/markdown/outline.scm
+++ b/crates/languages/src/markdown/outline.scm
@@ -1,5 +1,3 @@
-(atx_heading
-    .
-    (_) @context
-    .
-    (_) @name ) @item
+(section
+    (atx_heading
+        . (_) @context . (_) @name)) @item


### PR DESCRIPTION
Just make outline of markdown to be structured:

<img width="282" height="144" alt="image" src="https://github.com/user-attachments/assets/6c7e5d5f-ae09-47a9-965a-6f9f9b731ce6" />

Release Notes:

- Added structured outline for Markdown.
- Also fixed the breadcrumb display in Issue [#45663](https://github.com/zed-industries/zed/issues/45663).