### PR TITLE
docs: Add missing option for `show_whitespaces` setting

### DIFF
--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -3512,6 +3512,7 @@ Positive integer values
 2. `selection`
 3. `none`
 4. `boundary`
+5. `trailing`
 
 ## Whitespace Map
 


### PR DESCRIPTION
The value for the `trailing` option in the `show_whitespaces` setting was not documented, so I have added it.

Related Issue:
https://github.com/zed-industries/zed/pull/32329#issuecomment-3581576128

Release Notes:

- N/A
