### PR TITLE
Add missing #elifdef, #elifndef directives to C/C++ highlights

### DIFF
--- a/crates/languages/src/c/highlights.scm
+++ b/crates/languages/src/c/highlights.scm
@@ -29,6 +29,8 @@
 [
   "#define"
   "#elif"
+  "#elifdef"
+  "#elifndef"
   "#else"
   "#endif"
   "#if"

--- a/crates/languages/src/cpp/highlights.scm
+++ b/crates/languages/src/cpp/highlights.scm
@@ -168,6 +168,8 @@ type: (primitive_type) @type.builtin
 [
   "#define"
   "#elif"
+  "#elifdef"
+  "#elifndef"
   "#else"
   "#endif"
   "#if"


### PR DESCRIPTION
Release Notes:

- Add missing #elifdef, #elifndef directives to C/C++ highlights.
