### PR TITLE
Revive "good first issue" notifier

### DIFF
--- a/.github/workflows/good_first_issue_notifier.yml
+++ b/.github/workflows/good_first_issue_notifier.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   handle-good-first-issue:
-    if: github.event.label.name == 'good first issue' && github.repository_owner == 'zed-industries'
+    if: github.event.label.name == '.contrib/good first issue' && github.repository_owner == 'zed-industries'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
We adjusted the labels some time ago, but never took care of the `good first issue` notifier that posts the good first issues to discord.

Adjusting the label accordingly so that it notifies people again.

Release Notes:

- N/A
