### PR TITLE
vim: Fix word object count multiplier (2aw, 2iw)

### DIFF
--- a/crates/vim/src/object.rs
+++ b/crates/vim/src/object.rs
@@ -1947,6 +1947,14 @@ mod test {
         cx.set_shared_state("  ˇfoo-bar baz").await;
         cx.simulate_shared_keystrokes("2 d a w").await;
         cx.shared_state().await.assert_matches();
+
+        // Test 2diw with trailing whitespace and no next word
+        // In vim, whitespace counts as a word unit, so 2iw selects:
+        // 1st unit: "foo", 2nd unit: "   " (trailing whitespace)
+        // Result: entire line deleted
+        cx.set_shared_state("ˇfoo   ").await;
+        cx.simulate_shared_keystrokes("2 d i w").await;
+        cx.shared_state().await.assert_matches();
     }
 
     const PARAGRAPH_EXAMPLES: &[&str] = &[

--- a/crates/vim/test_data/test_word_object_with_count.json
+++ b/crates/vim/test_data/test_word_object_with_count.json
@@ -54,3 +54,27 @@
 {"Key":"i"}
 {"Key":"w"}
 {"Get":{"state":"ˇ","mode":"Normal"}}
+{"Put":{"state":"ˇone\ntwo\nthree"}}
+{"Key":"2"}
+{"Key":"d"}
+{"Key":"a"}
+{"Key":"w"}
+{"Get":{"state":"ˇthree","mode":"Normal"}}
+{"Put":{"state":"ˇone\ntwo\nthree\nfour"}}
+{"Key":"3"}
+{"Key":"d"}
+{"Key":"a"}
+{"Key":"w"}
+{"Get":{"state":"ˇfour","mode":"Normal"}}
+{"Put":{"state":"ˇone\ntwo\nthree"}}
+{"Key":"2"}
+{"Key":"d"}
+{"Key":"i"}
+{"Key":"w"}
+{"Get":{"state":"ˇthree","mode":"Normal"}}
+{"Put":{"state":"one ˇtwo\nthree four"}}
+{"Key":"2"}
+{"Key":"d"}
+{"Key":"a"}
+{"Key":"w"}
+{"Get":{"state":"one ˇfour","mode":"Normal"}}

--- a/crates/vim/test_data/test_word_object_with_count.json
+++ b/crates/vim/test_data/test_word_object_with_count.json
@@ -42,3 +42,9 @@
 {"Key":"w"}
 {"Key":"p"}
 {"Get":{"state":"oone twoˇ ne two three four","mode":"Normal"}}
+{"Put":{"state":"  ˇfoo-bar baz"}}
+{"Key":"2"}
+{"Key":"d"}
+{"Key":"a"}
+{"Key":"w"}
+{"Get":{"state":"  ˇbar baz","mode":"Normal"}}

--- a/crates/vim/test_data/test_word_object_with_count.json
+++ b/crates/vim/test_data/test_word_object_with_count.json
@@ -48,3 +48,9 @@
 {"Key":"a"}
 {"Key":"w"}
 {"Get":{"state":"  ˇbar baz","mode":"Normal"}}
+{"Put":{"state":"ˇfoo   "}}
+{"Key":"2"}
+{"Key":"d"}
+{"Key":"i"}
+{"Key":"w"}
+{"Get":{"state":"ˇ","mode":"Normal"}}

--- a/crates/vim/test_data/test_word_object_with_count.json
+++ b/crates/vim/test_data/test_word_object_with_count.json
@@ -1,0 +1,44 @@
+{"Put":{"state":"ˇone two three four"}}
+{"Key":"2"}
+{"Key":"d"}
+{"Key":"a"}
+{"Key":"w"}
+{"Get":{"state":"ˇthree four","mode":"Normal"}}
+{"Put":{"state":"ˇone two three four"}}
+{"Key":"d"}
+{"Key":"2"}
+{"Key":"a"}
+{"Key":"w"}
+{"Get":{"state":"ˇthree four","mode":"Normal"}}
+{"Put":{"state":"ˇone-two three-four five"}}
+{"Key":"2"}
+{"Key":"d"}
+{"Key":"a"}
+{"Key":"shift-w"}
+{"Get":{"state":"ˇfive","mode":"Normal"}}
+{"Put":{"state":"ˇone two three four five"}}
+{"Key":"3"}
+{"Key":"d"}
+{"Key":"a"}
+{"Key":"w"}
+{"Get":{"state":"ˇfour five","mode":"Normal"}}
+{"Put":{"state":"ˇone two three four five six"}}
+{"Key":"2"}
+{"Key":"d"}
+{"Key":"2"}
+{"Key":"a"}
+{"Key":"w"}
+{"Get":{"state":"ˇfive six","mode":"Normal"}}
+{"Put":{"state":"ˇone two three four"}}
+{"Key":"2"}
+{"Key":"c"}
+{"Key":"a"}
+{"Key":"w"}
+{"Get":{"state":"ˇthree four","mode":"Insert"}}
+{"Put":{"state":"ˇone two three four"}}
+{"Key":"2"}
+{"Key":"y"}
+{"Key":"a"}
+{"Key":"w"}
+{"Key":"p"}
+{"Get":{"state":"oone twoˇ ne two three four","mode":"Normal"}}


### PR DESCRIPTION
Closes #44251

## Context

Commands like `2daw` or `c2iw` were ignoring the count multiplier because the word text object functions (`in_word`, `around_word`) weren't using the `times` parameter. This fix propagates the count through these functions so all operators correctly handle multiple words.

## Before

https://github.com/user-attachments/assets/d5effa8a-4c04-4d70-a6b5-389cba730ca9

## After

https://github.com/user-attachments/assets/c50e4c0c-ea5c-4673-9c98-3d924b448025


Release Notes:

- Fixed vim mode count multiplier for word text objects (`2aw`, `2iw`, `2aW`, `2iW`)
