### PR TITLE
Fix OpenRouter reasoning details accumulation in streaming responses

### DIFF
--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1478,6 +1478,20 @@ impl Thread {
                     last_message.reasoning_details = Some(details);
                 }
             }
+            ReasoningDetailsAccumulable(details_arr) => {
+                let last_message = self.pending_message();
+                match last_message.reasoning_details {
+                    None => {
+                        last_message.reasoning_details = Some(serde_json::Value::Array(details_arr));
+                    }
+                    Some(serde_json::Value::Array(ref mut last_details) ) => {
+                        last_details.extend(details_arr);
+                    }
+                    _ => {
+                        return Err(anyhow!("Inconsistent reasoning_details type across events"));
+                    }
+                }
+            }
             ToolUse(tool_use) => {
                 return Ok(self.handle_tool_use_event(tool_use, event_stream, cx));
             }

--- a/crates/assistant_text_thread/src/text_thread.rs
+++ b/crates/assistant_text_thread/src/text_thread.rs
@@ -2078,7 +2078,8 @@ impl TextThread {
                                         );
                                     }
                                     LanguageModelCompletionEvent::StartMessage { .. } => {}
-                                    LanguageModelCompletionEvent::ReasoningDetails(_) => {
+                                    LanguageModelCompletionEvent::ReasoningDetails(_)
+                                    |  LanguageModelCompletionEvent::ReasoningDetailsAccumulable(_) => {
                                         // ReasoningDetails are metadata (signatures, encrypted data, format info)
                                         // used for request/response validation, not UI content.
                                         // The displayable thinking text is already handled by the Thinking event.

--- a/crates/eval/src/instance.rs
+++ b/crates/eval/src/instance.rs
@@ -1266,7 +1266,8 @@ pub fn response_events_to_markdown(
                 | LanguageModelCompletionEvent::UsageUpdated { .. }
                 | LanguageModelCompletionEvent::Queued { .. }
                 | LanguageModelCompletionEvent::Started
-                | LanguageModelCompletionEvent::ReasoningDetails(_),
+                | LanguageModelCompletionEvent::ReasoningDetails(_)
+                | LanguageModelCompletionEvent::ReasoningDetailsAccumulable(_)
             ) => {}
             Ok(LanguageModelCompletionEvent::ToolUseJsonParseError {
                 json_parse_error, ..
@@ -1353,6 +1354,7 @@ impl ThreadDialog {
                 | Ok(LanguageModelCompletionEvent::RedactedThinking { .. })
                 | Ok(LanguageModelCompletionEvent::StartMessage { .. })
                 | Ok(LanguageModelCompletionEvent::ReasoningDetails(_))
+                | Ok(LanguageModelCompletionEvent::ReasoningDetailsAccumulable(_))
                 | Ok(LanguageModelCompletionEvent::Stop(_))
                 | Ok(LanguageModelCompletionEvent::Queued { .. })
                 | Ok(LanguageModelCompletionEvent::Started)

--- a/crates/language_model/src/language_model.rs
+++ b/crates/language_model/src/language_model.rs
@@ -102,6 +102,7 @@ pub enum LanguageModelCompletionEvent {
         message_id: String,
     },
     ReasoningDetails(serde_json::Value),
+    ReasoningDetailsAccumulable(Vec<serde_json::Value>),
     UsageUpdate(TokenUsage),
 }
 
@@ -690,6 +691,7 @@ pub trait LanguageModel: Send + Sync {
                                 Ok(LanguageModelCompletionEvent::Thinking { .. }) => None,
                                 Ok(LanguageModelCompletionEvent::RedactedThinking { .. }) => None,
                                 Ok(LanguageModelCompletionEvent::ReasoningDetails(_)) => None,
+                                Ok(LanguageModelCompletionEvent::ReasoningDetailsAccumulable(_)) => None,
                                 Ok(LanguageModelCompletionEvent::Stop(_)) => None,
                                 Ok(LanguageModelCompletionEvent::ToolUse(_)) => None,
                                 Ok(LanguageModelCompletionEvent::ToolUseJsonParseError {

--- a/crates/language_models/src/provider/open_router.rs
+++ b/crates/language_models/src/provider/open_router.rs
@@ -556,7 +556,7 @@ fn add_message_content_part(
 
 pub struct OpenRouterEventMapper {
     tool_calls_by_index: HashMap<usize, RawToolCall>,
-    reasoning_details: Option<serde_json::Value>,
+    reasoning_details: Option<Vec<serde_json::Value>>,
 }
 
 impl OpenRouterEventMapper {
@@ -598,7 +598,7 @@ impl OpenRouterEventMapper {
 
         if let Some(details) = choice.delta.reasoning_details.clone() {
             // Emit reasoning_details immediately
-            events.push(Ok(LanguageModelCompletionEvent::ReasoningDetails(
+            events.push(Ok(LanguageModelCompletionEvent::ReasoningDetailsAccumulable(
                 details.clone(),
             )));
             self.reasoning_details = Some(details);
@@ -899,14 +899,14 @@ mod tests {
                         content: None,
                         reasoning: None,
                         tool_calls: None,
-                        reasoning_details: Some(serde_json::json!([
+                        reasoning_details: Some(vec![serde_json::json!(
                             {
                                 "type": "reasoning.text",
                                 "text": "Let me analyze this request...",
                                 "format": "google-gemini-v1",
                                 "index": 0
                             }
-                        ])),
+                        )]),
                     },
                     finish_reason: None,
                 }],
@@ -924,7 +924,7 @@ mod tests {
                         content: None,
                         reasoning: None,
                         tool_calls: None,
-                        reasoning_details: Some(serde_json::json!([
+                        reasoning_details: Some(vec![serde_json::json!(
                             {
                                 "type": "reasoning.encrypted",
                                 "data": "EtgDCtUDAdHtim9OF5jm4aeZSBAtl/randomized123",
@@ -932,7 +932,7 @@ mod tests {
                                 "index": 0,
                                 "id": "tool_call_abc123"
                             }
-                        ])),
+                        )]),
                     },
                     finish_reason: None,
                 }],
@@ -977,7 +977,7 @@ mod tests {
                         content: None,
                         reasoning: None,
                         tool_calls: None,
-                        reasoning_details: Some(serde_json::json!([])),
+                        reasoning_details: Some(vec![serde_json::json!({})]),
                     },
                     finish_reason: Some("tool_calls".into()),
                 }],
@@ -1005,7 +1005,7 @@ mod tests {
                     assert_eq!(tool_use.name.as_ref(), "list_directory");
                     thought_signature_value = tool_use.thought_signature.clone();
                 }
-                Ok(LanguageModelCompletionEvent::ReasoningDetails(details)) => {
+                Ok(LanguageModelCompletionEvent::ReasoningDetailsAccumulable(details)) => {
                     reasoning_details_events.push(details);
                 }
                 _ => {}
@@ -1016,28 +1016,24 @@ mod tests {
         assert!(has_tool_use, "Should have emitted ToolUse event");
         assert!(
             !reasoning_details_events.is_empty(),
-            "Should have emitted ReasoningDetails events"
+            "Should have emitted ReasoningDetailsAccumulable events"
         );
 
         // We should have received multiple reasoning_details events (text, encrypted, empty)
         // The agent layer is responsible for keeping only the first non-empty one
         assert!(
             reasoning_details_events.len() >= 2,
-            "Should have multiple reasoning_details events from streaming"
+            "Should have multiple ReasoningDetailsAccumulable events from streaming"
         );
 
         // Verify at least one contains the encrypted data
         let has_encrypted = reasoning_details_events.iter().any(|details| {
-            if let serde_json::Value::Array(arr) = details {
-                arr.iter().any(|item| {
-                    item["type"] == "reasoning.encrypted"
-                        && item["data"]
-                            .as_str()
-                            .map_or(false, |s| s.contains("EtgDCtUDAdHtim9OF5jm4aeZSBAtl"))
-                })
-            } else {
-                false
-            }
+            details.iter().any(|item| {
+                item["type"] == "reasoning.encrypted"
+                    && item["data"]
+                        .as_str()
+                        .map_or(false, |s| s.contains("EtgDCtUDAdHtim9OF5jm4aeZSBAtl"))
+            })
         });
         assert!(
             has_encrypted,

--- a/crates/open_router/src/open_router.rs
+++ b/crates/open_router/src/open_router.rs
@@ -355,7 +355,7 @@ pub struct ResponseMessageDelta {
     #[serde(default, skip_serializing_if = "is_none_or_empty")]
     pub tool_calls: Option<Vec<ToolCallChunk>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub reasoning_details: Option<serde_json::Value>,
+    pub reasoning_details: Option<Vec<serde_json::Value>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]


### PR DESCRIPTION
OpenRouter sends multiple `reasoning_details` chunks during streaming responses, with each chunk containing partial reasoning information. However, our code was only keeping the last chunk, causing reasoning details to be lost.

This PR introduces `ReasoningDetailsAccumulable` event type that properly accumulates all reasoning details chunks in order, as documented in [OpenRouter's streaming response behavior](https://openrouter.ai/docs/guides/best-practices/reasoning-tokens#streaming-response).

## Changes:
- Added `ReasoningDetailsAccumulable(Vec<serde_json::Value>)` event type to collect all reasoning detail chunks
- Added thread logic to extend reasoning details array when accumulable events are received
- Updated OpenRouter event mapper to use the accumulable variant
- Added test coverage for reasoning details accumulation

## Context:
I found this issue while I tested the new Minimax M2.1 model. It model shows itself very well into the opencode, but it works very stranger into Zed Agent. The investigation led me to that this model requires keeping all previous reasoning between requests to proper work. And the debugging of Zed and OpenCode requests showed me this issue. 

The full request and response bodies before and after this fix (I formatted the body of second requests and pointed out to the issue):
[after-patch.1.txt](https://github.com/user-attachments/files/24353941/after-patch.1.txt)
[after-patch.2.txt](https://github.com/user-attachments/files/24353939/after-patch.2.txt)
[before-patch.1.txt](https://github.com/user-attachments/files/24353942/before-patch.1.txt)
[before-patch.2.txt](https://github.com/user-attachments/files/24353940/before-patch.2.txt)

## Alternatives:
I don't like my solution with introducing the new event kind `ReasoningDetailsAccumulable`, but I hope it's minimally invasive.

### Some better and some bigger
As alternative I can replace type of value into ReasoningDetails event kind with a new enum type. Something like that:
```
enum ReasoningDetailsBehavior {
   Latest(serde_json::Value),
   Concatenate(Vec<serde_json::Value>)
```
It looks more correct, but it will require changes across other providers.

I am ready to implement this solution after approval of maintainers.

### Maybe but
From my point of view the best solution for this issue is migrating to Responses API that contains the summary into final message into stream. But it matches [this](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#things-we-will-probably-not-merge)

## Potential problems
These changes could break the thread when switching to or from other providers or OpenRouter. However, I'm not sure if it worked before.

## Release Notes:
- Fix OpenRouter reasoning details preservation in streaming responses
