### PR TITLE
ui: Add submenus to `ContextMenu`

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -56,6 +56,13 @@
     },
   },
   {
+    "context": "menu",
+    "bindings": {
+      "right": "menu::SelectChild",
+      "left": "menu::SelectParent",
+    },
+  },
+  {
     "context": "Editor",
     "bindings": {
       "escape": "editor::Cancel",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -55,6 +55,13 @@
     },
   },
   {
+    "context": "menu",
+    "bindings": {
+      "right": "menu::SelectChild",
+      "left": "menu::SelectParent",
+    },
+  },
+  {
     "context": "Editor",
     "use_key_equivalents": true,
     "bindings": {

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -55,6 +55,13 @@
     },
   },
   {
+    "context": "menu",
+    "bindings": {
+      "right": "menu::SelectChild",
+      "left": "menu::SelectParent",
+    },
+  },
+  {
     "context": "Editor",
     "use_key_equivalents": true,
     "bindings": {

--- a/crates/menu/src/menu.rs
+++ b/crates/menu/src/menu.rs
@@ -26,6 +26,10 @@ actions!(
         SelectFirst,
         /// Selects the last item in the menu.
         SelectLast,
+        /// Enters a submenu (navigates to child menu).
+        SelectChild,
+        /// Exits a submenu (navigates to parent menu).
+        SelectParent,
         /// Restarts the menu from the beginning.
         Restart,
         EndSlot,

--- a/crates/ui/src/components/context_menu.rs
+++ b/crates/ui/src/components/context_menu.rs
@@ -1142,10 +1142,8 @@ impl ContextMenu {
 
         // If we're switching from one submenu item to another, throw away any previously-captured
         // offset so we don't reuse a stale position.
-        if matches!(reason, SubmenuOpenTrigger::Keyboard) {
-            self.submenu_observed_bounds.set(None);
-            self.submenu_trigger_bounds.set(None);
-        }
+        self.submenu_observed_bounds.set(None);
+        self.submenu_trigger_bounds.set(None);
 
         self.submenu_safety_threshold_x = None;
         self.hover_target = HoverTarget::MainMenu;

--- a/crates/ui/src/components/context_menu.rs
+++ b/crates/ui/src/components/context_menu.rs
@@ -1491,14 +1491,15 @@ impl ContextMenu {
 
         div()
             .id(("submenu-container", ix))
+            .absolute()
+            .left_full()
+            .ml_neg_0p5()
+            .top(offset)
             .on_hover(cx.listener(|this, hovered, _, _| {
                 if *hovered {
                     this.hover_target = HoverTarget::Submenu;
                 }
             }))
-            .absolute()
-            .left_full()
-            .top(offset)
             .child(
                 anchored()
                     .anchor(Corner::TopLeft)

--- a/crates/ui/src/components/context_menu.rs
+++ b/crates/ui/src/components/context_menu.rs
@@ -1544,7 +1544,6 @@ impl ContextMenu {
         let bounds_cell = self.submenu_observed_bounds.clone();
         let canvas = canvas(
             {
-                let bounds_cell = bounds_cell;
                 move |bounds, _window, _cx| {
                     bounds_cell.set(Some(bounds));
                 }
@@ -1969,7 +1968,6 @@ impl Render for ContextMenu {
             let bounds_cell = self.submenu_observed_bounds.clone();
             let menu_bounds_measure = canvas(
                 {
-                    let bounds_cell = bounds_cell;
                     move |bounds, _window, _cx| {
                         bounds_cell.set(Some(bounds));
                     }

--- a/crates/ui/src/components/context_menu.rs
+++ b/crates/ui/src/components/context_menu.rs
@@ -1180,7 +1180,7 @@ impl ContextMenu {
         }
 
         let (submenu, dismiss_subscription) =
-            Self::create_submenu(builder, cx.entity().clone(), window, cx);
+            Self::create_submenu(builder, cx.entity(), window, cx);
 
         // If we're switching from one submenu item to another, throw away any previously-captured
         // offset so we don't reuse a stale position.
@@ -1524,7 +1524,7 @@ impl ContextMenu {
         let bounds_cell = self.submenu_observed_bounds.clone();
         let canvas = canvas(
             {
-                let bounds_cell = bounds_cell.clone();
+                let bounds_cell = bounds_cell;
                 move |bounds, _window, _cx| {
                     bounds_cell.set(Some(bounds));
                 }
@@ -1949,7 +1949,7 @@ impl Render for ContextMenu {
             let bounds_cell = self.submenu_observed_bounds.clone();
             let menu_bounds_measure = canvas(
                 {
-                    let bounds_cell = bounds_cell.clone();
+                    let bounds_cell = bounds_cell;
                     move |bounds, _window, _cx| {
                         bounds_cell.set(Some(bounds));
                     }
@@ -2059,7 +2059,7 @@ impl Render for ContextMenu {
                         })
                         .child(render_aside(aside, cx))
                 }))
-                .when_some(submenu_container.clone(), |this, (ix, submenu, offset)| {
+                .when_some(submenu_container, |this, (ix, submenu, offset)| {
                     this.child(self.render_submenu_container(ix, submenu, offset, cx))
                 })
         } else {

--- a/crates/ui/src/components/dropdown_menu.rs
+++ b/crates/ui/src/components/dropdown_menu.rs
@@ -247,6 +247,30 @@ impl Component for DropdownMenu {
                 .entry("Option 4", None, |_, _| {})
         });
 
+        let menu_with_submenu = ContextMenu::build(window, cx, |this, _, _| {
+            this.entry("Toggle All Docks", None, |_, _| {})
+                .submenu("Editor Layout", |menu, _, _| {
+                    menu.entry("Split Up", None, |_, _| {})
+                        .entry("Split Down", None, |_, _| {})
+                        .separator()
+                        .entry("Split Side", None, |_, _| {})
+                })
+                .separator()
+                .entry("Project Panel", None, |_, _| {})
+                .entry("Outline Panel", None, |_, _| {})
+                .separator()
+                .submenu("Autofill", |menu, _, _| {
+                    menu.entry("Contact…", None, |_, _| {})
+                        .entry("Passwords…", None, |_, _| {})
+                })
+                .submenu_with_icon("Predict", IconName::ZedPredict, |menu, _, _| {
+                    menu.entry("Everywhere", None, |_, _| {})
+                        .entry("At Cursor", None, |_, _| {})
+                        .entry("Over Here", None, |_, _| {})
+                        .entry("Over There", None, |_, _| {})
+                })
+        });
+
         Some(
             v_flex()
                 .gap_6()
@@ -270,6 +294,14 @@ impl Component for DropdownMenu {
                                 .into_any_element(),
                             ),
                         ],
+                    ),
+                    example_group_with_title(
+                        "Submenus",
+                        vec![single_example(
+                            "With Submenus",
+                            DropdownMenu::new("submenu", "Submenu", menu_with_submenu)
+                                .into_any_element(),
+                        )],
                     ),
                     example_group_with_title(
                         "Styles",


### PR DESCRIPTION
This PR introduces submenu functionality for Zed's dropdown/context menus. 

<img width="600" height="830" alt="Screenshot 2025-12-27 at 2  03@2x" src="https://github.com/user-attachments/assets/eadfcd74-07fe-4a1f-be76-11b547c16dc8" />

```rs
.submenu("Trigger", |menu, _, _| {
    menu.entry("Item…", None, |_, _| {})
        .entry("Item…", None, |_, _| {})
})
```

Release Notes:

- N/A
