### PR TITLE
Bump glsl to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20964,7 +20964,7 @@ dependencies = [
 
 [[package]]
 name = "zed_glsl"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "zed_extension_api 0.1.0",
 ]

--- a/extensions/glsl/Cargo.toml
+++ b/extensions/glsl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_glsl"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 publish.workspace = true
 license = "Apache-2.0"

--- a/extensions/glsl/extension.toml
+++ b/extensions/glsl/extension.toml
@@ -1,7 +1,7 @@
 id = "glsl"
 name = "GLSL"
 description = "GLSL support."
-version = "0.1.0"
+version = "0.2.0"
 schema_version = 1
 authors = ["Mikayla Maki <mikayla@zed.dev>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
Includes https://github.com/zed-industries/zed/pull/45727

Release Notes:

- N/A 
