### PR TITLE
svg_preview: Detect SVG in single-file mode by checking file name

### DIFF
--- a/crates/svg_preview/src/svg_preview_view.rs
+++ b/crates/svg_preview/src/svg_preview_view.rs
@@ -191,15 +191,23 @@ impl SvgPreviewView {
     }
 
     pub fn is_svg_file(buffer: &Entity<MultiBuffer>, cx: &App) -> bool {
-        buffer
-            .read(cx)
-            .as_singleton()
-            .and_then(|buffer| buffer.read(cx).file())
-            .is_some_and(|file| {
-                file.path()
-                    .extension()
-                    .is_some_and(|ext| ext.eq_ignore_ascii_case("svg"))
-            })
+        let Some(singleton) = buffer.read(cx).as_singleton() else {
+            return false;
+        };
+        let Some(file) = singleton.read(cx).file() else {
+            return false;
+        };
+
+        let rel_ext = file.path().extension();
+        let full_path = file.full_path(cx);
+        let full_ext = full_path.extension().and_then(|ext| ext.to_str());
+        let name_ext = std::path::Path::new(file.file_name(cx))
+            .extension()
+            .and_then(|ext| ext.to_str());
+
+        rel_ext.is_some_and(|ext| ext.eq_ignore_ascii_case("svg"))
+            || full_ext.is_some_and(|ext| ext.eq_ignore_ascii_case("svg"))
+            || name_ext.is_some_and(|ext| ext.eq_ignore_ascii_case("svg"))
     }
 
     pub fn register(workspace: &mut Workspace, _window: &mut Window, _cx: &mut Context<Workspace>) {

--- a/crates/svg_preview/src/svg_preview_view.rs
+++ b/crates/svg_preview/src/svg_preview_view.rs
@@ -191,23 +191,15 @@ impl SvgPreviewView {
     }
 
     pub fn is_svg_file(buffer: &Entity<MultiBuffer>, cx: &App) -> bool {
-        let Some(singleton) = buffer.read(cx).as_singleton() else {
-            return false;
-        };
-        let Some(file) = singleton.read(cx).file() else {
-            return false;
-        };
-
-        let rel_ext = file.path().extension();
-        let full_path = file.full_path(cx);
-        let full_ext = full_path.extension().and_then(|ext| ext.to_str());
-        let name_ext = std::path::Path::new(file.file_name(cx))
-            .extension()
-            .and_then(|ext| ext.to_str());
-
-        rel_ext.is_some_and(|ext| ext.eq_ignore_ascii_case("svg"))
-            || full_ext.is_some_and(|ext| ext.eq_ignore_ascii_case("svg"))
-            || name_ext.is_some_and(|ext| ext.eq_ignore_ascii_case("svg"))
+        buffer
+            .read(cx)
+            .as_singleton()
+            .and_then(|buffer| buffer.read(cx).file())
+            .is_some_and(|file| {
+                std::path::Path::new(file.file_name(cx))
+                    .extension()
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("svg"))
+            })
     }
 
     pub fn register(workspace: &mut Workspace, _window: &mut Window, _cx: &mut Context<Workspace>) {


### PR DESCRIPTION
Release Notes:

- Use the files name for "is svg" checks so SVG previews and the toolbar button work in single-file mode.
