### PR TITLE
Use temp_dir as root_dir fallback to avoid macOS TCC dialogues

### DIFF
--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -560,7 +560,9 @@ impl AcpThreadView {
                 })
                 .log_err()
             } else {
-                let root_dir = root_dir.unwrap_or(paths::home_dir().as_path().into());
+                // Use temp_dir instead of home_dir to avoid triggering macOS TCC dialogues
+                // when no worktree is available (e.g., during session restoration without a project)
+                let root_dir = root_dir.unwrap_or_else(|| paths::temp_dir().as_path().into());
                 cx.update(|_, cx| {
                     connection
                         .clone()


### PR DESCRIPTION
Release Notes:

- Fixed the issue where the OpenCode agent causes macOS TCC pop-ups

This issue is related to [#20913](https://github.com/zed-industries/zed/issues/20913). When your selected agent is OpenCode and hasn't opened any project, the TCC dialogue will prompt every time.
