### PR TITLE
terminal: Stop the emulator first then kill the child process

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -60,7 +60,7 @@ use std::{
     path::PathBuf,
     process::ExitStatus,
     sync::Arc,
-    time::Instant,
+    time::{Duration, Instant},
 };
 use thiserror::Error;
 
@@ -2338,8 +2338,9 @@ unsafe fn append_text_to_term(term: &mut Term<ZedListener>, text_lines: &[&str])
 impl Drop for Terminal {
     fn drop(&mut self) {
         if let TerminalType::Pty { pty_tx, info } = &mut self.terminal_type {
-            info.kill_child_process();
             pty_tx.0.send(Msg::Shutdown).ok();
+            std::thread::sleep(Duration::from_millis(100));
+            info.kill_child_process();
         }
     }
 }


### PR DESCRIPTION


Closes #44003
send shutdown to pty loop fist, then wait for 100ms send SIGKILL. 
Release Notes:

- fix #44003 (not writing to shell history because the shell is force to close) while ensure the shell will close.
