### PR TITLE
linux: Fix multiple keyring prompts

### DIFF
--- a/crates/gpui_linux/src/linux/platform.rs
+++ b/crates/gpui_linux/src/linux/platform.rs
@@ -4,6 +4,8 @@ use std::{
     rc::Rc,
     sync::Arc,
 };
+
+use smol::lock::OnceCell;
 #[cfg(any(feature = "wayland", feature = "x11"))]
 use std::{
     ffi::OsString,
@@ -17,6 +19,10 @@ use anyhow::{Context as _, anyhow};
 use calloop::{LoopSignal, channel::Sender};
 use futures::channel::oneshot;
 use gpui_util::{ResultExt as _, new_std_command};
+use oo7::{
+    Error as Oo7Error,
+    dbus::{Error as DbusError, ServiceError},
+};
 #[cfg(any(feature = "wayland", feature = "x11"))]
 use xkbcommon::xkb::{self, Keycode, Keysym, State};
 
@@ -123,6 +129,7 @@ pub(crate) struct LinuxCommon {
     pub(crate) callbacks: PlatformHandlers,
     pub(crate) signal: LoopSignal,
     pub(crate) menus: Vec<OwnedMenu>,
+    pub(crate) keyring: Arc<OnceCell<Result<Arc<oo7::Keyring>>>>,
     app_name: Option<String>,
     system_notifications: crate::linux::system_notifications::SystemNotificationState,
     #[cfg_attr(
@@ -165,6 +172,7 @@ impl LinuxCommon {
             callbacks,
             signal,
             menus: Vec::new(),
+            keyring: Arc::new(OnceCell::new()),
             app_name: None,
             system_notifications: crate::linux::system_notifications::SystemNotificationState::new(
             ),
@@ -653,36 +661,46 @@ impl<P: LinuxClient + 'static> Platform for LinuxPlatform<P> {
         let url = url.to_string();
         let username = username.to_string();
         let password = password.to_vec();
+        let keyring = self.inner.with_common(|common| common.keyring.clone());
+
         self.background_executor().spawn(async move {
-            let keyring = oo7::Keyring::new().await?;
-            keyring.unlock().await?;
-            keyring
-                .create_item(
-                    KEYRING_LABEL,
-                    &vec![("url", &url), ("username", &username)],
-                    password,
-                    true,
-                )
-                .await?;
-            Ok(())
+            let keyring = get_keyring(&keyring).await?;
+            let attrs = vec![("url", &url), ("username", &username)];
+
+            match keyring
+                .create_item(KEYRING_LABEL, &attrs, &password, true)
+                .await
+            {
+                Ok(()) => Ok(()),
+                Err(Oo7Error::DBus(DbusError::Service(ServiceError::IsLocked(_)))) => {
+                    keyring.unlock().await?;
+                    keyring
+                        .create_item(KEYRING_LABEL, &attrs, &password, true)
+                        .await?;
+                    Ok(())
+                }
+                Err(e) => Err(e.into()),
+            }
         })
     }
 
     fn read_credentials(&self, url: &str) -> Task<Result<Option<(String, Vec<u8>)>>> {
         let url = url.to_string();
-        self.background_executor().spawn(async move {
-            let keyring = oo7::Keyring::new().await?;
-            keyring.unlock().await?;
+        let keyring = self.inner.with_common(|common| common.keyring.clone());
 
+        self.background_executor().spawn(async move {
+            let keyring = get_keyring(&keyring).await?;
             let items = keyring.search_items(&vec![("url", &url)]).await?;
 
             for item in items.into_iter() {
                 if item.label().await.is_ok_and(|label| label == KEYRING_LABEL) {
+                    if item.is_locked().await? {
+                        item.unlock().await?;
+                    }
                     let attributes = item.attributes().await?;
                     let username = attributes
                         .get("username")
                         .context("Cannot find username in stored credentials")?;
-                    item.unlock().await?;
                     let secret = item.secret().await?;
 
                     // we lose the zeroizing capabilities at this boundary,
@@ -698,19 +716,21 @@ impl<P: LinuxClient + 'static> Platform for LinuxPlatform<P> {
 
     fn delete_credentials(&self, url: &str) -> Task<Result<()>> {
         let url = url.to_string();
-        self.background_executor().spawn(async move {
-            let keyring = oo7::Keyring::new().await?;
-            keyring.unlock().await?;
+        let keyring = self.inner.with_common(|common| common.keyring.clone());
 
+        self.background_executor().spawn(async move {
+            let keyring = get_keyring(&keyring).await?;
             let items = keyring.search_items(&vec![("url", &url)]).await?;
 
             for item in items.into_iter() {
                 if item.label().await.is_ok_and(|label| label == KEYRING_LABEL) {
+                    if item.is_locked().await? {
+                        item.unlock().await?;
+                    }
                     item.delete().await?;
                     return Ok(());
                 }
             }
-
             Ok(())
         })
     }
@@ -744,6 +764,22 @@ impl<P: LinuxClient + 'static> Platform for LinuxPlatform<P> {
     }
 
     fn add_recent_document(&self, _path: &Path) {}
+}
+
+async fn get_keyring(
+    keyring: &Arc<OnceCell<Result<Arc<oo7::Keyring>>>>,
+) -> Result<Arc<oo7::Keyring>> {
+    keyring
+        .get_or_init(|| async {
+            oo7::Keyring::new()
+                .await
+                .map(Arc::new)
+                .context("failed to initialize keyring")
+        })
+        .await
+        .as_ref()
+        .cloned()
+        .map_err(|e| anyhow::anyhow!("{e}"))
 }
 
 #[cfg(any(feature = "wayland", feature = "x11"))]


### PR DESCRIPTION
Related to #17460

On Linux, multiple keyring unlock prompts could appear due to `keyring.unlock()` calls. This change:

- Checks `item.is_locked()` before calling `item.unlock()` in read/delete
- Only unlocks collection in write if `IsLocked` error is returned

Users should now see at most one prompt if keyring is locked.

Tested on Debian 13.2 (trixie) with GNOME Keyring.

Release Notes:

- Fixed multiple keyring unlock prompts on Linux