### PR TITLE
signature_help: Fix crash when typing CJK in debug mode

### DIFF
--- a/crates/editor/src/signature_help.rs
+++ b/crates/editor/src/signature_help.rs
@@ -94,11 +94,16 @@ impl Editor {
         }
 
         let buffer_snapshot = self.buffer().read(cx).snapshot(cx);
-        let bracket_range = |position: MultiBufferOffset| match (position, position + 1usize) {
-            (MultiBufferOffset(0), b) if b <= buffer_snapshot.len() => MultiBufferOffset(0)..b,
-            (MultiBufferOffset(0), b) => MultiBufferOffset(0)..b - 1,
-            (a, b) if b <= buffer_snapshot.len() => a - 1..b,
-            (a, b) => a - 1..b - 1,
+        let bracket_range = |position: MultiBufferOffset| {
+            let range = match (position, position + 1usize) {
+                (MultiBufferOffset(0), b) if b <= buffer_snapshot.len() => MultiBufferOffset(0)..b,
+                (MultiBufferOffset(0), b) => MultiBufferOffset(0)..b - 1,
+                (a, b) if b <= buffer_snapshot.len() => a - 1..b,
+                (a, b) => a - 1..b - 1,
+            };
+            let start = buffer_snapshot.clip_offset(range.start, text::Bias::Left);
+            let end = buffer_snapshot.clip_offset(range.end, text::Bias::Right);
+            start..end
         };
         let not_quote_like_brackets =
             |buffer: &BufferSnapshot, start: Range<BufferOffset>, end: Range<BufferOffset>| {


### PR DESCRIPTION
Closes #ISSUE

in release mode: found many log error as `ERROR [rope::chunk] byte index 48 is not a char boundary; it is inside '，' (bytes 46..49)`

This is easy testing,
- enable signature help
- typing any CJK character
- crash in debug mode

Release Notes:

- N/A 