### PR TITLE
git_ui: Fix crash when viewing commits with binary files

### DIFF
--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -892,9 +892,16 @@ impl GitRepository for RealGitRepository {
 
                 // skip loading content for binary
                 if is_binary {
+                    // using old_text to signal if file was deleted (so commit_view can show red/green correctly)
+                    let old_text = if status_code == StatusCode::Deleted {
+                        Some(String::new())
+                    } else {
+                        None
+                    };
+
                     files.push(CommitFile {
                         path: RepoPath(Arc::from(rel_path)),
-                        old_text: None,
+                        old_text,
                         new_text: None,
                         is_binary: true,
                     });

--- a/crates/git_ui/src/commit_view.rs
+++ b/crates/git_ui/src/commit_view.rs
@@ -244,7 +244,7 @@ impl CommitView {
                 let display_name = format!("{short_sha} - {file_name}");
 
                 if file.is_binary {
-                    let is_deleted = file.new_text.is_none();
+                    let is_deleted = file.old_text.is_some();
                     let placeholder_text = format!("Binary file not displayed: {}", file_name);
                     let file = Arc::new(GitBlob {
                         path: file.path.clone(),

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -2375,6 +2375,7 @@ impl GitStore {
                     path: file.path.to_proto(),
                     old_text: file.old_text,
                     new_text: file.new_text,
+                    is_binary: file.is_binary,
                 })
                 .collect(),
         })
@@ -4111,6 +4112,7 @@ impl Repository {
                                     path: RepoPath::from_proto(&file.path)?,
                                     old_text: file.old_text,
                                     new_text: file.new_text,
+                                    is_binary: file.is_binary,
                                 })
                             })
                             .collect::<Result<Vec<_>>>()?,

--- a/crates/proto/proto/git.proto
+++ b/crates/proto/proto/git.proto
@@ -283,6 +283,7 @@ message CommitFile {
     string path = 1;
     optional string old_text = 2;
     optional string new_text = 3;
+    bool is_binary = 4;
 }
 
 message GitReset {


### PR DESCRIPTION
- Closes #45735

Detect binary files by extension and skip loading their content in commit view. 
Binary files will now display a placeholder message with proper red/green diff styling instead of rendering their content.


Release Notes:

- N/A 