### PR TITLE
languages: Include namespace in the outline for C++

### DIFF
--- a/crates/languages/src/cpp/outline.scm
+++ b/crates/languages/src/cpp/outline.scm
@@ -9,6 +9,11 @@
         "(" @context
         ")" @context)) @item
 
+(namespace_definition
+    "inline"? @context
+    "namespace" @context
+    name: (_) @name) @item
+
 (type_definition
     "typedef" @context
     declarator: (_) @name) @item


### PR DESCRIPTION
Before: 

<img width="389" height="147" alt="image" src="https://github.com/user-attachments/assets/5412bde6-2f1b-4bb4-a06f-111724597372" />

After:
<img width="404" height="139" alt="image" src="https://github.com/user-attachments/assets/8f906245-4c6e-4cf0-bb32-1b47048f46c0" />


Release Notes:

- Include namespace symbol in the outline view for C++.
