### PR TITLE
outline: Fix nesting issue for variable declarations

### DIFF
--- a/crates/languages/src/cpp/outline.scm
+++ b/crates/languages/src/cpp/outline.scm
@@ -37,7 +37,9 @@
     (type_qualifier)? @context
     type: (_) @context
     declarator: (init_declarator
-      declarator: (_) @name)) @item
+      ; The declaration may define multiple variables, using @item on the
+      ; declarator so that they get distinct ranges.
+      declarator: (_) @item @name))
 
 (function_definition
     (type_qualifier)? @context


### PR DESCRIPTION
Before:

<img width="665" height="116" alt="image" src="https://github.com/user-attachments/assets/3c0b6ea4-f030-4fef-a0eb-8251ce16a651" />

After:

<img width="601" height="104" alt="image" src="https://github.com/user-attachments/assets/31659c75-6f73-40e7-9d3b-c4ae99357b12" />

The fix is similar to https://github.com/zed-industries/zed/pull/36076.

Release Notes:

- Fix outline nesting issue for variable declarations in C++
