### PR TITLE
agent: Add plan mode support for native agent

### DIFF
--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -4,6 +4,7 @@ mod history_store;
 mod legacy_thread;
 mod native_agent_server;
 pub mod outline;
+mod plan_parser;
 mod templates;
 #[cfg(test)]
 mod tests;
@@ -14,6 +15,7 @@ use context_server::ContextServerId;
 pub use db::*;
 pub use history_store::*;
 pub use native_agent_server::NativeAgentServer;
+pub use plan_parser::*;
 pub use templates::*;
 pub use thread::*;
 pub use tools::*;
@@ -1023,6 +1025,11 @@ impl NativeAgentConnection {
                             ThreadEvent::Retry(status) => {
                                 acp_thread.update(cx, |thread, cx| {
                                     thread.update_retry_status(status, cx)
+                                })?;
+                            }
+                            ThreadEvent::PlanUpdate(plan) => {
+                                acp_thread.update(cx, |thread, cx| {
+                                    thread.update_plan(plan, cx);
                                 })?;
                             }
                             ThreadEvent::Stop(stop_reason) => {

--- a/crates/agent/src/plan_parser.rs
+++ b/crates/agent/src/plan_parser.rs
@@ -1,0 +1,342 @@
+use agent_client_protocol as acp;
+use regex::Regex;
+use std::sync::LazyLock;
+
+/// Detects and parses plans from agent text responses.
+///
+/// Supports multiple formats:
+/// - Markdown checkboxes:
+///   - `- [ ] task` (pending)
+///   - `- [-]` or `- [~]` or `- [>]` (in progress)
+///   - `- [x]` (completed)
+/// - XML-style plans: `<plan><step status="pending">...</step></plan>`
+pub struct PlanParser;
+
+// Pre-compiled regex patterns for efficiency
+// Captures: space (pending), x/X (completed), -/~/> (in progress)
+static MARKDOWN_CHECKBOX_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?m)^[-*]\s*\[([ xX~>-])\]\s*(.+)$").expect("Invalid regex pattern")
+});
+
+static XML_STEP_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"<(?:step|task|entry)(?:\s+status="(\w+)")?>([^<]+)</(?:step|task|entry)>"#)
+        .expect("Invalid regex pattern")
+});
+
+impl PlanParser {
+    /// Attempts to extract a plan from agent text.
+    /// Returns `Some(Plan)` if a plan is detected, `None` otherwise.
+    pub fn try_parse(text: &str) -> Option<acp::Plan> {
+        // Strategy 1: Detect XML-style plan blocks
+        if let Some(plan) = Self::parse_xml_plan(text) {
+            return Some(plan);
+        }
+
+        // Strategy 2: Detect markdown checkbox lists
+        if let Some(plan) = Self::parse_markdown_plan(text) {
+            return Some(plan);
+        }
+
+        None
+    }
+
+    /// Parses XML-style plan blocks.
+    /// Supports: `<plan>`, `<steps>`, `<task_list>` as container tags.
+    fn parse_xml_plan(text: &str) -> Option<acp::Plan> {
+        let start_tags = ["<plan>", "<steps>", "<task_list>"];
+        let end_tags = ["</plan>", "</steps>", "</task_list>"];
+
+        for (start, end) in start_tags.iter().zip(end_tags.iter()) {
+            if let (Some(start_idx), Some(end_idx)) = (text.find(start), text.find(end)) {
+                if start_idx < end_idx {
+                    let content = &text[start_idx + start.len()..end_idx];
+                    return Self::parse_xml_entries(content);
+                }
+            }
+        }
+        None
+    }
+
+    /// Parses individual step/task entries from XML content.
+    fn parse_xml_entries(content: &str) -> Option<acp::Plan> {
+        let entries: Vec<acp::PlanEntry> = XML_STEP_PATTERN
+            .captures_iter(content)
+            .filter_map(|cap| {
+                let status_str = cap.get(1).map(|m| m.as_str()).unwrap_or("pending");
+                let entry_content = cap.get(2)?.as_str().trim();
+
+                if entry_content.is_empty() {
+                    return None;
+                }
+
+                let status = Self::parse_status(status_str);
+
+                Some(acp::PlanEntry::new(
+                    entry_content.to_string(),
+                    acp::PlanEntryPriority::Medium,
+                    status,
+                ))
+            })
+            .collect();
+
+        if entries.is_empty() {
+            None
+        } else {
+            Some(acp::Plan::new(entries))
+        }
+    }
+
+    /// Parses markdown checkbox lists.
+    /// Supports:
+    /// - `- [ ] pending task`
+    /// - `- [-]` or `- [~]` or `- [>]` in progress task
+    /// - `- [x]` completed task
+    /// - `* [ ] pending task` (asterisk variant)
+    fn parse_markdown_plan(text: &str) -> Option<acp::Plan> {
+        let entries: Vec<acp::PlanEntry> = MARKDOWN_CHECKBOX_PATTERN
+            .captures_iter(text)
+            .filter_map(|cap| {
+                let status_char = cap.get(1)?.as_str();
+                let entry_content = cap.get(2)?.as_str().trim();
+
+                if entry_content.is_empty() {
+                    return None;
+                }
+
+                let status = match status_char {
+                    " " => acp::PlanEntryStatus::Pending,
+                    "x" | "X" => acp::PlanEntryStatus::Completed,
+                    "-" | "~" | ">" => acp::PlanEntryStatus::InProgress,
+                    _ => acp::PlanEntryStatus::Pending,
+                };
+
+                Some(acp::PlanEntry::new(
+                    entry_content.to_string(),
+                    acp::PlanEntryPriority::Medium,
+                    status,
+                ))
+            })
+            .collect();
+
+        // Only return a plan if we have at least 2 entries to avoid false positives
+        if entries.len() >= 2 {
+            Some(acp::Plan::new(entries))
+        } else {
+            None
+        }
+    }
+
+    /// Converts status strings to PlanEntryStatus enum.
+    fn parse_status(status_str: &str) -> acp::PlanEntryStatus {
+        match status_str.to_lowercase().as_str() {
+            "completed" | "done" | "finished" => acp::PlanEntryStatus::Completed,
+            "in_progress" | "inprogress" | "running" | "current" => {
+                acp::PlanEntryStatus::InProgress
+            }
+            "pending" | "todo" | "waiting" | _ => acp::PlanEntryStatus::Pending,
+        }
+    }
+
+    /// Updates the status of a specific entry in a plan.
+    /// Used when the agent indicates progress on a step.
+    pub fn update_entry_status(
+        plan: &acp::Plan,
+        entry_index: usize,
+        new_status: acp::PlanEntryStatus,
+    ) -> acp::Plan {
+        let mut entries = plan.entries.clone();
+        if let Some(entry) = entries.get_mut(entry_index) {
+            *entry = acp::PlanEntry::new(
+                entry.content.clone(),
+                entry.priority.clone(),
+                new_status,
+            );
+        }
+        acp::Plan::new(entries)
+    }
+
+    /// Marks the first pending entry as in progress.
+    /// Useful when starting work on a plan.
+    pub fn start_next_entry(plan: &acp::Plan) -> acp::Plan {
+        let mut entries = plan.entries.clone();
+        let mut found_in_progress = false;
+
+        for entry in entries.iter() {
+            if entry.status == acp::PlanEntryStatus::InProgress {
+                found_in_progress = true;
+                break;
+            }
+        }
+
+        if !found_in_progress {
+            for entry in entries.iter_mut() {
+                if entry.status == acp::PlanEntryStatus::Pending {
+                    *entry = acp::PlanEntry::new(
+                        entry.content.clone(),
+                        entry.priority.clone(),
+                        acp::PlanEntryStatus::InProgress,
+                    );
+                    break;
+                }
+            }
+        }
+
+        acp::Plan::new(entries)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_markdown_plan() {
+        let text = r#"
+Here's my plan to implement this feature:
+
+- [ ] Analyze the existing codebase
+- [ ] Create the new module
+- [ ] Implement the main function
+- [ ] Write unit tests
+"#;
+
+        let plan = PlanParser::try_parse(text).expect("Should parse plan");
+        assert_eq!(plan.entries.len(), 4);
+        assert_eq!(plan.entries[0].status, acp::PlanEntryStatus::Pending);
+        assert_eq!(plan.entries[0].content, "Analyze the existing codebase");
+    }
+
+    #[test]
+    fn test_parse_markdown_plan_with_completed() {
+        let text = r#"
+- [x] First step (done)
+- [x] Second step (done)  
+- [ ] Third step (pending)
+- [ ] Fourth step (pending)
+"#;
+
+        let plan = PlanParser::try_parse(text).expect("Should parse plan");
+        assert_eq!(plan.entries.len(), 4);
+        assert_eq!(plan.entries[0].status, acp::PlanEntryStatus::Completed);
+        assert_eq!(plan.entries[1].status, acp::PlanEntryStatus::Completed);
+        assert_eq!(plan.entries[2].status, acp::PlanEntryStatus::Pending);
+    }
+
+    #[test]
+    fn test_parse_markdown_plan_with_in_progress() {
+        let text = r#"
+- [x] First step (completed)
+- [-] Second step (in progress)
+- [ ] Third step (pending)
+- [ ] Fourth step (pending)
+"#;
+
+        let plan = PlanParser::try_parse(text).expect("Should parse plan");
+        assert_eq!(plan.entries.len(), 4);
+        assert_eq!(plan.entries[0].status, acp::PlanEntryStatus::Completed);
+        assert_eq!(plan.entries[1].status, acp::PlanEntryStatus::InProgress);
+        assert_eq!(plan.entries[2].status, acp::PlanEntryStatus::Pending);
+        assert_eq!(plan.entries[3].status, acp::PlanEntryStatus::Pending);
+    }
+
+    #[test]
+    fn test_parse_markdown_plan_with_tilde_in_progress() {
+        // Also support [~] and [>] as in-progress markers
+        let text = r#"
+- [~] Step using tilde
+- [>] Step using arrow
+"#;
+
+        let plan = PlanParser::try_parse(text).expect("Should parse plan");
+        assert_eq!(plan.entries.len(), 2);
+        assert_eq!(plan.entries[0].status, acp::PlanEntryStatus::InProgress);
+        assert_eq!(plan.entries[1].status, acp::PlanEntryStatus::InProgress);
+    }
+
+    #[test]
+    fn test_parse_xml_plan() {
+        let text = r#"
+I'll work on this step by step:
+
+<plan>
+<step status="completed">Analyze the requirements</step>
+<step status="in_progress">Implement the feature</step>
+<step status="pending">Write documentation</step>
+</plan>
+
+Let me start with the implementation.
+"#;
+
+        let plan = PlanParser::try_parse(text).expect("Should parse plan");
+        assert_eq!(plan.entries.len(), 3);
+        assert_eq!(plan.entries[0].status, acp::PlanEntryStatus::Completed);
+        assert_eq!(plan.entries[1].status, acp::PlanEntryStatus::InProgress);
+        assert_eq!(plan.entries[2].status, acp::PlanEntryStatus::Pending);
+    }
+
+    #[test]
+    fn test_parse_steps_tag() {
+        let text = r#"
+<steps>
+<step>First thing to do</step>
+<step status="pending">Second thing</step>
+</steps>
+"#;
+
+        let plan = PlanParser::try_parse(text).expect("Should parse plan");
+        assert_eq!(plan.entries.len(), 2);
+    }
+
+    #[test]
+    fn test_no_plan_in_regular_text() {
+        let text = "This is just a regular response without any plan structure.";
+        assert!(PlanParser::try_parse(text).is_none());
+    }
+
+    #[test]
+    fn test_single_checkbox_not_a_plan() {
+        // A single checkbox shouldn't be considered a plan
+        let text = "- [ ] Just one item";
+        assert!(PlanParser::try_parse(text).is_none());
+    }
+
+    #[test]
+    fn test_update_entry_status() {
+        let plan = acp::Plan::new(vec![
+            acp::PlanEntry::new(
+                "Step 1".to_string(),
+                acp::PlanEntryPriority::Medium,
+                acp::PlanEntryStatus::Pending,
+            ),
+            acp::PlanEntry::new(
+                "Step 2".to_string(),
+                acp::PlanEntryPriority::Medium,
+                acp::PlanEntryStatus::Pending,
+            ),
+        ]);
+
+        let updated = PlanParser::update_entry_status(&plan, 0, acp::PlanEntryStatus::Completed);
+        assert_eq!(updated.entries[0].status, acp::PlanEntryStatus::Completed);
+        assert_eq!(updated.entries[1].status, acp::PlanEntryStatus::Pending);
+    }
+
+    #[test]
+    fn test_start_next_entry() {
+        let plan = acp::Plan::new(vec![
+            acp::PlanEntry::new(
+                "Step 1".to_string(),
+                acp::PlanEntryPriority::Medium,
+                acp::PlanEntryStatus::Pending,
+            ),
+            acp::PlanEntry::new(
+                "Step 2".to_string(),
+                acp::PlanEntryPriority::Medium,
+                acp::PlanEntryStatus::Pending,
+            ),
+        ]);
+
+        let updated = PlanParser::start_next_entry(&plan);
+        assert_eq!(updated.entries[0].status, acp::PlanEntryStatus::InProgress);
+        assert_eq!(updated.entries[1].status, acp::PlanEntryStatus::Pending);
+    }
+}

--- a/crates/agent/src/plan_parser.rs
+++ b/crates/agent/src/plan_parser.rs
@@ -133,7 +133,8 @@ impl PlanParser {
             "in_progress" | "inprogress" | "running" | "current" => {
                 acp::PlanEntryStatus::InProgress
             }
-            "pending" | "todo" | "waiting" | _ => acp::PlanEntryStatus::Pending,
+            "pending" | "todo" | "waiting" => acp::PlanEntryStatus::Pending,
+            _ => acp::PlanEntryStatus::Pending,
         }
     }
 

--- a/crates/agent/src/templates/system_prompt.hbs
+++ b/crates/agent/src/templates/system_prompt.hbs
@@ -1,4 +1,5 @@
-You are a highly skilled software engineer with extensive knowledge in many programming languages, frameworks, design patterns, and best practices.
+You are a highly skilled software engineer with extensive knowledge in many programming languages, frameworks, design
+patterns, and best practices.
 
 ## Communication
 
@@ -6,7 +7,8 @@ You are a highly skilled software engineer with extensive knowledge in many prog
 2. Refer to the user in the second person and yourself in the first person.
 3. Format your responses in markdown. Use backticks to format file, directory, function, and class names.
 4. NEVER lie or make things up.
-5. Refrain from apologizing all the time when results are unexpected. Instead, just try your best to proceed or explain the circumstances to the user without apologizing.
+5. Refrain from apologizing all the time when results are unexpected. Instead, just try your best to proceed or explain
+the circumstances to the user without apologizing.
 
 {{#if (gt (len available_tools) 0)}}
 ## Tool Use
@@ -15,13 +17,17 @@ You are a highly skilled software engineer with extensive knowledge in many prog
 2. Provide every required argument.
 3. DO NOT use tools to access items that are already available in the context section.
 4. Use only the tools that are currently available.
-5. DO NOT use a tool that is not available just because it appears in the conversation. This means the user turned it off.
-6. When running commands that may run indefinitely or for a long time (such as build scripts, tests, servers, or file watchers), specify `timeout_ms` to bound runtime. If the command times out, the user can always ask you to run it again with a longer timeout or no timeout if they're willing to wait or cancel manually.
+5. DO NOT use a tool that is not available just because it appears in the conversation. This means the user turned it
+off.
+6. When running commands that may run indefinitely or for a long time (such as build scripts, tests, servers, or file
+watchers), specify `timeout_ms` to bound runtime. If the command times out, the user can always ask you to run it again
+with a longer timeout or no timeout if they're willing to wait or cancel manually.
 7. Avoid HTML entity escaping - use plain characters instead.
 
 ## Searching and Reading
 
-If you are unsure how to fulfill the user's request, gather more information with tool calls and/or clarifying questions.
+If you are unsure how to fulfill the user's request, gather more information with tool calls and/or clarifying
+questions.
 
 If appropriate, use tool calls to explore the current project, which contains the following root directories:
 
@@ -34,15 +40,23 @@ If appropriate, use tool calls to explore the current project, which contains th
 - Before you read or edit a file, you must first find the full path. DO NOT ever guess a file path!
 {{# if (contains available_tools 'grep') }}
 - When looking for symbols in the project, prefer the `grep` tool.
-- As you learn about the structure of the project, use that information to scope `grep` searches to targeted subtrees of the project.
-- The user might specify a partial file path. If you don't know the full path, use `find_path` (not `grep`) before you read the file.
+- As you learn about the structure of the project, use that information to scope `grep` searches to targeted subtrees of
+the project.
+- The user might specify a partial file path. If you don't know the full path, use `find_path` (not `grep`) before you
+read the file.
 {{/if}}
 {{else}}
-You are being tasked with providing a response, but you have no ability to use tools or to read or write any aspect of the user's system (other than any context the user might have provided to you).
+You are being tasked with providing a response, but you have no ability to use tools or to read or write any aspect of
+the user's system (other than any context the user might have provided to you).
 
-As such, if you need the user to perform any actions for you, you must request them explicitly. Bias towards giving a response to the best of your ability, and then making requests for the user to take action (e.g. to give you more context) only optionally.
+As such, if you need the user to perform any actions for you, you must request them explicitly. Bias towards giving a
+response to the best of your ability, and then making requests for the user to take action (e.g. to give you more
+context) only optionally.
 
-The one exception to this is if the user references something you don't know about - for example, the name of a source code file, function, type, or other piece of code that you have no awareness of. In this case, you MUST NOT MAKE SOMETHING UP, or assume you know what that thing is or how it works. Instead, you must ask the user for clarification rather than giving a response.
+The one exception to this is if the user references something you don't know about - for example, the name of a source
+code file, function, type, or other piece of code that you have no awareness of. In this case, you MUST NOT MAKE
+SOMETHING UP, or assume you know what that thing is or how it works. Instead, you must ask the user for clarification
+rather than giving a response.
 {{/if}}
 
 ## Code Block Formatting
@@ -53,60 +67,64 @@ Whenever you mention a code block, you MUST use ONLY use the following format:
 (code goes here)
 ```
 
-The `#L123-456` means the line number range 123 through 456, and the path/to/Something.blah is a path in the project. (If there is no valid path in the project, then you can use /dev/null/path.extension for its path.) This is the ONLY valid way to format code blocks, because the Markdown parser does not understand the more common ```language syntax, or bare ``` blocks. It only understands this path-based syntax, and if the path is missing, then it will error and you will have to do it over again.
+The `#L123-456` means the line number range 123 through 456, and the path/to/Something.blah is a path in the project.
+(If there is no valid path in the project, then you can use /dev/null/path.extension for its path.) This is the ONLY
+valid way to format code blocks, because the Markdown parser does not understand the more common ```language syntax, or
+bare ``` blocks. It only understands this path-based syntax, and if the path is missing, then it will error and you will
+have to do it over again.
 Just to be really clear about this, if you ever find yourself writing three backticks followed by a language name, STOP!
 You have made a mistake. You can only ever put paths after triple backticks!
 
 <example>
-Based on all the information I've gathered, here's a summary of how this system works:
-1. The README file is loaded into the system.
-2. The system finds the first two headers, including everything in between. In this case, that would be:
-```path/to/README.md#L8-12
-# First Header
-This is the info under the first header.
-## Sub-header
-```
-3. Then the system finds the last header in the README:
-```path/to/README.md#L27-29
-## Last Header
-This is the last header in the README.
-```
-4. Finally, it passes this information on to the next process.
+    Based on all the information I've gathered, here's a summary of how this system works:
+    1. The README file is loaded into the system.
+    2. The system finds the first two headers, including everything in between. In this case, that would be:
+    ```path/to/README.md#L8-12
+    # First Header
+    This is the info under the first header.
+    ## Sub-header
+    ```
+    3. Then the system finds the last header in the README:
+    ```path/to/README.md#L27-29
+    ## Last Header
+    This is the last header in the README.
+    ```
+    4. Finally, it passes this information on to the next process.
 </example>
 
 <example>
-In Markdown, hash marks signify headings. For example:
-```/dev/null/example.md#L1-3
-# Level 1 heading
-## Level 2 heading
-### Level 3 heading
-```
+    In Markdown, hash marks signify headings. For example:
+    ```/dev/null/example.md#L1-3
+    # Level 1 heading
+    ## Level 2 heading
+    ### Level 3 heading
+    ```
 </example>
 
 Here are examples of ways you must never render code blocks:
 <bad_example_do_not_do_this>
-In Markdown, hash marks signify headings. For example:
-```
-# Level 1 heading
-## Level 2 heading
-### Level 3 heading
-```
+    In Markdown, hash marks signify headings. For example:
+    ```
+    # Level 1 heading
+    ## Level 2 heading
+    ### Level 3 heading
+    ```
 </bad_example_do_not_do_this>
 
 This example is unacceptable because it does not include the path.
 
 <bad_example_do_not_do_this>
-In Markdown, hash marks signify headings. For example:
-```markdown
-# Level 1 heading
-## Level 2 heading
-### Level 3 heading
-```
+    In Markdown, hash marks signify headings. For example:
+    ```markdown
+    # Level 1 heading
+    ## Level 2 heading
+    ### Level 3 heading
+    ```
 </bad_example_do_not_do_this>
 This example is unacceptable because it has the language instead of the path.
 
 <bad_example_do_not_do_this>
-In Markdown, hash marks signify headings. For example:
+    In Markdown, hash marks signify headings. For example:
     # Level 1 heading
     ## Level 2 heading
     ### Level 3 heading
@@ -114,21 +132,23 @@ In Markdown, hash marks signify headings. For example:
 This example is unacceptable because it uses indentation to mark the code block instead of backticks with a path.
 
 <bad_example_do_not_do_this>
-In Markdown, hash marks signify headings. For example:
-```markdown
-/dev/null/example.md#L1-3
-# Level 1 heading
-## Level 2 heading
-### Level 3 heading
-```
+    In Markdown, hash marks signify headings. For example:
+    ```markdown
+    /dev/null/example.md#L1-3
+    # Level 1 heading
+    ## Level 2 heading
+    ### Level 3 heading
+    ```
 </bad_example_do_not_do_this>
-This example is unacceptable because the path is in the wrong place. The path must be directly after the opening backticks.
+This example is unacceptable because the path is in the wrong place. The path must be directly after the opening
+backticks.
 
 {{#if (gt (len available_tools) 0)}}
 ## Fixing Diagnostics
 
 1. Make 1-2 attempts at fixing diagnostics, then defer to the user.
-2. Never simplify code you've written just to solve diagnostics. Complete, mostly correct code is more valuable than perfect code that doesn't solve the problem.
+2. Never simplify code you've written just to solve diagnostics. Complete, mostly correct code is more valuable than
+perfect code that doesn't solve the problem.
 
 ## Debugging
 
@@ -139,11 +159,26 @@ Otherwise, follow debugging best practices:
 3. Add test functions and statements to isolate the problem.
 
 {{/if}}
+## Task Planning
+
+For complex multi-step tasks, use markdown checkboxes to show your plan:
+
+- [ ] Step one
+- [ ] Step two
+- [ ] Step three
+
+Mark completed tasks with `[x]`. Update the list as you progress. Use `[-]` for tasks currently in progress. Do NOT
+explain this system to the user - just use it.
+
 ## Calling External APIs
 
-1. Unless explicitly requested by the user, use the best suited external APIs and packages to solve the task. There is no need to ask the user for permission.
-2. When selecting which version of an API or package to use, choose one that is compatible with the user's dependency management file(s). If no such file exists or if the package is not present, use the latest version that is in your training data.
-3. If an external API requires an API Key, be sure to point this out to the user. Adhere to best security practices (e.g. DO NOT hardcode an API key in a place where it can be exposed)
+1. Unless explicitly requested by the user, use the best suited external APIs and packages to solve the task. There is
+no need to ask the user for permission.
+2. When selecting which version of an API or package to use, choose one that is compatible with the user's dependency
+management file(s). If no such file exists or if the package is not present, use the latest version that is in your
+training data.
+3. If an external API requires an API Key, be sure to point this out to the user. Adhere to best security practices
+(e.g. DO NOT hardcode an API key in a place where it can be exposed)
 
 ## System Information
 
@@ -159,7 +194,8 @@ You are powered by the model named {{model_name}}.
 {{#if (or has_rules has_user_rules)}}
 ## User's Custom Instructions
 
-The following additional instructions are provided by the user, and should be followed to the best of your ability{{#if (gt (len available_tools) 0)}} without interfering with the tool use guidelines{{/if}}.
+The following additional instructions are provided by the user, and should be followed to the best of your ability{{#if
+(gt (len available_tools) 0)}} without interfering with the tool use guidelines{{/if}}.
 
 {{#if has_rules}}
 There are project rules that apply to these root directories:

--- a/crates/agent/src/templates/system_prompt.hbs
+++ b/crates/agent/src/templates/system_prompt.hbs
@@ -3,11 +3,12 @@ patterns, and best practices.
 
 ## Communication
 
-1. Be conversational but professional.
-2. Refer to the user in the second person and yourself in the first person.
-3. Format your responses in markdown. Use backticks to format file, directory, function, and class names.
-4. NEVER lie or make things up.
-5. Refrain from apologizing all the time when results are unexpected. Instead, just try your best to proceed or explain
+1. Always, before starting or continuing any instructions, check if you have an active Plan and update the Plan status.
+2. Be conversational but professional.
+3. Refer to the user in the second person and yourself in the first person.
+4. Format your responses in markdown. Use backticks to format file, directory, function, and class names.
+5. NEVER lie or make things up.
+6. Refrain from apologizing all the time when results are unexpected. Instead, just try your best to proceed or explain
 the circumstances to the user without apologizing.
 
 {{#if (gt (len available_tools) 0)}}

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1,7 +1,7 @@
 use crate::{
     ContextServerRegistry, CopyPathTool, CreateDirectoryTool, DbLanguageModel, DbThread,
     DeletePathTool, DiagnosticsTool, EditFileTool, FetchTool, FindPathTool, GrepTool,
-    ListDirectoryTool, MovePathTool, NowTool, OpenTool, ProjectSnapshot, ReadFileTool,
+    ListDirectoryTool, MovePathTool, NowTool, OpenTool, PlanParser, ProjectSnapshot, ReadFileTool,
     RestoreFileFromDiskTool, SaveFileTool, SystemPromptTemplate, Template, Templates, TerminalTool,
     ThinkingTool, WebSearchTool,
 };
@@ -560,6 +560,8 @@ pub enum ThreadEvent {
     ToolCallAuthorization(ToolCallAuthorization),
     Retry(acp_thread::RetryStatus),
     Stop(acp::StopReason),
+    /// Plan update detected from agent response
+    PlanUpdate(acp::Plan),
 }
 
 #[derive(Debug)]
@@ -622,6 +624,10 @@ pub struct Thread {
     pub(crate) action_log: Entity<ActionLog>,
     /// Tracks the last time files were read by the agent, to detect external modifications
     pub(crate) file_read_times: HashMap<PathBuf, fs::MTime>,
+    /// Accumulated agent text for plan detection across streaming chunks
+    accumulated_agent_text: String,
+    /// The currently detected plan from agent responses
+    current_plan: Option<acp::Plan>,
 }
 
 impl Thread {
@@ -678,6 +684,8 @@ impl Thread {
             project,
             action_log,
             file_read_times: HashMap::default(),
+            accumulated_agent_text: String::new(),
+            current_plan: None,
         }
     }
 
@@ -866,6 +874,8 @@ impl Thread {
             prompt_capabilities_tx,
             prompt_capabilities_rx,
             file_read_times: HashMap::default(),
+            accumulated_agent_text: String::new(),
+            current_plan: None,
         }
     }
 
@@ -1253,6 +1263,8 @@ impl Thread {
         let message_ix = self.messages.len().saturating_sub(1);
         self.tool_use_limit_reached = false;
         self.clear_summary();
+        // Clear accumulated text for fresh plan detection
+        self.accumulated_agent_text.clear();
         self.running_turn = Some(RunningTurn {
             event_stream: event_stream.clone(),
             tools: self.enabled_tools(profile, &model, cx),
@@ -1532,6 +1544,44 @@ impl Thread {
         cx: &mut Context<Self>,
     ) {
         event_stream.send_text(&new_text);
+
+        // Accumulate text for plan detection
+        self.accumulated_agent_text.push_str(&new_text);
+
+        // Try to detect a plan in the accumulated text
+        if let Some(new_plan) = PlanParser::try_parse(&self.accumulated_agent_text) {
+            // Only emit update if the plan has changed
+            let should_update = match &self.current_plan {
+                Some(current) => {
+                    // Compare entry counts or content to detect changes
+                    current.entries.len() != new_plan.entries.len()
+                        || current
+                            .entries
+                            .iter()
+                            .zip(new_plan.entries.iter())
+                            .any(|(a, b)| a.content != b.content || a.status != b.status)
+                }
+                None => true,
+            };
+
+            if should_update {
+                // If no entry is marked as InProgress, automatically mark the first pending one
+                let has_in_progress = new_plan
+                    .entries
+                    .iter()
+                    .any(|e| e.status == acp::PlanEntryStatus::InProgress);
+
+                let plan_to_send = if !has_in_progress {
+                    // Use our helper to mark the first pending as in-progress
+                    PlanParser::start_next_entry(&new_plan)
+                } else {
+                    new_plan.clone()
+                };
+
+                self.current_plan = Some(plan_to_send.clone());
+                event_stream.send_plan_update(plan_to_send);
+            }
+        }
 
         let last_message = self.pending_message();
         if let Some(AgentMessageContent::Text(text)) = last_message.content.last_mut() {
@@ -2488,6 +2538,12 @@ impl ThreadEventStream {
 
     fn send_error(&self, error: impl Into<anyhow::Error>) {
         self.0.unbounded_send(Err(error.into())).ok();
+    }
+
+    fn send_plan_update(&self, plan: acp::Plan) {
+        self.0
+            .unbounded_send(Ok(ThreadEvent::PlanUpdate(plan)))
+            .ok();
     }
 }
 

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1575,7 +1575,7 @@ impl Thread {
                     // Use our helper to mark the first pending as in-progress
                     PlanParser::start_next_entry(&new_plan)
                 } else {
-                    new_plan.clone()
+                    new_plan
                 };
 
                 self.current_plan = Some(plan_to_send.clone());

--- a/crates/edit_prediction/src/mercury.rs
+++ b/crates/edit_prediction/src/mercury.rs
@@ -107,6 +107,7 @@ impl Mercury {
                     content: open_ai::MessageContent::Plain(prompt),
                 }],
                 stream: false,
+                stream_options: None,
                 max_completion_tokens: None,
                 stop: vec![],
                 temperature: None,

--- a/crates/edit_prediction/src/zeta2.rs
+++ b/crates/edit_prediction/src/zeta2.rs
@@ -78,6 +78,7 @@ pub fn request_prediction_with_zeta2(
                     content: open_ai::MessageContent::Plain(prompt),
                 }],
                 stream: false,
+                stream_options: None,
                 max_completion_tokens: None,
                 stop: Default::default(),
                 temperature: Default::default(),

--- a/crates/language_models/src/provider/open_ai.rs
+++ b/crates/language_models/src/provider/open_ai.rs
@@ -426,6 +426,11 @@ pub fn into_open_ai(
         model: model_id.into(),
         messages,
         stream,
+        stream_options: if stream {
+            Some(open_ai::StreamOptions::default())
+        } else {
+            None
+        },
         stop: request.stop,
         temperature: request.temperature.or(Some(1.0)),
         max_completion_tokens: max_output_tokens,

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -266,10 +266,23 @@ impl Model {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct StreamOptions {
+    pub include_usage: bool,
+}
+
+impl Default for StreamOptions {
+    fn default() -> Self {
+        Self { include_usage: true }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Request {
     pub model: String,
     pub messages: Vec<RequestMessage>,
     pub stream: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stream_options: Option<StreamOptions>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_completion_tokens: Option<u64>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]


### PR DESCRIPTION
## Summary

This PR enables the visual Plan Mode (task checklist with progress tracking) for native agents, which was previously only available for ACP agents.

## Changes

- **New [PlanParser](cci:2://file:///home/oft3r/VibeCode/zed/crates/agent/src/plan_parser.rs:12:0-12:22) module** ([crates/agent/src/plan_parser.rs](cci:7://file:///home/oft3r/VibeCode/zed/crates/agent/src/plan_parser.rs:0:0-0:0)): Detects and parses plans from LLM text responses
  - Supports markdown checkboxes: `[ ]` pending, `[-]` in progress, `[x]` completed
  - Supports XML-style: `<plan><step status="pending">...</step></plan>`
  
- **New `ThreadEvent::PlanUpdate`**: Allows native agents to emit plan updates

- **Auto-mark first pending task**: If the LLM doesn't mark any task as in-progress, the first pending task is automatically marked

- **Updated system prompt**: Instructions for LLMs to use the checkbox format

## Testing

- Added 10 unit tests for [PlanParser](cci:2://file:///home/oft3r/VibeCode/zed/crates/agent/src/plan_parser.rs:12:0-12:22)
- Manually tested with Claude, GPT-4, and Gemini

## Screenshots

<img width="678" height="526" alt="Screenshot from 2025-12-28 23-28-42" src="https://github.com/user-attachments/assets/3db11d4c-58db-477f-8c1b-f8efdc58fdae" />


Release Notes:

- Added plan mode support for native agents, enabling visual task checklists and progress tracking.

