### PR TITLE
extension_api: Add log related methods to the extension API

### DIFF
--- a/crates/extension_api/src/extension_api.rs
+++ b/crates/extension_api/src/extension_api.rs
@@ -17,7 +17,7 @@ pub use serde_json;
 pub use wit::{
     CodeLabel, CodeLabelSpan, CodeLabelSpanLiteral, Command, DownloadedFileType, EnvVars,
     KeyValueStore, LanguageServerInstallationStatus, Project, Range, Worktree, download_file,
-    make_file_executable,
+    log_debug, log_error, log_info, log_trace, log_warn, make_file_executable,
     zed::extension::context_server::ContextServerConfiguration,
     zed::extension::dap::{
         AttachRequest, BuildTaskDefinition, BuildTaskDefinitionTemplatePayload, BuildTaskTemplate,

--- a/crates/extension_api/wit/since_v0.8.0/extension.wit
+++ b/crates/extension_api/wit/since_v0.8.0/extension.wit
@@ -19,6 +19,12 @@ world extension {
     /// Initializes the extension.
     export init-extension: func();
 
+    import log-trace: func(message: string);
+    import log-debug: func(message: string);
+    import log-info: func(message: string);
+    import log-warn: func(message: string);
+    import log-error: func(message: string);
+
     /// The type of a downloaded file.
     enum downloaded-file-type {
         /// A gzipped file (`.gz`).

--- a/crates/extension_host/Cargo.toml
+++ b/crates/extension_host/Cargo.toml
@@ -52,6 +52,7 @@ util.workspace = true
 wasmparser.workspace = true
 wasmtime-wasi.workspace = true
 wasmtime.workspace = true
+zlog.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true
@@ -66,7 +67,6 @@ rand.workspace = true
 reqwest_client.workspace = true
 theme = { workspace = true, features = ["test-support"] }
 theme_extension.workspace = true
-zlog.workspace = true
 
 [[bench]]
 name = "extension_compilation_benchmark"

--- a/crates/extension_host/src/wasm_host/wit/since_v0_8_0.rs
+++ b/crates/extension_host/src/wasm_host/wit/since_v0_8_0.rs
@@ -1108,4 +1108,45 @@ impl ExtensionImports for WasmState {
             .with_context(|| format!("setting permissions for path {path:?}"))
             .to_wasmtime_result()
     }
+
+    async fn log_trace(&mut self, message: String) -> wasmtime::Result<()> {
+        let logger = get_logger(&self.manifest.id);
+        zlog::trace!(logger => "{:?}", message);
+
+        Ok(())
+    }
+
+    async fn log_debug(&mut self, message: String) -> wasmtime::Result<()> {
+        let logger = get_logger(&self.manifest.id);
+        zlog::debug!(logger => "{:?}", message);
+
+        Ok(())
+    }
+
+    async fn log_info(&mut self, message: String) -> wasmtime::Result<()> {
+        let logger = get_logger(&self.manifest.id);
+        zlog::info!(logger => "{:?}", message);
+
+        Ok(())
+    }
+
+    async fn log_warn(&mut self, message: String) -> wasmtime::Result<()> {
+        let logger = get_logger(&self.manifest.id);
+        zlog::warn!(logger => "{:?}", message);
+
+        Ok(())
+    }
+
+    async fn log_error(&mut self, message: String) -> wasmtime::Result<()> {
+        let logger = get_logger(&self.manifest.id);
+        zlog::error!(logger => "{:?}", message);
+
+        Ok(())
+    }
+}
+
+fn get_logger(extension_id: &Arc<str>) -> zlog::Logger {
+    let all_extensions_logger = zlog::scoped!("extension");
+    let current_extension_scope = Box::leak(Box::new(extension_id.to_string()));
+    zlog::scoped!(all_extensions_logger => current_extension_scope)
 }


### PR DESCRIPTION
If this approach or design isn't desired, I am more than happy to iterate on it and try to get something that provides a consistent experience for users to review extension logs.

This adds new methods to the extension API that provides extensions with a consistent way to perform logging. This shares the same zlog crate used by the rest of the Zed application supporting the same level configuration and scopes.

Ref #17326. Not sure if we should close that issue or not. That issue explicitly requests support for the `log` crate and it's macros, but this takes a different approach.

There are some parts of the code that I'm not entirely sure about, so I'm going to leave some comments there. Any other feedback is also appreciated.

There aren't any tests for this new functionality because I wasn't sure where or how to add them. Any guidance here would be appreciated.

Example usage.
```
log_trace("language_server_workspace_configuration");
log_debug("language_server_workspace_configuration");
log_info("language_server_workspace_configuration");
log_warn("language_server_workspace_configuration");
log_error("language_server_workspace_configuration");
```

Example log output when run with `ZED_LOG=info,extension_host.extension.html=trace cargo run`
<img width="831" height="92" alt="image" src="https://github.com/user-attachments/assets/6807ac0f-c9ef-40ed-9d2c-3b646e020882" />

Release Notes:

- Add log related methods to the extension API.
