### PR TITLE
docs: Specify that dev containers are currently previeiw-only

### DIFF
--- a/docs/src/dev-containers.md
+++ b/docs/src/dev-containers.md
@@ -6,6 +6,7 @@ If your repository includes a `.devcontainer/devcontainer.json` file, Zed can op
 
 ## Requirements
 
+- Download and install the latest Zed. You need at least Zed v0.218.
 - Docker must be installed and available in your `PATH`. Zed requires the `docker` command to be present. If you use Podman, you can alias it to `docker` (e.g., `alias docker=podman`).
 - Your project must contain a `.devcontainer/devcontainer.json` directory/file.
 

--- a/docs/src/dev-containers.md
+++ b/docs/src/dev-containers.md
@@ -6,7 +6,7 @@ If your repository includes a `.devcontainer/devcontainer.json` file, Zed can op
 
 ## Requirements
 
-- Download and install the latest Zed. You need at least Zed v0.218.
+- [(Preview Only)](https://zed.dev/releases/preview): Download and install the latest Zed.
 - Docker must be installed and available in your `PATH`. Zed requires the `docker` command to be present. If you use Podman, you can alias it to `docker` (e.g., `alias docker=podman`).
 - Your project must contain a `.devcontainer/devcontainer.json` directory/file.
 


### PR DESCRIPTION
Thanks for the cool project and making it open source! Started using Zed recently and I really enjoy it.

Made a tiny addition to devcontainer docs to specify the version. Wasn't able to  get it to work as shown in the [docs](https://zed.dev/docs/dev-containers) (should "just work"). The feature was introduced recently on [PR 44442](https://github.com/zed-industries/zed/pull/44442) and is only available as of v0.218 (currently still in preview), while I was still on the latest stable version.

So I thought of opening a small PR 😊 

Thanks again for the awesome project!

Release Notes:

- N/A
