### PR TITLE
Improve Git Panel with TreeView, VSCode-style grouping, commit history, and auto-fetch

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -883,6 +883,23 @@
       // Default: inherits editor scrollbar settings
       // "show": null
     },
+    // Whether to automatically fetch from remote repositories in the background.
+    //
+    // Default: true
+    "auto_fetch": true,
+    // Interval in seconds between automatic fetches.
+    // Minimum: 60 seconds. Maximum: 3600 seconds (1 hour).
+    //
+    // Default: 300 (5 minutes)
+    "auto_fetch_interval_secs": 300,
+    // Whether to show the commit history section in the git panel.
+    //
+    // Default: true
+    "show_commit_history": true,
+    // Number of commits to show in the commit history section.
+    //
+    // Default: 10
+    "commit_history_count": 10
   },
   "message_editor": {
     // Whether to automatically replace emoji shortcodes with emoji characters.

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -1971,6 +1971,13 @@ impl FakeFs {
         .unwrap();
     }
 
+    pub fn set_commits_for_repo(&self, dot_git: &Path, commits: Vec<git::repository::CommitSummary>) {
+        self.with_git_state(dot_git, true, |state| {
+            state.commits = commits;
+        })
+        .unwrap();
+    }
+
     /// Put the given git repository into a state with the given status,
     /// by mutating the head, index, and unmerged state.
     pub fn set_status_for_repo(&self, dot_git: &Path, statuses: &[(&str, FileStatus)]) {

--- a/crates/git_ui/src/blame_ui.rs
+++ b/crates/git_ui/src/blame_ui.rs
@@ -244,6 +244,7 @@ impl BlameRenderer for GitBlameRenderer {
                 .unwrap_or_default(),
             commit_timestamp: commit_time.unix_timestamp(),
             author_name: author.clone(),
+            author_email: author_email.to_string().into(),
             has_parent: false,
         };
 

--- a/crates/git_ui/src/branch_picker.rs
+++ b/crates/git_ui/src/branch_picker.rs
@@ -1268,6 +1268,7 @@ mod tests {
                 sha: "abc123".into(),
                 commit_timestamp: ts,
                 author_name: "Test Author".into(),
+                author_email: "test@example.com".into(),
                 subject: "Test commit".into(),
                 has_parent: true,
             }),

--- a/crates/git_ui/src/commit_tooltip.rs
+++ b/crates/git_ui/src/commit_tooltip.rs
@@ -250,6 +250,7 @@ impl Render for CommitTooltip {
                 }),
             commit_timestamp: self.commit.commit_time.unix_timestamp(),
             author_name: self.commit.author_name.clone(),
+            author_email: self.commit.author_email.clone(),
             has_parent: false,
         };
 

--- a/crates/git_ui/src/git_panel_settings.rs
+++ b/crates/git_ui/src/git_panel_settings.rs
@@ -14,6 +14,11 @@ pub struct ScrollbarSettings {
     pub show: Option<ShowScrollbar>,
 }
 
+const MIN_AUTO_FETCH_INTERVAL_SECS: u64 = 60;
+const MAX_AUTO_FETCH_INTERVAL_SECS: u64 = 3600;
+const DEFAULT_AUTO_FETCH_INTERVAL_SECS: u64 = 300;
+const DEFAULT_COMMIT_HISTORY_COUNT: usize = 10;
+
 #[derive(Debug, Clone, PartialEq, RegisterSetting)]
 pub struct GitPanelSettings {
     pub button: bool,
@@ -25,6 +30,14 @@ pub struct GitPanelSettings {
     pub sort_by_path: bool,
     pub collapse_untracked_diff: bool,
     pub tree_view: bool,
+    /// Whether to automatically fetch from remote repositories in the background.
+    pub auto_fetch: bool,
+    /// Interval in seconds between automatic fetches.
+    pub auto_fetch_interval_secs: u64,
+    /// Whether to show the commit history section in the git panel.
+    pub show_commit_history: bool,
+    /// Number of commits to show in the commit history section.
+    pub commit_history_count: usize,
 }
 
 impl ScrollbarVisibility for GitPanelSettings {
@@ -46,6 +59,11 @@ impl ScrollbarVisibility for GitPanelSettings {
 impl Settings for GitPanelSettings {
     fn from_settings(content: &settings::SettingsContent) -> Self {
         let git_panel = content.git_panel.clone().unwrap();
+        let auto_fetch_interval = git_panel
+            .auto_fetch_interval_secs
+            .unwrap_or(DEFAULT_AUTO_FETCH_INTERVAL_SECS)
+            .clamp(MIN_AUTO_FETCH_INTERVAL_SECS, MAX_AUTO_FETCH_INTERVAL_SECS);
+
         Self {
             button: git_panel.button.unwrap(),
             dock: git_panel.dock.unwrap().into(),
@@ -58,6 +76,12 @@ impl Settings for GitPanelSettings {
             sort_by_path: git_panel.sort_by_path.unwrap(),
             collapse_untracked_diff: git_panel.collapse_untracked_diff.unwrap(),
             tree_view: git_panel.tree_view.unwrap(),
+            auto_fetch: git_panel.auto_fetch.unwrap_or(true),
+            auto_fetch_interval_secs: auto_fetch_interval,
+            show_commit_history: git_panel.show_commit_history.unwrap_or(true),
+            commit_history_count: git_panel
+                .commit_history_count
+                .unwrap_or(DEFAULT_COMMIT_HISTORY_COUNT),
         }
     }
 }

--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -1540,6 +1540,7 @@ mod preview {
                         subject: "Modify stuff".into(),
                         commit_timestamp: 1710932954,
                         author_name: "John Doe".into(),
+                        author_email: "john@example.com".into(),
                         has_parent: true,
                     }),
                 }

--- a/crates/proto/proto/git.proto
+++ b/crates/proto/proto/git.proto
@@ -96,6 +96,7 @@ message CommitSummary {
     string subject = 2;
     int64 commit_timestamp = 3;
     string author_name = 4;
+    string author_email = 5;
 }
 
 message GitBranches {

--- a/crates/settings/src/settings_content.rs
+++ b/crates/settings/src/settings_content.rs
@@ -523,6 +523,27 @@ pub struct GitPanelSettingsContent {
     ///
     /// Default: false
     pub tree_view: Option<bool>,
+
+    /// Whether to automatically fetch from remote repositories in the background.
+    ///
+    /// Default: true
+    pub auto_fetch: Option<bool>,
+
+    /// Interval in seconds between automatic fetches.
+    /// Minimum: 60 seconds. Maximum: 3600 seconds (1 hour).
+    ///
+    /// Default: 300 (5 minutes)
+    pub auto_fetch_interval_secs: Option<u64>,
+
+    /// Whether to show the commit history section in the git panel.
+    ///
+    /// Default: true
+    pub show_commit_history: Option<bool>,
+
+    /// Number of commits to show in the commit history section.
+    ///
+    /// Default: 10
+    pub commit_history_count: Option<usize>,
 }
 
 #[derive(


### PR DESCRIPTION
Release notes

- **Grouping by Stage**: Files are now grouped into "Staged Changes" and "Changes" sections (VSCode-style), replacing the previous Conflict/Tracked/Untracked grouping. This provides a clearer workflow for staging and committing changes.

- **Commit History Section**: A new collapsible "Commits" section displays recent commit history with compact cards showing commit message, author, and relative timestamp. Clicking a commit opens the commit details view.

- **Auto Fetch**: The Git Panel now automatically fetches from remote repositories in the background at configurable intervals (default: every 5 minutes).

New settings:
- `git_panel.auto_fetch`: Enable/disable background fetching (default: true)
- `git_panel.auto_fetch_interval_secs`: Interval between fetches (default: 300)
- `git_panel.show_commit_history`: Show/hide commit history section (default: true)
- `git_panel.commit_history_count`: Number of commits to display (default: 10)

<img width="518" height="1439" alt="Screenshot 2025-12-30 at 09 00 26" src="https://github.com/user-attachments/assets/b95f10d0-af62-48f9-99b1-2bcae2410274" />

