### PR TITLE
Ensure reliable ACP agent process termination and session cancellation

### DIFF
--- a/crates/acp_thread/src/connection.rs
+++ b/crates/acp_thread/src/connection.rs
@@ -473,15 +473,10 @@ mod test_support {
         }
 
         fn cancel(&self, session_id: &acp::SessionId, _cx: &mut App) {
-            if let Some(end_turn_tx) = self
-                .sessions
-                .lock()
-                .get_mut(session_id)
-                .unwrap()
-                .response_tx
-                .take()
-            {
-                end_turn_tx.send(acp::StopReason::Cancelled).unwrap();
+            if let Some(session) = self.sessions.lock().get_mut(session_id) {
+                if let Some(end_turn_tx) = session.response_tx.take() {
+                    end_turn_tx.send(acp::StopReason::Cancelled).ok();
+                }
             }
         }
 


### PR DESCRIPTION
Closes [#ISSUE](https://github.com/zed-industries/zed/issues/45211)

Release Notes:

- Fixed Gemini CLI leaving orphaned node processes after session ends (Unix)

Problem:

When using the Gemini CLI agent, multiple node processes (typically 5) are spawned on launch. After quitting Zed, 4 of these processes remain running as orphaned processes, causing a resource leak.

Root Cause:

The Gemini CLI spawns additional child node processes **internally** for various purposes:

- MCP (Model Context Protocol) servers
- Tool executors
- Other internal functionality

When `AcpConnection` was dropped, the existing implementation only called `self.child.kill()`, which terminates just the immediate child process (the main Gemini CLI node process). However, the grandchild processes spawned by the Gemini CLI were not part of the same process group, so they were not terminated and became orphaned.

Solution:

Applied the same pattern used by the DAP transport in 
`crates/dap/src/transport.rs`:

1. Spawn child in its own process group (Unix): Modified `AcpConnection::stdio()` to use `util::set_pre_exec_to_start_new_session()`, which calls `libc::setsid()` before exec. This creates a new session/process group, ensuring all descendant processes belong to the same group.
2. Kill entire process group on drop (Unix): Modified the `Drop` implementation to use `libc::killpg(pid, SIGKILL)` instead of `kill()`. This terminates the entire process group, ensuring all descendant processes (MCP servers, tool executors, etc.) are properly cleaned up.

The fix doesn't depend on why child processes are spawned or how many are spawned. By putting the child in its own process group (setsid) and killing the entire group (killpg), we guarantee cleanup regardless of the process tree structure.

Recordings (clipped some waiting periods):

Before:

https://github.com/user-attachments/assets/65767652-b21a-43c1-bd83-8b3a812914be

After:

https://github.com/user-attachments/assets/fb2edbd6-7aa1-4ba0-a476-f707b0a918c6
