### PR TITLE
title_bar: Fix close button hover color on Windows

### DIFF
--- a/crates/title_bar/src/platforms/platform_windows.rs
+++ b/crates/title_bar/src/platforms/platform_windows.rs
@@ -33,7 +33,7 @@ impl WindowsWindowControls {
 }
 
 impl RenderOnce for WindowsWindowControls {
-    fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
+    fn render(self, window: &mut Window, _: &mut App) -> impl IntoElement {
         div()
             .id("windows-window-controls")
             .font_family(Self::get_font())
@@ -45,11 +45,11 @@ impl RenderOnce for WindowsWindowControls {
             .min_h(self.button_height)
             .child(WindowsCaptionButton::Minimize)
             .map(|this| {
-                if window.is_maximized() {
+                this.child(if window.is_maximized() {
                     WindowsCaptionButton::Restore
                 } else {
                     WindowsCaptionButton::Maximize
-                }
+                })
             })
             .child(WindowsCaptionButton::Close)
     }
@@ -83,10 +83,19 @@ impl WindowsCaptionButton {
             Self::Close => "\u{e8bb}",
         }
     }
+
+    #[inline]
+    fn control_area(&self) -> WindowControlArea {
+        match self {
+            Self::Close => WindowControlArea::Close,
+            Self::Maximize | Self::Restore => WindowControlArea::Max,
+            Self::Minimize => WindowControlArea::Min,
+        }
+    }
 }
 
 impl RenderOnce for WindowsCaptionButton {
-    fn render(self, _window: &mut Window, _cx: &mut App) -> impl IntoElement {
+    fn render(self, _: &mut Window, cx: &mut App) -> impl IntoElement {
         let (hover_bg, hover_fg, active_bg, active_fg) = match self {
             Self::Close => {
                 let color: Hsla = Rgba {
@@ -122,17 +131,7 @@ impl RenderOnce for WindowsCaptionButton {
             .text_size(px(10.0))
             .hover(|style| style.bg(hover_bg).text_color(hover_fg))
             .active(|style| style.bg(active_bg).text_color(active_fg))
-            .map(|this| match self.icon {
-                WindowsCaptionButtonIcon::Close => {
-                    this.window_control_area(WindowControlArea::Close)
-                }
-                WindowsCaptionButtonIcon::Maximize | WindowsCaptionButtonIcon::Restore => {
-                    this.window_control_area(WindowControlArea::Max)
-                }
-                WindowsCaptionButtonIcon::Minimize => {
-                    this.window_control_area(WindowControlArea::Min)
-                }
-            })
+            .window_control_area(self.control_area())
             .child(self.icon())
     }
 }

--- a/crates/title_bar/src/platforms/platform_windows.rs
+++ b/crates/title_bar/src/platforms/platform_windows.rs
@@ -89,14 +89,20 @@ impl RenderOnce for WindowsCaptionButton {
     fn render(self, _window: &mut Window, _cx: &mut App) -> impl IntoElement {
         let (hover_bg, hover_fg, active_bg, active_fg) = match self {
             Self::Close => {
-                let color = Rgba {
+                let color: Hsla = Rgba {
                     r: 232.0 / 255.0,
                     g: 17.0 / 255.0,
                     b: 32.0 / 255.0,
                     a: 1.0,
-                };
+                }
+                .into();
 
-                (color, gpui::white(), color, gpui::white())
+                (
+                    color,
+                    gpui::white(),
+                    color.opacity(0.8),
+                    gpui::white().opacity(0.8),
+                )
             }
             _ => (
                 cx.theme().colors().ghost_element_hover,


### PR DESCRIPTION
Release Notes:

- Fix close button hover text color on Windows

| Before | After |
| --- | --- |
| <img width="166" height="137" alt="before" src="https://github.com/user-attachments/assets/fcd225c4-c73f-4e21-8e8d-459395df27ec" /> |<img width="188" height="156" alt="after" src="https://github.com/user-attachments/assets/89f5dcba-d677-4eb9-a9b4-170eb9792cb2" /> |

https://github.com/user-attachments/assets/27e88bf1-eddd-4ec8-a360-6a68eef484e0

And I also improved this file's implementation to merge the `WindowsCaptionButtonIcon` into `WindowsCaptionButton`.