### PR TITLE
ui: Make docs aside in pickers and context menu render centered to its trigger

### DIFF
--- a/crates/agent_ui/src/acp/config_options.rs
+++ b/crates/agent_ui/src/acp/config_options.rs
@@ -593,7 +593,6 @@ impl PickerDelegate for ConfigOptionPickerDelegate {
 
                 ui::DocumentationAside::new(
                     ui::DocumentationSide::Left,
-                    ui::DocumentationEdge::Top,
                     Rc::new(move |_| {
                         v_flex()
                             .gap_1()
@@ -603,6 +602,10 @@ impl PickerDelegate for ConfigOptionPickerDelegate {
                     }),
                 )
             })
+    }
+
+    fn documentation_aside_index(&self) -> Option<usize> {
+        self.selected_description.as_ref().map(|(ix, _, _)| *ix)
     }
 }
 

--- a/crates/agent_ui/src/acp/mode_selector.rs
+++ b/crates/agent_ui/src/acp/mode_selector.rs
@@ -7,8 +7,8 @@ use gpui::{Context, Entity, FocusHandle, WeakEntity, Window, prelude::*};
 use settings::Settings as _;
 use std::{rc::Rc, sync::Arc};
 use ui::{
-    Button, ContextMenu, ContextMenuEntry, DocumentationEdge, DocumentationSide, KeyBinding,
-    PopoverMenu, PopoverMenuHandle, Tooltip, prelude::*,
+    Button, ContextMenu, ContextMenuEntry, DocumentationSide, KeyBinding, PopoverMenu,
+    PopoverMenuHandle, Tooltip, prelude::*,
 };
 
 use crate::{CycleModeSelector, ToggleProfileSelector, ui::HoldForDefault};
@@ -105,7 +105,7 @@ impl ModeSelector {
                     .toggleable(IconPosition::End, is_selected);
 
                 let entry = if let Some(description) = &mode.description {
-                    entry.documentation_aside(side, DocumentationEdge::Bottom, {
+                    entry.documentation_aside(side, {
                         let description = description.clone();
 
                         move |_| {

--- a/crates/agent_ui/src/acp/model_selector.rs
+++ b/crates/agent_ui/src/acp/model_selector.rs
@@ -16,7 +16,7 @@ use itertools::Itertools;
 use ordered_float::OrderedFloat;
 use picker::{Picker, PickerDelegate};
 use settings::SettingsStore;
-use ui::{DocumentationAside, DocumentationEdge, DocumentationSide, IntoElement, prelude::*};
+use ui::{DocumentationAside, DocumentationSide, IntoElement, prelude::*};
 use util::ResultExt;
 use zed_actions::agent::OpenSettings;
 
@@ -388,7 +388,6 @@ impl PickerDelegate for AcpModelPickerDelegate {
 
                 DocumentationAside::new(
                     DocumentationSide::Left,
-                    DocumentationEdge::Top,
                     Rc::new(move |_| {
                         v_flex()
                             .gap_1()
@@ -398,6 +397,10 @@ impl PickerDelegate for AcpModelPickerDelegate {
                     }),
                 )
             })
+    }
+
+    fn documentation_aside_index(&self) -> Option<usize> {
+        self.selected_description.as_ref().map(|(ix, _, _)| *ix)
     }
 
     fn render_footer(

--- a/crates/edit_prediction_ui/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_ui/src/edit_prediction_button.rs
@@ -36,8 +36,8 @@ use std::{
 };
 use supermaven::{AccountStatus, Supermaven};
 use ui::{
-    Clickable, ContextMenu, ContextMenuEntry, DocumentationEdge, DocumentationSide, IconButton,
-    IconButtonShape, Indicator, PopoverMenu, PopoverMenuHandle, ProgressBar, Tooltip, prelude::*,
+    Clickable, ContextMenu, ContextMenuEntry, DocumentationSide, IconButton, IconButtonShape,
+    Indicator, PopoverMenu, PopoverMenuHandle, ProgressBar, Tooltip, prelude::*,
 };
 use util::ResultExt as _;
 use workspace::{
@@ -680,7 +680,7 @@ impl EditPredictionButton {
                     menu = menu.item(
                         entry
                             .disabled(true)
-                            .documentation_aside(DocumentationSide::Left, DocumentationEdge::Top, move |_cx| {
+                            .documentation_aside(DocumentationSide::Left, move |_cx| {
                                 Label::new(format!("Edit predictions cannot be toggled for this buffer because they are disabled for {}", language.name()))
                                     .into_any_element()
                             })
@@ -726,7 +726,7 @@ impl EditPredictionButton {
                 .item(
                     ContextMenuEntry::new("Eager")
                         .toggleable(IconPosition::Start, eager_mode)
-                        .documentation_aside(DocumentationSide::Left, DocumentationEdge::Top, move |_| {
+                        .documentation_aside(DocumentationSide::Left, move |_| {
                             Label::new("Display predictions inline when there are no language server completions available.").into_any_element()
                         })
                         .handler({
@@ -739,7 +739,7 @@ impl EditPredictionButton {
                 .item(
                     ContextMenuEntry::new("Subtle")
                         .toggleable(IconPosition::Start, subtle_mode)
-                        .documentation_aside(DocumentationSide::Left, DocumentationEdge::Top, move |_| {
+                        .documentation_aside(DocumentationSide::Left, move |_| {
                             Label::new("Display predictions inline only when holding a modifier key (alt by default).").into_any_element()
                         })
                         .handler({
@@ -778,7 +778,7 @@ impl EditPredictionButton {
                             .toggleable(IconPosition::Start, data_collection.is_enabled())
                             .icon(icon_name)
                             .icon_color(icon_color)
-                            .documentation_aside(DocumentationSide::Left, DocumentationEdge::Top, move |cx| {
+                            .documentation_aside(DocumentationSide::Left, move |cx| {
                                 let (msg, label_color, icon_name, icon_color) = match (is_open_source, is_collecting) {
                                     (true, true) => (
                                         "Project identified as open source, and you're sharing data.",
@@ -862,7 +862,7 @@ impl EditPredictionButton {
             ContextMenuEntry::new("Configure Excluded Files")
                 .icon(IconName::LockOutlined)
                 .icon_color(Color::Muted)
-                .documentation_aside(DocumentationSide::Left, DocumentationEdge::Top, |_| {
+                .documentation_aside(DocumentationSide::Left, |_| {
                     Label::new(indoc!{"
                         Open your settings to add sensitive paths for which Zed will never predict edits."}).into_any_element()
                 })

--- a/crates/language_tools/src/lsp_button.rs
+++ b/crates/language_tools/src/lsp_button.rs
@@ -17,8 +17,8 @@ use project::{
 };
 use settings::{Settings as _, SettingsStore};
 use ui::{
-    Context, ContextMenu, ContextMenuEntry, ContextMenuItem, DocumentationAside, DocumentationEdge,
-    DocumentationSide, Indicator, PopoverMenu, PopoverMenuHandle, Tooltip, Window, prelude::*,
+    Context, ContextMenu, ContextMenuEntry, ContextMenuItem, DocumentationAside, DocumentationSide,
+    Indicator, PopoverMenu, PopoverMenuHandle, Tooltip, Window, prelude::*,
 };
 
 use util::{ResultExt, rel_path::RelPath};
@@ -384,7 +384,6 @@ impl LanguageServerState {
                 tooltip_text.map(|tooltip_text| {
                     DocumentationAside::new(
                         DocumentationSide::Right,
-                        DocumentationEdge::Top,
                         Rc::new(move |_| Label::new(tooltip_text.clone()).into_any_element()),
                     )
                 }),

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -9,19 +9,21 @@ use editor::{
     scroll::Autoscroll,
 };
 use gpui::{
-    Action, AnyElement, App, ClickEvent, Context, DismissEvent, Entity, EventEmitter, FocusHandle,
-    Focusable, Length, ListSizingBehavior, ListState, MouseButton, MouseUpEvent, Render,
-    ScrollStrategy, Task, UniformListScrollHandle, Window, actions, div, list, prelude::*,
-    uniform_list,
+    Action, AnyElement, App, Bounds, ClickEvent, Context, DismissEvent, Entity, EventEmitter,
+    FocusHandle, Focusable, Length, ListSizingBehavior, ListState, MouseButton, MouseUpEvent,
+    Pixels, Render, ScrollStrategy, Task, UniformListScrollHandle, Window, actions, canvas, div,
+    list, prelude::*, uniform_list,
 };
 use head::Head;
 use schemars::JsonSchema;
 use serde::Deserialize;
-use std::{ops::Range, sync::Arc, time::Duration};
+use std::{
+    cell::Cell, cell::RefCell, collections::HashMap, ops::Range, rc::Rc, sync::Arc, time::Duration,
+};
 use theme::ThemeSettings;
 use ui::{
-    Color, Divider, DocumentationAside, DocumentationEdge, DocumentationSide, Label, ListItem,
-    ListItemSpacing, ScrollAxes, Scrollbars, WithScrollbar, prelude::*, utils::WithRemSize, v_flex,
+    Color, Divider, DocumentationAside, DocumentationSide, Label, ListItem, ListItemSpacing,
+    ScrollAxes, Scrollbars, WithScrollbar, prelude::*, utils::WithRemSize, v_flex,
 };
 use workspace::{ModalView, item::Settings};
 
@@ -72,6 +74,10 @@ pub struct Picker<D: PickerDelegate> {
     ///
     /// Set this to `false` when rendering the `Picker` as part of a larger modal.
     is_modal: bool,
+    /// Bounds tracking for the picker container (for aside positioning)
+    picker_bounds: Rc<Cell<Option<Bounds<Pixels>>>>,
+    /// Bounds tracking for items (for aside positioning) - maps item index to bounds
+    item_bounds: Rc<RefCell<HashMap<usize, Bounds<Pixels>>>>,
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
@@ -243,6 +249,13 @@ pub trait PickerDelegate: Sized + 'static {
     ) -> Option<DocumentationAside> {
         None
     }
+
+    /// Returns the index of the item whose documentation aside should be shown.
+    /// This is used to position the aside relative to that item.
+    /// Typically this is the hovered item, not necessarily the selected item.
+    fn documentation_aside_index(&self) -> Option<usize> {
+        None
+    }
 }
 
 impl<D: PickerDelegate> Focusable for Picker<D> {
@@ -329,6 +342,8 @@ impl<D: PickerDelegate> Picker<D> {
             max_height: Some(rems(24.).into()),
             show_scrollbar: false,
             is_modal: true,
+            picker_bounds: Rc::new(Cell::new(None)),
+            item_bounds: Rc::new(RefCell::new(HashMap::default())),
         };
         this.update_matches("".to_string(), window, cx);
         // give the delegate 4ms to render the first set of suggestions.
@@ -750,9 +765,23 @@ impl<D: PickerDelegate> Picker<D> {
         cx: &mut Context<Self>,
         ix: usize,
     ) -> impl IntoElement + use<D> {
+        let item_bounds = self.item_bounds.clone();
+
         div()
             .id(("item", ix))
             .cursor_pointer()
+            .child(
+                canvas(
+                    move |bounds, _window, _cx| {
+                        item_bounds.borrow_mut().insert(ix, bounds);
+                    },
+                    |_bounds, _state, _window, _cx| {},
+                )
+                .size_full()
+                .absolute()
+                .top_0()
+                .left_0(),
+            )
             .on_click(cx.listener(move |this, event: &ClickEvent, window, cx| {
                 this.handle_click(ix, event.modifiers().secondary(), window, cx)
             }))
@@ -847,11 +876,24 @@ impl<D: PickerDelegate> Render for Picker<D> {
         let aside = self.delegate.documentation_aside(window, cx);
 
         let editor_position = self.delegate.editor_position();
+        let picker_bounds = self.picker_bounds.clone();
         let menu = v_flex()
             .key_context("Picker")
             .size_full()
             .when_some(self.width, |el, width| el.w(width))
             .overflow_hidden()
+            .child(
+                canvas(
+                    move |bounds, _window, _cx| {
+                        picker_bounds.set(Some(bounds));
+                    },
+                    |_bounds, _state, _window, _cx| {},
+                )
+                .size_full()
+                .absolute()
+                .top_0()
+                .left_0(),
+            )
             // This is a bit of a hack to remove the modal styling when we're rendering the `Picker`
             // as a part of a modal rather than the entire modal.
             //
@@ -949,21 +991,39 @@ impl<D: PickerDelegate> Render for Picker<D> {
         };
 
         if is_wide_window {
-            div().relative().child(menu).child(
-                h_flex()
-                    .absolute()
-                    .when(aside.side == DocumentationSide::Left, |this| {
-                        this.right_full().mr_1()
-                    })
-                    .when(aside.side == DocumentationSide::Right, |this| {
-                        this.left_full().ml_1()
-                    })
-                    .when(aside.edge == DocumentationEdge::Top, |this| this.top_0())
-                    .when(aside.edge == DocumentationEdge::Bottom, |this| {
-                        this.bottom_0()
-                    })
-                    .child(render_aside(aside, cx)),
-            )
+            let aside_index = self.delegate.documentation_aside_index();
+            let picker_bounds = self.picker_bounds.get();
+            let item_bounds =
+                aside_index.and_then(|ix| self.item_bounds.borrow().get(&ix).copied());
+
+            let item_position = match (picker_bounds, item_bounds) {
+                (Some(picker_bounds), Some(item_bounds)) => {
+                    let relative_top = item_bounds.origin.y - picker_bounds.origin.y;
+                    let height = item_bounds.size.height;
+                    Some((relative_top, height))
+                }
+                _ => None,
+            };
+
+            div()
+                .relative()
+                .child(menu)
+                // Only render the aside once we have bounds to avoid flicker
+                .when_some(item_position, |this, (top, height)| {
+                    this.child(
+                        h_flex()
+                            .absolute()
+                            .when(aside.side == DocumentationSide::Left, |el| {
+                                el.right_full().mr_1()
+                            })
+                            .when(aside.side == DocumentationSide::Right, |el| {
+                                el.left_full().ml_1()
+                            })
+                            .top(top)
+                            .h(height)
+                            .child(render_aside(aside, cx)),
+                    )
+                })
         } else {
             v_flex()
                 .w_full()

--- a/crates/zed/src/zed/quick_action_bar.rs
+++ b/crates/zed/src/zed/quick_action_bar.rs
@@ -19,8 +19,8 @@ use project::{DisableAiSettings, project_settings::DiagnosticSeverity};
 use search::{BufferSearchBar, buffer_search};
 use settings::{Settings, SettingsStore};
 use ui::{
-    ButtonStyle, ContextMenu, ContextMenuEntry, DocumentationEdge, DocumentationSide, IconButton,
-    IconName, IconSize, PopoverMenu, PopoverMenuHandle, Tooltip, prelude::*,
+    ButtonStyle, ContextMenu, ContextMenuEntry, DocumentationSide, IconButton, IconName, IconSize,
+    PopoverMenu, PopoverMenuHandle, Tooltip, prelude::*,
 };
 use vim_mode_setting::{HelixModeSetting, VimModeSetting};
 use workspace::item::ItemBufferKind;
@@ -416,7 +416,7 @@ impl Render for QuickActionBar {
                                         }
                                     });
                                 if !edit_predictions_enabled_at_cursor {
-                                    edit_prediction_entry = edit_prediction_entry.documentation_aside(DocumentationSide::Left, DocumentationEdge::Top, |_| {
+                                    edit_prediction_entry = edit_prediction_entry.documentation_aside(DocumentationSide::Left, |_| {
                                         Label::new("You can't toggle edit predictions for this file as it is within the excluded files list.").into_any_element()
                                     });
                                 }
@@ -467,7 +467,7 @@ impl Render for QuickActionBar {
                                             }
                                         });
                                     if !diagnostics_enabled {
-                                        inline_diagnostics_item = inline_diagnostics_item.disabled(true).documentation_aside(DocumentationSide::Left, DocumentationEdge::Top, |_|  Label::new("Inline diagnostics are not available until regular diagnostics are enabled.").into_any_element());
+                                        inline_diagnostics_item = inline_diagnostics_item.disabled(true).documentation_aside(DocumentationSide::Left, |_|  Label::new("Inline diagnostics are not available until regular diagnostics are enabled.").into_any_element());
                                     }
                                     menu = menu.item(inline_diagnostics_item)
                                 }


### PR DESCRIPTION
This has been something we've wanted to do for a long time since docs aside thus far have been hard-anchored either at the top or bottom of the container that their trigger is sitting in. This PR introduces the change so that they're centered with their trigger, regardless of whether it's on a context menu or picker, by including a canvas element in both the container and the trigger to calculate where the docs aside should precisely sit on. Here's the result:

https://github.com/user-attachments/assets/8147ad05-1927-4353-991d-405631de67d0

Note that at the moment, docs aside are only visible through _hovering_, and ideally, they should be available on both hover and selection (keyboard nav). But I'll leave that for later.

Release Notes:

- N/A
