### PR TITLE
extension_ci: Fix version bump not working

### DIFF
--- a/.github/workflows/extension_bump.yml
+++ b/.github/workflows/extension_bump.yml
@@ -79,7 +79,7 @@ jobs:
       with:
         clean: false
     - name: extension_bump::install_bump_2_version
-      run: pip install bump2version
+      run: pip install bump2version --break-system-packages
       shell: bash -euxo pipefail {0}
     - id: bump-version
       name: extension_bump::bump_version

--- a/tooling/xtask/src/tasks/workflows/extension_bump.rs
+++ b/tooling/xtask/src/tasks/workflows/extension_bump.rs
@@ -232,7 +232,10 @@ pub(crate) fn generate_token(
 }
 
 fn install_bump_2_version() -> Step<Run> {
-    named::run(runners::Platform::Linux, "pip install bump2version")
+    named::run(
+        runners::Platform::Linux,
+        "pip install bump2version --break-system-packages",
+    )
 }
 
 fn bump_version(current_version: &JobOutput, bump_type: &WorkflowInput) -> (Step<Run>, StepOutput) {


### PR DESCRIPTION
I changed the runner sizes to a smaller but more recent image yesterday and broke the version bumping in the process. This PR fixes this by force installing the needed package.

Release Notes:

- N/A