### PR TITLE
ui: Add fixes to the `NumberField` edit mode

### DIFF
--- a/crates/ui_input/src/number_field.rs
+++ b/crates/ui_input/src/number_field.rs
@@ -650,7 +650,7 @@ impl<T: NumberFieldType> RenderOnce for NumberField<T> {
 
                                     if !is_focused {
                                         let current_text = editor.read(cx).text(cx);
-                                        let last_synced = self.last_synced_value.read(cx).clone();
+                                        let last_synced = *self.last_synced_value.read(cx);
 
                                         // Detect if the value changed externally (e.g., reset button)
                                         let value_changed_externally = last_synced

--- a/crates/ui_input/src/number_field.rs
+++ b/crates/ui_input/src/number_field.rs
@@ -348,7 +348,6 @@ enum ValueChangeDirection {
 
 impl<T: NumberFieldType> RenderOnce for NumberField<T> {
     fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
-        let mut tab_index = self.tab_index;
         let is_edit_mode = matches!(*self.mode.read(cx), NumberFieldMode::Edit);
 
         let get_step = {

--- a/crates/ui_input/src/number_field.rs
+++ b/crates/ui_input/src/number_field.rs
@@ -456,10 +456,7 @@ impl<T: NumberFieldType> RenderOnce for NumberField<T> {
                 this.child(
                     IconButton::new("reset", IconName::RotateCcw)
                         .icon_size(IconSize::Small)
-                        .when_some(tab_index.as_mut(), |this, tab_index| {
-                            *tab_index += 1;
-                            this.tab_index(*tab_index - 1)
-                        })
+                        .when_some(self.tab_index, |this, _| this.tab_index(0isize))
                         .on_click(on_reset),
                 )
             })
@@ -489,27 +486,14 @@ impl<T: NumberFieldType> RenderOnce for NumberField<T> {
 
                         decrement.child(
                             base_button(IconName::Dash)
-                                .id("decrement_button")
+                                .id((self.id.clone(), "decrement_button"))
                                 .rounded_tl_sm()
                                 .rounded_bl_sm()
-                                .tab_index(
-                                    tab_index
-                                        .as_mut()
-                                        .map(|tab_index| {
-                                            *tab_index += 1;
-                                            *tab_index - 1
-                                        })
-                                        .unwrap_or(0),
-                                )
+                                .when_some(self.tab_index, |this, _| this.tab_index(0isize))
                                 .on_click(decrement_handler),
                         )
                     })
                     .child({
-                        let editor_tab_index = tab_index.as_mut().map(|ti| {
-                            *ti += 1;
-                            *ti - 1
-                        });
-
                         h_flex()
                             .min_w_16()
                             .size_full()
@@ -668,18 +652,10 @@ impl<T: NumberFieldType> RenderOnce for NumberField<T> {
 
                         increment.child(
                             base_button(IconName::Plus)
-                                .id("increment_button")
+                                .id((self.id.clone(), "increment_button"))
                                 .rounded_tr_sm()
                                 .rounded_br_sm()
-                                .tab_index(
-                                    tab_index
-                                        .as_mut()
-                                        .map(|tab_index| {
-                                            *tab_index += 1;
-                                            *tab_index - 1
-                                        })
-                                        .unwrap_or(0),
-                                )
+                                .when_some(self.tab_index, |this, _| this.tab_index(0isize))
                                 .on_click(increment_handler),
                         )
                     })

--- a/crates/ui_input/src/number_field.rs
+++ b/crates/ui_input/src/number_field.rs
@@ -506,7 +506,7 @@ impl<T: NumberFieldType> RenderOnce for NumberField<T> {
                                     .px_1()
                                     .flex_1()
                                     .justify_center()
-                                    .child(Label::new((self.format)(&self.value)))
+                                    .child(Label::new((self.format)(&self.value)).color(Color::Muted))
                                     .into_any_element(),
                                 NumberFieldMode::Edit => {
                                     let expected_text = format!("{}", self.value);
@@ -520,6 +520,7 @@ impl<T: NumberFieldType> RenderOnce for NumberField<T> {
                                                 let mut editor = Editor::single_line(window, cx);
 
                                                 editor.set_text_style_refinement(TextStyleRefinement {
+                                                    color: Some(cx.theme().colors().text),
                                                     text_align: Some(TextAlign::Center),
                                                     ..Default::default()
                                                 });

--- a/crates/ui_input/src/number_field.rs
+++ b/crates/ui_input/src/number_field.rs
@@ -633,7 +633,10 @@ impl<T: NumberFieldType> RenderOnce for NumberField<T> {
 
                                     h_flex()
                                         .flex_1()
-                                        .track_focus(&configured_handle)
+                                        .track_focus(&focus_handle)
+                                        .border_1()
+                                        .border_color(cx.theme().colors().border_transparent)
+                                        .when(focus_handle.is_focused(window), |this| this.border_color(cx.theme().colors().border_focused))
                                         .child(editor)
                                         .on_action::<menu::Confirm>({
                                             move |_, window, _| {

--- a/crates/ui_input/src/number_field.rs
+++ b/crates/ui_input/src/number_field.rs
@@ -11,9 +11,7 @@ use gpui::{
     TextStyleRefinement, WeakEntity,
 };
 
-use settings::{
-    CenteredPaddingSettings, CodeFade, DelayMs, FontSize, InactiveOpacity, MinimumContrast,
-};
+use settings::{CenteredPaddingSettings, CodeFade, DelayMs, InactiveOpacity, MinimumContrast};
 use ui::prelude::*;
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
@@ -107,7 +105,6 @@ macro_rules! impl_newtype_numeric_stepper_int {
 #[rustfmt::skip]
 impl_newtype_numeric_stepper_float!(FontWeight, 50., 100., 10., FontWeight::THIN, FontWeight::BLACK);
 impl_newtype_numeric_stepper_float!(CodeFade, 0.1, 0.2, 0.05, 0.0, 0.9);
-impl_newtype_numeric_stepper_float!(FontSize, 1.0, 4.0, 0.5, 6.0, 72.0);
 impl_newtype_numeric_stepper_float!(InactiveOpacity, 0.1, 0.2, 0.05, 0.0, 1.0);
 impl_newtype_numeric_stepper_float!(MinimumContrast, 1., 10., 0.5, 0.0, 106.0);
 impl_newtype_numeric_stepper_int!(DelayMs, 100, 500, 10, 0, 2000);


### PR DESCRIPTION
Follow up to https://github.com/zed-industries/zed/pull/45447 and in preparation to enable the edit mode in number field instances within the settings UI. This PR fixes the editor in the number field capturing focus automatically (unnecessary), tab index in the buttons and editor, and other things.

Release Notes:

- N/A
