### PR TITLE
project: Fix organize imports action not working for Python

### DIFF
--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -2052,6 +2052,12 @@ impl LspAdapter for BasedPyrightLspAdapter {
                     }
                     Some(())
                 });
+                // Disable basedpyright's organizeImports so ruff handles it instead
+                if let serde_json::map::Entry::Vacant(v) =
+                    object.entry("basedpyright.disableOrganizeImports")
+                {
+                    v.insert(Value::Bool(true));
+                }
             }
 
             user_settings


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/26819

Explained in https://github.com/zed-industries/zed/issues/26819#issuecomment-3399175027
That action is now the default on format in https://github.com/zed-industries/zed/pull/41103 since October, but applying manually is still broken.

Release Notes:

- Fixed an issue where the `editor: organize imports` action didn’t work for Python, even though imports were organized correctly during formatting.

