### PR TITLE
python: Add support for `uv run` as the shebang line

### DIFF
--- a/crates/languages/src/python/config.toml
+++ b/crates/languages/src/python/config.toml
@@ -1,7 +1,7 @@
 name = "Python"
 grammar = "python"
 path_suffixes = ["py", "pyi", "mpy"]
-first_line_pattern = '^#!.*\bpython[0-9.]*\b'
+first_line_pattern = '^#!.*((\bpython[0-9.]*\b)|(\buv run\b))'
 line_comments = ["# "]
 autoclose_before = ";:.,=}])>"
 brackets = [


### PR DESCRIPTION
`uv run` can be used to specify a shebang for a Python script.

See: https://docs.astral.sh/uv/guides/scripts/#using-a-shebang-to-create-an-executable-file

Release Notes:

- Added support for `uv run` in the shebang line to be interpreted as a Python script