### PR TITLE
Fixes a doc link to the license detection code

### DIFF
--- a/docs/src/ai/ai-improvement.md
+++ b/docs/src/ai/ai-improvement.md
@@ -51,7 +51,7 @@ Users who are working on open source licensed projects may optionally opt-in to 
 
 When working on other projects where you haven't opted-in, Zed will not persistently store user content or use user content for training of its models.
 
-You can see exactly how Zed detects open source licenses in: [license_detection.rs](https://github.com/zed-industries/zed/blob/main/crates/zeta/src/license_detection.rs).
+You can see exactly how Zed detects open source licenses in: [license_detection.rs](https://github.com/zed-industries/zed/blob/main/crates/edit_prediction/src/license_detection.rs).
 
 ### Exclusions
 


### PR DESCRIPTION
The existing link was 404-ing as the crate was renamed.

Not attached to any issue.

Release Notes:

- N/A
