### PR TITLE
auto_update_ui: Add error fallback for viewing release notes locally

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1400,7 +1400,6 @@ dependencies = [
  "client",
  "editor",
  "gpui",
- "http_client",
  "markdown_preview",
  "release_channel",
  "semver",

--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -250,26 +250,28 @@ pub fn check(_: &Check, window: &mut Window, cx: &mut App) {
     }
 }
 
-pub fn view_release_notes(_: &ViewReleaseNotes, cx: &mut App) -> Option<()> {
-    let auto_updater = AutoUpdater::get(cx)?;
+pub fn release_notes_url(cx: &mut App) -> Option<String> {
     let release_channel = ReleaseChannel::try_global(cx)?;
-
-    match release_channel {
+    let url = match release_channel {
         ReleaseChannel::Stable | ReleaseChannel::Preview => {
+            let auto_updater = AutoUpdater::get(cx)?;
             let auto_updater = auto_updater.read(cx);
-            let current_version = auto_updater.current_version.clone();
+            let current_version = &auto_updater.current_version;
             let release_channel = release_channel.dev_name();
             let path = format!("/releases/{release_channel}/{current_version}");
-            let url = &auto_updater.client.http_client().build_url(&path);
-            cx.open_url(url);
+            auto_updater.client.http_client().build_url(&path)
         }
         ReleaseChannel::Nightly => {
-            cx.open_url("https://github.com/zed-industries/zed/commits/nightly/");
+            "https://github.com/zed-industries/zed/commits/nightly/".to_string()
         }
-        ReleaseChannel::Dev => {
-            cx.open_url("https://github.com/zed-industries/zed/commits/main/");
-        }
-    }
+        ReleaseChannel::Dev => "https://github.com/zed-industries/zed/commits/main/".to_string(),
+    };
+    Some(url)
+}
+
+pub fn view_release_notes(_: &ViewReleaseNotes, cx: &mut App) -> Option<()> {
+    let url = release_notes_url(cx)?;
+    cx.open_url(&url);
     None
 }
 

--- a/crates/auto_update_ui/Cargo.toml
+++ b/crates/auto_update_ui/Cargo.toml
@@ -17,7 +17,6 @@ auto_update.workspace = true
 client.workspace = true
 editor.workspace = true
 gpui.workspace = true
-http_client.workspace = true
 markdown_preview.workspace = true
 release_channel.workspace = true
 semver.workspace = true


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/42140

Changes:

- Add show_view_release_notes_locally_error to prompt users when the operation fails.

<img width="1536" height="864" alt="image" src="https://github.com/user-attachments/assets/265bbf7e-6931-4559-99b2-7c1d8fbcd6cc" />

Release Notes:

- Added a notification with a link to view release notes online when Zed can’t load them locally.
