### PR TITLE
extension_host: Add error context to add_extension_to_index

### DIFF
--- a/crates/extension_host/src/extension_host.rs
+++ b/crates/extension_host/src/extension_host.rs
@@ -1555,7 +1555,7 @@ impl ExtensionStore {
                 let config = fs
                     .load(&language_config_path)
                     .await
-                    .with_context(|| format!("language config {language_config_path:?}"))?;
+                    .with_context(|| format!("loading language config from {language_config_path:?}"))?;
                 let config = ::toml::from_str::<LanguageConfig>(&config)?;
 
                 let relative_path = relative_path.to_path_buf();

--- a/crates/extension_host/src/extension_host.rs
+++ b/crates/extension_host/src/extension_host.rs
@@ -1534,12 +1534,14 @@ impl ExtensionStore {
         let is_dev = fs
             .metadata(&extension_dir)
             .await?
-            .context("directory does not exist")?
+            .with_context(|| format!("extension directory {extension_dir:?}"))?
             .is_symlink;
 
-        if let Ok(mut language_paths) = fs.read_dir(&extension_dir.join("languages")).await {
+        let language_dir = extension_dir.join("languages");
+        if let Ok(mut language_paths) = fs.read_dir(&language_dir).await {
             while let Some(language_path) = language_paths.next().await {
-                let language_path = language_path?;
+                let language_path =
+                    language_path.with_context(|| format!("language {language_dir:?}"))?;
                 let Ok(relative_path) = language_path.strip_prefix(&extension_dir) else {
                     continue;
                 };
@@ -1549,7 +1551,11 @@ impl ExtensionStore {
                 if !fs_metadata.is_dir {
                     continue;
                 }
-                let config = fs.load(&language_path.join("config.toml")).await?;
+                let language_config_path = language_path.join("config.toml");
+                let config = fs
+                    .load(&language_config_path)
+                    .await
+                    .with_context(|| format!("language config {language_config_path:?}"))?;
                 let config = ::toml::from_str::<LanguageConfig>(&config)?;
 
                 let relative_path = relative_path.to_path_buf();

--- a/crates/extension_host/src/extension_host.rs
+++ b/crates/extension_host/src/extension_host.rs
@@ -1540,8 +1540,8 @@ impl ExtensionStore {
         let language_dir = extension_dir.join("languages");
         if let Ok(mut language_paths) = fs.read_dir(&language_dir).await {
             while let Some(language_path) = language_paths.next().await {
-                let language_path =
-                    language_path.with_context(|| format!("reading entries in language dir {language_dir:?}"))?;
+                let language_path = language_path
+                    .with_context(|| format!("reading entries in language dir {language_dir:?}"))?;
                 let Ok(relative_path) = language_path.strip_prefix(&extension_dir) else {
                     continue;
                 };
@@ -1552,10 +1552,9 @@ impl ExtensionStore {
                     continue;
                 }
                 let language_config_path = language_path.join("config.toml");
-                let config = fs
-                    .load(&language_config_path)
-                    .await
-                    .with_context(|| format!("loading language config from {language_config_path:?}"))?;
+                let config = fs.load(&language_config_path).await.with_context(|| {
+                    format!("loading language config from {language_config_path:?}")
+                })?;
                 let config = ::toml::from_str::<LanguageConfig>(&config)?;
 
                 let relative_path = relative_path.to_path_buf();

--- a/crates/extension_host/src/extension_host.rs
+++ b/crates/extension_host/src/extension_host.rs
@@ -1534,7 +1534,7 @@ impl ExtensionStore {
         let is_dev = fs
             .metadata(&extension_dir)
             .await?
-            .with_context(|| format!("extension directory {extension_dir:?}"))?
+            .with_context(|| format!("missing extension directory {extension_dir:?}"))?
             .is_symlink;
 
         let language_dir = extension_dir.join("languages");

--- a/crates/extension_host/src/extension_host.rs
+++ b/crates/extension_host/src/extension_host.rs
@@ -1541,7 +1541,7 @@ impl ExtensionStore {
         if let Ok(mut language_paths) = fs.read_dir(&language_dir).await {
             while let Some(language_path) = language_paths.next().await {
                 let language_path =
-                    language_path.with_context(|| format!("language {language_dir:?}"))?;
+                    language_path.with_context(|| format!("reading entries in language dir {language_dir:?}"))?;
                 let Ok(relative_path) = language_path.strip_prefix(&extension_dir) else {
                     continue;
                 };


### PR DESCRIPTION
Missing required extension files or directories currently result in opaque "Directory not found" errors being logged during the update index phase. This can be frustrating to those developing extensions. Add some context so folks know where to start looking.

Release Notes:

- N/A
