### PR TITLE
Improve support for collecting edit prediction training and eval examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5254,6 +5254,7 @@ dependencies = [
  "text",
  "thiserror 2.0.17",
  "time",
+ "toml 0.8.23",
  "ui",
  "util",
  "uuid",

--- a/crates/edit_prediction/Cargo.toml
+++ b/crates/edit_prediction/Cargo.toml
@@ -56,6 +56,7 @@ telemetry_events.workspace = true
 text.workspace = true
 thiserror.workspace = true
 time.workspace = true
+toml.workspace = true
 ui.workspace = true
 util.workspace = true
 uuid.workspace = true

--- a/crates/edit_prediction/src/capture_example.rs
+++ b/crates/edit_prediction/src/capture_example.rs
@@ -82,6 +82,8 @@ pub fn capture_example(
             name: generate_timestamp_name(),
             repository_url,
             revision,
+            tags: Vec::new(),
+            reasoning: None,
             uncommitted_diff,
             cursor_path: cursor_path.as_std_path().into(),
             cursor_position: String::new(),
@@ -313,6 +315,8 @@ mod tests {
                 name: "test".to_string(),
                 repository_url: "https://github.com/test/repo.git".to_string(),
                 revision: "abc123def456".to_string(),
+                tags: Vec::new(),
+                reasoning: None,
                 uncommitted_diff: indoc! {"
                     --- a/project/src/main.rs
                     +++ b/project/src/main.rs

--- a/crates/edit_prediction/src/capture_example.rs
+++ b/crates/edit_prediction/src/capture_example.rs
@@ -74,7 +74,7 @@ pub fn capture_example(
             cursor_path: cursor_path.as_std_path().into(),
             cursor_position: String::new(),
             edit_history,
-            expected_patch: String::new(),
+            expected_patches: Vec::new(),
         };
         spec.set_cursor_excerpt(&cursor_excerpt, cursor_offset, &line_comment_prefix);
         Ok(spec)
@@ -350,7 +350,7 @@ mod tests {
                          seven();
                 "}
                 .to_string(),
-                expected_patch: "".to_string(),
+                expected_patches: Vec::new()
             }
         );
     }

--- a/crates/edit_prediction/src/edit_prediction.rs
+++ b/crates/edit_prediction/src/edit_prediction.rs
@@ -2046,7 +2046,9 @@ impl EditPredictionStore {
             "Edit Prediction Rated",
             rating,
             inputs = prediction.inputs,
-            output = prediction.edit_preview.as_unified_diff(&prediction.edits),
+            output = prediction
+                .edit_preview
+                .as_unified_diff(prediction.snapshot.file(), &prediction.edits),
             feedback
         );
         self.client.telemetry().flush_events().detach();

--- a/crates/edit_prediction/src/edit_prediction.rs
+++ b/crates/edit_prediction/src/edit_prediction.rs
@@ -688,12 +688,14 @@ impl EditPredictionStore {
     pub fn clear_history(&mut self) {
         for project_state in self.projects.values_mut() {
             project_state.events.clear();
+            project_state.last_event.take();
         }
     }
 
     pub fn clear_history_for_project(&mut self, project: &Entity<Project>) {
         if let Some(project_state) = self.projects.get_mut(&project.entity_id()) {
             project_state.events.clear();
+            project_state.last_event.take();
         }
     }
 

--- a/crates/edit_prediction/src/example_spec.rs
+++ b/crates/edit_prediction/src/example_spec.rs
@@ -15,7 +15,7 @@ pub struct ExampleSpec {
     pub cursor_path: Arc<Path>,
     pub cursor_position: String,
     pub edit_history: String,
-    pub expected_patch: String,
+    pub expected_patches: Vec<String>,
 }
 
 const UNCOMMITTED_DIFF_HEADING: &str = "Uncommitted Diff";
@@ -95,13 +95,15 @@ impl ExampleSpec {
 
         _ = writeln!(markdown, "## {}", EXPECTED_PATCH_HEADING);
         markdown.push('\n');
-        _ = writeln!(markdown, "```diff");
-        markdown.push_str(&self.expected_patch);
-        if !markdown.ends_with('\n') {
+        for patch in &self.expected_patches {
+            _ = writeln!(markdown, "```diff");
+            markdown.push_str(patch);
+            if !markdown.ends_with('\n') {
+                markdown.push('\n');
+            }
+            _ = writeln!(markdown, "```");
             markdown.push('\n');
         }
-        _ = writeln!(markdown, "```");
-        markdown.push('\n');
 
         markdown
     }
@@ -118,7 +120,7 @@ impl ExampleSpec {
             cursor_path: Path::new("").into(),
             cursor_position: String::new(),
             edit_history: String::new(),
-            expected_patch: String::new(),
+            expected_patches: Vec::new(),
         };
 
         if let Some(rest) = input.strip_prefix("+++\n")
@@ -212,7 +214,7 @@ impl ExampleSpec {
                             mem::take(&mut text);
                         }
                         Section::ExpectedPatch => {
-                            spec.expected_patch = mem::take(&mut text);
+                            spec.expected_patches.push(mem::take(&mut text));
                         }
                         Section::Start | Section::Other => {}
                     }
@@ -353,7 +355,7 @@ mod tests {
             cursor_path: Path::new("test.rs").into(),
             cursor_position: String::new(),
             edit_history: String::new(),
-            expected_patch: String::new(),
+            expected_patches: Vec::new(),
         };
 
         // Cursor before `42`

--- a/crates/edit_prediction/src/example_spec.rs
+++ b/crates/edit_prediction/src/example_spec.rs
@@ -104,11 +104,11 @@ impl ExampleSpec {
     }
 
     /// Parse an example spec from markdown.
-    pub fn from_markdown(name: String, mut input: &str) -> anyhow::Result<Self> {
+    pub fn from_markdown(mut input: &str) -> anyhow::Result<Self> {
         use pulldown_cmark::{CodeBlockKind, CowStr, Event, HeadingLevel, Parser, Tag, TagEnd};
 
         let mut spec = ExampleSpec {
-            name,
+            name: String::new(),
             repository_url: String::new(),
             revision: String::new(),
             uncommitted_diff: String::new(),
@@ -149,6 +149,9 @@ impl ExampleSpec {
             match event {
                 Event::Text(line) => {
                     text.push_str(&line);
+                }
+                Event::End(TagEnd::Heading(HeadingLevel::H1)) => {
+                    spec.name = mem::take(&mut text);
                 }
                 Event::End(TagEnd::Heading(HeadingLevel::H2)) => {
                     let title = mem::take(&mut text);

--- a/crates/edit_prediction/src/udiff.rs
+++ b/crates/edit_prediction/src/udiff.rs
@@ -157,10 +157,10 @@ pub fn strip_diff_metadata(diff: &str) -> String {
     result
 }
 
-pub fn apply_diff_to_string(original: &str, diff_str: &str) -> Result<String> {
+pub fn apply_diff_to_string(diff_str: &str, text: &str) -> Result<String> {
     let mut diff = DiffParser::new(diff_str);
 
-    let mut text = original.to_string();
+    let mut text = text.to_string();
 
     while let Some(event) = diff.next()? {
         match event {

--- a/crates/edit_prediction/src/udiff.rs
+++ b/crates/edit_prediction/src/udiff.rs
@@ -15,9 +15,7 @@ use collections::HashMap;
 use gpui::AsyncApp;
 use gpui::Entity;
 use language::{Anchor, Buffer, OffsetRangeExt as _, TextBufferSnapshot};
-use project::{Project, ProjectPath};
-use util::paths::PathStyle;
-use util::rel_path::RelPath;
+use project::Project;
 
 #[derive(Clone, Debug)]
 pub struct OpenedBuffers(#[allow(unused)] HashMap<String, Entity<Buffer>>);
@@ -30,27 +28,15 @@ pub async fn apply_diff(
 ) -> Result<OpenedBuffers> {
     let mut included_files = HashMap::default();
 
-    let worktree_id = project.read_with(cx, |project, cx| {
-        anyhow::Ok(
-            project
-                .visible_worktrees(cx)
-                .next()
-                .context("no worktrees")?
-                .read(cx)
-                .id(),
-        )
-    })??;
-
     for line in diff_str.lines() {
         let diff_line = DiffLine::parse(line);
 
         if let DiffLine::OldPath { path } = diff_line {
             let buffer = project
                 .update(cx, |project, cx| {
-                    let project_path = ProjectPath {
-                        worktree_id,
-                        path: RelPath::new(Path::new(path.as_ref()), PathStyle::Posix)?.into_arc(),
-                    };
+                    let project_path = project
+                        .find_project_path(path.as_ref(), cx)
+                        .context("no such path")?;
                     anyhow::Ok(project.open_buffer(project_path, cx))
                 })??
                 .await?;

--- a/crates/edit_prediction_cli/src/anthropic_client.rs
+++ b/crates/edit_prediction_cli/src/anthropic_client.rs
@@ -1,8 +1,10 @@
 use anthropic::{
-    ANTHROPIC_API_URL, Message, Request as AnthropicRequest, RequestContent,
-    Response as AnthropicResponse, Role, non_streaming_completion,
+    ANTHROPIC_API_URL, Event, Message, Request as AnthropicRequest, RequestContent,
+    Response as AnthropicResponse, ResponseContent, Role, Tool, ToolChoice,
+    non_streaming_completion, stream_completion,
 };
 use anyhow::Result;
+use futures::StreamExt as _;
 use http_client::HttpClient;
 use indoc::indoc;
 use reqwest_client::ReqwestClient;
@@ -15,12 +17,12 @@ use std::path::Path;
 use std::sync::Arc;
 
 pub struct PlainLlmClient {
-    http_client: Arc<dyn HttpClient>,
-    api_key: String,
+    pub http_client: Arc<dyn HttpClient>,
+    pub api_key: String,
 }
 
 impl PlainLlmClient {
-    fn new() -> Result<Self> {
+    pub fn new() -> Result<Self> {
         let http_client: Arc<dyn http_client::HttpClient> = Arc::new(ReqwestClient::new());
         let api_key = std::env::var("ANTHROPIC_API_KEY")
             .map_err(|_| anyhow::anyhow!("ANTHROPIC_API_KEY environment variable not set"))?;
@@ -30,7 +32,7 @@ impl PlainLlmClient {
         })
     }
 
-    async fn generate(
+    pub async fn generate(
         &self,
         model: &str,
         max_tokens: u64,
@@ -60,6 +62,172 @@ impl PlainLlmClient {
         )
         .await
         .map_err(|e| anyhow::anyhow!("{:?}", e))?;
+
+        Ok(response)
+    }
+
+    pub async fn generate_streaming<F>(
+        &self,
+        model: &str,
+        max_tokens: u64,
+        messages: Vec<Message>,
+        mut on_progress: F,
+    ) -> Result<AnthropicResponse>
+    where
+        F: FnMut(usize, &str),
+    {
+        let request = AnthropicRequest {
+            model: model.to_string(),
+            max_tokens,
+            messages,
+            tools: Vec::new(),
+            thinking: None,
+            tool_choice: None,
+            system: None,
+            metadata: None,
+            stop_sequences: Vec::new(),
+            temperature: None,
+            top_k: None,
+            top_p: None,
+        };
+
+        let mut stream = stream_completion(
+            self.http_client.as_ref(),
+            ANTHROPIC_API_URL,
+            &self.api_key,
+            request,
+            None,
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("{:?}", e))?;
+
+        let mut response: Option<AnthropicResponse> = None;
+        let mut text_content = String::new();
+
+        while let Some(event_result) = stream.next().await {
+            let event = event_result.map_err(|e| anyhow::anyhow!("{:?}", e))?;
+
+            match event {
+                Event::MessageStart { message } => {
+                    response = Some(message);
+                }
+                Event::ContentBlockDelta { delta, .. } => {
+                    if let anthropic::ContentDelta::TextDelta { text } = delta {
+                        text_content.push_str(&text);
+                        on_progress(text_content.len(), &text_content);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let mut response = response.ok_or_else(|| anyhow::anyhow!("No response received"))?;
+
+        if response.content.is_empty() && !text_content.is_empty() {
+            response
+                .content
+                .push(ResponseContent::Text { text: text_content });
+        }
+
+        Ok(response)
+    }
+
+    pub async fn generate_with_tools<F>(
+        &self,
+        model: &str,
+        max_tokens: u64,
+        messages: Vec<Message>,
+        tools: Vec<Tool>,
+        tool_choice: Option<ToolChoice>,
+        mut on_progress: F,
+    ) -> Result<AnthropicResponse>
+    where
+        F: FnMut(usize, &str),
+    {
+        let request = AnthropicRequest {
+            model: model.to_string(),
+            max_tokens,
+            messages,
+            tools,
+            thinking: None,
+            tool_choice,
+            system: None,
+            metadata: None,
+            stop_sequences: Vec::new(),
+            temperature: None,
+            top_k: None,
+            top_p: None,
+        };
+
+        let mut stream = stream_completion(
+            self.http_client.as_ref(),
+            ANTHROPIC_API_URL,
+            &self.api_key,
+            request,
+            None,
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("{:?}", e))?;
+
+        let mut response: Option<AnthropicResponse> = None;
+        let mut text_content = String::new();
+        let mut tool_use_blocks: Vec<ResponseContent> = Vec::new();
+        let mut current_tool_name = String::new();
+        let mut current_tool_id = String::new();
+        let mut current_tool_input = String::new();
+
+        while let Some(event_result) = stream.next().await {
+            let event = event_result.map_err(|e| anyhow::anyhow!("{:?}", e))?;
+
+            match event {
+                Event::MessageStart { message } => {
+                    response = Some(message);
+                }
+                Event::ContentBlockStart { content_block, .. } => {
+                    if let ResponseContent::ToolUse { id, name, .. } = content_block {
+                        current_tool_id = id;
+                        current_tool_name = name;
+                        current_tool_input.clear();
+                    }
+                }
+                Event::ContentBlockDelta { delta, .. } => match delta {
+                    anthropic::ContentDelta::TextDelta { text } => {
+                        text_content.push_str(&text);
+                        on_progress(text_content.len(), &text_content);
+                    }
+                    anthropic::ContentDelta::InputJsonDelta { partial_json } => {
+                        current_tool_input.push_str(&partial_json);
+                        on_progress(current_tool_input.len(), &current_tool_input);
+                    }
+                    _ => {}
+                },
+                Event::ContentBlockStop { .. } => {
+                    if !current_tool_name.is_empty() {
+                        let input: serde_json::Value =
+                            serde_json::from_str(&current_tool_input).unwrap_or_default();
+                        tool_use_blocks.push(ResponseContent::ToolUse {
+                            id: std::mem::take(&mut current_tool_id),
+                            name: std::mem::take(&mut current_tool_name),
+                            input,
+                        });
+                        current_tool_input.clear();
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let mut response = response.ok_or_else(|| anyhow::anyhow!("No response received"))?;
+
+        if !text_content.is_empty() {
+            response
+                .content
+                .push(ResponseContent::Text { text: text_content });
+        }
+
+        for tool_block in tool_use_blocks {
+            response.content.push(tool_block);
+        }
 
         Ok(response)
     }
@@ -403,6 +571,29 @@ impl AnthropicClient {
                 batching_llm_client
                     .generate(model, max_tokens, messages)
                     .await
+            }
+            AnthropicClient::Dummy => panic!("Dummy LLM client is not expected to be used"),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub async fn generate_streaming<F>(
+        &self,
+        model: &str,
+        max_tokens: u64,
+        messages: Vec<Message>,
+        on_progress: F,
+    ) -> Result<Option<AnthropicResponse>>
+    where
+        F: FnMut(usize, &str),
+    {
+        match self {
+            AnthropicClient::Plain(plain_llm_client) => plain_llm_client
+                .generate_streaming(model, max_tokens, messages, on_progress)
+                .await
+                .map(Some),
+            AnthropicClient::Batch(_) => {
+                anyhow::bail!("Streaming not supported with batching client")
             }
             AnthropicClient::Dummy => panic!("Dummy LLM client is not expected to be used"),
         }

--- a/crates/edit_prediction_cli/src/distill.rs
+++ b/crates/edit_prediction_cli/src/distill.rs
@@ -1,20 +1,15 @@
-use anyhow::{Result, anyhow};
+use anyhow::Result;
 use std::mem;
 
 use crate::example::Example;
 
 pub async fn run_distill(example: &mut Example) -> Result<()> {
-    let [prediction]: [_; 1] =
-        mem::take(&mut example.predictions)
-            .try_into()
-            .map_err(|preds: Vec<_>| {
-                anyhow!(
-                    "Example has {} predictions, but it should have exactly one",
-                    preds.len()
-                )
-            })?;
+    let predictions = mem::take(&mut example.predictions)
+        .into_iter()
+        .map(|p| p.actual_patch)
+        .collect();
 
-    example.spec.expected_patch = prediction.actual_patch;
+    example.spec.expected_patches = predictions;
     example.prompt = None;
     example.predictions = Vec::new();
     example.score = Vec::new();

--- a/crates/edit_prediction_cli/src/example.rs
+++ b/crates/edit_prediction_cli/src/example.rs
@@ -1,4 +1,4 @@
-use crate::{PredictionProvider, PromptFormat, metrics::ClassificationMetrics};
+use crate::{PredictionProvider, PromptFormat};
 use anyhow::{Context as _, Result};
 use collections::HashMap;
 use edit_prediction::example_spec::ExampleSpec;
@@ -87,7 +87,6 @@ pub struct ExamplePrediction {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ExampleScore {
     pub delta_chr_f: f32,
-    pub line_match: ClassificationMetrics,
 }
 
 impl Example {

--- a/crates/edit_prediction_cli/src/example.rs
+++ b/crates/edit_prediction_cli/src/example.rs
@@ -190,7 +190,11 @@ pub fn read_examples(inputs: &[PathBuf]) -> Vec<Example> {
                     .collect::<Vec<Example>>(),
             ),
             "md" => {
-                examples.push(parse_markdown_example(filename, &content).unwrap());
+                let mut example = parse_markdown_example(&content).unwrap();
+                if example.spec.name.is_empty() {
+                    example.spec.name = filename;
+                }
+                examples.push(example);
             }
             ext => {
                 panic!("{} has invalid example extension `{ext}`", path.display())
@@ -236,8 +240,8 @@ pub fn group_examples_by_repo(examples: &mut [Example]) -> Vec<Vec<&mut Example>
     examples_by_repo.into_values().collect()
 }
 
-fn parse_markdown_example(name: String, input: &str) -> Result<Example> {
-    let spec = ExampleSpec::from_markdown(name, input)?;
+fn parse_markdown_example(input: &str) -> Result<Example> {
+    let spec = ExampleSpec::from_markdown(input)?;
     Ok(Example {
         spec,
         buffer: None,

--- a/crates/edit_prediction_cli/src/format_prompt.rs
+++ b/crates/edit_prediction_cli/src/format_prompt.rs
@@ -86,6 +86,7 @@ impl TeacherPrompt {
     const PROMPT: &str = include_str!("teacher.prompt.md");
     pub(crate) const EDITABLE_REGION_START: &str = "<|editable_region_start|>\n";
     pub(crate) const EDITABLE_REGION_END: &str = "<|editable_region_end|>";
+    pub(crate) const USER_CURSOR_MARKER: &str = "<|user_cursor|>";
 
     /// Truncate edit history to this number of last lines
     const MAX_HISTORY_LINES: usize = 128;
@@ -181,13 +182,15 @@ impl TeacherPrompt {
         result.push_str(Self::EDITABLE_REGION_START);
 
         // TODO: control number of lines around cursor
-        result.push_str(&example.spec.cursor_position);
-        if !example.spec.cursor_position.ends_with('\n') {
+        let (mut excerpt, offset) = example.spec.cursor_excerpt().unwrap();
+        excerpt.insert_str(offset, Self::USER_CURSOR_MARKER);
+        result.push_str(&excerpt);
+        if !result.ends_with('\n') {
             result.push('\n');
         }
 
-        result.push_str(&format!("{}\n", Self::EDITABLE_REGION_END));
-        result.push_str("`````");
+        result.push_str(Self::EDITABLE_REGION_END);
+        result.push_str("\n`````");
 
         result
     }

--- a/crates/edit_prediction_cli/src/format_prompt.rs
+++ b/crates/edit_prediction_cli/src/format_prompt.rs
@@ -30,7 +30,13 @@ pub async fn run_format_prompt(
             let prompt = TeacherPrompt::format_prompt(example);
             example.prompt = Some(ExamplePrompt {
                 input: prompt,
-                expected_output: example.spec.expected_patch.clone(), // TODO
+                // TODO
+                expected_output: example
+                    .spec
+                    .expected_patches
+                    .first()
+                    .context("no expected patches")?
+                    .clone(),
                 format: prompt_format,
             });
         }
@@ -68,8 +74,15 @@ pub async fn run_format_prompt(
                 ))
             })??;
             let prompt = format_zeta_prompt(&input);
-            let expected_output =
-                zeta2_output_for_patch(&input, &example.spec.expected_patch.clone())?;
+            let expected_output = zeta2_output_for_patch(
+                &input,
+                &example
+                    .spec
+                    .expected_patches
+                    .first()
+                    .context("expected patches is empty")?
+                    .clone(),
+            )?;
             example.prompt = Some(ExamplePrompt {
                 input: prompt,
                 expected_output,

--- a/crates/edit_prediction_cli/src/format_prompt.rs
+++ b/crates/edit_prediction_cli/src/format_prompt.rs
@@ -30,13 +30,12 @@ pub async fn run_format_prompt(
             let prompt = TeacherPrompt::format_prompt(example);
             example.prompt = Some(ExamplePrompt {
                 input: prompt,
-                // TODO
                 expected_output: example
                     .spec
                     .expected_patches
                     .first()
-                    .context("no expected patches")?
-                    .clone(),
+                    .cloned()
+                    .unwrap_or_default(),
                 format: prompt_format,
             });
         }

--- a/crates/edit_prediction_cli/src/git.rs
+++ b/crates/edit_prediction_cli/src/git.rs
@@ -1,0 +1,110 @@
+use anyhow::{Context as _, Result};
+use collections::HashMap;
+use futures::lock::{Mutex, OwnedMutexGuard};
+use std::{
+    cell::RefCell,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use crate::paths::REPOS_DIR;
+
+thread_local! {
+    static REPO_LOCKS: RefCell<HashMap<PathBuf, Arc<Mutex<()>>>> = RefCell::new(HashMap::default());
+}
+
+#[must_use]
+pub async fn lock_repo(path: impl AsRef<Path>) -> OwnedMutexGuard<()> {
+    REPO_LOCKS
+        .with(|cell| {
+            cell.borrow_mut()
+                .entry(path.as_ref().to_path_buf())
+                .or_default()
+                .clone()
+        })
+        .lock_owned()
+        .await
+}
+
+pub async fn run_git(repo_path: &Path, args: &[&str]) -> Result<String> {
+    let output = smol::process::Command::new("git")
+        .current_dir(repo_path)
+        .args(args)
+        .output()
+        .await?;
+
+    anyhow::ensure!(
+        output.status.success(),
+        "`git {}` within `{}` failed with status: {}\nstderr:\n{}\nstdout:\n{}",
+        args.join(" "),
+        repo_path.display(),
+        output.status,
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout),
+    );
+    Ok(String::from_utf8(output.stdout)?.trim().to_string())
+}
+
+pub fn parse_repo_url(url: &str) -> Result<(String, String)> {
+    if url.contains('@') {
+        let (_, path) = url.split_once(':').context("expected : in git url")?;
+        let (owner, repo) = path.split_once('/').context("expected / in git url")?;
+        Ok((owner.to_string(), repo.trim_end_matches(".git").to_string()))
+    } else {
+        let parsed = http_client::Url::parse(url)?;
+        let mut segments = parsed.path_segments().context("empty http url")?;
+        let owner = segments.next().context("expected owner")?;
+        let repo = segments.next().context("expected repo")?;
+        Ok((owner.to_string(), repo.trim_end_matches(".git").to_string()))
+    }
+}
+
+pub fn repo_path_for_url(url: &str) -> Result<PathBuf> {
+    let (owner, name) = parse_repo_url(url)?;
+    Ok(REPOS_DIR.join(&owner).join(&name))
+}
+
+pub async fn ensure_repo_cloned(repo_url: &str) -> Result<PathBuf> {
+    let repo_path = repo_path_for_url(repo_url)?;
+    let _lock = lock_repo(&repo_path).await;
+
+    if !repo_path.is_dir() {
+        log::info!("Cloning {} into {:?}", repo_url, repo_path);
+        std::fs::create_dir_all(&repo_path)?;
+        run_git(&repo_path, &["init"]).await?;
+        run_git(&repo_path, &["remote", "add", "origin", repo_url]).await?;
+    }
+
+    // Always fetch to get latest commits
+    run_git(&repo_path, &["fetch", "origin"]).await?;
+
+    // Check if we have a valid HEAD, if not checkout FETCH_HEAD
+    let has_head = run_git(&repo_path, &["rev-parse", "HEAD"]).await.is_ok();
+    if !has_head {
+        // Use reset to set HEAD without needing a branch
+        run_git(&repo_path, &["reset", "--hard", "FETCH_HEAD"]).await?;
+    }
+
+    Ok(repo_path)
+}
+
+pub async fn fetch_if_needed(repo_path: &Path, revision: &str) -> Result<String> {
+    let resolved = run_git(
+        repo_path,
+        &["rev-parse", &format!("{}^{{commit}}", revision)],
+    )
+    .await;
+
+    if let Ok(sha) = resolved {
+        return Ok(sha);
+    }
+
+    if run_git(repo_path, &["fetch", "--depth", "1", "origin", revision])
+        .await
+        .is_err()
+    {
+        run_git(repo_path, &["fetch", "origin"]).await?;
+    }
+
+    run_git(repo_path, &["rev-parse", "FETCH_HEAD"]).await
+}

--- a/crates/edit_prediction_cli/src/load_project.rs
+++ b/crates/edit_prediction_cli/src/load_project.rs
@@ -1,27 +1,19 @@
 use crate::{
     example::{Example, ExampleBuffer, ExampleState},
+    git,
     headless::EpAppState,
-    paths::{REPOS_DIR, WORKTREES_DIR},
+    paths::WORKTREES_DIR,
     progress::{InfoStyle, Progress, Step, StepProgress},
 };
 use anyhow::{Context as _, Result};
-use collections::HashMap;
 use edit_prediction::EditPredictionStore;
 use edit_prediction::udiff::OpenedBuffers;
-use futures::{
-    AsyncWriteExt as _,
-    lock::{Mutex, OwnedMutexGuard},
-};
+use futures::AsyncWriteExt as _;
 use gpui::{AsyncApp, Entity};
 use language::{Anchor, Buffer, LanguageNotFound, ToOffset, ToPoint};
 use project::Project;
 use project::buffer_store::BufferStoreEvent;
-use std::{
-    cell::RefCell,
-    fs,
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use std::{fs, path::PathBuf, sync::Arc};
 
 pub async fn run_load_project(
     example: &mut Example,
@@ -195,17 +187,17 @@ async fn setup_project(
 
 async fn setup_worktree(example: &Example, step_progress: &StepProgress) -> Result<PathBuf> {
     let (repo_owner, repo_name) = example.repo_name().context("failed to get repo name")?;
-    let repo_dir = REPOS_DIR.join(repo_owner.as_ref()).join(repo_name.as_ref());
+    let repo_dir = git::repo_path_for_url(&example.spec.repository_url)?;
     let worktree_path = WORKTREES_DIR
         .join(repo_owner.as_ref())
         .join(repo_name.as_ref());
-    let repo_lock = lock_repo(&repo_dir).await;
+    let repo_lock = git::lock_repo(&repo_dir).await;
 
     if !repo_dir.is_dir() {
         step_progress.set_substatus(format!("cloning {}", repo_name));
         fs::create_dir_all(&repo_dir)?;
-        run_git(&repo_dir, &["init"]).await?;
-        run_git(
+        git::run_git(&repo_dir, &["init"]).await?;
+        git::run_git(
             &repo_dir,
             &["remote", "add", "origin", &example.spec.repository_url],
         )
@@ -213,53 +205,26 @@ async fn setup_worktree(example: &Example, step_progress: &StepProgress) -> Resu
     }
 
     // Resolve the example to a revision, fetching it if needed.
-    let revision = run_git(
-        &repo_dir,
-        &[
-            "rev-parse",
-            &format!("{}^{{commit}}", example.spec.revision),
-        ],
-    )
-    .await;
-    let revision = if let Ok(revision) = revision {
-        revision
-    } else {
-        step_progress.set_substatus("fetching");
-        if run_git(
-            &repo_dir,
-            &["fetch", "--depth", "1", "origin", &example.spec.revision],
-        )
-        .await
-        .is_err()
-        {
-            run_git(&repo_dir, &["fetch", "origin"]).await?;
-        }
-        let revision = run_git(&repo_dir, &["rev-parse", "FETCH_HEAD"]).await?;
-        revision
-    };
+    step_progress.set_substatus("fetching");
+    let revision = git::fetch_if_needed(&repo_dir, &example.spec.revision).await?;
 
     // Create the worktree for this example if needed.
     step_progress.set_substatus("preparing worktree");
     if worktree_path.is_dir() {
-        run_git(&worktree_path, &["clean", "--force", "-d"]).await?;
-        run_git(&worktree_path, &["reset", "--hard", "HEAD"]).await?;
-        run_git(&worktree_path, &["checkout", revision.as_str()]).await?;
+        git::run_git(&worktree_path, &["clean", "--force", "-d"]).await?;
+        git::run_git(&worktree_path, &["reset", "--hard", "HEAD"]).await?;
+        git::run_git(&worktree_path, &["checkout", revision.as_str()]).await?;
     } else {
         let worktree_path_string = worktree_path.to_string_lossy();
-        run_git(
+        let branch_name = example.spec.filename();
+        git::run_git(
             &repo_dir,
-            &["branch", "-f", &example.spec.name, revision.as_str()],
+            &["branch", "-f", &branch_name, revision.as_str()],
         )
         .await?;
-        run_git(
+        git::run_git(
             &repo_dir,
-            &[
-                "worktree",
-                "add",
-                "-f",
-                &worktree_path_string,
-                &example.spec.name,
-            ],
+            &["worktree", "add", "-f", &worktree_path_string, &branch_name],
         )
         .await?;
     }
@@ -301,40 +266,4 @@ async fn apply_edit_history(
     cx: &mut AsyncApp,
 ) -> Result<OpenedBuffers> {
     edit_prediction::udiff::apply_diff(&example.spec.edit_history, project, cx).await
-}
-
-thread_local! {
-    static REPO_LOCKS: RefCell<HashMap<PathBuf, Arc<Mutex<()>>>> = RefCell::new(HashMap::default());
-}
-
-#[must_use]
-pub async fn lock_repo(path: impl AsRef<Path>) -> OwnedMutexGuard<()> {
-    REPO_LOCKS
-        .with(|cell| {
-            cell.borrow_mut()
-                .entry(path.as_ref().to_path_buf())
-                .or_default()
-                .clone()
-        })
-        .lock_owned()
-        .await
-}
-
-async fn run_git(repo_path: &Path, args: &[&str]) -> Result<String> {
-    let output = smol::process::Command::new("git")
-        .current_dir(repo_path)
-        .args(args)
-        .output()
-        .await?;
-
-    anyhow::ensure!(
-        output.status.success(),
-        "`git {}` within `{}` failed with status: {}\nstderr:\n{}\nstdout:\n{}",
-        args.join(" "),
-        repo_path.display(),
-        output.status,
-        String::from_utf8_lossy(&output.stderr),
-        String::from_utf8_lossy(&output.stdout),
-    );
-    Ok(String::from_utf8(output.stdout)?.trim().to_string())
 }

--- a/crates/edit_prediction_cli/src/load_project.rs
+++ b/crates/edit_prediction_cli/src/load_project.rs
@@ -14,15 +14,14 @@ use futures::{
 };
 use gpui::{AsyncApp, Entity};
 use language::{Anchor, Buffer, LanguageNotFound, ToOffset, ToPoint};
+use project::Project;
 use project::buffer_store::BufferStoreEvent;
-use project::{Project, ProjectPath};
 use std::{
     cell::RefCell,
     fs,
     path::{Path, PathBuf},
     sync::Arc,
 };
-use util::{paths::PathStyle, rel_path::RelPath};
 use zeta_prompt::CURSOR_MARKER;
 
 pub async fn run_load_project(

--- a/crates/edit_prediction_cli/src/load_project.rs
+++ b/crates/edit_prediction_cli/src/load_project.rs
@@ -22,7 +22,6 @@ use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
-use zeta_prompt::CURSOR_MARKER;
 
 pub async fn run_load_project(
     example: &mut Example,
@@ -98,16 +97,9 @@ async fn cursor_position(
     let cursor_buffer = project
         .update(cx, |project, cx| project.open_buffer(cursor_path, cx))?
         .await?;
-    let cursor_offset_within_excerpt = example
-        .spec
-        .cursor_position
-        .find(CURSOR_MARKER)
-        .context("missing cursor marker")?;
-    let mut cursor_excerpt = example.spec.cursor_position.clone();
-    cursor_excerpt.replace_range(
-        cursor_offset_within_excerpt..(cursor_offset_within_excerpt + CURSOR_MARKER.len()),
-        "",
-    );
+
+    let (cursor_excerpt, cursor_offset_within_excerpt) = example.spec.cursor_excerpt()?;
+
     let excerpt_offset = cursor_buffer.read_with(cx, |buffer, _cx| {
         let text = buffer.text();
 

--- a/crates/edit_prediction_cli/src/main.rs
+++ b/crates/edit_prediction_cli/src/main.rs
@@ -175,10 +175,6 @@ struct SynthesizeArgs {
     #[clap(long, default_value_t = 100)]
     max_commits: usize,
 
-    /// Only generate examples that require retrieved context to make a correct prediction
-    #[clap(long)]
-    require_context: bool,
-
     /// Ignore state file and reprocess all commits
     #[clap(long)]
     fresh: bool,
@@ -229,7 +225,6 @@ fn main() {
                 count: synth_args.count,
                 max_commits: synth_args.max_commits,
                 output_dir,
-                require_context: synth_args.require_context,
                 fresh: synth_args.fresh,
             };
             smol::block_on(async {

--- a/crates/edit_prediction_cli/src/main.rs
+++ b/crates/edit_prediction_cli/src/main.rs
@@ -151,7 +151,7 @@ struct PredictArgs {
     repetitions: usize,
 }
 
-#[derive(Clone, Copy, Debug, ValueEnum, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, ValueEnum, Serialize, Deserialize)]
 enum PredictionProvider {
     Sweep,
     Mercury,

--- a/crates/edit_prediction_cli/src/main.rs
+++ b/crates/edit_prediction_cli/src/main.rs
@@ -176,7 +176,7 @@ struct SynthesizeArgs {
     max_commits: usize,
 
     /// Output directory for draft examples
-    #[clap(long, default_value = "staging")]
+    #[clap(short = 'o', long)]
     output_dir: PathBuf,
 
     /// Only generate examples that require retrieved context to make a correct prediction

--- a/crates/edit_prediction_cli/src/main.rs
+++ b/crates/edit_prediction_cli/src/main.rs
@@ -175,10 +175,6 @@ struct SynthesizeArgs {
     #[clap(long, default_value_t = 100)]
     max_commits: usize,
 
-    /// Output directory for draft examples
-    #[clap(short = 'o', long)]
-    output_dir: PathBuf,
-
     /// Only generate examples that require retrieved context to make a correct prediction
     #[clap(long)]
     require_context: bool,
@@ -225,11 +221,14 @@ fn main() {
             return;
         }
         Command::Synthesize(synth_args) => {
+            let Some(output_dir) = args.output else {
+                panic!("output dir is required");
+            };
             let config = SynthesizeConfig {
                 repo_url: synth_args.repo.clone(),
                 count: synth_args.count,
                 max_commits: synth_args.max_commits,
-                output_dir: synth_args.output_dir.clone(),
+                output_dir,
                 require_context: synth_args.require_context,
                 fresh: synth_args.fresh,
             };

--- a/crates/edit_prediction_cli/src/main.rs
+++ b/crates/edit_prediction_cli/src/main.rs
@@ -2,6 +2,7 @@ mod anthropic_client;
 mod distill;
 mod example;
 mod format_prompt;
+mod git;
 mod headless;
 mod load_project;
 mod metrics;
@@ -10,6 +11,7 @@ mod predict;
 mod progress;
 mod retrieve_context;
 mod score;
+mod synthesize;
 
 use clap::{Args, CommandFactory, Parser, Subcommand, ValueEnum};
 use edit_prediction::EditPredictionStore;
@@ -28,6 +30,7 @@ use crate::predict::run_prediction;
 use crate::progress::Progress;
 use crate::retrieve_context::run_context_retrieval;
 use crate::score::run_scoring;
+use crate::synthesize::{SynthesizeConfig, run_synthesize};
 
 #[derive(Parser, Debug)]
 #[command(name = "ep")]
@@ -67,6 +70,8 @@ enum Command {
     Distill,
     /// Print aggregated scores
     Eval(PredictArgs),
+    /// Generate eval examples by analyzing git commits from a repository
+    Synthesize(SynthesizeArgs),
     /// Remove git repositories and worktrees
     Clean,
 }
@@ -118,6 +123,9 @@ impl Display for Command {
                     .unwrap()
                     .get_name()
             ),
+            Command::Synthesize(args) => {
+                write!(f, "synthesize --repo={}", args.repo)
+            }
             Command::Clean => write!(f, "clean"),
         }
     }
@@ -151,6 +159,33 @@ enum PredictionProvider {
     Zeta2,
     Teacher,
     TeacherNonBatching,
+}
+
+#[derive(Debug, Args)]
+struct SynthesizeArgs {
+    /// Repository URL (git@github.com:owner/repo or https://...)
+    #[clap(long)]
+    repo: String,
+
+    /// Number of examples to generate
+    #[clap(long, default_value_t = 5)]
+    count: usize,
+
+    /// Maximum commits to scan before giving up
+    #[clap(long, default_value_t = 100)]
+    max_commits: usize,
+
+    /// Output directory for draft examples
+    #[clap(long, default_value = "staging")]
+    output_dir: PathBuf,
+
+    /// Only generate examples that require retrieved context to make a correct prediction
+    #[clap(long)]
+    require_context: bool,
+
+    /// Ignore state file and reprocess all commits
+    #[clap(long)]
+    fresh: bool,
 }
 
 impl EpArgs {
@@ -187,6 +222,23 @@ fn main() {
     match &command {
         Command::Clean => {
             std::fs::remove_dir_all(&*paths::DATA_DIR).unwrap();
+            return;
+        }
+        Command::Synthesize(synth_args) => {
+            let config = SynthesizeConfig {
+                repo_url: synth_args.repo.clone(),
+                count: synth_args.count,
+                max_commits: synth_args.max_commits,
+                output_dir: synth_args.output_dir.clone(),
+                require_context: synth_args.require_context,
+                fresh: synth_args.fresh,
+            };
+            smol::block_on(async {
+                if let Err(e) = run_synthesize(config).await {
+                    eprintln!("Error: {:?}", e);
+                    std::process::exit(1);
+                }
+            });
             return;
         }
         _ => {}
@@ -256,7 +308,7 @@ fn main() {
                                         run_scoring(example, &args, app_state.clone(), cx.clone())
                                             .await?;
                                     }
-                                    Command::Clean => {
+                                    Command::Clean | Command::Synthesize(_) => {
                                         unreachable!()
                                     }
                                 }

--- a/crates/edit_prediction_cli/src/metrics.rs
+++ b/crates/edit_prediction_cli/src/metrics.rs
@@ -160,7 +160,7 @@ fn ngram_delta_to_counts(delta: &CountsDelta) -> Counts {
     for (ngram, &delta) in delta {
         if delta > 0 {
             counts.insert(ngram.clone(), delta as usize);
-        } else {
+        } else if delta < 0 {
             counts.insert(format!("¬{ngram}"), delta.unsigned_abs());
         }
     }

--- a/crates/edit_prediction_cli/src/metrics.rs
+++ b/crates/edit_prediction_cli/src/metrics.rs
@@ -1,34 +1,17 @@
-use collections::{HashMap, HashSet};
-use edit_prediction::udiff::DiffLine;
-use serde::{Deserialize, Serialize};
+use collections::HashMap;
 
 type Counts = HashMap<String, usize>;
 type CountsDelta = HashMap<String, isize>;
 
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
-pub struct ClassificationMetrics {
-    pub true_positives: usize,
-    pub false_positives: usize,
-    pub false_negatives: usize,
+#[derive(Default, Debug, Clone)]
+struct ClassificationMetrics {
+    true_positives: usize,
+    false_positives: usize,
+    false_negatives: usize,
 }
 
 impl ClassificationMetrics {
-    pub fn from_sets(
-        expected: &HashSet<String>,
-        actual: &HashSet<String>,
-    ) -> ClassificationMetrics {
-        let true_positives = expected.intersection(actual).count();
-        let false_positives = actual.difference(expected).count();
-        let false_negatives = expected.difference(actual).count();
-
-        ClassificationMetrics {
-            true_positives,
-            false_positives,
-            false_negatives,
-        }
-    }
-
-    pub fn from_counts(expected: &Counts, actual: &Counts) -> ClassificationMetrics {
+    fn from_counts(expected: &Counts, actual: &Counts) -> ClassificationMetrics {
         let mut true_positives = 0;
         let mut false_positives = 0;
         let mut false_negatives = 0;
@@ -56,27 +39,7 @@ impl ClassificationMetrics {
         }
     }
 
-    pub fn aggregate<'a>(
-        scores: impl Iterator<Item = &'a ClassificationMetrics>,
-    ) -> ClassificationMetrics {
-        let mut true_positives = 0;
-        let mut false_positives = 0;
-        let mut false_negatives = 0;
-
-        for score in scores {
-            true_positives += score.true_positives;
-            false_positives += score.false_positives;
-            false_negatives += score.false_negatives;
-        }
-
-        ClassificationMetrics {
-            true_positives,
-            false_positives,
-            false_negatives,
-        }
-    }
-
-    pub fn precision(&self) -> f64 {
+    fn precision(&self) -> f64 {
         if self.true_positives + self.false_positives == 0 {
             0.0
         } else {
@@ -84,42 +47,13 @@ impl ClassificationMetrics {
         }
     }
 
-    pub fn recall(&self) -> f64 {
+    fn recall(&self) -> f64 {
         if self.true_positives + self.false_negatives == 0 {
             0.0
         } else {
             self.true_positives as f64 / (self.true_positives + self.false_negatives) as f64
         }
     }
-
-    pub fn f1_score(&self) -> f64 {
-        let recall = self.recall();
-        let precision = self.precision();
-        if precision + recall == 0.0 {
-            0.0
-        } else {
-            2.0 * precision * recall / (precision + recall)
-        }
-    }
-}
-
-pub fn line_match_score(
-    expected_patch: &[DiffLine],
-    actual_patch: &[DiffLine],
-) -> ClassificationMetrics {
-    let expected_change_lines = expected_patch
-        .iter()
-        .filter(|line| matches!(line, DiffLine::Addition(_) | DiffLine::Deletion(_)))
-        .map(|line| line.to_string())
-        .collect();
-
-    let actual_change_lines = actual_patch
-        .iter()
-        .filter(|line| matches!(line, DiffLine::Addition(_) | DiffLine::Deletion(_)))
-        .map(|line| line.to_string())
-        .collect();
-
-    ClassificationMetrics::from_sets(&expected_change_lines, &actual_change_lines)
 }
 
 enum ChrfWhitespace {
@@ -135,55 +69,26 @@ const CHR_F_WHITESPACE: ChrfWhitespace = ChrfWhitespace::Ignore;
 /// Computes a delta-chrF score that compares two sets of edits.
 ///
 /// This metric works by:
-/// 1. Reconstructing original, golden (expected result), and actual texts from diffs
-/// 2. Computing n-gram count differences (deltas) between original→golden and original→actual
-/// 3. Comparing these deltas to measure how well actual edits match expected edits
-pub fn delta_chr_f(expected: &[DiffLine], actual: &[DiffLine]) -> f64 {
-    // Reconstruct texts from diffs
-    let mut original_text = String::new(); // state of the text before any edits
-    let mut golden_text = String::new(); // text after applying golden edits
-    let mut actual_text = String::new(); // text after applying actual edits
-
-    for line in expected {
-        match line {
-            DiffLine::Context(s) => {
-                original_text.push_str(s);
-                golden_text.push_str(s);
-            }
-            DiffLine::Deletion(s) => {
-                original_text.push_str(s);
-            }
-            DiffLine::Addition(s) => {
-                golden_text.push_str(s);
-            }
-            _ => {}
-        }
-    }
-
-    for line in actual {
-        match line {
-            DiffLine::Context(s) | DiffLine::Addition(s) => {
-                actual_text.push_str(s);
-            }
-            _ => {}
-        }
-    }
-
-    // Edge case
-    if original_text == golden_text && golden_text == actual_text {
+/// 1. Computing n-gram count differences (deltas) between original→expected and original→actual
+/// 2. Comparing these deltas to measure how well actual edits match expected edits
+///
+/// Returns a score from 0.0 to 100.0, where 100.0 means the actual edits perfectly match
+/// the expected edits.
+pub fn delta_chr_f(original: &str, expected: &str, actual: &str) -> f64 {
+    // Edge case: if all texts are identical, the edits match perfectly
+    if original == expected && expected == actual {
         return 100.0;
     }
 
-    // Compute the metric
-    let original_ngrams = chr_f_ngram_counts(&original_text);
-    let golden_ngrams = chr_f_ngram_counts(&golden_text);
-    let actual_ngrams = chr_f_ngram_counts(&actual_text);
+    let original_ngrams = chr_f_ngram_counts(original);
+    let expected_ngrams = chr_f_ngram_counts(expected);
+    let actual_ngrams = chr_f_ngram_counts(actual);
 
     let mut total_precision = 0.0;
     let mut total_recall = 0.0;
 
     for order in 0..CHR_F_CHAR_ORDER {
-        let expected_delta = compute_ngram_delta(&golden_ngrams[order], &original_ngrams[order]);
+        let expected_delta = compute_ngram_delta(&expected_ngrams[order], &original_ngrams[order]);
         let actual_delta = compute_ngram_delta(&actual_ngrams[order], &original_ngrams[order]);
 
         if expected_delta.is_empty() && actual_delta.is_empty() {
@@ -278,94 +183,68 @@ fn count_ngrams(text: &str, n: usize) -> Counts {
 #[cfg(test)]
 mod test {
     use super::*;
-    use edit_prediction::udiff::DiffLine;
 
     #[test]
     fn test_delta_chr_f_perfect_match() {
-        let diff = vec![
-            DiffLine::Context("fn main() {"),
-            DiffLine::Deletion("    println!(\"Hello\");"),
-            DiffLine::Addition("    println!(\"Hello, World!\");"),
-            DiffLine::Context("}"),
-        ];
+        let original = "fn main() {    println!(\"Hello\");}";
+        let expected = "fn main() {    println!(\"Hello, World!\");}";
 
-        let score = delta_chr_f(&diff, &diff);
+        let score = delta_chr_f(original, expected, expected);
         assert!((score - 100.0).abs() < 1e-2);
     }
 
     #[test]
     fn test_delta_chr_f_wrong_edit() {
         // When the edit is wrong
-        let expected = vec![
-            DiffLine::Context("one "),
-            DiffLine::Deletion("two "),
-            DiffLine::Context("three"),
-        ];
-
-        let actual = vec![
-            DiffLine::Context("one "),
-            DiffLine::Context("two "),
-            DiffLine::Deletion("three"),
-            DiffLine::Addition("four"),
-        ];
+        let original = "one two three";
+        let expected = "one three"; // deleted "two "
+        let actual = "one two four"; // deleted "three", added "four"
 
         // Then the score should be low
-        let score = delta_chr_f(&expected, &actual);
+        let score = delta_chr_f(original, expected, actual);
         assert!(score > 20.0 && score < 40.0);
     }
 
     #[test]
     fn test_delta_chr_f_partial_match() {
-        let expected = vec![
-            DiffLine::Deletion("let x = 42;"),
-            DiffLine::Addition("let x = 100;"),
-        ];
-
-        let actual = vec![
-            DiffLine::Deletion("let x = 42;"),
-            DiffLine::Addition("let x = 99;"),
-        ];
+        let original = "let x = 42;";
+        let expected = "let x = 100;";
+        let actual = "let x = 99;";
 
         // We got the edit location right, but the replacement text is wrong.
         // Deleted ngrams will match, bringing the score somewhere in the middle.
-        let score = delta_chr_f(&expected, &actual);
+        let score = delta_chr_f(original, expected, actual);
         assert!(score > 40.0 && score < 60.0);
     }
 
     #[test]
     fn test_delta_chr_f_missed_edit() {
         // When predictions makes no changes
-        let expected = vec![
-            DiffLine::Context("prefix "),
-            DiffLine::Deletion("old"),
-            DiffLine::Addition("new"),
-            DiffLine::Context(" suffix"),
-        ];
-
-        let actual = vec![
-            DiffLine::Context("prefix "),
-            DiffLine::Context("old"),
-            DiffLine::Context(" suffix"),
-        ];
+        let original = "prefix old suffix";
+        let expected = "prefix new suffix";
+        let actual = "prefix old suffix"; // no change
 
         // Then the score should be low (all expected changes are false negatives)
-        let score = delta_chr_f(&expected, &actual);
+        let score = delta_chr_f(original, expected, actual);
         assert!(score < 20.0);
     }
 
     #[test]
     fn test_delta_chr_f_extra_edit() {
         // When adding unexpected content
-        let expected = vec![DiffLine::Context("hello"), DiffLine::Context("world")];
-
-        let actual = vec![
-            DiffLine::Context("hello"),
-            DiffLine::Addition("extra"),
-            DiffLine::Context("world"),
-        ];
+        let original = "helloworld";
+        let expected = "helloworld"; // no change expected
+        let actual = "helloextraworld"; // added "extra"
 
         // Then the score should be low (all actual changes are false positives)
-        let score = delta_chr_f(&expected, &actual);
+        let score = delta_chr_f(original, expected, actual);
         assert!(score < 20.0);
+    }
+
+    #[test]
+    fn test_delta_chr_f_no_changes() {
+        let text = "unchanged text";
+        let score = delta_chr_f(text, text, text);
+        assert!((score - 100.0).abs() < 1e-2);
     }
 }

--- a/crates/edit_prediction_cli/src/paths.rs
+++ b/crates/edit_prediction_cli/src/paths.rs
@@ -17,6 +17,8 @@ pub static RUN_DIR: LazyLock<PathBuf> = LazyLock::new(|| {
         .join(chrono::Local::now().format("%d-%m-%y-%H_%M_%S").to_string())
 });
 pub static LATEST_EXAMPLE_RUN_DIR: LazyLock<PathBuf> = LazyLock::new(|| DATA_DIR.join("latest"));
+pub static LATEST_FAILED_EXAMPLES_DIR: LazyLock<PathBuf> =
+    LazyLock::new(|| DATA_DIR.join("latest_failed"));
 pub static LLM_CACHE_DB: LazyLock<PathBuf> = LazyLock::new(|| CACHE_DIR.join("llm_cache.sqlite"));
 pub static SYNTHESIZE_STATE_FILE: LazyLock<PathBuf> =
     LazyLock::new(|| DATA_DIR.join("synthesize_state.json"));

--- a/crates/edit_prediction_cli/src/paths.rs
+++ b/crates/edit_prediction_cli/src/paths.rs
@@ -18,6 +18,8 @@ pub static RUN_DIR: LazyLock<PathBuf> = LazyLock::new(|| {
 });
 pub static LATEST_EXAMPLE_RUN_DIR: LazyLock<PathBuf> = LazyLock::new(|| DATA_DIR.join("latest"));
 pub static LLM_CACHE_DB: LazyLock<PathBuf> = LazyLock::new(|| CACHE_DIR.join("llm_cache.sqlite"));
+pub static SYNTHESIZE_STATE_FILE: LazyLock<PathBuf> =
+    LazyLock::new(|| DATA_DIR.join("synthesize_state.json"));
 pub static FAILED_EXAMPLES_DIR: LazyLock<PathBuf> =
     LazyLock::new(|| ensure_dir(&RUN_DIR.join("failed")));
 

--- a/crates/edit_prediction_cli/src/predict.rs
+++ b/crates/edit_prediction_cli/src/predict.rs
@@ -28,11 +28,15 @@ pub async fn run_prediction(
     app_state: Arc<EpAppState>,
     mut cx: AsyncApp,
 ) -> anyhow::Result<()> {
-    if !example.predictions.is_empty() {
-        return Ok(());
-    }
-
     let provider = provider.context("provider is required")?;
+
+    if let Some(existing_prediction) = example.predictions.first() {
+        if existing_prediction.provider == provider {
+            return Ok(());
+        } else {
+            example.predictions.clear();
+        }
+    }
 
     run_context_retrieval(example, app_state.clone(), cx.clone()).await?;
 

--- a/crates/edit_prediction_cli/src/predict.rs
+++ b/crates/edit_prediction_cli/src/predict.rs
@@ -184,7 +184,9 @@ pub async fn run_prediction(
         let actual_patch = prediction
             .and_then(|prediction| {
                 let prediction = prediction.prediction.ok()?;
-                prediction.edit_preview.as_unified_diff(&prediction.edits)
+                prediction
+                    .edit_preview
+                    .as_unified_diff(prediction.snapshot.file(), &prediction.edits)
             })
             .unwrap_or_default();
 

--- a/crates/edit_prediction_cli/src/progress.rs
+++ b/crates/edit_prediction_cli/src/progress.rs
@@ -46,6 +46,7 @@ pub enum Step {
     FormatPrompt,
     Predict,
     Score,
+    Synthesize,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -62,6 +63,7 @@ impl Step {
             Step::FormatPrompt => "Format",
             Step::Predict => "Predict",
             Step::Score => "Score",
+            Step::Synthesize => "Synthesize",
         }
     }
 
@@ -72,6 +74,7 @@ impl Step {
             Step::FormatPrompt => "\x1b[34m",
             Step::Predict => "\x1b[32m",
             Step::Score => "\x1b[31m",
+            Step::Synthesize => "\x1b[36m",
         }
     }
 }

--- a/crates/edit_prediction_cli/src/synthesize.rs
+++ b/crates/edit_prediction_cli/src/synthesize.rs
@@ -1,0 +1,904 @@
+use crate::{
+    anthropic_client::PlainLlmClient,
+    git::{ensure_repo_cloned, run_git},
+    paths::SYNTHESIZE_STATE_FILE,
+    progress::{InfoStyle, Progress, Step},
+};
+use anthropic::{Message, RequestContent, ResponseContent, Role, Tool, ToolChoice};
+use anyhow::Result;
+use collections::{HashMap, HashSet};
+use edit_prediction::{
+    example_spec::{ExampleSpec, INLINE_CURSOR_MARKER},
+    udiff::{apply_diff_to_string, extract_file_diff, strip_diff_metadata},
+};
+use indoc::indoc;
+use serde::{Deserialize, Serialize};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+#[derive(Debug, Clone)]
+pub struct SynthesizeConfig {
+    pub repo_url: String,
+    pub count: usize,
+    pub max_commits: usize,
+    pub output_dir: PathBuf,
+    pub require_context: bool,
+    pub fresh: bool,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct SynthesizeState {
+    repositories: HashMap<String, RepoState>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct RepoState {
+    processed_commits: HashSet<String>,
+    examples_generated: usize,
+}
+
+impl SynthesizeState {
+    fn load() -> Self {
+        if SYNTHESIZE_STATE_FILE.exists() {
+            std::fs::read_to_string(&*SYNTHESIZE_STATE_FILE)
+                .ok()
+                .and_then(|s| serde_json::from_str(&s).ok())
+                .unwrap_or_default()
+        } else {
+            Self::default()
+        }
+    }
+
+    fn save(&self) -> Result<()> {
+        let content = serde_json::to_string_pretty(self)?;
+        std::fs::write(&*SYNTHESIZE_STATE_FILE, content)?;
+        Ok(())
+    }
+
+    fn is_processed(&self, repo_url: &str, commit_sha: &str) -> bool {
+        self.repositories
+            .get(repo_url)
+            .is_some_and(|repo| repo.processed_commits.contains(commit_sha))
+    }
+
+    fn mark_processed(&mut self, repo_url: &str, commit_sha: &str, examples_count: usize) {
+        let repo = self.repositories.entry(repo_url.to_string()).or_default();
+        repo.processed_commits.insert(commit_sha.to_string());
+        repo.examples_generated += examples_count;
+    }
+}
+
+#[derive(Debug)]
+struct CommitInfo {
+    sha: String,
+    parent_sha: String,
+    message: String,
+    diff: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PatternCandidate {
+    file_path: String,
+    edit_history_description: String,
+    expected_patch_description: String,
+    cursor_location_hint: String,
+    reasoning: String,
+    #[serde(default)]
+    requires_context: bool,
+}
+
+#[derive(Debug)]
+struct FormulatedExample {
+    reasoning: String,
+    edit_history: String,
+    cursor_path: String,
+    cursor_excerpt: String,
+    cursor_offset: usize,
+    expected_patch: String,
+    tags: Vec<String>,
+}
+
+pub async fn run_synthesize(config: SynthesizeConfig) -> Result<()> {
+    let mut state = if config.fresh {
+        SynthesizeState::default()
+    } else {
+        SynthesizeState::load()
+    };
+
+    std::fs::create_dir_all(&config.output_dir)?;
+
+    let progress = Progress::global();
+    progress.set_total_examples(config.count);
+
+    let clone_progress = progress.start(Step::Synthesize, "clone");
+    let repo_path = ensure_repo_cloned(&config.repo_url).await?;
+    drop(clone_progress);
+
+    let client = PlainLlmClient::new()?;
+    let mut examples_generated = 0;
+    let mut commits_skipped = 0;
+    let batch_size = config.max_commits;
+
+    'outer: loop {
+        let list_progress = progress.start(Step::Synthesize, "list-commits");
+        let commits = list_commits(&repo_path, batch_size, commits_skipped).await?;
+        drop(list_progress);
+
+        if commits.is_empty() {
+            break;
+        }
+
+        commits_skipped += commits.len();
+
+        for commit in commits {
+            if examples_generated >= config.count {
+                break 'outer;
+            }
+
+            if !config.fresh && state.is_processed(&config.repo_url, &commit.sha) {
+                continue;
+            }
+
+            if should_skip_commit(&commit) {
+                continue;
+            }
+
+            let commit_label = format!(
+                "{} {}",
+                &commit.sha[..8],
+                truncate_message(&commit.message, 40)
+            );
+            let step_progress = Arc::new(progress.start(Step::Synthesize, &commit_label));
+
+            // Turn 1: Identify patterns using tool calls
+            step_progress.set_substatus("identifying patterns...");
+            let patterns = match identify_patterns(
+                &client,
+                &config,
+                &commit,
+                config.count - examples_generated,
+                step_progress.clone(),
+            )
+            .await
+            {
+                Ok(patterns) => patterns,
+                Err(e) => {
+                    step_progress.set_info(format!("error: {:?}", e), InfoStyle::Warning);
+                    state.mark_processed(&config.repo_url, &commit.sha, 0);
+                    state.save()?;
+                    continue;
+                }
+            };
+
+            if patterns.is_empty() {
+                step_progress.set_info("no patterns", InfoStyle::Normal);
+                state.mark_processed(&config.repo_url, &commit.sha, 0);
+                state.save()?;
+                continue;
+            }
+
+            // Turn 2: Formulate each pattern into a precise example
+            let mut valid_examples = Vec::new();
+            for (i, pattern) in patterns.iter().enumerate() {
+                if examples_generated + valid_examples.len() >= config.count {
+                    break;
+                }
+
+                step_progress.set_substatus(format!("formulating {}/{}...", i + 1, patterns.len()));
+
+                // Fetch file contents for this pattern
+                let file_context =
+                    match get_file_context(&repo_path, &commit.sha, &pattern.file_path).await {
+                        Ok(ctx) => ctx,
+                        Err(e) => {
+                            log::warn!(
+                                "Failed to get file context for {}: {:?}",
+                                pattern.file_path,
+                                e
+                            );
+                            continue;
+                        }
+                    };
+
+                // Get file-specific diff
+                let file_diff = match extract_file_diff(&commit.diff, &pattern.file_path) {
+                    Ok(diff) => diff,
+                    Err(e) => {
+                        log::warn!("Failed to extract diff for {}: {:?}", pattern.file_path, e);
+                        continue;
+                    }
+                };
+
+                match formulate_example(
+                    &client,
+                    pattern,
+                    &file_context,
+                    &file_diff,
+                    step_progress.clone(),
+                )
+                .await
+                {
+                    Ok(Some(example)) => {
+                        valid_examples.push(example);
+                    }
+                    Ok(None) => {
+                        log::debug!("Pattern did not produce a valid example");
+                    }
+                    Err(e) => {
+                        log::warn!("Failed to formulate example: {:?}", e);
+                    }
+                }
+            }
+
+            if valid_examples.is_empty() {
+                step_progress.set_info("0 valid", InfoStyle::Normal);
+                state.mark_processed(&config.repo_url, &commit.sha, 0);
+                state.save()?;
+                continue;
+            }
+
+            let count = valid_examples.len();
+            step_progress.set_info(format!("{} valid", count), InfoStyle::Normal);
+
+            // Write valid examples
+            for (i, example) in valid_examples.into_iter().enumerate() {
+                if examples_generated >= config.count {
+                    break;
+                }
+
+                let spec = build_example_spec(
+                    &config.repo_url,
+                    &commit.sha,
+                    &commit.parent_sha,
+                    i,
+                    example,
+                );
+
+                let path = config.output_dir.join(spec.filename() + ".md");
+                std::fs::write(&path, spec.to_markdown())?;
+                examples_generated += 1;
+            }
+
+            state.mark_processed(&config.repo_url, &commit.sha, count);
+            state.save()?;
+        }
+    }
+
+    progress.finalize();
+    Ok(())
+}
+
+fn truncate_message(msg: &str, max_len: usize) -> String {
+    let first_line = msg.lines().next().unwrap_or("");
+    if first_line.len() <= max_len {
+        first_line.to_string()
+    } else {
+        format!("{}...", &first_line[..max_len - 3])
+    }
+}
+
+fn should_skip_commit(commit: &CommitInfo) -> bool {
+    let lines_changed = commit
+        .diff
+        .lines()
+        .filter(|l| l.starts_with('+') || l.starts_with('-'))
+        .count();
+    return lines_changed < 10
+        || lines_changed > 1000
+        || is_non_code_commit(commit)
+        || is_rename_commit(commit);
+}
+
+fn is_non_code_commit(commit: &CommitInfo) -> bool {
+    let non_code_extensions = [
+        ".md", ".txt", ".json", ".yaml", ".yml", ".toml", ".lock", ".svg", ".png", ".jpg", ".gif",
+        ".ico", ".woff", ".ttf", ".eot",
+    ];
+
+    let diff_files: Vec<&str> = commit
+        .diff
+        .lines()
+        .filter(|l| l.starts_with("+++ b/") || l.starts_with("--- a/"))
+        .filter_map(|l| {
+            l.strip_prefix("+++ b/")
+                .or_else(|| l.strip_prefix("--- a/"))
+        })
+        .collect();
+
+    if diff_files.is_empty() {
+        return false;
+    }
+
+    let all_non_code = diff_files
+        .iter()
+        .all(|f| non_code_extensions.iter().any(|ext| f.ends_with(ext)));
+
+    all_non_code
+}
+
+fn is_rename_commit(commit: &CommitInfo) -> bool {
+    commit.diff.contains("similarity index")
+        || commit.diff.contains("rename from")
+        || commit.diff.contains("rename to")
+}
+
+async fn list_commits(
+    repo_path: &Path,
+    max_commits: usize,
+    skip: usize,
+) -> Result<Vec<CommitInfo>> {
+    let output = run_git(
+        repo_path,
+        &[
+            "log",
+            "--no-merges",
+            &format!("--skip={}", skip),
+            &format!("-{}", max_commits),
+            "--format=%H|%P|%s",
+        ],
+    )
+    .await?;
+
+    let mut commits = Vec::new();
+    for line in output.lines() {
+        let parts: Vec<&str> = line.splitn(3, '|').collect();
+        if parts.len() < 3 {
+            continue;
+        }
+        let sha = parts[0].to_string();
+        let parent_sha = parts[1].split_whitespace().next().unwrap_or("").to_string();
+        if parent_sha.is_empty() {
+            continue;
+        }
+        let diff = run_git(repo_path, &["show", "--format=", &sha])
+            .await
+            .unwrap_or_default();
+        commits.push(CommitInfo {
+            sha,
+            parent_sha,
+            message: parts[2].to_string(),
+            diff,
+        });
+    }
+
+    Ok(commits)
+}
+
+#[derive(Debug)]
+struct FileContext {
+    before_content: String,
+    after_content: String,
+}
+
+async fn get_file_context(
+    repo_path: &Path,
+    commit_sha: &str,
+    file_path: &str,
+) -> Result<FileContext> {
+    let after_content = run_git(
+        repo_path,
+        &["show", &format!("{}:{}", commit_sha, file_path)],
+    )
+    .await
+    .unwrap_or_default();
+
+    let before_content = run_git(
+        repo_path,
+        &["show", &format!("{}^:{}", commit_sha, file_path)],
+    )
+    .await
+    .unwrap_or_default();
+
+    Ok(FileContext {
+        before_content,
+        after_content,
+    })
+}
+
+fn build_tools() -> Vec<Tool> {
+    vec![
+        Tool {
+            name: "formulate_example".to_string(),
+            description: "Request to formulate a precise edit prediction example. Call this when you've identified a predictable pattern in the commit.".to_string(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "file_path": {
+                        "type": "string",
+                        "description": "Path to the file containing the predictable edit pattern"
+                    },
+                    "edit_history_description": {
+                        "type": "string",
+                        "description": "Description of which changes in the diff establish the pattern (the changes that come BEFORE the predicted edit). Reference specific hunks, line numbers, or code snippets."
+                    },
+                    "expected_patch_description": {
+                        "type": "string",
+                        "description": "Description of which change should be predicted (the change that logically follows from the edit history). This should be a small change (1-10 lines)."
+                    },
+                    "cursor_location_hint": {
+                        "type": "string",
+                        "description": "Description of where the cursor should be positioned - this is the location where the expected patch will be applied, described relative to surrounding code."
+                    },
+                    "reasoning": {
+                        "type": "string",
+                        "description": "2-4 sentences explaining why this is a predictable pattern. What establishes the pattern? Why would the expected patch logically follow?"
+                    },
+                    "requires_context": {
+                        "type": "boolean",
+                        "description": "Whether this prediction requires information from outside the immediate edit history (e.g., type definitions, function signatures from elsewhere in the file)"
+                    }
+                },
+                "required": ["file_path", "edit_history_description", "expected_patch_description", "cursor_location_hint", "reasoning"]
+            }),
+        },
+        Tool {
+            name: "no_predictable_pattern".to_string(),
+            description: "Indicate that no good predictable edit pattern was found in this commit.".to_string(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "reason": {
+                        "type": "string",
+                        "description": "Brief explanation of why no good predictable pattern exists in this commit"
+                    }
+                },
+                "required": ["reason"]
+            }),
+        },
+    ]
+}
+
+fn build_identification_prompt(
+    config: &SynthesizeConfig,
+    commit: &CommitInfo,
+    max_patterns: usize,
+) -> String {
+    let context_guidance = if config.require_context {
+        indoc! {r#"
+            IMPORTANT: Only identify patterns where a correct prediction REQUIRES information from outside the immediate edit history.
+
+            Look specifically for patterns where:
+            - A type/struct definition was changed, and usages need updating based on the NEW field names or types
+            - A function signature was modified, and call sites need updating based on the NEW parameters
+            - A new enum variant, struct field, or method was added, and other code needs to reference it
+            - An API pattern changed, and the prediction needs to know the new pattern from a definition
+
+            Do NOT identify patterns where:
+            - The pattern is purely mechanical (find/replace style)
+            - The edit history alone contains enough information to infer the change
+            - The prediction could be made just by looking at the immediate cursor context
+        "#}
+    } else {
+        ""
+    };
+
+    format!(
+        indoc! {r#"
+            You are analyzing a git commit to find "predictable edit" patterns for an edit prediction evaluation dataset.
+
+            A predictable edit is one where:
+            - A developer makes code changes in one or more locations
+            - Similar or related code changes need to be made elsewhere
+            - The pattern is clear enough that a model could predict the remaining changes after seeing the initial ones
+            - The expected patch is small
+
+            GOOD examples of predictable edits:
+            - Adding a new parameter to a function, then updating call sites to pass the new argument
+            - Adding a feature flag check in one place, then adding it to similar places
+            - Changing an API pattern (e.g., sync to async), then updating other usages
+            - Adding error handling to one function call, then adding similar handling to related calls
+
+            BAD examples (DO NOT identify these):
+            - File renames and updating import paths
+            - Simple find-and-replace style changes
+            - Changes that only involve string literals, comments, or configuration
+
+            {context_guidance}
+
+            ## Commit Information
+
+            Repository: {repo_url}
+            Commit: {sha}
+            Message: {message}
+
+            ## Diff
+
+            ```diff
+            {diff}
+            ```
+
+            ## Your Task
+
+            Analyze this commit and identify up to {max_patterns} predictable edit pattern(s).
+
+            For each pattern you find, call the `formulate_example` tool with details about the pattern.
+            If no good patterns exist in this commit, call `no_predictable_pattern` with a brief reason.
+
+            Remember:
+            - Focus on code changes, not paths/comments/strings
+            - The edit history establishes a pattern; the expected patch follows that pattern
+        "#},
+        context_guidance = context_guidance,
+        repo_url = config.repo_url,
+        sha = commit.sha,
+        message = commit.message,
+        diff = commit.diff,
+        max_patterns = max_patterns,
+    )
+}
+
+async fn identify_patterns(
+    client: &PlainLlmClient,
+    config: &SynthesizeConfig,
+    commit: &CommitInfo,
+    max_patterns: usize,
+    step_progress: Arc<crate::progress::StepProgress>,
+) -> Result<Vec<PatternCandidate>> {
+    let prompt = build_identification_prompt(config, commit, max_patterns);
+    let tools = build_tools();
+    let messages = vec![Message {
+        role: Role::User,
+        content: vec![RequestContent::Text {
+            text: prompt,
+            cache_control: None,
+        }],
+    }];
+
+    let response = client
+        .generate_with_tools(
+            "claude-sonnet-4-20250514",
+            4096,
+            messages,
+            tools,
+            Some(ToolChoice::Any),
+            |bytes, _text| {
+                step_progress.set_substatus(format!("identifying: {:.1}kb", bytes as f64 / 1000.0));
+            },
+        )
+        .await?;
+
+    let mut patterns = Vec::new();
+    for content in &response.content {
+        if let ResponseContent::ToolUse { name, input, .. } = content {
+            if name == "formulate_example" {
+                if let Ok(candidate) = serde_json::from_value::<PatternCandidate>(input.clone()) {
+                    patterns.push(candidate);
+                }
+            } else if name == "no_predictable_pattern" {
+                return Ok(Vec::new());
+            }
+        }
+    }
+
+    Ok(patterns)
+}
+
+fn build_formulation_prompt(
+    pattern: &PatternCandidate,
+    file_context: &FileContext,
+    file_diff: &str,
+) -> String {
+    format!(
+        indoc! {r#"
+        You are formulating a precise edit prediction example based on a pattern that was identified in a commit.
+
+        ## Pattern Description
+
+        **File:** {file_path}
+
+        **Edit History (changes that establish the pattern):**
+        {edit_history_description}
+
+        **Expected Patch (change to be predicted):**
+        {expected_patch_description}
+
+        **Cursor Location:**
+        {cursor_location_hint}
+
+        **Reasoning:**
+        {reasoning}
+
+        **Requires Context:** {requires_context}
+
+        ## File Contents BEFORE the Commit
+
+        ```
+        {before_content}
+        ```
+
+        ## File Contents AFTER the Commit
+
+        ```
+        {after_content}
+        ```
+
+        ## Diff for This File
+
+        ```diff
+        {file_diff}
+        ```
+
+        ## Your Task
+
+        Formulate the precise example in the following format. Be exact with the diff syntax and cursor positioning.
+
+        CRITICAL RULES:
+        1. The CURSOR_POSITION excerpt must show the file state AFTER the edit_history changes have been applied, but BEFORE the expected_patch is applied.
+        2. The cursor marker should point to code that WILL BE CHANGED by the expected_patch.
+        3. The expected_patch must be a valid unified diff that applies to the cursor position context.
+        4. Place the cursor marker <|user_cursor|> INLINE at the exact position where the cursor should be. For example: `func(<|user_cursor|>)` or `let x = <|user_cursor|>value`.
+
+        Output your response in this EXACT format:
+
+        EDIT_HISTORY:
+        ```diff
+        --- a/{file_path}
+        +++ b/{file_path}
+        @@ -<line>,<count> +<line>,<count> @@
+         <context line>
+        -<removed line>
+        +<added line>
+         <context line>
+        ```
+
+        CURSOR_POSITION:
+        ```
+        <5-15 lines of code showing the file state AFTER edit_history is applied, with the cursor marker>
+        ```
+
+        EXPECTED_PATCH:
+        ```diff
+        --- a/{file_path}
+        +++ b/{file_path}
+        @@ -<line>,<count> +<line>,<count> @@
+         <context line>
+        -<removed line>
+        +<added line>
+         <context line>
+        ```
+
+        If you cannot formulate a valid example (e.g., the pattern doesn't work as described), respond with:
+        CANNOT_FORMULATE: <reason>
+    "#},
+        file_path = pattern.file_path,
+        edit_history_description = pattern.edit_history_description,
+        expected_patch_description = pattern.expected_patch_description,
+        cursor_location_hint = pattern.cursor_location_hint,
+        reasoning = pattern.reasoning,
+        requires_context = pattern.requires_context,
+        before_content = file_context.before_content,
+        after_content = file_context.after_content,
+        file_diff = file_diff,
+    )
+}
+
+async fn formulate_example(
+    client: &PlainLlmClient,
+    pattern: &PatternCandidate,
+    file_context: &FileContext,
+    file_diff: &str,
+    step_progress: Arc<crate::progress::StepProgress>,
+) -> Result<Option<FormulatedExample>> {
+    let prompt = build_formulation_prompt(pattern, file_context, file_diff);
+
+    let messages = vec![Message {
+        role: Role::User,
+        content: vec![RequestContent::Text {
+            text: prompt,
+            cache_control: None,
+        }],
+    }];
+
+    let response = client
+        .generate_streaming(
+            "claude-sonnet-4-20250514",
+            8192,
+            messages,
+            |chars, _text| {
+                step_progress.set_substatus(format!("formulating: {:.1}K", chars as f64 / 1000.0));
+            },
+        )
+        .await?;
+
+    let response_text = response
+        .content
+        .iter()
+        .filter_map(|block| {
+            if let ResponseContent::Text { text } = block {
+                Some(text.as_str())
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    if response_text.contains("CANNOT_FORMULATE:") {
+        return Ok(None);
+    }
+
+    parse_formulated_example(&response_text, pattern, file_context)
+}
+
+fn parse_formulated_example(
+    response: &str,
+    pattern: &PatternCandidate,
+    file_context: &FileContext,
+) -> Result<Option<FormulatedExample>> {
+    let mut edit_history = String::new();
+    let mut cursor_position = String::new();
+    let mut expected_patch = String::new();
+
+    #[derive(PartialEq)]
+    enum Section {
+        None,
+        EditHistory,
+        CursorPosition,
+        ExpectedPatch,
+    }
+
+    let mut current_section = Section::None;
+    let mut in_code_block = false;
+    let mut current_block = String::new();
+
+    for line in response.lines() {
+        let trimmed = line.trim();
+
+        if trimmed.starts_with("EDIT_HISTORY:") {
+            current_section = Section::EditHistory;
+            continue;
+        } else if trimmed.starts_with("CURSOR_POSITION:") {
+            current_section = Section::CursorPosition;
+            continue;
+        } else if trimmed.starts_with("EXPECTED_PATCH:") {
+            current_section = Section::ExpectedPatch;
+            continue;
+        }
+
+        if trimmed.starts_with("```") {
+            if in_code_block {
+                in_code_block = false;
+                match current_section {
+                    Section::EditHistory => {
+                        edit_history = current_block.trim().to_string();
+                    }
+                    Section::CursorPosition => {
+                        cursor_position = current_block.trim().to_string();
+                    }
+                    Section::ExpectedPatch => {
+                        expected_patch = current_block.trim().to_string();
+                    }
+                    Section::None => {}
+                }
+                current_block.clear();
+            } else {
+                in_code_block = true;
+                current_block.clear();
+            }
+            continue;
+        }
+
+        if in_code_block {
+            current_block.push_str(line);
+            current_block.push('\n');
+        }
+    }
+
+    if cursor_position.is_empty() || expected_patch.is_empty() {
+        return Ok(None);
+    }
+
+    let edit_history = strip_diff_metadata(&edit_history);
+    let expected_patch = strip_diff_metadata(&expected_patch);
+
+    let cursor_offset = match cursor_position.find(INLINE_CURSOR_MARKER) {
+        Some(offset) => offset,
+        None => {
+            log::debug!("Cursor position missing cursor marker");
+            return Ok(None);
+        }
+    };
+    let cursor_excerpt = format!(
+        "{}{}",
+        &cursor_position[..cursor_offset],
+        &cursor_position[cursor_offset + INLINE_CURSOR_MARKER.len()..]
+    );
+
+    // Compute the intermediate state by applying edit_history to before_content
+    let intermediate_state = if edit_history.is_empty() {
+        file_context.before_content.clone()
+    } else {
+        match apply_diff_to_string(&file_context.before_content, &edit_history) {
+            Ok(state) => state,
+            Err(e) => {
+                log::debug!("Edit history failed to apply: {}", e);
+                return Ok(None);
+            }
+        }
+    };
+
+    // Validate that cursor position text actually exists in the intermediate state
+    if !intermediate_state.contains(&cursor_excerpt) {
+        log::debug!("Cursor position text not found in intermediate state");
+        return Ok(None);
+    }
+
+    // Validate that expected_patch applies to the intermediate state
+    if let Err(e) = apply_diff_to_string(&intermediate_state, &expected_patch) {
+        log::debug!(
+            "Expected patch failed to apply to intermediate state: {}",
+            e
+        );
+        return Ok(None);
+    }
+
+    let mut tags = Vec::new();
+    if pattern.requires_context {
+        tags.push("requires-context".to_string());
+    }
+
+    Ok(Some(FormulatedExample {
+        reasoning: pattern.reasoning.clone(),
+        edit_history,
+        cursor_path: pattern.file_path.clone(),
+        cursor_excerpt,
+        cursor_offset,
+        expected_patch,
+        tags,
+    }))
+}
+
+/// Get line comment prefix based on file extension
+fn line_comment_prefix(file_path: &str) -> &'static str {
+    let extension = file_path.rsplit('.').next().unwrap_or("");
+    match extension {
+        "rs" | "c" | "cpp" | "cc" | "h" | "hpp" | "js" | "ts" | "tsx" | "jsx" | "go" | "java"
+        | "swift" | "kt" | "kts" | "scala" | "cs" | "m" | "mm" | "zig" | "v" | "d" => "//",
+        "py" | "rb" | "sh" | "bash" | "zsh" | "pl" | "pm" | "r" | "jl" | "yaml" | "yml"
+        | "toml" | "coffee" | "cr" | "ex" | "exs" | "elixir" => "#",
+        "lua" | "hs" | "sql" => "--",
+        "lisp" | "clj" | "cljs" | "scm" | "rkt" | "el" => ";",
+        "erl" | "hrl" => "%",
+        _ => "//",
+    }
+}
+
+fn build_example_spec(
+    repo_url: &str,
+    commit_sha: &str,
+    parent_sha: &str,
+    index: usize,
+    example: FormulatedExample,
+) -> ExampleSpec {
+    let name = format!(
+        "draft-{}-{}-{}",
+        chrono::Local::now().format("%Y%m%d-%H%M%S"),
+        &commit_sha[..8.min(commit_sha.len())],
+        index
+    );
+
+    let comment_prefix = line_comment_prefix(&example.cursor_path);
+
+    let mut spec = ExampleSpec {
+        name,
+        repository_url: repo_url.to_string(),
+        // Use parent revision as the base state - edit_history transforms from here
+        revision: parent_sha.to_string(),
+        tags: example.tags,
+        reasoning: Some(example.reasoning),
+        uncommitted_diff: String::new(),
+        cursor_path: Path::new(&example.cursor_path).into(),
+        cursor_position: String::new(),
+        edit_history: example.edit_history,
+        expected_patches: vec![example.expected_patch],
+    };
+
+    spec.set_cursor_excerpt(
+        &example.cursor_excerpt,
+        example.cursor_offset,
+        comment_prefix,
+    );
+    spec
+}

--- a/crates/edit_prediction_ui/src/edit_prediction_ui.rs
+++ b/crates/edit_prediction_ui/src/edit_prediction_ui.rs
@@ -150,7 +150,7 @@ fn capture_example_as_markdown(
         .buffer()
         .read(cx)
         .text_anchor_for_position(editor.selections.newest_anchor().head(), cx)?;
-    let example = capture_example(project.clone(), buffer, cursor_anchor, true, cx)?;
+    let example = capture_example(project.clone(), buffer, cursor_anchor, cx)?;
 
     let examples_dir = AllLanguageSettings::get_global(cx)
         .edit_predictions

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -4545,12 +4545,6 @@ impl Project {
                             path: entry.path.clone(),
                         });
                     }
-                    if worktree_store.visible_worktrees(cx).count() == 1 {
-                        return Some(ProjectPath {
-                            worktree_id: worktree.id(),
-                            path: rel_path.into_arc(),
-                        });
-                    }
                 }
             }
         }

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -4538,13 +4538,19 @@ impl Project {
 
             for worktree in worktree_store.visible_worktrees(cx) {
                 let worktree = worktree.read(cx);
-                if let Ok(path) = RelPath::new(path, path_style)
-                    && let Some(entry) = worktree.entry_for_path(&path)
-                {
-                    return Some(ProjectPath {
-                        worktree_id: worktree.id(),
-                        path: entry.path.clone(),
-                    });
+                if let Ok(rel_path) = RelPath::new(path, path_style) {
+                    if let Some(entry) = worktree.entry_for_path(&rel_path) {
+                        return Some(ProjectPath {
+                            worktree_id: worktree.id(),
+                            path: entry.path.clone(),
+                        });
+                    }
+                    if worktree_store.visible_worktrees(cx).count() == 1 {
+                        return Some(ProjectPath {
+                            worktree_id: worktree.id(),
+                            path: rel_path.into_arc(),
+                        });
+                    }
                 }
             }
         }


### PR DESCRIPTION
* Fix some bugs in capture of EP examples from running app
* Tweak markdown format for EP examples
    * Store repo and revision in TOML front matter
    * Represent cursor position using a comment line
* Allow multiple expected patches in evals
* Remove line-based scoring criteria for evals
* Add a `synthesize` subcommand to the EP cli that generates examples from git commits

Release Notes:

- N/A
