### PR TITLE
docs: Remove reference to non-existing binding for `tab switcher: toggle all`

### DIFF
--- a/docs/src/tab-switcher.md
+++ b/docs/src/tab-switcher.md
@@ -20,10 +20,8 @@ the switcher is closed.
 
 ## Opening the Tab Switcher
 
-The Tab Switcher can also be opened with either {#action tab_switcher::Toggle}
-or {#action tab_switcher::ToggleAll}. Using {#kb tab_switcher::Toggle} will show
-only the tabs for the current pane, while {#kb tab_switcher::ToggleAll} shows
-all tabs for all panes.
+The Tab Switcher can also be opened with either {#action tab_switcher::Toggle} ({#kb tab_switcher::Toggle})
+or {#action tab_switcher::ToggleAll}.
 
 While the Tab Switcher is open, you can:
 


### PR DESCRIPTION
There is no default binding for `{#kb tab_switcher::ToggleAll}`, so the doc is rendered as:

<img width="1330" height="227" alt="image" src="https://github.com/user-attachments/assets/a5ce2efd-69c4-4eb4-a28b-3fdb7825ce34" />

Release Notes:

- N/A
