### PR TITLE
docs: Use inline code in `debugger.md`

### DIFF
--- a/docs/src/debugger.md
+++ b/docs/src/debugger.md
@@ -198,7 +198,7 @@ The settings for the debugger are grouped under the `debugger` key in `settings.
 
 1. Statement - The step should allow the program to run until the current statement has finished executing.
    The meaning of a statement is determined by the adapter and it may be considered equivalent to a line.
-   For example 'for(int i = 0; i < 10; i++)' could be considered to have 3 statements 'int i = 0', 'i < 10', and 'i++'.
+   For example `for(int i = 0; i < 10; i++)` could be considered to have 3 statements `int i = 0`, `i < 10`, and `i++`.
 
 ```json [settings]
 {


### PR DESCRIPTION
Release Notes:

- N/A
