### PR TITLE
Add comprehensive rules system with command execution and .rules.d support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12671,6 +12671,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assets",
+ "async-process",
  "chrono",
  "collections",
  "fs",
@@ -12685,6 +12686,9 @@ dependencies = [
  "paths",
  "rope",
  "serde",
+ "serde_json",
+ "serde_yaml",
+ "smol",
  "strum 0.27.2",
  "tempfile",
  "text",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -628,6 +628,7 @@ schemars = { version = "1.0", features = ["indexmap2"] }
 semver = { version = "1.0", features = ["serde"] }
 serde = { version = "1.0.221", features = ["derive", "rc"] }
 serde_json = { version = "1.0.144", features = ["preserve_order", "raw_value"] }
+serde_yaml = "0.9"
 serde_json_lenient = { version = "0.2", features = [
     "preserve_order",
     "raw_value",

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -31,7 +31,7 @@ use gpui::{
     App, AppContext, AsyncApp, Context, Entity, SharedString, Subscription, Task, WeakEntity,
 };
 use language_model::{IconOrSvg, LanguageModel, LanguageModelProvider, LanguageModelRegistry};
-use project::{Project, ProjectItem, ProjectPath, Worktree};
+use project::{Project, ProjectEntryId, ProjectItem, ProjectPath, Worktree, WorktreeId};
 use prompt_store::{
     ProjectContext, PromptStore, RULES_FILE_NAMES, RulesFileContext, UserRulesContext,
     WorktreeContext,
@@ -492,6 +492,8 @@ impl NativeAgent {
     ) -> Option<Task<Result<RulesFileContext>>> {
         let worktree = worktree.read(cx);
         let worktree_id = worktree.id();
+
+        // Check for single rules file
         let selected_rules_file = RULES_FILE_NAMES
             .into_iter()
             .filter_map(|name| {
@@ -502,9 +504,35 @@ impl NativeAgent {
             })
             .next();
 
-        // Note that Cline supports `.clinerules` being a directory, but that is not currently
-        // supported. This doesn't seem to occur often in GitHub repositories.
-        selected_rules_file.map(|path_in_worktree| {
+        // Check for .rules.d directory
+        let rules_dir_entry = worktree
+            .entry_for_path(RelPath::unix(".rules.d").unwrap())
+            .filter(|entry| entry.is_dir());
+
+        // If neither exists, return None
+        if selected_rules_file.is_none() && rules_dir_entry.is_none() {
+            return None;
+        }
+
+        // Load both if available
+        Some(Self::load_combined_rules(
+            worktree_id,
+            selected_rules_file,
+            rules_dir_entry.map(|entry| entry.id),
+            project.clone(),
+            cx,
+        ))
+    }
+
+    fn load_combined_rules(
+        worktree_id: WorktreeId,
+        rules_file_path: Option<Arc<RelPath>>,
+        rules_dir_entry_id: Option<ProjectEntryId>,
+        project: Entity<Project>,
+        cx: &mut App,
+    ) -> Task<Result<RulesFileContext>> {
+        // Load the single rules file if it exists
+        let rules_file_task = rules_file_path.as_ref().map(|path_in_worktree| {
             let project_path = ProjectPath {
                 worktree_id,
                 path: path_in_worktree.clone(),
@@ -517,15 +545,131 @@ impl NativeAgent {
                     anyhow::Ok((project_entry_id, buffer.as_rope().clone()))
                 })?
             });
-            // Build a string from the rope on a background thread.
             cx.background_spawn(async move {
                 let (project_entry_id, rope) = rope_task.await?;
-                anyhow::Ok(RulesFileContext {
-                    path_in_worktree,
-                    text: rope.to_string().trim().to_string(),
-                    project_entry_id: project_entry_id.to_usize(),
-                })
+                anyhow::Ok((rope.to_string().trim().to_string(), project_entry_id))
             })
+        });
+
+        // Load the rules directory if it exists
+        let rules_dir_task = rules_dir_entry_id.map(|dir_entry_id| {
+            Self::load_rules_from_directory_content(worktree_id, dir_entry_id, project.clone(), cx)
+        });
+
+        // Combine both
+        let rules_file_path_for_context = rules_file_path.clone();
+        cx.background_spawn(async move {
+            let mut combined_text = String::new();
+            let mut primary_entry_id = None;
+
+            // Add single rules file content
+            if let Some(task) = rules_file_task {
+                match task.await {
+                    Ok((text, entry_id)) => {
+                        combined_text.push_str(&text);
+                        primary_entry_id = Some(entry_id);
+                    }
+                    Err(e) => log::warn!("Failed to load rules file: {}", e),
+                }
+            }
+
+            // Add rules.d content
+            if let Some(task) = rules_dir_task {
+                match task.await {
+                    Ok((text, entry_id)) => {
+                        if !combined_text.is_empty() && !text.is_empty() {
+                            combined_text.push_str("\n\n");
+                        }
+                        combined_text.push_str(&text);
+                        // Use rules.d entry id if we don't have one yet
+                        if primary_entry_id.is_none() {
+                            primary_entry_id = Some(entry_id);
+                        }
+                    }
+                    Err(e) => log::warn!("Failed to load rules from .rules.d: {}", e),
+                }
+            }
+
+            let path_in_worktree = rules_file_path_for_context
+                .unwrap_or_else(|| RelPath::unix(".rules.d").unwrap().into());
+
+            anyhow::Ok(RulesFileContext {
+                path_in_worktree,
+                text: combined_text,
+                project_entry_id: primary_entry_id.context("no rules loaded")?.to_usize(),
+            })
+        })
+    }
+
+    fn load_rules_from_directory_content(
+        worktree_id: WorktreeId,
+        dir_entry_id: ProjectEntryId,
+        project: Entity<Project>,
+        cx: &mut App,
+    ) -> Task<Result<(String, ProjectEntryId)>> {
+        let worktree = project
+            .read(cx)
+            .worktree_for_id(worktree_id, cx)
+            .and_then(|worktree| Some(worktree.read(cx).snapshot()));
+
+        let snapshot = match worktree {
+            Some(snap) => snap,
+            None => return Task::ready(Err(anyhow!("worktree not found"))),
+        };
+
+        let dir_path = match snapshot.entry_for_id(dir_entry_id) {
+            Some(entry) => entry.path.clone(),
+            None => return Task::ready(Err(anyhow!("directory entry not found"))),
+        };
+
+        // Collect all markdown and text files in .rules.d
+        let mut file_paths = Vec::new();
+        for entry in snapshot.child_entries(&dir_path) {
+            if entry.is_file() {
+                if let Some(ext) = entry.path.extension() {
+                    if ext == "md" || ext == "txt" {
+                        file_paths.push(entry.path.clone());
+                    }
+                }
+            }
+        }
+
+        // Sort files for consistent ordering
+        file_paths.sort();
+
+        if file_paths.is_empty() {
+            return Task::ready(Err(anyhow!("no markdown or text files found in .rules.d")));
+        }
+
+        // Open all files and read their contents
+        let buffer_tasks: Vec<_> = file_paths
+            .iter()
+            .map(|path| {
+                let project_path = ProjectPath {
+                    worktree_id,
+                    path: path.clone(),
+                };
+                project.update(cx, |project, cx| project.open_buffer(project_path, cx))
+            })
+            .collect();
+
+        let rope_task = cx.spawn(async move |cx| {
+            let mut rules_texts = Vec::new();
+            for buffer_task in buffer_tasks {
+                let rope = buffer_task
+                    .await?
+                    .read_with(cx, |buffer, _cx| buffer.as_rope().clone())?;
+                rules_texts.push(rope.to_string().trim().to_string());
+            }
+            anyhow::Ok(rules_texts)
+        });
+
+        // Build concatenated string from all files
+        cx.background_spawn(async move {
+            let rules_texts = rope_task.await?;
+            let combined_text = rules_texts.join("\n\n");
+
+            anyhow::Ok((combined_text, dir_entry_id))
         })
     }
 
@@ -742,6 +886,7 @@ impl NativeAgent {
                         this.project_context.clone(),
                         this.context_server_registry.clone(),
                         this.templates.clone(),
+                        this.prompt_store.clone(),
                         cx,
                     );
                     thread.set_summarization_model(summarization_model, cx);
@@ -1208,6 +1353,7 @@ impl acp_thread::AgentConnection for NativeAgentConnection {
                             agent.context_server_registry.clone(),
                             agent.templates.clone(),
                             default_model,
+                            agent.prompt_store.clone(),
                             cx,
                         )
                     }))
@@ -1573,6 +1719,112 @@ mod internal_tests {
                     })
                 }]
             )
+        });
+    }
+
+    #[gpui::test]
+    async fn test_rules_d_directory(cx: &mut TestAppContext) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            "/",
+            json!({
+                "a": {}
+            }),
+        )
+        .await;
+        let project = Project::test(fs.clone(), [], cx).await;
+        let text_thread_store =
+            cx.new(|cx| assistant_text_thread::TextThreadStore::fake(project.clone(), cx));
+        let history_store = cx.new(|cx| HistoryStore::new(text_thread_store, cx));
+        let agent = NativeAgent::new(
+            project.clone(),
+            history_store,
+            Templates::new(),
+            None,
+            fs.clone(),
+            &mut cx.to_async(),
+        )
+        .await
+        .unwrap();
+
+        let worktree = project
+            .update(cx, |project, cx| project.create_worktree("/a", true, cx))
+            .await
+            .unwrap();
+        cx.run_until_parked();
+
+        // Test 1: .rules.d directory with multiple files
+        fs.insert_tree(
+            "/a",
+            json!({
+                ".rules.d": {
+                    "01-style.md": "# Coding Style\nUse tabs for indentation.",
+                    "02-testing.md": "# Testing\nWrite tests for all functions.",
+                    "03-docs.txt": "# Documentation\nDocument all public APIs."
+                }
+            }),
+        )
+        .await;
+        cx.run_until_parked();
+
+        agent.read_with(cx, |agent, cx| {
+            let context = agent.project_context.read(cx);
+            let rules_file = context.worktrees[0].rules_file.as_ref().unwrap();
+
+            // Check that all files are combined
+            assert!(rules_file.text.contains("Coding Style"));
+            assert!(rules_file.text.contains("Testing"));
+            assert!(rules_file.text.contains("Documentation"));
+
+            // Check they're in alphabetical order
+            let style_pos = rules_file.text.find("Coding Style").unwrap();
+            let testing_pos = rules_file.text.find("Testing").unwrap();
+            let docs_pos = rules_file.text.find("Documentation").unwrap();
+            assert!(style_pos < testing_pos);
+            assert!(testing_pos < docs_pos);
+        });
+
+        // Test 2: Both .rules file and .rules.d directory
+        fs.insert_file(
+            "/a/.rules",
+            "# Main Rules\nThis is the main rules file.".as_bytes(),
+        )
+        .await;
+        cx.run_until_parked();
+
+        agent.read_with(cx, |agent, cx| {
+            let context = agent.project_context.read(cx);
+            let rules_file = context.worktrees[0].rules_file.as_ref().unwrap();
+
+            // Check that both are combined
+            assert!(rules_file.text.contains("Main Rules"));
+            assert!(rules_file.text.contains("Coding Style"));
+            assert!(rules_file.text.contains("Testing"));
+
+            // .rules should come before .rules.d
+            let main_pos = rules_file.text.find("Main Rules").unwrap();
+            let style_pos = rules_file.text.find("Coding Style").unwrap();
+            assert!(main_pos < style_pos);
+        });
+
+        // Test 3: Remove .rules.d and keep only .rules file
+        fs.remove_dir("/a/.rules.d", Default::default())
+            .await
+            .unwrap();
+        cx.run_until_parked();
+
+        agent.read_with(cx, |agent, cx| {
+            let context = agent.project_context.read(cx);
+            let rules_file = context.worktrees[0].rules_file.as_ref().unwrap();
+
+            // Should only have .rules content now
+            assert!(rules_file.text.contains("Main Rules"));
+            assert!(!rules_file.text.contains("Coding Style"));
+            assert_eq!(
+                rules_file.text,
+                "# Main Rules\nThis is the main rules file."
+            );
         });
     }
 

--- a/crates/paths/src/paths.rs
+++ b/crates/paths/src/paths.rs
@@ -310,13 +310,7 @@ pub fn text_threads_dir() -> &'static PathBuf {
 /// This is where the prompts for use with the Assistant are stored.
 pub fn prompts_dir() -> &'static PathBuf {
     static PROMPTS_DIR: OnceLock<PathBuf> = OnceLock::new();
-    PROMPTS_DIR.get_or_init(|| {
-        if cfg!(target_os = "macos") {
-            config_dir().join("prompts")
-        } else {
-            data_dir().join("prompts")
-        }
-    })
+    PROMPTS_DIR.get_or_init(|| config_dir().join("prompts"))
 }
 
 /// Returns the path to the prompt templates directory.

--- a/crates/prompt_store/Cargo.toml
+++ b/crates/prompt_store/Cargo.toml
@@ -28,7 +28,11 @@ parking_lot.workspace = true
 paths.workspace = true
 rope.workspace = true
 serde.workspace = true
+serde_json.workspace = true
+serde_yaml.workspace = true
 strum.workspace = true
+async-process = "2.3"
+smol.workspace = true
 text.workspace = true
 util.workspace = true
 uuid.workspace = true
@@ -36,3 +40,4 @@ uuid.workspace = true
 [dev-dependencies]
 gpui = { workspace = true, features = ["test-support"] }
 tempfile.workspace = true
+

--- a/crates/prompt_store/src/command_approvals.rs
+++ b/crates/prompt_store/src/command_approvals.rs
@@ -1,0 +1,234 @@
+use anyhow::{Context as _, Result};
+use chrono::{DateTime, Utc};
+use fs::Fs;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{Arc, RwLock};
+
+/// Record describing an approval for a command signature.
+///
+/// - `allowed_always`: if true this command is permanently approved (no prompt)
+/// - `allowed_once_count`: number of one-time approvals remaining
+/// - `created_at` / `last_used_at`: timestamps for auditing
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Approval {
+    pub signature: String,
+    pub allowed_always: bool,
+    pub allowed_once_count: u32,
+    pub created_at: DateTime<Utc>,
+    pub last_used_at: Option<DateTime<Utc>>,
+    /// Optional human-readable note (e.g., "allowed on project X")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+}
+
+impl Approval {
+    fn new(
+        signature: String,
+        allowed_always: bool,
+        allowed_once_count: u32,
+        note: Option<String>,
+    ) -> Self {
+        Self {
+            signature,
+            allowed_always,
+            allowed_once_count,
+            created_at: Utc::now(),
+            last_used_at: None,
+            note,
+        }
+    }
+}
+
+/// Persisted approvals store.
+///
+/// This module manages approvals for executing commands from command rules.
+/// Approvals are stored in a JSON file inside the rules directory so they can
+/// be tracked with Git or synced by the user if desired.
+///
+/// API notes:
+/// - `is_approved` will consume one-time approvals (decrement `allowed_once_count`)
+///   and persist the change.
+/// - `approve_once` increases the `allowed_once_count` by one and persists.
+/// - `approve_always` marks the signature as permanently approved.
+/// - Signatures are plain canonical strings (see `signature_from_parts`).
+pub struct CommandApprovals {
+    approvals: RwLock<HashMap<String, Approval>>,
+    file_path: PathBuf,
+    fs: Arc<dyn Fs>,
+}
+
+impl CommandApprovals {
+    /// Create a new approvals manager that stores data under `rules_dir`.
+    ///
+    /// The on-disk path will be `rules_dir/_command_approvals.json`.
+    pub fn new(rules_dir: PathBuf, fs: Arc<dyn Fs>) -> Self {
+        let file_path = rules_dir.join("_command_approvals.json");
+        Self {
+            approvals: RwLock::new(HashMap::new()),
+            file_path,
+            fs,
+        }
+    }
+
+    /// Load approvals from disk into memory. If the file does not exist this will be a no-op.
+    pub async fn init(&self) -> Result<()> {
+        if self
+            .fs
+            .metadata(&self.file_path)
+            .await
+            .ok()
+            .flatten()
+            .is_some()
+        {
+            let data = self
+                .fs
+                .load(&self.file_path)
+                .await
+                .context("loading approvals file")?;
+            let map: HashMap<String, Approval> =
+                serde_json::from_str(&data).context("parsing approvals JSON")?;
+            let mut guard = self.approvals.write().unwrap();
+            *guard = map;
+        }
+        Ok(())
+    }
+
+    /// Persist current approvals to disk atomically.
+    async fn persist(&self) -> Result<()> {
+        let json = {
+            let guard = self.approvals.read().unwrap();
+            serde_json::to_string_pretty(&*guard).context("serializing approvals")?
+        };
+        // Ensure parent dir exists (best-effort)
+        if let Some(parent) = self.file_path.parent() {
+            let _ = self.fs.create_dir(parent).await;
+        }
+        self.fs
+            .atomic_write(self.file_path.clone(), json)
+            .await
+            .context("writing approvals file")?;
+        Ok(())
+    }
+
+    /// Canonical signature for a command + args.
+    ///
+    /// This is intentionally simple and stable: we join command and args
+    /// with the ASCII unit separator so that keys are reversible for debugging.
+    pub fn signature_from_parts(cmd: &str, args: &[String]) -> String {
+        // Use a separator that is unlikely to appear in normal shells.
+        // We deliberately avoid hashing to keep the store human-readable.
+        let sep = '\x1f';
+        let mut s =
+            String::with_capacity(cmd.len() + 1 + args.iter().map(|a| a.len() + 1).sum::<usize>());
+        s.push_str(cmd);
+        for arg in args {
+            s.push(sep);
+            s.push_str(arg);
+        }
+        s
+    }
+
+    /// Check whether the command signature is approved.
+    ///
+    /// If a one-time approval exists (allowed_once_count > 0) it will be consumed
+    /// (decremented) and persisted.
+    pub async fn is_approved(&self, signature: &str) -> Result<bool> {
+        let should_persist = {
+            let mut guard = self.approvals.write().unwrap();
+            if let Some(record) = guard.get_mut(signature) {
+                // If permanently allowed, return true
+                if record.allowed_always {
+                    record.last_used_at = Some(Utc::now());
+                    true
+                } else if record.allowed_once_count > 0 {
+                    // If one-time allowances exist, consume one and persist
+                    record.allowed_once_count = record.allowed_once_count.saturating_sub(1);
+                    record.last_used_at = Some(Utc::now());
+                    true
+                } else {
+                    false
+                }
+            } else {
+                false
+            }
+        };
+
+        if should_persist {
+            self.persist().await?;
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    /// Approve the signature for a single one-time run.
+    pub async fn approve_once(&self, signature: &str, note: Option<String>) -> Result<()> {
+        {
+            let mut guard = self.approvals.write().unwrap();
+            let record = guard
+                .entry(signature.to_string())
+                .or_insert_with(|| Approval::new(signature.to_string(), false, 0, note.clone()));
+            record.allowed_once_count = record.allowed_once_count.saturating_add(1);
+            if note.is_some() {
+                record.note = note;
+            }
+            record.last_used_at = Some(Utc::now());
+        }
+        self.persist().await?;
+        Ok(())
+    }
+
+    /// Approve the signature permanently.
+    pub async fn approve_always(&self, signature: &str, note: Option<String>) -> Result<()> {
+        {
+            let mut guard = self.approvals.write().unwrap();
+            let record = guard
+                .entry(signature.to_string())
+                .or_insert_with(|| Approval::new(signature.to_string(), true, 0, note.clone()));
+            record.allowed_always = true;
+            if note.is_some() {
+                record.note = note;
+            }
+            record.last_used_at = Some(Utc::now());
+        }
+        self.persist().await?;
+        Ok(())
+    }
+
+    /// Revoke approval (remove entry).
+    pub async fn revoke(&self, signature: &str) -> Result<()> {
+        {
+            let mut guard = self.approvals.write().unwrap();
+            guard.remove(signature);
+        }
+        self.persist().await?;
+        Ok(())
+    }
+
+    /// List all approvals (snapshot).
+    pub fn list(&self) -> Vec<Approval> {
+        let guard = self.approvals.read().unwrap();
+        guard.values().cloned().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn signature_is_stable() {
+        let sig1 = CommandApprovals::signature_from_parts(
+            "git",
+            &["status".to_string(), "--short".to_string()],
+        );
+        let sig2 = CommandApprovals::signature_from_parts(
+            "git",
+            &["status".to_string(), "--short".to_string()],
+        );
+        assert_eq!(sig1, sig2);
+        assert!(sig1.starts_with("git"));
+    }
+}

--- a/crates/prompt_store/src/command_executor.rs
+++ b/crates/prompt_store/src/command_executor.rs
@@ -1,0 +1,250 @@
+//! Command execution for command-based rules.
+//!
+//! This module provides functionality to execute shell commands specified in rules,
+//! with timeouts, output limits, and error handling.
+
+use anyhow::{Context as _, Result, anyhow};
+use async_process::{Command, Stdio};
+use futures::io::AsyncReadExt;
+use futures::{FutureExt, select};
+use smol::Timer;
+use std::time::Duration;
+
+use crate::file_store::CommandConfig;
+
+/// Result of command execution
+#[derive(Debug, Clone)]
+pub struct CommandExecutionResult {
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_code: Option<i32>,
+    pub success: bool,
+    pub truncated: bool,
+    pub timed_out: bool,
+}
+
+impl CommandExecutionResult {
+    /// Get the output to use as rule content (stdout only if successful)
+    pub fn output_for_rule(&self) -> Option<String> {
+        if self.success && !self.stdout.is_empty() {
+            Some(self.stdout.clone())
+        } else {
+            None
+        }
+    }
+}
+
+/// Execute a command with the given configuration
+pub async fn execute_command(config: &CommandConfig) -> Result<CommandExecutionResult> {
+    let timeout_duration = Duration::from_secs(config.timeout_seconds);
+
+    // Execute with timeout using futures::select
+    let execute_future = execute_command_inner(config).fuse();
+    let timeout_future = Timer::after(timeout_duration).fuse();
+
+    futures::pin_mut!(execute_future, timeout_future);
+
+    select! {
+        result = execute_future => result,
+        _ = timeout_future => {
+            // Timeout occurred
+            Ok(CommandExecutionResult {
+                stdout: String::new(),
+                stderr: format!("Command timed out after {} seconds", config.timeout_seconds),
+                exit_code: None,
+                success: false,
+                truncated: false,
+                timed_out: true,
+            })
+        }
+    }
+}
+
+async fn execute_command_inner(config: &CommandConfig) -> Result<CommandExecutionResult> {
+    let mut cmd = Command::new(&config.cmd);
+    cmd.args(&config.args);
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+
+    // Spawn the process
+    let mut child = cmd
+        .spawn()
+        .context(format!("Failed to spawn command: {}", config.cmd))?;
+
+    let mut stdout_handle = child
+        .stdout
+        .take()
+        .ok_or_else(|| anyhow!("Failed to capture stdout"))?;
+
+    let mut stderr_handle = child
+        .stderr
+        .take()
+        .ok_or_else(|| anyhow!("Failed to capture stderr"))?;
+
+    // Read stdout with size limit
+    let mut stdout_bytes = Vec::with_capacity(config.max_output_bytes.min(65536));
+    let mut buffer = vec![0u8; 8192];
+    let mut total_read = 0;
+    let mut truncated = false;
+
+    loop {
+        match stdout_handle.read(&mut buffer).await {
+            Ok(0) => break, // EOF
+            Ok(n) => {
+                total_read += n;
+                if total_read <= config.max_output_bytes {
+                    stdout_bytes.extend_from_slice(&buffer[..n]);
+                } else {
+                    // Truncate to max size
+                    let remaining = config.max_output_bytes.saturating_sub(stdout_bytes.len());
+                    if remaining > 0 {
+                        stdout_bytes.extend_from_slice(&buffer[..remaining.min(n)]);
+                    }
+                    truncated = true;
+                    break;
+                }
+            }
+            Err(e) => {
+                return Err(anyhow!("Failed to read stdout: {}", e));
+            }
+        }
+    }
+
+    // Read stderr (with same limit)
+    let mut stderr_bytes = Vec::with_capacity(config.max_output_bytes.min(65536));
+    let mut stderr_total = 0;
+
+    loop {
+        match stderr_handle.read(&mut buffer).await {
+            Ok(0) => break,
+            Ok(n) => {
+                stderr_total += n;
+                if stderr_total <= config.max_output_bytes {
+                    stderr_bytes.extend_from_slice(&buffer[..n]);
+                } else {
+                    let remaining = config.max_output_bytes.saturating_sub(stderr_bytes.len());
+                    if remaining > 0 {
+                        stderr_bytes.extend_from_slice(&buffer[..remaining.min(n)]);
+                    }
+                    break;
+                }
+            }
+            Err(e) => {
+                return Err(anyhow!("Failed to read stderr: {}", e));
+            }
+        }
+    }
+
+    // Wait for the process to complete
+    let status = child.status().await.context("Failed to wait for command")?;
+
+    let stdout = String::from_utf8_lossy(&stdout_bytes).to_string();
+    let stderr = String::from_utf8_lossy(&stderr_bytes).to_string();
+
+    Ok(CommandExecutionResult {
+        stdout,
+        stderr,
+        exit_code: status.code(),
+        success: status.success(),
+        truncated,
+        timed_out: false,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CommandConfig, execute_command};
+
+    #[gpui::test]
+    async fn test_execute_simple_command() {
+        let config = CommandConfig {
+            cmd: "echo".to_string(),
+            args: vec!["hello world".to_string()],
+            timeout_seconds: 5,
+            max_output_bytes: 10_000,
+            on_startup: false,
+            on_new_chat: true,
+            on_every_message: false,
+        };
+
+        let result = execute_command(&config).await.unwrap();
+        assert!(result.success);
+        assert_eq!(result.stdout.trim(), "hello world");
+        assert!(result.stderr.is_empty());
+        assert!(!result.truncated);
+        assert!(!result.timed_out);
+    }
+
+    #[gpui::test]
+    async fn test_command_with_stderr() {
+        let config = CommandConfig {
+            cmd: "sh".to_string(),
+            args: vec!["-c".to_string(), "echo error >&2".to_string()],
+            timeout_seconds: 5,
+            max_output_bytes: 10_000,
+            on_startup: false,
+            on_new_chat: true,
+            on_every_message: false,
+        };
+
+        let result = execute_command(&config).await.unwrap();
+        assert!(result.success);
+        assert!(result.stdout.is_empty());
+        assert_eq!(result.stderr.trim(), "error");
+    }
+
+    #[gpui::test]
+    async fn test_command_timeout() {
+        let config = CommandConfig {
+            cmd: "sleep".to_string(),
+            args: vec!["10".to_string()],
+            timeout_seconds: 1,
+            max_output_bytes: 10_000,
+            on_startup: false,
+            on_new_chat: true,
+            on_every_message: false,
+        };
+
+        let result = execute_command(&config).await.unwrap();
+        assert!(!result.success);
+        assert!(result.timed_out);
+    }
+
+    #[gpui::test]
+    async fn test_output_truncation() {
+        let config = CommandConfig {
+            cmd: "sh".to_string(),
+            args: vec![
+                "-c".to_string(),
+                "for i in $(seq 1 1000); do echo $i; done".to_string(),
+            ],
+            timeout_seconds: 5,
+            max_output_bytes: 100,
+            on_startup: false,
+            on_new_chat: true,
+            on_every_message: false,
+        };
+
+        let result = execute_command(&config).await.unwrap();
+        assert!(result.success);
+        assert!(result.truncated);
+        assert!(result.stdout.len() <= 100);
+    }
+
+    #[gpui::test]
+    async fn test_failed_command() {
+        let config = CommandConfig {
+            cmd: "sh".to_string(),
+            args: vec!["-c".to_string(), "exit 1".to_string()],
+            timeout_seconds: 5,
+            max_output_bytes: 10_000,
+            on_startup: false,
+            on_new_chat: true,
+            on_every_message: false,
+        };
+
+        let result = execute_command(&config).await.unwrap();
+        assert!(!result.success);
+        assert_eq!(result.exit_code, Some(1));
+    }
+}

--- a/crates/prompt_store/src/file_store.rs
+++ b/crates/prompt_store/src/file_store.rs
@@ -1,0 +1,369 @@
+//! File-based storage for user rules.
+//!
+//! This module provides functionality to store and load user rules as markdown files
+//! in the config directory, allowing them to be git-tracked and easily edited.
+
+use anyhow::{Context as _, Result, anyhow};
+use chrono::{DateTime, Utc};
+use fs::Fs;
+use futures::StreamExt;
+use gpui::SharedString;
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use uuid::Uuid;
+
+use crate::{PromptId, PromptMetadata, UserPromptId};
+
+/// Command execution configuration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommandConfig {
+    pub cmd: String,
+    pub args: Vec<String>,
+    #[serde(default = "default_timeout")]
+    pub timeout_seconds: u64,
+    #[serde(default = "default_max_output_bytes")]
+    pub max_output_bytes: usize,
+    #[serde(default)]
+    pub on_startup: bool,
+    #[serde(default)]
+    pub on_new_chat: bool,
+    #[serde(default)]
+    pub on_every_message: bool,
+}
+
+fn default_timeout() -> u64 {
+    5
+}
+
+fn default_max_output_bytes() -> usize {
+    40_000
+}
+
+/// Type of rule content
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum RuleType {
+    #[default]
+    Static,
+    Command,
+}
+
+/// Frontmatter metadata for a rule file
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RuleFrontmatter {
+    id: Uuid,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    title: Option<String>,
+    #[serde(default)]
+    default: bool,
+    saved_at: DateTime<Utc>,
+    #[serde(default, rename = "type")]
+    rule_type: RuleType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    command: Option<CommandConfig>,
+}
+
+/// A parsed rule file with metadata and content
+#[derive(Debug, Clone)]
+pub struct RuleFile {
+    pub id: UserPromptId,
+    pub title: Option<SharedString>,
+    pub default: bool,
+    pub saved_at: DateTime<Utc>,
+    pub rule_type: RuleType,
+    pub content: String,
+    pub command: Option<CommandConfig>,
+}
+
+impl RuleFile {
+    /// Convert to PromptMetadata
+    pub fn to_metadata(&self) -> PromptMetadata {
+        PromptMetadata {
+            id: PromptId::User { uuid: self.id },
+            title: self.title.clone(),
+            default: self.default,
+            saved_at: self.saved_at,
+            rule_type: self.rule_type.clone(),
+            command: self.command.clone(),
+        }
+    }
+
+    /// Check if this is a command rule
+    pub fn is_command(&self) -> bool {
+        self.rule_type == RuleType::Command
+    }
+
+    /// Check if this command should run on startup
+    pub fn runs_on_startup(&self) -> bool {
+        self.command.as_ref().map_or(false, |c| c.on_startup)
+    }
+
+    /// Check if this command should run on new chat
+    pub fn runs_on_new_chat(&self) -> bool {
+        self.command.as_ref().map_or(false, |c| c.on_new_chat)
+    }
+
+    /// Check if this command should run on every message
+    pub fn runs_on_every_message(&self) -> bool {
+        self.command.as_ref().map_or(false, |c| c.on_every_message)
+    }
+}
+
+/// File-based rules store
+pub struct FileStore {
+    rules_dir: PathBuf,
+    pub fs: Arc<dyn Fs>,
+}
+
+impl FileStore {
+    /// Create a new FileStore
+    pub fn new(rules_dir: PathBuf, fs: Arc<dyn Fs>) -> Self {
+        Self { rules_dir, fs }
+    }
+
+    /// Get the rules directory path
+    pub fn rules_dir(&self) -> &Path {
+        &self.rules_dir
+    }
+
+    /// Initialize the rules directory, creating it if needed
+    pub async fn init(&self) -> Result<()> {
+        self.fs
+            .create_dir(&self.rules_dir)
+            .await
+            .or_else(|_err| Ok::<(), anyhow::Error>(()))
+            .with_context(|| format!("Failed to create rules directory: {:?}", self.rules_dir))
+    }
+
+    /// List all rule files in the directory, including subdirectories
+    pub async fn list_all(&self) -> Result<Vec<PathBuf>> {
+        let mut rule_files = Vec::new();
+        self.list_all_recursive(&self.rules_dir, &mut rule_files)
+            .await?;
+        Ok(rule_files)
+    }
+
+    /// Recursively list all .md files in the directory and subdirectories
+    fn list_all_recursive<'a>(
+        &'a self,
+        dir: &'a Path,
+        rule_files: &'a mut Vec<PathBuf>,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<()>> + Send + 'a>> {
+        Box::pin(async move {
+            let mut entries = self.fs.read_dir(dir).await?;
+
+            while let Some(entry_result) = entries.next().await {
+                let path = entry_result?;
+
+                if let Ok(Some(metadata)) = self.fs.metadata(&path).await {
+                    if metadata.is_dir {
+                        // Recursively scan subdirectories
+                        self.list_all_recursive(&path, rule_files).await?;
+                    } else if path.extension().and_then(|s| s.to_str()) == Some("md") {
+                        rule_files.push(path);
+                    }
+                }
+            }
+
+            Ok(())
+        })
+    }
+
+    /// Load all rules from the directory
+    pub async fn load_all(&self) -> Result<Vec<RuleFile>> {
+        let paths = self.list_all().await?;
+        let mut rules = Vec::new();
+
+        for path in paths {
+            match self.load_from_path(&path).await {
+                Ok(rule) => rules.push(rule),
+                Err(err) => {
+                    log::warn!("Failed to load rule from {:?}: {}", path, err);
+                }
+            }
+        }
+
+        Ok(rules)
+    }
+
+    /// Load a specific rule by ID
+    pub async fn load(&self, id: &UserPromptId) -> Result<RuleFile> {
+        let paths = self.list_all().await?;
+
+        for path in paths {
+            if let Ok(rule) = self.load_from_path(&path).await {
+                if rule.id.0 == id.0 {
+                    return Ok(rule);
+                }
+            }
+        }
+
+        Err(anyhow!("Rule not found: {}", id.0))
+    }
+
+    /// Load a rule from a specific file path
+    async fn load_from_path(&self, path: &Path) -> Result<RuleFile> {
+        let content = self.fs.load(path).await?;
+        Self::parse_rule_file(&content)
+    }
+
+    /// Parse a rule file with frontmatter
+    fn parse_rule_file(content: &str) -> Result<RuleFile> {
+        // Check for frontmatter
+        if !content.starts_with("---\n") && !content.starts_with("---\r\n") {
+            return Err(anyhow!("Rule file must start with frontmatter (---)"));
+        }
+
+        // Find the end of frontmatter
+        let content_after_start = if let Some(stripped) = content.strip_prefix("---\r\n") {
+            stripped
+        } else {
+            content
+                .strip_prefix("---\n")
+                .ok_or_else(|| anyhow!("Rule file must start with frontmatter (---)"))?
+        };
+
+        let end_marker_idx = content_after_start
+            .find("\n---\n")
+            .or_else(|| content_after_start.find("\n---\r\n"))
+            .ok_or_else(|| anyhow!("Rule file missing closing frontmatter marker (---)"))?;
+
+        let frontmatter_str = &content_after_start[..end_marker_idx];
+        let frontmatter: RuleFrontmatter =
+            serde_yaml::from_str(frontmatter_str).context("Failed to parse frontmatter")?;
+
+        // Get content after frontmatter
+        let content_start = if content_after_start[end_marker_idx..].starts_with("\n---\r\n") {
+            end_marker_idx + 6
+        } else {
+            end_marker_idx + 5
+        };
+        let rule_content = content_after_start[content_start..].trim().to_string();
+
+        Ok(RuleFile {
+            id: UserPromptId(frontmatter.id),
+            title: frontmatter.title.map(SharedString::from),
+            default: frontmatter.default,
+            saved_at: frontmatter.saved_at,
+            rule_type: frontmatter.rule_type,
+            content: rule_content,
+            command: frontmatter.command,
+        })
+    }
+
+    /// Save a rule to a file, optionally in a subdirectory
+    pub async fn save(
+        &self,
+        id: &UserPromptId,
+        title: Option<&str>,
+        content: &str,
+        default: bool,
+        rule_type: RuleType,
+        command: Option<CommandConfig>,
+    ) -> Result<PathBuf> {
+        let frontmatter = RuleFrontmatter {
+            id: id.0,
+            title: title.map(|s| s.to_string()),
+            default,
+            saved_at: Utc::now(),
+            rule_type,
+            command,
+        };
+
+        let frontmatter_yaml =
+            serde_yaml::to_string(&frontmatter).context("Failed to serialize frontmatter")?;
+
+        let file_content = format!("---\n{}---\n\n{}\n", frontmatter_yaml, content.trim());
+
+        // Always use UUID-based filename to prevent file proliferation when title changes
+        let filename = format!("{}.md", id.0);
+        let file_path = self.rules_dir.join(&filename);
+
+        // Delete any old files with different names (e.g., from previous title-based saves)
+        self.delete_old_files_for_id(id).await.ok();
+
+        // Ensure parent directory exists
+        if let Some(parent) = file_path.parent() {
+            self.fs
+                .create_dir(parent)
+                .await
+                .or_else(|_| Ok::<(), anyhow::Error>(()))
+                .ok();
+        }
+
+        self.fs
+            .atomic_write(file_path.clone(), file_content)
+            .await
+            .context("Failed to write rule file")?;
+
+        Ok(file_path)
+    }
+
+    /// Delete a rule file
+    pub async fn delete(&self, id: &UserPromptId) -> Result<()> {
+        self.delete_old_files_for_id(id).await
+    }
+
+    /// Delete all files associated with a given UUID (handles cleanup of old title-based files)
+    async fn delete_old_files_for_id(&self, id: &UserPromptId) -> Result<()> {
+        let paths = self.list_all().await?;
+        let mut found = false;
+
+        for path in paths {
+            if let Ok(rule) = self.load_from_path(&path).await {
+                if rule.id.0 == id.0 {
+                    self.fs.remove_file(&path, Default::default()).await?;
+                    found = true;
+                }
+            }
+        }
+
+        if found {
+            Ok(())
+        } else {
+            Err(anyhow!("Rule not found: {}", id.0))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_rule_file() {
+        let content = r#"---
+id: 550e8400-e29b-41d4-a716-446655440000
+title: Test Rule
+default: true
+saved_at: 2024-01-01T00:00:00Z
+---
+
+This is the rule content.
+"#;
+
+        let rule = FileStore::parse_rule_file(content).unwrap();
+        assert_eq!(rule.title, Some(SharedString::from("Test Rule")));
+        assert_eq!(rule.default, true);
+        assert_eq!(rule.content, "This is the rule content.");
+    }
+
+    #[test]
+    fn test_parse_rule_file_no_title() {
+        let content = r#"---
+id: 550e8400-e29b-41d4-a716-446655440000
+default: false
+saved_at: 2024-01-01T00:00:00Z
+---
+
+Content without title.
+"#;
+
+        let rule = FileStore::parse_rule_file(content).unwrap();
+        assert_eq!(rule.title, None);
+        assert_eq!(rule.default, false);
+        assert_eq!(rule.content, "Content without title.");
+    }
+}

--- a/crates/prompt_store/src/project_rules.rs
+++ b/crates/prompt_store/src/project_rules.rs
@@ -1,0 +1,411 @@
+//! Project-specific rules parsing and execution.
+//!
+//! This module handles parsing `.rules` files in project directories to check if they
+//! contain command rule frontmatter. If they do, the commands are executed to generate
+//! dynamic content. Otherwise, the file content is used as-is.
+
+use anyhow::{Context as _, Result};
+
+use crate::command_executor;
+use crate::file_store::{CommandConfig, RuleType};
+
+/// A single parsed rule from a project rules file
+#[derive(Debug, Clone)]
+pub struct ParsedProjectRule {
+    pub rule_type: RuleType,
+    pub command: Option<CommandConfig>,
+    pub content: String,
+}
+
+impl ParsedProjectRule {
+    pub fn is_command(&self) -> bool {
+        self.rule_type == RuleType::Command
+    }
+}
+
+/// Parse a .rules file to extract all rules (supports multiple frontmatters)
+pub fn parse_project_rules_file(content: &str) -> Vec<ParsedProjectRule> {
+    // Try to parse multiple rules separated by frontmatter blocks
+    match try_parse_multiple_rules(content) {
+        Ok(rules) if !rules.is_empty() => rules,
+        _ => {
+            // No frontmatter found - treat entire file as single static rule
+            vec![ParsedProjectRule {
+                rule_type: RuleType::Static,
+                command: None,
+                content: content.to_string(),
+            }]
+        }
+    }
+}
+
+/// Parse multiple rules from a file (each with its own frontmatter)
+fn try_parse_multiple_rules(content: &str) -> Result<Vec<ParsedProjectRule>> {
+    let mut rules = Vec::new();
+    let mut remaining = content;
+
+    loop {
+        // Look for start of frontmatter
+        if !remaining.starts_with("---\n") && !remaining.starts_with("---\r\n") {
+            // No more frontmatter blocks
+            if !remaining.trim().is_empty() && rules.is_empty() {
+                // Content exists but no frontmatter - treat as static
+                return Ok(vec![ParsedProjectRule {
+                    rule_type: RuleType::Static,
+                    command: None,
+                    content: remaining.to_string(),
+                }]);
+            }
+            break;
+        }
+
+        // Parse one rule
+        match try_parse_single_rule(remaining)? {
+            Some((rule, rest)) => {
+                rules.push(rule);
+                remaining = rest.trim_start();
+            }
+            None => break,
+        }
+    }
+
+    Ok(rules)
+}
+
+/// Parse a single rule starting from the beginning of the string
+fn try_parse_single_rule(content: &str) -> Result<Option<(ParsedProjectRule, &str)>> {
+    if !content.starts_with("---\n") && !content.starts_with("---\r\n") {
+        return Ok(None);
+    }
+
+    // Skip opening ---
+    let content_after_start = if let Some(stripped) = content.strip_prefix("---\r\n") {
+        stripped
+    } else if let Some(stripped) = content.strip_prefix("---\n") {
+        stripped
+    } else {
+        return Ok(None);
+    };
+
+    // Find closing ---
+    let end_marker_idx = content_after_start
+        .find("\n---\n")
+        .or_else(|| content_after_start.find("\n---\r\n"));
+
+    let Some(end_marker_idx) = end_marker_idx else {
+        return Ok(None);
+    };
+
+    let frontmatter_str = &content_after_start[..end_marker_idx];
+
+    // Parse frontmatter
+    let frontmatter: ProjectRuleFrontmatter = serde_yaml::from_str(frontmatter_str)
+        .context("Failed to parse project rules frontmatter")?;
+
+    // Get content after frontmatter
+    let content_start = if content_after_start[end_marker_idx..].starts_with("\n---\r\n") {
+        end_marker_idx + 6
+    } else {
+        end_marker_idx + 5
+    };
+
+    let after_frontmatter = &content_after_start[content_start..];
+
+    // Find the next frontmatter block or use rest of file
+    let (rule_content, remaining) = if let Some(next_frontmatter_pos) = after_frontmatter
+        .find("\n---\n")
+        .or_else(|| after_frontmatter.find("\n---\r\n"))
+    {
+        // There's another rule after this one
+        let content = &after_frontmatter[..next_frontmatter_pos];
+        let remaining = &after_frontmatter[next_frontmatter_pos + 1..]; // +1 to skip the newline
+        (content.trim().to_string(), remaining)
+    } else {
+        // This is the last rule
+        (after_frontmatter.trim().to_string(), "")
+    };
+
+    let rule = ParsedProjectRule {
+        rule_type: frontmatter.rule_type,
+        command: frontmatter.command,
+        content: rule_content,
+    };
+
+    Ok(Some((rule, remaining)))
+}
+
+/// Frontmatter structure for project rules files
+#[derive(Debug, Clone, serde::Deserialize)]
+struct ProjectRuleFrontmatter {
+    #[serde(default, rename = "type")]
+    rule_type: RuleType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    command: Option<CommandConfig>,
+}
+
+/// Execute a command rule and return the combined content
+pub async fn execute_project_command_rule(
+    config: &CommandConfig,
+    _prefix_content: String,
+    title: &str,
+) -> Result<String> {
+    let result = command_executor::execute_command(config).await?;
+
+    if let Some(output) = result.output_for_rule() {
+        // Use only command output, ignore prefix content
+        Ok(output)
+    } else {
+        // Command failed, log stderr
+        if !result.stderr.is_empty() {
+            log::warn!("Project command rule '{}' failed: {}", title, result.stderr);
+        }
+        anyhow::bail!("Command execution failed")
+    }
+}
+
+/// Process a project rules file: parse all rules and execute command rules
+pub async fn process_project_rules_file(content: &str, file_path: &str) -> Result<Vec<String>> {
+    let rules = parse_project_rules_file(content);
+    let mut outputs = Vec::new();
+
+    for (index, rule) in rules.iter().enumerate() {
+        let rule_name = format!("{}#{}", file_path, index + 1);
+
+        let output = if rule.is_command() {
+            if let Some(config) = &rule.command {
+                log::info!("Executing command rule from project file: {}", rule_name);
+                match execute_project_command_rule(config, rule.content.clone(), &rule_name).await {
+                    Ok(result) => result,
+                    Err(e) => {
+                        log::warn!("Failed to execute command rule {}: {}", rule_name, e);
+                        continue; // Skip failed command rules
+                    }
+                }
+            } else {
+                // Command rule without config - use static content
+                rule.content.clone()
+            }
+        } else {
+            // Static rule
+            rule.content.clone()
+        };
+
+        outputs.push(output);
+    }
+
+    Ok(outputs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_static_content() {
+        let content = "This is just plain text rules content.";
+        let result = parse_project_rules_file(content);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].rule_type, RuleType::Static);
+        assert_eq!(result[0].content, content);
+    }
+
+    #[test]
+    fn test_parse_single_static_frontmatter() {
+        let content = r#"---
+type: static
+---
+
+Static rule content here."#;
+
+        let result = parse_project_rules_file(content);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].rule_type, RuleType::Static);
+        assert_eq!(result[0].content, "Static rule content here.");
+    }
+
+    #[test]
+    fn test_parse_single_command_rule() {
+        let content = r#"---
+type: command
+command:
+  cmd: git
+  args: ["status", "--short"]
+  timeout_seconds: 5
+  max_output_bytes: 10000
+  on_new_chat: true
+---
+
+This text appears before command output."#;
+
+        let result = parse_project_rules_file(content);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].rule_type, RuleType::Command);
+        assert!(result[0].command.is_some());
+
+        let config = result[0].command.as_ref().unwrap();
+        assert_eq!(config.cmd, "git");
+        assert_eq!(config.args, vec!["status", "--short"]);
+        assert_eq!(config.timeout_seconds, 5);
+        assert_eq!(config.max_output_bytes, 10000);
+        assert!(config.on_new_chat);
+        assert_eq!(
+            result[0].content,
+            "This text appears before command output."
+        );
+    }
+
+    #[test]
+    fn test_parse_no_frontmatter() {
+        let content = "Just regular rules without frontmatter";
+        let result = parse_project_rules_file(content);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].rule_type, RuleType::Static);
+        assert_eq!(result[0].content, content);
+    }
+
+    #[test]
+    fn test_parse_incomplete_frontmatter() {
+        let content = "---\nthis is not valid yaml\n";
+        let result = parse_project_rules_file(content);
+
+        // Should fall back to static content
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].rule_type, RuleType::Static);
+    }
+
+    #[test]
+    fn test_parse_multiple_rules() {
+        let content = r#"---
+type: static
+---
+
+First static rule content.
+
+---
+type: command
+command:
+  cmd: pwd
+  on_new_chat: true
+---
+
+Second rule is a command.
+
+---
+type: static
+---
+
+Third static rule."#;
+
+        let result = parse_project_rules_file(content);
+
+        assert_eq!(result.len(), 3);
+
+        // First rule - static
+        assert_eq!(result[0].rule_type, RuleType::Static);
+        assert_eq!(result[0].content, "First static rule content.");
+
+        // Second rule - command
+        assert_eq!(result[1].rule_type, RuleType::Command);
+        assert!(result[1].command.is_some());
+        assert_eq!(result[1].command.as_ref().unwrap().cmd, "pwd");
+        assert_eq!(result[1].content, "Second rule is a command.");
+
+        // Third rule - static
+        assert_eq!(result[2].rule_type, RuleType::Static);
+        assert_eq!(result[2].content, "Third static rule.");
+    }
+
+    #[test]
+    fn test_parse_mixed_rules_no_content_between() {
+        let content = r#"---
+type: command
+command:
+  cmd: echo
+  args: ["hello"]
+---
+Command rule content
+---
+type: static
+---
+Static rule content"#;
+
+        let result = parse_project_rules_file(content);
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].rule_type, RuleType::Command);
+        assert_eq!(result[0].content, "Command rule content");
+        assert_eq!(result[1].rule_type, RuleType::Static);
+        assert_eq!(result[1].content, "Static rule content");
+    }
+
+    #[gpui::test]
+    async fn test_execute_command_rule() {
+        let config = CommandConfig {
+            cmd: "echo".to_string(),
+            args: vec!["test output".to_string()],
+            timeout_seconds: 5,
+            max_output_bytes: 10_000,
+            on_startup: false,
+            on_new_chat: true,
+            on_every_message: false,
+        };
+
+        let prefix = "Prefix content".to_string();
+        let result = execute_project_command_rule(&config, prefix, "test.rules").await;
+
+        assert!(result.is_ok());
+        let output = result.unwrap();
+        // Command output replaces prefix content, so prefix should not be present
+        assert!(!output.contains("Prefix content"));
+        assert!(output.contains("test output"));
+    }
+
+    #[gpui::test]
+    async fn test_process_static_file() {
+        let content = "Static rules content";
+        let result = process_project_rules_file(content, ".rules").await;
+
+        assert!(result.is_ok());
+        let outputs = result.unwrap();
+        assert_eq!(outputs.len(), 1);
+        assert_eq!(outputs[0], content);
+    }
+
+    #[gpui::test]
+    async fn test_process_multiple_rules() {
+        let content = r#"---
+type: static
+---
+
+Static rule 1
+
+---
+type: command
+command:
+  cmd: echo
+  args: ["test"]
+  on_new_chat: true
+---
+
+Prefix for command
+
+---
+type: static
+---
+
+Static rule 2"#;
+
+        let result = process_project_rules_file(content, ".rules").await;
+
+        assert!(result.is_ok());
+        let outputs = result.unwrap();
+        assert_eq!(outputs.len(), 3);
+        assert_eq!(outputs[0], "Static rule 1");
+        assert!(outputs[1].contains("test")); // Command output
+        assert_eq!(outputs[2], "Static rule 2");
+    }
+}

--- a/docs/src/ai/rules.md
+++ b/docs/src/ai/rules.md
@@ -6,6 +6,9 @@ Currently, Zed supports adding rules through files inserted directly in the work
 ## `.rules` files
 
 Zed supports including `.rules` files at the top level of worktrees, and they act as project-level instructions that are included in all of your interactions with the Agent Panel.
+
+### Single Rules File
+
 Other names for this file are also supported for compatibility with other agents, but note that the first file which matches in this list will be used:
 
 - `.rules`
@@ -17,6 +20,26 @@ Other names for this file are also supported for compatibility with other agents
 - `AGENTS.md`
 - `CLAUDE.md`
 - `GEMINI.md`
+
+### Multiple Rules Files with `.rules.d`
+
+Zed also supports a `.rules.d` directory at the top level of worktrees. When this directory exists, **all** markdown (`.md`) and text (`.txt`) files within it are read and combined with any existing `.rules` file as project-level instructions. This allows you to:
+
+- **Organize rules by topic**: Split large rule sets into multiple files (e.g., `coding-style.md`, `testing-guidelines.md`, `architecture.md`)
+- **Share common rules**: Reuse rule files across multiple projects
+- **Manage rules with Git**: Track individual rule files separately for clearer history
+
+Files in `.rules.d` are read in alphabetical order and concatenated with blank lines between them. If both a `.rules` file and a `.rules.d` directory exist, the `.rules` file content is included first, followed by the combined content from `.rules.d`.
+
+Example structure:
+```
+project-root/
+├── .rules.d/
+│   ├── 01-coding-style.md
+│   ├── 02-testing.md
+│   └── 03-documentation.md
+└── src/
+```
 
 ## Rules Library {#rules-library}
 
@@ -40,9 +63,126 @@ Rules can be duplicated, deleted, or added to the default rules using the button
 
 ### Creating Rules {#creating-rules}
 
-To create a rule file, simply open the `Rules Library` and click the `+` button. Rules files are stored locally and can be accessed from the library at any time.
+To create a rule file, simply open the `Rules Library` and click the `+` button. Rules files are stored locally as markdown files in `~/.config/zed/prompts/rules/` (on Linux/FreeBSD and macOS) or `%APPDATA%\Zed\prompts\rules\` (on Windows), and can be accessed from the library at any time.
 
-Having a series of rules files specifically tailored to prompt engineering can also help you write consistent and effective rules.
+#### File-Based Storage
+
+Global rules are stored as markdown files with YAML frontmatter in the rules directory. This allows you to:
+
+- **Track rules with Git**: Since rules are plain text files, you can version control them
+- **Share rules easily**: Copy rule files between machines or share with team members
+- **Edit externally**: Edit rules in any text editor - changes are automatically detected and reloaded
+- **Organize with subdirectories**: Rules can be organized into subdirectories within the rules folder
+- **Backup and sync**: Use your preferred backup or sync solution for rule files
+
+Each rule file follows this format:
+
+```markdown
+---
+id: 550e8400-e29b-41d4-a716-446655440000
+title: My Rule
+default: true
+saved_at: 2024-01-01T00:00:00Z
+type: static
+---
+
+Rule content goes here...
+```
+
+The frontmatter contains:
+- `id`: A unique UUID for the rule
+- `title`: Optional display name for the rule
+- `default`: Whether this rule is included in all new threads by default
+- `saved_at`: Timestamp of when the rule was last saved
+- `type`: Rule type - either `static` (text content) or `command` (executes a command)
+- `command`: Optional command configuration (for command rules only)
+
+When you create or edit rules through the Rules Library UI, these files are automatically managed for you. You can also create rule files manually by placing `.md` files anywhere in the rules directory (including subdirectories) - they will be automatically detected and loaded.
+
+#### Command Rules
+
+Command rules allow you to dynamically generate rule content by executing shell commands. This enables context-aware rules that adapt to your current environment, git state, or project configuration.
+
+**Use Cases:**
+- Show current git branch and status
+- Display project-specific environment variables
+- Include system information
+- Run custom scripts that output relevant context
+
+**Command Rule Format:**
+
+```markdown
+---
+id: 550e8400-e29b-41d4-a716-446655440000
+title: Git Status
+default: true
+saved_at: 2024-01-01T00:00:00Z
+type: command
+command:
+  cmd: git
+  args: ["status", "--short", "--branch"]
+  timeout_seconds: 5
+  max_output_bytes: 10000
+  on_startup: false
+  on_new_chat: true
+---
+
+Optional static prefix that appears before command output...
+```
+
+**Command Configuration:**
+- `cmd`: The command to execute (e.g., `git`, `pwd`, `echo`)
+- `args`: Array of command-line arguments
+- `timeout_seconds`: Maximum execution time (default: 5 seconds)
+- `max_output_bytes`: Maximum output size (default: 10,000 bytes)
+- `on_startup`: Execute when Zed starts (default: false)
+- `on_new_chat`: Execute when starting a new chat thread (default: false)
+
+**Command Execution:**
+- Commands run asynchronously but complete before the first chat message
+- Only stdout is captured and used as rule content
+- stderr is logged and shown in notifications if non-empty
+- If a command fails or times out, the rule is skipped
+- No caching - commands re-run on each startup or new chat
+- User confirmation required on first execution for security
+
+**Security:**
+- You will be prompted to approve command execution the first time
+- Commands run with your user permissions (not sandboxed)
+- Review command rules carefully before enabling them
+- Avoid commands that modify system state
+
+**Example Command Rules:**
+
+Git branch and status:
+```yaml
+command:
+  cmd: git
+  args: ["status", "--short", "--branch"]
+  on_new_chat: true
+```
+
+Current working directory:
+```yaml
+command:
+  cmd: pwd
+  on_new_chat: true
+```
+
+Project structure:
+```yaml
+command:
+  cmd: tree
+  args: ["-L", "2", "-I", "node_modules|.git"]
+  timeout_seconds: 10
+  on_new_chat: true
+```
+
+#### Automatic File Watching
+
+The Rules Library automatically watches for changes to rule files on disk. When you edit a rule file externally (in another text editor or via Git pull), the changes are immediately reflected in Zed without needing to reload.
+
+Having a series of rules files specifically tailored to prompt engineering can also help you write consistent and effective rules. Since rules are now file-based, you can organize them in git repositories or sync them across machines.
 
 Here are a couple of helpful resources for writing better rules:
 
@@ -59,8 +199,18 @@ You can also manually add other rules (that are not flagged as default) as conte
 
 ## Migrating from Prompt Library
 
-Previously, the Rules Library was called the "Prompt Library".
-The new rules system replaces the Prompt Library except in a few specific cases, which are outlined below.
+Previously, the Rules Library was called the "Prompt Library" and stored rules in a database. The new rules system uses file-based storage exclusively and replaces the Prompt Library except in a few specific cases, which are outlined below.
+
+### Automatic Migration
+
+When you first launch Zed with the file-based rules system, any existing rules stored in the database will be automatically migrated to markdown files in the rules directory. This is a one-time migration that:
+
+1. Detects the old database if it exists
+2. Migrates all user rules to markdown files
+3. Preserves all metadata (title, default status, timestamps)
+4. Moves the old database to a `.bak` backup directory after successful migration
+
+The migration happens automatically in the background and you'll see log messages indicating the progress. After migration, all rules will be loaded from files.
 
 ### Slash Commands in Rules
 


### PR DESCRIPTION
**Builds upon:** #45820

Introduces a complete rules infrastructure for AI agent interactions with support for dynamic command-based rules, organized multi-file rules, and a full-featured rules library UI.

## Core Features

### Command Rules
- Execute shell commands to generate dynamic rule content
- Configure timeout, output limits, and execution triggers
- Support for `on_startup`, `on_new_chat`, and `on_every_message` execution
- Command approval system with persistent tracking for security
- Full error handling with timeout detection and output truncation
- Commands run asynchronously with proper cancellation support

### Project Rules (.rules.d)
- Support for `.rules.d` directory containing multiple rule files
- Automatically loads and combines all `.md` and `.txt` files in alphabetical order
- Backwards compatible with single `.rules` file at project root
- Supports additional rule file names (`.cursorrules`, `.windsurfrules`, etc.)
- Combined rules from both single file and directory sources

### Rules Library UI
- Full-featured editor with syntax highlighting for managing rules
- Rule type selector (static vs command) with live switching
- Command configuration UI with editors for all parameters
- Checkboxes for command triggers (on_startup, on_new_chat, on_every_message)
- "Run Command" action to test command rules immediately
- Rule duplication, deletion, and default toggling
- Restore built-in rules to default content

## Implementation Details

### New Modules
- `prompt_store/command_executor.rs`: Command execution with timeout and limits
- `prompt_store/command_approvals.rs`: Persistent approval tracking system
- `prompt_store/project_rules.rs`: Parse and execute project .rules files
- `prompt_store/file_store.rs`: File-based storage for user rules with frontmatter

### Storage Format
Rules stored as markdown files with YAML frontmatter:
```yaml
---
id: uuid
title: "Rule Name"
default: true/false
saved_at: timestamp
type: static|command
command:
  cmd: "command"
  args: ["arg1", "arg2"]
  timeout_seconds: 5
  max_output_bytes: 10000
  on_startup: false
  on_new_chat: true
  on_every_message: false
---
```

### Agent Integration
- Modified `NativeAgent` to load combined rules from `.rules` and `.rules.d`
- Command rules execute before agent responses when triggered
- Proper error handling and logging for command failures
- Async execution doesn't block UI or agent responses

### Security
- User confirmation required on first command execution
- Approvals stored persistently with timestamp tracking
- Support for "allow always" and "allow once" modes
- Command signatures track exact command + args for approval

## Bug Fixes
- Fixed `prompts_dir()` to use `config_dir` instead of `data_dir` on all platforms
  - Previously, Linux/Windows looked for rules in `~/.local/share/zed/prompts/rules`
  - Now correctly uses `~/.config/zed/prompts/rules` on all platforms
  - Matches documented behavior and user expectations

## Breaking Changes
- Rules frontmatter format updated with new fields (type, command)
- PromptStore API changes for command rule support
- Agent context now includes command execution results
- Prompts directory location changed on Linux/Windows (from data_dir to config_dir)

## Changes Summary

**Files Changed:** 13 files (+2,766/-290 lines)

This change provides a foundation for dynamic, context-aware AI agent rules while maintaining backwards compatibility with existing static rule files.

---

### Release Notes:

- N/A
