### PR TITLE
Add Ctrl+Shift+Enter to queue messages until agent finishes

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -321,17 +321,19 @@
     },
   },
   {
-    "context": "AcpThread > Editor && !use_modifier_to_send",
+    "context": "MessageEditor > Editor && !use_modifier_to_send",
     "use_key_equivalents": true,
     "bindings": {
       "enter": "agent::Chat",
+      "ctrl-shift-enter": "agent::Chat",
     },
   },
   {
-    "context": "AcpThread > Editor && use_modifier_to_send",
+    "context": "MessageEditor > Editor && use_modifier_to_send",
     "use_key_equivalents": true,
     "bindings": {
       "ctrl-enter": "agent::Chat",
+      "ctrl-shift-enter": "agent::Chat",
       "enter": "editor::Newline",
     },
   },

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -369,17 +369,19 @@
     },
   },
   {
-    "context": "AcpThread > Editor && !use_modifier_to_send",
+    "context": "MessageEditor > Editor && !use_modifier_to_send",
     "use_key_equivalents": true,
     "bindings": {
       "enter": "agent::Chat",
+      "cmd-shift-enter": "agent::Chat",
     },
   },
   {
-    "context": "AcpThread > Editor && use_modifier_to_send",
+    "context": "MessageEditor > Editor && use_modifier_to_send",
     "use_key_equivalents": true,
     "bindings": {
       "cmd-enter": "agent::Chat",
+      "cmd-shift-enter": "agent::Chat",
       "enter": "editor::Newline",
     },
   },

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -324,17 +324,19 @@
     },
   },
   {
-    "context": "AcpThread > Editor && !use_modifier_to_send",
+    "context": "MessageEditor > Editor && !use_modifier_to_send",
     "use_key_equivalents": true,
     "bindings": {
       "enter": "agent::Chat",
+      "ctrl-shift-enter": "agent::Chat",
     },
   },
   {
-    "context": "AcpThread > Editor && use_modifier_to_send",
+    "context": "MessageEditor > Editor && use_modifier_to_send",
     "use_key_equivalents": true,
     "bindings": {
       "ctrl-enter": "agent::Chat",
+      "ctrl-shift-enter": "agent::Chat",
       "enter": "editor::Newline",
     },
   },

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -1066,6 +1066,8 @@
     "context": "MessageEditor > Editor && VimControl",
     "bindings": {
       "enter": "agent::Chat",
+      "ctrl-shift-enter": "agent::Chat",
+      "cmd-shift-enter": "agent::Chat",
     },
   },
   {


### PR DESCRIPTION
This PR implements the ability to queue messages that automatically send once the agent completes its current response. Users press Ctrl+Shift+Enter (Cmd+Shift+Enter on macOS) to queue a message, which then sends automatically when the agent becomes idle.

This addresses a common pain point where users have to either wait for the agent to finish or interrupt it mid-response to send their next message.

## Related Discussions

Closes #42338
Closes #33501
Closes #41414

## Implementation

The implementation polls the agent status every 100ms to detect when it becomes idle. This polling approach was chosen because ThreadStatus changes happen internally without external notification mechanisms. The 100ms interval provides responsive UX without excessive CPU usage.

## Changes

- Modified MessageEditorEvent::Send to include wait_for_agent flag
- Added send_with_wait() and regenerate_with_wait() methods
- Added ctrl-shift-enter keybindings to all platform keymaps
- Visual feedback: send button turns green when modifiers held
- Queue indicator banner with cancel button
- Updated tooltips to reflect the feature

## Keybindings

- Linux/Windows: Ctrl+Shift+Enter
- macOS: Cmd+Shift+Enter
- Vim: Both supported

Note: Originally considered Shift+Enter but that conflicts with the existing newline shortcut.

## Testing

Tested on Linux with the agent panel. The message queues correctly, visual indicators appear, and the message sends automatically when the agent finishes responding.

## Release Notes:

- Added Ctrl+Shift+Enter (Cmd+Shift+Enter on macOS) to queue messages that automatically send once the agent finishes its current response