### PR TITLE
Add dynamic tasks and task-context to extension API

### DIFF
--- a/crates/extension/src/extension.rs
+++ b/crates/extension/src/extension.rs
@@ -168,6 +168,20 @@ pub trait Extension: Send + Sync + 'static {
         locator_name: String,
         config: SpawnInTerminal,
     ) -> Result<DebugRequest>;
+
+    async fn build_context(
+        &self,
+        language_name: String,
+        location: TaskContextLocation,
+        worktree: Arc<dyn WorktreeDelegate>,
+    ) -> Result<Vec<TaskVariable>>;
+
+    async fn associated_tasks(
+        &self,
+        language_name: String,
+        file: Option<TaskContextFile>,
+        worktree: Arc<dyn WorktreeDelegate>,
+    ) -> Result<Vec<TaskDefinition>>;
 }
 
 pub fn parse_wasm_extension_version(extension_id: &str, wasm_bytes: &[u8]) -> Result<Version> {

--- a/crates/extension/src/extension.rs
+++ b/crates/extension/src/extension.rs
@@ -179,6 +179,22 @@ pub trait Extension: Send + Sync + 'static {
         locator_name: String,
         config: SpawnInTerminal,
     ) -> Result<DebugRequest>;
+
+    async fn build_context(
+        &self,
+        language_name: String,
+        variables: task::TaskVariables,
+        project_env: Option<collections::HashMap<String, String>>,
+        location: TaskContextLocation,
+        worktree: Arc<dyn WorktreeDelegate>,
+    ) -> Result<task::TaskVariables>;
+
+    async fn associated_tasks(
+        &self,
+        language_name: String,
+        file: Option<TaskContextFile>,
+        worktree: Arc<dyn WorktreeDelegate>,
+    ) -> Result<Vec<task::TaskTemplate>>;
 }
 
 pub fn parse_wasm_extension_version(extension_id: &str, wasm_bytes: &[u8]) -> Result<Version> {

--- a/crates/extension/src/extension_host_proxy.rs
+++ b/crates/extension/src/extension_host_proxy.rs
@@ -32,6 +32,8 @@ pub struct ExtensionHostProxy {
     context_server_proxy: RwLock<Option<Arc<dyn ExtensionContextServerProxy>>>,
     debug_adapter_provider_proxy: RwLock<Option<Arc<dyn ExtensionDebugAdapterProviderProxy>>>,
     language_model_provider_proxy: RwLock<Option<Arc<dyn ExtensionLanguageModelProviderProxy>>>,
+    extension_provider_proxy: RwLock<Option<Arc<dyn ExtensionProviderProxy>>>,
+    worktree_proxy: RwLock<Option<Arc<dyn ExtensionWorktreeProxy>>>,
 }
 
 impl ExtensionHostProxy {
@@ -57,6 +59,8 @@ impl ExtensionHostProxy {
             context_server_proxy: RwLock::default(),
             debug_adapter_provider_proxy: RwLock::default(),
             language_model_provider_proxy: RwLock::default(),
+            extension_provider_proxy: RwLock::default(),
+            worktree_proxy: RwLock::default(),
         }
     }
 
@@ -97,6 +101,40 @@ impl ExtensionHostProxy {
         self.language_model_provider_proxy
             .write()
             .replace(Arc::new(proxy));
+    }
+
+    pub fn register_extension_provider_proxy(&self, proxy: impl ExtensionProviderProxy) {
+        self.extension_provider_proxy
+            .write()
+            .replace(Arc::new(proxy));
+    }
+
+    pub fn register_worktree_proxy(&self, proxy: impl ExtensionWorktreeProxy) {
+        self.worktree_proxy.write().replace(Arc::new(proxy));
+    }
+
+    pub fn extension_by_id(&self, extension_id: &str) -> Option<Arc<dyn Extension>> {
+        let proxy = self.extension_provider_proxy.read().clone()?;
+        proxy.extension_by_id(extension_id)
+    }
+}
+
+pub trait ExtensionWorktreeProxy: Send + Sync + 'static {
+    fn worktree_delegate(
+        &self,
+        worktree_id: u64,
+        cx: &mut App,
+    ) -> Option<Arc<dyn crate::WorktreeDelegate>>;
+}
+
+impl ExtensionWorktreeProxy for ExtensionHostProxy {
+    fn worktree_delegate(
+        &self,
+        worktree_id: u64,
+        cx: &mut App,
+    ) -> Option<Arc<dyn crate::WorktreeDelegate>> {
+        let proxy = self.worktree_proxy.read().clone()?;
+        proxy.worktree_delegate(worktree_id, cx)
     }
 }
 
@@ -282,6 +320,10 @@ impl ExtensionLanguageProxy for ExtensionHostProxy {
 
         proxy.remove_languages(languages_to_remove, grammars_to_remove)
     }
+}
+
+pub trait ExtensionProviderProxy: Send + Sync + 'static {
+    fn extension_by_id(&self, extension_id: &str) -> Option<Arc<dyn Extension>>;
 }
 
 pub trait ExtensionLanguageServerProxy: Send + Sync + 'static {

--- a/crates/extension/src/types.rs
+++ b/crates/extension/src/types.rs
@@ -2,6 +2,7 @@ mod context_server;
 mod dap;
 mod lsp;
 mod slash_command;
+mod tasks;
 
 use std::{ops::Range, path::PathBuf};
 
@@ -11,6 +12,7 @@ pub use context_server::*;
 pub use dap::*;
 pub use lsp::*;
 pub use slash_command::*;
+pub use tasks::*;
 
 /// A list of environment variables.
 pub type EnvVars = Vec<(String, String)>;

--- a/crates/extension/src/types/tasks.rs
+++ b/crates/extension/src/types/tasks.rs
@@ -141,7 +141,7 @@ impl language::ContextProvider for ExtensionContextProvider {
             path: file.path().as_std_path().to_string_lossy().to_string(),
         });
 
-        cx.spawn(async move |cx| {
+        cx.spawn(async move |cx: &mut gpui::AsyncApp| {
             let mut templates = static_templates.unwrap_or_default();
             let worktree_delegate = if let Some(worktree_id) = worktree_id {
                 cx.update(|cx| proxy.worktree_delegate(worktree_id, cx))

--- a/crates/extension/src/types/tasks.rs
+++ b/crates/extension/src/types/tasks.rs
@@ -1,0 +1,175 @@
+use crate::ExtensionWorktreeProxy;
+use anyhow::anyhow;
+use gpui::AppContext;
+use std::sync::Arc;
+
+use language::ToOffset;
+use task::{HideStrategy, RevealStrategy, RevealTarget, Shell, TaskTemplate};
+use util::ResultExt as _;
+
+#[derive(Debug, Clone)]
+pub struct TaskContextLocation {
+    pub worktree_id: u64,
+    /// Path relative to the worktree root.
+    pub file_path: String,
+    pub range: std::ops::Range<usize>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TaskContextFile {
+    pub worktree_id: u64,
+    /// Path relative to the worktree root.
+    pub path: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct TaskVariable {
+    pub name: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct TaskDefinition {
+    pub label: String,
+    pub command: String,
+    pub args: Vec<String>,
+    pub env: Vec<(String, String)>,
+    pub cwd: Option<String>,
+    pub use_new_terminal: Option<bool>,
+    pub allow_concurrent_runs: Option<bool>,
+    pub reveal: Option<RevealStrategy>,
+    pub reveal_target: Option<RevealTarget>,
+    pub hide: Option<HideStrategy>,
+    pub shell: Option<Shell>,
+    pub show_summary: Option<bool>,
+    pub show_command: Option<bool>,
+    pub tags: Vec<String>,
+}
+
+impl From<TaskDefinition> for TaskTemplate {
+    fn from(definition: TaskDefinition) -> Self {
+        Self {
+            label: definition.label,
+            command: definition.command,
+            args: definition.args,
+            env: definition.env.into_iter().collect(),
+            cwd: definition.cwd,
+            use_new_terminal: definition.use_new_terminal.unwrap_or_default(),
+            allow_concurrent_runs: definition.allow_concurrent_runs.unwrap_or_default(),
+            reveal: definition.reveal.unwrap_or_default(),
+            reveal_target: definition.reveal_target.unwrap_or_default(),
+            hide: definition.hide.unwrap_or_default(),
+            shell: definition.shell.unwrap_or_default(),
+            show_summary: definition.show_summary.unwrap_or(true),
+            show_command: definition.show_command.unwrap_or(true),
+            tags: definition.tags,
+        }
+    }
+}
+
+pub struct ExtensionContextProvider {
+    pub extension_id: Arc<str>,
+    pub language_name: language::LanguageName,
+    pub static_templates: Option<task::TaskTemplates>,
+}
+
+impl language::ContextProvider for ExtensionContextProvider {
+    fn build_context(
+        &self,
+        _variables: &task::TaskVariables,
+        location: language::ContextLocation<'_>,
+        _project_env: Option<collections::HashMap<String, String>>,
+        _toolchains: Arc<dyn language::LanguageToolchainStore>,
+        cx: &mut gpui::App,
+    ) -> gpui::Task<anyhow::Result<task::TaskVariables>> {
+        let extension_id = self.extension_id.clone();
+        let language_name = self.language_name.clone();
+        let proxy = crate::ExtensionHostProxy::global(cx);
+        let buffer = location.file_location.buffer.read(cx);
+        let file = buffer.file();
+        let worktree_id = file.map(|f| f.worktree_id(cx).to_proto()).unwrap_or(0);
+        let file_path = file
+            .map(|f| f.path().as_std_path().to_string_lossy().to_string())
+            .unwrap_or_default();
+        let snapshot = buffer.text_snapshot();
+        let range = location.file_location.range.start.to_offset(&snapshot)
+            ..location.file_location.range.end.to_offset(&snapshot);
+
+        let location = TaskContextLocation {
+            worktree_id,
+            file_path,
+            range,
+        };
+
+        let worktree_delegate = proxy.worktree_delegate(worktree_id, cx);
+
+        cx.background_spawn(async move {
+            let worktree_delegate =
+                worktree_delegate.ok_or_else(|| anyhow!("worktree delegate not found"))?;
+
+            let extension = proxy
+                .extension_by_id(&extension_id)
+                .ok_or_else(|| anyhow!("extension not found"))?;
+            let variables = extension
+                .build_context(language_name.to_string(), location, worktree_delegate)
+                .await?;
+            let mut result = task::TaskVariables::default();
+            for variable in variables {
+                result.insert(
+                    task::VariableName::Custom(variable.name.into()),
+                    variable.value,
+                );
+            }
+
+            Ok(result)
+        })
+    }
+
+    fn associated_tasks(
+        &self,
+        file: Option<Arc<dyn language::File>>,
+        cx: &gpui::App,
+    ) -> gpui::Task<Option<task::TaskTemplates>> {
+        let extension_id = self.extension_id.clone();
+        let language_name = self.language_name.clone();
+        let static_templates = self.static_templates.clone();
+        let proxy = crate::ExtensionHostProxy::global(cx);
+
+        let worktree_id = file.as_ref().map(|file| file.worktree_id(cx).to_proto());
+        let file = file.map(|file| TaskContextFile {
+            worktree_id: worktree_id.unwrap_or(0),
+            path: file.path().as_std_path().to_string_lossy().to_string(),
+        });
+
+        cx.spawn(async move |cx| {
+            let mut templates = static_templates.unwrap_or_default();
+            let worktree_delegate = if let Some(worktree_id) = worktree_id {
+                cx.update(|cx| proxy.worktree_delegate(worktree_id, cx))
+                    .ok()
+                    .flatten()
+            } else {
+                None
+            };
+
+            if let (Some(extension), Some(worktree_delegate)) =
+                (proxy.extension_by_id(&extension_id), worktree_delegate)
+            {
+                if let Some(definitions) = extension
+                    .associated_tasks(language_name.to_string(), file, worktree_delegate)
+                    .await
+                    .log_err()
+                {
+                    templates
+                        .0
+                        .extend(definitions.into_iter().map(task::TaskTemplate::from));
+                }
+            }
+
+            if templates.0.is_empty() {
+                None
+            } else {
+                Some(templates)
+            }
+        })
+    }
+}

--- a/crates/extension/src/types/tasks.rs
+++ b/crates/extension/src/types/tasks.rs
@@ -1,0 +1,129 @@
+use crate::ExtensionWorktreeProxy;
+use anyhow::anyhow;
+use gpui::AppContext;
+use std::sync::Arc;
+
+use language::ToOffset;
+use util::ResultExt as _;
+
+#[derive(Debug, Clone)]
+pub struct TaskContextLocation {
+    pub worktree_id: u64,
+    /// Path relative to the worktree root.
+    pub file_path: String,
+    pub range: std::ops::Range<usize>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TaskContextFile {
+    pub worktree_id: u64,
+    /// Path relative to the worktree root.
+    pub path: String,
+}
+
+pub struct ExtensionContextProvider {
+    pub extension_id: Arc<str>,
+    pub language_name: language::LanguageName,
+    pub static_templates: Option<task::TaskTemplates>,
+}
+
+impl language::ContextProvider for ExtensionContextProvider {
+    fn build_context(
+        &self,
+        variables: &task::TaskVariables,
+        location: language::ContextLocation<'_>,
+        project_env: Option<collections::HashMap<String, String>>,
+        _toolchains: Arc<dyn language::LanguageToolchainStore>,
+        cx: &mut gpui::App,
+    ) -> gpui::Task<anyhow::Result<task::TaskVariables>> {
+        let extension_id = self.extension_id.clone();
+        let language_name = self.language_name.clone();
+        let variables = variables.clone();
+        let proxy = crate::ExtensionHostProxy::global(cx);
+        let buffer = location.file_location.buffer.read(cx);
+        let file = buffer.file();
+        let snapshot = buffer.text_snapshot();
+        let range = location.file_location.range.start.to_offset(&snapshot)
+            ..location.file_location.range.end.to_offset(&snapshot);
+
+        let location = file.map(|file| TaskContextLocation {
+            worktree_id: file.worktree_id(cx).to_proto(),
+            file_path: file.path().as_std_path().to_string_lossy().to_string(),
+            range,
+        });
+        let worktree_delegate = location
+            .as_ref()
+            .and_then(|location| proxy.worktree_delegate(location.worktree_id, cx));
+
+        cx.background_spawn(async move {
+            let Some(location) = location else {
+                anyhow::bail!("buffer has no file; cannot build task context");
+            };
+            let worktree_delegate = worktree_delegate.ok_or_else(|| {
+                anyhow!(
+                    "no worktree found for id {}; cannot build task context",
+                    location.worktree_id
+                )
+            })?;
+
+            let extension = proxy
+                .extension_by_id(&extension_id)
+                .ok_or_else(|| anyhow!("extension not found"))?;
+            extension
+                .build_context(
+                    language_name.to_string(),
+                    variables,
+                    project_env,
+                    location,
+                    worktree_delegate,
+                )
+                .await
+        })
+    }
+
+    fn associated_tasks(
+        &self,
+        buffer: Option<gpui::Entity<language::Buffer>>,
+        cx: &gpui::App,
+    ) -> gpui::Task<Option<task::TaskTemplates>> {
+        let extension_id = self.extension_id.clone();
+        let language_name = self.language_name.clone();
+        let static_templates = self.static_templates.clone();
+        let proxy = crate::ExtensionHostProxy::global(cx);
+
+        let file = buffer.as_ref().and_then(|buffer| {
+            buffer.read(cx).file().map(|file| TaskContextFile {
+                worktree_id: file.worktree_id(cx).to_proto(),
+                path: file.path().as_std_path().to_string_lossy().to_string(),
+            })
+        });
+        let worktree_id = file.as_ref().map(|file| file.worktree_id);
+
+        cx.spawn(async move |cx: &mut gpui::AsyncApp| {
+            let mut templates = static_templates.unwrap_or_default();
+            let worktree_delegate = if let Some(worktree_id) = worktree_id {
+                cx.update(|cx| proxy.worktree_delegate(worktree_id, cx))
+            } else {
+                None
+            };
+
+            if let (Some(extension), Some(worktree_delegate)) =
+                (proxy.extension_by_id(&extension_id), worktree_delegate)
+            {
+                if let Some(definitions) = extension
+                    .associated_tasks(language_name.to_string(), file, worktree_delegate)
+                    .await
+                    .log_err()
+                {
+                    templates.0.extend(definitions);
+                }
+            }
+
+            if templates.0.is_empty() {
+                None
+            } else {
+                Some(templates)
+            }
+        })
+    }
+}

--- a/crates/extension/src/types/tasks.rs
+++ b/crates/extension/src/types/tasks.rs
@@ -107,8 +107,9 @@ impl language::ContextProvider for ExtensionContextProvider {
                 None
             };
 
-            if let (Some(extension), Some(worktree_delegate)) =
-                (proxy.extension_by_id(&extension_id), worktree_delegate)
+            if let Some((extension, worktree_delegate)) = proxy
+                .extension_by_id(&extension_id)
+                .zip(worktree_delegate)
             {
                 if let Some(definitions) = extension
                     .associated_tasks(language_name.to_string(), file, worktree_delegate)

--- a/crates/extension_api/src/extension_api.rs
+++ b/crates/extension_api/src/extension_api.rs
@@ -37,6 +37,10 @@ pub use wit::{
     zed::extension::slash_command::{
         SlashCommand, SlashCommandArgumentCompletion, SlashCommandOutput, SlashCommandOutputSection,
     },
+    zed::extension::task::{
+        HideStrategy, RevealStrategy, RevealTarget, Shell, ShellWithArguments, TaskContextFile,
+        TaskContextLocation, TaskDefinition, TaskVariable,
+    },
 };
 
 // Undocumented WIT re-exports.
@@ -175,7 +179,27 @@ pub trait Extension: Send + Sync {
         Ok(None)
     }
 
-    /// Returns a list of package names as suggestions to be included in the
+    /// Returns custom task variables for a given location in a file.
+    fn build_context(
+        &mut self,
+        _language_name: String,
+        _location: &TaskContextLocation,
+        _worktree: &Worktree,
+    ) -> Result<Vec<TaskVariable>> {
+        Ok(Vec::new())
+    }
+
+    /// Returns task definitions associated with the current file or project.
+    fn associated_tasks(
+        &mut self,
+        _language_name: String,
+        _file: Option<&TaskContextFile>,
+        _worktree: &Worktree,
+    ) -> Result<Vec<TaskDefinition>> {
+        Ok(Vec::new())
+    }
+
+    /// Returns a list of packages as suggestions to be included in the `/docs`
     /// search results of the `/docs` slash command.
     ///
     /// This can be used to provide completions for known packages (e.g., from the
@@ -516,6 +540,22 @@ impl wit::Guest for Component {
         build_task: TaskTemplate,
     ) -> Result<DebugRequest, String> {
         extension().run_dap_locator(locator_name, build_task)
+    }
+
+    fn build_context(
+        language_name: String,
+        location: TaskContextLocation,
+        worktree: &Worktree,
+    ) -> Result<Vec<TaskVariable>, String> {
+        extension().build_context(language_name, &location, worktree)
+    }
+
+    fn associated_tasks(
+        language_name: String,
+        file: Option<TaskContextFile>,
+        worktree: &Worktree,
+    ) -> Result<Vec<TaskDefinition>, String> {
+        extension().associated_tasks(language_name, file.as_ref(), worktree)
     }
 }
 

--- a/crates/extension_api/src/extension_api.rs
+++ b/crates/extension_api/src/extension_api.rs
@@ -37,6 +37,10 @@ pub use wit::{
     zed::extension::slash_command::{
         SlashCommand, SlashCommandArgumentCompletion, SlashCommandOutput, SlashCommandOutputSection,
     },
+    zed::extension::task::{
+        HideStrategy, RevealStrategy, RevealTarget, Shell, ShellWithArguments, TaskContextFile,
+        TaskContextLocation, TaskDefinition, TaskVariable,
+    },
 };
 
 // Undocumented WIT re-exports.
@@ -197,7 +201,35 @@ pub trait Extension: Send + Sync {
         Ok(None)
     }
 
-    /// Returns a list of package names as suggestions to be included in the
+    /// Returns custom task variables for a given location in a file.
+    ///
+    /// `variables` contains the task variables resolved so far and the names in the list
+    /// this method returns will be prefixed with `ZED_CUSTOM_` and then merged with it.
+    /// Note that if this returns variables by the same name as tree-sitter captures, (already
+    /// seen with `ZED_CUSTOM_` prefix here) it will override their values.
+
+    fn build_context(
+        &mut self,
+        _language_name: String,
+        _variables: Vec<TaskVariable>,
+        _project_env: Option<EnvVars>,
+        _location: &TaskContextLocation,
+        _worktree: &Worktree,
+    ) -> Result<Vec<TaskVariable>> {
+        Ok(Vec::new())
+    }
+
+    /// Returns task definitions associated with the current file or project.
+    fn associated_tasks(
+        &mut self,
+        _language_name: String,
+        _file: Option<&TaskContextFile>,
+        _worktree: &Worktree,
+    ) -> Result<Vec<TaskDefinition>> {
+        Ok(Vec::new())
+    }
+
+    /// Returns a list of packages as suggestions to be included in the `/docs`
     /// search results of the `/docs` slash command.
     ///
     /// This can be used to provide completions for known packages (e.g., from the
@@ -558,6 +590,24 @@ impl wit::Guest for Component {
         build_task: TaskTemplate,
     ) -> Result<DebugRequest, String> {
         extension().run_dap_locator(locator_name, build_task)
+    }
+
+    fn build_context(
+        language_name: String,
+        variables: Vec<TaskVariable>,
+        project_env: Option<EnvVars>,
+        location: TaskContextLocation,
+        worktree: &Worktree,
+    ) -> Result<Vec<TaskVariable>, String> {
+        extension().build_context(language_name, variables, project_env, &location, worktree)
+    }
+
+    fn associated_tasks(
+        language_name: String,
+        file: Option<TaskContextFile>,
+        worktree: &Worktree,
+    ) -> Result<Vec<TaskDefinition>, String> {
+        extension().associated_tasks(language_name, file.as_ref(), worktree)
     }
 }
 

--- a/crates/extension_api/src/extension_api.rs
+++ b/crates/extension_api/src/extension_api.rs
@@ -206,13 +206,13 @@ pub trait Extension: Send + Sync {
     /// `variables` contains the task variables resolved so far and the names in the list
     /// this method returns will be prefixed with `ZED_CUSTOM_` and then merged with it.
     /// Note that if this returns variables by the same name as tree-sitter captures, (already
-    /// seen with `ZED_CUSTOM_` prefix here) it will override their values.
+    /// seen with `ZED_CUSTOM_` prefix in `variables`) it will override their values.
 
     fn build_context(
         &mut self,
-        _language_name: String,
-        _variables: Vec<TaskVariable>,
-        _project_env: Option<EnvVars>,
+        _language_name: &LanguageName,
+        _variables: &[TaskVariable],
+        _project_env: Option<&EnvVars>,
         _location: &TaskContextLocation,
         _worktree: &Worktree,
     ) -> Result<Vec<TaskVariable>> {
@@ -222,7 +222,7 @@ pub trait Extension: Send + Sync {
     /// Returns task definitions associated with the current file or project.
     fn associated_tasks(
         &mut self,
-        _language_name: String,
+        _language_name: &LanguageName,
         _file: Option<&TaskContextFile>,
         _worktree: &Worktree,
     ) -> Result<Vec<TaskDefinition>> {
@@ -599,7 +599,13 @@ impl wit::Guest for Component {
         location: TaskContextLocation,
         worktree: &Worktree,
     ) -> Result<Vec<TaskVariable>, String> {
-        extension().build_context(language_name, variables, project_env, &location, worktree)
+        extension().build_context(
+            &LanguageName(language_name),
+            &variables,
+            project_env.as_ref(),
+            &location,
+            worktree,
+        )
     }
 
     fn associated_tasks(
@@ -607,7 +613,7 @@ impl wit::Guest for Component {
         file: Option<TaskContextFile>,
         worktree: &Worktree,
     ) -> Result<Vec<TaskDefinition>, String> {
-        extension().associated_tasks(language_name, file.as_ref(), worktree)
+        extension().associated_tasks(&LanguageName(language_name), file.as_ref(), worktree)
     }
 }
 
@@ -624,6 +630,28 @@ impl LanguageServerId {
 impl AsRef<str> for LanguageServerId {
     fn as_ref(&self) -> &str {
         &self.0
+    }
+}
+
+/// The name of a language.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+pub struct LanguageName(String);
+
+impl LanguageName {
+    pub fn new(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl AsRef<str> for LanguageName {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for LanguageName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 

--- a/crates/extension_api/wit/since_v0.8.0/extension.wit
+++ b/crates/extension_api/wit/since_v0.8.0/extension.wit
@@ -2,6 +2,7 @@ package zed:extension;
 
 world extension {
     import context-server;
+    import task;
     import dap;
     import github;
     import http-client;
@@ -11,6 +12,7 @@ world extension {
 
     use common.{env-vars, range};
     use context-server.{context-server-configuration};
+    use task.{task-context-location, task-variable, task-context-file, task-definition};
     use dap.{attach-request, build-task-template, debug-config, debug-adapter-binary, debug-task-definition, debug-request, debug-scenario, launch-request, resolved-task, start-debugging-request-arguments-request};
     use lsp.{completion, symbol};
     use process.{command};
@@ -133,6 +135,12 @@ world extension {
 
     export labels-for-completions: func(language-server-id: string, completions: list<completion>) -> result<list<option<code-label>>, string>;
     export labels-for-symbols: func(language-server-id: string, symbols: list<symbol>) -> result<list<option<code-label>>, string>;
+
+    /// Returns the task variables for the given location.
+    export build-context: func(language-name: string, location: task-context-location, worktree: borrow<worktree>) -> result<list<task-variable>, string>;
+
+    /// Returns the tasks associated with the given file.
+    export associated-tasks: func(language-name: string, file: option<task-context-file>, worktree: borrow<worktree>) -> result<list<task-definition>, string>;
 
 
     /// Returns the completions that should be shown when completing the provided slash command with the given query.

--- a/crates/extension_api/wit/since_v0.8.0/extension.wit
+++ b/crates/extension_api/wit/since_v0.8.0/extension.wit
@@ -2,6 +2,7 @@ package zed:extension;
 
 world extension {
     import context-server;
+    import task;
     import dap;
     import github;
     import http-client;
@@ -11,6 +12,7 @@ world extension {
 
     use common.{env-vars, range};
     use context-server.{context-server-configuration};
+    use task.{task-context-location, task-variable, task-context-file, task-definition};
     use dap.{attach-request, build-task-template, debug-config, debug-adapter-binary, debug-task-definition, debug-request, debug-scenario, launch-request, resolved-task, start-debugging-request-arguments-request};
     use lsp.{completion, symbol};
     use process.{command};
@@ -145,6 +147,15 @@ world extension {
 
     export labels-for-completions: func(language-server-id: string, completions: list<completion>) -> result<list<option<code-label>>, string>;
     export labels-for-symbols: func(language-server-id: string, symbols: list<symbol>) -> result<list<option<code-label>>, string>;
+
+    /// Returns the task variables for the given location.
+    ///
+    /// `variables` contains the task variables resolved so far and is input context only.
+    /// The result should contain the variables to add, overwriting same-named ones.
+    export build-context: func(language-name: string, variables: list<task-variable>, project-env: option<env-vars>, location: task-context-location, worktree: borrow<worktree>) -> result<list<task-variable>, string>;
+
+    /// Returns the tasks associated with the given file.
+    export associated-tasks: func(language-name: string, file: option<task-context-file>, worktree: borrow<worktree>) -> result<list<task-definition>, string>;
 
 
     /// Returns the completions that should be shown when completing the provided slash command with the given query.

--- a/crates/extension_api/wit/since_v0.8.0/task.wit
+++ b/crates/extension_api/wit/since_v0.8.0/task.wit
@@ -1,0 +1,54 @@
+interface task {
+    use common.{range, env-vars};
+
+    record task-context-location {
+        worktree-id: u64,
+        /// Path relative to the worktree root.
+        file-path: string,
+        range: range,
+    }
+
+    record task-context-file {
+        worktree-id: u64,
+        /// Path relative to the worktree root.
+        path: string,
+    }
+
+    record task-variable {
+        name: string,
+        value: string,
+    }
+
+    record task-definition {
+        label: string,
+        command: string,
+        args: list<string>,
+        env: env-vars,
+        cwd: option<string>,
+        use-new-terminal: option<bool>,
+        allow-concurrent-runs: option<bool>,
+        reveal: option<reveal-strategy>,
+        reveal-target: option<reveal-target>,
+        hide: option<hide-strategy>,
+        shell: option<shell>,
+        show-summary: option<bool>,
+        show-command: option<bool>,
+        tags: list<string>,
+    }
+
+    enum reveal-strategy { always, no-focus, never }
+    enum reveal-target { center, dock }
+    enum hide-strategy { never, always, on-success }
+
+    variant shell {
+        system,
+        program(string),
+        with-arguments(shell-with-arguments),
+    }
+
+    record shell-with-arguments {
+        program: string,
+        args: list<string>,
+        title-override: option<string>,
+    }
+}

--- a/crates/extension_host/Cargo.toml
+++ b/crates/extension_host/Cargo.toml
@@ -34,6 +34,7 @@ log.workspace = true
 lsp.workspace = true
 moka.workspace = true
 node_runtime.workspace = true
+parking_lot.workspace = true
 paths.workspace = true
 project.workspace = true
 remote.workspace = true

--- a/crates/extension_host/Cargo.toml
+++ b/crates/extension_host/Cargo.toml
@@ -35,6 +35,7 @@ log.workspace = true
 lsp.workspace = true
 moka.workspace = true
 node_runtime.workspace = true
+parking_lot.workspace = true
 paths.workspace = true
 project.workspace = true
 remote.workspace = true

--- a/crates/extension_host/src/extension_host.rs
+++ b/crates/extension_host/src/extension_host.rs
@@ -11,12 +11,12 @@ use async_compression::futures::bufread::GzipDecoder;
 use async_tar::Archive;
 use client::ExtensionProvides;
 use client::{Client, ExtensionMetadata, GetExtensionsResponse, proto, telemetry::Telemetry};
-use collections::{BTreeMap, BTreeSet, HashSet, btree_map};
+use collections::{BTreeMap, BTreeSet, HashMap, HashSet, btree_map};
 pub use extension::ExtensionManifest;
 use extension::extension_builder::{CompileExtensionOptions, ExtensionBuilder};
 use extension::{
-    ExtensionContextServerProxy, ExtensionDebugAdapterProviderProxy, ExtensionEvents,
-    ExtensionGrammarProxy, ExtensionHostProxy, ExtensionLanguageProxy,
+    ExtensionContextProvider, ExtensionContextServerProxy, ExtensionDebugAdapterProviderProxy,
+    ExtensionEvents, ExtensionGrammarProxy, ExtensionHostProxy, ExtensionLanguageProxy,
     ExtensionLanguageServerProxy, ExtensionSlashCommandProxy, ExtensionSnippetProxy,
     ExtensionThemeProxy,
 };
@@ -41,7 +41,8 @@ use language::{
     QUERY_FILENAME_PREFIXES, Rope,
 };
 use node_runtime::NodeRuntime;
-use project::ContextProviderWithTasks;
+use parking_lot::RwLock;
+
 use release_channel::ReleaseChannel;
 use remote::RemoteClient;
 use semver::Version;
@@ -68,6 +69,20 @@ pub use extension::{
 pub use extension_settings::ExtensionSettings;
 
 pub const RELOAD_DEBOUNCE_DURATION: Duration = Duration::from_millis(200);
+
+#[derive(Clone)]
+struct ExtensionProvider {
+    wasm_extensions: Arc<RwLock<HashMap<Arc<str>, Arc<WasmExtension>>>>,
+}
+
+impl extension::ExtensionProviderProxy for ExtensionProvider {
+    fn extension_by_id(&self, extension_id: &str) -> Option<Arc<dyn extension::Extension>> {
+        self.wasm_extensions
+            .read()
+            .get(extension_id)
+            .map(|extension| extension.clone() as Arc<dyn extension::Extension>)
+    }
+}
 const FS_WATCH_LATENCY: Duration = Duration::from_millis(100);
 
 /// The current extension [`SchemaVersion`] supported by Zed.
@@ -121,7 +136,8 @@ pub struct ExtensionStore {
     pub index_path: PathBuf,
     pub modified_extensions: HashSet<Arc<str>>,
     pub wasm_host: Arc<WasmHost>,
-    pub wasm_extensions: Vec<(Arc<ExtensionManifest>, WasmExtension)>,
+    extension_provider: Arc<ExtensionProvider>,
+    pub wasm_extensions: Vec<(Arc<ExtensionManifest>, Arc<WasmExtension>)>,
     pub tasks: Vec<Task<()>>,
     pub remote_clients: Vec<WeakEntity<RemoteClient>>,
     pub ssh_registered_tx: UnboundedSender<()>,
@@ -267,6 +283,9 @@ impl ExtensionStore {
                 work_dir,
                 cx,
             ),
+            extension_provider: Arc::new(ExtensionProvider {
+                wasm_extensions: Arc::new(RwLock::new(HashMap::default())),
+            }),
             wasm_extensions: Vec::new(),
             fs,
             http_client,
@@ -289,6 +308,9 @@ impl ExtensionStore {
                     this.fs.metadata(&this.installed_dir),
                 )
             });
+
+        let proxy = ExtensionHostProxy::global(cx);
+        proxy.register_extension_provider_proxy((*this.extension_provider).clone());
 
         // Normally, there is no need to rebuild the index. But if the index file
         // is invalid or is out-of-date according to the filesystem mtimes, then
@@ -1224,6 +1246,11 @@ impl ExtensionStore {
 
         self.wasm_extensions
             .retain(|(extension, _)| !extensions_to_unload.contains(&extension.id));
+        let mut wasm_extensions = self.extension_provider.wasm_extensions.write();
+        for id in &extensions_to_unload {
+            wasm_extensions.remove(id);
+        }
+        drop(wasm_extensions);
         self.proxy.remove_user_themes(themes_to_remove);
         self.proxy.remove_icon_themes(icon_themes_to_remove);
         self.proxy
@@ -1273,6 +1300,7 @@ impl ExtensionStore {
             .languages
             .iter()
             .filter(|(_, entry)| extensions_to_load.contains(&entry.extension))
+            .map(|(name, language)| (name.clone(), language.clone()))
             .collect::<Vec<_>>();
         for (language_name, language) in languages_to_add {
             let mut language_path = self.installed_dir.clone();
@@ -1280,6 +1308,11 @@ impl ExtensionStore {
                 Path::new(language.extension.as_ref()),
                 language.path.as_path(),
             ]);
+            let extension_id = language.extension.clone();
+            // let grammar = language.grammar.clone();
+            // let matcher = language.matcher.clone();
+            // let hidden = language.hidden;
+            let language_name = language_name.clone();
             self.proxy.register_language(
                 language_name.clone(),
                 language.grammar.clone(),
@@ -1289,14 +1322,17 @@ impl ExtensionStore {
                     let config = std::fs::read_to_string(language_path.join("config.toml"))?;
                     let config: LanguageConfig = ::toml::from_str(&config)?;
                     let queries = load_plugin_queries(&language_path);
-                    let context_provider =
+                    let static_templates =
                         std::fs::read_to_string(language_path.join("tasks.json"))
                             .ok()
-                            .and_then(|contents| {
-                                let definitions =
-                                    serde_json_lenient::from_str(&contents).log_err()?;
-                                Some(Arc::new(ContextProviderWithTasks::new(definitions)) as Arc<_>)
-                            });
+                            .and_then(|contents| serde_json_lenient::from_str(&contents).log_err());
+
+                    let context_provider = Some(Arc::new(ExtensionContextProvider {
+                        extension_id: extension_id.clone(),
+                        language_name: language_name.clone(),
+                        static_templates,
+                    })
+                        as Arc<dyn language::ContextProvider>);
 
                     Ok(LoadedLanguage {
                         config,
@@ -1396,7 +1432,7 @@ impl ExtensionStore {
                 this.reload_complete_senders.clear();
 
                 for (manifest, wasm_extension) in &wasm_extensions {
-                    let extension = Arc::new(wasm_extension.clone());
+                    let extension = wasm_extension.clone();
 
                     for (language_server_id, language_server_config) in &manifest.language_servers {
                         for language in language_server_config.languages() {
@@ -1451,7 +1487,11 @@ impl ExtensionStore {
                     }
                 }
 
-                this.wasm_extensions.extend(wasm_extensions);
+                this.wasm_extensions.extend(wasm_extensions.clone());
+                this.extension_provider
+                    .wasm_extensions
+                    .write()
+                    .extend(wasm_extensions.into_iter().map(|(m, e)| (m.id.clone(), e)));
                 this.proxy.set_extensions_loaded();
                 this.proxy.reload_current_theme(cx);
                 this.proxy.reload_current_icon_theme(cx);

--- a/crates/extension_host/src/extension_host.rs
+++ b/crates/extension_host/src/extension_host.rs
@@ -15,8 +15,8 @@ use collections::{BTreeMap, BTreeSet, FxHashSet, HashMap, HashSet, btree_map};
 pub use extension::ExtensionManifest;
 use extension::extension_builder::{CompileExtensionOptions, ExtensionBuilder};
 use extension::{
-    ExtensionContextServerProxy, ExtensionDebugAdapterProviderProxy, ExtensionEvents,
-    ExtensionGrammarProxy, ExtensionHostProxy, ExtensionLanguageProxy,
+    ExtensionContextProvider, ExtensionContextServerProxy, ExtensionDebugAdapterProviderProxy,
+    ExtensionEvents, ExtensionGrammarProxy, ExtensionHostProxy, ExtensionLanguageProxy,
     ExtensionLanguageServerProxy, ExtensionSnippetProxy, ExtensionThemeProxy,
 };
 use fs::{Fs, RemoveOptions, RenameOptions};
@@ -40,7 +40,8 @@ use language::{
     QueryFileContents, QueryFiles, Rope,
 };
 use node_runtime::NodeRuntime;
-use project::{ContextProviderWithTasks, Project};
+use parking_lot::RwLock;
+use project::Project;
 use release_channel::ReleaseChannel;
 use remote::{ConnectionState, RemoteClient, RemoteClientEvent};
 use semver::Version;
@@ -76,6 +77,20 @@ pub use extension_settings::ExtensionSettings;
 use crate::headless_host::hash_directory_contents;
 
 pub const RELOAD_DEBOUNCE_DURATION: Duration = Duration::from_millis(200);
+
+#[derive(Clone)]
+struct ExtensionProvider {
+    wasm_extensions: Arc<RwLock<HashMap<Arc<str>, Arc<WasmExtension>>>>,
+}
+
+impl extension::ExtensionProviderProxy for ExtensionProvider {
+    fn extension_by_id(&self, extension_id: &str) -> Option<Arc<dyn extension::Extension>> {
+        self.wasm_extensions
+            .read()
+            .get(extension_id)
+            .map(|extension| extension.clone() as Arc<dyn extension::Extension>)
+    }
+}
 const FS_WATCH_LATENCY: Duration = Duration::from_millis(100);
 pub(crate) const REMOTE_SYNC_RETRY_DELAY: Duration = Duration::from_secs(1);
 pub(crate) const MAX_REMOTE_SYNC_RETRY_DELAY: Duration = Duration::from_secs(60);
@@ -172,7 +187,8 @@ pub struct ExtensionStore {
     pub index_path: PathBuf,
     pub modified_extensions: HashSet<Arc<str>>,
     pub wasm_host: Arc<WasmHost>,
-    pub wasm_extensions: Vec<(Arc<ExtensionManifest>, WasmExtension)>,
+    extension_provider: Arc<ExtensionProvider>,
+    pub wasm_extensions: Vec<(Arc<ExtensionManifest>, Arc<WasmExtension>)>,
     pub tasks: Vec<Task<()>>,
     pub(crate) remote_clients: HashMap<EntityId, RemoteClientState>,
     pub(crate) initial_index_load: Shared<Task<()>>,
@@ -396,6 +412,9 @@ impl ExtensionStore {
                 work_dir,
                 cx,
             ),
+            extension_provider: Arc::new(ExtensionProvider {
+                wasm_extensions: Arc::new(RwLock::new(HashMap::default())),
+            }),
             wasm_extensions: Vec::new(),
             fs,
             http_client,
@@ -418,6 +437,9 @@ impl ExtensionStore {
                     this.fs.metadata(&this.installed_dir),
                 )
             });
+
+        let proxy = ExtensionHostProxy::global(cx);
+        proxy.register_extension_provider_proxy((*this.extension_provider).clone());
 
         // Normally, there is no need to rebuild the index. But if the index file
         // is invalid or is out-of-date according to the filesystem mtimes, then
@@ -1397,6 +1419,11 @@ impl ExtensionStore {
 
         self.wasm_extensions
             .retain(|(extension, _)| !extensions_to_unload.contains(&extension.id));
+        let mut wasm_extensions = self.extension_provider.wasm_extensions.write();
+        for id in &extensions_to_unload {
+            wasm_extensions.remove(id);
+        }
+        drop(wasm_extensions);
         self.proxy.remove_user_themes(themes_to_remove);
         self.proxy.remove_icon_themes(icon_themes_to_remove);
         self.proxy
@@ -1507,6 +1534,8 @@ impl ExtensionStore {
             ]);
             let rules_path = language_path.join(SemanticTokenRules::FILE_NAME);
 
+            let extension_id = language.extension.clone();
+            let language_name_for_loader = language_name.clone();
             let registered = self.proxy.register_language(
                 language_name.clone(),
                 language.grammar.clone(),
@@ -1515,11 +1544,24 @@ impl ExtensionStore {
                 Arc::new({
                     let fs = self.fs.clone();
                     let query_files = language.query_files;
+                    let extension_id = extension_id.clone();
+                    let language_name = language_name_for_loader;
                     move || {
                         let fs = fs.clone();
                         let language_path = language_path.clone();
-                        async move { load_plugin_language(fs, &language_path, query_files).await }
-                            .boxed()
+                        let extension_id = extension_id.clone();
+                        let language_name = language_name.clone();
+                        async move {
+                            load_plugin_language(
+                                fs,
+                                &language_path,
+                                query_files,
+                                extension_id,
+                                language_name,
+                            )
+                            .await
+                        }
+                        .boxed()
                     }
                 }),
             );
@@ -1527,7 +1569,7 @@ impl ExtensionStore {
                 continue;
             }
 
-            semantic_token_rules_paths.push((language_name, rules_path));
+            semantic_token_rules_paths.push((language_name.clone(), rules_path));
         }
 
         let fs = self.fs.clone();
@@ -1653,7 +1695,7 @@ impl ExtensionStore {
                 this.reload_complete_senders.clear();
 
                 for (manifest, wasm_extension) in &wasm_extensions {
-                    let extension = Arc::new(wasm_extension.clone());
+                    let extension = wasm_extension.clone();
 
                     for (language_server_id, language_server_config) in &manifest.language_servers {
                         for language in language_server_config.languages() {
@@ -1693,7 +1735,11 @@ impl ExtensionStore {
                     }
                 }
 
-                this.wasm_extensions.extend(wasm_extensions);
+                this.wasm_extensions.extend(wasm_extensions.clone());
+                this.extension_provider
+                    .wasm_extensions
+                    .write()
+                    .extend(wasm_extensions.into_iter().map(|(m, e)| (m.id.clone(), e)));
                 this.proxy.set_extensions_loaded();
                 this.proxy.reload_current_theme(cx);
                 this.proxy.reload_current_icon_theme(cx);
@@ -2329,6 +2375,8 @@ async fn load_plugin_language(
     fs: Arc<dyn Fs>,
     language_path: &Path,
     query_files: Option<QueryFiles>,
+    extension_id: Arc<str>,
+    language_name: LanguageName,
 ) -> Result<LoadedLanguage> {
     let config = {
         let fs = fs.clone();
@@ -2338,24 +2386,27 @@ async fn load_plugin_language(
             toml::from_str::<LanguageConfig>(&contents).map_err(anyhow::Error::from)
         }
     };
-    let context_provider = {
+    let static_templates = {
         let fs = fs.clone();
         let tasks_path = language_path.join(TaskTemplates::FILE_NAME);
         async move {
-            fs.load(&tasks_path).await.ok().and_then(|contents| {
-                serde_json_lenient::from_str(&contents)
-                    .log_err()
-                    .map(|definitions| {
-                        Arc::new(ContextProviderWithTasks::new(definitions)) as Arc<_>
-                    })
-            })
+            fs.load(&tasks_path)
+                .await
+                .ok()
+                .and_then(|contents| serde_json_lenient::from_str(&contents).log_err())
         }
     };
-    let (config, queries, context_provider) = futures::try_join!(
+    let (config, queries, static_templates) = futures::try_join!(
         config,
         async move { Ok(load_plugin_queries(fs, &language_path, query_files).await) },
-        async move { Ok(context_provider.await) }
+        async move { Ok(static_templates.await) }
     )?;
+
+    let context_provider = Some(Arc::new(ExtensionContextProvider {
+        extension_id,
+        language_name,
+        static_templates,
+    }) as Arc<dyn language::ContextProvider>);
 
     Ok(LoadedLanguage {
         config,

--- a/crates/extension_host/src/extension_host.rs
+++ b/crates/extension_host/src/extension_host.rs
@@ -1533,9 +1533,6 @@ impl ExtensionStore {
                 language.path.as_path(),
             ]);
             let rules_path = language_path.join(SemanticTokenRules::FILE_NAME);
-
-            let extension_id = language.extension.clone();
-            let language_name_for_loader = language_name.clone();
             let registered = self.proxy.register_language(
                 language_name.clone(),
                 language.grammar.clone(),
@@ -1544,8 +1541,8 @@ impl ExtensionStore {
                 Arc::new({
                     let fs = self.fs.clone();
                     let query_files = language.query_files;
-                    let extension_id = extension_id.clone();
-                    let language_name = language_name_for_loader;
+                    let extension_id = language.extension;
+                    let language_name = language_name.clone();
                     move || {
                         let fs = fs.clone();
                         let language_path = language_path.clone();
@@ -1736,10 +1733,11 @@ impl ExtensionStore {
                 }
 
                 this.wasm_extensions.extend(wasm_extensions.clone());
-                this.extension_provider
-                    .wasm_extensions
-                    .write()
-                    .extend(wasm_extensions.into_iter().map(|(m, e)| (m.id.clone(), e)));
+                this.extension_provider.wasm_extensions.write().extend(
+                    wasm_extensions
+                        .into_iter()
+                        .map(|(manifest, extension)| (manifest.id.clone(), extension)),
+                );
                 this.proxy.set_extensions_loaded();
                 this.proxy.reload_current_theme(cx);
                 this.proxy.reload_current_icon_theme(cx);

--- a/crates/extension_host/src/extension_store_test.rs
+++ b/crates/extension_host/src/extension_store_test.rs
@@ -4102,6 +4102,26 @@ impl Extension for FakeExtension {
         Arc::from(Path::new("/fake-extension-work-dir"))
     }
 
+    async fn build_context(
+        &self,
+        _language_name: String,
+        _variables: task::TaskVariables,
+        _project_env: Option<collections::HashMap<String, String>>,
+        _location: extension::TaskContextLocation,
+        _worktree: Arc<dyn WorktreeDelegate>,
+    ) -> anyhow::Result<task::TaskVariables> {
+        Ok(task::TaskVariables::default())
+    }
+
+    async fn associated_tasks(
+        &self,
+        _language_name: String,
+        _file: Option<extension::TaskContextFile>,
+        _worktree: Arc<dyn WorktreeDelegate>,
+    ) -> anyhow::Result<Vec<task::TaskTemplate>> {
+        Ok(Vec::new())
+    }
+
     async fn language_server_command(
         &self,
         _language_server_id: LanguageServerName,

--- a/crates/extension_host/src/headless_host.rs
+++ b/crates/extension_host/src/headless_host.rs
@@ -172,7 +172,7 @@ impl HeadlessExtensionStore {
         }
 
         let wasm_extension: Arc<dyn Extension> =
-            Arc::new(WasmExtension::load(&extension_dir, &manifest, wasm_host.clone(), cx).await?);
+            WasmExtension::load(&extension_dir, &manifest, wasm_host.clone(), cx).await?;
 
         for (language_server_id, language_server_config) in &manifest.language_servers {
             for language in language_server_config.languages() {

--- a/crates/extension_host/src/headless_host.rs
+++ b/crates/extension_host/src/headless_host.rs
@@ -282,9 +282,7 @@ impl HeadlessExtensionStore {
         let mut debug_locators = Vec::new();
         let mut wasm_extension: Option<Arc<dyn Extension>> = None;
         if manifest.allow_remote_load() {
-            wasm_extension = Some(Arc::new(
-                WasmExtension::load(&load_dir, &manifest, wasm_host, cx).await?,
-            ));
+            wasm_extension = Some(WasmExtension::load(&load_dir, &manifest, wasm_host, cx).await?);
 
             for (language_server_id, language_server_config) in &manifest.language_servers {
                 for language in language_server_config.languages() {

--- a/crates/extension_host/src/wasm_host.rs
+++ b/crates/extension_host/src/wasm_host.rs
@@ -9,7 +9,7 @@ use extension::{
     CodeLabel, Command, Completion, ContextServerConfiguration, DebugAdapterBinary,
     DebugTaskDefinition, ExtensionCapability, ExtensionHostProxy, KeyValueStoreDelegate,
     ProjectDelegate, SlashCommand, SlashCommandArgumentCompletion, SlashCommandOutput, Symbol,
-    WorktreeDelegate,
+    TaskContextFile, TaskContextLocation, TaskDefinition, TaskVariable, WorktreeDelegate,
 };
 use fs::{Fs, normalize_path};
 use futures::future::LocalBoxFuture;
@@ -62,7 +62,7 @@ pub struct WasmHost {
     main_thread_message_tx: mpsc::UnboundedSender<MainThreadCall>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct WasmExtension {
     tx: UnboundedSender<ExtensionCall>,
     pub manifest: Arc<ExtensionManifest>,
@@ -488,6 +488,48 @@ impl extension::Extension for WasmExtension {
         })
         .await?
     }
+
+    async fn build_context(
+        &self,
+        language_name: String,
+        location: TaskContextLocation,
+        worktree: Arc<dyn WorktreeDelegate>,
+    ) -> Result<Vec<TaskVariable>> {
+        self.call(|extension, store| {
+            async move {
+                let resource = store.data_mut().table().push(worktree)?;
+                let variables = extension
+                    .call_build_context(store, &language_name, location.into(), resource)
+                    .await?
+                    .map_err(|err| store.data().extension_error(err))?;
+
+                Ok(variables.into_iter().map(Into::into).collect())
+            }
+            .boxed()
+        })
+        .await?
+    }
+
+    async fn associated_tasks(
+        &self,
+        language_name: String,
+        file: Option<TaskContextFile>,
+        worktree: Arc<dyn WorktreeDelegate>,
+    ) -> Result<Vec<TaskDefinition>> {
+        self.call(|extension, store| {
+            async move {
+                let resource = store.data_mut().table().push(worktree)?;
+                let tasks = extension
+                    .call_associated_tasks(store, &language_name, file.map(Into::into), resource)
+                    .await?
+                    .map_err(|err| store.data().extension_error(err))?;
+
+                Ok(tasks.into_iter().map(Into::into).collect())
+            }
+            .boxed()
+        })
+        .await?
+    }
 }
 
 pub struct WasmState {
@@ -600,7 +642,7 @@ impl WasmHost {
         wasm_bytes: Vec<u8>,
         manifest: &Arc<ExtensionManifest>,
         cx: &AsyncApp,
-    ) -> Task<Result<WasmExtension>> {
+    ) -> Task<Result<Arc<WasmExtension>>> {
         let this = self.clone();
         let manifest = manifest.clone();
         let executor = cx.background_executor().clone();
@@ -668,13 +710,13 @@ impl WasmHost {
             // call into tokio, accessing its runtime handle when we trigger the `engine.increment_epoch()` above.
             let task = Arc::new(gpui_tokio::Tokio::spawn(cx, extension_task)?);
 
-            Ok(WasmExtension {
+            Ok(Arc::new(WasmExtension {
                 manifest,
                 work_dir,
                 tx,
                 zed_api_version,
                 _task: task,
-            })
+            }))
         })
     }
 
@@ -758,7 +800,7 @@ impl WasmExtension {
         manifest: &Arc<ExtensionManifest>,
         wasm_host: Arc<WasmHost>,
         cx: &AsyncApp,
-    ) -> Result<Self> {
+    ) -> Result<Arc<Self>> {
         let path = extension_dir.join("extension.wasm");
 
         let mut wasm_file = wasm_host

--- a/crates/extension_host/src/wasm_host.rs
+++ b/crates/extension_host/src/wasm_host.rs
@@ -556,10 +556,10 @@ impl extension::Extension for WasmExtension {
                     .await?
                     .map_err(|err| store.data().extension_error(err))?;
 
-                let mut result = TaskVariables::default();
-                for variable in variables {
-                    result.insert(VariableName::Custom(variable.name.into()), variable.value);
-                }
+                let result = variables
+                    .into_iter()
+                    .map(|variable| (VariableName::Custom(variable.name.into()), variable.value))
+                    .collect();
                 Ok(result)
             }
             .boxed()

--- a/crates/extension_host/src/wasm_host.rs
+++ b/crates/extension_host/src/wasm_host.rs
@@ -9,7 +9,7 @@ use extension::{
     CodeLabel, Command, Completion, ContextServerConfiguration, DebugAdapterBinary,
     DebugTaskDefinition, ExtensionCapability, ExtensionHostProxy, KeyValueStoreDelegate,
     ProjectDelegate, SlashCommand, SlashCommandArgumentCompletion, SlashCommandOutput, Symbol,
-    WorktreeDelegate,
+    TaskContextFile, TaskContextLocation, WorktreeDelegate,
 };
 use fs::Fs;
 use futures::future::LocalBoxFuture;
@@ -36,7 +36,9 @@ use std::{
     sync::{Arc, LazyLock, OnceLock},
     time::Duration,
 };
-use task::{DebugScenario, SpawnInTerminal, TaskTemplate, ZedDebugConfig};
+use task::{
+    DebugScenario, SpawnInTerminal, TaskTemplate, TaskVariables, VariableName, ZedDebugConfig,
+};
 use util::paths::SanitizedPath;
 use wasmtime::{
     CacheStore, Engine, Store,
@@ -59,7 +61,7 @@ pub struct WasmHost {
     main_thread_message_tx: mpsc::UnboundedSender<MainThreadCall>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct WasmExtension {
     tx: UnboundedSender<ExtensionCall>,
     pub manifest: Arc<ExtensionManifest>,
@@ -530,6 +532,61 @@ impl extension::Extension for WasmExtension {
         })
         .await?
     }
+
+    async fn build_context(
+        &self,
+        language_name: String,
+        variables: TaskVariables,
+        project_env: Option<collections::HashMap<String, String>>,
+        location: TaskContextLocation,
+        worktree: Arc<dyn WorktreeDelegate>,
+    ) -> Result<TaskVariables> {
+        self.call(|extension, store| {
+            async move {
+                let resource = store.data_mut().table.push(worktree)?;
+                let variables = extension
+                    .call_build_context(
+                        store,
+                        &language_name,
+                        &variables,
+                        project_env.as_ref(),
+                        location.into(),
+                        resource,
+                    )
+                    .await?
+                    .map_err(|err| store.data().extension_error(err))?;
+
+                let mut result = TaskVariables::default();
+                for variable in variables {
+                    result.insert(VariableName::Custom(variable.name.into()), variable.value);
+                }
+                Ok(result)
+            }
+            .boxed()
+        })
+        .await?
+    }
+
+    async fn associated_tasks(
+        &self,
+        language_name: String,
+        file: Option<TaskContextFile>,
+        worktree: Arc<dyn WorktreeDelegate>,
+    ) -> Result<Vec<TaskTemplate>> {
+        self.call(|extension, store| {
+            async move {
+                let resource = store.data_mut().table.push(worktree)?;
+                let tasks = extension
+                    .call_associated_tasks(store, &language_name, file.map(Into::into), resource)
+                    .await?
+                    .map_err(|err| store.data().extension_error(err))?;
+
+                Ok(tasks.into_iter().map(Into::into).collect())
+            }
+            .boxed()
+        })
+        .await?
+    }
 }
 
 pub struct WasmState {
@@ -637,7 +694,7 @@ impl WasmHost {
         wasm_bytes: Vec<u8>,
         manifest: &Arc<ExtensionManifest>,
         cx: &AsyncApp,
-    ) -> Task<Result<WasmExtension>> {
+    ) -> Task<Result<Arc<WasmExtension>>> {
         let this = self.clone();
         let manifest = manifest.clone();
         let executor = cx.background_executor().clone();
@@ -720,13 +777,13 @@ impl WasmHost {
             // calls may invoke wasi functions that require a tokio runtime.
             let task = Arc::new(gpui_tokio::Tokio::spawn(cx, extension_task));
 
-            Ok(WasmExtension {
+            Ok(Arc::new(WasmExtension {
                 manifest,
                 work_dir,
                 tx,
                 zed_api_version,
                 _task: task,
-            })
+            }))
         })
     }
 
@@ -852,7 +909,7 @@ impl WasmExtension {
         manifest: &Arc<ExtensionManifest>,
         wasm_host: Arc<WasmHost>,
         cx: &AsyncApp,
-    ) -> Result<Self> {
+    ) -> Result<Arc<Self>> {
         let path = extension_dir.join("extension.wasm");
 
         let mut wasm_file = wasm_host

--- a/crates/extension_host/src/wasm_host/wit.rs
+++ b/crates/extension_host/src/wasm_host/wit.rs
@@ -1159,12 +1159,12 @@ impl Extension {
         match self {
             Extension::V0_8_0(ext) => {
                 let config = config.into();
-                let dap_binary = ext
+                let scenario = ext
                     .call_dap_config_to_scenario(store, &config)
                     .await?
                     .map_err(|error| wasmtime::Error::msg(format!("{error:?}")))?;
 
-                Ok(Ok(dap_binary.try_into().into_wasmtime_result()?))
+                Ok(Ok(scenario.try_into().into_wasmtime_result()?))
             }
             Extension::V0_6_0(ext) => {
                 let config: latest::DebugConfig = config.into();
@@ -1200,7 +1200,7 @@ impl Extension {
         match self {
             Extension::V0_8_0(ext) => {
                 let build_config_template = build_config_template.into();
-                let dap_binary = ext
+                let scenario = ext
                     .call_dap_locator_create_scenario(
                         store,
                         &locator_name,
@@ -1210,7 +1210,7 @@ impl Extension {
                     )
                     .await?;
 
-                Ok(dap_binary
+                Ok(scenario
                     .map(TryInto::try_into)
                     .transpose()
                     .into_wasmtime_result()?)
@@ -1283,6 +1283,59 @@ impl Extension {
             | Extension::V0_0_1(_) => Err(wasmtime::Error::msg(
                 "`run_dap_locator` not available prior to v0.6.0",
             )),
+        }
+    }
+
+    pub async fn call_build_context(
+        &self,
+        store: &mut Store<WasmState>,
+        language_name: &str,
+        variables: &task::TaskVariables,
+        project_env: Option<&collections::HashMap<String, String>>,
+        location: latest::TaskContextLocation,
+        worktree: Resource<latest::ExtensionWorktree>,
+    ) -> wasmtime::Result<Result<Vec<latest::TaskVariable>, String>> {
+        match self {
+            Extension::V0_8_0(ext) => {
+                let wit_variables = variables
+                    .iter()
+                    .map(|(name, value)| latest::TaskVariable {
+                        name: name.to_string(),
+                        value: value.clone(),
+                    })
+                    .collect::<Vec<_>>();
+                let wit_project_env = project_env.map(|env| {
+                    env.iter()
+                        .map(|(k, v)| (k.clone(), v.clone()))
+                        .collect::<Vec<_>>()
+                });
+                ext.call_build_context(
+                    store,
+                    language_name,
+                    &wit_variables,
+                    wit_project_env.as_ref(),
+                    &location,
+                    worktree,
+                )
+                .await
+            }
+            _ => Ok(Ok(Vec::new())),
+        }
+    }
+
+    pub async fn call_associated_tasks(
+        &self,
+        store: &mut Store<WasmState>,
+        language_name: &str,
+        file: Option<latest::TaskContextFile>,
+        worktree: Resource<latest::ExtensionWorktree>,
+    ) -> wasmtime::Result<Result<Vec<latest::TaskDefinition>, String>> {
+        match self {
+            Extension::V0_8_0(ext) => {
+                ext.call_associated_tasks(store, language_name, file.as_ref(), worktree)
+                    .await
+            }
+            _ => Ok(Ok(Vec::new())),
         }
     }
 }

--- a/crates/extension_host/src/wasm_host/wit.rs
+++ b/crates/extension_host/src/wasm_host/wit.rs
@@ -1319,7 +1319,15 @@ impl Extension {
                 )
                 .await
             }
-            _ => Ok(Ok(Vec::new())),
+            Extension::V0_0_1(_)
+            | Extension::V0_0_4(_)
+            | Extension::V0_0_6(_)
+            | Extension::V0_1_0(_)
+            | Extension::V0_2_0(_)
+            | Extension::V0_3_0(_)
+            | Extension::V0_4_0(_)
+            | Extension::V0_5_0(_)
+            | Extension::V0_6_0(_) => Ok(Ok(Vec::new())),
         }
     }
 
@@ -1335,7 +1343,15 @@ impl Extension {
                 ext.call_associated_tasks(store, language_name, file.as_ref(), worktree)
                     .await
             }
-            _ => Ok(Ok(Vec::new())),
+            Extension::V0_0_1(_)
+            | Extension::V0_0_4(_)
+            | Extension::V0_0_6(_)
+            | Extension::V0_1_0(_)
+            | Extension::V0_2_0(_)
+            | Extension::V0_3_0(_)
+            | Extension::V0_4_0(_)
+            | Extension::V0_5_0(_)
+            | Extension::V0_6_0(_) => Ok(Ok(Vec::new())),
         }
     }
 }

--- a/crates/extension_host/src/wasm_host/wit/since_v0_8_0.rs
+++ b/crates/extension_host/src/wasm_host/wit/since_v0_8_0.rs
@@ -1,4 +1,3 @@
-use crate::wasm_host::wit::since_v0_6_0::slash_command::SlashCommandOutputSection;
 use crate::wasm_host::wit::{CompletionKind, CompletionLabelDetails, InsertTextFormat, SymbolKind};
 use crate::wasm_host::{
     WasmState,
@@ -6,6 +5,7 @@ use crate::wasm_host::{
 };
 use ::http_client::{AsyncBody, HttpRequestExt};
 use ::settings::{Settings, WorktreeId};
+use ::task::ZedDebugConfig;
 use anyhow::{Context as _, Result, bail};
 use async_compression::futures::bufread::GzipDecoder;
 use async_tar::Archive;
@@ -26,7 +26,6 @@ use std::{
     str::FromStr,
     sync::{Arc, OnceLock},
 };
-use task::{SpawnInTerminal, ZedDebugConfig};
 use url::Url;
 use util::{
     archive::extract_zip, fs::make_file_executable, maybe, paths::PathStyle, rel_path::RelPath,
@@ -111,6 +110,7 @@ impl TryFrom<dap::StartDebuggingRequestArguments> for extension::StartDebuggingR
         })
     }
 }
+
 impl From<dap::IpAddress> for IpAddr {
     fn from(value: dap::IpAddress) -> Self {
         match value {
@@ -167,7 +167,7 @@ impl From<dap::TcpArgumentsTemplate> for extension::TcpArgumentsTemplate {
     }
 }
 
-impl TryFrom<extension::DebugTaskDefinition> for DebugTaskDefinition {
+impl TryFrom<extension::DebugTaskDefinition> for self::dap::DebugTaskDefinition {
     type Error = anyhow::Error;
     fn try_from(value: extension::DebugTaskDefinition) -> Result<Self, Self::Error> {
         Ok(Self {
@@ -179,26 +179,130 @@ impl TryFrom<extension::DebugTaskDefinition> for DebugTaskDefinition {
     }
 }
 
-impl From<task::DebugRequest> for DebugRequest {
-    fn from(value: task::DebugRequest) -> Self {
-        match value {
-            task::DebugRequest::Launch(launch_request) => Self::Launch(launch_request.into()),
-            task::DebugRequest::Attach(attach_request) => Self::Attach(attach_request.into()),
+impl TryFrom<self::dap::DebugAdapterBinary> for extension::DebugAdapterBinary {
+    type Error = anyhow::Error;
+    fn try_from(value: self::dap::DebugAdapterBinary) -> Result<Self, Self::Error> {
+        Ok(Self {
+            command: value.command,
+            arguments: value.arguments,
+            envs: value.envs.into_iter().collect(),
+            cwd: value.cwd.map(PathBuf::from),
+            connection: value.connection.map(Into::into),
+            request_args: value.request_args.try_into()?,
+        })
+    }
+}
+
+impl From<ZedDebugConfig> for self::dap::DebugConfig {
+    fn from(value: ZedDebugConfig) -> Self {
+        Self {
+            label: value.label.to_string(),
+            adapter: value.adapter.to_string(),
+            request: value.request.into(),
+            stop_on_entry: value.stop_on_entry,
         }
     }
 }
 
-impl From<DebugRequest> for task::DebugRequest {
-    fn from(value: DebugRequest) -> Self {
-        match value {
-            DebugRequest::Launch(launch_request) => Self::Launch(launch_request.into()),
-            DebugRequest::Attach(attach_request) => Self::Attach(attach_request.into()),
+impl From<self::task::TaskDefinition> for ::task::TaskTemplate {
+    fn from(value: self::task::TaskDefinition) -> Self {
+        Self {
+            label: value.label,
+            command: value.command,
+            args: value.args,
+            env: value.env.into_iter().collect(),
+            cwd: value.cwd,
+            use_new_terminal: value.use_new_terminal.unwrap_or_default(),
+            allow_concurrent_runs: value.allow_concurrent_runs.unwrap_or_default(),
+            reveal: value.reveal.map(Into::into).unwrap_or_default(),
+            reveal_target: value.reveal_target.map(Into::into).unwrap_or_default(),
+            hide: value.hide.map(Into::into).unwrap_or_default(),
+            shell: value.shell.map(Into::into).unwrap_or_default(),
+            show_summary: value.show_summary.unwrap_or(true),
+            show_command: value.show_command.unwrap_or(true),
+            tags: value.tags,
+            save: Default::default(),
+            hooks: Default::default(),
         }
     }
 }
 
-impl From<task::LaunchRequest> for LaunchRequest {
-    fn from(value: task::LaunchRequest) -> Self {
+impl From<extension::TaskContextLocation> for self::task::TaskContextLocation {
+    fn from(value: extension::TaskContextLocation) -> Self {
+        Self {
+            worktree_id: value.worktree_id,
+            file_path: value.file_path,
+            range: self::common::Range {
+                start: value.range.start as u32,
+                end: value.range.end as u32,
+            },
+        }
+    }
+}
+
+impl From<extension::TaskContextFile> for self::task::TaskContextFile {
+    fn from(value: extension::TaskContextFile) -> Self {
+        Self {
+            worktree_id: value.worktree_id,
+            path: value.path,
+        }
+    }
+}
+
+impl From<self::task::RevealStrategy> for ::task::RevealStrategy {
+    fn from(value: self::task::RevealStrategy) -> Self {
+        match value {
+            self::task::RevealStrategy::Always => Self::Always,
+            self::task::RevealStrategy::NoFocus => Self::NoFocus,
+            self::task::RevealStrategy::Never => Self::Never,
+        }
+    }
+}
+
+impl From<self::task::RevealTarget> for ::task::RevealTarget {
+    fn from(value: self::task::RevealTarget) -> Self {
+        match value {
+            self::task::RevealTarget::Center => Self::Center,
+            self::task::RevealTarget::Dock => Self::Dock,
+        }
+    }
+}
+
+impl From<self::task::HideStrategy> for ::task::HideStrategy {
+    fn from(value: self::task::HideStrategy) -> Self {
+        match value {
+            self::task::HideStrategy::Never => Self::Never,
+            self::task::HideStrategy::Always => Self::Always,
+            self::task::HideStrategy::OnSuccess => Self::OnSuccess,
+        }
+    }
+}
+
+impl From<self::task::Shell> for ::task::Shell {
+    fn from(value: self::task::Shell) -> Self {
+        match value {
+            self::task::Shell::System => Self::System,
+            self::task::Shell::Program(p) => Self::Program(p),
+            self::task::Shell::WithArguments(s) => Self::WithArguments {
+                program: s.program,
+                args: s.args,
+                title_override: s.title_override,
+            },
+        }
+    }
+}
+
+impl From<::task::DebugRequest> for self::dap::DebugRequest {
+    fn from(value: ::task::DebugRequest) -> Self {
+        match value {
+            ::task::DebugRequest::Launch(launch) => Self::Launch(launch.into()),
+            ::task::DebugRequest::Attach(attach) => Self::Attach(attach.into()),
+        }
+    }
+}
+
+impl From<::task::LaunchRequest> for self::dap::LaunchRequest {
+    fn from(value: ::task::LaunchRequest) -> Self {
         Self {
             program: value.program,
             cwd: value.cwd.map(|p| p.to_string_lossy().into_owned()),
@@ -208,53 +312,39 @@ impl From<task::LaunchRequest> for LaunchRequest {
     }
 }
 
-impl From<task::AttachRequest> for AttachRequest {
-    fn from(value: task::AttachRequest) -> Self {
-        Self {
-            process_id: value.process_id,
-        }
-    }
-}
-
-impl From<LaunchRequest> for task::LaunchRequest {
-    fn from(value: LaunchRequest) -> Self {
+impl From<self::dap::LaunchRequest> for ::task::LaunchRequest {
+    fn from(value: self::dap::LaunchRequest) -> Self {
         Self {
             program: value.program,
-            cwd: value.cwd.map(|p| p.into()),
+            cwd: value.cwd.map(PathBuf::from),
             args: value.args,
             env: value.envs.into_iter().collect(),
         }
     }
 }
-impl From<AttachRequest> for task::AttachRequest {
-    fn from(value: AttachRequest) -> Self {
+
+impl From<::task::AttachRequest> for self::dap::AttachRequest {
+    fn from(value: ::task::AttachRequest) -> Self {
         Self {
             process_id: value.process_id,
         }
     }
 }
 
-impl From<ZedDebugConfig> for DebugConfig {
-    fn from(value: ZedDebugConfig) -> Self {
+impl From<self::dap::AttachRequest> for ::task::AttachRequest {
+    fn from(value: self::dap::AttachRequest) -> Self {
         Self {
-            label: value.label.into(),
-            adapter: value.adapter.into(),
-            request: value.request.into(),
-            stop_on_entry: value.stop_on_entry,
+            process_id: value.process_id,
         }
     }
 }
-impl TryFrom<DebugAdapterBinary> for extension::DebugAdapterBinary {
-    type Error = anyhow::Error;
-    fn try_from(value: DebugAdapterBinary) -> Result<Self, Self::Error> {
-        Ok(Self {
-            command: value.command,
-            arguments: value.arguments,
-            envs: value.envs.into_iter().collect(),
-            cwd: value.cwd.map(|s| s.into()),
-            connection: value.connection.map(Into::into),
-            request_args: value.request_args.try_into()?,
-        })
+
+impl From<self::dap::DebugRequest> for ::task::DebugRequest {
+    fn from(value: self::dap::DebugRequest) -> Self {
+        match value {
+            self::dap::DebugRequest::Launch(launch) => Self::Launch(launch.into()),
+            self::dap::DebugRequest::Attach(attach) => Self::Attach(attach.into()),
+        }
     }
 }
 
@@ -273,30 +363,42 @@ impl From<dap::BuildTaskDefinition> for extension::BuildTaskDefinition {
 impl From<extension::BuildTaskDefinition> for dap::BuildTaskDefinition {
     fn from(value: extension::BuildTaskDefinition) -> Self {
         match value {
-            extension::BuildTaskDefinition::ByName(name) => Self::ByName(name.into()),
+            extension::BuildTaskDefinition::ByName(name) => Self::ByName(name.to_string()),
             extension::BuildTaskDefinition::Template {
                 task_template,
                 locator_name,
             } => Self::Template(dap::BuildTaskDefinitionTemplatePayload {
                 template: task_template.into(),
-                locator_name: locator_name.map(String::from),
+                locator_name: locator_name.map(|s| s.as_ref().to_string()),
             }),
         }
     }
 }
-impl From<BuildTaskTemplate> for extension::BuildTaskTemplate {
-    fn from(value: BuildTaskTemplate) -> Self {
+
+impl From<self::dap::BuildTaskTemplate> for extension::BuildTaskTemplate {
+    fn from(value: self::dap::BuildTaskTemplate) -> Self {
         Self {
             label: value.label,
             command: value.command,
             args: value.args,
             env: value.env.into_iter().collect(),
             cwd: value.cwd,
-            ..Default::default()
+            use_new_terminal: Default::default(),
+            allow_concurrent_runs: Default::default(),
+            reveal: Default::default(),
+            reveal_target: Default::default(),
+            hide: Default::default(),
+            tags: Default::default(),
+            shell: Default::default(),
+            show_summary: true,
+            show_command: true,
+            save: Default::default(),
+            hooks: Default::default(),
         }
     }
 }
-impl From<extension::BuildTaskTemplate> for BuildTaskTemplate {
+
+impl From<extension::BuildTaskTemplate> for self::dap::BuildTaskTemplate {
     fn from(value: extension::BuildTaskTemplate) -> Self {
         Self {
             label: value.label,
@@ -308,10 +410,10 @@ impl From<extension::BuildTaskTemplate> for BuildTaskTemplate {
     }
 }
 
-impl TryFrom<DebugScenario> for extension::DebugScenario {
+impl TryFrom<self::dap::DebugScenario> for extension::DebugScenario {
     type Error = anyhow::Error;
 
-    fn try_from(value: DebugScenario) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: self::dap::DebugScenario) -> std::result::Result<Self, Self::Error> {
         Ok(Self {
             adapter: value.adapter.into(),
             label: value.label.into(),
@@ -322,11 +424,11 @@ impl TryFrom<DebugScenario> for extension::DebugScenario {
     }
 }
 
-impl From<extension::DebugScenario> for DebugScenario {
+impl From<extension::DebugScenario> for self::dap::DebugScenario {
     fn from(value: extension::DebugScenario) -> Self {
         Self {
-            adapter: value.adapter.into(),
-            label: value.label.into(),
+            adapter: value.adapter.to_string(),
+            label: value.label.to_string(),
             build: value.build.map(Into::into),
             config: value.config.to_string(),
             tcp_connection: value.tcp_connection.map(Into::into),
@@ -334,10 +436,10 @@ impl From<extension::DebugScenario> for DebugScenario {
     }
 }
 
-impl TryFrom<SpawnInTerminal> for ResolvedTask {
+impl TryFrom<::task::SpawnInTerminal> for self::dap::ResolvedTask {
     type Error = anyhow::Error;
 
-    fn try_from(value: SpawnInTerminal) -> Result<Self, Self::Error> {
+    fn try_from(value: ::task::SpawnInTerminal) -> Result<Self, Self::Error> {
         Ok(Self {
             label: value.label,
             command: value.command.context("missing command")?,
@@ -351,6 +453,21 @@ impl TryFrom<SpawnInTerminal> for ResolvedTask {
                     s.into_owned()
                 }
             }),
+        })
+    }
+}
+
+impl TryFrom<self::dap::ResolvedTask> for ::task::SpawnInTerminal {
+    type Error = anyhow::Error;
+
+    fn try_from(value: self::dap::ResolvedTask) -> Result<Self, Self::Error> {
+        Ok(Self {
+            label: value.label.clone(),
+            command: Some(value.command),
+            args: value.args,
+            env: value.env.into_iter().collect(),
+            cwd: value.cwd.map(PathBuf::from),
+            ..Default::default()
         })
     }
 }
@@ -502,8 +619,8 @@ impl From<extension::SlashCommand> for SlashCommand {
     }
 }
 
-impl From<SlashCommandOutput> for extension::SlashCommandOutput {
-    fn from(value: SlashCommandOutput) -> Self {
+impl From<self::slash_command::SlashCommandOutput> for extension::SlashCommandOutput {
+    fn from(value: self::slash_command::SlashCommandOutput) -> Self {
         Self {
             text: value.text,
             sections: value.sections.into_iter().map(Into::into).collect(),
@@ -511,10 +628,10 @@ impl From<SlashCommandOutput> for extension::SlashCommandOutput {
     }
 }
 
-impl From<SlashCommandOutputSection> for extension::SlashCommandOutputSection {
-    fn from(value: SlashCommandOutputSection) -> Self {
+impl From<self::slash_command::SlashCommandOutputSection> for extension::SlashCommandOutputSection {
+    fn from(value: self::slash_command::SlashCommandOutputSection) -> Self {
         Self {
-            range: value.range.start as usize..value.range.end as usize,
+            range: value.range.into(),
             label: value.label,
         }
     }
@@ -925,14 +1042,16 @@ impl slash_command::Host for WasmState {}
 #[async_trait]
 impl context_server::Host for WasmState {}
 
-impl dap::Host for WasmState {
+impl self::zed::extension::task::Host for WasmState {}
+
+impl self::zed::extension::dap::Host for WasmState {
     async fn resolve_tcp_template(
         &mut self,
         template: dap::TcpArgumentsTemplate,
     ) -> wasmtime::Result<Result<dap::TcpArguments, String>> {
         maybe!(async {
             let (host, port, timeout) =
-                ::dap::configure_tcp_connection(task::TcpArgumentsTemplate {
+                ::dap::configure_tcp_connection(::task::TcpArgumentsTemplate {
                     port: template.port,
                     host: template.host.map(Into::into),
                     timeout: template.timeout,

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -3973,6 +3973,33 @@ impl LspStore {
         }
     }
 
+    pub fn lsp_adapter_delegate(
+        &self,
+        worktree: Entity<Worktree>,
+        cx: &mut App,
+    ) -> Option<Arc<dyn LspAdapterDelegate>> {
+        let (languages, environment, weak, http_client, fs) = match &self.mode {
+            LspStoreMode::Local(local) => (
+                local.languages.clone(),
+                local.environment.clone(),
+                local.weak.clone(),
+                local.http_client.clone(),
+                local.fs.clone(),
+            ),
+            LspStoreMode::Remote(_) => return None,
+        };
+
+        Some(LocalLspAdapterDelegate::new(
+            languages,
+            &environment,
+            weak,
+            &worktree,
+            http_client,
+            fs,
+            cx,
+        ))
+    }
+
     pub fn upstream_client(&self) -> Option<(AnyProtoClient, u64)> {
         match &self.mode {
             LspStoreMode::Remote(RemoteLspStore {

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -4617,6 +4617,33 @@ impl LspStore {
         }
     }
 
+    pub fn lsp_adapter_delegate(
+        &self,
+        worktree: Entity<Worktree>,
+        cx: &mut App,
+    ) -> Option<Arc<dyn LspAdapterDelegate>> {
+        let (languages, environment, weak, http_client, fs) = match &self.mode {
+            LspStoreMode::Local(local) => (
+                local.languages.clone(),
+                local.environment.clone(),
+                local.weak.clone(),
+                local.http_client.clone(),
+                local.fs.clone(),
+            ),
+            LspStoreMode::Remote(_) => return None,
+        };
+
+        Some(LocalLspAdapterDelegate::new(
+            languages,
+            &environment,
+            weak,
+            &worktree,
+            http_client,
+            fs,
+            cx,
+        ))
+    }
+
     pub fn upstream_client(&self) -> Option<(AnyProtoClient, u64)> {
         match &self.mode {
             LspStoreMode::Remote(RemoteLspStore {

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -25,9 +25,11 @@ pub mod trusted_worktrees;
 pub mod worktree_store;
 
 mod environment;
+use async_trait::async_trait;
 use buffer_diff::BufferDiff;
 use context_server_store::ContextServerStore;
 pub use environment::ProjectEnvironmentEvent;
+use extension;
 use git::repository::get_git_committer;
 use git_store::{Repository, RepositoryId};
 pub mod search_history;
@@ -185,6 +187,81 @@ impl Default for LocalProjectFlags {
             init_worktree_trust: true,
             watch_global_configs: true,
         }
+    }
+}
+
+/// An adapter that allows an [`language::LspAdapterDelegate`] to be used as a [`WorktreeDelegate`].
+pub struct WorktreeDelegateAdapter(pub Arc<dyn language::LspAdapterDelegate>);
+
+#[async_trait]
+impl extension::WorktreeDelegate for WorktreeDelegateAdapter {
+    fn id(&self) -> u64 {
+        self.0.worktree_id().to_proto()
+    }
+
+    fn root_path(&self) -> String {
+        self.0.worktree_root_path().to_string_lossy().into_owned()
+    }
+
+    async fn read_text_file(&self, path: &RelPath) -> Result<String> {
+        self.0.read_text_file(path).await
+    }
+
+    async fn which(&self, binary_name: String) -> Option<String> {
+        self.0
+            .which(binary_name.as_ref())
+            .await
+            .map(|path| path.to_string_lossy().into_owned())
+    }
+
+    async fn shell_env(&self) -> Vec<(String, String)> {
+        self.0.shell_env().await.into_iter().collect()
+    }
+}
+
+#[derive(Default)]
+struct GlobalProjectRegistry(Vec<WeakEntity<Project>>);
+
+impl gpui::Global for GlobalProjectRegistry {}
+
+struct ProjectWorktreeProxy;
+
+impl extension::ExtensionWorktreeProxy for ProjectWorktreeProxy {
+    fn worktree_delegate(
+        &self,
+        worktree_id: u64,
+        cx: &mut App,
+    ) -> Option<Arc<dyn extension::WorktreeDelegate>> {
+        let worktree_id = WorktreeId::from_proto(worktree_id);
+        if !cx.has_global::<GlobalProjectRegistry>() {
+            return None;
+        }
+        let projects = {
+            let registry = cx.global_mut::<GlobalProjectRegistry>();
+            registry.0.retain(|handle| handle.upgrade().is_some());
+            registry.0.clone()
+        };
+
+        for project_handle in projects {
+            if let Some(project) = project_handle.upgrade() {
+                let (lsp_store, worktree) = project.read_with(cx, |project, app| {
+                    (
+                        project.lsp_store.clone(),
+                        project.worktree_for_id(worktree_id, app),
+                    )
+                });
+
+                if let Some(worktree) = worktree {
+                    let delegate = lsp_store.update(cx, |lsp_store, cx| {
+                        lsp_store.lsp_adapter_delegate(worktree, cx)
+                    });
+                    if let Some(delegate) = delegate {
+                        return Some(Arc::new(WorktreeDelegateAdapter(delegate)));
+                    }
+                }
+            }
+        }
+        None
     }
 }
 
@@ -1202,6 +1279,10 @@ impl Project {
         DapStore::init(&client, cx);
         BreakpointStore::init(&client);
         context_server_store::init(cx);
+
+        let proxy = extension::ExtensionHostProxy::global(cx);
+        proxy.register_worktree_proxy(ProjectWorktreeProxy);
+        cx.default_global::<GlobalProjectRegistry>();
     }
 
     pub fn local(
@@ -1215,6 +1296,13 @@ impl Project {
         cx: &mut App,
     ) -> Entity<Self> {
         cx.new(|cx: &mut Context<Self>| {
+            let weak_project = cx.weak_entity();
+            cx.defer(move |cx| {
+                cx.update_global::<GlobalProjectRegistry, _>(|registry, _| {
+                    registry.0.push(weak_project);
+                });
+            });
+
             let (tx, rx) = mpsc::unbounded();
             cx.spawn(async move |this, cx| Self::send_buffer_ordered_messages(this, rx, cx).await)
                 .detach();
@@ -1420,6 +1508,13 @@ impl Project {
         cx: &mut App,
     ) -> Entity<Self> {
         cx.new(|cx: &mut Context<Self>| {
+            let weak_project = cx.weak_entity();
+            cx.defer(move |cx| {
+                cx.update_global::<GlobalProjectRegistry, _>(|registry, _| {
+                    registry.0.push(weak_project);
+                });
+            });
+
             let (tx, rx) = mpsc::unbounded();
             cx.spawn(async move |this, cx| Self::send_buffer_ordered_messages(this, rx, cx).await)
                 .detach();
@@ -1854,6 +1949,13 @@ impl Project {
         let replica_id = ReplicaId::new(response.payload.replica_id as u16);
 
         let project = cx.new(|cx| {
+            let weak_project = cx.weak_entity();
+            cx.defer(move |cx| {
+                cx.update_global::<GlobalProjectRegistry, _>(|registry, _| {
+                    registry.0.push(weak_project);
+                });
+            });
+
             let snippets = SnippetProvider::new(fs.clone(), BTreeSet::from_iter([]), cx);
 
             let weak_self = cx.weak_entity();
@@ -2115,6 +2217,7 @@ impl Project {
         let clock = Arc::new(FakeSystemClock::new());
         let http_client = http_client::FakeHttpClient::with_404_response();
         let client = cx.update(|cx| client::Client::new(clock, http_client.clone(), cx));
+        cx.update(|cx| Self::init(&client, cx));
         let user_store = cx.new(|cx| UserStore::new(client.clone(), cx));
         let project = cx.update(|cx| {
             Project::local(

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -1037,6 +1037,7 @@ mod tests {
             let state = AppState::test(cx);
             crate::init(cx);
             editor::init(cx);
+            project::Project::init(&state.client, cx);
             state
         })
     }

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -3086,6 +3086,7 @@ mod tests {
             let state = AppState::test(cx);
             crate::init(cx);
             editor::init(cx);
+            project::Project::init(&state.client, cx);
             state
         })
     }

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -4978,6 +4978,7 @@ mod tests {
             call::init(app_state.client.clone(), app_state.user_store.clone(), cx);
             notifications::init(app_state.client.clone(), app_state.user_store.clone(), cx);
             workspace::init(app_state.clone(), cx);
+            project::Project::init(&app_state.client, cx);
             release_channel::init(Version::new(0, 0, 0), cx);
             command_palette::init(cx);
             editor::init(cx);
@@ -5010,10 +5011,7 @@ mod tests {
             repl::init(app_state.fs.clone(), cx);
             repl::notebook::init(cx);
             tasks_ui::init(cx);
-            project::debugger::breakpoint_store::BreakpointStore::init(
-                &app_state.client.clone().into(),
-            );
-            project::debugger::dap_store::DapStore::init(&app_state.client.clone().into(), cx);
+
             debugger_ui::init(cx);
             initialize_workspace(app_state.clone(), prompt_builder, cx);
             search::init(cx);

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -6108,6 +6108,7 @@ mod tests {
             call::init(app_state.client.clone(), app_state.user_store.clone(), cx);
             notifications::init(app_state.client.clone(), app_state.user_store.clone(), cx);
             workspace::init(app_state.clone(), cx);
+            project::Project::init(&app_state.client, cx);
             release_channel::init(Version::new(0, 0, 0), cx);
             command_palette::init(cx);
             editor::init(cx);
@@ -6151,10 +6152,7 @@ mod tests {
             repl::init(app_state.fs.clone(), cx);
             repl::notebook::init(cx);
             tasks_ui::init(cx);
-            project::debugger::breakpoint_store::BreakpointStore::init(
-                &app_state.client.clone().into(),
-            );
-            project::debugger::dap_store::DapStore::init(&app_state.client.clone().into(), cx);
+
             debugger_ui::init(cx);
             initialize_workspace(app_state.clone(), cx);
             search::init(cx);


### PR DESCRIPTION
Closes #17462 
Relates to https://github.com/zed-extensions/java/issues/94

This is a proposal for allowing extensions to dynamically provide tasks and task variables. The main intended purpose is to be able to reliably bridge different build tools and task runners (Make, Just, package.json, mvn, gradle etc.) with the Zed tasks and runnables system. 

## How to test: 
I work on the Java extension so I was testing with this fork of it: https://github.com/playdohface/zed-java/tree/test-dynamic-tasks which has some simple implementations of the methods. The main thing to do is point the the `extension_api` crate in the extension at this fork (`zed_extension_api = { git = "https://github.com/playdohface/zed.git", branch = "extension-context-provider-for-tasks" }
` and implement the two methods, and play around with it using the tasks ui. 

## How it works and why this way
It does so by adding two methods to the `Extension` trait in the `extension_api`: 
`build_context` and `associated_tasks`. 
`build_context` provides environment variables to tasks (visible like tree-sitter captures e.g. `$ZED_CUSTOM_MY_DYNAMIC_VAR`). 
`associated_tasks` provides task-templates based on the current file and project.
Both have access to the the worktree, meaning they can check whether an executable (e.g. `make`) is available, and they can read files (like `Makefile` or `package.json`) to intelligently dispatch tasks to existing tools based on availability and project configuration. 

This is inspired by how similar functionality is already achieved with built-in languages, and while originally I was looking to solve the linked issue in the java extension (where cross-platform, cross-build-tool runnables are not possible), this also opens up the possibility for e.g. Makefile or Justfile extensions to dynamically provide tasks and runnables based on the available targets. 

Release Notes:

- Improved the Extension API by adding dynamic tasks and task-variables
