### PR TITLE
Update community champions list

### DIFF
--- a/.github/workflows/community_champion_auto_labeler.yml
+++ b/.github/workflows/community_champion_auto_labeler.yml
@@ -33,18 +33,19 @@ jobs:
             bobbymannino
             CharlesChen0823
             chbk
-            cppcoffee
-            davidbarsky
             davewa
+            davidbarsky
             ddoemonn
             djsauble
             errmayank
             fantacell
+            fdncred
             findrakecil
             FloppyDisco
             gko
             huacnlee
             imumesh18
+            injust
             jacobtread
             jansol
             jeffreyguenther
@@ -56,21 +57,23 @@ jobs:
             marius851000
             mikebronner
             ognevny
+            PKief
             playdohface
             RemcoSmitsDev
             romaninsh
+            rxptr
             Simek
             someone13574
             sourcefrog
             suxiaoshao
             Takk8IS
+            tartarughina
             thedadams
             tidely
             timvermeulen
             valentinegb
             versecafe
             vitallium
-            warrenjokinen
             WhySoBad
             ya7010
             Zertsov


### PR DESCRIPTION
Updates the community champions list to the latest state, adding some of our active extension contributors, and sorts the list/removes duplicates.

Release Notes:

- N/A