### PR TITLE
language: Change signature of `initialization_options_schema`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8654,7 +8654,6 @@ dependencies = [
  "extension",
  "gpui",
  "language",
- "lsp",
  "paths",
  "project",
  "schemars",

--- a/crates/json_schema_store/Cargo.toml
+++ b/crates/json_schema_store/Cargo.toml
@@ -20,7 +20,6 @@ dap.workspace = true
 extension.workspace = true
 gpui.workspace = true
 language.workspace = true
-lsp.workspace = true
 paths.workspace = true
 project.workspace = true
 schemars.workspace = true

--- a/crates/json_schema_store/Cargo.toml
+++ b/crates/json_schema_store/Cargo.toml
@@ -30,11 +30,3 @@ snippet_provider.workspace = true
 task.workspace = true
 theme.workspace = true
 util.workspace = true
-
-
-
-# Uncomment other workspace dependencies as needed
-# assistant.workspace = true
-# client.workspace = true
-# project.workspace = true
-# settings.workspace = true

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -331,6 +331,21 @@ impl CachedLspAdapter {
             .unwrap_or_else(|| language_name.lsp_id())
     }
 
+    pub async fn initialization_options_schema(
+        &self,
+        delegate: &Arc<dyn LspAdapterDelegate>,
+        cx: &mut AsyncApp,
+    ) -> Option<serde_json::Value> {
+        self.adapter
+            .clone()
+            .initialization_options_schema(
+                delegate,
+                self.cached_binary.clone().lock_owned().await,
+                cx,
+            )
+            .await
+    }
+
     pub fn process_prompt_response(&self, context: &PromptResponseContext, cx: &mut AsyncApp) {
         self.adapter.process_prompt_response(context, cx)
     }
@@ -464,7 +479,9 @@ pub trait LspAdapter: 'static + Send + Sync + DynLspInstaller {
     /// Returns the JSON schema of the initialization_options for the language server.
     async fn initialization_options_schema(
         self: Arc<Self>,
-        _language_server_binary: &LanguageServerBinary,
+        _delegate: &Arc<dyn LspAdapterDelegate>,
+        _cached_binary: OwnedMutexGuard<Option<(bool, LanguageServerBinary)>>,
+        _cx: &mut AsyncApp,
     ) -> Option<serde_json::Value> {
         None
     }
@@ -591,6 +608,7 @@ pub trait DynLspInstaller {
         pre_release: bool,
         cx: &mut AsyncApp,
     ) -> Result<LanguageServerBinary>;
+
     fn get_language_server_command(
         self: Arc<Self>,
         delegate: Arc<dyn LspAdapterDelegate>,
@@ -686,17 +704,17 @@ where
                 return (Ok(binary), None);
             }
 
+            if let Some((pre_release, cached_binary)) = cached_binary_deref
+                && *pre_release == binary_options.pre_release
+            {
+                return (Ok(cached_binary.clone()), None);
+            }
+
             if !binary_options.allow_binary_download {
                 return (
                     Err(anyhow::anyhow!("downloading language servers disabled")),
                     None,
                 );
-            }
-
-            if let Some((pre_release, cached_binary)) = cached_binary_deref
-                && *pre_release == binary_options.pre_release
-            {
-                return (Ok(cached_binary.clone()), None);
             }
 
             let Some(container_dir) = delegate.language_server_download_dir(&self.name()).await

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -2,16 +2,17 @@ use anyhow::{Context as _, ensure};
 use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use collections::HashMap;
+use futures::lock::OwnedMutexGuard;
 use futures::{AsyncBufReadExt, StreamExt as _};
 use gpui::{App, AsyncApp, SharedString, Task};
 use http_client::github::{AssetKind, GitHubLspBinaryVersion, latest_github_release};
 use language::language_settings::language_settings;
-use language::{ContextLocation, LanguageToolchainStore, LspInstaller};
+use language::{ContextLocation, DynLspInstaller, LanguageToolchainStore, LspInstaller};
 use language::{ContextProvider, LspAdapter, LspAdapterDelegate};
 use language::{LanguageName, ManifestName, ManifestProvider, ManifestQuery};
 use language::{Toolchain, ToolchainList, ToolchainLister, ToolchainMetadata};
-use lsp::LanguageServerName;
 use lsp::{LanguageServerBinary, Uri};
+use lsp::{LanguageServerBinaryOptions, LanguageServerName};
 use node_runtime::{NodeRuntime, VersionStrategy};
 use pet_core::Configuration;
 use pet_core::os_environment::Environment;
@@ -2342,9 +2343,27 @@ impl LspAdapter for RuffLspAdapter {
 
     async fn initialization_options_schema(
         self: Arc<Self>,
-        language_server_binary: &LanguageServerBinary,
+        delegate: &Arc<dyn LspAdapterDelegate>,
+        cached_binary: OwnedMutexGuard<Option<(bool, LanguageServerBinary)>>,
+        cx: &mut AsyncApp,
     ) -> Option<serde_json::Value> {
-        let mut command = util::command::new_smol_command(&language_server_binary.path);
+        let binary = self
+            .get_language_server_command(
+                delegate.clone(),
+                None,
+                LanguageServerBinaryOptions {
+                    allow_path_lookup: true,
+                    allow_binary_download: false,
+                    pre_release: false,
+                },
+                cached_binary,
+                cx.clone(),
+            )
+            .await
+            .0
+            .ok()?;
+
+        let mut command = util::command::new_smol_command(&binary.path);
         command
             .args(&["config", "--output-format", "json"])
             .stdout(Stdio::piped())


### PR DESCRIPTION
This makes this take the LSP adapter delegate instead of the binary itself. 

Despite us passing `LanguageServerBinaryOptions` with `allow_download: false`, extensions would still try to download the binary because it was never implemented for these to respect that. This would cause us to try to download all langauge servers provided by extensions when opening a settings file and/or requesting the JSON schema for that.

This PR fixes this by passing the LSP adapter delegate instead, so the few language servers which actually want to have the binary for resolving the initialization options can decide on this by themselves. With that, we no longer download all language servers for the schema request

Release Notes:

- N/A
