### PR TITLE
languages: Enable terminal activation for uv-managed environments

### DIFF
--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -1357,7 +1357,12 @@ impl ToolchainLister for PythonToolchainProvider {
                     activation_script.push(format!("{manager} activate base"));
                 }
             }
-            Some(PythonEnvironmentKind::Venv | PythonEnvironmentKind::VirtualEnv) => {
+            Some(
+                PythonEnvironmentKind::Venv
+                | PythonEnvironmentKind::VirtualEnv
+                | PythonEnvironmentKind::Uv
+                | PythonEnvironmentKind::UvWorkspace,
+            ) => {
                 if let Some(activation_scripts) = &toolchain.activation_scripts {
                     if let Some(activate_script_path) = activation_scripts.get(&shell) {
                         let activate_keyword = shell.activate_keyword();
@@ -1414,9 +1419,12 @@ async fn venv_to_toolchain(venv: PythonEnvironment, fs: &dyn Fs) -> Option<Toolc
 
     let mut activation_scripts = HashMap::default();
     match venv.kind {
-        Some(PythonEnvironmentKind::Venv | PythonEnvironmentKind::VirtualEnv) => {
-            resolve_venv_activation_scripts(&venv, fs, &mut activation_scripts).await
-        }
+        Some(
+            PythonEnvironmentKind::Venv
+            | PythonEnvironmentKind::VirtualEnv
+            | PythonEnvironmentKind::Uv
+            | PythonEnvironmentKind::UvWorkspace,
+        ) => resolve_venv_activation_scripts(&venv, fs, &mut activation_scripts).await,
         _ => {}
     }
     let data = PythonToolchainData {


### PR DESCRIPTION
Currently, the Python toolchain can identify `uv` and `uv-workspace` environments (showing the correct labels in the UI), but it fails to activate them when opening a new terminal. This is because the activation script resolution and command generation logic were missing for these environment kinds.

This PR adds `uv` and `uv-workspace` to the standard virtual environment activation flow. Since `uv` creates environments with a standard `venv` structure, we can reuse the existing `resolve_venv_activation_scripts` logic to find and execute the appropriate `activate` scripts for different shells.

Release Notes:

- Fixed terminal activation for `uv` and `uv-workspace` Python environments.
