### PR TITLE
rust: Fix `rstml` injection inside Leptos `view!` macros

### DIFF
--- a/crates/languages/src/rust/injections.scm
+++ b/crates/languages/src/rust/injections.scm
@@ -9,6 +9,7 @@
         ((identifier) @_macro_name)
         (scoped_identifier (identifier) @_macro_name .)
     ]
+    (#not-any-of? @_macro_name "view" "html")
     (token_tree) @injection.content
     (#set! injection.language "rust"))
 


### PR DESCRIPTION
Fix the Rust tree-sitter language injection to syntax highlight HTML in Leptos `view!` macros.

A [cleanup commit](https://github.com/zed-industries/zed/commit/00278f43bb0c5ce7c9961fca42d8e924a0cb157a#diff-15e953fedef2880e09d9e57c8bddf9af5eb583b141fe7d2069c8e579378f4fccL6) erroneously removed the `(#not-any-of? @_macro_name "view" "html")` filter from a query that injects Rust into macro invocations. This causes the query to always match with higher precedence over another one that sets the `view!` macro language to `rstml`. I have verified that my fix works locally.

On a related note, I am not sure why language injection for the `sql` macro is there, which is not even exported by [sqlx](https://docs.rs/sqlx/latest/sqlx/). The commit author [mentions](https://github.com/zed-industries/zed/pull/41258#issue-3555384722) that it is for `sqlez`, a Go library, not a Rust crate.

Release Notes:

- Fixed rstml injection not working inside Leptos `view!` macros.