### PR TITLE
gpui: Add dynamic padding to prevent glyph clipping in text rendering on macOS

### DIFF
--- a/crates/gpui/src/platform/mac/text_system.rs
+++ b/crates/gpui/src/platform/mac/text_system.rs
@@ -348,28 +348,20 @@ impl MacTextSystemState {
 
     fn raster_bounds(&self, params: &RenderGlyphParams) -> Result<Bounds<DevicePixels>> {
         let font = &self.fonts[params.font_id.0];
-        let scale = Transform2F::from_scale(params.scale_factor);
         let mut bounds: Bounds<DevicePixels> = font
             .raster_bounds(
                 params.glyph_id.0,
                 params.font_size.into(),
-                scale,
+                Transform2F::from_scale(params.scale_factor),
                 HintingOptions::None,
                 font_kit::canvas::RasterizationOptions::GrayscaleAa,
             )?
             .into();
 
-        // Add padding to prevent glyph clipping, especially for numbers and characters
-        // with descenders or tall ascenders. This ensures the full glyph is rendered.
-        // Use a percentage-based padding that scales with font size (8% of font size).
-        let padding_ratio = 0.08; // 8% of font size
-        let padding_pixels = (params.font_size.0 * params.scale_factor * padding_ratio).ceil() as i32;
-        let padding = DevicePixels(padding_pixels.max(2)); // Minimum 2 pixels
-
-        bounds.origin.x -= padding;
-        bounds.origin.y -= padding;
-        bounds.size.width += DevicePixels(padding.0 * 2);
-        bounds.size.height += DevicePixels(padding.0 * 2);
+        // Adjust the x position to account for the scale factor to avoid glyph clipped.
+        let x_offset = DevicePixels(bounds.origin.x.0 / params.scale_factor as i32);
+        bounds.origin.x -= x_offset;
+        bounds.size.width += x_offset;
 
         Ok(bounds)
     }


### PR DESCRIPTION
Here may caused by [font-kit](https://github.com/servo/font-kit), I was tried to use [render-glyph](https://github.com/servo/font-kit/blob/main/examples/render-glyph.rs) example and also use the same option with `Transform2F::from_scale(2.0)` for `raster_bounds`. 

Then the `raster_bounds` will result same issue like the GPUI's font rendering issue.

| Transform2F::default() | Transform2F::from_scale(2.) |
| --- | -- |
| <img width="943" height="638" alt="image" src="https://github.com/user-attachments/assets/9b827c63-2cbb-45d3-bd62-b0e058a46614" /> | <img width="943" height="638" alt="image" src="https://github.com/user-attachments/assets/ee977a9b-2a7b-4b78-873b-146b2953c0db" /> |

## Before

<img width="1032" height="1398" alt="SCR-20260105-pgcp-2" src="https://github.com/user-attachments/assets/ebeb04cc-3a92-4333-99fc-8733a63b2553" />

## After

<img width="1032" height="1414" alt="SCR-20260105-pfny-1" src="https://github.com/user-attachments/assets/063d0452-56d7-447c-810b-fee7c891235b" />

Release Notes:

- Fixed incorrect rendering of characters at large font sizes on macOS