### PR TITLE
Make `extension` key context case-insensitive

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -529,7 +529,7 @@
     },
   },
   {
-    "context": "Editor && extension == md",
+    "context": "Editor && (extension == md || extension == MD)",
     "use_key_equivalents": true,
     "bindings": {
       "ctrl-k v": "markdown::OpenPreviewToTheSide",

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -529,7 +529,7 @@
     },
   },
   {
-    "context": "Editor && (extension == md || extension == MD)",
+    "context": "Editor && extension == md",
     "use_key_equivalents": true,
     "bindings": {
       "ctrl-k v": "markdown::OpenPreviewToTheSide",

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2680,7 +2680,7 @@ impl Editor {
                     file.full_path(cx)
                         .extension()?
                         .to_string_lossy()
-                        .into_owned(),
+                        .to_lowercase(),
                 )
             }) {
                 key_context.set("extension", extension);


### PR DESCRIPTION
Closes #45960 

Release Notes:

- Made the `extension` key context case-insensitive. This e.g. enables the `markdown: Open Preview` action to also handle files where the extension is capitalised as MD (case-sensitive file system).
