### PR TITLE
Clean up image resources for the current window

### DIFF
--- a/crates/image_viewer/src/image_viewer.rs
+++ b/crates/image_viewer/src/image_viewer.rs
@@ -44,7 +44,7 @@ impl ImageView {
         cx.on_release_in(window, |this, window, cx| {
             let image_data = this.image_item.read(cx).image.clone();
             if let Some(image) = image_data.clone().get_render_image(window, cx) {
-                cx.drop_image(image, None);
+                cx.drop_image(image, Some(window));
             }
             image_data.remove_asset(cx);
         })


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/35894

Trace: https://drive.google.com/file/d/1pXDFzOg4ZS4p2SX8fk9Cjnyy1Qd1Pkrx/view?usp=sharing
[Relevant part](https://github.com/user-attachments/files/24412472/image_leak.txt)


Release Notes:

- Fixed a memory leak when opening images
