### PR TITLE
languages: Support C++ module interface file and Objective-C/C++ files (`.m`, `.mm`)

### DIFF
--- a/crates/languages/src/c/config.toml
+++ b/crates/languages/src/c/config.toml
@@ -1,6 +1,6 @@
 name = "C"
 grammar = "c"
-path_suffixes = ["c"]
+path_suffixes = ["c", "m"]
 line_comments = ["// "]
 decrease_indent_patterns = [
   { pattern = "^\\s*\\{.*\\}?\\s*$", valid_after = ["if", "for", "while", "do", "switch", "else"] },

--- a/crates/languages/src/cpp/config.toml
+++ b/crates/languages/src/cpp/config.toml
@@ -1,6 +1,6 @@
 name = "C++"
 grammar = "cpp"
-path_suffixes = ["cc", "hh", "cpp", "h", "hpp", "cxx", "hxx", "c++", "h++", "ipp", "inl", "ino", "ixx", "cu", "cuh", "C", "H"]
+path_suffixes = ["C", "H", "c++", "cc", "cpp", "cu", "cuh", "cxx", "h", "h++", "hh", "hpp", "hxx", "inl", "ino", "ipp", "ixx"]
 line_comments = ["// ", "/// ", "//! "]
 decrease_indent_patterns = [
   { pattern = "^\\s*\\{.*\\}?\\s*$", valid_after = ["if", "for", "while", "do", "switch", "else"] },

--- a/crates/languages/src/cpp/config.toml
+++ b/crates/languages/src/cpp/config.toml
@@ -1,6 +1,6 @@
 name = "C++"
 grammar = "cpp"
-path_suffixes = ["C", "H", "c++", "cc", "cpp", "cu", "cuh", "cxx", "h", "h++", "hh", "hpp", "hxx", "inl", "ino", "ipp", "ixx"]
+path_suffixes = ["C", "H", "c++", "cc", "cpp", "cu", "cuh", "cxx", "h", "h++", "hh", "hpp", "hxx", "inl", "ino", "ipp", "ixx", "mm"]
 line_comments = ["// ", "/// ", "//! "]
 decrease_indent_patterns = [
   { pattern = "^\\s*\\{.*\\}?\\s*$", valid_after = ["if", "for", "while", "do", "switch", "else"] },

--- a/crates/languages/src/cpp/config.toml
+++ b/crates/languages/src/cpp/config.toml
@@ -1,6 +1,6 @@
 name = "C++"
 grammar = "cpp"
-path_suffixes = ["C", "H", "c++", "cc", "cpp", "cu", "cuh", "cxx", "h", "h++", "hh", "hpp", "hxx", "inl", "ino", "ipp", "ixx", "mm"]
+path_suffixes = ["C", "H", "c++", "cc", "ccm", "cpp", "cppm", "cu", "cuh", "cxx", "cxxm", "h", "h++", "hh", "hpp", "hxx", "inl", "ino", "ipp", "ixx", "mm"]
 line_comments = ["// ", "/// ", "//! "]
 decrease_indent_patterns = [
   { pattern = "^\\s*\\{.*\\}?\\s*$", valid_after = ["if", "for", "while", "do", "switch", "else"] },


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/45573. Supersedes https://github.com/zed-industries/zed/pull/45968 by @hokein.

For Objective-C:

| Before | After |
|:-----:|:---------:|
| <img width="1732" height="1125" alt="image" src="https://github.com/user-attachments/assets/bdf0f6ad-5639-42b0-a620-f4c31b7a5732" /> | <img width="1732" height="1125" alt="image" src="https://github.com/user-attachments/assets/30598534-7511-4250-9295-49adedfade36" /> |

For Objective-C++:

| Before | After |
|:-----:|:---------:|
| <img width="1732" height="1125" alt="image" src="https://github.com/user-attachments/assets/1648b05c-4fd5-4209-bfce-ea5e6e0ee9c3" /> | <img width="1732" height="1125" alt="image" src="https://github.com/user-attachments/assets/4333a2c4-440d-4f5f-937b-03b190405a19" /> |

Release Notes:

- Recognize `.m` (and `.mm`) files as C/C++ respectively
- Recognize module interface files as C++
