### PR TITLE
editor: Use a default font for the minimap

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -20275,6 +20275,7 @@ impl Editor {
         cx: &mut Context<Self>,
     ) -> Entity<Self> {
         const MINIMAP_FONT_WEIGHT: gpui::FontWeight = gpui::FontWeight::BLACK;
+        const MINIMAP_FONT_FAMILY: SharedString = ".ZedMono".into();
 
         let mut minimap = Editor::new_internal(
             EditorMode::Minimap {
@@ -20290,6 +20291,7 @@ impl Editor {
         minimap.set_text_style_refinement(TextStyleRefinement {
             font_size: Some(MINIMAP_FONT_SIZE),
             font_weight: Some(MINIMAP_FONT_WEIGHT),
+            font_family: Some(MINIMAP_FONT_FAMILY),
             ..Default::default()
         });
         minimap.update_minimap_configuration(minimap_settings, cx);

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -20275,7 +20275,7 @@ impl Editor {
         cx: &mut Context<Self>,
     ) -> Entity<Self> {
         const MINIMAP_FONT_WEIGHT: gpui::FontWeight = gpui::FontWeight::BLACK;
-        const MINIMAP_FONT_FAMILY: SharedString = ".ZedMono".into();
+        const MINIMAP_FONT_FAMILY: SharedString = SharedString::new_static(".ZedMono");
 
         let mut minimap = Editor::new_internal(
             EditorMode::Minimap {


### PR DESCRIPTION
Closes #45496
Should help #43460
And probably also #44503

The minimap usually renders about 10x more lines of code and shaped text than the editor. With expensive fonts such as Google Sans Code, this can cause noticeable lag, since we attempt to synthesize 300+ lines of code using a heavy font. Because minimap text is rendered at around 2px and is essentially illegible, it doesn’t make sense to use the custom buffer font.

Release Notes:

- Improved minimap performance when using custom fonts