### PR TITLE
Fix binary files displayed as garbled text in commit viewer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7150,6 +7150,7 @@ dependencies = [
  "git",
  "git_hosting_providers",
  "gpui",
+ "image",
  "indoc",
  "itertools 0.14.0",
  "language",

--- a/crates/git_ui/Cargo.toml
+++ b/crates/git_ui/Cargo.toml
@@ -31,6 +31,7 @@ futures.workspace = true
 fuzzy.workspace = true
 git.workspace = true
 gpui.workspace = true
+image.workspace = true
 itertools.workspace = true
 language.workspace = true
 language_model.workspace = true

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -2374,6 +2374,9 @@ impl GitStore {
                     path: file.path.to_proto(),
                     old_text: file.old_text,
                     new_text: file.new_text,
+                    is_binary: file.is_binary,
+                    image_data: file.image_data,
+                    file_size: file.file_size,
                 })
                 .collect(),
         })
@@ -4108,6 +4111,9 @@ impl Repository {
                                     path: RepoPath::from_proto(&file.path)?,
                                     old_text: file.old_text,
                                     new_text: file.new_text,
+                                    is_binary: file.is_binary,
+                                    image_data: file.image_data,
+                                    file_size: file.file_size,
                                 })
                             })
                             .collect::<Result<Vec<_>>>()?,

--- a/crates/proto/proto/git.proto
+++ b/crates/proto/proto/git.proto
@@ -283,6 +283,9 @@ message CommitFile {
     string path = 1;
     optional string old_text = 2;
     optional string new_text = 3;
+    bool is_binary = 4;
+    optional bytes image_data = 5;
+    optional uint64 file_size = 6;
 }
 
 message GitReset {


### PR DESCRIPTION
Binary files (such as images) were incorrectly displayed as garbled text when viewing commit changes. This happened because `String::from_utf8_lossy()` was used to convert binary data, replacing invalid UTF-8 sequences with replacement characters.

Closes #44065

Release Notes:
Binary files now show in a separate section with proper previews for images and file size metadata.

<img width="320" height="500" alt="image" src="https://github.com/user-attachments/assets/4ae2e26b-eecf-4737-8200-282bef55253c" />
