### PR TITLE
Lazy-init WasmStore for wasm grammars

### DIFF
--- a/crates/language/src/syntax_map.rs
+++ b/crates/language/src/syntax_map.rs
@@ -1381,6 +1381,12 @@ fn parse_text(
 ) -> anyhow::Result<Tree> {
     with_parser(|parser| {
         let mut chunks = text.chunks_in_range(start_byte..text.len());
+        if grammar.ts_language.is_wasm() {
+            let store = crate::take_or_create_wasm_store(parser)?;
+            parser
+                .set_wasm_store(store)
+                .context("Failed to attach tree-sitter WasmStore")?;
+        }
         parser.set_included_ranges(ranges)?;
         parser.set_language(&grammar.ts_language)?;
         parser


### PR DESCRIPTION
Release Notes:

- Fixed: lazily initialize tree-sitter WasmStore only when wasm grammars are parsed, restoring wasm grammar highlighting without eager Wasmtime init.

---

## Problem
`with_parser` always attached a WasmStore, which triggers Wasmtime/JIT initialization even for native grammars. On macOS this could crash or fail (SIGILL / "Failed to load the Wasm store") when wasm grammars are used.

## How I found it

While building a small gpui PoC on top of the Zed codebase, I ran into the crash/failure path when opening files backed by a wasm grammar.

DISCLOSURE: The PoC I was building and this PR was mainly driven by codex.

## Fix
- Parsers start without a WasmStore.
- WasmStore is created lazily when a wasm grammar is needed.
- `parse_text` attaches a store if the grammar is wasm (`ts_language.is_wasm()`), so wasm highlighting works without eager Wasmtime init.

## Repro
1. Build/run Zed from source on macOS.
2. Use a wasm grammar extension (e.g. Elixir).
3. Open an `.ex` or `.heex` file.
4. Before: SIGILL or "Failed to load the Wasm store".
5. After: syntax highlighting works, no eager Wasmtime init for native grammars.
