### PR TITLE
keymap_editor: Add a "create keybinding" modal

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -1202,6 +1202,7 @@
       "alt-c": "keymap_editor::ToggleConflictFilter",
       "enter": "keymap_editor::EditBinding",
       "alt-enter": "keymap_editor::CreateBinding",
+      "ctrl-k": "keymap_editor::OpenCreateKeybindingModal",
       "ctrl-c": "keymap_editor::CopyAction",
       "ctrl-shift-c": "keymap_editor::CopyContext",
       "ctrl-t": "keymap_editor::ShowMatchingKeybinds",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -1303,6 +1303,7 @@
       "cmd-alt-c": "keymap_editor::ToggleConflictFilter",
       "enter": "keymap_editor::EditBinding",
       "alt-enter": "keymap_editor::CreateBinding",
+      "cmd-k": "keymap_editor::OpenCreateKeybindingModal",
       "cmd-c": "keymap_editor::CopyAction",
       "cmd-shift-c": "keymap_editor::CopyContext",
       "cmd-t": "keymap_editor::ShowMatchingKeybinds",

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -1230,6 +1230,7 @@
       "alt-c": "keymap_editor::ToggleConflictFilter",
       "enter": "keymap_editor::EditBinding",
       "alt-enter": "keymap_editor::CreateBinding",
+      "ctrl-k": "keymap_editor::OpenCreateKeybindingModal",
       "ctrl-c": "keymap_editor::CopyAction",
       "ctrl-shift-c": "keymap_editor::CopyContext",
       "ctrl-t": "keymap_editor::ShowMatchingKeybinds",

--- a/crates/keymap_editor/src/action_completion_provider.rs
+++ b/crates/keymap_editor/src/action_completion_provider.rs
@@ -73,7 +73,6 @@ impl CompletionProvider for ActionCompletionProvider {
         let executor_for_fuzzy = executor.clone();
         let action_names = self.action_names.clone();
         let humanized_names = self.humanized_names.clone();
-        let replace_range_clone = replace_range.clone();
 
         executor.spawn(async move {
             let matches = fuzzy::match_strings(
@@ -98,7 +97,7 @@ impl CompletionProvider for ActionCompletionProvider {
                         .unwrap_or_else(|| action_name.into());
 
                     project::Completion {
-                        replace_range: replace_range_clone.clone(),
+                        replace_range: replace_range.clone(),
                         label: language::CodeLabel::plain(humanized.to_string(), None),
                         new_text: action_name.to_string(),
                         documentation: None,

--- a/crates/keymap_editor/src/action_completion_provider.rs
+++ b/crates/keymap_editor/src/action_completion_provider.rs
@@ -1,0 +1,137 @@
+use collections::HashMap;
+use command_palette;
+use editor::{CompletionProvider, Editor};
+use fuzzy::StringMatchCandidate;
+use gpui::{Context, Entity, SharedString, Window};
+use language::{self, ToOffset};
+use project::{self, CompletionDisplayOptions};
+
+pub struct ActionCompletionProvider {
+    action_names: Vec<&'static str>,
+    humanized_names: HashMap<&'static str, SharedString>,
+}
+
+impl ActionCompletionProvider {
+    pub fn new(
+        action_names: Vec<&'static str>,
+        humanized_names: HashMap<&'static str, SharedString>,
+    ) -> Self {
+        Self {
+            action_names,
+            humanized_names,
+        }
+    }
+}
+
+impl CompletionProvider for ActionCompletionProvider {
+    fn completions(
+        &self,
+        _excerpt_id: editor::ExcerptId,
+        buffer: &Entity<language::Buffer>,
+        buffer_position: language::Anchor,
+        _trigger: editor::CompletionContext,
+        _window: &mut Window,
+        cx: &mut Context<Editor>,
+    ) -> gpui::Task<anyhow::Result<Vec<project::CompletionResponse>>> {
+        let buffer = buffer.read(cx);
+        let mut count_back = 0;
+
+        for char in buffer.reversed_chars_at(buffer_position) {
+            if char.is_ascii_alphanumeric() || char == '_' || char == ':' {
+                count_back += 1;
+            } else {
+                break;
+            }
+        }
+
+        let start_anchor = buffer.anchor_before(
+            buffer_position
+                .to_offset(&buffer)
+                .saturating_sub(count_back),
+        );
+
+        let replace_range = start_anchor..buffer_position;
+        let snapshot = buffer.text_snapshot();
+        let query: String = snapshot.text_for_range(replace_range.clone()).collect();
+        let normalized_query = command_palette::normalize_action_query(&query);
+
+        let candidates: Vec<StringMatchCandidate> = self
+            .action_names
+            .iter()
+            .enumerate()
+            .map(|(ix, &name)| {
+                let humanized = self
+                    .humanized_names
+                    .get(name)
+                    .cloned()
+                    .unwrap_or_else(|| name.into());
+                StringMatchCandidate::new(ix, &humanized)
+            })
+            .collect();
+
+        let executor = cx.background_executor().clone();
+        let executor_for_fuzzy = executor.clone();
+        let action_names = self.action_names.clone();
+        let humanized_names = self.humanized_names.clone();
+        let replace_range_clone = replace_range.clone();
+
+        executor.spawn(async move {
+            let matches = fuzzy::match_strings(
+                &candidates,
+                &normalized_query,
+                true,
+                true,
+                action_names.len(),
+                &Default::default(),
+                executor_for_fuzzy,
+            )
+            .await;
+
+            let completions: Vec<project::Completion> = matches
+                .iter()
+                .take(50)
+                .map(|m| {
+                    let action_name = action_names[m.candidate_id];
+                    let humanized = humanized_names
+                        .get(action_name)
+                        .cloned()
+                        .unwrap_or_else(|| action_name.into());
+
+                    project::Completion {
+                        replace_range: replace_range_clone.clone(),
+                        label: language::CodeLabel::plain(humanized.to_string(), None),
+                        new_text: action_name.to_string(),
+                        documentation: None,
+                        source: project::CompletionSource::Custom,
+                        icon_path: None,
+                        match_start: None,
+                        snippet_deduplication_key: None,
+                        insert_text_mode: None,
+                        confirm: None,
+                    }
+                })
+                .collect();
+
+            Ok(vec![project::CompletionResponse {
+                completions,
+                display_options: CompletionDisplayOptions {
+                    dynamic_width: true,
+                },
+                is_incomplete: false,
+            }])
+        })
+    }
+
+    fn is_completion_trigger(
+        &self,
+        _buffer: &Entity<language::Buffer>,
+        _position: language::Anchor,
+        text: &str,
+        _trigger_in_words: bool,
+        _cx: &mut Context<Editor>,
+    ) -> bool {
+        text.chars().last().is_some_and(|last_char| {
+            last_char.is_ascii_alphanumeric() || last_char == '_' || last_char == ':'
+        })
+    }
+}

--- a/crates/keymap_editor/src/keymap_editor.rs
+++ b/crates/keymap_editor/src/keymap_editor.rs
@@ -62,6 +62,8 @@ actions!(
         EditBinding,
         /// Creates a new key binding for the selected action.
         CreateBinding,
+        /// Creates a new key binding from scratch, prompting for the action.
+        OpenCreateKeybindingModal,
         /// Deletes the selected key binding.
         DeleteBinding,
         /// Copies the action name to clipboard.
@@ -1258,7 +1260,12 @@ impl KeymapEditor {
         self.open_edit_keybinding_modal(true, window, cx);
     }
 
-    fn open_create_modal(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+    fn open_create_keybinding_modal(
+        &mut self,
+        _: &OpenCreateKeybindingModal,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         let keymap_editor = cx.entity();
 
         let action_information = ActionInformation::new(
@@ -1703,6 +1710,7 @@ impl Render for KeymapEditor {
             .on_action(cx.listener(Self::focus_search))
             .on_action(cx.listener(Self::edit_binding))
             .on_action(cx.listener(Self::create_binding))
+            .on_action(cx.listener(Self::open_create_keybinding_modal))
             .on_action(cx.listener(Self::delete_binding))
             .on_action(cx.listener(Self::copy_action_to_clipboard))
             .on_action(cx.listener(Self::copy_context_to_clipboard))
@@ -1743,7 +1751,7 @@ impl Render for KeymapEditor {
                             .child(
                                 h_flex()
                                     .gap_1()
-                                    .min_w_80()
+                                    .min_w_96()
                                     .child(
                                         IconButton::new(
                                             "KeymapEditorToggleFiltersIcon",
@@ -1874,9 +1882,16 @@ impl Render for KeymapEditor {
                                             .child(
                                                 Button::new("create", "Create Keybinding")
                                                     .style(ButtonStyle::Outlined)
-                                                    .on_click(cx.listener(|this, _, window, cx| {
-                                                        this.open_create_modal(window, cx);
-                                                    }))
+                                                    .key_binding(
+                                                        ui::KeyBinding::for_action_in(&OpenCreateKeybindingModal, &focus_handle, cx)
+                                                            .map(|kb| kb.size(rems_from_px(10.))),
+                                                    )
+                                                    .on_click(|_, window, cx| {
+                                                        window.dispatch_action(
+                                                            OpenCreateKeybindingModal.boxed_clone(),
+                                                            cx,
+                                                        );
+                                                    })
                                             )
 
                                     )
@@ -1889,7 +1904,7 @@ impl Render for KeymapEditor {
                                 h_flex()
                                     .gap_2()
                                     .child(self.keystroke_editor.clone())
-                                    .child(div().min_w_80()), // Spacer div to align with the search input
+                                    .child(div().min_w_96()), // Spacer div to align with the search input
                             )
                         },
                     ),

--- a/crates/keymap_editor/src/keymap_editor.rs
+++ b/crates/keymap_editor/src/keymap_editor.rs
@@ -2242,6 +2242,9 @@ impl EventEmitter<DismissEvent> for KeybindingEditorModal {}
 
 impl Focusable for KeybindingEditorModal {
     fn focus_handle(&self, cx: &App) -> FocusHandle {
+        if let Some(action_editor) = &self.action_editor {
+            return action_editor.focus_handle(cx);
+        }
         self.keybind_editor.focus_handle(cx)
     }
 }
@@ -2364,6 +2367,7 @@ impl KeybindingEditorModal {
         });
 
         let focus_state = KeybindingEditorModalFocusState::new(
+            action_editor.as_ref().map(|e| e.focus_handle(cx)),
             keybind_editor.focus_handle(cx),
             action_arguments_editor
                 .as_ref()
@@ -2873,15 +2877,21 @@ struct KeybindingEditorModalFocusState {
 
 impl KeybindingEditorModalFocusState {
     fn new(
+        action_editor: Option<FocusHandle>,
         keystrokes: FocusHandle,
-        action_input: Option<FocusHandle>,
+        action_arguments: Option<FocusHandle>,
         context: FocusHandle,
     ) -> Self {
         Self {
             handles: Vec::from_iter(
-                [Some(keystrokes), action_input, Some(context)]
-                    .into_iter()
-                    .flatten(),
+                [
+                    action_editor,
+                    Some(keystrokes),
+                    action_arguments,
+                    Some(context),
+                ]
+                .into_iter()
+                .flatten(),
             ),
         }
     }

--- a/crates/keymap_editor/src/keymap_editor.rs
+++ b/crates/keymap_editor/src/keymap_editor.rs
@@ -1889,7 +1889,7 @@ impl Render for KeymapEditor {
                                 h_flex()
                                     .gap_2()
                                     .child(self.keystroke_editor.clone())
-                                    .child(div().min_w_64()), // Spacer div to align with the search input
+                                    .child(div().min_w_80()), // Spacer div to align with the search input
                             )
                         },
                     ),

--- a/crates/keymap_editor/src/keymap_editor.rs
+++ b/crates/keymap_editor/src/keymap_editor.rs
@@ -2648,7 +2648,7 @@ impl KeybindingEditorModal {
         let keybind_for_save = if create {
             ProcessedBinding::Unmapped(action_information)
         } else {
-            existing_keybind.clone()
+            existing_keybind
         };
 
         cx.spawn(async move |this, cx| {

--- a/crates/keymap_editor/src/keymap_editor.rs
+++ b/crates/keymap_editor/src/keymap_editor.rs
@@ -3200,12 +3200,14 @@ impl ActionArgumentsEditor {
 }
 
 impl Render for ActionArgumentsEditor {
-    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let settings = theme::ThemeSettings::get_global(cx);
         let colors = cx.theme().colors();
 
         let border_color = if self.is_loading {
             colors.border_disabled
+        } else if self.focus_handle.contains_focused(window, cx) {
+            colors.border_focused
         } else {
             colors.border_variant
         };


### PR DESCRIPTION
Ever since we launched the keymap editor, we've received feedback about how "_creating_" a new keybinding was not obvious. At first, I was confused about this feedback because you can't "create" a keybinding, you need to rather _assign it_ to an action... so what always made sense to me was to start with searching for the action, which is an use case we already support. Regardless, having an easy to reach "create" button, which essentially still asks for action > keystroke > arguments (if needed) > and context, feels like a win UX-wise; a bit of a redundant flow that feels ultimately positive.

So, this PR adds a "Create Keybinding" button to the keymap editor, which you can reach with `cmd-k`. That will open up a modal with an action autocomplete, the keystroke recording input, the arguments input (if needed), and the context input.

https://github.com/user-attachments/assets/86f64314-4685-47bb-bb0d-72ca4c469d1f

Release Notes:

- keymap editor: Added a keybinding creation modal to make it easier to assign an action to a keystroke.
