### PR TITLE
Preserve final newline whitespace; add trim_final_newlines_on_save

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1384,8 +1384,8 @@
   "indent_list_on_tab": true,
   // Ensures there's a newline at the end of the file.
   "ensure_final_newline_on_save": true,
-  // Removes trailing newline characters at the end of the file. When combined
-  // with ensure_final_newline_on_save, this collapses multiple blank lines to one.
+  // Removes extra trailing newline characters at the end of the file,
+  // leaving at most one final newline.
   "trim_final_newlines_on_save": false,
   // How line endings should be handled for new files and during format and save.
   // This setting can take five values:

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1382,9 +1382,11 @@
   "extend_list_on_newline": true,
   // Whether to indent list items when pressing tab after a list marker.
   "indent_list_on_tab": true,
-  // Removes any lines containing only whitespace at the end of the file and
-  // ensures just one newline at the end.
+  // Ensures there's a newline at the end of the file.
   "ensure_final_newline_on_save": true,
+  // Removes trailing newline characters at the end of the file. When combined
+  // with ensure_final_newline_on_save, this collapses multiple blank lines to one.
+  "trim_final_newlines_on_save": false,
   // How line endings should be handled for new files and during format and save.
   // This setting can take five values:
   //

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -2261,28 +2261,61 @@ impl Buffer {
         })
     }
 
-    /// Ensures that the buffer ends with a single newline character, and
-    /// no other whitespace. Skips if the buffer is empty.
+    /// Removes trailing newline characters from the end of the buffer.
+    /// Skips if the buffer is empty.
+    pub fn trim_final_newlines(&mut self, cx: &mut Context<Self>) {
+        let len = self.len();
+        if len == 0 {
+            return;
+        }
+
+        let trim_end = {
+            let rope = self.as_rope();
+            let mut trim_end = len;
+            let mut found_non_newline = false;
+
+            for chunk in rope.reversed_chunks_in_range(0..len) {
+                for ch in chunk.chars().rev() {
+                    if ch == '\n' {
+                        trim_end -= ch.len_utf8();
+                    } else {
+                        found_non_newline = true;
+                        break;
+                    }
+                }
+
+                if found_non_newline || trim_end == 0 {
+                    break;
+                }
+            }
+
+            trim_end
+        };
+
+        if trim_end < len {
+            self.edit([(trim_end..len, "")], None, cx);
+        }
+    }
+
+    /// Ensures that the buffer ends with a newline character.
+    /// Skips if the buffer is empty.
     pub fn ensure_final_newline(&mut self, cx: &mut Context<Self>) {
         let len = self.len();
         if len == 0 {
             return;
         }
-        let mut offset = len;
-        for chunk in self.as_rope().reversed_chunks_in_range(0..len) {
-            let non_whitespace_len = chunk
-                .trim_end_matches(|c: char| c.is_ascii_whitespace())
-                .len();
-            offset -= chunk.len();
-            offset += non_whitespace_len;
-            if non_whitespace_len != 0 {
-                if offset == len - 1 && chunk.get(non_whitespace_len..) == Some("\n") {
-                    return;
-                }
-                break;
-            }
+
+        // Check if the buffer already ends with a newline
+        let rope = self.as_rope();
+        let last_char = rope
+            .reversed_chunks_in_range(0..len)
+            .next()
+            .and_then(|chunk| chunk.chars().next_back());
+
+        if last_char != Some('\n') {
+            // Add a newline at the end
+            self.edit([(len..len, "\n")], None, cx);
         }
-        self.edit([(offset..len, "\n")], None, cx);
     }
 
     /// Applies a diff to the buffer. If the buffer has changed since the given diff was

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -2261,42 +2261,33 @@ impl Buffer {
         })
     }
 
-    /// Removes trailing newline characters from the end of the buffer.
+    /// Removes extra trailing newline characters from the end of the buffer,
+    /// leaving a single final newline if present.
     /// Skips if the buffer is empty.
-    pub fn trim_final_newlines(&mut self, cx: &mut Context<Self>) -> bool {
+    pub fn trim_final_newlines(&mut self, cx: &mut Context<Self>) {
         let len = self.len();
         if len == 0 {
-            return false;
+            return;
         }
 
-        let (trim_end, found_non_newline) = {
-            let rope = self.as_rope();
-            let mut trim_end = len;
-            let mut found_non_newline = false;
-
-            for chunk in rope.reversed_chunks_in_range(0..len) {
-                for ch in chunk.chars().rev() {
-                    if ch == '\n' {
-                        trim_end -= ch.len_utf8();
-                    } else {
-                        found_non_newline = true;
-                        break;
-                    }
-                }
-
-                if found_non_newline || trim_end == 0 {
-                    break;
+        let rope = self.as_rope();
+        let mut trailing_newlines = 0usize;
+        'outer: for chunk in rope.reversed_chunks_in_range(0..len) {
+            for ch in chunk.chars().rev() {
+                if ch == '\n' {
+                    trailing_newlines += 1;
+                } else {
+                    break 'outer;
                 }
             }
-
-            (trim_end, found_non_newline)
-        };
-
-        if trim_end < len {
-            self.edit([(trim_end..len, "")], None, cx);
         }
 
-        !found_non_newline && trim_end == 0
+        if trailing_newlines <= 1 {
+            return;
+        }
+
+        let trim_start = len - (trailing_newlines - 1);
+        self.edit([(trim_start..len, "")], None, cx);
     }
 
     /// Ensures that the buffer ends with a newline character.

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -2263,13 +2263,13 @@ impl Buffer {
 
     /// Removes trailing newline characters from the end of the buffer.
     /// Skips if the buffer is empty.
-    pub fn trim_final_newlines(&mut self, cx: &mut Context<Self>) {
+    pub fn trim_final_newlines(&mut self, cx: &mut Context<Self>) -> bool {
         let len = self.len();
         if len == 0 {
-            return;
+            return false;
         }
 
-        let trim_end = {
+        let (trim_end, found_non_newline) = {
             let rope = self.as_rope();
             let mut trim_end = len;
             let mut found_non_newline = false;
@@ -2289,12 +2289,14 @@ impl Buffer {
                 }
             }
 
-            trim_end
+            (trim_end, found_non_newline)
         };
 
         if trim_end < len {
             self.edit([(trim_end..len, "")], None, cx);
         }
+
+        !found_non_newline && trim_end == 0
     }
 
     /// Ensures that the buffer ends with a newline character.

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -674,8 +674,9 @@ fn test_trim_final_newlines(cx: &mut gpui::App) {
     // Case 1: File ending with multiple newlines
     let buffer = cx.new(|cx| Buffer::local("code\n\n", cx));
     buffer.update(cx, |buffer, cx| {
-        buffer.trim_final_newlines(cx);
+        let trimmed_all_newlines = buffer.trim_final_newlines(cx);
         assert_eq!(buffer.text(), "code");
+        assert!(!trimmed_all_newlines);
     });
 
     // Case 2: File ending with single newline
@@ -702,8 +703,9 @@ fn test_trim_final_newlines(cx: &mut gpui::App) {
     // Case 5: Buffer of only newlines
     let buffer = cx.new(|cx| Buffer::local("\n\n", cx));
     buffer.update(cx, |buffer, cx| {
-        buffer.trim_final_newlines(cx);
+        let trimmed_all_newlines = buffer.trim_final_newlines(cx);
         assert_eq!(buffer.text(), "");
+        assert!(trimmed_all_newlines);
     });
 
     // Case 6: Empty buffer - should not change

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -617,6 +617,104 @@ async fn test_normalize_whitespace(cx: &mut gpui::TestAppContext) {
 }
 
 #[gpui::test]
+fn test_ensure_final_newline_preserves_whitespace(cx: &mut gpui::App) {
+    init_settings(cx, |_| {});
+
+    // Test that ensure_final_newline only adds a newline if missing,
+    // without stripping whitespace from blank lines at the end.
+    // This is a regression test for https://github.com/zed-industries/zed/issues/45407
+
+    // Case 1: File ending with blank line containing whitespace, no final newline
+    let buffer = cx.new(|cx| Buffer::local("code\n    ", cx));
+    buffer.update(cx, |buffer, cx| {
+        buffer.ensure_final_newline(cx);
+        assert_eq!(buffer.text(), "code\n    \n");
+    });
+
+    // Case 2: File already ending with newline - should not change
+    let buffer = cx.new(|cx| Buffer::local("code\n    \n", cx));
+    buffer.update(cx, |buffer, cx| {
+        buffer.ensure_final_newline(cx);
+        assert_eq!(buffer.text(), "code\n    \n");
+    });
+
+    // Case 3: File ending with multiple newlines - should not change
+    let buffer = cx.new(|cx| Buffer::local("code\n\n\n", cx));
+    buffer.update(cx, |buffer, cx| {
+        buffer.ensure_final_newline(cx);
+        assert_eq!(buffer.text(), "code\n\n\n");
+    });
+
+    // Case 4: File ending with multiple blank lines with whitespace
+    let buffer = cx.new(|cx| Buffer::local("code\n    \n  ", cx));
+    buffer.update(cx, |buffer, cx| {
+        buffer.ensure_final_newline(cx);
+        assert_eq!(buffer.text(), "code\n    \n  \n");
+    });
+
+    // Case 5: Simple file without trailing whitespace, no final newline
+    let buffer = cx.new(|cx| Buffer::local("code", cx));
+    buffer.update(cx, |buffer, cx| {
+        buffer.ensure_final_newline(cx);
+        assert_eq!(buffer.text(), "code\n");
+    });
+
+    // Case 6: Empty buffer - should not change
+    let buffer = cx.new(|cx| Buffer::local("", cx));
+    buffer.update(cx, |buffer, cx| {
+        buffer.ensure_final_newline(cx);
+        assert_eq!(buffer.text(), "");
+    });
+}
+
+#[gpui::test]
+fn test_trim_final_newlines(cx: &mut gpui::App) {
+    init_settings(cx, |_| {});
+
+    // Case 1: File ending with multiple newlines
+    let buffer = cx.new(|cx| Buffer::local("code\n\n", cx));
+    buffer.update(cx, |buffer, cx| {
+        buffer.trim_final_newlines(cx);
+        assert_eq!(buffer.text(), "code");
+    });
+
+    // Case 2: File ending with single newline
+    let buffer = cx.new(|cx| Buffer::local("code\n", cx));
+    buffer.update(cx, |buffer, cx| {
+        buffer.trim_final_newlines(cx);
+        assert_eq!(buffer.text(), "code");
+    });
+
+    // Case 3: File with no trailing newline
+    let buffer = cx.new(|cx| Buffer::local("code", cx));
+    buffer.update(cx, |buffer, cx| {
+        buffer.trim_final_newlines(cx);
+        assert_eq!(buffer.text(), "code");
+    });
+
+    // Case 4: Preserve trailing whitespace when trimming newlines
+    let buffer = cx.new(|cx| Buffer::local("code\n  \n\n", cx));
+    buffer.update(cx, |buffer, cx| {
+        buffer.trim_final_newlines(cx);
+        assert_eq!(buffer.text(), "code\n  ");
+    });
+
+    // Case 5: Buffer of only newlines
+    let buffer = cx.new(|cx| Buffer::local("\n\n", cx));
+    buffer.update(cx, |buffer, cx| {
+        buffer.trim_final_newlines(cx);
+        assert_eq!(buffer.text(), "");
+    });
+
+    // Case 6: Empty buffer - should not change
+    let buffer = cx.new(|cx| Buffer::local("", cx));
+    buffer.update(cx, |buffer, cx| {
+        buffer.trim_final_newlines(cx);
+        assert_eq!(buffer.text(), "");
+    });
+}
+
+#[gpui::test]
 async fn test_reparse(cx: &mut gpui::TestAppContext) {
     let text = "fn a() {}";
     let buffer = cx.new(|cx| Buffer::local(text, cx).with_language(rust_lang(), cx));

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -665,6 +665,16 @@ fn test_ensure_final_newline_preserves_whitespace(cx: &mut gpui::App) {
         buffer.ensure_final_newline(cx);
         assert_eq!(buffer.text(), "");
     });
+
+    // Case 7: CRLF buffers keep their line ending style. Buffer text is
+    // normalized internally; the line ending is reapplied when saved.
+    let buffer = cx.new(|cx| Buffer::local("one\r\ntwo", cx));
+    buffer.update(cx, |buffer, cx| {
+        assert_eq!(buffer.line_ending(), LineEnding::Windows);
+        buffer.ensure_final_newline(cx);
+        assert_eq!(buffer.text(), "one\ntwo\n");
+        assert_eq!(buffer.line_ending(), LineEnding::Windows);
+    });
 }
 
 #[gpui::test]
@@ -711,6 +721,31 @@ fn test_trim_final_newlines(cx: &mut gpui::App) {
     buffer.update(cx, |buffer, cx| {
         buffer.trim_final_newlines(cx);
         assert_eq!(buffer.text(), "");
+    });
+
+    // Case 7: CRLF buffers keep their line ending style. Buffer text is
+    // normalized internally; the line ending is reapplied when saved.
+    let buffer = cx.new(|cx| Buffer::local("one\r\ntwo\r\n\r\n", cx));
+    buffer.update(cx, |buffer, cx| {
+        assert_eq!(buffer.line_ending(), LineEnding::Windows);
+        buffer.trim_final_newlines(cx);
+        assert_eq!(buffer.text(), "one\ntwo\n");
+        assert_eq!(buffer.line_ending(), LineEnding::Windows);
+    });
+}
+
+#[gpui::test]
+async fn test_save_whitespace_pipeline(cx: &mut gpui::TestAppContext) {
+    let buffer = cx.new(|cx| Buffer::local("code  \n  \n\n", cx));
+
+    let diff = buffer
+        .update(cx, |buffer, cx| buffer.remove_trailing_whitespace(cx))
+        .await;
+    buffer.update(cx, |buffer, cx| {
+        buffer.apply_diff(diff, cx);
+        buffer.trim_final_newlines(cx);
+        buffer.ensure_final_newline(cx);
+        assert_eq!(buffer.text(), "code\n");
     });
 }
 

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -674,16 +674,15 @@ fn test_trim_final_newlines(cx: &mut gpui::App) {
     // Case 1: File ending with multiple newlines
     let buffer = cx.new(|cx| Buffer::local("code\n\n", cx));
     buffer.update(cx, |buffer, cx| {
-        let trimmed_all_newlines = buffer.trim_final_newlines(cx);
-        assert_eq!(buffer.text(), "code");
-        assert!(!trimmed_all_newlines);
+        buffer.trim_final_newlines(cx);
+        assert_eq!(buffer.text(), "code\n");
     });
 
     // Case 2: File ending with single newline
     let buffer = cx.new(|cx| Buffer::local("code\n", cx));
     buffer.update(cx, |buffer, cx| {
         buffer.trim_final_newlines(cx);
-        assert_eq!(buffer.text(), "code");
+        assert_eq!(buffer.text(), "code\n");
     });
 
     // Case 3: File with no trailing newline
@@ -697,15 +696,14 @@ fn test_trim_final_newlines(cx: &mut gpui::App) {
     let buffer = cx.new(|cx| Buffer::local("code\n  \n\n", cx));
     buffer.update(cx, |buffer, cx| {
         buffer.trim_final_newlines(cx);
-        assert_eq!(buffer.text(), "code\n  ");
+        assert_eq!(buffer.text(), "code\n  \n");
     });
 
     // Case 5: Buffer of only newlines
     let buffer = cx.new(|cx| Buffer::local("\n\n", cx));
     buffer.update(cx, |buffer, cx| {
-        let trimmed_all_newlines = buffer.trim_final_newlines(cx);
-        assert_eq!(buffer.text(), "");
-        assert!(trimmed_all_newlines);
+        buffer.trim_final_newlines(cx);
+        assert_eq!(buffer.text(), "\n");
     });
 
     // Case 6: Empty buffer - should not change

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -81,9 +81,12 @@ pub struct LanguageSettings {
     /// Whether or not to remove any trailing whitespace from lines of a buffer
     /// before saving it.
     pub remove_trailing_whitespace_on_save: bool,
-    /// Whether or not to ensure there's a single newline at the end of a buffer
+    /// Whether or not to ensure there's a newline at the end of a buffer
     /// when saving it.
     pub ensure_final_newline_on_save: bool,
+    /// Whether or not to trim newline characters at the end of a buffer
+    /// when saving it.
+    pub trim_final_newlines_on_save: bool,
     /// How line endings are initialized for new files and normalized during
     /// format and save.
     pub line_ending: LineEndingSetting,
@@ -698,6 +701,7 @@ impl settings::Settings for AllLanguageSettings {
                     .remove_trailing_whitespace_on_save
                     .unwrap(),
                 ensure_final_newline_on_save: settings.ensure_final_newline_on_save.unwrap(),
+                trim_final_newlines_on_save: settings.trim_final_newlines_on_save.unwrap(),
                 line_ending: settings.line_ending.unwrap(),
                 formatter: settings.formatter.unwrap(),
                 prettier: PrettierSettings {

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -59,7 +59,7 @@ pub fn lsp_formatting_options(settings: &LanguageSettings) -> lsp::FormattingOpt
         tab_size: settings.tab_size.into(),
         insert_spaces: !settings.hard_tabs,
         trim_trailing_whitespace: Some(settings.remove_trailing_whitespace_on_save),
-        trim_final_newlines: Some(settings.ensure_final_newline_on_save),
+        trim_final_newlines: Some(settings.trim_final_newlines_on_save),
         insert_final_newline: Some(settings.ensure_final_newline_on_save),
         ..lsp::FormattingOptions::default()
     }

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -1623,10 +1623,7 @@ impl LocalLspStore {
         if settings.trim_final_newlines_on_save {
             zlog::trace!(logger => "trimming final newlines");
             extend_formatting_transaction(buffer, formatting_transaction_id, cx, |buffer, cx| {
-                let trimmed_all_newlines = buffer.trim_final_newlines(cx);
-                if trimmed_all_newlines && settings.ensure_final_newline_on_save {
-                    buffer.edit([(0..0, "\n")], None, cx);
-                }
+                buffer.trim_final_newlines(cx);
             })?;
         }
 

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -1620,6 +1620,13 @@ impl LocalLspStore {
             })?;
         }
 
+        if settings.trim_final_newlines_on_save {
+            zlog::trace!(logger => "trimming final newlines");
+            extend_formatting_transaction(buffer, formatting_transaction_id, cx, |buffer, cx| {
+                buffer.trim_final_newlines(cx);
+            })?;
+        }
+
         if settings.ensure_final_newline_on_save {
             zlog::trace!(logger => "ensuring final newline");
             extend_formatting_transaction(buffer, formatting_transaction_id, cx, |buffer, cx| {

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -1623,7 +1623,10 @@ impl LocalLspStore {
         if settings.trim_final_newlines_on_save {
             zlog::trace!(logger => "trimming final newlines");
             extend_formatting_transaction(buffer, formatting_transaction_id, cx, |buffer, cx| {
-                buffer.trim_final_newlines(cx);
+                let trimmed_all_newlines = buffer.trim_final_newlines(cx);
+                if trimmed_all_newlines && settings.ensure_final_newline_on_save {
+                    buffer.edit([(0..0, "\n")], None, cx);
+                }
             })?;
         }
 

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -6740,6 +6740,119 @@ async fn assert_line_endings_after_format(
 }
 
 #[gpui::test]
+async fn test_trim_final_newlines_on_save_setting(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/dir"),
+        json!({
+            "trim_disabled.rs": "one\n\n\n",
+            "trim_enabled_lf.rs": "one\n\n\n",
+            "trim_enabled_crlf.rs": "one\r\ntwo\r\n\r\n",
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
+    let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+    language_registry.add(rust_lang());
+    let worktree_id = project.update(cx, |project, cx| {
+        project.worktrees(cx).next().unwrap().read(cx).id()
+    });
+
+    let cases = [
+        (
+            "disabled",
+            false,
+            "trim_disabled.rs",
+            LineEnding::Unix,
+            "one\n\n\n",
+        ),
+        (
+            "enabled_lf",
+            true,
+            "trim_enabled_lf.rs",
+            LineEnding::Unix,
+            "one\n",
+        ),
+        (
+            "enabled_crlf",
+            true,
+            "trim_enabled_crlf.rs",
+            LineEnding::Windows,
+            "one\r\ntwo\r\n",
+        ),
+    ];
+
+    for (case_name, trim_final_newlines_on_save, path, expected_line_ending, expected_contents) in
+        cases
+    {
+        cx.update(|cx| {
+            SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    settings
+                        .project
+                        .all_languages
+                        .defaults
+                        .trim_final_newlines_on_save = Some(trim_final_newlines_on_save);
+                });
+            });
+        });
+        cx.executor().run_until_parked();
+
+        let buffer = project
+            .update(cx, |project, cx| {
+                project.open_buffer((worktree_id, rel_path(path)), cx)
+            })
+            .await
+            .unwrap();
+        buffer.update(cx, |buffer, _| {
+            assert_eq!(
+                buffer.line_ending(),
+                expected_line_ending,
+                "unexpected initial line ending for {case_name}"
+            );
+        });
+
+        let mut buffers = HashSet::default();
+        buffers.insert(buffer.clone());
+        project
+            .update(cx, |project, cx| {
+                project.format(
+                    buffers,
+                    project::lsp_store::LspFormatTarget::Buffers,
+                    false,
+                    project::lsp_store::FormatTrigger::Save,
+                    cx,
+                )
+            })
+            .await
+            .unwrap();
+
+        buffer.update(cx, |buffer, _| {
+            assert_eq!(
+                buffer.line_ending(),
+                expected_line_ending,
+                "formatting changed line ending for {case_name}"
+            );
+        });
+
+        project
+            .update(cx, |project, cx| project.save_buffer(buffer, cx))
+            .await
+            .unwrap();
+
+        let saved_path = PathBuf::from(path!("/dir")).join(path);
+        assert_eq!(
+            fs.load(&saved_path).await.unwrap(),
+            expected_contents,
+            "unexpected saved contents for {case_name}",
+        );
+    }
+}
+
+#[gpui::test]
 async fn test_grouped_diagnostics(cx: &mut gpui::TestAppContext) {
     init_test(cx);
 

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -544,6 +544,7 @@ impl VsCodeSettings {
             edit_predictions_disabled_in: None,
             enable_language_server: None,
             ensure_final_newline_on_save: self.read_bool("files.insertFinalNewline"),
+            trim_final_newlines_on_save: self.read_bool("files.trimFinalNewlines"),
             line_ending: self.read_enum("files.eol", |s| match s {
                 "\n" => Some(LineEndingSetting::PreferLf),
                 "\r\n" => Some(LineEndingSetting::PreferCrlf),

--- a/crates/settings_content/src/language.rs
+++ b/crates/settings_content/src/language.rs
@@ -436,11 +436,16 @@ pub struct LanguageSettingsContent {
     ///
     /// Default: true
     pub remove_trailing_whitespace_on_save: Option<bool>,
-    /// Whether or not to ensure there's a single newline at the end of a buffer
+    /// Whether or not to ensure there's a newline at the end of a buffer
     /// when saving it.
     ///
     /// Default: true
     pub ensure_final_newline_on_save: Option<bool>,
+    /// Whether or not to trim newline characters at the end of a buffer
+    /// when saving it.
+    ///
+    /// Default: false
+    pub trim_final_newlines_on_save: Option<bool>,
     /// How line endings should be handled for new files and during format and
     /// save operations.
     ///

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -8225,7 +8225,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
             }),
             SettingsPageItem::SettingItem(SettingItem {
                 title: "Trim Final Newlines On Save",
-                description: "Whether or not to trim newline characters at the end of a buffer when saving it.",
+                description: "Whether or not to trim extra newline characters at the end of a buffer when saving it.",
                 field: Box::new(SettingField {
                     json_path: Some("languages.$(language).trim_final_newlines_on_save"),
                     pick: |settings_content| {

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -8156,7 +8156,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
         ]
     }
 
-    fn formatting_section() -> [SettingsPageItem; 8] {
+    fn formatting_section() -> [SettingsPageItem; 9] {
         [
             SettingsPageItem::SectionHeader("Formatting"),
             SettingsPageItem::SettingItem(SettingItem {
@@ -8206,7 +8206,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
             }),
             SettingsPageItem::SettingItem(SettingItem {
                 title: "Ensure Final Newline On Save",
-                description: "Whether or not to ensure there's a single newline at the end of a buffer when saving it.",
+                description: "Whether or not to ensure there's a newline at the end of a buffer when saving it.",
                 field: Box::new(SettingField {
                     json_path: Some("languages.$(language).ensure_final_newline_on_save"),
                     pick: |settings_content| {
@@ -8217,6 +8217,25 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
                     write: |settings_content, value, _| {
                         language_settings_field_mut(settings_content, value, |language, value| {
                             language.ensure_final_newline_on_save = value;
+                        })
+                    },
+                }),
+                metadata: None,
+                files: USER | PROJECT,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Trim Final Newlines On Save",
+                description: "Whether or not to trim newline characters at the end of a buffer when saving it.",
+                field: Box::new(SettingField {
+                    json_path: Some("languages.$(language).trim_final_newlines_on_save"),
+                    pick: |settings_content| {
+                        language_settings_field(settings_content, |language| {
+                            language.trim_final_newlines_on_save.as_ref()
+                        })
+                    },
+                    write: |settings_content, value, _| {
+                        language_settings_field_mut(settings_content, value, |language, value| {
+                            language.trim_final_newlines_on_save = value;
                         })
                     },
                 }),

--- a/docs/src/migrate/vs-code.md
+++ b/docs/src/migrate/vs-code.md
@@ -86,6 +86,7 @@ The following VS Code settings are automatically imported when you use **Import 
 | `files.autoSave`            | `autosave`                     |
 | `files.autoSaveDelay`       | `autosave.milliseconds`        |
 | `files.insertFinalNewline`  | `ensure_final_newline_on_save` |
+| `files.trimFinalNewlines`   | `trim_final_newlines_on_save`  |
 | `files.associations`        | `file_types`                   |
 | `files.watcherExclude`      | `file_scan_exclusions`         |
 | `files.watcherInclude`      | `file_scan_inclusions`         |

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -1638,7 +1638,7 @@ This setting enables integration with macOS’s native window tabbing feature. W
 
 ## Trim Final Newlines On Save
 
-- Description: Removes trailing newline characters at the end of the file when saving. When combined with `ensure_final_newline_on_save`, this collapses multiple blank lines to one.
+- Description: Removes extra trailing newline characters at the end of the file when saving, leaving at most one final newline.
 - Setting: `trim_final_newlines_on_save`
 - Default: `false`
 

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -1628,9 +1628,19 @@ This setting enables integration with macOS’s native window tabbing feature. W
 
 ## Ensure Final Newline On Save
 
-- Description: Removes any lines containing only whitespace at the end of the file and ensures just one newline at the end.
+- Description: Ensures there's a newline at the end of the file when saving.
 - Setting: `ensure_final_newline_on_save`
 - Default: `true`
+
+**Options**
+
+`boolean` values
+
+## Trim Final Newlines On Save
+
+- Description: Removes trailing newline characters at the end of the file when saving. When combined with `ensure_final_newline_on_save`, this collapses multiple blank lines to one.
+- Setting: `trim_final_newlines_on_save`
+- Default: `false`
 
 **Options**
 
@@ -2881,6 +2891,7 @@ The following settings can be overridden for each specific language:
 
 - [`enable_language_server`](#enable-language-server)
 - [`ensure_final_newline_on_save`](#ensure-final-newline-on-save)
+- [`trim_final_newlines_on_save`](#trim-final-newlines-on-save)
 - [`line_ending`](#line-ending)
 - [`format_on_save`](#format-on-save)
 - [`formatter`](#formatter)


### PR DESCRIPTION
## Why
`ensure_final_newline_on_save` currently collapses trailing blank lines/whitespace. That's surprising (and can be data loss) because the setting name implies "add a newline if missing," not "trim EOF content." We want EOF cleanup to be explicit and consistent with LSP formatting.

**Breaking change:** by default, trailing blank lines are no longer collapsed on save. This is worth it because it fixes the bug and makes the setting's behavior match its name. Users who prefer the old behavior can opt back in with a new setting.

Fixes #45407.

## What
- `ensure_final_newline` only appends a missing newline (no trimming).
- Add `trim_final_newlines_on_save` (default `false`) and wire it through the save pipeline and LSP formatting.
- Add a buffer helper for trimming extra trailing `\n` at EOF.
- Update defaults, settings UI, VS Code import, and docs.

## Mental model
EOF cleanup is three independent switches:
1. `remove_trailing_whitespace_on_save`: trims spaces/tabs at line ends.
2. `trim_final_newlines_on_save`: trims extra trailing `\n` at EOF (leaves at most one).
3. `ensure_final_newline_on_save`: guarantees a final newline if missing.

Save order: remove trailing whitespace -> trim final newlines -> ensure final newline. LSP formatting uses the same settings.

## Tests
- Unit coverage for `ensure_final_newline`, `trim_final_newlines`, and the combined whitespace pipeline.
- Project integration coverage for `trim_final_newlines_on_save` during formatting on save, including disabled/enabled behavior and CRLF files being written back as CRLF.

Validated locally:
- `cargo test -p project test_trim_final_newlines_on_save_setting`
- `cargo test -p language final_newline`
- `cargo test -p language test_save_whitespace_pipeline`
- `cargo check -p settings_ui`

## Migration
Set `trim_final_newlines_on_save = true` to restore the previous "collapse trailing blank lines to one newline" behavior.

Release Notes:

- Added `trim_final_newlines_on_save` to let users opt into trimming extra final newlines separately from ensuring a final newline.
