### PR TITLE
Fix fs watchers not being removed

### DIFF
--- a/crates/fs/src/fs_watcher.rs
+++ b/crates/fs/src/fs_watcher.rs
@@ -134,9 +134,12 @@ impl Watcher for FsWatcher {
     fn remove(&self, path: &std::path::Path) -> anyhow::Result<()> {
         log::trace!("remove watched path: {path:?}");
 
-        for (registration_path, _) in &mut { self.registrations.lock().clone() } {
-            if !registration_path.starts_with(path) {
-                continue;
+        let registrations = self.registrations.lock().clone();
+        let path: Arc<std::path::Path> = Arc::from(path);
+
+        for (registration_path, _) in registrations.range(path.clone()..) {
+            if !registration_path.starts_with(&path) {
+                break;
             }
 
             let Some(registration) = self.registrations.lock().remove(registration_path) else {

--- a/crates/fs/src/fs_watcher.rs
+++ b/crates/fs/src/fs_watcher.rs
@@ -134,7 +134,7 @@ impl Watcher for FsWatcher {
     fn remove(&self, path: &std::path::Path) -> anyhow::Result<()> {
         log::trace!("remove watched path: {path:?}");
 
-        for (registration_path, registration_id) in &mut { self.registrations.lock().clone() } {
+        for (registration_path, _) in &mut { self.registrations.lock().clone() } {
             if !registration_path.starts_with(path) {
                 continue;
             }

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -4662,7 +4662,9 @@ impl BackgroundScanner {
         // Remove any entries for paths that no longer exist or are being recursively
         // refreshed. Do this before adding any new entries, so that renames can be
         // detected regardless of the order of the paths.
-        for ((path, metadata), abs_path) in relative_paths.iter().zip(metadata.iter()).zip(abs_paths) {
+        for ((path, metadata), abs_path) in
+            relative_paths.iter().zip(metadata.iter()).zip(abs_paths)
+        {
             if matches!(metadata, Ok(None)) || doing_recursive_update {
                 state.remove_path(path);
                 self.watcher.remove(&abs_path).log_err();

--- a/crates/worktree/tests/integration/main.rs
+++ b/crates/worktree/tests/integration/main.rs
@@ -2918,3 +2918,109 @@ async fn test_refresh_entries_for_paths_creates_ancestors(cx: &mut TestAppContex
         );
     });
 }
+
+#[gpui::test]
+async fn test_fs_watcher(cx: &mut TestAppContext) {
+    init_test(cx);
+    cx.executor().allow_parking();
+    let dir = TempTree::new(json!({}));
+
+    let worktree = Worktree::local(
+        dir.path(),
+        true,
+        Arc::new(RealFs::new(None, cx.executor())),
+        Default::default(),
+        true,
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+
+    #[cfg(not(target_os = "macos"))]
+    fs::fs_watcher::global(|_| {}).unwrap();
+
+    cx.read(|cx| worktree.read(cx).as_local().unwrap().scan_complete())
+        .await;
+    worktree.flush_fs_events(cx).await;
+
+    let abc_dir = dir.path().join("abc");
+
+    std::fs::create_dir(&abc_dir).unwrap();
+    worktree.flush_fs_events(cx).await;
+    worktree.read_with(cx, |tree, _| {
+        assert!(tree.entry_for_path(rel_path("abc")).is_some());
+    });
+
+    std::fs::remove_dir(&abc_dir).unwrap();
+    worktree.flush_fs_events(cx).await;
+    worktree.read_with(cx, |tree, _| {
+        assert!(tree.entry_for_path(rel_path("abc")).is_none());
+    });
+
+    std::fs::create_dir(&abc_dir).unwrap();
+    worktree.flush_fs_events(cx).await;
+    worktree.read_with(cx, |tree, _| {
+        assert!(tree.entry_for_path(rel_path("abc")).is_some());
+    });
+
+    std::fs::write(&abc_dir.join("new_file"), "new file contents")
+        .unwrap_or_else(|e| panic!("Failed to create in {abc_dir:?} a new file: {e}"));
+    worktree.flush_fs_events(cx).await;
+
+    worktree.read_with(cx, |tree, _| {
+        assert!(tree.entry_for_path(rel_path("abc/new_file")).is_some());
+    });
+}
+
+#[gpui::test]
+async fn test_fs_watcher_2(cx: &mut TestAppContext) {
+    init_test(cx);
+    cx.executor().allow_parking();
+    let dir = TempTree::new(json!({}));
+
+    let worktree = Worktree::local(
+        dir.path(),
+        true,
+        Arc::new(RealFs::new(None, cx.executor())),
+        Default::default(),
+        true,
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+
+    #[cfg(not(target_os = "macos"))]
+    fs::fs_watcher::global(|_| {}).unwrap();
+
+    cx.read(|cx| worktree.read(cx).as_local().unwrap().scan_complete())
+        .await;
+    worktree.flush_fs_events(cx).await;
+
+    let abc_dir = dir.path().join("abc");
+
+    std::fs::create_dir_all(&abc_dir.join("abc2")).unwrap();
+    worktree.flush_fs_events(cx).await;
+    worktree.read_with(cx, |tree, _| {
+        assert!(tree.entry_for_path(rel_path("abc")).is_some());
+    });
+
+    std::fs::remove_dir_all(&abc_dir).unwrap();
+    worktree.flush_fs_events(cx).await;
+    worktree.read_with(cx, |tree, _| {
+        assert!(tree.entry_for_path(rel_path("abc")).is_none());
+    });
+
+    std::fs::create_dir_all(&abc_dir.join("abc2")).unwrap();
+    worktree.flush_fs_events(cx).await;
+    worktree.read_with(cx, |tree, _| {
+        assert!(tree.entry_for_path(rel_path("abc/abc2")).is_some());
+    });
+
+    std::fs::write(&abc_dir.join("abc2/new_file"), "new file contents")
+        .unwrap_or_else(|e| panic!("Failed to create in {abc_dir:?} a new file: {e}"));
+    worktree.flush_fs_events(cx).await;
+
+    worktree.read_with(cx, |tree, _| {
+        assert!(tree.entry_for_path(rel_path("abc/abc2/new_file")).is_some());
+    });
+}


### PR DESCRIPTION
When a folder is created then deleted and then created again it was logging "path to watch is already watched".
Edit the remove function in fs_watcher.rs so it removes all watchers in subfolders.
Added 2 tests

Should help #38109 

Release Notes:

- Fixed fs watchers not being removed
