### PR TITLE
Add `luaurc` path suffix to JSONC

### DIFF
--- a/crates/languages/src/jsonc/config.toml
+++ b/crates/languages/src/jsonc/config.toml
@@ -1,6 +1,6 @@
 name = "JSONC"
 grammar = "jsonc"
-path_suffixes = ["jsonc", "bun.lock", "devcontainer.json", "pyrightconfig.json", "tsconfig.json"]
+path_suffixes = ["jsonc", "bun.lock", "devcontainer.json", "pyrightconfig.json", "tsconfig.json", "luaurc"]
 line_comments = ["// "]
 autoclose_before = ",]}"
 brackets = [


### PR DESCRIPTION
Closes https://github.com/4teapo/zed-luau/issues/31

Luau `.luaurc` config files contain JSON but that allows comments and trailing commas, making them a perfect fit for JSONC.

Release Notes:

- N/A