### PR TITLE
workspace: Remove custom-positioned modal placement logic

### DIFF
--- a/crates/workspace/src/modal_layer.rs
+++ b/crates/workspace/src/modal_layer.rs
@@ -1,17 +1,8 @@
 use gpui::{
     AnyView, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable as _, ManagedView,
-    MouseButton, Pixels, Point, Subscription,
+    MouseButton, Subscription,
 };
 use ui::prelude::*;
-
-#[derive(Debug, Clone, Copy, Default)]
-pub enum ModalPlacement {
-    #[default]
-    Centered,
-    Anchored {
-        position: Point<Pixels>,
-    },
-}
 
 #[derive(Debug)]
 pub enum DismissDecision {
@@ -67,7 +58,6 @@ pub struct ActiveModal {
     _subscriptions: [Subscription; 2],
     previous_focus_handle: Option<FocusHandle>,
     focus_handle: FocusHandle,
-    placement: ModalPlacement,
 }
 
 pub struct ModalLayer {
@@ -98,19 +88,6 @@ impl ModalLayer {
         V: ModalView,
         B: FnOnce(&mut Window, &mut Context<V>) -> V,
     {
-        self.toggle_modal_with_placement(window, cx, ModalPlacement::Centered, build_view);
-    }
-
-    pub fn toggle_modal_with_placement<V, B>(
-        &mut self,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-        placement: ModalPlacement,
-        build_view: B,
-    ) where
-        V: ModalView,
-        B: FnOnce(&mut Window, &mut Context<V>) -> V,
-    {
         if let Some(active_modal) = &self.active_modal {
             let is_close = active_modal.modal.view().downcast::<V>().is_ok();
             let did_close = self.hide_modal(window, cx);
@@ -119,17 +96,12 @@ impl ModalLayer {
             }
         }
         let new_modal = cx.new(|cx| build_view(window, cx));
-        self.show_modal(new_modal, placement, window, cx);
+        self.show_modal(new_modal, window, cx);
         cx.emit(ModalOpenedEvent);
     }
 
-    fn show_modal<V>(
-        &mut self,
-        new_modal: Entity<V>,
-        placement: ModalPlacement,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) where
+    fn show_modal<V>(&mut self, new_modal: Entity<V>, window: &mut Window, cx: &mut Context<Self>)
+    where
         V: ModalView,
     {
         let focus_handle = cx.focus_handle();
@@ -151,7 +123,6 @@ impl ModalLayer {
             ],
             previous_focus_handle: window.focused(cx),
             focus_handle,
-            placement,
         });
         cx.defer_in(window, move |_, window, cx| {
             window.focus(&new_modal.focus_handle(cx), cx);
@@ -212,30 +183,6 @@ impl Render for ModalLayer {
             return active_modal.modal.view().into_any_element();
         }
 
-        let content = h_flex()
-            .occlude()
-            .child(active_modal.modal.view())
-            .on_mouse_down(MouseButton::Left, |_, _, cx| {
-                cx.stop_propagation();
-            });
-
-        let positioned = match active_modal.placement {
-            ModalPlacement::Centered => v_flex()
-                .h(px(0.0))
-                .top_20()
-                .items_center()
-                .track_focus(&active_modal.focus_handle)
-                .child(content)
-                .into_any_element(),
-            ModalPlacement::Anchored { position } => div()
-                .absolute()
-                .left(position.x)
-                .top(position.y - px(20.))
-                .track_focus(&active_modal.focus_handle)
-                .child(content)
-                .into_any_element(),
-        };
-
         div()
             .absolute()
             .size_full()
@@ -252,7 +199,21 @@ impl Render for ModalLayer {
                     this.hide_modal(window, cx);
                 }),
             )
-            .child(positioned)
+            .child(
+                v_flex()
+                    .h(px(0.0))
+                    .top_20()
+                    .items_center()
+                    .track_focus(&active_modal.focus_handle)
+                    .child(
+                        h_flex()
+                            .occlude()
+                            .child(active_modal.modal.view())
+                            .on_mouse_down(MouseButton::Left, |_, _, cx| {
+                                cx.stop_propagation();
+                            }),
+                    ),
+            )
             .into_any_element()
     }
 }

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1205,7 +1205,6 @@ pub struct Workspace {
     last_open_dock_positions: Vec<DockPosition>,
     removing: bool,
     utility_panes: UtilityPaneState,
-    next_modal_placement: Option<ModalPlacement>,
 }
 
 impl EventEmitter<Event> for Workspace {}
@@ -1632,7 +1631,6 @@ impl Workspace {
             last_open_dock_positions: Vec::new(),
             removing: false,
             utility_panes: UtilityPaneState::default(),
-            next_modal_placement: None,
         }
     }
 
@@ -6350,25 +6348,12 @@ impl Workspace {
         self.modal_layer.read(cx).active_modal()
     }
 
-    pub fn is_modal_open<V: 'static>(&self, cx: &App) -> bool {
-        self.modal_layer.read(cx).active_modal::<V>().is_some()
-    }
-
-    pub fn set_next_modal_placement(&mut self, placement: ModalPlacement) {
-        self.next_modal_placement = Some(placement);
-    }
-
-    fn take_next_modal_placement(&mut self) -> ModalPlacement {
-        self.next_modal_placement.take().unwrap_or_default()
-    }
-
     pub fn toggle_modal<V: ModalView, B>(&mut self, window: &mut Window, cx: &mut App, build: B)
     where
         B: FnOnce(&mut Window, &mut Context<V>) -> V,
     {
-        let placement = self.take_next_modal_placement();
         self.modal_layer.update(cx, |modal_layer, cx| {
-            modal_layer.toggle_modal_with_placement(window, cx, placement, build)
+            modal_layer.toggle_modal(window, cx, build)
         })
     }
 


### PR DESCRIPTION
This PR essentially removes the logic I introduced in https://github.com/zed-industries/zed/pull/45361 to position workspace modals based on the pointer click coordinates. All of this code has become unnecessary given in https://github.com/zed-industries/zed/pull/45924 we made the remote, project, and branch modals use popovers when triggered with a pointer, which already handles all the anchor positioning based on the trigger (and that's much better).

Release Notes:

- N/A
