### PR TITLE
collab: Remove unused invite code handlers

### DIFF
--- a/crates/collab/src/db/queries/users.rs
+++ b/crates/collab/src/db/queries/users.rs
@@ -136,8 +136,6 @@ impl Database {
                 github_user_id: ActiveValue::set(github_user_id),
                 github_user_created_at: ActiveValue::set(Some(github_user_created_at)),
                 admin: ActiveValue::set(false),
-                invite_count: ActiveValue::set(0),
-                invite_code: ActiveValue::set(None),
                 metrics_id: ActiveValue::set(Uuid::new_v4()),
                 ..Default::default()
             })

--- a/crates/collab/src/db/tables/user.rs
+++ b/crates/collab/src/db/tables/user.rs
@@ -15,8 +15,6 @@ pub struct Model {
     pub email_address: Option<String>,
     pub name: Option<String>,
     pub admin: bool,
-    pub invite_code: Option<String>,
-    pub invite_count: i32,
     pub connected_once: bool,
     pub metrics_id: Uuid,
     pub created_at: NaiveDateTime,

--- a/crates/proto/proto/app.proto
+++ b/crates/proto/proto/app.proto
@@ -1,11 +1,6 @@
 syntax = "proto3";
 package zed.messages;
 
-message UpdateInviteInfo {
-    string url = 1;
-    uint32 count = 2;
-}
-
 message ShutdownRemoteServer {}
 
 message Toast {

--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -122,7 +122,6 @@ message Envelope {
         PerformRenameResponse perform_rename_response = 86;
 
         UpdateContacts update_contacts = 89;
-        UpdateInviteInfo update_invite_info = 90;
         ShowContacts show_contacts = 91;
 
         GetUsers get_users = 92;
@@ -452,6 +451,7 @@ message Envelope {
     }
 
     reserved 87 to 88, 396;
+    reserved 90;
     reserved 102 to 103;
     reserved 158 to 161;
     reserved 164;

--- a/crates/proto/src/proto.rs
+++ b/crates/proto/src/proto.rs
@@ -274,7 +274,6 @@ messages!(
     (UpdateDiffBases, Foreground),
     (UpdateFollowers, Foreground),
     (UpdateGitBranch, Background),
-    (UpdateInviteInfo, Foreground),
     (UpdateLanguageServer, Foreground),
     (UpdateNotification, Foreground),
     (UpdateParticipantLocation, Foreground),


### PR DESCRIPTION
This PR removes some unused invite code RPC handlers, as well as the `UpdateInviteInfo` RPC message.

Release Notes:

- N/A
