### PR TITLE
collab: Remove unused `get_user_metrics_id` query

### DIFF
--- a/crates/collab/src/db.rs
+++ b/crates/collab/src/db.rs
@@ -385,7 +385,6 @@ pub struct NewUserParams {
 #[derive(Debug)]
 pub struct NewUserResult {
     pub user_id: UserId,
-    pub metrics_id: String,
     pub inviting_user_id: Option<UserId>,
     pub signup_device_id: Option<String>,
 }

--- a/crates/collab/src/db/queries/users.rs
+++ b/crates/collab/src/db/queries/users.rs
@@ -1,4 +1,3 @@
-use anyhow::Context as _;
 use chrono::NaiveDateTime;
 
 use super::*;
@@ -194,26 +193,6 @@ impl Database {
                 .offset(page as u64 * limit as u64)
                 .all(&*tx)
                 .await?)
-        })
-        .await
-    }
-
-    /// Returns the metrics id for the user.
-    pub async fn get_user_metrics_id(&self, id: UserId) -> Result<String> {
-        #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
-        enum QueryAs {
-            MetricsId,
-        }
-
-        self.transaction(|tx| async move {
-            let metrics_id: Uuid = user::Entity::find_by_id(id)
-                .select_only()
-                .column(user::Column::MetricsId)
-                .into_values::<_, QueryAs>()
-                .one(&*tx)
-                .await?
-                .context("could not find user")?;
-            Ok(metrics_id.to_string())
         })
         .await
     }

--- a/crates/collab/src/db/queries/users.rs
+++ b/crates/collab/src/db/queries/users.rs
@@ -19,7 +19,6 @@ impl Database {
                 github_login: ActiveValue::set(params.github_login.clone()),
                 github_user_id: ActiveValue::set(params.github_user_id),
                 admin: ActiveValue::set(admin),
-                metrics_id: ActiveValue::set(Uuid::new_v4()),
                 ..Default::default()
             })
             .on_conflict(
@@ -36,7 +35,6 @@ impl Database {
 
             Ok(NewUserResult {
                 user_id: user.id,
-                metrics_id: user.metrics_id.to_string(),
                 signup_device_id: None,
                 inviting_user_id: None,
             })
@@ -135,7 +133,6 @@ impl Database {
                 github_user_id: ActiveValue::set(github_user_id),
                 github_user_created_at: ActiveValue::set(Some(github_user_created_at)),
                 admin: ActiveValue::set(false),
-                metrics_id: ActiveValue::set(Uuid::new_v4()),
                 ..Default::default()
             })
             .exec_with_returning(tx)

--- a/crates/collab/src/db/tables/user.rs
+++ b/crates/collab/src/db/tables/user.rs
@@ -16,7 +16,6 @@ pub struct Model {
     pub name: Option<String>,
     pub admin: bool,
     pub connected_once: bool,
-    pub metrics_id: Uuid,
     pub created_at: NaiveDateTime,
 }
 

--- a/crates/collab/src/db/tests/db_tests.rs
+++ b/crates/collab/src/db/tests/db_tests.rs
@@ -12,7 +12,6 @@ test_both_dbs!(
 
 async fn test_get_users(db: &Arc<Database>) {
     let mut user_ids = Vec::new();
-    let mut user_metric_ids = Vec::new();
     for i in 1..=4 {
         let user = db
             .create_user(
@@ -27,7 +26,6 @@ async fn test_get_users(db: &Arc<Database>) {
             .await
             .unwrap();
         user_ids.push(user.user_id);
-        user_metric_ids.push(user.metrics_id);
     }
 
     assert_eq!(


### PR DESCRIPTION
This PR removes the unused `get_user_metrics_id` query method and the `metrics_id` field from the `User` model.

Release Notes:

- N/A
