### PR TITLE
agent ui: Render docs aside in the correct spot depending on dock position

### DIFF
--- a/crates/agent_ui/src/acp/config_options.rs
+++ b/crates/agent_ui/src/acp/config_options.rs
@@ -3,6 +3,7 @@ use std::{cmp::Reverse, rc::Rc, sync::Arc};
 use acp_thread::AgentSessionConfigOptions;
 use agent_client_protocol as acp;
 use agent_servers::AgentServer;
+use agent_settings::AgentSettings;
 use collections::HashSet;
 use fs::Fs;
 use fuzzy::StringMatchCandidate;
@@ -12,9 +13,10 @@ use gpui::{
 use ordered_float::OrderedFloat;
 use picker::popover_menu::PickerPopoverMenu;
 use picker::{Picker, PickerDelegate};
-use settings::SettingsStore;
+use settings::{Settings, SettingsStore};
 use ui::{
-    ElevationIndex, IconButton, ListItem, ListItemSpacing, PopoverMenuHandle, Tooltip, prelude::*,
+    DocumentationSide, ElevationIndex, IconButton, ListItem, ListItemSpacing, PopoverMenuHandle,
+    Tooltip, prelude::*,
 };
 use util::ResultExt as _;
 
@@ -583,7 +585,7 @@ impl PickerDelegate for ConfigOptionPickerDelegate {
     fn documentation_aside(
         &self,
         _window: &mut Window,
-        _cx: &mut Context<Picker<Self>>,
+        cx: &mut Context<Picker<Self>>,
     ) -> Option<ui::DocumentationAside> {
         self.selected_description
             .as_ref()
@@ -591,8 +593,16 @@ impl PickerDelegate for ConfigOptionPickerDelegate {
                 let description = description.clone();
                 let is_default = *is_default;
 
+                let settings = AgentSettings::get_global(cx);
+                let side = match settings.dock {
+                    settings::DockPosition::Left => DocumentationSide::Right,
+                    settings::DockPosition::Bottom | settings::DockPosition::Right => {
+                        DocumentationSide::Left
+                    }
+                };
+
                 ui::DocumentationAside::new(
-                    ui::DocumentationSide::Left,
+                    side,
                     Rc::new(move |_| {
                         v_flex()
                             .gap_1()

--- a/crates/agent_ui/src/acp/model_selector.rs
+++ b/crates/agent_ui/src/acp/model_selector.rs
@@ -3,6 +3,7 @@ use std::{cmp::Reverse, rc::Rc, sync::Arc};
 use acp_thread::{AgentModelIcon, AgentModelInfo, AgentModelList, AgentModelSelector};
 use agent_client_protocol::ModelId;
 use agent_servers::AgentServer;
+use agent_settings::AgentSettings;
 use anyhow::Result;
 use collections::{HashSet, IndexMap};
 use fs::Fs;
@@ -15,7 +16,7 @@ use gpui::{
 use itertools::Itertools;
 use ordered_float::OrderedFloat;
 use picker::{Picker, PickerDelegate};
-use settings::SettingsStore;
+use settings::{Settings, SettingsStore};
 use ui::{DocumentationAside, DocumentationSide, IntoElement, prelude::*};
 use util::ResultExt;
 use zed_actions::agent::OpenSettings;
@@ -378,7 +379,7 @@ impl PickerDelegate for AcpModelPickerDelegate {
     fn documentation_aside(
         &self,
         _window: &mut Window,
-        _cx: &mut Context<Picker<Self>>,
+        cx: &mut Context<Picker<Self>>,
     ) -> Option<ui::DocumentationAside> {
         self.selected_description
             .as_ref()
@@ -386,8 +387,16 @@ impl PickerDelegate for AcpModelPickerDelegate {
                 let description = description.clone();
                 let is_default = *is_default;
 
+                let settings = AgentSettings::get_global(cx);
+                let side = match settings.dock {
+                    settings::DockPosition::Left => DocumentationSide::Right,
+                    settings::DockPosition::Bottom | settings::DockPosition::Right => {
+                        DocumentationSide::Left
+                    }
+                };
+
                 DocumentationAside::new(
-                    DocumentationSide::Left,
+                    side,
                     Rc::new(move |_| {
                         v_flex()
                             .gap_1()


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/45847

Release Notes:

- agent: Fixed the docs aside placement in selectors (i.e., model and configuration) depending on the panel dock position.
