### PR TITLE
collab: Remove unused fields from `NewUserResult`

### DIFF
--- a/crates/collab/src/db.rs
+++ b/crates/collab/src/db.rs
@@ -385,8 +385,6 @@ pub struct NewUserParams {
 #[derive(Debug)]
 pub struct NewUserResult {
     pub user_id: UserId,
-    pub inviting_user_id: Option<UserId>,
-    pub signup_device_id: Option<String>,
 }
 
 /// The result of updating a channel membership.

--- a/crates/collab/src/db/queries/users.rs
+++ b/crates/collab/src/db/queries/users.rs
@@ -33,11 +33,7 @@ impl Database {
             .exec_with_returning(&*tx)
             .await?;
 
-            Ok(NewUserResult {
-                user_id: user.id,
-                signup_device_id: None,
-                inviting_user_id: None,
-            })
+            Ok(NewUserResult { user_id: user.id })
         })
         .await
     }


### PR DESCRIPTION
This PR removes two unused fields from the `NewUserResult` type.

Release Notes:

- N/A
