### PR TITLE
buffer_diff: Ensure that base text has finished parsing before completing update

### DIFF
--- a/crates/acp_thread/src/diff.rs
+++ b/crates/acp_thread/src/diff.rs
@@ -212,12 +212,16 @@ impl PendingDiff {
                     )
                 })?
                 .await;
-            buffer_diff.update(cx, |diff, cx| {
-                diff.set_snapshot(update.clone(), &text_snapshot, cx);
-                diff.secondary_diff().unwrap().update(cx, |diff, cx| {
-                    diff.set_snapshot(update, &text_snapshot, cx);
-                });
+            let (task1, task2) = buffer_diff.update(cx, |diff, cx| {
+                let task1 = diff.set_snapshot(update.clone(), &text_snapshot, cx);
+                let task2 = diff
+                    .secondary_diff()
+                    .unwrap()
+                    .update(cx, |diff, cx| diff.set_snapshot(update, &text_snapshot, cx));
+                (task1, task2)
             })?;
+            task1.await;
+            task2.await;
             diff.update(cx, |diff, cx| {
                 if let Diff::Pending(diff) = diff {
                     diff.update_visible_ranges(cx);
@@ -380,17 +384,20 @@ async fn build_buffer_diff(
         })?
         .await;
 
-    secondary_diff.update(cx, |secondary_diff, cx| {
-        secondary_diff.language_changed(language.clone(), language_registry.clone(), cx);
-        secondary_diff.set_snapshot(update.clone(), &buffer, cx);
-    })?;
+    secondary_diff
+        .update(cx, |secondary_diff, cx| {
+            secondary_diff.language_changed(language.clone(), language_registry.clone(), cx);
+            secondary_diff.set_snapshot(update.clone(), &buffer, cx)
+        })?
+        .await;
 
     let diff = cx.new(|cx| BufferDiff::new(&buffer, cx))?;
     diff.update(cx, |diff, cx| {
         diff.language_changed(language, language_registry, cx);
-        diff.set_snapshot(update.clone(), &buffer, cx);
         diff.set_secondary_diff(secondary_diff);
-    })?;
+        diff.set_snapshot(update.clone(), &buffer, cx)
+    })?
+    .await;
     Ok(diff)
 }
 

--- a/crates/action_log/src/action_log.rs
+++ b/crates/action_log/src/action_log.rs
@@ -401,10 +401,11 @@ impl ActionLog {
         if let Ok(update) = update {
             let update = update.await;
 
-            let diff_snapshot = diff.update(cx, |diff, cx| {
-                diff.set_snapshot(update.clone(), &buffer_snapshot, cx);
-                diff.snapshot(cx)
-            })?;
+            diff.update(cx, |diff, cx| {
+                diff.set_snapshot(update.clone(), &buffer_snapshot, cx)
+            })?
+            .await;
+            let diff_snapshot = diff.update(cx, |diff, cx| diff.snapshot(cx))?;
 
             unreviewed_edits = cx
                 .background_spawn({

--- a/crates/edit_prediction_ui/src/rate_prediction_modal.rs
+++ b/crates/edit_prediction_ui/src/rate_prediction_modal.rs
@@ -335,12 +335,12 @@ impl RatePredictionsModal {
                     );
                     cx.spawn(async move |diff, cx| {
                         let update = update.await;
-                        let task = diff
+                        if let Some(task) = diff
                             .update(cx, |diff, cx| {
                                 diff.set_snapshot(update, &new_buffer_snapshot.text, cx)
                             })
-                            .ok();
-                        if let Some(task) = task {
+                            .ok()
+                        {
                             task.await;
                         }
                     })

--- a/crates/edit_prediction_ui/src/rate_prediction_modal.rs
+++ b/crates/edit_prediction_ui/src/rate_prediction_modal.rs
@@ -335,9 +335,14 @@ impl RatePredictionsModal {
                     );
                     cx.spawn(async move |diff, cx| {
                         let update = update.await;
-                        diff.update(cx, |diff, cx| {
-                            diff.set_snapshot(update, &new_buffer_snapshot.text, cx);
-                        })
+                        let task = diff
+                            .update(cx, |diff, cx| {
+                                diff.set_snapshot(update, &new_buffer_snapshot.text, cx)
+                            })
+                            .ok();
+                        if let Some(task) = task {
+                            task.await;
+                        }
                     })
                     .detach();
                 });

--- a/crates/git_ui/src/commit_view.rs
+++ b/crates/git_ui/src/commit_view.rs
@@ -803,15 +803,11 @@ async fn build_buffer_diff(
         })?
         .await;
 
-    if let Some(task) = diff
-        .update(cx, |diff, cx| {
-            diff.language_changed(language, Some(language_registry.clone()), cx);
-            diff.set_snapshot(update, &buffer.text, cx)
-        })
-        .ok()
-    {
-        task.await;
-    }
+    diff.update(cx, |diff, cx| {
+        diff.language_changed(language, Some(language_registry.clone()), cx);
+        diff.set_snapshot(update, &buffer.text, cx)
+    })?
+    .await;
 
     Ok(diff)
 }

--- a/crates/git_ui/src/commit_view.rs
+++ b/crates/git_ui/src/commit_view.rs
@@ -803,11 +803,15 @@ async fn build_buffer_diff(
         })?
         .await;
 
-    diff.update(cx, |diff, cx| {
-        diff.language_changed(language, Some(language_registry.clone()), cx);
-        diff.set_snapshot(update, &buffer.text, cx)
-    })
-    .ok();
+    if let Some(task) = diff
+        .update(cx, |diff, cx| {
+            diff.language_changed(language, Some(language_registry.clone()), cx);
+            diff.set_snapshot(update, &buffer.text, cx)
+        })
+        .ok()
+    {
+        task.await;
+    }
 
     Ok(diff)
 }

--- a/crates/git_ui/src/file_diff_view.rs
+++ b/crates/git_ui/src/file_diff_view.rs
@@ -191,8 +191,9 @@ async fn build_buffer_diff(
             Some(language_registry),
             cx,
         );
-        diff.set_snapshot(update, &new_buffer_snapshot.text, cx);
-    })?;
+        diff.set_snapshot(update, &new_buffer_snapshot.text, cx)
+    })?
+    .await;
 
     Ok(diff)
 }

--- a/crates/git_ui/src/text_diff_view.rs
+++ b/crates/git_ui/src/text_diff_view.rs
@@ -275,8 +275,9 @@ async fn update_diff_buffer(
         .await;
 
     diff.update(cx, |diff, cx| {
-        diff.set_snapshot(update, &source_buffer_snapshot.text, cx);
-    })?;
+        diff.set_snapshot(update, &source_buffer_snapshot.text, cx)
+    })?
+    .await;
     Ok(())
 }
 

--- a/crates/multi_buffer/src/multi_buffer_tests.rs
+++ b/crates/multi_buffer/src/multi_buffer_tests.rs
@@ -4019,8 +4019,9 @@ async fn test_singleton_with_inverted_diff(cx: &mut TestAppContext) {
         })
         .await;
     diff.update(cx, |diff, cx| {
-        diff.set_snapshot(update, &buffer.read(cx).text_snapshot(), cx);
-    });
+        diff.set_snapshot(update, &buffer.read(cx).text_snapshot(), cx)
+    })
+    .await;
     cx.run_until_parked();
 
     assert_new_snapshot(
@@ -4056,8 +4057,9 @@ async fn test_singleton_with_inverted_diff(cx: &mut TestAppContext) {
         })
         .await;
     diff.update(cx, |diff, cx| {
-        diff.set_snapshot(update, &buffer.read(cx).text_snapshot(), cx);
-    });
+        diff.set_snapshot(update, &buffer.read(cx).text_snapshot(), cx)
+    })
+    .await;
     cx.run_until_parked();
 
     assert_new_snapshot(


### PR DESCRIPTION
Follow-up to #46001 

That initial fix partly addressed the issue for diffs managed by the `GitStore`, but not for other diffs (e.g. those managed by the `ActionLog` or `CommitView`). The underlying issue is that we switched to using a `Buffer` to represent the diff base text, and when updating the diff we were calling `set_text` on this buffer and not waiting for reparsing to finish. When the base text was represented by a series of independent `BufferSnapshot`s, this wasn't an issue because we would parse the base text in the background as part of computing the diff update. This PR fixes the issue by waiting on reparsing to finish after each call to `set_text`.

Release Notes:

- N/A