### PR TITLE
typescript: Use @type instead of @type.builtin in highlights

### DIFF
--- a/crates/languages/src/javascript/highlights.scm
+++ b/crates/languages/src/javascript/highlights.scm
@@ -4,9 +4,9 @@
 
 (call_expression
   function: (member_expression
-    object: (identifier) @type.builtin
+    object: (identifier) @type
     (#any-of?
-      @type.builtin
+      @type
       "Promise"
       "Array"
       "Object"

--- a/crates/languages/src/tsx/highlights.scm
+++ b/crates/languages/src/tsx/highlights.scm
@@ -4,9 +4,9 @@
 
 (call_expression
   function: (member_expression
-    object: (identifier) @type.builtin
+    object: (identifier) @type
     (#any-of?
-      @type.builtin
+      @type
       "Promise"
       "Array"
       "Object"

--- a/crates/languages/src/typescript/highlights.scm
+++ b/crates/languages/src/typescript/highlights.scm
@@ -4,9 +4,9 @@
 
 (call_expression
   function: (member_expression
-    object: (identifier) @type.builtin
+    object: (identifier) @type
     (#any-of?
-      @type.builtin
+      @type
       "Promise"
       "Array"
       "Object"


### PR DESCRIPTION
Closes #45251

In https://github.com/zed-industries/zed/pull/44532 the syntax highlighting of JS/TS was improved, but we only used `type.builtin` for a specific case. This resulted in less consistent syntax highlighting. Not all themes have this specific token and we don't use `type.builtin` in other places either, so while this is a little less specific it is more consistent.

Release Notes:

- Improved syntax highlighting consistency for builtins in JavaScript and TypeScript
