### PR TITLE
Add setting to disable binary downloads

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -138,6 +138,9 @@
   //  3. Do not restore previous workspaces
   //         "restore_on_startup": "none",
   "restore_on_startup": "last_session",
+  // Whether zed should automatically download binaries to run
+  // language servers if they are missing.
+  "allow_executable_downloads": true,
   // Whether to attempt to restore previous file's state when opening it again.
   // The state is stored per pane.
   // When disabled, defaults are applied instead of the state restoration.


### PR DESCRIPTION
Closes #12589, #12354

Follow up of #14034 #12703

This is still a tentative and wip. I don’t have a lot of experience with this part of Zed yet, so it might take me a bit longer. I’ve tried to pull together all the ideas and feedback from #12589, #12703, #14034, and #12354.

The plan is to split the implementation into two parts. First, add a global setting, block all downloads, and fall back to binaries on the user’s PATH. If nothing is found, we just log the error.

In the second part, I want to dig into how we should handle that error case properly, including notification behavior and whether we need api changes.

Release Notes:

- TODO
