### PR TITLE
agent_ui: Fix agent UI stealing focus on start up

### DIFF
--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -731,7 +731,9 @@ impl AcpThreadView {
                             })
                         });
 
-                        this.message_editor.focus_handle(cx).focus(window, cx);
+                        if this.focus_handle(cx).is_focused(window) {
+                            this.message_editor.focus_handle(cx).focus(window, cx);
+                        }
 
                         cx.notify();
                     }


### PR DESCRIPTION
Release Notes:

- Fixed Zed stealing element focus away briefly after startup, interrupting user workflows
