### PR TITLE
ci: Use `zed-zippy` identity for `bump_patch_version.yml`

### DIFF
--- a/.github/workflows/bump_patch_version.yml
+++ b/.github/workflows/bump_patch_version.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: branch
+        description: Branch name to run on
         required: true
         type: string
 jobs:

--- a/.github/workflows/bump_patch_version.yml
+++ b/.github/workflows/bump_patch_version.yml
@@ -19,13 +19,13 @@ jobs:
       with:
         app-id: ${{ secrets.ZED_ZIPPY_APP_ID }}
         private-key: ${{ secrets.ZED_ZIPPY_APP_PRIVATE_KEY }}
-    - name: Checkout code
+    - name: steps::checkout_repo_with_token
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         clean: false
         token: ${{ steps.get-app-token.outputs.token }}
         ref: ${{ inputs.branch }}
-    - name: Bump Patch Version
+    - name: bump_patch_version::run_bump_patch_version::bump_patch_version
       run: |
         channel="$(cat crates/zed/RELEASE_CHANNEL)"
 

--- a/.github/workflows/bump_patch_version.yml
+++ b/.github/workflows/bump_patch_version.yml
@@ -1,51 +1,58 @@
+# Generated from xtask::workflows::bump_patch_version
+# Rebuild with `cargo xtask workflows`.
 name: bump_patch_version
-
 on:
   workflow_dispatch:
     inputs:
       branch:
-        description: "Branch name to run on"
+        description: branch
         required: true
+        type: string
+jobs:
+  run_bump_patch_version:
+    if: github.repository_owner == 'zed-industries'
+    runs-on: namespace-profile-16x32-ubuntu-2204
+    steps:
+    - id: get-app-token
+      name: steps::authenticate_as_zippy
+      uses: actions/create-github-app-token@bef1eaf1c0ac2b148ee2a0a74c65fbe6db0631f1
+      with:
+        app-id: ${{ secrets.ZED_ZIPPY_APP_ID }}
+        private-key: ${{ secrets.ZED_ZIPPY_APP_PRIVATE_KEY }}
+    - name: Checkout code
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      with:
+        clean: false
+        token: ${{ steps.get-app-token.outputs.token }}
+        ref: ${{ inputs.branch }}
+    - name: Bump Patch Version
+      run: |
+        channel="$(cat crates/zed/RELEASE_CHANNEL)"
 
+        tag_suffix=""
+        case $channel in
+          stable)
+            ;;
+          preview)
+            tag_suffix="-pre"
+            ;;
+          *)
+            echo "this must be run on either of stable|preview release branches" >&2
+            exit 1
+            ;;
+        esac
+        which cargo-set-version > /dev/null || cargo install cargo-edit -f --no-default-features --features "set-version"
+        output="$(cargo set-version -p zed --bump patch 2>&1 | sed 's/.* //')"
+        git commit -am "Bump to $output for @$GITHUB_ACTOR"
+        git tag "v${output}${tag_suffix}"
+        git push origin HEAD "v${output}${tag_suffix}"
+      shell: bash -euxo pipefail {0}
+      env:
+        GIT_COMMITTER_NAME: Zed Zippy
+        GIT_COMMITTER_EMAIL: 234243425+zed-zippy[bot]@users.noreply.github.com
+        GIT_AUTHOR_NAME: Zed Zippy
+        GIT_AUTHOR_EMAIL: 234243425+zed-zippy[bot]@users.noreply.github.com
+        GITHUB_TOKEN: ${{ steps.get-app-token.outputs.token }}
 concurrency:
-  # Allow only one workflow per any non-`main` branch.
   group: ${{ github.workflow }}-${{ inputs.branch }}
   cancel-in-progress: true
-
-jobs:
-  bump_patch_version:
-    if: github.repository_owner == 'zed-industries'
-    runs-on:
-      - namespace-profile-16x32-ubuntu-2204
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          ref: ${{ github.event.inputs.branch }}
-          ssh-key: ${{ secrets.ZED_BOT_DEPLOY_KEY }}
-
-      - name: Bump Patch Version
-        run: |
-          set -eux
-
-          channel="$(cat crates/zed/RELEASE_CHANNEL)"
-
-          tag_suffix=""
-          case $channel in
-            stable)
-              ;;
-            preview)
-              tag_suffix="-pre"
-              ;;
-            *)
-              echo "this must be run on either of stable|preview release branches" >&2
-              exit 1
-              ;;
-          esac
-          which cargo-set-version > /dev/null || cargo install cargo-edit -f --no-default-features --features "set-version"
-          output="$(cargo set-version -p zed --bump patch 2>&1 | sed 's/.* //')"
-          export GIT_COMMITTER_NAME="Zed Bot"
-          export GIT_COMMITTER_EMAIL="hi@zed.dev"
-          git commit -am "Bump to $output for @$GITHUB_ACTOR" --author "Zed Bot <hi@zed.dev>"
-          git tag "v${output}${tag_suffix}"
-          git push origin HEAD "v${output}${tag_suffix}"

--- a/tooling/xtask/src/tasks/workflows.rs
+++ b/tooling/xtask/src/tasks/workflows.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 
 mod after_release;
 mod autofix_pr;
+mod bump_patch_version;
 mod cherry_pick;
 mod compare_perf;
 mod danger;
@@ -126,22 +127,23 @@ pub fn run_workflows(_: GenerateWorkflowArgs) -> Result<()> {
     }
 
     let workflows = [
-        WorkflowFile::zed(danger::danger),
-        WorkflowFile::zed(run_bundling::run_bundling),
-        WorkflowFile::zed(release_nightly::release_nightly),
-        WorkflowFile::zed(run_tests::run_tests),
-        WorkflowFile::zed(release::release),
-        WorkflowFile::zed(cherry_pick::cherry_pick),
-        WorkflowFile::zed(autofix_pr::autofix_pr),
-        WorkflowFile::zed(compare_perf::compare_perf),
-        WorkflowFile::zed(run_agent_evals::run_unit_evals),
-        WorkflowFile::zed(run_agent_evals::run_cron_unit_evals),
-        WorkflowFile::zed(run_agent_evals::run_agent_evals),
         WorkflowFile::zed(after_release::after_release),
-        WorkflowFile::zed(extension_tests::extension_tests),
+        WorkflowFile::zed(autofix_pr::autofix_pr),
+        WorkflowFile::zed(bump_patch_version::bump_patch_version),
+        WorkflowFile::zed(cherry_pick::cherry_pick),
+        WorkflowFile::zed(compare_perf::compare_perf),
+        WorkflowFile::zed(danger::danger),
         WorkflowFile::zed(extension_bump::extension_bump),
         WorkflowFile::zed(extension_release::extension_release),
+        WorkflowFile::zed(extension_tests::extension_tests),
         WorkflowFile::zed(extension_workflow_rollout::extension_workflow_rollout),
+        WorkflowFile::zed(release::release),
+        WorkflowFile::zed(release_nightly::release_nightly),
+        WorkflowFile::zed(run_agent_evals::run_agent_evals),
+        WorkflowFile::zed(run_agent_evals::run_cron_unit_evals),
+        WorkflowFile::zed(run_agent_evals::run_unit_evals),
+        WorkflowFile::zed(run_bundling::run_bundling),
+        WorkflowFile::zed(run_tests::run_tests),
         /* workflows used for CI/CD in extension repositories */
         WorkflowFile::extension(extensions::run_tests::run_tests),
         WorkflowFile::extension_shared(extensions::bump_version::bump_version),

--- a/tooling/xtask/src/tasks/workflows/bump_patch_version.rs
+++ b/tooling/xtask/src/tasks/workflows/bump_patch_version.rs
@@ -23,14 +23,11 @@ pub fn bump_patch_version() -> Workflow {
 
 fn run_bump_patch_version(branch: &WorkflowInput) -> steps::NamedJob {
     fn checkout_branch(branch: &WorkflowInput, token: &StepOutput) -> Step<Use> {
-        steps::checkout_repo_with_token(token)
-            .name("Checkout code")
-            .add_with(("ref", branch.to_string()))
+        steps::checkout_repo_with_token(token).add_with(("ref", branch.to_string()))
     }
 
     fn bump_patch_version(token: &StepOutput) -> Step<Run> {
-        Step::new("Bump Patch Version")
-            .run(indoc::indoc! {r#"
+        named::bash(indoc::indoc! {r#"
             channel="$(cat crates/zed/RELEASE_CHANNEL)"
 
             tag_suffix=""

--- a/tooling/xtask/src/tasks/workflows/bump_patch_version.rs
+++ b/tooling/xtask/src/tasks/workflows/bump_patch_version.rs
@@ -7,7 +7,7 @@ use crate::tasks::workflows::{
 };
 
 pub fn bump_patch_version() -> Workflow {
-    let branch = WorkflowInput::string("branch", None);
+    let branch = WorkflowInput::string("branch", None).description("Branch name to run on");
     let bump_patch_version_job = run_bump_patch_version(&branch);
     named::workflow()
         .on(Event::default()

--- a/tooling/xtask/src/tasks/workflows/bump_patch_version.rs
+++ b/tooling/xtask/src/tasks/workflows/bump_patch_version.rs
@@ -1,0 +1,80 @@
+use gh_workflow::*;
+
+use crate::tasks::workflows::{
+    runners,
+    steps::{self, named},
+    vars::{StepOutput, WorkflowInput},
+};
+
+pub fn bump_patch_version() -> Workflow {
+    let branch = WorkflowInput::string("branch", None);
+    let bump_patch_version_job = run_bump_patch_version(&branch);
+    named::workflow()
+        .on(Event::default()
+            .workflow_dispatch(WorkflowDispatch::default().add_input(branch.name, branch.input())))
+        .concurrency(
+            Concurrency::new(Expression::new(format!(
+                "${{{{ github.workflow }}}}-{branch}"
+            )))
+            .cancel_in_progress(true),
+        )
+        .add_job(bump_patch_version_job.name, bump_patch_version_job.job)
+}
+
+fn run_bump_patch_version(branch: &WorkflowInput) -> steps::NamedJob {
+    fn checkout_branch(branch: &WorkflowInput, token: &StepOutput) -> Step<Use> {
+        steps::checkout_repo_with_token(token)
+            .name("Checkout code")
+            .add_with(("ref", branch.to_string()))
+    }
+
+    fn bump_patch_version(token: &StepOutput) -> Step<Run> {
+        Step::new("Bump Patch Version")
+            .run(indoc::indoc! {r#"
+            channel="$(cat crates/zed/RELEASE_CHANNEL)"
+
+            tag_suffix=""
+            case $channel in
+              stable)
+                ;;
+              preview)
+                tag_suffix="-pre"
+                ;;
+              *)
+                echo "this must be run on either of stable|preview release branches" >&2
+                exit 1
+                ;;
+            esac
+            which cargo-set-version > /dev/null || cargo install cargo-edit -f --no-default-features --features "set-version"
+            output="$(cargo set-version -p zed --bump patch 2>&1 | sed 's/.* //')"
+            git commit -am "Bump to $output for @$GITHUB_ACTOR"
+            git tag "v${output}${tag_suffix}"
+            git push origin HEAD "v${output}${tag_suffix}"
+        "#})
+        .shell(steps::BASH_SHELL)
+        .add_env(("GIT_COMMITTER_NAME", "Zed Zippy"))
+        .add_env((
+            "GIT_COMMITTER_EMAIL",
+            "234243425+zed-zippy[bot]@users.noreply.github.com",
+        ))
+        .add_env(("GIT_AUTHOR_NAME", "Zed Zippy"))
+        .add_env((
+            "GIT_AUTHOR_EMAIL",
+            "234243425+zed-zippy[bot]@users.noreply.github.com",
+        ))
+        .add_env(("GITHUB_TOKEN", token))
+    }
+
+    let (authenticate, token) = steps::authenticate_as_zippy();
+
+    named::job(
+        Job::default()
+            .cond(Expression::new(
+                "github.repository_owner == 'zed-industries'",
+            ))
+            .runs_on(runners::LINUX_XL)
+            .add_step(authenticate)
+            .add_step(checkout_branch(branch, &token))
+            .add_step(bump_patch_version(&token)),
+    )
+}

--- a/tooling/xtask/src/tasks/workflows/vars.rs
+++ b/tooling/xtask/src/tasks/workflows/vars.rs
@@ -218,6 +218,7 @@ pub struct WorkflowInput {
     pub input_type: &'static str,
     pub name: &'static str,
     pub default: Option<String>,
+    pub description: Option<String>,
 }
 
 impl WorkflowInput {
@@ -226,6 +227,7 @@ impl WorkflowInput {
             input_type: "string",
             name,
             default,
+            description: None,
         }
     }
 
@@ -234,12 +236,21 @@ impl WorkflowInput {
             input_type: "boolean",
             name,
             default: default.as_ref().map(ToString::to_string),
+            description: None,
         }
+    }
+
+    pub fn description(mut self, description: impl ToString) -> Self {
+        self.description = Some(description.to_string());
+        self
     }
 
     pub fn input(&self) -> WorkflowDispatchInput {
         WorkflowDispatchInput {
-            description: self.name.to_owned(),
+            description: self
+                .description
+                .clone()
+                .unwrap_or_else(|| self.name.to_owned()),
             required: self.default.is_none(),
             input_type: self.input_type.to_owned(),
             default: self.default.clone(),


### PR DESCRIPTION
This PR updates the `bump_patch_version.yml` to also be generated by `cargo xtask workflows` and updates this to use the `zed-zippy` identity instead of the `ConradIrwin` identity.

Release Notes:

- N/A
