### PR TITLE
languages: Highlight enumerator values as constants in C++

### DIFF
--- a/crates/languages/src/cpp/highlights.scm
+++ b/crates/languages/src/cpp/highlights.scm
@@ -99,6 +99,9 @@ type: (primitive_type) @type.builtin
 ((identifier) @constant.builtin
  (#match? @constant.builtin "^_*[A-Z][A-Z\\d_]*$"))
 
+(enumerator
+  name: (identifier) @constant)
+
 (statement_identifier) @label
 (this) @variable.builtin
 ("static_assert") @function.builtin


### PR DESCRIPTION
Before:
<img width="496" height="102" alt="before" src="https://github.com/user-attachments/assets/ffc6957c-a7dc-49b9-acbf-d7295aeb0f59" />

After:

<img width="403" height="105" alt="after" src="https://github.com/user-attachments/assets/4269e045-4c7b-4b7b-b5b1-3578b9f46689" />

Release Notes:

- Fix constant highlight issue for enumerator values 
