### PR TITLE
languages: Capture escape sequences in C and C++

### DIFF
--- a/crates/languages/src/c/highlights.scm
+++ b/crates/languages/src/c/highlights.scm
@@ -98,6 +98,8 @@
   (char_literal)
 ] @string
 
+(escape_sequence) @string.escape
+
 (comment) @comment
 
 (number_literal) @number

--- a/crates/languages/src/cpp/highlights.scm
+++ b/crates/languages/src/cpp/highlights.scm
@@ -198,7 +198,7 @@ type: (primitive_type) @type.builtin
   (raw_string_literal)
 ] @string
 
-(escape_sequence) @constant.character.escape
+(escape_sequence) @string.escape
 
 [
   ","

--- a/crates/languages/src/cpp/highlights.scm
+++ b/crates/languages/src/cpp/highlights.scm
@@ -198,6 +198,8 @@ type: (primitive_type) @type.builtin
   (raw_string_literal)
 ] @string
 
+(escape_sequence) @constant.character.escape
+
 [
   ","
   ":"


### PR DESCRIPTION
Before:
<img width="901" height="247" alt="before" src="https://github.com/user-attachments/assets/95467f0a-e464-44ea-a8f3-bedccf57c6a9" />

After:
<img width="967" height="256" alt="after" src="https://github.com/user-attachments/assets/5eb43918-4348-42d2-9174-3fafd82919d0" />

Release Notes:

- Added highlighting for escape sequences for C and C++.
