### PR TITLE
languages: Support enum class/struct in outline in C++

### DIFF
--- a/crates/languages/src/cpp/outline.scm
+++ b/crates/languages/src/cpp/outline.scm
@@ -28,6 +28,10 @@
 
 (enum_specifier
     "enum" @context
+    [
+        "class"
+        "struct"
+    ]? @context
     name: (_) @name) @item
 
 (enumerator


### PR DESCRIPTION
Before:
<img width="964" height="318" alt="before" src="https://github.com/user-attachments/assets/946b1997-5e63-4d8c-8468-b6a93e73efa3" />

After:
<img width="981" height="335" alt="after" src="https://github.com/user-attachments/assets/177e1734-518f-4686-bd04-0015f486c421" />

Release Notes:

- Fixed missing enum class struct at outline panel for C++
