### PR TITLE
languages: Add structs, unions and enums to outline in C

### DIFF
--- a/crates/languages/src/c/highlights.scm
+++ b/crates/languages/src/c/highlights.scm
@@ -114,9 +114,6 @@
 ((identifier) @constant
  (#match? @constant "^_*[A-Z][A-Z\\d_]*$"))
 
-(enumerator
-  name: (identifier) @constant)
-
 (call_expression
   function: (identifier) @function)
 (call_expression

--- a/crates/languages/src/c/highlights.scm
+++ b/crates/languages/src/c/highlights.scm
@@ -114,6 +114,9 @@
 ((identifier) @constant
  (#match? @constant "^_*[A-Z][A-Z\\d_]*$"))
 
+(enumerator
+  name: (identifier) @constant)
+
 (call_expression
   function: (identifier) @function)
 (call_expression

--- a/crates/languages/src/c/outline.scm
+++ b/crates/languages/src/c/outline.scm
@@ -9,6 +9,25 @@
         "(" @context
         ")" @context)) @item
 
+(struct_specifier
+    "struct" @context
+    name: (_) @name) @item
+
+(union_specifier
+    "union" @context
+    name: (_) @name) @item
+
+(enum_specifier
+    "enum" @context
+    name: (_) @name) @item
+
+(enumerator
+    name: (_) @name) @item
+
+(field_declaration
+    type: (_) @context
+    declarator: (field_identifier) @name) @item
+
 (type_definition
     "typedef" @context
     declarator: (_) @name) @item


### PR DESCRIPTION
Before:
<img width="1179" height="739" alt="before" src="https://github.com/user-attachments/assets/de594de2-ac70-40cf-8813-bb8c02e95014" />


After:
<img width="1009" height="696" alt="after" src="https://github.com/user-attachments/assets/b68b9f84-7f15-4baf-99ed-a259ca07e815" />

Release Notes:

- Fixed struct union enum outline issues for c
