### PR TITLE
languages: Add union field declarations to outline in C++

### DIFF
--- a/crates/languages/src/cpp/outline.scm
+++ b/crates/languages/src/cpp/outline.scm
@@ -30,6 +30,10 @@
     "enum" @context
     name: (_) @name) @item
 
+(union_specifier
+    "union" @context
+    name: (_) @name) @item
+
 (enumerator
     name: (_) @name) @item
 


### PR DESCRIPTION
Before:
<img width="609" height="220" alt="before" src="https://github.com/user-attachments/assets/2bc10b8c-ecc5-419b-825b-5b7c8440b89b" />

After:
<img width="689" height="169" alt="after" src="https://github.com/user-attachments/assets/ff3de33e-f71c-4fe7-b1ef-df79d935667d" />

Release Notes:

- Fixed outline members outline issue of unions for C++
