### PR TITLE
Prevent app naps during audio playback on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9443,6 +9443,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "audio",
+ "cocoa 0.26.0",
  "collections",
  "core-foundation 0.10.0",
  "core-video",

--- a/crates/livekit_client/Cargo.toml
+++ b/crates/livekit_client/Cargo.toml
@@ -54,6 +54,7 @@ livekit = { rev = "5f04705ac3f356350ae31534ffbc476abc9ea83d", git = "https://git
 scap.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
+cocoa.workspace = true
 core-foundation.workspace = true
 core-video.workspace = true
 coreaudio-rs = "0.12.1"


### PR DESCRIPTION
Release Notes:

- Fixed an issue on macOS where audio playback would become temporarily scrambled when doing lots of IO operations, such as when running `git pull` or `git checkout` while in a call.

