### PR TITLE
docs: Add documentation for `auto_update_extensions`

### DIFF
--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -2929,6 +2929,7 @@ Configuration object for defining settings profiles. Example:
 - Description:
   Preview tabs allow you to open files in preview mode, where they close automatically when you switch to another file unless you explicitly pin them. This is useful for quickly viewing files without cluttering your workspace. Preview tabs display their file names in italics. \
    There are several ways to convert a preview tab into a regular tab:
+
   - Double-clicking on the file
   - Double-clicking on the tab header
   - Using the {#action project_panel::OpenPermanent} action

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -244,6 +244,16 @@ Define extensions which should be installed (`true`) or never installed (`false`
 }
 ```
 
+## Auto Update extensions
+
+- Description: Define extensions to be auto-updated or not auto-updated.
+- Setting: `auto_update_extensions`
+- Default: `true`
+
+**Options**
+
+`boolean` values
+
 ## Autosave
 
 - Description: When to automatically save edited buffers.

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -246,13 +246,13 @@ Define extensions which should be installed (`true`) or never installed (`false`
 
 ## Auto Update extensions
 
-- Description: Define extensions to be auto-updated or not auto-updated.
+- Description: Define extensions to be autoupdated or manually updated.
 - Setting: `auto_update_extensions`
 - Default: `null`
 
 **Options**
 
-Define extensions which should be auto-updated (`true`) vs. manually updated (`false`).
+Define extensions which will be autoupdated (`true`) vs. those that will be manually updated (`false`).
 
 ```json [settings]
 {
@@ -2929,7 +2929,6 @@ Configuration object for defining settings profiles. Example:
 - Description:
   Preview tabs allow you to open files in preview mode, where they close automatically when you switch to another file unless you explicitly pin them. This is useful for quickly viewing files without cluttering your workspace. Preview tabs display their file names in italics. \
    There are several ways to convert a preview tab into a regular tab:
-
   - Double-clicking on the file
   - Double-clicking on the tab header
   - Using the {#action project_panel::OpenPermanent} action

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -248,11 +248,21 @@ Define extensions which should be installed (`true`) or never installed (`false`
 
 - Description: Define extensions to be auto-updated or not auto-updated.
 - Setting: `auto_update_extensions`
-- Default: `true`
+- Default: `null`
 
 **Options**
 
-`boolean` values
+Define extensions which should be auto-updated (`true`) vs. manually updated (`false`).
+
+```json [settings]
+{
+  "auto_update_extensions": {
+    "html": true,
+    "dockerfile": true,
+    "docker-compose": false
+  }
+}
+```
 
 ## Autosave
 
@@ -2919,7 +2929,6 @@ Configuration object for defining settings profiles. Example:
 - Description:
   Preview tabs allow you to open files in preview mode, where they close automatically when you switch to another file unless you explicitly pin them. This is useful for quickly viewing files without cluttering your workspace. Preview tabs display their file names in italics. \
    There are several ways to convert a preview tab into a regular tab:
-
   - Double-clicking on the file
   - Double-clicking on the tab header
   - Using the {#action project_panel::OpenPermanent} action


### PR DESCRIPTION
Add documentation for the existing `auto_update_extensions` setting that allows users to toggle auto-updates per extension.

Release Notes:
- N/A

