### PR TITLE
languages: Fix C/C++ outline for mixed storage classes and type qualifiers

### DIFF
--- a/crates/languages/src/cpp/outline.scm
+++ b/crates/languages/src/cpp/outline.scm
@@ -38,8 +38,10 @@
     name: (_) @name) @item
 
 (declaration
-    (storage_class_specifier) @context
-    (type_qualifier)? @context
+    [
+        (storage_class_specifier)
+        (type_qualifier)
+    ]* @context
     type: (_) @context
     declarator: (init_declarator
       ; The declaration may define multiple variables, using @item on the
@@ -121,7 +123,10 @@
     (type_qualifier)? @context) @item
 
 (field_declaration
-    (type_qualifier)? @context
+    [
+        (storage_class_specifier)
+        (type_qualifier)
+    ]* @context
     type: (_) @context
     declarator: [
         (field_identifier) @name


### PR DESCRIPTION
Current tree sitter configuration for the outline was not working correctly since the rule required a strict order, firstly
storage_class_specifier then type_qualifier. This resulted in a failure to recognize types such as "constexpr int", "const double", etc. This PR proposes a solution with diagnostic capture of type and storage qualifiers which ensures full context capture and works well with C++.


Before:
<img width="924" height="365" alt="before" src="https://github.com/user-attachments/assets/d4e0baab-b074-42fc-8a45-46c93d1d352b" />

After:
<img width="866" height="367" alt="after" src="https://github.com/user-attachments/assets/0e69a4d8-fd91-44b3-bc7e-0c9e39b23d2e" />


Release Notes:

- Fixed outline configuration for C++ variables with complex specifiers.
