### PR TITLE
smol: Use `Unblock` instead of `Async` for stdin, stdout and stderr handles

### DIFF
--- a/crates/nc/src/nc.rs
+++ b/crates/nc/src/nc.rs
@@ -16,15 +16,15 @@ pub fn main(_socket: &str) -> Result<()> {
 pub fn main(socket: &str) -> Result<()> {
     use futures::{AsyncReadExt as _, AsyncWriteExt as _, FutureExt as _, io::BufReader, select};
     use net::async_net::UnixStream;
-    use smol::{Async, io::AsyncBufReadExt};
+    use smol::{Unblock, io::AsyncBufReadExt};
 
     smol::block_on(async {
         let socket_stream = UnixStream::connect(socket).await?;
         let (socket_read, mut socket_write) = socket_stream.split();
         let mut socket_reader = BufReader::new(socket_read);
 
-        let mut stdout = Async::new(std::io::stdout())?;
-        let stdin = Async::new(std::io::stdin())?;
+        let mut stdout = Unblock::new(std::io::stdout());
+        let stdin = Unblock::new(std::io::stdin());
         let mut stdin_reader = BufReader::new(stdin);
 
         let mut socket_line = Vec::new();


### PR DESCRIPTION
as per its documentation:

`Async` supports all networking types, as well as some OS-specific file descriptors like timerfd and inotify.

However, do not use `Async` with types like File, Stdin, Stdout, or Stderr because all operating systems have issues with them when put in non-blocking mode.

Release Notes:

- N/A *or* Added/Fixed/Improved ...
