### PR TITLE
docs: Update "Custom Keybindings for Extension-Based Agents section" to include a troubleshooting note for defining an agent name

### DIFF
--- a/docs/src/ai/external-agents.md
+++ b/docs/src/ai/external-agents.md
@@ -221,7 +221,7 @@ To assign a custom keybinding to start a new thread for agents that were added b
       {
         "agent": {
           "custom": {
-            "name": "My Agent", // The agent name as it appears in the UI (e.g., "OpenCode", "Auggie CLI", etc.)
+            "name": "My Agent", // The agent name as defined in the extension or in settings.json (e.g., "opencode", "Auggie CLI", etc.)
             "command": {
               "command": "my-agent", // The agent name in lowercase with no spaces
               "args": ["acp"]
@@ -233,6 +233,9 @@ To assign a custom keybinding to start a new thread for agents that were added b
   }
 },
 ```
+
+> For most extensions, the `agent.custom.name` attribute matches the name of the agent that appears in the [Agent Panel](../ai/agent-panel.html) UI.
+> In some cases however, the name might need to be written differently (e.g. in lowercase).
 
 ## Debugging Agents
 

--- a/docs/src/ai/external-agents.md
+++ b/docs/src/ai/external-agents.md
@@ -234,7 +234,7 @@ To assign a custom keybinding to start a new thread for agents that were added b
 },
 ```
 
-> For most extensions, the `agent.custom.name` attribute matches the name of the agent that appears in the [Agent Panel](../ai/agent-panel.html) UI.
+> For most extensions, the `agent.custom.name` attribute matches the name of the agent that appears in the [Agent Panel](../ai/agent-panel.md) UI.
 > In some cases however, the name might need to be written differently (e.g. in lowercase).
 
 ## Debugging Agents


### PR DESCRIPTION
## Description
When trying to setup the OpenCode external agent the other day, I was having trouble setting the keybinding using the docs. The issue was that it said to use the same name as the one written in the UI. While this works when the external agent is defined using the `settings.json` file, it didn't work when setting up the keybinding after installing the extension through the extension marketplace.

Since the solution I found was to define the agent name as 'opencode' instead of 'OpenCode' (which is the name that shows up in the UI) I thought it would be appropiate to indicate that sometimes you might need to set it up using a different name.

Release Notes:

- N/A 
