### PR TITLE
Fix case of libX11 in dependency list

### DIFF
--- a/script/freebsd
+++ b/script/freebsd
@@ -26,7 +26,7 @@ if [[ -n $pkg ]]; then
         llvm
         protobuf
         rustup-init
-        libx11
+        libX11
         alsa-lib
     )
     $maysudo "$pkg" install "${deps[@]}"


### PR DESCRIPTION
The library in FreeBSD is named libX11 with an uppercase X

Closes #ISSUE

Release Notes:

- Fix error when the script is run in FreeBSD 14.3