### PR TITLE
terminal_view: Fix hairline gaps in Powerline glyphs via pixel snapping

### DIFF
--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -185,12 +185,12 @@ impl LayoutRect {
             let alac_point = self.point;
             point(
                 (origin.x + alac_point.column as f32 * dimensions.cell_width).floor(),
-                origin.y + alac_point.line as f32 * dimensions.line_height,
+                (origin.y + alac_point.line as f32 * dimensions.line_height).floor(),
             )
         };
         let size = point(
             (dimensions.cell_width * self.num_of_cells as f32).ceil(),
-            dimensions.line_height,
+            (dimensions.line_height).ceil(),
         )
         .into();
 


### PR DESCRIPTION
Closes #46148

This PR enforces pixel snapping for terminal background rendering:
- Origin Y: Applies `.floor()` to align the starting position to the pixel grid.
- Height: Applies `.ceil()` to ensure the block covers the full line height.

Before:
<img width="524" height="37" alt="before" src="https://github.com/user-attachments/assets/5941828d-6e38-4be2-9aa6-8d9c6389f621" />

After:
<img width="524" height="37" alt="now" src="https://github.com/user-attachments/assets/39427436-0df2-43ac-91a7-ce0117f933da" />


Release Notes:

- Fixed rendering artifacts (hairline gaps) in terminal block glyphs.
