### PR TITLE
git: Respect upstream branch name when pushing

### DIFF
--- a/crates/fs/src/fake_git_repo.rs
+++ b/crates/fs/src/fake_git_repo.rs
@@ -597,6 +597,7 @@ impl GitRepository for FakeGitRepository {
     fn push(
         &self,
         _branch: String,
+        _remote_branch: String,
         _remote: String,
         _options: Option<PushOptions>,
         _askpass: AskPassDelegate,

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -573,6 +573,7 @@ pub trait GitRepository: Send + Sync {
     fn push(
         &self,
         branch_name: String,
+        remote_branch_name: String,
         upstream_name: String,
         options: Option<PushOptions>,
         askpass: AskPassDelegate,
@@ -1886,6 +1887,7 @@ impl GitRepository for RealGitRepository {
     fn push(
         &self,
         branch_name: String,
+        remote_branch_name: String,
         remote_name: String,
         options: Option<PushOptions>,
         ask_pass: AskPassDelegate,
@@ -1910,7 +1912,7 @@ impl GitRepository for RealGitRepository {
                     PushOptions::Force => "--force-with-lease",
                 }))
                 .arg(remote_name)
-                .arg(format!("{}:{}", branch_name, branch_name))
+                .arg(format!("{}:{}", branch_name, remote_branch_name))
                 .stdin(smol::process::Stdio::null())
                 .stdout(smol::process::Stdio::piped())
                 .stderr(smol::process::Stdio::piped());

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -3053,6 +3053,14 @@ impl GitPanel {
             let push = repo.update(cx, |repo, cx| {
                 repo.push(
                     branch.name().to_owned().into(),
+                    branch
+                        .upstream
+                        .as_ref()
+                        .filter(|u| matches!(u.tracking, UpstreamTracking::Tracked(_)))
+                        .and_then(|u| u.branch_name())
+                        .unwrap_or_else(|| branch.name())
+                        .to_owned()
+                        .into(),
                     remote.name.clone(),
                     options,
                     askpass_delegate,

--- a/crates/proto/proto/git.proto
+++ b/crates/proto/proto/git.proto
@@ -411,9 +411,9 @@ message Push {
     uint64 repository_id = 3;
     string remote_name = 4;
     string branch_name = 5;
-    string remote_branch_name = 6;
-    optional PushOptions options = 7;
-    uint64 askpass_id = 8;
+    optional PushOptions options = 6;
+    uint64 askpass_id = 7;
+    string remote_branch_name = 8;
 
     enum PushOptions {
         SET_UPSTREAM = 0;

--- a/crates/proto/proto/git.proto
+++ b/crates/proto/proto/git.proto
@@ -411,8 +411,9 @@ message Push {
     uint64 repository_id = 3;
     string remote_name = 4;
     string branch_name = 5;
-    optional PushOptions options = 6;
-    uint64 askpass_id = 7;
+    string remote_branch_name = 6;
+    optional PushOptions options = 7;
+    uint64 askpass_id = 8;
 
     enum PushOptions {
         SET_UPSTREAM = 0;


### PR DESCRIPTION
Closes #46119

Before:

https://github.com/user-attachments/assets/27b0123a-e964-463d-a0da-02b9a4630d9b

After:

https://github.com/user-attachments/assets/40574ecb-33f7-4f7d-9954-adb08e3868eb


Release Notes:

- Fixed git push to respect the upstream branch name instead of defaulting to the local branch name.
