### PR TITLE
Changes to make `ep split-commits` work

### DIFF
--- a/crates/edit_prediction_cli/src/main.rs
+++ b/crates/edit_prediction_cli/src/main.rs
@@ -242,7 +242,9 @@ fn main() {
             return;
         }
         Command::SplitCommit(split_commit_args) => {
-            if let Err(error) = split_commit::run_split_commit(split_commit_args) {
+            if let Err(error) =
+                split_commit::run_split_commit(split_commit_args, &args.inputs, output.as_ref())
+            {
                 eprintln!("{error:#}");
                 std::process::exit(1);
             }

--- a/crates/edit_prediction_cli/src/split_commit.rs
+++ b/crates/edit_prediction_cli/src/split_commit.rs
@@ -906,6 +906,18 @@ pub fn get_cursor_excerpt(
                         _ => {}
                     }
                 }
+                // If hunk only has deletions (file deletion), include deletion lines
+                if excerpt_lines.is_empty() {
+                    excerpt_first_line = hunk.old_start as usize;
+                    for line in &hunk.lines {
+                        match line {
+                            PatchLine::Deletion(s) => {
+                                excerpt_lines.push(s.clone());
+                            }
+                            _ => {}
+                        }
+                    }
+                }
             }
         }
     }
@@ -958,6 +970,18 @@ pub fn get_cursor_excerpt(
                             excerpt_lines.push(s.clone());
                         }
                         _ => {}
+                    }
+                }
+                // If hunk only has deletions, include deletion lines
+                if excerpt_lines.is_empty() {
+                    excerpt_first_line = hunk.old_start as usize;
+                    for line in &hunk.lines {
+                        match line {
+                            PatchLine::Deletion(s) => {
+                                excerpt_lines.push(s.clone());
+                            }
+                            _ => {}
+                        }
                     }
                 }
                 if !excerpt_lines.is_empty() {

--- a/crates/edit_prediction_cli/src/split_commit.rs
+++ b/crates/edit_prediction_cli/src/split_commit.rs
@@ -340,7 +340,7 @@ pub fn generate_evaluation_example_from_ordered_commit(
         // cursor_position: cursor.to_string(),
         cursor_path: Path::new(&cursor.file).into(),
         cursor_position: cursor_excerpt,
-        expected_patches: vec![split_commit.target_patch.clone()],
+        expected_patches: vec![split_commit.target_patch],
         tags: vec![],
         reasoning: None,
         uncommitted_diff: String::new(),
@@ -1067,7 +1067,7 @@ pub fn get_cursor_excerpt(
 
 #[cfg(test)]
 mod tests {
-    use std::{path::Path, sync::Arc};
+    use std::path::Path;
 
     use edit_prediction::example_spec::ExampleSpec;
 
@@ -1226,7 +1226,7 @@ Date: Mon Jan 1 00:00:00 2024
 
         // Results should be identical
         assert_eq!(result1.edit_history, result2.edit_history);
-        assert_eq!(result1.expected_patch, result2.expected_patch);
+        assert_eq!(result1.expected_patches, result2.expected_patches);
         assert_eq!(result1.cursor_position, result2.cursor_position);
     }
 
@@ -1359,9 +1359,9 @@ Date: Mon Jan 1 00:00:00 2024
 
         // Cursor excerpt should contain the cursor marker
         assert!(
-            result.cursor_excerpt.contains("<|user_cursor|>"),
+            result.cursor_position.contains("<|user_cursor|>"),
             "Cursor excerpt should contain marker: {}",
-            result.cursor_excerpt
+            result.cursor_position
         );
     }
 


### PR DESCRIPTION
1. `apply_diff` will create a file if the diff says so (by starting with `--- /dev/null`)
2. Update examples format to match recent changes
3. `ep split-commits` can work with a stream of inputs and generate `n` samples per input
4. Unicode handling fixes

Release Notes:

- N/A
