### PR TITLE
Fix nightly bundle 

### DIFF
--- a/script/bundle-mac
+++ b/script/bundle-mac
@@ -100,7 +100,7 @@ sed \
     "s/package.metadata.bundle-${channel}/package.metadata.bundle/" \
     Cargo.toml
 
-app_path=$(cargo bundle ${build_flag} --target $target_triple --select-workspace-root | xargs)
+app_path=$(cargo bundle ${build_flag} --target $target_triple --select-workspace-root --bin zed | xargs)
 
 mv Cargo.toml.backup Cargo.toml
 popd


### PR DESCRIPTION
The visual_test_runner binary (added in #45259) has `required-features = ["visual-tests"]`, so it doesn't get built in release builds. However, `cargo bundle` was trying to bundle all binaries defined in the zed crate's Cargo.toml, causing it to fail when visual_test_runner doesn't exist.

Adding `--bin zed` tells cargo bundle to only bundle the main zed binary.

**Note:** The `cli` binary is unaffected by this change - it's a separate package (`crates/cli`) that's built separately via `cargo build --package cli` and manually copied into the app bundle afterward (line 337). It was never part of `cargo bundle`'s scope.

Fixes the nightly build failure: https://github.com/zed-industries/zed/actions/runs/20740971838

Release Notes:

- N/A