### PR TITLE
ui_input: Only render number field border on focus

### DIFF
--- a/crates/ui_input/src/number_field.rs
+++ b/crates/ui_input/src/number_field.rs
@@ -687,11 +687,11 @@ impl<T: NumberFieldType> RenderOnce for NumberField<T> {
 
                                     h_flex()
                                         .flex_1()
+                                        .h_full()
                                         .track_focus(&focus_handle)
-                                        .border_1()
-                                        .border_color(cx.theme().colors().border_transparent)
                                         .when(is_focused, |this| {
-                                            this.border_color(cx.theme().colors().border_focused)
+                                            this.border_1()
+                                                .border_color(cx.theme().colors().border_focused)
                                         })
                                         .child(editor)
                                         .on_action::<menu::Confirm>({


### PR DESCRIPTION
The `NumberField.render` method was always rendering a `border_1` for the number input, even when not focused. Even though it was using `cx.theme().colors().border_transparent`, some themes don't have this value set to a fully transparent color so it ends up looking a little bit weird.

As such, this commit updates the way the border is rendered, to ensure it's actually only rendered, i.e., the `border_1` method is only called, when the field is actually focused.

Release Notes:

- Improved rendering of border on number field's input to ensure it's only rendered when the field is focused
