### PR TITLE
Fix bundle name when using --bin zed

### DIFF
--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -239,6 +239,9 @@ osx_minimum_system_version = "10.15.7"
 osx_info_plist_exts = ["resources/info/*"]
 osx_url_schemes = ["zed"]
 
+[package.metadata.bundle-dev.bin.zed]
+name = "Zed Dev"
+
 [package.metadata.bundle-nightly]
 icon = ["resources/app-icon-nightly@2x.png", "resources/app-icon-nightly.png"]
 identifier = "dev.zed.Zed-Nightly"
@@ -246,6 +249,9 @@ name = "Zed Nightly"
 osx_minimum_system_version = "10.15.7"
 osx_info_plist_exts = ["resources/info/*"]
 osx_url_schemes = ["zed"]
+
+[package.metadata.bundle-nightly.bin.zed]
+name = "Zed Nightly"
 
 [package.metadata.bundle-preview]
 icon = ["resources/app-icon-preview@2x.png", "resources/app-icon-preview.png"]
@@ -255,6 +261,9 @@ osx_minimum_system_version = "10.15.7"
 osx_info_plist_exts = ["resources/info/*"]
 osx_url_schemes = ["zed"]
 
+[package.metadata.bundle-preview.bin.zed]
+name = "Zed Preview"
+
 [package.metadata.bundle-stable]
 icon = ["resources/app-icon@2x.png", "resources/app-icon.png"]
 identifier = "dev.zed.Zed"
@@ -262,6 +271,9 @@ name = "Zed"
 osx_minimum_system_version = "10.15.7"
 osx_info_plist_exts = ["resources/info/*"]
 osx_url_schemes = ["zed"]
+
+[package.metadata.bundle-stable.bin.zed]
+name = "Zed"
 
 [package.metadata.cargo-machete]
 ignored = ["profiling", "zstd", "tracing"]


### PR DESCRIPTION
When using `--bin zed` (added in #46163 to fix the nightly build), cargo-bundle looks for per-binary bundle settings in `[package.metadata.bundle.bin.zed]`. Without this, it falls back to using the binary name ('zed') instead of the proper bundle name ('Zed Nightly', 'Zed', etc.).

This was causing auto-updates to fail because the mounted DMG contained 'zed.app' instead of 'Zed Nightly.app', so rsync couldn't find the app at the expected path.

**Root cause:** `cargo metadata` returns binaries in alphabetical order, so `visual_test_runner` comes before `zed`. Without `--bin zed`, cargo-bundle was trying to bundle `visual_test_runner` (which doesn't exist in release builds). With `--bin zed`, it bundles the right binary but was using the wrong name.

**Fix:** Add `[package.metadata.bundle-*.bin.zed]` sections that specify the correct bundle name for each release channel.