### PR TITLE
Rename visual_test_runner to zed_visual_test_runner

### DIFF
--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -43,7 +43,7 @@ name = "zed"
 path = "src/main.rs"
 
 [[bin]]
-name = "visual_test_runner"
+name = "zed_visual_test_runner"
 path = "src/visual_test_runner.rs"
 required-features = ["visual-tests"]
 

--- a/crates/zed/src/visual_test_runner.rs
+++ b/crates/zed/src/visual_test_runner.rs
@@ -14,10 +14,10 @@
 //! ## Usage
 //!
 //! Run the visual tests:
-//!   cargo run -p zed --bin visual_test_runner --features visual-tests
+//!   cargo run -p zed --bin zed_visual_test_runner --features visual-tests
 //!
 //! Update baseline images (when UI intentionally changes):
-//!   UPDATE_BASELINE=1 cargo run -p zed --bin visual_test_runner --features visual-tests
+//!   UPDATE_BASELINE=1 cargo run -p zed --bin zed_visual_test_runner --features visual-tests
 //!
 //! ## Environment Variables
 //!

--- a/docs/src/development/macos.md
+++ b/docs/src/development/macos.md
@@ -69,7 +69,7 @@ You must grant Screen Recording permission to your terminal:
 ### Running Visual Tests
 
 ```sh
-cargo run -p zed --bin visual_test_runner --features visual-tests
+cargo run -p zed --bin zed_visual_test_runner --features visual-tests
 ```
 
 ### Updating Baselines
@@ -77,7 +77,7 @@ cargo run -p zed --bin visual_test_runner --features visual-tests
 When UI changes are intentional, update the baseline images:
 
 ```sh
-UPDATE_BASELINE=1 cargo run -p zed --bin visual_test_runner --features visual-tests
+UPDATE_BASELINE=1 cargo run -p zed --bin zed_visual_test_runner --features visual-tests
 ```
 
 Baseline images are stored in `crates/zed/test_fixtures/visual_tests/` and should be committed to the repository.

--- a/script/bundle-mac
+++ b/script/bundle-mac
@@ -100,7 +100,7 @@ sed \
     "s/package.metadata.bundle-${channel}/package.metadata.bundle/" \
     Cargo.toml
 
-app_path=$(cargo bundle ${build_flag} --target $target_triple --select-workspace-root --bin zed | xargs)
+app_path=$(cargo bundle ${build_flag} --target $target_triple --select-workspace-root | xargs)
 
 mv Cargo.toml.backup Cargo.toml
 popd


### PR DESCRIPTION
This fixes the auto-update failure by ensuring cargo-bundle picks 'zed' as the first binary.

**Problem:** `cargo metadata` returns binaries alphabetically, so `visual_test_runner` was coming before `zed`. When cargo-bundle looks for the first binary to bundle (without `--bin`), it was picking `visual_test_runner` - which doesn't exist in release builds because it requires the `visual-tests` feature.

The previous fix (#46163) added `--bin zed` to explicitly select the binary, but this caused cargo-bundle to use the binary name ('zed') instead of the bundle metadata name ('Zed Nightly'), breaking auto-updates.

**Fix:** Rename the binary to `zed_visual_test_runner` so it comes after `zed` alphabetically. This restores the original bundle script behavior that has worked for years.

Also reverts the `--bin zed` workaround from #46163.

Release Notes:

- N/A