### PR TITLE
agent: Save conversations before switching repos or worktrees

### DIFF
--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -570,10 +570,18 @@ impl NativeAgent {
         &mut self,
         _project: Entity<Project>,
         event: &project::Event,
-        _cx: &mut Context<Self>,
+        cx: &mut Context<Self>,
     ) {
         match event {
             project::Event::WorktreeAdded(_) | project::Event::WorktreeRemoved(_) => {
+                let threads: Vec<_> = self
+                    .sessions
+                    .values()
+                    .map(|session| session.thread.clone())
+                    .collect();
+                for thread in threads {
+                    self.save_thread(thread, cx);
+                }
                 self.project_context_needs_refresh.send(()).ok();
             }
             project::Event::WorktreeUpdatedEntries(_, items) => {


### PR DESCRIPTION
- Closes #46078 where conversations were lost when switching between repositories or worktrees. Now all threads should be saved to database before the worktree is removed or added.

 Release Notes:

  - Fixed conversations not saving when switching repos

