### PR TITLE
collab: Update test database schema

### DIFF
--- a/crates/collab/migrations/20251208000000_test_schema.sql
+++ b/crates/collab/migrations/20251208000000_test_schema.sql
@@ -335,7 +335,9 @@ CREATE TABLE public.project_repositories (
     current_merge_conflicts character varying,
     branch_summary character varying,
     head_commit_details character varying,
-    merge_message character varying
+    merge_message character varying,
+    remote_upstream_url character varying,
+    remote_origin_url character varying
 );
 
 CREATE TABLE public.project_repository_statuses (


### PR DESCRIPTION
This PR updates the test database schema for the Collab tests.

These recently-added columns got missed in the last schema dump.

Release Notes:

- N/A
