### PR TITLE
data_table: #1 Add variable row height mode to table UI element

### DIFF
--- a/crates/gpui/src/styled.rs
+++ b/crates/gpui/src/styled.rs
@@ -271,6 +271,13 @@ pub trait Styled: Sized {
         self
     }
 
+    /// Sets the element to stretch flex items to fill the available space along the container's cross axis.
+    /// [Docs](https://tailwindcss.com/docs/align-items#stretch)
+    fn items_stretch(mut self) -> Self {
+        self.style().align_items = Some(AlignItems::Stretch);
+        self
+    }
+
     /// Sets the element to justify flex items against the start of the container's main axis.
     /// [Docs](https://tailwindcss.com/docs/justify-content#start)
     fn justify_start(mut self) -> Self {

--- a/crates/ui/src/components/data_table.rs
+++ b/crates/ui/src/components/data_table.rs
@@ -535,8 +535,15 @@ impl<const COLS: usize> Table<COLS> {
         self
     }
 
-    /// Enables variable row height list rendering for tables with rows of different heights.
-    /// This is theoretically slower than uniform_list but supports multiline content properly, which allows for non-uniform tables suitable for displaying CSV data.
+    /// Enables rendering of tables with variable row heights, allowing each row to have its own height.
+    ///
+    /// This mode is useful for displaying content such as CSV data or multiline cells, where rows may not have uniform heights.
+    /// It is generally slower than [`Table::uniform_list`] due to the need to measure each row individually, but it provides correct layout for non-uniform or multiline content.
+    ///
+    /// # Parameters
+    /// - `row_count`: The total number of rows in the table.
+    /// - `list_state`: The [`ListState`] used for managing scroll position and virtualization. This must be initialized and managed by the caller, and should be kept in sync with the number of rows.
+    /// - `render_row_fn`: A closure that renders a single row, given the row index, a mutable reference to [`Window`], and a mutable reference to [`App`]. It should return an array of [`AnyElement`]s, one for each column.
     pub fn variable_row_height_list(
         mut self,
         row_count: usize,

--- a/crates/ui/src/components/data_table.rs
+++ b/crates/ui/src/components/data_table.rs
@@ -67,16 +67,14 @@ pub struct TableInteractionState {
     pub focus_handle: FocusHandle,
     pub scroll_handle: UniformListScrollHandle,
     pub custom_scrollbar: Option<Scrollbars>,
-    pub list_state: ListState,
 }
 
 impl TableInteractionState {
-    pub fn new(cx: &mut App, list_state: ListState) -> Self {
+    pub fn new(cx: &mut App) -> Self {
         Self {
             focus_handle: cx.focus_handle(),
             scroll_handle: UniformListScrollHandle::new(),
             custom_scrollbar: None,
-            list_state,
         }
     }
 

--- a/crates/ui/src/components/data_table.rs
+++ b/crates/ui/src/components/data_table.rs
@@ -29,7 +29,7 @@ struct UniformListData<const COLS: usize> {
 }
 
 struct VariableRowHeightListData<const COLS: usize> {
-    /// Unlike UniformList, this closure renders only single row, allowing each one to have it's own height
+    /// Unlike UniformList, this closure renders only single row, allowing each one to have its own height
     render_row_fn: Box<dyn Fn(usize, &mut Window, &mut App) -> [AnyElement; COLS]>,
     list_state: ListState,
     row_count: usize,
@@ -681,10 +681,11 @@ pub fn render_table_row<const COLS: usize>(
         .column_widths
         .map_or([None; COLS], |widths| widths.map(Some));
 
-    let mut row = h_flex()
+    let mut row = div()
         // NOTE: `h_flex()` sneakily applies `items_center()` which is not default behavior for div element.
-        // Rolling back to items_stretch to allow for layout flexibility.
-        .items_stretch()
+        // Applying `.flex().flex_row()` manually to overcome that
+        .flex()
+        .flex_row()
         .id(("table_row", row_index))
         .size_full()
         .when_some(bg, |row, bg| row.bg(bg))


### PR DESCRIPTION
## Add variable row height mode to data table infrastructure

This PR introduces support for variable row heights in the data table component, laying the groundwork for more flexible tabular data rendering in Zed.

**Context:**  
This is the first in a series of infrastructure-focused PRs split out from the [original CSV preview draft PR](https://github.com/zed-industries/zed/pull/44344). The draft PR remains open as a reference and will be incrementally decomposed into smaller, reviewable pieces like this one.

**Details:**  
- Adds a variable row height mode to the data table, enabling future features that require rows of differing heights (such as CSV preview and, eventually, database table views).
- No user-facing changes; this is an internal refactor to support upcoming functionality.

**Thanks:**  
Big thanks to @Anthony-Eid for pairing sessions and guidance on how to best structure and land these changes incrementally.

---

Release Notes:

- N/A (internal infrastructure change, no user impact)
