### PR TITLE
Fix some issues with edit prediction CLI

### DIFF
--- a/crates/edit_prediction_cli/src/main.rs
+++ b/crates/edit_prediction_cli/src/main.rs
@@ -462,7 +462,7 @@ fn main() {
                                         Re-run this example with:
                                             cargo run -p edit_prediction_cli -- {} \x1b[36m{}\x1b[0m
                                     "},
-                                    example_name,
+                                    example.spec.name,
                                     e,
                                     err_path.display(),
                                     failed_example_path.display(),

--- a/crates/edit_prediction_cli/src/score.rs
+++ b/crates/edit_prediction_cli/src/score.rs
@@ -34,14 +34,14 @@ pub async fn run_scoring(
         .expected_patches
         .iter()
         .map(|patch| {
-            apply_diff_to_string(original_text, patch)
+            apply_diff_to_string(patch, original_text)
                 .with_context(|| format!("Expected patch did not apply for {}", example.spec.name))
         })
         .collect::<Result<Vec<_>, _>>()?;
 
     let mut scores = vec![];
     for prediction in &example.predictions {
-        let actual_text = match apply_diff_to_string(original_text, &prediction.actual_patch) {
+        let actual_text = match apply_diff_to_string(&prediction.actual_patch, original_text) {
             Ok(text) => text,
             Err(_) => {
                 scores.push(ExampleScore { delta_chr_f: 0.0 });

--- a/crates/edit_prediction_cli/src/synthesize.rs
+++ b/crates/edit_prediction_cli/src/synthesize.rs
@@ -687,7 +687,7 @@ async fn build_example(
 
     // Validate expected patch applies to intermediate state
     let expected_patch_with_header = ensure_diff_header(expected_patch, &cursor_file);
-    apply_diff_to_string(&intermediate_state, &expected_patch_with_header)
+    apply_diff_to_string(&expected_patch_with_header, &intermediate_state)
         .map_err(|e| format!("Expected patch failed to apply: {}", e))?;
 
     // Find where the expected patch edits would apply in the intermediate state
@@ -764,7 +764,7 @@ fn apply_edit_history_to_content(
         return Ok(content.to_string());
     }
 
-    apply_diff_to_string(content, &file_diff)
+    apply_diff_to_string(&file_diff, content)
         .map_err(|e| format!("Failed to apply edit history: {}", e))
 }
 


### PR DESCRIPTION
* Added `--repo` and `--name` flags for running only examples with a specific name, or repo (substring matching)
* Fixed a race condition that caused hangs when running multiple examples at the same repo and sha
* Fixed a bug where scoring was completely wrong because I had passed the arguments to `apply_diff_to_string` in the wrong order
* The current evals now run quickly and without errors.

Release Notes:

- N/A
