### PR TITLE
extension_ci: Be more explicit with version bump

### DIFF
--- a/.github/workflows/extension_bump.yml
+++ b/.github/workflows/extension_bump.yml
@@ -91,7 +91,11 @@ jobs:
             BUMP_FILES+=("Cargo.toml")
         fi
 
-        bump2version --verbose --current-version "$OLD_VERSION" --no-configured-files ${{ inputs.bump-type }} "${BUMP_FILES[@]}"
+        bump2version \
+            --search "version = \"{current_version}"\" \
+            --replace "version = \"{new_version}"\" \
+            --current-version "$OLD_VERSION" \
+            --no-configured-files ${{ inputs.bump-type }} "${BUMP_FILES[@]}"
 
         if [[ -f "Cargo.toml" ]]; then
             cargo update --workspace

--- a/tooling/xtask/src/tasks/workflows/extension_bump.rs
+++ b/tooling/xtask/src/tasks/workflows/extension_bump.rs
@@ -261,7 +261,11 @@ fn bump_version(current_version: &JobOutput, bump_type: &WorkflowInput) -> (Step
                 BUMP_FILES+=("Cargo.toml")
             fi
 
-            bump2version --verbose --current-version "$OLD_VERSION" --no-configured-files {} "${{BUMP_FILES[@]}}"
+            bump2version \
+                --search "version = \"{{current_version}}"\" \
+                --replace "version = \"{{new_version}}"\" \
+                --current-version "$OLD_VERSION" \
+                --no-configured-files {} "${{BUMP_FILES[@]}}"
 
             if [[ -f "Cargo.toml" ]]; then
                 cargo update --workspace


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/46175

I had very much hoped for bump2version to do this by default, well, left here disappointed I suppose

Release Notes:

- N/A