### PR TITLE
windows: Improve error message for credential write failures

### DIFF
--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -635,7 +635,14 @@ impl Platform for WindowsPlatform {
                 UserName: PWSTR::from_raw(username.as_mut_ptr()),
                 ..CREDENTIALW::default()
             };
-            unsafe { CredWriteW(&credentials, 0) }?;
+            unsafe {
+                CredWriteW(&credentials, 0).map_err(|err| {
+                    anyhow!(
+                        "Failed to write credentials to Windows Credential Manager: {}",
+                        err,
+                    )
+                })?;
+            }
             Ok(())
         })
     }


### PR DESCRIPTION
Release Notes:

- Improved Display the actual Windows error message when writing credentials to Credential Manager fails, instead of the generic "Failed to write API key to keychain" message. This helps users diagnose issues like permission problems.
