### PR TITLE
terminal: Fix last character of IME marked text not being deleted

### DIFF
--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -1482,12 +1482,12 @@ impl InputHandler for TerminalInputHandler {
         &mut self,
         _range_utf16: Option<std::ops::Range<usize>>,
         new_text: &str,
-        new_marked_range: Option<std::ops::Range<usize>>,
+        _new_marked_range: Option<std::ops::Range<usize>>,
         _window: &mut Window,
         cx: &mut App,
     ) {
         self.terminal_view.update(cx, |view, view_cx| {
-            view.set_marked_text(new_text.to_string(), new_marked_range, view_cx);
+            view.set_marked_text(new_text.to_string(), view_cx);
         });
     }
 

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -331,7 +331,9 @@ impl TerminalView {
 
     /// Gets the current marked range (UTF-16).
     pub(crate) fn marked_text_range(&self) -> Option<Range<usize>> {
-        self.ime_state.as_ref().map(|_| 0..1)
+        self.ime_state
+            .as_ref()
+            .map(|state| 0..state.marked_text.encode_utf16().count())
     }
 
     /// Clears the marked (pre-edit) text state.

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -62,7 +62,6 @@ use std::{
 
 struct ImeState {
     marked_text: String,
-    marked_range_utf16: Option<Range<usize>>,
 }
 
 const CURSOR_BLINK_INTERVAL: Duration = Duration::from_millis(500);
@@ -322,24 +321,17 @@ impl TerminalView {
     }
 
     /// Sets the marked (pre-edit) text from the IME.
-    pub(crate) fn set_marked_text(
-        &mut self,
-        text: String,
-        range: Option<Range<usize>>,
-        cx: &mut Context<Self>,
-    ) {
-        self.ime_state = Some(ImeState {
-            marked_text: text,
-            marked_range_utf16: range,
-        });
+    pub(crate) fn set_marked_text(&mut self, text: String, cx: &mut Context<Self>) {
+        if text.is_empty() {
+            return self.clear_marked_text(cx);
+        }
+        self.ime_state = Some(ImeState { marked_text: text });
         cx.notify();
     }
 
     /// Gets the current marked range (UTF-16).
     pub(crate) fn marked_text_range(&self) -> Option<Range<usize>> {
-        self.ime_state
-            .as_ref()
-            .and_then(|state| state.marked_range_utf16.clone())
+        self.ime_state.as_ref().map(|_| 0..1)
     }
 
     /// Clears the marked (pre-edit) text state.


### PR DESCRIPTION
Closes #46084

I'm not very familiar with this part of the code, so I'm not sure if this is the right way to fix it.

During debugging, I discovered that `marked_range_utf16` consistently stores an empty range representing the cursor position (e.g., `0..0`, `1..1`) instead of an actual marked range. This bug is caused by the range being empty.

In my testing, the IME starts working correctly as long as I change it to any non-empty range (e.g., `0..1`). Although I suspect the correct value should probably be `0..marked_text.encode_utf16().count()`.

Before/After:

https://github.com/user-attachments/assets/9ade119e-2f4f-4334-b33b-6ce8a97fa47c



Release Notes:

- Fixed an issue where backspace fails to remove the last character of IME marked text in the terminal.
