### PR TITLE
terminal: Avoid overlapping IME marked text with terminal content

### DIFF
--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -1363,6 +1363,14 @@ impl Element for TerminalElement {
                                     }],
                                     None
                                 );
+
+                                // Paint background to cover terminal text behind marked text
+                                let ime_background_bounds = Bounds::new(
+                                    ime_position,
+                                    size(shaped_line.width, layout.dimensions.line_height),
+                                );
+                                window.paint_quad(fill(ime_background_bounds, layout.background_color));
+
                                 shaped_line.paint(
                                     ime_position,
                                     layout.dimensions.line_height,


### PR DESCRIPTION
Closes #33157

|Before|After|
|--|--|
|<img width="922" height="158" alt="CleanShot 2026-01-07 at 12 18 21@2x" src="https://github.com/user-attachments/assets/2ba6020f-5159-4ed8-aa2e-374ea3ea4cf5" />|<img width="908" height="200" alt="CleanShot 2026-01-07 at 12 19 02@2x" src="https://github.com/user-attachments/assets/ec946c4e-3220-4944-b34a-1d8d5dcc7ae2" />|

Many other terminals seem to do it this way as well.

|Ghostty|Windows Terminal| Visual Studio Code|
|--|--|--|
|<img width="930" height="186" alt="CleanShot 2026-01-07 at 12 23 30@2x" src="https://github.com/user-attachments/assets/837189aa-2f4c-4a48-b060-f3576b8777e0" />|<img width="1414" height="128" alt="c89e03d2d92869d5ec1b8a05ade84df0" src="https://github.com/user-attachments/assets/8b6d69fb-b34d-4ccd-8a3a-9332487cd427" />|<img width="978" height="180" alt="CleanShot 2026-01-07 at 12 27 01@2x" src="https://github.com/user-attachments/assets/dbc0acc7-3c16-499f-ac32-35e3c0cd0d97" />|

Release Notes:

- Fixed UI overlap between IME marked text and terminal content.
