### PR TITLE
Add GH workflow to surface comments on closed bugs

### DIFF
--- a/.github/workflows/add_commented_closed_issue_to_project.yml
+++ b/.github/workflows/add_commented_closed_issue_to_project.yml
@@ -45,6 +45,5 @@ jobs:
       - if: steps.check-staff.outputs.result == 'false'
         uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:
-          # TODO: Change back to project 71 after testing
-          project-url: https://github.com/orgs/zed-industries/projects/73
+          project-url: https://github.com/orgs/zed-industries/projects/71
           github-token: ${{ steps.get-app-token.outputs.token }}

--- a/.github/workflows/add_commented_closed_issue_to_project.yml
+++ b/.github/workflows/add_commented_closed_issue_to_project.yml
@@ -1,0 +1,50 @@
+name: "Surface closed issues someone's commented on"
+
+on:
+  issue_comment:
+    types:
+      - created
+
+jobs:
+  add-to-project:
+    if: >
+      github.repository == 'zed-industries/zed' &&
+      github.event.issue.state == 'closed' &&
+      github.event.issue.type.name == 'Bug' &&
+      github.event.comment.user.type != 'Bot'
+    runs-on: ubuntu-latest
+    steps:
+      - id: get-app-token
+        uses: actions/create-github-app-token@df432ccc7b4c53164ccb55b2c30ff6705e2ffc81 # v1.11.7
+        with:
+          app-id: ${{ secrets.ZED_COMMUNITY_BOT_APP_ID }}
+          private-key: ${{ secrets.ZED_COMMUNITY_BOT_PRIVATE_KEY }}
+          owner: zed-industries
+
+      - id: check-staff
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ steps.get-app-token.outputs.token }}
+          script: |
+            try {
+              const response = await github.rest.teams.getMembershipForUserInOrg({
+                org: 'zed-industries',
+                team_slug: 'staff',
+                username: context.payload.comment.user.login
+              });
+              return response.data.state === 'active';
+            } catch (error) {
+              // 404 means user is not a member
+              if (error.status === 404) {
+                return false;
+              }
+              throw error;
+            }
+
+      # Add to the support team's board for triage
+      - if: steps.check-staff.outputs.result == 'false'
+        uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
+        with:
+          # TODO: Change back to project 71 after testing
+          project-url: https://github.com/orgs/zed-industries/projects/73
+          github-token: ${{ steps.get-app-token.outputs.token }}


### PR DESCRIPTION
Sometimes bugs come back or are not fixed all the way. We want to preserve the context of the issue we've closed prematurely so instead of always making people open a new github issue in this case we want to be able to notice if someone* comments on a closed bug and decide what to do about it.

Before:

Bug is closed → A user can again/still reproduce it on a new version and leaves a comment → Maybe someone sees the notification about it, maybe not; maybe they see it but forget to act on it right away and it's lost.

After:

Bug is closed → A user can again/still reproduce it on a new version and leaves a comment → The issue is added to a project board where it's visible until someone makes a call about it (maybe the comment was “oh my glob i'm so happy this was fixed” and no action is needed, or maybe the issue must be reopened as a regression).

*Someone in this case means (1) not a bot, (2) not a member of staff.

Release Notes:

- N/A