### PR TITLE
Fix the action version in Closed Bugs GH workflow

### DIFF
--- a/.github/workflows/add_commented_closed_issue_to_project.yml
+++ b/.github/workflows/add_commented_closed_issue_to_project.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: get-app-token
-        uses: actions/create-github-app-token@df432ccc7b4c53164ccb55b2c30ff6705e2ffc81 # v1.11.7
+        uses: actions/create-github-app-token@bef1eaf1c0ac2b148ee2a0a74c65fbe6db0631f1 # v2.1.4
         with:
           app-id: ${{ secrets.ZED_COMMUNITY_BOT_APP_ID }}
           private-key: ${{ secrets.ZED_COMMUNITY_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
fix-up for https://github.com/zed-industries/zed/pull/46249 because testing github workflows is fun and opus 4.5 thinks it's amusing.

Release Notes:

- N/A
