### PR TITLE
ep cli: Handle opening buffers from files created by the edit history

### DIFF
--- a/crates/edit_prediction_cli/src/load_project.rs
+++ b/crates/edit_prediction_cli/src/load_project.rs
@@ -27,9 +27,10 @@ pub async fn run_load_project(
 
     let project = setup_project(example, &app_state, &progress, &mut cx).await?;
 
-    let _open_buffers = apply_edit_history(example, &project, &mut cx).await?;
+    let open_buffers = apply_edit_history(example, &project, &mut cx).await?;
 
-    let (buffer, cursor_position) = cursor_position(example, &project, &mut cx).await?;
+    let (buffer, cursor_position) =
+        cursor_position(example, &project, &open_buffers, &mut cx).await?;
     let (example_buffer, language_name) = buffer.read_with(&cx, |buffer, _cx| {
         let cursor_point = cursor_position.to_point(&buffer);
         let language_name = buffer
@@ -54,7 +55,7 @@ pub async fn run_load_project(
         buffer,
         project,
         cursor_position,
-        _open_buffers,
+        _open_buffers: open_buffers,
     });
     Ok(())
 }
@@ -62,6 +63,7 @@ pub async fn run_load_project(
 async fn cursor_position(
     example: &Example,
     project: &Entity<Project>,
+    open_buffers: &OpenedBuffers,
     cx: &mut AsyncApp,
 ) -> Result<(Entity<Buffer>, Anchor)> {
     let language_registry = project.read_with(cx, |project, _| project.languages().clone())?;
@@ -75,25 +77,31 @@ async fn cursor_position(
         return Err(error);
     }
 
-    // Since the worktree scanner is disabled, manually refresh entries for the cursor path.
-    if let Some(worktree) = project.read_with(cx, |project, cx| project.worktrees(cx).next())? {
-        refresh_worktree_entries(&worktree, [&*example.spec.cursor_path], cx).await?;
-    }
+    let cursor_path_str = example.spec.cursor_path.to_string_lossy();
+    // We try open_buffers first because the file might be new and not saved to disk
+    let cursor_buffer = if let Some(buffer) = open_buffers.get(&cursor_path_str) {
+        buffer.clone()
+    } else {
+        // Since the worktree scanner is disabled, manually refresh entries for the cursor path.
+        if let Some(worktree) = project.read_with(cx, |project, cx| project.worktrees(cx).next())? {
+            refresh_worktree_entries(&worktree, [&*example.spec.cursor_path], cx).await?;
+        }
 
-    let cursor_path = project
-        .read_with(cx, |project, cx| {
-            project.find_project_path(&example.spec.cursor_path, cx)
-        })?
-        .with_context(|| {
-            format!(
-                "failed to find cursor path {}",
-                example.spec.cursor_path.display()
-            )
-        })?;
+        let cursor_path = project
+            .read_with(cx, |project, cx| {
+                project.find_project_path(&example.spec.cursor_path, cx)
+            })?
+            .with_context(|| {
+                format!(
+                    "failed to find cursor path {}",
+                    example.spec.cursor_path.display()
+                )
+            })?;
 
-    let cursor_buffer = project
-        .update(cx, |project, cx| project.open_buffer(cursor_path, cx))?
-        .await?;
+        project
+            .update(cx, |project, cx| project.open_buffer(cursor_path, cx))?
+            .await?
+    };
 
     let (cursor_excerpt, cursor_offset_within_excerpt) = example.spec.cursor_excerpt()?;
 


### PR DESCRIPTION
Since we don't persist new files to disk, they don't have entries, so we have to look them up in memory first.

Release Notes:

- N/A 