### PR TITLE
ep cli: Clean leftover git locks

### DIFF
--- a/crates/edit_prediction_cli/src/load_project.rs
+++ b/crates/edit_prediction_cli/src/load_project.rs
@@ -196,6 +196,17 @@ async fn setup_worktree(example: &Example, step_progress: &StepProgress) -> Resu
     let worktree_path = repo_name.worktree_path();
     let repo_lock = git::lock_repo(&repo_dir).await;
 
+    // Clean up any stale git lock files from previous crashed runs.
+    // Safe-ish since we have our own lock.
+    // WARNING: Can corrupt worktrees if multiple processes of the CLI are running.
+    let worktree_git_dir = repo_dir
+        .join(".git/worktrees")
+        .join(repo_name.name.as_ref());
+    let index_lock = worktree_git_dir.join("index.lock");
+    if index_lock.exists() {
+        fs::remove_file(&index_lock).ok();
+    }
+
     if !repo_dir.is_dir() {
         step_progress.set_substatus(format!("cloning {}", repo_name.name));
         fs::create_dir_all(&repo_dir)?;


### PR DESCRIPTION
Sometimes git locks are left over from crashed runs. We now assume there's only one process of the CLI running and clean them up. This seems fine for our existing use case, but we should come up with an alternative if we want to run multiple CLI processes concurrently for the same repos.

Release Notes:

- N/A