### PR TITLE
Skip worktree trust queries for remote collab project clients

### DIFF
--- a/crates/collab/src/tests/channel_buffer_tests.rs
+++ b/crates/collab/src/tests/channel_buffer_tests.rs
@@ -153,9 +153,9 @@ async fn test_channel_notes_participant_indices(
         .fs()
         .insert_tree("/root", json!({"file.txt": "123"}))
         .await;
-    let (project_a, worktree_id_a) = client_a.build_local_project("/root", cx_a).await;
-    let project_b = client_b.build_empty_local_project(cx_b);
-    let project_c = client_c.build_empty_local_project(cx_c);
+    let (project_a, worktree_id_a) = client_a.build_local_project_with_trust("/root", cx_a).await;
+    let project_b = client_b.build_empty_local_project(false, cx_b);
+    let project_c = client_c.build_empty_local_project(false, cx_c);
 
     let (workspace_a, mut cx_a) = client_a.build_workspace(&project_a, cx_a);
     let (workspace_b, mut cx_b) = client_b.build_workspace(&project_b, cx_b);

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1283,32 +1283,11 @@ impl Workspace {
                     this.collaborator_left(*peer_id, window, cx);
                 }
 
-                project::Event::WorktreeUpdatedEntries(worktree_id, _) => {
-                    if let Some(trusted_worktrees) = TrustedWorktrees::try_get_global(cx) {
-                        trusted_worktrees.update(cx, |trusted_worktrees, cx| {
-                            trusted_worktrees.can_trust(
-                                &this.project().read(cx).worktree_store(),
-                                *worktree_id,
-                                cx,
-                            );
-                        });
-                    }
-                }
-
                 project::Event::WorktreeRemoved(_) => {
                     this.update_worktree_data(window, cx);
                 }
 
-                project::Event::WorktreeAdded(worktree_id) => {
-                    if let Some(trusted_worktrees) = TrustedWorktrees::try_get_global(cx) {
-                        trusted_worktrees.update(cx, |trusted_worktrees, cx| {
-                            trusted_worktrees.can_trust(
-                                &this.project().read(cx).worktree_store(),
-                                *worktree_id,
-                                cx,
-                            );
-                        });
-                    }
+                project::Event::WorktreeUpdatedEntries(..) | project::Event::WorktreeAdded(..) => {
                     this.update_worktree_data(window, cx);
                 }
 

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -354,7 +354,7 @@ struct UpdateObservationState {
     _maintain_remote_snapshot: Task<Option<()>>,
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub enum Event {
     UpdatedEntries(UpdatedEntriesSet),
     UpdatedGitRepositories(UpdatedGitRepositoriesSet),


### PR DESCRIPTION
Release Notes:

- Skip worktree trust queries for remote collab project clients
