### PR TITLE
ep: Fix incorrect example count in failure summary

### DIFF
--- a/crates/edit_prediction_cli/src/main.rs
+++ b/crates/edit_prediction_cli/src/main.rs
@@ -256,8 +256,7 @@ async fn load_examples(
 
     let mut examples = read_example_files(&file_inputs);
 
-    let total_steps = examples.len() + captured_after_timestamps.len();
-    Progress::global().set_total_steps(total_steps);
+    Progress::global().set_total_examples(examples.len());
 
     let remaining_limit_for_snowflake =
         args.limit.map(|limit| limit.saturating_sub(examples.len()));
@@ -295,7 +294,7 @@ async fn load_examples(
         }
     }
 
-    Progress::global().set_total_steps(examples.len() + captured_after_timestamps.len());
+    Progress::global().set_total_examples(examples.len());
 
     Ok(examples)
 }

--- a/crates/edit_prediction_cli/src/progress.rs
+++ b/crates/edit_prediction_cli/src/progress.rs
@@ -19,7 +19,7 @@ struct ProgressInner {
     terminal_width: usize,
     max_example_name_len: usize,
     status_lines_displayed: usize,
-    total_steps: usize,
+    total_examples: usize,
     failed_examples: usize,
     last_line_is_logging: bool,
     ticker: Option<std::thread::JoinHandle<()>>,
@@ -103,7 +103,7 @@ impl Progress {
                         terminal_width: get_terminal_width(),
                         max_example_name_len: 0,
                         status_lines_displayed: 0,
-                        total_steps: 0,
+                        total_examples: 0,
                         failed_examples: 0,
                         last_line_is_logging: false,
                         ticker: None,
@@ -116,9 +116,9 @@ impl Progress {
             .clone()
     }
 
-    pub fn set_total_steps(&self, total: usize) {
+    pub fn set_total_examples(&self, total: usize) {
         let mut inner = self.inner.lock().unwrap();
-        inner.total_steps = total;
+        inner.total_examples = total;
     }
 
     pub fn increment_failed(&self) {
@@ -316,7 +316,7 @@ impl Progress {
 
         let range_label = format!(
             " {}/{}/{} ",
-            done_count, in_progress_count, inner.total_steps
+            done_count, in_progress_count, inner.total_examples
         );
 
         // Print a divider line with failed count on left, range label on right
@@ -396,15 +396,15 @@ impl Progress {
 
         // Print summary if there were failures
         if inner.failed_examples > 0 {
-            let total_processed = inner.completed.len();
-            let percentage = if total_processed > 0 {
-                inner.failed_examples as f64 / total_processed as f64 * 100.0
+            let total_examples = inner.total_examples;
+            let percentage = if total_examples > 0 {
+                inner.failed_examples as f64 / total_examples as f64 * 100.0
             } else {
                 0.0
             };
             eprintln!(
                 "\n{} of {} examples failed ({:.1}%)",
-                inner.failed_examples, total_processed, percentage
+                inner.failed_examples, total_examples, percentage
             );
         }
     }

--- a/crates/edit_prediction_cli/src/synthesize.rs
+++ b/crates/edit_prediction_cli/src/synthesize.rs
@@ -108,7 +108,7 @@ pub async fn run_synthesize(config: SynthesizeConfig) -> Result<()> {
     std::os::windows::fs::symlink_dir(&*FAILED_EXAMPLES_DIR, &*LATEST_FAILED_EXAMPLES_DIR)?;
 
     let progress = Progress::global();
-    progress.set_total_steps(config.count);
+    progress.set_total_examples(config.count);
 
     let clone_progress = progress.start(Step::Synthesize, "clone");
     let repo_path = ensure_repo_cloned(&config.repo_url).await?;


### PR DESCRIPTION
The 'X of Y examples failed' message was counting completed steps/tasks instead of actual examples. For example, with 2 examples each going through Load and Context steps, it would report '1 of 3' instead of '1 of 2'.

Release Notes:

- N/A
