### PR TITLE
ep: Fix revision resolution for tilde expressions

### DIFF
--- a/crates/edit_prediction_cli/src/git.rs
+++ b/crates/edit_prediction_cli/src/git.rs
@@ -106,5 +106,9 @@ pub async fn fetch_if_needed(repo_path: &Path, revision: &str) -> Result<String>
         run_git(repo_path, &["fetch", "origin"]).await?;
     }
 
-    run_git(repo_path, &["rev-parse", "FETCH_HEAD"]).await
+    run_git(
+        repo_path,
+        &["rev-parse", &format!("{}^{{commit}}", revision)],
+    )
+    .await
 }


### PR DESCRIPTION
When a revision like `abcd~1` wasn't found locally, the function would fetch and then return `FETCH_HEAD`, which points to the tip of the fetched branch rather than the requested revision expression.

Now it re-resolves the original revision after fetching, correctly handling tilde expressions and other git revision syntax.

Release Notes:

- N/A
