### PR TITLE
gpui: Add layer to handle system permissions

### DIFF
--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -1,6 +1,7 @@
 mod app_menu;
 mod keyboard;
 mod keystroke;
+mod permissions;
 
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
 mod linux;
@@ -74,6 +75,7 @@ use uuid::Uuid;
 pub use app_menu::*;
 pub use keyboard::*;
 pub use keystroke::*;
+pub use permissions::*;
 
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
 pub(crate) use linux::*;
@@ -284,6 +286,8 @@ pub(crate) trait Platform: 'static {
     fn keyboard_layout(&self) -> Box<dyn PlatformKeyboardLayout>;
     fn keyboard_mapper(&self) -> Rc<dyn PlatformKeyboardMapper>;
     fn on_keyboard_layout_change(&self, callback: Box<dyn FnMut()>);
+
+    fn permissions_handler(&self) -> Rc<dyn PlatformPermissionsHandler>;
 }
 
 /// A handle to a platform's display, e.g. a monitor or laptop screen.

--- a/crates/gpui/src/platform/mac.rs
+++ b/crates/gpui/src/platform/mac.rs
@@ -6,6 +6,7 @@ mod display_link;
 mod events;
 mod keyboard;
 mod pasteboard;
+mod permissions;
 
 #[cfg(feature = "screen-capture")]
 mod screen_capture;

--- a/crates/gpui/src/platform/mac/permissions.rs
+++ b/crates/gpui/src/platform/mac/permissions.rs
@@ -4,14 +4,38 @@ pub struct MacPermissionsHandler;
 
 impl PlatformPermissionsHandler for MacPermissionsHandler {
     fn status(&self, kind: PermissionKind) -> PermissionStatus {
-        todo!()
+        match kind {
+            PermissionKind::ScreenCapture => Self::screen_capture_status(),
+        }
     }
 
     fn request(&self, kind: PermissionKind) {
-        todo!()
+        match kind {
+            PermissionKind::ScreenCapture => Self::request_screen_capture(),
+        }
     }
 
-    fn open_settings(&self, kind: PermissionKind) {
-        todo!()
+    fn open_settings(&self, _kind: PermissionKind) {}
+}
+
+impl MacPermissionsHandler {
+    fn screen_capture_status() -> PermissionStatus {
+        if unsafe { CGPreflightScreenCaptureAccess() } {
+            PermissionStatus::Granted
+        } else {
+            PermissionStatus::NotDetermined
+        }
     }
+
+    fn request_screen_capture() {
+        unsafe {
+            CGRequestScreenCaptureAccess();
+        }
+    }
+}
+
+#[link(name = "CoreGraphics", kind = "framework")]
+unsafe extern "C" {
+    fn CGPreflightScreenCaptureAccess() -> bool;
+    fn CGRequestScreenCaptureAccess() -> bool;
 }

--- a/crates/gpui/src/platform/mac/permissions.rs
+++ b/crates/gpui/src/platform/mac/permissions.rs
@@ -1,0 +1,17 @@
+use crate::{PermissionKind, PermissionStatus, PlatformPermissionsHandler};
+
+pub struct MacPermissionsHandler;
+
+impl PlatformPermissionsHandler for MacPermissionsHandler {
+    fn status(&self, kind: PermissionKind) -> PermissionStatus {
+        todo!()
+    }
+
+    fn request(&self, kind: PermissionKind) {
+        todo!()
+    }
+
+    fn open_settings(&self, kind: PermissionKind) {
+        todo!()
+    }
+}

--- a/crates/gpui/src/platform/mac/permissions.rs
+++ b/crates/gpui/src/platform/mac/permissions.rs
@@ -18,8 +18,6 @@ impl PlatformPermissionsHandler for MacPermissionsHandler {
             PermissionKind::Microphone => Self::request_microphone(),
         }
     }
-
-    fn open_settings(&self, _kind: PermissionKind) {}
 }
 
 impl MacPermissionsHandler {

--- a/crates/gpui/src/platform/mac/permissions.rs
+++ b/crates/gpui/src/platform/mac/permissions.rs
@@ -23,6 +23,8 @@ impl MacPermissionsHandler {
         if unsafe { CGPreflightScreenCaptureAccess() } {
             PermissionStatus::Granted
         } else {
+            // Returns false even if the user has never been asked
+            // so we cannot distinguish between denied and not determined
             PermissionStatus::NotDetermined
         }
     }

--- a/crates/gpui/src/platform/mac/permissions.rs
+++ b/crates/gpui/src/platform/mac/permissions.rs
@@ -1,3 +1,5 @@
+use objc::{class, msg_send, sel, sel_impl};
+
 use crate::{PermissionKind, PermissionStatus, PlatformPermissionsHandler};
 
 pub struct MacPermissionsHandler;
@@ -6,12 +8,14 @@ impl PlatformPermissionsHandler for MacPermissionsHandler {
     fn status(&self, kind: PermissionKind) -> PermissionStatus {
         match kind {
             PermissionKind::ScreenCapture => Self::screen_capture_status(),
+            PermissionKind::Microphone => Self::microphone_status(),
         }
     }
 
     fn request(&self, kind: PermissionKind) {
         match kind {
             PermissionKind::ScreenCapture => Self::request_screen_capture(),
+            PermissionKind::Microphone => Self::request_microphone(),
         }
     }
 
@@ -23,8 +27,8 @@ impl MacPermissionsHandler {
         if unsafe { CGPreflightScreenCaptureAccess() } {
             PermissionStatus::Granted
         } else {
-            // Returns false even if the user has never been asked
-            // so we cannot distinguish between denied and not determined
+            // CGPreflightScreenCaptureAccess returns false both when denied
+            // and when not yet determined - we cannot distinguish between them
             PermissionStatus::NotDetermined
         }
     }
@@ -34,10 +38,32 @@ impl MacPermissionsHandler {
             CGRequestScreenCaptureAccess();
         }
     }
+
+    fn microphone_status() -> PermissionStatus {
+        unsafe {
+            let status: isize = msg_send![class!(AVCaptureDevice), authorizationStatusForMediaType: AVMediaTypeAudio];
+            match status {
+                0 => PermissionStatus::NotDetermined,
+                1 => PermissionStatus::Restricted,
+                2 => PermissionStatus::Denied,
+                3 => PermissionStatus::Granted,
+                _ => PermissionStatus::Unsupported,
+            }
+        }
+    }
+
+    fn request_microphone() {
+        todo!()
+    }
 }
 
 #[link(name = "CoreGraphics", kind = "framework")]
 unsafe extern "C" {
     fn CGPreflightScreenCaptureAccess() -> bool;
     fn CGRequestScreenCaptureAccess() -> bool;
+}
+
+#[link(name = "AVFoundation", kind = "framework")]
+unsafe extern "C" {
+    static AVMediaTypeAudio: *const objc::runtime::Object;
 }

--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -6,7 +6,8 @@ use crate::{
     KeyContext, Keymap, MacDispatcher, MacDisplay, MacWindow, Menu, MenuItem, OsMenu, OwnedMenu,
     PathPromptOptions, Platform, PlatformDisplay, PlatformKeyboardLayout, PlatformKeyboardMapper,
     PlatformTextSystem, PlatformWindow, Result, SystemMenuType, Task, WindowAppearance,
-    WindowParams, platform::mac::pasteboard::Pasteboard,
+    WindowParams,
+    platform::mac::{pasteboard::Pasteboard, permissions::MacPermissionsHandler},
 };
 use anyhow::{Context as _, anyhow};
 use block::ConcreteBlock;
@@ -1134,6 +1135,12 @@ impl Platform for MacPlatform {
             }
             Ok(())
         })
+    }
+
+    fn permissions_handler(
+        &self,
+    ) -> Rc<dyn crate::platform::permissions::PlatformPermissionsHandler> {
+        Rc::new(MacPermissionsHandler {})
     }
 }
 

--- a/crates/gpui/src/platform/permissions.rs
+++ b/crates/gpui/src/platform/permissions.rs
@@ -19,6 +19,8 @@ pub enum PermissionStatus {
 pub enum PermissionKind {
     /// Permission to capture the screen content.
     ScreenCapture,
+    /// Permission to use the microphone
+    Microphone,
 }
 
 /// Platform-specific handler for checking and requesting system permissions.
@@ -30,9 +32,6 @@ pub trait PlatformPermissionsHandler {
     /// Requests the specified permission from the user.
     /// This may show a system dialog prompting the user to grant access.
     fn request(&self, kind: PermissionKind);
-
-    /// Opens the system settings page for the specified permission type.
-    fn open_settings(&self, kind: PermissionKind);
 }
 
 /// A no-op permissions handler for platforms that don't support permission management.
@@ -45,6 +44,4 @@ impl PlatformPermissionsHandler for DummyPermissionsHandler {
     }
 
     fn request(&self, _kind: PermissionKind) {}
-
-    fn open_settings(&self, _kind: PermissionKind) {}
 }

--- a/crates/gpui/src/platform/permissions.rs
+++ b/crates/gpui/src/platform/permissions.rs
@@ -1,0 +1,47 @@
+/// The current status of a system permission.
+pub enum PermissionStatus {
+    /// The user has granted permission.
+    Granted,
+    /// The user has explicitly denied permission.
+    Denied,
+    /// The user has not yet been prompted for this permission.
+    NotDetermined,
+    /// Permission is restricted by system policy (e.g., parental controls, MDM).
+    Restricted,
+    /// This permission type is not supported on the current platform.
+    Unsupported,
+}
+
+/// Types of system permissions the application may request.
+pub enum PermissionKind {
+    /// Permission to capture the screen content.
+    ScreenCapture,
+}
+
+/// Platform-specific handler for checking and requesting system permissions.
+pub trait PlatformPermissionsHandler {
+    /// Returns the current status of the specified permission.
+    /// This check does not prompt the user.
+    fn status(&self, kind: PermissionKind) -> PermissionStatus;
+
+    /// Requests the specified permission from the user.
+    /// This may show a system dialog prompting the user to grant access.
+    fn request(&self, kind: PermissionKind);
+
+    /// Opens the system settings page for the specified permission type.
+    fn open_settings(&self, kind: PermissionKind);
+}
+
+/// A no-op permissions handler for platforms that don't support permission management.
+/// All permission checks return [`PermissionStatus::Unsupported`].
+pub struct DummyPermissionsHandler;
+
+impl PlatformPermissionsHandler for DummyPermissionsHandler {
+    fn status(&self, _kind: PermissionKind) -> PermissionStatus {
+        PermissionStatus::Unsupported
+    }
+
+    fn request(&self, _kind: PermissionKind) {}
+
+    fn open_settings(&self, _kind: PermissionKind) {}
+}

--- a/crates/gpui/src/platform/permissions.rs
+++ b/crates/gpui/src/platform/permissions.rs
@@ -1,4 +1,5 @@
 /// The current status of a system permission.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Default, Hash)]
 pub enum PermissionStatus {
     /// The user has granted permission.
     Granted,
@@ -9,10 +10,12 @@ pub enum PermissionStatus {
     /// Permission is restricted by system policy (e.g., parental controls, MDM).
     Restricted,
     /// This permission type is not supported on the current platform.
+    #[default]
     Unsupported,
 }
 
 /// Types of system permissions the application may request.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum PermissionKind {
     /// Permission to capture the screen content.
     ScreenCapture,

--- a/crates/gpui/src/platform/test/platform.rs
+++ b/crates/gpui/src/platform/test/platform.rs
@@ -3,7 +3,8 @@ use crate::{
     DummyKeyboardMapper, ForegroundExecutor, Keymap, NoopTextSystem, Platform, PlatformDisplay,
     PlatformKeyboardLayout, PlatformKeyboardMapper, PlatformTextSystem, PromptButton,
     ScreenCaptureFrame, ScreenCaptureSource, ScreenCaptureStream, SourceMetadata, Task,
-    TestDisplay, TestWindow, WindowAppearance, WindowParams, size,
+    TestDisplay, TestWindow, WindowAppearance, WindowParams,
+    platform::permissions::DummyPermissionsHandler, size,
 };
 use anyhow::Result;
 use collections::VecDeque;
@@ -448,6 +449,12 @@ impl Platform for TestPlatform {
 
     fn open_with_system(&self, _path: &Path) {
         unimplemented!()
+    }
+
+    fn permissions_handler(
+        &self,
+    ) -> Rc<dyn crate::platform::permissions::PlatformPermissionsHandler> {
+        Rc::new(DummyPermissionsHandler)
     }
 }
 

--- a/crates/title_bar/src/collab.rs
+++ b/crates/title_bar/src/collab.rs
@@ -35,13 +35,13 @@ pub fn toggle_screen_sharing(
     let permission_status = cx.permission_status(PermissionKind::ScreenCapture);
     let toggle_screen_sharing = match permission_status {
         PermissionStatus::Denied => Task::ready(Err(anyhow::anyhow!(
-            "Please grant Zed permissions to screen record. You will need to restart zed app."
+            "Screen recording permission was denied. Please enable it in your system settings and restart Zed."
         ))),
         PermissionStatus::NotDetermined => {
             cx.request_permission(PermissionKind::ScreenCapture);
 
             Task::ready(Err(anyhow::anyhow!(
-                "Please grant Zed permissions to screen record. You will need to restart zed app."
+                "Screen recording permission is required. Please grant access and restart Zed."
             )))
         }
         PermissionStatus::Granted


### PR DESCRIPTION
Right now, if a user tries to share their screen during a collab session without having previously granted permission, Zed just shows a message saying it can’t capture the screen and suggests checking system permissions. For users who aren’t comfortable digging around in system settings, this can be confusing and frustrating. It would be more helpful if Zed asked the system for permission directly and guided the user to the right place, which is how most apps handle this on macOS.

Having a permission layer like this will also be useful as accessibility support improves, since many macOS accessibility features require explicit permission before they can be used.

Release Notes:

- Zed now asks for screen capture permission when it hasn’t been granted yet and helps guide users to the correct system settings
