### PR TITLE
Add fallback message when preview changelog is empty

### DIFF
--- a/script/draft-release-notes
+++ b/script/draft-release-notes
@@ -77,7 +77,12 @@ async function main() {
     }
   }
 
-  console.log(releaseNotes.join("\n") + "\n");
+  if (releaseNotes.length === 0) {
+    const compareUrl = `https://github.com/zed-industries/zed/compare/${priorTag}...${tag}#commits_bucket`;
+    console.log(`No public-facing changes in this release. [View the commits](${compareUrl}).\n`);
+  } else {
+    console.log(releaseNotes.join("\n") + "\n");
+  }
 }
 
 function getCommits(oldTag, newTag) {


### PR DESCRIPTION
Avoid automatically publishing preview releases that mention nothing in the release notes:

<img width="947" height="258" alt="SCR-20260107-ioxx" src="https://github.com/user-attachments/assets/97204551-8f55-43fb-8c9c-35491a4f1378" />

Release Notes:

- N/A *or* Added/Fixed/Improved ...
