### PR TITLE
Update pulldown-cmark to v0.13.0 to fix crash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5238,7 +5238,7 @@ dependencies = [
  "postage",
  "pretty_assertions",
  "project",
- "pulldown-cmark 0.12.2",
+ "pulldown-cmark 0.13.0",
  "rand 0.9.2",
  "regex",
  "release_channel",
@@ -9721,7 +9721,7 @@ dependencies = [
  "linkify",
  "log",
  "node_runtime",
- "pulldown-cmark 0.12.2",
+ "pulldown-cmark 0.13.0",
  "settings",
  "sum_tree",
  "theme",
@@ -9745,7 +9745,7 @@ dependencies = [
  "log",
  "markup5ever_rcdom",
  "pretty_assertions",
- "pulldown-cmark 0.12.2",
+ "pulldown-cmark 0.13.0",
  "settings",
  "theme",
  "ui",
@@ -12887,9 +12887,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
+checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
 dependencies = [
  "bitflags 2.9.4",
  "memchr",
@@ -13762,7 +13762,7 @@ dependencies = [
  "gpui",
  "language",
  "linkify",
- "pulldown-cmark 0.12.2",
+ "pulldown-cmark 0.13.0",
  "theme",
  "ui",
  "util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -601,7 +601,7 @@ profiling = "1"
 prost = "0.9"
 prost-build = "0.9"
 prost-types = "0.9"
-pulldown-cmark = { version = "0.12.0", default-features = false }
+pulldown-cmark = { version = "0.13.0", default-features = false }
 quote = "1.0.9"
 rand = "0.9"
 rayon = "1.8"

--- a/crates/markdown/src/parser.rs
+++ b/crates/markdown/src/parser.rs
@@ -149,6 +149,8 @@ pub fn parse_markdown(
                     pulldown_cmark::Tag::Emphasis => MarkdownTag::Emphasis,
                     pulldown_cmark::Tag::Strong => MarkdownTag::Strong,
                     pulldown_cmark::Tag::Strikethrough => MarkdownTag::Strikethrough,
+                    pulldown_cmark::Tag::Superscript => MarkdownTag::Superscript,
+                    pulldown_cmark::Tag::Subscript => MarkdownTag::Subscript,
                     pulldown_cmark::Tag::Image {
                         link_type,
                         dest_url,
@@ -454,6 +456,8 @@ pub enum MarkdownTag {
     Emphasis,
     Strong,
     Strikethrough,
+    Superscript,
+    Subscript,
 
     /// A link.
     Link {

--- a/crates/markdown/src/parser.rs
+++ b/crates/markdown/src/parser.rs
@@ -18,7 +18,9 @@ const PARSE_OPTIONS: Options = Options::ENABLE_TABLES
     .union(Options::ENABLE_HEADING_ATTRIBUTES)
     .union(Options::ENABLE_PLUSES_DELIMITED_METADATA_BLOCKS)
     .union(Options::ENABLE_OLD_FOOTNOTES)
-    .union(Options::ENABLE_GFM);
+    .union(Options::ENABLE_GFM)
+    .union(Options::ENABLE_SUPERSCRIPT)
+    .union(Options::ENABLE_SUBSCRIPT);
 
 pub fn parse_markdown(
     text: &str,
@@ -552,7 +554,8 @@ mod tests {
 
     const UNWANTED_OPTIONS: Options = Options::ENABLE_YAML_STYLE_METADATA_BLOCKS
         .union(Options::ENABLE_MATH)
-        .union(Options::ENABLE_DEFINITION_LIST);
+        .union(Options::ENABLE_DEFINITION_LIST)
+        .union(Options::ENABLE_WIKILINKS);
 
     #[test]
     fn all_options_considered() {


### PR DESCRIPTION
Hi Zed team thank you for the awesome editor!

I recently stumbled upon a markdown sequence that seems to cause a crash

```md
-	[	] -
\
-
```

*easier to read escape characters below

```rust
let crash_input = "-\t[\t] -\r\\\n-"
println!("{}", crash_input)
```

## how to reproduce

1. copy the markdown above
2. save the file
3. `[shift]` + `[cmd]` + `p` to open the command palette
4. select `markdown: open preview`
5. crash

I've confirmed that the issue is a bug in pulldown-cmark version 12, and has been resolved in version [v0.13.0](https://github.com/pulldown-cmark/pulldown-cmark/releases/tag/v0.13.0) and specifically fixed in https://github.com/pulldown-cmark/pulldown-cmark/pull/1017

this PR simply bumps the pulldown-cmark version in zed which resolves the crash on my local machine. 


## recording 


https://github.com/user-attachments/assets/dc77132f-0d43-40f3-9841-0bf34fe714fb


Release Notes:

- Fixed a crash that could occur when using the Markdown preview