### PR TITLE
Polish the Closed Bugs GH workflow

### DIFF
--- a/.github/workflows/add_commented_closed_issue_to_project.yml
+++ b/.github/workflows/add_commented_closed_issue_to_project.yml
@@ -5,14 +5,20 @@ on:
     types:
       - created
 
+permissions:
+  contents: read
+
 jobs:
   add-to-project:
     if: >
       github.repository == 'zed-industries/zed' &&
       github.event.issue.state == 'closed' &&
+      github.event.issue.pull_request == null &&
+      github.event.issue.type != null &&
       github.event.issue.type.name == 'Bug' &&
       github.event.comment.user.type != 'Bot'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - id: get-app-token
         uses: actions/create-github-app-token@bef1eaf1c0ac2b148ee2a0a74c65fbe6db0631f1 # v2.1.4
@@ -41,70 +47,17 @@ jobs:
               throw error;
             }
 
-      # Add to the support team's board for triage
-      - id: add-to-project
-        if: steps.check-staff.outputs.result == 'false'
+      - if: steps.check-staff.outputs.result == 'true'
+        run: |
+          echo "::notice::Skipping issue #${{ github.event.issue.number }} - commenter is staff member"
+
+      # github-script outputs are JSON strings, so we compare against 'false' (string)
+      - if: steps.check-staff.outputs.result == 'false'
+        run: |
+          echo "::notice::Adding issue #${{ github.event.issue.number }} to project (comment by ${{ github.event.comment.user.login }})"
+
+      - if: steps.check-staff.outputs.result == 'false'
         uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:
-          project-url: https://github.com/orgs/zed-industries/projects/71
+          project-url: https://github.com/orgs/zed-industries/projects/73
           github-token: ${{ steps.get-app-token.outputs.token }}
-
-      # Set status to "Incoming" (overrides project's default "Closed" automation)
-      - if: steps.add-to-project.outputs.itemId
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        with:
-          github-token: ${{ steps.get-app-token.outputs.token }}
-          script: |
-            const itemId = '${{ steps.add-to-project.outputs.itemId }}';
-            const projectNumber = 71;
-
-            // Get project ID and Status field in one query
-            const { organization } = await github.graphql(`
-              query($org: String!, $projectNumber: Int!) {
-                organization(login: $org) {
-                  projectV2(number: $projectNumber) {
-                    id
-                    field(name: "Status") {
-                      ... on ProjectV2SingleSelectField {
-                        id
-                        options {
-                          id
-                          name
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            `, { org: 'zed-industries', projectNumber });
-
-            const project = organization.projectV2;
-            if (!project.field) {
-              throw new Error('Could not find "Status" field in project');
-            }
-
-            const incomingOption = project.field.options.find(o => o.name === 'Incoming');
-            if (!incomingOption) {
-              throw new Error('Could not find "Incoming" status option');
-            }
-
-            // Update the item's status
-            await github.graphql(`
-              mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
-                updateProjectV2ItemFieldValue(input: {
-                  projectId: $projectId
-                  itemId: $itemId
-                  fieldId: $fieldId
-                  value: { singleSelectOptionId: $optionId }
-                }) {
-                  projectV2Item {
-                    id
-                  }
-                }
-              }
-            `, {
-              projectId: project.id,
-              itemId,
-              fieldId: project.field.id,
-              optionId: incomingOption.id
-            });


### PR DESCRIPTION
Remove the attempts to have these issues land in the same 'inbox' (the existing project board for triage). Since they're closed, the automated workflow of the project board will move them to the 'Closed' column/status even with the API call specifically moving them to 'Incoming' instead. It is what it is, we'll have a separate project board for this.

Also:
- don't look at comments on PRs
- don't freak out if the issue has no type
- add a permissions block as a defensive measure (in case someone adds secrets.GITHUB_TOKEN later)
- add a timeout to avoid hanging out for six hours or whatever the default is
- add some logging.

Release Notes:

- N/A