### PR TITLE
ep: Add file deletion support in unified diff parsing

### DIFF
--- a/crates/edit_prediction/src/zeta2.rs
+++ b/crates/edit_prediction/src/zeta2.rs
@@ -18,8 +18,8 @@ use std::{path::Path, sync::Arc, time::Instant};
 use zeta_prompt::CURSOR_MARKER;
 use zeta_prompt::format_zeta_prompt;
 
-const MAX_CONTEXT_TOKENS: usize = 150;
-const MAX_REWRITE_TOKENS: usize = 350;
+pub const MAX_CONTEXT_TOKENS: usize = 150;
+pub const MAX_REWRITE_TOKENS: usize = 350;
 
 pub fn request_prediction_with_zeta2(
     store: &mut EditPredictionStore,

--- a/crates/edit_prediction_cli/src/example.rs
+++ b/crates/edit_prediction_cli/src/example.rs
@@ -9,6 +9,7 @@ use http_client::Url;
 use language::{Anchor, Buffer};
 use project::Project;
 use serde::{Deserialize, Serialize};
+use std::ops::Range;
 use std::sync::Arc;
 use std::{
     borrow::Cow,
@@ -69,6 +70,8 @@ pub struct ExampleBuffer {
     pub cursor_row: u32,
     pub cursor_column: u32,
     pub cursor_offset: usize,
+    pub context_range: Range<usize>,
+    pub editable_range: Range<usize>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/edit_prediction_cli/src/format_prompt.rs
+++ b/crates/edit_prediction_cli/src/format_prompt.rs
@@ -124,20 +124,19 @@ impl TeacherPrompt {
         // 2. Context retriever just didn't include cursor line.
         //
         // In that case, fallback to using `cursor_position` as excerpt.
-        let cursor_file = &example
+        let example_buffer = example
             .buffer
             .as_ref()
-            .context("`buffer` should be filled in in the context collection step")?
-            .content;
+            .context("`buffer` should be filled in in the context collection step")?;
+        let cursor_file = &example_buffer.content;
 
         // Extract updated (new) editable region from the model response.
         // The model may include editable region markers in its output, so we need to strip them.
         let new_editable_region = extract_last_codeblock(response);
         let mut new_editable_region = Self::extract_editable_region(&new_editable_region);
 
-        // Reconstruct old editable region we sent to the model
-        let old_editable_region = Self::format_editable_region(example);
-        let old_editable_region = Self::extract_editable_region(&old_editable_region);
+        let old_editable_region =
+            example_buffer.content[example_buffer.editable_range.clone()].to_string();
 
         // Normalize leading newlines: if old starts with newline but new doesn't,
         // prepend newline to new to preserve whitespace structure.
@@ -199,19 +198,29 @@ impl TeacherPrompt {
     fn format_editable_region(example: &Example) -> String {
         let mut result = String::new();
 
+        let example_buffer = example.buffer.as_ref().unwrap();
+
         let path_str = example.spec.cursor_path.to_string_lossy();
         result.push_str(&format!("`````path=\"{path_str}\"\n"));
+        result.push_str(
+            &example_buffer.content
+                [example_buffer.context_range.start..example_buffer.editable_range.start],
+        );
         result.push_str(Self::EDITABLE_REGION_START);
-
-        // TODO: control number of lines around cursor
-        let (mut excerpt, offset) = example.spec.cursor_excerpt().unwrap();
-        excerpt.insert_str(offset, Self::USER_CURSOR_MARKER);
-        result.push_str(&excerpt);
-        if !result.ends_with('\n') {
-            result.push('\n');
-        }
-
+        result.push_str(
+            &example_buffer.content
+                [example_buffer.editable_range.start..example_buffer.cursor_offset],
+        );
+        result.push_str(Self::USER_CURSOR_MARKER);
+        result.push_str(
+            &example_buffer.content
+                [example_buffer.cursor_offset..example_buffer.editable_range.end],
+        );
         result.push_str(Self::EDITABLE_REGION_END);
+        result.push_str(
+            &example_buffer.content
+                [example_buffer.editable_range.end..example_buffer.context_range.end],
+        );
         result.push_str("\n`````");
 
         result

--- a/crates/edit_prediction_cli/src/load_project.rs
+++ b/crates/edit_prediction_cli/src/load_project.rs
@@ -5,11 +5,13 @@ use crate::{
     progress::{InfoStyle, Progress, Step, StepProgress},
 };
 use anyhow::{Context as _, Result};
-use edit_prediction::EditPredictionStore;
 use edit_prediction::udiff::{OpenedBuffers, refresh_worktree_entries};
+use edit_prediction::{
+    EditPredictionStore, cursor_excerpt::editable_and_context_ranges_for_cursor_position, zeta2,
+};
 use futures::AsyncWriteExt as _;
 use gpui::{AsyncApp, Entity};
-use language::{Anchor, Buffer, LanguageNotFound, ToOffset, ToPoint};
+use language::{Anchor, Buffer, LanguageNotFound, OffsetRangeExt as _, ToOffset, ToPoint};
 use project::Project;
 use project::buffer_store::BufferStoreEvent;
 use std::{fs, path::PathBuf, sync::Arc};
@@ -31,8 +33,20 @@ pub async fn run_load_project(
 
     let (buffer, cursor_position) =
         cursor_position(example, &project, &open_buffers, &mut cx).await?;
+    buffer
+        .read_with(&cx, |buffer, _| buffer.parsing_idle())?
+        .await;
     let (example_buffer, language_name) = buffer.read_with(&cx, |buffer, _cx| {
         let cursor_point = cursor_position.to_point(&buffer);
+        let snapshot = buffer.snapshot();
+        let (editable_range, context_range) = editable_and_context_ranges_for_cursor_position(
+            cursor_point,
+            &snapshot,
+            zeta2::MAX_REWRITE_TOKENS,
+            zeta2::MAX_CONTEXT_TOKENS,
+        );
+        let editable_range = editable_range.to_offset(&snapshot);
+        let context_range = context_range.to_offset(&snapshot);
         let language_name = buffer
             .language()
             .map(|l| l.name().to_string())
@@ -43,6 +57,8 @@ pub async fn run_load_project(
                 cursor_row: cursor_point.row,
                 cursor_column: cursor_point.column,
                 cursor_offset: cursor_position.to_offset(&buffer),
+                context_range,
+                editable_range,
             },
             language_name,
         )

--- a/crates/edit_prediction_cli/src/progress.rs
+++ b/crates/edit_prediction_cli/src/progress.rs
@@ -99,7 +99,8 @@ impl Progress {
                     inner: Mutex::new(ProgressInner {
                         completed: Vec::new(),
                         in_progress: HashMap::new(),
-                        is_tty: std::io::stderr().is_terminal(),
+                        is_tty: std::env::var("NO_COLOR").is_err()
+                            && std::io::stderr().is_terminal(),
                         terminal_width: get_terminal_width(),
                         max_example_name_len: 0,
                         status_lines_displayed: 0,
@@ -110,7 +111,7 @@ impl Progress {
                     }),
                 });
                 let _ = log::set_logger(&LOGGER);
-                log::set_max_level(log::LevelFilter::Error);
+                log::set_max_level(log::LevelFilter::Info);
                 progress
             })
             .clone()

--- a/crates/edit_prediction_cli/src/reorder_patch.rs
+++ b/crates/edit_prediction_cli/src/reorder_patch.rs
@@ -155,7 +155,11 @@ impl ToString for Patch {
             } else {
                 result.push_str(&format!("--- a/{}\n", current_file));
             }
-            result.push_str(&format!("+++ b/{}\n", current_file));
+            if hunk.is_file_deletion() {
+                result.push_str("+++ /dev/null\n");
+            } else {
+                result.push_str(&format!("+++ b/{}\n", current_file));
+            }
             result.push_str(&hunk.to_string());
         }
 
@@ -190,10 +194,16 @@ impl Patch {
                 is_filename_inherited = true;
             } else if let Some(path) = line.strip_prefix("--- ") {
                 is_filename_inherited = false;
-                current_file = path.trim().strip_prefix("a/").unwrap_or(path).into();
+                let path = path.trim().strip_prefix("a/").unwrap_or(path);
+                if path != "/dev/null" {
+                    current_file = path.into();
+                }
             } else if let Some(path) = line.strip_prefix("+++ ") {
                 is_filename_inherited = false;
-                current_file = path.trim().strip_prefix("b/").unwrap_or(path).into();
+                let path = path.trim().strip_prefix("b/").unwrap_or(path);
+                if path != "/dev/null" {
+                    current_file = path.into();
+                }
             } else if let Some(line) = line.strip_prefix("+") {
                 hunk.lines.push(PatchLine::Addition(line.to_string()));
             } else if let Some(line) = line.strip_prefix("-") {
@@ -337,6 +347,11 @@ impl Hunk {
     /// Returns true if this hunk represents a file creation (old side is empty).
     pub fn is_file_creation(&self) -> bool {
         self.old_start == 0 && self.old_count == 0
+    }
+
+    /// Returns true if this hunk represents a file deletion (new side is empty).
+    pub fn is_file_deletion(&self) -> bool {
+        self.new_start == 0 && self.new_count == 0
     }
 
     /// Render the hunk header
@@ -1492,6 +1507,33 @@ mod tests {
             +fn main() {
             +    println!(\"hello\");
             +}
+        "}
+        );
+    }
+
+    #[test]
+    fn test_file_deletion_diff_header() {
+        // When new_start and new_count are both 0, the file is being deleted,
+        // so the +++ line should be /dev/null instead of b/filename
+        let patch = Patch::parse_unified_diff(indoc! {"
+            --- a/old_file.rs
+            +++ /dev/null
+            @@ -1,3 +0,0 @@
+            -fn main() {
+            -    println!(\"goodbye\");
+            -}
+        "});
+
+        let actual = patch.to_string();
+        assert_eq!(
+            actual,
+            indoc! {"
+            --- a/old_file.rs
+            +++ /dev/null
+            @@ -1,3 +0,0 @@
+            -fn main() {
+            -    println!(\"goodbye\");
+            -}
         "}
         );
     }


### PR DESCRIPTION
- Use the same editable region for teacher as for Zeta 2
- Handle file deletions in edit history
- Respect NO_COLOR env var and enable info-level logging


Release Notes:

- N/A
