### PR TITLE
Use transparent clear color for opaque windows on Linux

### DIFF
--- a/crates/gpui/src/platform/blade/blade_renderer.rs
+++ b/crates/gpui/src/platform/blade/blade_renderer.rs
@@ -709,11 +709,7 @@ impl BladeRenderer {
             gpu::RenderTargetSet {
                 colors: &[gpu::RenderTarget {
                     view: frame.texture_view(),
-                    init_op: gpu::InitOp::Clear(if self.surface_config.transparent {
-                        gpu::TextureColor::TransparentBlack
-                    } else {
-                        gpu::TextureColor::White
-                    }),
+                    init_op: gpu::InitOp::Clear(gpu::TextureColor::TransparentBlack),
                     finish_op: gpu::FinishOp::Store,
                 }],
                 depth_stencil: None,


### PR DESCRIPTION
https://github.com/zed-industries/zed/pull/45423 changed the Blade renderer to use a white clear color for "opaque" windows. This interacts poorly with our client-side decorations, causing the shadows around the window to be drawn over a white background.

Release Notes:

- N/A