### PR TITLE
git: Fix project diff sorting not matching the git panel when tree view is in use

### DIFF
--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -716,8 +716,7 @@ impl ProjectDiff {
 fn sort_prefix(repo: &Repository, repo_path: &RepoPath, status: FileStatus, cx: &App) -> u64 {
     let settings = GitPanelSettings::get_global(cx);
 
-    // Tree view can only sort by path
-    if settings.sort_by_path || settings.tree_view {
+    if settings.sort_by_path && !settings.tree_view {
         TRACKED_SORT_PREFIX
     } else if repo.had_conflict_on_last_merge_head_change(repo_path) {
         CONFLICT_SORT_PREFIX


### PR DESCRIPTION
The tree view effectively always sorts by status, not by path.

Release Notes:

- Fixed incorrect ordering of paths in the project diff when using the git panel's tree view.