### PR TITLE
workspace: Unpreview active tab when closing other tabs

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -6542,7 +6542,8 @@ mod tests {
         pane.update(cx, |pane, cx| {
             pane.set_preview_item_id(Some(item_c.item_id()), cx);
         });
-        assert!(pane.read_with(cx, |pane, _| pane.preview_item_id() == Some(item_c.item_id())));
+        assert!(pane.read_with(cx, |pane, _| pane.preview_item_id()
+            == Some(item_c.item_id())));
 
         pane.update_in(cx, |pane, window, cx| {
             pane.close_other_items(

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1562,6 +1562,8 @@ impl Pane {
             None => self.active_item_id(),
         };
 
+        self.unpreview_item_if_preview(active_item_id);
+
         let pinned_item_ids = self.pinned_item_ids();
 
         self.close_items(

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -6525,6 +6525,44 @@ mod tests {
     }
 
     #[gpui::test]
+    async fn test_close_other_items_unpreviews_active_item(cx: &mut TestAppContext) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.executor());
+
+        let project = Project::test(fs, None, cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
+        let pane = workspace.read_with(cx, |workspace, _| workspace.active_pane().clone());
+
+        add_labeled_item(&pane, "A", false, cx);
+        add_labeled_item(&pane, "B", false, cx);
+        let item_c = add_labeled_item(&pane, "C", false, cx);
+        assert_item_labels(&pane, ["A", "B", "C*"], cx);
+
+        pane.update(cx, |pane, cx| {
+            pane.set_preview_item_id(Some(item_c.item_id()), cx);
+        });
+        assert!(pane.read_with(cx, |pane, _| pane.preview_item_id() == Some(item_c.item_id())));
+
+        pane.update_in(cx, |pane, window, cx| {
+            pane.close_other_items(
+                &CloseOtherItems {
+                    save_intent: None,
+                    close_pinned: false,
+                },
+                Some(item_c.item_id()),
+                window,
+                cx,
+            )
+        })
+        .await
+        .unwrap();
+
+        assert!(pane.read_with(cx, |pane, _| pane.preview_item_id().is_none()));
+        assert_item_labels(&pane, ["C*"], cx);
+    }
+
+    #[gpui::test]
     async fn test_close_clean_items(cx: &mut TestAppContext) {
         init_test(cx);
         let fs = FakeFs::new(cx.executor());


### PR DESCRIPTION
Un-preview the active tab when closing other tabs. 

In my mind the intent when clicking `Close Others` is to keep the current tab around, so it should no longer be treated as a preview.
This also matches the VSCode behavior.


Release Notes:

- Make preview tab permanent after closing all other tabs
