### PR TITLE
Fix multiline regex

### DIFF
--- a/crates/project/src/search.rs
+++ b/crates/project/src/search.rs
@@ -759,4 +759,29 @@ mod tests {
             "Case sensitivity should not be enabled when \\C pattern item is preceded by a backslash."
         );
     }
+
+    #[gpui::test]
+    async fn test_multiline_regex(cx: &mut gpui::TestAppContext) {
+        let search_query = SearchQuery::regex(
+            "^hello$\n",
+            false,
+            false,
+            false,
+            false,
+            Default::default(),
+            Default::default(),
+            false,
+            None,
+        )
+        .expect("Should be able to create a regex SearchQuery");
+
+        use language::Buffer;
+        let text = crate::Rope::from("hello\nworld\nhello\nworld");
+        let snapshot = cx
+            .update(|app| Buffer::build_snapshot(text, None, None, app))
+            .await;
+
+        let results = search_query.search(&snapshot, None).await;
+        assert_eq!(results.len(), 2);
+    }
 }

--- a/crates/project/src/search.rs
+++ b/crates/project/src/search.rs
@@ -180,6 +180,10 @@ impl SearchQuery {
         }
 
         let multiline = query.contains('\n') || query.contains("\\n");
+        if multiline {
+            query.insert_str(0, "(?m)");
+        }
+
         let regex = RegexBuilder::new(&query)
             .case_insensitive(!case_sensitive)
             .build()?;

--- a/crates/project/src/search.rs
+++ b/crates/project/src/search.rs
@@ -782,6 +782,6 @@ mod tests {
             .await;
 
         let results = search_query.search(&snapshot, None).await;
-        assert_eq!(results.len(), 2);
+        assert_eq!(results, vec![0..6, 12..18]);
     }
 }


### PR DESCRIPTION
Closes #45776

It didn't enable multiline mode before `¯\_(ツ)_/¯`. If there is a reason this fix won't work please let me know but it seems like this one was just an easy fix.

Release Notes:
- Improved multiline regex behavior


