### PR TITLE
git: Fix base text in branch diff and text diff view not being highlighted (cherry-pick #46302)

### DIFF
--- a/crates/git_ui/src/text_diff_view.rs
+++ b/crates/git_ui/src/text_diff_view.rs
@@ -258,6 +258,7 @@ async fn update_diff_buffer(
 ) -> Result<()> {
     let source_buffer_snapshot = source_buffer.read_with(cx, |buffer, _| buffer.snapshot())?;
     let language = source_buffer_snapshot.language().cloned();
+    let language_registry = source_buffer.read_with(cx, |buffer, _| buffer.language_registry())?;
 
     let base_buffer_snapshot = clipboard_buffer.read_with(cx, |buffer, _| buffer.snapshot())?;
     let base_text = base_buffer_snapshot.text();
@@ -268,13 +269,14 @@ async fn update_diff_buffer(
                 source_buffer_snapshot.text.clone(),
                 Some(Arc::from(base_text.as_str())),
                 true,
-                language,
+                language.clone(),
                 cx,
             )
         })?
         .await;
 
     diff.update(cx, |diff, cx| {
+        diff.language_changed(language, language_registry, cx);
         diff.set_snapshot(update, &source_buffer_snapshot.text, cx)
     })?
     .await;

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -697,6 +697,7 @@ impl GitStore {
     ) -> Task<Result<Entity<BufferDiff>>> {
         cx.spawn(async move |this, cx| {
             let buffer_snapshot = buffer.update(cx, |buffer, _| buffer.snapshot())?;
+            let language_registry = buffer.update(cx, |buffer, _| buffer.language_registry())?;
             let content = match oid {
                 None => None,
                 Some(oid) => Some(
@@ -708,6 +709,11 @@ impl GitStore {
 
             buffer_diff
                 .update(cx, |buffer_diff, cx| {
+                    buffer_diff.language_changed(
+                        buffer_snapshot.language().cloned(),
+                        language_registry,
+                        cx,
+                    );
                     buffer_diff.set_base_text(
                         content.map(|s| s.as_str().into()),
                         buffer_snapshot.language().cloned(),


### PR DESCRIPTION
Release Notes:

- Fixed deleted portions of hunks in the branch diff and text diff views not being syntax-highlighted.