### PR TITLE
helix: Always offset cursor on selection

### DIFF
--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -73,6 +73,10 @@ impl Mode {
             Self::Normal | Self::Insert | Self::Replace | Self::HelixNormal => false,
         }
     }
+
+    pub fn is_helix(&self) -> bool {
+        matches!(self, Self::HelixNormal | Self::HelixSelect)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -2059,7 +2059,7 @@ impl Vim {
             collapse_matches: !HelixModeSetting::get_global(cx).0,
             input_enabled: self.editor_input_enabled(),
             autoindent: self.should_autoindent(),
-            cursor_offset_on_selection: self.mode.is_visual(),
+            cursor_offset_on_selection: self.mode.is_visual() || self.mode.is_helix(),
             line_mode: matches!(self.mode, Mode::VisualLine),
             hide_edit_predictions: !matches!(self.mode, Mode::Insert | Mode::Replace),
         }


### PR DESCRIPTION
https://github.com/zed-industries/zed/pull/42837 added the `cursor_offset_on_selection` field, which displays the cursor *after* the end of the selection unless a vim visual mode is enabled, in which case it gets displayed *at* the end of the selection.

However, the real helix is effectively *always* in select mode, and will always display the cursor at the end of the selection, whether that selection is made via its visual mode, a movement key, or with the mouse.

This makes it so that the helix mode setting is taken into account regardless of the visual-ness of the vim mode in the `sync_vim_settings` method.

I also considered simply moving `Mode::HelixNormal` up to the `true` arm of the match in the `is_visual` method since helix is kinda *always* in visual mode, but I figured that could have some unintended consequences and chose to err on the side of caution.

Possibly related to #20121

Closes #46998

Release Notes:

- Fixed the cursor offset in non-visual helix selections
