### PR TITLE
debugger: Fix path separator for remote debugging from Windows

### DIFF
--- a/crates/debugger_ui/src/tests/new_process_modal.rs
+++ b/crates/debugger_ui/src/tests/new_process_modal.rs
@@ -48,16 +48,23 @@ async fn test_debug_session_substitutes_variables_and_relativizes_paths(
 
     let home_dir = paths::home_dir();
 
+    let worktree_root = path!("/test/worktree/path");
+
     let test_cases: Vec<(&'static str, &'static str)> = vec![
         // Absolute path - should not be relativized
         (
             path!("/absolute/path/to/program"),
             path!("/absolute/path/to/program"),
         ),
-        // Relative path - should be prefixed with worktree root
+        // Relative path - should be prefixed with worktree root using the target's path style
         (
             format!(".{0}src{0}program", std::path::MAIN_SEPARATOR).leak(),
-            path!("/test/worktree/path/src/program"),
+            format!(
+                "{}{0}src{0}program",
+                worktree_root,
+                std::path::MAIN_SEPARATOR
+            )
+            .leak(),
         ),
         // Home directory path - should be expanded to full home directory path
         (


### PR DESCRIPTION
## Summary

- Fixes path separator issue when debugging remote WSL2 instances from Windows
- Uses project's `PathStyle` to determine correct separator for target system
- Adds comprehensive unit tests for `resolve_path`

## Problem

When running Zed on Windows and connecting to a remote WSL2 instance, debug configurations with relative paths like `./packages/agent` would produce invalid paths:

```
chdir(/home/darren/src/nanobot2\packages/agent) failed 2
```

Notice the backslash before `packages` - the path incorrectly mixes Unix and Windows separators.

## Root Cause

In `resolve_path`, the code used `std::path::MAIN_SEPARATOR` which is `\` on Windows, but when debugging a remote Unix system, paths need forward slashes.

## Solution

Use the project's `PathStyle` (which already correctly identifies remote system path conventions via `project.path_style(cx)`) instead of `std::path::MAIN_SEPARATOR`:

1. Add `PathStyle` parameter to `resolve_path` and `relativize_paths`
2. Use `path_style.primary_separator()` for the correct separator
3. Normalize path separators according to the target system

## Test plan

- [x] Added unit tests for `resolve_path` covering:
  - Posix style with forward/backward/mixed slash inputs
  - Windows style with forward/backward/mixed slash inputs  
  - Absolute paths (unchanged regardless of style)
  - Home directory expansion
- [ ] Manual testing: Windows → WSL2 remote debugging with relative paths

Fixes #46325

🤖 Generated with [Claude Code](https://claude.ai/code)