### PR TITLE
acp: Add XDouble icon for reject_always permission

### DIFF
--- a/assets/icons/x_double.svg
+++ b/assets/icons/x_double.svg
@@ -1,0 +1,4 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2.70581 4.5L9.294 11.5M9.294 4.5L2.70581 11.5" stroke="black" stroke-width="1.2" stroke-linecap="round"/>
+<path d="M6.70581 4.5L13.294 11.5M13.294 4.5L6.70581 11.5" stroke="black" stroke-width="1.2" stroke-linecap="round"/>
+</svg>

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -3499,9 +3499,11 @@ impl AcpThreadView {
                                 this.icon(IconName::Close).icon_color(Color::Error),
                                 Some(&RejectOnce as &dyn Action),
                             ),
-                            acp::PermissionOptionKind::RejectAlways | _ => {
-                                (this.icon(IconName::Close).icon_color(Color::Error), None)
-                            }
+                            acp::PermissionOptionKind::RejectAlways => (
+                                this.icon(IconName::XDouble).icon_color(Color::Error),
+                                None,
+                            ),
+                            _ => (this.icon(IconName::Close).icon_color(Color::Error), None)
                         };
 
                         let Some(action) = action else {

--- a/crates/icons/src/icons.rs
+++ b/crates/icons/src/icons.rs
@@ -259,6 +259,7 @@ pub enum IconName {
     WholeWord,
     XCircle,
     XCircleFilled,
+    XDouble,
     ZedAgent,
     ZedAgentTwo,
     ZedAssistant,


### PR DESCRIPTION
## Summary

Uses double X (✗✗) for "Reject Always" permission button, matching how "Allow Always" uses double checkmark (✓✓)

## Test plan

- [x] Built and ran Zed locally
- [x] Verified "Reject Always" button shows double X icon
- [x] Clippy passes

Before:
<img width="697" height="304" alt="zed" src="https://github.com/user-attachments/assets/ff5cdad2-c16d-40eb-b692-00569b114843" />

After:
<img width="1532" height="866" alt="after" src="https://github.com/user-attachments/assets/5e290d8c-9504-42f7-b454-663694121dc0" />
