### PR TITLE
Make URL parsing less strict for agent generated URLs

### DIFF
--- a/crates/acp_thread/src/mention.rs
+++ b/crates/acp_thread/src/mention.rs
@@ -566,6 +566,4 @@ mod tests {
             _ => panic!("Expected Selection variant"),
         }
     }
-
-    #[test]
 }


### PR DESCRIPTION
Before this we failed to parse some file:/// links the agent would
generate causing it to open in the system default app and not zed.

Release Notes:

- N/A
