### PR TITLE
editor: Don't paint hunk controls when the text area is too narrow to contain them

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -5791,6 +5791,10 @@ impl EditorElement {
 
                     let x = text_hitbox.bounds.right() - right_margin - px(10.) - size.width;
 
+                    if x < text_hitbox.bounds.left() {
+                        continue;
+                    }
+
                     let bounds = Bounds::new(gpui::Point::new(x, y), size);
                     control_bounds.push((display_row_range.start, bounds));
 


### PR DESCRIPTION
Release Notes:

- N/A