### PR TITLE
Fix symlinked directories not being watched

### DIFF
--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -4365,6 +4365,59 @@ impl BackgroundScanner {
             }
         }
 
+        // For symlinks inside the project root, filesystem events are reported via the
+        // canonical (real) path, so they are routed to the canonical entry (e.g. `real/file.rs`).
+        // But the worktree may also have entries under the symlink path (e.g. `linked/file.rs`).
+        // Reload those aliased entries too so both views stay in sync.
+        {
+            let snapshot = self.state.lock().await.snapshot.clone();
+            let mut extra_relative_paths: Vec<EventRoot> = Vec::new();
+            let mut extra_events: Vec<PathEvent> = Vec::new();
+            for (event, event_root) in events.iter().zip(relative_paths.iter()) {
+                let abs_path = SanitizedPath::new(&event.path);
+                for (canonical, symlink_path) in &snapshot.canonical_path_to_symlink {
+                    let Ok(suffix) =
+                        abs_path.strip_prefix(&SanitizedPath::new(canonical.as_ref()))
+                    else {
+                        continue;
+                    };
+                    let Ok(suffix_rel) = RelPath::new(suffix, PathStyle::local()) else {
+                        continue;
+                    };
+                    let alias_path = symlink_path.join(&suffix_rel);
+                    // Skip if the alias is the same as the primary relative path.
+                    // This happens when the event was already routed via the symlink
+                    // lookup in the else-branch above (symlink outside the project root).
+                    if alias_path == event_root.path {
+                        continue;
+                    }
+                    // Skip if the parent directory is not loaded.
+                    let parent_is_loaded = alias_path.parent().is_none_or(|parent| {
+                        snapshot
+                            .entry_for_path(parent)
+                            .is_some_and(|e| e.kind == EntryKind::Dir)
+                    });
+                    if !parent_is_loaded {
+                        continue;
+                    }
+                    if self.settings.is_path_excluded(&alias_path) {
+                        continue;
+                    }
+                    let alias_abs = root_path.join(alias_path.as_std_path());
+                    extra_relative_paths.push(EventRoot {
+                        path: alias_path,
+                        was_rescanned: event_root.was_rescanned,
+                    });
+                    extra_events.push(PathEvent {
+                        path: alias_abs,
+                        kind: event.kind,
+                    });
+                }
+            }
+            relative_paths.extend(extra_relative_paths);
+            events.extend(extra_events);
+        }
+
         if relative_paths.is_empty() && dot_git_abs_paths.is_empty() {
             return;
         }

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -48,7 +48,7 @@ use smallvec::{SmallVec, smallvec};
 use smol::channel::{self, Sender};
 use std::{
     any::Any,
-    borrow::Borrow as _,
+    borrow::{Borrow as _, Cow},
     cmp::Ordering,
     collections::hash_map,
     convert::TryFrom,
@@ -4261,22 +4261,42 @@ impl BackgroundScanner {
                     }
                 }
 
-                let relative_path = if let Ok(path) = abs_path.strip_prefix(&root_canonical_path)
+                let relative_path: Cow<RelPath> = if let Ok(path) = abs_path.strip_prefix(&root_canonical_path)
                     && let Ok(path) = RelPath::new(path, PathStyle::local())
                 {
                     path
                 } else {
-                    if is_git_related {
-                        log::debug!(
-                            "ignoring event {abs_path:?}, since it's in git dir outside of root path {root_canonical_path:?}",
-                        );
-                    } else {
-                        log::error!(
-                            "ignoring event {abs_path:?} outside of root path {root_canonical_path:?}",
-                        );
+                    // Path is outside root - check if it's within a symlinked directory's canonical path
+                    // This handles events from the canonical path of symlinked directories (issue #35173)
+                    let mut found_symlink_match: Option<Cow<RelPath>> = None;
+                    for entry in snapshot.entries(true, 0) {
+                        if let Some(canonical_path) = &entry.canonical_path {
+                            let canonical_sanitized = SanitizedPath::new(canonical_path.as_ref());
+                            if let Ok(suffix) = abs_path.strip_prefix(&canonical_sanitized) {
+                                if let Ok(suffix_rel) = RelPath::new(suffix, PathStyle::local()) {
+                                    let full_path = entry.path.join(&suffix_rel);
+                                    found_symlink_match = Some(Cow::Owned(full_path.as_ref().to_owned()));
+                                    break;
+                                }
+                            }
+                        }
                     }
-                    skip_ix(&mut ranges_to_drop, ix);
-                    continue;
+
+                    if let Some(path) = found_symlink_match {
+                        path
+                    } else {
+                        if is_git_related {
+                            log::debug!(
+                                "ignoring event {abs_path:?}, since it's in git dir outside of root path {root_canonical_path:?}",
+                            );
+                        } else {
+                            log::error!(
+                                "ignoring event {abs_path:?} outside of root path {root_canonical_path:?}",
+                            );
+                        }
+                        skip_ix(&mut ranges_to_drop, ix);
+                        continue;
+                    }
                 };
 
                 let absolute_path = abs_path.to_path_buf();
@@ -4779,7 +4799,23 @@ impl BackgroundScanner {
         }
 
         state.populate_dir(job.path.clone(), new_entries, new_ignore);
-        self.watcher.add(job.abs_path.as_ref()).log_err();
+
+        // Check if the directory is a symlink and watch both the symlink and canonical paths
+        if let Ok(canonical_path) = self.fs.canonicalize(&job.abs_path).await {
+            let is_symlink = canonical_path != job.abs_path.as_ref();
+
+            if is_symlink {
+                // Watch both the symlink path and the canonical path
+                // Events may come from either path depending on how the file was created
+                self.watcher.add(job.abs_path.as_ref()).log_err();
+                self.watcher.add(&canonical_path).log_err();
+            } else {
+                self.watcher.add(job.abs_path.as_ref()).log_err();
+            }
+        } else {
+            // Not a symlink, watch the path as-is
+            self.watcher.add(job.abs_path.as_ref()).log_err();
+        }
 
         for new_job in new_jobs.into_iter().flatten() {
             job.scan_queue

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -4298,7 +4298,7 @@ impl BackgroundScanner {
                                     .ok()?;
                                 let suffix_rel =
                                     RelPath::new(suffix, PathStyle::local()).ok()?;
-                                Some(symlink_path.join(&suffix_rel).as_ref().to_owned().into_arc())
+                                Some(symlink_path.join(&suffix_rel))
                             });
 
                     if let Some(path) = found_symlink_match {

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -3076,10 +3076,19 @@ impl BackgroundScannerState {
         for entry in removed_entries.cursor::<()>(()) {
             if entry.is_dir() {
                 removed_dir_abs_paths.push(self.snapshot.absolutize(&entry.path));
+                // For symlink directory entries, the parent scan sets canonical_path to
+                // the same value used as the map key, so we can remove in O(1). The root
+                // entry never has canonical_path set even when the root dir is itself a
+                // symlink, so in that case fall back to a linear search by value to avoid
+                // leaking the map entry.
                 if let Some(canonical_path) = &entry.canonical_path {
                     self.snapshot
                         .canonical_path_to_symlink
                         .remove(canonical_path.as_ref());
+                } else {
+                    self.snapshot
+                        .canonical_path_to_symlink
+                        .retain(|_, symlink_path| symlink_path != &entry.path);
                 }
             }
 

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -254,6 +254,10 @@ pub struct LocalSnapshot {
     /// The file handle of the worktree root
     /// (so we can find it after it's been moved)
     root_file_handle: Option<Arc<dyn fs::FileHandle>>,
+    /// Maps each watched canonical path of a symlinked directory to its symlink entry path.
+    /// Used to route filesystem events that are reported via the canonical path back to
+    /// the symlink path in the worktree
+    canonical_path_to_symlink: HashMap<Arc<Path>, Arc<RelPath>>,
 }
 
 struct BackgroundScannerState {
@@ -419,6 +423,7 @@ impl Worktree {
                 global_gitignore: Default::default(),
                 repo_exclude_by_work_dir_abs_path: Default::default(),
                 git_repositories: Default::default(),
+                canonical_path_to_symlink: Default::default(),
                 snapshot: Snapshot::new(
                     worktree_id,
                     abs_path
@@ -3071,6 +3076,11 @@ impl BackgroundScannerState {
         for entry in removed_entries.cursor::<()>(()) {
             if entry.is_dir() {
                 removed_dir_abs_paths.push(self.snapshot.absolutize(&entry.path));
+                if let Some(canonical_path) = &entry.canonical_path {
+                    self.snapshot
+                        .canonical_path_to_symlink
+                        .remove(canonical_path.as_ref());
+                }
             }
 
             match self.removed_entries.entry(entry.inode) {
@@ -4266,21 +4276,21 @@ impl BackgroundScanner {
                 {
                     path
                 } else {
-                    // Path is outside root - check if it's within a symlinked directory's canonical path
-                    // This handles events from the canonical path of symlinked directories (issue #35173)
-                    let mut found_symlink_match: Option<Cow<RelPath>> = None;
-                    for entry in snapshot.entries(true, 0) {
-                        if let Some(canonical_path) = &entry.canonical_path {
-                            let canonical_sanitized = SanitizedPath::new(canonical_path.as_ref());
-                            if let Ok(suffix) = abs_path.strip_prefix(&canonical_sanitized) {
-                                if let Ok(suffix_rel) = RelPath::new(suffix, PathStyle::local()) {
-                                    let full_path = entry.path.join(&suffix_rel);
-                                    found_symlink_match = Some(Cow::Owned(full_path.as_ref().to_owned()));
-                                    break;
-                                }
-                            }
-                        }
-                    }
+                    // Events for a symlinked directory may be reported via the canonical path.
+                    let found_symlink_match =
+                        snapshot
+                            .canonical_path_to_symlink
+                            .iter()
+                            .find_map(|(canonical, symlink_path)| {
+                                let suffix = abs_path
+                                    .strip_prefix(SanitizedPath::new(canonical.as_ref()))
+                                    .ok()?;
+                                let suffix_rel =
+                                    RelPath::new(suffix, PathStyle::local()).ok()?;
+                                Some(Cow::Owned(
+                                    symlink_path.join(&suffix_rel).as_ref().to_owned(),
+                                ))
+                            });
 
                     if let Some(path) = found_symlink_match {
                         path
@@ -4800,21 +4810,16 @@ impl BackgroundScanner {
 
         state.populate_dir(job.path.clone(), new_entries, new_ignore);
 
-        // Check if the directory is a symlink and watch both the symlink and canonical paths
+        self.watcher.add(job.abs_path.as_ref()).log_err();
+        // Also watch the canonical path; events may be reported via either path
         if let Ok(canonical_path) = self.fs.canonicalize(&job.abs_path).await {
-            let is_symlink = canonical_path != job.abs_path.as_ref();
-
-            if is_symlink {
-                // Watch both the symlink path and the canonical path
-                // Events may come from either path depending on how the file was created
-                self.watcher.add(job.abs_path.as_ref()).log_err();
+            if canonical_path != job.abs_path.as_ref() {
                 self.watcher.add(&canonical_path).log_err();
-            } else {
-                self.watcher.add(job.abs_path.as_ref()).log_err();
+                state
+                    .snapshot
+                    .canonical_path_to_symlink
+                    .insert(canonical_path.into(), job.path.clone());
             }
-        } else {
-            // Not a symlink, watch the path as-is
-            self.watcher.add(job.abs_path.as_ref()).log_err();
         }
 
         for new_job in new_jobs.into_iter().flatten() {

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -48,7 +48,7 @@ use smallvec::{SmallVec, smallvec};
 use smol::channel::{self, Sender};
 use std::{
     any::Any,
-    borrow::{Borrow as _, Cow},
+    borrow::Borrow as _,
     cmp::Ordering,
     collections::hash_map,
     convert::TryFrom,
@@ -4280,10 +4280,10 @@ impl BackgroundScanner {
                     }
                 }
 
-                let relative_path: Cow<RelPath> = if let Ok(path) = abs_path.strip_prefix(&root_canonical_path)
+                let relative_path: Arc<RelPath> = if let Ok(path) = abs_path.strip_prefix(&root_canonical_path)
                     && let Ok(path) = RelPath::new(path, PathStyle::local())
                 {
-                    path
+                    path.into_arc()
                 } else {
                     // Events for a symlinked directory may be reported via the canonical path.
                     let found_symlink_match =
@@ -4296,9 +4296,7 @@ impl BackgroundScanner {
                                     .ok()?;
                                 let suffix_rel =
                                     RelPath::new(suffix, PathStyle::local()).ok()?;
-                                Some(Cow::Owned(
-                                    symlink_path.join(&suffix_rel).as_ref().to_owned(),
-                                ))
+                                Some(symlink_path.join(&suffix_rel).as_ref().to_owned().into_arc())
                             });
 
                     if let Some(path) = found_symlink_match {
@@ -4364,7 +4362,7 @@ impl BackgroundScanner {
                 }
 
                 relative_paths.push(EventRoot {
-                    path: relative_path.into_arc(),
+                    path: relative_path,
                     was_rescanned: matches!(event.kind, Some(fs::PathEventKind::Rescan)),
                 });
             }

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -4207,8 +4207,10 @@ impl BackgroundScanner {
                 false
             }
         });
+        let canonical_path_to_symlink;
         {
             let snapshot = &self.state.lock().await.snapshot;
+            canonical_path_to_symlink = snapshot.canonical_path_to_symlink.clone();
 
             let mut ranges_to_drop = SmallVec::<[Range<usize>; 4]>::new();
 
@@ -4377,12 +4379,12 @@ impl BackgroundScanner {
         // But the worktree may also have entries under the symlink path (e.g. `linked/file.rs`).
         // Reload those aliased entries too so both views stay in sync.
         {
-            let snapshot = self.state.lock().await.snapshot.clone();
+            let state = self.state.lock().await;
             let mut extra_relative_paths: Vec<EventRoot> = Vec::new();
             let mut extra_events: Vec<PathEvent> = Vec::new();
             for (event, event_root) in events.iter().zip(relative_paths.iter()) {
                 let abs_path = SanitizedPath::new(&event.path);
-                for (canonical, symlink_path) in &snapshot.canonical_path_to_symlink {
+                for (canonical, symlink_path) in &canonical_path_to_symlink {
                     let Ok(suffix) =
                         abs_path.strip_prefix(&SanitizedPath::new(canonical.as_ref()))
                     else {
@@ -4400,7 +4402,8 @@ impl BackgroundScanner {
                     }
                     // Skip if the parent directory is not loaded.
                     let parent_is_loaded = alias_path.parent().is_none_or(|parent| {
-                        snapshot
+                        state
+                            .snapshot
                             .entry_for_path(parent)
                             .is_some_and(|e| e.kind == EntryKind::Dir)
                     });

--- a/crates/worktree/tests/integration/main.rs
+++ b/crates/worktree/tests/integration/main.rs
@@ -3262,3 +3262,132 @@ async fn test_single_file_worktree_deleted(cx: &mut TestAppContext) {
         "Should receive Deleted event when single-file worktree root is deleted"
     );
 }
+
+#[gpui::test]
+async fn test_symlinked_dir_file_creation(cx: &mut TestAppContext) {
+    // Tests that files created in symlinked directories are detected by the file watcher
+    // and show up in the worktree. This reproduces issue #35173.
+    init_test(cx);
+    let fs = FakeFs::new(cx.background_executor.clone());
+
+    // Create a directory structure with a symlinked directory
+    fs.insert_tree(
+        "/root",
+        json!({
+            "project": {
+                "src": {
+                    "main.rs": "fn main() {}",
+                },
+            },
+            "external": {
+                "lib.rs": "pub fn hello() {}",
+            }
+        }),
+    )
+    .await;
+
+    // Create a symlink from project/linked to external
+    fs.create_symlink(
+        Path::new("/root/project/linked"),
+        PathBuf::from("../external"),
+    )
+    .await
+    .unwrap();
+
+    let tree = Worktree::local(
+        Path::new("/root/project"),
+        true,
+        fs.clone(),
+        Default::default(),
+        true,
+        WorktreeId::from_proto(0),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+
+    cx.read(|cx| tree.read(cx).as_local().unwrap().scan_complete())
+        .await;
+
+    // Set up event tracking
+    let events = Arc::new(Mutex::new(Vec::new()));
+    tree.update(cx, |_, cx| {
+        let events = events.clone();
+        cx.subscribe(&tree, move |_, _, event, _| {
+            if let Event::UpdatedEntries(update) = event {
+                events.lock().extend(
+                    update
+                        .iter()
+                        .map(|(path, _, change)| (path.clone(), *change)),
+                );
+            }
+        })
+        .detach();
+    });
+
+    // Verify initial state - the symlinked directory should be visible
+    tree.read_with(cx, |tree, _| {
+        let linked_entry = tree.entry_for_path(rel_path("linked")).unwrap();
+        assert!(linked_entry.is_external, "symlinked dir should be marked external");
+        assert_eq!(linked_entry.kind, EntryKind::UnloadedDir);
+
+        // Initially we should see the symlink but not its contents
+        assert!(tree.entry_for_path(rel_path("linked/lib.rs")).is_none());
+    });
+
+    // Load the symlinked directory by reading a file in it
+    tree.update(cx, |tree, cx| {
+        tree.load_file(rel_path("linked/lib.rs"), cx)
+    })
+    .await
+    .unwrap();
+
+    tree.read_with(cx, |tree, _| {
+        let linked_entry = tree.entry_for_path(rel_path("linked")).unwrap();
+        assert_eq!(linked_entry.kind, EntryKind::Dir, "linked dir should now be loaded");
+        assert!(tree.entry_for_path(rel_path("linked/lib.rs")).is_some());
+    });
+
+    // Clear any events from the initial load
+    events.lock().clear();
+
+    // Now create a new file in the symlinked directory
+    // The key issue: when created via the canonical path, the file watcher
+    // reports the canonical path, but the worktree is watching the symlink path.
+    // This causes the event to be filtered out or not detected.
+    fs.insert_file("/root/external/new_file.rs", "pub fn new() {}".into())
+        .await;
+
+    // Emit the file system event using the canonical path (the real location)
+    // This simulates what happens when the OS filesystem watcher reports the event
+    fs.emit_fs_event("/root/external/new_file.rs", Some(fs::PathEventKind::Created));
+
+    tree.flush_fs_events(cx).await;
+
+    // Verify the new file appears in the worktree under the symlinked path
+    tree.read_with(cx, |tree, _| {
+        let new_file_entry = tree.entry_for_path(rel_path("linked/new_file.rs"));
+        assert!(
+            new_file_entry.is_some(),
+            "new file created in symlinked directory should be visible in worktree.\n\
+             This test reproduces issue #35173: files created in symlinked directories\n\
+             are not detected because the filesystem watcher reports events using the\n\
+             canonical path, but the worktree is watching the symlink path."
+        );
+
+        if let Some(entry) = new_file_entry {
+            assert!(entry.is_external, "file in symlinked dir should be marked external");
+        }
+    });
+
+    // Verify we received an update event for the new file
+    let captured_events = events.lock().clone();
+    assert!(
+        captured_events.iter().any(|(path, change)| {
+            path.as_ref() == rel_path("linked/new_file.rs")
+                && matches!(change, PathChange::Added | PathChange::AddedOrUpdated)
+        }),
+        "should have received an event for the new file. Events: {:#?}",
+        captured_events
+    );
+}

--- a/crates/worktree/tests/integration/main.rs
+++ b/crates/worktree/tests/integration/main.rs
@@ -3265,8 +3265,6 @@ async fn test_single_file_worktree_deleted(cx: &mut TestAppContext) {
 
 #[gpui::test]
 async fn test_symlinked_dir_file_creation(cx: &mut TestAppContext) {
-    // Tests that files created in symlinked directories are detected by the file watcher
-    // and show up in the worktree. This reproduces issue #35173.
     init_test(cx);
     let fs = FakeFs::new(cx.background_executor.clone());
 
@@ -3367,12 +3365,11 @@ async fn test_symlinked_dir_file_creation(cx: &mut TestAppContext) {
     // Verify the new file appears in the worktree under the symlinked path
     tree.read_with(cx, |tree, _| {
         let new_file_entry = tree.entry_for_path(rel_path("linked/new_file.rs"));
+        // Issue #35173: events reported via the canonical path should still map back
+        // to the symlinked path in the worktree.
         assert!(
             new_file_entry.is_some(),
-            "new file created in symlinked directory should be visible in worktree.\n\
-             This test reproduces issue #35173: files created in symlinked directories\n\
-             are not detected because the filesystem watcher reports events using the\n\
-             canonical path, but the worktree is watching the symlink path."
+            "new file in symlinked directory not visible in worktree"
         );
 
         if let Some(entry) = new_file_entry {

--- a/crates/worktree/tests/integration/main.rs
+++ b/crates/worktree/tests/integration/main.rs
@@ -3489,3 +3489,111 @@ async fn test_symlinked_dir_inside_project(cx: &mut TestAppContext) {
         captured_events
     );
 }
+
+#[gpui::test]
+async fn test_symlinked_dir_removal_cleans_up_routing(cx: &mut TestAppContext) {
+    init_test(cx);
+    let fs = FakeFs::new(cx.background_executor.clone());
+
+    fs.insert_tree(
+        "/root/project",
+        json!({
+            "real": {
+                "existing.rs": "// existing",
+            },
+        }),
+    )
+    .await;
+
+    fs.create_symlink(
+        Path::new("/root/project/linked"),
+        PathBuf::from("real"),
+    )
+    .await
+    .unwrap();
+
+    let tree = Worktree::local(
+        Path::new("/root/project"),
+        true,
+        fs.clone(),
+        Default::default(),
+        true,
+        WorktreeId::from_proto(0),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+
+    cx.read(|cx| tree.read(cx).as_local().unwrap().scan_complete())
+        .await;
+
+    tree.read_with(cx, |tree, _| {
+        assert!(
+            tree.entry_for_path(rel_path("linked")).is_some(),
+            "linked symlink should be visible after initial scan"
+        );
+        assert!(
+            tree.entry_for_path(rel_path("linked/existing.rs")).is_some(),
+            "file under linked symlink should be visible after initial scan"
+        );
+    });
+
+    // Verify that canonical-path events are routed through linked/ before removal.
+    fs.insert_file("/root/project/real/before_removal.rs", "// before".into())
+        .await;
+    fs.emit_fs_event(
+        "/root/project/real/before_removal.rs",
+        Some(fs::PathEventKind::Created),
+    );
+    tree.flush_fs_events(cx).await;
+
+    tree.read_with(cx, |tree, _| {
+        assert!(
+            tree.entry_for_path(rel_path("linked/before_removal.rs")).is_some(),
+            "new file in real/ should appear under linked/ via canonical-path routing"
+        );
+    });
+
+    // FakeFs has no remove-symlink primitive. Using rename to move the symlink
+    // out of the project so the worktree receives a Removed event for "linked".
+    fs.rename(
+        Path::new("/root/project/linked"),
+        Path::new("/root/linked_backup"),
+        Default::default(),
+    )
+    .await
+    .unwrap();
+
+    tree.flush_fs_events(cx).await;
+
+    tree.read_with(cx, |tree, _| {
+        assert!(
+            tree.entry_for_path(rel_path("linked")).is_none(),
+            "linked should be absent from the worktree after the symlink is removed"
+        );
+    });
+
+    // Create a new file in real/ and emit a filesystem event via the canonical
+    // path that linked used to resolve to. If remove_path did not clean up
+    // canonical_path_to_symlink, this event could be spuriously routed to
+    // linked/new_after_removal.rs even though linked no longer exists.
+    fs.insert_file(
+        "/root/project/real/new_after_removal.rs",
+        "// new".into(),
+    )
+    .await;
+    fs.emit_fs_event(
+        "/root/project/real/new_after_removal.rs",
+        Some(fs::PathEventKind::Created),
+    );
+
+    tree.flush_fs_events(cx).await;
+
+    tree.read_with(cx, |tree, _| {
+        assert!(
+            tree.entry_for_path(rel_path("linked/new_after_removal.rs")).is_none(),
+            "no entry should appear under the removed symlink path: \
+             canonical_path_to_symlink must have been cleaned up by remove_path"
+        );
+    });
+}

--- a/crates/worktree/tests/integration/main.rs
+++ b/crates/worktree/tests/integration/main.rs
@@ -3268,7 +3268,6 @@ async fn test_symlinked_dir_file_creation(cx: &mut TestAppContext) {
     init_test(cx);
     let fs = FakeFs::new(cx.background_executor.clone());
 
-    // Create a directory structure with a symlinked directory
     fs.insert_tree(
         "/root",
         json!({
@@ -3284,7 +3283,6 @@ async fn test_symlinked_dir_file_creation(cx: &mut TestAppContext) {
     )
     .await;
 
-    // Create a symlink from project/linked to external
     fs.create_symlink(
         Path::new("/root/project/linked"),
         PathBuf::from("../external"),
@@ -3307,7 +3305,6 @@ async fn test_symlinked_dir_file_creation(cx: &mut TestAppContext) {
     cx.read(|cx| tree.read(cx).as_local().unwrap().scan_complete())
         .await;
 
-    // Set up event tracking
     let events = Arc::new(Mutex::new(Vec::new()));
     tree.update(cx, |_, cx| {
         let events = events.clone();
@@ -3323,7 +3320,6 @@ async fn test_symlinked_dir_file_creation(cx: &mut TestAppContext) {
         .detach();
     });
 
-    // Verify initial state - the symlinked directory should be visible
     tree.read_with(cx, |tree, _| {
         let linked_entry = tree.entry_for_path(rel_path("linked")).unwrap();
         assert!(linked_entry.is_external, "symlinked dir should be marked external");
@@ -3333,7 +3329,6 @@ async fn test_symlinked_dir_file_creation(cx: &mut TestAppContext) {
         assert!(tree.entry_for_path(rel_path("linked/lib.rs")).is_none());
     });
 
-    // Load the symlinked directory by reading a file in it
     tree.update(cx, |tree, cx| {
         tree.load_file(rel_path("linked/lib.rs"), cx)
     })
@@ -3346,7 +3341,6 @@ async fn test_symlinked_dir_file_creation(cx: &mut TestAppContext) {
         assert!(tree.entry_for_path(rel_path("linked/lib.rs")).is_some());
     });
 
-    // Clear any events from the initial load
     events.lock().clear();
 
     // Now create a new file in the symlinked directory
@@ -3362,7 +3356,6 @@ async fn test_symlinked_dir_file_creation(cx: &mut TestAppContext) {
 
     tree.flush_fs_events(cx).await;
 
-    // Verify the new file appears in the worktree under the symlinked path
     tree.read_with(cx, |tree, _| {
         let new_file_entry = tree.entry_for_path(rel_path("linked/new_file.rs"));
         // Issue #35173: events reported via the canonical path should still map back
@@ -3377,7 +3370,6 @@ async fn test_symlinked_dir_file_creation(cx: &mut TestAppContext) {
         }
     });
 
-    // Verify we received an update event for the new file
     let captured_events = events.lock().clone();
     assert!(
         captured_events.iter().any(|(path, change)| {
@@ -3394,7 +3386,6 @@ async fn test_symlinked_dir_inside_project(cx: &mut TestAppContext) {
     init_test(cx);
     let fs = FakeFs::new(cx.background_executor.clone());
 
-    // Create a project with a real directory and a symlink to it inside the same project.
     fs.insert_tree(
         "/root/project",
         json!({
@@ -3405,7 +3396,6 @@ async fn test_symlinked_dir_inside_project(cx: &mut TestAppContext) {
     )
     .await;
 
-    // Create a symlink from project/linked to project/real (both inside the project root).
     fs.create_symlink(
         Path::new("/root/project/linked"),
         PathBuf::from("real"),
@@ -3428,7 +3418,6 @@ async fn test_symlinked_dir_inside_project(cx: &mut TestAppContext) {
     cx.read(|cx| tree.read(cx).as_local().unwrap().scan_complete())
         .await;
 
-    // Both the real directory and the symlinked directory should be scanned and visible.
     tree.read_with(cx, |tree, _| {
         assert!(
             tree.entry_for_path(rel_path("real")).is_some(),
@@ -3453,7 +3442,6 @@ async fn test_symlinked_dir_inside_project(cx: &mut TestAppContext) {
         );
     });
 
-    // Set up event tracking.
     let events = Arc::new(Mutex::new(Vec::new()));
     tree.update(cx, |_, cx| {
         let events = events.clone();
@@ -3469,7 +3457,6 @@ async fn test_symlinked_dir_inside_project(cx: &mut TestAppContext) {
         .detach();
     });
 
-    // Create a new file in the real (canonical) directory.
     fs.insert_file("/root/project/real/new_file.rs", "// new".into())
         .await;
 
@@ -3481,7 +3468,6 @@ async fn test_symlinked_dir_inside_project(cx: &mut TestAppContext) {
 
     tree.flush_fs_events(cx).await;
 
-    // The new file must appear under both the real path and the symlink path.
     tree.read_with(cx, |tree, _| {
         assert!(
             tree.entry_for_path(rel_path("real/new_file.rs")).is_some(),
@@ -3493,7 +3479,6 @@ async fn test_symlinked_dir_inside_project(cx: &mut TestAppContext) {
         );
     });
 
-    // Verify that an update event was emitted for the symlink-aliased path.
     let captured_events = events.lock().clone();
     assert!(
         captured_events.iter().any(|(path, change)| {

--- a/crates/worktree/tests/integration/main.rs
+++ b/crates/worktree/tests/integration/main.rs
@@ -3388,3 +3388,119 @@ async fn test_symlinked_dir_file_creation(cx: &mut TestAppContext) {
         captured_events
     );
 }
+
+#[gpui::test]
+async fn test_symlinked_dir_inside_project(cx: &mut TestAppContext) {
+    init_test(cx);
+    let fs = FakeFs::new(cx.background_executor.clone());
+
+    // Create a project with a real directory and a symlink to it inside the same project.
+    fs.insert_tree(
+        "/root/project",
+        json!({
+            "real": {
+                "existing.rs": "// existing",
+            },
+        }),
+    )
+    .await;
+
+    // Create a symlink from project/linked to project/real (both inside the project root).
+    fs.create_symlink(
+        Path::new("/root/project/linked"),
+        PathBuf::from("real"),
+    )
+    .await
+    .unwrap();
+
+    let tree = Worktree::local(
+        Path::new("/root/project"),
+        true,
+        fs.clone(),
+        Default::default(),
+        true,
+        WorktreeId::from_proto(0),
+        &mut cx.to_async(),
+    )
+    .await
+    .unwrap();
+
+    cx.read(|cx| tree.read(cx).as_local().unwrap().scan_complete())
+        .await;
+
+    // Both the real directory and the symlinked directory should be scanned and visible.
+    tree.read_with(cx, |tree, _| {
+        assert!(
+            tree.entry_for_path(rel_path("real")).is_some(),
+            "real directory should be visible"
+        );
+        assert!(
+            tree.entry_for_path(rel_path("real/existing.rs")).is_some(),
+            "file in real directory should be visible"
+        );
+        assert!(
+            tree.entry_for_path(rel_path("linked")).is_some(),
+            "symlinked directory should be visible"
+        );
+        assert!(
+            tree.entry_for_path(rel_path("linked/existing.rs")).is_some(),
+            "file via symlinked directory should be visible"
+        );
+        let linked_entry = tree.entry_for_path(rel_path("linked")).unwrap();
+        assert!(
+            !linked_entry.is_external,
+            "symlink pointing inside project should not be marked external"
+        );
+    });
+
+    // Set up event tracking.
+    let events = Arc::new(Mutex::new(Vec::new()));
+    tree.update(cx, |_, cx| {
+        let events = events.clone();
+        cx.subscribe(&tree, move |_, _, event, _| {
+            if let Event::UpdatedEntries(update) = event {
+                events.lock().extend(
+                    update
+                        .iter()
+                        .map(|(path, _, change)| (path.clone(), *change)),
+                );
+            }
+        })
+        .detach();
+    });
+
+    // Create a new file in the real (canonical) directory.
+    fs.insert_file("/root/project/real/new_file.rs", "// new".into())
+        .await;
+
+    // Emit a filesystem event via the canonical path, as a real OS watcher would do.
+    fs.emit_fs_event(
+        "/root/project/real/new_file.rs",
+        Some(fs::PathEventKind::Created),
+    );
+
+    tree.flush_fs_events(cx).await;
+
+    // The new file must appear under both the real path and the symlink path.
+    tree.read_with(cx, |tree, _| {
+        assert!(
+            tree.entry_for_path(rel_path("real/new_file.rs")).is_some(),
+            "new file should be visible under real path"
+        );
+        assert!(
+            tree.entry_for_path(rel_path("linked/new_file.rs")).is_some(),
+            "new file should be visible under symlinked path"
+        );
+    });
+
+    // Verify that an update event was emitted for the symlink-aliased path.
+    let captured_events = events.lock().clone();
+    assert!(
+        captured_events.iter().any(|(path, change)| {
+            path.as_ref() == rel_path("linked/new_file.rs")
+                && matches!(change, PathChange::Added | PathChange::AddedOrUpdated)
+        }),
+        "should have received an event for linked/new_file.rs. Events: {:#?}",
+        captured_events
+    );
+}


### PR DESCRIPTION
Closes #35173 and #27263

Code was written by AI agent. Test was reviewed and accepted as is. Fix was reviewed thoroughly and some fixes was done to improve code quality.

Release Notes:

- Fixed: Symlinked directories not not being watched