### PR TITLE
Fix edit prediction triggering in Vim/Helix mode

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -733,7 +733,7 @@
   // alt-l is provided as an alternative to tab/alt-tab. and will be displayed in the UI. This is
   // because alt-tab may not be available, as it is often used for window switching.
   {
-    "context": "Editor && edit_prediction",
+    "context": "Editor && edit_prediction && (vim_mode == insert || !VimControl)",
     "bindings": {
       "alt-tab": "editor::AcceptEditPrediction",
       "alt-l": "editor::AcceptEditPrediction",
@@ -743,7 +743,7 @@
     },
   },
   {
-    "context": "Editor && edit_prediction_conflict",
+    "context": "Editor && edit_prediction_conflict && (vim_mode == insert || !VimControl)",
     "bindings": {
       "alt-tab": "editor::AcceptEditPrediction",
       "alt-l": "editor::AcceptEditPrediction",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -795,7 +795,7 @@
     },
   },
   {
-    "context": "Editor && edit_prediction",
+    "context": "Editor && edit_prediction && (vim_mode == insert || !VimControl)",
     "bindings": {
       "alt-tab": "editor::AcceptEditPrediction",
       "tab": "editor::AcceptEditPrediction",
@@ -804,7 +804,7 @@
     },
   },
   {
-    "context": "Editor && edit_prediction_conflict",
+    "context": "Editor && edit_prediction_conflict && (vim_mode == insert || !VimControl)",
     "use_key_equivalents": true,
     "bindings": {
       "alt-tab": "editor::AcceptEditPrediction",

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -729,7 +729,7 @@
   // alt-l is provided as an alternative to tab/alt-tab. and will be displayed in the UI. This is
   // because alt-tab may not be available, as it is often used for window switching.
   {
-    "context": "Editor && edit_prediction",
+    "context": "Editor && edit_prediction && (vim_mode == insert || !VimControl)",
     "use_key_equivalents": true,
     "bindings": {
       "alt-tab": "editor::AcceptEditPrediction",
@@ -740,7 +740,7 @@
     },
   },
   {
-    "context": "Editor && edit_prediction_conflict",
+    "context": "Editor && edit_prediction_conflict && (vim_mode == insert || !VimControl)",
     "use_key_equivalents": true,
     "bindings": {
       "alt-tab": "editor::AcceptEditPrediction",

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -1058,10 +1058,11 @@
     },
   },
   {
-    "context": "Editor && edit_prediction",
+    "context": "Editor && edit_prediction && vim_mode == insert",
     "bindings": {
       // This is identical to the binding in the base keymap, but the vim bindings above to
       // "vim::Tab" shadow it, so it needs to be bound again.
+      // Only allow in insert mode to avoid conflicts with normal mode operations.
       "tab": "editor::AcceptEditPrediction",
     },
   },

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2367,6 +2367,16 @@ impl Editor {
                             });
                             if active {
                                 editor.show_mouse_cursor(cx);
+                                // Clear edit prediction preview when window is reactivated.
+                                if editor.edit_prediction_preview_is_active() {
+                                    editor.edit_prediction_preview =
+                                        EditPredictionPreview::Inactive {
+                                            released_too_fast: false,
+                                        };
+                                    editor.clear_row_highlights::<EditPredictionPreview>();
+                                    editor.update_visible_edit_prediction(window, cx);
+                                    cx.notify();
+                                }
                             }
                         }),
                     ]

--- a/crates/editor/src/test/editor_test_context.rs
+++ b/crates/editor/src/test/editor_test_context.rs
@@ -251,6 +251,14 @@ impl EditorTestContext {
         self.cx.dispatch_keystroke(self.window, keystroke);
     }
 
+    pub fn simulate_window_activation(&mut self) {
+        self.cx.simulate_window_activation(self.window);
+    }
+
+    pub fn simulate_window_deactivation(&mut self) {
+        self.cx.simulate_window_deactivation(self.window);
+    }
+
     pub fn run_until_parked(&mut self) {
         self.cx.background_executor.run_until_parked();
     }

--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -810,6 +810,18 @@ impl VisualTestContext {
         })
     }
 
+    /// Simulate window activation (e.g., Alt+Tab back to the window)
+    pub fn simulate_window_activation(&mut self, window: AnyWindowHandle) {
+        let test_window = self.test_window(window);
+        test_window.simulate_active_status_change(true);
+    }
+
+    /// Simulate window deactivation (e.g., Alt+Tab away from the window)
+    pub fn simulate_window_deactivation(&mut self, window: AnyWindowHandle) {
+        let test_window = self.test_window(window);
+        test_window.simulate_active_status_change(false);
+    }
+
     /// Simulates the user resizing the window to the new size.
     pub fn simulate_resize(&self, size: Size<Pixels>) {
         self.simulate_window_resize(self.window, size)


### PR DESCRIPTION
Closes #45485

Release Notes:

- Fixed edit prediction incorrectly triggered in Vim/Helix normal mode, and cancel it when the window reactivated.
