### PR TITLE
lsp_button: Fix long LSP version label

### DIFF
--- a/crates/language_tools/src/lsp_button.rs
+++ b/crates/language_tools/src/lsp_button.rs
@@ -489,8 +489,10 @@ impl LanguageServerState {
                             let metadata_label = metadata_label.clone();
                             move |_, _| {
                                 h_flex()
+                                    .id("metadata-container")
                                     .ml_neg_1()
                                     .gap_1()
+                                    .max_w_32()
                                     .child(
                                         Icon::new(IconName::Circle)
                                             .color(status_color)
@@ -511,8 +513,10 @@ impl LanguageServerState {
                                             .child(
                                                 Label::new(metadata)
                                                     .size(LabelSize::Small)
-                                                    .color(Color::Muted),
+                                                    .color(Color::Muted)
+                                                    .truncate(),
                                             )
+                                            .tooltip(Tooltip::text(metadata.clone()))
                                     })
                                     .into_any_element()
                             }

--- a/crates/language_tools/src/lsp_button.rs
+++ b/crates/language_tools/src/lsp_button.rs
@@ -492,7 +492,7 @@ impl LanguageServerState {
                                     .id("metadata-container")
                                     .ml_neg_1()
                                     .gap_1()
-                                    .max_w_52()
+                                    .max_w_56()
                                     .child(
                                         Icon::new(IconName::Circle)
                                             .color(status_color)

--- a/crates/language_tools/src/lsp_button.rs
+++ b/crates/language_tools/src/lsp_button.rs
@@ -492,7 +492,7 @@ impl LanguageServerState {
                                     .id("metadata-container")
                                     .ml_neg_1()
                                     .gap_1()
-                                    .max_w_32()
+                                    .max_w_52()
                                     .child(
                                         Icon::new(IconName::Circle)
                                             .color(status_color)


### PR DESCRIPTION
If the LSP version label ends up being super long, we now truncate it and add a tooltip so you can see the whole thing. This avoids the submenu width from being extremely big:

<img width="500" height="310" alt="Screenshot 2026-01-08 at 9  10@2x" src="https://github.com/user-attachments/assets/4729b3f8-000d-4bb5-8908-dc243a2d6e7b" />

Release Notes:

- Fixed a visual bug where long LSP version labels would increase the LSP submenu width too much.
