### PR TITLE
Enable test-support features for some dev dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18278,6 +18278,7 @@ dependencies = [
  "task",
  "text",
  "theme",
+ "title_bar",
  "tokio",
  "ui",
  "util",

--- a/crates/git_ui/Cargo.toml
+++ b/crates/git_ui/Cargo.toml
@@ -80,6 +80,7 @@ settings = { workspace = true, features = ["test-support"] }
 unindent.workspace = true
 workspace = { workspace = true, features = ["test-support"] }
 zlog.workspace = true
+recent_projects = { workspace = true, features = ["test-support"] }
 
 [package.metadata.cargo-machete]
 ignored = ["tracing"]

--- a/crates/vim/Cargo.toml
+++ b/crates/vim/Cargo.toml
@@ -57,7 +57,8 @@ zed_actions.workspace = true
 assets.workspace = true
 command_palette = { workspace = true, features = ["test-support"] }
 editor = { workspace = true, features = ["test-support"] }
-git_ui.workspace = true
+git_ui = { workspace = true, features = ["test-support"] }
+title_bar = { workspace = true, features = ["test-support"] }
 gpui = { workspace = true, features = ["test-support"] }
 indoc.workspace = true
 language = { workspace = true, features = ["test-support"] }


### PR DESCRIPTION
The `vim` crate's tests depend on `git_ui`, which transitively depends on `recent_projects` with `test-support` enabled. This causes `recent_projects` to include RemoteConnectionOptions::Mock` variant handling. However, `git_ui` was not enabling its `test-support` feature, causing compilation failures when the Mock variant was expected but not available.

This commit enables the `test-support` feature for both `git_ui` and `title_bar` dev-dependencies in the `vim` crate, ensuring the Mock variant is consistently available during testing.

Release Notes:

- N/A
