### PR TITLE
agent: Add Open Terminal option to Agent Panel

### DIFF
--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -56,6 +56,8 @@ actions!(
     [
         /// Creates a new text-based conversation thread.
         NewTextThread,
+        /// Opens a terminal in the Agent Panel.
+        OpenTerminal,
         /// Toggles the menu to create new agent threads.
         ToggleNewThreadMenu,
         /// Toggles the navigation menu for switching between threads and views.


### PR DESCRIPTION
Adds an "Open Terminal" option to the Agent Panel's "+" menu under External Agents. When clicked, it embeds a terminal directly in the Agent Panel, providing quick access to native CLI-based agent tools.

**Why this feature?**

While Zed's ACP (Agent Communication Protocol) is designed to provide a unified interface for external agents, this provides an escape hatch for developers who want to use native CLI agents (Claude Code CLI, OpenCode, Aider, Codex, etc.) within the Agent Panel UI without sacrificing their workspace layout:

- **Why not dock the terminal in the right panel?** - The terminal may already be in use in the bottom pane for running tests, builds, and other development tasks.
- **Why not just open a center pane with a terminal?** - Same reason panels exist at all - it's easier to keep tools contained and accessible without disrupting the editing flow.
- **Why not just use an external terminal and put it beside Zed?** - That works, but having it integrated in the Agent Panel keeps everything in one place and provides a more seamless workflow.

This complements rather than replaces ACP-based agents - it's positioned at the bottom of the External Agents section as a general-purpose option for CLI workflows.


Release Notes:

- Added `agent: open terminal` for running native CLI agents in the Agent Panel

### Screenshots

"Open Terminal" option

<img width="490" height="303" alt="Screenshot 2026-01-08 at 10 05 26 AM" src="https://github.com/user-attachments/assets/9f9a2e93-0fab-4129-9c1b-024b0176e88b" />

---

Native OpenCode CLI open in Agent panel terminal with regular terminal open in bottom dock

<img width="1728" height="1082" alt="Screenshot 2026-01-08 at 10 14 05 AM" src="https://github.com/user-attachments/assets/32029160-c21f-465b-957f-c90a0f1c8074" />
