### PR TITLE
agent: Make reject/accept keybindings consistent with restore/stage

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -203,8 +203,8 @@
   {
     "context": "Editor && editor_agent_diff",
     "bindings": {
-      "ctrl-y": "agent::Keep",
-      "ctrl-n": "agent::Reject",
+      "ctrl-alt-y": "agent::Keep",
+      "ctrl-alt-z": "agent::Reject",
       "ctrl-shift-y": "agent::KeepAll",
       "ctrl-shift-n": "agent::RejectAll",
       "shift-ctrl-r": "agent::OpenAgentDiff",
@@ -213,8 +213,8 @@
   {
     "context": "AgentDiff",
     "bindings": {
-      "ctrl-y": "agent::Keep",
-      "ctrl-n": "agent::Reject",
+      "ctrl-alt-y": "agent::Keep",
+      "ctrl-alt-z": "agent::Reject",
       "ctrl-shift-y": "agent::KeepAll",
       "ctrl-shift-n": "agent::RejectAll",
     },

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -241,8 +241,8 @@
     "context": "AgentDiff",
     "use_key_equivalents": true,
     "bindings": {
-      "cmd-y": "agent::Keep",
-      "cmd-n": "agent::Reject",
+      "cmd-alt-y": "agent::Keep",
+      "cmd-alt-z": "agent::Reject",
       "cmd-shift-y": "agent::KeepAll",
       "cmd-shift-n": "agent::RejectAll",
     },
@@ -251,8 +251,8 @@
     "context": "Editor && editor_agent_diff",
     "use_key_equivalents": true,
     "bindings": {
-      "cmd-y": "agent::Keep",
-      "cmd-n": "agent::Reject",
+      "cmd-alt-y": "agent::Keep",
+      "cmd-alt-z": "agent::Reject",
       "cmd-shift-y": "agent::KeepAll",
       "cmd-shift-n": "agent::RejectAll",
       "shift-ctrl-r": "agent::OpenAgentDiff",

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -202,8 +202,8 @@
     "context": "Editor && editor_agent_diff",
     "use_key_equivalents": true,
     "bindings": {
-      "ctrl-y": "agent::Keep",
-      "ctrl-n": "agent::Reject",
+      "ctrl-alt-y": "agent::Keep",
+      "ctrl-alt-z": "agent::Reject",
       "ctrl-shift-y": "agent::KeepAll",
       "ctrl-shift-n": "agent::RejectAll",
       "ctrl-shift-r": "agent::OpenAgentDiff",
@@ -213,8 +213,8 @@
     "context": "AgentDiff",
     "use_key_equivalents": true,
     "bindings": {
-      "ctrl-y": "agent::Keep",
-      "ctrl-n": "agent::Reject",
+      "ctrl-alt-y": "agent::Keep",
+      "ctrl-alt-z": "agent::Reject",
       "ctrl-shift-y": "agent::KeepAll",
       "ctrl-shift-n": "agent::RejectAll",
     },


### PR DESCRIPTION
This primarily frees up, for example, `cmd-n` to create a new untitled file if you're in the agent diff tab.

Release Notes:

- N/A
