### PR TITLE
Improve LSP button error message

### DIFF
--- a/crates/language_tools/src/lsp_button.rs
+++ b/crates/language_tools/src/lsp_button.rs
@@ -270,7 +270,15 @@ impl LanguageServerState {
                 .get(&server_info.id)
                 .and_then(|version| version.clone());
 
-            let metadata_label = match (&server_version, &message) {
+            let truncated_message = message.as_ref().and_then(|message| {
+                message
+                    .lines()
+                    .filter(|line| !line.trim().is_empty())
+                    .map(SharedString::new)
+                    .next()
+            });
+
+            let metadata_label = match (&server_version, &truncated_message) {
                 (None, None) => None,
                 (Some(version), None) => Some(SharedString::from(format!("v{}", version.as_ref()))),
                 (None, Some(message)) => Some(message.clone()),
@@ -492,7 +500,7 @@ impl LanguageServerState {
                                     .id("metadata-container")
                                     .ml_neg_1()
                                     .gap_1()
-                                    .max_w_56()
+                                    .max_w(rems(164.))
                                     .child(
                                         Icon::new(IconName::Circle)
                                             .color(status_color)
@@ -516,7 +524,6 @@ impl LanguageServerState {
                                                     .color(Color::Muted)
                                                     .truncate(),
                                             )
-                                            .tooltip(Tooltip::text(metadata.clone()))
                                     })
                                     .into_any_element()
                             }


### PR DESCRIPTION
Greatly increases max width of the message we show, but truncates the message to only ever show the first line

| LSP | OLD | NEW |
|-|-|-|
| JSON | <img width="720" height="199" alt="image" src="https://github.com/user-attachments/assets/77c2299a-0fd7-4210-9e50-b99c60b07f54" /> | <img width="1219" height="205" alt="Screenshot 2026-01-08 at 11 13 07 AM" src="https://github.com/user-attachments/assets/dfdb53a6-56e4-483a-8abc-25d99f0a5ae6" /> |
| PS1 | <img width="743" height="205" alt="image" src="https://github.com/user-attachments/assets/378d5d41-a005-4205-b3fc-956e227321c5" /> | <img width="1219" height="205" alt="Screenshot 2026-01-08 at 11 19 13 AM" src="https://github.com/user-attachments/assets/b8d05fb1-20f8-4983-be94-cb5735d84faf" /> |


Release Notes:

- N/A
