### PR TITLE
component_preview: Fix license symlink

### DIFF
--- a/crates/component_preview/LICENSE-GPL
+++ b/crates/component_preview/LICENSE-GPL
@@ -1,1 +1,1 @@
-LICENSE-GPL
+../../LICENSE-GPL


### PR DESCRIPTION
This PR fixes the symlink for the license in the `component_preview` crate, as it was referencing itself after https://github.com/zed-industries/zed/pull/45382.

Release Notes:

- N/A
