### PR TITLE
ep: Enable workspace test-support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5313,6 +5313,7 @@ dependencies = [
  "util",
  "wasmtime",
  "watch",
+ "workspace",
  "zeta_prompt",
 ]
 

--- a/crates/edit_prediction/Cargo.toml
+++ b/crates/edit_prediction/Cargo.toml
@@ -78,4 +78,5 @@ lsp.workspace = true
 parking_lot.workspace = true
 project = { workspace = true, features = ["test-support"] }
 settings = { workspace = true, features = ["test-support"] }
+workspace = { workspace = true, features = ["test-support"] }
 zlog.workspace = true

--- a/crates/edit_prediction_cli/Cargo.toml
+++ b/crates/edit_prediction_cli/Cargo.toml
@@ -67,8 +67,9 @@ similar = "2.7.0"
 ignored = ["wasmtime"]
 
 [dev-dependencies]
-indoc.workspace = true
 gpui = { workspace = true, features = ["test-support"] }
-project = { workspace = true, features = ["test-support"] }
+indoc.workspace = true
 pretty_assertions.workspace = true
+project = { workspace = true, features = ["test-support"] }
 tempfile.workspace = true
+workspace = { workspace = true, features = ["test-support"] }


### PR DESCRIPTION
Some code got added to `workspace` that prevents us from running tests for the `edit_prediction(cli)` crates specifically without the `test-support` feature flag.

Release Notes:

- N/A
