### PR TITLE
agent: Fix profiles tooltip border

### DIFF
--- a/crates/agent_ui/src/profile_selector.rs
+++ b/crates/agent_ui/src/profile_selector.rs
@@ -196,7 +196,7 @@ impl Render for ProfileSelector {
                         ))
                         .child(
                             container()
-                                .pb_1()
+                                .pt_1()
                                 .border_t_1()
                                 .border_color(cx.theme().colors().border_variant)
                                 .child(Label::new("Cycle Through Profiles"))

--- a/crates/agent_ui/src/profile_selector.rs
+++ b/crates/agent_ui/src/profile_selector.rs
@@ -197,7 +197,7 @@ impl Render for ProfileSelector {
                         .child(
                             container()
                                 .pb_1()
-                                .border_b_1()
+                                .border_t_1()
                                 .border_color(cx.theme().colors().border_variant)
                                 .child(Label::new("Cycle Through Profiles"))
                                 .child(KeyBinding::for_action_in(


### PR DESCRIPTION
One _character_ change to fix the dividing border in the agent panel's profile tooltip. 😬 

Release Notes:

- N/A
