### PR TITLE
git_ui: Add some fixes and improvements to the worktree picker

### DIFF
--- a/crates/git_ui/src/worktree_picker.rs
+++ b/crates/git_ui/src/worktree_picker.rs
@@ -18,7 +18,7 @@ use project::{
 use recent_projects::{RemoteConnectionModal, connect};
 use remote::{RemoteConnectionOptions, remote_client::ConnectionIdentifier};
 use std::{path::PathBuf, sync::Arc};
-use ui::{HighlightedLabel, KeyBinding, ListItem, ListItemSpacing, Tooltip, prelude::*};
+use ui::{HighlightedLabel, KeyBinding, ListItem, ListItemSpacing, prelude::*};
 use util::ResultExt;
 use workspace::{ModalView, Workspace, notifications::DetachAndPromptErr};
 


### PR DESCRIPTION
This PR adds some clean up to the worktree picker: making sure that worktree names render just one line, even when they might have multiple lines (that was making each line item break for me), removing superfluous icons, and making the footer controls more consistent with the branch picker, where the buttons change to "Create..." if you're in a state where the only match is the one to create a new worktree.

https://github.com/user-attachments/assets/e63aa8c9-b5a0-443d-a2ab-7759daed10d1

Release Notes:

- Git: Fixed some UI bugs in the worktree picker as well as improved the UX for creating worktrees based off of the current or default branch.
