### PR TITLE
Allow Escape to interrupt agent thread from conversation focus

### DIFF
--- a/crates/acp_thread/src/connection.rs
+++ b/crates/acp_thread/src/connection.rs
@@ -332,6 +332,7 @@ mod test_support {
         sessions: Arc<Mutex<HashMap<acp::SessionId, Session>>>,
         permission_requests: HashMap<acp::ToolCallId, Vec<acp::PermissionOption>>,
         next_prompt_updates: Arc<Mutex<Vec<acp::SessionUpdate>>>,
+        cancel_count: Arc<Mutex<usize>>,
     }
 
     struct Session {
@@ -345,7 +346,12 @@ mod test_support {
                 next_prompt_updates: Default::default(),
                 permission_requests: HashMap::default(),
                 sessions: Arc::default(),
+                cancel_count: Arc::default(),
             }
+        }
+
+        pub fn cancel_count(&self) -> usize {
+            *self.cancel_count.lock()
         }
 
         pub fn set_next_prompt_updates(&self, updates: Vec<acp::SessionUpdate>) {
@@ -513,6 +519,7 @@ mod test_support {
         }
 
         fn cancel(&self, session_id: &acp::SessionId, _cx: &mut App) {
+            *self.cancel_count.lock() += 1;
             if let Some(end_turn_tx) = self
                 .sessions
                 .lock()

--- a/crates/acp_thread/src/connection.rs
+++ b/crates/acp_thread/src/connection.rs
@@ -332,7 +332,6 @@ mod test_support {
         sessions: Arc<Mutex<HashMap<acp::SessionId, Session>>>,
         permission_requests: HashMap<acp::ToolCallId, Vec<acp::PermissionOption>>,
         next_prompt_updates: Arc<Mutex<Vec<acp::SessionUpdate>>>,
-        cancel_count: Arc<Mutex<usize>>,
     }
 
     struct Session {
@@ -346,12 +345,7 @@ mod test_support {
                 next_prompt_updates: Default::default(),
                 permission_requests: HashMap::default(),
                 sessions: Arc::default(),
-                cancel_count: Arc::default(),
             }
-        }
-
-        pub fn cancel_count(&self) -> usize {
-            *self.cancel_count.lock()
         }
 
         pub fn set_next_prompt_updates(&self, updates: Vec<acp::SessionUpdate>) {
@@ -519,7 +513,6 @@ mod test_support {
         }
 
         fn cancel(&self, session_id: &acp::SessionId, _cx: &mut App) {
-            *self.cancel_count.lock() += 1;
             if let Some(end_turn_tx) = self
                 .sessions
                 .lock()

--- a/crates/agent_ui/Cargo.toml
+++ b/crates/agent_ui/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/agent_ui.rs"
 doctest = false
 
 [features]
-test-support = ["assistant_text_thread/test-support", "acp_thread/test-support", "eval_utils", "gpui/test-support", "language/test-support", "reqwest_client", "workspace/test-support", "agent/test-support"]
+test-support = ["assistant_text_thread/test-support", "acp_thread/test-support", "eval_utils", "gpui/test-support", "language/test-support", "reqwest_client", "workspace/test-support", "agent/test-support", "rules_library/test-support"]
 unit-eval = []
 
 [dependencies]

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -8231,7 +8231,6 @@ pub(crate) mod tests {
         thread_view: Entity<AcpThreadView>,
         thread: Entity<AcpThread>,
         message_editor: Entity<MessageEditor>,
-        connection: StubAgentConnection,
     }
 
     async fn setup_generating_thread(
@@ -8279,7 +8278,6 @@ pub(crate) mod tests {
                 thread_view,
                 thread,
                 message_editor,
-                connection,
             },
             cx,
         )
@@ -8290,8 +8288,6 @@ pub(crate) mod tests {
         init_test(cx);
 
         let (setup, cx) = setup_generating_thread(cx).await;
-
-        assert_eq!(setup.connection.cancel_count(), 0);
 
         let focus_handle = setup
             .thread_view
@@ -8309,7 +8305,6 @@ pub(crate) mod tests {
         setup.thread.read_with(cx, |thread, _cx| {
             assert_eq!(thread.status(), ThreadStatus::Idle);
         });
-        assert_eq!(setup.connection.cancel_count(), 1);
     }
 
     #[gpui::test]
@@ -8317,8 +8312,6 @@ pub(crate) mod tests {
         init_test(cx);
 
         let (setup, cx) = setup_generating_thread(cx).await;
-
-        assert_eq!(setup.connection.cancel_count(), 0);
 
         let editor_focus_handle = setup
             .message_editor
@@ -8336,17 +8329,14 @@ pub(crate) mod tests {
         setup.thread.read_with(cx, |thread, _cx| {
             assert_eq!(thread.status(), ThreadStatus::Idle);
         });
-        assert_eq!(setup.connection.cancel_count(), 1);
     }
 
     #[gpui::test]
     async fn test_escape_when_idle_is_noop(cx: &mut TestAppContext) {
         init_test(cx);
 
-        let connection = StubAgentConnection::new();
-
         let (thread_view, cx) =
-            setup_thread_view(StubAgentServer::new(connection.clone()), cx).await;
+            setup_thread_view(StubAgentServer::new(StubAgentConnection::new()), cx).await;
         add_to_workspace(thread_view.clone(), cx);
 
         let thread = thread_view.read_with(cx, |view, _cx| view.thread().unwrap().clone());
@@ -8369,7 +8359,6 @@ pub(crate) mod tests {
         thread.read_with(cx, |thread, _cx| {
             assert_eq!(thread.status(), ThreadStatus::Idle);
         });
-        assert_eq!(connection.cancel_count(), 0);
     }
 
     #[gpui::test]

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -6788,6 +6788,9 @@ impl Render for AcpThreadView {
         v_flex()
             .size_full()
             .key_context("AcpThread")
+            .on_action(cx.listener(|this, _: &menu::Cancel, _, cx| {
+                this.cancel_generation(cx);
+            }))
             .on_action(cx.listener(Self::toggle_burn_mode))
             .on_action(cx.listener(Self::keep_all))
             .on_action(cx.listener(Self::reject_all))
@@ -8106,6 +8109,121 @@ pub(crate) mod tests {
                 user_message_editor.read(cx).text(cx),
                 "Edited message content"
             );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_escape_interrupts_thread_from_conversation_focus(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let connection = StubAgentConnection::new();
+
+        let (thread_view, cx) =
+            setup_thread_view(StubAgentServer::new(connection.clone()), cx).await;
+        add_to_workspace(thread_view.clone(), cx);
+
+        let message_editor = cx.read(|cx| thread_view.read(cx).message_editor.clone());
+        message_editor.update_in(cx, |editor, window, cx| {
+            editor.set_text("Hello", window, cx);
+        });
+        thread_view.update_in(cx, |thread_view, window, cx| {
+            thread_view.send(window, cx);
+        });
+
+        let (thread, session_id) = thread_view.read_with(cx, |view, cx| {
+            let thread = view.thread().unwrap();
+            (thread.clone(), thread.read(cx).session_id().clone())
+        });
+
+        cx.run_until_parked();
+
+        cx.update(|_, cx| {
+            connection.send_update(
+                session_id.clone(),
+                acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(
+                    "Response chunk".into(),
+                )),
+                cx,
+            );
+        });
+
+        cx.run_until_parked();
+
+        thread.read_with(cx, |thread, _cx| {
+            assert_eq!(thread.status(), ThreadStatus::Generating);
+        });
+
+        let focus_handle = thread_view.read_with(cx, |view, _cx| view.focus_handle.clone());
+        cx.update(|window, cx| {
+            window.focus(&focus_handle, cx);
+        });
+
+        thread_view.update_in(cx, |_, window, cx| {
+            window.dispatch_action(menu::Cancel.boxed_clone(), cx);
+        });
+
+        cx.run_until_parked();
+
+        thread.read_with(cx, |thread, _cx| {
+            assert_eq!(thread.status(), ThreadStatus::Idle);
+        });
+    }
+
+    #[gpui::test]
+    async fn test_escape_interrupts_thread_from_editor_focus(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let connection = StubAgentConnection::new();
+
+        let (thread_view, cx) =
+            setup_thread_view(StubAgentServer::new(connection.clone()), cx).await;
+        add_to_workspace(thread_view.clone(), cx);
+
+        let message_editor = cx.read(|cx| thread_view.read(cx).message_editor.clone());
+        message_editor.update_in(cx, |editor, window, cx| {
+            editor.set_text("Hello", window, cx);
+        });
+        thread_view.update_in(cx, |thread_view, window, cx| {
+            thread_view.send(window, cx);
+        });
+
+        let (thread, session_id) = thread_view.read_with(cx, |view, cx| {
+            let thread = view.thread().unwrap();
+            (thread.clone(), thread.read(cx).session_id().clone())
+        });
+
+        cx.run_until_parked();
+
+        cx.update(|_, cx| {
+            connection.send_update(
+                session_id.clone(),
+                acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(
+                    "Response chunk".into(),
+                )),
+                cx,
+            );
+        });
+
+        cx.run_until_parked();
+
+        thread.read_with(cx, |thread, _cx| {
+            assert_eq!(thread.status(), ThreadStatus::Generating);
+        });
+
+        let editor_focus_handle =
+            message_editor.read_with(cx, |editor, cx| editor.focus_handle(cx));
+        cx.update(|window, cx| {
+            window.focus(&editor_focus_handle, cx);
+        });
+
+        message_editor.update_in(cx, |_, window, cx| {
+            window.dispatch_action(editor::actions::Cancel.boxed_clone(), cx);
+        });
+
+        cx.run_until_parked();
+
+        thread.read_with(cx, |thread, _cx| {
+            assert_eq!(thread.status(), ThreadStatus::Idle);
         });
     }
 

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -8227,10 +8227,16 @@ pub(crate) mod tests {
         });
     }
 
-    #[gpui::test]
-    async fn test_escape_interrupts_thread_from_conversation_focus(cx: &mut TestAppContext) {
-        init_test(cx);
+    struct GeneratingThreadSetup {
+        thread_view: Entity<AcpThreadView>,
+        thread: Entity<AcpThread>,
+        message_editor: Entity<MessageEditor>,
+        connection: StubAgentConnection,
+    }
 
+    async fn setup_generating_thread(
+        cx: &mut TestAppContext,
+    ) -> (GeneratingThreadSetup, &mut VisualTestContext) {
         let connection = StubAgentConnection::new();
 
         let (thread_view, cx) =
@@ -8266,6 +8272,87 @@ pub(crate) mod tests {
 
         thread.read_with(cx, |thread, _cx| {
             assert_eq!(thread.status(), ThreadStatus::Generating);
+        });
+
+        (
+            GeneratingThreadSetup {
+                thread_view,
+                thread,
+                message_editor,
+                connection,
+            },
+            cx,
+        )
+    }
+
+    #[gpui::test]
+    async fn test_escape_cancels_generation_from_conversation_focus(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let (setup, cx) = setup_generating_thread(cx).await;
+
+        assert_eq!(setup.connection.cancel_count(), 0);
+
+        let focus_handle = setup
+            .thread_view
+            .read_with(cx, |view, _cx| view.focus_handle.clone());
+        cx.update(|window, cx| {
+            window.focus(&focus_handle, cx);
+        });
+
+        setup.thread_view.update_in(cx, |_, window, cx| {
+            window.dispatch_action(menu::Cancel.boxed_clone(), cx);
+        });
+
+        cx.run_until_parked();
+
+        setup.thread.read_with(cx, |thread, _cx| {
+            assert_eq!(thread.status(), ThreadStatus::Idle);
+        });
+        assert_eq!(setup.connection.cancel_count(), 1);
+    }
+
+    #[gpui::test]
+    async fn test_escape_cancels_generation_from_editor_focus(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let (setup, cx) = setup_generating_thread(cx).await;
+
+        assert_eq!(setup.connection.cancel_count(), 0);
+
+        let editor_focus_handle = setup
+            .message_editor
+            .read_with(cx, |editor, cx| editor.focus_handle(cx));
+        cx.update(|window, cx| {
+            window.focus(&editor_focus_handle, cx);
+        });
+
+        setup.message_editor.update_in(cx, |_, window, cx| {
+            window.dispatch_action(editor::actions::Cancel.boxed_clone(), cx);
+        });
+
+        cx.run_until_parked();
+
+        setup.thread.read_with(cx, |thread, _cx| {
+            assert_eq!(thread.status(), ThreadStatus::Idle);
+        });
+        assert_eq!(setup.connection.cancel_count(), 1);
+    }
+
+    #[gpui::test]
+    async fn test_escape_when_idle_is_noop(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let connection = StubAgentConnection::new();
+
+        let (thread_view, cx) =
+            setup_thread_view(StubAgentServer::new(connection.clone()), cx).await;
+        add_to_workspace(thread_view.clone(), cx);
+
+        let thread = thread_view.read_with(cx, |view, _cx| view.thread().unwrap().clone());
+
+        thread.read_with(cx, |thread, _cx| {
+            assert_eq!(thread.status(), ThreadStatus::Idle);
         });
 
         let focus_handle = thread_view.read_with(cx, |view, _cx| view.focus_handle.clone());
@@ -8282,64 +8369,7 @@ pub(crate) mod tests {
         thread.read_with(cx, |thread, _cx| {
             assert_eq!(thread.status(), ThreadStatus::Idle);
         });
-    }
-
-    #[gpui::test]
-    async fn test_escape_interrupts_thread_from_editor_focus(cx: &mut TestAppContext) {
-        init_test(cx);
-
-        let connection = StubAgentConnection::new();
-
-        let (thread_view, cx) =
-            setup_thread_view(StubAgentServer::new(connection.clone()), cx).await;
-        add_to_workspace(thread_view.clone(), cx);
-
-        let message_editor = cx.read(|cx| thread_view.read(cx).message_editor.clone());
-        message_editor.update_in(cx, |editor, window, cx| {
-            editor.set_text("Hello", window, cx);
-        });
-        thread_view.update_in(cx, |thread_view, window, cx| {
-            thread_view.send(window, cx);
-        });
-
-        let (thread, session_id) = thread_view.read_with(cx, |view, cx| {
-            let thread = view.thread().unwrap();
-            (thread.clone(), thread.read(cx).session_id().clone())
-        });
-
-        cx.run_until_parked();
-
-        cx.update(|_, cx| {
-            connection.send_update(
-                session_id.clone(),
-                acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(
-                    "Response chunk".into(),
-                )),
-                cx,
-            );
-        });
-
-        cx.run_until_parked();
-
-        thread.read_with(cx, |thread, _cx| {
-            assert_eq!(thread.status(), ThreadStatus::Generating);
-        });
-
-        let editor_focus_handle =
-            message_editor.read_with(cx, |editor, cx| editor.focus_handle(cx));
-        cx.update(|window, cx| {
-            window.focus(&editor_focus_handle, cx);
-        });
-
-        message_editor.update_in(cx, |_, window, cx| {
-            window.dispatch_action(editor::actions::Cancel.boxed_clone(), cx);
-        });
-
-        cx.run_until_parked();
-
-        thread.read_with(cx, |thread, _cx| {
-            assert_eq!(thread.status(), ThreadStatus::Idle);
-        });
+        assert_eq!(connection.cancel_count(), 0);
     }
 
     #[gpui::test]

--- a/crates/recent_projects/Cargo.toml
+++ b/crates/recent_projects/Cargo.toml
@@ -14,7 +14,7 @@ doctest = false
 
 [features]
 default = []
-test-support = ["remote/test-support"]
+test-support = ["remote/test-support", "project/test-support", "workspace/test-support"]
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/rules_library/Cargo.toml
+++ b/crates/rules_library/Cargo.toml
@@ -11,6 +11,9 @@ workspace = true
 [lib]
 path = "src/rules_library.rs"
 
+[features]
+test-support = ["title_bar/test-support"]
+
 [dependencies]
 anyhow.workspace = true
 collections.workspace = true


### PR DESCRIPTION
When focus is on the conversation part of the agent panel (not the message editor), pressing Escape now interrupts the running thread. Previously, Escape only worked when the message editor had focus.

Release Notes:

- Pressing Esc when the agent panel is focused now interrupts the running thread even if the text input box is not specifically focused.