### PR TITLE
Make apostrophes not brackets in markdown

### DIFF
--- a/crates/languages/src/markdown/brackets.scm
+++ b/crates/languages/src/markdown/brackets.scm
@@ -3,5 +3,4 @@
 ("{" @open "}" @close)
 (("\"" @open "\"" @close) (#set! rainbow.exclude))
 (("`" @open "`" @close) (#set! rainbow.exclude))
-(("'" @open "'" @close) (#set! rainbow.exclude))
 (((fenced_code_block_delimiter) @open (fenced_code_block_delimiter) @close) (#set! rainbow.exclude))


### PR DESCRIPTION
Closes #45912

Release Notes:

- Made apostrophes not brackets in markdown
