### PR TITLE
Add action listener to workspace for pane::CloseActiveItem

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -6231,6 +6231,24 @@ impl Workspace {
                     cx.propagate();
                 },
             ))
+            .on_action(cx.listener(
+                |workspace: &mut Workspace, action: &pane::CloseActiveItem, window, cx| {
+                    if let Some(active_dock) = workspace.active_dock(window, cx) {
+                        let dock = active_dock.read(cx);
+                        if let Some(active_panel) = dock.active_panel() {
+                            if active_panel.pane(cx).is_none() {
+                                let active_pane = workspace.active_pane().clone();
+                                active_pane.update(cx, |pane, cx| {
+                                    pane.close_active_item(action, window, cx)
+                                        .detach_and_log_err(cx);
+                                });
+                                return;
+                            }
+                        }
+                    }
+                    cx.propagate();
+                },
+            ))
             .on_action(
                 cx.listener(|workspace, _: &ToggleReadOnlyFile, window, cx| {
                     let pane = workspace.active_pane().clone();


### PR DESCRIPTION
Closes #45261


similar to #42588
this PR adds an action listener to the workspace that checks if the focus is currently on a dock that does not contain panes.
if that is true. it retrieves the active center pane from the workspace and closes the active item.

this improvement will allow users to set `cmd-w` to `pane::CloseActiveItem` instead of `workspace::CloseActiveDock` if that is the behavior they would prefer, which is also the typical behavior in most other editors.

here is a video showing the center panes being closed while focus is on the Project Panel. and the panes in the Terminal Panel closing as normal.

https://github.com/user-attachments/assets/2cdf8c35-ed22-4fac-a8c3-4f20f584b74e

Release Notes:

- Improved `pane::CloseActiveItem` to close center pane items even when focus is on a dock panel like the project panel or outline panel
