### PR TITLE
languages: Do not highlight JSX/TSX components too broadly

### DIFF
--- a/crates/languages/src/tsx/highlights.scm
+++ b/crates/languages/src/tsx/highlights.scm
@@ -381,11 +381,6 @@
   "override"
 ] @keyword
 
-; JSX elements
-(jsx_opening_element (identifier) @tag.jsx)
-(jsx_closing_element (identifier) @tag.jsx)
-(jsx_self_closing_element (identifier) @tag.jsx)
-
 (jsx_opening_element
   [
     (identifier) @type
@@ -394,7 +389,6 @@
       property: (property_identifier) @type
     )
   ]
-  (#match? @type "^[A-Z][^.]*$")
 )
 (jsx_closing_element
   [
@@ -404,7 +398,6 @@
       property: (property_identifier) @type
     )
   ]
-  (#match? @type "^[A-Z][^.]*$")
 )
 (jsx_self_closing_element
   [
@@ -414,8 +407,11 @@
       property: (property_identifier) @type
     )
   ]
-  (#match? @type "^[A-Z][^.]*$")
 )
+
+(jsx_opening_element (identifier) @tag.jsx (#match? @tag.jsx "^[a-z][^.]*$"))
+(jsx_closing_element (identifier) @tag.jsx (#match? @tag.jsx "^[a-z][^.]*$"))
+(jsx_self_closing_element (identifier) @tag.jsx (#match? @tag.jsx "^[a-z][^.]*$"))
 
 (jsx_attribute (property_identifier) @attribute.jsx)
 (jsx_opening_element (["<" ">"]) @punctuation.bracket.jsx)

--- a/crates/languages/src/tsx/highlights.scm
+++ b/crates/languages/src/tsx/highlights.scm
@@ -382,9 +382,9 @@
 ] @keyword
 
 ; JSX elements
-(jsx_opening_element (identifier) @tag.jsx (#match? @tag.jsx "^[a-z][^.]*$"))
-(jsx_closing_element (identifier) @tag.jsx (#match? @tag.jsx "^[a-z][^.]*$"))
-(jsx_self_closing_element (identifier) @tag.jsx (#match? @tag.jsx "^[a-z][^.]*$"))
+(jsx_opening_element (identifier) @tag.jsx)
+(jsx_closing_element (identifier) @tag.jsx)
+(jsx_self_closing_element (identifier) @tag.jsx)
 
 (jsx_opening_element
   [
@@ -394,6 +394,7 @@
       property: (property_identifier) @type
     )
   ]
+  (#match? @type "^[A-Z][^.]*$")
 )
 (jsx_closing_element
   [
@@ -403,6 +404,7 @@
       property: (property_identifier) @type
     )
   ]
+  (#match? @type "^[A-Z][^.]*$")
 )
 (jsx_self_closing_element
   [
@@ -412,6 +414,7 @@
       property: (property_identifier) @type
     )
   ]
+  (#match? @type "^[A-Z][^.]*$")
 )
 
 (jsx_attribute (property_identifier) @attribute.jsx)


### PR DESCRIPTION
Closes #46340

Release Notes:

- Fixed an issue where HTML tags where highlighted as JSX components.