### PR TITLE
remote: Add build-remote-server-binary for use in benchmarks

### DIFF
--- a/crates/remote/Cargo.toml
+++ b/crates/remote/Cargo.toml
@@ -15,6 +15,7 @@ doctest = false
 
 [features]
 default = []
+build-remote-server-binary = []
 test-support = ["fs/test-support"]
 
 [dependencies]

--- a/crates/remote/src/transport.rs
+++ b/crates/remote/src/transport.rs
@@ -170,7 +170,7 @@ fn handle_rpc_messages_over_child_process_stdio(
     })
 }
 
-#[cfg(debug_assertions)]
+#[cfg(any(debug_assertions, feature = "build-remote-server-binary"))]
 async fn build_remote_server_from_source(
     platform: &crate::RemotePlatform,
     delegate: &dyn crate::RemoteClientDelegate,
@@ -358,7 +358,7 @@ async fn build_remote_server_from_source(
     Ok(Some(path))
 }
 
-#[cfg(debug_assertions)]
+#[cfg(any(debug_assertions, feature = "build-remote-server-binary"))]
 async fn which(
     binary_name: impl AsRef<str>,
     cx: &mut AsyncApp,

--- a/crates/remote/src/transport/docker.rs
+++ b/crates/remote/src/transport/docker.rs
@@ -153,7 +153,7 @@ impl DockerExecConnection {
         let dst_path =
             paths::remote_server_dir_relative().join(RelPath::unix(&binary_name).unwrap());
 
-        #[cfg(debug_assertions)]
+        #[cfg(any(debug_assertions, feature = "build-remote-server-binary"))]
         if let Some(remote_server_path) =
             super::build_remote_server_from_source(&remote_platform, delegate.as_ref(), cx).await?
         {

--- a/crates/remote/src/transport/ssh.rs
+++ b/crates/remote/src/transport/ssh.rs
@@ -625,7 +625,7 @@ impl SshRemoteConnection {
         let dst_path =
             paths::remote_server_dir_relative().join(RelPath::unix(&binary_name).unwrap());
 
-        #[cfg(debug_assertions)]
+        #[cfg(any(debug_assertions, feature = "build-remote-server-binary"))]
         if let Some(remote_server_path) =
             super::build_remote_server_from_source(&self.ssh_platform, delegate.as_ref(), cx)
                 .await?

--- a/crates/remote/src/transport/wsl.rs
+++ b/crates/remote/src/transport/wsl.rs
@@ -181,7 +181,7 @@ impl WslRemoteConnection {
                 .map_err(|e| anyhow!("Failed to create directory: {}", e))?;
         }
 
-        #[cfg(debug_assertions)]
+        #[cfg(any(debug_assertions, feature = "build-remote-server-binary"))]
         if let Some(remote_server_path) =
             super::build_remote_server_from_source(&self.platform, delegate.as_ref(), cx).await?
         {


### PR DESCRIPTION
Benchmarks that depend on remote server would not rebuild the remote server binary outside of dev builds. Let dependants of remote opt into building the binary even in release builds.

Release Notes:

- N/A
