### PR TITLE
agent_ui: Add per-file and total number of lines added and removed

### DIFF
--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -4743,7 +4743,7 @@ impl AcpThreadView {
                 changed_buffers
                     .iter()
                     .enumerate()
-                    .flat_map(|(index, (buffer, _diff))| {
+                    .flat_map(|(index, (buffer, diff))| {
                         let file = buffer.read(cx).file()?;
                         let path = file.path();
                         let path_style = file.path_style(cx);
@@ -4769,7 +4769,7 @@ impl AcpThreadView {
                             Label::new(name.to_string())
                                 .size(LabelSize::XSmall)
                                 .buffer_font(cx)
-                                .ml_1p5()
+                                .ml_1()
                         });
 
                         let full_path = path.display(path_style).to_string();
@@ -4788,6 +4788,8 @@ impl AcpThreadView {
                             linear_color_stop(editor_bg_color, 1.),
                             linear_color_stop(editor_bg_color.opacity(0.2), 0.),
                         );
+
+                        let file_stats = DiffStats::single_file(buffer.read(cx), diff.read(cx), cx);
 
                         let element = h_flex()
                             .group("edited-code")
@@ -4818,6 +4820,14 @@ impl AcpThreadView {
                                             .child(file_icon)
                                             .children(file_name)
                                             .children(file_path)
+                                            .child(
+                                                DiffStat::new(
+                                                    "file",
+                                                    file_stats.lines_added as usize,
+                                                    file_stats.lines_removed as usize,
+                                                )
+                                                .label_size(LabelSize::XSmall),
+                                            )
                                             .tooltip(move |_, cx| {
                                                 Tooltip::with_meta(
                                                     "Go to File",

--- a/crates/ui/src/components/diff_stat.rs
+++ b/crates/ui/src/components/diff_stat.rs
@@ -5,6 +5,7 @@ pub struct DiffStat {
     id: ElementId,
     added: usize,
     removed: usize,
+    label_size: LabelSize,
 }
 
 impl DiffStat {
@@ -13,7 +14,13 @@ impl DiffStat {
             id: id.into(),
             added,
             removed,
+            label_size: LabelSize::Small,
         }
+    }
+
+    pub fn label_size(mut self, label_size: LabelSize) -> Self {
+        self.label_size = label_size;
+        self
     }
 }
 
@@ -33,7 +40,7 @@ impl RenderOnce for DiffStat {
                     .child(
                         Label::new(self.added.to_string())
                             .color(Color::Success)
-                            .size(LabelSize::Small),
+                            .size(self.label_size),
                     ),
             )
             .child(
@@ -47,7 +54,7 @@ impl RenderOnce for DiffStat {
                     .child(
                         Label::new(self.removed.to_string())
                             .color(Color::Error)
-                            .size(LabelSize::Small),
+                            .size(self.label_size),
                     ),
             )
     }


### PR DESCRIPTION
This PR adds the total and per-file number of lines added and removed per thread, using the same logic to compute these as in the commit view. Here's how they show up in the UI:

<img width="500" height="514" alt="Screenshot 2026-01-09 at 11  27@2x" src="https://github.com/user-attachments/assets/e3a4a14f-a4ee-4e95-a77b-86d14914e9d6" />

Release Notes:

- Agent: Added the total and per-file number of lines added and removed in a thread.
