### PR TITLE
remote: Pass `-q` on ssh remotes when running one shot commands

### DIFF
--- a/crates/remote/src/remote_client.rs
+++ b/crates/remote/src/remote_client.rs
@@ -491,7 +491,7 @@ impl RemoteClient {
         executor: BackgroundExecutor,
     ) -> Option<impl Future<Output = ()> + use<T>> {
         let state = self.state.take()?;
-        log::info!("shutting down ssh processes");
+        log::info!("shutting down remote processes");
 
         let State::Connected {
             multiplex_task,

--- a/crates/remote/src/transport/ssh.rs
+++ b/crates/remote/src/transport/ssh.rs
@@ -1552,6 +1552,9 @@ fn build_command(
         args.push(format!("{local_port}:{host}:{remote_port}"));
     }
 
+    // -q suppresses the "Connection to ... closed." message that SSH prints when
+    // the connection terminates with -t (pseudo-terminal allocation)
+    args.push("-q".into());
     args.push("-t".into());
     args.push(exec);
 
@@ -1592,6 +1595,7 @@ mod tests {
             [
                 "-p",
                 "2222",
+                "-q",
                 "-t",
                 "cd \"$HOME/work\" && exec env INPUT_VA=val remote_program arg1 arg2"
             ]
@@ -1624,6 +1628,7 @@ mod tests {
                 "2222",
                 "-L",
                 "1:foo:2",
+                "-q",
                 "-t",
                 "cd && exec env INPUT_VA=val /bin/fish -l"
             ]


### PR DESCRIPTION
This pollutes tasks and similar with a `connection closed` message otherwise.

Release Notes:

- Fixed terminal tool for agents ending with `connection closed` on remote hosts polluting context
