### PR TITLE
ep: Fix editable region for teacher models

### DIFF
--- a/crates/edit_prediction/src/udiff.rs
+++ b/crates/edit_prediction/src/udiff.rs
@@ -284,7 +284,7 @@ pub fn apply_diff_to_string(diff_str: &str, text: &str) -> Result<String> {
                     disambiguate_by_line_number(&candidates, hunk.start_line, |offset| {
                         text[..offset].matches('\n').count() as u32
                     })
-                    .ok_or_else(|| anyhow!("couldn't resolve hunk {:?}", hunk.context))?;
+                    .ok_or_else(|| anyhow!("couldn't resolve hunk: {}", hunk.context))?;
 
                 for edit in hunk.edits.iter().rev() {
                     let range = (hunk_offset + edit.range.start)..(hunk_offset + edit.range.end);

--- a/crates/edit_prediction/src/zeta2.rs
+++ b/crates/edit_prediction/src/zeta2.rs
@@ -18,8 +18,8 @@ use std::{path::Path, sync::Arc, time::Instant};
 use zeta_prompt::CURSOR_MARKER;
 use zeta_prompt::format_zeta_prompt;
 
-pub const MAX_CONTEXT_TOKENS: usize = 150;
-pub const MAX_REWRITE_TOKENS: usize = 350;
+pub const MAX_CONTEXT_TOKENS: usize = 350;
+pub const MAX_EDITABLE_TOKENS: usize = 150;
 
 pub fn request_prediction_with_zeta2(
     store: &mut EditPredictionStore,
@@ -206,8 +206,8 @@ pub fn zeta2_prompt_input(
         crate::cursor_excerpt::editable_and_context_ranges_for_cursor_position(
             cursor_point,
             snapshot,
+            MAX_EDITABLE_TOKENS,
             MAX_CONTEXT_TOKENS,
-            MAX_REWRITE_TOKENS,
         );
 
     let context_start_offset = context_range.start.to_offset(snapshot);

--- a/crates/edit_prediction_cli/src/load_project.rs
+++ b/crates/edit_prediction_cli/src/load_project.rs
@@ -44,7 +44,7 @@ pub async fn run_load_project(
         let (editable_range, context_range) = editable_and_context_ranges_for_cursor_position(
             cursor_point,
             &snapshot,
-            zeta2::MAX_REWRITE_TOKENS,
+            zeta2::MAX_EDITABLE_TOKENS,
             zeta2::MAX_CONTEXT_TOKENS,
         );
         let editable_range = editable_range.to_offset(&snapshot);


### PR DESCRIPTION
Editable region was different for Zeta2 and Teacher, leading to "Edits outside of editable region" errors.

Release Notes:

- N/A 