### PR TITLE
languages: Fix Python venv auto-activation for PowerShell 7

### DIFF
--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -1462,6 +1462,7 @@ async fn resolve_venv_activation_scripts(
             (ShellKind::Fish, "activate.fish"),
             (ShellKind::Nushell, "activate.nu"),
             (ShellKind::PowerShell, "activate.ps1"),
+            (ShellKind::Pwsh, "activate.ps1"),
             (ShellKind::Cmd, "activate.bat"),
             (ShellKind::Xonsh, "activate.xsh"),
         ] {


### PR DESCRIPTION
Summary
This PR fixes an issue where Python virtual environments (`venv`, `uv`, etc.) were not automatically activated when opening a terminal using PowerShell 7.

Details
`ShellKind` distinguishes between the legacy Windows PowerShell (`ShellKind::PowerShell`) and the newer PowerShell 7 (`ShellKind::Pwsh`). Previously, the logic in `resolve_venv_activation_scripts` only checked for `ShellKind::PowerShell`, causing `activate.ps1` resolution to fail for `Pwsh` users.
This change adds `ShellKind::Pwsh` to the resolution list, mapping it to `activate.ps1` just like the legacy PowerShell.

Release Notes:

- Fixed Python virtual environments not automatically activating in PowerShell 7
