### PR TITLE
Prepopulate empty patch in example capture

### DIFF
--- a/crates/edit_prediction/src/edit_prediction.rs
+++ b/crates/edit_prediction/src/edit_prediction.rs
@@ -1749,6 +1749,7 @@ impl EditPredictionStore {
                 active_buffer.clone(),
                 position,
                 events_for_capture,
+                false,
                 cx,
             ) {
                 cx.spawn(async move |_this, _cx| {

--- a/crates/edit_prediction_ui/src/edit_prediction_ui.rs
+++ b/crates/edit_prediction_ui/src/edit_prediction_ui.rs
@@ -154,7 +154,7 @@ fn capture_example_as_markdown(
     let events = ep_store.update(cx, |store, cx| {
         store.edit_history_for_project_with_pause_split_last_event(&project, cx)
     });
-    let example = capture_example(project.clone(), buffer, cursor_anchor, events, cx)?;
+    let example = capture_example(project.clone(), buffer, cursor_anchor, events, true, cx)?;
 
     let examples_dir = AllLanguageSettings::get_global(cx)
         .edit_predictions


### PR DESCRIPTION
This makes it a smoother workflow to capture an edit prediction example from Zed and then write what you'd expect the patch to be.

Release Notes:

- N/A