### PR TITLE
outline: Fix uninitiated var declaration not showing in outline

### DIFF
--- a/crates/languages/src/cpp/outline.scm
+++ b/crates/languages/src/cpp/outline.scm
@@ -51,10 +51,13 @@
         (type_qualifier)
     ]* @context
     type: (_) @context
-    declarator: (init_declarator
-      ; The declaration may define multiple variables, using @item on the
-      ; declarator so that they get distinct ranges.
-      declarator: (_) @item @name))
+    declarator: [
+        ; The declaration may define multiple variables, using @item on the
+        ; declarator so that they get distinct ranges.
+        (init_declarator
+            declarator: (_) @item @name)
+        (identifier) @item @name
+    ] @item)
 
 (function_definition
     (type_qualifier)? @context


### PR DESCRIPTION
For the following code, we didn't show anything; after the fix, they are shown in the outline:

<img width="617" height="170" alt="image" src="https://github.com/user-attachments/assets/091a905c-7c1c-4c3a-935f-65c2cd5ae2e5" />


Release Notes:

- Fix uninitiated var declaration is not shown in outline.
