### PR TITLE
project_symbols: Display line numbers in symbol picker

### DIFF
--- a/crates/project_symbols/src/project_symbols.rs
+++ b/crates/project_symbols/src/project_symbols.rs
@@ -246,7 +246,8 @@ impl PickerDelegate for ProjectSymbolsDelegate {
             } => abs_path.to_string_lossy(),
         };
         let label = symbol.label.text.clone();
-        let path = path.to_string();
+        let line_number = symbol.range.start.0.row + 1;
+        let path = format!("{}:{}", path, line_number);
 
         let settings = ThemeSettings::get_global(cx);
 

--- a/crates/project_symbols/src/project_symbols.rs
+++ b/crates/project_symbols/src/project_symbols.rs
@@ -247,7 +247,7 @@ impl PickerDelegate for ProjectSymbolsDelegate {
         };
         let label = symbol.label.text.clone();
         let line_number = symbol.range.start.0.row + 1;
-        let path = format!("{}:{}", path, line_number);
+        let path = path.into_owned();
 
         let settings = ThemeSettings::get_global(cx);
 
@@ -283,7 +283,15 @@ impl PickerDelegate for ProjectSymbolsDelegate {
                         .child(LabelLike::new().child(
                             StyledText::new(label).with_default_highlights(&text_style, highlights),
                         ))
-                        .child(Label::new(path).size(LabelSize::Small).color(Color::Muted)),
+                        .child(
+                            h_flex()
+                                .child(Label::new(path).size(LabelSize::Small).color(Color::Muted))
+                                .child(
+                                    Label::new(format!(":{}", line_number))
+                                        .size(LabelSize::Small)
+                                        .color(Color::Placeholder),
+                                ),
+                        ),
                 ),
         )
     }


### PR DESCRIPTION
Some language servers return local symbols in `workspace/symbol` responses, and languages like Julia can have multiple overloads for the same generic function name. In these cases, symbols may appear identical in the symbol picker, making it hard to distinguish between them. Adding line numbers helps users identify the correct symbol.

In the future, we may also want to consider using `containerName` from the LSP response for additional context.

> Before
<img width="671" height="573" alt="Screenshot 2026-01-10 at 19 21 08" src="https://github.com/user-attachments/assets/838c3eb7-0e1d-46ba-9076-286e971afc2c" />

> After
<img width="671" height="573" alt="Screenshot 2026-01-10 at 19 43 19" src="https://github.com/user-attachments/assets/31979d79-0169-4202-afc2-24fc7492dd47" />


Closes #ISSUE

Release Notes:

- Added line numbers to the project symbols picker to help distinguish between symbols with the same name
