### PR TITLE
Add diagnostic_color setting to color tab labels by severity

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1218,6 +1218,10 @@
     // 3. Mark files with errors and warnings:
     //    "all"
     "show_diagnostics": "off",
+    // Whether to color the tab label based on diagnostic severity.
+    // When enabled, tab labels will be colored red for errors and yellow for warnings.
+    // Requires `show_diagnostics` to be set to "errors" or "all".
+    "diagnostic_color": false,
   },
   // Settings related to preview tabs.
   "preview_tabs": {

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -678,7 +678,14 @@ impl Item for Editor {
     }
 
     fn tab_content(&self, params: TabContentParams, _: &Window, cx: &App) -> AnyElement {
-        let label_color = if ItemSettings::get_global(cx).git_status {
+        let item_settings = ItemSettings::get_global(cx);
+        let label_color = if item_settings.diagnostic_color {
+            if let Some(diagnostic_color) = params.diagnostic_color() {
+                diagnostic_color
+            } else {
+                entry_label_color(params.selected)
+            }
+        } else if item_settings.git_status {
             self.buffer()
                 .read(cx)
                 .as_singleton()

--- a/crates/settings/src/settings_content/workspace.rs
+++ b/crates/settings/src/settings_content/workspace.rs
@@ -142,6 +142,12 @@ pub struct ItemSettingsContent {
     ///
     /// Default: off
     pub show_diagnostics: Option<ShowDiagnostics>,
+    /// Whether to color the tab label based on diagnostic severity.
+    /// When enabled, tab labels will be colored red for errors and yellow for warnings.
+    /// Requires `show_diagnostics` to be set to "errors" or "all".
+    ///
+    /// Default: false
+    pub diagnostic_color: Option<bool>,
     /// Whether to always show the close button on tabs.
     ///
     /// Default: false

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -609,6 +609,7 @@ impl VsCodeSettings {
                     }
                 }),
             show_diagnostics: None,
+            diagnostic_color: None,
             show_close_button: self
                 .read_bool("workbench.editor.tabActionCloseVisibility")
                 .map(|b| {

--- a/crates/tab_switcher/src/tab_switcher.rs
+++ b/crates/tab_switcher/src/tab_switcher.rs
@@ -701,6 +701,7 @@ impl PickerDelegate for TabSwitcherDelegate {
             selected: true,
             preview: tab_match.preview,
             deemphasized: false,
+            diagnostic_severity: None,
         };
         let label = tab_match.item.tab_content(params, window, cx);
 

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -15,7 +15,7 @@ use gpui::{
     EventEmitter, FocusHandle, Focusable, Font, HighlightStyle, Pixels, Point, Render,
     SharedString, Task, WeakEntity, Window,
 };
-use language::Capability;
+use language::{Capability, DiagnosticSeverity};
 use project::{Project, ProjectEntryId, ProjectPath};
 pub use settings::{
     ActivateOnClose, ClosePosition, RegisterSetting, Settings, SettingsLocation, ShowCloseButton,
@@ -59,6 +59,7 @@ pub struct ItemSettings {
     pub activate_on_close: ActivateOnClose,
     pub file_icons: bool,
     pub show_diagnostics: ShowDiagnostics,
+    pub diagnostic_color: bool,
     pub show_close_button: ShowCloseButton,
 }
 
@@ -88,6 +89,7 @@ impl Settings for ItemSettings {
             activate_on_close: tabs.activate_on_close.unwrap(),
             file_icons: tabs.file_icons.unwrap(),
             show_diagnostics: tabs.show_diagnostics.unwrap(),
+            diagnostic_color: tabs.diagnostic_color.unwrap(),
             show_close_button: tabs.show_close_button.unwrap(),
         }
     }
@@ -139,6 +141,8 @@ pub struct TabContentParams {
     pub preview: bool,
     /// Tab content should be deemphasized when active pane does not have focus.
     pub deemphasized: bool,
+    /// The diagnostic severity for the tab, if any. This is used to color the tab label based on diagnostic severity.
+    pub diagnostic_severity: Option<DiagnosticSeverity>,
 }
 
 impl TabContentParams {
@@ -155,6 +159,15 @@ impl TabContentParams {
         } else {
             Color::Muted
         }
+    }
+    
+    /// Returns the diagnostic color if there is a diagnostic severity set.
+    pub fn diagnostic_color(&self) -> Option<Color> {
+        self.diagnostic_severity.map(|severity| match severity {
+            DiagnosticSeverity::ERROR => Color::Error,
+            DiagnosticSeverity::WARNING => Color::Warning,
+            _ => self.text_color(),
+        })
     }
 }
 

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -2609,20 +2609,21 @@ impl Pane {
             .map(|id| id == item.item_id())
             .unwrap_or(false);
 
+        let item_diagnostic = item
+            .project_path(cx)
+            .map_or(None, |project_path| self.diagnostics.get(&project_path));
+
         let label = item.tab_content(
             TabContentParams {
                 detail: Some(detail),
                 selected: is_active,
                 preview: is_preview,
                 deemphasized: !self.has_focus(window, cx),
+                diagnostic_severity: item_diagnostic.copied(),
             },
             window,
             cx,
         );
-
-        let item_diagnostic = item
-            .project_path(cx)
-            .map_or(None, |project_path| self.diagnostics.get(&project_path));
 
         let decorated_icon = item_diagnostic.map_or(None, |diagnostic| {
             let icon = match item.tab_icon(window, cx) {
@@ -4515,6 +4516,7 @@ impl Render for DraggedTab {
                 selected: false,
                 preview: false,
                 deemphasized: false,
+                diagnostic_severity: None,
             },
             window,
             cx,


### PR DESCRIPTION
This adds a new `tabs.diagnostic_color` setting that colors tab labels based on diagnostic severity (red for errors, yellow for warnings). The feature requires `show_diagnostics` to be set to "errors" or "all".


## as-is

// warning
<img width="674" height="520" alt="SCR-20260110-tkyv" src="https://github.com/user-attachments/assets/8ebcdcca-f161-42c1-88af-2f252c8c1c55" />

// error
<img width="979" height="533" alt="SCR-20260110-tlag" src="https://github.com/user-attachments/assets/a2e85275-27aa-47de-830e-8fe3a572677e" />

## to-be

// warning
<img width="1073" height="787" alt="SCR-20260110-tkpj" src="https://github.com/user-attachments/assets/e42c97b5-0ac1-4c96-ae1a-fa7cfa2bb847" />

// error
<img width="844" height="546" alt="SCR-20260110-tkdj" src="https://github.com/user-attachments/assets/9ae345d8-4876-46f9-a19f-2a6502190e4a" />


Closes #ISSUE

Release Notes:

-  Added `diagnostic_color` setting to color tab labels red for errors and yellow for warnings when diagnostics are present.
