### PR TITLE
Fix cancellation regression: make edit_file_tool handle cancellation

### DIFF
--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -1789,6 +1789,101 @@ async fn test_terminal_tool_cancellation_captures_output(cx: &mut TestAppContext
     verify_thread_recovery(&thread, &fake_model, cx).await;
 }
 
+#[gpui::test]
+async fn test_cancellation_aware_tool_responds_to_cancellation(cx: &mut TestAppContext) {
+    // This test verifies that tools which properly handle cancellation via
+    // `event_stream.cancelled_by_user()` (like edit_file_tool) respond promptly
+    // to cancellation and report that they were cancelled.
+    let ThreadTest { model, thread, .. } = setup(cx, TestModel::Fake).await;
+    always_allow_tools(cx);
+    let fake_model = model.as_fake();
+
+    let (tool, was_cancelled) = CancellationAwareTool::new();
+
+    let mut events = thread
+        .update(cx, |thread, cx| {
+            thread.add_tool(tool);
+            thread.send(
+                UserMessageId::new(),
+                ["call the cancellation aware tool"],
+                cx,
+            )
+        })
+        .unwrap();
+
+    cx.run_until_parked();
+
+    // Simulate the model calling the cancellation-aware tool
+    fake_model.send_last_completion_stream_event(LanguageModelCompletionEvent::ToolUse(
+        LanguageModelToolUse {
+            id: "cancellation_aware_1".into(),
+            name: "cancellation_aware".into(),
+            raw_input: r#"{}"#.into(),
+            input: json!({}),
+            is_input_complete: true,
+            thought_signature: None,
+        },
+    ));
+    fake_model.end_last_completion_stream();
+
+    cx.run_until_parked();
+
+    // Wait for the tool call to be reported
+    let mut tool_started = false;
+    let deadline = cx.executor().num_cpus() * 100;
+    for _ in 0..deadline {
+        cx.run_until_parked();
+
+        while let Some(Some(event)) = events.next().now_or_never() {
+            if let Ok(ThreadEvent::ToolCall(tool_call)) = &event {
+                if tool_call.title == "Cancellation Aware Tool" {
+                    tool_started = true;
+                    break;
+                }
+            }
+        }
+
+        if tool_started {
+            break;
+        }
+
+        cx.background_executor
+            .timer(Duration::from_millis(10))
+            .await;
+    }
+    assert!(tool_started, "expected cancellation aware tool to start");
+
+    // Cancel the thread and wait for it to complete
+    let cancel_task = thread.update(cx, |thread, cx| thread.cancel(cx));
+
+    // The cancel task should complete promptly because the tool handles cancellation
+    let timeout = cx.background_executor.timer(Duration::from_secs(5));
+    futures::select! {
+        _ = cancel_task.fuse() => {}
+        _ = timeout.fuse() => {
+            panic!("cancel task timed out - tool did not respond to cancellation");
+        }
+    }
+
+    // Verify the tool detected cancellation via its flag
+    assert!(
+        was_cancelled.load(std::sync::atomic::Ordering::SeqCst),
+        "tool should have detected cancellation via event_stream.cancelled_by_user()"
+    );
+
+    // Collect remaining events
+    let remaining_events = collect_events_until_stop(&mut events, cx).await;
+
+    // Verify we got a cancellation stop event
+    assert_eq!(
+        stop_events(remaining_events),
+        vec![acp::StopReason::Cancelled],
+    );
+
+    // Verify we can send a new message after cancellation
+    verify_thread_recovery(&thread, &fake_model, cx).await;
+}
+
 /// Helper to verify thread can recover after cancellation by sending a simple message.
 async fn verify_thread_recovery(
     thread: &Entity<Thread>,
@@ -3236,6 +3331,7 @@ async fn setup(cx: &mut TestAppContext, model: TestModel) -> ThreadTest {
                             WordListTool::name(): true,
                             ToolRequiringPermission::name(): true,
                             InfiniteTool::name(): true,
+                            CancellationAwareTool::name(): true,
                             ThinkingTool::name(): true,
                             "terminal": true,
                         }

--- a/crates/agent/src/tools/copy_path_tool.rs
+++ b/crates/agent/src/tools/copy_path_tool.rs
@@ -1,6 +1,7 @@
 use crate::{AgentTool, ToolCallEventStream};
 use agent_client_protocol::ToolKind;
 use anyhow::{Context as _, Result, anyhow};
+use futures::FutureExt as _;
 use gpui::{App, AppContext, Entity, Task};
 use project::Project;
 use schemars::JsonSchema;
@@ -75,7 +76,7 @@ impl AgentTool for CopyPathTool {
     fn run(
         self: Arc<Self>,
         input: Self::Input,
-        _event_stream: ToolCallEventStream,
+        event_stream: ToolCallEventStream,
         cx: &mut App,
     ) -> Task<Result<Self::Output>> {
         let copy_task = self.project.update(cx, |project, cx| {
@@ -98,7 +99,13 @@ impl AgentTool for CopyPathTool {
         });
 
         cx.background_spawn(async move {
-            let _ = copy_task.await.with_context(|| {
+            let result = futures::select! {
+                result = copy_task.fuse() => result,
+                _ = event_stream.cancelled_by_user().fuse() => {
+                    anyhow::bail!("Copy cancelled by user");
+                }
+            };
+            let _ = result.with_context(|| {
                 format!(
                     "Copying {} to {}",
                     input.source_path, input.destination_path

--- a/crates/agent/src/tools/fetch_tool.rs
+++ b/crates/agent/src/tools/fetch_tool.rs
@@ -4,7 +4,7 @@ use std::{borrow::Cow, cell::RefCell};
 
 use agent_client_protocol as acp;
 use anyhow::{Context as _, Result, bail};
-use futures::AsyncReadExt as _;
+use futures::{AsyncReadExt as _, FutureExt as _};
 use gpui::{App, AppContext as _, Task};
 use html_to_markdown::{TagHandler, convert_html_to_markdown, markdown};
 use http_client::{AsyncBody, HttpClientWithUrl};
@@ -145,7 +145,7 @@ impl AgentTool for FetchTool {
     ) -> Task<Result<Self::Output>> {
         let authorize = event_stream.authorize(input.url.clone(), cx);
 
-        let text = cx.background_spawn({
+        let fetch_task = cx.background_spawn({
             let http_client = self.http_client.clone();
             async move {
                 authorize.await?;
@@ -154,7 +154,12 @@ impl AgentTool for FetchTool {
         });
 
         cx.foreground_executor().spawn(async move {
-            let text = text.await?;
+            let text = futures::select! {
+                result = fetch_task.fuse() => result?,
+                _ = event_stream.cancelled_by_user().fuse() => {
+                    anyhow::bail!("Fetch cancelled by user");
+                }
+            };
             if text.trim().is_empty() {
                 bail!("no textual content found");
             }

--- a/crates/agent/src/tools/find_path_tool.rs
+++ b/crates/agent/src/tools/find_path_tool.rs
@@ -1,6 +1,7 @@
 use crate::{AgentTool, ToolCallEventStream};
 use agent_client_protocol as acp;
 use anyhow::{Result, anyhow};
+use futures::FutureExt as _;
 use gpui::{App, AppContext, Entity, SharedString, Task};
 use language_model::LanguageModelToolResultContent;
 use project::Project;
@@ -114,7 +115,12 @@ impl AgentTool for FindPathTool {
         let search_paths_task = search_paths(&input.glob, self.project.clone(), cx);
 
         cx.background_spawn(async move {
-            let matches = search_paths_task.await?;
+            let matches = futures::select! {
+                result = search_paths_task.fuse() => result?,
+                _ = event_stream.cancelled_by_user().fuse() => {
+                    anyhow::bail!("Path search cancelled by user");
+                }
+            };
             let paginated_matches: &[PathBuf] = &matches[cmp::min(input.offset, matches.len())
                 ..cmp::min(input.offset + RESULTS_PER_PAGE, matches.len())];
 

--- a/crates/agent/src/tools/read_file_tool.rs
+++ b/crates/agent/src/tools/read_file_tool.rs
@@ -1,6 +1,7 @@
 use action_log::ActionLog;
 use agent_client_protocol::{self as acp, ToolCallUpdateFields};
 use anyhow::{Context as _, Result, anyhow};
+use futures::FutureExt as _;
 use gpui::{App, Entity, SharedString, Task, WeakEntity};
 use indoc::formatdoc;
 use language::Point;
@@ -192,13 +193,18 @@ impl AgentTool for ReadFileTool {
         let action_log = self.action_log.clone();
 
         cx.spawn(async move |cx| {
-            let buffer = cx
-                .update(|cx| {
-                    project.update(cx, |project, cx| {
-                        project.open_buffer(project_path.clone(), cx)
-                    })
+            let open_buffer_task = cx.update(|cx| {
+                project.update(cx, |project, cx| {
+                    project.open_buffer(project_path.clone(), cx)
                 })
-                .await?;
+            });
+
+            let buffer = futures::select! {
+                result = open_buffer_task.fuse() => result?,
+                _ = event_stream.cancelled_by_user().fuse() => {
+                    anyhow::bail!("File read cancelled by user");
+                }
+            };
             if buffer.read_with(cx, |buffer, _| {
                 buffer
                     .file()

--- a/crates/agent/src/tools/save_file_tool.rs
+++ b/crates/agent/src/tools/save_file_tool.rs
@@ -1,6 +1,7 @@
 use agent_client_protocol as acp;
 use anyhow::Result;
 use collections::FxHashSet;
+use futures::FutureExt as _;
 use gpui::{App, Entity, SharedString, Task};
 use language::Buffer;
 use project::Project;
@@ -58,7 +59,7 @@ impl AgentTool for SaveFileTool {
     fn run(
         self: Arc<Self>,
         input: Self::Input,
-        _event_stream: ToolCallEventStream,
+        event_stream: ToolCallEventStream,
         cx: &mut App,
     ) -> Task<Result<String>> {
         let project = self.project.clone();
@@ -85,11 +86,18 @@ impl AgentTool for SaveFileTool {
                 let open_buffer_task =
                     project.update(cx, |project, cx| project.open_buffer(project_path, cx));
 
-                let buffer = match open_buffer_task.await {
-                    Ok(buffer) => buffer,
-                    Err(error) => {
-                        open_errors.push((path, error.to_string()));
-                        continue;
+                let buffer = futures::select! {
+                    result = open_buffer_task.fuse() => {
+                        match result {
+                            Ok(buffer) => buffer,
+                            Err(error) => {
+                                open_errors.push((path, error.to_string()));
+                                continue;
+                            }
+                        }
+                    }
+                    _ = event_stream.cancelled_by_user().fuse() => {
+                        anyhow::bail!("Save cancelled by user");
                     }
                 };
 
@@ -116,7 +124,13 @@ impl AgentTool for SaveFileTool {
 
                 let save_task = project.update(cx, |project, cx| project.save_buffer(buffer, cx));
 
-                if let Err(error) = save_task.await {
+                let save_result = futures::select! {
+                    result = save_task.fuse() => result,
+                    _ = event_stream.cancelled_by_user().fuse() => {
+                        anyhow::bail!("Save cancelled by user");
+                    }
+                };
+                if let Err(error) = save_result {
                     save_errors.push((path_for_buffer, error.to_string()));
                 }
             }


### PR DESCRIPTION
PR #46306 changed cancellation to wait for tools to complete before returning. This was correct behavior - it allows tools like terminal to capture their output on cancellation. The real issue was that many tools didn't check for cancellation, so they would continue running until they finished.

## The Problem

When the user pressed Escape to cancel during a tool operation, tools would continue running because they never checked for the cancellation signal. The thread correctly waited for tools to complete (so terminal could capture output), but tools like edit_file, grep, fetch, etc. would just keep going.

## The Fix

Add cancellation handling to all tools using the same pattern as `terminal_tool`: use `select!` to race between the tool's main work and `event_stream.cancelled_by_user()`. When cancelled, tools break out of their loops or return early.

## All Tools Now Cancellation-Aware

| Tool | Change |
|------|--------|
| `edit_file_tool` | Checks cancellation in edit event processing loop |
| `terminal_tool` | Already handled cancellation |
| `grep_tool` | Checks cancellation in search result iteration loop |
| `fetch_tool` | Checks cancellation during HTTP fetch |
| `web_search_tool` | Checks cancellation during web search |
| `find_path_tool` | Checks cancellation during path search |
| `read_file_tool` | Checks cancellation during buffer open |
| `copy_path_tool` | Checks cancellation during file copy |
| `move_path_tool` | Checks cancellation during file move/rename |
| `delete_path_tool` | Checks cancellation during delete operation |
| `create_directory_tool` | Checks cancellation during directory creation |
| `save_file_tool` | Checks cancellation during buffer open and save |
| `restore_file_from_disk_tool` | Checks cancellation during buffer open and reload |
| `open_tool` | Checks cancellation during authorization |
| `diagnostics_tool` | Checks cancellation during buffer open |
| `ContextServerTool` (MCP) | Checks cancellation during external server calls |

**Synchronous tools (no async work, return immediately):**
- `list_directory_tool` - Reads worktree snapshot synchronously
- `now_tool` - Returns current time immediately
- `thinking_tool` - Returns immediately

## MCP Tools Automatically Handled

MCP tools (user-defined tools via context servers) are now automatically cancellation-aware without any user action. The `ContextServerTool` wrapper races the external server request against `event_stream.cancelled_by_user()`.

## Testing

- Added `CancellationAwareTool` test helper that mirrors the cancellation pattern
- Updated `test_cancellation_aware_tool_responds_to_cancellation` to properly await the cancel task and verify the tool detected cancellation

Release Notes:

- Fixed a regression where pressing Escape wouldn't immediately cancel in-progress tool operations