### PR TITLE
agent: Add "open claude code" command

### DIFF
--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -340,6 +340,8 @@ pub mod agent {
             OpenAcpOnboardingModal,
             /// Opens the Claude Code onboarding modal.
             OpenClaudeCodeOnboardingModal,
+            /// Opens Claude Code in the agent panel.
+            OpenClaudeCode,
             /// Resets the agent onboarding state.
             ResetOnboarding,
             /// Starts a chat conversation with the agent.


### PR DESCRIPTION
Hello Zed team! 

I primarily use Claude Code and found myself wishing there was an easier way to navigate to Claude Code from within Zed, so I thought I would try my hand at implementing this (with some help from Claude Code, of course).

The change is small, but I'm a Rust newbie with only a few weeks of experience. I have also never programmed in gpui or contributed to Zed before (besides a simple keymap change). Any feedback at all would be appreciated.

<img width="1144" height="724" alt="image" src="https://github.com/user-attachments/assets/2cc3731c-6932-4a45-8d4a-d1a6a0302248" />

---

Adds a new command `agent: open claude code`.

Behavior:
- Opens Claude Code in the agent panel
- Reuses existing Claude Code thread if one is already open
- Creates a new thread if switching from a different agent type

Includes unit tests for both scenarios.

Release Notes:

- Added `agent: open claude code` action to quickly navigate to Claude Code in the agent panel.
