### PR TITLE
remote: Support local terminals in remote projects

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -11265,7 +11265,14 @@ impl Editor {
             .to_path_buf();
             Some(parent)
         }) {
-            window.dispatch_action(OpenTerminal { working_directory }.boxed_clone(), cx);
+            window.dispatch_action(
+                OpenTerminal {
+                    working_directory,
+                    local: false,
+                }
+                .boxed_clone(),
+                cx,
+            );
         }
     }
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -4282,6 +4282,7 @@ impl EditorElement {
                                         window.dispatch_action(
                                             OpenTerminal {
                                                 working_directory: parent_abs_path.clone(),
+                                                local: false,
                                             }
                                             .boxed_clone(),
                                             cx,

--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -2036,7 +2036,11 @@ impl OutlinePanel {
 
         if let Some(working_directory) = working_directory {
             window.dispatch_action(
-                workspace::OpenTerminal { working_directory }.boxed_clone(),
+                workspace::OpenTerminal {
+                    working_directory,
+                    local: false,
+                }
+                .boxed_clone(),
                 cx,
             )
         }

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -3156,7 +3156,11 @@ impl ProjectPanel {
             };
             if let Some(working_directory) = working_directory {
                 window.dispatch_action(
-                    workspace::OpenTerminal { working_directory }.boxed_clone(),
+                    workspace::OpenTerminal {
+                        working_directory,
+                        local: false,
+                    }
+                    .boxed_clone(),
                     cx,
                 )
             }

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -29,9 +29,9 @@ use util::{ResultExt, TryFutureExt};
 use workspace::{
     ActivateNextPane, ActivatePane, ActivatePaneDown, ActivatePaneLeft, ActivatePaneRight,
     ActivatePaneUp, ActivatePreviousPane, DraggedSelection, DraggedTab, ItemId, MoveItemToPane,
-    MoveItemToPaneInDirection, MovePaneDown, MovePaneLeft, MovePaneRight, MovePaneUp,
-    Pane, PaneGroup, SplitDirection, SplitDown, SplitLeft, SplitMode, SplitRight, SplitUp,
-    SwapPaneDown, SwapPaneLeft, SwapPaneRight, SwapPaneUp, ToggleZoom, Workspace,
+    MoveItemToPaneInDirection, MovePaneDown, MovePaneLeft, MovePaneRight, MovePaneUp, Pane,
+    PaneGroup, SplitDirection, SplitDown, SplitLeft, SplitMode, SplitRight, SplitUp, SwapPaneDown,
+    SwapPaneLeft, SwapPaneRight, SwapPaneUp, ToggleZoom, Workspace,
     dock::{DockPosition, Panel, PanelEvent, PanelHandle},
     item::SerializableItem,
     move_active_item, move_item, pane,

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -2021,7 +2021,6 @@ mod tests {
         let fs = FakeFs::new(cx.executor());
         let project = Project::test(fs, [], cx).await;
 
-        // Test that create_local_terminal successfully creates a terminal
         let terminal = project
             .update(cx, |project, cx| project.create_local_terminal(cx))
             .await;
@@ -2029,6 +2028,32 @@ mod tests {
         assert!(
             terminal.is_ok(),
             "create_local_terminal should successfully create a terminal"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_local_terminal_in_local_project_with_directory(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            "/test-project",
+            serde_json::json!({
+                "file.txt": "content"
+            }),
+        )
+        .await;
+
+        let project = Project::test(fs, [std::path::Path::new("/test-project")], cx).await;
+
+        // Verify create_local_terminal works in local projects with worktrees
+        let terminal = project
+            .update(cx, |project, cx| project.create_local_terminal(cx))
+            .await;
+
+        assert!(
+            terminal.is_ok(),
+            "create_local_terminal should work in local projects with worktrees"
         );
     }
 

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -2019,15 +2019,7 @@ mod tests {
         init_test(cx);
 
         let fs = FakeFs::new(cx.executor());
-        fs.insert_tree(
-            "/test-project",
-            serde_json::json!({
-                "file.txt": "content"
-            }),
-        )
-        .await;
-
-        let project = Project::test(fs, [std::path::Path::new("/test-project")], cx).await;
+        let project = Project::test(fs, [], cx).await;
         let workspace = cx.add_window(|window, cx| Workspace::test_new(project, window, cx));
 
         let (window_handle, terminal_panel) = workspace

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -3134,6 +3134,7 @@ impl Pane {
                                             window.dispatch_action(
                                                 OpenTerminal {
                                                     working_directory: parent_abs_path.clone(),
+                                                    local: false,
                                                 }
                                                 .boxed_clone(),
                                                 cx,
@@ -3891,7 +3892,7 @@ fn default_render_tab_bar_buttons(
                             )
                             .action("Search Symbols", ToggleProjectSymbols.boxed_clone())
                             .separator()
-                            .action("New Terminal", NewTerminal.boxed_clone())
+                            .action("New Terminal", NewTerminal::default().boxed_clone())
                     }))
                 }),
         )

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -231,8 +231,6 @@ actions!(
         FollowNextCollaborator,
         /// Moves the focused panel to the next position.
         MoveFocusedPanelToNextPosition,
-        /// Opens a new terminal in the center.
-        NewCenterTerminal,
         /// Creates a new file.
         NewFile,
         /// Creates a new file in a vertical split.
@@ -241,8 +239,6 @@ actions!(
         NewFileSplitHorizontal,
         /// Opens a new search.
         NewSearch,
-        /// Opens a new terminal.
-        NewTerminal,
         /// Opens a new window.
         NewWindow,
         /// Opens a file or directory.
@@ -406,6 +402,26 @@ pub struct ToggleFileFinder {
     pub separate_history: bool,
 }
 
+/// Opens a new terminal in the center.
+#[derive(Default, PartialEq, Eq, Clone, Deserialize, JsonSchema, Action)]
+#[action(namespace = workspace)]
+#[serde(deny_unknown_fields)]
+pub struct NewCenterTerminal {
+    /// If true, creates a local terminal even in remote projects.
+    #[serde(default)]
+    pub local: bool,
+}
+
+/// Opens a new terminal.
+#[derive(Default, PartialEq, Eq, Clone, Deserialize, JsonSchema, Action)]
+#[action(namespace = workspace)]
+#[serde(deny_unknown_fields)]
+pub struct NewTerminal {
+    /// If true, creates a local terminal even in remote projects.
+    #[serde(default)]
+    pub local: bool,
+}
+
 /// Increases size of a currently focused dock by a given amount of pixels.
 #[derive(Clone, PartialEq, Deserialize, JsonSchema, Action)]
 #[action(namespace = workspace)]
@@ -535,6 +551,9 @@ impl PartialEq for Toast {
 #[serde(deny_unknown_fields)]
 pub struct OpenTerminal {
     pub working_directory: PathBuf,
+    /// If true, creates a local terminal even in remote projects.
+    #[serde(default)]
+    pub local: bool,
 }
 
 #[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]


### PR DESCRIPTION
This PR adds the ability to open local terminals when working in remote projects. When working in a remote (often actually remoting into a local container) I always need to run separate terminals outside Zed so I can run local build tools, scripts, agents, etc. for the related project. I'd like to be able to run all of these in the same Zed window and this adds that ability via one-off local terminals.

## Changes

Adds an optional `local` parameter to terminal commands. When set to `true`, creates a local shell on your machine instead of connecting to the remote.

### Implementation
- Added `force_local` parameter to terminal creation logic
- Created `create_local_terminal()` method that bypasses remote client
- Updated terminal actions (`NewTerminal`, `NewCenterTerminal`) to accept optional `local: bool` field (defaults to `false`)

### Usage

**Via keybinding:**
```json
{
  "bindings": {
    "cmd-t": "workspace::NewCenterTerminal",
    "cmd-T": ["workspace::NewCenterTerminal", { "local": true }]
  }
},
{
  "context": "Terminal",
  "bindings": {
    "cmd-n": "workspace::NewTerminal",
    "cmd-N": ["workspace::NewTerminal", { "local": true }],
  },
},
```

**Behavior:**
- Default terminal commands continue to work as before (remote in remote projects, local in local projects)
- The `local` parameter is optional and defaults to `false`

Release Notes:

- Added support for opening local terminals in remote projects via `local` parameter on terminal commands.
