### PR TITLE
search: Use memchr::memmem instead of aho-corasick

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12519,7 +12519,6 @@ dependencies = [
 name = "project"
 version = "0.1.0"
 dependencies = [
- "aho-corasick",
  "anyhow",
  "askpass",
  "async-trait",
@@ -12552,6 +12551,7 @@ dependencies = [
  "log",
  "lsp",
  "markdown",
+ "memchr",
  "node_runtime",
  "parking_lot",
  "paths",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -544,6 +544,7 @@ log = { version = "0.4.16", features = ["kv_unstable_serde", "serde"] }
 lsp-types = { git = "https://github.com/zed-industries/lsp-types", rev = "b71ab4eeb27d9758be8092020a46fe33fbca4e33" }
 mach2 = "0.5"
 markup5ever_rcdom = "0.3.0"
+memchr = "2.7"
 metal = "0.29"
 minidumper = "0.8"
 moka = { version = "0.12.10", features = ["sync"] }

--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -29,7 +29,7 @@ test-support = [
 ]
 
 [dependencies]
-aho-corasick.workspace = true
+memchr.workspace = true
 anyhow.workspace = true
 askpass.workspace = true
 async-trait.workspace = true


### PR DESCRIPTION
We're always using just one pattern, so let's not bother with going through Aho-Corasick in such cases

Release Notes:

- Improved latency of project search results
