### PR TITLE
Enable extended reasoning for Anthropic models in Copilot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3696,6 +3696,7 @@ dependencies = [
 name = "copilot_chat"
 version = "0.1.0"
 dependencies = [
+ "anthropic",
  "anyhow",
  "collections",
  "dirs 4.0.0",

--- a/crates/anthropic/src/anthropic.rs
+++ b/crates/anthropic/src/anthropic.rs
@@ -995,7 +995,7 @@ pub enum Speed {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-struct StreamingRequest {
+pub struct StreamingRequest {
     #[serde(flatten)]
     pub base: Request,
     pub stream: bool,

--- a/crates/copilot_chat/Cargo.toml
+++ b/crates/copilot_chat/Cargo.toml
@@ -21,6 +21,7 @@ test-support = [
 ]
 
 [dependencies]
+anthropic.workspace = true
 anyhow.workspace = true
 collections.workspace = true
 dirs.workspace = true

--- a/crates/copilot_chat/src/copilot_chat.rs
+++ b/crates/copilot_chat/src/copilot_chat.rs
@@ -860,7 +860,7 @@ pub(crate) fn copilot_request_headers(
                 option_env!("CARGO_PKG_VERSION").unwrap_or("unknown")
             ),
         )
-        .header("X-GitHub-Api-Version", "2025-05-01")
+        .header("X-GitHub-Api-Version", "2025-10-01")
         .when_some(is_user_initiated, |builder, is_user_initiated| {
             builder.header(
                 "X-Initiator",

--- a/crates/copilot_chat/src/copilot_chat.rs
+++ b/crates/copilot_chat/src/copilot_chat.rs
@@ -52,6 +52,10 @@ impl CopilotChatConfiguration {
         format!("{}/responses", api_endpoint)
     }
 
+    pub fn messages_url(&self, api_endpoint: &str) -> String {
+        format!("{}/v1/messages", api_endpoint)
+    }
+
     pub fn models_url(&self, api_endpoint: &str) -> String {
         format!("{}/models", api_endpoint)
     }
@@ -203,6 +207,14 @@ struct ModelSupportedFeatures {
     parallel_tool_calls: bool,
     #[serde(default)]
     vision: bool,
+    #[serde(default)]
+    thinking: bool,
+    #[serde(default)]
+    adaptive_thinking: bool,
+    #[serde(default)]
+    max_thinking_budget: Option<u32>,
+    #[serde(default)]
+    min_thinking_budget: Option<u32>,
 }
 
 #[derive(Clone, Copy, Serialize, Deserialize, Debug, Eq, PartialEq)]
@@ -282,6 +294,31 @@ impl Model {
             && self
                 .supported_endpoints
                 .contains(&ModelSupportedEndpoint::Responses)
+    }
+
+    pub fn supports_messages(&self) -> bool {
+        self.supported_endpoints
+            .contains(&ModelSupportedEndpoint::Messages)
+    }
+
+    pub fn supports_thinking(&self) -> bool {
+        self.capabilities.supports.thinking
+    }
+
+    pub fn supports_adaptive_thinking(&self) -> bool {
+        self.capabilities.supports.adaptive_thinking
+    }
+
+    pub fn max_thinking_budget(&self) -> Option<u32> {
+        self.capabilities.supports.max_thinking_budget
+    }
+
+    pub fn min_thinking_budget(&self) -> Option<u32> {
+        self.capabilities.supports.min_thinking_budget
+    }
+
+    pub fn family(&self) -> &str {
+        &self.capabilities.family
     }
 
     pub fn multiplier(&self) -> f64 {
@@ -619,6 +656,29 @@ impl CopilotChat {
         .await
     }
 
+    pub async fn stream_messages(
+        body: String,
+        location: ChatLocation,
+        is_user_initiated: bool,
+        anthropic_beta: Option<String>,
+        mut cx: AsyncApp,
+    ) -> Result<BoxStream<'static, Result<anthropic::Event, anthropic::AnthropicError>>> {
+        let (client, oauth_token, api_endpoint, configuration) =
+            Self::get_auth_details(&mut cx).await?;
+
+        let api_url = configuration.messages_url(&api_endpoint);
+        stream_messages(
+            client.clone(),
+            oauth_token,
+            api_url,
+            body,
+            is_user_initiated,
+            location,
+            anthropic_beta,
+        )
+        .await
+    }
+
     async fn get_auth_details(
         cx: &mut AsyncApp,
     ) -> Result<(
@@ -948,6 +1008,62 @@ async fn stream_completion(
 
         Ok(futures::stream::once(async move { Ok(response) }).boxed())
     }
+}
+
+async fn stream_messages(
+    client: Arc<dyn HttpClient>,
+    oauth_token: String,
+    api_url: String,
+    body: String,
+    is_user_initiated: bool,
+    location: ChatLocation,
+    anthropic_beta: Option<String>,
+) -> Result<BoxStream<'static, Result<anthropic::Event, anthropic::AnthropicError>>> {
+    let mut request_builder = copilot_request_headers(
+        HttpRequest::builder().method(Method::POST).uri(&api_url),
+        &oauth_token,
+        Some(is_user_initiated),
+        Some(location),
+    );
+
+    if let Some(beta) = &anthropic_beta {
+        request_builder = request_builder.header("anthropic-beta", beta.as_str());
+    }
+
+    let request = request_builder.body(AsyncBody::from(body))?;
+    let mut response = client.send(request).await?;
+
+    if !response.status().is_success() {
+        let mut body = String::new();
+        response.body_mut().read_to_string(&mut body).await?;
+        anyhow::bail!("Failed to connect to API: {} {}", response.status(), body);
+    }
+
+    let reader = BufReader::new(response.into_body());
+    Ok(reader
+        .lines()
+        .filter_map(|line| async move {
+            match line {
+                Ok(line) => {
+                    let line = line
+                        .strip_prefix("data: ")
+                        .or_else(|| line.strip_prefix("data:"))?;
+                    match serde_json::from_str(line) {
+                        Ok(event) => Some(Ok(event)),
+                        Err(error) => {
+                            log::error!(
+                                "Failed to parse Copilot messages stream event: `{}`\nResponse: `{}`",
+                                error,
+                                line,
+                            );
+                            Some(Err(anthropic::AnthropicError::DeserializeResponse(error)))
+                        }
+                    }
+                }
+                Err(error) => Some(Err(anthropic::AnthropicError::ReadResponse(error))),
+            }
+        })
+        .boxed())
 }
 
 #[cfg(test)]

--- a/crates/copilot_chat/src/copilot_chat.rs
+++ b/crates/copilot_chat/src/copilot_chat.rs
@@ -860,7 +860,6 @@ pub(crate) fn copilot_request_headers(
                 option_env!("CARGO_PKG_VERSION").unwrap_or("unknown")
             ),
         )
-        .header("Copilot-Integration-Id", "vscode-chat")
         .header("X-GitHub-Api-Version", "2025-05-01")
         .when_some(is_user_initiated, |builder, is_user_initiated| {
             builder.header(
@@ -888,8 +887,7 @@ async fn request_models(
         &oauth_token,
         None,
         None,
-    )
-    .header("x-github-api-version", "2025-05-01");
+    );
 
     let request = request_builder.body(AsyncBody::empty())?;
 
@@ -1048,7 +1046,7 @@ async fn stream_messages(
                     let line = line
                         .strip_prefix("data: ")
                         .or_else(|| line.strip_prefix("data:"))?;
-                    if line.starts_with("[DONE]") {
+                    if line.starts_with("[DONE]") || line.is_empty() {
                         return None;
                     }
                     match serde_json::from_str(line) {

--- a/crates/copilot_chat/src/copilot_chat.rs
+++ b/crates/copilot_chat/src/copilot_chat.rs
@@ -215,6 +215,8 @@ struct ModelSupportedFeatures {
     max_thinking_budget: Option<u32>,
     #[serde(default)]
     min_thinking_budget: Option<u32>,
+    #[serde(default)]
+    reasoning_effort: Vec<String>,
 }
 
 #[derive(Clone, Copy, Serialize, Deserialize, Debug, Eq, PartialEq)]
@@ -315,6 +317,10 @@ impl Model {
 
     pub fn min_thinking_budget(&self) -> Option<u32> {
         self.capabilities.supports.min_thinking_budget
+    }
+
+    pub fn reasoning_effort_levels(&self) -> &[String] {
+        &self.capabilities.supports.reasoning_effort
     }
 
     pub fn family(&self) -> &str {

--- a/crates/copilot_chat/src/copilot_chat.rs
+++ b/crates/copilot_chat/src/copilot_chat.rs
@@ -311,6 +311,12 @@ impl Model {
         self.capabilities.supports.adaptive_thinking
     }
 
+    pub fn can_think(&self) -> bool {
+        self.supports_thinking()
+            || self.supports_adaptive_thinking()
+            || self.max_thinking_budget().is_some()
+    }
+
     pub fn max_thinking_budget(&self) -> Option<u32> {
         self.capabilities.supports.max_thinking_budget
     }
@@ -1681,6 +1687,11 @@ mod tests {
                     tool_calls: true,
                     parallel_tool_calls: false,
                     vision: false,
+                    thinking: false,
+                    adaptive_thinking: false,
+                    max_thinking_budget: None,
+                    min_thinking_budget: None,
+                    reasoning_effort: vec![],
                 },
                 model_type: "chat".to_string(),
                 tokenizer: None,

--- a/crates/copilot_chat/src/copilot_chat.rs
+++ b/crates/copilot_chat/src/copilot_chat.rs
@@ -861,7 +861,7 @@ pub(crate) fn copilot_request_headers(
             ),
         )
         .header("Copilot-Integration-Id", "vscode-chat")
-        .header("X-GitHub-Api-Version", "2025-10-01")
+        .header("X-GitHub-Api-Version", "2025-05-01")
         .when_some(is_user_initiated, |builder, is_user_initiated| {
             builder.header(
                 "X-Initiator",
@@ -1048,6 +1048,9 @@ async fn stream_messages(
                     let line = line
                         .strip_prefix("data: ")
                         .or_else(|| line.strip_prefix("data:"))?;
+                    if line.starts_with("[DONE]") {
+                        return None;
+                    }
                     match serde_json::from_str(line) {
                         Ok(event) => Some(Ok(event)),
                         Err(error) => {

--- a/crates/copilot_chat/src/copilot_chat.rs
+++ b/crates/copilot_chat/src/copilot_chat.rs
@@ -77,6 +77,30 @@ pub enum Role {
     System,
 }
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum ChatLocation {
+    #[default]
+    Panel,
+    Editor,
+    EditingSession,
+    Terminal,
+    Agent,
+    Other,
+}
+
+impl ChatLocation {
+    pub fn to_intent_string(self) -> &'static str {
+        match self {
+            ChatLocation::Panel => "conversation-panel",
+            ChatLocation::Editor => "conversation-inline",
+            ChatLocation::EditingSession => "conversation-edits",
+            ChatLocation::Terminal => "conversation-terminal",
+            ChatLocation::Agent => "conversation-agent",
+            ChatLocation::Other => "conversation-other",
+        }
+    }
+}
+
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
 pub enum ModelSupportedEndpoint {
     #[serde(rename = "/chat/completions")]
@@ -226,6 +250,10 @@ impl Model {
         self.capabilities.limits.max_context_window_tokens as u64
     }
 
+    pub fn max_output_tokens(&self) -> usize {
+        self.capabilities.limits.max_output_tokens
+    }
+
     pub fn supports_tools(&self) -> bool {
         self.capabilities.supports.tool_calls
     }
@@ -263,7 +291,6 @@ impl Model {
 
 #[derive(Serialize, Deserialize)]
 pub struct Request {
-    pub intent: bool,
     pub n: usize,
     pub stream: bool,
     pub temperature: f32,
@@ -273,6 +300,8 @@ pub struct Request {
     pub tools: Vec<Tool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool_choice: Option<ToolChoice>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thinking_budget: Option<u32>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -550,6 +579,7 @@ impl CopilotChat {
 
     pub async fn stream_completion(
         request: Request,
+        location: ChatLocation,
         is_user_initiated: bool,
         mut cx: AsyncApp,
     ) -> Result<BoxStream<'static, Result<ResponseEvent>>> {
@@ -563,12 +593,14 @@ impl CopilotChat {
             api_url.into(),
             request,
             is_user_initiated,
+            location,
         )
         .await
     }
 
     pub async fn stream_response(
         request: responses::Request,
+        location: ChatLocation,
         is_user_initiated: bool,
         mut cx: AsyncApp,
     ) -> Result<BoxStream<'static, Result<responses::StreamEvent>>> {
@@ -582,6 +614,7 @@ impl CopilotChat {
             api_url,
             request,
             is_user_initiated,
+            location,
         )
         .await
     }
@@ -755,6 +788,7 @@ pub(crate) fn copilot_request_headers(
     builder: http_client::Builder,
     oauth_token: &str,
     is_user_initiated: Option<bool>,
+    location: Option<ChatLocation>,
 ) -> http_client::Builder {
     builder
         .header("Authorization", format!("Bearer {}", oauth_token))
@@ -766,11 +800,19 @@ pub(crate) fn copilot_request_headers(
                 option_env!("CARGO_PKG_VERSION").unwrap_or("unknown")
             ),
         )
+        .header("Copilot-Integration-Id", "vscode-chat")
+        .header("X-GitHub-Api-Version", "2025-10-01")
         .when_some(is_user_initiated, |builder, is_user_initiated| {
             builder.header(
                 "X-Initiator",
                 if is_user_initiated { "user" } else { "agent" },
             )
+        })
+        .when_some(location, |builder, loc| {
+            let interaction_type = loc.to_intent_string();
+            builder
+                .header("X-Interaction-Type", interaction_type)
+                .header("OpenAI-Intent", interaction_type)
         })
 }
 
@@ -784,6 +826,7 @@ async fn request_models(
             .method(Method::GET)
             .uri(models_url.as_ref()),
         &oauth_token,
+        None,
         None,
     )
     .header("x-github-api-version", "2025-05-01");
@@ -830,6 +873,7 @@ async fn stream_completion(
     completion_url: Arc<str>,
     request: Request,
     is_user_initiated: bool,
+    location: ChatLocation,
 ) -> Result<BoxStream<'static, Result<ResponseEvent>>> {
     let is_vision_request = request.messages.iter().any(|message| match message {
         ChatMessage::User { content }
@@ -846,6 +890,7 @@ async fn stream_completion(
             .uri(completion_url.as_ref()),
         &oauth_token,
         Some(is_user_initiated),
+        Some(location),
     )
     .when(is_vision_request, |builder| {
         builder.header("Copilot-Vision-Request", is_vision_request.to_string())

--- a/crates/copilot_chat/src/responses.rs
+++ b/crates/copilot_chat/src/responses.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
-use super::copilot_request_headers;
+use super::{ChatLocation, copilot_request_headers};
 use anyhow::{Result, anyhow};
 use futures::{AsyncBufReadExt, AsyncReadExt, StreamExt, io::BufReader, stream::BoxStream};
-use http_client::{AsyncBody, HttpClient, Method, Request as HttpRequest};
+use http_client::{AsyncBody, HttpClient, HttpRequestExt, Method, Request as HttpRequest};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 pub use settings::OpenAiReasoningEffort as ReasoningEffort;
@@ -24,6 +24,7 @@ pub struct Request {
     pub reasoning: Option<ReasoningConfig>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub include: Option<Vec<ResponseIncludable>>,
+    pub store: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -280,6 +281,7 @@ pub async fn stream_response(
     api_url: String,
     request: Request,
     is_user_initiated: bool,
+    location: ChatLocation,
 ) -> Result<BoxStream<'static, Result<StreamEvent>>> {
     let is_vision_request = request.input.iter().any(|item| match item {
         ResponseInputItem::Message {
@@ -295,13 +297,11 @@ pub async fn stream_response(
         HttpRequest::builder().method(Method::POST).uri(&api_url),
         &oauth_token,
         Some(is_user_initiated),
-    );
-
-    let request_builder = if is_vision_request {
-        request_builder.header("Copilot-Vision-Request", "true")
-    } else {
-        request_builder
-    };
+        Some(location),
+    )
+    .when(is_vision_request, |builder| {
+        builder.header("Copilot-Vision-Request", "true")
+    });
 
     let is_streaming = request.stream;
     let json = serde_json::to_string(&request)?;

--- a/crates/copilot_chat/src/responses.rs
+++ b/crates/copilot_chat/src/responses.rs
@@ -321,9 +321,7 @@ pub async fn stream_response(
             .filter_map(|line| async move {
                 match line {
                     Ok(line) => {
-                        let line = line
-                            .strip_prefix("data: ")
-                            .or_else(|| line.strip_prefix("data:"))?;
+                        let line = line.strip_prefix("data: ")?;
                         if line.starts_with("[DONE]") || line.is_empty() {
                             return None;
                         }

--- a/crates/copilot_chat/src/responses.rs
+++ b/crates/copilot_chat/src/responses.rs
@@ -321,7 +321,9 @@ pub async fn stream_response(
             .filter_map(|line| async move {
                 match line {
                     Ok(line) => {
-                        let line = line.strip_prefix("data: ")?;
+                        let line = line
+                            .strip_prefix("data: ")
+                            .or_else(|| line.strip_prefix("data:"))?;
                         if line.starts_with("[DONE]") || line.is_empty() {
                             return None;
                         }

--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -974,7 +974,7 @@ fn into_copilot_chat(
     Ok(CopilotChatRequest {
         n: 1,
         stream: model.uses_streaming(),
-        temperature: temperature.map(|t| t as f32).unwrap_or(0.1),
+        temperature: temperature.unwrap_or(0.1),
         model: model.id().to_string(),
         messages,
         tools,

--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -381,15 +381,15 @@ impl LanguageModel for CopilotChatLanguageModel {
                     model.max_output_tokens() as u64,
                     if model.supports_adaptive_thinking() {
                         AnthropicModelMode::Thinking {
-                            budget_tokens: Some(4_096),
+                            budget_tokens: None,
                         }
                     } else if model.supports_thinking() {
-                        let budget = compute_thinking_budget(
-                            model.min_thinking_budget(),
-                            model.max_output_tokens() as u32,
-                        );
                         AnthropicModelMode::Thinking {
-                            budget_tokens: budget,
+                            budget_tokens: compute_thinking_budget(
+                                model.min_thinking_budget(),
+                                model.max_thinking_budget(),
+                                model.max_output_tokens() as u32,
+                            ),
                         }
                     } else {
                         AnthropicModelMode::Default
@@ -398,9 +398,11 @@ impl LanguageModel for CopilotChatLanguageModel {
 
                 anthropic_request.temperature = None;
 
-                if model.supports_adaptive_thinking() && anthropic_request.thinking.is_some() {
-                    anthropic_request.thinking = Some(anthropic::Thinking::Adaptive);
-                    anthropic_request.output_config = Some(anthropic::OutputConfig { effort });
+                if model.supports_adaptive_thinking() {
+                    if anthropic_request.thinking.is_some() {
+                        anthropic_request.thinking = Some(anthropic::Thinking::Adaptive);
+                        anthropic_request.output_config = Some(anthropic::OutputConfig { effort });
+                    }
                 }
 
                 let anthropic_beta =
@@ -410,14 +412,11 @@ impl LanguageModel for CopilotChatLanguageModel {
                         None
                     };
 
-                let body = {
-                    let mut value =
-                        serde_json::to_value(&anthropic_request).map_err(|e| anyhow::anyhow!(e))?;
-                    if let Some(obj) = value.as_object_mut() {
-                        obj.insert("stream".to_string(), serde_json::Value::Bool(true));
-                    }
-                    serde_json::to_string(&value).map_err(|e| anyhow::anyhow!(e))?
-                };
+                let body = serde_json::to_string(&anthropic::StreamingRequest {
+                    base: anthropic_request,
+                    stream: true,
+                })
+                .map_err(|e| anyhow::anyhow!(e))?;
 
                 let stream = CopilotChat::stream_messages(
                     body,
@@ -1057,11 +1056,20 @@ fn into_copilot_chat(
     })
 }
 
-fn compute_thinking_budget(min_budget: Option<u32>, max_output_tokens: u32) -> Option<u32> {
+fn compute_thinking_budget(
+    min_budget: Option<u32>,
+    max_budget: Option<u32>,
+    max_output_tokens: u32,
+) -> Option<u32> {
     let configured_budget: u32 = 16000;
     let min_budget = min_budget.unwrap_or(1024);
+    let max_budget = max_budget.unwrap_or(max_output_tokens.saturating_sub(1));
     let normalized = configured_budget.max(min_budget);
-    Some(normalized.min(max_output_tokens.saturating_sub(1)))
+    Some(
+        normalized
+            .min(max_budget)
+            .min(max_output_tokens.saturating_sub(1)),
+    )
 }
 
 fn intent_to_chat_location(intent: Option<CompletionIntent>) -> ChatLocation {

--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -258,31 +258,32 @@ impl LanguageModel for CopilotChatLanguageModel {
     }
 
     fn supports_thinking(&self) -> bool {
-        self.model.supports_thinking() || self.model.supports_adaptive_thinking()
+        self.model.supports_thinking()
+            || self.model.supports_adaptive_thinking()
+            || self.model.max_thinking_budget().is_some()
     }
 
     fn supported_effort_levels(&self) -> Vec<LanguageModelEffortLevel> {
-        if self.model.supports_adaptive_thinking() {
-            vec![
-                LanguageModelEffortLevel {
-                    name: "Low".into(),
-                    value: "low".into(),
-                    is_default: false,
-                },
-                LanguageModelEffortLevel {
-                    name: "Medium".into(),
-                    value: "medium".into(),
-                    is_default: false,
-                },
-                LanguageModelEffortLevel {
-                    name: "High".into(),
-                    value: "high".into(),
-                    is_default: true,
-                },
-            ]
-        } else {
-            vec![]
+        let levels = self.model.reasoning_effort_levels();
+        if levels.is_empty() {
+            return vec![];
         }
+        levels
+            .iter()
+            .map(|level| {
+                let name: SharedString = match level.as_str() {
+                    "low" => "Low".into(),
+                    "medium" => "Medium".into(),
+                    "high" => "High".into(),
+                    _ => SharedString::from(level.clone()),
+                };
+                LanguageModelEffortLevel {
+                    name,
+                    value: SharedString::from(level.clone()),
+                    is_default: level == "high",
+                }
+            })
+            .collect()
     }
 
     fn tool_input_format(&self) -> LanguageModelToolSchemaFormat {
@@ -383,7 +384,7 @@ impl LanguageModel for CopilotChatLanguageModel {
                         AnthropicModelMode::Thinking {
                             budget_tokens: None,
                         }
-                    } else if model.supports_thinking() {
+                    } else if model.supports_thinking() || model.max_thinking_budget().is_some() {
                         AnthropicModelMode::Thinking {
                             budget_tokens: compute_thinking_budget(
                                 model.min_thinking_budget(),
@@ -410,12 +411,13 @@ impl LanguageModel for CopilotChatLanguageModel {
                     }
                 }
 
-                let anthropic_beta =
-                    if !model.supports_adaptive_thinking() && model.supports_thinking() {
-                        Some("interleaved-thinking-2025-05-14".to_string())
-                    } else {
-                        None
-                    };
+                let anthropic_beta = if !model.supports_adaptive_thinking()
+                    && (model.supports_thinking() || model.max_thinking_budget().is_some())
+                {
+                    Some("interleaved-thinking-2025-05-14".to_string())
+                } else {
+                    None
+                };
 
                 let body = serde_json::to_string(&anthropic::StreamingRequest {
                     base: anthropic_request,

--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -258,9 +258,7 @@ impl LanguageModel for CopilotChatLanguageModel {
     }
 
     fn supports_thinking(&self) -> bool {
-        self.model.supports_thinking()
-            || self.model.supports_adaptive_thinking()
-            || self.model.max_thinking_budget().is_some()
+        self.model.can_think()
     }
 
     fn supported_effort_levels(&self) -> Vec<LanguageModelEffortLevel> {
@@ -384,7 +382,7 @@ impl LanguageModel for CopilotChatLanguageModel {
                         AnthropicModelMode::Thinking {
                             budget_tokens: None,
                         }
-                    } else if model.supports_thinking() || model.max_thinking_budget().is_some() {
+                    } else if model.can_think() {
                         AnthropicModelMode::Thinking {
                             budget_tokens: compute_thinking_budget(
                                 model.min_thinking_budget(),
@@ -411,9 +409,7 @@ impl LanguageModel for CopilotChatLanguageModel {
                     }
                 }
 
-                let anthropic_beta = if !model.supports_adaptive_thinking()
-                    && (model.supports_thinking() || model.max_thinking_budget().is_some())
-                {
+                let anthropic_beta = if !model.supports_adaptive_thinking() && model.can_think() {
                     Some("interleaved-thinking-2025-05-14".to_string())
                 } else {
                     None

--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -398,6 +398,11 @@ impl LanguageModel for CopilotChatLanguageModel {
 
                 anthropic_request.temperature = None;
 
+                // The Copilot proxy doesn't support eager_input_streaming on tools.
+                for tool in &mut anthropic_request.tools {
+                    tool.eager_input_streaming = false;
+                }
+
                 if model.supports_adaptive_thinking() {
                     if anthropic_request.thinking.is_some() {
                         anthropic_request.thinking = Some(anthropic::Thinking::Adaptive);

--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -396,21 +396,28 @@ impl LanguageModel for CopilotChatLanguageModel {
                     },
                 );
 
+                anthropic_request.temperature = None;
+
                 if model.supports_adaptive_thinking() && anthropic_request.thinking.is_some() {
                     anthropic_request.thinking = Some(anthropic::Thinking::Adaptive);
                     anthropic_request.output_config = Some(anthropic::OutputConfig { effort });
                 }
 
-                let anthropic_beta = if !model.supports_adaptive_thinking()
-                    && anthropic_request.thinking.is_some()
-                {
-                    Some("interleaved-thinking-2025-05-14".to_string())
-                } else {
-                    None
-                };
+                let anthropic_beta =
+                    if !model.supports_adaptive_thinking() && model.supports_thinking() {
+                        Some("interleaved-thinking-2025-05-14".to_string())
+                    } else {
+                        None
+                    };
 
-                let body =
-                    serde_json::to_string(&anthropic_request).map_err(|e| anyhow::anyhow!(e))?;
+                let body = {
+                    let mut value =
+                        serde_json::to_value(&anthropic_request).map_err(|e| anyhow::anyhow!(e))?;
+                    if let Some(obj) = value.as_object_mut() {
+                        obj.insert("stream".to_string(), serde_json::Value::Bool(true));
+                    }
+                    serde_json::to_string(&value).map_err(|e| anyhow::anyhow!(e))?
+                };
 
                 let stream = CopilotChat::stream_messages(
                     body,
@@ -1087,7 +1094,7 @@ fn into_copilot_responses(
         tool_choice,
         stop: _,
         temperature,
-        thinking_allowed: _,
+        thinking_allowed,
         thinking_effort: _,
         speed: _,
     } = request;
@@ -1266,7 +1273,14 @@ fn into_copilot_responses(
         temperature,
         tools: converted_tools,
         tool_choice: mapped_tool_choice,
-        reasoning: None, // We would need to add support for setting from user settings.
+        reasoning: if thinking_allowed {
+            Some(copilot_responses::ReasoningConfig {
+                effort: copilot_responses::ReasoningEffort::Medium,
+                summary: Some(copilot_responses::ReasoningSummary::Detailed),
+            })
+        } else {
+            None
+        },
         include: Some(vec![
             copilot_responses::ResponseIncludable::ReasoningEncryptedContent,
         ]),

--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -8,9 +8,10 @@ use collections::HashMap;
 use copilot::{GlobalCopilotAuth, Status};
 use copilot_chat::responses as copilot_responses;
 use copilot_chat::{
-    ChatMessage, ChatMessageContent, ChatMessagePart, CopilotChat, CopilotChatConfiguration,
-    Function, FunctionContent, ImageUrl, Model as CopilotChatModel, ModelVendor,
-    Request as CopilotChatRequest, ResponseEvent, Tool, ToolCall, ToolCallContent, ToolChoice,
+    ChatLocation, ChatMessage, ChatMessageContent, ChatMessagePart, CopilotChat,
+    CopilotChatConfiguration, Function, FunctionContent, ImageUrl, Model as CopilotChatModel,
+    ModelVendor, Request as CopilotChatRequest, ResponseEvent, Tool, ToolCall, ToolCallContent,
+    ToolChoice,
 };
 use futures::future::BoxFuture;
 use futures::stream::BoxStream;
@@ -334,11 +335,16 @@ impl LanguageModel for CopilotChatLanguageModel {
         });
 
         if self.model.supports_response() {
+            let location = intent_to_chat_location(request.intent);
             let responses_request = into_copilot_responses(&self.model, request);
             let request_limiter = self.request_limiter.clone();
             let future = cx.spawn(async move |cx| {
-                let request =
-                    CopilotChat::stream_response(responses_request, is_user_initiated, cx.clone());
+                let request = CopilotChat::stream_response(
+                    responses_request,
+                    location,
+                    is_user_initiated,
+                    cx.clone(),
+                );
                 request_limiter
                     .stream(async move {
                         let stream = request.await?;
@@ -350,6 +356,7 @@ impl LanguageModel for CopilotChatLanguageModel {
             return async move { Ok(future.await?.boxed()) }.boxed();
         }
 
+        let location = intent_to_chat_location(request.intent);
         let copilot_request = match into_copilot_chat(&self.model, request) {
             Ok(request) => request,
             Err(err) => return futures::future::ready(Err(err.into())).boxed(),
@@ -358,8 +365,12 @@ impl LanguageModel for CopilotChatLanguageModel {
 
         let request_limiter = self.request_limiter.clone();
         let future = cx.spawn(async move |cx| {
-            let request =
-                CopilotChat::stream_completion(copilot_request, is_user_initiated, cx.clone());
+            let request = CopilotChat::stream_completion(
+                copilot_request,
+                location,
+                is_user_initiated,
+                cx.clone(),
+            );
             request_limiter
                 .stream(async move {
                     let response = request.await?;
@@ -390,7 +401,7 @@ pub fn map_to_language_model_completion_events(
         events: Pin<Box<dyn Send + Stream<Item = Result<ResponseEvent>>>>,
         tool_calls_by_index: HashMap<usize, RawToolCall>,
         reasoning_opaque: Option<String>,
-        reasoning_text: Option<String>,
+        reasoning_text: String,
     }
 
     futures::stream::unfold(
@@ -398,7 +409,7 @@ pub fn map_to_language_model_completion_events(
             events,
             tool_calls_by_index: HashMap::default(),
             reasoning_opaque: None,
-            reasoning_text: None,
+            reasoning_text: String::new(),
         },
         move |mut state| async move {
             if let Some(event) = state.events.next().await {
@@ -429,12 +440,18 @@ pub fn map_to_language_model_completion_events(
                             events.push(Ok(LanguageModelCompletionEvent::Text(content)));
                         }
 
-                        // Capture reasoning data from the delta (e.g. for Gemini 3)
+                        // Capture reasoning data from the delta and emit Thinking events
                         if let Some(opaque) = delta.reasoning_opaque.clone() {
                             state.reasoning_opaque = Some(opaque);
                         }
                         if let Some(text) = delta.reasoning_text.clone() {
-                            state.reasoning_text = Some(text);
+                            if !text.is_empty() {
+                                state.reasoning_text.push_str(&text);
+                                events.push(Ok(LanguageModelCompletionEvent::Thinking {
+                                    text,
+                                    signature: None,
+                                }));
+                            }
                         }
 
                         for (index, tool_call) in delta.tool_calls.iter().enumerate() {
@@ -489,6 +506,32 @@ pub fn map_to_language_model_completion_events(
                             )));
                         }
 
+                        // Emit ReasoningDetails on finish so the agent stores reasoning
+                        // data in the message for subsequent requests.
+                        if choice.finish_reason.is_some()
+                            && (state.reasoning_opaque.is_some()
+                                || !state.reasoning_text.is_empty())
+                        {
+                            let mut details = serde_json::Map::new();
+                            if let Some(opaque) = state.reasoning_opaque.take() {
+                                details.insert(
+                                    "reasoning_opaque".to_string(),
+                                    serde_json::Value::String(opaque),
+                                );
+                            }
+                            if !state.reasoning_text.is_empty() {
+                                details.insert(
+                                    "reasoning_text".to_string(),
+                                    serde_json::Value::String(std::mem::take(
+                                        &mut state.reasoning_text,
+                                    )),
+                                );
+                            }
+                            events.push(Ok(LanguageModelCompletionEvent::ReasoningDetails(
+                                serde_json::Value::Object(details),
+                            )));
+                        }
+
                         match choice.finish_reason.as_deref() {
                             Some("stop") => {
                                 events.push(Ok(LanguageModelCompletionEvent::Stop(
@@ -496,32 +539,6 @@ pub fn map_to_language_model_completion_events(
                                 )));
                             }
                             Some("tool_calls") => {
-                                // Gemini 3 models send reasoning_opaque/reasoning_text that must
-                                // be preserved and sent back in subsequent requests. Emit as
-                                // ReasoningDetails so the agent stores it in the message.
-                                if state.reasoning_opaque.is_some()
-                                    || state.reasoning_text.is_some()
-                                {
-                                    let mut details = serde_json::Map::new();
-                                    if let Some(opaque) = state.reasoning_opaque.take() {
-                                        details.insert(
-                                            "reasoning_opaque".to_string(),
-                                            serde_json::Value::String(opaque),
-                                        );
-                                    }
-                                    if let Some(text) = state.reasoning_text.take() {
-                                        details.insert(
-                                            "reasoning_text".to_string(),
-                                            serde_json::Value::String(text),
-                                        );
-                                    }
-                                    events.push(Ok(
-                                        LanguageModelCompletionEvent::ReasoningDetails(
-                                            serde_json::Value::Object(details),
-                                        ),
-                                    ));
-                                }
-
                                 events.extend(state.tool_calls_by_index.drain().map(
                                     |(_, tool_call)| match parse_tool_arguments(
                                         &tool_call.arguments,
@@ -761,6 +778,43 @@ fn into_copilot_chat(
     model: &CopilotChatModel,
     request: LanguageModelRequest,
 ) -> Result<CopilotChatRequest> {
+    let location = intent_to_chat_location(request.intent);
+    let temperature = request.temperature;
+    let tool_choice = request.tool_choice;
+
+    let thinking_budget = if model.vendor() == ModelVendor::Anthropic
+        && location == ChatLocation::Agent
+        && request.thinking_allowed
+    {
+        let has_assistant_messages = request
+            .messages
+            .iter()
+            .any(|msg| msg.role == Role::Assistant);
+
+        let messages_contain_thinking = request
+            .messages
+            .iter()
+            .filter(|msg| msg.role == Role::Assistant)
+            .any(|msg| msg.reasoning_details.is_some());
+
+        let disable_thinking = has_assistant_messages && !messages_contain_thinking;
+
+        if disable_thinking {
+            None
+        } else {
+            let configured_budget: u32 = 4000;
+            let max_output = model.max_output_tokens() as u32;
+            let normalized_budget = configured_budget.max(1024);
+            Some(
+                normalized_budget
+                    .min(32000)
+                    .min(max_output.saturating_sub(1)),
+            )
+        }
+    } else {
+        None
+    };
+
     let mut request_messages: Vec<LanguageModelRequestMessage> = Vec::new();
     for message in request.messages {
         if let Some(last_message) = request_messages.last_mut() {
@@ -859,10 +913,9 @@ fn into_copilot_chat(
                 let text_content = {
                     let mut buffer = String::new();
                     for string in message.content.iter().filter_map(|content| match content {
-                        MessageContent::Text(text) | MessageContent::Thinking { text, .. } => {
-                            Some(text.as_str())
-                        }
-                        MessageContent::ToolUse(_)
+                        MessageContent::Text(text) => Some(text.as_str()),
+                        MessageContent::Thinking { .. }
+                        | MessageContent::ToolUse(_)
                         | MessageContent::RedactedThinking(_)
                         | MessageContent::ToolResult(_)
                         | MessageContent::Image(_) => None,
@@ -919,19 +972,34 @@ fn into_copilot_chat(
         .collect::<Vec<_>>();
 
     Ok(CopilotChatRequest {
-        intent: true,
         n: 1,
         stream: model.uses_streaming(),
-        temperature: 0.1,
+        temperature: temperature.map(|t| t as f32).unwrap_or(0.1),
         model: model.id().to_string(),
         messages,
         tools,
-        tool_choice: request.tool_choice.map(|choice| match choice {
+        tool_choice: tool_choice.map(|choice| match choice {
             LanguageModelToolChoice::Auto => ToolChoice::Auto,
             LanguageModelToolChoice::Any => ToolChoice::Any,
             LanguageModelToolChoice::None => ToolChoice::None,
         }),
+        thinking_budget,
     })
+}
+
+fn intent_to_chat_location(intent: Option<CompletionIntent>) -> ChatLocation {
+    match intent {
+        Some(CompletionIntent::UserPrompt) => ChatLocation::Agent,
+        Some(CompletionIntent::ToolResults) => ChatLocation::Agent,
+        Some(CompletionIntent::ThreadSummarization) => ChatLocation::Panel,
+        Some(CompletionIntent::ThreadContextSummarization) => ChatLocation::Panel,
+        Some(CompletionIntent::CreateFile) => ChatLocation::Agent,
+        Some(CompletionIntent::EditFile) => ChatLocation::Agent,
+        Some(CompletionIntent::InlineAssist) => ChatLocation::Editor,
+        Some(CompletionIntent::TerminalInlineAssist) => ChatLocation::Terminal,
+        Some(CompletionIntent::GenerateGitCommitMessage) => ChatLocation::Other,
+        None => ChatLocation::Panel,
+    }
 }
 
 fn into_copilot_responses(
@@ -1132,6 +1200,7 @@ fn into_copilot_responses(
         include: Some(vec![
             copilot_responses::ResponseIncludable::ReasoningEncryptedContent,
         ]),
+        store: false,
     }
 }
 

--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -507,7 +507,7 @@ pub fn map_to_language_model_completion_events(
         events: Pin<Box<dyn Send + Stream<Item = Result<ResponseEvent>>>>,
         tool_calls_by_index: HashMap<usize, RawToolCall>,
         reasoning_opaque: Option<String>,
-        reasoning_text: String,
+        reasoning_text: Option<String>,
     }
 
     futures::stream::unfold(
@@ -515,7 +515,7 @@ pub fn map_to_language_model_completion_events(
             events,
             tool_calls_by_index: HashMap::default(),
             reasoning_opaque: None,
-            reasoning_text: String::new(),
+            reasoning_text: None,
         },
         move |mut state| async move {
             if let Some(event) = state.events.next().await {
@@ -546,18 +546,12 @@ pub fn map_to_language_model_completion_events(
                             events.push(Ok(LanguageModelCompletionEvent::Text(content)));
                         }
 
-                        // Capture reasoning data from the delta and emit Thinking events
+                        // Capture reasoning data from the delta (e.g. for Gemini 3)
                         if let Some(opaque) = delta.reasoning_opaque.clone() {
                             state.reasoning_opaque = Some(opaque);
                         }
                         if let Some(text) = delta.reasoning_text.clone() {
-                            if !text.is_empty() {
-                                state.reasoning_text.push_str(&text);
-                                events.push(Ok(LanguageModelCompletionEvent::Thinking {
-                                    text,
-                                    signature: None,
-                                }));
-                            }
+                            state.reasoning_text = Some(text);
                         }
 
                         for (index, tool_call) in delta.tool_calls.iter().enumerate() {
@@ -612,32 +606,6 @@ pub fn map_to_language_model_completion_events(
                             )));
                         }
 
-                        // Emit ReasoningDetails on finish so the agent stores reasoning
-                        // data in the message for subsequent requests.
-                        if choice.finish_reason.is_some()
-                            && (state.reasoning_opaque.is_some()
-                                || !state.reasoning_text.is_empty())
-                        {
-                            let mut details = serde_json::Map::new();
-                            if let Some(opaque) = state.reasoning_opaque.take() {
-                                details.insert(
-                                    "reasoning_opaque".to_string(),
-                                    serde_json::Value::String(opaque),
-                                );
-                            }
-                            if !state.reasoning_text.is_empty() {
-                                details.insert(
-                                    "reasoning_text".to_string(),
-                                    serde_json::Value::String(std::mem::take(
-                                        &mut state.reasoning_text,
-                                    )),
-                                );
-                            }
-                            events.push(Ok(LanguageModelCompletionEvent::ReasoningDetails(
-                                serde_json::Value::Object(details),
-                            )));
-                        }
-
                         match choice.finish_reason.as_deref() {
                             Some("stop") => {
                                 events.push(Ok(LanguageModelCompletionEvent::Stop(
@@ -645,6 +613,32 @@ pub fn map_to_language_model_completion_events(
                                 )));
                             }
                             Some("tool_calls") => {
+                                // Gemini 3 models send reasoning_opaque/reasoning_text that must
+                                // be preserved and sent back in subsequent requests. Emit as
+                                // ReasoningDetails so the agent stores it in the message.
+                                if state.reasoning_opaque.is_some()
+                                    || state.reasoning_text.is_some()
+                                {
+                                    let mut details = serde_json::Map::new();
+                                    if let Some(opaque) = state.reasoning_opaque.take() {
+                                        details.insert(
+                                            "reasoning_opaque".to_string(),
+                                            serde_json::Value::String(opaque),
+                                        );
+                                    }
+                                    if let Some(text) = state.reasoning_text.take() {
+                                        details.insert(
+                                            "reasoning_text".to_string(),
+                                            serde_json::Value::String(text),
+                                        );
+                                    }
+                                    events.push(Ok(
+                                        LanguageModelCompletionEvent::ReasoningDetails(
+                                            serde_json::Value::Object(details),
+                                        ),
+                                    ));
+                                }
+
                                 events.extend(state.tool_calls_by_index.drain().map(
                                     |(_, tool_call)| match parse_tool_arguments(
                                         &tool_call.arguments,

--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -2,6 +2,7 @@ use std::pin::Pin;
 use std::str::FromStr as _;
 use std::sync::Arc;
 
+use anthropic::AnthropicModelMode;
 use anyhow::{Result, anyhow};
 use cloud_llm_client::CompletionIntent;
 use collections::HashMap;
@@ -21,8 +22,8 @@ use http_client::StatusCode;
 use language::language_settings::all_language_settings;
 use language_model::{
     AuthenticateError, IconOrSvg, LanguageModel, LanguageModelCompletionError,
-    LanguageModelCompletionEvent, LanguageModelCostInfo, LanguageModelId, LanguageModelName,
-    LanguageModelProvider, LanguageModelProviderId, LanguageModelProviderName,
+    LanguageModelCompletionEvent, LanguageModelCostInfo, LanguageModelEffortLevel, LanguageModelId,
+    LanguageModelName, LanguageModelProvider, LanguageModelProviderId, LanguageModelProviderName,
     LanguageModelProviderState, LanguageModelRequest, LanguageModelRequestMessage,
     LanguageModelToolChoice, LanguageModelToolResultContent, LanguageModelToolSchemaFormat,
     LanguageModelToolUse, MessageContent, RateLimiter, Role, StopReason, TokenUsage,
@@ -31,6 +32,7 @@ use settings::SettingsStore;
 use ui::prelude::*;
 use util::debug_panic;
 
+use crate::provider::anthropic::{AnthropicEventMapper, into_anthropic};
 use crate::provider::util::parse_tool_arguments;
 
 const PROVIDER_ID: LanguageModelProviderId = LanguageModelProviderId::new("copilot_chat");
@@ -255,6 +257,34 @@ impl LanguageModel for CopilotChatLanguageModel {
         self.model.supports_vision()
     }
 
+    fn supports_thinking(&self) -> bool {
+        self.model.supports_thinking() || self.model.supports_adaptive_thinking()
+    }
+
+    fn supported_effort_levels(&self) -> Vec<LanguageModelEffortLevel> {
+        if self.model.supports_adaptive_thinking() {
+            vec![
+                LanguageModelEffortLevel {
+                    name: "Low".into(),
+                    value: "low".into(),
+                    is_default: false,
+                },
+                LanguageModelEffortLevel {
+                    name: "Medium".into(),
+                    value: "medium".into(),
+                    is_default: false,
+                },
+                LanguageModelEffortLevel {
+                    name: "High".into(),
+                    value: "high".into(),
+                    is_default: true,
+                },
+            ]
+        } else {
+            vec![]
+        }
+    }
+
     fn tool_input_format(&self) -> LanguageModelToolSchemaFormat {
         match self.model.vendor() {
             ModelVendor::OpenAI | ModelVendor::Anthropic => {
@@ -333,6 +363,73 @@ impl LanguageModel for CopilotChatLanguageModel {
             | CompletionIntent::CreateFile
             | CompletionIntent::EditFile => false,
         });
+
+        if self.model.supports_messages() {
+            let location = intent_to_chat_location(request.intent);
+            let model = self.model.clone();
+            let request_limiter = self.request_limiter.clone();
+            let future = cx.spawn(async move |cx| {
+                let effort = request
+                    .thinking_effort
+                    .as_ref()
+                    .and_then(|e| anthropic::Effort::from_str(e).ok());
+
+                let mut anthropic_request = into_anthropic(
+                    request,
+                    model.id().to_string(),
+                    0.0,
+                    model.max_output_tokens() as u64,
+                    if model.supports_adaptive_thinking() {
+                        AnthropicModelMode::Thinking {
+                            budget_tokens: Some(4_096),
+                        }
+                    } else if model.supports_thinking() {
+                        let budget = compute_thinking_budget(
+                            model.min_thinking_budget(),
+                            model.max_output_tokens() as u32,
+                        );
+                        AnthropicModelMode::Thinking {
+                            budget_tokens: budget,
+                        }
+                    } else {
+                        AnthropicModelMode::Default
+                    },
+                );
+
+                if model.supports_adaptive_thinking() && anthropic_request.thinking.is_some() {
+                    anthropic_request.thinking = Some(anthropic::Thinking::Adaptive);
+                    anthropic_request.output_config = Some(anthropic::OutputConfig { effort });
+                }
+
+                let anthropic_beta = if !model.supports_adaptive_thinking()
+                    && anthropic_request.thinking.is_some()
+                {
+                    Some("interleaved-thinking-2025-05-14".to_string())
+                } else {
+                    None
+                };
+
+                let body =
+                    serde_json::to_string(&anthropic_request).map_err(|e| anyhow::anyhow!(e))?;
+
+                let stream = CopilotChat::stream_messages(
+                    body,
+                    location,
+                    is_user_initiated,
+                    anthropic_beta,
+                    cx.clone(),
+                );
+
+                request_limiter
+                    .stream(async move {
+                        let events = stream.await?;
+                        let mapper = AnthropicEventMapper::new();
+                        Ok(mapper.map_stream(events).boxed())
+                    })
+                    .await
+            });
+            return async move { Ok(future.await?.boxed()) }.boxed();
+        }
 
         if self.model.supports_response() {
             let location = intent_to_chat_location(request.intent);
@@ -778,42 +875,8 @@ fn into_copilot_chat(
     model: &CopilotChatModel,
     request: LanguageModelRequest,
 ) -> Result<CopilotChatRequest> {
-    let location = intent_to_chat_location(request.intent);
     let temperature = request.temperature;
     let tool_choice = request.tool_choice;
-
-    let thinking_budget = if model.vendor() == ModelVendor::Anthropic
-        && location == ChatLocation::Agent
-        && request.thinking_allowed
-    {
-        let has_assistant_messages = request
-            .messages
-            .iter()
-            .any(|msg| msg.role == Role::Assistant);
-
-        let messages_contain_thinking = request
-            .messages
-            .iter()
-            .filter(|msg| msg.role == Role::Assistant)
-            .any(|msg| msg.reasoning_details.is_some());
-
-        let disable_thinking = has_assistant_messages && !messages_contain_thinking;
-
-        if disable_thinking {
-            None
-        } else {
-            let configured_budget: u32 = 4000;
-            let max_output = model.max_output_tokens() as u32;
-            let normalized_budget = configured_budget.max(1024);
-            Some(
-                normalized_budget
-                    .min(32000)
-                    .min(max_output.saturating_sub(1)),
-            )
-        }
-    } else {
-        None
-    };
 
     let mut request_messages: Vec<LanguageModelRequestMessage> = Vec::new();
     for message in request.messages {
@@ -983,8 +1046,15 @@ fn into_copilot_chat(
             LanguageModelToolChoice::Any => ToolChoice::Any,
             LanguageModelToolChoice::None => ToolChoice::None,
         }),
-        thinking_budget,
+        thinking_budget: None,
     })
+}
+
+fn compute_thinking_budget(min_budget: Option<u32>, max_output_tokens: u32) -> Option<u32> {
+    let configured_budget: u32 = 16000;
+    let min_budget = min_budget.unwrap_or(1024);
+    let normalized = configured_budget.max(min_budget);
+    Some(normalized.min(max_output_tokens.saturating_sub(1)))
 }
 
 fn intent_to_chat_location(intent: Option<CompletionIntent>) -> ChatLocation {


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/45668

https://github.com/microsoft/vscode-copilot-chat used as a reference for headers and properties we need to set

| Before | After | 
| --- | --- |
| <img width="300" src="https://github.com/user-attachments/assets/d112a9ef-52d2-42ff-a77b-4b4b15f950fe" />| <img width="300" src="https://github.com/user-attachments/assets/0f1d7ae0-bee1-46f7-92ef-aea0fa6cde7a" /> |

Release Notes:

- Enabled thinking mode when using Anthropic models with Copilot