### PR TITLE
git_ui: Correct branch deletion to delete clicked item instead of selected item

### DIFF
--- a/crates/git_ui/src/branch_picker.rs
+++ b/crates/git_ui/src/branch_picker.rs
@@ -892,7 +892,8 @@ impl PickerDelegate for BranchListDelegate {
                     )
                 })
                 .disabled(is_head_branch)
-                .on_click(cx.listener(move |this, _, window, cx| {
+                .on_click(cx.listener(move |this, _event, window, cx| {
+                    this.delegate.set_selected_index(entry_ix, window, cx);
                     this.delegate.delete_at(entry_ix, window, cx);
                 }))
         };


### PR DESCRIPTION

Release Notes:

- Fixed correct branch deletion to delete clicked item instead of selected item

Previously, clicking the delete button on a branch would delete the currently selected branch (highlighted item) rather than the branch that was clicked. This happened because the button dispatched a DeleteBranch action which used picker.delegate.selected_index instead of the clicked item's index.
