### PR TITLE
Fix `gpui` Linux build failure due to ashpd/zbus incompatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,27 +784,6 @@ dependencies = [
 
 [[package]]
 name = "ashpd"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cbdf310d77fd3aaee6ea2093db7011dc2d35d2eb3481e5607f1f8d942ed99df"
-dependencies = [
- "async-fs",
- "async-net",
- "enumflags2",
- "futures-channel",
- "futures-util",
- "rand 0.9.2",
- "serde",
- "serde_repr",
- "url",
- "wayland-backend",
- "wayland-client",
- "wayland-protocols",
- "zbus",
-]
-
-[[package]]
-name = "ashpd"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da0986d5b4f0802160191ad75f8d33ada000558757db3defb70299ca95d9fcbd"
@@ -818,6 +797,9 @@ dependencies = [
  "serde",
  "serde_repr",
  "url",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
  "zbus",
 ]
 
@@ -6450,7 +6432,7 @@ name = "fs"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "ashpd 0.11.0",
+ "ashpd",
  "async-tar",
  "async-trait",
  "cocoa 0.26.0",
@@ -7335,7 +7317,7 @@ version = "0.2.2"
 dependencies = [
  "anyhow",
  "as-raw-xcb-connection",
- "ashpd 0.11.0",
+ "ashpd",
  "async-task",
  "backtrace",
  "bindgen 0.71.1",
@@ -10994,7 +10976,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3299dd401feaf1d45afd8fd1c0586f10fcfb22f244bb9afa942cec73503b89d"
 dependencies = [
  "aes",
- "ashpd 0.12.0",
+ "ashpd",
  "async-fs",
  "async-io",
  "async-lock 3.4.1",
@@ -20728,7 +20710,7 @@ dependencies = [
  "agent_ui",
  "agent_ui_v2",
  "anyhow",
- "ashpd 0.11.0",
+ "ashpd",
  "askpass",
  "assets",
  "audio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -450,7 +450,7 @@ alacritty_terminal = "0.25.1-rc1"
 any_vec = "0.14"
 anyhow = "1.0.86"
 arrayvec = { version = "0.7.4", features = ["serde"] }
-ashpd = { version = "0.11", default-features = false, features = ["async-std"] }
+ashpd = { version = "0.12", default-features = false, features = ["async-std"] }
 async-compat = "0.2.1"
 async-compression = { version = "0.4", features = ["gzip", "futures-io"] }
 async-dispatcher = "0.1"


### PR DESCRIPTION
`ashpd` 0.11 is incompatible with recent zbus/zvariant releases, causing a compilation error in Linux. Bumping to 0.12 fixes it.
See: https://github.com/bilelmoussaoui/ashpd/issues/323

To reproduce:

```toml
[package]
name = "test-gpui"
version = "0.1.0"
edition = "2021"

[dependencies]
gpui = { git = "https://github.com/zed-industries/zed" }
```

```bash
...
   Compiling ashpd v0.11.0
error[E0277]: the trait bound `AppID: Basic` is not satisfied
   --> /home/neulus/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/ashpd-0.11.0/src/documents/mod.rs:391:16
    |
391 |         self.0.call("Info", &(doc_id.into())).await
    |                ^^^^ unsatisfied trait bound
    |
help: the trait `Basic` is not implemented for `AppID`
   --> /home/neulus/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/ashpd-0.11.0/src/app_id.rs:10:1
    |
 10 | pub struct AppID(String);
    | ^^^^^^^^^^^^^^^^
    = help: the following other types implement trait `Basic`:
              &B
              BusName<'_>
              ErrorName<'_>
              InterfaceName<'_>
              MemberName<'_>
              NonZero<i16>
              NonZero<i32>
              NonZero<i64>
            and 35 others
    = note: required for `HashMap<AppID, Vec<Permission>>` to implement `zbus::zvariant::Type`
    = note: 1 redundant requirement hidden
    = note: required for `(file_path::FilePath, HashMap<AppID, Vec<Permission>>)` to implement `zbus::zvariant::Type`
note: required by a bound in `proxy::Proxy::<'a>::call`
   --> /home/neulus/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/ashpd-0.11.0/src/proxy.rs:172:40
    |
166 |     pub(crate) async fn call<R>(
    |                         ---- required by a bound in this associated function
...
172 |         R: for<'de> Deserialize<'de> + Type,
    |                                        ^^^^ required by this bound in `Proxy::<'a>::call`

error[E0277]: the trait bound `DocumentID: Basic` is not satisfied
   --> /home/neulus/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/ashpd-0.11.0/src/documents/mod.rs:500:16
    |
500 |         self.0.call_versioned("GetHostPaths", &(doc_ids,), 5).await
    |                ^^^^^^^^^^^^^^ unsatisfied trait bound
    |
help: the trait `Basic` is not implemented for `DocumentID`
   --> /home/neulus/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/ashpd-0.11.0/src/app_id.rs:98:1
    |
 98 | pub struct DocumentID(String);
    | ^^^^^^^^^^^^^^^^^^^^^
    = help: the following other types implement trait `Basic`:
              &B
              BusName<'_>
              ErrorName<'_>
              InterfaceName<'_>
              MemberName<'_>
              NonZero<i16>
              NonZero<i32>
              NonZero<i64>
            and 35 others
    = note: required for `HashMap<DocumentID, file_path::FilePath>` to implement `zbus::zvariant::Type`
note: required by a bound in `proxy::Proxy::<'a>::call_versioned`
   --> /home/neulus/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/ashpd-0.11.0/src/proxy.rs:195:40
    |
188 |     pub(crate) async fn call_versioned<R>(
    |                         -------------- required by a bound in this associated function
...
195 |         R: for<'de> Deserialize<'de> + Type,
    |                                        ^^^^ required by this bound in `Proxy::<'a>::call_versioned`

For more information about this error, try `rustc --explain E0277`.
error: could not compile `ashpd` (lib) due to 2 previous errors
```

Release Notes:

- N/A