### PR TITLE
Add user-extensible tree-sitter queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9107,6 +9107,7 @@ dependencies = [
  "lsp",
  "node_runtime",
  "parking_lot",
+ "paths",
  "pet",
  "pet-conda",
  "pet-core",

--- a/crates/languages/Cargo.toml
+++ b/crates/languages/Cargo.toml
@@ -52,6 +52,7 @@ log.workspace = true
 lsp.workspace = true
 node_runtime.workspace = true
 parking_lot.workspace = true
+paths.workspace = true
 pet-conda.workspace = true
 pet-core.workspace = true
 pet-fs.workspace = true

--- a/crates/paths/src/paths.rs
+++ b/crates/paths/src/paths.rs
@@ -291,6 +291,12 @@ pub fn snippets_dir() -> &'static PathBuf {
     SNIPPETS_DIR.get_or_init(|| config_dir().join("snippets"))
 }
 
+/// Returns the path to the user languages directory.
+pub fn languages_config_dir() -> &'static PathBuf {
+    static LANGUAGES_CONFIG_DIR: OnceLock<PathBuf> = OnceLock::new();
+    LANGUAGES_CONFIG_DIR.get_or_init(|| config_dir().join("languages"))
+}
+
 /// Returns the path to the contexts directory.
 ///
 /// This is where the saved contexts from the Assistant are stored.

--- a/docs/src/extensions/languages.md
+++ b/docs/src/extensions/languages.md
@@ -75,6 +75,11 @@ several features:
 The following sections elaborate on how [Tree-sitter queries](https://tree-sitter.github.io/tree-sitter/using-parsers/queries/index.html) enable these
 features in Zed, using [JSON syntax](https://www.json.org/json-en.html) as a guiding example.
 
+Note that user-defined queries may also be defined in `~/.config/zed/languages` (macOS and Linux) or `%USERPROFILE%\AppData\Roaming\Zed\languages\` (Windows).
+If found, the queries will be appended to builtin queries or queries from extensions.
+
+For example, to add a new language injection to Rust, create a query file at `~/.config/zed/languages/rust/injections.scm`. Note that Zed may need to be restarted for these changes to take effect.
+
 ### Syntax highlighting
 
 In Tree-sitter, the `highlights.scm` file defines syntax highlighting rules for a particular syntax.

--- a/docs/src/themes.md
+++ b/docs/src/themes.md
@@ -65,7 +65,7 @@ For example, add the following to your `settings.json` if you wish to override t
 }
 ```
 
-To see a comprehensive list of list of captures (like `comment` and `comment.doc`) see [Language Extensions: Syntax highlighting](./extensions/languages.md#syntax-highlighting).
+To see a comprehensive list of list of captures (like `comment` and `comment.doc`) see [Language Extensions: Syntax highlighting](./extensions/languages.md#syntax-highlighting). To add new captures, you can use a [custom Tree-sitter query](./extensions/languages.md#tree-sitter-queries).
 
 To see a list of available theme attributes look at the JSON file for your theme.
 For example, [assets/themes/one/one.json](https://github.com/zed-industries/zed/blob/main/assets/themes/one/one.json) for the default One Dark and One Light themes.


### PR DESCRIPTION
A simple first step toward closing #4612, and also helps with #9461 since it allows for user-customizable `highlights` queries (thus enabling more precise / complex syntax highlights).

If this is accepted, I have a few ideas for followup changes, which may require some discussion with the Zed team to make sure the ideas seem reasonable:

1. Similar to JSON schemas, register some kind of `zed://language/queries/...` handler to make it easier to see the concatenated query after Zed processes it.

2. Implement something like an `(#override!)` directive, which could be used in user-defined queries to disable builtin-defined or extension-defined queries. This would be a (very simple) way to offer something like neovim has, since the default behavior is more like neovim's `; extends`.

   - Possible future: `(#disable! @some.capture)` to selectively disable upstream captures. Since everything is getting concatenated into one query together before parsing I think this should be possible?

3. Possible future direction for #8795 would be to implement a `(#inherit! "other-language")`, although this probably requires a bit more careful design about how it should work.


Release Notes:

- Added the ability to define custom tree-sitter queries to extend builtin/extension queries.