### PR TITLE
Highlights: support per-language theming

### DIFF
--- a/crates/language/src/highlight_map.rs
+++ b/crates/language/src/highlight_map.rs
@@ -32,9 +32,7 @@ impl HighlightMap {
                             // the final component may match the TS language name, for per-lang customization
                             let capture_parts = capture_name.split('.').chain(grammar_name);
                             for key_part in key.split('.') {
-                                // hmm, is this logic correct? Seems like it should be a zip_longest kinda thing
-                                if capture_parts.clone().any(|part| part == key_part)
-                                {
+                                if capture_parts.clone().any(|part| part == key_part) {
                                     len += 1;
                                 } else {
                                     return None;
@@ -98,6 +96,7 @@ mod tests {
                 ("function", rgba(0x100000ff)),
                 ("function.method", rgba(0x200000ff)),
                 ("function.async", rgba(0x300000ff)),
+                ("function.async.javascript", rgba(0x700000ff)),
                 ("variable.builtin.self.rust", rgba(0x400000ff)),
                 ("variable.builtin", rgba(0x500000ff)),
                 ("variable", rgba(0x600000ff)),
@@ -111,11 +110,13 @@ mod tests {
             "function.special",
             "function.async",
             "variable.builtin.self",
+            "variable.builtin",
         ];
 
         let map = HighlightMap::new(capture_names, Some("rust"), &theme);
         assert_eq!(map.get(0).name(&theme), Some("function"));
         assert_eq!(map.get(1).name(&theme), Some("function.async"));
-        assert_eq!(map.get(2).name(&theme), Some("variable.builtin"));
+        assert_eq!(map.get(2).name(&theme), Some("variable.builtin.self.rust"));
+        assert_eq!(map.get(3).name(&theme), Some("variable.builtin"));
     }
 }

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -2095,8 +2095,11 @@ impl Language {
         if let Some(grammar) = self.grammar.as_ref()
             && let Some(highlights_config) = &grammar.highlights_config
         {
-            *grammar.highlight_map.lock() =
-                HighlightMap::new(highlights_config.query.capture_names(), theme);
+            *grammar.highlight_map.lock() = HighlightMap::new(
+                highlights_config.query.capture_names(),
+                self.config.grammar.as_deref(),
+                theme,
+            );
         }
     }
 

--- a/crates/languages/src/jsdoc/highlights.scm
+++ b/crates/languages/src/jsdoc/highlights.scm
@@ -1,3 +1,3 @@
-(tag_name) @keyword.jsdoc
-(type) @type.jsdoc
-(identifier) @variable.jsdoc
+(tag_name) @keyword
+(type) @type
+(identifier) @variable

--- a/crates/languages/src/regex/highlights.scm
+++ b/crates/languages/src/regex/highlights.scm
@@ -11,16 +11,16 @@
   "]"
   "{"
   "}"
-] @punctuation.bracket.regex
+] @punctuation.bracket
 
-(group_name) @label.regex
+(group_name) @label
 
 [
   (identity_escape)
   (control_letter_escape)
   (character_class_escape)
   (control_escape)
-] @string.escape.regex
+] @string.escape
 
 [
   "*"
@@ -33,23 +33,23 @@
   (end_assertion)
   (any_character)
   (lazy)
-] @operator.regex
+] @operator
 
 [
   (boundary_assertion)
   (non_boundary_assertion)
   (backreference_escape)
   (decimal_escape)
-] @keyword.operator.regex
+] @keyword.operator
 
 (count_quantifier
   [
-    (decimal_digits) @number.quantifier.regex
-    "," @punctuation.delimiter.regex
+    (decimal_digits) @number.quantifier
+    "," @punctuation.delimiter
   ])
 
 (character_class
   [
-    "^" @operator.regex
-    (class_range "-" @operator.regex)
+    "^" @operator
+    (class_range "-" @operator)
   ])

--- a/docs/src/themes.md
+++ b/docs/src/themes.md
@@ -50,6 +50,9 @@ For example, add the following to your `settings.json` if you wish to override t
         },
         "comment.doc": {
           "font_style": "italic"
+        },
+        "comment.doc.rust": {
+          "font_style": "normal"
         }
       },
       "accents": [
@@ -66,6 +69,8 @@ For example, add the following to your `settings.json` if you wish to override t
 ```
 
 To see a comprehensive list of list of captures (like `comment` and `comment.doc`) see [Language Extensions: Syntax highlighting](./extensions/languages.md#syntax-highlighting).
+
+Note that a final dot-separated component may be used to match the [grammar name](./extensions/languages.md#grammar), e.g. `comment.doc.javascript`, to customize highlighting for a specific language only.
 
 To see a list of available theme attributes look at the JSON file for your theme.
 For example, [assets/themes/one/one.json](https://github.com/zed-industries/zed/blob/main/assets/themes/one/one.json) for the default One Dark and One Light themes.


### PR DESCRIPTION
Closes #20166 (which was marked as stale, but I think still desirable)
Also relates to part of #9461 (number 2 in the description)

This effectively adds the Tree-sitter grammar name as the final component for every capture of every `highlights.scm` query, which allows users / theme developers to utilize this final component.

Some extensions (e.g. `html`) or builtin languages (e.g. `regex`) sometimes already use this "by convention", but this formalizes and standardizes it for all languages without requiring opt-in.

This is a backwards compatible change, as far as I know:
 - Existing themes' less-specific scopes continue to match the new more-specific, captures.
  Like how `@punctuation` matches `@punctuation.bracket`, `@keyword` will match `@keyword.rust`.

 - Extensions that use this convention remain functional, since new captures are a subset of existing captures 
   e.g. `@punctuation.bracket.html.html` will match everything that `@punctuation.bracket.html` previously matched.
   Extension authors may wish to remove the redundant captures but don't need to.

 - Builtin languages have had the redundant captures removed, primarily to serve as examples for extension authors.


Release Notes:

- Added support for per-language syntax theming
