### PR TITLE
Revert: Capture terminal output when thread is interrupted (#46306)

### DIFF
--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -1311,10 +1311,7 @@ impl acp_thread::AgentConnection for NativeAgentConnection {
         log::info!("Cancelling on session: {}", session_id);
         self.0.update(cx, |agent, cx| {
             if let Some(agent) = agent.sessions.get(session_id) {
-                agent
-                    .thread
-                    .update(cx, |thread, cx| thread.cancel(cx))
-                    .detach();
+                agent.thread.update(cx, |thread, cx| thread.cancel(cx));
             }
         });
     }

--- a/crates/agent/src/tools/terminal_tool.rs
+++ b/crates/agent/src/tools/terminal_tool.rs
@@ -2,7 +2,7 @@ use agent_client_protocol as acp;
 use agent_settings::AgentSettings;
 use anyhow::Result;
 use futures::FutureExt as _;
-use gpui::{App, Entity, SharedString, Task};
+use gpui::{App, AppContext, Entity, SharedString, Task};
 use project::Project;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -147,12 +147,13 @@ impl AgentTool for TerminalTool {
             let timeout = input.timeout_ms.map(Duration::from_millis);
 
             let mut timed_out = false;
-            let mut user_stopped_via_signal = false;
             let wait_for_exit = terminal.wait_for_exit(cx)?;
 
             match timeout {
                 Some(timeout) => {
-                    let timeout_task = cx.background_executor().timer(timeout);
+                    let timeout_task = cx.background_spawn(async move {
+                        smol::Timer::after(timeout).await;
+                    });
 
                     futures::select! {
                         _ = wait_for_exit.clone().fuse() => {},
@@ -161,32 +162,17 @@ impl AgentTool for TerminalTool {
                             terminal.kill(cx)?;
                             wait_for_exit.await;
                         }
-                        _ = event_stream.cancelled_by_user().fuse() => {
-                            user_stopped_via_signal = true;
-                            terminal.kill(cx)?;
-                            wait_for_exit.await;
-                        }
                     }
                 }
                 None => {
-                    futures::select! {
-                        _ = wait_for_exit.clone().fuse() => {},
-                        _ = event_stream.cancelled_by_user().fuse() => {
-                            user_stopped_via_signal = true;
-                            terminal.kill(cx)?;
-                            wait_for_exit.await;
-                        }
-                    }
+                    wait_for_exit.await;
                 }
             };
 
             // Check if user stopped - we check both:
             // 1. The cancellation signal from RunningTurn::cancel (e.g. user pressed main Stop button)
             // 2. The terminal's user_stopped flag (e.g. user clicked Stop on the terminal card)
-            // Note: user_stopped_via_signal is already set above if we detected cancellation in the select!
-            // but we also check was_cancelled_by_user() for cases where cancellation happened after wait_for_exit completed
-            let user_stopped_via_signal =
-                user_stopped_via_signal || event_stream.was_cancelled_by_user();
+            let user_stopped_via_signal = event_stream.was_cancelled_by_user();
             let user_stopped_via_terminal = terminal.was_stopped_by_user(cx).unwrap_or(false);
             let user_stopped = user_stopped_via_signal || user_stopped_via_terminal;
 


### PR DESCRIPTION
This reverts PR #46306 because I think the approach needs refinement.

## What we had to do to revert

GitHub couldn't auto-revert due to merge conflicts in the test file, so we manually reverted:

- `Thread::cancel()` - back to synchronous (doesn't return `Task`)
- `RunningTurn::cancel()` - no longer returns the task
- `run_turn_internal` - removed cancellation check in event loop
- `terminal_tool` - removed cancellation signal check in `wait_for_exit`
- Tests - removed `.await`/`.detach()` calls on `cancel()`, simplified the cancellation-aware tool test

Release Notes:

- N/A