### PR TITLE
Adding a missing conversion for elementID on paint example

### DIFF
--- a/crates/gpui/examples/painting.rs
+++ b/crates/gpui/examples/painting.rs
@@ -1,7 +1,7 @@
 use gpui::{
     Application, Background, Bounds, ColorSpace, Context, MouseDownEvent, Path, PathBuilder,
     PathStyle, Pixels, Point, Render, StrokeOptions, Window, WindowOptions, canvas, div,
-    linear_color_stop, linear_gradient, point, prelude::*, px, quad, rgb, size,
+    linear_color_stop, linear_gradient, point, prelude::*, px, quad, rgb, size, ElementId
 };
 
 struct PaintingViewer {
@@ -309,7 +309,7 @@ fn button(
     on_click: impl Fn(&mut PaintingViewer, &mut Context<PaintingViewer>) + 'static,
 ) -> impl IntoElement {
     div()
-        .id(text.to_string())
+        .id(ElementId::Name(text.to_string().into()))
         .child(text.to_string())
         .bg(gpui::black())
         .text_color(gpui::white())


### PR DESCRIPTION
Relatively new to gpui, but looking at an example on windows and found this compilation error. Hope this is the right way to contribute the patch. 

Release Notes:

- Fixed A compilation error in the gpui example painting. 
