### PR TITLE
linux: Fix duplicate IME input on Wayland and Sunshine remotes

### DIFF
--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -1207,6 +1207,12 @@ impl Dispatch<wl_seat::WlSeat, ()> for WaylandClientStatePtr {
             if capabilities.contains(wl_seat::Capability::Keyboard) {
                 let keyboard = seat.get_keyboard(qh, ());
 
+                if let Some(text_input) = state.text_input.take() {
+                    text_input.destroy();
+                    state.ime_pre_edit = None;
+                    state.composing = false;
+                }
+
                 state.text_input = state
                     .globals
                     .text_input_manager
@@ -1221,6 +1227,11 @@ impl Dispatch<wl_seat::WlSeat, ()> for WaylandClientStatePtr {
             }
             if capabilities.contains(wl_seat::Capability::Pointer) {
                 let pointer = seat.get_pointer(qh, ());
+
+                if let Some(cursor_shape_device) = state.cursor_shape_device.take() {
+                    cursor_shape_device.destroy();
+                }
+
                 state.cursor_shape_device = state
                     .globals
                     .cursor_shape_manager


### PR DESCRIPTION
## Summary
This PR fixes a issue where Chinese characters (and other IME-based inputs) would duplicate in the editor on Linux Wayland after remote desktop connected (e.g., via Sunshine) .

## Steps to Reproduce
requirement: linux with wayland, and Sunshine(this is remote desktop server) installed
1. opening zed
2. using other device connect to Sunshine
3. input Chinese characters such as "的"

### Expected Result
"的"

### Actual Result
"的的"

### bug recording
https://github.com/user-attachments/assets/d18961ec-48cb-4c06-a396-9fc604591769

