### PR TITLE
Update GPUI dependency: ashpd 0.12 -> 0.12.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,9 +784,9 @@ dependencies = [
 
 [[package]]
 name = "ashpd"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0986d5b4f0802160191ad75f8d33ada000558757db3defb70299ca95d9fcbd"
+checksum = "618a409b91d5265798a99e3d1d0b226911605e581c4e7255e83c1e397b172bce"
 dependencies = [
  "async-fs",
  "async-net",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -450,7 +450,7 @@ alacritty_terminal = "0.25.1-rc1"
 any_vec = "0.14"
 anyhow = "1.0.86"
 arrayvec = { version = "0.7.4", features = ["serde"] }
-ashpd = { version = "0.12", default-features = false, features = ["async-std"] }
+ashpd = { version = "0.12.1", default-features = false, features = ["async-std"] }
 async-compat = "0.2.1"
 async-compression = { version = "0.4", features = ["gzip", "futures-io"] }
 async-dispatcher = "0.1"


### PR DESCRIPTION
Release Notes:

- N/A

TL;DR: There was a closed issue 7 hours ago that changed ashpd version, it needed another bump.

A dependency of gpui called ashpd has a fix in v0.12.1, GPUI has the 0.12 version. After forking zed and patching the gpui source to be mine with 0.12.1 it was able to use GPUI as a dependency and compile the project. The error I was getting and the recomendation to do this PR can be seen in this [closed issue from ashpd](https://github.com/bilelmoussaoui/ashpd/issues/325). 

After changing the dependecy I hit cargo check:
```bash
   Finished `dev` profile [unoptimized + debuginfo] target(s) in 4m 24s
```

And cargo run:
```bash
  Compiling zed v0.220.0 (/home/user/git/xaviduds/zed/crates/zed)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 9m 44s
     Running `target/debug/zed`
```

Zed compiled and opened:
<img width="1920" height="1042" alt="image" src="https://github.com/user-attachments/assets/8bc524d1-bc4a-43f8-9da4-b02faecca30c" />