### PR TITLE
languages: Exclude TestMain from Go runnables

### DIFF
--- a/crates/languages/src/go/runnables.scm
+++ b/crates/languages/src/go/runnables.scm
@@ -2,7 +2,8 @@
 (
   (
     (function_declaration name: (_) @run
-      (#match? @run "^Test.*"))
+      (#match? @run "^Test.*")
+      (#not-match? @run "^TestMain$"))
   ) @_
   (#set! tag go-test)
 )


### PR DESCRIPTION
Exclude special [TestMain](https://pkg.go.dev/testing#hdr-Main) function from Go runnables.

Release Notes:

- Excluded `TestMain` function from Go runnables.