### PR TITLE
Update GPUI dependency: core-foundation =0.10.0 -> ~0.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -492,7 +492,7 @@ clap = { version = "4.4", features = ["derive", "wrap_help"] }
 cocoa = "=0.26.0"
 cocoa-foundation = "=0.2.0"
 convert_case = "0.8.0"
-core-foundation = "=0.10.0"
+core-foundation = "~0.10.0"
 core-foundation-sys = "0.8.6"
 core-video = { version = "0.4.3", features = ["metal"] }
 cpal = "0.16"


### PR DESCRIPTION
Release Notes:

- Fixed GPUI core-foundation dependency conflict when working with crates that depend on newer `core-foundation = 0.10.1`
