### PR TITLE
Stylize 'ty' correctly in python configuration docs

### DIFF
--- a/docs/src/languages/python.md
+++ b/docs/src/languages/python.md
@@ -82,7 +82,7 @@ These are disabled by default, but can be enabled in your settings. For example:
   "languages": {
     "Python": {
       "language_servers": [
-        // Disable basedpyright and enable Ty, and otherwise
+        // Disable basedpyright and enable ty, and otherwise
         // use the default configuration.
         "ty",
         "!basedpyright",


### PR DESCRIPTION
https://github.com/astral-sh/ty?tab=readme-ov-file#how-should-i-stylize-ty states that we should use "ty" rather than "Ty".