### PR TITLE
Always show worktree trust, even if other title bar items are hidden with settings

### DIFF
--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -161,11 +161,11 @@ impl Render for TitleBar {
                                 title_bar.child(menu)
                             },
                         )
+                        .children(self.render_restricted_mode(cx))
                         .when(render_project_items, |title_bar| {
                             title_bar
                                 .when(title_bar_settings.show_project_items, |title_bar| {
                                     title_bar
-                                        .children(self.render_restricted_mode(cx))
                                         .children(self.render_project_host(cx))
                                         .child(self.render_project_name(cx))
                                 })


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/discussions/46595

Release Notes:

- Fixed "show project items" keeping worktree trust title bar element hidden
