### PR TITLE
workspace: Improve the multi-project UX

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16927,6 +16927,7 @@ dependencies = [
  "git_ui",
  "gpui",
  "http_client",
+ "menu",
  "notifications",
  "pretty_assertions",
  "project",

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -561,6 +561,7 @@
       // "alt-ctrl-shift-o": "["projects::OpenRemote", { "from_existing_connection": true }]",
       "alt-ctrl-shift-o": ["projects::OpenRemote", { "from_existing_connection": false, "create_new_window": false }],
       "alt-ctrl-shift-b": "branches::OpenRecent",
+      "ctrl-alt-p": "workspace::SwitchProject",
       "alt-shift-enter": "toast::RunAction",
       "ctrl-~": "workspace::NewTerminal",
       "save": "workspace::Save",
@@ -1346,6 +1347,12 @@
       "alt-1": "git_picker::ActivateBranchesTab",
       "alt-2": "git_picker::ActivateWorktreesTab",
       "alt-3": "git_picker::ActivateStashTab",
+    },
+  },
+  {
+    "context": "MultiProjectDropdown",
+    "bindings": {
+      "shift-backspace": "project_dropdown::RemoveSelectedFolder",
     },
   },
 ]

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -1451,4 +1451,10 @@
       "cmd-3": "git_picker::ActivateStashTab",
     },
   },
+  {
+    "context": "MultiProjectDropdown",
+    "bindings": {
+      "shift-backspace": "project_dropdown::RemoveSelectedFolder",
+    },
+  },
 ]

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -631,6 +631,7 @@
       "ctrl-cmd-o": ["projects::OpenRemote", { "from_existing_connection": false, "create_new_window": false }],
       "ctrl-cmd-shift-o": ["projects::OpenRemote", { "from_existing_connection": true, "create_new_window": false }],
       "cmd-ctrl-b": "branches::OpenRecent",
+      "cmd-alt-p": "workspace::SwitchProject",
       "ctrl-~": "workspace::NewTerminal",
       "cmd-s": "workspace::Save",
       "cmd-k s": "workspace::SaveWithoutFormat",

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -560,6 +560,7 @@
       // "ctrl-shift-alt-o": "["projects::OpenRemote", { "from_existing_connection": true }]",
       "ctrl-shift-alt-o": ["projects::OpenRemote", { "from_existing_connection": false, "create_new_window": false }],
       "shift-alt-b": "branches::OpenRecent",
+      "ctrl-alt-p": "workspace::SwitchProject",
       "shift-alt-enter": "toast::RunAction",
       "ctrl-shift-`": "workspace::NewTerminal",
       "ctrl-s": "workspace::Save",
@@ -1367,6 +1368,12 @@
       "alt-1": "git_picker::ActivateBranchesTab",
       "alt-2": "git_picker::ActivateWorktreesTab",
       "alt-3": "git_picker::ActivateStashTab",
+    },
+  },
+  {
+    "context": "MultiProjectDropdown",
+    "bindings": {
+      "shift-backspace": "project_dropdown::RemoveSelectedFolder",
     },
   },
 ]

--- a/crates/git_ui/src/branch_picker.rs
+++ b/crates/git_ui/src/branch_picker.rs
@@ -61,7 +61,33 @@ pub fn open(
     cx: &mut Context<Workspace>,
 ) {
     let workspace_handle = workspace.weak_handle();
-    let repository = workspace.project().read(cx).active_repository(cx);
+    let project = workspace.project().clone();
+
+    // Check if there's a worktree override from the project dropdown.
+    // This ensures the branch picker shows branches for the project the user
+    // explicitly selected in the title bar, not just the focused file's project.
+    // This is only relevant if for multi-projects workspaces.
+    let repository = workspace
+        .active_worktree_override()
+        .and_then(|override_id| {
+            let project_ref = project.read(cx);
+            project_ref
+                .worktree_for_id(override_id, cx)
+                .and_then(|worktree| {
+                    let worktree_abs_path = worktree.read(cx).abs_path();
+                    let git_store = project_ref.git_store().read(cx);
+                    git_store
+                        .repositories()
+                        .values()
+                        .find(|repo| {
+                            let repo_path = &repo.read(cx).work_directory_abs_path;
+                            *repo_path == worktree_abs_path
+                                || worktree_abs_path.starts_with(repo_path.as_ref())
+                        })
+                        .cloned()
+                })
+        })
+        .or_else(|| project.read(cx).active_repository(cx));
 
     workspace.toggle_modal(window, cx, |window, cx| {
         BranchList::new(

--- a/crates/git_ui/src/git_picker.rs
+++ b/crates/git_ui/src/git_picker.rs
@@ -549,7 +549,33 @@ fn open_with_tab(
     cx: &mut Context<Workspace>,
 ) {
     let workspace_handle = workspace.weak_handle();
-    let repository = workspace.project().read(cx).active_repository(cx);
+    let project = workspace.project().clone();
+
+    // Check if there's a worktree override from the project dropdown.
+    // This ensures the git picker shows info for the project the user
+    // explicitly selected in the title bar, not just the focused file's project.
+    // This is only relevant if for multi-projects workspaces.
+    let repository = workspace
+        .active_worktree_override()
+        .and_then(|override_id| {
+            let project_ref = project.read(cx);
+            project_ref
+                .worktree_for_id(override_id, cx)
+                .and_then(|worktree| {
+                    let worktree_abs_path = worktree.read(cx).abs_path();
+                    let git_store = project_ref.git_store().read(cx);
+                    git_store
+                        .repositories()
+                        .values()
+                        .find(|repo| {
+                            let repo_path = &repo.read(cx).work_directory_abs_path;
+                            *repo_path == worktree_abs_path
+                                || worktree_abs_path.starts_with(repo_path.as_ref())
+                        })
+                        .cloned()
+                })
+        })
+        .or_else(|| project.read(cx).active_repository(cx));
 
     workspace.toggle_modal(window, cx, |window, cx| {
         GitPicker::new(workspace_handle, repository, tab, rems(34.), window, cx)

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -354,6 +354,7 @@ pub enum Event {
     EntryRenamed(ProjectTransaction, ProjectPath, PathBuf),
     WorkspaceEditApplied(ProjectTransaction),
     AgentLocationChanged,
+    BufferEdited,
 }
 
 pub struct AgentLocationChanged;
@@ -3409,6 +3410,10 @@ impl Project {
     ) -> Option<()> {
         if matches!(event, BufferEvent::Edited | BufferEvent::Reloaded) {
             self.request_buffer_diff_recalculation(&buffer, cx);
+        }
+
+        if matches!(event, BufferEvent::Edited) {
+            cx.emit(Event::BufferEdited);
         }
 
         let buffer_id = buffer.read(cx).remote_id();

--- a/crates/title_bar/Cargo.toml
+++ b/crates/title_bar/Cargo.toml
@@ -39,6 +39,7 @@ cloud_llm_client.workspace = true
 db.workspace = true
 git_ui.workspace = true
 gpui = { workspace = true, features = ["screen-capture"] }
+menu.workspace = true
 notifications.workspace = true
 project.workspace = true
 recent_projects.workspace = true

--- a/crates/title_bar/src/project_dropdown.rs
+++ b/crates/title_bar/src/project_dropdown.rs
@@ -141,7 +141,7 @@ impl ProjectDropdown {
                                 .icon_color(Color::Muted)
                                 .tooltip(move |_, cx| {
                                     Tooltip::for_action_in(
-                                        "Remove Project",
+                                        "Remove Folder",
                                         &RemoveSelectedFolder,
                                         &menu_focus_handle,
                                         cx,

--- a/crates/title_bar/src/project_dropdown.rs
+++ b/crates/title_bar/src/project_dropdown.rs
@@ -40,7 +40,7 @@ impl ProjectDropdown {
         let worktree_ids: Rc<RefCell<Vec<WorktreeId>>> = Rc::new(RefCell::new(Vec::new()));
 
         let menu = Self::build_menu(
-            project.clone(),
+            project,
             workspace.clone(),
             initial_active_worktree_id,
             menu_shell.clone(),
@@ -136,7 +136,7 @@ impl ProjectDropdown {
                                     ("remove", worktree_id.to_usize()),
                                     IconName::Close,
                                 )
-                                .visible_on_hover(name.clone())
+                                .visible_on_hover(name)
                                 .icon_size(IconSize::Small)
                                 .icon_color(Color::Muted)
                                 .tooltip(move |_, cx| {
@@ -148,7 +148,7 @@ impl ProjectDropdown {
                                     )
                                 })
                                 .on_click({
-                                    let workspace = workspace_for_remove.clone();
+                                    let workspace = workspace_for_remove;
                                     move |_, window, cx| {
                                         Self::handle_remove(
                                             workspace.clone(),

--- a/crates/title_bar/src/project_dropdown.rs
+++ b/crates/title_bar/src/project_dropdown.rs
@@ -1,0 +1,270 @@
+use gpui::{
+    Action, App, Context, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable, Subscription,
+    WeakEntity,
+};
+use project::{Project, Worktree, git_store::Repository};
+use settings::WorktreeId;
+use ui::{ContextMenu, prelude::*};
+use workspace::Workspace;
+
+use crate::TitleBar;
+
+struct ProjectEntry {
+    worktree_id: WorktreeId,
+    name: SharedString,
+    branch: Option<SharedString>,
+    is_active: bool,
+}
+
+pub struct ProjectDropdown {
+    menu: Entity<ContextMenu>,
+    _subscription: Subscription,
+}
+
+impl ProjectDropdown {
+    pub fn new(
+        project: Entity<Project>,
+        workspace: WeakEntity<Workspace>,
+        active_worktree_id: Option<WorktreeId>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let menu = Self::build_menu(project, workspace, active_worktree_id, window, cx);
+
+        let _subscription = cx.subscribe(&menu, |_, _, _: &DismissEvent, cx| {
+            cx.emit(DismissEvent);
+        });
+
+        Self {
+            menu,
+            _subscription,
+        }
+    }
+
+    fn build_menu(
+        project: Entity<Project>,
+        workspace: WeakEntity<Workspace>,
+        active_worktree_id: Option<WorktreeId>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Entity<ContextMenu> {
+        let entries = Self::get_project_entries(&project, active_worktree_id, cx);
+
+        ContextMenu::build(window, cx, move |menu, _window, _cx| {
+            let mut menu = menu.header("Open Folders");
+
+            for entry in entries {
+                let worktree_id = entry.worktree_id;
+                let name = entry.name.clone();
+                let branch = entry.branch.clone();
+                let is_active = entry.is_active;
+
+                let workspace_for_select = workspace.clone();
+                let workspace_for_remove = workspace.clone();
+
+                menu = menu.custom_entry(
+                    move |_window, _cx| {
+                        let name = name.clone();
+                        let branch = branch.clone();
+                        let workspace_for_remove = workspace_for_remove.clone();
+
+                        h_flex()
+                            .group(name.clone())
+                            .w_full()
+                            .justify_between()
+                            .child(
+                                h_flex()
+                                    .gap_1()
+                                    .child(
+                                        Label::new(name.clone())
+                                            .when(is_active, |label| label.color(Color::Accent)),
+                                    )
+                                    .when_some(branch, |this, branch| {
+                                        this.child(Label::new(branch).color(Color::Muted))
+                                    }),
+                            )
+                            .child(
+                                IconButton::new(
+                                    ("remove", worktree_id.to_usize()),
+                                    IconName::Close,
+                                )
+                                .visible_on_hover(name.clone())
+                                .icon_size(IconSize::Small)
+                                .icon_color(Color::Muted)
+                                .on_click({
+                                    let workspace = workspace_for_remove.clone();
+                                    move |_, window, cx| {
+                                        Self::handle_remove(
+                                            workspace.clone(),
+                                            worktree_id,
+                                            active_worktree_id,
+                                            window,
+                                            cx,
+                                        );
+                                    }
+                                }),
+                            )
+                            .into_any_element()
+                    },
+                    move |window, cx| {
+                        Self::handle_select(workspace_for_select.clone(), worktree_id, window, cx);
+                    },
+                );
+            }
+
+            menu.separator()
+                .action(
+                    "Add Folder to Workspace",
+                    workspace::AddFolderToProject.boxed_clone(),
+                )
+                .action(
+                    "Open Recent Projects",
+                    zed_actions::OpenRecent {
+                        create_new_window: false,
+                    }
+                    .boxed_clone(),
+                )
+        })
+    }
+
+    /// Get all projects sorted alphabetically with their branch info.
+    fn get_project_entries(
+        project: &Entity<Project>,
+        active_worktree_id: Option<WorktreeId>,
+        cx: &App,
+    ) -> Vec<ProjectEntry> {
+        let project = project.read(cx);
+        let git_store = project.git_store().read(cx);
+        let repositories: Vec<_> = git_store.repositories().values().cloned().collect();
+
+        let mut entries: Vec<ProjectEntry> = project
+            .visible_worktrees(cx)
+            .map(|worktree| {
+                let worktree_ref = worktree.read(cx);
+                let worktree_id = worktree_ref.id();
+                let name = SharedString::from(worktree_ref.root_name().as_unix_str().to_string());
+
+                let branch = Self::get_branch_for_worktree(worktree_ref, &repositories, cx);
+
+                let is_active = active_worktree_id == Some(worktree_id);
+
+                ProjectEntry {
+                    worktree_id,
+                    name,
+                    branch,
+                    is_active,
+                }
+            })
+            .collect();
+
+        entries.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+        entries
+    }
+
+    fn get_branch_for_worktree(
+        worktree: &Worktree,
+        repositories: &[Entity<Repository>],
+        cx: &App,
+    ) -> Option<SharedString> {
+        let worktree_abs_path = worktree.abs_path();
+
+        for repo in repositories {
+            let repo = repo.read(cx);
+            if repo.work_directory_abs_path == worktree_abs_path
+                || worktree_abs_path.starts_with(&*repo.work_directory_abs_path)
+            {
+                if let Some(branch) = &repo.branch {
+                    return Some(SharedString::from(branch.name().to_string()));
+                }
+            }
+        }
+        None
+    }
+
+    fn handle_select(
+        workspace: WeakEntity<Workspace>,
+        worktree_id: WorktreeId,
+        _window: &mut Window,
+        cx: &mut App,
+    ) {
+        if let Some(workspace) = workspace.upgrade() {
+            if let Some(titlebar) = workspace
+                .read(cx)
+                .titlebar_item()
+                .and_then(|item| item.downcast::<TitleBar>().ok())
+            {
+                titlebar.update(cx, |titlebar, cx| {
+                    titlebar.set_active_worktree_override(worktree_id, cx);
+                });
+            }
+        }
+    }
+
+    fn handle_remove(
+        workspace: WeakEntity<Workspace>,
+        worktree_id: WorktreeId,
+        active_worktree_id: Option<WorktreeId>,
+        _window: &mut Window,
+        cx: &mut App,
+    ) {
+        let is_removing_active = active_worktree_id == Some(worktree_id);
+
+        if let Some(workspace) = workspace.upgrade() {
+            workspace.update(cx, |workspace, cx| {
+                let project = workspace.project();
+
+                if is_removing_active {
+                    let worktrees: Vec<_> = project.read(cx).visible_worktrees(cx).collect();
+
+                    let mut sorted: Vec<_> = worktrees
+                        .iter()
+                        .map(|wt| {
+                            let wt = wt.read(cx);
+                            (wt.root_name().as_unix_str().to_string(), wt.id())
+                        })
+                        .collect();
+                    sorted.sort_by(|a, b| a.0.to_lowercase().cmp(&b.0.to_lowercase()));
+
+                    if let Some(idx) = sorted.iter().position(|(_, id)| *id == worktree_id) {
+                        let new_active_id = if idx > 0 {
+                            Some(sorted[idx - 1].1)
+                        } else if sorted.len() > 1 {
+                            Some(sorted[1].1)
+                        } else {
+                            None
+                        };
+
+                        if let Some(new_id) = new_active_id {
+                            if let Some(titlebar) = workspace
+                                .titlebar_item()
+                                .and_then(|item| item.downcast::<TitleBar>().ok())
+                            {
+                                titlebar.update(cx, |titlebar, cx| {
+                                    titlebar.set_active_worktree_override(new_id, cx);
+                                });
+                            }
+                        }
+                    }
+                }
+
+                project.update(cx, |project, cx| {
+                    project.remove_worktree(worktree_id, cx);
+                });
+            });
+        }
+    }
+}
+
+impl Render for ProjectDropdown {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        self.menu.clone()
+    }
+}
+
+impl EventEmitter<DismissEvent> for ProjectDropdown {}
+
+impl Focusable for ProjectDropdown {
+    fn focus_handle(&self, cx: &App) -> FocusHandle {
+        self.menu.focus_handle(cx)
+    }
+}

--- a/crates/title_bar/src/project_dropdown.rs
+++ b/crates/title_bar/src/project_dropdown.rs
@@ -5,6 +5,7 @@ use gpui::{
     Action, App, Context, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable, Subscription,
     WeakEntity,
 };
+use menu;
 use project::{Project, Worktree, git_store::Repository};
 use settings::WorktreeId;
 use ui::{ContextMenu, prelude::*};
@@ -147,6 +148,7 @@ impl ProjectDropdown {
                     },
                     move |window, cx| {
                         Self::handle_select(workspace_for_select.clone(), worktree_id, window, cx);
+                        window.dispatch_action(menu::Cancel.boxed_clone(), cx);
                     },
                 );
             }

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -301,8 +301,8 @@ impl TitleBar {
                     // Clear override when user types in any editor,
                     // so the title bar reflects the project they're actually working in
                     this.clear_active_worktree_override(cx);
+                    cx.notify();
                 }
-                cx.notify();
             }),
         );
         subscriptions.push(cx.observe(&active_call, |this, _, cx| this.active_call_changed(cx)));

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -76,7 +76,7 @@ pub fn init(cx: &mut App) {
             return;
         };
         let item = cx.new(|cx| TitleBar::new("title-bar", workspace, window, cx));
-        workspace.set_titlebar_item(item.clone().into(), window, cx);
+        workspace.set_titlebar_item(item.into(), window, cx);
 
         workspace.register_action(|workspace, _: &SwitchProject, window, cx| {
             if let Some(titlebar) = workspace
@@ -787,7 +787,7 @@ impl TitleBar {
 
         let settings = TitleBarSettings::get_global(cx);
 
-        let effective_repository = Some(repository.clone());
+        let effective_repository = Some(repository);
 
         Some(
             PopoverMenu::new("branch-menu")

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -3,6 +3,7 @@ pub mod collab;
 mod onboarding_banner;
 pub mod platform_title_bar;
 mod platforms;
+mod project_dropdown;
 mod system_window_tabs;
 mod title_bar_settings;
 
@@ -25,15 +26,17 @@ use call::ActiveCall;
 use client::{Client, UserStore, zed_urls};
 use cloud_llm_client::{Plan, PlanV1, PlanV2};
 use gpui::{
-    Action, AnyElement, App, Context, Corner, Element, Entity, Focusable, InteractiveElement,
-    IntoElement, MouseButton, ParentElement, Render, StatefulInteractiveElement, Styled,
-    Subscription, WeakEntity, Window, actions, div,
+    Action, AnyElement, App, Context, Corner, Element, Entity, FocusHandle, Focusable,
+    InteractiveElement, IntoElement, MouseButton, ParentElement, Render,
+    StatefulInteractiveElement, Styled, Subscription, WeakEntity, Window, actions, div,
 };
 use onboarding_banner::OnboardingBanner;
 use project::{
     Project, WorktreeSettings, git_store::GitStoreEvent, trusted_worktrees::TrustedWorktrees,
 };
+use project_dropdown::ProjectDropdown;
 use remote::RemoteConnectionOptions;
+use settings::WorktreeId;
 use settings::{Settings, SettingsLocation};
 use std::sync::Arc;
 use theme::ActiveTheme;
@@ -43,7 +46,7 @@ use ui::{
     PopoverMenuHandle, TintColor, Tooltip, prelude::*,
 };
 use util::{ResultExt, rel_path::RelPath};
-use workspace::{ToggleWorktreeSecurity, Workspace, notifications::NotifyResultExt};
+use workspace::{SwitchProject, ToggleWorktreeSecurity, Workspace, notifications::NotifyResultExt};
 use zed_actions::OpenRemote;
 
 pub use onboarding_banner::restore_banner;
@@ -75,7 +78,18 @@ pub fn init(cx: &mut App) {
             return;
         };
         let item = cx.new(|cx| TitleBar::new("title-bar", workspace, window, cx));
-        workspace.set_titlebar_item(item.into(), window, cx);
+        workspace.set_titlebar_item(item.clone().into(), window, cx);
+
+        workspace.register_action(|workspace, _: &SwitchProject, window, cx| {
+            if let Some(titlebar) = workspace
+                .titlebar_item()
+                .and_then(|item| item.downcast::<TitleBar>().ok())
+            {
+                titlebar.update(cx, |titlebar, cx| {
+                    titlebar.show_project_dropdown(window, cx);
+                });
+            }
+        });
 
         #[cfg(not(target_os = "macos"))]
         workspace.register_action(|workspace, action: &OpenApplicationMenu, window, cx| {
@@ -136,6 +150,8 @@ pub struct TitleBar {
     _subscriptions: Vec<Subscription>,
     banner: Entity<OnboardingBanner>,
     screen_share_popover_handle: PopoverMenuHandle<ContextMenu>,
+    project_dropdown_handle: PopoverMenuHandle<ProjectDropdown>,
+    active_worktree_override: Option<WorktreeId>,
 }
 
 impl Render for TitleBar {
@@ -170,7 +186,7 @@ impl Render for TitleBar {
                                         .child(self.render_project_name(cx))
                                 })
                                 .when(title_bar_settings.show_branch_name, |title_bar| {
-                                    title_bar.children(self.render_project_repo(cx))
+                                    title_bar.children(self.render_project_branch(cx))
                                 })
                         })
                 })
@@ -282,13 +298,27 @@ impl TitleBar {
                 cx.notify()
             }),
         );
-        subscriptions.push(cx.subscribe(&project, |_, _, _: &project::Event, cx| cx.notify()));
+        subscriptions.push(
+            cx.subscribe(&project, |this, _, event: &project::Event, cx| {
+                if let project::Event::BufferEdited = event {
+                    // Clear override when user types in any editor,
+                    // so the title bar reflects the project they're actually working in
+                    this.clear_active_worktree_override(cx);
+                }
+                cx.notify();
+            }),
+        );
         subscriptions.push(cx.observe(&active_call, |this, _, cx| this.active_call_changed(cx)));
         subscriptions.push(cx.observe_window_activation(window, Self::window_activation_changed));
         subscriptions.push(
-            cx.subscribe(&git_store, move |_, _, event, cx| match event {
-                GitStoreEvent::ActiveRepositoryChanged(_)
-                | GitStoreEvent::RepositoryUpdated(_, _, true) => {
+            cx.subscribe(&git_store, move |this, _, event, cx| match event {
+                GitStoreEvent::ActiveRepositoryChanged(_) => {
+                    // Clear override when focus-derived active repo changes
+                    // (meaning the user focused a file from a different project)
+                    this.clear_active_worktree_override(cx);
+                    cx.notify();
+                }
+                GitStoreEvent::RepositoryUpdated(_, _, true) => {
                     cx.notify();
                 }
                 _ => {}
@@ -326,28 +356,82 @@ impl TitleBar {
             _subscriptions: subscriptions,
             banner,
             screen_share_popover_handle: PopoverMenuHandle::default(),
+            project_dropdown_handle: PopoverMenuHandle::default(),
+            active_worktree_override: None,
         }
     }
 
-    fn project_name(&self, cx: &Context<Self>) -> Option<SharedString> {
-        self.project
-            .read(cx)
-            .visible_worktrees(cx)
-            .map(|worktree| {
-                let worktree = worktree.read(cx);
-                let settings_location = SettingsLocation {
-                    worktree_id: worktree.id(),
-                    path: RelPath::empty(),
-                };
+    fn worktree_count(&self, cx: &App) -> usize {
+        self.project.read(cx).visible_worktrees(cx).count()
+    }
 
-                let settings = WorktreeSettings::get(Some(settings_location), cx);
-                let name = match &settings.project_name {
-                    Some(name) => name.as_str(),
-                    None => worktree.root_name_str(),
-                };
-                SharedString::new(name)
-            })
-            .next()
+    pub fn show_project_dropdown(&self, window: &mut Window, cx: &mut App) {
+        if self.worktree_count(cx) > 1 {
+            self.project_dropdown_handle.show(window, cx);
+        }
+    }
+
+    /// Returns the worktree to display in the title bar.
+    /// - If there's an override set, use that (if still valid)
+    /// - Otherwise, derive from the active repository
+    /// - Fall back to the first visible worktree
+    fn effective_active_worktree(&self, cx: &App) -> Option<Entity<project::Worktree>> {
+        let project = self.project.read(cx);
+
+        if let Some(override_id) = self.active_worktree_override {
+            if let Some(worktree) = project.worktree_for_id(override_id, cx) {
+                return Some(worktree);
+            }
+        }
+
+        if let Some(repo) = project.active_repository(cx) {
+            let repo = repo.read(cx);
+            let repo_path = &repo.work_directory_abs_path;
+
+            for worktree in project.visible_worktrees(cx) {
+                let worktree_path = worktree.read(cx).abs_path();
+                if worktree_path == *repo_path || worktree_path.starts_with(repo_path.as_ref()) {
+                    return Some(worktree);
+                }
+            }
+        }
+
+        project.visible_worktrees(cx).next()
+    }
+
+    pub fn set_active_worktree_override(
+        &mut self,
+        worktree_id: WorktreeId,
+        cx: &mut Context<Self>,
+    ) {
+        self.active_worktree_override = Some(worktree_id);
+        cx.notify();
+    }
+
+    fn clear_active_worktree_override(&mut self, cx: &mut Context<Self>) {
+        if self.active_worktree_override.is_some() {
+            self.active_worktree_override = None;
+            cx.notify();
+        }
+    }
+
+    fn get_repository_for_worktree(
+        &self,
+        worktree: &Entity<project::Worktree>,
+        cx: &App,
+    ) -> Option<Entity<project::git_store::Repository>> {
+        let project = self.project.read(cx);
+        let git_store = project.git_store().read(cx);
+        let worktree_path = worktree.read(cx).abs_path();
+
+        for repo in git_store.repositories().values() {
+            let repo_path = &repo.read(cx).work_directory_abs_path;
+            if worktree_path == *repo_path || worktree_path.starts_with(repo_path.as_ref()) {
+                return Some(repo.clone());
+            }
+        }
+
+        None
     }
 
     fn render_remote_project_connection(&self, cx: &mut Context<Self>) -> Option<AnyElement> {
@@ -545,10 +629,15 @@ impl TitleBar {
     pub fn render_project_name(&self, cx: &mut Context<Self>) -> impl IntoElement {
         let workspace = self.workspace.clone();
 
-        let name = self.project_name(cx);
+        let name = self.effective_active_worktree(cx).map(|worktree| {
+            let worktree = worktree.read(cx);
+            SharedString::from(worktree.root_name().as_unix_str().to_string())
+        });
+
         let is_project_selected = name.is_some();
-        let name = if let Some(name) = name {
-            util::truncate_and_trailoff(&name, MAX_PROJECT_NAME_LENGTH)
+
+        let display_name = if let Some(ref name) = name {
+            util::truncate_and_trailoff(name, MAX_PROJECT_NAME_LENGTH)
         } else {
             "Open Recent Project".to_string()
         };
@@ -557,6 +646,24 @@ impl TitleBar {
             .upgrade()
             .map(|w| w.read(cx).focus_handle(cx))
             .unwrap_or_else(|| cx.focus_handle());
+
+        if self.worktree_count(cx) > 1 {
+            self.render_multi_project_menu(display_name, is_project_selected, cx)
+                .into_any_element()
+        } else {
+            self.render_single_project_menu(display_name, is_project_selected, focus_handle, cx)
+                .into_any_element()
+        }
+    }
+
+    fn render_single_project_menu(
+        &self,
+        name: String,
+        is_project_selected: bool,
+        focus_handle: FocusHandle,
+        _cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let workspace = self.workspace.clone();
 
         PopoverMenu::new("recent-projects-menu")
             .menu(move |window, cx| {
@@ -586,9 +693,58 @@ impl TitleBar {
             .anchor(gpui::Corner::TopLeft)
     }
 
-    pub fn render_project_repo(&self, cx: &mut Context<Self>) -> Option<impl IntoElement> {
-        let repository = self.project.read(cx).active_repository(cx)?;
-        let repository_count = self.project.read(cx).repositories(cx).len();
+    fn render_multi_project_menu(
+        &self,
+        name: String,
+        is_project_selected: bool,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let project = self.project.clone();
+        let workspace = self.workspace.clone();
+        let active_worktree_id = self
+            .effective_active_worktree(cx)
+            .map(|wt| wt.read(cx).id());
+
+        let focus_handle = workspace
+            .upgrade()
+            .map(|w| w.read(cx).focus_handle(cx))
+            .unwrap_or_else(|| cx.focus_handle());
+
+        PopoverMenu::new("project-dropdown-menu")
+            .with_handle(self.project_dropdown_handle.clone())
+            .menu(move |window, cx| {
+                let project = project.clone();
+                let workspace = workspace.clone();
+
+                Some(cx.new(|cx| {
+                    ProjectDropdown::new(
+                        project.clone(),
+                        workspace.clone(),
+                        active_worktree_id,
+                        window,
+                        cx,
+                    )
+                }))
+            })
+            .trigger_with_tooltip(
+                Button::new("project_name_trigger", name)
+                    .label_size(LabelSize::Small)
+                    .selected_style(ButtonStyle::Tinted(TintColor::Accent))
+                    .icon(IconName::ChevronDown)
+                    .icon_position(IconPosition::End)
+                    .icon_size(IconSize::XSmall)
+                    .icon_color(Color::Muted)
+                    .when(!is_project_selected, |s| s.color(Color::Muted)),
+                move |_, cx| {
+                    Tooltip::for_action_in("Switch Project", &SwitchProject, &focus_handle, cx)
+                },
+            )
+            .anchor(gpui::Corner::TopLeft)
+    }
+
+    pub fn render_project_branch(&self, cx: &mut Context<Self>) -> Option<impl IntoElement> {
+        let effective_worktree = self.effective_active_worktree(cx)?;
+        let repository = self.get_repository_for_worktree(&effective_worktree, cx)?;
         let workspace = self.workspace.upgrade()?;
 
         let (branch_name, icon_info) = {
@@ -608,22 +764,6 @@ impl TitleBar {
                     })
                 });
 
-            let branch_name = branch_name?;
-
-            let project_name = self.project_name(cx);
-            let repo_name = repo
-                .work_directory_abs_path
-                .file_name()
-                .and_then(|name| name.to_str())
-                .map(SharedString::new);
-            let show_repo_name =
-                repository_count > 1 && repo.branch.is_some() && repo_name != project_name;
-            let branch_name = if let Some(repo_name) = repo_name.filter(|_| show_repo_name) {
-                format!("{repo_name}/{branch_name}")
-            } else {
-                branch_name
-            };
-
             let status = repo.status_summary();
             let tracked = status.index + status.worktree;
             let icon_info = if status.conflict > 0 {
@@ -642,22 +782,22 @@ impl TitleBar {
         };
 
         let settings = TitleBarSettings::get_global(cx);
-        let project = self.project.clone();
+
+        let effective_repository = Some(repository.clone());
 
         Some(
             PopoverMenu::new("branch-menu")
                 .menu(move |window, cx| {
-                    let repository = project.read(cx).active_repository(cx);
                     Some(git_ui::branch_picker::popover(
                         workspace.downgrade(),
                         true,
-                        repository,
+                        effective_repository.clone(),
                         window,
                         cx,
                     ))
                 })
                 .trigger_with_tooltip(
-                    Button::new("project_branch_trigger", branch_name)
+                    Button::new("project_branch_trigger", branch_name?)
                         .selected_style(ButtonStyle::Tinted(TintColor::Accent))
                         .label_size(LabelSize::Small)
                         .color(Color::Muted)

--- a/crates/ui/src/components/context_menu.rs
+++ b/crates/ui/src/components/context_menu.rs
@@ -833,6 +833,10 @@ impl ContextMenu {
         self
     }
 
+    pub fn selected_index(&self) -> Option<usize> {
+        self.selected_index
+    }
+
     pub fn confirm(&mut self, _: &menu::Confirm, window: &mut Window, cx: &mut Context<Self>) {
         let Some(ix) = self.selected_index else {
             return;

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -213,6 +213,8 @@ actions!(
         ActivatePreviousWindow,
         /// Adds a folder to the current project.
         AddFolderToProject,
+        /// Opens the project switcher dropdown (only visible when multiple folders are open).
+        SwitchProject,
         /// Clears all notifications.
         ClearAllNotifications,
         /// Clears all navigation history, including forward/backward navigation, recently opened files, and recently closed tabs. **This action is irreversible**.

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1164,6 +1164,7 @@ pub struct Workspace {
     bottom_dock: Entity<Dock>,
     right_dock: Entity<Dock>,
     panes: Vec<Entity<Pane>>,
+    active_worktree_override: Option<WorktreeId>,
     panes_by_item: HashMap<EntityId, WeakEntity<Pane>>,
     active_pane: Entity<Pane>,
     last_active_center_pane: Option<WeakEntity<Pane>>,
@@ -1571,6 +1572,7 @@ impl Workspace {
             modal_layer,
             toast_layer,
             titlebar_item: None,
+            active_worktree_override: None,
             notifications: Notifications::default(),
             suppressed_notifications: HashSet::default(),
             left_dock,
@@ -2345,6 +2347,27 @@ impl Workspace {
 
     pub fn titlebar_item(&self) -> Option<AnyView> {
         self.titlebar_item.clone()
+    }
+
+    /// Returns the worktree override set by the user (e.g., via the project dropdown).
+    /// When set, git-related operations should use this worktree instead of deriving
+    /// the active worktree from the focused file.
+    pub fn active_worktree_override(&self) -> Option<WorktreeId> {
+        self.active_worktree_override
+    }
+
+    pub fn set_active_worktree_override(
+        &mut self,
+        worktree_id: Option<WorktreeId>,
+        cx: &mut Context<Self>,
+    ) {
+        self.active_worktree_override = worktree_id;
+        cx.notify();
+    }
+
+    pub fn clear_active_worktree_override(&mut self, cx: &mut Context<Self>) {
+        self.active_worktree_override = None;
+        cx.notify();
     }
 
     /// Call the given callback with a workspace whose project is local.

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -4757,6 +4757,7 @@ mod tests {
                 "pane",
                 "panel",
                 "picker",
+                "project_dropdown",
                 "project_panel",
                 "project_search",
                 "project_symbols",


### PR DESCRIPTION
This PR introduces a project dropdown when working with multiple folders/projects in one workspace. Here are some interaction details that I hope improves the UX of working on this scenario significantly:

- The dropdown shows the currently "active" project, which is determined by:
  - Either the file you're currently editing
  - Or the file you have just recently switched to
  - Some example cases:
     - If you are focused on file from project A but switch to project B in the titlebar, nothing happens. However, as soon as you type on the file from project A, the title bar will update and your active project will return to being project A.
     - If you're focused on file from project A and change tabs to a file from project B, the title bar will update, showing project B as the active one.
- The content you'll see in the branch picker will correspond to the currently active project
- It's still possible to reach the "Recent Projects" picker through the project dropdown
- It's possible to do all interactions (trigger dropdown, select active project, and remove project from workspace) with the keyboard

https://github.com/user-attachments/assets/e2346757-74df-47c5-bf4d-6354623b6f47

Note that this entire UX is valid only for a multiple folder workspace scenario; nothing changes for the single project case.

Release Notes:

- Workspace: Improved the UX of working with multiple projects in the same workspace through introducing a project dropdown that more clearly shows the currently active project as well as allowing you to change it.
