### PR TITLE
git: Correct pending ops state handling when git stage fail

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1780,6 +1780,7 @@ impl GitPanel {
                     if let Err(err) = result {
                         this.show_error_toast(if stage { "add" } else { "reset" }, err, cx);
                     }
+                    this.update_counts(active_repository.read(cx));
                     cx.notify()
                 })
             }
@@ -1797,11 +1798,11 @@ impl GitPanel {
         // 3. finally, if there is no info about this `entry` in the repo, we fall back to whatever status is encoded
         //    in `entry` arg.
         repo.pending_ops_for_path(&entry.repo_path)
-            .map(|ops| {
+            .and_then(|ops| {
                 if ops.staging() || ops.staged() {
-                    StageStatus::Staged
+                    Some(StageStatus::Staged)
                 } else {
-                    StageStatus::Unstaged
+                    None
                 }
             })
             .or_else(|| {
@@ -2004,6 +2005,7 @@ impl GitPanel {
                     if let Err(err) = result {
                         this.show_error_toast(if stage { "add" } else { "reset" }, err, cx);
                     }
+                    this.update_counts(active_repository.read(cx));
                     cx.notify();
                 })
             }
@@ -3594,10 +3596,11 @@ impl GitPanel {
             if staged_count == 1
                 && let Some(entry) = single_staged_entry.as_ref()
             {
-                if let Some(ops) = repo.pending_ops_for_path(&entry.repo_path) {
-                    if ops.staged() {
-                        self.single_staged_entry = single_staged_entry;
-                    }
+                if let Some(ops) = repo.pending_ops_for_path(&entry.repo_path)
+                    && ops.not_staged()
+                {
+                    // entry has been changed to other status
+                    self.single_staged_entry = None;
                 } else {
                     self.single_staged_entry = single_staged_entry;
                 }
@@ -4712,7 +4715,13 @@ impl GitPanel {
 
         let is_staging_or_staged = repo
             .pending_ops_for_path(&repo_path)
-            .map(|ops| ops.staging() || ops.staged())
+            .and_then(|ops| {
+                if ops.staging() || ops.staged() {
+                    Some(true)
+                } else {
+                    None
+                }
+            })
             .or_else(|| {
                 repo.status_for_path(&repo_path)
                     .and_then(|status| status.status.staging().as_bool())

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -3596,11 +3596,10 @@ impl GitPanel {
             if staged_count == 1
                 && let Some(entry) = single_staged_entry.as_ref()
             {
-                if let Some(ops) = repo.pending_ops_for_path(&entry.repo_path)
-                    && ops.not_staged()
-                {
-                    // entry has been changed to other status
-                    self.single_staged_entry = None;
+                if let Some(ops) = repo.pending_ops_for_path(&entry.repo_path) {
+                    if ops.staged() {
+                        self.single_staged_entry = single_staged_entry;
+                    }
                 } else {
                     self.single_staged_entry = single_staged_entry;
                 }

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -5031,12 +5031,9 @@ impl Repository {
                 .filter_map(|entry| {
                     if let Some(ops) =
                         pending_ops.get(&PathKey(entry.repo_path.as_ref().clone()), ())
+                        && (ops.staging() || ops.staged())
                     {
-                        if ops.staging() || ops.staged() {
-                            None
-                        } else {
-                            Some(entry.repo_path)
-                        }
+                        None
                     } else if entry.status.staging().is_fully_staged() {
                         None
                     } else {
@@ -5064,12 +5061,9 @@ impl Repository {
                 .filter_map(|entry| {
                     if let Some(ops) =
                         pending_ops.get(&PathKey(entry.repo_path.as_ref().clone()), ())
+                        && (ops.staging() || ops.staged())
                     {
-                        if !ops.staging() && !ops.staged() {
-                            None
-                        } else {
-                            Some(entry.repo_path)
-                        }
+                        Some(entry.repo_path)
                     } else if entry.status.staging().is_fully_unstaged() {
                         None
                     } else {

--- a/crates/project/src/git_store/pending_op.rs
+++ b/crates/project/src/git_store/pending_op.rs
@@ -121,10 +121,20 @@ impl PendingOps {
         false
     }
 
-    /// File is staged if the last job is not finished and has status Staged.
+    /// File is not staged if the last job is finished and has status other than Staged.
+    pub fn not_staged(&self) -> bool {
+        if let Some(last) = self.ops.last() {
+            if last.git_status != GitStatus::Staged && last.job_status == JobStatus::Finished {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// File is staging if the last job is running and has status Staged.
     pub fn staging(&self) -> bool {
         if let Some(last) = self.ops.last() {
-            if last.git_status == GitStatus::Staged && last.job_status != JobStatus::Finished {
+            if last.git_status == GitStatus::Staged && last.running() {
                 return true;
             }
         }

--- a/crates/project/src/git_store/pending_op.rs
+++ b/crates/project/src/git_store/pending_op.rs
@@ -121,16 +121,6 @@ impl PendingOps {
         false
     }
 
-    /// File is not staged if the last job is finished and has status other than Staged.
-    pub fn not_staged(&self) -> bool {
-        if let Some(last) = self.ops.last() {
-            if last.git_status != GitStatus::Staged && last.job_status == JobStatus::Finished {
-                return true;
-            }
-        }
-        false
-    }
-
     /// File is staging if the last job is running and has status Staged.
     pub fn staging(&self) -> bool {
         if let Some(last) = self.ops.last() {


### PR DESCRIPTION
Closes #46479

> This PR was initially submitted three months ago; I've rebased it onto the latest main branch and made minor adjustments.

Fix incorrect Git panel state after failed stage/unstage operations:

#### 1. Refine `PendingOps::staging()` logic
Previously, it incorrectly returned `true` for failed jobs with `JobStatus::Error` because it used `last.job_status != JobStatus::Finished` as the condition. Fixed by checking `last.running()` explicitly. This resolves the issue where Git panel checkboxes fall out of sync with the actual stage status. (Note: While full Git scans may still reset checkbox states, this fix significantly improves UI responsiveness by reducing perceived lag.)

#### 2. **Improve UI responsiveness on failure**
Added explicit `update_counts()` calls after `stage_all`/`stage_entries` operations fail. This ensures the "Stage All / Unstage All" buttons stay in sync with the stage status.

#### 3. **Avoid unreliable state negations**
Since `PendingOps::staging()` and `PendingOps::staged()` only inspect the `last` job (which could be an `Error`), the expression `!(ops.staging() || ops.staged())` does not reliably imply an "Unstaged" state. This PR refactors several logic paths to avoid this pattern and ensure more deterministic state checks.

---

Before:

https://github.com/user-attachments/assets/5509f68b-c9cc-49e0-959e-2fbafb58356a

After:

https://github.com/user-attachments/assets/86351825-b5c8-476e-82c5-09a6b822e0d4

Release Notes:

- Fixed incorrect Git panel state after failed stage/unstage operations
