### PR TITLE
agent_ui: Make stopping a running terminal cancel thread generation

### DIFF
--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -3778,10 +3778,11 @@ impl AcpThreadView {
                         })
                         .on_click({
                             let terminal = terminal.clone();
-                            cx.listener(move |_this, _event, _window, cx| {
+                            cx.listener(move |this, _event, _window, cx| {
                                 terminal.update(cx, |terminal, cx| {
                                     terminal.stop_by_user(cx);
                                 });
+                                this.cancel_generation(cx);
                             })
                         }),
                     )


### PR DESCRIPTION
This makes stopping a terminal tool call in the agent panel also cancel the thread generation:

https://github.com/user-attachments/assets/702ba078-53a8-4816-80f3-b6215e764365

Release Notes:

- Agent: Made the act of stopping a terminal tool call in the agent panel also cancel the thread generation.
