### PR TITLE
ollama: Save API URL and key upon confirmation

### DIFF
--- a/crates/language_models/src/provider/lmstudio.rs
+++ b/crates/language_models/src/provider/lmstudio.rs
@@ -642,9 +642,11 @@ impl ConfigurationView {
         let loading_models_task = Some(cx.spawn({
             let state = state.clone();
             async move |this, cx| {
-                if let Some(task) = Some(state.update(cx, |state, cx| state.authenticate(cx))) {
-                    task.await.log_err();
-                }
+                state
+                    .update(cx, |state, cx| state.authenticate(cx))
+                    .await
+                    .log_err();
+
                 this.update(cx, |this, cx| {
                     this.loading_models_task = None;
                     cx.notify();


### PR DESCRIPTION
Closes #46626

Release Notes:

- Improved the settings configuration page for Ollama to store the current URL value if changed when clicking on "Connect"
