### PR TITLE
Prevent stale related excerpts by avoiding storing their contents as strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5310,6 +5310,7 @@ name = "edit_prediction_context"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clock",
  "cloud_llm_client",
  "collections",
  "env_logger 0.11.8",

--- a/crates/edit_prediction/src/edit_prediction.rs
+++ b/crates/edit_prediction/src/edit_prediction.rs
@@ -2204,7 +2204,7 @@ impl EditPredictionStore {
     }
 }
 
-pub(crate) fn filter_intersecting_excerpts(
+pub(crate) fn filter_redundant_excerpts(
     mut related_files: Vec<RelatedFile>,
     cursor_path: &Path,
     cursor_row_range: Range<u32>,
@@ -2212,8 +2212,8 @@ pub(crate) fn filter_intersecting_excerpts(
     for file in &mut related_files {
         if file.path.as_ref() == cursor_path {
             file.excerpts.retain(|excerpt| {
-                excerpt.row_range.end < cursor_row_range.start
-                    || excerpt.row_range.start > cursor_row_range.end
+                excerpt.row_range.start < cursor_row_range.start
+                    || excerpt.row_range.end > cursor_row_range.end
             });
         }
     }

--- a/crates/edit_prediction/src/edit_prediction.rs
+++ b/crates/edit_prediction/src/edit_prediction.rs
@@ -766,22 +766,31 @@ impl EditPredictionStore {
     pub fn context_for_project<'a>(
         &'a self,
         project: &Entity<Project>,
-        cx: &'a App,
+        cx: &'a mut App,
     ) -> Vec<RelatedFile> {
         self.projects
             .get(&project.entity_id())
-            .map(|project| project.context.read(cx).related_files(cx))
+            .map(|project| {
+                project
+                    .context
+                    .update(cx, |context, cx| context.related_files(cx))
+            })
             .unwrap_or_default()
     }
 
     pub fn context_for_project_with_buffers<'a>(
         &'a self,
         project: &Entity<Project>,
-        cx: &'a App,
-    ) -> Option<impl 'a + Iterator<Item = (RelatedFile, Entity<Buffer>)>> {
+        cx: &'a mut App,
+    ) -> Vec<(RelatedFile, Entity<Buffer>)> {
         self.projects
             .get(&project.entity_id())
-            .map(|project| project.context.read(cx).related_files_with_buffers(cx))
+            .map(|project| {
+                project
+                    .context
+                    .update(cx, |context, cx| context.related_files_with_buffers(cx))
+            })
+            .unwrap_or_default()
     }
 
     pub fn usage(&self, cx: &App) -> Option<EditPredictionUsage> {

--- a/crates/edit_prediction/src/edit_prediction.rs
+++ b/crates/edit_prediction/src/edit_prediction.rs
@@ -2195,6 +2195,23 @@ impl EditPredictionStore {
     }
 }
 
+pub(crate) fn filter_intersecting_excerpts(
+    mut related_files: Vec<RelatedFile>,
+    cursor_path: &Path,
+    cursor_row_range: Range<u32>,
+) -> Vec<RelatedFile> {
+    for file in &mut related_files {
+        if file.path.as_ref() == cursor_path {
+            file.excerpts.retain(|excerpt| {
+                excerpt.row_range.end < cursor_row_range.start
+                    || excerpt.row_range.start > cursor_row_range.end
+            });
+        }
+    }
+    related_files.retain(|file| !file.excerpts.is_empty());
+    related_files
+}
+
 #[derive(Error, Debug)]
 #[error(
     "You must update to Zed version {minimum_version} or higher to continue using edit predictions."

--- a/crates/edit_prediction/src/mercury.rs
+++ b/crates/edit_prediction/src/mercury.rs
@@ -68,7 +68,7 @@ impl Mercury {
                     MAX_REWRITE_TOKENS,
                 );
 
-            let related_files = crate::filter_intersecting_excerpts(
+            let related_files = crate::filter_redundant_excerpts(
                 related_files,
                 full_path.as_ref(),
                 context_range.start.row..context_range.end.row,

--- a/crates/edit_prediction/src/mercury.rs
+++ b/crates/edit_prediction/src/mercury.rs
@@ -251,7 +251,7 @@ fn build_prompt(inputs: &ZetaPromptInput) -> String {
                             prompt.push_str(CODE_SNIPPET_FILE_PATH_PREFIX);
                             prompt.push_str(related_file.path.to_string_lossy().as_ref());
                             prompt.push('\n');
-                            prompt.push_str(&related_excerpt.text.to_string());
+                            prompt.push_str(related_excerpt.text.as_ref());
                         },
                     );
                 }

--- a/crates/edit_prediction/src/mercury.rs
+++ b/crates/edit_prediction/src/mercury.rs
@@ -68,6 +68,12 @@ impl Mercury {
                     MAX_REWRITE_TOKENS,
                 );
 
+            let related_files = crate::filter_intersecting_excerpts(
+                related_files,
+                full_path.as_ref(),
+                context_range.start.row..context_range.end.row,
+            );
+
             let context_offset_range = context_range.to_offset(&snapshot);
 
             let editable_offset_range = editable_range.to_offset(&snapshot);

--- a/crates/edit_prediction/src/prediction.rs
+++ b/crates/edit_prediction/src/prediction.rs
@@ -148,7 +148,7 @@ mod tests {
             edit_preview,
             inputs: ZetaPromptInput {
                 events: vec![],
-                related_files: vec![].into(),
+                related_files: vec![],
                 cursor_path: Path::new("path.txt").into(),
                 cursor_offset_in_excerpt: 0,
                 cursor_excerpt: "".into(),

--- a/crates/edit_prediction/src/sweep_ai.rs
+++ b/crates/edit_prediction/src/sweep_ai.rs
@@ -120,7 +120,8 @@ impl SweepAi {
                 })
                 .collect::<Vec<_>>();
 
-            let retrieval_chunks = related_files
+            let retrieval_chunks = inputs
+                .related_files
                 .iter()
                 .flat_map(|related_file| {
                     related_file.excerpts.iter().map(|excerpt| FileChunk {
@@ -205,7 +206,7 @@ impl SweepAi {
 
             let ep_inputs = zeta_prompt::ZetaPromptInput {
                 events: inputs.events,
-                related_files: related_files.clone(),
+                related_files: inputs.related_files.clone(),
                 cursor_path: full_path.clone(),
                 cursor_excerpt: request_body.file_contents.clone().into(),
                 // we actually don't know

--- a/crates/edit_prediction/src/sweep_ai.rs
+++ b/crates/edit_prediction/src/sweep_ai.rs
@@ -91,7 +91,7 @@ impl SweepAi {
             let text = inputs.snapshot.text();
 
             // todo! should we filter for sweep? Or just assume they'll figure it out themselves
-            let related_files = crate::filter_intersecting_excerpts(
+            let related_files = crate::filter_redundant_excerpts(
                 inputs.related_files,
                 full_path.as_ref(),
                 0..inputs.snapshot.max_point().row,

--- a/crates/edit_prediction/src/sweep_ai.rs
+++ b/crates/edit_prediction/src/sweep_ai.rs
@@ -90,13 +90,6 @@ impl SweepAi {
         let result = cx.background_spawn(async move {
             let text = inputs.snapshot.text();
 
-            // todo! should we filter for sweep? Or just assume they'll figure it out themselves
-            let related_files = crate::filter_redundant_excerpts(
-                inputs.related_files,
-                full_path.as_ref(),
-                0..inputs.snapshot.max_point().row,
-            );
-
             let mut recent_changes = String::new();
             for event in &inputs.events {
                 write_event(event.as_ref(), &mut recent_changes).unwrap();

--- a/crates/edit_prediction/src/zeta1.rs
+++ b/crates/edit_prediction/src/zeta1.rs
@@ -133,7 +133,7 @@ pub(crate) fn request_prediction_with_zeta1(
 
         let inputs = ZetaPromptInput {
             events: included_events.into(),
-            related_files: vec![].into(),
+            related_files: vec![],
             cursor_path: full_path,
             cursor_excerpt: snapshot
                 .text_for_range(context_range)

--- a/crates/edit_prediction/src/zeta2.rs
+++ b/crates/edit_prediction/src/zeta2.rs
@@ -202,6 +202,12 @@ pub fn zeta2_prompt_input(
             MAX_CONTEXT_TOKENS,
         );
 
+    let related_files = crate::filter_intersecting_excerpts(
+        related_files,
+        excerpt_path.as_ref(),
+        context_range.start.row..context_range.end.row,
+    );
+
     let context_start_offset = context_range.start.to_offset(snapshot);
     let editable_offset_range = editable_range.to_offset(snapshot);
     let cursor_offset_in_excerpt = cursor_offset - context_start_offset;

--- a/crates/edit_prediction/src/zeta2.rs
+++ b/crates/edit_prediction/src/zeta2.rs
@@ -202,7 +202,7 @@ pub fn zeta2_prompt_input(
             MAX_CONTEXT_TOKENS,
         );
 
-    let related_files = crate::filter_intersecting_excerpts(
+    let related_files = crate::filter_redundant_excerpts(
         related_files,
         excerpt_path.as_ref(),
         context_range.start.row..context_range.end.row,

--- a/crates/edit_prediction/src/zeta2.rs
+++ b/crates/edit_prediction/src/zeta2.rs
@@ -187,7 +187,7 @@ pub fn request_prediction_with_zeta2(
 
 pub fn zeta2_prompt_input(
     snapshot: &language::BufferSnapshot,
-    related_files: Arc<[zeta_prompt::RelatedFile]>,
+    related_files: Vec<zeta_prompt::RelatedFile>,
     events: Vec<Arc<zeta_prompt::Event>>,
     excerpt_path: Arc<Path>,
     cursor_offset: usize,

--- a/crates/edit_prediction_cli/src/example.rs
+++ b/crates/edit_prediction_cli/src/example.rs
@@ -10,7 +10,6 @@ use language::{Anchor, Buffer};
 use project::Project;
 use serde::{Deserialize, Serialize};
 use std::ops::Range;
-use std::sync::Arc;
 use std::{
     borrow::Cow,
     io::Read,
@@ -61,7 +60,7 @@ pub struct ExampleState {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ExampleContext {
-    pub files: Arc<[RelatedFile]>,
+    pub files: Vec<RelatedFile>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/edit_prediction_cli/src/format_prompt.rs
+++ b/crates/edit_prediction_cli/src/format_prompt.rs
@@ -218,7 +218,7 @@ impl TeacherPrompt {
         }
 
         let mut prompt = String::new();
-        for file in context.files.as_ref() {
+        for file in context.files.iter() {
             let path_str = file.path.to_string_lossy();
             writeln!(&mut prompt, "`````{path_str}").ok();
             let mut prev_row = 0;

--- a/crates/edit_prediction_context/Cargo.toml
+++ b/crates/edit_prediction_context/Cargo.toml
@@ -25,6 +25,7 @@ parking_lot.workspace = true
 project.workspace = true
 serde.workspace = true
 smallvec.workspace = true
+text.workspace = true
 tree-sitter.workspace = true
 util.workspace = true
 zeta_prompt.workspace = true

--- a/crates/edit_prediction_context/Cargo.toml
+++ b/crates/edit_prediction_context/Cargo.toml
@@ -12,16 +12,17 @@ workspace = true
 path = "src/edit_prediction_context.rs"
 
 [dependencies]
-parking_lot.workspace = true
 anyhow.workspace = true
+clock.workspace = true
 cloud_llm_client.workspace = true
 collections.workspace = true
 futures.workspace = true
 gpui.workspace = true
 language.workspace = true
-lsp.workspace = true
-project.workspace = true
 log.workspace = true
+lsp.workspace = true
+parking_lot.workspace = true
+project.workspace = true
 serde.workspace = true
 smallvec.workspace = true
 tree-sitter.workspace = true

--- a/crates/edit_prediction_context/src/assemble_excerpts.rs
+++ b/crates/edit_prediction_context/src/assemble_excerpts.rs
@@ -1,16 +1,15 @@
 use language::{BufferSnapshot, OffsetRangeExt as _, Point};
 use std::ops::Range;
-use zeta_prompt::RelatedExcerpt;
 
 #[cfg(not(test))]
 const MAX_OUTLINE_ITEM_BODY_SIZE: usize = 512;
 #[cfg(test)]
 const MAX_OUTLINE_ITEM_BODY_SIZE: usize = 24;
 
-pub fn assemble_excerpts(
+pub fn assemble_excerpt_ranges(
     buffer: &BufferSnapshot,
     mut input_ranges: Vec<Range<Point>>,
-) -> Vec<RelatedExcerpt> {
+) -> Vec<Range<u32>> {
     merge_ranges(&mut input_ranges);
 
     let mut outline_ranges = Vec::new();
@@ -76,10 +75,7 @@ pub fn assemble_excerpts(
 
     input_ranges
         .into_iter()
-        .map(|range| RelatedExcerpt {
-            row_range: range.start.row..range.end.row,
-            text: buffer.text_for_range(range).collect(),
-        })
+        .map(|range| range.start.row..range.end.row)
         .collect()
 }
 

--- a/crates/edit_prediction_context/src/edit_prediction_context.rs
+++ b/crates/edit_prediction_context/src/edit_prediction_context.rs
@@ -445,7 +445,7 @@ impl RelatedBuffer {
             })
             .collect::<Vec<_>>();
         self.cached_file = Some(CachedRelatedFile {
-            excerpts: excerpts.clone(),
+            excerpts: excerpts,
             buffer_version: buffer.version().clone(),
         });
         self.cached_file.as_ref().unwrap()

--- a/crates/edit_prediction_context/src/edit_prediction_context_tests.rs
+++ b/crates/edit_prediction_context/src/edit_prediction_context_tests.rs
@@ -43,7 +43,7 @@ async fn test_edit_prediction_context(cx: &mut TestAppContext) {
     });
 
     cx.executor().advance_clock(DEBOUNCE_DURATION);
-    related_excerpt_store.read_with(cx, |store, cx| {
+    related_excerpt_store.update(cx, |store, cx| {
         let excerpts = store.related_files(cx);
         assert_related_files(
             &excerpts,

--- a/crates/edit_prediction_ui/src/edit_prediction_context_view.rs
+++ b/crates/edit_prediction_ui/src/edit_prediction_context_view.rs
@@ -153,11 +153,9 @@ impl EditPredictionContextView {
         run.finished_at = Some(info.timestamp);
         run.metadata = info.metadata;
 
-        let related_files = self
-            .store
-            .read(cx)
-            .context_for_project_with_buffers(&self.project, cx)
-            .map_or(Vec::new(), |files| files.collect());
+        let related_files = self.store.update(cx, |store, cx| {
+            store.context_for_project_with_buffers(&self.project, cx)
+        });
 
         let editor = run.editor.clone();
         let multibuffer = run.editor.read(cx).buffer().clone();

--- a/crates/edit_prediction_ui/src/rate_prediction_modal.rs
+++ b/crates/edit_prediction_ui/src/rate_prediction_modal.rs
@@ -374,7 +374,7 @@ impl RatePredictionsModal {
 
             write!(&mut formatted_inputs, "## Related files\n\n").unwrap();
 
-            for included_file in prediction.inputs.related_files.as_ref() {
+            for included_file in prediction.inputs.related_files.iter() {
                 write!(
                     &mut formatted_inputs,
                     "### {}\n\n",

--- a/crates/zeta_prompt/src/zeta_prompt.rs
+++ b/crates/zeta_prompt/src/zeta_prompt.rs
@@ -66,7 +66,7 @@ pub struct RelatedFile {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RelatedExcerpt {
     pub row_range: Range<u32>,
-    pub text: String,
+    pub text: Arc<str>,
 }
 
 pub fn format_zeta_prompt(input: &ZetaPromptInput) -> String {

--- a/crates/zeta_prompt/src/zeta_prompt.rs
+++ b/crates/zeta_prompt/src/zeta_prompt.rs
@@ -13,7 +13,7 @@ pub struct ZetaPromptInput {
     pub editable_range_in_excerpt: Range<usize>,
     pub cursor_offset_in_excerpt: usize,
     pub events: Vec<Arc<Event>>,
-    pub related_files: Arc<[RelatedFile]>,
+    pub related_files: Vec<RelatedFile>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
This fixes an issue that we noticed in particular with Mercury edit predictions.

* [x] fix storage to not go stale
* [x] exclude excerpts that intersect the cursor excerpt
* [x] see if string representation of excerpts can be cached, to avoid rebuilding it on every prediction

Release Notes:

- N/A
