### PR TITLE
agents: Add copilot as an external agent via acp

### DIFF
--- a/crates/agent_servers/src/agent_servers.rs
+++ b/crates/agent_servers/src/agent_servers.rs
@@ -1,6 +1,7 @@
 mod acp;
 mod claude;
 mod codex;
+mod copilot;
 mod custom;
 mod gemini;
 
@@ -11,6 +12,7 @@ pub use claude::*;
 use client::ProxySettings;
 pub use codex::*;
 use collections::{HashMap, HashSet};
+pub use copilot::*;
 pub use custom::*;
 use fs::Fs;
 pub use gemini::*;

--- a/crates/agent_servers/src/copilot.rs
+++ b/crates/agent_servers/src/copilot.rs
@@ -1,0 +1,80 @@
+use settings::SettingsStore;
+use std::any::Any;
+use std::path::Path;
+use std::rc::Rc;
+
+use anyhow::{Context as _, Result};
+use gpui::{App, AppContext as _, SharedString, Task};
+use project::agent_server_store::{AllAgentServersSettings, GITHUB_COPILOT_NAME};
+
+use crate::{AgentServer, AgentServerDelegate, load_proxy_env};
+use acp_thread::AgentConnection;
+
+#[derive(Clone)]
+pub struct Copilot;
+
+impl AgentServer for Copilot {
+    fn name(&self) -> SharedString {
+        "GitHub Copilot".into()
+    }
+
+    fn logo(&self) -> ui::IconName {
+        ui::IconName::Copilot
+    }
+
+    fn connect(
+        &self,
+        root_dir: Option<&Path>,
+        delegate: AgentServerDelegate,
+        cx: &mut App,
+    ) -> Task<Result<(Rc<dyn AgentConnection>, Option<task::SpawnInTerminal>)>> {
+        let name = self.name();
+        let root_dir = root_dir.map(|root_dir| root_dir.to_string_lossy().into_owned());
+        let is_remote = delegate.project.read(cx).is_via_remote_server();
+        let store = delegate.store.downgrade();
+        let extra_env = load_proxy_env(cx);
+        let default_mode = self.default_mode(cx);
+        let default_model = self.default_model(cx);
+        let default_config_options = cx.read_global(|settings: &SettingsStore, _| {
+            settings
+                .get::<AllAgentServersSettings>(None)
+                .copilot
+                .as_ref()
+                .map(|s| s.default_config_options.clone())
+                .unwrap_or_default()
+        });
+
+        cx.spawn(async move |cx| {
+            let (command, root_dir, login) = store
+                .update(cx, |store, cx| {
+                    let agent = store
+                        .get_external_agent(&GITHUB_COPILOT_NAME.into())
+                        .context("GitHub Copilot is not registered")?;
+                    anyhow::Ok(agent.get_command(
+                        root_dir.as_deref(),
+                        extra_env,
+                        delegate.status_tx,
+                        delegate.new_version_available,
+                        &mut cx.to_async(),
+                    ))
+                })??
+                .await?;
+            let connection = crate::acp::connect(
+                name,
+                command,
+                root_dir.as_ref(),
+                default_mode,
+                default_model,
+                default_config_options,
+                is_remote,
+                cx,
+            )
+            .await?;
+            Ok((connection, login))
+        })
+    }
+
+    fn into_any(self: Rc<Self>) -> Rc<dyn Any> {
+        self
+    }
+}

--- a/crates/agent_servers/src/e2e_tests.rs
+++ b/crates/agent_servers/src/e2e_tests.rs
@@ -426,6 +426,11 @@ pub async fn init_test(cx: &mut TestAppContext) -> Arc<FakeFs> {
                     path: Some("codex-acp".into()),
                     ..Default::default()
                 }),
+                copilot: Some(BuiltinAgentServerSettings {
+                    path: Some("copilot".into()),
+                    args: Some(vec!["--acp".into()]),
+                    ..Default::default()
+                }),
                 custom: collections::HashMap::default(),
             },
             cx,

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -161,6 +161,7 @@ pub enum ExternalAgent {
     Gemini,
     ClaudeCode,
     Codex,
+    Copilot,
     NativeAgent,
     Custom { name: SharedString },
 }
@@ -175,6 +176,7 @@ impl ExternalAgent {
             Self::Gemini => Rc::new(agent_servers::Gemini),
             Self::ClaudeCode => Rc::new(agent_servers::ClaudeCode),
             Self::Codex => Rc::new(agent_servers::Codex),
+            Self::Copilot => Rc::new(agent_servers::Copilot),
             Self::NativeAgent => Rc::new(agent::NativeAgentServer::new(fs, thread_store)),
             Self::Custom { name } => Rc::new(agent_servers::CustomAgentServer::new(name.clone())),
         }

--- a/crates/settings/src/settings_content/agent.rs
+++ b/crates/settings/src/settings_content/agent.rs
@@ -333,6 +333,7 @@ pub struct AllAgentServersSettings {
     pub gemini: Option<BuiltinAgentServerSettings>,
     pub claude: Option<BuiltinAgentServerSettings>,
     pub codex: Option<BuiltinAgentServerSettings>,
+    pub copilot: Option<BuiltinAgentServerSettings>,
 
     /// Custom agent servers configured by the user
     #[serde(flatten)]


### PR DESCRIPTION
Adds Copilot as an external agent via its new `--acp` mode.

Mostly copied from the Gemini implementation. Seems to be working apart from authentication, which has to be done in advance.

Release Notes:

- Added Copilot as an External Agent
