### PR TITLE
Remove -q from .rules

### DIFF
--- a/.rules
+++ b/.rules
@@ -136,4 +136,3 @@ Other entities can then register a callback to handle these events by doing `cx.
 ## Build guidelines
 
 - Use `./script/clippy` instead of `cargo clippy`
-- Always invoke `cargo` commands with the `-q` flag


### PR DESCRIPTION
I like to be able to see what's happening with rust builds so I can kill
rust analyzer, see the output, etc.

Closes #ISSUE

Release Notes:

- N/A
