### PR TITLE
editor: Fix content that wasn't being auto-trimmed on paste

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -13525,9 +13525,10 @@ impl Editor {
                 let mut metadata = clipboard_string.metadata_json::<Vec<ClipboardSelection>>();
 
                 if entries.len() == 1 && self.mode.is_single_line() {
-                    let trimmed = text.trim_end_matches(['\n', '\r']);
-                    if trimmed.len() != text.len() {
-                        text = trimmed.to_string();
+                    let replaced = text.replace("\r\n", "").replace('\n', "").replace('\r', "");
+
+                    if replaced != text {
+                        text = replaced;
                         metadata = None;
                     }
                 }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -13525,7 +13525,7 @@ impl Editor {
                 let mut metadata = clipboard_string.metadata_json::<Vec<ClipboardSelection>>();
 
                 if entries.len() == 1 && self.mode.is_single_line() {
-                    let replaced = text.replace("\r\n", "").replace('\n', "").replace('\r', "");
+                    let replaced = text.replace(['\n', '\r'], "");
 
                     if replaced != text {
                         text = replaced;


### PR DESCRIPTION
Closes #45801

Release Notes:
- Trimmed only the trailing newline for single line mode and also set metadata to None when trimming otherwise it was causing out of bound panic.

