### PR TITLE
editor: Fix cursor collapse when typing with adjacent selections

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4361,7 +4361,6 @@ impl Editor {
         let mut clear_linked_edit_ranges = false;
         let mut all_selections_read_only = true;
         let mut has_adjacent_edits = false;
-        let mut in_adjacent_group = false;
 
         let mut regions = self
             .selections_with_autoclose_regions(selections, &snapshot)
@@ -4635,9 +4634,7 @@ impl Editor {
             // If not handling any auto-close operation, then just replace the selected
             // text with the given input and move the selection to the end of the
             // newly inserted text.
-            let anchor = if in_adjacent_group || next_is_adjacent {
-                // After edits the right bias would shift those anchor to the next visible fragment
-                // but we want to resolve to the previous one
+            let anchor = if next_is_adjacent {
                 snapshot.anchor_before(selection.end)
             } else {
                 snapshot.anchor_after(selection.end)
@@ -4673,7 +4670,6 @@ impl Editor {
             edits.push((selection.start..selection.end, text.clone()));
 
             has_adjacent_edits |= next_is_adjacent;
-            in_adjacent_group = next_is_adjacent;
         }
 
         if all_selections_read_only {


### PR DESCRIPTION
## Problem
When using 'Select All Occurrences' (Ctrl+Shift+L) on consecutive identical characters (e.g., selecting 'i' in 'piiiiks'), typing a replacement character would collapse all cursors into one, producing 'peks' instead of 'peeeeks'.

## Root Cause
In `handle_input()`, the anchor bias logic used `anchor_before` for ALL selections in an adjacent group:

```rust
let anchor = if in_adjacent_group || next_is_adjacent {
    snapshot.anchor_before(selection.end)
} ...
```

This caused all anchors to resolve to the same position after the first edit was applied, merging all cursors.

## Solution
Only use `anchor_before` when there's a NEXT adjacent selection. The last selection in each adjacent group now uses `anchor_after`, preventing collapse:

```rust
let anchor = if next_is_adjacent {
    snapshot.anchor_before(selection.end)
} ...
```

Removed unused `in_adjacent_group` variable.

## Testing
Added 10 test cases covering:
- Adjacent identical characters (original bug)
- Unicode characters
- Special characters
- Mixed adjacent/non-adjacent selections
- Backspace and delete operations
- Multiline scenarios

Release Notes:

- Fixed multi-cursor collapse when replacing consecutive identical characters

Closes #46602

Closes #ISSUE

Release Notes:

- N/A *or* Added/Fixed/Improved ...
