### PR TITLE
repl: Show active Python toolchain as recommended kernel

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -3906,6 +3906,7 @@ impl Project {
             .read(cx)
             .active_toolchain(path, language_name, cx)
     }
+
     pub fn language_server_statuses<'a>(
         &'a self,
         cx: &'a App,

--- a/crates/repl/src/components/kernel_options.rs
+++ b/crates/repl/src/components/kernel_options.rs
@@ -2,10 +2,7 @@ use crate::KERNEL_DOCS_URL;
 use crate::kernels::KernelSpecification;
 use crate::repl_store::ReplStore;
 
-use gpui::AnyView;
-use gpui::DismissEvent;
-
-use gpui::FontWeight;
+use gpui::{AnyView, DismissEvent, FontWeight};
 use picker::Picker;
 use picker::PickerDelegate;
 use project::WorktreeId;
@@ -31,12 +28,14 @@ where
     tooltip: TT,
     info_text: Option<SharedString>,
     worktree_id: WorktreeId,
+    active_toolchain_path: Option<SharedString>,
 }
 
 pub struct KernelPickerDelegate {
     all_kernels: Vec<KernelSpecification>,
     filtered_kernels: Vec<KernelSpecification>,
     selected_kernelspec: Option<KernelSpecification>,
+    active_toolchain_path: Option<SharedString>,
     on_select: OnSelect,
 }
 
@@ -55,7 +54,13 @@ where
     T: PopoverTrigger + ButtonCommon,
     TT: Fn(&mut Window, &mut App) -> AnyView + 'static,
 {
-    pub fn new(on_select: OnSelect, worktree_id: WorktreeId, trigger: T, tooltip: TT) -> Self {
+    pub fn new(
+        on_select: OnSelect,
+        worktree_id: WorktreeId,
+        active_toolchain_path: Option<SharedString>,
+        trigger: T,
+        tooltip: TT,
+    ) -> Self {
         KernelSelector {
             on_select,
             handle: None,
@@ -63,6 +68,7 @@ where
             tooltip,
             info_text: None,
             worktree_id,
+            active_toolchain_path,
         }
     }
 
@@ -74,6 +80,19 @@ where
     pub fn with_info_text(mut self, text: impl Into<SharedString>) -> Self {
         self.info_text = Some(text.into());
         self
+    }
+}
+
+impl KernelPickerDelegate {
+    /// Sort kernels by type: Python Environments, Jupyter, Remote
+    fn sort_kernels(kernels: Vec<KernelSpecification>) -> Vec<KernelSpecification> {
+        let mut sorted = kernels;
+        sorted.sort_by_key(|kernel| match kernel {
+            KernelSpecification::PythonEnv(_) => 0,
+            KernelSpecification::Jupyter(_) => 1,
+            KernelSpecification::Remote(_) => 2,
+        });
+        sorted
     }
 }
 
@@ -112,11 +131,6 @@ impl PickerDelegate for KernelPickerDelegate {
     ) -> Task<()> {
         let all_kernels = self.all_kernels.clone();
 
-        if query.is_empty() {
-            self.filtered_kernels = all_kernels;
-            return Task::ready(());
-        }
-
         self.filtered_kernels = if query.is_empty() {
             all_kernels
         } else {
@@ -125,6 +139,9 @@ impl PickerDelegate for KernelPickerDelegate {
                 .filter(|kernel| kernel.name().to_lowercase().contains(&query.to_lowercase()))
                 .collect()
         };
+
+        // Sort after filtering
+        self.filtered_kernels = Self::sort_kernels(self.filtered_kernels.clone());
 
         Task::ready(())
     }
@@ -147,6 +164,9 @@ impl PickerDelegate for KernelPickerDelegate {
     ) -> Option<Self::ListItem> {
         let kernelspec = self.filtered_kernels.get(ix)?;
         let is_selected = self.selected_kernelspec.as_ref() == Some(kernelspec);
+        // Mark Python environment as recommended if its path matches the active toolchain
+        let is_recommended = matches!(kernelspec, KernelSpecification::PythonEnv(_))
+            && self.active_toolchain_path.as_ref() == Some(&kernelspec.path());
         let icon = kernelspec.icon(cx);
 
         let (name, kernel_type, path_or_url) = match kernelspec {
@@ -207,7 +227,14 @@ impl PickerDelegate for KernelPickerDelegate {
                                             Label::new(kernel_type)
                                                 .size(LabelSize::Small)
                                                 .color(Color::Muted),
-                                        ),
+                                        )
+                                        .when(is_recommended, |flex| {
+                                            flex.child(
+                                                Label::new("Recommended")
+                                                    .size(LabelSize::Small)
+                                                    .color(Color::Accent),
+                                            )
+                                        }),
                                 ),
                         ),
                 )
@@ -261,11 +288,15 @@ where
 
         let selected_kernelspec = store.active_kernelspec(self.worktree_id, None, cx);
 
+        // Sort kernels by type
+        let sorted_kernels = KernelPickerDelegate::sort_kernels(all_kernels);
+
         let delegate = KernelPickerDelegate {
             on_select: self.on_select,
-            all_kernels: all_kernels.clone(),
-            filtered_kernels: all_kernels,
+            all_kernels: sorted_kernels.clone(),
+            filtered_kernels: sorted_kernels,
             selected_kernelspec,
+            active_toolchain_path: self.active_toolchain_path,
         };
 
         let picker_view = cx.new(|cx| {

--- a/crates/repl/src/notebook/notebook_ui.rs
+++ b/crates/repl/src/notebook/notebook_ui.rs
@@ -1093,6 +1093,7 @@ impl NotebookEditor {
                         }
                     }),
                     worktree_id,
+                    None,
                     Button::new("kernel-selector", kernel_name.clone())
                         .label_size(LabelSize::Small)
                         .icon(status_icon)

--- a/crates/repl/src/repl.rs
+++ b/crates/repl/src/repl.rs
@@ -12,8 +12,8 @@ mod session;
 use std::{sync::Arc, time::Duration};
 
 use async_dispatcher::{Dispatcher, Runnable, set_dispatcher};
-use gpui::{App, PlatformDispatcher, Priority, RunnableMeta};
-use project::Fs;
+use gpui::{App, PlatformDispatcher, Priority, RunnableMeta, SharedString};
+use project::{Fs, WorktreeId};
 pub use runtimelib::ExecutionState;
 
 pub use crate::jupyter_settings::JupyterSettings;
@@ -27,6 +27,13 @@ use crate::repl_store::ReplStore;
 pub use crate::session::Session;
 
 pub const KERNEL_DOCS_URL: &str = "https://zed.dev/docs/repl#changing-kernels";
+
+pub fn active_python_toolchain_path(worktree_id: WorktreeId, cx: &App) -> Option<SharedString> {
+    let store = ReplStore::global(cx).read(cx);
+    store
+        .active_python_toolchain(worktree_id)
+        .map(|t| t.path.clone())
+}
 
 pub fn init(fs: Arc<dyn Fs>, cx: &mut App) {
     set_dispatcher(zed_dispatcher(cx));

--- a/crates/repl/src/repl_store.rs
+++ b/crates/repl/src/repl_store.rs
@@ -5,9 +5,10 @@ use collections::HashMap;
 use command_palette_hooks::CommandPaletteFilter;
 use gpui::{App, Context, Entity, EntityId, Global, Subscription, Task, prelude::*};
 use jupyter_websocket_client::RemoteServer;
-use language::Language;
-use project::{Fs, Project, WorktreeId};
+use language::{Language, LanguageName, Toolchain};
+use project::{Fs, Project, ProjectPath, WorktreeId};
 use settings::{Settings, SettingsStore};
+use util::rel_path::RelPath;
 
 use crate::kernels::{
     list_remote_kernelspecs, local_kernel_specifications, python_env_kernel_specifications,
@@ -25,6 +26,7 @@ pub struct ReplStore {
     kernel_specifications: Vec<KernelSpecification>,
     selected_kernel_for_worktree: HashMap<WorktreeId, KernelSpecification>,
     kernel_specifications_for_worktree: HashMap<WorktreeId, Vec<KernelSpecification>>,
+    active_python_toolchain_for_worktree: HashMap<WorktreeId, Toolchain>,
     _subscriptions: Vec<Subscription>,
 }
 
@@ -59,6 +61,7 @@ impl ReplStore {
             _subscriptions: subscriptions,
             kernel_specifications_for_worktree: HashMap::default(),
             selected_kernel_for_worktree: HashMap::default(),
+            active_python_toolchain_for_worktree: HashMap::default(),
         };
         this.on_enabled_changed(cx);
         this
@@ -116,6 +119,13 @@ impl ReplStore {
         cx.notify();
     }
 
+    pub fn active_python_toolchain(
+        &self,
+        worktree_id: WorktreeId,
+    ) -> Option<&Toolchain> {
+        self.active_python_toolchain_for_worktree.get(&worktree_id)
+    }
+
     pub fn refresh_python_kernelspecs(
         &mut self,
         worktree_id: WorktreeId,
@@ -123,14 +133,30 @@ impl ReplStore {
         cx: &mut Context<Self>,
     ) -> Task<Result<()>> {
         let kernel_specifications = python_env_kernel_specifications(project, worktree_id, cx);
+        let active_toolchain = project.read(cx).active_toolchain(
+            ProjectPath {
+                worktree_id,
+                path: RelPath::empty().into(),
+            },
+            LanguageName::new_static("Python"),
+            cx,
+        );
         cx.spawn(async move |this, cx| {
             let kernel_specifications = kernel_specifications
                 .await
                 .context("getting python kernelspecs")?;
+            let active_toolchain = active_toolchain.await;
 
             this.update(cx, |this, cx| {
                 this.kernel_specifications_for_worktree
                     .insert(worktree_id, kernel_specifications);
+                if let Some(toolchain) = active_toolchain {
+                    this.active_python_toolchain_for_worktree
+                        .insert(worktree_id, toolchain);
+                } else {
+                    this.active_python_toolchain_for_worktree
+                        .remove(&worktree_id);
+                }
                 cx.notify();
             })
         })

--- a/crates/zed/src/zed/quick_action_bar/repl_menu.rs
+++ b/crates/zed/src/zed/quick_action_bar/repl_menu.rs
@@ -283,6 +283,8 @@ impl QuickActionBar {
             return div().into_any_element();
         };
 
+        let active_toolchain_path = repl::active_python_toolchain_path(worktree_id, cx);
+
         let session = repl::session(editor.downgrade(), cx);
 
         let current_kernelspec = match session {
@@ -305,6 +307,7 @@ impl QuickActionBar {
                 })
             },
             worktree_id,
+            active_toolchain_path,
             ButtonLike::new("kernel-selector")
                 .style(ButtonStyle::Subtle)
                 .size(ButtonSize::Compact)


### PR DESCRIPTION
Mark the active toolchain as the recommended kernel for the repl.

<img width="503" height="431" alt="image" src="https://github.com/user-attachments/assets/d5bb212f-b1b5-4047-933b-d9c4d3811e6b" />

Release Notes:

- List active toolchain/python environment as the recommend kernel for REPL usage
