### PR TITLE
languages: Separate control flow keywords for Shell Scripts

### DIFF
--- a/crates/languages/src/bash/highlights.scm
+++ b/crates/languages/src/bash/highlights.scm
@@ -11,26 +11,29 @@
 (variable_name) @variable
 
 [
+  "export"
+  "function"
+  "unset"
+  "local"
+  "declare"
+] @keyword
+
+[
   "case"
   "do"
   "done"
   "elif"
   "else"
   "esac"
-  "export"
   "fi"
   "for"
-  "function"
   "if"
   "in"
   "select"
   "then"
-  "unset"
   "until"
   "while"
-  "local"
-  "declare"
-] @keyword
+] @keyword.control
 
 (comment) @comment
 


### PR DESCRIPTION
Part of https://github.com/zed-industries/zed/issues/9461. Similar PRs:

- https://github.com/zed-industries/zed/pull/39683
- https://github.com/zed-industries/zed/pull/39801


## Release Notes:

- Added the ability to separately highlight control flow keywords for Shell Scripts for users and theme authors via the `keyword.control` syntax property.

## Screenshots

| **Before** | **After** |
|:--:|:--:|
| <img width="719" height="860" alt="image" src="https://github.com/user-attachments/assets/1e509e7b-a197-4fb0-a5da-bd3669b6bcd6" /> | <img width="718" height="855" alt="image" src="https://github.com/user-attachments/assets/9c5e253d-bfd6-4fe7-9e30-95af1b260fdf" /> |
