### PR TITLE
agent_ui: Fix reject all and keep all keybinding conflict

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -205,8 +205,8 @@
     "bindings": {
       "ctrl-alt-y": "agent::Keep",
       "ctrl-alt-z": "agent::Reject",
-      "ctrl-shift-y": "agent::KeepAll",
-      "ctrl-shift-n": "agent::RejectAll",
+      "shift-alt-y": "agent::KeepAll",
+      "shift-alt-z": "agent::RejectAll",
       "shift-ctrl-r": "agent::OpenAgentDiff",
     },
   },
@@ -215,8 +215,8 @@
     "bindings": {
       "ctrl-alt-y": "agent::Keep",
       "ctrl-alt-z": "agent::Reject",
-      "ctrl-shift-y": "agent::KeepAll",
-      "ctrl-shift-n": "agent::RejectAll",
+      "shift-alt-y": "agent::KeepAll",
+      "shift-alt-z": "agent::RejectAll",
     },
   },
   {
@@ -305,8 +305,8 @@
     "use_key_equivalents": true,
     "bindings": {
       "ctrl-shift-r": "agent::OpenAgentDiff",
-      "ctrl-shift-y": "agent::KeepAll",
-      "ctrl-shift-n": "agent::RejectAll",
+      "shift-alt-y": "agent::KeepAll",
+      "shift-alt-z": "agent::RejectAll",
       "ctrl-enter": "agent::ChatWithFollow",
       "ctrl-shift-enter": "agent::QueueMessage",
       "ctrl-shift-alt-enter": "agent::SendNextQueuedMessage",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -243,8 +243,8 @@
     "bindings": {
       "cmd-alt-y": "agent::Keep",
       "cmd-alt-z": "agent::Reject",
-      "cmd-shift-y": "agent::KeepAll",
-      "cmd-shift-n": "agent::RejectAll",
+      "shift-alt-y": "agent::KeepAll",
+      "shift-alt-z": "agent::RejectAll",
     },
   },
   {
@@ -253,8 +253,8 @@
     "bindings": {
       "cmd-alt-y": "agent::Keep",
       "cmd-alt-z": "agent::Reject",
-      "cmd-shift-y": "agent::KeepAll",
-      "cmd-shift-n": "agent::RejectAll",
+      "shift-alt-y": "agent::KeepAll",
+      "shift-alt-z": "agent::RejectAll",
       "shift-ctrl-r": "agent::OpenAgentDiff",
     },
   },
@@ -353,8 +353,8 @@
     "use_key_equivalents": true,
     "bindings": {
       "shift-ctrl-r": "agent::OpenAgentDiff",
-      "cmd-shift-y": "agent::KeepAll",
-      "cmd-shift-n": "agent::RejectAll",
+      "shift-alt-y": "agent::KeepAll",
+      "shift-alt-z": "agent::RejectAll",
       "cmd-enter": "agent::ChatWithFollow",
       "cmd-shift-enter": "agent::QueueMessage",
       "cmd-shift-alt-enter": "agent::SendNextQueuedMessage",

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -204,8 +204,8 @@
     "bindings": {
       "ctrl-alt-y": "agent::Keep",
       "ctrl-alt-z": "agent::Reject",
-      "ctrl-shift-y": "agent::KeepAll",
-      "ctrl-shift-n": "agent::RejectAll",
+      "shift-alt-y": "agent::KeepAll",
+      "shift-alt-z": "agent::RejectAll",
       "ctrl-shift-r": "agent::OpenAgentDiff",
     },
   },
@@ -215,8 +215,8 @@
     "bindings": {
       "ctrl-alt-y": "agent::Keep",
       "ctrl-alt-z": "agent::Reject",
-      "ctrl-shift-y": "agent::KeepAll",
-      "ctrl-shift-n": "agent::RejectAll",
+      "shift-alt-y": "agent::KeepAll",
+      "shift-alt-z": "agent::RejectAll",
     },
   },
   {
@@ -307,8 +307,8 @@
     "use_key_equivalents": true,
     "bindings": {
       "ctrl-shift-r": "agent::OpenAgentDiff",
-      "ctrl-shift-y": "agent::KeepAll",
-      "ctrl-shift-n": "agent::RejectAll",
+      "shift-alt-y": "agent::KeepAll",
+      "shift-alt-z": "agent::RejectAll",
       "ctrl-enter": "agent::ChatWithFollow",
       "ctrl-shift-enter": "agent::QueueMessage",
       "ctrl-shift-alt-enter": "agent::SendNextQueuedMessage",


### PR DESCRIPTION
This PR changes the keybinding for the `agent::RejectAll` and `agent::KeepAll` actions. My initial goal was to free up `cmd-shift-n` to open a new fresh window again, but that was being used for the reject all action. Given I had to change the reject all, I figured I had to change the keep all action, too, to keep them consistent.

Release Notes:

- Agent: Removed keybinding conflict (`cmd-shift-n`) between rejecting all changes in the agent panel vs. opening a new fresh window.
