### PR TITLE
project search: Fix alignment in the filter inputs

### DIFF
--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -2268,11 +2268,11 @@ impl Render for ProjectSearchBar {
             h_flex()
                 .w_full()
                 .gap_2()
+                .child(alignment_element())
                 .child(
                     h_flex()
-                        .gap_2()
                         .w(input_width)
-                        .child(alignment_element())
+                        .gap_2()
                         .child(include)
                         .child(exclude),
                 )


### PR DESCRIPTION
This is a small PR to fix an alignment bug I just noticed in the filter inputs within the project search page.

Release Notes:

- N/A
