### PR TITLE
danger: Use Danger Proxy running on Cloud

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -37,4 +37,4 @@ jobs:
       shell: bash -euxo pipefail {0}
       env:
         GITHUB_TOKEN: not_a_real_token
-        DANGER_GITHUB_API_BASE_URL: https://danger-proxy.fly.dev/github
+        DANGER_GITHUB_API_BASE_URL: https://danger-proxy.zed.dev/github

--- a/tooling/xtask/src/tasks/workflows/danger.rs
+++ b/tooling/xtask/src/tasks/workflows/danger.rs
@@ -30,12 +30,11 @@ fn danger_job() -> NamedJob {
             // This GitHub token is not used, but the value needs to be here to prevent
             // Danger from throwing an error.
             .add_env(("GITHUB_TOKEN", "not_a_real_token"))
-            // All requests are instead proxied through an instance of
-            // https://github.com/maxdeviant/danger-proxy that allows Danger to securely
-            // authenticate with GitHub while still being able to run on PRs from forks.
+            // All requests are instead proxied through a proxy that allows Danger to securely authenticate with GitHub
+            // while still being able to run on PRs from forks.
             .add_env((
                 "DANGER_GITHUB_API_BASE_URL",
-                "https://danger-proxy.fly.dev/github",
+                "https://danger-proxy.zed.dev/github",
             ))
     }
 


### PR DESCRIPTION
This PR updates Danger to use the new Danger Proxy that is running on Cloud.

Part of CLO-45.

Release Notes:

- N/A
