### PR TITLE
editor: Fix clipboard line numbers when copying from multibuffer

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1643,7 +1643,15 @@ impl ClipboardSelection {
             project.absolute_path(&project_path, cx)
         });
 
-        let line_range = file_path.as_ref().map(|_| range.start.row..=range.end.row);
+        let line_range = file_path.as_ref().and_then(|_| {
+            let (_, start_point, start_excerpt_id) = buffer.point_to_buffer_point(range.start)?;
+            let (_, end_point, end_excerpt_id) = buffer.point_to_buffer_point(range.end)?;
+            if start_excerpt_id == end_excerpt_id {
+                Some(start_point.row..=end_point.row)
+            } else {
+                None
+            }
+        });
 
         Self {
             len,


### PR DESCRIPTION
Release Notes:

- When copying and pasting from a multibuffer view (e.g. into the agent panel), the line numbers from the selection corresponded to the line numbers in the multibuffer view (incorrect), instead of the actual line numbers from the file itself.
- I also handled the case in which the selection spans multiple excerpts (different files in the multibuffer) by just returning None for that case, but maybe it should instead be split into two selections?

Left is before (bugged, should be lines 8:16, instead it is 38:46), right is after (fixed).
<div style="display:flex; gap:12px;">
  <img src="https://github.com/user-attachments/assets/b1bfce1d-8b6a-41c0-ac7e-51f7bd7b284e"
       width="48%" />
  <img src="https://github.com/user-attachments/assets/2a4c33a0-a969-4a3e-9aa5-d2c2fefba3b2"
       width="48%" />
</div>