### PR TITLE
Make auto-signature help respect popover delay

### DIFF
--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -48,7 +48,7 @@ use project::{
 };
 use serde_json::{self, json};
 use settings::{
-    AllLanguageSettingsContent, EditorSettingsContent, IndentGuideBackgroundColoring,
+    AllLanguageSettingsContent, DelayMs, EditorSettingsContent, IndentGuideBackgroundColoring,
     IndentGuideColoring, InlayHintSettingsContent, ProjectSettingsContent, SearchSettingsContent,
     SettingsStore,
 };
@@ -13466,6 +13466,7 @@ async fn test_handle_input_for_show_signature_help_auto_signature_help_true(
         cx.update_global::<SettingsStore, _>(|settings, cx| {
             settings.update_user_settings(cx, |settings| {
                 settings.editor.auto_signature_help = Some(true);
+                settings.editor.hover_popover_delay = Some(DelayMs(300));
             });
         });
     });

--- a/crates/editor/src/signature_help.rs
+++ b/crates/editor/src/signature_help.rs
@@ -10,6 +10,7 @@ use markdown::{Markdown, MarkdownElement};
 use multi_buffer::{Anchor, MultiBufferOffset, ToOffset};
 use settings::Settings;
 use std::ops::Range;
+use std::time::Duration;
 use text::Rope;
 use theme::ThemeSettings;
 use ui::{


### PR DESCRIPTION
Closes #46191

Release Notes:

- Make the auto signature popover —  `"auto_signature_help": true` —  respect `hover_popover_delay`.
