### PR TITLE
agent_ui: Use `.w_full()` instead of `.size_full()` when rendering markdown tables in lists

### DIFF
--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -1120,7 +1120,7 @@ impl Element for MarkdownElement {
                                     .when(!self.style.table_columns_min_size, |this| {
                                         this.grid_cols(column_count as u16)
                                     })
-                                    .size_full()
+                                    .w_full()
                                     .mb_2()
                                     .border(px(1.5))
                                     .border_color(cx.theme().colors().border)


### PR DESCRIPTION
This way, the table:
- Determines its height by the grid’s content
- Still keeps `width: 100%` so it fills its container horizontally

| Before | After |
|--------|--------|
| <img width="1732" height="1125" alt="image" src="https://github.com/user-attachments/assets/5d739664-5793-4c16-a765-dc373c7cb10f" /> | <img width="1732" height="1125" alt="image" src="https://github.com/user-attachments/assets/c857d28b-67c2-4ba1-b4a6-869a154b050b" /> | 

Closes #46768

Release Notes:

- Fixed issue where markdown tables rendered within lists would overlap items above/below it
