### PR TITLE
ui: Only show diff stat numbers if they're bigger than zero

### DIFF
--- a/crates/ui/src/components/diff_stat.rs
+++ b/crates/ui/src/components/diff_stat.rs
@@ -29,34 +29,38 @@ impl RenderOnce for DiffStat {
         h_flex()
             .id(self.id)
             .gap_1()
-            .child(
-                h_flex()
-                    .gap_0p5()
-                    .child(
-                        Icon::new(IconName::Plus)
-                            .size(IconSize::XSmall)
-                            .color(Color::Success),
-                    )
-                    .child(
-                        Label::new(self.added.to_string())
-                            .color(Color::Success)
-                            .size(self.label_size),
-                    ),
-            )
-            .child(
-                h_flex()
-                    .gap_0p5()
-                    .child(
-                        Icon::new(IconName::Dash)
-                            .size(IconSize::XSmall)
-                            .color(Color::Error),
-                    )
-                    .child(
-                        Label::new(self.removed.to_string())
-                            .color(Color::Error)
-                            .size(self.label_size),
-                    ),
-            )
+            .when(self.added > 0, |this| {
+                this.child(
+                    h_flex()
+                        .gap_0p5()
+                        .child(
+                            Icon::new(IconName::Plus)
+                                .size(IconSize::XSmall)
+                                .color(Color::Success),
+                        )
+                        .child(
+                            Label::new(self.added.to_string())
+                                .color(Color::Success)
+                                .size(self.label_size),
+                        ),
+                )
+            })
+            .when(self.removed > 0, |this| {
+                this.child(
+                    h_flex()
+                        .gap_0p5()
+                        .child(
+                            Icon::new(IconName::Dash)
+                                .size(IconSize::XSmall)
+                                .color(Color::Error),
+                        )
+                        .child(
+                            Label::new(self.removed.to_string())
+                                .color(Color::Error)
+                                .size(self.label_size),
+                        ),
+                )
+            })
     }
 }
 


### PR DESCRIPTION
No need to show, for example, "+25 -0" when there's been zero removed lines; the absence of that number communicates the message I think. :)

Release Notes:

- N/A
