### PR TITLE
html: Exclude all brackets from bracket colorization

### DIFF
--- a/extensions/html/languages/html/brackets.scm
+++ b/extensions/html/languages/html/brackets.scm
@@ -1,5 +1,21 @@
-("<" @open "/>" @close)
-("</" @open ">" @close)
-("<" @open ">" @close)
-(("\"" @open "\"" @close) (#set! rainbow.exclude))
-((element (start_tag) @open (end_tag) @close) (#set! newline.only) (#set! rainbow.exclude))
+(("<" @open
+  "/>" @close)
+  (#set! rainbow.exclude))
+
+(("</" @open
+  ">" @close)
+  (#set! rainbow.exclude))
+
+(("<" @open
+  ">" @close)
+  (#set! rainbow.exclude))
+
+(("\"" @open
+  "\"" @close)
+  (#set! rainbow.exclude))
+
+((element
+  (start_tag) @open
+  (end_tag) @close)
+  (#set! newline.only)
+  (#set! rainbow.exclude))


### PR DESCRIPTION
Closes #45755

Rainbow brackets in HTML files do not really make sense - a tag is always enclosed in angled brackets. With our current approach, that means that we will highlight all brackets in HTML files with the same color, because well, these angled brackets do not quite behave like in other languages. 

Hence, let themes color this again and just exluce HTML angled brackets from rainbow bracket colorization, as it is no real rainbow bracket colorization anyway.

Release Notes:

- N/A
