### PR TITLE
Cache JSON schemas to reduce foreground thread blocking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8682,10 +8682,12 @@ name = "json_schema_store"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "collections",
  "dap",
  "extension",
  "gpui",
  "language",
+ "parking_lot",
  "paths",
  "project",
  "schemars",

--- a/crates/json_schema_store/Cargo.toml
+++ b/crates/json_schema_store/Cargo.toml
@@ -16,7 +16,9 @@ default = []
 
 [dependencies]
 anyhow.workspace = true
+collections.workspace = true
 dap.workspace = true
+parking_lot.workspace = true
 extension.workspace = true
 gpui.workspace = true
 language.workspace = true

--- a/crates/json_schema_store/src/json_schema_store.rs
+++ b/crates/json_schema_store/src/json_schema_store.rs
@@ -1,9 +1,14 @@
 //! # json_schema_store
-use std::{str::FromStr, sync::Arc};
+use std::{
+    str::FromStr,
+    sync::{Arc, LazyLock},
+};
 
 use anyhow::{Context as _, Result};
+use collections::HashMap;
 use gpui::{App, AsyncApp, BorrowAppContext as _, Entity, Task, WeakEntity};
 use language::{LanguageRegistry, LspAdapterDelegate, language_settings::all_language_settings};
+use parking_lot::RwLock;
 use project::{LspStore, lsp_store::LocalLspAdapterDelegate};
 use settings::LSP_SETTINGS_SCHEMA_URL_PREFIX;
 use util::schemars::{AllowTrailingCommas, DefaultDenyUnknownFields};
@@ -11,6 +16,41 @@ use util::schemars::{AllowTrailingCommas, DefaultDenyUnknownFields};
 // Origin: https://github.com/SchemaStore/schemastore
 const TSCONFIG_SCHEMA: &str = include_str!("schemas/tsconfig.json");
 const PACKAGE_JSON_SCHEMA: &str = include_str!("schemas/package.json");
+
+// Static schemas that never change - computed once on first access
+static TASKS_SCHEMA: LazyLock<String> = LazyLock::new(|| {
+    serde_json::to_string(&task::TaskTemplates::generate_json_schema())
+        .expect("TaskTemplates schema should serialize")
+});
+
+static SNIPPETS_SCHEMA: LazyLock<String> = LazyLock::new(|| {
+    serde_json::to_string(&snippet_provider::format::VsSnippetsFile::generate_json_schema())
+        .expect("VsSnippetsFile schema should serialize")
+});
+
+static JSONC_SCHEMA: LazyLock<String> = LazyLock::new(|| {
+    serde_json::to_string(&generate_jsonc_schema()).expect("JSONC schema should serialize")
+});
+
+#[cfg(debug_assertions)]
+static INSPECTOR_STYLE_SCHEMA: LazyLock<String> = LazyLock::new(|| {
+    serde_json::to_string(&generate_inspector_style_schema())
+        .expect("Inspector style schema should serialize")
+});
+
+// Keymap schema - actions are registered at compile/link time via inventory, so this is static
+static KEYMAP_SCHEMA: LazyLock<String> = LazyLock::new(|| {
+    serde_json::to_string(&settings::KeymapFile::generate_json_schema_from_inventory())
+        .expect("Keymap schema should serialize")
+});
+
+// Cache for individual action schemas (also static since actions don't change at runtime)
+static ACTION_SCHEMA_CACHE: LazyLock<RwLock<HashMap<String, String>>> =
+    LazyLock::new(|| RwLock::new(HashMap::default()));
+
+// Runtime cache for dynamic schemas that can change
+static DYNAMIC_SCHEMA_CACHE: LazyLock<RwLock<HashMap<String, String>>> =
+    LazyLock::new(|| RwLock::new(HashMap::default()));
 
 pub fn init(cx: &mut App) {
     cx.set_global(SchemaStore::default());
@@ -57,6 +97,9 @@ impl gpui::Global for SchemaStore {}
 
 impl SchemaStore {
     fn notify_schema_changed(&mut self, uri: &str, cx: &mut App) {
+        // Invalidate cache for this URI
+        DYNAMIC_SCHEMA_CACHE.write().remove(uri);
+
         let uri = uri.to_string();
         self.lsp_stores.retain(|lsp_store| {
             let Some(lsp_store) = lsp_store.upgrade() else {
@@ -77,32 +120,88 @@ fn handle_schema_request(
     uri: String,
     cx: &mut AsyncApp,
 ) -> Task<Result<String>> {
-    let languages = lsp_store.read_with(cx, |lsp_store, _| lsp_store.languages.clone());
-    cx.spawn(async move |cx| {
-        let schema = resolve_schema_request(&languages, lsp_store, uri, cx).await?;
-        serde_json::to_string(&schema).context("Failed to serialize schema")
-    })
-}
+    let path = match uri.strip_prefix("zed://schemas/") {
+        Some(path) => path,
+        None => return Task::ready(Err(anyhow::anyhow!("Invalid URI: {}", uri))),
+    };
 
-pub async fn resolve_schema_request(
-    languages: &Arc<LanguageRegistry>,
-    lsp_store: Entity<LspStore>,
-    uri: String,
-    cx: &mut AsyncApp,
-) -> Result<serde_json::Value> {
-    let path = uri.strip_prefix("zed://schemas/").context("Invalid URI")?;
-    resolve_schema_request_inner(languages, lsp_store, path, cx).await
-}
-
-pub async fn resolve_schema_request_inner(
-    languages: &Arc<LanguageRegistry>,
-    lsp_store: Entity<LspStore>,
-    path: &str,
-    cx: &mut AsyncApp,
-) -> Result<serde_json::Value> {
     let (schema_name, rest) = path.split_once('/').unzip();
     let schema_name = schema_name.unwrap_or(path);
 
+    // Handle static schemas that are already JSON strings - no foreground work needed
+    match schema_name {
+        "tsconfig" => return Task::ready(Ok(TSCONFIG_SCHEMA.to_string())),
+        "package_json" => return Task::ready(Ok(PACKAGE_JSON_SCHEMA.to_string())),
+        "tasks" => return Task::ready(Ok(TASKS_SCHEMA.clone())),
+        "snippets" => return Task::ready(Ok(SNIPPETS_SCHEMA.clone())),
+        "jsonc" => return Task::ready(Ok(JSONC_SCHEMA.clone())),
+        "keymap" => return Task::ready(Ok(KEYMAP_SCHEMA.clone())),
+        "zed_inspector_style" => {
+            #[cfg(debug_assertions)]
+            return Task::ready(Ok(INSPECTOR_STYLE_SCHEMA.clone()));
+            #[cfg(not(debug_assertions))]
+            return Task::ready(Ok(serde_json::to_string(
+                &schemars::json_schema!(true).to_value(),
+            )
+            .expect("true schema should serialize")));
+        }
+        "action" => {
+            let normalized_action_name = match rest {
+                Some(name) => name,
+                None => return Task::ready(Err(anyhow::anyhow!("No action name provided"))),
+            };
+            let action_name = denormalize_action_name(normalized_action_name);
+
+            // Check cache first
+            if let Some(cached) = ACTION_SCHEMA_CACHE.read().get(&action_name).cloned() {
+                return Task::ready(Ok(cached));
+            }
+
+            // Generate and cache the schema
+            let schema = settings::KeymapFile::get_action_schema_by_name(&action_name);
+            let mut generator = settings::KeymapFile::action_schema_generator();
+            let json = serde_json::to_string(
+                &root_schema_from_action_schema(schema, &mut generator).to_value(),
+            )
+            .expect("Action schema should serialize");
+
+            ACTION_SCHEMA_CACHE
+                .write()
+                .insert(action_name, json.clone());
+            return Task::ready(Ok(json));
+        }
+        _ => {}
+    }
+
+    // Check runtime cache for dynamic schemas
+    if let Some(cached) = DYNAMIC_SCHEMA_CACHE.read().get(&uri).cloned() {
+        return Task::ready(Ok(cached));
+    }
+
+    // Cache miss for dynamic schema - need to generate
+    let languages = lsp_store.read_with(cx, |lsp_store, _| lsp_store.languages.clone());
+    let schema_name = schema_name.to_string();
+    let rest = rest.map(|s| s.to_string());
+    cx.spawn(async move |cx| {
+        let schema =
+            resolve_dynamic_schema(&languages, lsp_store, &schema_name, rest.as_deref(), cx)
+                .await?;
+        let json = serde_json::to_string(&schema).context("Failed to serialize schema")?;
+
+        // Store in cache
+        DYNAMIC_SCHEMA_CACHE.write().insert(uri, json.clone());
+
+        Ok(json)
+    })
+}
+
+async fn resolve_dynamic_schema(
+    languages: &Arc<LanguageRegistry>,
+    lsp_store: Entity<LspStore>,
+    schema_name: &str,
+    rest: Option<&str>,
+    cx: &mut AsyncApp,
+) -> Result<serde_json::Value> {
     let schema = match schema_name {
         "settings" if rest.is_some_and(|r| r.starts_with("lsp/")) => {
             let lsp_name = rest
@@ -191,28 +290,53 @@ pub async fn resolve_schema_request_inner(
                 )
             })
         }
-        "keymap" => cx.update(settings::KeymapFile::generate_json_schema_for_registered_actions),
+        "keymap" => settings::KeymapFile::generate_json_schema_from_inventory(),
         "action" => {
             let normalized_action_name = rest.context("No Action name provided")?;
             let action_name = denormalize_action_name(normalized_action_name);
+            let schema = settings::KeymapFile::get_action_schema_by_name(&action_name);
             let mut generator = settings::KeymapFile::action_schema_generator();
-            let schema = cx
-                // PERF: cx.action_schema_by_name(action_name, &mut generator)
-                .update(|cx| cx.action_schemas(&mut generator))
-                .into_iter()
-                .find_map(|(name, schema)| (name == action_name).then_some(schema))
-                .flatten();
             root_schema_from_action_schema(schema, &mut generator).to_value()
         }
-        "tasks" => task::TaskTemplates::generate_json_schema(),
         "debug_tasks" => {
             let adapter_schemas = cx.read_global::<dap::DapRegistry, _>(|dap_registry, _| {
                 dap_registry.adapters_schema()
             });
             task::DebugTaskFile::generate_json_schema(&adapter_schemas)
         }
-        "package_json" => package_json_schema(),
-        "tsconfig" => tsconfig_schema(),
+        _ => {
+            anyhow::bail!("Unrecognized builtin JSON schema: {schema_name}");
+        }
+    };
+    Ok(schema)
+}
+
+pub async fn resolve_schema_request(
+    languages: &Arc<LanguageRegistry>,
+    lsp_store: Entity<LspStore>,
+    uri: String,
+    cx: &mut AsyncApp,
+) -> Result<serde_json::Value> {
+    let path = uri.strip_prefix("zed://schemas/").context("Invalid URI")?;
+    resolve_schema_request_inner(languages, lsp_store, path, cx).await
+}
+
+pub async fn resolve_schema_request_inner(
+    languages: &Arc<LanguageRegistry>,
+    lsp_store: Entity<LspStore>,
+    path: &str,
+    cx: &mut AsyncApp,
+) -> Result<serde_json::Value> {
+    let (schema_name, rest) = path.split_once('/').unzip();
+    let schema_name = schema_name.unwrap_or(path);
+
+    // Handle static schemas
+    let schema = match schema_name {
+        "tsconfig" => serde_json::Value::from_str(TSCONFIG_SCHEMA)?,
+        "package_json" => serde_json::Value::from_str(PACKAGE_JSON_SCHEMA)?,
+        "tasks" => task::TaskTemplates::generate_json_schema(),
+        "snippets" => snippet_provider::format::VsSnippetsFile::generate_json_schema(),
+        "jsonc" => generate_jsonc_schema(),
         "zed_inspector_style" => {
             if cfg!(debug_assertions) {
                 generate_inspector_style_schema()
@@ -220,10 +344,8 @@ pub async fn resolve_schema_request_inner(
                 schemars::json_schema!(true).to_value()
             }
         }
-        "snippets" => snippet_provider::format::VsSnippetsFile::generate_json_schema(),
-        "jsonc" => jsonc_schema(),
         _ => {
-            anyhow::bail!("Unrecognized builtin JSON schema: {schema_name}");
+            return resolve_dynamic_schema(languages, lsp_store, schema_name, rest, cx).await;
         }
     };
     Ok(schema)
@@ -328,15 +450,7 @@ pub fn all_schema_file_associations(
     file_associations
 }
 
-fn tsconfig_schema() -> serde_json::Value {
-    serde_json::Value::from_str(TSCONFIG_SCHEMA).unwrap()
-}
-
-fn package_json_schema() -> serde_json::Value {
-    serde_json::Value::from_str(PACKAGE_JSON_SCHEMA).unwrap()
-}
-
-fn jsonc_schema() -> serde_json::Value {
+fn generate_jsonc_schema() -> serde_json::Value {
     let generator = schemars::generate::SchemaSettings::draft2019_09()
         .with_transform(DefaultDenyUnknownFields)
         .with_transform(AllowTrailingCommas)

--- a/crates/settings/src/keymap_file.rs
+++ b/crates/settings/src/keymap_file.rs
@@ -4,7 +4,7 @@ use fs::Fs;
 use gpui::{
     Action, ActionBuildError, App, InvalidKeystrokeError, KEYSTROKE_PARSE_EXPECTED_MESSAGE,
     KeyBinding, KeyBindingContextPredicate, KeyBindingMetaIndex, KeybindingKeystroke, Keystroke,
-    NoAction, SharedString, register_action,
+    NoAction, SharedString, generate_list_of_all_registered_actions, register_action,
 };
 use schemars::{JsonSchema, json_schema};
 use serde::Deserialize;
@@ -477,6 +477,62 @@ impl KeymapFile {
             deprecations,
             deprecation_messages,
         )
+    }
+
+    /// Generate JSON schema for all registered actions without requiring App context.
+    /// This works because actions are registered at compile/link time via inventory.
+    pub fn generate_json_schema_from_inventory() -> Value {
+        let mut generator = Self::action_schema_generator();
+
+        let mut action_schemas = Vec::new();
+        let mut documentation = HashMap::default();
+        let mut deprecations = HashMap::default();
+        let mut deprecation_messages = HashMap::default();
+
+        for action_data in generate_list_of_all_registered_actions() {
+            let schema = (action_data.json_schema)(&mut generator);
+            action_schemas.push((action_data.name, schema));
+
+            if let Some(doc) = action_data.documentation {
+                documentation.insert(action_data.name, doc);
+            }
+            if let Some(msg) = action_data.deprecation_message {
+                deprecation_messages.insert(action_data.name, msg);
+            }
+            for &alias in action_data.deprecated_aliases {
+                deprecations.insert(alias, action_data.name);
+                // Also add the alias as an action
+                let alias_schema = (action_data.json_schema)(&mut generator);
+                action_schemas.push((alias, alias_schema));
+            }
+        }
+
+        KeymapFile::generate_json_schema(
+            generator,
+            action_schemas,
+            &documentation,
+            &deprecations,
+            &deprecation_messages,
+        )
+    }
+
+    /// Get the JSON schema for a single action by name, without requiring App context.
+    /// Returns None if the action doesn't exist or has no schema.
+    pub fn get_action_schema_by_name(action_name: &str) -> Option<schemars::Schema> {
+        let mut generator = Self::action_schema_generator();
+
+        for action_data in generate_list_of_all_registered_actions() {
+            if action_data.name == action_name {
+                return (action_data.json_schema)(&mut generator);
+            }
+            // Also check deprecated aliases
+            for &alias in action_data.deprecated_aliases {
+                if alias == action_name {
+                    return (action_data.json_schema)(&mut generator);
+                }
+            }
+        }
+        None
     }
 
     fn generate_json_schema(


### PR DESCRIPTION
This PR reduces foreground thread blocking caused by JSON schema generation for the JSON language server. Schema requests were showing up as ~500ms hotspots in the profiler, blocking the UI.

- **Before**: Every schema request spawned a foreground task that could take ~500ms (mostly waiting for the saturated foreground thread)
- **After**: 
  - Static schemas: `Task::ready()` returns immediately with zero foreground thread work
  - Cached dynamic schemas: `Task::ready()` returns immediately  
  - Cache misses: Same as before, but only happens once per schema

## Changes

### 1. Static schemas computed once via `LazyLock`

The following schemas are now computed exactly once on first access and cached forever:

| Schema | Why it's safe |
|--------|---------------|
| `tsconfig` | Already `include_str!` at compile time - just return the string directly |
| `package_json` | Already `include_str!` at compile time - just return the string directly |
| `tasks` | Generated from `TaskTemplates` type via schemars - type is fixed at compile time |
| `snippets` | Generated from `VsSnippetsFile` type via schemars - type is fixed at compile time |
| `jsonc` | Static schema settings, no runtime data |
| `zed_inspector_style` | Generated from `gpui::StyleRefinement` type - fixed at compile time |
| `keymap` | **NEW** - Actions are registered at compile/link time via `inventory` crate, not at runtime |
| `action/{name}` | **NEW** - Same as keymap - actions cannot be added at runtime |

**Why keymap/action schemas are safe to cache permanently:**
- Actions are registered using the `inventory` crate which collects them at link time
- Extensions are WASM-based and **cannot register new actions** - they can only provide themes, languages, grammars, and language servers  
- The `ActionRegistry::load_actions()` function runs once at startup and never again
- There is no code path that adds actions after startup

### 2. Dynamic schemas with runtime cache

These schemas genuinely need runtime data and are cached until invalidated:

| Schema | What runtime data it needs | When invalidated |
|--------|---------------------------|------------------|
| `settings` | Font names, theme names, language names, LSP adapter names | When extensions change |
| `settings/lsp/{name}` | LSP adapter initialization options schema | When extensions change |
| `debug_tasks` | DAP adapter schemas | When DAP registry changes |

Cache invalidation happens through the existing `notify_schema_changed()` pathway which is already called when extensions change or the DAP registry changes.

### 3. New helper functions in `settings::KeymapFile`

- `generate_json_schema_from_inventory()` - Generates the keymap schema by iterating `inventory::iter::<MacroActionBuilder>` directly, without requiring `App` context
- `get_action_schema_by_name()` - Efficiently looks up a single action's schema without generating all of them (addresses the `// PERF` comment in the original code)

## Release Notes

- Improve performance by caching JSON schemas used for settings/keymap validation