### PR TITLE
Possible fix for wax crash

### DIFF
--- a/crates/project/src/project_search.rs
+++ b/crates/project/src/project_search.rs
@@ -840,7 +840,11 @@ impl PathInclusionMatcher {
                 query
                     .files_to_include()
                     .sources()
-                    .flat_map(|glob| Some(wax::Glob::new(glob).ok()?.partition().0)),
+                    .filter_map(|glob| {
+                        let prefix = wax::Glob::new(glob).ok()?.partition().0;
+                        // Skip patterns with empty prefixes (e.g., **/*.rs) to avoid panics in wax
+                        (!prefix.as_os_str().is_empty()).then_some(prefix)
+                    }),
             );
         }
         Self { included, query }


### PR DESCRIPTION
Closes #46790

**Summary**
Problem: Panic in wax::Glob::partition() when processing glob patterns without a fixed prefix (e.g., **/*.rs, *.txt). For such patterns, partition() returns an empty prefix, and wax internally calls drain(..1) on an empty vector, causing a panic.
Solution: Added a check to skip empty prefixes before adding them to included. Patterns with empty prefixes are skipped, preventing the panic.
Changes:
Replaced flat_map with filter_map for explicit filtering
Added !prefix.as_os_str().is_empty() before adding the prefix
Added a comment explaining why these patterns are skipped
Logic: If all patterns have empty prefixes, included will be empty, and should_scan_gitignored_dir returns true (lines 879-880), which is correct — such patterns can match files in any directory.
File with the bug: crates/project/src/project_search.rs (line 843)


**Release Notes:**

Possible fix for application crash. Looks dumb and I am not sure this is okay. Feel free to decline
