### PR TITLE
lsp: Add `container_name` to `lsp::Symbol`

### DIFF
--- a/crates/extension/src/types/lsp.rs
+++ b/crates/extension/src/types/lsp.rs
@@ -61,6 +61,7 @@ pub enum InsertTextFormat {
 pub struct Symbol {
     pub kind: SymbolKind,
     pub name: String,
+    pub container_name: Option<String>,
 }
 
 /// The kind of an LSP symbol.

--- a/crates/extension_api/wit/since_v0.8.0/lsp.wit
+++ b/crates/extension_api/wit/since_v0.8.0/lsp.wit
@@ -55,6 +55,7 @@ interface lsp {
     record symbol {
         kind: symbol-kind,
         name: string,
+        container-name: option<string>,
     }
 
     /// The kind of an LSP symbol.

--- a/crates/extension_host/src/wasm_host/wit.rs
+++ b/crates/extension_host/src/wasm_host/wit.rs
@@ -586,7 +586,7 @@ impl Extension {
                 .call_labels_for_completions(
                     store,
                     &language_server_id.0,
-                    &completions.into_iter().collect::<Vec<_>>(),
+                    &completions.into_iter().map(Into::into).collect::<Vec<_>>(),
                 )
                 .await?
                 .map(|labels| {
@@ -599,7 +599,7 @@ impl Extension {
                 .call_labels_for_completions(
                     store,
                     &language_server_id.0,
-                    &completions.into_iter().collect::<Vec<_>>(),
+                    &completions.into_iter().map(Into::into).collect::<Vec<_>>(),
                 )
                 .await?
                 .map(|labels| {
@@ -612,7 +612,7 @@ impl Extension {
                 .call_labels_for_completions(
                     store,
                     &language_server_id.0,
-                    &completions.into_iter().collect::<Vec<_>>(),
+                    &completions.into_iter().map(Into::into).collect::<Vec<_>>(),
                 )
                 .await?
                 .map(|labels| {
@@ -625,7 +625,7 @@ impl Extension {
                 .call_labels_for_completions(
                     store,
                     &language_server_id.0,
-                    &completions.into_iter().collect::<Vec<_>>(),
+                    &completions.into_iter().map(Into::into).collect::<Vec<_>>(),
                 )
                 .await?
                 .map(|labels| {
@@ -638,7 +638,7 @@ impl Extension {
                 .call_labels_for_completions(
                     store,
                     &language_server_id.0,
-                    &completions.into_iter().collect::<Vec<_>>(),
+                    &completions.into_iter().map(Into::into).collect::<Vec<_>>(),
                 )
                 .await?
                 .map(|labels| {
@@ -692,7 +692,7 @@ impl Extension {
                 .call_labels_for_symbols(
                     store,
                     &language_server_id.0,
-                    &symbols.into_iter().collect::<Vec<_>>(),
+                    &symbols.into_iter().map(Into::into).collect::<Vec<_>>(),
                 )
                 .await?
                 .map(|labels| {
@@ -705,7 +705,7 @@ impl Extension {
                 .call_labels_for_symbols(
                     store,
                     &language_server_id.0,
-                    &symbols.into_iter().collect::<Vec<_>>(),
+                    &symbols.into_iter().map(Into::into).collect::<Vec<_>>(),
                 )
                 .await?
                 .map(|labels| {
@@ -718,7 +718,7 @@ impl Extension {
                 .call_labels_for_symbols(
                     store,
                     &language_server_id.0,
-                    &symbols.into_iter().collect::<Vec<_>>(),
+                    &symbols.into_iter().map(Into::into).collect::<Vec<_>>(),
                 )
                 .await?
                 .map(|labels| {
@@ -731,7 +731,7 @@ impl Extension {
                 .call_labels_for_symbols(
                     store,
                     &language_server_id.0,
-                    &symbols.into_iter().collect::<Vec<_>>(),
+                    &symbols.into_iter().map(Into::into).collect::<Vec<_>>(),
                 )
                 .await?
                 .map(|labels| {
@@ -744,7 +744,7 @@ impl Extension {
                 .call_labels_for_symbols(
                     store,
                     &language_server_id.0,
-                    &symbols.into_iter().collect::<Vec<_>>(),
+                    &symbols.into_iter().map(Into::into).collect::<Vec<_>>(),
                 )
                 .await?
                 .map(|labels| {

--- a/crates/extension_host/src/wasm_host/wit/since_v0_2_0.rs
+++ b/crates/extension_host/src/wasm_host/wit/since_v0_2_0.rs
@@ -6,7 +6,7 @@ use semver::Version;
 use std::sync::{Arc, OnceLock};
 use wasmtime::component::{Linker, Resource};
 
-use super::latest;
+use super::{latest, since_v0_6_0};
 
 pub const MIN_VERSION: Version = Version::new(0, 2, 0);
 
@@ -20,7 +20,7 @@ wasmtime::component::bindgen!({
          "key-value-store": ExtensionKeyValueStore,
          "zed:extension/github": latest::zed::extension::github,
          "zed:extension/http-client": latest::zed::extension::http_client,
-         "zed:extension/lsp": latest::zed::extension::lsp,
+         "zed:extension/lsp": since_v0_6_0::zed::extension::lsp,
          "zed:extension/nodejs": latest::zed::extension::nodejs,
          "zed:extension/platform": latest::zed::extension::platform,
          "zed:extension/slash-command": latest::zed::extension::slash_command,

--- a/crates/extension_host/src/wasm_host/wit/since_v0_3_0.rs
+++ b/crates/extension_host/src/wasm_host/wit/since_v0_3_0.rs
@@ -6,7 +6,7 @@ use semver::Version;
 use std::sync::{Arc, OnceLock};
 use wasmtime::component::{Linker, Resource};
 
-use super::latest;
+use super::{latest, since_v0_6_0};
 
 pub const MIN_VERSION: Version = Version::new(0, 3, 0);
 
@@ -21,7 +21,7 @@ wasmtime::component::bindgen!({
          "zed:extension/common": latest::zed::extension::common,
          "zed:extension/github": latest::zed::extension::github,
          "zed:extension/http-client": latest::zed::extension::http_client,
-         "zed:extension/lsp": latest::zed::extension::lsp,
+         "zed:extension/lsp": since_v0_6_0::zed::extension::lsp,
          "zed:extension/nodejs": latest::zed::extension::nodejs,
          "zed:extension/platform": latest::zed::extension::platform,
          "zed:extension/process": latest::zed::extension::process,

--- a/crates/extension_host/src/wasm_host/wit/since_v0_4_0.rs
+++ b/crates/extension_host/src/wasm_host/wit/since_v0_4_0.rs
@@ -6,7 +6,7 @@ use semver::Version;
 use std::sync::{Arc, OnceLock};
 use wasmtime::component::{Linker, Resource};
 
-use super::latest;
+use super::{latest, since_v0_6_0};
 
 pub const MIN_VERSION: Version = Version::new(0, 4, 0);
 
@@ -21,7 +21,7 @@ wasmtime::component::bindgen!({
         "zed:extension/common": latest::zed::extension::common,
         "zed:extension/github": latest::zed::extension::github,
         "zed:extension/http-client": latest::zed::extension::http_client,
-        "zed:extension/lsp": latest::zed::extension::lsp,
+        "zed:extension/lsp": since_v0_6_0::zed::extension::lsp,
         "zed:extension/nodejs": latest::zed::extension::nodejs,
         "zed:extension/platform": latest::zed::extension::platform,
         "zed:extension/process": latest::zed::extension::process,

--- a/crates/extension_host/src/wasm_host/wit/since_v0_5_0.rs
+++ b/crates/extension_host/src/wasm_host/wit/since_v0_5_0.rs
@@ -6,7 +6,7 @@ use semver::Version;
 use std::sync::{Arc, OnceLock};
 use wasmtime::component::{Linker, Resource};
 
-use super::latest;
+use super::{latest, since_v0_6_0};
 
 pub const MIN_VERSION: Version = Version::new(0, 5, 0);
 
@@ -21,7 +21,7 @@ wasmtime::component::bindgen!({
         "zed:extension/common": latest::zed::extension::common,
         "zed:extension/github": latest::zed::extension::github,
         "zed:extension/http-client": latest::zed::extension::http_client,
-        "zed:extension/lsp": latest::zed::extension::lsp,
+        "zed:extension/lsp": since_v0_6_0::zed::extension::lsp,
         "zed:extension/nodejs": latest::zed::extension::nodejs,
         "zed:extension/platform": latest::zed::extension::platform,
         "zed:extension/process": latest::zed::extension::process,

--- a/crates/extension_host/src/wasm_host/wit/since_v0_6_0.rs
+++ b/crates/extension_host/src/wasm_host/wit/since_v0_6_0.rs
@@ -22,7 +22,6 @@ wasmtime::component::bindgen!({
         "zed:extension/common": latest::zed::extension::common,
         "zed:extension/github": latest::zed::extension::github,
         "zed:extension/http-client": latest::zed::extension::http_client,
-        "zed:extension/lsp": latest::zed::extension::lsp,
         "zed:extension/nodejs": latest::zed::extension::nodejs,
         "zed:extension/platform": latest::zed::extension::platform,
         "zed:extension/process": latest::zed::extension::process,
@@ -106,6 +105,115 @@ impl From<DownloadedFileType> for latest::DownloadedFileType {
         }
     }
 }
+
+impl From<latest::lsp::Symbol> for lsp::Symbol {
+    fn from(value: latest::lsp::Symbol) -> Self {
+        Self {
+            name: value.name,
+            kind: value.kind.into(),
+        }
+    }
+}
+
+impl From<latest::lsp::Completion> for lsp::Completion {
+    fn from(value: latest::lsp::Completion) -> Self {
+        Self {
+            label: value.label,
+            label_details: value.label_details.map(Into::into),
+            detail: value.detail,
+            kind: value.kind.map(Into::into),
+            insert_text_format: value.insert_text_format.map(Into::into),
+        }
+    }
+}
+
+impl From<latest::lsp::CompletionLabelDetails> for lsp::CompletionLabelDetails {
+    fn from(value: latest::lsp::CompletionLabelDetails) -> Self {
+        Self {
+            detail: value.detail,
+            description: value.description,
+        }
+    }
+}
+
+impl From<latest::lsp::CompletionKind> for lsp::CompletionKind {
+    fn from(value: latest::lsp::CompletionKind) -> Self {
+        match value {
+            latest::lsp::CompletionKind::Text => Self::Text,
+            latest::lsp::CompletionKind::Method => Self::Method,
+            latest::lsp::CompletionKind::Function => Self::Function,
+            latest::lsp::CompletionKind::Constructor => Self::Constructor,
+            latest::lsp::CompletionKind::Field => Self::Field,
+            latest::lsp::CompletionKind::Variable => Self::Variable,
+            latest::lsp::CompletionKind::Class => Self::Class,
+            latest::lsp::CompletionKind::Interface => Self::Interface,
+            latest::lsp::CompletionKind::Module => Self::Module,
+            latest::lsp::CompletionKind::Property => Self::Property,
+            latest::lsp::CompletionKind::Unit => Self::Unit,
+            latest::lsp::CompletionKind::Value => Self::Value,
+            latest::lsp::CompletionKind::Enum => Self::Enum,
+            latest::lsp::CompletionKind::Keyword => Self::Keyword,
+            latest::lsp::CompletionKind::Snippet => Self::Snippet,
+            latest::lsp::CompletionKind::Color => Self::Color,
+            latest::lsp::CompletionKind::File => Self::File,
+            latest::lsp::CompletionKind::Reference => Self::Reference,
+            latest::lsp::CompletionKind::Folder => Self::Folder,
+            latest::lsp::CompletionKind::EnumMember => Self::EnumMember,
+            latest::lsp::CompletionKind::Constant => Self::Constant,
+            latest::lsp::CompletionKind::Struct => Self::Struct,
+            latest::lsp::CompletionKind::Event => Self::Event,
+            latest::lsp::CompletionKind::Operator => Self::Operator,
+            latest::lsp::CompletionKind::TypeParameter => Self::TypeParameter,
+            latest::lsp::CompletionKind::Other(kind) => Self::Other(kind),
+        }
+    }
+}
+
+impl From<latest::lsp::InsertTextFormat> for lsp::InsertTextFormat {
+    fn from(value: latest::lsp::InsertTextFormat) -> Self {
+        match value {
+            latest::lsp::InsertTextFormat::PlainText => Self::PlainText,
+            latest::lsp::InsertTextFormat::Snippet => Self::Snippet,
+            latest::lsp::InsertTextFormat::Other(value) => Self::Other(value),
+        }
+    }
+}
+
+impl From<latest::lsp::SymbolKind> for lsp::SymbolKind {
+    fn from(value: latest::lsp::SymbolKind) -> Self {
+        match value {
+            latest::lsp::SymbolKind::File => Self::File,
+            latest::lsp::SymbolKind::Module => Self::Module,
+            latest::lsp::SymbolKind::Namespace => Self::Namespace,
+            latest::lsp::SymbolKind::Package => Self::Package,
+            latest::lsp::SymbolKind::Class => Self::Class,
+            latest::lsp::SymbolKind::Method => Self::Method,
+            latest::lsp::SymbolKind::Property => Self::Property,
+            latest::lsp::SymbolKind::Field => Self::Field,
+            latest::lsp::SymbolKind::Constructor => Self::Constructor,
+            latest::lsp::SymbolKind::Enum => Self::Enum,
+            latest::lsp::SymbolKind::Interface => Self::Interface,
+            latest::lsp::SymbolKind::Function => Self::Function,
+            latest::lsp::SymbolKind::Variable => Self::Variable,
+            latest::lsp::SymbolKind::Constant => Self::Constant,
+            latest::lsp::SymbolKind::String => Self::String,
+            latest::lsp::SymbolKind::Number => Self::Number,
+            latest::lsp::SymbolKind::Boolean => Self::Boolean,
+            latest::lsp::SymbolKind::Array => Self::Array,
+            latest::lsp::SymbolKind::Object => Self::Object,
+            latest::lsp::SymbolKind::Key => Self::Key,
+            latest::lsp::SymbolKind::Null => Self::Null,
+            latest::lsp::SymbolKind::EnumMember => Self::EnumMember,
+            latest::lsp::SymbolKind::Struct => Self::Struct,
+            latest::lsp::SymbolKind::Event => Self::Event,
+            latest::lsp::SymbolKind::Operator => Self::Operator,
+            latest::lsp::SymbolKind::TypeParameter => Self::TypeParameter,
+            latest::lsp::SymbolKind::Other(kind) => Self::Other(kind),
+        }
+    }
+}
+
+impl lsp::Host for WasmState {}
 
 impl HostKeyValueStore for WasmState {
     async fn insert(

--- a/crates/extension_host/src/wasm_host/wit/since_v0_8_0.rs
+++ b/crates/extension_host/src/wasm_host/wit/since_v0_8_0.rs
@@ -421,6 +421,7 @@ impl From<extension::Symbol> for Symbol {
         Self {
             kind: value.kind.into(),
             name: value.name,
+            container_name: value.container_name,
         }
     }
 }

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -457,8 +457,8 @@ pub trait LspAdapter: 'static + Send + Sync + DynLspInstaller {
         language: &Arc<Language>,
     ) -> Result<Vec<Option<CodeLabel>>> {
         let mut labels = Vec::new();
-        for (ix, lsp_label) in symbols.iter().enumerate() {
-            let label = self.label_for_symbol(lsp_label, language).await;
+        for (ix, symbol) in symbols.iter().enumerate() {
+            let label = self.label_for_symbol(symbol, language).await;
             if let Some(label) = label {
                 labels.resize(ix + 1, None);
                 *labels.last_mut().unwrap() = Some(label);

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -469,7 +469,7 @@ pub trait LspAdapter: 'static + Send + Sync + DynLspInstaller {
 
     async fn label_for_symbol(
         &self,
-        _lsp_symbol: &Symbol,
+        _symbol: &Symbol,
         _language: &Arc<Language>,
     ) -> Option<CodeLabel> {
         None

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -316,7 +316,7 @@ impl CachedLspAdapter {
 
     pub async fn labels_for_symbols(
         &self,
-        symbols: &[(String, lsp::SymbolKind)],
+        symbols: &[(String, lsp::SymbolKind, Option<String>)],
         language: &Arc<Language>,
     ) -> Result<Vec<Option<CodeLabel>>> {
         self.adapter
@@ -446,12 +446,14 @@ pub trait LspAdapter: 'static + Send + Sync + DynLspInstaller {
 
     async fn labels_for_symbols(
         self: Arc<Self>,
-        symbols: &[(String, lsp::SymbolKind)],
+        symbols: &[(String, lsp::SymbolKind, Option<String>)],
         language: &Arc<Language>,
     ) -> Result<Vec<Option<CodeLabel>>> {
         let mut labels = Vec::new();
-        for (ix, (name, kind)) in symbols.iter().enumerate() {
-            let label = self.label_for_symbol(name, *kind, language).await;
+        for (ix, (name, kind, container_name)) in symbols.iter().enumerate() {
+            let label = self
+                .label_for_symbol(name, *kind, container_name.as_deref(), language)
+                .await;
             if let Some(label) = label {
                 labels.resize(ix + 1, None);
                 *labels.last_mut().unwrap() = Some(label);
@@ -462,9 +464,10 @@ pub trait LspAdapter: 'static + Send + Sync + DynLspInstaller {
 
     async fn label_for_symbol(
         &self,
-        _: &str,
-        _: lsp::SymbolKind,
-        _: &Arc<Language>,
+        _name: &str,
+        _kind: lsp::SymbolKind,
+        _container_name: Option<&str>,
+        _language: &Arc<Language>,
     ) -> Option<CodeLabel> {
         None
     }

--- a/crates/language_extension/src/extension_lsp_adapter.rs
+++ b/crates/language_extension/src/extension_lsp_adapter.rs
@@ -421,17 +421,23 @@ impl LspAdapter for ExtensionLspAdapter {
 
     async fn labels_for_symbols(
         self: Arc<Self>,
-        symbols: &[(String, lsp::SymbolKind, Option<String>)],
+        symbols: &[language::Symbol],
         language: &Arc<Language>,
     ) -> Result<Vec<Option<CodeLabel>>> {
         let symbols = symbols
             .iter()
             .cloned()
-            .map(|(name, kind, container_name)| extension::Symbol {
-                name,
-                kind: lsp_symbol_kind_to_extension(kind),
-                container_name,
-            })
+            .map(
+                |language::Symbol {
+                     name,
+                     kind,
+                     container_name,
+                 }| extension::Symbol {
+                    name,
+                    kind: lsp_symbol_kind_to_extension(kind),
+                    container_name,
+                },
+            )
             .collect::<Vec<_>>();
 
         let labels = self

--- a/crates/language_extension/src/extension_lsp_adapter.rs
+++ b/crates/language_extension/src/extension_lsp_adapter.rs
@@ -421,15 +421,16 @@ impl LspAdapter for ExtensionLspAdapter {
 
     async fn labels_for_symbols(
         self: Arc<Self>,
-        symbols: &[(String, lsp::SymbolKind)],
+        symbols: &[(String, lsp::SymbolKind, Option<String>)],
         language: &Arc<Language>,
     ) -> Result<Vec<Option<CodeLabel>>> {
         let symbols = symbols
             .iter()
             .cloned()
-            .map(|(name, kind)| extension::Symbol {
+            .map(|(name, kind, container_name)| extension::Symbol {
                 name,
                 kind: lsp_symbol_kind_to_extension(kind),
+                container_name,
             })
             .collect::<Vec<_>>();
 

--- a/crates/languages/src/c.rs
+++ b/crates/languages/src/c.rs
@@ -289,6 +289,7 @@ impl super::LspAdapter for CLspAdapter {
         &self,
         name: &str,
         kind: lsp::SymbolKind,
+        _container_name: Option<&str>,
         language: &Arc<Language>,
     ) -> Option<CodeLabel> {
         let (text, filter_range, display_range) = match kind {

--- a/crates/languages/src/c.rs
+++ b/crates/languages/src/c.rs
@@ -290,8 +290,8 @@ impl super::LspAdapter for CLspAdapter {
         symbol: &language::Symbol,
         language: &Arc<Language>,
     ) -> Option<CodeLabel> {
-        let Symbol { name, kind, .. } = symbol;
-        let (text, filter_range, display_range) = match *kind {
+        let name = &symbol.name;
+        let (text, filter_range, display_range) = match symbol.kind {
             lsp::SymbolKind::METHOD | lsp::SymbolKind::FUNCTION => {
                 let text = format!("void {} () {{}}", name);
                 let filter_range = 0..name.len();

--- a/crates/languages/src/c.rs
+++ b/crates/languages/src/c.rs
@@ -287,12 +287,11 @@ impl super::LspAdapter for CLspAdapter {
 
     async fn label_for_symbol(
         &self,
-        name: &str,
-        kind: lsp::SymbolKind,
-        _container_name: Option<&str>,
+        symbol: &language::Symbol,
         language: &Arc<Language>,
     ) -> Option<CodeLabel> {
-        let (text, filter_range, display_range) = match kind {
+        let Symbol { name, kind, .. } = symbol;
+        let (text, filter_range, display_range) = match *kind {
             lsp::SymbolKind::METHOD | lsp::SymbolKind::FUNCTION => {
                 let text = format!("void {} () {{}}", name);
                 let filter_range = 0..name.len();

--- a/crates/languages/src/go.rs
+++ b/crates/languages/src/go.rs
@@ -334,12 +334,11 @@ impl LspAdapter for GoLspAdapter {
 
     async fn label_for_symbol(
         &self,
-        name: &str,
-        kind: lsp::SymbolKind,
-        _container_name: Option<&str>,
+        symbol: &language::Symbol,
         language: &Arc<Language>,
     ) -> Option<CodeLabel> {
-        let (text, filter_range, display_range) = match kind {
+        let name = &symbol.name;
+        let (text, filter_range, display_range) = match symbol.kind {
             lsp::SymbolKind::METHOD | lsp::SymbolKind::FUNCTION => {
                 let text = format!("func {} () {{}}", name);
                 let filter_range = 5..5 + name.len();

--- a/crates/languages/src/go.rs
+++ b/crates/languages/src/go.rs
@@ -336,6 +336,7 @@ impl LspAdapter for GoLspAdapter {
         &self,
         name: &str,
         kind: lsp::SymbolKind,
+        _container_name: Option<&str>,
         language: &Arc<Language>,
     ) -> Option<CodeLabel> {
         let (text, filter_range, display_range) = match kind {

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -8,7 +8,7 @@ use futures::{AsyncBufReadExt, StreamExt as _};
 use gpui::{App, AsyncApp, SharedString, Task};
 use http_client::github::{AssetKind, GitHubLspBinaryVersion, latest_github_release};
 use language::language_settings::language_settings;
-use language::{ContextLocation, DynLspInstaller, LanguageToolchainStore, LspInstaller};
+use language::{ContextLocation, DynLspInstaller, LanguageToolchainStore, LspInstaller, Symbol};
 use language::{ContextProvider, LspAdapter, LspAdapterDelegate};
 use language::{LanguageName, ManifestName, ManifestProvider, ManifestQuery};
 use language::{Toolchain, ToolchainList, ToolchainLister, ToolchainMetadata};
@@ -550,12 +550,11 @@ impl LspAdapter for PyrightLspAdapter {
 
     async fn label_for_symbol(
         &self,
-        name: &str,
-        kind: lsp::SymbolKind,
-        _container_name: Option<&str>,
+        symbol: &language::Symbol,
         language: &Arc<language::Language>,
     ) -> Option<language::CodeLabel> {
-        let (text, filter_range, display_range) = match kind {
+        let name = &symbol.name;
+        let (text, filter_range, display_range) = match symbol.kind {
             lsp::SymbolKind::METHOD | lsp::SymbolKind::FUNCTION => {
                 let text = format!("def {}():\n", name);
                 let filter_range = 4..4 + name.len();
@@ -1709,12 +1708,11 @@ impl LspAdapter for PyLspAdapter {
 
     async fn label_for_symbol(
         &self,
-        name: &str,
-        kind: lsp::SymbolKind,
-        _container_name: Option<&str>,
+        symbol: &language::Symbol,
         language: &Arc<language::Language>,
     ) -> Option<language::CodeLabel> {
-        let (text, filter_range, display_range) = match kind {
+        let name = &symbol.name;
+        let (text, filter_range, display_range) = match symbol.kind {
             lsp::SymbolKind::METHOD | lsp::SymbolKind::FUNCTION => {
                 let text = format!("def {}():\n", name);
                 let filter_range = 4..4 + name.len();
@@ -2002,12 +2000,11 @@ impl LspAdapter for BasedPyrightLspAdapter {
 
     async fn label_for_symbol(
         &self,
-        name: &str,
-        kind: lsp::SymbolKind,
-        _container_name: Option<&str>,
+        symbol: &Symbol,
         language: &Arc<language::Language>,
     ) -> Option<language::CodeLabel> {
-        let (text, filter_range, display_range) = match kind {
+        let name = &symbol.name;
+        let (text, filter_range, display_range) = match symbol.kind {
             lsp::SymbolKind::METHOD | lsp::SymbolKind::FUNCTION => {
                 let text = format!("def {}():\n", name);
                 let filter_range = 4..4 + name.len();

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -552,6 +552,7 @@ impl LspAdapter for PyrightLspAdapter {
         &self,
         name: &str,
         kind: lsp::SymbolKind,
+        _container_name: Option<&str>,
         language: &Arc<language::Language>,
     ) -> Option<language::CodeLabel> {
         let (text, filter_range, display_range) = match kind {
@@ -1710,6 +1711,7 @@ impl LspAdapter for PyLspAdapter {
         &self,
         name: &str,
         kind: lsp::SymbolKind,
+        _container_name: Option<&str>,
         language: &Arc<language::Language>,
     ) -> Option<language::CodeLabel> {
         let (text, filter_range, display_range) = match kind {
@@ -2002,6 +2004,7 @@ impl LspAdapter for BasedPyrightLspAdapter {
         &self,
         name: &str,
         kind: lsp::SymbolKind,
+        _container_name: Option<&str>,
         language: &Arc<language::Language>,
     ) -> Option<language::CodeLabel> {
         let (text, filter_range, display_range) = match kind {

--- a/crates/languages/src/rust.rs
+++ b/crates/languages/src/rust.rs
@@ -563,12 +563,11 @@ impl LspAdapter for RustLspAdapter {
 
     async fn label_for_symbol(
         &self,
-        name: &str,
-        kind: lsp::SymbolKind,
-        _container_name: Option<&str>,
+        symbol: &language::Symbol,
         language: &Arc<Language>,
     ) -> Option<CodeLabel> {
-        let (prefix, suffix) = match kind {
+        let name = &symbol.name;
+        let (prefix, suffix) = match symbol.kind {
             lsp::SymbolKind::METHOD | lsp::SymbolKind::FUNCTION => ("fn ", "();"),
             lsp::SymbolKind::STRUCT => ("struct ", ";"),
             lsp::SymbolKind::ENUM => ("enum ", "{}"),
@@ -1818,7 +1817,14 @@ mod tests {
 
         assert_eq!(
             adapter
-                .label_for_symbol("hello", lsp::SymbolKind::FUNCTION, None, &language)
+                .label_for_symbol(
+                    &language::Symbol {
+                        name: "hello".to_string(),
+                        kind: lsp::SymbolKind::FUNCTION,
+                        container_name: None,
+                    },
+                    &language
+                )
                 .await,
             Some(CodeLabel::new(
                 "fn hello".to_string(),
@@ -1829,7 +1835,14 @@ mod tests {
 
         assert_eq!(
             adapter
-                .label_for_symbol("World", lsp::SymbolKind::TYPE_PARAMETER, None, &language)
+                .label_for_symbol(
+                    &language::Symbol {
+                        name: "World".to_string(),
+                        kind: lsp::SymbolKind::TYPE_PARAMETER,
+                        container_name: None,
+                    },
+                    &language
+                )
                 .await,
             Some(CodeLabel::new(
                 "type World".to_string(),
@@ -1840,7 +1853,14 @@ mod tests {
 
         assert_eq!(
             adapter
-                .label_for_symbol("zed", lsp::SymbolKind::PACKAGE, None, &language)
+                .label_for_symbol(
+                    &language::Symbol {
+                        name: "zed".to_string(),
+                        kind: lsp::SymbolKind::PACKAGE,
+                        container_name: None,
+                    },
+                    &language
+                )
                 .await,
             Some(CodeLabel::new(
                 "extern crate zed".to_string(),
@@ -1851,7 +1871,14 @@ mod tests {
 
         assert_eq!(
             adapter
-                .label_for_symbol("Variant", lsp::SymbolKind::ENUM_MEMBER, None, &language)
+                .label_for_symbol(
+                    &language::Symbol {
+                        name: "Variant".to_string(),
+                        kind: lsp::SymbolKind::ENUM_MEMBER,
+                        container_name: None,
+                    },
+                    &language
+                )
                 .await,
             Some(CodeLabel::new(
                 "Variant".to_string(),

--- a/crates/languages/src/rust.rs
+++ b/crates/languages/src/rust.rs
@@ -565,6 +565,7 @@ impl LspAdapter for RustLspAdapter {
         &self,
         name: &str,
         kind: lsp::SymbolKind,
+        _container_name: Option<&str>,
         language: &Arc<Language>,
     ) -> Option<CodeLabel> {
         let (prefix, suffix) = match kind {
@@ -1817,7 +1818,7 @@ mod tests {
 
         assert_eq!(
             adapter
-                .label_for_symbol("hello", lsp::SymbolKind::FUNCTION, &language)
+                .label_for_symbol("hello", lsp::SymbolKind::FUNCTION, None, &language)
                 .await,
             Some(CodeLabel::new(
                 "fn hello".to_string(),
@@ -1828,7 +1829,7 @@ mod tests {
 
         assert_eq!(
             adapter
-                .label_for_symbol("World", lsp::SymbolKind::TYPE_PARAMETER, &language)
+                .label_for_symbol("World", lsp::SymbolKind::TYPE_PARAMETER, None, &language)
                 .await,
             Some(CodeLabel::new(
                 "type World".to_string(),
@@ -1839,7 +1840,7 @@ mod tests {
 
         assert_eq!(
             adapter
-                .label_for_symbol("zed", lsp::SymbolKind::PACKAGE, &language)
+                .label_for_symbol("zed", lsp::SymbolKind::PACKAGE, None, &language)
                 .await,
             Some(CodeLabel::new(
                 "extern crate zed".to_string(),
@@ -1850,7 +1851,7 @@ mod tests {
 
         assert_eq!(
             adapter
-                .label_for_symbol("Variant", lsp::SymbolKind::ENUM_MEMBER, &language)
+                .label_for_symbol("Variant", lsp::SymbolKind::ENUM_MEMBER, None, &language)
                 .await,
             Some(CodeLabel::new(
                 "Variant".to_string(),

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -7902,7 +7902,6 @@ impl LspStore {
                                         flat_responses
                                             .into_iter()
                                             .map(|lsp_symbol| {
-                                                #[allow(deprecated)]
                                                 (
                                                     lsp_symbol.name,
                                                     lsp_symbol.kind,
@@ -14485,12 +14484,10 @@ async fn populate_labels_for_symbols(
     let mut label_params = Vec::new();
     for (language, mut symbols) in symbols_by_language {
         label_params.clear();
-        label_params.extend(symbols.iter_mut().map(|symbol| {
-            (
-                mem::take(&mut symbol.name),
-                symbol.kind,
-                symbol.container_name.take(),
-            )
+        label_params.extend(symbols.iter_mut().map(|symbol| language::Symbol {
+            name: mem::take(&mut symbol.name),
+            kind: symbol.kind,
+            container_name: symbol.container_name.take(),
         }));
 
         let mut labels = Vec::new();
@@ -14510,7 +14507,17 @@ async fn populate_labels_for_symbols(
             }
         }
 
-        for ((symbol, (name, _, container_name)), label) in symbols
+        for (
+            (
+                symbol,
+                language::Symbol {
+                    name,
+                    container_name,
+                    ..
+                },
+            ),
+            label,
+        ) in symbols
             .into_iter()
             .zip(label_params.drain(..))
             .zip(labels.into_iter().chain(iter::repeat(None)))

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -829,6 +829,7 @@ pub struct Symbol {
     pub name: String,
     pub kind: lsp::SymbolKind,
     pub range: Range<Unclipped<PointUtf16>>,
+    pub container_name: Option<String>,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/proto/proto/lsp.proto
+++ b/crates/proto/proto/lsp.proto
@@ -109,6 +109,7 @@ message Symbol {
   PointUtf16 end = 8;
   bytes signature = 9;
   uint64 language_server_id = 10;
+  optional string container_name = 11;
 }
 
 message GetDocumentSymbols {


### PR DESCRIPTION
Some language servers include local symbols (e.g., local variables, parameters) in workspace symbol results. Without the `containerName` information, these symbols lack context information, making it difficult to distinguish them from top-level definitions and hindering efficient symbol lookup.

This change exposes the `container_name` field from LSP [`SymbolInformation`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#symbolInformation) to the extension API, allowing language server extensions to access `symbol.container_name` in `label_for_symbol` and provide meaningful context when rendering symbol labels.

Note: The `container_name `field is added to all extension API versions because they seem to share the same underlying Rust types via wasmtime bindgen. The field is optional, so existing extensions would remain compatible as far as I understand.

Closes #ISSUE

Release Notes:

- Added `container_name` field to `lsp::Symbol`, accessible via the extension API's `label_for_symbol` function