### PR TITLE
Use LazyLock for static JSON schemas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8682,10 +8682,12 @@ name = "json_schema_store"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "collections",
  "dap",
  "extension",
  "gpui",
  "language",
+ "parking_lot",
  "paths",
  "project",
  "schemars",

--- a/crates/json_schema_store/Cargo.toml
+++ b/crates/json_schema_store/Cargo.toml
@@ -16,7 +16,9 @@ default = []
 
 [dependencies]
 anyhow.workspace = true
+collections.workspace = true
 dap.workspace = true
+parking_lot.workspace = true
 extension.workspace = true
 gpui.workspace = true
 language.workspace = true

--- a/crates/json_schema_store/src/json_schema_store.rs
+++ b/crates/json_schema_store/src/json_schema_store.rs
@@ -390,6 +390,7 @@ fn generate_jsonc_schema() -> serde_json::Value {
     serde_json::to_value(schema).unwrap()
 }
 
+#[cfg(debug_assertions)]
 fn generate_inspector_style_schema() -> serde_json::Value {
     let schema = schemars::generate::SchemaSettings::draft2019_09()
         .with_transform(util::schemars::DefaultDenyUnknownFields)

--- a/crates/json_schema_store/src/json_schema_store.rs
+++ b/crates/json_schema_store/src/json_schema_store.rs
@@ -140,8 +140,9 @@ pub fn handle_schema_request(
                 return Task::ready(Ok(cached));
             }
 
-            let schema = settings::KeymapFile::get_action_schema_by_name(&action_name);
             let mut generator = settings::KeymapFile::action_schema_generator();
+            let schema =
+                settings::KeymapFile::get_action_schema_by_name(&action_name, &mut generator);
             let json = serde_json::to_string(
                 &root_schema_from_action_schema(schema, &mut generator).to_value(),
             )

--- a/crates/settings/src/keymap_file.rs
+++ b/crates/settings/src/keymap_file.rs
@@ -4,7 +4,7 @@ use fs::Fs;
 use gpui::{
     Action, ActionBuildError, App, InvalidKeystrokeError, KEYSTROKE_PARSE_EXPECTED_MESSAGE,
     KeyBinding, KeyBindingContextPredicate, KeyBindingMetaIndex, KeybindingKeystroke, Keystroke,
-    NoAction, SharedString, register_action,
+    NoAction, SharedString, generate_list_of_all_registered_actions, register_action,
 };
 use schemars::{JsonSchema, json_schema};
 use serde::Deserialize;
@@ -477,6 +477,62 @@ impl KeymapFile {
             deprecations,
             deprecation_messages,
         )
+    }
+
+    /// Generate JSON schema for all registered actions without requiring App context.
+    /// This works because actions are registered at compile/link time via inventory.
+    pub fn generate_json_schema_from_inventory() -> Value {
+        let mut generator = Self::action_schema_generator();
+
+        let mut action_schemas = Vec::new();
+        let mut documentation = HashMap::default();
+        let mut deprecations = HashMap::default();
+        let mut deprecation_messages = HashMap::default();
+
+        for action_data in generate_list_of_all_registered_actions() {
+            let schema = (action_data.json_schema)(&mut generator);
+            action_schemas.push((action_data.name, schema));
+
+            if let Some(doc) = action_data.documentation {
+                documentation.insert(action_data.name, doc);
+            }
+            if let Some(msg) = action_data.deprecation_message {
+                deprecation_messages.insert(action_data.name, msg);
+            }
+            for &alias in action_data.deprecated_aliases {
+                deprecations.insert(alias, action_data.name);
+                // Also add the alias as an action
+                let alias_schema = (action_data.json_schema)(&mut generator);
+                action_schemas.push((alias, alias_schema));
+            }
+        }
+
+        KeymapFile::generate_json_schema(
+            generator,
+            action_schemas,
+            &documentation,
+            &deprecations,
+            &deprecation_messages,
+        )
+    }
+
+    /// Get the JSON schema for a single action by name, without requiring App context.
+    /// Returns None if the action doesn't exist or has no schema.
+    pub fn get_action_schema_by_name(action_name: &str) -> Option<schemars::Schema> {
+        let mut generator = Self::action_schema_generator();
+
+        for action_data in generate_list_of_all_registered_actions() {
+            if action_data.name == action_name {
+                return (action_data.json_schema)(&mut generator);
+            }
+            // Also check deprecated aliases
+            for &alias in action_data.deprecated_aliases {
+                if alias == action_name {
+                    return (action_data.json_schema)(&mut generator);
+                }
+            }
+        }
+        None
     }
 
     fn generate_json_schema(

--- a/crates/settings/src/keymap_file.rs
+++ b/crates/settings/src/keymap_file.rs
@@ -479,8 +479,6 @@ impl KeymapFile {
         )
     }
 
-    /// Generate JSON schema for all registered actions without requiring App context.
-    /// This works because actions are registered at compile/link time via inventory.
     pub fn generate_json_schema_from_inventory() -> Value {
         let mut generator = Self::action_schema_generator();
 
@@ -501,7 +499,7 @@ impl KeymapFile {
             }
             for &alias in action_data.deprecated_aliases {
                 deprecations.insert(alias, action_data.name);
-                // Also add the alias as an action
+
                 let alias_schema = (action_data.json_schema)(&mut generator);
                 action_schemas.push((alias, alias_schema));
             }
@@ -516,8 +514,6 @@ impl KeymapFile {
         )
     }
 
-    /// Get the JSON schema for a single action by name, without requiring App context.
-    /// Returns None if the action doesn't exist or has no schema.
     pub fn get_action_schema_by_name(action_name: &str) -> Option<schemars::Schema> {
         let mut generator = Self::action_schema_generator();
 
@@ -525,7 +521,6 @@ impl KeymapFile {
             if action_data.name == action_name {
                 return (action_data.json_schema)(&mut generator);
             }
-            // Also check deprecated aliases
             for &alias in action_data.deprecated_aliases {
                 if alias == action_name {
                     return (action_data.json_schema)(&mut generator);

--- a/crates/settings/src/keymap_file.rs
+++ b/crates/settings/src/keymap_file.rs
@@ -514,16 +514,17 @@ impl KeymapFile {
         )
     }
 
-    pub fn get_action_schema_by_name(action_name: &str) -> Option<schemars::Schema> {
-        let mut generator = Self::action_schema_generator();
-
+    pub fn get_action_schema_by_name(
+        action_name: &str,
+        generator: &mut schemars::SchemaGenerator,
+    ) -> Option<schemars::Schema> {
         for action_data in generate_list_of_all_registered_actions() {
             if action_data.name == action_name {
-                return (action_data.json_schema)(&mut generator);
+                return (action_data.json_schema)(generator);
             }
             for &alias in action_data.deprecated_aliases {
                 if alias == action_name {
-                    return (action_data.json_schema)(&mut generator);
+                    return (action_data.json_schema)(generator);
                 }
             }
         }

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -931,16 +931,15 @@ fn handle_open_request(request: OpenRequest, app_state: Arc<AppState>, cx: &mut 
                                     .project()
                                     .update(cx, |project, _| project.lsp_store())
                             })?;
+                            let uri = format!("zed://schemas/{}", schema_path);
                             let json_schema_content =
-                                json_schema_store::resolve_schema_request_inner(
-                                    &app_state.languages,
-                                    lsp_store,
-                                    &schema_path,
-                                    cx,
-                                )
-                                .await?;
+                                json_schema_store::handle_schema_request(lsp_store, uri, cx)
+                                    .await?;
+                            let json_schema_value: serde_json::Value =
+                                serde_json::from_str(&json_schema_content)
+                                    .context("Failed to parse JSON Schema")?;
                             let json_schema_content =
-                                serde_json::to_string_pretty(&json_schema_content)
+                                serde_json::to_string_pretty(&json_schema_value)
                                     .context("Failed to serialize JSON Schema as JSON")?;
                             let buffer_task = workspace.update(cx, |workspace, cx| {
                                 workspace


### PR DESCRIPTION
Static schemas (tasks, snippets, jsonc, keymap, action/*, tsconfig, package_json, inspector_style) are now computed once on first access using LazyLock and returned immediately via Task::ready().

These schemas never change at runtime because:
- tasks, snippets, jsonc, inspector_style are derived from static Rust types
- tsconfig, package_json are bundled JSON files (include_str!)
- keymap and action/* depend only on registered actions, which are collected at compile/link time via the inventory crate (extensions cannot add actions)

This eliminates foreground thread blocking for these schema requests.

**New functions added to KeymapFile:**
- `generate_json_schema_from_inventory()`: generates keymap schema without App context
- `get_action_schema_by_name()`: looks up single action schema without App context

Release Notes:

- N/A