### PR TITLE
Fix project search with empty arguments

### DIFF
--- a/crates/project/src/project_search.rs
+++ b/crates/project/src/project_search.rs
@@ -840,7 +840,11 @@ impl PathInclusionMatcher {
                 query
                     .files_to_include()
                     .sources()
-                    .flat_map(|glob| Some(wax::Glob::new(glob).ok()?.partition().0)),
+                    .filter_map(|glob| {
+                        let prefix = wax::Glob::new(glob).ok()?.partition().0;
+                        // Skip patterns with empty prefixes (e.g., **/*.rs) to avoid panics in wax
+                        (!prefix.as_os_str().is_empty()).then_some(prefix)
+                    }),
             );
         }
         Self { included, query }


### PR DESCRIPTION
Closes [ISSUE
](https://github.com/zed-industries/zed/issues/46790)

<img width="1529" height="906" alt="image" src="https://github.com/user-attachments/assets/e818a5cd-c32b-482b-8ec1-f3ae7cc6cc29" />


**Release Notes:**

Safely extract prefix, catching any panics from wax::partition