### PR TITLE
markdown_preview: Fix wide tables not being fully visible

### DIFF
--- a/crates/markdown_preview/src/markdown_renderer.rs
+++ b/crates/markdown_preview/src/markdown_renderer.rs
@@ -561,14 +561,16 @@ fn render_markdown_table(parsed: &ParsedMarkdownTable, cx: &mut RenderContext) -
         .when_some(parsed.caption.as_ref(), |this, caption| {
             this.children(render_markdown_text(caption, cx))
         })
+        .border_1()
+        .border_color(cx.border_color)
+        .rounded_sm()
+        .overflow_hidden()
         .child(
             div()
+                .min_w_0()
+                .w_full()
                 .grid()
                 .grid_cols(max_column_count as u16)
-                .border(px(1.5))
-                .border_color(cx.border_color)
-                .rounded_sm()
-                .overflow_hidden()
                 .children(cells),
         )
         .into_any()

--- a/crates/markdown_preview/src/markdown_renderer.rs
+++ b/crates/markdown_preview/src/markdown_renderer.rs
@@ -9,7 +9,7 @@ use gpui::{
     AbsoluteLength, AnyElement, App, AppContext as _, Context, Div, Element, ElementId, Entity,
     HighlightStyle, Hsla, ImageSource, InteractiveText, IntoElement, Keystroke, Modifiers,
     ParentElement, Render, Resource, SharedString, Styled, StyledText, TextStyle, WeakEntity,
-    Window, div, img, px, rems,
+    Window, div, img, rems,
 };
 use settings::Settings;
 use std::{


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/44630

Content in markdown preview tables now wraps so you can see it all when it's a table with very long content:

<img width="600" height="692" alt="Screenshot 2026-01-14 at 6  23@2x" src="https://github.com/user-attachments/assets/ece39852-2e39-406e-a3f0-8ca399ee0be6" />

Release Notes:

- Fixed a bug with very wide tables not being fully visible in markdown previews.
