### PR TITLE
agent_ui: Refine the subagent UI design

### DIFF
--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -3556,6 +3556,17 @@ impl AcpThreadView {
             SharedString::from(format!("subagent-header-{}-{}", entry_ix, context_ix));
         let diff_stat_id = SharedString::from(format!("subagent-diff-{}-{}", entry_ix, context_ix));
 
+        let icon = h_flex().w_4().justify_center().child(if is_running {
+            SpinnerLabel::new()
+                .size(LabelSize::Small)
+                .into_any_element()
+        } else {
+            Icon::new(IconName::Check)
+                .size(IconSize::Small)
+                .color(Color::Success)
+                .into_any_element()
+        });
+
         v_flex()
             .w_full()
             .rounded_md()
@@ -3574,16 +3585,7 @@ impl AcpThreadView {
                     .child(
                         h_flex()
                             .gap_1p5()
-                            .child(if is_running {
-                                SpinnerLabel::new()
-                                    .size(LabelSize::Small)
-                                    .into_any_element()
-                            } else {
-                                Icon::new(IconName::Check)
-                                    .size(IconSize::Small)
-                                    .color(Color::Success)
-                                    .into_any_element()
-                            })
+                            .child(icon)
                             .child(
                                 Label::new(title.to_string())
                                     .size(LabelSize::Small)

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -3677,24 +3677,23 @@ impl AcpThreadView {
         scroll_handle.scroll_to_bottom();
 
         div()
+            .id(format!("subagent-content-{}", session_id))
             .w_full()
             .max_h_56()
+            .p_2()
             .border_t_1()
             .border_color(self.tool_card_border_color(cx))
-            .bg(cx.theme().colors().panel_background)
-            .child(
-                div()
-                    .id(format!("subagent-content-{}", session_id))
-                    .size_full()
-                    .p_2()
-                    .track_scroll(&scroll_handle)
-                    .when_some(last_assistant_markdown, |this, markdown| {
-                        this.child(self.render_markdown(
-                            markdown,
-                            default_markdown_style(false, false, window, cx),
-                        ))
-                    }),
-            )
+            .bg(cx.theme().colors().editor_background.opacity(0.2))
+            .overflow_hidden()
+            .track_scroll(&scroll_handle)
+            .when_some(last_assistant_markdown, |this, markdown| {
+                this.child(
+                    self.render_markdown(
+                        markdown,
+                        default_markdown_style(false, false, window, cx),
+                    ),
+                )
+            })
     }
 
     fn render_markdown_output(


### PR DESCRIPTION
This PR refines the design for the subagent card UI. Here's a quick preview:

<img width="500" height="544" alt="Screenshot 2026-01-14 at 6  43@2x" src="https://github.com/user-attachments/assets/a293b9ec-37cd-4098-b8ea-b321a239dea3" />

Release Notes:

- N/A
