### PR TITLE
Add "Agent Panel Error Shown" telemetry with ACP error details

### DIFF
--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -1883,24 +1883,6 @@ impl AcpThreadView {
                     "You reached your free usage limit. Upgrade to Zed Pro for more prompts."
                         .into(),
                 ),
-                ThreadError::ModelRequestLimitReached(plan) => {
-                    let message = match plan {
-                        cloud_llm_client::Plan::V1(PlanV1::ZedPro) => {
-                            "Upgrade to usage-based billing for more prompts."
-                        }
-                        cloud_llm_client::Plan::V1(PlanV1::ZedProTrial)
-                        | cloud_llm_client::Plan::V1(PlanV1::ZedFree) => {
-                            "Upgrade to Zed Pro for more prompts."
-                        }
-                        cloud_llm_client::Plan::V2(_) => "Model prompt limit reached.",
-                    };
-                    ("model_request_limit_reached", None, message.into())
-                }
-                ThreadError::ToolUseLimitReached => (
-                    "tool_use_limit_reached",
-                    None,
-                    "Consecutive tool use limit reached.".into(),
-                ),
                 ThreadError::Refusal => {
                     let model_or_agent_name = self.current_model_name(cx);
                     let message = format!(

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -1935,7 +1935,7 @@ impl AcpThreadView {
             session_id = session_id,
             kind = error_kind,
             acp_error_code = acp_error_code,
-            message = Some(message),
+            message = message,
         );
     }
 


### PR DESCRIPTION
Adds a new "Agent Panel Error Shown" telemetry event that fires when users see errors in the agent panel. For errors from external ACP agents (like Claude Code), we capture additional details.

Previously, we had no visibility into what errors users were encountering in the agent panel. This made it difficult to diagnose issues, especially with external agents.

The new telemetry event includes:
- `agent` — The agent telemetry ID
- `session_id` — The session ID
- `kind` — Error category (payment_required, authentication_required, refusal, other, etc.)
- `acp_error_code` — The ACP error code when available (e.g., "InternalError")
- `acp_error_message` — The ACP error message when available

Release Notes:

- N/A