### PR TITLE
workspace: Improve external file open to respect project boundaries

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -8097,6 +8097,7 @@ pub fn open_paths(
             });
 
             if open_options.open_new_workspace.is_none()
+                && (best_match.is_some() || open_options.prefer_focused_window)
                 && (existing.is_none() || open_options.prefer_focused_window)
                 && all_metadatas.iter().all(|file| !file.is_dir)
             {


### PR DESCRIPTION
Files opened from external sources (Finder, CLI, etc.) now open in a new window unless the file's path is inside an already-open project's worktree, or --wait flag is used.

Previously, Zed would handle directories correctly but would fall back to opening files in any available workspace window even if the file wasn't part of that project.

Added `test_external_file_opens_in_new_window` to verify files not belonging to any open project open in a new window. 

Closes #44355 

Release Notes:

- Improved external file opening to respect project boundaries, opening in a new window unless they belong to an already-open project
