### PR TITLE
Add injection-aware LSP support for embedded languages

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1127,6 +1127,10 @@
   "show_call_status_icon": true,
   // Whether to use language servers to provide code intelligence.
   "enable_language_server": true,
+  // Whether to enable language servers for injection regions (embedded languages).
+  // When enabled, language servers will be started for embedded language content,
+  // such as HTML templates inside Angular components or CSS in style blocks.
+  "enable_injection_language_servers": false,
   // Whether to perform linked edits of associated ranges, if the language server supports it.
   // For example, when editing opening <html> tag, the contents of the closing </html> tag will be edited as well.
   "linked_edits": true,

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -922,6 +922,11 @@ pub struct LanguageConfig {
     #[serde(default, deserialize_with = "deserialize_regex")]
     #[schemars(schema_with = "regex_json_schema")]
     pub import_path_strip_regex: Option<Regex>,
+    /// Languages that should also have their LSPs triggered when this language is detected
+    /// as an injection. For example, Angular can delegate to HTML so that HTML LSPs (emmet,
+    /// html-language-server, tailwind) also activate for Angular templates.
+    #[serde(default)]
+    pub delegate_languages: Vec<LanguageName>,
 }
 
 #[derive(Clone, Debug, Deserialize, Default, JsonSchema)]
@@ -1141,6 +1146,7 @@ impl Default for LanguageConfig {
             debuggers: Default::default(),
             ignored_import_segments: Default::default(),
             import_path_strip_regex: None,
+            delegate_languages: Default::default(),
         }
     }
 }
@@ -2034,6 +2040,12 @@ impl Language {
     }
     pub fn manifest(&self) -> Option<&ManifestName> {
         self.manifest_name.as_ref()
+    }
+
+    /// Returns languages that should also have their LSPs triggered when this language
+    /// is detected as an injection.
+    pub fn delegate_languages(&self) -> &[LanguageName] {
+        &self.config.delegate_languages
     }
 
     pub fn code_fence_block_name(&self) -> Arc<str> {

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -99,6 +99,8 @@ pub struct LanguageSettings {
     pub jsx_tag_auto_close: bool,
     /// Whether to use language servers to provide code intelligence.
     pub enable_language_server: bool,
+    /// Whether to enable language servers for injection regions (embedded languages).
+    pub enable_injection_language_servers: bool,
     /// The list of language servers to use (or disable) for this language.
     ///
     /// This array should consist of language server IDs, as well as the following
@@ -564,6 +566,9 @@ impl settings::Settings for AllLanguageSettings {
                 },
                 jsx_tag_auto_close: settings.jsx_tag_auto_close.unwrap().enabled.unwrap(),
                 enable_language_server: settings.enable_language_server.unwrap(),
+                enable_injection_language_servers: settings
+                    .enable_injection_language_servers
+                    .unwrap_or(false),
                 language_servers: settings.language_servers.unwrap(),
                 allow_rewrap: settings.allow_rewrap.unwrap(),
                 show_edit_predictions: settings.show_edit_predictions.unwrap(),

--- a/crates/languages/src/typescript/injections.scm
+++ b/crates/languages/src/typescript/injections.scm
@@ -98,8 +98,7 @@
     (pair
       key: (property_identifier) @_prop (#eq? @_prop "template")
       value: [
-        (string) @injection.content
-        (template_string) @injection.content
+        (string (string_fragment) @injection.content)
         (template_string (string_fragment) @injection.content)
       ]
     )))
@@ -115,12 +114,10 @@
     (pair
       key: (property_identifier) @_prop (#eq? @_prop "styles")
       value: [
-        (string) @injection.content
-        (template_string) @injection.content
+        (string (string_fragment) @injection.content)
         (template_string (string_fragment) @injection.content)
-        (array (string) @injection.content)
-        (array (template_string) @injection.content)
-        (array (template_string (string_fragment)) @injection.content)
+        (array (string (string_fragment) @injection.content))
+        (array (template_string (string_fragment) @injection.content))
       ]
     )))
   (#set! injection.language "css"))

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -3889,12 +3889,9 @@ impl Project {
         cx: &mut Context<Self>,
     ) -> Task<Result<Vec<DocumentHighlight>>> {
         let position = position.to_point_utf16(buffer.read(cx));
-        self.request_lsp(
-            buffer.clone(),
-            LanguageServerToQuery::FirstCapable,
-            GetDocumentHighlights { position },
-            cx,
-        )
+        self.lsp_store.update(cx, |lsp_store, cx| {
+            lsp_store.document_highlights(buffer, position, cx)
+        })
     }
 
     pub fn document_symbols(

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -430,6 +430,7 @@ impl VsCodeSettings {
             debuggers: None,
             edit_predictions_disabled_in: None,
             enable_language_server: None,
+            enable_injection_language_servers: None,
             ensure_final_newline_on_save: self.read_bool("files.insertFinalNewline"),
             extend_comment_on_newline: None,
             extend_list_on_newline: None,

--- a/crates/settings_content/src/language.rs
+++ b/crates/settings_content/src/language.rs
@@ -351,6 +351,15 @@ pub struct LanguageSettingsContent {
     ///
     /// Default: true
     pub enable_language_server: Option<bool>,
+    /// Whether to enable language servers for injection regions (embedded languages).
+    ///
+    /// When enabled, language servers will be started for embedded language content,
+    /// such as HTML templates inside Angular components or CSS in style blocks.
+    /// This provides completions, hover info, and other LSP features for the
+    /// embedded language content.
+    ///
+    /// Default: false
+    pub enable_injection_language_servers: Option<bool>,
     /// The list of language servers to use (or disable) for this language.
     ///
     /// This array should consist of language server IDs, as well as the following


### PR DESCRIPTION
This adds support for language servers to work with embedded/injected languages like HTML templates inside Angular components. Key changes:

- Add `enable_injection_language_servers` setting (default: false)
- Add `delegate_languages` trait method for language LSP delegation
- Create virtual URIs for injection regions (e.g., file.ts.__virtual__.html_0.html)
- Implement position mapping between parent and injection coordinates
- Support injection-aware completions, hover, document highlights, and colors
- Register buffers with injection servers using extracted content
- Handle didOpen/didChange/didClose for virtual documents

The feature is gated behind a settings flag and when disabled, behavior is identical to before these changes.

Closes #ISSUE

https://github.com/user-attachments/assets/bd1e4823-6bea-45ea-a430-7c8654cf24fd

Angular:


https://github.com/user-attachments/assets/acef2530-565e-48bc-b474-a52654b9e685



Release Notes:

- N/A *or* Added/Fixed/Improved ...
