### PR TITLE
workspace: Fix tab reordering regression

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -2765,7 +2765,7 @@ impl Pane {
             .on_drop(
                 cx.listener(move |this, dragged_tab: &DraggedTab, window, cx| {
                     this.drag_split_direction = None;
-                    this.handle_tab_drop(dragged_tab, this.items.len(), window, cx)
+                    this.handle_tab_drop(dragged_tab, ix, window, cx)
                 }),
             )
             .on_drop(


### PR DESCRIPTION
Closes [#46864](https://github.com/zed-industries/zed/issues/46864)
Initial PR: https://github.com/zed-industries/zed/pull/46573

## Summary

  Fix a regression where dragging a tab onto another tab would place it at the end of the tab bar instead of at the target position.

  The issue was in the `on_drop` handler: it used `this.items.len()` (evaluated at drop time) instead of the captured `ix` index (the position of the tab being dropped onto).

Release Notes:

- Fixed tab reordering not working correctly when dragging tabs

## Video after fix:

- when 'show_pinned_tabs_in_separate_row' is false:

https://github.com/user-attachments/assets/1ede0ce5-1161-4209-83f4-33a07572782a

- when 'show_pinned_tabs_in_separate_row' is true:

https://github.com/user-attachments/assets/d56c0e59-8372-41d4-973b-32a4895ca729
