### PR TITLE
agent_ui: Show MCP startup errors with expandable server output in settings

### DIFF
--- a/crates/agent_ui/src/agent_configuration/configure_context_server_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/configure_context_server_modal.rs
@@ -893,11 +893,11 @@ fn wait_for_context_server(
                         let _ = tx.send(Err("Context server stopped running".into()));
                     }
                 }
-                ContextServerStatus::Error(error) => {
+                ContextServerStatus::Error(error_details) => {
                     if server_id == &context_server_id
                         && let Some(tx) = tx.lock().unwrap().take()
                     {
-                        let _ = tx.send(Err(error.clone()));
+                        let _ = tx.send(Err(error_details.message.clone()));
                     }
                 }
                 _ => {}


### PR DESCRIPTION
Implements the feature request to surface MCP server startup failures in the Agent/LLM settings UI.

- Shows the full startup error message (including method + timeout duration for timeouts)
- Captures and displays recent MCP server stdout/stderr when startup fails
- Adds an expandable chevron toggle (collapsed by default) to keep the UI clean
- Output panes have scrollable, selectable text with copy button

Reference: https://github.com/zed-industries/zed/discussions/46812

<img width="1853" height="1537" alt="image" src="https://github.com/user-attachments/assets/955019b8-6bde-4703-97fc-2cbf4091fdfa" />

Release Notes:

- Improved: Agent settings now show detailed error messages when MCP servers fail to start, including expandable server output logs for easier debugging.
