### PR TITLE
workspace: Do not attempt to unnecessarily update jump list on worktree updates

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1303,12 +1303,15 @@ impl Workspace {
                     this.collaborator_left(*peer_id, window, cx);
                 }
 
-                project::Event::WorktreeRemoved(_) => {
-                    this.update_worktree_data(window, cx);
+                project::Event::WorktreeRemoved(_) | project::Event::WorktreeAdded(..) => {
+                    this.update_window_title(window, cx);
+                    this.serialize_workspace(window, cx);
+                    this.update_history(cx);
                 }
 
-                project::Event::WorktreeUpdatedEntries(..) | project::Event::WorktreeAdded(..) => {
-                    this.update_worktree_data(window, cx);
+                project::Event::WorktreeUpdatedEntries(..) => {
+                    this.update_window_title(window, cx);
+                    this.serialize_workspace(window, cx);
                 }
 
                 project::Event::DisconnectedFromHost => {
@@ -6715,13 +6718,6 @@ impl Workspace {
                 });
             }
         }
-    }
-
-    fn update_worktree_data(&mut self, window: &mut Window, cx: &mut Context<'_, Self>) {
-        self.update_window_title(window, cx);
-        self.serialize_workspace(window, cx);
-        // This event could be triggered by `AddFolderToProject` or `RemoveFromProject`.
-        self.update_history(cx);
     }
 }
 


### PR DESCRIPTION
It should be a no-op but causes massive main thread hangs on windows due to the winapi calls this emits, restores the behavior pre github.com/zed-industries/zed/pull/46256 without reverting the main changes of that.

Release Notes:

- N/A *or* Added/Fixed/Improved ...
