### PR TITLE
Fix delay in Copilot completion

### DIFF
--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -1021,7 +1021,7 @@ impl Copilot {
                     }
                     inline = inline_request => {
                         let completions = inline.into_response().ok().map(convert_inline).unwrap_or_default();
-                        if !completions.is_empty() && nes_result.is_some() {
+                        if !completions.is_empty() {
                             return Ok(completions);
                         }
                         inline_result = Some(completions);


### PR DESCRIPTION
This PR fixes an issue when copilot takes 3s to complete. Right now, in copilot edit prediction, we issue requests to both the Next Edit Suggestion (NES) and the regular copilot inline completion endpoints. Whichever come back first will be shown. However, there is a bug where even if inline completion (which is usually much faster) comes back, we still wait for NES (which takes about 3s).

This should address https://github.com/zed-industries/zed/issues/46389 and https://github.com/zed-industries/zed/issues/46880

Release notes:
- Improved responsiveness of Copilot inline completions.