### PR TITLE
Revert "collab: Bump minimum required version to collaborate from 0.204.1 to 0.220.0 to accomodate for project search RPC changes"

### DIFF
--- a/crates/collab/src/rpc/connection_pool.rs
+++ b/crates/collab/src/rpc/connection_pool.rs
@@ -30,8 +30,19 @@ impl fmt::Display for ZedVersion {
 
 impl ZedVersion {
     pub fn can_collaborate(&self) -> bool {
-        // v0.220.0 was the version in which we've updated the project search protocol.
-        self.0 >= Version::new(0, 220, 0)
+        // v0.204.1 was the first version after the auto-update bug.
+        // We reject any clients older than that to hope we can persuade them to upgrade.
+        if self.0 < Version::new(0, 204, 1) {
+            return false;
+        }
+
+        // Since we hotfixed the changes to no longer connect to Collab automatically to Preview, we also need to reject
+        // versions in the range [v0.199.0, v0.199.1].
+        if self.0 >= Version::new(0, 199, 0) && self.0 < Version::new(0, 199, 2) {
+            return false;
+        }
+
+        true
     }
 }
 


### PR DESCRIPTION
Reverts zed-industries/zed#46715
Closes #46889