### PR TITLE
languages: Support terminal auto-activation for `poetry` managed Python environment

### DIFF
--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -1362,7 +1362,8 @@ impl ToolchainLister for PythonToolchainProvider {
                 PythonEnvironmentKind::Venv
                 | PythonEnvironmentKind::VirtualEnv
                 | PythonEnvironmentKind::Uv
-                | PythonEnvironmentKind::UvWorkspace,
+                | PythonEnvironmentKind::UvWorkspace
+                | PythonEnvironmentKind::Poetry,
             ) => {
                 if let Some(activation_scripts) = &toolchain.activation_scripts {
                     if let Some(activate_script_path) = activation_scripts.get(&shell) {
@@ -1424,7 +1425,8 @@ async fn venv_to_toolchain(venv: PythonEnvironment, fs: &dyn Fs) -> Option<Toolc
             PythonEnvironmentKind::Venv
             | PythonEnvironmentKind::VirtualEnv
             | PythonEnvironmentKind::Uv
-            | PythonEnvironmentKind::UvWorkspace,
+            | PythonEnvironmentKind::UvWorkspace
+            | PythonEnvironmentKind::Poetry,
         ) => resolve_venv_activation_scripts(&venv, fs, &mut activation_scripts).await,
         _ => {}
     }


### PR DESCRIPTION
Although `poetry` may store virtual environments in a global cache directory (unlike the standard project-local `.venv`), the internal directory structure of these environments remains consistent with standard `venv` or `uv` environments.

Since our existing activation logic for `venv` environments relies on relative paths within the environment root, it is naturally compatible with `poetry` environments. Once the toolchain locates the environment's root directory, the activation scripts can be applied without further modification.

Testing:
- Verified on Windows: Confirmed working across `PowerShell`, `Pwsh`, and `Cmd` for global poetry environments.
- Observation: When using an in-project `.venv` directory, the toolchain may categorize the environment as `venv`-managed instead of `poetry`-managed. While this behavior relates to the toolchain's discovery logic, the activation itself remains fully functional as the underlying structure is compatible.

Release Notes:

- N/A *or* Added/Fixed/Improved ...
