### PR TITLE
agent_ui: Improve icon for discarding interrupted edit

### DIFF
--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -3268,7 +3268,7 @@ impl AcpThreadView {
                                                 this.child(
                                                     IconButton::new(
                                                         ("discard-partial-edit", entry_ix),
-                                                        IconName::Trash,
+                                                        IconName::Undo,
                                                     )
                                                     .icon_size(IconSize::Small)
                                                     .tooltip(move |_, cx| Tooltip::with_meta(


### PR DESCRIPTION
Just swapping it from the `Trash` icon for the `Undo` one given it's clearer.

Release Notes:

- N/A
