### PR TITLE
Revert "gpui: Add dynamic padding to prevent glyph clipping in text rendering on macOS (#45957)"

### DIFF
--- a/crates/gpui/src/platform/mac/text_system.rs
+++ b/crates/gpui/src/platform/mac/text_system.rs
@@ -356,22 +356,16 @@ impl MacTextSystemState {
 
     fn raster_bounds(&self, params: &RenderGlyphParams) -> Result<Bounds<DevicePixels>> {
         let font = &self.fonts[params.font_id.0];
-        let mut bounds: Bounds<DevicePixels> = font
+        let scale = Transform2F::from_scale(params.scale_factor);
+        Ok(font
             .raster_bounds(
                 params.glyph_id.0,
                 params.font_size.into(),
-                Transform2F::from_scale(params.scale_factor),
+                scale,
                 HintingOptions::None,
                 font_kit::canvas::RasterizationOptions::GrayscaleAa,
             )?
-            .into();
-
-        // Adjust the x position to account for the scale factor to avoid glyph clipped.
-        let x_offset = DevicePixels(bounds.origin.x.0 / params.scale_factor as i32);
-        bounds.origin.x -= x_offset;
-        bounds.size.width += x_offset;
-
-        Ok(bounds)
+            .into())
     }
 
     fn rasterize_glyph(


### PR DESCRIPTION
This reverts commit 83ca31055cf3e56aa8a704ac49e1686434f4e640.

This change produces bad clipping on macOS:

<img width="59" height="80" alt="Screenshot 2026-01-15 at 8 51 28 AM" src="https://github.com/user-attachments/assets/e1e295a4-f25c-4144-aa85-ec2fbbba03a8" />

<img width="218" height="67" alt="Screenshot 2026-01-15 at 8 51 35 AM" src="https://github.com/user-attachments/assets/e662f8df-b009-445e-afee-3440b7fc52f0" />

<img width="303" height="43" alt="Screenshot 2026-01-15 at 8 51 41 AM" src="https://github.com/user-attachments/assets/c972a1be-a07b-4b5f-970b-f75a51dac6b8" />

https://zed-industries.slack.com/archives/C04S5TU0RSN/p1768473926260279

Release Notes:

- Reverted #45957
