### PR TITLE
Fix open path prompt not showing hidden files

### DIFF
--- a/crates/open_path_prompt/src/open_path_prompt.rs
+++ b/crates/open_path_prompt/src/open_path_prompt.rs
@@ -912,15 +912,15 @@ fn get_dir_and_suffix(query: String, path_style: PathStyle) -> (String, String) 
         PathStyle::Windows => {
             let last_sep = query.rfind('\\').into_iter().chain(query.rfind('/')).max();
             let (mut dir, suffix) = if let Some(index) = last_sep {
-                (query[..index].to_string(), query[index + 1..].to_string())
+                (
+                    query[..index + 1].to_string(),
+                    query[index + 1..].to_string(),
+                )
             } else {
                 (query, String::new())
             };
             if dir.len() < 3 {
                 dir = "C:\\".to_string();
-            }
-            if !dir.ends_with('\\') && !dir.ends_with('/') {
-                dir.push('\\');
             }
             (dir, suffix)
         }
@@ -976,6 +976,22 @@ mod tests {
 
         let (dir, suffix) = get_dir_and_suffix("C:\\root\\.hidden".into(), PathStyle::Windows);
         assert_eq!(dir, "C:\\root\\");
+        assert_eq!(suffix, ".hidden");
+
+        let (dir, suffix) = get_dir_and_suffix("C:/root/".into(), PathStyle::Windows);
+        assert_eq!(dir, "C:/root/");
+        assert_eq!(suffix, "");
+
+        let (dir, suffix) = get_dir_and_suffix("C:/root/Use".into(), PathStyle::Windows);
+        assert_eq!(dir, "C:/root/");
+        assert_eq!(suffix, "Use");
+
+        let (dir, suffix) = get_dir_and_suffix("C:\\root/Use".into(), PathStyle::Windows);
+        assert_eq!(dir, "C:\\root/");
+        assert_eq!(suffix, "Use");
+
+        let (dir, suffix) = get_dir_and_suffix("C:/root\\.hidden".into(), PathStyle::Windows);
+        assert_eq!(dir, "C:/root\\");
         assert_eq!(suffix, ".hidden");
     }
 

--- a/crates/open_path_prompt/src/open_path_prompt.rs
+++ b/crates/open_path_prompt/src/open_path_prompt.rs
@@ -403,14 +403,15 @@ impl PickerDelegate for OpenPathDelegate {
                 return;
             };
 
+            if !hidden_entries {
+                new_entries.retain(|entry| !entry.path.string.starts_with('.'));
+            }
+
             let max_id = new_entries
                 .iter()
                 .map(|entry| entry.path.id)
                 .max()
                 .unwrap_or(0);
-            if !suffix.starts_with('.') && !hidden_entries {
-                new_entries.retain(|entry| !entry.path.string.starts_with('.'));
-            }
 
             if suffix.is_empty() {
                 let should_prepend_with_current_dir = this
@@ -489,6 +490,8 @@ impl PickerDelegate for OpenPathDelegate {
                 .filter_map(|entry| {
                     if is_create_state && !entry.is_dir && Some(&suffix) == Some(&entry.path.string)
                     {
+                        None
+                    } else if !suffix.is_empty() && entry.path.string == current_dir {
                         None
                     } else {
                         Some(&entry.path)

--- a/crates/open_path_prompt/src/open_path_prompt.rs
+++ b/crates/open_path_prompt/src/open_path_prompt.rs
@@ -41,6 +41,7 @@ pub struct OpenPathDelegate {
     replace_prompt: Task<()>,
     render_footer:
         Arc<dyn Fn(&mut Window, &mut Context<Picker<Self>>) -> Option<AnyElement> + 'static>,
+    hidden_entries: bool,
 }
 
 impl OpenPathDelegate {
@@ -68,6 +69,7 @@ impl OpenPathDelegate {
             path_style,
             replace_prompt: Task::ready(()),
             render_footer: Arc::new(|_, _| None),
+            hidden_entries: false,
         }
     }
 
@@ -81,6 +83,10 @@ impl OpenPathDelegate {
         self
     }
 
+    pub fn show_hidden(mut self) -> Self {
+        self.hidden_entries = true;
+        self
+    }
     fn get_entry(&self, selected_match_index: usize) -> Option<CandidateInfo> {
         match &self.directory_state {
             DirectoryState::List { entries, .. } => {
@@ -219,7 +225,8 @@ impl OpenPathPrompt {
         cx: &mut Context<Workspace>,
     ) {
         workspace.toggle_modal(window, cx, |window, cx| {
-            let delegate = OpenPathDelegate::new(tx, lister.clone(), creating_path, cx);
+            let delegate =
+                OpenPathDelegate::new(tx, lister.clone(), creating_path, cx).show_hidden();
             let picker = Picker::uniform_list(delegate, window, cx).width(rems(34.));
             let mut query = lister.default_query(cx);
             if let Some(suggested_name) = suggested_name {
@@ -300,10 +307,10 @@ impl PickerDelegate for OpenPathDelegate {
             }
             DirectoryState::None { .. } => Some(lister.list_directory(dir.clone(), cx)),
         };
-
         self.cancel_flag.store(true, atomic::Ordering::Release);
         self.cancel_flag = Arc::new(AtomicBool::new(false));
         let cancel_flag = self.cancel_flag.clone();
+        let hidden_entries = self.hidden_entries;
         let parent_path_is_root = self.prompt_root == dir;
         let current_dir = self.current_dir();
         cx.spawn_in(window, async move |this, cx| {
@@ -399,13 +406,11 @@ impl PickerDelegate for OpenPathDelegate {
             let max_id = new_entries
                 .iter()
                 .map(|entry| entry.path.id)
-                //     .max()
-                //     .unwrap_or(0);
-                // if !suffix.starts_with('.') && !hidden_entries {
-                //     new_entries.retain(|entry| !entry.path.string.starts_with('.'));
-                // }
-                .reduce(|acc, id| acc.max(id))
+                .max()
                 .unwrap_or(0);
+            if !suffix.starts_with('.') && !hidden_entries {
+                new_entries.retain(|entry| !entry.path.string.starts_with('.'));
+            }
 
             if suffix.is_empty() {
                 let should_prepend_with_current_dir = this
@@ -438,24 +443,16 @@ impl PickerDelegate for OpenPathDelegate {
                 }
 
                 this.update(cx, |this, cx| {
-                    let string_matches = new_entries
+                    this.delegate.selected_index = 0;
+                    this.delegate.string_matches = new_entries
                         .iter()
-                        .filter_map(|m| {
-                            if m.path.string.starts_with('.') && m.path.string != current_dir {
-                                None
-                            } else {
-                                Some(StringMatch {
-                                    candidate_id: m.path.id,
-                                    score: 0.0,
-                                    positions: Vec::new(),
-                                    string: m.path.string.clone(),
-                                })
-                            }
+                        .map(|m| StringMatch {
+                            candidate_id: m.path.id,
+                            score: 0.0,
+                            positions: Vec::new(),
+                            string: m.path.string.clone(),
                         })
                         .collect();
-
-                    this.delegate.selected_index = 0;
-                    this.delegate.string_matches = string_matches;
                     this.delegate.directory_state =
                         match &this.delegate.directory_state {
                             DirectoryState::None { create: false }
@@ -492,10 +489,6 @@ impl PickerDelegate for OpenPathDelegate {
                 .filter_map(|entry| {
                     if is_create_state && !entry.is_dir && Some(&suffix) == Some(&entry.path.string)
                     {
-                        None
-                    } else if !suffix.is_empty() && entry.path.string == current_dir {
-                        None
-                    } else if !suffix.starts_with('.') && entry.path.string.starts_with('.') {
                         None
                     } else {
                         Some(&entry.path)

--- a/crates/open_path_prompt/src/open_path_prompt.rs
+++ b/crates/open_path_prompt/src/open_path_prompt.rs
@@ -910,11 +910,7 @@ fn get_dir_and_suffix(query: String, path_style: PathStyle) -> (String, String) 
             (dir, suffix)
         }
         PathStyle::Windows => {
-            let last_sep = query
-                .rfind('\\')
-                .into_iter()
-                .chain(query.rfind('/'))
-                .max();
+            let last_sep = query.rfind('\\').into_iter().chain(query.rfind('/')).max();
             let (mut dir, suffix) = if let Some(index) = last_sep {
                 (query[..index].to_string(), query[index + 1..].to_string())
             } else {

--- a/crates/open_path_prompt/src/open_path_prompt_tests.rs
+++ b/crates/open_path_prompt/src/open_path_prompt_tests.rs
@@ -53,7 +53,7 @@ async fn test_open_path_prompt(cx: &mut TestAppContext) {
     #[cfg(windows)]
     let expected_separator = ".\\";
 
-    // If the query ends with a slash, the picker should show the contents of the directory.
+    // If the query ends with a slash, the picker should show the contents of the directory and not show any of the hidden entries.
     let query = path!("/root/");
     insert_query(query, &picker, cx).await;
     assert_eq!(
@@ -97,15 +97,15 @@ async fn test_open_path_prompt(cx: &mut TestAppContext) {
     insert_query(query, &picker, cx).await;
     assert_eq!(collect_match_candidates(&picker, cx), vec!["dir3", "dir4"]);
 
-    // Show candidates for the query ".".
+    // Don't show candidates for the query ".".
     let query = path!("/root/.");
     insert_query(query, &picker, cx).await;
-    assert_eq!(collect_match_candidates(&picker, cx), vec![".a1", ".b1"]);
+    assert_eq!(collect_match_candidates(&picker, cx), Vec::<String>::new());
 
-    // Show candidates for the query ".a".
+    // Don't show any candidates for the query ".a".
     let query = path!("/root/.a");
     insert_query(query, &picker, cx).await;
-    assert_eq!(collect_match_candidates(&picker, cx), vec![".a1"]);
+    assert_eq!(collect_match_candidates(&picker, cx), Vec::<String>::new());
 
     // Show candidates for the query "./".
     // Should show current directory and contents.
@@ -398,11 +398,13 @@ async fn test_open_path_prompt_with_show_hidden(cx: &mut TestAppContext) {
     let expected_separator = ".\\";
 
     insert_query(path!("/root/"), &picker, cx).await;
-
     assert_eq!(
         collect_match_candidates(&picker, cx),
         vec![expected_separator, ".hidden", "directory_1", "directory_2"]
     );
+
+    insert_query(path!("/root/."), &picker, cx).await;
+    assert_eq!(collect_match_candidates(&picker, cx), vec![".hidden"]);
 }
 
 fn init_test(cx: &mut TestAppContext) -> Arc<AppState> {

--- a/crates/open_path_prompt/src/open_path_prompt_tests.rs
+++ b/crates/open_path_prompt/src/open_path_prompt_tests.rs
@@ -19,6 +19,8 @@ async fn test_open_path_prompt(cx: &mut TestAppContext) {
         .insert_tree(
             path!("/root"),
             json!({
+                ".a1": ".A1",
+                ".b1": ".B1",
                 "a1": "A1",
                 "a2": "A2",
                 "a3": "A3",
@@ -94,6 +96,33 @@ async fn test_open_path_prompt(cx: &mut TestAppContext) {
     let query = path!("/root/dir2/di");
     insert_query(query, &picker, cx).await;
     assert_eq!(collect_match_candidates(&picker, cx), vec!["dir3", "dir4"]);
+
+    // Show candidates for the query ".".
+    let query = path!("/root/.");
+    insert_query(query, &picker, cx).await;
+    assert_eq!(collect_match_candidates(&picker, cx), vec![".a1", ".b1"]);
+
+    // Show candidates for the query ".a".
+    let query = path!("/root/.a");
+    insert_query(query, &picker, cx).await;
+    assert_eq!(collect_match_candidates(&picker, cx), vec![".a1"]);
+
+    // Show candidates for the query "./".
+    // Should show current directory and contents.
+    let query = path!("/root/./");
+    insert_query(query, &picker, cx).await;
+    assert_eq!(
+        collect_match_candidates(&picker, cx),
+        vec![expected_separator, "a1", "a2", "a3", "dir1", "dir2"]
+    );
+
+    // Show candidates for the query "../". Show parent contents.
+    let query = path!("/root/dir1/../");
+    insert_query(query, &picker, cx).await;
+    assert_eq!(
+        collect_match_candidates(&picker, cx),
+        vec![expected_separator, "a1", "a2", "a3", "dir1", "dir2"]
+    );
 }
 
 #[gpui::test]

--- a/crates/toolchain_selector/src/toolchain_selector.rs
+++ b/crates/toolchain_selector/src/toolchain_selector.rs
@@ -144,6 +144,7 @@ impl AddToolchainState {
         let (tx, rx) = oneshot::channel();
         let weak = cx.weak_entity();
         let lister = OpenPathDelegate::new(tx, DirectoryLister::Project(project), false, cx)
+            .show_hidden()
             .with_footer(Arc::new(move |_, cx| {
                 let error = weak
                     .read_with(cx, |this, _| {

--- a/crates/toolchain_selector/src/toolchain_selector.rs
+++ b/crates/toolchain_selector/src/toolchain_selector.rs
@@ -144,7 +144,6 @@ impl AddToolchainState {
         let (tx, rx) = oneshot::channel();
         let weak = cx.weak_entity();
         let lister = OpenPathDelegate::new(tx, DirectoryLister::Project(project), false, cx)
-            .show_hidden()
             .with_footer(Arc::new(move |_, cx| {
                 let error = weak
                     .read_with(cx, |this, _| {


### PR DESCRIPTION
Closes #39036 

The open path prompt will now show hidden files when "." is entered. Also fixes an issue with "open this directory" showing twice when used by the "toolchain: add toolchain" prompt.

With a tree of 
```
zed-industries
├── .hidden
├── .hidden-file
├── zed
├── zed-working
├── zeta
└── zeta-dataset
```
**Before:**
<img width="656" height="174" alt="image" src="https://github.com/user-attachments/assets/abf30ce3-b1c2-4a14-a45d-c17b6c3aef6f" />

**After (current directory view without inputting "."):**
<img width="648" height="261" alt="image" src="https://github.com/user-attachments/assets/00c65546-32c1-4c85-a05c-53152ab2f942" />

**After (when inputting "." to see hidden entries):**
<img width="618" height="156" alt="image" src="https://github.com/user-attachments/assets/8453ae89-b1a7-44d4-9f7d-ed89e55a7020" />


Release Notes:
- Made Zed's built in file picker to show all hidden files by default