### PR TITLE
Don't show diff review button on folded buffers

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -3112,9 +3112,18 @@ impl EditorElement {
         let display_row = indicator.display_row;
         let row_index = (display_row.0.saturating_sub(range.start.0)) as usize;
 
-        // Don't show on rows with expand excerpt buttons
         let row_info = row_infos.get(row_index);
         if row_info.is_some_and(|row_info| row_info.expand_info.is_some()) {
+            return None;
+        }
+
+        let buffer_id = row_info.and_then(|info| info.buffer_id);
+        if buffer_id.is_none() {
+            return None;
+        }
+
+        let editor = self.editor.read(cx);
+        if buffer_id.is_some_and(|buffer_id| editor.is_buffer_folded(buffer_id, cx)) {
             return None;
         }
 


### PR DESCRIPTION
We were incorrectly leaking the display of this button when the file was folded in the multibuffer:

| Before | After |
|--------|--------|
| <img width="788" height="400" alt="Screenshot 2026-01-15 at 11  42@2x" src="https://github.com/user-attachments/assets/2ef9d154-35b5-4788-91c2-0e7a8d45594c" /> | <img width="788" height="400" alt="Screenshot 2026-01-15 at 11  41@2x" src="https://github.com/user-attachments/assets/f4d9416b-9826-4616-8e36-8876ef5e25ec" /> | 

Release Notes:

- N/A
