### PR TITLE
ui: Fix extra horizontal padding in tab bar end container

### DIFF
--- a/crates/ui/src/components/tab_bar.rs
+++ b/crates/ui/src/components/tab_bar.rs
@@ -151,11 +151,15 @@ impl RenderOnce for TabBar {
             .when(
                 !self.end_children.is_empty() || !self.pre_end_children.is_empty(),
                 |this| {
+                    let has_pre_end_children = !self.pre_end_children.is_empty();
                     this.child(
                         h_flex()
                             .flex_none()
                             .gap(DynamicSpacing::Base04.rems(cx))
-                            .px(DynamicSpacing::Base06.rems(cx))
+                            .when(has_pre_end_children, |this| {
+                                this.pl(DynamicSpacing::Base06.rems(cx))
+                            })
+                            .pr(DynamicSpacing::Base06.rems(cx))
                             .children(self.pre_end_children)
                             .border_color(cx.theme().colors().border)
                             .border_b_1()


### PR DESCRIPTION
The tab bar's end container applied horizontal padding unconditionally via `.px()`. When no `pre_end_children` are present, this creates unnecessary dead space between the scrolling tab area and the end buttons.

This change applies left padding only when `pre_end_children` exist, while always applying right padding for edge spacing.

Release Notes:

- Fixed extra padding between the tab scroll area and end buttons in the tab bar
