### PR TITLE
ui: Adjust BoxShadow offset for elevation styles

### DIFF
--- a/crates/ui/src/styles/elevation.rs
+++ b/crates/ui/src/styles/elevation.rs
@@ -55,7 +55,7 @@ impl ElevationIndex {
                 },
                 BoxShadow {
                     color: hsla(0., 0., 0., if is_light { 0.03 } else { 0.06 }),
-                    offset: point(px(1.), px(1.)),
+                    offset: point(px(0.), px(1.)),
                     blur_radius: px(0.),
                     spread_radius: px(0.),
                 },
@@ -82,7 +82,7 @@ impl ElevationIndex {
                 },
                 BoxShadow {
                     color: hsla(0., 0., 0., if is_light { 0.04 } else { 0.12 }),
-                    offset: point(px(1.), px(1.)),
+                    offset: point(px(0.), px(1.)),
                     blur_radius: px(0.),
                     spread_radius: px(0.),
                 },


### PR DESCRIPTION
Changed the offset of shadow to improve shadow appearance. There was a 1px horizontal offset on all elevated surfaces — barely perceptible, but once you see it, it's all you see 

|Before|After|
|-|-|
|<img width="586" height="884" alt="before" src="https://github.com/user-attachments/assets/63fa36a7-7845-4c6f-9e73-36ad5056194b" />|<img width="586" height="884" alt="after" src="https://github.com/user-attachments/assets/41a032d3-e7d6-4188-9394-656d5caf822e" />|

Release Notes:

- N/A
