### PR TITLE
Make always_allow_tool_actions override always_confirm and default_mode

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -954,7 +954,9 @@
       //   "temperature": 1.0
       // }
     ],
-    // When enabled, the agent can run potentially destructive actions without asking for your confirmation.
+    // When enabled, the agent can run tool actions without asking for your confirmation.
+    // This setting takes precedence over `always_confirm` patterns and `default_mode` settings,
+    // but `always_deny` patterns still block actions for security.
     //
     // Note: This setting has no effect on external agents that support permission modes, such as Claude Code.
     //       You can set `agent_servers.claude.default_mode` to `bypassPermissions` to skip all permission requests.


### PR DESCRIPTION
Previously, `always_confirm` patterns would force confirmation even when `always_allow_tool_actions` was set to true. This was counterintuitive since the global setting should provide a way to skip all confirmations.

The new precedence order is:
1. **`always_deny`** - still blocks for security
2. **`always_allow_tool_actions`** - when true, allows all non-denied actions
3. **`always_confirm`** - prompts if `always_allow_tool_actions` is false
4. **`always_allow`** - allows without prompting
5. **`default_mode`** - fallback behavior

This means setting `always_allow_tool_actions=true` will now skip confirmation prompts from `always_confirm` patterns and override `default_mode: Deny` settings, while still respecting `always_deny` patterns for security.

(No release notes because granular tool permissions are still feature-flagged.)

Release Notes:

- N/A