### PR TITLE
ep: Make `EditPredictionModel` a trait

### DIFF
--- a/crates/edit_prediction/src/edit_prediction.rs
+++ b/crates/edit_prediction/src/edit_prediction.rs
@@ -37,7 +37,7 @@ use workspace::Workspace;
 use std::ops::Range;
 use std::path::Path;
 use std::rc::Rc;
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use std::{env, mem};
 use util::{RangeExt as _, ResultExt as _};
@@ -101,9 +101,6 @@ pub struct MercuryFeatureFlag;
 impl FeatureFlag for MercuryFeatureFlag {
     const NAME: &str = "mercury";
 }
-
-pub(crate) static EDIT_PREDICTIONS_MODEL_ID: LazyLock<Option<String>> =
-    LazyLock::new(|| env::var("ZED_ZETA_MODEL").ok());
 
 pub struct Zeta2FeatureFlag;
 

--- a/crates/edit_prediction/src/edit_prediction.rs
+++ b/crates/edit_prediction/src/edit_prediction.rs
@@ -155,18 +155,6 @@ pub struct EditPredictionStore {
     custom_predict_edits_url: Option<Arc<Url>>,
 }
 
-// todo! remove this enum
-#[derive(Copy, Clone, Default, PartialEq, Eq)]
-pub enum EditPredictionModel {
-    #[default]
-    Zeta1,
-    Zeta2 {
-        version: ZetaVersion,
-    },
-    Sweep,
-    Mercury,
-}
-
 pub struct EditPredictionModelInput {
     pub project: Entity<Project>,
     pub buffer: Entity<Buffer>,

--- a/crates/edit_prediction/src/edit_prediction.rs
+++ b/crates/edit_prediction/src/edit_prediction.rs
@@ -134,7 +134,7 @@ pub struct EditPredictionStore {
     _llm_token_subscription: Subscription,
     projects: HashMap<EntityId, ProjectState>,
     use_context: bool,
-    edit_prediction_model: Option<Box<dyn EditPredictionModel2>>,
+    edit_prediction_model: Option<Box<dyn EditPredictionModel>>,
     data_collection_choice: DataCollectionChoice,
     reject_predictions_tx: mpsc::UnboundedSender<EditPredictionRejection>,
     shown_predictions: VecDeque<EditPrediction>,
@@ -220,7 +220,7 @@ pub struct StoredEvent {
     pub old_snapshot: TextBufferSnapshot,
 }
 
-pub trait EditPredictionModel2: 'static {
+pub trait EditPredictionModel: 'static {
     /// Whether the edit prediction store should collect LSP-based context.
     /// If `false` is returned, [Self::request_prediction] will get an empty `context` slice.
     fn requires_context(&self) -> bool {
@@ -675,7 +675,7 @@ impl EditPredictionStore {
         self.custom_predict_edits_url = Some(url.into());
     }
 
-    pub fn set_edit_prediction_model(&mut self, model: Box<dyn EditPredictionModel2>) {
+    pub fn set_edit_prediction_model(&mut self, model: Box<dyn EditPredictionModel>) {
         self.edit_prediction_model = Some(model);
     }
 
@@ -697,7 +697,7 @@ impl EditPredictionStore {
             .is_some_and(|model| model.is_enabled(cx))
     }
 
-    pub fn model(&self) -> Option<&dyn EditPredictionModel2> {
+    pub fn model(&self) -> Option<&dyn EditPredictionModel> {
         self.edit_prediction_model.as_deref()
     }
 

--- a/crates/edit_prediction/src/edit_prediction_tests.rs
+++ b/crates/edit_prediction/src/edit_prediction_tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::{
     compute_diff_between_snapshots, udiff::apply_diff_to_string, zeta1::MAX_EVENT_TOKENS,
-    zeta1::Zeta1Model,
+    zeta1::Zeta1Model, zeta2::Zeta2Model,
 };
 use client::{UserStore, test::FakeServer};
 use clock::{FakeSystemClock, ReplicaId};
@@ -1409,6 +1409,17 @@ fn init_test_with_fake_client(
 
         let user_store = cx.new(|cx| UserStore::new(client.clone(), cx));
         let ep_store = EditPredictionStore::global(&client, &user_store, cx);
+
+        ep_store.update(cx, |ep_store, _cx| {
+            ep_store.set_edit_prediction_model(Box::new(Zeta2Model::new(
+                client,
+                ep_store.llm_token().clone(),
+                user_store.clone(),
+                ep_store.custom_predict_edits_url(),
+                ep_store.reject_predictions_tx(),
+                zeta_prompt::ZetaVersion::default(),
+            )));
+        });
 
         (
             ep_store,

--- a/crates/edit_prediction/src/edit_prediction_tests.rs
+++ b/crates/edit_prediction/src/edit_prediction_tests.rs
@@ -17,7 +17,7 @@ use futures::{
 };
 use gpui::{
     Entity, TestAppContext,
-    http_client::{FakeHttpClient, Response},
+    http_client::{self, FakeHttpClient, Method, Response},
 };
 use indoc::indoc;
 use language::Point;

--- a/crates/edit_prediction/src/edit_prediction_tests.rs
+++ b/crates/edit_prediction/src/edit_prediction_tests.rs
@@ -2088,6 +2088,7 @@ async fn make_test_ep_store(
             EditPredictionStore::new(client.clone(), project.read(cx).user_store(), cx);
         ep_store.set_edit_prediction_model(Box::new(Zeta1Model::new(
             client,
+            project.read(cx).user_store(),
             ep_store.llm_token().clone(),
             ep_store.custom_predict_edits_url(),
             ep_store.reject_predictions_tx(),
@@ -2193,6 +2194,7 @@ async fn test_unauthenticated_without_custom_url_blocks_prediction_impl(cx: &mut
     let completion_task = ep_store.update(cx, |ep_store, cx| {
         let model = Box::new(Zeta1Model::new(
             client,
+            project.read(cx).user_store(),
             ep_store.llm_token().clone(),
             ep_store.custom_predict_edits_url(),
             ep_store.reject_predictions_tx(),
@@ -2309,6 +2311,7 @@ async fn test_unauthenticated_with_custom_url_allows_prediction_impl(cx: &mut Te
         ep_store.set_custom_predict_edits_url(Url::parse("http://test/predict").unwrap());
         let model = Box::new(Zeta1Model::new(
             client,
+            project.read(cx).user_store(),
             ep_store.llm_token().clone(),
             ep_store.custom_predict_edits_url(),
             ep_store.reject_predictions_tx(),

--- a/crates/edit_prediction/src/mercury.rs
+++ b/crates/edit_prediction/src/mercury.rs
@@ -1,5 +1,5 @@
 use crate::{
-    DebugEvent, EditPredictionFinishedDebugEvent, EditPredictionId, EditPredictionModel2,
+    DebugEvent, EditPredictionFinishedDebugEvent, EditPredictionId, EditPredictionModel,
     EditPredictionModelInput, EditPredictionStartedDebugEvent,
     open_ai_response::text_from_response, prediction::EditPredictionResult,
 };
@@ -30,7 +30,7 @@ impl MercuryModel {
     }
 }
 
-impl EditPredictionModel2 for MercuryModel {
+impl EditPredictionModel for MercuryModel {
     fn requires_context(&self) -> bool {
         true
     }

--- a/crates/edit_prediction/src/mercury.rs
+++ b/crates/edit_prediction/src/mercury.rs
@@ -1,6 +1,6 @@
 use crate::{
     DebugEvent, EditPredictionFinishedDebugEvent, EditPredictionId, EditPredictionModel2,
-    EditPredictionModelInput, EditPredictionStartedDebugEvent, UserActionRecord,
+    EditPredictionModelInput, EditPredictionStartedDebugEvent,
     open_ai_response::text_from_response, prediction::EditPredictionResult,
 };
 use anyhow::{Context as _, Result};
@@ -11,7 +11,6 @@ use gpui::{
 };
 use language::{Buffer, OffsetRangeExt as _, ToOffset, ToPoint as _};
 use language_model::{ApiKeyState, EnvVar, env_var};
-use project::Project;
 use std::{mem, ops::Range, path::Path, sync::Arc, time::Instant};
 use zeta_prompt::{RelatedFile, ZetaPromptInput};
 
@@ -60,28 +59,14 @@ impl EditPredictionModel2 for MercuryModel {
 
     fn request_prediction(
         &self,
-        _project: Entity<Project>,
-        active_buffer: Entity<Buffer>,
-        position: language::Anchor,
-        context: Arc<[RelatedFile]>,
-        events: Vec<Arc<zeta_prompt::Event>>,
-        _user_actions: Vec<UserActionRecord>,
-        _can_collect_example: bool,
+        inputs: EditPredictionModelInput,
         cx: &mut App,
     ) -> Task<Result<Option<EditPredictionResult>>> {
-        self.mercury.request_prediction_impl(
-            active_buffer,
-            position,
-            context.to_vec(),
-            events,
-            None,
-            cx,
-        )
+        self.mercury.request_prediction(inputs, cx)
     }
 }
 
 impl Mercury {
-    #[allow(dead_code)]
     pub(crate) fn request_prediction(
         &self,
         EditPredictionModelInput {

--- a/crates/edit_prediction/src/sweep_ai.rs
+++ b/crates/edit_prediction/src/sweep_ai.rs
@@ -1,8 +1,7 @@
 use crate::{
-    CurrentEditPrediction, DebugEvent, EditPrediction, EditPredictionFinishedDebugEvent,
-    EditPredictionId, EditPredictionModel2, EditPredictionModelInput,
-    EditPredictionStartedDebugEvent, UserActionRecord, UserActionType,
-    prediction::EditPredictionResult,
+    CurrentEditPrediction, DebugEvent, EditPredictionFinishedDebugEvent, EditPredictionId,
+    EditPredictionModel2, EditPredictionModelInput, EditPredictionStartedDebugEvent,
+    UserActionRecord, UserActionType, prediction::EditPredictionResult,
 };
 use anyhow::{Result, bail};
 use client::Client;

--- a/crates/edit_prediction/src/sweep_ai.rs
+++ b/crates/edit_prediction/src/sweep_ai.rs
@@ -1,6 +1,6 @@
 use crate::{
     CurrentEditPrediction, DebugEvent, EditPredictionFinishedDebugEvent, EditPredictionId,
-    EditPredictionModel2, EditPredictionModelInput, EditPredictionStartedDebugEvent,
+    EditPredictionModel, EditPredictionModelInput, EditPredictionStartedDebugEvent,
     UserActionRecord, UserActionType, prediction::EditPredictionResult,
 };
 use anyhow::{Result, bail};
@@ -42,7 +42,7 @@ impl SweepModel {
     }
 }
 
-impl EditPredictionModel2 for SweepModel {
+impl EditPredictionModel for SweepModel {
     fn requires_context(&self) -> bool {
         true
     }

--- a/crates/edit_prediction/src/zed_edit_prediction_delegate.rs
+++ b/crates/edit_prediction/src/zed_edit_prediction_delegate.rs
@@ -7,7 +7,7 @@ use gpui::{App, Entity, prelude::*};
 use language::{Buffer, ToPoint as _};
 use project::Project;
 
-use crate::{BufferEditPrediction, EditPredictionModel, EditPredictionStore};
+use crate::{BufferEditPrediction, EditPredictionStore};
 
 pub struct ZedEditPredictionDelegate {
     store: Entity<EditPredictionStore>,
@@ -98,12 +98,7 @@ impl EditPredictionDelegate for ZedEditPredictionDelegate {
         _cursor_position: language::Anchor,
         cx: &App,
     ) -> bool {
-        let store = self.store.read(cx);
-        if store.edit_prediction_model == EditPredictionModel::Sweep {
-            store.has_sweep_api_token(cx)
-        } else {
-            true
-        }
+        self.store.read(cx).is_model_enabled(cx)
     }
 
     fn is_refreshing(&self, cx: &App) -> bool {

--- a/crates/edit_prediction/src/zeta1.rs
+++ b/crates/edit_prediction/src/zeta1.rs
@@ -3,9 +3,10 @@ use std::{fmt::Write, ops::Range, path::Path, sync::Arc, time::Instant};
 use crate::{
     CurrentEditPrediction, DebugEvent, EditPredictionFinishedDebugEvent, EditPredictionId,
     EditPredictionModel2, EditPredictionModelInput, EditPredictionStartedDebugEvent,
-    EditPredictionStore, ZedUpdateRequiredError,
+    ZedUpdateRequiredError,
     cursor_excerpt::{editable_and_context_ranges_for_cursor_position, guess_token_count},
     prediction::EditPredictionResult,
+    zeta_api,
 };
 use anyhow::{Context as _, Result};
 use client::{Client, EditPredictionUsage, UserStore};
@@ -159,7 +160,7 @@ impl EditPredictionModel2 for Zeta1Model {
                 body.input_excerpt
             );
 
-            let response = EditPredictionStore::send_api_request::<PredictEditsResponse>(
+            let response = zeta_api::send_api_request::<PredictEditsResponse>(
                 |request| {
                     Ok(request
                         .uri(uri.as_str())
@@ -321,7 +322,7 @@ pub(crate) fn edit_prediction_accepted(
                 .build_zed_llm_url("/predict_edits/accept", &[])?
         };
 
-        let response = EditPredictionStore::send_api_request::<()>(
+        let response = zeta_api::send_api_request::<()>(
             move |builder| {
                 let req = builder.uri(url.as_ref()).body(
                     serde_json::to_string(&cloud_llm_client::AcceptEditPredictionBody {

--- a/crates/edit_prediction/src/zeta1.rs
+++ b/crates/edit_prediction/src/zeta1.rs
@@ -2,7 +2,7 @@ use std::{fmt::Write, ops::Range, path::Path, sync::Arc, time::Instant};
 
 use crate::{
     CurrentEditPrediction, DebugEvent, EditPredictionFinishedDebugEvent, EditPredictionId,
-    EditPredictionModel2, EditPredictionModelInput, EditPredictionStartedDebugEvent,
+    EditPredictionModel, EditPredictionModelInput, EditPredictionStartedDebugEvent,
     ZedUpdateRequiredError,
     cursor_excerpt::{editable_and_context_ranges_for_cursor_position, guess_token_count},
     prediction::EditPredictionResult,
@@ -60,7 +60,7 @@ impl Zeta1Model {
     }
 }
 
-impl EditPredictionModel2 for Zeta1Model {
+impl EditPredictionModel for Zeta1Model {
     fn requires_edit_history(&self) -> bool {
         true
     }

--- a/crates/edit_prediction/src/zeta2.rs
+++ b/crates/edit_prediction/src/zeta2.rs
@@ -1,8 +1,8 @@
 use crate::prediction::EditPredictionResult;
 use crate::{
-    CurrentEditPrediction, DebugEvent, EDIT_PREDICTIONS_MODEL_ID, EditPredictionFinishedDebugEvent,
-    EditPredictionId, EditPredictionModel2, EditPredictionModelInput,
-    EditPredictionStartedDebugEvent, ZedUpdateRequiredError, zeta_api,
+    CurrentEditPrediction, DebugEvent, EditPredictionFinishedDebugEvent, EditPredictionId,
+    EditPredictionModel2, EditPredictionModelInput, EditPredictionStartedDebugEvent,
+    ZedUpdateRequiredError, zeta_api,
 };
 use anyhow::{Result, anyhow};
 use client::{Client, EditPredictionUsage, UserStore};
@@ -137,7 +137,7 @@ impl EditPredictionModel2 for Zeta2Model {
                 let (request_id, output_text, usage) = if let Some(custom_url) = custom_url {
                     let prompt = format_zeta_prompt(&prompt_input, zeta_version);
                     let request = RawCompletionRequest {
-                        model: EDIT_PREDICTIONS_MODEL_ID.clone().unwrap_or_default(),
+                        model: zeta_api::RAW_MODEL_ID.clone().unwrap_or_default(),
                         prompt,
                         temperature: None,
                         stop: vec![],

--- a/crates/edit_prediction/src/zeta2.rs
+++ b/crates/edit_prediction/src/zeta2.rs
@@ -1,7 +1,7 @@
 use crate::prediction::EditPredictionResult;
 use crate::{
     CurrentEditPrediction, DebugEvent, EditPredictionFinishedDebugEvent, EditPredictionId,
-    EditPredictionModel2, EditPredictionModelInput, EditPredictionStartedDebugEvent,
+    EditPredictionModel, EditPredictionModelInput, EditPredictionStartedDebugEvent,
     ZedUpdateRequiredError, zeta_api,
 };
 use anyhow::{Result, anyhow};
@@ -60,7 +60,7 @@ impl Zeta2Model {
     }
 }
 
-impl EditPredictionModel2 for Zeta2Model {
+impl EditPredictionModel for Zeta2Model {
     fn requires_context(&self) -> bool {
         true
     }

--- a/crates/edit_prediction/src/zeta2.rs
+++ b/crates/edit_prediction/src/zeta2.rs
@@ -82,15 +82,231 @@ impl EditPredictionModel2 for Zeta2Model {
         inputs: EditPredictionModelInput,
         cx: &mut App,
     ) -> Task<Result<Option<EditPredictionResult>>> {
-        request_prediction_with_zeta2_impl(
-            inputs,
-            self.version,
-            self.client.clone(),
-            self.llm_token.clone(),
-            self.user_store.clone(),
-            self.custom_predict_edits_url.clone(),
-            cx,
-        )
+        let EditPredictionModelInput {
+            buffer,
+            snapshot,
+            position,
+            related_files,
+            events,
+            debug_tx,
+            ..
+        } = inputs;
+        let zeta_version = self.version;
+        let client = self.client.clone();
+        let llm_token = self.llm_token.clone();
+        let user_store = self.user_store.clone();
+        let custom_url = self.custom_predict_edits_url.clone();
+        let buffer_snapshotted_at = Instant::now();
+
+        let Some(excerpt_path) = snapshot
+            .file()
+            .map(|file| -> Arc<Path> { file.full_path(cx).into() })
+        else {
+            return Task::ready(Err(anyhow!("No file path for excerpt")));
+        };
+
+        let app_version = AppVersion::global(cx);
+
+        let request_task = cx.background_spawn({
+            async move {
+                let cursor_offset = position.to_offset(&snapshot);
+                let (editable_offset_range, prompt_input) = zeta2_prompt_input(
+                    &snapshot,
+                    related_files,
+                    events,
+                    excerpt_path,
+                    cursor_offset,
+                    zeta_version,
+                );
+
+                if let Some(debug_tx) = &debug_tx {
+                    let prompt = format_zeta_prompt(&prompt_input, zeta_version);
+                    debug_tx
+                        .unbounded_send(DebugEvent::EditPredictionStarted(
+                            EditPredictionStartedDebugEvent {
+                                buffer: buffer.downgrade(),
+                                prompt: Some(prompt),
+                                position,
+                            },
+                        ))
+                        .ok();
+                }
+
+                log::trace!("Sending edit prediction request");
+
+                let (request_id, output_text, usage) = if let Some(custom_url) = custom_url {
+                    let prompt = format_zeta_prompt(&prompt_input, zeta_version);
+                    let request = RawCompletionRequest {
+                        model: EDIT_PREDICTIONS_MODEL_ID.clone().unwrap_or_default(),
+                        prompt,
+                        temperature: None,
+                        stop: vec![],
+                        max_tokens: Some(2048),
+                    };
+
+                    let (mut response, usage) = EditPredictionStore::send_raw_llm_request(
+                        request,
+                        client,
+                        Some(custom_url),
+                        llm_token,
+                        app_version,
+                    )
+                    .await?;
+
+                    let request_id = EditPredictionId(response.id.clone().into());
+                    let output_text = response.choices.pop().map(|choice| choice.text);
+                    (request_id, output_text, usage)
+                } else {
+                    let (response, usage) = EditPredictionStore::send_v3_request(
+                        prompt_input.clone(),
+                        zeta_version,
+                        client,
+                        llm_token,
+                        app_version,
+                    )
+                    .await?;
+
+                    let request_id = EditPredictionId(response.request_id.into());
+                    let output_text = if response.output.is_empty() {
+                        None
+                    } else {
+                        Some(response.output)
+                    };
+                    (request_id, output_text, usage)
+                };
+
+                let received_response_at = Instant::now();
+
+                log::trace!("Got edit prediction response");
+
+                let Some(mut output_text) = output_text else {
+                    return Ok((Some((request_id, None)), usage));
+                };
+
+                if let Some(debug_tx) = &debug_tx {
+                    debug_tx
+                        .unbounded_send(DebugEvent::EditPredictionFinished(
+                            EditPredictionFinishedDebugEvent {
+                                buffer: buffer.downgrade(),
+                                position,
+                                model_output: Some(output_text.clone()),
+                            },
+                        ))
+                        .ok();
+                }
+
+                if output_text.contains(CURSOR_MARKER) {
+                    log::trace!("Stripping out {CURSOR_MARKER} from response");
+                    output_text = output_text.replace(CURSOR_MARKER, "");
+                }
+
+                let mut old_text = snapshot
+                    .text_for_range(editable_offset_range.clone())
+                    .collect::<String>();
+
+                if !output_text.is_empty() && !output_text.ends_with('\n') {
+                    output_text.push('\n');
+                }
+                if !old_text.is_empty() && !old_text.ends_with('\n') {
+                    old_text.push('\n');
+                }
+
+                let edits: Vec<_> = language::text_diff(&old_text, &output_text)
+                    .into_iter()
+                    .map(|(range, text)| {
+                        (
+                            snapshot.anchor_after(editable_offset_range.start + range.start)
+                                ..snapshot.anchor_before(editable_offset_range.start + range.end),
+                            text,
+                        )
+                    })
+                    .collect();
+
+                anyhow::Ok((
+                    Some((
+                        request_id,
+                        Some((
+                            prompt_input,
+                            buffer,
+                            snapshot.clone(),
+                            edits,
+                            received_response_at,
+                        )),
+                    )),
+                    usage,
+                ))
+            }
+        });
+
+        cx.spawn({
+            async move |cx| {
+                let result = request_task.await;
+
+                let data = match result {
+                    Ok((data, usage)) => {
+                        if let Some(usage) = usage {
+                            user_store.update(cx, |user_store, cx| {
+                                user_store.update_edit_prediction_usage(usage, cx);
+                            });
+                        }
+                        data
+                    }
+                    Err(err) => {
+                        if err.is::<ZedUpdateRequiredError>() {
+                            cx.update(|cx| {
+                                let error_message: SharedString = err.to_string().into();
+                                show_app_notification(
+                                    NotificationId::unique::<ZedUpdateRequiredError>(),
+                                    cx,
+                                    move |cx| {
+                                        cx.new(|cx| {
+                                            ErrorMessagePrompt::new(error_message.clone(), cx)
+                                                .with_link_button(
+                                                    "Update Zed",
+                                                    "https://zed.dev/releases",
+                                                )
+                                        })
+                                    },
+                                );
+                            });
+                        }
+                        return Err(err);
+                    }
+                };
+
+                let Some((id, prediction)) = data else {
+                    return Ok(None);
+                };
+
+                let Some((
+                    inputs,
+                    edited_buffer,
+                    edited_buffer_snapshot,
+                    edits,
+                    received_response_at,
+                )) = prediction
+                else {
+                    return Ok(Some(EditPredictionResult {
+                        id,
+                        prediction: Err(EditPredictionRejectReason::Empty),
+                    }));
+                };
+
+                Ok(Some(
+                    EditPredictionResult::new(
+                        id,
+                        &edited_buffer,
+                        &edited_buffer_snapshot,
+                        edits.into(),
+                        buffer_snapshotted_at,
+                        received_response_at,
+                        inputs,
+                        cx,
+                    )
+                    .await,
+                ))
+            }
+        })
     }
 
     fn report_rejected_prediction(&self, rejection: EditPredictionRejection) {
@@ -98,431 +314,49 @@ impl EditPredictionModel2 for Zeta2Model {
     }
 
     fn report_accepted_prediction(&self, prediction: CurrentEditPrediction, cx: &mut App) {
-        edit_prediction_accepted_impl(
-            &self.client,
-            &self.llm_token,
-            self.custom_predict_edits_url.as_ref(),
-            prediction,
-            cx,
-        );
-    }
-}
+        let custom_predict_edits_url = self.custom_predict_edits_url.as_ref();
+        let custom_accept_url = env::var("ZED_ACCEPT_PREDICTION_URL").ok();
+        if custom_predict_edits_url.is_some() && custom_accept_url.is_none() {
+            return;
+        }
 
-pub fn request_prediction_with_zeta2_impl(
-    EditPredictionModelInput {
-        buffer,
-        snapshot,
-        position,
-        related_files,
-        events,
-        debug_tx,
-        ..
-    }: EditPredictionModelInput,
-    zeta_version: ZetaVersion,
-    client: Arc<Client>,
-    llm_token: LlmApiToken,
-    user_store: Entity<UserStore>,
-    custom_url: Option<Arc<Url>>,
-    cx: &mut App,
-) -> Task<Result<Option<EditPredictionResult>>> {
-    let buffer_snapshotted_at = Instant::now();
+        let request_id = prediction.prediction.id.to_string();
+        let require_auth = custom_accept_url.is_none();
+        let client = self.client.clone();
+        let llm_token = self.llm_token.clone();
+        let app_version = AppVersion::global(cx);
 
-    let Some(excerpt_path) = snapshot
-        .file()
-        .map(|file| -> Arc<Path> { file.full_path(cx).into() })
-    else {
-        return Task::ready(Err(anyhow!("No file path for excerpt")));
-    };
-
-    let app_version = AppVersion::global(cx);
-
-    let request_task = cx.background_spawn({
-        async move {
-            let cursor_offset = position.to_offset(&snapshot);
-            let (editable_offset_range, prompt_input) = zeta2_prompt_input(
-                &snapshot,
-                related_files,
-                events,
-                excerpt_path,
-                cursor_offset,
-                zeta_version,
-            );
-
-            if let Some(debug_tx) = &debug_tx {
-                let prompt = format_zeta_prompt(&prompt_input, zeta_version);
-                debug_tx
-                    .unbounded_send(DebugEvent::EditPredictionStarted(
-                        EditPredictionStartedDebugEvent {
-                            buffer: buffer.downgrade(),
-                            prompt: Some(prompt),
-                            position,
-                        },
-                    ))
-                    .ok();
-            }
-
-            log::trace!("Sending edit prediction request");
-
-            let (request_id, output_text, usage) = if let Some(custom_url) = custom_url {
-                let prompt = format_zeta_prompt(&prompt_input, zeta_version);
-                let request = RawCompletionRequest {
-                    model: EDIT_PREDICTIONS_MODEL_ID.clone().unwrap_or_default(),
-                    prompt,
-                    temperature: None,
-                    stop: vec![],
-                    max_tokens: Some(2048),
-                };
-
-                let (mut response, usage) = EditPredictionStore::send_raw_llm_request(
-                    request,
-                    client,
-                    Some(custom_url),
-                    llm_token,
-                    app_version,
-                )
-                .await?;
-
-                let request_id = EditPredictionId(response.id.clone().into());
-                let output_text = response.choices.pop().map(|choice| choice.text);
-                (request_id, output_text, usage)
+        cx.background_spawn(async move {
+            let url = if let Some(accept_edits_url) = custom_accept_url {
+                Url::parse(&accept_edits_url)?
             } else {
-                let (response, usage) = EditPredictionStore::send_v3_request(
-                    prompt_input.clone(),
-                    zeta_version,
-                    client,
-                    llm_token,
-                    app_version,
-                )
-                .await?;
-
-                let request_id = EditPredictionId(response.request_id.into());
-                let output_text = if response.output.is_empty() {
-                    None
-                } else {
-                    Some(response.output)
-                };
-                (request_id, output_text, usage)
+                client
+                    .http_client()
+                    .build_zed_llm_url("/predict_edits/accept", &[])?
             };
 
-            let received_response_at = Instant::now();
-
-            log::trace!("Got edit prediction response");
-
-            let Some(mut output_text) = output_text else {
-                return Ok((Some((request_id, None)), usage));
-            };
-
-            if let Some(debug_tx) = &debug_tx {
-                debug_tx
-                    .unbounded_send(DebugEvent::EditPredictionFinished(
-                        EditPredictionFinishedDebugEvent {
-                            buffer: buffer.downgrade(),
-                            position,
-                            model_output: Some(output_text.clone()),
-                        },
-                    ))
-                    .ok();
-            }
-
-            if output_text.contains(CURSOR_MARKER) {
-                log::trace!("Stripping out {CURSOR_MARKER} from response");
-                output_text = output_text.replace(CURSOR_MARKER, "");
-            }
-
-            let mut old_text = snapshot
-                .text_for_range(editable_offset_range.clone())
-                .collect::<String>();
-
-            if !output_text.is_empty() && !output_text.ends_with('\n') {
-                output_text.push('\n');
-            }
-            if !old_text.is_empty() && !old_text.ends_with('\n') {
-                old_text.push('\n');
-            }
-
-            let edits: Vec<_> = language::text_diff(&old_text, &output_text)
-                .into_iter()
-                .map(|(range, text)| {
-                    (
-                        snapshot.anchor_after(editable_offset_range.start + range.start)
-                            ..snapshot.anchor_before(editable_offset_range.start + range.end),
-                        text,
-                    )
-                })
-                .collect();
-
-            anyhow::Ok((
-                Some((
-                    request_id,
-                    Some((
-                        prompt_input,
-                        buffer,
-                        snapshot.clone(),
-                        edits,
-                        received_response_at,
-                    )),
-                )),
-                usage,
-            ))
-        }
-    });
-
-    cx.spawn({
-        async move |cx| {
-            let result = request_task.await;
-
-            let data = match result {
-                Ok((data, usage)) => {
-                    if let Some(usage) = usage {
-                        user_store.update(cx, |user_store, cx| {
-                            user_store.update_edit_prediction_usage(usage, cx);
-                        });
-                    }
-                    data
-                }
-                Err(err) => {
-                    if err.is::<ZedUpdateRequiredError>() {
-                        cx.update(|cx| {
-                            let error_message: SharedString = err.to_string().into();
-                            show_app_notification(
-                                NotificationId::unique::<ZedUpdateRequiredError>(),
-                                cx,
-                                move |cx| {
-                                    cx.new(|cx| {
-                                        ErrorMessagePrompt::new(error_message.clone(), cx)
-                                            .with_link_button(
-                                                "Update Zed",
-                                                "https://zed.dev/releases",
-                                            )
-                                    })
-                                },
-                            );
-                        });
-                    }
-                    return Err(err);
-                }
-            };
-
-            let Some((id, prediction)) = data else {
-                return Ok(None);
-            };
-
-            let Some((inputs, edited_buffer, edited_buffer_snapshot, edits, received_response_at)) =
-                prediction
-            else {
-                return Ok(Some(EditPredictionResult {
-                    id,
-                    prediction: Err(EditPredictionRejectReason::Empty),
-                }));
-            };
-
-            Ok(Some(
-                EditPredictionResult::new(
-                    id,
-                    &edited_buffer,
-                    &edited_buffer_snapshot,
-                    edits.into(),
-                    buffer_snapshotted_at,
-                    received_response_at,
-                    inputs,
-                    cx,
-                )
-                .await,
-            ))
-        }
-    })
-}
-
-pub fn request_prediction_with_zeta2(
-    store: &mut EditPredictionStore,
-    EditPredictionModelInput {
-        buffer,
-        snapshot,
-        position,
-        related_files,
-        events,
-        debug_tx,
-        ..
-    }: EditPredictionModelInput,
-    zeta_version: ZetaVersion,
-    cx: &mut Context<EditPredictionStore>,
-) -> Task<Result<Option<EditPredictionResult>>> {
-    let buffer_snapshotted_at = Instant::now();
-    let custom_url = store.custom_predict_edits_url.clone();
-
-    let Some(excerpt_path) = snapshot
-        .file()
-        .map(|file| -> Arc<Path> { file.full_path(cx).into() })
-    else {
-        return Task::ready(Err(anyhow!("No file path for excerpt")));
-    };
-
-    let client = store.client.clone();
-    let llm_token = store.llm_token.clone();
-    let app_version = AppVersion::global(cx);
-
-    let request_task = cx.background_spawn({
-        async move {
-            let cursor_offset = position.to_offset(&snapshot);
-            let (editable_offset_range, prompt_input) = zeta2_prompt_input(
-                &snapshot,
-                related_files,
-                events,
-                excerpt_path,
-                cursor_offset,
-                zeta_version,
-            );
-
-            if let Some(debug_tx) = &debug_tx {
-                let prompt = format_zeta_prompt(&prompt_input, zeta_version);
-                debug_tx
-                    .unbounded_send(DebugEvent::EditPredictionStarted(
-                        EditPredictionStartedDebugEvent {
-                            buffer: buffer.downgrade(),
-                            prompt: Some(prompt),
-                            position,
-                        },
-                    ))
-                    .ok();
-            }
-
-            log::trace!("Sending edit prediction request");
-
-            let (request_id, output_text, usage) = if let Some(custom_url) = custom_url {
-                // Use raw endpoint with custom URL
-                let prompt = format_zeta_prompt(&prompt_input, zeta_version);
-                let request = RawCompletionRequest {
-                    model: EDIT_PREDICTIONS_MODEL_ID.clone().unwrap_or_default(),
-                    prompt,
-                    temperature: None,
-                    stop: vec![],
-                    max_tokens: Some(2048),
-                };
-
-                let (mut response, usage) = EditPredictionStore::send_raw_llm_request(
-                    request,
-                    client,
-                    Some(custom_url),
-                    llm_token,
-                    app_version,
-                )
-                .await?;
-
-                let request_id = EditPredictionId(response.id.clone().into());
-                let output_text = response.choices.pop().map(|choice| choice.text);
-                (request_id, output_text, usage)
-            } else {
-                let (response, usage) = EditPredictionStore::send_v3_request(
-                    prompt_input.clone(),
-                    zeta_version,
-                    client,
-                    llm_token,
-                    app_version,
-                )
-                .await?;
-
-                let request_id = EditPredictionId(response.request_id.into());
-                let output_text = if response.output.is_empty() {
-                    None
-                } else {
-                    Some(response.output)
-                };
-                (request_id, output_text, usage)
-            };
-
-            let received_response_at = Instant::now();
-
-            log::trace!("Got edit prediction response");
-
-            let Some(mut output_text) = output_text else {
-                return Ok((Some((request_id, None)), usage));
-            };
-
-            if let Some(debug_tx) = &debug_tx {
-                debug_tx
-                    .unbounded_send(DebugEvent::EditPredictionFinished(
-                        EditPredictionFinishedDebugEvent {
-                            buffer: buffer.downgrade(),
-                            position,
-                            model_output: Some(output_text.clone()),
-                        },
-                    ))
-                    .ok();
-            }
-
-            if output_text.contains(CURSOR_MARKER) {
-                log::trace!("Stripping out {CURSOR_MARKER} from response");
-                output_text = output_text.replace(CURSOR_MARKER, "");
-            }
-
-            let mut old_text = snapshot
-                .text_for_range(editable_offset_range.clone())
-                .collect::<String>();
-
-            if !output_text.is_empty() && !output_text.ends_with('\n') {
-                output_text.push('\n');
-            }
-            if !old_text.is_empty() && !old_text.ends_with('\n') {
-                old_text.push('\n');
-            }
-
-            let edits: Vec<_> = language::text_diff(&old_text, &output_text)
-                .into_iter()
-                .map(|(range, text)| {
-                    (
-                        snapshot.anchor_after(editable_offset_range.start + range.start)
-                            ..snapshot.anchor_before(editable_offset_range.start + range.end),
-                        text,
-                    )
-                })
-                .collect();
-
-            anyhow::Ok((
-                Some((
-                    request_id,
-                    Some((
-                        prompt_input,
-                        buffer,
-                        snapshot.clone(),
-                        edits,
-                        received_response_at,
-                    )),
-                )),
-                usage,
-            ))
-        }
-    });
-
-    cx.spawn(async move |this, cx| {
-        let Some((id, prediction)) =
-            EditPredictionStore::handle_api_response(&this, request_task.await, cx)?
-        else {
-            return Ok(None);
-        };
-
-        let Some((inputs, edited_buffer, edited_buffer_snapshot, edits, received_response_at)) =
-            prediction
-        else {
-            return Ok(Some(EditPredictionResult {
-                id,
-                prediction: Err(EditPredictionRejectReason::Empty),
-            }));
-        };
-
-        Ok(Some(
-            EditPredictionResult::new(
-                id,
-                &edited_buffer,
-                &edited_buffer_snapshot,
-                edits.into(),
-                buffer_snapshotted_at,
-                received_response_at,
-                inputs,
-                cx,
+            let response = EditPredictionStore::send_api_request::<()>(
+                move |builder| {
+                    let req = builder.uri(url.as_ref()).body(
+                        serde_json::to_string(&AcceptEditPredictionBody {
+                            request_id: request_id.clone(),
+                        })?
+                        .into(),
+                    );
+                    Ok(req?)
+                },
+                client,
+                llm_token,
+                app_version,
+                require_auth,
             )
-            .await,
-        ))
-    })
+            .await;
+
+            response?;
+            anyhow::Ok(())
+        })
+        .detach_and_log_err(cx);
+    }
 }
 
 pub fn zeta2_prompt_input(

--- a/crates/edit_prediction/src/zeta2.rs
+++ b/crates/edit_prediction/src/zeta2.rs
@@ -1,15 +1,23 @@
 use crate::prediction::EditPredictionResult;
 use crate::{
     CurrentEditPrediction, DebugEvent, EDIT_PREDICTIONS_MODEL_ID, EditPredictionFinishedDebugEvent,
-    EditPredictionId, EditPredictionModelInput, EditPredictionStartedDebugEvent,
-    EditPredictionStore,
+    EditPredictionId, EditPredictionModel2, EditPredictionModelInput,
+    EditPredictionStartedDebugEvent, EditPredictionStore, UserActionRecord, ZedUpdateRequiredError,
 };
 use anyhow::{Result, anyhow};
+use client::{Client, UserStore};
 use cloud_llm_client::predict_edits_v3::RawCompletionRequest;
-use cloud_llm_client::{AcceptEditPredictionBody, EditPredictionRejectReason};
-use gpui::{App, Task, prelude::*};
-use language::{OffsetRangeExt as _, ToOffset as _, ToPoint};
+use cloud_llm_client::{
+    AcceptEditPredictionBody, EditPredictionRejectReason, EditPredictionRejection,
+};
+use futures::channel::mpsc;
+use gpui::{App, Entity, SharedString, Task, http_client::Url, prelude::*};
+use language::{Anchor, Buffer, OffsetRangeExt as _, ToOffset as _, ToPoint};
+use language_model::LlmApiToken;
+use project::Project;
 use release_channel::AppVersion;
+use workspace::notifications::{ErrorMessagePrompt, NotificationId, show_app_notification};
+use zeta_prompt::{Event, RelatedFile};
 
 use std::env;
 use std::{path::Path, sync::Arc, time::Instant};
@@ -23,6 +31,328 @@ pub fn max_editable_tokens(version: ZetaVersion) -> usize {
         ZetaVersion::V0112MiddleAtEnd | ZetaVersion::V0113Ordered => 150,
         ZetaVersion::V0114180EditableRegion => 180,
     }
+}
+
+pub struct Zeta2Model {
+    client: Arc<Client>,
+    llm_token: LlmApiToken,
+    user_store: Entity<UserStore>,
+    custom_predict_edits_url: Option<Arc<Url>>,
+    reject_predictions_tx: mpsc::UnboundedSender<EditPredictionRejection>,
+    version: ZetaVersion,
+}
+
+impl Zeta2Model {
+    pub fn new(
+        client: Arc<Client>,
+        llm_token: LlmApiToken,
+        user_store: Entity<UserStore>,
+        custom_predict_edits_url: Option<Arc<Url>>,
+        reject_predictions_tx: mpsc::UnboundedSender<EditPredictionRejection>,
+        version: ZetaVersion,
+    ) -> Self {
+        Self {
+            client,
+            llm_token,
+            user_store,
+            custom_predict_edits_url,
+            reject_predictions_tx,
+            version,
+        }
+    }
+}
+
+impl EditPredictionModel2 for Zeta2Model {
+    fn requires_context(&self) -> bool {
+        true
+    }
+
+    fn requires_edit_history(&self) -> bool {
+        true
+    }
+
+    fn is_enabled(&self, _cx: &App) -> bool {
+        true
+    }
+
+    fn request_prediction(
+        &self,
+        _project: Entity<Project>,
+        active_buffer: Entity<Buffer>,
+        position: Anchor,
+        context: Arc<[RelatedFile]>,
+        events: Vec<Arc<Event>>,
+        _user_actions: Vec<UserActionRecord>,
+        _can_collect_example: bool,
+        cx: &mut App,
+    ) -> Task<Result<Option<EditPredictionResult>>> {
+        let snapshot = active_buffer.read(cx).snapshot();
+
+        let inputs = EditPredictionModelInput {
+            project: _project,
+            buffer: active_buffer,
+            snapshot,
+            position,
+            events,
+            related_files: context.to_vec(),
+            recent_paths: std::collections::VecDeque::new(),
+            trigger: cloud_llm_client::PredictEditsRequestTrigger::Other,
+            diagnostic_search_range: language::Point::new(0, 0)..language::Point::new(0, 0),
+            debug_tx: None,
+            user_actions: vec![],
+        };
+
+        request_prediction_with_zeta2_impl(
+            inputs,
+            self.version,
+            self.client.clone(),
+            self.llm_token.clone(),
+            self.user_store.clone(),
+            self.custom_predict_edits_url.clone(),
+            cx,
+        )
+    }
+
+    fn report_rejected_prediction(&self, rejection: EditPredictionRejection) {
+        self.reject_predictions_tx.unbounded_send(rejection).ok();
+    }
+
+    fn report_accepted_prediction(&self, prediction: CurrentEditPrediction, cx: &mut App) {
+        edit_prediction_accepted_impl(
+            &self.client,
+            &self.llm_token,
+            self.custom_predict_edits_url.as_ref(),
+            prediction,
+            cx,
+        );
+    }
+}
+
+pub fn request_prediction_with_zeta2_impl(
+    EditPredictionModelInput {
+        buffer,
+        snapshot,
+        position,
+        related_files,
+        events,
+        debug_tx,
+        ..
+    }: EditPredictionModelInput,
+    zeta_version: ZetaVersion,
+    client: Arc<Client>,
+    llm_token: LlmApiToken,
+    user_store: Entity<UserStore>,
+    custom_url: Option<Arc<Url>>,
+    cx: &mut App,
+) -> Task<Result<Option<EditPredictionResult>>> {
+    let buffer_snapshotted_at = Instant::now();
+
+    let Some(excerpt_path) = snapshot
+        .file()
+        .map(|file| -> Arc<Path> { file.full_path(cx).into() })
+    else {
+        return Task::ready(Err(anyhow!("No file path for excerpt")));
+    };
+
+    let app_version = AppVersion::global(cx);
+
+    let request_task = cx.background_spawn({
+        async move {
+            let cursor_offset = position.to_offset(&snapshot);
+            let (editable_offset_range, prompt_input) = zeta2_prompt_input(
+                &snapshot,
+                related_files,
+                events,
+                excerpt_path,
+                cursor_offset,
+                zeta_version,
+            );
+
+            if let Some(debug_tx) = &debug_tx {
+                let prompt = format_zeta_prompt(&prompt_input, zeta_version);
+                debug_tx
+                    .unbounded_send(DebugEvent::EditPredictionStarted(
+                        EditPredictionStartedDebugEvent {
+                            buffer: buffer.downgrade(),
+                            prompt: Some(prompt),
+                            position,
+                        },
+                    ))
+                    .ok();
+            }
+
+            log::trace!("Sending edit prediction request");
+
+            let (request_id, output_text, usage) = if let Some(custom_url) = custom_url {
+                let prompt = format_zeta_prompt(&prompt_input, zeta_version);
+                let request = RawCompletionRequest {
+                    model: EDIT_PREDICTIONS_MODEL_ID.clone().unwrap_or_default(),
+                    prompt,
+                    temperature: None,
+                    stop: vec![],
+                    max_tokens: Some(2048),
+                };
+
+                let (mut response, usage) = EditPredictionStore::send_raw_llm_request(
+                    request,
+                    client,
+                    Some(custom_url),
+                    llm_token,
+                    app_version,
+                )
+                .await?;
+
+                let request_id = EditPredictionId(response.id.clone().into());
+                let output_text = response.choices.pop().map(|choice| choice.text);
+                (request_id, output_text, usage)
+            } else {
+                let (response, usage) = EditPredictionStore::send_v3_request(
+                    prompt_input.clone(),
+                    zeta_version,
+                    client,
+                    llm_token,
+                    app_version,
+                )
+                .await?;
+
+                let request_id = EditPredictionId(response.request_id.into());
+                let output_text = if response.output.is_empty() {
+                    None
+                } else {
+                    Some(response.output)
+                };
+                (request_id, output_text, usage)
+            };
+
+            let received_response_at = Instant::now();
+
+            log::trace!("Got edit prediction response");
+
+            let Some(mut output_text) = output_text else {
+                return Ok((Some((request_id, None)), usage));
+            };
+
+            if let Some(debug_tx) = &debug_tx {
+                debug_tx
+                    .unbounded_send(DebugEvent::EditPredictionFinished(
+                        EditPredictionFinishedDebugEvent {
+                            buffer: buffer.downgrade(),
+                            position,
+                            model_output: Some(output_text.clone()),
+                        },
+                    ))
+                    .ok();
+            }
+
+            if output_text.contains(CURSOR_MARKER) {
+                log::trace!("Stripping out {CURSOR_MARKER} from response");
+                output_text = output_text.replace(CURSOR_MARKER, "");
+            }
+
+            let mut old_text = snapshot
+                .text_for_range(editable_offset_range.clone())
+                .collect::<String>();
+
+            if !output_text.is_empty() && !output_text.ends_with('\n') {
+                output_text.push('\n');
+            }
+            if !old_text.is_empty() && !old_text.ends_with('\n') {
+                old_text.push('\n');
+            }
+
+            let edits: Vec<_> = language::text_diff(&old_text, &output_text)
+                .into_iter()
+                .map(|(range, text)| {
+                    (
+                        snapshot.anchor_after(editable_offset_range.start + range.start)
+                            ..snapshot.anchor_before(editable_offset_range.start + range.end),
+                        text,
+                    )
+                })
+                .collect();
+
+            anyhow::Ok((
+                Some((
+                    request_id,
+                    Some((
+                        prompt_input,
+                        buffer,
+                        snapshot.clone(),
+                        edits,
+                        received_response_at,
+                    )),
+                )),
+                usage,
+            ))
+        }
+    });
+
+    cx.spawn({
+        async move |cx| {
+            let result = request_task.await;
+
+            let data = match result {
+                Ok((data, usage)) => {
+                    if let Some(usage) = usage {
+                        cx.update(|cx| {
+                            user_store.update(cx, |user_store, cx| {
+                                user_store.update_edit_prediction_usage(usage, cx);
+                            });
+                        });
+                    }
+                    data
+                }
+                Err(err) => {
+                    if err.is::<ZedUpdateRequiredError>() {
+                        cx.update(|cx| {
+                            let error_message: SharedString = err.to_string().into();
+                            show_app_notification(
+                                NotificationId::unique::<ZedUpdateRequiredError>(),
+                                cx,
+                                move |cx| {
+                                    cx.new(|cx| {
+                                        ErrorMessagePrompt::new(error_message.clone(), cx)
+                                            .with_link_button(
+                                                "Update Zed",
+                                                "https://zed.dev/releases",
+                                            )
+                                    })
+                                },
+                            );
+                        });
+                    }
+                    return Err(err);
+                }
+            };
+
+            let Some((id, prediction)) = data else {
+                return Ok(None);
+            };
+
+            let Some((inputs, edited_buffer, edited_buffer_snapshot, edits, received_response_at)) =
+                prediction
+            else {
+                return Ok(Some(EditPredictionResult {
+                    id,
+                    prediction: Err(EditPredictionRejectReason::Empty),
+                }));
+            };
+
+            Ok(Some(
+                EditPredictionResult::new(
+                    id,
+                    &edited_buffer,
+                    &edited_buffer_snapshot,
+                    edits.into(),
+                    buffer_snapshotted_at,
+                    received_response_at,
+                    inputs,
+                    cx,
+                )
+                .await,
+            ))
+        }
+    })
 }
 
 pub fn request_prediction_with_zeta2(
@@ -261,25 +591,42 @@ pub fn zeta2_prompt_input(
     (editable_offset_range, prompt_input)
 }
 
+#[allow(dead_code)]
 pub(crate) fn edit_prediction_accepted(
     store: &EditPredictionStore,
     current_prediction: CurrentEditPrediction,
     cx: &App,
 ) {
+    edit_prediction_accepted_impl(
+        &store.client,
+        &store.llm_token,
+        store.custom_predict_edits_url.as_ref(),
+        current_prediction,
+        cx,
+    );
+}
+
+fn edit_prediction_accepted_impl(
+    client: &Arc<Client>,
+    llm_token: &LlmApiToken,
+    custom_predict_edits_url: Option<&Arc<Url>>,
+    current_prediction: CurrentEditPrediction,
+    cx: &App,
+) {
     let custom_accept_url = env::var("ZED_ACCEPT_PREDICTION_URL").ok();
-    if store.custom_predict_edits_url.is_some() && custom_accept_url.is_none() {
+    if custom_predict_edits_url.is_some() && custom_accept_url.is_none() {
         return;
     }
 
     let request_id = current_prediction.prediction.id.to_string();
     let require_auth = custom_accept_url.is_none();
-    let client = store.client.clone();
-    let llm_token = store.llm_token.clone();
+    let client = client.clone();
+    let llm_token = llm_token.clone();
     let app_version = AppVersion::global(cx);
 
     cx.background_spawn(async move {
         let url = if let Some(accept_edits_url) = custom_accept_url {
-            gpui::http_client::Url::parse(&accept_edits_url)?
+            Url::parse(&accept_edits_url)?
         } else {
             client
                 .http_client()

--- a/crates/edit_prediction/src/zeta_api.rs
+++ b/crates/edit_prediction/src/zeta_api.rs
@@ -9,11 +9,13 @@ use gpui::http_client::{self, AsyncBody, Method, Url};
 use language_model::LlmApiToken;
 use semver::Version;
 use serde::de::DeserializeOwned;
-use std::sync::Arc;
+use std::env;
+use std::sync::{Arc, LazyLock};
 use thiserror::Error;
 use zeta_prompt::{ZetaPromptInput, ZetaVersion};
 
-use crate::EDIT_PREDICTIONS_MODEL_ID;
+pub(crate) static RAW_MODEL_ID: LazyLock<Option<String>> =
+    LazyLock::new(|| env::var("ZED_ZETA_MODEL").ok());
 
 pub const ZED_VERSION_HEADER_NAME: &str = cloud_llm_client::ZED_VERSION_HEADER_NAME;
 
@@ -68,7 +70,7 @@ pub async fn send_v3_request(
 
     let request = PredictEditsV3Request {
         input,
-        model: EDIT_PREDICTIONS_MODEL_ID.clone(),
+        model: RAW_MODEL_ID.clone(),
         prompt_version,
     };
 

--- a/crates/edit_prediction/src/zeta_api.rs
+++ b/crates/edit_prediction/src/zeta_api.rs
@@ -1,0 +1,166 @@
+use anyhow::Result;
+use client::{Client, EditPredictionUsage};
+use cloud_llm_client::predict_edits_v3::{
+    PredictEditsV3Request, PredictEditsV3Response, RawCompletionRequest, RawCompletionResponse,
+};
+use cloud_llm_client::{EXPIRED_LLM_TOKEN_HEADER_NAME, MINIMUM_REQUIRED_VERSION_HEADER_NAME};
+use futures::AsyncReadExt as _;
+use gpui::http_client::{self, AsyncBody, Method, Url};
+use language_model::LlmApiToken;
+use semver::Version;
+use serde::de::DeserializeOwned;
+use std::sync::Arc;
+use thiserror::Error;
+use zeta_prompt::{ZetaPromptInput, ZetaVersion};
+
+use crate::EDIT_PREDICTIONS_MODEL_ID;
+
+pub const ZED_VERSION_HEADER_NAME: &str = cloud_llm_client::ZED_VERSION_HEADER_NAME;
+
+#[derive(Error, Debug)]
+#[error(
+    "You must update to Zed version {minimum_version} or higher to continue using edit predictions."
+)]
+pub struct ZedUpdateRequiredError {
+    pub minimum_version: Version,
+}
+
+pub async fn send_raw_llm_request(
+    request: RawCompletionRequest,
+    client: Arc<Client>,
+    custom_url: Option<Arc<Url>>,
+    llm_token: LlmApiToken,
+    app_version: Version,
+) -> Result<(RawCompletionResponse, Option<EditPredictionUsage>)> {
+    let url = if let Some(custom_url) = custom_url {
+        custom_url.as_ref().clone()
+    } else {
+        client
+            .http_client()
+            .build_zed_llm_url("/predict_edits/raw", &[])?
+    };
+
+    send_api_request(
+        |builder| {
+            let req = builder
+                .uri(url.as_ref())
+                .body(serde_json::to_string(&request)?.into());
+            Ok(req?)
+        },
+        client,
+        llm_token,
+        app_version,
+        true,
+    )
+    .await
+}
+
+pub async fn send_v3_request(
+    input: ZetaPromptInput,
+    prompt_version: ZetaVersion,
+    client: Arc<Client>,
+    llm_token: LlmApiToken,
+    app_version: Version,
+) -> Result<(PredictEditsV3Response, Option<EditPredictionUsage>)> {
+    let url = client
+        .http_client()
+        .build_zed_llm_url("/predict_edits/v3", &[])?;
+
+    let request = PredictEditsV3Request {
+        input,
+        model: EDIT_PREDICTIONS_MODEL_ID.clone(),
+        prompt_version,
+    };
+
+    send_api_request(
+        |builder| {
+            let req = builder
+                .uri(url.as_ref())
+                .body(serde_json::to_string(&request)?.into());
+            Ok(req?)
+        },
+        client,
+        llm_token,
+        app_version,
+        true,
+    )
+    .await
+}
+
+pub async fn send_api_request<Res>(
+    build: impl Fn(http_client::http::request::Builder) -> Result<http_client::Request<AsyncBody>>,
+    client: Arc<Client>,
+    llm_token: LlmApiToken,
+    app_version: Version,
+    require_auth: bool,
+) -> Result<(Res, Option<EditPredictionUsage>)>
+where
+    Res: DeserializeOwned,
+{
+    let http_client = client.http_client();
+
+    let mut token = if let Ok(custom_token) = std::env::var("ZED_PREDICT_EDITS_TOKEN") {
+        Some(custom_token)
+    } else if require_auth {
+        Some(llm_token.acquire(&client).await?)
+    } else {
+        llm_token.acquire(&client).await.ok()
+    };
+    let mut did_retry = false;
+
+    loop {
+        let request_builder = http_client::Request::builder().method(Method::POST);
+
+        let mut request_builder = request_builder
+            .header("Content-Type", "application/json")
+            .header(ZED_VERSION_HEADER_NAME, app_version.to_string());
+
+        // Only add Authorization header if we have a token
+        if let Some(ref token_value) = token {
+            request_builder =
+                request_builder.header("Authorization", format!("Bearer {}", token_value));
+        }
+
+        let request = build(request_builder)?;
+
+        let mut response = http_client.send(request).await?;
+
+        if let Some(minimum_required_version) = response
+            .headers()
+            .get(MINIMUM_REQUIRED_VERSION_HEADER_NAME)
+            .and_then(|version| Version::parse(version.to_str().ok()?).ok())
+        {
+            anyhow::ensure!(
+                app_version >= minimum_required_version,
+                ZedUpdateRequiredError {
+                    minimum_version: minimum_required_version
+                }
+            );
+        }
+
+        if response.status().is_success() {
+            let usage = EditPredictionUsage::from_headers(response.headers()).ok();
+
+            let mut body = Vec::new();
+            response.body_mut().read_to_end(&mut body).await?;
+            return Ok((serde_json::from_slice(&body)?, usage));
+        } else if !did_retry
+            && token.is_some()
+            && response
+                .headers()
+                .get(EXPIRED_LLM_TOKEN_HEADER_NAME)
+                .is_some()
+        {
+            did_retry = true;
+            token = Some(llm_token.refresh(&client).await?);
+        } else {
+            let mut body = String::new();
+            response.body_mut().read_to_string(&mut body).await?;
+            anyhow::bail!(
+                "Request failed with status: {:?}\nBody: {}",
+                response.status(),
+                body
+            );
+        }
+    }
+}

--- a/crates/edit_prediction_cli/src/predict.rs
+++ b/crates/edit_prediction_cli/src/predict.rs
@@ -95,6 +95,7 @@ pub async fn run_prediction(
         let model: Box<dyn EditPredictionModel2> = match provider {
             PredictionProvider::Zeta1 => Box::new(Zeta1Model::new(
                 app_state.client.clone(),
+                app_state.user_store.clone(),
                 store.llm_token().clone(),
                 store.custom_predict_edits_url(),
                 store.reject_predictions_tx(),

--- a/crates/edit_prediction_cli/src/predict.rs
+++ b/crates/edit_prediction_cli/src/predict.rs
@@ -108,10 +108,7 @@ pub async fn run_prediction(
                 store.reject_predictions_tx(),
                 version,
             )),
-            PredictionProvider::Sweep => Box::new(SweepModel::new(
-                edit_prediction::sweep_ai::SweepAi::new(cx),
-                app_state.client.clone(),
-            )),
+            PredictionProvider::Sweep => Box::new(SweepModel::new(app_state.client.clone(), cx)),
             PredictionProvider::Mercury => Box::new(MercuryModel::new(
                 edit_prediction::mercury::Mercury::new(cx),
             )),

--- a/crates/edit_prediction_cli/src/predict.rs
+++ b/crates/edit_prediction_cli/src/predict.rs
@@ -109,9 +109,7 @@ pub async fn run_prediction(
                 version,
             )),
             PredictionProvider::Sweep => Box::new(SweepModel::new(app_state.client.clone(), cx)),
-            PredictionProvider::Mercury => Box::new(MercuryModel::new(
-                edit_prediction::mercury::Mercury::new(cx),
-            )),
+            PredictionProvider::Mercury => Box::new(MercuryModel::new(cx)),
             PredictionProvider::Teacher(..) | PredictionProvider::TeacherNonBatching(..) => {
                 unreachable!()
             }

--- a/crates/edit_prediction_cli/src/predict.rs
+++ b/crates/edit_prediction_cli/src/predict.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use anyhow::Context as _;
 use edit_prediction::{
-    DebugEvent, EditPredictionModel2, EditPredictionStore, mercury::MercuryModel,
+    DebugEvent, EditPredictionModel, EditPredictionStore, mercury::MercuryModel,
     sweep_ai::SweepModel, zeta1::Zeta1Model, zeta2::Zeta2Model,
 };
 use futures::{FutureExt as _, StreamExt as _, future::Shared};
@@ -92,7 +92,7 @@ pub async fn run_prediction(
         .context("EditPredictionStore not initialized")?;
 
     ep_store.update(&mut cx, |store, cx| {
-        let model: Box<dyn EditPredictionModel2> = match provider {
+        let model: Box<dyn EditPredictionModel> = match provider {
             PredictionProvider::Zeta1 => Box::new(Zeta1Model::new(
                 app_state.client.clone(),
                 app_state.user_store.clone(),

--- a/crates/edit_prediction_ui/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_ui/src/edit_prediction_button.rs
@@ -319,14 +319,24 @@ impl Render for EditPredictionButton {
                             "Powered by Sweep"
                         };
                         missing_token = edit_prediction::EditPredictionStore::try_global(cx)
-                            .is_some_and(|ep_store| !ep_store.read(cx).has_sweep_api_token(cx));
+                            .is_some_and(|ep_store| {
+                                ep_store
+                                    .read(cx)
+                                    .model()
+                                    .is_some_and(|model| !model.is_enabled(cx))
+                            });
                     }
                     EditPredictionProvider::Experimental(
                         EXPERIMENTAL_MERCURY_EDIT_PREDICTION_PROVIDER_NAME,
                     ) => {
                         ep_icon = IconName::Inception;
                         missing_token = edit_prediction::EditPredictionStore::try_global(cx)
-                            .is_some_and(|ep_store| !ep_store.read(cx).has_mercury_api_token(cx));
+                            .is_some_and(|ep_store| {
+                                ep_store
+                                    .read(cx)
+                                    .model()
+                                    .is_some_and(|model| !model.is_enabled(cx))
+                            });
                         tooltip_meta = if missing_token {
                             "Missing API key for Mercury"
                         } else {

--- a/crates/zed/src/zed/edit_prediction_registry.rs
+++ b/crates/zed/src/zed/edit_prediction_registry.rs
@@ -204,7 +204,7 @@ fn assign_edit_prediction_provider(
                 && buffer.read(cx).file().is_some()
             {
                 let has_model = ep_store.update(cx, |ep_store, cx| {
-                    let model: Box<dyn edit_prediction::EditPredictionModel2> =
+                    let model: Box<dyn edit_prediction::EditPredictionModel> =
                         if let EditPredictionProvider::Experimental(name) = value {
                             if name == EXPERIMENTAL_SWEEP_EDIT_PREDICTION_PROVIDER_NAME
                                 && cx.has_flag::<SweepFeatureFlag>()

--- a/crates/zed/src/zed/edit_prediction_registry.rs
+++ b/crates/zed/src/zed/edit_prediction_registry.rs
@@ -224,9 +224,7 @@ fn assign_edit_prediction_provider(
                             } else if name == EXPERIMENTAL_MERCURY_EDIT_PREDICTION_PROVIDER_NAME
                                 && cx.has_flag::<MercuryFeatureFlag>()
                             {
-                                Box::new(MercuryModel::new(edit_prediction::mercury::Mercury::new(
-                                    cx,
-                                )))
+                                Box::new(MercuryModel::new(cx))
                             } else {
                                 return false;
                             }

--- a/crates/zed/src/zed/edit_prediction_registry.rs
+++ b/crates/zed/src/zed/edit_prediction_registry.rs
@@ -236,6 +236,7 @@ fn assign_edit_prediction_provider(
                         } else if user_store.read(cx).current_user().is_some() {
                             Box::new(Zeta1Model::new(
                                 client.clone(),
+                                user_store.clone(),
                                 ep_store.llm_token().clone(),
                                 ep_store.custom_predict_edits_url(),
                                 ep_store.reject_predictions_tx(),

--- a/crates/zed/src/zed/edit_prediction_registry.rs
+++ b/crates/zed/src/zed/edit_prediction_registry.rs
@@ -209,10 +209,7 @@ fn assign_edit_prediction_provider(
                             if name == EXPERIMENTAL_SWEEP_EDIT_PREDICTION_PROVIDER_NAME
                                 && cx.has_flag::<SweepFeatureFlag>()
                             {
-                                Box::new(SweepModel::new(
-                                    edit_prediction::sweep_ai::SweepAi::new(cx),
-                                    client.clone(),
-                                ))
+                                Box::new(SweepModel::new(client.clone(), cx))
                             } else if name == EXPERIMENTAL_ZETA2_EDIT_PREDICTION_PROVIDER_NAME
                                 && cx.has_flag::<Zeta2FeatureFlag>()
                             {


### PR DESCRIPTION
Instead of having a fixed enum for models, the store will now use a trait object, allowing providers to be defined in their own crates. The main motivation for this change is having Copilot also work via the store which will enable diagnostic-based jumps other behaviors.

Release Notes:

- N/A 
