### PR TITLE
rope: Fix an unintentional panic

### DIFF
--- a/crates/rope/src/chunk.rs
+++ b/crates/rope/src/chunk.rs
@@ -721,7 +721,7 @@ fn panic_char_boundary(text: &str, offset: usize) -> ! {
 #[inline(never)]
 #[track_caller]
 fn log_err_char_boundary(text: &str, offset: usize) {
-    if offset > text.len() {
+    if offset >= text.len() {
         log::error!(
             "byte index {} is out of bounds of `{:?}` (length: {})",
             offset,


### PR DESCRIPTION
Avoids the panic in #46974

But should be solved by using `saturating_sub` on the `start_overshoot` calculation, ref: https://github.com/zed-industries/zed/pull/47046#issuecomment-3762855786

https://github.com/zed-industries/zed/blob/37715d5a50666baaa824eafec2131ee6d80f8e0b/crates/rope/src/chunk.rs#L403C5-L415C6

This function gets called with PANIC = false from `slice`. But if the offset is outside the text, `log_err_char_boundary` will still panic, because the first `if` doesn’t bail out early.

Release Notes:

- N/A
