### PR TITLE
danger: Remove check for modifying prompts

### DIFF
--- a/script/danger/dangerfile.ts
+++ b/script/danger/dangerfile.ts
@@ -61,42 +61,6 @@ if (includesIssueUrl) {
   );
 }
 
-const PROMPT_PATHS = [
-  "assets/prompts/content_prompt.hbs",
-  "assets/prompts/terminal_assistant_prompt.hbs",
-  "crates/agent_settings/src/prompts/summarize_thread_detailed_prompt.txt",
-  "crates/agent_settings/src/prompts/summarize_thread_prompt.txt",
-  "crates/agent/src/templates/create_file_prompt.hbs",
-  "crates/agent/src/templates/edit_file_prompt_xml.hbs",
-  "crates/agent/src/templates/edit_file_prompt_diff_fenced.hbs",
-  "crates/git_ui/src/commit_message_prompt.txt",
-];
-
-const PROMPT_CHANGE_ATTESTATION = "I have ensured the LLM Worker works with these prompt changes.";
-
-const modifiedPrompts = danger.git.modified_files.filter((file) =>
-  PROMPT_PATHS.some((promptPath) => file.includes(promptPath)),
-);
-
-for (const promptPath of modifiedPrompts) {
-  if (body.includes(PROMPT_CHANGE_ATTESTATION)) {
-    message(
-      [
-        `This PR contains changes to "${promptPath}".`,
-        "The author has attested the LLM Worker works with the changes to this prompt.",
-      ].join("\n"),
-    );
-  } else {
-    fail(
-      [
-        `Modifying the "${promptPath}" prompt may require corresponding changes in the LLM Worker.`,
-        "If you are ensure what this entails, talk to @maxdeviant or another AI team member.",
-        `Once you have made the changes—or determined that none are necessary—add "${PROMPT_CHANGE_ATTESTATION}" to the PR description.`,
-      ].join("\n"),
-    );
-  }
-}
-
 const FIXTURE_CHANGE_ATTESTATION = "Changes to test fixtures are intentional and necessary.";
 
 const FIXTURES_PATHS = ["crates/assistant_tools/src/edit_agent/evals/fixtures"];


### PR DESCRIPTION
This PR removes the Danger check for modifying prompts, as we no longer need to account for these in Cloud.

Release Notes:

- N/A
