### PR TITLE
editor: Fix relative line numbers breaking with nested folds

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -26994,22 +26994,18 @@ impl EditorSnapshot {
             let wrap_row = wrap_snapshot
                 .make_wrap_point(first_visible_row, Bias::Left)
                 .row();
+
             wrap_row.0 as i64 - base_wrap_row.0 as i64
         } else {
-            let folds = if current_selection_head < first_visible_row {
-                self.folds_in_range(current_selection_head..first_visible_row)
-            } else {
-                self.folds_in_range(first_visible_row..current_selection_head)
-            };
+            let fold_snapshot = self.fold_snapshot();
+            let base_fold_row = fold_snapshot
+                .to_fold_point(self.to_inlay_point(current_selection_head), Bias::Left)
+                .row();
+            let fold_row = fold_snapshot
+                .to_fold_point(self.to_inlay_point(first_visible_row), Bias::Left)
+                .row();
 
-            let folded_lines = folds
-                .map(|fold| {
-                    let range = fold.range.0.to_point(self);
-                    range.end.row.saturating_sub(range.start.row)
-                })
-                .sum::<u32>() as i64;
-
-            first_visible_row.row as i64 - current_selection_head.row as i64 + folded_lines
+            fold_row as i64 - base_fold_row as i64
         }
     }
 


### PR DESCRIPTION
Closes #46516

The previous fix only worked for non-nested folds, whereas this one also considers nested folds properly. Also makes this more straightforward to read. 

Release Notes:

- Fixed an issue where relative line numbering would break with nested folds.
