### PR TITLE
Bump async-task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1225,8 +1225,7 @@ dependencies = [
 [[package]]
 name = "async-task"
 version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+source = "git+https://github.com/smol-rs/async-task.git?rev=b4486cd71e4e94fbda54ce6302444de14f4d190e#b4486cd71e4e94fbda54ce6302444de14f4d190e"
 
 [[package]]
 name = "async-trait"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -782,6 +782,7 @@ features = [
 ]
 
 [patch.crates-io]
+async-task = { git = "https://github.com/smol-rs/async-task.git", rev = "b4486cd71e4e94fbda54ce6302444de14f4d190e" }
 notify = { git = "https://github.com/zed-industries/notify.git", rev = "b4588b2e5aee68f4c0e100f140e808cbce7b1419" }
 notify-types = { git = "https://github.com/zed-industries/notify.git", rev = "b4588b2e5aee68f4c0e100f140e808cbce7b1419" }
 windows-capture = { git = "https://github.com/zed-industries/windows-capture.git", rev = "f0d6c1b6691db75461b732f6d5ff56eed002eeb9" }


### PR DESCRIPTION
This reduces total code-size of the project crate by ~25%, and reduces release build time by ~35s thanks to
@osiewicz's proposed fix https://github.com/smol-rs/async-task/issues/66

Release Notes:

- N/A
