### PR TITLE
Add a 'rejected patch' field to example specs, for DPO examples

### DIFF
--- a/crates/edit_prediction/src/capture_example.rs
+++ b/crates/edit_prediction/src/capture_example.rs
@@ -78,6 +78,7 @@ pub fn capture_example(
         // Initialize an empty patch with context lines, to make it easy
         // to write the expected patch by hand.
         let mut expected_patches = Vec::new();
+        let mut rejected_patch = None;
         if populate_expected_patch {
             let mut empty_patch = String::new();
             let start_row = cursor_excerpt_range.start.row + 1;
@@ -93,7 +94,9 @@ pub fn capture_example(
             for line in cursor_excerpt.lines() {
                 writeln!(&mut empty_patch, " {}", line).ok();
             }
-            expected_patches.push(empty_patch);
+
+            expected_patches.push(empty_patch.clone());
+            rejected_patch = Some(empty_patch);
         }
 
         let mut spec = ExampleSpec {
@@ -107,6 +110,7 @@ pub fn capture_example(
             cursor_position: String::new(),
             edit_history,
             expected_patches,
+            rejected_patch,
         };
         spec.set_cursor_excerpt(&cursor_excerpt, cursor_offset, &line_comment_prefix);
         Ok(spec)
@@ -483,27 +487,50 @@ mod tests {
                 .to_string(),
                 expected_patches: vec![
                     indoc! {"
-                    --- a/src/main.rs
-                    +++ b/src/main.rs
-                    @@ -1,16 +1,16 @@
-                     fn main() {
-                         // comment 1
-                         one();
-                         two();
-                         // comment 4
-                         three();
-                         four();
-                         // comment 3
-                         five();
-                         six();
-                         seven();
-                         eight();
-                         // comment 2
-                         nine();
-                     }
-                "}
+                        --- a/src/main.rs
+                        +++ b/src/main.rs
+                        @@ -1,16 +1,16 @@
+                         fn main() {
+                             // comment 1
+                             one();
+                             two();
+                             // comment 4
+                             three();
+                             four();
+                             // comment 3
+                             five();
+                             six();
+                             seven();
+                             eight();
+                             // comment 2
+                             nine();
+                         }
+                    "}
                     .to_string()
-                ]
+                ],
+                rejected_patch: Some(
+                    indoc! {"
+                        --- a/src/main.rs
+                        +++ b/src/main.rs
+                        @@ -1,16 +1,16 @@
+                         fn main() {
+                             // comment 1
+                             one();
+                             two();
+                             // comment 4
+                             three();
+                             four();
+                             // comment 3
+                             five();
+                             six();
+                             seven();
+                             eight();
+                             // comment 2
+                             nine();
+                         }
+                    "}
+                    .to_string()
+                )
             }
         );
     }

--- a/crates/edit_prediction_cli/src/load_project.rs
+++ b/crates/edit_prediction_cli/src/load_project.rs
@@ -254,12 +254,30 @@ async fn setup_worktree(example: &Example, step_progress: &StepProgress) -> Resu
     let worktree_git_dir = repo_dir
         .join(".git/worktrees")
         .join(repo_name.name.as_ref());
-    let index_lock = worktree_git_dir.join("index.lock");
-    if index_lock.exists() {
-        fs::remove_file(&index_lock).ok();
+    for lock_file in &["index.lock", "HEAD.lock", "config.lock"] {
+        let worktree_lock_path = worktree_git_dir.join(lock_file);
+        let repo_lock_path = repo_dir.join(".git").join(lock_file);
+        if worktree_lock_path.exists() {
+            fs::remove_file(&worktree_lock_path).ok();
+        }
+        if repo_lock_path.exists() {
+            fs::remove_file(&repo_lock_path).ok();
+        }
     }
 
-    if !repo_dir.is_dir() {
+    let mut git_repo_exists = false;
+    if repo_dir.is_dir() {
+        if git::run_git(&repo_dir, &["remote", "get-url", "origin"])
+            .await
+            .map_or(false, |origin| origin.trim() == example.spec.repository_url)
+        {
+            git_repo_exists = true;
+        } else {
+            fs::remove_dir_all(&repo_dir).ok();
+        }
+    }
+
+    if !git_repo_exists {
         step_progress.set_substatus(format!("cloning {}", repo_name.name));
         fs::create_dir_all(&repo_dir)?;
         git::run_git(&repo_dir, &["init"]).await?;
@@ -274,14 +292,36 @@ async fn setup_worktree(example: &Example, step_progress: &StepProgress) -> Resu
     step_progress.set_substatus("fetching");
     let revision = git::fetch_if_needed(&repo_dir, &example.spec.revision).await?;
 
+    // Clean up any stale worktree registrations from previous crashed runs.
+    git::run_git(&repo_dir, &["worktree", "prune"]).await.ok();
+
     // Create the worktree for this example if needed.
     step_progress.set_substatus("preparing worktree");
-    if worktree_path.is_dir() {
+
+    // Check if worktree exists and is valid (not just a directory from a crashed run).
+    let worktree_valid = worktree_path.is_dir()
+        && git::run_git(&worktree_path, &["rev-parse", "--git-dir"])
+            .await
+            .is_ok();
+
+    if worktree_valid {
         git::run_git(&worktree_path, &["clean", "--force", "-d"]).await?;
         git::run_git(&worktree_path, &["reset", "--hard", "HEAD"]).await?;
         git::run_git(&worktree_path, &["checkout", revision.as_str()]).await?;
     } else {
         let worktree_path_string = worktree_path.to_string_lossy();
+
+        // Clean up invalid worktree directory and registration if they exist.
+        if worktree_path.exists() {
+            fs::remove_dir_all(&worktree_path).ok();
+        }
+        git::run_git(
+            &repo_dir,
+            &["worktree", "remove", "--force", &worktree_path_string],
+        )
+        .await
+        .ok();
+
         let branch_name = example.spec.filename();
         git::run_git(
             &repo_dir,

--- a/crates/edit_prediction_cli/src/split_commit.rs
+++ b/crates/edit_prediction_cli/src/split_commit.rs
@@ -344,6 +344,7 @@ pub fn generate_evaluation_example_from_ordered_commit(
         tags: vec![],
         reasoning: None,
         uncommitted_diff: String::new(),
+        rejected_patch: None,
     })
 }
 
@@ -1374,6 +1375,7 @@ Date: Mon Jan 1 00:00:00 2024
             tags: vec![],
             reasoning: None,
             uncommitted_diff: String::new(),
+            rejected_patch: None,
         };
 
         let json = serde_json::to_string(&case).unwrap();

--- a/crates/edit_prediction_cli/src/synthesize.rs
+++ b/crates/edit_prediction_cli/src/synthesize.rs
@@ -791,6 +791,7 @@ async fn build_example(
         cursor_position: String::new(),
         edit_history,
         expected_patches: vec![expected_patch_with_header],
+        rejected_patch: None,
     };
     spec.set_cursor_excerpt(&excerpt, cursor_offset, comment_prefix);
 


### PR DESCRIPTION
The `capture example` action now populates the markdown file with a noop "Rejected Patch", so that you can easily specify the good and bad output.

Release Notes:

- N/A
