### PR TITLE
buffer_diff: Avoid usize underflow when computing start overshoot

### DIFF
--- a/crates/buffer_diff/src/buffer_diff.rs
+++ b/crates/buffer_diff/src/buffer_diff.rs
@@ -512,7 +512,9 @@ impl BufferDiffInner<Entity<language::Buffer>> {
 
             // Find where this hunk is in the index if it doesn't overlap
             let mut buffer_offset_range = buffer_range.to_offset(buffer);
-            let start_overshoot = buffer_offset_range.start - prev_unstaged_hunk_buffer_end;
+            let start_overshoot = buffer_offset_range
+                .start
+                .saturating_sub(prev_unstaged_hunk_buffer_end);
             let mut index_start = prev_unstaged_hunk_base_text_end + start_overshoot;
 
             loop {


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/47045

Release Notes:

- buffer_diff: Avoid usize underflow when computing start overshoot

