### PR TITLE
language_models: Add `reasoning_context` for OpenAI compatible providers

### DIFF
--- a/crates/language_models/src/provider/open_ai.rs
+++ b/crates/language_models/src/provider/open_ai.rs
@@ -782,6 +782,14 @@ impl OpenAiEventMapper {
         };
 
         if let Some(delta) = choice.delta.as_ref() {
+            // Handle reasoning_content field (used by OpenAI-compatible providers like Z.ai)
+            if let Some(reasoning_content) = delta.reasoning_content.clone() {
+                events.push(Ok(LanguageModelCompletionEvent::Thinking {
+                    text: reasoning_content,
+                    signature: None,
+                }));
+            }
+
             if let Some(content) = delta.content.clone() {
                 events.push(Ok(LanguageModelCompletionEvent::Text(content)));
             }
@@ -1364,6 +1372,7 @@ mod tests {
         ResponseFunctionToolCall, ResponseOutputItem, ResponseOutputMessage, ResponseStatusDetails,
         ResponseSummary, ResponseUsage, StreamEvent as ResponsesStreamEvent,
     };
+    use open_ai::{ChoiceDelta, ResponseMessageDelta, ResponseStreamEvent};
     use pretty_assertions::assert_eq;
     use serde_json::json;
 

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -455,6 +455,8 @@ pub struct ResponseMessageDelta {
     pub content: Option<String>,
     #[serde(default, skip_serializing_if = "is_none_or_empty")]
     pub tool_calls: Option<Vec<ToolCallChunk>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_content: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]


### PR DESCRIPTION
# Before
<img width="779" height="648" alt="Screenshot From 2026-01-17 12-30-26" src="https://github.com/user-attachments/assets/bca16b3a-4b80-4ca7-bf66-e091e52e4909" />
# After 
<img width="779" height="648" alt="Screenshot From 2026-01-17 12-27-15" src="https://github.com/user-attachments/assets/36fd38ab-e4ba-46e6-9fb9-07bb347a1462" />


Release Notes:

- Show 'Thinking' block for reasoning when model provides it
