### PR TITLE
agent: Check is_error flag in MCP tool responses

### DIFF
--- a/crates/agent/src/tools/context_server_registry.rs
+++ b/crates/agent/src/tools/context_server_registry.rs
@@ -382,6 +382,12 @@ impl AnyAgentTool for ContextServerTool {
                 }
             };
 
+            if response.is_error == Some(true) {
+                let error_message: String =
+                    response.content.iter().filter_map(|c| c.text()).collect();
+                bail!("MCP tool error: {}", error_message);
+            }
+
             let mut result = String::new();
             for content in response.content {
                 match content {

--- a/crates/agent/src/tools/context_server_registry.rs
+++ b/crates/agent/src/tools/context_server_registry.rs
@@ -385,7 +385,7 @@ impl AnyAgentTool for ContextServerTool {
             if response.is_error == Some(true) {
                 let error_message: String =
                     response.content.iter().filter_map(|c| c.text()).collect();
-                bail!(error_message);
+                anyhow::bail!(error_message);
             }
 
             let mut result = String::new();

--- a/crates/agent/src/tools/context_server_registry.rs
+++ b/crates/agent/src/tools/context_server_registry.rs
@@ -385,7 +385,7 @@ impl AnyAgentTool for ContextServerTool {
             if response.is_error == Some(true) {
                 let error_message: String =
                     response.content.iter().filter_map(|c| c.text()).collect();
-                bail!("MCP tool error: {}", error_message);
+                bail!(error_message);
             }
 
             let mut result = String::new();


### PR DESCRIPTION
Previously, when an MCP server returned a tool response with
`is_error: true`, the error content was incorrectly treated as
a successful result. This could mislead the LLM into thinking
the tool call succeeded when it actually failed.

Now we check the `is_error` flag and propagate the error message
properly, allowing the agent to handle failures appropriately.

Release Notes:

- N/A