### PR TITLE
Add `initialization_options_schema` support for extensions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21105,6 +21105,7 @@ dependencies = [
 name = "zed_extension_api"
 version = "0.8.0"
 dependencies = [
+ "async-trait",
  "serde",
  "serde_json",
  "wit-bindgen 0.41.0",

--- a/crates/extension/src/extension.rs
+++ b/crates/extension/src/extension.rs
@@ -87,6 +87,11 @@ pub trait Extension: Send + Sync + 'static {
         worktree: Arc<dyn WorktreeDelegate>,
     ) -> Result<Option<String>>;
 
+    async fn language_server_initialization_options_schema(
+        &self,
+        lsp_binary_path: PathBuf,
+    ) -> Option<String>;
+
     async fn language_server_additional_workspace_configuration(
         &self,
         language_server_id: LanguageServerName,

--- a/crates/extension_api/Cargo.toml
+++ b/crates/extension_api/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 path = "src/extension_api.rs"
 
 [dependencies]
+async-trait.workspace = true
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 wit-bindgen = "0.41"

--- a/crates/extension_api/src/extension_api.rs
+++ b/crates/extension_api/src/extension_api.rs
@@ -5,7 +5,9 @@ pub mod process;
 pub mod settings;
 
 use core::fmt;
+use std::path::PathBuf;
 
+use async_trait::async_trait;
 use wit::*;
 
 pub use serde_json;
@@ -66,6 +68,7 @@ pub fn set_language_server_installation_status(
 }
 
 /// A Zed extension.
+#[async_trait]
 pub trait Extension: Send + Sync {
     /// Returns a new instance of the extension.
     fn new() -> Self
@@ -89,6 +92,14 @@ pub trait Extension: Send + Sync {
         _worktree: &Worktree,
     ) -> Result<Option<serde_json::Value>> {
         Ok(None)
+    }
+
+    /// Returns the JSON schema of the initialization_options for the language server.
+    fn language_server_initialization_options_schema(
+        &self,
+        _binary_path: String,
+    ) -> Option<String> {
+        None
     }
 
     /// Returns the workspace configuration options to pass to the language server.
@@ -358,6 +369,10 @@ impl wit::Guest for Component {
         Ok(extension()
             .language_server_initialization_options(&language_server_id, worktree)?
             .and_then(|value| serde_json::to_string(&value).ok()))
+    }
+
+    fn language_server_initialization_options_schema(binary_path: String) -> Option<String> {
+        extension().language_server_initialization_options_schema(binary_path)
     }
 
     fn language_server_workspace_configuration(

--- a/crates/extension_api/wit/since_v0.8.0/extension.wit
+++ b/crates/extension_api/wit/since_v0.8.0/extension.wit
@@ -96,6 +96,9 @@ world extension {
     /// The initialization options are represented as a JSON string.
     export language-server-initialization-options: func(language-server-id: string, worktree: borrow<worktree>) -> result<option<string>, string>;
 
+    /// Returns the JSON schema for the initialization_options.
+    export language-server-initialization-options-schema: func(binary-path: string) -> option<string>;
+
     /// Returns the workspace configuration options to pass to the language server.
     export language-server-workspace-configuration: func(language-server-id: string, worktree: borrow<worktree>) -> result<option<string>, string>;
 

--- a/crates/extension_api/wit/since_v0.8.0/settings.rs
+++ b/crates/extension_api/wit/since_v0.8.0/settings.rs
@@ -14,6 +14,7 @@ pub struct LspSettings {
     /// The settings for the language server binary.
     pub binary: Option<CommandSettings>,
     /// The initialization options to pass to the language server.
+    // TODO: Adjust this
     pub initialization_options: Option<serde_json::Value>,
     /// The settings to pass to language server.
     pub settings: Option<serde_json::Value>,

--- a/crates/extension_host/src/wasm_host.rs
+++ b/crates/extension_host/src/wasm_host.rs
@@ -40,6 +40,7 @@ use std::{
     time::Duration,
 };
 use task::{DebugScenario, SpawnInTerminal, TaskTemplate, ZedDebugConfig};
+use util::ResultExt;
 use util::paths::SanitizedPath;
 use wasmtime::{
     CacheStore, Engine, Store,
@@ -137,6 +138,23 @@ impl extension::Extension for WasmExtension {
             .boxed()
         })
         .await?
+    }
+
+    async fn language_server_initialization_options_schema(
+        &self,
+        lsp_binary_path: PathBuf,
+    ) -> Option<String> {
+        let binary_path = lsp_binary_path.to_string_lossy().to_string();
+        self.call(|extension, store| {
+            async move {
+                extension
+                    .call_language_server_initialization_options_schema(store, binary_path)
+                    .await
+            }
+            .boxed()
+        })
+        .await
+        .log_err()?
     }
 
     async fn language_server_workspace_configuration(

--- a/crates/extension_host/src/wasm_host/wit.rs
+++ b/crates/extension_host/src/wasm_host/wit.rs
@@ -390,6 +390,28 @@ impl Extension {
         }
     }
 
+    pub async fn call_language_server_initialization_options_schema(
+        &self,
+        store: &mut Store<WasmState>,
+        binary_path: String,
+    ) -> Option<String> {
+        match self {
+            Extension::V0_8_0(ext) => ext
+                .call_language_server_initialization_options_schema(store, &binary_path)
+                .await
+                .ok()?,
+            Extension::V0_6_0(_)
+            | Extension::V0_5_0(_)
+            | Extension::V0_4_0(_)
+            | Extension::V0_3_0(_)
+            | Extension::V0_2_0(_)
+            | Extension::V0_1_0(_)
+            | Extension::V0_0_6(_)
+            | Extension::V0_0_4(_)
+            | Extension::V0_0_1(_) => None,
+        }
+    }
+
     pub async fn call_language_server_workspace_configuration(
         &self,
         store: &mut Store<WasmState>,

--- a/crates/language_extension/src/extension_lsp_adapter.rs
+++ b/crates/language_extension/src/extension_lsp_adapter.rs
@@ -349,6 +349,23 @@ impl LspAdapter for ExtensionLspAdapter {
         })
     }
 
+    async fn initialization_options_schema(
+        self: Arc<Self>,
+        language_server_binary: &LanguageServerBinary,
+    ) -> Option<serde_json::Value> {
+        let schema_json = self
+            .extension
+            .language_server_initialization_options_schema(language_server_binary.path.clone())
+            .await?;
+        serde_json::from_str(&schema_json)
+            .with_context(|| {
+                format!(
+                    "failed to parse initialization_options_schema from extension: {schema_json}"
+                )
+            })
+            .log_err()
+    }
+
     async fn additional_initialization_options(
         self: Arc<Self>,
         target_language_server_id: LanguageServerName,


### PR DESCRIPTION
Follow-up for #18287

Release Notes:

- Added initialization_options_schema support for extensions

Things left TODO:
- [ ] Settings schema support
- [ ] Spawn task for extension initialization_options_schema fetching to not block async executor
