### PR TITLE
Fix inverted char boundary check causing invalid offsets

### DIFF
--- a/crates/text/src/text.rs
+++ b/crates/text/src/text.rs
@@ -2417,7 +2417,7 @@ impl BufferSnapshot {
         {
             Anchor::max_for_buffer(self.remote_id)
         } else {
-            if self
+            if !self
                 .visible_text
                 .assert_char_boundary::<{ cfg!(debug_assertions) }>(offset)
             {
@@ -3125,7 +3125,7 @@ impl ToOffset for Point {
 impl ToOffset for usize {
     #[track_caller]
     fn to_offset(&self, snapshot: &BufferSnapshot) -> usize {
-        if snapshot
+        if !snapshot
             .as_rope()
             .assert_char_boundary::<{ cfg!(debug_assertions) }>(*self)
         {


### PR DESCRIPTION
The logic in `anchor_at_offset` and `to_offset` seems inverted when checking character boundaries. `assert_char_boundary` returns `true` when the offset IS valid, but the code was adjusting offsets when the function returned `true` (valid) instead of `false` (invalid).

Release Notes:

- N/A