### PR TITLE
terminal: Clear hovered link when no target found

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -1181,6 +1181,7 @@ impl Terminal {
                         self.process_hyperlink(hyperlink, *open, cx);
                     }
                     None => {
+                        self.last_content.last_hovered_word = None;
                         cx.emit(Event::NewNavigationTarget(None));
                     }
                 }


### PR DESCRIPTION
Release Notes:

- Fixed clear hovered link when no target found
