### PR TITLE
agent: Make sure ACP still gets classic tool permission UI

### DIFF
--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -1070,7 +1070,7 @@ impl acp::Client for ClientDelegate {
         let task = thread.update(cx, |thread, cx| {
             thread.request_tool_call_authorization(
                 arguments.tool_call,
-                arguments.options,
+                acp_thread::PermissionOptions::Flat(arguments.options),
                 respect_always_allow_setting,
                 cx,
             )


### PR DESCRIPTION
This makes sure all of the new granular permission logic and ui only applies to the zed agent and doesn't affect the UI of external agents.

Release Notes:

- N/A
