### PR TITLE
languages: Add attribute highlighting in C

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17560,9 +17560,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-c"
-version = "0.23.4"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afd2b1bf1585dc2ef6d69e87d01db8adb059006649dd5f96f31aa789ee6e9c71"
+checksum = "1a3aad8f0129083a59fe8596157552d2bb7148c492d44c21558d68ca1c722707"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -682,7 +682,7 @@ toml_edit = { version = "0.22", default-features = false, features = ["display",
 tower-http = "0.4.4"
 tree-sitter = { version = "0.26", features = ["wasm"] }
 tree-sitter-bash = "0.25.1"
-tree-sitter-c = "0.23"
+tree-sitter-c = "0.24.1"
 tree-sitter-cpp = { git = "https://github.com/tree-sitter/tree-sitter-cpp", rev = "5cb9b693cfd7bfacab1d9ff4acac1a4150700609" }
 tree-sitter-css = "0.23"
 tree-sitter-diff = "0.1.0"

--- a/crates/languages/src/c/highlights.scm
+++ b/crates/languages/src/c/highlights.scm
@@ -134,3 +134,16 @@
   (primitive_type)
   (sized_type_specifier)
 ] @type
+
+; GNU __attribute__
+(attribute_specifier) @attribute
+(attribute_specifier
+  (argument_list
+    (identifier) @attribute))
+
+; C23 [[attributes]]
+(attribute_declaration) @attribute
+(attribute
+  prefix: (identifier) @attribute)
+(attribute
+  name: (identifier) @attribute)

--- a/crates/languages/src/c/highlights.scm
+++ b/crates/languages/src/c/highlights.scm
@@ -142,7 +142,6 @@
     (identifier) @attribute))
 
 ; C23 [[attributes]]
-(attribute_declaration) @attribute
 (attribute
   prefix: (identifier) @attribute)
 (attribute


### PR DESCRIPTION
Closes #46125.

Before:
<img width="716" height="367" alt="before" src="https://github.com/user-attachments/assets/ce96d3bc-9e90-4eb7-9309-37cc9599e9d9" />

After:
<img width="690" height="345" alt="after" src="https://github.com/user-attachments/assets/5d8c84a4-5fe8-4f7c-9e4f-137b5f077171" />

Release Notes:

- Updated tree-sitter-c for highlighting attribute specifier in C
