### PR TITLE
settings_ui: Prevent panic when trying to configure edit prediction providers for language

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15035,6 +15035,7 @@ dependencies = [
  "fuzzy",
  "gpui",
  "heck 0.5.0",
+ "itertools 0.14.0",
  "language",
  "language_models",
  "log",

--- a/crates/settings_ui/Cargo.toml
+++ b/crates/settings_ui/Cargo.toml
@@ -27,6 +27,7 @@ fs.workspace = true
 fuzzy.workspace = true
 gpui.workspace = true
 heck.workspace = true
+itertools.workspace = true
 log.workspace = true
 menu.workspace = true
 paths.workspace = true

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -2928,7 +2928,7 @@ fn languages_and_tools_page(cx: &App) -> SettingsPage {
                             non_editor_language_settings_data(),
                             edit_prediction_language_settings_section()
                         );
-                        this.render_sub_page_items(items.iter().enumerate(), None, window, cx)
+                        this.render_sub_page_items(items.iter().enumerate(), window, cx)
                             .into_any_element()
                     }),
                 })

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -2,11 +2,12 @@ use gpui::{Action as _, App};
 use settings::{LanguageSettingsContent, SettingsContent};
 use std::sync::Arc;
 use strum::IntoDiscriminant as _;
-use ui::{IntoElement, SharedString};
+use ui::IntoElement;
 
 use crate::{
     ActionLink, DynamicItem, PROJECT, SettingField, SettingItem, SettingsFieldMetadata,
-    SettingsPage, SettingsPageItem, SubPageLink, USER, all_language_names, sub_page_stack,
+    SettingsPage, SettingsPageItem, SubPageLink, USER, active_language, all_language_names,
+    pages::render_edit_prediction_setup_page,
 };
 
 const DEFAULT_STRING: String = String::new();
@@ -2913,24 +2914,30 @@ fn languages_and_tools_page(cx: &App) -> SettingsPage {
     fn languages_list_section(cx: &App) -> Box<[SettingsPageItem]> {
         // todo(settings_ui): Refresh on extension (un)/installed
         // Note that `crates/json_schema_store` solves the same problem, there is probably a way to unify the two
-        std::iter::once(SettingsPageItem::SectionHeader(LANGUAGES_SECTION_HEADER))
+        std::iter::once(SettingsPageItem::SectionHeader("Languages"))
             .chain(all_language_names(cx).into_iter().map(|language_name| {
                 let link = format!("languages.{language_name}");
                 SettingsPageItem::SubPageLink(SubPageLink {
                     title: language_name,
+                    r#type: crate::SubPageType::Language,
                     description: None,
                     json_path: Some(link.leak()),
                     in_json: true,
                     files: USER | PROJECT,
-                    render: Arc::new(|this, window, cx| {
+                    render: |this, scroll_handle, window, cx| {
                         let items: Box<[SettingsPageItem]> = concat_sections!(
                             language_settings_data(),
                             non_editor_language_settings_data(),
                             edit_prediction_language_settings_section()
                         );
-                        this.render_sub_page_items(items.iter().enumerate(), window, cx)
-                            .into_any_element()
-                    }),
+                        this.render_sub_page_items(
+                            items.iter().enumerate(),
+                            scroll_handle,
+                            window,
+                            cx,
+                        )
+                        .into_any_element()
+                    },
                 })
             }))
             .collect()
@@ -7168,33 +7175,21 @@ fn network_page() -> SettingsPage {
     }
 }
 
-const LANGUAGES_SECTION_HEADER: &'static str = "Languages";
-
-fn current_language() -> Option<SharedString> {
-    sub_page_stack().iter().find_map(|page| {
-        (page.section_header == LANGUAGES_SECTION_HEADER).then(|| page.link.title.clone())
-    })
-}
-
 fn language_settings_field<T>(
     settings_content: &SettingsContent,
-    get: fn(&LanguageSettingsContent) -> Option<&T>,
+    get_language_setting_field: fn(&LanguageSettingsContent) -> Option<&T>,
 ) -> Option<&T> {
     let all_languages = &settings_content.project.all_languages;
-    if let Some(current_language_name) = current_language() {
-        if let Some(current_language) = all_languages
-            .languages
-            .0
-            .get(current_language_name.as_ref())
-        {
-            let value = get(current_language);
-            if value.is_some() {
-                return value;
-            }
-        }
-    }
-    let default_value = get(&all_languages.defaults);
-    return default_value;
+
+    active_language()
+        .and_then(|current_language_name| {
+            all_languages
+                .languages
+                .0
+                .get(current_language_name.as_ref())
+        })
+        .and_then(get_language_setting_field)
+        .or_else(|| get_language_setting_field(&all_languages.defaults))
 }
 
 fn language_settings_field_mut<T>(
@@ -7203,7 +7198,7 @@ fn language_settings_field_mut<T>(
     write: fn(&mut LanguageSettingsContent, Option<T>),
 ) {
     let all_languages = &mut settings_content.project.all_languages;
-    let language_content = if let Some(current_language) = current_language() {
+    let language_content = if let Some(current_language) = active_language() {
         all_languages
             .languages
             .0
@@ -8382,7 +8377,7 @@ fn language_settings_data() -> Box<[SettingsPageItem]> {
         ]
     }
 
-    let is_global = current_language().is_none();
+    let is_global = active_language().is_none();
 
     let lsp_document_colors_item = [SettingsPageItem::SettingItem(SettingItem {
         title: "LSP Document Colors",
@@ -8724,17 +8719,12 @@ fn edit_prediction_language_settings_section() -> [SettingsPageItem; 4] {
         SettingsPageItem::SectionHeader("Edit Predictions"),
         SettingsPageItem::SubPageLink(SubPageLink {
             title: "Configure Providers".into(),
+            r#type: Default::default(),
             json_path: Some("edit_predictions.providers"),
             description: Some("Set up different edit prediction providers in complement to Zed's built-in Zeta model.".into()),
             in_json: false,
             files: USER,
-            render: Arc::new(|_, window, cx| {
-                let settings_window = cx.entity();
-                let page = window.use_state(cx, |_, _| {
-                    crate::pages::EditPredictionSetupPage::new(settings_window)
-                });
-                page.into_any_element()
-            }),
+            render: render_edit_prediction_setup_page
         }),
         SettingsPageItem::SettingItem(SettingItem {
             title: "Show Edit Predictions",

--- a/crates/settings_ui/src/pages.rs
+++ b/crates/settings_ui/src/pages.rs
@@ -1,2 +1,2 @@
 mod edit_prediction_provider_setup;
-pub use edit_prediction_provider_setup::EditPredictionSetupPage;
+pub(crate) use edit_prediction_provider_setup::render_edit_prediction_setup_page;

--- a/crates/settings_ui/src/pages/edit_prediction_provider_setup.rs
+++ b/crates/settings_ui/src/pages/edit_prediction_provider_setup.rs
@@ -27,7 +27,7 @@ pub(crate) fn render_edit_prediction_setup_page(
     });
     let providers = [
         project.and_then(|project| {
-            Some(render_github_copilot_provider(project, window, cx)?.into_any_element())
+            render_github_copilot_provider(project, window, cx).map(IntoElement::into_any_element)
         }),
         cx.has_flag::<MercuryFeatureFlag>().then(|| {
             render_api_key_provider(

--- a/crates/settings_ui/src/pages/edit_prediction_provider_setup.rs
+++ b/crates/settings_ui/src/pages/edit_prediction_provider_setup.rs
@@ -82,7 +82,6 @@ impl Render for EditPredictionSetupPage {
                         settings_window
                             .render_sub_page_items_section(
                                 codestral_settings.iter().enumerate(),
-                                None,
                                 window,
                                 cx,
                             )

--- a/crates/settings_ui/src/pages/edit_prediction_provider_setup.rs
+++ b/crates/settings_ui/src/pages/edit_prediction_provider_setup.rs
@@ -7,108 +7,91 @@ use feature_flags::FeatureFlagAppExt as _;
 use gpui::{Entity, ScrollHandle, prelude::*};
 use language_models::provider::mistral::{CODESTRAL_API_URL, codestral_api_key};
 use project::Project;
-use ui::{ButtonLink, ConfiguredApiCard, WithScrollbar, prelude::*};
+use ui::{ButtonLink, ConfiguredApiCard, prelude::*};
 
 use crate::{
     SettingField, SettingItem, SettingsFieldMetadata, SettingsPageItem, SettingsWindow, USER,
     components::{SettingsInputField, SettingsSectionHeader},
 };
 
-pub struct EditPredictionSetupPage {
-    settings_window: Entity<SettingsWindow>,
-    scroll_handle: ScrollHandle,
-}
-
-impl EditPredictionSetupPage {
-    pub fn new(settings_window: Entity<SettingsWindow>) -> Self {
-        Self {
-            settings_window,
-            scroll_handle: ScrollHandle::new(),
-        }
-    }
-}
-
-impl Render for EditPredictionSetupPage {
-    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let settings_window = self.settings_window.clone();
-        let project = settings_window
-            .read(cx)
-            .original_window
-            .as_ref()
-            .and_then(|window| {
-                window
-                    .read_with(cx, |workspace, _| workspace.project().clone())
-                    .ok()
-            });
-        let providers = [
-            project.and_then(|project| {
-                Some(render_github_copilot_provider(project, window, cx)?.into_any_element())
-            }),
-            cx.has_flag::<MercuryFeatureFlag>().then(|| {
-                render_api_key_provider(
-                    IconName::Inception,
-                    "Mercury",
-                    "https://platform.inceptionlabs.ai/dashboard/api-keys".into(),
-                    mercury_api_token(cx),
-                    |_cx| MERCURY_CREDENTIALS_URL,
-                    None,
-                    window,
-                    cx,
-                )
-                .into_any_element()
-            }),
-            cx.has_flag::<SweepFeatureFlag>().then(|| {
-                render_api_key_provider(
-                    IconName::SweepAi,
-                    "Sweep",
-                    "https://app.sweep.dev/".into(),
-                    sweep_api_token(cx),
-                    |_cx| SWEEP_CREDENTIALS_URL,
-                    None,
-                    window,
-                    cx,
-                )
-                .into_any_element()
-            }),
-            Some(
-                render_api_key_provider(
-                    IconName::AiMistral,
-                    "Codestral",
-                    "https://console.mistral.ai/codestral".into(),
-                    codestral_api_key(cx),
-                    |cx| language_models::MistralLanguageModelProvider::api_url(cx),
-                    Some(settings_window.update(cx, |settings_window, cx| {
-                        let codestral_settings = codestral_settings();
-                        settings_window
-                            .render_sub_page_items_section(
-                                codestral_settings.iter().enumerate(),
-                                window,
-                                cx,
-                            )
-                            .into_any_element()
-                    })),
-                    window,
-                    cx,
-                )
-                .into_any_element(),
-            ),
-        ];
-
-        div()
-            .size_full()
-            .vertical_scrollbar_for(&self.scroll_handle, window, cx)
-            .child(
-                v_flex()
-                    .id("ep-setup-page")
-                    .min_w_0()
-                    .size_full()
-                    .px_8()
-                    .pb_16()
-                    .overflow_y_scroll()
-                    .track_scroll(&self.scroll_handle)
-                    .children(providers.into_iter().flatten()),
+pub(crate) fn render_edit_prediction_setup_page(
+    settings_window: &SettingsWindow,
+    scroll_handle: &ScrollHandle,
+    window: &mut Window,
+    cx: &mut Context<SettingsWindow>,
+) -> AnyElement {
+    let project = settings_window.original_window.as_ref().and_then(|window| {
+        window
+            .read_with(cx, |workspace, _| workspace.project().clone())
+            .ok()
+    });
+    let providers = [
+        project.and_then(|project| {
+            Some(render_github_copilot_provider(project, window, cx)?.into_any_element())
+        }),
+        cx.has_flag::<MercuryFeatureFlag>().then(|| {
+            render_api_key_provider(
+                IconName::Inception,
+                "Mercury",
+                "https://platform.inceptionlabs.ai/dashboard/api-keys".into(),
+                mercury_api_token(cx),
+                |_cx| MERCURY_CREDENTIALS_URL,
+                None,
+                window,
+                cx,
             )
-    }
+            .into_any_element()
+        }),
+        cx.has_flag::<SweepFeatureFlag>().then(|| {
+            render_api_key_provider(
+                IconName::SweepAi,
+                "Sweep",
+                "https://app.sweep.dev/".into(),
+                sweep_api_token(cx),
+                |_cx| SWEEP_CREDENTIALS_URL,
+                None,
+                window,
+                cx,
+            )
+            .into_any_element()
+        }),
+        Some(
+            render_api_key_provider(
+                IconName::AiMistral,
+                "Codestral",
+                "https://console.mistral.ai/codestral".into(),
+                codestral_api_key(cx),
+                |cx| language_models::MistralLanguageModelProvider::api_url(cx),
+                Some(
+                    settings_window
+                        .render_sub_page_items_section(
+                            codestral_settings().iter().enumerate(),
+                            window,
+                            cx,
+                        )
+                        .into_any_element(),
+                ),
+                window,
+                cx,
+            )
+            .into_any_element(),
+        ),
+    ];
+
+    div()
+        .size_full()
+        .child(
+            v_flex()
+                .id("ep-setup-page")
+                .min_w_0()
+                .size_full()
+                .px_8()
+                .pb_16()
+                .overflow_y_scroll()
+                .track_scroll(&scroll_handle)
+                .children(providers.into_iter().flatten()),
+        )
+        .into_any_element()
 }
 
 fn render_api_key_provider(
@@ -119,7 +102,7 @@ fn render_api_key_provider(
     current_url: fn(&mut App) -> SharedString,
     additional_fields: Option<AnyElement>,
     window: &mut Window,
-    cx: &mut Context<EditPredictionSetupPage>,
+    cx: &mut Context<SettingsWindow>,
 ) -> impl IntoElement {
     let weak_page = cx.weak_entity();
     _ = window.use_keyed_state(title, cx, |_, cx| {

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -2658,7 +2658,7 @@ impl SettingsWindow {
         if self.navbar_entries[navbar_entry_index].is_root
             || !self.is_nav_entry_visible(navbar_entry_index)
         {
-            if let Some(scroll_handle) = self.sub_page_scroll_handle() {
+            if let Some(scroll_handle) = self.current_sub_page_scroll_handle() {
                 scroll_handle.set_offset(point(px(0.), px(0.)));
             }
 
@@ -2732,7 +2732,7 @@ impl SettingsWindow {
             .position(|(index, _)| index == content_item_index)
             .unwrap_or(0);
         if index == 0 {
-            if let Some(scroll_handle) = self.sub_page_scroll_handle() {
+            if let Some(scroll_handle) = self.current_sub_page_scroll_handle() {
                 scroll_handle.set_offset(point(px(0.), px(0.)));
             }
 
@@ -2783,7 +2783,7 @@ impl SettingsWindow {
         cx.notify();
     }
 
-    fn sub_page_scroll_handle(&self) -> Option<&ScrollHandle> {
+    fn current_sub_page_scroll_handle(&self) -> Option<&ScrollHandle> {
         self.sub_page_stack.last().map(|page| &page.scroll_handle)
     }
 

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -743,6 +743,9 @@ impl Drop for SubPage {
     fn drop(&mut self) {
         if self.link.r#type == SubPageType::Language
             && let Some(mut active_language_global) = active_language_mut()
+            && active_language_global
+                .as_ref()
+                .is_some_and(|language_name| language_name == &self.link.title)
         {
             active_language_global.take();
         }

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -666,8 +666,7 @@ fn active_language() -> Option<SharedString> {
     ACTIVE_LANGUAGE
         .read()
         .ok()
-        .map(|language| language.clone())
-        .flatten()
+        .and_then(|language| language.clone())
 }
 
 fn active_language_mut() -> Option<std::sync::RwLockWriteGuard<'static, Option<SharedString>>> {


### PR DESCRIPTION
Closes #46502

The issue here was that we were not looking into the sub page stack when looking headers up, resulting in an out of bounds index. This PR fixes this.

Due to me also fixing another small bug in the UI (and adding proper support for the breadcrumbs), I had to move quite some stuff around here to get this to work. Namely, I made the `sub_page_stack` a field on the `SettingsWindow` and now only store the `active_language` in a global to ensure that we store scroll positions properly for all sub pages. For that to work with the edit prediction provider page, I had to remove the struct there and could just move that into a method, which was a nice side effect there I suppose.

Release Notes:

- Fixed a crash that could occur when trying to edit edit prediction providers in the settings UI.
