### PR TITLE
typescript: Fix type import highlighting when alias is not present

### DIFF
--- a/crates/languages/src/typescript/highlights.scm
+++ b/crates/languages/src/typescript/highlights.scm
@@ -98,10 +98,27 @@
        (statement_block) @nested
      ])))
 
+; Inline type imports: import { type Foo } or import { type Foo as Bar }
 (import_specifier
   "type"
   name: (identifier) @type
+)
+
+(import_specifier
+  "type"
   alias: (identifier) @type
+)
+
+; Full type imports: import type { Foo } or import type { Foo as Bar }
+(import_statement
+  "type"
+  (import_clause
+    (named_imports
+      (import_specifier
+        name: (identifier) @type
+      )
+    )
+  )
 )
 
 (import_statement
@@ -109,7 +126,6 @@
   (import_clause
     (named_imports
       (import_specifier
-        name: (identifier) @type
         alias: (identifier) @type
       )
     )


### PR DESCRIPTION
## Problem
The existing tree-sitter queries for type imports required both name and alias fields to match. This caused `import type { Foo }` and `import { type Foo }` to fall back to the generic identifier/variable highlighting instead of being colored as types.

- `import type { Foo }` → **NOT matched** (no alias)
- `import { type Foo }` → **NOT matched** (no alias)  
- `import type { Foo as Bar }` → Matched ✓
- `import { type Foo as Bar }` → Matched ✓

## Solution
Split the patterns to handle name and alias captures independently.

~## Disclaimer~
~DEBUGGING AND IMPLEMENTATION WAS DONE WITH **AI ASSISTANCE**.~
~**THE FIX HAS NOT BEEN TESTED** - I HAVE NOT COMPILED FROM SOURCE~
- @KyleBarton built from source and verified


Release Notes:

- Fixed typescript type import highlighting
