### PR TITLE
rope: Add missing early return in `log_err_char_boundary`

### DIFF
--- a/crates/rope/src/chunk.rs
+++ b/crates/rope/src/chunk.rs
@@ -728,6 +728,7 @@ fn log_err_char_boundary(text: &str, offset: usize) {
             text,
             text.len()
         );
+        return;
     }
     // find the character
     let char_start = text.floor_char_boundary(offset);


### PR DESCRIPTION
Closes ZED-465

Release Notes:

- N/A *or* Added/Fixed/Improved ...
