### PR TITLE
gpui_linux: Add name/description to display for wayland

### DIFF
--- a/crates/gpui/examples/layer_shell.rs
+++ b/crates/gpui/examples/layer_shell.rs
@@ -26,7 +26,8 @@ mod example {
 
     use gpui::{
         App, Bounds, Context, FontWeight, Size, Window, WindowBackgroundAppearance, WindowBounds,
-        WindowKind, WindowOptions, div, layer_shell::*, point, prelude::*, px, rems, rgba, white,
+        WindowKind, WindowOptions, div, layer_shell::*, point, prelude::*, px, rems, rgba,
+        white,
     };
     use gpui_platform::application;
 
@@ -75,42 +76,32 @@ mod example {
 
     pub fn main() {
         application().run(|cx: &mut App| {
-            cx.spawn(async move |cx| {
-                // Outputs are reported asynchronously by the wayland backend, so we need to wait
-                // for all outputs to be present before we can iterate over them.
-                cx.background_executor()
-                    .timer(Duration::from_millis(1))
-                    .await;
+            for display in cx.displays() {
+                println!("Opening window on {:?}", display.name());
 
-                let displays = cx.update(|cx| cx.displays());
-                displays.iter().for_each(|display| {
-                    println!("Opening window on {:?}", display.name());
-
-                    cx.open_window(
-                        WindowOptions {
-                            titlebar: None,
-                            window_bounds: Some(WindowBounds::Windowed(Bounds {
-                                origin: point(px(0.), px(0.)),
-                                size: Size::new(px(500.), px(200.)),
-                            })),
-                            display_id: Some(display.id()),
-                            app_id: Some("gpui-layer-shell-example".to_string()),
-                            window_background: WindowBackgroundAppearance::Transparent,
-                            kind: WindowKind::LayerShell(LayerShellOptions {
-                                namespace: "gpui".to_string(),
-                                anchor: Anchor::LEFT | Anchor::RIGHT | Anchor::BOTTOM,
-                                margin: Some((px(0.), px(0.), px(40.), px(0.))),
-                                keyboard_interactivity: KeyboardInteractivity::None,
-                                ..Default::default()
-                            }),
+                cx.open_window(
+                    WindowOptions {
+                        titlebar: None,
+                        window_bounds: Some(WindowBounds::Windowed(Bounds {
+                            origin: point(px(0.), px(0.)),
+                            size: Size::new(px(500.), px(200.)),
+                        })),
+                        display_id: Some(display.id()),
+                        app_id: Some("gpui-layer-shell-example".to_string()),
+                        window_background: WindowBackgroundAppearance::Transparent,
+                        kind: WindowKind::LayerShell(LayerShellOptions {
+                            namespace: "gpui".to_string(),
+                            anchor: Anchor::LEFT | Anchor::RIGHT | Anchor::BOTTOM,
+                            margin: Some((px(0.), px(0.), px(40.), px(0.))),
+                            keyboard_interactivity: KeyboardInteractivity::None,
                             ..Default::default()
-                        },
-                        |_, cx| cx.new(LayerShellExample::new),
-                    )
-                    .unwrap();
-                });
-            })
-            .detach();
+                        }),
+                        ..Default::default()
+                    },
+                    |_, cx| cx.new(LayerShellExample::new),
+                )
+                .unwrap();
+            }
         });
     }
 }

--- a/crates/gpui/examples/layer_shell.rs
+++ b/crates/gpui/examples/layer_shell.rs
@@ -75,27 +75,42 @@ mod example {
 
     pub fn main() {
         application().run(|cx: &mut App| {
-            cx.open_window(
-                WindowOptions {
-                    titlebar: None,
-                    window_bounds: Some(WindowBounds::Windowed(Bounds {
-                        origin: point(px(0.), px(0.)),
-                        size: Size::new(px(500.), px(200.)),
-                    })),
-                    app_id: Some("gpui-layer-shell-example".to_string()),
-                    window_background: WindowBackgroundAppearance::Transparent,
-                    kind: WindowKind::LayerShell(LayerShellOptions {
-                        namespace: "gpui".to_string(),
-                        anchor: Anchor::LEFT | Anchor::RIGHT | Anchor::BOTTOM,
-                        margin: Some((px(0.), px(0.), px(40.), px(0.))),
-                        keyboard_interactivity: KeyboardInteractivity::None,
-                        ..Default::default()
-                    }),
-                    ..Default::default()
-                },
-                |_, cx| cx.new(LayerShellExample::new),
-            )
-            .unwrap();
+            cx.spawn(async move |cx| {
+                // Outputs are reported asynchronously by the wayland backend, so we need to wait
+                // for all outputs to be present before we can iterate over them.
+                cx.background_executor()
+                    .timer(Duration::from_millis(1))
+                    .await;
+
+                let displays = cx.update(|cx| cx.displays());
+                displays.iter().for_each(|display| {
+                    println!("Opening window on {:?}", display.name());
+
+                    cx.open_window(
+                        WindowOptions {
+                            titlebar: None,
+                            window_bounds: Some(WindowBounds::Windowed(Bounds {
+                                origin: point(px(0.), px(0.)),
+                                size: Size::new(px(500.), px(200.)),
+                            })),
+                            display_id: Some(display.id()),
+                            app_id: Some("gpui-layer-shell-example".to_string()),
+                            window_background: WindowBackgroundAppearance::Transparent,
+                            kind: WindowKind::LayerShell(LayerShellOptions {
+                                namespace: "gpui".to_string(),
+                                anchor: Anchor::LEFT | Anchor::RIGHT | Anchor::BOTTOM,
+                                margin: Some((px(0.), px(0.), px(40.), px(0.))),
+                                keyboard_interactivity: KeyboardInteractivity::None,
+                                ..Default::default()
+                            }),
+                            ..Default::default()
+                        },
+                        |_, cx| cx.new(LayerShellExample::new),
+                    )
+                    .unwrap();
+                });
+            })
+            .detach();
         });
     }
 }

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -257,6 +257,21 @@ pub trait PlatformDisplay: Debug {
         let origin = point(center.x - offset.width, center.y - offset.height);
         Bounds::new(origin, clipped_window_size)
     }
+
+    /// Get the user-friendly name of this display. Guaranteed to be unique by the
+    /// compositor, but may change across restarts.
+    /// Examples: "HDMI-A-1", "DP-1", "eDP-1"
+    #[cfg(all(target_os = "linux", feature = "wayland"))]
+    fn name(&self) -> Option<&str> {
+        None
+    }
+
+    /// Get a human-readable description of this display, usually a model name. This is not
+    /// guaranteed to be unique, and may not be present for all compositors.
+    #[cfg(all(target_os = "linux", feature = "wayland"))]
+    fn description(&self) -> Option<&str> {
+        None
+    }
 }
 
 /// Thermal state of the system

--- a/crates/gpui_linux/src/linux/wayland/client.rs
+++ b/crates/gpui_linux/src/linux/wayland/client.rs
@@ -738,7 +738,6 @@ impl LinuxClient for WaylandClient {
         let mut state = self.0.borrow_mut();
 
         let parent = state.keyboard_focused_window.clone();
-
         let target_output = params.display_id.and_then(|display_id| {
             let target_protocol_id: u32 = display_id.into();
             state

--- a/crates/gpui_linux/src/linux/wayland/client.rs
+++ b/crates/gpui_linux/src/linux/wayland/client.rs
@@ -468,7 +468,8 @@ impl WaylandClient {
     pub(crate) fn new() -> Self {
         let conn = Connection::connect_to_env().unwrap();
 
-        let (globals, event_queue) = registry_queue_init::<WaylandClientStatePtr>(&conn).unwrap();
+        let (globals, mut event_queue) =
+            registry_queue_init::<WaylandClientStatePtr>(&conn).unwrap();
         let qh = event_queue.handle();
 
         let mut seat: Option<wl_seat::WlSeat> = None;
@@ -656,6 +657,14 @@ impl WaylandClient {
             pending_activation: None,
             event_loop: Some(event_loop),
         }));
+
+        // The initial registry roundtrip discovers and binds wl_output globals, but their
+        // property events (Name, Geometry, Mode, Scale, Done) are queued server-side. This
+        // extra roundtrip ensures all output events are delivered before we return, so
+        // displays() returns the full list immediately after init.
+        event_queue
+            .roundtrip(&mut WaylandClientStatePtr(Rc::downgrade(&state)))
+            .unwrap();
 
         WaylandSource::new(conn, event_queue)
             .insert(handle)

--- a/crates/gpui_linux/src/linux/wayland/client.rs
+++ b/crates/gpui_linux/src/linux/wayland/client.rs
@@ -179,6 +179,7 @@ impl Globals {
 #[derive(Default, Debug, Clone, PartialEq, Eq, Hash)]
 pub struct InProgressOutput {
     name: Option<String>,
+    description: Option<String>,
     scale: Option<i32>,
     position: Option<Point<DevicePixels>>,
     size: Option<Size<DevicePixels>>,
@@ -190,6 +191,7 @@ impl InProgressOutput {
             let scale = self.scale.unwrap_or(1);
             Some(Output {
                 name: self.name.clone(),
+                description: self.description.clone(),
                 scale,
                 bounds: Bounds::new(position, size),
             })
@@ -202,6 +204,7 @@ impl InProgressOutput {
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct Output {
     pub name: Option<String>,
+    pub description: Option<String>,
     pub scale: i32,
     pub bounds: Bounds<DevicePixels>,
 }
@@ -676,6 +679,7 @@ impl LinuxClient for WaylandClient {
                 Rc::new(WaylandDisplay {
                     id: id.clone(),
                     name: output.name.clone(),
+                    description: output.description.clone(),
                     bounds: output.bounds.to_pixels(output.scale as f32),
                 }) as Rc<dyn PlatformDisplay>
             })
@@ -692,6 +696,7 @@ impl LinuxClient for WaylandClient {
                     Rc::new(WaylandDisplay {
                         id: object_id.clone(),
                         name: output.name.clone(),
+                        description: output.description.clone(),
                         bounds: output.bounds.to_pixels(output.scale as f32),
                     }) as Rc<dyn PlatformDisplay>
                 })
@@ -1146,6 +1151,9 @@ impl Dispatch<wl_output::WlOutput, ()> for WaylandClientStatePtr {
         match event {
             wl_output::Event::Name { name } => {
                 in_progress_output.name = Some(name);
+            }
+            wl_output::Event::Description { description } => {
+                in_progress_output.description = Some(description);
             }
             wl_output::Event::Scale { factor } => {
                 in_progress_output.scale = Some(factor);

--- a/crates/gpui_linux/src/linux/wayland/display.rs
+++ b/crates/gpui_linux/src/linux/wayland/display.rs
@@ -14,6 +14,7 @@ pub(crate) struct WaylandDisplay {
     /// The ID of the wl_output object
     pub id: ObjectId,
     pub name: Option<String>,
+    pub description: Option<String>,
     pub bounds: Bounds<Pixels>,
 }
 
@@ -38,5 +39,13 @@ impl PlatformDisplay for WaylandDisplay {
 
     fn bounds(&self) -> Bounds<Pixels> {
         self.bounds
+    }
+
+    fn name(&self) -> Option<&str> {
+        self.name.as_deref()
+    }
+
+    fn description(&self) -> Option<&str> {
+        self.description.as_deref()
     }
 }

--- a/crates/gpui_linux/src/linux/wayland/window.rs
+++ b/crates/gpui_linux/src/linux/wayland/window.rs
@@ -1163,6 +1163,7 @@ impl PlatformWindow for WaylandWindow {
             Rc::new(WaylandDisplay {
                 id: id.clone(),
                 name: display.name.clone(),
+                description: display.description.clone(),
                 bounds: display.bounds.to_pixels(state.scale),
             }) as Rc<dyn PlatformDisplay>
         })


### PR DESCRIPTION
Not sure if I'm happy with having 2 wayland-only fields on `PlatformDisplay`, open to any suggestions. The only other idea I have is allowing access to the underlying `WaylandDisplay` through a wayland-only function.

The fact that we have to wait for a bit after startup for displays to be present is also unfortunate, but inherent to wayland, I suppose. I've updated the example to show that, could remove it again if not desirable.

Release Notes:

- N/A