### PR TITLE
remote: Bring back docker exit status mapping

### DIFF
--- a/crates/remote/src/transport/docker.rs
+++ b/crates/remote/src/transport/docker.rs
@@ -165,9 +165,23 @@ impl DockerExecConnection {
         let dst_path =
             paths::remote_server_dir_relative().join(RelPath::unix(&binary_name).unwrap());
 
+        let binary_exists_on_server = self
+            .run_docker_exec(
+                &dst_path.display(self.path_style()),
+                Some(&remote_dir_for_server),
+                &Default::default(),
+                &["version"],
+            )
+            .await
+            .is_ok();
         #[cfg(any(debug_assertions, feature = "build-remote-server-binary"))]
-        if let Some(remote_server_path) =
-            super::build_remote_server_from_source(&remote_platform, delegate.as_ref(), cx).await?
+        if let Some(remote_server_path) = super::build_remote_server_from_source(
+            &remote_platform,
+            delegate.as_ref(),
+            binary_exists_on_server,
+            cx,
+        )
+        .await?
         {
             let tmp_path = paths::remote_server_dir_relative().join(
                 RelPath::unix(&format!(
@@ -190,16 +204,7 @@ impl DockerExecConnection {
             return Ok(dst_path);
         }
 
-        if self
-            .run_docker_exec(
-                &dst_path.display(self.path_style()),
-                Some(&remote_dir_for_server),
-                &Default::default(),
-                &["version"],
-            )
-            .await
-            .is_ok()
-        {
+        if binary_exists_on_server {
             return Ok(dst_path);
         }
 
@@ -611,13 +616,22 @@ impl RemoteConnection for DockerExecConnection {
         let mut proxy_process = self.proxy_process.lock();
         *proxy_process = Some(child.id());
 
-        super::handle_rpc_messages_over_child_process_stdio(
-            child,
-            incoming_tx,
-            outgoing_rx,
-            connection_activity_tx,
-            cx,
-        )
+        cx.spawn(async move |cx| {
+            super::handle_rpc_messages_over_child_process_stdio(
+                child,
+                incoming_tx,
+                outgoing_rx,
+                connection_activity_tx,
+                cx,
+            )
+            .await
+            .and_then(|status| {
+                if status != 0 {
+                    anyhow::bail!("Remote server exited with status {status}");
+                }
+                Ok(0)
+            })
+        })
     }
 
     fn upload_directory(


### PR DESCRIPTION
cc https://github.com/zed-industries/zed/pull/45584, was removed in #47200 fully due to breaking ssh
Also makes ZED_BUILD_REMOTE_SERVER a bit easier to use

Release Notes:

- N/A *or* Added/Fixed/Improved ...
