### PR TITLE
ci: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/community_champion_auto_labeler.yml
+++ b/.github/workflows/community_champion_auto_labeler.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check if author is a community champion and apply label
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           COMMUNITY_CHAMPIONS: |
             0x2CA

--- a/.github/workflows/congrats.yml
+++ b/.github/workflows/congrats.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Get PR info and check if author is external
         id: check
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.CONGRATSBOT_GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/docs_automation.yml
+++ b/.github/workflows/docs_automation.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -46,7 +46,7 @@ jobs:
           "${HOME}/.local/bin/droid" --version
 
       - name: Setup Node.js (for Prettier)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 

--- a/.github/workflows/extension_bump.yml
+++ b/.github/workflows/extension_bump.yml
@@ -106,7 +106,7 @@ jobs:
         echo "new_version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
       shell: bash -euxo pipefail {0}
     - name: extension_bump::create_pull_request
-      uses: peter-evans/create-pull-request@v7
+      uses: peter-evans/create-pull-request@v8
       with:
         title: Bump version to ${{ steps.bump-version.outputs.new_version }}
         body: This PR bumps the version of this extension to v${{ steps.bump-version.outputs.new_version }}
@@ -136,7 +136,7 @@ jobs:
       with:
         clean: false
     - name: extension_bump::create_version_tag
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       with:
         script: |-
           github.rest.git.createRef({

--- a/.github/workflows/extension_workflow_rollout.yml
+++ b/.github/workflows/extension_workflow_rollout.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - id: list-repos
       name: extension_workflow_rollout::fetch_extension_repos::get_repositories
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       with:
         script: |
           const repos = await github.paginate(github.rest.repos.listForOrg, {
@@ -78,7 +78,7 @@ jobs:
       working-directory: zed
     - id: create-pr
       name: extension_workflow_rollout::rollout_workflows_to_extension::create_pull_request
-      uses: peter-evans/create-pull-request@v7
+      uses: peter-evans/create-pull-request@v8
       with:
         path: extension
         title: Update CI workflows to `zed@${{ steps.short-sha.outputs.sha_short }}`


### PR DESCRIPTION
Release Notes:

- Updated `peter-evans/create-pull-request` from `v7` to `v8` in `.github/workflows/extension_bump.yml`
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/docs_automation.yml`
- Updated `actions/github-script` from `v7` to `v8` in `.github/workflows/congrats.yml`
- Updated `actions/github-script` from `v7` to `v8` in `.github/workflows/extension_workflow_rollout.yml`
- Updated `peter-evans/create-pull-request` from `v7` to `v8` in `.github/workflows/extension_workflow_rollout.yml`
- Updated `actions/github-script` from `v7` to `v8` in `.github/workflows/community_champion_auto_labeler.yml`
- Updated `actions/github-script` from `v7` to `v8` in `.github/workflows/extension_bump.yml`
- Updated `actions/setup-node` from `v4` to `v6` in `.github/workflows/docs_automation.yml`

The PR body contains detailed changes for each affected file, including the specific versions updated and the workflows impacted.