### PR TITLE
Fix git panel not updating after commit

### DIFF
--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -3080,12 +3080,10 @@ impl BackgroundScannerState {
             .add(&common_dir_abs_path)
             .context("failed to add common directory to watcher")
             .log_err();
-        if !repository_dir_abs_path.starts_with(&common_dir_abs_path) {
-            watcher
-                .add(&repository_dir_abs_path)
-                .context("failed to add repository directory to watcher")
-                .log_err();
-        }
+        watcher
+            .add(&repository_dir_abs_path)
+            .context("failed to add repository directory to watcher")
+            .log_err();
 
         let work_directory_id = work_dir_entry.id;
 


### PR DESCRIPTION
Fixed git panel not update after commit or switch branch on Linux.

On macOS and Windows, the watcher implementation recursively watches subdirectories.
On Linux, the watcher is non-recursive.

In Git worktree scenarios, only `<project>/.git` is watched, but the actual worktree Git directory
`<project>/.git/worktrees/<worktree>`  is not.
Therefore, Git operations such as commits or branch switches inside a worktree do not emit watcher events on Linux, causing the Git panel to stay out of sync.

Release Notes:
- Fixed git panel not update after commit or switch branch on Linux with git worktrees.
