### PR TITLE
onboarding: Fix theme picker always updating theme based on system appearance

### DIFF
--- a/crates/onboarding/src/basics_page.rs
+++ b/crates/onboarding/src/basics_page.rs
@@ -215,7 +215,7 @@ fn render_theme_section(tab_index: &mut isize, cx: &mut App) -> impl IntoElement
                     get_theme_family_themes(&theme).unwrap_or((theme.as_ref(), theme.as_ref()));
 
                 settings.theme.theme = Some(settings::ThemeSelection::Dynamic {
-                    mode: theme_mode,
+                    mode: ThemeAppearanceMode::System,
                     light: ThemeName(light_theme.into()),
                     dark: ThemeName(dark_theme.into()),
                 });

--- a/crates/onboarding/src/basics_page.rs
+++ b/crates/onboarding/src/basics_page.rs
@@ -209,8 +209,8 @@ fn render_theme_section(tab_index: &mut isize, cx: &mut App) -> impl IntoElement
     ) {
         let fs = <dyn Fs>::global(cx);
         let theme = theme.into();
-        update_settings_file(fs, cx, move |settings, cx| match theme_mode.try_into() {
-            Err(_) => {
+        update_settings_file(fs, cx, move |settings, cx| match theme_mode {
+            ThemeAppearanceMode::System => {
                 let (light_theme, dark_theme) =
                     get_theme_family_themes(&theme).unwrap_or((theme.as_ref(), theme.as_ref()));
 
@@ -220,9 +220,18 @@ fn render_theme_section(tab_index: &mut isize, cx: &mut App) -> impl IntoElement
                     dark: ThemeName(dark_theme.into()),
                 });
             }
-            Ok(appearance) => {
-                theme::set_theme(settings, theme, appearance, *SystemAppearance::global(cx))
-            }
+            ThemeAppearanceMode::Light => theme::set_theme(
+                settings,
+                theme,
+                Appearance::Light,
+                *SystemAppearance::global(cx),
+            ),
+            ThemeAppearanceMode::Dark => theme::set_theme(
+                settings,
+                theme,
+                Appearance::Dark,
+                *SystemAppearance::global(cx),
+            ),
         });
     }
 }

--- a/crates/onboarding/src/basics_page.rs
+++ b/crates/onboarding/src/basics_page.rs
@@ -209,19 +209,19 @@ fn render_theme_section(tab_index: &mut isize, cx: &mut App) -> impl IntoElement
     ) {
         let fs = <dyn Fs>::global(cx);
         let theme = theme.into();
-        update_settings_file(fs, cx, move |settings, cx| {
-            if theme_mode == ThemeAppearanceMode::System {
+        update_settings_file(fs, cx, move |settings, cx| match theme_mode.try_into() {
+            Err(_) => {
                 let (light_theme, dark_theme) =
                     get_theme_family_themes(&theme).unwrap_or((theme.as_ref(), theme.as_ref()));
 
                 settings.theme.theme = Some(settings::ThemeSelection::Dynamic {
-                    mode: ThemeAppearanceMode::System,
+                    mode: theme_mode,
                     light: ThemeName(light_theme.into()),
                     dark: ThemeName(dark_theme.into()),
                 });
-            } else {
-                let appearance = *SystemAppearance::global(cx);
-                theme::set_theme(settings, theme, appearance, appearance);
+            }
+            Ok(appearance) => {
+                theme::set_theme(settings, theme, appearance, *SystemAppearance::global(cx))
             }
         });
     }

--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -86,18 +86,6 @@ impl From<WindowAppearance> for Appearance {
     }
 }
 
-impl TryFrom<ThemeAppearanceMode> for Appearance {
-    type Error = ();
-
-    fn try_from(value: ThemeAppearanceMode) -> Result<Self, Self::Error> {
-        match value {
-            ThemeAppearanceMode::Light => Ok(Self::Light),
-            ThemeAppearanceMode::Dark => Ok(Self::Dark),
-            ThemeAppearanceMode::System => Err(()),
-        }
-    }
-}
-
 impl From<Appearance> for ThemeAppearanceMode {
     fn from(value: Appearance) -> Self {
         match value {

--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -86,6 +86,18 @@ impl From<WindowAppearance> for Appearance {
     }
 }
 
+impl TryFrom<ThemeAppearanceMode> for Appearance {
+    type Error = ();
+
+    fn try_from(value: ThemeAppearanceMode) -> Result<Self, Self::Error> {
+        match value {
+            ThemeAppearanceMode::Light => Ok(Self::Light),
+            ThemeAppearanceMode::Dark => Ok(Self::Dark),
+            ThemeAppearanceMode::System => Err(()),
+        }
+    }
+}
+
 impl From<Appearance> for ThemeAppearanceMode {
     fn from(value: Appearance) -> Self {
         match value {


### PR DESCRIPTION
The settings store separate themes for Light and Dark modes. When the user clicks a theme, the code uses the system appearance to decide which to update, rather than the mode the user selected in the UI. This causes the wrong theme to be saved when the system appearance differs from the selected mode.

<img width="746" height="324" alt="image" src="https://github.com/user-attachments/assets/b8f8d937-172d-4da8-b572-4f3db7f1de9a" />

Release Notes:

- Fixed onboarding page saving the selected theme based on the system appearance and not the currently selected one.