### PR TITLE
Support Insider variants of Code and VSCodium for settings.json import

### DIFF
--- a/crates/paths/src/paths.rs
+++ b/crates/paths/src/paths.rs
@@ -502,8 +502,10 @@ fn vscode_user_data_paths() -> Vec<PathBuf> {
     // https://github.com/microsoft/vscode/blob/23e7148cdb6d8a27f0109ff77e5b1e019f8da051/src/vs/platform/environment/node/userDataPath.ts#L45
     const VSCODE_PRODUCT_NAMES: &[&str] = &[
         "Code",
+        "Code - Insiders",
         "Code - OSS",
         "VSCodium",
+        "VSCodium - Insiders",
         "Code Dev",
         "Code - OSS Dev",
         "code-oss-dev",


### PR DESCRIPTION
Release Notes: 

- Import VS Code Insiders and VSCodium Insiders user settings (`settings.json`).

Note:
- If multiple VS Code-family installs have a `settings.json`, Zed selects the last matching path in its search order (so Insiders is preferred over stable when both exist).