### PR TITLE
Use `anyOf` instead of `oneOf` in keymap schema

### DIFF
--- a/crates/settings/src/keymap_file.rs
+++ b/crates/settings/src/keymap_file.rs
@@ -670,7 +670,7 @@ impl KeymapFile {
         generator.definitions_mut().insert(
             KeymapAction::schema_name().to_string(),
             json!({
-                "oneOf": keymap_action_alternatives
+                "anyOf": keymap_action_alternatives
             }),
         );
 


### PR DESCRIPTION
Closes #ISSUE

Resolves some spurious warnings we were seeing in the keymap file due to keybind declarations matching multiple possible shapes which is not allowed with `oneOf` per the json-schema spec

Release Notes:

- N/A *or* Added/Fixed/Improved ...
