### PR TITLE
project_panel: Fix "Add Folder to Project" menu hidden on remote projects

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1087,6 +1087,7 @@ impl ProjectPanel {
             let is_unfoldable = auto_fold_dirs && self.is_unfoldable(entry, worktree);
             let is_read_only = project.is_read_only(cx);
             let is_remote = project.is_remote();
+            let is_collab = project.is_via_collab();
             let is_local = project.is_local();
 
             let settings = ProjectPanelSettings::get_global(cx);
@@ -1177,7 +1178,7 @@ impl ProjectPanel {
                             .when(!is_root, |menu| {
                                 menu.action("Delete", Box::new(Delete { skip_prompt: false }))
                             })
-                            .when(!is_remote && is_root, |menu| {
+                            .when(!is_collab && is_root, |menu| {
                                 menu.separator()
                                     .action(
                                         "Add Folder to Project…",


### PR DESCRIPTION
Fixes an unintended behavioral change from #40838.

Release Notes:

- Fixed "Add Folder to Project" and "Remove from Project" menu items being incorrectly hidden on remote projects.
