### PR TITLE
workspace: Fix Open Recent button not responding when terminal has focus

### DIFF
--- a/crates/workspace/src/welcome.rs
+++ b/crates/workspace/src/welcome.rs
@@ -114,7 +114,10 @@ impl RenderOnce for SectionButton {
                             .size(rems_from_px(12.)),
                     ),
             )
-            .on_click(move |_, window, cx| window.dispatch_action(self.action.boxed_clone(), cx))
+            .on_click(move |_, window, cx| {                                                                                                                                 
+                self.focus_handle                                                                                                                                            
+                    .dispatch_action(self.action.as_ref(), window, cx)                                                                                                       
+            })  
     }
 }
 


### PR DESCRIPTION
Fixes #47080

Closes #ISSUE
                                                                                                                                                                                      
Release Notes:

Use `focus_handle.dispatch_action` instead of `window.dispatch_action`  dispatch actions through the button's focus context rather than the focused element.
                                                                                                                                                                                        
  ## Test                                                                                                                                                                           
  1. Open Zed to the welcome page                                                                                                                                                       
  2. Open terminal dock at the bottom (so terminal has focus)                                                                                                                           
  3. Click on "Open Recent"                                                                                       
  4. Verify the button action triggers correctly                                                                                                                                        



https://github.com/user-attachments/assets/c9256f52-40bd-4117-9816-95891ec3dddf








