### PR TITLE
agent: Clearer distinction that we are in Text Thread history

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -612,7 +612,11 @@ impl AgentPanel {
                         if let Some(kind) = panel.read(cx).history_kind_for_selected_agent(cx) {
                             menu =
                                 Self::populate_recently_updated_menu_section(menu, panel, kind, cx);
-                            menu = menu.action("View All", Box::new(OpenHistory));
+                            let view_all_label = match kind {
+                                HistoryKind::AgentThreads => "View All",
+                                HistoryKind::TextThreads => "View All Text Threads",
+                            };
+                            menu = menu.action(view_all_label, Box::new(OpenHistory));
                         }
                     }
 
@@ -1405,7 +1409,7 @@ impl AgentPanel {
                     return menu;
                 }
 
-                menu = menu.header("Recently Updated");
+                menu = menu.header("Recent Text Threads");
 
                 for entry in entries {
                     let title = if entry.title.is_empty() {
@@ -1801,7 +1805,7 @@ impl AgentPanel {
             ActiveView::History { kind } => {
                 let title = match kind {
                     HistoryKind::AgentThreads => "History",
-                    HistoryKind::TextThreads => "Text Threads",
+                    HistoryKind::TextThreads => "Text Thread History",
                 };
                 Label::new(title).truncate().into_any_element()
             }

--- a/crates/agent_ui/src/text_thread_history.rs
+++ b/crates/agent_ui/src/text_thread_history.rs
@@ -521,7 +521,7 @@ impl Render for TextThreadHistory {
 
                 if has_no_history {
                     view.justify_center().items_center().child(
-                        Label::new("You don't have any past threads yet.")
+                        Label::new("You don't have any past text threads yet.")
                             .size(LabelSize::Small)
                             .color(Color::Muted),
                     )


### PR DESCRIPTION
Some users were a bit confused that the history between zed agent + text threads is split up now. Making it a bit clearer for the users still using text threads which history they are currently looking at.

Release Notes:

- N/A
