### PR TITLE
Use arithmetic expansion instead of `expr` in `./script/clear-target-dir-if-larger-than`

### DIFF
--- a/script/clear-target-dir-if-larger-than
+++ b/script/clear-target-dir-if-larger-than
@@ -15,7 +15,7 @@ fi
 max_size_gb=$1
 
 current_size=$(du -s target | cut -f1)
-current_size_gb=$(expr ${current_size} / 1024 / 1024)
+current_size_gb=$(( ${current_size} / 1024 / 1024 ))
 
 echo "target directory size: ${current_size_gb}gb. max size: ${max_size_gb}gb"
 


### PR DESCRIPTION
Fixes CI failures when the target dir is 0GB in size, which causes `expr` to output a non-zero exit code per the posix spec.

See exit status section of https://www.man7.org/linux/man-pages/man1/expr.1p.html

Release Notes:

- N/A *or* Added/Fixed/Improved ...
