### PR TITLE
Pop end row if the end is equal to the starting sticky row

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -4856,7 +4856,7 @@ impl EditorElement {
 
             while end_rows
                 .last()
-                .is_some_and(|&last_end| last_end < sticky_row)
+                .is_some_and(|&last_end| last_end <= sticky_row)
             {
                 end_rows.pop();
             }


### PR DESCRIPTION
Closes #47307

In markdown, the outline item for a heading actually ends on the same row as the next outline item (see #47307 for the visual glitch). This change makes it so that the end row calculation accounts for that, and you don't have two different display points where content is potentially scrolling out of view. Fixed visually:


https://github.com/user-attachments/assets/e0a7e57a-fd41-4484-87e9-ac3e51d0b927


Release Notes:

- Fixed a visual glitch with sticky scroll headers in markdown
