### PR TITLE
extension_ci: Remove rollout exclusion list

### DIFF
--- a/.github/workflows/extension_workflow_rollout.yml
+++ b/.github/workflows/extension_workflow_rollout.yml
@@ -14,18 +14,17 @@ jobs:
       uses: actions/github-script@v7
       with:
         script: |
-          const repos = await github.paginate(github.rest.repos.listForOrg, {
+          const repos = await github.paginate(github.rest.repos.listForOrg, {{
               org: 'zed-extensions',
               type: 'public',
               per_page: 100,
-          });
+          }});
 
           const filteredRepos = repos
               .filter(repo => !repo.archived)
-              .filter(repo => repo.name !== 'workflows' && repo.name !== 'material-icon-theme')
               .map(repo => repo.name);
 
-          console.log(`Found ${filteredRepos.length} extension repos`);
+          console.log(`Found ${{filteredRepos.length}} extension repos`);
           return filteredRepos;
         result-encoding: json
     outputs:
@@ -68,7 +67,11 @@ jobs:
     - name: extension_workflow_rollout::rollout_workflows_to_extension::copy_workflow_files
       run: |
         mkdir -p extension/.github/workflows
-        cp zed/extensions/workflows/shared/*.yml extension/.github/workflows/
+        if [ "${{ matrix.repo }}" = "workflows" ]; then
+            cp zed/extensions/workflows/*.yml extension/.github/workflows/
+        else
+            cp zed/extensions/workflows/shared/*.yml extension/.github/workflows/
+        fi
       shell: bash -euxo pipefail {0}
     - id: short-sha
       name: extension_workflow_rollout::rollout_workflows_to_extension::get_short_sha

--- a/.github/workflows/extension_workflow_rollout.yml
+++ b/.github/workflows/extension_workflow_rollout.yml
@@ -14,17 +14,17 @@ jobs:
       uses: actions/github-script@v7
       with:
         script: |
-          const repos = await github.paginate(github.rest.repos.listForOrg, {{
+          const repos = await github.paginate(github.rest.repos.listForOrg, {
               org: 'zed-extensions',
               type: 'public',
               per_page: 100,
-          }});
+          });
 
           const filteredRepos = repos
               .filter(repo => !repo.archived)
               .map(repo => repo.name);
 
-          console.log(`Found ${{filteredRepos.length}} extension repos`);
+          console.log(`Found ${filteredRepos.length} extension repos`);
           return filteredRepos;
         result-encoding: json
     outputs:

--- a/tooling/xtask/src/tasks/workflows/extension_workflow_rollout.rs
+++ b/tooling/xtask/src/tasks/workflows/extension_workflow_rollout.rs
@@ -11,8 +11,6 @@ use crate::tasks::workflows::{
     vars::{self, StepOutput},
 };
 
-const EXCLUDED_REPOS: &[&str] = &["workflows", "material-icon-theme"];
-
 pub(crate) fn extension_workflow_rollout() -> Workflow {
     let fetch_repos = fetch_extension_repos();
     let rollout_workflows = rollout_workflows_to_extension(&fetch_repos);
@@ -26,34 +24,24 @@ pub(crate) fn extension_workflow_rollout() -> Workflow {
 
 fn fetch_extension_repos() -> NamedJob {
     fn get_repositories() -> (Step<Use>, StepOutput) {
-        let exclusion_filter = EXCLUDED_REPOS
-            .iter()
-            .map(|repo| format!("repo.name !== '{}'", repo))
-            .collect::<Vec<_>>()
-            .join(" && ");
-
         let step = named::uses("actions", "github-script", "v7")
             .id("list-repos")
             .add_with((
                 "script",
-                format!(
-                    indoc! {r#"
-                        const repos = await github.paginate(github.rest.repos.listForOrg, {{
-                            org: 'zed-extensions',
-                            type: 'public',
-                            per_page: 100,
-                        }});
+                indoc! {r#"
+                    const repos = await github.paginate(github.rest.repos.listForOrg, {{
+                        org: 'zed-extensions',
+                        type: 'public',
+                        per_page: 100,
+                    }});
 
-                        const filteredRepos = repos
-                            .filter(repo => !repo.archived)
-                            .filter(repo => {})
-                            .map(repo => repo.name);
+                    const filteredRepos = repos
+                        .filter(repo => !repo.archived)
+                        .map(repo => repo.name);
 
-                        console.log(`Found ${{filteredRepos.length}} extension repos`);
-                        return filteredRepos;
-                    "#},
-                    exclusion_filter
-                ),
+                    console.log(`Found ${{filteredRepos.length}} extension repos`);
+                    return filteredRepos;
+                "#},
             ))
             .add_with(("result-encoding", "json"));
 
@@ -89,7 +77,11 @@ fn rollout_workflows_to_extension(fetch_repos_job: &NamedJob) -> NamedJob {
     fn copy_workflow_files() -> Step<Run> {
         named::bash(indoc! {r#"
             mkdir -p extension/.github/workflows
-            cp zed/extensions/workflows/shared/*.yml extension/.github/workflows/
+            if [ "${{ matrix.repo }}" = "workflows" ]; then
+                cp zed/extensions/workflows/*.yml extension/.github/workflows/
+            else
+                cp zed/extensions/workflows/shared/*.yml extension/.github/workflows/
+            fi
         "#})
     }
 

--- a/tooling/xtask/src/tasks/workflows/extension_workflow_rollout.rs
+++ b/tooling/xtask/src/tasks/workflows/extension_workflow_rollout.rs
@@ -29,17 +29,17 @@ fn fetch_extension_repos() -> NamedJob {
             .add_with((
                 "script",
                 indoc! {r#"
-                    const repos = await github.paginate(github.rest.repos.listForOrg, {{
+                    const repos = await github.paginate(github.rest.repos.listForOrg, {
                         org: 'zed-extensions',
                         type: 'public',
                         per_page: 100,
-                    }});
+                    });
 
                     const filteredRepos = repos
                         .filter(repo => !repo.archived)
                         .map(repo => repo.name);
 
-                    console.log(`Found ${{filteredRepos.length}} extension repos`);
+                    console.log(`Found ${filteredRepos.length} extension repos`);
                     return filteredRepos;
                 "#},
             ))


### PR DESCRIPTION
The last extension has now been migrated to the new workflows and with that, the entire zed-extensions org now uses the centralized workflows 🎉 

Given this, we can now remove the exclusion list and - as a little bonus - also rollout changes automatically to the repository hosting the shared workflows.

Release Notes:

- N/A
