### PR TITLE
agent_ui: Fix message editor stealing focus from other panels

### DIFF
--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -823,7 +823,9 @@ impl AcpThreadView {
                             })
                         });
 
-                        this.message_editor.focus_handle(cx).focus(window, cx);
+                        if this.focus_handle(cx).contains_focused(window, cx) {
+                            this.message_editor.focus_handle(cx).focus(window, cx);
+                        }
 
                         cx.notify();
                     }

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -823,7 +823,7 @@ impl AcpThreadView {
                             })
                         });
 
-                        if this.focus_handle(cx).contains_focused(window, cx) {
+                        if this.focus_handle.contains_focused(window, cx) {
                             this.message_editor.focus_handle(cx).focus(window, cx);
                         }
 


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/41278, Closes https://github.com/zed-industries/zed/issues/45576, Closes https://github.com/zed-industries/zed/issues/46513

Release Notes:

- Fixed message editor stealing focus (so the "Open Recent Project" modal stays open)

This issue has been driving me insane haha.


_Note: This is my first code contribution to this project. Please be kind and let me know if I have missed something. I tested this fix on my machine and it works. Tests are passing on my device. I have agreed to the Zed Contributor License and Feedback Agreement with my Zed Account that's linked to the same email as this GitHub account._
