### PR TITLE
project panel: Collapse All improvements

### DIFF
--- a/crates/project_panel/Cargo.toml
+++ b/crates/project_panel/Cargo.toml
@@ -16,6 +16,16 @@ harness = false
 path = "src/project_panel.rs"
 doctest = false
 
+[features]
+test-support = [
+    "client/test-support",
+    "editor/test-support",
+    "gpui/test-support",
+    "language/test-support",
+    "project/test-support",
+    "workspace/test-support",
+]
+
 [dependencies]
 anyhow.workspace = true
 collections.workspace = true

--- a/crates/project_panel/Cargo.toml
+++ b/crates/project_panel/Cargo.toml
@@ -16,16 +16,6 @@ harness = false
 path = "src/project_panel.rs"
 doctest = false
 
-[features]
-test-support = [
-    "client/test-support",
-    "editor/test-support",
-    "gpui/test-support",
-    "language/test-support",
-    "project/test-support",
-    "workspace/test-support",
-]
-
 [dependencies]
 anyhow.workspace = true
 collections.workspace = true

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1381,18 +1381,9 @@ impl ProjectPanel {
             let worktree_id = worktree.id();
             let entry_id = entry.id;
 
-            if self.project.read(cx).entry_is_worktree_root(entry_id, cx) {
-                self.collapse_all_entries(&CollapseAllEntries, window, cx);
-            } else {
-                self.collapse_all_for_entry(worktree_id, entry_id, cx);
-                self.update_visible_entries(
-                    Some((worktree_id, entry_id)),
-                    false,
-                    false,
-                    window,
-                    cx,
-                );
-            }
+            self.collapse_all_for_entry(worktree_id, entry_id, cx);
+
+            self.update_visible_entries(Some((worktree_id, entry_id)), false, false, window, cx);
             cx.notify();
         }
     }

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -286,7 +286,7 @@ actions!(
         ExpandSelectedEntry,
         /// Collapses the selected entry in the project tree.
         CollapseSelectedEntry,
-        // Collapses the selected entry and its children in the project tree.
+        /// Collapses the selected entry and its children in the project tree.
         CollapseSelectedEntryAndChildren,
         /// Collapses all entries in the project tree.
         CollapseAllEntries,

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -286,6 +286,8 @@ actions!(
         ExpandSelectedEntry,
         /// Collapses the selected entry in the project tree.
         CollapseSelectedEntry,
+        // Collapses the selected entry and it's children in the project tree.
+        CollapseSelectedEntryAndChildren,
         /// Collapses all entries in the project tree.
         CollapseAllEntries,
         /// Creates a new directory.
@@ -1141,6 +1143,10 @@ impl ProjectPanel {
                             .when(is_dir, |menu| {
                                 menu.separator()
                                     .action("Find in Folder…", Box::new(NewSearchInDirectory))
+                                    .action(
+                                        "Collapse All",
+                                        Box::new(CollapseSelectedEntryAndChildren),
+                                    )
                             })
                             .when(is_unfoldable, |menu| {
                                 menu.action("Unfold Directory", Box::new(UnfoldDirectory))
@@ -1198,10 +1204,6 @@ impl ProjectPanel {
                                         Box::new(workspace::AddFolderToProject),
                                     )
                                     .action("Remove from Project", Box::new(RemoveFromProject))
-                            })
-                            .when(is_root, |menu| {
-                                menu.separator()
-                                    .action("Collapse All", Box::new(CollapseAllEntries))
                             })
                     }
                 })
@@ -1367,7 +1369,27 @@ impl ProjectPanel {
         }
     }
 
-    pub fn collapse_all_entries(
+    fn collapse_selected_entry_and_children(
+        &mut self,
+        _: &CollapseSelectedEntryAndChildren,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some((worktree, entry)) = self.selected_entry(cx) {
+            let worktree_id = worktree.id();
+            let entry_id = entry.id;
+
+            if self.project.read(cx).entry_is_worktree_root(entry_id, cx) {
+                self.collapse_all_entries(&CollapseAllEntries, window, cx);
+            } else {
+                self.collapse_all_for_entry(worktree_id, entry_id, cx);
+                self.update_visible_entries(Some((worktree_id, entry_id)), cx);
+            }
+            cx.notify();
+        }
+    }
+
+    fn collapse_all_entries(
         &mut self,
         _: &CollapseAllEntries,
         window: &mut Window,
@@ -6217,6 +6239,7 @@ impl Render for ProjectPanel {
                 .on_action(cx.listener(Self::expand_selected_entry))
                 .on_action(cx.listener(Self::collapse_selected_entry))
                 .on_action(cx.listener(Self::collapse_all_entries))
+                .on_action(cx.listener(Self::collapse_selected_entry_and_children))
                 .on_action(cx.listener(Self::open))
                 .on_action(cx.listener(Self::open_permanent))
                 .on_action(cx.listener(Self::open_split_vertical))

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1143,10 +1143,6 @@ impl ProjectPanel {
                             .when(is_dir, |menu| {
                                 menu.separator()
                                     .action("Find in Folder…", Box::new(NewSearchInDirectory))
-                                    .action(
-                                        "Collapse All",
-                                        Box::new(CollapseSelectedEntryAndChildren),
-                                    )
                             })
                             .when(is_unfoldable, |menu| {
                                 menu.action("Unfold Directory", Box::new(UnfoldDirectory))
@@ -1204,6 +1200,12 @@ impl ProjectPanel {
                                         Box::new(workspace::AddFolderToProject),
                                     )
                                     .action("Remove from Project", Box::new(RemoveFromProject))
+                            })
+                            .when(is_dir, |menu| {
+                                menu.separator().action(
+                                    "Collapse All",
+                                    Box::new(CollapseSelectedEntryAndChildren),
+                                )
                             })
                     }
                 })

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1383,7 +1383,13 @@ impl ProjectPanel {
                 self.collapse_all_entries(&CollapseAllEntries, window, cx);
             } else {
                 self.collapse_all_for_entry(worktree_id, entry_id, cx);
-                self.update_visible_entries(Some((worktree_id, entry_id)), cx);
+                self.update_visible_entries(
+                    Some((worktree_id, entry_id)),
+                    false,
+                    false,
+                    window,
+                    cx,
+                );
             }
             cx.notify();
         }

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -286,7 +286,7 @@ actions!(
         ExpandSelectedEntry,
         /// Collapses the selected entry in the project tree.
         CollapseSelectedEntry,
-        // Collapses the selected entry and it's children in the project tree.
+        // Collapses the selected entry and its children in the project tree.
         CollapseSelectedEntryAndChildren,
         /// Collapses all entries in the project tree.
         CollapseAllEntries,

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1114,7 +1114,7 @@ impl ProjectPanel {
                     .is_some()
             };
 
-            let entity = cx.entity().clone();
+            let entity = cx.entity();
             let context_menu = ContextMenu::build(window, cx, |menu, _, _| {
                 menu.context(self.focus_handle.clone()).map(|menu| {
                     if is_read_only {

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1409,27 +1409,23 @@ impl ProjectPanel {
             return;
         };
 
-        let worktree_id = worktree.id();
-        let entry_id = entry.id;
-        let is_root = worktree.root_entry().map(|e| e.id) == Some(entry_id);
-
+        let is_root = worktree.root_entry().map(|e| e.id) == Some(entry.id);
         if !is_root {
             return;
         }
 
-        let single_visible_worktree = self.project.read(cx).visible_worktrees(cx).count() == 1;
+        let worktree_id = worktree.id();
+        let root_id = entry.id;
 
-        self.collapse_all_for_entry(worktree_id, entry_id, cx);
-
-        if single_visible_worktree {
-            if let Some(expanded_dir_ids) = self.state.expanded_dir_ids.get_mut(&worktree_id) {
-                if let Err(ix) = expanded_dir_ids.binary_search(&entry_id) {
-                    expanded_dir_ids.insert(ix, entry_id);
-                }
+        if let Some(expanded_dir_ids) = self.state.expanded_dir_ids.get_mut(&worktree_id) {
+            if self.project.read(cx).visible_worktrees(cx).count() == 1 {
+                expanded_dir_ids.retain(|id| id == &root_id);
+            } else {
+                expanded_dir_ids.clear();
             }
         }
 
-        self.update_visible_entries(Some((worktree_id, entry_id)), false, false, window, cx);
+        self.update_visible_entries(Some((worktree_id, root_id)), false, false, window, cx);
         cx.notify();
     }
 

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -6695,6 +6695,195 @@ async fn test_collapse_selected_entry_and_children_action(cx: &mut gpui::TestApp
 }
 
 #[gpui::test]
+async fn test_collapse_root_single_worktree(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/root"),
+        json!({
+            "dir1": {
+                "subdir1": {
+                    "file1.txt": ""
+                },
+                "file2.txt": ""
+            },
+            "dir2": {
+                "file3.txt": ""
+            }
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
+    let workspace = cx.add_window(|window, cx| Workspace::test_new(project.clone(), window, cx));
+    let cx = &mut VisualTestContext::from_window(*workspace, cx);
+
+    let panel = workspace.update(cx, ProjectPanel::new).unwrap();
+    cx.run_until_parked();
+
+    toggle_expand_dir(&panel, "root/dir1", cx);
+    toggle_expand_dir(&panel, "root/dir1/subdir1", cx);
+    toggle_expand_dir(&panel, "root/dir2", cx);
+
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..20, cx),
+        &[
+            "v root",
+            "    v dir1",
+            "        v subdir1",
+            "              file1.txt",
+            "          file2.txt",
+            "    v dir2  <== selected",
+            "          file3.txt",
+        ],
+        "Initial state with directories expanded"
+    );
+
+    // Select the root and collapse it and its children
+    select_path(&panel, "root", cx);
+    cx.run_until_parked();
+
+    panel.update_in(cx, |panel, window, cx| {
+        panel.collapse_selected_entry_and_children(
+            &CollapseSelectedEntryAndChildren,
+            window,
+            cx,
+        );
+    });
+    cx.run_until_parked();
+
+    // In a single-worktree project, collapsing the root delegates to collapse_all_entries,
+    // which keeps the root expanded but collapses all children.
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..20, cx),
+        &[
+            "v root  <== selected",
+            "    > dir1",
+            "    > dir2",
+        ],
+        "Root should stay expanded but all children should be collapsed"
+    );
+
+    // Re-expand dir1 and verify its children were recursively collapsed
+    toggle_expand_dir(&panel, "root/dir1", cx);
+    cx.run_until_parked();
+
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..20, cx),
+        &[
+            "v root",
+            "    v dir1  <== selected",
+            "        > subdir1",
+            "          file2.txt",
+            "    > dir2",
+        ],
+        "After re-expanding dir1, subdir1 should still be collapsed"
+    );
+}
+
+#[gpui::test]
+async fn test_collapse_root_multi_worktree(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/root1"),
+        json!({
+            "dir1": {
+                "subdir1": {
+                    "file1.txt": ""
+                },
+                "file2.txt": ""
+            }
+        }),
+    )
+    .await;
+    fs.insert_tree(
+        path!("/root2"),
+        json!({
+            "dir2": {
+                "file3.txt": ""
+            },
+            "file4.txt": ""
+        }),
+    )
+    .await;
+
+    let project = Project::test(
+        fs.clone(),
+        [path!("/root1").as_ref(), path!("/root2").as_ref()],
+        cx,
+    )
+    .await;
+    let workspace = cx.add_window(|window, cx| Workspace::test_new(project.clone(), window, cx));
+    let cx = &mut VisualTestContext::from_window(*workspace, cx);
+
+    let panel = workspace.update(cx, ProjectPanel::new).unwrap();
+    cx.run_until_parked();
+
+    toggle_expand_dir(&panel, "root1/dir1", cx);
+    toggle_expand_dir(&panel, "root1/dir1/subdir1", cx);
+    toggle_expand_dir(&panel, "root2/dir2", cx);
+
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..20, cx),
+        &[
+            "v root1",
+            "    v dir1",
+            "        v subdir1",
+            "              file1.txt",
+            "          file2.txt",
+            "v root2",
+            "    v dir2  <== selected",
+            "          file3.txt",
+            "      file4.txt",
+        ],
+        "Initial state with directories expanded across worktrees"
+    );
+
+    // Select root1 and collapse it and its children.
+    // In a multi-worktree project, this delegates to collapse_all_entries,
+    // which collapses all worktree roots entirely.
+    select_path(&panel, "root1", cx);
+    cx.run_until_parked();
+
+    panel.update_in(cx, |panel, window, cx| {
+        panel.collapse_selected_entry_and_children(
+            &CollapseSelectedEntryAndChildren,
+            window,
+            cx,
+        );
+    });
+    cx.run_until_parked();
+
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..20, cx),
+        &[
+            "> root1  <== selected",
+            "> root2",
+        ],
+        "All worktree roots should be collapsed"
+    );
+
+    // Re-expand both roots and verify children were recursively collapsed
+    toggle_expand_dir(&panel, "root1", cx);
+    toggle_expand_dir(&panel, "root2", cx);
+
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..20, cx),
+        &[
+            "v root1",
+            "    > dir1",
+            "v root2  <== selected",
+            "    > dir2",
+            "      file4.txt",
+        ],
+        "After re-expanding roots, all child directories should still be collapsed"
+    );
+}
+
+#[gpui::test]
 async fn test_create_entries_without_selection(cx: &mut gpui::TestAppContext) {
     init_test(cx);
 


### PR DESCRIPTION
Thanks to @jackTabsCode for the original commit that I based my work off of.

See: #27703

Release Notes:

- Fixed clicking "Collapse All" from context menu on a project root collapsing all project roots instead of that one.
- Added new `project panel: collapse selected entry and children` action that collapses the selected directory and all its subdirectories.
- Added "Collapse All" option to the context menu for all directories, not just project roots.