### PR TITLE
Add query and search options to pane::DeploySearch action

### DIFF
--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -1183,11 +1183,7 @@ impl ProjectSearchView {
             let query = editor.query_suggestion(window, cx);
             if query.is_empty() { None } else { Some(query) }
         });
-        let has_explicit_search_configuration = action.query.is_some()
-            || action.regex
-            || action.case_sensitive
-            || action.whole_word
-            || action.include_ignored;
+
 
         let search = if let Some(existing) = existing {
             workspace.activate_item(&existing, true, true, window, cx);
@@ -1219,17 +1215,23 @@ impl ProjectSearchView {
 
         search.update(cx, |search, cx| {
             search.replace_enabled |= action.replace_enabled;
-            if has_explicit_search_configuration {
-                search.set_search_option_enabled(SearchOptions::REGEX, action.regex, cx);
+            if let Some(regex) = action.regex {
+                search.set_search_option_enabled(SearchOptions::REGEX, regex, cx);
+            }
+            if let Some(case_sensitive) = action.case_sensitive {
                 search.set_search_option_enabled(
                     SearchOptions::CASE_SENSITIVE,
-                    action.case_sensitive,
+                    case_sensitive,
                     cx,
                 );
-                search.set_search_option_enabled(SearchOptions::WHOLE_WORD, action.whole_word, cx);
+            }
+            if let Some(whole_word) = action.whole_word {
+                search.set_search_option_enabled(SearchOptions::WHOLE_WORD, whole_word, cx);
+            }
+            if let Some(include_ignored) = action.include_ignored {
                 search.set_search_option_enabled(
                     SearchOptions::INCLUDE_IGNORED,
-                    action.include_ignored,
+                    include_ignored,
                     cx,
                 );
             }
@@ -5172,7 +5174,7 @@ pub mod tests {
     }
 
     #[gpui::test]
-    async fn test_deploy_search_with_options(cx: &mut TestAppContext) {
+    async fn test_deploy_search_applies_and_resets_options(cx: &mut TestAppContext) {
         init_test(cx);
 
         let fs = FakeFs::new(cx.background_executor.clone());
@@ -5200,11 +5202,11 @@ pub mod tests {
             ProjectSearchView::deploy_search(
                 workspace,
                 &workspace::DeploySearch {
-                    regex: true,
-                    case_sensitive: true,
-                    whole_word: true,
-                    include_ignored: true,
-                    query: Some("test_query".into()),
+                    regex: Some(true),
+                    case_sensitive: Some(true),
+                    whole_word: Some(true),
+                    include_ignored: Some(true),
+                    query: Some("Test_Query".into()),
                     ..Default::default()
                 },
                 window,
@@ -5248,60 +5250,18 @@ pub mod tests {
             );
             let query_text = search_view.query_editor.read(cx).text(cx);
             assert_eq!(
-                query_text, "test_query",
+                query_text, "Test_Query",
                 "Query should be set from the action"
             );
         });
-    }
 
-    #[gpui::test]
-    async fn test_deploy_search_with_options_resets_existing_search_options(
-        cx: &mut TestAppContext,
-    ) {
-        init_test(cx);
-
-        let fs = FakeFs::new(cx.background_executor.clone());
-        fs.insert_tree(
-            path!("/dir"),
-            json!({
-                "one.rs": "const ONE: usize = 1;",
-            }),
-        )
-        .await;
-        let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
-        let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project, window, cx));
-        let workspace = window
-            .read_with(cx, |mw, _| mw.workspace().clone())
-            .unwrap();
-        let cx = &mut VisualTestContext::from_window(window.into(), cx);
-        let search_bar = window.build_entity(cx, |_, _| ProjectSearchBar::new());
-
-        workspace.update_in(cx, |workspace, window, cx| {
-            workspace.panes()[0].update(cx, |pane, cx| {
-                pane.toolbar()
-                    .update(cx, |toolbar, cx| toolbar.add_item(search_bar, window, cx))
-            });
-
-            ProjectSearchView::deploy_search(
-                workspace,
-                &workspace::DeploySearch {
-                    regex: true,
-                    case_sensitive: true,
-                    whole_word: true,
-                    include_ignored: true,
-                    ..Default::default()
-                },
-                window,
-                cx,
-            )
-        });
-
+        // Redeploy with only regex — unspecified options should be preserved.
         cx.dispatch_action(menu::Cancel);
         workspace.update_in(cx, |workspace, window, cx| {
             ProjectSearchView::deploy_search(
                 workspace,
                 &workspace::DeploySearch {
-                    regex: true,
+                    regex: Some(true),
                     ..Default::default()
                 },
                 window,
@@ -5309,22 +5269,53 @@ pub mod tests {
             )
         });
 
-        let search_view = cx
-            .read(|cx| {
-                workspace
-                    .read(cx)
-                    .active_pane()
-                    .read(cx)
-                    .active_item()
-                    .and_then(|item| item.downcast::<ProjectSearchView>())
-            })
-            .expect("Search view should be active after redeploy");
+        search_view.update_in(cx, |search_view, _window, _cx| {
+            assert!(
+                search_view.search_options.contains(SearchOptions::REGEX),
+                "Regex should still be enabled"
+            );
+            assert!(
+                search_view
+                    .search_options
+                    .contains(SearchOptions::CASE_SENSITIVE),
+                "Case sensitive should be preserved from previous deploy"
+            );
+            assert!(
+                search_view
+                    .search_options
+                    .contains(SearchOptions::WHOLE_WORD),
+                "Whole word should be preserved from previous deploy"
+            );
+            assert!(
+                search_view
+                    .search_options
+                    .contains(SearchOptions::INCLUDE_IGNORED),
+                "Include ignored should be preserved from previous deploy"
+            );
+        });
+
+        // Redeploy explicitly turning off options.
+        cx.dispatch_action(menu::Cancel);
+        workspace.update_in(cx, |workspace, window, cx| {
+            ProjectSearchView::deploy_search(
+                workspace,
+                &workspace::DeploySearch {
+                    regex: Some(true),
+                    case_sensitive: Some(false),
+                    whole_word: Some(false),
+                    include_ignored: Some(false),
+                    ..Default::default()
+                },
+                window,
+                cx,
+            )
+        });
 
         search_view.update_in(cx, |search_view, _window, _cx| {
             assert_eq!(
                 search_view.search_options,
                 SearchOptions::REGEX,
-                "Redeploy should reset the search options to match the action"
+                "Explicit Some(false) should turn off options"
             );
         });
     }
@@ -5366,7 +5357,7 @@ pub mod tests {
             ProjectSearchView::deploy_search(
                 workspace,
                 &workspace::DeploySearch {
-                    case_sensitive: true,
+                    case_sensitive: Some(true),
                     query: Some("lowercase_query".into()),
                     ..Default::default()
                 },

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -1184,7 +1184,6 @@ impl ProjectSearchView {
             if query.is_empty() { None } else { Some(query) }
         });
 
-
         let search = if let Some(existing) = existing {
             workspace.activate_item(&existing, true, true, window, cx);
             existing
@@ -1219,11 +1218,7 @@ impl ProjectSearchView {
                 search.set_search_option_enabled(SearchOptions::REGEX, regex, cx);
             }
             if let Some(case_sensitive) = action.case_sensitive {
-                search.set_search_option_enabled(
-                    SearchOptions::CASE_SENSITIVE,
-                    case_sensitive,
-                    cx,
-                );
+                search.set_search_option_enabled(SearchOptions::CASE_SENSITIVE, case_sensitive, cx);
             }
             if let Some(whole_word) = action.whole_word {
                 search.set_search_option_enabled(SearchOptions::WHOLE_WORD, whole_word, cx);
@@ -5255,7 +5250,7 @@ pub mod tests {
             );
         });
 
-        // Redeploy with only regex — unspecified options should be preserved.
+        // Redeploy with only regex - unspecified options should be preserved.
         cx.dispatch_action(menu::Cancel);
         workspace.update_in(cx, |workspace, window, cx| {
             ProjectSearchView::deploy_search(
@@ -5316,6 +5311,28 @@ pub mod tests {
                 search_view.search_options,
                 SearchOptions::REGEX,
                 "Explicit Some(false) should turn off options"
+            );
+        });
+
+        // Redeploy with an empty query - should not overwrite the existing query.
+        cx.dispatch_action(menu::Cancel);
+        workspace.update_in(cx, |workspace, window, cx| {
+            ProjectSearchView::deploy_search(
+                workspace,
+                &workspace::DeploySearch {
+                    query: Some("".into()),
+                    ..Default::default()
+                },
+                window,
+                cx,
+            )
+        });
+
+        search_view.update_in(cx, |search_view, _window, cx| {
+            let query_text = search_view.query_editor.read(cx).text(cx);
+            assert_eq!(
+                query_text, "Test_Query",
+                "Empty query string should not overwrite the existing query"
             );
         });
     }
@@ -5391,7 +5408,7 @@ pub mod tests {
             assert_eq!(query_text, "lowercase_query");
         });
 
-        // Now deploy with an uppercase query — smartcase should enable case sensitivity.
+        // Now deploy with an uppercase query - smartcase should enable case sensitivity.
         workspace.update_in(cx, |workspace, window, cx| {
             ProjectSearchView::deploy_search(
                 workspace,

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -5254,6 +5254,82 @@ pub mod tests {
         });
     }
 
+    #[gpui::test]
+    async fn test_deploy_search_with_options_resets_existing_search_options(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.background_executor.clone());
+        fs.insert_tree(
+            path!("/dir"),
+            json!({
+                "one.rs": "const ONE: usize = 1;",
+            }),
+        )
+        .await;
+        let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
+        let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project, window, cx));
+        let workspace = window
+            .read_with(cx, |mw, _| mw.workspace().clone())
+            .unwrap();
+        let cx = &mut VisualTestContext::from_window(window.into(), cx);
+        let search_bar = window.build_entity(cx, |_, _| ProjectSearchBar::new());
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.panes()[0].update(cx, |pane, cx| {
+                pane.toolbar()
+                    .update(cx, |toolbar, cx| toolbar.add_item(search_bar, window, cx))
+            });
+
+            ProjectSearchView::deploy_search(
+                workspace,
+                &workspace::DeploySearch {
+                    regex: true,
+                    case_sensitive: true,
+                    whole_word: true,
+                    include_ignored: true,
+                    ..Default::default()
+                },
+                window,
+                cx,
+            )
+        });
+
+        cx.dispatch_action(menu::Cancel);
+        workspace.update_in(cx, |workspace, window, cx| {
+            ProjectSearchView::deploy_search(
+                workspace,
+                &workspace::DeploySearch {
+                    regex: true,
+                    ..Default::default()
+                },
+                window,
+                cx,
+            )
+        });
+
+        let search_view = cx
+            .read(|cx| {
+                workspace
+                    .read(cx)
+                    .active_pane()
+                    .read(cx)
+                    .active_item()
+                    .and_then(|item| item.downcast::<ProjectSearchView>())
+            })
+            .expect("Search view should be active after redeploy");
+
+        search_view.update_in(cx, |search_view, _window, _cx| {
+            assert_eq!(
+                search_view.search_options,
+                SearchOptions::REGEX,
+                "Redeploy should reset the search options to match the action"
+            );
+        });
+    }
+
+    #[gpui::test]
     fn init_test(cx: &mut TestAppContext) {
         cx.update(|cx| {
             let settings = SettingsStore::test(cx);

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -5163,13 +5163,13 @@ pub mod tests {
 
         let fs = FakeFs::new(cx.background_executor.clone());
         fs.insert_tree(
-            "/dir",
+            path!("/dir"),
             json!({
                 "one.rs": "const ONE: usize = 1;",
             }),
         )
         .await;
-        let project = Project::test(fs.clone(), ["/dir".as_ref()], cx).await;
+        let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
         let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project, window, cx));
         let workspace = window
             .read_with(cx, |mw, _| mw.workspace().clone())
@@ -5211,9 +5211,7 @@ pub mod tests {
 
         search_view.update_in(cx, |search_view, _window, cx| {
             assert!(
-                search_view
-                    .search_options
-                    .contains(SearchOptions::REGEX),
+                search_view.search_options.contains(SearchOptions::REGEX),
                 "Regex option should be enabled"
             );
             assert!(

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -769,6 +769,17 @@ impl ProjectSearchView {
         }
     }
 
+    fn set_search_option_enabled(
+        &mut self,
+        option: SearchOptions,
+        enabled: bool,
+        cx: &mut Context<Self>,
+    ) {
+        if self.search_options.contains(option) != enabled {
+            self.toggle_search_option(option, cx);
+        }
+    }
+
     fn toggle_search_option(&mut self, option: SearchOptions, cx: &mut Context<Self>) {
         self.search_options.toggle(option);
         ActiveSettings::update_global(cx, |settings, cx| {
@@ -1172,6 +1183,11 @@ impl ProjectSearchView {
             let query = editor.query_suggestion(window, cx);
             if query.is_empty() { None } else { Some(query) }
         });
+        let has_explicit_search_configuration = action.query.is_some()
+            || action.regex
+            || action.case_sensitive
+            || action.whole_word
+            || action.include_ignored;
 
         let search = if let Some(existing) = existing {
             workspace.activate_item(&existing, true, true, window, cx);
@@ -1203,21 +1219,19 @@ impl ProjectSearchView {
 
         search.update(cx, |search, cx| {
             search.replace_enabled |= action.replace_enabled;
-            if action.regex && !search.search_options.contains(SearchOptions::REGEX) {
-                search.toggle_search_option(SearchOptions::REGEX, cx);
-            }
-            if action.case_sensitive
-                && !search.search_options.contains(SearchOptions::CASE_SENSITIVE)
-            {
-                search.toggle_search_option(SearchOptions::CASE_SENSITIVE, cx);
-            }
-            if action.whole_word && !search.search_options.contains(SearchOptions::WHOLE_WORD) {
-                search.toggle_search_option(SearchOptions::WHOLE_WORD, cx);
-            }
-            if action.include_ignored
-                && !search.search_options.contains(SearchOptions::INCLUDE_IGNORED)
-            {
-                search.toggle_search_option(SearchOptions::INCLUDE_IGNORED, cx);
+            if has_explicit_search_configuration {
+                search.set_search_option_enabled(SearchOptions::REGEX, action.regex, cx);
+                search.set_search_option_enabled(
+                    SearchOptions::CASE_SENSITIVE,
+                    action.case_sensitive,
+                    cx,
+                );
+                search.set_search_option_enabled(SearchOptions::WHOLE_WORD, action.whole_word, cx);
+                search.set_search_option_enabled(
+                    SearchOptions::INCLUDE_IGNORED,
+                    action.include_ignored,
+                    cx,
+                );
             }
             let query = action
                 .query

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -1203,17 +1203,21 @@ impl ProjectSearchView {
 
         search.update(cx, |search, cx| {
             search.replace_enabled |= action.replace_enabled;
-            if action.regex {
-                search.search_options.insert(SearchOptions::REGEX);
+            if action.regex && !search.search_options.contains(SearchOptions::REGEX) {
+                search.toggle_search_option(SearchOptions::REGEX, cx);
             }
-            if action.case_sensitive {
-                search.search_options.insert(SearchOptions::CASE_SENSITIVE);
+            if action.case_sensitive
+                && !search.search_options.contains(SearchOptions::CASE_SENSITIVE)
+            {
+                search.toggle_search_option(SearchOptions::CASE_SENSITIVE, cx);
             }
-            if action.whole_word {
-                search.search_options.insert(SearchOptions::WHOLE_WORD);
+            if action.whole_word && !search.search_options.contains(SearchOptions::WHOLE_WORD) {
+                search.toggle_search_option(SearchOptions::WHOLE_WORD, cx);
             }
-            if action.include_ignored {
-                search.search_options.insert(SearchOptions::INCLUDE_IGNORED);
+            if action.include_ignored
+                && !search.search_options.contains(SearchOptions::INCLUDE_IGNORED)
+            {
+                search.toggle_search_option(SearchOptions::INCLUDE_IGNORED, cx);
             }
             let query = action.query.as_deref().or(query.as_deref());
             if let Some(query) = query {

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -5330,6 +5330,101 @@ pub mod tests {
     }
 
     #[gpui::test]
+    async fn test_smartcase_overrides_explicit_case_sensitive(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        cx.update(|cx| {
+            cx.update_global::<SettingsStore, _>(|store, cx| {
+                store.update_default_settings(cx, |settings| {
+                    settings.editor.use_smartcase_search = Some(true);
+                });
+            });
+        });
+
+        let fs = FakeFs::new(cx.background_executor.clone());
+        fs.insert_tree(
+            path!("/dir"),
+            json!({
+                "one.rs": "const ONE: usize = 1;",
+            }),
+        )
+        .await;
+        let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
+        let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project, window, cx));
+        let workspace = window
+            .read_with(cx, |mw, _| mw.workspace().clone())
+            .unwrap();
+        let cx = &mut VisualTestContext::from_window(window.into(), cx);
+        let search_bar = window.build_entity(cx, |_, _| ProjectSearchBar::new());
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.panes()[0].update(cx, |pane, cx| {
+                pane.toolbar()
+                    .update(cx, |toolbar, cx| toolbar.add_item(search_bar, window, cx))
+            });
+
+            ProjectSearchView::deploy_search(
+                workspace,
+                &workspace::DeploySearch {
+                    case_sensitive: true,
+                    query: Some("lowercase_query".into()),
+                    ..Default::default()
+                },
+                window,
+                cx,
+            )
+        });
+
+        let search_view = cx
+            .read(|cx| {
+                workspace
+                    .read(cx)
+                    .active_pane()
+                    .read(cx)
+                    .active_item()
+                    .and_then(|item| item.downcast::<ProjectSearchView>())
+            })
+            .expect("Search view should be active after deploy");
+
+        // Smartcase should override the explicit case_sensitive flag
+        // because the query is all lowercase.
+        search_view.update_in(cx, |search_view, _window, cx| {
+            assert!(
+                !search_view
+                    .search_options
+                    .contains(SearchOptions::CASE_SENSITIVE),
+                "Smartcase should disable case sensitivity for a lowercase query, \
+                 even when case_sensitive was explicitly set in the action"
+            );
+            let query_text = search_view.query_editor.read(cx).text(cx);
+            assert_eq!(query_text, "lowercase_query");
+        });
+
+        // Now deploy with an uppercase query — smartcase should enable case sensitivity.
+        workspace.update_in(cx, |workspace, window, cx| {
+            ProjectSearchView::deploy_search(
+                workspace,
+                &workspace::DeploySearch {
+                    query: Some("Uppercase_Query".into()),
+                    ..Default::default()
+                },
+                window,
+                cx,
+            )
+        });
+
+        search_view.update_in(cx, |search_view, _window, cx| {
+            assert!(
+                search_view
+                    .search_options
+                    .contains(SearchOptions::CASE_SENSITIVE),
+                "Smartcase should enable case sensitivity for a query containing uppercase"
+            );
+            let query_text = search_view.query_editor.read(cx).text(cx);
+            assert_eq!(query_text, "Uppercase_Query");
+        });
+    }
+
     fn init_test(cx: &mut TestAppContext) {
         cx.update(|cx| {
             let settings = SettingsStore::test(cx);

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -1219,7 +1219,11 @@ impl ProjectSearchView {
             {
                 search.toggle_search_option(SearchOptions::INCLUDE_IGNORED, cx);
             }
-            let query = action.query.as_deref().or(query.as_deref());
+            let query = action
+                .query
+                .as_deref()
+                .filter(|q| !q.is_empty())
+                .or(query.as_deref());
             if let Some(query) = query {
                 search.set_query(query, window, cx);
             }

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -1153,7 +1153,7 @@ impl ProjectSearchView {
         window: &mut Window,
         cx: &mut Context<Workspace>,
     ) {
-        Self::existing_or_new_search(workspace, None, &DeploySearch::find(), window, cx)
+        Self::existing_or_new_search(workspace, None, &DeploySearch::default(), window, cx)
     }
 
     fn existing_or_new_search(
@@ -3122,7 +3122,7 @@ pub mod tests {
 
             ProjectSearchView::deploy_search(
                 workspace,
-                &workspace::DeploySearch::find(),
+                &workspace::DeploySearch::default(),
                 window,
                 cx,
             )
@@ -3273,7 +3273,7 @@ pub mod tests {
         workspace.update_in(cx, |workspace, window, cx| {
             ProjectSearchView::deploy_search(
                 workspace,
-                &workspace::DeploySearch::find(),
+                &workspace::DeploySearch::default(),
                 window,
                 cx,
             )
@@ -3346,7 +3346,7 @@ pub mod tests {
 
             ProjectSearchView::deploy_search(
                 workspace,
-                &workspace::DeploySearch::find(),
+                &workspace::DeploySearch::default(),
                 window,
                 cx,
             )
@@ -4581,7 +4581,7 @@ pub mod tests {
         });
 
         // Deploy a new search
-        cx.dispatch_action(DeploySearch::find());
+        cx.dispatch_action(DeploySearch::default());
 
         // Both panes should now have a project search in them
         workspace.update_in(cx, |workspace, window, cx| {
@@ -4606,7 +4606,7 @@ pub mod tests {
             .unwrap();
 
         // Deploy a new search
-        cx.dispatch_action(DeploySearch::find());
+        cx.dispatch_action(DeploySearch::default());
 
         // The project search view should now be focused in the second pane
         // And the number of items should be unchanged.
@@ -4844,7 +4844,7 @@ pub mod tests {
             assert!(workspace.has_active_modal(window, cx));
         });
 
-        cx.dispatch_action(DeploySearch::find());
+        cx.dispatch_action(DeploySearch::default());
 
         workspace.update_in(cx, |workspace, window, cx| {
             assert!(!workspace.has_active_modal(window, cx));

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -5157,6 +5157,91 @@ pub mod tests {
             .unwrap();
     }
 
+    #[gpui::test]
+    async fn test_deploy_search_with_options(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.background_executor.clone());
+        fs.insert_tree(
+            "/dir",
+            json!({
+                "one.rs": "const ONE: usize = 1;",
+            }),
+        )
+        .await;
+        let project = Project::test(fs.clone(), ["/dir".as_ref()], cx).await;
+        let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project, window, cx));
+        let workspace = window
+            .read_with(cx, |mw, _| mw.workspace().clone())
+            .unwrap();
+        let cx = &mut VisualTestContext::from_window(window.into(), cx);
+        let search_bar = window.build_entity(cx, |_, _| ProjectSearchBar::new());
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.panes()[0].update(cx, |pane, cx| {
+                pane.toolbar()
+                    .update(cx, |toolbar, cx| toolbar.add_item(search_bar, window, cx))
+            });
+
+            ProjectSearchView::deploy_search(
+                workspace,
+                &workspace::DeploySearch {
+                    regex: true,
+                    case_sensitive: true,
+                    whole_word: true,
+                    include_ignored: true,
+                    query: Some("test_query".into()),
+                    ..Default::default()
+                },
+                window,
+                cx,
+            )
+        });
+
+        let search_view = cx
+            .read(|cx| {
+                workspace
+                    .read(cx)
+                    .active_pane()
+                    .read(cx)
+                    .active_item()
+                    .and_then(|item| item.downcast::<ProjectSearchView>())
+            })
+            .expect("Search view should be active after deploy");
+
+        search_view.update_in(cx, |search_view, _window, cx| {
+            assert!(
+                search_view
+                    .search_options
+                    .contains(SearchOptions::REGEX),
+                "Regex option should be enabled"
+            );
+            assert!(
+                search_view
+                    .search_options
+                    .contains(SearchOptions::CASE_SENSITIVE),
+                "Case sensitive option should be enabled"
+            );
+            assert!(
+                search_view
+                    .search_options
+                    .contains(SearchOptions::WHOLE_WORD),
+                "Whole word option should be enabled"
+            );
+            assert!(
+                search_view
+                    .search_options
+                    .contains(SearchOptions::INCLUDE_IGNORED),
+                "Include ignored option should be enabled"
+            );
+            let query_text = search_view.query_editor.read(cx).text(cx);
+            assert_eq!(
+                query_text, "test_query",
+                "Query should be set from the action"
+            );
+        });
+    }
+
     fn init_test(cx: &mut TestAppContext) {
         cx.update(|cx| {
             let settings = SettingsStore::test(cx);

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -1203,8 +1203,21 @@ impl ProjectSearchView {
 
         search.update(cx, |search, cx| {
             search.replace_enabled |= action.replace_enabled;
+            if action.regex {
+                search.search_options.insert(SearchOptions::REGEX);
+            }
+            if action.case_sensitive {
+                search.search_options.insert(SearchOptions::CASE_SENSITIVE);
+            }
+            if action.whole_word {
+                search.search_options.insert(SearchOptions::WHOLE_WORD);
+            }
+            if action.include_ignored {
+                search.search_options.insert(SearchOptions::INCLUDE_IGNORED);
+            }
+            let query = action.query.as_deref().or(query.as_deref());
             if let Some(query) = query {
-                search.set_query(&query, window, cx);
+                search.set_query(query, window, cx);
             }
             if let Some(included_files) = action.included_files.as_deref() {
                 search

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -195,6 +195,16 @@ pub struct DeploySearch {
     pub included_files: Option<String>,
     #[serde(default)]
     pub excluded_files: Option<String>,
+    #[serde(default)]
+    pub query: Option<String>,
+    #[serde(default)]
+    pub regex: bool,
+    #[serde(default)]
+    pub case_sensitive: bool,
+    #[serde(default)]
+    pub whole_word: bool,
+    #[serde(default)]
+    pub include_ignored: bool,
 }
 
 #[derive(Clone, Copy, PartialEq, Debug, Deserialize, JsonSchema, Default)]
@@ -312,6 +322,11 @@ impl DeploySearch {
             replace_enabled: false,
             included_files: None,
             excluded_files: None,
+            query: None,
+            regex: false,
+            case_sensitive: false,
+            whole_word: false,
+            include_ignored: false,
         }
     }
 }
@@ -4182,12 +4197,7 @@ fn default_render_tab_bar_buttons(
                             .separator()
                             .action(
                                 "Search Project",
-                                DeploySearch {
-                                    replace_enabled: false,
-                                    included_files: None,
-                                    excluded_files: None,
-                                }
-                                .boxed_clone(),
+                                DeploySearch::find().boxed_clone(),
                             )
                             .action("Search Symbols", ToggleProjectSymbols.boxed_clone())
                             .separator()

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -198,13 +198,13 @@ pub struct DeploySearch {
     #[serde(default)]
     pub query: Option<String>,
     #[serde(default)]
-    pub regex: bool,
+    pub regex: Option<bool>,
     #[serde(default)]
-    pub case_sensitive: bool,
+    pub case_sensitive: Option<bool>,
     #[serde(default)]
-    pub whole_word: bool,
+    pub whole_word: Option<bool>,
     #[serde(default)]
-    pub include_ignored: bool,
+    pub include_ignored: Option<bool>,
 }
 
 #[derive(Clone, Copy, PartialEq, Debug, Deserialize, JsonSchema, Default)]

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -316,12 +316,6 @@ actions!(
     ]
 );
 
-impl DeploySearch {
-    pub fn find() -> Self {
-        Self::default()
-    }
-}
-
 const MAX_NAVIGATION_HISTORY_LEN: usize = 1024;
 
 pub enum Event {
@@ -4186,10 +4180,7 @@ fn default_render_tab_bar_buttons(
                         menu.action("New File", NewFile.boxed_clone())
                             .action("Open File", ToggleFileFinder::default().boxed_clone())
                             .separator()
-                            .action(
-                                "Search Project",
-                                DeploySearch::find().boxed_clone(),
-                            )
+                            .action("Search Project", DeploySearch::default().boxed_clone())
                             .action("Search Symbols", ToggleProjectSymbols.boxed_clone())
                             .separator()
                             .action("New Terminal", NewTerminal::default().boxed_clone())

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -318,16 +318,7 @@ actions!(
 
 impl DeploySearch {
     pub fn find() -> Self {
-        Self {
-            replace_enabled: false,
-            included_files: None,
-            excluded_files: None,
-            query: None,
-            regex: false,
-            case_sensitive: false,
-            whole_word: false,
-            include_ignored: false,
-        }
+        Self::default()
     }
 }
 

--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -165,7 +165,7 @@ pub fn app_menus(cx: &mut App) -> Vec<Menu> {
                 MenuItem::os_action("Paste", editor::actions::Paste, OsAction::Paste),
                 MenuItem::separator(),
                 MenuItem::action("Find", search::buffer_search::Deploy::find()),
-                MenuItem::action("Find in Project", workspace::DeploySearch::find()),
+                MenuItem::action("Find in Project", workspace::DeploySearch::default()),
                 MenuItem::separator(),
                 MenuItem::action(
                     "Toggle Line Comment",


### PR DESCRIPTION
Extend the DeploySearch action to accept additional parameters for configuring the project search from keymaps:

- query: prefilled search query string
- regex: enable regex search mode
- case_sensitive: match case exactly
- whole_word: match whole words only
- include_ignored: search in gitignored files

With this change, the following keymap becomes possible:

```json
["pane::DeploySearch", { "query": "TODO|FIXME|NOTE|BUG|HACK|XXX|WARN", "regex": true }],
```

Release Notes:

- Added options to `pane::DeploySearch` for keymap-driven search initiation
