### PR TITLE
settings_ui: Fix project settings selecting wrong project

### DIFF
--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -400,7 +400,7 @@ pub fn init(cx: &mut App) {
                         .window_handle()
                         .downcast::<MultiWorkspace>()
                         .expect("Workspaces are root Windows");
-                    open_settings_editor(workspace, Some(&path), false, window_handle, cx);
+                    open_settings_editor(workspace, Some(&path), None, window_handle, cx);
                 },
             )
             .register_action(|workspace, _: &OpenSettings, window, cx| {
@@ -408,14 +408,24 @@ pub fn init(cx: &mut App) {
                     .window_handle()
                     .downcast::<MultiWorkspace>()
                     .expect("Workspaces are root Windows");
-                open_settings_editor(workspace, None, false, window_handle, cx);
+                open_settings_editor(workspace, None, None, window_handle, cx);
             })
             .register_action(|workspace, _: &OpenProjectSettings, window, cx| {
                 let window_handle = window
                     .window_handle()
                     .downcast::<MultiWorkspace>()
                     .expect("Workspaces are root Windows");
-                open_settings_editor(workspace, None, true, window_handle, cx);
+                let target_worktree_id = workspace
+                    .project()
+                    .read(cx)
+                    .visible_worktrees(cx)
+                    .find_map(|tree| {
+                        tree.read(cx)
+                            .root_entry()?
+                            .is_dir()
+                            .then_some(tree.read(cx).id())
+                    });
+                open_settings_editor(workspace, None, target_worktree_id, window_handle, cx);
             });
     })
     .detach();
@@ -554,7 +564,7 @@ fn init_renderers(cx: &mut App) {
 pub fn open_settings_editor(
     _workspace: &mut Workspace,
     path: Option<&str>,
-    open_project_settings: bool,
+    target_worktree_id: Option<WorktreeId>,
     workspace_handle: WindowHandle<MultiWorkspace>,
     cx: &mut App,
 ) {
@@ -563,8 +573,6 @@ pub fn open_settings_editor(
     /// Assumes a settings GUI window is already open
     fn open_path(
         path: &str,
-        // Note: This option is unsupported right now
-        _open_project_settings: bool,
         settings_window: &mut SettingsWindow,
         window: &mut Window,
         cx: &mut Context<SettingsWindow>,
@@ -617,16 +625,14 @@ pub fn open_settings_editor(
                 settings_window.original_window = Some(workspace_handle);
                 window.activate_window();
                 if let Some(path) = path {
-                    open_path(path, open_project_settings, settings_window, window, cx);
-                } else if open_project_settings {
-                    if let Some(file_index) = settings_window
+                    open_path(path, settings_window, window, cx);
+                } else if let Some(target_id) = target_worktree_id
+                    && let Some(file_index) = settings_window
                         .files
                         .iter()
-                        .position(|(file, _)| file.worktree_id().is_some())
-                    {
-                        settings_window.change_file(file_index, window, cx);
-                    }
-
+                        .position(|(file, _)| file.worktree_id() == Some(target_id))
+                {
+                    settings_window.change_file(file_index, window, cx);
                     cx.notify();
                 }
             })
@@ -680,17 +686,14 @@ pub fn open_settings_editor(
                     cx.new(|cx| SettingsWindow::new(Some(workspace_handle), window, cx));
                 settings_window.update(cx, |settings_window, cx| {
                     if let Some(path) = path {
-                        open_path(&path, open_project_settings, settings_window, window, cx);
-                    } else if open_project_settings {
-                        if let Some(file_index) = settings_window
+                        open_path(&path, settings_window, window, cx);
+                    } else if let Some(target_id) = target_worktree_id
+                        && let Some(file_index) = settings_window
                             .files
                             .iter()
-                            .position(|(file, _)| file.worktree_id().is_some())
-                        {
-                            settings_window.change_file(file_index, window, cx);
-                        }
-
-                        settings_window.fetch_files(window, cx);
+                            .position(|(file, _)| file.worktree_id() == Some(target_id))
+                    {
+                        settings_window.change_file(file_index, window, cx);
                     }
                 });
 


### PR DESCRIPTION

Opening project settings now selects active project instead of any open one by using worktree id matching the behavior of opening project settings file.

<details>
<summary>Before</summary>

https://github.com/user-attachments/assets/8bf9a6cb-06e4-48fc-bf47-429e51ef9d27
</details>

<details>
<summary>After</summary>

https://github.com/user-attachments/assets/d8f5c69d-796c-4eb6-90c7-4ecb8951a1d1

</details>

Release Notes: 
- Fixed an issue where the active project would not be opened in the settings UI with `zed: open project settings`
