### PR TITLE
git_ui: Add recent commits view and button

### DIFF
--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -1596,7 +1596,11 @@ impl GitRepository for RealGitRepository {
                     commit_delimiter
                 );
 
-                let mut args = vec!["--no-optional-locks", "log", "--follow", &format_string];
+                let mut args = vec!["--no-optional-locks", "log"];
+                if !path.is_empty() {
+                    args.push("--follow");
+                }
+                args.push(&format_string);
 
                 let skip_str;
                 let limit_str;
@@ -1616,7 +1620,11 @@ impl GitRepository for RealGitRepository {
                 let output = new_smol_command(&git_binary_path)
                     .current_dir(&working_directory)
                     .args(&args)
-                    .arg(path.as_unix_str())
+                    .arg(if path.is_empty() {
+                        "."
+                    } else {
+                        path.as_unix_str()
+                    })
                     .output()
                     .await?;
 

--- a/crates/git_ui/src/file_history_view.rs
+++ b/crates/git_ui/src/file_history_view.rs
@@ -268,12 +268,18 @@ impl FileHistoryView {
 
         if let Some(repo) = self.repository.upgrade() {
             let sha_str = entry.sha.to_string();
+            let file_filter = if self.history.path.is_empty() {
+                None
+            } else {
+                Some(self.history.path.clone())
+            };
+
             CommitView::open(
                 sha_str,
                 repo.downgrade(),
                 self.workspace.clone(),
                 None,
-                Some(self.history.path.clone()),
+                file_filter,
                 window,
                 cx,
             );
@@ -545,6 +551,10 @@ impl Item for FileHistoryView {
     }
 
     fn tab_content_text(&self, _detail: usize, _cx: &App) -> SharedString {
+        if self.history.path.is_empty() {
+            return "Recent Commits".into();
+        }
+
         let file_name = self
             .history
             .path
@@ -555,11 +565,19 @@ impl Item for FileHistoryView {
     }
 
     fn tab_tooltip_text(&self, _cx: &App) -> Option<SharedString> {
-        Some(format!("Git history for {}", self.history.path.as_unix_str()).into())
+        if self.history.path.is_empty() {
+            Some("Recent Commits".into())
+        } else {
+            Some(format!("Git history for {}", self.history.path.as_unix_str()).into())
+        }
     }
 
     fn tab_icon(&self, _window: &Window, _cx: &App) -> Option<Icon> {
-        Some(Icon::new(IconName::GitBranch))
+        if self.history.path.is_empty() {
+            Some(Icon::new(IconName::HistoryRerun))
+        } else {
+            Some(Icon::new(IconName::GitBranch))
+        }
     }
 
     fn telemetry_event_text(&self) -> Option<&'static str> {

--- a/crates/git_ui/src/git_history_view.rs
+++ b/crates/git_ui/src/git_history_view.rs
@@ -36,7 +36,7 @@ pub fn init(cx: &mut App) {
 
 const PAGE_SIZE: usize = 50;
 
-pub struct FileHistoryView {
+pub struct GitHistoryView {
     history: FileHistory,
     repository: WeakEntity<Repository>,
     git_store: WeakEntity<GitStore>,
@@ -49,7 +49,7 @@ pub struct FileHistoryView {
     has_more: bool,
 }
 
-impl FileHistoryView {
+impl GitHistoryView {
     pub fn open(
         path: RepoPath,
         git_store: WeakEntity<GitStore>,
@@ -76,7 +76,7 @@ impl FileHistoryView {
                     .update_in(cx, |workspace, window, cx| {
                         let project = workspace.project();
                         let view = cx.new(|cx| {
-                            FileHistoryView::new(
+                            GitHistoryView::new(
                                 file_history,
                                 git_store.clone(),
                                 repo.clone(),
@@ -90,7 +90,7 @@ impl FileHistoryView {
                         let pane = workspace.active_pane();
                         pane.update(cx, |pane, cx| {
                             let ix = pane.items().position(|item| {
-                                let view = item.downcast::<FileHistoryView>();
+                                let view = item.downcast::<GitHistoryView>();
                                 view.is_some_and(|v| v.read(cx).history.path == path)
                             });
                             if let Some(ix) = ix {
@@ -446,22 +446,22 @@ impl Asset for CommitAvatarAsset {
     }
 }
 
-impl EventEmitter<ItemEvent> for FileHistoryView {}
+impl EventEmitter<ItemEvent> for GitHistoryView {}
 
-impl Focusable for FileHistoryView {
+impl Focusable for GitHistoryView {
     fn focus_handle(&self, _cx: &App) -> FocusHandle {
         self.focus_handle.clone()
     }
 }
 
-impl Render for FileHistoryView {
+impl Render for GitHistoryView {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let _file_name = self.history.path.file_name().unwrap_or("File");
         let entry_count = self.history.entries.len();
 
         v_flex()
-            .id("file_history_view")
-            .key_context("FileHistoryView")
+            .id("git_history_view")
+            .key_context("GitHistoryView")
             .track_focus(&self.focus_handle)
             .on_action(cx.listener(Self::select_next))
             .on_action(cx.listener(Self::select_previous))
@@ -543,7 +543,7 @@ impl Render for FileHistoryView {
     }
 }
 
-impl Item for FileHistoryView {
+impl Item for GitHistoryView {
     type Event = ItemEvent;
 
     fn to_item_events(event: &Self::Event, mut f: impl FnMut(ItemEvent)) {

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -4475,23 +4475,52 @@ impl GitPanel {
                 )
                 .when(commit.has_parent, |this| {
                     let has_unstaged = self.has_unstaged_changes();
+                    let repo = active_repository.downgrade();
+                    let git_store = self.project.read(cx).git_store().downgrade();
+                    let workspace = self.workspace.clone();
+
                     this.pr_2().child(
-                        panel_icon_button("undo", IconName::Undo)
-                            .icon_size(IconSize::XSmall)
-                            .icon_color(Color::Muted)
-                            .tooltip(move |_window, cx| {
-                                Tooltip::with_meta(
-                                    "Uncommit",
-                                    Some(&git::Uncommit),
-                                    if has_unstaged {
-                                        "git reset HEAD^ --soft"
-                                    } else {
-                                        "git reset HEAD^"
-                                    },
-                                    cx,
-                                )
-                            })
-                            .on_click(cx.listener(|this, _, window, cx| this.uncommit(window, cx))),
+                        h_flex()
+                            .child(
+                                panel_icon_button("history", IconName::HistoryRerun)
+                                    .icon_size(IconSize::XSmall)
+                                    .icon_color(Color::Muted)
+                                    .tooltip(move |window, cx| {
+                                        Tooltip::text("Recent Commits")(window, cx)
+                                    })
+                                    .on_click(move |_, window, cx| {
+                                        FileHistoryView::open(
+                                            RepoPath::from_rel_path(RelPath::empty()),
+                                            git_store.clone(),
+                                            repo.clone(),
+                                            workspace.clone(),
+                                            window,
+                                            cx,
+                                        );
+                                    }),
+                            )
+                            .child(
+                                panel_icon_button("undo", IconName::Undo)
+                                    .icon_size(IconSize::XSmall)
+                                    .icon_color(Color::Muted)
+                                    .tooltip(move |_window, cx| {
+                                        Tooltip::with_meta(
+                                            "Uncommit",
+                                            Some(&git::Uncommit),
+                                            if has_unstaged {
+                                                "git reset HEAD^ --soft"
+                                            } else {
+                                                "git reset HEAD^"
+                                            },
+                                            cx,
+                                        )
+                                    })
+                                    .on_click(
+                                        cx.listener(|this, _, window, cx| {
+                                            this.uncommit(window, cx)
+                                        }),
+                                    ),
+                            ),
                     )
                 }),
         )

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -6,7 +6,7 @@ use crate::project_diff::{self, Diff, ProjectDiff};
 use crate::remote_output::{self, RemoteAction, SuccessMessage};
 use crate::{branch_picker, picker_prompt, render_remote_button};
 use crate::{
-    file_history_view::FileHistoryView, git_panel_settings::GitPanelSettings, git_status_icon,
+    git_history_view::GitHistoryView, git_panel_settings::GitPanelSettings, git_status_icon,
     repository_selector::RepositorySelector,
 };
 use agent_settings::AgentSettings;
@@ -1233,7 +1233,7 @@ impl GitPanel {
             let repo_path = entry.repo_path.clone();
             let git_store = self.project.read(cx).git_store();
 
-            FileHistoryView::open(
+            GitHistoryView::open(
                 repo_path,
                 git_store.downgrade(),
                 active_repo.downgrade(),
@@ -4489,7 +4489,7 @@ impl GitPanel {
                                         Tooltip::text("Recent Commits")(window, cx)
                                     })
                                     .on_click(move |_, window, cx| {
-                                        FileHistoryView::open(
+                                        GitHistoryView::open(
                                             RepoPath::from_rel_path(RelPath::empty()),
                                             git_store.clone(),
                                             repo.clone(),

--- a/crates/git_ui/src/git_ui.rs
+++ b/crates/git_ui/src/git_ui.rs
@@ -38,7 +38,7 @@ pub mod commit_tooltip;
 pub mod commit_view;
 mod conflict_view;
 pub mod file_diff_view;
-pub mod file_history_view;
+pub mod git_history_view;
 pub mod git_panel;
 mod git_panel_settings;
 pub mod git_picker;
@@ -62,7 +62,7 @@ actions!(
 pub fn init(cx: &mut App) {
     editor::set_blame_renderer(blame_ui::GitBlameRenderer, cx);
     commit_view::init(cx);
-    file_history_view::init(cx);
+    git_history_view::init(cx);
 
     cx.observe_new(|editor: &mut Editor, _, cx| {
         conflict_view::register_editor(editor, editor.buffer().clone(), cx);
@@ -266,7 +266,7 @@ pub fn init(cx: &mut App) {
             else {
                 return;
             };
-            file_history_view::FileHistoryView::open(
+            git_history_view::GitHistoryView::open(
                 repo_path,
                 git_store.downgrade(),
                 repo.downgrade(),

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -487,7 +487,7 @@ pub fn init(cx: &mut App) {
                         .read(cx)
                         .repository_and_path_for_project_path(&project_path, cx)
                     {
-                        git_ui::file_history_view::FileHistoryView::open(
+                        git_ui::git_history_view::GitHistoryView::open(
                             repo_path,
                             git_store.downgrade(),
                             repo.downgrade(),
@@ -517,7 +517,7 @@ pub fn init(cx: &mut App) {
                     .read(cx)
                     .repository_and_path_for_project_path(&project_path, cx)
                 {
-                    git_ui::file_history_view::FileHistoryView::open(
+                    git_ui::git_history_view::GitHistoryView::open(
                         repo_path,
                         git_store.downgrade(),
                         repo.downgrade(),


### PR DESCRIPTION
## Related Issues

#35945 
#26511 
#10807 

And its somewhat related with the `git-graph` feature that the zed team is working on but way more simplified

## Context

I needed to see what lines I changed for a rebase and this feature wasn't available in zed and ended up using _github desktop_ to solve it. I did my research and found out that there was a _file history_ functionality recently released that had all the necessary to implement this wanted recent commits feature in a simple and elegant way.

I decided to add a button next to the uncommit one at the bottom of the git panel since it was the place where previous commits are shown and actually the first place I looked at when I felt I needed the feature. It feels natural there for my liking.

## Release Notes:

- Add button with HistoryRerun icon next to the Uncommit button for "Recent Commits"
- Refactor `FileHistoryView` for both file history and recent commits history

## Video

I first show how the _file history_  view looks and then the new _recent commits_ button and view

https://github.com/user-attachments/assets/982e0561-f329-42b5-aff9-989f27712181


I hope the zed team consider this feature since its small yet really useful and it can provide a lot value before the graph view is released