### PR TITLE
lsp: Exclude dynamic settings from LanguageServerSeed identity

### DIFF
--- a/crates/project/src/manifest_tree/server_tree.rs
+++ b/crates/project/src/manifest_tree/server_tree.rs
@@ -421,11 +421,13 @@ impl ServerTreeRebase {
                     .and_then(|worktree_nodes| worktree_nodes.roots.get(&disposition.path.path))
                     .and_then(|roots| roots.get(&disposition.server_name))
                     .filter(|(old_node, _)| {
-                        (&disposition.toolchain, &disposition.settings)
-                            == (
-                                &old_node.disposition.toolchain,
-                                &old_node.disposition.settings,
-                            )
+                        // Only compare settings that require server restart.
+                        // Dynamic settings (settings.settings) can be updated via DidChangeConfiguration
+                        // without restarting the server.
+                        disposition.toolchain == old_node.disposition.toolchain
+                            && disposition.settings.binary == old_node.disposition.settings.binary
+                            && disposition.settings.initialization_options
+                                == old_node.disposition.settings.initialization_options
                     })
                 else {
                     return Some(node);

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -17,6 +17,7 @@ use rpc::{
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+pub use settings::BinarySettings;
 pub use settings::DirenvSettings;
 pub use settings::LspSettings;
 use settings::{


### PR DESCRIPTION
`LanguageServerSeed` is used as a key to identify language servers. Previously, it included the entire `LspSettings`, which meant that changing `lsp.<server>.settings` (dynamic configuration) would cause the server to restart unnecessarily.

Dynamic settings can be updated via LSP's `workspace/didChangeConfiguration` notification without requiring a server restart. Only `binary` and `initialization_options` should be part of the server identity, as changes to these genuinely require restarting the server.

This is a follow-up fix to #35270 which introduced `LanguageServerSeed` but inadvertently included dynamic settings in the server identity (although I remember that this dynamic settings reflection stopped working pretty recently, so there might be other commits besides #35270 that changed the behavior of `LanguageServerSeed`)

Closes #ISSUE

Release Notes:

- Fixed language servers unnecessarily restarting when changing `lsp.<server>.settings` configuration. Dynamic settings are now properly updated via `workspace/didChangeConfiguration` without requiring a server restart. 
