### PR TITLE
agent: Don't show inline assistant feedback buttons if setting is disabled

### DIFF
--- a/crates/agent_ui/src/inline_prompt_editor.rs
+++ b/crates/agent_ui/src/inline_prompt_editor.rs
@@ -1,5 +1,6 @@
 use crate::acp::AcpThreadHistory;
 use agent::ThreadStore;
+use agent_settings::AgentSettings;
 use collections::{HashMap, VecDeque};
 use editor::actions::Paste;
 use editor::code_context_menus::CodeContextMenu;
@@ -848,72 +849,78 @@ impl<T: 'static> PromptEditor<T> {
 
                     let mut buttons = Vec::new();
 
-                    buttons.push(
-                        h_flex()
-                            .pl_1()
-                            .gap_1()
-                            .border_l_1()
-                            .border_color(cx.theme().colors().border_variant)
-                            .child(
-                                IconButton::new("thumbs-up", IconName::ThumbsUp)
-                                    .shape(IconButtonShape::Square)
-                                    .map(|this| {
-                                        if rated {
-                                            this.disabled(true).icon_color(Color::Disabled).tooltip(
-                                                move |_, cx| {
-                                                    Tooltip::with_meta(
-                                                        "Good Result",
-                                                        None,
-                                                        "You already rated this result",
-                                                        cx,
-                                                    )
-                                                },
-                                            )
-                                        } else {
-                                            this.icon_color(Color::Muted).tooltip(move |_, cx| {
-                                                Tooltip::for_action(
-                                                    "Good Result",
-                                                    &ThumbsUpResult,
-                                                    cx,
+                    if AgentSettings::get_global(cx).enable_feedback {
+                        buttons.push(
+                            h_flex()
+                                .pl_1()
+                                .gap_1()
+                                .border_l_1()
+                                .border_color(cx.theme().colors().border_variant)
+                                .child(
+                                    IconButton::new("thumbs-up", IconName::ThumbsUp)
+                                        .shape(IconButtonShape::Square)
+                                        .map(|this| {
+                                            if rated {
+                                                this.disabled(true)
+                                                    .icon_color(Color::Disabled)
+                                                    .tooltip(move |_, cx| {
+                                                        Tooltip::with_meta(
+                                                            "Good Result",
+                                                            None,
+                                                            "You already rated this result",
+                                                            cx,
+                                                        )
+                                                    })
+                                            } else {
+                                                this.icon_color(Color::Muted).tooltip(
+                                                    move |_, cx| {
+                                                        Tooltip::for_action(
+                                                            "Good Result",
+                                                            &ThumbsUpResult,
+                                                            cx,
+                                                        )
+                                                    },
                                                 )
-                                            })
-                                        }
-                                    })
-                                    .on_click(cx.listener(|this, _, window, cx| {
-                                        this.thumbs_up(&ThumbsUpResult, window, cx);
-                                    })),
-                            )
-                            .child(
-                                IconButton::new("thumbs-down", IconName::ThumbsDown)
-                                    .shape(IconButtonShape::Square)
-                                    .map(|this| {
-                                        if rated {
-                                            this.disabled(true).icon_color(Color::Disabled).tooltip(
-                                                move |_, cx| {
-                                                    Tooltip::with_meta(
-                                                        "Bad Result",
-                                                        None,
-                                                        "You already rated this result",
-                                                        cx,
-                                                    )
-                                                },
-                                            )
-                                        } else {
-                                            this.icon_color(Color::Muted).tooltip(move |_, cx| {
-                                                Tooltip::for_action(
-                                                    "Bad Result",
-                                                    &ThumbsDownResult,
-                                                    cx,
+                                            }
+                                        })
+                                        .on_click(cx.listener(|this, _, window, cx| {
+                                            this.thumbs_up(&ThumbsUpResult, window, cx);
+                                        })),
+                                )
+                                .child(
+                                    IconButton::new("thumbs-down", IconName::ThumbsDown)
+                                        .shape(IconButtonShape::Square)
+                                        .map(|this| {
+                                            if rated {
+                                                this.disabled(true)
+                                                    .icon_color(Color::Disabled)
+                                                    .tooltip(move |_, cx| {
+                                                        Tooltip::with_meta(
+                                                            "Bad Result",
+                                                            None,
+                                                            "You already rated this result",
+                                                            cx,
+                                                        )
+                                                    })
+                                            } else {
+                                                this.icon_color(Color::Muted).tooltip(
+                                                    move |_, cx| {
+                                                        Tooltip::for_action(
+                                                            "Bad Result",
+                                                            &ThumbsDownResult,
+                                                            cx,
+                                                        )
+                                                    },
                                                 )
-                                            })
-                                        }
-                                    })
-                                    .on_click(cx.listener(|this, _, window, cx| {
-                                        this.thumbs_down(&ThumbsDownResult, window, cx);
-                                    })),
-                            )
-                            .into_any_element(),
-                    );
+                                            }
+                                        })
+                                        .on_click(cx.listener(|this, _, window, cx| {
+                                            this.thumbs_down(&ThumbsDownResult, window, cx);
+                                        })),
+                                )
+                                .into_any_element(),
+                        );
+                    }
 
                     buttons.push(accept);
 


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/47347

Release Notes:

- Agent: Fixed a bug where the inline assistant feedback buttons where being displayed despite the setting "Enable Feedback" was turned off.
