### PR TITLE
settings_ui: Fix font weight number field rendering

### DIFF
--- a/crates/settings_content/src/theme.rs
+++ b/crates/settings_content/src/theme.rs
@@ -1270,9 +1270,31 @@ pub enum FontStyleContent {
     Oblique,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Serialize, Deserialize, MergeFrom)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    PartialOrd,
+    Serialize,
+    Deserialize,
+    MergeFrom,
+    derive_more::FromStr,
+)]
 #[serde(transparent)]
 pub struct FontWeightContent(pub f32);
+
+impl Display for FontWeightContent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<f32> for FontWeightContent {
+    fn from(weight: f32) -> Self {
+        FontWeightContent(weight)
+    }
+}
 
 impl Default for FontWeightContent {
     fn default() -> Self {

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -497,7 +497,7 @@ fn init_renderers(cx: &mut App) {
         .add_basic_renderer::<NonZeroU32>(render_number_field)
         .add_basic_renderer::<settings::CodeFade>(render_number_field)
         .add_basic_renderer::<settings::DelayMs>(render_number_field)
-        .add_basic_renderer::<gpui::FontWeight>(render_number_field)
+        .add_basic_renderer::<settings::FontWeightContent>(render_number_field)
         .add_basic_renderer::<settings::CenteredPaddingSettings>(render_number_field)
         .add_basic_renderer::<settings::InactiveOpacity>(render_number_field)
         .add_basic_renderer::<settings::MinimumContrast>(render_number_field)

--- a/crates/ui_input/src/number_field.rs
+++ b/crates/ui_input/src/number_field.rs
@@ -12,7 +12,8 @@ use gpui::{
 };
 
 use settings::{
-    CenteredPaddingSettings, CodeFade, DelayMs, FontSize, InactiveOpacity, MinimumContrast,
+    CenteredPaddingSettings, CodeFade, DelayMs, FontSize, FontWeightContent, InactiveOpacity,
+    MinimumContrast,
 };
 use ui::prelude::*;
 
@@ -106,6 +107,7 @@ macro_rules! impl_newtype_numeric_stepper_int {
 
 #[rustfmt::skip]
 impl_newtype_numeric_stepper_float!(FontWeight, 50., 100., 10., FontWeight::THIN, FontWeight::BLACK);
+impl_newtype_numeric_stepper_float!(FontWeightContent, 50., 100., 10., FontWeightContent::THIN, FontWeightContent::BLACK);
 impl_newtype_numeric_stepper_float!(CodeFade, 0.1, 0.2, 0.05, 0.0, 0.9);
 impl_newtype_numeric_stepper_float!(FontSize, 1.0, 4.0, 0.5, 6.0, 72.0);
 impl_newtype_numeric_stepper_float!(InactiveOpacity, 0.1, 0.2, 0.05, 0.0, 1.0);

--- a/crates/ui_input/src/number_field.rs
+++ b/crates/ui_input/src/number_field.rs
@@ -107,7 +107,14 @@ macro_rules! impl_newtype_numeric_stepper_int {
 
 #[rustfmt::skip]
 impl_newtype_numeric_stepper_float!(FontWeight, 50., 100., 10., FontWeight::THIN, FontWeight::BLACK);
-impl_newtype_numeric_stepper_float!(FontWeightContent, 50., 100., 10., FontWeightContent::THIN, FontWeightContent::BLACK);
+impl_newtype_numeric_stepper_float!(
+    FontWeightContent,
+    50.,
+    100.,
+    10.,
+    FontWeightContent::THIN,
+    FontWeightContent::BLACK
+);
 impl_newtype_numeric_stepper_float!(CodeFade, 0.1, 0.2, 0.05, 0.0, 0.9);
 impl_newtype_numeric_stepper_float!(FontSize, 1.0, 4.0, 0.5, 6.0, 72.0);
 impl_newtype_numeric_stepper_float!(InactiveOpacity, 0.1, 0.2, 0.05, 0.0, 1.0);


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/47353

Release Notes:

- Settings Editor: Fixed a bug with the number field rendering of the font weight setting.
