### PR TITLE
acp: Support unstable session/resume request

### DIFF
--- a/crates/acp_thread/src/connection.rs
+++ b/crates/acp_thread/src/connection.rs
@@ -53,6 +53,29 @@ pub trait AgentConnection {
         Task::ready(Err(anyhow::Error::msg("Loading sessions is not supported")))
     }
 
+    /// Whether this agent supports resuming existing sessions without loading history.
+    fn supports_resume_session(&self, _cx: &App) -> bool {
+        false
+    }
+
+    /// Resume an existing session by ID without replaying previous messages.
+    fn resume_session(
+        self: Rc<Self>,
+        _session: AgentSessionInfo,
+        _project: Entity<Project>,
+        _cwd: &Path,
+        _cx: &mut App,
+    ) -> Task<Result<Entity<AcpThread>>> {
+        Task::ready(Err(anyhow::Error::msg(
+            "Resuming sessions is not supported",
+        )))
+    }
+
+    /// Whether this agent supports showing session history.
+    fn supports_session_history(&self, cx: &App) -> bool {
+        self.supports_load_session(cx) || self.supports_resume_session(cx)
+    }
+
     fn auth_methods(&self) -> &[acp::AuthMethod];
 
     fn authenticate(&self, method: acp::AuthMethodId, cx: &mut App) -> Task<Result<()>>;

--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -590,6 +590,15 @@ impl AgentConnection for AcpConnection {
         cx.has_flag::<AcpBetaFeatureFlag>() && self.agent_capabilities.load_session
     }
 
+    fn supports_resume_session(&self, cx: &App) -> bool {
+        cx.has_flag::<AcpBetaFeatureFlag>()
+            && self
+                .agent_capabilities
+                .session_capabilities
+                .resume
+                .is_some()
+    }
+
     fn load_session(
         self: Rc<Self>,
         session: AgentSessionInfo,
@@ -634,6 +643,84 @@ impl AgentConnection for AcpConnection {
                 .connection
                 .load_session(
                     acp::LoadSessionRequest::new(session.session_id.clone(), cwd)
+                        .mcp_servers(mcp_servers),
+                )
+                .await
+            {
+                Ok(response) => response,
+                Err(err) => {
+                    self.sessions.borrow_mut().remove(&session.session_id);
+                    return Err(map_acp_error(err));
+                }
+            };
+
+            let (modes, models, config_options) = cx.update(|cx| {
+                config_state(cx, response.modes, response.models, response.config_options)
+            });
+            if let Some(session) = self.sessions.borrow_mut().get_mut(&session.session_id) {
+                session.session_modes = modes;
+                session.models = models;
+                session.config_options = config_options.map(ConfigOptions::new);
+            }
+
+            if let Some(session_list) = &self.session_list {
+                session_list.notify_update();
+            }
+
+            Ok(thread)
+        })
+    }
+
+    fn resume_session(
+        self: Rc<Self>,
+        session: AgentSessionInfo,
+        project: Entity<Project>,
+        cwd: &Path,
+        cx: &mut App,
+    ) -> Task<Result<Entity<AcpThread>>> {
+        if !cx.has_flag::<AcpBetaFeatureFlag>()
+            || self
+                .agent_capabilities
+                .session_capabilities
+                .resume
+                .is_none()
+        {
+            return Task::ready(Err(anyhow!(LoadError::Other(
+                "Resuming sessions is not supported by this agent.".into()
+            ))));
+        }
+
+        let cwd = cwd.to_path_buf();
+        let mcp_servers = mcp_servers_for_project(&project, cx);
+        let action_log = cx.new(|_| ActionLog::new(project.clone()));
+        let thread: Entity<AcpThread> = cx.new(|cx| {
+            AcpThread::new(
+                self.server_name.clone(),
+                self.clone(),
+                project,
+                action_log,
+                session.session_id.clone(),
+                watch::Receiver::constant(self.agent_capabilities.prompt_capabilities.clone()),
+                cx,
+            )
+        });
+
+        self.sessions.borrow_mut().insert(
+            session.session_id.clone(),
+            AcpSession {
+                thread: thread.downgrade(),
+                suppress_abort_err: false,
+                session_modes: None,
+                models: None,
+                config_options: None,
+            },
+        );
+
+        cx.spawn(async move |cx| {
+            let response = match self
+                .connection
+                .resume_session(
+                    acp::ResumeSessionRequest::new(session.session_id.clone(), cwd)
                         .mcp_servers(mcp_servers),
                 )
                 .await

--- a/crates/agent_ui_v2/src/agents_panel.rs
+++ b/crates/agent_ui_v2/src/agents_panel.rs
@@ -151,7 +151,7 @@ impl AgentsPanel {
             };
 
             cx.update(|cx| {
-                if connection.supports_load_session(cx)
+                if connection.supports_session_history(cx)
                     && let Some(session_list) = connection.session_list(cx)
                 {
                     history_handle.update(cx, |history, cx| {


### PR DESCRIPTION
This is behind the beta flag. But some agents don't support a full load flow, but rather just a resume from the current state of the session. They don't emit notifications for past thread messages, which isn't ideal, but the user can at least resume their work without completely losing it.

We use it as a fallback if the agent doesn't support loading only, and signal to the user that they won't be able to see previous messages.

Release Notes:

- N/A
