### PR TITLE
Revert "Make apostrophes not brackets in markdown (#46414)"

### DIFF
--- a/crates/languages/src/markdown/brackets.scm
+++ b/crates/languages/src/markdown/brackets.scm
@@ -3,4 +3,5 @@
 ("{" @open "}" @close)
 (("\"" @open "\"" @close) (#set! rainbow.exclude))
 (("`" @open "`" @close) (#set! rainbow.exclude))
+(("'" @open "'" @close) (#set! rainbow.exclude))
 (((fenced_code_block_delimiter) @open (fenced_code_block_delimiter) @close) (#set! rainbow.exclude))


### PR DESCRIPTION
This reverts commit 8842cc696f55097de54a5cd7228afdd8f8acb883.

https://github.com/zed-industries/zed/commit/1062e2c5a9e9764b58c5c3fdec6a5b9bddd1dd2e was landed interim which has a test that's broken now.

Something-something build queue.

Release Notes:

- N/A
