### PR TITLE
terminal: Fix `test_terminal_eof` test failing on fish shell

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -2497,6 +2497,7 @@ mod tests {
     use smol::channel::Receiver;
     use task::{Shell, ShellBuilder};
 
+    #[cfg(target_os = "macos")]
     fn init_test(cx: &mut TestAppContext) {
         cx.update(|cx| {
             let settings_store = settings::SettingsStore::test(cx);

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -2497,6 +2497,14 @@ mod tests {
     use smol::channel::Receiver;
     use task::{Shell, ShellBuilder};
 
+    fn init_test(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            let settings_store = settings::SettingsStore::test(cx);
+            cx.set_global(settings_store);
+            theme::init(theme::LoadThemes::JustBase, cx);
+        });
+    }
+
     /// Helper to build a test terminal running a shell command.
     /// Returns the terminal entity and a receiver for the completion signal.
     async fn build_test_terminal(
@@ -2645,6 +2653,8 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[gpui::test(iterations = 10)]
     async fn test_terminal_eof(cx: &mut TestAppContext) {
+        init_test(cx);
+
         cx.executor().allow_parking();
 
         let (completion_tx, completion_rx) = smol::channel::unbounded();


### PR DESCRIPTION
It turns out Alacritty sends `AlacTermEvent::ColorRequest` when using the fish shell. That path relies on `cx.theme`, so this change is needed for it to pass.

Co-authored-by: Lukas <lukas@zed.dev>

Release Notes:

- N/A
