### PR TITLE
terminal: Fix terminal freeze when child process is killed by signal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,7 +508,8 @@ dependencies = [
 
 [[package]]
 name = "alacritty_terminal"
-version = "0.25.2-dev"
+version = "0.25.1"
+source = "git+https://github.com/zed-industries/alacritty?rev=936aee8761a17affc84ab418ae21306c27c26221#936aee8761a17affc84ab418ae21306c27c26221"
 dependencies = [
  "base64 0.22.1",
  "bitflags 2.9.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,9 +508,7 @@ dependencies = [
 
 [[package]]
 name = "alacritty_terminal"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46319972e74179d707445f64aaa2893bbf6a111de3a9af29b7eb382f8b39e282"
+version = "0.25.2-dev"
 dependencies = [
  "base64 0.22.1",
  "bitflags 2.9.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -453,7 +453,7 @@ ztracing_macro = { path = "crates/ztracing_macro" }
 
 agent-client-protocol = { version = "=0.9.3", features = ["unstable"] }
 aho-corasick = "1.1"
-alacritty_terminal = { path = "../alacritty/alacritty_terminal" }
+alacritty_terminal = { git = "https://github.com/zed-industries/alacritty", rev = "936aee8761a17affc84ab418ae21306c27c26221" }
 any_vec = "0.14"
 anyhow = "1.0.86"
 arrayvec = { version = "0.7.4", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -453,7 +453,7 @@ ztracing_macro = { path = "crates/ztracing_macro" }
 
 agent-client-protocol = { version = "=0.9.3", features = ["unstable"] }
 aho-corasick = "1.1"
-alacritty_terminal = "0.25.1"
+alacritty_terminal = { path = "../alacritty/alacritty_terminal" }
 any_vec = "0.14"
 anyhow = "1.0.86"
 arrayvec = { version = "0.7.4", features = ["serde"] }

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -2818,7 +2818,7 @@ mod tests {
                 #[cfg(target_os = "windows")]
                 assert_eq!(exit_status.code(), Some(1));
                 #[cfg(not(target_os = "windows"))]
-                assert_eq!(exit_status.code(), None);
+                assert_eq!(exit_status.code(), Some(127)); // code 127 means "command not found" on Unix
             }
         });
 

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -989,8 +989,8 @@ impl Terminal {
                     .unwrap_or_else(|| to_alac_rgb(get_color_at_index(index, cx.theme().as_ref())));
                 self.write_to_pty(format(color).into_bytes());
             }
-            AlacTermEvent::ChildExit(raw_wait_status) => {
-                self.register_task_finished(Some(raw_wait_status), cx);
+            AlacTermEvent::ChildExit(raw_status) => {
+                self.register_task_finished(Some(raw_status), cx);
             }
         }
     }
@@ -2195,8 +2195,8 @@ impl Terminal {
         Task::ready(None)
     }
 
-    fn register_task_finished(&mut self, raw_wait_status: Option<i32>, cx: &mut Context<Terminal>) {
-        let exit_status: Option<ExitStatus> = raw_wait_status.map(|value| {
+    fn register_task_finished(&mut self, raw_status: Option<i32>, cx: &mut Context<Terminal>) {
+        let exit_status: Option<ExitStatus> = raw_status.map(|value| {
             #[cfg(unix)]
             {
                 std::os::unix::process::ExitStatusExt::from_raw(value)


### PR DESCRIPTION
Closes #38168
Closes #42414

We were already using `ExitStatusExt::from_raw()` to construct an `ExitStatus`, but we were passing in the exit code from alacritty_terminal's `ChildExit` event. This worked fine on Windows where `from_raw()` expects an exit code, but on Unix, `from_raw()` ([read more](https://doc.rust-lang.org/std/os/unix/process/trait.ExitStatusExt.html#tymethod.from_raw)) expects a raw wait status from `waitpid()` and not an exit code.

When a child process was killed by a signal (e.g., SIGSEGV), `ExitStatus::code()` returns `None` since only normal exits have an exit code. This caused the terminal to hang because we weren't properly detecting the exit.

One fix would have been to remove the dependency on `ExitStatus` entirely, but using the raw wait status gives us more information, we can now detect exit codes, signal terminations, and more.

The actual fix was upstream in `alacritty_terminal` to send the raw wait status instead of just the exit code.

Currently using forked patch https://github.com/zed-industries/alacritty/tree/v0.16-child-exit-patch which is based on v0.25.1.

Upstream PR: https://github.com/alacritty/alacritty/pull/8825

Release Notes:

- Fixed terminal hanging when a child process is killed by a signal (e.g., SIGSEGV from null pointer dereference).
