### PR TITLE
editor: Fix Shift+Enter inserting newline at end instead of cursor position with JetBrains keymap

### DIFF
--- a/assets/keymaps/linux/jetbrains.json
+++ b/assets/keymaps/linux/jetbrains.json
@@ -29,7 +29,6 @@
       "ctrl-pageup": "editor::MovePageUp",
       // "ctrl-alt-shift-b": "editor::SelectToPreviousWordStart",
       "ctrl-alt-enter": "editor::NewlineAbove",
-      "shift-enter": "editor::NewlineBelow",
       // "ctrl--": "editor::Fold", // TODO: `ctrl-numpad--` (numpad not implemented)
       // "ctrl-+": "editor::UnfoldLines", // TODO: `ctrl-numpad+` (numpad not implemented)
       "alt-shift-g": "editor::SplitSelectionIntoLines",
@@ -68,6 +67,7 @@
   {
     "context": "Editor && mode == full",
     "bindings": {
+      "shift-enter": "editor::NewlineBelow",
       "ctrl-f12": "outline::Toggle",
       "ctrl-r": ["buffer_search::Deploy", { "replace_enabled": true }],
       "ctrl-e": "file_finder::Toggle",

--- a/assets/keymaps/macos/jetbrains.json
+++ b/assets/keymaps/macos/jetbrains.json
@@ -28,7 +28,6 @@
       "cmd-pageup": "editor::MovePageUp",
       "ctrl-alt-shift-b": "editor::SelectToPreviousWordStart",
       "cmd-alt-enter": "editor::NewlineAbove",
-      "shift-enter": "editor::NewlineBelow",
       "cmd--": "editor::Fold",
       "cmd-+": "editor::UnfoldLines",
       "alt-shift-g": "editor::SplitSelectionIntoLines",
@@ -66,6 +65,7 @@
   {
     "context": "Editor && mode == full",
     "bindings": {
+      "shift-enter": "editor::NewlineBelow",
       "cmd-f12": "outline::Toggle",
       "cmd-r": ["buffer_search::Deploy", { "replace_enabled": true }],
       "cmd-l": "go_to_line::Toggle",


### PR DESCRIPTION
Closes #47269 

Release Notes:

- Fixed shift-enter inserting newline at end of text instead of cursor position in the agent panel when using JetBrains keymap.

# Before:

(tested using shift-enter then enter in both editors)

https://github.com/user-attachments/assets/9e0a128b-eaff-4944-bc50-22bcb60d338a

# After: 

(tested using shift-enter then enter in both editors)

https://github.com/user-attachments/assets/5ebc1530-bbb2-458c-96d8-6fdc652f7c7d


