### PR TITLE
Improve TypeScript keyword syntax highlighting

### DIFF
--- a/crates/languages/src/javascript/highlights.scm
+++ b/crates/languages/src/javascript/highlights.scm
@@ -246,20 +246,13 @@
   "as"
   "async"
   "await"
-  "class"
-  "const"
   "debugger"
   "default"
   "delete"
-  "export"
   "extends"
-  "from"
-  "function"
   "get"
-  "import"
   "in"
   "instanceof"
-  "let"
   "new"
   "of"
   "set"
@@ -267,10 +260,23 @@
   "target"
   "typeof"
   "using"
-  "var"
   "void"
   "with"
 ] @keyword
+
+[
+  "const"
+  "let"
+  "var"
+  "function"
+  "class"
+] @keyword.declaration
+
+[
+  "export"
+  "from"
+  "import"
+] @keyword.import
 
 [
   "break"

--- a/crates/languages/src/tsx/highlights.scm
+++ b/crates/languages/src/tsx/highlights.scm
@@ -263,36 +263,57 @@
 )
 
 [
+  "abstract"
   "as"
   "async"
   "await"
-  "class"
-  "const"
   "debugger"
+  "declare"
   "default"
   "delete"
-  "export"
   "extends"
-  "from"
-  "function"
   "get"
-  "import"
+  "implements"
   "in"
+  "infer"
   "instanceof"
   "is"
-  "let"
+  "keyof"
+  "module"
+  "namespace"
   "new"
   "of"
+  "override"
+  "private"
+  "protected"
+  "public"
+  "readonly"
   "satisfies"
   "set"
   "static"
   "target"
   "typeof"
   "using"
-  "var"
   "void"
   "with"
 ] @keyword
+
+[
+  "const"
+  "let"
+  "var"
+  "function"
+  "class"
+  "enum"
+  "interface"
+  "type"
+] @keyword.declaration
+
+[
+  "export"
+  "from"
+  "import"
+] @keyword.import
 
 [
   "break"

--- a/crates/languages/src/typescript/highlights.scm
+++ b/crates/languages/src/typescript/highlights.scm
@@ -383,27 +383,18 @@
   "as"
   "async"
   "await"
-  "class"
-  "const"
   "debugger"
   "declare"
   "default"
   "delete"
-  "enum"
-  "export"
   "extends"
-  "from"
-  "function"
   "get"
   "implements"
-  "import"
   "in"
   "infer"
   "instanceof"
-  "interface"
   "is"
   "keyof"
-  "let"
   "module"
   "namespace"
   "new"
@@ -417,13 +408,28 @@
   "set"
   "static"
   "target"
-  "type"
   "typeof"
   "using"
-  "var"
   "void"
   "with"
 ] @keyword
+
+[
+  "const"
+  "let"
+  "var"
+  "function"
+  "class"
+  "enum"
+  "interface"
+  "type"
+] @keyword.declaration
+
+[
+  "export"
+  "from"
+  "import"
+] @keyword.import
 
 [
   "break"


### PR DESCRIPTION
Improve syntax highlighting of keywords by creating groups for declarations and import/export.

### Release Notes:
- Highlight declarations with `keyword.declaration`:
  - const
  - let
  - var
  - function
  - class
  - enum
  - interface
  - type

- Highlight imports and exports with `keyword.import`:
  - export
  - from
  - import
