### PR TITLE
copilot: Add the option to disable Next Edit Suggestions

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1522,11 +1522,13 @@
     //   "enterprise_uri": "",
     //   "proxy": "",
     //   "proxy_no_verify": false
+    //   "enabled_next_edit_suggestions": true
     // },
     "copilot": {
       "enterprise_uri": null,
       "proxy": null,
       "proxy_no_verify": null,
+      "enabled_next_edit_suggestions": true,
     },
     "codestral": {
       "api_url": "https://codestral.mistral.ai",

--- a/crates/edit_prediction_ui/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_ui/src/edit_prediction_button.rs
@@ -941,6 +941,11 @@ impl EditPredictionButton {
         cx: &mut Context<Self>,
     ) -> Entity<ContextMenu> {
         let all_language_settings = all_language_settings(None, cx);
+        let next_edit_suggestions = all_language_settings
+            .edit_predictions
+            .copilot
+            .enabled_next_edit_suggestions
+            .unwrap_or(true);
         let copilot_config = copilot_chat::CopilotChatConfiguration {
             enterprise_uri: all_language_settings
                 .edit_predictions
@@ -956,6 +961,27 @@ impl EditPredictionButton {
                 self.add_provider_switching_section(menu, EditPredictionProvider::Copilot, cx);
 
             menu.separator()
+                .item(
+                    ContextMenuEntry::new("Copilot: Next Edit Suggestions")
+                        .toggleable(IconPosition::Start, next_edit_suggestions)
+                        .handler({
+                            let fs = self.fs.clone();
+                            move |_, cx| {
+                                update_settings_file(fs.clone(), cx, move |settings, _| {
+                                    settings
+                                        .project
+                                        .all_languages
+                                        .edit_predictions
+                                        .get_or_insert_default()
+                                        .copilot
+                                        .get_or_insert_default()
+                                        .enabled_next_edit_suggestions =
+                                        Some(!next_edit_suggestions);
+                                });
+                            }
+                        }),
+                )
+                .separator()
                 .link(
                     "Go to Copilot Settings",
                     OpenBrowser { url: settings_url }.boxed_clone(),

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -425,6 +425,8 @@ pub struct CopilotSettings {
     pub proxy_no_verify: Option<bool>,
     /// Enterprise URI for Copilot.
     pub enterprise_uri: Option<String>,
+    /// Whether the Copilot Next Edit Suggestions feature is enabled.
+    pub enabled_next_edit_suggestions: Option<bool>,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -658,6 +660,7 @@ impl settings::Settings for AllLanguageSettings {
             proxy: copilot.proxy,
             proxy_no_verify: copilot.proxy_no_verify,
             enterprise_uri: copilot.enterprise_uri,
+            enabled_next_edit_suggestions: copilot.enabled_next_edit_suggestions,
         };
 
         let codestral = edit_predictions.codestral.unwrap();

--- a/crates/settings_content/src/language.rs
+++ b/crates/settings_content/src/language.rs
@@ -210,6 +210,10 @@ pub struct CopilotSettingsContent {
     ///
     /// Default: none
     pub enterprise_uri: Option<String>,
+    /// Whether the Copilot Next Edit Suggestions feature is enabled.
+    ///
+    /// Default: true
+    pub enabled_next_edit_suggestions: Option<bool>,
 }
 
 #[with_fallible_options]


### PR DESCRIPTION
Adds a new setting to GitHub Copilot to toggle the Next Edit Suggestions feature, it is enabled by default. 

## Motivations
Due to some current usability issues with this feature, see #46880, and some personal anecdotes of using it, it is currently rough to utilize, so this gives the option to disable it.

## Related
- #47071 
- #30124
- #44486
## Release Notes
- Adds the ability to disable GitHub Copilot's Next Edit Suggestions feature.
## User Interface
![image](https://github.com/user-attachments/assets/5a3d7166-68dd-4f5b-a220-0a9bd9282cd5)
## Text Example
The text example will be adding a `z` variable to a `Point3D` class in TypeScript.
### With Next Edit Suggestions
In this example I am able to just press auto-complete (press TAB) 3x.
```ts
class Point3D {
    x: number;
    y: number;
    z: number; // <-- Cursor before z: suggested

    constructor(x: number, 
                y: number
                , z: number // <-- Next Suggestion
                ) { 
        this.x = x;
        this.y = y;
        this.z = z; // <-- Last Suggestion
    }
}
```
### Without Next Edit Suggestions
```ts
class Point3D {
    x: number;
    y: number;
    z: number; // <-- Cursor before z: the only suggestion

    constructor(x: number, y: number) {
        this.x = x;
        this.y = y;
    }
}
```