### PR TITLE
languages: Add first-line C++ language detection for extensionless libcpp headers

### DIFF
--- a/crates/languages/src/cpp/config.toml
+++ b/crates/languages/src/cpp/config.toml
@@ -1,6 +1,7 @@
 name = "C++"
 grammar = "cpp"
 path_suffixes = ["cc", "hh", "cpp", "h", "hpp", "cxx", "hxx", "c++", "h++", "ipp", "inl", "ino", "ixx", "cu", "cuh", "C", "H"]
+first_line_pattern = '\/\/\s*-\*-\s*C\+\+\s*-\*-'
 line_comments = ["// ", "/// ", "//! "]
 decrease_indent_patterns = [
   { pattern = "^\\s*\\{.*\\}?\\s*$", valid_after = ["if", "for", "while", "do", "switch", "else"] },

--- a/crates/languages/src/cpp/config.toml
+++ b/crates/languages/src/cpp/config.toml
@@ -1,8 +1,8 @@
 name = "C++"
 grammar = "cpp"
 path_suffixes = ["cc", "hh", "cpp", "h", "hpp", "cxx", "hxx", "c++", "h++", "ipp", "inl", "ino", "ixx", "cu", "cuh", "C", "H"]
-first_line_pattern = '\/\/\s*-\*-\s*C\+\+\s*-\*-'
 line_comments = ["// ", "/// ", "//! "]
+first_line_pattern = '\/\/\s*-\*-\s*C\+\+\s*-\*-'
 decrease_indent_patterns = [
   { pattern = "^\\s*\\{.*\\}?\\s*$", valid_after = ["if", "for", "while", "do", "switch", "else"] },
   { pattern = "^\\s*else\\b", valid_after = ["if"] }


### PR DESCRIPTION
Several libcpp headers lack file extensions. Added a first line pattern for recognition.

https://github.com/llvm/llvm-project/blob/main/libcxx/include/random)](https://github.com/llvm/llvm-project/blob/main/libcxx/include/random

Before:
<img width="1229" height="512" alt="before" src="https://github.com/user-attachments/assets/fe62f904-73c9-494e-adf5-e5f259fab611" />

After:
<img width="1229" height="512" alt="after" src="https://github.com/user-attachments/assets/a68b4242-61b7-4dba-a12e-9424be4b06dc" />

Release Notes:

- Added first-line C++ language detection for extensionless libcpp headers.
