### PR TITLE
git_ui: Add commit log

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -128,6 +128,7 @@
       "ctrl-i": "editor::ShowSignatureHelp",
       "alt-g b": "git::Blame",
       "alt-g m": "git::OpenModifiedFiles",
+      "alt-g l": "git::CommitLog",
       "menu": "editor::OpenContextMenu",
       "shift-f10": "editor::OpenContextMenu",
       "ctrl-alt-shift-e": "editor::ToggleEditPrediction",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -151,6 +151,7 @@
       "cmd-\"": "editor::ExpandAllDiffHunks",
       "cmd-alt-g b": "git::Blame",
       "cmd-alt-g m": "git::OpenModifiedFiles",
+      "cmd-alt-g l": "git::CommitLog",
       "cmd-i": "editor::ShowSignatureHelp",
       "f9": "editor::ToggleBreakpoint",
       "shift-f9": "editor::EditLogBreakpoint",

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -123,6 +123,7 @@
       "ctrl-i": "editor::ShowSignatureHelp",
       "alt-g b": "git::Blame",
       "alt-g m": "git::OpenModifiedFiles",
+      "alt-g l": "git::CommitLog",
       "menu": "editor::OpenContextMenu",
       "shift-f10": "editor::OpenContextMenu",
       "ctrl-alt-e": "editor::ToggleEditPrediction",

--- a/crates/fs/src/fake_git_repo.rs
+++ b/crates/fs/src/fake_git_repo.rs
@@ -488,6 +488,19 @@ impl GitRepository for FakeGitRepository {
         .boxed()
     }
 
+    fn commit_log_paginated(
+        &self,
+        _skip: usize,
+        _limit: Option<usize>,
+    ) -> BoxFuture<'_, Result<git::repository::CommitLog>> {
+        async move {
+            Ok(git::repository::CommitLog {
+                entries: Vec::new(),
+            })
+        }
+        .boxed()
+    }
+
     fn stage_paths(
         &self,
         paths: Vec<RepoPath>,

--- a/crates/git/src/git.rs
+++ b/crates/git/src/git.rs
@@ -101,6 +101,8 @@ actions!(
         Clone,
         /// Adds a file to .gitignore.
         AddToGitignore,
+        /// Shows the commit history for the current repository.
+        CommitLog,
     ]
 );
 

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -342,6 +342,11 @@ pub struct FileHistory {
     pub path: RepoPath,
 }
 
+#[derive(Debug, Clone)]
+pub struct CommitLog {
+    pub entries: Vec<FileHistoryEntry>,
+}
+
 #[derive(Debug)]
 pub struct CommitDiff {
     pub files: Vec<CommitFile>,

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -1825,6 +1825,84 @@ impl GitRepository for RealGitRepository {
             .boxed()
     }
 
+    fn commit_log_paginated(
+        &self,
+        skip: usize,
+        limit: Option<usize>,
+    ) -> BoxFuture<'_, Result<CommitLog>> {
+        let working_directory = self.working_directory();
+        let git_binary_path = self.any_git_binary_path.clone();
+        self.executor
+            .spawn(async move {
+                let working_directory = working_directory?;
+                let commit_delimiter =
+                    concat!("<<COMMIT_END-", "3f8a9c2e-7d4b-4e1a-9f6c-8b5d2a1e4c3f>>",);
+
+                let format_string = format!(
+                    "--pretty=format:%H%x00%s%x00%B%x00%at%x00%an%x00%ae{}",
+                    commit_delimiter
+                );
+
+                let mut args = vec!["--no-optional-locks", "log", &format_string];
+
+                let skip_str;
+                let limit_str;
+                if skip > 0 {
+                    skip_str = skip.to_string();
+                    args.push("--skip");
+                    args.push(&skip_str);
+                }
+                if let Some(n) = limit {
+                    limit_str = n.to_string();
+                    args.push("-n");
+                    args.push(&limit_str);
+                }
+
+                let output = new_smol_command(&git_binary_path)
+                    .current_dir(&working_directory)
+                    .args(&args)
+                    .output()
+                    .await?;
+
+                if !output.status.success() {
+                    let stderr = String::from_utf8_lossy(&output.stderr);
+                    bail!("git log failed: {stderr}");
+                }
+
+                let stdout = std::str::from_utf8(&output.stdout)?;
+                let mut entries = Vec::new();
+
+                for commit_block in stdout.split(commit_delimiter) {
+                    let commit_block = commit_block.trim();
+                    if commit_block.is_empty() {
+                        continue;
+                    }
+
+                    let fields: Vec<&str> = commit_block.split('\0').collect();
+                    if fields.len() >= 6 {
+                        let sha = fields[0].trim().to_string().into();
+                        let subject = fields[1].trim().to_string().into();
+                        let message = fields[2].trim().to_string().into();
+                        let commit_timestamp = fields[3].trim().parse().unwrap_or(0);
+                        let author_name = fields[4].trim().to_string().into();
+                        let author_email = fields[5].trim().to_string().into();
+
+                        entries.push(FileHistoryEntry {
+                            sha,
+                            subject,
+                            message,
+                            commit_timestamp,
+                            author_name,
+                            author_email,
+                        });
+                    }
+                }
+
+                Ok(CommitLog { entries })
+            })
+            .boxed()
+    }
+
     fn diff(&self, diff: DiffType) -> BoxFuture<'_, Result<String>> {
         let working_directory = self.working_directory();
         let git_binary_path = self.any_git_binary_path.clone();

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -665,6 +665,12 @@ pub trait GitRepository: Send + Sync {
         limit: Option<usize>,
     ) -> BoxFuture<'_, Result<FileHistory>>;
 
+    fn commit_log_paginated(
+        &self,
+        skip: usize,
+        limit: Option<usize>,
+    ) -> BoxFuture<'_, Result<CommitLog>>;
+
     /// Returns the absolute path to the repository. For worktrees, this will be the path to the
     /// worktree's gitdir within the main repository (typically `.git/worktrees/<name>`).
     fn path(&self) -> PathBuf;

--- a/crates/git_ui/src/commit_log_view.rs
+++ b/crates/git_ui/src/commit_log_view.rs
@@ -1,0 +1,673 @@
+use anyhow::Result;
+use futures::Future;
+use git::repository::{CommitLog, FileHistoryEntry};
+use git::{GitHostingProviderRegistry, GitRemote, parse_git_remote_url};
+use gpui::{
+    AnyElement, AnyEntity, App, Asset, Context, Entity, EventEmitter, FocusHandle, Focusable,
+    IntoElement, Render, ScrollStrategy, SharedString, Task, UniformListScrollHandle, WeakEntity,
+    Window, actions, uniform_list,
+};
+use project::{
+    Project, ProjectPath,
+    git_store::{GitStore, Repository},
+};
+use std::any::{Any, TypeId};
+use std::sync::Arc;
+
+use time::OffsetDateTime;
+use ui::{Avatar, Chip, Divider, ListItem, WithScrollbar, prelude::*};
+use util::ResultExt;
+use workspace::{
+    Item, Workspace,
+    item::{ItemEvent, SaveOptions},
+};
+
+use crate::commit_view::CommitView;
+
+actions!(commit_log, [LoadMoreCommits]);
+
+pub fn init(cx: &mut App) {
+    cx.observe_new(|workspace: &mut Workspace, _window, _cx| {
+        workspace.register_action(|_workspace, _: &LoadMoreCommits, _window, _cx| {});
+    })
+    .detach();
+}
+
+const PAGE_SIZE: usize = 50;
+
+pub struct CommitLogView {
+    entries: Vec<FileHistoryEntry>,
+    repository: WeakEntity<Repository>,
+    git_store: WeakEntity<GitStore>,
+    workspace: WeakEntity<Workspace>,
+    remote: Option<GitRemote>,
+    repo_name: SharedString,
+    selected_entry: Option<usize>,
+    scroll_handle: UniformListScrollHandle,
+    focus_handle: FocusHandle,
+    loading_more: bool,
+    has_more: bool,
+}
+
+impl CommitLogView {
+    pub fn open(
+        git_store: WeakEntity<GitStore>,
+        repo: WeakEntity<Repository>,
+        workspace: WeakEntity<Workspace>,
+        window: &mut Window,
+        cx: &mut App,
+    ) {
+        let commit_log_task = git_store
+            .update(cx, |git_store, cx| {
+                repo.upgrade().map(|repo| {
+                    git_store.commit_log_paginated(&repo, 0, Some(PAGE_SIZE), cx)
+                })
+            })
+            .ok()
+            .flatten();
+
+        window
+            .spawn(cx, async move |cx| {
+                let commit_log = commit_log_task?.await.log_err()?;
+                let repo = repo.upgrade()?;
+
+                workspace
+                    .update_in(cx, |workspace, window, cx| {
+                        let project = workspace.project();
+                        let view = cx.new(|cx| {
+                            CommitLogView::new(
+                                commit_log,
+                                git_store.clone(),
+                                repo.clone(),
+                                workspace.weak_handle(),
+                                project.clone(),
+                                window,
+                                cx,
+                            )
+                        });
+
+                        let pane = workspace.active_pane();
+                        pane.update(cx, |pane, cx| {
+                            let ix = pane.items().position(|item| {
+                                item.downcast::<CommitLogView>().is_some()
+                            });
+                            if let Some(ix) = ix {
+                                pane.activate_item(ix, true, true, window, cx);
+                            } else {
+                                pane.add_item(Box::new(view), true, true, None, window, cx);
+                            }
+                        })
+                    })
+                    .log_err()
+            })
+            .detach();
+    }
+
+    fn new(
+        commit_log: CommitLog,
+        git_store: WeakEntity<GitStore>,
+        repository: Entity<Repository>,
+        workspace: WeakEntity<Workspace>,
+        _project: Entity<Project>,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let focus_handle = cx.focus_handle();
+        let scroll_handle = UniformListScrollHandle::new();
+        let has_more = commit_log.entries.len() >= PAGE_SIZE;
+
+        let snapshot = repository.read(cx).snapshot();
+        let remote_url = snapshot
+            .remote_upstream_url
+            .as_ref()
+            .or(snapshot.remote_origin_url.as_ref());
+
+        let remote = remote_url.and_then(|url| {
+            let provider_registry = GitHostingProviderRegistry::default_global(cx);
+            parse_git_remote_url(provider_registry, url).map(|(host, parsed)| GitRemote {
+                host,
+                owner: parsed.owner.into(),
+                repo: parsed.repo.into(),
+            })
+        });
+
+        let repo_name: SharedString = snapshot
+            .root_path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| "Repository".to_string())
+            .into();
+
+        Self {
+            entries: commit_log.entries,
+            git_store,
+            repository: repository.downgrade(),
+            workspace,
+            remote,
+            repo_name,
+            selected_entry: None,
+            scroll_handle,
+            focus_handle,
+            loading_more: false,
+            has_more,
+        }
+    }
+
+    fn load_more(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.loading_more || !self.has_more {
+            return;
+        }
+
+        self.loading_more = true;
+        cx.notify();
+
+        let current_count = self.entries.len();
+        let git_store = self.git_store.clone();
+        let repo = self.repository.clone();
+
+        let this = cx.weak_entity();
+        let task = window.spawn(cx, async move |cx| {
+            let commit_log_task = git_store
+                .update(cx, |git_store, cx| {
+                    repo.upgrade().map(|repo| {
+                        git_store.commit_log_paginated(
+                            &repo,
+                            current_count,
+                            Some(PAGE_SIZE),
+                            cx,
+                        )
+                    })
+                })
+                .ok()
+                .flatten();
+
+            if let Some(task) = commit_log_task {
+                if let Ok(more_commits) = task.await {
+                    this.update(cx, |this, cx| {
+                        this.loading_more = false;
+                        this.has_more = more_commits.entries.len() >= PAGE_SIZE;
+                        this.entries.extend(more_commits.entries);
+                        cx.notify();
+                    })
+                    .ok();
+                }
+            }
+        });
+
+        task.detach();
+    }
+
+    fn select_next(&mut self, _: &menu::SelectNext, _: &mut Window, cx: &mut Context<Self>) {
+        let entry_count = self.entries.len();
+        let ix = match self.selected_entry {
+            _ if entry_count == 0 => None,
+            None => Some(0),
+            Some(ix) => {
+                if ix == entry_count - 1 {
+                    Some(0)
+                } else {
+                    Some(ix + 1)
+                }
+            }
+        };
+        self.select_ix(ix, cx);
+    }
+
+    fn select_previous(
+        &mut self,
+        _: &menu::SelectPrevious,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let entry_count = self.entries.len();
+        let ix = match self.selected_entry {
+            _ if entry_count == 0 => None,
+            None => Some(entry_count - 1),
+            Some(ix) => {
+                if ix == 0 {
+                    Some(entry_count - 1)
+                } else {
+                    Some(ix - 1)
+                }
+            }
+        };
+        self.select_ix(ix, cx);
+    }
+
+    fn select_first(&mut self, _: &menu::SelectFirst, _: &mut Window, cx: &mut Context<Self>) {
+        let entry_count = self.entries.len();
+        let ix = if entry_count != 0 { Some(0) } else { None };
+        self.select_ix(ix, cx);
+    }
+
+    fn select_last(&mut self, _: &menu::SelectLast, _: &mut Window, cx: &mut Context<Self>) {
+        let entry_count = self.entries.len();
+        let ix = if entry_count != 0 {
+            Some(entry_count - 1)
+        } else {
+            None
+        };
+        self.select_ix(ix, cx);
+    }
+
+    fn select_ix(&mut self, ix: Option<usize>, cx: &mut Context<Self>) {
+        self.selected_entry = ix;
+        if let Some(ix) = ix {
+            self.scroll_handle.scroll_to_item(ix, ScrollStrategy::Top);
+        }
+        cx.notify();
+    }
+
+    fn confirm(&mut self, _: &menu::Confirm, window: &mut Window, cx: &mut Context<Self>) {
+        self.open_commit_view(window, cx);
+    }
+
+    fn open_commit_view(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(entry) = self
+            .selected_entry
+            .and_then(|ix| self.entries.get(ix))
+        else {
+            return;
+        };
+
+        if let Some(repo) = self.repository.upgrade() {
+            let sha_str = entry.sha.to_string();
+            CommitView::open(
+                sha_str,
+                repo.downgrade(),
+                self.workspace.clone(),
+                None,
+                None,
+                window,
+                cx,
+            );
+        }
+    }
+
+    fn render_commit_avatar(
+        &self,
+        sha: &SharedString,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> impl IntoElement {
+        let remote = self.remote.as_ref().filter(|r| r.host_supports_avatars());
+        let size = rems_from_px(20.);
+
+        if let Some(remote) = remote {
+            let avatar_asset = CommitAvatarAsset::new(remote.clone(), sha.clone());
+            if let Some(Some(url)) = window.use_asset::<CommitAvatarAsset>(&avatar_asset, cx) {
+                Avatar::new(url.to_string()).size(size)
+            } else {
+                Avatar::new("").size(size)
+            }
+        } else {
+            Avatar::new("").size(size)
+        }
+    }
+
+    fn render_commit_entry(
+        &self,
+        ix: usize,
+        entry: &FileHistoryEntry,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let pr_number = entry
+            .subject
+            .rfind("(#")
+            .and_then(|start| {
+                let rest = &entry.subject[start + 2..];
+                rest.find(')')
+                    .and_then(|end| rest[..end].parse::<u32>().ok())
+            })
+            .map(|num| format!("#{}", num))
+            .unwrap_or_else(|| {
+                if entry.sha.len() >= 7 {
+                    entry.sha[..7].to_string()
+                } else {
+                    entry.sha.to_string()
+                }
+            });
+
+        let commit_time = OffsetDateTime::from_unix_timestamp(entry.commit_timestamp)
+            .unwrap_or_else(|_| OffsetDateTime::UNIX_EPOCH);
+        let relative_timestamp = time_format::format_localized_timestamp(
+            commit_time,
+            OffsetDateTime::now_utc(),
+            time::UtcOffset::current_local_offset().unwrap_or(time::UtcOffset::UTC),
+            time_format::TimestampFormat::Relative,
+        );
+
+        ListItem::new(("commit", ix))
+            .toggle_state(Some(ix) == self.selected_entry)
+            .child(
+                h_flex()
+                    .h_8()
+                    .w_full()
+                    .pl_0p5()
+                    .pr_2p5()
+                    .gap_2()
+                    .child(
+                        div()
+                            .w(rems_from_px(52.))
+                            .flex_none()
+                            .child(Chip::new(pr_number)),
+                    )
+                    .child(self.render_commit_avatar(&entry.sha, window, cx))
+                    .child(
+                        h_flex()
+                            .min_w_0()
+                            .w_full()
+                            .justify_between()
+                            .child(
+                                h_flex()
+                                    .min_w_0()
+                                    .w_full()
+                                    .gap_1()
+                                    .child(
+                                        Label::new(entry.author_name.clone())
+                                            .size(LabelSize::Small)
+                                            .color(Color::Default)
+                                            .truncate(),
+                                    )
+                                    .child(
+                                        Label::new(&entry.subject)
+                                            .size(LabelSize::Small)
+                                            .color(Color::Muted)
+                                            .truncate(),
+                                    ),
+                            )
+                            .child(
+                                h_flex().flex_none().child(
+                                    Label::new(relative_timestamp)
+                                        .size(LabelSize::Small)
+                                        .color(Color::Muted),
+                                ),
+                            ),
+                    ),
+            )
+            .on_click(cx.listener(move |this, _, window, cx| {
+                this.selected_entry = Some(ix);
+                cx.notify();
+
+                this.open_commit_view(window, cx);
+            }))
+            .into_any_element()
+    }
+}
+
+#[derive(Clone, Debug)]
+struct CommitAvatarAsset {
+    sha: SharedString,
+    remote: GitRemote,
+}
+
+impl std::hash::Hash for CommitAvatarAsset {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.sha.hash(state);
+        self.remote.host.name().hash(state);
+    }
+}
+
+impl CommitAvatarAsset {
+    fn new(remote: GitRemote, sha: SharedString) -> Self {
+        Self { remote, sha }
+    }
+}
+
+impl Asset for CommitAvatarAsset {
+    type Source = Self;
+    type Output = Option<SharedString>;
+
+    fn load(
+        source: Self::Source,
+        cx: &mut App,
+    ) -> impl Future<Output = Self::Output> + Send + 'static {
+        let client = cx.http_client();
+        async move {
+            match source
+                .remote
+                .host
+                .commit_author_avatar_url(
+                    &source.remote.owner,
+                    &source.remote.repo,
+                    source.sha.clone(),
+                    client,
+                )
+                .await
+            {
+                Ok(Some(url)) => Some(SharedString::from(url.to_string())),
+                Ok(None) => None,
+                Err(_) => None,
+            }
+        }
+    }
+}
+
+impl EventEmitter<ItemEvent> for CommitLogView {}
+
+impl Focusable for CommitLogView {
+    fn focus_handle(&self, _cx: &App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+impl Render for CommitLogView {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let entry_count = self.entries.len();
+
+        v_flex()
+            .id("commit_log_view")
+            .key_context("CommitLogView")
+            .track_focus(&self.focus_handle)
+            .on_action(cx.listener(Self::select_next))
+            .on_action(cx.listener(Self::select_previous))
+            .on_action(cx.listener(Self::select_first))
+            .on_action(cx.listener(Self::select_last))
+            .on_action(cx.listener(Self::confirm))
+            .size_full()
+            .bg(cx.theme().colors().editor_background)
+            .child(
+                h_flex()
+                    .h(rems_from_px(41.))
+                    .pl_3()
+                    .pr_2()
+                    .justify_between()
+                    .border_b_1()
+                    .border_color(cx.theme().colors().border_variant)
+                    .child(
+                        Label::new(self.repo_name.clone())
+                            .color(Color::Muted)
+                            .buffer_font(cx),
+                    )
+                    .child(
+                        h_flex()
+                            .gap_1p5()
+                            .child(
+                                Label::new(format!("{} commits", entry_count))
+                                    .size(LabelSize::Small)
+                                    .color(Color::Muted)
+                                    .when(self.has_more, |this| this.mr_1()),
+                            )
+                            .when(self.has_more, |this| {
+                                this.child(Divider::vertical()).child(
+                                    Button::new("load-more", "Load More")
+                                        .disabled(self.loading_more)
+                                        .label_size(LabelSize::Small)
+                                        .icon(IconName::ArrowCircle)
+                                        .icon_size(IconSize::Small)
+                                        .icon_color(Color::Muted)
+                                        .icon_position(IconPosition::Start)
+                                        .on_click(cx.listener(|this, _, window, cx| {
+                                            this.load_more(window, cx);
+                                        })),
+                                )
+                            }),
+                    ),
+            )
+            .child(
+                v_flex()
+                    .flex_1()
+                    .size_full()
+                    .child({
+                        let view = cx.weak_entity();
+                        uniform_list(
+                            "commit-log-list",
+                            entry_count,
+                            move |range, window, cx| {
+                                let Some(view) = view.upgrade() else {
+                                    return Vec::new();
+                                };
+                                view.update(cx, |this, cx| {
+                                    let mut items = Vec::with_capacity(range.end - range.start);
+                                    for ix in range {
+                                        if let Some(entry) = this.entries.get(ix) {
+                                            items.push(
+                                                this.render_commit_entry(ix, entry, window, cx),
+                                            );
+                                        }
+                                    }
+                                    items
+                                })
+                            },
+                        )
+                        .flex_1()
+                        .size_full()
+                        .track_scroll(&self.scroll_handle)
+                    })
+                    .vertical_scrollbar_for(&self.scroll_handle, window, cx),
+            )
+    }
+}
+
+impl Item for CommitLogView {
+    type Event = ItemEvent;
+
+    fn to_item_events(event: &Self::Event, mut f: impl FnMut(ItemEvent)) {
+        f(*event)
+    }
+
+    fn tab_content_text(&self, _detail: usize, _cx: &App) -> SharedString {
+        "Commit Log".into()
+    }
+
+    fn tab_tooltip_text(&self, _cx: &App) -> Option<SharedString> {
+        Some(format!("Git commit log for {}", self.repo_name).into())
+    }
+
+    fn tab_icon(&self, _window: &Window, _cx: &App) -> Option<Icon> {
+        Some(Icon::new(IconName::GitBranch))
+    }
+
+    fn telemetry_event_text(&self) -> Option<&'static str> {
+        Some("commit log")
+    }
+
+    fn clone_on_split(
+        &self,
+        _workspace_id: Option<workspace::WorkspaceId>,
+        _window: &mut Window,
+        _cx: &mut Context<Self>,
+    ) -> Task<Option<Entity<Self>>> {
+        Task::ready(None)
+    }
+
+    fn navigate(
+        &mut self,
+        _: Arc<dyn Any + Send>,
+        _window: &mut Window,
+        _: &mut Context<Self>,
+    ) -> bool {
+        false
+    }
+
+    fn deactivated(&mut self, _window: &mut Window, _: &mut Context<Self>) {}
+
+    fn can_save(&self, _: &App) -> bool {
+        false
+    }
+
+    fn save(
+        &mut self,
+        _options: SaveOptions,
+        _project: Entity<Project>,
+        _window: &mut Window,
+        _: &mut Context<Self>,
+    ) -> Task<Result<()>> {
+        Task::ready(Ok(()))
+    }
+
+    fn save_as(
+        &mut self,
+        _project: Entity<Project>,
+        _path: ProjectPath,
+        _window: &mut Window,
+        _: &mut Context<Self>,
+    ) -> Task<Result<()>> {
+        Task::ready(Ok(()))
+    }
+
+    fn reload(
+        &mut self,
+        _project: Entity<Project>,
+        _window: &mut Window,
+        _: &mut Context<Self>,
+    ) -> Task<Result<()>> {
+        Task::ready(Ok(()))
+    }
+
+    fn is_dirty(&self, _: &App) -> bool {
+        false
+    }
+
+    fn has_conflict(&self, _: &App) -> bool {
+        false
+    }
+
+    fn breadcrumbs(
+        &self,
+        _theme: &theme::Theme,
+        _cx: &App,
+    ) -> Option<Vec<workspace::item::BreadcrumbText>> {
+        None
+    }
+
+    fn added_to_workspace(
+        &mut self,
+        _workspace: &mut Workspace,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        window.focus(&self.focus_handle, cx);
+    }
+
+    fn show_toolbar(&self) -> bool {
+        true
+    }
+
+    fn pixel_position_of_cursor(&self, _: &App) -> Option<gpui::Point<gpui::Pixels>> {
+        None
+    }
+
+    fn set_nav_history(
+        &mut self,
+        _: workspace::ItemNavHistory,
+        _window: &mut Window,
+        _: &mut Context<Self>,
+    ) {
+    }
+
+    fn act_as_type<'a>(
+        &'a self,
+        type_id: TypeId,
+        self_handle: &'a Entity<Self>,
+        _: &'a App,
+    ) -> Option<AnyEntity> {
+        if type_id == TypeId::of::<Self>() {
+            Some(self_handle.clone().into())
+        } else {
+            None
+        }
+    }
+}

--- a/crates/git_ui/src/commit_log_view.rs
+++ b/crates/git_ui/src/commit_log_view.rs
@@ -59,9 +59,8 @@ impl CommitLogView {
     ) {
         let commit_log_task = git_store
             .update(cx, |git_store, cx| {
-                repo.upgrade().map(|repo| {
-                    git_store.commit_log_paginated(&repo, 0, Some(PAGE_SIZE), cx)
-                })
+                repo.upgrade()
+                    .map(|repo| git_store.commit_log_paginated(&repo, 0, Some(PAGE_SIZE), cx))
             })
             .ok()
             .flatten();
@@ -88,9 +87,9 @@ impl CommitLogView {
 
                         let pane = workspace.active_pane();
                         pane.update(cx, |pane, cx| {
-                            let ix = pane.items().position(|item| {
-                                item.downcast::<CommitLogView>().is_some()
-                            });
+                            let ix = pane
+                                .items()
+                                .position(|item| item.downcast::<CommitLogView>().is_some());
                             if let Some(ix) = ix {
                                 pane.activate_item(ix, true, true, window, cx);
                             } else {
@@ -171,12 +170,7 @@ impl CommitLogView {
             let commit_log_task = git_store
                 .update(cx, |git_store, cx| {
                     repo.upgrade().map(|repo| {
-                        git_store.commit_log_paginated(
-                            &repo,
-                            current_count,
-                            Some(PAGE_SIZE),
-                            cx,
-                        )
+                        git_store.commit_log_paginated(&repo, current_count, Some(PAGE_SIZE), cx)
                     })
                 })
                 .ok()
@@ -264,10 +258,7 @@ impl CommitLogView {
     }
 
     fn open_commit_view(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        let Some(entry) = self
-            .selected_entry
-            .and_then(|ix| self.entries.get(ix))
-        else {
+        let Some(entry) = self.selected_entry.and_then(|ix| self.entries.get(ix)) else {
             return;
         };
 
@@ -512,26 +503,20 @@ impl Render for CommitLogView {
                     .size_full()
                     .child({
                         let view = cx.weak_entity();
-                        uniform_list(
-                            "commit-log-list",
-                            entry_count,
-                            move |range, window, cx| {
-                                let Some(view) = view.upgrade() else {
-                                    return Vec::new();
-                                };
-                                view.update(cx, |this, cx| {
-                                    let mut items = Vec::with_capacity(range.end - range.start);
-                                    for ix in range {
-                                        if let Some(entry) = this.entries.get(ix) {
-                                            items.push(
-                                                this.render_commit_entry(ix, entry, window, cx),
-                                            );
-                                        }
+                        uniform_list("commit-log-list", entry_count, move |range, window, cx| {
+                            let Some(view) = view.upgrade() else {
+                                return Vec::new();
+                            };
+                            view.update(cx, |this, cx| {
+                                let mut items = Vec::with_capacity(range.end - range.start);
+                                for ix in range {
+                                    if let Some(entry) = this.entries.get(ix) {
+                                        items.push(this.render_commit_entry(ix, entry, window, cx));
                                     }
-                                    items
-                                })
-                            },
-                        )
+                                }
+                                items
+                            })
+                        })
                         .flex_1()
                         .size_full()
                         .track_scroll(&self.scroll_handle)

--- a/crates/git_ui/src/commit_log_view.rs
+++ b/crates/git_ui/src/commit_log_view.rs
@@ -131,10 +131,10 @@ impl CommitLogView {
         });
 
         let repo_name: SharedString = snapshot
-            .root_path
+            .work_directory_abs_path
             .file_name()
-            .and_then(|n| n.to_str())
-            .map(|s| s.to_string())
+            .and_then(|n: &std::ffi::OsStr| n.to_str())
+            .map(|s: &str| s.to_string())
             .unwrap_or_else(|| "Repository".to_string())
             .into();
 

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -31,8 +31,8 @@ use git::stash::GitStash;
 use git::status::StageStatus;
 use git::{Amend, Signoff, ToggleStaged, repository::RepoPath, status::FileStatus};
 use git::{
-    ExpandCommitEditor, GitHostingProviderRegistry, RestoreTrackedFiles, StageAll, StashAll,
-    StashApply, StashPop, TrashUntrackedFiles, UnstageAll,
+    CommitLog, ExpandCommitEditor, GitHostingProviderRegistry, RestoreTrackedFiles, StageAll,
+    StashAll, StashApply, StashPop, TrashUntrackedFiles, UnstageAll,
 };
 use gpui::{
     Action, AsyncApp, AsyncWindowContext, Bounds, ClickEvent, Corner, DismissEvent, Entity,
@@ -172,6 +172,7 @@ fn git_panel_context_menu(
             .action("View Stash", zed_actions::git::ViewStash.boxed_clone())
             .separator()
             .action("Open Diff", project_diff::Diff.boxed_clone())
+            .action("Commit Log", CommitLog.boxed_clone())
             .separator()
             .action_disabled_when(
                 !state.has_tracked_changes,

--- a/crates/git_ui/src/git_ui.rs
+++ b/crates/git_ui/src/git_ui.rs
@@ -39,6 +39,7 @@ pub mod commit_view;
 mod conflict_view;
 pub mod file_diff_view;
 pub mod file_history_view;
+pub mod commit_log_view;
 pub mod git_panel;
 mod git_panel_settings;
 pub mod git_picker;

--- a/crates/git_ui/src/git_ui.rs
+++ b/crates/git_ui/src/git_ui.rs
@@ -277,6 +277,23 @@ pub fn init(cx: &mut App) {
                 cx,
             );
         });
+        workspace.register_action(|workspace, _: &git::CommitLog, window, cx| {
+            let Some(panel) = workspace.panel::<git_panel::GitPanel>(cx) else {
+                return;
+            };
+            let Some(repo) = panel.read(cx).active_repository.clone() else {
+                return;
+            };
+            let project = workspace.project();
+            let git_store = project.read(cx).git_store();
+            commit_log_view::CommitLogView::open(
+                git_store.downgrade(),
+                repo.downgrade(),
+                workspace.weak_handle(),
+                window,
+                cx,
+            );
+        });
     })
     .detach();
 }

--- a/crates/git_ui/src/git_ui.rs
+++ b/crates/git_ui/src/git_ui.rs
@@ -33,13 +33,13 @@ use crate::{git_panel::GitPanel, text_diff_view::TextDiffView};
 
 mod askpass_modal;
 pub mod branch_picker;
+pub mod commit_log_view;
 mod commit_modal;
 pub mod commit_tooltip;
 pub mod commit_view;
 mod conflict_view;
 pub mod file_diff_view;
 pub mod file_history_view;
-pub mod commit_log_view;
 pub mod git_panel;
 mod git_panel_settings;
 pub mod git_picker;

--- a/crates/git_ui/src/git_ui.rs
+++ b/crates/git_ui/src/git_ui.rs
@@ -64,6 +64,7 @@ pub fn init(cx: &mut App) {
     editor::set_blame_renderer(blame_ui::GitBlameRenderer, cx);
     commit_view::init(cx);
     file_history_view::init(cx);
+    commit_log_view::init(cx);
 
     cx.observe_new(|editor: &mut Editor, _, cx| {
         conflict_view::register_editor(editor, editor.buffer().clone(), cx);

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -4256,9 +4256,9 @@ impl Repository {
                 RepositoryState::Local(LocalRepositoryState { backend, .. }) => {
                     backend.commit_log_paginated(skip, limit).await
                 }
-                RepositoryState::Remote(_) => {
-                    Err(anyhow::anyhow!("commit log not yet supported for remote repositories"))
-                }
+                RepositoryState::Remote(_) => Err(anyhow::anyhow!(
+                    "commit log not yet supported for remote repositories"
+                )),
             }
         })
     }


### PR DESCRIPTION
  Closes #47402

Summary

  - Adds a new Commit Log view that displays the full commit history for the active repository
  - Mirrors the existing per-file history view but shows all commits repository-wide
  - Clicking a commit opens the full commit diff (all changed files)

Implementation

  - Added `CommitLog` action and `commit_log_paginated()` method to git repository layer
  - Created `CommitLogView` in `git_ui`, modeled after `FileHistoryView`
  - Added keyboard shortcuts: `alt-g l` (Linux and Windows), `cmd-alt-g l` (macOS)
  - Added "Commit Log" to git panel context menu

Future Expansion

- Search and filter commits
- Branch and tag decorations
- Infinite scroll pagination

Release Notes:

  - Added repository-wide commit log view accessible via command palette (`git: commit log`), keyboard shortcut (`alt-g l` or `cmd-alt-g l`), or git panel menu