### PR TITLE
git_ui: Add 'Add to .git/info/exclude' action to git panel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7282,6 +7282,7 @@ dependencies = [
  "watch",
  "windows 0.61.3",
  "workspace",
+ "worktree",
  "zed_actions",
  "zeroize",
  "zlog",

--- a/crates/git/src/git.rs
+++ b/crates/git/src/git.rs
@@ -101,6 +101,8 @@ actions!(
         Clone,
         /// Adds a file to .gitignore.
         AddToGitignore,
+        /// Adds a file to .git/info/exclude.
+        AddToGitExclude,
     ]
 );
 

--- a/crates/git_ui/Cargo.toml
+++ b/crates/git_ui/Cargo.toml
@@ -61,6 +61,7 @@ ui_input.workspace = true
 util.workspace = true
 watch.workspace = true
 workspace.workspace = true
+worktree.workspace = true
 zed_actions.workspace = true
 zeroize.workspace = true
 ztracing.workspace = true

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -5896,7 +5896,10 @@ fn parse_gitfile(content: &str) -> anyhow::Result<&Path> {
     Ok(Path::new(path.trim()))
 }
 
-async fn discover_git_paths(dot_git_abs_path: &Arc<Path>, fs: &dyn Fs) -> (Arc<Path>, Arc<Path>) {
+pub async fn discover_git_paths(
+    dot_git_abs_path: &Arc<Path>,
+    fs: &dyn Fs,
+) -> (Arc<Path>, Arc<Path>) {
     let mut repository_dir_abs_path = dot_git_abs_path.clone();
     let mut common_dir_abs_path = dot_git_abs_path.clone();
 


### PR DESCRIPTION
This adds a new context menu option to add untracked files to .git/info/exclude, which works like .gitignore but is local-only and not committed to the repository.

Implementation:
- Added AddToGitExclude action to git crate
- Refactored common logic into add_entry_to_ignore_file helper
- Both add_to_gitignore and add_to_git_exclude use the shared helper
- Added context menu entry after 'Add to .gitignore'
- Only enabled for untracked (created) files

This allows users to ignore files locally without modifying the shared .gitignore file, which is useful for personal development preferences.

Closes  #29507
  
Release Notes:

- Added: Git panel now has an 'Add to .git/info/exclude' option for untracked files, allowing local-only ignoring without modifying .gitignore

