### PR TITLE
Show the model provider in the favorited model list

### DIFF
--- a/crates/acp_thread/src/connection.rs
+++ b/crates/acp_thread/src/connection.rs
@@ -350,6 +350,7 @@ pub enum AgentModelIcon {
 pub struct AgentModelInfo {
     pub id: acp::ModelId,
     pub name: SharedString,
+    pub provider_name: Option<SharedString>,
     pub description: Option<SharedString>,
     pub icon: Option<AgentModelIcon>,
 }
@@ -359,7 +360,8 @@ impl From<acp::ModelInfo> for AgentModelInfo {
         Self {
             id: info.model_id,
             name: info.name.into(),
-            description: info.description.map(|desc| desc.into()),
+            provider_name: None,
+            description: info.description.map(Into::into),
             icon: None,
         }
     }
@@ -712,6 +714,7 @@ mod test_support {
                 selected_model: Arc::new(Mutex::new(AgentModelInfo {
                     id: acp::ModelId::new("visual-test-model"),
                     name: "Visual Test Model".into(),
+                    provider_name: Some("Zed".into()),
                     description: Some("A stub model for visual testing".into()),
                     icon: Some(AgentModelIcon::Named(ui::IconName::ZedAssistant)),
                 })),

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -159,6 +159,7 @@ impl LanguageModels {
         acp_thread::AgentModelInfo {
             id: Self::model_id(model),
             name: model.name().0,
+            provider_name: Some(provider.name().0),
             description: None,
             icon: Some(match provider.icon() {
                 IconOrSvg::Svg(path) => acp_thread::AgentModelIcon::Path(path),
@@ -1728,6 +1729,7 @@ mod internal_tests {
                 vec![AgentModelInfo {
                     id: acp::ModelId::new("fake/fake"),
                     name: "Fake".into(),
+                    provider_name: Some("Fake".into()),
                     description: None,
                     icon: Some(acp_thread::AgentModelIcon::Named(
                         ui::IconName::ZedAssistant

--- a/crates/agent_ui/src/acp/model_selector.rs
+++ b/crates/agent_ui/src/acp/model_selector.rs
@@ -323,12 +323,13 @@ impl PickerDelegate for AcpModelPickerDelegate {
             AcpModelPickerEntry::Separator(title) => {
                 Some(ModelSelectorHeader::new(title, ix > 1).into_any_element())
             }
-            AcpModelPickerEntry::Model(model_info, is_favorite) => {
+            AcpModelPickerEntry::Model(model_info, is_favorite_entry) => {
                 let is_selected = Some(model_info) == self.selected_model.as_ref();
                 let default_model = self.agent_server.default_model(cx);
                 let is_default = default_model.as_ref() == Some(&model_info.id);
 
-                let is_favorite = *is_favorite;
+                let is_favorite_entry = *is_favorite_entry;
+                let is_favorite = self.favorites.contains(&model_info.id);
                 let handle_action_click = {
                     let model_id = model_info.id.clone();
                     let fs = self.fs.clone();
@@ -360,6 +361,8 @@ impl PickerDelegate for AcpModelPickerDelegate {
                         })
                         .child(
                             ModelSelectorListItem::new(ix, model_info.name.clone())
+                                .provider_name(model_info.provider_name.clone())
+                                .show_provider_name(is_favorite_entry)
                                 .map(|this| match &model_info.icon {
                                     Some(AgentModelIcon::Path(path)) => this.icon_path(path.clone()),
                                     Some(AgentModelIcon::Named(icon)) => this.icon(*icon),
@@ -550,6 +553,7 @@ mod tests {
                         .map(|model| acp_thread::AgentModelInfo {
                             id: acp::ModelId::new(model.to_string()),
                             name: model.to_string().into(),
+                            provider_name: None,
                             description: None,
                             icon: None,
                         })
@@ -772,12 +776,14 @@ mod tests {
             acp_thread::AgentModelInfo {
                 id: acp::ModelId::new("zed/claude".to_string()),
                 name: "Claude".into(),
+                provider_name: Some("Anthropic".into()),
                 description: None,
                 icon: None,
             },
             acp_thread::AgentModelInfo {
                 id: acp::ModelId::new("zed/gemini".to_string()),
                 name: "Gemini".into(),
+                provider_name: Some("Google".into()),
                 description: None,
                 icon: None,
             },
@@ -818,12 +824,14 @@ mod tests {
             acp_thread::AgentModelInfo {
                 id: acp::ModelId::new("favorite-model".to_string()),
                 name: "Favorite".into(),
+                provider_name: None,
                 description: None,
                 icon: None,
             },
             acp_thread::AgentModelInfo {
                 id: acp::ModelId::new("regular-model".to_string()),
                 name: "Regular".into(),
+                provider_name: None,
                 description: None,
                 icon: None,
             },


### PR DESCRIPTION
When a user selects a model as favorite, the model name displays correctly, but the provider information is missing.
For example, a favorited "Gemini 3 Flash" model shows no indication of the provider (e.g., OpenRouter, Google API, GitHub Copilot). While the provider is clearly shown at the top of each model list, this context is lost once the model is favorited.

<img width="404" height="540" alt="obraz" src="https://github.com/user-attachments/assets/06a8efb9-bad2-4fa6-85fc-7586a4891b82" />

Proposed solution would be to display the provider name when hovering over favorite model like below:

<img width="401" height="502" alt="obraz" src="https://github.com/user-attachments/assets/2555948f-16be-42d3-9520-e62fcc7aedd5" />

This PR provides said modification.

Release Notes:

- Adds model provider name visibility when hovering over favorite model.