### PR TITLE
copilot: Rename enabled_next_edit_suggestions setting to enable_next_edit_suggestions

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1522,13 +1522,13 @@
     //   "enterprise_uri": "",
     //   "proxy": "",
     //   "proxy_no_verify": false
-    //   "enabled_next_edit_suggestions": true
+    //   "enable_next_edit_suggestions": true
     // },
     "copilot": {
       "enterprise_uri": null,
       "proxy": null,
       "proxy_no_verify": null,
-      "enabled_next_edit_suggestions": true,
+      "enable_next_edit_suggestions": true,
     },
     "codestral": {
       "api_url": "https://codestral.mistral.ai",

--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -932,7 +932,7 @@ impl Copilot {
         let nes_enabled = AllLanguageSettings::get_global(cx)
             .edit_predictions
             .copilot
-            .enabled_next_edit_suggestions
+            .enable_next_edit_suggestions
             .unwrap_or(true);
 
         cx.background_spawn(async move {

--- a/crates/edit_prediction_ui/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_ui/src/edit_prediction_button.rs
@@ -944,7 +944,7 @@ impl EditPredictionButton {
         let next_edit_suggestions = all_language_settings
             .edit_predictions
             .copilot
-            .enabled_next_edit_suggestions
+            .enable_next_edit_suggestions
             .unwrap_or(true);
         let copilot_config = copilot_chat::CopilotChatConfiguration {
             enterprise_uri: all_language_settings
@@ -975,7 +975,7 @@ impl EditPredictionButton {
                                         .get_or_insert_default()
                                         .copilot
                                         .get_or_insert_default()
-                                        .enabled_next_edit_suggestions =
+                                        .enable_next_edit_suggestions =
                                         Some(!next_edit_suggestions);
                                 });
                             }

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -426,7 +426,7 @@ pub struct CopilotSettings {
     /// Enterprise URI for Copilot.
     pub enterprise_uri: Option<String>,
     /// Whether the Copilot Next Edit Suggestions feature is enabled.
-    pub enabled_next_edit_suggestions: Option<bool>,
+    pub enable_next_edit_suggestions: Option<bool>,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -660,7 +660,7 @@ impl settings::Settings for AllLanguageSettings {
             proxy: copilot.proxy,
             proxy_no_verify: copilot.proxy_no_verify,
             enterprise_uri: copilot.enterprise_uri,
-            enabled_next_edit_suggestions: copilot.enabled_next_edit_suggestions,
+            enable_next_edit_suggestions: copilot.enable_next_edit_suggestions,
         };
 
         let codestral = edit_predictions.codestral.unwrap();

--- a/crates/settings_content/src/language.rs
+++ b/crates/settings_content/src/language.rs
@@ -213,7 +213,7 @@ pub struct CopilotSettingsContent {
     /// Whether the Copilot Next Edit Suggestions feature is enabled.
     ///
     /// Default: true
-    pub enabled_next_edit_suggestions: Option<bool>,
+    pub enable_next_edit_suggestions: Option<bool>,
 }
 
 #[with_fallible_options]


### PR DESCRIPTION
Co-authored-by: Marshall Bowers <marshall@zed.dev>

Closes #ISSUE

Release Notes:

- N/A
