### PR TITLE
git_graph: Fix subject not wrapping

### DIFF
--- a/crates/git_graph/src/git_graph.rs
+++ b/crates/git_graph/src/git_graph.rs
@@ -1116,6 +1116,7 @@ impl GitGraph {
                     .border_t_1()
                     .border_color(cx.theme().colors().border)
                     .p_3()
+                    .min_w_0()
                     .child(
                         v_flex()
                             .gap_2()


### PR DESCRIPTION
Before:

<img width="314" height="111" alt="image" src="https://github.com/user-attachments/assets/8e3b6ac9-81f5-4d21-aa51-9807afe4a732" />



After:

<img width="314" height="111" alt="image" src="https://github.com/user-attachments/assets/d209c38a-9105-4c4f-908e-ca0e063c0cbc" />


Release Notes:

- N/A
