### PR TITLE
languages: Fix C/C++ outline for function definitions and declarations with mixed storage and type qualifiers 

### DIFF
--- a/crates/languages/src/cpp/outline.scm
+++ b/crates/languages/src/cpp/outline.scm
@@ -60,7 +60,10 @@
     ] @item)
 
 (function_definition
-    (type_qualifier)? @context
+    [
+        (storage_class_specifier)
+        (type_qualifier)
+    ]* @context
     type: (_)? @context
     declarator: [
         (function_declarator
@@ -95,7 +98,10 @@
     (type_qualifier)? @context) @item
 
 (declaration
-    (type_qualifier)? @context
+    [
+        (storage_class_specifier)
+        (type_qualifier)
+    ]* @context
     type: (_)? @context
     declarator: [
         (field_identifier) @name


### PR DESCRIPTION
Before:
<img width="1002" height="228" alt="before" src="https://github.com/user-attachments/assets/94c5d0b7-a467-4bfe-8eaf-5a2c4b3cb7ea" />

After:
<img width="1002" height="228" alt="after" src="https://github.com/user-attachments/assets/73d049d2-4dd1-40a4-ac21-984ca3fd32ee" />

Release Notes:

- Fixed C/C++ outline for function definitions and declarations with mixed storage and type qualifiers.
