### PR TITLE
Add helper method for checking if the LLM token needs to be refreshed

### DIFF
--- a/crates/language_model/src/model/cloud_model.rs
+++ b/crates/language_model/src/model/cloud_model.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use client::Client;
 use cloud_api_types::websocket_protocol::MessageToClient;
+use cloud_llm_client::EXPIRED_LLM_TOKEN_HEADER_NAME;
 use gpui::{App, AppContext as _, Context, Entity, EventEmitter, Global, ReadGlobal as _};
 use smol::lock::{RwLock, RwLockUpgradableReadGuard, RwLockWriteGuard};
 use thiserror::Error;
@@ -49,6 +50,17 @@ impl LlmApiToken {
         let response = client.cloud_client().create_llm_token(system_id).await?;
         *lock = Some(response.token.0.clone());
         Ok(response.token.0)
+    }
+}
+
+pub trait NeedsLlmTokenRefresh {
+    /// Returns whether the LLM token needs to be refreshed.
+    fn needs_llm_token_refresh(&self) -> bool;
+}
+
+impl NeedsLlmTokenRefresh for http_client::Response<http_client::AsyncBody> {
+    fn needs_llm_token_refresh(&self) -> bool {
+        self.headers().get(EXPIRED_LLM_TOKEN_HEADER_NAME).is_some()
     }
 }
 


### PR DESCRIPTION
This PR adds a new `needs_llm_token_refresh` helper method for checking if the LLM token needs to be refreshed.

We were duplicating the check for the `x-zed-expired-token` header in a number of spots, and it will be gaining an additional case soon.

Release Notes:

- N/A
