### PR TITLE
git: Skip setting language on git index buffer

### DIFF
--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -3210,9 +3210,9 @@ impl BufferGitState {
                 unstaged_diff.as_ref().zip(new_unstaged_diff.clone())
             {
                 let task = unstaged_diff.update(cx, |diff, cx| {
-                    if language_changed {
-                        diff.language_changed(language.clone(), language_registry.clone(), cx);
-                    }
+                    // For git index buffer we skip assigning the language as we do not really need to perform any syntax highlighting on
+                    // it. As a result, by skipping it we are potentially shaving off a lot of RSS plus we get a snappier feel for large diff
+                    // view multibuffers.
                     diff.set_snapshot(new_unstaged_diff, &buffer, cx)
                 });
                 Some(task.await)


### PR DESCRIPTION
Skipping setting the language on the git index text buffer improves snappiness for (very) large git diff multibuffers and also significantly lower peak and steady-state RSS. When tested on the chromium repo with `git reset HEAD~1000` and *all* language extensions installed we notice:
* current `main`: peak RSS ~45GB, ss RSS ~39GB
* this patch: peak RSS ~30GB, ss RSS ~27GB

Release Notes:

- Improved memory usage of large git diff multibuffers.
