### PR TITLE
acp: Skip setting language on secondary diff buffer

### DIFF
--- a/crates/acp_thread/src/diff.rs
+++ b/crates/acp_thread/src/diff.rs
@@ -90,9 +90,10 @@ impl Diff {
             let mut diff = BufferDiff::new_unchanged(&buffer_text_snapshot, cx);
             diff.language_changed(language.clone(), language_registry.clone(), cx);
             let secondary_diff = cx.new(|cx| {
-                let mut diff = BufferDiff::new_unchanged(&buffer_text_snapshot, cx);
-                diff.language_changed(language, language_registry, cx);
-                diff
+                // For the secondary diff buffer we skip assigning the language as we do not really need to perform any syntax highlighting on
+                // it. As a result, by skipping it we are potentially shaving off a lot of RSS plus we get a snappier feel for large diff
+                // view multibuffers.
+                BufferDiff::new_unchanged(&buffer_text_snapshot, cx)
             });
             diff.set_secondary_diff(secondary_diff);
             diff
@@ -408,7 +409,6 @@ async fn build_buffer_diff(
 
     secondary_diff
         .update(cx, |secondary_diff, cx| {
-            secondary_diff.language_changed(language.clone(), language_registry.clone(), cx);
             secondary_diff.set_snapshot(update.clone(), &buffer, cx)
         })
         .await;


### PR DESCRIPTION
Mirrors https://github.com/zed-industries/zed/commit/3d4582d4dc9145270650e12f9ce5a534b888f4a2. We skip setting language on the secondary diff buffer which is not needed and will improve performance and memory usage.

Release Notes:

- Improved memory usage of large ACP thread diff multibuffers.
