### PR TITLE
terminal: Fix double quoting of commands on Windows cmd.exe

### DIFF
--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -199,14 +199,7 @@ impl Project {
                                         activation_script.join(&format!("{separator} "));
                                     let to_run = format_to_run();
 
-                                    let mut arg =
-                                        format!("{activation_script}{separator} {to_run}");
-                                    if shell_kind == ShellKind::Cmd {
-                                        // We need to put the entire command in quotes since otherwise CMD tries to execute them
-                                        // as separate commands rather than chaining one after another.
-                                        arg = format!("\"{arg}\"");
-                                    }
-
+                                    let arg = format!("{activation_script}{separator} {to_run}");
                                     let args = shell_kind.args_for_shell(false, arg);
 
                                     (


### PR DESCRIPTION
Closes #47303 

The command quoting for `cmd` shell was first introduced (at least in this case) in PR #41216 three months ago:
https://github.com/zed-industries/zed/blob/3d4582d4dc9145270650e12f9ce5a534b888f4a2/crates/project/src/terminals.rs#L202-L210

And a month ago, PR #42382 added command quoting for `cmd` in a different place:
https://github.com/zed-industries/zed/blob/3d4582d4dc9145270650e12f9ce5a534b888f4a2/crates/util/src/shell.rs#L413-L434

As a result, the command is now quoted twice when using `cmd`. `cmd` interprets the entire double-quoted string (e.g., ""command & args"") as a single (invalid) executable name, and this would lead to an error like “The system cannot find the path specified” in #47303 .

The solution is to remove the redundant manual quoting in `terminals.rs` and rely on the centralized logic in `util/src/shell.rs`.

/cc @Veykril @reflectronic 

Release Notes:

- Fixed a bug where terminal tasks failed to start on Windows when using `cmd.exe`.
