### PR TITLE
git: Add commit hooks toggle

### DIFF
--- a/crates/git/src/git.rs
+++ b/crates/git/src/git.rs
@@ -87,6 +87,8 @@ actions!(
         Amend,
         /// Enable the --signoff option.
         Signoff,
+        /// Enable the commit hooks option.
+        Hooks,
         /// Cancels the current git operation.
         Cancel,
         /// Expands the commit message editor.

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -364,6 +364,7 @@ impl Upstream {
 pub struct CommitOptions {
     pub amend: bool,
     pub signoff: bool,
+    pub hooks: bool,
 }
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]

--- a/crates/git_ui/src/commit_modal.rs
+++ b/crates/git_ui/src/commit_modal.rs
@@ -1,7 +1,7 @@
 use crate::branch_picker::{self, BranchList};
 use crate::git_panel::{GitPanel, commit_message_editor, panel_editor_style};
 use git::repository::CommitOptions;
-use git::{Amend, Commit, GenerateCommitMessage, Signoff};
+use git::{Amend, Commit, GenerateCommitMessage, Hooks, Signoff};
 use panel::panel_button;
 use project::DisableAiSettings;
 use settings::Settings;
@@ -281,6 +281,7 @@ impl CommitModal {
                     let git_panel = git_panel_entity.read(cx);
                     let amend_enabled = git_panel.amend_pending();
                     let signoff_enabled = git_panel.signoff_enabled();
+                    let hooks_enabled = git_panel.hooks_enabled();
                     let has_previous_commit = git_panel.head_commit(cx).is_some();
 
                     Some(ContextMenu::build(window, cx, |context_menu, _, _| {
@@ -320,6 +321,20 @@ impl CommitModal {
                                     }
                                 },
                             )
+                            .toggleable_entry(
+                                "Hooks",
+                                hooks_enabled,
+                                IconPosition::Start,
+                                Some(Box::new(Hooks)),
+                                {
+                                    let git_panel = git_panel_entity.clone();
+                                    move |window, cx| {
+                                        git_panel.update(cx, |git_panel, cx| {
+                                            git_panel.toggle_hooks_enabled(&Hooks, window, cx);
+                                        })
+                                    }
+                                },
+                            )
                     }))
                 }
             })
@@ -337,6 +352,7 @@ impl CommitModal {
             active_repo,
             is_amend_pending,
             is_signoff_enabled,
+            is_hooks_enabled,
             workspace,
         ) = self.git_panel.update(cx, |git_panel, cx| {
             let (can_commit, tooltip) = git_panel.configure_commit_button(cx);
@@ -346,6 +362,7 @@ impl CommitModal {
             let active_repo = git_panel.active_repository.clone();
             let is_amend_pending = git_panel.amend_pending();
             let is_signoff_enabled = git_panel.signoff_enabled();
+            let is_run_hooks = git_panel.hooks_enabled();
             (
                 can_commit,
                 tooltip,
@@ -355,6 +372,7 @@ impl CommitModal {
                 active_repo,
                 is_amend_pending,
                 is_signoff_enabled,
+                is_run_hooks,
                 git_panel.workspace.clone(),
             )
         });
@@ -452,6 +470,7 @@ impl CommitModal {
                                     CommitOptions {
                                         amend: is_amend_pending,
                                         signoff: is_signoff_enabled,
+                                        hooks: is_hooks_enabled,
                                     },
                                     window,
                                     cx,
@@ -472,9 +491,14 @@ impl CommitModal {
                                             &git::Commit
                                         }),
                                         format!(
-                                            "git commit{}{}",
+                                            "git commit{}{}{}",
                                             if is_amend_pending { " --amend" } else { "" },
-                                            if is_signoff_enabled { " --signoff" } else { "" }
+                                            if is_signoff_enabled { " --signoff" } else { "" },
+                                            if !is_hooks_enabled {
+                                                " --no-verify"
+                                            } else {
+                                                ""
+                                            }
                                         ),
                                         &focus_handle.clone(),
                                         cx,

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -31,7 +31,7 @@ use git::stash::GitStash;
 use git::status::{DiffStat, StageStatus};
 use git::{Amend, Signoff, ToggleStaged, repository::RepoPath, status::FileStatus};
 use git::{
-    ExpandCommitEditor, GitHostingProviderRegistry, RestoreTrackedFiles, StageAll, StashAll,
+    ExpandCommitEditor, GitHostingProviderRegistry, Hooks, RestoreTrackedFiles, StageAll, StashAll,
     StashApply, StashPop, TrashUntrackedFiles, UnstageAll,
 };
 use gpui::{
@@ -635,6 +635,7 @@ pub struct GitPanel {
     amend_pending: bool,
     original_commit_message: Option<String>,
     signoff_enabled: bool,
+    hooks_enabled: bool,
     pending_serialization: Task<()>,
     pub(crate) project: Entity<Project>,
     scroll_handle: UniformListScrollHandle,
@@ -837,6 +838,7 @@ impl GitPanel {
                 amend_pending: false,
                 original_commit_message: None,
                 signoff_enabled: false,
+                hooks_enabled: true,
                 pending_serialization: Task::ready(()),
                 single_staged_entry: None,
                 single_tracked_entry: None,
@@ -2166,6 +2168,7 @@ impl GitPanel {
                 CommitOptions {
                     amend: false,
                     signoff: self.signoff_enabled,
+                    hooks: self.hooks_enabled,
                 },
                 window,
                 cx,
@@ -2206,6 +2209,7 @@ impl GitPanel {
                         CommitOptions {
                             amend: true,
                             signoff: self.signoff_enabled,
+                            hooks: self.hooks_enabled,
                         },
                         window,
                         cx,
@@ -4176,6 +4180,7 @@ impl GitPanel {
                 let has_previous_commit = self.head_commit(cx).is_some();
                 let amend = self.amend_pending();
                 let signoff = self.signoff_enabled;
+                let hooks_enabled = self.hooks_enabled;
 
                 move |window, cx| {
                     Some(ContextMenu::build(window, cx, |context_menu, _, _| {
@@ -4207,6 +4212,13 @@ impl GitPanel {
                                 IconPosition::Start,
                                 Some(Box::new(Signoff)),
                                 move |window, cx| window.dispatch_action(Box::new(Signoff), cx),
+                            )
+                            .toggleable_entry(
+                                "Hooks",
+                                hooks_enabled,
+                                IconPosition::Start,
+                                Some(Box::new(Hooks)),
+                                move |window, cx| window.dispatch_action(Box::new(Hooks), cx),
                             )
                     }))
                 }
@@ -4480,6 +4492,7 @@ impl GitPanel {
         let commit_tooltip_focus_handle = self.commit_editor.focus_handle(cx);
         let amend = self.amend_pending();
         let signoff = self.signoff_enabled;
+        let hooks = self.hooks_enabled;
 
         let label_color = if self.pending_commit.is_some() {
             Color::Disabled
@@ -4513,7 +4526,11 @@ impl GitPanel {
                         git_panel
                             .update(cx, |git_panel, cx| {
                                 git_panel.commit_changes(
-                                    CommitOptions { amend, signoff },
+                                    CommitOptions {
+                                        amend,
+                                        signoff,
+                                        hooks,
+                                    },
                                     window,
                                     cx,
                                 );
@@ -5529,6 +5546,25 @@ impl GitPanel {
         cx.notify();
     }
 
+    pub fn hooks_enabled(&self) -> bool {
+        self.hooks_enabled
+    }
+
+    pub fn set_hooks_enabled(&mut self, value: bool, cx: &mut Context<Self>) {
+        self.hooks_enabled = value;
+        self.serialize(cx);
+        cx.notify();
+    }
+
+    pub fn toggle_hooks_enabled(
+        &mut self,
+        _: &Hooks,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.set_hooks_enabled(!self.hooks_enabled, cx);
+    }
+
     pub fn signoff_enabled(&self) -> bool {
         self.signoff_enabled
     }
@@ -5657,6 +5693,7 @@ impl Render for GitPanel {
                     .on_action(cx.listener(GitPanel::on_commit))
                     .on_action(cx.listener(GitPanel::on_amend))
                     .on_action(cx.listener(GitPanel::toggle_signoff_enabled))
+                    .on_action(cx.listener(GitPanel::toggle_hooks_enabled))
                     .on_action(cx.listener(Self::stage_all))
                     .on_action(cx.listener(Self::unstage_all))
                     .on_action(cx.listener(Self::stage_selected))

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -2232,6 +2232,7 @@ impl GitStore {
                     CommitOptions {
                         amend: options.amend,
                         signoff: options.signoff,
+                        hooks: options.hooks,
                     },
                     askpass,
                     cx,
@@ -5130,10 +5131,16 @@ impl Repository {
         let askpass_delegates = self.askpass_delegates.clone();
         let askpass_id = util::post_inc(&mut self.latest_askpass_id);
 
-        let rx = self.run_hook(RunHook::PreCommit, cx);
+        let rx = if options.hooks {
+            Some(self.run_hook(RunHook::PreCommit, cx))
+        } else {
+            None
+        };
 
         self.send_job(Some("git commit".into()), move |git_repo, _cx| async move {
-            rx.await??;
+            if let Some(rx) = rx {
+                rx.await??;
+            }
 
             match git_repo {
                 RepositoryState::Local(LocalRepositoryState {
@@ -5162,6 +5169,7 @@ impl Repository {
                             options: Some(proto::commit::CommitOptions {
                                 amend: options.amend,
                                 signoff: options.signoff,
+                                hooks: options.hooks,
                             }),
                             askpass_id,
                         })

--- a/crates/proto/proto/git.proto
+++ b/crates/proto/proto/git.proto
@@ -421,6 +421,7 @@ message Commit {
   message CommitOptions {
     bool amend = 1;
     bool signoff = 2;
+    bool hooks = 3;
   }
 }
 


### PR DESCRIPTION
With the Hooks toggle, found in both the commit modal and panel, users can choose to commit their changes without running the pre-commit hook.

The hooks option is enabled by default, which is what you want out of the box.

Closes #47124

Release Notes:

- Added toggle for to enable/disable git commit hooks in commit panel and modal.

**Design questions**

- When committing with hooks disabled, should it be enabled back after commit?
- Any suggestion for better naming of the action which I for now called `git::Hooks`?

**Screenshots**

Hooks option in commit panel
<img width="371" height="272" alt="image" src="https://github.com/user-attachments/assets/566318fb-e439-404a-ab0f-174bdc78f747" />

Hooks option in commit modal
<img width="737" height="495" alt="image" src="https://github.com/user-attachments/assets/27e40965-e3e3-44fb-8ff2-de352f3846da" />
