### PR TITLE
build: Re-enable incremental compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -800,8 +800,7 @@ calloop = { git = "https://github.com/zed-industries/calloop" }
 
 [profile.dev]
 split-debuginfo = "unpacked"
-# https://github.com/rust-lang/cargo/issues/16104
-incremental = false
+incremental = true
 codegen-units = 16
 
 # mirror configuration for crates compiled for the build platform


### PR DESCRIPTION
#47358 bumped Rust to the latest stable, which includes the fix for rust-lang/cargo#16104 (rust-lang/cargo#16262). We can now re-enable incremental compilation in the codebase.

Release Notes:

- N/A
