### PR TITLE
Ensure consistent newline behavior in auto-height editors with JetBrains keymap

### DIFF
--- a/assets/keymaps/linux/jetbrains.json
+++ b/assets/keymaps/linux/jetbrains.json
@@ -82,6 +82,13 @@
     },
   },
   {
+    "context": "Editor && mode == auto_height",
+    "bindings": {
+      "shift-enter": "editor::Newline",
+      "ctrl-shift-enter": "editor::NewlineBelow",
+    },
+  },
+  {
     "context": "BufferSearchBar",
     "bindings": {
       "shift-enter": "search::SelectPreviousMatch",

--- a/assets/keymaps/macos/jetbrains.json
+++ b/assets/keymaps/macos/jetbrains.json
@@ -80,6 +80,13 @@
     },
   },
   {
+    "context": "Editor && mode == auto_height",
+    "bindings": {
+      "shift-enter": "editor::Newline",
+      "ctrl-shift-enter": "editor::NewlineBelow",
+    },
+  },
+  {
     "context": "BufferSearchBar",
     "bindings": {
       "shift-enter": "search::SelectPreviousMatch",


### PR DESCRIPTION
Add an explicit `Editor && mode == auto_height` context block. This ensures that `Shift+Enter` and `Ctrl+Enter` correctly insert a newline at the cursor position in editors like the AI Agent Panel,
preventing them from inheriting conflicting overrides (e.g., JetBrains mapping `Shift+Enter` to `editor::NewlineBelow`).

Closes #47269

Release Notes:

- Fixed an issue where `Shift+Enter` would insert a newline at the end of the text instead of the cursor position in the Agent Panel when using certain keymaps.
