### PR TITLE
Fix link for `Ownership and data flow` in GPUI's README.md

### DIFF
--- a/crates/gpui/README.md
+++ b/crates/gpui/README.md
@@ -11,7 +11,7 @@ GPUI is still in active development as we work on the Zed code editor, and is st
 gpui = { version = "*" }
 ```
 
- - [Ownership and data flow](_ownership_and_data_flow)
+ - [Ownership and data flow](https://zed.dev/blog/gpui-ownership)
 
 Everything in GPUI starts with an `Application`. You can create one with `Application::new()`, and kick off your application by passing a callback to `Application::run()`. Inside this callback, you can create a new window with `App::open_window()`, and register your first root view. See [gpui.rs](https://www.gpui.rs/) for a complete example.
 


### PR DESCRIPTION
old link redirects to a non-existing page showing '404 - page not found', probably referring to `src/_ownership_and_data_flow.rs`. anyway I put the official article link

Release Notes:
- N/A