### PR TITLE
[WIP] System prompt customization

### DIFF
--- a/crates/agent/src/native_agent_server.rs
+++ b/crates/agent/src/native_agent_server.rs
@@ -10,7 +10,7 @@ use gpui::{App, Entity, SharedString, Task};
 use prompt_store::PromptStore;
 use settings::{LanguageModelSelection, Settings as _, update_settings_file};
 
-use crate::{NativeAgent, NativeAgentConnection, ThreadStore, templates::Templates};
+use crate::{NativeAgent, NativeAgentConnection, ThreadStore};
 
 #[derive(Clone)]
 pub struct NativeAgentServer {
@@ -53,14 +53,10 @@ impl AgentServer for NativeAgentServer {
         let thread_store = self.thread_store.clone();
         let prompt_store = PromptStore::global(cx);
         cx.spawn(async move |cx| {
-            log::debug!("Creating templates for native agent");
-            let templates = Templates::new();
             let prompt_store = prompt_store.await?;
 
             log::debug!("Creating native agent entity");
-            let agent =
-                NativeAgent::new(project, thread_store, templates, Some(prompt_store), fs, cx)
-                    .await?;
+            let agent = NativeAgent::new(project, thread_store, Some(prompt_store), fs, cx).await?;
 
             // Create the connection wrapper
             let connection = NativeAgentConnection(agent);

--- a/crates/agent/src/templates.rs
+++ b/crates/agent/src/templates.rs
@@ -1,9 +1,13 @@
-use anyhow::Result;
+use anyhow::{Result, anyhow, bail};
 use gpui::SharedString;
-use handlebars::Handlebars;
+use handlebars::{Handlebars, RenderError, Renderable, StringOutput};
 use rust_embed::RustEmbed;
 use serde::Serialize;
-use std::sync::Arc;
+use serde_json::{Map, Value as Json};
+use std::{
+    collections::{BTreeSet, HashMap},
+    sync::Arc,
+};
 
 #[derive(RustEmbed)]
 #[folder = "src/templates"]
@@ -14,11 +18,412 @@ pub struct Templates(Handlebars<'static>);
 
 impl Templates {
     pub fn new() -> Arc<Self> {
+        Self::new_with_section_config(None)
+    }
+
+    pub fn new_with_section_config(section_config: Option<TemplateSectionConfig>) -> Arc<Self> {
         let mut handlebars = Handlebars::new();
         handlebars.set_strict_mode(true);
         handlebars.register_helper("contains", Box::new(contains));
+        handlebars.register_helper(
+            "section",
+            Box::new(SectionHelper {
+                section_config: Arc::new(section_config.unwrap_or_default()),
+            }),
+        );
         handlebars.register_embed_templates::<Assets>().unwrap();
         Arc::new(Self(handlebars))
+    }
+
+    /// Returns the section graph for all embedded templates so callers can
+    /// understand which sections are nested beneath others.
+    pub fn section_graph() -> Result<SectionGraph> {
+        let mut graph = SectionGraph {
+            templates: HashMap::new(),
+        };
+        for template_name in Assets::iter() {
+            let asset = Assets::get(template_name.as_ref())
+                .ok_or_else(|| anyhow!("Missing template asset: {template_name}"))?;
+            let contents = std::str::from_utf8(asset.data.as_ref())
+                .map_err(|err| anyhow!("Invalid utf-8 in {template_name}: {err}"))?;
+            let template_graph = parse_section_graph_from_text(contents)
+                .map_err(|err| anyhow!("Failed to parse {template_name}: {err}"))?;
+            graph
+                .templates
+                .insert(template_name.into_owned(), template_graph);
+        }
+        Ok(graph)
+    }
+}
+
+/// The complete section graph for each embedded template.
+#[derive(Clone, Debug, Default)]
+pub struct SectionGraph {
+    pub templates: HashMap<String, TemplateSectionGraph>,
+}
+
+/// The section hierarchy for a single template.
+#[derive(Clone, Debug, Default)]
+pub struct TemplateSectionGraph {
+    /// All sections in the template keyed by name.
+    pub sections: HashMap<String, SectionNode>,
+    /// Sections that are not nested under any other section.
+    pub roots: Vec<String>,
+}
+
+/// A node in the section hierarchy with parent/child relationships.
+#[derive(Clone, Debug, Default)]
+pub struct SectionNode {
+    pub name: String,
+    pub children: Vec<String>,
+    pub parents: Vec<String>,
+    /// Available argument names for replacements rendered within this section.
+    pub arguments: Arc<Vec<String>>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct TemplateSectionConfig {
+    sections: HashMap<String, TemplateSectionOverride>,
+}
+
+impl TemplateSectionConfig {
+    pub fn insert_replace(
+        &mut self,
+        section_name: impl Into<String>,
+        replacement: impl Into<String>,
+    ) {
+        self.sections.insert(
+            section_name.into(),
+            TemplateSectionOverride::Replace(replacement.into()),
+        );
+    }
+
+    pub fn insert_remove(&mut self, section_name: impl Into<String>) {
+        self.sections
+            .insert(section_name.into(), TemplateSectionOverride::Remove);
+    }
+
+    fn section_override(&self, section_name: &str) -> Option<&TemplateSectionOverride> {
+        self.sections.get(section_name)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum TemplateSectionOverride {
+    Replace(String),
+    Remove,
+}
+
+struct SectionHelper {
+    section_config: Arc<TemplateSectionConfig>,
+}
+
+impl handlebars::HelperDef for SectionHelper {
+    fn call<'reg: 'rc, 'rc>(
+        &self,
+        helper: &handlebars::Helper<'reg, 'rc>,
+        registry: &'reg handlebars::Handlebars,
+        context: &'rc handlebars::Context,
+        render_context: &mut handlebars::RenderContext<'reg, 'rc>,
+        out: &mut dyn handlebars::Output,
+    ) -> handlebars::HelperResult {
+        let section_name = helper
+            .param(0)
+            .and_then(section_name_from_param)
+            .or_else(|| {
+                helper
+                    .hash_get("name")
+                    .and_then(|value| value.value().as_str())
+                    .map(str::to_owned)
+            })
+            .ok_or_else(|| handlebars::RenderError::new("section: missing name parameter"))?;
+
+        if let Some(section_override) = self.section_config.section_override(&section_name) {
+            match section_override {
+                TemplateSectionOverride::Replace(replacement) => {
+                    let rendered = render_replacement_with_context(
+                        replacement,
+                        registry,
+                        context,
+                        render_context,
+                    )?;
+                    out.write(&trim_section_trailing_newline(rendered))?;
+                }
+                TemplateSectionOverride::Remove => {
+                    if let Some(inverse) = helper.inverse() {
+                        let rendered =
+                            render_template_to_string(inverse, registry, context, render_context)?;
+                        out.write(&trim_section_trailing_newline(rendered))?;
+                    }
+                }
+            }
+            return Ok(());
+        }
+
+        let template = helper
+            .template()
+            .ok_or_else(|| handlebars::RenderError::new("section: missing block"))?;
+        let rendered = render_template_to_string(template, registry, context, render_context)?;
+        out.write(&trim_section_trailing_newline(rendered))?;
+        Ok(())
+    }
+}
+
+fn render_template_to_string<'reg, 'rc>(
+    template: &'reg handlebars::Template,
+    registry: &'reg handlebars::Handlebars<'reg>,
+    context: &'rc handlebars::Context,
+    render_context: &mut handlebars::RenderContext<'reg, 'rc>,
+) -> Result<String, RenderError> {
+    let mut output = StringOutput::new();
+    template.render(registry, context, render_context, &mut output)?;
+    output
+        .into_string()
+        .map_err(|err| RenderError::new(format!("section: invalid utf-8 output: {err}")))
+}
+
+fn render_replacement_with_context<'reg, 'rc>(
+    replacement: &str,
+    registry: &'reg handlebars::Handlebars<'reg>,
+    context: &'rc handlebars::Context,
+    render_context: &mut handlebars::RenderContext<'reg, 'rc>,
+) -> Result<String, RenderError> {
+    let replacement_context = replacement_context(context, render_context)?;
+    let context = replacement_context.as_ref().unwrap_or(context);
+    registry
+        .render_template_with_context(replacement, context)
+        .map_err(|err| RenderError::new(format!("section: replacement render failed: {err}")))
+}
+
+fn replacement_context<'reg, 'rc>(
+    context: &'rc handlebars::Context,
+    render_context: &handlebars::RenderContext<'reg, 'rc>,
+) -> Result<Option<handlebars::Context>, RenderError> {
+    let scoped = render_context.evaluate(context, "this")?;
+    if scoped.is_missing() {
+        return Ok(None);
+    }
+    let this_value = scoped.as_json().clone();
+    let root_value = context.data().clone();
+    let mut map = match &this_value {
+        Json::Object(map) => map.clone(),
+        _ => Map::new(),
+    };
+    map.insert("this".to_string(), this_value);
+    map.insert("root".to_string(), root_value);
+    let value = Json::Object(map);
+    let context = handlebars::Context::wraps(value)
+        .map_err(|err| RenderError::new(format!("section: invalid replacement context: {err}")))?;
+    Ok(Some(context))
+}
+
+fn section_name_from_param(param: &handlebars::PathAndJson) -> Option<String> {
+    if let Some(section_name) = param.value().as_str() {
+        return Some(section_name.to_owned());
+    }
+
+    if param.is_value_missing() {
+        return param.relative_path().cloned();
+    }
+
+    None
+}
+
+fn trim_section_trailing_newline(mut rendered: String) -> String {
+    if rendered.ends_with("\r\n\r\n") {
+        rendered.truncate(rendered.len() - 2);
+    } else if rendered.ends_with("\n\n") {
+        rendered.pop();
+    }
+    rendered
+}
+
+fn parse_section_graph_from_text(contents: &str) -> Result<TemplateSectionGraph> {
+    let mut sections: HashMap<String, SectionNode> = HashMap::new();
+    let mut argument_pool: HashMap<Vec<String>, Arc<Vec<String>>> = HashMap::new();
+    let mut roots = BTreeSet::new();
+    let mut stack: Vec<String> = Vec::new();
+    let mut scope_stack = vec![BlockScope {
+        name: None,
+        arguments: intern_arguments(&default_arguments(), &mut argument_pool),
+    }];
+    let mut index = 0;
+    while let Some(open_index) = contents[index..].find("{{") {
+        let tag_start = index + open_index;
+        let tag_end = contents[tag_start..]
+            .find("}}")
+            .map(|offset| tag_start + offset + 2)
+            .ok_or_else(|| anyhow!("Unterminated template tag"))?;
+        let tag = &contents[tag_start + 2..tag_end - 2];
+        let tag = tag.trim();
+        if tag.starts_with("!--") {
+            index = tag_end;
+            continue;
+        }
+        if let Some(section_name) = tag.strip_prefix("#section") {
+            let section_name =
+                parse_section_name(section_name).ok_or_else(|| anyhow!("section: missing name"))?;
+            let entry = sections
+                .entry(section_name.clone())
+                .or_insert_with(|| SectionNode {
+                    name: section_name.clone(),
+                    ..SectionNode::default()
+                });
+            entry.arguments = scope_stack
+                .last()
+                .map(|scope| scope.arguments.clone())
+                .unwrap_or_else(|| intern_arguments(&default_arguments(), &mut argument_pool));
+            if let Some(parent) = stack.last() {
+                add_unique(&mut entry.parents, parent);
+                let parent_entry = sections
+                    .entry(parent.clone())
+                    .or_insert_with(|| SectionNode {
+                        name: parent.clone(),
+                        arguments: scope_stack
+                            .last()
+                            .map(|scope| scope.arguments.clone())
+                            .unwrap_or_else(|| {
+                                intern_arguments(&default_arguments(), &mut argument_pool)
+                            }),
+                        ..SectionNode::default()
+                    });
+                add_unique(&mut parent_entry.children, &section_name);
+            } else {
+                roots.insert(section_name.clone());
+            }
+            stack.push(section_name);
+        } else if let Some(scope_name) = parse_block_start(tag) {
+            let arguments = if scope_name == "each" || scope_name == "with" {
+                let new_params = parse_block_params(tag);
+                if new_params.is_empty() {
+                    scope_stack
+                        .last()
+                        .map(|scope| scope.arguments.clone())
+                        .unwrap_or_else(|| {
+                            intern_arguments(&default_arguments(), &mut argument_pool)
+                        })
+                } else {
+                    let mut arguments = scope_stack
+                        .last()
+                        .map(|scope| (*scope.arguments).clone())
+                        .unwrap_or_else(default_arguments);
+                    arguments.extend(new_params);
+                    intern_arguments(&arguments, &mut argument_pool)
+                }
+            } else {
+                scope_stack
+                    .last()
+                    .map(|scope| scope.arguments.clone())
+                    .unwrap_or_else(|| intern_arguments(&default_arguments(), &mut argument_pool))
+            };
+            scope_stack.push(BlockScope {
+                name: Some(scope_name),
+                arguments,
+            });
+        } else if tag.starts_with("/section") {
+            if stack.pop().is_none() {
+                bail!("section: closing tag without opener");
+            }
+        } else if let Some(close_name) = parse_block_end(tag) {
+            if scope_stack.len() > 1
+                && scope_stack.last().and_then(|scope| scope.name.as_deref())
+                    == Some(close_name.as_str())
+            {
+                scope_stack.pop();
+            }
+        }
+        index = tag_end;
+    }
+    if !stack.is_empty() {
+        bail!("section: unclosed tag");
+    }
+    let roots = roots.into_iter().collect::<Vec<_>>();
+    Ok(TemplateSectionGraph { sections, roots })
+}
+
+#[derive(Clone, Debug)]
+struct BlockScope {
+    name: Option<String>,
+    arguments: Arc<Vec<String>>,
+}
+
+fn default_arguments() -> Vec<String> {
+    vec!["root".to_string(), "this".to_string()]
+}
+
+fn intern_arguments(
+    arguments: &[String],
+    pool: &mut HashMap<Vec<String>, Arc<Vec<String>>>,
+) -> Arc<Vec<String>> {
+    if let Some(shared) = pool.get(arguments) {
+        return shared.clone();
+    }
+    let shared = Arc::new(arguments.to_vec());
+    pool.insert(arguments.to_vec(), shared.clone());
+    shared
+}
+
+fn parse_block_start(tag: &str) -> Option<String> {
+    let tag = tag.trim_start();
+    let tag = tag.strip_prefix('#')?;
+    parse_block_name(tag)
+}
+
+fn parse_block_end(tag: &str) -> Option<String> {
+    let tag = tag.trim_start();
+    let tag = tag.strip_prefix('/')?;
+    parse_block_name(tag)
+}
+
+fn parse_block_name(tag: &str) -> Option<String> {
+    let end = tag
+        .find(|char: char| char.is_whitespace() || char == '}')
+        .unwrap_or(tag.len());
+    if end == 0 {
+        None
+    } else {
+        Some(tag[..end].to_string())
+    }
+}
+
+fn parse_block_params(tag: &str) -> Vec<String> {
+    let Some(as_index) = tag.find(" as |") else {
+        return Vec::new();
+    };
+    let after_as = &tag[as_index + " as |".len()..];
+    let Some(end) = after_as.find('|') else {
+        return Vec::new();
+    };
+    after_as[..end]
+        .split_whitespace()
+        .map(str::to_string)
+        .collect()
+}
+
+fn parse_section_name(tag_body: &str) -> Option<String> {
+    let tag_body = tag_body.trim();
+    if tag_body.is_empty() {
+        return None;
+    }
+
+    if let Some(quoted) = tag_body.strip_prefix('"') {
+        let end = quoted.find('"')?;
+        return Some(quoted[..end].to_string());
+    }
+
+    let name_end = tag_body
+        .find(|char: char| char.is_whitespace() || char == '}')
+        .unwrap_or(tag_body.len());
+    if name_end == 0 {
+        None
+    } else {
+        Some(tag_body[..name_end].to_string())
+    }
+}
+
+fn add_unique(target: &mut Vec<String>, value: &str) {
+    if !target.iter().any(|existing| existing == value) {
+        target.push(value.to_string());
     }
 }
 
@@ -73,6 +478,7 @@ fn contains(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn test_system_prompt_template() {
@@ -86,5 +492,120 @@ mod tests {
         let rendered = template.render(&templates).unwrap();
         assert!(rendered.contains("## Fixing Diagnostics"));
         assert!(rendered.contains("test-model"));
+    }
+
+    #[test]
+    fn test_section_override_removes_example_block() {
+        let mut section_config = TemplateSectionConfig::default();
+        section_config.insert_remove("edit_file_prompt_xml_example");
+        let templates = Templates::new_with_section_config(Some(section_config));
+        let rendered = templates
+            .0
+            .render(
+                "edit_file_prompt_xml.hbs",
+                &json!({
+                    "path": "/tmp/example.rs",
+                    "edit_description": "test",
+                }),
+            )
+            .unwrap();
+        assert!(!rendered.contains("struct User"));
+    }
+
+    #[test]
+    fn test_section_unquoted_name_trims_trailing_newline() {
+        let templates = Templates::new_with_section_config(None);
+        let rendered = templates
+            .0
+            .render_template("{{#section root}}\nhello\n{{/section}}\nworld", &json!({}))
+            .unwrap();
+        assert_eq!(rendered, "hello\nworld");
+    }
+
+    #[test]
+    fn test_section_graph_parses_roots_and_children() {
+        let graph = parse_section_graph_from_text(
+            "{{#section root}}\n{{#section child}}\ntext\n{{/section}}\n{{/section}}\n",
+        )
+        .unwrap();
+        let root = graph.sections.get("root").unwrap();
+        assert!(graph.roots.contains(&"root".to_string()));
+        assert_eq!(root.children, vec!["child".to_string()]);
+        assert!(root.arguments.contains(&"root".to_string()));
+        assert!(root.arguments.contains(&"this".to_string()));
+        let child = graph.sections.get("child").unwrap();
+        assert_eq!(child.parents, vec!["root".to_string()]);
+    }
+
+    #[test]
+    fn test_section_graph_ignores_comments() {
+        let graph = parse_section_graph_from_text(
+            "{{!-- {{#section ignored}} --}}\n{{#section root}}\ntext\n{{/section}}\n",
+        )
+        .unwrap();
+        assert!(graph.sections.contains_key("root"));
+        assert!(!graph.sections.contains_key("ignored"));
+    }
+
+    #[test]
+    fn test_section_graph_errors_on_unclosed_sections() {
+        let err = parse_section_graph_from_text("{{#section root}}\ntext\n").unwrap_err();
+        assert!(err.to_string().contains("section: unclosed tag"));
+    }
+
+    #[test]
+    fn test_section_replace_uses_context() {
+        let mut section_config = TemplateSectionConfig::default();
+        section_config.insert_replace("root", "Hello {{name}}");
+        let templates = Templates::new_with_section_config(Some(section_config));
+        let rendered = templates
+            .0
+            .render_template(
+                "{{#section root}}ignored{{/section}}",
+                &json!({"name": "Sandro"}),
+            )
+            .unwrap();
+        assert_eq!(rendered, "Hello Sandro");
+    }
+
+    #[test]
+    fn test_section_replace_uses_each_context() {
+        let mut section_config = TemplateSectionConfig::default();
+        section_config.insert_replace("root", "{{name}}\n");
+        let templates = Templates::new_with_section_config(Some(section_config));
+        let rendered = templates
+            .0
+            .render_template(
+                "{{#each assertions}}{{#section root}}ignored{{/section}}{{/each}}",
+                &json!({"assertions": [{"name": "A"}, {"name": "B"}]}),
+            )
+            .unwrap();
+        assert_eq!(rendered, "A\nB\n");
+    }
+
+    #[test]
+    fn test_section_graph_shares_arguments() {
+        let graph = parse_section_graph_from_text(
+            "{{#section root}}\n{{#section first}}x{{/section}}{{#section second}}y{{/section}}{{/section}}",
+        )
+        .unwrap();
+        let first = graph.sections.get("first").unwrap();
+        let second = graph.sections.get("second").unwrap();
+        assert!(Arc::ptr_eq(&first.arguments, &second.arguments));
+    }
+
+    #[test]
+    fn test_section_replace_exposes_root_context() {
+        let mut section_config = TemplateSectionConfig::default();
+        section_config.insert_replace("root", "{{root.title}}:{{name}}\n");
+        let templates = Templates::new_with_section_config(Some(section_config));
+        let rendered = templates
+            .0
+            .render_template(
+                "{{#each assertions}}{{#section root}}ignored{{/section}}{{/each}}",
+                &json!({"title": "Checklist", "assertions": [{"name": "A"}, {"name": "B"}]}),
+            )
+            .unwrap();
+        assert_eq!(rendered, "Checklist:A\nChecklist:B\n");
     }
 }

--- a/crates/agent/src/templates/create_file_prompt.hbs
+++ b/crates/agent/src/templates/create_file_prompt.hbs
@@ -1,4 +1,4 @@
-{{#section root}}
+{{#section create_file_prompt}}
 {{#section create_file_prompt_instructions}}
 You are an expert engineer and your task is to write a new file from scratch.
 

--- a/crates/agent/src/templates/create_file_prompt.hbs
+++ b/crates/agent/src/templates/create_file_prompt.hbs
@@ -1,3 +1,5 @@
+{{#section root}}
+{{#section create_file_prompt_instructions}}
 You are an expert engineer and your task is to write a new file from scratch.
 
 You MUST respond with the file's content wrapped in triple backticks (```).
@@ -5,11 +7,17 @@ The backticks should be on their own line.
 The text you output will be saved verbatim as the content of the file.
 Tool calls have been disabled.
 Start your response with ```.
+{{/section}}
 
+{{#section create_file_prompt_file_path}}
 <file_path>
 {{path}}
 </file_path>
+{{/section}}
 
+{{#section create_file_prompt_edit_description}}
 <edit_description>
 {{edit_description}}
 </edit_description>
+{{/section}}
+{{/section}}

--- a/crates/agent/src/templates/diff_judge.hbs
+++ b/crates/agent/src/templates/diff_judge.hbs
@@ -1,19 +1,31 @@
+{{#section root}}
+{{#section diff_judge_intro}}
 You are an expert coder, and have been tasked with looking at the following diff:
+{{/section}}
 
+{{#section diff_judge_diff}}
 <diff>
 {{diff}}
 </diff>
+{{/section}}
 
+{{#section diff_judge_assertions_intro}}
 Evaluate the following assertions:
+{{/section}}
 
+{{#section diff_judge_assertions}}
 <assertions>
 {{assertions}}
 </assertions>
+{{/section}}
 
+{{#section diff_judge_scoring_instructions}}
 You must respond with a short analysis and a score between 0 and 100, where:
 - 0 means no assertions pass
 - 100 means all the assertions pass perfectly
+{{/section}}
 
+{{#section diff_judge_response_format}}
 <analysis>
 - Assertion 1: one line describing why the first assertion passes or fails (even partially)
 - Assertion 2: one line describing why the second assertion passes or fails (even partially)
@@ -21,3 +33,5 @@ You must respond with a short analysis and a score between 0 and 100, where:
 - Assertion N: one line describing why the Nth assertion passes or fails (even partially)
 </analysis>
 <score>YOUR FINAL SCORE HERE</score>
+{{/section}}
+{{/section}}

--- a/crates/agent/src/templates/diff_judge.hbs
+++ b/crates/agent/src/templates/diff_judge.hbs
@@ -1,4 +1,4 @@
-{{#section root}}
+{{#section diff_judge}}
 {{#section diff_judge_intro}}
 You are an expert coder, and have been tasked with looking at the following diff:
 {{/section}}

--- a/crates/agent/src/templates/edit_file_prompt_diff_fenced.hbs
+++ b/crates/agent/src/templates/edit_file_prompt_diff_fenced.hbs
@@ -1,3 +1,5 @@
+{{#section root}}
+{{#section edit_file_prompt_diff_fenced_format}}
 You MUST respond with a series of edits to a file, using the following diff format:
 
 ```
@@ -17,7 +19,9 @@ return 0
 >>>>>>> REPLACE
 
 ```
+{{/section}}
 
+{{#section edit_file_prompt_diff_fenced_instructions}}
 # File Editing Instructions
 
 - Use the SEARCH/REPLACE diff format shown above
@@ -32,7 +36,9 @@ return 0
 - For multiple occurrences, repeat the same diff block for each instance
 - Edits are sequential - each assumes previous edits are already applied
 - Only edit the specified file
+{{/section}}
 
+{{#section edit_file_prompt_diff_fenced_example}}
 # Example
 
 ```
@@ -62,16 +68,23 @@ struct User {
     };
 >>>>>>> REPLACE
 ```
+{{/section}}
 
-
+{{#section edit_file_prompt_diff_fenced_final_instructions}}
 # Final instructions
 
 Tool calls have been disabled. You MUST respond using the SEARCH/REPLACE diff format only.
+{{/section}}
 
+{{#section edit_file_prompt_diff_fenced_file_to_edit}}
 <file_to_edit>
 {{path}}
 </file_to_edit>
+{{/section}}
 
+{{#section edit_file_prompt_diff_fenced_edit_description}}
 <edit_description>
 {{edit_description}}
 </edit_description>
+{{/section}}
+{{/section}}

--- a/crates/agent/src/templates/edit_file_prompt_diff_fenced.hbs
+++ b/crates/agent/src/templates/edit_file_prompt_diff_fenced.hbs
@@ -1,4 +1,4 @@
-{{#section root}}
+{{#section edit_file_prompt_diff_fenced}}
 {{#section edit_file_prompt_diff_fenced_format}}
 You MUST respond with a series of edits to a file, using the following diff format:
 

--- a/crates/agent/src/templates/edit_file_prompt_xml.hbs
+++ b/crates/agent/src/templates/edit_file_prompt_xml.hbs
@@ -1,4 +1,4 @@
-{{#section root}}
+{{#section edit_file_prompt_xml}}
 {{#section edit_file_prompt_xml_format}}
 You MUST respond with a series of edits to a file, using the following format:
 

--- a/crates/agent/src/templates/edit_file_prompt_xml.hbs
+++ b/crates/agent/src/templates/edit_file_prompt_xml.hbs
@@ -1,3 +1,5 @@
+{{#section root}}
+{{#section edit_file_prompt_xml_format}}
 You MUST respond with a series of edits to a file, using the following format:
 
 ```
@@ -26,7 +28,9 @@ NEW TEXT 3 HERE
 
 </edits>
 ```
+{{/section}}
 
+{{#section edit_file_prompt_xml_instructions}}
 # File Editing Instructions
 
 - Use `<old_text>` and `<new_text>` tags to replace content
@@ -42,8 +46,9 @@ NEW TEXT 3 HERE
 - Edits are sequential - each assumes previous edits are already applied
 - Only edit the specified file
 - Always close all tags properly
+{{/section}}
 
-
+{{#section edit_file_prompt_xml_example}}
 {{!-- The following example adds almost 10% pass rate for Gemini 2.5.
 Claude and gpt-4.1 don't really need it. --}}
 <example>
@@ -79,14 +84,21 @@ struct User {
 
 </edits>
 </example>
+{{/section}}
 
-
+{{#section edit_file_prompt_xml_file_to_edit}}
 <file_to_edit>
 {{path}}
 </file_to_edit>
+{{/section}}
 
+{{#section edit_file_prompt_xml_edit_description}}
 <edit_description>
 {{edit_description}}
 </edit_description>
+{{/section}}
 
+{{#section edit_file_prompt_xml_final_instructions}}
 Tool calls have been disabled. You MUST start your response with <edits>.
+{{/section}}
+{{/section}}

--- a/crates/agent/src/templates/system_prompt.hbs
+++ b/crates/agent/src/templates/system_prompt.hbs
@@ -1,5 +1,9 @@
+{{#section root}}
+{{#section system_prompt_intro}}
 You are a highly skilled software engineer with extensive knowledge in many programming languages, frameworks, design patterns, and best practices.
+{{/section}}
 
+{{#section system_prompt_communication}}
 ## Communication
 
 1. Be conversational but professional.
@@ -7,8 +11,10 @@ You are a highly skilled software engineer with extensive knowledge in many prog
 3. Format your responses in markdown. Use backticks to format file, directory, function, and class names.
 4. NEVER lie or make things up.
 5. Refrain from apologizing all the time when results are unexpected. Instead, just try your best to proceed or explain the circumstances to the user without apologizing.
+{{/section}}
 
 {{#if (gt (len available_tools) 0)}}
+{{#section system_prompt_tool_use}}
 ## Tool Use
 
 1. Make sure to adhere to the tools schema.
@@ -18,7 +24,9 @@ You are a highly skilled software engineer with extensive knowledge in many prog
 5. DO NOT use a tool that is not available just because it appears in the conversation. This means the user turned it off.
 6. When running commands that may run indefinitely or for a long time (such as build scripts, tests, servers, or file watchers), specify `timeout_ms` to bound runtime. If the command times out, the user can always ask you to run it again with a longer timeout or no timeout if they're willing to wait or cancel manually.
 7. Avoid HTML entity escaping - use plain characters instead.
+{{/section}}
 
+{{#section system_prompt_searching}}
 ## Searching and Reading
 
 If you are unsure how to fulfill the user's request, gather more information with tool calls and/or clarifying questions.
@@ -33,18 +41,24 @@ If appropriate, use tool calls to explore the current project, which contains th
 - When providing paths to tools, the path should always start with the name of a project root directory listed above.
 - Before you read or edit a file, you must first find the full path. DO NOT ever guess a file path!
 {{#if (contains available_tools 'grep') }}
+{{#section system_prompt_searching_grep}}
 - When looking for symbols in the project, prefer the `grep` tool.
 - As you learn about the structure of the project, use that information to scope `grep` searches to targeted subtrees of the project.
 - The user might specify a partial file path. If you don't know the full path, use `find_path` (not `grep`) before you read the file.
+{{/section}}
 {{/if}}
+{{/section}}
 {{else}}
+{{#section system_prompt_no_tools}}
 You are being tasked with providing a response, but you have no ability to use tools or to read or write any aspect of the user's system (other than any context the user might have provided to you).
 
 As such, if you need the user to perform any actions for you, you must request them explicitly. Bias towards giving a response to the best of your ability, and then making requests for the user to take action (e.g. to give you more context) only optionally.
 
 The one exception to this is if the user references something you don't know about - for example, the name of a source code file, function, type, or other piece of code that you have no awareness of. In this case, you MUST NOT MAKE SOMETHING UP, or assume you know what that thing is or how it works. Instead, you must ask the user for clarification rather than giving a response.
+{{/section}}
 {{/if}}
 
+{{#section system_prompt_code_block_formatting}}
 ## Code Block Formatting
 
 Whenever you mention a code block, you MUST use ONLY use the following format:
@@ -57,6 +71,7 @@ The `#L123-456` means the line number range 123 through 456, and the path/to/Som
 Just to be really clear about this, if you ever find yourself writing three backticks followed by a language name, STOP!
 You have made a mistake. You can only ever put paths after triple backticks!
 
+{{#section system_prompt_code_block_example_summary}}
 <example>
 Based on all the information I've gathered, here's a summary of how this system works:
 1. The README file is loaded into the system.
@@ -73,7 +88,9 @@ This is the last header in the README.
 ```
 4. Finally, it passes this information on to the next process.
 </example>
+{{/section}}
 
+{{#section system_prompt_code_block_example_markdown}}
 <example>
 In Markdown, hash marks signify headings. For example:
 ```/dev/null/example.md#L1-3
@@ -82,8 +99,11 @@ In Markdown, hash marks signify headings. For example:
 ### Level 3 heading
 ```
 </example>
+{{/section}}
 
+{{#section system_prompt_code_block_bad_examples}}
 Here are examples of ways you must never render code blocks:
+{{#section system_prompt_code_block_bad_example_1}}
 <bad_example_do_not_do_this>
 In Markdown, hash marks signify headings. For example:
 ```
@@ -92,9 +112,11 @@ In Markdown, hash marks signify headings. For example:
 ### Level 3 heading
 ```
 </bad_example_do_not_do_this>
+{{/section}}
 
 This example is unacceptable because it does not include the path.
 
+{{#section system_prompt_code_block_bad_example_2}}
 <bad_example_do_not_do_this>
 In Markdown, hash marks signify headings. For example:
 ```markdown
@@ -103,16 +125,20 @@ In Markdown, hash marks signify headings. For example:
 ### Level 3 heading
 ```
 </bad_example_do_not_do_this>
+{{/section}}
 This example is unacceptable because it has the language instead of the path.
 
+{{#section system_prompt_code_block_bad_example_3}}
 <bad_example_do_not_do_this>
 In Markdown, hash marks signify headings. For example:
     # Level 1 heading
     ## Level 2 heading
     ### Level 3 heading
 </bad_example_do_not_do_this>
+{{/section}}
 This example is unacceptable because it uses indentation to mark the code block instead of backticks with a path.
 
+{{#section system_prompt_code_block_bad_example_4}}
 <bad_example_do_not_do_this>
 In Markdown, hash marks signify headings. For example:
 ```markdown
@@ -122,14 +148,20 @@ In Markdown, hash marks signify headings. For example:
 ### Level 3 heading
 ```
 </bad_example_do_not_do_this>
+{{/section}}
 This example is unacceptable because the path is in the wrong place. The path must be directly after the opening backticks.
+{{/section}}
+{{/section}}
 
 {{#if (gt (len available_tools) 0)}}
+{{#section system_prompt_fixing_diagnostics}}
 ## Fixing Diagnostics
 
 1. Make 1-2 attempts at fixing diagnostics, then defer to the user.
 2. Never simplify code you've written just to solve diagnostics. Complete, mostly correct code is more valuable than perfect code that doesn't solve the problem.
+{{/section}}
 
+{{#section system_prompt_debugging}}
 ## Debugging
 
 When debugging, only make code changes if you are certain that you can solve the problem.
@@ -137,31 +169,40 @@ Otherwise, follow debugging best practices:
 1. Address the root cause instead of the symptoms.
 2. Add descriptive logging statements and error messages to track variable and code state.
 3. Add test functions and statements to isolate the problem.
-
+{{/section}}
 {{/if}}
+
+{{#section system_prompt_external_apis}}
 ## Calling External APIs
 
 1. Unless explicitly requested by the user, use the best suited external APIs and packages to solve the task. There is no need to ask the user for permission.
 2. When selecting which version of an API or package to use, choose one that is compatible with the user's dependency management file(s). If no such file exists or if the package is not present, use the latest version that is in your training data.
 3. If an external API requires an API Key, be sure to point this out to the user. Adhere to best security practices (e.g. DO NOT hardcode an API key in a place where it can be exposed)
+{{/section}}
 
+{{#section system_prompt_system_info}}
 ## System Information
 
 Operating System: {{os}}
 Default Shell: {{shell}}
+{{/section}}
 
 {{#if model_name}}
+{{#section system_prompt_model_info}}
 ## Model Information
 
 You are powered by the model named {{model_name}}.
-
+{{/section}}
 {{/if}}
+
 {{#if (or has_rules has_user_rules)}}
+{{#section system_prompt_custom_instructions}}
 ## User's Custom Instructions
 
 The following additional instructions are provided by the user, and should be followed to the best of your ability{{#if (gt (len available_tools) 0)}} without interfering with the tool use guidelines{{/if}}.
 
 {{#if has_rules}}
+{{#section system_prompt_project_rules}}
 There are project rules that apply to these root directories:
 {{#each worktrees}}
 {{#if rules_file}}
@@ -171,9 +212,11 @@ There are project rules that apply to these root directories:
 ``````
 {{/if}}
 {{/each}}
+{{/section}}
 {{/if}}
 
 {{#if has_user_rules}}
+{{#section system_prompt_user_rules}}
 The user has specified the following rules that should be applied:
 {{#each user_rules}}
 
@@ -184,5 +227,8 @@ Rules title: {{title}}
 {{contents}}
 ``````
 {{/each}}
+{{/section}}
 {{/if}}
+{{/section}}
 {{/if}}
+{{/section}}

--- a/crates/agent/src/templates/system_prompt.hbs
+++ b/crates/agent/src/templates/system_prompt.hbs
@@ -1,4 +1,4 @@
-{{#section root}}
+{{#section system_prompt}}
 {{#section system_prompt_intro}}
 You are a highly skilled software engineer with extensive knowledge in many programming languages, frameworks, design patterns, and best practices.
 {{/section}}

--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -2746,8 +2746,6 @@ async fn test_building_request_with_pending_tools(cx: &mut TestAppContext) {
 #[gpui::test]
 async fn test_agent_connection(cx: &mut TestAppContext) {
     cx.update(settings::init);
-    let templates = Templates::new();
-
     // Initialize language model system with test provider
     cx.update(|cx| {
         gpui_tokio::init(cx);
@@ -2773,7 +2771,6 @@ async fn test_agent_connection(cx: &mut TestAppContext) {
     let agent = NativeAgent::new(
         project.clone(),
         thread_store,
-        templates.clone(),
         None,
         fake_fs.clone(),
         &mut cx.to_async(),

--- a/crates/agent_ui/src/agent_configuration/manage_profiles_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/manage_profiles_modal.rs
@@ -2,20 +2,31 @@ mod profile_modal_header;
 
 use std::sync::Arc;
 
-use agent::ContextServerRegistry;
-use agent_settings::{AgentProfile, AgentProfileId, AgentSettings, builtin_profiles};
-use editor::Editor;
+use agent::{ContextServerRegistry, SectionGraph, TemplateSectionGraph, Templates};
+use agent_settings::{
+    AgentProfile, AgentProfileId, AgentSettings, PromptSectionOverride, builtin_profiles,
+};
+use collections::{BTreeSet, HashMap};
+use editor::{Editor, EditorMode};
 use fs::Fs;
 use gpui::{DismissEvent, Entity, EventEmitter, FocusHandle, Focusable, Subscription, prelude::*};
+use language::Buffer;
 use language_model::{LanguageModel, LanguageModelRegistry};
+use multi_buffer::MultiBuffer;
 use settings::SettingsStore;
 use settings::{
-    LanguageModelProviderSetting, LanguageModelSelection, Settings as _, update_settings_file,
+    AgentProfileContent, ContextServerPresetContent, LanguageModelProviderSetting,
+    LanguageModelSelection, PromptSectionOverrideContent, Settings as _, SoftWrap,
+    update_settings_file,
 };
+use ui::Tooltip;
 use ui::{
-    KeyBinding, ListItem, ListItemSpacing, ListSeparator, Navigable, NavigableEntry, prelude::*,
+    IconButton, IconButtonShape, KeyBinding, ListItem, ListItemSpacing, ListSeparator, Navigable,
+    NavigableEntry, prelude::*,
 };
+use util::ResultExt as _;
 use workspace::{ModalView, Workspace};
+use zed_actions::editor::{MoveDown, MoveUp};
 
 use crate::agent_configuration::manage_profiles_modal::profile_modal_header::ProfileModalHeader;
 use crate::agent_configuration::tool_picker::{ToolPicker, ToolPickerDelegate};
@@ -40,6 +51,11 @@ enum Mode {
         profile_id: AgentProfileId,
         model_picker: Entity<LanguageModelSelector>,
         _subscription: Subscription,
+    },
+    EditSectionOverride(EditSectionOverrideMode),
+    ConfigurePrompts {
+        profile_id: AgentProfileId,
+        create_section_override: NavigableEntry,
     },
 }
 
@@ -95,6 +111,7 @@ pub struct ViewProfileMode {
     configure_default_model: NavigableEntry,
     configure_tools: NavigableEntry,
     configure_mcps: NavigableEntry,
+    configure_prompts: NavigableEntry,
     delete_profile: NavigableEntry,
     cancel_item: NavigableEntry,
 }
@@ -105,12 +122,25 @@ pub struct NewProfileMode {
     base_profile_id: Option<AgentProfileId>,
 }
 
+pub struct EditSectionOverrideMode {
+    profile_id: AgentProfileId,
+    original_section: Option<Arc<str>>,
+    section_editor: Entity<Editor>,
+    replacement_editor: Entity<Editor>,
+    save_override: NavigableEntry,
+    cancel_item: NavigableEntry,
+    suggestion_index: Option<usize>,
+    last_section_name: String,
+}
+
 pub struct ManageProfilesModal {
     fs: Arc<dyn Fs>,
     context_server_registry: Entity<ContextServerRegistry>,
     active_model: Option<Arc<dyn LanguageModel>>,
     focus_handle: FocusHandle,
     mode: Mode,
+    section_graph: Option<SectionGraph>,
+    section_defaults: Option<HashMap<String, String>>,
     _settings_subscription: Subscription,
 }
 
@@ -150,6 +180,10 @@ impl ManageProfilesModal {
         cx: &mut Context<Self>,
     ) -> Self {
         let focus_handle = cx.focus_handle();
+        let section_graph = Templates::section_graph().log_err();
+        let section_defaults = Templates::section_defaults()
+            .log_err()
+            .map(|defaults| defaults.into_iter().collect());
 
         // Keep this modal in sync with settings changes (including profile deletion).
         let settings_subscription =
@@ -157,8 +191,8 @@ impl ManageProfilesModal {
                 if matches!(this.mode, Mode::ChooseProfile(_)) {
                     this.mode = Mode::choose_profile(window, cx);
                     this.focus_handle(cx).focus(window, cx);
-                    cx.notify();
                 }
+                cx.notify();
             });
 
         Self {
@@ -167,6 +201,8 @@ impl ManageProfilesModal {
             context_server_registry,
             focus_handle,
             mode: Mode::choose_profile(window, cx),
+            section_graph,
+            section_defaults,
             _settings_subscription: settings_subscription,
         }
     }
@@ -206,6 +242,7 @@ impl ManageProfilesModal {
             configure_default_model: NavigableEntry::focusable(cx),
             configure_tools: NavigableEntry::focusable(cx),
             configure_mcps: NavigableEntry::focusable(cx),
+            configure_prompts: NavigableEntry::focusable(cx),
             delete_profile: NavigableEntry::focusable(cx),
             cancel_item: NavigableEntry::focusable(cx),
         });
@@ -339,6 +376,91 @@ impl ManageProfilesModal {
         self.focus_handle(cx).focus(window, cx);
     }
 
+    fn configure_prompts(
+        &mut self,
+        profile_id: AgentProfileId,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.mode = Mode::ConfigurePrompts {
+            profile_id,
+            create_section_override: NavigableEntry::focusable(cx),
+        };
+        self.focus_handle(cx).focus(window, cx);
+    }
+
+    fn create_section_override(
+        &mut self,
+        profile_id: AgentProfileId,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.edit_section_override(profile_id, None, window, cx);
+    }
+
+    fn edit_section_override(
+        &mut self,
+        profile_id: AgentProfileId,
+        override_entry: Option<PromptSectionOverride>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let section_editor = cx.new(|cx| Editor::single_line(window, cx));
+        section_editor.update(cx, |editor, cx| {
+            editor.set_placeholder_text("Section name (e.g. system_prompt_intro)", window, cx);
+        });
+
+        let replacement_editor = cx.new(|cx| {
+            let buffer = cx.new(|cx| Buffer::local("", cx));
+            let buffer = cx.new(|cx| MultiBuffer::singleton(buffer, cx));
+            let mut editor = Editor::new(
+                EditorMode::AutoHeight {
+                    min_lines: 6,
+                    max_lines: Some(16),
+                },
+                buffer,
+                None,
+                window,
+                cx,
+            );
+            editor.set_soft_wrap_mode(SoftWrap::EditorWidth, cx);
+            editor.set_placeholder_text("Replacement template", window, cx);
+            editor
+        });
+
+        let original_section = override_entry
+            .as_ref()
+            .map(|override_entry| override_entry.section.clone());
+        let mut last_section_name = override_entry
+            .as_ref()
+            .map(|override_entry| override_entry.section.to_string())
+            .unwrap_or_default();
+        if let Some(override_entry) = override_entry {
+            section_editor.update(cx, |editor, cx| {
+                editor.set_text(override_entry.section.as_ref(), window, cx);
+            });
+            replacement_editor.update(cx, |editor, cx| {
+                editor.set_text(override_entry.replacement.as_ref(), window, cx);
+            });
+        }
+
+        if last_section_name.is_empty() {
+            last_section_name = section_editor.read(cx).text(cx).trim().to_string();
+        }
+
+        self.mode = Mode::EditSectionOverride(EditSectionOverrideMode {
+            profile_id,
+            original_section,
+            section_editor,
+            replacement_editor,
+            save_override: NavigableEntry::focusable(cx),
+            cancel_item: NavigableEntry::focusable(cx),
+            suggestion_index: None,
+            last_section_name,
+        });
+        self.focus_handle(cx).focus(window, cx);
+    }
+
     fn configure_builtin_tools(
         &mut self,
         profile_id: AgentProfileId,
@@ -398,6 +520,8 @@ impl ManageProfilesModal {
             Mode::ConfigureTools { .. } => {}
             Mode::ConfigureMcps { .. } => {}
             Mode::ConfigureDefaultModel { .. } => {}
+            Mode::EditSectionOverride(_) => {}
+            Mode::ConfigurePrompts { .. } => {}
         }
     }
 
@@ -459,7 +583,134 @@ impl ManageProfilesModal {
             Mode::ConfigureDefaultModel { profile_id, .. } => {
                 self.view_profile(profile_id.clone(), window, cx)
             }
+            Mode::EditSectionOverride(mode) => {
+                self.configure_prompts(mode.profile_id.clone(), window, cx)
+            }
+            Mode::ConfigurePrompts { profile_id, .. } => {
+                self.view_profile(profile_id.clone(), window, cx)
+            }
         }
+    }
+
+    fn save_section_override(
+        &mut self,
+        profile_id: AgentProfileId,
+        original_section: Option<Arc<str>>,
+        section: String,
+        replacement: String,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let section = section.trim().to_string();
+        if section.is_empty() {
+            self.configure_prompts(profile_id, window, cx);
+            return;
+        }
+        if let Some(section_graph) = &self.section_graph
+            && !section_exists(section_graph, &section)
+        {
+            return;
+        }
+
+        let default_profile = AgentSettings::get_global(cx)
+            .profiles
+            .get(&profile_id)
+            .cloned();
+        let Some(default_profile) = default_profile else {
+            self.configure_prompts(profile_id, window, cx);
+            return;
+        };
+
+        let fs = self.fs.clone();
+        update_settings_file(fs, cx, {
+            let profile_id = profile_id.clone();
+            let section = section.clone();
+            let replacement = replacement;
+            let default_profile = default_profile.clone();
+            move |settings, _cx| {
+                let agent_settings = settings.agent.get_or_insert_default();
+                let profiles = agent_settings.profiles.get_or_insert_default();
+                let profile = profiles
+                    .entry(profile_id.0)
+                    .or_insert_with(|| AgentProfileContent {
+                        name: default_profile.name.into(),
+                        tools: default_profile.tools,
+                        enable_all_context_servers: Some(
+                            default_profile.enable_all_context_servers,
+                        ),
+                        context_servers: default_profile
+                            .context_servers
+                            .into_iter()
+                            .map(|(server_id, preset)| {
+                                (
+                                    server_id,
+                                    ContextServerPresetContent {
+                                        tools: preset.tools,
+                                    },
+                                )
+                            })
+                            .collect(),
+                        default_model: default_profile.default_model.clone(),
+                        prompt_section_overrides: default_profile
+                            .prompt_section_overrides
+                            .iter()
+                            .cloned()
+                            .map(PromptSectionOverrideContent::from)
+                            .collect(),
+                        system_prompt_provider: default_profile.system_prompt_provider.clone(),
+                    });
+
+                if let Some(original_section) = original_section.as_deref()
+                    && original_section != section
+                {
+                    profile.prompt_section_overrides.retain(|override_entry| {
+                        override_entry.section.as_ref() != original_section
+                    });
+                }
+
+                let overrides = &mut profile.prompt_section_overrides;
+                if let Some(existing) = overrides
+                    .iter_mut()
+                    .find(|override_entry| override_entry.section.as_ref() == section)
+                {
+                    existing.replacement = replacement.clone().into();
+                } else {
+                    overrides.push(PromptSectionOverrideContent {
+                        section: section.clone().into(),
+                        replacement: replacement.clone().into(),
+                    });
+                }
+            }
+        });
+
+        self.configure_prompts(profile_id, window, cx);
+    }
+
+    fn delete_section_override(
+        &mut self,
+        profile_id: AgentProfileId,
+        section: Arc<str>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let fs = self.fs.clone();
+        update_settings_file(fs, cx, {
+            let profile_id = profile_id.clone();
+            let section = section.clone();
+            move |settings, _cx| {
+                let agent_settings = settings.agent.get_or_insert_default();
+                let profiles = agent_settings.profiles.get_or_insert_default();
+                let Some(profile) = profiles.get_mut(profile_id.0.as_ref()) else {
+                    return;
+                };
+
+                profile
+                    .prompt_section_overrides
+                    .retain(|override_entry| override_entry.section.as_ref() != section.as_ref());
+            }
+        });
+
+        self.configure_prompts(profile_id, window, cx);
     }
 }
 
@@ -474,6 +725,8 @@ impl Focusable for ManageProfilesModal {
             Mode::ConfigureTools { tool_picker, .. } => tool_picker.focus_handle(cx),
             Mode::ConfigureMcps { tool_picker, .. } => tool_picker.focus_handle(cx),
             Mode::ConfigureDefaultModel { model_picker, .. } => model_picker.focus_handle(cx),
+            Mode::EditSectionOverride(mode) => mode.section_editor.focus_handle(cx),
+            Mode::ConfigurePrompts { .. } => self.focus_handle.clone(),
         }
     }
 }
@@ -826,6 +1079,43 @@ impl ManageProfilesModal {
                         )
                         .child(
                             div()
+                                .id("configure-prompts")
+                                .track_focus(&mode.configure_prompts.focus_handle)
+                                .on_action({
+                                    let profile_id = mode.profile_id.clone();
+                                    cx.listener(move |this, _: &menu::Confirm, window, cx| {
+                                        this.configure_prompts(profile_id.clone(), window, cx);
+                                    })
+                                })
+                                .child(
+                                    ListItem::new("configure-prompts")
+                                        .toggle_state(
+                                            mode.configure_prompts
+                                                .focus_handle
+                                                .contains_focused(window, cx),
+                                        )
+                                        .inset(true)
+                                        .spacing(ListItemSpacing::Sparse)
+                                        .start_slot(
+                                            Icon::new(IconName::TextSnippet)
+                                                .size(IconSize::Small)
+                                                .color(Color::Muted),
+                                        )
+                                        .child(Label::new("Configure Prompts"))
+                                        .on_click({
+                                            let profile_id = mode.profile_id.clone();
+                                            cx.listener(move |this, _, window, cx| {
+                                                this.configure_prompts(
+                                                    profile_id.clone(),
+                                                    window,
+                                                    cx,
+                                                );
+                                            })
+                                        }),
+                                ),
+                        )
+                        .child(
+                            div()
                                 .id("delete-profile")
                                 .track_focus(&mode.delete_profile.focus_handle)
                                 .on_action({
@@ -907,6 +1197,7 @@ impl ManageProfilesModal {
         .entry(mode.configure_default_model)
         .entry(mode.configure_tools)
         .entry(mode.configure_mcps)
+        .entry(mode.configure_prompts)
         .entry(mode.delete_profile)
         .entry(mode.cancel_item)
     }
@@ -914,6 +1205,25 @@ impl ManageProfilesModal {
 
 impl Render for ManageProfilesModal {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        if let Mode::EditSectionOverride(mode) = &mut self.mode {
+            let section_query = mode.section_editor.read(cx).text(cx);
+            let section_query = section_query.trim();
+            if mode.last_section_name != section_query {
+                mode.last_section_name = section_query.to_string();
+                mode.suggestion_index = None;
+                if !section_query.is_empty() {
+                    let replacement = self
+                        .section_defaults
+                        .as_ref()
+                        .and_then(|defaults| defaults.get(section_query))
+                        .cloned()
+                        .unwrap_or_default();
+                    mode.replacement_editor.update(cx, |editor, cx| {
+                        editor.set_text(replacement, window, cx);
+                    });
+                }
+            }
+        }
         let settings = AgentSettings::get_global(cx);
 
         let go_back_item = div()
@@ -952,7 +1262,112 @@ impl Render for ManageProfilesModal {
             .elevation_3(cx)
             .w(rems(34.))
             .key_context("ManageProfilesModal")
+            .on_action(cx.listener(|this, _: &MoveDown, window, cx| {
+                let Mode::EditSectionOverride(mode) = &mut this.mode else {
+                    return;
+                };
+                if !mode
+                    .section_editor
+                    .focus_handle(cx)
+                    .contains_focused(window, cx)
+                {
+                    return;
+                }
+                let section_query = mode.section_editor.read(cx).text(cx);
+                let section_query = section_query.trim();
+                let section_graph = this.section_graph.as_ref();
+                let is_section_valid = section_graph
+                    .map(|graph| section_exists(graph, section_query))
+                    .unwrap_or(true);
+                let suggestions = section_graph
+                    .map(|graph| section_suggestions(graph, section_query))
+                    .unwrap_or_default();
+                if is_section_valid || suggestions.is_empty() {
+                    return;
+                }
+                let next_index = match mode.suggestion_index {
+                    Some(ix) => (ix + 1).min(suggestions.len() - 1),
+                    None => 0,
+                };
+                mode.suggestion_index = Some(next_index);
+                cx.notify();
+            }))
+            .on_action(cx.listener(|this, _: &MoveUp, window, cx| {
+                let Mode::EditSectionOverride(mode) = &mut this.mode else {
+                    return;
+                };
+                if !mode
+                    .section_editor
+                    .focus_handle(cx)
+                    .contains_focused(window, cx)
+                {
+                    return;
+                }
+                let section_query = mode.section_editor.read(cx).text(cx);
+                let section_query = section_query.trim();
+                let section_graph = this.section_graph.as_ref();
+                let is_section_valid = section_graph
+                    .map(|graph| section_exists(graph, section_query))
+                    .unwrap_or(true);
+                let suggestions = section_graph
+                    .map(|graph| section_suggestions(graph, section_query))
+                    .unwrap_or_default();
+                if is_section_valid || suggestions.is_empty() {
+                    return;
+                }
+                let next_index = match mode.suggestion_index {
+                    Some(ix) => ix.saturating_sub(1),
+                    None => suggestions.len() - 1,
+                };
+                mode.suggestion_index = Some(next_index);
+                cx.notify();
+            }))
             .on_action(cx.listener(|this, _: &menu::Cancel, window, cx| this.cancel(window, cx)))
+            .on_action(cx.listener(|this, _: &menu::Confirm, window, cx| {
+                let Mode::EditSectionOverride(mode) = &mut this.mode else {
+                    return;
+                };
+                if !mode
+                    .section_editor
+                    .focus_handle(cx)
+                    .contains_focused(window, cx)
+                {
+                    return;
+                }
+                let section_query = mode.section_editor.read(cx).text(cx);
+                let section_query = section_query.trim();
+                let section_graph = this.section_graph.as_ref();
+                let is_section_valid = section_graph
+                    .map(|graph| section_exists(graph, section_query))
+                    .unwrap_or(true);
+                let suggestions = section_graph
+                    .map(|graph| section_suggestions(graph, section_query))
+                    .unwrap_or_default();
+                if is_section_valid || suggestions.is_empty() {
+                    return;
+                }
+                let Some(index) = mode.suggestion_index else {
+                    return;
+                };
+                let Some(section_name) = suggestions.get(index).cloned() else {
+                    return;
+                };
+                mode.suggestion_index = None;
+                mode.last_section_name = section_name.clone();
+                mode.section_editor.update(cx, |editor, cx| {
+                    editor.set_text(section_name.as_str(), window, cx);
+                });
+                let default_replacement = this
+                    .section_defaults
+                    .as_ref()
+                    .and_then(|defaults| defaults.get(&section_name))
+                    .cloned()
+                    .unwrap_or_default();
+                mode.replacement_editor.update(cx, |editor, cx| {
+                    editor.set_text(default_replacement, window, cx);
+                });
+                cx.stop_propagation();
+            }))
             .on_action(cx.listener(|this, _: &menu::Confirm, window, cx| this.confirm(window, cx)))
             .capture_any_mouse_down(cx.listener(|this, _, window, cx| {
                 this.focus_handle(cx).focus(window, cx);
@@ -1037,6 +1452,692 @@ impl Render for ManageProfilesModal {
                         .child(go_back_item)
                         .into_any_element()
                 }
+                Mode::EditSectionOverride(mode) => {
+                    let profile_name = settings
+                        .profiles
+                        .get(&mode.profile_id)
+                        .map(|profile| profile.name.clone())
+                        .unwrap_or_else(|| "Unknown".into());
+                    let original_section = mode.original_section.clone();
+                    let profile_id = mode.profile_id.clone();
+                    let section_editor = mode.section_editor.clone();
+                    let replacement_editor = mode.replacement_editor.clone();
+                    let section_query = section_editor.read(cx).text(cx);
+                    let section_query = section_query.trim();
+                    let section_graph = self.section_graph.as_ref();
+                    let is_section_valid = section_graph
+                        .map(|graph| section_exists(graph, section_query))
+                        .unwrap_or(true);
+                    let section_suggestions = section_graph
+                        .map(|graph| section_suggestions(graph, section_query))
+                        .unwrap_or_default();
+                    let show_suggestions = !section_query.is_empty() && !is_section_valid;
+                    let default_replacement = self
+                        .section_defaults
+                        .as_ref()
+                        .and_then(|defaults| defaults.get(section_query))
+                        .cloned();
+                    let save_item = div()
+                        .id("save-section-override")
+                        .track_focus(&mode.save_override.focus_handle)
+                        .on_action({
+                            let profile_id = profile_id.clone();
+                            let section_editor = section_editor.clone();
+                            let replacement_editor = replacement_editor.clone();
+                            let original_section = original_section.clone();
+                            cx.listener(move |this, _: &menu::Confirm, window, cx| {
+                                let section = section_editor.read(cx).text(cx);
+                                let replacement = replacement_editor.read(cx).text(cx);
+                                this.save_section_override(
+                                    profile_id.clone(),
+                                    original_section.clone(),
+                                    section,
+                                    replacement,
+                                    window,
+                                    cx,
+                                );
+                            })
+                        })
+                        .child(
+                            ListItem::new("save-section-override")
+                                .toggle_state(
+                                    mode.save_override.focus_handle.contains_focused(window, cx),
+                                )
+                                .inset(true)
+                                .spacing(ListItemSpacing::Sparse)
+                                .start_slot(
+                                    Icon::new(IconName::Check)
+                                        .size(IconSize::Small)
+                                        .color(Color::Muted),
+                                )
+                                .child(Label::new("Save Section Override"))
+                                .disabled(!is_section_valid && !section_query.is_empty())
+                                .on_click({
+                                    let profile_id = profile_id.clone();
+                                    let section_editor = section_editor.clone();
+                                    let replacement_editor = replacement_editor.clone();
+                                    let original_section = original_section.clone();
+                                    cx.listener(move |this, _, window, cx| {
+                                        let section = section_editor.read(cx).text(cx);
+                                        let replacement = replacement_editor.read(cx).text(cx);
+                                        this.save_section_override(
+                                            profile_id.clone(),
+                                            original_section.clone(),
+                                            section,
+                                            replacement,
+                                            window,
+                                            cx,
+                                        );
+                                    })
+                                }),
+                        );
+                    let cancel_item = div()
+                        .id("cancel-item")
+                        .track_focus(&mode.cancel_item.focus_handle)
+                        .on_action({
+                            let profile_id = mode.profile_id.clone();
+                            cx.listener(move |this, _: &menu::Confirm, window, cx| {
+                                this.configure_prompts(profile_id.clone(), window, cx);
+                            })
+                        })
+                        .child(
+                            ListItem::new("cancel-item")
+                                .toggle_state(
+                                    mode.cancel_item.focus_handle.contains_focused(window, cx),
+                                )
+                                .inset(true)
+                                .spacing(ListItemSpacing::Sparse)
+                                .start_slot(
+                                    Icon::new(IconName::ArrowLeft)
+                                        .size(IconSize::Small)
+                                        .color(Color::Muted),
+                                )
+                                .child(Label::new("Go Back"))
+                                .on_click({
+                                    let profile_id = mode.profile_id.clone();
+                                    cx.listener(move |this, _, window, cx| {
+                                        this.configure_prompts(profile_id.clone(), window, cx);
+                                    })
+                                }),
+                        );
+                    let reset_item = div()
+                        .id("reset-section-override")
+                        .track_focus(&self.focus_handle)
+                        .on_action({
+                            let default_replacement = default_replacement.clone();
+                            let replacement_editor = replacement_editor.clone();
+                            cx.listener(move |_, _: &menu::Confirm, window, cx| {
+                                let Some(default_replacement) = default_replacement.clone() else {
+                                    return;
+                                };
+                                replacement_editor.update(cx, |editor, cx| {
+                                    editor.set_text(default_replacement, window, cx);
+                                });
+                            })
+                        })
+                        .child(
+                            ListItem::new("reset-section-override")
+                                .toggle_state(self.focus_handle.contains_focused(window, cx))
+                                .inset(true)
+                                .spacing(ListItemSpacing::Sparse)
+                                .start_slot(
+                                    Icon::new(IconName::Undo)
+                                        .size(IconSize::Small)
+                                        .color(Color::Muted),
+                                )
+                                .child(Label::new("Reset to Default"))
+                                .disabled(default_replacement.is_none())
+                                .on_click({
+                                    let default_replacement = default_replacement.clone();
+                                    let replacement_editor = replacement_editor.clone();
+                                    cx.listener(move |_, _, window, cx| {
+                                        let Some(default_replacement) = default_replacement.clone()
+                                        else {
+                                            return;
+                                        };
+                                        replacement_editor.update(cx, |editor, cx| {
+                                            editor.set_text(default_replacement, window, cx);
+                                        });
+                                    })
+                                }),
+                        );
+
+                    let title = if mode.original_section.is_some() {
+                        "Edit Section Override"
+                    } else {
+                        "New Section Override"
+                    };
+
+                    v_flex()
+                        .pb_1()
+                        .child(ProfileModalHeader::new(
+                            format!("{profile_name} — {title}"),
+                            Some(IconName::TextSnippet),
+                        ))
+                        .child(ListSeparator)
+                        .child(
+                            v_flex()
+                                .gap_2()
+                                .px_2()
+                                .pt_2()
+                                .child(
+                                    Label::new("Section Name")
+                                        .size(LabelSize::Small)
+                                        .color(Color::Muted),
+                                )
+                                .child(mode.section_editor.clone())
+                                .when(!is_section_valid && !section_query.is_empty(), |this| {
+                                    this.child(
+                                        Label::new("Section not found in the template graph.")
+                                            .size(LabelSize::Small)
+                                            .color(Color::Error),
+                                    )
+                                })
+                                .when(
+                                    show_suggestions && !section_suggestions.is_empty(),
+                                    |this| {
+                                        let section_editor = section_editor.clone();
+                                        let replacement_editor = replacement_editor.clone();
+                                        let section_defaults = self.section_defaults.clone();
+                                        let selected_index = mode.suggestion_index;
+                                        this.child(v_flex().gap_0p5().children(
+                                            section_suggestions.into_iter().enumerate().map(
+                                                move |(index, section_name)| {
+                                                    let section_editor = section_editor.clone();
+                                                    let replacement_editor =
+                                                        replacement_editor.clone();
+                                                    let section_defaults = section_defaults.clone();
+                                                    ListItem::new(format!(
+                                                        "section-suggestion-{}",
+                                                        section_name
+                                                    ))
+                                                    .toggle_state(selected_index == Some(index))
+                                                    .inset(true)
+                                                    .spacing(ListItemSpacing::Sparse)
+                                                    .child(Label::new(section_name.clone()))
+                                                    .on_click({
+                                                        let section_name = section_name.clone();
+                                                        cx.listener(move |this, _, window, cx| {
+                                                            let Mode::EditSectionOverride(mode) =
+                                                                &mut this.mode
+                                                            else {
+                                                                return;
+                                                            };
+                                                            mode.suggestion_index = None;
+                                                            mode.last_section_name =
+                                                                section_name.clone();
+                                                            section_editor.update(
+                                                                cx,
+                                                                |editor, cx| {
+                                                                    editor.set_text(
+                                                                        section_name.as_str(),
+                                                                        window,
+                                                                        cx,
+                                                                    );
+                                                                },
+                                                            );
+                                                            let default_replacement =
+                                                                section_defaults
+                                                                    .as_ref()
+                                                                    .and_then(|defaults| {
+                                                                        defaults.get(&section_name)
+                                                                    })
+                                                                    .cloned()
+                                                                    .unwrap_or_default();
+                                                            replacement_editor.update(
+                                                                cx,
+                                                                |editor, cx| {
+                                                                    editor.set_text(
+                                                                        default_replacement,
+                                                                        window,
+                                                                        cx,
+                                                                    );
+                                                                },
+                                                            );
+                                                        })
+                                                    })
+                                                    .into_any_element()
+                                                },
+                                            ),
+                                        ))
+                                    },
+                                )
+                                .child(
+                                    Label::new("Replacement Template")
+                                        .size(LabelSize::Small)
+                                        .color(Color::Muted),
+                                )
+                                .child(mode.replacement_editor.clone()),
+                        )
+                        .child(ListSeparator)
+                        .child(reset_item)
+                        .child(save_item)
+                        .child(cancel_item)
+                        .into_any_element()
+                }
+                Mode::ConfigurePrompts {
+                    profile_id,
+                    create_section_override,
+                } => {
+                    let profile_name = settings
+                        .profiles
+                        .get(profile_id)
+                        .map(|profile| profile.name.clone())
+                        .unwrap_or_else(|| "Unknown".into());
+                    let section_overrides = settings
+                        .profiles
+                        .get(profile_id)
+                        .map(|profile| profile.prompt_section_overrides.clone())
+                        .unwrap_or_default();
+                    let section_issues =
+                        section_override_issues(&section_overrides, self.section_graph.as_ref());
+
+                    v_flex()
+                        .pb_1()
+                        .child(ProfileModalHeader::new(
+                            format!("{profile_name} — Configure Prompts"),
+                            Some(IconName::TextSnippet),
+                        ))
+                        .child(ListSeparator)
+                        .child(
+                            v_flex()
+                                .gap_1()
+                                .child(
+                                    div().px_2().pt_2().child(
+                                        Label::new("Section Overrides")
+                                            .size(LabelSize::Small)
+                                            .color(Color::Muted),
+                                    ),
+                                )
+                                .child(
+                                    div()
+                                        .id("create-section-override")
+                                        .track_focus(&create_section_override.focus_handle)
+                                        .on_action({
+                                            let profile_id = profile_id.clone();
+                                            cx.listener(
+                                                move |this, _: &menu::Confirm, window, cx| {
+                                                    this.create_section_override(
+                                                        profile_id.clone(),
+                                                        window,
+                                                        cx,
+                                                    );
+                                                },
+                                            )
+                                        })
+                                        .child(
+                                            ListItem::new("create-section-override")
+                                                .toggle_state(
+                                                    create_section_override
+                                                        .focus_handle
+                                                        .contains_focused(window, cx),
+                                                )
+                                                .inset(true)
+                                                .spacing(ListItemSpacing::Sparse)
+                                                .start_slot(
+                                                    Icon::new(IconName::Plus)
+                                                        .size(IconSize::Small)
+                                                        .color(Color::Muted),
+                                                )
+                                                .child(Label::new("Create Section Override"))
+                                                .on_click({
+                                                    let profile_id = profile_id.clone();
+                                                    cx.listener(move |this, _, window, cx| {
+                                                        this.create_section_override(
+                                                            profile_id.clone(),
+                                                            window,
+                                                            cx,
+                                                        );
+                                                    })
+                                                }),
+                                        ),
+                                )
+                                .child(
+                                    div().px_2().pt_1().child(
+                                        Label::new("Overrides")
+                                            .size(LabelSize::Small)
+                                            .color(Color::Muted),
+                                    ),
+                                )
+                                .child(if section_overrides.is_empty() {
+                                    div()
+                                        .px_2()
+                                        .child(
+                                            Label::new("No overrides yet.")
+                                                .size(LabelSize::Small)
+                                                .color(Color::Muted),
+                                        )
+                                        .into_any_element()
+                                } else {
+                                    v_flex()
+                                        .gap_0p5()
+                                        .children(
+                                            section_overrides
+                                                .iter()
+                                                .map(|override_entry| {
+                                                    let issue = section_issues
+                                                        .get(override_entry.section.as_ref());
+                                                    let override_entry = override_entry.clone();
+                                                    let issue_icon = issue.map(|issue| {
+                                                        let (icon, color) = match issue.kind {
+                                                            SectionOverrideIssueKind::Missing => {
+                                                                (IconName::XCircle, Color::Error)
+                                                            }
+                                                            SectionOverrideIssueKind::Masked => {
+                                                                (IconName::Warning, Color::Warning)
+                                                            }
+                                                        };
+                                                        div()
+                                                            .id(format!(
+                                                                "section-override-issue-{}",
+                                                                override_entry.section
+                                                            ))
+                                                            .tooltip(Tooltip::text(
+                                                                issue.message.clone(),
+                                                            ))
+                                                            .child(
+                                                                Icon::new(icon)
+                                                                    .size(IconSize::Small)
+                                                                    .color(color),
+                                                            )
+                                                    });
+                                                    let delete_button = IconButton::new(
+                                                        format!(
+                                                            "delete-section-override-{}",
+                                                            override_entry.section
+                                                        ),
+                                                        IconName::Trash,
+                                                    )
+                                                    .shape(IconButtonShape::Square)
+                                                    .icon_size(IconSize::XSmall)
+                                                    .icon_color(Color::Muted)
+                                                    .on_click({
+                                                        let profile_id = profile_id.clone();
+                                                        let section =
+                                                            override_entry.section.clone();
+                                                        cx.listener(move |this, _, window, cx| {
+                                                            this.delete_section_override(
+                                                                profile_id.clone(),
+                                                                section.clone(),
+                                                                window,
+                                                                cx,
+                                                            );
+                                                            cx.stop_propagation();
+                                                        })
+                                                    });
+                                                    ListItem::new(format!(
+                                                        "section-override-{}",
+                                                        override_entry.section
+                                                    ))
+                                                    .inset(true)
+                                                    .spacing(ListItemSpacing::Sparse)
+                                                    .start_slot(
+                                                        Icon::new(IconName::TextSnippet)
+                                                            .size(IconSize::Small)
+                                                            .color(Color::Muted),
+                                                    )
+                                                    .child(Label::new(
+                                                        override_entry.section.to_string(),
+                                                    ))
+                                                    .end_slot(
+                                                        h_flex()
+                                                            .gap_1()
+                                                            .child(delete_button)
+                                                            .when_some(issue_icon, |this, icon| {
+                                                                this.child(icon)
+                                                            }),
+                                                    )
+                                                    .on_click({
+                                                        let profile_id = profile_id.clone();
+                                                        let override_entry = override_entry.clone();
+                                                        cx.listener(move |this, _, window, cx| {
+                                                            this.edit_section_override(
+                                                                profile_id.clone(),
+                                                                Some(override_entry.clone()),
+                                                                window,
+                                                                cx,
+                                                            );
+                                                        })
+                                                    })
+                                                    .into_any_element()
+                                                })
+                                                .collect::<Vec<_>>(),
+                                        )
+                                        .into_any_element()
+                                }),
+                        )
+                        .child(ListSeparator)
+                        .child(go_back_item)
+                        .into_any_element()
+                }
             })
     }
+}
+
+#[derive(Clone)]
+struct SectionOverrideIssue {
+    kind: SectionOverrideIssueKind,
+    message: String,
+}
+
+#[derive(Clone, Copy)]
+enum SectionOverrideIssueKind {
+    Missing,
+    Masked,
+}
+
+fn section_exists(section_graph: &SectionGraph, section: &str) -> bool {
+    if section.is_empty() {
+        return false;
+    }
+    section_graph
+        .templates
+        .values()
+        .any(|template| template.sections.contains_key(section))
+}
+
+fn section_suggestions(section_graph: &SectionGraph, query: &str) -> Vec<String> {
+    let query = query.trim();
+    let all_sections = all_sections(section_graph);
+    if query.is_empty() {
+        return all_sections.into_iter().take(6).collect();
+    }
+    let query = query.to_lowercase();
+    all_sections
+        .into_iter()
+        .filter(|section| section.to_lowercase().contains(&query))
+        .take(6)
+        .collect()
+}
+
+fn all_sections(section_graph: &SectionGraph) -> BTreeSet<String> {
+    let mut sections = BTreeSet::new();
+    for template in section_graph.templates.values() {
+        sections.extend(template.sections.keys().cloned());
+    }
+    sections
+}
+
+fn section_override_issues(
+    overrides: &[PromptSectionOverride],
+    section_graph: Option<&SectionGraph>,
+) -> HashMap<String, SectionOverrideIssue> {
+    let Some(section_graph) = section_graph else {
+        return HashMap::default();
+    };
+    let all_sections = all_sections(section_graph);
+    let mut issues = HashMap::default();
+    for override_entry in overrides {
+        let section = override_entry.section.as_ref();
+        if !all_sections.contains(section) {
+            issues.insert(
+                override_entry.section.to_string(),
+                SectionOverrideIssue {
+                    kind: SectionOverrideIssueKind::Missing,
+                    message: "Section no longer exists in templates.".to_string(),
+                },
+            );
+        }
+    }
+
+    let masked_by = masked_sections_by_parent_override(overrides, section_graph);
+    for (section, parents) in masked_by {
+        if issues.contains_key(&section) {
+            continue;
+        }
+        if parents.is_empty() {
+            continue;
+        }
+        let mut parent_list: Vec<String> = parents.into_iter().collect();
+        parent_list.sort();
+        let message = if parent_list.len() == 1 {
+            format!(
+                "Hidden because {} was overridden without including it.",
+                parent_list[0]
+            )
+        } else {
+            format!(
+                "Hidden because {} were overridden without including it.",
+                parent_list.join(", ")
+            )
+        };
+        issues.insert(
+            section,
+            SectionOverrideIssue {
+                kind: SectionOverrideIssueKind::Masked,
+                message,
+            },
+        );
+    }
+
+    issues
+}
+
+fn masked_sections_by_parent_override(
+    overrides: &[PromptSectionOverride],
+    section_graph: &SectionGraph,
+) -> HashMap<String, BTreeSet<String>> {
+    let mut masked_by = HashMap::default();
+    let mut references_by_section: HashMap<&str, BTreeSet<String>> = HashMap::default();
+    for override_entry in overrides {
+        references_by_section.insert(
+            override_entry.section.as_ref(),
+            section_references(override_entry.replacement.as_ref()),
+        );
+    }
+
+    for template in section_graph.templates.values() {
+        for override_entry in overrides {
+            let parent = override_entry.section.as_ref();
+            if !template.sections.contains_key(parent) {
+                continue;
+            }
+            let descendants = collect_descendants(template, parent);
+            if descendants.is_empty() {
+                continue;
+            }
+            let referenced = references_by_section
+                .get(parent)
+                .cloned()
+                .unwrap_or_default();
+            let mut reachable = BTreeSet::new();
+            for referenced_section in referenced {
+                if is_descendant_or_self(template, parent, &referenced_section) {
+                    reachable.extend(collect_descendants_including(template, &referenced_section));
+                }
+            }
+            for masked in descendants.difference(&reachable) {
+                masked_by
+                    .entry(masked.clone())
+                    .or_insert_with(BTreeSet::new)
+                    .insert(parent.to_string());
+            }
+        }
+    }
+
+    masked_by
+}
+
+fn collect_descendants(template: &TemplateSectionGraph, root: &str) -> BTreeSet<String> {
+    let mut descendants = BTreeSet::new();
+    let mut stack = vec![root.to_string()];
+    while let Some(section) = stack.pop() {
+        if let Some(node) = template.sections.get(&section) {
+            for child in &node.children {
+                if descendants.insert(child.clone()) {
+                    stack.push(child.clone());
+                }
+            }
+        }
+    }
+    descendants
+}
+
+fn collect_descendants_including(template: &TemplateSectionGraph, root: &str) -> BTreeSet<String> {
+    let mut descendants = collect_descendants(template, root);
+    descendants.insert(root.to_string());
+    descendants
+}
+
+fn is_descendant_or_self(template: &TemplateSectionGraph, ancestor: &str, candidate: &str) -> bool {
+    if ancestor == candidate {
+        return true;
+    }
+    let mut stack = vec![candidate.to_string()];
+    let mut visited = BTreeSet::new();
+    while let Some(section) = stack.pop() {
+        if !visited.insert(section.clone()) {
+            continue;
+        }
+        let Some(node) = template.sections.get(&section) else {
+            continue;
+        };
+        for parent in &node.parents {
+            if parent == ancestor {
+                return true;
+            }
+            stack.push(parent.clone());
+        }
+    }
+    false
+}
+
+fn section_references(text: &str) -> BTreeSet<String> {
+    let mut references = BTreeSet::new();
+    let mut index = 0;
+    while let Some(match_index) = text[index..].find("{{#section") {
+        let mut cursor = index + match_index + "{{#section".len();
+        let bytes = text.as_bytes();
+        while cursor < bytes.len() && bytes[cursor].is_ascii_whitespace() {
+            cursor += 1;
+        }
+        if cursor >= bytes.len() {
+            break;
+        }
+        let (section_name, next_index) = if bytes[cursor] == b'"' || bytes[cursor] == b'\'' {
+            let quote = bytes[cursor];
+            cursor += 1;
+            let start = cursor;
+            while cursor < bytes.len() && bytes[cursor] != quote {
+                cursor += 1;
+            }
+            let section_name = text.get(start..cursor).unwrap_or_default();
+            (section_name, cursor.saturating_add(1).min(bytes.len()))
+        } else {
+            let start = cursor;
+            while cursor < bytes.len()
+                && !bytes[cursor].is_ascii_whitespace()
+                && bytes[cursor] != b'}'
+            {
+                cursor += 1;
+            }
+            let section_name = text.get(start..cursor).unwrap_or_default();
+            (section_name, cursor.min(bytes.len()))
+        };
+        if !section_name.is_empty() {
+            references.insert(section_name.to_string());
+        }
+        index = next_index;
+    }
+    references
 }

--- a/crates/agent_ui/src/agent_configuration/tool_picker.rs
+++ b/crates/agent_ui/src/agent_configuration/tool_picker.rs
@@ -5,7 +5,10 @@ use agent_settings::{AgentProfileId, AgentProfileSettings};
 use fs::Fs;
 use gpui::{App, Context, DismissEvent, Entity, EventEmitter, Focusable, Task, WeakEntity, Window};
 use picker::{Picker, PickerDelegate};
-use settings::{AgentProfileContent, ContextServerPresetContent, update_settings_file};
+use settings::{
+    AgentProfileContent, ContextServerPresetContent, PromptSectionOverrideContent,
+    update_settings_file,
+};
 use ui::{ListItem, ListItemSpacing, prelude::*};
 use util::ResultExt as _;
 
@@ -315,6 +318,13 @@ impl PickerDelegate for ToolPickerDelegate {
                             })
                             .collect(),
                         default_model: default_profile.default_model.clone(),
+                        prompt_section_overrides: default_profile
+                            .prompt_section_overrides
+                            .iter()
+                            .cloned()
+                            .map(PromptSectionOverrideContent::from)
+                            .collect(),
+                        system_prompt_provider: default_profile.system_prompt_provider.clone(),
                     });
 
                 if let Some(server_id) = server_id {

--- a/crates/settings_content/src/agent.rs
+++ b/crates/settings_content/src/agent.rs
@@ -254,6 +254,18 @@ pub struct AgentProfileContent {
     pub context_servers: IndexMap<Arc<str>, ContextServerPresetContent>,
     /// The default language model selected when using this profile.
     pub default_model: Option<LanguageModelSelection>,
+    /// Inline prompt section overrides applied to this profile.
+    #[serde(default)]
+    pub prompt_section_overrides: Vec<PromptSectionOverrideContent>,
+    /// Extension-provided prompt provider for this profile.
+    pub system_prompt_provider: Option<Arc<str>>,
+}
+
+#[with_fallible_options]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize, JsonSchema, MergeFrom, Default)]
+pub struct PromptSectionOverrideContent {
+    pub section: Arc<str>,
+    pub replacement: Arc<str>,
 }
 
 #[with_fallible_options]


### PR DESCRIPTION
Implements the details asked at: https://github.com/zed-industries/zed/discussions/47609

Still work in progress...

Summary:
- Adds section-aware template overrides with replace/remove support and exposes section graphs/defaults for UI.
- Wires per-profile prompt section overrides through settings/UI and applies them when resolving templates.
- Caches template instances by override config to avoid re-parsing per thread.
- Updates prompt templates to use named sections for targeted overrides.

Notes:
 - Only the main agent (Zed Agent) is customizable, and not the ACP agents.
 - We still need to migrate other experiences (e.g. git commit in the git_panel) to templates and sections (those are already customizable using prompt store and the prompt overrides directory => but it will be nice to have a unified way to change prompts.

Release Notes:
Added the ability to fully customize system prompts.


Opening as a draft as I would appreciate some early feedback.

Current state:
![zed-custom-systemprompt-section](https://github.com/user-attachments/assets/2d301726-15b3-41c7-a180-4eb6e976869b)
<img width="1511" height="869" alt="image" src="https://github.com/user-attachments/assets/e721581d-bdb8-4556-8914-3c70f7627792" />
