### PR TITLE
gpui: Use memoryless storage for MSAA textures on Apple Silicon

### DIFF
--- a/crates/gpui/src/platform/mac/metal_renderer.rs
+++ b/crates/gpui/src/platform/mac/metal_renderer.rs
@@ -350,8 +350,15 @@ impl MetalRenderer {
 
         if self.path_sample_count > 1 {
             let mut msaa_descriptor = texture_descriptor;
+            #[cfg(target_arch = "aarch64")]
+            {
+                msaa_descriptor.set_storage_mode(metal::MTLStorageMode::Memoryless);
+            }
+            #[cfg(not(target_arch = "aarch64"))]
+            {
+                msaa_descriptor.set_storage_mode(metal::MTLStorageMode::Private);
+            }
             msaa_descriptor.set_texture_type(metal::MTLTextureType::D2Multisample);
-            msaa_descriptor.set_storage_mode(metal::MTLStorageMode::Private);
             msaa_descriptor.set_sample_count(self.path_sample_count as _);
             self.path_intermediate_msaa_texture = Some(self.device.new_texture(&msaa_descriptor));
         } else {


### PR DESCRIPTION
  Msaa textures uses `Memoryless` storage on Apple Silicon (aarch64), falls back to `Private` storage on Intel Macs.

  ## Benchmark (paths_bench, 2000 paths/frame)
  | Storage Mode | Avg FPS | Allocated |
  |--------------|---------|-----------|
  | Private            | 31.46   | ~50 MB    |
  | Memoryless   | 32.78   | 0 bytes   |

 This is a synthetic stress test with 2000 paths per frame, which is more extreme than typical usage. But it has some potential to reduce memory usage and help with battery life. 

Release Notes:

- N/A
