### PR TITLE
Update nim entry with additional file suffixes 

### DIFF
--- a/crates/theme/src/icon_theme.rs
+++ b/crates/theme/src/icon_theme.rs
@@ -164,7 +164,7 @@ const FILE_SUFFIXES_BY_ICON_KEY: &[(&str, &[&str])] = &[
     ("luau", &["luau"]),
     ("markdown", &["markdown", "md"]),
     ("metal", &["metal"]),
-    ("nim", &["nim"]),
+    ("nim", &["nim", "nims", "nimble"]),
     ("nix", &["nix"]),
     ("ocaml", &["ml", "mli"]),
     ("odin", &["odin"]),


### PR DESCRIPTION
Expanded the nim entry to include `nims` and `nimble` files

- [nims](https://nim-lang.org/docs/nims.html) is a subscript of Nim that runs in a VM
- [nimble](https://github.com/nim-lang/nimble) files are project files for Nim that are written in Nim

Release Notes:

- Updated Nim file aliases so icon is shown for nims/nimble files
