### PR TITLE
extensions_ui: Add support for offline viewing of extensions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5979,6 +5979,7 @@ dependencies = [
  "parking_lot",
  "pretty_assertions",
  "proto",
+ "rpc",
  "semver",
  "serde",
  "serde_json",

--- a/crates/extension/Cargo.toml
+++ b/crates/extension/Cargo.toml
@@ -26,6 +26,7 @@ log.workspace = true
 lsp.workspace = true
 parking_lot.workspace = true
 proto.workspace = true
+rpc.workspace = true
 semver.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/extension/src/extension_manifest.rs
+++ b/crates/extension/src/extension_manifest.rs
@@ -3,6 +3,7 @@ use collections::{BTreeMap, HashMap};
 use fs::Fs;
 use language::LanguageName;
 use lsp::LanguageServerName;
+use rpc::ExtensionProvides;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -147,6 +148,39 @@ impl ExtensionManifest {
         !self.language_servers.is_empty()
             || !self.debug_adapters.is_empty()
             || !self.debug_locators.is_empty()
+    }
+
+    pub fn is_providing(&self, p: ExtensionProvides) -> bool {
+        match p {
+            ExtensionProvides::Themes => !self.themes.is_empty(),
+            ExtensionProvides::IconThemes => !self.icon_themes.is_empty(),
+            ExtensionProvides::Languages => !self.languages.is_empty(),
+            ExtensionProvides::Grammars => !self.grammars.is_empty(),
+            ExtensionProvides::LanguageServers => !self.language_servers.is_empty(),
+            ExtensionProvides::ContextServers => !self.context_servers.is_empty(),
+            ExtensionProvides::AgentServers => !self.agent_servers.is_empty(),
+            ExtensionProvides::Snippets => self.snippets.is_some(),
+            ExtensionProvides::DebugAdapters => !self.debug_adapters.is_empty(),
+            ExtensionProvides::SlashCommands => !self.slash_commands.is_empty(),
+            ExtensionProvides::IndexedDocsProviders => false,
+        }
+    }
+
+    pub fn provides_iter(&self) -> impl Iterator<Item = ExtensionProvides> + '_ {
+        [
+            ExtensionProvides::Themes,
+            ExtensionProvides::IconThemes,
+            ExtensionProvides::Languages,
+            ExtensionProvides::Grammars,
+            ExtensionProvides::LanguageServers,
+            ExtensionProvides::ContextServers,
+            ExtensionProvides::AgentServers,
+            ExtensionProvides::SlashCommands,
+            ExtensionProvides::Snippets,
+            ExtensionProvides::DebugAdapters,
+        ]
+        .into_iter()
+        .filter(move |p| self.is_providing(*p))
     }
 }
 


### PR DESCRIPTION
This only shows the currently installed extensions if you are offline however, you can still uninstall extensions, search and filter via category.

Closes #12163

Release Notes:

- Added an offline view for extensions, showing your currently installed extensions when offline.

Examples:

Offline, all
![offline](https://github.com/user-attachments/assets/c0ce14bf-f347-4b3a-bc21-155a4974b5f2)

Offline, all with no extensions
![offline-no](https://github.com/user-attachments/assets/1e414e46-8854-4983-95e1-4a7992755f26)

Online (as usual)
![online](https://github.com/user-attachments/assets/2e3fc4e5-35df-4fbc-b437-2fe92c0fc11a)


Notes:
* Not sure how "permissive" the search/filtering function should be, I used `.contains(...)` and included the option to filter via the description (I prefer this, but it can easily be changed if not desired/is inconsistent).
* I also included the button to view the repository, for an edge-case where the API is down but you have an internet connection.
