### PR TITLE
project: Add spinner while search is underway

### DIFF
--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -41,7 +41,7 @@ use std::{
     sync::Arc,
 };
 use ui::{
-    IconButtonShape, KeyBinding, SpinnerLabel, Toggleable, Tooltip, prelude::*,
+    CommonAnimationExt, IconButtonShape, KeyBinding, Toggleable, Tooltip, prelude::*,
     utils::SearchInputWidth,
 };
 use util::{ResultExt as _, paths::PathMatcher, rel_path::RelPath};
@@ -2111,21 +2111,27 @@ impl Render for ProjectSearchBar {
                     .min_w(rems_from_px(40.))
                     .child(
                         h_flex()
-                            .gap_1()
-                            .child(Label::new(match_text).size(LabelSize::Small).color(
-                                if search.active_match_index.is_some() {
-                                    Color::Default
-                                } else {
-                                    Color::Disabled
-                                },
-                            ))
-                            .when(is_search_underway, |el| {
-                                el.child(SpinnerLabel::new().size(LabelSize::Small))
+                            .gap_1p5()
+                            .child(
+                                Label::new(match_text)
+                                    .size(LabelSize::Small)
+                                    .when(search.active_match_index.is_some(), |this| {
+                                        this.color(Color::Disabled)
+                                    }),
+                            )
+                            .when(is_search_underway, |this| {
+                                this.child(
+                                    Icon::new(IconName::ArrowCircle)
+                                        .color(Color::Accent)
+                                        .size(IconSize::Small)
+                                        .with_rotate_animation(2)
+                                        .into_any_element(),
+                                )
                             }),
                     )
-                    .when(limit_reached, |el| {
-                        el.tooltip(Tooltip::text(
-                            "Search limits reached.\nTry narrowing your search.",
+                    .when(limit_reached, |this| {
+                        this.tooltip(Tooltip::text(
+                            "Search Limits Reached\nTry narrowing your search",
                         ))
                     }),
             );

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -40,7 +40,10 @@ use std::{
     pin::pin,
     sync::Arc,
 };
-use ui::{IconButtonShape, KeyBinding, Toggleable, Tooltip, prelude::*, utils::SearchInputWidth};
+use ui::{
+    IconButtonShape, KeyBinding, SpinnerLabel, Toggleable, Tooltip, prelude::*,
+    utils::SearchInputWidth,
+};
 use util::{ResultExt as _, paths::PathMatcher, rel_path::RelPath};
 use workspace::{
     DeploySearch, ItemNavHistory, NewSearch, ToolbarItemEvent, ToolbarItemLocation,
@@ -2013,6 +2016,7 @@ impl Render for ProjectSearchBar {
         let theme_colors = cx.theme().colors();
         let project_search = search.entity.read(cx);
         let limit_reached = project_search.limit_reached;
+        let is_search_underway = project_search.pending_search.is_some();
 
         let color_override = match (
             &project_search.pending_search,
@@ -2105,13 +2109,20 @@ impl Render for ProjectSearchBar {
                     .id("matches")
                     .ml_2()
                     .min_w(rems_from_px(40.))
-                    .child(Label::new(match_text).size(LabelSize::Small).color(
-                        if search.active_match_index.is_some() {
-                            Color::Default
-                        } else {
-                            Color::Disabled
-                        },
-                    ))
+                    .child(
+                        h_flex()
+                            .gap_1()
+                            .child(Label::new(match_text).size(LabelSize::Small).color(
+                                if search.active_match_index.is_some() {
+                                    Color::Default
+                                } else {
+                                    Color::Disabled
+                                },
+                            ))
+                            .when(is_search_underway, |el| {
+                                el.child(SpinnerLabel::new().size(LabelSize::Small))
+                            }),
+                    )
                     .when(limit_reached, |el| {
                         el.tooltip(Tooltip::text(
                             "Search limits reached.\nTry narrowing your search.",


### PR DESCRIPTION
When there are no search results, it's clear that a search is still
ongoing because the landing page says "Searching...". However, once
there's at least one result found, it becomes completely unclear when
search is actually finished. This adds a spinner immediately to the
right of the result counter that stops once the search is finished.

https://github.com/user-attachments/assets/a0ca4e2a-c506-42a4-bc4b-c1eb32d69e79

Release Notes:

- Improved project search loading UI.