### PR TITLE
languages: Add highlighting for Go directives

### DIFF
--- a/crates/languages/src/go/highlights.scm
+++ b/crates/languages/src/go/highlights.scm
@@ -138,3 +138,11 @@
 ] @constant.builtin
 
 (comment) @comment
+
+; Go directives
+((comment) @attribute
+ (#match? @attribute "^//go:"))
+
+((comment) @attribute
+ (#match? @attribute "^// \\+build"))
+

--- a/crates/languages/src/go/highlights.scm
+++ b/crates/languages/src/go/highlights.scm
@@ -140,9 +140,9 @@
 (comment) @comment
 
 ; Go directives
-((comment) @attribute
- (#match? @attribute "^//go:"))
+((comment) @preproc
+ (#match? @preproc "^//go:"))
 
-((comment) @attribute
- (#match? @attribute "^// \\+build"))
+((comment) @preproc
+ (#match? @preproc "^// \\+build"))
 


### PR DESCRIPTION
Closes #4381
Before:
<img width="394" height="176" alt="before" src="https://github.com/user-attachments/assets/7b34b448-9fbc-4a69-abaf-8b621d22ef1e" />

After:
<img width="394" height="176" alt="after" src="https://github.com/user-attachments/assets/388f997c-ca02-4fb4-b8db-4d6f7e9cd302" />

Release Notes:

- Added highlighting for Go directives
