### PR TITLE
Revert "Fix link for `Ownership and data flow` in GPUI's README.md"

### DIFF
--- a/crates/gpui/README.md
+++ b/crates/gpui/README.md
@@ -11,7 +11,7 @@ GPUI is still in active development as we work on the Zed code editor, and is st
 gpui = { version = "*" }
 ```
 
- - [Ownership and data flow](https://zed.dev/blog/gpui-ownership)
+ - [Ownership and data flow](_ownership_and_data_flow)
 
 Everything in GPUI starts with an `Application`. You can create one with `Application::new()`, and kick off your application by passing a callback to `Application::run()`. Inside this callback, you can create a new window with `App::open_window()`, and register your first root view. See [gpui.rs](https://www.gpui.rs/) for a complete example.
 


### PR DESCRIPTION
Reverts zed-industries/zed#47599

The link here was intentional and linking to a file within GPUI, hence reverting.

Release Notes:

- N/A