### PR TITLE
project: Do not send `UpdateProject` message on remote server spawn

### DIFF
--- a/crates/project/src/worktree_store.rs
+++ b/crates/project/src/worktree_store.rs
@@ -913,7 +913,13 @@ impl WorktreeStore {
                 }
             }
         }
-        self.send_project_updates(cx);
+        // Only send project updates if we share in a collaborative mode.
+        // Otherwise we are the remote server which is currently constructing
+        // worktree store before the client actually has set up its message
+        // handlers.
+        if remote_id != REMOTE_SERVER_PROJECT_ID {
+            self.send_project_updates(cx);
+        }
     }
 
     pub fn unshared(&mut self, cx: &mut Context<Self>) {

--- a/crates/remote/src/remote_client.rs
+++ b/crates/remote/src/remote_client.rs
@@ -842,7 +842,7 @@ impl RemoteClient {
                             }
                         }
                     } else if exit_code > 0 {
-                        log::error!("proxy process terminated unexpectedly");
+                        log::error!("proxy process terminated unexpectedly: {exit_code}");
                         this.update(cx, |this, cx| {
                             this.reconnect(cx).ok();
                         })?;


### PR DESCRIPTION
The client has not yet setup its own side of things so the message will always error as being unhandled anyways.

Release Notes:

- N/A *or* Added/Fixed/Improved ...
