### PR TITLE
agent_ui: Add ability to add terminal output to agent context

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -1131,6 +1131,7 @@
       "ctrl-alt-r": "terminal::RerunTask",
       "alt-t": "terminal::RerunTask",
       "ctrl-shift-5": "pane::SplitRight",
+      "ctrl->": "agent::AddSelectionToThread",
     },
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -1210,6 +1210,7 @@
       "ctrl-alt-right": "pane::SplitRight",
       "cmd-d": "pane::SplitRight",
       "cmd-alt-r": "terminal::RerunTask",
+      "cmd->": "agent::AddSelectionToThread",
     },
   },
   {

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -1149,6 +1149,7 @@
       "ctrl-alt-r": "terminal::RerunTask",
       "alt-t": "terminal::RerunTask",
       "ctrl-shift-5": "pane::SplitRight",
+      "ctrl-shift-.": "agent::AddSelectionToThread",
     },
   },
   {

--- a/crates/acp_thread/src/mention.rs
+++ b/crates/acp_thread/src/mention.rs
@@ -54,6 +54,7 @@ pub enum MentionUri {
     Fetch {
         url: Url,
     },
+    Terminal,
 }
 
 impl MentionUri {
@@ -199,6 +200,8 @@ impl MentionUri {
                         abs_path: Some(path.into()),
                         line_range,
                     })
+                } else if path.starts_with("/agent/terminal-selection") {
+                    Ok(Self::Terminal)
                 } else {
                     bail!("invalid zed url: {:?}", input);
                 }
@@ -221,6 +224,7 @@ impl MentionUri {
             MentionUri::TextThread { name, .. } => name.clone(),
             MentionUri::Rule { name, .. } => name.clone(),
             MentionUri::Diagnostics { .. } => "Diagnostics".to_string(),
+            MentionUri::Terminal => "Terminal".to_string(),
             MentionUri::Selection {
                 abs_path: path,
                 line_range,
@@ -243,6 +247,7 @@ impl MentionUri {
             MentionUri::TextThread { .. } => IconName::Thread.path().into(),
             MentionUri::Rule { .. } => IconName::Reader.path().into(),
             MentionUri::Diagnostics { .. } => IconName::Warning.path().into(),
+            MentionUri::Terminal => IconName::Terminal.path().into(),
             MentionUri::Selection { .. } => IconName::Reader.path().into(),
             MentionUri::Fetch { .. } => IconName::ToolWeb.path().into(),
         }
@@ -337,6 +342,7 @@ impl MentionUri {
                 url
             }
             MentionUri::Fetch { url } => url.clone(),
+            MentionUri::Terminal => Url::parse("zed:///agent/terminal-selection").unwrap(),
         }
     }
 }
@@ -640,5 +646,17 @@ mod tests {
             }
             _ => panic!("Expected Selection variant"),
         }
+    }
+
+    #[test]
+    fn test_parse_terminal_selection_uri() {
+        let terminal_uri = "zed:///agent/terminal-selection";
+        let parsed = MentionUri::parse(terminal_uri, PathStyle::local()).unwrap();
+        match &parsed {
+            MentionUri::Terminal => {}
+            _ => panic!("Expected Terminal variant"),
+        }
+        assert_eq!(parsed.to_uri().to_string(), terminal_uri);
+        assert_eq!(parsed.name(), "Terminal");
     }
 }

--- a/crates/acp_thread/src/mention.rs
+++ b/crates/acp_thread/src/mention.rs
@@ -54,7 +54,7 @@ pub enum MentionUri {
     Fetch {
         url: Url,
     },
-    Terminal,
+    TerminalSelection,
 }
 
 impl MentionUri {
@@ -201,7 +201,7 @@ impl MentionUri {
                         line_range,
                     })
                 } else if path.starts_with("/agent/terminal-selection") {
-                    Ok(Self::Terminal)
+                    Ok(Self::TerminalSelection)
                 } else {
                     bail!("invalid zed url: {:?}", input);
                 }
@@ -224,7 +224,7 @@ impl MentionUri {
             MentionUri::TextThread { name, .. } => name.clone(),
             MentionUri::Rule { name, .. } => name.clone(),
             MentionUri::Diagnostics { .. } => "Diagnostics".to_string(),
-            MentionUri::Terminal => "Terminal".to_string(),
+            MentionUri::TerminalSelection => "Terminal".to_string(),
             MentionUri::Selection {
                 abs_path: path,
                 line_range,
@@ -247,7 +247,7 @@ impl MentionUri {
             MentionUri::TextThread { .. } => IconName::Thread.path().into(),
             MentionUri::Rule { .. } => IconName::Reader.path().into(),
             MentionUri::Diagnostics { .. } => IconName::Warning.path().into(),
-            MentionUri::Terminal => IconName::Terminal.path().into(),
+            MentionUri::TerminalSelection => IconName::Terminal.path().into(),
             MentionUri::Selection { .. } => IconName::Reader.path().into(),
             MentionUri::Fetch { .. } => IconName::ToolWeb.path().into(),
         }
@@ -342,7 +342,7 @@ impl MentionUri {
                 url
             }
             MentionUri::Fetch { url } => url.clone(),
-            MentionUri::Terminal => Url::parse("zed:///agent/terminal-selection").unwrap(),
+            MentionUri::TerminalSelection => Url::parse("zed:///agent/terminal-selection").unwrap(),
         }
     }
 }
@@ -653,7 +653,7 @@ mod tests {
         let terminal_uri = "zed:///agent/terminal-selection";
         let parsed = MentionUri::parse(terminal_uri, PathStyle::local()).unwrap();
         match &parsed {
-            MentionUri::Terminal => {}
+            MentionUri::TerminalSelection => {}
             _ => panic!("Expected Terminal variant"),
         }
         assert_eq!(parsed.to_uri().to_string(), terminal_uri);

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -317,6 +317,17 @@ impl UserMessage {
                         MentionUri::Diagnostics { .. } => {
                             write!(&mut diagnostics_context, "\n{}\n", content).ok();
                         }
+                        MentionUri::Terminal => {
+                            write!(
+                                &mut selection_context,
+                                "\n{}",
+                                MarkdownCodeBlock {
+                                    tag: "terminal",
+                                    text: content
+                                }
+                            )
+                            .ok();
+                        }
                     }
 
                     language_model::MessageContent::Text(uri.as_link().to_string())

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -322,7 +322,7 @@ impl UserMessage {
                                 &mut selection_context,
                                 "\n{}",
                                 MarkdownCodeBlock {
-                                    tag: "terminal",
+                                    tag: "console",
                                     text: content
                                 }
                             )

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -317,7 +317,7 @@ impl UserMessage {
                         MentionUri::Diagnostics { .. } => {
                             write!(&mut diagnostics_context, "\n{}\n", content).ok();
                         }
-                        MentionUri::Terminal => {
+                        MentionUri::TerminalSelection => {
                             write!(
                                 &mut selection_context,
                                 "\n{}",

--- a/crates/agent_ui/src/acp/message_editor.rs
+++ b/crates/agent_ui/src/acp/message_editor.rs
@@ -1018,7 +1018,14 @@ impl MessageEditor {
         cx: &mut Context<Self>,
     ) {
         let formatted_text = format!("```terminal\n{}\n```", text);
-        self.insert_crease_impl(formatted_text, "Terminal".to_string(), IconName::Terminal, false, window, cx);
+        self.insert_crease_impl(
+            formatted_text,
+            "Terminal".to_string(),
+            IconName::Terminal,
+            false,
+            window,
+            cx,
+        );
         self.editor.update(cx, |editor, cx| {
             editor.insert(" ", window, cx);
         });
@@ -1232,8 +1239,11 @@ impl MessageEditor {
                     while let Some(block_start) = chunk_text[search_start..].find("```terminal") {
                         let absolute_block_start = chunk_start + search_start + block_start;
                         // Find the closing ```
-                        if let Some(block_end_relative) = chunk_text[search_start + block_start + 11..].find("\n```") {
-                            let absolute_block_end = absolute_block_start + 11 + block_end_relative + 4;
+                        if let Some(block_end_relative) =
+                            chunk_text[search_start + block_start + 11..].find("\n```")
+                        {
+                            let absolute_block_end =
+                                absolute_block_start + 11 + block_end_relative + 4;
                             terminal_blocks.push(absolute_block_start..absolute_block_end);
                             search_start = search_start + block_start + 11 + block_end_relative + 4;
                         } else {

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -7647,6 +7647,18 @@ impl AcpThreadView {
         });
     }
 
+    /// Inserts terminal text as a crease into the message editor.
+    pub(crate) fn insert_terminal_text(
+        &self,
+        text: String,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.message_editor.update(cx, |message_editor, cx| {
+            message_editor.insert_terminal_crease(text, window, cx);
+        });
+    }
+
     /// Inserts code snippets as creases into the message editor.
     pub(crate) fn insert_code_crease(
         &self,

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -6866,7 +6866,7 @@ impl AcpThreadView {
                     cx.open_url(url.as_str());
                 }
                 MentionUri::Diagnostics { .. } => {}
-                MentionUri::Terminal => {}
+                MentionUri::TerminalSelection => {}
             })
         } else {
             cx.open_url(&url);

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -6866,6 +6866,7 @@ impl AcpThreadView {
                     cx.open_url(url.as_str());
                 }
                 MentionUri::Diagnostics { .. } => {}
+                MentionUri::Terminal => {}
             })
         } else {
             cx.open_url(&url);

--- a/crates/agent_ui/src/completion_provider.rs
+++ b/crates/agent_ui/src/completion_provider.rs
@@ -13,10 +13,12 @@ use editor::{
     CompletionProvider, Editor, ExcerptId, code_context_menus::COMPLETION_MENU_MAX_WIDTH,
 };
 use feature_flags::{FeatureFlagAppExt as _, UserSlashCommandsFeatureFlag};
+use futures::FutureExt as _;
 use fuzzy::{PathMatch, StringMatch, StringMatchCandidate};
 use gpui::{App, BackgroundExecutor, Entity, SharedString, Task, WeakEntity};
 use language::{Buffer, CodeLabel, CodeLabelBuilder, HighlightId};
 use lsp::CompletionContext;
+use multi_buffer::ToOffset as _;
 use ordered_float::OrderedFloat;
 use project::lsp_store::{CompletionDocumentation, SymbolLocation};
 use project::{
@@ -25,7 +27,10 @@ use project::{
 };
 use prompt_store::{PromptStore, UserPromptId};
 use rope::Point;
-use text::{Anchor, ToPoint as _};
+use settings::{Settings, TerminalDockPosition};
+use terminal::terminal_settings::TerminalSettings;
+use terminal_view::terminal_panel::TerminalPanel;
+use text::{Anchor, ToOffset as _, ToPoint as _};
 use ui::IconName;
 use ui::prelude::*;
 use util::ResultExt as _;
@@ -33,6 +38,7 @@ use util::paths::PathStyle;
 use util::rel_path::RelPath;
 use util::truncate_and_remove_front;
 use workspace::Workspace;
+use workspace::dock::DockPosition;
 
 use crate::AgentPanel;
 use crate::mention_set::MentionSet;
@@ -554,48 +560,129 @@ impl<T: PromptCompletionProviderDelegate> PromptCompletionProvider<T> {
     ) -> Option<Completion> {
         let (new_text, on_action) = match action {
             PromptContextAction::AddSelections => {
-                const PLACEHOLDER: &str = "selection ";
-                let selections = selection_ranges(workspace, cx)
+                // Collect non-empty editor selections
+                let editor_selections: Vec<_> = selection_ranges(workspace, cx)
+                    .into_iter()
+                    .filter(|(buffer, range)| {
+                        let snapshot = buffer.read(cx).snapshot();
+                        range.start.to_offset(&snapshot) != range.end.to_offset(&snapshot)
+                    })
+                    .collect();
+
+                // Collect terminal selections from all terminal views if the terminal panel is visible
+                let terminal_selections: Vec<String> =
+                    terminal_selections_if_panel_open(workspace, cx);
+
+                const EDITOR_PLACEHOLDER: &str = "selection ";
+                const TERMINAL_PLACEHOLDER: &str = "terminal ";
+
+                let selections = editor_selections
                     .into_iter()
                     .enumerate()
                     .map(|(ix, (buffer, range))| {
                         (
                             buffer,
                             range,
-                            (PLACEHOLDER.len() * ix)..(PLACEHOLDER.len() * (ix + 1) - 1),
+                            (EDITOR_PLACEHOLDER.len() * ix)
+                                ..(EDITOR_PLACEHOLDER.len() * (ix + 1) - 1),
                         )
                     })
                     .collect::<Vec<_>>();
 
-                let new_text: String = PLACEHOLDER.repeat(selections.len());
+                let mut new_text: String = EDITOR_PLACEHOLDER.repeat(selections.len());
+
+                // Add terminal placeholders for each terminal selection
+                let terminal_ranges: Vec<(String, std::ops::Range<usize>)> = terminal_selections
+                    .into_iter()
+                    .map(|text| {
+                        let start = new_text.len();
+                        new_text.push_str(TERMINAL_PLACEHOLDER);
+                        (text, start..(new_text.len() - 1))
+                    })
+                    .collect();
 
                 let callback = Arc::new({
                     let source_range = source_range.clone();
-                    move |_, window: &mut Window, cx: &mut App| {
+                    move |_: CompletionIntent, window: &mut Window, cx: &mut App| {
                         let editor = editor.clone();
                         let selections = selections.clone();
                         let mention_set = mention_set.clone();
                         let source_range = source_range.clone();
+                        let terminal_ranges = terminal_ranges.clone();
                         window.defer(cx, move |window, cx| {
                             if let Some(editor) = editor.upgrade() {
-                                mention_set
-                                    .update(cx, |store, cx| {
-                                        store.confirm_mention_for_selection(
-                                            source_range,
-                                            selections,
-                                            editor,
-                                            window,
-                                            cx,
-                                        )
-                                    })
-                                    .ok();
+                                // Insert editor selections
+                                if !selections.is_empty() {
+                                    mention_set
+                                        .update(cx, |store, cx| {
+                                            store.confirm_mention_for_selection(
+                                                source_range.clone(),
+                                                selections,
+                                                editor.clone(),
+                                                window,
+                                                cx,
+                                            )
+                                        })
+                                        .ok();
+                                }
+
+                                // Insert terminal selections
+                                for (terminal_text, terminal_range) in terminal_ranges {
+                                    let snapshot = editor.read(cx).buffer().read(cx).snapshot(cx);
+                                    let Some(start) =
+                                        snapshot.as_singleton_anchor(source_range.start)
+                                    else {
+                                        return;
+                                    };
+                                    let offset = start.to_offset(&snapshot);
+
+                                    let mention_uri = MentionUri::TerminalSelection;
+                                    let range = snapshot.anchor_after(offset + terminal_range.start)
+                                        ..snapshot.anchor_after(offset + terminal_range.end);
+
+                                    let crease = crate::mention_set::crease_for_mention(
+                                        mention_uri.name().into(),
+                                        mention_uri.icon_path(cx),
+                                        range,
+                                        editor.downgrade(),
+                                    );
+
+                                    let crease_id = editor.update(cx, |editor, cx| {
+                                        let crease_ids =
+                                            editor.insert_creases(vec![crease.clone()], cx);
+                                        editor.fold_creases(vec![crease], false, window, cx);
+                                        crease_ids.first().copied().unwrap()
+                                    });
+
+                                    mention_set
+                                        .update(cx, |mention_set, _| {
+                                            mention_set.insert_mention(
+                                                crease_id,
+                                                mention_uri.clone(),
+                                                gpui::Task::ready(Ok(
+                                                    crate::mention_set::Mention::Text {
+                                                        content: terminal_text,
+                                                        tracked_buffers: vec![],
+                                                    },
+                                                ))
+                                                .shared(),
+                                            );
+                                        })
+                                        .ok();
+                                }
                             }
                         });
                         false
                     }
                 });
 
-                (new_text, callback)
+                (
+                    new_text,
+                    callback
+                        as Arc<
+                            dyn Fn(CompletionIntent, &mut Window, &mut App) -> bool + Send + Sync,
+                        >,
+                )
             }
         };
 
@@ -1087,7 +1174,7 @@ impl<T: PromptCompletionProviderDelegate> PromptCompletionProvider<T> {
             entries.push(PromptContextEntry::Mode(PromptContextType::Thread));
         }
 
-        let has_selection = workspace
+        let has_editor_selection = workspace
             .read(cx)
             .active_item(cx)
             .and_then(|item| item.downcast::<Editor>())
@@ -1096,7 +1183,10 @@ impl<T: PromptCompletionProviderDelegate> PromptCompletionProvider<T> {
                     editor.has_non_empty_selection(&editor.display_snapshot(cx))
                 })
             });
-        if has_selection {
+
+        let has_terminal_selection = !terminal_selections_if_panel_open(workspace, cx).is_empty();
+
+        if has_editor_selection || has_terminal_selection {
             entries.push(PromptContextEntry::Action(
                 PromptContextAction::AddSelections,
             ));
@@ -2104,6 +2194,30 @@ fn build_code_label_for_path(
         label.push_str(&format!(" L{}", line_number), variable_highlight_id);
     }
     label.build()
+}
+
+/// Returns terminal selections from all terminal views if the terminal panel is open.
+fn terminal_selections_if_panel_open(workspace: &Entity<Workspace>, cx: &App) -> Vec<String> {
+    let Some(panel) = workspace.read(cx).panel::<TerminalPanel>(cx) else {
+        return Vec::new();
+    };
+
+    // Check if the dock containing this panel is open
+    let position = match TerminalSettings::get_global(cx).dock {
+        TerminalDockPosition::Left => DockPosition::Left,
+        TerminalDockPosition::Bottom => DockPosition::Bottom,
+        TerminalDockPosition::Right => DockPosition::Right,
+    };
+    let dock_is_open = workspace
+        .read(cx)
+        .dock_at_position(position)
+        .read(cx)
+        .is_open();
+    if !dock_is_open {
+        return Vec::new();
+    }
+
+    panel.read(cx).terminal_selections(cx)
 }
 
 fn selection_ranges(

--- a/crates/agent_ui/src/mention_set.rs
+++ b/crates/agent_ui/src/mention_set.rs
@@ -249,7 +249,7 @@ impl MentionSet {
                 debug_panic!("unexpected selection URI");
                 Task::ready(Err(anyhow!("unexpected selection URI")))
             }
-            MentionUri::Terminal => {
+            MentionUri::TerminalSelection => {
                 debug_panic!("unexpected terminal URI");
                 Task::ready(Err(anyhow!("unexpected terminal URI")))
             }

--- a/crates/agent_ui/src/mention_set.rs
+++ b/crates/agent_ui/src/mention_set.rs
@@ -249,6 +249,10 @@ impl MentionSet {
                 debug_panic!("unexpected selection URI");
                 Task::ready(Err(anyhow!("unexpected selection URI")))
             }
+            MentionUri::Terminal => {
+                debug_panic!("unexpected terminal URI");
+                Task::ready(Err(anyhow!("unexpected terminal URI")))
+            }
         };
         let task = cx
             .spawn(async move |_, _| task.await.map_err(|e| e.to_string()))

--- a/crates/agent_ui/src/text_thread_editor.rs
+++ b/crates/agent_ui/src/text_thread_editor.rs
@@ -1761,9 +1761,18 @@ impl TextThreadEditor {
         cx: &mut Context<Self>,
     ) {
         let crease_title = "terminal".to_string();
-        let formatted_text = format!("```terminal\n{}\n```", text);
+        let formatted_text = format!("```console\n{}\n```\n", text);
 
         self.editor.update(cx, |editor, cx| {
+            // Insert newline first if not at the start of a line
+            let point = editor
+                .selections
+                .newest::<Point>(&editor.display_snapshot(cx))
+                .head();
+            if point.column > 0 {
+                editor.insert("\n", window, cx);
+            }
+
             let point = editor
                 .selections
                 .newest::<Point>(&editor.display_snapshot(cx))
@@ -3642,7 +3651,7 @@ mod tests {
                 let text = editor.text(cx);
                 // The text should contain the terminal output wrapped in a code block
                 assert!(
-                    text.contains(&format!("```terminal\n{}\n```", terminal_output)),
+                    text.contains(&format!("```console\n{}\n```", terminal_output)),
                     "Terminal text should be wrapped in code block. Got: {}",
                     text
                 );

--- a/crates/agent_ui/src/text_thread_editor.rs
+++ b/crates/agent_ui/src/text_thread_editor.rs
@@ -64,13 +64,16 @@ use workspace::{
     CollaboratorId,
     searchable::{Direction, SearchableItemHandle},
 };
+
 use workspace::{
     Save, Toast, Workspace,
+    dock::Panel,
     item::{self, FollowableItem, Item},
     notifications::NotificationId,
     pane,
     searchable::{SearchEvent, SearchableItem},
 };
+use terminal_view::{TerminalView, terminal_panel::TerminalPanel};
 use zed_actions::agent::{AddSelectionToThread, PasteRaw, ToggleModelSelector};
 
 use crate::CycleFavoriteModels;
@@ -156,6 +159,14 @@ pub trait AgentPanelDelegate {
         workspace: &mut Workspace,
         selection_ranges: Vec<Range<Anchor>>,
         buffer: Entity<MultiBuffer>,
+        window: &mut Window,
+        cx: &mut Context<Workspace>,
+    );
+
+    fn quote_terminal_text(
+        &self,
+        workspace: &mut Workspace,
+        text: String,
         window: &mut Window,
         cx: &mut Context<Workspace>,
     );
@@ -1487,7 +1498,36 @@ impl TextThreadEditor {
             return;
         };
 
-        let Some((selections, buffer)) = maybe!({
+        // Try terminal selection first (requires focus, so more specific)
+        if let Some(terminal_text) = maybe!({
+            let terminal_panel = workspace.panel::<TerminalPanel>(cx)?;
+
+            if !terminal_panel.read(cx).focus_handle(cx).contains_focused(window, cx) {
+                return None;
+            }
+
+            let terminal_view = terminal_panel.read(cx).pane().and_then(|pane| {
+                pane.read(cx)
+                    .active_item()
+                    .and_then(|t| t.downcast::<TerminalView>())
+            })?;
+
+            terminal_view
+                .read(cx)
+                .terminal()
+                .read(cx)
+                .last_content
+                .selection_text
+                .clone()
+        }) {
+            if !terminal_text.is_empty() {
+                agent_panel_delegate.quote_terminal_text(workspace, terminal_text, window, cx);
+                return;
+            }
+        }
+
+        // Try editor selection
+        if let Some((selections, buffer)) = maybe!({
             let editor = workspace
                 .active_item(cx)
                 .and_then(|item| item.act_as::<Editor>(cx))?;
@@ -1506,15 +1546,11 @@ impl TextThreadEditor {
                     .collect::<Vec<_>>()
             });
             Some((selections, buffer))
-        }) else {
-            return;
-        };
-
-        if selections.is_empty() {
-            return;
+        }) {
+            if !selections.is_empty() {
+                agent_panel_delegate.quote_selection(workspace, selections, buffer, window, cx);
+            }
         }
-
-        agent_panel_delegate.quote_selection(workspace, selections, buffer, window, cx);
     }
 
     /// Handles the SendReviewToAgent action from the ProjectDiff toolbar.
@@ -1711,6 +1747,45 @@ impl TextThreadEditor {
                 editor.insert_creases(vec![crease], cx);
                 editor.fold_at(start_row, window, cx);
             }
+        })
+    }
+
+    pub fn quote_terminal_text(
+        &mut self,
+        text: String,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let crease_title = "terminal".to_string();
+        let formatted_text = format!("```terminal\n{}\n```", text);
+
+        self.editor.update(cx, |editor, cx| {
+            let point = editor
+                .selections
+                .newest::<Point>(&editor.display_snapshot(cx))
+                .head();
+            let start_row = MultiBufferRow(point.row);
+
+            editor.insert(&formatted_text, window, cx);
+
+            let snapshot = editor.buffer().read(cx).snapshot(cx);
+            let anchor_before = snapshot.anchor_after(point);
+            let anchor_after = editor
+                .selections
+                .newest_anchor()
+                .head()
+                .bias_left(&snapshot);
+
+            let fold_placeholder =
+                quote_selection_fold_placeholder(crease_title, cx.entity().downgrade());
+            let crease = Crease::inline(
+                anchor_before..anchor_after,
+                fold_placeholder,
+                render_quote_selection_output_toggle,
+                |_, _, _, _| Empty.into_any(),
+            );
+            editor.insert_creases(vec![crease], cx);
+            editor.fold_at(start_row, window, cx);
         })
     }
 
@@ -3548,4 +3623,31 @@ mod tests {
 
         theme::init(theme::LoadThemes::JustBase, cx);
     }
+
+    #[gpui::test]
+    async fn test_quote_terminal_text(cx: &mut TestAppContext) {
+        let (_context, text_thread_editor, mut cx) = setup_text_thread_editor_text(
+            vec![(Role::User, "")],
+            cx,
+        )
+        .await;
+
+        let terminal_output = "$ ls -la\ntotal 0\ndrwxr-xr-x  2 user user  40 Jan  1 00:00 .";
+
+        text_thread_editor.update_in(&mut cx, |text_thread_editor, window, cx| {
+            text_thread_editor.quote_terminal_text(terminal_output.to_string(), window, cx);
+
+            text_thread_editor.editor.update(cx, |editor, cx| {
+                let text = editor.text(cx);
+                // The text should contain the terminal output wrapped in a code block
+                assert!(
+                    text.contains(&format!("```terminal\n{}\n```", terminal_output)),
+                    "Terminal text should be wrapped in code block. Got: {}",
+                    text
+                );
+            });
+        });
+    }
+
+
 }

--- a/crates/agent_ui/src/text_thread_editor.rs
+++ b/crates/agent_ui/src/text_thread_editor.rs
@@ -65,6 +65,7 @@ use workspace::{
     searchable::{Direction, SearchableItemHandle},
 };
 
+use terminal_view::{TerminalView, terminal_panel::TerminalPanel};
 use workspace::{
     Save, Toast, Workspace,
     dock::Panel,
@@ -73,7 +74,6 @@ use workspace::{
     pane,
     searchable::{SearchEvent, SearchableItem},
 };
-use terminal_view::{TerminalView, terminal_panel::TerminalPanel};
 use zed_actions::agent::{AddSelectionToThread, PasteRaw, ToggleModelSelector};
 
 use crate::CycleFavoriteModels;
@@ -1502,7 +1502,11 @@ impl TextThreadEditor {
         if let Some(terminal_text) = maybe!({
             let terminal_panel = workspace.panel::<TerminalPanel>(cx)?;
 
-            if !terminal_panel.read(cx).focus_handle(cx).contains_focused(window, cx) {
+            if !terminal_panel
+                .read(cx)
+                .focus_handle(cx)
+                .contains_focused(window, cx)
+            {
                 return None;
             }
 
@@ -3626,11 +3630,8 @@ mod tests {
 
     #[gpui::test]
     async fn test_quote_terminal_text(cx: &mut TestAppContext) {
-        let (_context, text_thread_editor, mut cx) = setup_text_thread_editor_text(
-            vec![(Role::User, "")],
-            cx,
-        )
-        .await;
+        let (_context, text_thread_editor, mut cx) =
+            setup_text_thread_editor_text(vec![(Role::User, "")], cx).await;
 
         let terminal_output = "$ ls -la\ntotal 0\ndrwxr-xr-x  2 user user  40 Jan  1 00:00 .";
 
@@ -3648,6 +3649,4 @@ mod tests {
             });
         });
     }
-
-
 }

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -1084,6 +1084,32 @@ impl TerminalPanel {
         self.assistant_enabled
     }
 
+    /// Returns all panes in the terminal panel.
+    pub fn panes(&self) -> Vec<&Entity<Pane>> {
+        self.center.panes()
+    }
+
+    /// Returns all non-empty terminal selections from all terminal views in all panes.
+    pub fn terminal_selections(&self, cx: &App) -> Vec<String> {
+        self.center
+            .panes()
+            .iter()
+            .flat_map(|pane| {
+                pane.read(cx).items().filter_map(|item| {
+                    let terminal_view = item.downcast::<crate::TerminalView>()?;
+                    terminal_view
+                        .read(cx)
+                        .terminal()
+                        .read(cx)
+                        .last_content
+                        .selection_text
+                        .clone()
+                        .filter(|text| !text.is_empty())
+                })
+            })
+            .collect()
+    }
+
     fn is_enabled(&self, cx: &App) -> bool {
         self.workspace
             .upgrade()


### PR DESCRIPTION
Summary

This PR adds the ability to quote terminal selections into Agent threads, similar to how editor selections can be quoted. Users can now select text in the terminal and add it as context to their agent conversation.

### Features

- **Context menu**: Added "Add to Agent Thread" option to the terminal's right-click menu (only shows when text is selected)
- **Keyboard shortcut**: The existing `cmd->` / `ctrl->` shortcut now works in the terminal
- **Collapsed display**: Terminal output appears as a collapsed "Terminal" crease in the chat, just like code references
- **Works with both thread types**: Supports both ACP-style threads (Claude Code) and text threads

### Implementation

- Extended `quote_selection` handler to check for terminal panel focus after checking for editor selections
- Terminal content is formatted as ` ```terminal` code blocks via new `insert_terminal_crease` method
- Refactored crease insertion into `insert_crease_impl` helper to support both code snippets (with `TextSnippet` icon) and terminal output (with `Terminal` icon)
- Added automatic detection and folding of ` ```terminal` blocks in `set_message` so terminal content stays collapsed in sent message history
- Terminal creases use a trailing space instead of newline so cursor behavior matches user expectations

### Demo

1. Select text in terminal
2. Right-click → "Add to Agent Thread" (or press `cmd->`)
3. Terminal content appears as collapsed "Terminal" block in chat
4. Send message - AI receives full terminal output, but chat history shows it collapsed

### General note

I'm new to open source and the codebase in general so let me know if anything should be different! 
I tried to stay in line with other patterns I saw.
I didn't see a way to setup an end to end test with a real terminal so I just added a unit test for the adding of the text to the chat, if it exists and I missed it then I think the test coverage could be improved with a test that uses a real terminal + running the command

<img width="431" height="148" alt="image" src="https://github.com/user-attachments/assets/854732f9-2a7f-4f31-867e-d54af068c97c" />


Release Notes:

- agent: Added the ability to send selections from terminals into the Agent thread