### PR TITLE
project_panel: Fix alignment of folded directory path components

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -5360,6 +5360,7 @@ impl ProjectPanel {
                             "project_panel_path_component_{}_{index}",
                             entry_id.to_usize()
                         )))
+                        .when(index == 0, |this| this.ml_neg_0p5())
                         .px_0p5()
                         .rounded_xs()
                         .hover(|style| style.bg(cx.theme().colors().element_active))


### PR DESCRIPTION
The padding on folded directory path components was causing the first component to be misaligned with regular entry labels. This adds a negative margin to the first component to compensate for the left padding while preserving the hover background.

Before:
<img height="180" alt="before-1" src="https://github.com/user-attachments/assets/5be234a6-4fca-4940-a979-4cfb767875bb" /> <img height="180" alt="before-2" src="https://github.com/user-attachments/assets/1825e12b-eb55-48fe-9b3c-ac52e552581b" />

After:
<img height="180" alt="after-1" src="https://github.com/user-attachments/assets/03b1029d-6664-49bd-9371-680fc912c67c" /> <img height="180" alt="after-2" src="https://github.com/user-attachments/assets/fa4954d7-796c-48f3-8f77-6aaee7bfc35c" />

Release Notes:

- Fixed alignment of folded directory names in project panel.
