### PR TITLE
extension_cli: Validate that all snippets can be parsed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6011,6 +6011,8 @@ dependencies = [
  "rpc",
  "serde",
  "serde_json",
+ "serde_json_lenient",
+ "snippet_provider",
  "theme",
  "tokio",
  "toml 0.8.23",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15422,7 +15422,6 @@ dependencies = [
  "futures 0.3.31",
  "gpui",
  "indoc",
- "log",
  "parking_lot",
  "paths",
  "schemars",

--- a/crates/extension_cli/Cargo.toml
+++ b/crates/extension_cli/Cargo.toml
@@ -25,6 +25,8 @@ reqwest_client.workspace = true
 rpc.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+serde_json_lenient.workspace = true
+snippet_provider.workspace = true
 theme.workspace = true
 tokio = { workspace = true, features = ["full"] }
 toml.workspace = true

--- a/crates/snippet_provider/Cargo.toml
+++ b/crates/snippet_provider/Cargo.toml
@@ -18,7 +18,6 @@ extension.workspace = true
 fs.workspace = true
 futures.workspace = true
 gpui.workspace = true
-log.workspace = true
 parking_lot.workspace = true
 paths.workspace = true
 serde.workspace = true

--- a/crates/snippet_provider/src/lib.rs
+++ b/crates/snippet_provider/src/lib.rs
@@ -15,6 +15,7 @@ use fs::Fs;
 use futures::stream::StreamExt;
 use gpui::{App, AppContext as _, AsyncApp, Context, Entity, Task, WeakEntity};
 pub use registry::*;
+use util::ResultExt;
 
 pub fn init(cx: &mut App) {
     SnippetRegistry::init_global(cx);
@@ -31,30 +32,36 @@ fn file_stem_to_key(stem: &str) -> SnippetKind {
     }
 }
 
-fn file_to_snippets(file_contents: VsSnippetsFile, source: &Path) -> Vec<Arc<Snippet>> {
-    let mut snippets = vec![];
-    for (name, snippet) in file_contents.snippets {
-        let snippet_name = name.clone();
-        let prefixes = snippet
-            .prefix
-            .map_or_else(move || vec![snippet_name], |prefixes| prefixes.into());
-        let description = snippet
-            .description
-            .map(|description| description.to_string());
-        let body = snippet.body.to_string();
-        if let Err(e) = snippet::Snippet::parse(&body) {
-            log::error!("Invalid snippet name '{name}' in {source:?}: {e:#}");
-            continue;
-        }
-        snippets.push(Arc::new(Snippet {
-            body,
-            prefix: prefixes,
-            description,
-            name,
-        }));
-    }
-    snippets
+pub fn file_to_snippets(
+    file_contents: VsSnippetsFile,
+    source: &Path,
+) -> impl Iterator<Item = Result<Arc<Snippet>>> {
+    file_contents
+        .snippets
+        .into_iter()
+        .map(move |(name, snippet)| {
+            let snippet_name = name.clone();
+            let prefixes = snippet
+                .prefix
+                .map_or_else(move || vec![snippet_name], |prefixes| prefixes.into());
+            let description = snippet
+                .description
+                .map(|description| description.to_string());
+            let body = snippet.body.to_string();
+            match snippet::Snippet::parse(&body) {
+                Ok(_) => Ok(Arc::new(Snippet {
+                    body,
+                    prefix: prefixes,
+                    description,
+                    name,
+                })),
+                Err(e) => Err(anyhow::anyhow!(
+                    "Invalid snippet '{name}' in {source:?}: {e:#}"
+                )),
+            }
+        })
 }
+
 // Snippet with all of the metadata
 #[derive(Debug)]
 pub struct Snippet {
@@ -106,7 +113,8 @@ async fn process_updates(
                     return;
                 };
                 let snippets = file_to_snippets(as_json, entry_path.as_path());
-                *snippets_of_kind.entry(entry_path).or_default() = snippets;
+                *snippets_of_kind.entry(entry_path).or_default() =
+                    snippets.map(Result::log_err).flatten().collect();
             } else {
                 snippets_of_kind.remove(&entry_path);
             }

--- a/crates/snippet_provider/src/lib.rs
+++ b/crates/snippet_provider/src/lib.rs
@@ -114,7 +114,7 @@ async fn process_updates(
                 };
                 let snippets = file_to_snippets(as_json, entry_path.as_path());
                 *snippets_of_kind.entry(entry_path).or_default() =
-                    snippets.map(Result::log_err).flatten().collect();
+                    snippets.filter_map(Result::log_err).collect();
             } else {
                 snippets_of_kind.remove(&entry_path);
             }

--- a/crates/snippet_provider/src/registry.rs
+++ b/crates/snippet_provider/src/registry.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use collections::HashMap;
 use gpui::{App, Global, ReadGlobal, UpdateGlobal};
 use parking_lot::RwLock;
+use util::ResultExt;
 
 use crate::{Snippet, SnippetKind, file_stem_to_key};
 
@@ -43,7 +44,9 @@ impl SnippetRegistry {
             .file_stem()
             .and_then(|stem| stem.to_str().and_then(file_stem_to_key));
         let snippets = crate::file_to_snippets(snippets_in_file, file_path);
-        self.snippets.write().insert(kind, snippets);
+        self.snippets
+            .write()
+            .insert(kind, snippets.map(Result::log_err).flatten().collect());
 
         Ok(())
     }

--- a/crates/snippet_provider/src/registry.rs
+++ b/crates/snippet_provider/src/registry.rs
@@ -46,7 +46,7 @@ impl SnippetRegistry {
         let snippets = crate::file_to_snippets(snippets_in_file, file_path);
         self.snippets
             .write()
-            .insert(kind, snippets.map(Result::log_err).flatten().collect());
+            .insert(kind, snippets.filter_map(Result::log_err).collect());
 
         Ok(())
     }


### PR DESCRIPTION
With this, we can now ensure that snippet extensions we publish actually only contain valid snippets.

Release Notes:

- N/A
