### PR TITLE
docs: Remove preview indicator for Tailwind CSS Mode

### DIFF
--- a/docs/src/languages/tailwindcss.md
+++ b/docs/src/languages/tailwindcss.md
@@ -39,7 +39,7 @@ If by default the language server isn't enough to make Tailwind work for a given
 
 Refer to [the Tailwind CSS language server settings docs](https://github.com/tailwindlabs/tailwindcss-intellisense?tab=readme-ov-file#extension-settings) for more information.
 
-### Using Tailwind CSS Mode in CSS Files (Preview)
+### Using Tailwind CSS Mode in CSS Files
 
 Zed includes support for the Tailwind CSS language mode, which provides full CSS IntelliSense support even when using Tailwind-specific at-rules like `@apply`, `@layer`, and `@theme`.
 To use the Tailwind CSS language mode for CSS files, add the following to `languages` section of your `settings.json`:


### PR DESCRIPTION
Removes the preview indicator from the docs, since this is available in stable

Release Notes:

- N/A
