### PR TITLE
Fix Zed not entering disconnected state when remote proxy dies

### DIFF
--- a/crates/remote/src/remote_client.rs
+++ b/crates/remote/src/remote_client.rs
@@ -841,7 +841,7 @@ impl RemoteClient {
                                 })?;
                             }
                         }
-                    } else if exit_code > 0 {
+                    } else {
                         log::error!("proxy process terminated unexpectedly: {exit_code}");
                         this.update(cx, |this, cx| {
                             this.reconnect(cx).ok();


### PR DESCRIPTION
When I kill the remote proxy, it seems like `ssh` exits with code -1. Since that's less than or equal to 0, this means we don't try to restart the connection. The proxy really shouldn't exit for any reason, so let's get rid of this check altogether.

Release Notes:

- N/A
