### PR TITLE
Cap number of saved hang traces at 3

### DIFF
--- a/crates/zed/src/reliability.rs
+++ b/crates/zed/src/reliability.rs
@@ -19,7 +19,6 @@ use crate::STARTUP_TIME;
 const MAX_HANG_TRACES: usize = 3;
 
 pub fn init(client: Arc<Client>, cx: &mut App) {
-    cleanup_old_hang_traces();
     monitor_hangs(cx);
 
     if client.telemetry().diagnostics_enabled() {
@@ -85,6 +84,8 @@ fn monitor_hangs(cx: &App) {
         .spawn({
             let background_executor = background_executor.clone();
             async move {
+                cleanup_old_hang_traces();
+
                 let mut hang_time = None;
 
                 let mut hanging = false;

--- a/crates/zed/src/reliability.rs
+++ b/crates/zed/src/reliability.rs
@@ -145,25 +145,6 @@ fn save_hang_trace(
     background_executor: &gpui::BackgroundExecutor,
     hang_time: chrono::DateTime<chrono::Local>,
 ) {
-    if let Ok(entries) = std::fs::read_dir(paths::hang_traces_dir()) {
-        let mut files: Vec<_> = entries
-            .filter_map(|entry| entry.ok())
-            .filter(|entry| {
-                entry
-                    .path()
-                    .extension()
-                    .is_some_and(|ext| ext == "miniprof")
-            })
-            .collect();
-
-        if files.len() >= MAX_HANG_TRACES {
-            files.sort_by_key(|entry| entry.file_name());
-            for entry in files.iter().take(files.len() - (MAX_HANG_TRACES - 1)) {
-                std::fs::remove_file(entry.path()).log_err();
-            }
-        }
-    }
-
     let thread_timings = background_executor.dispatcher().get_all_timings();
     let thread_timings = thread_timings
         .into_iter()
@@ -187,6 +168,25 @@ fn save_hang_trace(
     else {
         return;
     };
+
+    if let Ok(entries) = std::fs::read_dir(paths::hang_traces_dir()) {
+        let mut files: Vec<_> = entries
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| {
+                entry
+                    .path()
+                    .extension()
+                    .is_some_and(|ext| ext == "miniprof")
+            })
+            .collect();
+
+        if files.len() >= MAX_HANG_TRACES {
+            files.sort_by_key(|entry| entry.file_name());
+            for entry in files.iter().take(files.len() - (MAX_HANG_TRACES - 1)) {
+                std::fs::remove_file(entry.path()).log_err();
+            }
+        }
+    }
 
     std::fs::write(&trace_path, timings)
         .context("hang trace file writing")

--- a/crates/zed/src/reliability.rs
+++ b/crates/zed/src/reliability.rs
@@ -16,7 +16,10 @@ use util::ResultExt;
 
 use crate::STARTUP_TIME;
 
+const MAX_HANG_TRACES: usize = 3;
+
 pub fn init(client: Arc<Client>, cx: &mut App) {
+    cleanup_old_hang_traces();
     monitor_hangs(cx);
 
     if client.telemetry().diagnostics_enabled() {
@@ -115,11 +118,51 @@ fn monitor_hangs(cx: &App) {
         .detach();
 }
 
+fn cleanup_old_hang_traces() {
+    if let Ok(entries) = std::fs::read_dir(paths::hang_traces_dir()) {
+        let mut files: Vec<_> = entries
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| {
+                entry
+                    .path()
+                    .extension()
+                    .is_some_and(|ext| ext == "miniprof")
+            })
+            .collect();
+
+        if files.len() > MAX_HANG_TRACES {
+            files.sort_by_key(|entry| entry.file_name());
+            for entry in files.iter().take(files.len() - MAX_HANG_TRACES) {
+                std::fs::remove_file(entry.path()).log_err();
+            }
+        }
+    }
+}
+
 fn save_hang_trace(
     main_thread_id: ThreadId,
     background_executor: &gpui::BackgroundExecutor,
     hang_time: chrono::DateTime<chrono::Local>,
 ) {
+    if let Ok(entries) = std::fs::read_dir(paths::hang_traces_dir()) {
+        let mut files: Vec<_> = entries
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| {
+                entry
+                    .path()
+                    .extension()
+                    .is_some_and(|ext| ext == "miniprof")
+            })
+            .collect();
+
+        if files.len() >= MAX_HANG_TRACES {
+            files.sort_by_key(|entry| entry.file_name());
+            for entry in files.iter().take(files.len() - (MAX_HANG_TRACES - 1)) {
+                std::fs::remove_file(entry.path()).log_err();
+            }
+        }
+    }
+
     let thread_timings = background_executor.dispatcher().get_all_timings();
     let thread_timings = thread_timings
         .into_iter()


### PR DESCRIPTION
Prevents unbounded grown of the `hang_traces` directory.

Release Notes:

- Fixed excessive disk space usage from the `hang_traces` directory.