### PR TITLE
Fix tool calling with empty call_id on OpenAI-compatible APIs

### DIFF
--- a/crates/language_models/Cargo.toml
+++ b/crates/language_models/Cargo.toml
@@ -63,6 +63,7 @@ tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
 ui.workspace = true
 ui_input.workspace = true
 util.workspace = true
+uuid = { workspace = true, features = ["v4"] }
 vercel = { workspace = true, features = ["schemars"] }
 x_ai = { workspace = true, features = ["schemars"] }
 


### PR DESCRIPTION
Fixes #47696

## Problem

When using Zed agent with enterprise OpenAI-compatible API endpoints (particularly AWS Bedrock-based), tool calls fail with validation errors:
```
Invalid length for parameter messages[3].content[1].toolUse.toolUseId, value: 0, valid min length: 1
Invalid length for parameter messages[3].content[1].toolUse.name, value: 0, valid min length: 1
```

### Root Cause

Some OpenAI-compatible APIs return tool calls with empty `id` and `name` fields. When Zed sends these back to the API as conversation history in subsequent requests, validation fails because these APIs require non-empty strings.

### Evidence from #47696

Zed was **sending** malformed tool calls in conversation history:
```json
"tool_calls": [
  {
    "id": "",  // Empty string causes validation error
    "type": "function",
    "function": {
      "name": "",  // Empty string causes validation error
      "arguments": "{\"path\":\"test\"}"
    }
  }
]
```

## Solution

Generate valid tool call IDs and names when serializing conversation history for API requests:

### Changes
- **Added UUID dependency** - Added `uuid` crate with v4 feature to language_models crate
- **Fixed request serialization** (`into_open_ai`) - Generate IDs/names when tool calls are sent **back to the API** as conversation history (the actual bug)
- **Fixed streaming responses** - Defense-in-depth: also fix empty IDs when receiving streaming responses
- **Fixed non-streaming responses** - Defense-in-depth: also fix empty IDs when receiving non-streaming responses
- **Added logging** - Warning logs when tool names are empty
- **Added tests** - Both response parsing and round-trip serialization tests

### Generated IDs Format
Uses OpenAI's convention: `call_{uuid}` (e.g., `call_123e4567-e89b-12d3-a456-426614174000`)

## Files Changed
- `crates/language_models/Cargo.toml` - Added uuid dependency
- `crates/language_models/src/provider/open_ai.rs` - Fixed tool call ID/name generation and added tests

---

## ⚠️ Remaining Issue: Empty Tool Names

The current PR fixes empty IDs but **only warns** about empty names without fixing them (lines 456-458):

```rust
let mut tool_name = tool_use.name.to_string();
if tool_name.is_empty() {
    log::warn\!("Tool call has empty name when sending to API, this may cause issues");
}
```

This still causes validation failures:
```
Invalid length for parameter messages[1].content[1].toolUse.name, value: 0, valid min length: 1
```

### Suggested Fix for Empty Names

**Option 1: Infer from arguments (best)**
Match the tool call arguments against the `tools` parameter to infer which tool was called:

```rust
if tool_name.is_empty() {
    // Try to infer from arguments by matching against available tools
    if let Ok(args) = serde_json::from_str::<serde_json::Value>(&tool_use.raw_input) {
        tool_name = infer_tool_name_from_args(&args, &request.tools)
            .unwrap_or_else(|| "unknown_tool".to_string());
    } else {
        tool_name = "unknown_tool".to_string();
    }
    log::warn\!("Generated tool name '{}' for empty name", tool_name);
}
```

Helper function:
```rust
fn infer_tool_name_from_args(args: &serde_json::Value, tools: &[LanguageModelTool]) -> Option<String> {
    let arg_keys: HashSet<&str> = args
        .as_object()?
        .keys()
        .map(|s| s.as_str())
        .collect();
    
    let mut best_match = None;
    let mut best_score = 0;
    
    for tool in tools {
        let required: HashSet<&str> = tool.input_schema.required
            .iter()
            .map(|s| s.as_str())
            .collect();
        let all_params: HashSet<&str> = tool.input_schema.properties
            .keys()
            .map(|s| s.as_str())
            .collect();
        
        let common = arg_keys.intersection(&all_params).count();
        let required_satisfied = required.is_subset(&arg_keys);
        
        if required_satisfied && common > best_score {
            best_score = common;
            best_match = Some(tool.name.to_string());
        }
    }
    
    best_match
}
```

**Option 2: Use placeholder (simpler)**
```rust
if tool_name.is_empty() {
    tool_name = "unknown_tool".to_string();
    log::warn\!("Using placeholder 'unknown_tool' for empty tool name");
}
```

### Testing for Empty Names

The test `into_open_ai_generates_ids_for_empty_tool_calls` currently only validates empty IDs with a valid name (`"create_directory"`). Please add a case that tests **both** empty IDs and empty names:

```rust
MessageContent::ToolUse(LanguageModelToolUse {
    id: LanguageModelToolUseId::from(""),  // Empty ID
    name: "".into(),                         // Empty name
    raw_input: r#"{"path":"test"}"#.to_string(),
    input: serde_json::json\!({"path": "test"}),
    is_input_complete: true,
    thought_signature: None,
})
```

Then verify the serialized request has both valid ID **and** name.

---

## Testing Context

Tested with LiteLLM proxy + custom hook that works around these issues. The hook successfully:
- Generates UUIDs for empty IDs
- Infers tool names by matching arguments against tool schemas
- Maintains ID consistency across conversation history

This workaround validates that the approach works end-to-end.