### PR TITLE
extension_ci: Set default target for all jobs

### DIFF
--- a/.github/workflows/extension_tests.yml
+++ b/.github/workflows/extension_tests.yml
@@ -6,6 +6,7 @@ env:
   RUST_BACKTRACE: '1'
   CARGO_INCREMENTAL: '0'
   ZED_EXTENSION_CLI_SHA: 7cfce605704d41ca247e3f84804bf323f6c6caaf
+  CARGO_BUILD_TARGET: wasm32-wasip2
 on:
   workflow_call: {}
 jobs:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20688,6 +20688,7 @@ dependencies = [
  "cargo_metadata",
  "cargo_toml",
  "clap",
+ "extension",
  "gh-workflow",
  "indexmap",
  "indoc",

--- a/crates/extension/src/extension_builder.rs
+++ b/crates/extension/src/extension_builder.rs
@@ -19,7 +19,7 @@ use wasm_encoder::{ComponentSectionId, Encode as _, RawSection, Section as _};
 use wasmparser::Parser;
 
 /// Currently, we compile with Rust's `wasm32-wasip2` target, which works with WASI `preview2` and the component model.
-const RUST_TARGET: &str = "wasm32-wasip2";
+pub const RUST_TARGET: &str = "wasm32-wasip2";
 
 /// Compiling Tree-sitter parsers from C to WASM requires Clang 17, and a WASM build of libc
 /// and clang's runtime library. The `wasi-sdk` provides these binaries.

--- a/tooling/xtask/Cargo.toml
+++ b/tooling/xtask/Cargo.toml
@@ -14,6 +14,7 @@ backtrace.workspace = true
 cargo_metadata.workspace = true
 cargo_toml.workspace = true
 clap = { workspace = true, features = ["derive"] }
+extension.workspace = true
 toml.workspace = true
 indoc.workspace = true
 indexmap.workspace = true

--- a/tooling/xtask/src/tasks/workflows/extension_tests.rs
+++ b/tooling/xtask/src/tasks/workflows/extension_tests.rs
@@ -32,6 +32,10 @@ pub(crate) fn extension_tests() -> Workflow {
         .add_env(("RUST_BACKTRACE", 1))
         .add_env(("CARGO_INCREMENTAL", 0))
         .add_env(("ZED_EXTENSION_CLI_SHA", ZED_EXTENSION_CLI_SHA))
+        .add_env((
+            "CARGO_BUILD_TARGET",
+            extension::extension_builder::RUST_TARGET,
+        ))
         .map(|workflow| {
             jobs.into_iter()
                 .chain([tests_pass])


### PR DESCRIPTION
Following the changes to the namespace caching, CI in the extensions broke because cache conflicts arose there seemingly. Trying to set the target here more explicitly in an effort to fix this.

Release Notes:

- N/A
