### PR TITLE
extension_ci: Ensure specified target is installed

### DIFF
--- a/.github/workflows/extension_tests.yml
+++ b/.github/workflows/extension_tests.yml
@@ -63,6 +63,9 @@ jobs:
       with:
         cache: rust
         path: ~/.rustup
+    - name: extension_tests::install_rust_target
+      run: rustup target add wasm32-wasip2
+      shell: bash -euxo pipefail {0}
     - name: steps::cargo_fmt
       run: cargo fmt --all -- --check
       shell: bash -euxo pipefail {0}

--- a/tooling/xtask/src/tasks/workflows/extension_tests.rs
+++ b/tooling/xtask/src/tasks/workflows/extension_tests.rs
@@ -45,6 +45,13 @@ pub(crate) fn extension_tests() -> Workflow {
         })
 }
 
+fn install_rust_target() -> Step<Run> {
+    named::bash(format!(
+        "rustup target add {rust_target}",
+        rust_target = extension::extension_builder::RUST_TARGET
+    ))
+}
+
 fn run_clippy() -> Step<Run> {
     named::bash("cargo clippy --release --all-targets --all-features -- --deny warnings")
 }
@@ -56,6 +63,7 @@ fn check_rust() -> NamedJob {
         .timeout_minutes(6u32)
         .add_step(steps::checkout_repo())
         .add_step(steps::cache_rust_dependencies_namespace())
+        .add_step(install_rust_target())
         .add_step(steps::cargo_fmt())
         .add_step(run_clippy())
         .add_step(steps::cargo_install_nextest())


### PR DESCRIPTION
Follow up to #47714 because it is still broken for the extension workflows post #47699 cache introduction. Keeping the cache around though in the hopes that it will now finally work.

Release Notes:

- N/A
