### PR TITLE
terminal_view: Add support for opening the terminal in the current file directory

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1591,15 +1591,18 @@
     // Default height when the terminal is docked to the bottom.
     "default_height": 320,
     // What working directory to use when launching the terminal.
-    // May take 4 values:
-    // 1. Use the current file's project directory. Fallback to the
+    // May take 5 values:
+    // 1. Use the current file's directory, falling back to the project
+    //    directory, then the first project in the workspace.
+    //      "working_directory": "current_file_directory"
+    // 2. Use the current file's project directory. Fallback to the
     //    first project directory strategy if unsuccessful
     //      "working_directory": "current_project_directory"
-    // 2. Use the first project in this workspace's directory
+    // 3. Use the first project in this workspace's directory
     //      "working_directory": "first_project_directory"
-    // 3. Always use this platform's home directory (if we can find it)
+    // 4. Always use this platform's home directory (if we can find it)
     //     "working_directory": "always_home"
-    // 4. Always use a specific directory. This value will be shell expanded.
+    // 5. Always use a specific directory. This value will be shell expanded.
     //    If this path is not a valid directory the terminal will default to
     //    this platform's home directory  (if we can find it)
     //      "working_directory": {

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -26,7 +26,7 @@ pub struct Terminals {
 }
 
 impl Project {
-    pub fn active_file_directory(&self, cx: &App) -> Option<PathBuf> {
+    pub fn active_entry_directory(&self, cx: &App) -> Option<PathBuf> {
         let entry_id = self.active_entry()?;
         let worktree = self.worktree_for_entry(entry_id, cx)?;
         let worktree = worktree.read(cx);

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -26,6 +26,20 @@ pub struct Terminals {
 }
 
 impl Project {
+    pub fn active_file_directory(&self, cx: &App) -> Option<PathBuf> {
+        let entry_id = self.active_entry()?;
+        let worktree = self.worktree_for_entry(entry_id, cx)?;
+        let worktree = worktree.read(cx);
+        let entry = worktree.entry_for_id(entry_id)?;
+
+        let absolute_path = worktree.absolutize(entry.path.as_ref());
+        if entry.is_dir() {
+            Some(absolute_path)
+        } else {
+            absolute_path.parent().map(|p| p.to_path_buf())
+        }
+    }
+
     pub fn active_project_directory(&self, cx: &App) -> Option<Arc<Path>> {
         self.active_entry()
             .and_then(|entry_id| self.worktree_for_entry(entry_id, cx))

--- a/crates/settings_content/src/terminal.rs
+++ b/crates/settings_content/src/terminal.rs
@@ -219,6 +219,9 @@ pub enum Shell {
 #[strum_discriminants(derive(strum::VariantArray, strum::VariantNames, strum::FromRepr))]
 #[serde(rename_all = "snake_case")]
 pub enum WorkingDirectory {
+    /// Use the current file's directory, falling back to the project directory,
+    /// then the first project in the workspace.
+    CurrentFileDirectory,
     /// Use the current file's project directory. Fallback to the
     /// first project directory strategy if unsuccessful.
     CurrentProjectDirectory,

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -5727,6 +5727,9 @@ fn terminal_page() -> SettingsPage {
                                     .working_directory
                                     .get_or_insert_with(|| settings::WorkingDirectory::CurrentProjectDirectory);
                                 *settings_value = match value {
+                                    settings::WorkingDirectoryDiscriminants::CurrentFileDirectory => {
+                                        settings::WorkingDirectory::CurrentFileDirectory
+                                    },
                                     settings::WorkingDirectoryDiscriminants::CurrentProjectDirectory => {
                                         settings::WorkingDirectory::CurrentProjectDirectory
                                     }
@@ -5762,6 +5765,7 @@ fn terminal_page() -> SettingsPage {
                     fields: dynamic_variants::<settings::WorkingDirectory>()
                         .into_iter()
                         .map(|variant| match variant {
+                            settings::WorkingDirectoryDiscriminants::CurrentFileDirectory => vec![],
                             settings::WorkingDirectoryDiscriminants::CurrentProjectDirectory => vec![],
                             settings::WorkingDirectoryDiscriminants::FirstProjectDirectory => vec![],
                             settings::WorkingDirectoryDiscriminants::AlwaysHome => vec![],

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -1593,7 +1593,7 @@ pub(crate) fn default_working_directory(workspace: &Workspace, cx: &App) -> Opti
         WorkingDirectory::CurrentFileDirectory => workspace
             .project()
             .read(cx)
-            .active_file_directory(cx)
+            .active_entry_directory(cx)
             .or_else(|| current_project_directory(workspace, cx)),
         WorkingDirectory::CurrentProjectDirectory => current_project_directory(workspace, cx),
         WorkingDirectory::FirstProjectDirectory => first_project_directory(workspace, cx),
@@ -1744,9 +1744,9 @@ mod tests {
         });
     }
 
-    // CurrentFileDirectory: No active entry -> returns None
+    // active_entry_directory: No active entry -> returns None (used by CurrentFileDirectory)
     #[gpui::test]
-    async fn current_file_directory_no_active_entry(cx: &mut TestAppContext) {
+    async fn active_entry_directory_no_active_entry(cx: &mut TestAppContext) {
         let (project, _workspace) = init_test(cx).await;
 
         let (_wt, _entry) = create_folder_wt(project.clone(), "/root/", cx).await;
@@ -1754,14 +1754,14 @@ mod tests {
         cx.update(|cx| {
             assert!(project.read(cx).active_entry().is_none());
 
-            let res = project.read(cx).active_file_directory(cx);
+            let res = project.read(cx).active_entry_directory(cx);
             assert_eq!(res, None);
         });
     }
 
-    // CurrentFileDirectory: Active entry is file -> returns parent directory
+    // active_entry_directory: Active entry is file -> returns parent directory (used by CurrentFileDirectory)
     #[gpui::test]
-    async fn current_file_directory_active_file(cx: &mut TestAppContext) {
+    async fn active_entry_directory_active_file(cx: &mut TestAppContext) {
         let (project, _workspace) = init_test(cx).await;
 
         let (wt, _entry) = create_folder_wt(project.clone(), "/root/", cx).await;
@@ -1786,21 +1786,21 @@ mod tests {
         insert_active_entry_for(wt, entry, project.clone(), cx);
 
         cx.update(|cx| {
-            let res = project.read(cx).active_file_directory(cx);
+            let res = project.read(cx).active_entry_directory(cx);
             assert_eq!(res, Some(Path::new("/root/src").to_path_buf()));
         });
     }
 
-    // CurrentFileDirectory: Active entry is directory -> returns that directory
+    // active_entry_directory: Active entry is directory -> returns that directory (used by CurrentFileDirectory)
     #[gpui::test]
-    async fn current_file_directory_active_dir(cx: &mut TestAppContext) {
+    async fn active_entry_directory_active_dir(cx: &mut TestAppContext) {
         let (project, _workspace) = init_test(cx).await;
 
         let (wt, entry) = create_folder_wt(project.clone(), "/root/", cx).await;
         insert_active_entry_for(wt, entry, project.clone(), cx);
 
         cx.update(|cx| {
-            let res = project.read(cx).active_file_directory(cx);
+            let res = project.read(cx).active_entry_directory(cx);
             assert_eq!(res, Some(Path::new("/root/").to_path_buf()));
         });
     }

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -4109,7 +4109,17 @@ Example command to set the title: `echo -e "\e]2;New Title\007";`
 
 **Options**
 
-1. Use the current file's project directory. Fallback to the first project directory strategy if unsuccessful.
+1. Use the directory of the currently open file, falling back to the project directory, then the first project in the workspace.
+
+```json [settings]
+{
+  "terminal": {
+    "working_directory": "current_file_directory"
+  }
+}
+```
+
+2. Use the current file's project directory. Fallback to the first project directory strategy if unsuccessful.
 
 ```json [settings]
 {
@@ -4119,7 +4129,7 @@ Example command to set the title: `echo -e "\e]2;New Title\007";`
 }
 ```
 
-2. Use the first project in this workspace's directory. Fallback to using this platform's home directory.
+3. Use the first project in this workspace's directory. Fallback to using this platform's home directory.
 
 ```json [settings]
 {
@@ -4129,7 +4139,7 @@ Example command to set the title: `echo -e "\e]2;New Title\007";`
 }
 ```
 
-3. Always use this platform's home directory if it can be found.
+4. Always use this platform's home directory if it can be found.
 
 ```json [settings]
 {
@@ -4139,7 +4149,7 @@ Example command to set the title: `echo -e "\e]2;New Title\007";`
 }
 ```
 
-4. Always use a specific directory. This value will be shell expanded. If this path is not a valid directory the terminal will default to this platform's home directory.
+5. Always use a specific directory. This value will be shell expanded. If this path is not a valid directory the terminal will default to this platform's home directory.
 
 ```json [settings]
 {

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -4109,7 +4109,7 @@ Example command to set the title: `echo -e "\e]2;New Title\007";`
 
 **Options**
 
-1. Use the directory of the currently open file, falling back to the project directory, then the first project in the workspace.
+1. Use the current file's directory, falling back to the project directory, then the first project in the workspace.
 
 ```json [settings]
 {

--- a/docs/src/terminal.md
+++ b/docs/src/terminal.md
@@ -60,8 +60,8 @@ Control where new terminals start:
 
 | Value                                         | Behavior                                                                                                                      |
 | --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `"current_file_directory"`                    | Uses the directory of the currently open file, falling back to the project directory, then the first project in the workspace |
-| `"current_project_directory"`                 | Uses the project directory of the currently open file (default)                                                               |
+| `"current_file_directory"`                    | Uses the current file's directory, falling back to the project directory, then the first project in the workspace             |
+| `"current_project_directory"`                 | Uses the current file's project directory (default)                                                                           |
 | `"first_project_directory"`                   | Uses the first project in your workspace                                                                                      |
 | `"always_home"`                               | Always starts in your home directory                                                                                          |
 | `{ "always": { "directory": "~/projects" } }` | Always starts in a specific directory                                                                                         |

--- a/docs/src/terminal.md
+++ b/docs/src/terminal.md
@@ -58,13 +58,13 @@ To pass arguments to your shell:
 
 Control where new terminals start:
 
-| Value                                         | Behavior                                                                                     |
-| --------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| `"current_file_directory"`                    | Uses the directory of the currently open file, falling back to the project directory         |
-| `"current_project_directory"`                 | Uses the project directory of the currently open file (default)                              |
-| `"first_project_directory"`                   | Uses the first project in your workspace                                                     |
-| `"always_home"`                               | Always starts in your home directory                                                         |
-| `{ "always": { "directory": "~/projects" } }` | Always starts in a specific directory                                                        |
+| Value                                         | Behavior                                                                                                                      |
+| --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `"current_file_directory"`                    | Uses the directory of the currently open file, falling back to the project directory, then the first project in the workspace |
+| `"current_project_directory"`                 | Uses the project directory of the currently open file (default)                                                               |
+| `"first_project_directory"`                   | Uses the first project in your workspace                                                                                      |
+| `"always_home"`                               | Always starts in your home directory                                                                                          |
+| `{ "always": { "directory": "~/projects" } }` | Always starts in a specific directory                                                                                         |
 
 ```json [settings]
 {

--- a/docs/src/terminal.md
+++ b/docs/src/terminal.md
@@ -58,12 +58,13 @@ To pass arguments to your shell:
 
 Control where new terminals start:
 
-| Value                                         | Behavior                                                        |
-| --------------------------------------------- | --------------------------------------------------------------- |
-| `"current_project_directory"`                 | Uses the project directory of the currently open file (default) |
-| `"first_project_directory"`                   | Uses the first project in your workspace                        |
-| `"always_home"`                               | Always starts in your home directory                            |
-| `{ "always": { "directory": "~/projects" } }` | Always starts in a specific directory                           |
+| Value                                         | Behavior                                                                                     |
+| --------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `"current_file_directory"`                    | Uses the directory of the currently open file, falling back to the project directory         |
+| `"current_project_directory"`                 | Uses the project directory of the currently open file (default)                              |
+| `"first_project_directory"`                   | Uses the first project in your workspace                                                     |
+| `"always_home"`                               | Always starts in your home directory                                                         |
+| `{ "always": { "directory": "~/projects" } }` | Always starts in a specific directory                                                        |
 
 ```json [settings]
 {

--- a/docs/src/terminal.md
+++ b/docs/src/terminal.md
@@ -58,13 +58,13 @@ To pass arguments to your shell:
 
 Control where new terminals start:
 
-| Value                                         | Behavior                                                                                                                      |
-| --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `"current_file_directory"`                    | Uses the current file's directory, falling back to the project directory, then the first project in the workspace             |
-| `"current_project_directory"`                 | Uses the current file's project directory (default)                                                                           |
-| `"first_project_directory"`                   | Uses the first project in your workspace                                                                                      |
-| `"always_home"`                               | Always starts in your home directory                                                                                          |
-| `{ "always": { "directory": "~/projects" } }` | Always starts in a specific directory                                                                                         |
+| Value                                         | Behavior                                                                                                          |
+| --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `"current_file_directory"`                    | Uses the current file's directory, falling back to the project directory, then the first project in the workspace |
+| `"current_project_directory"`                 | Uses the current file's project directory (default)                                                               |
+| `"first_project_directory"`                   | Uses the first project in your workspace                                                                          |
+| `"always_home"`                               | Always starts in your home directory                                                                              |
+| `{ "always": { "directory": "~/projects" } }` | Always starts in a specific directory                                                                             |
 
 ```json [settings]
 {


### PR DESCRIPTION
Closes #14863

Changes:
- Added `CurrentFileDirectory` variant to the `WorkingDirectory` enum.
- New terminals now open in the directory of the currently active file when this option is set.
- Falls back to project directory, then first workspace directory if no file is active.

Release Notes:

- Added `current_file_directory` option for terminal's `working_directory` setting. Set `"working_directory": current_file_directory"` to open new terminals in the directory of your currently open file.

---

Still relatively new to Rust, so happy to receive any feedback! 😁
