### PR TITLE
git_ui: Align repo and branch pickers

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -5775,7 +5775,7 @@ impl RenderOnce for PanelRepoFooter {
                 let project = project;
                 move |window, cx| {
                     let project = project.clone()?;
-                    Some(cx.new(|cx| RepositorySelector::new(project, rems(16.), window, cx)))
+                    Some(cx.new(|cx| RepositorySelector::new(project, rems(20.), window, cx)))
                 }
             })
             .trigger_with_tooltip(
@@ -5783,6 +5783,10 @@ impl RenderOnce for PanelRepoFooter {
                 Tooltip::text("Switch Active Repository"),
             )
             .anchor(Corner::BottomLeft)
+            .offset(gpui::Point {
+                x: px(0.0),
+                y: px(-2.0),
+            })
             .into_any_element();
 
         let branch_selector_button = Button::new("branch-selector", truncated_branch_name)

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -35,7 +35,7 @@ use git::{
     StashApply, StashPop, TrashUntrackedFiles, UnstageAll,
 };
 use gpui::{
-    Action, AsyncApp, AsyncWindowContext, Bounds, ClickEvent, Corner, DismissEvent, Entity,
+    Action, AsyncApp, AsyncWindowContext, Bounds, ClickEvent, Corner, DismissEvent, Empty, Entity,
     EventEmitter, FocusHandle, Focusable, KeyContext, MouseButton, MouseDownEvent, Point,
     PromptLevel, ScrollStrategy, Subscription, Task, UniformListScrollHandle, WeakEntity, actions,
     anchored, deferred, point, size, uniform_list,
@@ -5767,8 +5767,7 @@ impl RenderOnce for PanelRepoFooter {
 
         let repo_selector_trigger = Button::new("repo-selector", truncated_repo_name)
             .size(ButtonSize::None)
-            .label_size(LabelSize::Small)
-            .color(Color::Muted);
+            .label_size(LabelSize::Small);
 
         let repo_selector = PopoverMenu::new("repository-switcher")
             .menu({
@@ -5779,8 +5778,16 @@ impl RenderOnce for PanelRepoFooter {
                 }
             })
             .trigger_with_tooltip(
-                repo_selector_trigger.disabled(single_repo).truncate(true),
-                Tooltip::text("Switch Active Repository"),
+                repo_selector_trigger
+                    .when(single_repo, |this| this.disabled(true).color(Color::Muted))
+                    .truncate(true),
+                move |_, cx| {
+                    if single_repo {
+                        cx.new(|_| Empty).into()
+                    } else {
+                        Tooltip::simple("Switch Active Repository", cx)
+                    }
+                },
             )
             .anchor(Corner::BottomLeft)
             .offset(gpui::Point {

--- a/crates/git_ui/src/repository_selector.rs
+++ b/crates/git_ui/src/repository_selector.rs
@@ -66,6 +66,7 @@ impl RepositorySelector {
             Picker::uniform_list(delegate, window, cx)
                 .widest_item(widest_item_ix)
                 .max_height(Some(rems(20.).into()))
+                .show_scrollbar(true)
         });
 
         RepositorySelector { picker, width }

--- a/crates/git_ui/src/repository_selector.rs
+++ b/crates/git_ui/src/repository_selector.rs
@@ -1,13 +1,11 @@
 use crate::git_status_icon;
 use git::status::{FileStatus, StatusCode, TrackedStatus, UnmergedStatus, UnmergedStatusCode};
-use gpui::{
-    AnyElement, App, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable, Task, WeakEntity,
-};
+use gpui::{App, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable, Task, WeakEntity};
 use itertools::Itertools;
 use picker::{Picker, PickerDelegate, PickerEditorPosition};
 use project::{Project, git_store::Repository};
 use std::sync::Arc;
-use ui::{ListHeader, ListItem, ListItemSpacing, prelude::*};
+use ui::{ListItem, ListItemSpacing, prelude::*};
 use workspace::{ModalView, Workspace};
 
 pub fn register(workspace: &mut Workspace) {
@@ -236,18 +234,6 @@ impl PickerDelegate for RepositorySelectorDelegate {
             .ok();
     }
 
-    fn render_header(
-        &self,
-        _window: &mut Window,
-        _cx: &mut Context<Picker<Self>>,
-    ) -> Option<AnyElement> {
-        Some(
-            ListHeader::new("Repositories")
-                .inset(true)
-                .into_any_element(),
-        )
-    }
-
     fn render_match(
         &self,
         ix: usize,
@@ -264,25 +250,22 @@ impl PickerDelegate for RepositorySelectorDelegate {
             .as_ref()
             .is_some_and(|active| active == repo_info);
 
-        let branch_name = repo.branch.as_ref().map(|b| b.name().to_string());
-
         let mut item = ListItem::new(ix)
             .inset(true)
             .spacing(ListItemSpacing::Sparse)
             .toggle_state(selected)
-            .when(is_active, |item| {
-                item.start_slot(Icon::new(IconName::Check).color(Color::Accent))
-            })
-            .child(v_flex().child(Label::new(display_name)).when_some(
-                branch_name,
-                |el, branch| {
-                    el.child(
-                        Label::new(branch)
-                            .size(LabelSize::Small)
-                            .color(Color::Muted),
-                    )
-                },
-            ));
+            .child(
+                h_flex()
+                    .gap_1()
+                    .child(Label::new(display_name))
+                    .when(is_active, |this| {
+                        this.child(
+                            Icon::new(IconName::Check)
+                                .size(IconSize::Small)
+                                .color(Color::Accent),
+                        )
+                    }),
+            );
 
         if summary.count > 0 {
             let status = if summary.conflict > 0 {
@@ -301,13 +284,12 @@ impl PickerDelegate for RepositorySelectorDelegate {
                     worktree_status: StatusCode::Unmodified,
                 })
             } else {
-                // Added or untracked files
                 FileStatus::Tracked(TrackedStatus {
                     index_status: StatusCode::Added,
                     worktree_status: StatusCode::Unmodified,
                 })
             };
-            item = item.end_slot(git_status_icon(status));
+            item = item.end_slot(div().pr_2().child(git_status_icon(status)));
         }
 
         Some(item)

--- a/crates/git_ui/src/repository_selector.rs
+++ b/crates/git_ui/src/repository_selector.rs
@@ -228,7 +228,11 @@ impl PickerDelegate for RepositorySelectorDelegate {
         _window: &mut Window,
         _cx: &mut Context<Picker<Self>>,
     ) -> Option<AnyElement> {
-        Some(ListHeader::new("Repositories").inset(true).into_any_element())
+        Some(
+            ListHeader::new("Repositories")
+                .inset(true)
+                .into_any_element(),
+        )
     }
 
     fn render_match(


### PR DESCRIPTION
When working in a workspace with multiple repositories, the git panel provides a repository picker to switch between them. However, there was no visual indication of which repositories have uncommitted changes: users had to either select each repository individually or check the project panel where modified directories are highlighted.

This change adds git status icons to the repository picker, allowing users to see at a glance which repositories contain changes (modified, added, deleted, or conflicted files). The icons use the same visual language already established for file status throughout the git panel.

Additionally, the repository picker now matches the branch picker's styling for visual consistency:
- Added "Repositories" header
- Aligned popover width and positioning
- Added scrollbar
- Added check icon next to currently selected repo
- Added selected branch under repo list item
- Sort by display name is now case insensitive

Before:

<img width="1200" height="815" alt="Screenshot 2026-01-27 at 11 43 55" src="https://github.com/user-attachments/assets/12c1008b-4724-44bf-80c9-e9ad97755090" />

After:

<img width="1761" height="1196" alt="Screenshot 2026-01-27 at 14 07 52" src="https://github.com/user-attachments/assets/cd778f42-ade0-4da0-9732-2d8631c04124" />


Branch picker for style reference:

<img width="1200" height="815" alt="Screenshot 2026-01-27 at 11 44 03" src="https://github.com/user-attachments/assets/369b0d29-8fed-4293-98c2-52c2d780fe9a" />

Release Notes:

- Git: Improved the project picker in the panel by also displaying the GIt status icon on them, to clearly indicate which repos have changes.