### PR TITLE
Fix VSCode tasks.json parsing for tasks without explicit labels

### DIFF
--- a/crates/task/test_data/tasks-without-labels.json
+++ b/crates/task/test_data/tasks-without-labels.json
@@ -1,0 +1,22 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "npm",
+      "script": "start"
+    },
+    {
+      "label": "Explicit Label",
+      "type": "npm",
+      "script": "test"
+    },
+    {
+      "type": "gulp",
+      "task": "build"
+    },
+    {
+      "type": "shell",
+      "command": "echo hello"
+    }
+  ]
+}


### PR DESCRIPTION
Implements automatic label generation for VSCode tasks that don't have explicit 'label' fields, matching VSCode's behavior.

Changes:
- Made label field optional in VsCodeTaskDefinition deserialization
- Implemented custom deserializer to auto-generate labels:
  - npm tasks: 'npm: {script}' (e.g., 'npm: start')
  - shell tasks: first word of command (e.g., 'echo')
  - gulp tasks: 'gulp: {task}' (e.g., 'gulp: build')
  - fallback: 'Untitled Task'
- Added test data file with tasks without labels
- Added test cases

Closes #47749

Release Notes:

- Fixed: VSCode tasks.json files with tasks missing explicit `label` fields now parse correctly. Labels are auto-generated matching VSCode's behavior (e.g., "npm: start").
