### PR TITLE
editor: Stop updating IME position on every selection change

### DIFF
--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -895,8 +895,12 @@ impl WaylandWindowStatePtr {
         let mut bounds: Option<Bounds<Pixels>> = None;
         if let Some(mut input_handler) = state.input_handler.take() {
             drop(state);
-            if let Some(selection) = input_handler.marked_text_range() {
-                bounds = input_handler.bounds_for_range(selection.start..selection.start);
+            if let Some(selection) = input_handler.selected_text_range(true) {
+                bounds = input_handler.bounds_for_range(if selection.reversed {
+                    selection.range.start..selection.range.start
+                } else {
+                    selection.range.end..selection.range.end
+                });
             }
             self.state.borrow_mut().input_handler = Some(input_handler);
         }


### PR DESCRIPTION
Previously, selections_did_change() would invalidate character coordinates on every update, causing the IME candidate window to jump during composition. Removing this call stabilizes the IME panel while typing and preserves correct caret anchoring.

Release Notes:

- Fixed an issue where the IME candidate window could jump during text composition.

### Problem

On Windows, the IME candidate window used to jump around during typing when there was an active selection. This happened because selections_did_change() would invalidate character coordinates on every selection update, causing update_ime_position() to recalculate the caret position each keystroke.

### Solution

Stop calling invalidate_character_coordinates() on every selection change. Instead, the IME candidate window now anchors to the caret at the start of composition, remaining stable throughout typing.

---

**GIF 1 – Before Fix:**

> Shows the IME candidate window jumping around while typing, even when the caret should remain stable. This happens because the selection updates trigger recalculation of the caret position on every keystroke.

![zed-IME-1](https://github.com/user-attachments/assets/aa89f876-b57c-4f30-aaf5-82f031a14d46)


**GIF 2 – After Fix:**

> Shows the IME candidate window staying anchored at the correct caret position while typing, providing a stable and smooth input experience. The selection updates no longer cause the candidate window to jump.

![zed-IME-2](https://github.com/user-attachments/assets/cc9c4cf0-9bfa-4753-a6e4-97b9e2eed2a7)

