### PR TITLE
agent_ui: Fix inline assistant line height

### DIFF
--- a/crates/agent_ui/src/inline_prompt_editor.rs
+++ b/crates/agent_ui/src/inline_prompt_editor.rs
@@ -1118,14 +1118,13 @@ impl<T: 'static> PromptEditor<T> {
             .child({
                 let settings = ThemeSettings::get_global(cx);
                 let font_size = settings.buffer_font_size(cx);
-                let line_height = font_size * 1.2;
 
                 let text_style = TextStyle {
                     color: colors.editor_foreground,
                     font_family: settings.buffer_font.family.clone(),
                     font_features: settings.buffer_font.features.clone(),
                     font_size: font_size.into(),
-                    line_height: line_height.into(),
+                    line_height: relative(settings.buffer_line_height.value()),
                     ..Default::default()
                 };
 


### PR DESCRIPTION
This makes the inline assistant editor use the line height value configured in the settings, and fixes cut-off button creases:

| Before | After |
|--------|--------|
| <img width="656" height="276" alt="Screenshot 2026-01-27 at 11  55@2x" src="https://github.com/user-attachments/assets/fbb19e54-6663-4f7e-b706-b012fbfa2c99" /> | <img width="656" height="274" alt="Screenshot 2026-01-27 at 11  54@2x" src="https://github.com/user-attachments/assets/4577b752-3e18-45c7-9657-02919047f8ba" /> | 

Release Notes:

- Agent: Fixed cut-off mention creases in the inline assistant.
