### PR TITLE
gpui: Add `min_size` and `max_size` style methods

### DIFF
--- a/crates/gpui_macros/src/styles.rs
+++ b/crates/gpui_macros/src/styles.rs
@@ -915,8 +915,12 @@ fn box_prefixes() -> Vec<BoxStylePrefix> {
             fields: vec![quote! {size.width}, quote! {size.height}],
             doc_string_prefix: "Sets the width and height of the element.",
         },
-        // TODO: These don't use the same size ramp as the others
-        // see https://tailwindcss.com/docs/max-width
+        BoxStylePrefix {
+            prefix: "min_size",
+            auto_allowed: true,
+            fields: vec![quote! {min_size.width}, quote! {min_size.height}],
+            doc_string_prefix: "Sets the minimum width and height of the element.",
+        },
         BoxStylePrefix {
             prefix: "min_w",
             auto_allowed: true,
@@ -930,6 +934,12 @@ fn box_prefixes() -> Vec<BoxStylePrefix> {
             auto_allowed: true,
             fields: vec![quote! { min_size.height }],
             doc_string_prefix: "Sets the minimum height of the element. [Docs](https://tailwindcss.com/docs/min-height)",
+        },
+        BoxStylePrefix {
+            prefix: "max_size",
+            auto_allowed: true,
+            fields: vec![quote! {max_size.width}, quote! {max_size.height}],
+            doc_string_prefix: "Sets the maximum width and height of the element.",
         },
         // TODO: These don't use the same size ramp as the others
         // see https://tailwindcss.com/docs/max-width


### PR DESCRIPTION
The same way you can use `size` when width and height have the same value, it should also be possible to write `min_size` and `max_size`. This PR adds these two methods, which are also supported in Tailwind (but not documented in v4, surprisingly!).

Release Notes:

- N/A
