### PR TITLE
More permissions to GitHub duplicates bot

### DIFF
--- a/.github/workflows/identify_potential_duplicate_issues.yml
+++ b/.github/workflows/identify_potential_duplicate_issues.yml
@@ -24,6 +24,7 @@ jobs:
     permissions:
       contents: read
       issues: read
+      id-token: write
 
     steps:
       - name: Get github app token
@@ -115,7 +116,7 @@ jobs:
           steps.check-type.outputs.is_target_type == 'true' &&
           steps.check-staff.outputs.is_staff == 'false'
         id: analyze
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@231bd75b7196d48291c1498f1c6d277c2810d9a3 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY_ISSUE_DEDUP }}
           github_token: ${{ steps.get-app-token.outputs.token }}


### PR DESCRIPTION
The claude code action insists on needing `id-token: write` despite us using `github_token`, so maybe I misread the
[FAQ](https://github.com/anthropics/claude-code-action/blob/main/docs/faq.md#why-am-i-getting-oidc-authentication-errors) earlier. Pinning the sha of the currently-used version of the action for safety's sake.

Release Notes:

- N/A
