### PR TITLE
agent_ui: Improve image preview on mention hover

### DIFF
--- a/crates/agent_ui/src/mention_set.rs
+++ b/crates/agent_ui/src/mention_set.rs
@@ -1036,9 +1036,13 @@ struct ImageHover {
 }
 
 impl Render for ImageHover {
-    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         if let Some(image) = self.image.clone() {
-            gpui::img(image).max_w_96().max_h_96().into_any_element()
+            div()
+                .p_1p5()
+                .elevation_2(cx)
+                .child(gpui::img(image).h_auto().max_w_96().rounded_sm())
+                .into_any_element()
         } else {
             gpui::Empty.into_any_element()
         }


### PR DESCRIPTION
This PR improves the hover tooltip container for displaying a preview of the mentioned image in the agent panel.

<img width="600" height="414" alt="Screenshot 2026-01-27 at 1  03 2@2x" src="https://github.com/user-attachments/assets/f5a6f160-6abf-4c3c-8375-4613f4948360" />

Release Notes:

- N/A
