### PR TITLE
zeta2: Remove `experimental_edit_prediction_context_retrieval` setting

### DIFF
--- a/crates/edit_prediction/src/edit_prediction.rs
+++ b/crates/edit_prediction/src/edit_prediction.rs
@@ -34,7 +34,7 @@ use project::{Project, ProjectPath, WorktreeId};
 use release_channel::AppVersion;
 use semver::Version;
 use serde::de::DeserializeOwned;
-use settings::{EditPredictionProvider, SettingsStore, update_settings_file};
+use settings::{EditPredictionProvider, update_settings_file};
 use std::collections::{VecDeque, hash_map};
 use text::Edit;
 use workspace::Workspace;
@@ -149,7 +149,6 @@ pub struct EditPredictionStore {
     llm_token: LlmApiToken,
     _llm_token_subscription: Subscription,
     projects: HashMap<EntityId, ProjectState>,
-    use_context: bool,
     update_required: bool,
     edit_prediction_model: EditPredictionModel,
     pub sweep_ai: SweepAi,
@@ -610,11 +609,10 @@ impl EditPredictionStore {
         })
         .detach();
 
-        let mut this = Self {
+        let this = Self {
             projects: HashMap::default(),
             client,
             user_store,
-            use_context: false,
             llm_token,
             _llm_token_subscription: cx.subscribe(
                 &refresh_llm_token_listener,
@@ -645,19 +643,6 @@ impl EditPredictionStore {
             },
         };
 
-        this.configure_context_retrieval(cx);
-        let weak_this = cx.weak_entity();
-        cx.on_flags_ready(move |_, cx| {
-            weak_this
-                .update(cx, |this, cx| this.configure_context_retrieval(cx))
-                .ok();
-        })
-        .detach();
-        cx.observe_global::<SettingsStore>(|this, cx| {
-            this.configure_context_retrieval(cx);
-        })
-        .detach();
-
         this
     }
 
@@ -676,10 +661,6 @@ impl EditPredictionStore {
 
     pub fn has_mercury_api_token(&self, cx: &App) -> bool {
         self.mercury.api_token.read(cx).has_key()
-    }
-
-    pub fn set_use_context(&mut self, use_context: bool) {
-        self.use_context = use_context;
     }
 
     pub fn clear_history(&mut self) {
@@ -1718,11 +1699,7 @@ impl EditPredictionStore {
         let diagnostic_search_range =
             Point::new(diagnostic_search_start, 0)..Point::new(diagnostic_search_end, 0);
 
-        let related_files = if self.use_context {
-            self.context_for_project(&project, cx)
-        } else {
-            Vec::new()
-        };
+        let related_files = self.context_for_project(&project, cx);
 
         let inputs = EditPredictionModelInput {
             project: project.clone(),
@@ -2089,13 +2066,11 @@ impl EditPredictionStore {
         cursor_position: language::Anchor,
         cx: &mut Context<Self>,
     ) {
-        if self.use_context {
-            self.get_or_init_project(project, cx)
-                .context
-                .update(cx, |store, cx| {
-                    store.refresh(buffer.clone(), cursor_position, cx);
-                });
-        }
+        self.get_or_init_project(project, cx)
+            .context
+            .update(cx, |store, cx| {
+                store.refresh(buffer.clone(), cursor_position, cx);
+            });
     }
 
     #[cfg(feature = "cli-support")]
@@ -2236,14 +2211,6 @@ impl EditPredictionStore {
         );
         self.client.telemetry().flush_events().detach();
         cx.notify();
-    }
-
-    fn configure_context_retrieval(&mut self, cx: &mut Context<'_, EditPredictionStore>) {
-        if cfg!(feature = "cli-support") {
-            return;
-        }
-        self.use_context = cx.has_flag::<Zeta2FeatureFlag>()
-            && all_language_settings(None, cx).edit_predictions.use_context;
     }
 }
 

--- a/crates/edit_prediction_cli/src/retrieve_context.rs
+++ b/crates/edit_prediction_cli/src/retrieve_context.rs
@@ -74,7 +74,6 @@ pub async fn run_context_retrieval(
 
     let mut events = ep_store.update(&mut cx, |store, cx| {
         store.register_buffer(&state.buffer, &project, cx);
-        store.set_use_context(true);
         store.refresh_context(&project, &state.buffer, state.cursor_position, cx);
         store.debug_info(&project, cx)
     });

--- a/crates/edit_prediction_ui/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_ui/src/edit_prediction_button.rs
@@ -1127,30 +1127,6 @@ impl EditPredictionButton {
 
             menu = self.build_language_settings_menu(menu, window, cx);
 
-            if cx.has_flag::<Zeta2FeatureFlag>() {
-                let settings = all_language_settings(None, cx);
-                let context_retrieval = settings.edit_predictions.use_context;
-                menu = menu.separator().header("Context Retrieval").item(
-                    ContextMenuEntry::new("Enable Context Retrieval")
-                        .toggleable(IconPosition::Start, context_retrieval)
-                        .action(workspace::ToggleEditPrediction.boxed_clone())
-                        .handler({
-                            let fs = self.fs.clone();
-                            move |_, cx| {
-                                update_settings_file(fs.clone(), cx, move |settings, _| {
-                                    settings
-                                        .project
-                                        .all_languages
-                                        .features
-                                        .get_or_insert_default()
-                                        .experimental_edit_prediction_context_retrieval =
-                                        Some(!context_retrieval)
-                                });
-                            }
-                        }),
-                );
-            }
-
             menu = self.add_provider_switching_section(menu, provider, cx);
             menu = menu.separator().item(
                 ContextMenuEntry::new("Configure Providers")

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -378,8 +378,6 @@ impl InlayHintSettings {
 pub struct EditPredictionSettings {
     /// The provider that supplies edit predictions.
     pub provider: settings::EditPredictionProvider,
-    /// Whether to use the experimental edit prediction context retrieval system.
-    pub use_context: bool,
     /// A list of globs representing files that edit predictions should be disabled for.
     /// This list adds to a pre-existing, sensible default set of globs.
     /// Any additional ones you add are combined with them.
@@ -639,11 +637,6 @@ impl settings::Settings for AllLanguageSettings {
             .features
             .as_ref()
             .and_then(|f| f.edit_prediction_provider);
-        let use_edit_prediction_context = all_languages
-            .features
-            .as_ref()
-            .and_then(|f| f.experimental_edit_prediction_context_retrieval)
-            .unwrap_or_default();
 
         let edit_predictions = all_languages.edit_predictions.clone().unwrap();
         let edit_predictions_mode = edit_predictions.mode.unwrap();
@@ -694,7 +687,6 @@ impl settings::Settings for AllLanguageSettings {
                 } else {
                     EditPredictionProvider::None
                 },
-                use_context: use_edit_prediction_context,
                 disabled_globs: disabled_globs
                     .iter()
                     .filter_map(|g| {

--- a/crates/settings_content/src/language.rs
+++ b/crates/settings_content/src/language.rs
@@ -84,8 +84,6 @@ impl merge_from::MergeFrom for AllLanguageSettingsContent {
 pub struct FeaturesContent {
     /// Determines which edit prediction provider to use.
     pub edit_prediction_provider: Option<EditPredictionProvider>,
-    /// Enables the experimental edit prediction context retrieval system.
-    pub experimental_edit_prediction_context_retrieval: Option<bool>,
 }
 
 /// The provider that supplies edit predictions.


### PR DESCRIPTION
Closes #ISSUE

Release Notes:

- N/A *or* Added/Fixed/Improved ...
