### PR TITLE
docs: Add missing syntax highlighting captures

### DIFF
--- a/docs/src/extensions/languages.md
+++ b/docs/src/extensions/languages.md
@@ -99,6 +99,7 @@ This query marks strings, object keys, and numbers for highlighting. The followi
 | @comment                 | Captures comments                      |
 | @comment.doc             | Captures documentation comments        |
 | @constant                | Captures constants                     |
+| @constant.builtin        | Captures built-in constants            |
 | @constructor             | Captures constructors                  |
 | @embedded                | Captures embedded content              |
 | @emphasis                | Captures emphasized text               |
@@ -131,8 +132,10 @@ This query marks strings, object keys, and numbers for highlighting. The followi
 | @text.literal            | Captures literal text                  |
 | @title                   | Captures titles                        |
 | @type                    | Captures types                         |
+| @type.builtin            | Captures built-in types                |
 | @variable                | Captures variables                     |
 | @variable.special        | Captures special variables             |
+| @variable.parameter      | Captures function/method parameters    |
 | @variant                 | Captures variants                      |
 
 ### Bracket matching


### PR DESCRIPTION
## Summary

Adds three syntax highlighting captures that are used across multiple language definitions but were missing from the documentation table in `docs/src/extensions/languages.md`.

## Added Captures

| Capture | Used In |
|---------|---------|
| `@constant.builtin` | C, Go, C++, YAML, TSX |
| `@type.builtin` | C++, Python, Rust, JavaScript, TSX |
| `@variable.parameter` | TypeScript, JavaScript, Python, Rust, TSX, Diff |

## Context

While working on a [PR to add named argument highlighting to the PHP extension](https://github.com/zed-extensions/php/pull/95), I initially used `@label` because the documentation didn't list `@variable.parameter`. A reviewer pointed out that `@variable.parameter` is actually supported and preferred - the docs were just outdated.

This PR fixes that documentation gap.

Release Notes:

- N/A