### PR TITLE
languages: Fix block comment indentation for C/C++

### DIFF
--- a/crates/languages/src/c/indents.scm
+++ b/crates/languages/src/c/indents.scm
@@ -11,6 +11,9 @@
 (_ "{" "}" @end) @indent
 (_ "(" ")" @end) @indent
 
+((comment) @indent
+ (#match? @indent "^/\\*"))
+
 (if_statement) @start.if
 (for_statement) @start.for
 (while_statement) @start.while

--- a/crates/languages/src/cpp/indents.scm
+++ b/crates/languages/src/cpp/indents.scm
@@ -11,6 +11,9 @@
 (_ "{" "}" @end) @indent
 (_ "(" ")" @end) @indent
 
+((comment) @indent
+ (#match? @indent "^/\\*"))
+
 (if_statement) @start.if
 (for_statement) @start.for
 (while_statement) @start.while


### PR DESCRIPTION
Before:
<img width="426" height="128" alt="before" src="https://github.com/user-attachments/assets/89f84f4b-4810-4d11-b8a2-c841d8506cef" />

After:
<img width="437" height="125" alt="after" src="https://github.com/user-attachments/assets/a63c5265-8f1b-4926-a334-93effad22f2b" />

Release Notes:

- Fixed indentation of block comments in C and C++.
