### PR TITLE
Disable opening dev container from within a remote project

### DIFF
--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -236,8 +236,20 @@ pub fn init(cx: &mut App) {
         with_active_or_new_workspace(cx, move |workspace, window, cx| {
             let app_state = workspace.app_state().clone();
             let replace_window = window.window_handle().downcast::<Workspace>();
+            let is_local = workspace.project().read(cx).is_local();
 
             cx.spawn_in(window, async move |_, mut cx| {
+                if !is_local {
+                    cx.prompt(
+                        gpui::PromptLevel::Critical,
+                        "Cannot open Dev Container from remote  project",
+                        None,
+                        &["Ok"],
+                    )
+                    .await
+                    .ok();
+                    return;
+                }
                 let (connection, starting_dir) =
                     match start_dev_container(&mut cx, app_state.node_runtime.clone()).await {
                         Ok((c, s)) => (Connection::DevContainer(c), s),

--- a/crates/recent_projects/src/remote_servers.rs
+++ b/crates/recent_projects/src/remote_servers.rs
@@ -2522,6 +2522,13 @@ impl RemoteServerProjects {
             })
             .unwrap_or(false);
 
+        // We cannot currently connect a dev container from within a remote server due to the remote_server architecture
+        let is_local = self
+            .workspace
+            .upgrade()
+            .map(|workspace| workspace.read(cx).project().read(cx).is_local())
+            .unwrap_or(true);
+
         let modal_section = v_flex()
             .track_focus(&self.focus_handle(cx))
             .id("ssh-server-list")
@@ -2529,7 +2536,7 @@ impl RemoteServerProjects {
             .track_scroll(&state.scroll_handle)
             .size_full()
             .child(connect_button)
-            .when(has_open_project, |this| {
+            .when(has_open_project && is_local, |this| {
                 this.child(connect_dev_container_button)
             });
 
@@ -2564,7 +2571,7 @@ impl RemoteServerProjects {
         )
         .entry(state.add_new_server.clone());
 
-        if has_open_project {
+        if has_open_project && is_local {
             modal_section = modal_section.entry(state.add_new_devcontainer.clone());
         }
 


### PR DESCRIPTION
Closes #46320

Release Notes:

- Improves error messaging to guide user away from opening a dev container from within a remote project
