### PR TITLE
Add item for opening Markdown/SVG files in preview tab in right-click menu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9857,6 +9857,7 @@ dependencies = [
  "urlencoding",
  "util",
  "workspace",
+ "zed_actions",
 ]
 
 [[package]]
@@ -16154,6 +16155,7 @@ dependencies = [
  "multi_buffer",
  "ui",
  "workspace",
+ "zed_actions",
 ]
 
 [[package]]

--- a/crates/markdown_preview/Cargo.toml
+++ b/crates/markdown_preview/Cargo.toml
@@ -34,6 +34,7 @@ ui.workspace = true
 urlencoding.workspace = true
 util.workspace = true
 workspace.workspace = true
+zed_actions.workspace = true
 
 [dev-dependencies]
 editor = { workspace = true, features = ["test-support"] }

--- a/crates/markdown_preview/src/markdown_preview.rs
+++ b/crates/markdown_preview/src/markdown_preview.rs
@@ -7,6 +7,8 @@ pub mod markdown_parser;
 pub mod markdown_preview_view;
 pub mod markdown_renderer;
 
+pub use zed_actions::preview::markdown::{OpenPreview, OpenPreviewToTheSide};
+
 actions!(
     markdown,
     [
@@ -24,10 +26,6 @@ actions!(
         ScrollUpByItem,
         /// Scrolls down by one markdown element in the markdown preview
         ScrollDownByItem,
-        /// Opens a markdown preview for the current file.
-        OpenPreview,
-        /// Opens a markdown preview in a split pane.
-        OpenPreviewToTheSide,
         /// Opens a following markdown preview that syncs with the editor.
         OpenFollowingPreview
     ]

--- a/crates/svg_preview/Cargo.toml
+++ b/crates/svg_preview/Cargo.toml
@@ -18,3 +18,4 @@ gpui.workspace = true
 language.workspace = true
 ui.workspace = true
 workspace.workspace = true
+zed_actions.workspace = true

--- a/crates/svg_preview/src/svg_preview.rs
+++ b/crates/svg_preview/src/svg_preview.rs
@@ -3,13 +3,11 @@ use workspace::Workspace;
 
 pub mod svg_preview_view;
 
+pub use zed_actions::preview::svg::{OpenPreview, OpenPreviewToTheSide};
+
 actions!(
     svg,
     [
-        /// Opens an SVG preview for the current file.
-        OpenPreview,
-        /// Opens an SVG preview in a split pane.
-        OpenPreviewToTheSide,
         /// Opens a following SVG preview that syncs with the editor.
         OpenFollowingPreview
     ]

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -651,3 +651,33 @@ pub mod wsl_actions {
         pub create_new_window: bool,
     }
 }
+
+pub mod preview {
+    pub mod markdown {
+        use gpui::actions;
+
+        actions!(
+            markdown,
+            [
+                /// Opens a markdown preview for the current file.
+                OpenPreview,
+                /// Opens a markdown preview in a split pane.
+                OpenPreviewToTheSide,
+            ]
+        );
+    }
+
+    pub mod svg {
+        use gpui::actions;
+
+        actions!(
+            svg,
+            [
+                /// Opens an SVG preview for the current file.
+                OpenPreview,
+                /// Opens an SVG preview in a split pane.
+                OpenPreviewToTheSide,
+            ]
+        );
+    }
+}


### PR DESCRIPTION
Following user feedback, this should help making the Markdown Preview more discoverable.

| Buffer Right-click | Tab Right-click |
|--------|--------|
| <img width="2474" height="1824" alt="Screenshot 2026-01-27 at 10  16@2x" src="https://github.com/user-attachments/assets/251149e9-89c6-4d11-aed0-872669939cfb" /> | <img width="2464" height="1808" alt="Screenshot 2026-01-27 at 10  16 2@2x" src="https://github.com/user-attachments/assets/359a221b-2141-45b1-98a9-d9c77b601c0b" /> | 

Release Notes:

- Workspace: Added a menu item in the buffer and tab right-click menu for opening Markdown and SVG files in the preview tab.
