### PR TITLE
Fix issues with Windows SSH support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13624,6 +13624,7 @@ dependencies = [
  "anyhow",
  "askpass",
  "async-trait",
+ "base64 0.22.1",
  "collections",
  "fs",
  "futures 0.3.31",

--- a/crates/remote/Cargo.toml
+++ b/crates/remote/Cargo.toml
@@ -22,6 +22,7 @@ test-support = ["fs/test-support"]
 anyhow.workspace = true
 askpass.workspace = true
 async-trait.workspace = true
+base64.workspace = true
 collections.workspace = true
 fs.workspace = true
 futures.workspace = true

--- a/crates/remote/src/transport/ssh.rs
+++ b/crates/remote/src/transport/ssh.rs
@@ -1706,7 +1706,7 @@ fn build_command_windows(
         )?;
     }
 
-    // Windows OpenSSH has an 8K character limit for command lines. Sending a lot of environment varaibles easily puts us over the limit.
+    // Windows OpenSSH has an 8K character limit for command lines. Sending a lot of environment variables easily puts us over the limit.
     // Until we have a better solution for this, we just won't set environment variables for now.
     // for (k, v) in input_env.iter() {
     //     write!(

--- a/crates/util/src/shell.rs
+++ b/crates/util/src/shell.rs
@@ -482,9 +482,8 @@ impl ShellKind {
             | ShellKind::Rc
             | ShellKind::Fish
             | ShellKind::Pwsh
-            | ShellKind::PowerShell
             | ShellKind::Xonsh => "&&",
-            ShellKind::Nushell | ShellKind::Elvish => ";",
+            ShellKind::PowerShell | ShellKind::Nushell | ShellKind::Elvish => ";",
         }
     }
 
@@ -643,11 +642,7 @@ impl ShellKind {
     pub fn quote_cmd(arg: &str) -> Cow<'_, str> {
         let crt_quoted = Self::quote_windows(arg, true);
 
-        let needs_cmd_escaping = crt_quoted.contains('"')
-            || crt_quoted.contains('%')
-            || crt_quoted
-                .chars()
-                .any(|c| matches!(c, '^' | '<' | '>' | '&' | '|' | '(' | ')'));
+        let needs_cmd_escaping = crt_quoted.contains(['"', '%', '^', '<', '>', '&', '|', '(', ')']);
 
         if !needs_cmd_escaping {
             return crt_quoted;


### PR DESCRIPTION
- Remove the newlines in the unzip command string, which made it not work.
- Fix spawning the terminal and tasks. Unfortunately, the Windows OpenSSH server has limitations that require rather ugly workarounds.

Release Notes:

- N/A 