### PR TITLE
languages: Add attribute highlighting in C++

### DIFF
--- a/crates/languages/src/cpp/highlights.scm
+++ b/crates/languages/src/cpp/highlights.scm
@@ -93,8 +93,17 @@
 type: (primitive_type) @type.builtin
 (sized_type_specifier) @type.builtin
 
+; GNU __attribute__
+(attribute_specifier) @attribute
+(attribute_specifier
+  (argument_list
+    (identifier) @attribute))
+
+; C++11 [[attributes]]
 (attribute
-    name: (identifier) @attribute)
+  prefix: (identifier) @attribute)
+(attribute
+  name: (identifier) @attribute)
 
 ((identifier) @constant.builtin
  (#match? @constant.builtin "^_*[A-Z][A-Z\\d_]*$"))


### PR DESCRIPTION
Before:
<img width="587" height="360" alt="before" src="https://github.com/user-attachments/assets/85989888-2fc0-43aa-87ca-01d2c3101484" />

After:
<img width="591" height="357" alt="after" src="https://github.com/user-attachments/assets/9e1ceccf-7890-43f7-a0b9-938daa161d13" />

Release Notes:

- Added attribute highlighting in C++
