### PR TITLE
docs: Document default for include_warnings

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1376,6 +1376,8 @@
     // Whether to show the project diagnostics button in the status bar.
     "button": true,
     // Whether to show warnings or not by default.
+    //
+    // Default: true
     "include_warnings": true,
     // Settings for using LSP pull diagnostics mechanism in Zed.
     "lsp_pull_diagnostics": {

--- a/crates/settings_content/src/project.rs
+++ b/crates/settings_content/src/project.rs
@@ -526,6 +526,8 @@ pub struct DiagnosticsSettingsContent {
     pub button: Option<bool>,
 
     /// Whether or not to include warning diagnostics.
+    ///
+    /// Default: true
     pub include_warnings: Option<bool>,
 
     /// Settings for using LSP pull diagnostics mechanism in Zed.


### PR DESCRIPTION
## Summary
Add documentation for the default value of `include_warnings` in diagnostics settings. This makes it consistent with other settings that document their default values.

## Test plan
- Documentation-only change, no functional changes

Release Notes:

- N/A