### PR TITLE
markdown: Improve double-click word selection using CharClassifier

### DIFF
--- a/crates/markdown/Cargo.toml
+++ b/crates/markdown/Cargo.toml
@@ -37,6 +37,7 @@ assets.workspace = true
 env_logger.workspace = true
 fs = {workspace = true, features = ["test-support"]}
 gpui = { workspace = true, features = ["test-support"] }
+language = { workspace = true, features = ["test-support"] }
 languages = { workspace = true, features = ["load-grammars"] }
 node_runtime.workspace = true
 settings = { workspace = true, features = ["test-support"] }


### PR DESCRIPTION
Previously, double-click word selection in markdown used simple space-based boundaries, so `foo.bar()` would be selected as a single word.

Now we use `CharClassifier` which properly handles word boundaries:

- **Regular markdown text**: Punctuation (`.`, `(`, `)`, etc.) now acts as word boundaries. Double-clicking on `foo.bar()` selects just `foo` or `bar`.
- **Code blocks**: Uses the language's word characters. For example, in JavaScript, `$foo` and `#bar` are selected as whole words since `$` and `#` are configured as word characters.

Release Notes:

- Improved double-click word selection in Agent Panel to respect punctuation and language-specific word characters.