### PR TITLE
anthropic: Support alternative provider SSE formatting

### DIFF
--- a/crates/anthropic/src/anthropic.rs
+++ b/crates/anthropic/src/anthropic.rs
@@ -708,9 +708,6 @@ pub async fn stream_completion_with_rate_limit_info(
                             None => return None,
                         };
 
-                        if line.is_empty() {
-                            return None;
-                        }
                         match serde_json::from_str(line) {
                             Ok(response) => Some(Ok(response)),
                             Err(error) => Some(Err(AnthropicError::DeserializeResponse(error))),

--- a/crates/anthropic/src/anthropic.rs
+++ b/crates/anthropic/src/anthropic.rs
@@ -703,8 +703,6 @@ pub async fn stream_completion_with_rate_limit_info(
             .filter_map(|line| async move {
                 match line {
                     Ok(line) => {
-                        // Some Anthropic-compatible endpoints omit the space after `data:`.
-                        // Accept both `data: {json}` and `data:{json}`.
                         let line = match line.strip_prefix("data:") {
                             Some(rest) => rest.trim_start(),
                             None => return None,

--- a/crates/anthropic/src/anthropic.rs
+++ b/crates/anthropic/src/anthropic.rs
@@ -703,10 +703,9 @@ pub async fn stream_completion_with_rate_limit_info(
             .filter_map(|line| async move {
                 match line {
                     Ok(line) => {
-                        let line = match line.strip_prefix("data:") {
-                            Some(rest) => rest.trim_start(),
-                            None => return None,
-                        };
+                        let line = line
+                            .strip_prefix("data: ")
+                            .or_else(|| line.strip_prefix("data:"))?;
 
                         match serde_json::from_str(line) {
                             Ok(response) => Some(Ok(response)),


### PR DESCRIPTION
Closes #ISSUE

The issue I ran into was that responses from anthropic compatible providers, like Kimi for Coding, have no space after `data:`. This change just adds a quick check to also allow for those providers to work.

Before it just resolved but did not show any output:
<img width="50%" alt="CleanShot 2026-01-28 at 12 50 31@2x" src="https://github.com/user-attachments/assets/c3c8fe27-348e-4b21-a5f1-25bcc82f3774" width=50%/>

Now it returns the proper result:
<img width="50%" alt="CleanShot 2026-01-28 at 12 56 30@2x" src="https://github.com/user-attachments/assets/4e524c1e-78ab-4956-bd65-a919d46adc59" width=50%/>

Normal Anthropic models still work as expected:
<img width="50%" alt="CleanShot 2026-01-28 at 12 58 37@2x" src="https://github.com/user-attachments/assets/5a2906aa-1183-45b6-939b-01a6830f3385" />

Config to test
```json
 "language_models": {
    "anthropic": {
      "api_url": "https://api.kimi.com/coding",
      "available_models": [
          {
            "name": "kimi-for-coding",
            "display_name": "Kimi 2.5 Coding",
            "max_tokens": 262144,
            "max_output_tokens": 32768,
          },
      ],
    },
}
```


TLDR:
- Accepts SSE data:{...} lines (no space) emitted by some alternative Anthropic providers, in addition to the standard data: {...} format.

Release Notes:

- Fixed Anthropic streaming for alternative providers by accepting SSE data:{...} (no space) lines.