### PR TITLE
terminal: Update to new alacritty_terminal ExitStatus API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,8 +512,7 @@ dependencies = [
 
 [[package]]
 name = "alacritty_terminal"
-version = "0.25.1"
-source = "git+https://github.com/zed-industries/alacritty?rev=936aee8761a17affc84ab418ae21306c27c26221#936aee8761a17affc84ab418ae21306c27c26221"
+version = "0.25.2-dev"
 dependencies = [
  "base64 0.22.1",
  "bitflags 2.9.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -460,7 +460,7 @@ ztracing_macro = { path = "crates/ztracing_macro" }
 
 agent-client-protocol = { version = "=0.9.3", features = ["unstable"] }
 aho-corasick = "1.1"
-alacritty_terminal = { git = "https://github.com/zed-industries/alacritty", rev = "936aee8761a17affc84ab418ae21306c27c26221" }
+alacritty_terminal = { path = "../alacritty/alacritty_terminal" }
 any_vec = "0.14"
 anyhow = "1.0.86"
 arrayvec = { version = "0.7.4", features = ["serde"] }


### PR DESCRIPTION
Follow-up to #47420.

Updates to new alacritty API that uses `ExitStatus` directly instead of raw `i32`.

Upstream PR: https://github.com/alacritty/alacritty/pull/8825

**TODO:** Update `alacritty_terminal` dependency once upstream PR is merged.

Release Notes:

- N/A