### PR TITLE
Use `SharedString::new_static` for string literals

### DIFF
--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -27382,7 +27382,7 @@ async fn test_pulling_diagnostics(cx: &mut TestAppContext) {
         .next()
         .await
         .expect("should have sent the first diagnostics pull request");
-    ensure_result_id(Some(SharedString::new("1")), cx);
+    ensure_result_id(Some(SharedString::new_static("1")), cx);
 
     // Editing should trigger diagnostics
     editor.update_in(cx, |editor, window, cx| {
@@ -27395,7 +27395,7 @@ async fn test_pulling_diagnostics(cx: &mut TestAppContext) {
         2,
         "Editing should trigger diagnostic request"
     );
-    ensure_result_id(Some(SharedString::new("2")), cx);
+    ensure_result_id(Some(SharedString::new_static("2")), cx);
 
     // Moving cursor should not trigger diagnostic request
     editor.update_in(cx, |editor, window, cx| {
@@ -27410,7 +27410,7 @@ async fn test_pulling_diagnostics(cx: &mut TestAppContext) {
         2,
         "Cursor movement should not trigger diagnostic request"
     );
-    ensure_result_id(Some(SharedString::new("2")), cx);
+    ensure_result_id(Some(SharedString::new_static("2")), cx);
     // Multiple rapid edits should be debounced
     for _ in 0..5 {
         editor.update_in(cx, |editor, window, cx| {

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -3491,7 +3491,7 @@ mod tests {
                     sha: "060964da10574cd9bf06463a53bf6e0769c5c45e".into(),
                     subject: "generated protobuf".into(),
                     commit_timestamp: 1733187470,
-                    author_name: SharedString::new("John Doe"),
+                    author_name: SharedString::new_static("John Doe"),
                     has_parent: false,
                 })
             }]
@@ -3516,7 +3516,7 @@ mod tests {
                         sha: "eb0cae33272689bd11030822939dd2701c52f81e".into(),
                         subject: "Add feature".into(),
                         commit_timestamp: 1762948725,
-                        author_name: SharedString::new("Zed"),
+                        author_name: SharedString::new_static("Zed"),
                         has_parent: true,
                     })
                 },
@@ -3528,7 +3528,7 @@ mod tests {
                         sha: "895951d681e5561478c0acdd6905e8aacdfd2249".into(),
                         subject: "Initial commit".into(),
                         commit_timestamp: 1762948695,
-                        author_name: SharedString::new("Zed"),
+                        author_name: SharedString::new_static("Zed"),
                         has_parent: false,
                     })
                 }

--- a/crates/git_ui/src/remote_output.rs
+++ b/crates/git_ui/src/remote_output.rs
@@ -168,9 +168,9 @@ mod tests {
     #[test]
     fn test_push_new_branch_pull_request() {
         let action = RemoteAction::Push(
-            SharedString::new("test_branch"),
+            SharedString::new_static("test_branch"),
             Remote {
-                name: SharedString::new("test_remote"),
+                name: SharedString::new_static("test_remote"),
             },
         );
 
@@ -201,9 +201,9 @@ mod tests {
     #[test]
     fn test_push_new_branch_merge_request() {
         let action = RemoteAction::Push(
-            SharedString::new("test_branch"),
+            SharedString::new_static("test_branch"),
             Remote {
-                name: SharedString::new("test_remote"),
+                name: SharedString::new_static("test_remote"),
             },
         );
 
@@ -237,9 +237,9 @@ mod tests {
     #[test]
     fn test_push_branch_existing_merge_request() {
         let action = RemoteAction::Push(
-            SharedString::new("test_branch"),
+            SharedString::new_static("test_branch"),
             Remote {
-                name: SharedString::new("test_remote"),
+                name: SharedString::new_static("test_remote"),
             },
         );
 
@@ -270,9 +270,9 @@ mod tests {
     #[test]
     fn test_push_new_branch_no_link() {
         let action = RemoteAction::Push(
-            SharedString::new("test_branch"),
+            SharedString::new_static("test_branch"),
             Remote {
-                name: SharedString::new("test_remote"),
+                name: SharedString::new_static("test_remote"),
             },
         );
 

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -11234,7 +11234,7 @@ fn python_lang(fs: Arc<FakeFs>) -> Arc<Language> {
                 let venv_path = worktree_root.join(ancestor.as_std_path()).join(".venv");
                 if self.0.is_dir(&venv_path).await {
                     toolchains.push(Toolchain {
-                        name: SharedString::new("Python Venv"),
+                        name: SharedString::new_static("Python Venv"),
                         path: venv_path.to_string_lossy().into_owned().into(),
                         language_name: LanguageName(SharedString::new_static("Python")),
                         as_json: serde_json::Value::Null,

--- a/crates/project/tests/integration/signature_help.rs
+++ b/crates/project/tests/integration/signature_help.rs
@@ -42,7 +42,7 @@ fn test_create_signature_help_markdown_string_1(cx: &mut TestAppContext) {
     assert_eq!(
         markdown,
         (
-            SharedString::new("fn test(foo: u8, bar: &str)"),
+            SharedString::new_static("fn test(foo: u8, bar: &str)"),
             vec![(8..15, current_parameter())]
         )
     );
@@ -88,7 +88,7 @@ fn test_create_signature_help_markdown_string_2(cx: &mut TestAppContext) {
     assert_eq!(
         markdown,
         (
-            SharedString::new("fn test(foo: u8, bar: &str)"),
+            SharedString::new_static("fn test(foo: u8, bar: &str)"),
             vec![(17..26, current_parameter())]
         )
     );
@@ -148,7 +148,7 @@ fn test_create_signature_help_markdown_string_3(cx: &mut TestAppContext) {
     assert_eq!(
         markdown,
         (
-            SharedString::new("fn test1(foo: u8, bar: &str)"),
+            SharedString::new_static("fn test1(foo: u8, bar: &str)"),
             vec![(9..16, current_parameter())]
         )
     );
@@ -201,7 +201,7 @@ fn test_create_signature_help_markdown_string_4(cx: &mut TestAppContext) {
     assert_eq!(
         markdown,
         (
-            SharedString::new("fn test2(hoge: String, fuga: bool)"),
+            SharedString::new_static("fn test2(hoge: String, fuga: bool)"),
             vec![(9..21, current_parameter())]
         )
     );
@@ -254,7 +254,7 @@ fn test_create_signature_help_markdown_string_5(cx: &mut TestAppContext) {
     assert_eq!(
         markdown,
         (
-            SharedString::new("fn test2(hoge: String, fuga: bool)"),
+            SharedString::new_static("fn test2(hoge: String, fuga: bool)"),
             vec![(23..33, current_parameter())]
         )
     );
@@ -307,7 +307,7 @@ fn test_create_signature_help_markdown_string_6(cx: &mut TestAppContext) {
     assert_eq!(
         markdown,
         (
-            SharedString::new("fn test2(hoge: String, fuga: bool)"),
+            SharedString::new_static("fn test2(hoge: String, fuga: bool)"),
             vec![(9..21, current_parameter())]
         )
     );
@@ -375,7 +375,7 @@ fn test_create_signature_help_markdown_string_7(cx: &mut TestAppContext) {
     assert_eq!(
         markdown,
         (
-            SharedString::new("fn test3(one: usize, two: u32)"),
+            SharedString::new_static("fn test3(one: usize, two: u32)"),
             vec![(21..29, current_parameter())]
         )
     );
@@ -422,7 +422,7 @@ fn test_create_signature_help_markdown_string_9(cx: &mut TestAppContext) {
     assert_eq!(
         markdown,
         (
-            SharedString::new("fn test(foo: u8, bar: &str)"),
+            SharedString::new_static("fn test(foo: u8, bar: &str)"),
             vec![(8..15, current_parameter())]
         )
     );
@@ -510,7 +510,7 @@ fn test_create_signature_help_implements_utf16_spec(cx: &mut TestAppContext) {
     assert_eq!(
         markdown,
         (
-            SharedString::new("fn test(🦀: u8, 🦀: &str)"),
+            SharedString::new_static("fn test(🦀: u8, 🦀: &str)"),
             vec![(8..12, current_parameter())]
         )
     );


### PR DESCRIPTION
Basically just replaced `SharedString::new("` with `SharedShring::new_static("` which removes the allocation to `Arc<str>`.

Unfortunately this can't be enforced at compile time without trait specialization which is only available on nightly. You could assert that `TypeId`'s differ, but `TypeId` only exists at runtime.

Release Notes:

- N/A *or* Added/Fixed/Improved ...
