### PR TITLE
dap: Make `ProtoConversion::to_proto` consume `self`

### DIFF
--- a/crates/dap/src/proto_conversions.rs
+++ b/crates/dap/src/proto_conversions.rs
@@ -9,7 +9,7 @@ pub trait ProtoConversion {
     type ProtoType;
     type Output;
 
-    fn to_proto(&self) -> Self::ProtoType;
+    fn to_proto(self) -> Self::ProtoType;
     fn from_proto(payload: Self::ProtoType) -> Self::Output;
 }
 

--- a/crates/dap/src/proto_conversions.rs
+++ b/crates/dap/src/proto_conversions.rs
@@ -284,6 +284,25 @@ impl ProtoConversion for dap_types::StackFrame {
     }
 }
 
+impl ProtoConversion for dap_types::ModuleId {
+    type ProtoType = proto::dap_module_id::Id;
+    type Output = Self;
+
+    fn to_proto(self) -> Self::ProtoType {
+        match self {
+            Self::Number(num) => Self::ProtoType::Number(num),
+            Self::String(string) => Self::ProtoType::String(string),
+        }
+    }
+
+    fn from_proto(payload: Self::ProtoType) -> Self::Output {
+        match payload {
+            Self::ProtoType::Number(num) => Self::Number(num),
+            Self::ProtoType::String(string) => Self::String(string),
+        }
+    }
+}
+
 impl ProtoConversion for dap_types::Module {
     type ProtoType = DapModule;
     type Output = Result<Self>;

--- a/crates/dap/src/proto_conversions.rs
+++ b/crates/dap/src/proto_conversions.rs
@@ -112,22 +112,22 @@ impl ProtoConversion for dap_types::ScopePresentationHint {
 
     fn to_proto(self) -> Self::ProtoType {
         match self {
-            dap_types::ScopePresentationHint::Locals => DapScopePresentationHint::Locals,
-            dap_types::ScopePresentationHint::Arguments => DapScopePresentationHint::Arguments,
-            dap_types::ScopePresentationHint::Registers => DapScopePresentationHint::Registers,
-            dap_types::ScopePresentationHint::ReturnValue => DapScopePresentationHint::ReturnValue,
-            dap_types::ScopePresentationHint::Unknown => DapScopePresentationHint::ScopeUnknown,
+            Self::Locals => Self::ProtoType::Locals,
+            Self::Arguments => Self::ProtoType::Arguments,
+            Self::Registers => Self::ProtoType::Registers,
+            Self::ReturnValue => Self::ProtoType::ReturnValue,
+            Self::Unknown => Self::ProtoType::ScopeUnknown,
             _ => unreachable!(),
         }
     }
 
     fn from_proto(payload: Self::ProtoType) -> Self {
         match payload {
-            DapScopePresentationHint::Locals => dap_types::ScopePresentationHint::Locals,
-            DapScopePresentationHint::Arguments => dap_types::ScopePresentationHint::Arguments,
-            DapScopePresentationHint::Registers => dap_types::ScopePresentationHint::Registers,
-            DapScopePresentationHint::ReturnValue => dap_types::ScopePresentationHint::ReturnValue,
-            DapScopePresentationHint::ScopeUnknown => dap_types::ScopePresentationHint::Unknown,
+            Self::ProtoType::Locals => Self::Locals,
+            Self::ProtoType::Arguments => Self::Arguments,
+            Self::ProtoType::Registers => Self::Registers,
+            Self::ProtoType::ReturnValue => Self::ReturnValue,
+            Self::ProtoType::ScopeUnknown => Self::Unknown,
         }
     }
 }
@@ -138,23 +138,19 @@ impl ProtoConversion for dap_types::SourcePresentationHint {
 
     fn to_proto(self) -> Self::ProtoType {
         match self {
-            dap_types::SourcePresentationHint::Normal => DapSourcePresentationHint::SourceNormal,
-            dap_types::SourcePresentationHint::Emphasize => DapSourcePresentationHint::Emphasize,
-            dap_types::SourcePresentationHint::Deemphasize => {
-                DapSourcePresentationHint::Deemphasize
-            }
-            dap_types::SourcePresentationHint::Unknown => DapSourcePresentationHint::SourceUnknown,
+            Self::Normal => Self::ProtoType::SourceNormal,
+            Self::Emphasize => Self::ProtoType::Emphasize,
+            Self::Deemphasize => Self::ProtoType::Deemphasize,
+            Self::Unknown => Self::ProtoType::SourceUnknown,
         }
     }
 
     fn from_proto(payload: Self::ProtoType) -> Self {
         match payload {
-            DapSourcePresentationHint::SourceNormal => dap_types::SourcePresentationHint::Normal,
-            DapSourcePresentationHint::Emphasize => dap_types::SourcePresentationHint::Emphasize,
-            DapSourcePresentationHint::Deemphasize => {
-                dap_types::SourcePresentationHint::Deemphasize
-            }
-            DapSourcePresentationHint::SourceUnknown => dap_types::SourcePresentationHint::Unknown,
+            Self::ProtoType::SourceNormal => Self::Normal,
+            Self::ProtoType::Emphasize => Self::Emphasize,
+            Self::ProtoType::Deemphasize => Self::Deemphasize,
+            Self::ProtoType::SourceUnknown => Self::Unknown,
         }
     }
 }
@@ -184,20 +180,20 @@ impl ProtoConversion for dap_types::ChecksumAlgorithm {
 
     fn to_proto(self) -> Self::ProtoType {
         match self {
-            dap_types::ChecksumAlgorithm::Md5 => DapChecksumAlgorithm::Md5,
-            dap_types::ChecksumAlgorithm::Sha1 => DapChecksumAlgorithm::Sha1,
-            dap_types::ChecksumAlgorithm::Sha256 => DapChecksumAlgorithm::Sha256,
-            dap_types::ChecksumAlgorithm::Timestamp => DapChecksumAlgorithm::Timestamp,
+            Self::Md5 => DapChecksumAlgorithm::Md5,
+            Self::Sha1 => DapChecksumAlgorithm::Sha1,
+            Self::Sha256 => DapChecksumAlgorithm::Sha256,
+            Self::Timestamp => DapChecksumAlgorithm::Timestamp,
         }
     }
 
     fn from_proto(payload: Self::ProtoType) -> Self {
         match payload {
-            DapChecksumAlgorithm::Md5 => dap_types::ChecksumAlgorithm::Md5,
-            DapChecksumAlgorithm::Sha1 => dap_types::ChecksumAlgorithm::Sha1,
-            DapChecksumAlgorithm::Sha256 => dap_types::ChecksumAlgorithm::Sha256,
-            DapChecksumAlgorithm::Timestamp => dap_types::ChecksumAlgorithm::Timestamp,
-            DapChecksumAlgorithm::ChecksumAlgorithmUnspecified => unreachable!(),
+            Self::ProtoType::Md5 => Self::Md5,
+            Self::ProtoType::Sha1 => Self::Sha1,
+            Self::ProtoType::Sha256 => Self::Sha256,
+            Self::ProtoType::Timestamp => Self::Timestamp,
+            Self::ProtoType::ChecksumAlgorithmUnspecified => unreachable!(),
         }
     }
 }
@@ -345,17 +341,17 @@ impl ProtoConversion for dap_types::SteppingGranularity {
 
     fn to_proto(self) -> Self::ProtoType {
         match self {
-            dap_types::SteppingGranularity::Statement => proto::SteppingGranularity::Statement,
-            dap_types::SteppingGranularity::Line => proto::SteppingGranularity::Line,
-            dap_types::SteppingGranularity::Instruction => proto::SteppingGranularity::Instruction,
+            Self::Statement => Self::ProtoType::Statement,
+            Self::Line => Self::ProtoType::Line,
+            Self::Instruction => Self::ProtoType::Instruction,
         }
     }
 
     fn from_proto(payload: Self::ProtoType) -> Self {
         match payload {
-            proto::SteppingGranularity::Line => dap_types::SteppingGranularity::Line,
-            proto::SteppingGranularity::Instruction => dap_types::SteppingGranularity::Instruction,
-            proto::SteppingGranularity::Statement => dap_types::SteppingGranularity::Statement,
+            Self::ProtoType::Line => Self::Line,
+            Self::ProtoType::Instruction => Self::Instruction,
+            Self::ProtoType::Statement => Self::Statement,
         }
     }
 }
@@ -366,21 +362,21 @@ impl ProtoConversion for dap_types::OutputEventCategory {
 
     fn to_proto(self) -> Self::ProtoType {
         match self {
-            Self::Console => proto::DapOutputCategory::ConsoleOutput,
-            Self::Important => proto::DapOutputCategory::Important,
-            Self::Stdout => proto::DapOutputCategory::Stdout,
-            Self::Stderr => proto::DapOutputCategory::Stderr,
-            _ => proto::DapOutputCategory::Unknown,
+            Self::Console => Self::ProtoType::ConsoleOutput,
+            Self::Important => Self::ProtoType::Important,
+            Self::Stdout => Self::ProtoType::Stdout,
+            Self::Stderr => Self::ProtoType::Stderr,
+            _ => Self::ProtoType::Unknown,
         }
     }
 
     fn from_proto(payload: Self::ProtoType) -> Self {
         match payload {
-            proto::DapOutputCategory::ConsoleOutput => Self::Console,
-            proto::DapOutputCategory::Important => Self::Important,
-            proto::DapOutputCategory::Stdout => Self::Stdout,
-            proto::DapOutputCategory::Stderr => Self::Stderr,
-            proto::DapOutputCategory::Unknown => Self::Unknown,
+            Self::ProtoType::ConsoleOutput => Self::Console,
+            Self::ProtoType::Important => Self::Important,
+            Self::ProtoType::Stdout => Self::Stdout,
+            Self::ProtoType::Stderr => Self::Stderr,
+            Self::ProtoType::Unknown => Self::Unknown,
         }
     }
 }
@@ -390,7 +386,7 @@ impl ProtoConversion for dap_types::OutputEvent {
     type Output = Self;
 
     fn to_proto(self) -> Self::ProtoType {
-        proto::DapOutputEvent {
+        Self::ProtoType {
             category: self.category.map(|category| category.to_proto().into()),
             output: self.output.clone(),
             variables_reference: self.variables_reference,
@@ -402,7 +398,7 @@ impl ProtoConversion for dap_types::OutputEvent {
     }
 
     fn from_proto(payload: Self::ProtoType) -> Self {
-        dap_types::OutputEvent {
+        Self {
             category: payload
                 .category
                 .and_then(proto::DapOutputCategory::from_i32)
@@ -428,19 +424,17 @@ impl ProtoConversion for dap_types::OutputEventGroup {
 
     fn to_proto(self) -> Self::ProtoType {
         match self {
-            dap_types::OutputEventGroup::Start => proto::DapOutputEventGroup::Start,
-            dap_types::OutputEventGroup::StartCollapsed => {
-                proto::DapOutputEventGroup::StartCollapsed
-            }
-            dap_types::OutputEventGroup::End => proto::DapOutputEventGroup::End,
+            Self::Start => Self::ProtoType::Start,
+            Self::StartCollapsed => Self::ProtoType::StartCollapsed,
+            Self::End => Self::ProtoType::End,
         }
     }
 
     fn from_proto(payload: Self::ProtoType) -> Self {
         match payload {
-            proto::DapOutputEventGroup::Start => Self::Start,
-            proto::DapOutputEventGroup::StartCollapsed => Self::StartCollapsed,
-            proto::DapOutputEventGroup::End => Self::End,
+            Self::ProtoType::Start => Self::Start,
+            Self::ProtoType::StartCollapsed => Self::StartCollapsed,
+            Self::ProtoType::End => Self::End,
         }
     }
 }
@@ -450,7 +444,7 @@ impl ProtoConversion for dap_types::CompletionItem {
     type Output = Self;
 
     fn to_proto(self) -> Self::ProtoType {
-        proto::DapCompletionItem {
+        Self::ProtoType {
             label: self.label.clone(),
             text: self.text.clone(),
             detail: self.detail.clone(),
@@ -489,32 +483,24 @@ impl ProtoConversion for dap_types::EvaluateArgumentsContext {
 
     fn to_proto(self) -> Self::ProtoType {
         match self {
-            dap_types::EvaluateArgumentsContext::Variables => {
-                proto::DapEvaluateContext::EvaluateVariables
-            }
-            dap_types::EvaluateArgumentsContext::Watch => proto::DapEvaluateContext::Watch,
-            dap_types::EvaluateArgumentsContext::Hover => proto::DapEvaluateContext::Hover,
-            dap_types::EvaluateArgumentsContext::Repl => proto::DapEvaluateContext::Repl,
-            dap_types::EvaluateArgumentsContext::Clipboard => proto::DapEvaluateContext::Clipboard,
-            dap_types::EvaluateArgumentsContext::Unknown => {
-                proto::DapEvaluateContext::EvaluateUnknown
-            }
-            _ => proto::DapEvaluateContext::EvaluateUnknown,
+            Self::Variables => Self::ProtoType::EvaluateVariables,
+            Self::Watch => Self::ProtoType::Watch,
+            Self::Hover => Self::ProtoType::Hover,
+            Self::Repl => Self::ProtoType::Repl,
+            Self::Clipboard => Self::ProtoType::Clipboard,
+            Self::Unknown => Self::ProtoType::EvaluateUnknown,
+            _ => Self::ProtoType::EvaluateUnknown,
         }
     }
 
     fn from_proto(payload: Self::ProtoType) -> Self {
         match payload {
-            proto::DapEvaluateContext::EvaluateVariables => {
-                dap_types::EvaluateArgumentsContext::Variables
-            }
-            proto::DapEvaluateContext::Watch => dap_types::EvaluateArgumentsContext::Watch,
-            proto::DapEvaluateContext::Hover => dap_types::EvaluateArgumentsContext::Hover,
-            proto::DapEvaluateContext::Repl => dap_types::EvaluateArgumentsContext::Repl,
-            proto::DapEvaluateContext::Clipboard => dap_types::EvaluateArgumentsContext::Clipboard,
-            proto::DapEvaluateContext::EvaluateUnknown => {
-                dap_types::EvaluateArgumentsContext::Unknown
-            }
+            Self::ProtoType::EvaluateVariables => Self::Variables,
+            Self::ProtoType::Watch => Self::Watch,
+            Self::ProtoType::Hover => Self::Hover,
+            Self::ProtoType::Repl => Self::Repl,
+            Self::ProtoType::Clipboard => Self::Clipboard,
+            Self::ProtoType::EvaluateUnknown => Self::Unknown,
         }
     }
 }
@@ -525,49 +511,49 @@ impl ProtoConversion for dap_types::CompletionItemType {
 
     fn to_proto(self) -> Self::ProtoType {
         match self {
-            dap_types::CompletionItemType::Class => proto::DapCompletionItemType::Class,
-            dap_types::CompletionItemType::Color => proto::DapCompletionItemType::Color,
-            dap_types::CompletionItemType::Constructor => proto::DapCompletionItemType::Constructor,
-            dap_types::CompletionItemType::Customcolor => proto::DapCompletionItemType::Customcolor,
-            dap_types::CompletionItemType::Enum => proto::DapCompletionItemType::Enum,
-            dap_types::CompletionItemType::Field => proto::DapCompletionItemType::Field,
-            dap_types::CompletionItemType::File => proto::DapCompletionItemType::CompletionItemFile,
-            dap_types::CompletionItemType::Function => proto::DapCompletionItemType::Function,
-            dap_types::CompletionItemType::Interface => proto::DapCompletionItemType::Interface,
-            dap_types::CompletionItemType::Keyword => proto::DapCompletionItemType::Keyword,
-            dap_types::CompletionItemType::Method => proto::DapCompletionItemType::Method,
-            dap_types::CompletionItemType::Module => proto::DapCompletionItemType::Module,
-            dap_types::CompletionItemType::Property => proto::DapCompletionItemType::Property,
-            dap_types::CompletionItemType::Reference => proto::DapCompletionItemType::Reference,
-            dap_types::CompletionItemType::Snippet => proto::DapCompletionItemType::Snippet,
-            dap_types::CompletionItemType::Text => proto::DapCompletionItemType::Text,
-            dap_types::CompletionItemType::Unit => proto::DapCompletionItemType::Unit,
-            dap_types::CompletionItemType::Value => proto::DapCompletionItemType::Value,
-            dap_types::CompletionItemType::Variable => proto::DapCompletionItemType::Variable,
+            Self::Class => Self::ProtoType::Class,
+            Self::Color => Self::ProtoType::Color,
+            Self::Constructor => Self::ProtoType::Constructor,
+            Self::Customcolor => Self::ProtoType::Customcolor,
+            Self::Enum => Self::ProtoType::Enum,
+            Self::Field => Self::ProtoType::Field,
+            Self::File => Self::ProtoType::CompletionItemFile,
+            Self::Function => Self::ProtoType::Function,
+            Self::Interface => Self::ProtoType::Interface,
+            Self::Keyword => Self::ProtoType::Keyword,
+            Self::Method => Self::ProtoType::Method,
+            Self::Module => Self::ProtoType::Module,
+            Self::Property => Self::ProtoType::Property,
+            Self::Reference => Self::ProtoType::Reference,
+            Self::Snippet => Self::ProtoType::Snippet,
+            Self::Text => Self::ProtoType::Text,
+            Self::Unit => Self::ProtoType::Unit,
+            Self::Value => Self::ProtoType::Value,
+            Self::Variable => Self::ProtoType::Variable,
         }
     }
 
     fn from_proto(payload: Self::ProtoType) -> Self {
         match payload {
-            proto::DapCompletionItemType::Class => dap_types::CompletionItemType::Class,
-            proto::DapCompletionItemType::Color => dap_types::CompletionItemType::Color,
-            proto::DapCompletionItemType::CompletionItemFile => dap_types::CompletionItemType::File,
-            proto::DapCompletionItemType::Constructor => dap_types::CompletionItemType::Constructor,
-            proto::DapCompletionItemType::Customcolor => dap_types::CompletionItemType::Customcolor,
-            proto::DapCompletionItemType::Enum => dap_types::CompletionItemType::Enum,
-            proto::DapCompletionItemType::Field => dap_types::CompletionItemType::Field,
-            proto::DapCompletionItemType::Function => dap_types::CompletionItemType::Function,
-            proto::DapCompletionItemType::Interface => dap_types::CompletionItemType::Interface,
-            proto::DapCompletionItemType::Keyword => dap_types::CompletionItemType::Keyword,
-            proto::DapCompletionItemType::Method => dap_types::CompletionItemType::Method,
-            proto::DapCompletionItemType::Module => dap_types::CompletionItemType::Module,
-            proto::DapCompletionItemType::Property => dap_types::CompletionItemType::Property,
-            proto::DapCompletionItemType::Reference => dap_types::CompletionItemType::Reference,
-            proto::DapCompletionItemType::Snippet => dap_types::CompletionItemType::Snippet,
-            proto::DapCompletionItemType::Text => dap_types::CompletionItemType::Text,
-            proto::DapCompletionItemType::Unit => dap_types::CompletionItemType::Unit,
-            proto::DapCompletionItemType::Value => dap_types::CompletionItemType::Value,
-            proto::DapCompletionItemType::Variable => dap_types::CompletionItemType::Variable,
+            Self::ProtoType::Class => Self::Class,
+            Self::ProtoType::Color => Self::Color,
+            Self::ProtoType::CompletionItemFile => Self::File,
+            Self::ProtoType::Constructor => Self::Constructor,
+            Self::ProtoType::Customcolor => Self::Customcolor,
+            Self::ProtoType::Enum => Self::Enum,
+            Self::ProtoType::Field => Self::Field,
+            Self::ProtoType::Function => Self::Function,
+            Self::ProtoType::Interface => Self::Interface,
+            Self::ProtoType::Keyword => Self::Keyword,
+            Self::ProtoType::Method => Self::Method,
+            Self::ProtoType::Module => Self::Module,
+            Self::ProtoType::Property => Self::Property,
+            Self::ProtoType::Reference => Self::Reference,
+            Self::ProtoType::Snippet => Self::Snippet,
+            Self::ProtoType::Text => Self::Text,
+            Self::ProtoType::Unit => Self::Unit,
+            Self::ProtoType::Value => Self::Value,
+            Self::ProtoType::Variable => Self::Variable,
         }
     }
 }


### PR DESCRIPTION
Closes #ISSUE

Make `ProtoConversion::to_proto` consume `self`. We never create more than one `proto` type out of a single `dap` type, meaning having the conversation be non-consuming has no benefits, while consuming allows us to remove a bunch of clones.

Release Notes:

- N/A
