### PR TITLE
client: Fix ACP registry blog post URL

### DIFF
--- a/crates/client/src/zed_urls.rs
+++ b/crates/client/src/zed_urls.rs
@@ -70,7 +70,10 @@ pub fn edit_prediction_docs(cx: &App) -> String {
 
 /// Returns the URL to Zed's ACP registry blog post.
 pub fn acp_registry_blog(cx: &App) -> String {
-    format!("{server_url}/blog/acp-registry", server_url = server_url(cx))
+    format!(
+        "{server_url}/blog/acp-registry",
+        server_url = server_url(cx)
+    )
 }
 
 pub fn shared_agent_thread_url(session_id: &str) -> String {

--- a/crates/client/src/zed_urls.rs
+++ b/crates/client/src/zed_urls.rs
@@ -70,7 +70,7 @@ pub fn edit_prediction_docs(cx: &App) -> String {
 
 /// Returns the URL to Zed's ACP registry blog post.
 pub fn acp_registry_blog(cx: &App) -> String {
-    format!("{server_url}/blog/acp-registy", server_url = server_url(cx))
+    format!("{server_url}/blog/acp-registry", server_url = server_url(cx))
 }
 
 pub fn shared_agent_thread_url(session_id: &str) -> String {


### PR DESCRIPTION
Closes #47882

Release Notes:

- Fixed a typo in the link to the ACP registry URL blog post
