### PR TITLE
git: Hide toggle split diff button behind flag (cherry-pick #47878)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7251,6 +7251,7 @@ dependencies = [
  "ctor",
  "db",
  "editor",
+ "feature_flags",
  "futures 0.3.31",
  "fuzzy",
  "git",

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -72,7 +72,7 @@ pub use multi_buffer::{
     MultiBufferOffset, MultiBufferOffsetUtf16, MultiBufferSnapshot, PathKey, RowInfo, ToOffset,
     ToPoint,
 };
-pub use split::{SplittableEditor, ToggleLockedCursors, ToggleSplitDiff};
+pub use split::{SplitDiffFeatureFlag, SplittableEditor, ToggleLockedCursors, ToggleSplitDiff};
 pub use split_editor_view::SplitEditorView;
 pub use text::Bias;
 

--- a/crates/editor/src/split.rs
+++ b/crates/editor/src/split.rs
@@ -237,7 +237,7 @@ where
     })
 }
 
-struct SplitDiffFeatureFlag;
+pub struct SplitDiffFeatureFlag;
 
 impl FeatureFlag for SplitDiffFeatureFlag {
     const NAME: &'static str = "split-diff";

--- a/crates/git_ui/Cargo.toml
+++ b/crates/git_ui/Cargo.toml
@@ -27,6 +27,7 @@ command_palette_hooks.workspace = true
 component.workspace = true
 db.workspace = true
 editor.workspace = true
+feature_flags.workspace = true
 futures.workspace = true
 fuzzy.workspace = true
 git.workspace = true


### PR DESCRIPTION
Release Notes:

- N/A