### PR TITLE
git: Use CDN endpoint for GitHub avatars to avoid rate limiting

### DIFF
--- a/crates/git/src/hosting_provider.rs
+++ b/crates/git/src/hosting_provider.rs
@@ -42,10 +42,11 @@ impl GitRemote {
     pub async fn avatar_url(
         &self,
         commit: SharedString,
+        author_email: Option<SharedString>,
         client: Arc<dyn HttpClient>,
     ) -> Option<Url> {
         self.host
-            .commit_author_avatar_url(&self.owner, &self.repo, commit, client)
+            .commit_author_avatar_url(&self.owner, &self.repo, commit, author_email, client)
             .await
             .ok()
             .flatten()
@@ -139,6 +140,7 @@ pub trait GitHostingProvider {
         _repo_owner: &str,
         _repo: &str,
         _commit: SharedString,
+        _author_email: Option<SharedString>,
         _http_client: Arc<dyn HttpClient>,
     ) -> Result<Option<Url>> {
         Ok(None)

--- a/crates/git_graph/src/git_graph.rs
+++ b/crates/git_graph/src/git_graph.rs
@@ -967,7 +967,12 @@ impl GitGraph {
         let remote = repository.update(cx, |repo, cx| self.get_remote(repo, window, cx));
 
         let avatar = {
-            let avatar = CommitAvatar::new(&full_sha, remote.as_ref());
+            let author_email_for_avatar = if author_email.is_empty() {
+                None
+            } else {
+                Some(author_email.clone())
+            };
+            let avatar = CommitAvatar::new(&full_sha, author_email_for_avatar, remote.as_ref());
             v_flex()
                 .w(px(64.))
                 .h(px(64.))

--- a/crates/git_hosting_providers/src/providers/bitbucket.rs
+++ b/crates/git_hosting_providers/src/providers/bitbucket.rs
@@ -283,6 +283,7 @@ impl GitHostingProvider for Bitbucket {
         repo_owner: &str,
         repo: &str,
         commit: SharedString,
+        _author_email: Option<SharedString>,
         http_client: Arc<dyn HttpClient>,
     ) -> Result<Option<Url>> {
         let commit = commit.to_string();

--- a/crates/git_hosting_providers/src/providers/chromium.rs
+++ b/crates/git_hosting_providers/src/providers/chromium.rs
@@ -169,6 +169,7 @@ impl GitHostingProvider for Chromium {
         _repo_owner: &str,
         repo: &str,
         commit: SharedString,
+        _author_email: Option<SharedString>,
         http_client: Arc<dyn HttpClient>,
     ) -> Result<Option<Url>> {
         let commit = commit.to_string();

--- a/crates/git_hosting_providers/src/providers/forgejo.rs
+++ b/crates/git_hosting_providers/src/providers/forgejo.rs
@@ -233,6 +233,7 @@ impl GitHostingProvider for Forgejo {
         repo_owner: &str,
         repo: &str,
         commit: SharedString,
+        _author_email: Option<SharedString>,
         http_client: Arc<dyn HttpClient>,
     ) -> Result<Option<Url>> {
         let commit = commit.to_string();

--- a/crates/git_hosting_providers/src/providers/gitea.rs
+++ b/crates/git_hosting_providers/src/providers/gitea.rs
@@ -182,6 +182,7 @@ impl GitHostingProvider for Gitea {
         repo_owner: &str,
         repo: &str,
         commit: SharedString,
+        _author_email: Option<SharedString>,
         http_client: Arc<dyn HttpClient>,
     ) -> Result<Option<Url>> {
         let commit = commit.to_string();

--- a/crates/git_hosting_providers/src/providers/gitee.rs
+++ b/crates/git_hosting_providers/src/providers/gitee.rs
@@ -141,6 +141,7 @@ impl GitHostingProvider for Gitee {
         repo_owner: &str,
         repo: &str,
         commit: SharedString,
+        _author_email: Option<SharedString>,
         http_client: Arc<dyn HttpClient>,
     ) -> Result<Option<Url>> {
         let commit = commit.to_string();

--- a/crates/git_hosting_providers/src/providers/gitlab.rs
+++ b/crates/git_hosting_providers/src/providers/gitlab.rs
@@ -234,6 +234,7 @@ impl GitHostingProvider for Gitlab {
         repo_owner: &str,
         repo: &str,
         commit: SharedString,
+        _author_email: Option<SharedString>,
         http_client: Arc<dyn HttpClient>,
     ) -> Result<Option<Url>> {
         let commit = commit.to_string();

--- a/crates/git_ui/src/blame_ui.rs
+++ b/crates/git_ui/src/blame_ui.rs
@@ -44,9 +44,18 @@ impl BlameRenderer for GitBlameRenderer {
         let name = util::truncate_and_trailoff(author_name, GIT_BLAME_MAX_AUTHOR_CHARS_DISPLAYED);
 
         let avatar = if ProjectSettings::get_global(cx).git.blame.show_avatar {
+            let author_email = blame_entry.author_mail.as_ref().map(|email| {
+                SharedString::from(
+                    email
+                        .trim_start_matches('<')
+                        .trim_end_matches('>')
+                        .to_string(),
+                )
+            });
             Some(
                 CommitAvatar::new(
                     &blame_entry.sha.to_string().into(),
+                    author_email,
                     details.as_ref().and_then(|it| it.remote.as_ref()),
                 )
                 .render(window, cx),
@@ -186,8 +195,20 @@ impl BlameRenderer for GitBlameRenderer {
             .unwrap_or("<no name>".to_string())
             .into();
         let author_email = blame.author_mail.as_deref().unwrap_or_default();
-        let avatar = CommitAvatar::new(&sha, details.as_ref().and_then(|it| it.remote.as_ref()))
-            .render(window, cx);
+        let author_email_for_avatar = blame.author_mail.as_ref().map(|email| {
+            SharedString::from(
+                email
+                    .trim_start_matches('<')
+                    .trim_end_matches('>')
+                    .to_string(),
+            )
+        });
+        let avatar = CommitAvatar::new(
+            &sha,
+            author_email_for_avatar,
+            details.as_ref().and_then(|it| it.remote.as_ref()),
+        )
+        .render(window, cx);
 
         let short_commit_id = sha
             .get(..8)

--- a/crates/git_ui/src/commit_view.rs
+++ b/crates/git_ui/src/commit_view.rs
@@ -406,7 +406,11 @@ impl CommitView {
         cx: &mut App,
     ) -> AnyElement {
         let size = size.into();
-        let avatar = CommitAvatar::new(sha, self.remote.as_ref());
+        let avatar = CommitAvatar::new(
+            sha,
+            Some(self.commit.author_email.clone()),
+            self.remote.as_ref(),
+        );
 
         v_flex()
             .w(size)

--- a/crates/git_ui/src/file_history_view.rs
+++ b/crates/git_ui/src/file_history_view.rs
@@ -283,6 +283,7 @@ impl FileHistoryView {
     fn render_commit_avatar(
         &self,
         sha: &SharedString,
+        author_email: Option<SharedString>,
         window: &mut Window,
         cx: &mut App,
     ) -> impl IntoElement {
@@ -290,7 +291,7 @@ impl FileHistoryView {
         let size = rems_from_px(20.);
 
         if let Some(remote) = remote {
-            let avatar_asset = CommitAvatarAsset::new(remote.clone(), sha.clone());
+            let avatar_asset = CommitAvatarAsset::new(remote.clone(), sha.clone(), author_email);
             if let Some(Some(url)) = window.use_asset::<CommitAvatarAsset>(&avatar_asset, cx) {
                 Avatar::new(url.to_string()).size(size)
             } else {
@@ -349,7 +350,12 @@ impl FileHistoryView {
                             .flex_none()
                             .child(Chip::new(pr_number)),
                     )
-                    .child(self.render_commit_avatar(&entry.sha, window, cx))
+                    .child(self.render_commit_avatar(
+                        &entry.sha,
+                        Some(entry.author_email.clone()),
+                        window,
+                        cx,
+                    ))
                     .child(
                         h_flex()
                             .min_w_0()
@@ -395,6 +401,7 @@ impl FileHistoryView {
 #[derive(Clone, Debug)]
 struct CommitAvatarAsset {
     sha: SharedString,
+    author_email: Option<SharedString>,
     remote: GitRemote,
 }
 
@@ -406,8 +413,12 @@ impl std::hash::Hash for CommitAvatarAsset {
 }
 
 impl CommitAvatarAsset {
-    fn new(remote: GitRemote, sha: SharedString) -> Self {
-        Self { remote, sha }
+    fn new(remote: GitRemote, sha: SharedString, author_email: Option<SharedString>) -> Self {
+        Self {
+            remote,
+            sha,
+            author_email,
+        }
     }
 }
 
@@ -428,6 +439,7 @@ impl Asset for CommitAvatarAsset {
                     &source.remote.owner,
                     &source.remote.repo,
                     source.sha.clone(),
+                    source.author_email.clone(),
                     client,
                 )
                 .await


### PR DESCRIPTION
GitHub's commit API endpoint is rate limited to 60 requests/hour for unauthenticated users. This causes avatar loading to fail after toggling blame a few times.

  This PR uses GitHub's CDN avatar endpoint `https://avatars.githubusercontent.com/u/e?email={email}&s=128` instead, which doesn't count against API rate limits. The author email is already available from local git data (blame output), so
  no API calls are needed.

  - When author email is available, constructs the CDN URL directly (zero API calls)
  - Falls back to existing API-based behavior when email is unavailable
  - Adds unit tests for URL construction

  Closes #47590

  ## Test plan
  - [x] `./script/clippy` passes
  - [x] `cargo test -p git_hosting_providers` passes (89 tests including 3 new ones i added)
  - [ ] Manual test: Open a file, toggle git blame, verify avatars load without hitting rate limits

  Release Notes:

  - Fixed GitHub avatar rate limiting in git blame by using CDN endpoint instead of API calls (#47590)