### PR TITLE
git: Fix desynced scrolling between LHS and RHS of side-by-side diff

### DIFF
--- a/crates/collab_ui/src/channel_view.rs
+++ b/crates/collab_ui/src/channel_view.rs
@@ -563,18 +563,22 @@ impl FollowableItem for ChannelView {
         self.remote_id
     }
 
-    fn to_state_proto(&self, window: &Window, cx: &App) -> Option<proto::view::Variant> {
-        let channel_buffer = self.channel_buffer.read(cx);
-        if !channel_buffer.is_connected() {
+    fn to_state_proto(&self, window: &mut Window, cx: &mut App) -> Option<proto::view::Variant> {
+        let (is_connected, channel_id) = {
+            let channel_buffer = self.channel_buffer.read(cx);
+            (channel_buffer.is_connected(), channel_buffer.channel_id.0)
+        };
+        if !is_connected {
             return None;
         }
 
+        let editor_proto = self
+            .editor
+            .update(cx, |editor, cx| editor.to_state_proto(window, cx));
         Some(proto::view::Variant::ChannelView(
             proto::view::ChannelView {
-                channel_id: channel_buffer.channel_id.0,
-                editor: if let Some(proto::view::Variant::Editor(proto)) =
-                    self.editor.read(cx).to_state_proto(window, cx)
-                {
+                channel_id,
+                editor: if let Some(proto::view::Variant::Editor(proto)) = editor_proto {
                     Some(proto)
                 } else {
                     None
@@ -638,12 +642,12 @@ impl FollowableItem for ChannelView {
         &self,
         event: &EditorEvent,
         update: &mut Option<proto::update_view::Variant>,
-        window: &Window,
-        cx: &App,
+        window: &mut Window,
+        cx: &mut App,
     ) -> bool {
-        self.editor
-            .read(cx)
-            .add_event_to_update_proto(event, update, window, cx)
+        self.editor.update(cx, |editor, cx| {
+            editor.add_event_to_update_proto(event, update, window, cx)
+        })
     }
 
     fn apply_update_proto(

--- a/crates/debugger_ui/src/session.rs
+++ b/crates/debugger_ui/src/session.rs
@@ -141,7 +141,7 @@ impl FollowableItem for DebugSession {
         self.remote_id
     }
 
-    fn to_state_proto(&self, _window: &Window, _cx: &App) -> Option<proto::view::Variant> {
+    fn to_state_proto(&self, _window: &mut Window, _cx: &mut App) -> Option<proto::view::Variant> {
         None
     }
 
@@ -159,8 +159,8 @@ impl FollowableItem for DebugSession {
         &self,
         _event: &Self::Event,
         _update: &mut Option<proto::update_view::Variant>,
-        _window: &Window,
-        _cx: &App,
+        _window: &mut Window,
+        _cx: &mut App,
     ) -> bool {
         // update.get_or_insert_with(|| proto::update_view::Variant::DebugPanel(Default::default()));
 

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -2769,7 +2769,7 @@ pub mod tests {
 
         _ = cx.update_window(window, |_, window, cx| {
             let text_layout_details =
-                editor.update(cx, |editor, _cx| editor.text_layout_details(window));
+                editor.update(cx, |editor, cx| editor.text_layout_details(window, cx));
 
             let font_size = px(12.0);
             let wrap_width = Some(px(96.));

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -480,7 +480,37 @@ impl DisplayMap {
             });
         }
 
+        let companion_display_snapshot = self.companion.as_ref().and_then(|(companion_dm, _)| {
+            companion_dm
+                .update(cx, |dm, cx| Arc::new(dm.snapshot_simple(cx)))
+                .ok()
+        });
+
         DisplaySnapshot {
+            display_map_id: self.entity_id,
+            companion_display_snapshot,
+            block_snapshot,
+            diagnostics_max_severity: self.diagnostics_max_severity,
+            crease_snapshot: self.crease_map.snapshot(),
+            text_highlights: self.text_highlights.clone(),
+            inlay_highlights: self.inlay_highlights.clone(),
+            clip_at_line_ends: self.clip_at_line_ends,
+            masked: self.masked,
+            fold_placeholder: self.fold_placeholder.clone(),
+        }
+    }
+
+    fn snapshot_simple(&mut self, cx: &mut Context<Self>) -> DisplaySnapshot {
+        let (wrap_snapshot, wrap_edits) = self.sync_through_wrap(cx);
+
+        let block_snapshot = self
+            .block_map
+            .read(wrap_snapshot, wrap_edits, None, None)
+            .snapshot;
+
+        DisplaySnapshot {
+            display_map_id: self.entity_id,
+            companion_display_snapshot: None,
             block_snapshot,
             diagnostics_max_severity: self.diagnostics_max_severity,
             crease_snapshot: self.crease_map.snapshot(),
@@ -1547,6 +1577,8 @@ impl<'a> HighlightedChunk<'a> {
 
 #[derive(Clone)]
 pub struct DisplaySnapshot {
+    pub display_map_id: EntityId,
+    pub companion_display_snapshot: Option<Arc<DisplaySnapshot>>,
     pub crease_snapshot: CreaseSnapshot,
     block_snapshot: BlockSnapshot,
     text_highlights: TextHighlights,
@@ -1558,6 +1590,10 @@ pub struct DisplaySnapshot {
 }
 
 impl DisplaySnapshot {
+    pub fn companion_snapshot(&self) -> Option<&DisplaySnapshot> {
+        self.companion_display_snapshot.as_deref()
+    }
+
     pub fn wrap_snapshot(&self) -> &WrapSnapshot {
         &self.block_snapshot.wrap_snapshot
     }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1328,7 +1328,6 @@ pub struct Editor {
     folding_newlines: Task<()>,
     select_next_is_case_sensitive: Option<bool>,
     pub lookup_key: Option<Box<dyn Any + Send + Sync>>,
-    scroll_companion: Option<WeakEntity<Editor>>,
     on_local_selections_changed:
         Option<Box<dyn Fn(Point, &mut Window, &mut Context<Self>) + 'static>>,
     suppress_selection_callback: bool,
@@ -2538,7 +2537,6 @@ impl Editor {
             folding_newlines: Task::ready(()),
             lookup_key: None,
             select_next_is_case_sensitive: None,
-            scroll_companion: None,
             on_local_selections_changed: None,
             suppress_selection_callback: false,
             applicable_language_settings: HashMap::default(),
@@ -21050,14 +21048,6 @@ impl Editor {
 
     pub fn set_delegate_expand_excerpts(&mut self, delegate: bool) {
         self.delegate_expand_excerpts = delegate;
-    }
-
-    pub fn set_scroll_companion(&mut self, companion: Option<WeakEntity<Editor>>) {
-        self.scroll_companion = companion;
-    }
-
-    pub fn scroll_companion(&self) -> Option<&WeakEntity<Editor>> {
-        self.scroll_companion.as_ref()
     }
 
     pub fn set_on_local_selections_changed(

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -58,8 +58,8 @@ pub use editor_settings::{
     HideMouseMode, ScrollBeyondLastLine, ScrollbarAxes, SearchSettings, ShowMinimap,
 };
 pub use element::{
-    CursorLayout, EditorElement, HighlightedRange, HighlightedRangeLine, OverlayPainter,
-    OverlayPainterData, PointForPosition, render_breadcrumb_text,
+    CursorLayout, EditorElement, HighlightedRange, HighlightedRangeLine, PointForPosition,
+    render_breadcrumb_text,
 };
 pub use git::blame::BlameRenderer;
 pub use hover_popover::hover_markdown_style;

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1972,7 +1972,7 @@ impl Editor {
         let multi_buffer_snapshot = multi_buffer.snapshot(cx);
         let multi_buffer_visible_start = self
             .scroll_manager
-            .anchor(display_snapshot, cx)
+            .native_anchor(display_snapshot, cx)
             .anchor
             .to_point(&multi_buffer_snapshot);
         let max_row = multi_buffer_snapshot.max_point().row;
@@ -2576,8 +2576,9 @@ impl Editor {
                         editor.hide_signature_help(cx, SignatureHelpHiddenBy::Escape);
                         editor.inline_blame_popover.take();
                         let snapshot = editor.snapshot(window, cx);
-                        let new_anchor =
-                            editor.scroll_manager.anchor(&snapshot.display_snapshot, cx);
+                        let new_anchor = editor
+                            .scroll_manager
+                            .native_anchor(&snapshot.display_snapshot, cx);
                         editor.update_restoration_data(cx, move |data| {
                             data.scroll_position = (
                                 new_anchor.top_row(snapshot.buffer_snapshot()),
@@ -5580,7 +5581,7 @@ impl Editor {
         let multi_buffer_snapshot = multi_buffer.snapshot(cx);
         let multi_buffer_visible_start = self
             .scroll_manager
-            .anchor(&display_snapshot, cx)
+            .native_anchor(&display_snapshot, cx)
             .anchor
             .to_point(&multi_buffer_snapshot);
         let multi_buffer_visible_end = multi_buffer_snapshot.clip_point(
@@ -7552,7 +7553,7 @@ impl Editor {
         if on_buffer_edit || query_changed {
             let multi_buffer_visible_start = self
                 .scroll_manager
-                .anchor(&display_snapshot, cx)
+                .native_anchor(&display_snapshot, cx)
                 .anchor
                 .to_point(&multi_buffer_snapshot);
             let multi_buffer_visible_end = multi_buffer_snapshot.clip_point(
@@ -14968,7 +14969,7 @@ impl Editor {
         let display_snapshot = self.display_map.update(cx, |map, cx| map.snapshot(cx));
         let buffer = self.buffer.read(cx).read(cx);
         let cursor_position = cursor_anchor.to_point(&buffer);
-        let scroll_anchor = self.scroll_manager.anchor(&display_snapshot, cx);
+        let scroll_anchor = self.scroll_manager.native_anchor(&display_snapshot, cx);
         let scroll_top_row = scroll_anchor.top_row(&buffer);
         drop(buffer);
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -938,19 +938,34 @@ async fn test_navigation_history(cx: &mut TestAppContext) {
 
             // Set scroll position to check later
             editor.set_scroll_position(gpui::Point::<f64>::new(5.5, 5.5), window, cx);
-            let original_scroll_position = editor.scroll_manager.anchor();
+            let original_scroll_position = editor
+                .scroll_manager
+                .anchor(&editor.display_snapshot(cx), cx);
 
             // Jump to the end of the document and adjust scroll
             editor.move_to_end(&MoveToEnd, window, cx);
             editor.set_scroll_position(gpui::Point::<f64>::new(-2.5, -0.5), window, cx);
-            assert_ne!(editor.scroll_manager.anchor(), original_scroll_position);
+            assert_ne!(
+                editor
+                    .scroll_manager
+                    .anchor(&editor.display_snapshot(cx), cx),
+                original_scroll_position
+            );
 
             let nav_entry = pop_history(&mut editor, cx).unwrap();
             editor.navigate(nav_entry.data.unwrap(), window, cx);
-            assert_eq!(editor.scroll_manager.anchor(), original_scroll_position);
+            assert_eq!(
+                editor
+                    .scroll_manager
+                    .anchor(&editor.display_snapshot(cx), cx),
+                original_scroll_position
+            );
 
             // Ensure we don't panic when navigation data contains invalid anchors *and* points.
-            let mut invalid_anchor = editor.scroll_manager.anchor().anchor;
+            let mut invalid_anchor = editor
+                .scroll_manager
+                .anchor(&editor.display_snapshot(cx), cx)
+                .anchor;
             invalid_anchor.text_anchor.buffer_id = BufferId::new(999).ok();
             let invalid_point = Point::new(9999, 0);
             editor.navigate(
@@ -17708,12 +17723,14 @@ async fn test_following(cx: &mut TestAppContext) {
                 &leader_entity,
                 window,
                 move |_, leader, event, window, cx| {
-                    leader.read(cx).add_event_to_update_proto(
-                        event,
-                        &mut update.borrow_mut(),
-                        window,
-                        cx,
-                    );
+                    leader.update(cx, |leader, cx| {
+                        leader.add_event_to_update_proto(
+                            event,
+                            &mut update.borrow_mut(),
+                            window,
+                            cx,
+                        );
+                    });
                 },
             )
             .detach();
@@ -17934,12 +17951,9 @@ async fn test_following_with_multiple_excerpts(cx: &mut TestAppContext) {
         let update = update_message.clone();
         |_, window, cx| {
             cx.subscribe_in(&leader, window, move |_, leader, event, window, cx| {
-                leader.read(cx).add_event_to_update_proto(
-                    event,
-                    &mut update.borrow_mut(),
-                    window,
-                    cx,
-                );
+                leader.update(cx, |leader, cx| {
+                    leader.add_event_to_update_proto(event, &mut update.borrow_mut(), window, cx);
+                });
             })
             .detach();
         }

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -940,7 +940,7 @@ async fn test_navigation_history(cx: &mut TestAppContext) {
             editor.set_scroll_position(gpui::Point::<f64>::new(5.5, 5.5), window, cx);
             let original_scroll_position = editor
                 .scroll_manager
-                .anchor(&editor.display_snapshot(cx), cx);
+                .native_anchor(&editor.display_snapshot(cx), cx);
 
             // Jump to the end of the document and adjust scroll
             editor.move_to_end(&MoveToEnd, window, cx);
@@ -948,7 +948,7 @@ async fn test_navigation_history(cx: &mut TestAppContext) {
             assert_ne!(
                 editor
                     .scroll_manager
-                    .anchor(&editor.display_snapshot(cx), cx),
+                    .native_anchor(&editor.display_snapshot(cx), cx),
                 original_scroll_position
             );
 
@@ -957,14 +957,14 @@ async fn test_navigation_history(cx: &mut TestAppContext) {
             assert_eq!(
                 editor
                     .scroll_manager
-                    .anchor(&editor.display_snapshot(cx), cx),
+                    .native_anchor(&editor.display_snapshot(cx), cx),
                 original_scroll_position
             );
 
             // Ensure we don't panic when navigation data contains invalid anchors *and* points.
             let mut invalid_anchor = editor
                 .scroll_manager
-                .anchor(&editor.display_snapshot(cx), cx)
+                .native_anchor(&editor.display_snapshot(cx), cx)
                 .anchor;
             invalid_anchor.text_anchor.buffer_id = BufferId::new(999).ok();
             let invalid_point = Point::new(9999, 0);

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -10210,7 +10210,7 @@ impl Element for EditorElement {
 
                     self.editor.update(cx, |editor, cx| {
                         if editor.scroll_manager.clamp_scroll_left(scroll_max.x, cx) {
-                            scroll_position.x = editor.scroll_manager.offset(cx).x;
+                            scroll_position.x = scroll_max.x.min(scroll_position.x);
                         }
 
                         if needs_horizontal_autoscroll.0

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -10232,7 +10232,7 @@ impl Element for EditorElement {
 
                     self.editor.update(cx, |editor, cx| {
                         if editor.scroll_manager.clamp_scroll_left(scroll_max.x, cx) {
-                            scroll_position.x = scroll_position.x.min(scroll_max.x);
+                            scroll_position.x = editor.scroll_manager.offset(cx).x;
                         }
 
                         if needs_horizontal_autoscroll.0

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -4537,7 +4537,9 @@ impl EditorElement {
         let mut end_rows = Vec::<DisplayRow>::new();
         let mut rows = Vec::<StickyHeader>::new();
 
-        let items = editor.sticky_headers(style, cx).unwrap_or_default();
+        let items = editor
+            .sticky_headers(&snapshot.display_snapshot, style, cx)
+            .unwrap_or_default();
 
         for item in items {
             let start_point = item.range.start.to_point(snapshot.buffer_snapshot());
@@ -5239,7 +5241,7 @@ impl EditorElement {
                 snapshot,
                 visible_display_row_range.clone(),
                 max_size,
-                &editor.text_layout_details(window),
+                &editor.text_layout_details(window, cx),
                 window,
                 cx,
             )
@@ -10229,7 +10231,7 @@ impl Element for EditorElement {
                     );
 
                     self.editor.update(cx, |editor, cx| {
-                        if editor.scroll_manager.clamp_scroll_left(scroll_max.x) {
+                        if editor.scroll_manager.clamp_scroll_left(scroll_max.x, cx) {
                             scroll_position.x = scroll_position.x.min(scroll_max.x);
                         }
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -9632,38 +9632,6 @@ impl Element for EditorElement {
                         }
                     };
 
-                    // When jumping from one side of a side-by-side diff to the
-                    // other, we autoscroll autoscroll to keep the target range in view.
-                    //
-                    // If our scroll companion has a pending autoscroll request, process it
-                    // first so that both editors render with synchronized scroll positions.
-                    // This is important for split diff views where one editor may prepaint
-                    // before the other.
-                    if let Some(companion) = self
-                        .editor
-                        .read(cx)
-                        .scroll_companion()
-                        .and_then(|c| c.upgrade())
-                    {
-                        if companion.read(cx).scroll_manager.has_autoscroll_request() {
-                            companion.update(cx, |companion_editor, cx| {
-                                let companion_autoscroll_request =
-                                    companion_editor.scroll_manager.take_autoscroll_request();
-                                companion_editor.autoscroll_vertically(
-                                    bounds,
-                                    line_height,
-                                    max_scroll_top,
-                                    companion_autoscroll_request,
-                                    window,
-                                    cx,
-                                );
-                            });
-                            snapshot = self
-                                .editor
-                                .update(cx, |editor, cx| editor.snapshot(window, cx));
-                        }
-                    }
-
                     let (
                         autoscroll_request,
                         autoscroll_containing_element,

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -216,7 +216,7 @@ impl FollowableItem for Editor {
         }
 
         let display_snapshot = self.display_map.update(cx, |map, cx| map.snapshot(cx));
-        let scroll_anchor = self.scroll_manager.anchor(&display_snapshot, cx);
+        let scroll_anchor = self.scroll_manager.native_anchor(&display_snapshot, cx);
         let buffer = self.buffer.read(cx);
         let excerpts = buffer
             .read(cx)
@@ -310,7 +310,7 @@ impl FollowableItem for Editor {
                 EditorEvent::ScrollPositionChanged { autoscroll, .. } if !autoscroll => {
                     let display_snapshot = self.display_map.update(cx, |map, cx| map.snapshot(cx));
                     let snapshot = self.buffer.read(cx).snapshot(cx);
-                    let scroll_anchor = self.scroll_manager.anchor(&display_snapshot, cx);
+                    let scroll_anchor = self.scroll_manager.native_anchor(&display_snapshot, cx);
                     update.scroll_top_anchor =
                         Some(serialize_anchor(&scroll_anchor.anchor, &snapshot));
                     update.scroll_x = scroll_anchor.offset.x;

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -204,17 +204,20 @@ impl FollowableItem for Editor {
         cx.notify();
     }
 
-    fn to_state_proto(&self, _: &Window, cx: &App) -> Option<proto::view::Variant> {
-        let buffer = self.buffer.read(cx);
-        if buffer
+    fn to_state_proto(&self, _: &mut Window, cx: &mut App) -> Option<proto::view::Variant> {
+        let is_private = self
+            .buffer
+            .read(cx)
             .as_singleton()
             .and_then(|buffer| buffer.read(cx).file())
-            .is_some_and(|file| file.is_private())
-        {
+            .is_some_and(|file| file.is_private());
+        if is_private {
             return None;
         }
 
-        let scroll_anchor = self.scroll_manager.anchor();
+        let display_snapshot = self.display_map.update(cx, |map, cx| map.snapshot(cx));
+        let scroll_anchor = self.scroll_manager.anchor(&display_snapshot, cx);
+        let buffer = self.buffer.read(cx);
         let excerpts = buffer
             .read(cx)
             .excerpts()
@@ -269,8 +272,8 @@ impl FollowableItem for Editor {
         &self,
         event: &EditorEvent,
         update: &mut Option<proto::update_view::Variant>,
-        _: &Window,
-        cx: &App,
+        _: &mut Window,
+        cx: &mut App,
     ) -> bool {
         let update =
             update.get_or_insert_with(|| proto::update_view::Variant::Editor(Default::default()));
@@ -305,8 +308,9 @@ impl FollowableItem for Editor {
                     true
                 }
                 EditorEvent::ScrollPositionChanged { autoscroll, .. } if !autoscroll => {
+                    let display_snapshot = self.display_map.update(cx, |map, cx| map.snapshot(cx));
                     let snapshot = self.buffer.read(cx).snapshot(cx);
-                    let scroll_anchor = self.scroll_manager.anchor();
+                    let scroll_anchor = self.scroll_manager.anchor(&display_snapshot, cx);
                     update.scroll_top_anchor =
                         Some(serialize_anchor(&scroll_anchor.anchor, &snapshot));
                     update.scroll_x = scroll_anchor.offset.x;

--- a/crates/editor/src/mouse_context_menu.rs
+++ b/crates/editor/src/mouse_context_menu.rs
@@ -331,7 +331,7 @@ pub fn deploy_context_menu(
             cx,
         ),
         None => {
-            let character_size = editor.character_dimensions(window);
+            let character_size = editor.character_dimensions(window, cx);
             let menu_position = MenuPosition::PinnedToEditor {
                 source: source_anchor,
                 offset: gpui::point(character_size.em_width, character_size.line_height),

--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -4,7 +4,7 @@
 use super::{Bias, DisplayPoint, DisplaySnapshot, SelectionGoal, ToDisplayPoint};
 use crate::{
     DisplayRow, EditorStyle, ToOffset, ToPoint,
-    scroll::{ScrollAnchor, ScrollOffset},
+    scroll::{ScrollOffset, SharedScrollAnchor},
 };
 use gpui::{Pixels, WindowTextSystem};
 use language::{CharClassifier, Point};
@@ -29,7 +29,7 @@ pub struct TextLayoutDetails {
     pub(crate) text_system: Arc<WindowTextSystem>,
     pub(crate) editor_style: EditorStyle,
     pub(crate) rem_size: Pixels,
-    pub scroll_anchor: ScrollAnchor,
+    pub scroll_anchor: SharedScrollAnchor,
     pub visible_rows: Option<f64>,
     pub vertical_scroll_margin: ScrollOffset,
 }
@@ -1224,7 +1224,8 @@ mod tests {
         let editor = cx.editor.clone();
         let window = cx.window;
         _ = cx.update_window(window, |_, window, cx| {
-            let text_layout_details = editor.read(cx).text_layout_details(window);
+            let text_layout_details =
+                editor.update(cx, |editor, cx| editor.text_layout_details(window, cx));
 
             let font = font("Helvetica");
 

--- a/crates/editor/src/scroll.rs
+++ b/crates/editor/src/scroll.rs
@@ -603,20 +603,6 @@ impl Editor {
             cx,
         );
 
-        if local && was_scrolled.0 {
-            if let Some(companion) = self.scroll_companion.as_ref().and_then(|c| c.upgrade()) {
-                companion.update(cx, |companion_editor, cx| {
-                    companion_editor.set_scroll_position_internal(
-                        scroll_position,
-                        false,
-                        false,
-                        window,
-                        cx,
-                    );
-                });
-            }
-        }
-
         was_scrolled
     }
 

--- a/crates/editor/src/scroll.rs
+++ b/crates/editor/src/scroll.rs
@@ -616,6 +616,10 @@ impl ScrollManager {
 }
 
 impl Editor {
+    pub fn has_autoscroll_request(&self) -> bool {
+        self.scroll_manager.has_autoscroll_request()
+    }
+
     pub fn vertical_scroll_margin(&self) -> usize {
         self.scroll_manager.vertical_scroll_margin as usize
     }

--- a/crates/editor/src/scroll.rs
+++ b/crates/editor/src/scroll.rs
@@ -436,6 +436,7 @@ impl ScrollManager {
             anchor
         };
 
+        self.scroll_max_x.take();
         self.autoscroll_request.take();
 
         let current = self.anchor.read(cx);

--- a/crates/editor/src/scroll/autoscroll.rs
+++ b/crates/editor/src/scroll/autoscroll.rs
@@ -115,7 +115,7 @@ impl Editor {
         let viewport_height = bounds.size.height;
         let visible_lines = ScrollOffset::from(viewport_height / line_height);
         let display_map = self.display_map.update(cx, |map, cx| map.snapshot(cx));
-        let mut scroll_position = self.scroll_manager.scroll_position(&display_map);
+        let mut scroll_position = self.scroll_manager.scroll_position(&display_map, cx);
         let original_y = scroll_position.y;
         if let Some(last_bounds) = self.expect_bounds_change.take()
             && scroll_position.y != 0.
@@ -201,7 +201,7 @@ impl Editor {
                 .last_autoscroll
                 .as_ref()
                 .filter(|(offset, last_target_top, last_target_bottom, _)| {
-                    self.scroll_manager.anchor.offset == *offset
+                    self.scroll_manager.anchor(&display_map, cx).offset == *offset
                         && target_top == *last_target_top
                         && target_bottom == *last_target_bottom
                 })
@@ -264,7 +264,7 @@ impl Editor {
         };
 
         self.scroll_manager.last_autoscroll = Some((
-            self.scroll_manager.anchor.offset,
+            self.scroll_manager.anchor(&display_map, cx).offset,
             target_top,
             target_bottom,
             strategy,
@@ -292,7 +292,7 @@ impl Editor {
 
         let display_map = self.display_map.update(cx, |map, cx| map.snapshot(cx));
         let selections = self.selections.all::<Point>(&display_map);
-        let mut scroll_position = self.scroll_manager.scroll_position(&display_map);
+        let mut scroll_position = self.scroll_manager.scroll_position(&display_map, cx);
 
         let mut target_left;
         let mut target_right: f64;
@@ -334,7 +334,7 @@ impl Editor {
             return None;
         }
 
-        let scroll_left = self.scroll_manager.anchor.offset.x * em_advance;
+        let scroll_left = self.scroll_manager.anchor(&display_map, cx).offset.x * em_advance;
         let scroll_right = scroll_left + viewport_width;
 
         let was_scrolled = if target_left < scroll_left {

--- a/crates/editor/src/scroll/autoscroll.rs
+++ b/crates/editor/src/scroll/autoscroll.rs
@@ -201,7 +201,7 @@ impl Editor {
                 .last_autoscroll
                 .as_ref()
                 .filter(|(offset, last_target_top, last_target_bottom, _)| {
-                    self.scroll_manager.anchor(&display_map, cx).offset == *offset
+                    self.scroll_manager.offset(cx) == *offset
                         && target_top == *last_target_top
                         && target_bottom == *last_target_bottom
                 })
@@ -264,7 +264,7 @@ impl Editor {
         };
 
         self.scroll_manager.last_autoscroll = Some((
-            self.scroll_manager.anchor(&display_map, cx).offset,
+            self.scroll_manager.offset(cx),
             target_top,
             target_bottom,
             strategy,
@@ -334,7 +334,7 @@ impl Editor {
             return None;
         }
 
-        let scroll_left = self.scroll_manager.anchor(&display_map, cx).offset.x * em_advance;
+        let scroll_left = self.scroll_manager.offset(cx).x * em_advance;
         let scroll_right = scroll_left + viewport_width;
 
         let was_scrolled = if target_left < scroll_left {

--- a/crates/editor/src/split.rs
+++ b/crates/editor/src/split.rs
@@ -527,12 +527,8 @@ impl SplittableEditor {
             dm.set_companion(Some((rhs_display_map.downgrade(), companion)), cx);
         });
 
-        let rhs_weak = self.rhs_editor.downgrade();
-        let lhs_weak = lhs.editor.downgrade();
-
         let this = cx.entity().downgrade();
         self.rhs_editor.update(cx, |editor, _cx| {
-            editor.set_scroll_companion(Some(lhs_weak));
             let this = this.clone();
             editor.set_on_local_selections_changed(Some(Box::new(
                 move |cursor_position, window, cx| {
@@ -549,7 +545,6 @@ impl SplittableEditor {
             )));
         });
         lhs.editor.update(cx, |editor, _cx| {
-            editor.set_scroll_companion(Some(rhs_weak));
             let this = this.clone();
             editor.set_on_local_selections_changed(Some(Box::new(
                 move |cursor_position, window, cx| {
@@ -564,13 +559,6 @@ impl SplittableEditor {
                     })
                 },
             )));
-        });
-
-        let rhs_scroll_position = self
-            .rhs_editor
-            .update(cx, |editor, cx| editor.scroll_position(cx));
-        lhs.editor.update(cx, |editor, cx| {
-            editor.set_scroll_position_internal(rhs_scroll_position, false, false, window, cx);
         });
 
         // Copy soft wrap state from rhs (source of truth) to lhs
@@ -849,7 +837,6 @@ impl SplittableEditor {
         self.panes.remove(&lhs.pane, cx).unwrap();
         self.rhs_editor.update(cx, |rhs, cx| {
             rhs.set_on_local_selections_changed(None);
-            rhs.set_scroll_companion(None);
             rhs.set_delegate_expand_excerpts(false);
             rhs.buffer().update(cx, |buffer, cx| {
                 buffer.set_show_deleted_hunks(true, cx);
@@ -861,7 +848,6 @@ impl SplittableEditor {
         });
         lhs.editor.update(cx, |editor, _cx| {
             editor.set_on_local_selections_changed(None);
-            editor.set_scroll_companion(None);
         });
         cx.notify();
     }

--- a/crates/editor/src/split.rs
+++ b/crates/editor/src/split.rs
@@ -3570,11 +3570,11 @@ mod tests {
             lhs_editor.update_in(cx, |e, window, cx| e.snapshot(window, cx).scroll_position());
 
         assert!(
-            dbg!(rhs_pos.y) > 0.,
+            rhs_pos.y > 0.,
             "RHS should have scrolled vertically to show cursor at row 25"
         );
         assert!(
-            dbg!(rhs_pos.x) > 0.,
+            rhs_pos.x > 0.,
             "RHS should have scrolled horizontally to show cursor at column 150"
         );
         assert_eq!(

--- a/crates/editor/src/split.rs
+++ b/crates/editor/src/split.rs
@@ -848,7 +848,7 @@ impl SplittableEditor {
         self.panes.remove(&lhs.pane, cx).unwrap();
         self.rhs_editor.update(cx, |rhs, cx| {
             let rhs_snapshot = rhs.display_map.update(cx, |dm, cx| dm.snapshot(cx));
-            let native_anchor = rhs.scroll_manager.anchor(&rhs_snapshot, cx);
+            let native_anchor = rhs.scroll_manager.native_anchor(&rhs_snapshot, cx);
             let rhs_display_map_id = rhs_snapshot.display_map_id;
             rhs.scroll_manager
                 .scroll_anchor_entity()

--- a/crates/editor/src/split.rs
+++ b/crates/editor/src/split.rs
@@ -1678,6 +1678,7 @@ mod tests {
 
     async fn init_test(
         cx: &mut gpui::TestAppContext,
+        soft_wrap: SoftWrap,
     ) -> (Entity<SplittableEditor>, &mut VisualTestContext) {
         cx.update(|cx| {
             let store = SettingsStore::test(cx);
@@ -1703,7 +1704,7 @@ mod tests {
             );
             editor.split(&Default::default(), window, cx);
             editor.rhs_editor.update(cx, |editor, cx| {
-                editor.set_soft_wrap_mode(SoftWrap::EditorWidth, cx);
+                editor.set_soft_wrap_mode(soft_wrap, cx);
             });
             editor
                 .lhs
@@ -1711,7 +1712,7 @@ mod tests {
                 .unwrap()
                 .editor
                 .update(cx, |editor, cx| {
-                    editor.set_soft_wrap_mode(SoftWrap::EditorWidth, cx);
+                    editor.set_soft_wrap_mode(soft_wrap, cx);
                 });
             editor
         });
@@ -1782,7 +1783,7 @@ mod tests {
     async fn test_random_split_editor(mut rng: StdRng, cx: &mut gpui::TestAppContext) {
         use rand::prelude::*;
 
-        let (editor, cx) = init_test(cx).await;
+        let (editor, cx) = init_test(cx, SoftWrap::EditorWidth).await;
         let operations = std::env::var("OPERATIONS")
             .map(|i| i.parse().expect("invalid `OPERATIONS` variable"))
             .unwrap_or(10);
@@ -1866,7 +1867,7 @@ mod tests {
         use rope::Point;
         use unindent::Unindent as _;
 
-        let (editor, mut cx) = init_test(cx).await;
+        let (editor, mut cx) = init_test(cx, SoftWrap::EditorWidth).await;
 
         let base_text = "
             aaa
@@ -1995,7 +1996,7 @@ mod tests {
         use rope::Point;
         use unindent::Unindent as _;
 
-        let (editor, mut cx) = init_test(cx).await;
+        let (editor, mut cx) = init_test(cx, SoftWrap::EditorWidth).await;
 
         let base_text1 = "
             aaa
@@ -2153,7 +2154,7 @@ mod tests {
         use rope::Point;
         use unindent::Unindent as _;
 
-        let (editor, mut cx) = init_test(cx).await;
+        let (editor, mut cx) = init_test(cx, SoftWrap::EditorWidth).await;
 
         let base_text = "
             aaa
@@ -2272,7 +2273,7 @@ mod tests {
         use rope::Point;
         use unindent::Unindent as _;
 
-        let (editor, mut cx) = init_test(cx).await;
+        let (editor, mut cx) = init_test(cx, SoftWrap::EditorWidth).await;
 
         let base_text = "
             aaa
@@ -2401,7 +2402,7 @@ mod tests {
         use rope::Point;
         use unindent::Unindent as _;
 
-        let (editor, mut cx) = init_test(cx).await;
+        let (editor, mut cx) = init_test(cx, SoftWrap::EditorWidth).await;
 
         let base_text = "
             aaa
@@ -2526,7 +2527,7 @@ mod tests {
         use rope::Point;
         use unindent::Unindent as _;
 
-        let (editor, mut cx) = init_test(cx).await;
+        let (editor, mut cx) = init_test(cx, SoftWrap::EditorWidth).await;
 
         let base_text = "
             aaa
@@ -2639,7 +2640,7 @@ mod tests {
         use rope::Point;
         use unindent::Unindent as _;
 
-        let (editor, mut cx) = init_test(cx).await;
+        let (editor, mut cx) = init_test(cx, SoftWrap::EditorWidth).await;
 
         let text = "aaaa bbbb cccc dddd eeee ffff";
 
@@ -2707,7 +2708,7 @@ mod tests {
         use rope::Point;
         use unindent::Unindent as _;
 
-        let (editor, mut cx) = init_test(cx).await;
+        let (editor, mut cx) = init_test(cx, SoftWrap::EditorWidth).await;
 
         let base_text = "
             aaaa bbbb cccc dddd eeee ffff
@@ -2769,7 +2770,7 @@ mod tests {
         use rope::Point;
         use unindent::Unindent as _;
 
-        let (editor, mut cx) = init_test(cx).await;
+        let (editor, mut cx) = init_test(cx, SoftWrap::EditorWidth).await;
 
         let base_text = "
             aaaa bbbb cccc dddd eeee ffff
@@ -2838,7 +2839,7 @@ mod tests {
         use rope::Point;
         use unindent::Unindent as _;
 
-        let (editor, mut cx) = init_test(cx).await;
+        let (editor, mut cx) = init_test(cx, SoftWrap::EditorWidth).await;
 
         let text = "
             aaaa bbbb cccc dddd eeee ffff
@@ -2950,7 +2951,7 @@ mod tests {
         use rope::Point;
         use unindent::Unindent as _;
 
-        let (editor, mut cx) = init_test(cx).await;
+        let (editor, mut cx) = init_test(cx, SoftWrap::EditorWidth).await;
 
         let (buffer1, diff1) = buffer_with_diff("xxx\nyyy", "xxx\nyyy", &mut cx);
 
@@ -3054,7 +3055,7 @@ mod tests {
         use rope::Point;
         use unindent::Unindent as _;
 
-        let (editor, mut cx) = init_test(cx).await;
+        let (editor, mut cx) = init_test(cx, SoftWrap::EditorWidth).await;
 
         let base_text = "
             aaa
@@ -3136,7 +3137,7 @@ mod tests {
         use rope::Point;
         use unindent::Unindent as _;
 
-        let (editor, mut cx) = init_test(cx).await;
+        let (editor, mut cx) = init_test(cx, SoftWrap::EditorWidth).await;
 
         let base_text = "aaaa bbbb cccc dddd eeee ffff\n";
 
@@ -3215,7 +3216,7 @@ mod tests {
         use rope::Point;
         use unindent::Unindent as _;
 
-        let (editor, mut cx) = init_test(cx).await;
+        let (editor, mut cx) = init_test(cx, SoftWrap::EditorWidth).await;
 
         let base_text = "
             aaa
@@ -3337,7 +3338,7 @@ mod tests {
         use rope::Point;
         use unindent::Unindent as _;
 
-        let (editor, mut cx) = init_test(cx).await;
+        let (editor, mut cx) = init_test(cx, SoftWrap::EditorWidth).await;
 
         let base_text = "";
         let current_text = "
@@ -3413,7 +3414,7 @@ mod tests {
         use rope::Point;
         use unindent::Unindent as _;
 
-        let (editor, mut cx) = init_test(cx).await;
+        let (editor, mut cx) = init_test(cx, SoftWrap::EditorWidth).await;
 
         let base_text = "
             aaa
@@ -3499,6 +3500,90 @@ mod tests {
             ccc"
             .unindent(),
             &mut cx,
+        );
+    }
+
+    #[gpui::test]
+    async fn test_scrolling(cx: &mut gpui::TestAppContext) {
+        use crate::test::editor_content_with_blocks_and_size;
+        use gpui::size;
+        use rope::Point;
+
+        let (editor, mut cx) = init_test(cx, SoftWrap::None).await;
+
+        let long_line = "x".repeat(200);
+        let mut lines: Vec<String> = (0..50).map(|i| format!("line {i}")).collect();
+        lines[25] = long_line;
+        let content = lines.join("\n");
+
+        let (buffer, diff) = buffer_with_diff(&content, &content, &mut cx);
+
+        editor.update(cx, |editor, cx| {
+            let path = PathKey::for_buffer(&buffer, cx);
+            editor.set_excerpts_for_path(
+                path,
+                buffer.clone(),
+                vec![Point::new(0, 0)..buffer.read(cx).max_point()],
+                0,
+                diff.clone(),
+                cx,
+            );
+        });
+
+        cx.run_until_parked();
+
+        let (rhs_editor, lhs_editor) = editor.update(cx, |editor, _cx| {
+            let lhs = editor.lhs.as_ref().expect("should have lhs editor");
+            (editor.rhs_editor.clone(), lhs.editor.clone())
+        });
+
+        rhs_editor.update_in(cx, |e, window, cx| {
+            e.set_scroll_position(gpui::Point::new(0., 10.), window, cx);
+        });
+
+        let rhs_pos =
+            rhs_editor.update_in(cx, |e, window, cx| e.snapshot(window, cx).scroll_position());
+        let lhs_pos =
+            lhs_editor.update_in(cx, |e, window, cx| e.snapshot(window, cx).scroll_position());
+        assert_eq!(rhs_pos.y, 10., "RHS should be scrolled to row 10");
+        assert_eq!(
+            lhs_pos.y, rhs_pos.y,
+            "LHS should have same scroll position as RHS after set_scroll_position"
+        );
+
+        let draw_size = size(px(300.), px(300.));
+
+        rhs_editor.update_in(cx, |e, window, cx| {
+            e.change_selections(Some(crate::Autoscroll::fit()).into(), window, cx, |s| {
+                s.select_ranges([Point::new(25, 150)..Point::new(25, 150)]);
+            });
+        });
+
+        let _ = editor_content_with_blocks_and_size(&rhs_editor, draw_size, &mut cx);
+        cx.run_until_parked();
+        let _ = editor_content_with_blocks_and_size(&lhs_editor, draw_size, &mut cx);
+        cx.run_until_parked();
+
+        let rhs_pos =
+            rhs_editor.update_in(cx, |e, window, cx| e.snapshot(window, cx).scroll_position());
+        let lhs_pos =
+            lhs_editor.update_in(cx, |e, window, cx| e.snapshot(window, cx).scroll_position());
+
+        assert!(
+            dbg!(rhs_pos.y) > 0.,
+            "RHS should have scrolled vertically to show cursor at row 25"
+        );
+        assert!(
+            dbg!(rhs_pos.x) > 0.,
+            "RHS should have scrolled horizontally to show cursor at column 150"
+        );
+        assert_eq!(
+            lhs_pos.y, rhs_pos.y,
+            "LHS should have same vertical scroll position as RHS after autoscroll"
+        );
+        assert_eq!(
+            lhs_pos.x, rhs_pos.x,
+            "LHS should have same horizontal scroll position as RHS after autoscroll"
         );
     }
 }

--- a/crates/editor/src/split_editor_view.rs
+++ b/crates/editor/src/split_editor_view.rs
@@ -9,6 +9,7 @@ use gpui::{
 };
 use multi_buffer::{Anchor, ExcerptId};
 use settings::Settings;
+use smallvec::smallvec;
 use text::BufferId;
 use theme::ActiveTheme;
 use ui::scrollbars::ShowScrollbar;
@@ -171,7 +172,10 @@ impl RenderOnce for SplitEditorView {
         let state_for_drag = self.split_state.downgrade();
         let state_for_drop = self.split_state.downgrade();
 
-        let buffer_headers = SplitBufferHeadersElement::new(rhs_editor, self.style.clone());
+        let buffer_headers = SplitBufferHeadersElement::new(rhs_editor.clone(), self.style.clone());
+
+        let lhs_editor_for_order = lhs_editor.clone();
+        let rhs_editor_for_order = rhs_editor.clone();
 
         div()
             .id("split-editor-view-container")
@@ -179,6 +183,14 @@ impl RenderOnce for SplitEditorView {
             .relative()
             .child(
                 h_flex()
+                    .with_dynamic_prepaint_order(move |_window, cx| {
+                        let lhs_needs = lhs_editor_for_order.read(cx).has_autoscroll_request();
+                        let rhs_needs = rhs_editor_for_order.read(cx).has_autoscroll_request();
+                        match (lhs_needs, rhs_needs) {
+                            (false, true) => smallvec![2, 1, 0],
+                            _ => smallvec![0, 1, 2],
+                        }
+                    })
                     .id("split-editor-view")
                     .size_full()
                     .on_drag_move::<DraggedSplitHandle>(move |event, window, cx| {

--- a/crates/editor/src/split_editor_view.rs
+++ b/crates/editor/src/split_editor_view.rs
@@ -174,8 +174,8 @@ impl RenderOnce for SplitEditorView {
 
         let buffer_headers = SplitBufferHeadersElement::new(rhs_editor.clone(), self.style.clone());
 
-        let lhs_editor_for_order = lhs_editor.clone();
-        let rhs_editor_for_order = rhs_editor.clone();
+        let lhs_editor_for_order = lhs_editor;
+        let rhs_editor_for_order = rhs_editor;
 
         div()
             .id("split-editor-view-container")

--- a/crates/editor/src/test.rs
+++ b/crates/editor/src/test.rs
@@ -5,7 +5,7 @@ use std::{rc::Rc, sync::LazyLock};
 
 pub use crate::rust_analyzer_ext::expand_macro_recursively;
 use crate::{
-    DisplayPoint, Editor, EditorMode, FoldPlaceholder, MultiBuffer, SelectionEffects,
+    DisplayPoint, Editor, EditorMode, FoldPlaceholder, MultiBuffer, SelectionEffects, Size,
     display_map::{
         Block, BlockPlacement, CustomBlockId, DisplayMap, DisplayRow, DisplaySnapshot,
         ToDisplayPoint,
@@ -184,7 +184,15 @@ pub fn editor_content_with_blocks_and_width(
     width: Pixels,
     cx: &mut VisualTestContext,
 ) -> String {
-    let draw_size = size(width, px(3000.0));
+    editor_content_with_blocks_and_size(editor, size(width, px(3000.0)), cx)
+}
+
+pub fn editor_content_with_blocks_and_size(
+    editor: &Entity<Editor>,
+    draw_size: Size<Pixels>,
+    cx: &mut VisualTestContext,
+) -> String {
+    let draw_size = draw_size;
     cx.simulate_resize(draw_size);
     cx.draw(gpui::Point::default(), draw_size, |_, _| editor.clone());
     let (snapshot, mut lines, blocks) = editor.update_in(cx, |editor, window, cx| {

--- a/crates/editor/src/test.rs
+++ b/crates/editor/src/test.rs
@@ -192,7 +192,6 @@ pub fn editor_content_with_blocks_and_size(
     draw_size: Size<Pixels>,
     cx: &mut VisualTestContext,
 ) -> String {
-    let draw_size = draw_size;
     cx.simulate_resize(draw_size);
     cx.draw(gpui::Point::default(), draw_size, |_, _| editor.clone());
     let (snapshot, mut lines, blocks) = editor.update_in(cx, |editor, window, cx| {

--- a/crates/editor/src/test/editor_test_context.rs
+++ b/crates/editor/src/test/editor_test_context.rs
@@ -287,7 +287,7 @@ impl EditorTestContext {
                 .text
                 .line_height_in_pixels(window.rem_size());
             let snapshot = editor.snapshot(window, cx);
-            let details = editor.text_layout_details(window);
+            let details = editor.text_layout_details(window, cx);
 
             let y = pixel_position.y
                 + f32::from(line_height)

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -1311,7 +1311,7 @@ impl BufferSearchBar {
                 let search = self.update_matches(false, true, window, cx);
 
                 let width = editor.update(cx, |editor, cx| {
-                    let text_layout_details = editor.text_layout_details(window);
+                    let text_layout_details = editor.text_layout_details(window, cx);
                     let snapshot = editor.snapshot(window, cx).display_snapshot;
 
                     snapshot.x_for_display_point(snapshot.max_point(), &text_layout_details)

--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -2355,7 +2355,7 @@ impl Vim {
             let start = editor
                 .selections
                 .newest_display(&editor.display_snapshot(cx));
-            let text_layout_details = editor.text_layout_details(window);
+            let text_layout_details = editor.text_layout_details(window, cx);
             let (mut range, _) = motion
                 .range(
                     &snapshot,

--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -128,7 +128,7 @@ impl Vim {
         cx: &mut Context<Self>,
     ) {
         self.update_editor(cx, |_, editor, cx| {
-            let text_layout_details = editor.text_layout_details(window);
+            let text_layout_details = editor.text_layout_details(window, cx);
             editor.change_selections(Default::default(), window, cx, |s| {
                 if let Motion::ZedSearchResult { new_selections, .. } = &motion {
                     s.select_anchor_ranges(new_selections.clone());
@@ -319,7 +319,7 @@ impl Vim {
         cx: &mut Context<Self>,
     ) {
         self.update_editor(cx, |_, editor, cx| {
-            let text_layout_details = editor.text_layout_details(window);
+            let text_layout_details = editor.text_layout_details(window, cx);
             editor.change_selections(Default::default(), window, cx, |s| {
                 s.move_with(|map, selection| {
                     let goal = selection.goal;
@@ -399,7 +399,7 @@ impl Vim {
                 // In Helix mode, EndOfLine should position cursor ON the last character,
                 // not after it. We therefore need special handling for it.
                 self.update_editor(cx, |_, editor, cx| {
-                    let text_layout_details = editor.text_layout_details(window);
+                    let text_layout_details = editor.text_layout_details(window, cx);
                     editor.change_selections(Default::default(), window, cx, |s| {
                         s.move_with(|map, selection| {
                             let goal = selection.goal;

--- a/crates/vim/src/indent.rs
+++ b/crates/vim/src/indent.rs
@@ -102,7 +102,7 @@ impl Vim {
     ) {
         self.stop_recording(cx);
         self.update_editor(cx, |_, editor, cx| {
-            let text_layout_details = editor.text_layout_details(window);
+            let text_layout_details = editor.text_layout_details(window, cx);
             editor.transact(window, cx, |editor, window, cx| {
                 let mut selection_starts: HashMap<_, _> = Default::default();
                 editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {

--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -2871,8 +2871,7 @@ fn window_top(
 ) -> (DisplayPoint, SelectionGoal) {
     let first_visible_line = text_layout_details
         .scroll_anchor
-        .anchor
-        .to_display_point(map);
+        .scroll_top_display_point(map);
 
     if first_visible_line.row() != DisplayRow(0)
         && text_layout_details.vertical_scroll_margin as usize > times
@@ -2907,8 +2906,7 @@ fn window_middle(
     if let Some(visible_rows) = text_layout_details.visible_rows {
         let first_visible_line = text_layout_details
             .scroll_anchor
-            .anchor
-            .to_display_point(map);
+            .scroll_top_display_point(map);
 
         let max_visible_rows =
             (visible_rows as u32).min(map.max_point().row().0 - first_visible_line.row().0);
@@ -2933,10 +2931,10 @@ fn window_bottom(
     if let Some(visible_rows) = text_layout_details.visible_rows {
         let first_visible_line = text_layout_details
             .scroll_anchor
-            .anchor
-            .to_display_point(map);
+            .scroll_top_display_point(map);
         let bottom_row = first_visible_line.row().0
-            + (visible_rows + text_layout_details.scroll_anchor.offset.y - 1.).floor() as u32;
+            + (visible_rows + text_layout_details.scroll_anchor.scroll_anchor.offset.y - 1.).floor()
+                as u32;
         if bottom_row < map.max_point().row().0
             && text_layout_details.vertical_scroll_margin as usize > times
         {

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -579,7 +579,7 @@ impl Vim {
         cx: &mut Context<Self>,
     ) {
         self.update_editor(cx, |vim, editor, cx| {
-            let text_layout_details = editor.text_layout_details(window);
+            let text_layout_details = editor.text_layout_details(window, cx);
 
             // If vim is in temporary mode and the motion being used is
             // `EndOfLine` ($), we'll want to disable clipping at line ends so
@@ -748,7 +748,7 @@ impl Vim {
         self.start_recording(cx);
         self.switch_mode(Mode::Insert, false, window, cx);
         self.update_editor(cx, |_, editor, cx| {
-            let text_layout_details = editor.text_layout_details(window);
+            let text_layout_details = editor.text_layout_details(window, cx);
             editor.transact(window, cx, |editor, window, cx| {
                 let selections = editor.selections.all::<Point>(&editor.display_snapshot(cx));
                 let snapshot = editor.buffer().read(cx).snapshot(cx);

--- a/crates/vim/src/normal/change.rs
+++ b/crates/vim/src/normal/change.rs
@@ -35,7 +35,7 @@ impl Vim {
             None
         };
         self.update_editor(cx, |vim, editor, cx| {
-            let text_layout_details = editor.text_layout_details(window);
+            let text_layout_details = editor.text_layout_details(window, cx);
             editor.transact(window, cx, |editor, window, cx| {
                 // We are swapping to insert mode anyway. Just set the line end clipping behavior now
                 editor.set_clip_at_line_ends(false, cx);

--- a/crates/vim/src/normal/convert.rs
+++ b/crates/vim/src/normal/convert.rs
@@ -33,7 +33,7 @@ impl Vim {
         self.stop_recording(cx);
         self.update_editor(cx, |_, editor, cx| {
             editor.set_clip_at_line_ends(false, cx);
-            let text_layout_details = editor.text_layout_details(window);
+            let text_layout_details = editor.text_layout_details(window, cx);
             editor.transact(window, cx, |editor, window, cx| {
                 let mut selection_starts: HashMap<_, _> = Default::default();
                 editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {

--- a/crates/vim/src/normal/delete.rs
+++ b/crates/vim/src/normal/delete.rs
@@ -24,7 +24,7 @@ impl Vim {
     ) {
         self.stop_recording(cx);
         self.update_editor(cx, |vim, editor, cx| {
-            let text_layout_details = editor.text_layout_details(window);
+            let text_layout_details = editor.text_layout_details(window, cx);
             editor.transact(window, cx, |editor, window, cx| {
                 editor.set_clip_at_line_ends(false, cx);
                 let mut original_columns: HashMap<_, _> = Default::default();

--- a/crates/vim/src/normal/paste.rs
+++ b/crates/vim/src/normal/paste.rs
@@ -36,7 +36,7 @@ impl Vim {
         Vim::take_forced_motion(cx);
 
         self.update_editor(cx, |vim, editor, cx| {
-            let text_layout_details = editor.text_layout_details(window);
+            let text_layout_details = editor.text_layout_details(window, cx);
             editor.transact(window, cx, |editor, window, cx| {
                 editor.set_clip_at_line_ends(false, cx);
 
@@ -283,7 +283,7 @@ impl Vim {
         self.stop_recording(cx);
         let selected_register = self.selected_register.take();
         self.update_editor(cx, |_, editor, cx| {
-            let text_layout_details = editor.text_layout_details(window);
+            let text_layout_details = editor.text_layout_details(window, cx);
             editor.transact(window, cx, |editor, window, cx| {
                 editor.set_clip_at_line_ends(false, cx);
                 editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {

--- a/crates/vim/src/normal/scroll.rs
+++ b/crates/vim/src/normal/scroll.rs
@@ -1,7 +1,6 @@
 use crate::{Vim, state::Mode};
 use editor::{
-    DisplayPoint, Editor, EditorSettings, SelectionEffects,
-    display_map::{DisplayRow, ToDisplayPoint},
+    DisplayPoint, Editor, EditorSettings, SelectionEffects, display_map::DisplayRow,
     scroll::ScrollAmount,
 };
 use gpui::{Context, Window, actions};
@@ -113,7 +112,10 @@ fn scroll_editor(
     cx: &mut Context<Editor>,
 ) {
     let should_move_cursor = editor.newest_selection_on_screen(cx).is_eq();
-    let old_top_anchor = editor.scroll_manager.anchor().anchor;
+    let display_snapshot = editor.display_map.update(cx, |map, cx| map.snapshot(cx));
+    let old_top = editor
+        .scroll_manager
+        .scroll_top_display_point(&display_snapshot, cx);
 
     if editor.scroll_hover(amount, window, cx) {
         return;
@@ -144,7 +146,10 @@ fn scroll_editor(
         return;
     };
 
-    let top_anchor = editor.scroll_manager.anchor().anchor;
+    let display_snapshot = editor.display_map.update(cx, |map, cx| map.snapshot(cx));
+    let top = editor
+        .scroll_manager
+        .scroll_top_display_point(&display_snapshot, cx);
     let vertical_scroll_margin = EditorSettings::get_global(cx).vertical_scroll_margin;
 
     editor.change_selections(
@@ -159,7 +164,6 @@ fn scroll_editor(
                 // so we don't need to calculate both and deal with logic for
                 // both.
                 let mut head = selection.head();
-                let top = top_anchor.to_display_point(map);
                 let max_point = map.max_point();
                 let starting_column = head.column();
 
@@ -167,7 +171,6 @@ fn scroll_editor(
                     (vertical_scroll_margin as u32).min(visible_line_count as u32 / 2);
 
                 if preserve_cursor_position {
-                    let old_top = old_top_anchor.to_display_point(map);
                     let new_row = if old_top.row() == top.row() {
                         DisplayRow(
                             head.row()
@@ -175,7 +178,9 @@ fn scroll_editor(
                                 .saturating_add_signed(amount.lines(visible_line_count) as i32),
                         )
                     } else {
-                        DisplayRow(top.row().0 + selection.head().row().0 - old_top.row().0)
+                        DisplayRow(top.row().0.saturating_add_signed(
+                            selection.head().row().0 as i32 - old_top.row().0 as i32,
+                        ))
                     };
                     head = map.clip_point(DisplayPoint::new(new_row, head.column()), Bias::Left)
                 }
@@ -222,7 +227,7 @@ fn scroll_editor(
                 // maximum column for the current line, so the minimum column
                 // would end up being the same as the maximum column.
                 let min_column = match preserve_cursor_position {
-                    true => old_top_anchor.to_display_point(map).column(),
+                    true => old_top.column(),
                     false => top.column(),
                 };
 

--- a/crates/vim/src/normal/substitute.rs
+++ b/crates/vim/src/normal/substitute.rs
@@ -48,7 +48,7 @@ impl Vim {
         self.update_editor(cx, |vim, editor, cx| {
             editor.set_clip_at_line_ends(false, cx);
             editor.transact(window, cx, |editor, window, cx| {
-                let text_layout_details = editor.text_layout_details(window);
+                let text_layout_details = editor.text_layout_details(window, cx);
                 editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
                     s.move_with(|map, selection| {
                         if selection.start == selection.end {

--- a/crates/vim/src/normal/toggle_comments.rs
+++ b/crates/vim/src/normal/toggle_comments.rs
@@ -15,7 +15,7 @@ impl Vim {
     ) {
         self.stop_recording(cx);
         self.update_editor(cx, |_, editor, cx| {
-            let text_layout_details = editor.text_layout_details(window);
+            let text_layout_details = editor.text_layout_details(window, cx);
             editor.transact(window, cx, |editor, window, cx| {
                 let mut selection_starts: HashMap<_, _> = Default::default();
                 editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {

--- a/crates/vim/src/normal/yank.rs
+++ b/crates/vim/src/normal/yank.rs
@@ -25,7 +25,7 @@ impl Vim {
         cx: &mut Context<Self>,
     ) {
         self.update_editor(cx, |vim, editor, cx| {
-            let text_layout_details = editor.text_layout_details(window);
+            let text_layout_details = editor.text_layout_details(window, cx);
             editor.transact(window, cx, |editor, window, cx| {
                 editor.set_clip_at_line_ends(false, cx);
                 let mut original_positions: HashMap<_, _> = Default::default();

--- a/crates/vim/src/replace.rs
+++ b/crates/vim/src/replace.rs
@@ -197,7 +197,7 @@ impl Vim {
         self.stop_recording(cx);
         self.update_editor(cx, |vim, editor, cx| {
             editor.set_clip_at_line_ends(false, cx);
-            let text_layout_details = editor.text_layout_details(window);
+            let text_layout_details = editor.text_layout_details(window, cx);
             let mut selection = editor
                 .selections
                 .newest_display(&editor.display_snapshot(cx));

--- a/crates/vim/src/rewrap.rs
+++ b/crates/vim/src/rewrap.rs
@@ -56,7 +56,7 @@ impl Vim {
     ) {
         self.stop_recording(cx);
         self.update_editor(cx, |_, editor, cx| {
-            let text_layout_details = editor.text_layout_details(window);
+            let text_layout_details = editor.text_layout_details(window, cx);
             editor.transact(window, cx, |editor, window, cx| {
                 let mut selection_starts: HashMap<_, _> = Default::default();
                 editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {

--- a/crates/vim/src/surrounds.rs
+++ b/crates/vim/src/surrounds.rs
@@ -88,7 +88,7 @@ impl Vim {
         let forced_motion = Vim::take_forced_motion(cx);
         let mode = self.mode;
         self.update_editor(cx, |_, editor, cx| {
-            let text_layout_details = editor.text_layout_details(window);
+            let text_layout_details = editor.text_layout_details(window, cx);
             editor.transact(window, cx, |editor, window, cx| {
                 editor.set_clip_at_line_ends(false, cx);
 

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -218,7 +218,7 @@ impl Vim {
         cx: &mut Context<Self>,
     ) {
         self.update_editor(cx, |vim, editor, cx| {
-            let text_layout_details = editor.text_layout_details(window);
+            let text_layout_details = editor.text_layout_details(window, cx);
             if vim.mode == Mode::VisualBlock
                 && !matches!(
                     motion,
@@ -302,7 +302,7 @@ impl Vim {
             SelectionGoal,
         ) -> Option<(DisplayPoint, SelectionGoal)>,
     ) {
-        let text_layout_details = editor.text_layout_details(window);
+        let text_layout_details = editor.text_layout_details(window, cx);
         editor.change_selections(Default::default(), window, cx, |s| {
             let map = &s.display_snapshot();
             let mut head = s.newest_anchor().head().to_display_point(map);


### PR DESCRIPTION
- Remove old attempt to sync scrolling
- Share a `ScrollAnchor` between the two sides, and be sure to resolve it against the correct snapshot
- Allow either side to initiate an autoscroll request, and make sure that request is processed in the same frame by the other side

Release Notes:

- N/A