### PR TITLE
rust: Highlight enum variants as variant

### DIFF
--- a/crates/languages/src/rust.rs
+++ b/crates/languages/src/rust.rs
@@ -1807,6 +1807,7 @@ mod tests {
             ("keyword", Hsla::default()),
             ("function", Hsla::default()),
             ("property", Hsla::default()),
+            ("variant", Hsla::default()),
         ]);
 
         language.set_theme(&theme);
@@ -1814,6 +1815,7 @@ mod tests {
         let highlight_function = grammar.highlight_id_for_name("function").unwrap();
         let highlight_type = grammar.highlight_id_for_name("type").unwrap();
         let highlight_keyword = grammar.highlight_id_for_name("keyword").unwrap();
+        let highlight_variant = grammar.highlight_id_for_name("variant").unwrap();
 
         assert_eq!(
             adapter
@@ -1855,7 +1857,7 @@ mod tests {
             Some(CodeLabel::new(
                 "Variant".to_string(),
                 0..7,
-                vec![(0..7, highlight_type)],
+                vec![(0..7, highlight_variant)],
             ))
         );
     }

--- a/crates/languages/src/rust/highlights.scm
+++ b/crates/languages/src/rust/highlights.scm
@@ -58,7 +58,7 @@
  (#match? @constant "^_*[A-Z][A-Z\\d_]*$"))
 
 ; Ensure enum variants are highlighted correctly regardless of naming convention
-(enum_variant name: (identifier) @type)
+(enum_variant name: (identifier) @variant)
 
 [
   "("


### PR DESCRIPTION
Improve #45546, by changing the capture to be variant instead of type.

Release Notes:

- Improved Rust enum variant highlighting as variant instead of type.

Before (note variants have the same style as `Foo`):
<img width="276" height="162" alt="image" src="https://github.com/user-attachments/assets/fa0d8f48-a286-4a8d-b89d-269cb1657e55" />

After:
<img width="276" height="162" alt="image" src="https://github.com/user-attachments/assets/c442494a-7550-481a-a8b9-f2d944a67868" />
