### PR TITLE
agent_ui: Add adjustments to terminal selection as context

### DIFF
--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -317,7 +317,7 @@ impl UserMessage {
                         MentionUri::Diagnostics { .. } => {
                             write!(&mut diagnostics_context, "\n{}\n", content).ok();
                         }
-                        MentionUri::TerminalSelection => {
+                        MentionUri::TerminalSelection { .. } => {
                             write!(
                                 &mut selection_context,
                                 "\n{}",

--- a/crates/agent_ui/src/acp/message_editor.rs
+++ b/crates/agent_ui/src/acp/message_editor.rs
@@ -1017,7 +1017,8 @@ impl MessageEditor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let mention_uri = MentionUri::TerminalSelection;
+        let line_count = text.lines().count() as u32;
+        let mention_uri = MentionUri::TerminalSelection { line_count };
         let mention_text = mention_uri.as_link().to_string();
 
         let (excerpt_id, text_anchor, content_len) = self.editor.update(cx, |editor, cx| {

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -6877,7 +6877,7 @@ impl AcpThreadView {
                     cx.open_url(url.as_str());
                 }
                 MentionUri::Diagnostics { .. } => {}
-                MentionUri::TerminalSelection => {}
+                MentionUri::TerminalSelection { .. } => {}
             })
         } else {
             cx.open_url(&url);

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -6621,7 +6621,7 @@ impl AcpThreadView {
             .map(|active| active.prompt_capabilities.borrow().image)
             .unwrap_or_default();
 
-        let has_selection = workspace
+        let has_editor_selection = workspace
             .upgrade()
             .and_then(|ws| {
                 ws.read(cx)
@@ -6633,6 +6633,13 @@ impl AcpThreadView {
                     editor.has_non_empty_selection(&editor.display_snapshot(cx))
                 })
             });
+
+        let has_terminal_selection = workspace
+            .upgrade()
+            .and_then(|ws| ws.read(cx).panel::<TerminalPanel>(cx))
+            .is_some_and(|panel| !panel.read(cx).terminal_selections(cx).is_empty());
+
+        let has_selection = has_editor_selection || has_terminal_selection;
 
         ContextMenu::build(window, cx, move |menu, _window, _cx| {
             menu.key_context("AddContextMenu")

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -6728,10 +6728,10 @@ impl AcpThreadView {
                         .disabled(!has_selection)
                         .handler({
                             move |window, cx| {
-                                message_editor.focus_handle(cx).focus(window, cx);
-                                message_editor.update(cx, |editor, cx| {
-                                    editor.insert_selections(window, cx);
-                                });
+                                window.dispatch_action(
+                                    zed_actions::agent::AddSelectionToThread.boxed_clone(),
+                                    cx,
+                                );
                             }
                         }),
                 )

--- a/crates/agent_ui/src/completion_provider.rs
+++ b/crates/agent_ui/src/completion_provider.rs
@@ -636,7 +636,8 @@ impl<T: PromptCompletionProviderDelegate> PromptCompletionProvider<T> {
                                     };
                                     let offset = start.to_offset(&snapshot);
 
-                                    let mention_uri = MentionUri::TerminalSelection;
+                                    let line_count = terminal_text.lines().count() as u32;
+                                    let mention_uri = MentionUri::TerminalSelection { line_count };
                                     let range = snapshot.anchor_after(offset + terminal_range.start)
                                         ..snapshot.anchor_after(offset + terminal_range.end);
 

--- a/crates/agent_ui/src/mention_set.rs
+++ b/crates/agent_ui/src/mention_set.rs
@@ -249,7 +249,7 @@ impl MentionSet {
                 debug_panic!("unexpected selection URI");
                 Task::ready(Err(anyhow!("unexpected selection URI")))
             }
-            MentionUri::TerminalSelection => {
+            MentionUri::TerminalSelection { .. } => {
                 debug_panic!("unexpected terminal URI");
                 Task::ready(Err(anyhow!("unexpected terminal URI")))
             }

--- a/crates/agent_ui/src/text_thread_editor.rs
+++ b/crates/agent_ui/src/text_thread_editor.rs
@@ -1498,30 +1498,8 @@ impl TextThreadEditor {
             return;
         };
 
-        if let Some(terminal_text) = maybe!({
-            let terminal_panel = workspace.panel::<TerminalPanel>(cx)?;
-
-            let terminal_view = terminal_panel.read(cx).pane().and_then(|pane| {
-                pane.read(cx)
-                    .active_item()
-                    .and_then(|t| t.downcast::<TerminalView>())
-            })?;
-
-            terminal_view
-                .read(cx)
-                .terminal()
-                .read(cx)
-                .last_content
-                .selection_text
-                .clone()
-        }) {
-            if !terminal_text.is_empty() {
-                agent_panel_delegate.quote_terminal_text(workspace, terminal_text, window, cx);
-                return;
-            }
-        }
-
-        // Try editor selection
+        // Get buffer info for the delegate call (even if empty, AcpThreadView ignores these
+        // params and calls insert_selections which handles both terminal and buffer)
         if let Some((selections, buffer)) = maybe!({
             let editor = workspace
                 .active_item(cx)
@@ -1542,9 +1520,7 @@ impl TextThreadEditor {
             });
             Some((selections, buffer))
         }) {
-            if !selections.is_empty() {
-                agent_panel_delegate.quote_selection(workspace, selections, buffer, window, cx);
-            }
+            agent_panel_delegate.quote_selection(workspace, selections, buffer, window, cx);
         }
     }
 

--- a/crates/agent_ui/src/text_thread_editor.rs
+++ b/crates/agent_ui/src/text_thread_editor.rs
@@ -1498,17 +1498,8 @@ impl TextThreadEditor {
             return;
         };
 
-        // Try terminal selection first (requires focus, so more specific)
         if let Some(terminal_text) = maybe!({
             let terminal_panel = workspace.panel::<TerminalPanel>(cx)?;
-
-            if !terminal_panel
-                .read(cx)
-                .focus_handle(cx)
-                .contains_focused(window, cx)
-            {
-                return None;
-            }
 
             let terminal_view = terminal_panel.read(cx).pane().and_then(|pane| {
                 pane.read(cx)

--- a/crates/agent_ui/src/text_thread_editor.rs
+++ b/crates/agent_ui/src/text_thread_editor.rs
@@ -65,10 +65,8 @@ use workspace::{
     searchable::{Direction, SearchableItemHandle},
 };
 
-use terminal_view::{TerminalView, terminal_panel::TerminalPanel};
 use workspace::{
     Save, Toast, Workspace,
-    dock::Panel,
     item::{self, FollowableItem, Item},
     notifications::NotificationId,
     pane,


### PR DESCRIPTION
Follow up to https://github.com/zed-industries/zed/pull/47637

- Removes the requirement for the terminal to be focused to use the `cmd->` keybinding. This way, we match the behavior of buffer selections and you can always add what's selected in the terminal inside the agent panel
- Add number of lines selected in the mention button as well
- Make the "Selection" menu item inside the "Add Context" menu also observe terminal selections

<img width="420" height="254" alt="Screenshot 2026-01-29 at 1  36@2x" src="https://github.com/user-attachments/assets/25d2eb00-096f-44d9-8882-273932ca43e4" />

Release Notes:

- Agent: Add number of liners selected in the terminal context mention
