### PR TITLE
vim: Close search bar on Escape in Helix mode

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -853,6 +853,12 @@
     },
   },
   {
+    "context": "BufferSearchBar && !in_replace && (vim_mode == helix_normal || vim_mode == helix_select)",
+    "bindings": {
+      "escape": "buffer_search::Dismiss",
+    },
+  },
+  {
     "context": "VimControl && !menu || !Editor && !Terminal",
     "bindings": {
       // window related commands (ctrl-w X)


### PR DESCRIPTION
## Summary
Fixes the search bar not closing when pressing Escape in Helix keymap mode.

Fixes #47797

## Problem
In Helix mode, pressing Escape after using `/` to search didn't close the search bar. The Helix-specific context (`vim_mode == helix_normal`) was taking precedence over the `BufferSearchBar` context.

## Solution
Added a new keymap entry that combines `BufferSearchBar` with Helix mode contexts:

```json
{
  "context": "BufferSearchBar && !in_replace && (vim_mode == helix_normal || vim_mode == helix_select)",
  "bindings": {
    "escape": "buffer_search::Dismiss"
  }
}
```

This ensures Escape dismisses the search bar when it's open in Helix mode.

## Test plan
- [ ] Enable Helix keymap
- [ ] Press `/` to open search
- [ ] Press Escape - search bar should close

🤖 Generated with [Claude Code](https://claude.ai/code)