### PR TITLE
Add security warnings to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/10_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/10_bug_report.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Is this bug already reported? Upvote to get it noticed faster. [Here's the search](https://github.com/zed-industries/zed/issues). Upvote means giving it a :+1: reaction.
+        Is this bug already reported? Upvote to get it noticed faster. [Here’s the search](https://github.com/zed-industries/zed/issues). Upvote means giving it a :+1: reaction.
 
         Feature request? Please open in [discussions](https://github.com/zed-industries/zed/discussions/new/choose) instead.
 
@@ -48,6 +48,8 @@ body:
       label: Attach Zed log file
       description: |
         Open the command palette in Zed, then type `zed: open log` to see the last 1000 lines. Or type `zed: reveal log in file manager` in the command palette to reveal the log file itself.
+
+        ⚠️ **Please review your log file for secrets (API keys, tokens, etc.) before posting.**
       value: |
         <details><summary>Zed.log</summary>
 
@@ -64,6 +66,8 @@ body:
       label: Relevant Zed settings
       description: |
         Open the command palette in Zed, then type “zed: open settings file” and copy/paste any relevant (e.g., LSP-specific) settings.
+
+        ⚠️ **Please remove any secrets (API keys, tokens, etc.) from your settings before posting.**
       value: |
         <details><summary>settings.json</summary>
 
@@ -79,7 +83,7 @@ body:
     attributes:
       label: Relevant Keymap
       description: |
-        Open the command palette in Zed, then type “zed: open keymap file” and copy/paste the file's contents.
+        Open the command palette in Zed, then type “zed: open keymap file” and copy/paste the file’s contents.
       value: |
         <details><summary>keymap.json</summary>
 

--- a/.github/ISSUE_TEMPLATE/10_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/10_bug_report.yml
@@ -49,7 +49,7 @@ body:
       description: |
         Open the command palette in Zed, then type `zed: open log` to see the last 1000 lines. Or type `zed: reveal log in file manager` in the command palette to reveal the log file itself.
 
-        ⚠️ **Please review your log file for secrets (API keys, tokens, etc.) before posting.**
+        ⚠️ **Please review your log file for secrets (API keys, tokens, etc.) and partially or fully redact them before posting.**
       value: |
         <details><summary>Zed.log</summary>
 
@@ -67,7 +67,7 @@ body:
       description: |
         Open the command palette in Zed, then type “zed: open settings file” and copy/paste any relevant (e.g., LSP-specific) settings.
 
-        ⚠️ **Please remove any secrets (API keys, tokens, etc.) from your settings before posting.**
+        ⚠️ **Please review your settings file for secrets (API keys, tokens, etc.) and partially or fully redact them before posting.**
       value: |
         <details><summary>settings.json</summary>
 

--- a/.github/ISSUE_TEMPLATE/11_crash_report.yml
+++ b/.github/ISSUE_TEMPLATE/11_crash_report.yml
@@ -31,7 +31,7 @@ body:
       description: |
         Open the command palette in Zed, then type `zed: open log` to see the last 1000 lines. Or type `zed: reveal log in file manager` in the command palette to reveal the log file itself.
 
-        ⚠️ **Please review your log file for secrets (API keys, tokens, etc.) before posting.**
+        ⚠️ **Please review your log file for secrets (API keys, tokens, etc.) and partially or fully redact them before posting.**
       value: |
         <details><summary>Zed.log</summary>
 

--- a/.github/ISSUE_TEMPLATE/11_crash_report.yml
+++ b/.github/ISSUE_TEMPLATE/11_crash_report.yml
@@ -30,6 +30,8 @@ body:
       label: Attach Zed log file
       description: |
         Open the command palette in Zed, then type `zed: open log` to see the last 1000 lines. Or type `zed: reveal log in file manager` in the command palette to reveal the log file itself.
+
+        ⚠️ **Please review your log file for secrets (API keys, tokens, etc.) before posting.**
       value: |
         <details><summary>Zed.log</summary>
 


### PR DESCRIPTION
Warn users to review and remove secrets from logs and settings before posting them in bug reports and crash reports.

Release Notes:

- N/A
