### PR TITLE
command_palette: Add option to set language

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9166,6 +9166,7 @@ name = "language_selector"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "command_palette_hooks",
  "editor",
  "file_icons",
  "fuzzy",
@@ -9174,6 +9175,7 @@ dependencies = [
  "open_path_prompt",
  "picker",
  "project",
+ "serde_json",
  "settings",
  "ui",
  "util",

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -2290,6 +2290,11 @@
       "insert": "inherit",
     },
   },
+  // Language selector settings
+  "language_selector": {
+    // Whether to show "language: {language}" commands in the command palette.
+    "show_in_command_palette": false
+  },
   // Which-key popup settings
   "which_key": {
     // Whether to show the which-key popup when holding down key combinations.

--- a/crates/language_selector/Cargo.toml
+++ b/crates/language_selector/Cargo.toml
@@ -14,6 +14,7 @@ doctest = false
 
 [dependencies]
 anyhow.workspace = true
+command_palette_hooks.workspace = true
 editor.workspace = true
 file_icons.workspace = true
 fuzzy.workspace = true
@@ -22,6 +23,7 @@ language.workspace = true
 open_path_prompt.workspace = true
 picker.workspace = true
 project.workspace = true
+serde_json.workspace = true
 settings.workspace = true
 ui.workspace = true
 util.workspace = true

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -191,6 +191,7 @@ impl VsCodeSettings {
             image_viewer: None,
             journal: None,
             language_models: None,
+            language_selector: None,
             line_indicator_format: None,
             log: None,
             message_editor: None,

--- a/crates/settings_content/src/settings_content.rs
+++ b/crates/settings_content/src/settings_content.rs
@@ -171,6 +171,9 @@ pub struct SettingsContent {
     /// Default: false
     pub disable_ai: Option<SaturatingBool>,
 
+    /// Settings for the language selector.
+    pub language_selector: Option<LanguageSelectorSettingsContent>,
+
     /// Settings for the which-key popup.
     pub which_key: Option<WhichKeySettingsContent>,
 
@@ -1064,6 +1067,16 @@ pub struct ReplSettingsContent {
     ///
     /// Default: 50
     pub inline_output_max_length: Option<usize>,
+}
+
+/// Settings for the language selector.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, JsonSchema, MergeFrom)]
+pub struct LanguageSelectorSettingsContent {
+    /// Whether to show "language: {language}" commands in the command palette
+    /// for all available languages.
+    ///
+    /// Default: false
+    pub show_in_command_palette: Option<bool>,
 }
 
 /// Settings for configuring the which-key popup behaviour.

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -2956,12 +2956,41 @@ fn languages_and_tools_page(cx: &App) -> SettingsPage {
             .collect()
     }
 
+    fn language_selector_section() -> [SettingsPageItem; 2] {
+        [
+            SettingsPageItem::SectionHeader("Language Selector"),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Show in Command Palette",
+                description:
+                    "Show language selection commands in the command palette for all available languages.",
+                field: Box::new(SettingField {
+                    json_path: Some("language_selector.show_in_command_palette"),
+                    pick: |settings_content| {
+                        settings_content
+                            .language_selector
+                            .as_ref()
+                            .and_then(|settings| settings.show_in_command_palette.as_ref())
+                    },
+                    write: |settings_content, value| {
+                        settings_content
+                            .language_selector
+                            .get_or_insert_default()
+                            .show_in_command_palette = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+        ]
+    }
+
     SettingsPage {
         title: "Languages & Tools",
         items: {
             concat_sections!(
                 non_editor_language_settings_data(),
                 file_types_section(),
+                language_selector_section(),
                 diagnostics_section(),
                 inline_diagnostics_section(),
                 lsp_pull_diagnostics_section(),

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -663,7 +663,7 @@ fn main() {
         terminal_view::init(cx);
         journal::init(app_state.clone(), cx);
         encoding_selector::init(cx);
-        language_selector::init(cx);
+        language_selector::init(app_state.languages.clone(), cx);
         line_ending_selector::init(cx);
         toolchain_selector::init(cx);
         theme_selector::init(cx);

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -2602,6 +2602,48 @@ The following settings can be overridden for each specific language:
 
 These values take in the same options as the root-level settings with the same name.
 
+## Language Selector
+
+- Description: Settings for the language selector.
+- Setting: `language_selector`
+- Default:
+
+```json [settings]
+{
+  "language_selector": {
+    "show_in_command_palette": false
+  }
+}
+```
+
+### Show in Command Palette
+
+- Description: Whether to show "language: {language}" commands in the command palette for all available languages.
+- Setting: `show_in_command_palette`
+- Default: `false`
+
+**Options**
+
+1. Show language commands in the command palette:
+
+```json [settings]
+{
+  "language_selector": {
+    "show_in_command_palette": true
+  }
+}
+```
+
+2. Hide language commands from the command palette:
+
+```json [settings]
+{
+  "language_selector": {
+    "show_in_command_palette": false
+  }
+}
+```
+
 ## Language Models
 
 - Description: Configuration for language model providers


### PR DESCRIPTION
Add a new `language_selector.show_in_command_palette` setting that, when
enabled, populates the command palette with "language: {name}" entries
for every available language. This behaves the same as the Language Selector
but rather than being its own action with its own picker, it's part
of the command palette.

This is useful for those who prefer to go through the command palette
for everything. Although the Language Selector does a similar thing,
it requires knowing and calling a separate action.

<img width="460" height="390" alt="command-palette-1" src="https://github.com/user-attachments/assets/5b0a3704-b858-48ec-b7e3-fdadc4471dbd" />
<img width="460" height="390" alt="command-palette-2" src="https://github.com/user-attachments/assets/214af224-aa62-49cb-8c28-15f4e120dbe1" />
<img width="740" height="400" alt="settings" src="https://github.com/user-attachments/assets/2c66d372-946b-4a2f-8c87-61d97cad9be8" />


Release Notes:

- Added `language_selector.show_in_command_palette` setting to add the language selector entries to the command palette.
