### PR TITLE
Fix vim method/comment navigation with expanded diff hunks

### DIFF
--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -5141,7 +5141,7 @@ mod test {
         // comment.
         cx.simulate_keystrokes("] /");
         cx.assert_editor_state(indoc! {r#"
-            // First commenˇt
+            // first commenˇt
             fn first() {
                 // removed comment
                 println!("first");


### PR DESCRIPTION
## Summary

- Fixed `method_motion` and `comment_motion` coordinate space mismatch
- When diff hunks are expanded, raw buffer offsets ≠ MultiBuffer offsets
- Now follows the pattern already used by `section_motion`

Fixes #46612

## Test plan

- [x] Added `test_method_motion_with_expanded_diff_hunks` test
- [x] `cargo test -p vim --lib` passes (454 tests)
- [x] `./script/clippy -p vim` passes

Release Notes:

- Fixed vim method and comment navigation (`] m`, `[ m`, `] shift-m`, `[ shift-m`, `] /`, `[ /`) incorrectly positioning cursor when diff hunks are expanded

🤖 Generated with [Claude Code](https://claude.ai/claude-code)