### PR TITLE
gpui: Add configurable drag-drop types with URL support

### DIFF
--- a/crates/gpui/examples/external_drop.rs
+++ b/crates/gpui/examples/external_drop.rs
@@ -1,0 +1,170 @@
+//! Minimal example for testing external drag-drop with files and URLs.
+//!
+//! Run with: cargo run -p gpui --example external_drop
+//!
+//! Test by:
+//! 1. Dragging files from your file manager onto the window
+//! 2. Dragging URLs from your browser onto the window
+//! 3. Dragging mixed content (some browsers support this)
+
+use gpui::{
+    div, prelude::*, px, rgba, rgb, size, App, Application, Bounds, Context, DragMoveEvent,
+    DragType, DropItem, ExternalDrop, SharedString, Window, WindowBounds, WindowOptions,
+};
+use smallvec::smallvec;
+
+struct ExternalDropDemo {
+    dropped_items: Vec<DroppedItem>,
+    drag_hover: bool,
+}
+
+#[derive(Clone)]
+enum DroppedItem {
+    File(String),
+    Url(String),
+}
+
+impl ExternalDropDemo {
+    fn new() -> Self {
+        Self {
+            dropped_items: Vec::new(),
+            drag_hover: false,
+        }
+    }
+}
+
+impl Render for ExternalDropDemo {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let items_display: Vec<SharedString> = self
+            .dropped_items
+            .iter()
+            .map(|item| match item {
+                DroppedItem::File(path) => format!("[FILE] {}", path).into(),
+                DroppedItem::Url(url) => format!("[URL]  {}", url).into(),
+            })
+            .collect();
+
+        div()
+            .id("root")
+            .size_full()
+            .flex()
+            .flex_col()
+            .bg(rgb(0x1e1e1e))
+            .text_color(rgb(0xffffff))
+            .child(
+                div()
+                    .p_4()
+                    .child("External Drag-Drop Test")
+                    .text_xl()
+                    .border_b_1()
+                    .border_color(rgb(0x444444)),
+            )
+            .child(
+                div()
+                    .p_4()
+                    .text_sm()
+                    .text_color(rgb(0x888888))
+                    .child("Drag files or URLs from external apps onto the drop zone below"),
+            )
+            .child(
+                div()
+                    .id("drop-zone")
+                    .m_4()
+                    .p_4()
+                    .min_h(px(200.0))
+                    .flex()
+                    .flex_col()
+                    .gap_2()
+                    .border_2()
+                    .border_dashed()
+                    .rounded_lg()
+                    .when(self.drag_hover, |el| {
+                        el.border_color(rgb(0x4fc3f7)).bg(rgba(0x4fc3f71a))
+                    })
+                    .when(!self.drag_hover, |el| el.border_color(rgb(0x666666)))
+                    .on_drop(cx.listener(|this, drop: &ExternalDrop, _window, _cx| {
+                        for item in drop.items() {
+                            match item {
+                                DropItem::Path(path) => {
+                                    this.dropped_items
+                                        .push(DroppedItem::File(path.display().to_string()));
+                                }
+                                DropItem::Url(url) => {
+                                    this.dropped_items
+                                        .push(DroppedItem::Url(url.to_string()));
+                                }
+                            }
+                        }
+                        this.drag_hover = false;
+                    }))
+                    .on_drag_move(cx.listener(
+                        |this, _: &DragMoveEvent<ExternalDrop>, _window, _cx| {
+                            if !this.drag_hover {
+                                this.drag_hover = true;
+                            }
+                        },
+                    ))
+                    .when(items_display.is_empty(), |el| {
+                        el.justify_center().items_center().child(
+                            div()
+                                .text_color(rgb(0x666666))
+                                .child("Drop files or URLs here"),
+                        )
+                    })
+                    .when(!items_display.is_empty(), |el| {
+                        el.children(items_display.into_iter().map(|text| {
+                            div()
+                                .px_2()
+                                .py_1()
+                                .rounded_md()
+                                .bg(rgb(0x2d2d2d))
+                                .text_sm()
+                                .child(text)
+                        }))
+                    }),
+            )
+            .child(
+                div()
+                    .p_4()
+                    .flex()
+                    .gap_2()
+                    .child(
+                        div()
+                            .id("clear-button")
+                            .px_3()
+                            .py_1()
+                            .rounded_md()
+                            .bg(rgb(0x444444))
+                            .cursor_pointer()
+                            .hover(|el| el.bg(rgb(0x555555)))
+                            .on_click(cx.listener(|this, _, _window, _cx| {
+                                this.dropped_items.clear();
+                            }))
+                            .child("Clear"),
+                    )
+                    .child(
+                        div()
+                            .text_sm()
+                            .text_color(rgb(0x666666))
+                            .child(format!("{} items dropped", self.dropped_items.len())),
+                    ),
+            )
+    }
+}
+
+fn main() {
+    Application::new().run(|cx: &mut App| {
+        let bounds = Bounds::centered(None, size(px(600.), px(400.)), cx);
+        cx.open_window(
+            WindowOptions {
+                window_bounds: Some(WindowBounds::Windowed(bounds)),
+                drag_types: smallvec![DragType::Files, DragType::Urls],
+                ..Default::default()
+            },
+            |_, cx| cx.new(|_| ExternalDropDemo::new()),
+        )
+        .unwrap();
+
+        cx.activate(true);
+    });
+}

--- a/crates/gpui/src/interactive.rs
+++ b/crates/gpui/src/interactive.rs
@@ -603,7 +603,70 @@ impl Deref for MouseExitEvent {
     }
 }
 
-/// A collection of paths from the platform, such as from a file drop.
+/// Types of external content that can be dragged into a window.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default)]
+pub enum DragType {
+    /// File paths from the filesystem
+    #[default]
+    Files,
+    /// HTTP/HTTPS URLs (e.g., from browser)
+    Urls,
+}
+
+/// A single item from an external drag-drop operation.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DropItem {
+    /// A file path from the filesystem
+    Path(PathBuf),
+    /// An HTTP or HTTPS URL
+    Url(url::Url),
+}
+
+/// A collection of items from an external drag-drop operation.
+/// This is the modern replacement for `ExternalPaths`.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ExternalDrop(pub SmallVec<[DropItem; 2]>);
+
+impl ExternalDrop {
+    /// Create a new empty ExternalDrop.
+    pub fn new() -> Self {
+        Self(SmallVec::new())
+    }
+
+    /// Get the items as a slice.
+    pub fn items(&self) -> &[DropItem] {
+        &self.0
+    }
+
+    /// Get only the file paths, ignoring URLs.
+    pub fn paths(&self) -> impl Iterator<Item = &PathBuf> {
+        self.0.iter().filter_map(|item| match item {
+            DropItem::Path(p) => Some(p),
+            DropItem::Url(_) => None,
+        })
+    }
+
+    /// Get only the URLs, ignoring file paths.
+    pub fn urls(&self) -> impl Iterator<Item = &url::Url> {
+        self.0.iter().filter_map(|item| match item {
+            DropItem::Url(u) => Some(u),
+            DropItem::Path(_) => None,
+        })
+    }
+
+    /// Convert to ExternalPaths (paths only, ignoring URLs).
+    pub fn to_external_paths(&self) -> ExternalPaths {
+        ExternalPaths(self.paths().cloned().collect())
+    }
+}
+
+impl Render for ExternalDrop {
+    fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+        Empty
+    }
+}
+
+/// A collection of paths from the platform, such as from a file drop or clipboard.
 #[derive(Debug, Clone, Default, Eq, PartialEq)]
 pub struct ExternalPaths(pub SmallVec<[PathBuf; 2]>);
 
@@ -629,7 +692,11 @@ pub enum FileDropEvent {
         /// The position of the mouse relative to the window.
         position: Point<Pixels>,
         /// The paths of the files that are being dragged.
+        /// Deprecated: Use `items` field instead, which supports both files and URLs.
+        #[deprecated(note = "Use `items` field instead")]
         paths: ExternalPaths,
+        /// The items being dragged (files and/or URLs).
+        items: ExternalDrop,
     },
     /// The files are being dragged over the window
     Pending {

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -30,11 +30,11 @@ pub(crate) type PlatformScreenCaptureFrame = core_video::image_buffer::CVImageBu
 
 use crate::{
     Action, AnyWindowHandle, App, AsyncWindowContext, BackgroundExecutor, Bounds,
-    DEFAULT_WINDOW_SIZE, DevicePixels, DispatchEventResult, Font, FontId, FontMetrics, FontRun,
-    ForegroundExecutor, GlyphId, GpuSpecs, ImageSource, Keymap, LineLayout, Pixels, PlatformInput,
-    Point, Priority, RenderGlyphParams, RenderImage, RenderImageParams, RenderSvgParams, Scene,
-    ShapedGlyph, ShapedRun, SharedString, Size, SvgRenderer, SystemWindowTab, Task,
-    ThreadTaskTimings, Window, WindowControlArea, hash, point, px, size,
+    DEFAULT_WINDOW_SIZE, DevicePixels, DispatchEventResult, DragType, Font, FontId, FontMetrics,
+    FontRun, ForegroundExecutor, GlyphId, GpuSpecs, ImageSource, Keymap, LineLayout, Pixels,
+    PlatformInput, Point, Priority, RenderGlyphParams, RenderImage, RenderImageParams,
+    RenderSvgParams, Scene, ShapedGlyph, ShapedRun, SharedString, Size, SvgRenderer,
+    SystemWindowTab, Task, ThreadTaskTimings, Window, WindowControlArea, hash, point, px, size,
 };
 use anyhow::Result;
 #[cfg(any(target_os = "linux", target_os = "freebsd"))]
@@ -1424,6 +1424,10 @@ pub struct WindowOptions {
 
     /// Tab group name, allows opening the window as a native tab on macOS 10.12+. Windows with the same tabbing identifier will be grouped together.
     pub tabbing_identifier: Option<String>,
+
+    /// Types of external content to accept via drag-drop.
+    /// Default: `[DragType::Files]` for backwards compatibility.
+    pub drag_types: SmallVec<[DragType; 2]>,
 }
 
 /// The variables that can be configured when creating a new window
@@ -1474,6 +1478,9 @@ pub struct WindowParams {
     pub window_min_size: Option<Size<Pixels>>,
     #[cfg(target_os = "macos")]
     pub tabbing_identifier: Option<String>,
+
+    /// Types of external content to accept via drag-drop.
+    pub drag_types: SmallVec<[DragType; 2]>,
 }
 
 /// Represents the status of how a window should be opened.
@@ -1532,6 +1539,7 @@ impl Default for WindowOptions {
             window_min_size: None,
             window_decorations: None,
             tabbing_identifier: None,
+            drag_types: smallvec::smallvec![DragType::Files],
         }
     }
 }
@@ -1822,8 +1830,10 @@ pub enum ClipboardEntry {
     String(ClipboardString),
     /// An image entry
     Image(Image),
-    /// A file entry
+    /// A file paths entry
     ExternalPaths(crate::ExternalPaths),
+    /// A URLs entry (http/https)
+    Urls(SmallVec<[url::Url; 2]>),
 }
 
 impl ClipboardItem {
@@ -1874,7 +1884,7 @@ impl ClipboardItem {
         if answer.is_empty() {
             for entry in self.entries.iter() {
                 if let ClipboardEntry::ExternalPaths(paths) = entry {
-                    for path in &paths.0 {
+                    for path in paths.paths() {
                         use std::fmt::Write as _;
                         _ = write!(answer, "{}", path.display());
                     }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1135,6 +1135,7 @@ impl Window {
             window_decorations,
             #[cfg_attr(not(target_os = "macos"), allow(unused_variables))]
             tabbing_identifier,
+            drag_types,
         } = options;
 
         let window_bounds = window_bounds.unwrap_or_else(|| default_bounds(display_id, cx));
@@ -1153,6 +1154,7 @@ impl Window {
                 window_min_size,
                 #[cfg(target_os = "macos")]
                 tabbing_identifier,
+                drag_types,
             },
         )?;
 
@@ -4154,13 +4156,18 @@ impl Window {
             }
             // Translate dragging and dropping of external files from the operating system
             // to internal drag and drop events.
+            #[allow(deprecated)]
             PlatformInput::FileDrop(file_drop) => match file_drop {
-                FileDropEvent::Entered { position, paths } => {
+                FileDropEvent::Entered {
+                    position,
+                    paths: _,
+                    items,
+                } => {
                     self.mouse_position = position;
                     if cx.active_drag.is_none() {
                         cx.active_drag = Some(AnyDrag {
-                            value: Arc::new(paths.clone()),
-                            view: cx.new(|_| paths).into(),
+                            value: Arc::new(items.clone()),
+                            view: cx.new(|_| items).into(),
                             cursor_offset: position,
                             cursor_style: None,
                         });

--- a/crates/gpui/tests/drag_drop.rs
+++ b/crates/gpui/tests/drag_drop.rs
@@ -1,0 +1,63 @@
+//! Integration tests for drag-drop types.
+
+use gpui::{DragType, DropItem, ExternalDrop};
+use smallvec::smallvec;
+use std::path::PathBuf;
+
+#[test]
+fn test_external_drop_paths_only() {
+    let drop = ExternalDrop(smallvec![
+        DropItem::Path(PathBuf::from("/tmp/file1.txt")),
+        DropItem::Path(PathBuf::from("/tmp/file2.txt")),
+    ]);
+
+    let paths: Vec<_> = drop.paths().collect();
+    assert_eq!(paths.len(), 2);
+    assert_eq!(paths[0], &PathBuf::from("/tmp/file1.txt"));
+
+    let urls: Vec<_> = drop.urls().collect();
+    assert!(urls.is_empty());
+}
+
+#[test]
+fn test_external_drop_urls_only() {
+    let drop = ExternalDrop(smallvec![DropItem::Url(
+        url::Url::parse("https://example.com/image.png").unwrap()
+    ),]);
+
+    let paths: Vec<_> = drop.paths().collect();
+    assert!(paths.is_empty());
+
+    let urls: Vec<_> = drop.urls().collect();
+    assert_eq!(urls.len(), 1);
+    assert_eq!(urls[0].as_str(), "https://example.com/image.png");
+}
+
+#[test]
+fn test_external_drop_mixed() {
+    let drop = ExternalDrop(smallvec![
+        DropItem::Path(PathBuf::from("/tmp/file.txt")),
+        DropItem::Url(url::Url::parse("https://example.com/").unwrap()),
+    ]);
+
+    assert_eq!(drop.items().len(), 2);
+    assert_eq!(drop.paths().count(), 1);
+    assert_eq!(drop.urls().count(), 1);
+}
+
+#[test]
+fn test_external_drop_to_legacy() {
+    let drop = ExternalDrop(smallvec![
+        DropItem::Path(PathBuf::from("/tmp/file.txt")),
+        DropItem::Url(url::Url::parse("https://example.com/").unwrap()),
+    ]);
+
+    let legacy = drop.to_external_paths();
+    assert_eq!(legacy.paths().len(), 1);
+}
+
+#[test]
+fn test_drag_type_default() {
+    let default = DragType::default();
+    assert_eq!(default, DragType::Files);
+}

--- a/crates/gpui_linux/src/linux/wayland/client.rs
+++ b/crates/gpui_linux/src/linux/wayland/client.rs
@@ -91,12 +91,12 @@ use crate::linux::{
     xdg_desktop_portal::{Event as XDPEvent, XDPEventSource},
 };
 use gpui::{
-    AnyWindowHandle, Bounds, Capslock, CursorStyle, DevicePixels, DisplayId, FileDropEvent,
-    ForegroundExecutor, KeyDownEvent, KeyUpEvent, Keystroke, Modifiers, ModifiersChangedEvent,
-    MouseButton, MouseDownEvent, MouseExitEvent, MouseMoveEvent, MouseUpEvent, NavigationDirection,
-    Pixels, PlatformDisplay, PlatformInput, PlatformKeyboardLayout, PlatformWindow, Point,
-    ScrollDelta, ScrollWheelEvent, SharedString, Size, TaskTiming, TouchPhase, WindowButtonLayout,
-    WindowParams, point, profiler, px, size,
+    AnyWindowHandle, Bounds, Capslock, CursorStyle, DevicePixels, DisplayId, DropItem,
+    ExternalDrop, FileDropEvent, ForegroundExecutor, KeyDownEvent, KeyUpEvent, Keystroke, Modifiers,
+    ModifiersChangedEvent, MouseButton, MouseDownEvent, MouseExitEvent, MouseMoveEvent,
+    MouseUpEvent, NavigationDirection, Pixels, PlatformDisplay, PlatformInput,
+    PlatformKeyboardLayout, PlatformWindow, Point, ScrollDelta, ScrollWheelEvent, SharedString,
+    Size, TaskTiming, TouchPhase, WindowButtonLayout, WindowParams, point, profiler, px, size,
 };
 use gpui_wgpu::{CompositorGpuHint, GpuContext};
 use wayland_protocols::wp::linux_dmabuf::zv1::client::{
@@ -2230,22 +2230,30 @@ impl Dispatch<wl_data_device::WlDataDevice, ()> for WaylandClientStatePtr {
                                 }
                             };
 
-                            let paths: SmallVec<[_; 2]> = file_list
+                            let items: SmallVec<[DropItem; 2]> = file_list
                                 .lines()
-                                .filter_map(|path| Url::parse(path).log_err())
-                                .filter_map(|url| url.to_file_path().log_err())
+                                .filter_map(|line| Url::parse(line).log_err())
+                                .filter_map(|url| match url.scheme() {
+                                    "file" => url.to_file_path().log_err().map(DropItem::Path),
+                                    "http" | "https" => Some(DropItem::Url(url)),
+                                    _ => None,
+                                })
                                 .collect();
                             let position = Point::new(x.into(), y.into());
 
                             // Prevent dropping text from other programs.
-                            if paths.is_empty() {
+                            if items.is_empty() {
                                 data_offer.destroy();
                                 return;
                             }
 
+                            let items = ExternalDrop(items);
+                            // Convert to legacy ExternalPaths for backwards compatibility
+                            #[allow(deprecated)]
                             let input = PlatformInput::FileDrop(FileDropEvent::Entered {
                                 position,
-                                paths: gpui::ExternalPaths(paths),
+                                paths: items.to_external_paths(),
+                                items,
                             });
 
                             let client = this.get_client();

--- a/crates/gpui_linux/src/linux/x11/client.rs
+++ b/crates/gpui_linux/src/linux/x11/client.rs
@@ -59,10 +59,10 @@ use crate::linux::{
 use crate::linux::{LinuxCommon, LinuxKeyboardLayout, X11Window, modifiers_from_xinput_info};
 
 use gpui::{
-    AnyWindowHandle, Bounds, ClipboardItem, CursorStyle, DisplayId, FileDropEvent, Keystroke,
-    Modifiers, ModifiersChangedEvent, MouseButton, Pixels, PlatformDisplay, PlatformInput,
-    PlatformKeyboardLayout, PlatformWindow, Point, RequestFrameOptions, ScrollDelta, Size,
-    TouchPhase, WindowButtonLayout, WindowParams, point, px,
+    AnyWindowHandle, Bounds, ClipboardItem, CursorStyle, DisplayId, DropItem, ExternalDrop,
+    FileDropEvent, Keystroke, Modifiers, ModifiersChangedEvent, MouseButton, Pixels,
+    PlatformDisplay, PlatformInput, PlatformKeyboardLayout, PlatformWindow, Point,
+    RequestFrameOptions, ScrollDelta, Size, TouchPhase, WindowButtonLayout, WindowParams, point, px,
 };
 use gpui_wgpu::{CompositorGpuHint, GpuContext};
 
@@ -888,17 +888,26 @@ impl X11Client {
                 let Some(reply) = reply else {
                     return Some(());
                 };
+                #[allow(deprecated)]
                 if let Ok(file_list) = str::from_utf8(&reply.value) {
-                    let paths: SmallVec<[_; 2]> = file_list
+                    let items: SmallVec<[DropItem; 2]> = file_list
                         .lines()
-                        .filter_map(|path| Url::parse(path).log_err())
-                        .filter_map(|url| url.to_file_path().log_err())
+                        .filter_map(|line| Url::parse(line).log_err())
+                        .filter_map(|url| match url.scheme() {
+                            "file" => url.to_file_path().log_err().map(DropItem::Path),
+                            "http" | "https" => Some(DropItem::Url(url)),
+                            _ => None,
+                        })
                         .collect();
+                    let items = ExternalDrop(items);
+                    // Convert to legacy ExternalPaths for backwards compatibility
+                    let paths = items.to_external_paths();
                     let input = PlatformInput::FileDrop(FileDropEvent::Entered {
                         position: state.xdnd_state.position,
-                        paths: gpui::ExternalPaths(paths),
+                        paths,
+                        items,
                     });
-                    drop(state);
+                    std::mem::drop(state);
                     window.handle_input(input);
                     self.0.borrow_mut().xdnd_state.retrieved = true;
                 }

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -25,11 +25,11 @@ use cocoa::{
 };
 use dispatch2::DispatchQueue;
 use gpui::{
-    AnyWindowHandle, BackgroundExecutor, Bounds, Capslock, ExternalPaths, FileDropEvent,
-    ForegroundExecutor, KeyDownEvent, Keystroke, Modifiers, ModifiersChangedEvent, MouseButton,
-    MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels, PlatformAtlas, PlatformDisplay,
-    PlatformInput, PlatformInputHandler, PlatformWindow, Point, PromptButton, PromptLevel,
-    RequestFrameOptions, SharedString, Size, SystemWindowTab, WindowAppearance,
+    AnyWindowHandle, BackgroundExecutor, Bounds, Capslock, DragType, DropItem, ExternalDrop,
+    FileDropEvent, ForegroundExecutor, KeyDownEvent, Keystroke, Modifiers, ModifiersChangedEvent,
+    MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels, PlatformAtlas,
+    PlatformDisplay, PlatformInput, PlatformInputHandler, PlatformWindow, Point, PromptButton,
+    PromptLevel, RequestFrameOptions, SharedString, Size, SystemWindowTab, WindowAppearance,
     WindowBackgroundAppearance, WindowBounds, WindowControlArea, WindowKind, WindowParams, point,
     px, size,
 };
@@ -451,6 +451,8 @@ struct MacWindowState {
     closed: Arc<AtomicBool>,
     // The parent window if this window is a sheet (Dialog kind)
     sheet_parent: Option<id>,
+    // Types of external content to accept via drag-drop
+    drag_types: SmallVec<[DragType; 2]>,
 }
 
 impl MacWindowState {
@@ -619,6 +621,7 @@ impl MacWindow {
             display_id,
             window_min_size,
             tabbing_identifier,
+            drag_types,
         }: WindowParams,
         foreground_executor: ForegroundExecutor,
         background_executor: BackgroundExecutor,
@@ -713,11 +716,20 @@ impl MacWindow {
                 target_screen,
             );
             assert!(!native_window.is_null());
-            let () = msg_send![
-                native_window,
-                registerForDraggedTypes:
-                    NSArray::arrayWithObject(nil, NSFilenamesPboardType)
-            ];
+
+            // Register for drag types based on configuration
+            let mut pasteboard_types: Vec<id> = Vec::new();
+            if drag_types.contains(&DragType::Files) {
+                pasteboard_types.push(NSFilenamesPboardType);
+            }
+            if drag_types.contains(&DragType::Urls) {
+                pasteboard_types.push(ns_string("public.url"));
+            }
+            if !pasteboard_types.is_empty() {
+                let types_array = NSArray::arrayWithObjects(nil, &pasteboard_types);
+                let () = msg_send![native_window, registerForDraggedTypes: types_array];
+            }
+
             let () = msg_send![
                 native_window,
                 setReleasedWhenClosed: NO
@@ -775,6 +787,7 @@ impl MacWindow {
                 activated_least_once: false,
                 closed: Arc::new(AtomicBool::new(false)),
                 sheet_parent: None,
+                drag_types,
             })));
 
             (*native_window).set_ivar(
@@ -2574,14 +2587,24 @@ fn screen_point_to_gpui_point(this: &Object, position: NSPoint) -> Point<Pixels>
     point(px(window_x as f32), px(window_y as f32))
 }
 
+#[allow(deprecated)]
 extern "C" fn dragging_entered(this: &Object, _: Sel, dragging_info: id) -> NSDragOperation {
     let window_state = unsafe { get_window_state(this) };
     let position = drag_event_position(&window_state, dragging_info);
-    let paths = external_paths_from_event(dragging_info);
-    if let Some(event) = paths.map(|paths| FileDropEvent::Entered { position, paths })
-        && send_file_drop_event(window_state, event)
-    {
-        return NSDragOperationCopy;
+    let drag_types = window_state.lock().drag_types.clone();
+    let items = external_drop_from_event(dragging_info, &drag_types);
+    if let Some(items) = items {
+        let paths = items.to_external_paths();
+        if send_file_drop_event(
+            window_state,
+            FileDropEvent::Entered {
+                position,
+                paths,
+                items,
+            },
+        ) {
+            return NSDragOperationCopy;
+        }
     }
     NSDragOperationNone
 }
@@ -2607,22 +2630,68 @@ extern "C" fn perform_drag_operation(this: &Object, _: Sel, dragging_info: id) -
     send_file_drop_event(window_state, FileDropEvent::Submit { position }).to_objc()
 }
 
-fn external_paths_from_event(dragging_info: *mut Object) -> Option<ExternalPaths> {
-    let mut paths = SmallVec::new();
+fn external_drop_from_event(
+    dragging_info: *mut Object,
+    drag_types: &[DragType],
+) -> Option<ExternalDrop> {
+    let mut items = SmallVec::new();
     let pasteboard: id = unsafe { msg_send![dragging_info, draggingPasteboard] };
-    let filenames = unsafe { NSPasteboard::propertyListForType(pasteboard, NSFilenamesPboardType) };
-    if filenames == nil {
-        return None;
+
+    // Handle file paths
+    if drag_types.contains(&DragType::Files) {
+        let filenames =
+            unsafe { NSPasteboard::propertyListForType(pasteboard, NSFilenamesPboardType) };
+        if filenames != nil {
+            for file in unsafe { filenames.iter() } {
+                let path = unsafe {
+                    let f = NSString::UTF8String(file);
+                    CStr::from_ptr(f).to_string_lossy().into_owned()
+                };
+                items.push(DropItem::Path(PathBuf::from(path)));
+            }
+        }
     }
-    for file in unsafe { filenames.iter() } {
-        let path = unsafe {
-            let f = NSString::UTF8String(file);
-            CStr::from_ptr(f).to_string_lossy().into_owned()
-        };
-        paths.push(PathBuf::from(path))
+
+    // Handle URLs
+    if drag_types.contains(&DragType::Urls) {
+        unsafe {
+            let url_type = ns_string("public.url");
+            let url_string_type = ns_string("public.url-name");
+
+            // Try to get URL from pasteboard
+            let pasteboard_string: id = msg_send![pasteboard, stringForType: url_type];
+            if pasteboard_string != nil {
+                let url_cstr = NSString::UTF8String(pasteboard_string);
+                let url_string = CStr::from_ptr(url_cstr).to_string_lossy().into_owned();
+                if let Ok(url) = url::Url::parse(&url_string) {
+                    // Only accept http/https URLs
+                    if url.scheme() == "http" || url.scheme() == "https" {
+                        items.push(DropItem::Url(url));
+                    }
+                }
+            }
+
+            // Also check for URLs in the URL name type (some apps use this)
+            let url_name: id = msg_send![pasteboard, stringForType: url_string_type];
+            if url_name != nil && pasteboard_string == nil {
+                let name_cstr = NSString::UTF8String(url_name);
+                let name_string = CStr::from_ptr(name_cstr).to_string_lossy().into_owned();
+                if let Ok(url) = url::Url::parse(&name_string) {
+                    if url.scheme() == "http" || url.scheme() == "https" {
+                        items.push(DropItem::Url(url));
+                    }
+                }
+            }
+        }
     }
-    Some(ExternalPaths(paths))
+
+    if items.is_empty() {
+        None
+    } else {
+        Some(ExternalDrop(items))
+    }
 }
+
 
 extern "C" fn conclude_drag_operation(this: &Object, _: Sel, _: id) {
     let window_state = unsafe { get_window_state(this) };

--- a/crates/gpui_windows/src/clipboard.rs
+++ b/crates/gpui_windows/src/clipboard.rs
@@ -79,6 +79,7 @@ pub(crate) fn write_to_clipboard(item: ClipboardItem) {
                 ClipboardEntry::String(string) => write_string(string)?,
                 ClipboardEntry::Image(image) => write_image(image)?,
                 ClipboardEntry::ExternalPaths(_) => {}
+                ClipboardEntry::Urls(_) => {}
             }
         }
         Ok(())

--- a/crates/gpui_windows/src/window.rs
+++ b/crates/gpui_windows/src/window.rs
@@ -20,7 +20,7 @@ use windows::{
         Foundation::*,
         Graphics::Dwm::*,
         Graphics::Gdi::*,
-        System::{Com::*, LibraryLoader::*, Ole::*, SystemServices::*},
+        System::{Com::*, LibraryLoader::*, Memory::*, Ole::*, SystemServices::*},
         UI::{Controls::*, HiDpi::*, Input::KeyboardAndMouse::*, Shell::*, WindowsAndMessaging::*},
     },
     core::*,
@@ -960,6 +960,7 @@ impl WindowsDragDropHandler {
 
 #[allow(non_snake_case)]
 impl IDropTarget_Impl for WindowsDragDropHandler_Impl {
+    #[allow(deprecated)]
     fn DragEnter(
         &self,
         pdataobj: windows::core::Ref<IDataObject>,
@@ -969,7 +970,10 @@ impl IDropTarget_Impl for WindowsDragDropHandler_Impl {
     ) -> windows::core::Result<()> {
         unsafe {
             let idata_obj = pdataobj.ok()?;
-            let config = FORMATETC {
+            let mut items = SmallVec::<[DropItem; 2]>::new();
+
+            // Check for file drops (CF_HDROP)
+            let file_config = FORMATETC {
                 cfFormat: CF_HDROP.0,
                 ptd: std::ptr::null_mut() as _,
                 dwAspect: DVASPECT_CONTENT.0,
@@ -977,34 +981,69 @@ impl IDropTarget_Impl for WindowsDragDropHandler_Impl {
                 tymed: TYMED_HGLOBAL.0 as _,
             };
             let cursor_position = POINT { x: pt.x, y: pt.y };
-            if idata_obj.QueryGetData(&config as _) == S_OK {
-                *pdweffect = DROPEFFECT_COPY;
-                let Some(mut idata) = idata_obj.GetData(&config as _).log_err() else {
-                    return Ok(());
-                };
-                if idata.u.hGlobal.is_invalid() {
-                    return Ok(());
-                }
-                let hdrop = HDROP(idata.u.hGlobal.0);
-                let mut paths = SmallVec::<[PathBuf; 2]>::new();
-                with_file_names(hdrop, |file_name| {
-                    if let Some(path) = PathBuf::from_str(&file_name).log_err() {
-                        paths.push(path);
+
+            if idata_obj.QueryGetData(&file_config as _) == S_OK {
+                if let Some(mut idata) = idata_obj.GetData(&file_config as _).log_err() {
+                    if !idata.u.hGlobal.is_invalid() {
+                        let hdrop = HDROP(idata.u.hGlobal.0);
+                        with_file_names(hdrop, |file_name| {
+                            if let Some(path) = PathBuf::from_str(&file_name).log_err() {
+                                items.push(DropItem::Path(path));
+                            }
+                        });
                     }
-                });
-                ReleaseStgMedium(&mut idata);
+                    ReleaseStgMedium(&mut idata);
+                }
+            }
+
+            // Check for URL drops (CF_UNICODETEXT)
+            let url_config = FORMATETC {
+                cfFormat: CF_UNICODETEXT.0,
+                ptd: std::ptr::null_mut() as _,
+                dwAspect: DVASPECT_CONTENT.0,
+                lindex: -1,
+                tymed: TYMED_HGLOBAL.0 as _,
+            };
+
+            if items.is_empty() && idata_obj.QueryGetData(&url_config as _) == S_OK {
+                if let Some(mut idata) = idata_obj.GetData(&url_config as _).log_err() {
+                    if !idata.u.hGlobal.is_invalid() {
+                        let hglobal = idata.u.hGlobal;
+                        let ptr = GlobalLock(hglobal) as *const u16;
+                        if !ptr.is_null() {
+                            let len = (0..).take_while(|&i| *ptr.add(i) != 0).count();
+                            let slice = std::slice::from_raw_parts(ptr, len);
+                            let text = String::from_utf16_lossy(slice);
+                            GlobalUnlock(hglobal).log_err();
+
+                            // Try to parse as URL
+                            if let Ok(url) = url::Url::parse(&text) {
+                                if url.scheme() == "http" || url.scheme() == "https" {
+                                    items.push(DropItem::Url(url));
+                                }
+                            }
+                        }
+                    }
+                    ReleaseStgMedium(&mut idata);
+                }
+            }
+
+            if !items.is_empty() {
+                *pdweffect = DROPEFFECT_COPY;
                 let mut cursor_position = cursor_position;
                 ScreenToClient(self.0.hwnd, &mut cursor_position)
                     .ok()
                     .log_err();
                 let scale_factor = self.0.state.scale_factor.get();
+                let items = ExternalDrop(items);
                 let input = PlatformInput::FileDrop(FileDropEvent::Entered {
                     position: logical_point(
                         cursor_position.x as f32,
                         cursor_position.y as f32,
                         scale_factor,
                     ),
-                    paths: ExternalPaths(paths),
+                    paths: items.to_external_paths(),
+                    items,
                 });
                 self.handle_drag_drop(input);
             } else {


### PR DESCRIPTION
Extends #16830
Fixes #52110

This PR extends the existing file drag-drop support to also accept URLs (e.g., from browsers) into Zed windows.

## Summary

- Add `DragType` enum to configure accepted drag types (`Files`, `Urls`) via `WindowOptions::drag_types`
- Add `ExternalDrop` and `DropItem` types to represent dropped items (files and/or URLs)
- Implement URL drag-drop across all platforms (macOS, Linux X11/Wayland, Windows)
- Add `items` field to `FileDropEvent::Entered` (deprecating `paths` field)
- Add `ClipboardEntry::Urls` variant for clipboard URL support
- Add `external_drop` example (see below)

## Usage

```rust
// Configure window to accept both files and URLs
let options = WindowOptions {
    drag_types: smallvec![DragType::Files, DragType::Urls],
    ..Default::default()
};

// Handle drops
div().on_drop(|drop: ExternalDrop, _window, _cx| {
    for path in drop.paths() { /* file paths */ }
    for url in drop.urls() { /* http/https URLs */ }
})
```

## Testing

- [x] macOS: Drag files from Finder
- [x] macOS: Drag URL from browser
- [ ] Linux X11: Drag files from file manager
- [ ] Linux X11: Drag URL from browser
- [x] Linux Wayland: Drag files from file manager
- [x] Linux Wayland: Drag URL from browser
- [x] Windows: Drag files from Explorer
- [x] Windows: Drag URL from browser

Release Notes:

- Added URL drag-drop support to GPUI windows (configurable via `WindowOptions::drag_types`)

## Example `external_drop`

https://github.com/user-attachments/assets/de9a3bac-8a21-4c34-bf33-ad5a6cb2de69