### PR TITLE
rust: Highlight Self as keyword

### DIFF
--- a/crates/languages/src/rust/highlights.scm
+++ b/crates/languages/src/rust/highlights.scm
@@ -197,6 +197,10 @@
   "?"
 ] @operator
 
+; Self keyword
+((type_identifier) @keyword (#eq? @keyword "Self"))
+((identifier) @keyword (#eq? @keyword "Self"))
+
 ; Avoid highlighting these as operators when used in doc comments.
 (unary_expression "!" @operator)
 operator: "/" @operator


### PR DESCRIPTION
Added `Self` as keyword for Rust per [spec](https://doc.rust-lang.org/reference/keywords.html#r-lex.keywords.strict.list), currently treated as normal types.

Release Notes:

- Added `Self` as keyword for Rust highlighting.

Before:

<img width="318" height="172" alt="image" src="https://github.com/user-attachments/assets/ea8c76e2-980a-4718-a041-e9d98efe2eaa" />

After:

<img width="318" height="172" alt="image" src="https://github.com/user-attachments/assets/e9cd66cf-3d77-4042-b78f-f041960b52c8" />
