### PR TITLE
tasks: Omit arguments that resolve to empty strings during variable substitution

### DIFF
--- a/crates/task/src/task_template.rs
+++ b/crates/task/src/task_template.rs
@@ -423,6 +423,10 @@ fn substitute_all_template_variables_in_vec(
             variable_names,
             substituted_variables,
         )?;
+        // Prune arguments that became empty after substitution, but keep explicit empty args.
+        if new_value.is_empty() && new_value != *variable {
+            continue;
+        }
         expanded.push(new_value);
     }
 


### PR DESCRIPTION
Related issue #47985 

This PR addresses a potential issue regarding task argument parsing. I would appreciate feedback from the team on this approach.

## The error behind and the analysis
As reported in issue #47985, when debugging Rust programs, the terminal raises the error: `unexpected argument '' found`, I initially thought this was a `pwsh`-specific issue, but it turns out to be a general argument construction problem.

The failure occurs in `resolve_scenario()` within `crates/debugger_ui/src/session/running.rs` because the command is passed as `cargo build -p rusttest --bin rusttest '' ''`. These trailing empty strings cause Cargo to fail. The arguments are built in `resolve_task()` in `crates/task/src/task_template.rs`, which uses `substitute_all_template_variables_in_vec()` for for environment variable substitution. In my test case:
- Original args vec:
```["build", "-p", "$ZED_CUSTOM_RUST_PACKAGE", "--$ZED_CUSTOM_RUST_BIN_KIND", "$ZED_CUSTOM_RUST_BIN_NAME", "$ZED_CUSTOM_RUST_BIN_REQUIRED_FEATURES_FLAG", "$ZED_CUSTOM_RUST_BIN_REQUIRED_FEATURES"]```
- The Issue:
Because `$ZED_CUSTOM_RUST_BIN_REQUIRED_FEATURES_FLAG` and `$ZED_CUSTOM_RUST_BIN_REQUIRED_FEATURES` are both empty in this context, the final vec after substitution becomes:
```["build", "-p", "rusttest", "--bin", "rusttest", "", ""] ```

The substitution logic preserves these empty strings, which Cargo interprets as invalid positional arguments.

## what this PR does?
I have added logic to filter out arguments that resolve to empty strings only if they were originally environment variables that resulted in an empty value after substitution.

## Concerns
This change affects all tasks defined by users. Sometimes, a user might explicitly include an empty string (e.g., ["my-cmd", ""]) to satisfy a specific command's requirement. I have ensured that these explicitly defined empty strings are preserved.

This PR only filters cases where an environment variable is used but evaluates to an empty string. While relying on empty environment variables might not be the best way to define a task, some users may rely on this behavior, whether intentional or not.

An alternative approach would be to modify Zed's default Rust task definitions directly. This would be more specific but might leave the underlying substitution behavior prone to similar issues in other contexts.

Release Notes:

- N/A 
