### PR TITLE
agent_ui: Add confirmation dialog for "Reject All" in Agent panel

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -17,8 +17,9 @@ use crate::ManageProfiles;
 use crate::ui::{AcpOnboardingModal, ClaudeCodeOnboardingModal};
 use crate::{
     AddContextServer, AgentDiffPane, Follow, InlineAssistant, NewTextThread, NewThread,
-    OpenActiveThreadAsMarkdown, OpenAgentDiff, OpenHistory, ResetTrialEndUpsell, ResetTrialUpsell,
-    ToggleNavigationMenu, ToggleNewThreadMenu, ToggleOptionsMenu,
+    OpenActiveThreadAsMarkdown, OpenAgentDiff, OpenHistory, RejectAllConfirmation,
+    ResetRejectAllConfirmation, ResetTrialEndUpsell, ResetTrialUpsell, ToggleNavigationMenu,
+    ToggleNewThreadMenu, ToggleOptionsMenu,
     acp::AcpThreadView,
     agent_configuration::{AgentConfiguration, AssistantConfigurationEvent},
     slash_command::SlashCommandCompletionProvider,
@@ -205,6 +206,9 @@ pub fn init(cx: &mut App) {
                 })
                 .register_action(|_workspace, _: &ResetTrialEndUpsell, _window, cx| {
                     TrialEndUpsell::set_dismissed(false, cx);
+                })
+                .register_action(|_workspace, _: &ResetRejectAllConfirmation, _window, cx| {
+                    RejectAllConfirmation::set_dismissed(false, cx);
                 })
                 .register_action(|workspace, _: &ResetAgentZoom, window, cx| {
                     if let Some(panel) = workspace.panel::<AgentPanel>(cx) {

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -26,6 +26,8 @@ mod user_slash_command;
 use std::rc::Rc;
 use std::sync::Arc;
 
+use db::kvp::Dismissable;
+
 use agent_settings::{AgentProfileId, AgentSettings};
 use assistant_slash_command::SlashCommandRegistry;
 use client::Client;
@@ -107,6 +109,8 @@ actions!(
         Reject,
         /// Rejects all suggestions or changes.
         RejectAll,
+        /// Resets the "Don't show again" state for the Reject All confirmation dialog.
+        ResetRejectAllConfirmation,
         /// Keeps all suggestions or changes.
         KeepAll,
         /// Allow this operation only this time.
@@ -238,6 +242,14 @@ impl ManageProfiles {
             customize_tools: Some(profile_id),
         }
     }
+}
+
+/// Tracks whether the user has dismissed the "Reject All" confirmation dialog.
+/// When dismissed, clicking "Reject All" will immediately reject without prompting.
+pub struct RejectAllConfirmation;
+
+impl Dismissable for RejectAllConfirmation {
+    const KEY: &'static str = "reject_all_confirmation_dismissed";
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
Closes #39294

This adds a confirmation dialog that appears when clicking "Reject All" with three options:
- "Reject All" - proceeds with rejection
- "Don't Ask Again" - proceeds and permanently disables the dialog
- "Cancel" - aborts the action

The dialog can be re-enabled via the `agent: reset reject all confirmation` command in the command palette.

Release Notes:

- Added confirmation dialog that appears when clicking "Reject All"
- Added `agent: reset reject all confirmation` command in the command palette

The modal:

<img width="1047" height="688" alt="Screenshot 2026-01-30 at 13 38 31" src="https://github.com/user-attachments/assets/f8af61cb-bcd8-4279-b5df-48958a3970f9" />

And the new command:

<img width="614" height="193" alt="Screenshot 2026-01-30 at 13 39 22" src="https://github.com/user-attachments/assets/ea5b1a40-24a2-48fd-a2b5-b09e4aa651d8" />

