### PR TITLE
multi_buffer: Speed up `Anchor::to_offset` resolution

### DIFF
--- a/crates/multi_buffer/src/anchor.rs
+++ b/crates/multi_buffer/src/anchor.rs
@@ -4,7 +4,7 @@ use super::{ExcerptId, MultiBufferSnapshot, ToOffset, ToPoint};
 use language::Point;
 use std::{
     cmp::Ordering,
-    ops::{AddAssign, Range, Sub},
+    ops::{Add, AddAssign, Range, Sub},
 };
 use sum_tree::Bias;
 
@@ -185,7 +185,9 @@ impl Anchor {
         D: MultiBufferDimension
             + Ord
             + Sub<Output = D::TextDimension>
-            + AddAssign<D::TextDimension>,
+            + Sub<D::TextDimension, Output = D>
+            + AddAssign<D::TextDimension>
+            + Add<D::TextDimension, Output = D>,
         D::TextDimension: Sub<Output = D::TextDimension> + Ord,
     {
         snapshot.summary_for_anchor(self)

--- a/crates/sum_tree/src/sum_tree.rs
+++ b/crates/sum_tree/src/sum_tree.rs
@@ -613,6 +613,10 @@ impl<T: Item> SumTree<T> {
         self.rightmost_leaf().0.items().last()
     }
 
+    pub fn last_summary(&self) -> Option<&T::Summary> {
+        self.rightmost_leaf().0.child_summaries().last()
+    }
+
     pub fn update_last(
         &mut self,
         f: impl FnOnce(&mut T),


### PR DESCRIPTION
We used to just use the anchor resolution function that allows resolving multiple anchors in one loop before. That has a lot of overhead though when we only have a single anchor to resolve, so instead we just specialize that case now as resolving a single anchor to an offset is a super common operation.

Release Notes:

- N/A *or* Added/Fixed/Improved ...
