### PR TITLE
helix: Fix line select with empty first line

### DIFF
--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -1334,7 +1334,9 @@ mod test {
             line one
             ˇ
             line three
-            line four"},
+            line four
+            line five
+            line six"},
             Mode::HelixNormal,
         );
         cx.simulate_keystrokes("x");
@@ -1343,7 +1345,22 @@ mod test {
             line one
             «
             line three
-            ˇ»line four"},
+            ˇ»line four
+            line five
+            line six"},
+            Mode::HelixNormal,
+        );
+
+        // Another x should only select the next line
+        cx.simulate_keystrokes("x");
+        cx.assert_state(
+            indoc! {"
+            line one
+            «
+            line three
+            line four
+            ˇ»line five
+            line six"},
             Mode::HelixNormal,
         );
 

--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -713,7 +713,7 @@ impl Vim {
                 // Check if cursor is on empty line by checking first character
                 let line_start_offset = buffer_snapshot.point_to_offset(Point::new(start_row, 0));
                 let first_char = buffer_snapshot.chars_at(line_start_offset).next();
-                let extra_line = if first_char == Some('\n') { 1 } else { 0 };
+                let extra_line = if first_char == Some('\n') && selection.is_empty() { 1 } else { 0 };
 
                 let end_row = current_end_row + count as u32 + extra_line;
 

--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -713,7 +713,11 @@ impl Vim {
                 // Check if cursor is on empty line by checking first character
                 let line_start_offset = buffer_snapshot.point_to_offset(Point::new(start_row, 0));
                 let first_char = buffer_snapshot.chars_at(line_start_offset).next();
-                let extra_line = if first_char == Some('\n') && selection.is_empty() { 1 } else { 0 };
+                let extra_line = if first_char == Some('\n') && selection.is_empty() {
+                    1
+                } else {
+                    0
+                };
 
                 let end_row = current_end_row + count as u32 + extra_line;
 


### PR DESCRIPTION
Fixes `HelixSelectLine` with a pre-existing selection with an empty first line.

An extra line is only needed if the selection is empty, so make that part of the condition.

Also added a test which fails before the fix to validate.

Closes #48023 

Release Notes:

- Fixed `HelixSelectLine` with an empty first line and a pre-existing selection.
