### PR TITLE
Bump wax to 0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19212,16 +19212,16 @@ dependencies = [
 
 [[package]]
 name = "wax"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d12a78aa0bab22d2f26ed1a96df7ab58e8a93506a3e20adb47c51a93b4e1357"
+checksum = "1f8cbf8125142b9b30321ac8721f54c52fbcd6659f76cf863d5e2e38c07a3d7b"
 dependencies = [
  "const_format",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "nom 7.1.3",
  "pori",
  "regex",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "walkdir",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -732,7 +732,7 @@ wasmtime = { version = "33", default-features = false, features = [
     "parallel-compilation",
 ] }
 wasmtime-wasi = "33"
-wax = "0.6"
+wax = "0.7"
 which = "6.0.0"
 windows-core = "0.61"
 yawc = "0.2.5"


### PR DESCRIPTION
Closes #47756
Closes ZED-3WQ

Release Notes:

- N/A