### PR TITLE
Revert "Allow always_allow patterns for Nushell, Elvish, and Rc shells"

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -2421,6 +2421,7 @@ impl AcpThread {
 
         let project = self.project.clone();
         let language_registry = project.read(cx).languages().clone();
+        let is_windows = project.read(cx).path_style(cx).is_windows();
 
         let terminal_id = acp::TerminalId::new(Uuid::new_v4().to_string());
         let terminal_task = cx.spawn({
@@ -2434,9 +2435,10 @@ impl AcpThread {
                             .and_then(|r| r.read(cx).default_system_shell())
                     })
                     .unwrap_or_else(|| get_default_system_shell_preferring_bash());
-                let (task_command, task_args) = ShellBuilder::new(&Shell::Program(shell))
-                    .redirect_stdin_to_dev_null()
-                    .build(Some(command.clone()), &args);
+                let (task_command, task_args) =
+                    ShellBuilder::new(&Shell::Program(shell), is_windows)
+                        .redirect_stdin_to_dev_null()
+                        .build(Some(command.clone()), &args);
                 let terminal = project
                     .update(cx, |project, cx| {
                         project.create_terminal_task(
@@ -2790,7 +2792,7 @@ mod tests {
         // Create a real PTY terminal that runs a command which prints output then sleeps
         // We use printf instead of echo and chain with && sleep to ensure proper execution
         let (completion_tx, _completion_rx) = smol::channel::unbounded();
-        let (program, args) = ShellBuilder::new(&Shell::System).build(
+        let (program, args) = ShellBuilder::new(&Shell::System, false).build(
             Some("printf 'output_before_kill\\n' && sleep 60".to_owned()),
             &[],
         );

--- a/crates/acp_thread/src/terminal.rs
+++ b/crates/acp_thread/src/terminal.rs
@@ -227,7 +227,8 @@ pub async fn create_terminal_entity(
                 .map(Shell::Program)
         })
         .unwrap_or_else(|| Shell::Program(get_default_system_shell_preferring_bash()));
-    let (task_command, task_args) = task::ShellBuilder::new(&shell)
+    let is_windows = project.read_with(cx, |project, cx| project.path_style(cx).is_windows());
+    let (task_command, task_args) = task::ShellBuilder::new(&shell, is_windows)
         .redirect_stdin_to_dev_null()
         .build(Some(command.clone()), &args);
 

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -665,9 +665,7 @@ impl ToolPermissionContext {
         // Check if the user's shell supports POSIX-like command chaining.
         // See the doc comment above for the full explanation of why this is needed.
         let shell_supports_always_allow = if tool_name == TerminalTool::name() {
-            ShellKind::system()
-                .map(|k| k.supports_posix_chaining())
-                .unwrap_or(false)
+            ShellKind::system().supports_posix_chaining()
         } else {
             true
         };

--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -195,7 +195,7 @@ impl AcpConnection {
         cx: &mut AsyncApp,
     ) -> Result<Self> {
         let shell = cx.update(|cx| TerminalSettings::get(None, cx).shell.clone());
-        let builder = ShellBuilder::new(&shell).non_interactive();
+        let builder = ShellBuilder::new(&shell, cfg!(windows)).non_interactive();
         let mut child =
             builder.build_std_command(Some(command.path.display().to_string()), &command.args);
         child.envs(command.env.iter().flatten());

--- a/crates/askpass/src/askpass.rs
+++ b/crates/askpass/src/askpass.rs
@@ -20,11 +20,7 @@ use futures::{
 };
 use gpui::{AsyncApp, BackgroundExecutor, Task};
 use smol::fs;
-use util::{
-    ResultExt as _, debug_panic, maybe,
-    paths::PathExt,
-    shell::{PosixShell, ShellKind},
-};
+use util::{ResultExt as _, debug_panic, maybe, paths::PathExt, shell::ShellKind};
 
 /// Path to the program used for askpass
 ///
@@ -212,8 +208,7 @@ impl PasswordProxy {
         let shell_kind = if cfg!(windows) {
             ShellKind::PowerShell
         } else {
-            // TODO: Consider using the user's actual shell instead of hardcoding "sh"
-            ShellKind::Posix(PosixShell::Sh)
+            ShellKind::Posix
         };
         let askpass_program = ASKPASS_PROGRAM.get_or_init(|| current_exec);
         // Create an askpass script that communicates back to this process.
@@ -359,7 +354,7 @@ fn generate_askpass_script(
         .try_quote_prefix_aware(&askpass_program)
         .context("Failed to shell-escape Askpass program path")?;
     let askpass_socket = askpass_socket
-        .try_shell_safe(Some(&shell_kind))
+        .try_shell_safe(shell_kind)
         .context("Failed to shell-escape Askpass socket path")?;
     let print_args = "printf '%s\\0' \"$@\"";
     let shebang = "#!/bin/sh";
@@ -384,7 +379,7 @@ fn generate_askpass_script(
         .try_quote_prefix_aware(&askpass_program)
         .context("Failed to shell-escape Askpass program path")?;
     let askpass_socket = askpass_socket
-        .try_shell_safe(Some(&shell_kind))
+        .try_shell_safe(shell_kind)
         .context("Failed to shell-escape Askpass socket path")?;
     Ok(format!(
         r#"

--- a/crates/context_server/src/transport/stdio_transport.rs
+++ b/crates/context_server/src/transport/stdio_transport.rs
@@ -32,7 +32,7 @@ impl StdioTransport {
         cx: &AsyncApp,
     ) -> Result<Self> {
         let shell = cx.update(|cx| TerminalSettings::get(None, cx).shell.clone());
-        let builder = ShellBuilder::new(&shell).non_interactive();
+        let builder = ShellBuilder::new(&shell, cfg!(windows)).non_interactive();
         let mut command =
             builder.build_smol_command(Some(binary.executable.display().to_string()), &binary.args);
 

--- a/crates/dap_adapters/src/javascript.rs
+++ b/crates/dap_adapters/src/javascript.rs
@@ -6,10 +6,7 @@ use gpui::AsyncApp;
 use serde_json::Value;
 use std::{path::PathBuf, sync::OnceLock};
 use task::DebugRequest;
-use util::{
-    ResultExt, maybe,
-    shell::{PosixShell, ShellKind},
-};
+use util::{ResultExt, maybe, shell::ShellKind};
 
 use crate::*;
 
@@ -70,10 +67,7 @@ impl JsDebugAdapter {
                     .get("type")
                     .filter(|value| value == &"node-terminal")?;
                 let command = configuration.get("command")?.as_str()?.to_owned();
-                // TODO: Consider using the user's actual shell instead of hardcoding "sh"
-                let mut args = ShellKind::Posix(PosixShell::Sh)
-                    .split(&command)?
-                    .into_iter();
+                let mut args = ShellKind::Posix.split(&command)?.into_iter();
                 let program = args.next()?;
                 configuration.insert("runtimeExecutable".to_owned(), program.into());
                 configuration.insert(

--- a/crates/debugger_ui/src/new_process_modal.rs
+++ b/crates/debugger_ui/src/new_process_modal.rs
@@ -28,11 +28,7 @@ use ui::{
     prelude::*,
 };
 use ui_input::InputField;
-use util::{
-    ResultExt, debug_panic,
-    rel_path::RelPath,
-    shell::{PosixShell, ShellKind},
-};
+use util::{ResultExt, debug_panic, rel_path::RelPath, shell::ShellKind};
 use workspace::{ModalView, Workspace, notifications::DetachAndPromptErr, pane};
 
 use crate::{
@@ -874,8 +870,7 @@ impl ConfigureMode {
             };
         }
         let command = self.program.read(cx).text(cx);
-        // TODO: Consider using the user's actual shell instead of hardcoding "sh"
-        let mut args = ShellKind::Posix(PosixShell::Sh)
+        let mut args = ShellKind::Posix
             .split(&command)
             .into_iter()
             .flatten()
@@ -1303,8 +1298,7 @@ impl PickerDelegate for DebugDelegate {
             })
             .unwrap_or_default();
 
-        // TODO: Consider using the user's actual shell instead of hardcoding "sh"
-        let mut args = ShellKind::Posix(PosixShell::Sh)
+        let mut args = ShellKind::Posix
             .split(&text)
             .into_iter()
             .flatten()

--- a/crates/debugger_ui/src/session/running.rs
+++ b/crates/debugger_ui/src/session/running.rs
@@ -971,6 +971,7 @@ impl RunningState {
         let task_store = project.read(cx).task_store().downgrade();
         let weak_project = project.downgrade();
         let weak_workspace = workspace.downgrade();
+        let is_windows = project.read(cx).path_style(cx).is_windows();
         let remote_shell = project
             .read(cx)
             .remote_client()
@@ -1088,7 +1089,7 @@ impl RunningState {
                     task.resolved.shell = Shell::Program(remote_shell);
                 }
 
-                let builder = ShellBuilder::new(&task.resolved.shell);
+                let builder = ShellBuilder::new(&task.resolved.shell, is_windows);
                 let command_label = builder.command_label(task.resolved.command.as_deref().unwrap_or(""));
                 let (command, args) =
                     builder.build(task.resolved.command.clone(), &task.resolved.args);

--- a/crates/language/src/toolchain.rs
+++ b/crates/language/src/toolchain.rs
@@ -117,7 +117,7 @@ pub trait ToolchainLister: Send + Sync + 'static {
     fn activation_script(
         &self,
         toolchain: &Toolchain,
-        shell: Option<ShellKind>,
+        shell: ShellKind,
         cx: &App,
     ) -> BoxFuture<'static, Vec<String>>;
 

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -46,7 +46,7 @@ use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
-use task::{PosixShell, ShellKind, TaskTemplate, TaskTemplates, VariableName};
+use task::{ShellKind, TaskTemplate, TaskTemplates, VariableName};
 use util::{ResultExt, maybe};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -1168,15 +1168,13 @@ fn wr_distance(
     }
 }
 
-fn micromamba_shell_name(kind: Option<ShellKind>) -> &'static str {
+fn micromamba_shell_name(kind: ShellKind) -> &'static str {
     match kind {
-        Some(ShellKind::Csh) => "csh",
-        Some(ShellKind::Fish) => "fish",
-        Some(ShellKind::Nushell) => "nu",
-        Some(ShellKind::PowerShell) | Some(ShellKind::Pwsh) => "powershell",
-        Some(ShellKind::Cmd) => "cmd.exe",
-        #[cfg(windows)]
-        None => "powershell",
+        ShellKind::Csh => "csh",
+        ShellKind::Fish => "fish",
+        ShellKind::Nushell => "nu",
+        ShellKind::PowerShell => "powershell",
+        ShellKind::Cmd => "cmd.exe",
         // default / catch-all:
         _ => "posix",
     }
@@ -1341,7 +1339,7 @@ impl ToolchainLister for PythonToolchainProvider {
     fn activation_script(
         &self,
         toolchain: &Toolchain,
-        shell: Option<ShellKind>,
+        shell: ShellKind,
         cx: &App,
     ) -> BoxFuture<'static, Vec<String>> {
         let settings = TerminalSettings::get_global(cx);
@@ -1408,21 +1406,10 @@ impl ToolchainLister for PythonToolchainProvider {
                     | PythonEnvironmentKind::Poetry,
                 ) => {
                     if let Some(activation_scripts) = &toolchain.activation_scripts {
-                        // For unknown shells, fall back to platform-appropriate defaults:
-                        // POSIX (sh) on Unix, PowerShell on Windows
-                        #[cfg(unix)]
-                        let fallback_shell = ShellKind::Posix(PosixShell::Sh);
-                        #[cfg(windows)]
-                        let fallback_shell = ShellKind::PowerShell;
-
-                        let shell_kind = shell.unwrap_or(fallback_shell);
-                        // Use activation_script_key() to normalize POSIX shells (e.g., Bash, Zsh)
-                        // to Posix(Sh) for lookup, since activation scripts are stored with Posix(Sh) key
-                        let lookup_key = shell_kind.activation_script_key();
-                        if let Some(activate_script_path) = activation_scripts.get(&lookup_key) {
-                            let activate_keyword = shell_kind.activate_keyword();
+                        if let Some(activate_script_path) = activation_scripts.get(&shell) {
+                            let activate_keyword = shell.activate_keyword();
                             if let Some(quoted) =
-                                shell_kind.try_quote(&activate_script_path.to_string_lossy())
+                                shell.try_quote(&activate_script_path.to_string_lossy())
                             {
                                 activation_script.push(format!("{activate_keyword} {quoted}"));
                             }
@@ -1436,27 +1423,17 @@ impl ToolchainLister for PythonToolchainProvider {
                     let version = toolchain.environment.version.as_deref().unwrap_or("system");
                     let pyenv = &manager.executable;
                     let pyenv = pyenv.display();
-                    let pyenv_sh_activation = format!("\"{pyenv}\" shell - sh {version}");
                     activation_script.extend(match shell {
-                        Some(ShellKind::Fish) => {
-                            Some(format!("\"{pyenv}\" shell - fish {version}"))
-                        }
-                        Some(ShellKind::Posix(_)) => Some(pyenv_sh_activation),
-                        #[cfg(unix)]
-                        None => Some(pyenv_sh_activation),
-                        Some(ShellKind::Nushell) => {
-                            Some(format!("^\"{pyenv}\" shell - nu {version}"))
-                        }
-                        Some(ShellKind::PowerShell)
-                        | Some(ShellKind::Pwsh)
-                        | Some(ShellKind::Csh)
-                        | Some(ShellKind::Tcsh)
-                        | Some(ShellKind::Cmd)
-                        | Some(ShellKind::Rc)
-                        | Some(ShellKind::Xonsh)
-                        | Some(ShellKind::Elvish) => None,
-                        #[cfg(windows)]
-                        None => None,
+                        ShellKind::Fish => Some(format!("\"{pyenv}\" shell - fish {version}")),
+                        ShellKind::Posix => Some(format!("\"{pyenv}\" shell - sh {version}")),
+                        ShellKind::Nushell => Some(format!("^\"{pyenv}\" shell - nu {version}")),
+                        ShellKind::PowerShell | ShellKind::Pwsh => None,
+                        ShellKind::Csh => None,
+                        ShellKind::Tcsh => None,
+                        ShellKind::Cmd => None,
+                        ShellKind::Rc => None,
+                        ShellKind::Xonsh => None,
+                        ShellKind::Elvish => None,
                     })
                 }
                 _ => {}
@@ -1520,9 +1497,8 @@ async fn resolve_venv_activation_scripts(
 ) {
     log::debug!("(Python) Resolving activation scripts for venv toolchain {venv:?}");
     if let Some(prefix) = &venv.prefix {
-        // TODO: Consider using the user's actual shell instead of hardcoding "sh"
         for (shell_kind, script_name) in &[
-            (ShellKind::Posix(PosixShell::Sh), "activate"),
+            (ShellKind::Posix, "activate"),
             (ShellKind::Rc, "activate"),
             (ShellKind::Csh, "activate.csh"),
             (ShellKind::Tcsh, "activate.csh"),

--- a/crates/project/src/debugger/locators/cargo.rs
+++ b/crates/project/src/debugger/locators/cargo.rs
@@ -122,7 +122,7 @@ impl DapLocator for CargoLocator {
             .cwd
             .clone()
             .context("Couldn't get cwd from debug config which is needed for locators")?;
-        let builder = ShellBuilder::new(&build_config.shell).non_interactive();
+        let builder = ShellBuilder::new(&build_config.shell, cfg!(windows)).non_interactive();
         let mut child = builder
             .build_smol_command(
                 Some("cargo".into()),

--- a/crates/project/src/lsp_store/lsp_ext_command.rs
+++ b/crates/project/src/lsp_store/lsp_ext_command.rs
@@ -657,7 +657,7 @@ impl LspCommand for GetLspRunnables {
                     );
                     task_template.args.extend(cargo.cargo_args);
                     if !cargo.executable_args.is_empty() {
-                        let shell_kind = task_template.shell.shell_kind();
+                        let shell_kind = task_template.shell.shell_kind(cfg!(windows));
                         task_template.args.push("--".to_string());
                         task_template.args.extend(
                             cargo
@@ -683,8 +683,7 @@ impl LspCommand for GetLspRunnables {
                                 // That bit is not auto-expanded when using single quotes.
                                 // Escape extra cargo args unconditionally as those are unlikely to contain `~`.
                                 .flat_map(|extra_arg| {
-                                    util::shell::try_quote_option(shell_kind, &extra_arg)
-                                        .map(|s| s.to_string())
+                                    shell_kind.try_quote(&extra_arg).map(|s| s.to_string())
                                 }),
                         );
                     }

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -11266,7 +11266,7 @@ fn python_lang(fs: Arc<FakeFs>) -> Arc<Language> {
         fn activation_script(
             &self,
             _: &Toolchain,
-            _: Option<ShellKind>,
+            _: ShellKind,
             _: &gpui::App,
         ) -> futures::future::BoxFuture<'static, Vec<String>> {
             Box::pin(async { vec![] })

--- a/crates/prompt_store/src/prompts.rs
+++ b/crates/prompt_store/src/prompts.rs
@@ -57,12 +57,8 @@ impl ProjectContext {
             user_rules: default_user_rules,
             os: std::env::consts::OS.to_string(),
             arch: std::env::consts::ARCH.to_string(),
-            shell: ShellKind::new_with_fallback(
-                &get_default_system_shell_preferring_bash(),
-                cfg!(windows),
-            )
-            .name()
-            .to_string(),
+            shell: ShellKind::new(&get_default_system_shell_preferring_bash(), cfg!(windows))
+                .to_string(),
         }
     }
 }

--- a/crates/remote/src/transport/docker.rs
+++ b/crates/remote/src/transport/docker.rs
@@ -13,7 +13,7 @@ use std::{
     sync::Arc,
 };
 use util::ResultExt;
-use util::shell::{PosixShell, ShellKind};
+use util::shell::ShellKind;
 use util::{
     paths::{PathStyle, RemotePathBuf},
     rel_path::RelPath,
@@ -301,8 +301,7 @@ impl DockerExecConnection {
         delegate.set_status(Some("Extracting remote development server"), cx);
         let server_mode = 0o755;
 
-        // TODO: Consider using the remote's actual shell instead of hardcoding "sh"
-        let shell_kind = ShellKind::Posix(PosixShell::Sh);
+        let shell_kind = ShellKind::Posix;
         let orig_tmp_path = tmp_path.display(self.path_style());
         let server_mode = format!("{:o}", server_mode);
         let server_mode = shell_kind

--- a/crates/remote/src/transport/ssh.rs
+++ b/crates/remote/src/transport/ssh.rs
@@ -32,7 +32,7 @@ use tempfile::TempDir;
 use util::{
     paths::{PathStyle, RemotePathBuf},
     rel_path::RelPath,
-    shell::{PosixShell, ShellKind},
+    shell::ShellKind,
 };
 
 pub(crate) struct SshRemoteConnection {
@@ -591,7 +591,7 @@ impl SshRemoteConnection {
         let ssh_shell = socket.shell(is_windows).await;
         log::info!("Remote shell discovered: {}", ssh_shell);
 
-        let ssh_shell_kind = ShellKind::new_with_fallback(&ssh_shell, is_windows);
+        let ssh_shell_kind = ShellKind::new(&ssh_shell, is_windows);
         let ssh_platform = socket.platform(ssh_shell_kind, is_windows).await?;
         log::info!("Remote platform discovered: {:?}", ssh_platform);
 
@@ -918,7 +918,7 @@ impl SshRemoteConnection {
         dst_path: &RelPath,
         tmp_path: &RelPath,
     ) -> Result<()> {
-        let shell_kind = self.ssh_shell_kind;
+        let shell_kind = ShellKind::Posix;
         let server_mode = 0o755;
         let orig_tmp_path = tmp_path.display(self.path_style());
         let server_mode = format!("{:o}", server_mode);
@@ -1138,6 +1138,7 @@ impl SshSocket {
             .expect("shell quoting")
             .into_owned();
         for arg in args {
+            // We're trying to work with: sh, bash, zsh, fish, tcsh, ...?
             debug_assert!(
                 !arg.as_ref().contains('\n'),
                 "multiline arguments do not work in all shells"
@@ -1290,14 +1291,8 @@ impl SshSocket {
 
     async fn shell_posix(&self) -> String {
         const DEFAULT_SHELL: &str = "sh";
-        // TODO: Consider using the user's actual shell instead of hardcoding "sh"
         match self
-            .run_command(
-                ShellKind::Posix(PosixShell::Sh),
-                "sh",
-                &["-c", "echo $SHELL"],
-                false,
-            )
+            .run_command(ShellKind::Posix, "sh", &["-c", "echo $SHELL"], false)
             .await
         {
             Ok(output) => parse_shell(&output, DEFAULT_SHELL),
@@ -1391,8 +1386,7 @@ impl SshConnectionOptions {
             "-w",
         ];
 
-        // TODO: Consider using the user's actual shell instead of hardcoding "sh"
-        let mut tokens = ShellKind::Posix(PosixShell::Sh)
+        let mut tokens = ShellKind::Posix
             .split(input)
             .context("invalid input")?
             .into_iter();
@@ -1630,7 +1624,7 @@ fn build_command_posix(
                 .context("shell quoting")?
         )?;
         for arg in input_args {
-            let arg = ssh_shell_kind.try_quote(arg).context("shell quoting")?;
+            let arg = ssh_shell_kind.try_quote(&arg).context("shell quoting")?;
             write!(exec, " {}", &arg)?;
         }
     } else {
@@ -1672,7 +1666,7 @@ fn build_command_windows(
     ssh_env: HashMap<String, String>,
     ssh_path_style: PathStyle,
     ssh_shell: &str,
-    ssh_shell_kind: ShellKind,
+    _ssh_shell_kind: ShellKind,
     ssh_args: Vec<String>,
     interactive: Interactive,
 ) -> Result<CommandTemplate> {
@@ -1691,7 +1685,7 @@ fn build_command_windows(
             shell_kind
                 .try_quote(&working_dir)
                 .context("shell quoting")?,
-            ssh_shell_kind.sequential_and_commands_separator()
+            shell_kind.sequential_and_commands_separator()
         )?;
     }
 
@@ -1778,7 +1772,7 @@ mod tests {
             env.clone(),
             PathStyle::Posix,
             "/bin/bash",
-            ShellKind::Posix(PosixShell::Bash),
+            ShellKind::Posix,
             vec!["-o".to_string(), "ControlMaster=auto".to_string()],
             Interactive::No,
         )?;

--- a/crates/remote/src/transport/wsl.rs
+++ b/crates/remote/src/transport/wsl.rs
@@ -23,7 +23,7 @@ use std::{
 use util::{
     paths::{PathStyle, RemotePathBuf},
     rel_path::RelPath,
-    shell::{PosixShell, Shell, ShellKind},
+    shell::{Shell, ShellKind},
     shell_builder::ShellBuilder,
 };
 
@@ -75,8 +75,7 @@ impl WslRemoteConnection {
                 arch: RemoteArch::X86_64,
             },
             shell: String::new(),
-            // TODO: Consider using the user's actual shell instead of hardcoding "sh"
-            shell_kind: ShellKind::Posix(PosixShell::Sh),
+            shell_kind: ShellKind::Posix,
             default_system_shell: String::from("/bin/sh"),
             has_wsl_interop: false,
         };
@@ -86,8 +85,7 @@ impl WslRemoteConnection {
             .await
             .context("failed detecting shell")?;
         log::info!("Remote shell discovered: {}", this.shell);
-        // WSL is always Linux, so is_windows = false
-        this.shell_kind = ShellKind::new_with_fallback(&this.shell, false);
+        this.shell_kind = ShellKind::new(&this.shell, false);
         this.has_wsl_interop = this.detect_has_wsl_interop().await.unwrap_or_default();
         log::info!(
             "Remote has wsl interop {}",
@@ -470,7 +468,7 @@ impl RemoteConnection for WslRemoteConnection {
             write!(&mut exec, "{} -l", self.shell)?;
         }
         let (command, args) =
-            ShellBuilder::new(&Shell::Program(self.shell.clone())).build(Some(exec), &[]);
+            ShellBuilder::new(&Shell::Program(self.shell.clone()), false).build(Some(exec), &[]);
 
         let mut wsl_args = if let Some(user) = &self.connection_options.user {
             vec![

--- a/crates/task/src/task.rs
+++ b/crates/task/src/task.rs
@@ -25,7 +25,7 @@ pub use task_template::{
     DebugArgsRequest, HideStrategy, RevealStrategy, TaskTemplate, TaskTemplates,
     substitute_variables_in_map, substitute_variables_in_str,
 };
-pub use util::shell::{PosixShell, Shell, ShellKind};
+pub use util::shell::{Shell, ShellKind};
 pub use util::shell_builder::ShellBuilder;
 pub use vscode_debug_format::VsCodeDebugTaskFile;
 pub use vscode_format::VsCodeTaskFile;

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -516,7 +516,7 @@ impl TerminalBuilder {
             // the compilation target. This is fine right now due to the restricted
             // way we use the return value, but would become incorrect if we
             // supported remoting into windows.
-            let shell_kind = shell.shell_kind();
+            let shell_kind = shell.shell_kind(cfg!(windows));
 
             let pty_options = {
                 let alac_shell = shell_params.as_ref().map(|params| {
@@ -532,7 +532,7 @@ impl TerminalBuilder {
                     drain_on_exit: true,
                     env: env.clone().into_iter().collect(),
                     #[cfg(windows)]
-                    escape_args: shell_kind.map(|k| k.tty_escape_args()).unwrap_or(true),
+                    escape_args: shell_kind.tty_escape_args(),
                 }
             };
 
@@ -664,10 +664,7 @@ impl TerminalBuilder {
                 // and while we have sent the activation script to the pty, it will be executed asynchronously.
                 // Therefore, we somehow need to wait for the activation script to finish executing before we
                 // can proceed with clearing the screen.
-                let clear_cmd = shell_kind
-                    .map(|k| k.clear_screen_command())
-                    .unwrap_or("clear");
-                terminal.write_to_pty(clear_cmd.as_bytes());
+                terminal.write_to_pty(shell_kind.clear_screen_command().as_bytes());
                 // Simulate enter key press
                 terminal.write_to_pty(b"\x0d");
             }
@@ -2562,7 +2559,7 @@ mod tests {
         let (completion_tx, completion_rx) = smol::channel::unbounded();
         let args: Vec<String> = args.iter().map(|s| s.to_string()).collect();
         let (program, args) =
-            ShellBuilder::new(&Shell::System).build(Some(command.to_owned()), &args);
+            ShellBuilder::new(&Shell::System, false).build(Some(command.to_owned()), &args);
         let builder = cx
             .update(|cx| {
                 TerminalBuilder::new(
@@ -2783,7 +2780,7 @@ mod tests {
         cx.executor().allow_parking();
 
         let (completion_tx, completion_rx) = smol::channel::unbounded();
-        let (program, args) = ShellBuilder::new(&Shell::System)
+        let (program, args) = ShellBuilder::new(&Shell::System, false)
             .build(Some("asdasdasdasd".to_owned()), &["@@@@@".to_owned()]);
         let builder = cx
             .update(|cx| {

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -562,6 +562,7 @@ impl TerminalPanel {
         }
 
         let remote_client = project.remote_client();
+        let is_windows = project.path_style(cx).is_windows();
         let remote_shell = remote_client
             .as_ref()
             .and_then(|remote_client| remote_client.read(cx).shell());
@@ -574,7 +575,7 @@ impl TerminalPanel {
             task.shell.clone()
         };
 
-        let task = prepare_task_for_spawn(task, &shell);
+        let task = prepare_task_for_spawn(task, &shell, is_windows);
 
         if task.allow_concurrent_runs && task.use_new_terminal {
             return self.spawn_in_new_terminal(task, window, cx);
@@ -1161,8 +1162,12 @@ impl TerminalPanel {
 /// Prepares a `SpawnInTerminal` by computing the command, args, and command_label
 /// based on the shell configuration. This is a pure function that can be tested
 /// without spawning actual terminals.
-pub fn prepare_task_for_spawn(task: &SpawnInTerminal, shell: &Shell) -> SpawnInTerminal {
-    let builder = ShellBuilder::new(shell);
+pub fn prepare_task_for_spawn(
+    task: &SpawnInTerminal,
+    shell: &Shell,
+    is_windows: bool,
+) -> SpawnInTerminal {
+    let builder = ShellBuilder::new(shell, is_windows);
     let command_label = builder.command_label(task.command.as_deref().unwrap_or(""));
     let (command, args) = builder.build_no_quote(task.command.clone(), &task.args);
 
@@ -1854,7 +1859,7 @@ mod tests {
         let input = SpawnInTerminal::default();
         let shell = Shell::System;
 
-        let result = prepare_task_for_spawn(&input, &shell);
+        let result = prepare_task_for_spawn(&input, &shell, false);
 
         let expected_shell = util::get_system_shell();
         assert_eq!(result.env, HashMap::default());
@@ -1926,7 +1931,7 @@ mod tests {
         };
         let shell = Shell::System;
 
-        let result = prepare_task_for_spawn(&input, &shell);
+        let result = prepare_task_for_spawn(&input, &shell, false);
 
         let system_shell = util::get_system_shell();
         assert_eq!(result.env, HashMap::default());

--- a/crates/util/src/util.rs
+++ b/crates/util/src/util.rs
@@ -303,7 +303,7 @@ fn load_shell_from_passwd() -> Result<()> {
 }
 
 /// Returns a shell escaped path for the current zed executable
-pub fn get_shell_safe_zed_path(shell_kind: Option<&shell::ShellKind>) -> anyhow::Result<String> {
+pub fn get_shell_safe_zed_path(shell_kind: shell::ShellKind) -> anyhow::Result<String> {
     let mut zed_path =
         std::env::current_exe().context("Failed to determine current zed executable path.")?;
     if cfg!(target_os = "linux")


### PR DESCRIPTION
Reverts zed-industries/zed#47908

This PR inadvertently caused a regression:

- https://github.com/zed-industries/zed/issues/48047