### PR TITLE
Send selected text to terminal

### DIFF
--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -2489,9 +2489,25 @@ df.describe()
         assert!(buffer_text.contains("import pandas as pd"));
         assert!(buffer_text.contains("df.describe()"));
         assert!(selected_text.eq("import pa"));
-        // Sends event with newline false
+        // I'm going to send three events. One with newline and two without.
+        // the terminal should then contain "import pa/nimport paimportpa".
+        // and we'll know both work
         window
             .update(cx, |_workspace, window, cx| {
+                window.dispatch_action(
+                    SendToTerminal {
+                        append_newline: true,
+                    }
+                    .boxed_clone(),
+                    cx,
+                );
+                window.dispatch_action(
+                    SendToTerminal {
+                        append_newline: false,
+                    }
+                    .boxed_clone(),
+                    cx,
+                );
                 window.dispatch_action(
                     SendToTerminal {
                         append_newline: false,
@@ -2513,12 +2529,11 @@ df.describe()
                 .unwrap()
                 .downcast::<TerminalView>()
                 .unwrap();
-            // TODO: The problem here is that because the terminal contains a bunch of newlines, it's hard to tell if a newline is injected when we ask it to be
             terminal_view.update(cx, |view, cx| {
                 view.terminal().update(cx, |t, _cx| {
                     let text = t.get_content();
                     assert!(
-                        text.contains("import pa"),
+                        text.contains("import pa\nimport paimport pa"),
                         "text should be sent, got: '{}'",
                         text
                     );

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -865,14 +865,32 @@ impl TerminalView {
 
             let buffer = editor.read(cx).buffer().read(cx).snapshot(cx);
             let selection = editor.read(cx).selections.newest_anchor();
+
+            // Going to send selection **UNLESS** nothing is selected,
+            // then we'll use tree-sitter to figure out the thing to send.
             let selection_range =
                 selection.start.to_offset(&buffer)..selection.end.to_offset(&buffer);
-            let expression_text = buffer
-                .text_for_range(selection_range.clone())
-                .collect::<String>();
-
+            let (_selection_range, expression_text) =
+                if selection_range.start == selection_range.end {
+                    let cursor_offset = selection_range.start;
+                    if let Some((node, new_range)) =
+                        buffer.syntax_ancestor(cursor_offset..cursor_offset)
+                    {
+                        let new_text = buffer.text_for_range(new_range.clone()).collect::<String>();
+                        (new_range, new_text)
+                    } else {
+                        // I don't really understand this failure case, so I'll have to
+                        // figure out how to test it.
+                        (selection_range, "".to_string())
+                    }
+                } else {
+                    // This is the case where something is selected.
+                    let expression_text = buffer
+                        .text_for_range(selection_range.clone())
+                        .collect::<String>();
+                    (selection_range, expression_text)
+                };
             let expression_text = expression_text.trim().to_string();
-
             if expression_text.is_empty() {
                 return;
             }
@@ -2540,6 +2558,185 @@ df.describe()
                     );
                     assert!(
                         !text.contains("import pan"),
+                        "terminal should not contain the first unselected character"
+                    );
+                });
+            });
+        });
+    }
+
+    // This test looks upsettingly like the the above test case. It's a proof
+    // of concept to show it's working, but it's incomplete, as it doesn't
+    // cover the case where tree-sitter can't find anything to send.
+    //
+    // Once I have that tested, I'll have a good handle on everything that
+    // makes these two tests different, and will refactor.
+
+    #[gpui::test]
+    async fn test_send_to_terminal_treesitter(cx: &mut TestAppContext) {
+        cx.executor().allow_parking();
+        let params = cx.update(AppState::test);
+        params
+            .fs
+            .as_fake()
+            .insert_tree(
+                path!("/root"),
+                json!({
+                    "test.py": ""
+                }),
+            )
+            .await;
+
+        cx.update(|cx| {
+            editor::init(cx);
+            crate::init(cx);
+        });
+        let (project, _workspace, window) = init_test_with_fs(cx, params).await;
+        let python_lang = python_language();
+        project.update(cx, |project, _cx| {
+            project.languages().add(python_lang.clone());
+        });
+
+        let terminal_panel = window
+            .update(cx, |workspace, window, cx| {
+                let terminal_panel = cx.new(|cx| TerminalPanel::new(workspace, window, cx));
+                workspace.add_panel(terminal_panel.clone(), window, cx);
+                terminal_panel
+            })
+            .unwrap();
+
+        window
+            .update(cx, |_workspace, window, cx| {
+                window.dispatch_action(workspace::NewTerminal::default().boxed_clone(), cx);
+            })
+            .unwrap();
+
+        cx.run_until_parked();
+
+        let _res = window
+            .update(cx, |workspace, window, cx| {
+                workspace.open_paths(
+                    vec![PathBuf::from(path!("/root/test.py"))],
+                    OpenOptions {
+                        visible: Some(OpenVisible::All),
+                        ..Default::default()
+                    },
+                    None,
+                    window,
+                    cx,
+                )
+            })
+            .unwrap();
+        cx.run_until_parked();
+
+        let code = r#"
+import pandas as pd
+
+df = pd.read_csv("data.csv")
+print(df.head())
+
+df.describe()
+"#;
+        let editor = window
+            .update(cx, |workspace, _, cx| {
+                workspace.active_item_as::<Editor>(cx).unwrap()
+            })
+            .unwrap();
+
+        window
+            .update(cx, |_, window, cx| {
+                editor.update(cx, |editor, cx| {
+                    editor.set_text(code, window, cx);
+                    editor.buffer().update(cx, |multi_buffer, cx| {
+                        multi_buffer
+                            .as_singleton()
+                            .unwrap()
+                            .update(cx, |buffer, cx| {
+                                buffer.set_language(Some(python_lang.clone()), cx);
+                            });
+                    });
+                })
+            })
+            .unwrap();
+
+        cx.run_until_parked();
+
+        let selected_text = window
+            .update(cx, |_, window, cx| {
+                editor.update(cx, |editor, cx| {
+                    editor.change_selections(Default::default(), window, cx, |s| {
+                        s.select_ranges([PointUtf16::new(3, 10)..PointUtf16::new(3, 10)]);
+                    });
+                    let buffer = editor.buffer().read(cx).snapshot(cx);
+                    let selection = editor.selections.newest_anchor();
+                    let selection_range =
+                        selection.start.to_offset(&buffer)..selection.end.to_offset(&buffer);
+                    let expression_text = buffer
+                        .text_for_range(selection_range.clone())
+                        .collect::<String>();
+
+                    expression_text.trim().to_string()
+                })
+            })
+            .unwrap();
+
+        let buffer_text = editor.update(cx, |editor, cx| {
+            editor.buffer().read(cx).snapshot(cx).text()
+        });
+        assert!(buffer_text.contains("import pandas as pd"));
+        assert!(buffer_text.contains("df.describe()"));
+        dbg!(&selected_text);
+        assert!(selected_text.eq(""));
+        // I'm going to send three events. One with newline and two without.
+        // the terminal should then contain "import pa/nimport paimportpa".
+        // and we'll know both work
+        window
+            .update(cx, |_workspace, window, cx| {
+                window.dispatch_action(
+                    SendToTerminal {
+                        append_newline: true,
+                    }
+                    .boxed_clone(),
+                    cx,
+                );
+                window.dispatch_action(
+                    SendToTerminal {
+                        append_newline: false,
+                    }
+                    .boxed_clone(),
+                    cx,
+                );
+                window.dispatch_action(
+                    SendToTerminal {
+                        append_newline: false,
+                    }
+                    .boxed_clone(),
+                    cx,
+                );
+            })
+            .unwrap();
+
+        cx.run_until_parked();
+
+        terminal_panel.update(cx, |panel, cx| {
+            let terminal_view = panel
+                .pane()
+                .unwrap()
+                .read(cx)
+                .active_item()
+                .unwrap()
+                .downcast::<TerminalView>()
+                .unwrap();
+            terminal_view.update(cx, |view, cx| {
+                view.terminal().update(cx, |t, _cx| {
+                    let text = t.get_content();
+                    assert!(
+                        text.contains("read_csv\nread_csvread_csv"),
+                        "text should be sent, got: '{}'",
+                        text
+                    );
+                    assert!(
+                        !text.contains("read_csv("),
                         "terminal should not contain the first unselected character"
                     );
                 });

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -560,6 +560,16 @@ pub struct OpenTerminal {
     pub local: bool,
 }
 
+/// Opens a new terminal with the specified working directory.
+#[derive(Debug, Default, Clone, Deserialize, PartialEq, JsonSchema, Action)]
+#[action(namespace = workspace)]
+#[serde(deny_unknown_fields)]
+pub struct SendToTerminal {
+    /// If true, sends a newline after selection
+    #[serde(default)]
+    pub append_newline: bool,
+}
+
 #[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct WorkspaceId(i64);
 


### PR DESCRIPTION
Subset of #42467. This feature adds a `Workspace::SendToTerminal` action that can be assigned a keybinding that will either append a newline or not, it's entirely up to the user. It is limited in scope to the exact text selected, but can be expanded in the future infer the selected value from cursor position via tree sitter.

It's a draft I'm working on with @cameron1024, and I wanted to put it somewhere he could take a look async.

I've refactored `TerminalView::init_test` so that I can re-use it in this scenario where I need to get the `WindowHandle` back, and customize the `FakeFS` in the `TestAppContext`. The test confirms expected functionality.

