### PR TITLE
languages: Support double quoted keys in YAML highlights

### DIFF
--- a/crates/languages/src/yaml/highlights.scm
+++ b/crates/languages/src/yaml/highlights.scm
@@ -23,7 +23,12 @@
   (tag)
 ] @type
 
-key: (flow_node (plain_scalar (string_scalar) @property))
+key: (flow_node
+  [
+    (plain_scalar (string_scalar))
+    (double_quote_scalar)
+    (single_quote_scalar)
+  ] @property)
 
 [
  ","


### PR DESCRIPTION
Before:
<img width="520" height="74" alt="before" src="https://github.com/user-attachments/assets/5c010819-a20e-438e-b7f6-218b9f241070" />

After:
<img width="532" height="81" alt="after" src="https://github.com/user-attachments/assets/51528d3b-439f-4fcf-9a7c-b06dec6a7e81" />

Release Notes:

- Improved YAML highlights to support quoted keys
