### PR TITLE
languages: Add shebang highlight support for Bash

### DIFF
--- a/crates/languages/src/bash/highlights.scm
+++ b/crates/languages/src/bash/highlights.scm
@@ -37,6 +37,12 @@
 
 (comment) @comment
 
+; Shebang
+((program
+  .
+  (comment) @keyword.directive)
+  (#match? @keyword.directive "^#![ \t]*/"))
+
 (function_definition name: (word) @function)
 (command_name (word) @function)
 


### PR DESCRIPTION
Highlights the shebang line as a directive instead of a comment.

Before:
<img width="316" height="99" alt="before" src="https://github.com/user-attachments/assets/d77a7fbd-4610-4282-b48a-c994d37401b6" />

After:
<img width="316" height="99" alt="after" src="https://github.com/user-attachments/assets/7861ba9e-f64d-45be-aa0a-9e98a82b3746" />

Release Notes:

- Added shebang highlight support for Bash
