### PR TITLE
languages: Improve function parameter highlighting for Bash

### DIFF
--- a/crates/languages/src/bash/highlights.scm
+++ b/crates/languages/src/bash/highlights.scm
@@ -40,6 +40,12 @@
 (function_definition name: (word) @function)
 (command_name (word) @function)
 
+(command
+  argument: [
+    (word) @variable.parameter
+    (_ (word) @variable.parameter)
+  ])
+
 [
   (file_descriptor)
   (number)


### PR DESCRIPTION
Before:
<img width="371" height="93" alt="before" src="https://github.com/user-attachments/assets/f2e9ba9c-4ef7-4533-b565-9d977d60ae79" />

After: 
<img width="371" height="93" alt="after" src="https://github.com/user-attachments/assets/b385f0bc-3b23-4a3c-8bf3-639afad10e1e" />

Release Notes:

- Improves function parameter highlighting for Bash
