### PR TITLE
Fix history not being saved for external ACP agents

### DIFF
--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -599,6 +599,15 @@ impl AgentConnection for AcpConnection {
                 .is_some()
     }
 
+    /// Override the default implementation to check for session list capability.
+    /// Session history is available if the agent supports listing sessions,
+    /// regardless of whether it supports loading or resuming sessions.
+    fn supports_session_history(&self, cx: &App) -> bool {
+        // Session listing is available if the agent has list capability
+        // (indicated by session_list being Some) - this is independent of the beta flag
+        self.session_list.is_some()
+    }
+
     fn load_session(
         self: Rc<Self>,
         session: AgentSessionInfo,
@@ -889,11 +898,9 @@ impl AgentConnection for AcpConnection {
     }
 
     fn session_list(&self, cx: &mut App) -> Option<Rc<dyn AgentSessionList>> {
-        if cx.has_flag::<AcpBetaFeatureFlag>() {
-            self.session_list.clone().map(|s| s as _)
-        } else {
-            None
-        }
+        // Session listing is a core feature that doesn't require the beta flag.
+        // If the agent has list capability, return it regardless of beta flag status.
+        self.session_list.clone().map(|s| s as _)
     }
 
     fn into_any(self: Rc<Self>) -> Rc<dyn Any> {


### PR DESCRIPTION
## Problem

External ACP agents (like Gemini via ACP) were not having their threads saved to the history list. When users created threads with these agents, they would disappear after creating a new thread - they never appeared in the history sidebar.

## Root Cause

Fix #37074

The `session_list()` method was gated behind the `AcpBetaFeatureFlag`, meaning even if an external agent advertised session listing capability, it wouldn't be exposed to the UI when the beta flag wasn't enabled.

Additionally, `supports_session_history()` used the default implementation which checked `supports_load_session() || supports_resume_session()` - both of which were also gated behind the beta flag. This meant the history UI wouldn't even attempt to fetch sessions from external agents.

## Solution

1. **Removed beta flag check from `session_list()`** - Session listing is now available for external agents regardless of the beta flag status. If the agent has list capability, it will be returned.

2. **Added `supports_session_history()` override** - Added an explicit override in `AcpConnection` that checks for session list capability directly (`self.session_list.is_some()`) rather than relying on load/resume session support.

## Changes

- `crates/agent_servers/src/acp.rs`:
  - Removed `AcpBetaFeatureFlag` check from `session_list()` method
  - Added `supports_session_history()` override that checks for session list capability

## Testing

- External ACP agents (Gemini, Claude Code, etc.) should now have their sessions appear in the history sidebar
- Existing internal agent (NativeAgent) behavior should be unchanged

Release Notes:

- Fixed external ACP agents (like Gemini via ACP) not showing threads in history