### PR TITLE
auto_update: Detect read-only volume before updating on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1356,6 +1356,7 @@ dependencies = [
  "futures-lite 1.13.0",
  "gpui",
  "http_client",
+ "libc",
  "log",
  "parking_lot",
  "paths",

--- a/crates/auto_update/Cargo.toml
+++ b/crates/auto_update/Cargo.toml
@@ -34,6 +34,9 @@ workspace.workspace = true
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 which.workspace = true
 
+[target.'cfg(target_os = "macos")'.dependencies]
+libc.workspace = true
+
 [dev-dependencies]
 ctor.workspace = true
 clock= { workspace = true, "features" = ["test-support"] }


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/47679

Release Notes:

- Improved detect read-only volume before updating on macOS


When users run Zed directly from a mounted DMG without installing it to /Applications, the auto-updater would fail with cryptic rsync errors about a read-only file system.

This change adds is_read_only_volume() to check if the app is running from a read-only filesystem and returns a clear, actionable error message to users.
