### PR TITLE
git_ui: Fix visual optimistic staging bug for tree view

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1737,19 +1737,25 @@ impl GitPanel {
             return StageStatus::Unstaged;
         };
 
+        let show_placeholders = self.show_placeholders && !self.has_staged_changes();
         let mut fully_staged_count = 0usize;
         let mut any_staged_or_partially_staged = false;
 
         for descendant in descendants {
-            match GitPanel::stage_status_for_entry(descendant, repo) {
-                StageStatus::Staged => {
-                    fully_staged_count += 1;
-                    any_staged_or_partially_staged = true;
+            if show_placeholders && !descendant.status.is_created() {
+                fully_staged_count += 1;
+                any_staged_or_partially_staged = true;
+            } else {
+                match GitPanel::stage_status_for_entry(descendant, repo) {
+                    StageStatus::Staged => {
+                        fully_staged_count += 1;
+                        any_staged_or_partially_staged = true;
+                    }
+                    StageStatus::PartiallyStaged => {
+                        any_staged_or_partially_staged = true;
+                    }
+                    StageStatus::Unstaged => {}
                 }
-                StageStatus::PartiallyStaged => {
-                    any_staged_or_partially_staged = true;
-                }
-                StageStatus::Unstaged => {}
             }
         }
 


### PR DESCRIPTION
Before this PR we would not show the placeholder for the parent folders of a file entry inside the git tree view. This PR fixes that so it's visually correct.

**Before**

https://github.com/user-attachments/assets/3d0988de-f43b-4b2d-8f90-c531316ab290

**After**

https://github.com/user-attachments/assets/e28f9eba-e301-4f9a-8647-7f1f2f12f87d

Release Notes:

- Git UI: Fix optimistic placeholder for folders in the three view
