### PR TITLE
docs: Add section on disabling `autoUseWorkspaceTsdk` per-project

### DIFF
--- a/docs/src/languages/typescript.md
+++ b/docs/src/languages/typescript.md
@@ -184,6 +184,23 @@ When using `vtsls`:
 }
 ```
 
+## Workspace TypeScript version
+
+```json [settings]
+{
+  "lsp": {
+    "vtsls": {
+      "initialization_options": {
+        "vtsls": {
+          "autoUseWorkspaceTsdk": true,
+        },
+      },
+    },
+  },
+}
+
+```
+
 ## Debugging
 
 Zed supports debugging TypeScript code out of the box with `vscode-js-debug`.

--- a/docs/src/languages/typescript.md
+++ b/docs/src/languages/typescript.md
@@ -186,7 +186,7 @@ When using `vtsls`:
 
 ## Workspace TypeScript version
 
-`vtsls` will use your workspace typescript version by default.
+`vtsls` will use your workspace TypeScript version by default.
 
 ## Debugging
 

--- a/docs/src/languages/typescript.md
+++ b/docs/src/languages/typescript.md
@@ -186,7 +186,24 @@ When using `vtsls`:
 
 ## Workspace TypeScript version
 
-`vtsls` will use your workspace TypeScript version by default.
+This is enabled by default.
+
+Some projects require using the TypeScript version in `node_modules` to ensure compiler behavior, diagnostics, and editor tooling exactly match the build and CI environment, including framework and plugin compatibility. This avoids version-related inconsistencies and false errors across contributors and tooling.
+If you wish to disable this feature, it can be done as follows:
+
+```json [settings]
+{
+  "lsp": {
+    "vtsls": {
+      "settings": {
+        "vtsls": {
+          "autoUseWorkspaceTsdk": false
+        }
+      }
+    }
+  }
+}
+```
 
 ## Debugging
 

--- a/docs/src/languages/typescript.md
+++ b/docs/src/languages/typescript.md
@@ -186,20 +186,7 @@ When using `vtsls`:
 
 ## Workspace TypeScript version
 
-```json [settings]
-{
-  "lsp": {
-    "vtsls": {
-      "initialization_options": {
-        "vtsls": {
-          "autoUseWorkspaceTsdk": true,
-        },
-      },
-    },
-  },
-}
-
-```
+`vtsls` will use your workspace typescript version by default.
 
 ## Debugging
 


### PR DESCRIPTION
Add section on configuring workspace TypeScript version in vtsls.

This is important for libraries like [effect](https://effect.website/) where they ship their own LSP patches.

Release Notes:

- N/A