### PR TITLE
gpui: Rewrite Windows `PlatformTextSystem` for better performance

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -38,6 +38,15 @@
       },
     },
   },
+  "lsp": {
+    "rust-analyzer": {
+      "initialization_options": {
+        "procMacro": {
+          "processes": 4,
+        },
+      },
+    },
+  },
   "file_types": {
     "Dockerfile": ["Dockerfile*[!dockerignore]"],
     "JSONC": ["**/assets/**/*.json", "renovate.json"],

--- a/crates/gpui/src/text_system.rs
+++ b/crates/gpui/src/text_system.rs
@@ -943,3 +943,19 @@ pub(crate) fn font_name_with_fallbacks<'a>(name: &'a str, system: &'a str) -> &'
         _ => name,
     }
 }
+
+#[allow(unused)]
+pub(crate) fn font_name_with_fallbacks_shared<'a>(
+    name: &'a SharedString,
+    system: &'a SharedString,
+) -> &'a SharedString {
+    // Note: the "Zed Plex" fonts were deprecated as we are not allowed to use "Plex"
+    // in a derived font name. They are essentially indistinguishable from IBM Plex/Lilex,
+    // and so retained here for backward compatibility.
+    match name.as_str() {
+        ".SystemUIFont" => system,
+        ".ZedSans" | "Zed Plex Sans" => const { &SharedString::new_static("IBM Plex Sans") },
+        ".ZedMono" | "Zed Plex Mono" => const { &SharedString::new_static("Lilex") },
+        _ => name,
+    }
+}


### PR DESCRIPTION
The current setup is quite a mess, allocates a ton of unnecessary heap data when rendering text or querying font info and not really caching things well, this PR changes that.

Release Notes:

- N/A *or* Added/Fixed/Improved ...
