### PR TITLE
docs: Add Tailwind CSS LSP configuration for HTML

### DIFF
--- a/docs/src/languages/html.md
+++ b/docs/src/languages/html.md
@@ -64,6 +64,32 @@ You can customize various [formatting options](https://code.visualstudio.com/doc
   }
 ```
 
+## Using the Tailwind CSS Language Server with HTML
+
+To get all the features (autocomplete, linting, etc.) from the [Tailwind CSS language server](https://github.com/tailwindlabs/tailwindcss-intellisense/tree/HEAD/packages/tailwindcss-language-server#readme) in HTML files, you need to configure the language server so that it knows about where to look for CSS classes by adding the following to your `settings.json`:
+
+```json [settings]
+{
+  "lsp": {
+    "tailwindcss-language-server": {
+      "settings": {
+        "experimental": {
+          "classRegex": ["class=\"([^\"]*)\""]
+        }
+      }
+    }
+  }
+}
+```
+
+With these settings, you will get completions for Tailwind CSS classes in HTML `class` attributes. Examples:
+
+```html
+<div class="flex items-center <completion here>">
+  <p class="text-lg font-bold <completion here>">Hello World</p>
+</div>
+```
+
 ## See also
 
 - [CSS](./css.md)

--- a/docs/src/languages/tailwindcss.md
+++ b/docs/src/languages/tailwindcss.md
@@ -11,7 +11,7 @@ Languages which can be used with Tailwind CSS in Zed:
 - [ERB](./ruby.md)
 - [Gleam](./gleam.md)
 - [HEEx](./elixir.md#heex)
-- [HTML](./html.md)
+- [HTML](./html.md#using-the-tailwind-css-language-server-with-html)
 - [TypeScript](./typescript.md)
 - [JavaScript](./javascript.md)
 - [PHP](./php.md)


### PR DESCRIPTION
Documents how to configure the Tailwind CSS language server
for HTML files using classRegex.

Refs: #43969

Release Notes:

- N/A