### PR TITLE
docs: Add Tailwind configuration section for Svelte

### DIFF
--- a/docs/src/languages/html.md
+++ b/docs/src/languages/html.md
@@ -64,6 +64,32 @@ You can customize various [formatting options](https://code.visualstudio.com/doc
   }
 ```
 
+## Using the Tailwind CSS Language Server with HTML
+
+To get all the features (autocomplete, linting, etc.) from the [Tailwind CSS language server](https://github.com/tailwindlabs/tailwindcss-intellisense/tree/HEAD/packages/tailwindcss-language-server#readme) in HTML files, you need to configure the language server so that it knows about where to look for CSS classes by adding the following to your `settings.json`:
+
+```json [settings]
+{
+  "lsp": {
+    "tailwindcss-language-server": {
+      "settings": {
+        "experimental": {
+          "classRegex": ["class=\"([^\"]*)\""]
+        }
+      }
+    }
+  }
+}
+```
+
+With these settings, you will get completions for Tailwind CSS classes in HTML `class` attributes. Examples:
+
+```html
+<div class="flex items-center <completion here>">
+  <p class="text-lg font-bold <completion here>">Hello World</p>
+</div>
+```
+
 ## See also
 
 - [CSS](./css.md)

--- a/docs/src/languages/php.md
+++ b/docs/src/languages/php.md
@@ -149,8 +149,80 @@ The PHP extension provides a debug adapter for PHP via Xdebug. There are several
 
 These are common troubleshooting tips, in case you run into issues:
 
-- Ensure that you have Xdebug installed for the version of PHP you’re running.
+- Ensure that you have Xdebug installed for the version of PHP you're running.
 - Ensure that Xdebug is configured to run in `debug` mode.
 - Ensure that Xdebug is actually starting a debugging session.
 - Ensure that the host and port matches between Xdebug and Zed.
-- Look at the diagnostics log by using the `xdebug_info()` function in the page you’re trying to debug.
+- Look at the diagnostics log by using the `xdebug_info()` function in the page you're trying to debug.
+
+## Using the Tailwind CSS Language Server with PHP
+
+To get all the features (autocomplete, linting, etc.) from the [Tailwind CSS language server](https://github.com/tailwindlabs/tailwindcss-intellisense/tree/HEAD/packages/tailwindcss-language-server#readme) in PHP files, you need to configure the language server so that it knows about where to look for CSS classes by adding the following to your `settings.json`:
+
+```json [settings]
+{
+  "lsp": {
+    "tailwindcss-language-server": {
+      "settings": {
+        "includeLanguages": {
+          "php": "html"
+        },
+        "experimental": {
+          "classRegex": [
+            "class=\"([^\"]*)\"",
+            "class='([^']*)'",
+            "class=\\\"([^\\\"]*)\\\""
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+With these settings, you will get completions for Tailwind CSS classes in HTML attributes inside PHP files. Examples:
+
+```php
+<?php
+// PHP file with HTML:
+?>
+<div class="flex items-center <completion here>">
+  <p class="text-lg font-bold <completion here>">Hello World</p>
+</div>
+```
+
+### Laravel/Blade
+
+For Laravel/Blade files, you may need additional configuration to handle Blade directives:
+
+```json [settings]
+{
+  "lsp": {
+    "tailwindcss-language-server": {
+      "settings": {
+        "includeLanguages": {
+          "php": "html",
+          "blade": "html"
+        },
+        "experimental": {
+          "classRegex": [
+            "class=\"([^\"]*)\"",
+            "class='([^']*)'",
+            "class=\\\"([^\\\"]*)\\\"",
+            "@class\\(\\[([^\\]]*)\\]\\)"
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+This will also provide completions in Blade directives like:
+
+```blade
+{{-- Blade file --}}
+<div class="flex {{ $customClass }} <completion here>">
+  @class(['flex', 'items-center', '<completion here>'])
+</div>
+```

--- a/docs/src/languages/svelte.md
+++ b/docs/src/languages/svelte.md
@@ -71,3 +71,47 @@ To override these settings, use the following:
 ```
 
 See [the TypeScript language server `package.json`](https://github.com/microsoft/vscode/blob/main/extensions/typescript-language-features/package.json) for more information.
+
+## Using the Tailwind CSS Language Server with Svelte
+
+To get all the features (autocomplete, linting, etc.) from the [Tailwind CSS language server](https://github.com/tailwindlabs/tailwindcss-intellisense/tree/HEAD/packages/tailwindcss-language-server#readme) in Svelte files, you need to configure the language server so that it knows about where to look for CSS classes by adding the following to your `settings.json`:
+
+```json [settings]
+{
+  "lsp": {
+    "tailwindcss-language-server": {
+      "settings": {
+        "includeLanguages": {
+          "svelte": "html"
+        },
+        "experimental": {
+          "classRegex": [
+            "class=\"([^\"]*)\"",
+            "class='([^']*)'",
+            "class:\\s*([^\\s{]+)",
+            "\\{\\s*class:\\s*\"([^\"]*)\"",
+            "\\{\\s*class:\\s*'([^']*)'"
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+With these settings, you will get completions for Tailwind CSS classes in Svelte files. Examples:
+
+```svelte
+<!-- Standard class attribute -->
+<div class="flex items-center <completion here>">
+  <p class="text-lg font-bold <completion here>">Hello World</p>
+</div>
+
+<!-- Class directive -->
+<button class:active="bg-blue-500 <completion here>">Click me</button>
+
+<!-- Expression -->
+<div class={active ? "flex <completion here>" : "hidden <completion here>"}>
+  Content
+</div>
+```

--- a/docs/src/languages/tailwindcss.md
+++ b/docs/src/languages/tailwindcss.md
@@ -14,7 +14,7 @@ Languages which can be used with Tailwind CSS in Zed:
 - [HTML](./html.md#using-the-tailwind-css-language-server-with-html)
 - [TypeScript](./typescript.md)
 - [JavaScript](./javascript.md)
-- [PHP](./php.md)
+- [PHP](./php.md#using-the-tailwind-css-language-server-with-php)
 - [Svelte](./svelte.md)
 - [Vue](./vue.md)
 

--- a/docs/src/languages/tailwindcss.md
+++ b/docs/src/languages/tailwindcss.md
@@ -15,7 +15,7 @@ Languages which can be used with Tailwind CSS in Zed:
 - [TypeScript](./typescript.md)
 - [JavaScript](./javascript.md)
 - [PHP](./php.md#using-the-tailwind-css-language-server-with-php)
-- [Svelte](./svelte.md)
+- [Svelte](./svelte.md#using-the-tailwind-css-language-server-with-svelte)
 - [Vue](./vue.md)
 
 ## Configuration

--- a/docs/src/languages/tailwindcss.md
+++ b/docs/src/languages/tailwindcss.md
@@ -11,7 +11,7 @@ Languages which can be used with Tailwind CSS in Zed:
 - [ERB](./ruby.md)
 - [Gleam](./gleam.md)
 - [HEEx](./elixir.md#heex)
-- [HTML](./html.md)
+- [HTML](./html.md#using-the-tailwind-css-language-server-with-html)
 - [TypeScript](./typescript.md)
 - [JavaScript](./javascript.md)
 - [PHP](./php.md)


### PR DESCRIPTION
Documents how to configure the Tailwind CSS language server
for Svelte files, including class directives and expressions, using classRegex and includeLanguages.

Refs: #43969

Release Notes:

- N/A