### PR TITLE
workspace: Add copy button to ErrorMessagePrompt popup

### DIFF
--- a/crates/workspace/src/notifications.rs
+++ b/crates/workspace/src/notifications.rs
@@ -526,8 +526,9 @@ impl Render for ErrorMessagePrompt {
                                             .tooltip_label("Copy Error Message"),
                                     )
                                     .child(
-                                        ui::IconButton::new("close", ui::IconName::Close)
-                                            .on_click(cx.listener(|_, _, _, cx| cx.emit(DismissEvent))),
+                                        ui::IconButton::new("close", ui::IconName::Close).on_click(
+                                            cx.listener(|_, _, _, cx| cx.emit(DismissEvent)),
+                                        ),
                                     ),
                             ),
                     )

--- a/crates/workspace/src/notifications.rs
+++ b/crates/workspace/src/notifications.rs
@@ -519,8 +519,16 @@ impl Render for ErrorMessagePrompt {
                                     }),
                             )
                             .child(
-                                ui::IconButton::new("close", ui::IconName::Close)
-                                    .on_click(cx.listener(|_, _, _, cx| cx.emit(DismissEvent))),
+                                h_flex()
+                                    .gap_1()
+                                    .child(
+                                        CopyButton::new("copy-error-message", self.message.clone())
+                                            .tooltip_label("Copy Error Message"),
+                                    )
+                                    .child(
+                                        ui::IconButton::new("close", ui::IconName::Close)
+                                            .on_click(cx.listener(|_, _, _, cx| cx.emit(DismissEvent))),
+                                    ),
                             ),
                     )
                     .child(


### PR DESCRIPTION
My own uncreated issue. Super simple QOL change.
Just needed to copy errors and the only other place I'm aware of is console. 

The text inside the error popup is not selectable (at least on macos)


before:
<img width="461" height="213" alt="image" src="https://github.com/user-attachments/assets/f0cc4239-759c-4e1e-aae0-d2908a81cdc6" />

after:
<img width="482" height="233" alt="image" src="https://github.com/user-attachments/assets/61d458cc-3c25-4c1c-8bd7-3d6b83a51d28" />

Release Notes:

- Added `CopyButton` to `ErrorMessagePrompt`
