### PR TITLE
languages: Change syntax highlighting for C/C++ preprocessor directives

### DIFF
--- a/crates/languages/src/c/highlights.scm
+++ b/crates/languages/src/c/highlights.scm
@@ -38,7 +38,7 @@
   "#ifndef"
   "#include"
   (preproc_directive)
-] @keyword.directive
+] @preproc
 
 [
   "="

--- a/crates/languages/src/cpp/highlights.scm
+++ b/crates/languages/src/cpp/highlights.scm
@@ -177,7 +177,7 @@ type: (primitive_type) @type.builtin
   "#ifndef"
   "#include"
   (preproc_directive)
-] @keyword.directive
+] @preproc
 
 (comment) @comment
 


### PR DESCRIPTION
This changes the highlight capture for preprocessor directives from `@keyword.directive` to `@preproc` in both C and C++.

PR #44043 changed C from `@keyword` to `@keyword.directive` for consistency with C++, but `@keyword.directive` is still semantically wrong. Preprocessor directives are not language keywords — they are instructions to a separate preprocessing phase that runs before compilation.

Using `@preproc` reflects this distinction and allows themes to style them independently from actual language keywords like `const`, `struct`,`if`, etc. This is consistent with how editors like CLion handle preprocessor directives.

Before:
<img width="710" height="653" alt="before" src="https://github.com/user-attachments/assets/5c02fc06-bc19-4112-ae53-ad72eb8044e3" />

After:
<img width="710" height="653" alt="after" src="https://github.com/user-attachments/assets/2490e796-7286-4fbb-81b0-387f551cde8f" />

Release Notes:

- C/C++: Syntax highlighting for preprocessor directives can now be tweaked with @preproc capture group.