### PR TITLE
agent_servers: Execute agent servers directly without terminal shell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,6 +305,7 @@ dependencies = [
  "util",
  "uuid",
  "watch",
+ "workspace",
 ]
 
 [[package]]

--- a/crates/agent_servers/Cargo.toml
+++ b/crates/agent_servers/Cargo.toml
@@ -6,7 +6,7 @@ publish.workspace = true
 license = "GPL-3.0-or-later"
 
 [features]
-test-support = ["acp_thread/test-support", "gpui/test-support", "project/test-support", "dep:env_logger", "client/test-support", "dep:gpui_tokio", "reqwest_client/test-support"]
+test-support = ["acp_thread/test-support", "gpui/test-support", "project/test-support", "dep:env_logger", "client/test-support", "dep:gpui_tokio", "reqwest_client/test-support", "workspace/test-support"]
 e2e = []
 
 [lints]
@@ -53,6 +53,7 @@ terminal.workspace = true
 uuid.workspace = true
 util.workspace = true
 watch.workspace = true
+workspace.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true
@@ -66,5 +67,6 @@ language.workspace = true
 indoc.workspace = true
 acp_thread = { workspace = true, features = ["test-support"] }
 gpui = { workspace = true, features = ["test-support"] }
+workspace = { workspace = true, features = ["test-support"] }
 gpui_tokio.workspace = true
 reqwest_client = { workspace = true, features = ["test-support"] }


### PR DESCRIPTION
## Summary

Agent servers communicate via JSON-RPC over stdin/stdout. Using the user's custom terminal shell settings (e.g., `flatpak-spawn` for sandbox escaping) can interfere with the stdin/stdout pipes, causing the JSON-RPC messages to be misinterpreted as shell commands.

This change executes agent server binaries directly without any shell wrapper.

## The Problem

When users configure a custom terminal shell like:
```json
"shell": {
  "program": "flatpak-spawn",
  "args": ["--host", "/bin/bash"]
}
```

The agent command gets wrapped as:
```
flatpak-spawn --host /bin/bash -c "claude --acp"
```

This causes JSON-RPC messages to be interpreted as shell commands, resulting in:
```
/bin/bash: line 1: jsonrpc:2.0: command not found
```

## The Fix

Execute agent server binaries directly using `util::command::new_std_command()` instead of wrapping them in the user's terminal shell via `ShellBuilder`.

Agent servers don't need shell wrappers - they're executables that communicate via JSON-RPC pipes.

## Additional Changes

Also fixes test-support feature propagation for the `workspace` dependency to ensure tests compile properly.

Release Notes:

- Fixed agent servers (Claude Code, OpenCode, etc.) failing to launch when using custom terminal shells like `flatpak-spawn` for sandbox escaping

Fixes #47991