### PR TITLE
fix(editor): invalidate bracket colorization after fold restore

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -24952,6 +24952,11 @@ impl Editor {
                 if !valid_folds.is_empty() {
                     self.fold_ranges(valid_folds, false, window, cx);
 
+                    // Invalidate bracket colorization cache after restoring folds.
+                    // The cache stores which buffer row ranges have been processed,
+                    // and folding changes what's visible. See: #47846
+                    self.colorize_brackets(true, cx);
+
                     // Migrate folds to current entity_id before workspace cleanup runs.
                     // Entity IDs change between sessions, but workspace cleanup deletes
                     // old editor rows (cascading to folds) based on current entity IDs.


### PR DESCRIPTION
## Summary

When folds are restored on editor startup, the bracket colorization cache (`fetched_tree_sitter_chunks`) wasn't being invalidated. This caused brackets in and after the last restored fold to lose their colorization until the file was reparsed.

## The Problem

1. User folds some functions and closes Zed
2. User reopens Zed - folds are restored from the database
3. The last folded function and functions below it have white (uncolorized) brackets
4. Unfolding the function doesn't fix it
5. Closing and reopening Zed again fixes it (because folds aren't being restored the second time)

## Root Cause

The `fetched_tree_sitter_chunks` cache stores which buffer row ranges have already been processed for bracket colorization. When folds are restored:
- The visible regions change (folded regions become invisible)
- But the cache isn't invalidated
- So brackets in the newly visible regions (after the last fold) aren't processed

## The Fix

Call `colorize_brackets(true, cx)` after restoring folds to invalidate the stale cache and recalculate bracket colors for the newly visible regions.

## Testing

- All 534 editor tests pass
- All 9 bracket colorization tests pass

Release Notes:

- Fixed colorized brackets not appearing after folded functions are restored on editor restart

Fixes #47846