### PR TITLE
vim: Respect search settings in buffer search

### DIFF
--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -75,8 +75,8 @@ pub(crate) struct SearchUnderCursorPrevious {
 pub(crate) struct Search {
     #[serde(default)]
     backwards: bool,
-    #[serde(default = "default_true")]
-    regex: bool,
+    #[serde(default)]
+    regex: Option<bool>,
 }
 
 /// Executes a find command to search for patterns in the buffer.
@@ -244,15 +244,13 @@ impl Vim {
             cx.focus_self(window);
 
             search_bar.set_replacement(None, cx);
-            let mut options = SearchOptions::NONE;
-            if action.regex {
-                options |= SearchOptions::REGEX;
+            let mut options =
+                SearchOptions::from_settings(&EditorSettings::get_global(cx).search);
+            if let Some(regex) = action.regex {
+                options.set(SearchOptions::REGEX, regex);
             }
             if action.backwards {
                 options |= SearchOptions::BACKWARDS;
-            }
-            if EditorSettings::get_global(cx).search.case_sensitive {
-                options |= SearchOptions::CASE_SENSITIVE;
             }
             search_bar.set_search_options(options, cx);
             true

--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -1437,7 +1437,7 @@ mod test {
                 .expect("Buffer search bar should be deployed")
         });
 
-        cx.update_entity(search_bar.clone(), |bar, _window, _cx| {
+        cx.update_entity(search_bar, |bar, _window, _cx| {
             // Should have WHOLE_WORD and CASE_SENSITIVE from settings
             assert!(
                 bar.has_search_option(search::SearchOptions::WHOLE_WORD),

--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -244,8 +244,7 @@ impl Vim {
             cx.focus_self(window);
 
             search_bar.set_replacement(None, cx);
-            let mut options =
-                SearchOptions::from_settings(&EditorSettings::get_global(cx).search);
+            let mut options = SearchOptions::from_settings(&EditorSettings::get_global(cx).search);
             if let Some(regex) = action.regex {
                 options.set(SearchOptions::REGEX, regex);
             }


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/48007

Release Notes:

- Fixed Vim search not respecting `"search"` default settings