### PR TITLE
git: Disable vertical scrollbar for side-by-side diff LHS

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -21103,6 +21103,11 @@ impl Editor {
         cx.notify();
     }
 
+    pub fn set_number_deleted_lines(&mut self, number: bool, cx: &mut Context<Self>) {
+        self.number_deleted_lines = number;
+        cx.notify();
+    }
+
     pub fn set_delegate_expand_excerpts(&mut self, delegate: bool) {
         self.delegate_expand_excerpts = delegate;
     }

--- a/crates/editor/src/split.rs
+++ b/crates/editor/src/split.rs
@@ -2774,10 +2774,10 @@ mod tests {
             aaaa bbbb\x20
             cccc dddd\x20
             eeee ffff
-            deleted\x20
-            line one
-            deleted\x20
-            line two
+            deleted line\x20
+            one
+            deleted line\x20
+            two
             after"
                 .unindent(),
             &mut cx,

--- a/crates/editor/src/split.rs
+++ b/crates/editor/src/split.rs
@@ -384,8 +384,10 @@ impl SplittableEditor {
         let lhs_editor = cx.new(|cx| {
             let mut editor =
                 Editor::for_multibuffer(lhs_multibuffer.clone(), Some(project.clone()), window, cx);
-            editor.number_deleted_lines = true;
+            editor.set_number_deleted_lines(true, cx);
             editor.set_delegate_expand_excerpts(true);
+            editor.set_show_vertical_scrollbar(false, cx);
+            editor.set_minimap_visibility(crate::MinimapVisibility::Disabled, window, cx);
             editor
         });
 


### PR DESCRIPTION
Also the minimap, although this is currently symbolic since the minimap doesn't support multibuffers.

Release Notes:

- N/A