### PR TITLE
remote: Fix launching from WSL with fish as default shell

### DIFF
--- a/crates/remote/src/transport/wsl.rs
+++ b/crates/remote/src/transport/wsl.rs
@@ -362,7 +362,7 @@ impl RemoteConnection for WslRemoteConnection {
         }
 
         let proxy_process =
-            match wsl_command_impl(&self.connection_options, "env", &proxy_args, false)
+            match wsl_command_impl(&self.connection_options, "env", &proxy_args, true)
                 .kill_on_drop(true)
                 .spawn()
             {


### PR DESCRIPTION
Closes #46801

When connecting to WSL2 with fish as the default shell, Zed gets stuck at "Starting proxy". The connection works fine when bash is the default shell.

In `start_proxy()`, the WSL command was being invoked with:

```rust
let proxy_process = match wsl_command_impl(&self.connection_options, "env", &proxy_args, false)
```

Changing the last argument to true invokes the WSL command with `--exec`  flag which executes the command in the WSL environment without spawning a new shell.

With above fix I can launch Zed from WSL (Arch) with fish.