### PR TITLE
Update system prompt to make response to references always linkable

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -614,8 +614,10 @@ impl ContentBlock {
         cx: &mut App,
     ) -> ContentBlock {
         ContentBlock::Markdown {
-            markdown: cx
-                .new(|cx| Markdown::new(content.into(), Some(language_registry.clone()), None, cx)),
+            markdown: cx.new(|cx| {
+                Markdown::new(content.into(), Some(language_registry.clone()), None, cx)
+                    .skip_partial_links(true)
+            }),
         }
     }
 

--- a/crates/agent/src/templates/system_prompt.hbs
+++ b/crates/agent/src/templates/system_prompt.hbs
@@ -4,9 +4,31 @@ You are a highly skilled software engineer with extensive knowledge in many prog
 
 - Be conversational but professional.
 - Refer to the user in the second person and yourself in the first person.
-- Format your responses in markdown. Use backticks to format file, directory, function, and class names.
+- Format your responses in markdown.
+- It's mandatory to use the required Markdown link format for files, directories, symbols, and selections.
 - NEVER lie or make things up.
 - Refrain from apologizing all the time when results are unexpected. Instead, just try your best to proceed or explain the circumstances to the user without apologizing.
+
+## Project references formatting
+- For normal prose its mandatory to format file, directory, symbol, and selection references as markdown links: `[Label](uri)`.
+- File: [mention.rs](file:///abs/path/to/mention.rs)
+- Directory: [src](file:///abs/path/to/src/) (directory URIs must end with `/`)
+- Symbol (function/class/struct/method/symbol/etc): [MentionUri](file:///abs/path/to/mention.rs?symbol=MentionUri#L18:18)
+- Selection: [selection](file:///abs/path/to/mention.rs#L5:12)
+- Line fragments are 1-based and may use `#L10:20`, `#L10-20`, `#L10-L20`, or `#L10`.
+- Never include spaces inside markdown link URLs.
+- When constructing query params, use exact keys with no whitespace (e.g., `?symbol=parse`).
+- Never format references with backticks or plain text. Always use link reference markup format
+- If constructing URLs manually, verify the final URL string once and do not retype it.
+
+The `#L123:456` means the line number range 123 through 456, and the path/to/Something.blah is a path in the project.
+(If there is no valid path in the project, then you can use /dev/null/path.extension for its path.)
+This is the ONLY valid way to format references to file, directory, function, and class names,
+because the Markdown parser does not expect the more common `reference_to_something` but very specific reference links.
+It only understands this path-based link syntax, and if the path is missing or in incorrect format, then it will error and you will have to do it over again.
+Just to be really clear about this, if you ever find yourself writing three references to file, directory, function and class name using backtics, STOP!
+You have made a mistake. You can only ever put paths after triple backticks!
+
 
 {{#if (gt (len available_tools) 0)}}
 ## Tool Use

--- a/crates/markdown/src/skip_partial_links.rs
+++ b/crates/markdown/src/skip_partial_links.rs
@@ -1,0 +1,144 @@
+use super::SharedString;
+
+const MAX_HIDE_LEN: usize = 1024;
+
+pub(super) fn skip_partial_links(source: SharedString) -> SharedString {
+    let source_str = source.as_ref();
+    let mut tail_start = source_str.len().saturating_sub(MAX_HIDE_LEN);
+    while tail_start < source_str.len() && !source_str.is_char_boundary(tail_start) {
+        tail_start += 1;
+    }
+    let Some(start) = incomplete_link_start_in_tail(source_str, tail_start) else {
+        return source;
+    };
+
+    source_str[..start].to_string().into()
+}
+
+fn incomplete_link_start(text: &str) -> Option<usize> {
+    start_for_open_destination(text).or_else(|| start_for_open_label(text))
+}
+
+fn label_start_with_image(text: &str, label_start: usize) -> usize {
+    if label_start > 0 && text.as_bytes()[label_start - 1] == b'!' {
+        label_start - 1
+    } else {
+        label_start
+    }
+}
+
+fn start_for_open_destination(text: &str) -> Option<usize> {
+    let mut search_end = text.len();
+    while let Some(link_start) = text[..search_end].rfind("](") {
+        if text[link_start + 2..].contains(')') {
+            search_end = link_start;
+            continue;
+        }
+
+        let label_start = text[..link_start].rfind('[').unwrap_or(link_start);
+        return Some(label_start_with_image(text, label_start));
+    }
+
+    None
+}
+
+fn start_for_open_label(text: &str) -> Option<usize> {
+    let label_start = text.rfind('[')?;
+    let after_label = &text[label_start + 1..];
+
+    if let Some(close_offset) = after_label.find(']') {
+        let close_index = label_start + 1 + close_offset;
+        if text[close_index + 1..].trim().is_empty() {
+            return Some(label_start_with_image(text, label_start));
+        }
+        return None;
+    }
+
+    Some(label_start_with_image(text, label_start))
+}
+
+fn incomplete_link_start_in_tail(text: &str, tail_start: usize) -> Option<usize> {
+    let tail_text = &text[tail_start..];
+    let start_in_tail = incomplete_link_start(tail_text)?;
+    let tail_has_label_start = tail_text[..start_in_tail].contains('[');
+    if tail_text.as_bytes().get(start_in_tail) == Some(&b']') && !tail_has_label_start {
+        // Avoid hiding when the label start is outside the tail.
+        return None;
+    }
+
+    let mut start = tail_start + start_in_tail;
+    if start > 0 && text.as_bytes()[start - 1] == b'!' {
+        start -= 1;
+    }
+    let hidden_len = text.len().saturating_sub(start);
+    if hidden_len > MAX_HIDE_LEN {
+        return None;
+    }
+
+    Some(start)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MAX_HIDE_LEN, SharedString, skip_partial_links};
+
+    fn run(input: &str) -> String {
+        skip_partial_links(SharedString::new(input.to_string()))
+            .as_ref()
+            .to_string()
+    }
+
+    #[test]
+    fn leaves_plain_text_intact() {
+        assert_eq!(run("hello world"), "hello world");
+    }
+
+    #[test]
+    fn leaves_complete_link_intact() {
+        assert_eq!(run("see [link](dest)"), "see [link](dest)");
+    }
+
+    #[test]
+    fn trims_incomplete_destination() {
+        assert_eq!(run("see [link](dest"), "see ");
+    }
+
+    #[test]
+    fn trims_incomplete_label() {
+        assert_eq!(run("see [link"), "see ");
+    }
+
+    #[test]
+    fn trims_closed_label_without_destination() {
+        assert_eq!(run("see [link]"), "see ");
+    }
+
+    #[test]
+    fn trims_closed_label_with_only_whitespace_after() {
+        assert_eq!(run("see [link]   "), "see ");
+    }
+
+    #[test]
+    fn keeps_closed_label_with_trailing_text() {
+        assert_eq!(run("see [link] text"), "see [link] text");
+    }
+
+    #[test]
+    fn trims_incomplete_image_destination() {
+        assert_eq!(run("see ![alt](dest"), "see ");
+    }
+
+    #[test]
+    fn does_not_trim_when_label_starts_before_tail() {
+        let label_text = "a".repeat(MAX_HIDE_LEN);
+        let input_text = format!("[{label_text}](");
+        assert_eq!(run(&input_text), input_text);
+    }
+
+    #[test]
+    fn does_not_trim_when_image_prefix_is_outside_tail() {
+        let label_text = "a".repeat(MAX_HIDE_LEN - 1);
+        let input_text = format!("![{label_text}");
+        assert_eq!(run(&input_text), input_text);
+    }
+}


### PR DESCRIPTION
This change updates the system prompt with a clear guideline for using **MentionUri** Markdown so the model can generate *clickable, linkable references*.  

It also introduces a mechanism to **skip partial links** during Markdown chunk processing, ensuring only **fully-formed links** are rendered. This prevents broken intermediate states and results in smoother, cleaner link rendering.


It covers the following reference types:

- **File:** `[mention.rs](file:///abs/path/to/mention.rs)`
- **Directory:** `[src](file:///abs/path/to/src/)`
- **Symbol (function/class/struct/method/etc.):** `[MentionUri](file:///abs/path/to/mention.rs?symbol=MentionUri#L18:18)`
- **Selection:** `[selection](file:///abs/path/to/mention.rs#L5:12)`

Demo:

https://github.com/user-attachments/assets/90e51f43-412e-46b7-a068-881dba761592

References:

Native looking links in model responses are available here #48074 and depends on #48057

Closes #37563

## Release Notes
- Improved the system prompt so the agent responds with linkable references to files, directories, symbols, and selections.
