### PR TITLE
Add Ollama as an edit prediction provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11074,6 +11074,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ollama_edit_prediction"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "edit_prediction",
+ "edit_prediction_types",
+ "futures 0.3.31",
+ "gpui",
+ "http_client",
+ "language",
+ "log",
+ "ollama",
+ "serde",
+ "serde_json",
+ "settings",
+ "text",
+]
+
+[[package]]
 name = "onboarding"
 version = "0.1.0"
 dependencies = [
@@ -21046,6 +21065,7 @@ dependencies = [
  "nc",
  "node_runtime",
  "notifications",
+ "ollama_edit_prediction",
  "onboarding",
  "outline",
  "outline_panel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,6 +172,7 @@ members = [
     "crates/supermaven",
     "crates/supermaven_api",
     "crates/codestral",
+    "crates/ollama_edit_prediction",
     "crates/svg_preview",
     "crates/system_specs",
     "crates/tab_switcher",
@@ -409,6 +410,7 @@ sum_tree = { path = "crates/sum_tree" }
 supermaven = { path = "crates/supermaven" }
 supermaven_api = { path = "crates/supermaven_api" }
 codestral = { path = "crates/codestral" }
+ollama_edit_prediction = { path = "crates/ollama_edit_prediction" }
 system_specs = { path = "crates/system_specs" }
 tab_switcher = { path = "crates/tab_switcher" }
 task = { path = "crates/task" }

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1545,6 +1545,12 @@
       "model": "codestral-latest",
       "max_tokens": 150,
     },
+    "ollama": {
+      "api_url": "http://localhost:11434",
+      "model": "qwen2.5-coder:7b",
+      "max_tokens": 150,
+      "api_key": null,
+    },
     // Whether edit predictions are enabled when editing text threads in the agent panel.
     // This setting has no effect if globally disabled.
     "enabled_in_text_threads": true,

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -401,6 +401,7 @@ fn update_command_palette_filter(cx: &mut App) {
                 }
                 EditPredictionProvider::Zed
                 | EditPredictionProvider::Codestral
+                | EditPredictionProvider::Ollama
                 | EditPredictionProvider::Experimental(_) => {
                     filter.show_namespace("edit_prediction");
                     filter.hide_namespace("copilot");

--- a/crates/edit_prediction_ui/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_ui/src/edit_prediction_button.rs
@@ -306,7 +306,7 @@ impl Render for EditPredictionButton {
                         .with_handle(self.popover_menu_handle.clone()),
                 )
             }
-            provider @ (EditPredictionProvider::Experimental(_) | EditPredictionProvider::Zed) => {
+            provider @ (EditPredictionProvider::Experimental(_) | EditPredictionProvider::Zed | EditPredictionProvider::Ollama) => {
                 let enabled = self.editor_enabled.unwrap_or(true);
 
                 let ep_icon;
@@ -337,6 +337,14 @@ impl Render for EditPredictionButton {
                         } else {
                             "Powered by Mercury"
                         };
+                    }
+                    EditPredictionProvider::Ollama => {
+                        ep_icon = if enabled {
+                            IconName::ZedPredict
+                        } else {
+                            IconName::ZedPredictDisabled
+                        };
+                        tooltip_meta = "Powered by Ollama"
                     }
                     _ => {
                         ep_icon = if enabled {

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -388,6 +388,8 @@ pub struct EditPredictionSettings {
     pub copilot: CopilotSettings,
     /// Settings specific to Codestral.
     pub codestral: CodestralSettings,
+    /// Settings specific to Ollama.
+    pub ollama: OllamaSettings,
     /// Whether edit predictions are enabled in the assistant panel.
     /// This setting has no effect if globally disabled.
     pub enabled_in_text_threads: bool,
@@ -435,6 +437,18 @@ pub struct CodestralSettings {
     pub max_tokens: Option<u32>,
     /// Custom API URL to use for Codestral.
     pub api_url: Option<String>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct OllamaSettings {
+    /// Model to use for completions.
+    pub model: Option<String>,
+    /// Maximum tokens to generate.
+    pub max_tokens: Option<i32>,
+    /// API URL to use for Ollama.
+    pub api_url: Option<String>,
+    /// Optional API key for authentication.
+    pub api_key: Option<String>,
 }
 
 impl AllLanguageSettings {
@@ -663,6 +677,14 @@ impl settings::Settings for AllLanguageSettings {
             api_url: codestral.api_url,
         };
 
+        let ollama = edit_predictions.ollama.unwrap();
+        let ollama_settings = OllamaSettings {
+            model: ollama.model,
+            max_tokens: ollama.max_tokens,
+            api_url: ollama.api_url,
+            api_key: ollama.api_key,
+        };
+
         let enabled_in_text_threads = edit_predictions.enabled_in_text_threads.unwrap();
 
         let mut file_types: FxHashMap<Arc<str>, (GlobSet, Vec<String>)> = FxHashMap::default();
@@ -700,6 +722,7 @@ impl settings::Settings for AllLanguageSettings {
                 mode: edit_predictions_mode,
                 copilot: copilot_settings,
                 codestral: codestral_settings,
+                ollama: ollama_settings,
                 enabled_in_text_threads,
                 examples_dir: edit_predictions.examples_dir,
                 example_capture_rate: edit_predictions.example_capture_rate,

--- a/crates/ollama_edit_prediction/Cargo.toml
+++ b/crates/ollama_edit_prediction/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "ollama_edit_prediction"
+version = "0.1.0"
+edition = "2021"
+publish = false
+license = "GPL-3.0-or-later"
+
+[lib]
+path = "src/ollama_edit_prediction.rs"
+
+[dependencies]
+anyhow.workspace = true
+edit_prediction_types.workspace = true
+edit_prediction.workspace = true
+futures.workspace = true
+gpui.workspace = true
+http_client.workspace = true
+language.workspace = true
+log.workspace = true
+ollama.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+settings.workspace = true
+text.workspace = true

--- a/crates/ollama_edit_prediction/src/ollama_edit_prediction.rs
+++ b/crates/ollama_edit_prediction/src/ollama_edit_prediction.rs
@@ -1,0 +1,523 @@
+use anyhow::Result;
+use edit_prediction::cursor_excerpt;
+use edit_prediction_types::{EditPrediction, EditPredictionDelegate};
+use gpui::{App, Context, Entity, Task};
+use http_client::HttpClient;
+use language::{
+    language_settings::all_language_settings, Anchor, Buffer, BufferSnapshot, EditPreview, ToPoint,
+};
+use ollama::{GenerateOptions, GenerateRequest, OLLAMA_API_URL};
+use settings::KeepAlive;
+use std::{
+    ops::Range,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+use text::{OffsetRangeExt as _, ToOffset};
+
+pub const DEBOUNCE_TIMEOUT: Duration = Duration::from_millis(150);
+pub const DEFAULT_MODEL: &str = "qwen2.5-coder:7b";
+
+#[derive(Clone)]
+struct CurrentCompletion {
+    snapshot: BufferSnapshot,
+    edits: Arc<[(Range<Anchor>, Arc<str>)]>,
+    edit_preview: EditPreview,
+}
+
+impl CurrentCompletion {
+    fn interpolate(&self, new_snapshot: &BufferSnapshot) -> Option<Vec<(Range<Anchor>, Arc<str>)>> {
+        edit_prediction_types::interpolate_edits(&self.snapshot, new_snapshot, &self.edits)
+    }
+}
+
+pub struct OllamaEditPredictionDelegate {
+    http_client: Arc<dyn HttpClient>,
+    pending_request: Option<Task<Result<()>>>,
+    current_completion: Option<CurrentCompletion>,
+}
+
+impl OllamaEditPredictionDelegate {
+    pub fn new(http_client: Arc<dyn HttpClient>) -> Self {
+        Self {
+            http_client,
+            pending_request: None,
+            current_completion: None,
+        }
+    }
+
+    async fn fetch_completion(
+        http_client: Arc<dyn HttpClient>,
+        api_url: &str,
+        api_key: Option<&str>,
+        prompt: String,
+        suffix: String,
+        model: String,
+        max_tokens: Option<i32>,
+    ) -> Result<String> {
+        let start_time = Instant::now();
+
+        log::info!(
+            "Ollama: Requesting completion (model: {}, max_tokens: {:?})",
+            model,
+            max_tokens
+        );
+
+        let (fim_prompt, use_raw) = Self::format_fim_prompt(&model, &prompt, &suffix);
+
+        let request = GenerateRequest {
+            model,
+            prompt: fim_prompt,
+            suffix: None,
+            stream: false,
+            raw: if use_raw { Some(true) } else { None },
+            keep_alive: KeepAlive::indefinite(),
+            options: Some(GenerateOptions {
+                num_predict: max_tokens.or(Some(150)),
+                temperature: Some(0.2),
+                top_p: Some(1.0),
+                stop: None,
+            }),
+        };
+
+        log::info!("Ollama: Sending FIM request to {}", api_url);
+
+        let response = ollama::generate_completion(http_client.as_ref(), api_url, api_key, request)
+            .await?;
+
+        let elapsed = start_time.elapsed();
+
+        log::info!(
+            "Ollama: Completion received (eval_count: {:?}, {:.2}s)",
+            response.eval_count,
+            elapsed.as_secs_f64()
+        );
+
+        let completion = Self::clean_fim_response(&response.response);
+
+        Ok(completion)
+    }
+
+    fn format_fim_prompt(model: &str, prefix: &str, suffix: &str) -> (String, bool) {
+        let model_lower = model.to_lowercase();
+
+        if model_lower.contains("qwen") {
+            let prompt = format!(
+                "<|fim_prefix|>{}<|fim_suffix|>{}<|fim_middle|>",
+                prefix, suffix
+            );
+            (prompt, true)
+        } else if model_lower.contains("codellama") || model_lower.contains("code-llama") {
+            let prompt = format!("<PRE> {} <SUF>{} <MID>", prefix, suffix);
+            (prompt, true)
+        } else if model_lower.contains("starcoder") || model_lower.contains("star-coder") {
+            let prompt = format!(
+                "<fim_prefix>{}<fim_suffix>{}<fim_middle>",
+                prefix, suffix
+            );
+            (prompt, true)
+        } else if model_lower.contains("deepseek") {
+            let prompt = format!(
+                "<|fim_begin|>{}<|fim_hole|>{}<|fim_end|>",
+                prefix, suffix
+            );
+            (prompt, true)
+        } else if model_lower.contains("codestral") {
+            let prompt = format!("[SUFFIX]{suffix}[PREFIX]{prefix}");
+            (prompt, true)
+        } else {
+            log::warn!(
+                "Ollama: Unknown model '{}' - using basic completion without FIM tokens",
+                model
+            );
+            (prefix.to_string(), false)
+        }
+    }
+
+    fn clean_fim_response(response: &str) -> String {
+        let mut result = response.to_string();
+
+        let stop_patterns = [
+            "<|endoftext|>",
+            "<|fim_pad|>",
+            "<|fim_prefix|>",
+            "<|fim_suffix|>",
+            "<|fim_middle|>",
+            "<|end|>",
+            "<|im_end|>",
+            "<|eot_id|>",
+            "<EOT>",
+        ];
+
+        for pattern in &stop_patterns {
+            if let Some(idx) = result.find(pattern) {
+                result.truncate(idx);
+            }
+        }
+
+        result
+    }
+}
+
+impl EditPredictionDelegate for OllamaEditPredictionDelegate {
+    fn name() -> &'static str {
+        "ollama"
+    }
+
+    fn display_name() -> &'static str {
+        "Ollama"
+    }
+
+    fn show_predictions_in_menu() -> bool {
+        true
+    }
+
+    fn is_enabled(&self, _buffer: &Entity<Buffer>, _cursor_position: Anchor, _cx: &App) -> bool {
+        true
+    }
+
+    fn is_refreshing(&self, _cx: &App) -> bool {
+        self.pending_request.is_some()
+    }
+
+    fn refresh(
+        &mut self,
+        buffer: Entity<Buffer>,
+        cursor_position: language::Anchor,
+        debounce: bool,
+        cx: &mut Context<Self>,
+    ) {
+        log::info!("Ollama: Refresh called (debounce: {})", debounce);
+
+        let snapshot = buffer.read(cx).snapshot();
+
+        if let Some(current_completion) = self.current_completion.as_ref() {
+            if current_completion.interpolate(&snapshot).is_some() {
+                return;
+            }
+        }
+
+        if self.pending_request.is_some() {
+            log::debug!("Ollama: Request already pending, not starting a new one");
+            return;
+        }
+
+        let http_client = self.http_client.clone();
+
+        let settings = all_language_settings(None, cx);
+        let model = settings
+            .edit_predictions
+            .ollama
+            .model
+            .clone()
+            .unwrap_or_else(|| DEFAULT_MODEL.to_string());
+        let max_tokens = settings.edit_predictions.ollama.max_tokens;
+        let api_url = settings
+            .edit_predictions
+            .ollama
+            .api_url
+            .clone()
+            .unwrap_or_else(|| OLLAMA_API_URL.to_string());
+        let api_key = settings.edit_predictions.ollama.api_key.clone();
+
+        self.pending_request = Some(cx.spawn(async move |this, cx| {
+            if debounce {
+                log::debug!("Ollama: Debouncing for {:?}", DEBOUNCE_TIMEOUT);
+                cx.background_executor().timer(DEBOUNCE_TIMEOUT).await;
+            }
+
+            let cursor_offset = cursor_position.to_offset(&snapshot);
+            let cursor_point = cursor_offset.to_point(&snapshot);
+
+            const MAX_CONTEXT_TOKENS: usize = 150;
+            const MAX_REWRITE_TOKENS: usize = 350;
+
+            let (_, context_range) =
+                cursor_excerpt::editable_and_context_ranges_for_cursor_position(
+                    cursor_point,
+                    &snapshot,
+                    MAX_REWRITE_TOKENS,
+                    MAX_CONTEXT_TOKENS,
+                );
+
+            let context_range = context_range.to_offset(&snapshot);
+            let excerpt_text = snapshot
+                .text_for_range(context_range.clone())
+                .collect::<String>();
+            let cursor_within_excerpt = cursor_offset
+                .saturating_sub(context_range.start)
+                .min(excerpt_text.len());
+            let prompt = excerpt_text[..cursor_within_excerpt].to_string();
+            let suffix = excerpt_text[cursor_within_excerpt..].to_string();
+
+            let completion_text = match Self::fetch_completion(
+                http_client,
+                &api_url,
+                api_key.as_deref(),
+                prompt,
+                suffix,
+                model,
+                max_tokens,
+            )
+            .await
+            {
+                Ok(completion) => completion,
+                Err(e) => {
+                    log::error!("Ollama: Failed to fetch completion: {}", e);
+                    this.update(cx, |this, cx| {
+                        this.pending_request = None;
+                        cx.notify();
+                    })?;
+                    return Err(e);
+                }
+            };
+
+            if completion_text.trim().is_empty() {
+                log::info!("Ollama: Completion was empty after trimming; ignoring");
+                this.update(cx, |this, cx| {
+                    this.pending_request = None;
+                    cx.notify();
+                })?;
+                return Ok(());
+            }
+
+            let edits: Arc<[(Range<Anchor>, Arc<str>)]> =
+                vec![(cursor_position..cursor_position, completion_text.into())].into();
+            let edit_preview = buffer
+                .read_with(cx, |buffer, cx| buffer.preview_edits(edits.clone(), cx))
+                .await;
+
+            this.update(cx, |this, cx| {
+                log::info!("Ollama: Storing completion and notifying editor");
+                this.current_completion = Some(CurrentCompletion {
+                    snapshot,
+                    edits,
+                    edit_preview,
+                });
+                this.pending_request = None;
+                cx.notify();
+            })?;
+
+            Ok(())
+        }));
+    }
+
+    fn accept(&mut self, _cx: &mut Context<Self>) {
+        log::debug!("Ollama: Completion accepted");
+        self.pending_request = None;
+        self.current_completion = None;
+    }
+
+    fn discard(&mut self, _cx: &mut Context<Self>) {
+        log::debug!("Ollama: Completion discarded");
+        self.pending_request = None;
+        self.current_completion = None;
+    }
+
+    fn suggest(
+        &mut self,
+        buffer: &Entity<Buffer>,
+        cursor_position: Anchor,
+        cx: &mut Context<Self>,
+    ) -> Option<EditPrediction> {
+        let current_completion = match self.current_completion.as_ref() {
+            Some(c) => c,
+            None => {
+                log::debug!("Ollama suggest: No current completion");
+                return None;
+            }
+        };
+
+        let buffer = buffer.read(cx);
+        let new_snapshot = buffer.snapshot();
+
+        if let Some(edits) = current_completion.interpolate(&new_snapshot) {
+            if !edits.is_empty() {
+                log::info!("Ollama suggest: Returning {} interpolated edit(s)", edits.len());
+                return Some(EditPrediction::Local {
+                    id: None,
+                    edits,
+                    cursor_position: None,
+                    edit_preview: Some(current_completion.edit_preview.clone()),
+                });
+            }
+        }
+
+        let original_edits = &current_completion.edits;
+        if original_edits.len() == 1 {
+            let (original_range, completion_text) = &original_edits[0];
+            let original_start = original_range.start.to_offset(&new_snapshot);
+            let original_end = original_range.end.to_offset(&new_snapshot);
+            let cursor_offset = cursor_position.to_offset(&new_snapshot);
+
+            if original_start == original_end && cursor_offset >= original_start {
+                let distance = cursor_offset - original_start;
+                if distance <= 50 {
+                    log::info!(
+                        "Ollama suggest: Showing completion at cursor (moved {} chars from original)",
+                        distance
+                    );
+                    let edits = vec![(cursor_position..cursor_position, completion_text.clone())];
+                    return Some(EditPrediction::Local {
+                        id: None,
+                        edits,
+                        cursor_position: None,
+                        edit_preview: None,
+                    });
+                }
+            }
+        }
+
+        log::info!("Ollama suggest: Completion no longer valid for current cursor position");
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_fim_prompt_qwen() {
+        let (prompt, raw) =
+            OllamaEditPredictionDelegate::format_fim_prompt("qwen2.5-coder:7b", "def hello(", ")");
+        assert!(prompt.contains("<|fim_prefix|>"));
+        assert!(prompt.contains("<|fim_suffix|>"));
+        assert!(prompt.contains("<|fim_middle|>"));
+        assert_eq!(
+            prompt,
+            "<|fim_prefix|>def hello(<|fim_suffix|>)<|fim_middle|>"
+        );
+        assert!(raw);
+    }
+
+    #[test]
+    fn test_format_fim_prompt_codellama() {
+        let (prompt, raw) =
+            OllamaEditPredictionDelegate::format_fim_prompt("codellama:7b", "fn main() {", "}");
+        assert!(prompt.contains("<PRE>"));
+        assert!(prompt.contains("<SUF>"));
+        assert!(prompt.contains("<MID>"));
+        assert_eq!(prompt, "<PRE> fn main() { <SUF>} <MID>");
+        assert!(raw);
+    }
+
+    #[test]
+    fn test_format_fim_prompt_starcoder() {
+        let (prompt, raw) =
+            OllamaEditPredictionDelegate::format_fim_prompt("starcoder2:3b", "let x = ", ";");
+        assert!(prompt.contains("<fim_prefix>"));
+        assert!(prompt.contains("<fim_suffix>"));
+        assert!(prompt.contains("<fim_middle>"));
+        assert_eq!(prompt, "<fim_prefix>let x = <fim_suffix>;<fim_middle>");
+        assert!(raw);
+    }
+
+    #[test]
+    fn test_format_fim_prompt_deepseek() {
+        let (prompt, raw) = OllamaEditPredictionDelegate::format_fim_prompt(
+            "deepseek-coder:6.7b",
+            "async fn fetch(",
+            ") {}",
+        );
+        assert!(prompt.contains("<|fim_begin|>"));
+        assert!(prompt.contains("<|fim_hole|>"));
+        assert!(prompt.contains("<|fim_end|>"));
+        assert_eq!(
+            prompt,
+            "<|fim_begin|>async fn fetch(<|fim_hole|>) {}<|fim_end|>"
+        );
+        assert!(raw);
+    }
+
+    #[test]
+    fn test_format_fim_prompt_codestral() {
+        let (prompt, raw) = OllamaEditPredictionDelegate::format_fim_prompt(
+            "codestral:22b",
+            "class User:",
+            "\n    pass",
+        );
+        assert!(prompt.contains("[SUFFIX]"));
+        assert!(prompt.contains("[PREFIX]"));
+        assert_eq!(prompt, "[SUFFIX]\n    pass[PREFIX]class User:");
+        assert!(raw);
+    }
+
+    #[test]
+    fn test_format_fim_prompt_unknown_model() {
+        let (prompt, raw) = OllamaEditPredictionDelegate::format_fim_prompt(
+            "llama3:8b",
+            "print('hello')",
+            "",
+        );
+        assert_eq!(prompt, "print('hello')");
+        assert!(!raw);
+    }
+
+    #[test]
+    fn test_format_fim_prompt_case_insensitive() {
+        let (prompt, raw) =
+            OllamaEditPredictionDelegate::format_fim_prompt("QWEN2.5-CODER:7B", "x", "y");
+        assert!(prompt.contains("<|fim_prefix|>"));
+        assert!(raw);
+
+        let (prompt, raw) =
+            OllamaEditPredictionDelegate::format_fim_prompt("CodeLlama:13b", "x", "y");
+        assert!(prompt.contains("<PRE>"));
+        assert!(raw);
+    }
+
+    #[test]
+    fn test_clean_fim_response_with_endoftext() {
+        let result = OllamaEditPredictionDelegate::clean_fim_response(
+            "hello world<|endoftext|>extra stuff",
+        );
+        assert_eq!(result, "hello world");
+    }
+
+    #[test]
+    fn test_clean_fim_response_with_fim_pad() {
+        let result =
+            OllamaEditPredictionDelegate::clean_fim_response("completed code<|fim_pad|>garbage");
+        assert_eq!(result, "completed code");
+    }
+
+    #[test]
+    fn test_clean_fim_response_with_im_end() {
+        let result =
+            OllamaEditPredictionDelegate::clean_fim_response("return value<|im_end|>more");
+        assert_eq!(result, "return value");
+    }
+
+    #[test]
+    fn test_clean_fim_response_with_eot() {
+        let result = OllamaEditPredictionDelegate::clean_fim_response("some code<EOT>trailing");
+        assert_eq!(result, "some code");
+    }
+
+    #[test]
+    fn test_clean_fim_response_no_stop_token() {
+        let result = OllamaEditPredictionDelegate::clean_fim_response("clean completion text");
+        assert_eq!(result, "clean completion text");
+    }
+
+    #[test]
+    fn test_clean_fim_response_multiple_stop_tokens() {
+        let result = OllamaEditPredictionDelegate::clean_fim_response(
+            "first part<|endoftext|>second<|fim_pad|>third",
+        );
+        assert_eq!(result, "first part");
+    }
+
+    #[test]
+    fn test_clean_fim_response_empty() {
+        let result = OllamaEditPredictionDelegate::clean_fim_response("");
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn test_clean_fim_response_only_stop_token() {
+        let result = OllamaEditPredictionDelegate::clean_fim_response("<|endoftext|>");
+        assert_eq!(result, "");
+    }
+}

--- a/crates/settings_content/src/language.rs
+++ b/crates/settings_content/src/language.rs
@@ -96,6 +96,7 @@ pub enum EditPredictionProvider {
     Supermaven,
     Zed,
     Codestral,
+    Ollama,
     Experimental(&'static str),
 }
 
@@ -116,6 +117,7 @@ impl<'de> Deserialize<'de> for EditPredictionProvider {
             Supermaven,
             Zed,
             Codestral,
+            Ollama,
             Experimental(String),
         }
 
@@ -125,6 +127,7 @@ impl<'de> Deserialize<'de> for EditPredictionProvider {
             Content::Supermaven => EditPredictionProvider::Supermaven,
             Content::Zed => EditPredictionProvider::Zed,
             Content::Codestral => EditPredictionProvider::Codestral,
+            Content::Ollama => EditPredictionProvider::Ollama,
             Content::Experimental(name)
                 if name == EXPERIMENTAL_SWEEP_EDIT_PREDICTION_PROVIDER_NAME =>
             {
@@ -164,6 +167,7 @@ impl EditPredictionProvider {
             | EditPredictionProvider::Copilot
             | EditPredictionProvider::Supermaven
             | EditPredictionProvider::Codestral
+            | EditPredictionProvider::Ollama
             | EditPredictionProvider::Experimental(_) => false,
         }
     }
@@ -174,6 +178,7 @@ impl EditPredictionProvider {
             EditPredictionProvider::Copilot => Some("GitHub Copilot"),
             EditPredictionProvider::Supermaven => Some("Supermaven"),
             EditPredictionProvider::Codestral => Some("Codestral"),
+            EditPredictionProvider::Ollama => Some("Ollama"),
             EditPredictionProvider::Experimental(
                 EXPERIMENTAL_SWEEP_EDIT_PREDICTION_PROVIDER_NAME,
             ) => Some("Sweep"),
@@ -203,6 +208,8 @@ pub struct EditPredictionSettingsContent {
     pub copilot: Option<CopilotSettingsContent>,
     /// Settings specific to Codestral.
     pub codestral: Option<CodestralSettingsContent>,
+    /// Settings specific to Ollama edit predictions.
+    pub ollama: Option<OllamaEditPredictionSettingsContent>,
     /// Whether edit predictions are enabled in the assistant prompt editor.
     /// This has no effect if globally disabled.
     pub enabled_in_text_threads: Option<bool>,
@@ -248,6 +255,27 @@ pub struct CodestralSettingsContent {
     ///
     /// Default: "https://codestral.mistral.ai"
     pub api_url: Option<String>,
+}
+
+#[with_fallible_options]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema, MergeFrom, PartialEq)]
+pub struct OllamaEditPredictionSettingsContent {
+    /// Model to use for completions.
+    ///
+    /// Default: "qwen2.5-coder:7b"
+    pub model: Option<String>,
+    /// Maximum tokens to generate.
+    ///
+    /// Default: 150
+    pub max_tokens: Option<i32>,
+    /// API URL to use for completions.
+    ///
+    /// Default: "http://localhost:11434"
+    pub api_url: Option<String>,
+    /// Optional API key for authentication.
+    ///
+    /// Default: null
+    pub api_key: Option<String>,
 }
 
 /// The mode in which edit predictions should be displayed.

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -82,6 +82,7 @@ clap.workspace = true
 cli.workspace = true
 client.workspace = true
 codestral.workspace = true
+ollama_edit_prediction.workspace = true
 collab_ui.workspace = true
 collections.workspace = true
 command_palette.workspace = true

--- a/crates/zed/src/zed/edit_prediction_registry.rs
+++ b/crates/zed/src/zed/edit_prediction_registry.rs
@@ -1,5 +1,6 @@
 use client::{Client, UserStore};
 use codestral::CodestralEditPredictionDelegate;
+use ollama_edit_prediction::OllamaEditPredictionDelegate;
 use collections::HashMap;
 use copilot::CopilotEditPredictionDelegate;
 use edit_prediction::{
@@ -193,6 +194,12 @@ fn assign_edit_prediction_provider(
         EditPredictionProvider::Codestral => {
             let http_client = client.http_client();
             let provider = cx.new(|_| CodestralEditPredictionDelegate::new(http_client));
+            editor.set_edit_prediction_provider(Some(provider), window, cx);
+        }
+        EditPredictionProvider::Ollama => {
+            log::info!("Ollama: Registering edit prediction provider");
+            let http_client = client.http_client();
+            let provider = cx.new(|_| OllamaEditPredictionDelegate::new(http_client));
             editor.set_edit_prediction_provider(Some(provider), window, cx);
         }
         value @ (EditPredictionProvider::Experimental(_) | EditPredictionProvider::Zed) => {


### PR DESCRIPTION
## Summary
Add Ollama as an edit prediction provider, enabling local LLM-powered code completions.

Closes #15968

## Features
- FIM (Fill-in-the-Middle) support for multiple models:
  - Qwen2.5-Coder (default)
  - CodeLlama
  - StarCoder
  - DeepSeek Coder
  - Codestral
- Configurable: model, max_tokens, api_url, api_key
- 150ms debouncing to avoid overwhelming local server

## Configuration
```json
{
  "edit_predictions": {
    "mode": "eager",
    "provider": "ollama"
  }
}
```

Optionally customize:
```json
{
  "edit_predictions": {
    "ollama": {
      "model": "qwen2.5-coder:1.5b",
      "max_tokens": 100
    }
  }
}
```

## Test plan
- [x] Manual testing with qwen2.5-coder model
- [x] Verified FIM tokens produce code completions (not chat responses)
- [x] Unit tests for FIM formatting and response cleaning
- [x] `./script/clippy` passes with no warnings
- [x] `cargo test -p ollama_edit_prediction` passes