### PR TITLE
docs: Document visual mode bindings for multi-line insert/append

### DIFF
--- a/docs/src/vim.md
+++ b/docs/src/vim.md
@@ -125,14 +125,14 @@ per language.
 These commands help you manage multiple cursors in Zed.
 
 | Command                                                                           | Default Shortcut |
-| ----------------------------------------------------------------------------------| ---------------- |
+| --------------------------------------------------------------------------------- | ---------------- |
 | Add a cursor selecting the next copy of the current word                          | `g l`            |
 | Add a cursor selecting the previous copy of the current word                      | `g L`            |
+| Add a cursor at the end of every line in the current visual selection             | `g A`            |
+| Add a cursor at the first character of every line in the current visual selection | `g I`            |
+| Add a visual selection for every copy of the current word                         | `g a`            |
 | Skip latest word selection, and add next                                          | `g >`            |
 | Skip latest word selection, and add previous                                      | `g <`            |
-| Add a visual selection for every copy of the current word                         | `g a`            |
-| Add a cursor at the first character of every line in the current visual selection | `g I`            |
-| Add a cursor at the end of every line in the current visual selection             | `g A`            |
 
 ### Pane management
 
@@ -207,7 +207,6 @@ These text objects implement the behavior of the [mini.ai](https://github.com/ec
 #### Choosing Between Approaches
 
 - Use **AnyQuotes/AnyBrackets** if you:
-
   - Prefer traditional Vim behavior
   - Want consistent character-based selection prioritizing innermost delimiters
   - Need behavior that closely matches vanilla Vim's text objects

--- a/docs/src/vim.md
+++ b/docs/src/vim.md
@@ -124,13 +124,15 @@ per language.
 
 These commands help you manage multiple cursors in Zed.
 
-| Command                                                      | Default Shortcut |
-| ------------------------------------------------------------ | ---------------- |
-| Add a cursor selecting the next copy of the current word     | `g l`            |
-| Add a cursor selecting the previous copy of the current word | `g L`            |
-| Skip latest word selection, and add next                     | `g >`            |
-| Skip latest word selection, and add previous                 | `g <`            |
-| Add a visual selection for every copy of the current word    | `g a`            |
+| Command                                                                           | Default Shortcut |
+| ----------------------------------------------------------------------------------| ---------------- |
+| Add a cursor selecting the next copy of the current word                          | `g l`            |
+| Add a cursor selecting the previous copy of the current word                      | `g L`            |
+| Skip latest word selection, and add next                                          | `g >`            |
+| Skip latest word selection, and add previous                                      | `g <`            |
+| Add a visual selection for every copy of the current word                         | `g a`            |
+| Add a cursor at the first character of every line in the current visual selection | `g I`            |
+| Add a cursor at the end of every line in the current visual selection             | `g A`            |
 
 ### Pane management
 
@@ -534,18 +536,6 @@ The [vim-exchange](https://github.com/tommcdo/vim-exchange) feature does not hav
   "context": "vim_mode == visual",
   "bindings": {
     "shift-x": "vim::Exchange"
-  }
-}
-```
-
-In visual mode, pressing `I` or `A` when multiple lines are selected does not create multiple cursors by default. Adding the following bindings will enable this functionality, allowing you to insert at the beginning or append at the end of each selected line:
-
-```json [settings]
-{
-  "context": "vim_mode == visual && !VimBlockSelection",
-  "bindings": {
-    "shift-i": "vim::InsertBeforeFirstNonWhitespace",
-    "shift-a": "vim::InsertAfterEndOfLine"
   }
 }
 ```

--- a/docs/src/vim.md
+++ b/docs/src/vim.md
@@ -207,6 +207,7 @@ These text objects implement the behavior of the [mini.ai](https://github.com/ec
 #### Choosing Between Approaches
 
 - Use **AnyQuotes/AnyBrackets** if you:
+
   - Prefer traditional Vim behavior
   - Want consistent character-based selection prioritizing innermost delimiters
   - Need behavior that closely matches vanilla Vim's text objects

--- a/docs/src/vim.md
+++ b/docs/src/vim.md
@@ -538,6 +538,18 @@ The [vim-exchange](https://github.com/tommcdo/vim-exchange) feature does not hav
 }
 ```
 
+In visual mode, pressing `I` or `A` when multiple lines are selected does not create multiple cursors by default. Adding the following bindings will enable this functionality, allowing you to insert at the beginning or append at the end of each selected line:
+
+```json [settings]
+{
+  "context": "vim_mode == visual && !VimBlockSelection",
+  "bindings": {
+    "shift-i": "vim::InsertBeforeFirstNonWhitespace",
+    "shift-a": "vim::InsertAfterEndOfLine"
+  }
+}
+```
+
 ### Restoring common text editing and Zed keybindings
 
 If you're using vim mode on Linux or Windows, you may find it overrides keybindings you can't live without: `ctrl+v` to paste, `ctrl+f` to search, etc. You can restore them by copying this data into your keymap:


### PR DESCRIPTION
Closes #44420 

Added instructions and example keybindings to enable multi-cursor insert (`shift-i`) and append (`shift-a`) actions in visual mode, making it easier for users to perform these actions on multiple lines simultaneously.

Release Notes:

- N/A
