### PR TITLE
Fix capitalization of libX11 in FreeBSD dependencies

### DIFF
--- a/script/freebsd
+++ b/script/freebsd
@@ -26,7 +26,7 @@ if [[ -n $pkg ]]; then
         llvm
         protobuf
         rustup-init
-        libx11
+        libX11
         alsa-lib
     )
     $maysudo "$pkg" install "${deps[@]}"


### PR DESCRIPTION
This work :
> doas pkg install lib**X**11

Release Notes:

- N/A