### PR TITLE
title_bar: Add per-project background color setting

### DIFF
--- a/crates/platform_title_bar/src/platform_title_bar.rs
+++ b/crates/platform_title_bar/src/platform_title_bar.rs
@@ -31,6 +31,7 @@ pub struct PlatformTitleBar {
     system_window_tabs: Entity<SystemWindowTabs>,
     workspace_sidebar_open: bool,
     sidebar_has_notifications: bool,
+    override_background: Option<Hsla>,
 }
 
 impl PlatformTitleBar {
@@ -46,10 +47,31 @@ impl PlatformTitleBar {
             system_window_tabs,
             workspace_sidebar_open: false,
             sidebar_has_notifications: false,
+            override_background: None,
         }
     }
 
+    pub fn set_background_override(&mut self, color: Option<Hsla>) {
+        self.override_background = color;
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    pub fn height(window: &mut Window) -> Pixels {
+        (1.75 * window.rem_size()).max(px(34.))
+    }
+
+    #[cfg(target_os = "windows")]
+    pub fn height(_window: &mut Window) -> Pixels {
+        // todo(windows) instead of hard coded size report the actual size to the Windows platform API
+        px(32.)
+    }
+
+
     pub fn title_bar_color(&self, window: &mut Window, cx: &mut Context<Self>) -> Hsla {
+        if let Some(override_color) = self.override_background {
+            return override_color;
+        }
+
         if cfg!(any(target_os = "linux", target_os = "freebsd")) {
             if window.is_window_active() && !self.should_move {
                 cx.theme().colors().title_bar_background

--- a/crates/settings/src/settings_store.rs
+++ b/crates/settings/src/settings_store.rs
@@ -946,10 +946,12 @@ impl SettingsStore {
                     }),
                 }?;
                 if let Some(new_settings) = new_settings {
+                    let title_bar = new_settings.title_bar.clone();
                     match self.local_settings.entry((root_id, directory_path)) {
                         btree_map::Entry::Vacant(v) => {
                             v.insert(SettingsContent {
                                 project: new_settings,
+                                title_bar,
                                 ..Default::default()
                             });
                             zed_settings_changed = true;
@@ -958,6 +960,7 @@ impl SettingsStore {
                             if &o.get().project != &new_settings {
                                 o.insert(SettingsContent {
                                     project: new_settings,
+                                    title_bar,
                                     ..Default::default()
                                 });
                                 zed_settings_changed = true;

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -511,6 +511,7 @@ impl VsCodeSettings {
             slash_commands: None,
             git_hosting_providers: None,
             disable_ai: None,
+            title_bar: None,
         }
     }
 

--- a/crates/settings_content/src/project.rs
+++ b/crates/settings_content/src/project.rs
@@ -10,7 +10,8 @@ use util::serde::default_true;
 
 use crate::{
     AllLanguageSettingsContent, DelayMs, ExtendingVec, ParseStatus, ProjectTerminalSettingsContent,
-    RootUserSettings, SaturatingBool, SlashCommandSettings, fallible_options,
+    RootUserSettings, SaturatingBool, SlashCommandSettings, TitleBarSettingsContent,
+    fallible_options,
 };
 
 #[with_fallible_options]
@@ -84,6 +85,9 @@ pub struct ProjectSettingsContent {
     ///
     /// Default: false
     pub disable_ai: Option<SaturatingBool>,
+
+    /// Configuration for the title bar.
+    pub title_bar: Option<TitleBarSettingsContent>,
 }
 
 #[with_fallible_options]

--- a/crates/settings_content/src/settings_content.rs
+++ b/crates/settings_content/src/settings_content.rs
@@ -351,6 +351,13 @@ pub struct TitleBarSettingsContent {
     ///
     /// Default: false
     pub show_menus: Option<bool>,
+
+    /// Background color of the title bar.
+    /// Overrides the theme's title_bar.background color.
+    /// Accepts hex colors like "#FF0000" or "#FF0000FF".
+    ///
+    /// Default: null (uses theme color)
+    pub background: Option<String>,
 }
 
 /// Configuration of audio in Zed.

--- a/crates/theme/src/schema.rs
+++ b/crates/theme/src/schema.rs
@@ -839,7 +839,8 @@ pub fn theme_colors_refinement(
     }
 }
 
-pub(crate) fn try_parse_color(color: &str) -> anyhow::Result<Hsla> {
+/// Parses a color string (e.g., "#FF0000" or "#FF0000FF") into an Hsla value.
+pub fn try_parse_color(color: &str) -> anyhow::Result<Hsla> {
     let rgba = gpui::Rgba::try_from(color)?;
     let rgba = palette::rgb::Srgba::from_components((rgba.r, rgba.g, rgba.b, rgba.a));
     let hsla = palette::Hsla::from_color(rgba);

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -31,8 +31,7 @@ use gpui::{
 use onboarding_banner::OnboardingBanner;
 use project::{Project, git_store::GitStoreEvent, trusted_worktrees::TrustedWorktrees};
 use remote::RemoteConnectionOptions;
-use settings::Settings;
-use settings::WorktreeId;
+use settings::{Settings, SettingsLocation, WorktreeId};
 use std::sync::Arc;
 use theme::ActiveTheme;
 use title_bar_settings::TitleBarSettings;
@@ -42,6 +41,7 @@ use ui::{
 };
 use update_version::UpdateVersion;
 use util::ResultExt;
+use util::rel_path::RelPath;
 use workspace::{
     MultiWorkspace, ToggleWorkspaceSidebar, ToggleWorktreeSecurity, Workspace,
     notifications::NotifyResultExt,
@@ -156,7 +156,26 @@ pub struct TitleBar {
 
 impl Render for TitleBar {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let title_bar_settings = *TitleBarSettings::get_global(cx);
+        // Get settings location from first visible worktree for local settings override
+        let settings_location =
+            self.project
+                .read(cx)
+                .visible_worktrees(cx)
+                .next()
+                .map(|worktree| {
+                    let worktree = worktree.read(cx);
+                    SettingsLocation {
+                        worktree_id: worktree.id(),
+                        path: RelPath::empty(),
+                    }
+                });
+
+        let title_bar_settings = TitleBarSettings::get(settings_location, cx).clone();
+
+        // Set background override on platform titlebar
+        self.platform_titlebar.update(cx, |titlebar, _| {
+            titlebar.set_background_override(title_bar_settings.background);
+        });
 
         let show_menus = show_menus(cx);
 

--- a/crates/title_bar/src/title_bar_settings.rs
+++ b/crates/title_bar/src/title_bar_settings.rs
@@ -1,6 +1,8 @@
+use gpui::Hsla;
 use settings::{RegisterSetting, Settings, SettingsContent};
+use theme::try_parse_color;
 
-#[derive(Copy, Clone, Debug, RegisterSetting)]
+#[derive(Clone, Debug, RegisterSetting)]
 pub struct TitleBarSettings {
     pub show_branch_icon: bool,
     pub show_onboarding_banner: bool,
@@ -10,6 +12,7 @@ pub struct TitleBarSettings {
     pub show_sign_in: bool,
     pub show_user_menu: bool,
     pub show_menus: bool,
+    pub background: Option<Hsla>,
 }
 
 impl Settings for TitleBarSettings {
@@ -24,6 +27,10 @@ impl Settings for TitleBarSettings {
             show_sign_in: content.show_sign_in.unwrap(),
             show_user_menu: content.show_user_menu.unwrap(),
             show_menus: content.show_menus.unwrap(),
+            background: content
+                .background
+                .as_ref()
+                .and_then(|c| try_parse_color(c).ok()),
         }
     }
 }

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -4408,7 +4408,7 @@ Run the {#action theme_selector::Toggle} action in the command palette to see a 
 
 ## Title Bar
 
-- Description: Whether or not to show various elements in the title bar
+- Description: Configuration for the title bar, including visibility of elements and custom colors
 - Setting: `title_bar`
 - Default:
 
@@ -4427,6 +4427,7 @@ Run the {#action theme_selector::Toggle} action in the command palette to see a 
 
 **Options**
 
+- `background`: Background color of the title bar. Accepts hex colors like `"#FF0000"` or `"#FF0000FF"`. This setting can be used in project-level `.zed/settings.json` to visually distinguish different projects.
 - `show_branch_icon`: Whether to show the branch icon beside branch switcher in the titlebar
 - `show_branch_name`: Whether to show the branch name button in the titlebar
 - `show_project_items`: Whether to show the project host and name in the titlebar

--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -118,6 +118,7 @@ To disable this behavior use:
 ```json [settings]
   // Control which items are shown/hidden in the title bar
   "title_bar": {
+    "background": "#FF00FF",        // Custom background color (hex format)
     "show_branch_icon": false,      // Show/hide branch icon beside branch switcher
     "show_branch_name": true,       // Show/hide branch name
     "show_project_items": true,     // Show/hide project host and name
@@ -128,6 +129,8 @@ To disable this behavior use:
     "show_menus": false             // Show/hide menus
   },
 ```
+
+The `background` setting can also be used in project-level `.zed/settings.json` files to visually distinguish different projects by giving each a unique title bar color.
 
 ## Workspace
 


### PR DESCRIPTION
I have multiple Zed windows open, and I want to be able to tell them apart.

This adds a `background` option to the `title_bar` settings that can be configured per-project in `.zed/settings.json`.
I often work on multiple projects and wanted a way to quickly identify which window belongs to which project. Now I can set a different title bar color for each:

```json
{
  "title_bar": {
    "background": "#FF00FF"
  }
}
```