### PR TITLE
Commit message editor history

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -1001,6 +1001,8 @@
       "ctrl-shift-enter": "git::Amend",
       "alt-up": "git_panel::FocusChanges",
       "alt-l": "git::GenerateCommitMessage",
+      "up": "git_panel::PrevCommitEditorHistoryItem",
+      "down": "git_panel::NextCommitEditorHistoryItem",
     },
   },
   {

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -1001,8 +1001,8 @@
       "ctrl-shift-enter": "git::Amend",
       "alt-up": "git_panel::FocusChanges",
       "alt-l": "git::GenerateCommitMessage",
-      "up": "git_panel::PrevCommitEditorHistoryItem",
-      "down": "git_panel::NextCommitEditorHistoryItem",
+      "up": "git_panel::PrevCommitEditorHistoryEntry",
+      "down": "git_panel::NextCommitEditorHistoryEntry",
     },
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -1047,6 +1047,8 @@
       "alt-up": "git_panel::FocusChanges",
       "shift-escape": "git::ExpandCommitEditor",
       "alt-tab": "git::GenerateCommitMessage",
+      "up": "git_panel::PrevCommitEditorHistoryItem",
+      "down": "git_panel::NextCommitEditorHistoryItem",
     },
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -1047,8 +1047,8 @@
       "alt-up": "git_panel::FocusChanges",
       "shift-escape": "git::ExpandCommitEditor",
       "alt-tab": "git::GenerateCommitMessage",
-      "up": "git_panel::PrevCommitEditorHistoryItem",
-      "down": "git_panel::NextCommitEditorHistoryItem",
+      "up": "git_panel::PrevCommitEditorHistoryEntry",
+      "down": "git_panel::NextCommitEditorHistoryEntry",
     },
   },
   {

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -1004,6 +1004,8 @@
       "ctrl-shift-enter": "git::Amend",
       "alt-up": "git_panel::FocusChanges",
       "alt-l": "git::GenerateCommitMessage",
+      "up": "git_panel::PrevCommitEditorHistoryItem",
+      "down": "git_panel::NextCommitEditorHistoryItem",
     },
   },
   {

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -1004,8 +1004,8 @@
       "ctrl-shift-enter": "git::Amend",
       "alt-up": "git_panel::FocusChanges",
       "alt-l": "git::GenerateCommitMessage",
-      "up": "git_panel::PrevCommitEditorHistoryItem",
-      "down": "git_panel::NextCommitEditorHistoryItem",
+      "up": "git_panel::PrevCommitEditorHistoryEntry",
+      "down": "git_panel::NextCommitEditorHistoryEntry",
     },
   },
   {

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -2263,6 +2263,7 @@ impl GitPanel {
             return false;
         }
     }
+    
     pub fn head_commit(&self, cx: &App) -> Option<CommitDetails> {
         self.active_repository
             .as_ref()
@@ -2385,6 +2386,8 @@ impl GitPanel {
             self.fill_co_authors(&mut message, cx);
         }
 
+        let commit_history_message = message.clone();
+
         let task = if self.has_staged_changes() {
             // Repository serializes all git operations, so we can just send a commit immediately
             let commit_task = active_repository.update(cx, |repo, cx| {
@@ -2422,7 +2425,7 @@ impl GitPanel {
 
                 match result {
                     Ok(()) => {
-                        this.add_commit_history_entry(cx);
+                        this.add_commit_history_entry(commit_history_message, cx);
 
                         if options.amend {
                             this.set_amend_pending(false, cx);
@@ -2441,10 +2444,8 @@ impl GitPanel {
         self.pending_commit = Some(task);
     }
 
-    fn add_commit_history_entry(&mut self, cx: &mut Context<Self>) {
-        // FIXME: if there is no text, add placeholder text to the commit history
-        self.commit_editor_history
-            .add_new_entry(self.commit_editor.read(cx).text(cx));
+    fn add_commit_history_entry(&mut self, commit_message: String, cx: &mut Context<Self>) {
+        self.commit_editor_history.add_new_entry(commit_message);
         self.serialize(cx);
         cx.notify();
     }

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -113,6 +113,10 @@ actions!(
         ExpandSelectedEntry,
         /// Collapses the selected entry to hide its children.
         CollapseSelectedEntry,
+        /// Next commit message editor history item
+        NextCommitEditorHistoryItem,
+        /// Previous commit message editor history item
+        PrevCommitEditorHistoryItem,
     ]
 );
 
@@ -2112,6 +2116,24 @@ impl GitPanel {
         if self.commit(&self.commit_editor.focus_handle(cx), window, cx) {
             telemetry::event!("Git Committed", source = "Git Panel");
         }
+    }
+
+    fn next_commit_editor_history_item(
+        &mut self,
+        _: &NextCommitEditorHistoryItem,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        log::info!("Next editor history item");
+    }
+
+    fn prev_commit_editor_history_item(
+        &mut self,
+        _: &PrevCommitEditorHistoryItem,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        log::info!("Previous editor history item");
     }
 
     /// Commits staged changes with the current commit message.
@@ -5620,6 +5642,8 @@ impl Render for GitPanel {
             })
             .on_action(cx.listener(Self::toggle_sort_by_path))
             .on_action(cx.listener(Self::toggle_tree_view))
+            .on_action(cx.listener(Self::next_commit_editor_history_item))
+            .on_action(cx.listener(Self::prev_commit_editor_history_item))
             .size_full()
             .overflow_hidden()
             .bg(cx.theme().colors().panel_background)

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -2,6 +2,7 @@ use crate::askpass_modal::AskPassModal;
 use crate::commit_modal::CommitModal;
 use crate::commit_tooltip::CommitTooltip;
 use crate::commit_view::CommitView;
+use crate::git_panel::commit_editor_history::SerializedCommitEditorHistory;
 use crate::project_diff::{self, BranchDiff, Diff, ProjectDiff};
 use crate::remote_output::{self, RemoteAction, SuccessMessage};
 use crate::{branch_picker, picker_prompt, render_remote_button};
@@ -14,12 +15,13 @@ use anyhow::Context as _;
 use askpass::AskPassDelegate;
 use cloud_llm_client::CompletionIntent;
 use collections::{BTreeMap, HashMap, HashSet};
+use commit_editor_history::CommitEditorHistory;
 use db::kvp::KEY_VALUE_STORE;
 use editor::{
     Direction, Editor, EditorElement, EditorMode, MultiBuffer, MultiBufferOffset,
     actions::ExpandAllDiffHunks,
 };
-use editor::{EditorStyle, RewrapOptions};
+use editor::{EditorEvent, EditorStyle, RewrapOptions};
 use futures::StreamExt as _;
 use git::commit::ParsedCommitMessage;
 use git::repository::{
@@ -41,7 +43,7 @@ use gpui::{
     WeakEntity, actions, anchored, deferred, point, size, uniform_list,
 };
 use itertools::Itertools;
-use language::{Buffer, BufferEvent, File};
+use language::{Buffer, File};
 use language_model::{
     ConfiguredModel, LanguageModelRegistry, LanguageModelRequest, LanguageModelRequestMessage, Role,
 };
@@ -79,6 +81,8 @@ use workspace::{
     dock::{DockPosition, Panel, PanelEvent},
     notifications::{DetachAndPromptErr, ErrorMessagePrompt, NotificationId, NotifyResultExt},
 };
+
+mod commit_editor_history;
 
 actions!(
     git_panel,
@@ -266,6 +270,8 @@ struct SerializedGitPanel {
     amend_pending: bool,
     #[serde(default)]
     signoff_enabled: bool,
+    #[serde(default)]
+    commit_editor_history: SerializedCommitEditorHistory,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
@@ -620,6 +626,7 @@ impl TruncatedPatch {
 pub struct GitPanel {
     pub(crate) active_repository: Option<Entity<Repository>>,
     pub(crate) commit_editor: Entity<Editor>,
+    pub(crate) commit_editor_history: CommitEditorHistory,
     conflicted_count: usize,
     conflicted_staged_count: usize,
     add_coauthors: bool,
@@ -659,7 +666,7 @@ pub struct GitPanel {
     stash_entries: GitStash,
 
     _settings_subscription: Subscription,
-    _commit_message_buffer_subscription: Subscription,
+    _commit_editor_subscription: Subscription,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -745,7 +752,7 @@ impl GitPanel {
             // just to let us render a placeholder editor.
             // Once the active git repo is set, this buffer will be replaced.
             let temporary_buffer = cx.new(|cx| Buffer::local("", cx));
-            let commit_editor = cx.new(|cx| {
+            let mut commit_editor = cx.new(|cx| {
                 commit_message_editor(temporary_buffer, None, project.clone(), true, window, cx)
             });
 
@@ -753,9 +760,8 @@ impl GitPanel {
                 editor.clear(window, cx);
             });
 
-            let mut commit_message_buffer = Self::commit_message_buffer_impl(&commit_editor, cx);
-            let _commit_message_buffer_subscription =
-                Self::subscribe_to_commit_message_buffer(&mut commit_message_buffer, window, cx);
+            let _commit_editor_subscription =
+                Self::subscribe_to_commit_editor(&mut commit_editor, window, cx);
 
             let scroll_handle = UniformListScrollHandle::new();
 
@@ -798,6 +804,7 @@ impl GitPanel {
             let mut this = Self {
                 active_repository,
                 commit_editor,
+                commit_editor_history: CommitEditorHistory::default(),
                 conflicted_count: 0,
                 conflicted_staged_count: 0,
                 add_coauthors: true,
@@ -836,7 +843,7 @@ impl GitPanel {
                 bulk_staging: None,
                 stash_entries: Default::default(),
                 _settings_subscription,
-                _commit_message_buffer_subscription,
+                _commit_editor_subscription,
             };
 
             this.schedule_update(window, cx);
@@ -922,6 +929,7 @@ impl GitPanel {
         let width = self.width;
         let amend_pending = self.amend_pending;
         let signoff_enabled = self.signoff_enabled;
+        let commit_editor_history = self.commit_editor_history.to_serialized();
 
         self.pending_serialization = cx.spawn(async move |git_panel, cx| {
             cx.background_executor()
@@ -949,6 +957,7 @@ impl GitPanel {
                                 width,
                                 amend_pending,
                                 signoff_enabled,
+                                commit_editor_history,
                             })?,
                         )
                         .await?;
@@ -2063,11 +2072,7 @@ impl GitPanel {
     }
 
     pub fn commit_message_buffer(&self, cx: &App) -> Entity<Buffer> {
-        Self::commit_message_buffer_impl(&self.commit_editor, cx)
-    }
-
-    fn commit_message_buffer_impl(commit_editor: &Entity<Editor>, cx: &App) -> Entity<Buffer> {
-        commit_editor
+        self.commit_editor
             .read(cx)
             .buffer()
             .read(cx)
@@ -2075,19 +2080,18 @@ impl GitPanel {
             .unwrap()
     }
 
-    fn subscribe_to_commit_message_buffer(
-        commit_message_buffer: &mut Entity<Buffer>,
+    fn subscribe_to_commit_editor(
+        commit_editor: &mut Entity<Editor>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Subscription {
         cx.subscribe_in(
-            &commit_message_buffer,
+            &commit_editor,
             window,
-            |this, _commit_message_buffer, event, _window, cx| match event {
-                BufferEvent::Edited { .. } => {
+            |this, _commit_editor, event, _window, cx| match event {
+                EditorEvent::Edited { .. } => {
                     let text = this.commit_editor.read(cx).text(cx);
-                    log::info!("Typed into commit editor: {}", text);
-                    // TODO: set this string as "pending edit" in commit history object
+                    this.commit_editor_history.set_pending_edit(text);
                 }
                 _ => {}
             },
@@ -2153,7 +2157,24 @@ impl GitPanel {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        log::info!("Next editor history item");
+        let buffer = self.commit_message_buffer(cx);
+
+        match self.commit_editor_history.next() {
+            Some(entry) => buffer.update(cx, |buffer, cx| buffer.set_text(entry, cx)),
+            None => {
+                if self.commit_editor_history.get_pending_edit().is_some() {
+                    buffer.update(cx, |buffer, cx| {
+                        buffer.set_text(
+                            self.commit_editor_history
+                                .get_pending_edit()
+                                .expect("Pending edit should be present"),
+                            cx,
+                        )
+                    });
+                }
+                None
+            }
+        };
     }
 
     fn prev_commit_editor_history_entry(
@@ -2162,7 +2183,12 @@ impl GitPanel {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        log::info!("Previous editor history item");
+        let buffer = self.commit_message_buffer(cx);
+
+        match self.commit_editor_history.prev() {
+            Some(entry) => buffer.update(cx, |buffer, cx| buffer.set_text(entry, cx)),
+            None => None,
+        };
     }
 
     /// Commits staged changes with the current commit message.
@@ -2396,6 +2422,9 @@ impl GitPanel {
 
                 match result {
                     Ok(()) => {
+                        this.commit_editor_history
+                            .add_new_entry(this.commit_editor.read(cx).text(cx));
+
                         if options.amend {
                             this.set_amend_pending(false, cx);
                         } else {
@@ -3523,12 +3552,8 @@ impl GitPanel {
                         )
                     });
 
-                    git_panel._commit_message_buffer_subscription =
-                        Self::subscribe_to_commit_message_buffer(
-                            &mut git_panel.commit_message_buffer(cx),
-                            window,
-                            cx,
-                        );
+                    git_panel._commit_editor_subscription =
+                        Self::subscribe_to_commit_editor(&mut git_panel.commit_editor, window, cx);
                 }
             })
         })
@@ -5550,6 +5575,9 @@ impl GitPanel {
                     panel.width = serialized_panel.width;
                     panel.amend_pending = serialized_panel.amend_pending;
                     panel.signoff_enabled = serialized_panel.signoff_enabled;
+                    panel.commit_editor_history = CommitEditorHistory::from_serialized(
+                        serialized_panel.commit_editor_history,
+                    );
                     cx.notify();
                 })
             }

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -2162,16 +2162,9 @@ impl GitPanel {
         match self.commit_editor_history.next() {
             Some(entry) => buffer.update(cx, |buffer, cx| buffer.set_text(entry, cx)),
             None => {
-                if self.commit_editor_history.get_pending_edit().is_some() {
-                    buffer.update(cx, |buffer, cx| {
-                        buffer.set_text(
-                            self.commit_editor_history
-                                .get_pending_edit()
-                                .expect("Pending edit should be present"),
-                            cx,
-                        )
-                    });
-                }
+                buffer.update(cx, |buffer, cx| {
+                    buffer.set_text(self.commit_editor_history.get_pending_edit(), cx)
+                });
                 None
             }
         };

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -41,7 +41,7 @@ use gpui::{
     WeakEntity, actions, anchored, deferred, point, size, uniform_list,
 };
 use itertools::Itertools;
-use language::{Buffer, File};
+use language::{Buffer, BufferEvent, File};
 use language_model::{
     ConfiguredModel, LanguageModelRegistry, LanguageModelRequest, LanguageModelRequestMessage, Role,
 };
@@ -659,6 +659,7 @@ pub struct GitPanel {
     stash_entries: GitStash,
 
     _settings_subscription: Subscription,
+    _commit_message_buffer_subscription: Subscription,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -752,6 +753,16 @@ impl GitPanel {
                 editor.clear(window, cx);
             });
 
+            let mut commit_message_buffer = commit_editor
+                .read(cx)
+                .buffer()
+                .read(cx)
+                .as_singleton()
+                .unwrap();
+
+            let _commit_message_buffer_subscription =
+                Self::subscribe_to_commit_message_buffer(&mut commit_message_buffer, window, cx);
+
             let scroll_handle = UniformListScrollHandle::new();
 
             let mut was_ai_enabled = AgentSettings::get_global(cx).enabled(cx);
@@ -831,6 +842,7 @@ impl GitPanel {
                 bulk_staging: None,
                 stash_entries: Default::default(),
                 _settings_subscription,
+                _commit_message_buffer_subscription,
             };
 
             this.schedule_update(window, cx);
@@ -2063,6 +2075,25 @@ impl GitPanel {
             .read(cx)
             .as_singleton()
             .unwrap()
+    }
+
+    fn subscribe_to_commit_message_buffer(
+        commit_message_buffer: &mut Entity<Buffer>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Subscription {
+        cx.subscribe_in(
+            &commit_message_buffer,
+            window,
+            |this, _commit_message_buffer, event, _window, cx| match event {
+                BufferEvent::Edited { .. } => {
+                    let text = this.commit_editor.read(cx).text(cx);
+                    log::info!("Typed into commit editor: {}", text);
+                    // TODO: set this string as "pending edit" in commit history object
+                }
+                _ => {}
+            },
+        )
     }
 
     fn toggle_staged_for_selected(
@@ -3493,6 +3524,13 @@ impl GitPanel {
                             cx,
                         )
                     });
+
+                    git_panel._commit_message_buffer_subscription =
+                        Self::subscribe_to_commit_message_buffer(
+                            &mut git_panel.commit_message_buffer(cx),
+                            window,
+                            cx,
+                        );
                 }
             })
         })

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -114,9 +114,9 @@ actions!(
         /// Collapses the selected entry to hide its children.
         CollapseSelectedEntry,
         /// Next commit message editor history item
-        NextCommitEditorHistoryItem,
+        NextCommitEditorHistoryEntry,
         /// Previous commit message editor history item
-        PrevCommitEditorHistoryItem,
+        PrevCommitEditorHistoryEntry,
     ]
 );
 
@@ -2147,19 +2147,19 @@ impl GitPanel {
         }
     }
 
-    fn next_commit_editor_history_item(
+    fn next_commit_editor_history_entry(
         &mut self,
-        _: &NextCommitEditorHistoryItem,
-        window: &mut Window,
+        _: &NextCommitEditorHistoryEntry,
+        _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         log::info!("Next editor history item");
     }
 
-    fn prev_commit_editor_history_item(
+    fn prev_commit_editor_history_entry(
         &mut self,
-        _: &PrevCommitEditorHistoryItem,
-        window: &mut Window,
+        _: &PrevCommitEditorHistoryEntry,
+        _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         log::info!("Previous editor history item");
@@ -5678,8 +5678,8 @@ impl Render for GitPanel {
             })
             .on_action(cx.listener(Self::toggle_sort_by_path))
             .on_action(cx.listener(Self::toggle_tree_view))
-            .on_action(cx.listener(Self::next_commit_editor_history_item))
-            .on_action(cx.listener(Self::prev_commit_editor_history_item))
+            .on_action(cx.listener(Self::next_commit_editor_history_entry))
+            .on_action(cx.listener(Self::prev_commit_editor_history_entry))
             .size_full()
             .overflow_hidden()
             .bg(cx.theme().colors().panel_background)

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -2256,7 +2256,7 @@ impl GitPanel {
             return false;
         }
     }
-    
+
     pub fn head_commit(&self, cx: &App) -> Option<CommitDetails> {
         self.active_repository
             .as_ref()
@@ -7870,5 +7870,123 @@ mod tests {
         // "Update tracked"
         let message = panel.update(cx, |panel, cx| panel.suggest_commit_message(cx));
         assert_eq!(message, Some("Update tracked".to_string()));
+    }
+
+    #[gpui::test]
+    async fn test_commit_editor_history_basic_navigation(cx: &mut TestAppContext) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.background_executor.clone());
+        fs.insert_tree(
+            "/root",
+            json!({
+                "project": {
+                    ".git": {},
+                    "src": {
+                        "main.rs": "fn main() {}"
+                    }
+                }
+            }),
+        )
+        .await;
+
+        fs.set_status_for_repo(
+            Path::new(path!("/root/project/.git")),
+            &[("src/main.rs", StatusCode::Modified.worktree())],
+        );
+
+        let project = Project::test(fs.clone(), [Path::new(path!("/root/project"))], cx).await;
+        let workspace =
+            cx.add_window(|window, cx| Workspace::test_new(project.clone(), window, cx));
+        let cx = &mut VisualTestContext::from_window(*workspace, cx);
+
+        let panel = workspace.update(cx, GitPanel::new).unwrap();
+
+        // Build up history by adding entries directly (not through buffer)
+        panel.update(cx, |panel, cx| {
+            panel.add_commit_history_entry("First commit message".to_string(), cx);
+            panel.add_commit_history_entry("Second commit message".to_string(), cx);
+            panel.add_commit_history_entry("Third commit message".to_string(), cx);
+        });
+
+        // Test first prev - should get the most recent (Third)
+        panel.update_in(cx, |panel, window, cx| {
+            panel.prev_commit_editor_history_entry(&PrevCommitEditorHistoryEntry, window, cx);
+        });
+        cx.run_until_parked();
+        panel.read_with(cx, |panel, cx| {
+            assert_eq!(
+                panel.commit_message_buffer(cx).read(cx).text(),
+                "Third commit message"
+            );
+        });
+
+        // Test second prev - should get Second
+        panel.update_in(cx, |panel, window, cx| {
+            panel.prev_commit_editor_history_entry(&PrevCommitEditorHistoryEntry, window, cx);
+        });
+        cx.run_until_parked();
+        panel.read_with(cx, |panel, cx| {
+            assert_eq!(
+                panel.commit_message_buffer(cx).read(cx).text(),
+                "Second commit message"
+            );
+        });
+
+        // Test third prev - should get First
+        panel.update_in(cx, |panel, window, cx| {
+            panel.prev_commit_editor_history_entry(&PrevCommitEditorHistoryEntry, window, cx);
+        });
+        cx.run_until_parked();
+        panel.read_with(cx, |panel, cx| {
+            assert_eq!(
+                panel.commit_message_buffer(cx).read(cx).text(),
+                "First commit message"
+            );
+        });
+
+        // Test prev at end - should stay at First
+        panel.update_in(cx, |panel, window, cx| {
+            panel.prev_commit_editor_history_entry(&PrevCommitEditorHistoryEntry, window, cx);
+        });
+        cx.run_until_parked();
+        panel.read_with(cx, |panel, cx| {
+            assert_eq!(
+                panel.commit_message_buffer(cx).read(cx).text(),
+                "First commit message"
+            );
+        });
+
+        // Test first next - should get Second
+        panel.update_in(cx, |panel, window, cx| {
+            panel.next_commit_editor_history_entry(&NextCommitEditorHistoryEntry, window, cx);
+        });
+        cx.run_until_parked();
+        panel.read_with(cx, |panel, cx| {
+            assert_eq!(
+                panel.commit_message_buffer(cx).read(cx).text(),
+                "Second commit message"
+            );
+        });
+
+        // Test second next - should get Third
+        panel.update_in(cx, |panel, window, cx| {
+            panel.next_commit_editor_history_entry(&NextCommitEditorHistoryEntry, window, cx);
+        });
+        cx.run_until_parked();
+        panel.read_with(cx, |panel, cx| {
+            assert_eq!(
+                panel.commit_message_buffer(cx).read(cx).text(),
+                "Third commit message"
+            );
+        });
+
+        // Test next at beginning - should return to pending edit (empty)
+        panel.update_in(cx, |panel, window, cx| {
+            panel.next_commit_editor_history_entry(&NextCommitEditorHistoryEntry, window, cx);
+        });
+        cx.run_until_parked();
+        panel.read_with(cx, |panel, cx| {
+            assert_eq!(panel.commit_message_buffer(cx).read(cx).text(), "");
+        });
     }
 }

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -753,13 +753,7 @@ impl GitPanel {
                 editor.clear(window, cx);
             });
 
-            let mut commit_message_buffer = commit_editor
-                .read(cx)
-                .buffer()
-                .read(cx)
-                .as_singleton()
-                .unwrap();
-
+            let mut commit_message_buffer = Self::commit_message_buffer_impl(&commit_editor, cx);
             let _commit_message_buffer_subscription =
                 Self::subscribe_to_commit_message_buffer(&mut commit_message_buffer, window, cx);
 
@@ -2069,7 +2063,11 @@ impl GitPanel {
     }
 
     pub fn commit_message_buffer(&self, cx: &App) -> Entity<Buffer> {
-        self.commit_editor
+        Self::commit_message_buffer_impl(&self.commit_editor, cx)
+    }
+
+    fn commit_message_buffer_impl(commit_editor: &Entity<Editor>, cx: &App) -> Entity<Buffer> {
+        commit_editor
             .read(cx)
             .buffer()
             .read(cx)

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -2422,8 +2422,7 @@ impl GitPanel {
 
                 match result {
                     Ok(()) => {
-                        this.commit_editor_history
-                            .add_new_entry(this.commit_editor.read(cx).text(cx));
+                        this.add_commit_history_entry(cx);
 
                         if options.amend {
                             this.set_amend_pending(false, cx);
@@ -2440,6 +2439,14 @@ impl GitPanel {
         });
 
         self.pending_commit = Some(task);
+    }
+
+    fn add_commit_history_entry(&mut self, cx: &mut Context<Self>) {
+        // FIXME: if there is no text, add placeholder text to the commit history
+        self.commit_editor_history
+            .add_new_entry(self.commit_editor.read(cx).text(cx));
+        self.serialize(cx);
+        cx.notify();
     }
 
     pub(crate) fn uncommit(&mut self, window: &mut Window, cx: &mut Context<Self>) {

--- a/crates/git_ui/src/git_panel/commit_editor_history.rs
+++ b/crates/git_ui/src/git_panel/commit_editor_history.rs
@@ -12,7 +12,7 @@ pub(crate) struct SerializedCommitEditorHistory {
 pub(crate) struct CommitEditorHistory {
     entries: VecDeque<String>,
     cursor: Option<usize>, // index into entries VecDeque (0..len-1), the greater the index, the older is an item; None means pointing before the first entry
-    pending_edit: Option<String>,
+    pending_edit: String,
 }
 
 impl CommitEditorHistory {
@@ -85,12 +85,12 @@ impl CommitEditorHistory {
         }
     }
 
-    pub fn get_pending_edit(&self) -> Option<&str> {
-        self.pending_edit.as_deref()
+    pub fn get_pending_edit(&self) -> &str {
+        self.pending_edit.as_str()
     }
 
     pub fn set_pending_edit(&mut self, message: String) {
-        self.pending_edit = Some(message);
+        self.pending_edit = message;
         self.cursor = None;
     }
 

--- a/crates/git_ui/src/git_panel/commit_editor_history.rs
+++ b/crates/git_ui/src/git_panel/commit_editor_history.rs
@@ -35,7 +35,7 @@ impl CommitEditorHistory {
             self.entries.truncate(MAX_HISTORY);
         }
 
-        self.cursor = Some(0usize); // reset navigation state
+        self.cursor = None;
     }
 
     pub fn prev(&mut self) -> Option<&str> {

--- a/crates/git_ui/src/git_panel/commit_editor_history.rs
+++ b/crates/git_ui/src/git_panel/commit_editor_history.rs
@@ -16,11 +16,6 @@ pub(crate) struct CommitEditorHistory {
 }
 
 impl CommitEditorHistory {
-    pub fn entries(&self) -> impl Iterator<Item = &String> {
-        self.entries.iter()
-    }
-
-    // TODO: add 2nd param, String, taked from the editor text upon commit_changes
     pub fn add_new_entry(&mut self, message: String) {
         // not checking for an empty message - relying on the commit editor not letting it through
 

--- a/crates/git_ui/src/git_panel/commit_editor_history.rs
+++ b/crates/git_ui/src/git_panel/commit_editor_history.rs
@@ -1,0 +1,117 @@
+use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
+
+const MAX_HISTORY: usize = 50;
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub(crate) struct SerializedCommitEditorHistory {
+    entries: Vec<String>,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct CommitEditorHistory {
+    entries: VecDeque<String>,
+    cursor: Option<usize>, // index into entries VecDeque (0..len-1), the greater the index, the older is an item; None means pointing before the first entry
+    pending_edit: Option<String>,
+}
+
+impl CommitEditorHistory {
+    pub fn entries(&self) -> impl Iterator<Item = &String> {
+        self.entries.iter()
+    }
+
+    // TODO: add 2nd param, String, taked from the editor text upon commit_changes
+    pub fn add_new_entry(&mut self, message: String) {
+        // not checking for an empty message - relying on the commit editor not letting it through
+
+        // remove any exact duplicate
+        if let Some(pos) = self.entries.iter().position(|m| m == &message) {
+            self.entries.remove(pos);
+        }
+
+        self.entries.push_front(message);
+
+        while self.entries.len() > MAX_HISTORY {
+            self.entries.truncate(MAX_HISTORY);
+        }
+
+        self.cursor = Some(0usize); // reset navigation state
+    }
+
+    pub fn prev(&mut self) -> Option<&str> {
+        match self.cursor {
+            Some(cursor) => {
+                if cursor < self.entries.len() - 1 {
+                    self.cursor = Some(cursor + 1);
+                } else {
+                    return None;
+                }
+            }
+            None => {
+                if self.entries.is_empty() {
+                    return None;
+                } else {
+                    self.cursor = Some(0usize);
+                }
+            }
+        }
+
+        return self
+            .entries
+            .get(
+                self.cursor
+                    .expect("History must contain at least one entry"),
+            )
+            .map(|s| s.as_str());
+    }
+
+    pub fn next(&mut self) -> Option<&str> {
+        match self.cursor {
+            Some(cursor) => {
+                if cursor > 0 {
+                    self.cursor = Some(cursor - 1);
+                    self.entries
+                        .get(
+                            self.cursor
+                                .expect("History must contain at least one entry"),
+                        )
+                        .map(|s| s.as_str())
+                } else {
+                    self.cursor = None;
+                    None
+                }
+            }
+            None => None,
+        }
+    }
+
+    pub fn get_pending_edit(&self) -> Option<&str> {
+        self.pending_edit.as_deref()
+    }
+
+    pub fn set_pending_edit(&mut self, message: String) {
+        self.pending_edit = Some(message);
+        self.cursor = None;
+    }
+
+    pub fn to_serialized(&self) -> SerializedCommitEditorHistory {
+        let mut entries = Vec::with_capacity(MAX_HISTORY);
+        let (front, back) = self.entries.as_slices();
+        entries.extend_from_slice(front);
+        entries.extend_from_slice(back);
+
+        SerializedCommitEditorHistory { entries }
+    }
+
+    pub fn from_serialized(serialized: SerializedCommitEditorHistory) -> Self {
+        Self {
+            entries: VecDeque::from_iter(serialized.entries),
+            ..Default::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+   // TODO: add tests 
+}

--- a/crates/git_ui/src/git_panel/commit_editor_history.rs
+++ b/crates/git_ui/src/git_panel/commit_editor_history.rs
@@ -17,7 +17,9 @@ pub(crate) struct CommitEditorHistory {
 
 impl CommitEditorHistory {
     pub fn add_new_entry(&mut self, message: String) {
-        // not checking for an empty message - relying on the commit editor not letting it through
+        if message.is_empty() {
+            panic!("Empty commit message is not allowed in commit history"); // relying on "commit changes" checks logic
+        }
 
         // remove any exact duplicate
         if let Some(pos) = self.entries.iter().position(|m| m == &message) {
@@ -108,5 +110,291 @@ impl CommitEditorHistory {
 
 #[cfg(test)]
 mod tests {
-   // TODO: add tests 
+    use super::*;
+
+    #[test]
+    fn test_new_history_is_empty() {
+        let history = CommitEditorHistory::default();
+        assert_eq!(history.entries.len(), 0);
+        assert!(history.cursor.is_none());
+        assert_eq!(history.pending_edit, "");
+    }
+
+    #[test]
+    fn test_max_history_limit() {
+        let mut history = CommitEditorHistory::default();
+
+        // Add more than MAX_HISTORY entries
+        for i in 0..60 {
+            history.add_new_entry(format!("Commit {}", i));
+        }
+
+        assert_eq!(history.entries.len(), MAX_HISTORY);
+        assert_eq!(history.entries[0], "Commit 59");
+        assert_eq!(history.entries[MAX_HISTORY - 1], "Commit 10");
+    }
+
+    #[test]
+    fn test_prev_on_empty_history() {
+        let mut history = CommitEditorHistory::default();
+        assert!(history.prev().is_none());
+        assert!(history.cursor.is_none());
+    }
+
+    #[test]
+    fn test_prev_navigates_through_history() {
+        let mut history = CommitEditorHistory::default();
+        history.add_new_entry("First".to_string());
+        history.add_new_entry("Second".to_string());
+        history.add_new_entry("Third".to_string());
+
+        assert_eq!(history.prev(), Some("Third"));
+        assert_eq!(history.cursor, Some(0));
+
+        assert_eq!(history.prev(), Some("Second"));
+        assert_eq!(history.cursor, Some(1));
+
+        assert_eq!(history.prev(), Some("First"));
+        assert_eq!(history.cursor, Some(2));
+    }
+
+    #[test]
+    fn test_prev_at_end_of_history() {
+        let mut history = CommitEditorHistory::default();
+        history.add_new_entry("First".to_string());
+        history.add_new_entry("Second".to_string());
+
+        history.prev();
+        history.prev();
+
+        // Try to go past the end
+        assert!(history.prev().is_none());
+        assert_eq!(history.cursor, Some(1)); // Cursor should not change
+    }
+
+    #[test]
+    fn test_next_on_empty_history() {
+        let mut history = CommitEditorHistory::default();
+        assert!(history.next().is_none());
+        assert!(history.cursor.is_none());
+    }
+
+    #[test]
+    fn test_next_beyond_beginning() {
+        let mut history = CommitEditorHistory::default();
+        history.add_new_entry("First".to_string());
+        history.add_new_entry("Second".to_string());
+
+        assert!(history.next().is_none());
+        assert!(history.cursor.is_none());
+    }
+
+    #[test]
+    fn test_next_navigates_forward() {
+        let mut history = CommitEditorHistory::default();
+        history.add_new_entry("First".to_string());
+        history.add_new_entry("Second".to_string());
+        history.add_new_entry("Third".to_string());
+
+        history.prev();
+        history.prev();
+        history.prev();
+
+        assert_eq!(history.next(), Some("Second"));
+        assert_eq!(history.cursor, Some(1));
+
+        assert_eq!(history.next(), Some("Third"));
+        assert_eq!(history.cursor, Some(0));
+    }
+
+    #[test]
+    fn test_next_returns_to_beginning() {
+        let mut history = CommitEditorHistory::default();
+        history.add_new_entry("First".to_string());
+        history.add_new_entry("Second".to_string());
+
+        history.prev();
+        history.prev();
+
+        history.next();
+        assert_eq!(history.next(), None);
+        assert!(history.cursor.is_none());
+    }
+
+    #[test]
+    fn test_prev_next_combination() {
+        let mut history = CommitEditorHistory::default();
+        history.add_new_entry("A".to_string());
+        history.add_new_entry("B".to_string());
+        history.add_new_entry("C".to_string());
+
+        assert_eq!(history.prev(), Some("C"));
+        assert_eq!(history.prev(), Some("B"));
+        assert_eq!(history.next(), Some("C"));
+        assert_eq!(history.prev(), Some("B"));
+        assert_eq!(history.prev(), Some("A"));
+        assert_eq!(history.next(), Some("B"));
+        assert_eq!(history.next(), Some("C"));
+        assert_eq!(history.next(), None);
+    }
+
+    #[test]
+    fn test_single_entry_navigation() {
+        let mut history = CommitEditorHistory::default();
+        history.add_new_entry("Only entry".to_string());
+
+        assert_eq!(history.prev(), Some("Only entry"));
+        assert!(history.prev().is_none()); // Can't go further
+        assert_eq!(history.next(), None); // Back to start
+        assert!(history.next().is_none()); // Already at start
+    }
+    #[test]
+    fn test_pending_edit_default() {
+        let history = CommitEditorHistory::default();
+        assert_eq!(history.get_pending_edit(), "");
+    }
+
+    #[test]
+    fn test_set_and_get_pending_edit() {
+        let mut history = CommitEditorHistory::default();
+        history.set_pending_edit("Work in progress".to_string());
+
+        assert_eq!(history.get_pending_edit(), "Work in progress");
+    }
+
+    #[test]
+    fn test_set_pending_edit_resets_cursor() {
+        let mut history = CommitEditorHistory::default();
+        history.add_new_entry("First".to_string());
+        history.add_new_entry("Second".to_string());
+
+        history.prev();
+        assert_eq!(history.cursor, Some(0));
+
+        history.set_pending_edit("New edit".to_string());
+        assert!(history.cursor.is_none());
+    }
+
+    #[test]
+    #[should_panic(expected = "Empty commit message is not allowed in commit history")]
+    fn test_add_empty_message_panics() {
+        let mut history = CommitEditorHistory::default();
+        history.add_new_entry("".to_string());
+    }
+
+    #[test]
+    fn test_add_multiple_entries() {
+        let mut history = CommitEditorHistory::default();
+        history.add_new_entry("First commit".to_string());
+        history.add_new_entry("Second commit".to_string());
+        history.add_new_entry("Third commit".to_string());
+
+        assert_eq!(history.entries.len(), 3);
+        assert_eq!(history.entries[0], "Third commit");
+        assert_eq!(history.entries[1], "Second commit");
+        assert_eq!(history.entries[2], "First commit");
+    }
+
+    #[test]
+    fn test_add_duplicate_removes_old_entry() {
+        let mut history = CommitEditorHistory::default();
+        history.add_new_entry("First commit".to_string());
+        history.add_new_entry("Second commit".to_string());
+        history.add_new_entry("Third commit".to_string());
+        history.add_new_entry("Second commit".to_string());
+
+        assert_eq!(history.entries.len(), 3);
+        assert_eq!(history.entries[0], "Second commit");
+        assert_eq!(history.entries[1], "Third commit");
+        assert_eq!(history.entries[2], "First commit");
+    }
+    #[test]
+    fn test_add_new_entry_resets_cursor() {
+        let mut history = CommitEditorHistory::default();
+        history.add_new_entry("First".to_string());
+        history.add_new_entry("Second".to_string());
+
+        history.prev();
+        assert_eq!(history.cursor, Some(0));
+
+        history.add_new_entry("Third".to_string());
+        assert!(history.cursor.is_none());
+    }
+
+    #[test]
+    fn test_navigation_after_add() {
+        let mut history = CommitEditorHistory::default();
+        history.add_new_entry("First".to_string());
+
+        history.prev();
+        assert_eq!(history.cursor, Some(0));
+
+        // Adding new entry should reset cursor
+        history.add_new_entry("Second".to_string());
+        assert!(history.cursor.is_none());
+
+        // Should be able to navigate again
+        assert_eq!(history.prev(), Some("Second"));
+    }
+    #[test]
+    fn test_serialization_with_entries() {
+        let mut history = CommitEditorHistory::default();
+        history.add_new_entry("First".to_string());
+        history.add_new_entry("Second".to_string());
+        history.add_new_entry("Third".to_string());
+
+        let serialized = history.to_serialized();
+
+        assert_eq!(serialized.entries.len(), 3);
+        assert_eq!(serialized.entries[0], "Third");
+        assert_eq!(serialized.entries[1], "Second");
+        assert_eq!(serialized.entries[2], "First");
+    }
+
+    #[test]
+    fn test_deserialization_empty() {
+        let serialized = SerializedCommitEditorHistory { entries: vec![] };
+
+        let history = CommitEditorHistory::from_serialized(serialized);
+
+        assert_eq!(history.entries.len(), 0);
+        assert!(history.cursor.is_none());
+        assert_eq!(history.pending_edit, "");
+    }
+
+    #[test]
+    fn test_deserialization_with_entries() {
+        let serialized = SerializedCommitEditorHistory {
+            entries: vec![
+                "Third".to_string(),
+                "Second".to_string(),
+                "First".to_string(),
+            ],
+        };
+
+        let history = CommitEditorHistory::from_serialized(serialized);
+
+        assert_eq!(history.entries.len(), 3);
+        assert_eq!(history.entries[0], "Third");
+        assert_eq!(history.entries[1], "Second");
+        assert_eq!(history.entries[2], "First");
+        assert!(history.cursor.is_none());
+        assert_eq!(history.pending_edit, "");
+    }
+
+    #[test]
+    fn test_round_trip_serialization() {
+        let mut history = CommitEditorHistory::default();
+        history.add_new_entry("Message 1".to_string());
+        history.add_new_entry("Message 2".to_string());
+        history.add_new_entry("Message 3".to_string());
+
+        let serialized = history.to_serialized();
+        let deserialized = CommitEditorHistory::from_serialized(serialized);
+
+        assert_eq!(history.entries.len(), deserialized.entries.len());
+        for (i, entry) in history.entries.iter().enumerate() {
+            assert_eq!(entry, &deserialized.entries[i]);
+        }
+    }
 }


### PR DESCRIPTION
Implements https://github.com/zed-industries/zed/discussions/29084

Release Notes:

- Add the commit message editor history holding 50 last commit messages
- Enable commit message history navigation with actions `git_panel::PrevCommitEditorHistoryEntry` and `git_panel::NextCommitEditorHistoryEntry` (like [in VS Code](https://code.visualstudio.com/docs/sourcecontrol/staging-commits#:~:text=To%20cycle%20through%20your%20previous%20commit%20messages%2C%20press%20%E2%86%91%20and%20%E2%86%93%20while%20focused%20in%20the%20commit%20message%20input%20box.))

Demo:

https://github.com/user-attachments/assets/c85614fd-247f-414c-a239-c3abe8e1f602
