### PR TITLE
languages: Remove duplicate keywords in TSX syntax highlighting

### DIFF
--- a/crates/languages/src/tsx/highlights.scm
+++ b/crates/languages/src/tsx/highlights.scm
@@ -262,6 +262,7 @@
   ] @operator
 )
 
+; Keywords
 [
   "abstract"
   "as"
@@ -383,24 +384,7 @@
     ":"
   ]) @punctuation.special)
 
-; Keywords
 
-[ "abstract"
-  "declare"
-  "enum"
-  "export"
-  "implements"
-  "interface"
-  "keyof"
-  "module"
-  "namespace"
-  "private"
-  "protected"
-  "public"
-  "type"
-  "readonly"
-  "override"
-] @keyword
 
 (jsx_opening_element
   [


### PR DESCRIPTION
Closes #48178

Release Notes:

- Fixed issue where certain keywords were incorrectly highlighted in TSX files
