### PR TITLE
extension_api: Improve documentation for `make_file_executable`

### DIFF
--- a/crates/extension_api/wit/since_v0.8.0/extension.wit
+++ b/crates/extension_api/wit/since_v0.8.0/extension.wit
@@ -57,6 +57,8 @@ world extension {
     import download-file: func(url: string, file-path: string, file-type: downloaded-file-type) -> result<_, string>;
 
     /// Makes the file at the given path executable.
+    ///
+    /// This is a no-op on Windows.
     import make-file-executable: func(filepath: string) -> result<_, string>;
 
     /// Updates the installation status for the given language server.


### PR DESCRIPTION
Extension authors frequently guard this method in their extensions although this is not necessary. 

Thus, this PR updates the documentation of `make_file_executable` with a brief mention to indicate that this is not needed.

Release Notes:

- N/A 
