### PR TITLE
languages: Highlight case statements and special variables for Shell Scripts

### DIFF
--- a/crates/languages/src/bash/highlights.scm
+++ b/crates/languages/src/bash/highlights.scm
@@ -104,3 +104,6 @@
   (command (_) @constant)
   (#match? @constant "^-")
 )
+
+(case_item value: (_) @string.regex)
+(special_variable_name) @variable.special


### PR DESCRIPTION
Part of https://github.com/zed-industries/zed/issues/9461. Similar PRs:
- https://github.com/zed-industries/zed/pull/46722
- https://github.com/zed-industries/zed/pull/39683
- https://github.com/zed-industries/zed/pull/39801


## Release Notes:

- Allowed highlighting for case statement items for users and theme authors via the `string.regex` syntax property.
- Allowed highlighting for special variables via `variable.special`

## Screenshots

| **Before** | **After** |
|:--:|:--:|
| <img width="727" height="922" alt="image" src="https://github.com/user-attachments/assets/15126713-1f02-40f2-8115-0deb5476aebd" /> | <img width="742" height="900" alt="image" src="https://github.com/user-attachments/assets/e178934e-5735-448d-abb2-2d2ad08a9c8f" /> |
