### PR TITLE
agent_thread: Improve wording of confirmation label text in agent thread

### DIFF
--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -7678,7 +7678,7 @@ impl AcpServerView {
                     )
                     .child(
                         div().min_w(rems(8.)).child(
-                            LoadingLabel::new("Waiting Confirmation")
+                            LoadingLabel::new("Awaiting Confirmation")
                                 .size(LabelSize::Small)
                                 .color(Color::Muted),
                         ),


### PR DESCRIPTION
Waiting is usually followed by “for,” which would make the label too wordy. Awaiting is transitive and requires a direct object, in this case your confirmation.

Really not a crazy change, but something that has been bothering me for quite some time now. 😅

Release Notes:

- Improved wording of confirmation label text in agent thread
