### PR TITLE
toolchain: Include rust-src in the rust-toolchain components

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,7 @@
 [toolchain]
 channel = "1.93"
 profile = "minimal"
-components = [ "rustfmt", "clippy", "rust-analyzer" ]
+components = [ "rustfmt", "clippy", "rust-analyzer", "rust-src" ]
 targets = [
     "wasm32-wasip2", # extensions
     "x86_64-unknown-linux-musl", # remote server


### PR DESCRIPTION
Follow-up to #45321, which made it so that rust-analyzer is installed via the flake/toolchain.

Fixes `rust-analyzer` on nix. Without the `rust-src` included in the toolchain components, the toolchain-provided rust-analyzer can't analyze proc macros and gives you all sorts of crazy errors due to it doing its best, but resolving methods incorrectly. 

This is it thinking that the `update` method is the one from `itertools`:
<img width="1033" height="213" alt="2026-02-02-145320_1033x213_scrot" src="https://github.com/user-attachments/assets/23d727b0-6da6-4d04-a84e-38d763f9899d" />

I've got almost 500 of these errors :sweat_smile: 

This is rust-analyzer's "root" complaint:
```
Workspace `/home/josh/src/github.com/jrobsonchase/zed/Cargo.toml` has sysroot errors: can't load standard library from sysroot
/nix/store/bihjplqidw9x156qzp44pm0y1ag9x2d8-rust-minimal-1.93.0
(discovered via `rustc --print sysroot`)
try installing `rust-src` the same way you installed `rustc`
```

Release Notes:

- N/A
