### PR TITLE
Revert "rust: Highlight enum variants as variant"

### DIFF
--- a/crates/languages/src/rust.rs
+++ b/crates/languages/src/rust.rs
@@ -1807,7 +1807,6 @@ mod tests {
             ("keyword", Hsla::default()),
             ("function", Hsla::default()),
             ("property", Hsla::default()),
-            ("variant", Hsla::default()),
         ]);
 
         language.set_theme(&theme);
@@ -1815,7 +1814,6 @@ mod tests {
         let highlight_function = grammar.highlight_id_for_name("function").unwrap();
         let highlight_type = grammar.highlight_id_for_name("type").unwrap();
         let highlight_keyword = grammar.highlight_id_for_name("keyword").unwrap();
-        let highlight_variant = grammar.highlight_id_for_name("variant").unwrap();
 
         assert_eq!(
             adapter
@@ -1857,7 +1855,7 @@ mod tests {
             Some(CodeLabel::new(
                 "Variant".to_string(),
                 0..7,
-                vec![(0..7, highlight_variant)],
+                vec![(0..7, highlight_type)],
             ))
         );
     }

--- a/crates/languages/src/rust/highlights.scm
+++ b/crates/languages/src/rust/highlights.scm
@@ -58,7 +58,7 @@
  (#match? @constant "^_*[A-Z][A-Z\\d_]*$"))
 
 ; Ensure enum variants are highlighted correctly regardless of naming convention
-(enum_variant name: (identifier) @variant)
+(enum_variant name: (identifier) @type)
 
 [
   "("


### PR DESCRIPTION
Reverts zed-industries/zed#47918

Rationale: https://github.com/zed-industries/zed/pull/47918#issuecomment-3837291864

Release Notes:

- Reverted #47918