### PR TITLE
repl: Fix cursor visibility on last line after re-running cells

### DIFF
--- a/crates/repl/src/session.rs
+++ b/crates/repl/src/session.rs
@@ -93,9 +93,14 @@ impl EditorBlock {
                 });
             }
 
-            let invalidation_anchor = buffer.read(cx).read(cx).anchor_before(next_row_start);
+            // Re-read snapshot after potential buffer edit and create a fresh anchor for
+            // block placement. Using anchor_before (Bias::Left) ensures the anchor stays
+            // at the end of the code line regardless of whether we inserted a newline.
+            let buffer_snapshot = buffer.read(cx).snapshot(cx);
+            let block_placement_anchor = buffer_snapshot.anchor_before(end_point);
+            let invalidation_anchor = buffer_snapshot.anchor_before(next_row_start);
             let block = BlockProperties {
-                placement: BlockPlacement::Below(code_range.end),
+                placement: BlockPlacement::Below(block_placement_anchor),
                 // Take up at least one height for status, allow the editor to determine the real height based on the content from render
                 height: Some(1),
                 style: BlockStyle::Sticky,


### PR DESCRIPTION

- This also sends the cursor to block placement anchor which is the standard thing to happen when we run cmd/ctrl + shift + enter, this is usually used for Run and Move onto next cell.
- Perhaps  the ability to stay on the same code will be tackled on further works where not using the shift modifier would signify stay and "just" run the cell. Like #46868 

Closes #48069

Release Notes:

- Fixed cursor becoming invisible on the last line of REPL cells after re-running

