### PR TITLE
ci: Move more jobs to Namespace runners

### DIFF
--- a/.github/workflows/add_commented_closed_issue_to_project.yml
+++ b/.github/workflows/add_commented_closed_issue_to_project.yml
@@ -17,7 +17,7 @@ jobs:
       github.event.issue.type != null &&
       github.event.issue.type.name == 'Bug' &&
       github.event.comment.user.type != 'Bot'
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-2x4-ubuntu-2404
     timeout-minutes: 5
     steps:
       - id: get-app-token

--- a/.github/workflows/catch_blank_issues.yml
+++ b/.github/workflows/catch_blank_issues.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   add-triage-label:
     if: github.repository == 'zed-industries/zed'
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-2x4-ubuntu-2404
     timeout-minutes: 5
     steps:
       - id: get-app-token

--- a/.github/workflows/community_champion_auto_labeler.yml
+++ b/.github/workflows/community_champion_auto_labeler.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   label_community_champion:
     if: github.repository_owner == 'zed-industries'
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-2x4-ubuntu-2404
     steps:
       - name: Check if author is a community champion and apply label
         uses: actions/github-script@v7

--- a/.github/workflows/community_close_stale_issues.yml
+++ b/.github/workflows/community_close_stale_issues.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   stale:
     if: github.repository_owner == 'zed-industries'
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-2x4-ubuntu-2404
     steps:
       - uses: actions/stale@997185467fa4f803885201cee163a9f38240193d # v10
         with:

--- a/.github/workflows/community_update_all_top_ranking_issues.yml
+++ b/.github/workflows/community_update_all_top_ranking_issues.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   update_top_ranking_issues:
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-2x4-ubuntu-2404
     if: github.repository == 'zed-industries/zed'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/community_update_weekly_top_ranking_issues.yml
+++ b/.github/workflows/community_update_weekly_top_ranking_issues.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   update_top_ranking_issues:
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-2x4-ubuntu-2404
     if: github.repository == 'zed-industries/zed'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/congrats.yml
+++ b/.github/workflows/congrats.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   check-author:
     if: ${{ github.repository_owner == 'zed-industries' }}
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-2x4-ubuntu-2404
     outputs:
       should_congratulate: ${{ steps.check.outputs.should_congratulate }}
     steps:

--- a/.github/workflows/docs_automation.yml
+++ b/.github/workflows/docs_automation.yml
@@ -9,11 +9,11 @@ on:
   workflow_dispatch:
     inputs:
       pr_number:
-        description: 'PR number to analyze (gets full PR diff)'
+        description: "PR number to analyze (gets full PR diff)"
         required: false
         type: string
       trigger_sha:
-        description: 'Commit SHA to analyze (ignored if pr_number is set)'
+        description: "Commit SHA to analyze (ignored if pr_number is set)"
         required: false
         type: string
 
@@ -27,7 +27,7 @@ env:
 
 jobs:
   docs-automation:
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-8x32-ubuntu-2404
     timeout-minutes: 30
 
     steps:
@@ -48,7 +48,7 @@ jobs:
       - name: Setup Node.js (for Prettier)
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: "20"
 
       - name: Install Prettier
         run: npm install -g prettier

--- a/.github/workflows/first_contribution_labeler.yml
+++ b/.github/workflows/first_contribution_labeler.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   label_first_contribution:
     if: github.repository == 'zed-industries/zed'
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-2x4-ubuntu-2404
     timeout-minutes: 5
     steps:
       - id: get-app-token

--- a/.github/workflows/good_first_issue_notifier.yml
+++ b/.github/workflows/good_first_issue_notifier.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   handle-good-first-issue:
     if: github.event.label.name == '.contrib/good first issue' && github.repository_owner == 'zed-industries'
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-2x4-ubuntu-2404
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/slack_notify_first_responders.yml
+++ b/.github/workflows/slack_notify_first_responders.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   notify-slack:
     if: github.repository_owner == 'zed-industries'
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-2x4-ubuntu-2404
 
     steps:
       - name: Check if label requires first responder notification


### PR DESCRIPTION
This moves some more of our CI jobs over to xtask and gh-workflow. This primarily originated from the current GitHub actions outage to move these actions over to Namespace runners. However, while I was at it I decided to move these over to gh_workflow, as we benefit from sharing more stuff across these files and less hacking around in YAML-files directly.

Release Notes:

- N/A