### PR TITLE
Use remote user from devcontainer CLI and respect shell in passwd

### DIFF
--- a/crates/dev_container/src/devcontainer_api.rs
+++ b/crates/dev_container/src/devcontainer_api.rs
@@ -19,7 +19,7 @@ use crate::{DevContainerFeature, DevContainerSettings, DevContainerTemplate};
 struct DevContainerUp {
     _outcome: String,
     container_id: String,
-    _remote_user: String,
+    remote_user: String,
     remote_workspace_folder: String,
 }
 
@@ -156,6 +156,7 @@ pub async fn start_dev_container(
         Ok(DevContainerUp {
             container_id,
             remote_workspace_folder,
+            remote_user,
             ..
         }) => {
             let project_name = match devcontainer_read_configuration(
@@ -180,6 +181,7 @@ pub async fn start_dev_container(
                 name: project_name,
                 container_id: container_id,
                 use_podman,
+                remote_user,
             };
 
             Ok((connection, remote_workspace_folder))
@@ -563,7 +565,7 @@ mod tests {
             up.container_id,
             "826abcac45afd412abff083ab30793daff2f3c8ce2c831df728baf39933cb37a"
         );
-        assert_eq!(up._remote_user, "vscode");
+        assert_eq!(up.remote_user, "vscode");
         assert_eq!(up.remote_workspace_folder, "/workspaces/zed");
 
         let json_in_plaintext = r#"[2026-01-22T16:19:08.802Z] @devcontainers/cli 0.80.1. Node.js v22.21.1. darwin 24.6.0 arm64.
@@ -574,7 +576,7 @@ mod tests {
             up.container_id,
             "826abcac45afd412abff083ab30793daff2f3c8ce2c831df728baf39933cb37a"
         );
-        assert_eq!(up._remote_user, "vscode");
+        assert_eq!(up.remote_user, "vscode");
         assert_eq!(up.remote_workspace_folder, "/workspaces/zed");
     }
 }

--- a/crates/recent_projects/src/remote_connections.rs
+++ b/crates/recent_projects/src/remote_connections.rs
@@ -97,6 +97,7 @@ impl From<Connection> for RemoteConnectionOptions {
             Connection::DevContainer(conn) => {
                 RemoteConnectionOptions::Docker(DockerConnectionOptions {
                     name: conn.name,
+                    remote_user: conn.remote_user,
                     container_id: conn.container_id,
                     upload_binary_over_docker_exec: false,
                     use_podman: conn.use_podman,

--- a/crates/remote/src/transport/docker.rs
+++ b/crates/remote/src/transport/docker.rs
@@ -33,6 +33,7 @@ use crate::{
 pub struct DockerConnectionOptions {
     pub name: String,
     pub container_id: String,
+    pub remote_user: String,
     pub upload_binary_over_docker_exec: bool,
     pub use_podman: bool,
 }
@@ -440,6 +441,9 @@ impl DockerExecConnection {
             Some(dir) => vec!["-w".to_string(), dir.to_string()],
             None => vec![],
         };
+
+        args.push("-u".to_string());
+        args.push(self.connection_options.remote_user.clone());
 
         for (k, v) in env.iter() {
             args.push("-e".to_string());

--- a/crates/remote/src/transport/docker.rs
+++ b/crates/remote/src/transport/docker.rs
@@ -428,7 +428,7 @@ impl DockerExecConnection {
             "{}:{}",
             connection_options.remote_user, connection_options.remote_user,
         ));
-        chown_command.arg(format!("{}", &dst_path));
+        chown_command.arg(&dst_path);
 
         let output = chown_command.output().await?;
 
@@ -710,7 +710,7 @@ impl RemoteConnection for DockerExecConnection {
             dest_path_str,
         );
 
-        cx.background_spawn(async move { upload_task.await })
+        cx.background_spawn(upload_task)
     }
 
     async fn kill(&self) -> Result<()> {

--- a/crates/settings_content/src/settings_content.rs
+++ b/crates/settings_content/src/settings_content.rs
@@ -988,6 +988,7 @@ pub struct RemoteSettingsContent {
 )]
 pub struct DevContainerConnection {
     pub name: String,
+    pub remote_user: String,
     pub container_id: String,
     pub use_podman: bool,
 }

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -1448,7 +1448,8 @@ impl WorkspaceDb {
                 kind = RemoteConnectionKind::Docker;
                 container_id = Some(options.container_id);
                 name = Some(options.name);
-                use_podman = Some(options.use_podman)
+                use_podman = Some(options.use_podman);
+                user = Some(options.remote_user);
             }
             #[cfg(any(test, feature = "test-support"))]
             RemoteConnectionOptions::Mock(options) => {
@@ -1691,6 +1692,7 @@ impl WorkspaceDb {
                 Some(RemoteConnectionOptions::Docker(DockerConnectionOptions {
                     container_id: container_id?,
                     name: name?,
+                    remote_user: user?,
                     upload_binary_over_docker_exec: false,
                     use_podman: use_podman?,
                 }))

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -1425,7 +1425,7 @@ impl WorkspaceDb {
         options: RemoteConnectionOptions,
     ) -> Result<RemoteConnectionId> {
         let kind;
-        let mut user = None;
+        let user: Option<String>;
         let mut host = None;
         let mut port = None;
         let mut distro = None;
@@ -1455,6 +1455,7 @@ impl WorkspaceDb {
             RemoteConnectionOptions::Mock(options) => {
                 kind = RemoteConnectionKind::Ssh;
                 host = Some(format!("mock-{}", options.id));
+                user = Some(format!("mock-user-{}", options.id));
             }
         }
         Self::get_or_create_remote_connection_query(


### PR DESCRIPTION
Closes #46252
Closes #48355

Uses the `remoteUser` property returned from the devcontainer CLI so that settings are respected. Additionally, checks for a default shell in `passwd` if `$SHELL` is not set.

Release Notes:

- Fixed remote_user and shell inconsistencies from within dev containers
