### PR TITLE
Auto-detect Rust for CodeLLDB panic breakpoints

### DIFF
--- a/crates/dap_adapters/src/codelldb.rs
+++ b/crates/dap_adapters/src/codelldb.rs
@@ -380,6 +380,20 @@ impl DebugAdapter for CodeLldbDebugAdapter {
         };
         let mut json_config = config.config.clone();
 
+        // Auto-detect Rust projects and add sourceLanguages if not present.
+        // This enables panic breakpoints to work correctly with CodeLLDB.
+        if let Some(config_obj) = json_config.as_object_mut() {
+            if !config_obj.contains_key("sourceLanguages") {
+                // Check if this looks like a Rust binary (Cargo build output)
+                if let Some(program) = config_obj.get("program").and_then(|p| p.as_str()) {
+                    let path_str = program.replace('\\', "/");
+                    if path_str.contains("/target/debug/") || path_str.contains("/target/release/") {
+                        config_obj.insert("sourceLanguages".to_owned(), json!(["rust"]));
+                    }
+                }
+            }
+        }
+
         Ok(DebugAdapterBinary {
             command: Some(command.unwrap()),
             cwd: Some(delegate.worktree_root_path().to_path_buf()),

--- a/crates/dap_adapters/src/codelldb.rs
+++ b/crates/dap_adapters/src/codelldb.rs
@@ -387,7 +387,8 @@ impl DebugAdapter for CodeLldbDebugAdapter {
                 // Check if this looks like a Rust binary (Cargo build output)
                 if let Some(program) = config_obj.get("program").and_then(|p| p.as_str()) {
                     let path_str = program.replace('\\', "/");
-                    if path_str.contains("/target/debug/") || path_str.contains("/target/release/") {
+                    if path_str.contains("/target/debug/") || path_str.contains("/target/release/")
+                    {
                         config_obj.insert("sourceLanguages".to_owned(), json!(["rust"]));
                     }
                 }


### PR DESCRIPTION
Fixes #48231

## Problem
When debugging Rust programs with CodeLLDB, panic breakpoints ("Rust: on panic") don't work unless `sourceLanguages: ["rust"]` is explicitly set in the debug configuration.

Without this setting, CodeLLDB doesn't return the `rust_panic` exception filter, so the breakpoint shows `locations = 0 (pending)` and never triggers.

## Root Cause
The Cargo locator correctly adds `sourceLanguages: ["rust"]` ([cargo.rs:97-100](https://github.com/zed-industries/zed/blob/main/crates/project/src/debugger/locators/cargo.rs#L97-L100)), but other code paths may not:
- VSCode launch.json imports
- Manual debug configurations

## Solution
Auto-detect Rust binaries in `CodeLldbDebugAdapter::get_binary()` by checking if the program path contains `/target/debug/` or `/target/release/` (Cargo's standard output directories).

If detected and `sourceLanguages` isn't already set, we automatically add `["rust"]`.

Release Notes:

- Fixed Rust panic breakpoints not working in debugger when using CodeLLDB with non-Cargo debug configurations