### PR TITLE
settings: Improve performance for internal editorconfig resolution

### DIFF
--- a/crates/settings/src/editorconfig_store.rs
+++ b/crates/settings/src/editorconfig_store.rs
@@ -323,11 +323,12 @@ impl EditorconfigStore {
     ) -> Option<EditorconfigProperties> {
         let mut properties = EditorconfigProperties::new();
         let state = self.worktree_state.get(&for_worktree);
-        let empty_path: Arc<RelPath> = RelPath::empty().into();
         let internal_root_config_is_root = state
-            .and_then(|state| state.internal_configs.get(&empty_path))
+            .and_then(|state| state.internal_configs.get(RelPath::empty()))
             .and_then(|data| data.1.as_ref())
             .is_some_and(|ec| ec.is_root);
+
+        let std_path = for_path.as_std_path();
 
         if !internal_root_config_is_root {
             for (_, _, parsed_editorconfig) in self.external_configs(for_worktree) {
@@ -336,29 +337,32 @@ impl EditorconfigStore {
                         properties = EditorconfigProperties::new();
                     }
                     for section in &parsed_editorconfig.sections {
-                        section
-                            .apply_to(&mut properties, for_path.as_std_path())
-                            .log_err()?;
+                        section.apply_to(&mut properties, std_path).log_err()?;
                     }
                 }
             }
         }
 
-        for (directory_with_config, _, parsed_editorconfig) in self.internal_configs(for_worktree) {
-            if directory_with_config > for_path {
-                break;
+        if let Some(state) = state {
+            let mut internal_configs: SmallVec<[&Editorconfig; 8]> = SmallVec::new();
+
+            for ancestor in for_path.ancestors() {
+                if let Some((_, parsed)) = state.internal_configs.get(ancestor) {
+                    let config = parsed.as_ref()?;
+                    internal_configs.push(config);
+                    if config.is_root {
+                        break;
+                    }
+                }
             }
-            if !for_path.starts_with(directory_with_config) {
-                continue;
-            }
-            let parsed_editorconfig = parsed_editorconfig?;
-            if parsed_editorconfig.is_root {
-                properties = EditorconfigProperties::new();
-            }
-            for section in &parsed_editorconfig.sections {
-                section
-                    .apply_to(&mut properties, for_path.as_std_path())
-                    .log_err()?;
+
+            for config in internal_configs.into_iter().rev() {
+                if config.is_root {
+                    properties = EditorconfigProperties::new();
+                }
+                for section in &config.sections {
+                    section.apply_to(&mut properties, std_path).log_err()?;
+                }
             }
         }
 


### PR DESCRIPTION
Replaces O(N) iteration over all internal configs with O(D × log N) direct ancestor lookups, where D is path depth and N is total config count.

Release Notes:

- N/A