### PR TITLE
Fix incorrect memory display in the language servers menu on Linux

### DIFF
--- a/crates/language_tools/src/lsp_button.rs
+++ b/crates/language_tools/src/lsp_button.rs
@@ -89,8 +89,8 @@ impl ProcessMemoryCache {
             .unwrap_or(true);
 
         if cache_expired {
-            let refresh_kind =
-                RefreshKind::nothing().with_processes(ProcessRefreshKind::nothing().with_memory());
+            let refresh_kind = RefreshKind::nothing()
+                .with_processes(ProcessRefreshKind::nothing().without_tasks().with_memory());
             self.system.refresh_specifics(refresh_kind);
             self.memory_usage.clear();
             self.last_refresh = Some(Instant::now());


### PR DESCRIPTION

While trying out the new feature introduced in #48226, I noticed an issue on Linux where the reported memory usage is incorrect.

On Linux, even when using ProcessRefreshKind::nothing, thread information is still collected. To fix this, the memory calculation needs to explicitly exclude task/thread data by using without_tasks.

Before
<img width="544" height="186" src="https://github.com/user-attachments/assets/438c15b2-b1f1-42df-9ffe-dea2f5b1b6ce" />

After
<img width="531" height="139" src="https://github.com/user-attachments/assets/a0e5aae5-9558-4bfc-b368-8306bbc7c37e" />




Release Notes:

- N/A
