### PR TITLE
languages: Add support for detecting libstdc++ headers

### DIFF
--- a/crates/languages/src/cpp/config.toml
+++ b/crates/languages/src/cpp/config.toml
@@ -2,7 +2,7 @@ name = "C++"
 grammar = "cpp"
 path_suffixes = ["cc", "hh", "cpp", "h", "hpp", "cxx", "hxx", "c++", "h++", "ipp", "inl", "ino", "ixx", "cu", "cuh", "C", "H"]
 line_comments = ["// ", "/// ", "//! "]
-first_line_pattern = '\/\/\s*-\*-\s*C\+\+\s*-\*-'
+first_line_pattern = '\/\/\s*(<.*>\s)?-\*-\s*C\+\+\s*-\*-'
 decrease_indent_patterns = [
   { pattern = "^\\s*\\{.*\\}?\\s*$", valid_after = ["if", "for", "while", "do", "switch", "else"] },
   { pattern = "^\\s*else\\b", valid_after = ["if"] }


### PR DESCRIPTION
https://github.com/zed-industries/zed/pull/47443#issuecomment-3834807752

Support detect libstdc++ headers

<img width="1335" height="830" src="https://github.com/user-attachments/assets/4a8b8376-029b-41c5-a53b-d1a02a061818" />


Release Notes:

- N/A
