### PR TITLE
python: Respect user settings for toolchain discovery over the toolchain set in Zed

### DIFF
--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -596,8 +596,22 @@ impl LspAdapter for PyrightLspAdapter {
                     .and_then(|s| s.settings.clone())
                     .unwrap_or_default();
 
-            // If we have a detected toolchain, configure Pyright to use it
+            // If we have a detected toolchain, configure Pyright to use it - unless the user sets it themselves.
+            let should_insert_toolchain = || {
+                user_settings.as_object().is_none_or(|object| {
+                    [
+                        "venvPath",
+                        "venv",
+                        "python",
+                        "pythonPath",
+                        "defaultInterpreterPath",
+                    ]
+                    .into_iter()
+                    .any(|known_key| object.contains_key(known_key))
+                })
+            };
             if let Some(toolchain) = toolchain
+                && should_insert_toolchain()
                 && let Ok(env) =
                     serde_json::from_value::<PythonToolchainData>(toolchain.as_json.clone())
             {
@@ -2046,7 +2060,21 @@ impl LspAdapter for BasedPyrightLspAdapter {
                     .unwrap_or_default();
 
             // If we have a detected toolchain, configure Pyright to use it
+            let should_insert_toolchain = || {
+                user_settings.as_object().is_none_or(|object| {
+                    [
+                        "venvPath",
+                        "venv",
+                        "python",
+                        "pythonPath",
+                        "defaultInterpreterPath",
+                    ]
+                    .into_iter()
+                    .any(|known_key| object.contains_key(known_key))
+                })
+            };
             if let Some(toolchain) = toolchain
+                && should_insert_toolchain()
                 && let Ok(env) = serde_json::from_value::<
                     pet_core::python_environment::PythonEnvironment,
                 >(toolchain.as_json.clone())


### PR DESCRIPTION
Closes #46754

Release Notes:

- python: User settings now take precedence over toolchain set in Zed for pyright/basedpyright
