### PR TITLE
git_ui: Hide "View on GitHub" button when viewing stashes in commit view

### DIFF
--- a/crates/git_ui/src/commit_view.rs
+++ b/crates/git_ui/src/commit_view.rs
@@ -483,19 +483,23 @@ impl CommitView {
             time_format::TimestampFormat::MediumAbsolute,
         );
 
-        let remote_info = self.remote.as_ref().map(|remote| {
-            let provider = remote.host.name();
-            let parsed_remote = ParsedGitRemote {
-                owner: remote.owner.as_ref().into(),
-                repo: remote.repo.as_ref().into(),
-            };
-            let params = BuildCommitPermalinkParams { sha: &commit.sha };
-            let url = remote
-                .host
-                .build_commit_permalink(&parsed_remote, params)
-                .to_string();
-            (provider, url)
-        });
+        let remote_info = self
+            .remote
+            .as_ref()
+            .filter(|_| self.stash.is_none())
+            .map(|remote| {
+                let provider = remote.host.name();
+                let parsed_remote = ParsedGitRemote {
+                    owner: remote.owner.as_ref().into(),
+                    repo: remote.repo.as_ref().into(),
+                };
+                let params = BuildCommitPermalinkParams { sha: &commit.sha };
+                let url = remote
+                    .host
+                    .build_commit_permalink(&parsed_remote, params)
+                    .to_string();
+                (provider, url)
+            });
 
         let (additions, deletions) = self.calculate_changed_lines(cx);
 


### PR DESCRIPTION
Closes #48195

Filter out `remote_info` when viewing stashes by adding `.filter(|_| self.stash.is_none())`.


Release Notes:

- Fixed "View on GitHub" button incorrectly appearing when viewing stashes