### PR TITLE
Add support for absolute paths in file finder

### DIFF
--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -39,7 +39,7 @@ use ui::{
 };
 use util::{
     ResultExt, maybe,
-    paths::{PathStyle, PathWithPosition, looks_like_absolute},
+    paths::{PathWithPosition},
     post_inc,
     rel_path::RelPath,
 };
@@ -1424,21 +1424,16 @@ impl PickerDelegate for FileFinderDelegate {
                 path_position,
             };
 
-            let path_style = self.project.read(cx).path_style(cx);
-
             cx.spawn_in(window, async move |this, cx| {
                 let _ = maybe!(async move {
-                    let is_absolute_path = looks_like_absolute(path_str.unwrap_or(""), path_style);
-                    let did_resolve_abs_path = is_absolute_path
-                        && this
-                            .update_in(cx, |this, window, cx| {
-                                this.delegate
-                                    .lookup_absolute_path(query.clone(), window, cx)
-                            })?
-                            .await;
+                    let did_resolve_abs_path = this
+                        .update_in(cx, |this, window, cx| {
+                            this.delegate
+                                .lookup_absolute_path(query.clone(), window, cx)
+                        })?
+                        .await;
 
-                    // Only check for relative paths if no absolute paths were
-                    // found.
+                    // Only check for relative paths if no absolute paths were found.
                     if !did_resolve_abs_path {
                         this.update_in(cx, |this, window, cx| {
                             this.delegate.spawn_search(query, window, cx)

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -1424,14 +1424,18 @@ impl PickerDelegate for FileFinderDelegate {
                 path_position,
             };
 
+            let path_str_for_check = path_str.unwrap_or("");
+            let is_absolute_path = path.is_absolute() || path_str_for_check.starts_with('~');
+
             cx.spawn_in(window, async move |this, cx| {
                 let _ = maybe!(async move {
-                    let did_resolve_abs_path = this
-                        .update_in(cx, |this, window, cx| {
-                            this.delegate
-                                .lookup_absolute_path(query.clone(), window, cx)
-                        })?
-                        .await;
+                    let did_resolve_abs_path = is_absolute_path
+                        && this
+                            .update_in(cx, |this, window, cx| {
+                                this.delegate
+                                    .lookup_absolute_path(query.clone(), window, cx)
+                            })?
+                            .await;
 
                     // Only check for relative paths if no absolute paths were found.
                     if !did_resolve_abs_path {

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -39,7 +39,7 @@ use ui::{
 };
 use util::{
     ResultExt, maybe,
-    paths::{PathStyle, PathWithPosition},
+    paths::{PathStyle, PathWithPosition, is_absolute},
     post_inc,
     rel_path::RelPath,
 };
@@ -1424,9 +1424,11 @@ impl PickerDelegate for FileFinderDelegate {
                 path_position,
             };
 
+            let path_style = self.project.read(cx).path_style(cx);
+
             cx.spawn_in(window, async move |this, cx| {
                 let _ = maybe!(async move {
-                    let is_absolute_path = path.is_absolute();
+                    let is_absolute_path = is_absolute(path_str.unwrap_or(""), path_style);
                     let did_resolve_abs_path = is_absolute_path
                         && this
                             .update_in(cx, |this, window, cx| {

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -39,7 +39,7 @@ use ui::{
 };
 use util::{
     ResultExt, maybe,
-    paths::{PathStyle, PathWithPosition, is_absolute},
+    paths::{PathStyle, PathWithPosition, looks_like_absolute},
     post_inc,
     rel_path::RelPath,
 };
@@ -1428,7 +1428,7 @@ impl PickerDelegate for FileFinderDelegate {
 
             cx.spawn_in(window, async move |this, cx| {
                 let _ = maybe!(async move {
-                    let is_absolute_path = is_absolute(path_str.unwrap_or(""), path_style);
+                    let is_absolute_path = looks_like_absolute(path_str.unwrap_or(""), path_style);
                     let did_resolve_abs_path = is_absolute_path
                         && this
                             .update_in(cx, |this, window, cx| {

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -1425,11 +1425,11 @@ impl PickerDelegate for FileFinderDelegate {
             };
 
             let path_str_for_check = path_str.unwrap_or("");
-            let is_absolute_path = path.is_absolute() || path_str_for_check.starts_with('~');
+            let is_looks_absolute_path = path.is_absolute() || path_str_for_check.starts_with('~');
 
             cx.spawn_in(window, async move |this, cx| {
                 let _ = maybe!(async move {
-                    let did_resolve_abs_path = is_absolute_path
+                    let did_resolve_abs_path = is_looks_absolute_path
                         && this
                             .update_in(cx, |this, window, cx| {
                                 this.delegate

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -10,8 +10,8 @@ use file_icons::FileIcons;
 use fuzzy::{CharBag, PathMatch, PathMatchCandidate};
 use gpui::{
     Action, AnyElement, App, Context, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable,
-    KeyContext, Modifiers, ModifiersChangedEvent, ParentElement, PathStyle, Render, Styled, Task,
-    WeakEntity, Window, actions, rems,
+    KeyContext, Modifiers, ModifiersChangedEvent, ParentElement, Render, Styled, Task, WeakEntity,
+    Window, actions, rems,
 };
 use open_path_prompt::{
     OpenPathPrompt,
@@ -37,7 +37,12 @@ use ui::{
     ButtonLike, ContextMenu, HighlightedLabel, Indicator, KeyBinding, ListItem, ListItemSpacing,
     PopoverMenu, PopoverMenuHandle, TintColor, Tooltip, prelude::*,
 };
-use util::{ResultExt, maybe, paths::PathWithPosition, post_inc, rel_path::RelPath};
+use util::{
+    ResultExt, maybe,
+    paths::{PathStyle, PathWithPosition},
+    post_inc,
+    rel_path::RelPath,
+};
 use workspace::{
     ModalView, OpenOptions, OpenVisible, SplitDirection, Workspace, item::PreviewTabsSettings,
     notifications::NotifyResultExt, pane,

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -37,12 +37,7 @@ use ui::{
     ButtonLike, ContextMenu, HighlightedLabel, Indicator, KeyBinding, ListItem, ListItemSpacing,
     PopoverMenu, PopoverMenuHandle, TintColor, Tooltip, prelude::*,
 };
-use util::{
-    ResultExt, maybe,
-    paths::{PathWithPosition},
-    post_inc,
-    rel_path::RelPath,
-};
+use util::{ResultExt, maybe, paths::PathWithPosition, post_inc, rel_path::RelPath};
 use workspace::{
     ModalView, OpenOptions, OpenVisible, SplitDirection, Workspace, item::PreviewTabsSettings,
     notifications::NotifyResultExt, pane,
@@ -1424,18 +1419,14 @@ impl PickerDelegate for FileFinderDelegate {
                 path_position,
             };
 
-            let path_str_for_check = path_str.unwrap_or("");
-            let is_looks_absolute_path = path.is_absolute() || path_str_for_check.starts_with('~');
-
             cx.spawn_in(window, async move |this, cx| {
                 let _ = maybe!(async move {
-                    let did_resolve_abs_path = is_looks_absolute_path
-                        && this
-                            .update_in(cx, |this, window, cx| {
-                                this.delegate
-                                    .lookup_absolute_path(query.clone(), window, cx)
-                            })?
-                            .await;
+                    let did_resolve_abs_path = this
+                        .update_in(cx, |this, window, cx| {
+                            this.delegate
+                                .lookup_absolute_path(query.clone(), window, cx)
+                        })?
+                        .await;
 
                     // Only check for relative paths if no absolute paths were found.
                     if !did_resolve_abs_path {

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -10,8 +10,8 @@ use file_icons::FileIcons;
 use fuzzy::{CharBag, PathMatch, PathMatchCandidate};
 use gpui::{
     Action, AnyElement, App, Context, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable,
-    KeyContext, Modifiers, ModifiersChangedEvent, ParentElement, Render, Styled, Task, WeakEntity,
-    Window, actions, rems,
+    KeyContext, Modifiers, ModifiersChangedEvent, ParentElement, PathStyle, Render, Styled, Task,
+    WeakEntity, Window, actions, rems,
 };
 use open_path_prompt::{
     OpenPathPrompt,

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -1211,6 +1211,17 @@ impl FileFinderDelegate {
         window: &mut Window,
         cx: &mut Context<Picker<Self>>,
     ) -> Task<bool> {
+        let query_str = query.path_query().trim();
+
+        // Only try to resolve absolute paths, skip for simple relative queries
+        let looks_like_absolute = query_str.starts_with('/')
+            || query_str.starts_with('~')
+            || (cfg!(windows) && query_str.len() > 1 && query_str.chars().nth(1) == Some(':'));
+
+        if !looks_like_absolute {
+            return Task::ready(false);
+        }
+
         cx.spawn_in(window, async move |picker, cx| {
             let Some(project) = picker
                 .read_with(cx, |picker, _| picker.delegate.project.clone())
@@ -1431,13 +1442,14 @@ impl PickerDelegate for FileFinderDelegate {
 
             cx.spawn_in(window, async move |this, cx| {
                 let _ = maybe!(async move {
+                    // Try to resolve absolute paths first (e.g., /path/to/file or ~/file)
                     this.update_in(cx, |this, window, cx| {
                         this.delegate
                             .lookup_absolute_path(query.clone(), window, cx)
                     })?
                     .await;
 
-                    // Always check for relative paths as well
+                    // Always do a regular file search - results are combined with absolute path results
                     this.update_in(cx, |this, window, cx| {
                         this.delegate.spawn_search(query, window, cx)
                     })?

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -1219,19 +1219,23 @@ impl FileFinderDelegate {
                 return false;
             };
 
-            let query_path = Path::new(query.path_query());
             let mut path_matches = Vec::new();
 
-            let abs_file_exists = project
+            let resolved_path = project
                 .update(cx, |this, cx| {
                     this.resolve_abs_file_path(query.path_query(), cx)
                 })
-                .await
-                .is_some();
+                .await;
 
-            if abs_file_exists {
+            if let Some(resolved_path) = resolved_path {
+                let abs_path_str = match &resolved_path {
+                    project::ResolvedPath::AbsPath { path, .. } => path.clone(),
+                    project::ResolvedPath::ProjectPath { .. } => query.path_query().to_string(),
+                };
+                let abs_path = Path::new(&abs_path_str);
+
                 project.update(cx, |project, cx| {
-                    if let Some((worktree, relative_path)) = project.find_worktree(query_path, cx) {
+                    if let Some((worktree, relative_path)) = project.find_worktree(abs_path, cx) {
                         path_matches.push(ProjectPanelOrdMatch(PathMatch {
                             score: 1.0,
                             positions: Vec::new(),
@@ -1245,6 +1249,8 @@ impl FileFinderDelegate {
                 });
             }
 
+            let found_match = !path_matches.is_empty();
+
             picker
                 .update_in(cx, |picker, _, cx| {
                     let picker_delegate = &mut picker.delegate;
@@ -1254,7 +1260,7 @@ impl FileFinderDelegate {
                     anyhow::Ok(())
                 })
                 .log_err();
-            abs_file_exists
+            found_match
         })
     }
 

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -1200,11 +1200,10 @@ impl FileFinderDelegate {
 
     /// Attempts to resolve an absolute file path and update the search matches if found.
     ///
-    /// If the query path resolves to an absolute file that exists in the project,
-    /// this method will find the corresponding worktree and relative path, create a
-    /// match for it, and update the picker's search results.
-    ///
-    /// Returns `true` if the absolute path exists, otherwise returns `false`.
+    /// Returns `false` immediately if the query does not look like an absolute path
+    /// (i.e., does not start with `/`, `~`, or a Windows drive letter).
+    /// Otherwise, resolves the path asynchronously and returns `true` if a matching
+    /// file was found in the project's worktrees.
     fn lookup_absolute_path(
         &self,
         query: FileSearchQuery,
@@ -1213,7 +1212,6 @@ impl FileFinderDelegate {
     ) -> Task<bool> {
         let query_str = query.path_query().trim();
 
-        // Only try to resolve absolute paths, skip for simple relative queries
         let looks_like_absolute = query_str.starts_with('/')
             || query_str.starts_with('~')
             || (cfg!(windows) && query_str.len() > 1 && query_str.chars().nth(1) == Some(':'));
@@ -1230,55 +1228,45 @@ impl FileFinderDelegate {
                 return false;
             };
 
-            let mut path_matches = Vec::new();
-
-            // Expand ~ to home directory if present
-            let query_path = if query.path_query().starts_with('~') {
-                let home = util::paths::home_dir();
-                query
-                    .path_query()
-                    .replacen("~", home.to_string_lossy().as_ref(), 1)
-            } else {
-                query.path_query().to_string()
-            };
-
+            // resolve_abs_file_path handles tilde expansion internally via shellexpand
             let resolved_path = project
-                .update(cx, |this, cx| this.resolve_abs_file_path(&query_path, cx))
+                .update(cx, |project, cx| {
+                    project.resolve_abs_file_path(query.path_query(), cx)
+                })
                 .await;
 
-            if let Some(resolved_path) = resolved_path {
-                let abs_path_str = match &resolved_path {
-                    project::ResolvedPath::AbsPath { path, .. } => path.clone(),
-                    project::ResolvedPath::ProjectPath { .. } => query.path_query().to_string(),
-                };
-                let abs_path = Path::new(&abs_path_str);
+            let Some(project::ResolvedPath::AbsPath { path: abs_path, .. }) = resolved_path else {
+                return false;
+            };
 
-                project.update(cx, |project, cx| {
-                    if let Some((worktree, relative_path)) = project.find_worktree(abs_path, cx) {
-                        path_matches.push(ProjectPanelOrdMatch(PathMatch {
-                            score: 1.0,
-                            positions: Vec::new(),
-                            worktree_id: worktree.read(cx).id().to_usize(),
-                            path: relative_path,
-                            path_prefix: RelPath::empty().into(),
-                            is_dir: false, // File finder doesn't support directories
-                            distance_to_relative_ancestor: usize::MAX,
-                        }));
-                    }
-                });
-            }
+            let mut path_matches = Vec::new();
+            project.update(cx, |project, cx| {
+                if let Some((worktree, relative_path)) =
+                    project.find_worktree(Path::new(&abs_path), cx)
+                {
+                    path_matches.push(ProjectPanelOrdMatch(PathMatch {
+                        score: 1.0,
+                        positions: Vec::new(),
+                        worktree_id: worktree.read(cx).id().to_usize(),
+                        path: relative_path,
+                        path_prefix: RelPath::empty().into(),
+                        is_dir: false,
+                        distance_to_relative_ancestor: usize::MAX,
+                    }));
+                }
+            });
 
             let found_match = !path_matches.is_empty();
 
             picker
                 .update_in(cx, |picker, _, cx| {
-                    let picker_delegate = &mut picker.delegate;
-                    let search_id = util::post_inc(&mut picker_delegate.search_count);
-                    picker_delegate.set_search_matches(search_id, false, query, path_matches, cx);
-
+                    let delegate = &mut picker.delegate;
+                    let search_id = util::post_inc(&mut delegate.search_count);
+                    delegate.set_search_matches(search_id, false, query, path_matches, cx);
                     anyhow::Ok(())
                 })
                 .log_err();
+
             found_match
         })
     }

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -1408,7 +1408,6 @@ impl PickerDelegate for FileFinderDelegate {
         } else {
             let path_position = PathWithPosition::parse_str(raw_query);
             let raw_query = raw_query.trim().trim_end_matches(':').to_owned();
-            let path = path_position.path.clone();
             let path_str = path_position.path.to_str();
             let path_trimmed = path_str.unwrap_or(&raw_query).trim_end_matches(':');
             let file_query_end = if path_trimmed == raw_query {

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -1232,10 +1232,18 @@ impl FileFinderDelegate {
 
             let mut path_matches = Vec::new();
 
+            // Expand ~ to home directory if present
+            let query_path = if query.path_query().starts_with('~') {
+                let home = util::paths::home_dir();
+                query
+                    .path_query()
+                    .replacen("~", home.to_string_lossy().as_ref(), 1)
+            } else {
+                query.path_query().to_string()
+            };
+
             let resolved_path = project
-                .update(cx, |this, cx| {
-                    this.resolve_abs_file_path(query.path_query(), cx)
-                })
+                .update(cx, |this, cx| this.resolve_abs_file_path(&query_path, cx))
                 .await;
 
             if let Some(resolved_path) = resolved_path {

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -1442,18 +1442,20 @@ impl PickerDelegate for FileFinderDelegate {
 
             cx.spawn_in(window, async move |this, cx| {
                 let _ = maybe!(async move {
-                    // Try to resolve absolute paths first (e.g., /path/to/file or ~/file)
-                    this.update_in(cx, |this, window, cx| {
-                        this.delegate
-                            .lookup_absolute_path(query.clone(), window, cx)
-                    })?
-                    .await;
+                    let did_resolve_abs_path = this
+                        .update_in(cx, |this, window, cx| {
+                            this.delegate
+                                .lookup_absolute_path(query.clone(), window, cx)
+                        })?
+                        .await;
 
-                    // Always do a regular file search - results are combined with absolute path results
-                    this.update_in(cx, |this, window, cx| {
-                        this.delegate.spawn_search(query, window, cx)
-                    })?
-                    .await;
+                    // Only check for relative paths if no absolute paths were found.
+                    if !did_resolve_abs_path {
+                        this.update_in(cx, |this, window, cx| {
+                            this.delegate.spawn_search(query, window, cx)
+                        })?
+                        .await;
+                    }
                     anyhow::Ok(())
                 })
                 .await;

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -1431,20 +1431,17 @@ impl PickerDelegate for FileFinderDelegate {
 
             cx.spawn_in(window, async move |this, cx| {
                 let _ = maybe!(async move {
-                    let did_resolve_abs_path = this
-                        .update_in(cx, |this, window, cx| {
-                            this.delegate
-                                .lookup_absolute_path(query.clone(), window, cx)
-                        })?
-                        .await;
+                    this.update_in(cx, |this, window, cx| {
+                        this.delegate
+                            .lookup_absolute_path(query.clone(), window, cx)
+                    })?
+                    .await;
 
-                    // Only check for relative paths if no absolute paths were found.
-                    if !did_resolve_abs_path {
-                        this.update_in(cx, |this, window, cx| {
-                            this.delegate.spawn_search(query, window, cx)
-                        })?
-                        .await;
-                    }
+                    // Always check for relative paths as well
+                    this.update_in(cx, |this, window, cx| {
+                        this.delegate.spawn_search(query, window, cx)
+                    })?
+                    .await;
                     anyhow::Ok(())
                 })
                 .await;

--- a/crates/file_finder/src/file_finder_tests.rs
+++ b/crates/file_finder/src/file_finder_tests.rs
@@ -396,6 +396,89 @@ async fn test_absolute_paths(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_absolute_path_lookup(cx: &mut TestAppContext) {
+    let app_state = init_test(cx);
+    let home_dir = util::paths::home_dir();
+
+    app_state
+        .fs
+        .as_fake()
+        .insert_tree(
+            home_dir.as_ref(),
+            json!({
+                "a": {
+                    "file1.txt": "",
+                    "b": {
+                        "file2.txt": "",
+                    },
+                }
+            }),
+        )
+        .await;
+
+    let project = Project::test(app_state.fs.clone(), [home_dir.as_ref()], cx).await;
+    let (picker, _, cx) = build_find_picker(project, cx);
+
+    // Test cases: (query, expected_matches, description)
+    let test_cases = vec![
+        (
+            home_dir.join("a/b/file2.txt").to_string_lossy().to_string(),
+            vec![rel_path("a/b/file2.txt").into()],
+            "absolute path exists",
+        ),
+        (
+            format!("{}:42", home_dir.join("a/file1.txt").to_string_lossy()),
+            vec![rel_path("a/file1.txt").into()],
+            "absolute path with line number",
+        ),
+        (
+            format!("{}:10:5", home_dir.join("a/file1.txt").to_string_lossy()),
+            vec![rel_path("a/file1.txt").into()],
+            "absolute path with line:col",
+        ),
+        (
+            home_dir
+                .join("a/b/nonexistent.txt")
+                .to_string_lossy()
+                .to_string(),
+            vec![],
+            "nonexistent absolute path",
+        ),
+        (
+            "a/file1.txt".to_string(),
+            vec![rel_path("a/file1.txt").into()],
+            "relative path fallback",
+        ),
+        (
+            "~/a/file1.txt".to_string(),
+            vec![rel_path("a/file1.txt").into()],
+            "~ path inside project",
+        ),
+        (
+            "~/a/b/file2.txt:5".to_string(),
+            vec![rel_path("a/b/file2.txt").into()],
+            "~ path with line number inside project",
+        ),
+    ];
+
+    for (query, expected, description) in test_cases {
+        picker
+            .update_in(cx, |picker, window, cx| {
+                picker.delegate.update_matches(query.clone(), window, cx)
+            })
+            .await;
+        picker.update(cx, |picker, _| {
+            let matches = collect_search_matches(picker).search_paths_only();
+            assert_eq!(
+                matches, expected,
+                "Test case '{}' failed for query: {}",
+                description, query
+            )
+        });
+    }
+}
+
+#[gpui::test]
 async fn test_complex_path(cx: &mut TestAppContext) {
     let app_state = init_test(cx);
     app_state

--- a/crates/file_finder/src/file_finder_tests.rs
+++ b/crates/file_finder/src/file_finder_tests.rs
@@ -404,7 +404,7 @@ async fn test_absolute_path_lookup(cx: &mut TestAppContext) {
         .fs
         .as_fake()
         .insert_tree(
-            home_dir.as_ref(),
+            home_dir.as_path(),
             json!({
                 "a": {
                     "file1.txt": "",
@@ -416,7 +416,7 @@ async fn test_absolute_path_lookup(cx: &mut TestAppContext) {
         )
         .await;
 
-    let project = Project::test(app_state.fs.clone(), [home_dir.as_ref()], cx).await;
+    let project = Project::test(app_state.fs.clone(), [home_dir.as_path()], cx).await;
     let (picker, _, cx) = build_find_picker(project, cx);
 
     // Test cases: (query, expected_matches, description)

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -362,7 +362,7 @@ impl PathStyle {
     }
 
     pub fn is_absolute(&self, path_like: &str) -> bool {
-        path_like.starts_with('/') || path_like.starts_with('~')
+        path_like.starts_with('/')
             || *self == PathStyle::Windows
                 && (path_like.starts_with('\\')
                     || path_like
@@ -372,6 +372,13 @@ impl PathStyle {
                         && path_like[1..]
                             .strip_prefix(':')
                             .is_some_and(|path| path.starts_with('/') || path.starts_with('\\')))
+    }
+
+    /// Checks if a path looks like it should be resolved as an absolute path.
+    /// This includes filesystem absolute paths and home directory paths (~).
+    /// Used for UI contexts like file pickers where users may type shell-style paths.
+    pub fn looks_like_absolute(&self, path_like: &str) -> bool {
+        self.is_absolute(path_like) || path_like.starts_with('~')
     }
 
     pub fn is_windows(&self) -> bool {
@@ -474,7 +481,7 @@ impl Display for RemotePathBuf {
 }
 
 pub fn is_absolute(path_like: &str, path_style: PathStyle) -> bool {
-    path_like.starts_with('/') || path_like.starts_with('~')
+    path_like.starts_with('/')
         || path_style == PathStyle::Windows
             && (path_like.starts_with('\\')
                 || path_like
@@ -484,6 +491,13 @@ pub fn is_absolute(path_like: &str, path_style: PathStyle) -> bool {
                     && path_like[1..]
                         .strip_prefix(':')
                         .is_some_and(|path| path.starts_with('/') || path.starts_with('\\')))
+}
+
+/// Checks if a path looks like it should be resolved as an absolute path.
+/// This includes filesystem absolute paths and home directory paths (~).
+/// Used for UI contexts like file pickers where users may type shell-style paths.
+pub fn looks_like_absolute(path_like: &str, path_style: PathStyle) -> bool {
+    is_absolute(path_like, path_style) || path_like.starts_with('~')
 }
 
 #[derive(Debug, PartialEq)]

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -362,7 +362,7 @@ impl PathStyle {
     }
 
     pub fn is_absolute(&self, path_like: &str) -> bool {
-        path_like.starts_with('/')
+        path_like.starts_with('/') || path_like.starts_with('~')
             || *self == PathStyle::Windows
                 && (path_like.starts_with('\\')
                     || path_like
@@ -474,7 +474,7 @@ impl Display for RemotePathBuf {
 }
 
 pub fn is_absolute(path_like: &str, path_style: PathStyle) -> bool {
-    path_like.starts_with('/')
+    path_like.starts_with('/') || path_like.starts_with('~')
         || path_style == PathStyle::Windows
             && (path_like.starts_with('\\')
                 || path_like

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -374,13 +374,6 @@ impl PathStyle {
                             .is_some_and(|path| path.starts_with('/') || path.starts_with('\\')))
     }
 
-    /// Checks if a path looks like it should be resolved as an absolute path.
-    /// This includes filesystem absolute paths and home directory paths (~).
-    /// Used for UI contexts like file pickers where users may type shell-style paths.
-    pub fn looks_like_absolute(&self, path_like: &str) -> bool {
-        self.is_absolute(path_like) || path_like.starts_with('~')
-    }
-
     pub fn is_windows(&self) -> bool {
         *self == PathStyle::Windows
     }

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -486,13 +486,6 @@ pub fn is_absolute(path_like: &str, path_style: PathStyle) -> bool {
                         .is_some_and(|path| path.starts_with('/') || path.starts_with('\\')))
 }
 
-/// Checks if a path looks like it should be resolved as an absolute path.
-/// This includes filesystem absolute paths and home directory paths (~).
-/// Used for UI contexts like file pickers where users may type shell-style paths.
-pub fn looks_like_absolute(path_like: &str, path_style: PathStyle) -> bool {
-    is_absolute(path_like, path_style) || path_like.starts_with('~')
-}
-
 #[derive(Debug, PartialEq)]
 #[non_exhaustive]
 pub struct NormalizeError;


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/23740

Release Notes:
  -   The file finder now supports opening files using absolute paths, including home directory shortcuts (~). Previously, you could only search for files within your project workspace.   

Bug fix:
- The file finder checks for absolute path `&&` and then checks if it looks like absolute path