### PR TITLE
Disable default tool permissions

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -962,75 +962,76 @@
     // Per-tool permission rules for granular control over tool actions.
     // This setting only applies to the native Zed agent.
     "tool_permissions": {
+      // Here are some examples of tool-specific permissions.
       "tools": {
-        "terminal": {
-          "default_mode": "confirm",
-          "always_deny": [
-            // Dangerous rm commands
-            { "pattern": "rm\\s+-rf\\s+(/|\\.\\.|\"|~|\\*)" },
-            { "pattern": "rm\\s+-rf\\s*$" },
-            // Disk destruction
-            { "pattern": "> /dev/sd" },
-            { "pattern": "mkfs\\." },
-            { "pattern": "dd\\s+if=/dev/(zero|random)" },
-            // Fork bomb
-            { "pattern": ":\\(\\)\\{\\s*:\\|:&\\s*\\};:" },
-            // System files
-            { "pattern": "/etc/passwd" },
-            { "pattern": "/etc/shadow" },
-            // Windows destructive commands
-            { "pattern": "del /f /s /q c:\\\\" },
-            { "pattern": "format c:" },
-            { "pattern": "rd /s /q" },
-          ],
-          "always_confirm": [
-            // File deletion
-            { "pattern": "rm\\s" },
-            // Destructive git operations
-            { "pattern": "git\\s+(reset|clean)\\s+--hard" },
-            { "pattern": "git\\s+push\\s+(-f|--force)" },
-            // Database operations
-            { "pattern": "DROP\\s+TABLE", "case_sensitive": true },
-            { "pattern": "DELETE\\s+FROM", "case_sensitive": true },
-            // Privileged commands
-            { "pattern": "sudo\\s" },
-          ],
-        },
-        "edit_file": {
-          "default_mode": "confirm",
-          "always_deny": [
-            // Secrets and credentials
-            { "pattern": "\\.env($|\\.)" },
-            { "pattern": "secrets?/" },
-            { "pattern": "\\.pem$" },
-            { "pattern": "\\.key$" },
-          ],
-        },
-        "delete_path": {
-          "default_mode": "confirm",
-          "always_deny": [
-            // System directories
-            { "pattern": "^/etc" },
-            { "pattern": "^/usr" },
-            { "pattern": "^/bin" },
-            { "pattern": "^/sbin" },
-            { "pattern": "^/var" },
-            { "pattern": "^/boot" },
-            { "pattern": "^/root" },
-            // Home directory root
-            { "pattern": "^~$" },
-            { "pattern": "^/Users/[^/]+$" },
-            { "pattern": "^/home/[^/]+$" },
-            // Git directory
-            { "pattern": "\\.git/?$" },
-            // Windows system directories
-            { "pattern": "^C:\\\\Windows" },
-            { "pattern": "^C:\\\\Program Files" },
-          ],
-        },
-        "fetch": {
-          "default_mode": "confirm",
-        },
+        // "terminal": {
+        //   "default_mode": "confirm",
+        //   "always_deny": [
+        //     // Dangerous rm commands
+        //     { "pattern": "rm\\s+-rf\\s+(/|\\.\\.|\"|~|\\*)" },
+        //     { "pattern": "rm\\s+-rf\\s*$" },
+        //     // Disk destruction
+        //     { "pattern": "> /dev/sd" },
+        //     { "pattern": "mkfs\\." },
+        //     { "pattern": "dd\\s+if=/dev/(zero|random)" },
+        //     // Fork bomb
+        //     { "pattern": ":\\(\\)\\{\\s*:\\|:&\\s*\\};:" },
+        //     // System files
+        //     { "pattern": "/etc/passwd" },
+        //     { "pattern": "/etc/shadow" },
+        //     // Windows destructive commands
+        //     { "pattern": "del /f /s /q c:\\\\" },
+        //     { "pattern": "format c:" },
+        //     { "pattern": "rd /s /q" },
+        //   ],
+        //   "always_confirm": [
+        //     // File deletion
+        //     { "pattern": "rm\\s" },
+        //     // Destructive git operations
+        //     { "pattern": "git\\s+(reset|clean)\\s+--hard" },
+        //     { "pattern": "git\\s+push\\s+(-f|--force)" },
+        //     // Database operations
+        //     { "pattern": "DROP\\s+TABLE", "case_sensitive": true },
+        //     { "pattern": "DELETE\\s+FROM", "case_sensitive": true },
+        //     // Privileged commands
+        //     { "pattern": "sudo\\s" },
+        //   ],
+        // },
+        // "edit_file": {
+        //   "default_mode": "confirm",
+        //   "always_deny": [
+        //     // Secrets and credentials
+        //     { "pattern": "\\.env($|\\.)" },
+        //     { "pattern": "secrets?/" },
+        //     { "pattern": "\\.pem$" },
+        //     { "pattern": "\\.key$" },
+        //   ],
+        // },
+        // "delete_path": {
+        //   "default_mode": "confirm",
+        //   "always_deny": [
+        //     // System directories
+        //     { "pattern": "^/etc" },
+        //     { "pattern": "^/usr" },
+        //     { "pattern": "^/bin" },
+        //     { "pattern": "^/sbin" },
+        //     { "pattern": "^/var" },
+        //     { "pattern": "^/boot" },
+        //     { "pattern": "^/root" },
+        //     // Home directory root
+        //     { "pattern": "^~$" },
+        //     { "pattern": "^/Users/[^/]+$" },
+        //     { "pattern": "^/home/[^/]+$" },
+        //     // Git directory
+        //     { "pattern": "\\.git/?$" },
+        //     // Windows system directories
+        //     { "pattern": "^C:\\\\Windows" },
+        //     { "pattern": "^C:\\\\Program Files" },
+        //   ],
+        // },
+        // "fetch": {
+        //   "default_mode": "confirm",
+        // },
       },
     },
     // When enabled, agent edits will be displayed in single-file editors for review

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -966,35 +966,10 @@
       "tools": {
         // "terminal": {
         //   "default_mode": "confirm",
-        //   "always_deny": [
-        //     // Dangerous rm commands
-        //     { "pattern": "rm\\s+-rf\\s+(/|\\.\\.|\"|~|\\*)" },
-        //     { "pattern": "rm\\s+-rf\\s*$" },
-        //     // Disk destruction
-        //     { "pattern": "> /dev/sd" },
-        //     { "pattern": "mkfs\\." },
-        //     { "pattern": "dd\\s+if=/dev/(zero|random)" },
-        //     // Fork bomb
-        //     { "pattern": ":\\(\\)\\{\\s*:\\|:&\\s*\\};:" },
-        //     // System files
-        //     { "pattern": "/etc/passwd" },
-        //     { "pattern": "/etc/shadow" },
-        //     // Windows destructive commands
-        //     { "pattern": "del /f /s /q c:\\\\" },
-        //     { "pattern": "format c:" },
-        //     { "pattern": "rd /s /q" },
-        //   ],
         //   "always_confirm": [
-        //     // File deletion
-        //     { "pattern": "rm\\s" },
         //     // Destructive git operations
         //     { "pattern": "git\\s+(reset|clean)\\s+--hard" },
         //     { "pattern": "git\\s+push\\s+(-f|--force)" },
-        //     // Database operations
-        //     { "pattern": "DROP\\s+TABLE", "case_sensitive": true },
-        //     { "pattern": "DELETE\\s+FROM", "case_sensitive": true },
-        //     // Privileged commands
-        //     { "pattern": "sudo\\s" },
         //   ],
         // },
         // "edit_file": {
@@ -1006,31 +981,6 @@
         //     { "pattern": "\\.pem$" },
         //     { "pattern": "\\.key$" },
         //   ],
-        // },
-        // "delete_path": {
-        //   "default_mode": "confirm",
-        //   "always_deny": [
-        //     // System directories
-        //     { "pattern": "^/etc" },
-        //     { "pattern": "^/usr" },
-        //     { "pattern": "^/bin" },
-        //     { "pattern": "^/sbin" },
-        //     { "pattern": "^/var" },
-        //     { "pattern": "^/boot" },
-        //     { "pattern": "^/root" },
-        //     // Home directory root
-        //     { "pattern": "^~$" },
-        //     { "pattern": "^/Users/[^/]+$" },
-        //     { "pattern": "^/home/[^/]+$" },
-        //     // Git directory
-        //     { "pattern": "\\.git/?$" },
-        //     // Windows system directories
-        //     { "pattern": "^C:\\\\Windows" },
-        //     { "pattern": "^C:\\\\Program Files" },
-        //   ],
-        // },
-        // "fetch": {
-        //   "default_mode": "confirm",
         // },
       },
     },


### PR DESCRIPTION
Follow-up to https://github.com/zed-industries/zed/pull/48209 - those hardcoded rules are replacing these default settings, which will make the rules clearer by removing the "override" scenario.

(No release notes because granular tool permissions are still behind a feature flag.)

Release Notes:

- N/A