### PR TITLE
project_panel: Fix test-support feature mismatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12836,6 +12836,7 @@ dependencies = [
  "pretty_assertions",
  "project",
  "rayon",
+ "remote_connection",
  "schemars",
  "search",
  "serde",

--- a/crates/project_panel/Cargo.toml
+++ b/crates/project_panel/Cargo.toml
@@ -54,6 +54,7 @@ criterion.workspace = true
 editor = { workspace = true, features = ["test-support"] }
 gpui = { workspace = true, features = ["test-support"] }
 language = { workspace = true, features = ["test-support"] }
+remote_connection = { workspace = true, features = ["test-support"] }
 serde_json.workspace = true
 tempfile.workspace = true
 workspace = { workspace = true, features = ["test-support"] }


### PR DESCRIPTION
Follow-up to #46337

`project_panel` tests enable `remote/test-support` (via `workspace`/`project`), which adds `RemoteConnectionOptions::Mock`. But without `remote_connection/test-support`, the match arm for that variant isn't compiled, causing a non-exhaustive match error when testing the crate in isolation.

CI doesn't catch this because `git_ui` happens to enable `remote_connection/test-support` during workspace-wide tests.

Release Notes:

- N/A