### PR TITLE
editor: Ensure that spacer blocks are visible in light themes

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -4006,7 +4006,7 @@ impl EditorElement {
                 .w_full()
                 .h((*height as f32) * line_height)
                 .bg(pattern_slash(
-                    cx.theme().colors().border.opacity(0.5),
+                    cx.theme().colors().panel_background,
                     8.0,
                     8.0,
                 ))

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -49,8 +49,8 @@ use gpui::{
     Pixels, PressureStage, ScrollDelta, ScrollHandle, ScrollWheelEvent, ShapedLine, SharedString,
     Size, StatefulInteractiveElement, Style, Styled, StyledText, TextAlign, TextRun,
     TextStyleRefinement, WeakEntity, Window, anchored, deferred, div, fill, linear_color_stop,
-    linear_gradient, outline, pattern_slash, point, px, quad, relative, rgba, size,
-    solid_background, transparent_black,
+    linear_gradient, outline, pattern_slash, point, px, quad, relative, size, solid_background,
+    transparent_black,
 };
 use itertools::Itertools;
 use language::{IndentGuideSettings, language_settings::ShowWhitespaceSetting};
@@ -4005,7 +4005,11 @@ impl EditorElement {
                 .id(block_id)
                 .w_full()
                 .h((*height as f32) * line_height)
-                .bg(pattern_slash(rgba(0xFFFFFF10), 8.0, 8.0))
+                .bg(pattern_slash(
+                    cx.theme().colors().border.opacity(0.5),
+                    8.0,
+                    8.0,
+                ))
                 .into_any(),
         };
 


### PR DESCRIPTION
The color used for the slash pattern when rendering `Block::Spacer` was set to a fixed color, `0xFFFFFF10`, which is almost white, making it super hard to view in light themes, where the editor's background is almost white.

As such, this commit updates that color so as to use something that is more theme-specific, ensuring that it is easily visible in both light and dark themes.

Not entirely sure if the `border` color is the best one for this, so we might need to revisit that, depending on themes.

Release Notes:

- N/A
