### PR TITLE
Remove duplicated logic to unify code paths

### DIFF
--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -9,7 +9,6 @@ use std::path::PathBuf;
 #[cfg(target_os = "windows")]
 mod wsl_picker;
 
-use dev_container::{find_devcontainer_configs, start_dev_container_with_config};
 use remote::RemoteConnectionOptions;
 pub use remote_connection::{RemoteConnectionModal, connect};
 pub use remote_connections::open_remote_project;
@@ -37,8 +36,6 @@ use workspace::{
     with_active_or_new_workspace,
 };
 use zed_actions::{OpenDevContainer, OpenRecent, OpenRemote};
-
-use crate::remote_connections::Connection;
 
 #[derive(Clone, Debug)]
 pub struct RecentProjectEntry {
@@ -235,8 +232,6 @@ pub fn init(cx: &mut App) {
 
     cx.on_action(|_: &OpenDevContainer, cx| {
         with_active_or_new_workspace(cx, move |workspace, window, cx| {
-            let app_state = workspace.app_state().clone();
-            let replace_window = window.window_handle().downcast::<Workspace>();
             let is_local = workspace.project().read(cx).is_local();
 
             cx.spawn_in(window, async move |_, cx| {
@@ -252,70 +247,16 @@ pub fn init(cx: &mut App) {
                     return;
                 }
 
-                let configs = find_devcontainer_configs(cx);
-
-                if configs.len() > 1 {
-                    // Multiple configs found - show modal for selection
-                    cx.update(|_, cx| {
-                        with_active_or_new_workspace(cx, move |workspace, window, cx| {
-                            let fs = workspace.project().read(cx).fs().clone();
-                            let handle = cx.entity().downgrade();
-                            workspace.toggle_modal(window, cx, |window, cx| {
-                                RemoteServerProjects::new_dev_container(fs, window, handle, cx)
-                            });
+                cx.update(|_, cx| {
+                    with_active_or_new_workspace(cx, move |workspace, window, cx| {
+                        let fs = workspace.project().read(cx).fs().clone();
+                        let handle = cx.entity().downgrade();
+                        workspace.toggle_modal(window, cx, |window, cx| {
+                            RemoteServerProjects::new_dev_container(fs, window, handle, cx)
                         });
-                    })
-                    .log_err();
-                    return;
-                }
-
-                // Single or no config - proceed with opening directly
-                let config = configs.into_iter().next();
-                let (connection, starting_dir) = match start_dev_container_with_config(
-                    cx,
-                    app_state.node_runtime.clone(),
-                    config,
-                )
-                .await
-                {
-                    Ok((c, s)) => (Connection::DevContainer(c), s),
-                    Err(e) => {
-                        log::error!("Failed to start Dev Container: {:?}", e);
-                        cx.prompt(
-                            gpui::PromptLevel::Critical,
-                            "Failed to start Dev Container",
-                            Some(&format!("{:?}", e)),
-                            &["Ok"],
-                        )
-                        .await
-                        .ok();
-                        return;
-                    }
-                };
-
-                let result = open_remote_project(
-                    connection.into(),
-                    vec![starting_dir].into_iter().map(PathBuf::from).collect(),
-                    app_state,
-                    OpenOptions {
-                        replace_window,
-                        ..OpenOptions::default()
-                    },
-                    cx,
-                )
-                .await;
-
-                if let Err(e) = result {
-                    log::error!("Failed to connect: {e:#}");
-                    cx.prompt(
-                        gpui::PromptLevel::Critical,
-                        "Failed to connect",
-                        Some(&e.to_string()),
-                        &["Ok"],
-                    )
-                    .await
-                    .ok();
-                }
+                    });
+                })
+                .log_err();
             })
             .detach();
         });


### PR DESCRIPTION
Small fix for a bug introduced in #47411
In-progress dev container creation didn't show up in modal because of a duplicated code path. This unifies the logic and ensures that "creating dev container" shows up while creation in progress.

Release Notes:

- Fixed modal for creating dev container
