### PR TITLE
ci: Temporarily disable docs deployments

### DIFF
--- a/.github/workflows/deploy_cloudflare.yml
+++ b/.github/workflows/deploy_cloudflare.yml
@@ -25,12 +25,13 @@ jobs:
         env:
           DOCS_AMPLITUDE_API_KEY: ${{ secrets.DOCS_AMPLITUDE_API_KEY }}
 
-      - name: Deploy Docs
-        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy target/deploy --project-name=docs
+      # Temporarily disabled due to a Cloudflare Pages incident.
+      # - name: Deploy Docs
+      #   uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3
+      #   with:
+      #     apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      #     accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      #     command: pages deploy target/deploy --project-name=docs
 
       - name: Deploy Install
         uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3


### PR DESCRIPTION
This PR temporarily disables deployments of the docs.

There seems to be some lingering fallout from https://www.cloudflarestatus.com/incidents/jk2mx637l9k9 that is causing new deployments to not work.

We are rolling back to an older deployment, and are disabling deploys so that we don't clobber the rollback.

Release Notes:

- N/A
