### PR TITLE
Simplify error message and provide a route to Zed log

### DIFF
--- a/crates/dev_container/src/devcontainer_api.rs
+++ b/crates/dev_container/src/devcontainer_api.rs
@@ -78,14 +78,14 @@ impl Display for DevContainerError {
             "{}",
             match self {
                 DevContainerError::DockerNotAvailable =>
-                    "Docker CLI not found on $PATH".to_string(),
+                    "docker CLI not found on $PATH".to_string(),
                 DevContainerError::DevContainerCliNotAvailable =>
-                    "Docker not found on path".to_string(),
-                DevContainerError::DevContainerUpFailed(message) => {
-                    format!("DevContainer creation failed with error: {}", message)
+                    "devcontainer CLI not found on path".to_string(),
+                DevContainerError::DevContainerUpFailed(_) => {
+                    "DevContainer creation failed".to_string()
                 }
-                DevContainerError::DevContainerTemplateApplyFailed(message) => {
-                    format!("DevContainer template apply failed with error: {}", message)
+                DevContainerError::DevContainerTemplateApplyFailed(_) => {
+                    "DevContainer template apply failed".to_string()
                 }
                 DevContainerError::DevContainerNotFound =>
                     "No valid dev container definition found in project".to_string(),
@@ -255,13 +255,6 @@ pub fn find_devcontainer_configs(cx: &mut AsyncWindowContext) -> Vec<DevContaine
     };
 
     configs
-}
-
-pub async fn start_dev_container(
-    cx: &mut AsyncWindowContext,
-    node_runtime: NodeRuntime,
-) -> Result<(DevContainerConnection, String), DevContainerError> {
-    start_dev_container_with_config(cx, node_runtime, None).await
 }
 
 pub async fn start_dev_container_with_config(
@@ -479,7 +472,7 @@ async fn devcontainer_up(
                 parse_json_from_cli(&raw)
             } else {
                 let message = format!(
-                    "Non-success status running devcontainer up for workspace: out: {:?}, err: {:?}",
+                    "Non-success status running devcontainer up for workspace: out: {}, err: {}",
                     String::from_utf8_lossy(&output.stdout),
                     String::from_utf8_lossy(&output.stderr)
                 );

--- a/crates/dev_container/src/lib.rs
+++ b/crates/dev_container/src/lib.rs
@@ -47,8 +47,7 @@ use crate::devcontainer_api::DevContainerError;
 use crate::devcontainer_api::apply_dev_container_template;
 
 pub use devcontainer_api::{
-    DevContainerConfig, find_devcontainer_configs, start_dev_container,
-    start_dev_container_with_config,
+    DevContainerConfig, find_devcontainer_configs, start_dev_container_with_config,
 };
 
 #[derive(RegisterSetting)]

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -238,7 +238,7 @@ pub fn init(cx: &mut App) {
                 if !is_local {
                     cx.prompt(
                         gpui::PromptLevel::Critical,
-                        "Cannot open Dev Container from remote  project",
+                        "Cannot open Dev Container from remote project",
                         None,
                         &["Ok"],
                     )


### PR DESCRIPTION
Closes #46780

Creates a better flow for handling errors when a devcontainer fails, by shortening the message and giving the user a direct route to the Zed log. Additionally, the error from `stderr` is printed with proper line endings, making the log more legible

<img width="1716" height="1093" alt="Screenshot 2026-02-03 at 2 54 50 PM" src="https://github.com/user-attachments/assets/08d7847b-c9b8-49e9-9936-6ae417f82fb2" />
<img width="1711" height="908" alt="Screenshot 2026-02-03 at 2 55 07 PM" src="https://github.com/user-attachments/assets/a2676419-a118-432e-8e8a-32c6e92f4f3b" />
<img width="2901" height="542" alt="Screenshot 2026-02-03 at 2 55 48 PM" src="https://github.com/user-attachments/assets/ea9de533-c1c6-4cb7-bd79-e44bd035537c" />


Release Notes:

- Improved error messaging and handling in the event of a devcontainer launch failure
