### PR TITLE
ci: Re-enable docs deployments

### DIFF
--- a/.github/workflows/deploy_cloudflare.yml
+++ b/.github/workflows/deploy_cloudflare.yml
@@ -25,13 +25,12 @@ jobs:
         env:
           DOCS_AMPLITUDE_API_KEY: ${{ secrets.DOCS_AMPLITUDE_API_KEY }}
 
-      # Temporarily disabled due to a Cloudflare Pages incident.
-      # - name: Deploy Docs
-      #   uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3
-      #   with:
-      #     apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      #     accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-      #     command: pages deploy target/deploy --project-name=docs
+      - name: Deploy Docs
+        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy target/deploy --project-name=docs
 
       - name: Deploy Install
         uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3


### PR DESCRIPTION
This PR re-enables docs deployments.

The upstream incident has been resolved: https://www.cloudflarestatus.com/incidents/m1xvmqf37z97

Release Notes:

- N/A
