### PR TITLE
remote: Reuse existing window when opening zed://ssh/ URLs for the same host

### DIFF
--- a/crates/remote/src/remote_client.rs
+++ b/crates/remote/src/remote_client.rs
@@ -1275,6 +1275,21 @@ impl RemoteConnectionOptions {
             RemoteConnectionOptions::Mock(opts) => format!("mock-{}", opts.id),
         }
     }
+
+    pub fn same_host(&self, other: &Self) -> bool {
+        match (self, other) {
+            (RemoteConnectionOptions::Ssh(a), RemoteConnectionOptions::Ssh(b)) => {
+                a.host == b.host && a.username == b.username && a.port == b.port
+            }
+            (RemoteConnectionOptions::Wsl(a), RemoteConnectionOptions::Wsl(b)) => a == b,
+            (RemoteConnectionOptions::Docker(a), RemoteConnectionOptions::Docker(b)) => {
+                a.container_id == b.container_id
+            }
+            #[cfg(any(test, feature = "test-support"))]
+            (RemoteConnectionOptions::Mock(a), RemoteConnectionOptions::Mock(b)) => a.id == b.id,
+            _ => false,
+        }
+    }
 }
 
 impl From<SshConnectionOptions> for RemoteConnectionOptions {


### PR DESCRIPTION
When opening a `zed://ssh/$AUTHORITY/$PATH` url, zed always opened a new
window, even if there is already a window connected to that host. Now it
finds an existing workspace window with a matching remote connection and
opens the file there instead. This matches the behavior of the `zed` cli
when opening a local path.

Release Notes:

- Opening `zed://ssh/` urls will now reuse an existing window if possible.
