### PR TITLE
gpui: Allow OS caption/buttons for custom Windows titlebar

### DIFF
--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -958,8 +958,7 @@ impl WindowsWindowInner {
                 click_count,
                 first_mouse: false,
             });
-            let result = func(input);
-            let handled = !result.propagate || result.default_prevented;
+            let handled = !func(input).propagate;
             self.state.callbacks.input.set(Some(func));
 
             if handled {


### PR DESCRIPTION
## Summary
Fixes an issue where GPUI's handling of `WM_NCLBUTTONDOWN` prevented Windows from processing default titlebar interactions (dragging, caption buttons, and border resize).

## Changes
- Allow OS to handle `WM_NCLBUTTONDOWN` events for `HTCAPTION`, caption button areas, and resize border areas (`HTLEFT`, `HTRIGHT`, `HTTOP`, `HTBOTTOM`, `HTTOPLEFT`, `HTTOPRIGHT`, `HTBOTTOMLEFT`, `HTBOTTOMRIGHT`)
- Use current cursor position in `WM_NCHITTEST` for accurate hit-testing

## Testing
- Manual testing on Windows: titlebar dragging works
- Manual testing on Windows: minimize/maximize/close buttons work
- Manual testing on Windows: window border resize works in all directions

Release Notes:
- N/A