### PR TITLE
lsp: Add schema support for LSP settings field

### DIFF
--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -347,6 +347,17 @@ impl CachedLspAdapter {
             .await
     }
 
+    pub async fn settings_schema(
+        &self,
+        delegate: &Arc<dyn LspAdapterDelegate>,
+        cx: &mut AsyncApp,
+    ) -> Option<serde_json::Value> {
+        self.adapter
+            .clone()
+            .settings_schema(delegate, self.cached_binary.clone().lock_owned().await, cx)
+            .await
+    }
+
     pub fn process_prompt_response(&self, context: &PromptResponseContext, cx: &mut AsyncApp) {
         self.adapter.process_prompt_response(context, cx)
     }
@@ -479,6 +490,18 @@ pub trait LspAdapter: 'static + Send + Sync + DynLspInstaller {
 
     /// Returns the JSON schema of the initialization_options for the language server.
     async fn initialization_options_schema(
+        self: Arc<Self>,
+        _delegate: &Arc<dyn LspAdapterDelegate>,
+        _cached_binary: OwnedMutexGuard<Option<(bool, LanguageServerBinary)>>,
+        _cx: &mut AsyncApp,
+    ) -> Option<serde_json::Value> {
+        None
+    }
+
+    /// Returns the JSON schema of the settings for the language server.
+    /// This corresponds to the `settings` field in `LspSettings`, which is used
+    /// to respond to `workspace/configuration` requests from the language server.
+    async fn settings_schema(
         self: Arc<Self>,
         _delegate: &Arc<dyn LspAdapterDelegate>,
         _cached_binary: OwnedMutexGuard<Option<(bool, LanguageServerBinary)>>,

--- a/crates/settings/src/settings_store.rs
+++ b/crates/settings/src/settings_store.rs
@@ -1032,7 +1032,13 @@ impl SettingsStore {
                         properties_object.insert(
                             "initialization_options".to_string(),
                             serde_json::json!({
-                                "$ref": format!("{LSP_SETTINGS_SCHEMA_URL_PREFIX}{adapter_name}")
+                                "$ref": format!("{LSP_SETTINGS_SCHEMA_URL_PREFIX}{adapter_name}/initialization_options")
+                            }),
+                        );
+                        properties_object.insert(
+                            "settings".to_string(),
+                            serde_json::json!({
+                                "$ref": format!("{LSP_SETTINGS_SCHEMA_URL_PREFIX}{adapter_name}/settings")
                             }),
                         );
                     }
@@ -2352,7 +2358,23 @@ mod tests {
             .as_str()
             .unwrap();
 
-        assert_eq!(init_options_ref, "zed://schemas/settings/lsp/rust-analyzer");
+        assert_eq!(
+            init_options_ref,
+            "zed://schemas/settings/lsp/rust-analyzer/initialization_options"
+        );
+
+        let settings_ref = properties
+            .get("rust-analyzer")
+            .unwrap()
+            .pointer("/properties/settings/$ref")
+            .expect("settings should have a $ref")
+            .as_str()
+            .unwrap();
+
+        assert_eq!(
+            settings_ref,
+            "zed://schemas/settings/lsp/rust-analyzer/settings"
+        );
     }
 
     #[gpui::test]
@@ -2387,7 +2409,23 @@ mod tests {
             .as_str()
             .unwrap();
 
-        assert_eq!(init_options_ref, "zed://schemas/settings/lsp/rust-analyzer");
+        assert_eq!(
+            init_options_ref,
+            "zed://schemas/settings/lsp/rust-analyzer/initialization_options"
+        );
+
+        let settings_ref = properties
+            .get("rust-analyzer")
+            .unwrap()
+            .pointer("/properties/settings/$ref")
+            .expect("settings should have a $ref")
+            .as_str()
+            .unwrap();
+
+        assert_eq!(
+            settings_ref,
+            "zed://schemas/settings/lsp/rust-analyzer/settings"
+        );
     }
 
     #[gpui::test]


### PR DESCRIPTION
This extends the LSP settings schema system to also provide autocomplete for the `settings` field (used for `workspace/configuration` responses), in addition to the existing `initialization_options` support (#).

Changes:
- Add `settings_schema` method to `LspAdapter` trait and `CachedLspAdapter`
- Update schema URL paths to be more explicit:
  - `lsp/{adapter}/initialization_options` for init options schema
  - `lsp/{adapter}/settings` for settings schema
- Add schema resolution logic for the new settings path
- Update tests to verify both schema references

Release Notes:

- Added autocomplete support for the `settings` field in LSP configuration, complementing the existing `initialization_options` autocomplete.