### PR TITLE
gpui: Add `MicaBackdrop` and `MicaAltBackdrop` to be selectable on themes

### DIFF
--- a/crates/settings/src/content_into_gpui.rs
+++ b/crates/settings/src/content_into_gpui.rs
@@ -50,6 +50,8 @@ impl IntoGpui for WindowBackgroundContent {
             WindowBackgroundContent::Opaque => WindowBackgroundAppearance::Opaque,
             WindowBackgroundContent::Transparent => WindowBackgroundAppearance::Transparent,
             WindowBackgroundContent::Blurred => WindowBackgroundAppearance::Blurred,
+            WindowBackgroundContent::MicaBackdrop => WindowBackgroundAppearance::MicaBackdrop,
+            WindowBackgroundContent::MicaAltBackdrop => WindowBackgroundAppearance::MicaAltBackdrop,
         }
     }
 }

--- a/crates/settings_content/src/theme.rs
+++ b/crates/settings_content/src/theme.rs
@@ -1260,6 +1260,8 @@ pub enum WindowBackgroundContent {
     Opaque,
     Transparent,
     Blurred,
+    MicaBackdrop,
+    MicaAltBackdrop,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, MergeFrom, PartialEq)]

--- a/crates/ui/src/styles/appearance.rs
+++ b/crates/ui/src/styles/appearance.rs
@@ -14,6 +14,6 @@ fn window_appearance(cx: &mut App) -> WindowBackgroundAppearance {
 pub fn theme_is_transparent(cx: &mut App) -> bool {
     matches!(
         window_appearance(cx),
-        WindowBackgroundAppearance::Transparent | WindowBackgroundAppearance::Blurred
+        WindowBackgroundAppearance::Transparent | WindowBackgroundAppearance::Blurred | WindowBackgroundAppearance::MicaBackdrop | WindowBackgroundAppearance::MicaAltBackdrop
     )
 }


### PR DESCRIPTION
Following #41842, this is an extension to that contribution and it enables `MicaBackdrop` and `MicaAltBackdrop` for `"background.appearance"`

Release Notes:

- Add `MicaBackdrop` and `MicaAltBackdrop` to be selectable on themes

Additional Notes:

If PR is merged, theme schema should be updated to 0.2.1 or higher
