### PR TITLE
Do not treat binary Doom WAD files as text

### DIFF
--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -6129,4 +6129,6 @@ fn is_known_binary_header(bytes: &[u8]) -> bool {
         || bytes.starts_with(b"\xFF\xD8\xFF") // JPEG
         || bytes.starts_with(b"GIF87a") // GIF87a
         || bytes.starts_with(b"GIF89a") // GIF89a
+        || bytes.starts_with(b"IWAD") // Doom IWAD archive
+        || bytes.starts_with(b"PWAD") // Doom PWAD archive
 }


### PR DESCRIPTION
I primarily contribute to Doom source ports and related utilities. When working with Doom WADs, the primary archive format for the game, Zed will sometimes incorrectly assume that such files are plain text, due to the nature of said container format not being compressed, some common text files included in them will trigger a false positive in Zed's text detection mode.

Considering some of these files can go from a couple dozen to a few hundred megabytes, this usually makes Zed hang on my lower end machine, until I manually terminate it :/ and has happened when I accidentally clicked on one via the file explorer, or when viewing Git diffs.

Release Notes:

- Fixed Doom WAD files being erroneously treated as text