### PR TITLE
Fix incorrect first line detection for libstdc++ files

### DIFF
--- a/crates/languages/src/cpp/config.toml
+++ b/crates/languages/src/cpp/config.toml
@@ -2,7 +2,7 @@ name = "C++"
 grammar = "cpp"
 path_suffixes = ["cc", "hh", "cpp", "h", "hpp", "cxx", "hxx", "c++", "h++", "ipp", "inl", "ino", "ixx", "cu", "cuh", "C", "H"]
 line_comments = ["// ", "/// ", "//! "]
-first_line_pattern = '\/\/\s*(<.*>\s)?-\*-\s*C\+\+\s*-\*-'
+first_line_pattern = '^//.*-\*-\s*C\+\+\s*-\*-'
 decrease_indent_patterns = [
   { pattern = "^\\s*\\{.*\\}?\\s*$", valid_after = ["if", "for", "while", "do", "switch", "else"] },
   { pattern = "^\\s*else\\b", valid_after = ["if"] }


### PR DESCRIPTION
https://github.com/zed-industries/zed/pull/48250#issuecomment-3846774856

To ensure the fix covers all affected files, I have checked all C++ files without extensions using the following command:
```bash
find /usr/include/c++ -type f | grep -v '.h' | grep -v '.cpp' | grep -v '.tcc' | xargs head -1 | zed -
```

<details>
  <summary>Click to expand images</summary>
<img width="940" height="935" alt="image" src="https://github.com/user-attachments/assets/d0346ad4-d9f7-47d5-a85e-cb574dacf290" />

<img width="956" height="939" alt="image" src="https://github.com/user-attachments/assets/d9e872fc-f2b8-4fff-b5a9-99e8a4fc21a3" />

<img width="953" height="940" alt="image" src="https://github.com/user-attachments/assets/dee53cd4-d598-4d65-918d-353b037cdf1b" />

<img width="956" height="938" alt="image" src="https://github.com/user-attachments/assets/777b899c-db25-4dc8-b4a5-fafe28cc14a4" />

</details>

Release Notes:

- N/A
