### PR TITLE
languages: Do not show Zed keybinding context in language selector

### DIFF
--- a/crates/languages/src/zed-keybind-context/config.toml
+++ b/crates/languages/src/zed-keybind-context/config.toml
@@ -1,5 +1,6 @@
 name = "Zed Keybind Context"
 grammar = "rust"
+hidden = true
 autoclose_before = ")"
 brackets = [
     { start = "(", end = ")", close = true, newline = false },


### PR DESCRIPTION
This language is used for the keymap editor and should not be selectable for normal files. Hence, removing it here from the language selector

Release Notes:

- Fixed an issue where the Zed keybinding context would show up as a language in the language selector.
