### PR TITLE
agent_ui: Fix regression that made edited files unclickable

### DIFF
--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -5764,7 +5764,6 @@ impl AcpServerView {
                         })
                     }),
             )
-            .child(Divider::vertical().color(DividerColor::BorderVariant))
             .child(
                 Button::new(("reject-file", index), "Reject")
                     .label_size(LabelSize::Small)
@@ -5919,34 +5918,24 @@ impl AcpServerView {
                                         )
                                         .label_size(LabelSize::XSmall),
                                     )
-                                    .when(
-                                        match self.as_active_thread() {
-                                            Some(thread) => {
-                                                thread.hovered_edited_file_buttons == Some(index)
-                                            }
-                                            None => false,
-                                        },
-                                        |this| {
-                                            let full_path = full_path.clone();
-                                            this.hover(|s| s.bg(cx.theme().colors().element_hover))
-                                                .tooltip(move |_, cx| {
-                                                    Tooltip::with_meta(
-                                                        "Go to File",
-                                                        None,
-                                                        full_path.clone(),
-                                                        cx,
-                                                    )
-                                                })
-                                                .on_click({
-                                                    let buffer = buffer.clone();
-                                                    cx.listener(move |this, _, window, cx| {
-                                                        this.open_edited_buffer(
-                                                            &buffer, window, cx,
-                                                        );
-                                                    })
-                                                })
-                                        },
-                                    ),
+                                    .hover(|s| s.bg(cx.theme().colors().element_hover))
+                                    .tooltip({
+                                        let full_path = full_path.clone();
+                                        move |_, cx| {
+                                            Tooltip::with_meta(
+                                                "Go to File",
+                                                None,
+                                                full_path.clone(),
+                                                cx,
+                                            )
+                                        }
+                                    })
+                                    .on_click({
+                                        let buffer = buffer.clone();
+                                        cx.listener(move |this, _, window, cx| {
+                                            this.open_edited_buffer(&buffer, window, cx);
+                                        })
+                                    }),
                             )
                             .child(buttons);
 

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -5920,7 +5920,6 @@ impl AcpServerView {
                                     )
                                     .hover(|s| s.bg(cx.theme().colors().element_hover))
                                     .tooltip({
-                                        let full_path = full_path.clone();
                                         move |_, cx| {
                                             Tooltip::with_meta(
                                                 "Go to File",


### PR DESCRIPTION
There was a `when()` condition here looking at `hovered_edited_file_buttons`, which is never turned to true when hovering over the edited file button, and given we started to pass the hover styles, tooltip, and on_click handler inside the condition, they would never work. The solution here is to make these three things unconditional, so edited files are always clickable.

Release Notes:

- N/A
