### PR TITLE
ep: Lower max_output_tokens default for Ollama

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1503,7 +1503,7 @@
     "ollama": {
       "api_url": "http://localhost:11434",
       "model": "qwen2.5-coder:7b-base",
-      "max_output_tokens": 256,
+      "max_output_tokens": 64,
     },
     // Whether edit predictions are enabled when editing text threads in the agent panel.
     // This setting has no effect if globally disabled.

--- a/crates/edit_prediction/src/ollama.rs
+++ b/crates/edit_prediction/src/ollama.rs
@@ -3,7 +3,7 @@ use crate::{
     prediction::EditPredictionResult,
     zeta1::{
         self, MAX_CONTEXT_TOKENS as ZETA_MAX_CONTEXT_TOKENS,
-        MAX_EVENT_TOKENS as ZETA_MAX_EVENT_TOKENS,
+        MAX_EVENT_TOKENS as ZETA_MAX_EVENT_TOKENS, MAX_REWRITE_TOKENS as ZETA_MAX_REWRITE_TOKENS,
     },
 };
 use anyhow::{Context as _, Result};
@@ -136,7 +136,7 @@ impl Ollama {
                     cursor_point,
                     &path_str,
                     &snapshot,
-                    max_output_tokens as usize,
+                    ZETA_MAX_REWRITE_TOKENS,
                     ZETA_MAX_CONTEXT_TOKENS,
                 );
                 let input_events = zeta1::prompt_for_events(&events, ZETA_MAX_EVENT_TOKENS);

--- a/crates/edit_prediction/src/ollama.rs
+++ b/crates/edit_prediction/src/ollama.rs
@@ -3,7 +3,7 @@ use crate::{
     prediction::EditPredictionResult,
     zeta1::{
         self, MAX_CONTEXT_TOKENS as ZETA_MAX_CONTEXT_TOKENS,
-        MAX_EVENT_TOKENS as ZETA_MAX_EVENT_TOKENS, MAX_REWRITE_TOKENS as ZETA_MAX_REWRITE_TOKENS,
+        MAX_EVENT_TOKENS as ZETA_MAX_EVENT_TOKENS,
     },
 };
 use anyhow::{Context as _, Result};
@@ -110,7 +110,6 @@ impl Ollama {
         let Some(model) = settings.model.clone() else {
             return Task::ready(Ok(None));
         };
-        let max_output_tokens = settings.max_output_tokens;
         let api_url = settings.api_url.clone();
 
         log::debug!("Ollama: Requesting completion (model: {})", model);
@@ -127,7 +126,18 @@ impl Ollama {
 
         let is_zeta = is_zeta_model(&model);
 
+        // Zeta generates more tokens than FIM models. Ideally, we'd use MAX_REWRITE_TOKENS,
+        // but this might be too slow for local deployments. So we make it configurable,
+        // but we also have this hardcoded multiplier for now.
+        let max_output_tokens = if is_zeta {
+            settings.max_output_tokens * 4
+        } else {
+            settings.max_output_tokens
+        };
+
         let result = cx.background_spawn(async move {
+            let zeta_editable_region_tokens = max_output_tokens as usize;
+
             // For zeta models, use the dedicated zeta1 functions which handle their own
             // range computation with the correct token limits.
             let (prompt, stop_tokens, editable_range_override, inputs) = if is_zeta {
@@ -136,7 +146,7 @@ impl Ollama {
                     cursor_point,
                     &path_str,
                     &snapshot,
-                    ZETA_MAX_REWRITE_TOKENS,
+                    zeta_editable_region_tokens,
                     ZETA_MAX_CONTEXT_TOKENS,
                 );
                 let input_events = zeta1::prompt_for_events(&events, ZETA_MAX_EVENT_TOKENS);


### PR DESCRIPTION
Zeta 1 should not be configurable, not by this setting.

Release Notes:

- N/A
