### PR TITLE
Fix scroll in EP provider sub page when setting migration banner is showing

### DIFF
--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -3300,6 +3300,7 @@ impl SettingsWindow {
             .child(
                 div()
                     .flex_1()
+                    .min_h_0()
                     .size_full()
                     .tab_group()
                     .tab_index(CONTENT_GROUP_TAB_INDEX)


### PR DESCRIPTION
Closes #ISSUE

Release Notes:

- N/A *or* Added/Fixed/Improved ...
