### PR TITLE
git: Ensure the sides of the side-by-side diff use the same hunk controls

### DIFF
--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -288,6 +288,13 @@ impl ProjectDiff {
                 window,
                 cx,
             );
+            match branch_diff.read(cx).diff_base() {
+                DiffBase::Head => {}
+                DiffBase::Merge { .. } => diff_display_editor.set_render_diff_hunk_controls(
+                    Arc::new(|_, _, _, _, _, _, _, _| gpui::Empty.into_any_element()),
+                    cx,
+                ),
+            }
             diff_display_editor.rhs_editor().update(cx, |editor, cx| {
                 editor.disable_diagnostics(cx);
                 editor.set_show_diff_review_button(true, cx);
@@ -303,10 +310,6 @@ impl ProjectDiff {
                             branch_diff: branch_diff.clone(),
                         });
                         editor.start_temporary_diff_override();
-                        editor.set_render_diff_hunk_controls(
-                            Arc::new(|_, _, _, _, _, _, _, _| gpui::Empty.into_any_element()),
-                            cx,
-                        );
                     }
                 }
             });


### PR DESCRIPTION
Fixes hunk controls appearing on the LHS of the branch diff when they should be disabled

Release Notes:

- N/A