### PR TITLE
project: Change `INACTIVE_DIAGNOSTIC_SEVERITY` to Hint

### DIFF
--- a/crates/project/src/lsp_store/clangd_ext.rs
+++ b/crates/project/src/lsp_store/clangd_ext.rs
@@ -10,7 +10,7 @@ use crate::{LspStore, lsp_store::DocumentDiagnosticsUpdate};
 
 pub const CLANGD_SERVER_NAME: LanguageServerName = LanguageServerName::new_static("clangd");
 const INACTIVE_REGION_MESSAGE: &str = "inactive region";
-const INACTIVE_DIAGNOSTIC_SEVERITY: lsp::DiagnosticSeverity = lsp::DiagnosticSeverity::INFORMATION;
+const INACTIVE_DIAGNOSTIC_SEVERITY: lsp::DiagnosticSeverity = lsp::DiagnosticSeverity::HINT;
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
The diagnostic severity of Inactive Regions is at the same Info level as clangd's UnusedIncludes and MissingIncludes. So they appear on the scrollbar the same way. The latter can be fixed with code changes, but inactive regions are usually not.

Set the severity level of Inactive Regions one level lower to Note.

Release Notes:

- Changed Inactive Region severity level to Note
