### PR TITLE
agent_settings: Fix Bedrock model catalog URL

### DIFF
--- a/crates/language_models/src/provider/bedrock.rs
+++ b/crates/language_models/src/provider/bedrock.rs
@@ -1404,7 +1404,7 @@ impl Render for ConfigurationView {
                             .child(Label::new("Select the models you would like access to:"))
                             .child(ButtonLink::new(
                                 "Bedrock Model Catalog",
-                                "https://us-east-1.console.aws.amazon.com/bedrock/home?region=us-east-1#/modelaccess",
+                                "https://us-east-1.console.aws.amazon.com/bedrock/home?region=us-east-1#/model-catalog",
                             )),
                     ),
             )


### PR DESCRIPTION
The previous URL pointed to the model access page which no longer exists (not a 404, tho). The model catalog page is the current location for selecting and requesting access to Bedrock models.

| Before | After |
|--------|--------|
| <img width="1732" height="1125" alt="Screenshot 2026-02-04 at 12 50 13" src="https://github.com/user-attachments/assets/f513e7c9-aa70-439a-afd0-ef8177ada463" /> | <img width="1732" height="1125" alt="Screenshot 2026-02-04 at 12 52 11" src="https://github.com/user-attachments/assets/6609215e-1bbb-4ed1-b57d-422ed7893498" /> |

Release Notes:

- Fixed Bedrock model catalog URL in Agent Panel settings