### PR TITLE
Refer to devcontainer.js rather than devcontainer.cmd.js

### DIFF
--- a/crates/dev_container/src/devcontainer_api.rs
+++ b/crates/dev_container/src/devcontainer_api.rs
@@ -334,6 +334,10 @@ fn dev_container_cli() -> String {
     "devcontainer.cmd".to_string()
 }
 
+fn dev_container_script() -> String {
+    "devcontainer.js".to_string()
+}
+
 async fn check_for_docker(use_podman: bool) -> Result<(), DevContainerError> {
     let mut command = if use_podman {
         util::command::new_smol_command("podman")
@@ -371,7 +375,7 @@ async fn ensure_devcontainer_cli(
             .join("node_modules")
             .join("@devcontainers")
             .join("cli")
-            .join(format!("{}.js", &dev_container_cli()));
+            .join(&dev_container_script());
 
         log::debug!(
             "devcontainer not found in path, using local location: ${}",


### PR DESCRIPTION
Closes #46947

When installed with `npm install -g`, devcontainer gets created as `devcontainer.cmd`. However, when invoked as a script from node, it's still `devcontainer.js`. This addresses that difference so that we don't accidentally invoke `devcontainer.cmd.js`.

Release Notes:

- Fixed devcontainer operation on Windows for when the devcontainer cli is not installed globally
