### PR TITLE
git: Fix branch diff not updating when committing or changing branches

### DIFF
--- a/crates/project/src/git_store/branch_diff.rs
+++ b/crates/project/src/git_store/branch_diff.rs
@@ -70,7 +70,7 @@ impl BranchDiff {
                     }
                     GitStoreEvent::RepositoryUpdated(
                         event_repo_id,
-                        RepositoryEvent::StatusesChanged,
+                        RepositoryEvent::StatusesChanged | RepositoryEvent::BranchChanged,
                         _,
                     ) => this
                         .repo


### PR DESCRIPTION
This regressed in #47619 -- previously we would throw away and reopen the diffs used to construct the branch diff pretty eagerly, and as a result the branch diff would update itself when you committed or switched branches. We inadvertently lost that when we switched to retaining those diffs in the git store.

Release Notes:

- N/A