### PR TITLE
docs: Add documentation for granular tool permissions

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -13,6 +13,7 @@
 - [Overview](./ai/overview.md)
 - [Agent Panel](./ai/agent-panel.md)
   - [Tools](./ai/tools.md)
+  - [Tool Permissions](./ai/tool-permissions.md)
   - [External Agents](./ai/external-agents.md)
 - [Inline Assistant](./ai/inline-assistant.md)
 - [Edit Prediction](./ai/edit-prediction.md)

--- a/docs/src/ai/agent-panel.md
+++ b/docs/src/ai/agent-panel.md
@@ -173,15 +173,15 @@ To delete a custom profile, open the Agent Profile modal, select the profile you
 
 Zed's Agent Panel provides the `agent.tool_permissions.default` setting to control tool approval behavior:
 
-- `"confirm"` (default) - Prompts for approval before running any tool action
-- `"allow"` - Auto-approves tool actions without prompting
-- `"deny"` - Blocks all tool actions
+- `"confirm"` (default) — Prompts for approval before running any tool action
+- `"allow"` — Auto-approves tool actions without prompting
+- `"deny"` — Blocks all tool actions
 
 You can change this in either your `settings.json` or via the Agent Panel's settings view.
 
-Even with `default: "allow"`, you can configure per-tool rules using `always_deny` and `always_confirm` patterns to maintain safety guardrails for specific commands. For example, you can auto-approve most actions while still requiring confirmation for `sudo` commands.
+For more granular control, you can configure per-tool permission rules using regex patterns to auto-approve trusted actions, block dangerous ones, or always require confirmation for sensitive operations. See [Tool Permissions](./tool-permissions.md) for details.
 
-You can also give more granular permissions through the dropdown that appears in the UI whenever the agent requests authorization to run a tool call.
+When the agent requests permission for an action, the confirmation dialog includes options to allow or deny once, as well as "Always allow" and "Always deny" options that automatically add the appropriate pattern to your settings.
 
 ### Model Support {#model-support}
 

--- a/docs/src/ai/agent-settings.md
+++ b/docs/src/ai/agent-settings.md
@@ -68,7 +68,7 @@ Here's how you can customize your `settings.json` to add this functionality:
     "inline_alternatives": [
       {
         "provider": "zed.dev",
-        "model": "gpt-4-mini"
+        "model": "gpt-5-mini"
       }
     ]
   }
@@ -92,7 +92,7 @@ One with Claude Sonnet 4 (the default model), another with GPT-5-mini, and anoth
     "inline_alternatives": [
       {
         "provider": "zed.dev",
-        "model": "gpt-4-mini"
+        "model": "gpt-5-mini"
       },
       {
         "provider": "zed.dev",
@@ -108,23 +108,27 @@ One with Claude Sonnet 4 (the default model), another with GPT-5-mini, and anoth
 Specify a custom temperature for a provider and/or model:
 
 ```json [settings]
-"model_parameters": [
-  // To set parameters for all requests to OpenAI models:
-  {
-    "provider": "openai",
-    "temperature": 0.5
-  },
-  // To set parameters for all requests in general:
-  {
-    "temperature": 0
-  },
-  // To set parameters for a specific provider and model:
-  {
-    "provider": "zed.dev",
-    "model": "claude-sonnet-4",
-    "temperature": 1.0
+{
+  "agent": {
+    "model_parameters": [
+      // To set parameters for all requests to OpenAI models:
+      {
+        "provider": "openai",
+        "temperature": 0.5
+      },
+      // To set parameters for all requests in general:
+      {
+        "temperature": 0
+      },
+      // To set parameters for a specific provider and model:
+      {
+        "provider": "zed.dev",
+        "model": "claude-sonnet-4",
+        "temperature": 1.0
+      }
+    ]
   }
-],
+}
 ```
 
 ## Agent Panel Settings {#agent-panel-settings}
@@ -146,37 +150,42 @@ You can choose between `thread` (the default) and `text_thread`:
 
 ### Font Size
 
-Use the `agent_font_size` setting to change the font size of rendered agent responses in the panel.
+Use the `agent_ui_font_size` setting to change the font size of rendered agent responses in the panel.
 
 ```json [settings]
 {
-  "agent": {
-    "agent_font_size": 18
-  }
+  "agent_ui_font_size": 18
 }
 ```
 
 > Editors in the Agent Panel—whether that is the main message textarea or previous messages—use monospace fonts and therefore, are controlled by the `buffer_font_size` setting, which is defined globally in your `settings.json`.
 
-### Default Tool Permissions
+### Tool Permissions
 
-Control the default behavior for tool actions. The default value is `"confirm"`.
-
-- `"confirm"` - Prompts for approval before running any tool action (default)
-- `"allow"` - Auto-approves tool actions without prompting
-- `"deny"` - Blocks all tool actions
+For granular control over individual tool actions, you can configure regex-based rules that auto-approve, auto-deny, or always require confirmation for specific inputs.
 
 ```json [settings]
 {
   "agent": {
     "tool_permissions": {
-      "default": "allow"
+      "default": "allow",
+      "tools": {
+        "terminal": {
+          "default": "confirm",
+          "always_allow": [
+            { "pattern": "^cargo\\s+(build|test)" }
+          ],
+          "always_deny": [
+            { "pattern": "rm\\s+-rf\\s+" }
+          ]
+        }
+      }
     }
   }
 }
 ```
 
-Even with `default: "allow"`, per-tool `always_deny` and `always_confirm` patterns are still respected, allowing you to maintain safety guardrails for specific commands.
+See the [Tool Permissions](./tool-permissions.md) documentation for complete details on configuring per-tool rules.
 
 ### Single-file Review
 
@@ -186,12 +195,12 @@ The default value is `true`.
 ```json [settings]
 {
   "agent": {
-    "single_file_review": true
+    "single_file_review": false
   }
 }
 ```
 
-When set to false, these controls are only available in the multibuffer review tab.
+When set to `false`, these controls are only available in the multibuffer review tab.
 
 ### Sound Notification
 

--- a/docs/src/ai/agent-settings.md
+++ b/docs/src/ai/agent-settings.md
@@ -172,12 +172,8 @@ For granular control over individual tool actions, you can configure regex-based
       "tools": {
         "terminal": {
           "default": "confirm",
-          "always_allow": [
-            { "pattern": "^cargo\\s+(build|test)" }
-          ],
-          "always_deny": [
-            { "pattern": "rm\\s+-rf\\s+" }
-          ]
+          "always_allow": [{ "pattern": "^cargo\\s+(build|test)" }],
+          "always_deny": [{ "pattern": "rm\\s+-rf\\s+" }]
         }
       }
     }

--- a/docs/src/ai/mcp.md
+++ b/docs/src/ai/mcp.md
@@ -132,13 +132,13 @@ As an example, [the Dagger team suggests](https://container-use.com/agent-integr
 
 Zed's Agent Panel provides the `agent.tool_permissions.default` setting to control tool approval behavior:
 
-- `"confirm"` (default) - Prompts for approval before running any tool action, including MCP tool calls
-- `"allow"` - Auto-approves tool actions without prompting
-- `"deny"` - Blocks all tool actions
+- `"confirm"` (default) — Prompts for approval before running any tool action, including MCP tool calls
+- `"allow"` — Auto-approves tool actions without prompting
+- `"deny"` — Blocks all tool actions
 
 You can change this in either your `settings.json` or through the Agent Panel settings.
 
-Even with `default: "allow"`, per-tool `always_deny` and `always_confirm` patterns are still respected, allowing you to maintain safety guardrails for specific commands.
+For granular control over specific MCP tools, you can configure per-tool permission rules using regex patterns. MCP tools use the naming format `mcp:<server>:<tool_name>`. See [Tool Permissions](./tool-permissions.md) for details.
 
 ### External Agents
 

--- a/docs/src/ai/overview.md
+++ b/docs/src/ai/overview.md
@@ -20,6 +20,8 @@ Zed integrates AI throughout the editor: agentic coding, inline transformations,
 
 - [Tools](./tools.md): The built-in capabilities agents use: file operations, terminal commands, web search.
 
+- [Tool Permissions](./tool-permissions.md): Configure granular permission rules for agent tool actions.
+
 - [Model Context Protocol](./mcp.md): Extend agents with custom tools via MCP servers.
 
 - [Inline Assistant](./inline-assistant.md): Transform selected code or terminal output with `ctrl-enter`.

--- a/docs/src/ai/privacy-and-security.md
+++ b/docs/src/ai/privacy-and-security.md
@@ -12,6 +12,8 @@ Zed, including AI features, works without sharing data with us and without authe
 
 ## Documentation
 
+- [Tool Permissions](./tool-permissions.md): Configure granular rules to control which agent actions are auto-approved, blocked, or require confirmation.
+
 - [Worktree trust](../worktree-trust.md): How Zed opens files and directories in restricted mode.
 
 - [Telemetry](../telemetry.md): How Zed collects general telemetry data.

--- a/docs/src/ai/tool-permissions.md
+++ b/docs/src/ai/tool-permissions.md
@@ -1,0 +1,280 @@
+# Tool Permissions
+
+Configure which agent actions run automatically and which require your approval.
+
+## Quick Start
+
+You can use Zed's Settings UI to configure tool permissions, or add rules directly to your `settings.json`:
+
+```json [settings]
+{
+  "agent": {
+    "tool_permissions": {
+      "default": "allow",
+      "tools": {
+        "terminal": {
+          "default": "confirm",
+          "always_allow": [
+            { "pattern": "^cargo\\s+(build|test|check)" },
+            { "pattern": "^npm\\s+(install|test|run)" }
+          ],
+          "always_confirm": [
+            { "pattern": "sudo\\s+/" }
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+This example auto-approves `cargo` and `npm` commands in the terminal tool, while requiring manual confirmation on a case-by-case basis for `sudo` commands. Non-terminal commands are allowed by default, because of `"default": "allow"` under `"tool_permissions"`.
+
+## How It Works
+
+The `tool_permissions` setting lets you customize tool permissions by specifying regex patterns that:
+
+- **Auto-approve** actions you trust
+- **Auto-deny** dangerous actions (blocked even when `tool_permissions.default` is set to `"allow"`)
+- **Always confirm** sensitive actions regardless of other settings
+
+## Supported Tools
+
+| Tool | Input Matched Against |
+| --- | --- |
+| `terminal` | The shell command string |
+| `edit_file` | The file path |
+| `delete_path` | The path being deleted |
+| `move_path` | Source and destination paths |
+| `copy_path` | Source and destination paths |
+| `create_directory` | The directory path |
+| `save_file` | The file paths |
+| `fetch` | The URL |
+| `web_search` | The search query |
+
+For MCP tools, use the format `mcp:<server>:<tool_name>`. For example, a tool called `create_issue` on a server called `github` would be `mcp:github:create_issue`.
+
+## Configuration
+
+```json [settings]
+{
+  "agent": {
+    "tool_permissions": {
+      "default": "confirm",
+      "tools": {
+        "<tool_name>": {
+          "default": "confirm",
+          "always_allow": [{ "pattern": "...", "case_sensitive": false }],
+          "always_deny": [{ "pattern": "...", "case_sensitive": false }],
+          "always_confirm": [{ "pattern": "...", "case_sensitive": false }]
+        }
+      }
+    }
+  }
+}
+```
+
+### Options
+
+| Option | Description |
+| --- | --- |
+| `default` | Fallback when no patterns match: `"confirm"` (default), `"allow"`, or `"deny"` |
+| `always_allow` | Patterns that auto-approve (unless deny or confirm also matches) |
+| `always_deny` | Patterns that block immediately—highest priority, cannot be overridden |
+| `always_confirm` | Patterns that always prompt, even when `tool_permissions.default` is `"allow"` |
+
+### Pattern Syntax
+
+```json [settings]
+{
+  "pattern": "your-regex-here",
+  "case_sensitive": false
+}
+```
+
+Patterns use Rust regex syntax. Matching is case-insensitive by default.
+
+## Rule Precedence
+
+From highest to lowest priority:
+
+1. **Built-in security rules** — Hardcoded protections (e.g., `rm -rf /`). Cannot be overridden.
+2. **`always_deny`** — Blocks matching actions
+3. **`always_confirm`** — Requires confirmation for matching actions
+4. **`always_allow`** — Auto-approves matching actions
+5. **Tool-specific `default`** — Per-tool fallback when no patterns match (e.g., `tools.terminal.default`)
+6. **Global `default`** — Falls back to `tool_permissions.default` when no tool-specific default is set
+
+## Examples
+
+### Terminal: Auto-Approve Build Commands
+
+```json [settings]
+{
+  "agent": {
+    "tool_permissions": {
+      "tools": {
+        "terminal": {
+          "default": "confirm",
+          "always_allow": [
+            { "pattern": "^cargo\\s+(build|test|check|clippy|fmt)" },
+            { "pattern": "^npm\\s+(install|test|run|build)" },
+            { "pattern": "^git\\s+(status|log|diff|branch)" },
+            { "pattern": "^ls\\b" },
+            { "pattern": "^cat\\s" }
+          ],
+          "always_deny": [
+            { "pattern": "rm\\s+-rf\\s+(/|~)" },
+            { "pattern": "sudo\\s+rm" }
+          ],
+          "always_confirm": [
+            { "pattern": "sudo\\s" },
+            { "pattern": "git\\s+push" }
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+### File Editing: Protect Sensitive Files
+
+```json [settings]
+{
+  "agent": {
+    "tool_permissions": {
+      "tools": {
+        "edit_file": {
+          "default": "confirm",
+          "always_allow": [
+            { "pattern": "\\.(md|txt|json)$" },
+            { "pattern": "^src/" }
+          ],
+          "always_deny": [
+            { "pattern": "\\.env" },
+            { "pattern": "secrets?/" },
+            { "pattern": "\\.(pem|key)$" }
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+### Path Deletion: Block Critical Directories
+
+```json [settings]
+{
+  "agent": {
+    "tool_permissions": {
+      "tools": {
+        "delete_path": {
+          "default": "confirm",
+          "always_deny": [
+            { "pattern": "^/etc" },
+            { "pattern": "^/usr" },
+            { "pattern": "\\.git/?$" },
+            { "pattern": "node_modules/?$" }
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+### URL Fetching: Control External Access
+
+```json [settings]
+{
+  "agent": {
+    "tool_permissions": {
+      "tools": {
+        "fetch": {
+          "default": "confirm",
+          "always_allow": [
+            { "pattern": "docs\\.rs" },
+            { "pattern": "github\\.com" }
+          ],
+          "always_deny": [
+            { "pattern": "internal\\.company\\.com" }
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+### MCP Tools
+
+```json [settings]
+{
+  "agent": {
+    "tool_permissions": {
+      "tools": {
+        "mcp:github:create_issue": {
+          "default": "confirm"
+        },
+        "mcp:github:create_pull_request": {
+          "default": "confirm"
+        }
+      }
+    }
+  }
+}
+```
+
+## Global Auto-Approve
+
+To auto-approve all tool actions:
+
+```json [settings]
+{
+  "agent": {
+    "tool_permissions": {
+      "default": "allow"
+    }
+  }
+}
+```
+
+This bypasses confirmation prompts but `always_deny` patterns and built-in security rules still apply.
+
+## Shell Compatibility
+
+For the `terminal` tool, Zed parses chained commands (e.g., `echo hello && rm file`) to check each sub-command against your patterns.
+
+All supported shells work with tool permission patterns, including sh, bash, zsh, dash, fish, PowerShell 7+, pwsh, cmd, xonsh, csh, tcsh, Nushell, Elvish, and rc (Plan 9).
+
+## Writing Patterns
+
+- Use `\b` for word boundaries: `\brm\b` matches "rm" but not "storm"
+- Use `^` and `$` to anchor patterns to start/end of input
+- Escape special characters: `\.` for literal dot, `\\` for backslash
+- Test carefully—a typo in a deny pattern blocks legitimate actions
+
+## Built-in Security Rules
+
+Zed includes a small set of hardcoded security rules that **cannot be overridden** by any setting. These only apply to the **terminal** tool and block recursive deletion of critical directories:
+
+- `rm -rf /` and `rm -rf /*` — filesystem root
+- `rm -rf ~` and `rm -rf ~/*` — home directory
+- `rm -rf $HOME` / `rm -rf ${HOME}` (and `$HOME/*`) — home directory via environment variable
+- `rm -rf .` and `rm -rf ./*` — current directory
+- `rm -rf ..` and `rm -rf ../*` — parent directory
+
+These patterns catch any flag combination (e.g., `-fr`, `-rfv`, `-r -f`, `--recursive --force`) and are case-insensitive. They are checked against both the raw command and each parsed sub-command in chained commands (e.g., `ls && rm -rf /`).
+
+There are no other built-in rules. The default settings file ({#action zed::OpenDefaultSettings}) includes commented-out examples for protecting `.env` files, secrets directories, private keys, and `.git` directories — you can uncomment or adapt these to suit your needs.
+
+## UI Options
+
+When the agent requests permission, the dialog includes:
+
+- **Allow once** / **Deny once** — One-time decision
+- **Always allow** / **Always deny** — Adds a pattern to your settings
+
+Selecting "Always allow" or "Always deny" updates your `settings.json` with a pattern for that input.

--- a/docs/src/ai/tool-permissions.md
+++ b/docs/src/ai/tool-permissions.md
@@ -18,9 +18,7 @@ You can use Zed's Settings UI to configure tool permissions, or add rules direct
             { "pattern": "^cargo\\s+(build|test|check)" },
             { "pattern": "^npm\\s+(install|test|run)" }
           ],
-          "always_confirm": [
-            { "pattern": "sudo\\s+/" }
-          ]
+          "always_confirm": [{ "pattern": "sudo\\s+/" }]
         }
       }
     }
@@ -40,17 +38,17 @@ The `tool_permissions` setting lets you customize tool permissions by specifying
 
 ## Supported Tools
 
-| Tool | Input Matched Against |
-| --- | --- |
-| `terminal` | The shell command string |
-| `edit_file` | The file path |
-| `delete_path` | The path being deleted |
-| `move_path` | Source and destination paths |
-| `copy_path` | Source and destination paths |
-| `create_directory` | The directory path |
-| `save_file` | The file paths |
-| `fetch` | The URL |
-| `web_search` | The search query |
+| Tool               | Input Matched Against        |
+| ------------------ | ---------------------------- |
+| `terminal`         | The shell command string     |
+| `edit_file`        | The file path                |
+| `delete_path`      | The path being deleted       |
+| `move_path`        | Source and destination paths |
+| `copy_path`        | Source and destination paths |
+| `create_directory` | The directory path           |
+| `save_file`        | The file paths               |
+| `fetch`            | The URL                      |
+| `web_search`       | The search query             |
 
 For MCP tools, use the format `mcp:<server>:<tool_name>`. For example, a tool called `create_issue` on a server called `github` would be `mcp:github:create_issue`.
 
@@ -76,11 +74,11 @@ For MCP tools, use the format `mcp:<server>:<tool_name>`. For example, a tool ca
 
 ### Options
 
-| Option | Description |
-| --- | --- |
-| `default` | Fallback when no patterns match: `"confirm"` (default), `"allow"`, or `"deny"` |
-| `always_allow` | Patterns that auto-approve (unless deny or confirm also matches) |
-| `always_deny` | Patterns that block immediately—highest priority, cannot be overridden |
+| Option           | Description                                                                    |
+| ---------------- | ------------------------------------------------------------------------------ |
+| `default`        | Fallback when no patterns match: `"confirm"` (default), `"allow"`, or `"deny"` |
+| `always_allow`   | Patterns that auto-approve (unless deny or confirm also matches)               |
+| `always_deny`    | Patterns that block immediately—highest priority, cannot be overridden         |
 | `always_confirm` | Patterns that always prompt, even when `tool_permissions.default` is `"allow"` |
 
 ### Pattern Syntax
@@ -198,9 +196,7 @@ From highest to lowest priority:
             { "pattern": "docs\\.rs" },
             { "pattern": "github\\.com" }
           ],
-          "always_deny": [
-            { "pattern": "internal\\.company\\.com" }
-          ]
+          "always_deny": [{ "pattern": "internal\\.company\\.com" }]
         }
       }
     }

--- a/docs/src/ai/tools.md
+++ b/docs/src/ai/tools.md
@@ -2,6 +2,8 @@
 
 Zed's built-in agent has access to these tools for reading, searching, and editing your codebase.
 
+You can configure permissions for what tools are allowed to do, including situations where they are automatically approved, automatically denied, or require your confirmation on a case-by-case basis. See [Tool Permissions](./tool-permissions.md) for details.
+
 ## Read & Search Tools
 
 ### `diagnostics`
@@ -76,6 +78,20 @@ Saves a buffer's current contents to disk, preserving unsaved changes before the
 
 Moves or renames a file or directory in the project, performing a rename if only the filename differs.
 
+### `restore_file_from_disk`
+
+Discards unsaved changes in open buffers by reloading file contents from disk. Useful for resetting files to their on-disk state before retrying an edit.
+
+### `save_file`
+
+Saves files that have unsaved changes. Used when files need to be saved before further edits can be made.
+
 ### `terminal`
 
 Executes shell commands and returns the combined output, creating a new shell process for each invocation.
+
+## Other Tools
+
+### `subagent`
+
+Spawns a subagent with its own context window to perform a delegated task. Useful for running parallel investigations, completing self-contained tasks, or performing research where only the outcome matters. Each subagent has access to the same tools as the parent agent.


### PR DESCRIPTION
Revises documentation for the `tool_permissions` setting, which provides granular control over agent tool actions.

This PR targets the `always-allow-revision` branch and depends on https://github.com/zed-industries/zed/pull/48299 being merged first.

Release Notes:

- N/A