### PR TITLE
Remove cmpl- prefix validation from Mercury feedback

### DIFF
--- a/crates/edit_prediction/src/mercury.rs
+++ b/crates/edit_prediction/src/mercury.rs
@@ -381,14 +381,6 @@ fn send_feedback(
     let request_id = prediction_id.0;
     let app_version = AppVersion::global(cx);
     cx.background_spawn(async move {
-        if !request_id.starts_with("cmpl-") {
-            log::warn!(
-                "Mercury feedback: invalid request_id '{}' - must start with 'cmpl-'",
-                request_id
-            );
-            return anyhow::Ok(());
-        }
-
         let body = FeedbackRequest {
             request_id,
             provider_name: "zed",


### PR DESCRIPTION
Release Notes:

- Removes unnecessary prefix validation from Inception API's returned request ID.
