### PR TITLE
Revert "git: Render hunk gutter highlights for side-by-side diff (#48321)"

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -27103,13 +27103,7 @@ impl EditorSnapshot {
                 }
 
                 let hunk_start_point = Point::new(hunk.row_range.start.0, 0);
-                let hunk_end_point = if hunk.row_range.end > hunk.row_range.start {
-                    let last_row = MultiBufferRow(hunk.row_range.end.0 - 1);
-                    let line_len = self.buffer_snapshot().line_len(last_row);
-                    Point::new(last_row.0, line_len)
-                } else {
-                    Point::new(hunk.row_range.end.0, 0)
-                };
+                let hunk_end_point = Point::new(hunk.row_range.end.0, 0);
 
                 let hunk_display_start = self.point_to_display_point(hunk_start_point, Bias::Left);
                 let hunk_display_end = self.point_to_display_point(hunk_end_point, Bias::Right);

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -6058,12 +6058,7 @@ impl EditorElement {
         }
     }
 
-    fn paint_gutter_diff_hunks(
-        layout: &mut EditorLayout,
-        split_side: Option<SplitSide>,
-        window: &mut Window,
-        cx: &mut App,
-    ) {
+    fn paint_gutter_diff_hunks(layout: &mut EditorLayout, window: &mut Window, cx: &mut App) {
         if layout.display_hunks.is_empty() {
             return;
         }
@@ -6090,37 +6085,37 @@ impl EditorElement {
                         status,
                         display_row_range,
                         ..
-                    } => hitbox.as_ref().map(|hunk_hitbox| {
-                        let color = match split_side {
-                            Some(SplitSide::Left) => cx.theme().colors().version_control_deleted,
-                            Some(SplitSide::Right) => cx.theme().colors().version_control_added,
-                            None => match status.kind {
-                                DiffHunkStatusKind::Added => {
-                                    cx.theme().colors().version_control_added
-                                }
-                                DiffHunkStatusKind::Modified => {
-                                    cx.theme().colors().version_control_modified
-                                }
-                                DiffHunkStatusKind::Deleted => {
-                                    cx.theme().colors().version_control_deleted
-                                }
-                            },
-                        };
-                        match status.kind {
-                            DiffHunkStatusKind::Deleted if display_row_range.is_empty() => (
-                                Bounds::new(
-                                    point(
-                                        hunk_hitbox.origin.x - hunk_hitbox.size.width,
-                                        hunk_hitbox.origin.y,
-                                    ),
-                                    size(hunk_hitbox.size.width * 2., hunk_hitbox.size.height),
+                    } => hitbox.as_ref().map(|hunk_hitbox| match status.kind {
+                        DiffHunkStatusKind::Added => (
+                            hunk_hitbox.bounds,
+                            cx.theme().colors().version_control_added,
+                            Corners::all(px(0.)),
+                            *status,
+                        ),
+                        DiffHunkStatusKind::Modified => (
+                            hunk_hitbox.bounds,
+                            cx.theme().colors().version_control_modified,
+                            Corners::all(px(0.)),
+                            *status,
+                        ),
+                        DiffHunkStatusKind::Deleted if !display_row_range.is_empty() => (
+                            hunk_hitbox.bounds,
+                            cx.theme().colors().version_control_deleted,
+                            Corners::all(px(0.)),
+                            *status,
+                        ),
+                        DiffHunkStatusKind::Deleted => (
+                            Bounds::new(
+                                point(
+                                    hunk_hitbox.origin.x - hunk_hitbox.size.width,
+                                    hunk_hitbox.origin.y,
                                 ),
-                                color,
-                                Corners::all(1. * line_height),
-                                *status,
+                                size(hunk_hitbox.size.width * 2., hunk_hitbox.size.height),
                             ),
-                            _ => (hunk_hitbox.bounds, color, Corners::all(px(0.)), *status),
-                        }
+                            cx.theme().colors().version_control_deleted,
+                            Corners::all(1. * line_height),
+                            *status,
+                        ),
                     }),
                 };
 
@@ -6306,8 +6301,8 @@ impl EditorElement {
                     GitGutterSetting::TrackedFiles
                 )
             });
-        if show_git_gutter {
-            Self::paint_gutter_diff_hunks(layout, self.split_side, window, cx)
+        if show_git_gutter && self.split_side.is_none() {
+            Self::paint_gutter_diff_hunks(layout, window, cx)
         }
 
         let highlight_width = 0.275 * layout.position_map.line_height;


### PR DESCRIPTION
This reverts commit c390dda8241747e0b03dd18ccf0f2e4d7097ee0e.

Release Notes:

- N/A