### PR TITLE
git: Shader for checkerboard pattern for side-by-side diff

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -4008,7 +4008,7 @@ impl EditorElement {
                 .h((*height as f32) * line_height)
                 .bg(checkerboard(
                     cx.theme().colors().panel_background,
-                    Self::checkerboard_size(line_height.into(), 20.0),
+                    Self::checkerboard_size(line_height.into(), 20.0 * window.scale_factor()),
                 ))
                 .into_any(),
         };
@@ -13245,27 +13245,26 @@ mod tests {
     fn test_checkerboard_size() {
         // line height is smaller than target height, so we just return half the line height
         assert_eq!(EditorElement::checkerboard_size(10.0, 20.0), 5.0);
-        
+
         // line height is exactly half the target height, perfect match
         assert_eq!(EditorElement::checkerboard_size(20.0, 10.0), 10.0);
-        
+
         // line height is close to half the target height
         assert_eq!(EditorElement::checkerboard_size(20.0, 9.0), 10.0);
-        
+
         // line height is close to 1/4 the target height
         assert_eq!(EditorElement::checkerboard_size(20.0, 4.8), 5.0);
     }
-    
+
     #[gpui::test(iterations = 100)]
     fn test_random_checkerboard_size(mut rng: StdRng) {
         let line_height = rng.next_u32() as f32;
         let target_height = rng.next_u32() as f32;
-        
+
         let result = EditorElement::checkerboard_size(line_height, target_height);
-        
+
         let k = line_height / result;
-        assert!(k - k.round() < 0.0000001);  // approximately integer
-        assert!((k.round() as u32) % 2 == 0);  // even
-        
+        assert!(k - k.round() < 0.0000001); // approximately integer
+        assert!((k.round() as u32) % 2 == 0); // even
     }
 }

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -4008,7 +4008,6 @@ impl EditorElement {
                 .h((*height as f32) * line_height)
                 .bg(checkerboard(
                     cx.theme().colors().panel_background,
-                    // 20.0
                     Self::checkerboard_size(line_height.into(), 20.0),
                 ))
                 .into_any(),

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -40,17 +40,7 @@ use feature_flags::{DiffReviewFeatureFlag, FeatureFlagAppExt as _};
 use file_icons::FileIcons;
 use git::{Oid, blame::BlameEntry, commit::ParsedCommitMessage, status::FileStatus};
 use gpui::{
-    Action, Along, AnyElement, App, AppContext, AvailableSpace, Axis as ScrollbarAxis, BorderStyle,
-    Bounds, ClickEvent, ClipboardItem, ContentMask, Context, Corner, Corners, CursorStyle,
-    DispatchPhase, Edges, Element, ElementInputHandler, Entity, Focusable as _, FontId, FontWeight,
-    GlobalElementId, Hitbox, HitboxBehavior, Hsla, InteractiveElement, IntoElement, IsZero,
-    KeybindingKeystroke, Length, Modifiers, ModifiersChangedEvent, MouseButton, MouseClickEvent,
-    MouseDownEvent, MouseMoveEvent, MousePressureEvent, MouseUpEvent, PaintQuad, ParentElement,
-    Pixels, PressureStage, ScrollDelta, ScrollHandle, ScrollWheelEvent, ShapedLine, SharedString,
-    Size, StatefulInteractiveElement, Style, Styled, StyledText, TextAlign, TextRun,
-    TextStyleRefinement, WeakEntity, Window, anchored, deferred, div, fill, linear_color_stop,
-    linear_gradient, outline, pattern_slash, point, px, quad, relative, size, solid_background,
-    transparent_black,
+    Action, Along, AnyElement, App, AppContext, AvailableSpace, Axis as ScrollbarAxis, BorderStyle, Bounds, ClickEvent, ClipboardItem, ContentMask, Context, Corner, Corners, CursorStyle, DispatchPhase, Edges, Element, ElementInputHandler, Entity, Focusable as _, FontId, FontWeight, GlobalElementId, Hitbox, HitboxBehavior, Hsla, InteractiveElement, IntoElement, IsZero, KeybindingKeystroke, Length, Modifiers, ModifiersChangedEvent, MouseButton, MouseClickEvent, MouseDownEvent, MouseMoveEvent, MousePressureEvent, MouseUpEvent, PaintQuad, ParentElement, Pixels, PressureStage, ScrollDelta, ScrollHandle, ScrollWheelEvent, ShapedLine, SharedString, Size, StatefulInteractiveElement, Style, Styled, StyledText, TextAlign, TextRun, TextStyleRefinement, WeakEntity, Window, anchored, checkerboard, deferred, div, fill, linear_color_stop, linear_gradient, outline, pattern_slash, point, px, quad, relative, rgb, rgba, size, solid_background, transparent_black
 };
 use itertools::Itertools;
 use language::{IndentGuideSettings, language_settings::ShowWhitespaceSetting};
@@ -4005,10 +3995,9 @@ impl EditorElement {
                 .id(block_id)
                 .w_full()
                 .h((*height as f32) * line_height)
-                .bg(pattern_slash(
+                .bg(checkerboard(
                     cx.theme().colors().panel_background,
-                    8.0,
-                    8.0,
+                    f32::from(line_height) / 4.0,
                 ))
                 .into_any(),
         };

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -49,8 +49,8 @@ use gpui::{
     Pixels, PressureStage, ScrollDelta, ScrollHandle, ScrollWheelEvent, ShapedLine, SharedString,
     Size, StatefulInteractiveElement, Style, Styled, StyledText, TextAlign, TextRun,
     TextStyleRefinement, WeakEntity, Window, anchored, checkerboard, deferred, div, fill,
-    linear_color_stop, linear_gradient, outline, pattern_slash, point, px, quad, relative, rgb,
-    rgba, size, solid_background, transparent_black,
+    linear_color_stop, linear_gradient, outline, point, px, quad, relative, size, solid_background,
+    transparent_black,
 };
 use itertools::Itertools;
 use language::{IndentGuideSettings, language_settings::ShowWhitespaceSetting};
@@ -61,7 +61,7 @@ use multi_buffer::{
 };
 
 use edit_prediction_types::EditPredictionGranularity;
-use ordered_float::Float;
+
 use project::{
     DisableAiSettings, Entry, ProjectPath,
     debugger::breakpoint_store::{Breakpoint, BreakpointSessionState},
@@ -4009,10 +4009,7 @@ impl EditorElement {
                 .bg(checkerboard(cx.theme().colors().panel_background, {
                     let target_size = 16.0;
                     let scale = window.scale_factor();
-                    Self::checkerboard_size(
-                        f32::from(line_height) * scale,
-                        target_size * scale,
-                    )
+                    Self::checkerboard_size(f32::from(line_height) * scale, target_size * scale)
                 }))
                 .into_any(),
         };

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -4006,10 +4006,14 @@ impl EditorElement {
                 .id(block_id)
                 .w_full()
                 .h((*height as f32) * line_height)
-                .bg(checkerboard(
-                    cx.theme().colors().panel_background,
-                    Self::checkerboard_size(line_height.into(), 20.0 * window.scale_factor()),
-                ))
+                .bg(checkerboard(cx.theme().colors().panel_background, {
+                    let target_size = 16.0;
+                    let scale = window.scale_factor();
+                    Self::checkerboard_size(
+                        f32::from(line_height) * scale,
+                        target_size * scale,
+                    )
+                }))
                 .into_any(),
         };
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -13266,6 +13266,6 @@ mod tests {
 
         let k = line_height / result;
         assert!(k - k.round() < 0.0000001); // approximately integer
-        assert!((k.round() as u32).is_multiple_of(2)); 
+        assert!((k.round() as u32).is_multiple_of(2));
     }
 }

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -13266,6 +13266,6 @@ mod tests {
 
         let k = line_height / result;
         assert!(k - k.round() < 0.0000001); // approximately integer
-        assert!((k.round() as u32) % 2 == 0); // even
+        assert!((k.round() as u32).is_multiple_of(2)); 
     }
 }

--- a/crates/gpui/src/color.rs
+++ b/crates/gpui/src/color.rs
@@ -4,7 +4,7 @@ use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
     de::{self, Visitor},
 };
-use std::{borrow::Cow, marker::PhantomData};
+use std::borrow::Cow;
 use std::{
     fmt::{self, Display, Formatter},
     hash::{Hash, Hasher},

--- a/crates/gpui/src/color.rs
+++ b/crates/gpui/src/color.rs
@@ -4,7 +4,7 @@ use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
     de::{self, Visitor},
 };
-use std::borrow::Cow;
+use std::{borrow::Cow, marker::PhantomData};
 use std::{
     fmt::{self, Display, Formatter},
     hash::{Hash, Hasher},
@@ -658,6 +658,7 @@ pub(crate) enum BackgroundTag {
     Solid = 0,
     LinearGradient = 1,
     PatternSlash = 2,
+    Checkerboard = 3,
 }
 
 /// A color space for color interpolation.
@@ -701,20 +702,21 @@ impl std::fmt::Debug for Background {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self.tag {
             BackgroundTag::Solid => write!(f, "Solid({:?})", self.solid),
-            BackgroundTag::LinearGradient => {
-                write!(
-                    f,
-                    "LinearGradient({}, {:?}, {:?})",
-                    self.gradient_angle_or_pattern_height, self.colors[0], self.colors[1]
-                )
-            }
-            BackgroundTag::PatternSlash => {
-                write!(
-                    f,
-                    "PatternSlash({:?}, {})",
-                    self.solid, self.gradient_angle_or_pattern_height
-                )
-            }
+            BackgroundTag::LinearGradient => write!(
+                f,
+                "LinearGradient({}, {:?}, {:?})",
+                self.gradient_angle_or_pattern_height, self.colors[0], self.colors[1]
+            ),
+            BackgroundTag::PatternSlash => write!(
+                f,
+                "PatternSlash({:?}, {})",
+                self.solid, self.gradient_angle_or_pattern_height
+            ),
+            BackgroundTag::Checkerboard => write!(
+                f,
+                "Checkerboard({:?}, {})",
+                self.solid, self.gradient_angle_or_pattern_height
+            ),
         }
     }
 }
@@ -743,6 +745,16 @@ pub fn pattern_slash(color: impl Into<Hsla>, width: f32, interval: f32) -> Backg
         tag: BackgroundTag::PatternSlash,
         solid: color.into(),
         gradient_angle_or_pattern_height: height,
+        ..Default::default()
+    }
+}
+
+/// Creates a checkerboard pattern background
+pub fn checkerboard(color: impl Into<Hsla>, size: f32) -> Background {
+    Background {
+        tag: BackgroundTag::Checkerboard,
+        solid: color.into(),
+        gradient_angle_or_pattern_height: size,
         ..Default::default()
     }
 }
@@ -833,6 +845,7 @@ impl Background {
             BackgroundTag::Solid => self.solid.is_transparent(),
             BackgroundTag::LinearGradient => self.colors.iter().all(|c| c.color.is_transparent()),
             BackgroundTag::PatternSlash => self.solid.is_transparent(),
+            BackgroundTag::Checkerboard => self.solid.is_transparent(),
         }
     }
 }

--- a/crates/gpui/src/platform/blade/shaders.wgsl
+++ b/crates/gpui/src/platform/blade/shaders.wgsl
@@ -495,18 +495,14 @@ fn gradient_color(background: Background, position: vec2<f32>, bounds: Bounds,
         case 3u: {
             // checkerboard
             let size = background.gradient_angle_or_pattern_height;
+            let relative_position = position - bounds.origin;
             
-            let x_index = floor(position.x / size);
-            let y_index = floor(position.y / size);
+            let x_index = floor(relative_position.x / size);
+            let y_index = floor(relative_position.y / size);
             let should_be_colored = (x_index + y_index) % 2.0;
             
             background_color = solid_color;
             background_color.a *= saturate(should_be_colored);
-            // if should_be_colored == 0.0 {
-            //     background_color = solid_color;
-            // } else {
-            //     background_color = vec4(255.0, 0.0, 0.0, 255.0);
-            // }
         }
     }
 

--- a/crates/gpui/src/platform/blade/shaders.wgsl
+++ b/crates/gpui/src/platform/blade/shaders.wgsl
@@ -129,6 +129,7 @@ struct Background {
     // 0u is Solid
     // 1u is LinearGradient
     // 2u is PatternSlash
+    // 3u is Checkerboard
     tag: u32,
     // 0u is sRGB linear color
     // 1u is Oklab color
@@ -399,7 +400,7 @@ fn prepare_gradient_color(tag: u32, color_space: u32,
     solid: Hsla, colors: array<LinearColorStop, 2>) -> GradientColor {
     var result = GradientColor();
 
-    if (tag == 0u || tag == 2u) {
+    if (tag == 0u || tag == 2u || tag == 3u) {
         result.solid = hsla_to_rgba(solid);
     } else if (tag == 1u) {
         // The hsla_to_rgba is returns a linear sRGB color
@@ -473,6 +474,7 @@ fn gradient_color(background: Background, position: vec2<f32>, bounds: Bounds,
             }
         }
         case 2u: {
+            // pattern slash
             let gradient_angle_or_pattern_height = background.gradient_angle_or_pattern_height;
             let pattern_width = (gradient_angle_or_pattern_height / 65535.0f) / 255.0f;
             let pattern_interval = (gradient_angle_or_pattern_height % 65535.0f) / 255.0f;
@@ -489,6 +491,22 @@ fn gradient_color(background: Background, position: vec2<f32>, bounds: Bounds,
             let distance = min(pattern, pattern_period - pattern) - pattern_period * (pattern_width / pattern_height) /  2.0f;
             background_color = solid_color;
             background_color.a *= saturate(0.5 - distance);
+        }
+        case 3u: {
+            // checkerboard
+            let size = background.gradient_angle_or_pattern_height;
+            
+            let x_index = floor(position.x / size);
+            let y_index = floor(position.y / size);
+            let should_be_colored = (x_index + y_index) % 2.0;
+            
+            background_color = solid_color;
+            background_color.a *= saturate(should_be_colored);
+            // if should_be_colored == 0.0 {
+            //     background_color = solid_color;
+            // } else {
+            //     background_color = vec4(255.0, 0.0, 0.0, 255.0);
+            // }
         }
     }
 

--- a/crates/gpui/src/platform/mac/shaders.metal
+++ b/crates/gpui/src/platform/mac/shaders.metal
@@ -1236,11 +1236,11 @@ float4 fill_color(Background background,
     case 3: {
         // checkerboard
         float size = background.gradient_angle_or_pattern_height;
-        float2 relative_position = position - bounds.origin;
+        float2 relative_position = position - float2(bounds.origin.x, bounds.origin.y);
         
         float x_index = floor(relative_position.x / size);
         float y_index = floor(relative_position.y / size);
-        float should_be_colored = (x_index + y_index) % 2.0;
+        float should_be_colored = fmod(x_index + y_index, 2.0);
         
         color = solid_color;
         color.a *= saturate(should_be_colored);

--- a/crates/gpui/src/platform/mac/shaders.metal
+++ b/crates/gpui/src/platform/mac/shaders.metal
@@ -1140,7 +1140,7 @@ float4 over(float4 below, float4 above) {
 GradientColor prepare_fill_color(uint tag, uint color_space, Hsla solid,
                                      Hsla color0, Hsla color1) {
   GradientColor out;
-  if (tag == 0 || tag == 2) {
+  if (tag == 0 || tag == 2 || tag == 3) {
     out.solid = hsla_to_rgba(solid);
   } else if (tag == 1) {
     out.color0 = hsla_to_rgba(color0);
@@ -1232,6 +1232,19 @@ float4 fill_color(Background background,
         color = solid_color;
         color.a *= saturate(0.5 - distance);
         break;
+    }
+    case 3: {
+        // checkerboard
+        float size = background.gradient_angle_or_pattern_height;
+        float2 relative_position = position - bounds.origin;
+        
+        float x_index = floor(relative_position.x / size);
+        float y_index = floor(relative_position.y / size);
+        float should_be_colored = (x_index + y_index) % 2.0;
+        
+        color = solid_color;
+        color.a *= saturate(should_be_colored);
+        break; 
     }
   }
 

--- a/crates/gpui/src/platform/windows/shaders.hlsl
+++ b/crates/gpui/src/platform/windows/shaders.hlsl
@@ -411,8 +411,8 @@ float4 gradient_color(Background background,
             float y_index = floor(relative_position.y / size);
             float should_be_colored = (x_index + y_index) % 2.0;
             
-            background_color = solid_color;
-            background_color.a *= saturate(should_be_colored);
+            color = solid_color;
+            color.a *= saturate(should_be_colored);
             break;
         }
     }

--- a/crates/gpui/src/platform/windows/shaders.hlsl
+++ b/crates/gpui/src/platform/windows/shaders.hlsl
@@ -309,7 +309,7 @@ float quad_sdf(float2 pt, Bounds bounds, Corners corner_radii) {
 
 GradientColor prepare_gradient_color(uint tag, uint color_space, Hsla solid, LinearColorStop colors[2]) {
     GradientColor output;
-    if (tag == 0 || tag == 2) {
+    if (tag == 0 || tag == 2 || tag == 3) {
         output.solid = hsla_to_rgba(solid);
     } else if (tag == 1) {
         output.color0 = hsla_to_rgba(colors[0].color);
@@ -400,6 +400,19 @@ float4 gradient_color(Background background,
             float distance = min(pattern, pattern_period - pattern) - pattern_period * (pattern_width / pattern_height) /  2.0f;
             color = solid_color;
             color.a *= saturate(0.5 - distance);
+            break;
+        }
+        case 3: {
+            // checkerboard
+            float size = background.gradient_angle_or_pattern_height;
+            float2 relative_position = position - bounds.origin;
+            
+            float x_index = floor(relative_position.x / size);
+            float y_index = floor(relative_position.y / size);
+            float should_be_colored = (x_index + y_index) % 2.0;
+            
+            background_color = solid_color;
+            background_color.a *= saturate(should_be_colored);
             break;
         }
     }

--- a/crates/gpui/src/style.rs
+++ b/crates/gpui/src/style.rs
@@ -639,13 +639,15 @@ impl Style {
         if background_color.is_some_and(|color| !color.is_transparent()) {
             let mut border_color = match background_color {
                 Some(color) => match color.tag {
-                    BackgroundTag::Solid => color.solid,
+                    BackgroundTag::Solid
+                    | BackgroundTag::PatternSlash
+                    | BackgroundTag::Checkerboard => color.solid,
+
                     BackgroundTag::LinearGradient => color
                         .colors
                         .first()
                         .map(|stop| stop.color)
                         .unwrap_or_default(),
-                    BackgroundTag::PatternSlash => color.solid,
                 },
                 None => Hsla::default(),
             };


### PR DESCRIPTION
Adds `checkerboard` to `Background`, and use it for the side-by-side diff.
Note that, since the blockmap can contain multiple `Spacer`s without any gaps
in between, we ensure that the checkerboard pattern always shows an even
integer number of squares per line, so there are no obvious discontinuities
in the pattern when this happens.

<img width="590" height="300" alt="image" src="https://github.com/user-attachments/assets/e8f75f90-b230-4078-bce0-cb3c15613fe7" />


Release Notes:

- N/A *or* Added/Fixed/Improved ...
