### PR TITLE
project_panel: Fix collapse_all_entries collapsing single worktree root completely

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1375,7 +1375,7 @@ impl ProjectPanel {
     ) {
         // By keeping entries for fully collapsed worktrees, we avoid expanding them within update_visible_entries
         // (which is it's default behavior when there's no entry for a worktree in expanded_dir_ids).
-        let multiple_worktrees = self.project.read(cx).worktrees(cx).count() > 1;
+        let multiple_worktrees = self.project.read(cx).visible_worktrees(cx).count() > 1;
         let project = self.project.read(cx);
 
         self.state


### PR DESCRIPTION
For: https://github.com/zed-industries/zed/pull/47328

Release Notes:

- Fixed an issue where selecting "Collapse All" on the root directory or triggering the collapse all action would sometimes collapse the entire root instead of keeping it expanded when there's a single worktree.