### PR TITLE
languages: Remove unnecessary `unresolvedReference` semantic token rule

### DIFF
--- a/crates/languages/src/rust/semantic_token_rules.json
+++ b/crates/languages/src/rust/semantic_token_rules.json
@@ -146,9 +146,5 @@
   {
     "token_type": "union",
     "style": ["type"]
-  },
-  {
-    "token_type": "unresolvedReference",
-    "style": ["variable"]
   }
 ]


### PR DESCRIPTION
This prevents ast based highlighting in unconfigured code

Release Notes:

- N/A *or* Added/Fixed/Improved ...
