### PR TITLE
Add multibuffer file-based filtering

### DIFF
--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -858,6 +858,12 @@ actions!(
         ToggleSoftWrap,
         /// Toggles the tab bar display.
         ToggleTabBar,
+        /// Toggles the file filters panel in multibuffer views.
+        ToggleMultibufferFilters,
+        /// Focuses the include filter input in multibuffer views.
+        FocusMultibufferIncludeFilter,
+        /// Focuses the exclude filter input in multibuffer views.
+        FocusMultibufferExcludeFilter,
         /// Transposes characters around cursor.
         Transpose,
         /// Undoes the last edit.

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -34,6 +34,8 @@ mod linked_editing_ranges;
 mod lsp_ext;
 mod mouse_context_menu;
 pub mod movement;
+mod multibuffer_filter;
+pub mod multibuffer_filter_bar;
 mod persistence;
 mod rust_analyzer_ext;
 pub mod scroll;
@@ -80,7 +82,14 @@ pub use multi_buffer::{
     MultiBufferOffset, MultiBufferOffsetUtf16, MultiBufferSnapshot, PathKey, RowInfo, ToOffset,
     ToPoint,
 };
-pub use split::{SplittableEditor, ToggleSplitDiff};
+
+pub use split::{
+    SplitDiff, SplitDiffFeatureFlag, SplittableEditor, ToggleDiffView, ToggleLockedCursors,
+    ToggleSplitDiff,
+};
+
+pub use multibuffer_filter::FilterableMultibufferState;
+pub use multibuffer_filter_bar::MultibufferFilterBar;
 pub use split_editor_view::SplitEditorView;
 pub use text::Bias;
 
@@ -345,6 +354,25 @@ pub fn init(cx: &mut App) {
             workspace.register_action(Editor::new_file_horizontal);
             workspace.register_action(Editor::cancel_language_server_work);
             workspace.register_action(Editor::toggle_focus);
+
+            register_multibuffer_filter_action(
+                workspace,
+                |filter_bar, _: &ToggleMultibufferFilters, window, cx| {
+                    filter_bar.toggle_filters(window, cx);
+                },
+            );
+            register_multibuffer_filter_action(
+                workspace,
+                |filter_bar, _: &FocusMultibufferIncludeFilter, window, cx| {
+                    filter_bar.focus_include_editor(window, cx);
+                },
+            );
+            register_multibuffer_filter_action(
+                workspace,
+                |filter_bar, _: &FocusMultibufferExcludeFilter, window, cx| {
+                    filter_bar.focus_exclude_editor(window, cx);
+                },
+            );
         },
     )
     .detach();
@@ -388,6 +416,35 @@ pub fn init(cx: &mut App) {
 
 pub fn set_blame_renderer(renderer: impl BlameRenderer + 'static, cx: &mut App) {
     cx.set_global(GlobalBlameRenderer(Arc::new(renderer)));
+}
+
+fn register_multibuffer_filter_action<A: Action>(
+    workspace: &mut Workspace,
+    callback: fn(&mut MultibufferFilterBar, &A, &mut Window, &mut Context<MultibufferFilterBar>),
+) {
+    workspace.register_action(move |workspace, action: &A, window, cx| {
+        if workspace.has_active_modal(window, cx) && !workspace.hide_modal(window, cx) {
+            cx.propagate();
+            return;
+        }
+
+        workspace.active_pane().update(cx, |pane, cx| {
+            pane.toolbar().update(cx, |toolbar, cx| {
+                if let Some(filter_bar) = toolbar.item_of_type::<MultibufferFilterBar>() {
+                    filter_bar.update(cx, |filter_bar, cx| {
+                        if filter_bar.has_filterable_editor() {
+                            callback(filter_bar, action, window, cx);
+                            cx.notify();
+                        } else {
+                            cx.propagate();
+                        }
+                    });
+                } else {
+                    cx.propagate();
+                }
+            });
+        })
+    });
 }
 
 pub trait DiagnosticRenderer {
@@ -1355,6 +1412,7 @@ pub struct Editor {
     outline_symbols_at_cursor: Option<(BufferId, Vec<OutlineItem<Anchor>>)>,
     sticky_headers_task: Task<()>,
     sticky_headers: Option<Vec<OutlineItem<Anchor>>>,
+    pub filterable_state: Option<Entity<FilterableMultibufferState>>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -2606,6 +2664,7 @@ impl Editor {
             outline_symbols_at_cursor: None,
             sticky_headers_task: Task::ready(()),
             sticky_headers: None,
+            filterable_state: None,
         };
 
         if is_minimap {
@@ -18696,6 +18755,34 @@ impl Editor {
         }))
     }
 
+    /// Rebuilds the multibuffer from a new set of locations.
+    /// Used by the filter bar to update the visible locations without re-querying the LSP.
+    pub fn rebuild_multibuffer_from_locations(
+        &mut self,
+        locations: HashMap<Entity<Buffer>, Vec<Range<Point>>>,
+        title: String,
+        cx: &mut Context<Self>,
+    ) {
+        self.buffer.update(cx, |multibuffer, cx| {
+            multibuffer.clear(cx);
+
+            for (buffer, mut ranges_for_buffer) in locations {
+                ranges_for_buffer.sort_by_key(|range| (range.start, Reverse(range.end)));
+                multibuffer.set_excerpts_for_path(
+                    PathKey::for_buffer(&buffer, cx),
+                    buffer.clone(),
+                    ranges_for_buffer,
+                    multibuffer_context_lines(cx),
+                    cx,
+                );
+            }
+
+            multibuffer.set_title(title, cx);
+        });
+
+        cx.notify();
+    }
+
     /// Opens a multibuffer with the given project locations in it.
     pub fn open_locations_in_multibuffer(
         workspace: &mut Workspace,
@@ -18711,6 +18798,13 @@ impl Editor {
             log::error!("bug: open_locations_in_multibuffer called with empty list of locations");
             return None;
         }
+
+        // Clone locations for filterable state before consuming in the loop
+        let locations_for_filter: HashMap<Entity<Buffer>, Vec<Range<Point>>> = locations
+            .iter()
+            .map(|(buffer, ranges)| (buffer.clone(), ranges.clone()))
+            .collect();
+        let title_for_filter = title.clone();
 
         let capability = workspace.project().read(cx).capability();
         let mut ranges = <Vec<Range<Anchor>>>::new();
@@ -18763,6 +18857,22 @@ impl Editor {
                 editor
             })
         });
+
+        // Store filterable state for the filter bar (only for new editors)
+        if !was_existing {
+            let editor_weak = editor.downgrade();
+            let filterable_state = cx.new(|cx| {
+                FilterableMultibufferState::new(
+                    locations_for_filter,
+                    title_for_filter,
+                    editor_weak,
+                    cx,
+                )
+            });
+            editor.update(cx, |editor, _cx| {
+                editor.filterable_state = Some(filterable_state);
+            });
+        }
         editor.update(cx, |editor, cx| match multibuffer_selection_mode {
             MultibufferSelectionMode::First => {
                 if let Some(first_range) = ranges.first() {

--- a/crates/editor/src/multibuffer_filter.rs
+++ b/crates/editor/src/multibuffer_filter.rs
@@ -1,0 +1,155 @@
+use crate::Editor;
+use collections::HashMap;
+use gpui::{App, Entity, WeakEntity};
+use language::{Buffer, Point};
+use std::ops::Range;
+use std::sync::Arc;
+use util::{paths::PathMatcher, rel_path::RelPath};
+
+/// State for filtering locations in a multibuffer editor.
+/// Stores the original unfiltered locations so that filters can be changed
+/// without re-querying the LSP.
+pub struct FilterableMultibufferState {
+    /// Original unfiltered locations keyed by buffer
+    original_locations: HashMap<Entity<Buffer>, Vec<Range<Point>>>,
+    /// Cached paths for each buffer for efficient filtering
+    buffer_paths: HashMap<Entity<Buffer>, Option<Arc<RelPath>>>,
+    /// Title for the multibuffer
+    title: String,
+    /// Reference to the editor that owns this state
+    editor: WeakEntity<Editor>,
+    include_text: String,
+    exclude_text: String,
+    filters_enabled: bool,
+}
+
+impl FilterableMultibufferState {
+    pub fn new(
+        locations: HashMap<Entity<Buffer>, Vec<Range<Point>>>,
+        title: String,
+        editor: WeakEntity<Editor>,
+        cx: &App,
+    ) -> Self {
+        let buffer_paths = locations
+            .keys()
+            .map(|buffer| {
+                let path = buffer.read(cx).file().map(|f| f.path().clone());
+                (buffer.clone(), path)
+            })
+            .collect();
+
+        Self {
+            original_locations: locations,
+            buffer_paths,
+            title,
+            editor,
+            include_text: String::new(),
+            exclude_text: String::new(),
+            filters_enabled: false,
+        }
+    }
+
+    /// Returns the title of the multibuffer
+    pub fn title(&self) -> &str {
+        &self.title
+    }
+
+    /// Returns the original unfiltered locations
+    pub fn original_locations(&self) -> &HashMap<Entity<Buffer>, Vec<Range<Point>>> {
+        &self.original_locations
+    }
+
+    pub fn include_text(&self) -> &str {
+        &self.include_text
+    }
+
+    pub fn exclude_text(&self) -> &str {
+        &self.exclude_text
+    }
+
+    pub fn filters_enabled(&self) -> bool {
+        self.filters_enabled
+    }
+
+    pub fn set_filters_enabled(&mut self, enabled: bool) {
+        self.filters_enabled = enabled;
+    }
+
+    pub fn set_filter_texts(&mut self, include_text: String, exclude_text: String) {
+        self.include_text = include_text;
+        self.exclude_text = exclude_text;
+    }
+
+    /// Filters locations based on include/exclude patterns.
+    /// Returns a new HashMap containing only the locations that match the filters.
+    ///
+    /// Filtering logic (matching project search):
+    /// 1. If path matches exclude pattern → filter out
+    /// 2. If no include patterns set → include all (non-excluded)
+    /// 3. If path matches include pattern → include
+    /// 4. Check path ancestors for partial matches
+    pub fn filter_locations(
+        &self,
+        include: Option<&PathMatcher>,
+        exclude: Option<&PathMatcher>,
+    ) -> HashMap<Entity<Buffer>, Vec<Range<Point>>> {
+        self.original_locations
+            .iter()
+            .filter_map(|(buffer, ranges)| {
+                let path = self.buffer_paths.get(buffer)?.as_ref()?;
+
+                if self.matches_filters(path, include, exclude) {
+                    Some((buffer.clone(), ranges.clone()))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    /// Check if a path matches the include/exclude filters.
+    fn matches_filters(
+        &self,
+        path: &RelPath,
+        include: Option<&PathMatcher>,
+        exclude: Option<&PathMatcher>,
+    ) -> bool {
+        // Check exclude patterns first
+        if let Some(exclude_matcher) = exclude {
+            if exclude_matcher.is_match(path) {
+                return false;
+            }
+        }
+
+        // If no include patterns, include everything not excluded
+        let Some(include_matcher) = include else {
+            return true;
+        };
+
+        // Check include patterns - also check parent paths for partial matches
+        let mut current_path = path.to_rel_path_buf();
+        loop {
+            if include_matcher.is_match(&current_path) {
+                return true;
+            }
+            if !current_path.pop() {
+                return false;
+            }
+        }
+    }
+
+    /// Returns the editor that owns this state
+    pub fn editor(&self) -> &WeakEntity<Editor> {
+        &self.editor
+    }
+
+    /// Returns the number of files in the original (unfiltered) locations
+    pub fn original_file_count(&self) -> usize {
+        self.original_locations.len()
+    }
+
+    /// Returns the total number of locations in the original (unfiltered) set
+    pub fn original_location_count(&self) -> usize {
+        self.original_locations.values().map(|v| v.len()).sum()
+    }
+}

--- a/crates/editor/src/multibuffer_filter_bar.rs
+++ b/crates/editor/src/multibuffer_filter_bar.rs
@@ -1,0 +1,405 @@
+use crate::{Editor, EditorEvent, EditorStyle, FilterableMultibufferState};
+use collections::HashMap;
+use gpui::{
+    App, Context, Entity, EventEmitter, FocusHandle, Focusable, IntoElement, ParentElement, Render,
+    Styled, Subscription, Task, TextStyle, WeakEntity, Window, relative, rems,
+};
+use language::{Buffer, Point};
+use settings::Settings;
+use std::{ops::Range, time::Duration};
+use theme::ThemeSettings;
+use ui::{IconButton, IconButtonShape, Tooltip, prelude::*};
+use util::paths::{PathMatcher, PathStyle};
+use workspace::{
+    ToolbarItemEvent, ToolbarItemLocation, ToolbarItemView,
+    item::{ItemBufferKind, ItemHandle},
+};
+
+const FILTER_DEBOUNCE_MS: u64 = 150;
+
+/// Toolbar bar for filtering files in multibuffer views like "Find All References".
+pub struct MultibufferFilterBar {
+    include_editor: Entity<Editor>,
+    exclude_editor: Entity<Editor>,
+    filters_enabled: bool,
+    active_editor: Option<WeakEntity<Editor>>,
+    filter_state: Option<Entity<FilterableMultibufferState>>,
+    debounce_task: Task<()>,
+    _subscriptions: Vec<Subscription>,
+}
+
+impl MultibufferFilterBar {
+    pub fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
+        let include_editor = cx.new(|cx| {
+            let mut editor = Editor::single_line(window, cx);
+            editor.set_placeholder_text("Include: src/**/*.rs", window, cx);
+            editor
+        });
+
+        let exclude_editor = cx.new(|cx| {
+            let mut editor = Editor::single_line(window, cx);
+            editor.set_placeholder_text("Exclude: *_test.rs, test/**", window, cx);
+            editor
+        });
+
+        let subscriptions = vec![
+            cx.subscribe(&include_editor, |this, _, event: &EditorEvent, cx| {
+                if matches!(event, EditorEvent::BufferEdited) {
+                    this.schedule_filter_update(cx);
+                }
+            }),
+            cx.subscribe(&exclude_editor, |this, _, event: &EditorEvent, cx| {
+                if matches!(event, EditorEvent::BufferEdited) {
+                    this.schedule_filter_update(cx);
+                }
+            }),
+        ];
+
+        Self {
+            include_editor,
+            exclude_editor,
+            filters_enabled: false,
+            active_editor: None,
+            filter_state: None,
+            debounce_task: Task::ready(()),
+            _subscriptions: subscriptions,
+        }
+    }
+
+    fn schedule_filter_update(&mut self, cx: &mut Context<Self>) {
+        if !self.filters_enabled {
+            return;
+        }
+
+        self.debounce_task = cx.spawn(async move |this, cx| {
+            cx.background_executor()
+                .timer(Duration::from_millis(FILTER_DEBOUNCE_MS))
+                .await;
+            this.update(cx, |this, cx| {
+                this.apply_filters(cx);
+            })
+            .ok();
+        });
+    }
+
+    fn apply_filters(&mut self, cx: &mut Context<Self>) {
+        if !self.filters_enabled {
+            return;
+        }
+
+        let Some(editor) = self.active_editor.as_ref().and_then(|e| e.upgrade()) else {
+            return;
+        };
+
+        let Some(filter_state) = self.filter_state.clone() else {
+            return;
+        };
+
+        let include_text = self.include_editor.read(cx).text(cx);
+        let exclude_text = self.exclude_editor.read(cx).text(cx);
+
+        filter_state.update(cx, |state, _cx| {
+            state.set_filter_texts(include_text.clone(), exclude_text.clone());
+        });
+
+        let path_style = editor
+            .read(cx)
+            .project()
+            .map(|project| project.read(cx).path_style(cx))
+            .unwrap_or(PathStyle::local());
+
+        let include_matcher = if include_text.trim().is_empty() {
+            None
+        } else {
+            parse_path_matches(&include_text, path_style).ok()
+        };
+
+        let exclude_matcher = if exclude_text.trim().is_empty() {
+            None
+        } else {
+            parse_path_matches(&exclude_text, path_style).ok()
+        };
+
+        let filtered_locations = filter_state
+            .read(cx)
+            .filter_locations(include_matcher.as_ref(), exclude_matcher.as_ref());
+
+        self.rebuild_multibuffer(&editor, filter_state, filtered_locations, cx);
+    }
+
+    fn rebuild_multibuffer(
+        &self,
+        editor: &Entity<Editor>,
+        filter_state: Entity<FilterableMultibufferState>,
+        locations: HashMap<Entity<Buffer>, Vec<Range<Point>>>,
+        cx: &mut Context<Self>,
+    ) {
+        editor.update(cx, |editor, cx| {
+            editor.rebuild_multibuffer_from_locations(
+                locations,
+                filter_state.read(cx).title().to_string(),
+                cx,
+            );
+        });
+    }
+
+    fn toggle_filters_internal(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.filters_enabled = !self.filters_enabled;
+
+        if let Some(filter_state) = self.filter_state.as_ref() {
+            let include_text = self.include_editor.read(cx).text(cx);
+            let exclude_text = self.exclude_editor.read(cx).text(cx);
+            filter_state.update(cx, |state, _cx| {
+                state.set_filters_enabled(self.filters_enabled);
+                state.set_filter_texts(include_text, exclude_text);
+            });
+        }
+
+        if !self.filters_enabled {
+            // Reset filters when disabling - show all original locations
+            if let Some(filter_state) = self.filter_state.as_ref() {
+                if let Some(editor) = self.active_editor.as_ref().and_then(|e| e.upgrade()) {
+                    let locations = filter_state.read(cx).original_locations().clone();
+                    let title = filter_state.read(cx).title().to_string();
+                    editor.update(cx, |editor, cx| {
+                        editor.rebuild_multibuffer_from_locations(locations, title, cx);
+                    });
+                }
+            }
+        } else {
+            // Apply current filter text
+            self.apply_filters(cx);
+        }
+
+        cx.emit(ToolbarItemEvent::ChangeLocation(
+            self.determine_toolbar_location(cx),
+        ));
+        window.refresh();
+        cx.notify();
+    }
+
+    fn determine_toolbar_location(&self, _cx: &App) -> ToolbarItemLocation {
+        if self.filter_state.is_some() {
+            if self.filters_enabled {
+                ToolbarItemLocation::Secondary
+            } else {
+                ToolbarItemLocation::PrimaryRight
+            }
+        } else {
+            ToolbarItemLocation::Hidden
+        }
+    }
+
+    pub(crate) fn has_filterable_editor(&self) -> bool {
+        self.filter_state.is_some()
+    }
+
+    pub(crate) fn toggle_filters(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.toggle_filters_internal(window, cx);
+    }
+
+    pub(crate) fn focus_include_editor(&self, window: &mut Window, cx: &mut App) {
+        let handle = self.include_editor.focus_handle(cx);
+        handle.focus(window, cx);
+    }
+
+    pub(crate) fn focus_exclude_editor(&self, window: &mut Window, cx: &mut App) {
+        let handle = self.exclude_editor.focus_handle(cx);
+        handle.focus(window, cx);
+    }
+
+    fn sync_from_state(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(filter_state) = self.filter_state.as_ref() else {
+            self.filters_enabled = false;
+            return;
+        };
+
+        let include_text = filter_state.read(cx).include_text().to_string();
+        let exclude_text = filter_state.read(cx).exclude_text().to_string();
+        self.filters_enabled = filter_state.read(cx).filters_enabled();
+
+        let current_include = self.include_editor.read(cx).text(cx);
+        if current_include != include_text {
+            self.include_editor.update(cx, |editor, cx| {
+                editor.set_text(include_text, window, cx);
+            });
+        }
+
+        let current_exclude = self.exclude_editor.read(cx).text(cx);
+        if current_exclude != exclude_text {
+            self.exclude_editor.update(cx, |editor, cx| {
+                editor.set_text(exclude_text, window, cx);
+            });
+        }
+    }
+}
+
+impl EventEmitter<ToolbarItemEvent> for MultibufferFilterBar {}
+
+impl ToolbarItemView for MultibufferFilterBar {
+    fn set_active_pane_item(
+        &mut self,
+        active_pane_item: Option<&dyn ItemHandle>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> ToolbarItemLocation {
+        self.active_editor = None;
+        self.filter_state = None;
+        self.filters_enabled = false;
+
+        let Some(pane_item) = active_pane_item else {
+            return ToolbarItemLocation::Hidden;
+        };
+
+        // Only show for multibuffer editors (not singleton buffers)
+        if pane_item.buffer_kind(cx) == ItemBufferKind::Singleton {
+            return ToolbarItemLocation::Hidden;
+        }
+
+        let Some(editor) = pane_item.downcast::<Editor>() else {
+            return ToolbarItemLocation::Hidden;
+        };
+
+        let filter_state = editor.read(cx).filterable_state.clone();
+
+        self.active_editor = Some(editor.downgrade());
+        self.filter_state = filter_state;
+
+        self.sync_from_state(window, cx);
+
+        if self.filters_enabled {
+            self.apply_filters(cx);
+        }
+
+        self.determine_toolbar_location(cx)
+    }
+}
+
+impl Focusable for MultibufferFilterBar {
+    fn focus_handle(&self, cx: &App) -> FocusHandle {
+        self.include_editor.focus_handle(cx)
+    }
+}
+
+impl Render for MultibufferFilterBar {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        if self.filter_state.is_none() {
+            return div().into_any_element();
+        }
+
+        if !self.filters_enabled {
+            return h_flex()
+                .child(
+                    IconButton::new("open-filters", IconName::Filter)
+                        .shape(IconButtonShape::Square)
+                        .icon_size(IconSize::Small)
+                        .on_click(cx.listener(|this, _, window, cx| {
+                            this.toggle_filters(window, cx);
+                        }))
+                        .tooltip(Tooltip::text("Show Filters")),
+                )
+                .into_any_element();
+        }
+
+        let theme = cx.theme();
+        let border_color = theme.colors().border;
+
+        h_flex()
+            .w_full()
+            .gap_2()
+            .px_2()
+            .py_1()
+            .bg(theme.colors().toolbar_background)
+            .border_b_1()
+            .border_color(border_color)
+            .child(
+                Label::new("Filters:")
+                    .size(LabelSize::Small)
+                    .color(Color::Muted),
+            )
+            .child(
+                h_flex()
+                    .flex_1()
+                    .gap_2()
+                    .child(filter_input(
+                        &self.include_editor,
+                        "Include",
+                        border_color,
+                        cx,
+                    ))
+                    .child(filter_input(
+                        &self.exclude_editor,
+                        "Exclude",
+                        border_color,
+                        cx,
+                    )),
+            )
+            .child(
+                IconButton::new("close-filters", IconName::Close)
+                    .shape(IconButtonShape::Square)
+                    .icon_size(IconSize::Small)
+                    .on_click(cx.listener(|this, _, window, cx| {
+                        this.toggle_filters(window, cx);
+                    }))
+                    .tooltip(Tooltip::text("Close Filters")),
+            )
+            .into_any_element()
+    }
+}
+
+fn filter_input(
+    editor: &Entity<Editor>,
+    label: &'static str,
+    border_color: gpui::Hsla,
+    cx: &App,
+) -> impl IntoElement {
+    h_flex()
+        .flex_1()
+        .min_w_32()
+        .h_7()
+        .px_2()
+        .border_1()
+        .border_color(border_color)
+        .rounded_md()
+        .bg(cx.theme().colors().editor_background)
+        .child(
+            Label::new(label)
+                .size(LabelSize::Small)
+                .color(Color::Muted)
+                .mr_1(),
+        )
+        .child(render_filter_editor(editor, cx))
+}
+
+fn render_filter_editor(editor: &Entity<Editor>, cx: &App) -> impl IntoElement {
+    let settings = ThemeSettings::get_global(cx);
+    let text_style = TextStyle {
+        color: cx.theme().colors().text,
+        font_family: settings.buffer_font.family.clone(),
+        font_features: settings.buffer_font.features.clone(),
+        font_fallbacks: settings.buffer_font.fallbacks.clone(),
+        font_size: rems(0.875).into(),
+        font_weight: settings.buffer_font.weight,
+        line_height: relative(1.3),
+        ..TextStyle::default()
+    };
+
+    let editor_style = EditorStyle {
+        background: cx.theme().colors().editor_background,
+        local_player: cx.theme().players().local(),
+        text: text_style,
+        ..EditorStyle::default()
+    };
+
+    crate::EditorElement::new(editor, editor_style)
+}
+
+fn parse_path_matches(text: &str, path_style: PathStyle) -> anyhow::Result<PathMatcher> {
+    let queries = text
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+    Ok(PathMatcher::new(&queries, path_style)?)
+}

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -22,7 +22,7 @@ use breadcrumbs::Breadcrumbs;
 use client::zed_urls;
 use collections::VecDeque;
 use debugger_ui::debugger_panel::DebugPanel;
-use editor::{Editor, MultiBuffer};
+use editor::{Editor, MultiBuffer, MultibufferFilterBar};
 use extension_host::ExtensionStore;
 use feature_flags::{FeatureFlagAppExt as _, PanicFeatureFlag};
 use fs::Fs;
@@ -1174,6 +1174,8 @@ fn initialize_pane(
         pane.toolbar().update(cx, |toolbar, cx| {
             let multibuffer_hint = cx.new(|_| MultibufferHint::new());
             toolbar.add_item(multibuffer_hint, window, cx);
+            let multibuffer_filter_bar = cx.new(|cx| MultibufferFilterBar::new(window, cx));
+            toolbar.add_item(multibuffer_filter_bar, window, cx);
             let breadcrumbs = cx.new(|_| Breadcrumbs::new());
             toolbar.add_item(breadcrumbs, window, cx);
             let buffer_search_bar = cx.new(|cx| {


### PR DESCRIPTION
We already have this capability in the project search view and especially in big projects with lots of tests (like Terraform) it would be super useful if I could just filter out the test cases when trying to understand a code path.

<img width="1582" height="976" alt="Screenshot 2026-02-05 at 11 05 29" src="https://github.com/user-attachments/assets/34833efe-acce-4d9b-976d-74169e4ac046" />


Release Notes:

- Added file filter to multi-buffer views (e.g. Find all References)