### PR TITLE
languages: Remove duplicate keywords in JS syntax highlighting

### DIFF
--- a/crates/languages/src/javascript/highlights.scm
+++ b/crates/languages/src/javascript/highlights.scm
@@ -243,18 +243,29 @@
 )
 
 [
+  "abstract"
   "as"
   "async"
   "await"
   "debugger"
+  "declare"
   "default"
   "delete"
   "extends"
   "get"
+  "implements"
   "in"
   "instanceof"
+  "keyof"
+  "module"
+  "namespace"
   "new"
   "of"
+  "override"
+  "private"
+  "protected"
+  "public"
+  "readonly"
   "set"
   "static"
   "target"
@@ -270,6 +281,9 @@
   "var"
   "function"
   "class"
+  "enum"
+  "interface"
+  "type"
 ] @keyword.declaration
 
 [
@@ -307,25 +321,6 @@
   ">" @punctuation.bracket)
 
 (decorator "@" @punctuation.special)
-
-; Keywords
-
-[ "abstract"
-  "declare"
-  "enum"
-  "export"
-  "implements"
-  "interface"
-  "keyof"
-  "module"
-  "namespace"
-  "private"
-  "protected"
-  "public"
-  "type"
-  "readonly"
-  "override"
-] @keyword
 
 ; JSX elements
 (jsx_opening_element


### PR DESCRIPTION
Fixes an issue where syntax highlighting would be incorrect in certain cases for JS, because of duplicate keyword definitions.

Release Notes:

- Fixed issue where certain keywords were incorrectly highlighted in JS files
