### PR TITLE
Canonicalize --user-data-dir path to match file watcher events

### DIFF
--- a/crates/paths/src/paths.rs
+++ b/crates/paths/src/paths.rs
@@ -69,15 +69,10 @@ pub fn set_custom_data_dir(dir: &str) -> &'static PathBuf {
         panic!("set_custom_data_dir called after data_dir or config_dir was initialized");
     }
     CUSTOM_DATA_DIR.get_or_init(|| {
-        let mut path = PathBuf::from(dir);
-        if path.is_relative() && path.exists() {
-            let abs_path = path
-                .canonicalize()
-                .expect("failed to canonicalize custom data directory's path to an absolute path");
-            path = util::paths::SanitizedPath::new(&abs_path).into()
-        }
+        let path = PathBuf::from(dir);
         std::fs::create_dir_all(&path).expect("failed to create custom data directory");
-        path
+        path.canonicalize()
+            .expect("failed to canonicalize custom data directory's path to an absolute path")
     })
 }
 


### PR DESCRIPTION
This commit updates the `paths::set_custom_data_dir` implementation so as to always canonicalize the provided `dir`, even when dealing with an absolute path.

This ensures that we correctly deal with symlinks and don't end up not reacting to filesystem watcher events in this specific case. For example, when using `--user-data-dir /tmp/zed` on macOS, since `/tmp` is a symlink to `/private/tmp`, if any setting was changed, the application would not react, as the event would be using
`/private/tmp/zed/config/settings.json`, while the watcher would be looking out for `/tmp/zed/config/settings.json`.

Lastly, the canonicalization of the path is now done after `std::fs::create_dir_all` is called, in order to guarantee that the directory already exists at that point.

Release Notes:

- N/A
