### PR TITLE
Navigate between changes cross tabs

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -150,8 +150,6 @@
       "ctrl->": "agent::AddSelectionToThread",
       "ctrl-<": "assistant::InsertIntoEditor",
       "ctrl-alt-e": "editor::SelectEnclosingSymbol",
-      "ctrl-shift-backspace": "editor::GoToPreviousChange",
-      "ctrl-shift-alt-backspace": "editor::GoToNextChange",
       "alt-enter": "editor::OpenSelectionsInMultibuffer",
     },
   },
@@ -417,6 +415,8 @@
   {
     "context": "Pane",
     "bindings": {
+      "ctrl-shift-backspace": "pane::GoToPreviousChange",
+      "ctrl-shift-alt-backspace": "pane::GoToNextChange",
       "alt-1": ["pane::ActivateItem", 0],
       "alt-2": ["pane::ActivateItem", 1],
       "alt-3": ["pane::ActivateItem", 2],

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -601,14 +601,14 @@
     "bindings": {
       "cmd-shift-o": "outline::Toggle",
       "ctrl-g": "go_to_line::Toggle",
-      "cmd-shift-backspace": "editor::GoToPreviousChange",
-      "cmd-shift-alt-backspace": "editor::GoToNextChange",
     },
   },
   {
     "context": "Pane",
     "use_key_equivalents": true,
     "bindings": {
+      "cmd-shift-backspace": "pane::GoToPreviousChange",
+      "cmd-shift-alt-backspace": "pane::GoToNextChange",
       "ctrl-1": ["pane::ActivateItem", 0],
       "ctrl-2": ["pane::ActivateItem", 1],
       "ctrl-3": ["pane::ActivateItem", 2],

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -145,9 +145,15 @@
       "ctrl-shift-.": "agent::AddSelectionToThread",
       "ctrl-shift-,": "assistant::InsertIntoEditor",
       "shift-alt-e": "editor::SelectEnclosingSymbol",
-      "ctrl-shift-backspace": "editor::GoToPreviousChange",
-      "ctrl-shift-alt-backspace": "editor::GoToNextChange",
+
       "alt-enter": "editor::OpenSelectionsInMultibuffer",
+    },
+  },
+  {
+    "context": "Pane",
+    "bindings": {
+      "ctrl-shift-backspace": "pane::GoToPreviousChange",
+      "ctrl-shift-alt-backspace": "pane::GoToNextChange",
     },
   },
   {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2614,9 +2614,23 @@ impl Editor {
                     let vim_mode = vim_mode_setting::VimModeSetting::try_get(cx)
                         .map(|vim_mode| vim_mode.0)
                         .unwrap_or(false);
+
+                    let display_map = editor.display_snapshot(cx);
+                    let selections = editor.selections.all_adjusted_display(&display_map);
+
+                    if let Some(nav_history) = editor.nav_history.as_mut() {
+                        let new_positions: Vec<Anchor> = selections
+                            .iter()
+                            .map(|s| display_map.display_point_to_anchor(s.head(), Bias::Left))
+                            .collect();
+                        let row = new_positions
+                            .first()
+                            .map(|a| a.to_point(&display_map.buffer_snapshot()).row)
+                            .unwrap_or(0);
+                        nav_history.push_change(new_positions, row, cx);
+                    }
+
                     if !vim_mode {
-                        let display_map = editor.display_snapshot(cx);
-                        let selections = editor.selections.all_adjusted_display(&display_map);
                         let pop_state = editor
                             .change_list
                             .last()
@@ -2629,7 +2643,7 @@ impl Editor {
                             })
                             .unwrap_or(false);
                         let new_positions = selections
-                            .into_iter()
+                            .iter()
                             .map(|s| display_map.display_point_to_anchor(s.head(), Bias::Left))
                             .collect();
                         editor

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -228,6 +228,14 @@ pub trait Item: Focusable + EventEmitter<Self::Event> + Render + Sized {
         false
     }
 
+    fn navigate_to_position(
+        &mut self,
+        _data: Arc<dyn Any + Send + Sync>,
+        _window: &mut Window,
+        _cx: &mut Context<Self>,
+    ) {
+    }
+
     fn telemetry_event_text(&self) -> Option<&'static str> {
         None
     }
@@ -496,6 +504,7 @@ pub trait ItemHandle: 'static + Send {
     fn on_removed(&self, cx: &mut App);
     fn workspace_deactivated(&self, window: &mut Window, cx: &mut App);
     fn navigate(&self, data: Arc<dyn Any + Send>, window: &mut Window, cx: &mut App) -> bool;
+    fn navigate_to_position(&self, data: Arc<dyn Any + Send + Sync>, window: &mut Window, cx: &mut App);
     fn item_id(&self) -> EntityId;
     fn to_any_view(&self) -> AnyView;
     fn is_dirty(&self, cx: &App) -> bool;
@@ -966,6 +975,10 @@ impl<T: Item> ItemHandle for Entity<T> {
 
     fn navigate(&self, data: Arc<dyn Any + Send>, window: &mut Window, cx: &mut App) -> bool {
         self.update(cx, |this, cx| this.navigate(data, window, cx))
+    }
+
+    fn navigate_to_position(&self, data: Arc<dyn Any + Send + Sync>, window: &mut Window, cx: &mut App) {
+        self.update(cx, |this, cx| this.navigate_to_position(data, window, cx))
     }
 
     fn item_id(&self) -> EntityId {


### PR DESCRIPTION
Closes #19731

Adds `pane::GoToPreviousChange` and `pane::GoToNextChange` that work the same as `editor::GoToPreviousChange` and `editor::GoToNextChange` but across multiple tabs

Release Notes:

- Added a way to navigate between changes in multiple tabs with `pane::GoToPreviousChange` and `pane::GoToNextChange`
- Use `pane::GoToPreviousChange` and `pane::GoToNextChange` as default actions on hotkeys instead `editor::GoToPreviousChange` and `editor::GoToNextChange`
