### PR TITLE
docs: Remove broken Linear MCP extension from docs

### DIFF
--- a/docs/src/ai/mcp.md
+++ b/docs/src/ai/mcp.md
@@ -33,7 +33,6 @@ Popular servers:
 - [Brave Search](https://zed.dev/extensions/brave-search-mcp-server)
 - [Prisma](https://github.com/aqrln/prisma-mcp-zed)
 - [Framelink Figma](https://zed.dev/extensions/framelink-figma-mcp-server)
-- [Linear](https://zed.dev/extensions/linear-mcp-server)
 - [Resend](https://zed.dev/extensions/resend-mcp-server)
 
 ### As Custom Servers


### PR DESCRIPTION
The extension currently does not work, from my own testing. Since Zed has native support for remote MCPs over HTTP now, Linear can be configured like this:

```json
{
  "linear-remote": {
    "url": "https://mcp.linear.app/mcp",
    "headers": {
       "Authorization": "Bearer <YOUR LINEAR TOKEN>"
    }
  }
}
```

---

Release Notes:

- N/A