### PR TITLE
Add "show_menus_on_hover" option to title bar settings

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -449,6 +449,8 @@
     "show_sign_in": true,
     // Whether to show the menus in the titlebar.
     "show_menus": false,
+    // Whether to show the menus in the titlebar on hover.
+    "show_menus_on_hover": false,
   },
   "audio": {
     // Opt into the new audio system.

--- a/crates/settings_content/src/settings_content.rs
+++ b/crates/settings_content/src/settings_content.rs
@@ -316,6 +316,10 @@ pub struct TitleBarSettingsContent {
     ///
     /// Default: false
     pub show_menus: Option<bool>,
+    /// Whether to automatically reveal the menus in the title bar on hover.
+    ///
+    /// Default: false
+    pub show_menus_on_hover: Option<bool>,
 }
 
 /// Configuration of audio in Zed.

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -3496,7 +3496,7 @@ fn window_and_layout_page() -> SettingsPage {
         ]
     }
 
-    fn title_bar_section() -> [SettingsPageItem; 9] {
+    fn title_bar_section() -> [SettingsPageItem; 10] {
         [
             SettingsPageItem::SectionHeader("Title Bar"),
             SettingsPageItem::SettingItem(SettingItem {
@@ -3658,6 +3658,24 @@ fn window_and_layout_page() -> SettingsPage {
                             .title_bar
                             .get_or_insert_default()
                             .show_menus = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Open Menus on Hover",
+                description: "Automatically open menus in the titlebar on hover.",
+                field: Box::new(SettingField {
+                    json_path: Some("title_bar.show_menus_on_hover"),
+                    pick: |settings_content| {
+                        settings_content.title_bar.as_ref()?.show_menus_on_hover.as_ref()
+                    },
+                    write: |settings_content, value| {
+                        settings_content
+                            .title_bar
+                            .get_or_insert_default()
+                            .show_menus_on_hover = value;
                     },
                 }),
                 metadata: None,

--- a/crates/title_bar/src/application_menu.rs
+++ b/crates/title_bar/src/application_menu.rs
@@ -177,6 +177,7 @@ impl ApplicationMenu {
         let menu_name = entry.menu.name.clone();
         let entry = entry.clone();
 
+        let any_menu_deployed = self.entries.iter().any(|e| e.handle.is_deployed());
         let all_handles: Vec<_> = self
             .entries
             .iter()
@@ -202,7 +203,10 @@ impl ApplicationMenu {
                     .with_handle(current_handle.clone()),
             )
             .on_hover(move |hover_enter, window, cx| {
-                if *hover_enter && !current_handle.is_deployed() {
+                if *hover_enter
+                    && !current_handle.is_deployed()
+                    && (show_menus_on_hover(cx) || any_menu_deployed)
+                {
                     all_handles.iter().for_each(|h| h.hide(cx));
 
                     // We need to defer this so that this menu handle can take focus from the previous menu
@@ -271,6 +275,10 @@ impl ApplicationMenu {
 pub(crate) fn show_menus(cx: &mut App) -> bool {
     TitleBarSettings::get_global(cx).show_menus
         && (cfg!(not(target_os = "macos")) || option_env!("ZED_USE_CROSS_PLATFORM_MENU").is_some())
+}
+
+pub(crate) fn show_menus_on_hover(cx: &mut App) -> bool {
+    TitleBarSettings::get_global(cx).show_menus_on_hover
 }
 
 impl Render for ApplicationMenu {

--- a/crates/title_bar/src/application_menu.rs
+++ b/crates/title_bar/src/application_menu.rs
@@ -177,12 +177,12 @@ impl ApplicationMenu {
         let menu_name = entry.menu.name.clone();
         let entry = entry.clone();
 
-        let any_menu_deployed = self.entries.iter().any(|e| e.handle.is_deployed());
         let all_handles: Vec<_> = self
             .entries
             .iter()
             .map(|entry| entry.handle.clone())
             .collect();
+        let any_menu_deployed = all_handles.iter().any(|e| e.is_deployed());
 
         div()
             .id(format!("{}-menu-item", menu_name))

--- a/crates/title_bar/src/title_bar_settings.rs
+++ b/crates/title_bar/src/title_bar_settings.rs
@@ -10,6 +10,7 @@ pub struct TitleBarSettings {
     pub show_sign_in: bool,
     pub show_user_menu: bool,
     pub show_menus: bool,
+    pub show_menus_on_hover: bool,
 }
 
 impl Settings for TitleBarSettings {
@@ -24,6 +25,7 @@ impl Settings for TitleBarSettings {
             show_sign_in: content.show_sign_in.unwrap(),
             show_user_menu: content.show_user_menu.unwrap(),
             show_menus: content.show_menus.unwrap(),
+            show_menus_on_hover: content.show_menus_on_hover.unwrap(),
         }
     }
 }

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -4352,7 +4352,8 @@ Run the {#action theme_selector::Toggle} action in the command palette to see a 
   "show_user_picture": true,
   "show_user_menu": true,
   "show_sign_in": true,
-  "show_menus": false
+  "show_menus": false,
+  "show_menus_on_hover": false
 }
 ```
 

--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -113,14 +113,15 @@ To disable this behavior use:
 ```json [settings]
   // Control which items are shown/hidden in the title bar
   "title_bar": {
-    "show_branch_icon": false,      // Show/hide branch icon beside branch switcher
-    "show_branch_name": true,       // Show/hide branch name
-    "show_project_items": true,     // Show/hide project host and name
-    "show_onboarding_banner": true, // Show/hide onboarding banners
-    "show_user_picture": true,      // Show/hide user avatar
-    "show_user_menu": true,         // Show/hide app user button
-    "show_sign_in": true,           // Show/hide sign-in button
-    "show_menus": false             // Show/hide menus
+    "show_branch_icon": false,        // Show/hide branch icon beside branch switcher
+    "show_branch_name": true,         // Show/hide branch name
+    "show_project_items": true,       // Show/hide project host and name
+    "show_onboarding_banner": true,   // Show/hide onboarding banners
+    "show_user_picture": true,        // Show/hide user avatar
+    "show_user_menu": true,           // Show/hide app user button
+    "show_sign_in": true,             // Show/hide sign-in button
+    "show_menus": false,              // Show/hide menus
+    "show_menus_on_hover": false      // Automatically show menus on hover
   },
 ```
 


### PR DESCRIPTION
Closes #45603 

I wanted to open this and start a conversation/get some feedback after encouragement from people in the above discussion. Currently, the enabled `show_menus` setting causes them to open when hovered over, which generally breaks with a longstanding user expectation for desktop applications. It could be argued that this behavior shouldn't exist at all, but it's of course possible that some people prefer it. To that point, I explored adding an additional option, `show_menus_on_hover`, which is disabled by default. 

This also checks as to whether any menu is in use so that clicking a menu and then navigating through them opens them accordingly. As mentioned in the discussion, this doesn't address an existing bug where some of the pane icons will blink while moving through the menus.

I'm unsure of how this specifically can or should be tested since I'm learning as I go, so for now there's just screenshots from the aforementioned discussion. I'm open to suggestions. As I'm sure some might guess, these changes don't really apply to macOS as the menus are always visible. I also do not have access to a Windows installation at this point.

(Tested in Arch Linux / KDE  Plasma 6.5.5; ran the release build to take clips)

![hover-on](https://github.com/user-attachments/assets/6601f927-ef68-4d24-b05b-c442ecc87137)
![hover-off](https://github.com/user-attachments/assets/716e79e2-5a84-41df-a394-acfbac59b2be)
<img width="1380" height="752" alt="setting" src="https://github.com/user-attachments/assets/7a3614ae-d5fd-4767-9ca4-330c91e40bcc" />

Release Notes:

- Adjust the default behavior to not reveal menus on hover when `show_menus` is enabled, unless one is first clicked
- Add a setting (`show_menus_on_hover`) to allow the above