### PR TITLE
Add a way to display setting dropdown options with documentation aside

### DIFF
--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -803,6 +803,7 @@ pub struct ProjectPanelIndentGuidesSettings {
     Deserialize,
     JsonSchema,
     MergeFrom,
+    strum::EnumMessage,
     strum::VariantArray,
     strum::VariantNames,
 )]


### PR DESCRIPTION
<img width="1586" height="434" alt="image" src="https://github.com/user-attachments/assets/4f5bad0c-fb7a-4eb8-a059-5b826b48d964" />

For now, added to semantic token settings only, as requires `strum::EnumMessage` additionally.


Release Notes:

- N/A
