### PR TITLE
settings_content: Remove unused methods from `AgentSettingsContent`

### DIFF
--- a/crates/settings_content/src/agent.rs
+++ b/crates/settings_content/src/agent.rs
@@ -144,12 +144,6 @@ impl AgentSettingsContent {
     }
 
     pub fn set_model(&mut self, language_model: LanguageModelSelection) {
-        // let model = language_model.id().0.to_string();
-        // let provider = language_model.provider_id().0.to_string();
-        // self.default_model = Some(LanguageModelSelection {
-        //     provider: provider.into(),
-        //     model,
-        // });
         self.default_model = Some(language_model)
     }
 
@@ -158,39 +152,6 @@ impl AgentSettingsContent {
             provider: provider.into(),
             model,
         });
-    }
-    pub fn set_inline_assistant_use_streaming_tools(&mut self, use_tools: bool) {
-        self.inline_assistant_use_streaming_tools = Some(use_tools);
-    }
-
-    pub fn set_commit_message_model(&mut self, provider: String, model: String) {
-        self.commit_message_model = Some(LanguageModelSelection {
-            provider: provider.into(),
-            model,
-        });
-    }
-
-    pub fn set_thread_summary_model(&mut self, provider: String, model: String) {
-        self.thread_summary_model = Some(LanguageModelSelection {
-            provider: provider.into(),
-            model,
-        });
-    }
-
-    pub fn set_always_allow_tool_actions(&mut self, allow: bool) {
-        self.always_allow_tool_actions = Some(allow);
-    }
-
-    pub fn set_play_sound_when_agent_done(&mut self, allow: bool) {
-        self.play_sound_when_agent_done = Some(allow);
-    }
-
-    pub fn set_single_file_review(&mut self, allow: bool) {
-        self.single_file_review = Some(allow);
-    }
-
-    pub fn set_use_modifier_to_send(&mut self, always_use: bool) {
-        self.use_modifier_to_send = Some(always_use);
     }
 
     pub fn set_profile(&mut self, profile_id: Arc<str>) {


### PR DESCRIPTION
This PR removes some unused methods from the `AgentSettingsContent` type.

Release Notes:

- N/A
