### PR TITLE
settings_ui: Fix tab navigation in edit predictions settings

### DIFF
--- a/crates/copilot_ui/src/sign_in.rs
+++ b/crates/copilot_ui/src/sign_in.rs
@@ -568,6 +568,7 @@ impl ConfigurationView {
             .icon_color(Color::Muted)
             .icon_position(IconPosition::Start)
             .icon_size(IconSize::Small)
+            .when(edit_prediction, |this| this.tab_index(0isize))
             .on_click(|_, window, cx| {
                 if let Some(app_state) = AppState::global(cx).upgrade()
                     && let Some(copilot) = GlobalCopilotAuth::try_get_or_init(app_state, cx)

--- a/crates/settings_ui/src/pages/edit_prediction_provider_setup.rs
+++ b/crates/settings_ui/src/pages/edit_prediction_provider_setup.rs
@@ -157,6 +157,7 @@ fn render_provider_dropdown(window: &mut Window, cx: &mut App) -> AnyElement {
                 )
                 .child(
                     DropdownMenu::new("provider-dropdown", current_provider_name, menu)
+                        .tab_index(0)
                         .style(DropdownStyle::Outlined),
                 ),
         )


### PR DESCRIPTION
The provider dropdown and GitHub Copilot sign-in button were not tab-navigable because they lacked tab_index. The copilot button conditionally sets tab_index only when edit_prediction is true, since it's also used in the agent configuration panel where tab navigation isn't used.

Closes #48391

Release Notes:

- Fixed focus skipping provider dropdown and GitHub Copilot button in edit prediction settings
