### PR TITLE
agent: Add `agent.default_model.enable_thinking` setting

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -929,6 +929,8 @@
       "provider": "zed.dev",
       // The model to use.
       "model": "claude-sonnet-4",
+      // Whether thinking is enabled.
+      "enable_thinking": false,
     },
     // Additional parameters for language model requests. When making a request to a model, parameters will be taken
     // from the last entry in this list that matches the model's provider and name. In each entry, both provider

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -1161,13 +1161,23 @@ impl acp_thread::AgentModelSelector for NativeAgentModelSelector {
             move |settings, cx| {
                 let provider = model.provider_id().0.to_string();
                 let model = model.id().0.to_string();
+                let enable_thinking = settings
+                    .agent
+                    .as_ref()
+                    .and_then(|agent| {
+                        agent
+                            .default_model
+                            .as_ref()
+                            .map(|default_model| default_model.enable_thinking)
+                    })
+                    .unwrap_or_else(|| thread.read(cx).thinking_enabled());
                 settings
                     .agent
                     .get_or_insert_default()
                     .set_model(LanguageModelSelection {
                         provider: provider.into(),
                         model,
-                        enable_thinking: thread.read(cx).thinking_enabled(),
+                        enable_thinking,
                     });
             },
         );

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -1158,7 +1158,7 @@ impl acp_thread::AgentModelSelector for NativeAgentModelSelector {
         update_settings_file(
             self.connection.0.read(cx).fs.clone(),
             cx,
-            move |settings, _cx| {
+            move |settings, cx| {
                 let provider = model.provider_id().0.to_string();
                 let model = model.id().0.to_string();
                 settings
@@ -1167,6 +1167,7 @@ impl acp_thread::AgentModelSelector for NativeAgentModelSelector {
                     .set_model(LanguageModelSelection {
                         provider: provider.into(),
                         model,
+                        enable_thinking: thread.read(cx).thinking_enabled(),
                     });
             },
         );

--- a/crates/agent/src/native_agent_server.rs
+++ b/crates/agent/src/native_agent_server.rs
@@ -107,6 +107,7 @@ fn model_id_to_selection(model_id: &acp::ModelId) -> LanguageModelSelection {
     LanguageModelSelection {
         provider: provider.to_owned().into(),
         model: model.to_owned(),
+        enable_thinking: false,
     }
 }
 

--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -76,27 +76,6 @@ impl AgentSettings {
         return None;
     }
 
-    pub fn set_inline_assistant_model(&mut self, provider: String, model: String) {
-        self.inline_assistant_model = Some(LanguageModelSelection {
-            provider: provider.into(),
-            model,
-        });
-    }
-
-    pub fn set_commit_message_model(&mut self, provider: String, model: String) {
-        self.commit_message_model = Some(LanguageModelSelection {
-            provider: provider.into(),
-            model,
-        });
-    }
-
-    pub fn set_thread_summary_model(&mut self, provider: String, model: String) {
-        self.thread_summary_model = Some(LanguageModelSelection {
-            provider: provider.into(),
-            model,
-        });
-    }
-
     pub fn set_message_editor_max_lines(&self) -> usize {
         self.message_editor_min_lines * 2
     }

--- a/crates/agent_ui/src/acp/thread_view/active_thread.rs
+++ b/crates/agent_ui/src/acp/thread_view/active_thread.rs
@@ -1,4 +1,5 @@
 use gpui::List;
+use settings::{LanguageModelSelection, update_settings_file};
 
 use super::*;
 
@@ -2725,7 +2726,17 @@ impl AcpThreadView {
                 .on_click(cx.listener(move |this, _, _window, cx| {
                     if let Some(thread) = this.as_native_thread(cx) {
                         thread.update(cx, |thread, cx| {
-                            thread.set_thinking_enabled(!thread.thinking_enabled(), cx);
+                            let enable_thinking = !thread.thinking_enabled();
+                            thread.set_thinking_enabled(enable_thinking, cx);
+
+                            let fs = thread.project().read(cx).fs().clone();
+                            update_settings_file(fs, cx, move |settings, _| {
+                                if let Some(agent) = settings.agent.as_mut()
+                                    && let Some(default_model) = agent.default_model.as_mut()
+                                {
+                                    default_model.enable_thinking = enable_thinking;
+                                }
+                            });
                         });
                     }
                 })),

--- a/crates/agent_ui/src/acp/thread_view/active_thread.rs
+++ b/crates/agent_ui/src/acp/thread_view/active_thread.rs
@@ -1,5 +1,5 @@
 use gpui::List;
-use settings::{LanguageModelSelection, update_settings_file};
+use settings::update_settings_file;
 
 use super::*;
 

--- a/crates/agent_ui/src/agent_configuration/manage_profiles_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/manage_profiles_modal.rs
@@ -264,6 +264,7 @@ impl ManageProfilesModal {
                                     profile.default_model = Some(LanguageModelSelection {
                                         provider: LanguageModelProviderSetting(provider.clone()),
                                         model: model_id.clone(),
+                                        enable_thinking: model.supports_thinking(),
                                     });
                                 }
                             }

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1400,6 +1400,7 @@ impl AgentPanel {
                             .set_model(LanguageModelSelection {
                                 provider: LanguageModelProviderSetting(provider),
                                 model,
+                                enable_thinking: false,
                             })
                     });
                 }

--- a/crates/agent_ui/src/favorite_models.rs
+++ b/crates/agent_ui/src/favorite_models.rs
@@ -9,6 +9,7 @@ fn language_model_to_selection(model: &Arc<dyn LanguageModel>) -> LanguageModelS
     LanguageModelSelection {
         provider: model.provider_id().to_string().into(),
         model: model.id().0.to_string(),
+        enable_thinking: model.supports_thinking(),
     }
 }
 

--- a/crates/agent_ui/src/favorite_models.rs
+++ b/crates/agent_ui/src/favorite_models.rs
@@ -9,7 +9,7 @@ fn language_model_to_selection(model: &Arc<dyn LanguageModel>) -> LanguageModelS
     LanguageModelSelection {
         provider: model.provider_id().to_string().into(),
         model: model.id().0.to_string(),
-        enable_thinking: model.supports_thinking(),
+        enable_thinking: false,
     }
 }
 

--- a/crates/agent_ui/src/text_thread_editor.rs
+++ b/crates/agent_ui/src/text_thread_editor.rs
@@ -319,11 +319,13 @@ impl TextThreadEditor {
                         move |model, cx| {
                             update_settings_file(fs.clone(), cx, move |settings, _| {
                                 let provider = model.provider_id().0.to_string();
+                                let enable_thinking = model.supports_thinking();
                                 let model = model.id().0.to_string();
                                 settings.agent.get_or_insert_default().set_model(
                                     LanguageModelSelection {
                                         provider: LanguageModelProviderSetting(provider),
                                         model,
+                                        enable_thinking,
                                     },
                                 )
                             });

--- a/crates/settings_content/src/agent.rs
+++ b/crates/settings_content/src/agent.rs
@@ -151,6 +151,7 @@ impl AgentSettingsContent {
         self.inline_assistant_model = Some(LanguageModelSelection {
             provider: provider.into(),
             model,
+            enable_thinking: false,
         });
     }
 
@@ -262,6 +263,8 @@ pub enum NotifyWhenAgentWaiting {
 pub struct LanguageModelSelection {
     pub provider: LanguageModelProviderSetting,
     pub model: String,
+    #[serde(default)]
+    pub enable_thinking: bool,
 }
 
 #[with_fallible_options]


### PR DESCRIPTION
This PR adds a new `enable_thinking` setting for the default model, which controls whether the model uses thinking or not.

Release Notes:

- N/A
