### PR TITLE
git: Side-by-side search matches panic

### DIFF
--- a/crates/editor/src/split.rs
+++ b/crates/editor/src/split.rs
@@ -492,6 +492,7 @@ impl SplittableEditor {
                 if let Some(lhs) = &mut this.lhs {
                     if !lhs.was_last_focused {
                         lhs.was_last_focused = true;
+                        cx.emit(SearchEvent::MatchesInvalidated);
                         cx.notify();
                     }
                 }
@@ -504,6 +505,7 @@ impl SplittableEditor {
                 if let Some(lhs) = &mut this.lhs {
                     if lhs.was_last_focused {
                         lhs.was_last_focused = false;
+                        cx.emit(SearchEvent::MatchesInvalidated);
                         cx.notify();
                     }
                 }


### PR DESCRIPTION
Fixes a panic when using a search anchor from one side of a side-by-side in the
other.

Release Notes:

- N/A *or* Added/Fixed/Improved ...
