### PR TITLE
agent: Add support for setting thinking effort for Zed provider

### DIFF
--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -1160,7 +1160,7 @@ impl acp_thread::AgentModelSelector for NativeAgentModelSelector {
             cx,
             move |settings, cx| {
                 let provider = model.provider_id().0.to_string();
-                let model = model.id().0.to_string();
+                let model_id = model.id().0.to_string();
                 let enable_thinking = settings
                     .agent
                     .as_ref()
@@ -1171,13 +1171,28 @@ impl acp_thread::AgentModelSelector for NativeAgentModelSelector {
                             .map(|default_model| default_model.enable_thinking)
                     })
                     .unwrap_or_else(|| thread.read(cx).thinking_enabled());
+                let effort = settings
+                    .agent
+                    .as_ref()
+                    .and_then(|agent| {
+                        agent
+                            .default_model
+                            .as_ref()
+                            .and_then(|default_model| default_model.effort.clone())
+                    })
+                    .or_else(|| {
+                        model
+                            .default_effort_level()
+                            .map(|effort_level| effort_level.value.to_string())
+                    });
                 settings
                     .agent
                     .get_or_insert_default()
                     .set_model(LanguageModelSelection {
                         provider: provider.into(),
-                        model,
+                        model: model_id,
                         enable_thinking,
+                        effort,
                     });
             },
         );

--- a/crates/agent/src/edit_agent.rs
+++ b/crates/agent/src/edit_agent.rs
@@ -732,6 +732,7 @@ impl EditAgent {
             stop: Vec::new(),
             temperature: None,
             thinking_allowed: true,
+            thinking_effort: None,
         };
 
         Ok(self.model.stream_completion_text(request, cx).await?.stream)

--- a/crates/agent/src/native_agent_server.rs
+++ b/crates/agent/src/native_agent_server.rs
@@ -108,6 +108,7 @@ fn model_id_to_selection(model_id: &acp::ModelId) -> LanguageModelSelection {
         provider: provider.to_owned().into(),
         model: model.to_owned(),
         enable_thinking: false,
+        effort: None,
     }
 }
 

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -2329,6 +2329,7 @@ impl Thread {
             stop: Vec::new(),
             temperature: AgentSettings::temperature_for_model(model, cx),
             thinking_allowed: self.thinking_enabled,
+            thinking_effort: None,
         };
 
         log::debug!("Completion request built successfully");

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1259,6 +1259,10 @@ impl Thread {
         cx.notify();
     }
 
+    pub fn thinking_effort(&self) -> Option<&String> {
+        self.thinking_effort.as_ref()
+    }
+
     pub fn set_thinking_effort(&mut self, effort: Option<String>, cx: &mut Context<Self>) {
         self.thinking_effort = effort;
         cx.notify();

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -2354,7 +2354,7 @@ impl Thread {
             stop: Vec::new(),
             temperature: AgentSettings::temperature_for_model(model, cx),
             thinking_allowed: self.thinking_enabled,
-            thinking_effort: None,
+            thinking_effort: self.thinking_effort.clone(),
         };
 
         log::debug!("Completion request built successfully");

--- a/crates/agent_ui/src/acp/thread_view/active_thread.rs
+++ b/crates/agent_ui/src/acp/thread_view/active_thread.rs
@@ -2350,7 +2350,7 @@ impl AcpThreadView {
                             .gap_0p5()
                             .child(self.render_add_context_button(cx))
                             .child(self.render_follow_toggle(cx))
-                            .children(self.render_thinking_toggle(cx)),
+                            .children(self.render_thinking_control(cx)),
                     )
                     .child(
                         h_flex()
@@ -2694,7 +2694,7 @@ impl AcpThreadView {
         }
     }
 
-    fn render_thinking_toggle(&self, cx: &mut Context<Self>) -> Option<SplitButton> {
+    fn render_thinking_control(&self, cx: &mut Context<Self>) -> Option<SplitButton> {
         if !cx.has_flag::<CloudThinkingToggleFeatureFlag>() {
             return None;
         }

--- a/crates/agent_ui/src/acp/thread_view/active_thread.rs
+++ b/crates/agent_ui/src/acp/thread_view/active_thread.rs
@@ -2792,7 +2792,7 @@ impl AcpThreadView {
                             selected
                                 .clone()
                                 .or(default_effort_level)
-                                .map_or("Select Effort".into(), |effort| effort.name.clone()),
+                                .map_or("Select Effort".into(), |effort| effort.name),
                         )
                         .size(LabelSize::Small),
                     )

--- a/crates/agent_ui/src/agent_configuration/manage_profiles_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/manage_profiles_modal.rs
@@ -265,6 +265,9 @@ impl ManageProfilesModal {
                                         provider: LanguageModelProviderSetting(provider.clone()),
                                         model: model_id.clone(),
                                         enable_thinking: model.supports_thinking(),
+                                        effort: model
+                                            .default_effort_level()
+                                            .map(|effort| effort.value.to_string()),
                                     });
                                 }
                             }

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1401,6 +1401,7 @@ impl AgentPanel {
                                 provider: LanguageModelProviderSetting(provider),
                                 model,
                                 enable_thinking: false,
+                                effort: None,
                             })
                     });
                 }

--- a/crates/agent_ui/src/buffer_codegen.rs
+++ b/crates/agent_ui/src/buffer_codegen.rs
@@ -544,6 +544,7 @@ impl CodegenAlternative {
                 temperature,
                 messages,
                 thinking_allowed: false,
+                thinking_effort: None,
             }
         }))
     }
@@ -622,6 +623,7 @@ impl CodegenAlternative {
                 temperature,
                 messages: vec![request_message],
                 thinking_allowed: false,
+                thinking_effort: None,
             }
         }))
     }

--- a/crates/agent_ui/src/favorite_models.rs
+++ b/crates/agent_ui/src/favorite_models.rs
@@ -10,6 +10,7 @@ fn language_model_to_selection(model: &Arc<dyn LanguageModel>) -> LanguageModelS
         provider: model.provider_id().to_string().into(),
         model: model.id().0.to_string(),
         enable_thinking: false,
+        effort: None,
     }
 }
 

--- a/crates/agent_ui/src/terminal_inline_assistant.rs
+++ b/crates/agent_ui/src/terminal_inline_assistant.rs
@@ -275,6 +275,7 @@ impl TerminalInlineAssistant {
                 stop: Vec::new(),
                 temperature,
                 thinking_allowed: false,
+                thinking_effort: None,
             }
         }))
     }

--- a/crates/agent_ui/src/text_thread_editor.rs
+++ b/crates/agent_ui/src/text_thread_editor.rs
@@ -319,13 +319,15 @@ impl TextThreadEditor {
                         move |model, cx| {
                             update_settings_file(fs.clone(), cx, move |settings, _| {
                                 let provider = model.provider_id().0.to_string();
-                                let enable_thinking = model.supports_thinking();
-                                let model = model.id().0.to_string();
+                                let model_id = model.id().0.to_string();
                                 settings.agent.get_or_insert_default().set_model(
                                     LanguageModelSelection {
                                         provider: LanguageModelProviderSetting(provider),
-                                        model,
-                                        enable_thinking,
+                                        model: model_id,
+                                        enable_thinking: model.supports_thinking(),
+                                        effort: model
+                                            .default_effort_level()
+                                            .map(|effort| effort.value.to_string()),
                                     },
                                 )
                             });

--- a/crates/anthropic/src/anthropic.rs
+++ b/crates/anthropic/src/anthropic.rs
@@ -961,8 +961,9 @@ pub enum Thinking {
     Adaptive,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, EnumString)]
 #[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
 pub enum Effort {
     Low,
     Medium,

--- a/crates/assistant_text_thread/src/text_thread.rs
+++ b/crates/assistant_text_thread/src/text_thread.rs
@@ -2269,6 +2269,7 @@ impl TextThread {
             stop: Vec::new(),
             temperature: model.and_then(|model| AgentSettings::temperature_for_model(model, cx)),
             thinking_allowed: true,
+            thinking_effort: None,
         };
         for message in self.messages(cx) {
             if message.status != MessageStatus::Done {

--- a/crates/cloud_llm_client/src/cloud_llm_client.rs
+++ b/crates/cloud_llm_client/src/cloud_llm_client.rs
@@ -309,6 +309,8 @@ pub struct LanguageModel {
 pub struct SupportedEffortLevel {
     pub name: Arc<str>,
     pub value: Arc<str>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub is_default: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/eval/src/instance.rs
+++ b/crates/eval/src/instance.rs
@@ -563,6 +563,7 @@ impl ExampleInstance {
                 tool_choice: None,
                 stop: Vec::new(),
                 thinking_allowed: true,
+                thinking_effort: None,
             };
 
             let model = model.clone();

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -2695,13 +2695,14 @@ impl GitPanel {
                         role: Role::User,
                         content: vec![content.into()],
                         cache: false,
-            reasoning_details: None,
+                        reasoning_details: None,
                     }],
                     tools: Vec::new(),
                     tool_choice: None,
                     stop: Vec::new(),
                     temperature,
                     thinking_allowed: false,
+                    thinking_effort: None,
                 };
 
                 let stream = model.stream_completion_text(request, cx);

--- a/crates/language_model/src/language_model.rs
+++ b/crates/language_model/src/language_model.rs
@@ -577,6 +577,7 @@ impl Default for LanguageModelTextStream {
 pub struct LanguageModelEffortLevel {
     pub name: SharedString,
     pub value: SharedString,
+    pub is_default: bool,
 }
 
 pub trait LanguageModel: Send + Sync {
@@ -605,6 +606,13 @@ pub trait LanguageModel: Send + Sync {
     /// Returns the list of supported effort levels that can be used when thinking.
     fn supported_effort_levels(&self) -> Vec<LanguageModelEffortLevel> {
         Vec::new()
+    }
+
+    /// Returns the default effort level to use when thinking.
+    fn default_effort_level(&self) -> Option<LanguageModelEffortLevel> {
+        self.supported_effort_levels()
+            .into_iter()
+            .find(|effort_level| effort_level.is_default)
     }
 
     /// Whether this model supports images

--- a/crates/language_model/src/request.rs
+++ b/crates/language_model/src/request.rs
@@ -451,6 +451,7 @@ pub struct LanguageModelRequest {
     pub stop: Vec<String>,
     pub temperature: Option<f32>,
     pub thinking_allowed: bool,
+    pub thinking_effort: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]

--- a/crates/language_models/src/provider/anthropic.rs
+++ b/crates/language_models/src/provider/anthropic.rs
@@ -1165,6 +1165,7 @@ mod tests {
             tools: vec![],
             tool_choice: None,
             thinking_allowed: true,
+            thinking_effort: None,
         };
 
         let anthropic_request = into_anthropic(

--- a/crates/language_models/src/provider/cloud.rs
+++ b/crates/language_models/src/provider/cloud.rs
@@ -584,6 +584,7 @@ impl LanguageModel for CloudLanguageModel {
             .map(|effort_level| LanguageModelEffortLevel {
                 name: effort_level.name.clone().into(),
                 value: effort_level.value.clone().into(),
+                is_default: effort_level.is_default.unwrap_or(false),
             })
             .collect()
     }

--- a/crates/language_models/src/provider/cloud.rs
+++ b/crates/language_models/src/provider/cloud.rs
@@ -34,6 +34,7 @@ pub use settings::ZedDotDevAvailableModel as AvailableModel;
 pub use settings::ZedDotDevAvailableProvider as AvailableProvider;
 use smol::io::{AsyncReadExt, BufReader};
 use std::pin::Pin;
+use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 use thiserror::Error;
@@ -746,10 +747,14 @@ impl LanguageModel for CloudLanguageModel {
         } else {
             thinking_allowed && self.model.id.0.ends_with("-thinking")
         };
+        let effort = request
+            .thinking_effort
+            .as_ref()
+            .and_then(|effort| anthropic::Effort::from_str(effort).ok());
         let provider_name = provider_name(&self.model.provider);
         match self.model.provider {
             cloud_llm_client::LanguageModelProvider::Anthropic => {
-                let request = into_anthropic(
+                let mut request = into_anthropic(
                     request,
                     self.model.id.to_string(),
                     1.0,
@@ -762,6 +767,12 @@ impl LanguageModel for CloudLanguageModel {
                         AnthropicModelMode::Default
                     },
                 );
+
+                if enable_thinking && effort.is_some() {
+                    request.thinking = Some(anthropic::Thinking::Adaptive);
+                    request.output_config = Some(anthropic::OutputConfig { effort });
+                }
+
                 let client = self.client.clone();
                 let llm_api_token = self.llm_api_token.clone();
                 let future = self.request_limiter.stream(async move {

--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -929,6 +929,7 @@ fn into_copilot_responses(
         stop: _,
         temperature,
         thinking_allowed: _,
+        thinking_effort: _,
     } = request;
 
     let mut input_items: Vec<responses::ResponseInputItem> = Vec::new();

--- a/crates/language_models/src/provider/mistral.rs
+++ b/crates/language_models/src/provider/mistral.rs
@@ -861,6 +861,7 @@ mod tests {
             intent: None,
             stop: vec![],
             thinking_allowed: true,
+            thinking_effort: None,
         };
 
         let mistral_request = into_mistral(request, mistral::Model::MistralSmallLatest, None);
@@ -894,6 +895,7 @@ mod tests {
             intent: None,
             stop: vec![],
             thinking_allowed: true,
+            thinking_effort: None,
         };
 
         let mistral_request = into_mistral(request, mistral::Model::Pixtral12BLatest, None);

--- a/crates/language_models/src/provider/open_ai.rs
+++ b/crates/language_models/src/provider/open_ai.rs
@@ -552,6 +552,7 @@ pub fn into_open_ai_response(
         stop: _,
         temperature,
         thinking_allowed: _,
+        thinking_effort: _,
     } = request;
 
     let mut input_items = Vec::new();
@@ -1434,6 +1435,7 @@ mod tests {
             stop: vec![],
             temperature: None,
             thinking_allowed: true,
+            thinking_effort: None,
         };
 
         // Validate that all models are supported by tiktoken-rs
@@ -1570,6 +1572,7 @@ mod tests {
             stop: vec!["<STOP>".into()],
             temperature: None,
             thinking_allowed: false,
+            thinking_effort: None,
         };
 
         let response = into_open_ai_response(

--- a/crates/rules_library/src/rules_library.rs
+++ b/crates/rules_library/src/rules_library.rs
@@ -1103,6 +1103,7 @@ impl RulesLibrary {
                                     stop: Vec::new(),
                                     temperature: None,
                                     thinking_allowed: true,
+                                    thinking_effort: None,
                                 },
                                 cx,
                             )

--- a/crates/settings_content/src/agent.rs
+++ b/crates/settings_content/src/agent.rs
@@ -152,6 +152,7 @@ impl AgentSettingsContent {
             provider: provider.into(),
             model,
             enable_thinking: false,
+            effort: None,
         });
     }
 
@@ -265,6 +266,7 @@ pub struct LanguageModelSelection {
     pub model: String,
     #[serde(default)]
     pub enable_thinking: bool,
+    pub effort: Option<String>,
 }
 
 #[with_fallible_options]


### PR DESCRIPTION
This PR adds the ability to set the thinking effort of a model.

Right now this only applies to Opus 4.6 through the Zed provider.

This is gated behind the `cloud-thinking-toggle` feature flag.

UI is still rough; needs a design pass:

<img width="639" height="163" alt="Screenshot 2026-02-05 at 7 45 54 PM" src="https://github.com/user-attachments/assets/2b5a9ef8-74cd-498e-9c81-b92666572409" />

<img width="263" height="148" alt="Screenshot 2026-02-05 at 7 45 58 PM" src="https://github.com/user-attachments/assets/40232cb0-1743-443b-b04c-5cd33065513d" />

Release Notes:

- N/A
