### PR TITLE
auto_update: Strip pre-release and build metadata from release notes URL

### DIFF
--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -260,7 +260,9 @@ pub fn release_notes_url(cx: &mut App) -> Option<String> {
         ReleaseChannel::Stable | ReleaseChannel::Preview => {
             let auto_updater = AutoUpdater::get(cx)?;
             let auto_updater = auto_updater.read(cx);
-            let current_version = &auto_updater.current_version;
+            let mut current_version = auto_updater.current_version.clone();
+            current_version.pre = semver::Prerelease::EMPTY;
+            current_version.build = semver::BuildMetadata::EMPTY;
             let release_channel = release_channel.dev_name();
             let path = format!("/releases/{release_channel}/{current_version}");
             auto_updater.client.http_client().build_url(&path)
@@ -754,8 +756,8 @@ impl AutoUpdater {
         fetched_version: Version,
     ) -> Result<Option<VersionCheckType>> {
         // For non-nightly releases, ignore build and pre-release fields as they're not provided by our endpoints right now.
-        installed_version.build = semver::BuildMetadata::EMPTY;
         installed_version.pre = semver::Prerelease::EMPTY;
+        installed_version.build = semver::BuildMetadata::EMPTY;
         let should_download = fetched_version > installed_version;
         let newer_version = should_download.then(|| VersionCheckType::Semantic(fetched_version));
         Ok(newer_version)
@@ -1462,5 +1464,27 @@ mod tests {
             newer_version.unwrap(),
             Some(VersionCheckType::Sha(AppCommitSha::new(fetched_sha)))
         );
+    }
+
+    #[gpui::test]
+    fn test_release_notes_url_strips_build_metadata(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            settings::init(cx);
+
+            let mut version = semver::Version::new(0, 218, 0);
+            version.pre = semver::Prerelease::new("beta.1").unwrap();
+            version.build = semver::BuildMetadata::new("preview.131.68e98a53").unwrap();
+            release_channel::init_test(version, ReleaseChannel::Preview, cx);
+
+            let clock = Arc::new(FakeSystemClock::new());
+            let fake_http_client = FakeHttpClient::create(|_| async {
+                Ok(Response::builder().status(404).body("".into()).unwrap())
+            });
+            let client = Client::new(clock, fake_http_client, cx);
+            crate::init(client, cx);
+        });
+
+        let url = cx.update(|cx| release_notes_url(cx).expect("should return URL"));
+        assert!(url.ends_with("/releases/preview/0.218.0"));
     }
 }

--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -1465,26 +1465,4 @@ mod tests {
             Some(VersionCheckType::Sha(AppCommitSha::new(fetched_sha)))
         );
     }
-
-    #[gpui::test]
-    fn test_release_notes_url_strips_build_metadata(cx: &mut TestAppContext) {
-        cx.update(|cx| {
-            settings::init(cx);
-
-            let mut version = semver::Version::new(0, 218, 0);
-            version.pre = semver::Prerelease::new("beta.1").unwrap();
-            version.build = semver::BuildMetadata::new("preview.131.68e98a53").unwrap();
-            release_channel::init_test(version, ReleaseChannel::Preview, cx);
-
-            let clock = Arc::new(FakeSystemClock::new());
-            let fake_http_client = FakeHttpClient::create(|_| async {
-                Ok(Response::builder().status(404).body("".into()).unwrap())
-            });
-            let client = Client::new(clock, fake_http_client, cx);
-            crate::init(client, cx);
-        });
-
-        let url = cx.update(|cx| release_notes_url(cx).expect("should return URL"));
-        assert!(url.ends_with("/releases/preview/0.218.0"));
-    }
 }

--- a/crates/auto_update_ui/src/auto_update_ui.rs
+++ b/crates/auto_update_ui/src/auto_update_ui.rs
@@ -270,8 +270,8 @@ pub fn notify_if_app_was_updated(cx: &mut App) {
         if should_show_notification {
             cx.update(|cx| {
                 let mut version = updater.read(cx).current_version();
-                version.build = semver::BuildMetadata::EMPTY;
                 version.pre = semver::Prerelease::EMPTY;
+                version.build = semver::BuildMetadata::EMPTY;
                 let app_name = ReleaseChannel::global(cx).display_name();
 
                 if let Some(content) = announcement_for_version(&version) {


### PR DESCRIPTION
  Without this fix, the zed.dev server doesn't recognize the version with metadata and redirects to /releases, which
  defaults to the Stable channel, so Preview users end up seeing Stable release notes.

Closes #47539

  Changes:
  - Strip pre and build metadata from the semver version in release_notes_url before constructing the path, so the URL
  becomes /releases/preview/0.218.0 instead of /releases/preview/0.218.0-beta.1+preview.131.68e98a53.
  - Standardized the ordering of pre/build clearing to pre-first across all 4 call sites (2 were build-first).



  Open question: With this fix, the URL now points to the specific version you're running (e.g.
  /releases/preview/0.218.0). An alternative would be to link to /releases/preview (no version) so users can see all
  Preview releases, including ones newer than what they have installed. I went with per-version linking since it matches
  the existing intent of the code, but happy to change it if the team prefers the other approach.

  Release Notes:

  - Fixed "View Release Notes" in Preview/Stable opening the wrong release channel page due to build metadata in the URL.

