### PR TITLE
SplittableEditor: Sync custom blocks between RHS and LHS editors

### DIFF
--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -81,8 +81,8 @@ mod wrap_map;
 pub use crate::display_map::{fold_map::FoldMap, inlay_map::InlayMap, tab_map::TabMap};
 pub use block_map::{
     Block, BlockChunks as DisplayChunks, BlockContext, BlockId, BlockMap, BlockPlacement,
-    BlockPoint, BlockProperties, BlockRows, BlockStyle, CompanionView, CustomBlockId,
-    EditorMargins, RenderBlock, StickyHeaderExcerpt,
+    BlockPoint, BlockProperties, BlockRows, BlockStyle, CompanionView, CompanionViewWithBlockMap,
+    CustomBlockId, EditorMargins, RenderBlock, StickyHeaderExcerpt,
 };
 pub use crease_map::*;
 pub use fold_map::{
@@ -693,52 +693,67 @@ impl DisplayMap {
         let (self_wrap_snapshot, self_wrap_edits) =
             (self_new_wrap_snapshot.clone(), self_new_wrap_edits.clone());
 
-        let mut block_map = {
-            let companion_ref = self.companion.as_ref().map(|(_, c)| c.read(cx));
-            let companion_view = companion_wrap_data.as_ref().zip(companion_ref).map(
-                |((snapshot, edits), companion)| {
-                    CompanionView::new(self.entity_id, snapshot, edits, companion)
-                },
-            );
-            self.block_map
-                .write(self_new_wrap_snapshot, self_new_wrap_edits, companion_view)
-        };
-        let blocks = creases.into_iter().filter_map(|crease| {
-            if let Crease::Block {
-                range,
-                block_height,
-                render_block,
-                block_style,
-                block_priority,
-                ..
-            } = crease
-            {
-                Some((
+        let blocks = creases
+            .into_iter()
+            .filter_map(|crease| {
+                if let Crease::Block {
                     range,
-                    render_block,
                     block_height,
+                    render_block,
                     block_style,
                     block_priority,
-                ))
-            } else {
-                None
-            }
-        });
-        block_map.insert(
-            blocks
-                .into_iter()
-                .map(|(range, render, height, style, priority)| {
-                    let start = buffer_snapshot.anchor_before(range.start);
-                    let end = buffer_snapshot.anchor_after(range.end);
-                    BlockProperties {
-                        placement: BlockPlacement::Replace(start..=end),
-                        render,
-                        height: Some(height),
-                        style,
-                        priority,
-                    }
-                }),
-        );
+                    ..
+                } = crease
+                {
+                    Some((
+                        range,
+                        render_block,
+                        block_height,
+                        block_style,
+                        block_priority,
+                    ))
+                } else {
+                    None
+                }
+            })
+            .map(|(range, render, height, style, priority)| {
+                let start = buffer_snapshot.anchor_before(range.start);
+                let end = buffer_snapshot.anchor_after(range.end);
+                BlockProperties {
+                    placement: BlockPlacement::Replace(start..=end),
+                    render,
+                    height: Some(height),
+                    style,
+                    priority,
+                }
+            });
+
+        if let Some((companion_dm, companion)) = self.companion.as_ref()
+            && let Some((snapshot, edits)) = companion_wrap_data.as_ref()
+        {
+            companion_dm
+                .update(cx, |dm, cx| {
+                    let companion_view = CompanionViewWithBlockMap::new(
+                        self.entity_id,
+                        snapshot,
+                        edits,
+                        companion.read(cx),
+                        &mut dm.block_map,
+                    );
+                    self.block_map
+                        .write(
+                            self_new_wrap_snapshot,
+                            self_new_wrap_edits,
+                            Some(companion_view),
+                        )
+                        .insert(blocks);
+                })
+                .ok();
+        } else {
+            self.block_map
+                .write(self_new_wrap_snapshot, self_new_wrap_edits, None)
+                .insert(blocks);
+        };
 
         if let Some((companion_dm, _)) = &self.companion {
             let _ = companion_dm.update(cx, |dm, cx| {
@@ -805,15 +820,28 @@ impl DisplayMap {
         let (self_wrap_snapshot, self_wrap_edits) =
             (self_new_wrap_snapshot.clone(), self_new_wrap_edits.clone());
 
+        if let Some((companion_dm, companion)) = self.companion.as_ref()
+            && let Some((snapshot, edits)) = companion_wrap_data.as_ref()
         {
-            let companion_ref = self.companion.as_ref().map(|(_, c)| c.read(cx));
-            let companion_view = companion_wrap_data.as_ref().zip(companion_ref).map(
-                |((snapshot, edits), companion)| {
-                    CompanionView::new(self.entity_id, snapshot, edits, companion)
-                },
-            );
+            companion_dm
+                .update(cx, |dm, cx| {
+                    let companion_view = CompanionViewWithBlockMap::new(
+                        self.entity_id,
+                        snapshot,
+                        edits,
+                        companion.read(cx),
+                        &mut dm.block_map,
+                    );
+                    self.block_map.write(
+                        self_new_wrap_snapshot,
+                        self_new_wrap_edits,
+                        Some(companion_view),
+                    );
+                })
+                .ok();
+        } else {
             self.block_map
-                .write(self_new_wrap_snapshot, self_new_wrap_edits, companion_view);
+                .write(self_new_wrap_snapshot, self_new_wrap_edits, None);
         }
 
         if let Some((companion_dm, _)) = &self.companion {
@@ -886,20 +914,32 @@ impl DisplayMap {
         let (self_wrap_snapshot, self_wrap_edits) =
             (self_new_wrap_snapshot.clone(), self_new_wrap_edits.clone());
 
-        let mut block_map = {
-            let companion_ref = self.companion.as_ref().map(|(_, c)| c.read(cx));
-            let companion_view = companion_wrap_data.as_ref().zip(companion_ref).map(
-                |((snapshot, edits), companion)| {
-                    CompanionView::new(self.entity_id, snapshot, edits, companion)
-                },
-            );
-            self.block_map.write(
-                self_new_wrap_snapshot.clone(),
-                self_new_wrap_edits,
-                companion_view,
-            )
-        };
-        block_map.remove_intersecting_replace_blocks(offset_ranges, inclusive);
+        if let Some((companion_dm, companion)) = self.companion.as_ref()
+            && let Some((snapshot, edits)) = companion_wrap_data.as_ref()
+        {
+            companion_dm
+                .update(cx, |dm, cx| {
+                    let companion_view = CompanionViewWithBlockMap::new(
+                        self.entity_id,
+                        snapshot,
+                        edits,
+                        companion.read(cx),
+                        &mut dm.block_map,
+                    );
+                    self.block_map
+                        .write(
+                            self_new_wrap_snapshot.clone(),
+                            self_new_wrap_edits,
+                            Some(companion_view),
+                        )
+                        .remove_intersecting_replace_blocks(offset_ranges, inclusive);
+                })
+                .ok();
+        } else {
+            self.block_map
+                .write(self_new_wrap_snapshot.clone(), self_new_wrap_edits, None)
+                .remove_intersecting_replace_blocks(offset_ranges, inclusive);
+        }
 
         if let Some((companion_dm, _)) = &self.companion {
             let _ = companion_dm.update(cx, |dm, cx| {
@@ -934,19 +974,32 @@ impl DisplayMap {
                 .ok()
         });
 
-        let companion_ref = self.companion.as_ref().map(|(_, c)| c.read(cx));
-        let companion_view = companion_wrap_data.as_ref().zip(companion_ref).map(
-            |((snapshot, edits), companion)| {
-                CompanionView::new(self.entity_id, snapshot, edits, companion)
-            },
-        );
-
-        let mut block_map = self.block_map.write(
-            self_wrap_snapshot.clone(),
-            self_wrap_edits.clone(),
-            companion_view,
-        );
-        block_map.disable_header_for_buffer(buffer_id);
+        if let Some((companion_dm, companion)) = self.companion.as_ref()
+            && let Some((snapshot, edits)) = companion_wrap_data.as_ref()
+        {
+            companion_dm
+                .update(cx, |dm, cx| {
+                    let companion_view = CompanionViewWithBlockMap::new(
+                        self.entity_id,
+                        snapshot,
+                        edits,
+                        companion.read(cx),
+                        &mut dm.block_map,
+                    );
+                    self.block_map
+                        .write(
+                            self_wrap_snapshot.clone(),
+                            self_wrap_edits.clone(),
+                            Some(companion_view),
+                        )
+                        .disable_header_for_buffer(buffer_id);
+                })
+                .ok();
+        } else {
+            self.block_map
+                .write(self_wrap_snapshot.clone(), self_wrap_edits.clone(), None)
+                .disable_header_for_buffer(buffer_id);
+        }
 
         if let Some((companion_dm, _)) = &self.companion {
             let _ = companion_dm.update(cx, |dm, cx| {
@@ -1000,19 +1053,32 @@ impl DisplayMap {
                 .ok()
         });
 
-        let companion_ref = self.companion.as_ref().map(|(_, c)| c.read(cx));
-        let companion_view = companion_wrap_data.as_ref().zip(companion_ref).map(
-            |((snapshot, edits), companion)| {
-                CompanionView::new(self.entity_id, snapshot, edits, companion)
-            },
-        );
-
-        let mut block_map = self.block_map.write(
-            self_wrap_snapshot.clone(),
-            self_wrap_edits.clone(),
-            companion_view,
-        );
-        block_map.fold_buffers(buffer_ids.iter().copied(), self.buffer.read(cx), cx);
+        if let Some((companion_dm, companion)) = self.companion.as_ref()
+            && let Some((snapshot, edits)) = companion_wrap_data.as_ref()
+        {
+            companion_dm
+                .update(cx, |dm, cx| {
+                    let companion_view = CompanionViewWithBlockMap::new(
+                        self.entity_id,
+                        snapshot,
+                        edits,
+                        companion.read(cx),
+                        &mut dm.block_map,
+                    );
+                    self.block_map
+                        .write(
+                            self_wrap_snapshot.clone(),
+                            self_wrap_edits.clone(),
+                            Some(companion_view),
+                        )
+                        .fold_buffers(buffer_ids.iter().copied(), self.buffer.read(cx), cx);
+                })
+                .ok();
+        } else {
+            self.block_map
+                .write(self_wrap_snapshot.clone(), self_wrap_edits.clone(), None)
+                .fold_buffers(buffer_ids.iter().copied(), self.buffer.read(cx), cx);
+        }
 
         if let Some((companion_dm, companion_entity)) = &self.companion {
             let buffer_mapping = companion_entity
@@ -1025,19 +1091,18 @@ impl DisplayMap {
 
             let _ = companion_dm.update(cx, |dm, cx| {
                 if let Some((companion_snapshot, companion_edits)) = companion_wrap_data {
-                    let their_companion_ref = dm.companion.as_ref().map(|(_, c)| c.read(cx));
-                    let mut block_map = dm.block_map.write(
-                        companion_snapshot,
-                        companion_edits,
-                        their_companion_ref.map(|c| {
-                            CompanionView::new(
-                                dm.entity_id,
-                                &self_wrap_snapshot,
-                                &self_wrap_edits,
-                                c,
-                            )
-                        }),
-                    );
+                    let companion_view = dm.companion.as_ref().map(|(_, their_companion)| {
+                        CompanionViewWithBlockMap::new(
+                            dm.entity_id,
+                            &self_wrap_snapshot,
+                            &self_wrap_edits,
+                            their_companion.read(cx),
+                            &mut self.block_map,
+                        )
+                    });
+                    let mut block_map =
+                        dm.block_map
+                            .write(companion_snapshot, companion_edits, companion_view);
                     if !their_buffer_ids.is_empty() {
                         block_map.fold_buffers(their_buffer_ids, dm.buffer.read(cx), cx);
                     }
@@ -1078,19 +1143,32 @@ impl DisplayMap {
                 .ok()
         });
 
-        let companion_ref = self.companion.as_ref().map(|(_, c)| c.read(cx));
-        let companion_view = companion_wrap_data.as_ref().zip(companion_ref).map(
-            |((snapshot, edits), companion)| {
-                CompanionView::new(self.entity_id, snapshot, edits, companion)
-            },
-        );
-
-        let mut block_map = self.block_map.write(
-            self_wrap_snapshot.clone(),
-            self_wrap_edits.clone(),
-            companion_view,
-        );
-        block_map.unfold_buffers(buffer_ids.iter().copied(), self.buffer.read(cx), cx);
+        if let Some((companion_dm, companion)) = self.companion.as_ref()
+            && let Some((snapshot, edits)) = companion_wrap_data.as_ref()
+        {
+            companion_dm
+                .update(cx, |dm, cx| {
+                    let companion_view = CompanionViewWithBlockMap::new(
+                        self.entity_id,
+                        snapshot,
+                        edits,
+                        companion.read(cx),
+                        &mut dm.block_map,
+                    );
+                    self.block_map
+                        .write(
+                            self_wrap_snapshot.clone(),
+                            self_wrap_edits.clone(),
+                            Some(companion_view),
+                        )
+                        .unfold_buffers(buffer_ids.iter().copied(), self.buffer.read(cx), cx);
+                })
+                .ok();
+        } else {
+            self.block_map
+                .write(self_wrap_snapshot.clone(), self_wrap_edits.clone(), None)
+                .unfold_buffers(buffer_ids.iter().copied(), self.buffer.read(cx), cx);
+        }
 
         if let Some((companion_dm, companion_entity)) = &self.companion {
             let buffer_mapping = companion_entity
@@ -1103,19 +1181,18 @@ impl DisplayMap {
 
             let _ = companion_dm.update(cx, |dm, cx| {
                 if let Some((companion_snapshot, companion_edits)) = companion_wrap_data {
-                    let their_companion_ref = dm.companion.as_ref().map(|(_, c)| c.read(cx));
-                    let mut block_map = dm.block_map.write(
-                        companion_snapshot,
-                        companion_edits,
-                        their_companion_ref.map(|c| {
-                            CompanionView::new(
-                                dm.entity_id,
-                                &self_wrap_snapshot,
-                                &self_wrap_edits,
-                                c,
-                            )
-                        }),
-                    );
+                    let companion_view = dm.companion.as_ref().map(|(_, their_companion)| {
+                        CompanionViewWithBlockMap::new(
+                            dm.entity_id,
+                            &self_wrap_snapshot,
+                            &self_wrap_edits,
+                            their_companion.read(cx),
+                            &mut self.block_map,
+                        )
+                    });
+                    let mut block_map =
+                        dm.block_map
+                            .write(companion_snapshot, companion_edits, companion_view);
                     if !their_buffer_ids.is_empty() {
                         block_map.unfold_buffers(their_buffer_ids, dm.buffer.read(cx), cx);
                     }
@@ -1168,19 +1245,33 @@ impl DisplayMap {
                 .ok()
         });
 
-        let companion_ref = self.companion.as_ref().map(|(_, c)| c.read(cx));
-        let companion_view = companion_wrap_data.as_ref().zip(companion_ref).map(
-            |((snapshot, edits), companion)| {
-                CompanionView::new(self.entity_id, snapshot, edits, companion)
-            },
-        );
-
-        let mut block_map = self.block_map.write(
-            self_wrap_snapshot.clone(),
-            self_wrap_edits.clone(),
-            companion_view,
-        );
-        let result = block_map.insert(blocks);
+        let result = if let Some((companion_dm, companion)) = self.companion.as_ref()
+            && let Some((snapshot, edits)) = companion_wrap_data.as_ref()
+        {
+            companion_dm
+                .update(cx, |dm, cx| {
+                    let companion_view = CompanionViewWithBlockMap::new(
+                        self.entity_id,
+                        snapshot,
+                        edits,
+                        companion.read(cx),
+                        &mut dm.block_map,
+                    );
+                    self.block_map
+                        .write(
+                            self_wrap_snapshot.clone(),
+                            self_wrap_edits.clone(),
+                            Some(companion_view),
+                        )
+                        .insert(blocks)
+                })
+                .ok()
+                .expect("success inserting blocks with companion")
+        } else {
+            self.block_map
+                .write(self_wrap_snapshot.clone(), self_wrap_edits.clone(), None)
+                .insert(blocks)
+        };
 
         if let Some((companion_dm, _)) = &self.companion {
             let _ = companion_dm.update(cx, |dm, cx| {
@@ -1215,19 +1306,32 @@ impl DisplayMap {
                 .ok()
         });
 
-        let companion_ref = self.companion.as_ref().map(|(_, c)| c.read(cx));
-        let companion_view = companion_wrap_data.as_ref().zip(companion_ref).map(
-            |((snapshot, edits), companion)| {
-                CompanionView::new(self.entity_id, snapshot, edits, companion)
-            },
-        );
-
-        let mut block_map = self.block_map.write(
-            self_wrap_snapshot.clone(),
-            self_wrap_edits.clone(),
-            companion_view,
-        );
-        block_map.resize(heights);
+        if let Some((companion_dm, companion)) = self.companion.as_ref()
+            && let Some((snapshot, edits)) = companion_wrap_data.as_ref()
+        {
+            companion_dm
+                .update(cx, |dm, cx| {
+                    let companion_view = CompanionViewWithBlockMap::new(
+                        self.entity_id,
+                        snapshot,
+                        edits,
+                        companion.read(cx),
+                        &mut dm.block_map,
+                    );
+                    self.block_map
+                        .write(
+                            self_wrap_snapshot.clone(),
+                            self_wrap_edits.clone(),
+                            Some(companion_view),
+                        )
+                        .resize(heights);
+                })
+                .ok();
+        } else {
+            self.block_map
+                .write(self_wrap_snapshot.clone(), self_wrap_edits.clone(), None)
+                .resize(heights);
+        }
 
         if let Some((companion_dm, _)) = &self.companion {
             let _ = companion_dm.update(cx, |dm, cx| {
@@ -1265,19 +1369,32 @@ impl DisplayMap {
                 .ok()
         });
 
-        let companion_ref = self.companion.as_ref().map(|(_, c)| c.read(cx));
-        let companion_view = companion_wrap_data.as_ref().zip(companion_ref).map(
-            |((snapshot, edits), companion)| {
-                CompanionView::new(self.entity_id, snapshot, edits, companion)
-            },
-        );
-
-        let mut block_map = self.block_map.write(
-            self_wrap_snapshot.clone(),
-            self_wrap_edits.clone(),
-            companion_view,
-        );
-        block_map.remove(ids);
+        if let Some((companion_dm, companion)) = self.companion.as_ref()
+            && let Some((snapshot, edits)) = companion_wrap_data.as_ref()
+        {
+            companion_dm
+                .update(cx, |dm, cx| {
+                    let companion_view = CompanionViewWithBlockMap::new(
+                        self.entity_id,
+                        snapshot,
+                        edits,
+                        companion.read(cx),
+                        &mut dm.block_map,
+                    );
+                    self.block_map
+                        .write(
+                            self_wrap_snapshot.clone(),
+                            self_wrap_edits.clone(),
+                            Some(companion_view),
+                        )
+                        .remove(ids);
+                })
+                .ok();
+        } else {
+            self.block_map
+                .write(self_wrap_snapshot.clone(), self_wrap_edits.clone(), None)
+                .remove(ids);
+        }
 
         if let Some((companion_dm, _)) = &self.companion {
             let _ = companion_dm.update(cx, |dm, cx| {

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -535,7 +535,7 @@ impl DisplayMap {
                     // Sync existing custom blocks to the companion
                     if self.entity_id != companion.read(cx).rhs_display_map_id {
                         use gpui::{
-                            Element, InteractiveElement, Styled, div, pattern_slash, rgba,
+                            Element, InteractiveElement, Styled, div, pattern_slash, white,
                         };
                         let buffer_snapshot = snapshot.buffer_snapshot();
                         let their_custom_blocks: Vec<_> = dm
@@ -551,18 +551,12 @@ impl DisplayMap {
                                 their_anchor.to_point(companion_snapshot.buffer_snapshot());
                             let my_point = companion
                                 .read(cx)
-                                .convert_rows_from_companion(
+                                .convert_point_from_companion(
                                     self.entity_id,
                                     buffer_snapshot,
                                     companion_snapshot.buffer_snapshot(),
-                                    (Bound::Included(their_point), Bound::Included(their_point)),
+                                    their_point,
                                 )
-                                .first()
-                                .unwrap()
-                                .boundaries
-                                .first()
-                                .unwrap()
-                                .1
                                 .start;
                             let anchor = buffer_snapshot.anchor_before(my_point);
                             let height = block.height.unwrap_or(1);
@@ -575,7 +569,8 @@ impl DisplayMap {
                                         .id(cx.block_id)
                                         .w_full()
                                         .h(Pixels::from(cx.line_height * cx.height as f32))
-                                        .bg(pattern_slash(rgba(0xFFFFFF10), 8.0, 8.0))
+                                        .bg(pattern_slash(white(), 8.0, 8.0))
+                                        // .bg(pattern_slash(cx.theme().colors().panel_background, 8.0, 8.0))
                                         .into_any()
                                 }),
                                 priority: 0,

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -535,7 +535,7 @@ impl DisplayMap {
                     // Sync existing custom blocks to the companion
                     if self.entity_id != companion.read(cx).rhs_display_map_id {
                         use gpui::{
-                            Element, InteractiveElement, Styled, div, pattern_slash, white,
+                            Element, InteractiveElement, Styled, div, pattern_slash, rgba,
                         };
                         let buffer_snapshot = snapshot.buffer_snapshot();
                         let their_custom_blocks: Vec<_> = dm
@@ -573,9 +573,9 @@ impl DisplayMap {
                                 render: Arc::new(move |cx| {
                                     div()
                                         .id(cx.block_id)
-                                        .size_full()
+                                        .w_full()
                                         .h(Pixels::from(cx.line_height * cx.height as f32))
-                                        .bg(pattern_slash(white(), 8.0, 8.0))
+                                        .bg(pattern_slash(rgba(0xFFFFFF10), 8.0, 8.0))
                                         .into_any()
                                 }),
                                 priority: 0,

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -581,7 +581,7 @@ impl DisplayMap {
                                 priority: 0,
                             };
                             log::debug!(
-                                "Creating a matching companion block: {block:#?} => {new_block:#?}"
+                                "Inserting matching companion custom block: {block:#?} => {new_block:#?}"
                             );
                             new_block
                         });
@@ -595,11 +595,6 @@ impl DisplayMap {
                             .zip(their_custom_blocks.into_iter())
                         {
                             companion.update(cx, |companion, _| {
-                                log::debug!(
-                                    "self.entity_id != companion.rhs_display_map_id : {:?} != {:?}",
-                                    self.entity_id,
-                                    companion.rhs_display_map_id
-                                );
                                 companion.add_custom_block_mapping(
                                     their_custom_block.id,
                                     my_custom_block,

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -230,7 +230,7 @@ pub struct DisplayMap {
 // test change
 
 pub(crate) struct Companion {
-    pub(crate) rhs_display_map_id: EntityId,
+    rhs_display_map_id: EntityId,
     rhs_folded_buffers: HashSet<BufferId>,
     rhs_buffer_to_lhs_buffer: HashMap<BufferId, BufferId>,
     lhs_buffer_to_rhs_buffer: HashMap<BufferId, BufferId>,
@@ -238,8 +238,8 @@ pub(crate) struct Companion {
     lhs_excerpt_to_rhs_excerpt: HashMap<ExcerptId, ExcerptId>,
     rhs_rows_to_lhs_rows: ConvertMultiBufferRows,
     lhs_rows_to_rhs_rows: ConvertMultiBufferRows,
-    pub(crate) rhs_custom_blocks_to_lhs_custom_blocks: HashMap<CustomBlockId, CustomBlockId>,
-    pub(crate) lhs_custom_blocks_to_rhs_custom_blocks: HashMap<CustomBlockId, CustomBlockId>,
+    rhs_custom_blocks_to_lhs_custom_blocks: HashMap<CustomBlockId, CustomBlockId>,
+    lhs_custom_blocks_to_rhs_custom_blocks: HashMap<CustomBlockId, CustomBlockId>,
 }
 
 impl Companion {

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -492,10 +492,62 @@ impl DisplayMap {
         self.block_map
             .read(snapshot.clone(), edits.clone(), companion_view);
 
-        if let Some((companion_dm, _)) = &self.companion {
-            let _ = companion_dm.update(cx, |dm, _cx| {
+        if let Some((companion_dm, companion)) = &self.companion {
+            let _ = companion_dm.update(cx, |dm, cx| {
                 if let Some((companion_snapshot, companion_edits)) = companion_wrap_data {
-                    let their_companion_ref = dm.companion.as_ref().map(|(_, c)| c.read(_cx));
+                    let companion_ref = companion.read(cx);
+                    let their_companion_ref = dm.companion.as_ref().map(|(_, c)| c.read(cx));
+
+                    if self.entity_id != companion_ref.rhs_display_map_id {
+                        use gpui::{Element, InteractiveElement, Styled, div, pattern_slash, white};
+                        // Sync existing custom blocks to the companion
+                        let buffer_snapshot = snapshot.buffer_snapshot();
+                        let new_custom_blocks = dm.block_map.read(companion_snapshot.clone(), Patch::default(), None)
+                            .blocks
+                            .iter()
+                            .map(|block| {
+                                let their_anchor = block.placement.start();
+                                let their_point =
+                                    their_anchor.to_point(companion_snapshot.buffer_snapshot());
+                                let my_point = companion_ref
+                                    .convert_rows_from_companion(
+                                        self.entity_id,
+                                        buffer_snapshot,
+                                        companion_snapshot.buffer_snapshot(),
+                                        (
+                                            Bound::Included(their_point),
+                                            Bound::Included(their_point),
+                                        ),
+                                    )
+                                    .first()
+                                    .unwrap()
+                                    .boundaries
+                                    .first()
+                                    .unwrap()
+                                    .1
+                                    .start;
+                                let anchor = buffer_snapshot.anchor_before(my_point);
+                                let height = block.height.unwrap_or(1);
+                                let new_block = BlockProperties {
+                                    placement: BlockPlacement::Above(anchor),
+                                    height: Some(height),
+                                    style: BlockStyle::Sticky,
+                                    render: Arc::new(move |cx| {
+                                        div()
+                                            .id(cx.block_id)
+                                            .size_full()
+                                            .h(Pixels::from(cx.line_height * height as f32))
+                                            .bg(pattern_slash(white(), 8.0, 8.0))
+                                            .into_any()
+                                    }),
+                                    priority: 0,
+                                };
+                                log::debug!("Creating a matching companion block: {block:#?} => {new_block:#?}");
+                                new_block
+                            });
+                        self.block_map.write(snapshot.clone(), Patch::default(), None).insert(new_custom_blocks);
+                    }
+
                     dm.block_map.read(
                         companion_snapshot,
                         companion_edits,

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -574,7 +574,7 @@ impl DisplayMap {
                                     div()
                                         .id(cx.block_id)
                                         .size_full()
-                                        .h(Pixels::from(cx.line_height * height as f32))
+                                        .h(Pixels::from(cx.line_height * cx.height as f32))
                                         .bg(pattern_slash(white(), 8.0, 8.0))
                                         .into_any()
                                 }),

--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -1470,7 +1470,6 @@ impl BlockMap {
         companion_snapshot: &MultiBufferSnapshot,
         companion: &mut Companion,
     ) {
-        use gpui::{Element, InteractiveElement, Styled, div, pattern_slash, white};
         let their_anchor = block.placement.start();
         let their_point = their_anchor.to_point(companion_snapshot);
         let my_patches = companion.convert_rows_to_companion(
@@ -1489,17 +1488,13 @@ impl BlockMap {
             height: Some(height),
             style: BlockStyle::Sticky,
             render: Arc::new(move |cx| {
-                div()
-                    .id(cx.block_id)
-                    .w_full()
-                    .h(Pixels::from(cx.line_height * cx.height as f32))
-                    .bg(pattern_slash(white(), 8.0, 8.0))
-                    // .bg(pattern_slash(
-                    //     cx.theme().colors().panel_background,
-                    //     8.0,
-                    //     8.0,
-                    // ))
-                    .into_any()
+                crate::EditorElement::render_spacer_block(
+                    cx.block_id,
+                    cx.height,
+                    cx.line_height,
+                    cx.window,
+                    cx.app,
+                )
             }),
             priority: 0,
         };

--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -1643,7 +1643,7 @@ impl BlockMapWriter<'_> {
                 ..
             }) = self.companion.as_deref_mut()
             {
-                use gpui::{Element, InteractiveElement, Styled, div, pattern_slash, white};
+                use gpui::{Element, InteractiveElement, Styled, div, pattern_slash, rgba};
                 let my_anchor = block.placement.start();
                 let my_point = my_anchor.to_point(buffer);
                 let their_point = companion
@@ -1669,9 +1669,9 @@ impl BlockMapWriter<'_> {
                     render: Arc::new(move |cx| {
                         div()
                             .id(cx.block_id)
-                            .size_full()
+                            .w_full()
                             .h(Pixels::from(cx.line_height * cx.height as f32))
-                            .bg(pattern_slash(white(), 8.0, 8.0))
+                            .bg(pattern_slash(rgba(0xFFFFFF10), 8.0, 8.0))
                             .into_any()
                     }),
                     priority: 0,

--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -288,6 +288,7 @@ pub struct BlockContext<'a, 'b> {
     pub em_width: Pixels,
     pub line_height: Pixels,
     pub block_id: BlockId,
+    pub height: u32,
     pub selected: bool,
     pub editor_style: &'b EditorStyle,
 }
@@ -1669,7 +1670,7 @@ impl BlockMapWriter<'_> {
                         div()
                             .id(cx.block_id)
                             .size_full()
-                            .h(Pixels::from(cx.line_height * height as f32))
+                            .h(Pixels::from(cx.line_height * cx.height as f32))
                             .bg(pattern_slash(white(), 8.0, 8.0))
                             .into_any()
                     }),

--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -1478,7 +1478,9 @@ impl BlockMap {
             companion_snapshot,
             (Bound::Included(their_point), Bound::Included(their_point)),
         );
-        let my_excerpt = my_patches.first().unwrap();
+        let my_excerpt = my_patches
+            .first()
+            .expect("at least one companion excerpt exists");
         let my_range = my_excerpt.patch.edit_for_old_position(their_point).new;
         let my_point = my_range.start;
         let anchor = snapshot.buffer_snapshot().anchor_before(my_point);

--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -1643,23 +1643,18 @@ impl BlockMapWriter<'_> {
                 ..
             }) = self.companion.as_deref_mut()
             {
-                use gpui::{Element, InteractiveElement, Styled, div, pattern_slash, rgba};
+                use gpui::{Element, InteractiveElement, Styled, div, pattern_slash, white};
                 let my_anchor = block.placement.start();
                 let my_point = my_anchor.to_point(buffer);
-                let their_point = companion
-                    .convert_rows_to_companion(
-                        *their_entity_id,
-                        their_snapshot.buffer_snapshot(),
-                        buffer,
-                        (Bound::Included(my_point), Bound::Included(my_point)),
-                    )
-                    .first()
-                    .unwrap()
-                    .boundaries
-                    .first()
-                    .unwrap()
-                    .1
-                    .start;
+                let their_patches = companion.convert_rows_to_companion(
+                    *their_entity_id,
+                    their_snapshot.buffer_snapshot(),
+                    buffer,
+                    (Bound::Included(my_point), Bound::Included(my_point)),
+                );
+                let their_excerpt = their_patches.first().unwrap();
+                let their_range = their_excerpt.patch.edit_for_old_position(my_point).new;
+                let their_point = their_range.start;
                 let anchor = their_snapshot.buffer_snapshot().anchor_before(their_point);
                 let height = new_block.height.unwrap_or(1);
                 let their_new_block = BlockProperties {
@@ -1671,7 +1666,12 @@ impl BlockMapWriter<'_> {
                             .id(cx.block_id)
                             .w_full()
                             .h(Pixels::from(cx.line_height * cx.height as f32))
-                            .bg(pattern_slash(rgba(0xFFFFFF10), 8.0, 8.0))
+                            .bg(pattern_slash(white(), 8.0, 8.0))
+                            // .bg(pattern_slash(
+                            //     cx.theme().colors().panel_background,
+                            //     8.0,
+                            //     8.0,
+                            // ))
                             .into_any()
                     }),
                     priority: 0,

--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -48,7 +48,7 @@ pub struct BlockMap {
 }
 
 pub struct BlockMapReader<'a> {
-    blocks: &'a Vec<Arc<CustomBlock>>,
+    pub blocks: &'a Vec<Arc<CustomBlock>>,
     pub snapshot: BlockSnapshot,
 }
 

--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -1681,14 +1681,11 @@ impl BlockMapWriter<'_> {
                 let their_new_block_id = their_block_map
                     .write(their_snapshot.clone(), Patch::default(), None)
                     .insert([their_new_block])[0];
-                log::debug!(
-                    "their_entity_id != companion.rhs_display_map_id : {their_entity_id:?} != {:?}",
-                    companion.rhs_display_map_id
-                );
-                let (lhs_id, rhs_id) = (*their_entity_id == companion.rhs_display_map_id)
-                    .then_some((id, their_new_block_id))
-                    .unwrap_or((their_new_block_id, id));
-                companion.add_custom_block_mapping(lhs_id, rhs_id);
+                if *their_entity_id == companion.rhs_display_map_id {
+                    companion.add_custom_block_mapping(id, their_new_block_id)
+                } else {
+                    companion.add_custom_block_mapping(their_new_block_id, id)
+                }
             }
 
             edits = edits.compose([Edit {
@@ -1842,15 +1839,16 @@ impl BlockMapWriter<'_> {
                     let their_block_id = companion
                         .companion_custom_block_to_custom_block(*their_entity_id)
                         .get(my_block_id)?;
-                    log::debug!("{their_entity_id:?}: Remove theirs {their_block_id:?} for mine {my_block_id:?}");
+                    log::debug!("Removing custom block in the companion with id {their_block_id:?} for mine {my_block_id:?}");
                     Some(*their_block_id)
                 })
                 .collect();
             for (lhs_id, rhs_id) in their_block_ids.iter().zip(block_ids.iter()) {
-                let (lhs_id, rhs_id) = (*their_entity_id == companion.rhs_display_map_id)
-                    .then_some((lhs_id, rhs_id))
-                    .unwrap_or((rhs_id, lhs_id));
-                companion.remove_custom_block_mapping(lhs_id, rhs_id);
+                if *their_entity_id == companion.rhs_display_map_id {
+                    companion.remove_custom_block_mapping(lhs_id, rhs_id)
+                } else {
+                    companion.remove_custom_block_mapping(rhs_id, lhs_id)
+                }
             }
             their_block_map
                 .write(their_snapshot.clone(), Patch::default(), None)

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -3914,6 +3914,7 @@ impl EditorElement {
                         line_height,
                         em_width,
                         block_id,
+                        height: custom.height.unwrap_or(1),
                         selected,
                         max_width: text_hitbox.size.width.max(*scroll_width),
                         editor_style: &self.style,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -4005,26 +4005,9 @@ impl EditorElement {
                 result.into_any()
             }
 
-            Block::Spacer { height, .. } => div()
-                .id(block_id)
-                .w_full()
-                .h((*height as f32) * line_height)
-                // the checkerboard pattern is semi-transparent, so we render a
-                // solid background to prevent indent guides peeking through
-                .bg(cx.theme().colors().editor_background)
-                .child(
-                    div()
-                        .size_full()
-                        .bg(checkerboard(cx.theme().colors().panel_background, {
-                            let target_size = 16.0;
-                            let scale = window.scale_factor();
-                            Self::checkerboard_size(
-                                f32::from(line_height) * scale,
-                                target_size * scale,
-                            )
-                        })),
-                )
-                .into_any(),
+            Block::Spacer { height, .. } => {
+                Self::render_spacer_block(block_id, *height, line_height, window, cx)
+            }
         };
 
         // Discover the element's content height, then round up to the nearest multiple of line height.
@@ -4101,6 +4084,32 @@ impl EditorElement {
         } else {
             size_ceil
         }
+    }
+
+    pub fn render_spacer_block(
+        block_id: BlockId,
+        block_height: u32,
+        line_height: Pixels,
+        window: &mut Window,
+        cx: &App,
+    ) -> AnyElement {
+        div()
+            .id(block_id)
+            .w_full()
+            .h((block_height as f32) * line_height)
+            // the checkerboard pattern is semi-transparent, so we render a
+            // solid background to prevent indent guides peeking through
+            .bg(cx.theme().colors().editor_background)
+            .child(
+                div()
+                    .size_full()
+                    .bg(checkerboard(cx.theme().colors().panel_background, {
+                        let target_size = 16.0;
+                        let scale = window.scale_factor();
+                        Self::checkerboard_size(f32::from(line_height) * scale, target_size * scale)
+                    })),
+            )
+            .into_any()
     }
 
     fn render_buffer_header(

--- a/crates/editor/src/split.rs
+++ b/crates/editor/src/split.rs
@@ -1942,6 +1942,7 @@ mod tests {
 
     use crate::SplittableEditor;
     use crate::display_map::{BlockPlacement, BlockProperties, BlockStyle};
+    use crate::split::{SplitDiff, UnsplitDiff};
     use crate::test::{editor_content_with_blocks_and_width, set_block_content_for_tests};
 
     async fn init_test(
@@ -3999,6 +4000,558 @@ mod tests {
             bbb
             ccc"
             .unindent(),
+            &mut cx,
+        );
+    }
+
+    #[gpui::test]
+    async fn test_custom_block_deletion_and_resplit_sync(cx: &mut gpui::TestAppContext) {
+        use rope::Point;
+        use unindent::Unindent as _;
+
+        let (editor, mut cx) = init_test(cx, SoftWrap::None).await;
+
+        let base_text = "
+            bbb
+            ccc
+        "
+        .unindent();
+        let current_text = "
+            aaa
+            bbb
+            ccc
+        "
+        .unindent();
+
+        let (buffer, diff) = buffer_with_diff(&base_text, &current_text, &mut cx);
+
+        editor.update(cx, |editor, cx| {
+            let path = PathKey::for_buffer(&buffer, cx);
+            editor.set_excerpts_for_path(
+                path,
+                buffer.clone(),
+                vec![Point::new(0, 0)..buffer.read(cx).max_point()],
+                0,
+                diff.clone(),
+                cx,
+            );
+        });
+
+        cx.run_until_parked();
+
+        assert_split_content(
+            &editor,
+            "
+            § <no file>
+            § -----
+            aaa
+            bbb
+            ccc"
+            .unindent(),
+            "
+            § <no file>
+            § -----
+            § spacer
+            bbb
+            ccc"
+            .unindent(),
+            &mut cx,
+        );
+
+        let block_ids = editor.update(cx, |splittable_editor, cx| {
+            splittable_editor.rhs_editor.update(cx, |rhs_editor, cx| {
+                let snapshot = rhs_editor.buffer().read(cx).snapshot(cx);
+                let anchor1 = snapshot.anchor_before(Point::new(2, 0));
+                let anchor2 = snapshot.anchor_before(Point::new(3, 0));
+                rhs_editor.insert_blocks(
+                    [
+                        BlockProperties {
+                            placement: BlockPlacement::Above(anchor1),
+                            height: Some(1),
+                            style: BlockStyle::Fixed,
+                            render: Arc::new(|_| div().into_any()),
+                            priority: 0,
+                        },
+                        BlockProperties {
+                            placement: BlockPlacement::Above(anchor2),
+                            height: Some(1),
+                            style: BlockStyle::Fixed,
+                            render: Arc::new(|_| div().into_any()),
+                            priority: 0,
+                        },
+                    ],
+                    None,
+                    cx,
+                )
+            })
+        });
+
+        let rhs_editor = editor.read_with(cx, |editor, _| editor.rhs_editor.clone());
+        let lhs_editor =
+            editor.read_with(cx, |editor, _| editor.lhs.as_ref().unwrap().editor.clone());
+
+        cx.update(|_, cx| {
+            set_block_content_for_tests(&rhs_editor, block_ids[0], cx, |_| {
+                "custom block 1".to_string()
+            });
+            set_block_content_for_tests(&rhs_editor, block_ids[1], cx, |_| {
+                "custom block 2".to_string()
+            });
+        });
+
+        let (lhs_block_id_1, lhs_block_id_2) = lhs_editor.read_with(cx, |lhs_editor, cx| {
+            let display_map = lhs_editor.display_map.read(cx);
+            let companion = display_map.companion().unwrap().read(cx);
+            let mapping = companion.companion_custom_block_to_custom_block(
+                rhs_editor.read(cx).display_map.entity_id(),
+            );
+            (
+                *mapping.get(&block_ids[0]).unwrap(),
+                *mapping.get(&block_ids[1]).unwrap(),
+            )
+        });
+
+        cx.update(|_, cx| {
+            set_block_content_for_tests(&lhs_editor, lhs_block_id_1, cx, |_| {
+                "custom block 1".to_string()
+            });
+            set_block_content_for_tests(&lhs_editor, lhs_block_id_2, cx, |_| {
+                "custom block 2".to_string()
+            });
+        });
+
+        cx.run_until_parked();
+
+        assert_split_content(
+            &editor,
+            "
+            § <no file>
+            § -----
+            aaa
+            bbb
+            § custom block 1
+            ccc
+            § custom block 2"
+                .unindent(),
+            "
+            § <no file>
+            § -----
+            § spacer
+            bbb
+            § custom block 1
+            ccc
+            § custom block 2"
+                .unindent(),
+            &mut cx,
+        );
+
+        editor.update(cx, |splittable_editor, cx| {
+            splittable_editor.rhs_editor.update(cx, |rhs_editor, cx| {
+                rhs_editor.remove_blocks(HashSet::from_iter([block_ids[0]]), None, cx);
+            });
+        });
+
+        cx.run_until_parked();
+
+        assert_split_content(
+            &editor,
+            "
+            § <no file>
+            § -----
+            aaa
+            bbb
+            ccc
+            § custom block 2"
+                .unindent(),
+            "
+            § <no file>
+            § -----
+            § spacer
+            bbb
+            ccc
+            § custom block 2"
+                .unindent(),
+            &mut cx,
+        );
+
+        editor.update_in(cx, |splittable_editor, window, cx| {
+            splittable_editor.unsplit(&UnsplitDiff, window, cx);
+        });
+
+        cx.run_until_parked();
+
+        editor.update_in(cx, |splittable_editor, window, cx| {
+            splittable_editor.split(&SplitDiff, window, cx);
+        });
+
+        cx.run_until_parked();
+
+        let lhs_editor =
+            editor.read_with(cx, |editor, _| editor.lhs.as_ref().unwrap().editor.clone());
+
+        let lhs_block_id_2 = lhs_editor.read_with(cx, |lhs_editor, cx| {
+            let display_map = lhs_editor.display_map.read(cx);
+            let companion = display_map.companion().unwrap().read(cx);
+            let mapping = companion.companion_custom_block_to_custom_block(
+                rhs_editor.read(cx).display_map.entity_id(),
+            );
+            *mapping.get(&block_ids[1]).unwrap()
+        });
+
+        cx.update(|_, cx| {
+            set_block_content_for_tests(&lhs_editor, lhs_block_id_2, cx, |_| {
+                "custom block 2".to_string()
+            });
+        });
+
+        cx.run_until_parked();
+
+        assert_split_content(
+            &editor,
+            "
+            § <no file>
+            § -----
+            aaa
+            bbb
+            ccc
+            § custom block 2"
+                .unindent(),
+            "
+            § <no file>
+            § -----
+            § spacer
+            bbb
+            ccc
+            § custom block 2"
+                .unindent(),
+            &mut cx,
+        );
+    }
+
+    #[gpui::test]
+    async fn test_custom_block_sync_with_unsplit_start(cx: &mut gpui::TestAppContext) {
+        use rope::Point;
+        use unindent::Unindent as _;
+
+        let (editor, mut cx) = init_test(cx, SoftWrap::None).await;
+
+        let base_text = "
+            bbb
+            ccc
+        "
+        .unindent();
+        let current_text = "
+            aaa
+            bbb
+            ccc
+        "
+        .unindent();
+
+        let (buffer, diff) = buffer_with_diff(&base_text, &current_text, &mut cx);
+
+        editor.update(cx, |editor, cx| {
+            let path = PathKey::for_buffer(&buffer, cx);
+            editor.set_excerpts_for_path(
+                path,
+                buffer.clone(),
+                vec![Point::new(0, 0)..buffer.read(cx).max_point()],
+                0,
+                diff.clone(),
+                cx,
+            );
+        });
+
+        cx.run_until_parked();
+
+        editor.update_in(cx, |splittable_editor, window, cx| {
+            splittable_editor.unsplit(&UnsplitDiff, window, cx);
+        });
+
+        cx.run_until_parked();
+
+        let rhs_editor = editor.read_with(cx, |editor, _| editor.rhs_editor.clone());
+
+        let block_ids = editor.update(cx, |splittable_editor, cx| {
+            splittable_editor.rhs_editor.update(cx, |rhs_editor, cx| {
+                let snapshot = rhs_editor.buffer().read(cx).snapshot(cx);
+                let anchor1 = snapshot.anchor_before(Point::new(2, 0));
+                let anchor2 = snapshot.anchor_before(Point::new(3, 0));
+                rhs_editor.insert_blocks(
+                    [
+                        BlockProperties {
+                            placement: BlockPlacement::Above(anchor1),
+                            height: Some(1),
+                            style: BlockStyle::Fixed,
+                            render: Arc::new(|_| div().into_any()),
+                            priority: 0,
+                        },
+                        BlockProperties {
+                            placement: BlockPlacement::Above(anchor2),
+                            height: Some(1),
+                            style: BlockStyle::Fixed,
+                            render: Arc::new(|_| div().into_any()),
+                            priority: 0,
+                        },
+                    ],
+                    None,
+                    cx,
+                )
+            })
+        });
+
+        cx.update(|_, cx| {
+            set_block_content_for_tests(&rhs_editor, block_ids[0], cx, |_| {
+                "custom block 1".to_string()
+            });
+            set_block_content_for_tests(&rhs_editor, block_ids[1], cx, |_| {
+                "custom block 2".to_string()
+            });
+        });
+
+        cx.run_until_parked();
+
+        let rhs_content = editor_content_with_blocks_and_width(&rhs_editor, px(3000.0), &mut cx);
+        assert_eq!(
+            rhs_content,
+            "
+            § <no file>
+            § -----
+            aaa
+            bbb
+            § custom block 1
+            ccc
+            § custom block 2"
+                .unindent(),
+            "rhs content before split"
+        );
+
+        editor.update_in(cx, |splittable_editor, window, cx| {
+            splittable_editor.split(&SplitDiff, window, cx);
+        });
+
+        cx.run_until_parked();
+
+        let lhs_editor =
+            editor.read_with(cx, |editor, _| editor.lhs.as_ref().unwrap().editor.clone());
+
+        let (lhs_block_id_1, lhs_block_id_2) = lhs_editor.read_with(cx, |lhs_editor, cx| {
+            let display_map = lhs_editor.display_map.read(cx);
+            let companion = display_map.companion().unwrap().read(cx);
+            let mapping = companion.companion_custom_block_to_custom_block(
+                rhs_editor.read(cx).display_map.entity_id(),
+            );
+            (
+                *mapping.get(&block_ids[0]).unwrap(),
+                *mapping.get(&block_ids[1]).unwrap(),
+            )
+        });
+
+        cx.update(|_, cx| {
+            set_block_content_for_tests(&lhs_editor, lhs_block_id_1, cx, |_| {
+                "custom block 1".to_string()
+            });
+            set_block_content_for_tests(&lhs_editor, lhs_block_id_2, cx, |_| {
+                "custom block 2".to_string()
+            });
+        });
+
+        cx.run_until_parked();
+
+        assert_split_content(
+            &editor,
+            "
+            § <no file>
+            § -----
+            aaa
+            bbb
+            § custom block 1
+            ccc
+            § custom block 2"
+                .unindent(),
+            "
+            § <no file>
+            § -----
+            § spacer
+            bbb
+            § custom block 1
+            ccc
+            § custom block 2"
+                .unindent(),
+            &mut cx,
+        );
+
+        editor.update(cx, |splittable_editor, cx| {
+            splittable_editor.rhs_editor.update(cx, |rhs_editor, cx| {
+                rhs_editor.remove_blocks(HashSet::from_iter([block_ids[0]]), None, cx);
+            });
+        });
+
+        cx.run_until_parked();
+
+        assert_split_content(
+            &editor,
+            "
+            § <no file>
+            § -----
+            aaa
+            bbb
+            ccc
+            § custom block 2"
+                .unindent(),
+            "
+            § <no file>
+            § -----
+            § spacer
+            bbb
+            ccc
+            § custom block 2"
+                .unindent(),
+            &mut cx,
+        );
+
+        editor.update_in(cx, |splittable_editor, window, cx| {
+            splittable_editor.unsplit(&UnsplitDiff, window, cx);
+        });
+
+        cx.run_until_parked();
+
+        editor.update_in(cx, |splittable_editor, window, cx| {
+            splittable_editor.split(&SplitDiff, window, cx);
+        });
+
+        cx.run_until_parked();
+
+        let lhs_editor =
+            editor.read_with(cx, |editor, _| editor.lhs.as_ref().unwrap().editor.clone());
+
+        let lhs_block_id_2 = lhs_editor.read_with(cx, |lhs_editor, cx| {
+            let display_map = lhs_editor.display_map.read(cx);
+            let companion = display_map.companion().unwrap().read(cx);
+            let mapping = companion.companion_custom_block_to_custom_block(
+                rhs_editor.read(cx).display_map.entity_id(),
+            );
+            *mapping.get(&block_ids[1]).unwrap()
+        });
+
+        cx.update(|_, cx| {
+            set_block_content_for_tests(&lhs_editor, lhs_block_id_2, cx, |_| {
+                "custom block 2".to_string()
+            });
+        });
+
+        cx.run_until_parked();
+
+        assert_split_content(
+            &editor,
+            "
+            § <no file>
+            § -----
+            aaa
+            bbb
+            ccc
+            § custom block 2"
+                .unindent(),
+            "
+            § <no file>
+            § -----
+            § spacer
+            bbb
+            ccc
+            § custom block 2"
+                .unindent(),
+            &mut cx,
+        );
+
+        let new_block_ids = editor.update(cx, |splittable_editor, cx| {
+            splittable_editor.rhs_editor.update(cx, |rhs_editor, cx| {
+                let snapshot = rhs_editor.buffer().read(cx).snapshot(cx);
+                let anchor = snapshot.anchor_before(Point::new(2, 0));
+                rhs_editor.insert_blocks(
+                    [BlockProperties {
+                        placement: BlockPlacement::Above(anchor),
+                        height: Some(1),
+                        style: BlockStyle::Fixed,
+                        render: Arc::new(|_| div().into_any()),
+                        priority: 0,
+                    }],
+                    None,
+                    cx,
+                )
+            })
+        });
+
+        cx.update(|_, cx| {
+            set_block_content_for_tests(&rhs_editor, new_block_ids[0], cx, |_| {
+                "custom block 3".to_string()
+            });
+        });
+
+        let lhs_block_id_3 = lhs_editor.read_with(cx, |lhs_editor, cx| {
+            let display_map = lhs_editor.display_map.read(cx);
+            let companion = display_map.companion().unwrap().read(cx);
+            let mapping = companion.companion_custom_block_to_custom_block(
+                rhs_editor.read(cx).display_map.entity_id(),
+            );
+            *mapping.get(&new_block_ids[0]).unwrap()
+        });
+
+        cx.update(|_, cx| {
+            set_block_content_for_tests(&lhs_editor, lhs_block_id_3, cx, |_| {
+                "custom block 3".to_string()
+            });
+        });
+
+        cx.run_until_parked();
+
+        assert_split_content(
+            &editor,
+            "
+            § <no file>
+            § -----
+            aaa
+            bbb
+            § custom block 3
+            ccc
+            § custom block 2"
+                .unindent(),
+            "
+            § <no file>
+            § -----
+            § spacer
+            bbb
+            § custom block 3
+            ccc
+            § custom block 2"
+                .unindent(),
+            &mut cx,
+        );
+
+        editor.update(cx, |splittable_editor, cx| {
+            splittable_editor.rhs_editor.update(cx, |rhs_editor, cx| {
+                rhs_editor.remove_blocks(HashSet::from_iter([new_block_ids[0]]), None, cx);
+            });
+        });
+
+        cx.run_until_parked();
+
+        assert_split_content(
+            &editor,
+            "
+            § <no file>
+            § -----
+            aaa
+            bbb
+            ccc
+            § custom block 2"
+                .unindent(),
+            "
+            § <no file>
+            § -----
+            § spacer
+            bbb
+            ccc
+            § custom block 2"
+                .unindent(),
             &mut cx,
         );
     }


### PR DESCRIPTION
This fixes alignment issues in split view in presence of merge conflicts.

* current nightly
<img width="2280" height="1269" alt="Screenshot From 2026-02-06 10-34-30" src="https://github.com/user-attachments/assets/cdc269cf-e358-45d1-818d-ed690b0a4d68" />

* this patch
<img width="2262" height="1432" alt="Screenshot From 2026-02-06 10-38-21" src="https://github.com/user-attachments/assets/2d0b36af-face-488b-ba38-9b55fb7d0be0" />

Release Notes:

- Added handling of custom blocks in the RHS editor by creating matching dummy custom blocks rendered as spacer blocks in the LHS editor when in split view.
