### PR TITLE
Add reduce motion accessibility setting

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -190,6 +190,16 @@
   //
   // Default: "client"
   "window_decorations": "client",
+  // Whether to reduce motion in UI animations.
+  // 1. Follow the OS accessibility setting
+  //    "system"
+  // 2. Always reduce motion (skip animations)
+  //    "on"
+  // 3. Never reduce motion (always animate)
+  //    "off"
+  //
+  // Default: "system"
+  "reduce_motion": "system",
   // Whether to use the system provided dialogs for Open and Save As.
   // When set to false, Zed will use the built-in keyboard-first pickers.
   "use_system_path_prompts": true,

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -1271,6 +1271,11 @@ impl App {
         self.platform.should_auto_hide_scrollbars()
     }
 
+    /// Returns whether the platform's accessibility settings request reduced motion.
+    pub fn should_reduce_motion(&self) -> bool {
+        self.platform.should_reduce_motion()
+    }
+
     /// Restarts the application.
     pub fn restart(&mut self) {
         self.restart_observers

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -272,6 +272,9 @@ pub(crate) trait Platform: 'static {
 
     fn set_cursor_style(&self, style: CursorStyle);
     fn should_auto_hide_scrollbars(&self) -> bool;
+    fn should_reduce_motion(&self) -> bool {
+        false
+    }
 
     fn read_from_clipboard(&self) -> Option<ClipboardItem>;
     fn write_to_clipboard(&self, item: ClipboardItem);

--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -1031,6 +1031,14 @@ impl Platform for MacPlatform {
         }
     }
 
+    fn should_reduce_motion(&self) -> bool {
+        unsafe {
+            let workspace: id = msg_send![class!(NSWorkspace), sharedWorkspace];
+            let reduce: BOOL = msg_send![workspace, accessibilityDisplayShouldReduceMotion];
+            reduce != NO
+        }
+    }
+
     fn read_from_clipboard(&self) -> Option<ClipboardItem> {
         let state = self.0.lock();
         state.general_pasteboard.read()

--- a/crates/settings/src/reduce_motion_setting.rs
+++ b/crates/settings/src/reduce_motion_setting.rs
@@ -1,0 +1,242 @@
+use crate::{self as settings, settings_content::ReduceMotion};
+use settings::{RegisterSetting, Settings};
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default, RegisterSetting)]
+pub struct ReduceMotionSetting(pub ReduceMotion);
+
+impl ReduceMotionSetting {
+    pub fn should_reduce_motion(&self, cx: &gpui::App) -> bool {
+        match self.0 {
+            ReduceMotion::System => cx.should_reduce_motion(),
+            ReduceMotion::On => true,
+            ReduceMotion::Off => false,
+        }
+    }
+}
+
+pub fn should_reduce_motion(cx: &gpui::App) -> bool {
+    ReduceMotionSetting::get_global(cx).should_reduce_motion(cx)
+}
+
+impl Settings for ReduceMotionSetting {
+    fn from_settings(settings: &crate::settings_content::SettingsContent) -> Self {
+        ReduceMotionSetting(settings.workspace.reduce_motion.unwrap_or_default())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{SettingsStore, default_settings};
+    use gpui::{App, TestAppContext, UpdateGlobal};
+    use settings_content::ReduceMotion;
+
+    fn init_test(cx: &mut TestAppContext) {
+        let store = cx.update(|cx| SettingsStore::test(cx));
+        cx.update(|cx| cx.set_global(store));
+    }
+
+    fn set_reduce_motion(cx: &mut TestAppContext, value: ReduceMotion) {
+        cx.update(|cx| {
+            SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    settings.workspace.reduce_motion = Some(value);
+                });
+            });
+        });
+    }
+
+    #[test]
+    fn test_reduce_motion_default_is_system() {
+        assert_eq!(ReduceMotion::default(), ReduceMotion::System);
+    }
+
+    #[test]
+    fn test_reduce_motion_deserialize_string_variants() {
+        assert_eq!(
+            serde_json::from_str::<ReduceMotion>(r#""system""#).unwrap(),
+            ReduceMotion::System,
+        );
+        assert_eq!(
+            serde_json::from_str::<ReduceMotion>(r#""on""#).unwrap(),
+            ReduceMotion::On,
+        );
+        assert_eq!(
+            serde_json::from_str::<ReduceMotion>(r#""off""#).unwrap(),
+            ReduceMotion::Off,
+        );
+    }
+
+    #[test]
+    fn test_reduce_motion_deserialize_string_aliases() {
+        // serde(alias = "true") matches the JSON string "true", not the boolean true
+        assert_eq!(
+            serde_json::from_str::<ReduceMotion>(r#""true""#).unwrap(),
+            ReduceMotion::On,
+        );
+        assert_eq!(
+            serde_json::from_str::<ReduceMotion>(r#""false""#).unwrap(),
+            ReduceMotion::Off,
+        );
+    }
+
+    #[test]
+    fn test_reduce_motion_deserialize_rejects_invalid_values() {
+        assert!(serde_json::from_str::<ReduceMotion>("true").is_err());
+        assert!(serde_json::from_str::<ReduceMotion>("false").is_err());
+        assert!(serde_json::from_str::<ReduceMotion>(r#""bogus""#).is_err());
+        assert!(serde_json::from_str::<ReduceMotion>("42").is_err());
+        assert!(serde_json::from_str::<ReduceMotion>("null").is_err());
+    }
+
+    #[test]
+    fn test_reduce_motion_serialize_round_trip() {
+        for variant in [ReduceMotion::System, ReduceMotion::On, ReduceMotion::Off] {
+            let json = serde_json::to_string(&variant).unwrap();
+            let deserialized: ReduceMotion = serde_json::from_str(&json).unwrap();
+            assert_eq!(variant, deserialized);
+        }
+    }
+
+    #[gpui::test]
+    fn test_should_reduce_motion_on_returns_true(cx: &mut TestAppContext) {
+        init_test(cx);
+        cx.update(|cx| {
+            assert!(ReduceMotionSetting(ReduceMotion::On).should_reduce_motion(cx));
+        });
+    }
+
+    #[gpui::test]
+    fn test_should_reduce_motion_off_returns_false(cx: &mut TestAppContext) {
+        init_test(cx);
+        cx.update(|cx| {
+            assert!(!ReduceMotionSetting(ReduceMotion::Off).should_reduce_motion(cx));
+        });
+    }
+
+    #[gpui::test]
+    fn test_should_reduce_motion_system_delegates_to_platform(cx: &mut TestAppContext) {
+        init_test(cx);
+        cx.update(|cx| {
+            let platform_value = cx.should_reduce_motion();
+            let setting_value =
+                ReduceMotionSetting(ReduceMotion::System).should_reduce_motion(cx);
+            assert_eq!(setting_value, platform_value);
+        });
+    }
+
+    #[gpui::test]
+    fn test_from_settings_defaults_to_system(cx: &mut TestAppContext) {
+        init_test(cx);
+        cx.update(|cx| {
+            assert_eq!(ReduceMotionSetting::get_global(cx).0, ReduceMotion::System);
+        });
+    }
+
+    #[gpui::test]
+    fn test_from_settings_with_each_variant(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        for variant in [ReduceMotion::On, ReduceMotion::Off, ReduceMotion::System] {
+            set_reduce_motion(cx, variant);
+            cx.update(|cx| {
+                assert_eq!(ReduceMotionSetting::get_global(cx).0, variant);
+            });
+        }
+    }
+
+    #[gpui::test]
+    fn test_global_should_reduce_motion(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        cx.update(|cx| assert!(!should_reduce_motion(cx)));
+
+        set_reduce_motion(cx, ReduceMotion::On);
+        cx.update(|cx| assert!(should_reduce_motion(cx)));
+
+        set_reduce_motion(cx, ReduceMotion::Off);
+        cx.update(|cx| assert!(!should_reduce_motion(cx)));
+
+        set_reduce_motion(cx, ReduceMotion::System);
+        cx.update(|cx| assert!(!should_reduce_motion(cx)));
+    }
+
+    #[gpui::test]
+    fn test_settings_store_parses_reduce_motion_from_json(cx: &mut App) {
+        let mut store = SettingsStore::new(cx, &default_settings());
+        store.register_setting::<ReduceMotionSetting>();
+
+        store
+            .set_user_settings(r#"{ "reduce_motion": "on" }"#, cx)
+            .unwrap();
+        assert_eq!(
+            store.get::<ReduceMotionSetting>(None).0,
+            ReduceMotion::On,
+        );
+
+        store
+            .set_user_settings(r#"{ "reduce_motion": "off" }"#, cx)
+            .unwrap();
+        assert_eq!(
+            store.get::<ReduceMotionSetting>(None).0,
+            ReduceMotion::Off,
+        );
+
+        store
+            .set_user_settings(r#"{ "reduce_motion": "system" }"#, cx)
+            .unwrap();
+        assert_eq!(
+            store.get::<ReduceMotionSetting>(None).0,
+            ReduceMotion::System,
+        );
+    }
+
+    #[gpui::test]
+    fn test_settings_store_parses_string_aliases_from_json(cx: &mut App) {
+        let mut store = SettingsStore::new(cx, &default_settings());
+        store.register_setting::<ReduceMotionSetting>();
+
+        store
+            .set_user_settings(r#"{ "reduce_motion": "true" }"#, cx)
+            .unwrap();
+        assert_eq!(
+            store.get::<ReduceMotionSetting>(None).0,
+            ReduceMotion::On,
+        );
+
+        store
+            .set_user_settings(r#"{ "reduce_motion": "false" }"#, cx)
+            .unwrap();
+        assert_eq!(
+            store.get::<ReduceMotionSetting>(None).0,
+            ReduceMotion::Off,
+        );
+    }
+
+    #[gpui::test]
+    fn test_settings_store_defaults_when_reduce_motion_absent(cx: &mut App) {
+        let mut store = SettingsStore::new(cx, &default_settings());
+        store.register_setting::<ReduceMotionSetting>();
+
+        store.set_user_settings(r#"{}"#, cx).unwrap();
+        assert_eq!(
+            store.get::<ReduceMotionSetting>(None).0,
+            ReduceMotion::System,
+        );
+    }
+
+    #[gpui::test]
+    fn test_settings_store_assign_json_before_register(cx: &mut App) {
+        let mut store = SettingsStore::new(cx, &default_settings());
+
+        store
+            .set_user_settings(r#"{ "reduce_motion": "on" }"#, cx)
+            .unwrap();
+        store.register_setting::<ReduceMotionSetting>();
+
+        assert_eq!(
+            store.get::<ReduceMotionSetting>(None).0,
+            ReduceMotion::On,
+        );
+    }
+}

--- a/crates/settings/src/reduce_motion_setting.rs
+++ b/crates/settings/src/reduce_motion_setting.rs
@@ -20,7 +20,7 @@ pub fn should_reduce_motion(cx: &gpui::App) -> bool {
 
 impl Settings for ReduceMotionSetting {
     fn from_settings(settings: &crate::settings_content::SettingsContent) -> Self {
-        ReduceMotionSetting(settings.workspace.reduce_motion.unwrap_or_default())
+        ReduceMotionSetting(settings.workspace.reduce_motion.unwrap())
     }
 }
 

--- a/crates/settings/src/reduce_motion_setting.rs
+++ b/crates/settings/src/reduce_motion_setting.rs
@@ -2,9 +2,13 @@ use crate::{self as settings, settings_content::ReduceMotion};
 use settings::{RegisterSetting, Settings};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default, RegisterSetting)]
-pub struct ReduceMotionSetting(pub ReduceMotion);
+pub struct ReduceMotionSetting(ReduceMotion);
 
 impl ReduceMotionSetting {
+    pub fn value(&self) -> ReduceMotion {
+        self.0
+    }
+
     pub fn should_reduce_motion(&self, cx: &gpui::App) -> bool {
         match self.0 {
             ReduceMotion::System => cx.should_reduce_motion(),
@@ -109,7 +113,7 @@ mod tests {
         for variant in [ReduceMotion::On, ReduceMotion::Off, ReduceMotion::System] {
             set_reduce_motion(cx, variant);
             cx.update(|cx| {
-                assert_eq!(ReduceMotionSetting::get_global(cx).0, variant);
+                assert_eq!(ReduceMotionSetting::get_global(cx).value(), variant);
             });
         }
     }
@@ -146,7 +150,7 @@ mod tests {
 
         for (json, expected) in cases {
             store.set_user_settings(json, cx).unwrap();
-            assert_eq!(store.get::<ReduceMotionSetting>(None).0, *expected, "for JSON: {json}");
+            assert_eq!(store.get::<ReduceMotionSetting>(None).value(), *expected, "for JSON: {json}");
         }
     }
 
@@ -160,7 +164,7 @@ mod tests {
         store.register_setting::<ReduceMotionSetting>();
 
         assert_eq!(
-            store.get::<ReduceMotionSetting>(None).0,
+            store.get::<ReduceMotionSetting>(None).value(),
             ReduceMotion::On,
         );
     }

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -3,6 +3,7 @@ mod content_into_gpui;
 mod editable_setting_control;
 mod editorconfig_store;
 mod keymap_file;
+mod reduce_motion_setting;
 mod settings_file;
 mod settings_store;
 mod vscode_import;
@@ -34,6 +35,7 @@ pub use ::settings_content::*;
 pub use base_keymap_setting::*;
 pub use content_into_gpui::IntoGpui;
 pub use editable_setting_control::*;
+pub use reduce_motion_setting::*;
 pub use editorconfig_store::{
     Editorconfig, EditorconfigEvent, EditorconfigProperties, EditorconfigStore,
 };

--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -35,7 +35,6 @@ pub use ::settings_content::*;
 pub use base_keymap_setting::*;
 pub use content_into_gpui::IntoGpui;
 pub use editable_setting_control::*;
-pub use reduce_motion_setting::*;
 pub use editorconfig_store::{
     Editorconfig, EditorconfigEvent, EditorconfigProperties, EditorconfigStore,
 };
@@ -43,6 +42,7 @@ pub use keymap_file::{
     KeyBindingValidator, KeyBindingValidatorRegistration, KeybindSource, KeybindUpdateOperation,
     KeybindUpdateTarget, KeymapFile, KeymapFileLoadResult,
 };
+pub use reduce_motion_setting::*;
 pub use settings_file::*;
 pub use settings_json::*;
 pub use settings_store::{

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -983,6 +983,7 @@ impl VsCodeSettings {
                     CloseWindowWhenNoItems::KeepWindowOpen
                 }
             }),
+            reduce_motion: None,
             zoomed_padding: None,
         }
     }

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -116,6 +116,13 @@ pub struct WorkspaceSettingsContent {
     /// What draws window decorations/titlebar, the client application (Zed) or display server
     /// Default: client
     pub window_decorations: Option<WindowDecorations>,
+    /// Whether to reduce motion in UI animations.
+    /// When set to "system", follows the OS accessibility setting.
+    /// When set to "on", animations are always reduced.
+    /// When set to "off", animations always play.
+    ///
+    /// Default: system
+    pub reduce_motion: Option<ReduceMotion>,
 }
 
 #[with_fallible_options]
@@ -334,6 +341,33 @@ pub enum WindowDecorations {
     Client,
     /// Show system's window titlebar (server-side decoration; not supported by GNOME Wayland)
     Server,
+}
+
+#[derive(
+    Copy,
+    Clone,
+    Default,
+    Debug,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    JsonSchema,
+    MergeFrom,
+    strum::VariantArray,
+    strum::VariantNames,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum ReduceMotion {
+    /// Follow the OS accessibility setting for reduced motion
+    #[default]
+    System,
+    /// Always reduce motion (skip animations)
+    #[serde(alias = "true")]
+    On,
+    /// Never reduce motion (always animate)
+    #[serde(alias = "false")]
+    Off,
 }
 
 #[derive(

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -1047,6 +1047,27 @@ fn appearance_page() -> SettingsPage {
         ]
     }
 
+    fn reduce_motion_section() -> [SettingsPageItem; 2] {
+        [
+            SettingsPageItem::SectionHeader("Motion"),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Reduce Motion",
+                description: "Controls whether animations are reduced. When set to System, follows your OS accessibility preference.",
+                field: Box::new(SettingField {
+                    json_path: Some("reduce_motion"),
+                    pick: |settings_content| {
+                        settings_content.workspace.reduce_motion.as_ref()
+                    },
+                    write: |settings_content, value| {
+                        settings_content.workspace.reduce_motion = value;
+                    },
+                }),
+                metadata: None,
+                files: USER,
+            }),
+        ]
+    }
+
     fn cursor_section() -> [SettingsPageItem; 5] {
         [
             SettingsPageItem::SectionHeader("Cursor"),
@@ -1243,6 +1264,7 @@ fn appearance_page() -> SettingsPage {
         ui_font_section(),
         agent_panel_font_section(),
         text_rendering_section(),
+        reduce_motion_section(),
         cursor_section(),
         highlighting_section(),
         guides_section(),

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -1052,7 +1052,7 @@ fn appearance_page() -> SettingsPage {
             SettingsPageItem::SectionHeader("Motion"),
             SettingsPageItem::SettingItem(SettingItem {
                 title: "Reduce Motion",
-                description: "Controls whether animations are reduced. When set to System, follows your OS accessibility preference.",
+                description: "Reduce or disable animations. System uses your OS preference.",
                 field: Box::new(SettingField {
                     json_path: Some("reduce_motion"),
                     pick: |settings_content| {

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -1052,7 +1052,7 @@ fn appearance_page() -> SettingsPage {
             SettingsPageItem::SectionHeader("Motion"),
             SettingsPageItem::SettingItem(SettingItem {
                 title: "Reduce Motion",
-                description: "Reduce or disable animations. System uses your OS preference.",
+                description: "Reduce UI animations. System follows your macOS preference.",
                 field: Box::new(SettingField {
                     json_path: Some("reduce_motion"),
                     pick: |settings_content| {

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -535,6 +535,7 @@ fn init_renderers(cx: &mut App) {
         .add_basic_renderer::<settings::EditPredictionsMode>(render_dropdown)
         .add_basic_renderer::<settings::RelativeLineNumbers>(render_dropdown)
         .add_basic_renderer::<settings::WindowDecorations>(render_dropdown)
+        .add_basic_renderer::<settings::ReduceMotion>(render_dropdown)
         .add_basic_renderer::<settings::FontSize>(render_editable_number_field)
         .add_basic_renderer::<settings::OllamaModelName>(render_ollama_model_picker)
         .add_basic_renderer::<settings::SemanticTokens>(render_dropdown)


### PR DESCRIPTION
Follows up on #48295, scoped down per feedback to ship one primitive at a time.

## Summary

- Adds a `reduce_motion` setting (`"system"` | `"on"` | `"off"`, default: `"system"`)
- Queries macOS `accessibilityDisplayShouldReduceMotion` when set to `"system"`
- Applies the setting to toast slide-in animations as a first consumer
- Adds the setting to the Appearance page in Settings UI

## Next steps

- [ ] Add platform support for Linux (`gtk-enable-animations` / portal) and Windows (`SPI_GETCLIENTAREAANIMATION`)
- [ ] Gate more animation call sites (`with_animation` is used in ~15 other places: cursor blink, edit predictions, agent panel, spinners, etc.)
- [ ] Consider lifting the check into the `animate_in` trait itself so all callers get it for free

## Test plan

- [x] Unit tests for serialization, round-trip, aliases, and settings store integration
- [x] GPUI tests for `should_reduce_motion` with each variant
- [ ] Manual: set `"reduce_motion": "on"` and verify toast appears without animation
- [ ] Manual: set `"reduce_motion": "system"` and toggle macOS System Settings > Accessibility > Display > Reduce motion