### PR TITLE
feature_flags: Rename `cloud-thinking-toggle` feature flag

### DIFF
--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -21,7 +21,7 @@ use editor::{
     Editor, EditorEvent, EditorMode, MultiBuffer, PathKey, SelectionEffects, SizingBehavior,
 };
 use feature_flags::{
-    AgentSharingFeatureFlag, AgentV2FeatureFlag, CloudThinkingToggleFeatureFlag,
+    AgentSharingFeatureFlag, AgentV2FeatureFlag, CloudThinkingEffortFeatureFlag,
     FeatureFlagAppExt as _,
 };
 use file_icons::FileIcons;

--- a/crates/agent_ui/src/acp/thread_view/active_thread.rs
+++ b/crates/agent_ui/src/acp/thread_view/active_thread.rs
@@ -2696,7 +2696,7 @@ impl AcpThreadView {
     }
 
     fn render_thinking_control(&self, cx: &mut Context<Self>) -> Option<AnyElement> {
-        if !cx.has_flag::<CloudThinkingToggleFeatureFlag>() {
+        if !cx.has_flag::<CloudThinkingEffortFeatureFlag>() {
             return None;
         }
 

--- a/crates/feature_flags/src/flags.rs
+++ b/crates/feature_flags/src/flags.rs
@@ -60,11 +60,12 @@ impl FeatureFlag for DiffReviewFeatureFlag {
     }
 }
 
-/// Controls whether we show the new thinking toggle in the Agent Panel when using models through the Zed provider (Cloud).
-pub struct CloudThinkingToggleFeatureFlag;
+/// Controls whether we show the new thinking and effort level controls in the Agent Panel when using applicable models
+/// through the Zed provider (Cloud).
+pub struct CloudThinkingEffortFeatureFlag;
 
-impl FeatureFlag for CloudThinkingToggleFeatureFlag {
-    const NAME: &'static str = "cloud-thinking-toggle";
+impl FeatureFlag for CloudThinkingEffortFeatureFlag {
+    const NAME: &'static str = "cloud-thinking-effort";
 
     fn enabled_for_staff() -> bool {
         false

--- a/crates/language_models/src/provider/cloud.rs
+++ b/crates/language_models/src/provider/cloud.rs
@@ -9,7 +9,7 @@ use cloud_llm_client::{
     CompletionEvent, CountTokensBody, CountTokensResponse, ListModelsResponse,
     SERVER_SUPPORTS_STATUS_MESSAGES_HEADER_NAME, ZED_VERSION_HEADER_NAME,
 };
-use feature_flags::{CloudThinkingToggleFeatureFlag, FeatureFlagAppExt as _};
+use feature_flags::{CloudThinkingEffortFeatureFlag, FeatureFlagAppExt as _};
 use futures::{
     AsyncBufReadExt, FutureExt, Stream, StreamExt, future::BoxFuture, stream::BoxStream,
 };
@@ -168,14 +168,14 @@ impl State {
     }
 
     fn update_models(&mut self, response: ListModelsResponse, cx: &mut Context<Self>) {
-        let is_thinking_toggle_enabled = cx.has_flag::<CloudThinkingToggleFeatureFlag>();
+        let is_thinking_effort_enabled = cx.has_flag::<CloudThinkingEffortFeatureFlag>();
 
         let mut models = Vec::new();
 
         for model in response.models {
             models.push(Arc::new(model.clone()));
 
-            if !is_thinking_toggle_enabled {
+            if !is_thinking_effort_enabled {
                 // Right now we represent thinking variants of models as separate models on the client,
                 // so we need to insert variants for any model that supports thinking.
                 if model.supports_thinking {
@@ -740,9 +740,9 @@ impl LanguageModel for CloudLanguageModel {
         let intent = request.intent;
         let app_version = Some(cx.update(|cx| AppVersion::global(cx)));
         let thinking_allowed = request.thinking_allowed;
-        let is_thinking_toggle_enabled =
-            cx.update(|cx| cx.has_flag::<CloudThinkingToggleFeatureFlag>());
-        let enable_thinking = if is_thinking_toggle_enabled {
+        let is_thinking_effort_enabled =
+            cx.update(|cx| cx.has_flag::<CloudThinkingEffortFeatureFlag>());
+        let enable_thinking = if is_thinking_effort_enabled {
             thinking_allowed && self.model.supports_thinking
         } else {
             thinking_allowed && self.model.id.0.ends_with("-thinking")


### PR DESCRIPTION
This PR renames the `cloud-thinking-toggle` feature flag to `cloud-thinking-effort`.

This feature flag has expanded slightly in scope, so we want the name to be more representative of what it gates.

Release Notes:

- N/A
