### PR TITLE
Tweak stalebot (words, number of days)

### DIFF
--- a/.github/workflows/community_close_stale_issues.yml
+++ b/.github/workflows/community_close_stale_issues.yml
@@ -22,15 +22,15 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: >
-            Hi there!
             Zed development moves fast and a significant number of bugs become outdated.
-            If you can reproduce this bug on the latest stable Zed, please let us know by leaving a comment with the Zed version.
+            If you can reproduce this bug on the latest stable Zed, please let us know by leaving a comment with the Zed version,
+            it helps us focus on the right issues.
             If the bug doesn't appear for you anymore, feel free to close the issue yourself; otherwise, the bot will close it in a couple of weeks.
-
-            Thanks for your help!
+            But even after it's closed by the bot, you can leave a comment with the version where the bug is reproducible and we'll reopen the issue.
+            Thanks!
           close-issue-message: "This issue was closed due to inactivity. If you're still experiencing this problem, please leave a comment with your Zed version so that we can reopen the issue."
-          days-before-stale: 60
-          days-before-close: 14
+          days-before-stale: 90
+          days-before-close: 21
           only-issue-types: "Bug,Crash"
           operations-per-run: ${{ inputs.operations-per-run || 2000 }}
           ascending: true


### PR DESCRIPTION
While the 60 days of inactivity works for a lot of the issues, with other (more stubborn and popular) bugs it's too noisy to nag people every eight weeks.

Also changing days-before-close after seeing a few cases of people getting back to us after more than two weeks since the bot's question.

Release Notes:

- N/A