### PR TITLE
language: Avoid cloning the text version when creating a snapshot

### DIFF
--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -1256,7 +1256,7 @@ impl Buffer {
             syntax_map.snapshot()
         };
 
-        let tree_sitter_data = if self.text.version() != *self.tree_sitter_data.version() {
+        let tree_sitter_data = if self.text.version != *self.tree_sitter_data.version() {
             Arc::new(TreeSitterData::new(text))
         } else {
             self.tree_sitter_data.clone()


### PR DESCRIPTION
Found while profiling #48601

`clock::Global` contains a SmallVec which in hotpaths like snapshot creation or cloning adds can add a non trivial overhead. The same issue exists inside `text::BufferSnapshot` but wrapping it with an Arc will involve a lot of calls to Arc::make_mut which feels a bit sketchy to me

Trace:
[second.trace.zip](https://github.com/user-attachments/files/25135643/second.trace.zip)

Release Notes:

- N/A
