### PR TITLE
Improve performance when detecting JSX auto close

### DIFF
--- a/crates/editor/src/jsx_tag_auto_close.rs
+++ b/crates/editor/src/jsx_tag_auto_close.rs
@@ -318,8 +318,7 @@ pub(crate) fn refresh_enabled_in_any_buffer(
 
             let buffer = buffer.read(cx);
             let snapshot = buffer.snapshot();
-            for syntax_layer in snapshot.syntax_layers() {
-                let language = syntax_layer.language;
+            for language in snapshot.syntax_layers_languages() {
                 if language.config().jsx_tag_auto_close.is_none() {
                     continue;
                 }

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -3796,6 +3796,10 @@ impl BufferSnapshot {
             .layers_for_range(range, &self.text, include_hidden)
     }
 
+    pub fn syntax_layers_languages(&self) -> impl Iterator<Item = &Arc<Language>> {
+        self.syntax.languages(&self, true)
+    }
+
     pub fn smallest_syntax_layer_containing<D: ToOffset>(
         &self,
         range: Range<D>,


### PR DESCRIPTION
Helps #48601

<img width="1649" height="1071" alt="image" src="https://github.com/user-attachments/assets/ff3dfee0-cc65-430f-a5fa-b4b4c36e8183" />


`syntax_layers` does some offset conversion that might require getting some chunks from the rope, which is quite expensive. For detecting autoclose, we only use the language from those syntax layers, so having a short path that skips all the conversion should skip some sum_tree traversals. 
   
I'm pretty sure other places would benefit from this as well, but I haven't searched them yet.

Release Notes:

- N/A
