### PR TITLE
languages: Add syntax highlighting for HTML character references

### DIFF
--- a/crates/languages/src/javascript/highlights.scm
+++ b/crates/languages/src/javascript/highlights.scm
@@ -360,3 +360,4 @@
 (jsx_self_closing_element (["<" "/>"]) @punctuation.bracket.jsx)
 (jsx_attribute "=" @punctuation.delimiter.jsx)
 (jsx_text) @text.jsx
+(html_character_reference) @string.special

--- a/crates/languages/src/tsx/highlights.scm
+++ b/crates/languages/src/tsx/highlights.scm
@@ -424,3 +424,4 @@
 (jsx_self_closing_element (["<" "/>"]) @punctuation.bracket.jsx)
 (jsx_attribute "=" @punctuation.delimiter.jsx)
 (jsx_text) @text.jsx
+(html_character_reference) @string.special

--- a/extensions/html/languages/html/highlights.scm
+++ b/extensions/html/languages/html/highlights.scm
@@ -7,6 +7,7 @@
   (attribute_value)
 ] @string
 (comment) @comment
+(entity) @string.special
 
 "=" @punctuation.delimiter.html
 


### PR DESCRIPTION
HTML character references like `&middot;`, `&apos;`, and `&#123;` are correctly parsed by tree-sitter as named nodes (`html_character_reference` in TSX/JavaScript, `entity` in HTML), but no highlight query captures them. This means they render as plain, unhighlighted text in the editor.

This PR adds one-line highlight captures for each:

- **TSX** (`crates/languages/src/tsx/highlights.scm`): `(html_character_reference) @string.special`
- **JavaScript** (`crates/languages/src/javascript/highlights.scm`): `(html_character_reference) @string.special`
- **HTML** (`extensions/html/languages/html/highlights.scm`): `(entity) @string.special`

`@string.special` is already styled by all built-in themes (One Dark, Ayu, Gruvbox, etc.), so no theme changes are needed.

Release Notes:

- Added syntax highlighting for HTML character references (`&middot;`, `&apos;`, `&#123;`, etc.) in TSX, JavaScript, and HTML files.