### PR TITLE
Remove fine-grained tool streaming beta header (now GA)

### DIFF
--- a/crates/anthropic/src/anthropic.rs
+++ b/crates/anthropic/src/anthropic.rs
@@ -16,7 +16,6 @@ pub mod batches;
 
 pub const ANTHROPIC_API_URL: &str = "https://api.anthropic.com";
 
-pub const FINE_GRAINED_TOOL_STREAMING_BETA_HEADER: &str = "fine-grained-tool-streaming-2025-05-14";
 pub const CONTEXT_1M_BETA_HEADER: &str = "context-1m-2025-08-07";
 
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -534,32 +533,16 @@ impl Model {
         let mut headers = vec![];
 
         match self {
-            Self::ClaudeOpus4
-            | Self::ClaudeOpus4_1
-            | Self::ClaudeOpus4_5
-            | Self::ClaudeOpus4_6
-            | Self::ClaudeSonnet4
-            | Self::ClaudeSonnet4_5
-            | Self::ClaudeOpus4Thinking
-            | Self::ClaudeOpus4_1Thinking
-            | Self::ClaudeOpus4_5Thinking
-            | Self::ClaudeOpus4_6Thinking
-            | Self::ClaudeSonnet4Thinking
-            | Self::ClaudeSonnet4_5Thinking => {
-                headers.push(FINE_GRAINED_TOOL_STREAMING_BETA_HEADER.to_string());
-            }
             Self::ClaudeOpus4_6_1mContext
             | Self::ClaudeOpus4_6_1mContextThinking
             | Self::ClaudeSonnet4_5_1mContext
             | Self::ClaudeSonnet4_5_1mContextThinking => {
-                headers.push(FINE_GRAINED_TOOL_STREAMING_BETA_HEADER.to_string());
                 headers.push(CONTEXT_1M_BETA_HEADER.to_string());
             }
             Self::Claude3_7Sonnet | Self::Claude3_7SonnetThinking => {
                 // Try beta token-efficient tool use (supported in Claude 3.7 Sonnet only)
                 // https://docs.anthropic.com/en/docs/build-with-claude/tool-use/token-efficient-tool-use
                 headers.push("token-efficient-tools-2025-02-19".to_string());
-                headers.push(FINE_GRAINED_TOOL_STREAMING_BETA_HEADER.to_string());
             }
             Self::Custom {
                 extra_beta_headers, ..


### PR DESCRIPTION
Fine-grained tool streaming is now [generally available on all models and platforms](https://platform.claude.com/docs/en/release-notes/overview#february-5-2026) as of February 5, 2026, so the `fine-grained-tool-streaming-2025-05-14` beta header is officially listed as no longer needed.

See https://github.com/zed-industries/zed/pull/48508#discussion_r2773653965

Release Notes:

- N/A