### PR TITLE
markdown_preview: Fix slow checkbox check/uncheck UI updates

### DIFF
--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -310,6 +310,10 @@ impl MarkdownPreviewView {
         cx: &mut Context<Self>,
     ) {
         if let Some(state) = &self.active_editor {
+            // if there is already a task to update the ui and the current task is also debounced (not high priority), do nothing
+            if wait_for_debounce && self.parsing_markdown_task.is_some() {
+                return;
+            }
             self.parsing_markdown_task = Some(self.parse_markdown_in_background(
                 wait_for_debounce,
                 state.editor.clone(),
@@ -351,6 +355,7 @@ impl MarkdownPreviewView {
                 let scroll_top = view.list_state.logical_scroll_top();
                 view.list_state.reset(markdown_blocks_count);
                 view.list_state.scroll_to(scroll_top);
+                view.parsing_markdown_task = None;
                 cx.notify();
             })
         })


### PR DESCRIPTION
When checking a box in the markdown preview, it's generally very slow.

Preview updates when typing in the editor are debounced to be every 200ms, but when clicking an element in the preview, it feels sluggish to wait that long.

In debugging, I found that the debounced task from the editor event subscriptions replaced the non-debounced event on [line 605](https://github.com/zed-industries/zed/blob/263d8e58d809b493044160cb26fb690169007e4e/crates/markdown_preview/src/markdown_preview_view.rs#L600C49-L602C51), and the UI took around 200 ms to update.

Therefore, I've changed the markdown parsing function to not replace the task, unless another non-debounced task comes along. UI updates from the editor are still debounced.

Before: 
[Screencast_20260206_145702.webm](https://github.com/user-attachments/assets/fed5f8fa-866e-4291-9ec3-f876bb6dc6ab)

After:
[Screencast_20260206_150124.webm](https://github.com/user-attachments/assets/e4e7dc2b-d899-42ff-bd28-ad1dc5a8d3d9)

Release Notes:

- Improved speed at which markdown lists update after checking or unchecking items
