### PR TITLE
Fix MCP tool name parsing: use newline delimiter instead of colon

### DIFF
--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -1065,7 +1065,7 @@ fn test_permission_option_ids_for_terminal() {
     assert!(
         allow_ids
             .iter()
-            .any(|id| id.starts_with("always_allow_pattern:terminal:")),
+            .any(|id| id.starts_with("always_allow_pattern:terminal\n")),
         "Missing allow pattern option"
     );
 
@@ -1074,7 +1074,7 @@ fn test_permission_option_ids_for_terminal() {
     assert!(
         deny_ids
             .iter()
-            .any(|id| id.starts_with("always_deny_pattern:terminal:")),
+            .any(|id| id.starts_with("always_deny_pattern:terminal\n")),
         "Missing deny pattern option"
     );
 }

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -4944,7 +4944,7 @@ pub(crate) mod tests {
         assert!(
             allow_ids
                 .iter()
-                .any(|id| id.starts_with("always_allow_pattern:terminal:")),
+                .any(|id| id.starts_with("always_allow_pattern:terminal\n")),
             "Missing allow pattern option"
         );
     }
@@ -4969,7 +4969,7 @@ pub(crate) mod tests {
         assert!(
             deny_ids
                 .iter()
-                .any(|id| id.starts_with("always_deny_pattern:terminal:")),
+                .any(|id| id.starts_with("always_deny_pattern:terminal\n")),
             "Missing deny pattern option"
         );
     }


### PR DESCRIPTION
MCP tool names can contain colons (e.g. `mcp:server:tool`), which broke the `splitn(3, ':')` parsing of always-allow/always-deny pattern option IDs. This switches to newline (`\n`) as the delimiter between tool name and pattern, since newlines cannot appear in either component.

## Changes

- **Option ID format**: Changed from `always_allow_pattern:{tool}:{pattern}` to `always_allow_pattern:{tool}\n{pattern}`
- **Response parsing**: Replaced `splitn(3, ':')` with `strip_prefix` + `split_once('\n')`
- **Error logging**: Added `log::error!` when pattern parsing fails (previously silent)
- **Tests**: Updated test assertions in `agent` and `agent_ui` crates

No release notes because granular tool permissions are still feature-flagged.

Release Notes:

- N/A