### PR TITLE
Harden tool authorization: sensitive settings, deferred ops, copy/move patterns

### DIFF
--- a/crates/agent/src/pattern_extraction.rs
+++ b/crates/agent/src/pattern_extraction.rs
@@ -1,4 +1,5 @@
 use crate::shell_parser::extract_commands;
+use std::path::{Path, PathBuf};
 use url::Url;
 
 /// Extracts the command name from a shell command using the shell parser.
@@ -41,7 +42,7 @@ pub fn extract_terminal_pattern_display(command: &str) -> Option<String> {
 }
 
 pub fn extract_path_pattern(path: &str) -> Option<String> {
-    let parent = std::path::Path::new(path).parent()?;
+    let parent = Path::new(path).parent()?;
     let parent_str = parent.to_str()?;
     if parent_str.is_empty() || parent_str == "/" {
         return None;
@@ -50,12 +51,53 @@ pub fn extract_path_pattern(path: &str) -> Option<String> {
 }
 
 pub fn extract_path_pattern_display(path: &str) -> Option<String> {
-    let parent = std::path::Path::new(path).parent()?;
+    let parent = Path::new(path).parent()?;
     let parent_str = parent.to_str()?;
     if parent_str.is_empty() || parent_str == "/" {
         return None;
     }
     Some(format!("{}/", parent_str))
+}
+
+fn common_parent_dir(path_a: &str, path_b: &str) -> Option<PathBuf> {
+    let parent_a = Path::new(path_a).parent()?;
+    let parent_b = Path::new(path_b).parent()?;
+
+    let components_a: Vec<_> = parent_a.components().collect();
+    let components_b: Vec<_> = parent_b.components().collect();
+
+    let common_count = components_a
+        .iter()
+        .zip(components_b.iter())
+        .take_while(|(a, b)| a == b)
+        .count();
+
+    if common_count == 0 {
+        return None;
+    }
+
+    let common: PathBuf = components_a[..common_count].iter().collect();
+    Some(common)
+}
+
+pub fn extract_copy_move_pattern(input: &str) -> Option<String> {
+    let (source, dest) = input.split_once('\n')?;
+    let common = common_parent_dir(source, dest)?;
+    let common_str = common.to_str()?;
+    if common_str.is_empty() || common_str == "/" {
+        return None;
+    }
+    Some(format!("^{}/", regex::escape(common_str)))
+}
+
+pub fn extract_copy_move_pattern_display(input: &str) -> Option<String> {
+    let (source, dest) = input.split_once('\n')?;
+    let common = common_parent_dir(source, dest)?;
+    let common_str = common.to_str()?;
+    if common_str.is_empty() || common_str == "/" {
+        return None;
+    }
+    Some(format!("{}/", common_str))
 }
 
 pub fn extract_url_pattern(url: &str) -> Option<String> {
@@ -169,5 +211,57 @@ mod tests {
             extract_url_pattern("https://test.example.com/path"),
             Some("^https?://test\\.example\\.com".to_string())
         );
+    }
+
+    #[test]
+    fn test_extract_copy_move_pattern_same_directory() {
+        assert_eq!(
+            extract_copy_move_pattern(
+                "/Users/alice/project/src/old.rs\n/Users/alice/project/src/new.rs"
+            ),
+            Some("^/Users/alice/project/src/".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_copy_move_pattern_sibling_directories() {
+        assert_eq!(
+            extract_copy_move_pattern(
+                "/Users/alice/project/src/old.rs\n/Users/alice/project/dst/new.rs"
+            ),
+            Some("^/Users/alice/project/".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_copy_move_pattern_no_common_prefix() {
+        assert_eq!(
+            extract_copy_move_pattern("/home/file.txt\n/tmp/file.txt"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_extract_copy_move_pattern_relative_paths() {
+        assert_eq!(
+            extract_copy_move_pattern("src/old.rs\nsrc/new.rs"),
+            Some("^src/".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_copy_move_pattern_display() {
+        assert_eq!(
+            extract_copy_move_pattern_display(
+                "/Users/alice/project/src/old.rs\n/Users/alice/project/dst/new.rs"
+            ),
+            Some("/Users/alice/project/".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_copy_move_pattern_no_arrow() {
+        assert_eq!(extract_copy_move_pattern("just/a/path.rs"), None);
+        assert_eq!(extract_copy_move_pattern_display("just/a/path.rs"), None);
     }
 }

--- a/crates/agent/src/pattern_extraction.rs
+++ b/crates/agent/src/pattern_extraction.rs
@@ -2,6 +2,11 @@ use crate::shell_parser::extract_commands;
 use std::path::{Path, PathBuf};
 use url::Url;
 
+/// Normalize path separators to forward slashes for consistent cross-platform patterns.
+fn normalize_separators(path_str: &str) -> String {
+    path_str.replace('\\', "/")
+}
+
 /// Extracts the command name from a shell command using the shell parser.
 ///
 /// This parses the command properly to extract just the command name (first word),
@@ -43,16 +48,16 @@ pub fn extract_terminal_pattern_display(command: &str) -> Option<String> {
 
 pub fn extract_path_pattern(path: &str) -> Option<String> {
     let parent = Path::new(path).parent()?;
-    let parent_str = parent.to_str()?;
+    let parent_str = normalize_separators(parent.to_str()?);
     if parent_str.is_empty() || parent_str == "/" {
         return None;
     }
-    Some(format!("^{}/", regex::escape(parent_str)))
+    Some(format!("^{}/", regex::escape(&parent_str)))
 }
 
 pub fn extract_path_pattern_display(path: &str) -> Option<String> {
     let parent = Path::new(path).parent()?;
-    let parent_str = parent.to_str()?;
+    let parent_str = normalize_separators(parent.to_str()?);
     if parent_str.is_empty() || parent_str == "/" {
         return None;
     }
@@ -83,17 +88,17 @@ fn common_parent_dir(path_a: &str, path_b: &str) -> Option<PathBuf> {
 pub fn extract_copy_move_pattern(input: &str) -> Option<String> {
     let (source, dest) = input.split_once('\n')?;
     let common = common_parent_dir(source, dest)?;
-    let common_str = common.to_str()?;
+    let common_str = normalize_separators(common.to_str()?);
     if common_str.is_empty() || common_str == "/" {
         return None;
     }
-    Some(format!("^{}/", regex::escape(common_str)))
+    Some(format!("^{}/", regex::escape(&common_str)))
 }
 
 pub fn extract_copy_move_pattern_display(input: &str) -> Option<String> {
     let (source, dest) = input.split_once('\n')?;
     let common = common_parent_dir(source, dest)?;
-    let common_str = common.to_str()?;
+    let common_str = normalize_separators(common.to_str()?);
     if common_str.is_empty() || common_str == "/" {
         return None;
     }

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -675,9 +675,16 @@ impl ToolPermissionContext {
                 extract_terminal_pattern(input_value),
                 extract_terminal_pattern_display(input_value),
             )
+        } else if tool_name == CopyPathTool::NAME || tool_name == MovePathTool::NAME {
+            // input_value is "source\ndestination"; extract a pattern from the
+            // common parent directory of both paths so that "always allow" covers
+            // future checks against both the source and the destination.
+            (
+                extract_copy_move_pattern(input_value),
+                extract_copy_move_pattern_display(input_value),
+            )
         } else if tool_name == EditFileTool::NAME
             || tool_name == DeletePathTool::NAME
-            || tool_name == MovePathTool::NAME
             || tool_name == CreateDirectoryTool::NAME
             || tool_name == SaveFileTool::NAME
         {

--- a/crates/agent/src/tool_permissions.rs
+++ b/crates/agent/src/tool_permissions.rs
@@ -3,6 +3,7 @@ use crate::shell_parser::extract_commands;
 use crate::tools::TerminalTool;
 use agent_settings::{AgentSettings, CompiledRegex, ToolPermissions, ToolRules};
 use settings::ToolPermissionMode;
+use std::path::{Component, Path};
 use std::sync::LazyLock;
 use util::shell::ShellKind;
 
@@ -16,24 +17,44 @@ pub struct HardcodedSecurityRules {
 }
 
 pub static HARDCODED_SECURITY_RULES: LazyLock<HardcodedSecurityRules> = LazyLock::new(|| {
+    // Flag group matches any short flags (-rf, -rfv, -v, etc.) or long flags (--recursive, --force, etc.)
+    // This ensures extra flags like -rfv, -v -rf, --recursive --force don't bypass the rules.
+    const FLAGS: &str = r"(--[a-zA-Z0-9][-a-zA-Z0-9_]*(=[^\s]*)?\s+|-[a-zA-Z]+\s+)*";
+    // Trailing flags that may appear after the path operand (GNU rm accepts flags after operands)
+    const TRAILING_FLAGS: &str = r"(\s+--[a-zA-Z0-9][-a-zA-Z0-9_]*(=[^\s]*)?|\s+-[a-zA-Z]+)*\s*";
+
     HardcodedSecurityRules {
-        // Case-insensitive; `(-[rf]+\s+)*` handles `-rf`, `-fr`, `-RF`, `-r -f`, etc.
         terminal_deny: vec![
-            // Recursive deletion of root - "rm -rf /" or "rm -rf / "
-            CompiledRegex::new(r"rm\s+(-[rf]+\s+)*/\s*$", false)
-                .expect("hardcoded regex should compile"),
-            // Recursive deletion of home - "rm -rf ~" or "rm -rf ~/" (but not ~/subdir)
-            CompiledRegex::new(r"rm\s+(-[rf]+\s+)*~/?\s*$", false)
-                .expect("hardcoded regex should compile"),
-            // Recursive deletion of home via $HOME - "rm -rf $HOME" or "rm -rf ${HOME}"
-            CompiledRegex::new(r"rm\s+(-[rf]+\s+)*(\$HOME|\$\{HOME\})/?\s*$", false)
-                .expect("hardcoded regex should compile"),
-            // Recursive deletion of current directory - "rm -rf ." or "rm -rf ./"
-            CompiledRegex::new(r"rm\s+(-[rf]+\s+)*\./?\s*$", false)
-                .expect("hardcoded regex should compile"),
-            // Recursive deletion of parent directory - "rm -rf .." or "rm -rf ../"
-            CompiledRegex::new(r"rm\s+(-[rf]+\s+)*\.\./?\s*$", false)
-                .expect("hardcoded regex should compile"),
+            // Recursive deletion of root - "rm -rf /", "rm -rfv /", "rm -rf /*", "rm / -rf"
+            CompiledRegex::new(
+                &format!(r"\brm\s+{FLAGS}(--\s+)?/\*?{TRAILING_FLAGS}$"),
+                false,
+            )
+            .expect("hardcoded regex should compile"),
+            // Recursive deletion of home - "rm -rf ~" or "rm -rf ~/" or "rm -rf ~/*" or "rm ~ -rf" (but not ~/subdir)
+            CompiledRegex::new(
+                &format!(r"\brm\s+{FLAGS}(--\s+)?~/?\*?{TRAILING_FLAGS}$"),
+                false,
+            )
+            .expect("hardcoded regex should compile"),
+            // Recursive deletion of home via $HOME - "rm -rf $HOME" or "rm -rf ${HOME}" or "rm $HOME -rf" or with /*
+            CompiledRegex::new(
+                &format!(r"\brm\s+{FLAGS}(--\s+)?(\$HOME|\$\{{HOME\}})/?(\*)?{TRAILING_FLAGS}$"),
+                false,
+            )
+            .expect("hardcoded regex should compile"),
+            // Recursive deletion of current directory - "rm -rf ." or "rm -rf ./" or "rm -rf ./*" or "rm . -rf"
+            CompiledRegex::new(
+                &format!(r"\brm\s+{FLAGS}(--\s+)?\./?\*?{TRAILING_FLAGS}$"),
+                false,
+            )
+            .expect("hardcoded regex should compile"),
+            // Recursive deletion of parent directory - "rm -rf .." or "rm -rf ../" or "rm -rf ../*" or "rm .. -rf"
+            CompiledRegex::new(
+                &format!(r"\brm\s+{FLAGS}(--\s+)?\.\./?\*?{TRAILING_FLAGS}$"),
+                false,
+            )
+            .expect("hardcoded regex should compile"),
         ],
     }
 });
@@ -53,31 +74,126 @@ fn check_hardcoded_security_rules(
     let rules = &*HARDCODED_SECURITY_RULES;
     let terminal_patterns = &rules.terminal_deny;
 
-    // First: check the original input as-is
-    for pattern in terminal_patterns {
-        if pattern.is_match(input) {
-            return Some(ToolPermissionDecision::Deny(
-                HARDCODED_SECURITY_DENIAL_MESSAGE.into(),
-            ));
-        }
+    // First: check the original input as-is (and its path-normalized form)
+    if matches_hardcoded_patterns(input, terminal_patterns) {
+        return Some(ToolPermissionDecision::Deny(
+            HARDCODED_SECURITY_DENIAL_MESSAGE.into(),
+        ));
     }
 
     // Second: parse and check individual sub-commands (for chained commands)
     if shell_kind.supports_posix_chaining() {
         if let Some(commands) = extract_commands(input) {
             for command in &commands {
-                for pattern in terminal_patterns {
-                    if pattern.is_match(command) {
-                        return Some(ToolPermissionDecision::Deny(
-                            HARDCODED_SECURITY_DENIAL_MESSAGE.into(),
-                        ));
-                    }
+                if matches_hardcoded_patterns(command, terminal_patterns) {
+                    return Some(ToolPermissionDecision::Deny(
+                        HARDCODED_SECURITY_DENIAL_MESSAGE.into(),
+                    ));
                 }
             }
         }
     }
 
     None
+}
+
+/// Checks a single command against hardcoded patterns, both as-is and with
+/// path arguments normalized (to catch traversal bypasses like `rm -rf /tmp/../../`
+/// and multi-path bypasses like `rm -rf /tmp /`).
+fn matches_hardcoded_patterns(command: &str, patterns: &[CompiledRegex]) -> bool {
+    for pattern in patterns {
+        if pattern.is_match(command) {
+            return true;
+        }
+    }
+
+    for expanded in expand_rm_to_single_path_commands(command) {
+        for pattern in patterns {
+            if pattern.is_match(&expanded) {
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
+/// For rm commands, expands multi-path arguments into individual single-path
+/// commands with normalized paths. This catches both traversal bypasses like
+/// `rm -rf /tmp/../../` and multi-path bypasses like `rm -rf /tmp /`.
+fn expand_rm_to_single_path_commands(command: &str) -> Vec<String> {
+    let trimmed = command.trim();
+
+    let first_token = trimmed.split_whitespace().next();
+    if !first_token.is_some_and(|t| t.eq_ignore_ascii_case("rm")) {
+        return vec![];
+    }
+
+    let parts: Vec<&str> = trimmed.split_whitespace().collect();
+    let mut flags = Vec::new();
+    let mut paths = Vec::new();
+    let mut past_double_dash = false;
+
+    for part in parts.iter().skip(1) {
+        if !past_double_dash && *part == "--" {
+            past_double_dash = true;
+            flags.push(*part);
+            continue;
+        }
+        if !past_double_dash && part.starts_with('-') {
+            flags.push(*part);
+        } else {
+            paths.push(*part);
+        }
+    }
+
+    let flags_str = if flags.is_empty() {
+        String::new()
+    } else {
+        format!("{} ", flags.join(" "))
+    };
+
+    let mut results = Vec::new();
+    for path in &paths {
+        if path.starts_with('$') {
+            let home_prefix = if path.starts_with("${HOME}") {
+                Some("${HOME}")
+            } else if path.starts_with("$HOME") {
+                Some("$HOME")
+            } else {
+                None
+            };
+
+            if let Some(prefix) = home_prefix {
+                let suffix = &path[prefix.len()..];
+                if suffix.is_empty() {
+                    results.push(format!("rm {flags_str}{path}"));
+                } else if suffix.starts_with('/') {
+                    let normalized_suffix = normalize_path(suffix);
+                    let reconstructed = if normalized_suffix == "/" {
+                        prefix.to_string()
+                    } else {
+                        format!("{prefix}{normalized_suffix}")
+                    };
+                    results.push(format!("rm {flags_str}{reconstructed}"));
+                } else {
+                    results.push(format!("rm {flags_str}{path}"));
+                }
+            } else {
+                results.push(format!("rm {flags_str}{path}"));
+            }
+            continue;
+        }
+
+        let mut normalized = normalize_path(path);
+        if normalized.is_empty() && !Path::new(path).has_root() {
+            normalized = ".".to_string();
+        }
+
+        results.push(format!("rm {flags_str}{normalized}"));
+    }
+
+    results
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -92,28 +208,27 @@ impl ToolPermissionDecision {
     ///
     /// # Precedence Order (highest to lowest)
     ///
-    /// 1. **`always_allow_tool_actions`** - When enabled, allows all tool actions without
-    ///    prompting. This global setting bypasses all other checks including deny patterns.
-    ///    Use with caution as it disables all security rules.
-    /// 2. **`always_deny`** - If any deny pattern matches, the tool call is blocked immediately.
+    /// 1. **Hardcoded security rules** - Critical safety checks (e.g., blocking `rm -rf /`)
+    ///    that cannot be bypassed by any user settings, including `always_allow_tool_actions`.
+    /// 2. **`always_allow_tool_actions`** - When enabled, allows all tool actions without
+    ///    prompting. This global setting bypasses user-configured deny/confirm/allow patterns,
+    ///    but does **not** bypass hardcoded security rules.
+    /// 3. **`always_deny`** - If any deny pattern matches, the tool call is blocked immediately.
     ///    This takes precedence over `always_confirm` and `always_allow` patterns.
-    /// 3. **`always_confirm`** - If any confirm pattern matches (and no deny matched),
+    /// 4. **`always_confirm`** - If any confirm pattern matches (and no deny matched),
     ///    the user is prompted for confirmation.
-    /// 4. **`always_allow`** - If any allow pattern matches (and no deny/confirm matched),
+    /// 5. **`always_allow`** - If any allow pattern matches (and no deny/confirm matched),
     ///    the tool call proceeds without prompting.
-    /// 5. **`default_mode`** - If no patterns match, falls back to the tool's default mode.
+    /// 6. **`default_mode`** - If no patterns match, falls back to the tool's default mode.
     ///
     /// # Shell Compatibility (Terminal Tool Only)
     ///
     /// For the terminal tool, commands are parsed to extract sub-commands for security.
-    /// This parsing only works for shells with POSIX-like `&&` / `||` / `;` / `|` syntax:
-    ///
-    /// **Compatible shells:** Posix (sh, bash, dash, zsh), Fish 3.0+, PowerShell 7+/Pwsh,
-    /// Cmd, Xonsh, Csh, Tcsh
-    ///
-    /// **Incompatible shells:** Nushell, Elvish, Rc (Plan 9)
-    ///
-    /// For incompatible shells, `always_allow` patterns are disabled for safety.
+    /// All currently supported `ShellKind` variants are treated as compatible because
+    /// brush-parser can handle their command chaining syntax. If a new `ShellKind`
+    /// variant is added that brush-parser cannot safely parse, it should be excluded
+    /// from `ShellKind::supports_posix_chaining()`, which will cause `always_allow`
+    /// patterns to be disabled for that shell.
     ///
     /// # Pattern Matching Tips
     ///
@@ -303,14 +418,118 @@ pub fn decide_permission_from_settings(
     )
 }
 
+/// Normalizes a path by collapsing `.` and `..` segments without touching the filesystem.
+fn normalize_path(raw: &str) -> String {
+    let is_absolute = Path::new(raw).has_root();
+    let mut components: Vec<&str> = Vec::new();
+    for component in Path::new(raw).components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if components.last() == Some(&"..") {
+                    components.push("..");
+                } else if !components.is_empty() {
+                    components.pop();
+                } else if !is_absolute {
+                    components.push("..");
+                }
+            }
+            Component::Normal(segment) => {
+                if let Some(s) = segment.to_str() {
+                    components.push(s);
+                }
+            }
+            Component::RootDir | Component::Prefix(_) => {}
+        }
+    }
+    let joined = components.join("/");
+    if is_absolute {
+        format!("/{joined}")
+    } else {
+        joined
+    }
+}
+
+/// Decides permission by checking both the raw input path and a simplified/canonicalized
+/// version. Returns the most restrictive decision (Deny > Confirm > Allow).
+pub fn decide_permission_for_path(
+    tool_name: &str,
+    raw_path: &str,
+    settings: &AgentSettings,
+) -> ToolPermissionDecision {
+    let raw_decision = decide_permission_from_settings(tool_name, raw_path, settings);
+
+    let simplified = normalize_path(raw_path);
+    if simplified == raw_path {
+        return raw_decision;
+    }
+
+    let simplified_decision = decide_permission_from_settings(tool_name, &simplified, settings);
+
+    most_restrictive(raw_decision, simplified_decision)
+}
+
+fn most_restrictive(
+    a: ToolPermissionDecision,
+    b: ToolPermissionDecision,
+) -> ToolPermissionDecision {
+    match (&a, &b) {
+        (ToolPermissionDecision::Deny(_), _) => a,
+        (_, ToolPermissionDecision::Deny(_)) => b,
+        (ToolPermissionDecision::Confirm, _) | (_, ToolPermissionDecision::Confirm) => {
+            ToolPermissionDecision::Confirm
+        }
+        _ => a,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::AgentTool;
     use crate::pattern_extraction::extract_terminal_pattern;
     use crate::tools::{EditFileTool, TerminalTool};
-    use agent_settings::{CompiledRegex, InvalidRegexPattern, ToolRules};
+    use agent_settings::{AgentProfileId, CompiledRegex, InvalidRegexPattern, ToolRules};
+    use gpui::px;
+    use settings::{DefaultAgentView, DockPosition, DockSide, NotifyWhenAgentWaiting};
     use std::sync::Arc;
+
+    fn test_agent_settings(
+        tool_permissions: ToolPermissions,
+        always_allow_tool_actions: bool,
+    ) -> AgentSettings {
+        AgentSettings {
+            enabled: true,
+            button: true,
+            dock: DockPosition::Right,
+            agents_panel_dock: DockSide::Left,
+            default_width: px(300.),
+            default_height: px(600.),
+            default_model: None,
+            inline_assistant_model: None,
+            inline_assistant_use_streaming_tools: false,
+            commit_message_model: None,
+            thread_summary_model: None,
+            inline_alternatives: vec![],
+            favorite_models: vec![],
+            default_profile: AgentProfileId::default(),
+            default_view: DefaultAgentView::Thread,
+            profiles: Default::default(),
+            always_allow_tool_actions,
+            notify_when_agent_waiting: NotifyWhenAgentWaiting::default(),
+            play_sound_when_agent_done: false,
+            single_file_review: false,
+            model_parameters: vec![],
+            enable_feedback: false,
+            expand_edit_card: true,
+            expand_terminal_card: true,
+            cancel_generation_on_terminal_stop: true,
+            use_modifier_to_send: true,
+            message_editor_min_lines: 1,
+            tool_permissions,
+            show_turn_stats: false,
+        }
+    }
 
     fn pattern(command: &str) -> &'static str {
         Box::leak(
@@ -1125,6 +1344,18 @@ mod tests {
         t("rm -r -f /").is_deny();
         t("rm -f -r /").is_deny();
         t("RM -RF /").is_deny();
+        // Long flags
+        t("rm --recursive --force /").is_deny();
+        t("rm --force --recursive /").is_deny();
+        // Extra short flags
+        t("rm -rfv /").is_deny();
+        t("rm -v -rf /").is_deny();
+        // Glob wildcards
+        t("rm -rf /*").is_deny();
+        t("rm -rf /* ").is_deny();
+        // End-of-options marker
+        t("rm -rf -- /").is_deny();
+        t("rm -- /").is_deny();
     }
 
     #[test]
@@ -1141,6 +1372,40 @@ mod tests {
         t("rm -FR ${HOME}/").is_deny();
         t("rm -R -F ${HOME}/").is_deny();
         t("RM -RF ~").is_deny();
+        // Long flags
+        t("rm --recursive --force ~").is_deny();
+        t("rm --recursive --force ~/").is_deny();
+        t("rm --recursive --force $HOME").is_deny();
+        t("rm --force --recursive ${HOME}/").is_deny();
+        // Extra short flags
+        t("rm -rfv ~").is_deny();
+        t("rm -v -rf ~/").is_deny();
+        // Glob wildcards
+        t("rm -rf ~/*").is_deny();
+        t("rm -rf $HOME/*").is_deny();
+        t("rm -rf ${HOME}/*").is_deny();
+        // End-of-options marker
+        t("rm -rf -- ~").is_deny();
+        t("rm -rf -- ~/").is_deny();
+        t("rm -rf -- $HOME").is_deny();
+    }
+
+    #[test]
+    fn hardcoded_blocks_rm_rf_home_with_traversal() {
+        // Path traversal after $HOME / ${HOME} should still be blocked
+        t("rm -rf $HOME/./").is_deny();
+        t("rm -rf $HOME/foo/..").is_deny();
+        t("rm -rf ${HOME}/.").is_deny();
+        t("rm -rf ${HOME}/./").is_deny();
+        t("rm -rf $HOME/a/b/../..").is_deny();
+        t("rm -rf ${HOME}/foo/bar/../..").is_deny();
+        // Subdirectories should NOT be blocked
+        t("rm -rf $HOME/subdir")
+            .mode(ToolPermissionMode::Allow)
+            .is_allow();
+        t("rm -rf ${HOME}/Documents")
+            .mode(ToolPermissionMode::Allow)
+            .is_allow();
     }
 
     #[test]
@@ -1156,6 +1421,18 @@ mod tests {
         t("rm -R -F ../").is_deny();
         t("RM -RF .").is_deny();
         t("RM -RF ..").is_deny();
+        // Long flags
+        t("rm --recursive --force .").is_deny();
+        t("rm --force --recursive ../").is_deny();
+        // Extra short flags
+        t("rm -rfv .").is_deny();
+        t("rm -v -rf ../").is_deny();
+        // Glob wildcards
+        t("rm -rf ./*").is_deny();
+        t("rm -rf ../*").is_deny();
+        // End-of-options marker
+        t("rm -rf -- .").is_deny();
+        t("rm -rf -- ../").is_deny();
     }
 
     #[test]
@@ -1209,5 +1486,321 @@ mod tests {
         t("echo hello; rm -rf $HOME").is_deny();
         t("echo hello; rm -rf .").is_deny();
         t("echo hello; rm -rf ..").is_deny();
+    }
+
+    #[test]
+    fn hardcoded_blocks_rm_with_trailing_flags() {
+        // GNU rm accepts flags after operands by default
+        t("rm / -rf").is_deny();
+        t("rm / -fr").is_deny();
+        t("rm / -RF").is_deny();
+        t("rm / -r -f").is_deny();
+        t("rm / --recursive --force").is_deny();
+        t("rm / -rfv").is_deny();
+        t("rm /* -rf").is_deny();
+        // Mixed: some flags before path, some after
+        t("rm -r / -f").is_deny();
+        t("rm -f / -r").is_deny();
+        // Home
+        t("rm ~ -rf").is_deny();
+        t("rm ~/ -rf").is_deny();
+        t("rm ~ -r -f").is_deny();
+        t("rm $HOME -rf").is_deny();
+        t("rm ${HOME} -rf").is_deny();
+        // Dot / dotdot
+        t("rm . -rf").is_deny();
+        t("rm ./ -rf").is_deny();
+        t("rm . -r -f").is_deny();
+        t("rm .. -rf").is_deny();
+        t("rm ../ -rf").is_deny();
+        t("rm .. -r -f").is_deny();
+        // Trailing flags in chained commands
+        t("ls && rm / -rf").is_deny();
+        t("echo hello; rm ~ -rf").is_deny();
+        // Safe paths with trailing flags should NOT be blocked
+        t("rm ./build -rf")
+            .mode(ToolPermissionMode::Allow)
+            .is_allow();
+        t("rm /tmp/test -rf")
+            .mode(ToolPermissionMode::Allow)
+            .is_allow();
+        t("rm ~/Documents -rf")
+            .mode(ToolPermissionMode::Allow)
+            .is_allow();
+    }
+
+    #[test]
+    fn hardcoded_blocks_rm_with_flag_equals_value() {
+        // --flag=value syntax should not bypass the rules
+        t("rm --no-preserve-root=yes -rf /").is_deny();
+        t("rm --no-preserve-root=yes --recursive --force /").is_deny();
+        t("rm -rf --no-preserve-root=yes /").is_deny();
+        t("rm --interactive=never -rf /").is_deny();
+        t("rm --no-preserve-root=yes -rf ~").is_deny();
+        t("rm --no-preserve-root=yes -rf .").is_deny();
+        t("rm --no-preserve-root=yes -rf ..").is_deny();
+        t("rm --no-preserve-root=yes -rf $HOME").is_deny();
+        // Trailing --flag=value after path
+        t("rm / --no-preserve-root=yes -rf").is_deny();
+        t("rm ~ -rf --no-preserve-root=yes").is_deny();
+        // Safe paths with --flag=value should NOT be blocked
+        t("rm --no-preserve-root=yes -rf ./build")
+            .mode(ToolPermissionMode::Allow)
+            .is_allow();
+        t("rm --interactive=never -rf /tmp/test")
+            .mode(ToolPermissionMode::Allow)
+            .is_allow();
+    }
+
+    #[test]
+    fn hardcoded_blocks_rm_with_path_traversal() {
+        // Traversal to root via ..
+        t("rm -rf /tmp/../../").is_deny();
+        t("rm -rf /tmp/../..").is_deny();
+        t("rm -rf /var/log/../../").is_deny();
+        // Root via /./
+        t("rm -rf /./").is_deny();
+        t("rm -rf /.").is_deny();
+        // Double slash (equivalent to /)
+        t("rm -rf //").is_deny();
+        // Home traversal via ~/./
+        t("rm -rf ~/./").is_deny();
+        t("rm -rf ~/.").is_deny();
+        // Dot traversal via indirect paths
+        t("rm -rf ./foo/..").is_deny();
+        t("rm -rf ../foo/..").is_deny();
+        // Traversal in chained commands
+        t("ls && rm -rf /tmp/../../").is_deny();
+        t("echo hello; rm -rf /./").is_deny();
+        // Traversal cannot be bypassed by global or allow patterns
+        t("rm -rf /tmp/../../").global(true).is_deny();
+        t("rm -rf /./").allow(&[".*"]).is_deny();
+        // Safe paths with traversal should still be allowed
+        t("rm -rf /tmp/../tmp/foo")
+            .mode(ToolPermissionMode::Allow)
+            .is_allow();
+        t("rm -rf ~/Documents/./subdir")
+            .mode(ToolPermissionMode::Allow)
+            .is_allow();
+    }
+
+    #[test]
+    fn hardcoded_blocks_rm_multi_path_with_dangerous_last() {
+        t("rm -rf /tmp /").is_deny();
+        t("rm -rf /tmp/foo /").is_deny();
+        t("rm -rf /var/log ~").is_deny();
+        t("rm -rf /safe $HOME").is_deny();
+    }
+
+    #[test]
+    fn hardcoded_blocks_rm_multi_path_with_dangerous_first() {
+        t("rm -rf / /tmp").is_deny();
+        t("rm -rf ~ /var/log").is_deny();
+        t("rm -rf . /tmp/foo").is_deny();
+        t("rm -rf .. /safe").is_deny();
+    }
+
+    #[test]
+    fn hardcoded_allows_rm_multi_path_all_safe() {
+        t("rm -rf /tmp /home/user")
+            .mode(ToolPermissionMode::Allow)
+            .is_allow();
+        t("rm -rf ./build ./dist")
+            .mode(ToolPermissionMode::Allow)
+            .is_allow();
+        t("rm -rf /var/log/app /tmp/cache")
+            .mode(ToolPermissionMode::Allow)
+            .is_allow();
+    }
+
+    #[test]
+    fn hardcoded_blocks_rm_multi_path_with_traversal() {
+        t("rm -rf /safe /tmp/../../").is_deny();
+        t("rm -rf /tmp/../../ /safe").is_deny();
+        t("rm -rf /safe /var/log/../../").is_deny();
+    }
+
+    #[test]
+    fn normalize_path_relative_no_change() {
+        assert_eq!(normalize_path("foo/bar"), "foo/bar");
+    }
+
+    #[test]
+    fn normalize_path_relative_with_curdir() {
+        assert_eq!(normalize_path("foo/./bar"), "foo/bar");
+    }
+
+    #[test]
+    fn normalize_path_relative_with_parent() {
+        assert_eq!(normalize_path("foo/bar/../baz"), "foo/baz");
+    }
+
+    #[test]
+    fn normalize_path_absolute_preserved() {
+        assert_eq!(normalize_path("/etc/passwd"), "/etc/passwd");
+    }
+
+    #[test]
+    fn normalize_path_absolute_with_traversal() {
+        assert_eq!(normalize_path("/tmp/../etc/passwd"), "/etc/passwd");
+    }
+
+    #[test]
+    fn normalize_path_root() {
+        assert_eq!(normalize_path("/"), "/");
+    }
+
+    #[test]
+    fn normalize_path_parent_beyond_root_clamped() {
+        assert_eq!(normalize_path("/../../../etc/passwd"), "/etc/passwd");
+    }
+
+    #[test]
+    fn normalize_path_curdir_only() {
+        assert_eq!(normalize_path("."), "");
+    }
+
+    #[test]
+    fn normalize_path_empty() {
+        assert_eq!(normalize_path(""), "");
+    }
+
+    #[test]
+    fn normalize_path_relative_traversal_above_start() {
+        assert_eq!(normalize_path("../../../etc/passwd"), "../../../etc/passwd");
+    }
+
+    #[test]
+    fn normalize_path_relative_traversal_with_curdir() {
+        assert_eq!(normalize_path("../../."), "../..");
+    }
+
+    #[test]
+    fn normalize_path_relative_partial_traversal_above_start() {
+        assert_eq!(normalize_path("foo/../../bar"), "../bar");
+    }
+
+    #[test]
+    fn most_restrictive_deny_vs_allow() {
+        assert!(matches!(
+            most_restrictive(
+                ToolPermissionDecision::Deny("x".into()),
+                ToolPermissionDecision::Allow
+            ),
+            ToolPermissionDecision::Deny(_)
+        ));
+    }
+
+    #[test]
+    fn most_restrictive_allow_vs_deny() {
+        assert!(matches!(
+            most_restrictive(
+                ToolPermissionDecision::Allow,
+                ToolPermissionDecision::Deny("x".into())
+            ),
+            ToolPermissionDecision::Deny(_)
+        ));
+    }
+
+    #[test]
+    fn most_restrictive_deny_vs_confirm() {
+        assert!(matches!(
+            most_restrictive(
+                ToolPermissionDecision::Deny("x".into()),
+                ToolPermissionDecision::Confirm
+            ),
+            ToolPermissionDecision::Deny(_)
+        ));
+    }
+
+    #[test]
+    fn most_restrictive_confirm_vs_deny() {
+        assert!(matches!(
+            most_restrictive(
+                ToolPermissionDecision::Confirm,
+                ToolPermissionDecision::Deny("x".into())
+            ),
+            ToolPermissionDecision::Deny(_)
+        ));
+    }
+
+    #[test]
+    fn most_restrictive_deny_vs_deny() {
+        assert!(matches!(
+            most_restrictive(
+                ToolPermissionDecision::Deny("a".into()),
+                ToolPermissionDecision::Deny("b".into())
+            ),
+            ToolPermissionDecision::Deny(_)
+        ));
+    }
+
+    #[test]
+    fn most_restrictive_confirm_vs_allow() {
+        assert_eq!(
+            most_restrictive(
+                ToolPermissionDecision::Confirm,
+                ToolPermissionDecision::Allow
+            ),
+            ToolPermissionDecision::Confirm
+        );
+    }
+
+    #[test]
+    fn most_restrictive_allow_vs_confirm() {
+        assert_eq!(
+            most_restrictive(
+                ToolPermissionDecision::Allow,
+                ToolPermissionDecision::Confirm
+            ),
+            ToolPermissionDecision::Confirm
+        );
+    }
+
+    #[test]
+    fn most_restrictive_allow_vs_allow() {
+        assert_eq!(
+            most_restrictive(ToolPermissionDecision::Allow, ToolPermissionDecision::Allow),
+            ToolPermissionDecision::Allow
+        );
+    }
+
+    #[test]
+    fn decide_permission_for_path_no_dots_early_return() {
+        // When the path has no `.` or `..`, normalize_path returns the same string,
+        // so decide_permission_for_path returns the raw decision directly.
+        let settings = test_agent_settings(
+            ToolPermissions {
+                tools: Default::default(),
+            },
+            false,
+        );
+        let decision = decide_permission_for_path(EditFileTool::NAME, "src/main.rs", &settings);
+        assert_eq!(decision, ToolPermissionDecision::Confirm);
+    }
+
+    #[test]
+    fn decide_permission_for_path_traversal_triggers_deny() {
+        let deny_regex = CompiledRegex::new("/etc/passwd", false).unwrap();
+        let mut tools = collections::HashMap::default();
+        tools.insert(
+            Arc::from(EditFileTool::NAME),
+            ToolRules {
+                default_mode: ToolPermissionMode::Allow,
+                always_allow: vec![],
+                always_deny: vec![deny_regex],
+                always_confirm: vec![],
+                invalid_patterns: vec![],
+            },
+        );
+        let settings = test_agent_settings(ToolPermissions { tools }, false);
+
+        let decision =
+            decide_permission_for_path(EditFileTool::NAME, "/tmp/../etc/passwd", &settings);
+        assert!(
+            matches!(decision, ToolPermissionDecision::Deny(_)),
+            "expected Deny for traversal to /etc/passwd, got {:?}",
+            decision
+        );
     }
 }

--- a/crates/agent/src/tools/copy_path_tool.rs
+++ b/crates/agent/src/tools/copy_path_tool.rs
@@ -1,15 +1,17 @@
-use crate::{
-    AgentTool, ToolCallEventStream, ToolPermissionDecision, decide_permission_from_settings,
+use super::edit_file_tool::{
+    SensitiveSettingsKind, is_sensitive_settings_path, sensitive_settings_kind,
 };
+use crate::{AgentTool, ToolCallEventStream, ToolPermissionDecision, decide_permission_for_path};
 use agent_client_protocol::ToolKind;
 use agent_settings::AgentSettings;
 use anyhow::{Context as _, Result, anyhow};
 use futures::FutureExt as _;
-use gpui::{App, AppContext, Entity, Task};
+use gpui::{App, Entity, Task};
 use project::Project;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::Settings;
+use std::path::Path;
 use std::sync::Arc;
 use util::markdown::MarkdownInlineCode;
 
@@ -83,56 +85,70 @@ impl AgentTool for CopyPathTool {
     ) -> Task<Result<Self::Output>> {
         let settings = AgentSettings::get_global(cx);
 
-        let source_decision =
-            decide_permission_from_settings(Self::NAME, &input.source_path, settings);
+        let source_decision = decide_permission_for_path(Self::NAME, &input.source_path, settings);
         if let ToolPermissionDecision::Deny(reason) = source_decision {
             return Task::ready(Err(anyhow!("{}", reason)));
         }
 
         let dest_decision =
-            decide_permission_from_settings(Self::NAME, &input.destination_path, settings);
+            decide_permission_for_path(Self::NAME, &input.destination_path, settings);
         if let ToolPermissionDecision::Deny(reason) = dest_decision {
             return Task::ready(Err(anyhow!("{}", reason)));
         }
 
         let needs_confirmation = matches!(source_decision, ToolPermissionDecision::Confirm)
-            || matches!(dest_decision, ToolPermissionDecision::Confirm);
+            || matches!(dest_decision, ToolPermissionDecision::Confirm)
+            || (!settings.always_allow_tool_actions
+                && matches!(source_decision, ToolPermissionDecision::Allow)
+                && is_sensitive_settings_path(Path::new(&input.source_path)))
+            || (!settings.always_allow_tool_actions
+                && matches!(dest_decision, ToolPermissionDecision::Allow)
+                && is_sensitive_settings_path(Path::new(&input.destination_path)));
 
         let authorize = if needs_confirmation {
             let src = MarkdownInlineCode(&input.source_path);
             let dest = MarkdownInlineCode(&input.destination_path);
             let context = crate::ToolPermissionContext {
                 tool_name: Self::NAME.to_string(),
-                input_value: input.source_path.clone(),
+                input_value: format!("{}\n{}", input.source_path, input.destination_path),
             };
-            Some(event_stream.authorize(format!("Copy {src} to {dest}"), context, cx))
+            let title = format!("Copy {src} to {dest}");
+            let sensitive_kind = sensitive_settings_kind(Path::new(&input.source_path))
+                .or_else(|| sensitive_settings_kind(Path::new(&input.destination_path)));
+            let title = match sensitive_kind {
+                Some(SensitiveSettingsKind::Local) => format!("{title} (local settings)"),
+                Some(SensitiveSettingsKind::Global) => format!("{title} (settings)"),
+                None => title,
+            };
+            Some(event_stream.authorize(title, context, cx))
         } else {
             None
         };
 
-        let copy_task = self.project.update(cx, |project, cx| {
-            match project
-                .find_project_path(&input.source_path, cx)
-                .and_then(|project_path| project.entry_for_path(&project_path, cx))
-            {
-                Some(entity) => match project.find_project_path(&input.destination_path, cx) {
-                    Some(project_path) => project.copy_entry(entity.id, project_path, cx),
-                    None => Task::ready(Err(anyhow!(
-                        "Destination path {} was outside the project.",
-                        input.destination_path
-                    ))),
-                },
-                None => Task::ready(Err(anyhow!(
-                    "Source path {} was not found in the project.",
-                    input.source_path
-                ))),
-            }
-        });
-
-        cx.background_spawn(async move {
+        let project = self.project.clone();
+        cx.spawn(async move |cx| {
             if let Some(authorize) = authorize {
                 authorize.await?;
             }
+
+            let copy_task = project.update(cx, |project, cx| {
+                match project
+                    .find_project_path(&input.source_path, cx)
+                    .and_then(|project_path| project.entry_for_path(&project_path, cx))
+                {
+                    Some(entity) => match project.find_project_path(&input.destination_path, cx) {
+                        Some(project_path) => Ok(project.copy_entry(entity.id, project_path, cx)),
+                        None => Err(anyhow!(
+                            "Destination path {} was outside the project.",
+                            input.destination_path
+                        )),
+                    },
+                    None => Err(anyhow!(
+                        "Source path {} was not found in the project.",
+                        input.source_path
+                    )),
+                }
+            })?;
 
             let result = futures::select! {
                 result = copy_task.fuse() => result,

--- a/crates/agent/src/tools/create_directory_tool.rs
+++ b/crates/agent/src/tools/create_directory_tool.rs
@@ -1,3 +1,4 @@
+use super::edit_file_tool::{SensitiveSettingsKind, sensitive_settings_kind};
 use agent_client_protocol::ToolKind;
 use agent_settings::AgentSettings;
 use anyhow::{Context as _, Result, anyhow};
@@ -7,12 +8,11 @@ use project::Project;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::Settings;
+use std::path::Path;
 use std::sync::Arc;
 use util::markdown::MarkdownInlineCode;
 
-use crate::{
-    AgentTool, ToolCallEventStream, ToolPermissionDecision, decide_permission_from_settings,
-};
+use crate::{AgentTool, ToolCallEventStream, ToolPermissionDecision, decide_permission_for_path};
 
 /// Creates a new directory at the specified path within the project. Returns confirmation that the directory was created.
 ///
@@ -71,7 +71,15 @@ impl AgentTool for CreateDirectoryTool {
         cx: &mut App,
     ) -> Task<Result<Self::Output>> {
         let settings = AgentSettings::get_global(cx);
-        let decision = decide_permission_from_settings(Self::NAME, &input.path, settings);
+        let mut decision = decide_permission_for_path(Self::NAME, &input.path, settings);
+        let sensitive_kind = sensitive_settings_kind(Path::new(&input.path));
+
+        if matches!(decision, ToolPermissionDecision::Allow)
+            && !settings.always_allow_tool_actions
+            && sensitive_kind.is_some()
+        {
+            decision = ToolPermissionDecision::Confirm;
+        }
 
         let authorize = match decision {
             ToolPermissionDecision::Allow => None,
@@ -79,34 +87,34 @@ impl AgentTool for CreateDirectoryTool {
                 return Task::ready(Err(anyhow!("{}", reason)));
             }
             ToolPermissionDecision::Confirm => {
+                let title = format!("Create directory {}", MarkdownInlineCode(&input.path));
+                let title = match &sensitive_kind {
+                    Some(SensitiveSettingsKind::Local) => format!("{title} (local settings)"),
+                    Some(SensitiveSettingsKind::Global) => format!("{title} (settings)"),
+                    None => title,
+                };
                 let context = crate::ToolPermissionContext {
                     tool_name: Self::NAME.to_string(),
                     input_value: input.path.clone(),
                 };
-                Some(event_stream.authorize(
-                    format!("Create directory {}", MarkdownInlineCode(&input.path)),
-                    context,
-                    cx,
-                ))
+                Some(event_stream.authorize(title, context, cx))
             }
         };
 
-        let project_path = match self.project.read(cx).find_project_path(&input.path, cx) {
-            Some(project_path) => project_path,
-            None => {
-                return Task::ready(Err(anyhow!("Path to create was outside the project")));
-            }
-        };
         let destination_path: Arc<str> = input.path.as_str().into();
 
-        let create_entry = self.project.update(cx, |project, cx| {
-            project.create_entry(project_path.clone(), true, cx)
-        });
-
-        cx.spawn(async move |_cx| {
+        let project = self.project.clone();
+        cx.spawn(async move |cx| {
             if let Some(authorize) = authorize {
                 authorize.await?;
             }
+
+            let create_entry = project.update(cx, |project, cx| {
+                match project.find_project_path(&input.path, cx) {
+                    Some(project_path) => Ok(project.create_entry(project_path, true, cx)),
+                    None => Err(anyhow!("Path to create was outside the project")),
+                }
+            })?;
 
             futures::select! {
                 result = create_entry.fuse() => {

--- a/crates/agent/src/tools/delete_path_tool.rs
+++ b/crates/agent/src/tools/delete_path_tool.rs
@@ -1,6 +1,7 @@
-use crate::{
-    AgentTool, ToolCallEventStream, ToolPermissionDecision, decide_permission_from_settings,
+use super::edit_file_tool::{
+    SensitiveSettingsKind, is_sensitive_settings_path, sensitive_settings_kind,
 };
+use crate::{AgentTool, ToolCallEventStream, ToolPermissionDecision, decide_permission_for_path};
 use action_log::ActionLog;
 use agent_client_protocol::ToolKind;
 use agent_settings::AgentSettings;
@@ -11,6 +12,7 @@ use project::{Project, ProjectPath};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::Settings;
+use std::path::Path;
 use std::sync::Arc;
 use util::markdown::MarkdownInlineCode;
 
@@ -76,7 +78,14 @@ impl AgentTool for DeletePathTool {
         let path = input.path;
 
         let settings = AgentSettings::get_global(cx);
-        let decision = decide_permission_from_settings(Self::NAME, &path, settings);
+        let mut decision = decide_permission_for_path(Self::NAME, &path, settings);
+
+        if matches!(decision, ToolPermissionDecision::Allow)
+            && !settings.always_allow_tool_actions
+            && is_sensitive_settings_path(Path::new(&path))
+        {
+            decision = ToolPermissionDecision::Confirm;
+        }
 
         let authorize = match decision {
             ToolPermissionDecision::Allow => None,
@@ -88,52 +97,15 @@ impl AgentTool for DeletePathTool {
                     tool_name: Self::NAME.to_string(),
                     input_value: path.clone(),
                 };
-                Some(event_stream.authorize(
-                    format!("Delete {}", MarkdownInlineCode(&path)),
-                    context,
-                    cx,
-                ))
+                let title = format!("Delete {}", MarkdownInlineCode(&path));
+                let title = match sensitive_settings_kind(Path::new(&path)) {
+                    Some(SensitiveSettingsKind::Local) => format!("{title} (local settings)"),
+                    Some(SensitiveSettingsKind::Global) => format!("{title} (settings)"),
+                    None => title,
+                };
+                Some(event_stream.authorize(title, context, cx))
             }
         };
-
-        let Some(project_path) = self.project.read(cx).find_project_path(&path, cx) else {
-            return Task::ready(Err(anyhow!(
-                "Couldn't delete {path} because that path isn't in this project."
-            )));
-        };
-
-        let Some(worktree) = self
-            .project
-            .read(cx)
-            .worktree_for_id(project_path.worktree_id, cx)
-        else {
-            return Task::ready(Err(anyhow!(
-                "Couldn't delete {path} because that path isn't in this project."
-            )));
-        };
-
-        let worktree_snapshot = worktree.read(cx).snapshot();
-        let (mut paths_tx, mut paths_rx) = mpsc::channel(256);
-        cx.background_spawn({
-            let project_path = project_path.clone();
-            async move {
-                for entry in
-                    worktree_snapshot.traverse_from_path(true, false, false, &project_path.path)
-                {
-                    if !entry.path.starts_with(&project_path.path) {
-                        break;
-                    }
-                    paths_tx
-                        .send(ProjectPath {
-                            worktree_id: project_path.worktree_id,
-                            path: entry.path.clone(),
-                        })
-                        .await?;
-                }
-                anyhow::Ok(())
-            }
-        })
-        .detach();
 
         let project = self.project.clone();
         let action_log = self.action_log.clone();
@@ -141,6 +113,41 @@ impl AgentTool for DeletePathTool {
             if let Some(authorize) = authorize {
                 authorize.await?;
             }
+
+            let (project_path, worktree_snapshot) = project.read_with(cx, |project, cx| {
+                let project_path = project.find_project_path(&path, cx).ok_or_else(|| {
+                    anyhow!("Couldn't delete {path} because that path isn't in this project.")
+                })?;
+                let worktree = project
+                    .worktree_for_id(project_path.worktree_id, cx)
+                    .ok_or_else(|| {
+                        anyhow!("Couldn't delete {path} because that path isn't in this project.")
+                    })?;
+                let worktree_snapshot = worktree.read(cx).snapshot();
+                anyhow::Ok((project_path, worktree_snapshot))
+            })?;
+
+            let (mut paths_tx, mut paths_rx) = mpsc::channel(256);
+            cx.background_spawn({
+                let project_path = project_path.clone();
+                async move {
+                    for entry in
+                        worktree_snapshot.traverse_from_path(true, false, false, &project_path.path)
+                    {
+                        if !entry.path.starts_with(&project_path.path) {
+                            break;
+                        }
+                        paths_tx
+                            .send(ProjectPath {
+                                worktree_id: project_path.worktree_id,
+                                path: entry.path.clone(),
+                            })
+                            .await?;
+                    }
+                    anyhow::Ok(())
+                }
+            })
+            .detach();
 
             loop {
                 let path_result = futures::select! {

--- a/crates/agent/src/tools/edit_file_tool.rs
+++ b/crates/agent/src/tools/edit_file_tool.rs
@@ -2,7 +2,7 @@ use super::restore_file_from_disk_tool::RestoreFileFromDiskTool;
 use super::save_file_tool::SaveFileTool;
 use crate::{
     AgentTool, Templates, Thread, ToolCallEventStream, ToolPermissionDecision,
-    decide_permission_from_settings,
+    decide_permission_for_path,
     edit_agent::{EditAgent, EditAgentOutput, EditAgentOutputEvent, EditFormat},
 };
 use acp_thread::Diff;
@@ -161,72 +161,139 @@ impl EditFileTool {
         event_stream: &ToolCallEventStream,
         cx: &mut App,
     ) -> Task<Result<()>> {
-        let path_str = input.path.to_string_lossy();
-        let settings = agent_settings::AgentSettings::get_global(cx);
-        let decision = decide_permission_from_settings(Self::NAME, &path_str, settings);
+        authorize_file_edit(
+            Self::NAME,
+            &input.path,
+            &input.display_description,
+            &self.thread,
+            event_stream,
+            cx,
+        )
+    }
+}
 
-        match decision {
-            ToolPermissionDecision::Allow => return Task::ready(Ok(())),
-            ToolPermissionDecision::Deny(reason) => {
-                return Task::ready(Err(anyhow!("{}", reason)));
+pub enum SensitiveSettingsKind {
+    Local,
+    Global,
+}
+
+/// Returns the kind of sensitive settings location this path targets, if any:
+/// either inside a `.zed/` local-settings directory or inside the global config dir.
+pub fn sensitive_settings_kind(path: &Path) -> Option<SensitiveSettingsKind> {
+    let local_settings_folder = paths::local_settings_folder_name();
+    if path.components().any(|component| {
+        component.as_os_str() == <_ as AsRef<OsStr>>::as_ref(&local_settings_folder)
+    }) {
+        return Some(SensitiveSettingsKind::Local);
+    }
+
+    // Walk up the path hierarchy until we find an ancestor that exists and can
+    // be canonicalized, then reconstruct the path from there. This handles
+    // cases where multiple levels of subdirectories don't exist yet (e.g.
+    // ~/.config/zed/new_subdir/evil.json).
+    let canonical_path = {
+        let mut current: Option<&Path> = Some(path);
+        let mut suffix_components = Vec::new();
+        loop {
+            match current {
+                Some(ancestor) => match std::fs::canonicalize(ancestor) {
+                    Ok(canonical) => {
+                        let mut result = canonical;
+                        for component in suffix_components.into_iter().rev() {
+                            result.push(component);
+                        }
+                        break Some(result);
+                    }
+                    Err(_) => {
+                        if let Some(file_name) = ancestor.file_name() {
+                            suffix_components.push(file_name.to_os_string());
+                        }
+                        current = ancestor.parent();
+                    }
+                },
+                None => break None,
             }
-            ToolPermissionDecision::Confirm => {}
         }
+    };
+    if let Some(canonical_path) = canonical_path {
+        let config_dir = std::fs::canonicalize(paths::config_dir())
+            .unwrap_or_else(|_| paths::config_dir().to_path_buf());
+        if canonical_path.starts_with(&config_dir) {
+            return Some(SensitiveSettingsKind::Global);
+        }
+    }
 
-        // If any path component matches the local settings folder, then this could affect
-        // the editor in ways beyond the project source, so prompt.
-        let local_settings_folder = paths::local_settings_folder_name();
-        let path = Path::new(&input.path);
-        if path.components().any(|component| {
-            component.as_os_str() == <_ as AsRef<OsStr>>::as_ref(&local_settings_folder)
-        }) {
+    None
+}
+
+pub fn is_sensitive_settings_path(path: &Path) -> bool {
+    sensitive_settings_kind(path).is_some()
+}
+
+pub fn authorize_file_edit(
+    tool_name: &str,
+    path: &Path,
+    display_description: &str,
+    thread: &WeakEntity<Thread>,
+    event_stream: &ToolCallEventStream,
+    cx: &mut App,
+) -> Task<Result<()>> {
+    let path_str = path.to_string_lossy();
+    let settings = agent_settings::AgentSettings::get_global(cx);
+    let decision = decide_permission_for_path(tool_name, &path_str, settings);
+
+    if let ToolPermissionDecision::Deny(reason) = decision {
+        return Task::ready(Err(anyhow!("{}", reason)));
+    }
+
+    let explicitly_allowed = matches!(decision, ToolPermissionDecision::Allow);
+
+    if explicitly_allowed
+        && (settings.always_allow_tool_actions || !is_sensitive_settings_path(path))
+    {
+        return Task::ready(Ok(()));
+    }
+
+    match sensitive_settings_kind(path) {
+        Some(SensitiveSettingsKind::Local) => {
             let context = crate::ToolPermissionContext {
-                tool_name: Self::NAME.to_string(),
+                tool_name: tool_name.to_string(),
                 input_value: path_str.to_string(),
             };
             return event_stream.authorize(
-                format!("{} (local settings)", input.display_description),
+                format!("{} (local settings)", display_description),
                 context,
                 cx,
             );
         }
-
-        // It's also possible that the global config dir is configured to be inside the project,
-        // so check for that edge case too.
-        // TODO this is broken when remoting
-        if let Ok(canonical_path) = std::fs::canonicalize(&input.path)
-            && canonical_path.starts_with(paths::config_dir())
-        {
+        Some(SensitiveSettingsKind::Global) => {
             let context = crate::ToolPermissionContext {
-                tool_name: Self::NAME.to_string(),
+                tool_name: tool_name.to_string(),
                 input_value: path_str.to_string(),
             };
             return event_stream.authorize(
-                format!("{} (global settings)", input.display_description),
+                format!("{} (settings)", display_description),
                 context,
                 cx,
             );
         }
+        None => {}
+    }
 
-        // Check if path is inside the global config directory
-        // First check if it's already inside project - if not, try to canonicalize
-        let Ok(project_path) = self.thread.read_with(cx, |thread, cx| {
-            thread.project().read(cx).find_project_path(&input.path, cx)
-        }) else {
-            return Task::ready(Err(anyhow!("thread was dropped")));
+    let Ok(project_path) = thread.read_with(cx, |thread, cx| {
+        thread.project().read(cx).find_project_path(path, cx)
+    }) else {
+        return Task::ready(Err(anyhow!("thread was dropped")));
+    };
+
+    if project_path.is_some() {
+        Task::ready(Ok(()))
+    } else {
+        let context = crate::ToolPermissionContext {
+            tool_name: tool_name.to_string(),
+            input_value: path_str.to_string(),
         };
-
-        // If the path is inside the project, and it's not one of the above edge cases,
-        // then no confirmation is necessary. Otherwise, confirmation is necessary.
-        if project_path.is_some() {
-            Task::ready(Ok(()))
-        } else {
-            let context = crate::ToolPermissionContext {
-                tool_name: Self::NAME.to_string(),
-                input_value: path_str.to_string(),
-            };
-            event_stream.authorize(&input.display_description, context, cx)
-        }
+        event_stream.authorize(display_description, context, cx)
     }
 }
 
@@ -2281,6 +2348,44 @@ mod tests {
             error_msg.contains("save or revert the file manually"),
             "Error should ask user to manually save or revert when tools aren't available, got: {}",
             error_msg
+        );
+    }
+
+    #[test]
+    fn test_sensitive_settings_kind_detects_nonexistent_subdirectory() {
+        let config_dir = paths::config_dir();
+        let path = config_dir.join("nonexistent_subdir_xyz").join("evil.json");
+        assert!(
+            matches!(
+                sensitive_settings_kind(&path),
+                Some(SensitiveSettingsKind::Global)
+            ),
+            "Path in non-existent subdirectory of config dir should be detected as sensitive: {:?}",
+            path
+        );
+    }
+
+    #[test]
+    fn test_sensitive_settings_kind_detects_deeply_nested_nonexistent_subdirectory() {
+        let config_dir = paths::config_dir();
+        let path = config_dir.join("a").join("b").join("c").join("evil.json");
+        assert!(
+            matches!(
+                sensitive_settings_kind(&path),
+                Some(SensitiveSettingsKind::Global)
+            ),
+            "Path in deeply nested non-existent subdirectory of config dir should be detected as sensitive: {:?}",
+            path
+        );
+    }
+
+    #[test]
+    fn test_sensitive_settings_kind_returns_none_for_non_config_path() {
+        let path = PathBuf::from("/tmp/not_a_config_dir/some_file.json");
+        assert!(
+            sensitive_settings_kind(&path).is_none(),
+            "Path outside config dir should not be detected as sensitive: {:?}",
+            path
         );
     }
 }

--- a/crates/agent/src/tools/move_path_tool.rs
+++ b/crates/agent/src/tools/move_path_tool.rs
@@ -1,11 +1,12 @@
-use crate::{
-    AgentTool, ToolCallEventStream, ToolPermissionDecision, decide_permission_from_settings,
+use super::edit_file_tool::{
+    SensitiveSettingsKind, is_sensitive_settings_path, sensitive_settings_kind,
 };
+use crate::{AgentTool, ToolCallEventStream, ToolPermissionDecision, decide_permission_for_path};
 use agent_client_protocol::ToolKind;
 use agent_settings::AgentSettings;
 use anyhow::{Context as _, Result, anyhow};
 use futures::FutureExt as _;
-use gpui::{App, AppContext, Entity, SharedString, Task};
+use gpui::{App, Entity, SharedString, Task};
 use project::Project;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -97,56 +98,70 @@ impl AgentTool for MovePathTool {
     ) -> Task<Result<Self::Output>> {
         let settings = AgentSettings::get_global(cx);
 
-        let source_decision =
-            decide_permission_from_settings(Self::NAME, &input.source_path, settings);
+        let source_decision = decide_permission_for_path(Self::NAME, &input.source_path, settings);
         if let ToolPermissionDecision::Deny(reason) = source_decision {
             return Task::ready(Err(anyhow!("{}", reason)));
         }
 
         let dest_decision =
-            decide_permission_from_settings(Self::NAME, &input.destination_path, settings);
+            decide_permission_for_path(Self::NAME, &input.destination_path, settings);
         if let ToolPermissionDecision::Deny(reason) = dest_decision {
             return Task::ready(Err(anyhow!("{}", reason)));
         }
 
         let needs_confirmation = matches!(source_decision, ToolPermissionDecision::Confirm)
-            || matches!(dest_decision, ToolPermissionDecision::Confirm);
+            || matches!(dest_decision, ToolPermissionDecision::Confirm)
+            || (!settings.always_allow_tool_actions
+                && matches!(source_decision, ToolPermissionDecision::Allow)
+                && is_sensitive_settings_path(Path::new(&input.source_path)))
+            || (!settings.always_allow_tool_actions
+                && matches!(dest_decision, ToolPermissionDecision::Allow)
+                && is_sensitive_settings_path(Path::new(&input.destination_path)));
 
         let authorize = if needs_confirmation {
             let src = MarkdownInlineCode(&input.source_path);
             let dest = MarkdownInlineCode(&input.destination_path);
             let context = crate::ToolPermissionContext {
                 tool_name: Self::NAME.to_string(),
-                input_value: input.source_path.clone(),
+                input_value: format!("{}\n{}", input.source_path, input.destination_path),
             };
-            Some(event_stream.authorize(format!("Move {src} to {dest}"), context, cx))
+            let title = format!("Move {src} to {dest}");
+            let settings_kind = sensitive_settings_kind(Path::new(&input.source_path))
+                .or_else(|| sensitive_settings_kind(Path::new(&input.destination_path)));
+            let title = match settings_kind {
+                Some(SensitiveSettingsKind::Local) => format!("{title} (local settings)"),
+                Some(SensitiveSettingsKind::Global) => format!("{title} (settings)"),
+                None => title,
+            };
+            Some(event_stream.authorize(title, context, cx))
         } else {
             None
         };
 
-        let rename_task = self.project.update(cx, |project, cx| {
-            match project
-                .find_project_path(&input.source_path, cx)
-                .and_then(|project_path| project.entry_for_path(&project_path, cx))
-            {
-                Some(entity) => match project.find_project_path(&input.destination_path, cx) {
-                    Some(project_path) => project.rename_entry(entity.id, project_path, cx),
-                    None => Task::ready(Err(anyhow!(
-                        "Destination path {} was outside the project.",
-                        input.destination_path
-                    ))),
-                },
-                None => Task::ready(Err(anyhow!(
-                    "Source path {} was not found in the project.",
-                    input.source_path
-                ))),
-            }
-        });
-
-        cx.background_spawn(async move {
+        let project = self.project.clone();
+        cx.spawn(async move |cx| {
             if let Some(authorize) = authorize {
                 authorize.await?;
             }
+
+            let rename_task = project.update(cx, |project, cx| {
+                match project
+                    .find_project_path(&input.source_path, cx)
+                    .and_then(|project_path| project.entry_for_path(&project_path, cx))
+                {
+                    Some(entity) => match project.find_project_path(&input.destination_path, cx) {
+                        Some(project_path) => Ok(project.rename_entry(entity.id, project_path, cx)),
+                        None => Err(anyhow!(
+                            "Destination path {} was outside the project.",
+                            input.destination_path
+                        )),
+                    },
+                    None => Err(anyhow!(
+                        "Source path {} was not found in the project.",
+                        input.source_path
+                    )),
+                }
+            })?;
 
             let result = futures::select! {
                 result = rename_task.fuse() => result,

--- a/crates/agent/src/tools/save_file_tool.rs
+++ b/crates/agent/src/tools/save_file_tool.rs
@@ -9,13 +9,32 @@ use project::Project;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::Settings;
-use std::path::PathBuf;
+use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 use util::markdown::MarkdownInlineCode;
 
-use crate::{
-    AgentTool, ToolCallEventStream, ToolPermissionDecision, decide_permission_from_settings,
+use super::edit_file_tool::{
+    SensitiveSettingsKind, is_sensitive_settings_path, sensitive_settings_kind,
 };
+use crate::{AgentTool, ToolCallEventStream, ToolPermissionDecision, decide_permission_for_path};
+
+fn common_parent_for_paths(paths: &[String]) -> Option<PathBuf> {
+    let first = paths.first()?;
+    let mut common: Vec<Component<'_>> = Path::new(first).parent()?.components().collect();
+    for path in &paths[1..] {
+        let parent: Vec<Component<'_>> = Path::new(path).parent()?.components().collect();
+        let prefix_len = common
+            .iter()
+            .zip(parent.iter())
+            .take_while(|(a, b)| a == b)
+            .count();
+        common.truncate(prefix_len);
+    }
+    if common.is_empty() {
+        return None;
+    }
+    Some(common.iter().collect())
+}
 
 /// Saves files that have unsaved changes.
 ///
@@ -66,53 +85,65 @@ impl AgentTool for SaveFileTool {
         cx: &mut App,
     ) -> Task<Result<String>> {
         let settings = AgentSettings::get_global(cx);
-        let mut needs_confirmation = false;
+        let mut confirmation_paths: Vec<String> = Vec::new();
 
         for path in &input.paths {
             let path_str = path.to_string_lossy();
-            let decision = decide_permission_from_settings(Self::NAME, &path_str, settings);
+            let decision = decide_permission_for_path(Self::NAME, &path_str, settings);
             match decision {
-                ToolPermissionDecision::Allow => {}
+                ToolPermissionDecision::Allow => {
+                    if !settings.always_allow_tool_actions
+                        && is_sensitive_settings_path(Path::new(&*path_str))
+                    {
+                        confirmation_paths.push(path_str.to_string());
+                    }
+                }
                 ToolPermissionDecision::Deny(reason) => {
                     return Task::ready(Err(anyhow::anyhow!("{}", reason)));
                 }
                 ToolPermissionDecision::Confirm => {
-                    needs_confirmation = true;
+                    confirmation_paths.push(path_str.to_string());
                 }
             }
         }
 
-        let authorize = if needs_confirmation {
-            let title = if input.paths.len() == 1 {
-                format!(
-                    "Save {}",
-                    MarkdownInlineCode(&input.paths[0].to_string_lossy())
-                )
+        let authorize = if !confirmation_paths.is_empty() {
+            let title = if confirmation_paths.len() == 1 {
+                format!("Save {}", MarkdownInlineCode(&confirmation_paths[0]))
             } else {
-                let paths: Vec<_> = input
-                    .paths
+                let paths: Vec<_> = confirmation_paths
                     .iter()
                     .take(3)
-                    .map(|p| p.to_string_lossy().to_string())
+                    .map(|p| p.as_str())
                     .collect();
-                if input.paths.len() > 3 {
+                if confirmation_paths.len() > 3 {
                     format!(
                         "Save {}, and {} more",
                         paths.join(", "),
-                        input.paths.len() - 3
+                        confirmation_paths.len() - 3
                     )
                 } else {
                     format!("Save {}", paths.join(", "))
                 }
             };
-            let first_path = input
-                .paths
-                .first()
-                .map(|p| p.to_string_lossy().to_string())
-                .unwrap_or_default();
+            let sensitive_kind = confirmation_paths
+                .iter()
+                .find_map(|p| sensitive_settings_kind(Path::new(p)));
+            let title = match sensitive_kind {
+                Some(SensitiveSettingsKind::Local) => format!("{title} (local settings)"),
+                Some(SensitiveSettingsKind::Global) => format!("{title} (settings)"),
+                None => title,
+            };
+            let input_value = if confirmation_paths.len() == 1 {
+                confirmation_paths[0].clone()
+            } else {
+                common_parent_for_paths(&confirmation_paths)
+                    .map(|parent| format!("{}/_", parent.display()))
+                    .unwrap_or_else(|| confirmation_paths[0].clone())
+            };
             let context = crate::ToolPermissionContext {
                 tool_name: Self::NAME.to_string(),
-                input_value: first_path,
+                input_value,
             };
             Some(event_stream.authorize(title, context, cx))
         } else {


### PR DESCRIPTION
This PR hardens the authorization flow for all file and directory tools.

## Sensitive settings protection

All file/directory tools (copy, move, create_directory, delete, save, edit, streaming_edit) now detect and protect sensitive settings paths:
- Paths inside `.zed/` directories (local settings)
- Paths inside the global config directory (`~/.config/zed/` or equivalent)

Even when the global default is `allow`, modifications to these paths require explicit confirmation. The authorization dialog title is annotated with "(local settings)" or "(settings)" to inform the user.

`sensitive_settings_kind` walks up ancestor directories to handle paths where intermediate subdirectories don't exist yet (e.g. `~/.config/zed/new_subdir/evil.json`).

## Deferred filesystem operations

Copy, move, create_directory, and delete tools now defer all project/filesystem operations until after the user authorizes the action. Previously, some tools began resolving project paths or traversing directories before authorization.

## streaming_edit_file permissions

`streaming_edit_file` now shares `edit_file`'s tool name for permission checks, ensuring consistent permission rules between the two edit tool variants. The duplicated authorization logic is replaced by a shared `authorize_file_edit` function.

## Copy/move pattern extraction

Copy and move tools now include both source and destination paths in their permission context (`input_value`). The always-allow pattern is extracted from the common parent directory of both paths, ensuring the pattern covers future checks against both.

## Save tool improvements

- Authorization title now shows only the paths that need confirmation, not all paths
- Title is annotated with "(local settings)" or "(settings)" for sensitive paths

Release Notes:

- File and directory tool operations now require confirmation before modifying sensitive settings paths.