### PR TITLE
languages: Add Doxygen language

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9276,6 +9276,7 @@ dependencies = [
  "tree-sitter-cpp",
  "tree-sitter-css",
  "tree-sitter-diff",
+ "tree-sitter-doxygen",
  "tree-sitter-gitcommit",
  "tree-sitter-go",
  "tree-sitter-gomod",
@@ -17794,6 +17795,15 @@ name = "tree-sitter-diff"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfe1e5ca280a65dfe5ba4205c1bcc84edf486464fed315db53dee6da9a335889"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-doxygen"
+version = "1.1.0"
+source = "git+https://github.com/amaanq/tree-sitter-doxygen?rev=d5f58fd027929692bae779c8f914cadace85fc5a#d5f58fd027929692bae779c8f914cadace85fc5a"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -695,6 +695,7 @@ tree-sitter-c = "0.24.1"
 tree-sitter-cpp = { git = "https://github.com/tree-sitter/tree-sitter-cpp", rev = "5cb9b693cfd7bfacab1d9ff4acac1a4150700609" }
 tree-sitter-css = "0.23"
 tree-sitter-diff = "0.1.0"
+tree-sitter-doxygen = { git = "https://github.com/amaanq/tree-sitter-doxygen", rev = "d5f58fd027929692bae779c8f914cadace85fc5a" }
 tree-sitter-elixir = "0.3"
 tree-sitter-embedded-template = "0.23.0"
 tree-sitter-gitcommit = { git = "https://github.com/zed-industries/tree-sitter-git-commit", rev = "88309716a69dd13ab83443721ba6e0b491d37ee9" }

--- a/crates/languages/Cargo.toml
+++ b/crates/languages/Cargo.toml
@@ -19,6 +19,7 @@ load-grammars = [
     "tree-sitter-cpp",
     "tree-sitter-css",
     "tree-sitter-diff",
+    "tree-sitter-doxygen",
     "tree-sitter-gitcommit",
     "tree-sitter-go",
     "tree-sitter-go-mod",
@@ -81,6 +82,7 @@ tree-sitter-c = { workspace = true, optional = true }
 tree-sitter-cpp = { workspace = true, optional = true }
 tree-sitter-css = { workspace = true, optional = true }
 tree-sitter-diff = { workspace = true, optional = true }
+tree-sitter-doxygen = { workspace = true, optional = true }
 tree-sitter-gitcommit = { workspace = true, optional = true }
 tree-sitter-go = { workspace = true, optional = true }
 tree-sitter-go-mod = { workspace = true, optional = true }

--- a/crates/languages/src/doxygen/config.toml
+++ b/crates/languages/src/doxygen/config.toml
@@ -1,0 +1,3 @@
+name = "Doxygen"
+grammar = "doxygen"
+hidden = true

--- a/crates/languages/src/doxygen/highlights.scm
+++ b/crates/languages/src/doxygen/highlights.scm
@@ -1,0 +1,19 @@
+[
+  (tag_name)
+  "@code"
+  "@endcode"
+  "in"
+  "out"
+  "inout"
+] @keyword
+
+[
+  (document)
+  (text)
+  (description)
+  (brief_description)
+  (brief_header)
+  (code_block_content)
+] @comment.doc
+
+(identifier) @variable

--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -67,6 +67,7 @@ pub fn init(languages: Arc<LanguageRegistry>, fs: Arc<dyn Fs>, node: NodeRuntime
         ("cpp", tree_sitter_cpp::LANGUAGE),
         ("css", tree_sitter_css::LANGUAGE),
         ("diff", tree_sitter_diff::LANGUAGE),
+        ("doxygen", tree_sitter_doxygen::LANGUAGE),
         ("go", tree_sitter_go::LANGUAGE),
         ("gomod", tree_sitter_go_mod::LANGUAGE),
         ("gowork", tree_sitter_gowork::LANGUAGE),
@@ -135,6 +136,10 @@ pub fn init(languages: Arc<LanguageRegistry>, fs: Arc<dyn Fs>, node: NodeRuntime
         LanguageInfo {
             name: "diff",
             adapters: vec![],
+            ..Default::default()
+        },
+        LanguageInfo {
+            name: "doxygen",
             ..Default::default()
         },
         LanguageInfo {


### PR DESCRIPTION
Closes #48569

Before:
<img width="731" height="375" alt="before" src="https://github.com/user-attachments/assets/27bbb0fb-3611-4d66-a540-72f5bcaa3e32" />

After:
<img width="731" height="375" alt="after" src="https://github.com/user-attachments/assets/d51487b4-d393-4b83-a79d-6ac7ce5aa80e" />

Doxygen injection patterns were added to c/cpp in #47556, but the doxygen language itself was not there. This PR adds highlighting support for Doxygen.

Release Notes:
- Added Doxygen language 
