### PR TITLE
Add markdown preview buffer event tests

### DIFF
--- a/crates/markdown_preview/Cargo.toml
+++ b/crates/markdown_preview/Cargo.toml
@@ -39,3 +39,4 @@ zed_actions.workspace = true
 [dev-dependencies]
 editor = { workspace = true, features = ["test-support"] }
 language = { workspace = true, features = ["test-support"] }
+project = { workspace = true, features = ["test-support"] }


### PR DESCRIPTION
Attempting #47900 

- [x] Tests or screenshots needed?
- [ ] Code Reviewed
- [ ] Manual QA

Release Notes:

- Trying to fix the markdown preview not updating dynamically on edits, still in draft mode. Although the behaviour might be intentional, i suspect the preview "Locks" or freezes if the raw file isnt open. Not ready to be merged yet, but open to suggestions.

AI disclosure: used codex for coding large parts of the PR