### PR TITLE
docs: Add theme ID suffix recommendation

### DIFF
--- a/docs/src/extensions/developing-extensions.md
+++ b/docs/src/extensions/developing-extensions.md
@@ -40,6 +40,8 @@ description = "My cool extension"
 repository = "https://github.com/your-name/my-zed-extension"
 ```
 
+> Note, for theme extensions, it is recommended that you suffix your theme's ID with `-theme`.
+
 In addition to this, there are several other optional files and directories that can be used to add functionality to a Zed extension. An example directory structure of an extension that provides all capabilities is as follows:
 
 ```

--- a/docs/src/extensions/developing-extensions.md
+++ b/docs/src/extensions/developing-extensions.md
@@ -40,7 +40,7 @@ description = "My cool extension"
 repository = "https://github.com/your-name/my-zed-extension"
 ```
 
-> Note, for theme extensions, it is recommended that you suffix your theme's ID with `-theme`.
+> Note: If you are working on a theme extension with the intend of publishing it later, is is recommended that you suffix your theme's extension ID with `-theme`. This might otherwise be raised during the process of [releasing your extension](#publishing-your-extension).
 
 In addition to this, there are several other optional files and directories that can be used to add functionality to a Zed extension. An example directory structure of an extension that provides all capabilities is as follows:
 


### PR DESCRIPTION
Added note about suffixing theme IDs with '-theme' for clarity.

As discussed in https://github.com/zed-industries/extensions/pull/4693#pullrequestreview-3751636461

- [ ] ~Tests or screenshots needed?~
- [x] Code Reviewed
- [ ] ~Manual QA~

Release Notes:

- Clarified theme ID suffixing in extension docs
