### PR TITLE
language: Return early if no grammars are added

### DIFF
--- a/crates/language/src/language_registry.rs
+++ b/crates/language/src/language_registry.rs
@@ -552,15 +552,16 @@ impl LanguageRegistry {
     }
 
     /// Adds paths to WASM grammar files, which can be loaded if needed.
-    pub fn register_wasm_grammars(
-        &self,
-        grammars: impl IntoIterator<Item = (impl Into<Arc<str>>, PathBuf)>,
-    ) {
+    pub fn register_wasm_grammars(&self, grammars: Vec<(Arc<str>, PathBuf)>) {
+        if grammars.is_empty() {
+            return;
+        }
+
         let mut state = self.state.write();
         state.grammars.extend(
             grammars
                 .into_iter()
-                .map(|(name, path)| (name.into(), AvailableGrammar::Unloaded(path))),
+                .map(|(name, path)| (name, AvailableGrammar::Unloaded(path))),
         );
         state.version += 1;
         state.reload_count += 1;


### PR DESCRIPTION
Helps #48601

Whenever an extension is installed, we call `register_grammars` even when the grammar list is empty. This unnecessarily increments reload_count and notifies the LSP store, which clears all languages and triggers a full reparse.

Clearing languages also emits `LanguageChanged` events for buffers, causing the editor to perform expensive recomputations (like https://github.com/zed-industries/zed/pull/48622) which can block the main thread for large multibuffers.

This PR addresses the empty-grammar case. If an extension actually adds a grammar, the underlying issue still exists and will require additional fixes to fully resolve.

- [ ] Tests or screenshots needed?
- [x] Code Reviewed
- [ ] Manual QA

Release Notes:

- Fixed an issue where installing theme extensions could block the main thread
