### PR TITLE
worktree: Include file size in DiskState to fix stale buffer reload

### DIFF
--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -1780,6 +1780,7 @@ mod tests {
         fn disk_state(&self) -> language::DiskState {
             language::DiskState::Present {
                 mtime: ::fs::MTime::from_seconds_and_nanos(100, 42),
+                size: 0,
             }
         }
 

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -435,7 +435,7 @@ pub enum DiskState {
     /// File created in Zed that has not been saved.
     New,
     /// File present on the filesystem.
-    Present { mtime: MTime },
+    Present { mtime: MTime, size: u64 },
     /// Deleted file that was previously present.
     Deleted,
     /// An old version of a file that was previously present
@@ -448,7 +448,7 @@ impl DiskState {
     pub fn mtime(self) -> Option<MTime> {
         match self {
             DiskState::New => None,
-            DiskState::Present { mtime } => Some(mtime),
+            DiskState::Present { mtime, .. } => Some(mtime),
             DiskState::Deleted => None,
             DiskState::Historic { .. } => None,
         }
@@ -2373,7 +2373,7 @@ impl Buffer {
         };
         match file.disk_state() {
             DiskState::New => false,
-            DiskState::Present { mtime } => match self.saved_mtime {
+            DiskState::Present { mtime, .. } => match self.saved_mtime {
                 Some(saved_mtime) => {
                     mtime.bad_is_greater_than(saved_mtime) && self.has_unsaved_edits()
                 }

--- a/crates/project/src/buffer_store.rs
+++ b/crates/project/src/buffer_store.rs
@@ -532,7 +532,10 @@ impl LocalBufferStore {
             let new_file = if let Some(entry) = snapshot_entry {
                 File {
                     disk_state: match entry.mtime {
-                        Some(mtime) => DiskState::Present { mtime },
+                        Some(mtime) => DiskState::Present {
+                            mtime,
+                            size: entry.size,
+                        },
                         None => old_file.disk_state,
                     },
                     is_local: true,

--- a/crates/project/src/image_store.rs
+++ b/crates/project/src/image_store.rs
@@ -808,7 +808,10 @@ impl LocalImageStore {
             let new_file = if let Some(entry) = snapshot_entry {
                 worktree::File {
                     disk_state: match entry.mtime {
-                        Some(mtime) => DiskState::Present { mtime },
+                        Some(mtime) => DiskState::Present {
+                            mtime,
+                            size: entry.size,
+                        },
                         None => old_file.disk_state,
                     },
                     is_local: true,

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -12249,3 +12249,155 @@ mod disable_ai_settings_tests {
         });
     }
 }
+
+#[gpui::test]
+async fn test_buffer_reload_during_truncate_then_write(cx: &mut gpui::TestAppContext) {
+    // Reproduces the truncate-then-write race condition from #38109.
+    //
+    // When an AI agent (Claude Code, Cursor, etc.) writes a file, the typical
+    // pattern is File::create() (which truncates to 0 bytes) followed by write_all().
+    // If Zed's scanner processes the truncation event before the write completes,
+    // the buffer reloads to empty and may become permanently stuck.
+    //
+    // We reproduce this deterministically on a real filesystem by:
+    // 1. Truncating the file to empty
+    // 2. Forcing scanner to process (flush_fs_events) → buffer reloads to empty
+    // 3. Writing new content but resetting mtime to match the truncated file's mtime
+    // 4. Flushing again → scanner sees same mtime but different size → buffer recovers
+    use worktree::WorktreeModelHandle as _;
+
+    init_test(cx);
+    cx.executor().allow_parking();
+
+    let dir = TempTree::new(json!({
+        "file.txt": "original content that should not be lost",
+    }));
+
+    let project =
+        Project::test(Arc::new(RealFs::new(None, cx.executor())), [dir.path()], cx).await;
+    let tree = project.update(cx, |project, cx| project.worktrees(cx).next().unwrap());
+    tree.flush_fs_events(cx).await;
+
+    let buffer = project
+        .update(cx, |p, cx| p.open_local_buffer(dir.path().join("file.txt"), cx))
+        .await
+        .unwrap();
+
+    buffer.read_with(cx, |buffer, _| {
+        assert_eq!(buffer.text(), "original content that should not be lost");
+        assert!(!buffer.is_dirty());
+    });
+
+    let file_path = dir.path().join("file.txt");
+
+    // Step 1: Truncate the file to empty (simulating the first half of an agent write).
+    // An AI agent's File::create() does exactly this — opens with O_TRUNC.
+    std::fs::write(&file_path, "").unwrap();
+
+    // Capture the mtime of the truncated (empty) file.
+    let truncated_mtime = std::fs::metadata(&file_path).unwrap().modified().unwrap();
+
+    // Step 2: Force the scanner to process this truncation event.
+    // This simulates the race where FSEvents delivers the truncation before the write.
+    tree.flush_fs_events(cx).await;
+
+    // The buffer should now be empty — it reloaded the 0-byte file.
+    buffer.read_with(cx, |buffer, _| {
+        assert_eq!(
+            buffer.text(),
+            "",
+            "buffer should be empty after reloading truncated file"
+        );
+    });
+
+    // Step 3: Write the actual content (the second half of the agent write).
+    std::fs::write(&file_path, "new content from AI agent").unwrap();
+
+    // Step 4: Reset the file's mtime to match the truncated file's mtime.
+    // This simulates the scenario where both the truncation and write happen
+    // within the same mtime granularity (same timestamp). On a busy system with
+    // coarse-grained timestamps, or when the OS doesn't update mtime for rapid
+    // writes, this is how the race manifests.
+    let times = std::fs::FileTimes::new().set_modified(truncated_mtime);
+    let file_handle = std::fs::File::options()
+        .write(true)
+        .open(&file_path)
+        .unwrap();
+    file_handle.set_times(times).unwrap();
+    drop(file_handle);
+
+    // Step 5: Force scanner to process the write event.
+    tree.flush_fs_events(cx).await;
+
+    // With the fix (size in DiskState::Present), the scanner sees the file size
+    // changed from 0 to 25 bytes even though mtime is the same. This triggers
+    // ReloadNeeded and the buffer recovers.
+    buffer.read_with(cx, |buffer, _| {
+        let file = buffer.file().expect("buffer should have a file");
+        assert!(
+            matches!(file.disk_state(), DiskState::Present { .. }),
+            "disk state should be Present, got {:?}",
+            file.disk_state()
+        );
+
+        assert_eq!(
+            buffer.text(),
+            "new content from AI agent",
+            "buffer should recover after truncate-then-write even with same mtime, \
+             because DiskState::Present now includes file size"
+        );
+    });
+}
+
+#[gpui::test]
+async fn test_buffer_recovers_from_truncate_when_mtime_differs(cx: &mut gpui::TestAppContext) {
+    // Control test for test_buffer_reload_during_truncate_then_write.
+    // Same truncate-then-write sequence, but WITHOUT resetting the mtime.
+    // With distinct mtimes (which APFS nanosecond precision provides), the
+    // scanner detects the change and the buffer recovers.
+    use worktree::WorktreeModelHandle as _;
+
+    init_test(cx);
+    cx.executor().allow_parking();
+
+    let dir = TempTree::new(json!({
+        "file.txt": "original content",
+    }));
+
+    let project =
+        Project::test(Arc::new(RealFs::new(None, cx.executor())), [dir.path()], cx).await;
+    let tree = project.update(cx, |project, cx| project.worktrees(cx).next().unwrap());
+    tree.flush_fs_events(cx).await;
+
+    let buffer = project
+        .update(cx, |p, cx| p.open_local_buffer(dir.path().join("file.txt"), cx))
+        .await
+        .unwrap();
+
+    buffer.read_with(cx, |buffer, _| {
+        assert_eq!(buffer.text(), "original content");
+    });
+
+    let file_path = dir.path().join("file.txt");
+
+    // Truncate
+    std::fs::write(&file_path, "").unwrap();
+    tree.flush_fs_events(cx).await;
+
+    buffer.read_with(cx, |buffer, _| {
+        assert_eq!(buffer.text(), "", "buffer should be empty after truncation");
+    });
+
+    // Write new content (mtime will naturally differ on APFS)
+    std::fs::write(&file_path, "recovered content").unwrap();
+    tree.flush_fs_events(cx).await;
+
+    // With a different mtime, the scanner detects the change and triggers reload.
+    buffer.read_with(cx, |buffer, _| {
+        assert_eq!(
+            buffer.text(),
+            "recovered content",
+            "buffer should recover when mtime differs after truncate-then-write"
+        );
+    });
+}

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -12252,18 +12252,9 @@ mod disable_ai_settings_tests {
 
 #[gpui::test]
 async fn test_buffer_reload_during_truncate_then_write(cx: &mut gpui::TestAppContext) {
-    // Reproduces the truncate-then-write race condition from #38109.
-    //
-    // When an AI agent (Claude Code, Cursor, etc.) writes a file, the typical
-    // pattern is File::create() (which truncates to 0 bytes) followed by write_all().
-    // If Zed's scanner processes the truncation event before the write completes,
-    // the buffer reloads to empty and may become permanently stuck.
-    //
-    // We reproduce this deterministically on a real filesystem by:
-    // 1. Truncating the file to empty
-    // 2. Forcing scanner to process (flush_fs_events) → buffer reloads to empty
-    // 3. Writing new content but resetting mtime to match the truncated file's mtime
-    // 4. Flushing again → scanner sees same mtime but different size → buffer recovers
+    // Reproduces #38109: scanner catches a truncated file mid-write,
+    // buffer reloads to empty, and the final write has the same mtime.
+    // Without size in DiskState, the buffer stays stuck empty.
     use worktree::WorktreeModelHandle as _;
 
     init_test(cx);
@@ -12273,13 +12264,14 @@ async fn test_buffer_reload_during_truncate_then_write(cx: &mut gpui::TestAppCon
         "file.txt": "original content that should not be lost",
     }));
 
-    let project =
-        Project::test(Arc::new(RealFs::new(None, cx.executor())), [dir.path()], cx).await;
+    let project = Project::test(Arc::new(RealFs::new(None, cx.executor())), [dir.path()], cx).await;
     let tree = project.update(cx, |project, cx| project.worktrees(cx).next().unwrap());
     tree.flush_fs_events(cx).await;
 
     let buffer = project
-        .update(cx, |p, cx| p.open_local_buffer(dir.path().join("file.txt"), cx))
+        .update(cx, |p, cx| {
+            p.open_local_buffer(dir.path().join("file.txt"), cx)
+        })
         .await
         .unwrap();
 
@@ -12290,18 +12282,13 @@ async fn test_buffer_reload_during_truncate_then_write(cx: &mut gpui::TestAppCon
 
     let file_path = dir.path().join("file.txt");
 
-    // Step 1: Truncate the file to empty (simulating the first half of an agent write).
-    // An AI agent's File::create() does exactly this — opens with O_TRUNC.
+    // Truncate the file (first half of std::fs::write).
     std::fs::write(&file_path, "").unwrap();
-
-    // Capture the mtime of the truncated (empty) file.
     let truncated_mtime = std::fs::metadata(&file_path).unwrap().modified().unwrap();
 
-    // Step 2: Force the scanner to process this truncation event.
-    // This simulates the race where FSEvents delivers the truncation before the write.
+    // Scanner picks up the truncation.
     tree.flush_fs_events(cx).await;
 
-    // The buffer should now be empty — it reloaded the 0-byte file.
     buffer.read_with(cx, |buffer, _| {
         assert_eq!(
             buffer.text(),
@@ -12310,14 +12297,11 @@ async fn test_buffer_reload_during_truncate_then_write(cx: &mut gpui::TestAppCon
         );
     });
 
-    // Step 3: Write the actual content (the second half of the agent write).
+    // Write actual content (second half of std::fs::write).
     std::fs::write(&file_path, "new content from AI agent").unwrap();
 
-    // Step 4: Reset the file's mtime to match the truncated file's mtime.
-    // This simulates the scenario where both the truncation and write happen
-    // within the same mtime granularity (same timestamp). On a busy system with
-    // coarse-grained timestamps, or when the OS doesn't update mtime for rapid
-    // writes, this is how the race manifests.
+    // Force mtime to match the truncated file's mtime, simulating
+    // coarse-grained timestamps or rapid sequential writes.
     let times = std::fs::FileTimes::new().set_modified(truncated_mtime);
     let file_handle = std::fs::File::options()
         .write(true)
@@ -12326,12 +12310,9 @@ async fn test_buffer_reload_during_truncate_then_write(cx: &mut gpui::TestAppCon
     file_handle.set_times(times).unwrap();
     drop(file_handle);
 
-    // Step 5: Force scanner to process the write event.
     tree.flush_fs_events(cx).await;
 
-    // With the fix (size in DiskState::Present), the scanner sees the file size
-    // changed from 0 to 25 bytes even though mtime is the same. This triggers
-    // ReloadNeeded and the buffer recovers.
+    // Size changed (0 -> 25 bytes) even though mtime is the same.
     buffer.read_with(cx, |buffer, _| {
         let file = buffer.file().expect("buffer should have a file");
         assert!(
@@ -12343,18 +12324,16 @@ async fn test_buffer_reload_during_truncate_then_write(cx: &mut gpui::TestAppCon
         assert_eq!(
             buffer.text(),
             "new content from AI agent",
-            "buffer should recover after truncate-then-write even with same mtime, \
-             because DiskState::Present now includes file size"
+            "buffer should recover when size changes even if mtime matches"
         );
     });
 }
 
 #[gpui::test]
 async fn test_buffer_recovers_from_truncate_when_mtime_differs(cx: &mut gpui::TestAppContext) {
-    // Control test for test_buffer_reload_during_truncate_then_write.
-    // Same truncate-then-write sequence, but WITHOUT resetting the mtime.
-    // With distinct mtimes (which APFS nanosecond precision provides), the
-    // scanner detects the change and the buffer recovers.
+    // Control: same sequence without forcing mtime to match.
+    // APFS nanosecond precision means the mtime naturally differs,
+    // so the buffer recovers without the size fix.
     use worktree::WorktreeModelHandle as _;
 
     init_test(cx);
@@ -12364,13 +12343,14 @@ async fn test_buffer_recovers_from_truncate_when_mtime_differs(cx: &mut gpui::Te
         "file.txt": "original content",
     }));
 
-    let project =
-        Project::test(Arc::new(RealFs::new(None, cx.executor())), [dir.path()], cx).await;
+    let project = Project::test(Arc::new(RealFs::new(None, cx.executor())), [dir.path()], cx).await;
     let tree = project.update(cx, |project, cx| project.worktrees(cx).next().unwrap());
     tree.flush_fs_events(cx).await;
 
     let buffer = project
-        .update(cx, |p, cx| p.open_local_buffer(dir.path().join("file.txt"), cx))
+        .update(cx, |p, cx| {
+            p.open_local_buffer(dir.path().join("file.txt"), cx)
+        })
         .await
         .unwrap();
 
@@ -12392,7 +12372,7 @@ async fn test_buffer_recovers_from_truncate_when_mtime_differs(cx: &mut gpui::Te
     std::fs::write(&file_path, "recovered content").unwrap();
     tree.flush_fs_events(cx).await;
 
-    // With a different mtime, the scanner detects the change and triggers reload.
+    // Different mtime triggers reload via the existing path.
     buffer.read_with(cx, |buffer, _| {
         assert_eq!(
             buffer.text(),

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -1322,6 +1322,7 @@ impl LocalWorktree {
                         path,
                         disk_state: DiskState::Present {
                             mtime: metadata.mtime,
+                            size: metadata.len,
                         },
                         is_local: true,
                         is_private,
@@ -1378,6 +1379,7 @@ impl LocalWorktree {
                         path,
                         disk_state: DiskState::Present {
                             mtime: metadata.mtime,
+                            size: metadata.len,
                         },
                         is_local: true,
                         is_private,
@@ -1575,6 +1577,7 @@ impl LocalWorktree {
                     path,
                     disk_state: DiskState::Present {
                         mtime: metadata.mtime,
+                        size: metadata.len,
                     },
                     entry_id: None,
                     is_local: true,
@@ -3280,7 +3283,10 @@ impl File {
             worktree,
             path: entry.path.clone(),
             disk_state: if let Some(mtime) = entry.mtime {
-                DiskState::Present { mtime }
+                DiskState::Present {
+                    mtime,
+                    size: entry.size,
+                }
             } else {
                 DiskState::New
             },
@@ -3309,7 +3315,7 @@ impl File {
         } else if proto.is_deleted {
             DiskState::Deleted
         } else if let Some(mtime) = proto.mtime.map(&Into::into) {
-            DiskState::Present { mtime }
+            DiskState::Present { mtime, size: 0 }
         } else {
             DiskState::New
         };

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -3315,6 +3315,8 @@ impl File {
         } else if proto.is_deleted {
             DiskState::Deleted
         } else if let Some(mtime) = proto.mtime.map(&Into::into) {
+            // Size is not sent over the wire. Remote buffers don't make
+            // local reload decisions so this is unused in practice.
             DiskState::Present { mtime, size: 0 }
         } else {
             DiskState::New


### PR DESCRIPTION
Related to #38109

When an external tool writes a file using `std::fs::write()` (truncate + write), the scanner can read the 0-byte file during the truncation window. The buffer reloads to empty. If the subsequent write produces the same mtime, `file_updated()` sees no `DiskState` change and never triggers a second reload. The buffer is permanently stuck empty.

Adds `size: u64` to `DiskState::Present { mtime, size }`. The derived `PartialEq` now detects size changes even when mtime matches, so a 0→N byte transition always triggers `ReloadNeeded`. The scanner already tracks file size in `Entry.size`, this threads it through `File::for_entry()` and `local_worktree_entry_changed()` into the reload comparison.

Remote/collab callers pass `size: 0` since remote buffers don't make local reload decisions (the reload path checks `!self.is_via_collab()`).

Root cause analysis: https://github.com/zed-industries/zed/issues/38109#issuecomment-3865011551

Related issues:
- Fixes #48439
- May improve #20872, #15791, #43990

Note: the two RealFs tests use `allow_parking()` + `flush_fs_events()` and must be run individually (`--exact`), not in parallel with other RealFs tests. This matches the existing pattern in the crate.

- [x] Tests
- [ ] Code Reviewed
- [ ] Manual QA

Release Notes:

- Fixed an issue where open buffers could become permanently empty when external tools (AI agents, formatters) wrote files while they were open in the editor.