### PR TITLE
buffer: Reload after undo when file changed while dirty

### DIFF
--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -2848,8 +2848,18 @@ impl Buffer {
 
         self.reparse(cx, true);
         cx.emit(BufferEvent::Edited);
-        if was_dirty != self.is_dirty() {
+        let is_dirty = self.is_dirty();
+        if was_dirty != is_dirty {
             cx.emit(BufferEvent::DirtyChanged);
+        }
+        if was_dirty && !is_dirty {
+            if let Some(file) = self.file.as_ref() {
+                if matches!(file.disk_state(), DiskState::Present { .. })
+                    && file.disk_state().mtime() != self.saved_mtime
+                {
+                    cx.emit(BufferEvent::ReloadNeeded);
+                }
+            }
         }
         cx.notify();
     }


### PR DESCRIPTION
Fixes #48697

## Problem

If you edit a file and an external tool writes to it while you have unsaved changes, Zed tracks the new file but skips the reload to preserve your edits. If you then undo everything, the buffer goes back to clean but still shows the old content. The disk has moved on, but nothing triggers a reload.

Part of #38109. Discovered during research for #48691.

## Fix

In `did_edit()`, when the buffer transitions from dirty to clean, check if the file's mtime changed while it was dirty. If so, emit `ReloadNeeded`. Only fires for files that still exist on disk (`DiskState::Present`).

7 lines in `crates/language/src/buffer.rs`.

### No double reload

`file_updated()` suppresses `ReloadNeeded` when the buffer is dirty (that's the whole bug). So by the time `did_edit()` fires on dirty-to-clean, no prior reload was emitted for this file change. The two paths are mutually exclusive.

### Independent of #48691

This fix compares mtime only, which is sufficient here because the external write always produces a new mtime. The size-based fix in #48691 addresses a different scenario (same mtime, different size). The two PRs don't conflict and don't depend on each other.

## Test plan

- New: `test_dirty_buffer_reloads_after_undo`
- No regression in `test_buffer_is_dirty` or other buffer tests
- All 54 language buffer tests pass
- clippy clean

Release Notes:

- Fixed an issue where buffer content could become stale after undoing edits when an external tool wrote to the file while the buffer was dirty.