### PR TITLE
git: Rescan repositories when window regains focus

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -6420,6 +6420,117 @@ mod tests {
     }
 
     #[gpui::test]
+    async fn test_git_panel_updates_on_reload_repositories(cx: &mut TestAppContext) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.background_executor.clone());
+        fs.insert_tree(
+            "/root",
+            json!({
+                "project": {
+                    ".git": {},
+                    "src": {
+                        "main.rs": "fn main() {}",
+                        "lib.rs": "pub fn hello() {}",
+                    }
+                }
+            }),
+        )
+        .await;
+
+        fs.set_status_for_repo(
+            Path::new(path!("/root/project/.git")),
+            &[("src/main.rs", StatusCode::Modified.worktree())],
+        );
+
+        let project = Project::test(fs.clone(), [path!("/root/project").as_ref()], cx).await;
+        let workspace =
+            cx.add_window(|window, cx| Workspace::test_new(project.clone(), window, cx));
+        let cx = &mut VisualTestContext::from_window(*workspace, cx);
+
+        cx.read(|cx| {
+            project
+                .read(cx)
+                .worktrees(cx)
+                .next()
+                .unwrap()
+                .read(cx)
+                .as_local()
+                .unwrap()
+                .scan_complete()
+        })
+        .await;
+
+        cx.executor().run_until_parked();
+
+        let panel = workspace.update(cx, GitPanel::new).unwrap();
+
+        let handle = cx.update_window_entity(&panel, |panel, _, _| {
+            std::mem::replace(&mut panel.update_visible_entries_task, Task::ready(()))
+        });
+        cx.executor().advance_clock(2 * UPDATE_DEBOUNCE);
+        handle.await;
+
+        // Verify initial state: only main.rs is modified.
+        let entries = panel.read_with(cx, |panel, _| panel.entries.clone());
+        assert_eq!(entries.len(), 2);
+        pretty_assertions::assert_matches!(
+            &entries[1],
+            GitListEntry::Status(entry) if entry.repo_path == repo_path("src/main.rs")
+        );
+
+        // Simulate an external git operation that Zed missed (e.g. after
+        // sleep/wake where FSEvents were lost). The FakeFs status change
+        // doesn't fire any worktree events, so the git store is unaware.
+        fs.set_status_for_repo(
+            Path::new(path!("/root/project/.git")),
+            &[
+                ("src/main.rs", StatusCode::Modified.worktree()),
+                ("src/lib.rs", StatusCode::Modified.worktree()),
+            ],
+        );
+
+        cx.executor().run_until_parked();
+
+        // Panel still shows only main.rs because no events fired.
+        let entries = panel.read_with(cx, |panel, _| panel.entries.clone());
+        assert_eq!(
+            entries.len(),
+            2,
+            "panel should not yet see lib.rs (no events fired)"
+        );
+
+        // Trigger a full rescan of all repositories (as window activation does).
+        let git_store = project.read_with(cx, |project, _| project.git_store().clone());
+        git_store.update(cx, |store, cx| {
+            store.reload_repositories(cx);
+        });
+
+        cx.executor().run_until_parked();
+
+        let handle = cx.update_window_entity(&panel, |panel, _, _| {
+            std::mem::replace(&mut panel.update_visible_entries_task, Task::ready(()))
+        });
+        cx.executor().advance_clock(2 * UPDATE_DEBOUNCE);
+        handle.await;
+
+        // Now both files should appear.
+        let entries = panel.read_with(cx, |panel, _| panel.entries.clone());
+        assert_eq!(
+            entries.len(),
+            3,
+            "panel should show both modified files after reload"
+        );
+        pretty_assertions::assert_matches!(
+            &entries[1],
+            GitListEntry::Status(entry) if entry.repo_path == repo_path("src/lib.rs")
+        );
+        pretty_assertions::assert_matches!(
+            &entries[2],
+            GitListEntry::Status(entry) if entry.repo_path == repo_path("src/main.rs")
+        );
+    }
+
+    #[gpui::test]
     async fn test_bulk_staging(cx: &mut TestAppContext) {
         use GitListEntry::*;
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -5763,6 +5763,11 @@ impl Workspace {
         if window.is_window_active() {
             self.update_active_view_for_followers(window, cx);
 
+            let git_store = self.project.read(cx).git_store().clone();
+            git_store.update(cx, |store, cx| {
+                store.reload_repositories(cx);
+            });
+
             if let Some(database_id) = self.database_id {
                 cx.background_spawn(persistence::DB.update_timestamp(database_id))
                     .detach();


### PR DESCRIPTION
Fixes #48703
Related to #38109, #13176

## Problem

The git panel can show stale branch and file status after switching back from a terminal where you ran git commands (checkout, rebase, reset, stash pop). Same thing happens after laptop sleep/wake.

Git state only refreshes when Zed sees changes inside `.git/` via filesystem events. If those events are lost, stale state persists indefinitely. No manual refresh, no periodic rescan.

## Approach

This is a safety net, not a targeted fix for a specific event-loss path. We can't reliably prove which FSEvents get dropped during sleep/wake or heavy IO, but we can make sure the git panel recovers when the user comes back to Zed.

Add `reload_repositories()` to GitStore, called from `Workspace::on_window_activation_changed` when the window becomes active. This triggers `schedule_scan()` for all repositories, running a full `git status .` on a background thread.

### Performance

`schedule_scan` uses keyed job deduplication (`GitJobKey::ReloadGitState`), so rapid window switches collapse into one scan. In large monorepos `git status` can be slow (see #43861). If this turns out to be a problem, a cooldown or debounce could be added, but the dedup already prevents the worst case.

## Changes

3 files, ~20 lines of production code:
- `git_store.rs`: new `reload_repositories()` method
- `workspace.rs`: call it on window activation
- `git_panel.rs`: test

## Test plan

- New: `test_git_panel_updates_on_reload_repositories` sets up git panel, changes git status without firing events (simulating lost FSEvents), calls `reload_repositories`, verifies panel updates
- All 12 existing git panel tests pass
- clippy clean

Release Notes:

- Fixed an issue where the git panel could show stale branch and file status after switching back from a terminal or after sleep/wake.