### PR TITLE
docs: Add note about escaping `$` in snippets

### DIFF
--- a/docs/src/snippets.md
+++ b/docs/src/snippets.md
@@ -13,6 +13,7 @@ The snippets are located in `~/.config/zed/snippets` directory to which you can 
   // Use placeholders like $1, $2 or ${1:defaultValue} to define tab stops.
   // The $0 determines the final cursor position.
   // Placeholders with the same value are linked.
+  // If the snippet contains the $ symbol outside of a placeholder, it must be escaped with two slashes (ex. \\$var).
   "Log to console": {
     "prefix": "log",
     "body": ["console.info(\"Hello, ${1:World}!\")", "$0"],

--- a/docs/src/snippets.md
+++ b/docs/src/snippets.md
@@ -13,7 +13,7 @@ The snippets are located in `~/.config/zed/snippets` directory to which you can 
   // Use placeholders like $1, $2 or ${1:defaultValue} to define tab stops.
   // The $0 determines the final cursor position.
   // Placeholders with the same value are linked.
-  // If the snippet contains the $ symbol outside of a placeholder, it must be escaped with two slashes (ex. \\$var).
+  // If the snippet contains the $ symbol outside of a placeholder, it must be escaped with two slashes (e.g. \\$var).
   "Log to console": {
     "prefix": "log",
     "body": ["console.info(\"Hello, ${1:World}!\")", "$0"],


### PR DESCRIPTION
In writing PHP snippets, I ran into this issue and only discovered this has to be done through reviewing examples of other PHP snippets.

I think it would be useful to include some mention of this behavior in the documentation - although I'm not great at writing docs and not sure if this is the best place or way to write this out. 

Open to any feedback on this or perfectly okay if maintainers find this unnecessary.

Release Notes:

- N/A