### PR TITLE
Add auto_preview_markdown setting

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -185,6 +185,8 @@
   //
   // Default: true
   "zoomed_padding": true,
+  // Whether to automatically open a markdown preview when opening markdown files.
+  "auto_preview_markdown": false,
   // What draws Zed's window decorations (titlebar):
   // 1. Client application (Zed) draws its own window decorations
   //    "client"

--- a/crates/markdown_preview/src/markdown_preview.rs
+++ b/crates/markdown_preview/src/markdown_preview.rs
@@ -39,4 +39,12 @@ pub fn init(cx: &mut App) {
         markdown_preview_view::MarkdownPreviewView::register(workspace, window, cx);
     })
     .detach();
+
+    cx.observe_new(|workspace: &mut Workspace, window, cx| {
+        let Some(window) = window else {
+            return;
+        };
+        markdown_preview_view::register_auto_preview(workspace, window, cx);
+    })
+    .detach();
 }

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -16,7 +16,7 @@ use settings::Settings;
 use theme::ThemeSettings;
 use ui::{WithScrollbar, prelude::*};
 use workspace::item::{Item, ItemHandle};
-use workspace::{Pane, Workspace};
+use workspace::{Pane, Workspace, WorkspaceSettings};
 
 use crate::markdown_elements::ParsedMarkdownElement;
 use crate::markdown_renderer::CheckboxClickedEvent;
@@ -126,7 +126,98 @@ impl MarkdownPreviewView {
             }
         });
     }
+}
 
+pub fn register_auto_preview(
+    workspace: &mut Workspace,
+    window: &mut Window,
+    cx: &mut Context<Workspace>,
+) {
+    let workspace_handle = workspace.weak_handle();
+    cx.subscribe_in(
+        &workspace_handle.upgrade().expect("workspace should exist during registration"),
+        window,
+        move |workspace, _, event, window, cx| {
+            if let workspace::Event::ItemAdded { item } = event {
+                handle_item_added(workspace, item.as_ref(), window, cx);
+            }
+        },
+    )
+    .detach();
+}
+
+fn handle_item_added(
+    workspace: &mut Workspace,
+    item: &dyn ItemHandle,
+    window: &mut Window,
+    cx: &mut Context<Workspace>,
+) {
+    if !WorkspaceSettings::get_global(cx).auto_preview_markdown {
+        return;
+    }
+
+    let Some(editor) = item.act_as::<Editor>(cx) else {
+        return;
+    };
+    if !MarkdownPreviewView::is_markdown_file(&editor, cx) {
+        return;
+    }
+
+    // Don't auto-preview if the item was added to a pane that already has a markdown preview
+    // (this likely means it was opened from within a preview)
+    let has_preview_in_same_pane = workspace
+        .active_pane()
+        .read(cx)
+        .items_of_type::<MarkdownPreviewView>()
+        .next()
+        .is_some();
+    if has_preview_in_same_pane {
+        return;
+    }
+
+    if preview_exists_for_editor(workspace, &editor, cx) {
+        return;
+    }
+
+    let view = MarkdownPreviewView::create_markdown_view(workspace, editor.clone(), window, cx);
+    let pane = workspace
+        .find_pane_in_direction(workspace::SplitDirection::Right, cx)
+        .unwrap_or_else(|| {
+            workspace.split_pane(
+                workspace.active_pane().clone(),
+                workspace::SplitDirection::Right,
+                window,
+                cx,
+            )
+        });
+
+    pane.update(cx, |pane, cx| {
+        pane.add_item(Box::new(view), false, false, None, window, cx);
+    });
+
+    editor.focus_handle(cx).focus(window, cx);
+    cx.notify();
+}
+
+fn preview_exists_for_editor(workspace: &Workspace, editor: &Entity<Editor>, cx: &App) -> bool {
+    for pane in workspace.panes() {
+        let pane_read = pane.read(cx);
+        for view in pane_read.items_of_type::<MarkdownPreviewView>() {
+            let view_read = view.read(cx);
+            if view_read.mode == MarkdownPreviewMode::Default
+                && view_read
+                    .active_editor
+                    .as_ref()
+                    .is_some_and(|state| state.editor == *editor)
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+impl MarkdownPreviewView {
     fn find_existing_independent_preview_item_idx(
         pane: &Pane,
         editor: &Entity<Editor>,
@@ -159,7 +250,7 @@ impl MarkdownPreviewView {
         None
     }
 
-    fn create_markdown_view(
+    pub fn create_markdown_view(
         workspace: &mut Workspace,
         editor: Entity<Editor>,
         window: &mut Window,

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -873,6 +873,7 @@ impl VsCodeSettings {
                 }
             }),
             zoomed_padding: None,
+            auto_preview_markdown: None,
         }
     }
 

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -113,6 +113,11 @@ pub struct WorkspaceSettingsContent {
     ///
     /// Default: true
     pub zoomed_padding: Option<bool>,
+    /// Whether to automatically open a markdown preview when opening markdown files.
+    /// When enabled, opening a markdown file will also open a preview pane to the side.
+    ///
+    /// Default: false
+    pub auto_preview_markdown: Option<bool>,
     /// What draws window decorations/titlebar, the client application (Zed) or display server
     /// Default: client
     pub window_decorations: Option<WindowDecorations>,

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -33,6 +33,7 @@ pub struct WorkspaceSettings {
     pub close_on_file_delete: bool,
     pub use_system_window_tabs: bool,
     pub zoomed_padding: bool,
+    pub auto_preview_markdown: bool,
     pub window_decorations: settings::WindowDecorations,
 }
 
@@ -110,6 +111,7 @@ impl Settings for WorkspaceSettings {
             close_on_file_delete: workspace.close_on_file_delete.unwrap(),
             use_system_window_tabs: workspace.use_system_window_tabs.unwrap(),
             zoomed_padding: workspace.zoomed_padding.unwrap(),
+            auto_preview_markdown: workspace.auto_preview_markdown.unwrap(),
             window_decorations: workspace.window_decorations.unwrap(),
         }
     }


### PR DESCRIPTION
Partially addresses #10966

## Summary

Adds a simple `auto_preview_markdown` boolean setting that automatically opens a preview pane to the right when opening markdown files.

## Approach

Subscribes to `workspace::Event::ItemAdded` during `markdown_preview::init()`. When a markdown file is opened and the setting is enabled, creates a preview in a pane to the right while keeping focus on the editor.

Key behaviors:
- Editor remains focused (not the preview)
- No duplicate previews created for the same file
- Skips auto-preview when opening markdown from within a preview pane
- Defaults to `false` to preserve existing behavior

## Release Notes

- Added `auto_preview_markdown` setting to automatically open markdown preview alongside editor