### PR TITLE
Fix Conda activation error appearing during task execution

### DIFF
--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -181,7 +181,7 @@ impl Project {
                                     let to_run = format_to_run();
 
                                     let arg = format!("{activation_script}{separator} {to_run}");
-                                    let args = shell_kind.args_for_shell(false, arg);
+                                    let args = shell_kind.args_for_shell(true, arg);
                                     let shell = remote_client
                                         .read(cx)
                                         .shell()
@@ -214,7 +214,7 @@ impl Project {
                                     let to_run = format_to_run();
 
                                     let arg = format!("{activation_script}{separator} {to_run}");
-                                    let args = shell_kind.args_for_shell(false, arg);
+                                    let args = shell_kind.args_for_shell(true, arg);
 
                                     (
                                         Shell::WithArguments {


### PR DESCRIPTION
Closes #48732

- [X] Tests or screenshots needed? 
- [X] Code Reviewed
- [X] Manual QA
The fix enables interactive mode during task execution, resolving the Conda activation error. However, enabling this mode adds some overhead. In my environment, the task startup time increased by approximately 1 seconds due to the loading of ~/.zshrc.


[录屏 2026-02-08 23-49-53.webm](https://github.com/user-attachments/assets/4064e366-b0d2-4a8c-9599-c4108e76af9f)

Release Notes:

- Fixed conda activation error appears during task execution.
