### PR TITLE
Allow specifying different fonts for inlays

### DIFF
--- a/crates/collab/tests/integration/editor_tests.rs
+++ b/crates/collab/tests/integration/editor_tests.rs
@@ -2230,6 +2230,9 @@ async fn test_inlay_hint_refresh_is_forwarded(
                         show_other_hints: Some(false),
                         show_background: Some(false),
                         toggle_on_modifiers_press: None,
+                        font_family: None,
+                        font_weight: None,
+                        font_features: None,
                     })
             });
         });
@@ -2248,6 +2251,9 @@ async fn test_inlay_hint_refresh_is_forwarded(
                         show_other_hints: Some(true),
                         show_background: Some(false),
                         toggle_on_modifiers_press: None,
+                        font_family: None,
+                        font_weight: None,
+                        font_features: None,
                     })
             });
         });

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -1487,11 +1487,39 @@ pub enum ChunkReplacement {
     Str(SharedString),
 }
 
+#[derive(Copy, Clone, Debug, Default)]
+pub enum ChunkSpecial {
+    #[default]
+    None,
+    InlayHint,
+    EditPrediction,
+}
+
+impl From<fold_map::ChunkSpecial> for ChunkSpecial {
+    fn from(chunk_special: fold_map::ChunkSpecial) -> Self {
+        match chunk_special {
+            fold_map::ChunkSpecial::InlayHint => ChunkSpecial::InlayHint,
+            fold_map::ChunkSpecial::EditPrediction => ChunkSpecial::EditPrediction,
+            fold_map::ChunkSpecial::None => ChunkSpecial::None,
+        }
+    }
+}
+
+impl From<ChunkSpecial> for fold_map::ChunkSpecial {
+    fn from(chunk_special: ChunkSpecial) -> Self {
+        match chunk_special {
+            ChunkSpecial::None => fold_map::ChunkSpecial::None,
+            ChunkSpecial::InlayHint => fold_map::ChunkSpecial::InlayHint,
+            ChunkSpecial::EditPrediction => fold_map::ChunkSpecial::EditPrediction,
+        }
+    }
+}
+
 pub struct HighlightedChunk<'a> {
     pub text: &'a str,
     pub style: Option<HighlightStyle>,
     pub is_tab: bool,
-    pub is_inlay: bool,
+    pub special: ChunkSpecial,
     pub replacement: Option<ChunkReplacement>,
 }
 
@@ -1506,7 +1534,7 @@ impl<'a> HighlightedChunk<'a> {
         let style = self.style;
         let is_tab = self.is_tab;
         let renderer = self.replacement;
-        let is_inlay = self.is_inlay;
+        let special = self.special;
         iter::from_fn(move || {
             let mut prefix_len = 0;
             while let Some(&chunk) = chunks.peek() {
@@ -1524,7 +1552,7 @@ impl<'a> HighlightedChunk<'a> {
                         text: prefix,
                         style,
                         is_tab,
-                        is_inlay,
+                        special,
                         replacement: renderer.clone(),
                     });
                 }
@@ -1550,7 +1578,7 @@ impl<'a> HighlightedChunk<'a> {
                         text: prefix,
                         style: Some(invisible_style),
                         is_tab: false,
-                        is_inlay,
+                        special,
                         replacement: Some(ChunkReplacement::Str(replacement.into())),
                     });
                 } else {
@@ -1573,7 +1601,7 @@ impl<'a> HighlightedChunk<'a> {
                         text: prefix,
                         style: Some(invisible_style),
                         is_tab: false,
-                        is_inlay,
+                        special,
                         replacement: renderer.clone(),
                     });
                 }
@@ -1586,7 +1614,7 @@ impl<'a> HighlightedChunk<'a> {
                     text: remainder,
                     style,
                     is_tab,
-                    is_inlay,
+                    special,
                     replacement: renderer.clone(),
                 })
             } else {
@@ -1912,12 +1940,16 @@ impl DisplaySnapshot {
                 HighlightStyle {
                     // For color inlays, blend the color with the editor background
                     // if the color has transparency (alpha < 1.0)
-                    color: chunk_highlight.color.map(|color| {
-                        if chunk.is_inlay && !color.is_opaque() {
-                            editor_style.background.blend(color)
-                        } else {
-                            color
+                    color: chunk_highlight.color.map(|color| match chunk.special {
+                        fold_map::ChunkSpecial::InlayHint => {
+                            if !color.is_opaque() {
+                                editor_style.background.blend(color)
+                            } else {
+                                color
+                            }
                         }
+                        fold_map::ChunkSpecial::EditPrediction => color,
+                        fold_map::ChunkSpecial::None => color,
                     }),
                     underline: chunk_highlight
                         .underline
@@ -1965,7 +1997,7 @@ impl DisplaySnapshot {
                 text: chunk.text,
                 style,
                 is_tab: chunk.is_tab,
-                is_inlay: chunk.is_inlay,
+                special: chunk.special.into(),
                 replacement: chunk.renderer.map(ChunkReplacement::Renderer),
             }
             .highlight_invisibles(editor_style)

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -97,7 +97,9 @@ use gpui::{
     App, Context, Entity, EntityId, Font, HighlightStyle, LineLayout, Pixels, UnderlineStyle,
     WeakEntity,
 };
-use language::{Point, Subscription as BufferSubscription, language_settings::language_settings};
+use language::{
+    ChunkSpecial, Point, Subscription as BufferSubscription, language_settings::language_settings,
+};
 use multi_buffer::{
     Anchor, AnchorRangeExt, ExcerptId, MultiBuffer, MultiBufferOffset, MultiBufferOffsetUtf16,
     MultiBufferPoint, MultiBufferRow, MultiBufferSnapshot, RowInfo, ToOffset, ToPoint,
@@ -1487,34 +1489,6 @@ pub enum ChunkReplacement {
     Str(SharedString),
 }
 
-#[derive(Copy, Clone, Debug, Default)]
-pub enum ChunkSpecial {
-    #[default]
-    None,
-    InlayHint,
-    EditPrediction,
-}
-
-impl From<fold_map::ChunkSpecial> for ChunkSpecial {
-    fn from(chunk_special: fold_map::ChunkSpecial) -> Self {
-        match chunk_special {
-            fold_map::ChunkSpecial::InlayHint => ChunkSpecial::InlayHint,
-            fold_map::ChunkSpecial::EditPrediction => ChunkSpecial::EditPrediction,
-            fold_map::ChunkSpecial::None => ChunkSpecial::None,
-        }
-    }
-}
-
-impl From<ChunkSpecial> for fold_map::ChunkSpecial {
-    fn from(chunk_special: ChunkSpecial) -> Self {
-        match chunk_special {
-            ChunkSpecial::None => fold_map::ChunkSpecial::None,
-            ChunkSpecial::InlayHint => fold_map::ChunkSpecial::InlayHint,
-            ChunkSpecial::EditPrediction => fold_map::ChunkSpecial::EditPrediction,
-        }
-    }
-}
-
 pub struct HighlightedChunk<'a> {
     pub text: &'a str,
     pub style: Option<HighlightStyle>,
@@ -1535,6 +1509,7 @@ impl<'a> HighlightedChunk<'a> {
         let is_tab = self.is_tab;
         let renderer = self.replacement;
         let special = self.special;
+
         iter::from_fn(move || {
             let mut prefix_len = 0;
             while let Some(&chunk) = chunks.peek() {
@@ -1941,15 +1916,14 @@ impl DisplaySnapshot {
                     // For color inlays, blend the color with the editor background
                     // if the color has transparency (alpha < 1.0)
                     color: chunk_highlight.color.map(|color| match chunk.special {
-                        fold_map::ChunkSpecial::InlayHint => {
+                        ChunkSpecial::InlayHint => {
                             if !color.is_opaque() {
                                 editor_style.background.blend(color)
                             } else {
                                 color
                             }
                         }
-                        fold_map::ChunkSpecial::EditPrediction => color,
-                        fold_map::ChunkSpecial::None => color,
+                        _ => color,
                     }),
                     underline: chunk_highlight
                         .underline
@@ -4000,7 +3974,6 @@ pub mod tests {
             DisplayPoint::new(DisplayRow(1), 11)
         )
     }
-
     fn syntax_chunks(
         rows: Range<DisplayRow>,
         map: &Entity<DisplayMap>,

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -1971,7 +1971,7 @@ impl DisplaySnapshot {
                 text: chunk.text,
                 style,
                 is_tab: chunk.is_tab,
-                kind: chunk.kind.into(),
+                kind: chunk.kind,
                 replacement: chunk.renderer.map(ChunkReplacement::Renderer),
             }
             .highlight_invisibles(editor_style)

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -4114,7 +4114,7 @@ pub mod tests {
             text: pilot_emoji,
             style: None,
             is_tab: false,
-            is_inlay: false,
+            kind: ChunkKind::None,
             replacement: None,
         };
 

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -98,7 +98,7 @@ use gpui::{
     WeakEntity,
 };
 use language::{
-    ChunkSpecial, Point, Subscription as BufferSubscription, language_settings::language_settings,
+    ChunkKind, Point, Subscription as BufferSubscription, language_settings::language_settings,
 };
 use multi_buffer::{
     Anchor, AnchorRangeExt, ExcerptId, MultiBuffer, MultiBufferOffset, MultiBufferOffsetUtf16,
@@ -1493,7 +1493,7 @@ pub struct HighlightedChunk<'a> {
     pub text: &'a str,
     pub style: Option<HighlightStyle>,
     pub is_tab: bool,
-    pub special: ChunkSpecial,
+    pub kind: ChunkKind,
     pub replacement: Option<ChunkReplacement>,
 }
 
@@ -1508,7 +1508,7 @@ impl<'a> HighlightedChunk<'a> {
         let style = self.style;
         let is_tab = self.is_tab;
         let renderer = self.replacement;
-        let special = self.special;
+        let kind = self.kind;
 
         iter::from_fn(move || {
             let mut prefix_len = 0;
@@ -1527,7 +1527,7 @@ impl<'a> HighlightedChunk<'a> {
                         text: prefix,
                         style,
                         is_tab,
-                        special,
+                        kind,
                         replacement: renderer.clone(),
                     });
                 }
@@ -1553,7 +1553,7 @@ impl<'a> HighlightedChunk<'a> {
                         text: prefix,
                         style: Some(invisible_style),
                         is_tab: false,
-                        special,
+                        kind,
                         replacement: Some(ChunkReplacement::Str(replacement.into())),
                     });
                 } else {
@@ -1576,7 +1576,7 @@ impl<'a> HighlightedChunk<'a> {
                         text: prefix,
                         style: Some(invisible_style),
                         is_tab: false,
-                        special,
+                        kind,
                         replacement: renderer.clone(),
                     });
                 }
@@ -1589,7 +1589,7 @@ impl<'a> HighlightedChunk<'a> {
                     text: remainder,
                     style,
                     is_tab,
-                    special,
+                    kind,
                     replacement: renderer.clone(),
                 })
             } else {
@@ -1915,8 +1915,8 @@ impl DisplaySnapshot {
                 HighlightStyle {
                     // For color inlays, blend the color with the editor background
                     // if the color has transparency (alpha < 1.0)
-                    color: chunk_highlight.color.map(|color| match chunk.special {
-                        ChunkSpecial::InlayHint => {
+                    color: chunk_highlight.color.map(|color| match chunk.kind {
+                        ChunkKind::InlayHint => {
                             if !color.is_opaque() {
                                 editor_style.background.blend(color)
                             } else {
@@ -1971,7 +1971,7 @@ impl DisplaySnapshot {
                 text: chunk.text,
                 style,
                 is_tab: chunk.is_tab,
-                special: chunk.special.into(),
+                kind: chunk.kind.into(),
                 replacement: chunk.renderer.map(ChunkReplacement::Renderer),
             }
             .highlight_invisibles(editor_style)

--- a/crates/editor/src/display_map/fold_map.rs
+++ b/crates/editor/src/display_map/fold_map.rs
@@ -5,7 +5,7 @@ use super::{
     inlay_map::{InlayBufferRows, InlayChunks, InlayEdit, InlayOffset, InlayPoint, InlaySnapshot},
 };
 use gpui::{AnyElement, App, ElementId, HighlightStyle, Pixels, SharedString, Stateful, Window};
-use language::{ChunkSpecial, Edit, HighlightId, Point};
+use language::{ChunkKind, Edit, HighlightId, Point};
 use multi_buffer::{
     Anchor, AnchorRangeExt, MBTextSummary, MultiBufferOffset, MultiBufferRow, MultiBufferSnapshot,
     RowInfo, ToOffset,
@@ -1392,8 +1392,8 @@ pub struct Chunk<'a> {
     pub underline: bool,
     /// Whether this chunk of text was originally a tab character.
     pub is_tab: bool,
-    /// Special property of chunk.
-    pub special: ChunkSpecial,
+    /// What kind of chunk this is.
+    pub kind: ChunkKind,
     /// An optional recipe for how the chunk should be presented.
     pub renderer: Option<ChunkRenderer>,
     /// Bitmap of tab character locations in chunk
@@ -1586,7 +1586,7 @@ impl<'a> Iterator for FoldChunks<'a> {
                 diagnostic_severity: chunk.diagnostic_severity,
                 is_unnecessary: chunk.is_unnecessary,
                 is_tab: chunk.is_tab,
-                special: chunk.special,
+                kind: chunk.kind,
                 underline: chunk.underline,
                 renderer: inlay_chunk.renderer,
             });

--- a/crates/editor/src/display_map/fold_map.rs
+++ b/crates/editor/src/display_map/fold_map.rs
@@ -5,7 +5,7 @@ use super::{
     inlay_map::{InlayBufferRows, InlayChunks, InlayEdit, InlayOffset, InlayPoint, InlaySnapshot},
 };
 use gpui::{AnyElement, App, ElementId, HighlightStyle, Pixels, SharedString, Stateful, Window};
-use language::{Edit, HighlightId, Point};
+use language::{ChunkSpecial, Edit, HighlightId, Point};
 use multi_buffer::{
     Anchor, AnchorRangeExt, MBTextSummary, MultiBufferOffset, MultiBufferRow, MultiBufferSnapshot,
     RowInfo, ToOffset,
@@ -1373,14 +1373,6 @@ impl Iterator for FoldRows<'_> {
     }
 }
 
-#[derive(Copy, Clone, Debug, Default)]
-pub enum ChunkSpecial {
-    #[default]
-    None,
-    InlayHint,
-    EditPrediction,
-}
-
 /// A chunk of a buffer's text, along with its syntax highlight and
 /// diagnostic status.
 #[derive(Clone, Debug, Default)]
@@ -1594,7 +1586,7 @@ impl<'a> Iterator for FoldChunks<'a> {
                 diagnostic_severity: chunk.diagnostic_severity,
                 is_unnecessary: chunk.is_unnecessary,
                 is_tab: chunk.is_tab,
-                special: ChunkSpecial::InlayHint,
+                special: chunk.special,
                 underline: chunk.underline,
                 renderer: inlay_chunk.renderer,
             });

--- a/crates/editor/src/display_map/fold_map.rs
+++ b/crates/editor/src/display_map/fold_map.rs
@@ -1373,6 +1373,14 @@ impl Iterator for FoldRows<'_> {
     }
 }
 
+#[derive(Copy, Clone, Debug, Default)]
+pub enum ChunkSpecial {
+    #[default]
+    None,
+    InlayHint,
+    EditPrediction,
+}
+
 /// A chunk of a buffer's text, along with its syntax highlight and
 /// diagnostic status.
 #[derive(Clone, Debug, Default)]
@@ -1392,8 +1400,8 @@ pub struct Chunk<'a> {
     pub underline: bool,
     /// Whether this chunk of text was originally a tab character.
     pub is_tab: bool,
-    /// Whether this chunk of text was originally a tab character.
-    pub is_inlay: bool,
+    /// Special property of chunk.
+    pub special: ChunkSpecial,
     /// An optional recipe for how the chunk should be presented.
     pub renderer: Option<ChunkRenderer>,
     /// Bitmap of tab character locations in chunk
@@ -1586,7 +1594,7 @@ impl<'a> Iterator for FoldChunks<'a> {
                 diagnostic_severity: chunk.diagnostic_severity,
                 is_unnecessary: chunk.is_unnecessary,
                 is_tab: chunk.is_tab,
-                is_inlay: chunk.is_inlay,
+                special: ChunkSpecial::InlayHint,
                 underline: chunk.underline,
                 renderer: inlay_chunk.renderer,
             });

--- a/crates/editor/src/display_map/inlay_map.rs
+++ b/crates/editor/src/display_map/inlay_map.rs
@@ -328,7 +328,7 @@ impl<'a> Iterator for InlayChunks<'a> {
                 }
 
                 let mut renderer = None;
-                let (mut highlight_style, chunk_special) = match inlay.id {
+                let (mut highlight_style, chunk_kind) = match inlay.id {
                     InlayId::EditPrediction(_) => (
                         self.highlight_styles.edit_prediction.map(|s| {
                             if inlay.text().chars().all(|c| c.is_whitespace()) {
@@ -475,7 +475,7 @@ impl<'a> Iterator for InlayChunks<'a> {
                         tabs: new_tabs,
                         newlines: new_newlines,
                         highlight_style,
-                        kind: chunk_special,
+                        kind: chunk_kind,
                         ..Chunk::default()
                     },
                     renderer,

--- a/crates/editor/src/display_map/inlay_map.rs
+++ b/crates/editor/src/display_map/inlay_map.rs
@@ -309,6 +309,7 @@ impl<'a> Iterator for InlayChunks<'a> {
                         chars,
                         tabs,
                         newlines,
+                        special: ChunkSpecial::None,
                         ..chunk.clone()
                     },
                     renderer: None,
@@ -486,7 +487,6 @@ impl<'a> Iterator for InlayChunks<'a> {
             self.inlay_chunks = None;
             self.transforms.next();
         }
-
         Some(chunk)
     }
 }

--- a/crates/editor/src/display_map/inlay_map.rs
+++ b/crates/editor/src/display_map/inlay_map.rs
@@ -10,7 +10,7 @@ use crate::{
     inlays::{Inlay, InlayContent},
 };
 use collections::BTreeSet;
-use language::{Chunk, Edit, Point, TextSummary};
+use language::{Chunk, ChunkSpecial, Edit, Point, TextSummary};
 use multi_buffer::{
     MBTextSummary, MultiBufferOffset, MultiBufferRow, MultiBufferRows, MultiBufferSnapshot,
     RowInfo, ToOffset,
@@ -327,16 +327,21 @@ impl<'a> Iterator for InlayChunks<'a> {
                 }
 
                 let mut renderer = None;
-                let mut highlight_style = match inlay.id {
-                    InlayId::EditPrediction(_) => self.highlight_styles.edit_prediction.map(|s| {
-                        if inlay.text().chars().all(|c| c.is_whitespace()) {
-                            s.whitespace
-                        } else {
-                            s.insertion
-                        }
-                    }),
-                    InlayId::Hint(_) => self.highlight_styles.inlay_hint,
-                    InlayId::DebuggerValue(_) => self.highlight_styles.inlay_hint,
+                let (mut highlight_style, chunk_special) = match inlay.id {
+                    InlayId::EditPrediction(_) => (
+                        self.highlight_styles.edit_prediction.map(|s| {
+                            if inlay.text().chars().all(|c| c.is_whitespace()) {
+                                s.whitespace
+                            } else {
+                                s.insertion
+                            }
+                        }),
+                        ChunkSpecial::EditPrediction,
+                    ),
+                    InlayId::Hint(_) => (self.highlight_styles.inlay_hint, ChunkSpecial::InlayHint),
+                    InlayId::DebuggerValue(_) => {
+                        (self.highlight_styles.inlay_hint, ChunkSpecial::InlayHint)
+                    }
                     InlayId::ReplResult(_) => {
                         let text = inlay.text().to_string();
                         renderer = Some(ChunkRenderer {
@@ -362,7 +367,7 @@ impl<'a> Iterator for InlayChunks<'a> {
                             constrain_width: false,
                             measured_width: None,
                         });
-                        self.highlight_styles.inlay_hint
+                        (self.highlight_styles.inlay_hint, ChunkSpecial::InlayHint)
                     }
                     InlayId::Color(_) => {
                         if let InlayContent::Color(color) = inlay.content {
@@ -393,7 +398,7 @@ impl<'a> Iterator for InlayChunks<'a> {
                                 measured_width: None,
                             });
                         }
-                        self.highlight_styles.inlay_hint
+                        (self.highlight_styles.inlay_hint, ChunkSpecial::InlayHint)
                     }
                 };
                 let next_inlay_highlight_endpoint;
@@ -469,7 +474,7 @@ impl<'a> Iterator for InlayChunks<'a> {
                         tabs: new_tabs,
                         newlines: new_newlines,
                         highlight_style,
-                        is_inlay: true,
+                        special: chunk_special,
                         ..Chunk::default()
                     },
                     renderer,
@@ -2305,7 +2310,10 @@ mod tests {
         // Verify the highlighted portion includes the complete ellipsis character
         let highlighted_chunks: Vec<_> = chunks
             .iter()
-            .filter(|c| c.chunk.highlight_style.is_some() && c.chunk.is_inlay)
+            .filter(|c| {
+                c.chunk.highlight_style.is_some()
+                    && matches!(c.chunk.special, ChunkSpecial::InlayHint)
+            })
             .collect();
 
         assert_eq!(highlighted_chunks.len(), 1);
@@ -2425,7 +2433,10 @@ mod tests {
             // Verify that the highlighted portion matches expectations
             let highlighted_text: String = chunks
                 .iter()
-                .filter(|c| c.chunk.highlight_style.is_some() && c.chunk.is_inlay)
+                .filter(|c| {
+                    c.chunk.highlight_style.is_some()
+                        && matches!(c.chunk.special, ChunkSpecial::InlayHint)
+                })
                 .map(|c| c.chunk.text)
                 .collect();
             assert_eq!(

--- a/crates/editor/src/display_map/inlay_map.rs
+++ b/crates/editor/src/display_map/inlay_map.rs
@@ -10,7 +10,7 @@ use crate::{
     inlays::{Inlay, InlayContent},
 };
 use collections::BTreeSet;
-use language::{Chunk, ChunkSpecial, Edit, Point, TextSummary};
+use language::{Chunk, ChunkKind, Edit, Point, TextSummary};
 use multi_buffer::{
     MBTextSummary, MultiBufferOffset, MultiBufferRow, MultiBufferRows, MultiBufferSnapshot,
     RowInfo, ToOffset,
@@ -309,7 +309,7 @@ impl<'a> Iterator for InlayChunks<'a> {
                         chars,
                         tabs,
                         newlines,
-                        special: ChunkSpecial::None,
+                        kind: ChunkKind::None,
                         ..chunk.clone()
                     },
                     renderer: None,
@@ -337,11 +337,11 @@ impl<'a> Iterator for InlayChunks<'a> {
                                 s.insertion
                             }
                         }),
-                        ChunkSpecial::EditPrediction,
+                        ChunkKind::EditPrediction,
                     ),
-                    InlayId::Hint(_) => (self.highlight_styles.inlay_hint, ChunkSpecial::InlayHint),
+                    InlayId::Hint(_) => (self.highlight_styles.inlay_hint, ChunkKind::InlayHint),
                     InlayId::DebuggerValue(_) => {
-                        (self.highlight_styles.inlay_hint, ChunkSpecial::InlayHint)
+                        (self.highlight_styles.inlay_hint, ChunkKind::InlayHint)
                     }
                     InlayId::ReplResult(_) => {
                         let text = inlay.text().to_string();
@@ -368,7 +368,7 @@ impl<'a> Iterator for InlayChunks<'a> {
                             constrain_width: false,
                             measured_width: None,
                         });
-                        (self.highlight_styles.inlay_hint, ChunkSpecial::InlayHint)
+                        (self.highlight_styles.inlay_hint, ChunkKind::InlayHint)
                     }
                     InlayId::Color(_) => {
                         if let InlayContent::Color(color) = inlay.content {
@@ -399,7 +399,7 @@ impl<'a> Iterator for InlayChunks<'a> {
                                 measured_width: None,
                             });
                         }
-                        (self.highlight_styles.inlay_hint, ChunkSpecial::InlayHint)
+                        (self.highlight_styles.inlay_hint, ChunkKind::InlayHint)
                     }
                 };
                 let next_inlay_highlight_endpoint;
@@ -475,7 +475,7 @@ impl<'a> Iterator for InlayChunks<'a> {
                         tabs: new_tabs,
                         newlines: new_newlines,
                         highlight_style,
-                        special: chunk_special,
+                        kind: chunk_special,
                         ..Chunk::default()
                     },
                     renderer,
@@ -2311,8 +2311,7 @@ mod tests {
         let highlighted_chunks: Vec<_> = chunks
             .iter()
             .filter(|c| {
-                c.chunk.highlight_style.is_some()
-                    && matches!(c.chunk.special, ChunkSpecial::InlayHint)
+                c.chunk.highlight_style.is_some() && matches!(c.chunk.kind, ChunkKind::InlayHint)
             })
             .collect();
 
@@ -2435,7 +2434,7 @@ mod tests {
                 .iter()
                 .filter(|c| {
                     c.chunk.highlight_style.is_some()
-                        && matches!(c.chunk.special, ChunkSpecial::InlayHint)
+                        && matches!(c.chunk.kind, ChunkKind::InlayHint)
                 })
                 .map(|c| c.chunk.text)
                 .collect();

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -566,7 +566,9 @@ pub struct EditorStyle {
     pub syntax: Arc<SyntaxTheme>,
     pub status: StatusColors,
     pub inlay_hints_style: HighlightStyle,
+    pub inlay_hints_font: Option<SharedString>,
     pub edit_prediction_styles: EditPredictionStyles,
+    pub edit_prediction_font: Option<SharedString>,
     pub unnecessary_code_fade: f32,
     pub show_underlines: bool,
 }
@@ -585,10 +587,12 @@ impl Default for EditorStyle {
             // style and retrieve them directly from the theme.
             status: StatusColors::dark(),
             inlay_hints_style: HighlightStyle::default(),
+            inlay_hints_font: None,
             edit_prediction_styles: EditPredictionStyles {
                 insertion: HighlightStyle::default(),
                 whitespace: HighlightStyle::default(),
             },
+            edit_prediction_font: None,
             unnecessary_code_fade: Default::default(),
             show_underlines: true,
         }
@@ -25776,7 +25780,9 @@ impl Editor {
             syntax: cx.theme().syntax().clone(),
             status: cx.theme().status().clone(),
             inlay_hints_style: make_inlay_hints_style(cx),
+            inlay_hints_font: Some("Monaspace Krypton".into()),
             edit_prediction_styles: make_suggestion_styles(cx),
+            edit_prediction_font: Some("Monaspace Krypton".into()),
             unnecessary_code_fade: settings.unnecessary_code_fade,
             show_underlines: self.diagnostics_enabled(),
         }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -566,9 +566,9 @@ pub struct EditorStyle {
     pub syntax: Arc<SyntaxTheme>,
     pub status: StatusColors,
     pub inlay_hints_style: HighlightStyle,
-    pub inlay_hints_font: Option<SharedString>,
+    pub inlay_hints_font: gpui::Font,
     pub edit_prediction_styles: EditPredictionStyles,
-    pub edit_prediction_font: Option<SharedString>,
+    pub edit_predictions_font: gpui::Font,
     pub unnecessary_code_fade: f32,
     pub show_underlines: bool,
 }
@@ -587,12 +587,12 @@ impl Default for EditorStyle {
             // style and retrieve them directly from the theme.
             status: StatusColors::dark(),
             inlay_hints_style: HighlightStyle::default(),
-            inlay_hints_font: None,
+            inlay_hints_font: TextStyle::default().font(),
             edit_prediction_styles: EditPredictionStyles {
                 insertion: HighlightStyle::default(),
                 whitespace: HighlightStyle::default(),
             },
-            edit_prediction_font: None,
+            edit_predictions_font: TextStyle::default().font(),
             unnecessary_code_fade: Default::default(),
             show_underlines: true,
         }
@@ -25780,12 +25780,9 @@ impl Editor {
             syntax: cx.theme().syntax().clone(),
             status: cx.theme().status().clone(),
             inlay_hints_style: make_inlay_hints_style(cx),
-            inlay_hints_font: settings.inlay_hint_font_family.as_ref().map(|s| s.into()),
+            inlay_hints_font: settings.inlay_hints_font.clone(),
             edit_prediction_styles: make_suggestion_styles(cx),
-            edit_prediction_font: settings
-                .edit_prediction_font_family
-                .as_ref()
-                .map(|s| s.into()),
+            edit_predictions_font: settings.edit_predictions_font.clone(),
             unnecessary_code_fade: settings.unnecessary_code_fade,
             show_underlines: self.diagnostics_enabled(),
         }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -25780,10 +25780,7 @@ impl Editor {
             syntax: cx.theme().syntax().clone(),
             status: cx.theme().status().clone(),
             inlay_hints_style: make_inlay_hints_style(cx),
-            inlay_hints_font: settings
-                .edit_prediction_font_family
-                .as_ref()
-                .map(|s| s.into()),
+            inlay_hints_font: settings.inlay_hint_font_family.as_ref().map(|s| s.into()),
             edit_prediction_styles: make_suggestion_styles(cx),
             edit_prediction_font: settings
                 .edit_prediction_font_family

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -25780,9 +25780,15 @@ impl Editor {
             syntax: cx.theme().syntax().clone(),
             status: cx.theme().status().clone(),
             inlay_hints_style: make_inlay_hints_style(cx),
-            inlay_hints_font: Some("Monaspace Krypton".into()),
+            inlay_hints_font: settings
+                .edit_prediction_font_family
+                .as_ref()
+                .map(|s| s.into()),
             edit_prediction_styles: make_suggestion_styles(cx),
-            edit_prediction_font: Some("Monaspace Krypton".into()),
+            edit_prediction_font: settings
+                .edit_prediction_font_family
+                .as_ref()
+                .map(|s| s.into()),
             unnecessary_code_fade: settings.unnecessary_code_fade,
             show_underlines: self.diagnostics_enabled(),
         }

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -52,7 +52,7 @@ use gpui::{
 };
 use itertools::Itertools;
 use language::{
-    ChunkSpecial, HighlightedText, IndentGuideSettings, language_settings::ShowWhitespaceSetting,
+    ChunkKind, HighlightedText, IndentGuideSettings, language_settings::ShowWhitespaceSetting,
 };
 use markdown::Markdown;
 use multi_buffer::{
@@ -8767,13 +8767,13 @@ impl fmt::Debug for LineFragment {
 impl LineWithInvisibles {
     /// Helper function to get the appropriate font for a chunk, using inlay font if available
     fn font_for_chunk(
-        special: ChunkSpecial,
+        kind: ChunkKind,
         base_font: gpui::Font,
         editor_style: &EditorStyle,
         highlight_style: Option<gpui::HighlightStyle>,
     ) -> gpui::Font {
-        let mut font = match special {
-            ChunkSpecial::InlayHint => {
+        let mut font = match kind {
+            ChunkKind::InlayHint => {
                 // Use inlay-specific font if configured
                 if let Some(inlay_font) = &editor_style.inlay_hints_font {
                     let mut font = base_font.clone();
@@ -8783,7 +8783,7 @@ impl LineWithInvisibles {
                     base_font.clone()
                 }
             }
-            ChunkSpecial::EditPrediction => {
+            ChunkKind::EditPrediction => {
                 // Use inlay-specific font if configured
                 if let Some(edit_prediction_font) = &editor_style.edit_prediction_font {
                     let mut font = base_font.clone();
@@ -8848,7 +8848,7 @@ impl LineWithInvisibles {
             text: "\n",
             style: None,
             is_tab: false,
-            special: ChunkSpecial::None,
+            kind: ChunkKind::None,
             replacement: None,
         }]) {
             if let Some(replacement) = highlighted_chunk.replacement {
@@ -8922,7 +8922,7 @@ impl LineWithInvisibles {
                         let run = TextRun {
                             len: x.len(),
                             font: Self::font_for_chunk(
-                                highlighted_chunk.special,
+                                highlighted_chunk.kind,
                                 text_style.font(),
                                 editor_style,
                                 highlighted_chunk.style,
@@ -8997,7 +8997,7 @@ impl LineWithInvisibles {
                         styles.push(TextRun {
                             len: line_chunk.len(),
                             font: Self::font_for_chunk(
-                                highlighted_chunk.special,
+                                highlighted_chunk.kind,
                                 text_style.font(),
                                 editor_style,
                                 highlighted_chunk.style,
@@ -9009,8 +9009,8 @@ impl LineWithInvisibles {
                         });
 
                         if editor_mode.is_full() {
-                            match highlighted_chunk.special {
-                                ChunkSpecial::InlayHint => {}
+                            match highlighted_chunk.kind {
+                                ChunkKind::InlayHint => {}
                                 _ => {
                                     // Line wrap pads its contents with fake whitespaces,
                                     // avoid printing them

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -41,14 +41,15 @@ use git::{Oid, blame::BlameEntry, commit::ParsedCommitMessage, status::FileStatu
 use gpui::{
     Action, Along, AnyElement, App, AppContext, AvailableSpace, Axis as ScrollbarAxis, BorderStyle,
     Bounds, ClickEvent, ClipboardItem, ContentMask, Context, Corner, Corners, CursorStyle,
-    DispatchPhase, Edges, Element, ElementInputHandler, Entity, Focusable as _, Font, FontId,
-    FontWeight, GlobalElementId, Hitbox, HitboxBehavior, Hsla, InteractiveElement, IntoElement,
-    IsZero, Length, Modifiers, ModifiersChangedEvent, MouseButton, MouseClickEvent, MouseDownEvent,
-    MouseMoveEvent, MousePressureEvent, MouseUpEvent, PaintQuad, ParentElement, Pixels,
-    PressureStage, ScrollDelta, ScrollHandle, ScrollWheelEvent, ShapedLine, SharedString, Size,
-    StatefulInteractiveElement, Style, Styled, StyledText, TextAlign, TextRun, TextStyleRefinement,
-    WeakEntity, Window, anchored, deferred, div, fill, linear_color_stop, linear_gradient, outline,
-    pattern_slash, point, px, quad, relative, size, solid_background, transparent_black,
+    DispatchPhase, Edges, Element, ElementInputHandler, Entity, Focusable as _, Font, FontId, FontWeight,
+    GlobalElementId, Hitbox, HitboxBehavior, Hsla, InteractiveElement, IntoElement, IsZero,
+    Length, Modifiers, ModifiersChangedEvent, MouseButton, MouseClickEvent,
+    MouseDownEvent, MouseMoveEvent, MousePressureEvent, MouseUpEvent, PaintQuad, ParentElement,
+    Pixels, PressureStage, ScrollDelta, ScrollHandle, ScrollWheelEvent, ShapedLine, SharedString,
+    Size, StatefulInteractiveElement, Style, Styled, StyledText, TextAlign, TextRun, TextStyle,
+    TextStyleRefinement, WeakEntity, Window, anchored, checkerboard, deferred, div, fill,
+    linear_color_stop, linear_gradient, outline, pattern_slash, point, px, quad, relative, size, solid_background,
+    transparent_black,
 };
 use itertools::Itertools;
 use language::{
@@ -8768,13 +8769,13 @@ impl LineWithInvisibles {
     /// Helper function to get the appropriate font for a chunk, using inlay font if available
     fn font_for_chunk(
         kind: ChunkKind,
-        base_font: gpui::Font,
+        text_style: &TextStyle,
         editor_style: &EditorStyle,
     ) -> gpui::Font {
         match kind {
             ChunkKind::InlayHint => editor_style.inlay_hints_font.clone(),
             ChunkKind::EditPrediction => editor_style.edit_predictions_font.clone(),
-            _ => base_font,
+            _ => text_style.font(),
         }
     }
 
@@ -8885,7 +8886,7 @@ impl LineWithInvisibles {
                             len: x.len(),
                             font: Self::font_for_chunk(
                                 highlighted_chunk.kind,
-                                text_style.font(),
+                                &text_style,
                                 editor_style,
                             ),
                             color: text_style.color,
@@ -8959,7 +8960,7 @@ impl LineWithInvisibles {
                             len: line_chunk.len(),
                             font: Self::font_for_chunk(
                                 highlighted_chunk.kind,
-                                text_style.font(),
+                                &text_style,
                                 editor_style,
                             ),
                             color: text_style.color,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -41,14 +41,14 @@ use git::{Oid, blame::BlameEntry, commit::ParsedCommitMessage, status::FileStatu
 use gpui::{
     Action, Along, AnyElement, App, AppContext, AvailableSpace, Axis as ScrollbarAxis, BorderStyle,
     Bounds, ClickEvent, ClipboardItem, ContentMask, Context, Corner, Corners, CursorStyle,
-    DispatchPhase, Edges, Element, ElementInputHandler, Entity, Focusable as _, Font, FontId, FontWeight,
-    GlobalElementId, Hitbox, HitboxBehavior, Hsla, InteractiveElement, IntoElement, IsZero,
-    Length, Modifiers, ModifiersChangedEvent, MouseButton, MouseClickEvent,
-    MouseDownEvent, MouseMoveEvent, MousePressureEvent, MouseUpEvent, PaintQuad, ParentElement,
-    Pixels, PressureStage, ScrollDelta, ScrollHandle, ScrollWheelEvent, ShapedLine, SharedString,
-    Size, StatefulInteractiveElement, Style, Styled, StyledText, TextAlign, TextRun, TextStyle,
-    TextStyleRefinement, WeakEntity, Window, anchored, checkerboard, deferred, div, fill,
-    linear_color_stop, linear_gradient, outline, pattern_slash, point, px, quad, relative, size, solid_background,
+    DispatchPhase, Edges, Element, ElementInputHandler, Entity, Focusable as _, Font, FontId,
+    FontWeight, GlobalElementId, Hitbox, HitboxBehavior, Hsla, InteractiveElement, IntoElement,
+    IsZero, Length, Modifiers, ModifiersChangedEvent, MouseButton, MouseClickEvent, MouseDownEvent,
+    MouseMoveEvent, MousePressureEvent, MouseUpEvent, PaintQuad, ParentElement, Pixels,
+    PressureStage, ScrollDelta, ScrollHandle, ScrollWheelEvent, ShapedLine, SharedString, Size,
+    StatefulInteractiveElement, Style, Styled, StyledText, TextAlign, TextRun, TextStyle,
+    TextStyleRefinement, WeakEntity, Window, anchored, deferred, div, fill, linear_color_stop,
+    linear_gradient, outline, pattern_slash, point, px, quad, relative, size, solid_background,
     transparent_black,
 };
 use itertools::Itertools;

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -8770,50 +8770,12 @@ impl LineWithInvisibles {
         kind: ChunkKind,
         base_font: gpui::Font,
         editor_style: &EditorStyle,
-        highlight_style: Option<gpui::HighlightStyle>,
     ) -> gpui::Font {
-        let mut font = match kind {
-            ChunkKind::InlayHint => {
-                // Use inlay-specific font if configured
-                if let Some(inlay_font) = &editor_style.inlay_hints_font {
-                    let mut font = base_font.clone();
-                    font.family = inlay_font.clone();
-                    font
-                } else {
-                    base_font.clone()
-                }
-            }
-            ChunkKind::EditPrediction => {
-                // Use inlay-specific font if configured
-                if let Some(edit_prediction_font) = &editor_style.edit_prediction_font {
-                    let mut font = base_font.clone();
-                    font.family = edit_prediction_font.clone();
-                    font
-                } else {
-                    base_font.clone()
-                }
-            }
-            _ => base_font.clone(),
-        };
-
-        // Apply weight and style from highlight style or inlay_hints_style
-        if let Some(style) = highlight_style {
-            if let Some(weight) = style.font_weight {
-                font.weight = weight;
-            }
-            if let Some(font_style) = style.font_style {
-                font.style = font_style;
-            }
-        } else {
-            if let Some(weight) = editor_style.inlay_hints_style.font_weight {
-                font.weight = weight;
-            }
-            if let Some(font_style) = editor_style.inlay_hints_style.font_style {
-                font.style = font_style;
-            }
+        match kind {
+            ChunkKind::InlayHint => editor_style.inlay_hints_font.clone(),
+            ChunkKind::EditPrediction => editor_style.edit_predictions_font.clone(),
+            _ => base_font,
         }
-
-        font
     }
 
     fn from_chunks<'a>(
@@ -8925,7 +8887,6 @@ impl LineWithInvisibles {
                                 highlighted_chunk.kind,
                                 text_style.font(),
                                 editor_style,
-                                highlighted_chunk.style,
                             ),
                             color: text_style.color,
                             background_color: text_style.background_color,
@@ -9000,7 +8961,6 @@ impl LineWithInvisibles {
                                 highlighted_chunk.kind,
                                 text_style.font(),
                                 editor_style,
-                                highlighted_chunk.style,
                             ),
                             color: text_style.color,
                             background_color: text_style.background_color,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -13,8 +13,8 @@ use crate::{
     code_context_menus::{CodeActionsMenu, MENU_ASIDE_MAX_WIDTH, MENU_ASIDE_MIN_WIDTH, MENU_GAP},
     column_pixels,
     display_map::{
-        Block, BlockContext, BlockStyle, ChunkRendererId, ChunkSpecial, DisplaySnapshot,
-        EditorMargins, HighlightKey, HighlightedChunk, ToDisplayPoint,
+        Block, BlockContext, BlockStyle, ChunkRendererId, DisplaySnapshot, EditorMargins,
+        HighlightKey, HighlightedChunk, ToDisplayPoint,
     },
     editor_settings::{
         CurrentLineHighlight, DocumentColorsRenderMode, DoubleClickInMultibuffer, Minimap,
@@ -51,7 +51,9 @@ use gpui::{
     pattern_slash, point, px, quad, relative, size, solid_background, transparent_black,
 };
 use itertools::Itertools;
-use language::{HighlightedText, IndentGuideSettings, language_settings::ShowWhitespaceSetting};
+use language::{
+    ChunkSpecial, HighlightedText, IndentGuideSettings, language_settings::ShowWhitespaceSetting,
+};
 use markdown::Markdown;
 use multi_buffer::{
     Anchor, ExcerptId, ExcerptInfo, ExpandExcerptDirection, ExpandInfo, MultiBufferPoint,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -13,8 +13,8 @@ use crate::{
     code_context_menus::{CodeActionsMenu, MENU_ASIDE_MAX_WIDTH, MENU_ASIDE_MIN_WIDTH, MENU_GAP},
     column_pixels,
     display_map::{
-        Block, BlockContext, BlockStyle, ChunkRendererId, DisplaySnapshot, EditorMargins,
-        HighlightKey, HighlightedChunk, ToDisplayPoint,
+        Block, BlockContext, BlockStyle, ChunkRendererId, ChunkSpecial, DisplaySnapshot,
+        EditorMargins, HighlightKey, HighlightedChunk, ToDisplayPoint,
     },
     editor_settings::{
         CurrentLineHighlight, DocumentColorsRenderMode, DoubleClickInMultibuffer, Minimap,
@@ -8763,6 +8763,57 @@ impl fmt::Debug for LineFragment {
 }
 
 impl LineWithInvisibles {
+    /// Helper function to get the appropriate font for a chunk, using inlay font if available
+    fn font_for_chunk(
+        special: ChunkSpecial,
+        base_font: gpui::Font,
+        editor_style: &EditorStyle,
+        highlight_style: Option<gpui::HighlightStyle>,
+    ) -> gpui::Font {
+        let mut font = match special {
+            ChunkSpecial::InlayHint => {
+                // Use inlay-specific font if configured
+                if let Some(inlay_font) = &editor_style.inlay_hints_font {
+                    let mut font = base_font.clone();
+                    font.family = inlay_font.clone();
+                    font
+                } else {
+                    base_font.clone()
+                }
+            }
+            ChunkSpecial::EditPrediction => {
+                // Use inlay-specific font if configured
+                if let Some(edit_prediction_font) = &editor_style.edit_prediction_font {
+                    let mut font = base_font.clone();
+                    font.family = edit_prediction_font.clone();
+                    font
+                } else {
+                    base_font.clone()
+                }
+            }
+            _ => base_font.clone(),
+        };
+
+        // Apply weight and style from highlight style or inlay_hints_style
+        if let Some(style) = highlight_style {
+            if let Some(weight) = style.font_weight {
+                font.weight = weight;
+            }
+            if let Some(font_style) = style.font_style {
+                font.style = font_style;
+            }
+        } else {
+            if let Some(weight) = editor_style.inlay_hints_style.font_weight {
+                font.weight = weight;
+            }
+            if let Some(font_style) = editor_style.inlay_hints_style.font_style {
+                font.style = font_style;
+            }
+        }
+
+        font
+    }
+
     fn from_chunks<'a>(
         chunks: impl Iterator<Item = HighlightedChunk<'a>>,
         editor_style: &EditorStyle,
@@ -8795,7 +8846,7 @@ impl LineWithInvisibles {
             text: "\n",
             style: None,
             is_tab: false,
-            is_inlay: false,
+            special: ChunkSpecial::None,
             replacement: None,
         }]) {
             if let Some(replacement) = highlighted_chunk.replacement {
@@ -8868,7 +8919,12 @@ impl LineWithInvisibles {
 
                         let run = TextRun {
                             len: x.len(),
-                            font: text_style.font(),
+                            font: Self::font_for_chunk(
+                                highlighted_chunk.special,
+                                text_style.font(),
+                                editor_style,
+                                highlighted_chunk.style,
+                            ),
                             color: text_style.color,
                             background_color: text_style.background_color,
                             underline: text_style.underline,
@@ -8938,40 +8994,50 @@ impl LineWithInvisibles {
 
                         styles.push(TextRun {
                             len: line_chunk.len(),
-                            font: text_style.font(),
+                            font: Self::font_for_chunk(
+                                highlighted_chunk.special,
+                                text_style.font(),
+                                editor_style,
+                                highlighted_chunk.style,
+                            ),
                             color: text_style.color,
                             background_color: text_style.background_color,
                             underline: text_style.underline,
                             strikethrough: text_style.strikethrough,
                         });
 
-                        if editor_mode.is_full() && !highlighted_chunk.is_inlay {
-                            // Line wrap pads its contents with fake whitespaces,
-                            // avoid printing them
-                            let is_soft_wrapped = is_row_soft_wrapped(row);
-                            if highlighted_chunk.is_tab {
-                                if non_whitespace_added || !is_soft_wrapped {
-                                    invisibles.push(Invisible::Tab {
-                                        line_start_offset: line.len(),
-                                        line_end_offset: line.len() + line_chunk.len(),
-                                    });
-                                }
-                            } else {
-                                invisibles.extend(line_chunk.char_indices().filter_map(
-                                    |(index, c)| {
-                                        let is_whitespace = c.is_whitespace();
-                                        non_whitespace_added |= !is_whitespace;
-                                        if is_whitespace
-                                            && (non_whitespace_added || !is_soft_wrapped)
-                                        {
-                                            Some(Invisible::Whitespace {
-                                                line_offset: line.len() + index,
-                                            })
-                                        } else {
-                                            None
+                        if editor_mode.is_full() {
+                            match highlighted_chunk.special {
+                                ChunkSpecial::InlayHint => {}
+                                _ => {
+                                    // Line wrap pads its contents with fake whitespaces,
+                                    // avoid printing them
+                                    let is_soft_wrapped = is_row_soft_wrapped(row);
+                                    if highlighted_chunk.is_tab {
+                                        if non_whitespace_added || !is_soft_wrapped {
+                                            invisibles.push(Invisible::Tab {
+                                                line_start_offset: line.len(),
+                                                line_end_offset: line.len() + line_chunk.len(),
+                                            });
                                         }
-                                    },
-                                ))
+                                    } else {
+                                        invisibles.extend(line_chunk.char_indices().filter_map(
+                                            |(index, c)| {
+                                                let is_whitespace = c.is_whitespace();
+                                                non_whitespace_added |= !is_whitespace;
+                                                if is_whitespace
+                                                    && (non_whitespace_added || !is_soft_wrapped)
+                                                {
+                                                    Some(Invisible::Whitespace {
+                                                        line_offset: line.len() + index,
+                                                    })
+                                                } else {
+                                                    None
+                                                }
+                                            },
+                                        ))
+                                    }
+                                }
                             }
                         }
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -8970,8 +8970,7 @@ impl LineWithInvisibles {
 
                         if editor_mode.is_full() {
                             match highlighted_chunk.kind {
-                                ChunkKind::InlayHint => {}
-                                _ => {
+                                ChunkKind::None => {
                                     // Line wrap pads its contents with fake whitespaces,
                                     // avoid printing them
                                     let is_soft_wrapped = is_row_soft_wrapped(row);
@@ -9000,6 +8999,7 @@ impl LineWithInvisibles {
                                         ))
                                     }
                                 }
+                                _ => {}
                             }
                         }
 

--- a/crates/editor/src/hover_links.rs
+++ b/crates/editor/src/hover_links.rs
@@ -1192,6 +1192,9 @@ mod tests {
                 show_other_hints: Some(true),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
 

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -1757,6 +1757,9 @@ mod tests {
                 show_other_hints: Some(true),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
 

--- a/crates/editor/src/inlays/inlay_hints.rs
+++ b/crates/editor/src/inlays/inlay_hints.rs
@@ -4646,6 +4646,9 @@ let c = 3;"#
                 show_other_hints: Some(true),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_features: None,
+                font_weight: None,
             })
         });
 

--- a/crates/editor/src/inlays/inlay_hints.rs
+++ b/crates/editor/src/inlays/inlay_hints.rs
@@ -1037,6 +1037,9 @@ pub mod tests {
                 show_other_hints: Some(allowed_hint_kinds.contains(&None)),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
         let (_, editor, fake_server) = prepare_test_objects(cx, |fake_server, file_with_hints| {
@@ -1231,6 +1234,9 @@ pub mod tests {
                 show_other_hints: Some(true),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
 
@@ -1341,6 +1347,9 @@ pub mod tests {
                 show_other_hints: Some(true),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
 
@@ -1590,6 +1599,9 @@ pub mod tests {
                 show_other_hints: Some(allowed_hint_kinds.contains(&None)),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
 
@@ -1755,6 +1767,9 @@ pub mod tests {
                     show_other_hints: Some(new_allowed_hint_kinds.contains(&None)),
                     show_background: Some(false),
                     toggle_on_modifiers_press: None,
+                    font_family: None,
+                    font_weight: None,
+                    font_features: None,
                 })
             });
             cx.executor().run_until_parked();
@@ -1802,6 +1817,9 @@ pub mod tests {
                 show_other_hints: Some(another_allowed_hint_kinds.contains(&None)),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
         cx.executor().run_until_parked();
@@ -1875,6 +1893,9 @@ pub mod tests {
                 show_other_hints: Some(final_allowed_hint_kinds.contains(&None)),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
         cx.executor().run_until_parked();
@@ -1949,6 +1970,9 @@ pub mod tests {
                 show_other_hints: Some(true),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
 
@@ -2313,6 +2337,9 @@ pub mod tests {
                 show_other_hints: Some(true),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
 
@@ -2929,6 +2956,9 @@ let c = 3;"#
                 show_other_hints: Some(false),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
 
@@ -3129,6 +3159,9 @@ let c = 3;"#
                 show_other_hints: Some(true),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
         cx.executor().run_until_parked();
@@ -3168,6 +3201,9 @@ let c = 3;"#
                 show_other_hints: Some(true),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
 
@@ -3279,6 +3315,9 @@ let c = 3;"#
                 show_other_hints: Some(true),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
 
@@ -3361,6 +3400,9 @@ let c = 3;"#
                 show_other_hints: Some(true),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
         cx.executor().run_until_parked();
@@ -3427,6 +3469,9 @@ let c = 3;"#
                 show_other_hints: Some(true),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
 
@@ -3653,6 +3698,9 @@ let c = 3;"#
                 show_other_hints: Some(true),
                 show_background: Some(false),
                 toggle_on_modifiers_press: None,
+                font_family: None,
+                font_weight: None,
+                font_features: None,
             })
         });
 

--- a/crates/editor/src/inlays/inlay_hints.rs
+++ b/crates/editor/src/inlays/inlay_hints.rs
@@ -40,7 +40,7 @@ pub fn inlay_hint_settings(
 ) -> InlayHintSettings {
     let file = snapshot.file_at(location);
     let language = snapshot.language_at(location).map(|l| l.name());
-    language_settings(language, file, cx).inlay_hints.clone()
+    language_settings(language, file, cx).inlay_hints
 }
 
 #[derive(Debug)]

--- a/crates/editor/src/inlays/inlay_hints.rs
+++ b/crates/editor/src/inlays/inlay_hints.rs
@@ -40,7 +40,7 @@ pub fn inlay_hint_settings(
 ) -> InlayHintSettings {
     let file = snapshot.file_at(location);
     let language = snapshot.language_at(location).map(|l| l.name());
-    language_settings(language, file, cx).inlay_hints
+    language_settings(language, file, cx).inlay_hints.clone()
 }
 
 #[derive(Debug)]

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -570,7 +570,7 @@ pub struct BufferChunks<'a> {
 }
 
 #[derive(Copy, Clone, Debug, Default)]
-pub enum ChunkSpecial {
+pub enum ChunkKind {
     #[default]
     None,
     InlayHint,
@@ -600,8 +600,8 @@ pub struct Chunk<'a> {
     pub is_unnecessary: bool,
     /// Whether this chunk of text was originally a tab character.
     pub is_tab: bool,
-    /// Whether this chunk of text was originally an inlay.
-    pub special: ChunkSpecial,
+    /// What kind of chunk this is.
+    pub kind: ChunkKind,
     /// Whether to underline the corresponding text range in the editor.
     pub underline: bool,
 }

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -569,6 +569,14 @@ pub struct BufferChunks<'a> {
     highlights: Option<BufferChunkHighlights<'a>>,
 }
 
+#[derive(Copy, Clone, Debug, Default)]
+pub enum ChunkSpecial {
+    #[default]
+    None,
+    InlayHint,
+    EditPrediction,
+}
+
 /// A chunk of a buffer's text, along with its syntax highlight and
 /// diagnostic status.
 #[derive(Clone, Debug, Default)]
@@ -593,7 +601,7 @@ pub struct Chunk<'a> {
     /// Whether this chunk of text was originally a tab character.
     pub is_tab: bool,
     /// Whether this chunk of text was originally an inlay.
-    pub is_inlay: bool,
+    pub special: ChunkSpecial,
     /// Whether to underline the corresponding text range in the editor.
     pub underline: bool,
 }

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -936,6 +936,8 @@ impl VsCodeSettings {
             unnecessary_code_fade: None,
             experimental_theme_overrides: None,
             theme_overrides: Default::default(),
+            inlay_hints_font_family: None,
+            edit_predictions_font_family: None,
         }
     }
 

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -916,6 +916,9 @@ impl VsCodeSettings {
 
     fn theme_settings_content(&self) -> ThemeSettingsContent {
         let (buffer_font_family, buffer_font_fallbacks) = self.read_fonts("editor.fontFamily");
+        let (inlay_hints_font_family, _) = self.read_fonts("editor.inlayHints.fontFamily");
+        let (edit_predictions_font_family, _) = self.read_fonts("editor.inlineSuggest.fontFamily");
+
         ThemeSettingsContent {
             ui_font_size: None,
             ui_font_family: None,
@@ -936,8 +939,12 @@ impl VsCodeSettings {
             unnecessary_code_fade: None,
             experimental_theme_overrides: None,
             theme_overrides: Default::default(),
-            inlay_hints_font_family: None,
-            edit_predictions_font_family: None,
+            inlay_hints_font_family,
+            inlay_hints_font_weight: None,
+            inlay_hints_font_features: None,
+            edit_predictions_font_family,
+            edit_predictions_font_weight: None,
+            edit_predictions_font_features: None,
         }
     }
 

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -514,6 +514,7 @@ impl VsCodeSettings {
     }
 
     fn default_language_settings_content(&self) -> LanguageSettingsContent {
+        let (inlay_hints_font_family, _) = self.read_fonts("editor.inlayHints.fontFamily");
         LanguageSettingsContent {
             allow_rewrap: None,
             always_treat_brackets_as_autoclosed: None,
@@ -550,7 +551,21 @@ impl VsCodeSettings {
                 enabled: self.read_bool("editor.guides.indentation"),
                 ..Default::default()
             }),
-            inlay_hints: None,
+            inlay_hints: if self.read_string("editor.inlayHints.enabled").is_some() {
+                Some(InlayHintSettingsContent {
+                    enabled: self.read_enum("editor.inlayHints.enabled", |s| {
+                        Some(match s {
+                            "on" => true,
+                            "onUnlessPressed" => true,
+                            _ => false,
+                        })
+                    }),
+                    font_family: inlay_hints_font_family,
+                    ..Default::default()
+                })
+            } else {
+                None
+            },
             jsx_tag_auto_close: None,
             language_servers: None,
             semantic_tokens: self
@@ -629,6 +644,8 @@ impl VsCodeSettings {
             .read_value("cursor.general.globalCursorIgnoreList")?
             .as_array()?;
 
+        let (edit_predictions_font_family, _) = self.read_fonts("editor.inlineSuggest.fontFamily");
+
         skip_default(EditPredictionSettingsContent {
             disabled_globs: skip_default(
                 disabled_globs
@@ -637,6 +654,7 @@ impl VsCodeSettings {
                     .map(|s| s.to_string())
                     .collect(),
             ),
+            font_family: edit_predictions_font_family,
             ..Default::default()
         })
     }
@@ -916,8 +934,6 @@ impl VsCodeSettings {
 
     fn theme_settings_content(&self) -> ThemeSettingsContent {
         let (buffer_font_family, buffer_font_fallbacks) = self.read_fonts("editor.fontFamily");
-        let (inlay_hints_font_family, _) = self.read_fonts("editor.inlayHints.fontFamily");
-        let (edit_predictions_font_family, _) = self.read_fonts("editor.inlineSuggest.fontFamily");
 
         ThemeSettingsContent {
             ui_font_size: None,
@@ -939,12 +955,6 @@ impl VsCodeSettings {
             unnecessary_code_fade: None,
             experimental_theme_overrides: None,
             theme_overrides: Default::default(),
-            inlay_hints_font_family,
-            inlay_hints_font_weight: None,
-            inlay_hints_font_features: None,
-            edit_predictions_font_family,
-            edit_predictions_font_weight: None,
-            edit_predictions_font_features: None,
         }
     }
 

--- a/crates/settings_content/src/language.rs
+++ b/crates/settings_content/src/language.rs
@@ -6,7 +6,10 @@ use serde::{Deserialize, Serialize, de::Error as _};
 use settings_macros::{MergeFrom, with_fallible_options};
 use std::sync::Arc;
 
-use crate::{DocumentFoldingRanges, DocumentSymbols, ExtendingVec, SemanticTokens, merge_from};
+use crate::{
+    DocumentFoldingRanges, DocumentSymbols, ExtendingVec, FontFamilyName, FontFeaturesContent,
+    FontWeightContent, SemanticTokens, merge_from,
+};
 
 /// The state of the modifier keys at some point in time
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema, MergeFrom)]
@@ -192,6 +195,19 @@ pub struct EditPredictionSettingsContent {
     pub enabled_in_text_threads: Option<bool>,
     /// The directory where manually captured edit prediction examples are stored.
     pub examples_dir: Option<Arc<Path>>,
+
+    /// The name of a font to use for rendering edit predictions.
+    ///
+    /// Defaults to inlay hints' font family.
+    pub font_family: Option<FontFamilyName>,
+    /// The weight of the editor font in CSS units from 100 to 900.
+    ///
+    /// Defaults to inlay hints' font weight.
+    pub font_weight: Option<FontWeightContent>,
+    /// The OpenType features to enable for rendering edit predictions.
+    ///
+    /// Defaults to inlay hints' font features.
+    pub font_features: Option<FontFeaturesContent>,
 }
 
 #[with_fallible_options]
@@ -716,7 +732,7 @@ pub struct JsxTagAutoCloseSettingsContent {
 
 /// The settings for inlay hints.
 #[with_fallible_options]
-#[derive(Clone, Default, Debug, Serialize, Deserialize, JsonSchema, MergeFrom, PartialEq, Eq)]
+#[derive(Clone, Default, Debug, Serialize, Deserialize, JsonSchema, MergeFrom, PartialEq)]
 pub struct InlayHintSettingsContent {
     /// Global switch to toggle hints on and off.
     ///
@@ -763,6 +779,19 @@ pub struct InlayHintSettingsContent {
     ///
     /// Default: null
     pub toggle_on_modifiers_press: Option<ModifiersContent>,
+
+    /// The name of a font to use for rendering inlay hints.
+    ///
+    /// Defaults to buffer's font family.
+    pub font_family: Option<FontFamilyName>,
+    /// The weight of the editor font in CSS units from 100 to 900.
+    ///
+    /// Defaults to buffer's font weight.
+    pub font_weight: Option<FontWeightContent>,
+    /// The OpenType features to enable for rendering inlay hints.
+    ///
+    /// Defaults to buffer's font features.
+    pub font_features: Option<FontFeaturesContent>,
 }
 
 /// The kind of an inlay hint.

--- a/crates/settings_content/src/theme.rs
+++ b/crates/settings_content/src/theme.rs
@@ -177,12 +177,10 @@ pub struct ThemeSettingsContent {
     pub theme_overrides: HashMap<String, ThemeStyleContent>,
 
     /// The font used for inlay hints.
-    #[serde(alias = "inlay_hints.font_family")]
-    pub inlay_hints_font_family: Option<String>,
+    pub inlay_hints_font_family: Option<FontFamilyName>,
 
     /// The font used for edit predictions.
-    #[serde(alias = "edit_predictions.font_family")]
-    pub edit_predictions_font_family: Option<String>,
+    pub edit_predictions_font_family: Option<FontFamilyName>,
 }
 
 /// A font size value in pixels, wrapping around `f32` for custom settings UI rendering.

--- a/crates/settings_content/src/theme.rs
+++ b/crates/settings_content/src/theme.rs
@@ -178,9 +178,13 @@ pub struct ThemeSettingsContent {
 
     /// The font used for inlay hints.
     pub inlay_hints_font_family: Option<FontFamilyName>,
+    pub inlay_hints_font_weight: Option<FontWeightContent>,
+    pub inlay_hints_font_features: Option<FontFeaturesContent>,
 
     /// The font used for edit predictions.
     pub edit_predictions_font_family: Option<FontFamilyName>,
+    pub edit_predictions_font_weight: Option<FontWeightContent>,
+    pub edit_predictions_font_features: Option<FontFeaturesContent>,
 }
 
 /// A font size value in pixels, wrapping around `f32` for custom settings UI rendering.

--- a/crates/settings_content/src/theme.rs
+++ b/crates/settings_content/src/theme.rs
@@ -175,6 +175,14 @@ pub struct ThemeSettingsContent {
     /// These values will override the ones on the specified theme
     #[serde(default)]
     pub theme_overrides: HashMap<String, ThemeStyleContent>,
+
+    /// The font used for inlay hints.
+    #[serde(alias = "inlay_hints.font_family")]
+    pub inlay_hints_font_family: Option<String>,
+
+    /// The font used for edit predictions.
+    #[serde(alias = "edit_predictions.font_family")]
+    pub edit_predictions_font_family: Option<String>,
 }
 
 /// A font size value in pixels, wrapping around `f32` for custom settings UI rendering.

--- a/crates/settings_content/src/theme.rs
+++ b/crates/settings_content/src/theme.rs
@@ -175,16 +175,6 @@ pub struct ThemeSettingsContent {
     /// These values will override the ones on the specified theme
     #[serde(default)]
     pub theme_overrides: HashMap<String, ThemeStyleContent>,
-
-    /// The font used for inlay hints.
-    pub inlay_hints_font_family: Option<FontFamilyName>,
-    pub inlay_hints_font_weight: Option<FontWeightContent>,
-    pub inlay_hints_font_features: Option<FontFeaturesContent>,
-
-    /// The font used for edit predictions.
-    pub edit_predictions_font_family: Option<FontFamilyName>,
-    pub edit_predictions_font_weight: Option<FontWeightContent>,
-    pub edit_predictions_font_features: Option<FontFeaturesContent>,
 }
 
 /// A font size value in pixels, wrapping around `f32` for custom settings UI rendering.

--- a/crates/theme/src/settings.rs
+++ b/crates/theme/src/settings.rs
@@ -711,10 +711,28 @@ impl settings::Settings for ThemeSettings {
 
         let buffer_font_family = content.buffer_font_family.as_ref().unwrap();
 
-        let buffer_font_features = content.buffer_font_features.clone().unwrap().into_gpui();
+        let buffer_font_features = content.buffer_font_features.clone().unwrap();
         let buffer_font_fallbacks =
             font_fallbacks_from_settings(content.buffer_font_fallbacks.clone());
-        let buffer_font_weight = content.buffer_font_weight.unwrap().into_gpui();
+        let buffer_font_weight = content.buffer_font_weight.unwrap();
+
+        // Inlay hints work in an "inheritance" manner. Base level is buffer options
+        // They can then be overridden by inlay hints options
+        // Then the underlying inlay hint type, which only edit predictions are
+        // supported for this atm.
+        // buffer > inlay hints > inlay type
+        let buffer_font_size = content.buffer_font_size.unwrap();
+        let inlay_hints_font_family = content
+            .inlay_hints_font_family
+            .as_ref()
+            .unwrap_or(buffer_font_family);
+        let inlay_hints_font_weight = content
+            .inlay_hints_font_weight
+            .unwrap_or(buffer_font_weight);
+        let inlay_hints_font_features = content
+            .inlay_hints_font_features
+            .clone()
+            .unwrap_or(buffer_font_features.clone());
 
         Self {
             ui_font_size: clamp_font_size(content.ui_font_size.unwrap().into_gpui()),
@@ -726,39 +744,41 @@ impl settings::Settings for ThemeSettings {
                 style: Default::default(),
             },
             inlay_hints_font: Font {
-                family: content
-                    .inlay_hints_font_family
-                    .as_ref()
-                    .unwrap_or(buffer_font_family)
-                    .0
-                    .clone()
-                    .into(),
-                features: buffer_font_features.clone(),
+                family: inlay_hints_font_family.0.clone().into(),
+                features: inlay_hints_font_features.clone().into_gpui(),
                 fallbacks: buffer_font_fallbacks.clone(),
-                weight: buffer_font_weight,
+                weight: inlay_hints_font_weight.into_gpui(),
                 style: FontStyle::default(),
             },
             edit_predictions_font: Font {
                 family: content
                     .edit_predictions_font_family
                     .as_ref()
-                    .unwrap_or(buffer_font_family)
+                    .unwrap_or(inlay_hints_font_family)
                     .0
                     .clone()
                     .into(),
-                features: buffer_font_features.clone(),
+                features: content
+                    .edit_predictions_font_features
+                    .clone()
+                    .unwrap_or(inlay_hints_font_features)
+                    .clone()
+                    .into_gpui(),
                 fallbacks: buffer_font_fallbacks.clone(),
-                weight: buffer_font_weight,
+                weight: content
+                    .edit_predictions_font_weight
+                    .unwrap_or(inlay_hints_font_weight)
+                    .into_gpui(),
                 style: FontStyle::default(),
             },
             buffer_font: Font {
                 family: buffer_font_family.0.clone().into(),
-                features: buffer_font_features,
+                features: buffer_font_features.clone().into_gpui(),
                 fallbacks: buffer_font_fallbacks,
-                weight: buffer_font_weight,
+                weight: buffer_font_weight.into_gpui(),
                 style: FontStyle::default(),
             },
-            buffer_font_size: clamp_font_size(content.buffer_font_size.unwrap().into_gpui()),
+            buffer_font_size: clamp_font_size(buffer_font_size.into_gpui()),
             buffer_line_height: content.buffer_line_height.unwrap().into(),
             agent_ui_font_size: content.agent_ui_font_size.map(|s| s.into_gpui()),
             agent_buffer_font_size: content.agent_buffer_font_size.map(|s| s.into_gpui()),

--- a/crates/theme/src/settings.rs
+++ b/crates/theme/src/settings.rs
@@ -136,9 +136,9 @@ pub struct ThemeSettings {
     /// The amount of fading applied to unnecessary code.
     pub unnecessary_code_fade: f32,
     /// The font used for inlay hints.
-    pub inlay_hint_font_family: Option<String>,
+    pub inlay_hints_font: Font,
     /// The font used for edit predictions.
-    pub edit_prediction_font_family: Option<String>,
+    pub edit_predictions_font: Font,
 }
 
 /// Returns the name of the default theme for the given [`Appearance`].
@@ -708,6 +708,14 @@ impl settings::Settings for ThemeSettings {
         let content = &content.theme;
         let theme_selection: ThemeSelection = content.theme.clone().unwrap().into();
         let icon_theme_selection: IconThemeSelection = content.icon_theme.clone().unwrap().into();
+
+        let buffer_font_family = content.buffer_font_family.as_ref().unwrap();
+
+        let buffer_font_features = content.buffer_font_features.clone().unwrap().into_gpui();
+        let buffer_font_fallbacks =
+            font_fallbacks_from_settings(content.buffer_font_fallbacks.clone());
+        let buffer_font_weight = content.buffer_font_weight.unwrap().into_gpui();
+
         Self {
             ui_font_size: clamp_font_size(content.ui_font_size.unwrap().into_gpui()),
             ui_font: Font {
@@ -717,17 +725,37 @@ impl settings::Settings for ThemeSettings {
                 weight: content.ui_font_weight.unwrap().into_gpui(),
                 style: Default::default(),
             },
-            buffer_font: Font {
+            inlay_hints_font: Font {
                 family: content
-                    .buffer_font_family
+                    .inlay_hints_font_family
                     .as_ref()
-                    .unwrap()
+                    .unwrap_or(buffer_font_family)
                     .0
                     .clone()
                     .into(),
-                features: content.buffer_font_features.clone().unwrap().into_gpui(),
-                fallbacks: font_fallbacks_from_settings(content.buffer_font_fallbacks.clone()),
-                weight: content.buffer_font_weight.unwrap().into_gpui(),
+                features: buffer_font_features.clone(),
+                fallbacks: buffer_font_fallbacks.clone(),
+                weight: buffer_font_weight,
+                style: FontStyle::default(),
+            },
+            edit_predictions_font: Font {
+                family: content
+                    .edit_predictions_font_family
+                    .as_ref()
+                    .unwrap_or(buffer_font_family)
+                    .0
+                    .clone()
+                    .into(),
+                features: buffer_font_features.clone(),
+                fallbacks: buffer_font_fallbacks.clone(),
+                weight: buffer_font_weight,
+                style: FontStyle::default(),
+            },
+            buffer_font: Font {
+                family: buffer_font_family.0.clone().into(),
+                features: buffer_font_features,
+                fallbacks: buffer_font_fallbacks,
+                weight: buffer_font_weight,
                 style: FontStyle::default(),
             },
             buffer_font_size: clamp_font_size(content.buffer_font_size.unwrap().into_gpui()),
@@ -740,8 +768,6 @@ impl settings::Settings for ThemeSettings {
             icon_theme: icon_theme_selection,
             ui_density: content.ui_density.unwrap_or_default().into(),
             unnecessary_code_fade: content.unnecessary_code_fade.unwrap().0.clamp(0.0, 0.9),
-            inlay_hint_font_family: content.inlay_hints_font_family.clone(),
-            edit_prediction_font_family: content.edit_predictions_font_family.clone(),
         }
     }
 }

--- a/crates/theme/src/settings.rs
+++ b/crates/theme/src/settings.rs
@@ -11,7 +11,7 @@ use refineable::Refineable;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 pub use settings::{FontFamilyName, IconThemeName, ThemeAppearanceMode, ThemeName};
-use settings::{IntoGpui, RegisterSetting, Settings, SettingsContent};
+use settings::{InlayHintSettingsContent, IntoGpui, RegisterSetting, Settings, SettingsContent};
 use std::sync::Arc;
 
 const MIN_FONT_SIZE: Pixels = px(6.0);
@@ -705,6 +705,7 @@ fn font_fallbacks_from_settings(
 
 impl settings::Settings for ThemeSettings {
     fn from_settings(content: &settings::SettingsContent) -> Self {
+        let project_content = &content.project;
         let content = &content.theme;
         let theme_selection: ThemeSelection = content.theme.clone().unwrap().into();
         let icon_theme_selection: IconThemeSelection = content.icon_theme.clone().unwrap().into();
@@ -721,18 +722,33 @@ impl settings::Settings for ThemeSettings {
         // Then the underlying inlay hint type, which only edit predictions are
         // supported for this atm.
         // buffer > inlay hints > inlay type
+        let inlay_content = project_content
+            .all_languages
+            .defaults
+            .inlay_hints
+            .clone()
+            .unwrap_or_else(|| InlayHintSettingsContent {
+                font_family: Some(buffer_font_family.clone()),
+                font_weight: Some(buffer_font_weight),
+                font_features: Some(buffer_font_features.clone()),
+                ..Default::default()
+            });
         let buffer_font_size = content.buffer_font_size.unwrap();
-        let inlay_hints_font_family = content
-            .inlay_hints_font_family
+        let inlay_hints_font_family = inlay_content
+            .font_family
             .as_ref()
             .unwrap_or(buffer_font_family);
-        let inlay_hints_font_weight = content
-            .inlay_hints_font_weight
-            .unwrap_or(buffer_font_weight);
-        let inlay_hints_font_features = content
-            .inlay_hints_font_features
+        let inlay_hints_font_weight = inlay_content.font_weight.unwrap_or(buffer_font_weight);
+        let inlay_hints_font_features = inlay_content
+            .font_features
             .clone()
             .unwrap_or(buffer_font_features.clone());
+
+        let edit_prediction_content = project_content
+            .all_languages
+            .edit_predictions
+            .clone()
+            .unwrap_or_default();
 
         Self {
             ui_font_size: clamp_font_size(content.ui_font_size.unwrap().into_gpui()),
@@ -751,21 +767,20 @@ impl settings::Settings for ThemeSettings {
                 style: FontStyle::default(),
             },
             edit_predictions_font: Font {
-                family: content
-                    .edit_predictions_font_family
+                family: edit_prediction_content
+                    .font_family
                     .as_ref()
                     .unwrap_or(inlay_hints_font_family)
                     .0
                     .clone()
                     .into(),
-                features: content
-                    .edit_predictions_font_features
-                    .clone()
+                features: edit_prediction_content
+                    .font_features
                     .unwrap_or(inlay_hints_font_features)
                     .into_gpui(),
                 fallbacks: buffer_font_fallbacks.clone(),
-                weight: content
-                    .edit_predictions_font_weight
+                weight: edit_prediction_content
+                    .font_weight
                     .unwrap_or(inlay_hints_font_weight)
                     .into_gpui(),
                 style: FontStyle::default(),

--- a/crates/theme/src/settings.rs
+++ b/crates/theme/src/settings.rs
@@ -135,6 +135,10 @@ pub struct ThemeSettings {
     pub ui_density: UiDensity,
     /// The amount of fading applied to unnecessary code.
     pub unnecessary_code_fade: f32,
+    /// The font used for inlay hints.
+    pub inlay_hint_font_family: Option<String>,
+    /// The font used for edit predictions.
+    pub edit_prediction_font_family: Option<String>,
 }
 
 /// Returns the name of the default theme for the given [`Appearance`].
@@ -736,6 +740,8 @@ impl settings::Settings for ThemeSettings {
             icon_theme: icon_theme_selection,
             ui_density: content.ui_density.unwrap_or_default().into(),
             unnecessary_code_fade: content.unnecessary_code_fade.unwrap().0.clamp(0.0, 0.9),
+            inlay_hint_font_family: content.inlay_hints_font_family.clone(),
+            edit_prediction_font_family: content.edit_predictions_font_family.clone(),
         }
     }
 }

--- a/crates/theme/src/settings.rs
+++ b/crates/theme/src/settings.rs
@@ -762,7 +762,6 @@ impl settings::Settings for ThemeSettings {
                     .edit_predictions_font_features
                     .clone()
                     .unwrap_or(inlay_hints_font_features)
-                    .clone()
                     .into_gpui(),
                 fallbacks: buffer_font_fallbacks.clone(),
                 weight: content
@@ -773,7 +772,7 @@ impl settings::Settings for ThemeSettings {
             },
             buffer_font: Font {
                 family: buffer_font_family.0.clone().into(),
-                features: buffer_font_features.clone().into_gpui(),
+                features: buffer_font_features.into_gpui(),
                 fallbacks: buffer_font_fallbacks,
                 weight: buffer_font_weight.into_gpui(),
                 style: FontStyle::default(),

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -599,7 +599,10 @@ For the case of "open", regular selection behavior can be achieved by holding `a
       "**/*.crt",
       "**/.dev.vars",
       "**/secrets.yml"
-    ]
+    ],
+    "font_family": null,
+    "font_weight": null,
+    "font_features": null
   }
 ```
 
@@ -2611,7 +2614,10 @@ Run the {#action icon_theme_selector::Toggle} action in the command palette to s
     "show_background": false,
     "edit_debounce_ms": 700,
     "scroll_debounce_ms": 50,
-    "toggle_on_modifiers_press": null
+    "toggle_on_modifiers_press": null,
+    "font_family": null,
+    "font_weight": null,
+    "font_features": null
   }
 }
 ```


### PR DESCRIPTION
Rework `is_inlay` on chunks to specify the kind of chunk instead as an enum.

Mark all existing inlay hint kinds as InlayHint except for edit predictions which are marked separately.

This allows us to handle rendering differently at the element level, currently this is used to adjust the font.

Closes #15716

- [x] Tests or screenshots needed?
- [x] Code Reviewed
- [x] Manual QA

Release Notes:

- Add support for specifying different fonts for inlay hints and edit predictions

https://github.com/user-attachments/assets/af0bb920-6d4a-4f56-9142-d6a03900e530

<img width="523" height="253" alt="image" src="https://github.com/user-attachments/assets/54175d3b-b2a1-47f1-b10c-65d0d4098eb0" />

Fonts in use:
- Monaspace Neon (buffer font)
- Monaspace Krypton (edit prediction font)
- OpenDyslexic Nerd Font Propo for inlay hints

Please note I have only dabbled in rust, so could be holding it wrong.