### PR TITLE
windows: Kill child process trees on exit using Job Objects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18360,6 +18360,7 @@ dependencies = [
  "util_macros",
  "walkdir",
  "which 6.0.3",
+ "windows 0.61.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -790,6 +790,7 @@ features = [
     "Win32_System_Pipes",
     "Win32_System_SystemInformation",
     "Win32_System_SystemServices",
+    "Win32_System_JobObjects",
     "Win32_System_Threading",
     "Win32_System_Variant",
     "Win32_System_WinRT",

--- a/crates/util/Cargo.toml
+++ b/crates/util/Cargo.toml
@@ -58,6 +58,7 @@ mach2.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 tendril = "0.4.3"
+windows.workspace = true
 
 [dev-dependencies]
 git2.workspace = true

--- a/crates/util/src/process.rs
+++ b/crates/util/src/process.rs
@@ -5,6 +5,91 @@ use std::process::Stdio;
 /// are killed when the process is terminated by using process groups.
 pub struct Child {
     process: smol::process::Child,
+    /// A Windows Job Object configured with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`.
+    /// When this handle is closed (on drop), all processes assigned to the job
+    /// — including any grandchildren — are terminated automatically.
+    #[cfg(windows)]
+    _job: Option<Win32JobObject>,
+}
+
+/// RAII wrapper around a Windows Job Object handle.
+///
+/// The job is created with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`, so closing
+/// the last handle to the job will terminate all processes assigned to it.
+#[cfg(windows)]
+struct Win32JobObject {
+    handle: windows::Win32::Foundation::HANDLE,
+}
+
+#[cfg(windows)]
+// SAFETY: The Win32 Job Object handle can be safely sent between threads.
+// Job object handles in Windows are kernel objects and the operations we
+// perform (close/terminate) are inherently thread-safe.
+unsafe impl Send for Win32JobObject {}
+
+#[cfg(windows)]
+// SAFETY: The Win32 Job Object handle can be safely shared between threads.
+// We only perform atomic kernel operations (close/terminate) on the handle.
+unsafe impl Sync for Win32JobObject {}
+
+#[cfg(windows)]
+impl Win32JobObject {
+    /// Creates a new anonymous Job Object configured to kill all assigned
+    /// processes when the job handle is closed.
+    fn new() -> Result<Self> {
+        use windows::Win32::System::JobObjects::{
+            CreateJobObjectW, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+            JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectExtendedLimitInformation,
+            SetInformationJobObject,
+        };
+
+        unsafe {
+            let handle = CreateJobObjectW(None, None).context("failed to create job object")?;
+
+            let mut info = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+            info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+
+            SetInformationJobObject(
+                handle,
+                JobObjectExtendedLimitInformation,
+                &info as *const _ as *const std::ffi::c_void,
+                std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+            )
+            .context("failed to set job object information")?;
+
+            Ok(Self { handle })
+        }
+    }
+
+    /// Assigns a process to this job object by its raw handle.
+    fn assign_process(&self, process_handle: windows::Win32::Foundation::HANDLE) -> Result<()> {
+        use windows::Win32::System::JobObjects::AssignProcessToJobObject;
+
+        unsafe {
+            AssignProcessToJobObject(self.handle, process_handle)
+                .context("failed to assign process to job object")?;
+        }
+        Ok(())
+    }
+
+    /// Terminates all processes in the job object.
+    fn terminate(&self) -> Result<()> {
+        use windows::Win32::System::JobObjects::TerminateJobObject;
+
+        unsafe {
+            TerminateJobObject(self.handle, 1).context("failed to terminate job object")?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+impl Drop for Win32JobObject {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = windows::Win32::Foundation::CloseHandle(self.handle);
+        }
+    }
 }
 
 impl std::ops::Deref for Child {
@@ -47,8 +132,9 @@ impl Child {
         stdout: Stdio,
         stderr: Stdio,
     ) -> Result<Self> {
-        // TODO(windows): create a job object and add the child process handle to it,
-        // see https://learn.microsoft.com/en-us/windows/win32/procthread/job-objects
+        use std::os::windows::io::AsRawHandle;
+        use windows::Win32::Foundation::HANDLE;
+
         let mut command = smol::process::Command::from(command);
         let process = command
             .stdin(stdin)
@@ -57,10 +143,42 @@ impl Child {
             .spawn()
             .with_context(|| format!("failed to spawn command {command:?}"))?;
 
-        Ok(Self { process })
+        // Create a job object and assign the child process to it.
+        // The job is configured with JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE so that
+        // all processes in the job (including any children spawned by the process)
+        // are terminated when the job handle is closed (i.e. when Child is dropped).
+        let job = match Win32JobObject::new() {
+            Ok(job) => {
+                let raw_handle = process.as_raw_handle();
+                let process_handle = HANDLE(raw_handle);
+                match job.assign_process(process_handle) {
+                    Ok(()) => Some(job),
+                    Err(e) => {
+                        log::warn!("failed to assign child process to job object: {e:#}");
+                        None
+                    }
+                }
+            }
+            Err(e) => {
+                log::warn!("failed to create job object for child process: {e:#}");
+                None
+            }
+        };
+
+        Ok(Self { process, _job: job })
     }
 
+    /// Consumes this wrapper and returns the inner `smol::process::Child`.
+    ///
+    /// On Windows, this leaks the job object handle so the process is not
+    /// killed. The caller assumes full responsibility for process lifetime.
     pub fn into_inner(self) -> smol::process::Child {
+        #[cfg(windows)]
+        {
+            // Leak the job object handle so that dropping it doesn't kill the
+            // process tree. The caller now owns the process lifetime.
+            std::mem::forget(self._job);
+        }
         self.process
     }
 
@@ -75,8 +193,12 @@ impl Child {
 
     #[cfg(windows)]
     pub fn kill(&mut self) -> Result<()> {
-        // TODO(windows): terminate the job object in kill
-        self.process.kill()?;
+        if let Some(ref job) = self._job {
+            job.terminate()?;
+        } else {
+            // Fallback: kill only the immediate process if no job object
+            self.process.kill()?;
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

Uses Win32 Job Objects with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` to ensure that child processes (Node.js runtimes, language servers, etc.) and their descendants are terminated when Zed exits on Windows.

## Problem

On Windows, child processes spawned by Zed (Node.js runtimes for language servers, Claude Code agent, etc.) survive as zombie processes after Zed is closed. This happens because Windows does not automatically terminate child processes when the parent exits, unlike Unix systems which can use process groups.

Closes #46474

## Implementation

- Creates a `Win32JobObject` RAII wrapper around Windows Job Object handles
- Each spawned child process gets its own Job Object configured with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`
- When the `Child` wrapper is dropped, the job handle is closed, which automatically terminates the entire process tree (including grandchildren)
- Falls back gracefully to direct process kill if job object creation fails
- `into_inner()` properly leaks the job handle via `std::mem::forget` to transfer process lifetime ownership to the caller
- `kill()` uses `TerminateJobObject` to kill the entire process tree instead of just the immediate child

## Testing

Verified manually on Windows 11:
- Node.js processes no longer persist in Task Manager after closing Zed
- Language servers and their child processes are properly cleaned up
- No regression in normal editor operation

## Release Notes:

- Fixed zombie Node.js processes remaining after closing Zed on Windows (#46474)
