### PR TITLE
git: Fix a panic in `spacer_blocks`

### DIFF
--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -1335,7 +1335,7 @@ impl BlockMap {
                     &mut our_wrapper,
                     &mut companion_wrapper,
                     current_boundary,
-                    current_range.end,
+                    current_range.end.min(excerpt.target_excerpt_range.end),
                     delta,
                 );
 
@@ -1368,7 +1368,7 @@ impl BlockMap {
                     &mut our_wrapper,
                     &mut companion_wrapper,
                     current_boundary,
-                    current_range.start,
+                    current_range.start.min(excerpt.target_excerpt_range.end),
                     delta,
                 );
                 delta = delta_at_start;
@@ -1408,7 +1408,7 @@ impl BlockMap {
                         &mut our_wrapper,
                         &mut companion_wrapper,
                         current_boundary,
-                        current_range.end,
+                        current_range.end.min(excerpt.target_excerpt_range.end),
                         delta,
                     );
                     delta = delta_at_end;

--- a/crates/editor/src/split.rs
+++ b/crates/editor/src/split.rs
@@ -250,16 +250,8 @@ fn patch_for_excerpt(
         .skip_while(|edit| edit.old.end < source_excerpt_start_in_buffer)
         .take_while(|edit| edit.old.start <= source_excerpt_end_in_buffer)
         .map(|edit| {
-            let clamped_source_start = edit
-                .old
-                .start
-                .max(source_excerpt_start_in_buffer)
-                .min(source_excerpt_end_in_buffer);
-            let clamped_source_end = edit
-                .old
-                .end
-                .max(source_excerpt_start_in_buffer)
-                .min(source_excerpt_end_in_buffer);
+            let clamped_source_start = edit.old.start.max(source_excerpt_start_in_buffer);
+            let clamped_source_end = edit.old.end.min(source_excerpt_end_in_buffer);
             let source_multibuffer_start = source_excerpt_start_in_multibuffer
                 + (clamped_source_start - source_excerpt_start_in_buffer);
             let source_multibuffer_end = source_excerpt_start_in_multibuffer


### PR DESCRIPTION
Closes ZED-4X5

Release Notes:

- N/A *or* Added/Fixed/Improved ...
