### PR TITLE
repl: Shutdown all kernels on app quit

### DIFF
--- a/crates/repl/src/kernels/mod.rs
+++ b/crates/repl/src/kernels/mod.rs
@@ -170,6 +170,7 @@ pub trait RunningKernel: Send + Debug {
     fn kernel_info(&self) -> Option<&KernelInfoReply>;
     fn set_kernel_info(&mut self, info: KernelInfoReply);
     fn force_shutdown(&mut self, window: &mut Window, cx: &mut App) -> Task<anyhow::Result<()>>;
+    fn kill(&mut self);
 }
 
 #[derive(Debug, Clone)]

--- a/crates/repl/src/kernels/remote_kernels.rs
+++ b/crates/repl/src/kernels/remote_kernels.rs
@@ -289,4 +289,8 @@ impl RunningKernel for RemoteRunningKernel {
             Ok(())
         })
     }
+
+    fn kill(&mut self) {
+        self.request_tx.close_channel();
+    }
 }

--- a/crates/repl/src/repl_store.rs
+++ b/crates/repl/src/repl_store.rs
@@ -289,7 +289,11 @@ impl ReplStore {
     fn shutdown_all_sessions(&mut self, cx: &mut Context<Self>) -> impl Future<Output = ()> + use<> {
         for session in self.sessions.values() {
             session.update(cx, |session, _cx| {
-                session.kernel = Kernel::Shutdown;
+                if let Kernel::RunningKernel(mut kernel) =
+                    std::mem::replace(&mut session.kernel, Kernel::Shutdown)
+                {
+                    kernel.kill();
+                }
             });
         }
         self.sessions.clear();

--- a/crates/repl/src/repl_store.rs
+++ b/crates/repl/src/repl_store.rs
@@ -11,8 +11,7 @@ use project::{Fs, Project, WorktreeId};
 use settings::{Settings, SettingsStore};
 
 use crate::kernels::{
-    Kernel, list_remote_kernelspecs, local_kernel_specifications,
-    python_env_kernel_specifications,
+    Kernel, list_remote_kernelspecs, local_kernel_specifications, python_env_kernel_specifications,
 };
 use crate::{JupyterSettings, KernelSpecification, Session};
 
@@ -286,7 +285,10 @@ impl ReplStore {
         self.sessions.remove(&entity_id);
     }
 
-    fn shutdown_all_sessions(&mut self, cx: &mut Context<Self>) -> impl Future<Output = ()> + use<> {
+    fn shutdown_all_sessions(
+        &mut self,
+        cx: &mut Context<Self>,
+    ) -> impl Future<Output = ()> + use<> {
         for session in self.sessions.values() {
             session.update(cx, |session, _cx| {
                 if let Kernel::RunningKernel(mut kernel) =

--- a/crates/repl/src/repl_store.rs
+++ b/crates/repl/src/repl_store.rs
@@ -1,3 +1,4 @@
+use std::future::Future;
 use std::sync::Arc;
 
 use anyhow::{Context as _, Result};
@@ -10,7 +11,8 @@ use project::{Fs, Project, WorktreeId};
 use settings::{Settings, SettingsStore};
 
 use crate::kernels::{
-    list_remote_kernelspecs, local_kernel_specifications, python_env_kernel_specifications,
+    Kernel, list_remote_kernelspecs, local_kernel_specifications,
+    python_env_kernel_specifications,
 };
 use crate::{JupyterSettings, KernelSpecification, Session};
 
@@ -47,9 +49,12 @@ impl ReplStore {
     }
 
     pub fn new(fs: Arc<dyn Fs>, cx: &mut Context<Self>) -> Self {
-        let subscriptions = vec![cx.observe_global::<SettingsStore>(move |this, cx| {
-            this.set_enabled(JupyterSettings::enabled(cx), cx);
-        })];
+        let subscriptions = vec![
+            cx.observe_global::<SettingsStore>(move |this, cx| {
+                this.set_enabled(JupyterSettings::enabled(cx), cx);
+            }),
+            cx.on_app_quit(Self::shutdown_all_sessions),
+        ];
 
         let this = Self {
             fs,
@@ -279,6 +284,16 @@ impl ReplStore {
 
     pub fn remove_session(&mut self, entity_id: EntityId) {
         self.sessions.remove(&entity_id);
+    }
+
+    fn shutdown_all_sessions(&mut self, cx: &mut Context<Self>) -> impl Future<Output = ()> + use<> {
+        for session in self.sessions.values() {
+            session.update(cx, |session, _cx| {
+                session.kernel = Kernel::Shutdown;
+            });
+        }
+        self.sessions.clear();
+        futures::future::ready(())
     }
 
     #[cfg(test)]


### PR DESCRIPTION
Closes #17985
Closes #21911

Force the shutdown of the kernel by ensuring the kernel sessions are dropped on app quit.

Release Notes:

- Fixed shutdown of kernels on app exit