### PR TITLE
repl: Pluck project off of editor directly

### DIFF
--- a/crates/repl/src/repl_sessions_ui.rs
+++ b/crates/repl/src/repl_sessions_ui.rs
@@ -78,9 +78,8 @@ pub fn init(cx: &mut App) {
                 return;
             }
 
-            cx.defer_in(window, |editor, window, cx| {
-                let workspace = Workspace::for_window(window, cx);
-                let project = workspace.map(|workspace| workspace.read(cx).project().clone());
+            cx.defer_in(window, |editor, _window, cx| {
+                let project = editor.project().cloned();
 
                 let is_local_project = project
                     .as_ref()


### PR DESCRIPTION
The new multi workspace introduced in #47795 changed the window root from `Workspace` to `MultiWorkspace`, which broke `Workspace::for_window()` (assuming that was meant to). That returns `None` now.  The REPL action registration in `repl_sessions_ui.rs` used this to check if the project was local, so when it got None, it silently skipped registering `repl::Run` and `repl::RunInPlace` on every editor.

Luckily we can just get the project directly from the editor in order to register actions.

Release Notes:

- N/A