### PR TITLE
gpui: Fix services menu passing NSMenuItem instead of NSMenu on macOS

### DIFF
--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -420,7 +420,7 @@ impl MacPlatform {
                     match menu_type {
                         SystemMenuType::Services => {
                             let app: id = msg_send![APP_CLASS, sharedApplication];
-                            app.setServicesMenu_(item);
+                            app.setServicesMenu_(submenu);
                         }
                     }
 


### PR DESCRIPTION
`setServicesMenu:` expects an `NSMenu` parameter, but was being passed `item` (an `NSMenuItem`) instead of `submenu` (the actual `NSMenu`).

Release Notes:

- N/A
