### PR TITLE
Add 'Recent in This Project' section to agent thread history

### DIFF
--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -840,6 +840,12 @@ impl NativeAgent {
         }
 
         let database_future = ThreadsDatabase::connect(cx);
+        let worktree_paths: Vec<String> = self
+            .project
+            .read(cx)
+            .visible_worktrees(cx)
+            .map(|worktree| worktree.read(cx).abs_path().to_string_lossy().to_string())
+            .collect();
         let (id, db_thread) =
             thread.update(cx, |thread, cx| (thread.id().clone(), thread.to_db(cx)));
         let Some(session) = self.sessions.get_mut(&id) else {
@@ -851,7 +857,10 @@ impl NativeAgent {
                 return;
             };
             let db_thread = db_thread.await;
-            database.save_thread(id, db_thread).await.log_err();
+            database
+                .save_thread(id, db_thread, worktree_paths)
+                .await
+                .log_err();
             thread_store.update(cx, |store, cx| store.reload(cx));
         });
     }

--- a/crates/agent/src/db.rs
+++ b/crates/agent/src/db.rs
@@ -29,6 +29,8 @@ pub struct DbThreadMetadata {
     #[serde(alias = "summary")]
     pub title: SharedString,
     pub updated_at: DateTime<Utc>,
+    #[serde(default)]
+    pub worktree_paths: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -357,6 +359,17 @@ impl ThreadsDatabase {
         "})?()
         .map_err(|e| anyhow!("Failed to create threads table: {}", e))?;
 
+        // For existing databases created before worktree_paths was added to the
+        // schema above. Silently ignored when the column already exists.
+        if let Ok(mut migrate) = connection.exec(indoc! {"
+            ALTER TABLE threads ADD COLUMN worktree_paths TEXT
+        "})
+        {
+            // Expected to fail with "duplicate column" on databases that already
+            // have the column — that error is harmless and intentionally discarded.
+            migrate().ok();
+        }
+
         let db = Self {
             executor,
             connection: Arc::new(Mutex::new(connection)),
@@ -369,6 +382,7 @@ impl ThreadsDatabase {
         connection: &Arc<Mutex<Connection>>,
         id: acp::SessionId,
         thread: DbThread,
+        worktree_paths: Vec<String>,
     ) -> Result<()> {
         const COMPRESSION_LEVEL: i32 = 3;
 
@@ -392,11 +406,20 @@ impl ThreadsDatabase {
         let data_type = DataType::Zstd;
         let data = compressed;
 
-        let mut insert = connection.exec_bound::<(Arc<str>, String, String, DataType, Vec<u8>)>(indoc! {"
-            INSERT OR REPLACE INTO threads (id, summary, updated_at, data_type, data) VALUES (?, ?, ?, ?, ?)
+        let worktree_paths_json = serde_json::to_string(&worktree_paths)?;
+
+        let mut insert = connection.exec_bound::<(Arc<str>, String, String, DataType, Vec<u8>, String)>(indoc! {"
+            INSERT OR REPLACE INTO threads (id, summary, updated_at, data_type, data, worktree_paths) VALUES (?, ?, ?, ?, ?, ?)
         "})?;
 
-        insert((id.0, title, updated_at, data_type, data))?;
+        insert((
+            id.0,
+            title,
+            updated_at,
+            data_type,
+            data,
+            worktree_paths_json,
+        ))?;
 
         Ok(())
     }
@@ -407,19 +430,23 @@ impl ThreadsDatabase {
         self.executor.spawn(async move {
             let connection = connection.lock();
 
-            let mut select =
-                connection.select_bound::<(), (Arc<str>, String, String)>(indoc! {"
-                SELECT id, summary, updated_at FROM threads ORDER BY updated_at DESC
+            let mut select = connection
+                .select_bound::<(), (Arc<str>, String, String, Option<String>)>(indoc! {"
+                SELECT id, summary, updated_at, worktree_paths FROM threads ORDER BY updated_at DESC
             "})?;
 
             let rows = select(())?;
             let mut threads = Vec::new();
 
-            for (id, summary, updated_at) in rows {
+            for (id, summary, updated_at, worktree_paths_json) in rows {
+                let worktree_paths = worktree_paths_json
+                    .and_then(|json| serde_json::from_str::<Vec<String>>(&json).ok())
+                    .unwrap_or_default();
                 threads.push(DbThreadMetadata {
                     id: acp::SessionId::new(id),
                     title: summary.into(),
                     updated_at: DateTime::parse_from_rfc3339(&updated_at)?.with_timezone(&Utc),
+                    worktree_paths,
                 });
             }
 
@@ -453,11 +480,16 @@ impl ThreadsDatabase {
         })
     }
 
-    pub fn save_thread(&self, id: acp::SessionId, thread: DbThread) -> Task<Result<()>> {
+    pub fn save_thread(
+        &self,
+        id: acp::SessionId,
+        thread: DbThread,
+        worktree_paths: Vec<String>,
+    ) -> Task<Result<()>> {
         let connection = self.connection.clone();
 
         self.executor
-            .spawn(async move { Self::save_thread_sync(&connection, id, thread) })
+            .spawn(async move { Self::save_thread_sync(&connection, id, thread, worktree_paths) })
     }
 
     pub fn delete_thread(&self, id: acp::SessionId) -> Task<Result<()>> {
@@ -572,11 +604,11 @@ mod tests {
         );
 
         database
-            .save_thread(older_id.clone(), older_thread)
+            .save_thread(older_id.clone(), older_thread, vec![])
             .await
             .unwrap();
         database
-            .save_thread(newer_id.clone(), newer_thread)
+            .save_thread(newer_id.clone(), newer_thread, vec![])
             .await
             .unwrap();
 
@@ -601,11 +633,11 @@ mod tests {
         );
 
         database
-            .save_thread(thread_id.clone(), original_thread)
+            .save_thread(thread_id.clone(), original_thread, vec![])
             .await
             .unwrap();
         database
-            .save_thread(thread_id.clone(), updated_thread)
+            .save_thread(thread_id.clone(), updated_thread, vec![])
             .await
             .unwrap();
 

--- a/crates/agent/src/thread_store.rs
+++ b/crates/agent/src/thread_store.rs
@@ -78,12 +78,13 @@ impl ThreadStore {
         &mut self,
         id: acp::SessionId,
         thread: crate::DbThread,
+        worktree_paths: Vec<String>,
         cx: &mut Context<Self>,
     ) -> Task<Result<()>> {
         let database_future = ThreadsDatabase::connect(cx);
         cx.spawn(async move |this, cx| {
             let database = database_future.await.map_err(|err| anyhow!(err))?;
-            database.save_thread(id, thread).await?;
+            database.save_thread(id, thread, worktree_paths).await?;
             this.update(cx, |this, cx| this.reload(cx))
         })
     }
@@ -129,6 +130,22 @@ impl ThreadStore {
 
     pub fn entries(&self) -> impl Iterator<Item = DbThreadMetadata> + '_ {
         self.threads.iter().cloned()
+    }
+
+    pub fn entries_for_project<'a>(
+        &'a self,
+        worktree_paths: &'a [String],
+    ) -> impl Iterator<Item = DbThreadMetadata> + 'a {
+        self.threads
+            .iter()
+            .filter(move |thread| {
+                !thread.worktree_paths.is_empty()
+                    && thread
+                        .worktree_paths
+                        .iter()
+                        .any(|path| worktree_paths.iter().any(|wp| util::paths::paths_eq(path, wp)))
+            })
+            .cloned()
     }
 }
 
@@ -177,12 +194,12 @@ mod tests {
         );
 
         let save_older = thread_store.update(cx, |store, cx| {
-            store.save_thread(older_id.clone(), older_thread, cx)
+            store.save_thread(older_id.clone(), older_thread, vec![], cx)
         });
         save_older.await.unwrap();
 
         let save_newer = thread_store.update(cx, |store, cx| {
-            store.save_thread(newer_id.clone(), newer_thread, cx)
+            store.save_thread(newer_id.clone(), newer_thread, vec![], cx)
         });
         save_newer.await.unwrap();
 
@@ -205,8 +222,9 @@ mod tests {
             Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap(),
         );
 
-        let save_task =
-            thread_store.update(cx, |store, cx| store.save_thread(thread_id, thread, cx));
+        let save_task = thread_store.update(cx, |store, cx| {
+            store.save_thread(thread_id, thread, vec![], cx)
+        });
         save_task.await.unwrap();
 
         cx.run_until_parked();
@@ -237,11 +255,11 @@ mod tests {
         );
 
         let save_first = thread_store.update(cx, |store, cx| {
-            store.save_thread(first_id.clone(), first_thread, cx)
+            store.save_thread(first_id.clone(), first_thread, vec![], cx)
         });
         save_first.await.unwrap();
         let save_second = thread_store.update(cx, |store, cx| {
-            store.save_thread(second_id.clone(), second_thread, cx)
+            store.save_thread(second_id.clone(), second_thread, vec![], cx)
         });
         save_second.await.unwrap();
         cx.run_until_parked();
@@ -274,11 +292,11 @@ mod tests {
         );
 
         let save_first = thread_store.update(cx, |store, cx| {
-            store.save_thread(first_id.clone(), first_thread, cx)
+            store.save_thread(first_id.clone(), first_thread, vec![], cx)
         });
         save_first.await.unwrap();
         let save_second = thread_store.update(cx, |store, cx| {
-            store.save_thread(second_id.clone(), second_thread, cx)
+            store.save_thread(second_id.clone(), second_thread, vec![], cx)
         });
         save_second.await.unwrap();
         cx.run_until_parked();
@@ -288,7 +306,7 @@ mod tests {
             Utc.with_ymd_and_hms(2024, 1, 3, 0, 0, 0).unwrap(),
         );
         let update_task = thread_store.update(cx, |store, cx| {
-            store.save_thread(first_id.clone(), updated_first, cx)
+            store.save_thread(first_id.clone(), updated_first, vec![], cx)
         });
         update_task.await.unwrap();
         cx.run_until_parked();
@@ -297,5 +315,52 @@ mod tests {
         assert_eq!(entries.len(), 2);
         assert_eq!(entries[0].id, first_id);
         assert_eq!(entries[1].id, second_id);
+    }
+
+    #[gpui::test]
+    async fn test_entries_for_project_filters_by_worktree_paths(cx: &mut TestAppContext) {
+        let thread_store = cx.new(|cx| ThreadStore::new(cx));
+        cx.run_until_parked();
+
+        let with_project_id = session_id("thread-a");
+        let without_project_id = session_id("thread-b");
+        let project_path = "/Users/test/my-project".to_string();
+
+        let thread = make_thread(
+            "Thread with project",
+            Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap(),
+        );
+        let paths = vec![project_path.clone()];
+        thread_store
+            .update(cx, |store, cx| {
+                store.save_thread(with_project_id.clone(), thread, paths, cx)
+            })
+            .await
+            .unwrap();
+
+        let thread = make_thread(
+            "Thread without project",
+            Utc.with_ymd_and_hms(2024, 1, 2, 0, 0, 0).unwrap(),
+        );
+        thread_store
+            .update(cx, |store, cx| {
+                store.save_thread(without_project_id.clone(), thread, vec![], cx)
+            })
+            .await
+            .unwrap();
+        cx.run_until_parked();
+
+        let matched: Vec<_> = thread_store.read_with(cx, |store, _cx| {
+            store.entries_for_project(&[project_path]).collect()
+        });
+        assert_eq!(matched.len(), 1);
+        assert_eq!(matched[0].id, with_project_id);
+
+        let unmatched: Vec<_> = thread_store.read_with(cx, |store, _cx| {
+            store
+                .entries_for_project(&["/Users/test/other".to_string()])
+                .collect()
+        });
+        assert_eq!(unmatched.len(), 0);
     }
 }

--- a/crates/agent_ui/src/acp/thread_view/active_thread.rs
+++ b/crates/agent_ui/src/acp/thread_view/active_thread.rs
@@ -225,6 +225,8 @@ pub struct AcpThreadView {
     pub message_editor: Entity<MessageEditor>,
     pub add_context_menu_handle: PopoverMenuHandle<ContextMenu>,
     pub project: WeakEntity<Project>,
+    pub thread_store: Option<Entity<ThreadStore>>,
+    pub project_history_count: usize,
     pub recent_history_entries: Vec<AgentSessionInfo>,
     pub hovered_recent_history_item: Option<usize>,
     pub show_codex_windows_warning: bool,
@@ -287,7 +289,7 @@ impl AcpThreadView {
             let mut editor = MessageEditor::new(
                 workspace.clone(),
                 project.clone(),
-                thread_store,
+                thread_store.clone(),
                 history.downgrade(),
                 prompt_store,
                 prompt_capabilities.clone(),
@@ -334,7 +336,8 @@ impl AcpThreadView {
             Self::handle_message_editor_event,
         ));
 
-        let recent_history_entries = history.read(cx).get_recent_sessions(3);
+        let (project_history_count, recent_history_entries) =
+            Self::compute_recent_history(thread_store.as_ref(), &project, &history, cx);
 
         Self {
             id,
@@ -391,6 +394,8 @@ impl AcpThreadView {
             message_editor,
             add_context_menu_handle: PopoverMenuHandle::default(),
             project,
+            thread_store,
+            project_history_count,
             recent_history_entries,
             hovered_recent_history_item: None,
             history,
@@ -1453,6 +1458,11 @@ impl AcpThreadView {
         let thread_store = session_list.thread_store().clone();
 
         let client = project.read(cx).client();
+        let worktree_paths: Vec<String> = project
+            .read(cx)
+            .visible_worktrees(cx)
+            .map(|worktree| worktree.read(cx).abs_path().to_string_lossy().to_string())
+            .collect();
         let session_id = self.thread.read(cx).session_id().clone();
 
         cx.spawn_in(window, async move |this, cx| {
@@ -1468,7 +1478,7 @@ impl AcpThreadView {
 
             thread_store
                 .update(&mut cx.clone(), |store, cx| {
-                    store.save_thread(session_id.clone(), db_thread, cx)
+                    store.save_thread(session_id.clone(), db_thread, worktree_paths, cx)
                 })
                 .await?;
 
@@ -6664,9 +6674,74 @@ impl AcpThreadView {
         history: &Entity<AcpThreadHistory>,
         cx: &mut Context<Self>,
     ) {
-        self.recent_history_entries = history.read(cx).get_recent_sessions(3);
+        let (project_history_count, recent_history_entries) =
+            Self::compute_recent_history(self.thread_store.as_ref(), &self.project, history, cx);
+        self.project_history_count = project_history_count;
+        self.recent_history_entries = recent_history_entries;
         self.hovered_recent_history_item = None;
         cx.notify();
+    }
+
+    fn compute_recent_history(
+        thread_store: Option<&Entity<ThreadStore>>,
+        project: &WeakEntity<Project>,
+        history: &Entity<AcpThreadHistory>,
+        cx: &App,
+    ) -> (usize, Vec<AgentSessionInfo>) {
+        let worktree_paths: Vec<String> = project
+            .upgrade()
+            .map(|project| {
+                project
+                    .read(cx)
+                    .visible_worktrees(cx)
+                    .map(|worktree| worktree.read(cx).abs_path().to_string_lossy().to_string())
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let project_entries: Vec<AgentSessionInfo> = match thread_store {
+            Some(store) if !worktree_paths.is_empty() => store
+                .read(cx)
+                .entries_for_project(&worktree_paths)
+                .take(3)
+                .map(|entry| AgentSessionInfo {
+                    session_id: entry.id,
+                    cwd: None,
+                    title: Some(entry.title),
+                    updated_at: Some(entry.updated_at),
+                    meta: None,
+                })
+                .collect(),
+            _ => Vec::new(),
+        };
+
+        let project_count = project_entries.len();
+        let project_ids: Vec<_> = project_entries
+            .iter()
+            .map(|entry| entry.session_id.clone())
+            .collect();
+
+        let recent_entries: Vec<AgentSessionInfo> = history
+            .read(cx)
+            .get_recent_sessions(3 + project_count)
+            .into_iter()
+            .filter(|entry| !project_ids.contains(&entry.session_id))
+            .take(3)
+            .collect();
+
+        // Only split into two sections when both have entries.
+        // When all chats happen to be in this project there is
+        // nothing to distinguish from, so show them all as "Recent".
+        let effective_project_count = if recent_entries.is_empty() {
+            0
+        } else {
+            project_count
+        };
+
+        let mut entries = project_entries;
+        entries.extend(recent_entries);
+
+        (effective_project_count, entries)
     }
 
     fn render_empty_state_section_header(
@@ -6694,66 +6769,102 @@ impl AcpThreadView {
     }
 
     fn render_recent_history(&self, cx: &mut Context<Self>) -> AnyElement {
-        let render_history = !self.recent_history_entries.is_empty();
+        if self.recent_history_entries.is_empty() {
+            return v_flex().size_full().into_any();
+        }
 
-        v_flex()
-            .size_full()
-            .when(render_history, |this| {
-                let recent_history = self.recent_history_entries.clone();
-                this.justify_end().child(
-                    v_flex()
-                        .child(
-                            self.render_empty_state_section_header(
-                                "Recent",
-                                Some(
-                                    Button::new("view-history", "View All")
-                                        .style(ButtonStyle::Subtle)
-                                        .label_size(LabelSize::Small)
-                                        .key_binding(
-                                            KeyBinding::for_action_in(
-                                                &OpenHistory,
-                                                &self.focus_handle(cx),
-                                                cx,
-                                            )
-                                            .map(|kb| kb.size(rems_from_px(12.))),
-                                        )
-                                        .on_click(move |_event, window, cx| {
-                                            window.dispatch_action(OpenHistory.boxed_clone(), cx);
-                                        })
-                                        .into_any_element(),
-                                ),
-                                cx,
-                            ),
-                        )
-                        .child(v_flex().p_1().pr_1p5().gap_1().children({
-                            let supports_delete = self.history.read(cx).supports_delete();
-                            recent_history
-                                .into_iter()
-                                .enumerate()
-                                .map(move |(index, entry)| {
-                                    // TODO: Add keyboard navigation.
-                                    let is_hovered =
-                                        self.hovered_recent_history_item == Some(index);
-                                    crate::acp::thread_history::AcpHistoryEntryElement::new(
-                                        entry,
-                                        self.server_view.clone(),
-                                    )
-                                    .hovered(is_hovered)
-                                    .supports_delete(supports_delete)
-                                    .on_hover(cx.listener(move |this, is_hovered, _window, cx| {
-                                        if *is_hovered {
-                                            this.hovered_recent_history_item = Some(index);
-                                        } else if this.hovered_recent_history_item == Some(index) {
-                                            this.hovered_recent_history_item = None;
-                                        }
-                                        cx.notify();
-                                    }))
-                                    .into_any_element()
-                                })
-                        })),
-                )
+        let supports_delete = self.history.read(cx).supports_delete();
+        let project_count = self.project_history_count;
+        let total_count = self.recent_history_entries.len();
+
+        let mut content = v_flex();
+
+        if project_count > 0 {
+            content = content
+                .child(self.render_empty_state_section_header(
+                    "Recent in This Project",
+                    Some(self.render_view_all_button(cx)),
+                    cx,
+                ))
+                .child(
+                    v_flex().p_1().pr_1p5().gap_1().children(
+                        self.recent_history_entries[..project_count]
+                            .iter()
+                            .cloned()
+                            .enumerate()
+                            .map(|(index, entry)| {
+                                self.render_recent_history_entry(entry, index, supports_delete, cx)
+                            }),
+                    ),
+                );
+        }
+
+        if total_count > project_count {
+            content = content
+                .child(self.render_empty_state_section_header(
+                    "Recent",
+                    if project_count == 0 {
+                        Some(self.render_view_all_button(cx))
+                    } else {
+                        None
+                    },
+                    cx,
+                ))
+                .child(
+                    v_flex().p_1().pr_1p5().gap_1().children(
+                        self.recent_history_entries[project_count..]
+                            .iter()
+                            .cloned()
+                            .enumerate()
+                            .map(|(i, entry)| {
+                                self.render_recent_history_entry(
+                                    entry,
+                                    project_count + i,
+                                    supports_delete,
+                                    cx,
+                                )
+                            }),
+                    ),
+                );
+        }
+
+        v_flex().size_full().justify_end().child(content).into_any()
+    }
+
+    fn render_view_all_button(&self, cx: &mut Context<Self>) -> AnyElement {
+        Button::new("view-history", "View All")
+            .style(ButtonStyle::Subtle)
+            .label_size(LabelSize::Small)
+            .key_binding(
+                KeyBinding::for_action_in(&OpenHistory, &self.focus_handle(cx), cx)
+                    .map(|kb| kb.size(rems_from_px(12.))),
+            )
+            .on_click(move |_event, window, cx| {
+                window.dispatch_action(OpenHistory.boxed_clone(), cx);
             })
-            .into_any()
+            .into_any_element()
+    }
+
+    fn render_recent_history_entry(
+        &self,
+        entry: AgentSessionInfo,
+        index: usize,
+        supports_delete: bool,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let is_hovered = self.hovered_recent_history_item == Some(index);
+        crate::acp::thread_history::AcpHistoryEntryElement::new(entry, self.server_view.clone())
+            .hovered(is_hovered)
+            .supports_delete(supports_delete)
+            .on_hover(cx.listener(move |this, is_hovered, _window, cx| {
+                if *is_hovered {
+                    this.hovered_recent_history_item = Some(index);
+                } else if this.hovered_recent_history_item == Some(index) {
+                    this.hovered_recent_history_item = None;
+                }
+                cx.notify();
+            }))
+            .into_any_element()
     }
 
     fn render_codex_windows_warning(&self, cx: &mut Context<Self>) -> Callout {

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1420,11 +1420,17 @@ impl AgentPanel {
         let thread_store = self.thread_store.clone();
         let title = db_thread.title.clone();
         let workspace = self.workspace.clone();
+        let worktree_paths: Vec<String> = self
+            .project
+            .read(cx)
+            .visible_worktrees(cx)
+            .map(|worktree| worktree.read(cx).abs_path().to_string_lossy().to_string())
+            .collect();
 
         cx.spawn_in(window, async move |this, cx| {
             thread_store
                 .update(&mut cx.clone(), |store, cx| {
-                    store.save_thread(session_id.clone(), db_thread, cx)
+                    store.save_thread(session_id.clone(), db_thread, worktree_paths, cx)
                 })
                 .await?;
 
@@ -1584,42 +1590,119 @@ impl AgentPanel {
     ) -> ContextMenu {
         match kind {
             HistoryKind::AgentThreads => {
-                let entries = panel
+                let project = panel.read(cx).project.clone();
+                let thread_store = panel.read(cx).thread_store.clone();
+
+                let worktree_paths: Vec<String> = project
+                    .read(cx)
+                    .visible_worktrees(cx)
+                    .map(|worktree| worktree.read(cx).abs_path().to_string_lossy().to_string())
+                    .collect();
+
+                let project_entries: Vec<AgentSessionInfo> = if worktree_paths.is_empty() {
+                    Vec::new()
+                } else {
+                    thread_store
+                        .read(cx)
+                        .entries_for_project(&worktree_paths)
+                        .take(RECENTLY_UPDATED_MENU_LIMIT)
+                        .map(|entry| AgentSessionInfo {
+                            session_id: entry.id,
+                            cwd: None,
+                            title: Some(entry.title),
+                            updated_at: Some(entry.updated_at),
+                            meta: None,
+                        })
+                        .collect()
+                };
+
+                let project_session_ids: Vec<_> = project_entries
+                    .iter()
+                    .map(|entry| entry.session_id.clone())
+                    .collect();
+
+                let recent_entries: Vec<_> = panel
                     .read(cx)
                     .acp_history
                     .read(cx)
                     .sessions()
                     .iter()
+                    .filter(|entry| !project_session_ids.contains(&entry.session_id))
                     .take(RECENTLY_UPDATED_MENU_LIMIT)
                     .cloned()
-                    .collect::<Vec<_>>();
+                    .collect();
 
-                if entries.is_empty() {
+                if project_entries.is_empty() && recent_entries.is_empty() {
                     return menu;
                 }
 
-                menu = menu.header("Recently Updated");
+                // Only split into two sections when there are entries
+                // in both categories. When all chats happen to be in
+                // this project there is nothing to distinguish from, so
+                // just show them as "Recently Updated".
+                let show_project_section =
+                    !project_entries.is_empty() && !recent_entries.is_empty();
 
-                for entry in entries {
-                    let title = entry
-                        .title
-                        .as_ref()
-                        .filter(|title| !title.is_empty())
-                        .cloned()
-                        .unwrap_or_else(|| SharedString::new_static(DEFAULT_THREAD_TITLE));
+                if show_project_section {
+                    menu = menu.header("Recent in This Project");
 
-                    menu = menu.entry(title, None, {
-                        let panel = panel.downgrade();
-                        let entry = entry.clone();
-                        move |window, cx| {
+                    for entry in &project_entries {
+                        let title = entry
+                            .title
+                            .as_ref()
+                            .filter(|title| !title.is_empty())
+                            .cloned()
+                            .unwrap_or_else(|| SharedString::new_static(DEFAULT_THREAD_TITLE));
+
+                        menu = menu.entry(title, None, {
+                            let panel = panel.downgrade();
                             let entry = entry.clone();
-                            panel
-                                .update(cx, move |this, cx| {
-                                    this.load_agent_thread(entry.clone(), window, cx);
-                                })
-                                .ok();
-                        }
-                    });
+                            move |window, cx| {
+                                let entry = entry.clone();
+                                panel
+                                    .update(cx, move |this, cx| {
+                                        this.load_agent_thread(entry.clone(), window, cx);
+                                    })
+                                    .ok();
+                            }
+                        });
+                    }
+
+                    menu = menu.separator();
+                }
+
+                let recently_updated_entries = if show_project_section {
+                    recent_entries
+                } else {
+                    let mut merged = project_entries;
+                    merged.extend(recent_entries);
+                    merged
+                };
+
+                if !recently_updated_entries.is_empty() {
+                    menu = menu.header("Recently Updated");
+
+                    for entry in recently_updated_entries {
+                        let title = entry
+                            .title
+                            .as_ref()
+                            .filter(|title| !title.is_empty())
+                            .cloned()
+                            .unwrap_or_else(|| SharedString::new_static(DEFAULT_THREAD_TITLE));
+
+                        menu = menu.entry(title, None, {
+                            let panel = panel.downgrade();
+                            let entry = entry.clone();
+                            move |window, cx| {
+                                let entry = entry.clone();
+                                panel
+                                    .update(cx, move |this, cx| {
+                                        this.load_agent_thread(entry.clone(), window, cx);
+                                    })
+                                    .ok();
+                            }
+                        });
+                    }
                 }
             }
             HistoryKind::TextThreads => {

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -38,6 +38,17 @@ pub fn home_dir() -> &'static PathBuf {
     })
 }
 
+/// Compares two path strings for equality using the local filesystem's
+/// case sensitivity: case-insensitive on macOS/Windows, case-sensitive
+/// elsewhere.
+pub fn paths_eq(a: &str, b: &str) -> bool {
+    if cfg!(any(target_os = "macos", target_os = "windows")) {
+        a.eq_ignore_ascii_case(b)
+    } else {
+        a == b
+    }
+}
+
 pub trait PathExt {
     /// Compacts a given file path by replacing the user's home directory
     /// prefix with a tilde (`~`).

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -886,14 +886,25 @@ fn handle_open_request(request: OpenRequest, app_state: Arc<AppState>, cx: &mut 
                     let workspace =
                         multi_workspace.read_with(cx, |mw, _| mw.workspace().clone())?;
 
-                    let (client, thread_store) =
+                    let (client, thread_store, worktree_paths) =
                         multi_workspace.update(cx, |_, _window, cx| {
                             workspace.update(cx, |workspace, cx| {
-                                let client = workspace.project().read(cx).client();
+                                let project = workspace.project().read(cx);
+                                let client = project.client();
+                                let worktree_paths: Vec<String> = project
+                                    .visible_worktrees(cx)
+                                    .map(|worktree| {
+                                        worktree
+                                            .read(cx)
+                                            .abs_path()
+                                            .to_string_lossy()
+                                            .to_string()
+                                    })
+                                    .collect();
                                 let thread_store: Option<gpui::Entity<ThreadStore>> = workspace
                                     .panel::<AgentPanel>(cx)
                                     .map(|panel| panel.read(cx).thread_store().clone());
-                                anyhow::Ok((client, thread_store))
+                                anyhow::Ok((client, thread_store, worktree_paths))
                             })
                         })??;
 
@@ -916,7 +927,7 @@ fn handle_open_request(request: OpenRequest, app_state: Arc<AppState>, cx: &mut 
 
                     thread_store
                         .update(&mut cx.clone(), |store, cx| {
-                            store.save_thread(save_session_id.clone(), db_thread, cx)
+                            store.save_thread(save_session_id.clone(), db_thread, worktree_paths, cx)
                         })
                         .await?;
 


### PR DESCRIPTION
### Problem

When working across multiple projects, it'\''s useful to glance at previous chats to remember what you were last working on in a specific project. Previously, the recent chat history was global — it showed the most recent chats regardless of which project they belonged to, making it hard to quickly pick up where you left off.

### Solution

Associate each agent chat with the project'\''s worktree paths when saving, and use that metadata to show a **"Recent in This Project"** section alongside the existing **"Recent" / "Recently Updated"** section. This applies in both the empty-state of the ACP thread view and the agent panel'\''s session picker menu.

- Threads are now saved with `worktree_paths`, linking them to the project they were used in.
- The recent history is split into two sections: project-specific entries first, then general recent entries (deduplicated).
- Path matching is case-insensitive on macOS/Windows.
- When all recent chats already belong to the current project, we don'\''t show both sections — there'\''s nothing to distinguish from, so they'\''re displayed as a single "Recent" list to avoid redundancy.

Screenshots:
<img width="559" height="409" alt="image" src="https://github.com/user-attachments/assets/57f0eca5-064a-49ba-82bf-4f20488261bd" />
<img width="344" height="336" alt="image" src="https://github.com/user-attachments/assets/2fba382f-72bc-4662-a195-8d7853ff6394" />


Release Notes:

- Improved the agent thread navigation menu to show a "Recent in This Project" section, making it easier to find past conversations relevant to your current project.
