### PR TITLE
git: Side-by-side action renames and linked mode toggle

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -79,7 +79,7 @@ pub use multi_buffer::{
     ToPoint,
 };
 pub use split::{
-    SplitDiff, SplitDiffFeatureFlag, SplittableEditor, ToggleLockedCursors, ToggleSplitDiff,
+    SideBySideDiffView, SplitDiffFeatureFlag, SplittableEditor, ToggleLinkedCursors, ToggleSplitDiff,
 };
 pub use split_editor_view::SplitEditorView;
 pub use text::Bias;

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -79,7 +79,7 @@ pub use multi_buffer::{
     ToPoint,
 };
 pub use split::{
-    SideBySideDiffView, SplitDiffFeatureFlag, SplittableEditor, ToggleLinkedCursors, ToggleSplitDiff,
+    SideBySideDiffView, SplitDiffFeatureFlag, SplittableEditor, ToggleLinkedCursors, ToggleDiffView,
 };
 pub use split_editor_view::SplitEditorView;
 pub use text::Bias;

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -79,7 +79,7 @@ pub use multi_buffer::{
     ToPoint,
 };
 pub use split::{
-    SideBySideDiffView, SplitDiffFeatureFlag, SplittableEditor, ToggleLinkedCursors, ToggleDiffView,
+    SideBySideDiffView, SplitDiffFeatureFlag, SplittableEditor, ToggleDiffView, ToggleLinkedCursors,
 };
 pub use split_editor_view::SplitEditorView;
 pub use text::Bias;

--- a/crates/editor/src/split.rs
+++ b/crates/editor/src/split.rs
@@ -40,7 +40,6 @@ use crate::{
 };
 use util::ResultExt as _;
 
-
 const LINKED_CURSORS_KEY: &str = "split_diff_linked_cursors";
 
 fn read_linked_cursors_enabled() -> bool {

--- a/crates/editor/src/split.rs
+++ b/crates/editor/src/split.rs
@@ -34,13 +34,12 @@ use workspace::{
 };
 
 use crate::{
-    Autoscroll, DisplayMap, Editor, EditorEvent, RenderDiffHunkControlsFn, ToggleCodeActions,
-    ToggleSoftWrap,
+    Autoscroll, DisplayMap, Editor, EditorEvent, RenderDiffHunkControlsFn, ToggleSoftWrap,
     actions::{DisableBreakpoint, EditLogBreakpoint, EnableBreakpoint, ToggleBreakpoint},
     display_map::Companion,
 };
 use util::ResultExt as _;
-use zed_actions::assistant::InlineAssist;
+
 
 const LINKED_CURSORS_KEY: &str = "split_diff_linked_cursors";
 
@@ -851,19 +850,6 @@ impl SplittableEditor {
         }
     }
 
-    fn intercept_toggle_code_actions(
-        &mut self,
-        _: &ToggleCodeActions,
-        _window: &mut Window,
-        cx: &mut Context<Self>,
-    ) {
-        if self.lhs.is_some() {
-            cx.stop_propagation();
-        } else {
-            cx.propagate();
-        }
-    }
-
     fn intercept_toggle_breakpoint(
         &mut self,
         _: &ToggleBreakpoint,
@@ -931,19 +917,6 @@ impl SplittableEditor {
             } else {
                 cx.propagate();
             }
-        } else {
-            cx.propagate();
-        }
-    }
-
-    fn intercept_inline_assist(
-        &mut self,
-        _: &InlineAssist,
-        _window: &mut Window,
-        cx: &mut Context<Self>,
-    ) {
-        if self.lhs.is_some() {
-            cx.stop_propagation();
         } else {
             cx.propagate();
         }
@@ -1874,12 +1847,10 @@ impl Render for SplittableEditor {
             .on_action(cx.listener(Self::activate_pane_left))
             .on_action(cx.listener(Self::activate_pane_right))
             .on_action(cx.listener(Self::toggle_linked_cursors))
-            .on_action(cx.listener(Self::intercept_toggle_code_actions))
             .on_action(cx.listener(Self::intercept_toggle_breakpoint))
             .on_action(cx.listener(Self::intercept_enable_breakpoint))
             .on_action(cx.listener(Self::intercept_disable_breakpoint))
             .on_action(cx.listener(Self::intercept_edit_log_breakpoint))
-            .on_action(cx.listener(Self::intercept_inline_assist))
             .capture_action(cx.listener(Self::toggle_soft_wrap))
             .size_full()
             .child(inner)

--- a/crates/editor/src/split.rs
+++ b/crates/editor/src/split.rs
@@ -364,7 +364,7 @@ struct StackedDiffView;
 
 #[derive(Clone, Copy, PartialEq, Eq, Action, Default)]
 #[action(namespace = editor)]
-pub struct ToggleSplitDiff;
+pub struct ToggleDiffView;
 
 #[derive(Clone, Copy, PartialEq, Eq, Action, Default)]
 #[action(namespace = editor)]
@@ -843,7 +843,7 @@ impl SplittableEditor {
         });
     }
 
-    fn toggle_split(&mut self, _: &ToggleSplitDiff, window: &mut Window, cx: &mut Context<Self>) {
+    fn toggle_split(&mut self, _: &ToggleDiffView, window: &mut Window, cx: &mut Context<Self>) {
         if self.lhs.is_some() {
             self.unsplit(&StackedDiffView, window, cx);
         } else {

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -14,7 +14,7 @@ use any_vec::AnyVec;
 use collections::HashMap;
 use editor::{
     DisplayPoint, Editor, EditorSettings, MultiBufferOffset, SplitDiffFeatureFlag,
-    SplittableEditor, ToggleSplitDiff,
+    SplittableEditor, ToggleLinkedCursors, ToggleSplitDiff,
     actions::{Backtab, FoldAll, Tab, ToggleFoldAll, UnfoldAll},
 };
 use feature_flags::FeatureFlagAppExt as _;
@@ -146,6 +146,29 @@ impl Render for BufferSearchBar {
                                     })
                                 }),
                         )
+                        .when(is_split, |this| {
+                            let linked_cursors = splittable_editor.read(cx).linked_cursors();
+                            let focus_handle = focus_handle.clone();
+                            this.child(
+                                IconButton::new("linked-cursors", IconName::Link)
+                                    .shape(IconButtonShape::Square)
+                                    .toggle_state(linked_cursors)
+                                    .tooltip(|_, cx| {
+                                        Tooltip::for_action(
+                                            "Linked Cursor Mode",
+                                            &ToggleLinkedCursors,
+                                            cx,
+                                        )
+                                    })
+                                    .on_click(move |_, window, cx| {
+                                        focus_handle.focus(window, cx);
+                                        window.dispatch_action(
+                                            ToggleLinkedCursors.boxed_clone(),
+                                            cx,
+                                        );
+                                    }),
+                            )
+                        })
                 })
         } else {
             None

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -14,7 +14,7 @@ use any_vec::AnyVec;
 use collections::HashMap;
 use editor::{
     DisplayPoint, Editor, EditorSettings, MultiBufferOffset, SplitDiffFeatureFlag,
-    SplittableEditor, ToggleLinkedCursors, ToggleDiffView,
+    SplittableEditor, ToggleDiffView, ToggleLinkedCursors,
     actions::{Backtab, FoldAll, Tab, ToggleFoldAll, UnfoldAll},
 };
 use feature_flags::FeatureFlagAppExt as _;
@@ -162,10 +162,8 @@ impl Render for BufferSearchBar {
                                     })
                                     .on_click(move |_, window, cx| {
                                         focus_handle.focus(window, cx);
-                                        window.dispatch_action(
-                                            ToggleLinkedCursors.boxed_clone(),
-                                            cx,
-                                        );
+                                        window
+                                            .dispatch_action(ToggleLinkedCursors.boxed_clone(), cx);
                                     }),
                             )
                         })

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -14,7 +14,7 @@ use any_vec::AnyVec;
 use collections::HashMap;
 use editor::{
     DisplayPoint, Editor, EditorSettings, MultiBufferOffset, SplitDiffFeatureFlag,
-    SplittableEditor, ToggleLinkedCursors, ToggleSplitDiff,
+    SplittableEditor, ToggleLinkedCursors, ToggleDiffView,
     actions::{Backtab, FoldAll, Tab, ToggleFoldAll, UnfoldAll},
 };
 use feature_flags::FeatureFlagAppExt as _;
@@ -118,13 +118,13 @@ impl Render for BufferSearchBar {
                                 .shape(IconButtonShape::Square)
                                 .toggle_state(!is_split)
                                 .tooltip(|_, cx| {
-                                    Tooltip::for_action("Stacked", &ToggleSplitDiff, cx)
+                                    Tooltip::for_action("Stacked", &ToggleDiffView, cx)
                                 })
                                 .when(is_split, |button| {
                                     let focus_handle = focus_handle.clone();
                                     button.on_click(move |_, window, cx| {
                                         focus_handle.focus(window, cx);
-                                        window.dispatch_action(ToggleSplitDiff.boxed_clone(), cx);
+                                        window.dispatch_action(ToggleDiffView.boxed_clone(), cx);
                                     })
                                 }),
                         )
@@ -133,7 +133,7 @@ impl Render for BufferSearchBar {
                                 .shape(IconButtonShape::Square)
                                 .toggle_state(is_split)
                                 .tooltip(|_, cx| {
-                                    Tooltip::for_action("Side by Side", &ToggleSplitDiff, cx)
+                                    Tooltip::for_action("Side by Side", &ToggleDiffView, cx)
                                 })
                                 .when(!is_split, |button| {
                                     button.on_click({
@@ -141,7 +141,7 @@ impl Render for BufferSearchBar {
                                         move |_, window, cx| {
                                             focus_handle.focus(window, cx);
                                             window
-                                                .dispatch_action(ToggleSplitDiff.boxed_clone(), cx);
+                                                .dispatch_action(ToggleDiffView.boxed_clone(), cx);
                                         }
                                     })
                                 }),


### PR DESCRIPTION
Renames some actions. Rationale for standardizing on "side by side" over "split" is that:
- "split" already refers to regular split panes
- (related) in vim mode, `:split` will not autocomplete to `editor::SplitDiff` because `:split` is a vim command

The actual renames are
- `editor::SplitDiff` -> `editor::SideBySideDiffView`
- `editor::UnsplitDiff` -> `editor::StackedDiffView`
- `editor::ToggleSplitDiff` -> `editor::ToggleDiffView`
- `editor::JumpToCorrespondingRow` -> `editor::JumpToCorrespondingPosition` (not yet implemented)
- `editor::ToggleLockedMode` -> `editor::ToggleLinkedMode`

It also adds an icon button toggle for linked mode

Release Notes:

- N/A *or* Added/Fixed/Improved ...
