### PR TITLE
gpui: Skip chord pending state when IME is composing

### DIFF
--- a/crates/gpui/src/key_dispatch.rs
+++ b/crates/gpui/src/key_dispatch.rs
@@ -1102,4 +1102,74 @@ mod tests {
         cx.simulate_keystrokes("ctrl-b [");
         test.update(cx, |test, _| assert_eq!(test.text.borrow().as_str(), "["))
     }
+
+    #[derive(Clone)]
+    struct ImeTestView(FocusHandle);
+
+    impl Element for ImeTestView {
+        type RequestLayoutState = ();
+        type PrepaintState = ();
+        fn id(&self) -> Option<ElementId> { Some("ime-test".into()) }
+        fn source_location(&self) -> Option<&'static panic::Location<'static>> { None }
+        fn request_layout(&mut self, _: Option<&GlobalElementId>, _: Option<&InspectorElementId>, window: &mut Window, cx: &mut App) -> (LayoutId, ()) {
+            (window.request_layout(Style::default(), [], cx), ())
+        }
+        fn prepaint(&mut self, _: Option<&GlobalElementId>, _: Option<&InspectorElementId>, _: Bounds<Pixels>, _: &mut (), window: &mut Window, cx: &mut App) {
+            window.set_focus_handle(&self.0, cx);
+        }
+        fn paint(&mut self, _: Option<&GlobalElementId>, _: Option<&InspectorElementId>, _: Bounds<Pixels>, _: &mut (), _: &mut (), window: &mut Window, cx: &mut App) {
+            let mut ctx = KeyContext::default();
+            ctx.add("ImeTest");
+            window.set_key_context(ctx);
+            window.handle_input(&self.0, self.clone(), cx);
+            window.on_action(std::any::TypeId::of::<TestAction>(), |_, _, _, _| {});
+        }
+    }
+
+    impl IntoElement for ImeTestView {
+        type Element = Self;
+        fn into_element(self) -> Self { self }
+    }
+
+    impl InputHandler for ImeTestView {
+        fn selected_text_range(&mut self, _: bool, _: &mut Window, _: &mut App) -> Option<UTF16Selection> { None }
+        fn marked_text_range(&mut self, _: &mut Window, _: &mut App) -> Option<Range<usize>> { None }
+        fn text_for_range(&mut self, _: Range<usize>, _: &mut Option<Range<usize>>, _: &mut Window, _: &mut App) -> Option<String> { None }
+        fn replace_text_in_range(&mut self, _: Option<Range<usize>>, _: &str, _: &mut Window, _: &mut App) {}
+        fn replace_and_mark_text_in_range(&mut self, _: Option<Range<usize>>, _: &str, _: Option<Range<usize>>, _: &mut Window, _: &mut App) {}
+        fn unmark_text(&mut self, _: &mut Window, _: &mut App) {}
+        fn bounds_for_range(&mut self, _: Range<usize>, _: &mut Window, _: &mut App) -> Option<Bounds<Pixels>> { None }
+        fn character_index_for_point(&mut self, _: Point<Pixels>, _: &mut Window, _: &mut App) -> Option<usize> { None }
+    }
+
+    impl Render for ImeTestView {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement { self.clone() }
+    }
+
+    #[crate::test]
+    fn test_ime_keystroke_skips_chord_pending(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            cx.bind_keys([KeyBinding::new("g g", TestAction, Some("ImeTest"))]);
+        });
+
+        let (view, cx) = cx.add_window_view(|_, cx| ImeTestView(cx.focus_handle()));
+        let focus_handle = view.update(cx, |view, _| view.0.clone());
+        cx.update(|window, cx| {
+            window.focus(&focus_handle, cx);
+            window.activate_window();
+        });
+
+        // Korean IME: physical 'g' → 'ㅎ'. Should NOT enter chord pending.
+        cx.update(|window, cx| {
+            window.dispatch_keystroke(Keystroke { key: "g".into(), key_char: Some("ㅎ".into()), modifiers: Default::default() }, cx);
+        });
+        cx.run_until_parked();
+        cx.update(|window, _| assert!(!window.has_pending_keystrokes()));
+
+        // English: physical 'g' → 'g'. SHOULD enter chord pending.
+        cx.update(|window, cx| {
+            window.dispatch_keystroke(Keystroke { key: "g".into(), key_char: Some("g".into()), modifiers: Default::default() }, cx);
+        });
+        cx.update(|window, _| assert!(window.has_pending_keystrokes()));
+    }
 }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -4113,6 +4113,35 @@ impl Window {
         }
 
         if !match_result.pending.is_empty() {
+            let ime_is_composing = event
+                .downcast_ref::<KeyDownEvent>()
+                .and_then(|e| {
+                    let ks = &e.keystroke;
+                    ks.key_char.as_ref().filter(|ch| {
+                        *ch != &ks.key
+                            && !ks.modifiers.control
+                            && !ks.modifiers.platform
+                            && !ks.modifiers.function
+                    })
+                })
+                .and_then(|_| self.platform_window.take_input_handler())
+                .map_or(false, |mut handler| {
+                    let accepts = handler.accepts_text_input(self, cx);
+                    self.platform_window.set_input_handler(handler);
+                    accepts
+                });
+
+            if ime_is_composing {
+                self.finish_dispatch_key_event(
+                    event,
+                    dispatch_path,
+                    match_result.context_stack,
+                    cx,
+                );
+                self.pending_input_changed(cx);
+                return;
+            }
+
             currently_pending.timer.take();
             currently_pending.keystrokes = match_result.pending;
             currently_pending.focus = self.focus;


### PR DESCRIPTION
When a non-ASCII keyboard layout (e.g. Korean, Japanese, Chinese) transforms a physical key into a different character, chord bindings intercept the keystroke and prevent IME composition. For example, with a `g g` chord binding, typing Korean characters starting with 'ㅎ' (physical 'g' key) causes decomposition into individual jamo — typing '하' produces 'ㅎㅏ' instead.

This affects all CJK IME users who have any chord binding starting with a key that maps to an IME character. Vim mode users are especially impacted since the default keymap has 40+ `g`-prefixed chords (`g g`, `g d`, `g h`, etc.).

**Root cause**: `dispatch_key()` matches physical key `"g"` against chord bindings like `"g g"`, entering pending state. This prevents the event from reaching the IME. When pending times out, `replay_pending_input()` calls `dispatch_input("ㅎ")` directly, bypassing IME composition entirely.

**Fix**: Before entering chord pending state, check if the keystroke is dominated by IME — `key_char` differs from `key` without control/platform/function modifiers, and the focused element accepts text input. When true, skip pending and let the event propagate to the IME for normal composition.

| Scenario | key | key_char | Result |
|---------|-----|----------|--------|
| Korean mode 'g' key | `"g"` | `"ㅎ"` | IME composes normally |
| English mode 'g' key | `"g"` | `"g"` | Chord pending works |
| Ctrl+G in Korean | `"g"` | None | Chord pending works |

- [x] Tests or screenshots needed?
- [ ] Code Reviewed
- [ ] Manual QA

Release Notes:

- Fixed CJK IME composition breaking when chord keybindings match the physical key (e.g. Korean 'ㅎ' on 'g' key conflicting with `g g` chord)

**bug**
<img width="622" height="580" alt="Screenshot 2026-02-10 at 1 07 59 AM" src="https://github.com/user-attachments/assets/c1ff4398-3776-44f4-88f5-8fcde2e316ad" />


**fixed**
<img width="702" height="575" alt="Screenshot 2026-02-10 at 1 08 51 AM" src="https://github.com/user-attachments/assets/b4a82e84-eee8-4b55-b6ea-98f718b6ace2" />


