### PR TITLE
devcontainer: Fix project search returning no results on single-CPU containers

### DIFF
--- a/crates/gpui/src/executor.rs
+++ b/crates/gpui/src/executor.rs
@@ -349,10 +349,20 @@ impl BackgroundExecutor {
     /// How many CPUs are available to the dispatcher.
     pub fn num_cpus(&self) -> usize {
         #[cfg(any(test, feature = "test-support"))]
-        if self.dispatcher.as_test().is_some() {
-            return 4;
+        if let Some(test) = self.dispatcher.as_test() {
+            return test.num_cpus_override().unwrap_or(4);
         }
         num_cpus::get()
+    }
+
+    /// Override the number of CPUs reported by this executor in tests.
+    /// Panics if not called on a test executor.
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn set_num_cpus(&self, count: usize) {
+        self.dispatcher
+            .as_test()
+            .expect("set_num_cpus can only be called on a test executor")
+            .set_num_cpus(count);
     }
 
     /// Whether we're on the main thread.

--- a/crates/project/src/project_search.rs
+++ b/crates/project/src/project_search.rs
@@ -335,7 +335,8 @@ impl Search {
                     assert!(num_cpus > 0);
                     _executor
                         .scoped(|scope| {
-                            for _ in 0..num_cpus - 1 {
+                            let worker_count = (num_cpus - 1).max(1);
+                            for _ in 0..worker_count {
                                 let worker = Worker {
                                     query: query.clone(),
                                     open_buffers: open_buffers.clone(),

--- a/crates/remote_server/src/remote_editing_tests.rs
+++ b/crates/remote_server/src/remote_editing_tests.rs
@@ -288,6 +288,53 @@ async fn test_remote_project_search(cx: &mut TestAppContext, server_cx: &mut Tes
 }
 
 #[gpui::test]
+async fn test_remote_project_search_single_cpu(
+    cx: &mut TestAppContext,
+    server_cx: &mut TestAppContext,
+) {
+    let fs = FakeFs::new(server_cx.executor());
+    fs.insert_tree(
+        path!("/code"),
+        json!({
+            "project1": {
+                ".git": {},
+                "README.md": "# project 1",
+                "src": {
+                    "lib.rs": "fn one() -> usize { 1 }"
+                }
+            },
+        }),
+    )
+    .await;
+
+    // Simulate a single-CPU environment (e.g. a devcontainer with 1 visible CPU).
+    // This causes the worker pool in project search to spawn num_cpus - 1 = 0 workers,
+    // which silently drops all search channels and produces zero results.
+    server_cx.executor().set_num_cpus(1);
+
+    let (project, _) = init_test(&fs, cx, server_cx).await;
+
+    project
+        .update(cx, |project, cx| {
+            project.find_or_create_worktree(path!("/code/project1"), true, cx)
+        })
+        .await
+        .unwrap();
+
+    cx.run_until_parked();
+
+    do_search_and_assert(
+        &project,
+        "project",
+        Default::default(),
+        false,
+        &[path!("project1/README.md")],
+        cx.clone(),
+    )
+    .await;
+}
+
+#[gpui::test]
 async fn test_remote_project_search_inclusion(
     cx: &mut TestAppContext,
     server_cx: &mut TestAppContext,


### PR DESCRIPTION
Closes #47489

The search worker pool was sized as `num_cpus - 1`, which spawned zero workers when a devcontainer exposed only 1 CPU. All search channels closed immediately and the search yielded zero results, while file finder and LSP symbols worked fine.

The fix ensures at least 1 worker is always spawned: `(num_cpus - 1).max(1)`. A `num_cpus` override on `TestDispatcher` and a new test reproduce the bug with `server_cx.executor().set_num_cpus(1)`.

## Manual testing

Add a `.devcontainer/` directory to a new project with these files:

```
// docker-compose.yml
services:
  dev:
    image: debian:bookworm-slim
    cpuset: "0"
    volumes:
      - ..:/workspace:cached
    command: sleep infinity
```

```
// devcontainer.json
{
  "name": "zed-sandbox (1 CPU)",
  "dockerComposeFile": "docker-compose.yml",
  "service": "dev",
  "workspaceFolder": "/workspace"
}
```

Build zed and point it at the new project:

```
cargo run -p zed -- ~/Repos/zed-sandbox-project
```

Open the built-in terminal, confirm `nproc` prints `1`.

Finally, run a project search (`Cmd+Shift+F`) and search for contents that exist in it. 

Results should appear 🎉 

Release Notes:

- Fixed project search returning no results in devcontainers with a single visible CPU.