### PR TITLE
repl: Pluck project off editor directly

### DIFF
--- a/crates/repl/src/repl_sessions_ui.rs
+++ b/crates/repl/src/repl_sessions_ui.rs
@@ -79,8 +79,7 @@ pub fn init(cx: &mut App) {
             }
 
             cx.defer_in(window, |editor, window, cx| {
-                let workspace = Workspace::for_window(window, cx);
-                let project = workspace.map(|workspace| workspace.read(cx).project().clone());
+                let project = editor.project.cloned();
 
                 let is_local_project = project
                     .as_ref()


### PR DESCRIPTION
Clean up code by pulling the project off the editor directly.

Repeat of https://github.com/zed-industries/zed/pull/48762 since reversion happened in https://github.com/zed-industries/zed/pull/48776.

Release Notes:

- N/A