### PR TITLE
languages: Add runnable support for bash 

### DIFF
--- a/crates/languages/src/bash.rs
+++ b/crates/languages/src/bash.rs
@@ -11,6 +11,7 @@ pub(super) fn bash_task_context() -> ContextProviderWithTasks {
         TaskTemplate {
             label: format!("run '{}'", VariableName::File.template_value()),
             command: VariableName::File.template_value(),
+            tags: vec!["bash-script".to_owned()],
             ..TaskTemplate::default()
         },
     ]))

--- a/crates/languages/src/bash/runnables.scm
+++ b/crates/languages/src/bash/runnables.scm
@@ -1,0 +1,5 @@
+; Run bash scripts
+(
+  (program . (_) @run) @_bash-script
+  (#set! tag bash-script)
+)


### PR DESCRIPTION
Bash:
<img width="469" height="149" alt="bash" src="https://github.com/user-attachments/assets/179c9157-58b4-49a3-a166-78486eee5334" />

Bash output:
<img width="319" height="77" alt="bash_output" src="https://github.com/user-attachments/assets/2f5f6582-8538-4508-81cc-84007779d359" />

Zsh:
<img width="414" height="139" alt="zsh" src="https://github.com/user-attachments/assets/23cbb61c-6af1-4956-91a6-39d00319d4fc" />

Zsh output:
<img width="326" height="69" alt="zsh_output" src="https://github.com/user-attachments/assets/beb76f68-fb0c-4140-91ea-bf66a50294fc" />

Dash:
<img width="343" height="121" alt="dash" src="https://github.com/user-attachments/assets/47f44fda-2130-4076-9f65-12c5b1094a53" />

Dash output:
<img width="343" height="75" alt="dash_output" src="https://github.com/user-attachments/assets/176459a2-9dd7-4bd9-8a3d-a7fe39d3b7c3" />

- [x] Code Reviewed
- [x] Manual QA

Release Notes:

- Added runnable support for bash.
