### PR TITLE
extension_rollout: Improve naming for PR titles

### DIFF
--- a/.github/workflows/extension_workflow_rollout.yml
+++ b/.github/workflows/extension_workflow_rollout.yml
@@ -39,7 +39,7 @@ jobs:
       matrix:
         repo: ${{ fromJson(needs.fetch_extension_repos.outputs.repos) }}
       fail-fast: false
-      max-parallel: 5
+      max-parallel: 10
     steps:
     - id: generate-token
       name: extension_bump::generate_token

--- a/.github/workflows/extension_workflow_rollout.yml
+++ b/.github/workflows/extension_workflow_rollout.yml
@@ -133,11 +133,11 @@ jobs:
       uses: peter-evans/create-pull-request@v7
       with:
         path: extension
-        title: Update CI workflows to `zed@${{ steps.short-sha.outputs.sha_short }}`
+        title: Update CI workflows to `${{ steps.short-sha.outputs.sha_short }}`
         body: |
           This PR updates the CI workflow files from the main Zed repository
           based on the commit zed-industries/zed@${{ github.sha }}
-        commit-message: Update CI workflows to `zed@${{ steps.short-sha.outputs.sha_short }}`
+        commit-message: Update CI workflows to `${{ steps.short-sha.outputs.sha_short }}`
         branch: update-workflows
         committer: zed-zippy[bot] <234243425+zed-zippy[bot]@users.noreply.github.com>
         author: zed-zippy[bot] <234243425+zed-zippy[bot]@users.noreply.github.com>

--- a/tooling/xtask/src/tasks/workflows/extension_workflow_rollout.rs
+++ b/tooling/xtask/src/tasks/workflows/extension_workflow_rollout.rs
@@ -234,7 +234,7 @@ fn rollout_workflows_to_extension(fetch_repos_job: &NamedJob) -> NamedJob {
         .strategy(
             Strategy::default()
                 .fail_fast(false)
-                .max_parallel(5u32)
+                .max_parallel(10u32)
                 .matrix(json!({
                     "repo": format!("${{{{ fromJson(needs.{}.outputs.repos) }}}}", fetch_repos_job.name)
                 })),

--- a/tooling/xtask/src/tasks/workflows/extension_workflow_rollout.rs
+++ b/tooling/xtask/src/tasks/workflows/extension_workflow_rollout.rs
@@ -168,7 +168,7 @@ fn rollout_workflows_to_extension(fetch_repos_job: &NamedJob) -> NamedJob {
     }
 
     fn create_pull_request(token: &StepOutput, short_sha: &StepOutput) -> Step<Use> {
-        let title = format!("Update CI workflows to `zed@{}`", short_sha);
+        let title = format!("Update CI workflows to `{short_sha}`");
 
         named::uses("peter-evans", "create-pull-request", "v7")
             .add_with(("path", "extension"))


### PR DESCRIPTION
This PR updates the names for the PRs to roll out to the extensions, as having the `zed@` prefix does not look too pretty.

It also increases the concurrency of matrix jobs run to 10, as the rollout has matured by now and is safe to perform for more repositories at once.

Release Notes:

- N/A 
