### PR TITLE
repl: Bump `runtimed` ecosystem packages to 1.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3346,7 +3346,7 @@ dependencies = [
  "dap",
  "dap-types",
  "dap_adapters",
- "dashmap 6.1.0",
+ "dashmap",
  "debugger_ui",
  "editor",
  "envy",
@@ -4629,19 +4629,6 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.106",
-]
-
-[[package]]
-name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
 ]
 
 [[package]]
@@ -8869,9 +8856,9 @@ dependencies = [
 
 [[package]]
 name = "jupyter-protocol"
-version = "0.10.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c047f6b5e551563af2ddb13dafed833f0ec5a5b0f9621d5ad740a9ff1e1095"
+checksum = "ec0c2e3fba7f516ac3bc703f28abe3b83157320e603fb4abbee5ba9c016e2578"
 dependencies = [
  "async-trait",
  "bytes 1.11.1",
@@ -8885,9 +8872,9 @@ dependencies = [
 
 [[package]]
 name = "jupyter-websocket-client"
-version = "0.15.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4197fa926a6b0bddfed7377d9fed3d00a0dec44a1501e020097bd26604699cae"
+checksum = "1ef5a543b517583059b5b11daceb37690d6ac206f9321075993cd82ab1541c28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10459,9 +10446,9 @@ dependencies = [
 
 [[package]]
 name = "nbformat"
-version = "0.15.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89c7229d604d847227002715e1235cd84e81919285d904ccb290a42ecc409348"
+checksum = "5903b59b1e05b1dda851281e3668ad3b6b32b1d6677d591563bc2091474d7d3c"
 dependencies = [
  "anyhow",
  "chrono",
@@ -14248,9 +14235,9 @@ dependencies = [
 
 [[package]]
 name = "runtimelib"
-version = "0.30.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "481b48894073a0096f28cbe9860af01fc1b861e55b3bc96afafc645ee3de62dc"
+checksum = "25a8031614aa3913648d167bc69e2b9fda7731f2226ef588b50323c392bfeb58"
 dependencies = [
  "async-dispatcher",
  "async-std",
@@ -14581,6 +14568,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "saa"
+version = "5.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0ba8adb63e0deebd0744d8fc5bea394c08029159deaf680513fec1a3949144"
+
+[[package]]
 name = "safetensors"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14606,6 +14599,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "scc"
+version = "3.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4bd9d1727de391b6982925d830baad51692fa2aa6e337733c03d95121ca2793"
+dependencies = [
+ "saa",
+ "sdd",
 ]
 
 [[package]]
@@ -14752,6 +14755,12 @@ dependencies = [
  "ring",
  "untrusted 0.9.0",
 ]
+
+[[package]]
+name = "sdd"
+version = "4.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c25da4ae64b24edfcb0b0d30b96b2b0dbc64ec63aefeb6ec35bfc5ef167e5c9e"
 
 [[package]]
 name = "sea-bae"
@@ -21411,9 +21420,9 @@ dependencies = [
 
 [[package]]
 name = "zeromq"
-version = "0.5.0-pre"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1fe92954d37e77bed5e2775cb0fed7dba5f6bc4be6f7f76172a4eb371dc6a9b"
+checksum = "b32e1e46c4e278efd0c1153f2db0113924b9bc5fff9f9221853d035e2d26fadf"
 dependencies = [
  "async-dispatcher",
  "async-std",
@@ -21421,14 +21430,14 @@ dependencies = [
  "asynchronous-codec",
  "bytes 1.11.1",
  "crossbeam-queue",
- "dashmap 5.5.3",
  "futures 0.3.31",
  "log",
  "num-traits",
  "once_cell",
  "parking_lot",
- "rand 0.8.5",
+ "rand 0.9.2",
  "regex",
+ "scc",
  "thiserror 1.0.69",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -553,8 +553,8 @@ itertools = "0.14.0"
 json_dotpath = "1.1"
 jsonschema = "0.37.0"
 jsonwebtoken = "10.0"
-jupyter-protocol = "0.10.0"
-jupyter-websocket-client = "0.15.0"
+jupyter-protocol = "1.1.0"
+jupyter-websocket-client = "1.0.0"
 libc = "0.2"
 libsqlite3-sys = { version = "0.30.1", features = ["bundled"] }
 linkify = "0.10.0"
@@ -567,7 +567,7 @@ minidumper = "0.8"
 moka = { version = "0.12.10", features = ["sync"] }
 naga = { version = "25.0", features = ["wgsl-in"] }
 nanoid = "0.4"
-nbformat = "0.15.0"
+nbformat = "1.0.0"
 nix = "0.29"
 num-format = "0.4.4"
 objc = "0.2"
@@ -636,7 +636,7 @@ reqwest = { git = "https://github.com/zed-industries/reqwest.git", rev = "c15662
     "stream",
 ], package = "zed-reqwest", version = "0.12.15-zed" }
 rsa = "0.9.6"
-runtimelib = { version = "0.30.0", default-features = false, features = [
+runtimelib = { version = "1.1.0", default-features = false, features = [
     "async-dispatcher-runtime", "aws-lc-rs"
 ] }
 rust-embed = { version = "8.4", features = ["include-exclude"] }

--- a/crates/repl/src/outputs.rs
+++ b/crates/repl/src/outputs.rs
@@ -389,16 +389,13 @@ impl Output {
         cx: &mut App,
     ) -> Self {
         match data.richest(rank_mime_type) {
-            Some(MimeType::Json(json_object)) => {
-                let json_value = serde_json::Value::Object(json_object.clone());
-                match JsonView::from_value(json_value) {
-                    Ok(json_view) => Output::Json {
-                        content: cx.new(|_| json_view),
-                        display_id,
-                    },
-                    Err(_) => Output::Message("Failed to parse JSON".to_string()),
-                }
-            }
+            Some(MimeType::Json(json_value)) => match JsonView::from_value(json_value.clone()) {
+                Ok(json_view) => Output::Json {
+                    content: cx.new(|_| json_view),
+                    display_id,
+                },
+                Err(_) => Output::Message("Failed to parse JSON".to_string()),
+            },
             Some(MimeType::Plain(text)) => Output::Plain {
                 content: cx.new(|cx| TerminalOutput::from(text, window, cx)),
                 display_id,


### PR DESCRIPTION
Bump the runtimed ecosystem packages to their 1.0 releases:

- `jupyter-protocol`: 0.10.0 → 1.1.0
- `jupyter-websocket-client`: 0.15.0 → 1.0.0
- `nbformat`: 0.15.0 → 1.0.0
- `runtimelib`: 0.30.0 → 1.1.0

One breaking change: `MimeType::Json` now wraps `serde_json::Value` directly instead of `serde_json::Map<String, Value>`, so the redundant `Value::Object(...)` wrapping in `outputs.rs` was removed.

Closes #41649

More Quality of Life improvements and Bug Fixes are coming in new PRs after this is merged.

Release Notes:

- Fixes startup for R kernels and Python kernels on windows.