### PR TITLE
repl: Use split() on shell and control dealer sockets

### DIFF
--- a/crates/repl/src/kernels/mod.rs
+++ b/crates/repl/src/kernels/mod.rs
@@ -1,11 +1,7 @@
 mod native_kernel;
 use std::{fmt::Debug, future::Future, path::PathBuf};
 
-use futures::{
-    channel::mpsc::{self, Receiver},
-    future::Shared,
-    stream,
-};
+use futures::{channel::mpsc, future::Shared};
 use gpui::{App, Entity, Task, Window};
 use language::LanguageName;
 pub use native_kernel::*;
@@ -25,8 +21,6 @@ pub trait KernelSession: Sized {
     fn route(&mut self, message: &JupyterMessage, window: &mut Window, cx: &mut Context<Self>);
     fn kernel_errored(&mut self, error_message: String, cx: &mut Context<Self>);
 }
-
-pub type JupyterMessageChannel = stream::SelectAll<Receiver<JupyterMessage>>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum KernelSpecification {


### PR DESCRIPTION
Hot on the heels of https://github.com/zed-industries/zed/pull/48817 I'm bringing the best improvement to the repl underneath: `split()`-able sockets! Much more will be unlocked by having this.

This split the shell and control `DealerSocket` connections into independent send/recv halves using the new `split()` API from zeromq 0.5.0 and runtimelib 1.x. This also nicely cleaned things up so we could have a single `select!` loop over iopub, shell, and control recv halves. That replaces three separate recv tasks.

This likely closes some issues for certain kernels that would get stuck either during startup or other flows due to them not sending replies to specific requests. I'll see if I can find some issues people already reported I can link back to this.

This allows us to unlock some nifty new things we can do on the shell socket, particularly autocompletion for in-memory values, stdin support, and others. I _think_ it also help with sending and receving `KernelInfo`, which not all kernels do properly at the start. This makes us a bit more resilient to errant kernels.

Release Notes:

- N/A