### PR TITLE
extension_ci: Increase timeout for extension version bump job

### DIFF
--- a/.github/workflows/extension_bump.yml
+++ b/.github/workflows/extension_bump.yml
@@ -96,7 +96,7 @@ jobs:
             --no-configured-files ${{ inputs.bump-type }} "${BUMP_FILES[@]}"
 
         if [[ -f "Cargo.toml" ]]; then
-            cargo update --workspace --offline
+            cargo update --workspace
         fi
 
         NEW_VERSION="$(sed -n 's/version = \"\(.*\)\"/\1/p' < extension.toml)"

--- a/.github/workflows/extension_bump.yml
+++ b/.github/workflows/extension_bump.yml
@@ -115,7 +115,7 @@ jobs:
         token: ${{ steps.generate-token.outputs.token }}
         sign-commits: true
         assignees: ${{ github.actor }}
-    timeout-minutes: 1
+    timeout-minutes: 3
   create_version_label:
     needs:
     - check_version_changed

--- a/tooling/xtask/src/tasks/workflows/extension_bump.rs
+++ b/tooling/xtask/src/tasks/workflows/extension_bump.rs
@@ -195,7 +195,7 @@ fn bump_extension_version(
             version_changed = version_changed_output.expr(),
         )))
         .runs_on(runners::LINUX_SMALL)
-        .timeout_minutes(1u32)
+        .timeout_minutes(3u32)
         .add_step(generate_token)
         .add_step(steps::checkout_repo())
         .add_step(install_bump_2_version())

--- a/tooling/xtask/src/tasks/workflows/extension_bump.rs
+++ b/tooling/xtask/src/tasks/workflows/extension_bump.rs
@@ -271,7 +271,7 @@ fn bump_version(current_version: &JobOutput, bump_type: &WorkflowInput) -> (Step
             --no-configured-files {bump_type} "${{BUMP_FILES[@]}}"
 
         if [[ -f "Cargo.toml" ]]; then
-            cargo update --workspace --offline
+            cargo update --workspace
         fi
 
         NEW_VERSION="$({VERSION_CHECK})"


### PR DESCRIPTION
This fixes another issue for the ruby extension where a cargo index update can sometimes take quite some time. However, this will not change anything for all other extensions, as they continue to bump within the defined timeout.

Release Notes:

- N/A
