### PR TITLE
Add explicit setting for choosing rendering color space

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -178,6 +178,15 @@
   //  3. Use grayscale text rendering:
   //         "text_rendering_mode": "grayscale"
   "text_rendering_mode": "platform_default",
+  // The color space to use for rendering.
+  // May take 3 values:
+  //  1. Use standard sRGB:
+  //         "color_space": "srgb"
+  //  2. Use wide gamut Display P3 color space:
+  //         "color_space": "display_p3"
+  //  3. Use untagged (device) color space
+  //         "color_space": "untagged"
+  "color_space": "srgb",
   // Whether to show padding for zoomed panels.
   // When enabled, zoomed center panels (e.g. code editor) will have padding all around,
   // while zoomed bottom/left/right panels will have padding to the top/right/left (respectively).

--- a/crates/gpui/examples/gradient.rs
+++ b/crates/gpui/examples/gradient.rs
@@ -50,8 +50,10 @@ impl Render for GradientViewer {
                                 .active(|this| this.opacity(0.8))
                                 .on_click(cx.listener(move |this, _, _, cx| {
                                     this.color_space = match this.color_space {
-                                        ColorSpace::Oklab => ColorSpace::Srgb,
                                         ColorSpace::Srgb => ColorSpace::Oklab,
+                                        ColorSpace::Oklab => ColorSpace::DisplayP3,
+                                        ColorSpace::DisplayP3 => ColorSpace::Untagged,
+                                        ColorSpace::Untagged => ColorSpace::Srgb,
                                     };
                                     cx.notify();
                                 })),

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -38,9 +38,9 @@ pub use visual_test_context::*;
 use crate::InspectorElementRegistry;
 use crate::{
     Action, ActionBuildError, ActionRegistry, Any, AnyView, AnyWindowHandle, AppContext, Arena,
-    ArenaBox, Asset, AssetSource, BackgroundExecutor, Bounds, ClipboardItem, CursorStyle,
-    DispatchPhase, DisplayId, EventEmitter, FocusHandle, FocusMap, ForegroundExecutor, Global,
-    KeyBinding, KeyContext, Keymap, Keystroke, LayoutId, Menu, MenuItem, OwnedMenu,
+    ArenaBox, Asset, AssetSource, BackgroundExecutor, Bounds, ClipboardItem, ColorSpace,
+    CursorStyle, DispatchPhase, DisplayId, EventEmitter, FocusHandle, FocusMap, ForegroundExecutor,
+    Global, KeyBinding, KeyContext, Keymap, Keystroke, LayoutId, Menu, MenuItem, OwnedMenu,
     PathPromptOptions, Pixels, Platform, PlatformDisplay, PlatformKeyboardLayout,
     PlatformKeyboardMapper, Point, Priority, PromptBuilder, PromptButton, PromptHandle,
     PromptLevel, Render, RenderImage, RenderablePromptHandle, Reservation, ScreenCaptureSource,
@@ -624,6 +624,7 @@ pub struct App {
     #[cfg(any(test, feature = "test-support", debug_assertions))]
     pub(crate) name: Option<&'static str>,
     pub(crate) text_rendering_mode: Rc<Cell<TextRenderingMode>>,
+    pub(crate) color_space: Rc<Cell<ColorSpace>>,
     quit_mode: QuitMode,
     quitting: bool,
     /// Per-App element arena. This isolates element allocations between different
@@ -658,6 +659,7 @@ impl App {
                 platform: platform.clone(),
                 text_system,
                 text_rendering_mode: Rc::new(Cell::new(TextRenderingMode::default())),
+                color_space: Rc::new(Cell::new(ColorSpace::default())),
                 mode: GpuiMode::Production,
                 actions: Rc::new(ActionRegistry::default()),
                 flushing_effects: false,
@@ -1159,6 +1161,22 @@ impl App {
     /// Returns the current text rendering mode for the application.
     pub fn text_rendering_mode(&self) -> TextRenderingMode {
         self.text_rendering_mode.get()
+    }
+
+    /// Sets the color space for the application.
+    pub fn set_color_space(&mut self, color_space: ColorSpace) {
+        self.color_space.set(color_space);
+        // Notify all windows to update
+        for window in self.windows.values() {
+            if let Some(window) = window.as_ref() {
+                window.set_color_space(color_space);
+            }
+        }
+    }
+
+    /// Returns the current color space for the application.
+    pub fn color_space(&self) -> ColorSpace {
+        self.color_space.get()
     }
 
     /// Writes data to the platform clipboard.

--- a/crates/gpui/src/color.rs
+++ b/crates/gpui/src/color.rs
@@ -674,6 +674,10 @@ pub enum ColorSpace {
     Srgb = 0,
     /// The Oklab color space.
     Oklab = 1,
+    /// The Display P3 wide gamut color space.
+    DisplayP3 = 2,
+    /// Untagged device color space without color management.
+    Untagged = 3,
 }
 
 impl Display for ColorSpace {
@@ -681,6 +685,8 @@ impl Display for ColorSpace {
         match self {
             ColorSpace::Srgb => write!(f, "sRGB"),
             ColorSpace::Oklab => write!(f, "Oklab"),
+            ColorSpace::DisplayP3 => write!(f, "Display P3"),
+            ColorSpace::Untagged => write!(f, "Untagged"),
         }
     }
 }

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -29,7 +29,7 @@ pub(crate) type PlatformScreenCaptureFrame = ();
 pub(crate) type PlatformScreenCaptureFrame = core_video::image_buffer::CVImageBuffer;
 
 use crate::{
-    Action, AnyWindowHandle, App, AsyncWindowContext, BackgroundExecutor, Bounds,
+    Action, AnyWindowHandle, App, AsyncWindowContext, BackgroundExecutor, Bounds, ColorSpace,
     DEFAULT_WINDOW_SIZE, DevicePixels, DispatchEventResult, Font, FontId, FontMetrics, FontRun,
     ForegroundExecutor, GlyphId, GpuSpecs, ImageSource, Keymap, LineLayout, Pixels, PlatformInput,
     Point, Priority, RenderGlyphParams, RenderImage, RenderImageParams, RenderSvgParams, Scene,
@@ -473,6 +473,7 @@ pub trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     fn background_appearance(&self) -> WindowBackgroundAppearance;
     fn set_title(&mut self, title: &str);
     fn set_background_appearance(&self, background_appearance: WindowBackgroundAppearance);
+    fn set_color_space(&self, color_space: ColorSpace);
     fn minimize(&self);
     fn zoom(&self);
     fn toggle_fullscreen(&self);

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -204,6 +204,10 @@ impl PlatformWindow for TestWindow {
         WindowBackgroundAppearance::Opaque
     }
 
+    fn set_color_space(&self, _color_space: crate::ColorSpace) {
+        // Test platform - no-op
+    }
+
     fn is_subpixel_rendering_supported(&self) -> bool {
         false
     }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -3,7 +3,7 @@ use crate::Inspector;
 use crate::{
     Action, AnyDrag, AnyElement, AnyImageCache, AnyTooltip, AnyView, App, AppContext, Arena, Asset,
     AsyncWindowContext, AvailableSpace, Background, BorderStyle, Bounds, BoxShadow, Capslock,
-    Context, Corners, CursorStyle, Decorations, DevicePixels, DispatchActionListener,
+    ColorSpace, Context, Corners, CursorStyle, Decorations, DevicePixels, DispatchActionListener,
     DispatchNodeId, DispatchTree, DisplayId, Edges, Effect, Entity, EntityId, EventEmitter,
     FileDropEvent, FontId, Global, GlobalElementId, GlyphId, GpuSpecs, Hsla, InputHandler, IsZero,
     KeyBinding, KeyContext, KeyDownEvent, KeyEvent, Keystroke, KeystrokeEvent, LayoutId,
@@ -901,6 +901,7 @@ pub struct Window {
     sprite_atlas: Arc<dyn PlatformAtlas>,
     text_system: Arc<WindowTextSystem>,
     text_rendering_mode: Rc<Cell<TextRenderingMode>>,
+    color_space: Rc<Cell<ColorSpace>>,
     rem_size: Pixels,
     /// The stack of override values for the window's rem size.
     ///
@@ -1394,6 +1395,7 @@ impl Window {
             sprite_atlas,
             text_system,
             text_rendering_mode: cx.text_rendering_mode.clone(),
+            color_space: cx.color_space.clone(),
             rem_size: px(16.),
             rem_size_override_stack: SmallVec::new(),
             viewport_size: content_size,
@@ -1485,6 +1487,11 @@ impl ContentMask<Pixels> {
 }
 
 impl Window {
+    pub(crate) fn set_color_space(&self, color_space: ColorSpace) {
+        self.color_space.set(color_space);
+        self.platform_window.set_color_space(color_space);
+    }
+
     fn mark_view_dirty(&mut self, view_id: EntityId) {
         // Mark ancestor views as dirty. If already in the `dirty_views` set, then all its ancestors
         // should already be dirty.

--- a/crates/gpui_linux/src/linux/wayland/window.rs
+++ b/crates/gpui_linux/src/linux/wayland/window.rs
@@ -1252,6 +1252,10 @@ impl PlatformWindow for WaylandWindow {
         self.borrow().background_appearance
     }
 
+    fn set_color_space(&self, _color_space: crate::ColorSpace) {
+        // TODO: Implement color space support for Wayland/Linux
+    }
+
     fn is_subpixel_rendering_supported(&self) -> bool {
         let client = self.borrow().client.get_client();
         let state = client.borrow();

--- a/crates/gpui_linux/src/linux/x11/window.rs
+++ b/crates/gpui_linux/src/linux/x11/window.rs
@@ -1487,6 +1487,10 @@ impl PlatformWindow for X11Window {
         self.0.state.borrow().background_appearance
     }
 
+    fn set_color_space(&self, _color_space: crate::ColorSpace) {
+        // TODO: Implement color space support for X11/Linux
+    }
+
     fn is_subpixel_rendering_supported(&self) -> bool {
         self.0
             .state

--- a/crates/gpui_macos/src/metal_renderer.rs
+++ b/crates/gpui_macos/src/metal_renderer.rs
@@ -7,9 +7,9 @@ use cocoa::{
     quartzcore::AutoresizingMask,
 };
 use gpui::{
-    AtlasTextureId, Background, Bounds, ContentMask, DevicePixels, MonochromeSprite, PaintSurface,
-    Path, Point, PolychromeSprite, PrimitiveBatch, Quad, ScaledPixels, Scene, Shadow, Size,
-    Surface, Underline, point, size,
+    AtlasTextureId, Background, Bounds, ColorSpace, ContentMask, DevicePixels, MonochromeSprite,
+    PaintSurface, Path, Point, PolychromeSprite, PrimitiveBatch, Quad, ScaledPixels, Scene, Shadow,
+    Size, Surface, Underline, point, size,
 };
 #[cfg(any(test, feature = "test-support"))]
 use image::RgbaImage;
@@ -297,7 +297,7 @@ impl MetalRenderer {
         let core_video_texture_cache =
             CVMetalTextureCache::new(None, device.clone(), None).unwrap();
 
-        Self {
+        let renderer = Self {
             device,
             layer,
             presents_with_transaction: false,
@@ -319,7 +319,12 @@ impl MetalRenderer {
             path_intermediate_texture: None,
             path_intermediate_msaa_texture: None,
             path_sample_count: PATH_SAMPLE_COUNT,
-        }
+        };
+
+        // Set initial color space to default (sRGB)
+        renderer.update_color_space(ColorSpace::default());
+
+        renderer
     }
 
     pub fn layer(&self) -> &metal::MetalLayerRef {
@@ -398,6 +403,36 @@ impl MetalRenderer {
 
     pub fn update_transparency(&self, transparent: bool) {
         self.layer.set_opaque(!transparent);
+    }
+
+    pub fn update_color_space(&self, color_space: ColorSpace) {
+        use core_foundation::string::CFString;
+        use core_graphics::color_space::CGColorSpace;
+
+        unsafe {
+            match color_space {
+                ColorSpace::Srgb | ColorSpace::Oklab => {
+                    let srgb_name = CFString::from_static_string("kCGColorSpaceSRGB");
+                    if let Some(colorspace) =
+                        CGColorSpace::create_with_name(srgb_name.as_concrete_TypeRef())
+                    {
+                        let _: () = msg_send![&*self.layer, setColorspace: colorspace.as_ptr()];
+                    }
+                }
+                ColorSpace::DisplayP3 => {
+                    let p3_name = CFString::from_static_string("kCGColorSpaceDisplayP3");
+                    if let Some(colorspace) =
+                        CGColorSpace::create_with_name(p3_name.as_concrete_TypeRef())
+                    {
+                        let _: () = msg_send![&*self.layer, setColorspace: colorspace.as_ptr()];
+                    }
+                }
+                ColorSpace::Untagged => {
+                    let _: () =
+                        msg_send![&*self.layer, setColorspace: std::ptr::null::<cocoa::base::id>()];
+                }
+            }
+        }
     }
 
     pub fn destroy(&self) {

--- a/crates/gpui_macos/src/window.rs
+++ b/crates/gpui_macos/src/window.rs
@@ -23,11 +23,11 @@ use cocoa::{
 };
 use dispatch2::DispatchQueue;
 use gpui::{
-    AnyWindowHandle, BackgroundExecutor, Bounds, Capslock, ExternalPaths, FileDropEvent,
-    ForegroundExecutor, KeyDownEvent, Keystroke, Modifiers, ModifiersChangedEvent, MouseButton,
-    MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels, PlatformAtlas, PlatformDisplay,
-    PlatformInput, PlatformInputHandler, PlatformWindow, Point, PromptButton, PromptLevel,
-    RequestFrameOptions, SharedString, Size, SystemWindowTab, WindowAppearance,
+    AnyWindowHandle, BackgroundExecutor, Bounds, Capslock, ColorSpace, ExternalPaths,
+    FileDropEvent, ForegroundExecutor, KeyDownEvent, Keystroke, Modifiers, ModifiersChangedEvent,
+    MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels, PlatformAtlas,
+    PlatformDisplay, PlatformInput, PlatformInputHandler, PlatformWindow, Point, PromptButton,
+    PromptLevel, RequestFrameOptions, SharedString, Size, SystemWindowTab, WindowAppearance,
     WindowBackgroundAppearance, WindowBounds, WindowControlArea, WindowKind, WindowParams, point,
     px, size,
 };
@@ -1376,6 +1376,11 @@ impl PlatformWindow for MacWindow {
 
     fn background_appearance(&self) -> WindowBackgroundAppearance {
         self.0.as_ref().lock().background_appearance
+    }
+
+    fn set_color_space(&self, color_space: ColorSpace) {
+        let this = self.0.as_ref().lock();
+        this.renderer.update_color_space(color_space);
     }
 
     fn is_subpixel_rendering_supported(&self) -> bool {

--- a/crates/gpui_windows/src/window.rs
+++ b/crates/gpui_windows/src/window.rs
@@ -797,6 +797,10 @@ impl PlatformWindow for WindowsWindow {
         true
     }
 
+    fn set_color_space(&self, _color_space: crate::ColorSpace) {
+        // TODO: Implement color space support for Windows using DXGI color space API
+    }
+
     fn set_title(&mut self, title: &str) {
         unsafe { SetWindowTextW(self.0.hwnd, &HSTRING::from(title)) }
             .inspect_err(|e| log::error!("Set title failed: {e}"))

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -937,6 +937,7 @@ impl VsCodeSettings {
         WorkspaceSettingsContent {
             active_pane_modifiers: self.active_pane_modifiers(),
             text_rendering_mode: None,
+            color_space: None,
             autosave: self.read_enum("files.autoSave", |s| match s {
                 "off" => Some(AutosaveSetting::Off),
                 "afterDelay" => Some(AutosaveSetting::AfterDelay {

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -19,6 +19,10 @@ pub struct WorkspaceSettingsContent {
     ///
     /// Default: platform_default
     pub text_rendering_mode: Option<TextRenderingMode>,
+    /// The color space to use for rendering.
+    ///
+    /// Default: srgb
+    pub color_space: Option<ColorSpace>,
     /// Layout mode for the bottom dock
     ///
     /// Default: contained
@@ -621,6 +625,34 @@ pub enum TextRenderingMode {
     Subpixel,
     /// Use grayscale text rendering.
     Grayscale,
+}
+
+/// The color space to use for rendering.
+#[derive(
+    Copy,
+    Clone,
+    Default,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    MergeFrom,
+    PartialEq,
+    Eq,
+    Debug,
+    strum::VariantArray,
+    strum::VariantNames,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum ColorSpace {
+    /// Standard sRGB (default).
+    #[default]
+    #[strum(serialize = "sRGB")]
+    Srgb,
+    /// Wide gamut color space for modern displays.
+    #[strum(serialize = "Display P3")]
+    DisplayP3,
+    /// Untagged (device) color space
+    Untagged,
 }
 
 impl OnLastWindowClosed {

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -1035,6 +1035,28 @@ fn appearance_page() -> SettingsPage {
         ]
     }
 
+    fn color_management_section() -> [SettingsPageItem; 2] {
+        [
+            SettingsPageItem::SectionHeader("Color Management"),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Color Space",
+                description: "The color space to use for rendering. Changing this affects how colors are displayed on your screen.",
+                field: Box::new(SettingField {
+                    json_path: Some("color_space"),
+                    pick: |settings_content| settings_content.workspace.color_space.as_ref(),
+                    write: |settings_content, value| {
+                        settings_content.workspace.color_space = value;
+                    },
+                }),
+                metadata: Some(Box::new(SettingsFieldMetadata {
+                    placeholder: None,
+                    should_do_titlecase: Some(false),
+                })),
+                files: USER,
+            }),
+        ]
+    }
+
     fn cursor_section() -> [SettingsPageItem; 5] {
         [
             SettingsPageItem::SectionHeader("Cursor"),
@@ -1234,6 +1256,7 @@ fn appearance_page() -> SettingsPage {
         cursor_section(),
         highlighting_section(),
         guides_section(),
+        color_management_section(),
     );
 
     SettingsPage {

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -467,6 +467,7 @@ fn init_renderers(cx: &mut App) {
         .add_basic_renderer::<settings::OnLastWindowClosed>(render_dropdown)
         .add_basic_renderer::<settings::CloseWindowWhenNoItems>(render_dropdown)
         .add_basic_renderer::<settings::TextRenderingMode>(render_dropdown)
+        .add_basic_renderer::<settings::ColorSpace>(render_dropdown)
         .add_basic_renderer::<settings::FontFamilyName>(render_font_picker)
         .add_basic_renderer::<settings::BaseKeymapContent>(render_dropdown)
         .add_basic_renderer::<settings::MultiCursorModifier>(render_dropdown)

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -29,6 +29,7 @@ pub struct WorkspaceSettings {
     pub when_closing_with_no_tabs: settings::CloseWindowWhenNoItems,
     pub on_last_window_closed: settings::OnLastWindowClosed,
     pub text_rendering_mode: settings::TextRenderingMode,
+    pub color_space: settings::ColorSpace,
     pub resize_all_panels_in_dock: Vec<DockPosition>,
     pub close_on_file_delete: bool,
     pub close_panel_on_toggle: bool,
@@ -101,6 +102,7 @@ impl Settings for WorkspaceSettings {
             when_closing_with_no_tabs: workspace.when_closing_with_no_tabs.unwrap(),
             on_last_window_closed: workspace.on_last_window_closed.unwrap(),
             text_rendering_mode: workspace.text_rendering_mode.unwrap(),
+            color_space: workspace.color_space.unwrap(),
             resize_all_panels_in_dock: workspace
                 .resize_all_panels_in_dock
                 .clone()

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -773,6 +773,12 @@ fn main() {
                     },
                 );
 
+                cx.set_color_space(match WorkspaceSettings::get_global(cx).color_space {
+                    settings::ColorSpace::Srgb => gpui::ColorSpace::Srgb,
+                    settings::ColorSpace::DisplayP3 => gpui::ColorSpace::DisplayP3,
+                    settings::ColorSpace::Untagged => gpui::ColorSpace::Untagged,
+                });
+
                 let new_host = &client::ClientSettings::get_global(cx).server_url;
                 if &http.base_url() != new_host {
                     http.set_base_url(new_host);


### PR DESCRIPTION
The default color space used by Zed is sRGB. This is a good default, as most image assets in the wild are untagged, and hence assumed to be sRGB, making Zed render them correctly.

However for wide-gamut image assets, Zed will fail to render them in their full gamut, clamping them to sRGB.

In addition, any color defined in a theme will be constrained to sRGB. This is surprising for users, who may be comparing to editors that are either fully color managed (and let themes specify colors in wider gamut color spaces), or just ignore color management altogether, always rendering #ff0000 red as the most vibrant red the current display can show.

Zed now has a setting to choose the target color space for all of its rendering, so users can choose vibrant themes over correct sRGB image viewing, and vice versa.

Longer term, a fully color managed pipeline, as well as theme support for specifying wide gamut colors, would remove the need for this setting.

Improves #9057

Release Notes:

- Added setting for choosing render color space
