### PR TITLE
git: Maintain multibuffer for the left-hand side even when not split

### DIFF
--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -3017,7 +3017,13 @@ impl MultiBuffer {
         if !diffs.is_empty() {
             let mut diffs_to_add = Vec::new();
             for (id, diff) in diffs {
-                if diff.is_inverted || buffer_diff.get(id).is_none() {
+                if buffer_diff.get(id).is_none_or(|existing_diff| {
+                    diff.diff
+                        .read(cx)
+                        .base_text(cx)
+                        .version()
+                        .changed_since(existing_diff.base_text().version())
+                }) {
                     if diffs_to_add.capacity() == 0 {
                         // we'd rather overallocate than reallocate as buffer diffs are quite big
                         // meaning re-allocations will be fairly expensive


### PR DESCRIPTION
This helps smooth out performance when toggling from non-split to split, at the cost of doing extra work when updating excerpts when non-split

Release Notes:

- N/A