### PR TITLE
ci: Run cross-platform tests for community members

### DIFF
--- a/.github/workflows/community_ci.yml
+++ b/.github/workflows/community_ci.yml
@@ -41,6 +41,8 @@ jobs:
         uses: swatinem/rust-cache@v2
       - name: Install Linux dependencies
         run: ./script/linux
+      - name: Install Mold
+        run: ./script/install-mold
       - name: Configure CI
         run: |
           mkdir -p ./../.cargo

--- a/.github/workflows/community_ci.yml
+++ b/.github/workflows/community_ci.yml
@@ -35,7 +35,6 @@ jobs:
   linux:
     needs: [gate]
     runs-on: ubuntu-latest
-    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
       - name: Cache dependencies
@@ -73,7 +72,6 @@ jobs:
     # macOS is slower and more expensive so make sure tests basically pass, first
     needs: [gate, linux]
     runs-on: macos-latest
-    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
       - name: Cache dependencies
@@ -100,7 +98,6 @@ jobs:
   windows:
     needs: [gate, linux]
     runs-on: windows-latest
-    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
       - name: Cache dependencies

--- a/.github/workflows/community_ci.yml
+++ b/.github/workflows/community_ci.yml
@@ -1,0 +1,121 @@
+# Run cross-platform tests for community members.
+#
+# The main tests workflow requires access to Zed's self-hosted
+# runners, which aren't available to non-organization members
+# without permission. However it's still useful for community
+# members to get cross-platform test feedback without blocking
+# on approval.
+#
+# The GitHub provided workers will be much slower than the official runners.
+name: Community CI
+
+on:
+  push:
+    branches: ["**"]
+  # pull_request:
+  #   branches: ["**"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  RUST_BACKTRACE: 1
+
+jobs:
+  gate:
+    if: github.repository_owner != 'zed-industries'
+    # `run_tests.yml` and so on runs only in non-forks.
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Running community CI"
+
+  linux:
+    needs: [gate]
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cache dependencies
+        uses: swatinem/rust-cache@v2
+      - name: Install Linux dependencies
+        run: ./script/linux
+      - name: Configure CI
+        run: |
+          mkdir -p ./../.cargo
+          cp ./.cargo/ci-config.toml ./../.cargo/config.toml
+      - name: cargo fmt
+        run: cargo fmt --all -- --check
+      - name: Check for typos
+        uses: crate-ci/typos@v1.24.6
+        with:
+          config: ./typos.toml
+      - name: cargo clippy
+        run: ./script/clippy
+      - name: Install cargo-nextest
+        run: cargo install cargo-nextest --locked
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+      - name: Run tests
+        run: cargo nextest run --workspace --no-fail-fast --failure-output immediate-final
+      - name: Run doctests
+        run: cargo test --workspace --doc --no-fail-fast
+      - name: Build Zed
+        run: cargo build -p zed
+      - name: Clean CI config
+        if: always()
+        run: rm -rf ./../.cargo
+
+  macos:
+    # macOS is slower and more expensive so make sure tests basically pass, first
+    needs: [gate, linux]
+    runs-on: macos-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure CI
+        run: |
+          mkdir -p ./../.cargo
+          cp ./.cargo/ci-config.toml ./../.cargo/config.toml
+      - name: cargo clippy
+        run: ./script/clippy
+      - name: Install cargo-nextest
+        run: cargo install cargo-nextest --locked
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+      - name: Run tests
+        run: cargo nextest run --workspace --no-fail-fast --failure-output immediate-final
+      - name: Build workspace
+        run: cargo build --workspace --bins --all-features
+      - name: Clean CI config
+        if: always()
+        run: rm -rf ./../.cargo
+
+  windows:
+    needs: [gate, linux]
+    runs-on: windows-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure CI
+        run: |
+          New-Item -ItemType Directory -Path "./../.cargo" -Force
+          Copy-Item -Path "./.cargo/ci-config.toml" -Destination "./../.cargo/config.toml"
+      - name: cargo clippy
+        run: .\script\clippy.ps1
+      - name: Install cargo-nextest
+        run: cargo install cargo-nextest --locked
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+      - name: Run tests
+        run: cargo nextest run --workspace --no-fail-fast --failure-output immediate-final
+      - name: Build Zed
+        run: cargo build
+      - name: Clean CI config
+        if: always()
+        run: Remove-Item -Recurse -Path "./../.cargo" -Force -ErrorAction SilentlyContinue

--- a/.github/workflows/community_ci.yml
+++ b/.github/workflows/community_ci.yml
@@ -76,6 +76,8 @@ jobs:
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
+      - name: Cache dependencies
+        uses: swatinem/rust-cache@v2
       - name: Configure CI
         run: |
           mkdir -p ./../.cargo
@@ -101,6 +103,8 @@ jobs:
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
+      - name: Cache dependencies
+        uses: swatinem/rust-cache@v2
       - name: Configure CI
         run: |
           New-Item -ItemType Directory -Path "./../.cargo" -Force


### PR DESCRIPTION
Add a GitHub Actions workflow that runs on hosted runners for non-organization contributors (github.repository_owner != 'zed-industries'). It exercises Linux, macOS, and Windows jobs running clippy, cargo-nextest tests, doctests, and builds, and copies/cleans a temporary CI cargo config during runs.

Closes N/A

- [ ] Tests or screenshots needed?
- [ ] Code Reviewed
- [ ] Manual QA

Release Notes:

- N/A *or* Added/Fixed/Improved ...
