### PR TITLE
repl: Support Jupyter widgets

### DIFF
--- a/crates/repl/src/notebook/cell.rs
+++ b/crates/repl/src/notebook/cell.rs
@@ -18,7 +18,7 @@ use util::ResultExt;
 
 use crate::{
     notebook::{CODE_BLOCK_INSET, GUTTER_WIDTH},
-    outputs::{Output, WidgetStore, plain, plain::TerminalOutput, user_error::ErrorView},
+    outputs::{Output, plain, plain::TerminalOutput, user_error::ErrorView},
     repl_settings::ReplSettings,
 };
 

--- a/crates/repl/src/notebook/cell.rs
+++ b/crates/repl/src/notebook/cell.rs
@@ -18,7 +18,7 @@ use util::ResultExt;
 
 use crate::{
     notebook::{CODE_BLOCK_INSET, GUTTER_WIDTH},
-    outputs::{Output, plain, plain::TerminalOutput, user_error::ErrorView},
+    outputs::{Output, WidgetStore, plain, plain::TerminalOutput, user_error::ErrorView},
     repl_settings::ReplSettings,
 };
 

--- a/crates/repl/src/outputs.rs
+++ b/crates/repl/src/outputs.rs
@@ -34,7 +34,7 @@
 //! interpreting and displaying various types of Jupyter output.
 
 use editor::{Editor, MultiBuffer};
-use gpui::{AnyElement, ClipboardItem, Entity, EventEmitter, Render, WeakEntity};
+use gpui::{AnyElement, ClipboardItem, Entity, EventEmitter, Render, Subscription, WeakEntity};
 use language::Buffer;
 use menu;
 use runtimelib::{ExecutionState, JupyterMessage, JupyterMessageContent, MimeBundle, MimeType};
@@ -59,6 +59,10 @@ use plain::TerminalOutput;
 
 pub(crate) mod user_error;
 use user_error::ErrorView;
+
+mod widget;
+use widget::WidgetStore;
+
 use workspace::Workspace;
 
 use crate::repl_settings::ReplSettings;
@@ -136,6 +140,11 @@ pub enum Output {
         content: Entity<JsonView>,
         display_id: Option<String>,
     },
+    Widget {
+        store: Entity<WidgetStore>,
+        model_id: String,
+        display_id: Option<String>,
+    },
     ClearOutputWaitMarker,
 }
 
@@ -173,7 +182,8 @@ impl Output {
             Output::Image { .. }
             | Output::Markdown { .. }
             | Output::Table { .. }
-            | Output::Json { .. } => None,
+            | Output::Json { .. }
+            | Output::Widget { .. } => None,
             Output::Message(_) => None,
             Output::ClearOutputWaitMarker => None,
         }
@@ -262,6 +272,10 @@ impl Output {
             Self::Message(message) => Some(div().child(message.clone()).into_any_element()),
             Self::Table { content, .. } => Some(content.clone().into_any_element()),
             Self::Json { content, .. } => Some(content.clone().into_any_element()),
+            Self::Widget { store, model_id, .. } => {
+                let store_ref = store.read(cx);
+                Some(store_ref.render_widget(model_id, window, cx))
+            }
             Self::ErrorOutput(error_view) => error_view.render(window, cx),
             Self::ClearOutputWaitMarker => None,
         }
@@ -370,6 +384,7 @@ impl Output {
                         .into_any_element(),
                 ),
                 Self::Message(_) => None,
+                Self::Widget { .. } => None,
                 Self::Table { content, .. } => {
                     Self::render_output_controls(content.clone(), workspace, window, cx)
                 }
@@ -387,6 +402,7 @@ impl Output {
             Output::Table { display_id, .. } => display_id.clone(),
             Output::Markdown { display_id, .. } => display_id.clone(),
             Output::Json { display_id, .. } => display_id.clone(),
+            Output::Widget { display_id, .. } => display_id.clone(),
             Output::ClearOutputWaitMarker => None,
         }
     }
@@ -484,6 +500,8 @@ pub struct ExecutionView {
     pub outputs: Vec<Output>,
     pub status: ExecutionStatus,
     pending_input: Option<PendingInput>,
+    widget_store: Entity<WidgetStore>,
+    _subscriptions: Vec<Subscription>,
 }
 
 impl EventEmitter<ExecutionViewFinishedEmpty> for ExecutionView {}
@@ -494,13 +512,20 @@ impl ExecutionView {
     pub fn new(
         status: ExecutionStatus,
         workspace: WeakEntity<Workspace>,
-        _cx: &mut Context<Self>,
+        cx: &mut Context<Self>,
     ) -> Self {
+        let widget_store = cx.new(|_| WidgetStore::new());
+        let observation = cx.observe(&widget_store, |_this, _store, cx| {
+            cx.notify();
+        });
+
         Self {
             workspace,
             outputs: Default::default(),
             status,
             pending_input: None,
+            widget_store,
+            _subscriptions: vec![observation],
         }
     }
 
@@ -561,18 +586,67 @@ impl ExecutionView {
         cx: &mut Context<Self>,
     ) {
         let output: Output = match message {
-            JupyterMessageContent::ExecuteResult(result) => Output::new(
-                &result.data,
-                result.transient.as_ref().and_then(|t| t.display_id.clone()),
-                window,
-                cx,
-            ),
-            JupyterMessageContent::DisplayData(result) => Output::new(
-                &result.data,
-                result.transient.as_ref().and_then(|t| t.display_id.clone()),
-                window,
-                cx,
-            ),
+            JupyterMessageContent::CommOpen(comm_open) => {
+                self.widget_store.update(cx, |store, _cx| {
+                    store.create_model(&comm_open.comm_id.0, &comm_open.data);
+                });
+                cx.notify();
+                return;
+            }
+            JupyterMessageContent::CommMsg(comm_msg) => {
+                self.widget_store.update(cx, |store, _cx| {
+                    store.update_model(&comm_msg.comm_id.0, &comm_msg.data);
+                });
+                cx.notify();
+                return;
+            }
+            JupyterMessageContent::CommClose(_) => {
+                return;
+            }
+            JupyterMessageContent::ExecuteResult(result) => {
+                if let Some(model_id) = widget::extract_widget_model_id(&result.data) {
+                    Output::Widget {
+                        store: self.widget_store.clone(),
+                        model_id,
+                        display_id: result
+                            .transient
+                            .as_ref()
+                            .and_then(|t| t.display_id.clone()),
+                    }
+                } else {
+                    Output::new(
+                        &result.data,
+                        result
+                            .transient
+                            .as_ref()
+                            .and_then(|t| t.display_id.clone()),
+                        window,
+                        cx,
+                    )
+                }
+            }
+            JupyterMessageContent::DisplayData(result) => {
+                if let Some(model_id) = widget::extract_widget_model_id(&result.data) {
+                    Output::Widget {
+                        store: self.widget_store.clone(),
+                        model_id,
+                        display_id: result
+                            .transient
+                            .as_ref()
+                            .and_then(|t| t.display_id.clone()),
+                    }
+                } else {
+                    Output::new(
+                        &result.data,
+                        result
+                            .transient
+                            .as_ref()
+                            .and_then(|t| t.display_id.clone()),
+                        window,
+                        cx,
+                    )
+                }
+            }
             JupyterMessageContent::StreamContent(result) => {
                 // Previous stream data will combine together, handling colors, carriage returns, etc
                 if let Some(new_terminal) = self.apply_terminal_text(&result.text, window, cx) {

--- a/crates/repl/src/outputs.rs
+++ b/crates/repl/src/outputs.rs
@@ -273,9 +273,9 @@ impl Output {
             Self::Message(message) => Some(div().child(message.clone()).into_any_element()),
             Self::Table { content, .. } => Some(content.clone().into_any_element()),
             Self::Json { content, .. } => Some(content.clone().into_any_element()),
-            Self::Widget { store, model_id, .. } => {
-                Some(WidgetStore::render_widget(store, model_id, window, cx))
-            }
+            Self::Widget {
+                store, model_id, ..
+            } => Some(WidgetStore::render_widget(store, model_id, window, cx)),
             Self::ErrorOutput(error_view) => error_view.render(window, cx),
             Self::ClearOutputWaitMarker => None,
         }
@@ -591,18 +591,12 @@ impl ExecutionView {
                     Output::Widget {
                         store: self.widget_store.clone(),
                         model_id,
-                        display_id: result
-                            .transient
-                            .as_ref()
-                            .and_then(|t| t.display_id.clone()),
+                        display_id: result.transient.as_ref().and_then(|t| t.display_id.clone()),
                     }
                 } else {
                     Output::new(
                         &result.data,
-                        result
-                            .transient
-                            .as_ref()
-                            .and_then(|t| t.display_id.clone()),
+                        result.transient.as_ref().and_then(|t| t.display_id.clone()),
                         window,
                         cx,
                     )
@@ -613,18 +607,12 @@ impl ExecutionView {
                     Output::Widget {
                         store: self.widget_store.clone(),
                         model_id,
-                        display_id: result
-                            .transient
-                            .as_ref()
-                            .and_then(|t| t.display_id.clone()),
+                        display_id: result.transient.as_ref().and_then(|t| t.display_id.clone()),
                     }
                 } else {
                     Output::new(
                         &result.data,
-                        result
-                            .transient
-                            .as_ref()
-                            .and_then(|t| t.display_id.clone()),
+                        result.transient.as_ref().and_then(|t| t.display_id.clone()),
                         window,
                         cx,
                     )
@@ -809,6 +797,10 @@ impl ExecutionView {
 
 impl Render for ExecutionView {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        self.widget_store.update(cx, |store, cx| {
+            store.create_missing_text_editors(window, cx);
+        });
+
         let status = match &self.status {
             ExecutionStatus::ConnectingToKernel => Label::new("Connecting to kernel...")
                 .color(Color::Muted)

--- a/crates/repl/src/outputs.rs
+++ b/crates/repl/src/outputs.rs
@@ -61,7 +61,8 @@ pub(crate) mod user_error;
 use user_error::ErrorView;
 
 mod widget;
-use widget::WidgetStore;
+pub(crate) use widget::WidgetCommMessage;
+pub(crate) use widget::WidgetStore;
 
 use workspace::Workspace;
 
@@ -273,8 +274,7 @@ impl Output {
             Self::Table { content, .. } => Some(content.clone().into_any_element()),
             Self::Json { content, .. } => Some(content.clone().into_any_element()),
             Self::Widget { store, model_id, .. } => {
-                let store_ref = store.read(cx);
-                Some(store_ref.render_widget(model_id, window, cx))
+                Some(WidgetStore::render_widget(store, model_id, window, cx))
             }
             Self::ErrorOutput(error_view) => error_view.render(window, cx),
             Self::ClearOutputWaitMarker => None,
@@ -512,9 +512,9 @@ impl ExecutionView {
     pub fn new(
         status: ExecutionStatus,
         workspace: WeakEntity<Workspace>,
+        widget_store: Entity<WidgetStore>,
         cx: &mut Context<Self>,
     ) -> Self {
-        let widget_store = cx.new(|_| WidgetStore::new());
         let observation = cx.observe(&widget_store, |_this, _store, cx| {
             cx.notify();
         });
@@ -586,23 +586,6 @@ impl ExecutionView {
         cx: &mut Context<Self>,
     ) {
         let output: Output = match message {
-            JupyterMessageContent::CommOpen(comm_open) => {
-                self.widget_store.update(cx, |store, _cx| {
-                    store.create_model(&comm_open.comm_id.0, &comm_open.data);
-                });
-                cx.notify();
-                return;
-            }
-            JupyterMessageContent::CommMsg(comm_msg) => {
-                self.widget_store.update(cx, |store, _cx| {
-                    store.update_model(&comm_msg.comm_id.0, &comm_msg.data);
-                });
-                cx.notify();
-                return;
-            }
-            JupyterMessageContent::CommClose(_) => {
-                return;
-            }
             JupyterMessageContent::ExecuteResult(result) => {
                 if let Some(model_id) = widget::extract_widget_model_id(&result.data) {
                     Output::Widget {
@@ -988,7 +971,10 @@ mod tests {
         weak_workspace: WeakEntity<workspace::Workspace>,
     ) -> Entity<ExecutionView> {
         cx.update(|_window, cx| {
-            cx.new(|cx| ExecutionView::new(ExecutionStatus::Queued, weak_workspace, cx))
+            let widget_store = cx.new(|_| widget::WidgetStore::new());
+            cx.new(|cx| {
+                ExecutionView::new(ExecutionStatus::Queued, weak_workspace, widget_store, cx)
+            })
         })
     }
 

--- a/crates/repl/src/outputs.rs
+++ b/crates/repl/src/outputs.rs
@@ -799,6 +799,7 @@ impl Render for ExecutionView {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         self.widget_store.update(cx, |store, cx| {
             store.create_missing_text_editors(window, cx);
+            store.create_missing_markdown_views(cx);
         });
 
         let status = match &self.status {

--- a/crates/repl/src/outputs/widget.rs
+++ b/crates/repl/src/outputs/widget.rs
@@ -1,0 +1,264 @@
+use collections::HashMap;
+use gpui::{AnyElement, App, Window};
+use runtimelib::{MimeBundle, MimeType};
+use theme::ActiveTheme;
+use ui::prelude::*;
+use ui::ProgressBar;
+
+struct WidgetModel {
+    state: serde_json::Map<String, serde_json::Value>,
+    model_name: String,
+}
+
+pub struct WidgetStore {
+    models: HashMap<String, WidgetModel>,
+}
+
+impl WidgetStore {
+    pub fn new() -> Self {
+        Self {
+            models: HashMap::default(),
+        }
+    }
+
+    pub fn create_model(&mut self, comm_id: &str, data: &serde_json::Map<String, serde_json::Value>) {
+        let state = data
+            .get("state")
+            .and_then(|v| v.as_object())
+            .cloned()
+            .unwrap_or_default();
+
+        let model_name = state
+            .get("_model_name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("UnknownModel")
+            .to_string();
+
+        self.models.insert(
+            comm_id.to_string(),
+            WidgetModel { state, model_name },
+        );
+    }
+
+    pub fn update_model(&mut self, comm_id: &str, data: &serde_json::Map<String, serde_json::Value>) {
+        let method = data.get("method").and_then(|v| v.as_str());
+        if method != Some("update") {
+            return;
+        }
+
+        let state_patch = match data.get("state").and_then(|v| v.as_object()) {
+            Some(patch) => patch,
+            None => return,
+        };
+
+        if let Some(model) = self.models.get_mut(comm_id) {
+            for (key, value) in state_patch {
+                model.state.insert(key.clone(), value.clone());
+            }
+        }
+    }
+
+    pub fn render_widget(&self, model_id: &str, window: &mut Window, cx: &App) -> AnyElement {
+        let model = match self.models.get(model_id) {
+            Some(m) => m,
+            None => return div().into_any_element(),
+        };
+
+        match model.model_name.as_str() {
+            "FloatProgressModel" | "IntProgressModel" => render_progress(model, window, cx),
+            "LabelModel" => render_label(model),
+            "HTMLModel" => render_html_as_text(model),
+            "HBoxModel" => render_hbox(self, model, window, cx),
+            "VBoxModel" | "BoxModel" => render_vbox(self, model, window, cx),
+            // Layout and style models are metadata-only, no visual rendering
+            "LayoutModel" | "ProgressStyleModel" | "ButtonStyleModel"
+            | "SliderStyleModel" | "DescriptionStyleModel" | "StyleModel" => {
+                div().into_any_element()
+            }
+            _ => render_unsupported(model),
+        }
+    }
+}
+
+fn render_unsupported(model: &WidgetModel) -> AnyElement {
+    Label::new(format!("Unsupported widget: {}", model.model_name))
+        .size(LabelSize::Small)
+        .color(Color::Muted)
+        .into_any_element()
+}
+
+fn render_progress(model: &WidgetModel, _window: &mut Window, cx: &App) -> AnyElement {
+    let value = model
+        .state
+        .get("value")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.0) as f32;
+    let min = model
+        .state
+        .get("min")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.0) as f32;
+    let max = model
+        .state
+        .get("max")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(100.0) as f32;
+    let description = model
+        .state
+        .get("description")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let bar_style = model
+        .state
+        .get("bar_style")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    let mut progress_bar = ProgressBar::new("widget-progress", value - min, max - min, cx);
+
+    match bar_style {
+        "success" => {
+            progress_bar = progress_bar.fg_color(cx.theme().status().success);
+        }
+        "info" => {
+            progress_bar = progress_bar.fg_color(cx.theme().status().info);
+        }
+        "warning" => {
+            progress_bar = progress_bar.fg_color(cx.theme().status().warning);
+        }
+        "danger" => {
+            progress_bar = progress_bar.fg_color(cx.theme().status().error);
+        }
+        _ => {}
+    }
+
+    h_flex()
+        .gap_2()
+        .items_center()
+        .flex_1()
+        .when(!description.is_empty(), |el| {
+            el.child(
+                Label::new(description.to_string())
+                    .size(LabelSize::Small)
+                    .color(Color::Muted),
+            )
+        })
+        .child(div().flex_1().child(progress_bar))
+        .into_any_element()
+}
+
+fn render_label(model: &WidgetModel) -> AnyElement {
+    let value = model
+        .state
+        .get("value")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    if value.is_empty() {
+        return div().into_any_element();
+    }
+
+    Label::new(value.to_string())
+        .size(LabelSize::Small)
+        .color(Color::Muted)
+        .into_any_element()
+}
+
+fn render_html_as_text(model: &WidgetModel) -> AnyElement {
+    let value = model
+        .state
+        .get("value")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    if value.is_empty() {
+        return div().into_any_element();
+    }
+
+    let text = strip_html_tags(value);
+    if text.is_empty() {
+        return div().into_any_element();
+    }
+
+    Label::new(text)
+        .size(LabelSize::Small)
+        .color(Color::Muted)
+        .into_any_element()
+}
+
+fn strip_html_tags(html: &str) -> String {
+    let mut result = String::with_capacity(html.len());
+    let mut inside_tag = false;
+
+    for ch in html.chars() {
+        match ch {
+            '<' => inside_tag = true,
+            '>' => inside_tag = false,
+            _ if !inside_tag => result.push(ch),
+            _ => {}
+        }
+    }
+
+    decode_html_entities(&result)
+}
+
+fn decode_html_entities(text: &str) -> String {
+    text.replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+        .replace("&nbsp;", " ")
+}
+
+const IPY_MODEL_PREFIX: &str = "IPY_MODEL_";
+
+fn render_hbox(store: &WidgetStore, model: &WidgetModel, window: &mut Window, cx: &App) -> AnyElement {
+    let children = model.state.get("children").and_then(|v| v.as_array());
+
+    let mut flex = h_flex().gap_1().items_center();
+
+    if let Some(children) = children {
+        for child_ref in children {
+            if let Some(child_id) = child_ref
+                .as_str()
+                .and_then(|s| s.strip_prefix(IPY_MODEL_PREFIX))
+            {
+                flex = flex.child(store.render_widget(child_id, window, cx));
+            }
+        }
+    }
+
+    flex.into_any_element()
+}
+
+fn render_vbox(store: &WidgetStore, model: &WidgetModel, window: &mut Window, cx: &App) -> AnyElement {
+    let children = model.state.get("children").and_then(|v| v.as_array());
+
+    let mut flex = v_flex().gap_1();
+
+    if let Some(children) = children {
+        for child_ref in children {
+            if let Some(child_id) = child_ref
+                .as_str()
+                .and_then(|s| s.strip_prefix(IPY_MODEL_PREFIX))
+            {
+                flex = flex.child(store.render_widget(child_id, window, cx));
+            }
+        }
+    }
+
+    flex.into_any_element()
+}
+
+pub(crate) fn extract_widget_model_id(data: &MimeBundle) -> Option<String> {
+    for mime in &data.content {
+        if let MimeType::WidgetView(json) = mime {
+            return json
+                .get("model_id")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+        }
+    }
+    None
+}

--- a/crates/repl/src/outputs/widget.rs
+++ b/crates/repl/src/outputs/widget.rs
@@ -407,15 +407,71 @@ fn convert_html_to_markdown_string(html: &str) -> String {
 
 const IPY_MODEL_PREFIX: &str = "IPY_MODEL_";
 
+struct LayoutProps {
+    align_items: Option<String>,
+    justify_content: Option<String>,
+    #[allow(dead_code)]
+    width: Option<String>,
+    #[allow(dead_code)]
+    flex_flow: Option<String>,
+}
+
+fn get_layout_props(store_ref: &WidgetStore, model: &WidgetModel) -> LayoutProps {
+    let layout_id = model
+        .state
+        .get("layout")
+        .and_then(|v| v.as_str())
+        .and_then(|s| s.strip_prefix(IPY_MODEL_PREFIX));
+
+    let layout_state = layout_id.and_then(|id| store_ref.get_state(id));
+
+    LayoutProps {
+        align_items: layout_state
+            .and_then(|s| s.get("align_items"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
+        justify_content: layout_state
+            .and_then(|s| s.get("justify_content"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
+        width: layout_state
+            .and_then(|s| s.get("width"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
+        flex_flow: layout_state
+            .and_then(|s| s.get("flex_flow"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
+    }
+}
+
 fn render_hbox(
     store: &Entity<WidgetStore>,
     model: &WidgetModel,
     window: &mut Window,
     cx: &App,
 ) -> AnyElement {
+    let store_ref = store.read(cx);
+    let layout = get_layout_props(&store_ref, model);
     let children = model.state.get("children").and_then(|v| v.as_array());
 
-    let mut flex = h_flex().gap_1().items_center();
+    let mut flex = h_flex().gap_2();
+
+    flex = match layout.align_items.as_deref() {
+        Some("center") => flex.items_center(),
+        Some("start" | "flex-start") => flex.items_start(),
+        Some("end" | "flex-end") => flex.items_end(),
+        _ => flex.items_center(),
+    };
+
+    flex = match layout.justify_content.as_deref() {
+        Some("center") => flex.justify_center(),
+        Some("start" | "flex-start") => flex.justify_start(),
+        Some("end" | "flex-end") => flex.justify_end(),
+        Some("space-between") => flex.justify_between(),
+        Some("space-around") => flex.justify_around(),
+        _ => flex,
+    };
 
     if let Some(children) = children {
         for child_ref in children {
@@ -437,9 +493,27 @@ fn render_vbox(
     window: &mut Window,
     cx: &App,
 ) -> AnyElement {
+    let store_ref = store.read(cx);
+    let layout = get_layout_props(&store_ref, model);
     let children = model.state.get("children").and_then(|v| v.as_array());
 
-    let mut flex = v_flex().gap_1();
+    let mut flex = v_flex().gap_2();
+
+    flex = match layout.align_items.as_deref() {
+        Some("center") => flex.items_center(),
+        Some("start" | "flex-start") => flex.items_start(),
+        Some("end" | "flex-end") => flex.items_end(),
+        _ => flex,
+    };
+
+    flex = match layout.justify_content.as_deref() {
+        Some("center") => flex.justify_center(),
+        Some("start" | "flex-start") => flex.justify_start(),
+        Some("end" | "flex-end") => flex.justify_end(),
+        Some("space-between") => flex.justify_between(),
+        Some("space-around") => flex.justify_around(),
+        _ => flex,
+    };
 
     if let Some(children) = children {
         for child_ref in children {

--- a/crates/repl/src/outputs/widget.rs
+++ b/crates/repl/src/outputs/widget.rs
@@ -1,9 +1,10 @@
 use collections::HashMap;
-use gpui::{AnyElement, App, Context, Entity, EventEmitter, Window};
+use editor::{Editor, EditorEvent};
+use gpui::{AnyElement, App, Context, Corner, Entity, EventEmitter, Subscription, Window};
 use runtimelib::{CommId, CommMsg, JupyterMessage, MimeBundle, MimeType};
 use theme::ActiveTheme;
 use ui::prelude::*;
-use ui::{Checkbox, ProgressBar, ToggleState};
+use ui::{Checkbox, ContextMenu, PopoverMenu, ProgressBar, ToggleState};
 
 struct WidgetModel {
     comm_id: String,
@@ -13,6 +14,8 @@ struct WidgetModel {
 
 pub struct WidgetStore {
     models: HashMap<String, WidgetModel>,
+    text_editors: HashMap<String, Entity<Editor>>,
+    _editor_subscriptions: Vec<Subscription>,
 }
 
 pub(crate) struct WidgetCommMessage(pub JupyterMessage);
@@ -23,6 +26,8 @@ impl WidgetStore {
     pub fn new() -> Self {
         Self {
             models: HashMap::default(),
+            text_editors: HashMap::default(),
+            _editor_subscriptions: Vec::new(),
         }
     }
 
@@ -43,15 +48,6 @@ impl WidgetStore {
             .unwrap_or("UnknownModel")
             .to_string();
 
-        let state_keys: Vec<&String> = state.keys().collect();
-        log::info!(
-            "widget create_model: comm_id={}, model_name={}, state_keys={:?}, data_keys={:?}",
-            comm_id,
-            model_name,
-            state_keys,
-            data.keys().collect::<Vec<_>>()
-        );
-
         self.models.insert(
             comm_id.to_string(),
             WidgetModel {
@@ -64,6 +60,65 @@ impl WidgetStore {
 
     pub fn close_model(&mut self, comm_id: &str) {
         self.models.remove(comm_id);
+        self.text_editors.remove(comm_id);
+    }
+
+    pub fn create_missing_text_editors(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let needed: Vec<(String, String, bool)> = self
+            .models
+            .iter()
+            .filter(|(_, m)| m.model_name == "TextModel" || m.model_name == "TextareaModel")
+            .filter(|(id, _)| !self.text_editors.contains_key(*id))
+            .map(|(id, m)| {
+                let value = m
+                    .state
+                    .get("value")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let is_textarea = m.model_name == "TextareaModel";
+                (id.clone(), value, is_textarea)
+            })
+            .collect();
+
+        for (model_id, value, is_textarea) in needed {
+            let editor = cx.new(|cx| {
+                let mut editor = if is_textarea {
+                    Editor::auto_height(3, 10, window, cx)
+                } else {
+                    Editor::single_line(window, cx)
+                };
+                if !value.is_empty() {
+                    editor.set_text(value, window, cx);
+                }
+                editor
+            });
+
+            let subscription = cx.subscribe(&editor, {
+                let model_id = model_id.clone();
+                move |this: &mut Self, editor, event: &EditorEvent, cx| {
+                    if !matches!(event, EditorEvent::BufferEdited) {
+                        return;
+                    }
+                    let new_text = editor.read(cx).text(cx);
+                    let model_value = this
+                        .models
+                        .get(&model_id)
+                        .and_then(|m| m.state.get("value"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
+                    if new_text == model_value {
+                        return;
+                    }
+                    let mut state_patch = serde_json::Map::new();
+                    state_patch.insert("value".into(), serde_json::Value::String(new_text));
+                    this.send_update(&model_id, state_patch, cx);
+                }
+            });
+
+            self.text_editors.insert(model_id, editor);
+            self._editor_subscriptions.push(subscription);
+        }
     }
 
     pub fn update_model(
@@ -72,13 +127,6 @@ impl WidgetStore {
         data: &serde_json::Map<String, serde_json::Value>,
     ) {
         let method = data.get("method").and_then(|v| v.as_str());
-        log::info!(
-            "widget update_model: comm_id={}, method={:?}, data_keys={:?}",
-            comm_id,
-            method,
-            data.keys().collect::<Vec<_>>()
-        );
-
         if method != Some("update") {
             return;
         }
@@ -88,20 +136,15 @@ impl WidgetStore {
             None => return,
         };
 
-        let patch_keys: Vec<&String> = state_patch.keys().collect();
-        let found = self.models.contains_key(comm_id);
-        log::info!(
-            "widget update_model: comm_id={}, found_in_store={}, patch_keys={:?}",
-            comm_id,
-            found,
-            patch_keys
-        );
-
         if let Some(model) = self.models.get_mut(comm_id) {
             for (key, value) in state_patch {
                 model.state.insert(key.clone(), value.clone());
             }
         }
+    }
+
+    fn get_state(&self, model_id: &str) -> Option<&serde_json::Map<String, serde_json::Value>> {
+        self.models.get(model_id).map(|m| &m.state)
     }
 
     pub fn send_update(
@@ -158,22 +201,10 @@ impl WidgetStore {
         let store_ref = store.read(cx);
         let model = match store_ref.models.get(model_id) {
             Some(m) => m,
-            None => {
-                log::warn!("widget render_widget: model_id={} NOT FOUND in store (store has {} models: {:?})",
-                    model_id,
-                    store_ref.models.len(),
-                    store_ref.models.keys().collect::<Vec<_>>()
-                );
-                return div().into_any_element();
-            }
+            None => return div().into_any_element(),
         };
 
-        log::info!(
-            "widget render_widget: model_id={}, model_name={}, state_keys={:?}",
-            model_id,
-            model.model_name,
-            model.state.keys().collect::<Vec<_>>()
-        );
+        let text_editor = store_ref.text_editors.get(model_id).cloned();
 
         match model.model_name.as_str() {
             "FloatProgressModel" | "IntProgressModel" => render_progress(model, window, cx),
@@ -184,13 +215,15 @@ impl WidgetStore {
             "ButtonModel" => render_button(store, model),
             "CheckboxModel" => render_checkbox(store, model),
             "DropdownModel" => render_dropdown(store, model),
-            "IntSliderModel" | "FloatSliderModel" => render_slider(model),
-            "TextModel" | "TextareaModel" => render_text(model),
+            "IntSliderModel" | "FloatSliderModel" => render_slider(store, model, window, cx),
+            "TextModel" | "TextareaModel" => render_text(model, text_editor, cx),
             "OutputModel" => render_output_widget(store, model, window, cx),
-            "LayoutModel" | "ProgressStyleModel" | "ButtonStyleModel"
-            | "SliderStyleModel" | "DescriptionStyleModel" | "StyleModel" => {
-                div().into_any_element()
-            }
+            "LayoutModel"
+            | "ProgressStyleModel"
+            | "ButtonStyleModel"
+            | "SliderStyleModel"
+            | "DescriptionStyleModel"
+            | "StyleModel" => div().into_any_element(),
             _ => render_unsupported(model),
         }
     }
@@ -337,13 +370,6 @@ fn render_hbox(
 ) -> AnyElement {
     let children = model.state.get("children").and_then(|v| v.as_array());
 
-    log::info!(
-        "widget render_hbox: comm_id={}, has_children={}, children_raw={:?}",
-        model.comm_id,
-        children.is_some(),
-        model.state.get("children")
-    );
-
     let mut flex = h_flex().gap_1().items_center();
 
     if let Some(children) = children {
@@ -352,10 +378,7 @@ fn render_hbox(
                 .as_str()
                 .and_then(|s| s.strip_prefix(IPY_MODEL_PREFIX))
             {
-                log::info!("widget render_hbox: rendering child_id={}", child_id);
                 flex = flex.child(WidgetStore::render_widget(store, child_id, window, cx));
-            } else {
-                log::warn!("widget render_hbox: child_ref not IPY_MODEL_: {:?}", child_ref);
             }
         }
     }
@@ -388,11 +411,6 @@ fn render_vbox(
 }
 
 fn render_button(store: &Entity<WidgetStore>, model: &WidgetModel) -> AnyElement {
-    log::info!(
-        "widget render_button: comm_id={}, state={:?}",
-        model.comm_id,
-        model.state
-    );
     let description = model
         .state
         .get("description")
@@ -415,8 +433,10 @@ fn render_button(store: &Entity<WidgetStore>, model: &WidgetModel) -> AnyElement
     .disabled(disabled)
     .on_click(move |_, _window, cx| {
         let model_id = model_id.clone();
+        let mut content = serde_json::Map::new();
+        content.insert("event".into(), "click".into());
         store.update(cx, |widget_store, cx| {
-            widget_store.send_custom(&model_id, serde_json::Map::new(), cx);
+            widget_store.send_custom(&model_id, content, cx);
         });
     })
     .into_any_element()
@@ -489,13 +509,14 @@ fn render_dropdown(store: &Entity<WidgetStore>, model: &WidgetModel) -> AnyEleme
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
 
-    let options: Vec<String> = model
+    let options: Vec<(usize, String)> = model
         .state
         .get("_options_labels")
         .and_then(|v| v.as_array())
         .map(|arr| {
             arr.iter()
-                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .enumerate()
+                .filter_map(|(i, v)| v.as_str().map(|s| (i, s.to_string())))
                 .collect()
         })
         .unwrap_or_default();
@@ -507,18 +528,15 @@ fn render_dropdown(store: &Entity<WidgetStore>, model: &WidgetModel) -> AnyEleme
         .unwrap_or(0) as usize;
 
     let current_label = options
-        .get(current_index)
-        .cloned()
+        .iter()
+        .find(|(i, _)| *i == current_index)
+        .map(|(_, label)| label.clone())
         .unwrap_or_else(|| "—".to_string());
 
-    let next_index = if options.is_empty() {
-        0
-    } else {
-        (current_index + 1) % options.len()
-    };
-
     let model_id = model.comm_id.clone();
-    let store = store.clone();
+    let store_for_menu = store.clone();
+    let model_id_for_menu = model_id.clone();
+    let has_options = !options.is_empty();
 
     h_flex()
         .gap_2()
@@ -531,27 +549,70 @@ fn render_dropdown(store: &Entity<WidgetStore>, model: &WidgetModel) -> AnyEleme
             )
         })
         .child(
-            Button::new(
-                SharedString::from(format!("widget-dd-{}", model_id)),
-                format!("{} ▾", current_label),
-            )
-            .disabled(disabled || options.is_empty())
-            .on_click(move |_, _window, cx| {
-                let mut state_patch = serde_json::Map::new();
-                state_patch.insert(
-                    "index".into(),
-                    serde_json::Value::Number(serde_json::Number::from(next_index as u64)),
-                );
-                let model_id = model_id.clone();
-                store.update(cx, |widget_store, cx| {
-                    widget_store.send_update(&model_id, state_patch, cx);
-                });
-            }),
+            PopoverMenu::new(SharedString::from(format!("widget-dd-pop-{}", model_id)))
+                .menu(move |window, cx| {
+                    let fresh_index = store_for_menu
+                        .read(cx)
+                        .get_state(&model_id_for_menu)
+                        .and_then(|s| s.get("index"))
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(0) as usize;
+
+                    Some(ContextMenu::build(window, cx, {
+                        let store = store_for_menu.clone();
+                        let model_id = model_id_for_menu.clone();
+                        let options = options.clone();
+                        move |mut menu, _, _| {
+                            for (index, label) in &options {
+                                let is_selected = *index == fresh_index;
+                                let store = store.clone();
+                                let model_id = model_id.clone();
+                                let new_index = *index;
+                                menu = menu.toggleable_entry(
+                                    label.clone(),
+                                    is_selected,
+                                    IconPosition::End,
+                                    None,
+                                    move |_window, cx| {
+                                        let mut state_patch = serde_json::Map::new();
+                                        state_patch.insert(
+                                            "index".into(),
+                                            serde_json::Value::Number(serde_json::Number::from(
+                                                new_index as u64,
+                                            )),
+                                        );
+                                        store.update(cx, |widget_store, cx| {
+                                            widget_store.send_update(&model_id, state_patch, cx);
+                                        });
+                                    },
+                                );
+                            }
+                            menu
+                        }
+                    }))
+                })
+                .trigger(
+                    Button::new(
+                        SharedString::from(format!("widget-dd-{}", model_id)),
+                        current_label,
+                    )
+                    .icon(IconName::ChevronUpDown)
+                    .icon_position(IconPosition::End)
+                    .icon_size(IconSize::XSmall)
+                    .icon_color(Color::Muted)
+                    .disabled(disabled || !has_options),
+                )
+                .attach(Corner::BottomLeft),
         )
         .into_any_element()
 }
 
-fn render_slider(model: &WidgetModel) -> AnyElement {
+fn render_slider(
+    store: &Entity<WidgetStore>,
+    model: &WidgetModel,
+    _window: &mut Window,
+    cx: &App,
+) -> AnyElement {
     let value = model
         .state
         .get("value")
@@ -567,17 +628,147 @@ fn render_slider(model: &WidgetModel) -> AnyElement {
         .get("max")
         .and_then(|v| v.as_f64())
         .unwrap_or(100.0);
+    let step = model
+        .state
+        .get("step")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(1.0);
     let description = model
         .state
         .get("description")
         .and_then(|v| v.as_str())
         .unwrap_or("");
+    let disabled = model
+        .state
+        .get("disabled")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
 
     let is_int = model.model_name == "IntSliderModel";
     let value_text = if is_int {
         format!("{}", value as i64)
     } else {
         format!("{:.2}", value)
+    };
+
+    let dec_value = (value - step).max(min);
+    let inc_value = (value + step).min(max);
+    let model_id = model.comm_id.clone();
+
+    let store_dec = store.clone();
+    let model_id_dec = model_id.clone();
+
+    let store_inc = store.clone();
+    let model_id_inc = model_id.clone();
+
+    h_flex()
+        .gap_2()
+        .items_center()
+        .when(!description.is_empty(), |el| {
+            el.child(
+                Label::new(description.to_string())
+                    .size(LabelSize::Small)
+                    .color(Color::Muted),
+            )
+        })
+        .child(
+            IconButton::new(
+                SharedString::from(format!("slider-dec-{}", model_id)),
+                IconName::Dash,
+            )
+            .size(ButtonSize::Compact)
+            .disabled(disabled || value <= min)
+            .on_click(move |_, _window, cx| {
+                let mut state_patch = serde_json::Map::new();
+                if is_int {
+                    state_patch.insert("value".into(), serde_json::Value::from(dec_value as i64));
+                } else {
+                    state_patch.insert(
+                        "value".into(),
+                        serde_json::Number::from_f64(dec_value)
+                            .map(serde_json::Value::Number)
+                            .unwrap_or(serde_json::Value::from(dec_value as i64)),
+                    );
+                }
+                store_dec.update(cx, |widget_store, cx| {
+                    widget_store.send_update(&model_id_dec, state_patch, cx);
+                });
+            }),
+        )
+        .child(
+            div()
+                .flex_1()
+                .child(ProgressBar::new(
+                    format!("slider-bar-{}", model_id),
+                    (value - min) as f32,
+                    (max - min) as f32,
+                    cx,
+                ))
+                .min_w(px(80.0)),
+        )
+        .child(
+            IconButton::new(
+                SharedString::from(format!("slider-inc-{}", model_id)),
+                IconName::Plus,
+            )
+            .size(ButtonSize::Compact)
+            .disabled(disabled || value >= max)
+            .on_click(move |_, _window, cx| {
+                let mut state_patch = serde_json::Map::new();
+                if is_int {
+                    state_patch.insert("value".into(), serde_json::Value::from(inc_value as i64));
+                } else {
+                    state_patch.insert(
+                        "value".into(),
+                        serde_json::Number::from_f64(inc_value)
+                            .map(serde_json::Value::Number)
+                            .unwrap_or(serde_json::Value::from(inc_value as i64)),
+                    );
+                }
+                store_inc.update(cx, |widget_store, cx| {
+                    widget_store.send_update(&model_id_inc, state_patch, cx);
+                });
+            }),
+        )
+        .child(
+            Label::new(value_text)
+                .size(LabelSize::Small)
+                .color(Color::Default),
+        )
+        .into_any_element()
+}
+
+fn render_text(model: &WidgetModel, editor: Option<Entity<Editor>>, cx: &App) -> AnyElement {
+    let description = model
+        .state
+        .get("description")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    let content: AnyElement = if let Some(editor) = editor {
+        div().w(px(260.0)).child(editor).into_any_element()
+    } else {
+        let value = model
+            .state
+            .get("value")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let is_textarea = model.model_name == "TextareaModel";
+        div()
+            .px_2()
+            .py_1()
+            .min_w(px(120.0))
+            .rounded_md()
+            .border_1()
+            .border_color(cx.theme().colors().border)
+            .bg(cx.theme().colors().editor_background)
+            .when(is_textarea, |el| el.min_h(px(60.0)))
+            .child(
+                Label::new(value.to_string())
+                    .size(LabelSize::Small)
+                    .color(Color::Default),
+            )
+            .into_any_element()
     };
 
     h_flex()
@@ -590,41 +781,7 @@ fn render_slider(model: &WidgetModel) -> AnyElement {
                     .color(Color::Muted),
             )
         })
-        .child(
-            Label::new(format!("{} [{}, {}]", value_text, min, max))
-                .size(LabelSize::Small)
-                .color(Color::Default),
-        )
-        .into_any_element()
-}
-
-fn render_text(model: &WidgetModel) -> AnyElement {
-    let value = model
-        .state
-        .get("value")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
-    let description = model
-        .state
-        .get("description")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
-
-    h_flex()
-        .gap_2()
-        .items_center()
-        .when(!description.is_empty(), |el| {
-            el.child(
-                Label::new(description.to_string())
-                    .size(LabelSize::Small)
-                    .color(Color::Muted),
-            )
-        })
-        .child(
-            Label::new(value.to_string())
-                .size(LabelSize::Small)
-                .color(Color::Default),
-        )
+        .child(content)
         .into_any_element()
 }
 

--- a/crates/repl/src/outputs/widget.rs
+++ b/crates/repl/src/outputs/widget.rs
@@ -72,7 +72,7 @@ impl WidgetStore {
     }
 
     pub fn create_missing_text_editors(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        let needed: Vec<(String, String, bool)> = self
+        let needed: Vec<(String, String, bool, bool)> = self
             .models
             .iter()
             .filter(|(_, m)| {
@@ -90,11 +90,12 @@ impl WidgetStore {
                     .unwrap_or("")
                     .to_string();
                 let is_textarea = m.model_name == "TextareaModel";
-                (id.clone(), value, is_textarea)
+                let is_password = m.model_name == "PasswordModel";
+                (id.clone(), value, is_textarea, is_password)
             })
             .collect();
 
-        for (model_id, value, is_textarea) in needed {
+        for (model_id, value, is_textarea, is_password) in needed {
             let editor = cx.new(|cx| {
                 let mut editor = if is_textarea {
                     Editor::auto_height(3, 10, window, cx)
@@ -103,6 +104,9 @@ impl WidgetStore {
                 };
                 if !value.is_empty() {
                     editor.set_text(value, window, cx);
+                }
+                if is_password {
+                    editor.set_masked(true, cx);
                 }
                 editor
             });
@@ -552,6 +556,7 @@ fn render_button(store: &Entity<WidgetStore>, model: &WidgetModel) -> AnyElement
                 description,
             )
             .style(ButtonStyle::Outlined)
+            .size(ButtonSize::Medium)
             .disabled(disabled)
             .on_click(move |_, _window, cx| {
                 let model_id = model_id.clone();

--- a/crates/repl/src/outputs/widget.rs
+++ b/crates/repl/src/outputs/widget.rs
@@ -1,11 +1,12 @@
 use collections::HashMap;
-use gpui::{AnyElement, App, Window};
-use runtimelib::{MimeBundle, MimeType};
+use gpui::{AnyElement, App, Context, Entity, EventEmitter, Window};
+use runtimelib::{CommId, CommMsg, JupyterMessage, MimeBundle, MimeType};
 use theme::ActiveTheme;
 use ui::prelude::*;
-use ui::ProgressBar;
+use ui::{Checkbox, ProgressBar, ToggleState};
 
 struct WidgetModel {
+    comm_id: String,
     state: serde_json::Map<String, serde_json::Value>,
     model_name: String,
 }
@@ -14,6 +15,10 @@ pub struct WidgetStore {
     models: HashMap<String, WidgetModel>,
 }
 
+pub(crate) struct WidgetCommMessage(pub JupyterMessage);
+
+impl EventEmitter<WidgetCommMessage> for WidgetStore {}
+
 impl WidgetStore {
     pub fn new() -> Self {
         Self {
@@ -21,7 +26,11 @@ impl WidgetStore {
         }
     }
 
-    pub fn create_model(&mut self, comm_id: &str, data: &serde_json::Map<String, serde_json::Value>) {
+    pub fn create_model(
+        &mut self,
+        comm_id: &str,
+        data: &serde_json::Map<String, serde_json::Value>,
+    ) {
         let state = data
             .get("state")
             .and_then(|v| v.as_object())
@@ -34,14 +43,42 @@ impl WidgetStore {
             .unwrap_or("UnknownModel")
             .to_string();
 
+        let state_keys: Vec<&String> = state.keys().collect();
+        log::info!(
+            "widget create_model: comm_id={}, model_name={}, state_keys={:?}, data_keys={:?}",
+            comm_id,
+            model_name,
+            state_keys,
+            data.keys().collect::<Vec<_>>()
+        );
+
         self.models.insert(
             comm_id.to_string(),
-            WidgetModel { state, model_name },
+            WidgetModel {
+                comm_id: comm_id.to_string(),
+                state,
+                model_name,
+            },
         );
     }
 
-    pub fn update_model(&mut self, comm_id: &str, data: &serde_json::Map<String, serde_json::Value>) {
+    pub fn close_model(&mut self, comm_id: &str) {
+        self.models.remove(comm_id);
+    }
+
+    pub fn update_model(
+        &mut self,
+        comm_id: &str,
+        data: &serde_json::Map<String, serde_json::Value>,
+    ) {
         let method = data.get("method").and_then(|v| v.as_str());
+        log::info!(
+            "widget update_model: comm_id={}, method={:?}, data_keys={:?}",
+            comm_id,
+            method,
+            data.keys().collect::<Vec<_>>()
+        );
+
         if method != Some("update") {
             return;
         }
@@ -51,6 +88,15 @@ impl WidgetStore {
             None => return,
         };
 
+        let patch_keys: Vec<&String> = state_patch.keys().collect();
+        let found = self.models.contains_key(comm_id);
+        log::info!(
+            "widget update_model: comm_id={}, found_in_store={}, patch_keys={:?}",
+            comm_id,
+            found,
+            patch_keys
+        );
+
         if let Some(model) = self.models.get_mut(comm_id) {
             for (key, value) in state_patch {
                 model.state.insert(key.clone(), value.clone());
@@ -58,19 +104,89 @@ impl WidgetStore {
         }
     }
 
-    pub fn render_widget(&self, model_id: &str, window: &mut Window, cx: &App) -> AnyElement {
-        let model = match self.models.get(model_id) {
+    pub fn send_update(
+        &mut self,
+        model_id: &str,
+        state_patch: serde_json::Map<String, serde_json::Value>,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(model) = self.models.get_mut(model_id) {
+            for (key, value) in &state_patch {
+                model.state.insert(key.clone(), value.clone());
+            }
+
+            let mut data = serde_json::Map::new();
+            data.insert("method".into(), "update".into());
+            data.insert("state".into(), serde_json::Value::Object(state_patch));
+
+            let message: JupyterMessage = CommMsg {
+                comm_id: CommId(model.comm_id.clone()),
+                data,
+            }
+            .into();
+            cx.emit(WidgetCommMessage(message));
+        }
+        cx.notify();
+    }
+
+    pub fn send_custom(
+        &mut self,
+        model_id: &str,
+        content: serde_json::Map<String, serde_json::Value>,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(model) = self.models.get(model_id) {
+            let mut data = serde_json::Map::new();
+            data.insert("method".into(), "custom".into());
+            data.insert("content".into(), serde_json::Value::Object(content));
+
+            let message: JupyterMessage = CommMsg {
+                comm_id: CommId(model.comm_id.clone()),
+                data,
+            }
+            .into();
+            cx.emit(WidgetCommMessage(message));
+        }
+    }
+
+    pub fn render_widget(
+        store: &Entity<Self>,
+        model_id: &str,
+        window: &mut Window,
+        cx: &App,
+    ) -> AnyElement {
+        let store_ref = store.read(cx);
+        let model = match store_ref.models.get(model_id) {
             Some(m) => m,
-            None => return div().into_any_element(),
+            None => {
+                log::warn!("widget render_widget: model_id={} NOT FOUND in store (store has {} models: {:?})",
+                    model_id,
+                    store_ref.models.len(),
+                    store_ref.models.keys().collect::<Vec<_>>()
+                );
+                return div().into_any_element();
+            }
         };
+
+        log::info!(
+            "widget render_widget: model_id={}, model_name={}, state_keys={:?}",
+            model_id,
+            model.model_name,
+            model.state.keys().collect::<Vec<_>>()
+        );
 
         match model.model_name.as_str() {
             "FloatProgressModel" | "IntProgressModel" => render_progress(model, window, cx),
             "LabelModel" => render_label(model),
             "HTMLModel" => render_html_as_text(model),
-            "HBoxModel" => render_hbox(self, model, window, cx),
-            "VBoxModel" | "BoxModel" => render_vbox(self, model, window, cx),
-            // Layout and style models are metadata-only, no visual rendering
+            "HBoxModel" => render_hbox(store, model, window, cx),
+            "VBoxModel" | "BoxModel" => render_vbox(store, model, window, cx),
+            "ButtonModel" => render_button(store, model),
+            "CheckboxModel" => render_checkbox(store, model),
+            "DropdownModel" => render_dropdown(store, model),
+            "IntSliderModel" | "FloatSliderModel" => render_slider(model),
+            "TextModel" | "TextareaModel" => render_text(model),
+            "OutputModel" => render_output_widget(store, model, window, cx),
             "LayoutModel" | "ProgressStyleModel" | "ButtonStyleModel"
             | "SliderStyleModel" | "DescriptionStyleModel" | "StyleModel" => {
                 div().into_any_element()
@@ -213,8 +329,20 @@ fn decode_html_entities(text: &str) -> String {
 
 const IPY_MODEL_PREFIX: &str = "IPY_MODEL_";
 
-fn render_hbox(store: &WidgetStore, model: &WidgetModel, window: &mut Window, cx: &App) -> AnyElement {
+fn render_hbox(
+    store: &Entity<WidgetStore>,
+    model: &WidgetModel,
+    window: &mut Window,
+    cx: &App,
+) -> AnyElement {
     let children = model.state.get("children").and_then(|v| v.as_array());
+
+    log::info!(
+        "widget render_hbox: comm_id={}, has_children={}, children_raw={:?}",
+        model.comm_id,
+        children.is_some(),
+        model.state.get("children")
+    );
 
     let mut flex = h_flex().gap_1().items_center();
 
@@ -224,7 +352,10 @@ fn render_hbox(store: &WidgetStore, model: &WidgetModel, window: &mut Window, cx
                 .as_str()
                 .and_then(|s| s.strip_prefix(IPY_MODEL_PREFIX))
             {
-                flex = flex.child(store.render_widget(child_id, window, cx));
+                log::info!("widget render_hbox: rendering child_id={}", child_id);
+                flex = flex.child(WidgetStore::render_widget(store, child_id, window, cx));
+            } else {
+                log::warn!("widget render_hbox: child_ref not IPY_MODEL_: {:?}", child_ref);
             }
         }
     }
@@ -232,7 +363,12 @@ fn render_hbox(store: &WidgetStore, model: &WidgetModel, window: &mut Window, cx
     flex.into_any_element()
 }
 
-fn render_vbox(store: &WidgetStore, model: &WidgetModel, window: &mut Window, cx: &App) -> AnyElement {
+fn render_vbox(
+    store: &Entity<WidgetStore>,
+    model: &WidgetModel,
+    window: &mut Window,
+    cx: &App,
+) -> AnyElement {
     let children = model.state.get("children").and_then(|v| v.as_array());
 
     let mut flex = v_flex().gap_1();
@@ -243,7 +379,287 @@ fn render_vbox(store: &WidgetStore, model: &WidgetModel, window: &mut Window, cx
                 .as_str()
                 .and_then(|s| s.strip_prefix(IPY_MODEL_PREFIX))
             {
-                flex = flex.child(store.render_widget(child_id, window, cx));
+                flex = flex.child(WidgetStore::render_widget(store, child_id, window, cx));
+            }
+        }
+    }
+
+    flex.into_any_element()
+}
+
+fn render_button(store: &Entity<WidgetStore>, model: &WidgetModel) -> AnyElement {
+    log::info!(
+        "widget render_button: comm_id={}, state={:?}",
+        model.comm_id,
+        model.state
+    );
+    let description = model
+        .state
+        .get("description")
+        .and_then(|v| v.as_str())
+        .unwrap_or("Button")
+        .to_string();
+    let disabled = model
+        .state
+        .get("disabled")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    let model_id = model.comm_id.clone();
+    let store = store.clone();
+
+    Button::new(
+        SharedString::from(format!("widget-btn-{}", model_id)),
+        description,
+    )
+    .disabled(disabled)
+    .on_click(move |_, _window, cx| {
+        let model_id = model_id.clone();
+        store.update(cx, |widget_store, cx| {
+            widget_store.send_custom(&model_id, serde_json::Map::new(), cx);
+        });
+    })
+    .into_any_element()
+}
+
+fn render_checkbox(store: &Entity<WidgetStore>, model: &WidgetModel) -> AnyElement {
+    let value = model
+        .state
+        .get("value")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let description = model
+        .state
+        .get("description")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let disabled = model
+        .state
+        .get("disabled")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    let toggle_state = if value {
+        ToggleState::Selected
+    } else {
+        ToggleState::Unselected
+    };
+
+    let model_id = model.comm_id.clone();
+    let store = store.clone();
+
+    h_flex()
+        .gap_2()
+        .items_center()
+        .child(
+            Checkbox::new(
+                SharedString::from(format!("widget-cb-{}", model_id)),
+                toggle_state,
+            )
+            .disabled(disabled)
+            .on_click(move |new_state, _window, cx| {
+                let new_value = matches!(new_state, ToggleState::Selected);
+                let mut state_patch = serde_json::Map::new();
+                state_patch.insert("value".into(), serde_json::Value::Bool(new_value));
+                let model_id = model_id.clone();
+                store.update(cx, |widget_store, cx| {
+                    widget_store.send_update(&model_id, state_patch, cx);
+                });
+            }),
+        )
+        .when(!description.is_empty(), |el| {
+            el.child(
+                Label::new(description.to_string())
+                    .size(LabelSize::Small)
+                    .color(Color::Default),
+            )
+        })
+        .into_any_element()
+}
+
+fn render_dropdown(store: &Entity<WidgetStore>, model: &WidgetModel) -> AnyElement {
+    let description = model
+        .state
+        .get("description")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let disabled = model
+        .state
+        .get("disabled")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    let options: Vec<String> = model
+        .state
+        .get("_options_labels")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let current_index = model
+        .state
+        .get("index")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as usize;
+
+    let current_label = options
+        .get(current_index)
+        .cloned()
+        .unwrap_or_else(|| "—".to_string());
+
+    let next_index = if options.is_empty() {
+        0
+    } else {
+        (current_index + 1) % options.len()
+    };
+
+    let model_id = model.comm_id.clone();
+    let store = store.clone();
+
+    h_flex()
+        .gap_2()
+        .items_center()
+        .when(!description.is_empty(), |el| {
+            el.child(
+                Label::new(description.to_string())
+                    .size(LabelSize::Small)
+                    .color(Color::Muted),
+            )
+        })
+        .child(
+            Button::new(
+                SharedString::from(format!("widget-dd-{}", model_id)),
+                format!("{} ▾", current_label),
+            )
+            .disabled(disabled || options.is_empty())
+            .on_click(move |_, _window, cx| {
+                let mut state_patch = serde_json::Map::new();
+                state_patch.insert(
+                    "index".into(),
+                    serde_json::Value::Number(serde_json::Number::from(next_index as u64)),
+                );
+                let model_id = model_id.clone();
+                store.update(cx, |widget_store, cx| {
+                    widget_store.send_update(&model_id, state_patch, cx);
+                });
+            }),
+        )
+        .into_any_element()
+}
+
+fn render_slider(model: &WidgetModel) -> AnyElement {
+    let value = model
+        .state
+        .get("value")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.0);
+    let min = model
+        .state
+        .get("min")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.0);
+    let max = model
+        .state
+        .get("max")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(100.0);
+    let description = model
+        .state
+        .get("description")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    let is_int = model.model_name == "IntSliderModel";
+    let value_text = if is_int {
+        format!("{}", value as i64)
+    } else {
+        format!("{:.2}", value)
+    };
+
+    h_flex()
+        .gap_2()
+        .items_center()
+        .when(!description.is_empty(), |el| {
+            el.child(
+                Label::new(description.to_string())
+                    .size(LabelSize::Small)
+                    .color(Color::Muted),
+            )
+        })
+        .child(
+            Label::new(format!("{} [{}, {}]", value_text, min, max))
+                .size(LabelSize::Small)
+                .color(Color::Default),
+        )
+        .into_any_element()
+}
+
+fn render_text(model: &WidgetModel) -> AnyElement {
+    let value = model
+        .state
+        .get("value")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let description = model
+        .state
+        .get("description")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    h_flex()
+        .gap_2()
+        .items_center()
+        .when(!description.is_empty(), |el| {
+            el.child(
+                Label::new(description.to_string())
+                    .size(LabelSize::Small)
+                    .color(Color::Muted),
+            )
+        })
+        .child(
+            Label::new(value.to_string())
+                .size(LabelSize::Small)
+                .color(Color::Default),
+        )
+        .into_any_element()
+}
+
+fn render_output_widget(
+    store: &Entity<WidgetStore>,
+    model: &WidgetModel,
+    window: &mut Window,
+    cx: &App,
+) -> AnyElement {
+    let children = model.state.get("children").and_then(|v| v.as_array());
+    let outputs = model.state.get("outputs").and_then(|v| v.as_array());
+
+    let mut flex = v_flex().gap_1();
+
+    if let Some(children) = children {
+        for child_ref in children {
+            if let Some(child_id) = child_ref
+                .as_str()
+                .and_then(|s| s.strip_prefix(IPY_MODEL_PREFIX))
+            {
+                flex = flex.child(WidgetStore::render_widget(store, child_id, window, cx));
+            }
+        }
+    }
+
+    if let Some(outputs) = outputs {
+        for output in outputs {
+            if let Some(text) = output.get("text").and_then(|v| v.as_str()) {
+                if !text.is_empty() {
+                    flex = flex.child(
+                        Label::new(text.to_string())
+                            .size(LabelSize::Small)
+                            .color(Color::Default),
+                    );
+                }
             }
         }
     }

--- a/crates/repl/src/outputs/widget.rs
+++ b/crates/repl/src/outputs/widget.rs
@@ -1,8 +1,12 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
 use collections::HashMap;
 use editor::{Editor, EditorEvent};
 use gpui::{AnyElement, App, Context, Corner, Entity, EventEmitter, Subscription, Window};
+use html_to_markdown::{TagHandler, convert_html_to_markdown, markdown as html_md};
+use markdown::{Markdown, MarkdownElement, MarkdownFont, MarkdownStyle};
 use runtimelib::{CommId, CommMsg, JupyterMessage, MimeBundle, MimeType};
-use theme::ActiveTheme;
 use ui::prelude::*;
 use ui::{Checkbox, ContextMenu, PopoverMenu, ProgressBar, ToggleState};
 
@@ -15,6 +19,7 @@ struct WidgetModel {
 pub struct WidgetStore {
     models: HashMap<String, WidgetModel>,
     text_editors: HashMap<String, Entity<Editor>>,
+    markdown_views: HashMap<String, Entity<Markdown>>,
     _editor_subscriptions: Vec<Subscription>,
 }
 
@@ -27,6 +32,7 @@ impl WidgetStore {
         Self {
             models: HashMap::default(),
             text_editors: HashMap::default(),
+            markdown_views: HashMap::default(),
             _editor_subscriptions: Vec::new(),
         }
     }
@@ -61,13 +67,19 @@ impl WidgetStore {
     pub fn close_model(&mut self, comm_id: &str) {
         self.models.remove(comm_id);
         self.text_editors.remove(comm_id);
+        self.markdown_views.remove(comm_id);
     }
 
     pub fn create_missing_text_editors(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let needed: Vec<(String, String, bool)> = self
             .models
             .iter()
-            .filter(|(_, m)| m.model_name == "TextModel" || m.model_name == "TextareaModel")
+            .filter(|(_, m)| {
+                matches!(
+                    m.model_name.as_str(),
+                    "TextModel" | "TextareaModel" | "PasswordModel"
+                )
+            })
             .filter(|(id, _)| !self.text_editors.contains_key(*id))
             .map(|(id, m)| {
                 let value = m
@@ -118,6 +130,31 @@ impl WidgetStore {
 
             self.text_editors.insert(model_id, editor);
             self._editor_subscriptions.push(subscription);
+        }
+    }
+
+    pub fn create_missing_markdown_views(&mut self, cx: &mut Context<Self>) {
+        let needed: Vec<(String, String)> = self
+            .models
+            .iter()
+            .filter(|(_, m)| m.model_name == "HTMLModel")
+            .filter(|(id, _)| !self.markdown_views.contains_key(*id))
+            .map(|(id, m)| {
+                let html = m
+                    .state
+                    .get("value")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                (id.clone(), html)
+            })
+            .collect();
+
+        for (model_id, html) in needed {
+            let markdown_text = convert_html_to_markdown_string(&html);
+            let markdown_entity =
+                cx.new(|cx| Markdown::new(markdown_text.into(), None, None, cx));
+            self.markdown_views.insert(model_id, markdown_entity);
         }
     }
 
@@ -205,18 +242,19 @@ impl WidgetStore {
         };
 
         let text_editor = store_ref.text_editors.get(model_id).cloned();
+        let markdown_view = store_ref.markdown_views.get(model_id).cloned();
 
         match model.model_name.as_str() {
             "FloatProgressModel" | "IntProgressModel" => render_progress(model, window, cx),
             "LabelModel" => render_label(model),
-            "HTMLModel" => render_html_as_text(model),
+            "HTMLModel" => render_html_as_markdown(model, markdown_view, window, cx),
             "HBoxModel" => render_hbox(store, model, window, cx),
             "VBoxModel" | "BoxModel" => render_vbox(store, model, window, cx),
             "ButtonModel" => render_button(store, model),
             "CheckboxModel" => render_checkbox(store, model),
             "DropdownModel" => render_dropdown(store, model),
             "IntSliderModel" | "FloatSliderModel" => render_slider(store, model, window, cx),
-            "TextModel" | "TextareaModel" => render_text(model, text_editor, cx),
+            "TextModel" | "TextareaModel" | "PasswordModel" => render_text(model, text_editor, cx),
             "OutputModel" => render_output_widget(store, model, window, cx),
             "LayoutModel"
             | "ProgressStyleModel"
@@ -313,51 +351,57 @@ fn render_label(model: &WidgetModel) -> AnyElement {
         .into_any_element()
 }
 
-fn render_html_as_text(model: &WidgetModel) -> AnyElement {
-    let value = model
-        .state
-        .get("value")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
+fn render_html_as_markdown(
+    model: &WidgetModel,
+    markdown_entity: Option<Entity<Markdown>>,
+    window: &Window,
+    cx: &App,
+) -> AnyElement {
+    if let Some(markdown) = markdown_entity {
+        let style = MarkdownStyle::themed(MarkdownFont::Editor, window, cx);
+        div()
+            .w_full()
+            .child(MarkdownElement::new(markdown, style))
+            .into_any_element()
+    } else {
+        let value = model
+            .state
+            .get("value")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
 
-    if value.is_empty() {
-        return div().into_any_element();
-    }
-
-    let text = strip_html_tags(value);
-    if text.is_empty() {
-        return div().into_any_element();
-    }
-
-    Label::new(text)
-        .size(LabelSize::Small)
-        .color(Color::Muted)
-        .into_any_element()
-}
-
-fn strip_html_tags(html: &str) -> String {
-    let mut result = String::with_capacity(html.len());
-    let mut inside_tag = false;
-
-    for ch in html.chars() {
-        match ch {
-            '<' => inside_tag = true,
-            '>' => inside_tag = false,
-            _ if !inside_tag => result.push(ch),
-            _ => {}
+        if value.is_empty() {
+            return div().into_any_element();
         }
-    }
 
-    decode_html_entities(&result)
+        let markdown_text = convert_html_to_markdown_string(value);
+        if markdown_text.trim().is_empty() {
+            return div().into_any_element();
+        }
+
+        div()
+            .child(
+                Label::new(markdown_text)
+                    .size(LabelSize::Small)
+                    .color(Color::Default),
+            )
+            .into_any_element()
+    }
 }
 
-fn decode_html_entities(text: &str) -> String {
-    text.replace("&amp;", "&")
-        .replace("&lt;", "<")
-        .replace("&gt;", ">")
-        .replace("&quot;", "\"")
-        .replace("&#39;", "'")
-        .replace("&nbsp;", " ")
+fn convert_html_to_markdown_string(html: &str) -> String {
+    let mut handlers: Vec<TagHandler> = vec![
+        Rc::new(RefCell::new(html_md::WebpageChromeRemover)),
+        Rc::new(RefCell::new(html_md::ParagraphHandler)),
+        Rc::new(RefCell::new(html_md::HeadingHandler)),
+        Rc::new(RefCell::new(html_md::ListHandler)),
+        Rc::new(RefCell::new(html_md::TableHandler::new())),
+        Rc::new(RefCell::new(html_md::StyledTextHandler)),
+        Rc::new(RefCell::new(html_md::CodeHandler)),
+    ];
+
+    convert_html_to_markdown(html.as_bytes(), &mut handlers)
+        .unwrap_or_else(|_| html.to_string())
 }
 
 const IPY_MODEL_PREFIX: &str = "IPY_MODEL_";

--- a/crates/repl/src/outputs/widget.rs
+++ b/crates/repl/src/outputs/widget.rs
@@ -477,6 +477,7 @@ fn render_button(store: &Entity<WidgetStore>, model: &WidgetModel) -> AnyElement
                 SharedString::from(format!("widget-btn-{}", model_id)),
                 description,
             )
+            .style(ButtonStyle::Outlined)
             .disabled(disabled)
             .on_click(move |_, _window, cx| {
                 let model_id = model_id.clone();

--- a/crates/repl/src/outputs/widget.rs
+++ b/crates/repl/src/outputs/widget.rs
@@ -157,8 +157,7 @@ impl WidgetStore {
 
         for (model_id, html) in needed {
             let markdown_text = convert_html_to_markdown_string(&html);
-            let markdown_entity =
-                cx.new(|cx| Markdown::new(markdown_text.into(), None, None, cx));
+            let markdown_entity = cx.new(|cx| Markdown::new(markdown_text.into(), None, None, cx));
             self.markdown_views.insert(model_id, markdown_entity);
         }
     }
@@ -405,8 +404,7 @@ fn convert_html_to_markdown_string(html: &str) -> String {
         Rc::new(RefCell::new(html_md::CodeHandler)),
     ];
 
-    convert_html_to_markdown(html.as_bytes(), &mut handlers)
-        .unwrap_or_else(|_| html.to_string())
+    convert_html_to_markdown(html.as_bytes(), &mut handlers).unwrap_or_else(|_| html.to_string())
 }
 
 const IPY_MODEL_PREFIX: &str = "IPY_MODEL_";

--- a/crates/repl/src/outputs/widget.rs
+++ b/crates/repl/src/outputs/widget.rs
@@ -7,6 +7,7 @@ use gpui::{AnyElement, App, Context, Corner, Entity, EventEmitter, Subscription,
 use html_to_markdown::{TagHandler, convert_html_to_markdown, markdown as html_md};
 use markdown::{Markdown, MarkdownElement, MarkdownFont, MarkdownStyle};
 use runtimelib::{CommId, CommMsg, JupyterMessage, MimeBundle, MimeType};
+use theme::ActiveTheme;
 use ui::prelude::*;
 use ui::{Checkbox, ContextMenu, PopoverMenu, ProgressBar, ToggleState};
 
@@ -470,20 +471,23 @@ fn render_button(store: &Entity<WidgetStore>, model: &WidgetModel) -> AnyElement
     let model_id = model.comm_id.clone();
     let store = store.clone();
 
-    Button::new(
-        SharedString::from(format!("widget-btn-{}", model_id)),
-        description,
-    )
-    .disabled(disabled)
-    .on_click(move |_, _window, cx| {
-        let model_id = model_id.clone();
-        let mut content = serde_json::Map::new();
-        content.insert("event".into(), "click".into());
-        store.update(cx, |widget_store, cx| {
-            widget_store.send_custom(&model_id, content, cx);
-        });
-    })
-    .into_any_element()
+    h_flex()
+        .child(
+            Button::new(
+                SharedString::from(format!("widget-btn-{}", model_id)),
+                description,
+            )
+            .disabled(disabled)
+            .on_click(move |_, _window, cx| {
+                let model_id = model_id.clone();
+                let mut content = serde_json::Map::new();
+                content.insert("event".into(), "click".into());
+                store.update(cx, |widget_store, cx| {
+                    widget_store.send_custom(&model_id, content, cx);
+                });
+            }),
+        )
+        .into_any_element()
 }
 
 fn render_checkbox(store: &Entity<WidgetStore>, model: &WidgetModel) -> AnyElement {
@@ -788,24 +792,36 @@ fn render_text(model: &WidgetModel, editor: Option<Entity<Editor>>, cx: &App) ->
         .get("description")
         .and_then(|v| v.as_str())
         .unwrap_or("");
+    let is_textarea = model.model_name == "TextareaModel";
+    let theme_colors = cx.theme().colors();
 
     let content: AnyElement = if let Some(editor) = editor {
-        div().w(px(260.0)).child(editor).into_any_element()
+        h_flex()
+            .py_1()
+            .px_2()
+            .when(is_textarea, |el| el.min_h(px(80.0)))
+            .when(!is_textarea, |el| el.h_8())
+            .min_w_64()
+            .rounded_md()
+            .border_1()
+            .border_color(theme_colors.border)
+            .bg(theme_colors.editor_background)
+            .child(editor)
+            .into_any_element()
     } else {
         let value = model
             .state
             .get("value")
             .and_then(|v| v.as_str())
             .unwrap_or("");
-        let is_textarea = model.model_name == "TextareaModel";
         div()
             .px_2()
             .py_1()
             .min_w(px(120.0))
             .rounded_md()
             .border_1()
-            .border_color(cx.theme().colors().border)
-            .bg(cx.theme().colors().editor_background)
+            .border_color(theme_colors.border)
+            .bg(theme_colors.editor_background)
             .when(is_textarea, |el| el.min_h(px(60.0)))
             .child(
                 Label::new(value.to_string())

--- a/crates/repl/src/session.rs
+++ b/crates/repl/src/session.rs
@@ -80,9 +80,8 @@ impl EditorBlock {
         let editor = editor.upgrade().context("editor is not open")?;
         let workspace = editor.read(cx).workspace().context("workspace dropped")?;
 
-        let execution_view = cx.new(|cx| {
-            ExecutionView::new(status, workspace.downgrade(), widget_store, cx)
-        });
+        let execution_view =
+            cx.new(|cx| ExecutionView::new(status, workspace.downgrade(), widget_store, cx));
 
         let (block_id, invalidation_anchor) = editor.update(cx, |editor, cx| {
             let buffer = editor.buffer().clone();
@@ -255,10 +254,12 @@ impl Session {
             .ok();
 
         let widget_store = cx.new(|_| WidgetStore::new());
-        let widget_subscription =
-            cx.subscribe(&widget_store, |session, _store, event: &WidgetCommMessage, cx| {
+        let widget_subscription = cx.subscribe(
+            &widget_store,
+            |session, _store, event: &WidgetCommMessage, cx| {
                 session.send(event.0.clone(), cx).log_err();
-            });
+            },
+        );
 
         let mut session = Self {
             fs,

--- a/crates/repl/src/session.rs
+++ b/crates/repl/src/session.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     outputs::{
         ExecutionStatus, ExecutionView, ExecutionViewFinishedEmpty, ExecutionViewFinishedSmall,
-        InputReplyEvent,
+        InputReplyEvent, WidgetCommMessage, WidgetStore,
     },
     repl_settings::ReplSettings,
 };
@@ -53,6 +53,7 @@ pub struct Session {
     blocks: HashMap<String, EditorBlock>,
     result_inlays: HashMap<String, (InlayId, Range<Anchor>, usize)>,
     next_inlay_id: usize,
+    widget_store: Entity<WidgetStore>,
 
     _subscriptions: Vec<Subscription>,
 }
@@ -72,13 +73,16 @@ impl EditorBlock {
         editor: WeakEntity<Editor>,
         code_range: Range<Anchor>,
         status: ExecutionStatus,
+        widget_store: Entity<WidgetStore>,
         on_close: CloseBlockFn,
         cx: &mut Context<Session>,
     ) -> anyhow::Result<Self> {
         let editor = editor.upgrade().context("editor is not open")?;
         let workspace = editor.read(cx).workspace().context("workspace dropped")?;
 
-        let execution_view = cx.new(|cx| ExecutionView::new(status, workspace.downgrade(), cx));
+        let execution_view = cx.new(|cx| {
+            ExecutionView::new(status, workspace.downgrade(), widget_store, cx)
+        });
 
         let (block_id, invalidation_anchor) = editor.update(cx, |editor, cx| {
             let buffer = editor.buffer().clone();
@@ -250,6 +254,12 @@ impl Session {
             })
             .ok();
 
+        let widget_store = cx.new(|_| WidgetStore::new());
+        let widget_subscription =
+            cx.subscribe(&widget_store, |session, _store, event: &WidgetCommMessage, cx| {
+                session.send(event.0.clone(), cx).log_err();
+            });
+
         let mut session = Self {
             fs,
             editor,
@@ -258,7 +268,8 @@ impl Session {
             result_inlays: HashMap::default(),
             next_inlay_id: 0,
             kernel_specification,
-            _subscriptions: vec![subscription],
+            widget_store,
+            _subscriptions: vec![subscription, widget_subscription],
         };
 
         session.start_kernel(window, cx);
@@ -721,6 +732,7 @@ impl Session {
             self.editor.clone(),
             anchor_range.clone(),
             status,
+            self.widget_store.clone(),
             on_close,
             cx,
         ) else {
@@ -983,6 +995,27 @@ impl KernelSession for Session {
         };
 
         match &message.content {
+            JupyterMessageContent::CommOpen(comm_open) => {
+                self.widget_store.update(cx, |store, cx| {
+                    store.create_model(&comm_open.comm_id.0, &comm_open.data);
+                    cx.notify();
+                });
+                return;
+            }
+            JupyterMessageContent::CommMsg(comm_msg) => {
+                self.widget_store.update(cx, |store, cx| {
+                    store.update_model(&comm_msg.comm_id.0, &comm_msg.data);
+                    cx.notify();
+                });
+                return;
+            }
+            JupyterMessageContent::CommClose(comm_close) => {
+                self.widget_store.update(cx, |store, cx| {
+                    store.close_model(&comm_close.comm_id.0);
+                    cx.notify();
+                });
+                return;
+            }
             JupyterMessageContent::Status(status) => {
                 self.kernel.set_execution_state(&status.execution_state);
 


### PR DESCRIPTION
This PR adds basic support for IPython/Jupyter widgets.

At the very least, I wanted to get `tqdm` supported which as every ML engineer knows is the most used library in machine learning. The progress bar.

https://github.com/user-attachments/assets/91a95b47-0b32-4d88-ba72-f742d4ddc33f

What took way more work though is supporting the Jupyter widgets which handle more generic components. I did a _lot_ of them with what we have in GPUI/Zed here. They could be better but it's a start.

![widgets](https://github.com/user-attachments/assets/773740c6-6e3c-41d7-a0d3-7224e27eb8b2)

Release Notes:

- Added Jupyter/IPython widgets support to REPL
