### PR TITLE
project_panel: Fix appending copy marker for directory at wrong position

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -3060,6 +3060,13 @@ impl ProjectPanel {
         if target_entry.is_file() || (target_entry.is_dir() && target_entry.id == source.entry_id) {
             new_path.pop();
         }
+
+        let source_worktree = self
+            .project
+            .read(cx)
+            .worktree_for_entry(source.entry_id, cx)?;
+        let source_entry = source_worktree.read(cx).entry_for_id(source.entry_id)?;
+
         let clipboard_entry_file_name = self
             .project
             .read(cx)
@@ -3068,8 +3075,18 @@ impl ProjectPanel {
             .file_name()?
             .to_string();
         new_path.push(RelPath::unix(&clipboard_entry_file_name).unwrap());
-        let extension = new_path.extension().map(|s| s.to_string());
-        let file_name_without_extension = new_path.file_stem()?.to_string();
+
+        // For files, insert the disambiguation before the extension. For directories, always append
+        // it to the end of the directory name (dots are valid characters in directory names).
+        let (extension, file_name_without_extension) = if source_entry.is_file() {
+            (
+                new_path.extension().map(|s| s.to_string()),
+                new_path.file_stem()?.to_string(),
+            )
+        } else {
+            (None, clipboard_entry_file_name.clone())
+        };
+
         let file_name_len = file_name_without_extension.len();
         let mut disambiguation_range = None;
         let mut ix = 0;

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -3067,17 +3067,9 @@ impl ProjectPanel {
             .worktree_for_entry(source.entry_id, cx)?;
         let source_entry = source_worktree.read(cx).entry_for_id(source.entry_id)?;
 
-        let clipboard_entry_file_name = self
-            .project
-            .read(cx)
-            .path_for_entry(source.entry_id, cx)?
-            .path
-            .file_name()?
-            .to_string();
+        let clipboard_entry_file_name = source_entry.path.file_name()?.to_string();
         new_path.push(RelPath::unix(&clipboard_entry_file_name).unwrap());
 
-        // For files, insert the disambiguation before the extension. For directories, always append
-        // it to the end of the directory name (dots are valid characters in directory names).
         let (extension, file_name_without_extension) = if source_entry.is_file() {
             (
                 new_path.extension().map(|s| s.to_string()),

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -1794,7 +1794,8 @@ async fn test_copy_paste_directory(cx: &mut gpui::TestAppContext) {
             "        > inner_dir",
             "          one.txt",
             "          two.txt",
-            "    > d.1.20",
+            "    v d.1.20",
+            "          default.conf",
             "    > [EDITOR: 'd.1.20 copy']  <== selected",
         ],
         "Dotted directory names should not be split at the dot when disambiguating"

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -3561,6 +3561,60 @@ async fn test_rename_item_and_check_history(cx: &mut gpui::TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_duplicate_directory_name_with_dot(cx: &mut gpui::TestAppContext) {
+    init_test_with_editor(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        "/src",
+        json!({
+            "static": {
+                "nginx": {
+                    "1.20": {
+                        "default.conf": ""
+                    }
+                }
+            }
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), ["/src".as_ref()], cx).await;
+    let workspace = cx.add_window(|window, cx| Workspace::test_new(project.clone(), window, cx));
+    let cx = &mut VisualTestContext::from_window(*workspace, cx);
+    let panel = workspace
+        .update(cx, |workspace, window, cx| {
+            let panel = ProjectPanel::new(workspace, window, cx);
+            workspace.add_panel(panel.clone(), window, cx);
+            panel
+        })
+        .unwrap();
+    cx.run_until_parked();
+
+    toggle_expand_dir(&panel, "src", cx);
+    toggle_expand_dir(&panel, "src/static", cx);
+    toggle_expand_dir(&panel, "src/static/nginx", cx);
+
+    select_path(&panel, "src/static/nginx/1.20", cx);
+    panel.update_in(cx, |panel, window, cx| {
+        panel.duplicate(&Duplicate, window, cx);
+    });
+    cx.executor().run_until_parked();
+
+    let entries = visible_entries_as_strings(&panel, 0..50, cx);
+    assert!(
+        entries
+            .iter()
+            .any(|line| line.contains("[EDITOR: '1.20 copy']")),
+        "Expected duplicated directory to be named '1.20 copy', got: {entries:?}"
+    );
+    assert!(
+        !entries.iter().any(|line| line.contains("1 copy.20")),
+        "Did not expect directory name to be treated like a file extension, got: {entries:?}"
+    );
+}
+
+#[gpui::test]
 async fn test_select_git_entry(cx: &mut gpui::TestAppContext) {
     init_test_with_editor(cx);
 

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -1635,7 +1635,10 @@ async fn test_copy_paste_directory(cx: &mut gpui::TestAppContext) {
                     "four.txt": "",
                 }
             },
-            "b": {}
+            "b": {},
+            "d.1.20": {
+                "default.conf": "",
+            }
         }),
     )
     .await;
@@ -1688,6 +1691,7 @@ async fn test_copy_paste_directory(cx: &mut gpui::TestAppContext) {
             "                  three.txt",
             "              one.txt",
             "              two.txt",
+            "    > d.1.20",
         ]
     );
 
@@ -1709,7 +1713,8 @@ async fn test_copy_paste_directory(cx: &mut gpui::TestAppContext) {
             "                  four.txt",
             "                  three.txt",
             "              one.txt",
-            "              two.txt"
+            "              two.txt",
+            "    > d.1.20",
         ]
     );
 
@@ -1732,7 +1737,8 @@ async fn test_copy_paste_directory(cx: &mut gpui::TestAppContext) {
             "                  four.txt",
             "                  three.txt",
             "              one.txt",
-            "              two.txt"
+            "              two.txt",
+            "    > d.1.20",
         ]
     );
 
@@ -1760,7 +1766,38 @@ async fn test_copy_paste_directory(cx: &mut gpui::TestAppContext) {
             "        > inner_dir",
             "          one.txt",
             "          two.txt",
+            "    > d.1.20",
         ]
+    );
+
+    select_path(&panel, "root/d.1.20", cx);
+    panel.update_in(cx, |panel, window, cx| {
+        panel.copy(&Default::default(), window, cx);
+        panel.paste(&Default::default(), window, cx);
+    });
+    cx.executor().run_until_parked();
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..50, cx),
+        &[
+            //
+            "v root",
+            "    > a",
+            "    v b",
+            "        v a",
+            "            v inner_dir",
+            "                  four.txt",
+            "                  three.txt",
+            "              one.txt",
+            "              two.txt",
+            "    v c",
+            "        > a",
+            "        > inner_dir",
+            "          one.txt",
+            "          two.txt",
+            "    > d.1.20",
+            "    > [EDITOR: 'd.1.20 copy']  <== selected",
+        ],
+        "Dotted directory names should not be split at the dot when disambiguating"
     );
 }
 
@@ -3560,59 +3597,6 @@ async fn test_rename_item_and_check_history(cx: &mut gpui::TestAppContext) {
     });
 }
 
-#[gpui::test]
-async fn test_duplicate_directory_name_with_dot(cx: &mut gpui::TestAppContext) {
-    init_test_with_editor(cx);
-
-    let fs = FakeFs::new(cx.executor());
-    fs.insert_tree(
-        "/src",
-        json!({
-            "static": {
-                "nginx": {
-                    "1.20": {
-                        "default.conf": ""
-                    }
-                }
-            }
-        }),
-    )
-    .await;
-
-    let project = Project::test(fs.clone(), ["/src".as_ref()], cx).await;
-    let workspace = cx.add_window(|window, cx| Workspace::test_new(project.clone(), window, cx));
-    let cx = &mut VisualTestContext::from_window(*workspace, cx);
-    let panel = workspace
-        .update(cx, |workspace, window, cx| {
-            let panel = ProjectPanel::new(workspace, window, cx);
-            workspace.add_panel(panel.clone(), window, cx);
-            panel
-        })
-        .unwrap();
-    cx.run_until_parked();
-
-    toggle_expand_dir(&panel, "src", cx);
-    toggle_expand_dir(&panel, "src/static", cx);
-    toggle_expand_dir(&panel, "src/static/nginx", cx);
-
-    select_path(&panel, "src/static/nginx/1.20", cx);
-    panel.update_in(cx, |panel, window, cx| {
-        panel.duplicate(&Duplicate, window, cx);
-    });
-    cx.executor().run_until_parked();
-
-    let entries = visible_entries_as_strings(&panel, 0..50, cx);
-    assert!(
-        entries
-            .iter()
-            .any(|line| line.contains("[EDITOR: '1.20 copy']")),
-        "Expected duplicated directory to be named '1.20 copy', got: {entries:?}"
-    );
-    assert!(
-        !entries.iter().any(|line| line.contains("1 copy.20")),
-        "Did not expect directory name to be treated like a file extension, got: {entries:?}"
-    );
-}
 
 #[gpui::test]
 async fn test_select_git_entry(cx: &mut gpui::TestAppContext) {

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -3597,7 +3597,6 @@ async fn test_rename_item_and_check_history(cx: &mut gpui::TestAppContext) {
     });
 }
 
-
 #[gpui::test]
 async fn test_select_git_entry(cx: &mut gpui::TestAppContext) {
     init_test_with_editor(cx);


### PR DESCRIPTION
Closes #48765 


Release Notes:

- Fixed appends copy marker for copied file in the wrong position of filename
