### PR TITLE
repl: Bump jupyter-protocol to v1.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8856,9 +8856,9 @@ dependencies = [
 
 [[package]]
 name = "jupyter-protocol"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0c2e3fba7f516ac3bc703f28abe3b83157320e603fb4abbee5ba9c016e2578"
+checksum = "073486929b8271fc18bd001fb8604f4b4d88c0fae134b88ed943c46c8826d9eb"
 dependencies = [
  "async-trait",
  "bytes 1.11.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -553,7 +553,7 @@ itertools = "0.14.0"
 json_dotpath = "1.1"
 jsonschema = "0.37.0"
 jsonwebtoken = "10.0"
-jupyter-protocol = "1.1.0"
+jupyter-protocol = "1.1.1"
 jupyter-websocket-client = "1.0.0"
 libc = "0.2"
 libsqlite3-sys = { version = "0.30.1", features = ["bundled"] }


### PR DESCRIPTION
Bringing in the handling of the lack of execution count noticed while testing other kernels. xref: https://github.com/zed-industries/zed/pull/48837

Release Notes:

- N/A