### PR TITLE
docs: Add default environment variable for Deno

### DIFF
--- a/docs/src/languages/deno.md
+++ b/docs/src/languages/deno.md
@@ -115,7 +115,7 @@ To run deno tasks like tests from the ui, add this to `.zed/tasks.json`
 [
   {
     "label": "deno test",
-    "command": "deno test -A --filter '/^$ZED_CUSTOM_DENO_TEST_NAME$/' '$ZED_FILE'",
+    "command": "deno test -A --filter '/^${ZED_CUSTOM_DENO_TEST_NAME:hello_world}$/' '$ZED_FILE'",
     "tags": ["js-test"]
   }
 ]


### PR DESCRIPTION
Closes #48537 

In the Deno docs, we have an uninitialized variable `ZED_CUSTOM_DENO_TEST_NAME` preventing the task from appearing when running `task: spawn`. To fix this, we add a default of `hello_world` to the command in the docs which fixes the issue.


- [X] Tests or screenshots needed?
Before:
<img width="904" height="520" alt="Screenshot 2026-02-09 at 11 45 53 PM" src="https://github.com/user-attachments/assets/266000ae-4e90-40a1-97c1-19d59f332d88" />
After:
<img width="955" height="522" alt="Screenshot 2026-02-09 at 11 45 33 PM" src="https://github.com/user-attachments/assets/1c22fb61-ae1b-4694-9b22-a63a5d893fed" />


- [] Code Reviewed
- [] Manual QA

Release Notes:

- N/A
