### PR TITLE
gpui: Prioritize topmost hitbox for window control hit testing

### DIFF
--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1310,11 +1310,19 @@ impl Window {
             Box::new(move || {
                 handle
                     .update(&mut cx, |_, window, _cx| {
-                        for (area, hitbox) in &window.rendered_frame.window_control_hitboxes {
-                            if window.mouse_hit_test.ids.contains(&hitbox.id) {
-                                return Some(*area);
+                        for hitbox_id in &window.mouse_hit_test.ids {
+                            for (area, hitbox) in &window.rendered_frame.window_control_hitboxes {
+                                if hitbox.id == *hitbox_id {
+                                    return Some(*area);
+                                }
                             }
+
+                            // Topmost hovered hitbox is not a window control area.
+                            // Do not allow controls underneath (e.g. ancestor Drag area)
+                            // to capture this point as non-client.
+                            return None;
                         }
+
                         None
                     })
                     .log_err()

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1310,17 +1310,12 @@ impl Window {
             Box::new(move || {
                 handle
                     .update(&mut cx, |_, window, _cx| {
-                        for hitbox_id in &window.mouse_hit_test.ids {
+                        if let Some(hitbox_id) = (&window.mouse_hit_test.ids).into_iter().next() {
                             for (area, hitbox) in &window.rendered_frame.window_control_hitboxes {
                                 if hitbox.id == *hitbox_id {
                                     return Some(*area);
                                 }
                             }
-
-                            // Topmost hovered hitbox is not a window control area.
-                            // Do not allow controls underneath (e.g. ancestor Drag area)
-                            // to capture this point as non-client.
-                            return None;
                         }
 
                         None


### PR DESCRIPTION
Closes #ISSUE

## Summary
Follow-up to #48330.

Fix a Windows regression where interactive child elements inside a
`WindowControlArea::Drag` region do not receive clicks because hit-testing can
resolve to the ancestor drag area (`HTCAPTION`).

## Changes
- Update `on_hit_test_window_control` in `crates/gpui/src/window.rs`
- Evaluate hovered hitboxes in topmost-first order (`mouse_hit_test.ids`)
- Return a window control area only if the topmost hovered hitbox is a control hitbox
- If the topmost hovered hitbox is not a control hitbox, return `None`

## Testing
- Reproduced using the report snippet from the PR comment (custom titlebar with a button inside `WindowControlArea::Drag`)
- Verified that the child button click handler fires after this change on Windows
- Verified that drag/caption hit-testing still works for intended titlebar controls

Release Notes:

- Fixed Windows custom titlebar hit-testing so clickable child UI is not overridden by ancestor `WindowControlArea::Drag`.
