### PR TITLE
editor: Filter out empty candidates during link capture

### DIFF
--- a/crates/editor/src/hover_links.rs
+++ b/crates/editor/src/hover_links.rs
@@ -681,7 +681,9 @@ fn link_pattern_file_candidates(candidate: &str) -> Vec<(String, Range<usize>)> 
 
     if let Some(captures) = MD_LINK_REGEX.captures(candidate) {
         if let Some(link) = captures.get(1) {
-            candidates.push((link.as_str().to_string(), link.range()));
+            if !link.as_str().is_empty() {
+                candidates.push((link.as_str().to_string(), link.range()));
+            }
         }
     }
     candidates
@@ -1463,7 +1465,31 @@ mod tests {
         assert_eq!(
             candidates,
             vec!["LinkTitle](link_(link_file)file.txt)", "link_(link_file",]
-        )
+        );
+
+        // Empty parens (zero-arg function calls like `foo()`) must not
+        // produce an empty-string candidate. The regex captures "" from
+        // inside `()`, which resolve_path_in_buffer turns into a worktree
+        // root match that blocks definitions() from ever being called.
+        let candidates: Vec<String> = link_pattern_file_candidates("foo()")
+            .into_iter()
+            .map(|(c, _)| c)
+            .collect();
+        assert_eq!(candidates, vec!["foo()"]);
+
+        let candidates: Vec<String> =
+            link_pattern_file_candidates("std::collections::HashMap::new()")
+                .into_iter()
+                .map(|(c, _)| c)
+                .collect();
+        assert_eq!(candidates, vec!["std::collections::HashMap::new()"]);
+
+        // Non-empty parens still produce an inner candidate
+        let candidates: Vec<String> = link_pattern_file_candidates("foo(bar)")
+            .into_iter()
+            .map(|(c, _)| c)
+            .collect();
+        assert_eq!(candidates, vec!["foo(bar)", "bar"]);
     }
 
     #[gpui::test]


### PR DESCRIPTION
## Problem

Hovering over identifiers followed by `()` (zero-arg function calls) never triggers goto-definition. The underline doesn't appear and the LSP is never queried.

I ran into this while working on a Zed extension for a Rust-like language that doesn't use trailing semicolons. In that language, `surrounding_filename` captures text like `foo()` as a single token since there's no `;` to act as a boundary. But the bug exists for any language: the regex match on empty parens always produces a bad candidate regardless of what surrounds it.

## Cause

`surrounding_filename` captures non-whitespace text around the cursor, e.g. `foo()`. Then `link_pattern_file_candidates` applies the markdown link regex `\(([^)]*)\)` to extract file paths from parenthesized text. For empty parens, this captures `""`.

The empty string gets passed to `resolve_path_in_buffer("")`, which matches the worktree root entry. Since `find_file` runs before `definitions()` in the hover pipeline, this false-positive file match short-circuits the flow and the LSP definition request never happens.

## Fix

Skip empty regex captures in `link_pattern_file_candidates`. The empty string is never a valid file path candidate.

## Test plan

- Added unit test cases for `foo()`, `std::collections::HashMap::new()`, and `foo(bar)` to `test_link_pattern_file_candidates`
- All 12 existing `hover_links` tests pass

Release Notes:

- Fixed go-to-definition not triggering on identifiers followed by empty parentheses (e.g. `foo()`).