### PR TITLE
Bump tree-sitter-go to v0.25.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17855,9 +17855,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-go"
-version = "0.23.4"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b13d476345220dbe600147dd444165c5791bf85ef53e28acbedd46112ee18431"
+checksum = "c8560a4d2f835cc0d4d2c2e03cbd0dde2f6114b43bc491164238d333e28b16ea"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -700,7 +700,7 @@ tree-sitter-diff = "0.1.0"
 tree-sitter-elixir = "0.3"
 tree-sitter-embedded-template = "0.23.0"
 tree-sitter-gitcommit = { git = "https://github.com/zed-industries/tree-sitter-git-commit", rev = "88309716a69dd13ab83443721ba6e0b491d37ee9" }
-tree-sitter-go = "0.23"
+tree-sitter-go = "0.25"
 tree-sitter-go-mod = { git = "https://github.com/camdencheek/tree-sitter-go-mod", rev = "2e886870578eeba1927a2dc4bd2e2b3f598c5f9a", package = "tree-sitter-gomod" }
 tree-sitter-gowork = { git = "https://github.com/zed-industries/tree-sitter-go-work", rev = "acb0617bf7f4fda02c6217676cc64acb89536dc7" }
 tree-sitter-heex = { git = "https://github.com/zed-industries/tree-sitter-heex", rev = "1dd45142fbb05562e35b2040c6129c9bca346592" }

--- a/crates/languages/src/go/runnables.scm
+++ b/crates/languages/src/go/runnables.scm
@@ -166,35 +166,37 @@
       (#eq? @_range_var @_collection_var)
     )
     body: (block
-      (expression_statement
-        (call_expression
-          function: (selector_expression
-            operand: (identifier)
-            field: (field_identifier) @_run_method
-            (#eq? @_run_method "Run")
-          )
-          arguments: (argument_list
-            .
-            [
-              (selector_expression
-                operand: (identifier) @_tc_var
-                (#eq? @_tc_var @_loop_var_inner)
-                field: (field_identifier) @_field_check
-                (#eq? @_field_check @_field_name)
-              )
-              (identifier) @_arg_var
-              (#eq? @_arg_var @_loop_var_outer)
-            ]
-            .
-            (func_literal
-              parameters: (parameter_list
-                (parameter_declaration
-                  type: (pointer_type
-                    (qualified_type
-                      package: (package_identifier) @_pkg
-                      name: (type_identifier) @_type
-                      (#eq? @_pkg "testing")
-                      (#eq? @_type "T")
+      (statement_list
+        (expression_statement
+          (call_expression
+            function: (selector_expression
+              operand: (identifier)
+              field: (field_identifier) @_run_method
+              (#eq? @_run_method "Run")
+            )
+            arguments: (argument_list
+              .
+              [
+                (selector_expression
+                  operand: (identifier) @_tc_var
+                  (#eq? @_tc_var @_loop_var_inner)
+                  field: (field_identifier) @_field_check
+                  (#eq? @_field_check @_field_name)
+                )
+                (identifier) @_arg_var
+                (#eq? @_arg_var @_loop_var_outer)
+              ]
+              .
+              (func_literal
+                parameters: (parameter_list
+                  (parameter_declaration
+                    type: (pointer_type
+                      (qualified_type
+                        package: (package_identifier) @_pkg
+                        name: (type_identifier) @_type
+                        (#eq? @_pkg "testing")
+                        (#eq? @_type "T")
+                      )
                     )
                   )
                 )
@@ -260,35 +262,37 @@
       )
     )
     body: (block
-      (expression_statement
-        (call_expression
-          function: (selector_expression
-            operand: (identifier)
-            field: (field_identifier) @_run_method
-            (#eq? @_run_method "Run")
-          )
-          arguments: (argument_list
-            .
-            [
-              (selector_expression
-                operand: (identifier) @_tc_var
-                (#eq? @_tc_var @_loop_var_inner)
-                field: (field_identifier) @_field_check
-                (#eq? @_field_check @_field_name)
-              )
-              (identifier) @_arg_var
-              (#eq? @_arg_var @_loop_var_outer)
-            ]
-            .
-            (func_literal
-              parameters: (parameter_list
-                (parameter_declaration
-                  type: (pointer_type
-                    (qualified_type
-                      package: (package_identifier) @_pkg
-                      name: (type_identifier) @_type
-                      (#eq? @_pkg "testing")
-                      (#eq? @_type "T")
+      (statement_list
+        (expression_statement
+          (call_expression
+            function: (selector_expression
+              operand: (identifier)
+              field: (field_identifier) @_run_method
+              (#eq? @_run_method "Run")
+            )
+            arguments: (argument_list
+              .
+              [
+                (selector_expression
+                  operand: (identifier) @_tc_var
+                  (#eq? @_tc_var @_loop_var_inner)
+                  field: (field_identifier) @_field_check
+                  (#eq? @_field_check @_field_name)
+                )
+                (identifier) @_arg_var
+                (#eq? @_arg_var @_loop_var_outer)
+              ]
+              .
+              (func_literal
+                parameters: (parameter_list
+                  (parameter_declaration
+                    type: (pointer_type
+                      (qualified_type
+                        package: (package_identifier) @_pkg
+                        name: (type_identifier) @_type
+                        (#eq? @_pkg "testing")
+                        (#eq? @_type "T")
+                      )
                     )
                   )
                 )


### PR DESCRIPTION
Fixes #48357

## Summary

- Bumps `tree-sitter-go` from `0.23` to `0.25`
- This fixes wrong syntax highlighting with chained indexing in Go (e.g. `a[b][c] = 0` being incorrectly parsed as a type instantiation expression instead of an index expression)
- The upstream fix ([tree-sitter/tree-sitter-go#160](https://github.com/tree-sitter/tree-sitter-go/issues/160)) landed in v0.25.0, which gives index expressions a higher dynamic precedence over type instantiation expressions
- Updated `runnables.scm` to account for the new `statement_list` node that wraps statements inside blocks in tree-sitter-go 0.25

## Test plan

- [x] `cargo test -p languages` — all 47 tests pass
- Verified that existing Go runnables queries (table tests, subtests, test detection) work with the updated grammar

Release Notes:

- Fixed wrong syntax highlighting with chained indexing in Go (e.g. `a[b][c]`) by bumping tree-sitter-go to 0.25