### PR TITLE
project_panel: Add "rescan worktrees" action

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -364,6 +364,8 @@ actions!(
         SelectPrevDirectory,
         /// Opens a diff view to compare two marked files.
         CompareMarkedFiles,
+        /// Forces a re-scan of all local worktrees and refreshes the project panel.
+        RescanWorktrees,
     ]
 );
 
@@ -479,6 +481,14 @@ pub fn init(cx: &mut App) {
         workspace.register_action(|workspace, action: &Delete, window, cx| {
             if let Some(panel) = workspace.panel::<ProjectPanel>(cx) {
                 panel.update(cx, |panel, cx| panel.delete(action, window, cx));
+            }
+        });
+
+        workspace.register_action(|workspace, action: &RescanWorktrees, window, cx| {
+            if let Some(panel) = workspace.panel::<ProjectPanel>(cx) {
+                panel.update(cx, |panel, cx| {
+                    panel.rescan_worktrees(action, window, cx);
+                });
             }
         });
 
@@ -1477,6 +1487,26 @@ impl ProjectPanel {
 
         self.update_visible_entries(None, false, false, window, cx);
         cx.notify();
+    }
+
+    fn rescan_worktrees(
+        &mut self,
+        _: &RescanWorktrees,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let worktrees = self
+            .project
+            .read(cx)
+            .visible_worktrees(cx)
+            .collect::<Vec<_>>();
+        for worktree in worktrees {
+            worktree.update(cx, |worktree, _cx| {
+                if let Some(local) = worktree.as_local() {
+                    local.refresh_entries_for_paths(vec![RelPath::empty().into()]);
+                }
+            });
+        }
     }
 
     fn toggle_expanded(

--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -438,7 +438,16 @@ TBD: Centered layout related settings
 
 ## Project Panel
 
-Project panel can be shown/hidden with {#action project_panel::ToggleFocus} ({#kb project_panel::ToggleFocus}) or with {#action pane::RevealInProjectPanel} ({#kb pane::RevealInProjectPanel}).
+Project panel can be shown/hidden with
+{#action project_panel::ToggleFocus}
+({#kb project_panel::ToggleFocus}) or with
+{#action pane::RevealInProjectPanel}
+({#kb pane::RevealInProjectPanel}).
+
+To force the project panel to re-scan all worktrees and
+pick up external file system changes, use
+{#action project_panel::RescanWorktrees}
+({#kb project_panel::RescanWorktrees}).
 
 ```json [settings]
   // Project Panel Settings


### PR DESCRIPTION
Project panel (file tree sidebar) sometimes fails to reflect changes
made outside Zed, or is slow to sync after internal rename/move operations.

Zed relies on the OS file system watcher (`notify` crate) to detect changes,
but watchers can miss events (especially on Linux with non-recursive inotify)
or deliver them with latency. There is currently **no user-facing action** to
force a rescan of the worktree.

The `refresh_entries_for_paths` already exists internally, what is missing is a piece of user facing action that calls it in order to force the rescan.

Users can trigger `RescanWorktrees` via the command palette or as a keybind.

<img width="733" height="511" alt="dms-screenshot-1770725584803" src="https://github.com/user-attachments/assets/8497c692-0e98-42c5-a3b3-af76f9459632" />



Keybind:

```json
[
    {
      "context": "Workspace",
      "bindings": {
        "ctrl-shift-r": "project_panel::RescanWorktrees"
      }
    }
  ]
```

Closes #29598
Related #26857

- [x] Tests or screenshots needed?
- [x] Code Reviewed
- [x] Manual QA

Release Notes:

- N/A *or* Added/Fixed/Improved ...
