### PR TITLE
Revert "ci: Restore mtime of source files to the git log time"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,6 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         clean: false
-        fetch-depth: 0
-    - name: steps::restore_mtime
-      uses: zed-industries/git-restore-mtime-action@72cefcf20b50bf4fcd74ea8a0d2927b0680e2114
     - name: steps::setup_cargo_config
       run: |
         mkdir -p ./../.cargo
@@ -52,9 +49,6 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         clean: false
-        fetch-depth: 0
-    - name: steps::restore_mtime
-      uses: zed-industries/git-restore-mtime-action@72cefcf20b50bf4fcd74ea8a0d2927b0680e2114
     - name: steps::setup_cargo_config
       run: |
         mkdir -p ./../.cargo
@@ -101,9 +95,6 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         clean: false
-        fetch-depth: 0
-    - name: steps::restore_mtime
-      uses: zed-industries/git-restore-mtime-action@72cefcf20b50bf4fcd74ea8a0d2927b0680e2114
     - name: steps::setup_cargo_config
       run: |
         New-Item -ItemType Directory -Path "./../.cargo" -Force
@@ -133,9 +124,6 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         clean: false
-        fetch-depth: 0
-    - name: steps::restore_mtime
-      uses: zed-industries/git-restore-mtime-action@72cefcf20b50bf4fcd74ea8a0d2927b0680e2114
     - name: steps::setup_cargo_config
       run: |
         mkdir -p ./../.cargo
@@ -156,9 +144,6 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         clean: false
-        fetch-depth: 0
-    - name: steps::restore_mtime
-      uses: zed-industries/git-restore-mtime-action@72cefcf20b50bf4fcd74ea8a0d2927b0680e2114
     - name: steps::setup_cargo_config
       run: |
         mkdir -p ./../.cargo
@@ -185,9 +170,6 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         clean: false
-        fetch-depth: 0
-    - name: steps::restore_mtime
-      uses: zed-industries/git-restore-mtime-action@72cefcf20b50bf4fcd74ea8a0d2927b0680e2114
     - name: steps::setup_cargo_config
       run: |
         New-Item -ItemType Directory -Path "./../.cargo" -Force
@@ -258,9 +240,6 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         clean: false
-        fetch-depth: 0
-    - name: steps::restore_mtime
-      uses: zed-industries/git-restore-mtime-action@72cefcf20b50bf4fcd74ea8a0d2927b0680e2114
     - name: steps::setup_sentry
       uses: matbour/setup-sentry-cli@3e938c54b3018bdd019973689ef984e033b0454b
       with:
@@ -301,9 +280,6 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         clean: false
-        fetch-depth: 0
-    - name: steps::restore_mtime
-      uses: zed-industries/git-restore-mtime-action@72cefcf20b50bf4fcd74ea8a0d2927b0680e2114
     - name: steps::setup_sentry
       uses: matbour/setup-sentry-cli@3e938c54b3018bdd019973689ef984e033b0454b
       with:
@@ -349,9 +325,6 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         clean: false
-        fetch-depth: 0
-    - name: steps::restore_mtime
-      uses: zed-industries/git-restore-mtime-action@72cefcf20b50bf4fcd74ea8a0d2927b0680e2114
     - name: steps::setup_node
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
       with:
@@ -397,9 +370,6 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         clean: false
-        fetch-depth: 0
-    - name: steps::restore_mtime
-      uses: zed-industries/git-restore-mtime-action@72cefcf20b50bf4fcd74ea8a0d2927b0680e2114
     - name: steps::setup_node
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
       with:
@@ -449,9 +419,6 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         clean: false
-        fetch-depth: 0
-    - name: steps::restore_mtime
-      uses: zed-industries/git-restore-mtime-action@72cefcf20b50bf4fcd74ea8a0d2927b0680e2114
     - name: steps::setup_sentry
       uses: matbour/setup-sentry-cli@3e938c54b3018bdd019973689ef984e033b0454b
       with:
@@ -497,9 +464,6 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         clean: false
-        fetch-depth: 0
-    - name: steps::restore_mtime
-      uses: zed-industries/git-restore-mtime-action@72cefcf20b50bf4fcd74ea8a0d2927b0680e2114
     - name: steps::setup_sentry
       uses: matbour/setup-sentry-cli@3e938c54b3018bdd019973689ef984e033b0454b
       with:

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -33,9 +33,6 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         clean: false
-        fetch-depth: 0
-    - name: steps::restore_mtime
-      uses: zed-industries/git-restore-mtime-action@72cefcf20b50bf4fcd74ea8a0d2927b0680e2114
     - name: steps::setup_cargo_config
       run: |
         New-Item -ItemType Directory -Path "./../.cargo" -Force
@@ -65,9 +62,6 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         clean: false
-        fetch-depth: 0
-    - name: steps::restore_mtime
-      uses: zed-industries/git-restore-mtime-action@72cefcf20b50bf4fcd74ea8a0d2927b0680e2114
     - name: steps::setup_cargo_config
       run: |
         New-Item -ItemType Directory -Path "./../.cargo" -Force
@@ -92,9 +86,6 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         clean: false
-        fetch-depth: 0
-    - name: steps::restore_mtime
-      uses: zed-industries/git-restore-mtime-action@72cefcf20b50bf4fcd74ea8a0d2927b0680e2114
     - name: run_bundling::set_release_channel_to_nightly
       run: |
         set -eu
@@ -141,9 +132,6 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         clean: false
-        fetch-depth: 0
-    - name: steps::restore_mtime
-      uses: zed-industries/git-restore-mtime-action@72cefcf20b50bf4fcd74ea8a0d2927b0680e2114
     - name: run_bundling::set_release_channel_to_nightly
       run: |
         set -eu
@@ -195,9 +183,6 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         clean: false
-        fetch-depth: 0
-    - name: steps::restore_mtime
-      uses: zed-industries/git-restore-mtime-action@72cefcf20b50bf4fcd74ea8a0d2927b0680e2114
     - name: run_bundling::set_release_channel_to_nightly
       run: |
         set -eu
@@ -249,9 +234,6 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         clean: false
-        fetch-depth: 0
-    - name: steps::restore_mtime
-      uses: zed-industries/git-restore-mtime-action@72cefcf20b50bf4fcd74ea8a0d2927b0680e2114
     - name: run_bundling::set_release_channel_to_nightly
       run: |
         set -eu
@@ -307,9 +289,6 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         clean: false
-        fetch-depth: 0
-    - name: steps::restore_mtime
-      uses: zed-industries/git-restore-mtime-action@72cefcf20b50bf4fcd74ea8a0d2927b0680e2114
     - name: run_bundling::set_release_channel_to_nightly
       run: |
         $ErrorActionPreference = "Stop"
@@ -363,9 +342,6 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         clean: false
-        fetch-depth: 0
-    - name: steps::restore_mtime
-      uses: zed-industries/git-restore-mtime-action@72cefcf20b50bf4fcd74ea8a0d2927b0680e2114
     - name: run_bundling::set_release_channel_to_nightly
       run: |
         $ErrorActionPreference = "Stop"

--- a/.github/workflows/run_bundling.yml
+++ b/.github/workflows/run_bundling.yml
@@ -24,9 +24,6 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         clean: false
-        fetch-depth: 0
-    - name: steps::restore_mtime
-      uses: zed-industries/git-restore-mtime-action@72cefcf20b50bf4fcd74ea8a0d2927b0680e2114
     - name: steps::setup_sentry
       uses: matbour/setup-sentry-cli@3e938c54b3018bdd019973689ef984e033b0454b
       with:
@@ -66,9 +63,6 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         clean: false
-        fetch-depth: 0
-    - name: steps::restore_mtime
-      uses: zed-industries/git-restore-mtime-action@72cefcf20b50bf4fcd74ea8a0d2927b0680e2114
     - name: steps::setup_sentry
       uses: matbour/setup-sentry-cli@3e938c54b3018bdd019973689ef984e033b0454b
       with:
@@ -113,9 +107,6 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         clean: false
-        fetch-depth: 0
-    - name: steps::restore_mtime
-      uses: zed-industries/git-restore-mtime-action@72cefcf20b50bf4fcd74ea8a0d2927b0680e2114
     - name: steps::setup_node
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
       with:
@@ -160,9 +151,6 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         clean: false
-        fetch-depth: 0
-    - name: steps::restore_mtime
-      uses: zed-industries/git-restore-mtime-action@72cefcf20b50bf4fcd74ea8a0d2927b0680e2114
     - name: steps::setup_node
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
       with:
@@ -211,9 +199,6 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         clean: false
-        fetch-depth: 0
-    - name: steps::restore_mtime
-      uses: zed-industries/git-restore-mtime-action@72cefcf20b50bf4fcd74ea8a0d2927b0680e2114
     - name: steps::setup_sentry
       uses: matbour/setup-sentry-cli@3e938c54b3018bdd019973689ef984e033b0454b
       with:
@@ -258,9 +243,6 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         clean: false
-        fetch-depth: 0
-    - name: steps::restore_mtime
-      uses: zed-industries/git-restore-mtime-action@72cefcf20b50bf4fcd74ea8a0d2927b0680e2114
     - name: steps::setup_sentry
       uses: matbour/setup-sentry-cli@3e938c54b3018bdd019973689ef984e033b0454b
       with:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -151,9 +151,6 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         clean: false
-        fetch-depth: 0
-    - name: steps::restore_mtime
-      uses: zed-industries/git-restore-mtime-action@72cefcf20b50bf4fcd74ea8a0d2927b0680e2114
     - name: steps::setup_cargo_config
       run: |
         New-Item -ItemType Directory -Path "./../.cargo" -Force
@@ -173,9 +170,6 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         clean: false
-        fetch-depth: 0
-    - name: steps::restore_mtime
-      uses: zed-industries/git-restore-mtime-action@72cefcf20b50bf4fcd74ea8a0d2927b0680e2114
     - name: steps::setup_cargo_config
       run: |
         mkdir -p ./../.cargo
@@ -204,9 +198,6 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         clean: false
-        fetch-depth: 0
-    - name: steps::restore_mtime
-      uses: zed-industries/git-restore-mtime-action@72cefcf20b50bf4fcd74ea8a0d2927b0680e2114
     - name: steps::setup_cargo_config
       run: |
         mkdir -p ./../.cargo
@@ -229,9 +220,6 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         clean: false
-        fetch-depth: 0
-    - name: steps::restore_mtime
-      uses: zed-industries/git-restore-mtime-action@72cefcf20b50bf4fcd74ea8a0d2927b0680e2114
     - name: steps::setup_cargo_config
       run: |
         New-Item -ItemType Directory -Path "./../.cargo" -Force
@@ -263,9 +251,6 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         clean: false
-        fetch-depth: 0
-    - name: steps::restore_mtime
-      uses: zed-industries/git-restore-mtime-action@72cefcf20b50bf4fcd74ea8a0d2927b0680e2114
     - name: steps::setup_cargo_config
       run: |
         mkdir -p ./../.cargo
@@ -314,9 +299,6 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         clean: false
-        fetch-depth: 0
-    - name: steps::restore_mtime
-      uses: zed-industries/git-restore-mtime-action@72cefcf20b50bf4fcd74ea8a0d2927b0680e2114
     - name: steps::setup_cargo_config
       run: |
         mkdir -p ./../.cargo
@@ -351,9 +333,6 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         clean: false
-        fetch-depth: 0
-    - name: steps::restore_mtime
-      uses: zed-industries/git-restore-mtime-action@72cefcf20b50bf4fcd74ea8a0d2927b0680e2114
     - name: steps::cache_rust_dependencies_namespace
       uses: namespacelabs/nscloud-cache-action@v1
       with:

--- a/tooling/xtask/src/tasks/workflows/run_bundling.rs
+++ b/tooling/xtask/src/tasks/workflows/run_bundling.rs
@@ -73,8 +73,7 @@ pub(crate) fn bundle_mac(
         job: bundle_job(deps)
             .runs_on(runners::MAC_DEFAULT)
             .envs(bundle_envs(platform))
-            .add_step(steps::checkout_repo().add_with(("fetch-depth", 0)))
-            .add_step(steps::restore_mtime())
+            .add_step(steps::checkout_repo())
             .when_some(release_channel, |job, release_channel| {
                 job.add_step(set_release_channel(platform, release_channel))
             })
@@ -125,8 +124,7 @@ pub(crate) fn bundle_linux(
         job: bundle_job(deps)
             .runs_on(arch.linux_bundler())
             .envs(bundle_envs(platform))
-            .add_step(steps::checkout_repo().add_with(("fetch-depth", 0)))
-            .add_step(steps::restore_mtime())
+            .add_step(steps::checkout_repo())
             .when_some(release_channel, |job, release_channel| {
                 job.add_step(set_release_channel(platform, release_channel))
             })
@@ -166,8 +164,7 @@ pub(crate) fn bundle_windows(
         job: bundle_job(deps)
             .runs_on(runners::WINDOWS_DEFAULT)
             .envs(bundle_envs(platform))
-            .add_step(steps::checkout_repo().add_with(("fetch-depth", 0)))
-            .add_step(steps::restore_mtime())
+            .add_step(steps::checkout_repo())
             .when_some(release_channel, |job, release_channel| {
                 job.add_step(set_release_channel(platform, release_channel))
             })

--- a/tooling/xtask/src/tasks/workflows/run_tests.rs
+++ b/tooling/xtask/src/tasks/workflows/run_tests.rs
@@ -384,8 +384,7 @@ pub(crate) fn clippy(platform: Platform) -> NamedJob {
         name: format!("clippy_{platform}"),
         job: release_job(&[])
             .runs_on(runner)
-            .add_step(steps::checkout_repo().add_with(("fetch-depth", 0)))
-            .add_step(steps::restore_mtime())
+            .add_step(steps::checkout_repo())
             .add_step(steps::setup_cargo_config(platform))
             .when(
                 platform == Platform::Linux || platform == Platform::Mac,
@@ -431,8 +430,7 @@ fn run_platform_tests_impl(platform: Platform, filter_packages: bool) -> NamedJo
                         ),
                 )
             })
-            .add_step(steps::checkout_repo().add_with(("fetch-depth", 0)))
-            .add_step(steps::restore_mtime())
+            .add_step(steps::checkout_repo())
             .add_step(steps::setup_cargo_config(platform))
             .when(
                 platform == Platform::Linux || platform == Platform::Mac,
@@ -515,8 +513,7 @@ fn doctests() -> NamedJob {
     named::job(
         release_job(&[])
             .runs_on(runners::LINUX_DEFAULT)
-            .add_step(steps::checkout_repo().add_with(("fetch-depth", 0)))
-            .add_step(steps::restore_mtime())
+            .add_step(steps::checkout_repo())
             .add_step(steps::cache_rust_dependencies_namespace())
             .map(steps::install_linux_dependencies)
             .add_step(steps::setup_cargo_config(Platform::Linux))

--- a/tooling/xtask/src/tasks/workflows/steps.rs
+++ b/tooling/xtask/src/tasks/workflows/steps.rs
@@ -47,14 +47,6 @@ impl From<Nextest> for Step<Run> {
     }
 }
 
-pub fn restore_mtime() -> Step<Use> {
-    named::uses(
-        "zed-industries",
-        "git-restore-mtime-action",
-        "72cefcf20b50bf4fcd74ea8a0d2927b0680e2114",
-    )
-}
-
 pub fn checkout_repo() -> Step<Use> {
     named::uses(
         "actions",


### PR DESCRIPTION
Reverts zed-industries/zed#48607

The problem we've ran into is that CI started reusing already-cached runs from newer branches (that did not have that change pulled in).

Yet this unveiled another potential issue, which is that relying on mtime might make it so that an artifact for a different (newer) commit would be reused by an unrelated run of CI.

The answer is: checksum-based-freshness.

Release Notes:
- N/A