### PR TITLE
Revert "linux: Forward env vars starting with ZED_ to flatpak-spawn"

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -952,13 +952,6 @@ mod flatpak {
     pub fn try_restart_to_host() {
         if let Some(flatpak_dir) = get_flatpak_dir() {
             let mut args = vec!["/usr/bin/flatpak-spawn".into(), "--host".into()];
-
-            for (name, value) in env::vars() {
-                if name.starts_with("ZED_") {
-                    args.push(format!("--env={}={}", name, value).into());
-                }
-            }
-
             args.append(&mut get_xdg_env_args());
             args.push("--env=ZED_UPDATE_EXPLANATION=Please use flatpak to update zed".into());
             args.push(


### PR DESCRIPTION
Reverts zed-industries/zed#48118