### PR TITLE
terminal: Fix Spawn Task and Agent terminal hangs on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -514,13 +514,14 @@ dependencies = [
 [[package]]
 name = "alacritty_terminal"
 version = "0.25.1"
-source = "git+https://github.com/zed-industries/alacritty?rev=936aee8761a17affc84ab418ae21306c27c26221#936aee8761a17affc84ab418ae21306c27c26221"
+source = "git+https://github.com/zed-industries/alacritty?rev=9d9640d4#9d9640d4e56d67a09d049f9c0a300aae08d4f61e"
 dependencies = [
  "base64 0.22.1",
  "bitflags 2.10.0",
  "home",
  "libc",
  "log",
+ "mach2 0.5.0",
  "miow",
  "parking_lot",
  "piper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -462,7 +462,7 @@ ztracing_macro = { path = "crates/ztracing_macro" }
 
 agent-client-protocol = { version = "=0.9.4", features = ["unstable"] }
 aho-corasick = "1.1"
-alacritty_terminal = { git = "https://github.com/zed-industries/alacritty", rev = "936aee8761a17affc84ab418ae21306c27c26221" }
+alacritty_terminal = { git = "https://github.com/zed-industries/alacritty", rev = "9d9640d4" }
 any_vec = "0.14"
 anyhow = "1.0.86"
 arrayvec = { version = "0.7.4", features = ["serde"] }


### PR DESCRIPTION
Follow-up to #47420 and #44193.

#47420 fixed child-exit status handling via upstream alacritty change (https://github.com/alacritty/alacritty/pull/8825). However, stable/preview/nightly builds still reproduced hangs that dev builds did not.

The root cause matches #44193: spawned children inherit crash-handler Mach exception ports and hang. We already reset exception ports in `util::command::new_smol_command` and `util::set_pre_exec_to_start_new_session`, but PTY child spawning in `alacritty_terminal` was not covered.

This PR updates `alacritty_terminal` to include PTY `pre_exec` exception-port reset:
https://github.com/zed-industries/alacritty/commit/9d9640d4e56d67a09d049f9c0a300aae08d4f61e

Upstream:
- https://github.com/alacritty/alacritty/pull/8835

Release Notes:

- Fixed terminal tasks hanging on macOS when a spawned process is killed by a signal.