### PR TITLE
ci: Fix builds on Windows following mtime finnickery

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -952,13 +952,6 @@ mod flatpak {
     pub fn try_restart_to_host() {
         if let Some(flatpak_dir) = get_flatpak_dir() {
             let mut args = vec!["/usr/bin/flatpak-spawn".into(), "--host".into()];
-
-            for (name, value) in env::vars() {
-                if name.starts_with("ZED_") {
-                    args.push(format!("--env={}={}", name, value).into());
-                }
-            }
-
             args.append(&mut get_xdg_env_args());
             args.push("--env=ZED_UPDATE_EXPLANATION=Please use flatpak to update zed".into());
             args.push(

--- a/crates/tab_switcher/src/tab_switcher.rs
+++ b/crates/tab_switcher/src/tab_switcher.rs
@@ -591,15 +591,29 @@ impl TabSwitcherDelegate {
             let Some(workspace) = self.workspace.upgrade() else {
                 return;
             };
-            workspace.update(cx, |workspace, cx| {
-                workspace.close_items_with_project_path(
-                    &project_path,
-                    SaveIntent::Close,
-                    true,
-                    window,
-                    cx,
-                );
-            });
+            let panes_and_items: Vec<_> = workspace
+                .read(cx)
+                .panes()
+                .iter()
+                .map(|pane| {
+                    let items_to_close: Vec<_> = pane
+                        .read(cx)
+                        .items()
+                        .filter(|item| item.project_path(cx) == Some(project_path.clone()))
+                        .map(|item| item.item_id())
+                        .collect();
+                    (pane.clone(), items_to_close)
+                })
+                .collect();
+
+            for (pane, items_to_close) in panes_and_items {
+                for item_id in items_to_close {
+                    pane.update(cx, |pane, cx| {
+                        pane.close_item_by_id(item_id, SaveIntent::Close, window, cx)
+                            .detach_and_log_err(cx);
+                    });
+                }
+            }
         } else {
             let Some(pane) = tab_match.pane.upgrade() else {
                 return;

--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -1627,12 +1627,12 @@ fn generate_commands(_: &App) -> Vec<VimCommand> {
         VimCommand::new(("cq", "uit"), zed_actions::Quit),
         VimCommand::new(
             ("bd", "elete"),
-            workspace::CloseItemInAllPanes {
+            workspace::CloseActiveItem {
                 save_intent: Some(SaveIntent::Close),
                 close_pinned: false,
             },
         )
-        .bang(workspace::CloseItemInAllPanes {
+        .bang(workspace::CloseActiveItem {
             save_intent: Some(SaveIntent::Skip),
             close_pinned: true,
         }),

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -782,10 +782,6 @@ impl Pane {
         self.active_item_index
     }
 
-    pub fn is_active_item_pinned(&self) -> bool {
-        self.is_tab_pinned(self.active_item_index)
-    }
-
     pub fn activation_history(&self) -> &[ActivationHistoryEntry] {
         &self.activation_history
     }
@@ -1621,26 +1617,6 @@ impl Pane {
     ) -> Task<Result<()>> {
         self.close_items(window, cx, save_intent, move |view_id| {
             view_id == item_id_to_close
-        })
-    }
-
-    pub fn close_items_for_project_path(
-        &mut self,
-        project_path: &ProjectPath,
-        save_intent: SaveIntent,
-        close_pinned: bool,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) -> Task<Result<()>> {
-        let pinned_item_ids = self.pinned_item_ids();
-        let matching_item_ids: Vec<_> = self
-            .items()
-            .filter(|item| item.project_path(cx).as_ref() == Some(project_path))
-            .map(|item| item.item_id())
-            .collect();
-        self.close_items(window, cx, save_intent, move |item_id| {
-            matching_item_ids.contains(&item_id)
-                && (close_pinned || !pinned_item_ids.contains(&item_id))
         })
     }
 


### PR DESCRIPTION
- **Revert "vim: Make `:bdelete` use new `workspace::CloseItemInAllPanes` command  (#48592)"**
- **Revert "linux: Forward env vars starting with ZED_ to flatpak-spawn (#48118)"**
- **ci: Fix builds on hel1-windows-1**


- [x] Tests or screenshots needed?
- [x] Code Reviewed
- [x] Manual QA

Release Notes:

- N/A
