### PR TITLE
Un-feature-flag granular tool permissions

### DIFF
--- a/crates/feature_flags/src/flags.rs
+++ b/crates/feature_flags/src/flags.rs
@@ -24,16 +24,6 @@ impl FeatureFlag for AcpBetaFeatureFlag {
     const NAME: &'static str = "acp-beta";
 }
 
-pub struct ToolPermissionsFeatureFlag;
-
-impl FeatureFlag for ToolPermissionsFeatureFlag {
-    const NAME: &'static str = "tool-permissions";
-
-    fn enabled_for_staff() -> bool {
-        false
-    }
-}
-
 pub struct AgentSharingFeatureFlag;
 
 impl FeatureFlag for AgentSharingFeatureFlag {


### PR DESCRIPTION
The granular tool permissions feature is now generally available, and this flag is no longer used anywhere.

Release Notes:

- N/A