### PR TITLE
repl: Test outputs and ExecutionView

### DIFF
--- a/crates/repl/Cargo.toml
+++ b/crates/repl/Cargo.toml
@@ -72,4 +72,5 @@ theme = { workspace = true, features = ["test-support"] }
 tree-sitter-md.workspace = true
 tree-sitter-typescript.workspace = true
 tree-sitter-python.workspace = true
+workspace = { workspace = true, features = ["test-support"] }
 util = { workspace = true, features = ["test-support"] }


### PR DESCRIPTION
More tests for outputs and the `ExecutionView`. Wanting to get more of these in before we progress on Notebooks and Widgets.

Release Notes:

- N/A
