### PR TITLE
Add configurable autoscroll strategy for go to definition

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -318,6 +318,13 @@
   // 1. Do nothing: `none`
   // 2. Find references for the same symbol: `find_all_references` (default)
   "go_to_definition_fallback": "find_all_references",
+  // How to position the cursor when navigating to a definition.
+  // Options: "fit" (default), "center", "focused", "top", "bottom"
+  // Or use an object for relative positioning:
+  //   {"strategy": "center_relative", "offset": -10}  // 10 lines above center
+  //   {"strategy": "top_relative", "offset": 5}       // 5 lines from top
+  //   {"strategy": "bottom_relative", "offset": 10}   // 10 lines from bottom
+  "go_to_definition_autoscroll": "fit",
   // Which level to use to filter out diagnostics displayed in the editor.
   //
   // Affects the editor rendering only, and does not interrupt

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -104,7 +104,10 @@ use edit_prediction_types::{
     EditPredictionDelegate, EditPredictionDelegateHandle, EditPredictionDiscardReason,
     EditPredictionGranularity, SuggestionDisplayType,
 };
-use editor_settings::{GoToDefinitionFallback, Minimap as MinimapSettings};
+use editor_settings::{
+    GoToDefinitionAutoscroll, GoToDefinitionAutoscrollStrategy, GoToDefinitionFallback,
+    Minimap as MinimapSettings,
+};
 use element::{AcceptEditPredictionBinding, LineWithInvisibles, PositionMap, layout_line};
 use futures::{
     FutureExt,
@@ -17601,8 +17604,37 @@ impl Editor {
         let Some(end) = multibuffer.buffer_point_to_anchor(&buffer, range.end, cx) else {
             return;
         };
+
+        let autoscroll = match &EditorSettings::get_global(cx).go_to_definition_autoscroll {
+            GoToDefinitionAutoscroll::Simple(strategy) => match strategy {
+                GoToDefinitionAutoscrollStrategy::Fit => Autoscroll::fit(),
+                GoToDefinitionAutoscrollStrategy::Center => Autoscroll::center(),
+                GoToDefinitionAutoscrollStrategy::Focused => Autoscroll::focused(),
+                GoToDefinitionAutoscrollStrategy::Top => Autoscroll::top(),
+                GoToDefinitionAutoscrollStrategy::Bottom => Autoscroll::bottom(),
+            },
+            GoToDefinitionAutoscroll::WithOffset { strategy, offset } => match strategy.as_str() {
+                "center_relative" => Autoscroll::center_relative(*offset),
+                "top_relative" => {
+                    if *offset >= 0 {
+                        Autoscroll::top_relative(*offset as usize)
+                    } else {
+                        Autoscroll::fit()
+                    }
+                }
+                "bottom_relative" => {
+                    if *offset >= 0 {
+                        Autoscroll::bottom_relative(*offset as usize)
+                    } else {
+                        Autoscroll::fit()
+                    }
+                }
+                _ => Autoscroll::fit(),
+            },
+        };
+
         self.change_selections(
-            SelectionEffects::default().nav_history(true),
+            SelectionEffects::scroll(autoscroll).nav_history(true),
             window,
             cx,
             |s| s.select_anchor_ranges([start..end]),

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -5,9 +5,10 @@ use language::CursorShape;
 use project::project_settings::DiagnosticSeverity;
 pub use settings::{
     CompletionDetailAlignment, CurrentLineHighlight, DelayMs, DiffViewStyle, DisplayIn,
-    DocumentColorsRenderMode, DoubleClickInMultibuffer, GoToDefinitionFallback, HideMouseMode,
-    MinimapThumb, MinimapThumbBorder, MultiCursorModifier, ScrollBeyondLastLine,
-    ScrollbarDiagnostics, SeedQuerySetting, ShowMinimap, SnippetSortOrder,
+    DocumentColorsRenderMode, DoubleClickInMultibuffer, GoToDefinitionAutoscroll,
+    GoToDefinitionAutoscrollStrategy, GoToDefinitionFallback, HideMouseMode, MinimapThumb,
+    MinimapThumbBorder, MultiCursorModifier, ScrollBeyondLastLine, ScrollbarDiagnostics,
+    SeedQuerySetting, ShowMinimap, SnippetSortOrder,
 };
 use settings::{RegisterSetting, RelativeLineNumbers, Settings};
 use ui::scrollbars::{ScrollbarVisibility, ShowScrollbar};
@@ -49,6 +50,7 @@ pub struct EditorSettings {
     pub auto_signature_help: bool,
     pub show_signature_help_after_edits: bool,
     pub go_to_definition_fallback: GoToDefinitionFallback,
+    pub go_to_definition_autoscroll: GoToDefinitionAutoscroll,
     pub jupyter: Jupyter,
     pub hide_mouse: Option<HideMouseMode>,
     pub snippet_sort_order: SnippetSortOrder,
@@ -281,6 +283,7 @@ impl Settings for EditorSettings {
             auto_signature_help: editor.auto_signature_help.unwrap(),
             show_signature_help_after_edits: editor.show_signature_help_after_edits.unwrap(),
             go_to_definition_fallback: editor.go_to_definition_fallback.unwrap(),
+            go_to_definition_autoscroll: editor.go_to_definition_autoscroll.clone().unwrap(),
             jupyter: Jupyter {
                 enabled: editor.jupyter.unwrap().enabled.unwrap(),
             },

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -24204,6 +24204,159 @@ async fn test_goto_definition_no_fallback(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_goto_definition_autoscroll(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorLspTestContext::new_rust(
+        lsp::ServerCapabilities {
+            definition_provider: Some(lsp::OneOf::Left(true)),
+            ..lsp::ServerCapabilities::default()
+        },
+        cx,
+    )
+    .await;
+
+    // Generate enough lines so the definition target is well off screen,
+    // with plenty of lines both above and below the target to avoid
+    // scroll clamping at the buffer edges.
+    let line_count: u32 = 200;
+    let target_line: u32 = 100;
+    let mut source = String::new();
+    source.push_str("fn ˇcaller() { callee(); }\n");
+    for i in 1..line_count - 1 {
+        if i == target_line {
+            source.push_str("fn callee() {}\n");
+        } else {
+            source.push_str(&format!("// line {i}\n"));
+        }
+    }
+    source.push_str("// end\n");
+    cx.set_state(&source);
+
+    // The LSP always returns the definition at the target line.
+    cx.lsp
+        .set_request_handler::<lsp::request::GotoDefinition, _, _>(move |params, _| async move {
+            Ok(Some(lsp::GotoDefinitionResponse::Scalar(lsp::Location {
+                uri: params.text_document_position_params.text_document.uri,
+                range: lsp::Range::new(
+                    lsp::Position::new(target_line, 3),
+                    lsp::Position::new(target_line, 9),
+                ),
+            })))
+        });
+
+    // Size the window to show ~10 lines.
+    let line_height = cx.update_editor(|editor, window, cx| {
+        editor.set_vertical_scroll_margin(0, cx);
+        editor
+            .style(cx)
+            .text
+            .line_height_in_pixels(window.rem_size())
+    });
+    let visible_lines = 10.0_f64;
+    let window = cx.window;
+    cx.simulate_window_resize(window, size(px(1000.), visible_lines as f32 * line_height));
+
+    // Helper: reset cursor to line 0, navigate to definition, return scroll y.
+    async fn navigate_and_get_scroll(cx: &mut EditorLspTestContext) -> f64 {
+        cx.update_editor(|editor, window, cx| {
+            editor.change_selections(Default::default(), window, cx, |s| {
+                s.select_ranges([Point::new(0, 3)..Point::new(0, 3)]);
+            });
+        });
+        cx.update_editor(|editor, window, cx| editor.go_to_definition(&GoToDefinition, window, cx))
+            .await
+            .expect("go_to_definition should succeed");
+        cx.update_editor(|editor, window, cx| editor.snapshot(window, cx).scroll_position().y)
+    }
+
+    // Collect scroll positions for each strategy.
+    let mut scroll_positions: Vec<(&str, f64)> = Vec::new();
+
+    let strategies = [
+        (
+            "top",
+            GoToDefinitionAutoscroll::Simple(GoToDefinitionAutoscrollStrategy::Top),
+        ),
+        (
+            "center",
+            GoToDefinitionAutoscroll::Simple(GoToDefinitionAutoscrollStrategy::Center),
+        ),
+        (
+            "bottom",
+            GoToDefinitionAutoscroll::Simple(GoToDefinitionAutoscrollStrategy::Bottom),
+        ),
+        (
+            "top_relative(3)",
+            GoToDefinitionAutoscroll::WithOffset {
+                strategy: "top_relative".to_string(),
+                offset: 3,
+            },
+        ),
+        (
+            "center_relative(-3)",
+            GoToDefinitionAutoscroll::WithOffset {
+                strategy: "center_relative".to_string(),
+                offset: -3,
+            },
+        ),
+        (
+            "center_relative(3)",
+            GoToDefinitionAutoscroll::WithOffset {
+                strategy: "center_relative".to_string(),
+                offset: 3,
+            },
+        ),
+    ];
+
+    for (name, autoscroll) in strategies {
+        cx.update_editor(|_, _, cx| {
+            let mut settings = EditorSettings::get_global(cx).clone();
+            settings.go_to_definition_autoscroll = autoscroll;
+            EditorSettings::override_global(settings, cx);
+        });
+        let scroll_y = navigate_and_get_scroll(&mut cx).await;
+        scroll_positions.push((name, scroll_y));
+    }
+
+    let get = |name: &str| -> f64 { scroll_positions.iter().find(|(n, _)| *n == name).unwrap().1 };
+
+    // "top" scrolls the most (target near row 0 of viewport).
+    // "bottom" scrolls the least (target near last row of viewport).
+    // "center" should be between top and bottom.
+    assert!(
+        get("top") > get("center"),
+        "top (scroll_y={}) should scroll more than center (scroll_y={})",
+        get("top"),
+        get("center"),
+    );
+    assert!(
+        get("center") > get("bottom"),
+        "center (scroll_y={}) should scroll more than bottom (scroll_y={})",
+        get("center"),
+        get("bottom"),
+    );
+
+    // "top_relative(3)" should place the target 3 lines from top,
+    // so it scrolls less than "top" (which places it at row 0).
+    assert!(
+        get("top") > get("top_relative(3)"),
+        "top (scroll_y={}) should scroll more than top_relative(3) (scroll_y={})",
+        get("top"),
+        get("top_relative(3)"),
+    );
+
+    // center_relative: negative offset places the target above center (higher scroll_y),
+    // positive offset places it below center (lower scroll_y).
+    assert!(
+        get("center_relative(-3)") > get("center_relative(3)"),
+        "center_relative(-3) (scroll_y={}) should scroll more than center_relative(3) (scroll_y={})",
+        get("center_relative(-3)"),
+        get("center_relative(3)"),
+    );
+}
+
+#[gpui::test]
 async fn test_find_all_references_editor_reuse(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
     let mut cx = EditorLspTestContext::new_rust(

--- a/crates/editor/src/scroll/autoscroll.rs
+++ b/crates/editor/src/scroll/autoscroll.rs
@@ -30,6 +30,12 @@ impl Autoscroll {
         Self::Strategy(AutoscrollStrategy::Center, None)
     }
 
+    /// Scrolls so that the newest cursor is roughly an n-th line from the center.
+    /// Negative n places cursor above center, positive n places it below center.
+    pub fn center_relative(n: isize) -> Self {
+        Self::Strategy(AutoscrollStrategy::CenterRelative(n), None)
+    }
+
     /// scrolls so the newest cursor is near the top
     /// (offset by vertical_scroll_margin)
     pub fn focused() -> Self {
@@ -83,6 +89,7 @@ pub enum AutoscrollStrategy {
     Newest,
     #[default]
     Center,
+    CenterRelative(isize),
     Focused,
     Top,
     Bottom,
@@ -238,6 +245,10 @@ impl Editor {
             }
             AutoscrollStrategy::Center => {
                 scroll_position.y = (target_top - margin).max(0.0);
+                self.set_scroll_position_internal(scroll_position, local, true, window, cx)
+            }
+            AutoscrollStrategy::CenterRelative(lines) => {
+                scroll_position.y = (target_top - margin - lines as ScrollOffset).max(0.0);
                 self.set_scroll_position_internal(scroll_position, local, true, window, cx)
             }
             AutoscrollStrategy::Focused => {

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -261,6 +261,7 @@ impl VsCodeSettings {
             fast_scroll_sensitivity: self.read_f32("editor.fastScrollSensitivity"),
             sticky_scroll: self.sticky_scroll_content(),
             go_to_definition_fallback: None,
+            go_to_definition_autoscroll: None,
             gutter: self.gutter_content(),
             hide_mouse: None,
             horizontal_scroll_margin: None,

--- a/crates/settings_content/src/editor.rs
+++ b/crates/settings_content/src/editor.rs
@@ -176,6 +176,18 @@ pub struct EditorSettingsContent {
     /// Default: FindAllReferences
     pub go_to_definition_fallback: Option<GoToDefinitionFallback>,
 
+    /// How to position the cursor when navigating to a definition.
+    ///
+    /// Can be a simple strategy: "fit", "center", "focused", "top", "bottom"
+    ///
+    /// Or an object for relative positioning:
+    /// - {"strategy": "center_relative", "offset": -10} - negative=above center, positive=below
+    /// - {"strategy": "top_relative", "offset": 5} - 5 lines from top
+    /// - {"strategy": "bottom_relative", "offset": 10} - 10 lines from bottom
+    ///
+    /// Default: "fit"
+    pub go_to_definition_autoscroll: Option<GoToDefinitionAutoscroll>,
+
     /// Jupyter REPL settings.
     pub jupyter: Option<JupyterContent>,
 
@@ -724,6 +736,58 @@ pub enum GoToDefinitionFallback {
     /// Looks up references of the same symbol instead.
     #[default]
     FindAllReferences,
+}
+
+/// Autoscroll strategy for navigating to definitions.
+///
+/// Default: "fit"
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema, MergeFrom)]
+#[serde(untagged, rename_all = "snake_case")]
+pub enum GoToDefinitionAutoscroll {
+    /// Simple strategy name: "fit", "center", "focused", "top", "bottom"
+    Simple(GoToDefinitionAutoscrollStrategy),
+    /// Strategy with numeric offset for relative positioning
+    WithOffset {
+        /// Strategy name: "center_relative", "top_relative", or "bottom_relative"
+        strategy: String,
+        /// Offset value. For center_relative: negative=above center, positive=below center.
+        /// For top_relative/bottom_relative: number of lines from top/bottom.
+        offset: isize,
+    },
+}
+
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    JsonSchema,
+    MergeFrom,
+    strum::VariantArray,
+    strum::VariantNames,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum GoToDefinitionAutoscrollStrategy {
+    /// Scroll minimally to fit the target on screen (original behavior)
+    #[default]
+    Fit,
+    /// Center the target vertically
+    Center,
+    /// Place target near the top with vertical_scroll_margin
+    Focused,
+    /// Place target at the top
+    Top,
+    /// Place target at the bottom
+    Bottom,
+}
+
+impl Default for GoToDefinitionAutoscroll {
+    fn default() -> Self {
+        Self::Simple(GoToDefinitionAutoscrollStrategy::Fit)
+    }
 }
 
 /// Determines when the mouse cursor should be hidden in an editor or input box.


### PR DESCRIPTION
When navigating to a definition (e.g., via editor::GoToDefinition or Cmd+Click), the target is now positioned according to a new configurable setting rather than always using the minimal "fit" behavior.

The new `go_to_definition_autoscroll` setting supports:
- Simple strategies: "fit", "center", "focused", "top", "bottom"
- Parameterized strategies with offsets:
  - {"strategy": "center_relative", "offset": -10} for positioning relative to center (negative=above, positive=below)
  - {"strategy": "top_relative", "offset": N} for N lines from top
  - {"strategy": "bottom_relative", "offset": N} for N lines from bottom

The default remains "fit" to preserve the original behavior.

Implementation details:
- Added AutoscrollStrategy::CenterRelative(isize) variant
- Created GoToDefinitionAutoscroll enum with Simple and WithOffset variants
- Updated go_to_singleton_buffer_range to use the setting
- Added default value and documentation to default.json

Release Notes:

- Add configurable autoscroll strategy for go to definition
