### PR TITLE
Fix agent panel sizing to be responsive to window size

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1779,12 +1779,25 @@ impl Panel for AgentPanel {
     }
 
     fn size(&self, window: &Window, cx: &App) -> Pixels {
-        let settings = AgentSettings::get_global(cx);
+        let viewport_size = window.viewport_size();
+
         match self.position(window, cx) {
             DockPosition::Left | DockPosition::Right => {
-                self.width.unwrap_or(settings.default_width)
+                if let Some(width) = self.width {
+                    width
+                } else {
+                    let percentage_width = viewport_size.width * 0.4;
+                    percentage_width.max(px(300.0)).min(px(800.0))
+                }
             }
-            DockPosition::Bottom => self.height.unwrap_or(settings.default_height),
+            DockPosition::Bottom => {
+                if let Some(height) = self.height {
+                    height
+                } else {
+                    let percentage_height = viewport_size.height * 0.3;
+                    percentage_height.max(px(200.0)).min(px(600.0))
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #48442

## Problem
The agent panel used fixed pixel sizing (640px width, 320px height), which caused it to be too large in small/floating windows while looking fine in maximized windows.

## Solution
- Changed to **percentage-based sizing**: 40% of viewport width (left/right dock), 30% of viewport height (bottom dock)
- Added **constraints**: 
  - Width: 300px min, 800px max
  - Height: 200px min, 600px max
- Preserves user's manual resize preferences

## Testing
- ✅ Tested in small floating windows (panel scales down appropriately)
- ✅ Tested in maximized windows (panel scales up but respects max limit)
- ✅ Manual resizing still works as expected

## Open Questions
**Are the sizing values appropriate?** The current values are:
- Width: 40% of viewport (clamped to 300-800px)
- Height: 30% of viewport (clamped to 200-600px)

I'm happy to adjust these percentages or constraints based on maintainer feedback and user preferences.

## Fix Recording
[Screencast from 2026-02-11 08-16-32.webm](https://github.com/user-attachments/assets/eecbce73-17fe-4518-9103-db39ffde01a1)

## Alternative Considered
Could make these values configurable via settings, but kept it simple for this initial fix. Happy to add settings in a follow-up PR if desired.