### PR TITLE
go: Add first-line pattern detection for executable Go scripts

### DIFF
--- a/crates/languages/src/go/config.toml
+++ b/crates/languages/src/go/config.toml
@@ -2,6 +2,7 @@ name = "Go"
 grammar = "go"
 path_suffixes = ["go"]
 line_comments = ["// "]
+first_line_pattern = '^//.*\bgo run\b'
 autoclose_before = ";:.,=}])>"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },


### PR DESCRIPTION
Add support for detecting Go files that can be executed directly via shebang-style comments (e.g., '// usr/bin/env go run "$0" "$@"; exit "$?"').

This allows Zed to recognize Go scripts with first-line comments containing 'go run' as executable Go files, similar to how other languages detect shebangs or mode lines.

Reference: https://stackoverflow.com/q/7707178/1458343

Release Notes:

- Improved: Go language detection now recognizes executable Go scripts with first-line 'go run' comments.
