### PR TITLE
editor: Fix documentation tooltip reappearing after editor regains focus

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -24779,7 +24779,9 @@ impl Editor {
                 }
             });
 
-            if let Some(position_map) = self.last_position_map.clone() {
+            if let Some(position_map) = self.last_position_map.clone()
+                && !self.mouse_cursor_hidden
+            {
                 EditorElement::mouse_moved(
                     self,
                     &MouseMoveEvent {


### PR DESCRIPTION
Closes #48922

When the editor regains focus, it internally triggers the mouse_moved logic again. This causes the hover documentation to be shown even if it was previously dismissed due to user editing.

This change skips mouse_moved handling when the cursor is hidden, preventing unintended tooltip popups.


[录屏 2026-02-11 19-04-14.webm](https://github.com/user-attachments/assets/ea9f9438-34bf-4771-bbc8-335e9ea59dd7)

- [x] Tests or screenshots needed?
- [x] Code Reviewed
- [x] Manual QA

Release Notes:

- Fixed documentation tooltip reappearing after editor regains focus
