### PR TITLE
agent_ui: Fix editor not getting focused when adding selections

### DIFF
--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -2335,6 +2335,7 @@ impl AcpServerView {
             active_thread.update(cx, |thread, cx| {
                 thread.message_editor.update(cx, |editor, cx| {
                     editor.insert_dragged_files(paths, added_worktrees, window, cx);
+                    editor.focus_handle(cx).focus(window, cx);
                 })
             });
         }
@@ -2469,7 +2470,7 @@ impl Render for AcpServerView {
         self.sync_queued_message_editors(window, cx);
 
         v_flex()
-            .track_focus(&self.focus_handle(cx))
+            .track_focus(&self.focus_handle)
             .size_full()
             .bg(cx.theme().colors().panel_background)
             .child(match &self.server_state {

--- a/crates/agent_ui/src/acp/thread_view/active_thread.rs
+++ b/crates/agent_ui/src/acp/thread_view/active_thread.rs
@@ -7154,7 +7154,7 @@ impl Render for AcpThreadView {
 
         v_flex()
             .key_context("AcpThread")
-            .track_focus(&self.focus_handle(cx))
+            .track_focus(&self.focus_handle)
             .on_action(cx.listener(|this, _: &menu::Cancel, _, cx| {
                 if this.parent_id.is_none() {
                     this.cancel_generation(cx);


### PR DESCRIPTION
Fixes a regression that was introduced by the thread view refactor (Nightly only).
Also fixed another minor focus issue: Dropping files into the agent panel would not focus the message editor.

- [x] Code Reviewed
- [x] Manual QA

Release Notes:

- N/A
