### PR TITLE
Fix terminal pane showing welcome screen during loading

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1446,6 +1446,7 @@ impl Workspace {
                 cx,
             );
             center_pane.set_can_split(Some(Arc::new(|_, _, _, _| true)));
+            center_pane.set_should_display_welcome_page(true);
             center_pane
         });
         cx.subscribe_in(&center_pane, window, Self::handle_pane_event)


### PR DESCRIPTION
This fixes an issue where we would show the welcome screen when opening the terminal panel.
The issue could technically occur in any panel, but was only occurred in the terminal panel since we only render some content after the `cx.spawn` inside `new_terminal_pane` completes. This caused the welcome screen to show up for a single frame. This PR fixes this by showing a blank panel instead.

Before

https://github.com/user-attachments/assets/4b805c42-5dc5-4742-b090-2f62e8839f3e

After 

https://github.com/user-attachments/assets/5da16b73-5999-461d-9057-438714d8d4ee

Screenshot from the videos:

Before

<img width="1164" height="579" alt="image" src="https://github.com/user-attachments/assets/87ba2dff-d7c0-4104-b983-31bdd21cf0f9" />

After

<img width="1537" height="803" alt="image" src="https://github.com/user-attachments/assets/359bc413-9794-4565-832d-83548b67cea5" />

- [x] Tests or screenshots needed?
- [x] Code Reviewed
- [x] Manual QA

Release Notes:

- Fixed an issue where the welcome screen would show up in the terminal panel if the terminal was slow to load
