### PR TITLE
image viewer: Support mac trackpad pinch-to-zoom

### DIFF
--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -15,6 +15,8 @@
 //! and Tailwind-like styling that you can use to build your own custom elements. Div is
 //! constructed by combining these two systems into an all-in-one element.
 
+#[cfg(target_os = "macos")]
+use crate::MagnifyEvent;
 use crate::{
     AbsoluteLength, Action, AnyDrag, AnyElement, AnyTooltip, AnyView, App, Bounds, ClickEvent,
     DispatchPhase, Display, Element, ElementId, Entity, FocusHandle, Global, GlobalElementId,
@@ -348,6 +350,23 @@ impl Interactivity {
         self.scroll_wheel_listeners
             .push(Box::new(move |event, phase, hitbox, window, cx| {
                 if phase == DispatchPhase::Bubble && hitbox.should_handle_scroll(window) {
+                    (listener)(event, window, cx);
+                }
+            }));
+    }
+
+    /// Bind the given callback to trackpad magnify (pinch-to-zoom) gesture events during the bubble phase.
+    /// The imperative API equivalent to [`InteractiveElement::on_magnify`].
+    ///
+    /// See [`Context::listener`](crate::Context::listener) to get access to a view's state from this callback.
+    #[cfg(target_os = "macos")]
+    pub fn on_magnify(
+        &mut self,
+        listener: impl Fn(&MagnifyEvent, &mut Window, &mut App) + 'static,
+    ) {
+        self.magnify_listeners
+            .push(Box::new(move |event, phase, hitbox, window, cx| {
+                if phase == DispatchPhase::Bubble && hitbox.is_hovered(window) {
                     (listener)(event, window, cx);
                 }
             }));
@@ -905,6 +924,19 @@ pub trait InteractiveElement: Sized {
         self
     }
 
+    /// Bind the given callback to trackpad magnify (pinch-to-zoom) gesture events during the bubble phase.
+    /// The fluent API equivalent to [`Interactivity::on_magnify`].
+    ///
+    /// See [`Context::listener`](crate::Context::listener) to get access to a view's state from this callback.
+    #[cfg(target_os = "macos")]
+    fn on_magnify(
+        mut self,
+        listener: impl Fn(&MagnifyEvent, &mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.interactivity().on_magnify(listener);
+        self
+    }
+
     /// Capture the given action, before normal action dispatch can fire.
     /// The fluent API equivalent to [`Interactivity::capture_action`].
     ///
@@ -1290,6 +1322,10 @@ pub(crate) type MouseMoveListener =
 pub(crate) type ScrollWheelListener =
     Box<dyn Fn(&ScrollWheelEvent, DispatchPhase, &Hitbox, &mut Window, &mut App) + 'static>;
 
+#[cfg(target_os = "macos")]
+pub(crate) type MagnifyListener =
+    Box<dyn Fn(&MagnifyEvent, DispatchPhase, &Hitbox, &mut Window, &mut App) + 'static>;
+
 pub(crate) type ClickListener = Rc<dyn Fn(&ClickEvent, &mut Window, &mut App) + 'static>;
 
 pub(crate) type DragListener =
@@ -1644,6 +1680,8 @@ pub struct Interactivity {
     pub(crate) mouse_pressure_listeners: Vec<MousePressureListener>,
     pub(crate) mouse_move_listeners: Vec<MouseMoveListener>,
     pub(crate) scroll_wheel_listeners: Vec<ScrollWheelListener>,
+    #[cfg(target_os = "macos")]
+    pub(crate) magnify_listeners: Vec<MagnifyListener>,
     pub(crate) key_down_listeners: Vec<KeyDownListener>,
     pub(crate) key_up_listeners: Vec<KeyUpListener>,
     pub(crate) modifiers_changed_listeners: Vec<ModifiersChangedListener>,
@@ -1847,6 +1885,16 @@ impl Interactivity {
             || !self.click_listeners.is_empty()
             || !self.aux_click_listeners.is_empty()
             || !self.scroll_wheel_listeners.is_empty()
+            || {
+                #[cfg(target_os = "macos")]
+                {
+                    !self.magnify_listeners.is_empty()
+                }
+                #[cfg(not(target_os = "macos"))]
+                {
+                    false
+                }
+            }
             || self.drag_listener.is_some()
             || !self.drop_listeners.is_empty()
             || self.tooltip_builder.is_some()
@@ -2209,6 +2257,14 @@ impl Interactivity {
         for listener in self.scroll_wheel_listeners.drain(..) {
             let hitbox = hitbox.clone();
             window.on_mouse_event(move |event: &ScrollWheelEvent, phase, window, cx| {
+                listener(event, phase, &hitbox, window, cx);
+            })
+        }
+
+        #[cfg(target_os = "macos")]
+        for listener in self.magnify_listeners.drain(..) {
+            let hitbox = hitbox.clone();
+            window.on_mouse_event(move |event: &MagnifyEvent, phase, window, cx| {
                 listener(event, phase, &hitbox, window, cx);
             })
         }

--- a/crates/gpui/src/interactive.rs
+++ b/crates/gpui/src/interactive.rs
@@ -452,6 +452,47 @@ impl Deref for ScrollWheelEvent {
     }
 }
 
+/// A trackpad magnify (pinch-to-zoom) gesture event from the platform.
+#[cfg(target_os = "macos")]
+#[derive(Clone, Debug, Default)]
+pub struct MagnifyEvent {
+    /// The position of the gesture on the window.
+    pub position: Point<Pixels>,
+
+    /// The incremental magnification delta.
+    /// Positive values indicate zoom in, negative values indicate zoom out.
+    /// For example, 0.02 means a 2% zoom-in increment.
+    pub magnification: f32,
+
+    /// The modifiers that were held down during the gesture.
+    pub modifiers: Modifiers,
+
+    /// The phase of the touch gesture.
+    pub touch_phase: TouchPhase,
+}
+
+#[cfg(target_os = "macos")]
+impl Sealed for MagnifyEvent {}
+
+#[cfg(target_os = "macos")]
+impl InputEvent for MagnifyEvent {
+    fn to_platform_input(self) -> PlatformInput {
+        PlatformInput::Magnify(self)
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl MouseEvent for MagnifyEvent {}
+
+#[cfg(target_os = "macos")]
+impl Deref for MagnifyEvent {
+    type Target = Modifiers;
+
+    fn deref(&self) -> &Self::Target {
+        &self.modifiers
+    }
+}
+
 /// The scroll delta for a scroll wheel event.
 #[derive(Clone, Copy, Debug)]
 pub enum ScrollDelta {
@@ -628,6 +669,9 @@ pub enum PlatformInput {
     ScrollWheel(ScrollWheelEvent),
     /// Files were dragged and dropped onto the window.
     FileDrop(FileDropEvent),
+    /// A trackpad magnify (pinch-to-zoom) gesture.
+    #[cfg(target_os = "macos")]
+    Magnify(MagnifyEvent),
 }
 
 impl PlatformInput {
@@ -643,6 +687,8 @@ impl PlatformInput {
             PlatformInput::MouseExited(event) => Some(event),
             PlatformInput::ScrollWheel(event) => Some(event),
             PlatformInput::FileDrop(event) => Some(event),
+            #[cfg(target_os = "macos")]
+            PlatformInput::Magnify(event) => Some(event),
         }
     }
 
@@ -658,6 +704,8 @@ impl PlatformInput {
             PlatformInput::MouseExited(_) => None,
             PlatformInput::ScrollWheel(_) => None,
             PlatformInput::FileDrop(_) => None,
+            #[cfg(target_os = "macos")]
+            PlatformInput::Magnify(_) => None,
         }
     }
 }

--- a/crates/gpui/src/platform/mac/events.rs
+++ b/crates/gpui/src/platform/mac/events.rs
@@ -1,6 +1,6 @@
 use crate::{
-    Capslock, KeyDownEvent, KeyUpEvent, Keystroke, Modifiers, ModifiersChangedEvent, MouseButton,
-    MouseDownEvent, MouseExitEvent, MouseMoveEvent, MousePressureEvent, MouseUpEvent,
+    Capslock, KeyDownEvent, KeyUpEvent, Keystroke, MagnifyEvent, Modifiers, ModifiersChangedEvent,
+    MouseButton, MouseDownEvent, MouseExitEvent, MouseMoveEvent, MousePressureEvent, MouseUpEvent,
     NavigationDirection, Pixels, PlatformInput, PressureStage, ScrollDelta, ScrollWheelEvent,
     TouchPhase,
     platform::mac::{
@@ -308,6 +308,25 @@ impl PlatformInput {
 
                         pressed_button: None,
                         modifiers: read_modifiers(native_event),
+                    })
+                }),
+                NSEventType::NSEventTypeMagnify => window_height.map(|window_height| {
+                    let phase = match native_event.phase() {
+                        NSEventPhase::NSEventPhaseMayBegin | NSEventPhase::NSEventPhaseBegan => {
+                            TouchPhase::Started
+                        }
+                        NSEventPhase::NSEventPhaseEnded => TouchPhase::Ended,
+                        _ => TouchPhase::Moved,
+                    };
+
+                    Self::Magnify(MagnifyEvent {
+                        position: point(
+                            px(native_event.locationInWindow().x as f32),
+                            window_height - px(native_event.locationInWindow().y as f32),
+                        ),
+                        magnification: native_event.magnification() as f32,
+                        modifiers: read_modifiers(native_event),
+                        touch_phase: phase,
                     })
                 }),
                 _ => None,

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -182,6 +182,10 @@ unsafe fn build_classes() {
                     handle_view_event as extern "C" fn(&Object, Sel, id),
                 );
                 decl.add_method(
+                    sel!(magnifyWithEvent:),
+                    handle_view_event as extern "C" fn(&Object, Sel, id),
+                );
+                decl.add_method(
                     sel!(flagsChanged:),
                     handle_view_event as extern "C" fn(&Object, Sel, id),
                 );

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -3927,6 +3927,12 @@ impl Window {
                 self.modifiers = scroll_wheel.modifiers;
                 PlatformInput::ScrollWheel(scroll_wheel)
             }
+            #[cfg(target_os = "macos")]
+            PlatformInput::Magnify(magnify) => {
+                self.mouse_position = magnify.position;
+                self.modifiers = magnify.modifiers;
+                PlatformInput::Magnify(magnify)
+            }
             // Translate dragging and dropping of external files from the operating system
             // to internal drag and drop events.
             PlatformInput::FileDrop(file_drop) => match file_drop {

--- a/crates/image_viewer/src/image_viewer.rs
+++ b/crates/image_viewer/src/image_viewer.rs
@@ -6,6 +6,8 @@ use std::path::Path;
 use anyhow::Context as _;
 use editor::{EditorSettings, items::entry_git_aware_label_color};
 use file_icons::FileIcons;
+#[cfg(target_os = "macos")]
+use gpui::MagnifyEvent;
 use gpui::{
     AnyElement, App, Bounds, Context, DispatchPhase, Element, ElementId, Entity, EventEmitter,
     FocusHandle, Focusable, GlobalElementId, InspectorElementId, InteractiveElement, IntoElement,
@@ -221,6 +223,17 @@ impl ImageView {
             self.pan_offset += delta;
             cx.notify();
         }
+    }
+
+    #[cfg(target_os = "macos")]
+    fn handle_magnify(
+        &mut self,
+        event: &MagnifyEvent,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let zoom_factor = 1.0 + event.magnification;
+        self.set_zoom(self.zoom_level * zoom_factor, Some(event.position), cx);
     }
 
     fn handle_mouse_down(
@@ -704,6 +717,30 @@ impl Focusable for ImageView {
 
 impl Render for ImageView {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let mut image_container = div()
+            .id("image-container")
+            .size_full()
+            .overflow_hidden()
+            .cursor(if self.is_dragging() {
+                gpui::CursorStyle::ClosedHand
+            } else {
+                gpui::CursorStyle::OpenHand
+            })
+            .on_scroll_wheel(cx.listener(Self::handle_scroll_wheel));
+
+        #[cfg(target_os = "macos")]
+        {
+            image_container = image_container.on_magnify(cx.listener(Self::handle_magnify));
+        }
+
+        image_container = image_container
+            .on_mouse_down(MouseButton::Left, cx.listener(Self::handle_mouse_down))
+            .on_mouse_down(MouseButton::Middle, cx.listener(Self::handle_mouse_down))
+            .on_mouse_up(MouseButton::Left, cx.listener(Self::handle_mouse_up))
+            .on_mouse_up(MouseButton::Middle, cx.listener(Self::handle_mouse_up))
+            .on_mouse_move(cx.listener(Self::handle_mouse_move))
+            .child(ImageContentElement::new(cx.entity()));
+
         div()
             .track_focus(&self.focus_handle(cx))
             .key_context("ImageViewer")
@@ -715,24 +752,7 @@ impl Render for ImageView {
             .size_full()
             .relative()
             .bg(cx.theme().colors().editor_background)
-            .child(
-                div()
-                    .id("image-container")
-                    .size_full()
-                    .overflow_hidden()
-                    .cursor(if self.is_dragging() {
-                        gpui::CursorStyle::ClosedHand
-                    } else {
-                        gpui::CursorStyle::OpenHand
-                    })
-                    .on_scroll_wheel(cx.listener(Self::handle_scroll_wheel))
-                    .on_mouse_down(MouseButton::Left, cx.listener(Self::handle_mouse_down))
-                    .on_mouse_down(MouseButton::Middle, cx.listener(Self::handle_mouse_down))
-                    .on_mouse_up(MouseButton::Left, cx.listener(Self::handle_mouse_up))
-                    .on_mouse_up(MouseButton::Middle, cx.listener(Self::handle_mouse_up))
-                    .on_mouse_move(cx.listener(Self::handle_mouse_move))
-                    .child(ImageContentElement::new(cx.entity())),
-            )
+            .child(image_container)
     }
 }
 


### PR DESCRIPTION
On macOS, the image viewer will now react to [NSEventTypeMagnify](https://developer.apple.com/documentation/appkit/nsevent/eventtype/magnify), enabling pinch-to-zoom when using a trackpad. 

This already works on Windows because it simulates scroll wheel events while holding <kbd>Ctrl</kbd> which we already listen to for mouse zooming. Linux will also do this depending on configuration.

Release Notes:

- Add support for pinch-to-zoom when using the image viewer on macOS