### PR TITLE
multiagent: Fix workspace switcher button on linux/windows

### DIFF
--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -1011,6 +1011,7 @@ impl Render for Sidebar {
                     .when(cfg!(target_os = "macos"), |this| {
                         this.pl(px(TRAFFIC_LIGHT_PADDING))
                     })
+                    .when(cfg!(not(target_os = "macos")), |this| this.pl_2())
                     .justify_between()
                     .border_b_1()
                     .border_color(cx.theme().colors().border)

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -185,6 +185,7 @@ impl Render for TitleBar {
                     let mut render_project_items = title_bar_settings.show_branch_name
                         || title_bar_settings.show_project_items;
                     title_bar
+                        .children(self.render_workspace_sidebar_toggle(window, cx))
                         .when_some(
                             self.application_menu.clone().filter(|_| !show_menus),
                             |title_bar, menu| {
@@ -193,7 +194,6 @@ impl Render for TitleBar {
                                 title_bar.child(menu)
                             },
                         )
-                        .children(self.render_workspace_sidebar_toggle(window, cx))
                         .children(self.render_restricted_mode(cx))
                         .when(render_project_items, |title_bar| {
                             title_bar


### PR DESCRIPTION
The workspace switcher button previously would be rendered after the application menu, and without padding. Now it isn't.

Release Notes:

- N/A
