### PR TITLE
Fix assistant commands visibility when agent is disabled

### DIFF
--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -377,12 +377,12 @@ fn update_command_palette_filter(cx: &mut App) {
             if agent_enabled {
                 filter.show_namespace("agent");
                 filter.show_namespace("agents");
+                filter.show_namespace("assistant");
             } else {
                 filter.hide_namespace("agent");
                 filter.hide_namespace("agents");
+                filter.hide_namespace("assistant");
             }
-
-            filter.show_namespace("assistant");
 
             match edit_prediction_provider {
                 EditPredictionProvider::None => {
@@ -582,6 +582,10 @@ mod tests {
                 !filter.is_hidden(&NewThread),
                 "NewThread should be visible by default"
             );
+            assert!(
+                !filter.is_hidden(&text_thread_editor::CopyCode),
+                "CopyCode should be visible when agent is enabled"
+            );
         });
 
         // Disable agent
@@ -600,6 +604,10 @@ mod tests {
             assert!(
                 filter.is_hidden(&NewThread),
                 "NewThread should be hidden when agent is disabled"
+            );
+            assert!(
+                filter.is_hidden(&text_thread_editor::CopyCode),
+                "CopyCode should be hidden when agent is disabled"
             );
         });
 


### PR DESCRIPTION
## Changes
- Hide `assistant` namespace when `agent.enabled = false`
- Added test coverage for assistant command visibility

## Testing
- Verified manually that commands are hidden/shown dynamically
- Added test assertions in [test_agent_command_palette_visibility](cci:1://file:///media/omchillure/Projects/zed-oss/zed/crates/agent_ui/src/agent_ui.rs:525:4-657:5)
- Test passes: `cargo test -p agent_ui test_agent_command_palette_visibility`

## Video : 
[Screencast from 2026-02-11 21-01-30.webm](https://github.com/user-attachments/assets/bbdb3e44-4ba9-4def-ad05-74e412bc5dba)

Closes #48713.

Release Notes:

- Fixed assistant commands (Copy Code, Insert Into Editor, etc.) remaining visible in the command palette when the agent is disabled in settings.
