### PR TITLE
git: Disable some more expensive things for the split diff's left-hand side

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1179,6 +1179,8 @@ pub struct Editor {
     delegate_expand_excerpts: bool,
     delegate_stage_and_restore: bool,
     delegate_open_excerpts: bool,
+    enable_lsp_data: bool,
+    enable_runnables: bool,
     show_line_numbers: Option<bool>,
     use_relative_line_numbers: Option<bool>,
     show_git_diff_gutter: Option<bool>,
@@ -2409,6 +2411,8 @@ impl Editor {
             delegate_expand_excerpts: false,
             delegate_stage_and_restore: false,
             delegate_open_excerpts: false,
+            enable_lsp_data: true,
+            enable_runnables: true,
             show_git_diff_gutter: None,
             show_code_actions: None,
             show_runnables: None,
@@ -16905,7 +16909,7 @@ impl Editor {
     }
 
     fn refresh_runnables(&mut self, window: &mut Window, cx: &mut Context<Self>) -> Task<()> {
-        if !EditorSettings::get_global(cx).gutter.runnables {
+        if !EditorSettings::get_global(cx).gutter.runnables || !self.enable_runnables {
             self.clear_tasks();
             return Task::ready(());
         }
@@ -25216,6 +25220,10 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<'_, Self>,
     ) {
+        if !self.enable_lsp_data {
+            return;
+        }
+
         if let Some(buffer_id) = for_buffer {
             self.pull_diagnostics(buffer_id, window, cx);
             self.update_semantic_tokens(Some(buffer_id), None, cx);
@@ -25349,6 +25357,14 @@ impl Editor {
             font: Some(settings.buffer_font.clone()),
         }));
         Some(breadcrumbs)
+    }
+
+    fn disable_lsp_data(&mut self) {
+        self.enable_lsp_data = false;
+    }
+
+    fn disable_runnables(&mut self) {
+        self.enable_runnables = false;
     }
 }
 

--- a/crates/editor/src/split.rs
+++ b/crates/editor/src/split.rs
@@ -528,6 +528,7 @@ impl SplittableEditor {
             editor.set_show_vertical_scrollbar(false, cx);
             editor.disable_lsp_data();
             editor.disable_runnables();
+            editor.disable_diagnostics(cx);
             editor.set_minimap_visibility(crate::MinimapVisibility::Disabled, window, cx);
             editor
         });

--- a/crates/editor/src/split.rs
+++ b/crates/editor/src/split.rs
@@ -526,6 +526,8 @@ impl SplittableEditor {
             editor.set_delegate_stage_and_restore(true);
             editor.set_delegate_open_excerpts(true);
             editor.set_show_vertical_scrollbar(false, cx);
+            editor.disable_lsp_data();
+            editor.disable_runnables();
             editor.set_minimap_visibility(crate::MinimapVisibility::Disabled, window, cx);
             editor
         });

--- a/crates/git_ui/src/conflict_view.rs
+++ b/crates/git_ui/src/conflict_view.rs
@@ -47,6 +47,7 @@ pub fn register_editor(editor: &mut Editor, buffer: Entity<MultiBuffer>, cx: &mu
     if !editor.mode().is_full()
         || (!editor.buffer().read(cx).is_singleton()
             && !editor.buffer().read(cx).all_diff_hunks_expanded())
+        || editor.read_only(cx)
     {
         return;
     }


### PR DESCRIPTION
- Conflict UI
- LSP data
- Runnables

Release Notes:

- Improved performance when opening the split diff view.