### PR TITLE
Fix error when loading ACP registry

### DIFF
--- a/crates/project/src/agent_registry_store.rs
+++ b/crates/project/src/agent_registry_store.rs
@@ -536,8 +536,6 @@ struct RegistryIndex {
     #[serde(rename = "version")]
     _version: String,
     agents: Vec<RegistryEntry>,
-    #[serde(rename = "extensions")]
-    _extensions: Vec<RegistryEntry>,
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
This [change](https://github.com/agentclientprotocol/registry/pull/34) broke the ACP registry in Zed, since we did not have `#[serde(default)]` on the `_extensions`  field. 

- [x] Tests or screenshots needed?
- [x] Code Reviewed
- [x] Manual QA

Release Notes:

- Fixed an issue where the ACP registry would fail to load
