### PR TITLE
settings: Disable debug-embed feature on rust-embed crate

### DIFF
--- a/crates/settings/Cargo.toml
+++ b/crates/settings/Cargo.toml
@@ -27,7 +27,7 @@ log.workspace = true
 migrator.workspace = true
 paths.workspace = true
 release_channel.workspace = true
-rust-embed = { workspace = true, features = ["debug-embed"] }
+rust-embed.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION
Danilo reported not seeing  the new icons after a rebuild, and this should hopefully remedy that

- [x] Tests or screenshots needed?
- [ ] Code Reviewed
- [x] Manual QA

Release Notes:

- N/A
