### PR TITLE
editor: Fix removing indentation while converting selected lines

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -12442,11 +12442,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.manipulate_text(window, cx, |text| {
-            text.split('\n')
-                .map(|line| line.to_case(Case::Title))
-                .join("\n")
-        })
+        self.manipulate_text(window, cx, |text| Self::convert_text(text, Case::Title))
     }
 
     pub fn convert_to_snake_case(
@@ -12455,7 +12451,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.manipulate_text(window, cx, |text| text.to_case(Case::Snake))
+        self.manipulate_text(window, cx, |text| Self::convert_text(text, Case::Snake))
     }
 
     pub fn convert_to_kebab_case(
@@ -12464,7 +12460,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.manipulate_text(window, cx, |text| text.to_case(Case::Kebab))
+        self.manipulate_text(window, cx, |text| Self::convert_text(text, Case::Kebab))
     }
 
     pub fn convert_to_upper_camel_case(
@@ -12474,9 +12470,7 @@ impl Editor {
         cx: &mut Context<Self>,
     ) {
         self.manipulate_text(window, cx, |text| {
-            text.split('\n')
-                .map(|line| line.to_case(Case::UpperCamel))
-                .join("\n")
+            Self::convert_text(text, Case::UpperCamel)
         })
     }
 
@@ -12486,7 +12480,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.manipulate_text(window, cx, |text| text.to_case(Case::Camel))
+        self.manipulate_text(window, cx, |text| Self::convert_text(text, Case::Camel))
     }
 
     pub fn convert_to_opposite_case(
@@ -12514,7 +12508,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.manipulate_text(window, cx, |text| text.to_case(Case::Sentence))
+        self.manipulate_text(window, cx, |text| Self::convert_text(text, Case::Sentence))
     }
 
     pub fn toggle_case(&mut self, _: &ToggleCase, window: &mut Window, cx: &mut Context<Self>) {
@@ -12562,6 +12556,16 @@ impl Editor {
                 })
                 .collect()
         })
+    }
+
+    fn convert_text(text: &str, case: Case) -> String {
+        text.split('\n')
+            .map(|line| {
+                let indent_len = line.len() - line.trim_start().len();
+                let (indent, code) = line.split_at(indent_len);
+                format!("{}{}", indent, code.to_case(case))
+            })
+            .join("\n")
     }
 
     fn manipulate_text<Fn>(&mut self, window: &mut Window, cx: &mut Context<Self>, mut callback: Fn)

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -12442,7 +12442,9 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.manipulate_text(window, cx, |text| Self::convert_text(text, Case::Title))
+        self.manipulate_text(window, cx, |text| {
+            Self::convert_text_case(text, Case::Title)
+        })
     }
 
     pub fn convert_to_snake_case(
@@ -12451,7 +12453,9 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.manipulate_text(window, cx, |text| Self::convert_text(text, Case::Snake))
+        self.manipulate_text(window, cx, |text| {
+            Self::convert_text_case(text, Case::Snake)
+        })
     }
 
     pub fn convert_to_kebab_case(
@@ -12460,7 +12464,9 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.manipulate_text(window, cx, |text| Self::convert_text(text, Case::Kebab))
+        self.manipulate_text(window, cx, |text| {
+            Self::convert_text_case(text, Case::Kebab)
+        })
     }
 
     pub fn convert_to_upper_camel_case(
@@ -12470,7 +12476,7 @@ impl Editor {
         cx: &mut Context<Self>,
     ) {
         self.manipulate_text(window, cx, |text| {
-            Self::convert_text(text, Case::UpperCamel)
+            Self::convert_text_case(text, Case::UpperCamel)
         })
     }
 
@@ -12480,7 +12486,9 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.manipulate_text(window, cx, |text| Self::convert_text(text, Case::Camel))
+        self.manipulate_text(window, cx, |text| {
+            Self::convert_text_case(text, Case::Camel)
+        })
     }
 
     pub fn convert_to_opposite_case(
@@ -12508,7 +12516,9 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.manipulate_text(window, cx, |text| Self::convert_text(text, Case::Sentence))
+        self.manipulate_text(window, cx, |text| {
+            Self::convert_text_case(text, Case::Sentence)
+        })
     }
 
     pub fn toggle_case(&mut self, _: &ToggleCase, window: &mut Window, cx: &mut Context<Self>) {
@@ -12558,7 +12568,7 @@ impl Editor {
         })
     }
 
-    fn convert_text(text: &str, case: Case) -> String {
+    fn convert_text_case(text: &str, case: Case) -> String {
         text.split('\n')
             .map(|line| {
                 let indent_len = line.len() - line.trim_start().len();

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -5616,6 +5616,199 @@ async fn test_convert_to_sentence_case(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_convert_to_functions_maintain_indentation(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+    
+    // Test convert_to_upper_case()
+    cx.set_state(indoc! {"
+        «   hello worldˇ»
+    "});
+    cx.update_editor(|e, window, cx| e.convert_to_upper_case(&ConvertToUpperCase, window, cx));
+    cx.assert_editor_state(indoc! {"
+        «   HELLO WORLDˇ»
+    "});
+    
+    // Test convert_to_lower_case()
+    cx.set_state(indoc! {"
+        «   HELLO WORLDˇ»
+    "});
+    cx.update_editor(|e, window, cx| e.convert_to_lower_case(&ConvertToLowerCase, window, cx));
+    cx.assert_editor_state(indoc! {"
+        «   hello worldˇ»
+    "});
+    
+    // Test convert_to_title_case()
+    cx.set_state(indoc! {"
+        «   hello worldˇ»
+    "});
+    cx.update_editor(|e, window, cx| e.convert_to_title_case(&ConvertToTitleCase, window, cx));
+    cx.assert_editor_state(indoc! {"
+        «   Hello Worldˇ»
+    "});
+    
+    // Test convert_to_snake_case()
+    cx.set_state(indoc! {"
+        «   hello worldˇ»
+    "});
+    cx.update_editor(|e, window, cx| e.convert_to_snake_case(&ConvertToSnakeCase, window, cx));
+    cx.assert_editor_state(indoc! {"
+        «   hello_worldˇ»
+    "});
+    
+    // Test convert_to_kebab_case()
+    cx.set_state(indoc! {"
+        «   hello worldˇ»
+    "});
+    cx.update_editor(|e, window, cx| e.convert_to_kebab_case(&ConvertToKebabCase, window, cx));
+    cx.assert_editor_state(indoc! {"
+        «   hello-worldˇ»
+    "});
+    
+    // Test convert_to_upper_camel_case()
+    cx.set_state(indoc! {"
+        «   hello worldˇ»
+    "});
+    cx.update_editor(|e, window, cx| e.convert_to_upper_camel_case(&ConvertToUpperCamelCase, window, cx));
+    cx.assert_editor_state(indoc! {"
+        «   HelloWorldˇ»
+    "});
+    
+    // Test convert_to_lower_camel_case()
+    cx.set_state(indoc! {"
+        «   hello worldˇ»
+    "});
+    cx.update_editor(|e, window, cx| e.convert_to_lower_camel_case(&ConvertToLowerCamelCase, window, cx));
+    cx.assert_editor_state(indoc! {"
+        «   helloWorldˇ»
+    "});
+    
+    // Test convert_to_sentence_case()
+    cx.set_state(indoc! {"
+        «   hello worldˇ»
+    "});
+    cx.update_editor(|e, window, cx| e.convert_to_sentence_case(&ConvertToSentenceCase, window, cx));
+    cx.assert_editor_state(indoc! {"
+        «   Hello worldˇ»
+    "});
+    
+    // Test convert_to_opposite_case()
+    cx.set_state(indoc! {"
+        «   hello worldˇ»
+    "});
+    cx.update_editor(|e, window, cx| e.convert_to_opposite_case(&ConvertToOppositeCase, window, cx));
+    cx.assert_editor_state(indoc! {"
+        «   HELLO WORLDˇ»
+    "});
+}
+
+
+#[gpui::test]
+async fn test_convert_to_functions_maintain_indentation_on_multiple_lines(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+    
+    // Test convert_to_upper_case()
+    cx.set_state(indoc! {"
+        «   hello world
+                nested blockˇ»
+    "});
+    cx.update_editor(|e, window, cx| e.convert_to_upper_case(&ConvertToUpperCase, window, cx));
+    cx.assert_editor_state(indoc! {"
+        «   HELLO WORLD
+                NESTED BLOCKˇ»
+    "});
+    
+    // Test convert_to_lower_case()
+    cx.set_state(indoc! {"
+        «   HELLO WORLDˇ»
+    "});
+    cx.update_editor(|e, window, cx| e.convert_to_lower_case(&ConvertToLowerCase, window, cx));
+    cx.assert_editor_state(indoc! {"
+        «   hello worldˇ»
+    "});
+    
+    // Test convert_to_title_case()
+    cx.set_state(indoc! {"
+        «   hello world
+                nested blockˇ»
+    "});
+    cx.update_editor(|e, window, cx| e.convert_to_title_case(&ConvertToTitleCase, window, cx));
+    cx.assert_editor_state(indoc! {"
+        «   Hello World
+                Nested Blockˇ»
+    "});
+    
+    // Test convert_to_snake_case()
+    cx.set_state(indoc! {"
+        «   hello world
+                nested blockˇ»
+    "});
+    cx.update_editor(|e, window, cx| e.convert_to_snake_case(&ConvertToSnakeCase, window, cx));
+    cx.assert_editor_state(indoc! {"
+        «   hello_world
+                nested_blockˇ»
+    "});
+    
+    // Test convert_to_kebab_case()
+    cx.set_state(indoc! {"
+        «   hello world
+                nested blockˇ»
+    "});
+    cx.update_editor(|e, window, cx| e.convert_to_kebab_case(&ConvertToKebabCase, window, cx));
+    cx.assert_editor_state(indoc! {"
+        «   hello-world
+                nested-blockˇ»
+    "});
+    
+    // Test convert_to_upper_camel_case()
+    cx.set_state(indoc! {"
+        «   hello world
+                nested blockˇ»
+    "});
+    cx.update_editor(|e, window, cx| e.convert_to_upper_camel_case(&ConvertToUpperCamelCase, window, cx));
+    cx.assert_editor_state(indoc! {"
+        «   HelloWorld
+                NestedBlockˇ»
+    "});
+    
+    // Test convert_to_lower_camel_case()
+    cx.set_state(indoc! {"
+        «   hello world
+                nested blockˇ»
+    "});
+    cx.update_editor(|e, window, cx| e.convert_to_lower_camel_case(&ConvertToLowerCamelCase, window, cx));
+    cx.assert_editor_state(indoc! {"
+        «   helloWorld
+                nestedBlockˇ»
+    "});
+    
+    // Test convert_to_sentence_case()
+    cx.set_state(indoc! {"
+        «   hello world
+                nested blockˇ»
+    "});
+    cx.update_editor(|e, window, cx| e.convert_to_sentence_case(&ConvertToSentenceCase, window, cx));
+    cx.assert_editor_state(indoc! {"
+        «   Hello world
+                Nested blockˇ»
+    "});
+    
+    // Test convert_to_opposite_case()
+    cx.set_state(indoc! {"
+        «   hello world
+                nested blockˇ»
+    "});
+    cx.update_editor(|e, window, cx| e.convert_to_opposite_case(&ConvertToOppositeCase, window, cx));
+    cx.assert_editor_state(indoc! {"
+        «   HELLO WORLD
+                NESTED BLOCKˇ»
+    "});
+}
+
+#[gpui::test]
 async fn test_manipulate_text(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -5620,7 +5620,7 @@ async fn test_convert_to_functions_maintain_indentation(cx: &mut TestAppContext)
     init_test(cx, |_| {});
 
     let mut cx = EditorTestContext::new(cx).await;
-    
+
     // Test convert_to_upper_case()
     cx.set_state(indoc! {"
         «   hello worldˇ»
@@ -5629,7 +5629,7 @@ async fn test_convert_to_functions_maintain_indentation(cx: &mut TestAppContext)
     cx.assert_editor_state(indoc! {"
         «   HELLO WORLDˇ»
     "});
-    
+
     // Test convert_to_lower_case()
     cx.set_state(indoc! {"
         «   HELLO WORLDˇ»
@@ -5638,7 +5638,7 @@ async fn test_convert_to_functions_maintain_indentation(cx: &mut TestAppContext)
     cx.assert_editor_state(indoc! {"
         «   hello worldˇ»
     "});
-    
+
     // Test convert_to_title_case()
     cx.set_state(indoc! {"
         «   hello worldˇ»
@@ -5647,7 +5647,7 @@ async fn test_convert_to_functions_maintain_indentation(cx: &mut TestAppContext)
     cx.assert_editor_state(indoc! {"
         «   Hello Worldˇ»
     "});
-    
+
     // Test convert_to_snake_case()
     cx.set_state(indoc! {"
         «   hello worldˇ»
@@ -5656,7 +5656,7 @@ async fn test_convert_to_functions_maintain_indentation(cx: &mut TestAppContext)
     cx.assert_editor_state(indoc! {"
         «   hello_worldˇ»
     "});
-    
+
     // Test convert_to_kebab_case()
     cx.set_state(indoc! {"
         «   hello worldˇ»
@@ -5665,51 +5665,58 @@ async fn test_convert_to_functions_maintain_indentation(cx: &mut TestAppContext)
     cx.assert_editor_state(indoc! {"
         «   hello-worldˇ»
     "});
-    
+
     // Test convert_to_upper_camel_case()
     cx.set_state(indoc! {"
         «   hello worldˇ»
     "});
-    cx.update_editor(|e, window, cx| e.convert_to_upper_camel_case(&ConvertToUpperCamelCase, window, cx));
+    cx.update_editor(|e, window, cx| {
+        e.convert_to_upper_camel_case(&ConvertToUpperCamelCase, window, cx)
+    });
     cx.assert_editor_state(indoc! {"
         «   HelloWorldˇ»
     "});
-    
+
     // Test convert_to_lower_camel_case()
     cx.set_state(indoc! {"
         «   hello worldˇ»
     "});
-    cx.update_editor(|e, window, cx| e.convert_to_lower_camel_case(&ConvertToLowerCamelCase, window, cx));
+    cx.update_editor(|e, window, cx| {
+        e.convert_to_lower_camel_case(&ConvertToLowerCamelCase, window, cx)
+    });
     cx.assert_editor_state(indoc! {"
         «   helloWorldˇ»
     "});
-    
+
     // Test convert_to_sentence_case()
     cx.set_state(indoc! {"
         «   hello worldˇ»
     "});
-    cx.update_editor(|e, window, cx| e.convert_to_sentence_case(&ConvertToSentenceCase, window, cx));
+    cx.update_editor(|e, window, cx| {
+        e.convert_to_sentence_case(&ConvertToSentenceCase, window, cx)
+    });
     cx.assert_editor_state(indoc! {"
         «   Hello worldˇ»
     "});
-    
+
     // Test convert_to_opposite_case()
     cx.set_state(indoc! {"
         «   hello worldˇ»
     "});
-    cx.update_editor(|e, window, cx| e.convert_to_opposite_case(&ConvertToOppositeCase, window, cx));
+    cx.update_editor(|e, window, cx| {
+        e.convert_to_opposite_case(&ConvertToOppositeCase, window, cx)
+    });
     cx.assert_editor_state(indoc! {"
         «   HELLO WORLDˇ»
     "});
 }
-
 
 #[gpui::test]
 async fn test_convert_to_functions_maintain_indentation_on_multiple_lines(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 
     let mut cx = EditorTestContext::new(cx).await;
-    
+
     // Test convert_to_upper_case()
     cx.set_state(indoc! {"
         «   hello world
@@ -5720,7 +5727,7 @@ async fn test_convert_to_functions_maintain_indentation_on_multiple_lines(cx: &m
         «   HELLO WORLD
                 NESTED BLOCKˇ»
     "});
-    
+
     // Test convert_to_lower_case()
     cx.set_state(indoc! {"
         «   HELLO WORLDˇ»
@@ -5729,7 +5736,7 @@ async fn test_convert_to_functions_maintain_indentation_on_multiple_lines(cx: &m
     cx.assert_editor_state(indoc! {"
         «   hello worldˇ»
     "});
-    
+
     // Test convert_to_title_case()
     cx.set_state(indoc! {"
         «   hello world
@@ -5740,7 +5747,7 @@ async fn test_convert_to_functions_maintain_indentation_on_multiple_lines(cx: &m
         «   Hello World
                 Nested Blockˇ»
     "});
-    
+
     // Test convert_to_snake_case()
     cx.set_state(indoc! {"
         «   hello world
@@ -5751,7 +5758,7 @@ async fn test_convert_to_functions_maintain_indentation_on_multiple_lines(cx: &m
         «   hello_world
                 nested_blockˇ»
     "});
-    
+
     // Test convert_to_kebab_case()
     cx.set_state(indoc! {"
         «   hello world
@@ -5762,46 +5769,54 @@ async fn test_convert_to_functions_maintain_indentation_on_multiple_lines(cx: &m
         «   hello-world
                 nested-blockˇ»
     "});
-    
+
     // Test convert_to_upper_camel_case()
     cx.set_state(indoc! {"
         «   hello world
                 nested blockˇ»
     "});
-    cx.update_editor(|e, window, cx| e.convert_to_upper_camel_case(&ConvertToUpperCamelCase, window, cx));
+    cx.update_editor(|e, window, cx| {
+        e.convert_to_upper_camel_case(&ConvertToUpperCamelCase, window, cx)
+    });
     cx.assert_editor_state(indoc! {"
         «   HelloWorld
                 NestedBlockˇ»
     "});
-    
+
     // Test convert_to_lower_camel_case()
     cx.set_state(indoc! {"
         «   hello world
                 nested blockˇ»
     "});
-    cx.update_editor(|e, window, cx| e.convert_to_lower_camel_case(&ConvertToLowerCamelCase, window, cx));
+    cx.update_editor(|e, window, cx| {
+        e.convert_to_lower_camel_case(&ConvertToLowerCamelCase, window, cx)
+    });
     cx.assert_editor_state(indoc! {"
         «   helloWorld
                 nestedBlockˇ»
     "});
-    
+
     // Test convert_to_sentence_case()
     cx.set_state(indoc! {"
         «   hello world
                 nested blockˇ»
     "});
-    cx.update_editor(|e, window, cx| e.convert_to_sentence_case(&ConvertToSentenceCase, window, cx));
+    cx.update_editor(|e, window, cx| {
+        e.convert_to_sentence_case(&ConvertToSentenceCase, window, cx)
+    });
     cx.assert_editor_state(indoc! {"
         «   Hello world
                 Nested blockˇ»
     "});
-    
+
     // Test convert_to_opposite_case()
     cx.set_state(indoc! {"
         «   hello world
                 nested blockˇ»
     "});
-    cx.update_editor(|e, window, cx| e.convert_to_opposite_case(&ConvertToOppositeCase, window, cx));
+    cx.update_editor(|e, window, cx| {
+        e.convert_to_opposite_case(&ConvertToOppositeCase, window, cx)
+    });
     cx.assert_editor_state(indoc! {"
         «   HELLO WORLD
                 NESTED BLOCKˇ»


### PR DESCRIPTION
Closes #48945 

Release Notes:

- Fixed removing line indentations when formatting the lines with:
     - `editor: convert to title case` 
     - `editor: convert to lower camel case`
     - `editor: convert to upper camel case`

As well as the commands:
  -  `editor: convert to kebab case`
  -  `editor: convert to sentence case`
  - `editor: convert to snake case`
