### PR TITLE
lsp: Ensure all language servers registered go to `all_lsp_adapters`

### DIFF
--- a/crates/language/src/language_registry.rs
+++ b/crates/language/src/language_registry.rs
@@ -391,6 +391,8 @@ impl LanguageRegistry {
             return;
         }
 
+        let cached = CachedLspAdapter::new(adapter.clone());
+        state.all_lsp_adapters.insert(cached.name.clone(), cached);
         state.available_lsp_adapters.insert(
             name,
             Arc::new(move || CachedLspAdapter::new(adapter.clone())),


### PR DESCRIPTION
Closes #46556

Release Notes:

- Fixed settings schema not recognizing `ty`, `pyright`, and `pylsp` language servers as valid properties in `settings.json`.