### PR TITLE
Use document symbols' ranges to derive their outline labels

### DIFF
--- a/crates/collab/tests/integration/editor_tests.rs
+++ b/crates/collab/tests/integration/editor_tests.rs
@@ -5639,7 +5639,7 @@ async fn test_document_symbols(cx_a: &mut TestAppContext, cx_b: &mut TestAppCont
         let texts: Vec<_> = breadcrumbs.iter().map(|b| b.text.as_str()).collect();
         assert_eq!(
             texts,
-            vec!["main.rs", "Foo"],
+            vec!["main.rs", "struct Foo"],
             "Host should see file path and LSP symbol 'Foo' in breadcrumbs"
         );
     });
@@ -5665,13 +5665,14 @@ async fn test_document_symbols(cx_a: &mut TestAppContext, cx_b: &mut TestAppCont
     executor.run_until_parked();
 
     editor_b.update(cx_b, |editor, cx| {
-        let breadcrumbs = editor
-            .breadcrumbs(cx)
-            .expect("Client B should have breadcrumbs");
-        let texts: Vec<_> = breadcrumbs.iter().map(|b| b.text.as_str()).collect();
         assert_eq!(
-            texts,
-            vec!["main.rs", "Foo"],
+            editor
+                .breadcrumbs(cx)
+                .expect("Client B should have breadcrumbs")
+                .iter()
+                .map(|b| b.text.as_str())
+                .collect::<Vec<_>>(),
+            vec!["main.rs", "struct Foo"],
             "Client B should see file path and LSP symbol 'Foo' via remote project"
         );
     });

--- a/crates/editor/src/document_symbols.rs
+++ b/crates/editor/src/document_symbols.rs
@@ -476,7 +476,7 @@ mod tests {
         cx.run_until_parked();
 
         cx.update_editor(|editor, _window, _cx| {
-            assert_eq!(outline_symbol_names(editor), vec!["main"]);
+            assert_eq!(outline_symbol_names(editor), vec!["fn main"]);
         });
     }
 
@@ -533,7 +533,7 @@ mod tests {
         cx.update_editor(|editor, _window, _cx| {
             assert_eq!(
                 outline_symbol_names(editor),
-                vec!["Foo", "bar"],
+                vec!["struct Foo", "bar"],
                 "cursor is inside Foo > bar, so we expect the containing chain"
             );
         });
@@ -762,7 +762,7 @@ mod tests {
         cx.update_editor(|editor, _window, _cx| {
             assert_eq!(
                 outline_symbol_names(editor),
-                vec!["MyModule", "my_function"]
+                vec!["mod MyModule", "fn my_function"]
             );
         });
     }

--- a/crates/outline/src/outline.rs
+++ b/crates/outline/src/outline.rs
@@ -785,7 +785,7 @@ mod tests {
         let lsp_names = outline_names(&outline_view, cx);
         assert_eq!(
             lsp_names,
-            vec!["Foo", "bar", "lsp_only_field"],
+            vec!["struct Foo", "bar", "lsp_only_field"],
             "Step 2: LSP-provided symbols should be displayed"
         );
         assert_eq!(

--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -8086,7 +8086,7 @@ outline: struct Foo  <==== selected
                 ),
                 indoc!(
                     "
-outline: Foo  <==== selected
+outline: struct Foo  <==== selected
   outline: bar
   outline: lsp_only_field"
                 ),


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/48780

Before:
<img width="1728" height="1084" alt="before" src="https://github.com/user-attachments/assets/fd68a8c5-9d47-4205-9fa6-d83da5e042c4" />


After:
<img width="1728" height="1084" alt="after" src="https://github.com/user-attachments/assets/98b1bce3-d81e-4082-95e5-c02312b3ec0c" />


Release Notes:

- N/A
