### PR TITLE
workspace: Fix read-only button tooltip for non-toggleable buffers

### DIFF
--- a/crates/gpui/src/platform/windows/directx_renderer.rs
+++ b/crates/gpui/src/platform/windows/directx_renderer.rs
@@ -1016,7 +1016,7 @@ impl<T> PipelineState<T> {
     ) -> Result<()> {
         if self.buffer_size < data.len() {
             let new_buffer_size = data.len().next_power_of_two();
-            log::info!(
+            log::debug!(
                 "Updating {} buffer size from {} to {}",
                 self.label,
                 self.buffer_size,

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -2802,7 +2802,16 @@ impl Pane {
                 .icon_size(IconSize::Small)
                 .disabled(!toggleable)
                 .tooltip(move |_, cx| {
-                    Tooltip::with_meta("Unlock File", None, "This will make this file editable", cx)
+                    if toggleable {
+                        Tooltip::with_meta(
+                            "Unlock File",
+                            None,
+                            "This will make this file editable",
+                            cx,
+                        )
+                    } else {
+                        Tooltip::with_meta("Locked File", None, "This file is read-only", cx)
+                    }
                 })
                 .on_click(cx.listener(move |pane, _, window, cx| {
                     if let Some(item) = pane.item_for_index(ix) {

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -4469,7 +4469,7 @@ impl BackgroundScanner {
                 Ok(Some(metadata)) => metadata,
                 Ok(None) => continue,
                 Err(err) => {
-                    log::error!("error processing {child_abs_path:?}: {err:#}");
+                    log::error!("error processing {:?}: {err:#}", child_abs_path.display());
                     continue;
                 }
             };


### PR DESCRIPTION
Release Notes:

- Fixed an incorrect hover label for read-only file lock buttons
