### PR TITLE
util: Speed up `RelPath::cmp`

### DIFF
--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -6199,18 +6199,17 @@ impl Repository {
                     bail!("not a local repository")
                 };
 
-                let paths = changed_paths.iter().cloned().collect::<Vec<_>>();
-                if paths.is_empty() {
+                if changed_paths.is_empty() {
                     return Ok(());
                 }
+                let paths = changed_paths.iter().cloned().collect::<Vec<_>>();
                 let statuses = backend.status(&paths).await?;
                 let stash_entries = backend.stash_entries().await?;
 
                 let changed_path_statuses = cx
                     .background_spawn(async move {
                         let mut changed_path_statuses = Vec::new();
-                        let prev_statuses = prev_snapshot.statuses_by_path.clone();
-                        let mut cursor = prev_statuses.cursor::<PathProgress>(());
+                        let mut cursor = prev_snapshot.statuses_by_path.cursor::<PathProgress>(());
 
                         for (repo_path, status) in &*statuses.entries {
                             changed_paths.remove(repo_path);
@@ -6225,7 +6224,7 @@ impl Repository {
                                 status: *status,
                             }));
                         }
-                        let mut cursor = prev_statuses.cursor::<PathProgress>(());
+                        let mut cursor = prev_snapshot.statuses_by_path.cursor::<PathProgress>(());
                         for path in changed_paths.into_iter() {
                             if cursor.seek_forward(&PathTarget::Path(&path), Bias::Left) {
                                 changed_path_statuses

--- a/crates/util/src/rel_path.rs
+++ b/crates/util/src/rel_path.rs
@@ -276,7 +276,7 @@ impl PartialOrd for RelPath {
 
 impl Ord for RelPath {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.components().cmp(other.components())
+        self.0.cmp(&other.0)
     }
 }
 


### PR DESCRIPTION
Meant to use `std::str::Split` but the remainder function is not yet stable ...
Release Notes:

- N/A *or* Added/Fixed/Improved ...
