### PR TITLE
gpui: Fix Core Foundation object leaks on macOS

### DIFF
--- a/crates/gpui_macos/src/display.rs
+++ b/crates/gpui_macos/src/display.rs
@@ -5,6 +5,7 @@ use cocoa::{
     base::{id, nil},
     foundation::{NSArray, NSDictionary},
 };
+use core_foundation::base::CFRelease;
 use core_foundation::uuid::{CFUUIDGetUUIDBytes, CFUUIDRef};
 use core_graphics::display::{CGDirectDisplayID, CGDisplayBounds, CGGetActiveDisplayList};
 use gpui::{Bounds, DisplayId, Pixels, PlatformDisplay, point, px, size};
@@ -83,6 +84,7 @@ impl PlatformDisplay for MacDisplay {
         );
 
         let bytes = unsafe { CFUUIDGetUUIDBytes(cfuuid) };
+        unsafe { CFRelease(cfuuid as _) };
         Ok(Uuid::from_bytes([
             bytes.byte0,
             bytes.byte1,

--- a/crates/gpui_macos/src/keyboard.rs
+++ b/crates/gpui_macos/src/keyboard.rs
@@ -69,6 +69,8 @@ impl MacKeyboardLayout {
             let name: *const std::os::raw::c_char = msg_send![name, UTF8String];
             let name = CStr::from_ptr(name).to_str().unwrap().to_string();
 
+            let _: () = msg_send![current_keyboard, release];
+
             Self { id, name }
         }
     }


### PR DESCRIPTION
release `TISInputSource` returned by `TISCopyCurrentKeyboardLayoutInputSource` in `MacKeyboardLayout::new()`, and `CFUUIDRef` returned by `CGDisplayCreateUUIDFromDisplayID` in `MacDisplay::uuid()`. both follow the core foundation create rule and must be released by the caller.

Release Notes:

- N/A