### PR TITLE
Default agent panel to left dock when multi-workspace is enabled

### DIFF
--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -32,7 +32,7 @@ use client::Client;
 use command_palette_hooks::CommandPaletteFilter;
 use feature_flags::{AgentV2FeatureFlag, FeatureFlagAppExt as _};
 use fs::Fs;
-use gpui::{Action, App, Context, Entity, SharedString, Window, actions};
+use gpui::{Action, App, Context, Entity, SharedString, UpdateGlobal, Window, actions};
 use language::{
     LanguageRegistry,
     language_settings::{AllLanguageSettings, EditPredictionProvider},
@@ -44,7 +44,7 @@ use project::DisableAiSettings;
 use prompt_store::PromptBuilder;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use settings::{LanguageModelSelection, Settings as _, SettingsStore};
+use settings::{DockPosition, LanguageModelSelection, Settings as _, SettingsStore};
 use std::any::TypeId;
 use workspace::Workspace;
 
@@ -334,6 +334,19 @@ pub fn init(
 
     cx.on_flags_ready(|_, cx| {
         update_command_palette_filter(cx);
+    })
+    .detach();
+
+    cx.observe_flag::<AgentV2FeatureFlag, _>(|is_enabled, cx| {
+        SettingsStore::update_global(cx, |store, cx| {
+            store.update_default_settings(cx, |defaults| {
+                defaults.agent.get_or_insert_default().dock = Some(if is_enabled {
+                    DockPosition::Left
+                } else {
+                    DockPosition::Right
+                });
+            });
+        });
     })
     .detach();
 }

--- a/crates/settings/src/settings_store.rs
+++ b/crates/settings/src/settings_store.rs
@@ -794,6 +794,17 @@ impl SettingsStore {
         edits
     }
 
+    /// Mutates the default settings in place and recomputes all setting values.
+    pub fn update_default_settings(
+        &mut self,
+        cx: &mut App,
+        update: impl FnOnce(&mut SettingsContent),
+    ) {
+        let default_settings = Rc::make_mut(&mut self.default_settings);
+        update(default_settings);
+        self.recompute_values(None, cx);
+    }
+
     /// Sets the default settings via a JSON string.
     ///
     /// The string should contain a JSON object with a default value for every setting.


### PR DESCRIPTION
When users have the `multi-workspace` feature flag enabled (agent-v2), the default dock position for the agent panel is changed from right to left.

This adds a `update_default_settings` method to `SettingsStore` that allows mutating defaults in place, then observes the `AgentV2FeatureFlag` to update the agent dock default accordingly. Because this modifies the defaults layer, user-configured dock positions still take precedence.

Closes AI-15

(No release notes because multi-agent is feature-flagged.)

Release Notes:

- N/A