### PR TITLE
Add audio file support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1299,6 +1299,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "audio_viewer"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "db",
+ "editor",
+ "file_icons",
+ "gpui",
+ "language",
+ "log",
+ "project",
+ "rodio",
+ "serde",
+ "settings",
+ "theme",
+ "ui",
+ "util",
+ "workspace",
+]
+
+[[package]]
 name = "auditable-serde"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12708,6 +12729,7 @@ dependencies = [
  "snippet",
  "snippet_provider",
  "sum_tree",
+ "symphonia",
  "task",
  "tempfile",
  "terminal",
@@ -16219,10 +16241,12 @@ dependencies = [
  "symphonia-bundle-flac",
  "symphonia-bundle-mp3",
  "symphonia-codec-aac",
+ "symphonia-codec-adpcm",
  "symphonia-codec-pcm",
  "symphonia-codec-vorbis",
  "symphonia-core",
  "symphonia-format-isomp4",
+ "symphonia-format-mkv",
  "symphonia-format-ogg",
  "symphonia-format-riff",
  "symphonia-metadata",
@@ -16259,6 +16283,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c263845aa86881416849c1729a54c7f55164f8b96111dba59de46849e73a790"
 dependencies = [
  "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-adpcm"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dddc50e2bbea4cfe027441eece77c46b9f319748605ab8f3443350129ddd07f"
+dependencies = [
  "log",
  "symphonia-core",
 ]
@@ -16304,6 +16338,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "243739585d11f81daf8dac8d9f3d18cc7898f6c09a259675fc364b382c30e0a5"
 dependencies = [
  "encoding_rs",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-mkv"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "122d786d2c43a49beb6f397551b4a050d8229eaa54c7ddf9ee4b98899b8742d0"
+dependencies = [
+ "lazy_static",
  "log",
  "symphonia-core",
  "symphonia-metadata",
@@ -21093,6 +21140,7 @@ dependencies = [
  "askpass",
  "assets",
  "audio",
+ "audio_viewer",
  "auto_update",
  "auto_update_ui",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ members = [
     "crates/http_client_tls",
     "crates/icons",
     "crates/image_viewer",
+    "crates/audio_viewer",
     "crates/inspector_ui",
     "crates/install_cli",
     "crates/journal",
@@ -328,6 +329,7 @@ http_client = { path = "crates/http_client" }
 http_client_tls = { path = "crates/http_client_tls" }
 icons = { path = "crates/icons" }
 image_viewer = { path = "crates/image_viewer" }
+audio_viewer = { path = "crates/audio_viewer" }
 edit_prediction_types = { path = "crates/edit_prediction_types" }
 edit_prediction_ui = { path = "crates/edit_prediction_ui" }
 edit_prediction_context = { path = "crates/edit_prediction_context" }
@@ -668,6 +670,7 @@ stacksafe = "0.1"
 streaming-iterator = "0.1"
 strsim = "0.11"
 strum = { version = "0.27.2", features = ["derive"] }
+symphonia = { version = "0.5.5", features = ["mp3", "aac", "flac", "pcm", "vorbis", "isomp4", "ogg", "wav"] }
 syn = { version = "2.0.101", features = ["full", "extra-traits", "visit-mut"] }
 sys-locale = "0.3.1"
 sysinfo = "0.37.0"
@@ -846,6 +849,7 @@ command_palette_hooks = { codegen-units = 1 }
 feature_flags = { codegen-units = 1 }
 file_icons = { codegen-units = 1 }
 image_viewer = { codegen-units = 1 }
+audio_viewer = { codegen-units = 1 }
 edit_prediction_ui = { codegen-units = 1 }
 install_cli = { codegen-units = 1 }
 journal = { codegen-units = 1 }

--- a/crates/audio_viewer/Cargo.toml
+++ b/crates/audio_viewer/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "audio_viewer"
+version = "0.1.0"
+edition.workspace = true
+publish.workspace = true
+license = "GPL-3.0-or-later"
+
+[lints]
+workspace = true
+
+[lib]
+path = "src/audio_viewer.rs"
+doctest = false
+
+[features]
+test-support = ["gpui/test-support", "editor/test-support"]
+
+[dependencies]
+anyhow.workspace = true
+db.workspace = true
+editor.workspace = true
+file_icons.workspace = true
+gpui.workspace = true
+language.workspace = true
+log.workspace = true
+project.workspace = true
+rodio.workspace = true
+serde.workspace = true
+settings.workspace = true
+theme.workspace = true
+ui.workspace = true
+util.workspace = true
+workspace.workspace = true
+
+[dev-dependencies]
+editor = { workspace = true, features = ["test-support"] }

--- a/crates/audio_viewer/LICENSE-GPL
+++ b/crates/audio_viewer/LICENSE-GPL
@@ -1,0 +1,1 @@
+../../LICENSE-GPL

--- a/crates/audio_viewer/src/audio_info.rs
+++ b/crates/audio_viewer/src/audio_info.rs
@@ -1,0 +1,105 @@
+use gpui::{Context, Entity, IntoElement, ParentElement, Render, Subscription, div};
+use project::audio_store::AudioMetadata;
+use ui::prelude::*;
+use util::size::format_file_size;
+use workspace::{ItemHandle, StatusItemView, Workspace};
+
+use crate::AudioView;
+
+pub struct AudioInfo {
+    metadata: Option<AudioMetadata>,
+    _observe_active_audio: Option<Subscription>,
+    observe_audio_item: Option<Subscription>,
+}
+
+impl AudioInfo {
+    pub fn new(_workspace: &Workspace) -> Self {
+        Self {
+            metadata: None,
+            _observe_active_audio: None,
+            observe_audio_item: None,
+        }
+    }
+
+    fn update_metadata(&mut self, audio_view: &Entity<AudioView>, cx: &mut Context<Self>) {
+        let audio_item = audio_view.read(cx).audio_item.clone();
+        let current_metadata = audio_item.read(cx).audio_metadata;
+        if current_metadata.is_some() {
+            self.metadata = current_metadata;
+            cx.notify();
+        } else {
+            self.observe_audio_item = Some(cx.observe(&audio_item, |this, item, cx| {
+                this.metadata = item.read(cx).audio_metadata;
+                cx.notify();
+            }));
+        }
+    }
+}
+
+fn format_duration(duration: &std::time::Duration) -> String {
+    let total_seconds = duration.as_secs();
+    let minutes = total_seconds / 60;
+    let seconds = total_seconds % 60;
+    format!("{}:{:02}", minutes, seconds)
+}
+
+impl Render for AudioInfo {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        let Some(metadata) = self.metadata.as_ref() else {
+            return div().hidden();
+        };
+
+        let mut components = Vec::new();
+
+        if let Some(duration) = &metadata.duration {
+            components.push(format_duration(duration));
+        }
+
+        if metadata.sample_rate > 0 {
+            let sample_rate_khz = metadata.sample_rate as f64 / 1000.0;
+            if sample_rate_khz == sample_rate_khz.floor() {
+                components.push(format!("{}kHz", sample_rate_khz as u32));
+            } else {
+                components.push(format!("{:.1}kHz", sample_rate_khz));
+            }
+        }
+
+        match metadata.channels {
+            1 => components.push("Mono".to_string()),
+            2 => components.push("Stereo".to_string()),
+            count => components.push(format!("{} channels", count)),
+        }
+
+        if let Some(bitrate) = metadata.bitrate {
+            components.push(format!("{}kbps", bitrate));
+        }
+
+        components.push(format_file_size(metadata.file_size, false));
+        components.push(metadata.format.to_string());
+
+        div().child(Label::new(components.join(" • ")).size(LabelSize::Small))
+    }
+}
+
+impl StatusItemView for AudioInfo {
+    fn set_active_pane_item(
+        &mut self,
+        active_pane_item: Option<&dyn ItemHandle>,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self._observe_active_audio = None;
+        self.observe_audio_item = None;
+
+        if let Some(audio_view) = active_pane_item.and_then(|item| item.act_as::<AudioView>(cx)) {
+            self.update_metadata(&audio_view, cx);
+
+            self._observe_active_audio = Some(cx.observe(&audio_view, |this, view, cx| {
+                this.update_metadata(&view, cx);
+            }));
+        } else {
+            self.metadata = None;
+        }
+        cx.notify();
+    }
+}

--- a/crates/audio_viewer/src/audio_viewer.rs
+++ b/crates/audio_viewer/src/audio_viewer.rs
@@ -1,0 +1,802 @@
+mod audio_info;
+
+use std::io::Cursor;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Context as _;
+use editor::{EditorSettings, items::entry_git_aware_label_color};
+use file_icons::FileIcons;
+use gpui::{
+    AnyElement, App, Context, Entity, EventEmitter, FocusHandle, Focusable, IntoElement,
+    MouseButton, MouseDownEvent, ParentElement, Render, Styled, Task, WeakEntity, Window, actions,
+    canvas, div, point, px, size,
+};
+use language::File as _;
+use persistence::AUDIO_VIEWER;
+use project::{AudioItem, Project, ProjectPath, audio_store::AudioItemEvent};
+use rodio::{Decoder, OutputStream, OutputStreamBuilder, Source as _, mixer::Mixer};
+use settings::Settings;
+use theme::ThemeSettings;
+use ui::{Tooltip, prelude::*};
+use util::paths::PathExt;
+use workspace::{
+    ItemId, ItemSettings, Pane, ToolbarItemEvent, ToolbarItemLocation, ToolbarItemView, Workspace,
+    WorkspaceId, delete_unloaded_items,
+    invalid_item_view::InvalidItemView,
+    item::{BreadcrumbText, Item, ItemHandle, ProjectItem, SerializableItem, TabContentParams},
+};
+
+pub use crate::audio_info::*;
+
+actions!(
+    audio_viewer,
+    [
+        /// Toggle play/pause.
+        TogglePlayback,
+    ]
+);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PlaybackState {
+    Stopped,
+    Playing,
+    Paused,
+}
+
+pub struct AudioView {
+    audio_item: Entity<AudioItem>,
+    project: Entity<Project>,
+    focus_handle: FocusHandle,
+    playback_state: PlaybackState,
+    current_position: Duration,
+    duration: Option<Duration>,
+    output_handle: Option<OutputStream>,
+    mixer: Option<Mixer>,
+    _position_update_task: Option<Task<()>>,
+}
+
+impl AudioView {
+    pub fn new(
+        audio_item: Entity<AudioItem>,
+        project: Entity<Project>,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        cx.subscribe(&audio_item, Self::on_audio_event).detach();
+
+        let duration = audio_item
+            .read(cx)
+            .audio_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.duration);
+
+        Self {
+            audio_item,
+            project,
+            focus_handle: cx.focus_handle(),
+            playback_state: PlaybackState::Stopped,
+            current_position: Duration::ZERO,
+            duration,
+            output_handle: None,
+            mixer: None,
+            _position_update_task: None,
+        }
+    }
+
+    fn on_audio_event(
+        &mut self,
+        _: Entity<AudioItem>,
+        event: &AudioItemEvent,
+        cx: &mut Context<Self>,
+    ) {
+        match event {
+            AudioItemEvent::MetadataUpdated | AudioItemEvent::FileHandleChanged => {
+                self.duration = self
+                    .audio_item
+                    .read(cx)
+                    .audio_metadata
+                    .as_ref()
+                    .and_then(|metadata| metadata.duration);
+                cx.emit(AudioViewEvent::TitleChanged);
+                cx.notify();
+            }
+            AudioItemEvent::Reloaded => {
+                self.stop_playback(cx);
+                cx.emit(AudioViewEvent::TitleChanged);
+                cx.notify();
+            }
+            AudioItemEvent::ReloadNeeded => {}
+        }
+    }
+
+    fn toggle_playback(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
+        match self.playback_state {
+            PlaybackState::Playing => self.pause_playback(cx),
+            PlaybackState::Paused | PlaybackState::Stopped => self.start_playback(cx),
+        }
+    }
+
+    fn start_playback(&mut self, cx: &mut Context<Self>) {
+        let audio_bytes = self.audio_item.read(cx).audio_bytes.clone();
+        let skip = self.current_position;
+
+        match self.try_start_playback(audio_bytes, skip) {
+            Ok(()) => {
+                self.playback_state = PlaybackState::Playing;
+                self.start_position_tracking(cx);
+                cx.notify();
+            }
+            Err(error) => {
+                log::error!("Failed to start audio playback: {error:#}");
+            }
+        }
+    }
+
+    fn try_start_playback(
+        &mut self,
+        audio_bytes: Arc<Vec<u8>>,
+        skip: Duration,
+    ) -> anyhow::Result<()> {
+        let mut output_handle =
+            OutputStreamBuilder::open_default_stream().context("Could not open audio output")?;
+        output_handle.log_on_drop(false);
+
+        let (mixer, mixer_source) = rodio::mixer::mixer(rodio::nz!(2), rodio::nz!(44100));
+        mixer.add(rodio::source::Zero::new(rodio::nz!(2), rodio::nz!(44100)));
+
+        let cursor = Cursor::new((*audio_bytes).clone());
+        let mut source = Decoder::new(cursor).context("Could not decode audio")?;
+        if skip > Duration::ZERO {
+            source
+                .try_seek(skip)
+                .context("Could not seek audio source")?;
+        }
+        mixer.add(source);
+
+        output_handle.mixer().add(mixer_source);
+
+        self.output_handle = Some(output_handle);
+        self.mixer = Some(mixer);
+
+        Ok(())
+    }
+
+    fn start_position_tracking(&mut self, cx: &mut Context<Self>) {
+        let start_time = std::time::Instant::now();
+        let start_position = self.current_position;
+
+        self._position_update_task = Some(cx.spawn(async move |this, cx| {
+            loop {
+                cx.background_executor()
+                    .timer(Duration::from_millis(100))
+                    .await;
+
+                let should_continue = this
+                    .update(cx, |this, cx| {
+                        if this.playback_state != PlaybackState::Playing {
+                            return false;
+                        }
+
+                        let elapsed = start_time.elapsed();
+                        this.current_position = start_position + elapsed;
+
+                        if let Some(duration) = this.duration {
+                            if this.current_position >= duration {
+                                this.current_position = duration;
+                                this.playback_state = PlaybackState::Stopped;
+                                this.current_position = Duration::ZERO;
+                                this.output_handle = None;
+                                this.mixer = None;
+                                this._position_update_task = None;
+                                cx.notify();
+                                return false;
+                            }
+                        }
+
+                        cx.notify();
+                        true
+                    })
+                    .unwrap_or(false);
+
+                if !should_continue {
+                    break;
+                }
+            }
+        }));
+    }
+
+    fn pause_playback(&mut self, cx: &mut Context<Self>) {
+        self.playback_state = PlaybackState::Paused;
+        self._position_update_task = None;
+        self.output_handle = None;
+        self.mixer = None;
+        cx.notify();
+    }
+
+    fn stop_playback(&mut self, cx: &mut Context<Self>) {
+        self.playback_state = PlaybackState::Stopped;
+        self.current_position = Duration::ZERO;
+        self._position_update_task = None;
+        self.output_handle = None;
+        self.mixer = None;
+        cx.notify();
+    }
+
+    fn toggle_playback_action(
+        &mut self,
+        _: &TogglePlayback,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.toggle_playback(window, cx);
+    }
+
+    fn seek_to_fraction(&mut self, fraction: f32, cx: &mut Context<Self>) {
+        let Some(duration) = self.duration else {
+            return;
+        };
+
+        let target =
+            Duration::from_secs_f64(duration.as_secs_f64() * fraction.clamp(0.0, 1.0) as f64);
+        self.current_position = target;
+
+        if self.playback_state == PlaybackState::Playing {
+            self.output_handle = None;
+            self.mixer = None;
+            self._position_update_task = None;
+            self.start_playback(cx);
+        } else {
+            cx.notify();
+        }
+    }
+
+    fn format_time_display(&self) -> String {
+        let position = format_duration(self.current_position);
+        if let Some(duration) = self.duration {
+            format!("{} / {}", position, format_duration(duration))
+        } else {
+            position
+        }
+    }
+
+    fn playback_fraction(&self) -> f32 {
+        if let Some(duration) = self.duration {
+            if duration.as_secs_f64() > 0.0 {
+                return (self.current_position.as_secs_f64() / duration.as_secs_f64()) as f32;
+            }
+        }
+        0.0
+    }
+}
+
+fn format_duration(duration: Duration) -> String {
+    let total_seconds = duration.as_secs();
+    let minutes = total_seconds / 60;
+    let seconds = total_seconds % 60;
+    format!("{}:{:02}", minutes, seconds)
+}
+
+pub enum AudioViewEvent {
+    TitleChanged,
+}
+
+impl EventEmitter<AudioViewEvent> for AudioView {}
+
+impl Item for AudioView {
+    type Event = AudioViewEvent;
+
+    fn to_item_events(event: &Self::Event, mut f: impl FnMut(workspace::item::ItemEvent)) {
+        match event {
+            AudioViewEvent::TitleChanged => {
+                f(workspace::item::ItemEvent::UpdateTab);
+                f(workspace::item::ItemEvent::UpdateBreadcrumbs);
+            }
+        }
+    }
+
+    fn for_each_project_item(
+        &self,
+        cx: &App,
+        f: &mut dyn FnMut(gpui::EntityId, &dyn project::ProjectItem),
+    ) {
+        f(self.audio_item.entity_id(), self.audio_item.read(cx))
+    }
+
+    fn tab_tooltip_text(&self, cx: &App) -> Option<SharedString> {
+        let abs_path = self.audio_item.read(cx).abs_path(cx)?;
+        let file_path = abs_path.compact().to_string_lossy().into_owned();
+        Some(file_path.into())
+    }
+
+    fn tab_content(&self, params: TabContentParams, _window: &Window, cx: &App) -> AnyElement {
+        let project_path = self.audio_item.read(cx).project_path(cx);
+
+        let label_color = if ItemSettings::get_global(cx).git_status {
+            let git_status = self
+                .project
+                .read(cx)
+                .project_path_git_status(&project_path, cx)
+                .map(|status| status.summary())
+                .unwrap_or_default();
+
+            self.project
+                .read(cx)
+                .entry_for_path(&project_path, cx)
+                .map(|entry| {
+                    entry_git_aware_label_color(git_status, entry.is_ignored, params.selected)
+                })
+                .unwrap_or_else(|| params.text_color())
+        } else {
+            params.text_color()
+        };
+
+        Label::new(self.tab_content_text(params.detail.unwrap_or_default(), cx))
+            .single_line()
+            .color(label_color)
+            .when(params.preview, |this| this.italic())
+            .into_any_element()
+    }
+
+    fn tab_content_text(&self, _: usize, cx: &App) -> SharedString {
+        self.audio_item
+            .read(cx)
+            .file
+            .file_name(cx)
+            .to_string()
+            .into()
+    }
+
+    fn tab_icon(&self, _: &Window, cx: &App) -> Option<Icon> {
+        let path = self.audio_item.read(cx).abs_path(cx)?;
+        ItemSettings::get_global(cx)
+            .file_icons
+            .then(|| FileIcons::get_icon(&path, cx))
+            .flatten()
+            .map(Icon::from_path)
+    }
+
+    fn breadcrumb_location(&self, cx: &App) -> ToolbarItemLocation {
+        let show_breadcrumb = EditorSettings::get_global(cx).toolbar.breadcrumbs;
+        if show_breadcrumb {
+            ToolbarItemLocation::PrimaryLeft
+        } else {
+            ToolbarItemLocation::Hidden
+        }
+    }
+
+    fn breadcrumbs(&self, cx: &App) -> Option<Vec<BreadcrumbText>> {
+        let text = breadcrumbs_text_for_audio(self.project.read(cx), self.audio_item.read(cx), cx);
+        let settings = ThemeSettings::get_global(cx);
+
+        Some(vec![BreadcrumbText {
+            text,
+            highlights: None,
+            font: Some(settings.buffer_font.clone()),
+        }])
+    }
+
+    fn can_split(&self) -> bool {
+        true
+    }
+
+    fn clone_on_split(
+        &self,
+        _workspace_id: Option<WorkspaceId>,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Task<Option<Entity<Self>>>
+    where
+        Self: Sized,
+    {
+        Task::ready(Some(cx.new(|cx| Self {
+            audio_item: self.audio_item.clone(),
+            project: self.project.clone(),
+            focus_handle: cx.focus_handle(),
+            playback_state: PlaybackState::Stopped,
+            current_position: Duration::ZERO,
+            duration: self.duration,
+            output_handle: None,
+            mixer: None,
+            _position_update_task: None,
+        })))
+    }
+
+    fn has_deleted_file(&self, cx: &App) -> bool {
+        self.audio_item.read(cx).file.disk_state().is_deleted()
+    }
+
+    fn buffer_kind(&self, _: &App) -> workspace::item::ItemBufferKind {
+        workspace::item::ItemBufferKind::Singleton
+    }
+}
+
+fn breadcrumbs_text_for_audio(project: &Project, audio: &AudioItem, cx: &App) -> String {
+    let mut path = audio.file.path().clone();
+    if project.visible_worktrees(cx).count() > 1
+        && let Some(worktree) = project.worktree_for_id(audio.project_path(cx).worktree_id, cx)
+    {
+        path = worktree.read(cx).root_name().join(&path);
+    }
+
+    path.display(project.path_style(cx)).to_string()
+}
+
+impl EventEmitter<()> for AudioView {}
+
+impl Focusable for AudioView {
+    fn focus_handle(&self, _cx: &App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+impl Render for AudioView {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let is_playing = matches!(self.playback_state, PlaybackState::Playing);
+        let fraction = self.playback_fraction();
+        let time_display = self.format_time_display();
+        let track_color = cx.theme().colors().border;
+        let fill_color = cx.theme().colors().icon_accent;
+        let entity = cx.entity();
+
+        div()
+            .track_focus(&self.focus_handle(cx))
+            .key_context("AudioViewer")
+            .on_action(cx.listener(Self::toggle_playback_action))
+            .size_full()
+            .bg(cx.theme().colors().editor_background)
+            .flex()
+            .flex_col()
+            .items_center()
+            .justify_center()
+            .gap_4()
+            .child(
+                Icon::new(IconName::AudioOn)
+                    .size(IconSize::XLarge)
+                    .color(Color::Muted),
+            )
+            .child(Label::new(time_display).size(LabelSize::Large))
+            .child(
+                h_flex()
+                    .items_center()
+                    .gap_2()
+                    .child(
+                        IconButton::new(
+                            "play-pause",
+                            if is_playing {
+                                IconName::DebugPause
+                            } else {
+                                IconName::PlayFilled
+                            },
+                        )
+                        .icon_size(IconSize::Medium)
+                        .tooltip(move |_window, cx| {
+                            Tooltip::for_action(
+                                if is_playing { "Pause" } else { "Play" },
+                                &TogglePlayback,
+                                cx,
+                            )
+                        })
+                        .on_click(cx.listener(|this, _, window, cx| {
+                            this.toggle_playback(window, cx);
+                        })),
+                    )
+                    .child(
+                        div()
+                            .w(px(240.0))
+                            .h(px(6.0))
+                            .rounded(px(3.0))
+                            .cursor_pointer()
+                            .child(
+                                canvas(move |bounds, _window, _cx| bounds, {
+                                    let entity = entity;
+                                    move |bounds, _, window, _cx| {
+                                        window.on_mouse_event({
+                                            let entity = entity.clone();
+                                            move |event: &MouseDownEvent, _phase, _window, cx| {
+                                                if event.button != MouseButton::Left {
+                                                    return;
+                                                }
+                                                if !bounds.contains(&event.position) {
+                                                    return;
+                                                }
+                                                let click_x: f32 =
+                                                    (event.position.x - bounds.origin.x).into();
+                                                let width: f32 = bounds.size.width.into();
+                                                if width > 0.0 {
+                                                    entity.update(cx, |this, cx| {
+                                                        this.seek_to_fraction(click_x / width, cx);
+                                                    });
+                                                }
+                                            }
+                                        });
+                                        let origin_x: f32 = bounds.origin.x.into();
+                                        let origin_y: f32 = bounds.origin.y.into();
+                                        let width: f32 = bounds.size.width.into();
+                                        let height: f32 = bounds.size.height.into();
+
+                                        window.paint_quad(gpui::fill(
+                                            gpui::Bounds::new(
+                                                point(px(origin_x), px(origin_y)),
+                                                size(px(width), px(height)),
+                                            ),
+                                            track_color,
+                                        ));
+
+                                        let fill_width = width * fraction;
+                                        if fill_width > 0.0 {
+                                            window.paint_quad(gpui::fill(
+                                                gpui::Bounds::new(
+                                                    point(px(origin_x), px(origin_y)),
+                                                    size(px(fill_width), px(height)),
+                                                ),
+                                                fill_color,
+                                            ));
+                                        }
+                                    }
+                                })
+                                .size_full(),
+                            ),
+                    ),
+            )
+    }
+}
+
+impl ProjectItem for AudioView {
+    type Item = AudioItem;
+
+    fn for_project_item(
+        project: Entity<Project>,
+        _: Option<&Pane>,
+        item: Entity<Self::Item>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self
+    where
+        Self: Sized,
+    {
+        Self::new(item, project, window, cx)
+    }
+
+    fn for_broken_project_item(
+        abs_path: &Path,
+        is_local: bool,
+        error: &anyhow::Error,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> Option<InvalidItemView>
+    where
+        Self: Sized,
+    {
+        Some(InvalidItemView::new(abs_path, is_local, error, window, cx))
+    }
+}
+
+impl SerializableItem for AudioView {
+    fn serialized_item_kind() -> &'static str {
+        "AudioView"
+    }
+
+    fn deserialize(
+        project: Entity<Project>,
+        _workspace: WeakEntity<Workspace>,
+        workspace_id: WorkspaceId,
+        item_id: ItemId,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> Task<anyhow::Result<Entity<Self>>> {
+        window.spawn(cx, async move |cx| {
+            let audio_path = AUDIO_VIEWER
+                .get_audio_path(item_id, workspace_id)?
+                .context("No audio path found")?;
+
+            let (worktree, relative_path) = project
+                .update(cx, |project, cx| {
+                    project.find_or_create_worktree(audio_path.clone(), false, cx)
+                })
+                .await
+                .context("Path not found")?;
+            let worktree_id = worktree.update(cx, |worktree, _cx| worktree.id());
+
+            let project_path = ProjectPath {
+                worktree_id,
+                path: relative_path,
+            };
+
+            let audio_item = project
+                .update(cx, |project, cx| project.open_audio(project_path, cx))
+                .await?;
+
+            cx.update(
+                |window, cx| Ok(cx.new(|cx| AudioView::new(audio_item, project, window, cx))),
+            )?
+        })
+    }
+
+    fn cleanup(
+        workspace_id: WorkspaceId,
+        alive_items: Vec<ItemId>,
+        _window: &mut Window,
+        cx: &mut App,
+    ) -> Task<anyhow::Result<()>> {
+        delete_unloaded_items(
+            alive_items,
+            workspace_id,
+            "audio_viewers",
+            &AUDIO_VIEWER,
+            cx,
+        )
+    }
+
+    fn serialize(
+        &mut self,
+        workspace: &mut Workspace,
+        item_id: ItemId,
+        _closing: bool,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Option<Task<anyhow::Result<()>>> {
+        let workspace_id = workspace.database_id()?;
+        let audio_path = self.audio_item.read(cx).abs_path(cx)?;
+
+        Some(cx.background_spawn({
+            async move {
+                log::debug!("Saving audio at path {audio_path:?}");
+                AUDIO_VIEWER
+                    .save_audio_path(item_id, workspace_id, audio_path)
+                    .await
+            }
+        }))
+    }
+
+    fn should_serialize(&self, _event: &Self::Event) -> bool {
+        false
+    }
+}
+
+pub struct AudioViewToolbarControls {
+    audio_view: Option<WeakEntity<AudioView>>,
+    _subscription: Option<gpui::Subscription>,
+}
+
+impl AudioViewToolbarControls {
+    pub fn new() -> Self {
+        Self {
+            audio_view: None,
+            _subscription: None,
+        }
+    }
+}
+
+impl Render for AudioViewToolbarControls {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let Some(audio_view) = self.audio_view.as_ref().and_then(|v| v.upgrade()) else {
+            return div().into_any_element();
+        };
+
+        let audio_view_state = audio_view.read(cx);
+        let is_playing = matches!(audio_view_state.playback_state, PlaybackState::Playing);
+        let time_display = audio_view_state.format_time_display();
+
+        h_flex()
+            .gap_1()
+            .child(
+                IconButton::new(
+                    "play-pause",
+                    if is_playing {
+                        IconName::DebugPause
+                    } else {
+                        IconName::PlayFilled
+                    },
+                )
+                .icon_size(IconSize::Small)
+                .tooltip(move |_window, cx| {
+                    Tooltip::for_action(
+                        if is_playing { "Pause" } else { "Play" },
+                        &TogglePlayback,
+                        cx,
+                    )
+                })
+                .on_click({
+                    let audio_view = audio_view.downgrade();
+                    move |_, window, cx| {
+                        if let Some(view) = audio_view.upgrade() {
+                            view.update(cx, |this, cx| {
+                                this.toggle_playback(window, cx);
+                            });
+                        }
+                    }
+                }),
+            )
+            .child(
+                Label::new(time_display)
+                    .size(LabelSize::Small)
+                    .color(Color::Muted),
+            )
+            .into_any_element()
+    }
+}
+
+impl EventEmitter<ToolbarItemEvent> for AudioViewToolbarControls {}
+
+impl ToolbarItemView for AudioViewToolbarControls {
+    fn set_active_pane_item(
+        &mut self,
+        active_pane_item: Option<&dyn ItemHandle>,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> ToolbarItemLocation {
+        self.audio_view = None;
+        self._subscription = None;
+
+        if let Some(item) = active_pane_item.and_then(|i| i.downcast::<AudioView>()) {
+            self._subscription = Some(cx.observe(&item, |_, _, cx| {
+                cx.notify();
+            }));
+            self.audio_view = Some(item.downgrade());
+            cx.notify();
+            return ToolbarItemLocation::PrimaryRight;
+        }
+
+        ToolbarItemLocation::Hidden
+    }
+}
+
+pub fn init(cx: &mut App) {
+    workspace::register_project_item::<AudioView>(cx);
+    workspace::register_serializable_item::<AudioView>(cx);
+}
+
+mod persistence {
+    use std::path::PathBuf;
+
+    use db::{
+        query,
+        sqlez::{domain::Domain, thread_safe_connection::ThreadSafeConnection},
+        sqlez_macros::sql,
+    };
+    use workspace::{ItemId, WorkspaceDb, WorkspaceId};
+
+    pub struct AudioViewerDb(ThreadSafeConnection);
+
+    impl Domain for AudioViewerDb {
+        const NAME: &str = stringify!(AudioViewerDb);
+
+        const MIGRATIONS: &[&str] = &[sql!(
+                CREATE TABLE audio_viewers (
+                    workspace_id INTEGER,
+                    item_id INTEGER UNIQUE,
+
+                    audio_path BLOB,
+
+                    PRIMARY KEY(workspace_id, item_id),
+                    FOREIGN KEY(workspace_id) REFERENCES workspaces(workspace_id)
+                    ON DELETE CASCADE
+                ) STRICT;
+        )];
+    }
+
+    db::static_connection!(AUDIO_VIEWER, AudioViewerDb, [WorkspaceDb]);
+
+    impl AudioViewerDb {
+        query! {
+            pub async fn save_audio_path(
+                item_id: ItemId,
+                workspace_id: WorkspaceId,
+                audio_path: PathBuf
+            ) -> Result<()> {
+                INSERT OR REPLACE INTO audio_viewers(item_id, workspace_id, audio_path)
+                VALUES (?, ?, ?)
+            }
+        }
+
+        query! {
+            pub fn get_audio_path(item_id: ItemId, workspace_id: WorkspaceId) -> Result<Option<PathBuf>> {
+                SELECT audio_path
+                FROM audio_viewers
+                WHERE item_id = ? AND workspace_id = ?
+            }
+        }
+    }
+}

--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -86,6 +86,7 @@ smol.workspace = true
 snippet.workspace = true
 snippet_provider.workspace = true
 sum_tree.workspace = true
+symphonia.workspace = true
 task.workspace = true
 tempfile.workspace = true
 terminal.workspace = true

--- a/crates/project/src/audio_store.rs
+++ b/crates/project/src/audio_store.rs
@@ -1,0 +1,782 @@
+use crate::{
+    Project, ProjectEntryId, ProjectItem, ProjectPath,
+    worktree_store::{WorktreeStore, WorktreeStoreEvent},
+};
+use anyhow::{Context as _, Result};
+use collections::{HashMap, HashSet, hash_map};
+use futures::{StreamExt, channel::oneshot};
+use gpui::{
+    App, AsyncApp, Context, Entity, EventEmitter, Subscription, Task, WeakEntity, prelude::*,
+};
+use language::{DiskState, File};
+use rpc::{AnyProtoClient, ErrorExt as _};
+use std::num::NonZeroU64;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+use symphonia::core::formats::FormatOptions;
+use symphonia::core::io::MediaSourceStream;
+use symphonia::core::meta::MetadataOptions;
+use symphonia::core::probe::Hint;
+use util::{ResultExt, rel_path::RelPath};
+use worktree::{LoadedBinaryFile, PathChange, Worktree};
+
+const AUDIO_EXTENSIONS: &[&str] = &[
+    "mp3", "wav", "ogg", "oga", "flac", "aac", "m4a", "opus", "wma", "webm",
+];
+
+#[derive(Clone, Copy, Debug, Hash, PartialEq, PartialOrd, Ord, Eq)]
+pub struct AudioId(NonZeroU64);
+
+impl AudioId {
+    pub fn to_proto(&self) -> u64 {
+        self.0.get()
+    }
+}
+
+impl std::fmt::Display for AudioId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<NonZeroU64> for AudioId {
+    fn from(id: NonZeroU64) -> Self {
+        AudioId(id)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AudioFormat {
+    Mp3,
+    Wav,
+    Ogg,
+    Flac,
+    Aac,
+    M4a,
+    Unknown,
+}
+
+impl std::fmt::Display for AudioFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AudioFormat::Mp3 => write!(f, "MP3"),
+            AudioFormat::Wav => write!(f, "WAV"),
+            AudioFormat::Ogg => write!(f, "OGG"),
+            AudioFormat::Flac => write!(f, "FLAC"),
+            AudioFormat::Aac => write!(f, "AAC"),
+            AudioFormat::M4a => write!(f, "M4A"),
+            AudioFormat::Unknown => write!(f, "Unknown"),
+        }
+    }
+}
+
+impl AudioFormat {
+    pub fn from_extension(extension: &str) -> Self {
+        match extension.to_lowercase().as_str() {
+            "mp3" => AudioFormat::Mp3,
+            "wav" => AudioFormat::Wav,
+            "ogg" | "oga" | "opus" => AudioFormat::Ogg,
+            "flac" => AudioFormat::Flac,
+            "aac" => AudioFormat::Aac,
+            "m4a" => AudioFormat::M4a,
+            _ => AudioFormat::Unknown,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct AudioMetadata {
+    pub duration: Option<Duration>,
+    pub sample_rate: u32,
+    pub channels: u16,
+    pub format: AudioFormat,
+    pub file_size: u64,
+    pub bitrate: Option<u32>,
+}
+
+#[derive(Debug)]
+pub enum AudioItemEvent {
+    ReloadNeeded,
+    Reloaded,
+    FileHandleChanged,
+    MetadataUpdated,
+}
+
+impl EventEmitter<AudioItemEvent> for AudioItem {}
+
+pub enum AudioStoreEvent {
+    AudioAdded(Entity<AudioItem>),
+}
+
+impl EventEmitter<AudioStoreEvent> for AudioStore {}
+
+pub struct AudioItem {
+    pub id: AudioId,
+    pub file: Arc<worktree::File>,
+    pub audio_bytes: Arc<Vec<u8>>,
+    reload_task: Option<Task<()>>,
+    pub audio_metadata: Option<AudioMetadata>,
+}
+
+impl AudioItem {
+    pub fn compute_metadata_from_bytes(
+        audio_bytes: &[u8],
+        extension: Option<&str>,
+    ) -> Result<AudioMetadata> {
+        let cursor = std::io::Cursor::new(audio_bytes.to_vec());
+        let media_source_stream = MediaSourceStream::new(Box::new(cursor), Default::default());
+
+        let mut hint = Hint::new();
+        if let Some(ext) = extension {
+            hint.with_extension(ext);
+        }
+
+        let probed = symphonia::default::get_probe().format(
+            &hint,
+            media_source_stream,
+            &FormatOptions::default(),
+            &MetadataOptions::default(),
+        )?;
+
+        let format_reader = probed.format;
+        let track = format_reader
+            .default_track()
+            .context("no audio track found")?;
+        let codec_params = &track.codec_params;
+
+        let sample_rate = codec_params.sample_rate.unwrap_or(0);
+        let channels = codec_params
+            .channels
+            .map(|channel_layout| channel_layout.count() as u16)
+            .unwrap_or(0);
+        let duration = codec_params
+            .n_frames
+            .and_then(|frames| {
+                let rate = codec_params.sample_rate?;
+                if rate == 0 {
+                    return None;
+                }
+                Some(Duration::from_secs_f64(frames as f64 / rate as f64))
+            })
+            .or_else(|| {
+                codec_params.time_base.and_then(|time_base| {
+                    codec_params.n_frames.map(|num_frames| {
+                        let time = time_base.calc_time(num_frames);
+                        Duration::from_secs_f64(time.seconds as f64 + time.frac)
+                    })
+                })
+            });
+        let bitrate = codec_params.bits_per_coded_sample;
+
+        let audio_format = extension
+            .map(AudioFormat::from_extension)
+            .unwrap_or(AudioFormat::Unknown);
+
+        Ok(AudioMetadata {
+            duration,
+            sample_rate,
+            channels,
+            format: audio_format,
+            file_size: audio_bytes.len() as u64,
+            bitrate,
+        })
+    }
+
+    pub async fn load_audio_metadata(
+        audio: Entity<AudioItem>,
+        project: Entity<Project>,
+        cx: &mut AsyncApp,
+    ) -> Result<AudioMetadata> {
+        let (fs, audio_path, extension) = cx.update(|cx| {
+            let fs = project.read(cx).fs().clone();
+            let audio_item = audio.read(cx);
+            let audio_path = audio_item
+                .abs_path(cx)
+                .context("absolutizing audio file path")?;
+            let extension = audio_item
+                .file
+                .path()
+                .extension()
+                .map(|ext| ext.to_string());
+            anyhow::Ok((fs, audio_path, extension))
+        })?;
+
+        let audio_bytes = fs.load_bytes(&audio_path).await?;
+        Self::compute_metadata_from_bytes(&audio_bytes, extension.as_deref())
+    }
+
+    pub fn project_path(&self, cx: &App) -> ProjectPath {
+        ProjectPath {
+            worktree_id: self.file.worktree_id(cx),
+            path: self.file.path().clone(),
+        }
+    }
+
+    pub fn abs_path(&self, cx: &App) -> Option<PathBuf> {
+        Some(self.file.as_local()?.abs_path(cx))
+    }
+
+    fn file_updated(&mut self, new_file: Arc<worktree::File>, cx: &mut Context<Self>) {
+        let mut file_changed = false;
+
+        let old_file = &self.file;
+        if new_file.path() != old_file.path() {
+            file_changed = true;
+        }
+
+        let old_state = old_file.disk_state();
+        let new_state = new_file.disk_state();
+        if old_state != new_state {
+            file_changed = true;
+            if matches!(new_state, DiskState::Present { .. }) {
+                cx.emit(AudioItemEvent::ReloadNeeded)
+            }
+        }
+
+        self.file = new_file;
+        if file_changed {
+            cx.emit(AudioItemEvent::FileHandleChanged);
+            cx.notify();
+        }
+    }
+
+    fn reload(&mut self, cx: &mut Context<Self>) -> Option<oneshot::Receiver<()>> {
+        let local_file = self.file.as_local()?;
+        let (sender, receiver) = futures::channel::oneshot::channel();
+
+        let content = local_file.load_bytes(cx);
+        self.reload_task = Some(cx.spawn(async move |this, cx| {
+            if let Some(bytes) = content
+                .await
+                .context("Failed to load audio content")
+                .log_err()
+            {
+                this.update(cx, |this, cx| {
+                    this.audio_bytes = Arc::new(bytes);
+                    cx.emit(AudioItemEvent::Reloaded);
+                })
+                .log_err();
+            }
+            _ = sender.send(());
+        }));
+        Some(receiver)
+    }
+}
+
+pub fn is_audio_file(project: &Entity<Project>, path: &ProjectPath, cx: &App) -> bool {
+    let extension = util::maybe!({
+        let worktree_abs_path = project
+            .read(cx)
+            .worktree_for_id(path.worktree_id, cx)?
+            .read(cx)
+            .abs_path();
+        path.path
+            .extension()
+            .or_else(|| worktree_abs_path.extension()?.to_str())
+            .map(str::to_lowercase)
+    });
+
+    match extension {
+        Some(ext) => AUDIO_EXTENSIONS.contains(&ext.as_str()),
+        None => false,
+    }
+}
+
+impl ProjectItem for AudioItem {
+    fn try_open(
+        project: &Entity<Project>,
+        path: &ProjectPath,
+        cx: &mut App,
+    ) -> Option<Task<anyhow::Result<Entity<Self>>>> {
+        if is_audio_file(project, path, cx) {
+            Some(cx.spawn({
+                let path = path.clone();
+                let project = project.clone();
+                async move |cx| {
+                    project
+                        .update(cx, |project, cx| project.open_audio(path, cx))
+                        .await
+                }
+            }))
+        } else {
+            None
+        }
+    }
+
+    fn entry_id(&self, _: &App) -> Option<ProjectEntryId> {
+        self.file.entry_id
+    }
+
+    fn project_path(&self, cx: &App) -> Option<ProjectPath> {
+        Some(self.project_path(cx))
+    }
+
+    fn is_dirty(&self) -> bool {
+        false
+    }
+}
+
+#[allow(dead_code)]
+trait AudioStoreImpl {
+    fn open_audio(
+        &self,
+        path: Arc<RelPath>,
+        worktree: Entity<Worktree>,
+        cx: &mut Context<AudioStore>,
+    ) -> Task<Result<Entity<AudioItem>>>;
+
+    fn reload_audios(
+        &self,
+        audios: HashSet<Entity<AudioItem>>,
+        cx: &mut Context<AudioStore>,
+    ) -> Task<Result<()>>;
+
+    fn as_local(&self) -> Option<Entity<LocalAudioStore>>;
+    fn as_remote(&self) -> Option<Entity<RemoteAudioStore>>;
+}
+
+// TODO: Add proto messages for remote audio store support (analogous to CreateImageForPeer, OpenImageByPath, etc.)
+struct RemoteAudioStore {
+    _upstream_client: AnyProtoClient,
+    _project_id: u64,
+}
+
+struct LocalAudioStore {
+    local_audio_ids_by_path: HashMap<ProjectPath, AudioId>,
+    local_audio_ids_by_entry_id: HashMap<ProjectEntryId, AudioId>,
+    audio_store: WeakEntity<AudioStore>,
+    _subscription: Subscription,
+}
+
+pub struct AudioStore {
+    state: Box<dyn AudioStoreImpl>,
+    opened_audios: HashMap<AudioId, WeakEntity<AudioItem>>,
+    worktree_store: Entity<WorktreeStore>,
+    #[allow(clippy::type_complexity)]
+    loading_audios_by_path: HashMap<
+        ProjectPath,
+        postage::watch::Receiver<Option<Result<Entity<AudioItem>, Arc<anyhow::Error>>>>,
+    >,
+}
+
+impl AudioStore {
+    pub fn local(worktree_store: Entity<WorktreeStore>, cx: &mut Context<Self>) -> Self {
+        let this = cx.weak_entity();
+        Self {
+            state: Box::new(cx.new(|cx| {
+                let subscription = cx.subscribe(
+                    &worktree_store,
+                    |this: &mut LocalAudioStore, _, event, cx| {
+                        if let WorktreeStoreEvent::WorktreeAdded(worktree) = event {
+                            this.subscribe_to_worktree(worktree, cx);
+                        }
+                    },
+                );
+
+                LocalAudioStore {
+                    local_audio_ids_by_path: Default::default(),
+                    local_audio_ids_by_entry_id: Default::default(),
+                    audio_store: this,
+                    _subscription: subscription,
+                }
+            })),
+            opened_audios: Default::default(),
+            loading_audios_by_path: Default::default(),
+            worktree_store,
+        }
+    }
+
+    pub fn remote(
+        worktree_store: Entity<WorktreeStore>,
+        upstream_client: AnyProtoClient,
+        project_id: u64,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        Self {
+            state: Box::new(cx.new(|_| RemoteAudioStore {
+                _upstream_client: upstream_client,
+                _project_id: project_id,
+            })),
+            opened_audios: Default::default(),
+            loading_audios_by_path: Default::default(),
+            worktree_store,
+        }
+    }
+
+    pub fn audios(&self) -> impl '_ + Iterator<Item = Entity<AudioItem>> {
+        self.opened_audios
+            .values()
+            .filter_map(|audio| audio.upgrade())
+    }
+
+    pub fn get(&self, audio_id: AudioId) -> Option<Entity<AudioItem>> {
+        self.opened_audios
+            .get(&audio_id)
+            .and_then(|audio| audio.upgrade())
+    }
+
+    pub fn get_by_path(&self, path: &ProjectPath, cx: &App) -> Option<Entity<AudioItem>> {
+        self.audios()
+            .find(|audio| &audio.read(cx).project_path(cx) == path)
+    }
+
+    pub fn open_audio(
+        &mut self,
+        project_path: ProjectPath,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<Entity<AudioItem>>> {
+        let existing_audio = self.get_by_path(&project_path, cx);
+        if let Some(existing_audio) = existing_audio {
+            return Task::ready(Ok(existing_audio));
+        }
+
+        let Some(worktree) = self
+            .worktree_store
+            .read(cx)
+            .worktree_for_id(project_path.worktree_id, cx)
+        else {
+            return Task::ready(Err(anyhow::anyhow!("no such worktree")));
+        };
+
+        let loading_watch = match self.loading_audios_by_path.entry(project_path.clone()) {
+            hash_map::Entry::Occupied(entry) => entry.get().clone(),
+
+            hash_map::Entry::Vacant(entry) => {
+                let (mut sender, receiver) = postage::watch::channel();
+                entry.insert(receiver.clone());
+
+                let load_audio = self
+                    .state
+                    .open_audio(project_path.path.clone(), worktree, cx);
+
+                cx.spawn(async move |this, cx| {
+                    let load_result = load_audio.await;
+                    *sender.borrow_mut() = Some(this.update(cx, |this, _cx| {
+                        this.loading_audios_by_path.remove(&project_path);
+                        let audio = load_result.map_err(Arc::new)?;
+                        Ok(audio)
+                    })?);
+                    anyhow::Ok(())
+                })
+                .detach();
+                receiver
+            }
+        };
+
+        cx.background_spawn(async move {
+            Self::wait_for_loading_audio(loading_watch)
+                .await
+                .map_err(|error| error.cloned())
+        })
+    }
+
+    pub async fn wait_for_loading_audio(
+        mut receiver: postage::watch::Receiver<
+            Option<Result<Entity<AudioItem>, Arc<anyhow::Error>>>,
+        >,
+    ) -> Result<Entity<AudioItem>, Arc<anyhow::Error>> {
+        loop {
+            if let Some(result) = receiver.borrow().as_ref() {
+                match result {
+                    Ok(audio) => return Ok(audio.to_owned()),
+                    Err(error) => return Err(error.to_owned()),
+                }
+            }
+            receiver.next().await;
+        }
+    }
+
+    pub fn reload_audios(
+        &self,
+        audios: HashSet<Entity<AudioItem>>,
+        cx: &mut Context<AudioStore>,
+    ) -> Task<Result<()>> {
+        if audios.is_empty() {
+            return Task::ready(Ok(()));
+        }
+
+        self.state.reload_audios(audios, cx)
+    }
+
+    fn add_audio(&mut self, audio: Entity<AudioItem>, cx: &mut Context<AudioStore>) -> Result<()> {
+        let audio_id = audio.read(cx).id;
+        self.opened_audios.insert(audio_id, audio.downgrade());
+        cx.subscribe(&audio, Self::on_audio_event).detach();
+        cx.emit(AudioStoreEvent::AudioAdded(audio));
+        Ok(())
+    }
+
+    fn on_audio_event(
+        &mut self,
+        audio: Entity<AudioItem>,
+        event: &AudioItemEvent,
+        cx: &mut Context<Self>,
+    ) {
+        if let AudioItemEvent::FileHandleChanged = event
+            && let Some(local) = self.state.as_local()
+        {
+            local.update(cx, |local, cx| {
+                local.audio_changed_file(audio, cx);
+            })
+        }
+    }
+}
+
+impl AudioStoreImpl for Entity<LocalAudioStore> {
+    fn open_audio(
+        &self,
+        path: Arc<RelPath>,
+        worktree: Entity<Worktree>,
+        cx: &mut Context<AudioStore>,
+    ) -> Task<Result<Entity<AudioItem>>> {
+        let this = self.clone();
+
+        let load_file = worktree.update(cx, |worktree, cx| {
+            worktree.load_binary_file(path.as_ref(), cx)
+        });
+        cx.spawn(async move |audio_store, cx| {
+            let LoadedBinaryFile { file, content } = load_file.await?;
+
+            let entity = cx.new(|cx| AudioItem {
+                id: cx.entity_id().as_non_zero_u64().into(),
+                file: file.clone(),
+                audio_bytes: Arc::new(content),
+                audio_metadata: None,
+                reload_task: None,
+            });
+
+            let audio_id = cx.read_entity(&entity, |model, _| model.id);
+
+            this.update(cx, |this, cx| {
+                audio_store.update(cx, |audio_store, cx| {
+                    audio_store.add_audio(entity.clone(), cx)
+                })??;
+                this.local_audio_ids_by_path.insert(
+                    ProjectPath {
+                        worktree_id: file.worktree_id(cx),
+                        path: file.path.clone(),
+                    },
+                    audio_id,
+                );
+
+                if let Some(entry_id) = file.entry_id {
+                    this.local_audio_ids_by_entry_id.insert(entry_id, audio_id);
+                }
+
+                anyhow::Ok(())
+            })?;
+
+            Ok(entity)
+        })
+    }
+
+    fn reload_audios(
+        &self,
+        audios: HashSet<Entity<AudioItem>>,
+        cx: &mut Context<AudioStore>,
+    ) -> Task<Result<()>> {
+        cx.spawn(async move |_, cx| {
+            for audio in audios {
+                if let Some(receiver) = audio.update(cx, |audio, cx| audio.reload(cx)) {
+                    receiver.await?
+                }
+            }
+            Ok(())
+        })
+    }
+
+    fn as_local(&self) -> Option<Entity<LocalAudioStore>> {
+        Some(self.clone())
+    }
+
+    fn as_remote(&self) -> Option<Entity<RemoteAudioStore>> {
+        None
+    }
+}
+
+impl AudioStoreImpl for Entity<RemoteAudioStore> {
+    fn open_audio(
+        &self,
+        _path: Arc<RelPath>,
+        _worktree: Entity<Worktree>,
+        _cx: &mut Context<AudioStore>,
+    ) -> Task<Result<Entity<AudioItem>>> {
+        // TODO: Implement remote audio opening once proto messages are added
+        Task::ready(Err(anyhow::anyhow!(
+            "Opening audio from remote is not yet supported"
+        )))
+    }
+
+    fn reload_audios(
+        &self,
+        _audios: HashSet<Entity<AudioItem>>,
+        _cx: &mut Context<AudioStore>,
+    ) -> Task<Result<()>> {
+        Task::ready(Err(anyhow::anyhow!(
+            "Reloading audio from remote is not supported"
+        )))
+    }
+
+    fn as_local(&self) -> Option<Entity<LocalAudioStore>> {
+        None
+    }
+
+    fn as_remote(&self) -> Option<Entity<RemoteAudioStore>> {
+        Some(self.clone())
+    }
+}
+
+impl LocalAudioStore {
+    fn subscribe_to_worktree(&mut self, worktree: &Entity<Worktree>, cx: &mut Context<Self>) {
+        cx.subscribe(worktree, |this, worktree, event, cx| {
+            if worktree.read(cx).is_local()
+                && let worktree::Event::UpdatedEntries(changes) = event
+            {
+                this.local_worktree_entries_changed(&worktree, changes, cx);
+            }
+        })
+        .detach();
+    }
+
+    fn local_worktree_entries_changed(
+        &mut self,
+        worktree_handle: &Entity<Worktree>,
+        changes: &[(Arc<RelPath>, ProjectEntryId, PathChange)],
+        cx: &mut Context<Self>,
+    ) {
+        let snapshot = worktree_handle.read(cx).snapshot();
+        for (path, entry_id, _) in changes {
+            self.local_worktree_entry_changed(*entry_id, path, worktree_handle, &snapshot, cx);
+        }
+    }
+
+    fn local_worktree_entry_changed(
+        &mut self,
+        entry_id: ProjectEntryId,
+        path: &Arc<RelPath>,
+        worktree: &Entity<worktree::Worktree>,
+        snapshot: &worktree::Snapshot,
+        cx: &mut Context<Self>,
+    ) -> Option<()> {
+        let project_path = ProjectPath {
+            worktree_id: snapshot.id(),
+            path: path.clone(),
+        };
+        let audio_id = match self.local_audio_ids_by_entry_id.get(&entry_id) {
+            Some(&audio_id) => audio_id,
+            None => self.local_audio_ids_by_path.get(&project_path).copied()?,
+        };
+
+        let audio = self
+            .audio_store
+            .update(cx, |audio_store, _| {
+                if let Some(audio) = audio_store.get(audio_id) {
+                    Some(audio)
+                } else {
+                    audio_store.opened_audios.remove(&audio_id);
+                    None
+                }
+            })
+            .ok()
+            .flatten();
+        let audio = if let Some(audio) = audio {
+            audio
+        } else {
+            self.local_audio_ids_by_path.remove(&project_path);
+            self.local_audio_ids_by_entry_id.remove(&entry_id);
+            return None;
+        };
+
+        audio.update(cx, |audio, cx| {
+            let old_file = &audio.file;
+            if old_file.worktree != *worktree {
+                return;
+            }
+
+            let snapshot_entry = old_file
+                .entry_id
+                .and_then(|entry_id| snapshot.entry_for_id(entry_id))
+                .or_else(|| snapshot.entry_for_path(old_file.path.as_ref()));
+
+            let new_file = if let Some(entry) = snapshot_entry {
+                worktree::File {
+                    disk_state: match entry.mtime {
+                        Some(mtime) => DiskState::Present { mtime },
+                        None => old_file.disk_state,
+                    },
+                    is_local: true,
+                    entry_id: Some(entry.id),
+                    path: entry.path.clone(),
+                    worktree: worktree.clone(),
+                    is_private: entry.is_private,
+                }
+            } else {
+                worktree::File {
+                    disk_state: DiskState::Deleted,
+                    is_local: true,
+                    entry_id: old_file.entry_id,
+                    path: old_file.path.clone(),
+                    worktree: worktree.clone(),
+                    is_private: old_file.is_private,
+                }
+            };
+
+            if new_file == **old_file {
+                return;
+            }
+
+            if new_file.path != old_file.path {
+                self.local_audio_ids_by_path.remove(&ProjectPath {
+                    path: old_file.path.clone(),
+                    worktree_id: old_file.worktree_id(cx),
+                });
+                self.local_audio_ids_by_path.insert(
+                    ProjectPath {
+                        worktree_id: new_file.worktree_id(cx),
+                        path: new_file.path.clone(),
+                    },
+                    audio_id,
+                );
+            }
+
+            if new_file.entry_id != old_file.entry_id {
+                if let Some(entry_id) = old_file.entry_id {
+                    self.local_audio_ids_by_entry_id.remove(&entry_id);
+                }
+                if let Some(entry_id) = new_file.entry_id {
+                    self.local_audio_ids_by_entry_id.insert(entry_id, audio_id);
+                }
+            }
+
+            audio.file_updated(Arc::new(new_file), cx);
+        });
+        None
+    }
+
+    fn audio_changed_file(&mut self, audio: Entity<AudioItem>, cx: &mut App) -> Option<()> {
+        let audio = audio.read(cx);
+        let file = &audio.file;
+
+        let audio_id = audio.id;
+        if let Some(entry_id) = file.entry_id {
+            match self.local_audio_ids_by_entry_id.get(&entry_id) {
+                Some(_) => {
+                    return None;
+                }
+                None => {
+                    self.local_audio_ids_by_entry_id.insert(entry_id, audio_id);
+                }
+            }
+        };
+        self.local_audio_ids_by_path.insert(
+            ProjectPath {
+                worktree_id: file.worktree_id(cx),
+                path: file.path.clone(),
+            },
+            audio_id,
+        );
+
+        Some(())
+    }
+}

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -137,6 +137,7 @@ edit_prediction.workspace = true
 edit_prediction_ui.workspace = true
 http_client.workspace = true
 image_viewer.workspace = true
+audio_viewer.workspace = true
 inspector_ui.workspace = true
 install_cli.workspace = true
 journal.workspace = true

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -643,6 +643,7 @@ fn main() {
 
         editor::init(cx);
         image_viewer::init(cx);
+        audio_viewer::init(cx);
         repl::notebook::init(cx);
         diagnostics::init(cx);
 

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -4795,6 +4795,7 @@ mod tests {
                 "app_menu",
                 "assistant",
                 "assistant2",
+                "audio_viewer",
                 "auto_update",
                 "branch_picker",
                 "bedrock",


### PR DESCRIPTION
I work with Audio files and audio projects all the time at [Udio](https://udio.com) and for open source projects like [freqmoda](https://github.com/jonaylor89/freqmoda). This is a huge lift for me personally so I added support for it. It's a pretty big PR so if you all need me to break it up into small stacked PRs, I can do that.

Closes #14409

- [x] Tests or screenshots needed?

<img width="1195" height="694" alt="Screenshot 2026-02-12 at 10 26 17 AM" src="https://github.com/user-attachments/assets/78d397f6-39c2-4a2b-9161-80a67f61e0ed" />

- [x] Code Reviewed
- [x] Manual QA

I tested with mp3, flac, wav, and whatever other formats I had handy. Most files were only a few minutes long so I'm not sure how a several hour podcast might perform. I manually tested on MacOS and Linux (PopOS and Arch) which seemed to work as expected

Release Notes:

- Added in-editor and gpui audio support

-----

This is my first contribution to this repo so codex was a major help in understanding the codebase, what changes need to be made, and fixing any crashes.