### PR TITLE
Increase SQLite busy_timeout from 1ms to 500ms

### DIFF
--- a/crates/db/src/db.rs
+++ b/crates/db/src/db.rs
@@ -28,7 +28,7 @@ const CONNECTION_INITIALIZE_QUERY: &str = sql!(
 
 const DB_INITIALIZE_QUERY: &str = sql!(
     PRAGMA journal_mode=WAL;
-    PRAGMA busy_timeout=1;
+    PRAGMA busy_timeout=500;
     PRAGMA case_sensitive_like=TRUE;
     PRAGMA synchronous=NORMAL;
 );


### PR DESCRIPTION
When two Zed instances share the same data directory (e.g. a release build and a dev build running simultaneously), SQLite operations can fail with "database is locked" (error code 5), surfacing as a "Failed to Launch" error in the agent panel.

The root cause is `PRAGMA busy_timeout=1` in `crates/db/src/db.rs`, which gives SQLite only 1ms to wait for a write lock before giving up. With WAL mode, the actual lock hold times are microseconds — the problem isn't long-held locks, it's that we give up before even trying to wait. During startup, both instances hit the DB heavily for workspace restoration, so even tiny overlaps fail.

This changes `busy_timeout` from 1ms to 500ms, giving SQLite more room to retry without (hopefully) any perceptible delay to the user.

Closes AI-20

Release Notes:

- N/A