### PR TITLE
Suppress agent popup notification when status is already visible

### DIFF
--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -2180,23 +2180,20 @@ impl AcpServerView {
         self.show_notification(caption, icon, window, cx);
     }
 
-    fn agent_panel_visible(&self, window: &Window, cx: &App) -> bool {
-        let workspace_is_foreground = window
-            .root::<MultiWorkspace>()
-            .flatten()
-            .and_then(|mw| {
-                let mw = mw.read(cx);
-                self.workspace.upgrade().map(|ws| mw.workspace() == &ws)
-            })
+    fn agent_panel_visible(
+        &self,
+        multi_workspace: Option<&Entity<MultiWorkspace>>,
+        cx: &App,
+    ) -> bool {
+        let Some(workspace) = self.workspace.upgrade() else {
+            return false;
+        };
+
+        let workspace_is_foreground = multi_workspace
+            .map(|mw| mw.read(cx).workspace() == &workspace)
             .unwrap_or(true);
 
-        if workspace_is_foreground {
-            if let Some(workspace) = self.workspace.upgrade() {
-                return AgentPanel::is_visible(&workspace, cx);
-            }
-        }
-
-        false
+        workspace_is_foreground && AgentPanel::is_visible(&workspace, cx)
     }
 
     fn agent_status_visible(&self, window: &Window, cx: &App) -> bool {
@@ -2204,18 +2201,21 @@ impl AcpServerView {
             return false;
         }
 
-        let sidebar_open = window
-            .root::<MultiWorkspace>()
-            .flatten()
+        let multi_workspace = window.root::<MultiWorkspace>().flatten();
+
+        let sidebar_open = multi_workspace
+            .as_ref()
             .is_some_and(|mw| mw.read(cx).is_sidebar_open());
 
-        sidebar_open || self.agent_panel_visible(window, cx)
+        sidebar_open || self.agent_panel_visible(multi_workspace.as_ref(), cx)
     }
 
     fn play_notification_sound(&self, window: &Window, cx: &mut App) {
         let settings = AgentSettings::get_global(cx);
+        let multi_workspace = window.root::<MultiWorkspace>().flatten();
         if settings.play_sound_when_agent_done
-            && !(window.is_window_active() && self.agent_panel_visible(window, cx))
+            && !(window.is_window_active()
+                && self.agent_panel_visible(multi_workspace.as_ref(), cx))
         {
             Audio::play_sound(Sound::AgentDone, cx);
         }

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -2180,42 +2180,10 @@ impl AcpServerView {
         self.show_notification(caption, icon, window, cx);
     }
 
-    fn agent_is_visible(&self, window: &Window, cx: &App) -> bool {
-        if window.is_window_active() {
-            let workspace_is_foreground = window
-                .root::<MultiWorkspace>()
-                .flatten()
-                .and_then(|mw| {
-                    let mw = mw.read(cx);
-                    self.workspace.upgrade().map(|ws| mw.workspace() == &ws)
-                })
-                .unwrap_or(true);
-
-            if workspace_is_foreground {
-                if let Some(workspace) = self.workspace.upgrade() {
-                    return AgentPanel::is_visible(&workspace, cx);
-                }
-            }
-        }
-
-        false
-    }
-
-    fn agent_status_visible(&self, window: &Window, cx: &App) -> bool {
-        if !window.is_window_active() {
-            return false;
-        }
-
-        let multi_workspace = window.root::<MultiWorkspace>().flatten();
-
-        if multi_workspace
-            .as_ref()
-            .is_some_and(|mw| mw.read(cx).is_sidebar_open())
-        {
-            return true;
-        }
-
-        let workspace_is_foreground = multi_workspace
+    fn agent_panel_visible(&self, window: &Window, cx: &App) -> bool {
+        let workspace_is_foreground = window
+            .root::<MultiWorkspace>()
+            .flatten()
             .and_then(|mw| {
                 let mw = mw.read(cx);
                 self.workspace.upgrade().map(|ws| mw.workspace() == &ws)
@@ -2231,9 +2199,24 @@ impl AcpServerView {
         false
     }
 
+    fn agent_status_visible(&self, window: &Window, cx: &App) -> bool {
+        if !window.is_window_active() {
+            return false;
+        }
+
+        let sidebar_open = window
+            .root::<MultiWorkspace>()
+            .flatten()
+            .is_some_and(|mw| mw.read(cx).is_sidebar_open());
+
+        sidebar_open || self.agent_panel_visible(window, cx)
+    }
+
     fn play_notification_sound(&self, window: &Window, cx: &mut App) {
         let settings = AgentSettings::get_global(cx);
-        if settings.play_sound_when_agent_done && !self.agent_is_visible(window, cx) {
+        if settings.play_sound_when_agent_done
+            && !(window.is_window_active() && self.agent_panel_visible(window, cx))
+        {
             Audio::play_sound(Sound::AgentDone, cx);
         }
     }

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -2344,30 +2344,6 @@ impl AcpServerView {
                         }
                     })
                 });
-
-            // If the user activates this workspace via the sidebar, dismiss the popup.
-            if let Some(multi_workspace) = window.root::<MultiWorkspace>().flatten() {
-                let workspace_handle = self.workspace.clone();
-                let pop_up_weak = pop_up.downgrade();
-                self.notification_subscriptions
-                    .entry(screen_window)
-                    .or_insert_with(Vec::new)
-                    .push(
-                        cx.observe(&multi_workspace, move |_this, multi_workspace, cx| {
-                            let is_active = workspace_handle
-                                .upgrade()
-                                .map(|ws| multi_workspace.read(cx).workspace() == &ws)
-                                .unwrap_or(false);
-                            if is_active {
-                                if let Some(pop_up) = pop_up_weak.upgrade() {
-                                    pop_up.update(cx, |notification, cx| {
-                                        notification.dismiss(cx);
-                                    });
-                                }
-                            }
-                        }),
-                    );
-            }
         }
     }
 

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -2201,6 +2201,36 @@ impl AcpServerView {
         false
     }
 
+    fn agent_status_visible(&self, window: &Window, cx: &App) -> bool {
+        if !window.is_window_active() {
+            return false;
+        }
+
+        let multi_workspace = window.root::<MultiWorkspace>().flatten();
+
+        if multi_workspace
+            .as_ref()
+            .is_some_and(|mw| mw.read(cx).is_sidebar_open())
+        {
+            return true;
+        }
+
+        let workspace_is_foreground = multi_workspace
+            .and_then(|mw| {
+                let mw = mw.read(cx);
+                self.workspace.upgrade().map(|ws| mw.workspace() == &ws)
+            })
+            .unwrap_or(true);
+
+        if workspace_is_foreground {
+            if let Some(workspace) = self.workspace.upgrade() {
+                return AgentPanel::is_visible(&workspace, cx);
+            }
+        }
+
+        false
+    }
+
     fn play_notification_sound(&self, window: &Window, cx: &mut App) {
         let settings = AgentSettings::get_global(cx);
         if settings.play_sound_when_agent_done && !self.agent_is_visible(window, cx) {
@@ -2221,7 +2251,7 @@ impl AcpServerView {
 
         let settings = AgentSettings::get_global(cx);
 
-        let should_notify = !self.agent_is_visible(window, cx);
+        let should_notify = !self.agent_status_visible(window, cx);
 
         if !should_notify {
             return;
@@ -2325,7 +2355,7 @@ impl AcpServerView {
                     let pop_up_weak = pop_up.downgrade();
 
                     cx.observe_window_activation(window, move |this, window, cx| {
-                        if this.agent_is_visible(window, cx)
+                        if this.agent_status_visible(window, cx)
                             && let Some(pop_up) = pop_up_weak.upgrade()
                         {
                             pop_up.update(cx, |notification, cx| {
@@ -2334,6 +2364,30 @@ impl AcpServerView {
                         }
                     })
                 });
+
+            // If the user activates this workspace via the sidebar, dismiss the popup.
+            if let Some(multi_workspace) = window.root::<MultiWorkspace>().flatten() {
+                let workspace_handle = self.workspace.clone();
+                let pop_up_weak = pop_up.downgrade();
+                self.notification_subscriptions
+                    .entry(screen_window)
+                    .or_insert_with(Vec::new)
+                    .push(
+                        cx.observe(&multi_workspace, move |_this, multi_workspace, cx| {
+                            let is_active = workspace_handle
+                                .upgrade()
+                                .map(|ws| multi_workspace.read(cx).workspace() == &ws)
+                                .unwrap_or(false);
+                            if is_active {
+                                if let Some(pop_up) = pop_up_weak.upgrade() {
+                                    pop_up.update(cx, |notification, cx| {
+                                        notification.dismiss(cx);
+                                    });
+                                }
+                            }
+                        }),
+                    );
+            }
         }
     }
 

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -2180,20 +2180,12 @@ impl AcpServerView {
         self.show_notification(caption, icon, window, cx);
     }
 
-    fn agent_panel_visible(
-        &self,
-        multi_workspace: Option<&Entity<MultiWorkspace>>,
-        cx: &App,
-    ) -> bool {
+    fn agent_panel_visible(&self, multi_workspace: &Entity<MultiWorkspace>, cx: &App) -> bool {
         let Some(workspace) = self.workspace.upgrade() else {
             return false;
         };
 
-        let workspace_is_foreground = multi_workspace
-            .map(|mw| mw.read(cx).workspace() == &workspace)
-            .unwrap_or(true);
-
-        workspace_is_foreground && AgentPanel::is_visible(&workspace, cx)
+        multi_workspace.read(cx).workspace() == &workspace && AgentPanel::is_visible(&workspace, cx)
     }
 
     fn agent_status_visible(&self, window: &Window, cx: &App) -> bool {
@@ -2201,22 +2193,21 @@ impl AcpServerView {
             return false;
         }
 
-        let multi_workspace = window.root::<MultiWorkspace>().flatten();
+        let Some(multi_workspace) = window.root::<MultiWorkspace>().flatten() else {
+            return false;
+        };
 
-        let sidebar_open = multi_workspace
-            .as_ref()
-            .is_some_and(|mw| mw.read(cx).is_sidebar_open());
-
-        sidebar_open || self.agent_panel_visible(multi_workspace.as_ref(), cx)
+        multi_workspace.read(cx).is_sidebar_open() || self.agent_panel_visible(&multi_workspace, cx)
     }
 
     fn play_notification_sound(&self, window: &Window, cx: &mut App) {
         let settings = AgentSettings::get_global(cx);
-        let multi_workspace = window.root::<MultiWorkspace>().flatten();
-        if settings.play_sound_when_agent_done
-            && !(window.is_window_active()
-                && self.agent_panel_visible(multi_workspace.as_ref(), cx))
-        {
+        let visible = window.is_window_active()
+            && window
+                .root::<MultiWorkspace>()
+                .flatten()
+                .is_some_and(|mw| self.agent_panel_visible(&mw, cx));
+        if settings.play_sound_when_agent_done && !visible {
             Audio::play_sound(Sound::AgentDone, cx);
         }
     }

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -2193,20 +2193,26 @@ impl AcpServerView {
             return false;
         }
 
-        let Some(multi_workspace) = window.root::<MultiWorkspace>().flatten() else {
-            return false;
-        };
-
-        multi_workspace.read(cx).is_sidebar_open() || self.agent_panel_visible(&multi_workspace, cx)
+        if let Some(multi_workspace) = window.root::<MultiWorkspace>().flatten() {
+            multi_workspace.read(cx).is_sidebar_open()
+                || self.agent_panel_visible(&multi_workspace, cx)
+        } else {
+            self.workspace
+                .upgrade()
+                .is_some_and(|workspace| AgentPanel::is_visible(&workspace, cx))
+        }
     }
 
     fn play_notification_sound(&self, window: &Window, cx: &mut App) {
         let settings = AgentSettings::get_global(cx);
         let visible = window.is_window_active()
-            && window
-                .root::<MultiWorkspace>()
-                .flatten()
-                .is_some_and(|mw| self.agent_panel_visible(&mw, cx));
+            && if let Some(mw) = window.root::<MultiWorkspace>().flatten() {
+                self.agent_panel_visible(&mw, cx)
+            } else {
+                self.workspace
+                    .upgrade()
+                    .is_some_and(|workspace| AgentPanel::is_visible(&workspace, cx))
+            };
         if settings.play_sound_when_agent_done && !visible {
             Audio::play_sound(Sound::AgentDone, cx);
         }


### PR DESCRIPTION
If you have Zed open and the sidebar open, don't show a notification when a thread finishes.

Closes AI-18

(No release notes because multi-agent is still feature-flagged.)

Release Notes:

- N/A