### PR TITLE
Potentially fix hang when opening LSP menu

### DIFF
--- a/crates/language_tools/src/lsp_button.rs
+++ b/crates/language_tools/src/lsp_button.rs
@@ -125,7 +125,7 @@ impl ProcessMemoryCache {
 
     fn is_descendant_of(&self, pid: Pid, root_pid: Pid, parent_map: &HashMap<Pid, Pid>) -> bool {
         let mut current = pid;
-        let mut visited = HashSet::new();
+        let mut visited = HashSet::default();
         while current != root_pid {
             if !visited.insert(current) {
                 return false;

--- a/crates/language_tools/src/lsp_button.rs
+++ b/crates/language_tools/src/lsp_button.rs
@@ -125,7 +125,11 @@ impl ProcessMemoryCache {
 
     fn is_descendant_of(&self, pid: Pid, root_pid: Pid, parent_map: &HashMap<Pid, Pid>) -> bool {
         let mut current = pid;
+        let mut visited = HashSet::new();
         while current != root_pid {
+            if !visited.insert(current) {
+                return false;
+            }
             match parent_map.get(&current) {
                 Some(&parent) => current = parent,
                 None => return false,


### PR DESCRIPTION
It is maybe possible that, if a process's parent dies, the PID can be reused by a different process. This could cause an infinite loop in `is_descendant_of`. To fix this, break out of the loop when a cycle is detected.

- [ ] Tests or screenshots needed?
- [X] Code Reviewed
- [X] Manual QA

Release Notes:

- N/A
