### PR TITLE
Back action can navigate to previous workspace

### DIFF
--- a/crates/agent_ui/src/acp/thread_view/active_thread.rs
+++ b/crates/agent_ui/src/acp/thread_view/active_thread.rs
@@ -7200,13 +7200,18 @@ impl Render for AcpThreadView {
                 }
             }))
             .on_action(cx.listener(|this, _: &workspace::GoBack, window, cx| {
-                if let Some(parent_session_id) = this.parent_id.clone() {
-                    this.server_view
-                        .update(cx, |view, cx| {
-                            view.navigate_to_session(parent_session_id, window, cx);
-                        })
-                        .ok();
-                }
+                this.server_view
+                    .update(cx, |view, cx| {
+                        view.go_back(window, cx);
+                    })
+                    .ok();
+            }))
+            .on_action(cx.listener(|this, _: &workspace::GoForward, window, cx| {
+                this.server_view
+                    .update(cx, |view, cx| {
+                        view.go_forward(window, cx);
+                    })
+                    .ok();
             }))
             .on_action(cx.listener(Self::keep_all))
             .on_action(cx.listener(Self::reject_all))


### PR DESCRIPTION
When switching to a new agent thread, performing a Back action (e.g. via keyboard shortcut) previously did nothing because the new thread had no navigation history. Now it navigates back to the previously viewed thread.

This adds backward/forward session stacks to `ConnectedServerState` so that session navigation is tracked. `navigate_to_session` records history (pushes current session to backward stack, clears forward stack). New `go_back`/`go_forward` methods are added at both the `ConnectedServerState` and `AcpServerView` levels.

The `GoBack` handler on `AcpThreadView` now uniformly uses `go_back()` for both top-level and subagent threads (previously subagents used `navigate_to_session(parent_id)` which would create a navigation cycle now that history is tracked). A `GoForward` handler is also added.

Closes AI-21

Release Notes:

- Back/Forward navigation now works between agent threads — pressing Back switches to the previously viewed thread instead of doing nothing.