### PR TITLE
lsp: Add clangd readonly token modifier to semantic token rules to highlight constant variables as constant

### DIFF
--- a/crates/languages/src/cpp.rs
+++ b/crates/languages/src/cpp.rs
@@ -1,3 +1,15 @@
+use settings::SemanticTokenRules;
+
+use crate::LanguageDir;
+
+pub(crate) fn semantic_token_rules() -> SemanticTokenRules {
+    let content = LanguageDir::get("cpp/semantic_token_rules.json")
+        .expect("missing cpp/semantic_token_rules.json");
+    let json = std::str::from_utf8(&content.data).expect("invalid utf-8 in semantic_token_rules");
+    settings::parse_json_with_comments::<SemanticTokenRules>(json)
+        .expect("failed to parse cpp semantic_token_rules.json")
+}
+
 #[cfg(test)]
 mod tests {
     use gpui::{AppContext as _, BorrowAppContext, TestAppContext};

--- a/crates/languages/src/cpp/semantic_token_rules.json
+++ b/crates/languages/src/cpp/semantic_token_rules.json
@@ -1,0 +1,7 @@
+[
+  {
+    "token_type": "variable",
+    "token_modifiers": ["readonly"],
+    "style": ["constant"]
+  }
+]

--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -125,6 +125,7 @@ pub fn init(languages: Arc<LanguageRegistry>, fs: Arc<dyn Fs>, node: NodeRuntime
         LanguageInfo {
             name: "cpp",
             adapters: vec![c_lsp_adapter],
+            semantic_token_rules: Some(cpp::semantic_token_rules()),
             ..Default::default()
         },
         LanguageInfo {


### PR DESCRIPTION
Clangd uses the "readonly" token modifier instead of "constant". Therefore, "readonly" should be mapped to highlight constant variables as constants.

Before:
<img width="706" height="48" alt="before" src="https://github.com/user-attachments/assets/8cc2a310-7825-490b-b868-58ea231612fa" />

After:
<img width="762" height="46" alt="after" src="https://github.com/user-attachments/assets/e271d4cd-cc59-45f9-a8b4-2885857915db" />

- [x] Code Reviewed
- [x] Manual QA

Release Notes:

- Added clangd readonly token modifier to semantic token rules to highlight constant variables as constant.
