### PR TITLE
sidebar: Improve subheader component

### DIFF
--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -17,10 +17,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use theme::ActiveTheme;
 use ui::utils::TRAFFIC_LIGHT_PADDING;
-use ui::{
-    Divider, DividerColor, KeyBinding, ListItem, ListSubHeader, Tab, ThreadItem, Tooltip,
-    prelude::*,
-};
+use ui::{Divider, DividerColor, KeyBinding, ListSubHeader, Tab, ThreadItem, Tooltip, prelude::*};
 use ui_input::ErasedEditor;
 use util::ResultExt as _;
 use workspace::{

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -17,7 +17,10 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use theme::ActiveTheme;
 use ui::utils::TRAFFIC_LIGHT_PADDING;
-use ui::{Divider, KeyBinding, ListItem, Tab, ThreadItem, Tooltip, prelude::*};
+use ui::{
+    Divider, DividerColor, KeyBinding, ListItem, ListSubHeader, Tab, ThreadItem, Tooltip,
+    prelude::*,
+};
 use ui_input::ErasedEditor;
 use util::ResultExt as _;
 use workspace::{
@@ -519,18 +522,13 @@ impl PickerDelegate for WorkspacePickerDelegate {
 
         match entry {
             SidebarEntry::Separator(title) => Some(
-                div()
-                    .px_0p5()
-                    .when(index > 0, |this| this.mt_1().child(Divider::horizontal()))
-                    .child(
-                        ListItem::new("section_header").selectable(false).child(
-                            Label::new(title.clone())
-                                .size(LabelSize::XSmall)
-                                .color(Color::Muted)
-                                .when(index > 0, |this| this.mt_1p5())
-                                .mb_1(),
-                        ),
-                    )
+                v_flex()
+                    .when(index > 0, |this| {
+                        this.mt_1()
+                            .gap_2()
+                            .child(Divider::horizontal().color(DividerColor::BorderFaded))
+                    })
+                    .child(ListSubHeader::new(title.clone()).inset(true))
                     .into_any_element(),
             ),
             SidebarEntry::WorkspaceThread(thread_entry) => {


### PR DESCRIPTION
This PR uses the already-existing `ListSubHeader` component for the section subheader as opposed to a custom label.

<img width="350" height="942" alt="Screenshot 2026-02-12 at 8  30@2x" src="https://github.com/user-attachments/assets/a86ce59d-9d3b-4b10-87c8-69da1469743d" />

- [x] Code Reviewed
- [x] Manual QA

Release Notes:

- N/A
