### PR TITLE
Fix document highlight data issues

### DIFF
--- a/crates/project/src/lsp_store/document_symbols.rs
+++ b/crates/project/src/lsp_store/document_symbols.rs
@@ -75,6 +75,7 @@ impl LspStore {
                                 .symbols
                                 .values()
                                 .flatten()
+                                .unique()
                                 .cloned()
                                 .sorted_by(|a, b| a.range.start.cmp(&b.range.start, &snapshot))
                                 .collect(),
@@ -156,6 +157,7 @@ impl LspStore {
                             .symbols
                             .values()
                             .flatten()
+                            .unique()
                             .cloned()
                             .sorted_by(|a, b| a.range.start.cmp(&b.range.start, &snapshot))
                             .collect()


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/48780

Fixes incorrect multi byte characters treatment in the symbol range when highlighting:
<img width="1728" height="507" alt="image" src="https://github.com/user-attachments/assets/c6639220-f08a-4ea8-bf99-926566e356ae" />

Fixes multiple language servers' duplicate data display:
<img width="1726" height="925" alt="image" src="https://github.com/user-attachments/assets/ca98ee29-732e-4c8e-adf4-21a9523a5a9c" />


Release Notes:

- N/A
