### PR TITLE
lsp: Sanitize newlines in document and workspace symbol names

### DIFF
--- a/crates/editor/src/folding_ranges.rs
+++ b/crates/editor/src/folding_ranges.rs
@@ -859,7 +859,7 @@ mod tests {
                     "    }\n",
                     "}\n",
                     "\n",
-                    "fn newline() {   … }\n",
+                    "fn newline() { … }\n",
                 ]
                 .concat(),
             );
@@ -996,7 +996,7 @@ mod tests {
                     "\n",
                     "fn outer() { outer… }\n",
                     "\n",
-                    "fn newline() {   … }\n",
+                    "fn newline() { … }\n",
                 ]
                 .concat(),
             );

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -4799,17 +4799,10 @@ impl LspCommand for GetFoldingRanges {
                 );
                 let start = snapshot.anchor_after(start);
                 let end = snapshot.anchor_before(end);
-                let collapsed_text =
-                    folding_range
-                        .collapsed_text
-                        .filter(|t| !t.is_empty())
-                        .map(|t| {
-                            if t.contains('\n') {
-                                SharedString::from(t.replace('\n', " "))
-                            } else {
-                                SharedString::from(t)
-                            }
-                        });
+                let collapsed_text = folding_range
+                    .collapsed_text
+                    .filter(|t| !t.is_empty())
+                    .map(|t| SharedString::from(crate::lsp_store::collapse_newlines(&t, " ")));
                 LspFoldingRange {
                     range: start..end,
                     collapsed_text,

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -14276,14 +14276,10 @@ async fn populate_labels_for_symbols(
     }
 }
 
-fn collapse_newlines(text: &str, separator: &str) -> String {
-    if !text.contains('\n') {
-        return text.to_string();
-    }
-    text.split('\n')
+pub(crate) fn collapse_newlines(text: &str, separator: &str) -> String {
+    text.lines()
         .map(|line| line.trim())
         .filter(|line| !line.is_empty())
-        .collect::<Vec<_>>()
         .join(separator)
 }
 

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -7668,9 +7668,10 @@ impl LspStore {
                                         source_worktree_id,
                                         path,
                                         kind: symbol_kind,
-                                        name: symbol_name,
+                                        name: collapse_newlines(&symbol_name, "↵ "),
                                         range: range_from_lsp(symbol_location.range),
-                                        container_name,
+                                        container_name: container_name
+                                            .map(|c| collapse_newlines(&c, "↵ ")),
                                     })
                                 },
                             )
@@ -14273,6 +14274,17 @@ async fn populate_labels_for_symbols(
             });
         }
     }
+}
+
+fn collapse_newlines(text: &str, separator: &str) -> String {
+    if !text.contains('\n') {
+        return text.to_string();
+    }
+    text.split('\n')
+        .map(|line| line.trim())
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join(separator)
 }
 
 fn include_text(server: &lsp::LanguageServer) -> Option<bool> {

--- a/crates/project/src/lsp_store/document_symbols.rs
+++ b/crates/project/src/lsp_store/document_symbols.rs
@@ -249,6 +249,8 @@ fn flatten_document_symbols(
     output: &mut Vec<OutlineItem<Anchor>>,
 ) {
     for symbol in symbols {
+        let name = super::collapse_newlines(&symbol.name, " ");
+
         let start = snapshot.clip_point_utf16(symbol.range.start, Bias::Right);
         let end = snapshot.clip_point_utf16(symbol.range.end, Bias::Left);
         let selection_start = snapshot.clip_point_utf16(symbol.selection_range.start, Bias::Right);
@@ -258,18 +260,12 @@ fn flatten_document_symbols(
         let selection_range =
             snapshot.anchor_after(selection_start)..snapshot.anchor_before(selection_end);
 
-        let (text, name_ranges, source_range_for_text) = enriched_symbol_text(
-            &symbol.name,
-            start,
-            selection_start,
-            selection_end,
-            snapshot,
-        )
-        .unwrap_or_else(|| {
-            let name = symbol.name.clone();
-            let name_len = name.len();
-            (name, vec![0..name_len], selection_range.clone())
-        });
+        let (text, name_ranges, source_range_for_text) =
+            enriched_symbol_text(&name, start, selection_start, selection_end, snapshot)
+                .unwrap_or_else(|| {
+                    let name_len = name.len();
+                    (name.clone(), vec![0..name_len], selection_range.clone())
+                });
 
         output.push(OutlineItem {
             depth,
@@ -453,5 +449,45 @@ mod tests {
         let mut items = Vec::new();
         flatten_document_symbols(&symbols, &snapshot, 0, &mut items);
         assert!(items.is_empty());
+    }
+
+    #[test]
+    fn test_collapse_newlines() {
+        use super::super::collapse_newlines;
+
+        assert_eq!(collapse_newlines("a\nb", " "), "a b");
+        assert_eq!(collapse_newlines("a\n  b\nc", " "), "a b c");
+
+        // With ↵ separator (project symbols)
+        assert_eq!(collapse_newlines("a\nb", "↵ "), "a↵ b");
+
+        // Leading/trailing whitespace trimmed per line
+        assert_eq!(collapse_newlines("  a  \n  b  ", " "), "a b");
+
+        // Edge cases
+        assert_eq!(collapse_newlines("hello", " "), "hello");
+        // Empty lines filtered out
+        assert_eq!(collapse_newlines("a\n\nb", " "), "a b");
+    }
+
+    #[gpui::test]
+    async fn test_newlines_collapsed_in_name(cx: &mut TestAppContext) {
+        let buffer = cx.new(|cx| Buffer::local("x = 1\n", cx));
+
+        let symbols = vec![make_symbol(
+            "line1\nline2",
+            lsp::SymbolKind::VARIABLE,
+            (0, 0)..(0, 5),
+            (0, 0)..(0, 1),
+            vec![],
+        )];
+
+        let snapshot = buffer.read_with(cx, |buffer, _| buffer.snapshot());
+        let mut items = Vec::new();
+        flatten_document_symbols(&symbols, &snapshot, 0, &mut items);
+
+        assert_eq!(items.len(), 1);
+        // Name newlines collapsed to space
+        assert_eq!(items[0].text, "line1 line2");
     }
 }

--- a/crates/project/src/lsp_store/document_symbols.rs
+++ b/crates/project/src/lsp_store/document_symbols.rs
@@ -451,43 +451,49 @@ mod tests {
         assert!(items.is_empty());
     }
 
-    #[test]
-    fn test_collapse_newlines() {
-        use super::super::collapse_newlines;
-
-        assert_eq!(collapse_newlines("a\nb", " "), "a b");
-        assert_eq!(collapse_newlines("a\n  b\nc", " "), "a b c");
-
-        // With ↵ separator (project symbols)
-        assert_eq!(collapse_newlines("a\nb", "↵ "), "a↵ b");
-
-        // Leading/trailing whitespace trimmed per line
-        assert_eq!(collapse_newlines("  a  \n  b  ", " "), "a b");
-
-        // Edge cases
-        assert_eq!(collapse_newlines("hello", " "), "hello");
-        // Empty lines filtered out
-        assert_eq!(collapse_newlines("a\n\nb", " "), "a b");
-    }
-
     #[gpui::test]
     async fn test_newlines_collapsed_in_name(cx: &mut TestAppContext) {
-        let buffer = cx.new(|cx| Buffer::local("x = 1\n", cx));
+        let buffer = cx.new(|cx| Buffer::local("x = 1\ny = 2\n", cx));
 
-        let symbols = vec![make_symbol(
-            "line1\nline2",
-            lsp::SymbolKind::VARIABLE,
-            (0, 0)..(0, 5),
-            (0, 0)..(0, 1),
-            vec![],
-        )];
+        let symbols = vec![
+            make_symbol(
+                "line1\nline2",
+                lsp::SymbolKind::VARIABLE,
+                (0, 0)..(0, 5),
+                (0, 0)..(0, 1),
+                vec![],
+            ),
+            make_symbol(
+                "  a  \n  b  ",
+                lsp::SymbolKind::VARIABLE,
+                (1, 0)..(1, 5),
+                (1, 0)..(1, 1),
+                vec![],
+            ),
+            make_symbol(
+                "a\r\nb",
+                lsp::SymbolKind::VARIABLE,
+                (0, 0)..(1, 5),
+                (0, 0)..(0, 1),
+                vec![],
+            ),
+            make_symbol(
+                "a\n\nb",
+                lsp::SymbolKind::VARIABLE,
+                (0, 0)..(1, 5),
+                (0, 0)..(0, 1),
+                vec![],
+            ),
+        ];
 
         let snapshot = buffer.read_with(cx, |buffer, _| buffer.snapshot());
         let mut items = Vec::new();
         flatten_document_symbols(&symbols, &snapshot, 0, &mut items);
 
-        assert_eq!(items.len(), 1);
-        // Name newlines collapsed to space
+        assert_eq!(items.len(), 4);
         assert_eq!(items[0].text, "line1 line2");
+        assert_eq!(items[1].text, "a b");
+        assert_eq!(items[2].text, "a b");
+        assert_eq!(items[3].text, "a b");
     }
 }


### PR DESCRIPTION
LSP servers may return symbol names containing newlines. Since outline panel, breadcrumbs, and project search modal all expect single-line items, collapse newlines before display.

- Document symbols: collapse newlines to spaces in name
- Workspace symbols: collapse newlines with `↵ ` separator for name and container_name, preserving visual hint of original structure

Closes #ISSUE

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- N/A
