### PR TITLE
document_symbols: Display LSP detail field in outline

### DIFF
--- a/crates/editor/src/document_symbols.rs
+++ b/crates/editor/src/document_symbols.rs
@@ -252,8 +252,13 @@ fn apply_highlights(
         let symbol_range = item.range.to_offset(buffer_snapshot);
         let selection_start = item.source_range_for_text.start.to_offset(buffer_snapshot);
 
-        if let Some(highlights) = highlights_from_buffer(
-            &item.text,
+        // Only apply syntax highlights to the name portion of the text,
+        // not to any appended detail text.
+        let name_end = item.name_ranges.last().map_or(0, |r| r.end);
+        let name_text = &item.text[..name_end];
+
+        if let Some(syntax_highlights) = highlights_from_buffer(
+            name_text,
             0,
             buffer_id,
             buffer_snapshot,
@@ -262,7 +267,13 @@ fn apply_highlights(
             selection_start,
             syntax_theme,
         ) {
-            item.highlight_ranges = highlights;
+            if item.highlight_ranges.is_empty() {
+                item.highlight_ranges = syntax_highlights;
+            } else {
+                item.highlight_ranges =
+                    gpui::combine_highlights(syntax_highlights, item.highlight_ranges.drain(..))
+                        .collect();
+            }
         }
     }
 }
@@ -427,6 +438,7 @@ mod tests {
 
     fn nested_symbol(
         name: &str,
+        detail: Option<&str>,
         kind: lsp::SymbolKind,
         range: lsp::Range,
         selection_range: lsp::Range,
@@ -435,7 +447,7 @@ mod tests {
         #[allow(deprecated)]
         lsp::DocumentSymbol {
             name: name.to_string(),
-            detail: None,
+            detail: detail.map(|d| d.to_string()),
             kind,
             tags: None,
             deprecated: None,
@@ -471,6 +483,7 @@ mod tests {
                     Ok(Some(lsp::DocumentSymbolResponse::Nested(vec![
                         nested_symbol(
                             "main",
+                            None,
                             lsp::SymbolKind::FUNCTION,
                             lsp_range(0, 0, 2, 1),
                             lsp_range(0, 3, 0, 7),
@@ -511,12 +524,14 @@ mod tests {
                     Ok(Some(lsp::DocumentSymbolResponse::Nested(vec![
                         nested_symbol(
                             "Foo",
+                            Some("{ bar: u32, baz: String }"),
                             lsp::SymbolKind::STRUCT,
                             lsp_range(0, 0, 3, 1),
                             lsp_range(0, 7, 0, 10),
                             vec![
                                 nested_symbol(
                                     "bar",
+                                    Some(""),
                                     lsp::SymbolKind::FIELD,
                                     lsp_range(1, 4, 1, 13),
                                     lsp_range(1, 4, 1, 7),
@@ -524,6 +539,7 @@ mod tests {
                                 ),
                                 nested_symbol(
                                     "baz",
+                                    None,
                                     lsp::SymbolKind::FIELD,
                                     lsp_range(2, 4, 2, 15),
                                     lsp_range(2, 4, 2, 7),
@@ -542,8 +558,8 @@ mod tests {
         cx.update_editor(|editor, _window, _cx| {
             assert_eq!(
                 outline_symbol_names(editor),
-                vec!["struct Foo", "bar"],
-                "cursor is inside Foo > bar, so we expect the containing chain"
+                vec!["struct Foo { bar: u32, baz: String }", "bar"],
+                "detail is appended to Foo; empty detail on bar is ignored"
             );
         });
     }
@@ -567,6 +583,7 @@ mod tests {
                     Ok(Some(lsp::DocumentSymbolResponse::Nested(vec![
                         nested_symbol(
                             "lsp_main_symbol",
+                            None,
                             lsp::SymbolKind::FUNCTION,
                             lsp_range(0, 0, 2, 1),
                             lsp_range(0, 3, 0, 7),
@@ -651,6 +668,7 @@ mod tests {
                     Ok(Some(lsp::DocumentSymbolResponse::Nested(vec![
                         nested_symbol(
                             "main",
+                            None,
                             lsp::SymbolKind::FUNCTION,
                             lsp_range(0, 0, 2, 1),
                             lsp_range(0, 3, 0, 7),
@@ -749,11 +767,13 @@ mod tests {
                     Ok(Some(lsp::DocumentSymbolResponse::Nested(vec![
                         nested_symbol(
                             "MyModule",
+                            None,
                             lsp::SymbolKind::MODULE,
                             lsp_range(0, 0, 4, 1),
                             lsp_range(0, 4, 0, 12),
                             vec![nested_symbol(
                                 "my_function",
+                                None,
                                 lsp::SymbolKind::FUNCTION,
                                 lsp_range(1, 4, 3, 5),
                                 lsp_range(1, 7, 1, 18),
@@ -806,6 +826,7 @@ mod tests {
                     Ok(Some(lsp::DocumentSymbolResponse::Nested(vec![
                         nested_symbol(
                             "test",
+                            None,
                             lsp::SymbolKind::FUNCTION,
                             lsp_range(0, 0, 1, 13), // includes doc comment
                             lsp_range(1, 3, 1, 7),  // "test"
@@ -914,6 +935,7 @@ mod tests {
                     Ok(Some(lsp::DocumentSymbolResponse::Nested(vec![
                         nested_symbol(
                             "should_not_appear",
+                            None,
                             lsp::SymbolKind::FUNCTION,
                             lsp_range(0, 0, 2, 1),
                             lsp_range(0, 3, 0, 7),

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -28302,10 +28302,7 @@ pub fn styled_runs_for_code_label<'a>(
     syntax_theme: &'a theme::SyntaxTheme,
     local_player: &'a theme::PlayerColor,
 ) -> impl 'a + Iterator<Item = (Range<usize>, HighlightStyle)> {
-    let fade_out = HighlightStyle {
-        fade_out: Some(0.35),
-        ..Default::default()
-    };
+    let fade_out = HighlightStyle::FADE_OUT;
 
     let mut prev_end = label.filter_range.end;
     label

--- a/crates/gpui/src/style.rs
+++ b/crates/gpui/src/style.rs
@@ -891,6 +891,18 @@ impl From<&TextStyle> for HighlightStyle {
 }
 
 impl HighlightStyle {
+    /// A highlight style that fades out supplemental text (e.g. completion label
+    /// details, document symbol details).
+    pub const FADE_OUT: Self = Self {
+        color: None,
+        font_weight: None,
+        font_style: None,
+        background_color: None,
+        underline: None,
+        strikethrough: None,
+        fade_out: Some(0.35),
+    };
+
     /// Create a highlight style with just a color
     pub fn color(color: Hsla) -> Self {
         Self {

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -1711,6 +1711,7 @@ impl LspCommand for GetDocumentSymbols {
                 .into_iter()
                 .map(|lsp_symbol| DocumentSymbol {
                     name: lsp_symbol.name,
+                    detail: None,
                     kind: lsp_symbol.kind,
                     range: range_from_lsp(lsp_symbol.location.range),
                     selection_range: range_from_lsp(lsp_symbol.location.range),
@@ -1721,6 +1722,7 @@ impl LspCommand for GetDocumentSymbols {
                 fn convert_symbol(lsp_symbol: lsp::DocumentSymbol) -> DocumentSymbol {
                     DocumentSymbol {
                         name: lsp_symbol.name,
+                        detail: lsp_symbol.detail,
                         kind: lsp_symbol.kind,
                         range: range_from_lsp(lsp_symbol.range),
                         selection_range: range_from_lsp(lsp_symbol.selection_range),
@@ -1795,6 +1797,7 @@ impl LspCommand for GetDocumentSymbols {
                             .into_iter()
                             .map(convert_symbol_to_proto)
                             .collect(),
+                        detail: symbol.detail,
                     }
                 }
                 convert_symbol_to_proto(symbol)
@@ -1831,6 +1834,7 @@ impl LspCommand for GetDocumentSymbols {
 
                 Ok(DocumentSymbol {
                     name: serialized_symbol.name,
+                    detail: serialized_symbol.detail,
                     kind,
                     range: Unclipped(PointUtf16::new(start.row, start.column))
                         ..Unclipped(PointUtf16::new(end.row, end.column)),

--- a/crates/project/src/lsp_store/document_symbols.rs
+++ b/crates/project/src/lsp_store/document_symbols.rs
@@ -7,7 +7,7 @@ use clock::Global;
 use collections::HashMap;
 use futures::FutureExt as _;
 use futures::future::{Shared, join_all};
-use gpui::{AppContext as _, Context, Entity, Task};
+use gpui::{AppContext as _, Context, Entity, HighlightStyle, Task};
 use itertools::Itertools;
 use language::{Buffer, BufferSnapshot, OutlineItem};
 use lsp::LanguageServerId;
@@ -248,6 +248,8 @@ fn flatten_document_symbols(
     depth: usize,
     output: &mut Vec<OutlineItem<Anchor>>,
 ) {
+    let fade_out = HighlightStyle::FADE_OUT;
+
     for symbol in symbols {
         let name = super::collapse_newlines(&symbol.name, " ");
 
@@ -260,19 +262,45 @@ fn flatten_document_symbols(
         let selection_range =
             snapshot.anchor_after(selection_start)..snapshot.anchor_before(selection_end);
 
-        let (text, name_ranges, source_range_for_text) =
+        let is_whitespace_name = symbol.name.trim().is_empty();
+
+        let (mut text, mut name_ranges, source_range_for_text) = if is_whitespace_name {
+            (name.clone(), vec![0..name.len()], selection_range.clone())
+        } else {
             enriched_symbol_text(&name, start, selection_start, selection_end, snapshot)
                 .unwrap_or_else(|| {
                     let name_len = name.len();
                     (name.clone(), vec![0..name_len], selection_range.clone())
-                });
+                })
+        };
+
+        let mut highlight_ranges = Vec::new();
+
+        if let Some(raw_detail) = &symbol.detail {
+            let detail = super::collapse_newlines(raw_detail, " ");
+            if is_whitespace_name {
+                // Case A: name is whitespace-only (e.g. Namespace symbols from JETLS).
+                // Use detail as the display text, faded out entirely.
+                text = detail.clone();
+                let text_len = text.len();
+                name_ranges = vec![0..text_len];
+                highlight_ranges.push((0..text_len, fade_out));
+            } else if !detail.is_empty() {
+                // Case B: regular symbol with non-empty detail.
+                // Append detail after separator, faded out.
+                let detail_start = text.len() + 1;
+                text.push(' ');
+                text.push_str(&detail);
+                highlight_ranges.push((detail_start..text.len(), fade_out));
+            }
+        }
 
         output.push(OutlineItem {
             depth,
             range,
             source_range_for_text,
             text,
-            highlight_ranges: Vec::new(),
+            highlight_ranges,
             name_ranges,
             body_range: None,
             annotation_range: None,
@@ -331,6 +359,7 @@ mod tests {
 
     fn make_symbol(
         name: &str,
+        detail: Option<&str>,
         kind: lsp::SymbolKind,
         range: std::ops::Range<(u32, u32)>,
         selection_range: std::ops::Range<(u32, u32)>,
@@ -339,6 +368,7 @@ mod tests {
         use text::PointUtf16;
         DocumentSymbol {
             name: name.to_string(),
+            detail: detail.map(|d| d.to_string()),
             kind,
             range: Unclipped(PointUtf16::new(range.start.0, range.start.1))
                 ..Unclipped(PointUtf16::new(range.end.0, range.end.1)),
@@ -377,12 +407,14 @@ mod tests {
         let symbols = vec![
             make_symbol(
                 "Foo",
+                Some("{\n  bar: u32,\n  baz: String\n}"),
                 lsp::SymbolKind::STRUCT,
                 (0, 0)..(3, 1),
                 (0, 7)..(0, 10),
                 vec![
                     make_symbol(
                         "bar",
+                        Some(""),
                         lsp::SymbolKind::FIELD,
                         (1, 4)..(1, 13),
                         (1, 4)..(1, 7),
@@ -390,6 +422,7 @@ mod tests {
                     ),
                     make_symbol(
                         "baz",
+                        None,
                         lsp::SymbolKind::FIELD,
                         (2, 4)..(2, 15),
                         (2, 4)..(2, 7),
@@ -399,11 +432,13 @@ mod tests {
             ),
             make_symbol(
                 "Foo",
+                None,
                 lsp::SymbolKind::STRUCT,
                 (5, 0)..(9, 1),
                 (5, 5)..(5, 8),
                 vec![make_symbol(
                     "new",
+                    None,
                     lsp::SymbolKind::FUNCTION,
                     (6, 4)..(8, 5),
                     (6, 7)..(6, 10),
@@ -419,13 +454,19 @@ mod tests {
 
         assert_eq!(items.len(), 5);
 
+        // Non-empty detail is appended with FADE_OUT.
         assert_eq!(items[0].depth, 0);
-        assert_eq!(items[0].text, "struct Foo");
+        assert_eq!(items[0].text, "struct Foo { bar: u32, baz: String }");
         assert_eq!(items[0].name_ranges, vec![7..10]);
+        assert_eq!(items[0].highlight_ranges.len(), 1);
+        assert_eq!(items[0].highlight_ranges[0].0, 11..36);
+        assert_eq!(items[0].highlight_ranges[0].1, HighlightStyle::FADE_OUT);
 
+        // Empty detail is not appended.
         assert_eq!(items[1].depth, 1);
         assert_eq!(items[1].text, "bar");
         assert_eq!(items[1].name_ranges, vec![0..3]);
+        assert!(items[1].highlight_ranges.is_empty());
 
         assert_eq!(items[2].depth, 1);
         assert_eq!(items[2].text, "baz");
@@ -438,6 +479,38 @@ mod tests {
         assert_eq!(items[4].depth, 1);
         assert_eq!(items[4].text, "fn new");
         assert_eq!(items[4].name_ranges, vec![3..6]);
+
+        // Whitespace-only name is replaced by detail entirely
+        let buffer =
+            cx.new(|cx| Buffer::local(concat!("let x = 42\n", "    y = x + 1\n", "end\n"), cx));
+
+        let symbols = vec![make_symbol(
+            " ",
+            Some("let\n  x = 42"),
+            lsp::SymbolKind::NAMESPACE,
+            (0, 0)..(2, 3),
+            (0, 0)..(0, 1),
+            vec![make_symbol(
+                "x",
+                None,
+                lsp::SymbolKind::VARIABLE,
+                (0, 4)..(0, 5),
+                (0, 4)..(0, 5),
+                vec![],
+            )],
+        )];
+
+        let snapshot = buffer.read_with(cx, |buffer, _| buffer.snapshot());
+        let mut items = Vec::new();
+        flatten_document_symbols(&symbols, &snapshot, 0, &mut items);
+
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].text, "let x = 42");
+        assert_eq!(items[0].name_ranges, vec![0..10]);
+        assert_eq!(items[0].highlight_ranges.len(), 1);
+        assert_eq!(items[0].highlight_ranges[0].0, 0..10);
+        assert_eq!(items[0].highlight_ranges[0].1, HighlightStyle::FADE_OUT);
+        assert_eq!(items[1].text, "x");
     }
 
     #[gpui::test]
@@ -449,51 +522,5 @@ mod tests {
         let mut items = Vec::new();
         flatten_document_symbols(&symbols, &snapshot, 0, &mut items);
         assert!(items.is_empty());
-    }
-
-    #[gpui::test]
-    async fn test_newlines_collapsed_in_name(cx: &mut TestAppContext) {
-        let buffer = cx.new(|cx| Buffer::local("x = 1\ny = 2\n", cx));
-
-        let symbols = vec![
-            make_symbol(
-                "line1\nline2",
-                lsp::SymbolKind::VARIABLE,
-                (0, 0)..(0, 5),
-                (0, 0)..(0, 1),
-                vec![],
-            ),
-            make_symbol(
-                "  a  \n  b  ",
-                lsp::SymbolKind::VARIABLE,
-                (1, 0)..(1, 5),
-                (1, 0)..(1, 1),
-                vec![],
-            ),
-            make_symbol(
-                "a\r\nb",
-                lsp::SymbolKind::VARIABLE,
-                (0, 0)..(1, 5),
-                (0, 0)..(0, 1),
-                vec![],
-            ),
-            make_symbol(
-                "a\n\nb",
-                lsp::SymbolKind::VARIABLE,
-                (0, 0)..(1, 5),
-                (0, 0)..(0, 1),
-                vec![],
-            ),
-        ];
-
-        let snapshot = buffer.read_with(cx, |buffer, _| buffer.snapshot());
-        let mut items = Vec::new();
-        flatten_document_symbols(&symbols, &snapshot, 0, &mut items);
-
-        assert_eq!(items.len(), 4);
-        assert_eq!(items[0].text, "line1 line2");
-        assert_eq!(items[1].text, "a b");
-        assert_eq!(items[2].text, "a b");
-        assert_eq!(items[3].text, "a b");
     }
 }

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -839,6 +839,7 @@ pub struct Symbol {
 #[derive(Clone, Debug)]
 pub struct DocumentSymbol {
     pub name: String,
+    pub detail: Option<String>,
     pub kind: lsp::SymbolKind,
     pub range: Range<Unclipped<PointUtf16>>,
     pub selection_range: Range<Unclipped<PointUtf16>>,

--- a/crates/proto/proto/lsp.proto
+++ b/crates/proto/proto/lsp.proto
@@ -132,6 +132,7 @@ message DocumentSymbol {
   PointUtf16 selection_start = 5;
   PointUtf16 selection_end = 6;
   repeated DocumentSymbol children = 7;
+  optional string detail = 8;
 }
 
 message InlayHints {


### PR DESCRIPTION
Propagate the LSP `detail` field through `DocumentSymbol` so that outline views can show supplemental text.
When the symbol name is whitespace-only, `detail` replaces the display text entirely. Otherwise it is appended with a faded style. The `detail` text is also searchable in the outline panel.

Also extract `HighlightStyle::FADE_OUT` as a shared constant, reused by both completion labels and document symbol details.

Closes #ISSUE

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- N/A *or* Added/Fixed/Improved ...

---

Example using [JETLS](https://github.com/aviatesk/JETLS.jl) Julia language server:
<img width="636" height="704" alt="Screenshot 2026-02-13 at 21 50 15" src="https://github.com/user-attachments/assets/6e6f9766-b578-4587-8909-f2d44f49f11c" />
