### PR TITLE
agent_ui: Fix max tokens error not being shown

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -1955,6 +1955,11 @@ impl AcpThread {
                         cx.emit(AcpThreadEvent::Error);
                         Err(e)
                     }
+                    Ok(Ok(r)) if r.stop_reason == acp::StopReason::MaxTokens => {
+                        this.send_task.take();
+                        cx.emit(AcpThreadEvent::Error);
+                        Err(anyhow!("Max tokens reached"))
+                    }
                     result => {
                         let canceled = matches!(
                             result,


### PR DESCRIPTION
Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Fixed an issue where no error was shown when an LLM request exceeded the maximum tokens supported by the model
