### PR TITLE
acp_thread: Await Tree-sitter parsing before building agent panel diffs

### DIFF
--- a/crates/acp_thread/src/diff.rs
+++ b/crates/acp_thread/src/diff.rs
@@ -36,6 +36,7 @@ impl Diff {
                     .log_err();
 
                 buffer.update(cx, |buffer, cx| buffer.set_language(language.clone(), cx));
+                buffer.update(cx, |buffer, _| buffer.parsing_idle()).await;
 
                 let diff = build_buffer_diff(
                     old_text.unwrap_or("".into()).into(),
@@ -287,6 +288,7 @@ impl PendingDiff {
         let buffer_diff = cx.spawn({
             let buffer = buffer.clone();
             async move |_this, cx| {
+                buffer.update(cx, |buffer, _| buffer.parsing_idle()).await;
                 build_buffer_diff(base_text, &buffer, language_registry, cx).await
             }
         });


### PR DESCRIPTION
## Summary

Fixes https://github.com/zed-industries/zed/issues/48684

- Await `parsing_idle()` after `set_language()` in both `Diff::finalized()` and `PendingDiff::finalize()` so that tree-sitter parsing completes before buffer snapshots are taken for excerpts
- Without this, the 1ms sync parse timeout almost always expires for non-trivial files, causing excerpts to be created with empty syntax trees and missing syntax highlighting

## Root Cause

When the agent panel creates or finalizes a diff, it creates a new `Buffer`, calls `set_language()` (which triggers async tree-sitter parsing), then immediately proceeds to take buffer snapshots and create excerpts **without waiting for parsing to complete**. The sync parse timeout is only 1ms in production (`buffer.rs:1138`), so large files almost always fail the sync parse and fall back to async parsing — but no one awaits the async parse before building the diff.

## Fix

Add `buffer.update(cx, |buffer, _| buffer.parsing_idle()).await` after `set_language()` in both code paths (`Diff::finalized()` and `PendingDiff::finalize()`). This is the same pattern already used in `buffer_diff.rs:1728-1731`.

## Test plan

- [x] `cargo test -p acp_thread` — all relevant tests pass
- [x] `./script/clippy` — no warnings
- [x] Manual test: open agent panel, ask it to generate a Python file with multiline strings (`"""`), verify syntax highlighting is correct after diff is finalized

Release Notes:

- Fixed missing syntax highlighting for multiline strings in agent panel diffs

🤖 Generated with [Claude Code](https://claude.com/claude-code)