### PR TITLE
Turn `subagents` flag to false

### DIFF
--- a/crates/feature_flags/src/flags.rs
+++ b/crates/feature_flags/src/flags.rs
@@ -40,7 +40,7 @@ impl FeatureFlag for SubagentsFeatureFlag {
     const NAME: &'static str = "subagents";
 
     fn enabled_for_staff() -> bool {
-        true
+        false
     }
 }
 


### PR DESCRIPTION
Accidentally committed the feature flag change in https://github.com/zed-industries/zed/pull/49100 as I had it turned to true for local testing. This PR reverts that and turns it to off again — sorry!

Release Notes:

- N/A
