### PR TITLE
Fix user global settings overriding language-specific defaults

### DIFF
--- a/crates/settings_content/src/language.rs
+++ b/crates/settings_content/src/language.rs
@@ -52,12 +52,16 @@ impl merge_from::MergeFrom for AllLanguageSettingsContent {
         self.file_types.merge_from(&other.file_types);
         self.edit_predictions.merge_from(&other.edit_predictions);
 
-        // A user's global settings override the default global settings and
-        // all default language-specific settings.
-        //
+        // A user's global settings override the default global settings.
         self.defaults.merge_from(&other.defaults);
+
+        // A user's global settings fill in any gaps in default language-specific
+        // settings, but do not override values that were already explicitly set
+        // for a language (e.g. Markdown's `allow_rewrap: "anywhere"`).
         for language_settings in self.languages.0.values_mut() {
-            language_settings.merge_from(&other.defaults);
+            let mut merged = other.defaults.clone();
+            merged.merge_from(language_settings);
+            *language_settings = merged;
         }
 
         // A user's language-specific settings override default language-specific settings.
@@ -1116,6 +1120,147 @@ mod test {
         let raw_auto = "{\"formatter\": {}}";
         let (_, result) = fallible_options::parse_json::<LanguageSettingsContent>(raw_auto);
         assert!(matches!(result, ParseStatus::Failed { .. }));
+    }
+
+    #[test]
+    fn test_user_global_defaults_do_not_override_language_specific_settings() {
+        use crate::merge_from::MergeFrom;
+
+        // Simulate default.json: global allow_rewrap is "in_comments",
+        // but Markdown has "anywhere"
+        let mut defaults = AllLanguageSettingsContent {
+            defaults: LanguageSettingsContent {
+                allow_rewrap: Some(RewrapBehavior::InComments),
+                ..Default::default()
+            },
+            languages: LanguageToSettingsMap({
+                let mut map = HashMap::default();
+                map.insert(
+                    "Markdown".to_string(),
+                    LanguageSettingsContent {
+                        allow_rewrap: Some(RewrapBehavior::Anywhere),
+                        ..Default::default()
+                    },
+                );
+                map
+            }),
+            ..Default::default()
+        };
+
+        // Simulate user settings.json: explicitly sets global allow_rewrap to "in_comments"
+        let user_settings = AllLanguageSettingsContent {
+            defaults: LanguageSettingsContent {
+                allow_rewrap: Some(RewrapBehavior::InComments),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        defaults.merge_from(&user_settings);
+
+        // Markdown's "anywhere" should be preserved, not overridden by user global "in_comments"
+        let markdown_settings = defaults.languages.0.get("Markdown").unwrap();
+        assert_eq!(
+            markdown_settings.allow_rewrap,
+            Some(RewrapBehavior::Anywhere),
+        );
+    }
+
+    #[test]
+    fn test_user_language_specific_settings_override_defaults() {
+        use crate::merge_from::MergeFrom;
+
+        let mut defaults = AllLanguageSettingsContent {
+            defaults: LanguageSettingsContent {
+                allow_rewrap: Some(RewrapBehavior::InComments),
+                ..Default::default()
+            },
+            languages: LanguageToSettingsMap({
+                let mut map = HashMap::default();
+                map.insert(
+                    "Markdown".to_string(),
+                    LanguageSettingsContent {
+                        allow_rewrap: Some(RewrapBehavior::Anywhere),
+                        ..Default::default()
+                    },
+                );
+                map
+            }),
+            ..Default::default()
+        };
+
+        // User explicitly sets Markdown to "in_selections"
+        let user_settings = AllLanguageSettingsContent {
+            languages: LanguageToSettingsMap({
+                let mut map = HashMap::default();
+                map.insert(
+                    "Markdown".to_string(),
+                    LanguageSettingsContent {
+                        allow_rewrap: Some(RewrapBehavior::InSelections),
+                        ..Default::default()
+                    },
+                );
+                map
+            }),
+            ..Default::default()
+        };
+
+        defaults.merge_from(&user_settings);
+
+        let markdown_settings = defaults.languages.0.get("Markdown").unwrap();
+        assert_eq!(
+            markdown_settings.allow_rewrap,
+            Some(RewrapBehavior::InSelections),
+        );
+    }
+
+    #[test]
+    fn test_user_global_defaults_fill_gaps_in_language_settings() {
+        use crate::merge_from::MergeFrom;
+        use std::num::NonZeroU32;
+
+        // Default: Markdown has allow_rewrap set but no tab_size
+        let mut defaults = AllLanguageSettingsContent {
+            defaults: LanguageSettingsContent {
+                allow_rewrap: Some(RewrapBehavior::InComments),
+                ..Default::default()
+            },
+            languages: LanguageToSettingsMap({
+                let mut map = HashMap::default();
+                map.insert(
+                    "Markdown".to_string(),
+                    LanguageSettingsContent {
+                        allow_rewrap: Some(RewrapBehavior::Anywhere),
+                        ..Default::default()
+                    },
+                );
+                map
+            }),
+            ..Default::default()
+        };
+
+        // User sets global tab_size to 8
+        let user_settings = AllLanguageSettingsContent {
+            defaults: LanguageSettingsContent {
+                tab_size: Some(NonZeroU32::new(8).unwrap()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        defaults.merge_from(&user_settings);
+
+        let markdown_settings = defaults.languages.0.get("Markdown").unwrap();
+        // Markdown's allow_rewrap should be preserved
+        assert_eq!(
+            markdown_settings.allow_rewrap,
+            Some(RewrapBehavior::Anywhere),
+        );
+        // User's global tab_size should fill in the gap
+        assert_eq!(
+            markdown_settings.tab_size,
+            Some(NonZeroU32::new(8).unwrap()),
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fixes #49088
- When a user explicitly set a global setting like `"allow_rewrap": "in_comments"` in their `settings.json`, it would override language-specific defaults from `default.json` (e.g. Markdown's `"allow_rewrap": "anywhere"`), breaking rewrap in Markdown, Plain Text, and Git Commit files.
- The fix reverses the merge direction in `AllLanguageSettingsContent::merge_from` so that language-specific default values take priority over user global defaults, while user globals still fill in any unset fields.

## Root Cause

In `crates/settings_content/src/language.rs`, the `merge_from` implementation had this step:

```rust
for language_settings in self.languages.0.values_mut() {
    language_settings.merge_from(&other.defaults); // user global overrides language defaults
}
```

This unconditionally overwrites language-specific settings with the user's global defaults. For Markdown, this turns `"allow_rewrap": "anywhere"` into `"in_comments"`. Since Markdown has no comment syntax, `inside_comment` is always `false`, and rewrap is rejected.

## Fix

Reverse the merge direction so language-specific values take priority:

```rust
for language_settings in self.languages.0.values_mut() {
    let mut merged = other.defaults.clone();
    merged.merge_from(language_settings); // language defaults override user global
    *language_settings = merged;
}
```

This preserves explicitly configured language defaults while still allowing user global settings to fill in any gaps.

## Test Plan

- [x] Added 3 unit tests covering: global defaults don't override language settings, user language-specific settings still override, and global defaults fill gaps for unset fields
- [x] All existing `settings_content` (23) and `settings` (17) tests pass
- [x] Manual testing: set `"allow_rewrap": "in_comments"` globally, verified `editor::Rewrap` works in Markdown files

Release Notes:

- Fixed `editor::Rewrap` not working in Markdown/Plain Text files when `allow_rewrap` is explicitly set to `in_comments` in user settings ([#49088](https://github.com/zed-industries/zed/issues/49088)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)