### PR TITLE
linux: Fix desktop entry pointing to wrong binary in manual install docs

### DIFF
--- a/docs/src/linux.md
+++ b/docs/src/linux.md
@@ -93,7 +93,7 @@ If you'd like integration with an XDG-compatible desktop environment, you will a
 ```sh
 install -D ~/.local/zed.app/share/applications/dev.zed.Zed.desktop -t ~/.local/share/applications
 sed -i "s|Icon=zed|Icon=$HOME/.local/zed.app/share/icons/hicolor/512x512/apps/zed.png|g" ~/.local/share/applications/dev.zed.Zed.desktop
-sed -i "s|Exec=zed|Exec=$HOME/.local/zed.app/libexec/zed-editor|g" ~/.local/share/applications/dev.zed.Zed.desktop
+sed -i "s|Exec=zed|Exec=$HOME/.local/zed.app/bin/zed|g" ~/.local/share/applications/dev.zed.Zed.desktop
 ```
 
 ## Uninstalling Zed


### PR DESCRIPTION
Follow-up to #21137

The manual install instructions in `linux.md` set `Exec=` to `libexec/zed-editor` (main binary) instead of `bin/zed` (cli).

Using `zed-editor` directly throws "zed is already running" error and files won't open from the file explorer. The "Open a new workspace" right-click option on the desktop entry also doesn't work correctly.

Release Notes:

- N/A