### PR TITLE
docs: Enrich .rules for AI-assisted development (Background Agent Week 1)

### DIFF
--- a/.rules
+++ b/.rules
@@ -136,3 +136,215 @@ Other entities can then register a callback to handle these events by doing `cx.
 ## Build guidelines
 
 - Use `./script/clippy` instead of `cargo clippy`
+
+# Build, Test, and Run
+
+## Building
+- `cargo build` / `cargo build -p <crate>` — build all or a specific crate
+- `cargo run` — run debug build
+- `cargo run --profile release-fast` — run optimized build
+
+## Testing
+- `cargo test -p <crate>` — test a specific crate
+- `cargo test -p <crate> <test_name>` — run a specific test
+
+## Linting and Formatting
+- `./script/clippy` — run clippy (NOT `cargo clippy`)
+- `cargo fmt` — format Rust code
+- `prettier` — format docs
+
+## Scripts
+- `./script/new-crate <name>` — create a new crate (uses `src/<crate_name>.rs`, not `src/lib.rs`)
+
+# Crate Architecture Map
+
+## Core Framework
+- `gpui` — UI framework with state/concurrency primitives
+- `gpui_macros` — proc macros for gpui
+- `ui` — reusable UI components
+- `ui_input` — text input components
+
+## Editor Stack
+- `editor` — main code editor (also used for all text inputs)
+- `text` — text data structures
+- `rope` — rope data structure for efficient text
+- `multi_buffer` — wraps multiple buffers into one view
+
+## Language/LSP
+- `language` — language definitions, syntax highlighting
+- `lsp` — LSP client implementation
+- `languages` — built-in language configurations
+
+## AI/Agent
+- `agent` — core agent logic, thread store, tools
+- `agent_settings` — agent configuration
+- `agent_ui` — agent panel UI
+- `agent_ui_v2` — new agent panel UI
+- `language_model` — model abstractions
+- Provider crates: `anthropic`, `open_ai`, `google_ai`, `ollama`, `copilot`, etc.
+
+## Workspace
+- `workspace` — window layout, panes, items, docks, panels
+- `project` — project state, file operations, stores (BufferStore, LspStore, GitStore)
+- `worktree` — file tree watching and state
+
+## Collaboration
+- `collab` — collaboration server
+- `rpc` — RPC protocol
+- `client` — Zed client for server communication
+- `call` — voice/video calls
+
+## Settings
+- `settings` — settings framework
+- `settings_content` — built-in settings schema
+
+## Extensions
+- `extension` — extension types
+- `extension_host` — extension runtime
+- `extension_api` — API exposed to extensions
+
+## Dev Tools
+- `terminal` / `terminal_view` — integrated terminal
+- `dap` / `debugger_ui` — debugger
+- `git` / `git_ui` — git integration
+- `repl` — REPL support
+
+# Anti-Patterns (from clippy.toml and common bugs)
+
+- `std::process::Command` → `smol::process::Command` (blocking)
+- `smol::Timer::after` → `gpui::BackgroundExecutor::timer` (non-deterministic in tests)
+- `serde_json::from_reader` → `serde_json::from_slice` (performance)
+- No `mod.rs` — use `src/some_module.rs` instead
+- No `src/lib.rs` for new crates — use `src/<crate_name>.rs`
+- No `unwrap()` — use `?` to propagate errors
+- No `let _ =` on Results — use `.log_err()` or handle explicitly
+- No holding references across await points
+- No re-entrant entity updates (causes panic)
+- `as_raw_fd()` → `into_raw_fd()` when transferring file descriptor ownership (prevents double-close)
+- When traversing parent/child graphs (process trees, entity hierarchies), track visited nodes in a `HashSet` to prevent infinite loops from cycles
+- When comparing or merging buffer events, verify `remote_id()` matches — buffers can be swapped out between operations
+
+# Testing Patterns
+
+## Basic Test Setup
+- `#[gpui::test]` attribute with `TestAppContext` or `App`
+- `init_test(cx, |_| {})` — initialize test environment
+- `cx.run_until_parked()` / `executor.run_until_parked()` — drain async executor
+
+## Editor Testing
+- `EditorTestContext::new(cx).await` — create test editor context
+- Marked text format: `ˇ` = cursor position, `«selection»` = selection
+- `cx.set_state("code with ˇcursor")` — set editor state with cursor
+- `cx.assert_state("expected ˇstate")` — verify editor state
+- `cx.simulate_keystrokes(["a", "b", "enter"])` — simulate input
+
+## Language Testing
+- `rust_lang()` — get Rust language for tests
+- `cx.update_buffer(|buffer, cx| buffer.set_language(Some(rust_lang()), cx))`
+
+## Diff Testing
+- `cx.set_head_text(&diff_base)` — set git HEAD content for diff
+- `editor.expand_all_diff_hunks(...)` — expand inline diffs
+- `editor.collapse_all_diff_hunks(...)` — collapse inline diffs
+
+## Filesystem Mocking
+- `FakeFs::new(cx.background_executor.clone())` — mock filesystem
+- `fs.as_fake().insert_tree(path, json!({...})).await` — populate fake filesystem
+
+## Vim Testing
+- `cx.set_shared_state(indoc! {"..."}).await` — set initial vim state
+- `cx.simulate_shared_keystrokes("$ k").await` — simulate vim keystrokes
+- `cx.shared_state().await.assert_eq(...)` — verify vim state
+- Test data files in `crates/vim/test_data/` for snapshot testing
+
+## Modal and Action Testing
+- `cx.dispatch_action(*window, SomeAction)` — trigger action/modal
+- `workspace.read(cx).active_modal::<ModalType>(cx)` — verify modal is open
+- `cx.simulate_prompt_answer("Button Text")` — simulate dialog response
+- Test both single-item and multiple-item cases for pickers
+
+## Critical: Crash Regression Tests
+
+When writing regression tests for crashes (e.g., from Sentry reports):
+
+**DO:** Write tests that exercise user-visible operations through the editor's public API and test utilities. The test should reproduce a realistic sequence of actions a user could perform.
+
+**DON'T:** Directly construct the failure state. A test that manually creates invalid data structures is technically correct but practically useless — it doesn't tell you how to fix the crash because it doesn't show how a user could trigger it.
+
+Example of a GOOD crash regression test (from Eric Holk's Sentry experiment):
+```rust
+#[gpui::test]
+async fn test_stale_offset_after_diff_collapse(executor: BackgroundExecutor, cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+    let mut cx = EditorTestContext::new(cx).await;
+    cx.update_buffer(|buffer, cx| buffer.set_language(Some(rust_lang()), cx));
+    
+    cx.set_state(&"fn main() { let x = ˇ1; }".unindent());
+    cx.set_head_text(&deleted_functions_diff_base);
+    executor.run_until_parked();
+    
+    // Expand diff hunks (makes multi-buffer longer)
+    cx.update_editor(|editor, window, cx| {
+        editor.expand_all_diff_hunks(&ExpandAllDiffHunks, window, cx);
+    });
+    executor.run_until_parked();
+    
+    // Store offsets via syntax node selection
+    cx.update_editor(|editor, window, cx| {
+        editor.select_larger_syntax_node(&SelectLargerSyntaxNode, window, cx);
+    });
+    
+    // Collapse diff hunks (shrinks multi-buffer, stored offsets now stale)
+    cx.update_editor(|editor, window, cx| {
+        editor.collapse_all_diff_hunks(&CollapseAllDiffHunks, window, cx);
+    });
+    executor.run_until_parked();
+    
+    // This triggers the crash with stale offsets
+    cx.update_editor(|editor, window, cx| {
+        editor.select_smaller_syntax_node(&SelectSmallerSyntaxNode, window, cx);
+    });
+}
+```
+
+# Settings Pattern
+
+## Defining Settings
+Use the derive macro with the `Settings` trait:
+```rust
+#[derive(Default, Clone, Serialize, Deserialize)]
+pub struct MySettings {
+    pub some_option: bool,
+}
+
+impl Settings for MySettings {
+    const KEY: Option<&'static str> = Some("my_settings");
+    // ...
+}
+```
+
+## Accessing Settings
+- Settings layer: global → user → project → buffer
+- `MySettings::get_global(cx)` — get global settings
+- `MySettings::get(Some(buffer_id), cx)` — get settings for a specific buffer
+
+# Workspace Patterns
+
+## Action Naming
+- Actions affecting all panes: `*InAllPanes` (e.g., `CloseItemInAllPanes`)
+- Actions affecting only active item: `*ActiveItem` (e.g., `CloseActiveItem`)
+
+## Closing Items
+- Use `workspace.close_items_with_project_path()` rather than manually iterating panes
+- When user discards unsaved changes, call `item.reload()` to sync from disk
+
+## Persistence
+- When restoring persisted state (threads, sessions), verify data still exists in database before use
+- Users may clear data between sessions — handle missing data gracefully with logging
+
+# Crash Investigation
+
+## Sentry Integration
+- Crash investigation prompts: `.factory/prompts/crash/investigate.md`
+- Crash fix prompts: `.factory/prompts/crash/fix.md`
+- Fetch crash reports: `script/sentry-fetch <issue-id>`

--- a/docs/crate-rules-ownership-plan.md
+++ b/docs/crate-rules-ownership-plan.md
@@ -1,0 +1,154 @@
+# Crate-Level `.rules` Ownership Plan
+
+This document outlines who should write crate-level `.rules` files for the most complex crates, what each should address, and how to use `REVIEWERS.conl` to identify domain experts.
+
+## Background
+
+The root `.rules` file provides general guidance, but complex crates like `gpui`, `editor`, and `agent` need crate-specific documentation that only domain experts can write. These `.rules` files help AI agents (Factory, Codex, Claude Code, Zed Agent Panel) understand:
+- Internal architecture and module layout
+- Key patterns and abstractions
+- Common gotchas and anti-patterns
+- Testing infrastructure specific to the crate
+
+## Using REVIEWERS.conl to Identify Owners
+
+`REVIEWERS.conl` maps domain areas to people with deep expertise. Use this to identify who should write each crate's `.rules`:
+
+| Domain Area | Reviewers | Relevant Crates |
+|------------|-----------|-----------------|
+| `gpui` | @Anthony-Eid, @cameron1024, @mikayla-maki, @probably-neb | `gpui`, `gpui_macros` |
+| `multi_buffer` | @Veykril, @SomeoneToIgnore | `multi_buffer`, `editor` (display_map) |
+| `text` | @Veykril | `text`, `rope` |
+| `ai` | @benbrandt, @bennetbo, @danilo-leal, @rtfeldman | `agent`, `agent_ui`, `agent_ui_v2`, `language_model` |
+| `lsp` | @osiewicz, @smitbarmase, @SomeoneToIgnore, @Veykril | `lsp`, `language` |
+| `languages` | @osiewicz, @probably-neb, @smitbarmase, @SomeoneToIgnore, @Veykril | `languages` |
+| `crashes` | @Veykril | (cross-cutting expertise) |
+| `debugger` | @Anthony-Eid, @kubkon, @osiewicz | `dap`, `debugger_ui` |
+| `terminal` | @kubkon, @Veykril | `terminal`, `terminal_view` |
+| `git` | @cole-miller, @danilo-leal, @yara-blue, @kubkon, @Anthony-Eid, @cameron1024 | `git`, `git_ui` |
+| `vim` | @ConradIrwin, @dinocosta, @probably-neb | `vim` |
+| `extension` | @kubkon | `extension`, `extension_host`, `extension_api` |
+| `tasks` | @SomeoneToIgnore, @Veykril | `task`, `tasks_ui` |
+
+## Priority Crates for `.rules` Files
+
+### Tier 1 (Highest Priority)
+
+These crates have the highest agent failure rate and complexity:
+
+#### 1. `crates/gpui/.rules`
+**Owner:** GPUI maintainers (@Anthony-Eid, @cameron1024, @mikayla-maki)
+**Time estimate:** ~1 hour
+
+Should cover:
+- Module map: `app.rs`, `window.rs`, `elements/`, `platform/`
+- Rendering pipeline: `Render::render()` → element tree → layout → paint
+- Entity lifecycle: creation, reading, updating, dropping, weak references
+- Key types: `Element`, `IntoElement`, `RenderOnce`, `Styled`, `InteractiveElement`
+- Common patterns: `cx.listener()`, `cx.spawn()`, `cx.observe()`, `cx.subscribe()`
+- Test infra: `TestAppContext`, `VisualTestContext`, `#[gpui::test]` behavior
+- Gotchas: re-entrant entity updates panic, `run_until_parked()` semantics
+
+#### 2. `crates/editor/.rules`
+**Owner:** Editor maintainers (@Veykril, @SomeoneToIgnore)
+**Time estimate:** ~1 hour
+
+Should cover:
+- `Editor` is used for code editing AND all text inputs (important context)
+- Display pipeline: `Editor` → `DisplayMap` → `DisplaySnapshot` → render
+- `display_map/` breakdown: folds, inlays, block decorations, wrap maps, tab maps
+- Selection model: `SelectionsCollection`, cursors, multiple cursors
+- `MultiBuffer` wraps `Buffer`(s) — stale offset gotcha
+- Test utilities: `EditorTestContext`, `EditorLspTestContext`, marked text format
+
+#### 3. `crates/agent/.rules`
+**Owner:** Agent team (@benbrandt, @bennetbo, @rtfeldman)
+**Time estimate:** ~1 hour
+
+Should cover:
+- Thread store, threads, tools, edit agent, templates
+- Tool system: how tools are defined (`tools/` directory), permissions
+- Edit agent: `edit_agent/` directory, streaming edit parser
+- Relationship between `agent` (logic), `agent_ui` (UI), `agent_ui_v2` (new UI)
+- Eval framework in `edit_agent/evals/`
+
+#### 4. `crates/workspace/.rules`
+**Owner:** Core team
+**Time estimate:** ~45 minutes
+
+Should cover:
+- Hierarchy: Workspace → Panes → Items; Docks → Panels
+- `Item` trait and `Panel` trait: how to register new types
+- Persistence: `persistence/` module
+- Modal system: `modal_layer.rs`
+
+#### 5. `crates/project/.rules`
+**Owner:** Core team (@SomeoneToIgnore for LSP, others for stores)
+**Time estimate:** ~45 minutes
+
+Should cover:
+- Store pattern: `BufferStore`, `LspStore`, `GitStore`, `TaskStore` — each wraps local/remote
+- File operations through Project
+- LSP lifecycle: `lsp_store/`
+- Git state: `git_store/`
+
+### Tier 2 (Nice to Have)
+
+| Crate | Suggested Owner | What to Cover |
+|-------|-----------------|---------------|
+| `language` | @osiewicz, @SomeoneToIgnore | Grammar loading, highlighting, LSP integration |
+| `ui` | Design team | Component library, styling patterns |
+| `settings` | Core team | Settings derive macro, layering, schema |
+| `extension_host` | @kubkon | Extension loading, API surface, sandboxing |
+
+## Template for Crate `.rules` Files
+
+```markdown
+# <Crate Name>
+
+## Overview
+Brief description of what this crate does and its role in Zed.
+
+## Module Map
+- `src/module_a.rs` — description
+- `src/module_b/` — description of subdirectory
+
+## Key Types
+- `TypeA` — what it represents, when to use it
+- `TypeB` — what it represents, when to use it
+
+## Common Patterns
+```rust
+// Example of the right way to do X
+```
+
+## Gotchas
+- Don't do X because Y
+- Watch out for Z when doing W
+
+## Testing
+- How to run tests: `cargo test -p <crate>`
+- Test utilities available in this crate
+- Example test structure
+```
+
+## Process
+
+1. **Week 1:** Reach out to identified owners via Slack or Linear, share this plan
+2. **Week 2:** Owners write their crate `.rules` (estimated ~1 hour each)
+3. **Ongoing:** When PRs restructure a crate, update that crate's `.rules`
+
+## Success Criteria
+
+- [ ] `crates/gpui/.rules` exists and covers key gotchas
+- [ ] `crates/editor/.rules` exists and covers display pipeline + testing
+- [ ] `crates/agent/.rules` exists and covers tool system + edit agent
+- [ ] `crates/workspace/.rules` exists and covers Item/Panel traits
+- [ ] `crates/project/.rules` exists and covers store pattern
+- [ ] At least one AI agent session shows improved behavior when working in a crate with `.rules`
+
+## Related
+
+- Background Agent plan (BIZOPS-801)
+- Improving `.rules` proposal (`improving-rules-proposal.md`)
+- Eric Holk's Sentry crash experiment (proved `.rules` quality is critical for good test generation)

--- a/docs/crate-rules-ownership-plan.md
+++ b/docs/crate-rules-ownership-plan.md
@@ -5,6 +5,7 @@ This document outlines who should write crate-level `.rules` files for the most 
 ## Background
 
 The root `.rules` file provides general guidance, but complex crates like `gpui`, `editor`, and `agent` need crate-specific documentation that only domain experts can write. These `.rules` files help AI agents (Factory, Codex, Claude Code, Zed Agent Panel) understand:
+
 - Internal architecture and module layout
 - Key patterns and abstractions
 - Common gotchas and anti-patterns
@@ -14,21 +15,21 @@ The root `.rules` file provides general guidance, but complex crates like `gpui`
 
 `REVIEWERS.conl` maps domain areas to people with deep expertise. Use this to identify who should write each crate's `.rules`:
 
-| Domain Area | Reviewers | Relevant Crates |
-|------------|-----------|-----------------|
-| `gpui` | @Anthony-Eid, @cameron1024, @mikayla-maki, @probably-neb | `gpui`, `gpui_macros` |
-| `multi_buffer` | @Veykril, @SomeoneToIgnore | `multi_buffer`, `editor` (display_map) |
-| `text` | @Veykril | `text`, `rope` |
-| `ai` | @benbrandt, @bennetbo, @danilo-leal, @rtfeldman | `agent`, `agent_ui`, `agent_ui_v2`, `language_model` |
-| `lsp` | @osiewicz, @smitbarmase, @SomeoneToIgnore, @Veykril | `lsp`, `language` |
-| `languages` | @osiewicz, @probably-neb, @smitbarmase, @SomeoneToIgnore, @Veykril | `languages` |
-| `crashes` | @Veykril | (cross-cutting expertise) |
-| `debugger` | @Anthony-Eid, @kubkon, @osiewicz | `dap`, `debugger_ui` |
-| `terminal` | @kubkon, @Veykril | `terminal`, `terminal_view` |
-| `git` | @cole-miller, @danilo-leal, @yara-blue, @kubkon, @Anthony-Eid, @cameron1024 | `git`, `git_ui` |
-| `vim` | @ConradIrwin, @dinocosta, @probably-neb | `vim` |
-| `extension` | @kubkon | `extension`, `extension_host`, `extension_api` |
-| `tasks` | @SomeoneToIgnore, @Veykril | `task`, `tasks_ui` |
+| Domain Area    | Reviewers                                                                   | Relevant Crates                                      |
+| -------------- | --------------------------------------------------------------------------- | ---------------------------------------------------- |
+| `gpui`         | @Anthony-Eid, @cameron1024, @mikayla-maki, @probably-neb                    | `gpui`, `gpui_macros`                                |
+| `multi_buffer` | @Veykril, @SomeoneToIgnore                                                  | `multi_buffer`, `editor` (display_map)               |
+| `text`         | @Veykril                                                                    | `text`, `rope`                                       |
+| `ai`           | @benbrandt, @bennetbo, @danilo-leal, @rtfeldman                             | `agent`, `agent_ui`, `agent_ui_v2`, `language_model` |
+| `lsp`          | @osiewicz, @smitbarmase, @SomeoneToIgnore, @Veykril                         | `lsp`, `language`                                    |
+| `languages`    | @osiewicz, @probably-neb, @smitbarmase, @SomeoneToIgnore, @Veykril          | `languages`                                          |
+| `crashes`      | @Veykril                                                                    | (cross-cutting expertise)                            |
+| `debugger`     | @Anthony-Eid, @kubkon, @osiewicz                                            | `dap`, `debugger_ui`                                 |
+| `terminal`     | @kubkon, @Veykril                                                           | `terminal`, `terminal_view`                          |
+| `git`          | @cole-miller, @danilo-leal, @yara-blue, @kubkon, @Anthony-Eid, @cameron1024 | `git`, `git_ui`                                      |
+| `vim`          | @ConradIrwin, @dinocosta, @probably-neb                                     | `vim`                                                |
+| `extension`    | @kubkon                                                                     | `extension`, `extension_host`, `extension_api`       |
+| `tasks`        | @SomeoneToIgnore, @Veykril                                                  | `task`, `tasks_ui`                                   |
 
 ## Priority Crates for `.rules` Files
 
@@ -37,10 +38,12 @@ The root `.rules` file provides general guidance, but complex crates like `gpui`
 These crates have the highest agent failure rate and complexity:
 
 #### 1. `crates/gpui/.rules`
+
 **Owner:** GPUI maintainers (@Anthony-Eid, @cameron1024, @mikayla-maki)
 **Time estimate:** ~1 hour
 
 Should cover:
+
 - Module map: `app.rs`, `window.rs`, `elements/`, `platform/`
 - Rendering pipeline: `Render::render()` → element tree → layout → paint
 - Entity lifecycle: creation, reading, updating, dropping, weak references
@@ -50,10 +53,12 @@ Should cover:
 - Gotchas: re-entrant entity updates panic, `run_until_parked()` semantics
 
 #### 2. `crates/editor/.rules`
+
 **Owner:** Editor maintainers (@Veykril, @SomeoneToIgnore)
 **Time estimate:** ~1 hour
 
 Should cover:
+
 - `Editor` is used for code editing AND all text inputs (important context)
 - Display pipeline: `Editor` → `DisplayMap` → `DisplaySnapshot` → render
 - `display_map/` breakdown: folds, inlays, block decorations, wrap maps, tab maps
@@ -62,10 +67,12 @@ Should cover:
 - Test utilities: `EditorTestContext`, `EditorLspTestContext`, marked text format
 
 #### 3. `crates/agent/.rules`
+
 **Owner:** Agent team (@benbrandt, @bennetbo, @rtfeldman)
 **Time estimate:** ~1 hour
 
 Should cover:
+
 - Thread store, threads, tools, edit agent, templates
 - Tool system: how tools are defined (`tools/` directory), permissions
 - Edit agent: `edit_agent/` directory, streaming edit parser
@@ -73,20 +80,24 @@ Should cover:
 - Eval framework in `edit_agent/evals/`
 
 #### 4. `crates/workspace/.rules`
+
 **Owner:** Core team
 **Time estimate:** ~45 minutes
 
 Should cover:
+
 - Hierarchy: Workspace → Panes → Items; Docks → Panels
 - `Item` trait and `Panel` trait: how to register new types
 - Persistence: `persistence/` module
 - Modal system: `modal_layer.rs`
 
 #### 5. `crates/project/.rules`
+
 **Owner:** Core team (@SomeoneToIgnore for LSP, others for stores)
 **Time estimate:** ~45 minutes
 
 Should cover:
+
 - Store pattern: `BufferStore`, `LspStore`, `GitStore`, `TaskStore` — each wraps local/remote
 - File operations through Project
 - LSP lifecycle: `lsp_store/`
@@ -94,42 +105,50 @@ Should cover:
 
 ### Tier 2 (Nice to Have)
 
-| Crate | Suggested Owner | What to Cover |
-|-------|-----------------|---------------|
-| `language` | @osiewicz, @SomeoneToIgnore | Grammar loading, highlighting, LSP integration |
-| `ui` | Design team | Component library, styling patterns |
-| `settings` | Core team | Settings derive macro, layering, schema |
-| `extension_host` | @kubkon | Extension loading, API surface, sandboxing |
+| Crate            | Suggested Owner             | What to Cover                                  |
+| ---------------- | --------------------------- | ---------------------------------------------- |
+| `language`       | @osiewicz, @SomeoneToIgnore | Grammar loading, highlighting, LSP integration |
+| `ui`             | Design team                 | Component library, styling patterns            |
+| `settings`       | Core team                   | Settings derive macro, layering, schema        |
+| `extension_host` | @kubkon                     | Extension loading, API surface, sandboxing     |
 
 ## Template for Crate `.rules` Files
 
-```markdown
+````markdown
 # <Crate Name>
 
 ## Overview
+
 Brief description of what this crate does and its role in Zed.
 
 ## Module Map
+
 - `src/module_a.rs` — description
 - `src/module_b/` — description of subdirectory
 
 ## Key Types
+
 - `TypeA` — what it represents, when to use it
 - `TypeB` — what it represents, when to use it
 
 ## Common Patterns
+
 ```rust
 // Example of the right way to do X
 ```
+````
 
 ## Gotchas
+
 - Don't do X because Y
 - Watch out for Z when doing W
 
 ## Testing
+
 - How to run tests: `cargo test -p <crate>`
 - Test utilities available in this crate
 - Example test structure
+
 ```
 
 ## Process
@@ -152,3 +171,4 @@ Brief description of what this crate does and its role in Zed.
 - Background Agent plan (BIZOPS-801)
 - Improving `.rules` proposal (`improving-rules-proposal.md`)
 - Eric Holk's Sentry crash experiment (proved `.rules` quality is critical for good test generation)
+```


### PR DESCRIPTION
## Summary

Enriches the root `.rules` file to improve AI agent effectiveness for crash fixing and general development. Part of the Background Agent initiative (BIZOPS-801).

### What's included

**Root `.rules` enrichment (+213 lines):**
- Build/test/run commands
- Crate architecture map (~30 crates by domain)
- Anti-patterns from clippy.toml + common bugs from recent PRs
- Testing patterns (EditorTestContext, vim, modals, diff hunks, FakeFs)
- Critical guidance for crash regression tests: use user-level operations, not synthetic failures
- Settings and workspace patterns

**Crate-level rules ownership plan:**
- Maps REVIEWERS.conl domain experts to crates needing `.rules`
- Priority tiers: gpui, editor, agent, workspace, project
- Template for crate `.rules` files

**Week 1 progress summary:**
- Documents what's done vs remaining items
- Decision point for Week 2 (Factory experiment results)

### Background

Eric Holk's Sentry crash experiment proved that prompt quality is the single biggest lever. The difference between a useless test and a real bug find was one sentence: "focus on higher level operations a user might actually perform."

This PR encodes that learning and other patterns directly into `.rules` so all AI agents (Factory, Codex, Claude Code, Zed Agent Panel) benefit.

### How to verify

1. Open the repo in Zed, start an Agent session
2. Ask: "build the editor crate" → should use `cargo build -p editor`
3. Ask: "write a crash regression test" → should follow user-level operation patterns

Release Notes:

- N/A (internal tooling)