### PR TITLE
Fix inline edit predictions not working in text threads

### DIFF
--- a/crates/agent_ui/src/text_thread_editor.rs
+++ b/crates/agent_ui/src/text_thread_editor.rs
@@ -250,7 +250,7 @@ impl TextThreadEditor {
 
         let editor = cx.new(|cx| {
             let mut editor =
-                Editor::for_buffer(text_thread.read(cx).buffer().clone(), None, window, cx);
+                Editor::for_buffer(text_thread.read(cx).buffer().clone(), Some(project.clone()), window, cx);
             editor.disable_scrollbars_and_minimap(window, cx);
             editor.set_soft_wrap_mode(SoftWrap::EditorWidth, cx);
             editor.set_show_line_numbers(false, cx);
@@ -3473,6 +3473,21 @@ mod tests {
                     text.contains(&format!("```console\n{}\n```", terminal_output)),
                     "Terminal text should be wrapped in code block. Got: {}",
                     text
+                );
+            });
+        });
+    }
+
+    #[gpui::test]
+    async fn test_text_thread_editor_has_project(cx: &mut TestAppContext) {
+        let (_text_thread, text_thread_editor, mut cx) =
+            setup_text_thread_editor_text(vec![(Role::User, "")], cx).await;
+
+        text_thread_editor.update_in(&mut cx, |text_thread_editor, _window, cx| {
+            text_thread_editor.editor.update(cx, |editor, _cx| {
+                assert!(
+                    editor.project().is_some(),
+                    "Text thread editor should have a project reference for edit predictions"
                 );
             });
         });

--- a/crates/zed/src/zed/edit_prediction_registry.rs
+++ b/crates/zed/src/zed/edit_prediction_registry.rs
@@ -197,7 +197,6 @@ fn assign_edit_prediction_provider(
 
             if let Some(project) = editor.project()
                 && let Some(buffer) = &singleton_buffer
-                && buffer.read(cx).file().is_some()
             {
                 let has_model = ep_store.update(cx, |ep_store, cx| {
                     let model = match value {


### PR DESCRIPTION
## Summary

- Pass `project` reference to the text thread's inner `Editor`, so that edit prediction providers can be registered (previously `None` was passed, causing all providers to silently skip registration)
- Remove the `file().is_some()` guard on Zed-based providers (Ollama, Zed, Mercury, Sweep) in `edit_prediction_registry`, allowing them to work with non-file buffers like text threads (downstream code already handles `file = None` defensively)

Fixes #48728

## Test plan

- [x] Added unit test `test_text_thread_editor_has_project` verifying the editor has a project reference
- [x] All 5 existing `text_thread_editor` tests pass
- [x] `./script/clippy` passes with zero warnings
- [x] Manually verified on macOS: inline completions now appear in text threads with Copilot

Release Notes:

- Fixed inline edit predictions not working in text threads (#48728)

🤖 Generated with [Claude Code](https://claude.com/claude-code)