### PR TITLE
editor: Fix multi-cursor editing breaking indentation

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4915,11 +4915,16 @@ impl Editor {
             let initial_buffer_versions =
                 jsx_tag_auto_close::construct_initial_buffer_versions_map(this, &edits, cx);
 
+            let autoindent_mode = if !text.contains('\n') && edits.len() > 1 {
+                None
+            } else {
+                this.autoindent_mode.clone()
+            };
             this.buffer.update(cx, |buffer, cx| {
                 if has_adjacent_edits {
-                    buffer.edit_non_coalesce(edits, this.autoindent_mode.clone(), cx);
+                    buffer.edit_non_coalesce(edits, autoindent_mode.clone(), cx);
                 } else {
-                    buffer.edit(edits, this.autoindent_mode.clone(), cx);
+                    buffer.edit(edits, autoindent_mode, cx);
                 }
             });
             for (buffer, edits) in linked_edits {
@@ -10843,8 +10848,24 @@ impl Editor {
         let mut selections = self.selections.all_adjusted(&self.display_snapshot(cx));
         let buffer = self.buffer.read(cx);
         let snapshot = buffer.snapshot(cx);
-        let rows_iter = selections.iter().map(|s| s.head().row);
-        let suggested_indents = snapshot.suggested_indents(rows_iter, cx);
+
+        // When there are multiple empty cursors on different rows, skip
+        // suggested-indent logic so Tab uniformly adds one indent level
+        // instead of jumping each cursor to a language-suggested position.
+        let has_multiple_cursor_rows = {
+            let mut rows = selections
+                .iter()
+                .filter(|s| s.is_empty())
+                .map(|s| s.head().row);
+            let first = rows.next();
+            first.is_some() && rows.any(|row| Some(row) != first)
+        };
+        let suggested_indents = if has_multiple_cursor_rows {
+            BTreeMap::new()
+        } else {
+            let rows_iter = selections.iter().map(|s| s.head().row);
+            snapshot.suggested_indents(rows_iter, cx)
+        };
 
         let has_some_cursor_in_whitespace = selections
             .iter()

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4922,7 +4922,7 @@ impl Editor {
             };
             this.buffer.update(cx, |buffer, cx| {
                 if has_adjacent_edits {
-                    buffer.edit_non_coalesce(edits, autoindent_mode.clone(), cx);
+                    buffer.edit_non_coalesce(edits, autoindent_mode, cx);
                 } else {
                     buffer.edit(edits, autoindent_mode, cx);
                 }

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -3917,8 +3917,8 @@ async fn test_tab_in_leading_whitespace_auto_indents_lines(cx: &mut TestAppConte
     );
     cx.update_buffer(|buffer, cx| buffer.set_language(Some(language), cx));
 
-    // test when all cursors are not at suggested indent
-    // then simply move to their suggested indent location
+    // multi-cursor on different rows: Tab inserts uniform tab instead of
+    // jumping to language-suggested indent
     cx.set_state(indoc! {"
         const a: B = (
             c(
@@ -3930,13 +3930,12 @@ async fn test_tab_in_leading_whitespace_auto_indents_lines(cx: &mut TestAppConte
     cx.assert_editor_state(indoc! {"
         const a: B = (
             c(
-                ˇ
-            ˇ)
+            ˇ
+            ˇ    )
         );
     "});
 
-    // test cursor already at suggested indent not moving when
-    // other cursors are yet to reach their suggested indents
+    // multi-cursor on different rows: all cursors get uniform tab inserted
     cx.set_state(indoc! {"
         ˇ
         const a: B = (
@@ -3948,36 +3947,34 @@ async fn test_tab_in_leading_whitespace_auto_indents_lines(cx: &mut TestAppConte
         ˇ    )
         );
     "});
-    cx.update_editor(|e, window, cx| e.tab(&Tab, window, cx));
-    cx.assert_editor_state(indoc! {"
-        ˇ
-        const a: B = (
-            c(
-                d(
-                    ˇ
-                )
-                ˇ
-            ˇ)
-        );
-    "});
-    // test when all cursors are at suggested indent then tab is inserted
     cx.update_editor(|e, window, cx| e.tab(&Tab, window, cx));
     cx.assert_editor_state(indoc! {"
             ˇ
         const a: B = (
             c(
                 d(
-                        ˇ
+            ˇ
                 )
-                    ˇ
-                ˇ)
+            ˇ
+            ˇ    )
+        );
+    "});
+    // second Tab press: another uniform tab inserted at each cursor
+    cx.update_editor(|e, window, cx| e.tab(&Tab, window, cx));
+    cx.assert_editor_state(indoc! {"
+                ˇ
+        const a: B = (
+            c(
+                d(
+                ˇ
+                )
+                ˇ
+                ˇ    )
         );
     "});
 
-    // test when current indent is less than suggested indent,
-    // we adjust line to match suggested indent and move cursor to it
-    //
-    // when no other cursor is at word boundary, all of them should move
+    // multi-cursor on different rows with varying indentation:
+    // uniform tab inserted at each cursor position
     cx.set_state(indoc! {"
         const a: B = (
             c(
@@ -3992,16 +3989,14 @@ async fn test_tab_in_leading_whitespace_auto_indents_lines(cx: &mut TestAppConte
         const a: B = (
             c(
                 d(
-                    ˇ
-                ˇ)
-            ˇ)
+            ˇ
+            ˇ   )
+            ˇ   )
         );
     "});
 
-    // test when current indent is less than suggested indent,
-    // we adjust line to match suggested indent and move cursor to it
-    //
-    // when some other cursor is at word boundary, it should not move
+    // multi-cursor on different rows: cursor not at column 0 gets
+    // spaces to next tab stop
     cx.set_state(indoc! {"
         const a: B = (
             c(
@@ -4016,16 +4011,13 @@ async fn test_tab_in_leading_whitespace_auto_indents_lines(cx: &mut TestAppConte
         const a: B = (
             c(
                 d(
-                    ˇ
-                ˇ)
+            ˇ
+            ˇ   )
             ˇ)
         );
     "});
 
-    // test when current indent is more than suggested indent,
-    // we just move cursor to current indent instead of suggested indent
-    //
-    // when no other cursor is at word boundary, all of them should move
+    // multi-cursor on different rows with over-indented lines
     cx.set_state(indoc! {"
         const a: B = (
             c(
@@ -4040,9 +4032,9 @@ async fn test_tab_in_leading_whitespace_auto_indents_lines(cx: &mut TestAppConte
         const a: B = (
             c(
                 d(
-                    ˇ
-                        ˇ)
-            ˇ)
+            ˇ
+            ˇ                )
+            ˇ   )
         );
     "});
     cx.update_editor(|e, window, cx| e.tab(&Tab, window, cx));
@@ -4050,16 +4042,14 @@ async fn test_tab_in_leading_whitespace_auto_indents_lines(cx: &mut TestAppConte
         const a: B = (
             c(
                 d(
-                        ˇ
-                            ˇ)
-                ˇ)
+                ˇ
+                ˇ                )
+                ˇ   )
         );
     "});
 
-    // test when current indent is more than suggested indent,
-    // we just move cursor to current indent instead of suggested indent
-    //
-    // when some other cursor is at word boundary, it doesn't move
+    // multi-cursor on different rows: cursor already past leading
+    // whitespace gets tab to next tab stop
     cx.set_state(indoc! {"
         const a: B = (
             c(
@@ -4074,13 +4064,13 @@ async fn test_tab_in_leading_whitespace_auto_indents_lines(cx: &mut TestAppConte
         const a: B = (
             c(
                 d(
-                    ˇ
-                        ˇ)
-            ˇ)
+            ˇ
+            ˇ                )
+                ˇ)
         );
     "});
 
-    // handle auto-indent when there are multiple cursors on the same line
+    // multi-cursor on same and different rows: uniform tab inserted
     cx.set_state(indoc! {"
         const a: B = (
             c(
@@ -4092,8 +4082,8 @@ async fn test_tab_in_leading_whitespace_auto_indents_lines(cx: &mut TestAppConte
     cx.assert_editor_state(indoc! {"
         const a: B = (
             c(
-                ˇ
-            ˇ)
+            ˇ        ˇ
+            ˇ    )
         );
     "});
 }
@@ -4287,10 +4277,61 @@ async fn test_indent_yaml_non_comments_with_multiple_cursors(cx: &mut TestAppCon
     cx.update_editor(|e, window, cx| e.tab(&Tab, window, cx));
 
     cx.assert_editor_state(
+        r#"    ˇingress:
+    ˇ  api:
+    ˇ    enabled: false
+    ˇ    pathType: Prefix
+"#,
+    );
+}
+
+#[gpui::test]
+async fn test_multicursor_input_does_not_break_yaml_indentation(cx: &mut TestAppContext) {
+    // Regression test for issue #21334:
+    // When using multi-cursor to insert characters at the beginning of indented YAML lines,
+    // autoindent would re-evaluate indentation based on modified adjacent lines, causing
+    // unwanted indentation changes.
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+    let yaml_language = languages::language("yaml", tree_sitter_yaml::LANGUAGE.into());
+    cx.update_buffer(|buffer, cx| buffer.set_language(Some(yaml_language), cx));
+
+    cx.set_state(
         r#"ˇingress:
-    ˇapi:
-        ˇenabled: false
-        ˇpathType: Prefix
+ˇ  api:
+ˇ    enabled: false
+ˇ    pathType: Prefix
+ˇ  console:
+ˇ    enabled: false
+ˇ    pathType: Prefix
+"#,
+    );
+
+    cx.update_editor(|e, window, cx| e.handle_input("#", window, cx));
+    cx.wait_for_autoindent_applied().await;
+
+    cx.assert_editor_state(
+        r#"#ˇingress:
+#ˇ  api:
+#ˇ    enabled: false
+#ˇ    pathType: Prefix
+#ˇ  console:
+#ˇ    enabled: false
+#ˇ    pathType: Prefix
+"#,
+    );
+
+    // Undo should restore the original state
+    cx.update_editor(|e, window, cx| e.undo(&crate::actions::Undo, window, cx));
+    cx.assert_editor_state(
+        r#"ˇingress:
+ˇ  api:
+ˇ    enabled: false
+ˇ    pathType: Prefix
+ˇ  console:
+ˇ    enabled: false
+ˇ    pathType: Prefix
 "#,
     );
 }
@@ -26222,19 +26263,19 @@ async fn test_tab_in_leading_whitespace_auto_indents_for_python(cx: &mut TestApp
     cx.wait_for_autoindent_applied().await;
     cx.assert_editor_state(indoc! {"
         def main():
-            ˇfor item in items:
-                ˇwhile item.active:
-                    ˇif item.value > 10:
-                        ˇcontinue
-                    ˇelif item.value < 0:
-                        ˇbreak
-                    ˇelse:
-                        ˇwith item.context() as ctx:
-                            ˇyield count
-                ˇelse:
-                    ˇlog('while else')
-            ˇelse:
-                ˇlog('for else')
+            ˇ    for item in items:
+            ˇ        while item.active:
+            ˇ            if item.value > 10:
+            ˇ                continue
+            ˇ            elif item.value < 0:
+            ˇ                break
+            ˇ            else:
+            ˇ                with item.context() as ctx:
+            ˇ                    yield count
+            ˇ        else:
+            ˇ            log('while else')
+            ˇ    else:
+            ˇ        log('for else')
     "});
     // test relative indent is preserved when tab
     // for `if`, `elif`, `else`, `while`, `with` and `for`
@@ -26242,19 +26283,19 @@ async fn test_tab_in_leading_whitespace_auto_indents_for_python(cx: &mut TestApp
     cx.wait_for_autoindent_applied().await;
     cx.assert_editor_state(indoc! {"
         def main():
-                ˇfor item in items:
-                    ˇwhile item.active:
-                        ˇif item.value > 10:
-                            ˇcontinue
-                        ˇelif item.value < 0:
-                            ˇbreak
-                        ˇelse:
-                            ˇwith item.context() as ctx:
-                                ˇyield count
-                    ˇelse:
-                        ˇlog('while else')
-                ˇelse:
-                    ˇlog('for else')
+                ˇ    for item in items:
+                ˇ        while item.active:
+                ˇ            if item.value > 10:
+                ˇ                continue
+                ˇ            elif item.value < 0:
+                ˇ                break
+                ˇ            else:
+                ˇ                with item.context() as ctx:
+                ˇ                    yield count
+                ˇ        else:
+                ˇ            log('while else')
+                ˇ    else:
+                ˇ        log('for else')
     "});
 
     // test cursor move to start of each line on tab
@@ -26276,16 +26317,16 @@ async fn test_tab_in_leading_whitespace_auto_indents_for_python(cx: &mut TestApp
     cx.wait_for_autoindent_applied().await;
     cx.assert_editor_state(indoc! {"
         def main():
-            ˇtry:
-                ˇfetch()
-            ˇexcept ValueError:
-                ˇhandle_error()
-            ˇelse:
-                ˇmatch value:
-                    ˇcase _:
-            ˇfinally:
-                ˇdef status():
-                    ˇreturn 0
+            ˇ    try:
+            ˇ        fetch()
+            ˇ    except ValueError:
+            ˇ        handle_error()
+            ˇ    else:
+            ˇ        match value:
+            ˇ            case _:
+            ˇ    finally:
+            ˇ        def status():
+            ˇ            return 0
     "});
     // test relative indent is preserved when tab
     // for `try`, `except`, `else`, `finally`, `match` and `def`
@@ -26293,16 +26334,16 @@ async fn test_tab_in_leading_whitespace_auto_indents_for_python(cx: &mut TestApp
     cx.wait_for_autoindent_applied().await;
     cx.assert_editor_state(indoc! {"
         def main():
-                ˇtry:
-                    ˇfetch()
-                ˇexcept ValueError:
-                    ˇhandle_error()
-                ˇelse:
-                    ˇmatch value:
-                        ˇcase _:
-                ˇfinally:
-                    ˇdef status():
-                        ˇreturn 0
+                ˇ    try:
+                ˇ        fetch()
+                ˇ    except ValueError:
+                ˇ        handle_error()
+                ˇ    else:
+                ˇ        match value:
+                ˇ            case _:
+                ˇ    finally:
+                ˇ        def status():
+                ˇ            return 0
     "});
 }
 
@@ -26682,36 +26723,36 @@ async fn test_tab_in_leading_whitespace_auto_indents_for_bash(cx: &mut TestAppCo
     cx.wait_for_autoindent_applied().await;
     cx.assert_editor_state(indoc! {"
         function main() {
-            ˇfor item in $items; do
-                ˇwhile [ -n \"$item\" ]; do
-                    ˇif [ \"$value\" -gt 10 ]; then
-                        ˇcontinue
-                    ˇelif [ \"$value\" -lt 0 ]; then
-                        ˇbreak
-                    ˇelse
-                        ˇecho \"$item\"
-                    ˇfi
-                ˇdone
-            ˇdone
-        ˇ}
+            ˇ    for item in $items; do
+            ˇ        while [ -n \"$item\" ]; do
+            ˇ            if [ \"$value\" -gt 10 ]; then
+            ˇ                continue
+            ˇ            elif [ \"$value\" -lt 0 ]; then
+            ˇ                break
+            ˇ            else
+            ˇ                echo \"$item\"
+            ˇ            fi
+            ˇ        done
+            ˇ    done
+            ˇ}
     "});
     // test relative indent is preserved when tab
     cx.update_editor(|e, window, cx| e.tab(&Tab, window, cx));
     cx.wait_for_autoindent_applied().await;
     cx.assert_editor_state(indoc! {"
         function main() {
-                ˇfor item in $items; do
-                    ˇwhile [ -n \"$item\" ]; do
-                        ˇif [ \"$value\" -gt 10 ]; then
-                            ˇcontinue
-                        ˇelif [ \"$value\" -lt 0 ]; then
-                            ˇbreak
-                        ˇelse
-                            ˇecho \"$item\"
-                        ˇfi
-                    ˇdone
-                ˇdone
-            ˇ}
+                ˇ    for item in $items; do
+                ˇ        while [ -n \"$item\" ]; do
+                ˇ            if [ \"$value\" -gt 10 ]; then
+                ˇ                continue
+                ˇ            elif [ \"$value\" -lt 0 ]; then
+                ˇ                break
+                ˇ            else
+                ˇ                echo \"$item\"
+                ˇ            fi
+                ˇ        done
+                ˇ    done
+                ˇ}
     "});
 
     // test cursor move to start of each line on tab
@@ -26735,18 +26776,18 @@ async fn test_tab_in_leading_whitespace_auto_indents_for_bash(cx: &mut TestAppCo
     cx.wait_for_autoindent_applied().await;
     cx.assert_editor_state(indoc! {"
         function handle() {
-            ˇcase \"$1\" in
-                ˇstart)
-                    ˇecho \"a\"
-                    ˇ;;
-                ˇstop)
-                    ˇecho \"b\"
-                    ˇ;;
-                ˇ*)
-                    ˇecho \"c\"
-                    ˇ;;
-            ˇesac
-        ˇ}
+            ˇ    case \"$1\" in
+            ˇ        start)
+            ˇ            echo \"a\"
+            ˇ            ;;
+            ˇ        stop)
+            ˇ            echo \"b\"
+            ˇ            ;;
+            ˇ        *)
+            ˇ            echo \"c\"
+            ˇ            ;;
+            ˇ    esac
+            ˇ}
     "});
 }
 


### PR DESCRIPTION
Closes #21334 

- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) -> no UI changes

When using multi-cursor to insert characters at the beginning of indented lines, autoindent would re-evaluate each line's indentation based on the combined post-edit state, causing adjacent edits to interfere with each other's indent suggestions and wreaking havoc on indentation—especially in indent-sensitive formats like YAML and Python.

Release Notes:

Disable `AutoindentMode::EachLine` when inserting non-newline text with multiple cursors. Single-cursor auto-outdent is preserved. When multiple cursors are on different rows, skip suggested_indents and insert a uniform tab instead of jumping each cursor to a language-computed indent level. This makes Tab behave predictably with multi-cursor, preserving relative indentation.