### PR TITLE
docs: SEO content improvements for AI section

### DIFF
--- a/docs/src/ai/agent-panel.md
+++ b/docs/src/ai/agent-panel.md
@@ -5,7 +5,7 @@ description: Use Zed's AI coding agent to generate, refactor, and debug code wit
 
 # Agent Panel
 
-The Agent Panel is where you interact with AI agents that can read, write, and run code in your project. Use it for code generation, refactoring, debugging, documentation, and general questions.
+The Agent Panel is where you interact with AI agents that can read, write, and run code in your project. It's the core of Zed's AI code editing experience — use it for code generation, refactoring, debugging, documentation, and general questions.
 
 Open it with `agent: new thread` from [the Command Palette](../getting-started.md#command-palette) or click the ✨ icon in the status bar.
 

--- a/docs/src/ai/billing.md
+++ b/docs/src/ai/billing.md
@@ -5,6 +5,8 @@ description: Manage Zed AI billing, payment methods, invoices, threshold billing
 
 # Billing
 
+This page covers billing for Zed's [subscription plans](./subscription.md). For details on what's included in each plan and how token usage works, see [Plans and Usage](./plans-and-usage.md).
+
 We use Stripe as our payments provider, and Orb for invoicing and metering. All Pro plans require payment via credit card or other supported payment method.
 For invoice-based billing, a Business plan is required. Contact [sales@zed.dev](mailto:sales@zed.dev) for more information.
 

--- a/docs/src/ai/configuration.md
+++ b/docs/src/ai/configuration.md
@@ -5,7 +5,7 @@ description: Set up AI in Zed with hosted models, your own API keys, or external
 
 # Configuration
 
-When using AI in Zed, you can configure multiple dimensions:
+Zed is an AI code editor with flexible configuration. You can configure multiple dimensions:
 
 1. Which LLM providers you can use
    - Zed's hosted models, which require [authentication](../authentication.md) and [subscription](./subscription.md)

--- a/docs/src/ai/edit-prediction.md
+++ b/docs/src/ai/edit-prediction.md
@@ -5,7 +5,7 @@ description: Set up AI code completions in Zed with Zeta (built-in), GitHub Copi
 
 # Edit Prediction
 
-Edit Prediction is Zed's LLM mechanism for predicting the code you want to write.
+Edit Prediction is how Zed's AI code completions work: an LLM predicts the code you want to write.
 Each keystroke sends a new request to the edit prediction provider, which returns individual or multi-line suggestions that can be quickly accepted by pressing `tab`.
 
 The default provider is [Zeta, a proprietary open source and open dataset model](https://huggingface.co/zed-industries/zeta), but you can also use [other providers](#other-providers) like GitHub Copilot, Supermaven, and Codestral.

--- a/docs/src/ai/llm-providers.md
+++ b/docs/src/ai/llm-providers.md
@@ -5,9 +5,9 @@ description: Bring your own API keys to Zed. Set up Anthropic, OpenAI, Google AI
 
 # LLM Providers
 
-To use AI in Zed, you need to have at least one large language model provider set up.
+To use AI in Zed, you need to have at least one large language model provider set up. Once configured, providers are available in the [Agent Panel](./agent-panel.md), [Inline Assistant](./inline-assistant.md), and [Text Threads](./text-threads.md).
 
-You can do that by either subscribing to [one of Zed's plans](./plans-and-usage.md), or by using API keys you already have for the supported providers.
+You can do that by either subscribing to [one of Zed's plans](./plans-and-usage.md), or by using API keys you already have for the supported providers. For general AI setup, see [Configuration](./configuration.md).
 
 ## Use Your Own Keys {#use-your-own-keys}
 

--- a/docs/src/ai/models.md
+++ b/docs/src/ai/models.md
@@ -5,7 +5,7 @@ description: AI models available via Zed Pro including Claude, GPT-5, Gemini, an
 
 # Models
 
-Zed's plans offer hosted versions of major LLMs with higher rate limits than direct API access. Model availability is updated regularly.
+Zed's plans offer hosted versions of major LLMs with higher rate limits than direct API access. Model availability is updated regularly. To use your own API keys instead, see [LLM Providers](./llm-providers.md). For general setup, see [Configuration](./configuration.md).
 
 | Model                  | Provider  | Token Type          | Provider Price per 1M tokens | Zed Price per 1M tokens |
 | ---------------------- | --------- | ------------------- | ---------------------------- | ----------------------- |

--- a/docs/src/ai/overview.md
+++ b/docs/src/ai/overview.md
@@ -11,7 +11,7 @@ Zed is an open-source AI code editor. AI runs throughout the editing experience:
 
 Zed's AI features run inside a native, GPU-accelerated application built in Rust. There is no Electron layer between you and the model output.
 
-- **Open source.** The full codebase is public. You can read how AI features are implemented, how data flows to providers, and how tool calls execute.
+- **Open source.** The editor and all AI features are [open source](https://github.com/zed-industries/zed). You can read how AI is implemented, how data flows to providers, and how tool calls execute.
 - **Multi-model.** Connect to Anthropic, OpenAI, Google, DeepSeek, Mistral, Ollama, or any OpenAI-compatible provider. Switch models per task from the model selector.
 - **External agents.** Run Claude Code, Gemini CLI, Codex, and other CLI-based agents directly in Zed through the Agent Client Protocol. See [External Agents](./external-agents.md).
 - **Privacy by default.** AI data sharing is opt-in. When you use your own API keys, Zed maintains zero-data retention agreements with providers. See [Privacy and Security](./privacy-and-security.md).

--- a/docs/src/ai/overview.md
+++ b/docs/src/ai/overview.md
@@ -5,36 +5,38 @@ description: Docs for AI in Zed, the open-source AI code editor. Agentic coding,
 
 # AI
 
-Zed is an open-source AI code editor. AI is integrated throughout the editing experience: agentic coding, inline transformations, edit prediction, and direct model conversations.
+Zed is an open-source AI code editor. AI runs throughout the editing experience: agents that read and write your code, inline transformations, code completions on every keystroke, and conversations with models in any buffer.
 
-## Setting Up AI
+## How Zed approaches AI
+
+Zed's AI features run inside a native, GPU-accelerated application built in Rust. There is no Electron layer between you and the model output.
+
+- **Open source.** The full codebase is public. You can read how AI features are implemented, how data flows to providers, and how tool calls execute.
+- **Multi-model.** Connect to Anthropic, OpenAI, Google, DeepSeek, Mistral, Ollama, or any OpenAI-compatible provider. Switch models per task from the model selector.
+- **External agents.** Run Claude Code, Gemini CLI, Codex, and other CLI-based agents directly in Zed through the Agent Client Protocol. See [External Agents](./external-agents.md).
+- **Privacy by default.** AI data sharing is opt-in. When you use your own API keys, Zed maintains zero-data retention agreements with providers. See [Privacy and Security](./privacy-and-security.md).
+
+## Agentic editing
+
+The [Agent Panel](./agent-panel.md) is where you work with AI agents. Agents can read files, edit code, run terminal commands, search the web, and access diagnostics through [built-in tools](./tools.md).
+
+You can extend agents with additional tools through [MCP servers](./mcp.md), control what they can access with [tool permissions](./tool-permissions.md), and shape their behavior with [rules](./rules.md).
+
+The [Inline Assistant](./inline-assistant.md) works differently: select code or a terminal command, describe what you want, and the model rewrites the selection in place. It works with multiple cursors.
+
+## Code completions
+
+[Edit Prediction](./edit-prediction.md) provides AI code completions on every keystroke. Each keypress sends a request to the prediction provider, which returns single or multi-line suggestions you accept with `tab`.
+
+The default provider is Zeta, Zed's open-source model trained on open data. You can also use GitHub Copilot, Supermaven, or Codestral.
+
+## Text threads
+
+[Text Threads](./text-threads.md) are conversations with models inside any buffer. They work like a regular editor with your keybindings, multiple cursors, and standard editing features. Content is organized into message blocks with roles (You, Assistant, System).
+
+## Getting started
 
 - [Configuration](./configuration.md): Connect to Anthropic, OpenAI, Ollama, Google AI, or other LLM providers.
-
 - [External Agents](./external-agents.md): Run Claude Code, Codex, Aider, or other external agents inside Zed.
-
 - [Subscription](./subscription.md): Zed's hosted models and billing.
-
 - [Privacy and Security](./privacy-and-security.md): How Zed handles data when using AI features.
-
-## Agentic Editing
-
-- [Agent Panel](./agent-panel.md): Chat with AI agents that can read, write, and run code in your project.
-
-- [Rules](./rules.md): Define specific instructions for AI behavior.
-
-- [Tools](./tools.md): The built-in capabilities agents use: file operations, terminal commands, web search.
-
-- [Tool Permissions](./tool-permissions.md): Configure granular permission rules for agent tool actions.
-
-- [Model Context Protocol](./mcp.md): Extend agents with custom tools via MCP servers.
-
-- [Inline Assistant](./inline-assistant.md): Transform selected code or terminal output with `ctrl-enter`.
-
-## Edit Prediction
-
-- [Edit Prediction](./edit-prediction.md): AI-powered autocomplete that predicts multi-line edits as you type.
-
-## Text Threads
-
-- [Text Threads](./text-threads.md): Lightweight conversations with models inside any buffer.

--- a/docs/src/ai/overview.md
+++ b/docs/src/ai/overview.md
@@ -13,7 +13,7 @@ Zed's AI features run inside a native, GPU-accelerated application built in Rust
 
 - **Open source.** The editor and all AI features are [open source](https://github.com/zed-industries/zed). You can read how AI is implemented, how data flows to providers, and how tool calls execute.
 - **Multi-model.** Use Zed's hosted models or [bring your own API keys](./llm-providers.md) from Anthropic, OpenAI, Google, Ollama, and 8+ other providers. Run local models, connect to cloud APIs, or mix both. Switch models per task.
-- **External agents.** Run Claude Code, Gemini CLI, Codex, and other CLI-based agents directly in Zed through the Agent Client Protocol. See [External Agents](./external-agents.md).
+- **External agents.** Run Claude Code, Gemini CLI, Codex, and other CLI-based agents directly in Zed through the [Agent Client Protocol](https://zed.dev/acp). See [External Agents](./external-agents.md).
 - **Privacy by default.** AI data sharing is opt-in. When you use your own API keys, Zed maintains zero-data retention agreements with providers. See [Privacy and Security](./privacy-and-security.md).
 
 ## Agentic editing

--- a/docs/src/ai/overview.md
+++ b/docs/src/ai/overview.md
@@ -12,7 +12,7 @@ Zed is an open-source AI code editor. AI runs throughout the editing experience:
 Zed's AI features run inside a native, GPU-accelerated application built in Rust. There is no Electron layer between you and the model output.
 
 - **Open source.** The editor and all AI features are [open source](https://github.com/zed-industries/zed). You can read how AI is implemented, how data flows to providers, and how tool calls execute.
-- **Multi-model.** Connect to Anthropic, OpenAI, Google, DeepSeek, Mistral, Ollama, or any OpenAI-compatible provider. Switch models per task from the model selector.
+- **Multi-model.** Use Zed's hosted models or [bring your own API keys](./llm-providers.md) from Anthropic, OpenAI, Google, Ollama, and 8+ other providers. Run local models, connect to cloud APIs, or mix both. Switch models per task.
 - **External agents.** Run Claude Code, Gemini CLI, Codex, and other CLI-based agents directly in Zed through the Agent Client Protocol. See [External Agents](./external-agents.md).
 - **Privacy by default.** AI data sharing is opt-in. When you use your own API keys, Zed maintains zero-data retention agreements with providers. See [Privacy and Security](./privacy-and-security.md).
 

--- a/docs/src/ai/overview.md
+++ b/docs/src/ai/overview.md
@@ -5,7 +5,7 @@ description: Docs for AI in Zed, the open-source AI code editor. Agentic coding,
 
 # AI
 
-Zed integrates AI throughout the editor: agentic coding, inline transformations, edit prediction, and direct model conversations.
+Zed is an open-source AI code editor. AI is integrated throughout the editing experience: agentic coding, inline transformations, edit prediction, and direct model conversations.
 
 ## Setting Up AI
 

--- a/docs/src/ai/overview.md
+++ b/docs/src/ai/overview.md
@@ -40,3 +40,5 @@ The default provider is Zeta, Zed's open-source model trained on open data. You 
 - [External Agents](./external-agents.md): Run Claude Code, Codex, Aider, or other external agents inside Zed.
 - [Subscription](./subscription.md): Zed's hosted models and billing.
 - [Privacy and Security](./privacy-and-security.md): How Zed handles data when using AI features.
+
+New to Zed? Start with [Getting Started](../getting-started.md), then come back here to set up AI. For a higher-level overview, see [zed.dev/ai](https://zed.dev/ai).

--- a/docs/src/ai/rules.md
+++ b/docs/src/ai/rules.md
@@ -5,7 +5,7 @@ description: Configure AI behavior in Zed with .rules files, .cursorrules, CLAUD
 
 # Using Rules {#using-rules}
 
-Rules are prompts inserted at the beginning of each agent interaction. Add them via files in your worktree (`.rules`, etc.) or through the Rules Library for reuse across projects and threads.
+Rules are prompts inserted at the beginning of each [Agent Panel](./agent-panel.md) interaction. Add them via files in your worktree (`.rules`, etc.) or through the Rules Library for reuse across projects and threads.
 
 ## `.rules` files
 

--- a/docs/src/ai/tool-permissions.md
+++ b/docs/src/ai/tool-permissions.md
@@ -1,6 +1,6 @@
 # Tool Permissions
 
-Configure which agent actions run automatically and which require your approval.
+Configure which [Agent Panel](./agent-panel.md) actions run automatically and which require your approval. For a list of available tools, see [Tools](./tools.md).
 
 > **Note:** In Zed v0.224.0 and above, this page documents the granular `agent.tool_permissions` system.
 >

--- a/docs/src/ai/tools.md
+++ b/docs/src/ai/tools.md
@@ -5,9 +5,11 @@ description: Built-in tools for Zed's AI agent including file editing, code sear
 
 # Tools
 
-Zed's built-in agent has access to these tools for reading, searching, and editing your codebase.
+Zed's built-in agent has access to these tools for reading, searching, and editing your codebase. These tools are used in the [Agent Panel](./agent-panel.md) during conversations with AI agents.
 
 You can configure permissions for tool actions, including situations where they are automatically approved, automatically denied, or require your confirmation on a case-by-case basis. See [Tool Permissions](./tool-permissions.md) for the list of permission-gated tools and details.
+
+To add custom tools beyond these built-in ones, see [MCP servers](./mcp.md).
 
 ## Read & Search Tools
 

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -138,4 +138,5 @@ These are useful for sharing configuration tips or linking from documentation.
 
 - [Appearance](./appearance.md) — Themes, fonts, and visual customization
 - [Key bindings](./key-bindings.md) — Customize keyboard shortcuts
+- [AI Configuration](./ai/configuration.md) — Set up AI providers, models, and agent settings
 - [All Settings](./reference/all-settings.md) — Complete settings reference

--- a/docs/src/editing-code.md
+++ b/docs/src/editing-code.md
@@ -32,5 +32,6 @@ For example, you might:
 
 ## Related Features
 
+- [AI Features](./ai/overview.md) — Agentic editing, inline code transformations, and AI code completions
 - [Configuring Languages](./configuring-languages.md) — Set up language servers for your project
 - [Key Bindings](./key-bindings.md) — Customize keyboard shortcuts for editing commands

--- a/docs/src/remote-development.md
+++ b/docs/src/remote-development.md
@@ -13,7 +13,7 @@ Remote development requires two computers, your local machine that runs the Zed 
 
 ![Architectural overview of Zed Remote Development](https://zed.dev/img/remote-development/diagram.png)
 
-On your local machine, Zed runs its UI, talks to language models, uses Tree-sitter to parse and syntax-highlight code, and store unsaved changes and recent projects. The source code, language servers, tasks, and the terminal all run on the remote server.
+On your local machine, Zed runs its UI, talks to language models, uses Tree-sitter to parse and syntax-highlight code, and store unsaved changes and recent projects. The source code, language servers, tasks, and the terminal all run on the remote server. [AI features](./ai/overview.md) work in remote sessions, including the Agent Panel and Inline Assistant.
 
 > **Note:** The original version of remote development sent traffic via Zed's servers. As of Zed v0.157 you can no-longer use that mode.
 

--- a/docs/src/terminal.md
+++ b/docs/src/terminal.md
@@ -344,12 +344,12 @@ The terminal integrates with Zed's [task system](./tasks.md). When you run a tas
 
 ## AI Assistance
 
-Get help with terminal commands using inline assist:
+Get help with terminal commands using the [Inline Assistant](./ai/inline-assistant.md):
 
 - macOS: `Ctrl+Enter`
 - Linux/Windows: `Ctrl+Enter` or `Ctrl+I`
 
-This opens the AI assistant to help explain errors, suggest commands, or troubleshoot issues.
+This opens the Inline Assistant to help explain errors, suggest commands, or troubleshoot issues. AI agents in the [Agent Panel](./ai/agent-panel.md) can also run terminal commands as part of their workflow.
 
 ## Sending Text and Keystrokes
 


### PR DESCRIPTION
## Summary

- **Add category-claiming keywords** to 4 key AI doc intros (overview, agent panel, edit prediction, configuration) so Google associates these pages with "AI code editor" search terms
- **Expand AI overview into a pillar page** with substantive feature summaries and a "How Zed approaches AI" differentiation section (open source, native performance, multi-model, external agents, privacy)
- **Improve internal linking** across 11 files to strengthen the AI topic cluster

## Internal linking changes

**Inbound links (non-AI docs → AI section):**
- `editing-code.md` → AI overview
- `terminal.md` → Inline Assistant + Agent Panel
- `configuring-zed.md` → AI Configuration
- `remote-development.md` → AI overview

**Fix orphans within AI section:**
- `billing.md` linked to subscription + plans (was orphaned with zero internal links)
- `tools.md`, `rules.md`, `llm-providers.md`, `tool-permissions.md`, `models.md` all now cross-link to related AI pages

**Outbound:**
- `overview.md` → `zed.dev/ai` and `getting-started.md`

## Test plan

- [ ] `mdbook build docs` succeeds
- [ ] Spot-check links resolve correctly in built output
- [ ] Review overview.md content for docs voice fit

🤖 Generated with [Claude Code](https://claude.com/claude-code)