### PR TITLE
Add git worktree remove/rename API

### DIFF
--- a/crates/fs/src/fake_git_repo.rs
+++ b/crates/fs/src/fake_git_repo.rs
@@ -1,4 +1,4 @@
-use crate::{FakeFs, FakeFsEntry, Fs};
+use crate::{FakeFs, FakeFsEntry, Fs, RemoveOptions, RenameOptions};
 use anyhow::{Context as _, Result, bail};
 use collections::{HashMap, HashSet};
 use futures::future::{self, BoxFuture, join_all};
@@ -421,12 +421,19 @@ impl GitRepository for FakeGitRepository {
         async move {
             let path = directory.join(&name);
             executor.simulate_random_delay().await;
+            // Check for simulated error before any side effects
+            fs.with_git_state(&dot_git_path, false, |state| {
+                if let Some(message) = &state.simulated_create_worktree_error {
+                    anyhow::bail!("{message}");
+                }
+                Ok(())
+            })??;
+            // Create directory before updating state so state is never
+            // inconsistent with the filesystem
+            fs.create_dir(&path).await?;
             fs.with_git_state(&dot_git_path, true, {
                 let path = path.clone();
                 move |state| {
-                    if let Some(message) = &state.simulated_create_worktree_error {
-                        anyhow::bail!("{message}");
-                    }
                     let ref_name = format!("refs/heads/{name}");
                     let sha = from_commit.unwrap_or_else(|| "fake-sha".to_string());
                     state.worktrees.push(Worktree {
@@ -438,37 +445,72 @@ impl GitRepository for FakeGitRepository {
                     Ok::<(), anyhow::Error>(())
                 }
             })??;
-            fs.create_dir(&path).await?;
             Ok(())
         }
         .boxed()
     }
 
     fn remove_worktree(&self, path: PathBuf, _force: bool) -> BoxFuture<'_, Result<()>> {
-        self.with_state_async(true, move |state| {
-            let initial_len = state.worktrees.len();
-            state.worktrees.retain(|worktree| worktree.path != path);
-            if state.worktrees.len() == initial_len {
-                bail!("no worktree found at path: {}", path.display());
-            }
+        let fs = self.fs.clone();
+        let executor = self.executor.clone();
+        let dot_git_path = self.dot_git_path.clone();
+        async move {
+            executor.simulate_random_delay().await;
+            // Remove the directory first, then update state
+            fs.remove_dir(
+                &path,
+                RemoveOptions {
+                    recursive: true,
+                    ignore_if_not_exists: false,
+                },
+            )
+            .await?;
+            fs.with_git_state(&dot_git_path, true, move |state| {
+                let initial_len = state.worktrees.len();
+                state.worktrees.retain(|worktree| worktree.path != path);
+                if state.worktrees.len() == initial_len {
+                    bail!("no worktree found at path: {}", path.display());
+                }
+                Ok(())
+            })??;
             Ok(())
-        })
+        }
+        .boxed()
     }
 
     fn rename_worktree(&self, old_path: PathBuf, new_path: PathBuf) -> BoxFuture<'_, Result<()>> {
-        self.with_state_async(true, move |state| {
-            let worktree = state
-                .worktrees
-                .iter_mut()
-                .find(|worktree| worktree.path == old_path);
-            match worktree {
-                Some(worktree) => {
-                    worktree.path = new_path;
-                    Ok(())
+        let fs = self.fs.clone();
+        let executor = self.executor.clone();
+        let dot_git_path = self.dot_git_path.clone();
+        async move {
+            executor.simulate_random_delay().await;
+            // Move the directory first, then update state
+            fs.rename(
+                &old_path,
+                &new_path,
+                RenameOptions {
+                    overwrite: false,
+                    ignore_if_exists: false,
+                    create_parents: true,
+                },
+            )
+            .await?;
+            fs.with_git_state(&dot_git_path, true, move |state| {
+                let worktree = state
+                    .worktrees
+                    .iter_mut()
+                    .find(|worktree| worktree.path == old_path);
+                match worktree {
+                    Some(worktree) => {
+                        worktree.path = new_path;
+                        Ok(())
+                    }
+                    None => bail!("no worktree found at path: {}", old_path.display()),
                 }
-                None => bail!("no worktree found at path: {}", old_path.display()),
-            }
-        })
+            })??;
+            Ok(())
+        }
+        .boxed()
     }
 
     fn change_branch(&self, name: String) -> BoxFuture<'_, Result<()>> {
@@ -863,6 +905,12 @@ mod tests {
         assert_eq!(worktrees[0].ref_name.as_ref(), "refs/heads/feature-branch");
         assert_eq!(worktrees[0].sha.as_ref(), "abc123");
 
+        // Directory should exist in FakeFs after create
+        assert!(
+            fs.is_dir(Path::new("/worktrees/feature-branch")).await,
+            "worktree directory should be created in FakeFs"
+        );
+
         // Create a second worktree (without explicit commit)
         repo.create_worktree(
             "bugfix-branch".to_string(),
@@ -874,6 +922,10 @@ mod tests {
 
         let worktrees = repo.worktrees().await.unwrap();
         assert_eq!(worktrees.len(), 2);
+        assert!(
+            fs.is_dir(Path::new("/worktrees/bugfix-branch")).await,
+            "second worktree directory should be created in FakeFs"
+        );
 
         // Rename the first worktree
         repo.rename_worktree(
@@ -898,6 +950,16 @@ mod tests {
             "old path should no longer exist"
         );
 
+        // Directory should be moved in FakeFs after rename
+        assert!(
+            !fs.is_dir(Path::new("/worktrees/feature-branch")).await,
+            "old worktree directory should not exist after rename"
+        );
+        assert!(
+            fs.is_dir(Path::new("/worktrees/renamed-branch")).await,
+            "new worktree directory should exist after rename"
+        );
+
         // Rename a nonexistent worktree should fail
         let result = repo
             .rename_worktree(PathBuf::from("/nonexistent"), PathBuf::from("/somewhere"))
@@ -913,6 +975,12 @@ mod tests {
         assert_eq!(worktrees.len(), 1);
         assert_eq!(worktrees[0].path, PathBuf::from("/worktrees/bugfix-branch"));
 
+        // Directory should be removed from FakeFs after remove
+        assert!(
+            !fs.is_dir(Path::new("/worktrees/renamed-branch")).await,
+            "worktree directory should be removed from FakeFs"
+        );
+
         // Remove a nonexistent worktree should fail
         let result = repo
             .remove_worktree(PathBuf::from("/nonexistent"), false)
@@ -926,5 +994,9 @@ mod tests {
 
         let worktrees = repo.worktrees().await.unwrap();
         assert!(worktrees.is_empty());
+        assert!(
+            !fs.is_dir(Path::new("/worktrees/bugfix-branch")).await,
+            "last worktree directory should be removed from FakeFs"
+        );
     }
 }

--- a/crates/fs/src/fake_git_repo.rs
+++ b/crates/fs/src/fake_git_repo.rs
@@ -434,8 +434,12 @@ impl GitRepository for FakeGitRepository {
             fs.with_git_state(&dot_git_path, true, {
                 let path = path.clone();
                 move |state| {
+                    if state.branches.contains(&name) {
+                        bail!("a branch named '{}' already exists", name);
+                    }
                     let ref_name = format!("refs/heads/{name}");
                     let sha = from_commit.unwrap_or_else(|| "fake-sha".to_string());
+                    state.refs.insert(ref_name.clone(), sha.clone());
                     state.worktrees.push(Worktree {
                         path,
                         ref_name: ref_name.into(),
@@ -456,7 +460,17 @@ impl GitRepository for FakeGitRepository {
         let dot_git_path = self.dot_git_path.clone();
         async move {
             executor.simulate_random_delay().await;
-            // Remove the directory first, then update state
+            // Validate the worktree exists in state before touching the filesystem
+            fs.with_git_state(&dot_git_path, false, {
+                let path = path.clone();
+                move |state| {
+                    if !state.worktrees.iter().any(|w| w.path == path) {
+                        bail!("no worktree found at path: {}", path.display());
+                    }
+                    Ok(())
+                }
+            })??;
+            // Now remove the directory
             fs.remove_dir(
                 &path,
                 RemoveOptions {
@@ -465,13 +479,10 @@ impl GitRepository for FakeGitRepository {
                 },
             )
             .await?;
+            // Update state
             fs.with_git_state(&dot_git_path, true, move |state| {
-                let initial_len = state.worktrees.len();
                 state.worktrees.retain(|worktree| worktree.path != path);
-                if state.worktrees.len() == initial_len {
-                    bail!("no worktree found at path: {}", path.display());
-                }
-                Ok(())
+                Ok::<(), anyhow::Error>(())
             })??;
             Ok(())
         }
@@ -484,7 +495,17 @@ impl GitRepository for FakeGitRepository {
         let dot_git_path = self.dot_git_path.clone();
         async move {
             executor.simulate_random_delay().await;
-            // Move the directory first, then update state
+            // Validate the worktree exists in state before touching the filesystem
+            fs.with_git_state(&dot_git_path, false, {
+                let old_path = old_path.clone();
+                move |state| {
+                    if !state.worktrees.iter().any(|w| w.path == old_path) {
+                        bail!("no worktree found at path: {}", old_path.display());
+                    }
+                    Ok(())
+                }
+            })??;
+            // Now move the directory
             fs.rename(
                 &old_path,
                 &new_path,
@@ -495,18 +516,15 @@ impl GitRepository for FakeGitRepository {
                 },
             )
             .await?;
+            // Update state
             fs.with_git_state(&dot_git_path, true, move |state| {
                 let worktree = state
                     .worktrees
                     .iter_mut()
-                    .find(|worktree| worktree.path == old_path);
-                match worktree {
-                    Some(worktree) => {
-                        worktree.path = new_path;
-                        Ok(())
-                    }
-                    None => bail!("no worktree found at path: {}", old_path.display()),
-                }
+                    .find(|worktree| worktree.path == old_path)
+                    .expect("worktree was validated above");
+                worktree.path = new_path;
+                Ok::<(), anyhow::Error>(())
             })??;
             Ok(())
         }

--- a/crates/fs/src/fake_git_repo.rs
+++ b/crates/fs/src/fake_git_repo.rs
@@ -916,10 +916,7 @@ mod tests {
         // List worktrees — should have one
         let worktrees = repo.worktrees().await.unwrap();
         assert_eq!(worktrees.len(), 1);
-        assert_eq!(
-            worktrees[0].path,
-            PathBuf::from("/worktrees/feature-branch")
-        );
+        assert_eq!(worktrees[0].path, Path::new("/worktrees/feature-branch"));
         assert_eq!(worktrees[0].ref_name.as_ref(), "refs/heads/feature-branch");
         assert_eq!(worktrees[0].sha.as_ref(), "abc123");
 
@@ -958,13 +955,13 @@ mod tests {
         assert!(
             worktrees
                 .iter()
-                .any(|w| w.path == PathBuf::from("/worktrees/renamed-branch")),
+                .any(|w| w.path == Path::new("/worktrees/renamed-branch")),
             "renamed worktree should exist at new path"
         );
         assert!(
             worktrees
                 .iter()
-                .all(|w| w.path != PathBuf::from("/worktrees/feature-branch")),
+                .all(|w| w.path != Path::new("/worktrees/feature-branch")),
             "old path should no longer exist"
         );
 
@@ -991,7 +988,7 @@ mod tests {
 
         let worktrees = repo.worktrees().await.unwrap();
         assert_eq!(worktrees.len(), 1);
-        assert_eq!(worktrees[0].path, PathBuf::from("/worktrees/bugfix-branch"));
+        assert_eq!(worktrees[0].path, Path::new("/worktrees/bugfix-branch"));
 
         // Directory should be removed from FakeFs after remove
         assert!(

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -2069,6 +2069,13 @@ impl FakeFs {
         .unwrap();
     }
 
+    pub fn set_create_worktree_error(&self, dot_git: &Path, message: Option<String>) {
+        self.with_git_state(dot_git, true, |state| {
+            state.simulated_create_worktree_error = message;
+        })
+        .unwrap();
+    }
+
     pub fn paths(&self, include_dot_git: bool) -> Vec<PathBuf> {
         let mut result = Vec::new();
         let mut queue = collections::VecDeque::new();

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -203,7 +203,8 @@ impl Worktree {
 
 pub fn parse_worktrees_from_str<T: AsRef<str>>(raw_worktrees: T) -> Vec<Worktree> {
     let mut worktrees = Vec::new();
-    let entries = raw_worktrees.as_ref().split("\n\n");
+    let normalized = raw_worktrees.as_ref().replace("\r\n", "\n");
+    let entries = normalized.split("\n\n");
     for entry in entries {
         let mut path = None;
         let mut sha = None;
@@ -1585,9 +1586,11 @@ impl GitRepository for RealGitRepository {
             OsString::from("--no-optional-locks"),
             OsString::from("worktree"),
             OsString::from("add"),
+            OsString::from("-b"),
+            OsString::from(name.as_str()),
+            OsString::from("--"),
             OsString::from(final_path.as_os_str()),
         ];
-        args.extend([OsString::from("-b"), OsString::from(name.as_str())]);
         if let Some(from_commit) = from_commit {
             args.push(OsString::from(from_commit));
         } else {
@@ -1621,11 +1624,12 @@ impl GitRepository for RealGitRepository {
                     "--no-optional-locks".into(),
                     "worktree".into(),
                     "remove".into(),
-                    path.as_os_str().into(),
                 ];
                 if force {
                     args.push("--force".into());
                 }
+                args.push("--".into());
+                args.push(path.as_os_str().into());
                 GitBinary::new(git_binary_path, working_directory?, executor)
                     .run(args)
                     .await?;
@@ -1645,6 +1649,7 @@ impl GitRepository for RealGitRepository {
                     "--no-optional-locks".into(),
                     "worktree".into(),
                     "move".into(),
+                    "--".into(),
                     old_path.as_os_str().into(),
                     new_path.as_os_str().into(),
                 ];
@@ -3687,6 +3692,14 @@ mod tests {
         // Leading/trailing whitespace on lines should be tolerated
         let input =
             "  worktree /home/user/project  \n  HEAD abc123  \n  branch refs/heads/main  \n\n";
+        let result = parse_worktrees_from_str(input);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].path, PathBuf::from("/home/user/project"));
+        assert_eq!(result[0].sha.as_ref(), "abc123");
+        assert_eq!(result[0].ref_name.as_ref(), "refs/heads/main");
+
+        // Windows-style line endings should be handled
+        let input = "worktree /home/user/project\r\nHEAD abc123\r\nbranch refs/heads/main\r\n\r\n";
         let result = parse_worktrees_from_str(input);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].path, PathBuf::from("/home/user/project"));

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -3743,7 +3743,10 @@ mod tests {
         // List worktrees — should have just the main one
         let worktrees = repo.worktrees().await.unwrap();
         assert_eq!(worktrees.len(), 1);
-        assert_eq!(worktrees[0].path, repo_dir.path().canonicalize().unwrap());
+        assert_eq!(
+            worktrees[0].path.canonicalize().unwrap(),
+            repo_dir.path().canonicalize().unwrap()
+        );
 
         // Create a new worktree
         let worktree_dir = tempfile::tempdir().unwrap();
@@ -3764,7 +3767,7 @@ mod tests {
             .find(|w| w.branch() == "test-branch")
             .expect("should find worktree with test-branch");
         assert_eq!(
-            new_worktree.path,
+            new_worktree.path.canonicalize().unwrap(),
             worktree_dir
                 .path()
                 .join("test-branch")
@@ -3966,7 +3969,10 @@ mod tests {
             .iter()
             .find(|w| w.branch() == "old-name")
             .expect("should find worktree by branch name");
-        assert_eq!(moved_worktree.path, new_path.canonicalize().unwrap());
+        assert_eq!(
+            moved_worktree.path.canonicalize().unwrap(),
+            new_path.canonicalize().unwrap()
+        );
     }
 
     impl RealGitRepository {

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -205,16 +205,24 @@ pub fn parse_worktrees_from_str<T: AsRef<str>>(raw_worktrees: T) -> Vec<Worktree
     let mut worktrees = Vec::new();
     let entries = raw_worktrees.as_ref().split("\n\n");
     for entry in entries {
-        let mut parts = entry.splitn(3, '\n');
-        let path = parts
-            .next()
-            .and_then(|p| p.split_once(' ').map(|(_, path)| path.to_string()));
-        let sha = parts
-            .next()
-            .and_then(|p| p.split_once(' ').map(|(_, sha)| sha.to_string()));
-        let ref_name = parts
-            .next()
-            .and_then(|p| p.split_once(' ').map(|(_, ref_name)| ref_name.to_string()));
+        let mut path = None;
+        let mut sha = None;
+        let mut ref_name = None;
+
+        for line in entry.lines() {
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+            if let Some(rest) = line.strip_prefix("worktree ") {
+                path = Some(rest.to_string());
+            } else if let Some(rest) = line.strip_prefix("HEAD ") {
+                sha = Some(rest.to_string());
+            } else if let Some(rest) = line.strip_prefix("branch ") {
+                ref_name = Some(rest.to_string());
+            }
+            // Ignore other lines: detached, bare, locked, prunable, etc.
+        }
 
         if let (Some(path), Some(sha), Some(ref_name)) = (path, sha, ref_name) {
             worktrees.push(Worktree {
@@ -1579,12 +1587,11 @@ impl GitRepository for RealGitRepository {
             OsString::from("add"),
             OsString::from(final_path.as_os_str()),
         ];
+        args.extend([OsString::from("-b"), OsString::from(name.as_str())]);
         if let Some(from_commit) = from_commit {
-            args.extend([
-                OsString::from("-b"),
-                OsString::from(name.as_str()),
-                OsString::from(from_commit),
-            ]);
+            args.push(OsString::from(from_commit));
+        } else {
+            args.push(OsString::from("HEAD"));
         }
         self.executor
             .spawn(async move {
@@ -1597,7 +1604,7 @@ impl GitRepository for RealGitRepository {
                     Ok(())
                 } else {
                     let stderr = String::from_utf8_lossy(&output.stderr);
-                    anyhow::bail!("git worktree list failed: {stderr}");
+                    anyhow::bail!("git worktree add failed: {stderr}");
                 }
             })
             .boxed()
@@ -3663,6 +3670,28 @@ mod tests {
         let result = parse_worktrees_from_str(input);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].path, PathBuf::from("/home/user/project"));
+
+        // Extra porcelain lines (locked, prunable) should be ignored
+        let input = "worktree /home/user/project\nHEAD abc123\nbranch refs/heads/main\n\n\
+                      worktree /home/user/locked-wt\nHEAD def456\nbranch refs/heads/locked-branch\nlocked\n\n\
+                      worktree /home/user/prunable-wt\nHEAD 789aaa\nbranch refs/heads/prunable-branch\nprunable\n\n";
+        let result = parse_worktrees_from_str(input);
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0].path, PathBuf::from("/home/user/project"));
+        assert_eq!(result[0].ref_name.as_ref(), "refs/heads/main");
+        assert_eq!(result[1].path, PathBuf::from("/home/user/locked-wt"));
+        assert_eq!(result[1].ref_name.as_ref(), "refs/heads/locked-branch");
+        assert_eq!(result[2].path, PathBuf::from("/home/user/prunable-wt"));
+        assert_eq!(result[2].ref_name.as_ref(), "refs/heads/prunable-branch");
+
+        // Leading/trailing whitespace on lines should be tolerated
+        let input =
+            "  worktree /home/user/project  \n  HEAD abc123  \n  branch refs/heads/main  \n\n";
+        let result = parse_worktrees_from_str(input);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].path, PathBuf::from("/home/user/project"));
+        assert_eq!(result[0].sha.as_ref(), "abc123");
+        assert_eq!(result[0].ref_name.as_ref(), "refs/heads/main");
     }
 
     #[gpui::test]


### PR DESCRIPTION
Add `remove_worktree()` and `rename_worktree()` to the `GitRepository` trait with `RealGitRepository` implementations that shell out to `git worktree remove/move`.

Implement all 4 worktree methods (`worktrees`, `create_worktree`, `remove_worktree`, `rename_worktree`) on `FakeGitRepository` backed by `FakeGitRepositoryState`, with `simulated_create_worktree_error` for test-time fault injection.

Add `set_create_worktree_error()` helper on `FakeFs`.

Add `parse_worktrees_from_str` helper and 7 new tests covering real git operations and fake worktree lifecycle.

Closes AI-31

Release Notes:

- N/A