### PR TITLE
agent_ui:  Use circular progress component for displaying context window use

### DIFF
--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -50,10 +50,10 @@ use terminal_view::terminal_panel::TerminalPanel;
 use text::{Anchor, ToPoint as _};
 use theme::AgentFontSize;
 use ui::{
-    Callout, CommonAnimationExt, ContextMenu, ContextMenuEntry, CopyButton, DecoratedIcon,
-    DiffStat, Disclosure, Divider, DividerColor, IconDecoration, IconDecorationKind, KeyBinding,
-    PopoverMenu, PopoverMenuHandle, SpinnerLabel, TintColor, Tooltip, WithScrollbar, prelude::*,
-    right_click_menu,
+    Callout, CircularProgress, CommonAnimationExt, ContextMenu, ContextMenuEntry, CopyButton,
+    DecoratedIcon, DiffStat, Disclosure, Divider, DividerColor, IconDecoration, IconDecorationKind,
+    KeyBinding, PopoverMenu, PopoverMenuHandle, SpinnerLabel, TintColor, Tooltip, WithScrollbar,
+    prelude::*, right_click_menu,
 };
 use util::{ResultExt, size::format_file_size, time::duration_alt_display};
 use util::{debug_panic, defer};

--- a/crates/ui/src/components/progress/circular_progress.rs
+++ b/crates/ui/src/components/progress/circular_progress.rs
@@ -10,6 +10,7 @@ pub struct CircularProgress {
     value: f32,
     max_value: f32,
     size: Pixels,
+    stroke_width: Pixels,
     bg_color: Hsla,
     progress_color: Hsla,
 }
@@ -20,6 +21,7 @@ impl CircularProgress {
             value,
             max_value,
             size,
+            stroke_width: px(4.0),
             bg_color: cx.theme().colors().border_variant,
             progress_color: cx.theme().status().info,
         }
@@ -40,6 +42,12 @@ impl CircularProgress {
     /// Sets the size (diameter) of the circular progress indicator.
     pub fn size(mut self, size: Pixels) -> Self {
         self.size = size;
+        self
+    }
+
+    /// Sets the stroke width of the circular progress indicator.
+    pub fn stroke_width(mut self, stroke_width: Pixels) -> Self {
+        self.stroke_width = stroke_width;
         self
     }
 
@@ -72,7 +80,7 @@ impl RenderOnce for CircularProgress {
                 let center_x = bounds.origin.x + bounds.size.width / 2.0;
                 let center_y = bounds.origin.y + bounds.size.height / 2.0;
 
-                let stroke_width = px(4.0);
+                let stroke_width = self.stroke_width;
                 let radius = (size / 2.0) - stroke_width;
 
                 // Draw background circle (full 360 degrees)


### PR DESCRIPTION
This PR uses the recently introduced `CircularProgress` component to display context window use information. It creates more space for the message editor controls as well as simplifies the UI a little bit. Through a tooltip, we communicate the same things we communicated before (and more, actually, because rules use will be displayed there, too). Note that this doesn't touch the display of split token use (for models like GPT and whatnot).

<img width="500" height="484" alt="Screenshot 2026-02-13 at 6  16@2x" src="https://github.com/user-attachments/assets/831cdfbf-fddd-4a11-8ac6-e9a25609aae9" />

Release Notes:

- Agent: Simplified context window use display by using a circular progress component.
