### PR TITLE
Add agent worktree directory setting + worktree info persistence

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1487,10 +1487,21 @@
     "path_style": "file_name_first",
     // Directory where git worktrees are created, relative to the repository
     // working directory.
+    //
+    // When the resolved directory is outside the project root, the
+    // project's directory name is automatically appended so that
+    // sibling repos don't collide. For example, with the default
+    // "../worktrees" and a project at ~/src/zed, worktrees are
+    // created under ~/src/worktrees/zed/.
+    //
+    // When the resolved directory is inside the project root, no
+    // extra component is added (it's already project-scoped).
+    //
     // Examples:
-    //   "../worktrees" — sibling of the project root (default)
-    //   ".git/zed-worktrees" — inside the git directory
-    //   "my-worktrees" — subdirectory of the project root
+    //   "../worktrees" — ~/src/worktrees/<project>/ (default)
+    //   ".git/zed-worktrees" — <project>/.git/zed-worktrees/
+    //   "my-worktrees" — <project>/my-worktrees/
+    //
     // Trailing slashes are ignored.
     "worktree_directory": "../worktrees",
   },

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1491,14 +1491,14 @@
     // When the resolved directory is outside the project root, the
     // project's directory name is automatically appended so that
     // sibling repos don't collide. For example, with the default
-    // "../worktrees" and a project at ~/src/zed, worktrees are
-    // created under ~/src/worktrees/zed/.
+    // "../worktrees" and a project at ~/code/zed, worktrees are
+    // created under ~/code/worktrees/zed/.
     //
     // When the resolved directory is inside the project root, no
     // extra component is added (it's already project-scoped).
     //
     // Examples:
-    //   "../worktrees" — ~/src/worktrees/<project>/ (default)
+    //   "../worktrees" — ~/code/worktrees/<project>/ (default)
     //   ".git/zed-worktrees" — <project>/.git/zed-worktrees/
     //   "my-worktrees" — <project>/my-worktrees/
     //

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1485,6 +1485,14 @@
     // Should the name or path be displayed first in the git view.
     // "path_style": "file_name_first" or "file_path_first"
     "path_style": "file_name_first",
+    // Directory where git worktrees are created, relative to the repository
+    // working directory.
+    // Examples:
+    //   "../worktrees" — sibling of the project root (default)
+    //   ".git/zed-worktrees" — inside the git directory
+    //   "my-worktrees" — subdirectory of the project root
+    // Trailing slashes are ignored.
+    "worktree_directory": "../worktrees",
   },
   // The list of custom Git hosting providers.
   "git_hosting_providers": [

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -1467,12 +1467,23 @@ impl NativeAgentSessionList {
     }
 
     fn to_session_info(entry: DbThreadMetadata) -> AgentSessionInfo {
+        // Serialize worktree_branch into the untyped `meta` map expected by
+        // AgentSessionInfo. If a typed metadata struct is introduced, migrate.
+        let meta = entry.worktree_branch.map(|branch| {
+            let mut map = serde_json::Map::new();
+            map.insert(
+                "worktree_branch".to_string(),
+                serde_json::Value::String(branch),
+            );
+            map
+        });
+
         AgentSessionInfo {
             session_id: entry.id,
             cwd: None,
             title: Some(entry.title),
             updated_at: Some(entry.updated_at),
-            meta: None,
+            meta,
         }
     }
 

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -1467,23 +1467,12 @@ impl NativeAgentSessionList {
     }
 
     fn to_session_info(entry: DbThreadMetadata) -> AgentSessionInfo {
-        // Serialize worktree_branch into the untyped `meta` map expected by
-        // AgentSessionInfo. If a typed metadata struct is introduced, migrate.
-        let meta = entry.worktree_branch.map(|branch| {
-            let mut map = serde_json::Map::new();
-            map.insert(
-                "worktree_branch".to_string(),
-                serde_json::Value::String(branch),
-            );
-            map
-        });
-
         AgentSessionInfo {
             session_id: entry.id,
             cwd: None,
             title: Some(entry.title),
             updated_at: Some(entry.updated_at),
-            meta,
+            meta: None,
         }
     }
 

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1,8 +1,8 @@
 use crate::{
-    ContextServerRegistry, CopyPathTool, CreateDirectoryTool, DbLanguageModel, DbThread,
-    DeletePathTool, DiagnosticsTool, EditFileTool, FetchTool, FindPathTool, GrepTool,
-    ListDirectoryTool, MovePathTool, NowTool, OpenTool, ProjectSnapshot, ReadFileTool,
-    RestoreFileFromDiskTool, SaveFileTool, StreamingEditFileTool, SubagentTool,
+    AgentGitWorktreeInfo, ContextServerRegistry, CopyPathTool, CreateDirectoryTool,
+    DbLanguageModel, DbThread, DeletePathTool, DiagnosticsTool, EditFileTool, FetchTool,
+    FindPathTool, GrepTool, ListDirectoryTool, MovePathTool, NowTool, OpenTool, ProjectSnapshot,
+    ReadFileTool, RestoreFileFromDiskTool, SaveFileTool, StreamingEditFileTool, SubagentTool,
     SystemPromptTemplate, Template, Templates, TerminalTool, ToolPermissionDecision, WebSearchTool,
     decide_permission_from_settings,
 };
@@ -870,6 +870,8 @@ pub struct Thread {
     subagent_context: Option<SubagentContext>,
     /// Weak references to running subagent threads for cancellation propagation
     running_subagents: Vec<WeakEntity<Thread>>,
+    /// Git worktree info if this thread is running in an agent worktree.
+    pub(crate) git_worktree_info: Option<AgentGitWorktreeInfo>,
 }
 
 impl Thread {
@@ -960,6 +962,7 @@ impl Thread {
             imported: false,
             subagent_context: None,
             running_subagents: Vec::new(),
+            git_worktree_info: None,
         }
     }
 
@@ -1013,7 +1016,6 @@ impl Thread {
         stream: &ThreadEventStream,
         cx: &mut Context<Self>,
     ) {
-        // Extract saved output and status first, so they're available even if tool is not found
         let output = tool_result
             .as_ref()
             .and_then(|result| result.output.clone());
@@ -1041,10 +1043,6 @@ impl Thread {
         });
 
         let Some(tool) = tool else {
-            // Tool not found (e.g., MCP server not connected after restart),
-            // but still display the saved result if available.
-            // We need to send both ToolCall and ToolCallUpdate events because the UI
-            // only converts raw_output to displayable content in update_fields, not from_acp.
             stream
                 .0
                 .unbounded_send(Ok(ThreadEvent::ToolCall(
@@ -1184,6 +1182,7 @@ impl Thread {
             imported: db_thread.imported,
             subagent_context: db_thread.subagent_context,
             running_subagents: Vec::new(),
+            git_worktree_info: db_thread.git_worktree_info,
         }
     }
 
@@ -1204,6 +1203,7 @@ impl Thread {
             profile: Some(self.profile_id.clone()),
             imported: self.imported,
             subagent_context: self.subagent_context.clone(),
+            git_worktree_info: self.git_worktree_info.clone(),
         };
 
         cx.background_spawn(async move {

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1016,6 +1016,7 @@ impl Thread {
         stream: &ThreadEventStream,
         cx: &mut Context<Self>,
     ) {
+        // Extract saved output and status first, so they're available even if tool is not found
         let output = tool_result
             .as_ref()
             .and_then(|result| result.output.clone());
@@ -1043,6 +1044,10 @@ impl Thread {
         });
 
         let Some(tool) = tool else {
+            // Tool not found (e.g., MCP server not connected after restart),
+            // but still display the saved result if available.
+            // We need to send both ToolCall and ToolCallUpdate events because the UI
+            // only converts raw_output to displayable content in update_fields, not from_acp.
             stream
                 .0
                 .unbounded_send(Ok(ThreadEvent::ToolCall(

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -871,7 +871,7 @@ pub struct Thread {
     /// Weak references to running subagent threads for cancellation propagation
     running_subagents: Vec<WeakEntity<Thread>>,
     /// Git worktree info if this thread is running in an agent worktree.
-    pub(crate) git_worktree_info: Option<AgentGitWorktreeInfo>,
+    git_worktree_info: Option<AgentGitWorktreeInfo>,
 }
 
 impl Thread {

--- a/crates/agent/src/thread_store.rs
+++ b/crates/agent/src/thread_store.rs
@@ -162,6 +162,7 @@ mod tests {
             profile: None,
             imported: false,
             subagent_context: None,
+            git_worktree_info: None,
         }
     }
 

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -219,7 +219,13 @@ impl Settings for EditorSettings {
             scrollbar: Scrollbar {
                 show: scrollbar.show.map(Into::into).unwrap(),
                 git_diff: scrollbar.git_diff.unwrap()
-                    && content.git.unwrap().enabled.unwrap().is_git_diff_enabled(),
+                    && content
+                        .git
+                        .as_ref()
+                        .unwrap()
+                        .enabled
+                        .unwrap()
+                        .is_git_diff_enabled(),
                 selected_text: scrollbar.selected_text.unwrap(),
                 selected_symbol: scrollbar.selected_symbol.unwrap(),
                 search_results: scrollbar.search_results.unwrap(),

--- a/crates/fs/src/fake_git_repo.rs
+++ b/crates/fs/src/fake_git_repo.rs
@@ -8,7 +8,7 @@ use git::{
     repository::{
         AskPassDelegate, Branch, CommitDataReader, CommitDetails, CommitOptions, FetchOptions,
         GRAPH_CHUNK_SIZE, GitRepository, GitRepositoryCheckpoint, InitialGraphCommitData, LogOrder,
-        LogSource, PushOptions, Remote, RepoPath, ResetMode, Worktree, validate_worktree_directory,
+        LogSource, PushOptions, Remote, RepoPath, ResetMode, Worktree,
     },
     status::{
         DiffTreeType, FileStatus, GitStatus, StatusCode, TrackedStatus, TreeDiff, TreeDiffStatus,
@@ -412,20 +412,13 @@ impl GitRepository for FakeGitRepository {
     fn create_worktree(
         &self,
         name: String,
-        worktree_directory: String,
+        directory: PathBuf,
         from_commit: Option<String>,
     ) -> BoxFuture<'_, Result<()>> {
         let fs = self.fs.clone();
         let executor = self.executor.clone();
         let dot_git_path = self.dot_git_path.clone();
-        let working_directory = self
-            .dot_git_path
-            .parent()
-            .unwrap_or(&self.dot_git_path)
-            .to_path_buf();
-        let directory = validate_worktree_directory(&working_directory, &worktree_directory);
         async move {
-            let directory = directory?;
             let path = directory.join(&name);
             executor.simulate_random_delay().await;
             // Check for simulated error before any side effects
@@ -914,19 +907,19 @@ mod tests {
             let worktrees = repo.worktrees().await.unwrap();
             assert!(worktrees.is_empty());
 
-            // Create a worktree
-            repo.create_worktree(
-                "feature-branch".to_string(),
-                worktree_dir_setting.to_string(),
-                Some("abc123".to_string()),
-            )
-            .await
-            .unwrap();
-
             let expected_dir = git::repository::resolve_worktree_directory(
                 Path::new("/project"),
                 worktree_dir_setting,
             );
+
+            // Create a worktree
+            repo.create_worktree(
+                "feature-branch".to_string(),
+                expected_dir.clone(),
+                Some("abc123".to_string()),
+            )
+            .await
+            .unwrap();
 
             // List worktrees — should have one
             let worktrees = repo.worktrees().await.unwrap();
@@ -946,13 +939,9 @@ mod tests {
             );
 
             // Create a second worktree (without explicit commit)
-            repo.create_worktree(
-                "bugfix-branch".to_string(),
-                worktree_dir_setting.to_string(),
-                None,
-            )
-            .await
-            .unwrap();
+            repo.create_worktree("bugfix-branch".to_string(), expected_dir.clone(), None)
+                .await
+                .unwrap();
 
             let worktrees = repo.worktrees().await.unwrap();
             assert_eq!(worktrees.len(), 2);

--- a/crates/fs/src/fake_git_repo.rs
+++ b/crates/fs/src/fake_git_repo.rs
@@ -8,7 +8,7 @@ use git::{
     repository::{
         AskPassDelegate, Branch, CommitDataReader, CommitDetails, CommitOptions, FetchOptions,
         GRAPH_CHUNK_SIZE, GitRepository, GitRepositoryCheckpoint, InitialGraphCommitData, LogOrder,
-        LogSource, PushOptions, Remote, RepoPath, ResetMode, Worktree,
+        LogSource, PushOptions, Remote, RepoPath, ResetMode, Worktree, validate_worktree_directory,
     },
     status::{
         DiffTreeType, FileStatus, GitStatus, StatusCode, TrackedStatus, TreeDiff, TreeDiffStatus,
@@ -412,13 +412,20 @@ impl GitRepository for FakeGitRepository {
     fn create_worktree(
         &self,
         name: String,
-        directory: PathBuf,
+        worktree_directory: String,
         from_commit: Option<String>,
     ) -> BoxFuture<'_, Result<()>> {
         let fs = self.fs.clone();
         let executor = self.executor.clone();
         let dot_git_path = self.dot_git_path.clone();
+        let working_directory = self
+            .dot_git_path
+            .parent()
+            .unwrap_or(&self.dot_git_path)
+            .to_path_buf();
+        let directory = validate_worktree_directory(&working_directory, &worktree_directory);
         async move {
+            let directory = directory?;
             let path = directory.join(&name);
             executor.simulate_random_delay().await;
             // Check for simulated error before any side effects
@@ -893,125 +900,138 @@ mod tests {
 
     #[gpui::test]
     async fn test_fake_worktree_lifecycle(cx: &mut TestAppContext) {
-        let fs = FakeFs::new(cx.executor());
-        fs.insert_tree("/project", json!({".git": {}, "file.txt": "content"}))
-            .await;
-        let repo = fs
-            .open_repo(Path::new("/project/.git"), None)
-            .expect("should open fake repo");
+        let worktree_dir_settings = &["../worktrees", ".git/zed-worktrees", "my-worktrees/"];
 
-        // Initially no worktrees
-        let worktrees = repo.worktrees().await.unwrap();
-        assert!(worktrees.is_empty());
+        for worktree_dir_setting in worktree_dir_settings {
+            let fs = FakeFs::new(cx.executor());
+            fs.insert_tree("/project", json!({".git": {}, "file.txt": "content"}))
+                .await;
+            let repo = fs
+                .open_repo(Path::new("/project/.git"), None)
+                .expect("should open fake repo");
 
-        // Create a worktree
-        repo.create_worktree(
-            "feature-branch".to_string(),
-            PathBuf::from("/worktrees"),
-            Some("abc123".to_string()),
-        )
-        .await
-        .unwrap();
+            // Initially no worktrees
+            let worktrees = repo.worktrees().await.unwrap();
+            assert!(worktrees.is_empty());
 
-        // List worktrees — should have one
-        let worktrees = repo.worktrees().await.unwrap();
-        assert_eq!(worktrees.len(), 1);
-        assert_eq!(worktrees[0].path, Path::new("/worktrees/feature-branch"));
-        assert_eq!(worktrees[0].ref_name.as_ref(), "refs/heads/feature-branch");
-        assert_eq!(worktrees[0].sha.as_ref(), "abc123");
-
-        // Directory should exist in FakeFs after create
-        assert!(
-            fs.is_dir(Path::new("/worktrees/feature-branch")).await,
-            "worktree directory should be created in FakeFs"
-        );
-
-        // Create a second worktree (without explicit commit)
-        repo.create_worktree(
-            "bugfix-branch".to_string(),
-            PathBuf::from("/worktrees"),
-            None,
-        )
-        .await
-        .unwrap();
-
-        let worktrees = repo.worktrees().await.unwrap();
-        assert_eq!(worktrees.len(), 2);
-        assert!(
-            fs.is_dir(Path::new("/worktrees/bugfix-branch")).await,
-            "second worktree directory should be created in FakeFs"
-        );
-
-        // Rename the first worktree
-        repo.rename_worktree(
-            PathBuf::from("/worktrees/feature-branch"),
-            PathBuf::from("/worktrees/renamed-branch"),
-        )
-        .await
-        .unwrap();
-
-        let worktrees = repo.worktrees().await.unwrap();
-        assert_eq!(worktrees.len(), 2);
-        assert!(
-            worktrees
-                .iter()
-                .any(|w| w.path == Path::new("/worktrees/renamed-branch")),
-            "renamed worktree should exist at new path"
-        );
-        assert!(
-            worktrees
-                .iter()
-                .all(|w| w.path != Path::new("/worktrees/feature-branch")),
-            "old path should no longer exist"
-        );
-
-        // Directory should be moved in FakeFs after rename
-        assert!(
-            !fs.is_dir(Path::new("/worktrees/feature-branch")).await,
-            "old worktree directory should not exist after rename"
-        );
-        assert!(
-            fs.is_dir(Path::new("/worktrees/renamed-branch")).await,
-            "new worktree directory should exist after rename"
-        );
-
-        // Rename a nonexistent worktree should fail
-        let result = repo
-            .rename_worktree(PathBuf::from("/nonexistent"), PathBuf::from("/somewhere"))
-            .await;
-        assert!(result.is_err());
-
-        // Remove a worktree
-        repo.remove_worktree(PathBuf::from("/worktrees/renamed-branch"), false)
+            // Create a worktree
+            repo.create_worktree(
+                "feature-branch".to_string(),
+                worktree_dir_setting.to_string(),
+                Some("abc123".to_string()),
+            )
             .await
             .unwrap();
 
-        let worktrees = repo.worktrees().await.unwrap();
-        assert_eq!(worktrees.len(), 1);
-        assert_eq!(worktrees[0].path, Path::new("/worktrees/bugfix-branch"));
+            let expected_dir = git::repository::resolve_worktree_directory(
+                Path::new("/project"),
+                worktree_dir_setting,
+            );
 
-        // Directory should be removed from FakeFs after remove
-        assert!(
-            !fs.is_dir(Path::new("/worktrees/renamed-branch")).await,
-            "worktree directory should be removed from FakeFs"
-        );
+            // List worktrees — should have one
+            let worktrees = repo.worktrees().await.unwrap();
+            assert_eq!(worktrees.len(), 1);
+            assert_eq!(
+                worktrees[0].path,
+                expected_dir.join("feature-branch"),
+                "failed for worktree_directory setting: {worktree_dir_setting:?}"
+            );
+            assert_eq!(worktrees[0].ref_name.as_ref(), "refs/heads/feature-branch");
+            assert_eq!(worktrees[0].sha.as_ref(), "abc123");
 
-        // Remove a nonexistent worktree should fail
-        let result = repo
-            .remove_worktree(PathBuf::from("/nonexistent"), false)
-            .await;
-        assert!(result.is_err());
+            // Directory should exist in FakeFs after create
+            assert!(
+                fs.is_dir(&expected_dir.join("feature-branch")).await,
+                "worktree directory should be created in FakeFs for setting {worktree_dir_setting:?}"
+            );
 
-        // Remove the last worktree
-        repo.remove_worktree(PathBuf::from("/worktrees/bugfix-branch"), false)
+            // Create a second worktree (without explicit commit)
+            repo.create_worktree(
+                "bugfix-branch".to_string(),
+                worktree_dir_setting.to_string(),
+                None,
+            )
             .await
             .unwrap();
 
-        let worktrees = repo.worktrees().await.unwrap();
-        assert!(worktrees.is_empty());
-        assert!(
-            !fs.is_dir(Path::new("/worktrees/bugfix-branch")).await,
-            "last worktree directory should be removed from FakeFs"
-        );
+            let worktrees = repo.worktrees().await.unwrap();
+            assert_eq!(worktrees.len(), 2);
+            assert!(
+                fs.is_dir(&expected_dir.join("bugfix-branch")).await,
+                "second worktree directory should be created in FakeFs for setting {worktree_dir_setting:?}"
+            );
+
+            // Rename the first worktree
+            repo.rename_worktree(
+                expected_dir.join("feature-branch"),
+                expected_dir.join("renamed-branch"),
+            )
+            .await
+            .unwrap();
+
+            let worktrees = repo.worktrees().await.unwrap();
+            assert_eq!(worktrees.len(), 2);
+            assert!(
+                worktrees
+                    .iter()
+                    .any(|w| w.path == expected_dir.join("renamed-branch")),
+                "renamed worktree should exist at new path for setting {worktree_dir_setting:?}"
+            );
+            assert!(
+                worktrees
+                    .iter()
+                    .all(|w| w.path != expected_dir.join("feature-branch")),
+                "old path should no longer exist for setting {worktree_dir_setting:?}"
+            );
+
+            // Directory should be moved in FakeFs after rename
+            assert!(
+                !fs.is_dir(&expected_dir.join("feature-branch")).await,
+                "old worktree directory should not exist after rename for setting {worktree_dir_setting:?}"
+            );
+            assert!(
+                fs.is_dir(&expected_dir.join("renamed-branch")).await,
+                "new worktree directory should exist after rename for setting {worktree_dir_setting:?}"
+            );
+
+            // Rename a nonexistent worktree should fail
+            let result = repo
+                .rename_worktree(PathBuf::from("/nonexistent"), PathBuf::from("/somewhere"))
+                .await;
+            assert!(result.is_err());
+
+            // Remove a worktree
+            repo.remove_worktree(expected_dir.join("renamed-branch"), false)
+                .await
+                .unwrap();
+
+            let worktrees = repo.worktrees().await.unwrap();
+            assert_eq!(worktrees.len(), 1);
+            assert_eq!(worktrees[0].path, expected_dir.join("bugfix-branch"));
+
+            // Directory should be removed from FakeFs after remove
+            assert!(
+                !fs.is_dir(&expected_dir.join("renamed-branch")).await,
+                "worktree directory should be removed from FakeFs for setting {worktree_dir_setting:?}"
+            );
+
+            // Remove a nonexistent worktree should fail
+            let result = repo
+                .remove_worktree(PathBuf::from("/nonexistent"), false)
+                .await;
+            assert!(result.is_err());
+
+            // Remove the last worktree
+            repo.remove_worktree(expected_dir.join("bugfix-branch"), false)
+                .await
+                .unwrap();
+
+            let worktrees = repo.worktrees().await.unwrap();
+            assert!(worktrees.is_empty());
+            assert!(
+                !fs.is_dir(&expected_dir.join("bugfix-branch")).await,
+                "last worktree directory should be removed from FakeFs for setting {worktree_dir_setting:?}"
+            );
+        }
     }
 }

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -2813,30 +2813,7 @@ impl Fs for FakeFs {
 }
 
 pub fn normalize_path(path: &Path) -> PathBuf {
-    let mut components = path.components().peekable();
-    let mut ret = if let Some(c @ Component::Prefix(..)) = components.peek().cloned() {
-        components.next();
-        PathBuf::from(c.as_os_str())
-    } else {
-        PathBuf::new()
-    };
-
-    for component in components {
-        match component {
-            Component::Prefix(..) => unreachable!(),
-            Component::RootDir => {
-                ret.push(component.as_os_str());
-            }
-            Component::CurDir => {}
-            Component::ParentDir => {
-                ret.pop();
-            }
-            Component::Normal(c) => {
-                ret.push(c);
-            }
-        }
-    }
-    ret
+    util::normalize_path(path)
 }
 
 pub async fn copy_recursive<'a>(

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -33,9 +33,11 @@ use is_executable::IsExecutable;
 use rope::Rope;
 use serde::{Deserialize, Serialize};
 use smol::io::AsyncWriteExt;
+#[cfg(any(target_os = "windows", feature = "test-support"))]
+use std::path::Component;
 use std::{
     io::{self, Write},
-    path::{Component, Path, PathBuf},
+    path::{Path, PathBuf},
     pin::Pin,
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -61,13 +61,31 @@ pub const DEFAULT_WORKTREE_DIRECTORY: &str = "../worktrees";
 /// (e.g. `"../worktrees"`, `".git/zed-worktrees"`, `"my-worktrees/"`).
 /// Trailing slashes are stripped. The path is resolved relative to
 /// `working_directory` (the repository's working directory root).
+///
+/// When the resolved directory falls outside the working directory
+/// (e.g. `"../worktrees"`), the repository's directory name is
+/// automatically appended so that sibling repos don't collide.
+/// For example, with working directory `~/src/zed` and setting
+/// `"../worktrees"`, this returns `~/src/worktrees/zed`.
+///
+/// When the resolved directory is inside the working directory
+/// (e.g. `".git/zed-worktrees"`), no extra component is added
+/// because the path is already project-scoped.
 pub fn resolve_worktree_directory(
     working_directory: &Path,
     worktree_directory_setting: &str,
 ) -> PathBuf {
     let trimmed = worktree_directory_setting.trim_end_matches(['/', '\\']);
     let joined = working_directory.join(trimmed);
-    normalize_path(&joined)
+    let resolved = normalize_path(&joined);
+
+    if resolved.starts_with(working_directory) {
+        resolved
+    } else if let Some(repo_dir_name) = working_directory.file_name() {
+        resolved.join(repo_dir_name)
+    } else {
+        resolved
+    }
 }
 
 /// Validates that the resolved worktree directory is acceptable:
@@ -731,7 +749,7 @@ pub trait GitRepository: Send + Sync {
     fn create_worktree(
         &self,
         name: String,
-        worktree_directory: String,
+        directory: PathBuf,
         from_commit: Option<String>,
     ) -> BoxFuture<'_, Result<()>>;
 
@@ -1673,35 +1691,32 @@ impl GitRepository for RealGitRepository {
     fn create_worktree(
         &self,
         name: String,
-        worktree_directory: String,
+        directory: PathBuf,
         from_commit: Option<String>,
     ) -> BoxFuture<'_, Result<()>> {
         let git_binary_path = self.any_git_binary_path.clone();
         let working_directory = self.working_directory();
+        let final_path = directory.join(&name);
+        let mut args = vec![
+            OsString::from("--no-optional-locks"),
+            OsString::from("worktree"),
+            OsString::from("add"),
+            OsString::from("-b"),
+            OsString::from(name.as_str()),
+            OsString::from("--"),
+            OsString::from(final_path.as_os_str()),
+        ];
+        if let Some(from_commit) = from_commit {
+            args.push(OsString::from(from_commit));
+        } else {
+            args.push(OsString::from("HEAD"));
+        }
 
         self.executor
             .spawn(async move {
-                let working_directory = working_directory?;
-                let directory =
-                    validate_worktree_directory(&working_directory, &worktree_directory)?;
-                let final_path = directory.join(&name);
-                let mut args = vec![
-                    OsString::from("--no-optional-locks"),
-                    OsString::from("worktree"),
-                    OsString::from("add"),
-                    OsString::from("-b"),
-                    OsString::from(name.as_str()),
-                    OsString::from("--"),
-                    OsString::from(final_path.as_os_str()),
-                ];
-                if let Some(from_commit) = from_commit {
-                    args.push(OsString::from(from_commit));
-                } else {
-                    args.push(OsString::from("HEAD"));
-                }
                 std::fs::create_dir_all(&directory)?;
                 let output = new_command(&git_binary_path)
-                    .current_dir(&working_directory)
+                    .current_dir(working_directory?)
                     .args(args)
                     .output()
                     .await?;
@@ -3857,7 +3872,7 @@ mod tests {
             // Create a new worktree
             repo.create_worktree(
                 "test-branch".to_string(),
-                worktree_dir_setting.to_string(),
+                resolve_worktree_directory(repo_dir.path(), worktree_dir_setting),
                 Some("HEAD".to_string()),
             )
             .await
@@ -3921,7 +3936,7 @@ mod tests {
             // Create a worktree
             repo.create_worktree(
                 "to-remove".to_string(),
-                worktree_dir_setting.to_string(),
+                resolve_worktree_directory(repo_dir.path(), worktree_dir_setting),
                 Some("HEAD".to_string()),
             )
             .await
@@ -3986,7 +4001,7 @@ mod tests {
             // Create a worktree
             repo.create_worktree(
                 "dirty-wt".to_string(),
-                worktree_dir_setting.to_string(),
+                resolve_worktree_directory(repo_dir.path(), worktree_dir_setting),
                 Some("HEAD".to_string()),
             )
             .await
@@ -4055,7 +4070,7 @@ mod tests {
             // Create a worktree
             repo.create_worktree(
                 "old-name".to_string(),
-                worktree_dir_setting.to_string(),
+                resolve_worktree_directory(repo_dir.path(), worktree_dir_setting),
                 Some("HEAD".to_string()),
             )
             .await
@@ -4097,19 +4112,19 @@ mod tests {
     fn test_resolve_worktree_directory() {
         let work_dir = Path::new("/code/my-project");
 
-        // Sibling directory
+        // Sibling directory — outside project, so repo dir name is appended
         assert_eq!(
             resolve_worktree_directory(work_dir, "../worktrees"),
-            PathBuf::from("/code/worktrees")
+            PathBuf::from("/code/worktrees/my-project")
         );
 
-        // Git subdir
+        // Git subdir — inside project, no repo name appended
         assert_eq!(
             resolve_worktree_directory(work_dir, ".git/zed-worktrees"),
             PathBuf::from("/code/my-project/.git/zed-worktrees")
         );
 
-        // Simple subdir
+        // Simple subdir — inside project, no repo name appended
         assert_eq!(
             resolve_worktree_directory(work_dir, "my-worktrees"),
             PathBuf::from("/code/my-project/my-worktrees")
@@ -4118,7 +4133,7 @@ mod tests {
         // Trailing slash is stripped
         assert_eq!(
             resolve_worktree_directory(work_dir, "../worktrees/"),
-            PathBuf::from("/code/worktrees")
+            PathBuf::from("/code/worktrees/my-project")
         );
         assert_eq!(
             resolve_worktree_directory(work_dir, "my-worktrees/"),
@@ -4141,16 +4156,16 @@ mod tests {
             PathBuf::from("/code/my-project/foo")
         );
 
-        // Empty string resolves to the working directory itself
+        // Empty string resolves to the working directory itself (inside)
         assert_eq!(
             resolve_worktree_directory(work_dir, ""),
             PathBuf::from("/code/my-project")
         );
 
-        // Just ".." resolves to the parent directory
+        // Just ".." — outside project, repo dir name appended
         assert_eq!(
             resolve_worktree_directory(work_dir, ".."),
-            PathBuf::from("/code")
+            PathBuf::from("/code/my-project")
         );
     }
 
@@ -4192,17 +4207,19 @@ mod tests {
     fn test_worktree_path_for_branch() {
         let work_dir = Path::new("/code/my-project");
 
+        // Outside project — repo dir name is part of the resolved directory
         assert_eq!(
             worktree_path_for_branch(work_dir, "../worktrees", "feature/foo"),
-            PathBuf::from("/code/worktrees/feature/foo")
+            PathBuf::from("/code/worktrees/my-project/feature/foo")
         );
 
+        // Inside project — no repo dir name inserted
         assert_eq!(
             worktree_path_for_branch(work_dir, ".git/zed-worktrees", "my-branch"),
             PathBuf::from("/code/my-project/.git/zed-worktrees/my-branch")
         );
 
-        // Trailing slash on setting
+        // Trailing slash on setting (inside project)
         assert_eq!(
             worktree_path_for_branch(work_dir, "my-worktrees/", "branch"),
             PathBuf::from("/code/my-project/my-worktrees/branch")

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -65,8 +65,8 @@ pub const DEFAULT_WORKTREE_DIRECTORY: &str = "../worktrees";
 /// When the resolved directory falls outside the working directory
 /// (e.g. `"../worktrees"`), the repository's directory name is
 /// automatically appended so that sibling repos don't collide.
-/// For example, with working directory `~/src/zed` and setting
-/// `"../worktrees"`, this returns `~/src/worktrees/zed`.
+/// For example, with working directory `~/code/zed` and setting
+/// `"../worktrees"`, this returns `~/code/worktrees/zed`.
 ///
 /// When the resolved directory is inside the working directory
 /// (e.g. `".git/zed-worktrees"`), no extra component is added

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -21,7 +21,7 @@ use text::LineEnding;
 
 use std::collections::HashSet;
 use std::ffi::{OsStr, OsString};
-use std::path::Component;
+
 use std::process::ExitStatus;
 use std::str::FromStr;
 use std::{
@@ -35,7 +35,7 @@ use thiserror::Error;
 use util::command::{Stdio, new_command};
 use util::paths::PathStyle;
 use util::rel_path::RelPath;
-use util::{ResultExt, paths};
+use util::{ResultExt, normalize_path, paths};
 use uuid::Uuid;
 
 pub use askpass::{AskPassDelegate, AskPassResult, AskPassSession};
@@ -112,6 +112,15 @@ pub fn validate_worktree_directory(
         );
     }
 
+    if worktree_directory_setting.is_empty() {
+        anyhow::bail!("git.worktree_directory must not be empty");
+    }
+
+    let trimmed = worktree_directory_setting.trim_end_matches(['/', '\\']);
+    if trimmed == ".." {
+        anyhow::bail!("git.worktree_directory must not be \"..\" (use \"../some-name\" instead)");
+    }
+
     let resolved = resolve_worktree_directory(working_directory, worktree_directory_setting);
 
     let parent = working_directory.parent().unwrap_or(working_directory);
@@ -135,35 +144,6 @@ pub fn worktree_path_for_branch(
     branch: &str,
 ) -> PathBuf {
     resolve_worktree_directory(working_directory, worktree_directory_setting).join(branch)
-}
-
-/// Normalizes a path by resolving `.` and `..` components without
-/// requiring the path to exist on disk (unlike `canonicalize`).
-fn normalize_path(path: &Path) -> PathBuf {
-    let mut components = path.components().peekable();
-    let mut ret = if let Some(c @ Component::Prefix(..)) = components.peek().cloned() {
-        components.next();
-        PathBuf::from(c.as_os_str())
-    } else {
-        PathBuf::new()
-    };
-
-    for component in components {
-        match component {
-            Component::Prefix(..) => unreachable!(),
-            Component::RootDir => {
-                ret.push(component.as_os_str());
-            }
-            Component::CurDir => {}
-            Component::ParentDir => {
-                ret.pop();
-            }
-            Component::Normal(c) => {
-                ret.push(c);
-            }
-        }
-    }
-    ret
 }
 
 /// Commit data needed for the git graph visualization.
@@ -3896,6 +3876,13 @@ mod tests {
 
             // Clean up so the next iteration starts fresh
             repo.remove_worktree(expected_path, true).await.unwrap();
+
+            // Clean up the worktree base directory if it was created outside repo_dir
+            // (e.g. for the "../worktrees" setting, it won't be inside the TempDir)
+            let resolved_dir = resolve_worktree_directory(repo_dir.path(), worktree_dir_setting);
+            if !resolved_dir.starts_with(repo_dir.path()) {
+                let _ = std::fs::remove_dir_all(&resolved_dir);
+            }
         }
     }
 
@@ -3961,6 +3948,13 @@ mod tests {
 
             // Verify the directory is removed
             assert!(!worktree_path.exists());
+
+            // Clean up the worktree base directory if it was created outside repo_dir
+            // (e.g. for the "../worktrees" setting, it won't be inside the TempDir)
+            let resolved_dir = resolve_worktree_directory(repo_dir.path(), worktree_dir_setting);
+            if !resolved_dir.starts_with(repo_dir.path()) {
+                let _ = std::fs::remove_dir_all(&resolved_dir);
+            }
         }
     }
 
@@ -4030,6 +4024,13 @@ mod tests {
             let worktrees = repo.worktrees().await.unwrap();
             assert_eq!(worktrees.len(), 1);
             assert!(!worktree_path.exists());
+
+            // Clean up the worktree base directory if it was created outside repo_dir
+            // (e.g. for the "../worktrees" setting, it won't be inside the TempDir)
+            let resolved_dir = resolve_worktree_directory(repo_dir.path(), worktree_dir_setting);
+            if !resolved_dir.starts_with(repo_dir.path()) {
+                let _ = std::fs::remove_dir_all(&resolved_dir);
+            }
         }
     }
 
@@ -4105,6 +4106,13 @@ mod tests {
 
             // Clean up so the next iteration starts fresh
             repo.remove_worktree(new_path, true).await.unwrap();
+
+            // Clean up the worktree base directory if it was created outside repo_dir
+            // (e.g. for the "../worktrees" setting, it won't be inside the TempDir)
+            let resolved_dir = resolve_worktree_directory(repo_dir.path(), worktree_dir_setting);
+            if !resolved_dir.starts_with(repo_dir.path()) {
+                let _ = std::fs::remove_dir_all(&resolved_dir);
+            }
         }
     }
 
@@ -4180,11 +4188,19 @@ mod tests {
         assert!(validate_worktree_directory(work_dir, ".git/zed-worktrees").is_ok());
         assert!(validate_worktree_directory(work_dir, "my-worktrees").is_ok());
 
-        // Valid: just ".." resolves to parent dir itself
-        assert!(validate_worktree_directory(work_dir, "..").is_ok());
+        // Invalid: just ".." would resolve back to the working directory itself
+        let err = validate_worktree_directory(work_dir, "..").unwrap_err();
+        assert!(err.to_string().contains("must not be \"..\""));
 
-        // Valid: empty string resolves to working directory (under parent)
-        assert!(validate_worktree_directory(work_dir, "").is_ok());
+        // Invalid: ".." with trailing separators
+        let err = validate_worktree_directory(work_dir, "..\\").unwrap_err();
+        assert!(err.to_string().contains("must not be \"..\""));
+        let err = validate_worktree_directory(work_dir, "../").unwrap_err();
+        assert!(err.to_string().contains("must not be \"..\""));
+
+        // Invalid: empty string would resolve to the working directory itself
+        let err = validate_worktree_directory(work_dir, "").unwrap_err();
+        assert!(err.to_string().contains("must not be empty"));
 
         // Invalid: absolute path
         let err = validate_worktree_directory(work_dir, "/tmp/worktrees").unwrap_err();

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -21,6 +21,7 @@ use text::LineEnding;
 
 use std::collections::HashSet;
 use std::ffi::{OsStr, OsString};
+use std::path::Component;
 use std::process::ExitStatus;
 use std::str::FromStr;
 use std::{
@@ -50,6 +51,102 @@ static GRAPH_COMMIT_FORMAT: &str = "--format=%H%x00%P%x00%D";
 
 /// Number of commits to load per chunk for the git graph.
 pub const GRAPH_CHUNK_SIZE: usize = 1000;
+
+/// Default value for the `git.worktree_directory` setting.
+pub const DEFAULT_WORKTREE_DIRECTORY: &str = "../worktrees";
+
+/// Resolves the configured worktree directory to an absolute path.
+///
+/// `worktree_directory_setting` is the raw string from the user setting
+/// (e.g. `"../worktrees"`, `".git/zed-worktrees"`, `"my-worktrees/"`).
+/// Trailing slashes are stripped. The path is resolved relative to
+/// `working_directory` (the repository's working directory root).
+pub fn resolve_worktree_directory(
+    working_directory: &Path,
+    worktree_directory_setting: &str,
+) -> PathBuf {
+    let trimmed = worktree_directory_setting.trim_end_matches(['/', '\\']);
+    let joined = working_directory.join(trimmed);
+    normalize_path(&joined)
+}
+
+/// Validates that the resolved worktree directory is acceptable:
+/// - The setting must not be an absolute path.
+/// - The resolved path must be either a subdirectory of the working
+///   directory or a subdirectory of its parent (i.e., a sibling).
+///
+/// Returns `Ok(resolved_path)` or an error with a user-facing message.
+pub fn validate_worktree_directory(
+    working_directory: &Path,
+    worktree_directory_setting: &str,
+) -> Result<PathBuf> {
+    // Check the original setting before trimming, since a path like "///"
+    // is absolute but becomes "" after stripping trailing separators.
+    // Also check for leading `/` or `\` explicitly, because on Windows
+    // `Path::is_absolute()` requires a drive letter — so `/tmp/worktrees`
+    // would slip through even though it's clearly not a relative path.
+    if Path::new(worktree_directory_setting).is_absolute()
+        || worktree_directory_setting.starts_with('/')
+        || worktree_directory_setting.starts_with('\\')
+    {
+        anyhow::bail!(
+            "git.worktree_directory must be a relative path, got: {worktree_directory_setting:?}"
+        );
+    }
+
+    let resolved = resolve_worktree_directory(working_directory, worktree_directory_setting);
+
+    let parent = working_directory.parent().unwrap_or(working_directory);
+
+    if !resolved.starts_with(parent) {
+        anyhow::bail!(
+            "git.worktree_directory resolved to {resolved:?}, which is outside \
+             the project root and its parent directory. It must resolve to a \
+             subdirectory of {working_directory:?} or a sibling of it."
+        );
+    }
+
+    Ok(resolved)
+}
+
+/// Returns the full absolute path for a specific branch's worktree
+/// given the resolved worktree directory.
+pub fn worktree_path_for_branch(
+    working_directory: &Path,
+    worktree_directory_setting: &str,
+    branch: &str,
+) -> PathBuf {
+    resolve_worktree_directory(working_directory, worktree_directory_setting).join(branch)
+}
+
+/// Normalizes a path by resolving `.` and `..` components without
+/// requiring the path to exist on disk (unlike `canonicalize`).
+fn normalize_path(path: &Path) -> PathBuf {
+    let mut components = path.components().peekable();
+    let mut ret = if let Some(c @ Component::Prefix(..)) = components.peek().cloned() {
+        components.next();
+        PathBuf::from(c.as_os_str())
+    } else {
+        PathBuf::new()
+    };
+
+    for component in components {
+        match component {
+            Component::Prefix(..) => unreachable!(),
+            Component::RootDir => {
+                ret.push(component.as_os_str());
+            }
+            Component::CurDir => {}
+            Component::ParentDir => {
+                ret.pop();
+            }
+            Component::Normal(c) => {
+                ret.push(c);
+            }
+        }
+    }
+    ret
+}
 
 /// Commit data needed for the git graph visualization.
 #[derive(Debug, Clone)]
@@ -634,7 +731,7 @@ pub trait GitRepository: Send + Sync {
     fn create_worktree(
         &self,
         name: String,
-        directory: PathBuf,
+        worktree_directory: String,
         from_commit: Option<String>,
     ) -> BoxFuture<'_, Result<()>>;
 
@@ -1576,30 +1673,35 @@ impl GitRepository for RealGitRepository {
     fn create_worktree(
         &self,
         name: String,
-        directory: PathBuf,
+        worktree_directory: String,
         from_commit: Option<String>,
     ) -> BoxFuture<'_, Result<()>> {
         let git_binary_path = self.any_git_binary_path.clone();
         let working_directory = self.working_directory();
-        let final_path = directory.join(&name);
-        let mut args = vec![
-            OsString::from("--no-optional-locks"),
-            OsString::from("worktree"),
-            OsString::from("add"),
-            OsString::from("-b"),
-            OsString::from(name.as_str()),
-            OsString::from("--"),
-            OsString::from(final_path.as_os_str()),
-        ];
-        if let Some(from_commit) = from_commit {
-            args.push(OsString::from(from_commit));
-        } else {
-            args.push(OsString::from("HEAD"));
-        }
+
         self.executor
             .spawn(async move {
+                let working_directory = working_directory?;
+                let directory =
+                    validate_worktree_directory(&working_directory, &worktree_directory)?;
+                let final_path = directory.join(&name);
+                let mut args = vec![
+                    OsString::from("--no-optional-locks"),
+                    OsString::from("worktree"),
+                    OsString::from("add"),
+                    OsString::from("-b"),
+                    OsString::from(name.as_str()),
+                    OsString::from("--"),
+                    OsString::from(final_path.as_os_str()),
+                ];
+                if let Some(from_commit) = from_commit {
+                    args.push(OsString::from(from_commit));
+                } else {
+                    args.push(OsString::from("HEAD"));
+                }
+                std::fs::create_dir_all(&directory)?;
                 let output = new_command(&git_binary_path)
-                    .current_dir(working_directory?)
+                    .current_dir(&working_directory)
                     .args(args)
                     .output()
                     .await?;
@@ -3707,73 +3809,79 @@ mod tests {
         assert_eq!(result[0].ref_name.as_ref(), "refs/heads/main");
     }
 
+    const TEST_WORKTREE_DIRECTORIES: &[&str] =
+        &["../worktrees", ".git/zed-worktrees", "my-worktrees/"];
+
     #[gpui::test]
     async fn test_create_and_list_worktrees(cx: &mut TestAppContext) {
         disable_git_global_config();
         cx.executor().allow_parking();
 
-        let repo_dir = tempfile::tempdir().unwrap();
-        git2::Repository::init(repo_dir.path()).unwrap();
+        for worktree_dir_setting in TEST_WORKTREE_DIRECTORIES {
+            let repo_dir = tempfile::tempdir().unwrap();
+            git2::Repository::init(repo_dir.path()).unwrap();
 
-        let repo = RealGitRepository::new(
-            &repo_dir.path().join(".git"),
-            None,
-            Some("git".into()),
-            cx.executor(),
-        )
-        .unwrap();
+            let repo = RealGitRepository::new(
+                &repo_dir.path().join(".git"),
+                None,
+                Some("git".into()),
+                cx.executor(),
+            )
+            .unwrap();
 
-        // Create an initial commit (required for worktrees)
-        smol::fs::write(repo_dir.path().join("file.txt"), "content")
+            // Create an initial commit (required for worktrees)
+            smol::fs::write(repo_dir.path().join("file.txt"), "content")
+                .await
+                .unwrap();
+            repo.stage_paths(vec![repo_path("file.txt")], Arc::new(HashMap::default()))
+                .await
+                .unwrap();
+            repo.commit(
+                "Initial commit".into(),
+                None,
+                CommitOptions::default(),
+                AskPassDelegate::new(&mut cx.to_async(), |_, _, _| {}),
+                Arc::new(checkpoint_author_envs()),
+            )
             .await
             .unwrap();
-        repo.stage_paths(vec![repo_path("file.txt")], Arc::new(HashMap::default()))
+
+            // List worktrees — should have just the main one
+            let worktrees = repo.worktrees().await.unwrap();
+            assert_eq!(worktrees.len(), 1);
+            assert_eq!(
+                worktrees[0].path.canonicalize().unwrap(),
+                repo_dir.path().canonicalize().unwrap()
+            );
+
+            // Create a new worktree
+            repo.create_worktree(
+                "test-branch".to_string(),
+                worktree_dir_setting.to_string(),
+                Some("HEAD".to_string()),
+            )
             .await
             .unwrap();
-        repo.commit(
-            "Initial commit".into(),
-            None,
-            CommitOptions::default(),
-            AskPassDelegate::new(&mut cx.to_async(), |_, _, _| {}),
-            Arc::new(checkpoint_author_envs()),
-        )
-        .await
-        .unwrap();
 
-        // List worktrees — should have just the main one
-        let worktrees = repo.worktrees().await.unwrap();
-        assert_eq!(worktrees.len(), 1);
-        assert_eq!(
-            worktrees[0].path.canonicalize().unwrap(),
-            repo_dir.path().canonicalize().unwrap()
-        );
+            // List worktrees — should have two
+            let worktrees = repo.worktrees().await.unwrap();
+            assert_eq!(worktrees.len(), 2);
 
-        // Create a new worktree
-        let worktree_dir = tempfile::tempdir().unwrap();
-        repo.create_worktree(
-            "test-branch".to_string(),
-            worktree_dir.path().to_path_buf(),
-            Some("HEAD".to_string()),
-        )
-        .await
-        .unwrap();
+            let expected_path =
+                worktree_path_for_branch(repo_dir.path(), worktree_dir_setting, "test-branch");
+            let new_worktree = worktrees
+                .iter()
+                .find(|w| w.branch() == "test-branch")
+                .expect("should find worktree with test-branch");
+            assert_eq!(
+                new_worktree.path.canonicalize().unwrap(),
+                expected_path.canonicalize().unwrap(),
+                "failed for worktree_directory setting: {worktree_dir_setting:?}"
+            );
 
-        // List worktrees — should have two
-        let worktrees = repo.worktrees().await.unwrap();
-        assert_eq!(worktrees.len(), 2);
-
-        let new_worktree = worktrees
-            .iter()
-            .find(|w| w.branch() == "test-branch")
-            .expect("should find worktree with test-branch");
-        assert_eq!(
-            new_worktree.path.canonicalize().unwrap(),
-            worktree_dir
-                .path()
-                .join("test-branch")
-                .canonicalize()
-                .unwrap()
-        );
+            // Clean up so the next iteration starts fresh
+            repo.remove_worktree(expected_path, true).await.unwrap();
+        }
     }
 
     #[gpui::test]
@@ -3781,62 +3889,64 @@ mod tests {
         disable_git_global_config();
         cx.executor().allow_parking();
 
-        let repo_dir = tempfile::tempdir().unwrap();
-        git2::Repository::init(repo_dir.path()).unwrap();
+        for worktree_dir_setting in TEST_WORKTREE_DIRECTORIES {
+            let repo_dir = tempfile::tempdir().unwrap();
+            git2::Repository::init(repo_dir.path()).unwrap();
 
-        let repo = RealGitRepository::new(
-            &repo_dir.path().join(".git"),
-            None,
-            Some("git".into()),
-            cx.executor(),
-        )
-        .unwrap();
-
-        // Create an initial commit
-        smol::fs::write(repo_dir.path().join("file.txt"), "content")
-            .await
+            let repo = RealGitRepository::new(
+                &repo_dir.path().join(".git"),
+                None,
+                Some("git".into()),
+                cx.executor(),
+            )
             .unwrap();
-        repo.stage_paths(vec![repo_path("file.txt")], Arc::new(HashMap::default()))
-            .await
-            .unwrap();
-        repo.commit(
-            "Initial commit".into(),
-            None,
-            CommitOptions::default(),
-            AskPassDelegate::new(&mut cx.to_async(), |_, _, _| {}),
-            Arc::new(checkpoint_author_envs()),
-        )
-        .await
-        .unwrap();
 
-        // Create a worktree
-        let worktree_dir = tempfile::tempdir().unwrap();
-        repo.create_worktree(
-            "to-remove".to_string(),
-            worktree_dir.path().to_path_buf(),
-            Some("HEAD".to_string()),
-        )
-        .await
-        .unwrap();
-
-        let worktree_path = worktree_dir.path().join("to-remove");
-        assert!(worktree_path.exists());
-
-        // Remove the worktree
-        repo.remove_worktree(worktree_path.clone(), false)
+            // Create an initial commit
+            smol::fs::write(repo_dir.path().join("file.txt"), "content")
+                .await
+                .unwrap();
+            repo.stage_paths(vec![repo_path("file.txt")], Arc::new(HashMap::default()))
+                .await
+                .unwrap();
+            repo.commit(
+                "Initial commit".into(),
+                None,
+                CommitOptions::default(),
+                AskPassDelegate::new(&mut cx.to_async(), |_, _, _| {}),
+                Arc::new(checkpoint_author_envs()),
+            )
             .await
             .unwrap();
 
-        // Verify it's gone from the list
-        let worktrees = repo.worktrees().await.unwrap();
-        assert_eq!(worktrees.len(), 1);
-        assert!(
-            worktrees.iter().all(|w| w.branch() != "to-remove"),
-            "removed worktree should not appear in list"
-        );
+            // Create a worktree
+            repo.create_worktree(
+                "to-remove".to_string(),
+                worktree_dir_setting.to_string(),
+                Some("HEAD".to_string()),
+            )
+            .await
+            .unwrap();
 
-        // Verify the directory is removed
-        assert!(!worktree_path.exists());
+            let worktree_path =
+                worktree_path_for_branch(repo_dir.path(), worktree_dir_setting, "to-remove");
+            assert!(worktree_path.exists());
+
+            // Remove the worktree
+            repo.remove_worktree(worktree_path.clone(), false)
+                .await
+                .unwrap();
+
+            // Verify it's gone from the list
+            let worktrees = repo.worktrees().await.unwrap();
+            assert_eq!(worktrees.len(), 1);
+            assert!(
+                worktrees.iter().all(|w| w.branch() != "to-remove"),
+                "removed worktree should not appear in list"
+            );
+
+            // Verify the directory is removed
+            assert!(!worktree_path.exists());
+        }
     }
 
     #[gpui::test]
@@ -3844,66 +3954,68 @@ mod tests {
         disable_git_global_config();
         cx.executor().allow_parking();
 
-        let repo_dir = tempfile::tempdir().unwrap();
-        git2::Repository::init(repo_dir.path()).unwrap();
+        for worktree_dir_setting in TEST_WORKTREE_DIRECTORIES {
+            let repo_dir = tempfile::tempdir().unwrap();
+            git2::Repository::init(repo_dir.path()).unwrap();
 
-        let repo = RealGitRepository::new(
-            &repo_dir.path().join(".git"),
-            None,
-            Some("git".into()),
-            cx.executor(),
-        )
-        .unwrap();
-
-        // Create an initial commit
-        smol::fs::write(repo_dir.path().join("file.txt"), "content")
-            .await
+            let repo = RealGitRepository::new(
+                &repo_dir.path().join(".git"),
+                None,
+                Some("git".into()),
+                cx.executor(),
+            )
             .unwrap();
-        repo.stage_paths(vec![repo_path("file.txt")], Arc::new(HashMap::default()))
-            .await
-            .unwrap();
-        repo.commit(
-            "Initial commit".into(),
-            None,
-            CommitOptions::default(),
-            AskPassDelegate::new(&mut cx.to_async(), |_, _, _| {}),
-            Arc::new(checkpoint_author_envs()),
-        )
-        .await
-        .unwrap();
 
-        // Create a worktree
-        let worktree_dir = tempfile::tempdir().unwrap();
-        repo.create_worktree(
-            "dirty-wt".to_string(),
-            worktree_dir.path().to_path_buf(),
-            Some("HEAD".to_string()),
-        )
-        .await
-        .unwrap();
-
-        let worktree_path = worktree_dir.path().join("dirty-wt");
-
-        // Add uncommitted changes in the worktree
-        smol::fs::write(worktree_path.join("dirty-file.txt"), "uncommitted")
+            // Create an initial commit
+            smol::fs::write(repo_dir.path().join("file.txt"), "content")
+                .await
+                .unwrap();
+            repo.stage_paths(vec![repo_path("file.txt")], Arc::new(HashMap::default()))
+                .await
+                .unwrap();
+            repo.commit(
+                "Initial commit".into(),
+                None,
+                CommitOptions::default(),
+                AskPassDelegate::new(&mut cx.to_async(), |_, _, _| {}),
+                Arc::new(checkpoint_author_envs()),
+            )
             .await
             .unwrap();
 
-        // Non-force removal should fail with dirty worktree
-        let result = repo.remove_worktree(worktree_path.clone(), false).await;
-        assert!(
-            result.is_err(),
-            "non-force removal of dirty worktree should fail"
-        );
-
-        // Force removal should succeed
-        repo.remove_worktree(worktree_path.clone(), true)
+            // Create a worktree
+            repo.create_worktree(
+                "dirty-wt".to_string(),
+                worktree_dir_setting.to_string(),
+                Some("HEAD".to_string()),
+            )
             .await
             .unwrap();
 
-        let worktrees = repo.worktrees().await.unwrap();
-        assert_eq!(worktrees.len(), 1);
-        assert!(!worktree_path.exists());
+            let worktree_path =
+                worktree_path_for_branch(repo_dir.path(), worktree_dir_setting, "dirty-wt");
+
+            // Add uncommitted changes in the worktree
+            smol::fs::write(worktree_path.join("dirty-file.txt"), "uncommitted")
+                .await
+                .unwrap();
+
+            // Non-force removal should fail with dirty worktree
+            let result = repo.remove_worktree(worktree_path.clone(), false).await;
+            assert!(
+                result.is_err(),
+                "non-force removal of dirty worktree should fail"
+            );
+
+            // Force removal should succeed
+            repo.remove_worktree(worktree_path.clone(), true)
+                .await
+                .unwrap();
+
+            let worktrees = repo.worktrees().await.unwrap();
+            assert_eq!(worktrees.len(), 1);
+            assert!(!worktree_path.exists());
+        }
     }
 
     #[gpui::test]
@@ -3911,67 +4023,189 @@ mod tests {
         disable_git_global_config();
         cx.executor().allow_parking();
 
-        let repo_dir = tempfile::tempdir().unwrap();
-        git2::Repository::init(repo_dir.path()).unwrap();
+        for worktree_dir_setting in TEST_WORKTREE_DIRECTORIES {
+            let repo_dir = tempfile::tempdir().unwrap();
+            git2::Repository::init(repo_dir.path()).unwrap();
 
-        let repo = RealGitRepository::new(
-            &repo_dir.path().join(".git"),
-            None,
-            Some("git".into()),
-            cx.executor(),
-        )
-        .unwrap();
-
-        // Create an initial commit
-        smol::fs::write(repo_dir.path().join("file.txt"), "content")
-            .await
+            let repo = RealGitRepository::new(
+                &repo_dir.path().join(".git"),
+                None,
+                Some("git".into()),
+                cx.executor(),
+            )
             .unwrap();
-        repo.stage_paths(vec![repo_path("file.txt")], Arc::new(HashMap::default()))
-            .await
-            .unwrap();
-        repo.commit(
-            "Initial commit".into(),
-            None,
-            CommitOptions::default(),
-            AskPassDelegate::new(&mut cx.to_async(), |_, _, _| {}),
-            Arc::new(checkpoint_author_envs()),
-        )
-        .await
-        .unwrap();
 
-        // Create a worktree
-        let worktree_dir = tempfile::tempdir().unwrap();
-        repo.create_worktree(
-            "old-name".to_string(),
-            worktree_dir.path().to_path_buf(),
-            Some("HEAD".to_string()),
-        )
-        .await
-        .unwrap();
-
-        let old_path = worktree_dir.path().join("old-name");
-        assert!(old_path.exists());
-
-        // Move the worktree to a new path
-        let new_path = worktree_dir.path().join("new-name");
-        repo.rename_worktree(old_path.clone(), new_path.clone())
+            // Create an initial commit
+            smol::fs::write(repo_dir.path().join("file.txt"), "content")
+                .await
+                .unwrap();
+            repo.stage_paths(vec![repo_path("file.txt")], Arc::new(HashMap::default()))
+                .await
+                .unwrap();
+            repo.commit(
+                "Initial commit".into(),
+                None,
+                CommitOptions::default(),
+                AskPassDelegate::new(&mut cx.to_async(), |_, _, _| {}),
+                Arc::new(checkpoint_author_envs()),
+            )
             .await
             .unwrap();
 
-        // Verify the old path is gone and new path exists
-        assert!(!old_path.exists());
-        assert!(new_path.exists());
+            // Create a worktree
+            repo.create_worktree(
+                "old-name".to_string(),
+                worktree_dir_setting.to_string(),
+                Some("HEAD".to_string()),
+            )
+            .await
+            .unwrap();
 
-        // Verify it shows up in worktree list at the new path
-        let worktrees = repo.worktrees().await.unwrap();
-        assert_eq!(worktrees.len(), 2);
-        let moved_worktree = worktrees
-            .iter()
-            .find(|w| w.branch() == "old-name")
-            .expect("should find worktree by branch name");
+            let old_path =
+                worktree_path_for_branch(repo_dir.path(), worktree_dir_setting, "old-name");
+            assert!(old_path.exists());
+
+            // Move the worktree to a new path
+            let new_path =
+                resolve_worktree_directory(repo_dir.path(), worktree_dir_setting).join("new-name");
+            repo.rename_worktree(old_path.clone(), new_path.clone())
+                .await
+                .unwrap();
+
+            // Verify the old path is gone and new path exists
+            assert!(!old_path.exists());
+            assert!(new_path.exists());
+
+            // Verify it shows up in worktree list at the new path
+            let worktrees = repo.worktrees().await.unwrap();
+            assert_eq!(worktrees.len(), 2);
+            let moved_worktree = worktrees
+                .iter()
+                .find(|w| w.branch() == "old-name")
+                .expect("should find worktree by branch name");
+            assert_eq!(
+                moved_worktree.path.canonicalize().unwrap(),
+                new_path.canonicalize().unwrap()
+            );
+
+            // Clean up so the next iteration starts fresh
+            repo.remove_worktree(new_path, true).await.unwrap();
+        }
+    }
+
+    #[test]
+    fn test_resolve_worktree_directory() {
+        let work_dir = Path::new("/code/my-project");
+
+        // Sibling directory
         assert_eq!(
-            moved_worktree.path.canonicalize().unwrap(),
-            new_path.canonicalize().unwrap()
+            resolve_worktree_directory(work_dir, "../worktrees"),
+            PathBuf::from("/code/worktrees")
+        );
+
+        // Git subdir
+        assert_eq!(
+            resolve_worktree_directory(work_dir, ".git/zed-worktrees"),
+            PathBuf::from("/code/my-project/.git/zed-worktrees")
+        );
+
+        // Simple subdir
+        assert_eq!(
+            resolve_worktree_directory(work_dir, "my-worktrees"),
+            PathBuf::from("/code/my-project/my-worktrees")
+        );
+
+        // Trailing slash is stripped
+        assert_eq!(
+            resolve_worktree_directory(work_dir, "../worktrees/"),
+            PathBuf::from("/code/worktrees")
+        );
+        assert_eq!(
+            resolve_worktree_directory(work_dir, "my-worktrees/"),
+            PathBuf::from("/code/my-project/my-worktrees")
+        );
+
+        // Multiple trailing slashes
+        assert_eq!(
+            resolve_worktree_directory(work_dir, "foo///"),
+            PathBuf::from("/code/my-project/foo")
+        );
+
+        // Trailing backslashes (Windows-style)
+        assert_eq!(
+            resolve_worktree_directory(work_dir, "my-worktrees\\"),
+            PathBuf::from("/code/my-project/my-worktrees")
+        );
+        assert_eq!(
+            resolve_worktree_directory(work_dir, "foo\\/\\"),
+            PathBuf::from("/code/my-project/foo")
+        );
+
+        // Empty string resolves to the working directory itself
+        assert_eq!(
+            resolve_worktree_directory(work_dir, ""),
+            PathBuf::from("/code/my-project")
+        );
+
+        // Just ".." resolves to the parent directory
+        assert_eq!(
+            resolve_worktree_directory(work_dir, ".."),
+            PathBuf::from("/code")
+        );
+    }
+
+    #[test]
+    fn test_validate_worktree_directory() {
+        let work_dir = Path::new("/code/my-project");
+
+        // Valid: sibling
+        assert!(validate_worktree_directory(work_dir, "../worktrees").is_ok());
+
+        // Valid: subdirectory
+        assert!(validate_worktree_directory(work_dir, ".git/zed-worktrees").is_ok());
+        assert!(validate_worktree_directory(work_dir, "my-worktrees").is_ok());
+
+        // Valid: just ".." resolves to parent dir itself
+        assert!(validate_worktree_directory(work_dir, "..").is_ok());
+
+        // Valid: empty string resolves to working directory (under parent)
+        assert!(validate_worktree_directory(work_dir, "").is_ok());
+
+        // Invalid: absolute path
+        let err = validate_worktree_directory(work_dir, "/tmp/worktrees").unwrap_err();
+        assert!(err.to_string().contains("relative path"));
+
+        // Invalid: "/" is absolute on Unix
+        let err = validate_worktree_directory(work_dir, "/").unwrap_err();
+        assert!(err.to_string().contains("relative path"));
+
+        // Invalid: "///" is absolute
+        let err = validate_worktree_directory(work_dir, "///").unwrap_err();
+        assert!(err.to_string().contains("relative path"));
+
+        // Invalid: escapes too far up
+        let err = validate_worktree_directory(work_dir, "../../other-project/wt").unwrap_err();
+        assert!(err.to_string().contains("outside"));
+    }
+
+    #[test]
+    fn test_worktree_path_for_branch() {
+        let work_dir = Path::new("/code/my-project");
+
+        assert_eq!(
+            worktree_path_for_branch(work_dir, "../worktrees", "feature/foo"),
+            PathBuf::from("/code/worktrees/feature/foo")
+        );
+
+        assert_eq!(
+            worktree_path_for_branch(work_dir, ".git/zed-worktrees", "my-branch"),
+            PathBuf::from("/code/my-project/.git/zed-worktrees/my-branch")
+        );
+
+        // Trailing slash on setting
+        assert_eq!(
+            worktree_path_for_branch(work_dir, "my-worktrees/", "branch"),
+            PathBuf::from("/code/my-project/my-worktrees/branch")
         );
     }
 

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -1714,7 +1714,7 @@ impl GitRepository for RealGitRepository {
 
         self.executor
             .spawn(async move {
-                std::fs::create_dir_all(&directory)?;
+                std::fs::create_dir_all(final_path.parent().unwrap_or(&final_path))?;
                 let output = new_command(&git_binary_path)
                     .current_dir(working_directory?)
                     .args(args)

--- a/crates/git_ui/src/worktree_picker.rs
+++ b/crates/git_ui/src/worktree_picker.rs
@@ -2,7 +2,7 @@ use anyhow::Context as _;
 use collections::HashSet;
 use fuzzy::StringMatchCandidate;
 
-use git::repository::{Worktree as GitWorktree, worktree_path_for_branch};
+use git::repository::{Worktree as GitWorktree, validate_worktree_directory};
 use gpui::{
     Action, App, AsyncWindowContext, Context, DismissEvent, Entity, EventEmitter, FocusHandle,
     Focusable, InteractiveElement, IntoElement, Modifiers, ModifiersChangedEvent, ParentElement,
@@ -271,15 +271,16 @@ impl WorktreeListDelegate {
         let workspace = self.workspace.clone();
         cx.spawn_in(window, async move |_, cx| {
             let (receiver, new_worktree_path) = repo.update(cx, |repo, cx| {
-                let worktree_directory = ProjectSettings::get_global(cx)
+                let worktree_directory_setting = ProjectSettings::get_global(cx)
                     .git
                     .worktree_directory
                     .clone();
                 let work_dir = repo.work_directory_abs_path.clone();
-                let receiver =
-                    repo.create_worktree(branch.clone(), worktree_directory.clone(), commit);
-                let path = worktree_path_for_branch(&work_dir, &worktree_directory, &branch);
-                anyhow::Ok((receiver, path))
+                let directory =
+                    validate_worktree_directory(&work_dir, &worktree_directory_setting)?;
+                let new_worktree_path = directory.join(&branch);
+                let receiver = repo.create_worktree(branch.clone(), directory, commit);
+                anyhow::Ok((receiver, new_worktree_path))
             })?;
             receiver.await??;
 

--- a/crates/git_ui/src/worktree_picker.rs
+++ b/crates/git_ui/src/worktree_picker.rs
@@ -346,7 +346,12 @@ impl WorktreeListDelegate {
             anyhow::Ok(())
         })
         .detach_and_prompt_err("Failed to create worktree", window, cx, |e, _, _| {
-            Some(e.to_string())
+            let msg = e.to_string();
+            if msg.contains("git.worktree_directory") {
+                Some(format!("Invalid git.worktree_directory setting: {}", e))
+            } else {
+                Some(msg)
+            }
         });
     }
 

--- a/crates/git_ui/src/worktree_picker.rs
+++ b/crates/git_ui/src/worktree_picker.rs
@@ -2,21 +2,21 @@ use anyhow::Context as _;
 use collections::HashSet;
 use fuzzy::StringMatchCandidate;
 
-use git::repository::Worktree as GitWorktree;
+use git::repository::{Worktree as GitWorktree, worktree_path_for_branch};
 use gpui::{
     Action, App, AsyncWindowContext, Context, DismissEvent, Entity, EventEmitter, FocusHandle,
     Focusable, InteractiveElement, IntoElement, Modifiers, ModifiersChangedEvent, ParentElement,
-    PathPromptOptions, Render, SharedString, Styled, Subscription, Task, WeakEntity, Window,
-    actions, rems,
+    Render, SharedString, Styled, Subscription, Task, WeakEntity, Window, actions, rems,
 };
 use picker::{Picker, PickerDelegate, PickerEditorPosition};
+use project::project_settings::ProjectSettings;
 use project::{
-    DirectoryLister,
     git_store::Repository,
     trusted_worktrees::{PathTrust, TrustedWorktrees},
 };
 use remote::{RemoteConnectionOptions, remote_client::ConnectionIdentifier};
 use remote_connection::{RemoteConnectionModal, connect};
+use settings::Settings;
 use std::{path::PathBuf, sync::Arc};
 use ui::{HighlightedLabel, KeyBinding, ListItem, ListItemSpacing, prelude::*};
 use util::ResultExt;
@@ -267,40 +267,21 @@ impl WorktreeListDelegate {
             return;
         };
 
-        let worktree_path = self
-            .workspace
-            .clone()
-            .update(cx, |this, cx| {
-                this.prompt_for_open_path(
-                    PathPromptOptions {
-                        files: false,
-                        directories: true,
-                        multiple: false,
-                        prompt: Some("Select directory for new worktree".into()),
-                    },
-                    DirectoryLister::Project(this.project().clone()),
-                    window,
-                    cx,
-                )
-            })
-            .log_err();
-        let Some(worktree_path) = worktree_path else {
-            return;
-        };
-
         let branch = worktree_branch.to_string();
         let workspace = self.workspace.clone();
         cx.spawn_in(window, async move |_, cx| {
-            let Some(paths) = worktree_path.await? else {
-                return anyhow::Ok(());
-            };
-            let path = paths.get(0).cloned().context("No path selected")?;
-
-            repo.update(cx, |repo, _| {
-                repo.create_worktree(branch.clone(), path.clone(), commit)
-            })
-            .await??;
-            let new_worktree_path = path.join(branch);
+            let (receiver, new_worktree_path) = repo.update(cx, |repo, cx| {
+                let worktree_directory = ProjectSettings::get_global(cx)
+                    .git
+                    .worktree_directory
+                    .clone();
+                let work_dir = repo.work_directory_abs_path.clone();
+                let receiver =
+                    repo.create_worktree(branch.clone(), worktree_directory.clone(), commit);
+                let path = worktree_path_for_branch(&work_dir, &worktree_directory, &branch);
+                anyhow::Ok((receiver, path))
+            })?;
+            receiver.await??;
 
             workspace.update(cx, |workspace, cx| {
                 if let Some(trusted_worktrees) = TrustedWorktrees::try_get_global(cx) {

--- a/crates/outline_panel/src/outline_panel_settings.rs
+++ b/crates/outline_panel/src/outline_panel_settings.rs
@@ -53,6 +53,7 @@ impl Settings for OutlinePanelSettings {
             git_status: panel.git_status.unwrap()
                 && content
                     .git
+                    .as_ref()
                     .unwrap()
                     .enabled
                     .unwrap()

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -2285,13 +2285,13 @@ impl GitStore {
     ) -> Result<proto::Ack> {
         let repository_id = RepositoryId::from_proto(envelope.payload.repository_id);
         let repository_handle = Self::repository_for_request(&this, repository_id, &mut cx)?;
+        let directory = PathBuf::from(envelope.payload.directory);
         let name = envelope.payload.name;
-        let worktree_directory = envelope.payload.directory;
         let commit = envelope.payload.commit;
 
         repository_handle
             .update(&mut cx, |repository_handle, _| {
-                repository_handle.create_worktree(name, worktree_directory, commit)
+                repository_handle.create_worktree(name, directory, commit)
             })
             .await??;
 
@@ -5532,7 +5532,7 @@ impl Repository {
     pub fn create_worktree(
         &mut self,
         name: String,
-        worktree_directory: String,
+        directory: PathBuf,
         commit: Option<String>,
     ) -> oneshot::Receiver<Result<()>> {
         let id = self.id;
@@ -5541,9 +5541,7 @@ impl Repository {
             move |repo, _cx| async move {
                 match repo {
                     RepositoryState::Local(LocalRepositoryState { backend, .. }) => {
-                        backend
-                            .create_worktree(name, worktree_directory.clone(), commit)
-                            .await
+                        backend.create_worktree(name, directory, commit).await
                     }
                     RepositoryState::Remote(RemoteRepositoryState { project_id, client }) => {
                         client
@@ -5551,7 +5549,7 @@ impl Repository {
                                 project_id: project_id.0,
                                 repository_id: id.to_proto(),
                                 name,
-                                directory: worktree_directory,
+                                directory: directory.to_string_lossy().to_string(),
                                 commit,
                             })
                             .await?;

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -2285,13 +2285,13 @@ impl GitStore {
     ) -> Result<proto::Ack> {
         let repository_id = RepositoryId::from_proto(envelope.payload.repository_id);
         let repository_handle = Self::repository_for_request(&this, repository_id, &mut cx)?;
-        let directory = PathBuf::from(envelope.payload.directory);
         let name = envelope.payload.name;
+        let worktree_directory = envelope.payload.directory;
         let commit = envelope.payload.commit;
 
         repository_handle
             .update(&mut cx, |repository_handle, _| {
-                repository_handle.create_worktree(name, directory, commit)
+                repository_handle.create_worktree(name, worktree_directory, commit)
             })
             .await??;
 
@@ -5532,7 +5532,7 @@ impl Repository {
     pub fn create_worktree(
         &mut self,
         name: String,
-        path: PathBuf,
+        worktree_directory: String,
         commit: Option<String>,
     ) -> oneshot::Receiver<Result<()>> {
         let id = self.id;
@@ -5541,7 +5541,9 @@ impl Repository {
             move |repo, _cx| async move {
                 match repo {
                     RepositoryState::Local(LocalRepositoryState { backend, .. }) => {
-                        backend.create_worktree(name, path, commit).await
+                        backend
+                            .create_worktree(name, worktree_directory.clone(), commit)
+                            .await
                     }
                     RepositoryState::Remote(RemoteRepositoryState { project_id, client }) => {
                         client
@@ -5549,7 +5551,7 @@ impl Repository {
                                 project_id: project_id.0,
                                 repository_id: id.to_proto(),
                                 name,
-                                directory: path.to_string_lossy().to_string(),
+                                directory: worktree_directory,
                                 commit,
                             })
                             .await?;

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -456,7 +456,9 @@ pub struct GitSettings {
     /// Default: file_name_first
     pub path_style: GitPathStyle,
     /// Directory where git worktrees are created, relative to the repository
-    /// working directory.
+    /// working directory. When the resolved directory is outside the project
+    /// root, the project's directory name is automatically appended so that
+    /// sibling repos don't collide.
     ///
     /// Default: ../worktrees
     pub worktree_directory: String,

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -4,6 +4,7 @@ use context_server::ContextServerCommand;
 use dap::adapters::DebugAdapterName;
 use fs::Fs;
 use futures::StreamExt as _;
+use git::repository::DEFAULT_WORKTREE_DIRECTORY;
 use gpui::{AsyncApp, BorrowAppContext, Context, Entity, EventEmitter, Subscription, Task};
 use lsp::{DEFAULT_LSP_REQUEST_TIMEOUT_SECS, LanguageServerName};
 use paths::{
@@ -421,7 +422,7 @@ impl GoToDiagnosticSeverityFilter {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub struct GitSettings {
     /// Whether or not git integration is enabled.
     ///
@@ -454,6 +455,11 @@ pub struct GitSettings {
     ///
     /// Default: file_name_first
     pub path_style: GitPathStyle,
+    /// Directory where git worktrees are created, relative to the repository
+    /// working directory.
+    ///
+    /// Default: ../worktrees
+    pub worktree_directory: String,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -643,6 +649,10 @@ impl Settings for ProjectSettings {
             },
             hunk_style: git.hunk_style.unwrap(),
             path_style: git.path_style.unwrap().into(),
+            worktree_directory: git
+                .worktree_directory
+                .clone()
+                .unwrap_or_else(|| DEFAULT_WORKTREE_DIRECTORY.to_string()),
         };
         Self {
             context_servers: project

--- a/crates/project_panel/src/project_panel_settings.rs
+++ b/crates/project_panel/src/project_panel_settings.rs
@@ -96,6 +96,7 @@ impl Settings for ProjectPanelSettings {
             git_status: project_panel.git_status.unwrap()
                 && content
                     .git
+                    .as_ref()
                     .unwrap()
                     .enabled
                     .unwrap()

--- a/crates/settings_content/src/project.rs
+++ b/crates/settings_content/src/project.rs
@@ -476,10 +476,19 @@ pub struct GitSettings {
     /// Directory where git worktrees are created, relative to the repository
     /// working directory.
     ///
+    /// When the resolved directory is outside the project root, the
+    /// project's directory name is automatically appended so that
+    /// sibling repos don't collide. For example, with the default
+    /// `"../worktrees"` and a project at `~/src/zed`, worktrees are
+    /// created under `~/src/worktrees/zed/`.
+    ///
+    /// When the resolved directory is inside the project root, no
+    /// extra component is added (it's already project-scoped).
+    ///
     /// Examples:
-    /// - `"../worktrees"` — sibling of the project root (default)
-    /// - `".git/zed-worktrees"` — inside the git directory
-    /// - `"my-worktrees"` — subdirectory of the project root
+    /// - `"../worktrees"` — `~/src/worktrees/<project>/` (default)
+    /// - `".git/zed-worktrees"` — `<project>/.git/zed-worktrees/`
+    /// - `"my-worktrees"` — `<project>/my-worktrees/`
     ///
     /// Trailing slashes are ignored.
     ///

--- a/crates/settings_content/src/project.rs
+++ b/crates/settings_content/src/project.rs
@@ -479,14 +479,14 @@ pub struct GitSettings {
     /// When the resolved directory is outside the project root, the
     /// project's directory name is automatically appended so that
     /// sibling repos don't collide. For example, with the default
-    /// `"../worktrees"` and a project at `~/src/zed`, worktrees are
-    /// created under `~/src/worktrees/zed/`.
+    /// `"../worktrees"` and a project at `~/code/zed`, worktrees are
+    /// created under `~/code/worktrees/zed/`.
     ///
     /// When the resolved directory is inside the project root, no
     /// extra component is added (it's already project-scoped).
     ///
     /// Examples:
-    /// - `"../worktrees"` — `~/src/worktrees/<project>/` (default)
+    /// - `"../worktrees"` — `~/code/worktrees/<project>/` (default)
     /// - `".git/zed-worktrees"` — `<project>/.git/zed-worktrees/`
     /// - `"my-worktrees"` — `<project>/my-worktrees/`
     ///

--- a/crates/settings_content/src/project.rs
+++ b/crates/settings_content/src/project.rs
@@ -439,7 +439,7 @@ impl std::fmt::Debug for ContextServerCommand {
 }
 
 #[with_fallible_options]
-#[derive(Copy, Clone, Debug, PartialEq, Default, Serialize, Deserialize, JsonSchema, MergeFrom)]
+#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize, JsonSchema, MergeFrom)]
 pub struct GitSettings {
     /// Whether or not to enable git integration.
     ///
@@ -473,6 +473,18 @@ pub struct GitSettings {
     ///
     /// Default: file_name_first
     pub path_style: Option<GitPathStyle>,
+    /// Directory where git worktrees are created, relative to the repository
+    /// working directory.
+    ///
+    /// Examples:
+    /// - `"../worktrees"` — sibling of the project root (default)
+    /// - `".git/zed-worktrees"` — inside the git directory
+    /// - `"my-worktrees"` — subdirectory of the project root
+    ///
+    /// Trailing slashes are ignored.
+    ///
+    /// Default: ../worktrees
+    pub worktree_directory: Option<String>,
 }
 
 #[with_fallible_options]

--- a/crates/util/src/util.rs
+++ b/crates/util/src/util.rs
@@ -22,7 +22,7 @@ use futures::Future;
 use itertools::Either;
 use paths::PathExt;
 use regex::Regex;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{LazyLock, OnceLock};
 use std::{
     borrow::Cow,
@@ -1053,6 +1053,36 @@ pub fn some_or_debug_panic<T>(option: Option<T>) -> Option<T> {
         panic!("Unexpected None");
     }
     option
+}
+
+/// Normalizes a path by resolving `.` and `..` components without
+/// requiring the path to exist on disk (unlike `canonicalize`).
+pub fn normalize_path(path: &Path) -> PathBuf {
+    use std::path::Component;
+    let mut components = path.components().peekable();
+    let mut ret = if let Some(c @ Component::Prefix(..)) = components.peek().cloned() {
+        components.next();
+        PathBuf::from(c.as_os_str())
+    } else {
+        PathBuf::new()
+    };
+
+    for component in components {
+        match component {
+            Component::Prefix(..) => unreachable!(),
+            Component::RootDir => {
+                ret.push(component.as_os_str());
+            }
+            Component::CurDir => {}
+            Component::ParentDir => {
+                ret.pop();
+            }
+            Component::Normal(c) => {
+                ret.push(c);
+            }
+        }
+    }
+    ret
 }
 
 #[cfg(test)]

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -79,6 +79,7 @@ impl Settings for ItemSettings {
             git_status: tabs.git_status.unwrap()
                 && content
                     .git
+                    .as_ref()
                     .unwrap()
                     .enabled
                     .unwrap()


### PR DESCRIPTION
Add `agent_worktree_directory` to `GitSettings` for configuring where agent worktrees are stored (default: Zed data dir). Remove `Copy` derive from `GitSettings`/`GitContentSettings` (incompatible with String field) and fix downstream `.as_ref().unwrap()` call sites.

Define `AgentGitWorktreeInfo` (branch, worktree_path, base_ref) and add it to `DbThread` + `DbThreadMetadata` for persistence and session list display.

Closes AI-33

Release Notes:

- N/A