### PR TITLE
agent_servers: Add support for ACP session delete, close, set title, and message count

### DIFF
--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -80,15 +80,19 @@ pub struct AcpSession {
 
 pub struct AcpSessionList {
     connection: Rc<acp::ClientSideConnection>,
+    supports_delete: bool,
+    sessions: Rc<RefCell<Vec<AgentSessionInfo>>>,
     updates_tx: smol::channel::Sender<acp_thread::SessionListUpdate>,
     updates_rx: smol::channel::Receiver<acp_thread::SessionListUpdate>,
 }
 
 impl AcpSessionList {
-    fn new(connection: Rc<acp::ClientSideConnection>) -> Self {
+    fn new(connection: Rc<acp::ClientSideConnection>, supports_delete: bool) -> Self {
         let (tx, rx) = smol::channel::unbounded();
         Self {
             connection,
+            supports_delete,
+            sessions: Rc::new(RefCell::new(Vec::new())),
             updates_tx: tx,
             updates_rx: rx,
         }
@@ -114,30 +118,124 @@ impl AgentSessionList for AcpSessionList {
         cx: &mut App,
     ) -> Task<Result<AgentSessionListResponse>> {
         let conn = self.connection.clone();
+        let sessions_cache = self.sessions.clone();
+        let is_first_page = request.cursor.is_none();
         cx.foreground_executor().spawn(async move {
             let acp_request = acp::ListSessionsRequest::new()
                 .cwd(request.cwd)
                 .cursor(request.cursor);
             let response = conn.list_sessions(acp_request).await?;
+            let sessions: Vec<AgentSessionInfo> = response
+                .sessions
+                .into_iter()
+                .map(|s| AgentSessionInfo {
+                    session_id: s.session_id,
+                    cwd: Some(s.cwd),
+                    title: s.title.map(Into::into),
+                    updated_at: s.updated_at.and_then(|date_str| {
+                        chrono::DateTime::parse_from_rfc3339(&date_str)
+                            .ok()
+                            .map(|dt| dt.with_timezone(&chrono::Utc))
+                    }),
+                    meta: s.meta,
+                })
+                .collect();
+
+            let mut cache = sessions_cache.borrow_mut();
+            if is_first_page {
+                *cache = sessions.clone();
+            } else {
+                cache.extend(sessions.clone());
+            }
+            drop(cache);
+
             Ok(AgentSessionListResponse {
-                sessions: response
-                    .sessions
-                    .into_iter()
-                    .map(|s| AgentSessionInfo {
-                        session_id: s.session_id,
-                        cwd: Some(s.cwd),
-                        title: s.title.map(Into::into),
-                        updated_at: s.updated_at.and_then(|date_str| {
-                            chrono::DateTime::parse_from_rfc3339(&date_str)
-                                .ok()
-                                .map(|dt| dt.with_timezone(&chrono::Utc))
-                        }),
-                        meta: s.meta,
-                    })
-                    .collect(),
+                sessions,
                 next_cursor: response.next_cursor,
                 meta: response.meta,
             })
+        })
+    }
+
+    fn supports_delete(&self) -> bool {
+        self.supports_delete
+    }
+
+    fn delete_session(&self, session_id: &acp::SessionId, cx: &mut App) -> Task<Result<()>> {
+        let conn = self.connection.clone();
+        let session_id = session_id.clone();
+        let cwd = self
+            .sessions
+            .borrow()
+            .iter()
+            .find(|s| s.session_id == session_id)
+            .and_then(|s| s.cwd.clone());
+        let sessions_cache = self.sessions.clone();
+        let updates_tx = self.updates_tx.clone();
+
+        cx.foreground_executor().spawn(async move {
+            let params = serde_json::json!({
+                "sessionId": session_id.0,
+                "cwd": cwd,
+            });
+            let raw_params: std::sync::Arc<serde_json::value::RawValue> =
+                serde_json::value::to_raw_value(&params)?.into();
+
+            conn.ext_method(acp::ExtRequest::new("session/delete", raw_params))
+                .await
+                .map_err(|err| anyhow!("{}", err))?;
+
+            sessions_cache
+                .borrow_mut()
+                .retain(|s| s.session_id != session_id);
+            updates_tx
+                .try_send(acp_thread::SessionListUpdate::Refresh)
+                .ok();
+
+            Ok(())
+        })
+    }
+
+    fn delete_sessions(&self, cx: &mut App) -> Task<Result<()>> {
+        let session_entries: Vec<_> = self
+            .sessions
+            .borrow()
+            .iter()
+            .map(|s| (s.session_id.clone(), s.cwd.clone()))
+            .collect();
+        let conn = self.connection.clone();
+        let sessions_cache = self.sessions.clone();
+        let updates_tx = self.updates_tx.clone();
+
+        cx.foreground_executor().spawn(async move {
+            let mut first_error = None;
+            for (session_id, cwd) in session_entries {
+                let params = serde_json::json!({
+                    "sessionId": session_id.0,
+                    "cwd": cwd,
+                });
+                let raw_params: std::sync::Arc<serde_json::value::RawValue> =
+                    serde_json::value::to_raw_value(&params)?.into();
+
+                if let Err(err) = conn
+                    .ext_method(acp::ExtRequest::new("session/delete", raw_params))
+                    .await
+                {
+                    if first_error.is_none() {
+                        first_error = Some(anyhow!("{}", err));
+                    }
+                }
+            }
+
+            sessions_cache.borrow_mut().clear();
+            updates_tx
+                .try_send(acp_thread::SessionListUpdate::Refresh)
+                .ok();
+
+            match first_error {
+                Some(err) => Err(err),
+                None => Ok(()),
+            }
         })
     }
 
@@ -313,13 +411,25 @@ impl AcpConnection {
             // Otherwise, just use the name
             .unwrap_or_else(|| server_name.clone());
 
+        let supports_session_delete = response
+            .agent_capabilities
+            .session_capabilities
+            .meta
+            .as_ref()
+            .and_then(|meta| meta.get("delete"))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
         let session_list = if response
             .agent_capabilities
             .session_capabilities
             .list
             .is_some()
         {
-            let list = Rc::new(AcpSessionList::new(connection.clone()));
+            let list = Rc::new(AcpSessionList::new(
+                connection.clone(),
+                supports_session_delete,
+            ));
             *client_session_list.borrow_mut() = Some(list.clone());
             Some(list)
         } else {

--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -48,6 +48,8 @@ pub struct AcpConnection {
     root_dir: PathBuf,
     child: Child,
     session_list: Option<Rc<AcpSessionList>>,
+    server_supports_close: bool,
+    server_supports_set_title: bool,
     _io_task: Task<Result<(), acp::Error>>,
     _wait_task: Task<Result<()>>,
     _stderr_task: Task<Result<()>>,
@@ -411,12 +413,21 @@ impl AcpConnection {
             // Otherwise, just use the name
             .unwrap_or_else(|| server_name.clone());
 
-        let supports_session_delete = response
+        let session_meta = response
             .agent_capabilities
             .session_capabilities
             .meta
-            .as_ref()
+            .as_ref();
+        let supports_session_delete = session_meta
             .and_then(|meta| meta.get("delete"))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let server_supports_close = session_meta
+            .and_then(|meta| meta.get("close"))
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let server_supports_set_title = session_meta
+            .and_then(|meta| meta.get("setTitle"))
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
 
@@ -448,6 +459,8 @@ impl AcpConnection {
             default_model,
             default_config_options,
             session_list,
+            server_supports_close,
+            server_supports_set_title,
             _io_task: io_task,
             _wait_task: wait_task,
             _stderr_task: stderr_task,
@@ -697,6 +710,31 @@ impl AgentConnection for AcpConnection {
 
     fn supports_load_session(&self, cx: &App) -> bool {
         cx.has_flag::<AcpBetaFeatureFlag>() && self.agent_capabilities.load_session
+    }
+
+    fn supports_close_session(&self, _cx: &App) -> bool {
+        true
+    }
+
+    fn close_session(&self, session_id: &acp::SessionId, cx: &mut App) -> Task<Result<()>> {
+        self.sessions.borrow_mut().remove(session_id);
+
+        if self.server_supports_close {
+            let connection = self.connection.clone();
+            let session_id = session_id.clone();
+            cx.foreground_executor().spawn(async move {
+                let params = serde_json::json!({ "sessionId": session_id.0 });
+                let raw_params: std::sync::Arc<serde_json::value::RawValue> =
+                    serde_json::value::to_raw_value(&params)?.into();
+                connection
+                    .ext_method(acp::ExtRequest::new("session/close", raw_params))
+                    .await
+                    .ok();
+                Ok(())
+            })
+        } else {
+            Task::ready(Ok(()))
+        }
     }
 
     fn supports_resume_session(&self, cx: &App) -> bool {
@@ -997,6 +1035,23 @@ impl AgentConnection for AcpConnection {
         }) as _)
     }
 
+    fn set_title(
+        &self,
+        session_id: &acp::SessionId,
+        _cx: &App,
+    ) -> Option<Rc<dyn acp_thread::AgentSessionSetTitle>> {
+        if !self.server_supports_set_title {
+            return None;
+        }
+        if !self.sessions.borrow().contains_key(session_id) {
+            return None;
+        }
+        Some(Rc::new(AcpSessionSetTitle {
+            session_id: session_id.clone(),
+            connection: self.connection.clone(),
+        }))
+    }
+
     fn session_list(&self, cx: &mut App) -> Option<Rc<dyn AgentSessionList>> {
         if cx.has_flag::<AcpBetaFeatureFlag>() {
             self.session_list.clone().map(|s| s as _)
@@ -1007,6 +1062,31 @@ impl AgentConnection for AcpConnection {
 
     fn into_any(self: Rc<Self>) -> Rc<dyn Any> {
         self
+    }
+}
+
+struct AcpSessionSetTitle {
+    session_id: acp::SessionId,
+    connection: Rc<acp::ClientSideConnection>,
+}
+
+impl acp_thread::AgentSessionSetTitle for AcpSessionSetTitle {
+    fn run(&self, title: SharedString, cx: &mut App) -> Task<Result<()>> {
+        let connection = self.connection.clone();
+        let session_id = self.session_id.clone();
+        cx.foreground_executor().spawn(async move {
+            let params = serde_json::json!({
+                "sessionId": session_id.0,
+                "title": title.as_ref(),
+            });
+            let raw_params: std::sync::Arc<serde_json::value::RawValue> =
+                serde_json::value::to_raw_value(&params)?.into();
+            connection
+                .ext_method(acp::ExtRequest::new("session/setTitle", raw_params))
+                .await
+                .map_err(|err| anyhow!("{}", err))?;
+            Ok(())
+        })
     }
 }
 

--- a/crates/agent_ui/src/acp/thread_history.rs
+++ b/crates/agent_ui/src/acp/thread_history.rs
@@ -27,6 +27,10 @@ fn thread_title(entry: &AgentSessionInfo) -> &SharedString {
         .unwrap_or(DEFAULT_TITLE)
 }
 
+fn message_count(entry: &AgentSessionInfo) -> Option<u64> {
+    entry.meta.as_ref()?.get("messageCount")?.as_u64()
+}
+
 pub struct AcpThreadHistory {
     session_list: Option<Rc<dyn AgentSessionList>>,
     sessions: Vec<AgentSessionInfo>,
@@ -636,6 +640,7 @@ impl AcpThreadHistory {
         };
 
         let title = thread_title(entry).clone();
+        let msg_count = message_count(entry);
         let full_date = entry_time
             .map(|time| {
                 EntryTimeFormat::DateAndTime.format_timestamp(time.timestamp(), self.local_timezone)
@@ -661,13 +666,30 @@ impl AcpThreadHistory {
                                     .truncate(),
                             )
                             .child(
-                                Label::new(display_text)
-                                    .color(Color::Muted)
-                                    .size(LabelSize::XSmall),
+                                h_flex()
+                                    .gap_1()
+                                    .flex_shrink_0()
+                                    .when_some(msg_count, |this, count| {
+                                        this.child(
+                                            Label::new(format!("{count} msgs"))
+                                                .color(Color::Muted)
+                                                .size(LabelSize::XSmall),
+                                        )
+                                    })
+                                    .child(
+                                        Label::new(display_text)
+                                            .color(Color::Muted)
+                                            .size(LabelSize::XSmall),
+                                    ),
                             ),
                     )
                     .tooltip(move |_, cx| {
-                        Tooltip::with_meta(title.clone(), None, full_date.clone(), cx)
+                        let meta_text = if let Some(count) = msg_count {
+                            format!("{full_date} · {count} messages")
+                        } else {
+                            full_date.clone()
+                        };
+                        Tooltip::with_meta(title.clone(), None, meta_text, cx)
                     })
                     .on_hover(cx.listener(move |this, is_hovered, _window, cx| {
                         if *is_hovered {
@@ -882,6 +904,7 @@ impl RenderOnce for AcpHistoryEntryElement {
     fn render(self, _window: &mut Window, _cx: &mut App) -> impl IntoElement {
         let id = ElementId::Name(self.entry.session_id.0.clone().into());
         let title = thread_title(&self.entry).clone();
+        let msg_count = message_count(&self.entry);
         let formatted_time = self
             .entry
             .updated_at
@@ -901,6 +924,9 @@ impl RenderOnce for AcpHistoryEntryElement {
             })
             .unwrap_or_else(|| "Unknown".to_string());
 
+        let tooltip_title = title.clone();
+        let tooltip_time = formatted_time.clone();
+
         ListItem::new(id)
             .rounded()
             .toggle_state(self.selected)
@@ -912,11 +938,31 @@ impl RenderOnce for AcpHistoryEntryElement {
                     .justify_between()
                     .child(Label::new(title).size(LabelSize::Small).truncate())
                     .child(
-                        Label::new(formatted_time)
-                            .color(Color::Muted)
-                            .size(LabelSize::XSmall),
+                        h_flex()
+                            .gap_1()
+                            .flex_shrink_0()
+                            .when_some(msg_count, |this, count| {
+                                this.child(
+                                    Label::new(format!("{count} msgs"))
+                                        .color(Color::Muted)
+                                        .size(LabelSize::XSmall),
+                                )
+                            })
+                            .child(
+                                Label::new(formatted_time)
+                                    .color(Color::Muted)
+                                    .size(LabelSize::XSmall),
+                            ),
                     ),
             )
+            .tooltip(move |_, cx| {
+                let meta_text = if let Some(count) = msg_count {
+                    format!("{tooltip_time} · {count} messages")
+                } else {
+                    tooltip_time.clone()
+                };
+                Tooltip::with_meta(tooltip_title.clone(), None, meta_text, cx)
+            })
             .on_hover(self.on_hover)
             .end_slot::<IconButton>(if (self.hovered || self.selected) && self.supports_delete {
                 Some(


### PR DESCRIPTION
## feat: ACP session delete, close, set title & message count

Adds support for session management features for ACP agents (e.g. Claude Code):

### Session delete
- Read `_meta.delete` capability from `sessionCapabilities`
- Implement `delete_session` and `delete_sessions` via `session/delete` ext method
- Cache sessions in `AcpSessionList` for `cwd` lookup during delete

### Session close
- Implement `close_session` on `AcpConnection` — always cleans up the local session map
- When the server advertises `_meta.close`, also sends a `session/close` ext method call (best-effort)

### Session set title
- Read `_meta.setTitle` capability from `sessionCapabilities`
- Implement `set_title` via `session/setTitle` ext method
- When supported, the title editor becomes editable

### Message count
- Display `_meta.messageCount` from session metadata in history entries
- Show count in tooltips ("Feb 13, 2026 · 5 messages")

All ext method features (`delete`, `close`, `setTitle`) are gated behind server-advertised capabilities and degrade gracefully when the server doesn't support them.

Depends on server-side support in [claude-code-acp#308](https://github.com/zed-industries/claude-code-acp/pull/308).


Release Notes:

- Added session delete, close, set title, and message count support for ACP agents (e.g. Claude Code)
