### PR TITLE
edit_prediction: Fix crash when anchor buffer_id doesn't match snapshot

### DIFF
--- a/.factory/prompts/crash/fix.md
+++ b/.factory/prompts/crash/fix.md
@@ -39,6 +39,7 @@ Apply the minimal change needed to resolve the root cause. Guidelines:
 - **Don't add unnecessary changes.** No drive-by improvements, keep the diff focused.
 - **Add a comment only if the fix is non-obvious.** If a reader might wonder "why is this check here?", a brief comment explaining the crash scenario is appropriate.
 - **Consider long term maintainability** Please make a targeted fix while being sure to consider the long term maintainability and reliability of the codebase
+- **Write readable conditionals.** When checking the same property across multiple objects, extract a helper closure to make intent explicit. Prefer positive logic (`is_none_or`, `all()`) over verbose chains of negated conditions.
 
 ### Step 4: Verify the Fix
 

--- a/crates/edit_prediction/src/edit_prediction.rs
+++ b/crates/edit_prediction/src/edit_prediction.rs
@@ -248,6 +248,26 @@ impl StoredEvent {
             return false;
         }
 
+        // Anchors must belong to the same buffer as the snapshot we're converting them with.
+        // Buffers can be swapped out between operations, leaving stale anchors.
+        let snapshot_buffer_id = new_snapshot.remote_id();
+        let anchor_matches_snapshot = |anchor: &Anchor| {
+            anchor
+                .buffer_id
+                .is_none_or(|id| id == snapshot_buffer_id)
+        };
+
+        let all_anchors_valid = anchor_matches_snapshot(&self.edit_range.start)
+            && anchor_matches_snapshot(&self.edit_range.end)
+            && anchor_matches_snapshot(&next_old_event.edit_range.start)
+            && anchor_matches_snapshot(&next_old_event.edit_range.end)
+            && anchor_matches_snapshot(&last_edit_range.start)
+            && anchor_matches_snapshot(&last_edit_range.end);
+
+        if !all_anchors_valid {
+            return false;
+        }
+
         let a_is_predicted = matches!(
             self.event.as_ref(),
             zeta_prompt::Event::BufferChange {

--- a/crates/edit_prediction/src/edit_prediction.rs
+++ b/crates/edit_prediction/src/edit_prediction.rs
@@ -251,11 +251,8 @@ impl StoredEvent {
         // Anchors must belong to the same buffer as the snapshot we're converting them with.
         // Buffers can be swapped out between operations, leaving stale anchors.
         let snapshot_buffer_id = new_snapshot.remote_id();
-        let anchor_matches_snapshot = |anchor: &Anchor| {
-            anchor
-                .buffer_id
-                .is_none_or(|id| id == snapshot_buffer_id)
-        };
+        let anchor_matches_snapshot =
+            |anchor: &Anchor| anchor.buffer_id.is_none_or(|id| id == snapshot_buffer_id);
 
         let all_anchors_valid = anchor_matches_snapshot(&self.edit_range.start)
             && anchor_matches_snapshot(&self.edit_range.end)


### PR DESCRIPTION
## Summary

Fixes **ZED-519** - "invalid anchor - buffer id does not match" crash in edit_prediction event merging.

**Impact:** 3 users affected, 4 occurrences - moderate impact, affects nightly users.

## Root Cause

The `can_merge()` function in `edit_prediction.rs` validates that snapshots have matching `remote_id()` values, but doesn't validate that the `Anchor` objects stored in `edit_range` also belong to the same buffer. When buffers are swapped out between operations, stale anchors with different `buffer_id` values can remain in `StoredEvent` objects.

When `to_point(new_snapshot)` is called on these stale anchors, the text crate panics:
```
invalid anchor - buffer id does not match: anchor Anchor { ... buffer_id: Some(BufferId(55834574913)) }; buffer id: 4294967598
```

This is a known anti-pattern documented in `.rules`:
> When comparing or merging buffer events, verify `remote_id()` matches — buffers can be swapped out between operations

## Fix

Add validation that all anchor `buffer_id` values match the snapshot's `remote_id` before attempting to convert anchors to points. If any anchor belongs to a different buffer, `can_merge()` returns `false` early, avoiding the panic.

## Testing

This crash is difficult to reproduce in unit tests because it requires specific timing of buffer swaps during edit prediction event processing. The fix is defensive - it prevents the panic by detecting the mismatch condition and gracefully declining to merge events.

All existing edit_prediction tests pass (66 tests).

## Context: Background Agent Experiment

This PR is the third crash investigation as part of testing the **Sentry crash → fix** workflow for the Background Agent initiative (BIZOPS-801).

| Issue | Type | Fix | Testing |
|-------|------|-----|---------|
| ZED-4VS | UTF-8 boundary | Bounds checking | Unit tests |
| ZED-3DJ | GPU device loss | Return Option | Manual (hardware) |
| **ZED-519** | Buffer ID mismatch | Early validation | Defensive (timing-dependent) |

This validates that the workflow can identify and fix crashes even when reproduction is difficult due to timing-dependent race conditions.

Release Notes:

- Fixed a crash in edit prediction when buffer IDs don't match during event merging
