### PR TITLE
Fix exotic fold range kinds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9720,7 +9720,7 @@ dependencies = [
 [[package]]
 name = "lsp-types"
 version = "0.95.1"
-source = "git+https://github.com/zed-industries/lsp-types?rev=fb6bcad59522455a041b7eb9579f706e5cfb2d6f#fb6bcad59522455a041b7eb9579f706e5cfb2d6f"
+source = "git+https://github.com/zed-industries/lsp-types?rev=a4f410987660bf560d1e617cb78117c6b6b9f599#a4f410987660bf560d1e617cb78117c6b6b9f599"
 dependencies = [
  "bitflags 1.3.2",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -559,7 +559,7 @@ libc = "0.2"
 libsqlite3-sys = { version = "0.30.1", features = ["bundled"] }
 linkify = "0.10.0"
 log = { version = "0.4.16", features = ["kv_unstable_serde", "serde"] }
-lsp-types = { git = "https://github.com/zed-industries/lsp-types", rev = "fb6bcad59522455a041b7eb9579f706e5cfb2d6f" }
+lsp-types = { git = "https://github.com/zed-industries/lsp-types", rev = "a4f410987660bf560d1e617cb78117c6b6b9f599" }
 mach2 = "0.5"
 markup5ever_rcdom = "0.3.0"
 metal = "0.29"


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/48611

Despite Zed not declaring such support in its capabilities,

https://github.com/zed-industries/zed/blob/a0eb63d1affb6e7b7991e477c7e05824d0250255/crates/lsp/src/lsp.rs#L1010-L1016

`json-language-server` returns `object` as a folding range kind:

<img width="1728" height="720" alt="bad" src="https://github.com/user-attachments/assets/ee574879-8657-41c8-ab12-562f3882f057" />

The spec, even 3.18, does not really seem to allow it explicitly: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#foldingRangeKind

but mentions that the real type

> The type is a string since the value set is extensible

The PR adds a capture enum variant for such cases, to get the folds in instead of failing on deserialization.

See also: https://github.com/zed-industries/lsp-types/pull/10

Release Notes:

- Fixed `json-language-server` document folds not being parsed correctly
