### PR TITLE
auto_update_ui: Set a title when viewing release notes locally

### DIFF
--- a/crates/auto_update_ui/src/auto_update_ui.rs
+++ b/crates/auto_update_ui/src/auto_update_ui.rs
@@ -31,10 +31,6 @@ pub fn init(cx: &mut App) {
 
 #[derive(Deserialize)]
 struct ReleaseNotesBody {
-    #[expect(
-        unused,
-        reason = "This field was found to be unused with serde library bump; it's left as is due to insufficient context on PO's side, but it *may* be fine to remove"
-    )]
     title: String,
     release_notes: String,
 }
@@ -123,7 +119,7 @@ fn view_release_notes_locally(
                 buffer.edit([(0..0, body.release_notes)], None, cx)
             });
 
-            let buffer = cx.new(|cx| MultiBuffer::singleton(buffer, cx));
+            let buffer = cx.new(|cx| MultiBuffer::singleton(buffer, cx).with_title(body.title));
 
             let ws_handle = workspace.clone();
             workspace

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -528,7 +528,7 @@ impl Item for MarkdownPreviewView {
             .map(|editor_state| {
                 let buffer = editor_state.editor.read(cx).buffer().read(cx);
                 let title = buffer.title(cx);
-                format!("Preview {}", title.to_string()).into()
+                format!("Preview {}", title).into()
             })
             .unwrap_or_else(|| SharedString::from("Markdown Preview"))
     }

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -525,15 +525,10 @@ impl Item for MarkdownPreviewView {
     fn tab_content_text(&self, _detail: usize, cx: &App) -> SharedString {
         self.active_editor
             .as_ref()
-            .and_then(|editor_state| {
+            .map(|editor_state| {
                 let buffer = editor_state.editor.read(cx).buffer().read(cx);
-                let buffer = buffer.as_singleton()?;
-                let file = buffer.read(cx).file()?;
-                let local_file = file.as_local()?;
-                local_file
-                    .abs_path(cx)
-                    .file_name()
-                    .map(|name| format!("Preview {}", name.to_string_lossy()).into())
+                let title = buffer.title(cx);
+                format!("Preview {}", title.to_string()).into()
             })
             .unwrap_or_else(|| SharedString::from("Markdown Preview"))
     }


### PR DESCRIPTION
| before | after |
| - | - |
| <img width="447" height="177" alt="image" src="https://github.com/user-attachments/assets/bf030e11-5c03-43c6-8a7b-ff7057bada5f" /> | <img width="463" height="176" alt="image" src="https://github.com/user-attachments/assets/e6f6a3d5-e454-469f-adb4-62a38181cb6f" /> |

Title for markdown preview is still the same:
<img width="463" height="176" alt="image" src="https://github.com/user-attachments/assets/b83fdf54-804f-4f98-8d3b-0c7b93f44b83" />

Closes https://github.com/zed-industries/zed/issues/47385

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [ ] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Fixed title of the release notes local preview
