### PR TITLE
chore: remove no-longer needed search_on_input=false toggle before tests

### DIFF
--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -2576,8 +2576,7 @@ pub mod tests {
     use project::FakeFs;
     use serde_json::json;
     use settings::{
-        InlayHintSettingsContent, SearchSettingsContent, SettingsStore, ThemeColorsContent,
-        ThemeStyleContent,
+        InlayHintSettingsContent, SettingsStore, ThemeColorsContent, ThemeStyleContent,
     };
     use util::{path, paths::PathStyle, rel_path::rel_path};
     use util_macros::perf;
@@ -4795,15 +4794,6 @@ pub mod tests {
         cx.update(|cx| {
             let settings = SettingsStore::test(cx);
             cx.set_global(settings);
-
-            SettingsStore::update_global(cx, |store, cx| {
-                store.update_user_settings(cx, |settings| {
-                    settings.editor.search = Some(SearchSettingsContent {
-                        search_on_input: Some(false),
-                        ..Default::default()
-                    });
-                });
-            });
 
             theme::init(theme::LoadThemes::JustBase, cx);
 


### PR DESCRIPTION
Just cleaning up after myself.

When search_on_input was toggled default [in this PR](https://github.com/zed-industries/zed/pull/42889/changes/1f831e028d4de9e872a78b0af8b9d24e33f7d3c7)  I toggled it to false before a few tests that weren't expecting it.

Then [this PR changed](https://github.com/zed-industries/zed/pull/49150) it to be false by default and the extra toggle before the tests slipped through.

Think it's a good idea to remove this to avoid any confusion in the future.
@SomeoneToIgnore 


Release Notes:

- N/A
