### PR TITLE
Revert project search on type

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -667,8 +667,6 @@
     "regex": false,
     // Whether to center the cursor on each search match when navigating.
     "center_on_match": false,
-    // Whether to search on input.
-    "search_on_input": true,
   },
   // When to populate a new search's query based on the text under the cursor.
   // This setting can take the following three values:

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -667,11 +667,8 @@
     "regex": false,
     // Whether to center the cursor on each search match when navigating.
     "center_on_match": false,
-    // Whether to search on input in project search.
-    "search_on_input": false,
-    // Debounce time in milliseconds for search on input in project search.
-    // Set to 0 to disable debouncing.
-    "search_on_input_debounce_ms": 200,
+    // Whether to search on input.
+    "search_on_input": true,
   },
   // When to populate a new search's query based on the text under the cursor.
   // This setting can take the following three values:

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -175,8 +175,6 @@ pub struct SearchSettings {
     pub regex: bool,
     /// Whether to center the cursor on each search match when navigating.
     pub center_on_match: bool,
-    /// Whether to search on input.
-    pub search_on_input: bool,
 }
 
 impl EditorSettings {
@@ -273,7 +271,6 @@ impl Settings for EditorSettings {
                 include_ignored: search.include_ignored.unwrap(),
                 regex: search.regex.unwrap(),
                 center_on_match: search.center_on_match.unwrap(),
-                search_on_input: search.search_on_input.unwrap(),
             },
             auto_signature_help: editor.auto_signature_help.unwrap(),
             show_signature_help_after_edits: editor.show_signature_help_after_edits.unwrap(),

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -175,11 +175,8 @@ pub struct SearchSettings {
     pub regex: bool,
     /// Whether to center the cursor on each search match when navigating.
     pub center_on_match: bool,
-    /// Whether to search on input in project search.
+    /// Whether to search on input.
     pub search_on_input: bool,
-    /// Debounce time in milliseconds for search on input in project search.
-    /// Set to 0 to disable debouncing.
-    pub search_on_input_debounce_ms: u64,
 }
 
 impl EditorSettings {
@@ -277,7 +274,6 @@ impl Settings for EditorSettings {
                 regex: search.regex.unwrap(),
                 center_on_match: search.center_on_match.unwrap(),
                 search_on_input: search.search_on_input.unwrap(),
-                search_on_input_debounce_ms: search.search_on_input_debounce_ms.unwrap(),
             },
             auto_signature_help: editor.auto_signature_help.unwrap(),
             show_signature_help_after_edits: editor.show_signature_help_after_edits.unwrap(),

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -3421,7 +3421,6 @@ mod tests {
                 include_ignored: false,
                 regex: false,
                 center_on_match: false,
-                search_on_input: false,
             },
             cx,
         );
@@ -3485,7 +3484,6 @@ mod tests {
                 include_ignored: false,
                 regex: false,
                 center_on_match: false,
-                search_on_input: false,
             },
             cx,
         );
@@ -3524,7 +3522,6 @@ mod tests {
                 include_ignored: false,
                 regex: false,
                 center_on_match: false,
-                search_on_input: false,
             },
             cx,
         );
@@ -3607,91 +3604,9 @@ mod tests {
                         include_ignored: Some(search_settings.include_ignored),
                         regex: Some(search_settings.regex),
                         center_on_match: Some(search_settings.center_on_match),
-                        search_on_input: Some(search_settings.search_on_input),
                     });
                 });
             });
-        });
-    }
-    #[gpui::test]
-    async fn test_search_on_input_setting(cx: &mut TestAppContext) {
-        let (editor, search_bar, cx) = init_test(cx);
-
-        update_search_settings(
-            SearchSettings {
-                button: true,
-                whole_word: false,
-                case_sensitive: false,
-                include_ignored: false,
-                regex: false,
-                center_on_match: false,
-                search_on_input: false,
-            },
-            cx,
-        );
-
-        search_bar.update_in(cx, |search_bar, window, cx| {
-            search_bar.show(window, cx);
-            search_bar.query_editor.update(cx, |query_editor, cx| {
-                query_editor.buffer().update(cx, |buffer, cx| {
-                    buffer.edit(
-                        [(MultiBufferOffset(0)..MultiBufferOffset(0), "expression")],
-                        None,
-                        cx,
-                    );
-                });
-            });
-        });
-
-        cx.background_executor.run_until_parked();
-
-        editor.update_in(cx, |editor, window, cx| {
-            let highlights = editor.all_text_background_highlights(window, cx);
-            assert!(
-                highlights.is_empty(),
-                "No highlights should appear when search_on_input is false"
-            );
-        });
-
-        update_search_settings(
-            SearchSettings {
-                button: true,
-                whole_word: false,
-                case_sensitive: false,
-                include_ignored: false,
-                regex: false,
-                center_on_match: false,
-                search_on_input: true,
-            },
-            cx,
-        );
-
-        search_bar.update_in(cx, |search_bar, window, cx| {
-            search_bar.dismiss(&Dismiss, window, cx);
-            search_bar.show(window, cx);
-        });
-
-        search_bar
-            .update_in(cx, |search_bar, window, cx| {
-                search_bar.search("expression", None, true, window, cx)
-            })
-            .await
-            .unwrap();
-
-        editor.update_in(cx, |editor, window, cx| {
-            let highlights = display_points_of(editor.all_text_background_highlights(window, cx));
-            assert_eq!(
-                highlights.len(),
-                2,
-                "Should find 2 matches for 'expression' when search_on_input is true"
-            );
-            assert_eq!(
-                highlights,
-                &[
-                    DisplayPoint::new(DisplayRow(0), 10)..DisplayPoint::new(DisplayRow(0), 20),
-                    DisplayPoint::new(DisplayRow(1), 9)..DisplayPoint::new(DisplayRow(1), 19),
-                ]
-            );
         });
     }
 }

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -3422,7 +3422,6 @@ mod tests {
                 regex: false,
                 center_on_match: false,
                 search_on_input: false,
-                search_on_input_debounce_ms: 0,
             },
             cx,
         );
@@ -3487,7 +3486,6 @@ mod tests {
                 regex: false,
                 center_on_match: false,
                 search_on_input: false,
-                search_on_input_debounce_ms: 0,
             },
             cx,
         );
@@ -3527,7 +3525,6 @@ mod tests {
                 regex: false,
                 center_on_match: false,
                 search_on_input: false,
-                search_on_input_debounce_ms: 0,
             },
             cx,
         );
@@ -3611,9 +3608,6 @@ mod tests {
                         regex: Some(search_settings.regex),
                         center_on_match: Some(search_settings.center_on_match),
                         search_on_input: Some(search_settings.search_on_input),
-                        search_on_input_debounce_ms: Some(
-                            search_settings.search_on_input_debounce_ms,
-                        ),
                     });
                 });
             });
@@ -3632,7 +3626,6 @@ mod tests {
                 regex: false,
                 center_on_match: false,
                 search_on_input: false,
-                search_on_input_debounce_ms: 0,
             },
             cx,
         );
@@ -3669,7 +3662,6 @@ mod tests {
                 regex: false,
                 center_on_match: false,
                 search_on_input: true,
-                search_on_input_debounce_ms: 0,
             },
             cx,
         );

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -2576,7 +2576,8 @@ pub mod tests {
     use project::FakeFs;
     use serde_json::json;
     use settings::{
-        InlayHintSettingsContent, SettingsStore, ThemeColorsContent, ThemeStyleContent,
+        InlayHintSettingsContent, SearchSettingsContent, SettingsStore, ThemeColorsContent,
+        ThemeStyleContent,
     };
     use util::{path, paths::PathStyle, rel_path::rel_path};
     use util_macros::perf;
@@ -4794,6 +4795,15 @@ pub mod tests {
         cx.update(|cx| {
             let settings = SettingsStore::test(cx);
             cx.set_global(settings);
+
+            SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    settings.editor.search = Some(SearchSettingsContent {
+                        search_on_input: Some(false),
+                        ..Default::default()
+                    });
+                });
+            });
 
             theme::init(theme::LoadThemes::JustBase, cx);
 

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -39,7 +39,6 @@ use std::{
     ops::{Not, Range},
     pin::pin,
     sync::Arc,
-    time::Duration,
 };
 use ui::{
     CommonAnimationExt, IconButtonShape, KeyBinding, Toggleable, Tooltip, prelude::*,
@@ -271,7 +270,6 @@ pub struct ProjectSearchView {
     included_opened_only: bool,
     regex_language: Option<Arc<Language>>,
     results_collapsed: bool,
-    current_search_on_input: Task<()>,
     _subscriptions: Vec<Subscription>,
 }
 
@@ -881,11 +879,11 @@ impl ProjectSearchView {
                             this.toggle_search_option(SearchOptions::CASE_SENSITIVE, cx);
                         }
                     }
-
-                    let search_settings = &EditorSettings::get_global(cx).search;
-                    if search_settings.search_on_input {
-                        if this.query_editor.read(cx).is_empty(cx) {
-                            this.current_search_on_input = Task::ready(());
+                    // Trigger search on input:
+                    if EditorSettings::get_global(cx).search.search_on_input {
+                        let query = this.search_query_text(cx);
+                        if query.is_empty() {
+                            // Clear results immediately when query is empty and abort ongoing search
                             this.entity.update(cx, |model, cx| {
                                 model.pending_search = None;
                                 model.match_ranges.clear();
@@ -895,18 +893,7 @@ impl ProjectSearchView {
                                 cx.notify();
                             });
                         } else {
-                            let debounce = search_settings.search_on_input_debounce_ms;
-                            this.current_search_on_input = cx.spawn(async move |this, cx| {
-                                if debounce > 0 {
-                                    cx.background_executor()
-                                        .timer(Duration::from_millis(debounce))
-                                        .await;
-                                }
-                                this.update(cx, |this, cx| {
-                                    this.search(cx);
-                                })
-                                .ok();
-                            });
+                            this.search(cx);
                         }
                     }
                 }
@@ -1028,7 +1015,6 @@ impl ProjectSearchView {
             included_opened_only: false,
             regex_language: None,
             results_collapsed: false,
-            current_search_on_input: Task::ready(()),
             _subscriptions: subscriptions,
         };
 

--- a/crates/settings_content/src/editor.rs
+++ b/crates/settings_content/src/editor.rs
@@ -828,8 +828,6 @@ pub struct SearchSettingsContent {
     pub regex: Option<bool>,
     /// Whether to center the cursor on each search match when navigating.
     pub center_on_match: Option<bool>,
-    /// Whether to search on input.
-    pub search_on_input: Option<bool>,
 }
 
 #[with_fallible_options]

--- a/crates/settings_content/src/editor.rs
+++ b/crates/settings_content/src/editor.rs
@@ -828,14 +828,8 @@ pub struct SearchSettingsContent {
     pub regex: Option<bool>,
     /// Whether to center the cursor on each search match when navigating.
     pub center_on_match: Option<bool>,
-    /// Whether to search on input in project search.
+    /// Whether to search on input.
     pub search_on_input: Option<bool>,
-    /// Debounce time in milliseconds for search on input in project search.
-    ///
-    /// Set to 0 to disable debouncing.
-    ///
-    /// Default: 200
-    pub search_on_input_debounce_ms: Option<u64>,
 }
 
 #[with_fallible_options]

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -2999,7 +2999,7 @@ fn languages_and_tools_page(cx: &App) -> SettingsPage {
 }
 
 fn search_and_files_page() -> SettingsPage {
-    fn search_section() -> [SettingsPageItem; 10] {
+    fn search_section() -> [SettingsPageItem; 9] {
         [
             SettingsPageItem::SectionHeader("Search"),
             SettingsPageItem::SettingItem(SettingItem {
@@ -3128,29 +3128,6 @@ fn search_and_files_page() -> SettingsPage {
                             .search
                             .get_or_insert_default()
                             .center_on_match = value;
-                    },
-                }),
-                metadata: None,
-                files: USER,
-            }),
-            SettingsPageItem::SettingItem(SettingItem {
-                title: "Search on Input",
-                description: "Whether to search on input.",
-                field: Box::new(SettingField {
-                    json_path: Some("editor.search.search_on_input"),
-                    pick: |settings_content| {
-                        settings_content
-                            .editor
-                            .search
-                            .as_ref()
-                            .and_then(|search| search.search_on_input.as_ref())
-                    },
-                    write: |settings_content, value| {
-                        settings_content
-                            .editor
-                            .search
-                            .get_or_insert_default()
-                            .search_on_input = value;
                     },
                 }),
                 metadata: None,

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -2999,7 +2999,7 @@ fn languages_and_tools_page(cx: &App) -> SettingsPage {
 }
 
 fn search_and_files_page() -> SettingsPage {
-    fn search_section() -> [SettingsPageItem; 11] {
+    fn search_section() -> [SettingsPageItem; 10] {
         [
             SettingsPageItem::SectionHeader("Search"),
             SettingsPageItem::SettingItem(SettingItem {
@@ -3135,7 +3135,7 @@ fn search_and_files_page() -> SettingsPage {
             }),
             SettingsPageItem::SettingItem(SettingItem {
                 title: "Search on Input",
-                description: "Whether to search on input in project search.",
+                description: "Whether to search on input.",
                 field: Box::new(SettingField {
                     json_path: Some("editor.search.search_on_input"),
                     pick: |settings_content| {
@@ -3151,29 +3151,6 @@ fn search_and_files_page() -> SettingsPage {
                             .search
                             .get_or_insert_default()
                             .search_on_input = value;
-                    },
-                }),
-                metadata: None,
-                files: USER,
-            }),
-            SettingsPageItem::SettingItem(SettingItem {
-                title: "Search on Input Debounce",
-                description: "Debounce time in milliseconds for search on input (set to 0 to disable debouncing).",
-                field: Box::new(SettingField {
-                    json_path: Some("editor.search.search_on_input_debounce_ms"),
-                    pick: |settings_content| {
-                        settings_content
-                            .editor
-                            .search
-                            .as_ref()
-                            .and_then(|search| search.search_on_input_debounce_ms.as_ref())
-                    },
-                    write: |settings_content, value| {
-                        settings_content
-                            .editor
-                            .search
-                            .get_or_insert_default()
-                            .search_on_input_debounce_ms = value;
                     },
                 }),
                 metadata: None,

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -3270,12 +3270,6 @@ Non-negative `integer` values
 - Setting: `regex`
 - Default: `false`
 
-### Search On Input
-
-- Description: Whether to search on input.
-- Setting: `search_on_input
-- Default: `true`
-
 ### Center On Match
 
 - Description: Whether to center the cursor on each search match when navigating.
@@ -3287,6 +3281,12 @@ Non-negative `integer` values
 - Description: If `search_wrap` is disabled, search result do not wrap around the end of the file
 - Setting: `search_wrap`
 - Default: `true`
+
+## Center on Match
+
+- Description: If `center_on_match` is enabled, the editor will center the cursor on the current match when searching.
+- Setting: `center_on_match`
+- Default: `false`
 
 ## Seed Search Query From Cursor
 

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -3272,15 +3272,9 @@ Non-negative `integer` values
 
 ### Search On Input
 
-- Description: Whether to search on input in project search.
-- Setting: `search_on_input`
-- Default: `false`
-
-### Search On Input Debounce Ms
-
-- Description: Debounce time in milliseconds for search on input in project search. Set to 0 to disable debouncing.
-- Setting: `search_on_input_debounce_ms`
-- Default: `200`
+- Description: Whether to search on input.
+- Setting: `search_on_input
+- Default: `true`
 
 ### Center On Match
 


### PR DESCRIPTION
Reverts the whole "project search on type" set of PRs until we figure out better ways to deal with flickering between search results appearing.

Release Notes:

- N/A 
