### PR TITLE
Fix confusing panic when D-Bus is unavailable during GPU init failure

### DIFF
--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -61,30 +61,34 @@ impl<T> ResultExt for anyhow::Result<T> {
         match self {
             Ok(v) => v,
             Err(e) => {
+                eprintln!(
+                    "{msg}: {e:?}. See https://zed.dev/docs/linux for troubleshooting steps."
+                );
+
                 use ashpd::desktop::notification::{Notification, NotificationProxy, Priority};
                 use futures::executor::block_on;
 
-                let proxy = block_on(NotificationProxy::new()).expect(msg);
+                if let Ok(proxy) = block_on(NotificationProxy::new()) {
+                    let notification_id = "dev.zed.Oops";
+                    block_on(
+                        proxy.add_notification(
+                            notification_id,
+                            Notification::new("Zed failed to launch")
+                                .body(Some(
+                                    format!(
+                                        "{e:?}. See https://zed.dev/docs/linux for troubleshooting steps."
+                                    )
+                                    .as_str(),
+                                ))
+                                .priority(Priority::High)
+                                .icon(ashpd::desktop::Icon::with_names(&[
+                                    "dialog-question-symbolic",
+                                ])),
+                        )
+                    ).ok();
+                }
 
-                let notification_id = "dev.zed.Oops";
-                block_on(
-                    proxy.add_notification(
-                        notification_id,
-                        Notification::new("Zed failed to launch")
-                            .body(Some(
-                                format!(
-                                    "{e:?}. See https://zed.dev/docs/linux for troubleshooting steps."
-                                )
-                                .as_str(),
-                            ))
-                            .priority(Priority::High)
-                            .icon(ashpd::desktop::Icon::with_names(&[
-                                "dialog-question-symbolic",
-                            ])),
-                    )
-                ).expect(msg);
-
-                panic!("{msg}");
+                std::process::exit(1);
             }
         }
     }


### PR DESCRIPTION
## Summary

- When GPU initialization fails (e.g., missing Vulkan in Docker), `notify_err` attempted to send a desktop notification via D-Bus. If D-Bus was also unavailable, `.expect()` caused a panic whose message showed the D-Bus error instead of the original GPU error, confusing users.
- Now the original error is always printed to stderr first, notification delivery gracefully degrades when D-Bus is unavailable, and the process exits cleanly with `process::exit(1)` instead of panicking.

Closes #49131

## Normal startup path

```
Zed starts
  → Detects display server (Wayland / X11)
  → Creates X11Client or WaylandClient
  → Client constructor calls BladeContext::new()
    → gpu::Context::init()
      → Loads libvulkan.so.1
      → Initializes GPU via Vulkan
    → Success → returns Ok(BladeContext)
  → .notify_err() receives Ok, returns the value directly
  → Continues to create windows, render UI ...
```

## Failure path in the issue

```
Zed starts
  → Detects X11 (DISPLAY=:0, Xvfb is running)
  → Creates X11Client
  → BladeContext::new()
    → gpu::Context::init()
      → dlopen("libvulkan.so.1") fails (not installed in Docker)
      → Returns Err("Missing Vulkan entry points: LibraryLoadFailure(...)")
    → Returns Err(...)
  → .notify_err("Unable to init GPU context") receives Err
    → Enters Err branch
    → Attempts to send desktop notification:
      → NotificationProxy::new()
        → Connects to D-Bus session bus
          → Opens unix socket /run/user/1000/bus
            → No dbus-daemon in Docker, file does not exist
          → Returns Err(Zbus(InputOutput(Os { code: 2, "No such file or directory" })))
      → .expect("Unable to init GPU context")
        → panic!  ← 💥 crashes here
        
        (Original GPU error is lost, user only sees the D-Bus error)
```

## Failure path after the fix

```
Zed starts
  → ... same as above ...
  → .notify_err("Unable to init GPU context") receives Err
    → Enters Err branch
    → eprintln! outputs the original error to stderr  ← user sees the real cause
      "Unable to init GPU context: Failed to request GPU adapter: 
       vulkan drivers/libraries could not be loaded ...
       See https://zed.dev/docs/linux ..."
    → Attempts to send desktop notification:
      → NotificationProxy::new() fails
      → if let Ok does not match, skips notification  ← graceful degradation
    → process::exit(1)  ← clean exit
```

## Test plan

- [x] Reproduced the original panic in Docker (Ubuntu 22.04 container, Xvfb running, libvulkan removed, no D-Bus)
- [x] Verified the fix shows clear GPU error on stderr and exits cleanly (Ubuntu 24.04 container, same conditions)
- [x] `cargo check -p gpui` passes

Release Notes:

- Fixed confusing panic message when running Zed in environments without both GPU drivers and D-Bus (e.g., Docker containers). The actual GPU error is now clearly reported to stderr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)