### PR TITLE
gpui: Fix content size scaling regression on X11

### DIFF
--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -28,8 +28,7 @@ use x11rb::{
 };
 
 use std::{
-    cell::RefCell, ffi::c_void, fmt::Display, num::NonZeroU32, ptr::NonNull, rc::Rc,
-    sync::Arc,
+    cell::RefCell, ffi::c_void, fmt::Display, num::NonZeroU32, ptr::NonNull, rc::Rc, sync::Arc,
 };
 
 use super::{X11Display, XINPUT_ALL_DEVICE_GROUPS, XINPUT_ALL_DEVICES};

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -28,7 +28,7 @@ use x11rb::{
 };
 
 use std::{
-    cell::RefCell, ffi::c_void, fmt::Display, num::NonZeroU32, ops::Div, ptr::NonNull, rc::Rc,
+    cell::RefCell, ffi::c_void, fmt::Display, num::NonZeroU32, ptr::NonNull, rc::Rc,
     sync::Arc,
 };
 

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -1264,12 +1264,10 @@ impl PlatformWindow for X11Window {
     }
 
     fn content_size(&self) -> Size<Pixels> {
-        // We divide by the scale factor here because this value is queried to determine how much to draw,
-        // but it will be multiplied later by the scale to adjust for scaling.
-        let state = self.0.state.borrow();
-        state
-            .content_size()
-            .map(|size| size.div(state.scale_factor))
+        // After the wgpu migration, X11WindowState::content_size() returns logical pixels
+        // (bounds.size is already divided by scale_factor in set_bounds), so no further
+        // division is needed here. This matches the Wayland implementation.
+        self.0.state.borrow().content_size()
     }
 
     fn resize(&mut self, size: Size<Pixels>) {


### PR DESCRIPTION
Closes #49172

- Fixes a regression on X11 where content size was divided by the scale factor twice after the wgpu migration, causing half-sized rendering on HiDPI screens.
- Aligns X11 [content_size()] behavior with Wayland by returning logical pixel bounds directly.

Video :
[Screencast from 2026-02-14 18-58-36.webm](https://github.com/user-attachments/assets/cf4edf3b-7b93-4ded-bf46-e900be44b22b)


Release Notes:

- N/A 