### PR TITLE
workspace: Use FolderOpen icon for active workspace project

### DIFF
--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -535,6 +535,7 @@ impl PickerDelegate for WorkspacePickerDelegate {
                 let workspace_index = thread_entry.index;
                 let multi_workspace = self.multi_workspace.clone();
                 let workspace_count = self.multi_workspace.read(cx).workspaces().len();
+                let is_active = self.active_workspace_index == workspace_index;
                 let is_hovered = self.hovered_thread_item == Some(workspace_index);
 
                 let remove_btn = IconButton::new(
@@ -568,7 +569,11 @@ impl PickerDelegate for WorkspacePickerDelegate {
                         ("workspace-item", thread_entry.index),
                         thread_subtitle.unwrap_or("New Thread".into()),
                     )
-                    .icon(IconName::Folder)
+                    .icon(if is_active {
+                        IconName::FolderOpen
+                    } else {
+                        IconName::Folder
+                    })
                     .running(running)
                     .generation_done(has_notification)
                     .selected(selected)


### PR DESCRIPTION
Differentiate the active workspace in the sidebar project list by using IconName::FolderOpen instead of IconName::Folder

Before:
<img width="1761" height="1196" alt="Image" src="https://github.com/user-attachments/assets/1a6d3708-9e3b-4ebc-b8e5-7b68194e55b7" />

After:
<img width="1717" height="1152" alt="image" src="https://github.com/user-attachments/assets/1784dc83-b38a-4f6a-8984-ccd3b877b100" />

Closes #49179

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- N/A
