### PR TITLE
extensions_ui: Respect category filter for installed extensions when searching

### DIFF
--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -487,6 +487,10 @@ impl ExtensionsPage {
                         matches!(status, ExtensionStatus::NotInstalled)
                     }
                 })
+                .filter(|(_, extension)| match self.provides_filter {
+                    Some(provides) => extension.manifest.provides.contains(&provides),
+                    None => true,
+                })
                 .map(|(ix, _)| ix),
         );
         cx.notify();


### PR DESCRIPTION
This PR updates the extensions UI to respect the category filter for already-installed extensions when searching for extensions.

Closes #48628.

Release Notes:

- The extension search will now properly respect the category filter for extensions that are already installed ([#48628](https://github.com/zed-industries/zed/issues/48628)).
