### PR TITLE
gpui: Fix swapped '<' and '>' in `guess_ascii` for Linux

### DIFF
--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -843,9 +843,9 @@ fn guess_ascii(keycode: Keycode, shift: bool) -> Option<char> {
         (57, _) => 'n',
         (58, _) => 'm',
         (59, false) => ',',
-        (59, true) => '>',
+        (59, true) => '<',
         (60, false) => '.',
-        (60, true) => '<',
+        (60, true) => '>',
         (61, false) => '/',
         (61, true) => '?',
 


### PR DESCRIPTION
the guess_ascii fallback (used for non-latin keyboard layouts) had the shifted characters for comma (keycode 59) and period (keycode 60) swapped. shift+comma should produce '<' and shift+period should produce '>', not the other way around.

Release Notes:

- N/A
