### PR TITLE
Revert "gpui: Fix RefCell panic in thermal/keyboard state callbacks"

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -732,15 +732,12 @@ impl App {
             let app = Rc::downgrade(&app);
             move || {
                 if let Some(app) = app.upgrade() {
-                    // Use try_borrow_mut because this callback can be called asynchronously
-                    // from macOS while the app is already borrowed during an update.
-                    if let Ok(mut cx) = app.try_borrow_mut() {
-                        cx.keyboard_layout = cx.platform.keyboard_layout();
-                        cx.keyboard_mapper = cx.platform.keyboard_mapper();
-                        cx.keyboard_layout_observers
-                            .clone()
-                            .retain(&(), move |callback| (callback)(&mut cx));
-                    }
+                    let cx = &mut app.borrow_mut();
+                    cx.keyboard_layout = cx.platform.keyboard_layout();
+                    cx.keyboard_mapper = cx.platform.keyboard_mapper();
+                    cx.keyboard_layout_observers
+                        .clone()
+                        .retain(&(), move |callback| (callback)(cx));
                 }
             }
         }));
@@ -749,13 +746,10 @@ impl App {
             let app = Rc::downgrade(&app);
             move || {
                 if let Some(app) = app.upgrade() {
-                    // Use try_borrow_mut because this callback can be called asynchronously
-                    // from macOS while the app is already borrowed during an update.
-                    if let Ok(mut cx) = app.try_borrow_mut() {
-                        cx.thermal_state_observers
-                            .clone()
-                            .retain(&(), move |callback| (callback)(&mut cx));
-                    }
+                    let cx = &mut app.borrow_mut();
+                    cx.thermal_state_observers
+                        .clone()
+                        .retain(&(), move |callback| (callback)(cx));
                 }
             }
         }));


### PR DESCRIPTION
Reverts zed-industries/zed#49187

fixing the crash is good, silently dropping the update seems bad. 