### PR TITLE
gpui: Defer thermal/keyboard state updates when app is borrowed

### DIFF
--- a/crates/gpui/.rules
+++ b/crates/gpui/.rules
@@ -1,0 +1,9 @@
+# GPUI crate-specific rules
+#
+# This file is non-exhaustive. Check the root .rules for general guidelines.
+
+# Platform callbacks
+
+* Platform callbacks (e.g., `on_keyboard_layout_change`, `on_thermal_state_change`) can fire
+  asynchronously from macOS while `AppCell` is already borrowed. Defer work via
+  `ForegroundExecutor::spawn` rather than borrowing `AppCell` directly in the callback body.


### PR DESCRIPTION
Follow-up to #49187.

Instead of silently skipping updates when `try_borrow_mut` fails, this PR defers the update by spawning it on the foreground executor. This ensures the state change is eventually processed after the current borrow completes.

This addresses the feedback: "if we pull something out of the event queue asynchronously and the state we want to update is unavailable, either we should put it back in the queue or if that doesn't work, retry in a loop."

Release Notes:

- N/A