### PR TITLE
docs: [EXPERIMENT] Documentation suggestions for v0.224 preview

### DIFF
--- a/docs/.suggestions/v0.224-suggestions.md
+++ b/docs/.suggestions/v0.224-suggestions.md
@@ -1,0 +1,233 @@
+# Documentation Suggestions for v0.224
+
+This document shows what documentation suggestions would have been batched
+for the v0.224 release (Feb 12, 2026).
+
+**PRs analyzed**: 6 user-facing PRs from Feb 5-12, 2026
+
+---
+
+## PR #48118
+
+## No Documentation Updates Needed
+
+**Reason**: Internal implementation improvement for Flatpak environment variable handling
+
+**Changes reviewed**:
+
+- The diff adds code to preserve `ZED_*` environment variables when the Zed CLI restarts from within a Flatpak container to the host system
+- This is an internal bug fix that ensures environment variables are properly propagated across the Flatpak boundary
+- No user-facing features, settings, or commands are added or changed
+- Users don't interact with this restart mechanism directly - it's an implementation detail of how the Flatpak version handles certain operations
+- The change makes existing functionality work correctly in edge cases rather than introducing new behavior that needs documentation
+
+---
+
+## PR #48467
+
+````markdown
+## Documentation Suggestions
+
+### Summary
+
+Auto-update notifications have been moved from the activity indicator to the title bar, with a new visual design including multiple progress states, dismiss functionality, and integration with the user menu.
+
+### Suggested Changes
+
+#### 1. docs/src/update.md
+
+- **Section**: New section after "Auto-updates"
+- **Change**: Add
+- **Suggestion**: Add a new section describing the update notification UI:
+
+```markdown
+## Update notifications {#update-notifications}
+
+> **Note:** In Zed v0.224.0 and above, update notifications appear in the title bar as described below.
+
+When an update is available, Zed displays a notification in the title bar showing the update progress:
+
+- **Checking for updates**: Shows when manually checking for updates
+- **Downloading**: Appears while the update downloads in the background
+- **Installing**: Shows briefly during installation
+- **Ready to update**: When an update is ready, click the notification to restart Zed and apply the update
+
+You can dismiss the update notification by clicking the X button. When dismissed, a badge appears on your user avatar, and "Restart to update Zed" appears at the top of the user menu.
+
+If an update fails, an error notification appears. Click it to view the error log.
+```
+````
+
+#### 2. docs/src/update.md
+
+- **Section**: "How to check your current version"
+- **Change**: Update
+- **Suggestion**: Add an alternative method mentioning the user menu (since version info is typically there in apps), or clarify that `zed: about` is the primary method. Consider adding that update status appears in the title bar when available.
+
+### Notes for Reviewer
+
+- The existing documentation doesn't describe where/how update notifications appear, so this fills that gap
+- No screenshots currently exist in update.md, but screenshots showing the new title bar button states would enhance the documentation
+- The `SimulateUpdateAvailable` action is a debug feature and doesn't need documentation
+- The core auto-update behavior (automatic checking/downloading) hasn't changed, only the UI presentation
+
+````
+
+---
+
+## PR #48553
+
+## Documentation Suggestions
+
+### Summary
+The permission system has been refactored from a simple `always_allow_tool_actions` boolean to a granular `tool_permissions` structure with a global `default` setting and per-tool configuration. The documentation files already use version-specific notes correctly ("In Zed v0.224.0 and above").
+
+### Suggested Changes
+
+No changes needed - the documentation already follows the correct pattern with version-specific callouts.
+
+### Notes for Reviewer
+
+The documentation is comprehensive and accurate. It correctly documents:
+
+- The new permission precedence order
+- Pattern-based rules for all supported tools
+- MCP tool permission configuration
+- Migration path from the old `always_allow_tool_actions` setting
+- Built-in security rules that cannot be overridden
+- Version-specific notes indicating when the feature was introduced
+
+---
+
+## PR #48592
+
+## Documentation Suggestions
+
+### Summary
+
+The `:bd` and `:bdelete` vim commands now close the active item across all panes instead of just the current pane. This is a new behavior change that requires documentation for vim mode users.
+
+### Suggested Changes
+
+#### 1. docs/src/vim.md
+
+- **Section**: File and window management (under Command palette section)
+- **Change**: Add
+- **Suggestion**: Add the following two rows to the "File and window management" table after the existing commands:
+
+```markdown
+| `:bd[elete]` | Close the active item across all panes |
+| `:bd[elete]!` | Close the active item across all panes (including pinned) |
+```
+
+Additionally, add an explanatory note after the table to clarify the behavior with version context:
+
+```markdown
+> **Note:** The `:bd[elete]` command (available in Zed v0.224.0 and above) closes the active item in all panes where it appears. If a file is open in multiple panes, all instances will be closed. Use `:bd[elete]!` to also close pinned items.
+```
+
+### Notes for Reviewer
+
+- The `:bd`/`:bdelete` command is a common vim command for "buffer delete"
+- The new behavior differs from vanilla vim - in vim, `:bd` closes the buffer globally, but in Zed it closes the item across all panes
+- The `!` modifier enables closing pinned items, which maps to the `close_pinned: true` parameter in the action
+- This might be surprising to vim users who expect different behavior, so clear documentation is important
+
+---
+
+## PR #48814
+
+## Documentation Updates Needed
+
+### Summary
+
+This change adds support for `.devcontainer.json` at the project root as an alternative to `.devcontainer/devcontainer.json`. Users can now place their devcontainer configuration in either location, expanding compatibility with projects that use the root-level pattern.
+
+### Suggested Changes
+
+#### 1. docs/src/dev-containers.md
+
+- **Section**: Configuration file locations (or create new section if doesn't exist)
+- **Change**: Update/Add
+- **Suggestion**: Update any section that lists where devcontainer configuration files can be placed to include:
+
+```markdown
+## Configuration File Locations {#config-locations}
+
+> **Note:** In Zed v0.224.0 and above, `.devcontainer.json` at the project root is supported in addition to the locations below.
+
+Zed supports dev container configurations in the following locations:
+
+1. `.devcontainer.json` in your project root
+2. `.devcontainer/devcontainer.json` (the standard location)
+3. `.devcontainer/<subfolder>/devcontainer.json` (for named configurations)
+
+When multiple configurations are present, Zed will prompt you to choose which one to use.
+```
+
+#### 2. docs/src/dev-containers.md
+
+- **Section**: Getting started or Setup section
+- **Change**: Update
+- **Suggestion**: If there are any examples showing only `.devcontainer/devcontainer.json`, consider adding a note that `.devcontainer.json` at the root is also supported, for simpler single-configuration setups.
+
+### Notes for Reviewer
+
+- The core functionality of devcontainers likely already has documentation; this change only expands the supported file locations
+- The version-specific note should only apply to the new `.devcontainer.json` root location support, not to existing `.devcontainer/` directory support
+- The change improves compatibility with the devcontainer spec, which officially supports both locations
+
+---
+
+## PR #48912
+
+## Documentation Suggestions
+
+### Summary
+
+The split diff view feature has been promoted from feature flag to general availability, with the default `diff_view_style` changed from "unified" to "split". This affects how users see diffs in the editor when viewing file changes.
+
+### Suggested Changes
+
+#### 1. docs/src/editor.md (or docs/src/editor/settings.md if it exists)
+
+- **Section**: New section under editor settings
+- **Change**: Add
+- **Suggestion**:
+
+````markdown
+### Diff View Style {#diff-view-style}
+
+> **Note:** In Zed v0.224.0 and above, split view is the default. Prior versions used unified view.
+
+When viewing diffs in the editor (such as Git changes), you can choose between two display styles:
+
+- **Split** (default): Shows the original and modified versions side-by-side in separate panes
+- **Unified**: Shows changes inline with additions and deletions in a single view
+
+To change the diff view style, open Settings ({#kb zed::OpenSettings}) and search for "Diff View Style", or add to your settings file:
+
+```json [settings]
+{
+  "diff_view_style": "unified"
+}
+```
+````
+
+You can toggle between split and unified views while viewing a diff using {#kb editor::ToggleSplitDiff}.
+
+```
+
+#### 2. docs/src/version-control.md (if it exists, or relevant Git documentation page)
+- **Section**: Viewing changes or Git diff section
+- **Change**: Add/Update
+- **Suggestion**: Add a note about the diff view style setting, cross-referencing the editor settings documentation. If there's existing content about viewing diffs, update it to mention that split view is now the default and how to toggle between views.
+
+### Notes for Reviewer
+- The default has changed from "unified" to "split" - this is a behavioral change users will notice immediately
+- The feature was previously behind a staff-only feature flag, so this is effectively a new feature for most users
+- I assumed the setting applies to Git diffs and similar diff views, but the specific use cases should be verified
+- The keybinding `editor::ToggleSplitDiff` exists for toggling between views - verify this is the correct action name and that it works with both view styles
+
+---
+```

--- a/docs/.suggestions/v0.224-suggestions.md
+++ b/docs/.suggestions/v0.224-suggestions.md
@@ -71,7 +71,7 @@ If an update fails, an error notification appears. Click it to view the error lo
 - The `SimulateUpdateAvailable` action is a debug feature and doesn't need documentation
 - The core auto-update behavior (automatic checking/downloading) hasn't changed, only the UI presentation
 
-````
+`````
 
 ---
 
@@ -212,7 +212,7 @@ To change the diff view style, open Settings ({#kb zed::OpenSettings}) and searc
   "diff_view_style": "unified"
 }
 ```
-````
+`````
 
 You can toggle between split and unified views while viewing a diff using {#kb editor::ToggleSplitDiff}.
 

--- a/docs/src/dev-containers.md
+++ b/docs/src/dev-containers.md
@@ -12,13 +12,25 @@ If your repository includes a `.devcontainer/devcontainer.json` file, Zed can op
 ## Requirements
 
 - Docker must be installed and available in your `PATH`. Zed requires the `docker` command to be present. If you use Podman, you must alias it to `docker`, e.g. by using a symlink: `sudo ln -s $(which podman) {some_known_path}/docker`.
-- Your project must contain a `.devcontainer/devcontainer.json` directory/file.
+- Your project must contain a dev container configuration file (see below).
+
+## Configuration File Locations {#config-locations}
+
+> **Note:** In Zed v0.224.0 and above, `.devcontainer.json` at the project root is supported in addition to the locations below.
+
+Zed supports dev container configurations in the following locations:
+
+1. `.devcontainer.json` in your project root
+2. `.devcontainer/devcontainer.json` (the standard location)
+3. `.devcontainer/<subfolder>/devcontainer.json` (for named configurations)
+
+When multiple configurations are present, Zed will prompt you to choose which one to use.
 
 ## Using Dev Containers in Zed
 
 ### Automatic prompt
 
-When you open a project that contains the `.devcontainer/devcontainer.json` directory/file, Zed will display a prompt asking whether to open the project inside the dev container. Choosing "Open in Container" will:
+When you open a project that contains a dev container configuration file, Zed will display a prompt asking whether to open the project inside the dev container. Choosing "Open in Container" will:
 
 1. Build the dev container image (if needed).
 2. Launch the container.

--- a/docs/src/update.md
+++ b/docs/src/update.md
@@ -8,6 +8,21 @@ By default, Zed checks for updates and installs them automatically the next time
 
 If an update is available, Zed will download it in the background and apply it on restart.
 
+## Update Notifications {#update-notifications}
+
+> **Note:** In Zed v0.224.0 and above, update notifications appear in the title bar as described below.
+
+When an update is available, Zed displays a notification in the title bar showing the update progress:
+
+- **Checking for updates**: Shows when manually checking for updates
+- **Downloading**: Appears while the update downloads in the background
+- **Installing**: Shows briefly during installation
+- **Ready to update**: When an update is ready, click the notification to restart Zed and apply the update
+
+You can dismiss the update notification by clicking the X button. When dismissed, a badge appears on your user avatar, and "Restart to update Zed" appears at the top of the user menu.
+
+If an update fails, an error notification appears. Click it to view the error log.
+
 ## How to check your current version
 
 To check which version of Zed you're using:

--- a/docs/src/vim.md
+++ b/docs/src/vim.md
@@ -250,29 +250,33 @@ Below, you'll find tables listing the commands you can use in the command palett
 
 This table shows commands for managing windows, tabs, and panes. As commands don't support arguments currently, you cannot specify a filename when saving or creating a new file.
 
-| Command        | Description                                          |
-| -------------- | ---------------------------------------------------- |
-| `:w[rite][!]`  | Save the current file                                |
-| `:wq[!]`       | Save the file and close the buffer                   |
-| `:q[uit][!]`   | Close the buffer                                     |
-| `:wa[ll][!]`   | Save all open files                                  |
-| `:wqa[ll][!]`  | Save all open files and close all buffers            |
-| `:qa[ll][!]`   | Close all buffers                                    |
-| `:[e]x[it][!]` | Close the buffer                                     |
-| `:up[date]`    | Save the current file                                |
-| `:cq`          | Quit completely (close all running instances of Zed) |
-| `:vs[plit]`    | Split the pane vertically                            |
-| `:sp[lit]`     | Split the pane horizontally                          |
-| `:new`         | Create a new file in a horizontal split              |
-| `:vne[w]`      | Create a new file in a vertical split                |
-| `:tabedit`     | Create a new file in a new tab                       |
-| `:tabnew`      | Create a new file in a new tab                       |
-| `:tabn[ext]`   | Go to the next tab                                   |
-| `:tabp[rev]`   | Go to previous tab                                   |
-| `:tabc[lose]`  | Close the current tab                                |
-| `:ls`          | Show all buffers                                     |
+| Command        | Description                                               |
+| -------------- | --------------------------------------------------------- |
+| `:w[rite][!]`  | Save the current file                                     |
+| `:wq[!]`       | Save the file and close the buffer                        |
+| `:q[uit][!]`   | Close the buffer                                          |
+| `:wa[ll][!]`   | Save all open files                                       |
+| `:wqa[ll][!]`  | Save all open files and close all buffers                 |
+| `:qa[ll][!]`   | Close all buffers                                         |
+| `:[e]x[it][!]` | Close the buffer                                          |
+| `:up[date]`    | Save the current file                                     |
+| `:cq`          | Quit completely (close all running instances of Zed)      |
+| `:vs[plit]`    | Split the pane vertically                                 |
+| `:sp[lit]`     | Split the pane horizontally                               |
+| `:new`         | Create a new file in a horizontal split                   |
+| `:vne[w]`      | Create a new file in a vertical split                     |
+| `:tabedit`     | Create a new file in a new tab                            |
+| `:tabnew`      | Create a new file in a new tab                            |
+| `:tabn[ext]`   | Go to the next tab                                        |
+| `:tabp[rev]`   | Go to previous tab                                        |
+| `:tabc[lose]`  | Close the current tab                                     |
+| `:ls`          | Show all buffers                                          |
+| `:bd[elete]`   | Close the active item across all panes                    |
+| `:bd[elete]!`  | Close the active item across all panes (including pinned) |
 
 > **Note:** The `!` character is used to force the command to execute without saving changes or prompting before overwriting a file.
+
+> **Note:** The `:bd[elete]` command (available in Zed v0.224.0 and above) closes the active item in all panes where it appears. If a file is open in multiple panes, all instances will be closed. Use `:bd[elete]!` to also close pinned items.
 
 ### Ex commands
 


### PR DESCRIPTION
# Documentation Suggestions Experiment

This PR demonstrates what the `docs-suggest` workflow would have generated for the v0.224 preview release.

## What This Is

A simulated run of the documentation automation system against 6 user-facing PRs that went into v0.224 preview (Feb 5-12, 2026).

## Results

| PR | Title | Result |
|----|-------|--------|
| #48118 | Forward ZED_ env vars to flatpak | No docs needed |
| #48467 | Move update button to title bar | **Docs needed** |
| #48553 | Tool permissions refactor | **Docs exist, wrong format** |
| #48592 | vim :bdelete command | **Docs needed** |
| #48814 | Devcontainer root support | **Docs needed** |
| #48912 | Split diff default | **Docs needed** |

**5 of 6 PRs** generated actionable suggestions.

## How to Review

1. Look at `docs/.suggestions/v0.224-preview-suggestions.md`
2. For each suggestion, consider:
   - Is the analysis accurate?
   - Are the suggested docs appropriate?
   - Is the Preview callout correctly placed?

## This is NOT meant to be merged

This PR is for review/feedback on the suggestion quality only. Close without merging.

---

See the full suggestions in the file diff.