### PR TITLE
editor: Fix to remove non-functional folding creases from the gutter

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -27496,7 +27496,7 @@ impl EditorSnapshot {
             }
         }
 
-        is_foldable |= self.starts_indent(buffer_row);
+        is_foldable |= !self.use_lsp_folding_ranges && self.starts_indent(buffer_row);
 
         if folded || (is_foldable && (row_contains_cursor || self.gutter_hovered)) {
             Some(


### PR DESCRIPTION
Lsp-based folding disables indentation-based folding. Even though indentation-based folding is non-functional, the crease icon is still displayed in the gutter. This PR fixes this mismatch.

Before:
<img width="651" height="199" alt="before" src="https://github.com/user-attachments/assets/ebd202e8-9eda-43c9-adbd-767e9802e590" />

After:
<img width="666" height="197" alt="after" src="https://github.com/user-attachments/assets/b498e325-cd06-4c51-afdb-fcda4f1a25e6" />


Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Removed non-functional folding creases from the gutter.
