### PR TITLE
remote: Auto-reconnect terminals after SSH reconnection

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -398,6 +398,7 @@ pub enum Event {
     WorkspaceEditApplied(ProjectTransaction),
     AgentLocationChanged,
     BufferEdited,
+    ReconnectedToRemote,
 }
 
 pub struct AgentLocationChanged;
@@ -3505,6 +3506,9 @@ impl Project {
                     lsp_store.disconnected_from_ssh_remote()
                 });
                 cx.emit(Event::DisconnectedFromRemote { server_not_running });
+            }
+            remote::RemoteClientEvent::Reconnected => {
+                cx.emit(Event::ReconnectedToRemote);
             }
         }
     }

--- a/crates/remote/src/remote_client.rs
+++ b/crates/remote/src/remote_client.rs
@@ -237,6 +237,10 @@ impl State {
         matches!(self, Self::ServerNotRunning)
     }
 
+    fn is_connected(&self) -> bool {
+        matches!(self, Self::Connected { .. })
+    }
+
     fn is_reconnecting(&self) -> bool {
         matches!(self, Self::Reconnecting { .. })
     }
@@ -325,6 +329,7 @@ pub struct RemoteClient {
 #[derive(Debug)]
 pub enum RemoteClientEvent {
     Disconnected { server_not_running: bool },
+    Reconnected,
 }
 
 impl EventEmitter<RemoteClientEvent> for RemoteClient {}
@@ -708,7 +713,10 @@ impl RemoteClient {
                     }
                 });
 
-                if this.state_is(State::is_reconnect_failed) {
+                if this.state_is(State::is_connected) {
+                    cx.emit(RemoteClientEvent::Reconnected);
+                    Ok(())
+                } else if this.state_is(State::is_reconnect_failed) {
                     this.reconnect(cx)
                 } else if this.state_is(State::is_reconnect_exhausted) {
                     Ok(())

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -2277,6 +2277,14 @@ impl Terminal {
         self.vi_mode_enabled
     }
 
+    pub fn has_exited(&self) -> bool {
+        self.child_exited.is_some()
+    }
+
+    pub fn is_remote(&self) -> bool {
+        self.is_remote_terminal
+    }
+
     pub fn clone_builder(&self, cx: &App, cwd: Option<PathBuf>) -> Task<Result<TerminalBuilder>> {
         let working_directory = self.working_directory().or_else(|| cwd);
         TerminalBuilder::new(

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -260,12 +260,23 @@ impl TerminalView {
             )
         });
 
-        let subscriptions = vec![
+        let mut subscriptions = vec![
             focus_in,
             focus_out,
             cx.observe(&blink_manager, |_, _, cx| cx.notify()),
             cx.observe_global::<SettingsStore>(Self::settings_changed),
         ];
+        if let Some(project) = project.upgrade() {
+            subscriptions.push(cx.subscribe_in(
+                &project,
+                window,
+                |this, _project, event, window, cx| {
+                    if let project::Event::ReconnectedToRemote = event {
+                        this.handle_remote_reconnection(window, cx);
+                    }
+                },
+            ));
+        }
 
         Self {
             terminal,
@@ -294,6 +305,40 @@ impl TerminalView {
             _subscriptions: subscriptions,
             _terminal_subscriptions: terminal_subscriptions,
         }
+    }
+
+    fn handle_remote_reconnection(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let is_remote = self.terminal.read(cx).is_remote();
+        let has_exited = self.terminal.read(cx).has_exited();
+
+        if !is_remote || !has_exited {
+            return;
+        }
+
+        let Ok(builder_task) = self.project.update(cx, |project, cx| {
+            project.clone_terminal(&self.terminal, cx, None)
+        }) else {
+            return;
+        };
+
+        let workspace = self.workspace.clone();
+        cx.spawn_in(window, async move |this, cx| {
+            let new_terminal = builder_task.await?;
+            this.update_in(cx, |this, window, cx| {
+                let terminal_subscriptions = subscribe_for_terminal_events(
+                    &new_terminal,
+                    workspace,
+                    window,
+                    cx,
+                );
+                this._terminal_subscriptions = terminal_subscriptions;
+                this.terminal = new_terminal;
+                this.scroll_handle = TerminalScrollHandle::new(this.terminal.read(cx));
+                cx.notify();
+            })?;
+            anyhow::Ok(())
+        })
+        .detach_and_log_err(cx);
     }
 
     /// Enable 'embedded' mode where the terminal displays the full content with an optional limit of lines.


### PR DESCRIPTION
## Summary

- Add a `Reconnected` event to `RemoteClientEvent` so subsystems can react when an SSH connection is successfully re-established
- Terminal views now subscribe to this event and automatically recreate dead remote terminal SSH sessions, replacing the frozen shell with a fresh one
- Add `has_exited()` and `is_remote()` public accessors to `Terminal`

Fixes the terminal-related part of #47003. After investigation, AI agent conversations and file review state are already preserved across successful reconnections (in-memory entities survive the reconnect cycle), so only terminal sessions needed fixing.

## How it works

1. `RemoteClient` emits `Reconnected` after transitioning from `Reconnecting` → `Connected`
2. `Project` forwards this as `ReconnectedToRemote`
3. `TerminalView` subscribes to the event — when received, checks if the terminal is a dead remote terminal (`is_remote() && has_exited()`)
4. If so, uses `clone_terminal()` to create a new SSH shell session with the same parameters, replacing the frozen terminal in-place

## Test plan

- [x] Build dev Zed with the fix
- [x] Connect to a remote host via SSH remote development
- [x] Open a terminal, run `top`
- [x] Kill the SSH master process (`kill <pid>` of `ssh -N ControlMaster=yes ...`)
- [x] Wait ~25s for heartbeat timeout → automatic reconnection
- [x] Verify terminal tab auto-recovers to a new working shell (instead of staying permanently frozen)
- [x] Verify new terminal accepts input normally

Release Notes:

- Fixed remote terminals staying permanently frozen after SSH reconnection by automatically recreating terminal sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)