### PR TITLE
git_ui: Add git init button to empty repository state

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -228,6 +228,11 @@ pub fn register(workspace: &mut Workspace) {
     workspace.register_action(|workspace, _: &ExpandCommitEditor, window, cx| {
         CommitModal::toggle(workspace, None, window, cx)
     });
+    workspace.register_action(|workspace, _: &git::Init, window, cx| {
+        if let Some(panel) = workspace.panel::<GitPanel>(cx) {
+            panel.update(cx, |panel, cx| panel.git_init(window, cx));
+        }
+    });
 }
 
 #[derive(Debug, Clone)]

--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -1671,9 +1671,12 @@ impl RenderOnce for ProjectDiffEmptyState {
             v_flex()
                 .gap_1()
                 .when(self.no_repo, |this| {
-                    // TODO: add git init
                     this.text_center()
                         .child(Label::new("No Repository").color(Color::Muted))
+                        .child(
+                            Button::new("initialize-repo", "Initialize Repository")
+                                .on_click(move |_, _, cx| cx.dispatch_action(&git::Init)),
+                        )
                 })
                 .map(|this| {
                     if not_ahead_or_behind && self.current_branch.is_some() {


### PR DESCRIPTION
Release Notes:

- Git: Added `git init` button that quickly allows to turn an empty repository into a Git repository.

https://github.com/user-attachments/assets/58b0d49f-b813-4d1c-a086-4bd21d226916
