### PR TITLE
markdown_preview: Allow copying rendered preview as text

### DIFF
--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -1650,6 +1650,8 @@ pub struct ClipboardItem {
 pub enum ClipboardEntry {
     /// A string entry
     String(ClipboardString),
+    /// An HTML entry
+    Html(String),
     /// An image entry
     Image(Image),
     /// A file entry
@@ -1662,6 +1664,19 @@ impl ClipboardItem {
         Self {
             entries: vec![ClipboardEntry::String(ClipboardString::new(text))],
         }
+    }
+
+    /// Create a new ClipboardItem::Html
+    pub fn new_html(html: String) -> Self {
+        Self {
+            entries: vec![ClipboardEntry::Html(html)],
+        }
+    }
+
+    /// Add an HTML entry to the item
+    pub fn with_html(mut self, html: String) -> Self {
+        self.entries.push(ClipboardEntry::Html(html));
+        self
     }
 
     /// Create a new ClipboardItem::String with the given text and associated metadata
@@ -1688,6 +1703,21 @@ impl ClipboardItem {
         Self {
             entries: vec![ClipboardEntry::Image(image.clone())],
         }
+    }
+
+    pub fn entries(&self) -> &[ClipboardEntry] {
+        &self.entries
+    }
+
+    pub fn into_entries(self) -> Vec<ClipboardEntry> {
+        self.entries
+    }
+
+    /// Returns true if the item contains an HTML entry.
+    pub fn has_html(&self) -> bool {
+        self.entries
+            .iter()
+            .any(|e| matches!(e, ClipboardEntry::Html(_)))
     }
 
     /// Concatenates together all the ClipboardString entries in the item.

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -839,6 +839,9 @@ impl LinuxClient for WaylandClient {
             let serial = state.serial_tracker.get(SerialKind::KeyPress);
             let data_source = primary_selection_manager.create_source(&state.globals.qh, ());
             for mime_type in TEXT_MIME_TYPES {
+                if mime_type == TEXT_HTML_MIME_TYPE && !item.has_html() {
+                    continue;
+                }
                 data_source.offer(mime_type.to_string());
             }
             data_source.offer(state.clipboard.self_mime());
@@ -859,6 +862,9 @@ impl LinuxClient for WaylandClient {
             let serial = state.serial_tracker.get(SerialKind::KeyPress);
             let data_source = data_device_manager.create_data_source(&state.globals.qh, ());
             for mime_type in TEXT_MIME_TYPES {
+                if mime_type == TEXT_HTML_MIME_TYPE && !item.has_html() {
+                    continue;
+                }
                 data_source.offer(mime_type.to_string());
             }
             data_source.offer(state.clipboard.self_mime());

--- a/crates/gpui/src/platform/linux/wayland/clipboard.rs
+++ b/crates/gpui/src/platform/linux/wayland/clipboard.rs
@@ -15,10 +15,10 @@ use crate::{
     platform::linux::platform::read_fd,
 };
 
-/// Text mime types that we'll offer to other programs.
-pub(crate) const TEXT_MIME_TYPES: [&str; 3] =
-    ["text/plain;charset=utf-8", "UTF8_STRING", "text/plain"];
+pub(crate) const TEXT_MIME_TYPES: [&str; 4] =
+    ["text/plain;charset=utf-8", "UTF8_STRING", "text/plain", "text/html"];
 pub(crate) const FILE_LIST_MIME_TYPE: &str = "text/uri-list";
+pub(crate) const TEXT_HTML_MIME_TYPE: &str = "text/html";
 
 /// Text mime types that we'll accept from other programs.
 pub(crate) const ALLOWED_TEXT_MIME_TYPES: [&str; 2] = ["text/plain;charset=utf-8", "UTF8_STRING"];
@@ -116,7 +116,11 @@ impl<T: ReceiveData> DataOffer<T> {
         // copying from eg: firefox inserts a lot of blank
         // lines, and that is super annoying.
         let result = text_content.replace("\r\n", "\n");
-        Some(ClipboardItem::new_string(result))
+        if mime_type == TEXT_HTML_MIME_TYPE {
+            Some(ClipboardItem::new_html(result))
+        } else {
+            Some(ClipboardItem::new_string(result))
+        }
     }
 
     fn read_image(&self, connection: &Connection) -> Option<ClipboardItem> {
@@ -179,13 +183,41 @@ impl Clipboard {
         self.self_mime.clone()
     }
 
-    pub fn send(&self, _mime_type: String, fd: OwnedFd) {
+    pub fn send(&self, mime_type: String, fd: OwnedFd) {
+        if mime_type == TEXT_HTML_MIME_TYPE {
+            if let Some(html) = self.contents.as_ref().and_then(|contents| {
+                contents.entries().iter().find_map(|entry| {
+                    if let ClipboardEntry::Html(html) = entry {
+                        Some(html)
+                    } else {
+                        None
+                    }
+                })
+            }) {
+                self.send_internal(fd, html.as_bytes().to_owned());
+                return;
+            }
+        }
         if let Some(text) = self.contents.as_ref().and_then(|contents| contents.text()) {
             self.send_internal(fd, text.as_bytes().to_owned());
         }
     }
 
-    pub fn send_primary(&self, _mime_type: String, fd: OwnedFd) {
+    pub fn send_primary(&self, mime_type: String, fd: OwnedFd) {
+        if mime_type == TEXT_HTML_MIME_TYPE {
+            if let Some(html) = self.primary_contents.as_ref().and_then(|contents| {
+                contents.entries().iter().find_map(|entry| {
+                    if let ClipboardEntry::Html(html) = entry {
+                        Some(html)
+                    } else {
+                        None
+                    }
+                })
+            }) {
+                self.send_internal(fd, html.as_bytes().to_owned());
+                return;
+            }
+        }
         if let Some(text) = self
             .primary_contents
             .as_ref()
@@ -205,9 +237,19 @@ impl Clipboard {
             return self.contents.clone();
         }
 
-        let item = offer
-            .read_text(&self.connection)
-            .or_else(|| offer.read_image(&self.connection))?;
+        let item = if offer.has_mime_type(TEXT_HTML_MIME_TYPE) {
+            offer
+                .read_bytes(&self.connection, TEXT_HTML_MIME_TYPE)
+                .and_then(|bytes| {
+                    String::from_utf8(bytes)
+                        .ok()
+                        .map(|html| ClipboardItem::new_html(html.replace("\r\n", "\n")))
+                })
+        } else {
+            None
+        }
+        .or_else(|| offer.read_text(&self.connection))
+        .or_else(|| offer.read_image(&self.connection))?;
 
         self.cached_read = Some(item.clone());
         Some(item)
@@ -223,9 +265,19 @@ impl Clipboard {
             return self.primary_contents.clone();
         }
 
-        let item = offer
-            .read_text(&self.connection)
-            .or_else(|| offer.read_image(&self.connection))?;
+        let item = if offer.has_mime_type(TEXT_HTML_MIME_TYPE) {
+            offer
+                .read_bytes(&self.connection, TEXT_HTML_MIME_TYPE)
+                .and_then(|bytes| {
+                    String::from_utf8(bytes)
+                        .ok()
+                        .map(|html| ClipboardItem::new_html(html.replace("\r\n", "\n")))
+                })
+        } else {
+            None
+        }
+        .or_else(|| offer.read_text(&self.connection))
+        .or_else(|| offer.read_image(&self.connection))?;
 
         self.cached_primary_read = Some(item.clone());
         Some(item)

--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -1614,8 +1614,8 @@ impl LinuxClient for X11Client {
         let mut state = self.0.borrow_mut();
         state
             .clipboard
-            .set_text(
-                std::borrow::Cow::Owned(item.text().unwrap_or_default()),
+            .write(
+                item.clone(),
                 clipboard::ClipboardKind::Clipboard,
                 clipboard::WaitConfig::None,
             )

--- a/crates/gpui/src/platform/linux/x11/clipboard.rs
+++ b/crates/gpui/src/platform/linux/x11/clipboard.rs
@@ -75,8 +75,7 @@ x11rb::atom_manager! {
         // See: https://tronche.com/gui/x/icccm/sec-2.html#s-2.6.2
         TEXT,
         TEXT_MIME_UNKNOWN: b"text/plain",
-
-        // HTML: b"text/html",
+        TEXT_HTML: b"text/html",
         // URI_LIST: b"text/uri-list",
 
         PNG__MIME: ImageFormat::mime_type(ImageFormat::Png ).as_bytes(),
@@ -989,27 +988,55 @@ impl Clipboard {
         self.inner.write(data, selection, wait)
     }
 
-    #[allow(unused)]
-    pub(crate) fn set_image(
-        &self,
-        image: Image,
-        selection: ClipboardKind,
-        wait: WaitConfig,
-    ) -> Result<()> {
-        let format = match image.format {
-            ImageFormat::Png => self.inner.atoms.PNG__MIME,
-            ImageFormat::Jpeg => self.inner.atoms.JPEG_MIME,
-            ImageFormat::Webp => self.inner.atoms.WEBP_MIME,
-            ImageFormat::Gif => self.inner.atoms.GIF__MIME,
-            ImageFormat::Svg => self.inner.atoms.SVG__MIME,
-            ImageFormat::Bmp => self.inner.atoms.BMP__MIME,
-            ImageFormat::Tiff => self.inner.atoms.TIFF_MIME,
             ImageFormat::Ico => self.inner.atoms.ICO__MIME,
         };
         let data = vec![ClipboardData {
             bytes: image.bytes,
-            format: self.inner.atoms.PNG__MIME,
+            format: format,
         }];
+        self.inner.write(data, selection, wait)
+    }
+
+    pub(crate) fn write(
+        &self,
+        item: ClipboardItem,
+        selection: ClipboardKind,
+        wait: WaitConfig,
+    ) -> Result<()> {
+        let mut data = Vec::new();
+        for entry in item.into_entries() {
+            match entry {
+                ClipboardEntry::String(s) => {
+                    data.push(ClipboardData {
+                        bytes: s.text.into_bytes(),
+                        format: self.inner.atoms.UTF8_STRING,
+                    });
+                }
+                ClipboardEntry::Html(html) => {
+                    data.push(ClipboardData {
+                        bytes: html.into_bytes(),
+                        format: self.inner.atoms.TEXT_HTML,
+                    });
+                }
+                ClipboardEntry::Image(image) => {
+                    let format = match image.format {
+                        ImageFormat::Png => self.inner.atoms.PNG__MIME,
+                        ImageFormat::Jpeg => self.inner.atoms.JPEG_MIME,
+                        ImageFormat::Webp => self.inner.atoms.WEBP_MIME,
+                        ImageFormat::Gif => self.inner.atoms.GIF__MIME,
+                        ImageFormat::Svg => self.inner.atoms.SVG__MIME,
+                        ImageFormat::Bmp => self.inner.atoms.BMP__MIME,
+                        ImageFormat::Tiff => self.inner.atoms.TIFF_MIME,
+                        ImageFormat::Ico => self.inner.atoms.ICO__MIME,
+                    };
+                    data.push(ClipboardData {
+                        bytes: image.bytes,
+                        format,
+                    });
+                }
+                _ => {}
+            }
+        }
         self.inner.write(data, selection, wait)
     }
 
@@ -1034,8 +1061,9 @@ impl Clipboard {
             ImageFormat::Tiff,
         ];
 
-        const TEXT_FORMAT_COUNT: usize = 6;
+        const TEXT_FORMAT_COUNT: usize = 7;
         let text_format_atoms: [Atom; TEXT_FORMAT_COUNT] = [
+            self.inner.atoms.TEXT_HTML,
             self.inner.atoms.UTF8_STRING,
             self.inner.atoms.UTF8_MIME_0,
             self.inner.atoms.UTF8_MIME_1,
@@ -1073,6 +1101,11 @@ impl Clipboard {
                     bytes,
                 }));
             }
+        }
+
+        if result.format == self.inner.atoms.TEXT_HTML {
+            let html = String::from_utf8(result.bytes).map_err(|_| Error::ConversionFailure)?;
+            return Ok(ClipboardItem::new_html(html));
         }
 
         let text = if result.format == self.inner.atoms.STRING {

--- a/crates/gpui/src/platform/mac/pasteboard.rs
+++ b/crates/gpui/src/platform/mac/pasteboard.rs
@@ -50,17 +50,23 @@ impl Pasteboard {
 
             if msg_send![pasteboard_types, containsObject: string_type] {
                 let data = self.inner.dataForType(string_type);
-                if data == nil {
-                    return None;
-                } else if data.bytes().is_null() {
-                    // https://developer.apple.com/documentation/foundation/nsdata/1410616-bytes?language=objc
-                    // "If the length of the NSData object is 0, this property returns nil."
-                    return Some(self.read_string(&[]));
-                } else {
+                if data != nil && !data.bytes().is_null() {
                     let bytes =
                         slice::from_raw_parts(data.bytes() as *mut u8, data.length() as usize);
-
                     return Some(self.read_string(bytes));
+                }
+            }
+
+            let html_type: id = ns_string("public.html");
+            if msg_send![pasteboard_types, containsObject: html_type] {
+                let data = self.inner.dataForType(html_type);
+                if data != nil && !data.bytes().is_null() {
+                    let bytes =
+                        slice::from_raw_parts(data.bytes() as *mut u8, data.length() as usize);
+                    let html = String::from_utf8_lossy(bytes).to_string();
+                    return Some(ClipboardItem {
+                        entries: vec![ClipboardEntry::Html(html)],
+                    });
                 }
             }
 
@@ -135,53 +141,26 @@ impl Pasteboard {
 
     pub fn write(&self, item: ClipboardItem) {
         unsafe {
-            match item.entries.as_slice() {
-                [] => {
-                    // Writing an empty list of entries just clears the clipboard.
-                    self.inner.clearContents();
-                }
-                [ClipboardEntry::String(string)] => {
-                    self.write_plaintext(string);
-                }
-                [ClipboardEntry::Image(image)] => {
-                    self.write_image(image);
-                }
-                [ClipboardEntry::ExternalPaths(_)] => {}
-                _ => {
-                    // Agus NB: We're currently only writing string entries to the clipboard when we have more than one.
-                    //
-                    // This was the existing behavior before I refactored the outer clipboard code:
-                    // https://github.com/zed-industries/zed/blob/65f7412a0265552b06ce122655369d6cc7381dd6/crates/gpui/src/platform/mac/platform.rs#L1060-L1110
-                    //
-                    // Note how `any_images` is always `false`. We should fix that, but that's orthogonal to the refactor.
-
-                    let mut combined = ClipboardString {
-                        text: String::new(),
-                        metadata: None,
-                    };
-
-                    for entry in item.entries {
-                        match entry {
-                            ClipboardEntry::String(text) => {
-                                combined.text.push_str(&text.text());
-                                if combined.metadata.is_none() {
-                                    combined.metadata = text.metadata;
-                                }
-                            }
-                            _ => {}
-                        }
+            self.inner.clearContents();
+            for entry in item.entries {
+                match entry {
+                    ClipboardEntry::String(string) => {
+                        self.write_plaintext_inner(&string);
                     }
-
-                    self.write_plaintext(&combined);
+                    ClipboardEntry::Html(html) => {
+                        self.write_html_inner(&html);
+                    }
+                    ClipboardEntry::Image(image) => {
+                        self.write_image_inner(&image);
+                    }
+                    ClipboardEntry::ExternalPaths(_) => {}
                 }
             }
         }
     }
 
-    fn write_plaintext(&self, string: &ClipboardString) {
+    fn write_plaintext_inner(&self, string: &ClipboardString) {
         unsafe {
-            self.inner.clearContents();
-
             let text_bytes = NSData::dataWithBytes_length_(
                 nil,
                 string.text.as_ptr() as *const c_void,
@@ -210,10 +189,20 @@ impl Pasteboard {
         }
     }
 
-    unsafe fn write_image(&self, image: &Image) {
+    fn write_html_inner(&self, html: &str) {
         unsafe {
-            self.inner.clearContents();
+            let html_bytes = NSData::dataWithBytes_length_(
+                nil,
+                html.as_ptr() as *const c_void,
+                html.len() as u64,
+            );
+            self.inner
+                .setData_forType(html_bytes, ns_string("public.html"));
+        }
+    }
 
+    unsafe fn write_image_inner(&self, image: &Image) {
+        unsafe {
             let bytes = NSData::dataWithBytes_length_(
                 nil,
                 image.bytes.as_ptr() as *const c_void,

--- a/crates/gpui/src/platform/windows/clipboard.rs
+++ b/crates/gpui/src/platform/windows/clipboard.rs
@@ -38,6 +38,8 @@ static CLIPBOARD_PNG_FORMAT: LazyLock<u32> =
     LazyLock::new(|| register_clipboard_format(windows::core::w!("PNG")));
 static CLIPBOARD_JPG_FORMAT: LazyLock<u32> =
     LazyLock::new(|| register_clipboard_format(windows::core::w!("JFIF")));
+static CLIPBOARD_HTML_FORMAT: LazyLock<u32> =
+    LazyLock::new(|| register_clipboard_format(windows::core::w!("HTML Format")));
 
 // Helper maps and sets
 static FORMATS_MAP: LazyLock<FxHashMap<u32, ClipboardFormatType>> = LazyLock::new(|| {
@@ -47,6 +49,7 @@ static FORMATS_MAP: LazyLock<FxHashMap<u32, ClipboardFormatType>> = LazyLock::ne
     formats_map.insert(*CLIPBOARD_GIF_FORMAT, ClipboardFormatType::Image);
     formats_map.insert(*CLIPBOARD_JPG_FORMAT, ClipboardFormatType::Image);
     formats_map.insert(*CLIPBOARD_SVG_FORMAT, ClipboardFormatType::Image);
+    formats_map.insert(*CLIPBOARD_HTML_FORMAT, ClipboardFormatType::Html);
     formats_map.insert(CF_DIB.0 as u32, ClipboardFormatType::Image);
     formats_map.insert(CF_HDROP.0 as u32, ClipboardFormatType::Files);
     formats_map
@@ -63,6 +66,7 @@ static IMAGE_FORMATS_MAP: LazyLock<FxHashMap<u32, ImageFormat>> = LazyLock::new(
 #[derive(Debug, Clone, Copy)]
 enum ClipboardFormatType {
     Text,
+    Html,
     Image,
     Files,
 }
@@ -75,6 +79,7 @@ pub(crate) fn read_from_clipboard() -> Option<ClipboardItem> {
     with_clipboard(|| {
         with_best_match_format(|item_format| match format_to_type(item_format) {
             ClipboardFormatType::Text => read_string_from_clipboard(),
+            ClipboardFormatType::Html => read_html_from_clipboard(),
             ClipboardFormatType::Image => read_image_from_clipboard(item_format),
             ClipboardFormatType::Files => read_files_from_clipboard(),
         })
@@ -149,18 +154,18 @@ fn write_to_clipboard_inner(item: ClipboardItem) -> Result<()> {
     unsafe {
         EmptyClipboard()?;
     }
-    match item.entries().first() {
-        Some(entry) => match entry {
+    for entry in item.into_entries() {
+        match entry {
             ClipboardEntry::String(string) => {
-                write_string_to_clipboard(string)?;
+                write_string_to_clipboard(&string)?;
+            }
+            ClipboardEntry::Html(html) => {
+                write_html_to_clipboard(&html)?;
             }
             ClipboardEntry::Image(image) => {
-                write_image_to_clipboard(image)?;
+                write_image_to_clipboard(&image)?;
             }
             ClipboardEntry::ExternalPaths(_) => {}
-        },
-        None => {
-            // Writing an empty list of entries just clears the clipboard.
         }
     }
     Ok(())
@@ -182,6 +187,37 @@ fn write_string_to_clipboard(item: &ClipboardString) -> Result<()> {
         let metadata_wide = metadata.encode_utf16().chain(Some(0)).collect_vec();
         set_data_to_clipboard(&metadata_wide, *CLIPBOARD_METADATA_FORMAT)?;
     }
+    Ok(())
+}
+
+fn write_html_to_clipboard(html: &str) -> Result<()> {
+    let header = "Version:0.9\r\nStartHTML:00000000\r\nEndHTML:00000000\r\nStartFragment:00000000\r\nEndFragment:00000000\r\n";
+    let start_fragment_marker = "<!--StartFragment-->";
+    let end_fragment_marker = "<!--EndFragment-->";
+
+    let mut data = String::new();
+    data.push_str(header);
+    data.push_str("<!DOCTYPE html>\r\n<html><body>");
+    data.push_str(start_fragment_marker);
+    data.push_str(html);
+    data.push_str(end_fragment_marker);
+    data.push_str("</body></html>");
+
+    let start_html = header.len();
+    let end_html = data.len();
+    let start_fragment = data.find(start_fragment_marker).unwrap() + start_fragment_marker.len();
+    let end_fragment = data.find(end_fragment_marker).unwrap();
+
+    let header_with_offsets = format!(
+        "Version:0.9\r\nStartHTML:{:08}\r\nEndHTML:{:08}\r\nStartFragment:{:08}\r\nEndFragment:{:08}\r\n",
+        start_html, end_html, start_fragment, end_fragment
+    );
+
+    let mut final_data = header_with_offsets.into_bytes();
+    final_data.extend_from_slice(&data.as_bytes()[header.len()..]);
+    final_data.push(0);
+
+    set_data_to_clipboard(&final_data, *CLIPBOARD_HTML_FORMAT)?;
     Ok(())
 }
 
@@ -249,6 +285,7 @@ where
     F: Fn(u32) -> Option<ClipboardEntry>,
 {
     let mut text = None;
+    let mut html = None;
     let mut image = None;
     let mut files = None;
     let count = unsafe { CountClipboardFormats() };
@@ -260,6 +297,7 @@ where
         };
         let bucket = match item_format {
             ClipboardFormatType::Text if text.is_none() => &mut text,
+            ClipboardFormatType::Html if html.is_none() => &mut html,
             ClipboardFormatType::Image if image.is_none() => &mut image,
             ClipboardFormatType::Files if files.is_none() => &mut files,
             _ => continue,
@@ -269,7 +307,7 @@ where
         }
     }
 
-    if let Some(entry) = [image, files, text].into_iter().flatten().next() {
+    if let Some(entry) = [image, files, html, text].into_iter().flatten().next() {
         return Some(ClipboardItem {
             entries: vec![entry],
         });
@@ -312,6 +350,14 @@ fn read_string_from_clipboard() -> Option<ClipboardEntry> {
     } else {
         Some(ClipboardEntry::String(ClipboardString::new(text)))
     }
+}
+
+fn read_html_from_clipboard() -> Option<ClipboardEntry> {
+    with_clipboard_data(*CLIPBOARD_HTML_FORMAT, |data_ptr, size| {
+        let bytes = unsafe { std::slice::from_raw_parts(data_ptr as *const u8, size) };
+        let html = String::from_utf8_lossy(bytes).into_owned();
+        Some(ClipboardEntry::Html(html))
+    })?
 }
 
 fn read_hash_from_clipboard() -> Option<u64> {

--- a/crates/markdown_preview/src/markdown_elements.rs
+++ b/crates/markdown_preview/src/markdown_elements.rs
@@ -22,6 +22,35 @@ pub enum ParsedMarkdownElement {
 }
 
 impl ParsedMarkdownElement {
+    pub fn to_text(&self) -> String {
+        match self {
+            Self::Heading(heading) => heading.to_text(),
+            Self::ListItem(list_item) => list_item.to_text(),
+            Self::Table(table) => table.to_text(),
+            Self::BlockQuote(block_quote) => block_quote.to_text(),
+            Self::CodeBlock(code_block) => code_block.contents.to_string(),
+            Self::MermaidDiagram(mermaid) => mermaid.contents.contents.to_string(),
+            Self::Paragraph(text) => text
+                .iter()
+                .map(|chunk| match chunk {
+                    MarkdownParagraphChunk::Text(t) => t.contents.to_string(),
+                    MarkdownParagraphChunk::Image(image) => image
+                        .alt_text
+                        .as_ref()
+                        .map(|a| a.to_string())
+                        .unwrap_or_else(|| image.link.to_string()),
+                })
+                .collect::<Vec<_>>()
+                .join(""),
+            Self::HorizontalRule(_) => "---".to_string(),
+            Self::Image(image) => image
+                .alt_text
+                .as_ref()
+                .map(|a| a.to_string())
+                .unwrap_or_else(|| image.link.to_string()),
+        }
+    }
+
     pub fn source_range(&self) -> Option<Range<usize>> {
         Some(match self {
             Self::Heading(heading) => heading.source_range.clone(),
@@ -59,6 +88,16 @@ pub struct ParsedMarkdown {
     pub children: Vec<ParsedMarkdownElement>,
 }
 
+impl ParsedMarkdown {
+    pub fn to_text(&self) -> String {
+        self.children
+            .iter()
+            .map(|child| child.to_text())
+            .collect::<Vec<_>>()
+            .join("\n\n")
+    }
+}
+
 #[derive(Debug)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct ParsedMarkdownListItem {
@@ -69,6 +108,25 @@ pub struct ParsedMarkdownListItem {
     pub content: Vec<ParsedMarkdownElement>,
     /// Whether we can expect nested list items inside of this items `content`.
     pub nested: bool,
+}
+
+impl ParsedMarkdownListItem {
+    pub fn to_text(&self) -> String {
+        let mut text = self
+            .content
+            .iter()
+            .map(|child| child.to_text())
+            .collect::<Vec<_>>()
+            .join("\n");
+        if self.nested {
+            text = text
+                .lines()
+                .map(|line| format!("  {}", line))
+                .collect::<Vec<_>>()
+                .join("\n");
+        }
+        text
+    }
 }
 
 #[derive(Debug)]
@@ -109,6 +167,23 @@ pub struct ParsedMarkdownHeading {
     pub contents: MarkdownParagraph,
 }
 
+impl ParsedMarkdownHeading {
+    pub fn to_text(&self) -> String {
+        self.contents
+            .iter()
+            .map(|chunk| match chunk {
+                MarkdownParagraphChunk::Text(t) => t.contents.to_string(),
+                MarkdownParagraphChunk::Image(image) => image
+                    .alt_text
+                    .as_ref()
+                    .map(|a| a.to_string())
+                    .unwrap_or_else(|| image.link.to_string()),
+            })
+            .collect::<Vec<_>>()
+            .join("")
+    }
+}
+
 #[derive(Debug, PartialEq)]
 pub enum HeadingLevel {
     H1,
@@ -125,6 +200,36 @@ pub struct ParsedMarkdownTable {
     pub header: Vec<ParsedMarkdownTableRow>,
     pub body: Vec<ParsedMarkdownTableRow>,
     pub caption: Option<MarkdownParagraph>,
+}
+
+impl ParsedMarkdownTable {
+    pub fn to_text(&self) -> String {
+        let mut text = String::new();
+        for row in self.header.iter().chain(self.body.iter()) {
+            let row_text = row
+                .columns
+                .iter()
+                .map(|col| {
+                    col.children
+                        .iter()
+                        .map(|chunk| match chunk {
+                            MarkdownParagraphChunk::Text(t) => t.contents.to_string(),
+                            MarkdownParagraphChunk::Image(image) => image
+                                .alt_text
+                                .as_ref()
+                                .map(|a| a.to_string())
+                                .unwrap_or_else(|| image.link.to_string()),
+                        })
+                        .collect::<Vec<_>>()
+                        .join("")
+                })
+                .collect::<Vec<_>>()
+                .join(" | ");
+            text.push_str(&row_text);
+            text.push('\n');
+        }
+        text
+    }
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -176,6 +281,20 @@ impl ParsedMarkdownTableRow {
 pub struct ParsedMarkdownBlockQuote {
     pub source_range: Range<usize>,
     pub children: Vec<ParsedMarkdownElement>,
+}
+
+impl ParsedMarkdownBlockQuote {
+    pub fn to_text(&self) -> String {
+        self.children
+            .iter()
+            .map(|child| child.to_text())
+            .collect::<Vec<_>>()
+            .join("\n")
+            .lines()
+            .map(|line| format!("> {}", line))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/markdown_preview/src/markdown_elements.rs
+++ b/crates/markdown_preview/src/markdown_elements.rs
@@ -6,6 +6,21 @@ use language::HighlightId;
 use std::{fmt::Display, ops::Range, path::PathBuf};
 use urlencoding;
 
+fn escape_html(s: &str) -> String {
+    let mut escaped = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '<' => escaped.push_str("&lt;"),
+            '>' => escaped.push_str("&gt;"),
+            '&' => escaped.push_str("&amp;"),
+            '"' => escaped.push_str("&quot;"),
+            '\'' => escaped.push_str("&#39;"),
+            _ => escaped.push(c),
+        }
+    }
+    escaped
+}
+
 #[derive(Debug)]
 #[cfg_attr(test, derive(PartialEq))]
 pub enum ParsedMarkdownElement {
@@ -48,6 +63,27 @@ impl ParsedMarkdownElement {
                 .as_ref()
                 .map(|a| a.to_string())
                 .unwrap_or_else(|| image.link.to_string()),
+        }
+    }
+
+    pub fn to_html(&self) -> String {
+        match self {
+            Self::Heading(heading) => heading.to_html(),
+            Self::ListItem(list_item) => list_item.to_html(),
+            Self::Table(table) => table.to_html(),
+            Self::BlockQuote(block_quote) => block_quote.to_html(),
+            Self::CodeBlock(code_block) => code_block.to_html(),
+            Self::MermaidDiagram(mermaid) => {
+                format!(
+                    "<pre class=\"mermaid\">{}</pre>",
+                    escape_html(&mermaid.contents.contents)
+                )
+            }
+            Self::Paragraph(text) => {
+                format!("<p>{}</p>", render_paragraph_html(text))
+            }
+            Self::HorizontalRule(_) => "<hr />".to_string(),
+            Self::Image(image) => image.to_html(),
         }
     }
 
@@ -96,6 +132,52 @@ impl ParsedMarkdown {
             .collect::<Vec<_>>()
             .join("\n\n")
     }
+
+    pub fn to_html(&self) -> String {
+        let mut html = String::new();
+        let mut in_list = None;
+
+        for child in &self.children {
+            if let ParsedMarkdownElement::ListItem(li) = child {
+                let current_is_ordered =
+                    matches!(li.item_type, ParsedMarkdownListItemType::Ordered(_));
+                match in_list {
+                    Some(ordered) if ordered == current_is_ordered => {}
+                    _ => {
+                        if let Some(ordered) = in_list {
+                            html.push_str(if ordered { "</ol>\n" } else { "</ul>\n" });
+                        }
+                        html.push_str(if current_is_ordered { "<ol>\n" } else { "<ul>\n" });
+                        in_list = Some(current_is_ordered);
+                    }
+                }
+                html.push_str(&li.to_html());
+                html.push('\n');
+            } else {
+                if let Some(ordered) = in_list {
+                    html.push_str(if ordered { "</ol>\n" } else { "</ul>\n" });
+                    in_list = None;
+                }
+                html.push_str(&child.to_html());
+                html.push('\n');
+            }
+        }
+        if let Some(ordered) = in_list {
+            html.push_str(if ordered { "</ol>\n" } else { "</ul>\n" });
+        }
+        html
+    }
+}
+
+fn render_paragraph_html(chunks: &[MarkdownParagraphChunk]) -> String {
+    chunks
+        .iter()
+        .map(|chunk| match chunk {
+            MarkdownParagraphChunk::Text(t) => t.to_html(),
+            MarkdownParagraphChunk::Image(i) => i.to_html(),
+        })
+        .collect::<Vec<_>>()
+        .join("")
 }
 
 #[derive(Debug)]
@@ -127,6 +209,23 @@ impl ParsedMarkdownListItem {
         }
         text
     }
+
+    pub fn to_html(&self) -> String {
+        let mut html = String::new();
+        html.push_str("<li>");
+        if let ParsedMarkdownListItemType::Task(checked, _) = self.item_type {
+            html.push_str(if checked {
+                "<input type=\"checkbox\" checked disabled /> "
+            } else {
+                "<input type=\"checkbox\" disabled /> "
+            });
+        }
+        for child in &self.content {
+            html.push_str(&child.to_html());
+        }
+        html.push_str("</li>");
+        html
+    }
 }
 
 #[derive(Debug)]
@@ -144,6 +243,21 @@ pub struct ParsedMarkdownCodeBlock {
     pub language: Option<String>,
     pub contents: SharedString,
     pub highlights: Option<Vec<(Range<usize>, HighlightId)>>,
+}
+
+impl ParsedMarkdownCodeBlock {
+    pub fn to_html(&self) -> String {
+        let lang_class = self
+            .language
+            .as_ref()
+            .map(|l| format!(" class=\"language-{}\"", escape_html(l)))
+            .unwrap_or_default();
+        format!(
+            "<pre><code{}>{}</code></pre>",
+            lang_class,
+            escape_html(&self.contents)
+        )
+    }
 }
 
 #[derive(Debug)]
@@ -181,6 +295,23 @@ impl ParsedMarkdownHeading {
             })
             .collect::<Vec<_>>()
             .join("")
+    }
+
+    pub fn to_html(&self) -> String {
+        let tag = match self.level {
+            HeadingLevel::H1 => "h1",
+            HeadingLevel::H2 => "h2",
+            HeadingLevel::H3 => "h3",
+            HeadingLevel::H4 => "h4",
+            HeadingLevel::H5 => "h5",
+            HeadingLevel::H6 => "h6",
+        };
+        format!(
+            "<{}>{}</{}>",
+            tag,
+            render_paragraph_html(&self.contents),
+            tag
+        )
     }
 }
 
@@ -230,6 +361,47 @@ impl ParsedMarkdownTable {
         }
         text
     }
+
+    pub fn to_html(&self) -> String {
+        let mut html = String::new();
+        html.push_str("<table>\n");
+        if !self.header.is_empty() {
+            html.push_str("<thead>\n");
+            for row in &self.header {
+                html.push_str("<tr>\n");
+                for col in &row.columns {
+                    html.push_str("<th");
+                    if let Some(align) = col.alignment_str() {
+                        html.push_str(&format!(" align=\"{}\"", align));
+                    }
+                    html.push_str(">");
+                    html.push_str(&render_paragraph_html(&col.children));
+                    html.push_str("</th>\n");
+                }
+                html.push_str("</tr>\n");
+            }
+            html.push_str("</thead>\n");
+        }
+        if !self.body.is_empty() {
+            html.push_str("<tbody>\n");
+            for row in &self.body {
+                html.push_str("<tr>\n");
+                for col in &row.columns {
+                    html.push_str("<td");
+                    if let Some(align) = col.alignment_str() {
+                        html.push_str(&format!(" align=\"{}\"", align));
+                    }
+                    html.push_str(">");
+                    html.push_str(&render_paragraph_html(&col.children));
+                    html.push_str("</td>\n");
+                }
+                html.push_str("</tr>\n");
+            }
+            html.push_str("</tbody>\n");
+        }
+        html.push_str("</table>");
+        html
+    }
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -250,6 +422,17 @@ pub struct ParsedMarkdownTableColumn {
     pub is_header: bool,
     pub children: MarkdownParagraph,
     pub alignment: ParsedMarkdownTableAlignment,
+}
+
+impl ParsedMarkdownTableColumn {
+    fn alignment_str(&self) -> Option<&'static str> {
+        match self.alignment {
+            ParsedMarkdownTableAlignment::None => None,
+            ParsedMarkdownTableAlignment::Left => Some("left"),
+            ParsedMarkdownTableAlignment::Center => Some("center"),
+            ParsedMarkdownTableAlignment::Right => Some("right"),
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -295,6 +478,16 @@ impl ParsedMarkdownBlockQuote {
             .collect::<Vec<_>>()
             .join("\n")
     }
+
+    pub fn to_html(&self) -> String {
+        let inner = self
+            .children
+            .iter()
+            .map(|child| child.to_html())
+            .collect::<Vec<_>>()
+            .join("");
+        format!("<blockquote>{}</blockquote>", inner)
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -307,6 +500,86 @@ pub struct ParsedMarkdownText {
     pub highlights: Vec<(Range<usize>, MarkdownHighlight)>,
     /// The regions of the Markdown document.
     pub regions: Vec<(Range<usize>, ParsedRegion)>,
+}
+
+impl ParsedMarkdownText {
+    pub fn to_html(&self) -> String {
+        let mut html = String::new();
+        let content = self.contents.as_ref();
+        let mut events = Vec::new();
+
+        for (range, highlight) in &self.highlights {
+            events.push((range.start, true, Some(highlight), None));
+            events.push((range.end, false, Some(highlight), None));
+        }
+
+        for (range, region) in &self.regions {
+            if let Some(link) = &region.link {
+                events.push((range.start, true, None, Some(link)));
+                events.push((range.end, false, None, Some(link)));
+            }
+        }
+
+        events.sort_by(|a, b| {
+            if a.0 != b.0 {
+                a.0.cmp(&b.0)
+            } else {
+                // End tags should come before start tags at the same position for same content?
+                // Actually for HTML nesting, it's better if we sort them correctly.
+                b.1.cmp(&a.1)
+            }
+        });
+
+        let mut last_pos = 0;
+        for (pos, is_start, highlight, link) in events {
+            if pos > last_pos {
+                html.push_str(&escape_html(&content[last_pos..pos]));
+                last_pos = pos;
+            }
+
+            if let Some(h) = highlight {
+                if let MarkdownHighlight::Style(style) = h {
+                    if is_start {
+                        if style.weight == FontWeight::BOLD {
+                            html.push_str("<b>");
+                        }
+                        if style.italic {
+                            html.push_str("<i>");
+                        }
+                        if style.strikethrough {
+                            html.push_str("<strike>");
+                        }
+                        if style.underline {
+                            html.push_str("<u>");
+                        }
+                    } else {
+                        if style.underline {
+                            html.push_str("</u>");
+                        }
+                        if style.strikethrough {
+                            html.push_str("</strike>");
+                        }
+                        if style.italic {
+                            html.push_str("</i>");
+                        }
+                        if style.weight == FontWeight::BOLD {
+                            html.push_str("</b>");
+                        }
+                    }
+                }
+            }
+
+            if let Some(l) = link {
+                if is_start {
+                    html.push_str(&format!("<a href=\"{}\">", escape_html(&l.to_string())));
+                } else {
+                    html.push_str("</a>");
+                }
+            }
+        }
+        html.push_str(&escape_html(&content[last_pos..]));
+        html
+    }
 }
 
 /// A run of highlighted Markdown text.
@@ -488,5 +761,18 @@ impl Image {
 
     pub fn set_height(&mut self, height: DefiniteLength) {
         self.height = Some(height);
+    }
+
+    pub fn to_html(&self) -> String {
+        let alt = self
+            .alt_text
+            .as_ref()
+            .map(|a| format!(" alt=\"{}\"", escape_html(a)))
+            .unwrap_or_default();
+        format!(
+            "<img src=\"{}\"{} />",
+            escape_html(&self.link.to_string()),
+            alt
+        )
     }
 }

--- a/crates/markdown_preview/src/markdown_preview.rs
+++ b/crates/markdown_preview/src/markdown_preview.rs
@@ -27,7 +27,9 @@ actions!(
         /// Scrolls down by one markdown element in the markdown preview
         ScrollDownByItem,
         /// Opens a following markdown preview that syncs with the editor.
-        OpenFollowingPreview
+        OpenFollowingPreview,
+        /// Copies the rendered markdown as text.
+        Copy
     ]
 );
 

--- a/crates/markdown_preview/src/markdown_preview.rs
+++ b/crates/markdown_preview/src/markdown_preview.rs
@@ -29,7 +29,9 @@ actions!(
         /// Opens a following markdown preview that syncs with the editor.
         OpenFollowingPreview,
         /// Copies the rendered markdown as text.
-        Copy
+        Copy,
+        /// Copies the rendered markdown as plain text only.
+        CopyAsPlainText
     ]
 );
 

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -21,7 +21,7 @@ use workspace::{Pane, Workspace};
 use crate::markdown_elements::ParsedMarkdownElement;
 use crate::markdown_renderer::{CheckboxClickedEvent, MermaidState};
 use crate::{
-    Copy, OpenFollowingPreview, OpenPreview, OpenPreviewToTheSide, ScrollPageDown, ScrollPageUp,
+    Copy, CopyAsPlainText, OpenFollowingPreview, OpenPreview, OpenPreviewToTheSide, ScrollPageDown, ScrollPageUp,
     markdown_elements::ParsedMarkdown,
     markdown_parser::parse_markdown,
     markdown_renderer::{RenderContext, render_markdown_block},
@@ -509,6 +509,14 @@ impl MarkdownPreviewView {
     fn copy(&mut self, _: &Copy, _window: &mut Window, cx: &mut Context<Self>) {
         if let Some(contents) = &self.contents {
             let text = contents.to_text();
+            let html = contents.to_html();
+            cx.write_to_clipboard(ClipboardItem::new_string(text).with_html(html));
+        }
+    }
+
+    fn copy_as_plain_text(&mut self, _: &CopyAsPlainText, _window: &mut Window, cx: &mut Context<Self>) {
+        if let Some(contents) = &self.contents {
+            let text = contents.to_text();
             cx.write_to_clipboard(ClipboardItem::new_string(text));
         }
     }
@@ -570,6 +578,7 @@ impl Render for MarkdownPreviewView {
             .on_action(cx.listener(MarkdownPreviewView::scroll_up_by_item))
             .on_action(cx.listener(MarkdownPreviewView::scroll_down_by_item))
             .on_action(cx.listener(MarkdownPreviewView::copy))
+            .on_action(cx.listener(MarkdownPreviewView::copy_as_plain_text))
             .size_full()
             .bg(cx.theme().colors().editor_background)
             .p_4()
@@ -581,6 +590,9 @@ impl Render for MarkdownPreviewView {
                         ContextMenu::build(window, cx, |menu, _, _| {
                             menu.entry("Copy Rendered Text", None, move |window, cx| {
                                 window.dispatch_action(Box::new(Copy), cx)
+                            })
+                            .entry("Copy as Plaintext", None, move |window, cx| {
+                                window.dispatch_action(Box::new(CopyAsPlainText), cx)
                             })
                         })
                     })

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -7,21 +7,21 @@ use anyhow::Result;
 use editor::scroll::Autoscroll;
 use editor::{Editor, EditorEvent, MultiBufferOffset, SelectionEffects};
 use gpui::{
-    App, ClickEvent, Context, Entity, EventEmitter, FocusHandle, Focusable, InteractiveElement,
-    IntoElement, IsZero, ListState, ParentElement, Render, RetainAllImageCache, Styled,
-    Subscription, Task, WeakEntity, Window, list,
+    App, ClickEvent, ClipboardItem, Context, Entity, EventEmitter, FocusHandle, Focusable,
+    InteractiveElement, IntoElement, IsZero, ListState, ParentElement, Render,
+    RetainAllImageCache, Styled, Subscription, Task, WeakEntity, Window, list,
 };
 use language::LanguageRegistry;
 use settings::Settings;
 use theme::ThemeSettings;
-use ui::{WithScrollbar, prelude::*};
+use ui::{WithScrollbar, prelude::*, right_click_menu, ContextMenu};
 use workspace::item::{Item, ItemHandle};
 use workspace::{Pane, Workspace};
 
 use crate::markdown_elements::ParsedMarkdownElement;
 use crate::markdown_renderer::{CheckboxClickedEvent, MermaidState};
 use crate::{
-    OpenFollowingPreview, OpenPreview, OpenPreviewToTheSide, ScrollPageDown, ScrollPageUp,
+    Copy, OpenFollowingPreview, OpenPreview, OpenPreviewToTheSide, ScrollPageDown, ScrollPageUp,
     markdown_elements::ParsedMarkdown,
     markdown_parser::parse_markdown,
     markdown_renderer::{RenderContext, render_markdown_block},
@@ -505,6 +505,13 @@ impl MarkdownPreviewView {
         }
         cx.notify();
     }
+
+    fn copy(&mut self, _: &Copy, _window: &mut Window, cx: &mut Context<Self>) {
+        if let Some(contents) = &self.contents {
+            let text = contents.to_text();
+            cx.write_to_clipboard(ClipboardItem::new_string(text));
+        }
+    }
 }
 
 impl Focusable for MarkdownPreviewView {
@@ -537,7 +544,13 @@ impl Item for MarkdownPreviewView {
         Some("Markdown Preview Opened")
     }
 
-    fn to_item_events(_event: &Self::Event, _f: impl FnMut(workspace::item::ItemEvent)) {}
+    fn tab_extra_context_menu_actions(
+        &self,
+        _window: &mut Window,
+        _cx: &mut Context<Self>,
+    ) -> Vec<(SharedString, Box<dyn Action>)> {
+        vec![("Copy Rendered Text".into(), Box::new(Copy))]
+    }
 }
 
 impl Render for MarkdownPreviewView {
@@ -556,115 +569,151 @@ impl Render for MarkdownPreviewView {
             .on_action(cx.listener(MarkdownPreviewView::scroll_down))
             .on_action(cx.listener(MarkdownPreviewView::scroll_up_by_item))
             .on_action(cx.listener(MarkdownPreviewView::scroll_down_by_item))
+            .on_action(cx.listener(MarkdownPreviewView::copy))
             .size_full()
             .bg(cx.theme().colors().editor_background)
             .p_4()
             .text_size(buffer_size)
             .line_height(relative(buffer_line_height.value()))
-            .child(div().flex_grow().map(|this| {
-                this.child(
-                    list(
-                        self.list_state.clone(),
-                        cx.processor(|this, ix, window, cx| {
-                            let Some(contents) = &this.contents else {
-                                return div().into_any();
-                            };
+            .child(
+                right_click_menu("markdown-preview-context-menu")
+                    .menu(move |window, cx| {
+                        ContextMenu::build(window, cx, |menu, _, _| {
+                            menu.entry("Copy Rendered Text", None, move |window, cx| {
+                                window.dispatch_action(Box::new(Copy), cx)
+                            })
+                        })
+                    })
+                    .trigger(|_, _, _| {
+                        div().flex_grow().map(|this| {
+                            this.child(
+                                list(
+                                    self.list_state.clone(),
+                                    cx.processor(|this, ix, window, cx| {
+                                        let Some(contents) = &this.contents else {
+                                            return div().into_any();
+                                        };
 
-                            let mut render_cx = RenderContext::new(
-                                Some(this.workspace.clone()),
-                                &this.mermaid_state,
-                                window,
-                                cx,
-                            )
-                            .with_checkbox_clicked_callback(cx.listener(
-                                move |this, e: &CheckboxClickedEvent, window, cx| {
-                                    if let Some(editor) =
-                                        this.active_editor.as_ref().map(|s| s.editor.clone())
-                                    {
-                                        editor.update(cx, |editor, cx| {
-                                            let task_marker =
-                                                if e.checked() { "[x]" } else { "[ ]" };
+                                        let mut render_cx = RenderContext::new(
+                                            Some(this.workspace.clone()),
+                                            &this.mermaid_state,
+                                            window,
+                                            cx,
+                                        )
+                                        .with_checkbox_clicked_callback(cx.listener(
+                                            move |this, e: &CheckboxClickedEvent, window, cx| {
+                                                if let Some(editor) = this
+                                                    .active_editor
+                                                    .as_ref()
+                                                    .map(|s| s.editor.clone())
+                                                {
+                                                    editor.update(cx, |editor, cx| {
+                                                        let task_marker = if e.checked() {
+                                                            "[x]"
+                                                        } else {
+                                                            "[ ]"
+                                                        };
 
-                                            editor.edit(
-                                                [(
-                                                    MultiBufferOffset(e.source_range().start)
-                                                        ..MultiBufferOffset(e.source_range().end),
-                                                    task_marker,
-                                                )],
-                                                cx,
+                                                        editor.edit(
+                                                            [(
+                                                                MultiBufferOffset(
+                                                                    e.source_range().start,
+                                                                )
+                                                                    ..MultiBufferOffset(
+                                                                        e.source_range().end,
+                                                                    ),
+                                                                task_marker,
+                                                            )],
+                                                            cx,
+                                                        );
+                                                    });
+                                                    this.parse_markdown_from_active_editor(
+                                                        false, window, cx,
+                                                    );
+                                                    cx.notify();
+                                                }
+                                            },
+                                        ));
+
+                                        let block = contents.children.get(ix).unwrap();
+                                        let rendered_block =
+                                            render_markdown_block(block, &mut render_cx);
+
+                                        let should_apply_padding =
+                                            Self::should_apply_padding_between(
+                                                block,
+                                                contents.children.get(ix + 1),
                                             );
-                                        });
-                                        this.parse_markdown_from_active_editor(false, window, cx);
-                                        cx.notify();
-                                    }
-                                },
-                            ));
 
-                            let block = contents.children.get(ix).unwrap();
-                            let rendered_block = render_markdown_block(block, &mut render_cx);
-
-                            let should_apply_padding = Self::should_apply_padding_between(
-                                block,
-                                contents.children.get(ix + 1),
-                            );
-
-                            let selected_block = this.selected_block;
-                            let scaled_rems = render_cx.scaled_rems(1.0);
-                            div()
-                                .id(ix)
-                                .when(should_apply_padding, |this| {
-                                    this.pb(render_cx.scaled_rems(0.75))
-                                })
-                                .group("markdown-block")
-                                .on_click(cx.listener(
-                                    move |this, event: &ClickEvent, window, cx| {
-                                        if event.click_count() == 2
-                                            && let Some(source_range) = this
-                                                .contents
-                                                .as_ref()
-                                                .and_then(|c| c.children.get(ix))
-                                                .and_then(|block: &ParsedMarkdownElement| {
-                                                    block.source_range()
-                                                })
-                                        {
-                                            this.move_cursor_to_block(
-                                                window,
-                                                cx,
-                                                MultiBufferOffset(source_range.start)
-                                                    ..MultiBufferOffset(source_range.start),
-                                            );
-                                        }
-                                    },
-                                ))
-                                .map(move |container| {
-                                    let indicator = div()
-                                        .h_full()
-                                        .w(px(4.0))
-                                        .when(ix == selected_block, |this| {
-                                            this.bg(cx.theme().colors().border)
-                                        })
-                                        .group_hover("markdown-block", |s| {
-                                            if ix == selected_block {
-                                                s
-                                            } else {
-                                                s.bg(cx.theme().colors().border_variant)
-                                            }
-                                        })
-                                        .rounded_xs();
-
-                                    container.child(
+                                        let selected_block = this.selected_block;
+                                        let scaled_rems = render_cx.scaled_rems(1.0);
                                         div()
-                                            .relative()
-                                            .child(div().pl(scaled_rems).child(rendered_block))
-                                            .child(indicator.absolute().left_0().top_0()),
-                                    )
-                                })
-                                .into_any()
-                        }),
-                    )
-                    .size_full(),
-                )
-            }))
+                                            .id(ix)
+                                            .when(should_apply_padding, |this| {
+                                                this.pb(render_cx.scaled_rems(0.75))
+                                            })
+                                            .group("markdown-block")
+                                            .on_click(cx.listener(
+                                                move |this, event: &ClickEvent, window, cx| {
+                                                    if event.click_count() == 2
+                                                        && let Some(source_range) = this
+                                                            .contents
+                                                            .as_ref()
+                                                            .and_then(|c| c.children.get(ix))
+                                                            .and_then(
+                                                                |block: &ParsedMarkdownElement| {
+                                                                    block.source_range()
+                                                                },
+                                                            )
+                                                    {
+                                                        this.move_cursor_to_block(
+                                                            window,
+                                                            cx,
+                                                            MultiBufferOffset(source_range.start)
+                                                                ..MultiBufferOffset(
+                                                                    source_range.start,
+                                                                ),
+                                                        );
+                                                    }
+                                                },
+                                            ))
+                                            .map(move |container| {
+                                                let indicator = div()
+                                                    .h_full()
+                                                    .w(px(4.0))
+                                                    .when(ix == selected_block, |this| {
+                                                        this.bg(cx.theme().colors().border)
+                                                    })
+                                                    .group_hover("markdown-block", |s| {
+                                                        if ix == selected_block {
+                                                            s
+                                                        } else {
+                                                            s.bg(cx.theme().colors().border_variant)
+                                                        }
+                                                    })
+                                                    .rounded_xs();
+
+                                                container.child(
+                                                    div()
+                                                        .relative()
+                                                        .child(
+                                                            div()
+                                                                .pl(scaled_rems)
+                                                                .child(rendered_block),
+                                                        )
+                                                        .child(
+                                                            indicator.absolute().left_0().top_0(),
+                                                        ),
+                                                )
+                                            })
+                                            .into_any()
+                                    }),
+                                )
+                                .size_full(),
+                            )
+                        }))
+                    }),
+            )
             .vertical_scrollbar_for(&self.list_state, window, cx)
     }
 }


### PR DESCRIPTION
This PR adds the ability to copy the rendered Markdown preview as both formatted text (HTML) and plain text.

Key changes:
- **HTML Clipboard Support**: Implemented HTML clipboard support across all platforms (Windows, macOS, Linux/Wayland/X11) in GPUI.
- **Copy Actions**: Added both \Copy\ and \CopyAsPlainText\ actions for the \markdown_preview\ crate.
- **AST extraction**:
    - Implemented \	o_text()\ methods for extracting plain text from the parsed Markdown AST.
    - Implemented \	o_html()\ methods for extracting formatted HTML from the parsed Markdown AST.
- **UI Integration**:
    - Handled both copy actions in \MarkdownPreviewView\.
    - Added a right-click context menu with both \
Copy
Rendered
Text\ and \Copy
as
Plaintext\ options.
    - Added \Copy
Rendered
Text\ to the tab context menu.

Closes #49208
