### PR TITLE
Implement responsive panel sizing at dock level

### DIFF
--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -987,6 +987,7 @@ impl VsCodeSettings {
                 }
             }),
             zoomed_padding: None,
+            panels: Default::default(),
         }
     }
 

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -116,6 +116,9 @@ pub struct WorkspaceSettingsContent {
     /// What draws window decorations/titlebar, the client application (Zed) or display server
     /// Default: client
     pub window_decorations: Option<WindowDecorations>,
+    /// Per-panel settings.
+    #[serde(default)]
+    pub panels: HashMap<String, PanelDockSettingsContent>,
 }
 
 #[with_fallible_options]
@@ -789,6 +792,19 @@ pub enum ProjectPanelSortMode {
 )]
 pub struct ProjectPanelIndentGuidesSettings {
     pub show: Option<ShowIndentGuides>,
+}
+
+#[with_fallible_options]
+#[derive(Clone, Default, Serialize, Deserialize, JsonSchema, MergeFrom, Debug, PartialEq)]
+pub struct PanelDockSettingsContent {
+    pub size: Option<PanelSize>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, MergeFrom, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum PanelSize {
+    Fixed(f32),
+    Responsive(f32),
 }
 
 /// Controls how semantic tokens from language servers are used for syntax highlighting.

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -4,13 +4,16 @@ use crate::{Workspace, status_bar::StatusItemView};
 use anyhow::Context as _;
 use client::proto;
 
+use crate::workspace_settings::{PanelDockSettings, PanelSize, WorkspaceSettings};
+
 use gpui::{
     Action, AnyView, App, Axis, Context, Corner, Entity, EntityId, EventEmitter, FocusHandle,
     Focusable, IntoElement, KeyContext, MouseButton, MouseDownEvent, MouseUpEvent, ParentElement,
     Render, SharedString, StyleRefinement, Styled, Subscription, WeakEntity, Window, deferred, div,
     px,
 };
-use settings::SettingsStore;
+use settings::{Settings, SettingsStore};
+use std::collections::HashMap;
 use std::sync::Arc;
 use ui::{ContextMenu, Divider, DividerColor, IconButton, Tooltip, h_flex};
 use ui::{prelude::*, right_click_menu};
@@ -208,6 +211,8 @@ pub struct Dock {
     zoom_layer_open: bool,
     modal_layer: Entity<ModalLayer>,
     _subscriptions: [Subscription; 2],
+    responsive_overrides: HashMap<EntityId, f32>,
+    last_settings: HashMap<EntityId, PanelDockSettings>,
 }
 
 impl Focusable for Dock {
@@ -303,6 +308,8 @@ impl Dock {
                 serialized_dock: None,
                 zoom_layer_open: false,
                 modal_layer,
+                responsive_overrides: Default::default(),
+                last_settings: Default::default(),
             }
         });
 
@@ -472,6 +479,25 @@ impl Dock {
                 let panel = panel.clone();
 
                 move |this, window, cx| {
+                    let settings = WorkspaceSettings::get_global(cx);
+                    let panel_settings = settings
+                        .panels
+                        .get(panel.persistent_name())
+                        .cloned()
+                        .unwrap_or_default();
+
+                    if let Some(last_settings) = this.last_settings.get(&panel.panel_id()) {
+                        if last_settings != &panel_settings {
+                            this.responsive_overrides.remove(&panel.panel_id());
+                            this.last_settings
+                                .insert(panel.panel_id(), panel_settings.clone());
+                            cx.notify();
+                        }
+                    } else {
+                        this.last_settings
+                            .insert(panel.panel_id(), panel_settings.clone());
+                    }
+
                     let new_position = panel.read(cx).position(window, cx);
                     if new_position == this.position {
                         return;
@@ -734,12 +760,32 @@ impl Dock {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if let Some(entry) = self.active_panel_entry() {
-            let size = size.map(|size| size.max(RESIZE_HANDLE_SIZE).round());
+        let panel = if let Some(entry) = self.active_panel_entry() {
+            entry.panel.clone()
+        } else {
+            return;
+        };
 
-            entry.panel.set_size(size, window, cx);
-            cx.notify();
+        let size = size.map(|size| size.max(RESIZE_HANDLE_SIZE).round());
+
+        if let Some(size) = size {
+            let settings = WorkspaceSettings::get_global(cx);
+            if let Some(panel_settings) = settings.panels.get(panel.persistent_name()) {
+                if let Some(PanelSize::Responsive(_)) = &panel_settings.size {
+                    let viewport_size = window.viewport_size();
+                    let dimension = match self.position().axis() {
+                        Axis::Horizontal => viewport_size.width,
+                        Axis::Vertical => viewport_size.height,
+                    };
+                    let fraction = size / dimension;
+                    self.responsive_overrides
+                        .insert(panel.panel_id(), fraction);
+                }
+            }
         }
+
+        panel.set_size(size, window, cx);
+        cx.notify();
     }
 
     pub fn resize_all_panels(
@@ -748,8 +794,27 @@ impl Dock {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        let size = size.map(|size| size.max(RESIZE_HANDLE_SIZE).round());
+        let viewport_size = window.viewport_size();
+        let dimension = match self.position().axis() {
+            Axis::Horizontal => viewport_size.width,
+            Axis::Vertical => viewport_size.height,
+        };
+
+        if let Some(size) = size {
+            let settings = WorkspaceSettings::get_global(cx);
+            for entry in &self.panel_entries {
+                if let Some(panel_settings) = settings.panels.get(entry.panel.persistent_name()) {
+                    if let Some(PanelSize::Responsive(_)) = &panel_settings.size {
+                        let fraction = size / dimension;
+                        self.responsive_overrides
+                            .insert(entry.panel.panel_id(), fraction);
+                    }
+                }
+            }
+        }
+
         for entry in &mut self.panel_entries {
-            let size = size.map(|size| size.max(RESIZE_HANDLE_SIZE).round());
             entry.panel.set_size(size, window, cx);
         }
         cx.notify();
@@ -783,8 +848,28 @@ impl Dock {
 impl Render for Dock {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let dispatch_context = Self::dispatch_context();
+        let settings = WorkspaceSettings::get_global(cx);
         if let Some(entry) = self.visible_entry() {
-            let size = entry.panel.size(window, cx);
+            let mut size = entry.panel.size(window, cx);
+            if let Some(panel_settings) = settings.panels.get(entry.panel.persistent_name()) {
+                if let Some(mode) = &panel_settings.size {
+                    match mode {
+                        PanelSize::Fixed(pixels) => size = px(*pixels),
+                        PanelSize::Responsive(fraction) => {
+                            let fraction = *self
+                                .responsive_overrides
+                                .get(&entry.panel.panel_id())
+                                .unwrap_or(fraction);
+                            let viewport_size = window.viewport_size();
+                            let dimension = match self.position().axis() {
+                                Axis::Horizontal => viewport_size.width,
+                                Axis::Vertical => viewport_size.height,
+                            };
+                            size = dimension * fraction;
+                        }
+                    }
+                }
+            }
 
             let position = self.position;
             let create_resize_handle = || {

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -9,6 +9,8 @@ pub use settings::{
     RestoreOnStartupBehavior, Settings,
 };
 
+pub use settings::PanelSize;
+
 #[derive(RegisterSetting)]
 pub struct WorkspaceSettings {
     pub active_pane_modifiers: ActivePanelModifiers,
@@ -34,6 +36,12 @@ pub struct WorkspaceSettings {
     pub use_system_window_tabs: bool,
     pub zoomed_padding: bool,
     pub window_decorations: settings::WindowDecorations,
+    pub panels: HashMap<String, PanelDockSettings>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct PanelDockSettings {
+    pub size: Option<PanelSize>,
 }
 
 #[derive(Copy, Clone, PartialEq, Debug, Default)]
@@ -111,6 +119,18 @@ impl Settings for WorkspaceSettings {
             use_system_window_tabs: workspace.use_system_window_tabs.unwrap(),
             zoomed_padding: workspace.zoomed_padding.unwrap(),
             window_decorations: workspace.window_decorations.unwrap(),
+            panels: workspace
+                .panels
+                .iter()
+                .map(|(k, v)| {
+                    (
+                        k.clone(),
+                        PanelDockSettings {
+                            size: v.size.clone(),
+                        },
+                    )
+                })
+                .collect(),
         }
     }
 }


### PR DESCRIPTION
Extension of feedback received  at PR #48903 and fixing #48442

## Summary

This PR introduces a generic system for responsive panel sizing across the entire workspace. Users can now configure panels (like the Project Panel, Terminal, etc.) to take up a specific percentage of the window's width or height, rather than a fixed pixel value.

## Changes : 

- Settings Schema: Added a specific  panels section to `settings.json.`
- Supports responsive (0.0 - 1.0) and fixed (pixels) sizing modes.
- Dock Implementation: Updated Dock::render to dynamically calculate panel sizes based on the window's viewport dimensions.
- Resizing Behavior:
- Manual resizing of a "responsive" panel creates a runtime override, so the user can still drag to adjust the size comfortably.
- This override persists until the settings are modified, at which point the explicit configuration takes precedence again.


## Configuration Example :

Users can add the following to their settings.json to make the Project Panel take up 25% of the width and the Terminal 40% of the height (if bottom docked):
```
"panels": {
  "Project Panel": {
    "size": { "responsive": 0.25 } // 25% of window width
  },
  "TerminalPanel": {
    "size": { "responsive": 0.4 } // 40% of window height (if bottom docked)
  }
}
```

**NOTE : Panel Identification: The keys in the panels.rs configuration map directly to each panel's persistent_name(). This ensures that settings are applied correctly.**

## Manual Testing : 
 
- Verified that panels resize proportionally when the window is resized.
- Verified that manual dragging still works as expected.
- Verified that Fixed mode remains the default behavior if no settings are provided.


## Video :
 
[Screencast from 2026-02-15 19-26-09.webm](https://github.com/user-attachments/assets/fece86d7-3500-489f-8832-4f4e952d286b)


## Release Notes:

- Added support for responsive panel sizing. You can now configure panels (like the Project Panel, Terminal, etc.) to take up a specific percentage of the window's width or height in your settings.json.
- Implemented manual resize overrides, allowing you to drag panel borders to adjust their size without losing your responsive configuration permanently.
