### PR TITLE
docs: Simplify Deno test task example

### DIFF
--- a/docs/src/languages/deno.md
+++ b/docs/src/languages/deno.md
@@ -115,7 +115,7 @@ To run deno tasks like tests from the ui, add this to `.zed/tasks.json`
 [
   {
     "label": "deno test",
-    "command": "deno test -A --filter '/^$ZED_CUSTOM_DENO_TEST_NAME$/' '$ZED_FILE'",
+    "command": "deno test -A '$ZED_FILE'",
     "tags": ["js-test"]
   }
 ]


### PR DESCRIPTION
Closes #48537 

**Explanation:**
The Deno test task example wasn't appearing because the undefined ZED_CUSTOM_DENO_TEST_NAME variable made the filter invalid. Instead of adding a default value, simplify the example to run all tests in the file, which is the most common use case and works out of the box.


Before you mark this PR as ready for review, make sure that you have:
Screenshots:
Before:
<img width="3434" height="1349" alt="image" src="https://github.com/user-attachments/assets/bc514103-9b33-489f-a69e-84257ea82acf" />

After:
<img width="3438" height="1376" alt="image" src="https://github.com/user-attachments/assets/47674dde-ede8-4a9d-b365-d2df8e128e18" />


Release Notes:

- N/A

