### PR TITLE
multi_buffer: Guard unresolved anchors during summary resolution

### DIFF
--- a/crates/multi_buffer/src/multi_buffer_tests.rs
+++ b/crates/multi_buffer/src/multi_buffer_tests.rs
@@ -1259,12 +1259,22 @@ fn test_resolving_anchors_after_replacing_their_excerpts(cx: &mut App) {
         ),
         MultiBufferOffset(0)
     );
+    let unresolved_anchor = snapshot_1.anchor_after(MultiBufferOffset(5));
+    assert_eq!(
+        snapshot_2.summary_for_anchor::<MultiBufferOffset>(&unresolved_anchor),
+        MultiBufferOffset(0)
+    );
     assert_eq!(
         snapshot_2.summaries_for_anchors::<MultiBufferOffset, _>(&[
             snapshot_1.anchor_before(MultiBufferOffset(2)),
-            snapshot_1.anchor_after(MultiBufferOffset(3))
+            snapshot_1.anchor_after(MultiBufferOffset(3)),
+            unresolved_anchor,
         ]),
-        vec![MultiBufferOffset(0), MultiBufferOffset(0)]
+        vec![
+            MultiBufferOffset(0),
+            MultiBufferOffset(0),
+            MultiBufferOffset(0)
+        ]
     );
 
     // Refresh anchors from the old snapshot. The return value indicates that both
@@ -1272,12 +1282,14 @@ fn test_resolving_anchors_after_replacing_their_excerpts(cx: &mut App) {
     let refresh = snapshot_2.refresh_anchors(&[
         snapshot_1.anchor_before(MultiBufferOffset(2)),
         snapshot_1.anchor_after(MultiBufferOffset(3)),
+        unresolved_anchor,
     ]);
     assert_eq!(
         refresh,
         &[
             (0, snapshot_2.anchor_before(MultiBufferOffset(0)), false),
             (1, snapshot_2.anchor_after(MultiBufferOffset(0)), false),
+            (2, snapshot_2.anchor_after(MultiBufferOffset(0)), false),
         ]
     );
 


### PR DESCRIPTION
## Summary
Fixes a crash in anchor summary resolution (ZED-1FF) by handling unresolved text anchors after excerpt replacement.

## What changed
- Guard  when  is false.
- Guard  with the same check and fall back to excerpt start.
- Extend  with an unresolved-anchor regression case.

## Verification
- 
running 1 test
test multi_buffer_tests::test_resolving_anchors_after_replacing_their_excerpts ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 47 filtered out; finished in 0.03s
- 
running 48 tests
test multi_buffer_tests::test_empty_multibuffer ... ok
test multi_buffer_tests::test_empty_singleton ... ok
test multi_buffer_tests::test_excerpts_containment_functions ... ok
test multi_buffer_tests::test_enclosing_indent ... ok
test multi_buffer_tests::test_excerpt_events ... ok
test multi_buffer_tests::test_expand_excerpts ... ok
test multi_buffer_tests::test_cannot_seek_backward_after_excerpt_replacement ... ok
test multi_buffer_tests::test_excerpt_boundaries_and_clipping ... ok
test multi_buffer_tests::test_multibuffer_anchors ... ok
test multi_buffer_tests::test_new_empty_buffer_uses_truncated_first_line_for_title_after_merging_adjacent_spaces ... ok
test multi_buffer_tests::test_new_empty_buffer_uses_truncated_first_line_for_title ... ok
test multi_buffer_tests::test_new_empty_buffer_takes_trimmed_first_line_for_title ... ok
test multi_buffer_tests::test_new_empty_buffer_uses_untitled_title ... ok
test multi_buffer_tests::test_new_empty_buffer_takes_first_line_for_title ... ok
test multi_buffer_tests::test_new_empty_buffer_uses_untitled_title_when_only_contains_whitespace ... ok
test multi_buffer_tests::test_new_empty_buffers_title_can_be_set ... ok
test multi_buffer_tests::test_range_to_buffer_ranges_with_range_bounds ... ok
test multi_buffer_tests::test_remote ... ok
test multi_buffer_tests::test_resolving_anchors_after_replacing_their_excerpts ... ok
test multi_buffer_tests::test_diff_boundary_anchors ... ok
test multi_buffer_tests::test_empty_diff_excerpt ... ok
test multi_buffer_tests::test_set_excerpts_for_buffer ... ok
test multi_buffer_tests::test_set_excerpts_for_buffer_ordering ... ok
test multi_buffer_tests::test_set_excerpts_for_buffer_rename ... ok
test multi_buffer_tests::test_inverted_diff_base_text_change ... ok
test multi_buffer_tests::test_singleton ... ok
test multi_buffer_tests::test_singleton_multibuffer_anchors ... ok
test multi_buffer_tests::test_summaries_for_anchors ... ok
test multi_buffer_tests::test_inverted_diff_hunks_in_range ... ok
test multi_buffer_tests::test_trailing_deletion_without_newline ... ok
test multi_buffer_tests::test_diff_hunks_in_range_query_starting_at_added_row ... ok
test multi_buffer_tests::test_repeatedly_expand_a_diff_hunk ... ok
test multi_buffer_tests::test_diff_hunks_in_range ... ok
test multi_buffer_tests::test_singleton_with_inverted_diff ... ok
test multi_buffer_tests::test_editing_text_in_diff_hunks ... ok
test multi_buffer_tests::test_diff_hunks_with_multiple_excerpts ... ok
test multi_buffer_tests::test_basic_diff_hunks ... ok
test multi_buffer_tests::test_set_anchored_excerpts_for_path ... ok
test multi_buffer_tests::test_word_diff_simple_replacement ... ok
test multi_buffer_tests::test_word_diff_modified_lines_with_deletion_between ... ok
test multi_buffer_tests::test_word_diff_white_space ... ok
test multi_buffer_tests::test_word_diff_consecutive_modified_lines ... ok
test multi_buffer_tests::test_history ... ok
test multi_buffer_tests::test_word_diff_disabled ... ok
test multi_buffer_tests::test_random_set_ranges ... ok
test multi_buffer_tests::test_random_chunk_bitmaps ... ok
test multi_buffer_tests::test_random_chunk_bitmaps_with_diffs ... ok
test multi_buffer_tests::test_random_multibuffer ... ok

test result: ok. 48 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 12.91s
- 

Release Notes:
- Fixed a crash when resolving stale anchors after excerpt replacement in multi-buffer summary computation.