### PR TITLE
Fix non-breaking space, form feed, etc. shifting whitespace markers

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -8832,8 +8832,9 @@ impl LineWithInvisibles {
                             if highlighted_chunk.is_tab {
                                 if non_whitespace_added || !is_soft_wrapped {
                                     invisibles.push(Invisible::Tab {
-                                        line_start_offset: line_scratchspace.len(),
-                                        line_end_offset: line_scratchspace.len() + line_chunk.len(),
+                                        line_start_offset: line_ingested_utf8_bytes,
+                                        line_end_offset: line_ingested_utf8_bytes
+                                            + line_chunk.len(),
                                     });
                                 }
                             } else {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -8644,10 +8644,11 @@ impl LineWithInvisibles {
         let text_style = &editor_style.text;
         let mut layouts = Vec::with_capacity(max_line_count);
         let mut fragments: SmallVec<[LineFragment; 1]> = SmallVec::new();
-        let mut line = String::new();
+        let mut line_scratchspace = String::new();
+        let mut line_ingested_utf8_bytes = 0;
         let mut invisibles = Vec::new();
         let mut width = Pixels::ZERO;
-        let mut len = 0;
+        let mut line_sum_of_fragment_lens_utf8_bytes = 0;
         let mut styles = Vec::new();
         let mut non_whitespace_added = false;
         let mut row = 0;
@@ -8665,23 +8666,28 @@ impl LineWithInvisibles {
             replacement: None,
         }]) {
             if let Some(replacement) = highlighted_chunk.replacement {
-                if !line.is_empty() {
+                if !line_scratchspace.is_empty() {
                     let segments = bg_segments_per_row.get(row).map(|v| &v[..]).unwrap_or(&[]);
                     let text_runs: &[TextRun] = if segments.is_empty() {
                         &styles
                     } else {
-                        &Self::split_runs_by_bg_segments(&styles, segments, min_contrast, len)
+                        &Self::split_runs_by_bg_segments(
+                            &styles,
+                            segments,
+                            min_contrast,
+                            line_sum_of_fragment_lens_utf8_bytes,
+                        )
                     };
                     let shaped_line = window.text_system().shape_line(
-                        line.clone().into(),
+                        line_scratchspace.clone().into(),
                         font_size,
                         text_runs,
                         None,
                     );
                     width += shaped_line.width;
-                    len += shaped_line.len;
+                    line_sum_of_fragment_lens_utf8_bytes += shaped_line.len;
                     fragments.push(LineFragment::Text(shaped_line));
-                    line.clear();
+                    line_scratchspace.clear();
                     styles.clear();
                 }
 
@@ -8717,13 +8723,14 @@ impl LineWithInvisibles {
                         );
 
                         width += size.width;
-                        len += highlighted_chunk.text.len();
+                        line_sum_of_fragment_lens_utf8_bytes += highlighted_chunk.text.len();
                         fragments.push(LineFragment::Element {
                             id: renderer.id,
                             element: Some(element),
                             size,
                             len: highlighted_chunk.text.len(),
                         });
+                        line_ingested_utf8_bytes += highlighted_chunk.text.len();
                     }
                     ChunkReplacement::Str(x) => {
                         let text_style = if let Some(style) = highlighted_chunk.style {
@@ -8746,8 +8753,9 @@ impl LineWithInvisibles {
                             .with_len(highlighted_chunk.text.len());
 
                         width += line_layout.width;
-                        len += highlighted_chunk.text.len();
-                        fragments.push(LineFragment::Text(line_layout))
+                        line_sum_of_fragment_lens_utf8_bytes += highlighted_chunk.text.len();
+                        line_ingested_utf8_bytes += line_layout.len;
+                        fragments.push(LineFragment::Text(line_layout));
                     }
                 }
             } else {
@@ -8757,26 +8765,32 @@ impl LineWithInvisibles {
                         let text_runs = if segments.is_empty() {
                             &styles
                         } else {
-                            &Self::split_runs_by_bg_segments(&styles, segments, min_contrast, len)
+                            &Self::split_runs_by_bg_segments(
+                                &styles,
+                                segments,
+                                min_contrast,
+                                line_sum_of_fragment_lens_utf8_bytes,
+                            )
                         };
                         let shaped_line = window.text_system().shape_line(
-                            line.clone().into(),
+                            line_scratchspace.clone().into(),
                             font_size,
                             text_runs,
                             None,
                         );
                         width += shaped_line.width;
-                        len += shaped_line.len;
+                        line_sum_of_fragment_lens_utf8_bytes += shaped_line.len;
                         fragments.push(LineFragment::Text(shaped_line));
                         layouts.push(Self {
                             width: mem::take(&mut width),
-                            len: mem::take(&mut len),
+                            len: mem::take(&mut line_sum_of_fragment_lens_utf8_bytes),
                             fragments: mem::take(&mut fragments),
                             invisibles: std::mem::take(&mut invisibles),
                             font_size,
                         });
+                        line_ingested_utf8_bytes = 0;
 
-                        line.clear();
+                        line_scratchspace.clear();
                         styles.clear();
                         row += 1;
                         line_exceeded_max_len = false;
@@ -8793,8 +8807,8 @@ impl LineWithInvisibles {
                             Cow::Borrowed(text_style)
                         };
 
-                        if line.len() + line_chunk.len() > max_line_len {
-                            let mut chunk_len = max_line_len - line.len();
+                        if line_scratchspace.len() + line_chunk.len() > max_line_len {
+                            let mut chunk_len = max_line_len - line_scratchspace.len();
                             while !line_chunk.is_char_boundary(chunk_len) {
                                 chunk_len -= 1;
                             }
@@ -8818,8 +8832,8 @@ impl LineWithInvisibles {
                             if highlighted_chunk.is_tab {
                                 if non_whitespace_added || !is_soft_wrapped {
                                     invisibles.push(Invisible::Tab {
-                                        line_start_offset: line.len(),
-                                        line_end_offset: line.len() + line_chunk.len(),
+                                        line_start_offset: line_scratchspace.len(),
+                                        line_end_offset: line_scratchspace.len() + line_chunk.len(),
                                     });
                                 }
                             } else {
@@ -8831,17 +8845,18 @@ impl LineWithInvisibles {
                                             && (non_whitespace_added || !is_soft_wrapped)
                                         {
                                             Some(Invisible::Whitespace {
-                                                line_offset: line.len() + index,
+                                                line_offset: line_ingested_utf8_bytes + index,
                                             })
                                         } else {
                                             None
                                         }
                                     },
-                                ))
+                                ));
                             }
                         }
 
-                        line.push_str(line_chunk);
+                        line_scratchspace.push_str(line_chunk);
+                        line_ingested_utf8_bytes += line_chunk.len();
                     }
                 }
             }
@@ -12743,7 +12758,7 @@ mod tests {
     fn test_all_invisibles_drawing(cx: &mut TestAppContext) {
         const TAB_SIZE: u32 = 4;
 
-        let input_text = "\t \t|\t| a b";
+        let input_text = "\t \t|\t| a b c ";
         let expected_invisibles = vec![
             Invisible::Tab {
                 line_start_offset: 0,
@@ -12764,14 +12779,17 @@ mod tests {
                 line_offset: TAB_SIZE as usize * 3 + 1,
             },
             Invisible::Whitespace {
-                line_offset: TAB_SIZE as usize * 3 + 3,
+                line_offset: TAB_SIZE as usize * 3 + 5,
+            },
+            Invisible::Whitespace {
+                line_offset: TAB_SIZE as usize * 3 + 7,
             },
         ];
         assert_eq!(
             expected_invisibles.len(),
             input_text
                 .chars()
-                .filter(|initial_char| initial_char.is_whitespace())
+                .filter(|initial_char| initial_char.is_ascii_whitespace())
                 .count(),
             "Hardcoded expected invisibles differ from the actual ones in '{input_text}'"
         );


### PR DESCRIPTION
Keep track of both rendered and currently buffered chars to correctly place whitespace after any character that is: 1. is_invisible(c) 2. replacement(c).is_some()

Closes #49186 

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Fixed some special whitespace characters (e.x. non-breaking space, form feed) causing regular whitespace markers in the same line to shift to the left

### Before nbsp:
<img width="781" height="316" alt="nbsp-before" src="https://github.com/user-attachments/assets/38c2b84e-b261-413c-a702-ac6e82eb5062" />

### After nbsp:
<img width="1190" height="659" alt="nbsp-after" src="https://github.com/user-attachments/assets/f34f3d0f-1eef-4be8-ad60-459f571f7995" />

### Before form feed:
<img width="1232" height="659" alt="ff-before" src="https://github.com/user-attachments/assets/592302bd-a189-40e4-bcca-7a8018844f69" />

### After form feed:
<img width="860" height="335" alt="ff-after" src="https://github.com/user-attachments/assets/b4d7361f-a65c-445d-9d5f-a5dbf25e4993" />

### Before more dots:
<img width="1129" height="433" alt="weird-before" src="https://github.com/user-attachments/assets/9a4ac5c0-24e5-4f8b-87fa-2a20790474e3" />

### After more dots:
<img width="1091" height="376" alt="weird-after" src="https://github.com/user-attachments/assets/e6e5cc26-16c9-4f4f-b666-4231ce289d98" />

