### PR TITLE
svg_preview: Fix SVG preview opening duplicate tabs

### DIFF
--- a/crates/svg_preview/src/svg_preview_view.rs
+++ b/crates/svg_preview/src/svg_preview_view.rs
@@ -141,7 +141,7 @@ impl SvgPreviewView {
         buffer: &Entity<MultiBuffer>,
         cx: &App,
     ) -> Option<usize> {
-        let buffer_id = buffer.entity_id();
+        let buffer_id = buffer.read(cx).as_singleton()?.entity_id();
         pane.items_of_type::<SvgPreviewView>()
             .find(|view| {
                 view.read(cx)


### PR DESCRIPTION
Release Notes:

- Fixed SVG preview always opening a new tab instead of reusing an existing one for the same file.