### PR TITLE
Revert "gpui: Defer thermal/keyboard state updates when app is borrowed"

### DIFF
--- a/crates/gpui/.rules
+++ b/crates/gpui/.rules
@@ -1,9 +1,0 @@
-# GPUI crate-specific rules
-#
-# This file is non-exhaustive. Check the root .rules for general guidelines.
-
-# Platform callbacks
-
-* Platform callbacks (e.g., `on_keyboard_layout_change`, `on_thermal_state_change`) can fire
-  asynchronously from macOS while `AppCell` is already borrowed. Defer work via
-  `ForegroundExecutor::spawn` rather than borrowing `AppCell` directly in the callback body.

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -732,15 +732,12 @@ impl App {
             let app = Rc::downgrade(&app);
             move || {
                 if let Some(app) = app.upgrade() {
-                    // Use try_borrow_mut because this callback can be called asynchronously
-                    // from macOS while the app is already borrowed during an update.
-                    if let Ok(mut cx) = app.try_borrow_mut() {
-                        cx.keyboard_layout = cx.platform.keyboard_layout();
-                        cx.keyboard_mapper = cx.platform.keyboard_mapper();
-                        cx.keyboard_layout_observers
-                            .clone()
-                            .retain(&(), move |callback| (callback)(&mut cx));
-                    }
+                    let cx = &mut app.borrow_mut();
+                    cx.keyboard_layout = cx.platform.keyboard_layout();
+                    cx.keyboard_mapper = cx.platform.keyboard_mapper();
+                    cx.keyboard_layout_observers
+                        .clone()
+                        .retain(&(), move |callback| (callback)(cx));
                 }
             }
         }));
@@ -749,13 +746,10 @@ impl App {
             let app = Rc::downgrade(&app);
             move || {
                 if let Some(app) = app.upgrade() {
-                    // Use try_borrow_mut because this callback can be called asynchronously
-                    // from macOS while the app is already borrowed during an update.
-                    if let Ok(mut cx) = app.try_borrow_mut() {
-                        cx.thermal_state_observers
-                            .clone()
-                            .retain(&(), move |callback| (callback)(&mut cx));
-                    }
+                    let cx = &mut app.borrow_mut();
+                    cx.thermal_state_observers
+                        .clone()
+                        .retain(&(), move |callback| (callback)(cx));
                 }
             }
         }));

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -654,7 +654,6 @@ impl App {
     ) -> Rc<AppCell> {
         let background_executor = platform.background_executor();
         let foreground_executor = platform.foreground_executor();
-        let callback_executor = foreground_executor.clone();
         assert!(
             background_executor.is_main_thread(),
             "must construct App on main thread"
@@ -731,36 +730,32 @@ impl App {
 
         platform.on_keyboard_layout_change(Box::new({
             let app = Rc::downgrade(&app);
-            let executor = callback_executor.clone();
             move || {
                 if let Some(app) = app.upgrade() {
-                    executor
-                        .spawn(async move {
-                            let mut cx = app.borrow_mut();
-                            cx.keyboard_layout = cx.platform.keyboard_layout();
-                            cx.keyboard_mapper = cx.platform.keyboard_mapper();
-                            cx.keyboard_layout_observers
-                                .clone()
-                                .retain(&(), move |callback| (callback)(&mut cx));
-                        })
-                        .detach();
+                    // Use try_borrow_mut because this callback can be called asynchronously
+                    // from macOS while the app is already borrowed during an update.
+                    if let Ok(mut cx) = app.try_borrow_mut() {
+                        cx.keyboard_layout = cx.platform.keyboard_layout();
+                        cx.keyboard_mapper = cx.platform.keyboard_mapper();
+                        cx.keyboard_layout_observers
+                            .clone()
+                            .retain(&(), move |callback| (callback)(&mut cx));
+                    }
                 }
             }
         }));
 
         platform.on_thermal_state_change(Box::new({
             let app = Rc::downgrade(&app);
-            let executor = callback_executor;
             move || {
                 if let Some(app) = app.upgrade() {
-                    executor
-                        .spawn(async move {
-                            let mut cx = app.borrow_mut();
-                            cx.thermal_state_observers
-                                .clone()
-                                .retain(&(), move |callback| (callback)(&mut cx));
-                        })
-                        .detach();
+                    // Use try_borrow_mut because this callback can be called asynchronously
+                    // from macOS while the app is already borrowed during an update.
+                    if let Ok(mut cx) = app.try_borrow_mut() {
+                        cx.thermal_state_observers
+                            .clone()
+                            .retain(&(), move |callback| (callback)(&mut cx));
+                    }
                 }
             }
         }));


### PR DESCRIPTION
Reverts #49189
Reverts #49187

#49189 introduces a panic (https://github.com/zed-industries/zed/pull/49189#issuecomment-3904914597, https://github.com/zed-industries/zed/issues/49181#issuecomment-3906639392)
#49187 It's wrong since it leads to missing updates

The original crash should be fixed with #49086

cc: @bennetbo 

Release Notes:

- N/A
