### PR TITLE
editor: Show hover popover at the cursor position instead of the start of the range

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -5268,8 +5268,7 @@ impl EditorElement {
                 cx,
             )
         });
-        let Some((popover_position, hover_popovers, popover_alignment)) = hover_popovers
-        else {
+        let Some((popover_position, hover_popovers, popover_alignment)) = hover_popovers else {
             return;
         };
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -24,7 +24,7 @@ use crate::{
     git::blame::{BlameRenderer, GitBlame, GlobalBlameRenderer},
     hover_popover::{
         self, HOVER_POPOVER_GAP, MIN_POPOVER_CHARACTER_WIDTH, MIN_POPOVER_LINE_HEIGHT,
-        POPOVER_RIGHT_OFFSET, hover_at,
+        POPOVER_LEFT_OFFSET, POPOVER_RIGHT_OFFSET, hover_at,
     },
     inlay_hint_settings,
     mouse_context_menu::{self, MenuPosition},
@@ -5268,7 +5268,8 @@ impl EditorElement {
                 cx,
             )
         });
-        let Some((popover_position, hover_popovers)) = hover_popovers else {
+        let Some((popover_position, hover_popovers, is_popover_left_aligned)) = hover_popovers
+        else {
             return;
         };
 
@@ -5291,9 +5292,14 @@ impl EditorElement {
         let mut measured_hover_popovers = Vec::new();
         for (position, mut hover_popover) in hover_popovers.into_iter().with_position() {
             let size = hover_popover.layout_as_root(AvailableSpace::min_size(), window, cx);
-            let horizontal_offset =
-                (hitbox.top_right().x - POPOVER_RIGHT_OFFSET - (hovered_point.x + size.width))
-                    .min(Pixels::ZERO);
+            let horizontal_offset = if is_popover_left_aligned {
+                (hitbox.left() + POPOVER_LEFT_OFFSET - (hovered_point.x - size.width))
+                    .max(Pixels::ZERO)
+                    - size.width
+            } else {
+                (hitbox.right() - POPOVER_RIGHT_OFFSET - (hovered_point.x + size.width))
+                    .min(Pixels::ZERO)
+            };
             match position {
                 itertools::Position::Middle | itertools::Position::Last => {
                     overall_height += HOVER_POPOVER_GAP

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -5268,7 +5268,7 @@ impl EditorElement {
                 cx,
             )
         });
-        let Some((popover_position, hover_popovers, is_popover_left_aligned)) = hover_popovers
+        let Some((popover_position, hover_popovers, popover_alignment)) = hover_popovers
         else {
             return;
         };
@@ -5293,7 +5293,7 @@ impl EditorElement {
         for (position, mut hover_popover) in hover_popovers.into_iter().with_position() {
             let size = hover_popover.layout_as_root(AvailableSpace::min_size(), window, cx);
             let horizontal_offset = hover_popover_horizontal_offset(
-                is_popover_left_aligned,
+                popover_alignment,
                 hovered_point.x,
                 size.width,
                 hitbox.bounds,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -24,7 +24,7 @@ use crate::{
     git::blame::{BlameRenderer, GitBlame, GlobalBlameRenderer},
     hover_popover::{
         self, HOVER_POPOVER_GAP, MIN_POPOVER_CHARACTER_WIDTH, MIN_POPOVER_LINE_HEIGHT,
-        POPOVER_LEFT_OFFSET, POPOVER_RIGHT_OFFSET, hover_at,
+        POPOVER_RIGHT_OFFSET, hover_at, hover_popover_horizontal_offset,
     },
     inlay_hint_settings,
     mouse_context_menu::{self, MenuPosition},
@@ -5292,14 +5292,12 @@ impl EditorElement {
         let mut measured_hover_popovers = Vec::new();
         for (position, mut hover_popover) in hover_popovers.into_iter().with_position() {
             let size = hover_popover.layout_as_root(AvailableSpace::min_size(), window, cx);
-            let horizontal_offset = if is_popover_left_aligned {
-                (hitbox.left() + POPOVER_LEFT_OFFSET - (hovered_point.x - size.width))
-                    .max(Pixels::ZERO)
-                    - size.width
-            } else {
-                (hitbox.right() - POPOVER_RIGHT_OFFSET - (hovered_point.x + size.width))
-                    .min(Pixels::ZERO)
-            };
+            let horizontal_offset = hover_popover_horizontal_offset(
+                is_popover_left_aligned,
+                hovered_point.x,
+                size.width,
+                hitbox.bounds,
+            );
             match position {
                 itertools::Position::Middle | itertools::Position::Last => {
                     overall_height += HOVER_POPOVER_GAP

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -35,22 +35,31 @@ pub const POPOVER_RIGHT_OFFSET: Pixels = px(8.0);
 pub const POPOVER_LEFT_OFFSET: Pixels = px(8.0);
 pub const HOVER_POPOVER_GAP: Pixels = px(10.);
 
-/// Computes the horizontal offset for a hover popover. If `is_popover_left_aligned` is true,
-/// the popover ends at cursor and does not extend past the left side of `bounds`. Otherwise,
-/// the popover starts at cursor and does not extend past the right side of `bounds`.
+#[derive(Clone, Copy)]
+pub enum PopoverAlignment {
+    Left,
+    Right,
+}
+
+/// Computes the horizontal offset for a hover popover. If `popover_alignment` is `Left`,
+/// the popover ends at cursor and does not extend past the left side of `hitbox_bounds`. Otherwise,
+/// the popover starts at cursor and does not extend past the right side of `hitbox_bounds`.
 pub(crate) fn hover_popover_horizontal_offset(
-    is_popover_left_aligned: bool,
+    popover_alignment: PopoverAlignment,
     hovered_point_x: Pixels,
     popover_width: Pixels,
     hitbox_bounds: Bounds<Pixels>,
 ) -> Pixels {
-    if is_popover_left_aligned {
-        (hitbox_bounds.left() + POPOVER_LEFT_OFFSET - (hovered_point_x - popover_width))
-            .max(Pixels::ZERO)
-            - popover_width
-    } else {
-        (hitbox_bounds.right() - POPOVER_RIGHT_OFFSET - (hovered_point_x + popover_width))
-            .min(Pixels::ZERO)
+    match popover_alignment {
+        PopoverAlignment::Left => {
+            (hitbox_bounds.left() + POPOVER_LEFT_OFFSET - (hovered_point_x - popover_width))
+                .max(Pixels::ZERO)
+                - popover_width
+        }
+        PopoverAlignment::Right => {
+            (hitbox_bounds.right() - POPOVER_RIGHT_OFFSET - (hovered_point_x + popover_width))
+                .min(Pixels::ZERO)
+        }
     }
 }
 
@@ -810,13 +819,18 @@ impl HoverState {
         text_layout_details: &TextLayoutDetails,
         window: &mut Window,
         cx: &mut Context<Editor>,
-    ) -> Option<(DisplayPoint, Vec<AnyElement>, bool)> {
+    ) -> Option<(DisplayPoint, Vec<AnyElement>, PopoverAlignment)> {
         if !self.visible() {
             return None;
         }
+
         // align the popover to the left of the cursor if there is a diagnostic (e.g. a warning or error)
         // and to the right otherwise (e.g. an LSP hover)
-        let is_popover_left_aligned = self.diagnostic_popover.is_some();
+        let popover_alignment = if self.diagnostic_popover.is_some() {
+            PopoverAlignment::Left
+        } else {
+            PopoverAlignment::Right
+        };
 
         // If there is a diagnostic, position the popovers at the cursor/hover position.
         // Otherwise use the start of the hover range
@@ -878,7 +892,7 @@ impl HoverState {
             elements.push(info_popover.render(max_size, window, cx));
         }
 
-        Some((point, elements, is_popover_left_aligned))
+        Some((point, elements, popover_alignment))
     }
 
     pub fn focused(&self, window: &mut Window, cx: &mut Context<Editor>) -> bool {

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -1090,7 +1090,7 @@ mod tests {
         test::editor_lsp_test_context::EditorLspTestContext,
     };
     use collections::BTreeSet;
-    use gpui::App;
+    use gpui::{App, Bounds, Point};
     use indoc::indoc;
     use markdown::parser::MarkdownEvent;
     use project::InlayId;
@@ -2039,5 +2039,85 @@ mod tests {
             range,
             InlayOffset(MultiBufferOffset(104))..InlayOffset(MultiBufferOffset(108))
         );
+    }
+
+    #[test]
+    fn test_hover_popover_horizontal_offset_left_aligned_does_not_exceed_border() {
+        let hitbox_bounds = Bounds {
+            origin: Point::default(),
+            size: Size {
+                width: px(300.),
+                height: px(0.),
+            },
+        };
+        let cursor_x = px(200.);
+        let popover_width = px(80.);
+        let horizontal_offset = hover_popover_horizontal_offset(
+            PopoverAlignment::Left,
+            cursor_x,
+            popover_width,
+            hitbox_bounds,
+        );
+        assert_eq!(horizontal_offset, px(-80.));
+    }
+
+    #[test]
+    fn test_hover_popover_horizontal_offset_left_aligned_exceeds_border() {
+        let hitbox_bounds = Bounds {
+            origin: Point::default(),
+            size: Size {
+                width: px(300.),
+                height: px(0.),
+            },
+        };
+        let cursor_x = px(50.);
+        let popover_width = px(80.);
+        let horizontal_offset = hover_popover_horizontal_offset(
+            PopoverAlignment::Left,
+            cursor_x,
+            popover_width,
+            hitbox_bounds,
+        );
+        assert_eq!(horizontal_offset, px(-50.) + POPOVER_LEFT_OFFSET);
+    }
+
+    #[test]
+    fn test_hover_popover_horizontal_offset_right_aligned_does_not_exceed_border() {
+        let hitbox_bounds = Bounds {
+            origin: Point::default(),
+            size: Size {
+                width: px(300.),
+                height: px(0.),
+            },
+        };
+        let cursor_x = px(50.);
+        let popover_width = px(80.);
+        let horizontal_offset = hover_popover_horizontal_offset(
+            PopoverAlignment::Right,
+            cursor_x,
+            popover_width,
+            hitbox_bounds,
+        );
+        assert_eq!(horizontal_offset, px(0.));
+    }
+
+    #[test]
+    fn test_hover_popover_horizontal_offset_right_aligned_exceeds_border() {
+        let hitbox_bounds = Bounds {
+            origin: Point::default(),
+            size: Size {
+                width: px(300.),
+                height: px(0.),
+            },
+        };
+        let cursor_x = px(250.);
+        let popover_width = px(80.);
+        let horizontal_offset = hover_popover_horizontal_offset(
+            PopoverAlignment::Right,
+            cursor_x,
+            popover_width,
+            hitbox_bounds,
+        );
+        assert_eq!(horizontal_offset, px(-30.) - POPOVER_RIGHT_OFFSET);
     }
 }

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -794,12 +794,12 @@ impl HoverState {
         if !self.visible() {
             return None;
         }
-        // If there is a diagnostic, position the popovers based on that.
+        // If there is a diagnostic, position the popovers at the cursor/hover position.
         // Otherwise use the start of the hover range
         let anchor = self
             .diagnostic_popover
             .as_ref()
-            .map(|diagnostic_popover| &diagnostic_popover.local_diagnostic.range.start)
+            .map(|diagnostic_popover| &diagnostic_popover.anchor)
             .or_else(|| {
                 self.info_popovers.iter().find_map(|info_popover| {
                     match &info_popover.symbol_range {
@@ -818,11 +818,11 @@ impl HoverState {
             })?;
         let mut point = anchor.to_display_point(&snapshot.display_snapshot);
         // Clamp the point within the visible rows in case the popup source spans multiple lines
-        if visible_rows.end <= point.row() {
+        if point.row() >= visible_rows.end {
             point = crate::movement::up_by_rows(
                 &snapshot.display_snapshot,
                 point,
-                1 + (point.row() - visible_rows.end).0,
+                (point.row() - visible_rows.end + 1).0,
                 text::SelectionGoal::None,
                 true,
                 text_layout_details,

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -32,6 +32,7 @@ use workspace::{OpenOptions, OpenVisible, Workspace};
 pub const MIN_POPOVER_CHARACTER_WIDTH: f32 = 20.;
 pub const MIN_POPOVER_LINE_HEIGHT: f32 = 4.;
 pub const POPOVER_RIGHT_OFFSET: Pixels = px(8.0);
+pub const POPOVER_LEFT_OFFSET: Pixels = px(8.0);
 pub const HOVER_POPOVER_GAP: Pixels = px(10.);
 
 /// Bindable action which uses the most recent selection head to trigger a hover
@@ -790,10 +791,14 @@ impl HoverState {
         text_layout_details: &TextLayoutDetails,
         window: &mut Window,
         cx: &mut Context<Editor>,
-    ) -> Option<(DisplayPoint, Vec<AnyElement>)> {
+    ) -> Option<(DisplayPoint, Vec<AnyElement>, bool)> {
         if !self.visible() {
             return None;
         }
+        // align the popover to the left of the cursor if there is a diagnostic (e.g. a warning or error)
+        // and to the right otherwise (e.g. an LSP hover)
+        let is_popover_left_aligned = self.diagnostic_popover.is_some();
+
         // If there is a diagnostic, position the popovers at the cursor/hover position.
         // Otherwise use the start of the hover range
         let anchor = self
@@ -854,7 +859,7 @@ impl HoverState {
             elements.push(info_popover.render(max_size, window, cx));
         }
 
-        Some((point, elements))
+        Some((point, elements, is_popover_left_aligned))
     }
 
     pub fn focused(&self, window: &mut Window, cx: &mut Context<Editor>) -> bool {

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use anyhow::Context as _;
 use gpui::{
-    AnyElement, AsyncWindowContext, Context, Entity, Focusable as _, FontWeight, Hsla,
+    AnyElement, AsyncWindowContext, Bounds, Context, Entity, Focusable as _, FontWeight, Hsla,
     InteractiveElement, IntoElement, MouseButton, ParentElement, Pixels, ScrollHandle, Size,
     StatefulInteractiveElement, StyleRefinement, Styled, Subscription, Task, TextStyleRefinement,
     Window, div, px,
@@ -34,6 +34,25 @@ pub const MIN_POPOVER_LINE_HEIGHT: f32 = 4.;
 pub const POPOVER_RIGHT_OFFSET: Pixels = px(8.0);
 pub const POPOVER_LEFT_OFFSET: Pixels = px(8.0);
 pub const HOVER_POPOVER_GAP: Pixels = px(10.);
+
+/// Computes the horizontal offset for a hover popover. If `is_popover_left_aligned` is true,
+/// the popover ends at cursor and does not extend past the left side of `bounds`. Otherwise,
+/// the popover starts at cursor and does not extend past the right side of `bounds`.
+pub(crate) fn hover_popover_horizontal_offset(
+    is_popover_left_aligned: bool,
+    hovered_point_x: Pixels,
+    popover_width: Pixels,
+    hitbox_bounds: Bounds<Pixels>,
+) -> Pixels {
+    if is_popover_left_aligned {
+        (hitbox_bounds.left() + POPOVER_LEFT_OFFSET - (hovered_point_x - popover_width))
+            .max(Pixels::ZERO)
+            - popover_width
+    } else {
+        (hitbox_bounds.right() - POPOVER_RIGHT_OFFSET - (hovered_point_x + popover_width))
+            .min(Pixels::ZERO)
+    }
+}
 
 /// Bindable action which uses the most recent selection head to trigger a hover
 pub fn hover(editor: &mut Editor, _: &Hover, window: &mut Window, cx: &mut Context<Editor>) {


### PR DESCRIPTION
Closes #46841

When hovering over a multiline diagnostic (eg, a warning or an error), the popover is currently shown at the start of the diagnostic range (i.e., the first line). This can be problematic when the diagnostic spans multiple lines and the user is hovering near the bottom lines.

Users typically expect the popover to appear near their cursor position, not several lines above it. Additionally, if the cursor moves into surrounding whitespace, the popover disappears, as shown in the original issue #46841 by @injust (credit: the video below is taken from that issue)

https://github.com/user-attachments/assets/21b501be-cda1-4303-8c1e-267e854190fb

The PR #47471 by @daydalek proposed keeping the diagnostic hover visible as long as the mouse row intersects with the active diagnostic's range, as shown below (credit: the video below is taken from that PR)

https://github.com/user-attachments/assets/26269986-31d5-4385-8727-bad7d5d9b55e

However, as previously mentioned, users typically expect the popover to appear near their cursor position. Also, @xdBronch noticed that...
> a possible problem with this [fix] is how it interacts with inactive regions in clangd which are implemented using diagnostics. since its between #ifdefs the diagnostic can often be hundreds or even thousands of lines which means the hover will basically never go away since the whole screen is a diagnostic

This PR proposes fixing the aforementioned issues by positioning the popover near the cursor instead of the start of the diagnostic range, similar to user expectations and the behavior of other editors, such as VS Code.

In the videos below, note that the popovers do not exceed the window boundaries.

### Hovering with the mouse

https://github.com/user-attachments/assets/54ed40c7-355c-45ae-8917-6b49d5cf1dd1

### Hovering with the keyboard in Vim mode (Shift+K)

https://github.com/user-attachments/assets/99469ebf-3c4d-4c15-8570-c726636200c2

---

Checklist

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- The diagnostic hover popover is now shown at the cursor position instead of the start of the diagnostic range.
- Diagnostic hover popovers are aligned to the left of the cursor.
- Other hover popovers (e.g., LSP hints and type definitions) remain aligned to the right of the cursor.

---

## AI Assistance Disclosure

The tests in this PR were generated using AI, then reviewed and enhanced by me.
The implementation and overall changes were written by me with the assistance of AI.
This PR description is written by me and peer-reviewed by AI.