### PR TITLE
Add automatic syntax highlighting for GeoJSON files

### DIFF
--- a/crates/languages/src/json/config.toml
+++ b/crates/languages/src/json/config.toml
@@ -1,6 +1,6 @@
 name = "JSON"
 grammar = "json"
-path_suffixes = ["json", "flake.lock"]
+path_suffixes = ["json", "flake.lock", "geojson"]
 line_comments = ["// "]
 autoclose_before = ",]}"
 brackets = [


### PR DESCRIPTION
GeoJSON is a popular geospatial data interchange format, standardised as [RFC 7946](https://datatracker.ietf.org/doc/html/rfc7946). Because all GeoJSON files are valid JSON files, they can be highlighted using Zed's existing JSON language support.

This change adds `geojson` as a recognised path suffix, so GeoJSON files automatically open as JSON and get the standard JSON syntax highlighting.

Before and after screenshots:

<img width="1748" height="755" alt="geojson" src="https://github.com/user-attachments/assets/40199248-1ce5-451e-9200-5b2f012b865f" />

Release Notes:

- Added automatic syntax highlighting for GeoJSON files
