### PR TITLE
ruby: Add Kanayago as an available language server

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -2095,7 +2095,7 @@
       "language_servers": ["basedpyright", "ruff", "!ty", "!pyrefly", "!pyright", "!pylsp", "..."],
     },
     "Ruby": {
-      "language_servers": ["solargraph", "!ruby-lsp", "!rubocop", "!sorbet", "!steep", "..."],
+      "language_servers": ["solargraph", "!ruby-lsp", "!rubocop", "!sorbet", "!steep", "!kanayago", "..."],
     },
     "Rust": {
       "debuggers": ["CodeLLDB"],


### PR DESCRIPTION
Add Kanayago as an available Ruby language server in default settings. Disabled by default (prefixed with `!`), users can opt-in via their settings.

This corresponds to the extension-side support added in zed-extensions/ruby#224.

Release Notes:

- ruby: Added Kanayago as an available language server.