### PR TITLE
acp: Refresh history less often

### DIFF
--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -1452,16 +1452,58 @@ impl NativeAgentSessionList {
     fn new(thread_store: Entity<ThreadStore>, cx: &mut App) -> Self {
         let (tx, rx) = smol::channel::unbounded();
         let this_tx = tx.clone();
-        let subscription = cx.observe(&thread_store, move |_, _| {
-            this_tx
-                .try_send(acp_thread::SessionListUpdate::Refresh)
-                .ok();
+        let mut previous_entries: Vec<DbThreadMetadata> = thread_store.read(cx).entries().collect();
+        let subscription = cx.observe(&thread_store, move |store, cx| {
+            let current_entries: Vec<DbThreadMetadata> = store.read(cx).entries().collect();
+            Self::diff_and_send(&this_tx, &previous_entries, &current_entries);
+            previous_entries = current_entries;
         });
         Self {
             thread_store,
             updates_tx: tx,
             updates_rx: rx,
             _subscription: subscription,
+        }
+    }
+
+    fn diff_and_send(
+        tx: &smol::channel::Sender<acp_thread::SessionListUpdate>,
+        previous: &[DbThreadMetadata],
+        current: &[DbThreadMetadata],
+    ) {
+        let previous_ids: HashSet<&acp::SessionId> = previous.iter().map(|e| &e.id).collect();
+        let current_ids: HashSet<&acp::SessionId> = current.iter().map(|e| &e.id).collect();
+
+        if previous_ids != current_ids {
+            tx.try_send(acp_thread::SessionListUpdate::Refresh)
+                .log_err();
+            return;
+        }
+
+        let previous_by_id: HashMap<&acp::SessionId, &DbThreadMetadata> =
+            previous.iter().map(|e| (&e.id, e)).collect();
+        for entry in current {
+            let Some(previous_entry) = previous_by_id.get(&entry.id) else {
+                continue;
+            };
+            let title_changed = entry.title != previous_entry.title;
+            let updated_at_changed = entry.updated_at != previous_entry.updated_at;
+            if !title_changed && !updated_at_changed {
+                continue;
+            }
+
+            let mut info_update = acp::SessionInfoUpdate::new();
+            if title_changed {
+                info_update = info_update.title(entry.title.to_string());
+            }
+            if updated_at_changed {
+                info_update = info_update.updated_at(entry.updated_at.to_rfc3339());
+            }
+            tx.try_send(acp_thread::SessionListUpdate::SessionInfo {
+                session_id: entry.id.clone(),
+                update: info_update,
+            })
+            .log_err();
         }
     }
 

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -1452,58 +1452,16 @@ impl NativeAgentSessionList {
     fn new(thread_store: Entity<ThreadStore>, cx: &mut App) -> Self {
         let (tx, rx) = smol::channel::unbounded();
         let this_tx = tx.clone();
-        let mut previous_entries: Vec<DbThreadMetadata> = thread_store.read(cx).entries().collect();
-        let subscription = cx.observe(&thread_store, move |store, cx| {
-            let current_entries: Vec<DbThreadMetadata> = store.read(cx).entries().collect();
-            Self::diff_and_send(&this_tx, &previous_entries, &current_entries);
-            previous_entries = current_entries;
+        let subscription = cx.observe(&thread_store, move |_, _| {
+            this_tx
+                .try_send(acp_thread::SessionListUpdate::Refresh)
+                .ok();
         });
         Self {
             thread_store,
             updates_tx: tx,
             updates_rx: rx,
             _subscription: subscription,
-        }
-    }
-
-    fn diff_and_send(
-        tx: &smol::channel::Sender<acp_thread::SessionListUpdate>,
-        previous: &[DbThreadMetadata],
-        current: &[DbThreadMetadata],
-    ) {
-        let previous_ids: HashSet<&acp::SessionId> = previous.iter().map(|e| &e.id).collect();
-        let current_ids: HashSet<&acp::SessionId> = current.iter().map(|e| &e.id).collect();
-
-        if previous_ids != current_ids {
-            tx.try_send(acp_thread::SessionListUpdate::Refresh)
-                .log_err();
-            return;
-        }
-
-        let previous_by_id: HashMap<&acp::SessionId, &DbThreadMetadata> =
-            previous.iter().map(|e| (&e.id, e)).collect();
-        for entry in current {
-            let Some(previous_entry) = previous_by_id.get(&entry.id) else {
-                continue;
-            };
-            let title_changed = entry.title != previous_entry.title;
-            let updated_at_changed = entry.updated_at != previous_entry.updated_at;
-            if !title_changed && !updated_at_changed {
-                continue;
-            }
-
-            let mut info_update = acp::SessionInfoUpdate::new();
-            if title_changed {
-                info_update = info_update.title(entry.title.to_string());
-            }
-            if updated_at_changed {
-                info_update = info_update.updated_at(entry.updated_at.to_rfc3339());
-            }
-            tx.try_send(acp_thread::SessionListUpdate::SessionInfo {
-                session_id: entry.id.clone(),
-                update: info_update,
-            })
-            .log_err();
         }
     }
 

--- a/crates/agent_ui/src/acp/thread_history.rs
+++ b/crates/agent_ui/src/acp/thread_history.rs
@@ -29,6 +29,7 @@ fn thread_title(entry: &AgentSessionInfo) -> &SharedString {
 
 pub struct AcpThreadHistory {
     session_list: Option<Rc<dyn AgentSessionList>>,
+    prefer_full_refreshes: bool,
     sessions: Vec<AgentSessionInfo>,
     scroll_handle: UniformListScrollHandle,
     selected_index: usize,
@@ -99,6 +100,7 @@ impl AcpThreadHistory {
 
         let mut this = Self {
             session_list: None,
+            prefer_full_refreshes: false,
             sessions: Vec::new(),
             scroll_handle,
             selected_index: 0,
@@ -183,7 +185,7 @@ impl AcpThreadHistory {
         let Some(rx) = session_list.watch(cx) else {
             // No watch support - do a one-time refresh
             self._watch_task = None;
-            self.refresh_sessions(false, cx);
+            self.refresh_sessions(false, self.prefer_full_refreshes, cx);
             return;
         };
         session_list.notify_refresh();
@@ -196,25 +198,36 @@ impl AcpThreadHistory {
                     updates.push(update);
                 }
 
-                let needs_refresh = updates
-                    .iter()
-                    .any(|u| matches!(u, SessionListUpdate::Refresh));
-
                 this.update(cx, |this, cx| {
-                    // We will refresh the whole list anyway, so no need to apply incremental updates or do several refreshes
-                    if needs_refresh {
-                        this.refresh_sessions(true, cx);
-                    } else {
-                        for update in updates {
-                            if let SessionListUpdate::SessionInfo { session_id, update } = update {
+                    let mut needs_refresh = false;
+                    for update in updates {
+                        match update {
+                            SessionListUpdate::Refresh => needs_refresh = true,
+                            SessionListUpdate::SessionInfo { session_id, update } => {
                                 this.apply_info_update(session_id, update, cx);
                             }
                         }
+                    }
+
+                    if needs_refresh {
+                        this.refresh_sessions(true, this.prefer_full_refreshes, cx);
                     }
                 })
                 .ok();
             }
         }));
+    }
+
+    pub(crate) fn refresh_full_history(&mut self, cx: &mut Context<Self>) {
+        self.refresh_sessions(true, true, cx);
+    }
+
+    pub(crate) fn set_prefer_full_refreshes(
+        &mut self,
+        prefer_full_refreshes: bool,
+        _cx: &mut Context<Self>,
+    ) {
+        self.prefer_full_refreshes = prefer_full_refreshes;
     }
 
     fn apply_info_update(
@@ -258,7 +271,12 @@ impl AcpThreadHistory {
         self.update_visible_items(true, cx);
     }
 
-    fn refresh_sessions(&mut self, preserve_selected_item: bool, cx: &mut Context<Self>) {
+    fn refresh_sessions(
+        &mut self,
+        preserve_selected_item: bool,
+        load_all_pages: bool,
+        cx: &mut Context<Self>,
+    ) {
         let Some(session_list) = self.session_list.clone() else {
             self.update_visible_items(preserve_selected_item, cx);
             return;
@@ -299,6 +317,10 @@ impl AcpThreadHistory {
                 .ok();
 
                 is_first_page = false;
+                if !load_all_pages {
+                    break;
+                }
+
                 match next_cursor {
                     Some(next_cursor) => {
                         if cursor.as_ref() == Some(&next_cursor) {
@@ -1054,7 +1076,11 @@ mod tests {
     use acp_thread::AgentSessionListResponse;
     use chrono::NaiveDate;
     use gpui::TestAppContext;
-    use std::any::Any;
+    use std::{
+        any::Any,
+        cell::RefCell,
+        sync::{Arc, Mutex},
+    };
 
     fn init_test(cx: &mut TestAppContext) {
         cx.update(|cx| {
@@ -1106,6 +1132,389 @@ mod tests {
         fn into_any(self: Rc<Self>) -> Rc<dyn Any> {
             self
         }
+    }
+
+    #[derive(Clone)]
+    struct PaginatedTestSessionList {
+        first_page_sessions: Vec<AgentSessionInfo>,
+        second_page_sessions: Vec<AgentSessionInfo>,
+        requested_cursors: Rc<RefCell<Vec<Option<String>>>>,
+        updates_tx: smol::channel::Sender<SessionListUpdate>,
+        updates_rx: smol::channel::Receiver<SessionListUpdate>,
+    }
+
+    impl PaginatedTestSessionList {
+        fn new(
+            first_page_sessions: Vec<AgentSessionInfo>,
+            second_page_sessions: Vec<AgentSessionInfo>,
+        ) -> Self {
+            let (tx, rx) = smol::channel::unbounded();
+            Self {
+                first_page_sessions,
+                second_page_sessions,
+                requested_cursors: Rc::new(RefCell::new(Vec::new())),
+                updates_tx: tx,
+                updates_rx: rx,
+            }
+        }
+
+        fn requested_cursors(&self) -> Vec<Option<String>> {
+            self.requested_cursors.borrow().clone()
+        }
+
+        fn clear_requested_cursors(&self) {
+            self.requested_cursors.borrow_mut().clear();
+        }
+
+        fn send_update(&self, update: SessionListUpdate) {
+            self.updates_tx.try_send(update).ok();
+        }
+    }
+
+    impl AgentSessionList for PaginatedTestSessionList {
+        fn list_sessions(
+            &self,
+            request: AgentSessionListRequest,
+            _cx: &mut App,
+        ) -> Task<anyhow::Result<AgentSessionListResponse>> {
+            self.requested_cursors
+                .borrow_mut()
+                .push(request.cursor.clone());
+
+            let response = match request.cursor.as_deref() {
+                None => AgentSessionListResponse {
+                    sessions: self.first_page_sessions.clone(),
+                    next_cursor: Some("page-2".to_string()),
+                    meta: None,
+                },
+                Some("page-2") => AgentSessionListResponse::new(self.second_page_sessions.clone()),
+                Some(_) => AgentSessionListResponse::new(Vec::new()),
+            };
+
+            Task::ready(Ok(response))
+        }
+
+        fn watch(&self, _cx: &mut App) -> Option<smol::channel::Receiver<SessionListUpdate>> {
+            Some(self.updates_rx.clone())
+        }
+
+        fn notify_refresh(&self) {
+            self.updates_tx.try_send(SessionListUpdate::Refresh).ok();
+        }
+
+        fn into_any(self: Rc<Self>) -> Rc<dyn Any> {
+            self
+        }
+    }
+
+    #[derive(Clone)]
+    struct AsyncPaginatedTestSessionList {
+        first_page_sessions: Vec<AgentSessionInfo>,
+        second_page_sessions: Vec<AgentSessionInfo>,
+        requested_cursors: Arc<Mutex<Vec<Option<String>>>>,
+        updates_tx: smol::channel::Sender<SessionListUpdate>,
+        updates_rx: smol::channel::Receiver<SessionListUpdate>,
+    }
+
+    impl AsyncPaginatedTestSessionList {
+        fn new(
+            first_page_sessions: Vec<AgentSessionInfo>,
+            second_page_sessions: Vec<AgentSessionInfo>,
+        ) -> Self {
+            let (tx, rx) = smol::channel::unbounded();
+            Self {
+                first_page_sessions,
+                second_page_sessions,
+                requested_cursors: Arc::new(Mutex::new(Vec::new())),
+                updates_tx: tx,
+                updates_rx: rx,
+            }
+        }
+
+        fn requested_cursors(&self) -> Vec<Option<String>> {
+            self.requested_cursors.lock().unwrap().clone()
+        }
+
+        fn clear_requested_cursors(&self) {
+            self.requested_cursors.lock().unwrap().clear();
+        }
+    }
+
+    impl AgentSessionList for AsyncPaginatedTestSessionList {
+        fn list_sessions(
+            &self,
+            request: AgentSessionListRequest,
+            cx: &mut App,
+        ) -> Task<anyhow::Result<AgentSessionListResponse>> {
+            let requested_cursors = self.requested_cursors.clone();
+            let first_page_sessions = self.first_page_sessions.clone();
+            let second_page_sessions = self.second_page_sessions.clone();
+            cx.foreground_executor().spawn(async move {
+                smol::future::yield_now().await;
+
+                requested_cursors
+                    .lock()
+                    .unwrap()
+                    .push(request.cursor.clone());
+
+                let response = match request.cursor.as_deref() {
+                    None => AgentSessionListResponse {
+                        sessions: first_page_sessions,
+                        next_cursor: Some("page-2".to_string()),
+                        meta: None,
+                    },
+                    Some("page-2") => AgentSessionListResponse::new(second_page_sessions),
+                    Some(_) => AgentSessionListResponse::new(Vec::new()),
+                };
+
+                Ok(response)
+            })
+        }
+
+        fn watch(&self, _cx: &mut App) -> Option<smol::channel::Receiver<SessionListUpdate>> {
+            Some(self.updates_rx.clone())
+        }
+
+        fn notify_refresh(&self) {
+            self.updates_tx.try_send(SessionListUpdate::Refresh).ok();
+        }
+
+        fn into_any(self: Rc<Self>) -> Rc<dyn Any> {
+            self
+        }
+    }
+
+    fn test_session(session_id: &str, title: &str) -> AgentSessionInfo {
+        AgentSessionInfo {
+            session_id: acp::SessionId::new(session_id),
+            cwd: None,
+            title: Some(title.to_string().into()),
+            updated_at: None,
+            meta: None,
+        }
+    }
+
+    #[gpui::test]
+    async fn test_refresh_only_loads_first_page_by_default(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let session_list = Rc::new(PaginatedTestSessionList::new(
+            vec![test_session("session-1", "First")],
+            vec![test_session("session-2", "Second")],
+        ));
+
+        let (history, cx) = cx.add_window_view(|window, cx| {
+            AcpThreadHistory::new(Some(session_list.clone()), window, cx)
+        });
+        cx.run_until_parked();
+
+        history.update(cx, |history, _cx| {
+            assert_eq!(history.sessions.len(), 1);
+            assert_eq!(
+                history.sessions[0].session_id,
+                acp::SessionId::new("session-1")
+            );
+        });
+        assert_eq!(session_list.requested_cursors(), vec![None]);
+    }
+
+    #[gpui::test]
+    async fn test_enabling_full_pagination_loads_all_pages(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let session_list = Rc::new(PaginatedTestSessionList::new(
+            vec![test_session("session-1", "First")],
+            vec![test_session("session-2", "Second")],
+        ));
+
+        let (history, cx) = cx.add_window_view(|window, cx| {
+            AcpThreadHistory::new(Some(session_list.clone()), window, cx)
+        });
+        cx.run_until_parked();
+        session_list.clear_requested_cursors();
+
+        history.update(cx, |history, cx| history.refresh_full_history(cx));
+        cx.run_until_parked();
+
+        history.update(cx, |history, _cx| {
+            assert_eq!(history.sessions.len(), 2);
+            assert_eq!(
+                history.sessions[0].session_id,
+                acp::SessionId::new("session-1")
+            );
+            assert_eq!(
+                history.sessions[1].session_id,
+                acp::SessionId::new("session-2")
+            );
+        });
+        assert_eq!(
+            session_list.requested_cursors(),
+            vec![None, Some("page-2".to_string())]
+        );
+    }
+
+    #[gpui::test]
+    async fn test_standard_refresh_replaces_with_first_page_after_full_history_refresh(
+        cx: &mut TestAppContext,
+    ) {
+        init_test(cx);
+
+        let session_list = Rc::new(PaginatedTestSessionList::new(
+            vec![test_session("session-1", "First")],
+            vec![test_session("session-2", "Second")],
+        ));
+
+        let (history, cx) = cx.add_window_view(|window, cx| {
+            AcpThreadHistory::new(Some(session_list.clone()), window, cx)
+        });
+        cx.run_until_parked();
+
+        history.update(cx, |history, cx| history.refresh_full_history(cx));
+        cx.run_until_parked();
+        session_list.clear_requested_cursors();
+
+        history.update(cx, |history, cx| {
+            history.set_prefer_full_refreshes(false, cx);
+            history.refresh(cx);
+        });
+        cx.run_until_parked();
+
+        history.update(cx, |history, _cx| {
+            assert_eq!(history.sessions.len(), 1);
+            assert_eq!(
+                history.sessions[0].session_id,
+                acp::SessionId::new("session-1")
+            );
+        });
+        assert_eq!(session_list.requested_cursors(), vec![None]);
+    }
+
+    #[gpui::test]
+    async fn test_re_entering_full_pagination_reloads_all_pages(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let session_list = Rc::new(PaginatedTestSessionList::new(
+            vec![test_session("session-1", "First")],
+            vec![test_session("session-2", "Second")],
+        ));
+
+        let (history, cx) = cx.add_window_view(|window, cx| {
+            AcpThreadHistory::new(Some(session_list.clone()), window, cx)
+        });
+        cx.run_until_parked();
+
+        history.update(cx, |history, cx| history.refresh_full_history(cx));
+        cx.run_until_parked();
+        session_list.clear_requested_cursors();
+
+        history.update(cx, |history, cx| history.refresh_full_history(cx));
+        cx.run_until_parked();
+
+        history.update(cx, |history, _cx| {
+            assert_eq!(history.sessions.len(), 2);
+        });
+        assert_eq!(
+            session_list.requested_cursors(),
+            vec![None, Some("page-2".to_string())]
+        );
+    }
+
+    #[gpui::test]
+    async fn test_refresh_messages_use_full_pagination_when_preferred(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let session_list = Rc::new(PaginatedTestSessionList::new(
+            vec![test_session("session-1", "First")],
+            vec![test_session("session-2", "Second")],
+        ));
+
+        let (history, cx) = cx.add_window_view(|window, cx| {
+            AcpThreadHistory::new(Some(session_list.clone()), window, cx)
+        });
+        cx.run_until_parked();
+        session_list.clear_requested_cursors();
+
+        history.update(cx, |history, cx| {
+            history.set_prefer_full_refreshes(true, cx);
+        });
+        session_list.notify_refresh();
+        cx.run_until_parked();
+
+        history.update(cx, |history, _cx| {
+            assert_eq!(history.sessions.len(), 2);
+        });
+        assert_eq!(
+            session_list.requested_cursors(),
+            vec![None, Some("page-2".to_string())]
+        );
+    }
+
+    #[gpui::test]
+    async fn test_partial_refresh_batch_drops_non_first_page_sessions(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let second_page_session_id = acp::SessionId::new("session-2");
+        let session_list = Rc::new(PaginatedTestSessionList::new(
+            vec![test_session("session-1", "First")],
+            vec![test_session("session-2", "Second")],
+        ));
+
+        let (history, cx) = cx.add_window_view(|window, cx| {
+            AcpThreadHistory::new(Some(session_list.clone()), window, cx)
+        });
+        cx.run_until_parked();
+
+        history.update(cx, |history, cx| history.refresh_full_history(cx));
+        cx.run_until_parked();
+
+        history.update(cx, |history, cx| {
+            history.set_prefer_full_refreshes(false, cx);
+        });
+        session_list.clear_requested_cursors();
+
+        session_list.send_update(SessionListUpdate::SessionInfo {
+            session_id: second_page_session_id.clone(),
+            update: acp::SessionInfoUpdate::new().title("Updated Second"),
+        });
+        session_list.send_update(SessionListUpdate::Refresh);
+        cx.run_until_parked();
+
+        history.update(cx, |history, _cx| {
+            assert_eq!(history.sessions.len(), 1);
+            assert_eq!(history.sessions[0].session_id, acp::SessionId::new("session-1"));
+            assert!(history
+                .sessions
+                .iter()
+                .all(|session| session.session_id != second_page_session_id));
+        });
+        assert_eq!(session_list.requested_cursors(), vec![None]);
+    }
+
+    #[gpui::test]
+    async fn test_full_pagination_works_with_async_page_fetches(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let session_list = Rc::new(AsyncPaginatedTestSessionList::new(
+            vec![test_session("session-1", "First")],
+            vec![test_session("session-2", "Second")],
+        ));
+
+        let (history, cx) = cx.add_window_view(|window, cx| {
+            AcpThreadHistory::new(Some(session_list.clone()), window, cx)
+        });
+        cx.run_until_parked();
+        session_list.clear_requested_cursors();
+
+        history.update(cx, |history, cx| history.refresh_full_history(cx));
+        cx.run_until_parked();
+
+        history.update(cx, |history, _cx| {
+            assert_eq!(history.sessions.len(), 2);
+        });
+        assert_eq!(
+            session_list.requested_cursors(),
+            vec![None, Some("page-2".to_string())]
+        );
     }
 
     #[gpui::test]

--- a/crates/agent_ui/src/acp/thread_history.rs
+++ b/crates/agent_ui/src/acp/thread_history.rs
@@ -38,7 +38,8 @@ pub struct AcpThreadHistory {
     visible_items: Vec<ListItemType>,
     local_timezone: UtcOffset,
     confirming_delete_history: bool,
-    _update_task: Task<()>,
+    _visible_items_task: Task<()>,
+    _refresh_task: Task<()>,
     _watch_task: Option<Task<()>>,
     _subscriptions: Vec<gpui::Subscription>,
 }
@@ -111,7 +112,8 @@ impl AcpThreadHistory {
             search_query: SharedString::default(),
             confirming_delete_history: false,
             _subscriptions: vec![search_editor_subscription],
-            _update_task: Task::ready(()),
+            _visible_items_task: Task::ready(()),
+            _refresh_task: Task::ready(()),
             _watch_task: None,
         };
         this.set_session_list(session_list, cx);
@@ -131,7 +133,7 @@ impl AcpThreadHistory {
             None
         };
 
-        self._update_task = cx.spawn(async move |this, cx| {
+        self._visible_items_task = cx.spawn(async move |this, cx| {
             let new_visible_items = new_list_items.await;
             this.update(cx, |this, cx| {
                 let new_selected_index = if let Some(history_entry) = selected_history_entry {
@@ -170,6 +172,8 @@ impl AcpThreadHistory {
         self.sessions.clear();
         self.visible_items.clear();
         self.selected_index = 0;
+        self._visible_items_task = Task::ready(());
+        self._refresh_task = Task::ready(());
 
         let Some(session_list) = self.session_list.as_ref() else {
             self._watch_task = None;
@@ -260,7 +264,7 @@ impl AcpThreadHistory {
             return;
         };
 
-        self._update_task = cx.spawn(async move |this, cx| {
+        self._refresh_task = cx.spawn(async move |this, cx| {
             let mut cursor: Option<String> = None;
             let mut is_first_page = true;
 

--- a/crates/agent_ui/src/acp/thread_history.rs
+++ b/crates/agent_ui/src/acp/thread_history.rs
@@ -199,18 +199,18 @@ impl AcpThreadHistory {
                 }
 
                 this.update(cx, |this, cx| {
-                    let mut needs_refresh = false;
-                    for update in updates {
-                        match update {
-                            SessionListUpdate::Refresh => needs_refresh = true,
-                            SessionListUpdate::SessionInfo { session_id, update } => {
-                                this.apply_info_update(session_id, update, cx);
-                            }
-                        }
-                    }
+                    let needs_refresh = updates
+                        .iter()
+                        .any(|u| matches!(u, SessionListUpdate::Refresh));
 
                     if needs_refresh {
                         this.refresh_sessions(true, this.prefer_full_refreshes, cx);
+                    } else {
+                        for update in updates {
+                            if let SessionListUpdate::SessionInfo { session_id, update } = update {
+                                this.apply_info_update(session_id, update, cx);
+                            }
+                        }
                     }
                 })
                 .ok();
@@ -222,11 +222,7 @@ impl AcpThreadHistory {
         self.refresh_sessions(true, true, cx);
     }
 
-    pub(crate) fn set_prefer_full_refreshes(
-        &mut self,
-        prefer_full_refreshes: bool,
-        _cx: &mut Context<Self>,
-    ) {
+    pub(crate) fn set_prefer_full_refreshes(&mut self, prefer_full_refreshes: bool) {
         self.prefer_full_refreshes = prefer_full_refreshes;
     }
 
@@ -282,6 +278,9 @@ impl AcpThreadHistory {
             return;
         };
 
+        // If a new refresh arrives while pagination is in progress, the previous
+        // `_refresh_task` is cancelled. This is intentional (latest refresh wins),
+        // but means sessions may be in a partial state until the new refresh completes.
         self._refresh_task = cx.spawn(async move |this, cx| {
             let mut cursor: Option<String> = None;
             let mut is_first_page = true;
@@ -1078,7 +1077,6 @@ mod tests {
     use gpui::TestAppContext;
     use std::{
         any::Any,
-        cell::RefCell,
         sync::{Arc, Mutex},
     };
 
@@ -1138,7 +1136,8 @@ mod tests {
     struct PaginatedTestSessionList {
         first_page_sessions: Vec<AgentSessionInfo>,
         second_page_sessions: Vec<AgentSessionInfo>,
-        requested_cursors: Rc<RefCell<Vec<Option<String>>>>,
+        requested_cursors: Arc<Mutex<Vec<Option<String>>>>,
+        async_responses: bool,
         updates_tx: smol::channel::Sender<SessionListUpdate>,
         updates_rx: smol::channel::Receiver<SessionListUpdate>,
     }
@@ -1152,18 +1151,24 @@ mod tests {
             Self {
                 first_page_sessions,
                 second_page_sessions,
-                requested_cursors: Rc::new(RefCell::new(Vec::new())),
+                requested_cursors: Arc::new(Mutex::new(Vec::new())),
+                async_responses: false,
                 updates_tx: tx,
                 updates_rx: rx,
             }
         }
 
+        fn with_async_responses(mut self) -> Self {
+            self.async_responses = true;
+            self
+        }
+
         fn requested_cursors(&self) -> Vec<Option<String>> {
-            self.requested_cursors.borrow().clone()
+            self.requested_cursors.lock().unwrap().clone()
         }
 
         fn clear_requested_cursors(&self) {
-            self.requested_cursors.borrow_mut().clear();
+            self.requested_cursors.lock().unwrap().clear()
         }
 
         fn send_update(&self, update: SessionListUpdate) {
@@ -1175,100 +1180,37 @@ mod tests {
         fn list_sessions(
             &self,
             request: AgentSessionListRequest,
-            _cx: &mut App,
-        ) -> Task<anyhow::Result<AgentSessionListResponse>> {
-            self.requested_cursors
-                .borrow_mut()
-                .push(request.cursor.clone());
-
-            let response = match request.cursor.as_deref() {
-                None => AgentSessionListResponse {
-                    sessions: self.first_page_sessions.clone(),
-                    next_cursor: Some("page-2".to_string()),
-                    meta: None,
-                },
-                Some("page-2") => AgentSessionListResponse::new(self.second_page_sessions.clone()),
-                Some(_) => AgentSessionListResponse::new(Vec::new()),
-            };
-
-            Task::ready(Ok(response))
-        }
-
-        fn watch(&self, _cx: &mut App) -> Option<smol::channel::Receiver<SessionListUpdate>> {
-            Some(self.updates_rx.clone())
-        }
-
-        fn notify_refresh(&self) {
-            self.updates_tx.try_send(SessionListUpdate::Refresh).ok();
-        }
-
-        fn into_any(self: Rc<Self>) -> Rc<dyn Any> {
-            self
-        }
-    }
-
-    #[derive(Clone)]
-    struct AsyncPaginatedTestSessionList {
-        first_page_sessions: Vec<AgentSessionInfo>,
-        second_page_sessions: Vec<AgentSessionInfo>,
-        requested_cursors: Arc<Mutex<Vec<Option<String>>>>,
-        updates_tx: smol::channel::Sender<SessionListUpdate>,
-        updates_rx: smol::channel::Receiver<SessionListUpdate>,
-    }
-
-    impl AsyncPaginatedTestSessionList {
-        fn new(
-            first_page_sessions: Vec<AgentSessionInfo>,
-            second_page_sessions: Vec<AgentSessionInfo>,
-        ) -> Self {
-            let (tx, rx) = smol::channel::unbounded();
-            Self {
-                first_page_sessions,
-                second_page_sessions,
-                requested_cursors: Arc::new(Mutex::new(Vec::new())),
-                updates_tx: tx,
-                updates_rx: rx,
-            }
-        }
-
-        fn requested_cursors(&self) -> Vec<Option<String>> {
-            self.requested_cursors.lock().unwrap().clone()
-        }
-
-        fn clear_requested_cursors(&self) {
-            self.requested_cursors.lock().unwrap().clear();
-        }
-    }
-
-    impl AgentSessionList for AsyncPaginatedTestSessionList {
-        fn list_sessions(
-            &self,
-            request: AgentSessionListRequest,
             cx: &mut App,
         ) -> Task<anyhow::Result<AgentSessionListResponse>> {
             let requested_cursors = self.requested_cursors.clone();
             let first_page_sessions = self.first_page_sessions.clone();
             let second_page_sessions = self.second_page_sessions.clone();
-            cx.foreground_executor().spawn(async move {
-                smol::future::yield_now().await;
 
+            let respond = move || {
                 requested_cursors
                     .lock()
                     .unwrap()
                     .push(request.cursor.clone());
 
-                let response = match request.cursor.as_deref() {
+                match request.cursor.as_deref() {
                     None => AgentSessionListResponse {
                         sessions: first_page_sessions,
                         next_cursor: Some("page-2".to_string()),
                         meta: None,
                     },
                     Some("page-2") => AgentSessionListResponse::new(second_page_sessions),
-                    Some(_) => AgentSessionListResponse::new(Vec::new()),
-                };
+                    _ => AgentSessionListResponse::new(Vec::new()),
+                }
+            };
 
-                Ok(response)
-            })
+            if self.async_responses {
+                cx.foreground_executor().spawn(async move {
+                    smol::future::yield_now().await;
+                    Ok(respond())
+                })
+            } else {
+                Task::ready(Ok(respond()))
+            }
         }
 
         fn watch(&self, _cx: &mut App) -> Option<smol::channel::Receiver<SessionListUpdate>> {
@@ -1276,7 +1218,7 @@ mod tests {
         }
 
         fn notify_refresh(&self) {
-            self.updates_tx.try_send(SessionListUpdate::Refresh).ok();
+            self.send_update(SessionListUpdate::Refresh);
         }
 
         fn into_any(self: Rc<Self>) -> Rc<dyn Any> {
@@ -1374,7 +1316,7 @@ mod tests {
         session_list.clear_requested_cursors();
 
         history.update(cx, |history, cx| {
-            history.set_prefer_full_refreshes(false, cx);
+            history.set_prefer_full_refreshes(false);
             history.refresh(cx);
         });
         cx.run_until_parked();
@@ -1434,8 +1376,8 @@ mod tests {
         cx.run_until_parked();
         session_list.clear_requested_cursors();
 
-        history.update(cx, |history, cx| {
-            history.set_prefer_full_refreshes(true, cx);
+        history.update(cx, |history, _cx| {
+            history.set_prefer_full_refreshes(true);
         });
         session_list.notify_refresh();
         cx.run_until_parked();
@@ -1467,8 +1409,8 @@ mod tests {
         history.update(cx, |history, cx| history.refresh_full_history(cx));
         cx.run_until_parked();
 
-        history.update(cx, |history, cx| {
-            history.set_prefer_full_refreshes(false, cx);
+        history.update(cx, |history, _cx| {
+            history.set_prefer_full_refreshes(false);
         });
         session_list.clear_requested_cursors();
 
@@ -1481,11 +1423,16 @@ mod tests {
 
         history.update(cx, |history, _cx| {
             assert_eq!(history.sessions.len(), 1);
-            assert_eq!(history.sessions[0].session_id, acp::SessionId::new("session-1"));
-            assert!(history
-                .sessions
-                .iter()
-                .all(|session| session.session_id != second_page_session_id));
+            assert_eq!(
+                history.sessions[0].session_id,
+                acp::SessionId::new("session-1")
+            );
+            assert!(
+                history
+                    .sessions
+                    .iter()
+                    .all(|session| session.session_id != second_page_session_id)
+            );
         });
         assert_eq!(session_list.requested_cursors(), vec![None]);
     }
@@ -1494,10 +1441,13 @@ mod tests {
     async fn test_full_pagination_works_with_async_page_fetches(cx: &mut TestAppContext) {
         init_test(cx);
 
-        let session_list = Rc::new(AsyncPaginatedTestSessionList::new(
-            vec![test_session("session-1", "First")],
-            vec![test_session("session-2", "Second")],
-        ));
+        let session_list = Rc::new(
+            PaginatedTestSessionList::new(
+                vec![test_session("session-1", "First")],
+                vec![test_session("session-2", "Second")],
+            )
+            .with_async_responses(),
+        );
 
         let (history, cx) = cx.add_window_view(|window, cx| {
             AcpThreadHistory::new(Some(session_list.clone()), window, cx)

--- a/crates/agent_ui/src/acp/thread_history.rs
+++ b/crates/agent_ui/src/acp/thread_history.rs
@@ -29,7 +29,6 @@ fn thread_title(entry: &AgentSessionInfo) -> &SharedString {
 
 pub struct AcpThreadHistory {
     session_list: Option<Rc<dyn AgentSessionList>>,
-    prefer_full_refreshes: bool,
     sessions: Vec<AgentSessionInfo>,
     scroll_handle: UniformListScrollHandle,
     selected_index: usize,
@@ -100,7 +99,6 @@ impl AcpThreadHistory {
 
         let mut this = Self {
             session_list: None,
-            prefer_full_refreshes: false,
             sessions: Vec::new(),
             scroll_handle,
             selected_index: 0,
@@ -185,7 +183,7 @@ impl AcpThreadHistory {
         let Some(rx) = session_list.watch(cx) else {
             // No watch support - do a one-time refresh
             self._watch_task = None;
-            self.refresh_sessions(false, self.prefer_full_refreshes, cx);
+            self.refresh_sessions(false, false, cx);
             return;
         };
         session_list.notify_refresh();
@@ -204,7 +202,7 @@ impl AcpThreadHistory {
                         .any(|u| matches!(u, SessionListUpdate::Refresh));
 
                     if needs_refresh {
-                        this.refresh_sessions(true, this.prefer_full_refreshes, cx);
+                        this.refresh_sessions(true, false, cx);
                     } else {
                         for update in updates {
                             if let SessionListUpdate::SessionInfo { session_id, update } = update {
@@ -220,10 +218,6 @@ impl AcpThreadHistory {
 
     pub(crate) fn refresh_full_history(&mut self, cx: &mut Context<Self>) {
         self.refresh_sessions(true, true, cx);
-    }
-
-    pub(crate) fn set_prefer_full_refreshes(&mut self, prefer_full_refreshes: bool) {
-        self.prefer_full_refreshes = prefer_full_refreshes;
     }
 
     fn apply_info_update(
@@ -1316,7 +1310,6 @@ mod tests {
         session_list.clear_requested_cursors();
 
         history.update(cx, |history, cx| {
-            history.set_prefer_full_refreshes(false);
             history.refresh(cx);
         });
         cx.run_until_parked();
@@ -1362,36 +1355,6 @@ mod tests {
     }
 
     #[gpui::test]
-    async fn test_refresh_messages_use_full_pagination_when_preferred(cx: &mut TestAppContext) {
-        init_test(cx);
-
-        let session_list = Rc::new(PaginatedTestSessionList::new(
-            vec![test_session("session-1", "First")],
-            vec![test_session("session-2", "Second")],
-        ));
-
-        let (history, cx) = cx.add_window_view(|window, cx| {
-            AcpThreadHistory::new(Some(session_list.clone()), window, cx)
-        });
-        cx.run_until_parked();
-        session_list.clear_requested_cursors();
-
-        history.update(cx, |history, _cx| {
-            history.set_prefer_full_refreshes(true);
-        });
-        session_list.notify_refresh();
-        cx.run_until_parked();
-
-        history.update(cx, |history, _cx| {
-            assert_eq!(history.sessions.len(), 2);
-        });
-        assert_eq!(
-            session_list.requested_cursors(),
-            vec![None, Some("page-2".to_string())]
-        );
-    }
-
-    #[gpui::test]
     async fn test_partial_refresh_batch_drops_non_first_page_sessions(cx: &mut TestAppContext) {
         init_test(cx);
 
@@ -1409,9 +1372,6 @@ mod tests {
         history.update(cx, |history, cx| history.refresh_full_history(cx));
         cx.run_until_parked();
 
-        history.update(cx, |history, _cx| {
-            history.set_prefer_full_refreshes(false);
-        });
         session_list.clear_requested_cursors();
 
         session_list.send_update(SessionListUpdate::SessionInfo {

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -1106,8 +1106,6 @@ impl AcpServerView {
                 if should_send_queued {
                     self.send_queued_message_at_index(0, false, window, cx);
                 }
-
-                self.history.update(cx, |history, cx| history.refresh(cx));
             }
             AcpThreadEvent::Refusal => {
                 let error = ThreadError::Refusal;
@@ -1162,7 +1160,6 @@ impl AcpServerView {
                         }
                     });
                 }
-                self.history.update(cx, |history, cx| history.refresh(cx));
             }
             AcpThreadEvent::PromptCapabilitiesUpdated => {
                 if let Some(active) = self.thread_view(&thread_id) {

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1752,9 +1752,6 @@ impl AgentPanel {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.acp_history
-            .update(cx, |history, cx| history.refresh(cx));
-
         match agent {
             AgentType::TextThread => {
                 window.dispatch_action(NewTextThread.boxed_clone(), cx);
@@ -2276,11 +2273,8 @@ impl AgentPanel {
             .with_handle(self.agent_navigation_menu_handle.clone())
             .menu({
                 let menu = self.agent_navigation_menu.clone();
-                let history = self.acp_history.clone();
                 move |window, cx| {
                     telemetry::event!("View Thread History Clicked");
-
-                    history.update(cx, |history, cx| history.refresh(cx));
 
                     if let Some(menu) = menu.as_ref() {
                         menu.update(cx, |_, cx| {

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1591,12 +1591,10 @@ impl AgentPanel {
             }
         );
 
-        self.acp_history.update(cx, |history, cx| {
-            history.set_prefer_full_refreshes(is_in_agent_history);
-            if !was_in_agent_history && is_in_agent_history {
-                history.refresh_full_history(cx);
-            }
-        });
+        if !was_in_agent_history && is_in_agent_history {
+            self.acp_history
+                .update(cx, |history, cx| history.refresh_full_history(cx));
+        }
 
         if focus {
             self.focus_handle(cx).focus(window, cx);
@@ -1754,6 +1752,9 @@ impl AgentPanel {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.acp_history
+            .update(cx, |history, cx| history.refresh(cx));
+
         match agent {
             AgentType::TextThread => {
                 window.dispatch_action(NewTextThread.boxed_clone(), cx);
@@ -2275,8 +2276,11 @@ impl AgentPanel {
             .with_handle(self.agent_navigation_menu_handle.clone())
             .menu({
                 let menu = self.agent_navigation_menu.clone();
+                let history = self.acp_history.clone();
                 move |window, cx| {
                     telemetry::event!("View Thread History Clicked");
+
+                    history.update(cx, |history, cx| history.refresh(cx));
 
                     if let Some(menu) = menu.as_ref() {
                         menu.update(cx, |_, cx| {

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1592,7 +1592,7 @@ impl AgentPanel {
         );
 
         self.acp_history.update(cx, |history, cx| {
-            history.set_prefer_full_refreshes(is_in_agent_history, cx);
+            history.set_prefer_full_refreshes(is_in_agent_history);
             if !was_in_agent_history && is_in_agent_history {
                 history.refresh_full_history(cx);
             }

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1124,22 +1124,7 @@ impl AgentPanel {
         match self.active_view {
             ActiveView::Configuration | ActiveView::History { .. } => {
                 if let Some(previous_view) = self.previous_view.take() {
-                    self.active_view = previous_view;
-                    cx.emit(AgentPanelEvent::ActiveViewChanged);
-
-                    match &self.active_view {
-                        ActiveView::AgentThread { thread_view } => {
-                            thread_view.focus_handle(cx).focus(window, cx);
-                        }
-                        ActiveView::TextThread {
-                            text_thread_editor, ..
-                        } => {
-                            text_thread_editor.focus_handle(cx).focus(window, cx);
-                        }
-                        ActiveView::Uninitialized
-                        | ActiveView::History { .. }
-                        | ActiveView::Configuration => {}
-                    }
+                    self.set_active_view(previous_view, true, window, cx);
                 }
                 cx.notify();
             }
@@ -1561,6 +1546,12 @@ impl AgentPanel {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        let was_in_agent_history = matches!(
+            self.active_view,
+            ActiveView::History {
+                kind: HistoryKind::AgentThreads
+            }
+        );
         let current_is_uninitialized = matches!(self.active_view, ActiveView::Uninitialized);
         let current_is_history = matches!(self.active_view, ActiveView::History { .. });
         let new_is_history = matches!(new_view, ActiveView::History { .. });
@@ -1592,6 +1583,20 @@ impl AgentPanel {
             }
             _ => None,
         };
+
+        let is_in_agent_history = matches!(
+            self.active_view,
+            ActiveView::History {
+                kind: HistoryKind::AgentThreads
+            }
+        );
+
+        self.acp_history.update(cx, |history, cx| {
+            history.set_prefer_full_refreshes(is_in_agent_history, cx);
+            if !was_in_agent_history && is_in_agent_history {
+                history.refresh_full_history(cx);
+            }
+        });
 
         if focus {
             self.focus_handle(cx).focus(window, cx);


### PR DESCRIPTION
Changes the AcpThreadHistory behavior to only load the full paginated list if we are in the history view, and only reloads the first page otherwise. And it also updates the first page in way fewer cases to reduce load on the agents.

Release Notes:

- N/A
