### PR TITLE
Add OpenAI-compatible edit predictions provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5478,6 +5478,7 @@ dependencies = [
  "markdown",
  "menu",
  "multi_buffer",
+ "open_ai_edit_prediction",
  "paths",
  "pretty_assertions",
  "project",
@@ -11204,6 +11205,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "open_ai_edit_prediction"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "edit_prediction",
+ "edit_prediction_types",
+ "futures 0.3.31",
+ "gpui",
+ "http_client",
+ "icons",
+ "language",
+ "language_model",
+ "log",
+ "serde",
+ "serde_json",
+ "settings_content",
+ "text",
+]
+
+[[package]]
 name = "open_path_prompt"
 version = "0.1.0"
 dependencies = [
@@ -15232,6 +15253,7 @@ dependencies = [
  "log",
  "menu",
  "node_runtime",
+ "open_ai_edit_prediction",
  "paths",
  "picker",
  "platform_title_bar",
@@ -21070,6 +21092,7 @@ dependencies = [
  "node_runtime",
  "notifications",
  "onboarding",
+ "open_ai_edit_prediction",
  "outline",
  "outline_panel",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,6 +173,7 @@ members = [
     "crates/supermaven",
     "crates/supermaven_api",
     "crates/codestral",
+    "crates/open_ai_edit_prediction",
     "crates/svg_preview",
     "crates/system_specs",
     "crates/tab_switcher",
@@ -411,6 +412,7 @@ sum_tree = { path = "crates/sum_tree" }
 supermaven = { path = "crates/supermaven" }
 supermaven_api = { path = "crates/supermaven_api" }
 codestral = { path = "crates/codestral" }
+open_ai_edit_prediction = { path = "crates/open_ai_edit_prediction" }
 system_specs = { path = "crates/system_specs" }
 tab_switcher = { path = "crates/tab_switcher" }
 task = { path = "crates/task" }

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1504,6 +1504,15 @@
       "model": "codestral-latest",
       "max_tokens": 150,
     },
+    "open_ai_compatible": {
+      "api_url": null,
+      "model": null,
+      "max_tokens": 256,
+      "temperature": 0.2,
+      // Controls the length of completions: "short" (1-3 lines),
+      // "medium" (up to ~10 lines), or "long" (no length restriction).
+      "completion_length": "short"
+    },
     "sweep": {
       // When enabled, Sweep will not store edit prediction inputs or outputs.
       // When disabled, Sweep may collect data including buffer contents,

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -401,6 +401,7 @@ fn update_command_palette_filter(cx: &mut App) {
                 }
                 EditPredictionProvider::Zed
                 | EditPredictionProvider::Codestral
+                | EditPredictionProvider::OpenAiCompatible
                 | EditPredictionProvider::Ollama
                 | EditPredictionProvider::Sweep
                 | EditPredictionProvider::Mercury

--- a/crates/edit_prediction_ui/Cargo.toml
+++ b/crates/edit_prediction_ui/Cargo.toml
@@ -20,6 +20,7 @@ time.workspace = true
 client.workspace = true
 cloud_llm_client.workspace = true
 codestral.workspace = true
+open_ai_edit_prediction.workspace = true
 command_palette_hooks.workspace = true
 copilot.workspace = true
 copilot_chat.workspace = true

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -390,6 +390,8 @@ pub struct EditPredictionSettings {
     pub copilot: CopilotSettings,
     /// Settings specific to Codestral.
     pub codestral: CodestralSettings,
+    /// Settings specific to a generic OpenAI-compatible endpoint.
+    pub open_ai_compatible: OpenAiCompatibleEditPredictionSettings,
     /// Settings specific to Sweep.
     pub sweep: SweepSettings,
     /// Settings specific to Ollama.
@@ -450,6 +452,20 @@ pub struct SweepSettings {
     /// diagnostics, file paths, repository names, and generated predictions
     /// to improve the service.
     pub privacy_mode: bool,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct OpenAiCompatibleEditPredictionSettings {
+    /// API URL for the OpenAI-compatible endpoint.
+    pub api_url: Option<String>,
+    /// Model name to use for completions.
+    pub model: Option<String>,
+    /// Maximum tokens to generate.
+    pub max_tokens: Option<u32>,
+    /// Temperature for sampling.
+    pub temperature: Option<f32>,
+    /// Controls the length of completions.
+    pub completion_length: settings::CompletionLength,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -689,6 +705,17 @@ impl settings::Settings for AllLanguageSettings {
             api_url: codestral.api_url,
         };
 
+        let open_ai_compatible = edit_predictions.open_ai_compatible.unwrap();
+        let open_ai_compatible_settings = OpenAiCompatibleEditPredictionSettings {
+            api_url: open_ai_compatible.api_url,
+            model: open_ai_compatible.model,
+            max_tokens: open_ai_compatible.max_tokens,
+            temperature: open_ai_compatible.temperature,
+            completion_length: open_ai_compatible
+                .completion_length
+                .unwrap_or_default(),
+        };
+
         let sweep = edit_predictions.sweep.unwrap();
         let sweep_settings = SweepSettings {
             privacy_mode: sweep.privacy_mode.unwrap(),
@@ -737,6 +764,7 @@ impl settings::Settings for AllLanguageSettings {
                 mode: edit_predictions_mode,
                 copilot: copilot_settings,
                 codestral: codestral_settings,
+                open_ai_compatible: open_ai_compatible_settings,
                 sweep: sweep_settings,
                 ollama: ollama_settings,
                 enabled_in_text_threads,

--- a/crates/open_ai_edit_prediction/Cargo.toml
+++ b/crates/open_ai_edit_prediction/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "open_ai_edit_prediction"
+version = "0.1.0"
+edition = "2021"
+publish = false
+license = "GPL-3.0-or-later"
+
+[lib]
+path = "src/open_ai_edit_prediction.rs"
+
+[dependencies]
+anyhow.workspace = true
+edit_prediction.workspace = true
+edit_prediction_types.workspace = true
+futures.workspace = true
+gpui.workspace = true
+http_client.workspace = true
+icons.workspace = true
+language.workspace = true
+language_model.workspace = true
+log.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+settings_content.workspace = true
+text.workspace = true
+
+[dev-dependencies]

--- a/crates/open_ai_edit_prediction/src/open_ai_edit_prediction.rs
+++ b/crates/open_ai_edit_prediction/src/open_ai_edit_prediction.rs
@@ -1,0 +1,493 @@
+use anyhow::Result;
+use edit_prediction::cursor_excerpt;
+use edit_prediction_types::{
+    EditPrediction, EditPredictionDelegate, EditPredictionDiscardReason, EditPredictionIconSet,
+};
+use futures::AsyncReadExt;
+use gpui::{App, AppContext as _, Context, Entity, Global, SharedString, Task};
+use http_client::HttpClient;
+use icons::IconName;
+use language::{
+    Anchor, Buffer, BufferSnapshot, EditPreview, ToPoint, language_settings::all_language_settings,
+};
+use language_model::{ApiKeyState, AuthenticateError, EnvVar, env_var};
+use serde::{Deserialize, Serialize};
+
+use std::{
+    ops::Range,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+use text::{OffsetRangeExt as _, ToOffset};
+
+pub const DEBOUNCE_TIMEOUT: Duration = Duration::from_millis(150);
+
+static OPEN_AI_COMPATIBLE_EP_API_KEY_ENV_VAR: std::sync::LazyLock<EnvVar> =
+    env_var!("OPENAI_COMPATIBLE_EDIT_PREDICTION_API_KEY");
+
+struct GlobalOpenAiCompatibleEpApiKey(Entity<ApiKeyState>);
+
+impl Global for GlobalOpenAiCompatibleEpApiKey {}
+
+pub fn open_ai_compatible_ep_api_key_state(cx: &mut App) -> Entity<ApiKeyState> {
+    if let Some(global) = cx.try_global::<GlobalOpenAiCompatibleEpApiKey>() {
+        return global.0.clone();
+    }
+    let api_url = open_ai_compatible_ep_api_url(cx);
+    let entity = cx.new(|_cx| {
+        ApiKeyState::new(api_url, OPEN_AI_COMPATIBLE_EP_API_KEY_ENV_VAR.clone())
+    });
+    cx.set_global(GlobalOpenAiCompatibleEpApiKey(entity.clone()));
+    entity
+}
+
+pub fn open_ai_compatible_ep_api_key(cx: &App) -> Option<Arc<str>> {
+    let url = open_ai_compatible_ep_api_url(cx);
+    cx.try_global::<GlobalOpenAiCompatibleEpApiKey>()?
+        .0
+        .read(cx)
+        .key(&url)
+}
+
+pub fn load_open_ai_compatible_ep_api_key(cx: &mut App) -> Task<Result<(), AuthenticateError>> {
+    let api_url = open_ai_compatible_ep_api_url(cx);
+    open_ai_compatible_ep_api_key_state(cx).update(cx, |key_state, cx| {
+        key_state.load_if_needed(api_url, |s| s, cx)
+    })
+}
+
+pub fn open_ai_compatible_ep_api_url(cx: &App) -> SharedString {
+    all_language_settings(None, cx)
+        .edit_predictions
+        .open_ai_compatible
+        .api_url
+        .clone()
+        .unwrap_or_default()
+        .into()
+}
+
+#[derive(Clone)]
+struct CurrentCompletion {
+    snapshot: BufferSnapshot,
+    edits: Arc<[(Range<Anchor>, Arc<str>)]>,
+    edit_preview: EditPreview,
+}
+
+impl CurrentCompletion {
+    fn interpolate(&self, new_snapshot: &BufferSnapshot) -> Option<Vec<(Range<Anchor>, Arc<str>)>> {
+        edit_prediction_types::interpolate_edits(&self.snapshot, new_snapshot, &self.edits)
+    }
+}
+
+pub struct OpenAiCompatibleEditPredictionDelegate {
+    http_client: Arc<dyn HttpClient>,
+    pending_request: Option<Task<Result<()>>>,
+    current_completion: Option<CurrentCompletion>,
+}
+
+impl OpenAiCompatibleEditPredictionDelegate {
+    pub fn new(http_client: Arc<dyn HttpClient>) -> Self {
+        Self {
+            http_client,
+            pending_request: None,
+            current_completion: None,
+        }
+    }
+
+    pub fn ensure_api_key_loaded(cx: &mut App) {
+        load_open_ai_compatible_ep_api_key(cx).detach();
+    }
+
+    async fn fetch_completion(
+        http_client: Arc<dyn HttpClient>,
+        api_key: &str,
+        api_url: &str,
+        request: ChatCompletionRequest,
+    ) -> Result<String> {
+        let start_time = Instant::now();
+
+        let url = format!("{}/chat/completions", api_url.trim_end_matches('/'));
+        log::debug!(
+            "OpenAI Compatible EP: Requesting completion (url: {}, model: {}, max_tokens: {})",
+            url,
+            request.model,
+            request.max_tokens
+        );
+
+        let request_body = serde_json::to_string(&request)?;
+
+        let http_request = http_client::Request::builder()
+            .method(http_client::Method::POST)
+            .uri(&url)
+            .header("Content-Type", "application/json")
+            .header("Authorization", format!("Bearer {}", api_key))
+            .body(http_client::AsyncBody::from(request_body))?;
+
+        let mut response = http_client.send(http_request).await?;
+        let status = response.status();
+
+        log::debug!("OpenAI Compatible EP: Response status: {}", status);
+
+        let mut body = String::new();
+        response.body_mut().read_to_string(&mut body).await?;
+
+        if !status.is_success() {
+            return Err(anyhow::anyhow!(
+                "OpenAI Compatible EP API error: {} - {}",
+                status,
+                body
+            ));
+        }
+
+        let completion_response: ChatCompletionResponse = serde_json::from_str(&body)?;
+
+        let elapsed = start_time.elapsed();
+
+        if let Some(choice) = completion_response.choices.first() {
+            log::debug!(
+                "OpenAI Compatible EP: Completion received ({:.2}s)",
+                elapsed.as_secs_f64()
+            );
+
+            Ok(strip_markdown_code_fences(&choice.message.content))
+        } else {
+            log::error!("OpenAI Compatible EP: No completion returned in response");
+            Err(anyhow::anyhow!(
+                "No completion returned from OpenAI Compatible endpoint"
+            ))
+        }
+    }
+}
+
+impl EditPredictionDelegate for OpenAiCompatibleEditPredictionDelegate {
+    fn name() -> &'static str {
+        "open-ai-compatible"
+    }
+
+    fn display_name() -> &'static str {
+        "OpenAI Compatible"
+    }
+
+    fn show_predictions_in_menu() -> bool {
+        true
+    }
+
+    fn icons(&self, _cx: &App) -> EditPredictionIconSet {
+        EditPredictionIconSet::new(IconName::AiOpenAiCompat)
+    }
+
+    fn is_enabled(&self, _buffer: &Entity<Buffer>, _cursor_position: Anchor, cx: &App) -> bool {
+        open_ai_compatible_ep_api_key(cx).is_some()
+    }
+
+    fn is_refreshing(&self, _cx: &App) -> bool {
+        self.pending_request.is_some()
+    }
+
+    fn refresh(
+        &mut self,
+        buffer: Entity<Buffer>,
+        cursor_position: language::Anchor,
+        debounce: bool,
+        cx: &mut Context<Self>,
+    ) {
+        log::debug!(
+            "OpenAI Compatible EP: Refresh called (debounce: {})",
+            debounce
+        );
+
+        let Some(api_key) = open_ai_compatible_ep_api_key(cx) else {
+            log::warn!("OpenAI Compatible EP: No API key configured, skipping refresh");
+            return;
+        };
+
+        let snapshot = buffer.read(cx).snapshot();
+
+        if let Some(current_completion) = self.current_completion.as_ref() {
+            if current_completion.interpolate(&snapshot).is_some() {
+                return;
+            }
+        }
+
+        let http_client = self.http_client.clone();
+
+        let settings = all_language_settings(None, cx);
+        let open_ai_settings = &settings.edit_predictions.open_ai_compatible;
+
+        let Some(model) = open_ai_settings.model.clone() else {
+            log::warn!("OpenAI Compatible EP: No model configured, skipping refresh");
+            return;
+        };
+
+        let Some(ref api_url) = open_ai_settings.api_url else {
+            log::warn!("OpenAI Compatible EP: No API URL configured, skipping refresh");
+            return;
+        };
+        let api_url = api_url.clone();
+
+        let completion_length = open_ai_settings.completion_length;
+        let max_tokens = open_ai_settings.max_tokens.unwrap_or(match completion_length {
+            settings_content::CompletionLength::Short => 64,
+            settings_content::CompletionLength::Medium => 256,
+            settings_content::CompletionLength::Long => 512,
+        });
+        let temperature = open_ai_settings.temperature.unwrap_or(0.2);
+
+        self.pending_request = Some(cx.spawn(async move |this, cx| {
+            if debounce {
+                log::debug!(
+                    "OpenAI Compatible EP: Debouncing for {:?}",
+                    DEBOUNCE_TIMEOUT
+                );
+                cx.background_executor().timer(DEBOUNCE_TIMEOUT).await;
+            }
+
+            let cursor_offset = cursor_position.to_offset(&snapshot);
+            let cursor_point = cursor_offset.to_point(&snapshot);
+
+            const MAX_CONTEXT_TOKENS: usize = 150;
+            const MAX_REWRITE_TOKENS: usize = 350;
+
+            let (_, context_range) =
+                cursor_excerpt::editable_and_context_ranges_for_cursor_position(
+                    cursor_point,
+                    &snapshot,
+                    MAX_REWRITE_TOKENS,
+                    MAX_CONTEXT_TOKENS,
+                );
+
+            let context_range = context_range.to_offset(&snapshot);
+            let excerpt_text = snapshot
+                .text_for_range(context_range.clone())
+                .collect::<String>();
+            let cursor_within_excerpt = cursor_offset
+                .saturating_sub(context_range.start)
+                .min(excerpt_text.len());
+            let prompt = excerpt_text[..cursor_within_excerpt].to_string();
+            let suffix = excerpt_text[cursor_within_excerpt..].to_string();
+
+            let user_content = if suffix.is_empty() {
+                format!(
+                    "Continue the code from the cursor position marked <CURSOR>. \
+                     Output ONLY the code to insert.\n\n{prompt}<CURSOR>"
+                )
+            } else {
+                format!(
+                    "Fill in the code at the cursor position marked <CURSOR>. \
+                     Output ONLY the code to insert.\n\n{prompt}<CURSOR>{suffix}"
+                )
+            };
+
+            let length_instruction = match completion_length {
+                settings_content::CompletionLength::Short =>
+                    " Keep completions concise: 1-3 lines. Only produce more \
+                     when absolutely necessary to complete a started block.",
+                settings_content::CompletionLength::Medium =>
+                    " Produce moderate completions of up to ~10 lines.",
+                settings_content::CompletionLength::Long =>
+                    "",
+            };
+
+            let system_content = format!(
+                "You are a code completion engine. Output ONLY raw code \
+                 that should be inserted at the cursor position. Do not include \
+                 explanations, markdown formatting, code fences, or any text \
+                 other than the code itself. Do not repeat code that is already \
+                 present before or after the cursor.{length_instruction}"
+            );
+
+            let request = ChatCompletionRequest {
+                model,
+                messages: vec![
+                    ChatMessage {
+                        role: "system",
+                        content: system_content,
+                    },
+                    ChatMessage {
+                        role: "user",
+                        content: user_content,
+                    },
+                ],
+                max_tokens,
+                temperature,
+                stream: false,
+            };
+
+            let completion_text = match Self::fetch_completion(
+                http_client,
+                &api_key,
+                &api_url,
+                request,
+            )
+            .await
+            {
+                Ok(completion) => completion,
+                Err(error) => {
+                    log::error!(
+                        "OpenAI Compatible EP: Failed to fetch completion: {}",
+                        error
+                    );
+                    this.update(cx, |this, cx| {
+                        this.pending_request = None;
+                        cx.notify();
+                    })?;
+                    return Err(error);
+                }
+            };
+
+            if completion_text.trim().is_empty() {
+                log::debug!("OpenAI Compatible EP: Completion was empty after trimming; ignoring");
+                this.update(cx, |this, cx| {
+                    this.pending_request = None;
+                    cx.notify();
+                })?;
+                return Ok(());
+            }
+
+            let completion_text =
+                if needs_leading_newline(&prompt, &suffix, &completion_text) {
+                    format!("\n{completion_text}")
+                } else {
+                    completion_text
+                };
+
+            let edits: Arc<[(Range<Anchor>, Arc<str>)]> =
+                vec![(cursor_position..cursor_position, completion_text.into())].into();
+            let edit_preview = buffer
+                .read_with(cx, |buffer, cx| buffer.preview_edits(edits.clone(), cx))
+                .await;
+
+            this.update(cx, |this, cx| {
+                this.current_completion = Some(CurrentCompletion {
+                    snapshot,
+                    edits,
+                    edit_preview,
+                });
+                this.pending_request = None;
+                cx.notify();
+            })?;
+
+            Ok(())
+        }));
+    }
+
+    fn accept(&mut self, _cx: &mut Context<Self>) {
+        log::debug!("OpenAI Compatible EP: Completion accepted");
+        self.pending_request = None;
+        self.current_completion = None;
+    }
+
+    fn discard(&mut self, _reason: EditPredictionDiscardReason, _cx: &mut Context<Self>) {
+        log::debug!("OpenAI Compatible EP: Completion discarded");
+        self.pending_request = None;
+        self.current_completion = None;
+    }
+
+    fn suggest(
+        &mut self,
+        buffer: &Entity<Buffer>,
+        _cursor_position: Anchor,
+        cx: &mut Context<Self>,
+    ) -> Option<EditPrediction> {
+        let current_completion = self.current_completion.as_ref()?;
+        let buffer = buffer.read(cx);
+        let edits = current_completion.interpolate(&buffer.snapshot())?;
+        if edits.is_empty() {
+            return None;
+        }
+        Some(EditPrediction::Local {
+            id: None,
+            edits,
+            cursor_position: None,
+            edit_preview: Some(current_completion.edit_preview.clone()),
+        })
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct ChatCompletionRequest {
+    model: String,
+    messages: Vec<ChatMessage>,
+    max_tokens: u32,
+    temperature: f32,
+    stream: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct ChatMessage {
+    role: &'static str,
+    content: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatCompletionResponse {
+    choices: Vec<ChatCompletionChoice>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatCompletionChoice {
+    message: ChatCompletionMessage,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatCompletionMessage {
+    content: String,
+}
+
+/// Strip markdown code fences that instruct models sometimes add despite instructions.
+fn strip_markdown_code_fences(text: &str) -> String {
+    let trimmed = text.trim();
+    if let Some(after_opening) = trimmed.strip_prefix("```") {
+        // Skip optional language tag on the first line
+        let after_lang = after_opening
+            .find('\n')
+            .map(|i| &after_opening[i + 1..])
+            .unwrap_or(after_opening);
+        let code = after_lang
+            .strip_suffix("```")
+            .unwrap_or(after_lang)
+            .trim_end();
+        code.to_string()
+    } else {
+        text.to_string()
+    }
+}
+
+/// Check if we need to insert a newline before the completion text.
+/// This handles the case where the cursor is at the end of a complete line
+/// (e.g. a comment or statement) and the model omits the leading newline.
+fn needs_leading_newline(prompt: &str, suffix: &str, completion: &str) -> bool {
+    if completion.starts_with('\n') {
+        return false;
+    }
+
+    // If the prompt already ends with a newline, the cursor is at the start
+    // of a new line — no need to add another.
+    if prompt.ends_with('\n') || prompt.is_empty() {
+        return false;
+    }
+
+    // Cursor must be at the end of a line (suffix starts with newline or is empty)
+    if !suffix.is_empty() && !suffix.starts_with('\n') {
+        return false;
+    }
+
+    let last_line = match prompt.lines().last() {
+        Some(line) => line,
+        None => return false,
+    };
+    let trimmed = last_line.trim_end();
+    if trimmed.is_empty() {
+        return false;
+    }
+
+    // If the line ends with characters that expect a continuation on the same line,
+    // don't add a newline (e.g. `let x = `, `foo(`, `[1, `)
+    if let Some(last_char) = trimmed.chars().last() {
+        if matches!(last_char, '=' | '(' | '[' | ',') {
+            return false;
+        }
+    }
+
+    true
+}

--- a/crates/settings_content/src/language.rs
+++ b/crates/settings_content/src/language.rs
@@ -84,6 +84,7 @@ pub enum EditPredictionProvider {
     Supermaven,
     Zed,
     Codestral,
+    OpenAiCompatible,
     Ollama,
     Sweep,
     Mercury,
@@ -105,6 +106,7 @@ impl<'de> Deserialize<'de> for EditPredictionProvider {
             Supermaven,
             Zed,
             Codestral,
+            OpenAiCompatible,
             Ollama,
             Sweep,
             Mercury,
@@ -117,6 +119,7 @@ impl<'de> Deserialize<'de> for EditPredictionProvider {
             Content::Supermaven => EditPredictionProvider::Supermaven,
             Content::Zed => EditPredictionProvider::Zed,
             Content::Codestral => EditPredictionProvider::Codestral,
+            Content::OpenAiCompatible => EditPredictionProvider::OpenAiCompatible,
             Content::Ollama => EditPredictionProvider::Ollama,
             Content::Sweep => EditPredictionProvider::Sweep,
             Content::Mercury => EditPredictionProvider::Mercury,
@@ -145,6 +148,7 @@ impl EditPredictionProvider {
             | EditPredictionProvider::Copilot
             | EditPredictionProvider::Supermaven
             | EditPredictionProvider::Codestral
+            | EditPredictionProvider::OpenAiCompatible
             | EditPredictionProvider::Ollama
             | EditPredictionProvider::Sweep
             | EditPredictionProvider::Mercury
@@ -158,6 +162,7 @@ impl EditPredictionProvider {
             EditPredictionProvider::Copilot => Some("GitHub Copilot"),
             EditPredictionProvider::Supermaven => Some("Supermaven"),
             EditPredictionProvider::Codestral => Some("Codestral"),
+            EditPredictionProvider::OpenAiCompatible => Some("OpenAI Compatible"),
             EditPredictionProvider::Sweep => Some("Sweep"),
             EditPredictionProvider::Mercury => Some("Mercury"),
             EditPredictionProvider::Experimental(
@@ -186,6 +191,8 @@ pub struct EditPredictionSettingsContent {
     pub copilot: Option<CopilotSettingsContent>,
     /// Settings specific to Codestral.
     pub codestral: Option<CodestralSettingsContent>,
+    /// Settings specific to a generic OpenAI-compatible endpoint.
+    pub open_ai_compatible: Option<OpenAiCompatibleEditPredictionSettingsContent>,
     /// Settings specific to Sweep.
     pub sweep: Option<SweepSettingsContent>,
     /// Settings specific to Ollama.
@@ -235,6 +242,41 @@ pub struct CodestralSettingsContent {
     ///
     /// Default: "https://codestral.mistral.ai"
     pub api_url: Option<String>,
+}
+
+#[with_fallible_options]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema, MergeFrom, PartialEq)]
+pub struct OpenAiCompatibleEditPredictionSettingsContent {
+    /// API URL for the OpenAI-compatible endpoint (e.g. "http://localhost:8000/v1").
+    ///
+    /// Default: none (must be configured)
+    pub api_url: Option<String>,
+    /// Model name to use for completions.
+    ///
+    /// Default: none (must be configured)
+    pub model: Option<String>,
+    /// Maximum tokens to generate.
+    ///
+    /// Default: 256
+    pub max_tokens: Option<u32>,
+    /// Temperature for sampling.
+    ///
+    /// Default: 0.2
+    pub temperature: Option<f32>,
+    /// Controls the length of completions: "short" (1-3 lines, default),
+    /// "medium" (up to ~10 lines), or "long" (no length restriction).
+    ///
+    /// Default: "short"
+    pub completion_length: Option<CompletionLength>,
+}
+
+#[derive(Copy, Clone, Debug, Default, Serialize, Deserialize, JsonSchema, MergeFrom, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum CompletionLength {
+    #[default]
+    Short,
+    Medium,
+    Long,
 }
 
 #[with_fallible_options]

--- a/crates/settings_ui/Cargo.toml
+++ b/crates/settings_ui/Cargo.toml
@@ -22,6 +22,7 @@ anyhow.workspace = true
 bm25 = "2.3.2"
 component.workspace = true
 codestral.workspace = true
+open_ai_edit_prediction.workspace = true
 copilot.workspace = true
 copilot_ui.workspace = true
 edit_prediction.workspace = true

--- a/crates/settings_ui/src/pages/edit_prediction_provider_setup.rs
+++ b/crates/settings_ui/src/pages/edit_prediction_provider_setup.rs
@@ -7,7 +7,9 @@ use edit_prediction::{
 use edit_prediction_ui::{get_available_providers, set_completion_provider};
 use gpui::{Entity, ScrollHandle, prelude::*};
 use language::language_settings::AllLanguageSettings;
-
+use open_ai_edit_prediction::{
+    open_ai_compatible_ep_api_key_state, open_ai_compatible_ep_api_url,
+};
 use settings::Settings as _;
 use ui::{ButtonLink, ConfiguredApiCard, ContextMenu, DropdownMenu, DropdownStyle, prelude::*};
 use workspace::AppState;
@@ -76,6 +78,28 @@ pub(crate) fn render_edit_prediction_setup_page(
                     settings_window
                         .render_sub_page_items_section(
                             codestral_settings().iter().enumerate(),
+                            true,
+                            window,
+                            cx,
+                        )
+                        .into_any_element(),
+                ),
+                window,
+                cx,
+            )
+            .into_any_element(),
+        ),
+        Some(
+            render_api_key_provider(
+                IconName::AiOpenAiCompat,
+                "OpenAI Compatible",
+                "https://platform.openai.com/docs/api-reference/completions".into(),
+                open_ai_compatible_ep_api_key_state(cx),
+                |cx| open_ai_compatible_ep_api_url(cx),
+                Some(
+                    settings_window
+                        .render_sub_page_items_section(
+                            open_ai_compatible_settings().iter().enumerate(),
                             true,
                             window,
                             cx,
@@ -558,6 +582,104 @@ fn codestral_settings() -> Box<[SettingsPageItem]> {
                 placeholder: Some("codestral-latest"),
                 ..Default::default()
             })),
+            files: USER,
+        }),
+    ])
+}
+
+fn open_ai_compatible_settings() -> Box<[SettingsPageItem]> {
+    Box::new([
+        SettingsPageItem::SettingItem(SettingItem {
+            title: "API URL",
+            description: "The base URL of the OpenAI-compatible endpoint (e.g. http://localhost:8000).",
+            field: Box::new(SettingField {
+                pick: |settings| {
+                    settings
+                        .project
+                        .all_languages
+                        .edit_predictions
+                        .as_ref()?
+                        .open_ai_compatible
+                        .as_ref()?
+                        .api_url
+                        .as_ref()
+                },
+                write: |settings, value| {
+                    settings
+                        .project
+                        .all_languages
+                        .edit_predictions
+                        .get_or_insert_default()
+                        .open_ai_compatible
+                        .get_or_insert_default()
+                        .api_url = value;
+                },
+                json_path: Some("edit_predictions.open_ai_compatible.api_url"),
+            }),
+            metadata: Some(Box::new(SettingsFieldMetadata {
+                placeholder: Some("http://localhost:8000/v1"),
+                ..Default::default()
+            })),
+            files: USER,
+        }),
+        SettingsPageItem::SettingItem(SettingItem {
+            title: "Model",
+            description: "The model name to use for completions.",
+            field: Box::new(SettingField {
+                pick: |settings| {
+                    settings
+                        .project
+                        .all_languages
+                        .edit_predictions
+                        .as_ref()?
+                        .open_ai_compatible
+                        .as_ref()?
+                        .model
+                        .as_ref()
+                },
+                write: |settings, value| {
+                    settings
+                        .project
+                        .all_languages
+                        .edit_predictions
+                        .get_or_insert_default()
+                        .open_ai_compatible
+                        .get_or_insert_default()
+                        .model = value;
+                },
+                json_path: Some("edit_predictions.open_ai_compatible.model"),
+            }),
+            metadata: None,
+            files: USER,
+        }),
+        SettingsPageItem::SettingItem(SettingItem {
+            title: "Max Tokens",
+            description: "The maximum number of tokens to generate.",
+            field: Box::new(SettingField {
+                pick: |settings| {
+                    settings
+                        .project
+                        .all_languages
+                        .edit_predictions
+                        .as_ref()?
+                        .open_ai_compatible
+                        .as_ref()?
+                        .max_tokens
+                        .as_ref()
+                },
+                write: |settings, value| {
+                    settings
+                        .project
+                        .all_languages
+                        .edit_predictions
+                        .get_or_insert_default()
+                        .open_ai_compatible
+                        .get_or_insert_default()
+                        .max_tokens = value;
+                },
+                json_path: Some("edit_predictions.open_ai_compatible.max_tokens"),
+            }),
+            metadata: None,
             files: USER,
         }),
     ])

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -83,6 +83,7 @@ clap.workspace = true
 cli.workspace = true
 client.workspace = true
 codestral.workspace = true
+open_ai_edit_prediction.workspace = true
 collab_ui.workspace = true
 collections.workspace = true
 command_palette.workspace = true


### PR DESCRIPTION
Closes #ISSUE

Before you mark this PR as ready for review, make sure that you have:
- [ ] Added a solid test coverage and/or screenshots from doing manual testing
- [ ] Done a self-review taking into account security and performance aspects
- [ ] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)
- [ ] Improved predictions behaviour

Release Notes:

- added OpenAI API compatible predictions provider 
- Settings UI for API URL and key
- predictions menu in the lower right corner adapted