### PR TITLE
acp: Allow permissions on existing terminal tool calls

### DIFF
--- a/crates/agent_ui/src/acp/thread_view/active_thread.rs
+++ b/crates/agent_ui/src/acp/thread_view/active_thread.rs
@@ -4479,6 +4479,12 @@ impl AcpThreadView {
             ToolCallStatus::Rejected | ToolCallStatus::Canceled | ToolCallStatus::Failed
         );
 
+        let confirmation_options = match &tool_call.status {
+            ToolCallStatus::WaitingForConfirmation { options, .. } => Some(options),
+            _ => None,
+        };
+        let needs_confirmation = confirmation_options.is_some();
+
         let output = terminal_data.output();
         let command_finished = output.is_some();
         let truncated_output =
@@ -4547,7 +4553,7 @@ impl AcpThreadView {
                             .color(Color::Muted),
                     ),
             )
-            .when(!command_finished, |header| {
+            .when(!command_finished && !needs_confirmation, |header| {
                 header
                     .gap_1p5()
                     .child(
@@ -4724,6 +4730,14 @@ impl AcpThreadView {
                                 .into_any_element()
                         })),
                 )
+            })
+            .when_some(confirmation_options, |this, options| {
+                this.child(self.render_permission_buttons(
+                    options,
+                    entry_ix,
+                    tool_call.id.clone(),
+                    cx,
+                ))
             })
             .into_any()
     }


### PR DESCRIPTION
It is possible, when the agent is streaming the tool call, that we will get a permission request on an existing terminal and we need to render that.

When Zed controls the terminal this won't happen, but when we are just rendering the output, it can happen and we need to show it.

Release Notes:

- agent: Fix permission options not rendering on terminal commands
