### PR TITLE
acp: Allow permissions on existing terminal tool calls (#49270)

### DIFF
--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -4669,6 +4669,12 @@ impl AcpServerView {
             ToolCallStatus::Rejected | ToolCallStatus::Canceled | ToolCallStatus::Failed
         );
 
+        let confirmation_options = match &tool_call.status {
+            ToolCallStatus::WaitingForConfirmation { options, .. } => Some(options),
+            _ => None,
+        };
+        let needs_confirmation = confirmation_options.is_some();
+
         let output = terminal_data.output();
         let command_finished = output.is_some();
         let truncated_output =
@@ -4741,7 +4747,7 @@ impl AcpServerView {
                             .color(Color::Muted),
                     ),
             )
-            .when(!command_finished, |header| {
+            .when(!command_finished && !needs_confirmation, |header| {
                 header
                     .gap_1p5()
                     .child(
@@ -4923,6 +4929,14 @@ impl AcpServerView {
                                 .into_any_element()
                         })),
                 )
+            })
+            .when_some(confirmation_options, |this, options| {
+                this.child(self.render_permission_buttons(
+                    options,
+                    entry_ix,
+                    tool_call.id.clone(),
+                    cx,
+                ))
             })
             .into_any()
     }


### PR DESCRIPTION
It is possible, when the agent is streaming the tool call, that we will
get a permission request on an existing terminal and we need to render
that.

When Zed controls the terminal this won't happen, but when we are just
rendering the output, it can happen and we need to show it.

Release Notes:

- agent: Fix permission options not rendering on terminal commands
