### PR TITLE
docs: Fix theme publishing link in themes guide

### DIFF
--- a/docs/src/themes.md
+++ b/docs/src/themes.md
@@ -24,7 +24,7 @@ Many popular themes have been ported to Zed, and if you're struggling to choose 
 You can use [Zed's Theme Builder](https://zed.dev/theme-builder) to design your own custom theme based on an existing one.
 
 This tool lets you fine-tune and preview how every surface in the Zed app will look.
-You can then export the JSON for [local use](/themes.md#local-themes) or for [publishing in Zed's extension store](/extensions/themes.md).
+You can then export the JSON for [local use](./themes.md#local-themes) or for [publishing in Zed's extension store](./extensions/themes.md).
 
 ## Configuring a Theme
 


### PR DESCRIPTION
## Summary
- add a Build Your Theme section to docs/src/themes.md
- point publishing guidance to ./extensions/themes.md (docs route) instead of a broken root-level URL
- include a local-theme anchor link for exported JSON usage

Release Notes:

- N/A