### PR TITLE
lsp: Add rust-analyzer semantic token modifier support

### DIFF
--- a/crates/editor/src/semantic_tokens.rs
+++ b/crates/editor/src/semantic_tokens.rs
@@ -1418,6 +1418,250 @@ mod tests {
         assert_eq!(full_counter_toml.load(atomic::Ordering::Acquire), 2);
     }
 
+    #[gpui::test]
+    async fn test_modifier_based_styling_rules(cx: &mut TestAppContext) {
+        use gpui::UpdateGlobal as _;
+        use settings::SemanticTokenRule;
+
+        init_test(cx, |_| {});
+
+        update_test_language_settings(cx, |language_settings| {
+            language_settings.languages.0.insert(
+                "Rust".into(),
+                LanguageSettingsContent {
+                    semantic_tokens: Some(SemanticTokens::Full),
+                    ..LanguageSettingsContent::default()
+                },
+            );
+        });
+
+        cx.update(|cx| {
+            SettingsStore::update_global(cx, |store, _| {
+                store.set_language_semantic_token_rules(
+                    "Rust".into(),
+                    SemanticTokenRules {
+                        rules: vec![
+                            SemanticTokenRule {
+                                token_modifiers: vec!["unsafe".into()],
+                                font_weight: Some(
+                                    settings::SemanticTokenFontWeight::Bold,
+                                ),
+                                ..SemanticTokenRule::default()
+                            },
+                            SemanticTokenRule {
+                                token_modifiers: vec!["mutable".into()],
+                                underline: Some(
+                                    settings::SemanticTokenColorOverride::InheritForeground(
+                                        true,
+                                    ),
+                                ),
+                                ..SemanticTokenRule::default()
+                            },
+                            SemanticTokenRule {
+                                token_modifiers: vec!["consuming".into()],
+                                font_style: Some(
+                                    settings::SemanticTokenFontStyle::Italic,
+                                ),
+                                ..SemanticTokenRule::default()
+                            },
+                            SemanticTokenRule {
+                                token_modifiers: vec!["deprecated".into()],
+                                strikethrough: Some(
+                                    settings::SemanticTokenColorOverride::InheritForeground(
+                                        true,
+                                    ),
+                                ),
+                                ..SemanticTokenRule::default()
+                            },
+                        ],
+                    },
+                );
+            });
+        });
+
+        let mut cx = EditorLspTestContext::new_rust(
+            lsp::ServerCapabilities {
+                semantic_tokens_provider: Some(
+                    lsp::SemanticTokensServerCapabilities::SemanticTokensOptions(
+                        lsp::SemanticTokensOptions {
+                            legend: lsp::SemanticTokensLegend {
+                                token_types: vec!["function".into()],
+                                token_modifiers: vec![
+                                    "unsafe".into(),
+                                    "mutable".into(),
+                                    "consuming".into(),
+                                    "deprecated".into(),
+                                ],
+                            },
+                            full: Some(lsp::SemanticTokensFullOptions::Delta { delta: None }),
+                            ..lsp::SemanticTokensOptions::default()
+                        },
+                    ),
+                ),
+                ..lsp::ServerCapabilities::default()
+            },
+            cx,
+        )
+        .await;
+
+        // Test unsafe modifier (bit 0) → bold
+        let mut full_request = cx
+            .set_request_handler::<lsp::request::SemanticTokensFullRequest, _, _>(
+                move |_, _, _| async move {
+                    Ok(Some(lsp::SemanticTokensResult::Tokens(
+                        lsp::SemanticTokens {
+                            data: vec![
+                                0, // delta_line
+                                3, // delta_start
+                                4, // length
+                                0, // token_type (function)
+                                1, // token_modifiers_bitset (bit 0 = unsafe)
+                            ],
+                            result_id: None,
+                        },
+                    )))
+                },
+            );
+
+        cx.set_state("ˇfn main() {}");
+        full_request.next().await;
+        cx.run_until_parked();
+
+        let styles = extract_semantic_highlight_styles(&cx.editor, &cx);
+        assert_eq!(styles.len(), 1, "Should have one highlight style");
+        assert_eq!(
+            styles[0].font_weight,
+            Some(FontWeight::BOLD),
+            "Token with unsafe modifier should be bold"
+        );
+
+        // Test mutable modifier (bit 1) → underline
+        let mut full_request = cx
+            .set_request_handler::<lsp::request::SemanticTokensFullRequest, _, _>(
+                move |_, _, _| async move {
+                    Ok(Some(lsp::SemanticTokensResult::Tokens(
+                        lsp::SemanticTokens {
+                            data: vec![
+                                0, // delta_line
+                                3, // delta_start
+                                4, // length
+                                0, // token_type (function)
+                                2, // token_modifiers_bitset (bit 1 = mutable)
+                            ],
+                            result_id: None,
+                        },
+                    )))
+                },
+            );
+
+        cx.set_state("ˇfn main() { }");
+        full_request.next().await;
+        cx.run_until_parked();
+
+        let styles = extract_semantic_highlight_styles(&cx.editor, &cx);
+        assert_eq!(styles.len(), 1, "Should have one highlight style");
+        assert!(
+            styles[0].underline.is_some(),
+            "Token with mutable modifier should be underlined"
+        );
+
+        // Test consuming modifier (bit 2) → italic
+        let mut full_request = cx
+            .set_request_handler::<lsp::request::SemanticTokensFullRequest, _, _>(
+                move |_, _, _| async move {
+                    Ok(Some(lsp::SemanticTokensResult::Tokens(
+                        lsp::SemanticTokens {
+                            data: vec![
+                                0, // delta_line
+                                3, // delta_start
+                                4, // length
+                                0, // token_type (function)
+                                4, // token_modifiers_bitset (bit 2 = consuming)
+                            ],
+                            result_id: None,
+                        },
+                    )))
+                },
+            );
+
+        cx.set_state("ˇfn main() {  }");
+        full_request.next().await;
+        cx.run_until_parked();
+
+        let styles = extract_semantic_highlight_styles(&cx.editor, &cx);
+        assert_eq!(styles.len(), 1, "Should have one highlight style");
+        assert_eq!(
+            styles[0].font_style,
+            Some(FontStyle::Italic),
+            "Token with consuming modifier should be italic"
+        );
+
+        // Test deprecated modifier (bit 3) → strikethrough
+        let mut full_request = cx
+            .set_request_handler::<lsp::request::SemanticTokensFullRequest, _, _>(
+                move |_, _, _| async move {
+                    Ok(Some(lsp::SemanticTokensResult::Tokens(
+                        lsp::SemanticTokens {
+                            data: vec![
+                                0, // delta_line
+                                3, // delta_start
+                                4, // length
+                                0, // token_type (function)
+                                8, // token_modifiers_bitset (bit 3 = deprecated)
+                            ],
+                            result_id: None,
+                        },
+                    )))
+                },
+            );
+
+        cx.set_state("ˇfn main() {   }");
+        full_request.next().await;
+        cx.run_until_parked();
+
+        let styles = extract_semantic_highlight_styles(&cx.editor, &cx);
+        assert_eq!(styles.len(), 1, "Should have one highlight style");
+        assert!(
+            styles[0].strikethrough.is_some(),
+            "Token with deprecated modifier should have strikethrough"
+        );
+
+        // Test combined modifiers: unsafe (bit 0) + mutable (bit 1) → bold + underline
+        let mut full_request = cx
+            .set_request_handler::<lsp::request::SemanticTokensFullRequest, _, _>(
+                move |_, _, _| async move {
+                    Ok(Some(lsp::SemanticTokensResult::Tokens(
+                        lsp::SemanticTokens {
+                            data: vec![
+                                0, // delta_line
+                                3, // delta_start
+                                4, // length
+                                0, // token_type (function)
+                                3, // token_modifiers_bitset (bits 0+1 = unsafe + mutable)
+                            ],
+                            result_id: None,
+                        },
+                    )))
+                },
+            );
+
+        cx.set_state("ˇfn main() {    }");
+        full_request.next().await;
+        cx.run_until_parked();
+
+        let styles = extract_semantic_highlight_styles(&cx.editor, &cx);
+        assert_eq!(styles.len(), 1, "Should have one highlight style");
+        assert_eq!(
+            styles[0].font_weight,
+            Some(FontWeight::BOLD),
+            "Combined modifiers: should be bold from unsafe"
+        );
+        assert!(
+            styles[0].underline.is_some(),
+            "Combined modifiers: should be underlined from mutable"
+        );
+    }
+
     fn extract_semantic_highlights(
         editor: &Entity<Editor>,
         cx: &TestAppContext,

--- a/crates/languages/src/rust/semantic_token_rules.json
+++ b/crates/languages/src/rust/semantic_token_rules.json
@@ -1,5 +1,26 @@
 [
   {
+    "token_modifiers": ["unsafe"],
+    "font_weight": "bold"
+  },
+  {
+    "token_modifiers": ["mutable"],
+    "underline": true
+  },
+  {
+    "token_modifiers": ["consuming"],
+    "font_style": "italic"
+  },
+  {
+    "token_modifiers": ["deprecated"],
+    "strikethrough": true
+  },
+  {
+    "token_type": "keyword",
+    "token_modifiers": ["controlFlow"],
+    "style": ["keyword.control", "keyword"]
+  },
+  {
     "token_type": "angle",
     "style": ["punctuation.bracket"]
   },

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -389,6 +389,22 @@ pub const SEMANTIC_TOKEN_MODIFIERS: &[SemanticTokenModifier] = &[
     // Language specific things below.
     // Rust
     SemanticTokenModifier::new("constant"),
+    SemanticTokenModifier::new("unsafe"),
+    SemanticTokenModifier::new("mutable"),
+    SemanticTokenModifier::new("consuming"),
+    SemanticTokenModifier::new("callable"),
+    SemanticTokenModifier::new("trait"),
+    SemanticTokenModifier::new("library"),
+    SemanticTokenModifier::new("public"),
+    SemanticTokenModifier::new("reference"),
+    SemanticTokenModifier::new("controlFlow"),
+    SemanticTokenModifier::new("crateRoot"),
+    SemanticTokenModifier::new("injected"),
+    SemanticTokenModifier::new("intraDocLink"),
+    SemanticTokenModifier::new("associated"),
+    SemanticTokenModifier::new("attribute"),
+    SemanticTokenModifier::new("macro"),
+    SemanticTokenModifier::new("procMacro"),
 ];
 
 impl LanguageServer {


### PR DESCRIPTION
Register all 17 `rust-analyzer` custom semantic token modifiers and add default visual styling rules for Rust:

- `unsafe` → bold
- `mutable` → underline
- `consuming` → italic
- `deprecated` → strikethrough
- `keyword` + `controlFlow` → `keyword.control` (forward-compatible scope for themes that distinguish control-flow keywords)

The modifier registration in `SEMANTIC_TOKEN_MODIFIERS` tells rust-analyzer that Zed understands these modifiers, enabling richer token data.

An example of porting the [Pale Fire](https://github.com/matklad/pale-fire) theme to Zed:

<img width="297" height="267" alt="image" src="https://github.com/user-attachments/assets/eb17c6b6-c7c6-4537-9089-9a2479275830" />

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Improved semantic token support for Rust
