### PR TITLE
collab: Remove `POST /users/:id/access_tokens` endpoint

### DIFF
--- a/crates/collab/src/auth.rs
+++ b/crates/collab/src/auth.rs
@@ -1,6 +1,6 @@
 use crate::{
     AppState, Error, Result,
-    db::{self, AccessTokenId, Database, UserId},
+    db::{AccessTokenId, Database, UserId},
     rpc::Principal,
 };
 use anyhow::Context as _;
@@ -108,38 +108,11 @@ pub async fn validate_header<B>(mut req: Request<B>, next: Next<B>) -> impl Into
     ))
 }
 
-pub const MAX_ACCESS_TOKENS_TO_STORE: usize = 8;
-
 #[derive(Serialize, Deserialize)]
 pub struct AccessTokenJson {
     pub version: usize,
     pub id: AccessTokenId,
     pub token: String,
-}
-
-/// Creates a new access token to identify the given user. before returning it, you should
-/// encrypt it with the user's public key.
-pub async fn create_access_token(
-    db: &db::Database,
-    user_id: UserId,
-    impersonated_user_id: Option<UserId>,
-) -> Result<String> {
-    const VERSION: usize = 1;
-    let access_token = rpc::auth::random_token();
-    let access_token_hash = hash_access_token(&access_token);
-    let id = db
-        .create_access_token(
-            user_id,
-            impersonated_user_id,
-            &access_token_hash,
-            MAX_ACCESS_TOKENS_TO_STORE,
-        )
-        .await?;
-    Ok(serde_json::to_string(&AccessTokenJson {
-        version: VERSION,
-        id,
-        token: access_token,
-    })?)
 }
 
 /// Hashing prevents anyone with access to the database being able to login.

--- a/crates/collab/src/auth.rs
+++ b/crates/collab/src/auth.rs
@@ -150,22 +150,6 @@ pub fn hash_access_token(token: &str) -> String {
     format!("$sha256${}", BASE64_URL_SAFE.encode(digest))
 }
 
-/// Encrypts the given access token with the given public key to avoid leaking it on the way
-/// to the client.
-pub fn encrypt_access_token(access_token: &str, public_key: String) -> Result<String> {
-    use rpc::auth::EncryptionFormat;
-
-    /// The encryption format to use for the access token.
-    const ENCRYPTION_FORMAT: EncryptionFormat = EncryptionFormat::V1;
-
-    let native_app_public_key =
-        rpc::auth::PublicKey::try_from(public_key).context("failed to parse app public key")?;
-    let encrypted_access_token = native_app_public_key
-        .encrypt_string(access_token, ENCRYPTION_FORMAT)
-        .context("failed to encrypt access token with public key")?;
-    Ok(encrypted_access_token)
-}
-
 pub struct VerifyAccessTokenResult {
     pub is_valid: bool,
     pub impersonator_id: Option<UserId>,

--- a/crates/collab/src/db/queries/access_tokens.rs
+++ b/crates/collab/src/db/queries/access_tokens.rs
@@ -1,6 +1,5 @@
 use super::*;
 use anyhow::Context as _;
-use sea_orm::sea_query::Query;
 
 impl Database {
     /// Creates a new access token for the given user.
@@ -12,6 +11,8 @@ impl Database {
         access_token_hash: &str,
         max_access_token_count: usize,
     ) -> Result<AccessTokenId> {
+        use sea_orm::sea_query::Query;
+
         self.transaction(|tx| async {
             let tx = tx;
 

--- a/crates/collab/src/db/queries/access_tokens.rs
+++ b/crates/collab/src/db/queries/access_tokens.rs
@@ -4,6 +4,7 @@ use sea_orm::sea_query::Query;
 
 impl Database {
     /// Creates a new access token for the given user.
+    #[cfg(any(test, feature = "test-support"))]
     pub async fn create_access_token(
         &self,
         user_id: UserId,

--- a/crates/collab/tests/integration/collab_tests.rs
+++ b/crates/collab/tests/integration/collab_tests.rs
@@ -53,8 +53,7 @@ fn channel_id(room: &Entity<Room>, cx: &mut TestAppContext) -> Option<ChannelId>
 
 mod auth_token_tests {
     use collab::auth::{
-        AccessTokenJson, MAX_ACCESS_TOKENS_TO_STORE, VerifyAccessTokenResult, create_access_token,
-        verify_access_token,
+        AccessTokenJson, VerifyAccessTokenResult, hash_access_token, verify_access_token,
     };
     use rand::prelude::*;
     use scrypt::Scrypt;
@@ -63,6 +62,31 @@ mod auth_token_tests {
 
     use collab::db::{Database, NewUserParams, UserId, access_token};
     use collab::*;
+
+    const MAX_ACCESS_TOKENS_TO_STORE: usize = 8;
+
+    async fn create_access_token(
+        db: &db::Database,
+        user_id: UserId,
+        impersonated_user_id: Option<UserId>,
+    ) -> Result<String> {
+        const VERSION: usize = 1;
+        let access_token = ::rpc::auth::random_token();
+        let access_token_hash = hash_access_token(&access_token);
+        let id = db
+            .create_access_token(
+                user_id,
+                impersonated_user_id,
+                &access_token_hash,
+                MAX_ACCESS_TOKENS_TO_STORE,
+            )
+            .await?;
+        Ok(serde_json::to_string(&AccessTokenJson {
+            version: VERSION,
+            id,
+            token: access_token,
+        })?)
+    }
 
     #[gpui::test]
     async fn test_verify_access_token(cx: &mut gpui::TestAppContext) {


### PR DESCRIPTION
This PR removes the `POST /users/:id/access_tokens` endpoint from Collab, as it is no longer used.

Closes CLO-290.

Release Notes:

- N/A
