### PR TITLE
Harden background-agent MVP workflow security

### DIFF
--- a/.github/workflows/background_agent_mvp.yml
+++ b/.github/workflows/background_agent_mvp.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Install Droid CLI
         run: |
@@ -171,6 +171,7 @@ Constraints:
 - Do not merge or auto-approve.
 - Keep changes narrowly scoped to this crash.
 - Do not modify files in .github/, .factory/, or script/ directories.
+- When investigating git history, limit your search to the last 2 weeks of commits. Do not traverse older history.
 - If the crash is not solvable with available context, write a clear blocker summary to PR_BODY.md.
 EOF
 

--- a/.github/workflows/background_agent_mvp.yml
+++ b/.github/workflows/background_agent_mvp.yml
@@ -74,41 +74,22 @@ jobs:
         run: |
           set -euo pipefail
 
+          PREFETCH_DIR="/tmp/crash-data"
+          ARGS=(--select-only --prefetch-dir "$PREFETCH_DIR" --org "$SENTRY_ORG")
           if [ -n "$INPUT_CRASH_IDS" ]; then
-            IDS="$(echo "$INPUT_CRASH_IDS" | tr -d '[:space:]')"
-            echo "Using manually supplied crash IDs: $IDS"
-            echo "ids=$IDS" >> "$GITHUB_OUTPUT"
-            exit 0
+            ARGS+=(--crash-ids "$INPUT_CRASH_IDS")
+          elif [ -n "$INPUT_TOP" ]; then
+            ARGS+=(--top "$INPUT_TOP")
           fi
 
-          TOP="$INPUT_TOP"
-          if [ -z "$TOP" ]; then
-            TOP="3"
-          fi
-          # Cap top to prevent runaway runs
-          if [ "$TOP" -gt 10 ] 2>/dev/null; then
-            echo "Capping --top from $TOP to 10"
-            TOP="10"
-          fi
-
-          python3 script/select-sentry-crash-candidates \
-            --org "$SENTRY_ORG" \
-            --top "$TOP" \
-            --output /tmp/sentry-candidates.json
-
-          IDS="$(python3 - <<'PY'
-import json
-with open('/tmp/sentry-candidates.json', 'r', encoding='utf-8') as f:
-    data = json.load(f)
-print(','.join(item['short_id'] for item in data.get('selected', [])))
-PY
-          )"
+          IDS="$(python3 script/run-background-agent-mvp-local "${ARGS[@]}")"
 
           if [ -z "$IDS" ]; then
             echo "No candidates selected"
             exit 1
           fi
 
+          echo "Using crash IDs: $IDS"
           echo "ids=$IDS" >> "$GITHUB_OUTPUT"
 
       - name: Run background agent pipeline per crash
@@ -150,30 +131,45 @@ PY
             git fetch origin main
             git checkout -B "$BRANCH" origin/main
 
-            cat > /tmp/background-agent-prompt.md <<EOF
-You are running the weekly background crash-fix MVP pipeline for crash ${CRASH_ID}.
+            CRASH_DATA_FILE="/tmp/crash-data/crash-${CRASH_ID}.md"
+            if [ ! -f "$CRASH_DATA_FILE" ]; then
+              echo "WARNING: No pre-fetched crash data for $CRASH_ID at $CRASH_DATA_FILE — skipping"
+              continue
+            fi
 
-Required workflow:
-1. Fetch crash data with: script/sentry-fetch ${CRASH_ID}
-2. Follow .factory/prompts/crash/investigate.md and write ANALYSIS.md
-3. Follow .factory/prompts/crash/link-issues.md and write LINKED_ISSUES.md
-4. Follow .factory/prompts/crash/fix.md to implement a minimal fix with tests
-5. Run validators required by the fix prompt for the affected crate(s)
-6. Write PR_BODY.md with sections:
-   - Crash Summary
-   - Root Cause
-   - Fix
-   - Validation
-   - Potentially Related Issues (High/Medium/Low from LINKED_ISSUES.md)
-   - Reviewer Checklist
+            python3 -c "
+          import sys
+          crash_id, data_file = sys.argv[1], sys.argv[2]
+          prompt = f'''You are running the weekly background crash-fix MVP pipeline for crash {crash_id}.
 
-Constraints:
-- Do not merge or auto-approve.
-- Keep changes narrowly scoped to this crash.
-- Do not modify files in .github/, .factory/, or script/ directories.
-- When investigating git history, limit your search to the last 2 weeks of commits. Do not traverse older history.
-- If the crash is not solvable with available context, write a clear blocker summary to PR_BODY.md.
-EOF
+          The crash report has been pre-fetched and is available at: {data_file}
+          Read this file to get the crash data. Do not call script/sentry-fetch.
+
+          Required workflow:
+          1. Read the crash report from {data_file}
+          2. Follow .factory/prompts/crash/investigate.md and write ANALYSIS.md
+          3. Follow .factory/prompts/crash/link-issues.md and write LINKED_ISSUES.md
+          4. Follow .factory/prompts/crash/fix.md to implement a minimal fix with tests
+          5. Run validators required by the fix prompt for the affected crate(s)
+          6. Write PR_BODY.md with sections:
+             - Crash Summary
+             - Root Cause
+             - Fix
+             - Validation
+             - Potentially Related Issues (High/Medium/Low from LINKED_ISSUES.md)
+             - Reviewer Checklist
+
+          Constraints:
+          - Do not merge or auto-approve.
+          - Keep changes narrowly scoped to this crash.
+          - Do not modify files in .github/, .factory/, or script/ directories.
+          - When investigating git history, limit your search to the last 2 weeks of commits. Do not traverse older history.
+          - If the crash is not solvable with available context, write a clear blocker summary to PR_BODY.md.
+          '''
+          import textwrap
+          with open('/tmp/background-agent-prompt.md', 'w') as f:
+              f.write(textwrap.dedent(prompt))
+          " "$CRASH_ID" "$CRASH_DATA_FILE"
 
             if ! "$DROID_BIN" exec --auto medium -m "$DROID_MODEL" -f /tmp/background-agent-prompt.md; then
               echo "Droid execution failed for $CRASH_ID, continuing to next candidate"
@@ -198,9 +194,7 @@ EOF
             fi
 
             if ! git diff --cached --quiet; then
-              git commit -m "fix: draft crash fix for ${CRASH_ID}
-
-Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>"
+              git commit -m "fix: draft crash fix for ${CRASH_ID}"
             fi
 
             git push -u origin "$BRANCH"
@@ -209,11 +203,7 @@ Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.g
             BODY_FILE="PR_BODY.md"
             if [ ! -f "$BODY_FILE" ]; then
               BODY_FILE="/tmp/pr-body-${CRASH_ID}.md"
-              cat > "$BODY_FILE" <<EOF
-Automated draft crash-fix pipeline output for ${CRASH_ID}.
-
-No PR_BODY.md was generated by the agent; please review commit and linked artifacts manually.
-EOF
+              printf "Automated draft crash-fix pipeline output for %s.\n\nNo PR_BODY.md was generated by the agent; please review commit and linked artifacts manually.\n" "$CRASH_ID" > "$BODY_FILE"
             fi
 
             EXISTING_PR="$(gh pr list --head "$BRANCH" --json number --jq '.[0].number')"
@@ -233,6 +223,10 @@ EOF
               done
             fi
           done
+
+      - name: Cleanup pre-fetched crash data
+        if: always()
+        run: rm -rf /tmp/crash-data
 
       - name: Workflow summary
         if: always()

--- a/.github/workflows/background_agent_mvp.yml
+++ b/.github/workflows/background_agent_mvp.yml
@@ -26,7 +26,6 @@ permissions:
 env:
   FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
   DROID_MODEL: claude-opus-4-5-20251101
-  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
   SENTRY_ORG: zed-dev
 
 jobs:
@@ -38,7 +37,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Install Droid CLI
         run: |
@@ -54,10 +53,11 @@ jobs:
 
       - name: Resolve reviewers
         id: reviewers
+        env:
+          INPUT_REVIEWERS: ${{ inputs.reviewers }}
+          DEFAULT_REVIEWERS: ${{ vars.BACKGROUND_AGENT_REVIEWERS }}
         run: |
           set -euo pipefail
-          INPUT_REVIEWERS="${{ inputs.reviewers }}"
-          DEFAULT_REVIEWERS="${{ vars.BACKGROUND_AGENT_REVIEWERS }}"
           if [ -z "$DEFAULT_REVIEWERS" ]; then
             DEFAULT_REVIEWERS="eholk,morgankrey,osiewicz,bennetbo"
           fi
@@ -67,19 +67,28 @@ jobs:
 
       - name: Select crash candidates
         id: candidates
+        env:
+          INPUT_CRASH_IDS: ${{ inputs.crash_ids }}
+          INPUT_TOP: ${{ inputs.top }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           set -euo pipefail
 
-          if [ -n "${{ inputs.crash_ids }}" ]; then
-            IDS="$(echo "${{ inputs.crash_ids }}" | tr -d '[:space:]')"
+          if [ -n "$INPUT_CRASH_IDS" ]; then
+            IDS="$(echo "$INPUT_CRASH_IDS" | tr -d '[:space:]')"
             echo "Using manually supplied crash IDs: $IDS"
             echo "ids=$IDS" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          TOP="${{ inputs.top }}"
+          TOP="$INPUT_TOP"
           if [ -z "$TOP" ]; then
             TOP="3"
+          fi
+          # Cap top to prevent runaway runs
+          if [ "$TOP" -gt 10 ] 2>/dev/null; then
+            echo "Capping --top from $TOP to 10"
+            TOP="10"
           fi
 
           python3 script/select-sentry-crash-candidates \
@@ -113,14 +122,30 @@ PY
           git config user.name "factory-droid[bot]"
           git config user.email "138933559+factory-droid[bot]@users.noreply.github.com"
 
+          # Crash ID format validation regex
+          CRASH_ID_PATTERN='^[A-Za-z0-9]+-[A-Za-z0-9]+$'
+
           IFS=',' read -r -a CRASH_ID_ARRAY <<< "$CRASH_IDS"
 
           for CRASH_ID in "${CRASH_ID_ARRAY[@]}"; do
             CRASH_ID="$(echo "$CRASH_ID" | xargs)"
             [ -z "$CRASH_ID" ] && continue
 
+            # Validate crash ID format to prevent injection via branch names or prompts
+            if ! [[ "$CRASH_ID" =~ $CRASH_ID_PATTERN ]]; then
+              echo "ERROR: Invalid crash ID format: '$CRASH_ID' — skipping"
+              continue
+            fi
+
             BRANCH="background-agent/mvp-${CRASH_ID,,}-$(date +%Y%m%d)"
             echo "Running crash pipeline for $CRASH_ID on $BRANCH"
+
+            # Deduplication: skip if a draft PR already exists for this crash
+            EXISTING_BRANCH_PR="$(gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number' || echo "")"
+            if [ -n "$EXISTING_BRANCH_PR" ]; then
+              echo "Draft PR #$EXISTING_BRANCH_PR already exists for $CRASH_ID — skipping"
+              continue
+            fi
 
             git fetch origin main
             git checkout -B "$BRANCH" origin/main
@@ -145,6 +170,7 @@ Required workflow:
 Constraints:
 - Do not merge or auto-approve.
 - Keep changes narrowly scoped to this crash.
+- Do not modify files in .github/, .factory/, or script/ directories.
 - If the crash is not solvable with available context, write a clear blocker summary to PR_BODY.md.
 EOF
 
@@ -158,7 +184,18 @@ EOF
               continue
             fi
 
-            git add -A
+            # Stage only expected file types — not git add -A
+            git add -- '*.rs' '*.toml' 'Cargo.lock' 'ANALYSIS.md' 'LINKED_ISSUES.md' 'PR_BODY.md'
+
+            # Reject changes to protected paths
+            PROTECTED_CHANGES="$(git diff --cached --name-only | grep -E '^(\.github/|\.factory/|script/)' || true)"
+            if [ -n "$PROTECTED_CHANGES" ]; then
+              echo "ERROR: Agent modified protected paths — aborting commit for $CRASH_ID:"
+              echo "$PROTECTED_CHANGES"
+              git reset HEAD -- .
+              continue
+            fi
+
             if ! git diff --cached --quiet; then
               git commit -m "fix: draft crash fix for ${CRASH_ID}
 
@@ -198,15 +235,18 @@ EOF
 
       - name: Workflow summary
         if: always()
+        env:
+          SUMMARY_CRASH_IDS: ${{ steps.candidates.outputs.ids }}
+          SUMMARY_REVIEWERS: ${{ steps.reviewers.outputs.reviewers }}
         run: |
           {
             echo "## Background Agent MVP"
             echo ""
-            echo "- Crash IDs: ${{ steps.candidates.outputs.ids }}"
-            echo "- Reviewer routing: ${{ steps.reviewers.outputs.reviewers || 'NOT CONFIGURED' }}"
+            echo "- Crash IDs: ${SUMMARY_CRASH_IDS:-none}"
+            echo "- Reviewer routing: ${SUMMARY_REVIEWERS:-NOT CONFIGURED}"
             echo "- Pipeline: investigate -> link-issues -> fix -> draft PR"
           } >> "$GITHUB_STEP_SUMMARY"
 
 concurrency:
-  group: background-agent-mvp-${{ github.ref_name }}
+  group: background-agent-mvp
   cancel-in-progress: false

--- a/script/run-background-agent-mvp-local
+++ b/script/run-background-agent-mvp-local
@@ -41,10 +41,35 @@ def validate_crash_ids(ids: list[str]) -> list[str]:
     return valid
 
 
+MAX_TOP = 10
+
+
+def prefetch_crash_data(crash_ids: list[str], output_dir: str) -> None:
+    """Fetch crash reports via script/sentry-fetch and save to output_dir/crash-{ID}.md."""
+    os.makedirs(output_dir, exist_ok=True)
+    for crash_id in crash_ids:
+        output_path = os.path.join(output_dir, f"crash-{crash_id}.md")
+        result = run(
+            ["python3", "script/sentry-fetch", crash_id],
+            check=False,
+            capture_output=True,
+        )
+        if result.returncode != 0:
+            print(f"WARNING: Failed to fetch crash data for {crash_id}: {result.stderr.strip()}", file=sys.stderr)
+            continue
+        with open(output_path, "w", encoding="utf-8") as f:
+            f.write(result.stdout)
+        print(f"Fetched crash data for {crash_id} -> {output_path}", file=sys.stderr)
+
+
 def resolve_crash_ids(args) -> list[str]:
     if args.crash_ids:
         raw = [item.strip() for item in args.crash_ids.split(",") if item.strip()]
         return validate_crash_ids(raw)
+
+    top = min(args.top, MAX_TOP)
+    if args.top > MAX_TOP:
+        print(f"Capping --top from {args.top} to {MAX_TOP}", file=sys.stderr)
 
     with tempfile.NamedTemporaryFile(mode="w+", suffix=".json", delete=False) as file:
         output_path = file.name
@@ -57,7 +82,7 @@ def resolve_crash_ids(args) -> list[str]:
                 "--org",
                 args.org,
                 "--top",
-                str(args.top),
+                str(top),
                 "--output",
                 output_path,
             ]
@@ -72,11 +97,21 @@ def resolve_crash_ids(args) -> list[str]:
             pass
 
 
-def write_prompt(crash_id: str) -> Path:
+def write_prompt(crash_id: str, crash_data_file: str | None = None) -> Path:
+    if crash_data_file:
+        fetch_step = (
+            f"The crash report has been pre-fetched and is available at: {crash_data_file}\n"
+            f"Read this file to get the crash data. Do not call script/sentry-fetch.\n"
+            f"\n"
+            f"1. Read the crash report from {crash_data_file}"
+        )
+    else:
+        fetch_step = f"1. Fetch crash data with: script/sentry-fetch {crash_id}"
+
     prompt = f"""You are running the weekly background crash-fix MVP pipeline for crash {crash_id}.
 
 Required workflow:
-1. Fetch crash data with: script/sentry-fetch {crash_id}
+{fetch_step}
 2. Follow .factory/prompts/crash/investigate.md and write ANALYSIS.md
 3. Follow .factory/prompts/crash/link-issues.md and write LINKED_ISSUES.md
 4. Follow .factory/prompts/crash/fix.md to implement a minimal fix with tests
@@ -137,8 +172,18 @@ def run_pipeline_for_crash(args, crash_id: str) -> dict:
 def main() -> int:
     parser = argparse.ArgumentParser(description="Run local background-agent MVP dry-run workflow")
     parser.add_argument("--crash-ids", help="Comma-separated crash IDs (e.g. ZED-4VS,ZED-123)")
-    parser.add_argument("--top", type=int, default=3, help="Top N crashes when --crash-ids is omitted")
+    parser.add_argument("--top", type=int, default=3, help="Top N crashes when --crash-ids is omitted (max 10)")
     parser.add_argument("--org", default="zed-dev", help="Sentry org slug")
+    parser.add_argument(
+        "--select-only",
+        action="store_true",
+        help="Resolve crash IDs and print them comma-separated, then exit. No agent execution.",
+    )
+    parser.add_argument(
+        "--prefetch-dir",
+        help="When used with --select-only, also fetch crash data via script/sentry-fetch "
+        "and save reports to DIR/crash-{ID}.md for each resolved ID.",
+    )
     parser.add_argument("--model", default=os.environ.get("DROID_MODEL", "claude-opus-4-5-20251101"))
     parser.add_argument("--droid-bin", default=os.environ.get("DROID_BIN", "droid"))
     parser.add_argument(
@@ -152,6 +197,12 @@ def main() -> int:
     if not crash_ids:
         print("No crash IDs were selected.", file=sys.stderr)
         return 1
+
+    if args.select_only:
+        if args.prefetch_dir:
+            prefetch_crash_data(crash_ids, args.prefetch_dir)
+        print(",".join(crash_ids))
+        return 0
 
     print(f"Running local dry-run for crashes: {', '.join(crash_ids)}")
     results = [run_pipeline_for_crash(args, crash_id) for crash_id in crash_ids]

--- a/script/run-background-agent-mvp-local
+++ b/script/run-background-agent-mvp-local
@@ -7,11 +7,15 @@ Default mode is dry-run: generate branch + agent output without commit/push/PR.
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
 from datetime import datetime
 from pathlib import Path
+
+
+CRASH_ID_PATTERN = re.compile(r"^[A-Za-z0-9]+-[A-Za-z0-9]+$")
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -27,9 +31,20 @@ def run(command: list[str], check: bool = True, capture_output: bool = False) ->
     )
 
 
+def validate_crash_ids(ids: list[str]) -> list[str]:
+    valid = []
+    for crash_id in ids:
+        if not CRASH_ID_PATTERN.match(crash_id):
+            print(f"WARNING: Skipping invalid crash ID format: '{crash_id}'", file=sys.stderr)
+            continue
+        valid.append(crash_id)
+    return valid
+
+
 def resolve_crash_ids(args) -> list[str]:
     if args.crash_ids:
-        return [item.strip() for item in args.crash_ids.split(",") if item.strip()]
+        raw = [item.strip() for item in args.crash_ids.split(",") if item.strip()]
+        return validate_crash_ids(raw)
 
     with tempfile.NamedTemporaryFile(mode="w+", suffix=".json", delete=False) as file:
         output_path = file.name
@@ -49,7 +64,7 @@ def resolve_crash_ids(args) -> list[str]:
         )
         with open(output_path, "r", encoding="utf-8") as file:
             payload = json.load(file)
-        return [item["short_id"] for item in payload.get("selected", [])]
+        return validate_crash_ids([item["short_id"] for item in payload.get("selected", [])])
     finally:
         try:
             os.remove(output_path)
@@ -79,7 +94,7 @@ Constraints:
 - If the crash is not solvable with available context, write a clear blocker summary to PR_BODY.md.
 """
 
-    file_path = REPO_ROOT / f".tmp-background-agent-{crash_id}.md"
+    file_path = Path(tempfile.gettempdir()) / f"background-agent-{crash_id}.md"
     file_path.write_text(prompt, encoding="utf-8")
     return file_path
 

--- a/script/select-sentry-crash-candidates
+++ b/script/select-sentry-crash-candidates
@@ -50,7 +50,7 @@ def api_get(path: str, token: str):
     request.add_header("Accept", "application/json")
 
     try:
-        with urllib.request.urlopen(request) as response:
+        with urllib.request.urlopen(request, timeout=30) as response:
             return json.loads(response.read().decode("utf-8"))
     except urllib.error.HTTPError as error:
         body = error.read().decode("utf-8", errors="replace")


### PR DESCRIPTION
## Summary

Security hardening for the background-agent crash MVP pipeline, based on a three-agent security review (code audit, STRIDE threat model, architecture review).

### Commit 1: Harden workflow security

- **Expression injection**: Move all `${{ inputs.* }}`, `${{ vars.* }}`, and `${{ steps.*.outputs.* }}` from `run:` blocks to step-level `env:` blocks — prevents shell metacharacter injection via `workflow_dispatch` inputs
- **Secret scoping**: `SENTRY_AUTH_TOKEN` removed from workflow-level `env:`, scoped only to the "Select crash candidates" step
- **Scoped staging**: Replace `git add -A` with explicit file patterns (`*.rs`, `*.toml`, `Cargo.lock`, `ANALYSIS.md`, `LINKED_ISSUES.md`, `PR_BODY.md`) plus a post-stage guard that aborts if `.github/`, `.factory/`, or `script/` are modified
- **Crash ID validation**: Regex check (`^[A-Za-z0-9]+-[A-Za-z0-9]+$`) in both the workflow and local script to prevent injection via branch names or prompts
- **Deduplication**: Skip crash IDs that already have an open draft PR
- **Top cap**: Limit `--top` to 10 to prevent runaway pipeline runs
- **Concurrency**: Fixed group name (`background-agent-mvp`) so scheduled and manual runs can't overlap
- **HTTP deadline**: Added 30s limit to Sentry API calls in `select-sentry-crash-candidates`
- **Temp file hygiene**: Prompt file in local script moved from repo root to system temp directory

### Commit 2: Revert shallow clone, add history limit to prompt

- Restore `fetch-depth: 0` so full history is available to the agent
- Instead of restricting at the git level, instruct the agent to limit history traversal to the last 2 weeks

### Commit 3: Pre-fetch crash data so Droid never needs Sentry token

- Add `--select-only` and `--prefetch-dir` flags to `run-background-agent-mvp-local`
- The select step (which holds `SENTRY_AUTH_TOKEN`) now resolves IDs and fetches crash reports in one call via `script/sentry-fetch`, saving them to `/tmp/crash-data/crash-{ID}.md`
- The pipeline step reads pre-fetched files — the agent prompt explicitly blocks `sentry-fetch` calls
- `write_prompt()` gains a `crash_data_file` param to support both CI (pre-fetched) and local (direct fetch) modes
- Fix all heredocs that produced content at column 1, which broke `actionlint` YAML validation
- Cleanup step (`if: always`) removes `/tmp/crash-data` after the run

## Test plan

- [x] `python3 -m py_compile script/select-sentry-crash-candidates` passes
- [x] `python3 -m py_compile script/run-background-agent-mvp-local` passes
- [x] Both scripts' `--help` output shows new flags correctly
- [x] `actionlint` passes on the workflow file (original had pre-existing failures)
- [x] Zero `${{ inputs/vars/steps }}` expressions inside any `run:` block
- [x] `SENTRY_AUTH_TOKEN` appears on exactly 1 line (select step `env:`)
- [x] No direct `sentry-fetch` calls in the pipeline agent prompt
- [x] Crash ID regex accepts `ZED-4VS`, `ZED-123`; rejects `; echo pwned`, `../etc/passwd`
- [x] `--select-only` with `--crash-ids` outputs correct comma-separated IDs
- [x] `--select-only` filters invalid IDs with warning on stderr
- [x] `--select-only` exits 1 when all IDs are invalid
- [x] `--prefetch-dir` attempts fetch and warns gracefully without a Sentry token