### PR TITLE
fs: Avoid panic when metadata tasks are cancelled (ZED-4GH)

### DIFF
--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -882,14 +882,20 @@ impl Fs for RealFs {
         let symlink_metadata = match self
             .executor
             .spawn(async move { std::fs::symlink_metadata(&path_buf) })
+            .fallible()
             .await
         {
-            Ok(metadata) => metadata,
-            Err(err) => {
+            Some(Ok(metadata)) => metadata,
+            Some(Err(err)) => {
                 return match err.kind() {
                     io::ErrorKind::NotFound | io::ErrorKind::NotADirectory => Ok(None),
                     _ => Err(anyhow::Error::new(err)),
                 };
+            }
+            None => {
+                return Err(anyhow!(
+                    "metadata task was cancelled before completion for path {path:?}"
+                ));
             }
         };
 
@@ -900,10 +906,11 @@ impl Fs for RealFs {
             match self
                 .executor
                 .spawn(async move { std::fs::metadata(path_buf) })
+                .fallible()
                 .await
             {
-                Ok(target_metadata) => target_metadata,
-                Err(err) => {
+                Some(Ok(target_metadata)) => target_metadata,
+                Some(Err(err)) => {
                     if err.kind() != io::ErrorKind::NotFound {
                         // TODO: Also FilesystemLoop when that's stable
                         log::warn!(
@@ -914,6 +921,11 @@ impl Fs for RealFs {
                     // as edge cases, a symlink into a directory we can't read, which is hard
                     // to distinguish from just being broken.)
                     symlink_metadata
+                }
+                None => {
+                    return Err(anyhow!(
+                        "metadata task was cancelled before completion for path {path:?}"
+                    ));
                 }
             }
         } else {
@@ -936,7 +948,11 @@ impl Fs for RealFs {
         let is_executable = self
             .executor
             .spawn(async move { path_buf.is_executable() })
-            .await;
+            .fallible()
+            .await
+            .ok_or_else(|| {
+                anyhow!("metadata task was cancelled before completion for path {path:?}")
+            })?;
 
         Ok(Some(Metadata {
             inode,

--- a/crates/fs/tests/integration/fs.rs
+++ b/crates/fs/tests/integration/fs.rs
@@ -450,6 +450,16 @@ async fn test_realfs_atomic_write_non_existing_file(executor: BackgroundExecutor
 }
 
 #[gpui::test]
+async fn test_realfs_metadata_after_executor_close(executor: BackgroundExecutor) {
+    let fs = RealFs::new(None, executor.clone());
+    let temp_dir = TempDir::new().unwrap();
+    executor.close();
+
+    let result = fs.metadata(temp_dir.path()).await;
+    assert!(result.is_err());
+}
+
+#[gpui::test]
 #[cfg(target_os = "windows")]
 async fn test_realfs_canonicalize(executor: BackgroundExecutor) {
     use util::paths::SanitizedPath;


### PR DESCRIPTION
Fixes a crash where RealFs::metadata could panic with 'Task polled after completion' when the executor is closed and a spawned runnable is cancelled.

This switches metadata task awaits to fallible awaits and returns structured errors on cancellation, plus adds a regression test for metadata calls after executor shutdown.

Release Notes:

- Fixed a panic in filesystem metadata scanning when background executor tasks are cancelled during shutdown.