### PR TITLE
workspace: Stop middle-click event propagation on tab close

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -2856,6 +2856,7 @@ impl Pane {
 
                     pane.close_item_by_id(item_id, SaveIntent::Close, window, cx)
                         .detach_and_log_err(cx);
+                    cx.stop_propagation();
                 }),
             )
             .on_drag(


### PR DESCRIPTION
## Summary

- On Linux, middle-clicking a tab to close it also triggered a paste of the primary selection into the editor behind it, because the event bubbled to the editor's `mouse_up()` handler
- Added `cx.stop_propagation()` in the `on_aux_click` handler in `pane.rs` after closing the tab, matching the pattern already used by the editor's own middle-click handler in `element.rs:1037`

Closes #47381

## Test plan

- [x] `cargo test -p workspace` passes (124 tests, 0 failures)
- [x] Select text in editor (filling primary selection), middle-click a tab to close it → tab closes, no paste in the editor behind
- [x] Middle-click inside the editor area → still pastes from primary selection as expected

Release Notes:

- Fixed middle-click on a tab to close it also pasting into the editor on Linux.