### PR TITLE
ui_prompt: Fix Escape key not dismissing single-button prompts

### DIFF
--- a/crates/ui_prompt/src/ui_prompt.rs
+++ b/crates/ui_prompt/src/ui_prompt.rs
@@ -69,6 +69,8 @@ impl ZedPromptRenderer {
     fn cancel(&mut self, _: &menu::Cancel, _window: &mut Window, cx: &mut Context<Self>) {
         if let Some(ix) = self.actions.iter().position(|a| a == "Cancel") {
             cx.emit(PromptResponse(ix));
+        } else {
+            cx.emit(PromptResponse(self.actions.len().saturating_sub(1)));
         }
     }
 


### PR DESCRIPTION
## Problem

On Linux and FreeBSD, pressing Escape on a single-button prompt (e.g., "No changes to commit" with only an "Ok" button) does nothing. The dialog can only be dismissed by clicking the button with the mouse.

This happens because `ZedPromptRenderer::cancel()` only emits a `PromptResponse` when it finds a button labeled exactly "Cancel". When no such button exists, the Escape key is silently ignored.

Closes #48246

## Solution

When no "Cancel" button is found, fall back to emitting `PromptResponse` with the last button's index:

- **Single-button prompts** (`&["Ok"]`): last = 0 = the only option, dismisses the dialog
- **Multi-button prompts with "Cancel"**: existing `if let Some` branch handles it (no change)
- **Multi-button prompts without "Cancel"** (`&["Save", "Don't Save"]`): last = least destructive option by convention (matches macOS `NSAlert` button ordering)

## Test plan

- [x] Open a git repo with no staged changes, click "Commit" in the Git Panel → "No changes to commit" prompt appears → press Escape → prompt dismisses
- [x] Open a prompt with a "Cancel" button (e.g., delete confirmation in Project Panel) → press Escape → still triggers "Cancel" as before
- [x] `cargo test -p ui_prompt` passes
- [x] `cargo test -p git_ui` passes (46 tests)