### PR TITLE
collab: Remove `GET /rpc_server_snapshot` endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1941,27 +1941,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "axum-extra"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a320103719de37b7b4da4c8eb629d4573f6bcfd3dfe80d3208806895ccf81d"
-dependencies = [
- "axum",
- "bytes 1.11.1",
- "futures-util",
- "http 0.2.12",
- "mime",
- "pin-project-lite",
- "serde",
- "serde_json",
- "tokio",
- "tower 0.4.13",
- "tower-http 0.3.5",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3223,7 +3202,6 @@ dependencies = [
  "aws-sdk-kinesis",
  "aws-sdk-s3",
  "axum",
- "axum-extra",
  "base64 0.22.1",
  "buffer_diff",
  "call",
@@ -17518,24 +17496,6 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper 1.0.2",
  "tokio",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
-dependencies = [
- "bitflags 1.3.2",
- "bytes 1.11.1",
- "futures-core",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "http-range-header",
- "pin-project-lite",
  "tower-layer",
  "tower-service",
 ]

--- a/crates/collab/Cargo.toml
+++ b/crates/collab/Cargo.toml
@@ -33,7 +33,6 @@ aws-config = { version = "1.1.5" }
 aws-sdk-kinesis = "1.51.0"
 aws-sdk-s3 = { version = "1.15.0" }
 axum = { version = "0.6", features = ["json", "headers", "ws"] }
-axum-extra = { version = "0.4", features = ["erased-json"] }
 base64.workspace = true
 chrono.workspace = true
 clock.workspace = true

--- a/crates/collab/src/api.rs
+++ b/crates/collab/src/api.rs
@@ -1,19 +1,9 @@
 pub mod events;
 pub mod extensions;
 
-use crate::{AppState, Error, Result, rpc};
-use axum::{
-    Extension, Router,
-    body::Body,
-    headers::Header,
-    http::{self, HeaderName, Request, StatusCode},
-    middleware::{self, Next},
-    response::IntoResponse,
-    routing::get,
-};
-use axum_extra::response::ErasedJson;
-use std::sync::{Arc, OnceLock};
-use tower::ServiceBuilder;
+use crate::Result;
+use axum::{headers::Header, http::HeaderName};
+use std::sync::OnceLock;
 
 pub use extensions::fetch_extensions_from_blob_store_periodically;
 
@@ -81,51 +71,4 @@ impl std::fmt::Display for SystemIdHeader {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
     }
-}
-
-pub fn routes(rpc_server: Arc<rpc::Server>) -> Router<(), Body> {
-    Router::new()
-        .route("/rpc_server_snapshot", get(get_rpc_server_snapshot))
-        .layer(
-            ServiceBuilder::new()
-                .layer(Extension(rpc_server))
-                .layer(middleware::from_fn(validate_api_token)),
-        )
-}
-
-pub async fn validate_api_token<B>(req: Request<B>, next: Next<B>) -> impl IntoResponse {
-    let token = req
-        .headers()
-        .get(http::header::AUTHORIZATION)
-        .and_then(|header| header.to_str().ok())
-        .ok_or_else(|| {
-            Error::http(
-                StatusCode::BAD_REQUEST,
-                "missing authorization header".to_string(),
-            )
-        })?
-        .strip_prefix("token ")
-        .ok_or_else(|| {
-            Error::http(
-                StatusCode::BAD_REQUEST,
-                "invalid authorization header".to_string(),
-            )
-        })?;
-
-    let state = req.extensions().get::<Arc<AppState>>().unwrap();
-
-    if token != state.config.api_token {
-        Err(Error::http(
-            StatusCode::UNAUTHORIZED,
-            "invalid authorization token".to_string(),
-        ))?
-    }
-
-    Ok::<_, Error>(next.run(req).await)
-}
-
-async fn get_rpc_server_snapshot(
-    Extension(rpc_server): Extension<Arc<rpc::Server>>,
-) -> Result<ErasedJson> {
-    Ok(ErasedJson::pretty(rpc_server.snapshot().await))
 }

--- a/crates/collab/src/main.rs
+++ b/crates/collab/src/main.rs
@@ -94,9 +94,7 @@ async fn main() -> Result<()> {
                     let rpc_server = collab::rpc::Server::new(epoch, state.clone());
                     rpc_server.start().await?;
 
-                    app = app
-                        .merge(collab::api::routes(rpc_server.clone()))
-                        .merge(collab::rpc::routes(rpc_server.clone()));
+                    app = app.merge(collab::rpc::routes(rpc_server.clone()));
 
                     on_shutdown = Some(Box::new(move || rpc_server.teardown()));
                 }

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -50,7 +50,6 @@ use rpc::{
     },
 };
 use semver::Version;
-use serde::{Serialize, Serializer};
 use std::{
     any::TypeId,
     future::Future,
@@ -276,22 +275,6 @@ pub struct Server {
 struct ConnectionPoolGuard<'a> {
     guard: parking_lot::MutexGuard<'a, ConnectionPool>,
     _not_send: PhantomData<Rc<()>>,
-}
-
-#[derive(Serialize)]
-pub struct ServerSnapshot<'a> {
-    peer: &'a Peer,
-    #[serde(serialize_with = "serialize_deref")]
-    connection_pool: ConnectionPoolGuard<'a>,
-}
-
-pub fn serialize_deref<S, T, U>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-    T: Deref<Target = U>,
-    U: Serialize,
-{
-    Serialize::serialize(value.deref(), serializer)
 }
 
 impl Server {
@@ -988,16 +971,6 @@ impl Server {
         }
 
         Ok(())
-    }
-
-    pub async fn snapshot(self: &Arc<Self>) -> ServerSnapshot<'_> {
-        ServerSnapshot {
-            connection_pool: ConnectionPoolGuard {
-                guard: self.connection_pool.lock(),
-                _not_send: PhantomData,
-            },
-            peer: &self.peer,
-        }
     }
 }
 


### PR DESCRIPTION
This PR removes the `GET /rpc_server_snapshot` endpoint from Collab, as it is not being used (and also didn't seem to be functional).

Release Notes:

- N/A
