### PR TITLE
ep: Rework `ep repair` to use original teacher prompt

### DIFF
--- a/crates/edit_prediction_cli/src/prompts/repair.md
+++ b/crates/edit_prediction_cli/src/prompts/repair.md
@@ -1,103 +1,42 @@
-# Instructions
+# Repair Request
 
-You are an edit prediction assistant in a code editor. Your task is to generate an improved prediction based on feedback from a quality assessment.
+Your previous prediction has quality issues that need to be addressed. Please generate an improved prediction.
 
-A previous model generated a prediction that was judged to have issues. Your job is to generate a better prediction that addresses the feedback.
+## Quality Feedback
 
-## Focus on
+{quality_feedback}
 
-- Completing any partially-applied changes made
-- Ensuring consistency with the programming style and patterns already established
-- Making edits that maintain or improve code quality
-- NOT reverting or undoing changes the user intentionally made
-
-## Rules
-
-- **NEVER undo or revert the user's recent edits.** Examine the diff in the edit history carefully:
-  - If a line was removed (starts with `-`), do NOT restore that content—even if the code now appears incomplete or broken without it
-  - If a line was added (starts with `+`), do NOT delete or significantly modify it
-  - If code appears broken or incomplete after the user's edit, output `NO_EDITS` rather than "fixing" it by reverting
-  - Only add NEW content that extends the user's work forward; never restore what they removed
-  - **Key test**: if your prediction would make the code more similar to what it was BEFORE the user's edit, output `NO_EDITS` instead
-  - **Never assume a deletion was accidental.** Even if removing content breaks the code, breaks a pattern, or leaves text looking "incomplete", respect it. The user may be mid-rewrite. Do NOT "complete" partial text by restoring what was deleted.
-- Do not just mechanically apply patterns - reason about what changes make sense given the context and the programmer's apparent goals.
-- Do not just fix syntax errors - look for the broader refactoring pattern and apply it systematically throughout the code.
-- Keep existing formatting unless it's absolutely necessary
-- When edit history and surrounding code suggest different edits, prioritize the most recent edits in the history as they best reflect current intent.
-- When uncertain, predict only the minimal, high-confidence portion of the edit. Prefer a small, correct prediction over a large, speculative one.
-- Don't write a lot of code if you're not sure what to do
-- Do not delete or remove text that was just added in the edit history. If a recent edit introduces incomplete or incorrect code, finish or fix it in place, or simply output `NO_EDITS` rather than removing it. Only remove a recent edit if the history explicitly shows the user undoing it themselves.
-- Treat partial text at or near the cursor as the beginning of something the user is actively typing. Complete the code the user appears to be creating based on context.
-
-# Input Format
-
-You will be provided with:
-1. The user's *edit history*, in chronological order. Use this to infer the user's trajectory and predict the next most logical edit.
-2. A set of *related excerpts* from the user's codebase. Some of these may be needed for correctly predicting the next edit.
-   - `…` may appear within a related file to indicate that some code has been skipped.
-3. An excerpt from the user's *current file*.
-    - Within the user's current file, there is an *editable region* delimited by the `<|editable_region_start|>` and `<|editable_region_end|>` tags. You can only predict edits in this region.
-    - The `<|user_cursor|>` tag marks the user's current cursor position, as it stands after the last edit in the history.
-4. The *previous prediction* that was generated and needs improvement.
-5. *Quality feedback* explaining why the previous prediction was problematic.
-
-# Output Format
-
-- Briefly explain what was wrong with the previous prediction and how you'll improve it.
-- Output the entire editable region, applying the edits that you predict the user will make next.
-- If you're unsure about some portion of the next edit, you may still predict the surrounding code (such as a function definition, `for` loop, etc) and place the `<|user_cursor|>` within it for the user to fill in.
-- Wrap the edited code in a codeblock with exactly five backticks.
-- There are two special outputs for when you don't want to generate a new prediction. **These have different meanings — use the correct one:**
-
-  1. **`NO_EDITS`** — The code is already complete and correct as-is. No edits should be made at all. The editable region should remain unchanged. Use this when:
-     - The code needs no modifications whatsoever
-     - Any prediction would revert or undo the user's intentional changes
-     - You are unsure what edit to make and prefer to do nothing
-
-     `````
-     NO_EDITS
-     `````
-
-  2. **`KEEP_PREVIOUS`** — The previous prediction was actually correct and should be used as-is. Use this when:
-     - After reviewing the quality feedback, you determine the previous prediction is good
-     - You cannot find a meaningful improvement over the previous prediction
-     - The quality feedback was too cautious and the previous prediction correctly addresses the user's intent
-
-     `````
-     KEEP_PREVIOUS
-     `````
-
-  **Important:** `NO_EDITS` and `KEEP_PREVIOUS` are NOT interchangeable.
-  - `NO_EDITS` means "make zero changes to the code" (empty prediction).
-  - `KEEP_PREVIOUS` means "the previous prediction is correct, use it" (reuse the previous prediction).
-  - If you believe the previous prediction was correct, you MUST use `KEEP_PREVIOUS`, not `NO_EDITS`. Using `NO_EDITS` would discard the previous prediction entirely.
-
-# 1. User Edits History
-
-`````
-{edit_history}
-`````
-
-# 2. Related excerpts
-
-{context}
-
-# 3. Current File
-
-{cursor_excerpt}
-
-# 4. Previous Prediction (needs improvement)
-
-The previous model generated the following edit (in word-diff format):
+## Your Previous Prediction (word-diff format)
 
 `````
 {actual_patch_word_diff}
 `````
 
-# 5. Quality Feedback
+## Instructions
 
-{quality_feedback}
+Generate an improved prediction following the same rules and output format from the original instructions. The key rules remain:
 
-# Your Improved Prediction
+- **NEVER undo or revert the user's recent edits** — if a line was removed in the edit history, do NOT restore it
+- If your prediction would make the code more similar to what it was BEFORE the user's edit, output `NO_EDITS` instead
+- When uncertain, predict only the minimal, high-confidence portion of the edit
 
-Based on the feedback above, generate an improved prediction. Address the issues identified in the quality feedback. If the previous prediction was actually correct, output `KEEP_PREVIOUS`. If no edits should be made at all, output `NO_EDITS`.
+## Output Format
+
+Follow the same output format as before, with one addition:
+
+- If the code is complete as-is and no edits should be made, output `NO_EDITS`
+- **NEW: If your previous prediction was actually correct** (the quality feedback was overly cautious), output `KEEP_PREVIOUS`:
+
+  `````
+  KEEP_PREVIOUS
+  `````
+
+  Use `KEEP_PREVIOUS` when you determine the original prediction correctly addresses the user's intent despite the feedback.
+
+**Important:** `NO_EDITS` and `KEEP_PREVIOUS` are NOT interchangeable:
+- `NO_EDITS` = make zero changes to the code (discard the previous prediction)
+- `KEEP_PREVIOUS` = the previous prediction is correct, use it as-is
+
+## Your Improved Prediction
+
+Briefly explain what was wrong with your previous prediction (or why it was actually correct), then provide the improved output.


### PR DESCRIPTION
It now creates multi-turn conversation, where first two messages are the original teacher prompt and output.

This way, we'll have changes in teacher prompt automatically applied to repair without having to explicitly sync them.


Release Notes:

- N/A
