### PR TITLE
Fix transient "Failed to load the database file" on startup

### DIFF
--- a/crates/db/src/db.rs
+++ b/crates/db/src/db.rs
@@ -27,8 +27,8 @@ const CONNECTION_INITIALIZE_QUERY: &str = sql!(
 );
 
 const DB_INITIALIZE_QUERY: &str = sql!(
+    PRAGMA busy_timeout=1000;
     PRAGMA journal_mode=WAL;
-    PRAGMA busy_timeout=500;
     PRAGMA case_sensitive_like=TRUE;
     PRAGMA synchronous=NORMAL;
 );
@@ -292,6 +292,46 @@ mod tests {
         }
 
         for guard in guards.into_iter() {
+            assert!(guard.join().is_ok());
+        }
+    }
+
+    #[gpui::test(iterations = 30)]
+    async fn test_concurrent_db_initialization(cx: &mut gpui::TestAppContext) {
+        cx.executor().allow_parking();
+
+        enum ConcurrentDB {}
+
+        impl Domain for ConcurrentDB {
+            const NAME: &str = "concurrent_init_test";
+            const MIGRATIONS: &[&str] = &[sql!(
+                CREATE TABLE IF NOT EXISTS concurrent_test(value TEXT);
+            )];
+        }
+
+        let tempdir = tempfile::Builder::new()
+            .prefix("ConcurrentInitTest")
+            .tempdir()
+            .unwrap();
+
+        let mut guards = vec![];
+        for _ in 0..10 {
+            let tmp_path = tempdir.path().to_path_buf();
+            let guard = thread::spawn(move || {
+                let connection = smol::block_on(open_db::<ConcurrentDB>(
+                    tmp_path.as_path(),
+                    release_channel::ReleaseChannel::Dev.dev_name(),
+                ));
+                assert!(
+                    connection.persistent(),
+                    "Expected persistent file-backed connection, got in-memory fallback"
+                );
+            });
+
+            guards.push(guard);
+        }
+
+        for guard in guards {
             assert!(guard.join().is_ok());
         }
     }

--- a/crates/sqlez/src/connection.rs
+++ b/crates/sqlez/src/connection.rs
@@ -9,6 +9,13 @@ use std::{
 use anyhow::Result;
 use libsqlite3_sys::*;
 
+/// Returns true if the given SQLite extended error code represents a transient
+/// lock/busy condition that may resolve on retry.
+pub fn is_transient_lock_error(extended_code: i32) -> bool {
+    let primary_code = extended_code & 0xFF;
+    primary_code == SQLITE_BUSY || primary_code == SQLITE_LOCKED
+}
+
 pub struct Connection {
     pub(crate) sqlite3: *mut sqlite3,
     persistent: bool,
@@ -207,6 +214,10 @@ impl Connection {
 
             anyhow::bail!("Sqlite call failed with code {code} and message: {message:?}")
         }
+    }
+
+    pub fn last_extended_error_code(&self) -> i32 {
+        unsafe { sqlite3_extended_errcode(self.sqlite3) }
     }
 
     pub(crate) fn with_write<T>(&self, callback: impl FnOnce(&Connection) -> T) -> T {

--- a/crates/sqlez/src/thread_safe_connection.rs
+++ b/crates/sqlez/src/thread_safe_connection.rs
@@ -7,12 +7,18 @@ use std::{
     ops::Deref,
     sync::{Arc, LazyLock},
     thread,
+    time::Duration,
 };
 use thread_local::ThreadLocal;
 
-use crate::{connection::Connection, domain::Migrator, util::UnboundedSyncSender};
+use crate::{
+    connection::Connection, connection::is_transient_lock_error, domain::Migrator,
+    util::UnboundedSyncSender,
+};
 
 const MIGRATION_RETRIES: usize = 10;
+const INIT_PRAGMA_RETRIES: usize = 10;
+const INIT_PRAGMA_RETRY_DELAY: Duration = Duration::from_millis(100);
 
 type QueuedWrite = Box<dyn 'static + Send + FnOnce()>;
 type WriteQueue = Box<dyn 'static + Send + Sync + Fn(QueuedWrite)>;
@@ -82,12 +88,54 @@ impl<M: Migrator> ThreadSafeConnectionBuilder<M> {
         self.connection
             .write(move |connection| {
                 if let Some(db_initialize_query) = db_initialize_query {
-                    connection.exec(db_initialize_query).with_context(|| {
-                        format!(
-                            "Db initialize query failed to execute: {}",
-                            db_initialize_query
-                        )
-                    })?()?;
+                    let mut last_err = None;
+
+                    for attempt in 0..INIT_PRAGMA_RETRIES {
+                        match connection
+                            .exec(db_initialize_query)
+                            .and_then(|mut exec| exec())
+                        {
+                            Ok(()) => {
+                                if attempt > 0 {
+                                    log::info!(
+                                        "Database initialization PRAGMAs succeeded on attempt {}",
+                                        attempt + 1
+                                    );
+                                }
+                                last_err = None;
+                                break;
+                            }
+                            Err(err) => {
+                                let extended_code = connection.last_extended_error_code();
+                                if !is_transient_lock_error(extended_code) {
+                                    return Err(err).with_context(|| {
+                                        format!(
+                                            "Db initialize query failed with non-transient error (code {}): {}",
+                                            extended_code, db_initialize_query
+                                        )
+                                    });
+                                }
+
+                                log::warn!(
+                                    "Database initialization PRAGMA attempt {} failed with transient lock error (code {}), retrying in {}ms",
+                                    attempt + 1,
+                                    extended_code,
+                                    INIT_PRAGMA_RETRY_DELAY.as_millis()
+                                );
+                                last_err = Some(err);
+                                thread::sleep(INIT_PRAGMA_RETRY_DELAY);
+                            }
+                        }
+                    }
+
+                    if let Some(err) = last_err {
+                        return Err(err).with_context(|| {
+                            format!(
+                                "Db initialize query failed after {} retries: {}",
+                                INIT_PRAGMA_RETRIES, db_initialize_query
+                            )
+                        });
+                    }
                 }
 
                 // Retry failed migrations in case they were run in parallel from different
@@ -301,6 +349,8 @@ mod test {
                 let builder =
                     ThreadSafeConnection::builder::<TestDomain>("annoying-test.db", false)
                         .with_db_initialization_query("PRAGMA journal_mode=WAL")
+                        // Intentionally low busy_timeout to stress-test concurrent initialization.
+                        // Production code uses a much higher value (see DB_INITIALIZE_QUERY in db crate).
                         .with_connection_initialize_query(indoc! {"
                                 PRAGMA synchronous=NORMAL;
                                 PRAGMA busy_timeout=1;

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -7145,12 +7145,16 @@ fn notify_if_database_failed(window: WindowHandle<MultiWorkspace>, cx: &mut Asyn
                         cx,
                         |cx| {
                             cx.new(|cx| {
-                                MessageNotification::new("Failed to load the database file.", cx)
-                                    .primary_message("File an Issue")
-                                    .primary_icon(IconName::Plus)
-                                    .primary_on_click(|window, cx| {
-                                        window.dispatch_action(Box::new(FileBugReport), cx)
-                                    })
+                                MessageNotification::new(
+                                    "The database file could not be opened. Zed is running with temporary storage — recent projects, window layout, and other persisted data are unavailable. This is usually caused by a temporary lock and restarting Zed should fix it.",
+                                    cx,
+                                )
+                                .with_title("Database Unavailable")
+                                .secondary_message("File an Issue")
+                                .secondary_icon(IconName::Plus)
+                                .secondary_on_click(|window, cx| {
+                                    window.dispatch_action(Box::new(FileBugReport), cx)
+                                })
                             })
                         },
                     );


### PR DESCRIPTION
## Summary

Fixes #49241

- Adds retry logic for database initialization PRAGMAs (10 retries, 100ms delay) to handle transient `SQLITE_BUSY` / `SQLITE_LOCKED` errors during startup
- Non-transient errors (corruption, permissions) fail immediately without retry
- Moves `PRAGMA busy_timeout` first in the initialization sequence and increases it from 500ms to 1000ms so the timeout is active before WAL mode acquisition
- Improves the database failure notification with a descriptive message and restart suggestion
- Adds `is_transient_lock_error()` helper and `last_extended_error_code()` to the sqlez connection layer

## Test plan

- [x] `./script/clippy` passes
- [x] `cargo test -p sqlez` — 17/17 tests pass (including `many_initialize_and_migrate_queries_at_once`)
- [x] `cargo test -p db` — 6/6 tests pass (including new `test_concurrent_db_initialization` with 30 iterations × 10 threads)
- [x] Manual: locked a fresh DB with `BEGIN EXCLUSIVE`, launched Zed — observed 10 retry attempts in logs, then fallback to in-memory with improved "Database Unavailable" notification
- [x] Manual: lock released mid-retry — initialization succeeded on attempt 9 with `INFO Database initialization PRAGMAs succeeded on attempt 9`
- [x] Manual: two Zed instances opened simultaneously — no contention errors