### PR TITLE
acp: Claude Code -> Claude Agent (#49345)

### DIFF
--- a/crates/agent_servers/src/claude.rs
+++ b/crates/agent_servers/src/claude.rs
@@ -9,7 +9,7 @@ use std::{any::Any, path::PathBuf};
 
 use anyhow::{Context as _, Result};
 use gpui::{App, AppContext as _, SharedString, Task};
-use project::agent_server_store::{AllAgentServersSettings, CLAUDE_CODE_NAME};
+use project::agent_server_store::{AllAgentServersSettings, CLAUDE_AGENT_NAME};
 
 use crate::{AgentServer, AgentServerDelegate, load_proxy_env};
 use acp_thread::AgentConnection;
@@ -24,7 +24,7 @@ pub struct AgentServerLoginCommand {
 
 impl AgentServer for ClaudeCode {
     fn name(&self) -> SharedString {
-        "Claude Code".into()
+        "Claude Agent".into()
     }
 
     fn logo(&self) -> ui::IconName {
@@ -232,8 +232,8 @@ impl AgentServer for ClaudeCode {
             let (command, root_dir, login) = store
                 .update(cx, |store, cx| {
                     let agent = store
-                        .get_external_agent(&CLAUDE_CODE_NAME.into())
-                        .context("Claude Code is not registered")?;
+                        .get_external_agent(&CLAUDE_AGENT_NAME.into())
+                        .context("Claude Agent is not registered")?;
                     anyhow::Ok(agent.get_command(
                         root_dir.as_deref(),
                         extra_env,

--- a/crates/agent_ui/src/acp/message_editor.rs
+++ b/crates/agent_ui/src/acp/message_editor.rs
@@ -1688,7 +1688,7 @@ mod tests {
                     None,
                     prompt_capabilities.clone(),
                     available_commands.clone(),
-                    "Claude Code".into(),
+                    "Claude Agent".into(),
                     "Test",
                     EditorMode::AutoHeight {
                         min_lines: 1,
@@ -1713,7 +1713,7 @@ mod tests {
         // Should fail because available_commands is empty (no commands supported)
         assert!(contents_result.is_err());
         let error_message = contents_result.unwrap_err().to_string();
-        assert!(error_message.contains("not supported by Claude Code"));
+        assert!(error_message.contains("not supported by Claude Agent"));
         assert!(error_message.contains("Available commands: none"));
 
         // Now simulate Claude providing its list of available commands (which doesn't include file)
@@ -1730,7 +1730,7 @@ mod tests {
 
         assert!(contents_result.is_err());
         let error_message = contents_result.unwrap_err().to_string();
-        assert!(error_message.contains("not supported by Claude Code"));
+        assert!(error_message.contains("not supported by Claude Agent"));
         assert!(error_message.contains("/file"));
         assert!(error_message.contains("Available commands: /help"));
 

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -2386,7 +2386,7 @@ impl AcpServerView {
 
     fn current_model_name(&self, cx: &App) -> SharedString {
         // For native agent (Zed Agent), use the specific model name (e.g., "Claude 3.5 Sonnet")
-        // For ACP agents, use the agent name (e.g., "Claude Code", "Gemini CLI")
+        // For ACP agents, use the agent name (e.g., "Claude Agent", "Gemini CLI")
         // This provides better clarity about what refused the request
         if self.as_native_connection(cx).is_some() {
             self.active_thread()
@@ -2395,7 +2395,7 @@ impl AcpServerView {
                 .map(|model| model.name.clone())
                 .unwrap_or_else(|| SharedString::from("The model"))
         } else {
-            // ACP agent - use the agent name (e.g., "Claude Code", "Gemini CLI")
+            // ACP agent - use the agent name (e.g., "Claude Agent", "Gemini CLI")
             self.agent.name()
         }
     }

--- a/crates/agent_ui/src/acp/thread_view/active_thread.rs
+++ b/crates/agent_ui/src/acp/thread_view/active_thread.rs
@@ -6749,7 +6749,7 @@ impl AcpThreadView {
 
     fn current_model_name(&self, cx: &App) -> SharedString {
         // For native agent (Zed Agent), use the specific model name (e.g., "Claude 3.5 Sonnet")
-        // For ACP agents, use the agent name (e.g., "Claude Code", "Gemini CLI")
+        // For ACP agents, use the agent name (e.g., "Claude Agent", "Gemini CLI")
         // This provides better clarity about what refused the request
         if self.as_native_connection(cx).is_some() {
             self.model_selector
@@ -6758,7 +6758,7 @@ impl AcpThreadView {
                 .map(|model| model.name.clone())
                 .unwrap_or_else(|| SharedString::from("The model"))
         } else {
-            // ACP agent - use the agent name (e.g., "Claude Code", "Gemini CLI")
+            // ACP agent - use the agent name (e.g., "Claude Agent", "Gemini CLI")
             self.agent_name.clone()
         }
     }

--- a/crates/agent_ui/src/agent_configuration.rs
+++ b/crates/agent_ui/src/agent_configuration.rs
@@ -29,7 +29,7 @@ use language_models::AllLanguageModelSettings;
 use notifications::status_toast::{StatusToast, ToastIcon};
 use project::{
     agent_server_store::{
-        AgentServerStore, CLAUDE_CODE_NAME, CODEX_NAME, ExternalAgentServerName,
+        AgentServerStore, CLAUDE_AGENT_NAME, CODEX_NAME, ExternalAgentServerName,
         ExternalAgentSource, GEMINI_NAME,
     },
     context_server_store::{ContextServerConfiguration, ContextServerStatus, ContextServerStore},
@@ -942,7 +942,7 @@ impl AgentConfiguration {
         let user_defined_agents = agent_server_store
             .external_agents()
             .filter(|name| {
-                name.0 != GEMINI_NAME && name.0 != CLAUDE_CODE_NAME && name.0 != CODEX_NAME
+                name.0 != GEMINI_NAME && name.0 != CLAUDE_AGENT_NAME && name.0 != CODEX_NAME
             })
             .cloned()
             .collect::<Vec<_>>();
@@ -1056,8 +1056,8 @@ impl AgentConfiguration {
                             .gap_2()
                             .child(self.render_agent_server(
                                 AgentIcon::Name(IconName::AiClaude),
-                                "Claude Code",
-                                "Claude Code",
+                                "Claude Agent",
+                                "Claude Agent",
                                 ExternalAgentSource::Builtin,
                                 cx,
                             ))

--- a/crates/agent_ui/src/agent_registry_ui.rs
+++ b/crates/agent_ui/src/agent_registry_ui.rs
@@ -55,7 +55,10 @@ fn keywords_by_agent_feature() -> &'static BTreeMap<BuiltInAgent, Vec<&'static s
         OnceLock::new();
     KEYWORDS_BY_FEATURE.get_or_init(|| {
         BTreeMap::from_iter([
-            (BuiltInAgent::Claude, vec!["claude", "claude code"]),
+            (
+                BuiltInAgent::Claude,
+                vec!["claude", "claude code", "claude agent"],
+            ),
             (BuiltInAgent::Codex, vec!["codex", "codex cli"]),
             (BuiltInAgent::Gemini, vec!["gemini", "gemini cli"]),
         ])
@@ -325,8 +328,8 @@ impl AgentRegistryPage {
         for feature in &self.upsells {
             let banner = match feature {
                 BuiltInAgent::Claude => self.render_feature_upsell_banner(
-                    "Claude Code support is built-in to Zed!".into(),
-                    "https://zed.dev/docs/ai/external-agents#claude-code".into(),
+                    "Claude Agent support is built-in to Zed!".into(),
+                    "https://zed.dev/docs/ai/external-agents#claude-agent".into(),
                 ),
                 BuiltInAgent::Codex => self.render_feature_upsell_banner(
                     "Codex CLI support is built-in to Zed!".into(),

--- a/crates/agent_ui/src/ui.rs
+++ b/crates/agent_ui/src/ui.rs
@@ -1,6 +1,6 @@
 mod acp_onboarding_modal;
 mod agent_notification;
-mod claude_code_onboarding_modal;
+mod claude_agent_onboarding_modal;
 mod end_trial_upsell;
 mod hold_for_default;
 mod mention_crease;
@@ -9,7 +9,7 @@ mod onboarding_modal;
 
 pub use acp_onboarding_modal::*;
 pub use agent_notification::*;
-pub use claude_code_onboarding_modal::*;
+pub use claude_agent_onboarding_modal::*;
 pub use end_trial_upsell::*;
 pub use hold_for_default::*;
 pub use mention_crease::*;

--- a/crates/agent_ui/src/ui/claude_agent_onboarding_modal.rs
+++ b/crates/agent_ui/src/ui/claude_agent_onboarding_modal.rs
@@ -8,7 +8,7 @@ use workspace::{ModalView, Workspace};
 
 use crate::agent_panel::{AgentPanel, AgentType};
 
-macro_rules! claude_code_onboarding_event {
+macro_rules! claude_agent_onboarding_event {
     ($name:expr) => {
         telemetry::event!($name, source = "ACP Claude Code Onboarding");
     };
@@ -37,21 +37,21 @@ impl ClaudeCodeOnboardingModal {
 
             if let Some(panel) = workspace.panel::<AgentPanel>(cx) {
                 panel.update(cx, |panel, cx| {
-                    panel.new_agent_thread(AgentType::ClaudeCode, window, cx);
+                    panel.new_agent_thread(AgentType::ClaudeAgent, window, cx);
                 });
             }
         });
 
         cx.emit(DismissEvent);
 
-        claude_code_onboarding_event!("Open Panel Clicked");
+        claude_agent_onboarding_event!("Open Panel Clicked");
     }
 
     fn view_docs(&mut self, _: &ClickEvent, _: &mut Window, cx: &mut Context<Self>) {
         cx.open_url(&zed_urls::external_agents_docs(cx));
         cx.notify();
 
-        claude_code_onboarding_event!("Documentation Link Clicked");
+        claude_agent_onboarding_event!("Documentation Link Clicked");
     }
 
     fn cancel(&mut self, _: &menu::Cancel, _: &mut Window, cx: &mut Context<Self>) {
@@ -172,7 +172,7 @@ impl Render for ClaudeCodeOnboardingModal {
                                     .size(IconSize::Small)
                                     .color(Color::Muted),
                             )
-                            .child(Label::new("New Claude Code Thread").size(LabelSize::Small)),
+                            .child(Label::new("New Claude Agent Thread").size(LabelSize::Small)),
                     )
                     .child(illustration_element(
                         IconName::Stop,
@@ -190,11 +190,11 @@ impl Render for ClaudeCodeOnboardingModal {
                     .size(LabelSize::Small)
                     .color(Color::Muted),
             )
-            .child(Headline::new("Claude Code: Natively in Zed").size(HeadlineSize::Large));
+            .child(Headline::new("Claude Agent: Natively in Zed").size(HeadlineSize::Large));
 
-        let copy = "Powered by the Agent Client Protocol, you can now run Claude Code as\na first-class citizen in Zed's agent panel.";
+        let copy = "Powered by the Agent Client Protocol, you can now run Claude Agent as\na first-class citizen in Zed's agent panel.";
 
-        let open_panel_button = Button::new("open-panel", "Start with Claude Code")
+        let open_panel_button = Button::new("open-panel", "Start with Claude Agent")
             .icon_size(IconSize::Indicator)
             .style(ButtonStyle::Tinted(TintColor::Accent))
             .full_width()
@@ -210,7 +210,7 @@ impl Render for ClaudeCodeOnboardingModal {
         let close_button = h_flex().absolute().top_2().right_2().child(
             IconButton::new("cancel", IconName::Close).on_click(cx.listener(
                 |_, _: &ClickEvent, _window, cx| {
-                    claude_code_onboarding_event!("Canceled", trigger = "X click");
+                    claude_agent_onboarding_event!("Canceled", trigger = "X click");
                     cx.emit(DismissEvent);
                 },
             )),
@@ -227,7 +227,7 @@ impl Render for ClaudeCodeOnboardingModal {
             .overflow_hidden()
             .on_action(cx.listener(Self::cancel))
             .on_action(cx.listener(|_, _: &menu::Cancel, _window, cx| {
-                claude_code_onboarding_event!("Canceled", trigger = "Action");
+                claude_agent_onboarding_event!("Canceled", trigger = "Action");
                 cx.emit(DismissEvent);
             }))
             .on_any_mouse_down(cx.listener(|this, _: &MouseDownEvent, window, cx| {

--- a/crates/ai_onboarding/src/plan_definitions.rs
+++ b/crates/ai_onboarding/src/plan_definitions.rs
@@ -14,7 +14,7 @@ impl PlanDefinitions {
                 "Unlimited prompts with your AI API keys",
             ))
             .child(ListBulletItem::new(
-                "Unlimited use of external agents like Claude Code",
+                "Unlimited use of external agents like Claude Agent",
             ))
     }
 

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -248,7 +248,10 @@ fn keywords_by_feature() -> &'static BTreeMap<Feature, Vec<&'static str>> {
     static KEYWORDS_BY_FEATURE: OnceLock<BTreeMap<Feature, Vec<&'static str>>> = OnceLock::new();
     KEYWORDS_BY_FEATURE.get_or_init(|| {
         BTreeMap::from_iter([
-            (Feature::AgentClaude, vec!["claude", "claude code"]),
+            (
+                Feature::AgentClaude,
+                vec!["claude", "claude code", "claude agent"],
+            ),
             (Feature::AgentCodex, vec!["codex", "codex cli"]),
             (Feature::AgentGemini, vec!["gemini", "gemini cli"]),
             (
@@ -1567,8 +1570,8 @@ impl ExtensionsPage {
         for feature in &self.upsells {
             let banner = match feature {
                 Feature::AgentClaude => self.render_feature_upsell_banner(
-                    "Claude Code support is built-in to Zed!".into(),
-                    "https://zed.dev/docs/ai/external-agents#claude-code".into(),
+                    "Claude Agent support is built-in to Zed!".into(),
+                    "https://zed.dev/docs/ai/external-agents#claude-agent".into(),
                     false,
                     cx,
                 ),

--- a/crates/nc/src/nc.rs
+++ b/crates/nc/src/nc.rs
@@ -3,11 +3,6 @@ use anyhow::Result;
 #[cfg(windows)]
 pub fn main(_socket: &str) -> Result<()> {
     // It looks like we can't get an async stdio stream on Windows from smol.
-    //
-    // We decided to merge this with a panic on Windows since this is only used
-    // by the experimental Claude Code Agent Server.
-    //
-    // We're tracking this internally, and we will address it before shipping the integration.
     panic!("--nc isn't yet supported on Windows");
 }
 

--- a/crates/project/src/agent_server_store.rs
+++ b/crates/project/src/agent_server_store.rs
@@ -460,7 +460,7 @@ impl AgentServerStore {
             ),
         );
         self.external_agents.insert(
-            CLAUDE_CODE_NAME.into(),
+            CLAUDE_AGENT_NAME.into(),
             ExternalAgentEntry::new(
                 Box::new(LocalClaudeCode {
                     fs: fs.clone(),
@@ -677,12 +677,12 @@ impl AgentServerStore {
         // will have them.
         let external_agents: [(ExternalAgentServerName, ExternalAgentEntry); 3] = [
             (
-                CLAUDE_CODE_NAME.into(),
+                CLAUDE_AGENT_NAME.into(),
                 ExternalAgentEntry::new(
                     Box::new(RemoteExternalAgentServer {
                         project_id,
                         upstream_client: upstream_client.clone(),
-                        name: CLAUDE_CODE_NAME.into(),
+                        name: CLAUDE_AGENT_NAME.into(),
                         status_tx: None,
                         new_version_available_tx: None,
                     }) as Box<dyn ExternalAgentServer>,
@@ -909,7 +909,7 @@ impl AgentServerStore {
                 .map(|name| {
                     let agent_name = ExternalAgentServerName(name.clone().into());
                     let fallback_source =
-                        if name == GEMINI_NAME || name == CLAUDE_CODE_NAME || name == CODEX_NAME {
+                        if name == GEMINI_NAME || name == CLAUDE_AGENT_NAME || name == CODEX_NAME {
                             ExternalAgentSource::Builtin
                         } else {
                             ExternalAgentSource::Custom
@@ -1449,26 +1449,8 @@ impl ExternalAgentServer for LocalClaudeCode {
                 )
                 .await?;
                 command.env = Some(env);
-                let login = command
-                    .args
-                    .first()
-                    .and_then(|path| {
-                        path.strip_suffix("/@zed-industries/claude-code-acp/dist/index.js")
-                    })
-                    .map(|path_prefix| task::SpawnInTerminal {
-                        command: Some(command.path.to_string_lossy().into_owned()),
-                        args: vec![
-                            Path::new(path_prefix)
-                                .join("@anthropic-ai/claude-agent-sdk/cli.js")
-                                .to_string_lossy()
-                                .to_string(),
-                            "/login".into(),
-                        ],
-                        env: command.env.clone().unwrap_or_default(),
-                        label: "claude /login".into(),
-                        ..Default::default()
-                    });
-                (command, login)
+
+                (command, None)
             };
 
             command.env.get_or_insert_default().extend(extra_env);
@@ -2229,7 +2211,7 @@ impl ExternalAgentServer for LocalCustomAgent {
 }
 
 pub const GEMINI_NAME: &'static str = "gemini";
-pub const CLAUDE_CODE_NAME: &'static str = "claude";
+pub const CLAUDE_AGENT_NAME: &'static str = "claude";
 pub const CODEX_NAME: &'static str = "codex";
 
 #[derive(Default, Clone, JsonSchema, Debug, PartialEq, RegisterSetting)]

--- a/crates/settings_content/src/agent.rs
+++ b/crates/settings_content/src/agent.rs
@@ -119,7 +119,7 @@ pub struct AgentSettingsContent {
     /// require confirmation.
     ///
     /// The global `default` applies when no tool-specific rules match.
-    /// For external agent servers (e.g. Claude Code) that define their own
+    /// For external agent servers (e.g. Claude Agent) that define their own
     /// permission modes, "deny" and "confirm" still take precedence — the
     /// external agent's permission system is only used when Zed would allow
     /// the action. Per-tool regex patterns (`always_allow`, `always_deny`,

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -346,9 +346,9 @@ impl TitleBar {
             OnboardingBanner::new(
                 "ACP Claude Code Onboarding",
                 IconName::AiClaude,
-                "Claude Code",
+                "Claude Agent",
                 Some("Introducing:".into()),
-                zed_actions::agent::OpenClaudeCodeOnboardingModal.boxed_clone(),
+                zed_actions::agent::OpenClaudeAgentOnboardingModal.boxed_clone(),
                 cx,
             )
             // When updating this to a non-AI feature release, remove this line.

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -434,8 +434,8 @@ pub mod agent {
             OpenOnboardingModal,
             /// Opens the ACP onboarding modal.
             OpenAcpOnboardingModal,
-            /// Opens the Claude Code onboarding modal.
-            OpenClaudeCodeOnboardingModal,
+            /// Opens the Claude Agent onboarding modal.
+            OpenClaudeAgentOnboardingModal,
             /// Resets the agent onboarding state.
             ResetOnboarding,
             /// Starts a chat conversation with the agent.

--- a/docs/src/ai/agent-panel.md
+++ b/docs/src/ai/agent-panel.md
@@ -11,7 +11,7 @@ You can do that by:
 
 1. [subscribing to our Pro plan](https://zed.dev/pricing), so you have access to our hosted models
 2. [using your own API keys](./llm-providers.md#use-your-own-keys), either from model providers like Anthropic or model gateways like OpenRouter.
-3. using an [external agent](./external-agents.md) like [Gemini CLI](./external-agents.md#gemini-cli) or [Claude Code](./external-agents.md#claude-code)
+3. using an [external agent](./external-agents.md) like [Gemini CLI](./external-agents.md#gemini-cli) or [Claude Agent](./external-agents.md#claude-agent)
 
 ## Overview {#overview}
 
@@ -19,7 +19,8 @@ With an LLM provider or external agent configured, type in the message editor an
 
 Responses stream in with indicators showing [which tools](./tools.md) the model is using. The sections below cover what you can do from here.
 
-> Note that for external agents, like [Gemini CLI](./external-agents.md#gemini-cli) or [Claude Code](./external-agents.md#claude-code), some of the features outlined below may _not_ be supported—for example, _restoring threads from history_, _checkpoints_, _token usage display_, and others. Their availability varies depending on the agent.
+> Note that for external agents, like [Gemini CLI](./external-agents.md#gemini-cli) or [Claude Agent](./external-agents.md#claude-agent), some of the features outlined below may _not_ be supported—for example, _restoring threads from history_, _checkpoints_, _token usage display_, and others.
+> Their availability varies depending on the agent.
 
 ### Creating New Threads {#new-thread}
 

--- a/docs/src/ai/configuration.md
+++ b/docs/src/ai/configuration.md
@@ -4,8 +4,8 @@ When using AI in Zed, you can configure multiple dimensions:
 
 1. Which LLM providers you can use
    - Zed's hosted models, which require [authentication](../authentication.md) and [subscription](./subscription.md)
-   - [Using your own API keys](./llm-providers.md), which do not
-   - Using [external agents like Claude Code](./external-agents.md), which do not
+   - [Using your own API keys](./llm-providers.md), which do not require the above
+   - Using [external agents like Claude Agent](./external-agents.md), which also do not require the above
 2. [Model parameters and usage](./agent-settings.md#model-settings)
 3. [Interactions with the Agent Panel](./agent-settings.md#agent-panel-settings)
 

--- a/docs/src/ai/external-agents.md
+++ b/docs/src/ai/external-agents.md
@@ -1,8 +1,13 @@
+---
+title: Use Claude Agent, Gemini CLI, and Codex in Zed
+description: Run Claude Agent, Gemini CLI, Codex, and other AI coding agents directly in Zed via the Agent Client Protocol (ACP).
+---
+
 # External Agents
 
 Zed supports many external agents, including CLI-based ones, through the [Agent Client Protocol (ACP)](https://agentclientprotocol.com).
 
-Zed supports [Gemini CLI](https://github.com/google-gemini/gemini-cli) (the reference ACP implementation), [Claude Code](https://www.anthropic.com/claude-code), [Codex](https://developers.openai.com/codex), [GitHub Copilot](https://github.com/github/copilot-language-server-release), and [additional agents](#add-more-agents) you can configure.
+Zed supports [Gemini CLI](https://github.com/google-gemini/gemini-cli) (the reference ACP implementation), [Claude Agent](https://platform.claude.com/docs/en/agent-sdk/overview), [Codex](https://developers.openai.com/codex), [GitHub Copilot](https://github.com/github/copilot-language-server-release), and [additional agents](#add-more-agents) you can configure.
 
 > Note that Zed's interaction with external agents is strictly UI-based; the billing, legal, and terms arrangement is directly between you and the agent provider.
 > Zed does not charge for use of external agents, and our [zero-data retention agreements/privacy guarantees](./ai-improvement.md) are **_only_** applicable for Zed's hosted models.
@@ -68,14 +73,14 @@ Gemini CLI supports the same workflows as Zed's first-party agent: code generati
 
 > Some agent panel features are not yet available with Gemini CLI: editing past messages, resuming threads from history, and checkpointing.
 
-## Claude Code
+## Claude Agent
 
-Similar to Gemini CLI, you can also run [Claude Code](https://www.anthropic.com/claude-code) directly via Zed's [agent panel](./agent-panel.md).
-Under the hood, Zed runs Claude Code and communicate to it over ACP, through [a dedicated adapter](https://github.com/zed-industries/claude-code-acp).
+Similar to Gemini CLI, you can also run [Claude Agent](https://platform.claude.com/docs/en/agent-sdk/overview) directly via Zed's [agent panel](./agent-panel.md).
+Under the hood, Zed runs the Claude Agent SDK, which runs Claude Code under the hood, and communicates to it over ACP, through [a dedicated adapter](https://github.com/zed-industries/claude-code-acp).
 
 ### Getting Started
 
-Open the agent panel with {#kb agent::ToggleFocus}, and then use the `+` button in the top right to start a new Claude Code thread.
+Open the agent panel with {#kb agent::ToggleFocus}, and then use the `+` button in the top right to start a new Claude Agent thread.
 
 If you'd like to bind this to a keyboard shortcut, you can do so by editing your `keymap.json` file via the `zed: open keymap file` command to include:
 
@@ -83,7 +88,7 @@ If you'd like to bind this to a keyboard shortcut, you can do so by editing your
 [
   {
     "bindings": {
-      "cmd-alt-c": ["agent::NewExternalAgentThread", { "agent": "claude_code" }]
+      "cmd-alt-c": ["agent::NewExternalAgentThread", { "agent": "claude" }]
     }
   }
 ]
@@ -91,18 +96,18 @@ If you'd like to bind this to a keyboard shortcut, you can do so by editing your
 
 ### Authentication
 
-As of version `0.202.7`, authentication to Zed's Claude Code installation is decoupled entirely from Zed's agent.
-That is to say, an Anthropic API key added via the [Zed Agent's settings](./llm-providers.md#anthropic) will _not_ be utilized by Claude Code for authentication and billing.
+As of version `0.202.7`, authentication to Zed's Claude Agent installation is decoupled entirely from Zed's agent.
+That is to say, an Anthropic API key added via the [Zed Agent's settings](./llm-providers.md#anthropic) will _not_ be utilized by Claude Agent for authentication and billing.
 
-To ensure you're using your billing method of choice, [open a new Claude Code thread](./agent-panel.md#new-thread).
+To ensure you're using your billing method of choice, [open a new Claude Agent thread](./agent-panel.md#new-thread).
 Then, run `/login`, and authenticate either via API key, or via `Log in with Claude Code` to use a Claude Pro/Max subscription.
 
 #### Installation
 
-The first time you create a Claude Code thread, Zed will install [@zed-industries/claude-code-acp](https://github.com/zed-industries/claude-code-acp).
+The first time you create a Claude Agent thread, Zed will install [@zed-industries/claude-code-acp](https://github.com/zed-industries/claude-code-acp).
 This installation is only available to Zed and is kept up to date as you use the agent.
 
-Zed will always use this managed version of the Claude Code adapter, which includes a vendored version of the Claude Code CLI, even if you have it installed globally.
+Zed will always use this managed version of the Claude Agent adapter, which includes a vendored version of the Claude Code CLI, even if you have it installed globally.
 
 If you want to override the executable used by the adapter, you can set the `CLAUDE_CODE_EXECUTABLE` environment variable in your settings to the path of your preferred executable.
 
@@ -120,22 +125,22 @@ If you want to override the executable used by the adapter, you can set the `CLA
 
 ### Usage
 
-Claude Code supports the same workflows as Zed's first-party agent. Add context by @-mentioning files, recent threads, diagnostics, or symbols.
+Claude Agent supports the same workflows as Zed's first-party agent. Add context by @-mentioning files, recent threads, diagnostics, or symbols.
 
-In complement to talking to it [over ACP](https://agentclientprotocol.com), Zed relies on the [Claude Code SDK](https://docs.anthropic.com/en/docs/claude-code/sdk/sdk-overview) to support some of its specific features.
+In complement to talking to it [over ACP](https://agentclientprotocol.com), Zed relies on the [Claude Agent SDK](https://platform.claude.com/docs/en/agent-sdk/overview) to support some of its specific features.
 However, the SDK doesn't yet expose everything needed to fully support all of them:
 
 - Slash Commands: A subset of [built-in commands](https://docs.anthropic.com/en/docs/claude-code/slash-commands#built-in-slash-commands) are supported, while [custom slash commands](https://docs.anthropic.com/en/docs/claude-code/slash-commands#custom-slash-commands) are fully supported.
 - [Subagents](https://docs.anthropic.com/en/docs/claude-code/sub-agents) are supported.
 - [Hooks](https://docs.anthropic.com/en/docs/claude-code/hooks-guide) are currently _not_ supported.
 
-> Some [agent panel](./agent-panel.md) features are not yet available with Claude Code: editing past messages, resuming threads from history, and checkpointing.
+> Some [agent panel](./agent-panel.md) features are not yet available with Claude Agent: editing past messages, resuming threads from history, and checkpointing.
 
 #### CLAUDE.md
 
-Claude Code in Zed will automatically use any `CLAUDE.md` file found in your project root, project subdirectories, or root `.claude` directory.
+Claude Agent in Zed will automatically use any `CLAUDE.md` file found in your project root, project subdirectories, or root `.claude` directory.
 
-If you don't have a `CLAUDE.md` file, you can ask Claude Code to create one for you through the `init` slash command.
+If you don't have a `CLAUDE.md` file, you can ask Claude Agent to create one for you through the `init` slash command.
 
 ## Codex CLI
 
@@ -251,9 +256,9 @@ This lets you see the messages being sent and received between Zed and the agent
 
 ![The debug view for ACP logs.](https://zed.dev/img/acp/acp-logs.webp)
 
-It's helpful to attach data from this view if you're opening issues about problems with external agents like Claude Code, Codex, OpenCode, etc.
+It's helpful to attach data from this view if you're opening issues about problems with external agents like Claude Agent, Codex, OpenCode, etc.
 
 ## MCP Servers
 
 Note that for external agents, access to MCP servers [installed from Zed](./mcp.md) may vary depending on the ACP implementation.
-For example, Claude Code and Codex both support it, but Gemini CLI does not yet.
+For example, Claude Agent and Codex both support it, but Gemini CLI does not yet.

--- a/docs/src/ai/mcp.md
+++ b/docs/src/ai/mcp.md
@@ -152,5 +152,5 @@ See [Per-tool Permission Rules](./agent-settings.md#per-tool-permission-rules) a
 
 Note that for [external agents](./external-agents.md) connected through the [Agent Client Protocol](https://agentclientprotocol.com/), access to MCP servers installed from Zed may vary depending on the ACP agent implementation.
 
-Regarding the built-in ones, Claude Code and Codex both support it, and Gemini CLI does not yet.
+Regarding the built-in ones, Claude Agent and Codex both support it, and Gemini CLI does not yet.
 In the meantime, learn how to add MCP server support to Gemini CLI through [their documentation](https://github.com/google-gemini/gemini-cli?tab=readme-ov-file#using-mcp-servers).

--- a/docs/src/ai/overview.md
+++ b/docs/src/ai/overview.md
@@ -2,12 +2,37 @@
 
 Zed integrates AI throughout the editor: agentic coding, inline transformations, edit prediction, and direct model conversations.
 
-## Setting Up AI
+## How Zed approaches AI
+
+Zed's AI features run inside a native, GPU-accelerated application built in Rust. There is no Electron layer between you and the model output.
+
+- **Open source.** The editor and all AI features are [open source](https://github.com/zed-industries/zed). You can read how AI is implemented, how data flows to providers, and how tool calls execute.
+- **Multi-model.** Use Zed's hosted models or [bring your own API keys](./llm-providers.md) from Anthropic, OpenAI, Google, Ollama, and 8+ other providers. Run local models, connect to cloud APIs, or mix both. Switch models per task.
+- **External agents.** Run Claude Agent, Gemini CLI, Codex, and other CLI-based agents directly in Zed through the [Agent Client Protocol](https://zed.dev/acp). See [External Agents](./external-agents.md).
+- **Privacy by default.** AI data sharing is opt-in. When you use your own API keys, Zed maintains zero-data retention agreements with providers. See [Privacy and Security](./privacy-and-security.md).
+
+## Agentic editing
+
+The [Agent Panel](./agent-panel.md) is where you work with AI agents. Agents can read files, edit code, run terminal commands, search the web, and access diagnostics through [built-in tools](./tools.md).
+
+You can extend agents with additional tools through [MCP servers](./mcp.md), control what they can access with [tool permissions](./tool-permissions.md), and shape their behavior with [rules](./rules.md).
+
+The [Inline Assistant](./inline-assistant.md) works differently: select code or a terminal command, describe what you want, and the model rewrites the selection in place. It works with multiple cursors.
+
+## Code completions
+
+[Edit Prediction](./edit-prediction.md) provides AI code completions on every keystroke. Each keypress sends a request to the prediction provider, which returns single or multi-line suggestions you accept with `tab`.
+
+The default provider is Zeta, Zed's open-source model trained on open data. You can also use GitHub Copilot, Supermaven, or Codestral.
+
+## Text threads
+
+[Text Threads](./text-threads.md) are conversations with models inside any buffer. They work like a regular editor with your keybindings, multiple cursors, and standard editing features. Content is organized into message blocks with roles (You, Assistant, System).
+
+## Getting started
 
 - [Configuration](./configuration.md): Connect to Anthropic, OpenAI, Ollama, Google AI, or other LLM providers.
-
-- [External Agents](./external-agents.md): Run Claude Code, Codex, Aider, or other external agents inside Zed.
-
+- [External Agents](./external-agents.md): Run Claude Agent, Codex, Aider, or other external agents inside Zed.
 - [Subscription](./subscription.md): Zed's hosted models and billing.
 
 - [Privacy and Security](./privacy-and-security.md): How Zed handles data when using AI features.

--- a/docs/src/migrate/intellij.md
+++ b/docs/src/migrate/intellij.md
@@ -311,7 +311,7 @@ To use other AI models in Zed, you have several options:
 
 - Use Zed's hosted models, with higher rate limits. Requires [authentication](https://zed.dev/docs/accounts.html) and subscription to [Zed Pro](https://zed.dev/docs/ai/subscription.html).
 - Bring your own [API keys](https://zed.dev/docs/ai/llm-providers.html), no authentication needed
-- Use [external agents like Claude Code](https://zed.dev/docs/ai/external-agents.html)
+- Use [external agents like Claude Agent](https://zed.dev/docs/ai/external-agents.html)
 
 ## Advanced Config and Productivity Tweaks
 

--- a/docs/src/migrate/pycharm.md
+++ b/docs/src/migrate/pycharm.md
@@ -379,7 +379,7 @@ To use other AI models in Zed, you have several options:
 
 - Use Zed's hosted models, with higher rate limits. Requires [authentication](https://zed.dev/docs/accounts.html) and subscription to [Zed Pro](https://zed.dev/docs/ai/subscription.html).
 - Bring your own [API keys](https://zed.dev/docs/ai/llm-providers.html), no authentication needed
-- Use [external agents like Claude Code](https://zed.dev/docs/ai/external-agents.html)
+- Use [external agents like Claude Agent](https://zed.dev/docs/ai/external-agents.html)
 
 ## Advanced Config and Productivity Tweaks
 

--- a/docs/src/migrate/rustrover.md
+++ b/docs/src/migrate/rustrover.md
@@ -402,7 +402,7 @@ To use other AI models in Zed, you have several options:
 
 - Use Zed's hosted models, with higher rate limits. Requires [authentication](https://zed.dev/docs/accounts.html) and subscription to [Zed Pro](https://zed.dev/docs/ai/subscription.html).
 - Bring your own [API keys](https://zed.dev/docs/ai/llm-providers.html), no authentication needed
-- Use [external agents like Claude Code](https://zed.dev/docs/ai/external-agents.html)
+- Use [external agents like Claude Agent](https://zed.dev/docs/ai/external-agents.html)
 
 ## Advanced Config and Productivity Tweaks
 

--- a/docs/src/migrate/vs-code.md
+++ b/docs/src/migrate/vs-code.md
@@ -338,7 +338,7 @@ To use other AI models in Zed, you have several options:
 
 - Use Zed’s hosted models, with higher rate limits. Requires [authentication](https://zed.dev/docs/accounts.html) and subscription to [Zed Pro](https://zed.dev/docs/ai/subscription.html).
 - Bring your own [API keys](https://zed.dev/docs/ai/llm-providers.html), no authentication needed
-- Use [external agents like Claude Code](https://zed.dev/docs/ai/external-agents.html).
+- Use [external agents like Claude Agent](https://zed.dev/docs/ai/external-agents.html).
 
 ### Advanced Config and Productivity Tweaks
 

--- a/docs/src/migrate/webstorm.md
+++ b/docs/src/migrate/webstorm.md
@@ -380,7 +380,7 @@ To use other AI models in Zed, you have several options:
 
 - Use Zed's hosted models, with higher rate limits. Requires [authentication](https://zed.dev/docs/accounts.html) and subscription to [Zed Pro](https://zed.dev/docs/ai/subscription.html).
 - Bring your own [API keys](https://zed.dev/docs/ai/llm-providers.html), no authentication needed
-- Use [external agents like Claude Code](https://zed.dev/docs/ai/external-agents.html)
+- Use [external agents like Claude Agent](https://zed.dev/docs/ai/external-agents.html)
 
 ## Advanced Config and Productivity Tweaks
 


### PR DESCRIPTION
Update based on
https://platform.claude.com/docs/en/agent-sdk/overview#branding-guidelines

ACP package will be updated shortly.

Release Notes:

- acp: Claude Code is now referred to as Claude Agent, per Anthropic
branding guidelines.
