### PR TITLE
Revert "gpui: Allow OS caption/buttons for custom Windows titlebar"

### DIFF
--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -904,7 +904,8 @@ impl WindowsWindowInner {
                 click_count,
                 first_mouse: false,
             });
-            let handled = !func(input).propagate;
+            let result = func(input);
+            let handled = !result.propagate || result.default_prevented;
             self.state.callbacks.input.set(Some(func));
 
             if handled {


### PR DESCRIPTION
Reverts zed-industries/zed#48330

This broke clickable title bar buttons on windows

Release Notes:

- Fixed an issue where buttons in the title bar could not be clicked on Windows. (Preview only)