### PR TITLE
Add support for Claude Sonnet 4.6

### DIFF
--- a/crates/anthropic/src/anthropic.rs
+++ b/crates/anthropic/src/anthropic.rs
@@ -102,7 +102,6 @@ pub enum Model {
         alias = "claude-sonnet-4-thinking-latest"
     )]
     ClaudeSonnet4Thinking,
-    #[default]
     #[serde(rename = "claude-sonnet-4-5", alias = "claude-sonnet-4-5-latest")]
     ClaudeSonnet4_5,
     #[serde(
@@ -120,6 +119,24 @@ pub enum Model {
         alias = "claude-sonnet-4-5-1m-context-thinking-latest"
     )]
     ClaudeSonnet4_5_1mContextThinking,
+    #[default]
+    #[serde(rename = "claude-sonnet-4-6", alias = "claude-sonnet-4-6-latest")]
+    ClaudeSonnet4_6,
+    #[serde(
+        rename = "claude-sonnet-4-6-thinking",
+        alias = "claude-sonnet-4-6-thinking-latest"
+    )]
+    ClaudeSonnet4_6Thinking,
+    #[serde(
+        rename = "claude-sonnet-4-6-1m-context",
+        alias = "claude-sonnet-4-6-1m-context-latest"
+    )]
+    ClaudeSonnet4_6_1mContext,
+    #[serde(
+        rename = "claude-sonnet-4-6-1m-context-thinking",
+        alias = "claude-sonnet-4-6-1m-context-thinking-latest"
+    )]
+    ClaudeSonnet4_6_1mContextThinking,
     #[serde(rename = "claude-3-7-sonnet", alias = "claude-3-7-sonnet-latest")]
     Claude3_7Sonnet,
     #[serde(
@@ -209,6 +226,22 @@ impl Model {
             return Ok(Self::ClaudeOpus4);
         }
 
+        if id.starts_with("claude-sonnet-4-6-1m-context-thinking") {
+            return Ok(Self::ClaudeSonnet4_6_1mContextThinking);
+        }
+
+        if id.starts_with("claude-sonnet-4-6-1m-context") {
+            return Ok(Self::ClaudeSonnet4_6_1mContext);
+        }
+
+        if id.starts_with("claude-sonnet-4-6-thinking") {
+            return Ok(Self::ClaudeSonnet4_6Thinking);
+        }
+
+        if id.starts_with("claude-sonnet-4-6") {
+            return Ok(Self::ClaudeSonnet4_6);
+        }
+
         if id.starts_with("claude-sonnet-4-5-1m-context-thinking") {
             return Ok(Self::ClaudeSonnet4_5_1mContextThinking);
         }
@@ -292,6 +325,12 @@ impl Model {
             Self::ClaudeSonnet4_5_1mContextThinking => {
                 "claude-sonnet-4-5-1m-context-thinking-latest"
             }
+            Self::ClaudeSonnet4_6 => "claude-sonnet-4-6-latest",
+            Self::ClaudeSonnet4_6Thinking => "claude-sonnet-4-6-thinking-latest",
+            Self::ClaudeSonnet4_6_1mContext => "claude-sonnet-4-6-1m-context-latest",
+            Self::ClaudeSonnet4_6_1mContextThinking => {
+                "claude-sonnet-4-6-1m-context-thinking-latest"
+            }
             Self::Claude3_5Sonnet => "claude-3-5-sonnet-latest",
             Self::Claude3_7Sonnet => "claude-3-7-sonnet-latest",
             Self::Claude3_7SonnetThinking => "claude-3-7-sonnet-thinking-latest",
@@ -320,6 +359,10 @@ impl Model {
             | Self::ClaudeSonnet4_5Thinking
             | Self::ClaudeSonnet4_5_1mContext
             | Self::ClaudeSonnet4_5_1mContextThinking => "claude-sonnet-4-5-20250929",
+            Self::ClaudeSonnet4_6
+            | Self::ClaudeSonnet4_6Thinking
+            | Self::ClaudeSonnet4_6_1mContext
+            | Self::ClaudeSonnet4_6_1mContextThinking => "claude-sonnet-4-6",
             Self::Claude3_5Sonnet => "claude-3-5-sonnet-latest",
             Self::Claude3_7Sonnet | Self::Claude3_7SonnetThinking => "claude-3-7-sonnet-latest",
             Self::ClaudeHaiku4_5 | Self::ClaudeHaiku4_5Thinking => "claude-haiku-4-5-20251001",
@@ -349,6 +392,10 @@ impl Model {
             Self::ClaudeSonnet4_5Thinking => "Claude Sonnet 4.5 Thinking",
             Self::ClaudeSonnet4_5_1mContext => "Claude Sonnet 4.5 (1M context)",
             Self::ClaudeSonnet4_5_1mContextThinking => "Claude Sonnet 4.5 Thinking (1M context)",
+            Self::ClaudeSonnet4_6 => "Claude Sonnet 4.6",
+            Self::ClaudeSonnet4_6Thinking => "Claude Sonnet 4.6 Thinking",
+            Self::ClaudeSonnet4_6_1mContext => "Claude Sonnet 4.6 (1M context)",
+            Self::ClaudeSonnet4_6_1mContextThinking => "Claude Sonnet 4.6 Thinking (1M context)",
             Self::Claude3_7Sonnet => "Claude 3.7 Sonnet",
             Self::Claude3_5Sonnet => "Claude 3.5 Sonnet",
             Self::Claude3_7SonnetThinking => "Claude 3.7 Sonnet Thinking",
@@ -382,6 +429,10 @@ impl Model {
             | Self::ClaudeSonnet4_5Thinking
             | Self::ClaudeSonnet4_5_1mContext
             | Self::ClaudeSonnet4_5_1mContextThinking
+            | Self::ClaudeSonnet4_6
+            | Self::ClaudeSonnet4_6Thinking
+            | Self::ClaudeSonnet4_6_1mContext
+            | Self::ClaudeSonnet4_6_1mContextThinking
             | Self::Claude3_5Sonnet
             | Self::ClaudeHaiku4_5
             | Self::ClaudeHaiku4_5Thinking
@@ -415,6 +466,8 @@ impl Model {
             | Self::ClaudeSonnet4Thinking
             | Self::ClaudeSonnet4_5
             | Self::ClaudeSonnet4_5Thinking
+            | Self::ClaudeSonnet4_6
+            | Self::ClaudeSonnet4_6Thinking
             | Self::Claude3_5Sonnet
             | Self::ClaudeHaiku4_5
             | Self::ClaudeHaiku4_5Thinking
@@ -427,7 +480,9 @@ impl Model {
             Self::ClaudeOpus4_6_1mContext
             | Self::ClaudeOpus4_6_1mContextThinking
             | Self::ClaudeSonnet4_5_1mContext
-            | Self::ClaudeSonnet4_5_1mContextThinking => 1_000_000,
+            | Self::ClaudeSonnet4_5_1mContextThinking
+            | Self::ClaudeSonnet4_6_1mContext
+            | Self::ClaudeSonnet4_6_1mContextThinking => 1_000_000,
             Self::Custom { max_tokens, .. } => *max_tokens,
         }
     }
@@ -447,6 +502,10 @@ impl Model {
             | Self::ClaudeSonnet4_5Thinking
             | Self::ClaudeSonnet4_5_1mContext
             | Self::ClaudeSonnet4_5_1mContextThinking
+            | Self::ClaudeSonnet4_6
+            | Self::ClaudeSonnet4_6Thinking
+            | Self::ClaudeSonnet4_6_1mContext
+            | Self::ClaudeSonnet4_6_1mContextThinking
             | Self::Claude3_7Sonnet
             | Self::Claude3_7SonnetThinking
             | Self::ClaudeHaiku4_5
@@ -480,6 +539,10 @@ impl Model {
             | Self::ClaudeSonnet4_5Thinking
             | Self::ClaudeSonnet4_5_1mContext
             | Self::ClaudeSonnet4_5_1mContextThinking
+            | Self::ClaudeSonnet4_6
+            | Self::ClaudeSonnet4_6Thinking
+            | Self::ClaudeSonnet4_6_1mContext
+            | Self::ClaudeSonnet4_6_1mContextThinking
             | Self::Claude3_5Sonnet
             | Self::Claude3_7Sonnet
             | Self::Claude3_7SonnetThinking
@@ -506,6 +569,8 @@ impl Model {
             | Self::ClaudeSonnet4
             | Self::ClaudeSonnet4_5
             | Self::ClaudeSonnet4_5_1mContext
+            | Self::ClaudeSonnet4_6
+            | Self::ClaudeSonnet4_6_1mContext
             | Self::Claude3_5Sonnet
             | Self::Claude3_7Sonnet
             | Self::ClaudeHaiku4_5
@@ -521,6 +586,8 @@ impl Model {
             | Self::ClaudeSonnet4Thinking
             | Self::ClaudeSonnet4_5Thinking
             | Self::ClaudeSonnet4_5_1mContextThinking
+            | Self::ClaudeSonnet4_6Thinking
+            | Self::ClaudeSonnet4_6_1mContextThinking
             | Self::ClaudeHaiku4_5Thinking
             | Self::Claude3_7SonnetThinking => AnthropicModelMode::Thinking {
                 budget_tokens: Some(4_096),
@@ -536,7 +603,9 @@ impl Model {
             Self::ClaudeOpus4_6_1mContext
             | Self::ClaudeOpus4_6_1mContextThinking
             | Self::ClaudeSonnet4_5_1mContext
-            | Self::ClaudeSonnet4_5_1mContextThinking => {
+            | Self::ClaudeSonnet4_5_1mContextThinking
+            | Self::ClaudeSonnet4_6_1mContext
+            | Self::ClaudeSonnet4_6_1mContextThinking => {
                 headers.push(CONTEXT_1M_BETA_HEADER.to_string());
             }
             Self::Claude3_7Sonnet | Self::Claude3_7SonnetThinking => {

--- a/crates/bedrock/src/models.rs
+++ b/crates/bedrock/src/models.rs
@@ -84,6 +84,13 @@ pub enum Model {
         alias = "claude-opus-4-6-thinking-latest"
     )]
     ClaudeOpus4_6Thinking,
+    #[serde(rename = "claude-sonnet-4-6", alias = "claude-sonnet-4-6-latest")]
+    ClaudeSonnet4_6,
+    #[serde(
+        rename = "claude-sonnet-4-6-thinking",
+        alias = "claude-sonnet-4-6-thinking-latest"
+    )]
+    ClaudeSonnet4_6Thinking,
 
     // Meta Llama 4 models
     #[serde(rename = "llama-4-scout-17b")]
@@ -186,6 +193,10 @@ impl Model {
             Ok(Self::ClaudeOpus4_1Thinking)
         } else if id.starts_with("claude-opus-4-1") {
             Ok(Self::ClaudeOpus4_1)
+        } else if id.starts_with("claude-sonnet-4-6-thinking") {
+            Ok(Self::ClaudeSonnet4_6Thinking)
+        } else if id.starts_with("claude-sonnet-4-6") {
+            Ok(Self::ClaudeSonnet4_6)
         } else if id.starts_with("claude-sonnet-4-5-thinking") {
             Ok(Self::ClaudeSonnet4_5Thinking)
         } else if id.starts_with("claude-sonnet-4-5") {
@@ -214,6 +225,8 @@ impl Model {
             Self::ClaudeOpus4_5Thinking => "claude-opus-4-5-thinking",
             Self::ClaudeOpus4_6 => "claude-opus-4-6",
             Self::ClaudeOpus4_6Thinking => "claude-opus-4-6-thinking",
+            Self::ClaudeSonnet4_6 => "claude-sonnet-4-6",
+            Self::ClaudeSonnet4_6Thinking => "claude-sonnet-4-6-thinking",
             Self::Llama4Scout17B => "llama-4-scout-17b",
             Self::Llama4Maverick17B => "llama-4-maverick-17b",
             Self::Gemma3_4B => "gemma-3-4b",
@@ -261,6 +274,7 @@ impl Model {
                 "anthropic.claude-opus-4-5-20251101-v1:0"
             }
             Self::ClaudeOpus4_6 | Self::ClaudeOpus4_6Thinking => "anthropic.claude-opus-4-6-v1",
+            Self::ClaudeSonnet4_6 | Self::ClaudeSonnet4_6Thinking => "anthropic.claude-sonnet-4-6",
             Self::Llama4Scout17B => "meta.llama4-scout-17b-instruct-v1:0",
             Self::Llama4Maverick17B => "meta.llama4-maverick-17b-instruct-v1:0",
             Self::Gemma3_4B => "google.gemma-3-4b-it",
@@ -305,6 +319,8 @@ impl Model {
             Self::ClaudeOpus4_5Thinking => "Claude Opus 4.5 Thinking",
             Self::ClaudeOpus4_6 => "Claude Opus 4.6",
             Self::ClaudeOpus4_6Thinking => "Claude Opus 4.6 Thinking",
+            Self::ClaudeSonnet4_6 => "Claude Sonnet 4.6",
+            Self::ClaudeSonnet4_6Thinking => "Claude Sonnet 4.6 Thinking",
             Self::Llama4Scout17B => "Llama 4 Scout 17B",
             Self::Llama4Maverick17B => "Llama 4 Maverick 17B",
             Self::Gemma3_4B => "Gemma 3 4B",
@@ -354,7 +370,9 @@ impl Model {
             | Self::ClaudeOpus4_5
             | Self::ClaudeOpus4_5Thinking
             | Self::ClaudeOpus4_6
-            | Self::ClaudeOpus4_6Thinking => 200_000,
+            | Self::ClaudeOpus4_6Thinking
+            | Self::ClaudeSonnet4_6
+            | Self::ClaudeSonnet4_6Thinking => 200_000,
             Self::Llama4Scout17B | Self::Llama4Maverick17B => 128_000,
             Self::Gemma3_4B | Self::Gemma3_12B | Self::Gemma3_27B => 128_000,
             Self::MagistralSmall | Self::MistralLarge3 | Self::PixtralLarge => 128_000,
@@ -382,7 +400,9 @@ impl Model {
             | Self::ClaudeSonnet4_5
             | Self::ClaudeSonnet4_5Thinking
             | Self::ClaudeOpus4_5
-            | Self::ClaudeOpus4_5Thinking => 64_000,
+            | Self::ClaudeOpus4_5Thinking
+            | Self::ClaudeSonnet4_6
+            | Self::ClaudeSonnet4_6Thinking => 64_000,
             Self::ClaudeSonnet4 | Self::ClaudeSonnet4Thinking => 64_000,
             Self::ClaudeOpus4_1 | Self::ClaudeOpus4_1Thinking => 32_000,
             Self::ClaudeOpus4_6 | Self::ClaudeOpus4_6Thinking => 128_000,
@@ -424,7 +444,9 @@ impl Model {
             | Self::ClaudeOpus4_5
             | Self::ClaudeOpus4_5Thinking
             | Self::ClaudeOpus4_6
-            | Self::ClaudeOpus4_6Thinking => 1.0,
+            | Self::ClaudeOpus4_6Thinking
+            | Self::ClaudeSonnet4_6
+            | Self::ClaudeSonnet4_6Thinking => 1.0,
             Self::Custom {
                 default_temperature,
                 ..
@@ -445,7 +467,9 @@ impl Model {
             | Self::ClaudeOpus4_5
             | Self::ClaudeOpus4_5Thinking
             | Self::ClaudeOpus4_6
-            | Self::ClaudeOpus4_6Thinking => true,
+            | Self::ClaudeOpus4_6Thinking
+            | Self::ClaudeSonnet4_6
+            | Self::ClaudeSonnet4_6Thinking => true,
             Self::NovaLite | Self::NovaPro | Self::NovaPremier | Self::Nova2Lite => true,
             Self::MistralLarge3 | Self::PixtralLarge | Self::MagistralSmall => true,
             // Gemma accepts toolConfig without error but produces unreliable tool
@@ -476,7 +500,9 @@ impl Model {
             | Self::ClaudeOpus4_5
             | Self::ClaudeOpus4_5Thinking
             | Self::ClaudeOpus4_6
-            | Self::ClaudeOpus4_6Thinking => true,
+            | Self::ClaudeOpus4_6Thinking
+            | Self::ClaudeSonnet4_6
+            | Self::ClaudeSonnet4_6Thinking => true,
             Self::NovaLite | Self::NovaPro => true,
             Self::PixtralLarge => true,
             Self::Qwen3VL235B => true,
@@ -496,6 +522,8 @@ impl Model {
                 | Self::ClaudeOpus4_5Thinking
                 | Self::ClaudeOpus4_6
                 | Self::ClaudeOpus4_6Thinking
+                | Self::ClaudeSonnet4_6
+                | Self::ClaudeSonnet4_6Thinking
         )
     }
 
@@ -511,7 +539,9 @@ impl Model {
             | Self::ClaudeOpus4_5
             | Self::ClaudeOpus4_5Thinking
             | Self::ClaudeOpus4_6
-            | Self::ClaudeOpus4_6Thinking => true,
+            | Self::ClaudeOpus4_6Thinking
+            | Self::ClaudeSonnet4_6
+            | Self::ClaudeSonnet4_6Thinking => true,
             Self::Custom {
                 cache_configuration,
                 ..
@@ -531,7 +561,9 @@ impl Model {
             | Self::ClaudeOpus4_5
             | Self::ClaudeOpus4_5Thinking
             | Self::ClaudeOpus4_6
-            | Self::ClaudeOpus4_6Thinking => Some(BedrockModelCacheConfiguration {
+            | Self::ClaudeOpus4_6Thinking
+            | Self::ClaudeSonnet4_6
+            | Self::ClaudeSonnet4_6Thinking => Some(BedrockModelCacheConfiguration {
                 max_cache_anchors: 4,
                 min_total_token: 1024,
             }),
@@ -562,6 +594,9 @@ impl Model {
             Self::ClaudeOpus4_6Thinking => BedrockModelMode::AdaptiveThinking {
                 effort: BedrockAdaptiveThinkingEffort::default(),
             },
+            Self::ClaudeSonnet4_6Thinking => BedrockModelMode::AdaptiveThinking {
+                effort: BedrockAdaptiveThinkingEffort::default(),
+            },
             _ => BedrockModelMode::Default,
         }
     }
@@ -584,6 +619,8 @@ impl Model {
                 | Self::ClaudeOpus4_5Thinking
                 | Self::ClaudeOpus4_6
                 | Self::ClaudeOpus4_6Thinking
+                | Self::ClaudeSonnet4_6
+                | Self::ClaudeSonnet4_6Thinking
                 | Self::Nova2Lite
         );
 
@@ -646,6 +683,8 @@ impl Model {
                 | Self::ClaudeOpus4_5Thinking
                 | Self::ClaudeOpus4_6
                 | Self::ClaudeOpus4_6Thinking
+                | Self::ClaudeSonnet4_6
+                | Self::ClaudeSonnet4_6Thinking
                 | Self::Nova2Lite,
                 "global",
             ) => Ok(format!("{}.{}", region_group, model_id)),
@@ -668,6 +707,8 @@ impl Model {
                 | Self::ClaudeOpus4_5Thinking
                 | Self::ClaudeOpus4_6
                 | Self::ClaudeOpus4_6Thinking
+                | Self::ClaudeSonnet4_6
+                | Self::ClaudeSonnet4_6Thinking
                 | Self::Llama4Scout17B
                 | Self::Llama4Maverick17B
                 | Self::NovaLite
@@ -690,6 +731,8 @@ impl Model {
                 | Self::ClaudeSonnet4_5Thinking
                 | Self::ClaudeOpus4_6
                 | Self::ClaudeOpus4_6Thinking
+                | Self::ClaudeSonnet4_6
+                | Self::ClaudeSonnet4_6Thinking
                 | Self::NovaLite
                 | Self::NovaPro
                 | Self::Nova2Lite,
@@ -702,7 +745,9 @@ impl Model {
                 | Self::ClaudeSonnet4_5
                 | Self::ClaudeSonnet4_5Thinking
                 | Self::ClaudeOpus4_6
-                | Self::ClaudeOpus4_6Thinking,
+                | Self::ClaudeOpus4_6Thinking
+                | Self::ClaudeSonnet4_6
+                | Self::ClaudeSonnet4_6Thinking,
                 "au",
             ) => Ok(format!("{}.{}", region_group, model_id)),
 

--- a/crates/language_models/src/provider/anthropic.rs
+++ b/crates/language_models/src/provider/anthropic.rs
@@ -141,8 +141,8 @@ impl LanguageModelProvider for AnthropicLanguageModelProvider {
 
     fn recommended_models(&self, _cx: &App) -> Vec<Arc<dyn LanguageModel>> {
         [
-            anthropic::Model::ClaudeSonnet4_5,
-            anthropic::Model::ClaudeSonnet4_5Thinking,
+            anthropic::Model::ClaudeSonnet4_6,
+            anthropic::Model::ClaudeSonnet4_6Thinking,
         ]
         .into_iter()
         .map(|model| self.create_language_model(model))


### PR DESCRIPTION

<img width="435" height="211" alt="Screenshot 2026-02-17 at 1 32 48 PM" src="https://github.com/user-attachments/assets/136c188d-5001-4526-961e-9f7faccc5f7a" />


Add support for the new Claude Sonnet 4.6 model across the anthropic, bedrock, and language_models crates. Includes base, thinking, and 1M context variants.

Closes AI-39

Release Notes:

- Added BYOK support for Claude Sonnet 4.6