### PR TITLE
edit_predictions: OpenAI-compatible endpoint 

### DIFF
--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -406,6 +406,7 @@ fn update_command_palette_filter(cx: &mut App) {
                 EditPredictionProvider::Zed
                 | EditPredictionProvider::Codestral
                 | EditPredictionProvider::Ollama
+                | EditPredictionProvider::OpenAiCompatible
                 | EditPredictionProvider::Sweep
                 | EditPredictionProvider::Mercury
                 | EditPredictionProvider::Experimental(_) => {

--- a/crates/edit_prediction/src/edit_prediction.rs
+++ b/crates/edit_prediction/src/edit_prediction.rs
@@ -59,6 +59,7 @@ pub mod mercury;
 pub mod ollama;
 mod onboarding_modal;
 pub mod open_ai_response;
+pub mod openai_compatible;
 mod prediction;
 pub mod sweep_ai;
 
@@ -76,6 +77,7 @@ use crate::license_detection::LicenseDetectionWatcher;
 use crate::mercury::Mercury;
 use crate::ollama::Ollama;
 use crate::onboarding_modal::ZedPredictModal;
+use crate::openai_compatible::OpenAiCompatibleEditPrediction;
 pub use crate::prediction::EditPrediction;
 pub use crate::prediction::EditPredictionId;
 use crate::prediction::EditPredictionResult;
@@ -138,6 +140,7 @@ pub struct EditPredictionStore {
     pub sweep_ai: SweepAi,
     pub mercury: Mercury,
     pub ollama: Ollama,
+    pub openai_compatible: OpenAiCompatibleEditPrediction,
     data_collection_choice: DataCollectionChoice,
     reject_predictions_tx: mpsc::UnboundedSender<EditPredictionRejection>,
     shown_predictions: VecDeque<EditPrediction>,
@@ -152,6 +155,7 @@ pub enum EditPredictionModel {
     Sweep,
     Mercury,
     Ollama,
+    OpenAiCompatible,
 }
 
 #[derive(Clone)]
@@ -688,6 +692,7 @@ impl EditPredictionStore {
             sweep_ai: SweepAi::new(cx),
             mercury: Mercury::new(cx),
             ollama: Ollama::new(),
+            openai_compatible: OpenAiCompatibleEditPrediction::new(),
 
             data_collection_choice,
             reject_predictions_tx: reject_tx,
@@ -739,6 +744,9 @@ impl EditPredictionStore {
             }
             EditPredictionModel::Ollama => {
                 edit_prediction_types::EditPredictionIconSet::new(IconName::AiOllama)
+            }
+            EditPredictionModel::OpenAiCompatible => {
+                edit_prediction_types::EditPredictionIconSet::new(IconName::AiOpenAiCompat)
             }
         }
     }
@@ -1285,7 +1293,7 @@ impl EditPredictionStore {
                     cx,
                 );
             }
-            EditPredictionModel::Ollama => {}
+            EditPredictionModel::Ollama | EditPredictionModel::OpenAiCompatible => {}
             EditPredictionModel::Zeta1 | EditPredictionModel::Zeta2 => {
                 zeta2::edit_prediction_accepted(self, current_prediction, cx)
             }
@@ -1431,7 +1439,9 @@ impl EditPredictionStore {
                     })
                     .log_err();
             }
-            EditPredictionModel::Sweep | EditPredictionModel::Ollama => {}
+            EditPredictionModel::Sweep
+            | EditPredictionModel::Ollama
+            | EditPredictionModel::OpenAiCompatible => {}
             EditPredictionModel::Mercury => {
                 mercury::edit_prediction_rejected(
                     prediction_id,
@@ -1621,9 +1631,12 @@ impl EditPredictionStore {
             -> Task<Result<Option<(EditPredictionResult, PredictionRequestedBy)>>>
         + 'static,
     ) {
-        let is_ollama = self.edit_prediction_model == EditPredictionModel::Ollama;
-        let drop_on_cancel = is_ollama;
-        let max_pending_predictions = if is_ollama { 1 } else { 2 };
+        let is_local = matches!(
+            self.edit_prediction_model,
+            EditPredictionModel::Ollama | EditPredictionModel::OpenAiCompatible
+        );
+        let drop_on_cancel = is_local;
+        let max_pending_predictions = if is_local { 1 } else { 2 };
         let project_state = self.get_or_init_project(&project, cx);
         let pending_prediction_id = project_state.next_pending_prediction_id;
         project_state.next_pending_prediction_id += 1;
@@ -1855,6 +1868,9 @@ impl EditPredictionStore {
             EditPredictionModel::Sweep => self.sweep_ai.request_prediction_with_sweep(inputs, cx),
             EditPredictionModel::Mercury => self.mercury.request_prediction(inputs, cx),
             EditPredictionModel::Ollama => self.ollama.request_prediction(inputs, cx),
+            EditPredictionModel::OpenAiCompatible => {
+                self.openai_compatible.request_prediction(inputs, cx)
+            }
         };
 
         cx.spawn(async move |this, cx| {

--- a/crates/edit_prediction/src/edit_prediction.rs
+++ b/crates/edit_prediction/src/edit_prediction.rs
@@ -58,8 +58,8 @@ mod license_detection;
 pub mod mercury;
 pub mod ollama;
 mod onboarding_modal;
+pub mod open_ai_compatible;
 pub mod open_ai_response;
-pub mod openai_compatible;
 mod prediction;
 pub mod sweep_ai;
 
@@ -77,7 +77,7 @@ use crate::license_detection::LicenseDetectionWatcher;
 use crate::mercury::Mercury;
 use crate::ollama::Ollama;
 use crate::onboarding_modal::ZedPredictModal;
-use crate::openai_compatible::OpenAiCompatibleEditPrediction;
+use crate::open_ai_compatible::OpenAiCompatibleEditPrediction;
 pub use crate::prediction::EditPrediction;
 pub use crate::prediction::EditPredictionId;
 use crate::prediction::EditPredictionResult;

--- a/crates/edit_prediction/src/ollama.rs
+++ b/crates/edit_prediction/src/ollama.rs
@@ -203,9 +203,18 @@ impl Ollama {
                     in_open_source_repo: false,
                 };
 
-                let prefix = inputs.cursor_excerpt[..inputs.cursor_offset_in_excerpt].to_string();
-                let suffix = inputs.cursor_excerpt[inputs.cursor_offset_in_excerpt..].to_string();
-                let prompt = format_fim_prompt(&model, &prefix, &suffix);
+                let Some((prefix, suffix)) = inputs
+                    .cursor_excerpt
+                    .split_at_checked(inputs.cursor_offset_in_excerpt)
+                else {
+                    return Err(anyhow::anyhow!(
+                        "cursor offset {} was out of bounds for excerpt length {}",
+                        inputs.cursor_offset_in_excerpt,
+                        inputs.cursor_excerpt.len()
+                    ));
+                };
+
+                let prompt = format_fim_prompt(&model, prefix, suffix);
                 let stop_tokens = get_fim_stop_tokens();
 
                 (prompt, stop_tokens, None, inputs)

--- a/crates/edit_prediction/src/open_ai_compatible.rs
+++ b/crates/edit_prediction/src/open_ai_compatible.rs
@@ -4,7 +4,6 @@ use crate::{
         clean_fim_completion, clean_zeta_completion, format_fim_prompt, get_fim_stop_tokens,
         get_zeta_stop_tokens, is_zeta_model,
     },
-    open_ai_response::text_from_response,
     prediction::EditPredictionResult,
     zeta1::{
         self, MAX_CONTEXT_TOKENS as ZETA_MAX_CONTEXT_TOKENS,
@@ -18,8 +17,33 @@ use language::{
     Anchor, Buffer, BufferSnapshot, OffsetRangeExt as _, ToOffset, ToPoint as _,
     language_settings::all_language_settings,
 };
+use serde::{Deserialize, Serialize};
 use std::{path::Path, sync::Arc, time::Instant};
 use zeta_prompt::{ZetaPromptInput, zeta1::format_zeta1_prompt};
+
+#[derive(Serialize)]
+struct CompletionRequest {
+    model: String,
+    prompt: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    max_tokens: Option<u64>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    stop: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    temperature: Option<f32>,
+    stream: bool,
+}
+
+#[derive(Deserialize)]
+struct CompletionResponse {
+    id: String,
+    choices: Vec<CompletionChoice>,
+}
+
+#[derive(Deserialize)]
+struct CompletionChoice {
+    text: String,
+}
 
 const FIM_CONTEXT_TOKENS: usize = 512;
 
@@ -35,12 +59,12 @@ struct RequestOutput {
     buffer_snapshotted_at: Instant,
 }
 
-fn chat_completions_url(api_url: &str) -> String {
+fn completions_url(api_url: &str) -> String {
     let trimmed = api_url.trim_end_matches('/');
     if trimmed.ends_with("/v1") {
-        format!("{}/chat/completions", trimmed)
+        format!("{}/completions", trimmed)
     } else {
-        format!("{}/v1/chat/completions", trimmed)
+        format!("{}/v1/completions", trimmed)
     }
 }
 
@@ -179,26 +203,19 @@ impl OpenAiCompatibleEditPrediction {
                 (prompt, stop_tokens, None, inputs)
             };
 
-            let request_body = open_ai::Request {
+            let request_body = CompletionRequest {
                 model: model.clone(),
-                messages: vec![open_ai::RequestMessage::User {
-                    content: open_ai::MessageContent::Plain(prompt),
-                }],
-                stream: false,
-                max_completion_tokens: Some(max_output_tokens as u64),
+                prompt,
+                max_tokens: Some(max_output_tokens as u64),
                 stop: stop_tokens,
                 temperature: Some(0.2),
-                tool_choice: None,
-                parallel_tool_calls: None,
-                tools: vec![],
-                prompt_cache_key: None,
-                reasoning_effort: None,
+                stream: false,
             };
 
             let buf = serde_json::to_vec(&request_body)?;
             let body: http_client::AsyncBody = buf.into();
 
-            let url = chat_completions_url(&api_url);
+            let url = completions_url(&api_url);
 
             let mut request_builder = http_client::Request::builder()
                 .method(http_client::Method::POST)
@@ -241,11 +258,16 @@ impl OpenAiCompatibleEditPrediction {
                 (response_received_at - buffer_snapshotted_at).as_secs_f64()
             );
 
-            let mut open_ai_response: open_ai::Response =
-                serde_json::from_slice(&body_bytes).context("Failed to parse OpenAI response")?;
+            let completion_response: CompletionResponse = serde_json::from_slice(&body_bytes)
+                .context("Failed to parse completions response")?;
 
-            let id = std::mem::take(&mut open_ai_response.id);
-            let response_str = text_from_response(open_ai_response).unwrap_or_default();
+            let id = completion_response.id;
+            let response_str = completion_response
+                .choices
+                .into_iter()
+                .next()
+                .map(|c| c.text)
+                .unwrap_or_default();
 
             log::trace!("open_ai_compatible response: {}", response_str);
 
@@ -307,44 +329,44 @@ impl OpenAiCompatibleEditPrediction {
 
 #[cfg(test)]
 mod tests {
-    use super::chat_completions_url;
+    use super::{CompletionRequest, completions_url};
     use crate::ollama::{
         format_fim_prompt, get_fim_stop_tokens, get_zeta_stop_tokens, is_zeta_model,
     };
 
     #[test]
-    fn chat_completions_url_appends_v1_when_missing() {
+    fn completions_url_appends_v1_when_missing() {
         assert_eq!(
-            chat_completions_url("http://localhost:8000"),
-            "http://localhost:8000/v1/chat/completions"
+            completions_url("http://localhost:8000"),
+            "http://localhost:8000/v1/completions"
         );
         assert_eq!(
-            chat_completions_url("http://localhost:8000/"),
-            "http://localhost:8000/v1/chat/completions"
-        );
-    }
-
-    #[test]
-    fn chat_completions_url_does_not_duplicate_v1() {
-        assert_eq!(
-            chat_completions_url("http://localhost:8000/v1"),
-            "http://localhost:8000/v1/chat/completions"
-        );
-        assert_eq!(
-            chat_completions_url("http://localhost:8000/v1/"),
-            "http://localhost:8000/v1/chat/completions"
+            completions_url("http://localhost:8000/"),
+            "http://localhost:8000/v1/completions"
         );
     }
 
     #[test]
-    fn chat_completions_url_with_custom_path_prefix() {
+    fn completions_url_does_not_duplicate_v1() {
         assert_eq!(
-            chat_completions_url("http://localhost:8000/api/v1"),
-            "http://localhost:8000/api/v1/chat/completions"
+            completions_url("http://localhost:8000/v1"),
+            "http://localhost:8000/v1/completions"
         );
         assert_eq!(
-            chat_completions_url("http://my-server.example.com/v1"),
-            "http://my-server.example.com/v1/chat/completions"
+            completions_url("http://localhost:8000/v1/"),
+            "http://localhost:8000/v1/completions"
+        );
+    }
+
+    #[test]
+    fn completions_url_with_custom_path_prefix() {
+        assert_eq!(
+            completions_url("http://localhost:8000/api/v1"),
+            "http://localhost:8000/api/v1/completions"
+        );
+        assert_eq!(
+            completions_url("http://my-server.example.com/v1"),
+            "http://my-server.example.com/v1/completions"
         );
     }
 
@@ -362,34 +384,25 @@ mod tests {
     #[test]
     fn zeta_request_body_structure() {
         let stop_tokens = get_zeta_stop_tokens();
-        let request = open_ai::Request {
+        let request = CompletionRequest {
             model: "zeta".into(),
-            messages: vec![open_ai::RequestMessage::User {
-                content: open_ai::MessageContent::Plain("test prompt".into()),
-            }],
+            prompt: "test prompt".into(),
             stream: false,
-            max_completion_tokens: Some(1024),
+            max_tokens: Some(1024),
             stop: stop_tokens.clone(),
             temperature: Some(0.2),
-            tool_choice: None,
-            parallel_tool_calls: None,
-            tools: vec![],
-            prompt_cache_key: None,
-            reasoning_effort: None,
         };
 
         let json = serde_json::to_value(&request).unwrap();
         assert_eq!(json["model"], "zeta");
         assert_eq!(json["stream"], false);
-        assert_eq!(json["max_completion_tokens"], 1024);
+        assert_eq!(json["max_tokens"], 1024);
         let temperature = json["temperature"].as_f64().unwrap();
         assert!(
             (temperature - 0.2).abs() < 0.001,
             "temperature should be ~0.2, got {temperature}"
         );
-        assert_eq!(json["messages"].as_array().unwrap().len(), 1);
-        assert_eq!(json["messages"][0]["role"], "user");
-        assert_eq!(json["messages"][0]["content"], "test prompt");
+        assert_eq!(json["prompt"], "test prompt");
 
         let stop_arr = json["stop"].as_array().unwrap();
         assert!(stop_arr.len() >= 2);
@@ -408,27 +421,20 @@ mod tests {
         let prompt = format_fim_prompt("qwen2.5-coder", prefix, suffix);
         let stop_tokens = get_fim_stop_tokens();
 
-        let request = open_ai::Request {
+        let request = CompletionRequest {
             model: "qwen2.5-coder".into(),
-            messages: vec![open_ai::RequestMessage::User {
-                content: open_ai::MessageContent::Plain(prompt.clone()),
-            }],
+            prompt: prompt.clone(),
             stream: false,
-            max_completion_tokens: Some(256),
+            max_tokens: Some(256),
             stop: stop_tokens,
             temperature: Some(0.2),
-            tool_choice: None,
-            parallel_tool_calls: None,
-            tools: vec![],
-            prompt_cache_key: None,
-            reasoning_effort: None,
         };
 
         let json = serde_json::to_value(&request).unwrap();
         assert_eq!(json["model"], "qwen2.5-coder");
-        assert_eq!(json["max_completion_tokens"], 256);
+        assert_eq!(json["max_tokens"], 256);
 
-        let content = json["messages"][0]["content"].as_str().unwrap();
+        let content = json["prompt"].as_str().unwrap();
         assert!(
             content.contains(prefix),
             "FIM prompt should contain the prefix"
@@ -443,7 +449,7 @@ mod tests {
     fn authorization_header_only_when_key_present() {
         let mut builder = gpui::http_client::Request::builder()
             .method(gpui::http_client::Method::POST)
-            .uri("http://localhost:8000/v1/chat/completions")
+            .uri("http://localhost:8000/v1/completions")
             .header("Content-Type", "application/json");
 
         let api_key: Option<String> = None;
@@ -455,7 +461,7 @@ mod tests {
 
         let mut builder = gpui::http_client::Request::builder()
             .method(gpui::http_client::Method::POST)
-            .uri("http://localhost:8000/v1/chat/completions")
+            .uri("http://localhost:8000/v1/completions")
             .header("Content-Type", "application/json");
 
         let api_key = Some("sk-test-key".to_string());

--- a/crates/edit_prediction/src/open_ai_compatible.rs
+++ b/crates/edit_prediction/src/open_ai_compatible.rs
@@ -247,7 +247,7 @@ impl OpenAiCompatibleEditPrediction {
             let id = std::mem::take(&mut open_ai_response.id);
             let response_str = text_from_response(open_ai_response).unwrap_or_default();
 
-            log::trace!("openai_compatible response: {}", response_str);
+            log::trace!("open_ai_compatible response: {}", response_str);
 
             let edits = if is_zeta {
                 let editable_range =

--- a/crates/edit_prediction/src/openai_compatible.rs
+++ b/crates/edit_prediction/src/openai_compatible.rs
@@ -35,6 +35,15 @@ struct RequestOutput {
     buffer_snapshotted_at: Instant,
 }
 
+fn chat_completions_url(api_url: &str) -> String {
+    let trimmed = api_url.trim_end_matches('/');
+    if trimmed.ends_with("/v1") {
+        format!("{}/chat/completions", trimmed)
+    } else {
+        format!("{}/v1/chat/completions", trimmed)
+    }
+}
+
 impl OpenAiCompatibleEditPrediction {
     pub fn new() -> Self {
         Self
@@ -154,9 +163,17 @@ impl OpenAiCompatibleEditPrediction {
                     in_open_source_repo: false,
                 };
 
-                let prefix = inputs.cursor_excerpt[..inputs.cursor_offset_in_excerpt].to_string();
-                let suffix = inputs.cursor_excerpt[inputs.cursor_offset_in_excerpt..].to_string();
-                let prompt = format_fim_prompt(&model, &prefix, &suffix);
+                let Some((prefix, suffix)) = inputs
+                    .cursor_excerpt
+                    .split_at_checked(inputs.cursor_offset_in_excerpt)
+                else {
+                    return Err(anyhow::anyhow!(
+                        "cursor offset {} was out of bounds for excerpt length {}",
+                        inputs.cursor_offset_in_excerpt,
+                        inputs.cursor_excerpt.len()
+                    ));
+                };
+                let prompt = format_fim_prompt(&model, prefix, suffix);
                 let stop_tokens = get_fim_stop_tokens();
 
                 (prompt, stop_tokens, None, inputs)
@@ -181,7 +198,7 @@ impl OpenAiCompatibleEditPrediction {
             let buf = serde_json::to_vec(&request_body)?;
             let body: http_client::AsyncBody = buf.into();
 
-            let url = format!("{}/chat/completions", api_url.trim_end_matches('/'));
+            let url = chat_completions_url(&api_url);
 
             let mut request_builder = http_client::Request::builder()
                 .method(http_client::Method::POST)
@@ -234,7 +251,7 @@ impl OpenAiCompatibleEditPrediction {
 
             let edits = if is_zeta {
                 let editable_range =
-                    editable_range_override.expect("zeta model should have editable range");
+                    editable_range_override.context("zeta model should have editable range")?;
 
                 let cleaned = clean_zeta_completion(&response_str);
                 match zeta1::parse_edits(cleaned, editable_range, &snapshot) {
@@ -285,5 +302,34 @@ impl OpenAiCompatibleEditPrediction {
                 .await,
             ))
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::chat_completions_url;
+
+    #[test]
+    fn chat_completions_url_appends_v1_when_missing() {
+        assert_eq!(
+            chat_completions_url("http://localhost:8000"),
+            "http://localhost:8000/v1/chat/completions"
+        );
+        assert_eq!(
+            chat_completions_url("http://localhost:8000/"),
+            "http://localhost:8000/v1/chat/completions"
+        );
+    }
+
+    #[test]
+    fn chat_completions_url_does_not_duplicate_v1() {
+        assert_eq!(
+            chat_completions_url("http://localhost:8000/v1"),
+            "http://localhost:8000/v1/chat/completions"
+        );
+        assert_eq!(
+            chat_completions_url("http://localhost:8000/v1/"),
+            "http://localhost:8000/v1/chat/completions"
+        );
     }
 }

--- a/crates/edit_prediction/src/openai_compatible.rs
+++ b/crates/edit_prediction/src/openai_compatible.rs
@@ -1,5 +1,10 @@
 use crate::{
     EditPredictionId, EditPredictionModelInput, cursor_excerpt,
+    ollama::{
+        clean_fim_completion, clean_zeta_completion, format_fim_prompt, get_fim_stop_tokens,
+        get_zeta_stop_tokens, is_zeta_model,
+    },
+    open_ai_response::text_from_response,
     prediction::EditPredictionResult,
     zeta1::{
         self, MAX_CONTEXT_TOKENS as ZETA_MAX_CONTEXT_TOKENS,
@@ -8,80 +13,20 @@ use crate::{
 };
 use anyhow::{Context as _, Result};
 use futures::AsyncReadExt as _;
-use gpui::{App, AppContext as _, Entity, SharedString, Task, http_client};
+use gpui::{App, AppContext as _, Entity, Task, http_client};
 use language::{
     Anchor, Buffer, BufferSnapshot, OffsetRangeExt as _, ToOffset, ToPoint as _,
     language_settings::all_language_settings,
 };
-use language_model::{LanguageModelProviderId, LanguageModelRegistry};
-use serde::{Deserialize, Serialize};
 use std::{path::Path, sync::Arc, time::Instant};
-use zeta_prompt::{
-    ZetaPromptInput,
-    zeta1::{EDITABLE_REGION_END_MARKER, format_zeta1_prompt},
-};
+use zeta_prompt::{ZetaPromptInput, zeta1::format_zeta1_prompt};
 
 const FIM_CONTEXT_TOKENS: usize = 512;
 
-pub struct Ollama;
+pub struct OpenAiCompatibleEditPrediction;
 
-#[derive(Debug, Serialize)]
-struct OllamaGenerateRequest {
-    model: String,
-    prompt: String,
-    raw: bool,
-    stream: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    options: Option<OllamaGenerateOptions>,
-}
-
-#[derive(Debug, Serialize)]
-struct OllamaGenerateOptions {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    num_predict: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    temperature: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    stop: Option<Vec<String>>,
-}
-
-#[derive(Debug, Deserialize)]
-struct OllamaGenerateResponse {
-    created_at: String,
-    response: String,
-}
-
-const PROVIDER_ID: LanguageModelProviderId = LanguageModelProviderId::new("ollama");
-
-pub fn is_available(cx: &App) -> bool {
-    LanguageModelRegistry::read_global(cx)
-        .provider(&PROVIDER_ID)
-        .is_some_and(|provider| provider.is_authenticated(cx))
-}
-
-pub fn ensure_authenticated(cx: &mut App) {
-    if let Some(provider) = LanguageModelRegistry::read_global(cx).provider(&PROVIDER_ID) {
-        provider.authenticate(cx).detach_and_log_err(cx);
-    }
-}
-
-pub fn fetch_models(cx: &mut App) -> Vec<SharedString> {
-    let Some(provider) = LanguageModelRegistry::read_global(cx).provider(&PROVIDER_ID) else {
-        return Vec::new();
-    };
-    provider.authenticate(cx).detach_and_log_err(cx);
-    let mut models: Vec<SharedString> = provider
-        .provided_models(cx)
-        .into_iter()
-        .map(|model| SharedString::from(model.id().0.to_string()))
-        .collect();
-    models.sort();
-    models
-}
-
-/// Output from the Ollama HTTP request, containing all data needed to create the prediction result.
-struct OllamaRequestOutput {
-    created_at: String,
+struct RequestOutput {
+    id: String,
     edits: Vec<(std::ops::Range<Anchor>, Arc<str>)>,
     snapshot: BufferSnapshot,
     response_received_at: Instant,
@@ -90,7 +35,7 @@ struct OllamaRequestOutput {
     buffer_snapshotted_at: Instant,
 }
 
-impl Ollama {
+impl OpenAiCompatibleEditPrediction {
     pub fn new() -> Self {
         Self
     }
@@ -106,13 +51,23 @@ impl Ollama {
         }: EditPredictionModelInput,
         cx: &mut App,
     ) -> Task<Result<Option<EditPredictionResult>>> {
-        let settings = &all_language_settings(None, cx).edit_predictions.ollama;
+        let settings = &all_language_settings(None, cx)
+            .edit_predictions
+            .openai_compatible;
         let Some(model) = settings.model.clone() else {
             return Task::ready(Ok(None));
         };
         let api_url = settings.api_url.clone();
+        let api_key = settings
+            .api_key
+            .clone()
+            .or_else(|| std::env::var("OPENAI_COMPATIBLE_EDIT_PREDICTION_API_KEY").ok());
 
-        log::debug!("Ollama: Requesting completion (model: {})", model);
+        log::debug!(
+            "OpenAI Compatible: Requesting completion (model: {}, url: {})",
+            model,
+            api_url
+        );
 
         let full_path: Arc<Path> = snapshot
             .file()
@@ -126,20 +81,16 @@ impl Ollama {
 
         let is_zeta = is_zeta_model(&model);
 
-        // Zeta generates more tokens than FIM models. Ideally, we'd use MAX_REWRITE_TOKENS,
-        // but this might be too slow for local deployments. So we make it configurable,
-        // but we also have this hardcoded multiplier for now.
+        let max_output_tokens = settings.max_output_tokens;
         let max_output_tokens = if is_zeta {
-            settings.max_output_tokens * 4
+            max_output_tokens * 4
         } else {
-            settings.max_output_tokens
+            max_output_tokens
         };
 
         let result = cx.background_spawn(async move {
             let zeta_editable_region_tokens = max_output_tokens as usize;
 
-            // For zeta models, use the dedicated zeta1 functions which handle their own
-            // range computation with the correct token limits.
             let (prompt, stop_tokens, editable_range_override, inputs) = if is_zeta {
                 let path_str = full_path.to_string_lossy();
                 let input_excerpt = zeta1::excerpt_for_cursor_position(
@@ -211,65 +162,90 @@ impl Ollama {
                 (prompt, stop_tokens, None, inputs)
             };
 
-            let request = OllamaGenerateRequest {
+            let request_body = open_ai::Request {
                 model: model.clone(),
-                prompt,
-                raw: true,
+                messages: vec![open_ai::RequestMessage::User {
+                    content: open_ai::MessageContent::Plain(prompt),
+                }],
                 stream: false,
-                options: Some(OllamaGenerateOptions {
-                    num_predict: Some(max_output_tokens),
-                    temperature: Some(0.2),
-                    stop: Some(stop_tokens),
-                }),
+                max_completion_tokens: Some(max_output_tokens as u64),
+                stop: stop_tokens,
+                temperature: Some(0.2),
+                tool_choice: None,
+                parallel_tool_calls: None,
+                tools: vec![],
+                prompt_cache_key: None,
+                reasoning_effort: None,
             };
 
-            let request_body = serde_json::to_string(&request)?;
-            let http_request = http_client::Request::builder()
+            let buf = serde_json::to_vec(&request_body)?;
+            let body: http_client::AsyncBody = buf.into();
+
+            let url = format!("{}/chat/completions", api_url.trim_end_matches('/'));
+
+            let mut request_builder = http_client::Request::builder()
                 .method(http_client::Method::POST)
-                .uri(format!("{}/api/generate", api_url))
-                .header("Content-Type", "application/json")
-                .body(http_client::AsyncBody::from(request_body))?;
+                .uri(&url)
+                .header("Content-Type", "application/json");
+
+            if let Some(key) = &api_key {
+                request_builder =
+                    request_builder.header("Authorization", format!("Bearer {}", key));
+            }
+
+            let http_request = request_builder.body(body)?;
 
             let mut response = http_client.send(http_request).await?;
             let status = response.status();
 
-            log::debug!("Ollama: Response status: {}", status);
+            log::debug!("OpenAI Compatible: Response status: {}", status);
 
             if !status.is_success() {
                 let mut body = String::new();
                 response.body_mut().read_to_string(&mut body).await?;
-                return Err(anyhow::anyhow!("Ollama API error: {} - {}", status, body));
+                return Err(anyhow::anyhow!(
+                    "OpenAI Compatible API error: {} - {}",
+                    status,
+                    body
+                ));
             }
 
-            let mut body = String::new();
-            response.body_mut().read_to_string(&mut body).await?;
-
-            let ollama_response: OllamaGenerateResponse =
-                serde_json::from_str(&body).context("Failed to parse Ollama response")?;
+            let mut body_bytes: Vec<u8> = Vec::new();
+            response
+                .body_mut()
+                .read_to_end(&mut body_bytes)
+                .await
+                .context("Failed to read response body")?;
 
             let response_received_at = Instant::now();
 
             log::debug!(
-                "Ollama: Completion received ({:.2}s)",
+                "OpenAI Compatible: Completion received ({:.2}s)",
                 (response_received_at - buffer_snapshotted_at).as_secs_f64()
             );
+
+            let mut open_ai_response: open_ai::Response =
+                serde_json::from_slice(&body_bytes).context("Failed to parse OpenAI response")?;
+
+            let id = std::mem::take(&mut open_ai_response.id);
+            let response_str = text_from_response(open_ai_response).unwrap_or_default();
+
+            log::trace!("openai_compatible response: {}", response_str);
 
             let edits = if is_zeta {
                 let editable_range =
                     editable_range_override.expect("zeta model should have editable range");
 
-                log::trace!("ollama response: {}", ollama_response.response);
-
-                let response = clean_zeta_completion(&ollama_response.response);
-                match zeta1::parse_edits(&response, editable_range, &snapshot) {
+                let cleaned = clean_zeta_completion(&response_str);
+                match zeta1::parse_edits(cleaned, editable_range, &snapshot) {
                     Ok(edits) => edits,
                     Err(err) => {
-                        log::warn!("Ollama zeta: Failed to parse response: {}", err);
+                        log::warn!("OpenAI Compatible zeta: Failed to parse response: {}", err);
                         vec![]
                     }
                 }
             } else {
-                let completion: Arc<str> = clean_fim_completion(&ollama_response.response).into();
+                let completion: Arc<str> = clean_fim_completion(&response_str).into();
                 if completion.is_empty() {
                     vec![]
                 } else {
@@ -279,8 +255,8 @@ impl Ollama {
                 }
             };
 
-            anyhow::Ok(OllamaRequestOutput {
-                created_at: ollama_response.created_at,
+            anyhow::Ok(RequestOutput {
+                id,
                 edits,
                 snapshot,
                 response_received_at,
@@ -291,10 +267,12 @@ impl Ollama {
         });
 
         cx.spawn(async move |cx: &mut gpui::AsyncApp| {
-            let output = result.await.context("Ollama edit prediction failed")?;
+            let output = result
+                .await
+                .context("OpenAI Compatible edit prediction failed")?;
             anyhow::Ok(Some(
                 EditPredictionResult::new(
-                    EditPredictionId(output.created_at.into()),
+                    EditPredictionId(output.id.into()),
                     &output.buffer,
                     &output.snapshot,
                     output.edits.into(),
@@ -308,101 +286,4 @@ impl Ollama {
             ))
         })
     }
-}
-
-pub(crate) fn is_zeta_model(model: &str) -> bool {
-    model.to_lowercase().contains("zeta")
-}
-
-pub(crate) fn get_zeta_stop_tokens() -> Vec<String> {
-    vec![EDITABLE_REGION_END_MARKER.to_string(), "```".to_string()]
-}
-
-pub(crate) fn format_fim_prompt(model: &str, prefix: &str, suffix: &str) -> String {
-    let model_base = model.split(':').next().unwrap_or(model);
-
-    match model_base {
-        "codellama" | "code-llama" => {
-            format!("<PRE> {prefix} <SUF>{suffix} <MID>")
-        }
-        "starcoder" | "starcoder2" | "starcoderbase" => {
-            format!("<fim_prefix>{prefix}<fim_suffix>{suffix}<fim_middle>")
-        }
-        "deepseek-coder" | "deepseek-coder-v2" => {
-            format!("<｜fim▁begin｜>{prefix}<｜fim▁hole｜>{suffix}<｜fim▁end｜>")
-        }
-        "qwen2.5-coder" | "qwen-coder" | "qwen" => {
-            format!("<|fim_prefix|>{prefix}<|fim_suffix|>{suffix}<|fim_middle|>")
-        }
-        "codegemma" => {
-            format!("<|fim_prefix|>{prefix}<|fim_suffix|>{suffix}<|fim_middle|>")
-        }
-        "codestral" | "mistral" => {
-            format!("[SUFFIX]{suffix}[PREFIX]{prefix}")
-        }
-        "glm" | "glm-4" | "glm-4.5" => {
-            format!("<|code_prefix|>{prefix}<|code_suffix|>{suffix}<|code_middle|>")
-        }
-        _ => {
-            format!("<fim_prefix>{prefix}<fim_suffix>{suffix}<fim_middle>")
-        }
-    }
-}
-
-pub(crate) fn get_fim_stop_tokens() -> Vec<String> {
-    vec![
-        "<|endoftext|>".to_string(),
-        "<|file_separator|>".to_string(),
-        "<|fim_pad|>".to_string(),
-        "<|fim_prefix|>".to_string(),
-        "<|fim_middle|>".to_string(),
-        "<|fim_suffix|>".to_string(),
-        "<fim_prefix>".to_string(),
-        "<fim_middle>".to_string(),
-        "<fim_suffix>".to_string(),
-        "<PRE>".to_string(),
-        "<SUF>".to_string(),
-        "<MID>".to_string(),
-        "[PREFIX]".to_string(),
-        "[SUFFIX]".to_string(),
-    ]
-}
-
-pub(crate) fn clean_zeta_completion(mut response: &str) -> &str {
-    if let Some(last_newline_ix) = response.rfind('\n') {
-        let last_line = &response[last_newline_ix + 1..];
-        if EDITABLE_REGION_END_MARKER.starts_with(&last_line) {
-            response = &response[..last_newline_ix]
-        }
-    }
-    response
-}
-
-pub(crate) fn clean_fim_completion(response: &str) -> String {
-    let mut result = response.to_string();
-
-    let end_tokens = [
-        "<|endoftext|>",
-        "<|file_separator|>",
-        "<|fim_pad|>",
-        "<|fim_prefix|>",
-        "<|fim_middle|>",
-        "<|fim_suffix|>",
-        "<fim_prefix>",
-        "<fim_middle>",
-        "<fim_suffix>",
-        "<PRE>",
-        "<SUF>",
-        "<MID>",
-        "[PREFIX]",
-        "[SUFFIX]",
-    ];
-
-    for token in &end_tokens {
-        if let Some(pos) = result.find(token) {
-            result.truncate(pos);
-        }
-    }
-
-    result
 }

--- a/crates/edit_prediction/src/openai_compatible.rs
+++ b/crates/edit_prediction/src/openai_compatible.rs
@@ -308,6 +308,9 @@ impl OpenAiCompatibleEditPrediction {
 #[cfg(test)]
 mod tests {
     use super::chat_completions_url;
+    use crate::ollama::{
+        format_fim_prompt, get_fim_stop_tokens, get_zeta_stop_tokens, is_zeta_model,
+    };
 
     #[test]
     fn chat_completions_url_appends_v1_when_missing() {
@@ -330,6 +333,139 @@ mod tests {
         assert_eq!(
             chat_completions_url("http://localhost:8000/v1/"),
             "http://localhost:8000/v1/chat/completions"
+        );
+    }
+
+    #[test]
+    fn chat_completions_url_with_custom_path_prefix() {
+        assert_eq!(
+            chat_completions_url("http://localhost:8000/api/v1"),
+            "http://localhost:8000/api/v1/chat/completions"
+        );
+        assert_eq!(
+            chat_completions_url("http://my-server.example.com/v1"),
+            "http://my-server.example.com/v1/chat/completions"
+        );
+    }
+
+    #[test]
+    fn is_zeta_model_detection() {
+        assert!(is_zeta_model("zeta"));
+        assert!(is_zeta_model("Zeta"));
+        assert!(is_zeta_model("my-org/zeta-v1"));
+        assert!(is_zeta_model("ZETA-large"));
+        assert!(!is_zeta_model("qwen2.5-coder:3b-base"));
+        assert!(!is_zeta_model("codellama"));
+        assert!(!is_zeta_model("starcoder2"));
+    }
+
+    #[test]
+    fn zeta_request_body_structure() {
+        let stop_tokens = get_zeta_stop_tokens();
+        let request = open_ai::Request {
+            model: "zeta".into(),
+            messages: vec![open_ai::RequestMessage::User {
+                content: open_ai::MessageContent::Plain("test prompt".into()),
+            }],
+            stream: false,
+            max_completion_tokens: Some(1024),
+            stop: stop_tokens.clone(),
+            temperature: Some(0.2),
+            tool_choice: None,
+            parallel_tool_calls: None,
+            tools: vec![],
+            prompt_cache_key: None,
+            reasoning_effort: None,
+        };
+
+        let json = serde_json::to_value(&request).unwrap();
+        assert_eq!(json["model"], "zeta");
+        assert_eq!(json["stream"], false);
+        assert_eq!(json["max_completion_tokens"], 1024);
+        let temperature = json["temperature"].as_f64().unwrap();
+        assert!(
+            (temperature - 0.2).abs() < 0.001,
+            "temperature should be ~0.2, got {temperature}"
+        );
+        assert_eq!(json["messages"].as_array().unwrap().len(), 1);
+        assert_eq!(json["messages"][0]["role"], "user");
+        assert_eq!(json["messages"][0]["content"], "test prompt");
+
+        let stop_arr = json["stop"].as_array().unwrap();
+        assert!(stop_arr.len() >= 2);
+        for token in &stop_tokens {
+            assert!(
+                stop_arr.iter().any(|v| v.as_str() == Some(token)),
+                "stop tokens should contain {token}"
+            );
+        }
+    }
+
+    #[test]
+    fn fim_request_body_structure() {
+        let prefix = "fn main() {\n    let x = ";
+        let suffix = ";\n}\n";
+        let prompt = format_fim_prompt("qwen2.5-coder", prefix, suffix);
+        let stop_tokens = get_fim_stop_tokens();
+
+        let request = open_ai::Request {
+            model: "qwen2.5-coder".into(),
+            messages: vec![open_ai::RequestMessage::User {
+                content: open_ai::MessageContent::Plain(prompt.clone()),
+            }],
+            stream: false,
+            max_completion_tokens: Some(256),
+            stop: stop_tokens,
+            temperature: Some(0.2),
+            tool_choice: None,
+            parallel_tool_calls: None,
+            tools: vec![],
+            prompt_cache_key: None,
+            reasoning_effort: None,
+        };
+
+        let json = serde_json::to_value(&request).unwrap();
+        assert_eq!(json["model"], "qwen2.5-coder");
+        assert_eq!(json["max_completion_tokens"], 256);
+
+        let content = json["messages"][0]["content"].as_str().unwrap();
+        assert!(
+            content.contains(prefix),
+            "FIM prompt should contain the prefix"
+        );
+        assert!(
+            content.contains(suffix),
+            "FIM prompt should contain the suffix"
+        );
+    }
+
+    #[test]
+    fn authorization_header_only_when_key_present() {
+        let mut builder = gpui::http_client::Request::builder()
+            .method(gpui::http_client::Method::POST)
+            .uri("http://localhost:8000/v1/chat/completions")
+            .header("Content-Type", "application/json");
+
+        let api_key: Option<String> = None;
+        if let Some(key) = &api_key {
+            builder = builder.header("Authorization", format!("Bearer {}", key));
+        }
+        let request = builder.body(gpui::http_client::AsyncBody::empty()).unwrap();
+        assert!(request.headers().get("Authorization").is_none());
+
+        let mut builder = gpui::http_client::Request::builder()
+            .method(gpui::http_client::Method::POST)
+            .uri("http://localhost:8000/v1/chat/completions")
+            .header("Content-Type", "application/json");
+
+        let api_key = Some("sk-test-key".to_string());
+        if let Some(key) = &api_key {
+            builder = builder.header("Authorization", format!("Bearer {}", key));
+        }
+        let request = builder.body(gpui::http_client::AsyncBody::empty()).unwrap();
+        assert_eq!(
+            request.headers().get("Authorization").unwrap(),
+            "Bearer sk-test-key"
         );
     }
 }

--- a/crates/edit_prediction/src/zed_edit_prediction_delegate.rs
+++ b/crates/edit_prediction/src/zed_edit_prediction_delegate.rs
@@ -78,6 +78,9 @@ impl EditPredictionDelegate for ZedEditPredictionDelegate {
                     .with_error(IconName::ZedPredictError)
             }
             EditPredictionModel::Ollama => EditPredictionIconSet::new(IconName::AiOllama),
+            EditPredictionModel::OpenAiCompatible => {
+                EditPredictionIconSet::new(IconName::AiOpenAiCompat)
+            }
         }
     }
 

--- a/crates/edit_prediction_ui/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_ui/src/edit_prediction_button.rs
@@ -403,6 +403,60 @@ impl Render for EditPredictionButton {
                         .with_handle(self.popover_menu_handle.clone()),
                 )
             }
+            EditPredictionProvider::OpenAiCompatible => {
+                let enabled = self.editor_enabled.unwrap_or(true);
+                let this = cx.weak_entity();
+
+                div().child(
+                    PopoverMenu::new("openai-compatible")
+                        .menu(move |window, cx| {
+                            this.update(cx, |this, cx| {
+                                this.build_edit_prediction_context_menu(
+                                    EditPredictionProvider::OpenAiCompatible,
+                                    window,
+                                    cx,
+                                )
+                            })
+                            .ok()
+                        })
+                        .anchor(Corner::BottomRight)
+                        .trigger_with_tooltip(
+                            IconButton::new("openai-compatible-icon", IconName::AiOpenAiCompat)
+                                .shape(IconButtonShape::Square)
+                                .when(!enabled, |this| {
+                                    this.indicator(Indicator::dot().color(Color::Ignored))
+                                        .indicator_border_color(Some(
+                                            cx.theme().colors().status_bar_background,
+                                        ))
+                                }),
+                            move |_window, cx| {
+                                let settings = all_language_settings(None, cx);
+                                let tooltip_meta = match settings
+                                    .edit_predictions
+                                    .openai_compatible
+                                    .model
+                                    .as_deref()
+                                {
+                                    Some(model) if !model.trim().is_empty() => {
+                                        format!("Powered by OpenAI Compatible ({model})")
+                                    }
+                                    _ => {
+                                        "OpenAI Compatible model not configured — configure a model before use"
+                                            .to_string()
+                                    }
+                                };
+
+                                Tooltip::with_meta(
+                                    "Edit Prediction",
+                                    Some(&ToggleMenu),
+                                    tooltip_meta,
+                                    cx,
+                                )
+                            },
+                        )
+                        .with_handle(self.popover_menu_handle.clone()),
+                )
+            }
             provider @ (EditPredictionProvider::Experimental(_)
             | EditPredictionProvider::Zed
             | EditPredictionProvider::Sweep
@@ -1498,6 +1552,15 @@ pub fn get_available_providers(cx: &mut App) -> Vec<EditPredictionProvider> {
 
     if edit_prediction::ollama::is_available(cx) {
         providers.push(EditPredictionProvider::Ollama);
+    }
+
+    if all_language_settings(None, cx)
+        .edit_predictions
+        .openai_compatible
+        .model
+        .is_some()
+    {
+        providers.push(EditPredictionProvider::OpenAiCompatible);
     }
 
     if edit_prediction::sweep_ai::sweep_api_token(cx)

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -720,13 +720,25 @@ impl settings::Settings for AllLanguageSettings {
             api_url: ollama.api_url.unwrap().into(),
         };
 
-        let openai_compatible = edit_predictions.openai_compatible.unwrap();
-        let openai_compatible_settings = OpenAiCompatibleSettings {
-            model: openai_compatible.model,
-            max_output_tokens: openai_compatible.max_output_tokens.unwrap(),
-            api_url: openai_compatible.api_url.unwrap().into(),
-            api_key: openai_compatible.api_key,
-        };
+        let openai_compatible_settings =
+            if let Some(openai_compatible) = edit_predictions.openai_compatible {
+                OpenAiCompatibleSettings {
+                    model: openai_compatible.model,
+                    max_output_tokens: openai_compatible.max_output_tokens.unwrap_or(256),
+                    api_url: openai_compatible
+                        .api_url
+                        .unwrap_or_else(|| "http://localhost:8000/v1".into())
+                        .into(),
+                    api_key: openai_compatible.api_key,
+                }
+            } else {
+                OpenAiCompatibleSettings {
+                    model: None,
+                    max_output_tokens: 256,
+                    api_url: "http://localhost:8000/v1".into(),
+                    api_key: None,
+                }
+            };
 
         let enabled_in_text_threads = edit_predictions.enabled_in_text_threads.unwrap();
 

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -399,6 +399,8 @@ pub struct EditPredictionSettings {
     pub sweep: SweepSettings,
     /// Settings specific to Ollama.
     pub ollama: OllamaSettings,
+    /// Settings specific to OpenAI-compatible providers (vLLM, TGI, llama.cpp, etc.).
+    pub openai_compatible: OpenAiCompatibleSettings,
     /// Whether edit predictions are enabled in the assistant panel.
     /// This setting has no effect if globally disabled.
     pub enabled_in_text_threads: bool,
@@ -464,6 +466,18 @@ pub struct OllamaSettings {
     pub max_output_tokens: u32,
     /// Custom API URL to use for Ollama.
     pub api_url: Arc<str>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct OpenAiCompatibleSettings {
+    /// Model name to use for completions.
+    pub model: Option<String>,
+    /// Maximum tokens to generate.
+    pub max_output_tokens: u32,
+    /// Base URL for the OpenAI-compatible API.
+    pub api_url: Arc<str>,
+    /// Optional API key for authenticated endpoints.
+    pub api_key: Option<String>,
 }
 
 impl AllLanguageSettings {
@@ -706,6 +720,14 @@ impl settings::Settings for AllLanguageSettings {
             api_url: ollama.api_url.unwrap().into(),
         };
 
+        let openai_compatible = edit_predictions.openai_compatible.unwrap();
+        let openai_compatible_settings = OpenAiCompatibleSettings {
+            model: openai_compatible.model,
+            max_output_tokens: openai_compatible.max_output_tokens.unwrap(),
+            api_url: openai_compatible.api_url.unwrap().into(),
+            api_key: openai_compatible.api_key,
+        };
+
         let enabled_in_text_threads = edit_predictions.enabled_in_text_threads.unwrap();
 
         let mut file_types: FxHashMap<Arc<str>, (GlobSet, Vec<String>)> = FxHashMap::default();
@@ -745,6 +767,7 @@ impl settings::Settings for AllLanguageSettings {
                 codestral: codestral_settings,
                 sweep: sweep_settings,
                 ollama: ollama_settings,
+                openai_compatible: openai_compatible_settings,
                 enabled_in_text_threads,
                 examples_dir: edit_predictions.examples_dir,
             },

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -1019,4 +1019,64 @@ mod tests {
             ])
         );
     }
+
+    #[test]
+    fn test_openai_compatible_settings_defaults() {
+        let settings = OpenAiCompatibleSettings::default();
+        assert_eq!(settings.model, None);
+        assert_eq!(settings.max_output_tokens, 0);
+        assert_eq!(&*settings.api_url, "");
+        assert_eq!(settings.api_key, None);
+    }
+
+    #[test]
+    fn test_openai_compatible_settings_constructed_values() {
+        let settings = OpenAiCompatibleSettings {
+            model: Some("zeta".into()),
+            max_output_tokens: 512,
+            api_url: "http://my-server:9000/v1".into(),
+            api_key: Some("sk-test-123".into()),
+        };
+        assert_eq!(settings.model.as_deref(), Some("zeta"));
+        assert_eq!(settings.max_output_tokens, 512);
+        assert_eq!(&*settings.api_url, "http://my-server:9000/v1");
+        assert_eq!(settings.api_key.as_deref(), Some("sk-test-123"));
+    }
+
+    #[test]
+    fn test_openai_compatible_settings_no_model_means_no_key_needed() {
+        let settings = OpenAiCompatibleSettings {
+            model: None,
+            max_output_tokens: 256,
+            api_url: "http://localhost:8000/v1".into(),
+            api_key: None,
+        };
+        assert!(settings.model.is_none());
+        assert!(settings.api_key.is_none());
+    }
+
+    #[test]
+    fn test_edit_prediction_settings_includes_openai_compatible() {
+        let settings = EditPredictionSettings {
+            provider: EditPredictionProvider::OpenAiCompatible,
+            openai_compatible: OpenAiCompatibleSettings {
+                model: Some("my-model".into()),
+                max_output_tokens: 1024,
+                api_url: "http://localhost:8000/v1".into(),
+                api_key: Some("key".into()),
+            },
+            ..Default::default()
+        };
+        assert_eq!(settings.provider, EditPredictionProvider::OpenAiCompatible);
+        assert_eq!(
+            settings.openai_compatible.model.as_deref(),
+            Some("my-model")
+        );
+        assert_eq!(settings.openai_compatible.max_output_tokens, 1024);
+        assert_eq!(
+            &*settings.openai_compatible.api_url,
+            "http://localhost:8000/v1"
+        );
+        assert_eq!(settings.openai_compatible.api_key.as_deref(), Some("key"));
+    }
 }

--- a/crates/settings_content/src/language.rs
+++ b/crates/settings_content/src/language.rs
@@ -85,6 +85,7 @@ pub enum EditPredictionProvider {
     Zed,
     Codestral,
     Ollama,
+    #[serde(rename = "openai_compatible")]
     OpenAiCompatible,
     Sweep,
     Mercury,
@@ -107,6 +108,7 @@ impl<'de> Deserialize<'de> for EditPredictionProvider {
             Zed,
             Codestral,
             Ollama,
+            #[serde(rename = "openai_compatible")]
             OpenAiCompatible,
             Sweep,
             Mercury,
@@ -1166,5 +1168,129 @@ mod test {
                 .expect("options were flattened")
                 .contains_key("tabWidth")
         );
+    }
+
+    #[test]
+    fn test_edit_prediction_provider_deserialization() {
+        let cases: &[(&str, EditPredictionProvider)] = &[
+            ("\"none\"", EditPredictionProvider::None),
+            ("\"copilot\"", EditPredictionProvider::Copilot),
+            ("\"supermaven\"", EditPredictionProvider::Supermaven),
+            ("\"zed\"", EditPredictionProvider::Zed),
+            ("\"codestral\"", EditPredictionProvider::Codestral),
+            ("\"ollama\"", EditPredictionProvider::Ollama),
+            (
+                "\"openai_compatible\"",
+                EditPredictionProvider::OpenAiCompatible,
+            ),
+            ("\"sweep\"", EditPredictionProvider::Sweep),
+            ("\"mercury\"", EditPredictionProvider::Mercury),
+        ];
+        for (json, expected) in cases {
+            let parsed: EditPredictionProvider = serde_json::from_str(json).unwrap_or_else(|err| {
+                panic!("Failed to deserialize {json}: {err}");
+            });
+            assert_eq!(parsed, *expected, "mismatch for {json}");
+        }
+    }
+
+    #[test]
+    fn test_edit_prediction_provider_serialization_roundtrip() {
+        let providers = [
+            EditPredictionProvider::None,
+            EditPredictionProvider::Copilot,
+            EditPredictionProvider::Supermaven,
+            EditPredictionProvider::Zed,
+            EditPredictionProvider::Codestral,
+            EditPredictionProvider::Ollama,
+            EditPredictionProvider::OpenAiCompatible,
+            EditPredictionProvider::Sweep,
+            EditPredictionProvider::Mercury,
+        ];
+        for provider in providers {
+            let json = serde_json::to_string(&provider).unwrap();
+            let roundtripped: EditPredictionProvider = serde_json::from_str(&json).unwrap();
+            assert_eq!(roundtripped, provider, "roundtrip failed for {json}");
+        }
+    }
+
+    #[test]
+    fn test_edit_prediction_provider_openai_compatible_not_open_ai_compatible() {
+        let result = serde_json::from_str::<EditPredictionProvider>("\"open_ai_compatible\"");
+        assert!(
+            result.is_err(),
+            "\"open_ai_compatible\" (with extra underscore) should not be accepted"
+        );
+
+        let serialized = serde_json::to_string(&EditPredictionProvider::OpenAiCompatible).unwrap();
+        assert_eq!(
+            serialized, "\"openai_compatible\"",
+            "should serialize as openai_compatible, not open_ai_compatible"
+        );
+    }
+
+    #[test]
+    fn test_edit_prediction_settings_with_openai_compatible() {
+        let raw = r#"{
+            "provider": "openai_compatible",
+            "openai_compatible": {
+                "api_url": "http://localhost:8000/v1",
+                "model": "zeta",
+                "max_output_tokens": 512,
+                "api_key": "test-key"
+            }
+        }"#;
+        let settings: EditPredictionSettingsContent =
+            serde_json::from_str(raw).expect("Failed to parse edit prediction settings");
+        assert_eq!(
+            settings.provider,
+            Some(EditPredictionProvider::OpenAiCompatible)
+        );
+        let compat = settings
+            .openai_compatible
+            .expect("openai_compatible should be present");
+        assert_eq!(compat.model.as_deref(), Some("zeta"));
+        assert_eq!(compat.max_output_tokens, Some(512));
+        assert_eq!(compat.api_url.as_deref(), Some("http://localhost:8000/v1"));
+        assert_eq!(compat.api_key.as_deref(), Some("test-key"));
+    }
+
+    #[test]
+    fn test_edit_prediction_settings_openai_compatible_minimal() {
+        let raw = r#"{
+            "provider": "openai_compatible",
+            "openai_compatible": {
+                "model": "my-model"
+            }
+        }"#;
+        let settings: EditPredictionSettingsContent =
+            serde_json::from_str(raw).expect("Failed to parse edit prediction settings");
+        assert_eq!(
+            settings.provider,
+            Some(EditPredictionProvider::OpenAiCompatible)
+        );
+        let compat = settings
+            .openai_compatible
+            .expect("openai_compatible should be present");
+        assert_eq!(compat.model.as_deref(), Some("my-model"));
+        assert_eq!(compat.max_output_tokens, None);
+        assert_eq!(compat.api_url, None);
+        assert_eq!(compat.api_key, None);
+    }
+
+    #[test]
+    fn test_edit_prediction_settings_openai_compatible_empty_block() {
+        let raw = r#"{
+            "openai_compatible": {}
+        }"#;
+        let settings: EditPredictionSettingsContent =
+            serde_json::from_str(raw).expect("Failed to parse edit prediction settings");
+        let compat = settings
+            .openai_compatible
+            .expect("openai_compatible should be present");
+        assert_eq!(compat.model, None);
+        assert_eq!(compat.max_output_tokens, None);
+        assert_eq!(compat.api_url, None);
+        assert_eq!(compat.api_key, None);
     }
 }

--- a/crates/settings_content/src/language.rs
+++ b/crates/settings_content/src/language.rs
@@ -85,6 +85,7 @@ pub enum EditPredictionProvider {
     Zed,
     Codestral,
     Ollama,
+    OpenAiCompatible,
     Sweep,
     Mercury,
     Experimental(&'static str),
@@ -106,6 +107,7 @@ impl<'de> Deserialize<'de> for EditPredictionProvider {
             Zed,
             Codestral,
             Ollama,
+            OpenAiCompatible,
             Sweep,
             Mercury,
             Experimental(String),
@@ -118,6 +120,7 @@ impl<'de> Deserialize<'de> for EditPredictionProvider {
             Content::Zed => EditPredictionProvider::Zed,
             Content::Codestral => EditPredictionProvider::Codestral,
             Content::Ollama => EditPredictionProvider::Ollama,
+            Content::OpenAiCompatible => EditPredictionProvider::OpenAiCompatible,
             Content::Sweep => EditPredictionProvider::Sweep,
             Content::Mercury => EditPredictionProvider::Mercury,
             Content::Experimental(name)
@@ -146,6 +149,7 @@ impl EditPredictionProvider {
             | EditPredictionProvider::Supermaven
             | EditPredictionProvider::Codestral
             | EditPredictionProvider::Ollama
+            | EditPredictionProvider::OpenAiCompatible
             | EditPredictionProvider::Sweep
             | EditPredictionProvider::Mercury
             | EditPredictionProvider::Experimental(_) => false,
@@ -160,6 +164,7 @@ impl EditPredictionProvider {
             EditPredictionProvider::Codestral => Some("Codestral"),
             EditPredictionProvider::Sweep => Some("Sweep"),
             EditPredictionProvider::Mercury => Some("Mercury"),
+            EditPredictionProvider::OpenAiCompatible => Some("OpenAI Compatible"),
             EditPredictionProvider::Experimental(
                 EXPERIMENTAL_ZETA2_EDIT_PREDICTION_PROVIDER_NAME,
             ) => Some("Zeta2"),
@@ -190,6 +195,8 @@ pub struct EditPredictionSettingsContent {
     pub sweep: Option<SweepSettingsContent>,
     /// Settings specific to Ollama.
     pub ollama: Option<OllamaEditPredictionSettingsContent>,
+    /// Settings specific to OpenAI-compatible providers (vLLM, TGI, llama.cpp, etc.).
+    pub openai_compatible: Option<OpenAiCompatibleEditPredictionSettingsContent>,
     /// Whether edit predictions are enabled in the assistant prompt editor.
     /// This has no effect if globally disabled.
     pub enabled_in_text_threads: Option<bool>,
@@ -287,6 +294,28 @@ pub struct OllamaEditPredictionSettingsContent {
     ///
     /// Default: "http://localhost:11434"
     pub api_url: Option<String>,
+}
+
+#[with_fallible_options]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema, MergeFrom, PartialEq)]
+pub struct OpenAiCompatibleEditPredictionSettingsContent {
+    /// Model name to use for completions (e.g. "zeta" or a HuggingFace model ID).
+    ///
+    /// Default: none (must be configured)
+    pub model: Option<String>,
+    /// Maximum tokens to generate.
+    ///
+    /// Default: 256
+    pub max_output_tokens: Option<u32>,
+    /// Base URL for the OpenAI-compatible API (e.g. "http://localhost:8000/v1").
+    ///
+    /// Default: "http://localhost:8000/v1"
+    pub api_url: Option<String>,
+    /// Optional API key for authenticated endpoints.
+    /// If not set, falls back to the OPENAI_COMPATIBLE_EDIT_PREDICTION_API_KEY environment variable.
+    ///
+    /// Default: none
+    pub api_key: Option<String>,
 }
 
 /// The mode in which edit predictions should be displayed.

--- a/crates/settings_ui/src/pages/edit_prediction_provider_setup.rs
+++ b/crates/settings_ui/src/pages/edit_prediction_provider_setup.rs
@@ -67,7 +67,7 @@ pub(crate) fn render_edit_prediction_setup_page(
             .into_any_element(),
         ),
         Some(render_ollama_provider(settings_window, window, cx).into_any_element()),
-        Some(render_openai_compatible_provider(settings_window, window, cx).into_any_element()),
+        Some(render_open_ai_compatible_provider(settings_window, window, cx).into_any_element()),
         Some(
             render_api_key_provider(
                 IconName::AiMistral,
@@ -332,7 +332,7 @@ fn sweep_settings() -> Box<[SettingsPageItem]> {
     })])
 }
 
-fn render_openai_compatible_provider(
+fn render_open_ai_compatible_provider(
     settings_window: &SettingsWindow,
     window: &mut Window,
     cx: &mut Context<SettingsWindow>,

--- a/crates/settings_ui/src/pages/edit_prediction_provider_setup.rs
+++ b/crates/settings_ui/src/pages/edit_prediction_provider_setup.rs
@@ -14,6 +14,8 @@ use workspace::AppState;
 
 const OLLAMA_API_URL_PLACEHOLDER: &str = "http://localhost:11434";
 const OLLAMA_MODEL_PLACEHOLDER: &str = "qwen2.5-coder:3b-base";
+const OPENAI_COMPATIBLE_API_URL_PLACEHOLDER: &str = "http://localhost:8000/v1";
+const OPENAI_COMPATIBLE_MODEL_PLACEHOLDER: &str = "zeta";
 
 use crate::{
     SettingField, SettingItem, SettingsFieldMetadata, SettingsPageItem, SettingsWindow, USER,
@@ -65,6 +67,7 @@ pub(crate) fn render_edit_prediction_setup_page(
             .into_any_element(),
         ),
         Some(render_ollama_provider(settings_window, window, cx).into_any_element()),
+        Some(render_openai_compatible_provider(settings_window, window, cx).into_any_element()),
         Some(
             render_api_key_provider(
                 IconName::AiMistral,
@@ -329,6 +332,34 @@ fn sweep_settings() -> Box<[SettingsPageItem]> {
     })])
 }
 
+fn render_openai_compatible_provider(
+    settings_window: &SettingsWindow,
+    window: &mut Window,
+    cx: &mut Context<SettingsWindow>,
+) -> impl IntoElement {
+    let openai_compatible_settings = openai_compatible_settings();
+    let additional_fields = settings_window
+        .render_sub_page_items_section(
+            openai_compatible_settings.iter().enumerate(),
+            true,
+            window,
+            cx,
+        )
+        .into_any_element();
+
+    v_flex()
+        .id("openai-compatible")
+        .min_w_0()
+        .pt_8()
+        .gap_1p5()
+        .child(
+            SettingsSectionHeader::new("OpenAI Compatible")
+                .icon(IconName::AiOpenAiCompat)
+                .no_padding(true),
+        )
+        .child(div().px_neg_8().child(additional_fields))
+}
+
 fn render_ollama_provider(
     settings_window: &SettingsWindow,
     window: &mut Window,
@@ -446,6 +477,137 @@ fn ollama_settings() -> Box<[SettingsPageItem]> {
                         .max_output_tokens = value;
                 },
                 json_path: Some("edit_predictions.ollama.max_output_tokens"),
+            }),
+            metadata: None,
+            files: USER,
+        }),
+    ])
+}
+
+fn openai_compatible_settings() -> Box<[SettingsPageItem]> {
+    Box::new([
+        SettingsPageItem::SettingItem(SettingItem {
+            title: "API URL",
+            description: "The base URL of your OpenAI-compatible server (e.g. vLLM, TGI, llama.cpp).",
+            field: Box::new(SettingField {
+                pick: |settings| {
+                    settings
+                        .project
+                        .all_languages
+                        .edit_predictions
+                        .as_ref()?
+                        .openai_compatible
+                        .as_ref()?
+                        .api_url
+                        .as_ref()
+                },
+                write: |settings, value| {
+                    settings
+                        .project
+                        .all_languages
+                        .edit_predictions
+                        .get_or_insert_default()
+                        .openai_compatible
+                        .get_or_insert_default()
+                        .api_url = value;
+                },
+                json_path: Some("edit_predictions.openai_compatible.api_url"),
+            }),
+            metadata: Some(Box::new(SettingsFieldMetadata {
+                placeholder: Some(OPENAI_COMPATIBLE_API_URL_PLACEHOLDER),
+                ..Default::default()
+            })),
+            files: USER,
+        }),
+        SettingsPageItem::SettingItem(SettingItem {
+            title: "Model",
+            description: "The model name to use for edit predictions.",
+            field: Box::new(SettingField {
+                pick: |settings| {
+                    settings
+                        .project
+                        .all_languages
+                        .edit_predictions
+                        .as_ref()?
+                        .openai_compatible
+                        .as_ref()?
+                        .model
+                        .as_ref()
+                },
+                write: |settings, value| {
+                    settings
+                        .project
+                        .all_languages
+                        .edit_predictions
+                        .get_or_insert_default()
+                        .openai_compatible
+                        .get_or_insert_default()
+                        .model = value;
+                },
+                json_path: Some("edit_predictions.openai_compatible.model"),
+            }),
+            metadata: Some(Box::new(SettingsFieldMetadata {
+                placeholder: Some(OPENAI_COMPATIBLE_MODEL_PLACEHOLDER),
+                ..Default::default()
+            })),
+            files: USER,
+        }),
+        SettingsPageItem::SettingItem(SettingItem {
+            title: "API Key",
+            description: "Optional API key for authenticated endpoints. Falls back to OPENAI_COMPATIBLE_EDIT_PREDICTION_API_KEY env var.",
+            field: Box::new(SettingField {
+                pick: |settings| {
+                    settings
+                        .project
+                        .all_languages
+                        .edit_predictions
+                        .as_ref()?
+                        .openai_compatible
+                        .as_ref()?
+                        .api_key
+                        .as_ref()
+                },
+                write: |settings, value| {
+                    settings
+                        .project
+                        .all_languages
+                        .edit_predictions
+                        .get_or_insert_default()
+                        .openai_compatible
+                        .get_or_insert_default()
+                        .api_key = value;
+                },
+                json_path: Some("edit_predictions.openai_compatible.api_key"),
+            }),
+            metadata: None,
+            files: USER,
+        }),
+        SettingsPageItem::SettingItem(SettingItem {
+            title: "Max Output Tokens",
+            description: "The maximum number of tokens to generate.",
+            field: Box::new(SettingField {
+                pick: |settings| {
+                    settings
+                        .project
+                        .all_languages
+                        .edit_predictions
+                        .as_ref()?
+                        .openai_compatible
+                        .as_ref()?
+                        .max_output_tokens
+                        .as_ref()
+                },
+                write: |settings, value| {
+                    settings
+                        .project
+                        .all_languages
+                        .edit_predictions
+                        .get_or_insert_default()
+                        .openai_compatible
+                        .get_or_insert_default()
+                        .max_output_tokens = value;
+                },
+                json_path: Some("edit_predictions.openai_compatible.max_output_tokens"),
             }),
             metadata: None,
             files: USER,

--- a/crates/zed/src/zed/edit_prediction_registry.rs
+++ b/crates/zed/src/zed/edit_prediction_registry.rs
@@ -191,6 +191,7 @@ fn assign_edit_prediction_provider(
         value @ (EditPredictionProvider::Experimental(_)
         | EditPredictionProvider::Zed
         | EditPredictionProvider::Ollama
+        | EditPredictionProvider::OpenAiCompatible
         | EditPredictionProvider::Sweep
         | EditPredictionProvider::Mercury) => {
             let ep_store = edit_prediction::EditPredictionStore::global(client, &user_store, cx);
@@ -209,6 +210,9 @@ fn assign_edit_prediction_provider(
                                 return false;
                             }
                             edit_prediction::EditPredictionModel::Ollama
+                        }
+                        EditPredictionProvider::OpenAiCompatible => {
+                            edit_prediction::EditPredictionModel::OpenAiCompatible
                         }
                         EditPredictionProvider::Experimental(name)
                             if name == EXPERIMENTAL_ZETA2_EDIT_PREDICTION_PROVIDER_NAME


### PR DESCRIPTION
No issue available - this takes up the second suggestion made at https://github.com/zed-industries/zed/discussions/24859#discussioncomment-15787092 - cc @probably-neb 👋 

> if someone were to open a PR that made it so we used the OpenAI-compatible ollama endpoint instead of the ollama specific one (or just **add support for OpenAI-compatible API** support) then users could use runtimes like vllm to run zeta with speculative decoding locally.

Still testing and refining, but could use feedback. So far I can see predictions when using  qwen2.5-coder:3b-base on Ollama

Release Notes:

- Added support for OpenAI-compatible API in edit predictions
