### PR TITLE
Add support for Claude Sonnet 4.6 (#49386) (cherry-pick to stable)

### DIFF
--- a/crates/anthropic/src/anthropic.rs
+++ b/crates/anthropic/src/anthropic.rs
@@ -103,7 +103,6 @@ pub enum Model {
         alias = "claude-sonnet-4-thinking-latest"
     )]
     ClaudeSonnet4Thinking,
-    #[default]
     #[serde(rename = "claude-sonnet-4-5", alias = "claude-sonnet-4-5-latest")]
     ClaudeSonnet4_5,
     #[serde(
@@ -121,6 +120,24 @@ pub enum Model {
         alias = "claude-sonnet-4-5-1m-context-thinking-latest"
     )]
     ClaudeSonnet4_5_1mContextThinking,
+    #[default]
+    #[serde(rename = "claude-sonnet-4-6", alias = "claude-sonnet-4-6-latest")]
+    ClaudeSonnet4_6,
+    #[serde(
+        rename = "claude-sonnet-4-6-thinking",
+        alias = "claude-sonnet-4-6-thinking-latest"
+    )]
+    ClaudeSonnet4_6Thinking,
+    #[serde(
+        rename = "claude-sonnet-4-6-1m-context",
+        alias = "claude-sonnet-4-6-1m-context-latest"
+    )]
+    ClaudeSonnet4_6_1mContext,
+    #[serde(
+        rename = "claude-sonnet-4-6-1m-context-thinking",
+        alias = "claude-sonnet-4-6-1m-context-thinking-latest"
+    )]
+    ClaudeSonnet4_6_1mContextThinking,
     #[serde(rename = "claude-3-7-sonnet", alias = "claude-3-7-sonnet-latest")]
     Claude3_7Sonnet,
     #[serde(
@@ -210,6 +227,22 @@ impl Model {
             return Ok(Self::ClaudeOpus4);
         }
 
+        if id.starts_with("claude-sonnet-4-6-1m-context-thinking") {
+            return Ok(Self::ClaudeSonnet4_6_1mContextThinking);
+        }
+
+        if id.starts_with("claude-sonnet-4-6-1m-context") {
+            return Ok(Self::ClaudeSonnet4_6_1mContext);
+        }
+
+        if id.starts_with("claude-sonnet-4-6-thinking") {
+            return Ok(Self::ClaudeSonnet4_6Thinking);
+        }
+
+        if id.starts_with("claude-sonnet-4-6") {
+            return Ok(Self::ClaudeSonnet4_6);
+        }
+
         if id.starts_with("claude-sonnet-4-5-1m-context-thinking") {
             return Ok(Self::ClaudeSonnet4_5_1mContextThinking);
         }
@@ -293,6 +326,12 @@ impl Model {
             Self::ClaudeSonnet4_5_1mContextThinking => {
                 "claude-sonnet-4-5-1m-context-thinking-latest"
             }
+            Self::ClaudeSonnet4_6 => "claude-sonnet-4-6-latest",
+            Self::ClaudeSonnet4_6Thinking => "claude-sonnet-4-6-thinking-latest",
+            Self::ClaudeSonnet4_6_1mContext => "claude-sonnet-4-6-1m-context-latest",
+            Self::ClaudeSonnet4_6_1mContextThinking => {
+                "claude-sonnet-4-6-1m-context-thinking-latest"
+            }
             Self::Claude3_5Sonnet => "claude-3-5-sonnet-latest",
             Self::Claude3_7Sonnet => "claude-3-7-sonnet-latest",
             Self::Claude3_7SonnetThinking => "claude-3-7-sonnet-thinking-latest",
@@ -321,6 +360,10 @@ impl Model {
             | Self::ClaudeSonnet4_5Thinking
             | Self::ClaudeSonnet4_5_1mContext
             | Self::ClaudeSonnet4_5_1mContextThinking => "claude-sonnet-4-5-20250929",
+            Self::ClaudeSonnet4_6
+            | Self::ClaudeSonnet4_6Thinking
+            | Self::ClaudeSonnet4_6_1mContext
+            | Self::ClaudeSonnet4_6_1mContextThinking => "claude-sonnet-4-6",
             Self::Claude3_5Sonnet => "claude-3-5-sonnet-latest",
             Self::Claude3_7Sonnet | Self::Claude3_7SonnetThinking => "claude-3-7-sonnet-latest",
             Self::ClaudeHaiku4_5 | Self::ClaudeHaiku4_5Thinking => "claude-haiku-4-5-20251001",
@@ -350,6 +393,10 @@ impl Model {
             Self::ClaudeSonnet4_5Thinking => "Claude Sonnet 4.5 Thinking",
             Self::ClaudeSonnet4_5_1mContext => "Claude Sonnet 4.5 (1M context)",
             Self::ClaudeSonnet4_5_1mContextThinking => "Claude Sonnet 4.5 Thinking (1M context)",
+            Self::ClaudeSonnet4_6 => "Claude Sonnet 4.6",
+            Self::ClaudeSonnet4_6Thinking => "Claude Sonnet 4.6 Thinking",
+            Self::ClaudeSonnet4_6_1mContext => "Claude Sonnet 4.6 (1M context)",
+            Self::ClaudeSonnet4_6_1mContextThinking => "Claude Sonnet 4.6 Thinking (1M context)",
             Self::Claude3_7Sonnet => "Claude 3.7 Sonnet",
             Self::Claude3_5Sonnet => "Claude 3.5 Sonnet",
             Self::Claude3_7SonnetThinking => "Claude 3.7 Sonnet Thinking",
@@ -383,6 +430,10 @@ impl Model {
             | Self::ClaudeSonnet4_5Thinking
             | Self::ClaudeSonnet4_5_1mContext
             | Self::ClaudeSonnet4_5_1mContextThinking
+            | Self::ClaudeSonnet4_6
+            | Self::ClaudeSonnet4_6Thinking
+            | Self::ClaudeSonnet4_6_1mContext
+            | Self::ClaudeSonnet4_6_1mContextThinking
             | Self::Claude3_5Sonnet
             | Self::ClaudeHaiku4_5
             | Self::ClaudeHaiku4_5Thinking
@@ -416,6 +467,8 @@ impl Model {
             | Self::ClaudeSonnet4Thinking
             | Self::ClaudeSonnet4_5
             | Self::ClaudeSonnet4_5Thinking
+            | Self::ClaudeSonnet4_6
+            | Self::ClaudeSonnet4_6Thinking
             | Self::Claude3_5Sonnet
             | Self::ClaudeHaiku4_5
             | Self::ClaudeHaiku4_5Thinking
@@ -428,7 +481,9 @@ impl Model {
             Self::ClaudeOpus4_6_1mContext
             | Self::ClaudeOpus4_6_1mContextThinking
             | Self::ClaudeSonnet4_5_1mContext
-            | Self::ClaudeSonnet4_5_1mContextThinking => 1_000_000,
+            | Self::ClaudeSonnet4_5_1mContextThinking
+            | Self::ClaudeSonnet4_6_1mContext
+            | Self::ClaudeSonnet4_6_1mContextThinking => 1_000_000,
             Self::Custom { max_tokens, .. } => *max_tokens,
         }
     }
@@ -448,6 +503,10 @@ impl Model {
             | Self::ClaudeSonnet4_5Thinking
             | Self::ClaudeSonnet4_5_1mContext
             | Self::ClaudeSonnet4_5_1mContextThinking
+            | Self::ClaudeSonnet4_6
+            | Self::ClaudeSonnet4_6Thinking
+            | Self::ClaudeSonnet4_6_1mContext
+            | Self::ClaudeSonnet4_6_1mContextThinking
             | Self::Claude3_7Sonnet
             | Self::Claude3_7SonnetThinking
             | Self::ClaudeHaiku4_5
@@ -481,6 +540,10 @@ impl Model {
             | Self::ClaudeSonnet4_5Thinking
             | Self::ClaudeSonnet4_5_1mContext
             | Self::ClaudeSonnet4_5_1mContextThinking
+            | Self::ClaudeSonnet4_6
+            | Self::ClaudeSonnet4_6Thinking
+            | Self::ClaudeSonnet4_6_1mContext
+            | Self::ClaudeSonnet4_6_1mContextThinking
             | Self::Claude3_5Sonnet
             | Self::Claude3_7Sonnet
             | Self::Claude3_7SonnetThinking
@@ -507,6 +570,8 @@ impl Model {
             | Self::ClaudeSonnet4
             | Self::ClaudeSonnet4_5
             | Self::ClaudeSonnet4_5_1mContext
+            | Self::ClaudeSonnet4_6
+            | Self::ClaudeSonnet4_6_1mContext
             | Self::Claude3_5Sonnet
             | Self::Claude3_7Sonnet
             | Self::ClaudeHaiku4_5
@@ -522,6 +587,8 @@ impl Model {
             | Self::ClaudeSonnet4Thinking
             | Self::ClaudeSonnet4_5Thinking
             | Self::ClaudeSonnet4_5_1mContextThinking
+            | Self::ClaudeSonnet4_6Thinking
+            | Self::ClaudeSonnet4_6_1mContextThinking
             | Self::ClaudeHaiku4_5Thinking
             | Self::Claude3_7SonnetThinking => AnthropicModelMode::Thinking {
                 budget_tokens: Some(4_096),
@@ -551,7 +618,9 @@ impl Model {
             Self::ClaudeOpus4_6_1mContext
             | Self::ClaudeOpus4_6_1mContextThinking
             | Self::ClaudeSonnet4_5_1mContext
-            | Self::ClaudeSonnet4_5_1mContextThinking => {
+            | Self::ClaudeSonnet4_5_1mContextThinking
+            | Self::ClaudeSonnet4_6_1mContext
+            | Self::ClaudeSonnet4_6_1mContextThinking => {
                 headers.push(FINE_GRAINED_TOOL_STREAMING_BETA_HEADER.to_string());
                 headers.push(CONTEXT_1M_BETA_HEADER.to_string());
             }

--- a/crates/bedrock/src/models.rs
+++ b/crates/bedrock/src/models.rs
@@ -58,6 +58,13 @@ pub enum Model {
         alias = "claude-opus-4-5-thinking-latest"
     )]
     ClaudeOpus4_5Thinking,
+    #[serde(rename = "claude-sonnet-4-6", alias = "claude-sonnet-4-6-latest")]
+    ClaudeSonnet4_6,
+    #[serde(
+        rename = "claude-sonnet-4-6-thinking",
+        alias = "claude-sonnet-4-6-thinking-latest"
+    )]
+    ClaudeSonnet4_6Thinking,
     #[serde(rename = "claude-3-5-sonnet-v2", alias = "claude-3-5-sonnet-latest")]
     Claude3_5SonnetV2,
     #[serde(rename = "claude-3-7-sonnet", alias = "claude-3-7-sonnet-latest")]
@@ -174,6 +181,10 @@ impl Model {
             Ok(Self::Claude3_7Sonnet)
         } else if id.starts_with("claude-3-7-sonnet-thinking") {
             Ok(Self::Claude3_7SonnetThinking)
+        } else if id.starts_with("claude-sonnet-4-6-thinking") {
+            Ok(Self::ClaudeSonnet4_6Thinking)
+        } else if id.starts_with("claude-sonnet-4-6") {
+            Ok(Self::ClaudeSonnet4_6)
         } else if id.starts_with("claude-sonnet-4-5-thinking") {
             Ok(Self::ClaudeSonnet4_5Thinking)
         } else if id.starts_with("claude-sonnet-4-5") {
@@ -193,6 +204,8 @@ impl Model {
             Model::ClaudeSonnet4Thinking => "claude-sonnet-4-thinking",
             Model::ClaudeSonnet4_5 => "claude-sonnet-4-5",
             Model::ClaudeSonnet4_5Thinking => "claude-sonnet-4-5-thinking",
+            Model::ClaudeSonnet4_6 => "claude-sonnet-4-6",
+            Model::ClaudeSonnet4_6Thinking => "claude-sonnet-4-6-thinking",
             Model::ClaudeOpus4 => "claude-opus-4",
             Model::ClaudeOpus4_1 => "claude-opus-4-1",
             Model::ClaudeOpus4Thinking => "claude-opus-4-thinking",
@@ -259,6 +272,9 @@ impl Model {
             }
             Model::ClaudeSonnet4_5 | Model::ClaudeSonnet4_5Thinking => {
                 "anthropic.claude-sonnet-4-5-20250929-v1:0"
+            }
+            Model::ClaudeSonnet4_6 | Model::ClaudeSonnet4_6Thinking => {
+                "anthropic.claude-sonnet-4-6"
             }
             Model::ClaudeOpus4 | Model::ClaudeOpus4Thinking => {
                 "anthropic.claude-opus-4-20250514-v1:0"
@@ -329,6 +345,8 @@ impl Model {
             Self::ClaudeSonnet4Thinking => "Claude Sonnet 4 Thinking",
             Self::ClaudeSonnet4_5 => "Claude Sonnet 4.5",
             Self::ClaudeSonnet4_5Thinking => "Claude Sonnet 4.5 Thinking",
+            Self::ClaudeSonnet4_6 => "Claude Sonnet 4.6",
+            Self::ClaudeSonnet4_6Thinking => "Claude Sonnet 4.6 Thinking",
             Self::ClaudeOpus4 => "Claude Opus 4",
             Self::ClaudeOpus4_1 => "Claude Opus 4.1",
             Self::ClaudeOpus4Thinking => "Claude Opus 4 Thinking",
@@ -404,6 +422,8 @@ impl Model {
             | Self::ClaudeSonnet4Thinking
             | Self::ClaudeSonnet4_5
             | Self::ClaudeSonnet4_5Thinking
+            | Self::ClaudeSonnet4_6
+            | Self::ClaudeSonnet4_6Thinking
             | Self::ClaudeOpus4Thinking
             | Self::ClaudeOpus4_1Thinking
             | Self::ClaudeOpus4_5
@@ -423,6 +443,8 @@ impl Model {
             Self::ClaudeSonnet4 | Self::ClaudeSonnet4Thinking => 64_000,
             Self::ClaudeSonnet4_5
             | Self::ClaudeSonnet4_5Thinking
+            | Self::ClaudeSonnet4_6
+            | Self::ClaudeSonnet4_6Thinking
             | Self::ClaudeHaiku4_5
             | Self::ClaudeOpus4_5
             | Self::ClaudeOpus4_5Thinking => 64_000,
@@ -455,7 +477,9 @@ impl Model {
             | Self::ClaudeSonnet4
             | Self::ClaudeSonnet4Thinking
             | Self::ClaudeSonnet4_5
-            | Self::ClaudeSonnet4_5Thinking => 1.0,
+            | Self::ClaudeSonnet4_5Thinking
+            | Self::ClaudeSonnet4_6
+            | Self::ClaudeSonnet4_6Thinking => 1.0,
             Self::Custom {
                 default_temperature,
                 ..
@@ -483,6 +507,8 @@ impl Model {
             | Self::ClaudeSonnet4Thinking
             | Self::ClaudeSonnet4_5
             | Self::ClaudeSonnet4_5Thinking
+            | Self::ClaudeSonnet4_6
+            | Self::ClaudeSonnet4_6Thinking
             | Self::Claude3_5Haiku
             | Self::ClaudeHaiku4_5 => true,
 
@@ -517,6 +543,8 @@ impl Model {
             | Self::ClaudeSonnet4Thinking
             | Self::ClaudeSonnet4_5
             | Self::ClaudeSonnet4_5Thinking
+            | Self::ClaudeSonnet4_6
+            | Self::ClaudeSonnet4_6Thinking
             | Self::ClaudeOpus4
             | Self::ClaudeOpus4Thinking
             | Self::ClaudeOpus4_1
@@ -541,6 +569,8 @@ impl Model {
             | Self::Claude3_7SonnetThinking
             | Self::ClaudeSonnet4
             | Self::ClaudeSonnet4Thinking
+            | Self::ClaudeSonnet4_6
+            | Self::ClaudeSonnet4_6Thinking
             | Self::ClaudeOpus4
             | Self::ClaudeOpus4Thinking
             | Self::ClaudeOpus4_1
@@ -570,11 +600,11 @@ impl Model {
             Model::Claude3_7SonnetThinking => BedrockModelMode::Thinking {
                 budget_tokens: Some(4096),
             },
-            Model::ClaudeSonnet4Thinking | Model::ClaudeSonnet4_5Thinking => {
-                BedrockModelMode::Thinking {
-                    budget_tokens: Some(4096),
-                }
-            }
+            Model::ClaudeSonnet4Thinking
+            | Model::ClaudeSonnet4_5Thinking
+            | Model::ClaudeSonnet4_6Thinking => BedrockModelMode::Thinking {
+                budget_tokens: Some(4096),
+            },
             Model::ClaudeOpus4Thinking
             | Model::ClaudeOpus4_1Thinking
             | Model::ClaudeOpus4_5Thinking => BedrockModelMode::Thinking {
@@ -602,6 +632,8 @@ impl Model {
                 | Model::ClaudeSonnet4Thinking
                 | Model::ClaudeSonnet4_5
                 | Model::ClaudeSonnet4_5Thinking
+                | Model::ClaudeSonnet4_6
+                | Model::ClaudeSonnet4_6Thinking
         );
 
         let region_group = if region.starts_with("us-gov-") {
@@ -641,7 +673,9 @@ impl Model {
                 | Model::ClaudeSonnet4
                 | Model::ClaudeSonnet4Thinking
                 | Model::ClaudeSonnet4_5
-                | Model::ClaudeSonnet4_5Thinking,
+                | Model::ClaudeSonnet4_5Thinking
+                | Model::ClaudeSonnet4_6
+                | Model::ClaudeSonnet4_6Thinking,
                 "global",
                 _,
             ) => Ok(format!("{}.{}", region_group, model_id)),
@@ -652,19 +686,29 @@ impl Model {
                 | Model::Claude3_7Sonnet
                 | Model::Claude3_7SonnetThinking
                 | Model::ClaudeSonnet4_5
-                | Model::ClaudeSonnet4_5Thinking,
+                | Model::ClaudeSonnet4_5Thinking
+                | Model::ClaudeSonnet4_6
+                | Model::ClaudeSonnet4_6Thinking,
                 "us-gov",
                 _,
             ) => Ok(format!("{}.{}", region_group, model_id)),
 
             (
-                Model::ClaudeHaiku4_5 | Model::ClaudeSonnet4_5 | Model::ClaudeSonnet4_5Thinking,
+                Model::ClaudeHaiku4_5
+                | Model::ClaudeSonnet4_5
+                | Model::ClaudeSonnet4_5Thinking
+                | Model::ClaudeSonnet4_6
+                | Model::ClaudeSonnet4_6Thinking,
                 "apac",
                 "ap-southeast-2" | "ap-southeast-4",
             ) => Ok(format!("au.{}", model_id)),
 
             (
-                Model::ClaudeHaiku4_5 | Model::ClaudeSonnet4_5 | Model::ClaudeSonnet4_5Thinking,
+                Model::ClaudeHaiku4_5
+                | Model::ClaudeSonnet4_5
+                | Model::ClaudeSonnet4_5Thinking
+                | Model::ClaudeSonnet4_6
+                | Model::ClaudeSonnet4_6Thinking,
                 "apac",
                 "ap-northeast-1" | "ap-northeast-3",
             ) => Ok(format!("jp.{}", model_id)),
@@ -688,6 +732,8 @@ impl Model {
                 | Model::ClaudeSonnet4Thinking
                 | Model::ClaudeSonnet4_5
                 | Model::ClaudeSonnet4_5Thinking
+                | Model::ClaudeSonnet4_6
+                | Model::ClaudeSonnet4_6Thinking
                 | Model::ClaudeOpus4
                 | Model::ClaudeOpus4Thinking
                 | Model::ClaudeOpus4_1
@@ -728,6 +774,8 @@ impl Model {
                 | Model::ClaudeSonnet4
                 | Model::ClaudeSonnet4_5
                 | Model::ClaudeSonnet4_5Thinking
+                | Model::ClaudeSonnet4_6
+                | Model::ClaudeSonnet4_6Thinking
                 | Model::Claude3Haiku
                 | Model::Claude3Sonnet
                 | Model::MetaLlama321BInstructV1
@@ -747,6 +795,7 @@ impl Model {
                 | Model::Claude3_7Sonnet
                 | Model::Claude3_7SonnetThinking
                 | Model::ClaudeSonnet4
+                | Model::ClaudeSonnet4_6
                 | Model::Claude3Haiku
                 | Model::Claude3Sonnet,
                 "apac",

--- a/crates/language_models/src/provider/anthropic.rs
+++ b/crates/language_models/src/provider/anthropic.rs
@@ -139,8 +139,8 @@ impl LanguageModelProvider for AnthropicLanguageModelProvider {
 
     fn recommended_models(&self, _cx: &App) -> Vec<Arc<dyn LanguageModel>> {
         [
-            anthropic::Model::ClaudeSonnet4_5,
-            anthropic::Model::ClaudeSonnet4_5Thinking,
+            anthropic::Model::ClaudeSonnet4_6,
+            anthropic::Model::ClaudeSonnet4_6Thinking,
         ]
         .into_iter()
         .map(|model| self.create_language_model(model))


### PR DESCRIPTION
Cherry-pick of #49386 to stable

----
<img width="435" height="211" alt="Screenshot 2026-02-17 at 1 32 48 PM"
src="https://github.com/user-attachments/assets/136c188d-5001-4526-961e-9f7faccc5f7a"
/>


Add support for the new Claude Sonnet 4.6 model across the anthropic,
bedrock, and language_models crates. Includes base, thinking, and 1M
context variants.

Closes AI-39

Release Notes:

- Added BYOK support for Claude Sonnet 4.6