### PR TITLE
ui: Put back left-border in tab bar end actions

### DIFF
--- a/crates/ui/src/components/tab_bar.rs
+++ b/crates/ui/src/components/tab_bar.rs
@@ -145,6 +145,7 @@ impl RenderOnce for TabBar {
                         .px(DynamicSpacing::Base06.rems(cx))
                         .border_color(cx.theme().colors().border)
                         .border_b_1()
+                        .border_l_1()
                         .children(self.end_children),
                 )
             })

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -7927,8 +7927,8 @@ mod tests {
         let scroll_bounds = tab_bar_scroll_handle.bounds();
         let scroll_offset = tab_bar_scroll_handle.offset();
         assert!(tab_bounds.right() <= scroll_bounds.right());
-        // -38.5 is the magic number for this setup
-        assert_eq!(scroll_offset.x, px(-38.5));
+        // -39.5 is the magic number for this setup
+        assert_eq!(scroll_offset.x, px(-39.5));
         assert!(
             !tab_bounds.intersects(&new_tab_button_bounds),
             "Tab should not overlap with the new tab button, if this is failing check if there's been a redesign!"


### PR DESCRIPTION
Fixing a minor UI issue that regressed in https://github.com/zed-industries/zed/pull/49038.

Release Notes:

- N/A
