### PR TITLE
extension_ci: Make parsing of current version more robust

### DIFF
--- a/.github/workflows/extension_bump.yml
+++ b/.github/workflows/extension_bump.yml
@@ -37,7 +37,7 @@ jobs:
     - id: compare-versions-check
       name: extension_bump::compare_versions
       run: |
-        CURRENT_VERSION="$(sed -n 's/version = \"\(.*\)\"/\1/p' < extension.toml)"
+        CURRENT_VERSION="$(sed -n 's/^version = \"\(.*\)\"/\1/p' < extension.toml | tr -d '[:space:]')"
         PR_PARENT_SHA="${{ github.event.pull_request.head.sha }}"
 
         if [[ -n "$PR_PARENT_SHA" ]]; then
@@ -48,7 +48,7 @@ jobs:
             git checkout "$(git log -1 --format=%H)"~1
         fi
 
-        PARENT_COMMIT_VERSION="$(sed -n 's/version = \"\(.*\)\"/\1/p' < extension.toml)"
+        PARENT_COMMIT_VERSION="$(sed -n 's/^version = \"\(.*\)\"/\1/p' < extension.toml | tr -d '[:space:]')"
 
         [[ "$CURRENT_VERSION" == "$PARENT_COMMIT_VERSION" ]] && \
             echo "version_changed=false" >> "$GITHUB_OUTPUT" || \
@@ -99,7 +99,7 @@ jobs:
             cargo update --workspace
         fi
 
-        NEW_VERSION="$(sed -n 's/version = \"\(.*\)\"/\1/p' < extension.toml)"
+        NEW_VERSION="$(sed -n 's/^version = \"\(.*\)\"/\1/p' < extension.toml | tr -d '[:space:]')"
 
         echo "new_version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
     - name: extension_bump::create_pull_request

--- a/.github/workflows/extension_tests.yml
+++ b/.github/workflows/extension_tests.yml
@@ -105,7 +105,7 @@ jobs:
     - id: compare-versions-check
       name: extension_bump::compare_versions
       run: |
-        CURRENT_VERSION="$(sed -n 's/version = \"\(.*\)\"/\1/p' < extension.toml)"
+        CURRENT_VERSION="$(sed -n 's/^version = \"\(.*\)\"/\1/p' < extension.toml | tr -d '[:space:]')"
         PR_PARENT_SHA="${{ github.event.pull_request.head.sha }}"
 
         if [[ -n "$PR_PARENT_SHA" ]]; then
@@ -116,7 +116,7 @@ jobs:
             git checkout "$(git log -1 --format=%H)"~1
         fi
 
-        PARENT_COMMIT_VERSION="$(sed -n 's/version = \"\(.*\)\"/\1/p' < extension.toml)"
+        PARENT_COMMIT_VERSION="$(sed -n 's/^version = \"\(.*\)\"/\1/p' < extension.toml | tr -d '[:space:]')"
 
         [[ "$CURRENT_VERSION" == "$PARENT_COMMIT_VERSION" ]] && \
             echo "version_changed=false" >> "$GITHUB_OUTPUT" || \

--- a/tooling/xtask/src/tasks/workflows/extension_bump.rs
+++ b/tooling/xtask/src/tasks/workflows/extension_bump.rs
@@ -13,7 +13,8 @@ use crate::tasks::workflows::{
     },
 };
 
-const VERSION_CHECK: &str = r#"sed -n 's/version = \"\(.*\)\"/\1/p' < extension.toml"#;
+const VERSION_CHECK: &str =
+    r#"sed -n 's/^version = \"\(.*\)\"/\1/p' < extension.toml | tr -d '[:space:]'"#;
 
 // This is used by various extensions repos in the zed-extensions org to bump extension versions.
 pub(crate) fn extension_bump() -> Workflow {


### PR DESCRIPTION
This removes trailing whitespace when getting the current version of the extension, as we ran into some cases where a `\r` was added to that for some reason.

Release Notes:

- N/A
