### PR TITLE
acp: Use musl build of codex-acp on Linux

### DIFF
--- a/crates/project/src/agent_server_store.rs
+++ b/crates/project/src/agent_server_store.rs
@@ -1689,7 +1689,7 @@ fn get_platform_info() -> Option<(&'static str, &'static str, &'static str)> {
     } else if cfg!(target_os = "windows") {
         "pc-windows-msvc"
     } else if cfg!(target_os = "linux") {
-        "unknown-linux-gnu"
+        "unknown-linux-musl"
     } else {
         return None;
     };


### PR DESCRIPTION
## Description with a bit of a context

I am using Zed to write a native GUI app in Rust and want to produce portable binaries that will work on (almost) any Linux distribution. To achieve this, I build my app inside a container based on Rocky Linux 8 (which is based on RHEL 8) which contains an ancient version of glibc. For simplicity, I use the same container as a devcontainer with Zed. The only problem is that `codex-acp` which is downloaded by default is built as dynamic binary with newer version of glibc and thus fails to run in my devcontaner.

## Commit message

This allows codex-acp to work inside devcontainers with older versions of libc or with other shared libraries missing (like libssl.so.3).

Normal dynamic+libc build fails with following error in the log file:

	2026-02-16T05:31:20+01:00 WARN  [agent_servers::acp] agent stderr: /root/.local/share/zed/external_agents/codex/v0.9.2/codex-acp: /lib64/libc.so.6: version `GLIBC_2.32' not found (required by /root/.local/share/zed/external_agents/codex/v0.9.2/codex-acp)

And GUI just shows an infinite "Loading..." in this case.

Closes https://github.com/zed-industries/zed/issues/45927

Before you mark this PR as ready for review, make sure that you have:
- [Not applicable] Added a solid test coverage and/or screenshots from doing manual testing
- [V] Done a self-review taking into account security and performance aspects
- [Not applicable] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

I built `remote_server` with this patch and tested it with my devcontainer.

Release Notes:

- Fix `codex-acp` in devcontainers with older libc or missing shared libraries
