### PR TITLE
Fix Bedrock API validation errors from malformed message history

### DIFF
--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -537,6 +537,7 @@ impl AgentMessage {
             cache: false,
             reasoning_details: self.reasoning_details.clone(),
         };
+        let mut emitted_tool_use_ids = collections::HashSet::default();
         for chunk in &self.content {
             match chunk {
                 AgentMessageContent::Text(text) => {
@@ -559,6 +560,7 @@ impl AgentMessage {
                 }
                 AgentMessageContent::ToolUse(tool_use) => {
                     if self.tool_results.contains_key(&tool_use.id) {
+                        emitted_tool_use_ids.insert(tool_use.id.clone());
                         assistant_message
                             .content
                             .push(language_model::MessageContent::ToolUse(tool_use.clone()));
@@ -575,6 +577,9 @@ impl AgentMessage {
         };
 
         for tool_result in self.tool_results.values() {
+            if !emitted_tool_use_ids.contains(&tool_result.tool_use_id) {
+                continue;
+            }
             let mut tool_result = tool_result.clone();
             // Surprisingly, the API fails if we return an empty string here.
             // It thinks we are sending a tool use without a tool result.
@@ -4244,5 +4249,98 @@ mod tests {
                 assert!(last_message.tool_results.contains_key(&tool_use_id));
             });
         });
+    }
+}
+
+#[cfg(test)]
+mod agent_message_tests {
+    use super::*;
+    use language_model::{
+        LanguageModelToolResult, LanguageModelToolResultContent, LanguageModelToolUse,
+        LanguageModelToolUseId, MessageContent, Role,
+    };
+
+    #[test]
+    fn test_to_request_skips_orphaned_tool_results() {
+        // Reproduce the bug from a real broken thread: message has 4 ToolUse entries
+        // in content but 5 tool_results (one orphaned with no matching ToolUse).
+        // The API rejects this because the user message has more toolResult blocks
+        // than the assistant message has toolUse blocks.
+
+        let tool_id_a: LanguageModelToolUseId = "tool_a".into();
+        let tool_id_b: LanguageModelToolUseId = "tool_b".into();
+        let orphan_id: LanguageModelToolUseId = "tool_orphan".into();
+
+        let mut tool_results = IndexMap::default();
+        for (id, name) in [
+            (tool_id_a.clone(), "read_file"),
+            (tool_id_b.clone(), "grep"),
+            (orphan_id.clone(), "read_file"),
+        ] {
+            tool_results.insert(
+                id.clone(),
+                LanguageModelToolResult {
+                    tool_use_id: id,
+                    tool_name: name.into(),
+                    is_error: false,
+                    content: LanguageModelToolResultContent::Text("result".into()),
+                    output: None,
+                },
+            );
+        }
+
+        let message = AgentMessage {
+            content: vec![
+                AgentMessageContent::Text("Let me check.".into()),
+                AgentMessageContent::ToolUse(LanguageModelToolUse {
+                    id: tool_id_a.clone(),
+                    name: "read_file".into(),
+                    raw_input: "{}".into(),
+                    input: serde_json::json!({}),
+                    is_input_complete: true,
+                    thought_signature: None,
+                }),
+                AgentMessageContent::ToolUse(LanguageModelToolUse {
+                    id: tool_id_b.clone(),
+                    name: "grep".into(),
+                    raw_input: "{}".into(),
+                    input: serde_json::json!({}),
+                    is_input_complete: true,
+                    thought_signature: None,
+                }),
+                // Note: no ToolUse for orphan_id
+            ],
+            tool_results,
+            reasoning_details: None,
+        };
+
+        let request_messages = message.to_request();
+
+        let assistant_msg = request_messages
+            .iter()
+            .find(|m| m.role == Role::Assistant)
+            .expect("should have assistant message");
+        let user_msg = request_messages
+            .iter()
+            .find(|m| m.role == Role::User)
+            .expect("should have user message");
+
+        let tool_use_count = assistant_msg
+            .content
+            .iter()
+            .filter(|c| matches!(c, MessageContent::ToolUse(_)))
+            .count();
+        let tool_result_count = user_msg
+            .content
+            .iter()
+            .filter(|c| matches!(c, MessageContent::ToolResult(_)))
+            .count();
+
+        assert_eq!(
+            tool_use_count, tool_result_count,
+            "tool_result count ({tool_result_count}) must equal tool_use count ({tool_use_count}); orphaned results must be dropped"
+        );
+        assert_eq!(tool_use_count, 2);
+        assert_eq!(tool_result_count, 2);
     }
 }

--- a/crates/language_models/src/provider/anthropic.rs
+++ b/crates/language_models/src/provider/anthropic.rs
@@ -348,6 +348,17 @@ pub fn into_anthropic_count_tokens_request(
         }
     }
 
+    // Same thinking-block-first reordering as in into_anthropic — see comment there.
+    for message in &mut new_messages {
+        if message.role == anthropic::Role::Assistant {
+            message.content.sort_by_key(|block| match block {
+                anthropic::RequestContent::Thinking { .. }
+                | anthropic::RequestContent::RedactedThinking { .. } => 0,
+                _ => 1,
+            });
+        }
+    }
+
     CountTokensRequest {
         model,
         messages: new_messages,
@@ -688,6 +699,21 @@ pub fn into_anthropic(
                 }
                 system_message.push_str(&message.string_contents());
             }
+        }
+    }
+
+    // Anthropic requires that thinking blocks come before all other content in
+    // assistant messages. When consecutive assistant messages are merged (e.g.,
+    // an incomplete response followed by a complete one), text blocks can end
+    // up before thinking blocks, violating this constraint. Use a stable sort
+    // to move thinking blocks to the front while preserving relative order.
+    for message in &mut new_messages {
+        if message.role == anthropic::Role::Assistant {
+            message.content.sort_by_key(|block| match block {
+                anthropic::RequestContent::Thinking { .. }
+                | anthropic::RequestContent::RedactedThinking { .. } => 0,
+                _ => 1,
+            });
         }
     }
 
@@ -1261,6 +1287,146 @@ mod tests {
             0,
             "An assistant message whose only content was an unsigned thinking block \
              should be omitted entirely"
+        );
+    }
+
+    fn request_with_multiple_messages(
+        messages: Vec<LanguageModelRequestMessage>,
+    ) -> anthropic::Request {
+        let request = LanguageModelRequest {
+            messages,
+            thread_id: None,
+            prompt_id: None,
+            intent: None,
+            stop: vec![],
+            temperature: None,
+            tools: vec![],
+            tool_choice: None,
+            thinking_allowed: true,
+            thinking_effort: None,
+        };
+        into_anthropic(
+            request,
+            "claude-sonnet-4-5".to_string(),
+            1.0,
+            16000,
+            AnthropicModelMode::Thinking {
+                budget_tokens: Some(10000),
+            },
+        )
+    }
+
+    #[test]
+    fn test_thinking_blocks_reordered_before_text_after_merge() {
+        // Simulate the bug: an incomplete assistant response (text only, no thinking
+        // block) followed by a complete assistant response (thinking + text). When
+        // into_anthropic merges these consecutive same-role messages, the text from
+        // the first message would end up before the thinking block from the second,
+        // causing the API to reject the request with:
+        //   "If an assistant message contains any thinking blocks, the first block
+        //    must be thinking or redacted_thinking. Found text."
+        let result = request_with_multiple_messages(vec![
+            LanguageModelRequestMessage {
+                role: Role::User,
+                content: vec![MessageContent::Text("Hello".to_string())],
+                cache: false,
+                reasoning_details: None,
+            },
+            // Incomplete assistant response (e.g., interrupted mid-stream)
+            LanguageModelRequestMessage {
+                role: Role::Assistant,
+                content: vec![MessageContent::Text("The".to_string())],
+                cache: false,
+                reasoning_details: None,
+            },
+            // Complete assistant response with thinking
+            LanguageModelRequestMessage {
+                role: Role::Assistant,
+                content: vec![
+                    MessageContent::Thinking {
+                        text: "Let me think about this.".to_string(),
+                        signature: Some("valid-sig".to_string()),
+                    },
+                    MessageContent::Text("Here is my full response.".to_string()),
+                ],
+                cache: false,
+                reasoning_details: None,
+            },
+        ]);
+
+        // The two assistant messages should be merged into one
+        let assistant_messages: Vec<_> = result
+            .messages
+            .iter()
+            .filter(|m| m.role == anthropic::Role::Assistant)
+            .collect();
+        assert_eq!(
+            assistant_messages.len(),
+            1,
+            "consecutive assistant messages should be merged"
+        );
+
+        let content = &assistant_messages[0].content;
+        assert_eq!(content.len(), 3, "merged message should have 3 content blocks");
+
+        // The thinking block must come first, regardless of insertion order
+        assert!(
+            matches!(&content[0], anthropic::RequestContent::Thinking { .. }),
+            "first block must be a thinking block, got: {:?}",
+            content[0]
+        );
+        assert!(
+            matches!(&content[1], anthropic::RequestContent::Text { .. }),
+            "second block should be text"
+        );
+        assert!(
+            matches!(&content[2], anthropic::RequestContent::Text { .. }),
+            "third block should be text"
+        );
+    }
+
+    #[test]
+    fn test_redacted_thinking_blocks_also_reordered_before_text() {
+        let result = request_with_multiple_messages(vec![
+            LanguageModelRequestMessage {
+                role: Role::User,
+                content: vec![MessageContent::Text("Hello".to_string())],
+                cache: false,
+                reasoning_details: None,
+            },
+            // Incomplete assistant response
+            LanguageModelRequestMessage {
+                role: Role::Assistant,
+                content: vec![MessageContent::Text("The".to_string())],
+                cache: false,
+                reasoning_details: None,
+            },
+            // Complete assistant response with redacted thinking
+            LanguageModelRequestMessage {
+                role: Role::Assistant,
+                content: vec![
+                    MessageContent::RedactedThinking("redacted-data".to_string()),
+                    MessageContent::Text("Response after redacted thinking.".to_string()),
+                ],
+                cache: false,
+                reasoning_details: None,
+            },
+        ]);
+
+        let assistant_messages: Vec<_> = result
+            .messages
+            .iter()
+            .filter(|m| m.role == anthropic::Role::Assistant)
+            .collect();
+        assert_eq!(assistant_messages.len(), 1);
+
+        let content = &assistant_messages[0].content;
+        assert_eq!(content.len(), 3);
+
+        assert!(
+            matches!(&content[0], anthropic::RequestContent::RedactedThinking { .. }),
+            "first block must be a redacted thinking block, got: {:?}",
+            content[0]
         );
     }
 }

--- a/crates/language_models/src/provider/bedrock.rs
+++ b/crates/language_models/src/provider/bedrock.rs
@@ -1008,6 +1008,23 @@ pub fn into_bedrock(
         }
     }
 
+    // Bedrock requires that thinking blocks come before all other content in
+    // assistant messages. When consecutive assistant messages are merged (e.g.,
+    // an incomplete response followed by a complete one), text blocks can end
+    // up before thinking blocks, violating this constraint. Use a stable sort
+    // to move thinking blocks to the front while preserving relative order.
+    for message in &mut new_messages {
+        if message.role == bedrock::BedrockRole::Assistant {
+            message.content.sort_by_key(|block| {
+                if matches!(block, BedrockInnerContent::ReasoningContent(_)) {
+                    0
+                } else {
+                    1
+                }
+            });
+        }
+    }
+
     let mut tool_spec: Vec<BedrockTool> = if supports_tool_use {
         request
             .tools
@@ -1693,5 +1710,151 @@ impl ConfigurationView {
                 .size(LabelSize::Small)
                 .color(Color::Muted)
             )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use language_model::{LanguageModelRequestMessage, MessageContent};
+
+    fn bedrock_request_with_messages(
+        messages: Vec<LanguageModelRequestMessage>,
+    ) -> bedrock::Request {
+        let request = LanguageModelRequest {
+            messages,
+            thread_id: None,
+            prompt_id: None,
+            intent: None,
+            stop: vec![],
+            temperature: None,
+            tools: vec![],
+            tool_choice: None,
+            thinking_allowed: true,
+            thinking_effort: None,
+        };
+        into_bedrock(
+            request,
+            "us.anthropic.claude-sonnet-4-20250514-v1:0".to_string(),
+            1.0,
+            16000,
+            BedrockModelMode::Thinking {
+                budget_tokens: Some(10000),
+            },
+            false,
+            false,
+            false,
+        )
+        .expect("into_bedrock should succeed")
+    }
+
+    #[test]
+    fn test_thinking_blocks_reordered_before_text_after_merge() {
+        // Simulate the bug: an incomplete assistant response (text only, no thinking
+        // block) followed by a complete assistant response (thinking + text). When
+        // into_bedrock merges these consecutive same-role messages, the text from
+        // the first message would end up before the thinking block from the second,
+        // causing Bedrock to reject the request with:
+        //   "If an assistant message contains any thinking blocks, the first block
+        //    must be thinking or redacted_thinking. Found text."
+        let result = bedrock_request_with_messages(vec![
+            LanguageModelRequestMessage {
+                role: Role::User,
+                content: vec![MessageContent::Text("Hello".to_string())],
+                cache: false,
+                reasoning_details: None,
+            },
+            // Incomplete assistant response (e.g., interrupted mid-stream)
+            LanguageModelRequestMessage {
+                role: Role::Assistant,
+                content: vec![MessageContent::Text("The".to_string())],
+                cache: false,
+                reasoning_details: None,
+            },
+            // Complete assistant response with thinking
+            LanguageModelRequestMessage {
+                role: Role::Assistant,
+                content: vec![
+                    MessageContent::Thinking {
+                        text: "Let me think about this.".to_string(),
+                        signature: Some("valid-sig".to_string()),
+                    },
+                    MessageContent::Text("Here is my full response.".to_string()),
+                ],
+                cache: false,
+                reasoning_details: None,
+            },
+        ]);
+
+        // The two assistant messages should be merged into one
+        let assistant_messages: Vec<_> = result
+            .messages
+            .iter()
+            .filter(|m| m.role == bedrock::BedrockRole::Assistant)
+            .collect();
+        assert_eq!(
+            assistant_messages.len(),
+            1,
+            "consecutive assistant messages should be merged"
+        );
+
+        let content = &assistant_messages[0].content;
+        assert_eq!(content.len(), 3, "merged message should have 3 content blocks");
+
+        // The thinking block must come first, regardless of insertion order
+        assert!(
+            matches!(content[0], BedrockInnerContent::ReasoningContent(_)),
+            "first block must be a thinking block, got: {:?}",
+            content[0]
+        );
+        assert!(
+            matches!(content[1], BedrockInnerContent::Text(_)),
+            "second block should be text"
+        );
+        assert!(
+            matches!(content[2], BedrockInnerContent::Text(_)),
+            "third block should be text"
+        );
+    }
+
+    #[test]
+    fn test_thinking_block_order_preserved_when_already_correct() {
+        // When a single assistant message already has thinking first, the order
+        // should remain unchanged.
+        let result = bedrock_request_with_messages(vec![
+            LanguageModelRequestMessage {
+                role: Role::User,
+                content: vec![MessageContent::Text("Hello".to_string())],
+                cache: false,
+                reasoning_details: None,
+            },
+            LanguageModelRequestMessage {
+                role: Role::Assistant,
+                content: vec![
+                    MessageContent::Thinking {
+                        text: "thinking".to_string(),
+                        signature: Some("sig".to_string()),
+                    },
+                    MessageContent::Text("response".to_string()),
+                ],
+                cache: false,
+                reasoning_details: None,
+            },
+        ]);
+
+        let assistant_msg = result
+            .messages
+            .iter()
+            .find(|m| m.role == bedrock::BedrockRole::Assistant)
+            .expect("should have assistant message");
+
+        assert!(matches!(
+            assistant_msg.content[0],
+            BedrockInnerContent::ReasoningContent(_)
+        ));
+        assert!(matches!(
+            assistant_msg.content[1],
+            BedrockInnerContent::Text(_)
+        ));
     }
 }


### PR DESCRIPTION
### Problem

Long agent chat threads can accumulate malformed message data that causes Bedrock `ValidationException` errors. Two distinct bugs were identified, both reproduced against Bedrock. The Anthropic API likely has the same constraints but was not the source of the original errors.

**Bug 1 — Thinking block ordering after message merge**

`into_bedrock()` and `into_anthropic()` merge consecutive same-role messages by extending the last message's content array. When an incomplete/interrupted assistant response (text only, no thinking block) is followed by a complete response (thinking + text), the merge produces:

```
[Text("The"), Thinking("..."), Text("Full response")]
```

Both APIs require thinking blocks to come before all other content. Bedrock rejects this with:

> *"messages.N.content.0: If an assistant message contains any thinking blocks, the first block must be thinking or redacted_thinking. Found text."*

**Bug 2 — Orphaned tool results with no matching tool use**

`AgentMessage::to_request()` conditionally emits `ToolUse` blocks (only if they have a matching `tool_result`), but unconditionally emits all `tool_result` entries. When a `ToolUse` content block is lost during cancellation or an interrupted stream, its orphaned `tool_result` creates a count mismatch. Bedrock rejects this with:

> *"number of toolResult blocks at messages.N.content exceeds the number of toolUse blocks of previous turn."*

### Investigation

Thread data is stored in `~/Library/Application Support/Zed/threads/threads.db` as zstd-compressed JSON blobs. Extracting and inspecting with `jq` revealed the root causes.

**Bug 1:** Thread "Zod Infer vs Template Literal Types Tradeoffs" (`0ccd9860-...`). Message at index 53 was an interrupted 3-character response saved without its thinking block:

```
$ jq '.messages[53]' broken_thread.json
{
  "Agent": {
    "content": [{"Text": "The"}],
    "tool_results": {},
    "reasoning_details": null
  }
}
```

When `into_bedrock()` merges this with the next assistant message (which has thinking blocks), the text ends up before the thinking block, violating the API constraint.

**Bug 2:** Thread "Identifying Who Commits to Git Repo" (`7b8a52c2-...`). Message at index 135 had 4 `ToolUse` entries in `content` but 5 entries in `tool_results`:

```
$ jq '{
  content_tool_use_ids: [.messages[135].Agent.content[] |
    select(type == "object" and has("ToolUse")) | .ToolUse.id],
  tool_result_ids: (.messages[135].Agent.tool_results | keys)
}' broken_thread.json
{
  "content_tool_use_ids": [
    "tooluse_zi6Be3NTg26FfSoRiPiVs8",
    "tooluse_JEwViln0DjQwow6LfDMuE3",
    "tooluse_MwiJSm5kjiXcWLSkphe4nP",
    "tooluse_gGUQc6OVZwDhUDq88lC48j"
  ],
  "tool_result_ids": [
    "tooluse_JEwViln0DjQwow6LfDMuE3",
    "tooluse_MwiJSm5kjiXcWLSkphe4nP",
    "tooluse_gGUQc6OVZwDhUDq88lC48j",
    "tooluse_v26EzBOJAYNq55u3e74iuz",
    "tooluse_zi6Be3NTg26FfSoRiPiVs8"
  ]
}
```

The orphan `tooluse_v26EzBOJAYNq55u3e74iuz` exists in `tool_results` but has no matching `ToolUse` in `content` — likely lost during cancellation or an interrupted stream.

#### Manual rectification:

```shell
cat "$TMPDIR/broken_thread3.json" \
  | jq 'del(.messages[135].Agent.tool_results.tooluse_v26EzBOJAYNq55u3e74iuz)' \
  | zstd -3 -o "$TMPDIR/broken_thread3_fixed.zst" \
&& sqlite3 ~/Library/Application\ Support/Zed/threads/threads.db \
     "UPDATE threads SET data = readfile('$TMPDIR/broken_thread3_fixed.zst') WHERE id = '7b8a52c2-ae22-4946-a45e-45278ee17a21';"
```

### Fix

**Bug 1:** Added a stable sort post-processing step after the message collection loop in `into_bedrock()`, `into_anthropic()`, and `into_anthropic_count_tokens_request()`. This moves thinking/reasoning blocks to the front of assistant messages while preserving relative order within each group.

**Bug 2:** Track which `tool_use` IDs are actually emitted into the assistant message in `AgentMessage::to_request()`, then skip `tool_result` entries that don't have a matching `ToolUse` in the content.

### Relationship to #48002

PR #48002 (`d83d9d3e8c`) fixed one specific root cause of orphaned tool_results: `handle_tool_use_json_parse_error_event()` was creating a `tool_result` without adding the corresponding `ToolUse` to content. That fix addresses the **write path** for that one scenario.

This PR's Bug 2 fix is complementary — it's a **read path** defense in `to_request()` that catches orphans regardless of how they were created (cancellation, stream interruption, or any future code path). It also handles already-corrupted threads that were saved before #48002 landed.

### Testing

- `test_thinking_blocks_reordered_before_text_after_merge` (bedrock + anthropic)
- `test_thinking_block_order_preserved_when_already_correct` (bedrock)
- `test_redacted_thinking_blocks_also_reordered_before_text` (anthropic)
- `test_to_request_skips_orphaned_tool_results` (agent)

### Notes

- Both bugs were reproduced and diagnosed against **Bedrock**. The Anthropic fix is defensive — the same merging code path exists in `into_anthropic()` but the error was not observed there firsthand.
- Both bugs manifest only in long-running threads where interrupted responses or cancelled tool uses accumulate in the message history.

--

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:
- Fixed Bedrock API errors in long agent threads caused by thinking blocks appearing out of order after message merging
- Fixed API errors from orphaned tool results that no longer have a matching tool use in the conversation history
