### PR TITLE
Filter collection of snowflake requests to those with latest schemas

### DIFF
--- a/crates/edit_prediction/src/capture_example.rs
+++ b/crates/edit_prediction/src/capture_example.rs
@@ -155,6 +155,7 @@ pub fn capture_example(
                 events: captured_events,
                 related_files: captured_related_files,
                 in_open_source_repo: false,
+                zed_version: None,
             }
         });
 

--- a/crates/edit_prediction/src/example_spec.rs
+++ b/crates/edit_prediction/src/example_spec.rs
@@ -68,6 +68,8 @@ pub struct CapturedPromptInput {
     pub related_files: Vec<CapturedRelatedFile>,
     #[serde(default)]
     pub in_open_source_repo: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub zed_version: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Hash, Serialize, Deserialize)]


### PR DESCRIPTION
This allows us to just pull requests that have the latest EP request schema with the `predicted` boolean on events in the edit history.

Release Notes:

- N/A
