### PR TITLE
Some git worktree cleanups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,7 +180,6 @@ dependencies = [
  "gpui",
  "gpui_tokio",
  "handlebars 4.5.0",
- "heck 0.5.0",
  "html_to_markdown",
  "http_client",
  "indoc",

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -38,7 +38,7 @@ futures.workspace = true
 git.workspace = true
 gpui.workspace = true
 handlebars = { workspace = true, features = ["rust-embed"] }
-heck.workspace = true
+
 html_to_markdown.workspace = true
 http_client.workspace = true
 indoc.workspace = true

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -1396,19 +1396,12 @@ impl acp_thread::AgentConnection for NativeAgentConnection {
     fn set_title(
         &self,
         session_id: &acp::SessionId,
-        cx: &App,
+        _cx: &App,
     ) -> Option<Rc<dyn acp_thread::AgentSessionSetTitle>> {
-        self.0.read_with(cx, |agent, _cx| {
-            agent
-                .sessions
-                .get(session_id)
-                .filter(|s| !s.thread.read(cx).is_subagent())
-                .map(|session| {
-                    Rc::new(NativeAgentSessionSetTitle {
-                        thread: session.thread.clone(),
-                    }) as _
-                })
-        })
+        Some(Rc::new(NativeAgentSessionSetTitle {
+            connection: self.clone(),
+            session_id: session_id.clone(),
+        }) as _)
     }
 
     fn session_list(&self, cx: &mut App) -> Option<Rc<dyn AgentSessionList>> {
@@ -1567,13 +1560,17 @@ impl acp_thread::AgentSessionRetry for NativeAgentSessionRetry {
 }
 
 struct NativeAgentSessionSetTitle {
-    thread: Entity<Thread>,
+    connection: NativeAgentConnection,
+    session_id: acp::SessionId,
 }
 
 impl acp_thread::AgentSessionSetTitle for NativeAgentSessionSetTitle {
     fn run(&self, title: SharedString, cx: &mut App) -> Task<Result<()>> {
-        self.thread
-            .update(cx, |thread, cx| thread.set_title(title, cx));
+        let Some(session) = self.connection.0.read(cx).sessions.get(&self.session_id) else {
+            return Task::ready(Err(anyhow!("session not found")));
+        };
+        let thread = session.thread.clone();
+        thread.update(cx, |thread, cx| thread.set_title(title, cx));
         Task::ready(Ok(()))
     }
 }

--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -1828,11 +1828,11 @@ async fn test_mcp_tool_truncation(cx: &mut TestAppContext) {
         cx,
     );
 
-    // Server with spaces in name - tests snake_case conversion for API compatibility
+    // Server with spaces in name - tests disambiguation with server ID prefix
     let _server4_calls = setup_context_server(
         "Azure DevOps",
         vec![context_server::types::Tool {
-            name: "echo".into(), // Also conflicts - will be disambiguated as azure_dev_ops_echo
+            name: "echo".into(), // Also conflicts - will be disambiguated as Azure DevOps_echo
             description: None,
             input_schema: serde_json::to_value(EchoTool::input_schema(
                 LanguageModelToolSchemaFormat::JsonSchema,
@@ -1855,7 +1855,7 @@ async fn test_mcp_tool_truncation(cx: &mut TestAppContext) {
     assert_eq!(
         tool_names_for_completion(&completion),
         vec![
-            "azure_dev_ops_echo",
+            "Azure DevOps_echo",
             "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
             "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
             "delay",

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -32,7 +32,7 @@ use futures::{
 use gpui::{
     App, AppContext, AsyncApp, Context, Entity, EventEmitter, SharedString, Task, WeakEntity,
 };
-use heck::ToSnakeCase as _;
+
 use language_model::{
     LanguageModel, LanguageModelCompletionError, LanguageModelCompletionEvent, LanguageModelId,
     LanguageModelImage, LanguageModelProviderId, LanguageModelRegistry, LanguageModelRequest,
@@ -2525,14 +2525,14 @@ impl Thread {
         }
 
         // When there are duplicate tool names, disambiguate by prefixing them
-        // with the server ID (converted to snake_case for API compatibility).
-        // In the rare case there isn't enough space for the disambiguated tool
+        // with the server ID. In the rare case there isn't enough space for the
+        // disambiguated tool
         // name, keep only the last tool with this name.
         for (server_id, tool_name, tool) in context_server_tools {
             if duplicate_tool_names.contains(&tool_name) {
                 let available = MAX_TOOL_NAME_LENGTH.saturating_sub(tool_name.len());
                 if available >= 2 {
-                    let mut disambiguated = server_id.0.to_snake_case();
+                    let mut disambiguated = server_id.0.to_string();
                     disambiguated.truncate(available - 1);
                     disambiguated.push('_');
                     disambiguated.push_str(&tool_name);


### PR DESCRIPTION
Extracts three unrelated behavioral changes from #49139:
- Remove subagent filter from set_title (lazy session lookup)
- Remove snake_case conversion for MCP tool name disambiguation
- Remove dead heck dependency from agent crate

Split out to keep the worktree-directory PR focused.

Release Notes:

- N/A