### PR TITLE
feat: add RefreshProject action to project panel

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -307,6 +307,8 @@ actions!(
         CollapseSelectedEntryAndChildren,
         /// Collapses all entries in the project tree.
         CollapseAllEntries,
+        /// Refreshes the project tree to pick up external file changes.
+        RefreshProject,
         /// Creates a new directory.
         NewDirectory,
         /// Creates a new file.
@@ -1450,6 +1452,19 @@ impl ProjectPanel {
 
         self.update_visible_entries(Some((worktree_id, root_id)), false, false, window, cx);
         cx.notify();
+    }
+
+    fn refresh_project(
+        &mut self,
+        _: &RefreshProject,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let project = self.project.read(cx);
+        for worktree in project.visible_worktrees(cx) {
+            worktree.read(cx).add_path_prefix_to_scan(RelPath::empty());
+        }
+        self.update_visible_entries(None, false, false, window, cx);
     }
 
     fn collapse_all_entries(
@@ -6323,6 +6338,7 @@ impl Render for ProjectPanel {
                 .on_action(cx.listener(Self::expand_selected_entry))
                 .on_action(cx.listener(Self::collapse_selected_entry))
                 .on_action(cx.listener(Self::collapse_all_entries))
+                .on_action(cx.listener(Self::refresh_project))
                 .on_action(cx.listener(Self::collapse_selected_entry_and_children))
                 .on_action(cx.listener(Self::open))
                 .on_action(cx.listener(Self::open_permanent))


### PR DESCRIPTION
## Summary

This PR adds a manual "Refresh Project" action to the project panel that allows users to refresh the file tree to pick up external file changes without reloading the entire workspace.

This serves as a workaround for the file watcher issues described in #38109, where:
- Open buffers don't update when files change externally
- Project panel doesn't show new files created outside Zed
- Git panel shows stale state

## The Problem

The file watcher in Zed can occasionally miss external file changes due to:
- Linux inotify stale registrations
- Network filesystem issues (WSL, NFS, FUSE)
- The mtime race condition with external tools

When this happens, users currently need to either:
- Restart Zed entirely (which loses terminal state, agent sessions, etc.)
- Use "Workspace: Reload" which also closes all windows

## The Solution

Add a `RefreshProject` action that:
1. Scans all worktrees for external changes
2. Updates the project panel view
3. Doesn't affect terminal sessions, agents, or open windows

Users can trigger this action when they notice the project panel is out of sync.

## Changes

- `crates/project_panel/src/project_panel.rs`:
  - Add `RefreshProject` action to the actions list
  - Implement `refresh_project` handler that calls `add_path_prefix_to_scan` on all worktrees
  - Register the action handler

## Usage

The action can be triggered via the command palette (`Cmd+Shift+P` / `Ctrl+Shift+P`) or bound to a keyboard shortcut:

```json
{
  "key": "cmd+r",
  "context": "ProjectPanel"
}
```

## Test plan

- [ ] Create a file outside Zed (e.g., via terminal)
- [ ] Verify it doesn't appear in the project panel
- [ ] Run the RefreshProject action
- [ ] Verify the new file now appears

Related to #38109