### PR TITLE
terminal: use OSC-set title in tab label

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -2121,7 +2121,18 @@ impl Terminal {
             None => self
                 .title_override
                 .as_ref()
-                .map(|title_override| title_override.to_string())
+                .map(|s| s.to_string())
+                .or_else(|| {
+                    if !self.breadcrumb_text.is_empty() {
+                        Some(if truncate {
+                            truncate_and_trailoff(&self.breadcrumb_text, MAX_CHARS)
+                        } else {
+                            self.breadcrumb_text.clone()
+                        })
+                    } else {
+                        None
+                    }
+                })
                 .unwrap_or_else(|| match &self.terminal_type {
                     TerminalType::Pty { info, .. } => info
                         .current

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -1080,7 +1080,11 @@ fn subscribe_for_terminal_events(
                         cx,
                     ),
                 },
-                Event::BreadcrumbsChanged => cx.emit(ItemEvent::UpdateBreadcrumbs),
+                Event::BreadcrumbsChanged => {
+                    cx.notify();
+                    cx.emit(ItemEvent::UpdateTab);
+                    cx.emit(ItemEvent::UpdateBreadcrumbs);
+                }
                 Event::CloseTerminal => cx.emit(ItemEvent::CloseItem),
                 Event::SelectionsChanged => {
                     window.invalidate_character_coordinates();


### PR DESCRIPTION
## Summary

Zed's terminal already receives dynamic title updates from running programs via OSC 2 escape sequences (`\e]2;Title\007`). The title text is stored in `breadcrumb_text` and shown in the optional breadcrumbs toolbar, but never reaches the **tab label**.

Two minimal changes wire this up end-to-end:

**`crates/terminal/src/terminal.rs`** — insert `breadcrumb_text` into the `title()` priority chain between `title_override` and the PTY process-name fallback. The existing `truncate` flag is respected.

Priority chain (new):
1. Active task label
2. `title_override` (set at construction)
3. **`breadcrumb_text`** (OSC-set by running program) ← added
4. PTY process name + CWD basename
5. `"Terminal"` fallback

**`crates/terminal_view/src/terminal_view.rs`** — the `BreadcrumbsChanged` event handler previously only emitted `ItemEvent::UpdateBreadcrumbs`. It now also calls `cx.notify()` and emits `ItemEvent::UpdateTab`, so the tab label re-renders on every OSC title change.

## Test plan

- [ ] Open a terminal pane in Zed
- [ ] Run `printf '\033]2;Hello from OSC\007'` — tab label should change to `Hello from OSC`
- [ ] Run a program that sets titles dynamically (e.g. Claude Code, vim) — tab should update in real time
- [ ] Verify that `title_override` (e.g. shell-integration-set titles) still takes precedence over OSC titles
- [ ] Verify that task labels (spawned tasks) still take highest precedence

Closes #19996