### PR TITLE
acp: Update terminal tool call updates if we recieve a new one

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -314,6 +314,13 @@ impl ToolCall {
         }
 
         if let Some(title) = title {
+            if self.kind == acp::ToolKind::Execute {
+                for terminal in self.terminals() {
+                    terminal.update(cx, |terminal, cx| {
+                        terminal.update_command_label(&title, cx);
+                    });
+                }
+            }
             self.label.update(cx, |label, cx| {
                 if self.kind == acp::ToolKind::Execute {
                     label.replace(title, cx);

--- a/crates/acp_thread/src/terminal.rs
+++ b/crates/acp_thread/src/terminal.rs
@@ -167,6 +167,12 @@ impl Terminal {
         &self.command
     }
 
+    pub fn update_command_label(&self, label: &str, cx: &mut App) {
+        self.command.update(cx, |command, cx| {
+            command.replace(format!("```\n{}\n```", label), cx);
+        });
+    }
+
     pub fn working_dir(&self) -> &Option<PathBuf> {
         &self.working_dir
     }


### PR DESCRIPTION
This showed up mostly in agents that stream terminal output to Zed that
the title wasn't updated in time to see the command when needing to
provide permissions.

Release Notes:

- acp: Fix for ACP terminal titles not always being updated to their latest value.
