### PR TITLE
agent: Show toast when clicking file path outside project

### DIFF
--- a/crates/agent_ui/src/acp/thread_view/active_thread.rs
+++ b/crates/agent_ui/src/acp/thread_view/active_thread.rs
@@ -7452,6 +7452,22 @@ impl Render for AcpThreadView {
     }
 }
 
+fn show_path_outside_project_toast(
+    workspace: &mut Workspace,
+    path: &Path,
+    cx: &mut Context<Workspace>,
+) {
+    struct PathOutsideProjectToast;
+    workspace.show_toast(
+        Toast::new(
+            NotificationId::unique::<PathOutsideProjectToast>(),
+            format!("Cannot open path outside the project: {}", path.display()),
+        )
+        .autohide(),
+        cx,
+    );
+}
+
 pub(crate) fn open_link(
     url: SharedString,
     workspace: &WeakEntity<Workspace>,
@@ -7468,8 +7484,9 @@ pub(crate) fn open_link(
             MentionUri::File { abs_path } => {
                 let project = workspace.project();
                 let Some(path) =
-                    project.update(cx, |project, cx| project.find_project_path(abs_path, cx))
+                    project.update(cx, |project, cx| project.find_project_path(&abs_path, cx))
                 else {
+                    show_path_outside_project_toast(workspace, &abs_path, cx);
                     return;
                 };
 
@@ -7480,9 +7497,17 @@ pub(crate) fn open_link(
             MentionUri::PastedImage => {}
             MentionUri::Directory { abs_path } => {
                 let project = workspace.project();
+                let Some(project_path) =
+                    project.update(cx, |project, cx| project.find_project_path(&abs_path, cx))
+                else {
+                    show_path_outside_project_toast(workspace, &abs_path, cx);
+                    return;
+                };
+
                 let Some(entry_id) = project.update(cx, |project, cx| {
-                    let path = project.find_project_path(abs_path, cx)?;
-                    project.entry_for_path(&path, cx).map(|entry| entry.id)
+                    project
+                        .entry_for_path(&project_path, cx)
+                        .map(|entry| entry.id)
                 }) else {
                     return;
                 };
@@ -7501,13 +7526,14 @@ pub(crate) fn open_link(
                 line_range,
             } => {
                 let project = workspace.project();
-                let Some(path) =
-                    project.update(cx, |project, cx| project.find_project_path(path, cx))
+                let Some(project_path) =
+                    project.update(cx, |project, cx| project.find_project_path(&path, cx))
                 else {
+                    show_path_outside_project_toast(workspace, &path, cx);
                     return;
                 };
 
-                let item = workspace.open_path(path, None, true, window, cx);
+                let item = workspace.open_path(project_path, None, true, window, cx);
                 window
                     .spawn(cx, async move |cx| {
                         let Some(editor) = item.await?.downcast::<Editor>() else {


### PR DESCRIPTION
When clicking a file or directory link in the agent panel that points to a path outside the project's worktrees (e.g., files in `~/.claude/` or `/tmp/`), the click was silently ignored with no feedback to the user.

## Changes

- Add `show_path_outside_project_toast()` helper that shows an auto-hiding toast: "Cannot open path outside the project: /path/to/file"
- Show the toast for `File`, `Directory`, and `Symbol`/`Selection` link types when `find_project_path` returns `None`
- Split the `Directory` branch so the toast only fires for paths outside the project (not when the entry exists in the project but can't be found)

## Testing

Manually verified by:
1. Starting a Claude Code session in Zed with a project open
2. Having the agent reference files outside the project (e.g., `~/.claude/settings.json`)
3. Clicking the file link → toast notification appears and auto-hides
4. Clicking file links inside the project → still opens normally

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [ ] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Fixed silent failure when clicking file paths outside the project in the agent panel; a toast notification is now shown.