### PR TITLE
prompts: Require recovery correctness in crash workflows

### DIFF
--- a/.factory/prompts/crash/fix.md
+++ b/.factory/prompts/crash/fix.md
@@ -1,6 +1,6 @@
 # Crash Fix
 
-You are fixing a crash that has been analyzed and has a reproduction test case. Your goal is to implement a minimal, correct fix that resolves the root cause and makes the reproduction test pass.
+You are fixing a crash that has been analyzed and has a reproduction test case (or a validated manual reproduction when automation is not feasible). Your goal is to implement a minimal, correct fix that resolves the root cause and preserves user-visible correctness.
 
 ## Inputs
 
@@ -8,6 +8,8 @@ Before starting, you should have:
 
 1. **ANALYSIS.md** — the crash analysis from the investigation phase. Read it thoroughly.
 2. **A failing test** — a reproduction test that triggers the crash. Run it first to confirm it fails as expected.
+
+If deterministic automated reproduction is not feasible (for example: GPU device loss, driver resets, OS-level events), require a concrete manual validation protocol with expected outcomes before and after the fix.
 
 If either is missing, ask the user to provide them or run the investigation phase first (`/prompt crash/investigate`).
 
@@ -29,12 +31,14 @@ Read the "Suggested Fix" section of ANALYSIS.md and the relevant source code. Be
 
 1. **What invariant is being violated** — what property of the data does the crashing code assume?
 2. **Where the invariant breaks** — which function produces the bad state?
+3. **What correctness must be preserved** — define acceptance criteria beyond "no crash" (for example: no corrupted frame, no stale content, successful recovery on the next render cycle).
 
 ### Step 3: Implement the Fix
 
 Apply the minimal change needed to resolve the root cause. Guidelines:
 
 - **Fix the root cause, not the symptom.** Don't just catch the panic with a bounds check if the real problem is an incorrect offset calculation. Fix the calculation.
+- **Do not trade crashes for corrupted output.** If state becomes invalid for the current frame, prefer dropping/invalidating that frame and forcing a full rerender instead of partially drawing with missing resources.
 - **Preserve existing behavior** for all non-crashing cases. The fix should only change what happens in the scenario that was previously crashing.
 - **Don't add unnecessary changes.** No drive-by improvements, keep the diff focused.
 - **Add a comment only if the fix is non-obvious.** If a reader might wonder "why is this check here?", a brief comment explaining the crash scenario is appropriate.
@@ -56,6 +60,14 @@ cargo test -p <crate>
 
 If any tests fail, determine whether the fix introduced a regression. Fix regressions before proceeding.
 
+Also verify the user-visible behavior in the reproduced scenario:
+
+- No crash
+- No corrupted/partially rendered frame
+- Recovery path completes (for example, next forced render repopulates needed resources)
+
+When the scenario depends on external hardware/OS behavior, document exact manual verification steps and observed results.
+
 ### Step 5: Run Clippy
 
 ```
@@ -70,7 +82,7 @@ Write a brief summary of the fix for use in a PR description. Include:
 
 - **What was the bug** — one sentence on the root cause.
 - **What the fix does** — one sentence on the change.
-- **How it was verified** — note that the reproduction test now passes.
+- **How it was verified** — note test results and any manual validation performed for non-deterministic scenarios.
 - **Sentry issue link** — if available from ANALYSIS.md.
 
 We use the following template for pull request descriptions. Please add information to answer the relevant sections, especially for release notes.

--- a/.factory/prompts/crash/investigate.md
+++ b/.factory/prompts/crash/investigate.md
@@ -43,6 +43,8 @@ Work backwards from the crash site to determine **what sequence of events or dat
 
 Ask yourself: *What user action or sequence of actions could lead to this state?* The crash came from a real user, so there is some natural usage pattern that triggers it.
 
+Also identify whether a naive guard (for example, returning early on missing data) would cause degraded behavior such as corrupted UI, stale state, or dropped functionality. Call this out explicitly so the fix phase can avoid "no crash but broken output" regressions.
+
 ### Step 4: Write a Reproduction Test
 
 Write a minimal test case that:
@@ -52,6 +54,8 @@ Write a minimal test case that:
 3. **Is minimal** — include only what's necessary to trigger the crash. Remove anything that isn't load-bearing.
 4. **Lives in the right place** — add the test to the existing test module of the crate where the bug lives. Follow the existing test patterns in that module.
 5. **Avoid overly verbose comments** - the test should be self-explanatory and concise. More detailed descriptions of the test can go in ANALYSIS.md (see the next section).
+
+If fully automated reproduction is not feasible (hardware/driver/OS-triggered crashes), provide a deterministic manual reproduction protocol with expected before/after outcomes and any observability signals (logs, screenshots, visible artifacts).
 
 When the test fails, its stack trace should share the key application frames from the original crash report. The outermost frames (crash handler, signal handling) will differ since we're in a test environment — that's expected.
 
@@ -80,6 +84,11 @@ Include the exact command to run the test, e.g.:
 ## Suggested Fix
 <Describe the fix approach. Be specific: which function, what check to add,
 what computation to change. If there are multiple options, list them with tradeoffs.>
+
+## Fix Acceptance Criteria
+- No crash in the reproduced scenario
+- No user-visible corruption/degradation introduced by the mitigation
+- Recovery behavior is explicit and testable (automated or manual)
 ```
 
 ## Guidelines

--- a/crates/gpui/.rules
+++ b/crates/gpui/.rules
@@ -1,0 +1,15 @@
+# GPUI crate-specific rules
+#
+# This file is non-exhaustive. Check the root .rules for general guidelines.
+
+# Platform callbacks
+
+* Platform callbacks (e.g., `on_keyboard_layout_change`, `on_thermal_state_change`) can fire
+  asynchronously from macOS while `AppCell` is already borrowed. Defer work via
+  `ForegroundExecutor::spawn` rather than borrowing `AppCell` directly in the callback body.
+
+# Windows device-lost rendering
+
+* During Windows GPU device-loss recovery, only call `DirectXRenderer::mark_drawable()` when
+  handling the forced redraw path (`force_render = true`). Calling it on regular paint events can
+  render stale scene batches against a cleared atlas, leading to crashes or corrupted frames.


### PR DESCRIPTION
## Summary
- tighten .factory/prompts/crash/fix.md to require user-visible correctness checks (not just crash elimination), especially for non-deterministic GPU/OS scenarios
- tighten .factory/prompts/crash/investigate.md to explicitly call out crash-only mitigations that can still leave corrupted/stale output
- add a gpui rule covering Windows device-loss recovery (mark_drawable only on forced redraw)

## Why
A recent reviewer note pointed out that a crash fix could still leave a corrupted window. These prompt/rule changes are meant to steer future crash work toward full recovery correctness, not only panic avoidance.

Release Notes:
- N/A