### PR TITLE
editor: More perf work

### DIFF
--- a/crates/buffer_diff/src/buffer_diff.rs
+++ b/crates/buffer_diff/src/buffer_diff.rs
@@ -914,28 +914,25 @@ impl BufferDiffInner<language::BufferSnapshot> {
         buffer: &'a text::BufferSnapshot,
         secondary: Option<&'a Self>,
     ) -> impl 'a + Iterator<Item = DiffHunk> {
-        let mut cursor = self.hunks.filter::<_, DiffHunkSummary>(buffer, filter);
-
-        let anchor_iter = iter::from_fn(move || {
-            cursor.next();
-            cursor.item()
-        })
-        .flat_map(move |hunk| {
-            [
-                (
-                    &hunk.buffer_range.start,
+        let anchor_iter = self
+            .hunks
+            .filter::<_, DiffHunkSummary>(buffer, filter)
+            .flat_map(move |hunk| {
+                [
                     (
-                        hunk.buffer_range.start,
-                        hunk.diff_base_byte_range.start,
-                        hunk,
+                        &hunk.buffer_range.start,
+                        (
+                            hunk.buffer_range.start,
+                            hunk.diff_base_byte_range.start,
+                            hunk,
+                        ),
                     ),
-                ),
-                (
-                    &hunk.buffer_range.end,
-                    (hunk.buffer_range.end, hunk.diff_base_byte_range.end, hunk),
-                ),
-            ]
-        });
+                    (
+                        &hunk.buffer_range.end,
+                        (hunk.buffer_range.end, hunk.diff_base_byte_range.end, hunk),
+                    ),
+                ]
+            });
 
         let mut pending_hunks_cursor = self.pending_hunks.cursor::<DiffHunkSummary>(buffer);
         pending_hunks_cursor.next();

--- a/crates/clock/src/clock.rs
+++ b/crates/clock/src/clock.rs
@@ -66,11 +66,25 @@ pub struct Lamport {
 }
 
 /// A [version vector](https://en.wikipedia.org/wiki/Version_vector).
-#[derive(Clone, Default, Hash, Eq, PartialEq)]
+#[derive(Default, Hash, Eq, PartialEq)]
 pub struct Global {
     // 4 is chosen as it is the biggest count that does not increase the size of the field itself.
     // Coincidentally, it also covers all the important non-collab replica ids.
     values: SmallVec<[u32; 4]>,
+}
+
+impl Clone for Global {
+    fn clone(&self) -> Self {
+        // We manually implement clone to avoid the overhead of SmallVec's clone implementation.
+        // Using `from_slice` is faster than `clone` for SmallVec as we can use our `Copy` implementation of u32.
+        Self {
+            values: SmallVec::from_slice(&self.values),
+        }
+    }
+
+    fn clone_from(&mut self, source: &Self) {
+        self.values.clone_from(&source.values);
+    }
 }
 
 impl Global {

--- a/crates/editor/src/split.rs
+++ b/crates/editor/src/split.rs
@@ -2013,13 +2013,13 @@ impl LhsEditor {
         diff: Entity<BufferDiff>,
         lhs_cx: &mut Context<MultiBuffer>,
     ) -> Option<(Vec<ExcerptId>, Vec<Vec<ExcerptId>>)> {
-        let rhs_excerpt_ids: Vec<ExcerptId> =
-            rhs_multibuffer.excerpts_for_path(&path_key).collect();
-
         let Some(excerpt_id) = rhs_multibuffer.excerpts_for_path(&path_key).next() else {
             lhs_multibuffer.remove_excerpts_for_path(path_key, lhs_cx);
             return None;
         };
+
+        let rhs_excerpt_ids: Vec<ExcerptId> =
+            rhs_multibuffer.excerpts_for_path(&path_key).collect();
 
         let rhs_multibuffer_snapshot = rhs_multibuffer.snapshot(lhs_cx);
         let main_buffer = rhs_multibuffer_snapshot

--- a/crates/multi_buffer/src/path_key.rs
+++ b/crates/multi_buffer/src/path_key.rs
@@ -57,7 +57,7 @@ impl MultiBuffer {
         self.excerpts_by_path
             .get(path)
             .map(|excerpts| excerpts.as_slice())
-            .unwrap_or(&[])
+            .unwrap_or_default()
             .iter()
             .copied()
     }


### PR DESCRIPTION
Seems that `SmallVec::clone` is pretty expensive in a generic case, and specialising it improves the performance quite a bit!

Release Notes:

- Improved performance of different building blocks within the MultiBuffer.
