### PR TITLE
terminal: Show actionable notification for remote bell events

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -2091,6 +2091,10 @@ impl Terminal {
         }
     }
 
+    pub fn is_remote_terminal(&self) -> bool {
+        self.is_remote_terminal
+    }
+
     /// Returns the working directory of the process that's connected to the PTY.
     /// That means it returns the working directory of the local shell or program
     /// that's running inside the terminal.

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -55,6 +55,7 @@ use workspace::{
     item::{
         BreadcrumbText, Item, ItemEvent, SerializableItem, TabContentParams, TabTooltipContent,
     },
+    notifications::{NotificationId, simple_message_notification::MessageNotification},
     register_serializable_item,
     searchable::{
         Direction, SearchEvent, SearchOptions, SearchToken, SearchableItem, SearchableItemHandle,
@@ -193,6 +194,8 @@ struct HoverTarget {
 impl EventEmitter<Event> for TerminalView {}
 impl EventEmitter<ItemEvent> for TerminalView {}
 impl EventEmitter<SearchEvent> for TerminalView {}
+
+struct RemoteTerminalBellNotification;
 
 impl Focusable for TerminalView {
     fn focus_handle(&self, _cx: &App) -> FocusHandle {
@@ -999,6 +1002,37 @@ fn subscribe_for_terminal_events(
 
                 Event::Bell => {
                     terminal_view.has_bell = true;
+                    if terminal.read(cx).is_remote_terminal()
+                        && !terminal_view.focus_handle.is_focused(window)
+                    {
+                        let terminal_title = terminal.read(cx).title(true);
+                        let notification_id =
+                            NotificationId::composite::<RemoteTerminalBellNotification>(
+                                terminal.entity_id().as_u64().to_string(),
+                            );
+                        let terminal_focus_handle = terminal_view.focus_handle.clone();
+                        if let Some(workspace) = workspace.upgrade() {
+                            workspace
+                                .update(cx, |workspace, cx| {
+                                    workspace.show_notification(notification_id, cx, move |cx| {
+                                        let terminal_focus_handle = terminal_focus_handle.clone();
+                                        let terminal_title = terminal_title.clone();
+                                        cx.new(move |cx| {
+                                            MessageNotification::new(
+                                                format!("Remote terminal alert: {terminal_title}"),
+                                                cx,
+                                            )
+                                            .primary_message("Focus Terminal")
+                                            .primary_on_click(move |window, cx| {
+                                                terminal_focus_handle.focus(window, cx);
+                                            })
+                                            .show_suppress_button(false)
+                                        })
+                                    });
+                                })
+                                .ok();
+                        }
+                    }
                     cx.emit(Event::Wakeup);
                 }
 


### PR DESCRIPTION
## Summary
- add `Terminal::is_remote_terminal()` accessor
- when a remote terminal emits `Bell` and the terminal is unfocused, show a workspace notification
- notification includes an action button (`Focus Terminal`) that returns focus to that terminal

This is a practical first step for remote SSH workflows where long-running agent tasks can emit `BEL` on completion.

Fixes #49468

## Testing
- `cargo check -p terminal_view` *(fails in this VPS env because system `x11.pc` is missing)*
- functional behavior verified by code path inspection in `Event::Bell` handling
