### PR TITLE
feature_flags: Remove `acp-beta` feature flag

### DIFF
--- a/crates/feature_flags/src/flags.rs
+++ b/crates/feature_flags/src/flags.rs
@@ -22,12 +22,6 @@ impl FeatureFlag for AgentV2FeatureFlag {
     }
 }
 
-pub struct AcpBetaFeatureFlag;
-
-impl FeatureFlag for AcpBetaFeatureFlag {
-    const NAME: &'static str = "acp-beta";
-}
-
 pub struct AgentSharingFeatureFlag;
 
 impl FeatureFlag for AgentSharingFeatureFlag {


### PR DESCRIPTION
This PR removes the `acp-beta` feature flag.

The last usages of it were removed in https://github.com/zed-industries/zed/pull/49449.

Release Notes:

- N/A
