### PR TITLE
feature_flags: Add note about `acp-beta` feature flag

### DIFF
--- a/crates/feature_flags/src/flags.rs
+++ b/crates/feature_flags/src/flags.rs
@@ -22,6 +22,9 @@ impl FeatureFlag for AgentV2FeatureFlag {
     }
 }
 
+/// A feature flag for granting access to beta ACP features.
+///
+/// We reuse this feature flag for new betas, so don't delete it if it is not currently in use.
 pub struct AcpBetaFeatureFlag;
 
 impl FeatureFlag for AcpBetaFeatureFlag {


### PR DESCRIPTION
This PR adds a note to the `acp-beta` feature flag about how it is used, and that it should not be deleted if unreferenced.

Release Notes:

- N/A
