### PR TITLE
agent_ui: Route agent thread feedback comments through cloud

### DIFF
--- a/crates/cloud_api_client/src/cloud_api_client.rs
+++ b/crates/cloud_api_client/src/cloud_api_client.rs
@@ -207,6 +207,34 @@ impl CloudApiClient {
         Ok(())
     }
 
+    pub async fn submit_agent_feedback_comments(
+        &self,
+        body: SubmitAgentThreadFeedbackCommentsBody,
+    ) -> Result<()> {
+        let request = self.build_request(
+            Request::builder().method(Method::POST).uri(
+                self.http_client
+                    .build_zed_cloud_url("/client/feedback/agent_thread_comments")?
+                    .as_ref(),
+            ),
+            AsyncBody::from(serde_json::to_string(&body)?),
+        )?;
+
+        let mut response = self.http_client.send(request).await?;
+
+        if !response.status().is_success() {
+            let mut body = String::new();
+            response.body_mut().read_to_string(&mut body).await?;
+
+            anyhow::bail!(
+                "Failed to submit agent feedback comments.\nStatus: {:?}\nBody: {body}",
+                response.status()
+            )
+        }
+
+        Ok(())
+    }
+
     pub async fn submit_edit_prediction_feedback(
         &self,
         body: SubmitEditPredictionFeedbackBody,

--- a/crates/cloud_api_types/src/cloud_api_types.rs
+++ b/crates/cloud_api_types/src/cloud_api_types.rs
@@ -67,6 +67,15 @@ pub struct SubmitAgentThreadFeedbackBody {
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct SubmitAgentThreadFeedbackCommentsBody {
+    pub organization_id: Option<OrganizationId>,
+    pub agent: String,
+    pub session_id: String,
+    pub comments: String,
+    pub thread: serde_json::Value,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct SubmitEditPredictionFeedbackBody {
     pub organization_id: Option<OrganizationId>,
     pub request_id: String,


### PR DESCRIPTION
The agent thread feedback comments event was still going through the standard telemetry pipeline. This routes it through cloud instead, as was just done for agent thread rated and edit prediction rated, so we can enforce organization data and privacy settings.

Part of CLO-297