### PR TITLE
Seperate throttles for jump and edit based predictions

### DIFF
--- a/crates/edit_prediction/src/edit_prediction.rs
+++ b/crates/edit_prediction/src/edit_prediction.rs
@@ -1897,14 +1897,14 @@ impl EditPredictionStore {
 
         let inputs = EditPredictionModelInput {
             project: project.clone(),
-            buffer: active_buffer.clone(),
-            snapshot: snapshot.clone(),
+            buffer: active_buffer,
+            snapshot: snapshot,
             position,
             events,
             related_files,
             recent_paths: project_state.recent_paths.clone(),
             trigger,
-            diagnostic_search_range: diagnostic_search_range.clone(),
+            diagnostic_search_range: diagnostic_search_range,
             debug_tx,
             user_actions,
         };

--- a/crates/edit_prediction/src/edit_prediction.rs
+++ b/crates/edit_prediction/src/edit_prediction.rs
@@ -142,8 +142,6 @@ pub struct EditPredictionStore {
     reject_predictions_tx: mpsc::UnboundedSender<EditPredictionRejection>,
     shown_predictions: VecDeque<EditPrediction>,
     rated_predictions: HashSet<EditPredictionId>,
-    #[cfg(test)]
-    throttle_timeout_override: Option<Duration>,
 }
 
 #[derive(Copy, Clone, Default, PartialEq, Eq)]
@@ -704,8 +702,6 @@ impl EditPredictionStore {
             reject_predictions_tx: reject_tx,
             rated_predictions: Default::default(),
             shown_predictions: Default::default(),
-            #[cfg(test)]
-            throttle_timeout_override: None,
         };
 
         this
@@ -728,20 +724,6 @@ impl EditPredictionStore {
 
     pub fn zeta2_raw_config(&self) -> Option<&Zeta2RawConfig> {
         self.zeta2_raw_config.as_ref()
-    }
-
-    #[cfg(test)]
-    pub fn set_throttle_timeout_override(&mut self, duration: Duration) {
-        self.throttle_timeout_override = Some(duration);
-    }
-
-    fn throttle_timeout(&self) -> Duration {
-        #[cfg(test)]
-        return self
-            .throttle_timeout_override
-            .unwrap_or(Self::THROTTLE_TIMEOUT);
-        #[cfg(not(test))]
-        return Self::THROTTLE_TIMEOUT;
     }
 
     pub fn icons(&self) -> edit_prediction_types::EditPredictionIconSet {
@@ -1660,10 +1642,7 @@ impl EditPredictionStore {
         true
     }
 
-    #[cfg(not(test))]
     pub const THROTTLE_TIMEOUT: Duration = Duration::from_millis(300);
-    #[cfg(test)]
-    pub const THROTTLE_TIMEOUT: Duration = Duration::ZERO;
 
     fn queue_prediction_refresh(
         &mut self,
@@ -1693,7 +1672,7 @@ impl EditPredictionStore {
         let is_ollama = self.edit_prediction_model == EditPredictionModel::Ollama;
         let drop_on_cancel = is_ollama;
         let max_pending_predictions = if is_ollama { 1 } else { 2 };
-        let throttle_timeout = self.throttle_timeout();
+        let throttle_timeout = Self::THROTTLE_TIMEOUT;
         let project_state = self.get_or_init_project(&project, cx);
         let pending_prediction_id = project_state.next_pending_prediction_id;
         project_state.next_pending_prediction_id += 1;

--- a/crates/edit_prediction/src/edit_prediction_tests.rs
+++ b/crates/edit_prediction/src/edit_prediction_tests.rs
@@ -1378,9 +1378,6 @@ async fn test_cancel_second_on_third_request(cx: &mut TestAppContext) {
 #[gpui::test]
 async fn test_jump_and_edit_throttles_are_independent(cx: &mut TestAppContext) {
     let (ep_store, mut requests) = init_test_with_fake_client(cx);
-    ep_store.update(cx, |ep_store, _cx| {
-        ep_store.set_throttle_timeout_override(Duration::from_millis(200));
-    });
 
     let fs = FakeFs::new(cx.executor());
     fs.insert_tree(
@@ -1473,7 +1470,7 @@ async fn test_jump_and_edit_throttles_are_independent(cx: &mut TestAppContext) {
 
     // Wait for both throttles to expire.
     cx.background_executor
-        .advance_clock(Duration::from_millis(250));
+        .advance_clock(EditPredictionStore::THROTTLE_TIMEOUT);
     cx.background_executor.run_until_parked();
     cx.run_until_parked();
 

--- a/crates/edit_prediction/src/edit_prediction_tests.rs
+++ b/crates/edit_prediction/src/edit_prediction_tests.rs
@@ -1406,6 +1406,14 @@ async fn test_jump_and_edit_throttles_are_independent(cx: &mut TestAppContext) {
         ep_store.register_buffer(&buffer, &project, cx);
     });
 
+    // First edit request - no prior edit, so not throttled.
+    ep_store.update(cx, |ep_store, cx| {
+        ep_store.refresh_prediction_from_buffer(project.clone(), buffer.clone(), position, cx);
+    });
+    let (_edit_request, edit_response_tx) = requests.predict.next().await.unwrap();
+    edit_response_tx.send(empty_response()).unwrap();
+    cx.run_until_parked();
+
     let diagnostic = lsp::Diagnostic {
         range: lsp::Range::new(lsp::Position::new(1, 1), lsp::Position::new(1, 5)),
         severity: Some(lsp::DiagnosticSeverity::ERROR),
@@ -1413,6 +1421,7 @@ async fn test_jump_and_edit_throttles_are_independent(cx: &mut TestAppContext) {
         ..Default::default()
     };
 
+    // First jump request triggered by diagnostic event on buffer - no prior jump, so not throttled (independent from edit).
     project.update(cx, |project, cx| {
         project.lsp_store().update(cx, |lsp_store, cx| {
             lsp_store
@@ -1430,23 +1439,6 @@ async fn test_jump_and_edit_throttles_are_independent(cx: &mut TestAppContext) {
                 )
                 .unwrap();
         });
-    });
-
-    // First edit request - no prior edit, so not throttled.
-    ep_store.update(cx, |ep_store, cx| {
-        ep_store.refresh_prediction_from_buffer(project.clone(), buffer.clone(), position, cx);
-    });
-    let (_edit_request, edit_response_tx) = requests.predict.next().await.unwrap();
-    edit_response_tx.send(empty_response()).unwrap();
-    cx.run_until_parked();
-
-    // First jump request - no prior jump, so not throttled (independent from edit).
-    ep_store.update(cx, |ep_store, cx| {
-        ep_store.refresh_prediction_from_diagnostics(
-            project.clone(),
-            DiagnosticSearchScope::Global,
-            cx,
-        );
     });
     let (_jump_request, jump_response_tx) = requests.predict.next().await.unwrap();
     jump_response_tx.send(empty_response()).unwrap();


### PR DESCRIPTION
Closes #ISSUE

Before you mark this PR as ready for review, make sure that you have:
- [ ] Added a solid test coverage and/or screenshots from doing manual testing
- [ ] Done a self-review taking into account security and performance aspects
- [ ] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- N/A *or* Added/Fixed/Improved ...
