### PR TITLE
Save tool permission regex edits on blur

### DIFF
--- a/crates/settings_ui/src/pages.rs
+++ b/crates/settings_ui/src/pages.rs
@@ -8,7 +8,7 @@ pub(crate) use audio_input_output_setup::{
 };
 pub(crate) use audio_test_window::open_audio_test_window;
 pub(crate) use edit_prediction_provider_setup::render_edit_prediction_setup_page;
-pub(crate) use tool_permissions_setup::render_tool_permissions_setup_page;
+pub(crate) use tool_permissions_setup::{render_tool_permissions_setup_page, save_pattern};
 
 pub use tool_permissions_setup::{
     render_copy_path_tool_config, render_create_directory_tool_config,

--- a/crates/settings_ui/src/pages/tool_permissions_setup.rs
+++ b/crates/settings_ui/src/pages/tool_permissions_setup.rs
@@ -979,6 +979,7 @@ fn render_user_pattern_row(
         .tab_index(0)
         .with_buffer_font()
         .color(Color::Default)
+        .confirm_on_blur()
         .action_slot(
             IconButton::new(delete_id, IconName::Trash)
                 .icon_size(IconSize::Small)


### PR DESCRIPTION
When editing an existing regex pattern in the tool permissions settings UI, the change now saves when the input field loses focus (e.g. tabbing away), not only when pressing Enter.

This leverages the existing reconciliation check in `SettingsInputField` that detects when the editor text differs from the initial text while unfocused. When `confirm_on_blur` is enabled, instead of resetting the text, we defer the confirm callback to save the change. The deferred callback runs after the current render cycle completes, avoiding re-entrancy issues with the `SettingsWindow` entity.

Closes AI-42

Release Notes:

- Fixed tool permission regex edits in settings not saving when tabbing away; they now save on blur in addition to pressing Enter.