### PR TITLE
cloud_llm_client: Delete unused variants of CompletionRequestStatus

### DIFF
--- a/crates/cloud_llm_client/src/cloud_llm_client.rs
+++ b/crates/cloud_llm_client/src/cloud_llm_client.rs
@@ -222,11 +222,6 @@ pub enum CompletionRequestStatus {
         /// Retry duration in seconds.
         retry_after: Option<f64>,
     },
-    UsageUpdated {
-        amount: usize,
-        limit: UsageLimit,
-    },
-    ToolUseLimitReached,
     /// The cloud sends a StreamEnded message when the stream from the LLM provider finishes.
     StreamEnded,
     #[serde(other)]

--- a/crates/language_model/src/language_model.rs
+++ b/crates/language_model/src/language_model.rs
@@ -111,10 +111,6 @@ impl LanguageModelCompletionEvent {
             }
             CompletionRequestStatus::Started => Ok(Some(LanguageModelCompletionEvent::Started)),
             CompletionRequestStatus::Unknown | CompletionRequestStatus::StreamEnded => Ok(None),
-            CompletionRequestStatus::UsageUpdated { .. }
-            | CompletionRequestStatus::ToolUseLimitReached => Err(
-                LanguageModelCompletionError::Other(anyhow!("Unexpected status: {status:?}")),
-            ),
             CompletionRequestStatus::Failed {
                 code,
                 message,


### PR DESCRIPTION
Small clean up commit.

Co-authored-by: Marshall <marshall@zed.dev>

Release Notes:

- N/A