### PR TITLE
Fix shell quoting and gh auth in docs suggestions workflow

### DIFF
--- a/.github/workflows/docs_suggestions.yml
+++ b/.github/workflows/docs_suggestions.yml
@@ -94,6 +94,9 @@ jobs:
       - name: Analyze PR for documentation needs
         id: analyze
         run: |
+          # Ensure gh CLI is authenticated (GH_TOKEN may not be auto-detected)
+          echo "$GH_TOKEN" | gh auth login --with-token
+          
           OUTPUT_FILE=$(mktemp)
           
           ./script/docs-suggest \
@@ -119,12 +122,12 @@ jobs:
 
       - name: Commit suggestions to queue branch
         if: steps.analyze.outputs.has_suggestions == 'true'
+        env:
+          PR_NUM: ${{ steps.pr.outputs.number }}
+          PR_TITLE: ${{ steps.pr.outputs.title }}
+          OUTPUT_FILE: ${{ steps.analyze.outputs.output_file }}
         run: |
           set -euo pipefail
-          
-          PR_NUM="${{ steps.pr.outputs.number }}"
-          PR_TITLE="${{ steps.pr.outputs.title }}"
-          OUTPUT_FILE="${{ steps.analyze.outputs.output_file }}"
           
           # Configure git
           git config user.name "github-actions[bot]"
@@ -264,6 +267,9 @@ jobs:
       - name: Analyze PR for documentation needs
         id: analyze
         run: |
+          # Ensure gh CLI is authenticated (GH_TOKEN may not be auto-detected)
+          echo "$GH_TOKEN" | gh auth login --with-token
+          
           OUTPUT_FILE=$(mktemp)
           
           # Cherry-picks don't get preview callout


### PR DESCRIPTION
Fixes two issues in the documentation suggestions workflow:

1. **Shell quoting bug**: PR titles containing quotes (e.g., `agent_ui: Add the ability to undo "reject all"`) were breaking the shell script because the title was substituted directly into the script. Moved `PR_TITLE`, `PR_NUM`, and `OUTPUT_FILE` to environment variables where special characters are handled safely.

2. **GH CLI auth issue**: The `gh` CLI sometimes fails to auto-detect `GH_TOKEN` in the environment, causing `gh pr view` and `gh pr diff` to fail with "Bad credentials". Added explicit `gh auth login --with-token` in both the batch-suggestions and cherry-pick-suggestions jobs.

Release Notes:

- N/A