### PR TITLE
workspace: Display remote projects correctly

### DIFF
--- a/crates/workspace/src/welcome.rs
+++ b/crates/workspace/src/welcome.rs
@@ -329,8 +329,14 @@ impl WelcomePage {
                     .unwrap_or_else(|| "Untitled".to_string());
                 (IconName::Folder, name)
             }
-            SerializedWorkspaceLocation::Remote(_) => {
-                (IconName::Server, "Remote Project".to_string())
+            SerializedWorkspaceLocation::Remote(connection_options) => {
+                let path = paths.paths().first().map(|p| p.as_path());
+                let project_name = path
+                    .and_then(|p| p.file_name())
+                    .map(|n| n.to_string_lossy().to_string())
+                    .unwrap_or_else(|| "Remote Project".to_string());
+                let name = format!("{} ({})", project_name, connection_options.display_name());
+                (IconName::Server, name)
             }
         };
 


### PR DESCRIPTION
Display the remote project directory name along with the server’s display name, instead of showing only “Remote Project” for all remote workspaces.

Closes #49418.

Before you mark this PR as ready for review, make sure that you have:
- [ ] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Fixed an issue where remote projects were always labeled “Remote Projects” on the welcome screen
