### PR TITLE
linux: Fix RefCell crash when creating workspace

### DIFF
--- a/crates/workspace/src/multi_workspace.rs
+++ b/crates/workspace/src/multi_workspace.rs
@@ -423,20 +423,33 @@ impl MultiWorkspace {
         if !self.multi_workspace_enabled(cx) {
             return;
         }
+
+        // Clone app_state before spawning since we can't access self in async context
         let app_state = self.workspace().read(cx).app_state().clone();
-        let project = Project::local(
-            app_state.client.clone(),
-            app_state.node_runtime.clone(),
-            app_state.user_store.clone(),
-            app_state.languages.clone(),
-            app_state.fs.clone(),
-            None,
-            project::LocalProjectFlags::default(),
-            cx,
-        );
-        let new_workspace = cx.new(|cx| Workspace::new(None, project, app_state, window, cx));
-        self.activate(new_workspace, cx);
-        self.focus_active_workspace(window, cx);
+
+        // Spawn async task with window context to create workspace.
+        // This avoids RefCell borrow conflict on Linux where the window's
+        // Callbacks RefCell may be borrowed during event processing.
+        cx.spawn_in(window, async move |this, cx| {
+            this.update_in(cx, |this, window, cx| {
+                let project = Project::local(
+                    app_state.client.clone(),
+                    app_state.node_runtime.clone(),
+                    app_state.user_store.clone(),
+                    app_state.languages.clone(),
+                    app_state.fs.clone(),
+                    None,
+                    project::LocalProjectFlags::default(),
+                    cx,
+                );
+                let new_workspace =
+                    cx.new(|cx| Workspace::new(None, project, app_state, window, cx));
+                this.activate(new_workspace, cx);
+                this.focus_active_workspace(window, cx);
+            })
+            .ok();
+        })
+        .detach();
     }
 
     pub fn remove_workspace(&mut self, index: usize, window: &mut Window, cx: &mut Context<Self>) {


### PR DESCRIPTION
## Summary

Fixes a crash on Linux when clicking the "New Workspace" button in the multi-workspace sidebar. The crash occurs with:

```
thread 'main' panicked at crates/gpui/src/platform/linux/wayland/window.rs:1294:26:
already borrowed: BorrowMutError
```

### Root Cause

When clicking the button:
1. The click handler calls `create_workspace()` synchronously
2. `Workspace::new()` triggers `initialize_workspace` via `observe_new`
3. `initialize_workspace` calls `window.on_window_should_close()` (zed.rs:488)
4. This tries to `borrow_mut()` the window's Callbacks RefCell
5. But the RefCell is already borrowed by the event processing loop

### Fix

Use `cx.spawn_in()` to defer workspace creation to a new frame, after the current event handler completes and releases the RefCell borrow. This pattern is already used elsewhere in the codebase for similar operations.

## Test Plan

1. Build and run on Linux (Wayland or X11)
2. Enable multi-workspace feature (debug builds have it enabled)
3. Click the "+" button in the workspace sidebar to create a new workspace
4. Verify no crash occurs and the new workspace is created

## Release Notes

- Fixed a crash on Linux when creating new workspaces via the multi-workspace sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)