### PR TITLE
gpui(linux): Fix RefCell borrow panic when callbacks register new callbacks

### DIFF
--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -25,7 +25,6 @@ mod ui;
 use std::rc::Rc;
 use std::sync::Arc;
 
-// Another comment
 use agent_settings::{AgentProfileId, AgentSettings};
 use assistant_slash_command::SlashCommandRegistry;
 use client::Client;


### PR DESCRIPTION
## Summary

  Fixes RefCell borrow panic on Linux (Wayland and X11) when callbacks try to register new callbacks.

  **Root cause:** Linux GPUI backends invoked callbacks while still holding a `RefCell` borrow on the `Callbacks` struct. If a callback tried to register a new
  callback (e.g., `on_window_should_close`), it would panic with "already borrowed: BorrowMutError".

  **Bug pattern:**
  ```rust
  // Callback runs while borrow is held - panics if callback borrows callbacks
  if let Some(ref mut fun) = self.callbacks.borrow_mut().input {
      fun(input);
  }

  Fix: Apply the take-call-restore pattern (already used in macOS backend):
  // Take callback out, release borrow, call, restore
  let callback = self.callbacks.borrow_mut().input.take();
  if let Some(mut fun) = callback {
      let result = fun(input);
      self.callbacks.borrow_mut().input = Some(fun);
  }

  Changes

  - Wayland (window.rs): Fixed 6 callback invocations
  - X11 (window.rs): Fixed 4 callback invocations

  Test plan

  - cargo check -p gpui compiles successfully
  - Tested on Linux (Wayland) - no more RefCell panic

  Release Notes:

  - Fixed a crash on Linux when window callbacks attempted to register new callbacks