### PR TITLE
Fix git auth conflict in background_agent_mvp workflow

### DIFF
--- a/.github/workflows/background_agent_mvp.yml
+++ b/.github/workflows/background_agent_mvp.yml
@@ -148,8 +148,6 @@ jobs:
               continue
             fi
 
-            git config --local http.https://github.com/.extraheader "AUTHORIZATION: bearer ${GH_TOKEN}"
-
             if ! git fetch origin main; then
               echo "WARNING: Failed to fetch origin/main for $CRASH_ID — skipping"
               continue

--- a/.github/workflows/docs_suggestions.yml
+++ b/.github/workflows/docs_suggestions.yml
@@ -94,6 +94,9 @@ jobs:
       - name: Analyze PR for documentation needs
         id: analyze
         run: |
+          # Ensure gh CLI is authenticated (GH_TOKEN may not be auto-detected)
+          echo "$GH_TOKEN" | gh auth login --with-token
+          
           OUTPUT_FILE=$(mktemp)
           
           ./script/docs-suggest \
@@ -119,12 +122,12 @@ jobs:
 
       - name: Commit suggestions to queue branch
         if: steps.analyze.outputs.has_suggestions == 'true'
+        env:
+          PR_NUM: ${{ steps.pr.outputs.number }}
+          PR_TITLE: ${{ steps.pr.outputs.title }}
+          OUTPUT_FILE: ${{ steps.analyze.outputs.output_file }}
         run: |
           set -euo pipefail
-          
-          PR_NUM="${{ steps.pr.outputs.number }}"
-          PR_TITLE="${{ steps.pr.outputs.title }}"
-          OUTPUT_FILE="${{ steps.analyze.outputs.output_file }}"
           
           # Configure git
           git config user.name "github-actions[bot]"
@@ -264,6 +267,9 @@ jobs:
       - name: Analyze PR for documentation needs
         id: analyze
         run: |
+          # Ensure gh CLI is authenticated (GH_TOKEN may not be auto-detected)
+          echo "$GH_TOKEN" | gh auth login --with-token
+          
           OUTPUT_FILE=$(mktemp)
           
           # Cherry-picks don't get preview callout


### PR DESCRIPTION
Fix git auth conflict in background_agent_mvp workflow

The workflow was manually configuring git authentication with:
```bash
git config --local http.https://github.com/.extraheader "AUTHORIZATION: bearer ..."
```

This conflicted with the authentication already set up by `actions/checkout@v4`, which uses `AUTHORIZATION: basic ...`.

The conflict caused all crash pipeline runs to fail with:
```
fatal: could not read Username for 'https://github.com'
```

This morning's run (22147984206) failed for all 15 crash candidates (ZED-4VS, ZED-202, etc.) with this error.

Remove the redundant git config since actions/checkout already handles authentication properly.

Release Notes:

- N/A