### PR TITLE
editor: Fix semantic tokens being fetched when LSP data is disabled

### DIFF
--- a/crates/editor/src/semantic_tokens.rs
+++ b/crates/editor/src/semantic_tokens.rs
@@ -119,7 +119,7 @@ impl Editor {
         for_server: Option<RefreshForServer>,
         cx: &mut Context<Self>,
     ) {
-        if !self.mode().is_full() || !self.semantic_token_state.enabled() {
+        if !self.mode().is_full() || !self.semantic_token_state.enabled() || !self.enable_lsp_data {
             self.invalidate_semantic_tokens(None);
             self.display_map.update(cx, |display_map, _| {
                 display_map.semantic_token_highlights.clear();


### PR DESCRIPTION
`disable_lsp_data` is currently only used for lhs of split diff view. However, disabling the semantic highlighting is useful in for tasks where a multi-buffer is rendered too(for example, fetching semantic tokens for every buffer is heavyweight operation in project search). 

Issue:
`refresh_semantic_tokens` is called directly by `project::Event::RefreshSemanticTokens`, `theme_changed`, and `settings_changed`. Since the `enable_lsp_data` check is bypassed in `refresh_semantic_tokens`, semantic tokens are still requested for the buffer.  

Release Notes:

- Fixed semantic tokens being fetched with LSP data is disabled.
