### PR TITLE
Fix font weight in multiple elements

### DIFF
--- a/crates/agent_ui/src/acp/message_editor.rs
+++ b/crates/agent_ui/src/acp/message_editor.rs
@@ -1334,7 +1334,7 @@ impl Render for MessageEditor {
                     font_fallbacks: settings.buffer_font.fallbacks.clone(),
                     font_features: settings.buffer_font.features.clone(),
                     font_size: settings.agent_buffer_font_size(cx).into(),
-                    font_weight: settings.buffer_font.weight.clone(),
+                    font_weight: settings.buffer_font.weight,
                     line_height: relative(settings.buffer_line_height.value()),
                     ..Default::default()
                 };

--- a/crates/agent_ui/src/acp/message_editor.rs
+++ b/crates/agent_ui/src/acp/message_editor.rs
@@ -1334,6 +1334,7 @@ impl Render for MessageEditor {
                     font_fallbacks: settings.buffer_font.fallbacks.clone(),
                     font_features: settings.buffer_font.features.clone(),
                     font_size: settings.agent_buffer_font_size(cx).into(),
+                    font_weight: settings.buffer_font.weight.clone(),
                     line_height: relative(settings.buffer_line_height.value()),
                     ..Default::default()
                 };

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -28257,7 +28257,7 @@ impl ui_input::ErasedEditor for ErasedEditorImpl {
             font_family: settings.ui_font.family.clone(),
             font_features: settings.ui_font.features.clone(),
             font_size: rems(0.875).into(),
-            font_weight: settings.buffer_font.weight,
+            font_weight: settings.ui_font.weight,
             font_style: FontStyle::Normal,
             line_height: relative(1.2),
             color: theme_color.text,

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -613,7 +613,7 @@ pub fn hover_markdown_style(window: &Window, cx: &App) -> MarkdownStyle {
     let buffer_font_family = settings.buffer_font.family.clone();
     let buffer_font_features = settings.buffer_font.features.clone();
     let buffer_font_fallbacks = settings.buffer_font.fallbacks.clone();
-    let buffer_font_weight = settings.buffer_font.weight.clone();
+    let buffer_font_weight = settings.buffer_font.weight;
 
     let mut base_text_style = window.text_style();
     base_text_style.refine(&TextStyleRefinement {
@@ -629,7 +629,7 @@ pub fn hover_markdown_style(window: &Window, cx: &App) -> MarkdownStyle {
             .my(rems(1.))
             .font_buffer(cx)
             .font_features(buffer_font_features.clone())
-            .font_weight(buffer_font_weight.clone()),
+            .font_weight(buffer_font_weight),
         inline_code: TextStyleRefinement {
             background_color: Some(cx.theme().colors().background),
             font_family: Some(buffer_font_family),

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -613,6 +613,7 @@ pub fn hover_markdown_style(window: &Window, cx: &App) -> MarkdownStyle {
     let buffer_font_family = settings.buffer_font.family.clone();
     let buffer_font_features = settings.buffer_font.features.clone();
     let buffer_font_fallbacks = settings.buffer_font.fallbacks.clone();
+    let buffer_font_weight = settings.buffer_font.weight.clone();
 
     let mut base_text_style = window.text_style();
     base_text_style.refine(&TextStyleRefinement {
@@ -627,12 +628,14 @@ pub fn hover_markdown_style(window: &Window, cx: &App) -> MarkdownStyle {
         code_block: StyleRefinement::default()
             .my(rems(1.))
             .font_buffer(cx)
-            .font_features(buffer_font_features.clone()),
+            .font_features(buffer_font_features.clone())
+            .font_weight(buffer_font_weight.clone()),
         inline_code: TextStyleRefinement {
             background_color: Some(cx.theme().colors().background),
             font_family: Some(buffer_font_family),
             font_features: Some(buffer_font_features),
             font_fallbacks: buffer_font_fallbacks,
+            font_weight: Some(buffer_font_weight),
             ..Default::default()
         },
         rule_color: cx.theme().colors().border,

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -112,6 +112,7 @@ impl MarkdownStyle {
         let theme_settings = ThemeSettings::get_global(cx);
         let colors = cx.theme().colors();
 
+        let buffer_font_weight = theme_settings.buffer_font.weight;
         let (buffer_font_size, ui_font_size) = match font {
             MarkdownFont::Agent => (
                 theme_settings.agent_buffer_font_size(cx),
@@ -196,6 +197,7 @@ impl MarkdownStyle {
                     font_fallbacks: theme_settings.buffer_font.fallbacks.clone(),
                     font_features: Some(theme_settings.buffer_font.features.clone()),
                     font_size: Some(buffer_font_size.into()),
+                    font_weight: Some(buffer_font_weight.clone()),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -205,6 +207,7 @@ impl MarkdownStyle {
                 font_fallbacks: theme_settings.buffer_font.fallbacks.clone(),
                 font_features: Some(theme_settings.buffer_font.features.clone()),
                 font_size: Some(buffer_font_size.into()),
+                font_weight: Some(buffer_font_weight),
                 background_color: Some(colors.editor_foreground.opacity(0.08)),
                 ..Default::default()
             },

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -197,7 +197,7 @@ impl MarkdownStyle {
                     font_fallbacks: theme_settings.buffer_font.fallbacks.clone(),
                     font_features: Some(theme_settings.buffer_font.features.clone()),
                     font_size: Some(buffer_font_size.into()),
-                    font_weight: Some(buffer_font_weight.clone()),
+                    font_weight: Some(buffer_font_weight),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/crates/ui/src/components/label/label_like.rs
+++ b/crates/ui/src/components/label/label_like.rs
@@ -190,7 +190,7 @@ impl LabelCommon for LabelLike {
 
     fn buffer_font(mut self, cx: &App) -> Self {
         let font = theme::ThemeSettings::get_global(cx).buffer_font.clone();
-        self.weight = Some(font.weight.clone());
+        self.weight = Some(font.weight);
         self.base = self.base.font(font);
         self
     }

--- a/crates/ui/src/components/label/label_like.rs
+++ b/crates/ui/src/components/label/label_like.rs
@@ -189,9 +189,9 @@ impl LabelCommon for LabelLike {
     }
 
     fn buffer_font(mut self, cx: &App) -> Self {
-        self.base = self
-            .base
-            .font(theme::ThemeSettings::get_global(cx).buffer_font.clone());
+        let font = theme::ThemeSettings::get_global(cx).buffer_font.clone();
+        self.weight = Some(font.weight.clone());
+        self.base = self.base.font(font);
         self
     }
 


### PR DESCRIPTION
* Update the font weight used in the Agent Panel's editor to respect the `buffer_font_weight` setting.
* Update the font weight used in the Command Palette to use the `ui_font_weight` setting value, seeing as the command palette is using the `ui_font` settings for the font family and features
* Update the font weight used in the popovers to match the `buffer_font_weight`, as it's also using the buffer font family and features
* Update the `LabelLike.buffer_font` method in order to correctly set the font weight, which fixes the font weight used in the file header when displaying a multibuffer editor


Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Fixed incorrect font weight in the Command Pallete input
- Fixed missing font weight the Agent Panel's buffer
- Fixed missing font weight the Hover Popover
- Fixed missing font weight in Markdown's code block and inline code
