### PR TITLE
gpui: Fix RefCell borrow conflict in Linux input callback dispatch

### DIFF
--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -54,6 +54,19 @@ pub(crate) struct Callbacks {
     appearance_changed: Option<Box<dyn FnMut()>>,
 }
 
+fn dispatch_input_callback(
+    callbacks: &RefCell<Callbacks>,
+    input: PlatformInput,
+) -> Option<crate::DispatchEventResult> {
+    let mut callback = callbacks.borrow_mut().input.take()?;
+    let result = callback(input);
+    let mut callbacks = callbacks.borrow_mut();
+    if callbacks.input.is_none() {
+        callbacks.input = Some(callback);
+    }
+    Some(result)
+}
+
 struct RawWindow {
     window: *mut c_void,
     display: *mut c_void,
@@ -972,10 +985,10 @@ impl WaylandWindowStatePtr {
         if self.is_blocked() {
             return;
         }
-        if let Some(ref mut fun) = self.callbacks.borrow_mut().input
-            && !fun(input.clone()).propagate
-        {
-            return;
+        if let Some(result) = dispatch_input_callback(&self.callbacks, input.clone()) {
+            if !result.propagate {
+                return;
+            }
         }
         if let PlatformInput::KeyDown(event) = input
             && event.keystroke.modifiers.is_subset_of(&Modifiers::shift())
@@ -1521,4 +1534,61 @@ fn inset_by_tiling(mut bounds: Bounds<Pixels>, inset: Pixels, tiling: Tiling) ->
     }
 
     bounds
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::rc::Rc;
+
+    #[test]
+    fn input_callback_can_mutate_callbacks_without_borrow_conflict() {
+        let callbacks = Rc::new(RefCell::new(Callbacks::default()));
+        let callbacks_for_input = callbacks.clone();
+        callbacks.borrow_mut().input = Some(Box::new(move |_| {
+            callbacks_for_input.borrow_mut().should_close = Some(Box::new(|| true));
+            crate::DispatchEventResult {
+                propagate: true,
+                default_prevented: false,
+            }
+        }));
+
+        let result = dispatch_input_callback(
+            callbacks.as_ref(),
+            PlatformInput::ModifiersChanged(Default::default()),
+        );
+
+        assert!(result.is_some_and(|result| result.propagate));
+        let callbacks = callbacks.borrow();
+        assert!(callbacks.input.is_some());
+        assert!(callbacks.should_close.is_some());
+    }
+
+    #[test]
+    fn input_callback_replacement_inside_callback_is_preserved() {
+        let callbacks = Rc::new(RefCell::new(Callbacks::default()));
+        let callbacks_for_input = callbacks.clone();
+        callbacks.borrow_mut().input = Some(Box::new(move |_| {
+            callbacks_for_input.borrow_mut().input = Some(Box::new(|_| crate::DispatchEventResult {
+                propagate: false,
+                default_prevented: false,
+            }));
+            crate::DispatchEventResult {
+                propagate: true,
+                default_prevented: false,
+            }
+        }));
+
+        let first = dispatch_input_callback(
+            callbacks.as_ref(),
+            PlatformInput::ModifiersChanged(Default::default()),
+        );
+        assert!(first.is_some_and(|result| result.propagate));
+
+        let second = dispatch_input_callback(
+            callbacks.as_ref(),
+            PlatformInput::ModifiersChanged(Default::default()),
+        );
+        assert!(second.is_some_and(|result| !result.propagate));
+    }
 }

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -253,6 +253,19 @@ pub struct Callbacks {
     appearance_changed: Option<Box<dyn FnMut()>>,
 }
 
+fn dispatch_input_callback(
+    callbacks: &RefCell<Callbacks>,
+    input: PlatformInput,
+) -> Option<DispatchEventResult> {
+    let mut callback = callbacks.borrow_mut().input.take()?;
+    let result = callback(input);
+    let mut callbacks = callbacks.borrow_mut();
+    if callbacks.input.is_none() {
+        callbacks.input = Some(callback);
+    }
+    Some(result)
+}
+
 pub struct X11WindowState {
     pub destroyed: bool,
     parent: Option<X11WindowStatePtr>,
@@ -1057,10 +1070,10 @@ impl X11WindowStatePtr {
         if self.is_blocked() {
             return;
         }
-        if let Some(ref mut fun) = self.callbacks.borrow_mut().input
-            && !fun(input.clone()).propagate
-        {
-            return;
+        if let Some(result) = dispatch_input_callback(&self.callbacks, input.clone()) {
+            if !result.propagate {
+                return;
+            }
         }
         if let PlatformInput::KeyDown(event) = input {
             // only allow shift modifier when inserting text
@@ -1756,5 +1769,62 @@ impl PlatformWindow for X11Window {
 
     fn gpu_specs(&self) -> Option<GpuSpecs> {
         self.0.state.borrow().renderer.gpu_specs().into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::rc::Rc;
+
+    #[test]
+    fn input_callback_can_mutate_callbacks_without_borrow_conflict() {
+        let callbacks = Rc::new(RefCell::new(Callbacks::default()));
+        let callbacks_for_input = callbacks.clone();
+        callbacks.borrow_mut().input = Some(Box::new(move |_| {
+            callbacks_for_input.borrow_mut().should_close = Some(Box::new(|| true));
+            DispatchEventResult {
+                propagate: true,
+                default_prevented: false,
+            }
+        }));
+
+        let result = dispatch_input_callback(
+            callbacks.as_ref(),
+            PlatformInput::ModifiersChanged(Default::default()),
+        );
+
+        assert!(result.is_some_and(|result| result.propagate));
+        let callbacks = callbacks.borrow();
+        assert!(callbacks.input.is_some());
+        assert!(callbacks.should_close.is_some());
+    }
+
+    #[test]
+    fn input_callback_replacement_inside_callback_is_preserved() {
+        let callbacks = Rc::new(RefCell::new(Callbacks::default()));
+        let callbacks_for_input = callbacks.clone();
+        callbacks.borrow_mut().input = Some(Box::new(move |_| {
+            callbacks_for_input.borrow_mut().input = Some(Box::new(|_| DispatchEventResult {
+                propagate: false,
+                default_prevented: false,
+            }));
+            DispatchEventResult {
+                propagate: true,
+                default_prevented: false,
+            }
+        }));
+
+        let first = dispatch_input_callback(
+            callbacks.as_ref(),
+            PlatformInput::ModifiersChanged(Default::default()),
+        );
+        assert!(first.is_some_and(|result| result.propagate));
+
+        let second = dispatch_input_callback(
+            callbacks.as_ref(),
+            PlatformInput::ModifiersChanged(Default::default()),
+        );
+        assert!(second.is_some_and(|result| !result.propagate));
     }
 }


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/issues/49526

## Summary

- Extract `dispatch_input_callback` helper in both Wayland and X11 window modules that uses a take-and-restore pattern, so the `RefCell<Callbacks>` is never held while the input callback executes
- This prevents a panic (`RefCell already borrowed`) when the input callback chain re-borrows the same RefCell (e.g. clicking "+" to create a new workspace triggers `initialize_workspace` → `on_should_close` registration)
- The helper guards against callback self-replacement: it only restores the original callback when no new one was installed during execution

## Test plan

- [x] Added unit tests: `input_callback_can_mutate_callbacks_without_borrow_conflict` — verifies callback can mutate other callbacks without panic
- [x] Added unit tests: `input_callback_replacement_inside_callback_is_preserved` — verifies callback self-replacement is preserved correctly
- [ ] Manual: Enable `AgentV2FeatureFlag`, open a project, click "+" to create new workspace — should no longer crash on Linux Wayland/X11

Release Notes:

- Fixed a crash on Linux (Wayland/X11) when creating a new workspace caused by a RefCell borrow conflict in window callback dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)