### PR TITLE
Fix gh auth conflict when GH_TOKEN is already set

### DIFF
--- a/.github/workflows/docs_suggestions.yml
+++ b/.github/workflows/docs_suggestions.yml
@@ -95,7 +95,8 @@ jobs:
         id: analyze
         run: |
           # Ensure gh CLI is authenticated (GH_TOKEN may not be auto-detected)
-          echo "$GH_TOKEN" | gh auth login --with-token
+          # Unset GH_TOKEN first to allow gh auth login to store credentials
+          echo "$GH_TOKEN" | (unset GH_TOKEN && gh auth login --with-token)
           
           OUTPUT_FILE=$(mktemp)
           
@@ -268,7 +269,8 @@ jobs:
         id: analyze
         run: |
           # Ensure gh CLI is authenticated (GH_TOKEN may not be auto-detected)
-          echo "$GH_TOKEN" | gh auth login --with-token
+          # Unset GH_TOKEN first to allow gh auth login to store credentials
+          echo "$GH_TOKEN" | (unset GH_TOKEN && gh auth login --with-token)
           
           OUTPUT_FILE=$(mktemp)
           


### PR DESCRIPTION
Fixes the workflow failure where `gh auth login --with-token` fails because `GH_TOKEN` is already set in the environment.

The error was:
```
The value of the GH_TOKEN environment variable is being used for authentication.
To have GitHub CLI store credentials instead, first clear the value from the environment.
```

The fix uses a subshell to unset `GH_TOKEN` before calling `gh auth login`:
```bash
echo "$GH_TOKEN" | (unset GH_TOKEN && gh auth login --with-token)
```

Release Notes:

- N/A