### PR TITLE
settings: Add `allow_binary_download` setting for Node.js runtime

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1862,6 +1862,9 @@
     // to prevent this, and force Zed to always download and install its own
     // version of Node.
     "ignore_system_version": false,
+    // Whether Zed is allowed to download and install a managed Node.js runtime
+    // when a suitable system Node.js is unavailable.
+    "allow_binary_download": true,
     // You can also specify alternative paths to Node and NPM. If you specify
     // `path`, but not `npm_path`, Zed will assume that `npm` is located at
     // `${path}/../npm`.

--- a/crates/edit_prediction_cli/src/headless.rs
+++ b/crates/edit_prediction_cli/src/headless.rs
@@ -99,7 +99,7 @@ pub fn init(cx: &mut App) -> EpAppState {
         let settings = &ProjectSettings::get_global(cx).node;
         let options = NodeBinaryOptions {
             allow_path_lookup: !settings.ignore_system_version,
-            allow_binary_download: true,
+            allow_binary_download: settings.allow_binary_download,
             use_paths: settings.path.as_ref().map(|node_path| {
                 let node_path = PathBuf::from(shellexpand::tilde(node_path).as_ref());
                 let npm_path = settings

--- a/crates/eval/src/eval.rs
+++ b/crates/eval/src/eval.rs
@@ -405,7 +405,7 @@ pub fn init(cx: &mut App) -> Arc<AgentAppState> {
         let settings = &ProjectSettings::get_global(cx).node;
         let options = NodeBinaryOptions {
             allow_path_lookup: !settings.ignore_system_version,
-            allow_binary_download: true,
+            allow_binary_download: settings.allow_binary_download,
             use_paths: settings.path.as_ref().map(|node_path| {
                 let node_path = PathBuf::from(shellexpand::tilde(node_path).as_ref());
                 let npm_path = settings

--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -183,23 +183,19 @@ impl NodeRuntime {
             }
         } else if let Some(system_node_error) = system_node_error {
             // failure case not cached, since it's cheap to check again
-            //
-            // TODO: When support is added for setting `options.allow_binary_download`, update this
-            // error message.
             return Box::new(UnavailableNodeRuntime {
                 error_message: format!(
-                    "failure while checking system Node.js from PATH: {}",
+                    "failure while checking system Node.js from PATH: {}. \
+                    Set `node.allow_binary_download` to `true` to allow using managed Node.js.",
                     system_node_error
                 )
                 .into(),
             });
         } else {
             // failure case is cached because it will always happen with these options
-            //
-            // TODO: When support is added for setting `options.allow_binary_download`, update this
-            // error message.
             Box::new(UnavailableNodeRuntime {
-                error_message: "`node` settings do not allow any way to use Node.js"
+                error_message: "`node` settings do not allow any way to use Node.js: \
+                `node.ignore_system_version` is `true` and `node.allow_binary_download` is `false`."
                     .to_string()
                     .into(),
             })

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -105,6 +105,8 @@ pub struct NodeBinarySettings {
     pub npm_path: Option<String>,
     /// If enabled, Zed will download its own copy of Node.
     pub ignore_system_version: bool,
+    /// If enabled, Zed may download and install a managed Node.js copy when needed.
+    pub allow_binary_download: bool,
 }
 
 impl From<settings::NodeBinarySettings> for NodeBinarySettings {
@@ -113,6 +115,7 @@ impl From<settings::NodeBinarySettings> for NodeBinarySettings {
             path: settings.path,
             npm_path: settings.npm_path,
             ignore_system_version: settings.ignore_system_version.unwrap_or(false),
+            allow_binary_download: settings.allow_binary_download.unwrap_or(true),
         }
     }
 }

--- a/crates/remote_server/src/server.rs
+++ b/crates/remote_server/src/server.rs
@@ -1083,8 +1083,7 @@ fn initialize_settings(
             log::info!("Got new node settings: {new_node_settings:?}");
             let options = NodeBinaryOptions {
                 allow_path_lookup: !new_node_settings.ignore_system_version,
-                // TODO: Implement this setting
-                allow_binary_download: true,
+                allow_binary_download: new_node_settings.allow_binary_download,
                 use_paths: new_node_settings.path.as_ref().map(|node_path| {
                     let node_path = PathBuf::from(shellexpand::tilde(node_path).as_ref());
                     let npm_path = new_node_settings

--- a/crates/settings_content/src/project.rs
+++ b/crates/settings_content/src/project.rs
@@ -682,6 +682,8 @@ pub struct NodeBinarySettings {
     pub npm_path: Option<String>,
     /// If enabled, Zed will download its own copy of Node.
     pub ignore_system_version: Option<bool>,
+    /// If enabled, Zed may download and install a managed Node.js copy when needed.
+    pub allow_binary_download: Option<bool>,
 }
 
 #[derive(Clone, PartialEq, Debug, Default, Serialize, Deserialize, JsonSchema, MergeFrom)]

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -478,8 +478,7 @@ fn main() {
             let settings = &ProjectSettings::get_global(cx).node;
             let options = NodeBinaryOptions {
                 allow_path_lookup: !settings.ignore_system_version,
-                // TODO: Expose this setting
-                allow_binary_download: true,
+                allow_binary_download: settings.allow_binary_download,
                 use_paths: settings.path.as_ref().map(|node_path| {
                     let node_path = PathBuf::from(shellexpand::tilde(node_path).as_ref());
                     let npm_path = settings

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -2735,6 +2735,7 @@ Positive `integer` values or `null` for unlimited tabs
 {
   "node": {
     "ignore_system_version": false,
+    "allow_binary_download": true,
     "path": null,
     "npm_path": null
   }
@@ -2744,6 +2745,7 @@ Positive `integer` values or `null` for unlimited tabs
 **Options**
 
 - `ignore_system_version`: Whether to ignore the system Node.js version
+- `allow_binary_download`: Whether Zed may download and install a managed Node.js runtime when needed
 - `path`: Custom path to Node.js binary
 - `npm_path`: Custom path to npm binary
 


### PR DESCRIPTION
Release Notes:

- Added `allow_binary_download` setting for Node.js runtime
