### PR TITLE
editor: Remove duplicate method

### DIFF
--- a/crates/debugger_ui/src/session/running/console.rs
+++ b/crates/debugger_ui/src/session/running/console.rs
@@ -251,7 +251,7 @@ impl Console {
                         let range = buffer.anchor_after(MultiBufferOffset(range.start))
                             ..buffer.anchor_before(MultiBufferOffset(range.end));
                         let color_fn = color_fetcher(color);
-                        console.highlight_background_key(
+                        console.highlight_background(
                             HighlightKey::ConsoleAnsiHighlight(start_offset),
                             &[range],
                             move |_, theme| color_fn(theme),

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -23483,19 +23483,6 @@ impl Editor {
         cx.notify();
     }
 
-    pub fn highlight_background_key(
-        &mut self,
-        key: HighlightKey,
-        ranges: &[Range<Anchor>],
-        color_fetcher: impl Fn(&usize, &Theme) -> Hsla + Send + Sync + 'static,
-        cx: &mut Context<Self>,
-    ) {
-        self.background_highlights
-            .insert(key, (Arc::new(color_fetcher), Arc::from(ranges)));
-        self.scrollbar_marker_state.dirty = true;
-        cx.notify();
-    }
-
     pub fn clear_background_highlights(
         &mut self,
         key: HighlightKey,

--- a/crates/language_tools/src/highlights_tree_view.rs
+++ b/crates/language_tools/src/highlights_tree_view.rs
@@ -556,7 +556,7 @@ impl HighlightsTreeView {
         ranges: &[Range<Anchor>],
         cx: &mut Context<Editor>,
     ) {
-        editor.highlight_background_key(
+        editor.highlight_background(
             HighlightKey::HighlightsTreeView(key),
             ranges,
             |_, theme| theme.colors().editor_document_highlight_write_background,

--- a/crates/language_tools/src/syntax_tree_view.rs
+++ b/crates/language_tools/src/syntax_tree_view.rs
@@ -484,7 +484,7 @@ impl SyntaxTreeView {
         ranges: &[Range<Anchor>],
         cx: &mut Context<Editor>,
     ) {
-        editor.highlight_background_key(
+        editor.highlight_background(
             HighlightKey::SyntaxTreeView(key),
             ranges,
             |_, theme| theme.colors().editor_document_highlight_write_background,


### PR DESCRIPTION
`highlight_background` and `highlight_background_key` currently have the same implementation

Release Notes:

- N/A
