### PR TITLE
zlog: Broaden filter for usvg parser warnings

### DIFF
--- a/crates/zlog/src/filter.rs
+++ b/crates/zlog/src/filter.rs
@@ -43,7 +43,7 @@ const DEFAULT_FILTERS: &[(&str, log::LevelFilter)] = &[
     ("naga::back::spv::writer", log::LevelFilter::Warn),
     // usvg prints a lot of warnings on rendering an SVG with partial errors, which
     // can happen a lot with the SVG preview
-    ("usvg::parser::style", log::LevelFilter::Error),
+    ("usvg::parser", log::LevelFilter::Error),
 ];
 
 pub fn init_env_filter(filter: env_config::EnvFilter) {


### PR DESCRIPTION
Noticed this while looking into #49595

Release Notes:

- N/A 
