### PR TITLE
Support MCP image content in tool responses

### DIFF
--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -2082,6 +2082,333 @@ async fn test_mcp_tool_truncation(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_mcp_tool_image_response(cx: &mut TestAppContext) {
+    struct TestCase {
+        name: &'static str,
+        response_content: Vec<context_server::types::ToolResponseContent>,
+        expected_ui_image_count: usize,
+        expected_ui_text_count: usize,
+        expect_llm_image: bool,
+        expected_llm_text: Option<&'static str>,
+    }
+
+    let test_image_base64 = test_png_base64();
+    let test_gif_base64 = test_gif_base64();
+
+    let test_cases = vec![
+        TestCase {
+            name: "text only",
+            response_content: vec![context_server::types::ToolResponseContent::Text {
+                text: "Here is the result.".into(),
+            }],
+            expected_ui_image_count: 0,
+            expected_ui_text_count: 1,
+            expect_llm_image: false,
+            expected_llm_text: Some("Here is the result."),
+        },
+        TestCase {
+            name: "gif image (re-encoded to PNG)",
+            response_content: vec![context_server::types::ToolResponseContent::Image {
+                data: test_gif_base64.clone(),
+                mime_type: "image/gif".into(),
+            }],
+            expected_ui_image_count: 1,
+            expected_ui_text_count: 0,
+            expect_llm_image: true,
+            expected_llm_text: None,
+        },
+        TestCase {
+            name: "png image",
+            response_content: vec![context_server::types::ToolResponseContent::Image {
+                data: test_image_base64.clone(),
+                mime_type: "image/png".into(),
+            }],
+            expected_ui_image_count: 1,
+            expected_ui_text_count: 0,
+            expect_llm_image: true,
+            expected_llm_text: None,
+        },
+        TestCase {
+            name: "mixed text and image",
+            response_content: vec![
+                context_server::types::ToolResponseContent::Text {
+                    text: "Analysis results: Found 5 items.".into(),
+                },
+                context_server::types::ToolResponseContent::Image {
+                    data: test_image_base64.clone(),
+                    mime_type: "image/png".into(),
+                },
+            ],
+            expected_ui_image_count: 1,
+            expected_ui_text_count: 1,
+            expect_llm_image: true,
+            expected_llm_text: None,
+        },
+        TestCase {
+            name: "multiple images",
+            response_content: vec![
+                context_server::types::ToolResponseContent::Image {
+                    data: test_image_base64.clone(),
+                    mime_type: "image/png".into(),
+                },
+                context_server::types::ToolResponseContent::Image {
+                    data: test_gif_base64.clone(),
+                    mime_type: "image/gif".into(),
+                },
+            ],
+            expected_ui_image_count: 2,
+            expected_ui_text_count: 0,
+            expect_llm_image: true,
+            expected_llm_text: None,
+        },
+        TestCase {
+            name: "interleaved text and images",
+            response_content: vec![
+                context_server::types::ToolResponseContent::Text {
+                    text: "Item #1".into(),
+                },
+                context_server::types::ToolResponseContent::Image {
+                    data: test_image_base64.clone(),
+                    mime_type: "image/png".into(),
+                },
+                context_server::types::ToolResponseContent::Text {
+                    text: "Item #2".into(),
+                },
+                context_server::types::ToolResponseContent::Image {
+                    data: test_gif_base64.clone(),
+                    mime_type: "image/gif".into(),
+                },
+                context_server::types::ToolResponseContent::Text {
+                    text: "Item #3".into(),
+                },
+            ],
+            expected_ui_image_count: 2,
+            expected_ui_text_count: 3,
+            expect_llm_image: true,
+            expected_llm_text: None,
+        },
+    ];
+
+    for test_case in test_cases {
+        let (test, mut mcp_tool_calls) = setup_mcp_image_test(cx, "test_server", "run_tool").await;
+        let fake_model = test.model.as_fake();
+
+        let mut events = drive_mcp_tool_call(
+            &test.thread,
+            &fake_model,
+            &mut mcp_tool_calls,
+            "run_tool",
+            test_case.response_content,
+            cx,
+        )
+        .await;
+
+        // Verify live preview: content should be pushed to the UI during execution.
+        let expected_total = test_case.expected_ui_image_count + test_case.expected_ui_text_count;
+        if expected_total > 0 {
+            let mut found_image_count = 0;
+            let mut found_text_count = 0;
+            while let Some(event) = events.next().now_or_never() {
+                if let Some(Ok(ThreadEvent::ToolCallUpdate(
+                    acp_thread::ToolCallUpdate::UpdateFields(update),
+                ))) = event
+                {
+                    if let Some(content) = &update.fields.content {
+                        for item in content {
+                            match item {
+                                acp::ToolCallContent::Content(acp::Content {
+                                    content: acp::ContentBlock::Image(img),
+                                    ..
+                                }) => {
+                                    assert_eq!(
+                                        img.mime_type, "image/png",
+                                        "case: {}: all images should be re-encoded as PNG",
+                                        test_case.name
+                                    );
+                                    assert!(
+                                        !img.data.is_empty(),
+                                        "case: {}: image data should not be empty",
+                                        test_case.name
+                                    );
+                                    found_image_count += 1;
+                                }
+                                acp::ToolCallContent::Content(acp::Content {
+                                    content: acp::ContentBlock::Text(text),
+                                    ..
+                                }) => {
+                                    assert!(
+                                        !text.text.is_empty(),
+                                        "case: {}: text content should not be empty",
+                                        test_case.name
+                                    );
+                                    found_text_count += 1;
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+                }
+            }
+            assert_eq!(
+                found_image_count, test_case.expected_ui_image_count,
+                "case: {}: wrong number of image content blocks in UI",
+                test_case.name
+            );
+            assert_eq!(
+                found_text_count, test_case.expected_ui_text_count,
+                "case: {}: wrong number of text content blocks in UI",
+                test_case.name
+            );
+        }
+
+        // Verify LLM tool result content.
+        let tool_result = extract_single_tool_result(&fake_model, test_case.name);
+        if test_case.expect_llm_image {
+            let has_image = tool_result.content.iter().any(|c| {
+                matches!(c, language_model::LanguageModelToolResultContent::Image(img) if img.size.is_some())
+            });
+            assert!(
+                has_image,
+                "case: {}: expected Image with size in LLM tool result (from process_image)",
+                test_case.name
+            );
+        }
+        if let Some(expected_text) = test_case.expected_llm_text {
+            let has_text = tool_result.content.iter().any(|c| {
+                matches!(c, language_model::LanguageModelToolResultContent::Text(t) if t.as_ref() == expected_text)
+            });
+            assert!(
+                has_text,
+                "case: {}: expected text '{}' in LLM tool result",
+                test_case.name, expected_text
+            );
+        }
+
+        finish_turn(&fake_model, events).await;
+    }
+}
+
+#[gpui::test]
+async fn test_mcp_tool_image_response_without_image_support(cx: &mut TestAppContext) {
+    let (test, mut mcp_tool_calls) = setup_mcp_image_test(cx, "no_image_server", "get_image").await;
+    let fake_model = test.model.as_fake();
+
+    // Override: the model does NOT support images.
+    fake_model.set_supports_images(false);
+
+    let events = drive_mcp_tool_call(
+        &test.thread,
+        &fake_model,
+        &mut mcp_tool_calls,
+        "get_image",
+        vec![context_server::types::ToolResponseContent::Image {
+            data: test_png_base64(),
+            mime_type: "image/png".into(),
+        }],
+        cx,
+    )
+    .await;
+
+    let tool_result = extract_single_tool_result(&fake_model, "without_image_support");
+
+    // When the model doesn't support images, the request builder replaces
+    // image content with a fallback text message so the LLM gets
+    // something meaningful instead of an unsupported payload.
+    match tool_result
+        .content
+        .last()
+        .expect("should have fallback text")
+    {
+        language_model::LanguageModelToolResultContent::Text(text) => {
+            assert!(
+                text.contains("doesn't support"),
+                "expected fallback text about missing image support, got: {text:?}"
+            );
+        }
+        other => panic!(
+            "expected text fallback when model lacks image support, got: {:?}",
+            other
+        ),
+    }
+
+    finish_turn(&fake_model, events).await;
+}
+
+#[gpui::test]
+async fn test_mcp_tool_image_restored_on_replay(cx: &mut TestAppContext) {
+    let (test, mut mcp_tool_calls) =
+        setup_mcp_image_test(cx, "image_replay_server", "get_screenshot").await;
+    let fake_model = test.model.as_fake();
+
+    let events = drive_mcp_tool_call(
+        &test.thread,
+        &fake_model,
+        &mut mcp_tool_calls,
+        "get_screenshot",
+        vec![context_server::types::ToolResponseContent::Image {
+            data: test_png_base64(),
+            mime_type: "image/png".into(),
+        }],
+        cx,
+    )
+    .await;
+
+    // Complete the turn — pop the pending completion so finish_turn starts a fresh one.
+    let _completion = fake_model
+        .pending_completions()
+        .pop()
+        .expect("should have a pending completion after tool call");
+    fake_model.send_last_completion_stream_text_chunk("Here's the screenshot!");
+    fake_model
+        .send_last_completion_stream_event(LanguageModelCompletionEvent::Stop(StopReason::EndTurn));
+    fake_model.end_last_completion_stream();
+    events.collect::<Vec<_>>().await;
+
+    // Simulate app restart: disconnect the MCP server
+    test.context_server_store.update(cx, |store, cx| {
+        store
+            .stop_server(&ContextServerId("image_replay_server".into()), cx)
+            .log_err();
+    });
+    cx.run_until_parked();
+
+    // Replay the thread (simulates loading a saved thread after restart)
+    let mut replay_events = test.thread.update(cx, |thread, cx| thread.replay(cx));
+
+    let mut found_image_content = false;
+    while let Some(event) = replay_events.next().await {
+        let event = event.unwrap();
+        if let ThreadEvent::ToolCallUpdate(acp_thread::ToolCallUpdate::UpdateFields(update)) =
+            &event
+        {
+            if update.tool_call_id.to_string() == "tool_1" {
+                if let Some(content) = &update.fields.content {
+                    for item in content {
+                        if let acp::ToolCallContent::Content(acp::Content {
+                            content: acp::ContentBlock::Image(image),
+                            ..
+                        }) = item
+                        {
+                            assert!(
+                                !image.data.is_empty(),
+                                "Image data should be restored from saved tool result"
+                            );
+                            assert_eq!(image.mime_type, "image/png");
+                            found_image_content = true;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    assert!(
+        found_image_content,
+        "Image content should be restored when replaying tool call"
+    );
+}
+
+#[gpui::test]
 #[cfg_attr(not(feature = "e2e"), ignore)]
 async fn test_cancellation(cx: &mut TestAppContext) {
     let ThreadTest { thread, .. } = setup(cx, TestModel::Sonnet4).await;
@@ -4463,6 +4790,166 @@ fn setup_context_server(
     });
     cx.run_until_parked();
     mcp_tool_calls_rx
+}
+
+/// Returns a base64-encoded 1x1 red pixel PNG for testing.
+///
+/// This is a minimal valid PNG image suitable for use in MCP image response tests.
+fn test_png_base64() -> String {
+    // 1x1 red pixel PNG (RGBA [255, 0, 0, 255])
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==".to_string()
+}
+
+/// Returns a base64-encoded 1x1 transparent GIF for testing.
+fn test_gif_base64() -> String {
+    "R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==".to_string()
+}
+
+/// Extracts the single tool result from the fake model's latest pending completion.
+///
+/// Panics with context if there is no pending completion or the message doesn't
+/// contain exactly one tool result.
+fn extract_single_tool_result(
+    fake_model: &FakeLanguageModel,
+    case_name: &str,
+) -> language_model::LanguageModelToolResult {
+    let completion = fake_model
+        .pending_completions()
+        .pop()
+        .unwrap_or_else(|| panic!("case: {case_name}: should have a pending completion"));
+    let tool_results: Vec<_> = completion
+        .messages
+        .last()
+        .unwrap_or_else(|| panic!("case: {case_name}: completion should have messages"))
+        .content
+        .iter()
+        .filter_map(|c| match c {
+            MessageContent::ToolResult(result) => Some(result.clone()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        tool_results.len(),
+        1,
+        "case: {case_name}: expected exactly one tool result"
+    );
+    tool_results.into_iter().next().unwrap()
+}
+
+/// Completes an MCP tool call turn by sending a final text chunk and draining the
+/// event stream.
+async fn finish_turn(
+    fake_model: &FakeLanguageModel,
+    events: UnboundedReceiver<Result<ThreadEvent>>,
+) {
+    fake_model.send_last_completion_stream_text_chunk("Done!");
+    fake_model.end_last_completion_stream();
+    events.collect::<Vec<_>>().await;
+}
+
+/// Sets up a test environment with a single MCP context server, image support enabled,
+/// and auto-allow tool permissions.
+async fn setup_mcp_image_test(
+    cx: &mut TestAppContext,
+    server_name: &'static str,
+    tool_name: &'static str,
+) -> (
+    ThreadTest,
+    UnboundedReceiver<(
+        context_server::types::CallToolParams,
+        oneshot::Sender<context_server::types::CallToolResponse>,
+    )>,
+) {
+    let test = setup(cx, TestModel::Fake).await;
+    test.model.as_fake().set_supports_images(true);
+
+    test.fs
+        .insert_file(
+            paths::settings_file(),
+            json!({
+                "agent": {
+                    "tool_permissions": { "default": "allow" },
+                    "profiles": {
+                        "test": {
+                            "name": "Test Profile",
+                            "enable_all_context_servers": true,
+                            "tools": {}
+                        },
+                    }
+                }
+            })
+            .to_string()
+            .into_bytes(),
+        )
+        .await;
+    cx.run_until_parked();
+    test.thread.update(cx, |thread, cx| {
+        thread.set_profile(AgentProfileId("test".into()), cx)
+    });
+
+    let mcp_tool_calls = setup_context_server(
+        server_name,
+        vec![context_server::types::Tool {
+            name: tool_name.into(),
+            title: None,
+            description: Some("Test tool".into()),
+            input_schema: json!({"type": "object", "properties": {}}),
+            output_schema: None,
+            annotations: None,
+        }],
+        &test.context_server_store,
+        cx,
+    );
+
+    (test, mcp_tool_calls)
+}
+
+/// Sends a user message, streams a tool use from the fake model, and responds to the
+/// MCP tool call with the given content. Returns the event stream for further assertions.
+async fn drive_mcp_tool_call(
+    thread: &Entity<Thread>,
+    fake_model: &FakeLanguageModel,
+    mcp_tool_calls: &mut UnboundedReceiver<(
+        context_server::types::CallToolParams,
+        oneshot::Sender<context_server::types::CallToolResponse>,
+    )>,
+    tool_name: &str,
+    response_content: Vec<context_server::types::ToolResponseContent>,
+    cx: &mut TestAppContext,
+) -> UnboundedReceiver<Result<ThreadEvent>> {
+    let events = thread.update(cx, |thread, cx| {
+        thread
+            .send(UserMessageId::new(), ["Run the tool"], cx)
+            .unwrap()
+    });
+    cx.run_until_parked();
+
+    fake_model.send_last_completion_stream_event(LanguageModelCompletionEvent::ToolUse(
+        LanguageModelToolUse {
+            id: "tool_1".into(),
+            name: tool_name.into(),
+            raw_input: json!({}).to_string(),
+            input: json!({}),
+            is_input_complete: true,
+            thought_signature: None,
+        },
+    ));
+    fake_model.end_last_completion_stream();
+    cx.run_until_parked();
+
+    let (tool_call_params, tool_call_response) = mcp_tool_calls.next().await.unwrap();
+    assert_eq!(tool_call_params.name, tool_name);
+    tool_call_response
+        .send(context_server::types::CallToolResponse {
+            content: response_content,
+            is_error: None,
+            meta: None,
+            structured_content: None,
+        })
+        .unwrap();
+    cx.run_until_parked();
+
+    events
 }
 
 #[gpui::test]

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -984,6 +984,32 @@ pub struct Thread {
     running_subagents: Vec<WeakEntity<Thread>>,
 }
 
+fn tool_result_to_tool_call_content(
+    tool_result: Option<&LanguageModelToolResult>,
+) -> Option<Vec<acp::ToolCallContent>> {
+    tool_result
+        .map(|result| {
+            result
+                .content
+                .iter()
+                .map(|part| match part {
+                    LanguageModelToolResultContent::Text(text) => {
+                        acp::ToolCallContent::Content(acp::Content::new(acp::ContentBlock::Text(
+                            acp::TextContent::new(text.to_string()),
+                        )))
+                    }
+                    LanguageModelToolResultContent::Image(image) => acp::ToolCallContent::Content(
+                        acp::Content::new(acp::ContentBlock::Image(acp::ImageContent::new(
+                            image.source.to_string(),
+                            "image/png".to_string(),
+                        ))),
+                    ),
+                })
+                .collect::<Vec<_>>()
+        })
+        .filter(|c| !c.is_empty())
+}
+
 impl Thread {
     fn prompt_capabilities(model: Option<&dyn LanguageModel>) -> acp::PromptCapabilities {
         let image = model.map_or(true, |model| model.supports_images());
@@ -1209,13 +1235,13 @@ impl Thread {
                         .raw_input(tool_use.input.clone()),
                 )))
                 .ok();
-            stream.update_tool_call_fields(
-                &tool_use.id,
-                acp::ToolCallUpdateFields::new()
-                    .status(status)
-                    .raw_output(output),
-                None,
-            );
+            let mut update_fields = acp::ToolCallUpdateFields::new()
+                .status(status)
+                .raw_output(output);
+            if let Some(content) = tool_result_to_tool_call_content(tool_result) {
+                update_fields = update_fields.content(content);
+            }
+            stream.update_tool_call_fields(&tool_use.id, update_fields, None);
             return;
         };
 
@@ -1242,13 +1268,13 @@ impl Thread {
                 .log_err();
         }
 
-        stream.update_tool_call_fields(
-            &tool_use.id,
-            acp::ToolCallUpdateFields::new()
-                .status(status)
-                .raw_output(output),
-            None,
-        );
+        let mut update_fields = acp::ToolCallUpdateFields::new()
+            .status(status)
+            .raw_output(output);
+        if let Some(content) = tool_result_to_tool_call_content(tool_result) {
+            update_fields = update_fields.content(content);
+        }
+        stream.update_tool_call_fields(&tool_use.id, update_fields, None);
     }
 
     pub fn from_db(
@@ -4279,6 +4305,61 @@ mod tests {
     use language_model::fake_provider::FakeLanguageModel;
     use serde_json::json;
     use std::sync::Arc;
+
+    fn make_tool_result(content: Vec<LanguageModelToolResultContent>) -> LanguageModelToolResult {
+        LanguageModelToolResult {
+            tool_use_id: LanguageModelToolUseId::from("id"),
+            tool_name: Arc::from("tool"),
+            is_error: false,
+            content,
+            output: None,
+        }
+    }
+
+    #[test]
+    fn test_tool_result_to_tool_call_content_none() {
+        assert!(tool_result_to_tool_call_content(None).is_none());
+    }
+
+    #[test]
+    fn test_tool_result_to_tool_call_content_empty() {
+        let result = make_tool_result(vec![]);
+        assert!(tool_result_to_tool_call_content(Some(&result)).is_none());
+    }
+
+    #[test]
+    fn test_tool_result_to_tool_call_content_text() {
+        let result = make_tool_result(vec![LanguageModelToolResultContent::Text(Arc::from(
+            "hello",
+        ))]);
+        let content = tool_result_to_tool_call_content(Some(&result)).unwrap();
+        assert_eq!(content.len(), 1);
+        assert!(matches!(
+            &content[0],
+            acp::ToolCallContent::Content(acp::Content {
+                content: acp::ContentBlock::Text(t), ..
+            }) if t.text == "hello"
+        ));
+    }
+
+    #[test]
+    fn test_tool_result_to_tool_call_content_image() {
+        let result = make_tool_result(vec![LanguageModelToolResultContent::Image(
+            LanguageModelImage {
+                source: "data:image/png;base64,abc".into(),
+                size: None,
+            },
+        )]);
+        let content = tool_result_to_tool_call_content(Some(&result)).unwrap();
+        assert_eq!(content.len(), 1);
+        assert!(matches!(
+            &content[0],
+            acp::ToolCallContent::Content(acp::Content {
+                content: acp::ContentBlock::Image(_),
+                ..
+            })
+        ));
+    }
 
     async fn setup_thread_for_test(cx: &mut TestAppContext) -> (Entity<Thread>, ThreadEventStream) {
         cx.update(|cx| {

--- a/crates/agent/src/tools/context_server_registry.rs
+++ b/crates/agent/src/tools/context_server_registry.rs
@@ -5,7 +5,7 @@ use collections::{BTreeMap, HashMap};
 use context_server::{ContextServerId, client::NotificationSubscription};
 use futures::FutureExt as _;
 use gpui::{App, AppContext, AsyncApp, Context, Entity, EventEmitter, SharedString, Task};
-use language_model::LanguageModelToolResultContent;
+use language_model::{LanguageModelImage, LanguageModelImageExt, LanguageModelToolResultContent};
 use project::context_server_store::{ContextServerStatus, ContextServerStore};
 use std::sync::Arc;
 use util::ResultExt;
@@ -401,8 +401,19 @@ impl AnyAgentTool for ContextServerTool {
                         concatenated_text.push_str(&text);
                         llm_output.push(LanguageModelToolResultContent::Text(text.into()));
                     }
-                    context_server::types::ToolResponseContent::Image { .. } => {
-                        log::warn!("Ignoring image content from tool response");
+                    context_server::types::ToolResponseContent::Image { data, mime_type } => {
+                        match LanguageModelImage::from_base64(data) {
+                            Ok(image) => {
+                                llm_output.push(LanguageModelToolResultContent::Image(image));
+                            }
+                            Err(err) => {
+                                let msg =
+                                    format!("Image ({mime_type}) could not be processed: {err}");
+                                log::warn!("{msg}");
+                                concatenated_text.push_str(&msg);
+                                llm_output.push(LanguageModelToolResultContent::Text(msg.into()));
+                            }
+                        }
                     }
                     context_server::types::ToolResponseContent::Audio { .. } => {
                         log::warn!("Ignoring audio content from tool response");
@@ -415,7 +426,30 @@ impl AnyAgentTool for ContextServerTool {
                     }
                 }
             }
+            // Images are intentionally omitted from raw_output, which is only used as a
+            // plain-text display fallback for clients that don't consume the `content` field.
             let raw_output = serde_json::Value::String(concatenated_text);
+
+            // Push content to the UI for live preview during tool execution.
+            let ui_content: Vec<_> = llm_output
+                .iter()
+                .map(|part| match part {
+                    LanguageModelToolResultContent::Image(img) => {
+                        acp::ToolCallContent::Content(acp::Content::new(acp::ContentBlock::Image(
+                            acp::ImageContent::new(img.source.to_string(), "image/png"),
+                        )))
+                    }
+                    LanguageModelToolResultContent::Text(text) => {
+                        acp::ToolCallContent::Content(acp::Content::new(acp::ContentBlock::Text(
+                            acp::TextContent::new(text.to_string()),
+                        )))
+                    }
+                })
+                .collect();
+            if !ui_content.is_empty() {
+                event_stream.update_fields(acp::ToolCallUpdateFields::new().content(ui_content));
+            }
+
             Ok(AgentToolOutput {
                 raw_output,
                 llm_output,

--- a/crates/language_model/src/request.rs
+++ b/crates/language_model/src/request.rs
@@ -4,7 +4,8 @@ use std::sync::Arc;
 use anyhow::Result;
 use base64::write::EncoderWriter;
 use gpui::{
-    App, AppContext as _, DevicePixels, Image, ImageFormat, ObjectFit, Size, Task, point, px, size,
+    App, AppContext as _, DevicePixels, Image, ImageFormat, ObjectFit, SharedString, Size, Task,
+    point, px, size,
 };
 use image::GenericImageView as _;
 use image::codecs::png::PngEncoder;
@@ -28,11 +29,29 @@ const MAX_IMAGE_DOWNSCALE_PASSES: usize = 8;
 /// Extension trait for `LanguageModelImage` that provides GPUI-dependent functionality.
 pub trait LanguageModelImageExt {
     const FORMAT: ImageFormat;
+    /// Decode base64 image data of any supported format, re-encode as PNG with
+    /// size constraints applied. Used for MCP tool response images.
+    fn from_base64(base64_data: impl Into<SharedString>) -> Result<Self>
+    where
+        Self: Sized;
     fn from_image(data: Arc<Image>, cx: &mut App) -> Task<Option<LanguageModelImage>>;
 }
 
 impl LanguageModelImageExt for LanguageModelImage {
     const FORMAT: ImageFormat = ImageFormat::Png;
+
+    fn from_base64(base64_data: impl Into<SharedString>) -> Result<Self> {
+        use base64::Engine;
+
+        let raw_base64: SharedString = base64_data.into();
+        anyhow::ensure!(!raw_base64.is_empty(), "empty base64 data");
+
+        let bytes = base64::engine::general_purpose::STANDARD.decode(raw_base64.as_bytes())?;
+        let dynamic_image = image::ImageReader::new(Cursor::new(&bytes))
+            .with_guessed_format()?
+            .decode()?;
+        process_image(dynamic_image)
+    }
 
     fn from_image(data: Arc<Image>, cx: &mut App) -> Task<Option<LanguageModelImage>> {
         cx.background_spawn(async move {
@@ -54,81 +73,86 @@ impl LanguageModelImageExt for LanguageModelImage {
             }
             .log_err()?;
 
-            let width = dynamic_image.width();
-            let height = dynamic_image.height();
-            let image_size = size(DevicePixels(width as i32), DevicePixels(height as i32));
-
-            // First apply any provider-specific dimension constraints we know about (Anthropic).
-            let mut processed_image = if image_size.width.0 > ANTHROPIC_SIZE_LIMIT as i32
-                || image_size.height.0 > ANTHROPIC_SIZE_LIMIT as i32
-            {
-                let new_bounds = ObjectFit::ScaleDown.get_bounds(
-                    gpui::Bounds {
-                        origin: point(px(0.0), px(0.0)),
-                        size: size(px(ANTHROPIC_SIZE_LIMIT), px(ANTHROPIC_SIZE_LIMIT)),
-                    },
-                    image_size,
-                );
-                dynamic_image.resize(
-                    new_bounds.size.width.into(),
-                    new_bounds.size.height.into(),
-                    image::imageops::FilterType::Triangle,
-                )
-            } else {
-                dynamic_image
-            };
-
-            // Then enforce a default per-image size cap on the encoded PNG bytes.
-            //
-            // We always send PNG bytes (either original PNG bytes, or re-encoded PNG) base64'd.
-            // The upstream provider limit we want to respect is effectively on the binary image
-            // payload size, so we enforce against the encoded PNG bytes before base64 encoding.
-            let mut encoded_png = encode_png_bytes(&processed_image).log_err()?;
-            for _pass in 0..MAX_IMAGE_DOWNSCALE_PASSES {
-                if encoded_png.len() <= DEFAULT_IMAGE_MAX_BYTES {
-                    break;
-                }
-
-                // Scale down geometrically to converge quickly. We don't know the final PNG size
-                // as a function of pixels, so we iteratively shrink.
-                let (w, h) = processed_image.dimensions();
-                if w <= 1 || h <= 1 {
-                    break;
-                }
-
-                // Shrink by ~15% each pass (0.85). This is a compromise between speed and
-                // preserving image detail.
-                let new_w = ((w as f32) * 0.85).round().max(1.0) as u32;
-                let new_h = ((h as f32) * 0.85).round().max(1.0) as u32;
-
-                processed_image =
-                    processed_image.resize(new_w, new_h, image::imageops::FilterType::Triangle);
-                encoded_png = encode_png_bytes(&processed_image).log_err()?;
-            }
-
-            if encoded_png.len() > DEFAULT_IMAGE_MAX_BYTES {
-                // Still too large after multiple passes; treat as non-convertible for now.
-                // (Provider-specific handling can be introduced later.)
-                return None;
-            }
-
-            // Now base64 encode the PNG bytes.
-            let base64_image = encode_bytes_as_base64(encoded_png.as_slice()).log_err()?;
-
-            // SAFETY: The base64 encoder should not produce non-UTF8.
-            let source = unsafe { String::from_utf8_unchecked(base64_image) };
-
-            let (final_width, final_height) = processed_image.dimensions();
-
-            Some(LanguageModelImage {
-                size: Some(ImageSize {
-                    width: final_width as i32,
-                    height: final_height as i32,
-                }),
-                source: source.into(),
-            })
+            process_image(dynamic_image).log_err()
         })
     }
+}
+
+/// Normalize an image to PNG with provider size constraints applied.
+fn process_image(dynamic_image: image::DynamicImage) -> Result<LanguageModelImage> {
+    let width = dynamic_image.width();
+    let height = dynamic_image.height();
+    let image_size = size(DevicePixels(width as i32), DevicePixels(height as i32));
+
+    // First apply any provider-specific dimension constraints we know about (Anthropic).
+    let mut processed_image = if image_size.width.0 > ANTHROPIC_SIZE_LIMIT as i32
+        || image_size.height.0 > ANTHROPIC_SIZE_LIMIT as i32
+    {
+        let new_bounds = ObjectFit::ScaleDown.get_bounds(
+            gpui::Bounds {
+                origin: point(px(0.0), px(0.0)),
+                size: size(px(ANTHROPIC_SIZE_LIMIT), px(ANTHROPIC_SIZE_LIMIT)),
+            },
+            image_size,
+        );
+        dynamic_image.resize(
+            new_bounds.size.width.into(),
+            new_bounds.size.height.into(),
+            image::imageops::FilterType::Triangle,
+        )
+    } else {
+        dynamic_image
+    };
+
+    // Then enforce a default per-image size cap on the encoded PNG bytes.
+    //
+    // We always send PNG bytes (either original PNG bytes, or re-encoded PNG) base64'd.
+    // The upstream provider limit we want to respect is effectively on the binary image
+    // payload size, so we enforce against the encoded PNG bytes before base64 encoding.
+    let mut encoded_png = encode_png_bytes(&processed_image)?;
+    for _pass in 0..MAX_IMAGE_DOWNSCALE_PASSES {
+        if encoded_png.len() <= DEFAULT_IMAGE_MAX_BYTES {
+            break;
+        }
+
+        // Scale down geometrically to converge quickly. We don't know the final PNG size
+        // as a function of pixels, so we iteratively shrink.
+        let (w, h) = processed_image.dimensions();
+        if w <= 1 || h <= 1 {
+            break;
+        }
+
+        // Shrink by ~15% each pass (0.85). This is a compromise between speed and
+        // preserving image detail.
+        let new_w = ((w as f32) * 0.85).round().max(1.0) as u32;
+        let new_h = ((h as f32) * 0.85).round().max(1.0) as u32;
+
+        processed_image =
+            processed_image.resize(new_w, new_h, image::imageops::FilterType::Triangle);
+        encoded_png = encode_png_bytes(&processed_image)?;
+    }
+
+    anyhow::ensure!(
+        encoded_png.len() <= DEFAULT_IMAGE_MAX_BYTES,
+        "image still exceeds size limit after downscaling ({} bytes)",
+        encoded_png.len()
+    );
+
+    // Now base64 encode the PNG bytes.
+    let base64_image = encode_bytes_as_base64(encoded_png.as_slice())?;
+
+    // SAFETY: The base64 encoder only produces ASCII.
+    let source = unsafe { String::from_utf8_unchecked(base64_image) };
+
+    let (final_width, final_height) = processed_image.dimensions();
+
+    Ok(LanguageModelImage {
+        size: Some(ImageSize {
+            width: final_width as i32,
+            height: final_height as i32,
+        }),
+        source: source.into(),
+    })
 }
 
 fn encode_png_bytes(image: &image::DynamicImage) -> Result<Vec<u8>> {

--- a/crates/language_model_core/src/request.rs
+++ b/crates/language_model_core/src/request.rs
@@ -50,24 +50,27 @@ impl LanguageModelImage {
         }
 
         let source = source?;
-        let size_obj = size_obj?;
 
-        let mut width = None;
-        let mut height = None;
+        let size = size_obj.and_then(|size_obj| {
+            let mut width = None;
+            let mut height = None;
 
-        for (k, v) in size_obj.iter() {
-            match k.to_lowercase().as_str() {
-                "width" => width = v.as_i64().map(|w| w as i32),
-                "height" => height = v.as_i64().map(|h| h as i32),
-                _ => {}
+            for (k, v) in size_obj.iter() {
+                match k.to_lowercase().as_str() {
+                    "width" => width = v.as_i64().map(|w| w as i32),
+                    "height" => height = v.as_i64().map(|h| h as i32),
+                    _ => {}
+                }
             }
-        }
 
-        Some(Self {
-            size: Some(ImageSize {
+            Some(ImageSize {
                 width: width?,
                 height: height?,
-            }),
+            })
+        });
+
+        Some(Self {
+            size,
             source: SharedString::from(source.to_string()),
         })
     }
@@ -622,5 +625,50 @@ mod tests {
             reasoning_details: None,
         };
         assert_eq!(message.string_contents(), "prefix first second suffix");
+    }
+
+    #[test]
+    fn test_deserialize_tool_result_content_mixed() {
+        // Simulates a stored tool result with text + image (no size field),
+        // as produced by MCP tool responses.
+        let json = serde_json::json!([
+            {"Text": "Analysis complete."},
+            {"Image": {"source": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg=="}}
+        ]);
+
+        let content: Vec<LanguageModelToolResultContent> =
+            serde_json::from_value(json).expect("should deserialize mixed content");
+
+        assert_eq!(content.len(), 2);
+        assert!(
+            matches!(&content[0], LanguageModelToolResultContent::Text(t) if t.as_ref() == "Analysis complete.")
+        );
+        assert!(
+            matches!(&content[1], LanguageModelToolResultContent::Image(img) if !img.source.is_empty() && img.size.is_none())
+        );
+    }
+
+    #[test]
+    fn test_deserialize_tool_result_content_image_with_size() {
+        let json = serde_json::json!(
+            {"Image": {"source": "abc123", "size": {"width": 100, "height": 200}}}
+        );
+
+        let content: LanguageModelToolResultContent =
+            serde_json::from_value(json).expect("should deserialize image with size");
+
+        match content {
+            LanguageModelToolResultContent::Image(img) => {
+                assert_eq!(img.source.as_ref(), "abc123");
+                assert_eq!(
+                    img.size,
+                    Some(ImageSize {
+                        width: 100,
+                        height: 200
+                    })
+                );
+            }
+            _ => panic!("expected Image variant"),
+        }
     }
 }


### PR DESCRIPTION
Previously, MCP tool responses containing images were simply ignored with a warning log. This change properly handles image content by:

1. Extracting image data from MCP ToolResponseContent::Image
2. Creating LanguageModelImage for the LLM to process
3. Updating the tool call UI via event_stream.update_fields()
4. Returning image content as LanguageModelToolResultContent::Image

The change also:
- Properly handles text content by updating the UI with TextContent blocks
- Logs resource content URIs for debugging instead of silently ignoring
- Adds supports_images field to FakeLanguageModel for testing

## Testing

Added unit tests for MCP tool returning only image content and mixed text/image content.

### Manual Testing with MCP Test Server
The [MCP Test Server](https://github.com/dastrobu/mcp-test-server) was used to verify image handling.

<img width="837" height="846" alt="image" src="https://github.com/user-attachments/assets/5a7089cb-b208-47ef-af4a-8fb955c106ba" />

with image previews in tool responses:

<img width="836" height="907" alt="image" src="https://github.com/user-attachments/assets/811e33b6-e8e1-458a-b5f6-749e6be5b955" />


#### Setup
1. Install the test server: `cargo install --git https://github.com/dastrobu/mcp-test-server`
2. Add to Zed `settings.json`: ```json "context_servers": { "mcp-test-server": { "command": "mcp-test-server" } } ```
3. Tested PNG, GIF, JPEG, and WebP formats - all work correctly

Release Notes:

- Added support for image content in MCP tool responses


