### PR TITLE
theme: Add adaptive icon themes

### DIFF
--- a/crates/theme/src/icon_theme.rs
+++ b/crates/theme/src/icon_theme.rs
@@ -3,7 +3,32 @@ use std::sync::{Arc, LazyLock};
 use collections::HashMap;
 use gpui::SharedString;
 
-use crate::Appearance;
+/// The appearance of an icon theme.
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum IconAppearance {
+    /// A light appearance.
+    Light,
+    /// A dark appearance.
+    Dark,
+    /// A monochrome theme where icons are rendered with the theme's text color.
+    Monochrome,
+}
+
+impl IconAppearance {
+    /// Returns whether the icon theme is monochrome.
+    pub fn is_monochrome(&self) -> bool {
+        matches!(self, Self::Monochrome)
+    }
+
+    /// Icon sort order: monochrome > dark > light.
+    pub fn sort_order(&self) -> u8 {
+        match self {
+            Self::Monochrome => 0,
+            Self::Dark => 1,
+            Self::Light => 2,
+        }
+    }
+}
 
 /// A family of icon themes.
 pub struct IconThemeFamily {
@@ -24,8 +49,8 @@ pub struct IconTheme {
     pub id: String,
     /// The name of the icon theme.
     pub name: SharedString,
-    /// The appearance of the icon theme (e.g., light or dark).
-    pub appearance: Appearance,
+    /// The appearance of the icon theme (e.g., light, dark, or monochrome).
+    pub appearance: IconAppearance,
     /// The icons used for directories.
     pub directory_icons: DirectoryIcons,
     /// The icons used for named directories.
@@ -395,7 +420,7 @@ static DEFAULT_ICON_THEME: LazyLock<Arc<IconTheme>> = LazyLock::new(|| {
     Arc::new(IconTheme {
         id: "zed".into(),
         name: DEFAULT_ICON_THEME_NAME.into(),
-        appearance: Appearance::Dark,
+        appearance: IconAppearance::Dark,
         directory_icons: DirectoryIcons {
             collapsed: Some("icons/file_icons/folder.svg".into()),
             expanded: Some("icons/file_icons/folder_open.svg".into()),

--- a/crates/theme/src/icon_theme_schema.rs
+++ b/crates/theme/src/icon_theme_schema.rs
@@ -5,7 +5,13 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-use crate::AppearanceContent;
+#[derive(Debug, PartialEq, Clone, Copy, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum IconAppearanceContent {
+    Light,
+    Dark,
+    Monochrome,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct IconThemeFamilyContent {
@@ -17,7 +23,7 @@ pub struct IconThemeFamilyContent {
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct IconThemeContent {
     pub name: String,
-    pub appearance: AppearanceContent,
+    pub appearance: IconAppearanceContent,
     #[serde(default)]
     pub directory_icons: DirectoryIconsContent,
     #[serde(default)]

--- a/crates/theme/src/registry.rs
+++ b/crates/theme/src/registry.rs
@@ -12,9 +12,9 @@ use thiserror::Error;
 use util::ResultExt;
 
 use crate::{
-    Appearance, AppearanceContent, ChevronIcons, DEFAULT_ICON_THEME_NAME, DirectoryIcons,
-    IconDefinition, IconTheme, Theme, ThemeFamily, ThemeFamilyContent, default_icon_theme,
-    read_icon_theme, read_user_theme, refine_theme_family,
+    Appearance, ChevronIcons, DEFAULT_ICON_THEME_NAME, DirectoryIcons, IconAppearance,
+    IconAppearanceContent, IconDefinition, IconTheme, Theme, ThemeFamily, ThemeFamilyContent,
+    default_icon_theme, read_icon_theme, read_user_theme, refine_theme_family,
 };
 
 /// The metadata for a theme.
@@ -24,6 +24,15 @@ pub struct ThemeMeta {
     pub name: SharedString,
     /// The appearance of the theme.
     pub appearance: Appearance,
+}
+
+/// The metadata for an icon theme.
+#[derive(Debug, Clone)]
+pub struct IconThemeMeta {
+    /// The name of the icon theme.
+    pub name: SharedString,
+    /// The appearance of the icon theme.
+    pub appearance: IconAppearance,
 }
 
 /// An error indicating that the theme with the given name was not found.
@@ -243,12 +252,12 @@ impl ThemeRegistry {
     }
 
     /// Returns the metadata of all icon themes in the registry.
-    pub fn list_icon_themes(&self) -> Vec<ThemeMeta> {
+    pub fn list_icon_themes(&self) -> Vec<IconThemeMeta> {
         self.state
             .read()
             .icon_themes
             .values()
-            .map(|theme| ThemeMeta {
+            .map(|theme| IconThemeMeta {
                 name: theme.name.clone(),
                 appearance: theme.appearance,
             })
@@ -320,8 +329,9 @@ impl ThemeRegistry {
                 id: uuid::Uuid::new_v4().to_string(),
                 name: icon_theme.name.into(),
                 appearance: match icon_theme.appearance {
-                    AppearanceContent::Light => Appearance::Light,
-                    AppearanceContent::Dark => Appearance::Dark,
+                    IconAppearanceContent::Light => IconAppearance::Light,
+                    IconAppearanceContent::Dark => IconAppearance::Dark,
+                    IconAppearanceContent::Monochrome => IconAppearance::Monochrome,
                 },
                 directory_icons: DirectoryIcons {
                     collapsed: icon_theme.directory_icons.collapsed.map(resolve_icon_path),

--- a/crates/theme_selector/src/icon_theme_selector.rs
+++ b/crates/theme_selector/src/icon_theme_selector.rs
@@ -8,7 +8,7 @@ use picker::{Picker, PickerDelegate};
 use settings::{Settings as _, SettingsStore, update_settings_file};
 use std::sync::Arc;
 use theme::{
-    Appearance, IconThemeName, IconThemeSelection, SystemAppearance, ThemeMeta, ThemeRegistry,
+    Appearance, IconThemeMeta, IconThemeName, IconThemeSelection, SystemAppearance, ThemeRegistry,
     ThemeSettings,
 };
 use ui::{ListItem, ListItemSpacing, prelude::*, v_flex};
@@ -52,7 +52,7 @@ impl Render for IconThemeSelector {
 
 pub(crate) struct IconThemeSelectorDelegate {
     fs: Arc<dyn Fs>,
-    themes: Vec<ThemeMeta>,
+    themes: Vec<IconThemeMeta>,
     matches: Vec<StringMatch>,
     original_theme: IconThemeName,
     selection_completed: bool,
@@ -88,8 +88,8 @@ impl IconThemeSelectorDelegate {
 
         themes.sort_unstable_by(|a, b| {
             a.appearance
-                .is_light()
-                .cmp(&b.appearance.is_light())
+                .sort_order()
+                .cmp(&b.appearance.sort_order())
                 .then(a.name.cmp(&b.name))
         });
         let matches = themes

--- a/crates/ui/src/components/icon.rs
+++ b/crates/ui/src/components/icon.rs
@@ -1,9 +1,6 @@
 mod decorated_icon;
 mod icon_decoration;
 
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
-
 pub use decorated_icon::*;
 use gpui::{AnimationElement, AnyElement, Hsla, IntoElement, Rems, Transformation, img, svg};
 pub use icon_decoration::*;
@@ -121,7 +118,7 @@ enum IconSource {
     /// Currently our SVG renderer is missing support for rendering polychrome SVGs.
     ///
     /// In order to support icon themes, we render the icons as images instead.
-    External(Arc<Path>),
+    External(SharedString),
     /// An SVG not embedded in the Zed binary.
     ExternalSvg(SharedString),
 }
@@ -152,7 +149,7 @@ impl Icon {
         let source = if path.starts_with("icons/") {
             IconSource::Embedded(path)
         } else {
-            IconSource::External(Arc::from(PathBuf::from(path.as_ref())))
+            IconSource::External(path)
         };
         Self {
             source,
@@ -214,11 +211,26 @@ impl RenderOnce for Icon {
                 .flex_none()
                 .text_color(self.color.color(cx))
                 .into_any_element(),
-            IconSource::External(path) => img(path)
-                .size(self.size)
-                .flex_none()
-                .text_color(self.color.color(cx))
-                .into_any_element(),
+            IconSource::External(path) => {
+                // TODO: support monochrome rendering for non-SVG icons
+                if theme::GlobalTheme::icon_theme(cx).appearance.is_monochrome()
+                    && path.ends_with(".svg")
+                {
+                    svg()
+                        .external_path(path)
+                        .with_transformation(self.transformation)
+                        .size(self.size)
+                        .flex_none()
+                        .text_color(self.color.color(cx))
+                        .into_any_element()
+                } else {
+                    img(path)
+                        .size(self.size)
+                        .flex_none()
+                        .text_color(self.color.color(cx))
+                        .into_any_element()
+                }
+            }
         }
     }
 }

--- a/docs/src/extensions/icon-themes.md
+++ b/docs/src/extensions/icon-themes.md
@@ -13,7 +13,7 @@ There are two important directories for an icon theme extension:
 - `icon_themes`: This directory will contain one or more JSON files containing the icon theme definitions.
 - `icons`: This directory contains the icon assets that will be distributed with the extension. You can created subdirectories in this directory, if so desired.
 
-Each icon theme file should adhere to the JSON schema specified at [`https://zed.dev/schema/icon_themes/v0.3.0.json`](https://zed.dev/schema/icon_themes/v0.3.0.json).
+Each icon theme file should adhere to the JSON schema specified at [`https://zed.dev/schema/icon_themes/v0.4.0.json`](https://zed.dev/schema/icon_themes/v0.4.0.json).
 
 Here is an example of the structure of an icon theme:
 
@@ -76,3 +76,10 @@ icons/
   folder.svg
   rust.svg
 ```
+### Appearance
+
+The `appearance` field controls grouping and how the icon theme is displayed:
+
+  * `dark`: The icon theme is intended to be used with dark themes.
+  * `light`: The icon theme is intended to be used with light themes.
+  * `monochrome`: The icon theme will be treated as monochromatic, and icons will display with the same color as `text.muted` for the current theme (.svg only)


### PR DESCRIPTION
This PR adds a new `monochrome` value to the `appearance` field for icon themes. If a theme uses this value, svg icons will be rendered in the same way as builtin and extension icons, styling them with the current theme value for `text.muted`.

![adaptive_icons](https://github.com/user-attachments/assets/72487b80-68cf-4064-a3df-8e15f2f11f8c)

The implementation is currently incomplete, since raster icons are not affected, and would still appear in color, but addressing that is a deeper cut, so I'm posting this as a draft to see if there's interest in this feature and to discuss implementation if there is. This code is also probably at least one level too high in the call chain.

Note also that the change to the icon themes schema version number is just a placeholder; I expect someone else would make that call if this moves forward.

Release Notes:
  - Add additional icon theme appearance `monochrome`, which allows single-color icon themes to change style with the color theme.