### PR TITLE
Add gemini-3.1-pro-preview model

### DIFF
--- a/crates/google_ai/src/google_ai.rs
+++ b/crates/google_ai/src/google_ai.rs
@@ -514,6 +514,8 @@ pub enum Model {
     Gemini3Pro,
     #[serde(rename = "gemini-3-flash-preview")]
     Gemini3Flash,
+    #[serde(rename = "gemini-3.1-pro-preview")]
+    Gemini31Pro,
     #[serde(rename = "custom")]
     Custom {
         name: String,
@@ -537,6 +539,7 @@ impl Model {
             Self::Gemini25Pro => "gemini-2.5-pro",
             Self::Gemini3Pro => "gemini-3-pro-preview",
             Self::Gemini3Flash => "gemini-3-flash-preview",
+            Self::Gemini31Pro => "gemini-3.1-pro-preview",
             Self::Custom { name, .. } => name,
         }
     }
@@ -547,6 +550,7 @@ impl Model {
             Self::Gemini25Pro => "gemini-2.5-pro",
             Self::Gemini3Pro => "gemini-3-pro-preview",
             Self::Gemini3Flash => "gemini-3-flash-preview",
+            Self::Gemini31Pro => "gemini-3.1-pro-preview",
             Self::Custom { name, .. } => name,
         }
     }
@@ -558,6 +562,7 @@ impl Model {
             Self::Gemini25Pro => "Gemini 2.5 Pro",
             Self::Gemini3Pro => "Gemini 3 Pro",
             Self::Gemini3Flash => "Gemini 3 Flash",
+            Self::Gemini31Pro => "Gemini 3.1 Pro",
             Self::Custom {
                 name, display_name, ..
             } => display_name.as_ref().unwrap_or(name),
@@ -570,7 +575,8 @@ impl Model {
             | Self::Gemini25Flash
             | Self::Gemini25Pro
             | Self::Gemini3Pro
-            | Self::Gemini3Flash => 1_048_576,
+            | Self::Gemini3Flash
+            | Self::Gemini31Pro => 1_048_576,
             Self::Custom { max_tokens, .. } => *max_tokens,
         }
     }
@@ -581,7 +587,8 @@ impl Model {
             | Model::Gemini25Flash
             | Model::Gemini25Pro
             | Model::Gemini3Pro
-            | Model::Gemini3Flash => Some(65_536),
+            | Model::Gemini3Flash
+            | Model::Gemini31Pro => Some(65_536),
             Model::Custom { .. } => None,
         }
     }
@@ -607,6 +614,9 @@ impl Model {
                 }
             }
             Self::Gemini3Flash => GoogleModelMode::Default,
+            Self::Gemini31Pro => GoogleModelMode::Thinking {
+                budget_tokens: None,
+            },
             Self::Custom { mode, .. } => *mode,
         }
     }


### PR DESCRIPTION
Closes AI-48

Release Notes:

- Added support for Gemini 3.1 Pro