### PR TITLE
cloud_api_client: Bump `yawc` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16290,7 +16290,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "webpki-roots",
+ "webpki-roots 0.26.8",
 ]
 
 [[package]]
@@ -19984,6 +19984,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webrtc-sys"
 version = "0.3.23"
 source = "git+https://github.com/zed-industries/livekit-rust-sdks?rev=cf4375b244ebb51702968df7fc36e192d0f45ad5#cf4375b244ebb51702968df7fc36e192d0f45ad5"
@@ -21674,23 +21683,25 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yawc"
-version = "0.2.5"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a5d82922135b4ae73a079a4ffb5501e9aadb4d785b8c660eaa0a8b899028c5"
+checksum = "90d444f0daf07fca269c92049547f598cab089a4366b60cfb17963231acdd243"
 dependencies = [
  "base64 0.22.1",
  "bytes 1.11.1",
  "flate2",
  "futures 0.3.31",
+ "getrandom 0.2.16",
  "http-body-util",
  "hyper 1.7.0",
  "hyper-util",
  "js-sys",
+ "log",
  "nom 8.0.0",
  "pin-project",
  "rand 0.8.5",
  "sha1",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-rustls 0.26.2",
  "tokio-util",
@@ -21698,7 +21709,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -781,7 +781,7 @@ wasm-bindgen = "0.2.113"
 web-time = "1.1.0"
 wgpu = { git = "https://github.com/zed-industries/wgpu", rev = "465557eccfe77c840a9b4936f1408da9503372c4" }
 windows-core = "0.61"
-yawc = "0.2.5"
+yawc = "0.3.3"
 zeroize = "1.8"
 zstd = "0.11"
 

--- a/crates/cloud_api_client/src/websocket.rs
+++ b/crates/cloud_api_client/src/websocket.rs
@@ -4,30 +4,27 @@ use std::time::Duration;
 use anyhow::Result;
 use cloud_api_types::websocket_protocol::MessageToClient;
 use futures::channel::mpsc::unbounded;
-use futures::stream::{SplitSink, SplitStream};
 use futures::{FutureExt as _, SinkExt as _, Stream, StreamExt as _, TryStreamExt as _, pin_mut};
 use gpui::{App, BackgroundExecutor, Task};
-use yawc::WebSocket;
-use yawc::frame::{FrameView, OpCode};
+use yawc::TcpWebSocket;
+use yawc::frame::{Frame, OpCode};
 
 const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(1);
 
 pub type MessageStream = Pin<Box<dyn Stream<Item = Result<MessageToClient>>>>;
 
-pub struct Connection {
-    tx: SplitSink<WebSocket, FrameView>,
-    rx: SplitStream<WebSocket>,
-}
+/// Wrapper around a [`WebSocket`] which provides a [`spawn`](Self::spawn) method.
+///
+/// This allows handling a [`tokio`] based websocket using a [`gpui::Task`].
+pub struct Connection(TcpWebSocket);
 
 impl Connection {
-    pub fn new(ws: WebSocket) -> Self {
-        let (tx, rx) = ws.split();
-
-        Self { tx, rx }
+    pub fn new(ws: TcpWebSocket) -> Self {
+        Self(ws)
     }
 
     pub fn spawn(self, cx: &App) -> (MessageStream, Task<()>) {
-        let (mut tx, rx) = (self.tx, self.rx);
+        let (mut tx, rx) = self.0.split();
 
         let (message_tx, message_rx) = unbounded();
 
@@ -42,7 +39,7 @@ impl Connection {
             loop {
                 futures::select_biased! {
                     _ = keepalive_timer => {
-                        let _ = tx.send(FrameView::ping(Vec::new())).await;
+                        let _ = tx.send(Frame::ping(Vec::new())).await;
 
                         keepalive_timer.set(executor.timer(KEEPALIVE_INTERVAL).fuse());
                     }
@@ -51,9 +48,9 @@ impl Connection {
                             break;
                         };
 
-                        match frame.opcode {
+                        match frame.opcode() {
                             OpCode::Binary => {
-                                let message_result = MessageToClient::deserialize(&frame.payload);
+                                let message_result = MessageToClient::deserialize(frame.payload());
                                 message_tx.unbounded_send(message_result).ok();
                             }
                             OpCode::Close => {


### PR DESCRIPTION
Closes #ISSUE

Bumps the `yawc` dependency used for WebSockets.

Motivation:

- Removes the strict dependency on `tokio`, meaning we can bring WebSocket handling under Zed's own scheduler in a future PR, this would remove the need for the whole `Connection` struct
- Simplified API
- Slightly improved performance

Before you mark this PR as ready for review, make sure that you have:
- [ ] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [ ] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- N/A
