### PR TITLE
repl: Add clear output(s) command

### DIFF
--- a/crates/repl/src/repl.rs
+++ b/crates/repl/src/repl.rs
@@ -20,7 +20,7 @@ pub use crate::jupyter_settings::JupyterSettings;
 pub use crate::kernels::{Kernel, KernelSpecification, KernelStatus, PythonEnvKernelSpecification};
 pub use crate::repl_editor::*;
 pub use crate::repl_sessions_ui::{
-    ClearOutputs, Interrupt, ReplSessionsPage, Restart, Run, Sessions, Shutdown,
+    ClearCurrentOutput, ClearOutputs, Interrupt, ReplSessionsPage, Restart, Run, Sessions, Shutdown,
 };
 pub use crate::repl_settings::ReplSettings;
 pub use crate::repl_store::ReplStore;

--- a/crates/repl/src/repl_sessions_ui.rs
+++ b/crates/repl/src/repl_sessions_ui.rs
@@ -21,6 +21,8 @@ actions!(
         RunInPlace,
         /// Clears all outputs in the REPL.
         ClearOutputs,
+        /// Clears the output of the cell at the current cursor position.
+        ClearCurrentOutput,
         /// Opens the REPL sessions panel.
         Sessions,
         /// Interrupts the currently running kernel.


### PR DESCRIPTION
Closes #15947

This adds `repl:ClearCurrentOutput` and `repl:ClearOutputs` commands. No keybindings are set for this. Just an action people can bind.

Release Notes:

- Added ability to clear outputs by action