### PR TITLE
workspace: Add window title customization

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -194,6 +194,12 @@
   //
   // Default: "client"
   "window_decorations": "client",
+  // A template string for the window title.
+  // Available variables: $ZED_TAB_TITLE, $ZED_PROJECTS, $ZED_COLLAB,
+  // $ZED_FILE, $ZED_FILENAME, $ZED_STEM, $ZED_DIRNAME,
+  // $ZED_RELATIVE_FILE, $ZED_RELATIVE_DIR, $ZED_WORKTREE_ROOT
+  // Use ${VAR:default} for fallback values.
+  "window_title_template": "${ZED_PROJECTS:empty project}${ZED_SEPARATOR: — }$ZED_FILENAME${ZED_SEPARATOR: — }${ZED_COLLAB}",
   // Whether to use the system provided dialogs for Open and Save As.
   // When set to false, Zed will use the built-in keyboard-first pickers.
   "use_system_path_prompts": true,

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -989,6 +989,7 @@ impl VsCodeSettings {
                 }
             }),
             zoomed_padding: None,
+            window_title_template: None,
         }
     }
 

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -122,6 +122,29 @@ pub struct WorkspaceSettingsContent {
     /// What draws window decorations/titlebar, the client application (Zed) or display server
     /// Default: client
     pub window_decorations: Option<WindowDecorations>,
+    /// A template string for the window title.
+    ///
+    /// Available variables:
+    /// - `$ZED_TAB_TITLE` — Active tab's title text (empty string if none)
+    /// - `$ZED_PROJECTS` — Comma-separated project names
+    /// - `$ZED_COLLAB` — Collab indicator (` ↙` for remote, ` ↗` for shared, or empty)
+    /// - `$ZED_FILE` — Absolute path of the currently opened file
+    /// - `$ZED_FILENAME` — Name of the currently opened file
+    /// - `$ZED_STEM` — Filename without extension
+    /// - `$ZED_DIRNAME` — Absolute path of the file's parent directory
+    /// - `$ZED_RELATIVE_FILE` — File path relative to worktree root
+    /// - `$ZED_RELATIVE_DIR` — Directory path relative to worktree root
+    /// - `$ZED_WORKTREE_ROOT` — Absolute path of the active worktree root
+    /// - `$ZED_SEPARATOR` — A conditional separator that only renders when both
+    ///   adjacent sides have non-empty content. Use `${ZED_SEPARATOR: — }` to
+    ///   specify the separator value (defaults to ` — `).
+    ///
+    /// File-related variables are only set when a file is active.
+    /// Use `${VAR:default}` syntax for fallback values,
+    /// e.g. `${ZED_PROJECTS:empty project}`.
+    ///
+    /// Default: `${ZED_PROJECTS:empty project}${ZED_SEPARATOR: — }$ZED_FILENAME${ZED_SEPARATOR: — }${ZED_COLLAB}`
+    pub window_title_template: Option<String>,
 }
 
 #[with_fallible_options]

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -4118,7 +4118,7 @@ fn window_and_layout_page() -> SettingsPage {
         ]
     }
 
-    fn window_section() -> [SettingsPageItem; 3] {
+    fn window_section() -> [SettingsPageItem; 4] {
         [
             SettingsPageItem::SectionHeader("Window"),
             // todo(settings_ui): Should we filter by platform.as_ref()?
@@ -4148,6 +4148,24 @@ fn window_and_layout_page() -> SettingsPage {
                     },
                 }),
                 metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Window Title Template",
+                description: "The template used to generate the window title. Supported variables: $ZED_PROJECTS, $ZED_TAB_TITLE, $ZED_COLLAB, $ZED_FILE, $ZED_FILENAME, $ZED_STEM, $ZED_DIRNAME, $ZED_RELATIVE_FILE, $ZED_RELATIVE_DIR, $ZED_WORKTREE_ROOT.",
+                field: Box::new(SettingField {
+                    json_path: Some("window_title_template"),
+                    pick: |settings_content| {
+                        settings_content.workspace.window_title_template.as_ref()
+                    },
+                    write: |settings_content, value| {
+                        settings_content.workspace.window_title_template = value;
+                    },
+                }),
+                metadata: Some(Box::new(SettingsFieldMetadata {
+                    placeholder: Some("${ZED_PROJECTS} — ${ZED_TAB_TITLE}${ZED_COLLAB}"),
+                    ..Default::default()
+                })),
                 files: USER,
             }),
         ]

--- a/crates/task/src/task.rs
+++ b/crates/task/src/task.rs
@@ -24,7 +24,8 @@ pub use debug_format::{
 };
 pub use task_template::{
     DebugArgsRequest, HideStrategy, RevealStrategy, TaskTemplate, TaskTemplates,
-    substitute_variables_in_map, substitute_variables_in_str,
+    file_template_variables, substitute_template_variables, substitute_variables_in_map,
+    substitute_variables_in_str, template_references_variable,
 };
 pub use util::shell::{Shell, ShellKind};
 pub use util::shell_builder::ShellBuilder;

--- a/crates/task/src/task_template.rs
+++ b/crates/task/src/task_template.rs
@@ -3,7 +3,7 @@ use collections::{HashMap, HashSet};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use util::schemars::{AllowTrailingCommas, DefaultDenyUnknownFields};
 use util::serde::default_true;
 use util::{ResultExt, truncate_and_remove_front};
@@ -365,6 +365,164 @@ pub fn substitute_variables_in_str(template_str: &str, context: &TaskContext) ->
         &mut substituted_variables,
     )
 }
+
+/// Substitutes `$ZED_*` / `${ZED_VAR:default}` variables in a template string
+/// using a plain `HashMap<String, String>`. Unlike [`substitute_variables_in_str`],
+/// this does not track which `VariableName`s were substituted.
+///
+/// Semantics:
+/// - Known variable (in map) → substitute its value, ignore any default
+/// - Unknown `ZED_*` with `${ZED_VAR:default}` → use default
+/// - Unknown `ZED_*` without default → return `None` (substitution failure)
+/// - Non-`ZED_*` variables → left as-is (passthrough)
+/// - `ZED_SEPARATOR` is special: it acts as a conditional separator that only
+///   renders when both adjacent sides have non-empty content. Use
+///   `${ZED_SEPARATOR: — }` to specify the separator value (defaults to ` — `).
+pub fn substitute_template_variables(
+    template_str: &str,
+    variables: &HashMap<String, String>,
+) -> Option<String> {
+    const SEPARATOR_VARIABLE: &str = "ZED_SEPARATOR";
+    const SENTINEL_START: char = '\x01';
+    const SENTINEL_END: char = '\x02';
+    const DEFAULT_SEPARATOR: &str = " \u{2014} ";
+
+    let mut has_separator = false;
+    let substituted = shellexpand::env_with_context(template_str, |var| {
+        let colon_position = var.find(':').unwrap_or(var.len());
+        let (variable_name, default) = var.split_at(colon_position);
+        if variable_name == SEPARATOR_VARIABLE {
+            has_separator = true;
+            let sep_value = if !default.is_empty() {
+                &default[1..]
+            } else {
+                DEFAULT_SEPARATOR
+            };
+            return Ok(Some(format!("{SENTINEL_START}{sep_value}{SENTINEL_END}")));
+        }
+        if let Some(value) = variables.get(variable_name) {
+            return Ok(Some(value.clone()));
+        } else if variable_name.starts_with(ZED_VARIABLE_NAME_PREFIX) {
+            if !default.is_empty() {
+                return Ok(Some(default[1..].to_owned()));
+            } else {
+                bail!("Unknown variable name: {variable_name}");
+            }
+        }
+        if !default.is_empty() {
+            return Ok(Some(format!("${{{var}}}")));
+        }
+        Ok(None)
+    })
+    .ok()?;
+
+    let result = substituted.into_owned();
+    if !has_separator {
+        return Some(result);
+    }
+    Some(collapse_conditional_separators(&result))
+}
+
+fn collapse_conditional_separators(input: &str) -> String {
+    const SENTINEL_START: char = '\x01';
+    const SENTINEL_END: char = '\x02';
+
+    let mut segments: Vec<&str> = Vec::new();
+    let mut separators: Vec<&str> = Vec::new();
+    let mut rest = input;
+
+    while let Some(start) = rest.find(SENTINEL_START) {
+        segments.push(&rest[..start]);
+        rest = &rest[start + SENTINEL_START.len_utf8()..];
+        if let Some(end) = rest.find(SENTINEL_END) {
+            separators.push(&rest[..end]);
+            rest = &rest[end + SENTINEL_END.len_utf8()..];
+        }
+    }
+    segments.push(rest);
+
+    // Collect non-empty segments paired with the separator that preceded them.
+    // When multiple empty segments are skipped, the first separator crossing
+    // from a non-empty segment to the next non-empty segment is used.
+    let mut kept: Vec<(&str, Option<&str>)> = Vec::new();
+    let mut pending_sep: Option<&str> = None;
+    for (i, segment) in segments.iter().enumerate() {
+        if !segment.trim().is_empty() {
+            kept.push((segment, pending_sep));
+            pending_sep = None;
+        }
+        if i < separators.len() && pending_sep.is_none() {
+            pending_sep = Some(separators[i]);
+        }
+    }
+
+    let mut result = String::new();
+    for (i, (segment, sep)) in kept.iter().enumerate() {
+        if i > 0 {
+            if let Some(sep) = sep {
+                result.push_str(sep);
+            }
+        }
+        result.push_str(segment);
+    }
+    result
+}
+
+/// Returns `true` if the template string references the given variable name.
+/// Checks for `$VAR_NAME`, `${VAR_NAME}`, and `${VAR_NAME:...}` patterns.
+pub fn template_references_variable(template: &str, var_name: &str) -> bool {
+    if let Some(pos) = template.find(var_name) {
+        if pos > 0 {
+            let before = template.as_bytes()[pos - 1];
+            return before == b'$' || before == b'{';
+        }
+    }
+    false
+}
+
+/// Computes file-related template variables from path components.
+/// Returns a `HashMap` with keys: `ZED_FILE`, `ZED_FILENAME`, `ZED_STEM`,
+/// `ZED_DIRNAME`, `ZED_RELATIVE_FILE`, `ZED_RELATIVE_DIR`, `ZED_WORKTREE_ROOT`.
+pub fn file_template_variables(
+    abs_file: &Path,
+    worktree_root: &Path,
+    relative_path: &Path,
+) -> HashMap<String, String> {
+    let mut variables = HashMap::default();
+    variables.insert(
+        "ZED_WORKTREE_ROOT".to_string(),
+        worktree_root.to_string_lossy().into_owned(),
+    );
+    variables.insert(
+        "ZED_RELATIVE_FILE".to_string(),
+        relative_path.to_string_lossy().into_owned(),
+    );
+    if let Some(relative_dir) = relative_path.parent() {
+        variables.insert(
+            "ZED_RELATIVE_DIR".to_string(),
+            if relative_dir.as_os_str().is_empty() {
+                ".".to_string()
+            } else {
+                relative_dir.to_string_lossy().into_owned()
+            },
+        );
+    }
+    if let Some(filename) = abs_file.file_name().and_then(|f| f.to_str()) {
+        variables.insert("ZED_FILENAME".to_string(), filename.to_string());
+    }
+    if let Some(stem) = abs_file.file_stem().and_then(|s| s.to_str()) {
+        variables.insert("ZED_STEM".to_string(), stem.to_string());
+    }
+    if let Some(dirname) = abs_file.parent().and_then(|p| p.to_str()) {
+        variables.insert("ZED_DIRNAME".to_string(), dirname.to_string());
+    }
+    variables.insert(
+        "ZED_FILE".to_string(),
+        abs_file.to_string_lossy().into_owned(),
+    );
+    variables
+}
+
 fn substitute_all_template_variables_in_str<A: AsRef<str>>(
     template_str: &str,
     task_variables: &HashMap<String, A>,
@@ -1073,5 +1231,106 @@ mod tests {
         };
 
         assert!(task.unknown_variables().is_empty());
+    }
+    #[test]
+    fn test_file_template_variables_and_substitution() {
+        let worktree_root = Path::new("/projects/app");
+        // On Windows, paths use backslashes, so to make this test robust across platforms
+        // (since it might run on Windows), we should be careful with path separators.
+        // However, `Path::new` creates platform-native paths.
+        // Let's use `join` to construct paths properly.
+        let relative_path = Path::new("src").join("main.rs");
+        let abs_file = worktree_root.join(&relative_path);
+
+        let variables = file_template_variables(&abs_file, worktree_root, &relative_path);
+
+        // We check for presence of keys and some content without relying on strict string equality
+        // for paths that might vary by OS separator.
+        assert!(variables.contains_key("ZED_WORKTREE_ROOT"));
+        assert!(variables.contains_key("ZED_RELATIVE_FILE"));
+        assert_eq!(variables.get("ZED_RELATIVE_DIR").unwrap(), "src");
+        assert_eq!(variables.get("ZED_FILENAME").unwrap(), "main.rs");
+        assert_eq!(variables.get("ZED_STEM").unwrap(), "main");
+
+        let template = "File: ${ZED_FILENAME} | Stem: $ZED_STEM";
+        let substituted = substitute_template_variables(template, &variables).unwrap();
+
+        assert_eq!(substituted, "File: main.rs | Stem: main");
+
+        // Test check for references
+        assert!(template_references_variable(template, "ZED_FILENAME"));
+        assert!(template_references_variable(template, "ZED_STEM"));
+        assert!(!template_references_variable(template, "ZED_NONEXISTENT"));
+
+        // Test default values
+
+        let template_default = "${ZED_UNKNOWN:default_val}";
+        let variables_empty = HashMap::default();
+        let substituted_default =
+            substitute_template_variables(template_default, &variables_empty).unwrap();
+        assert_eq!(substituted_default, "default_val");
+    }
+
+    #[test]
+    fn test_conditional_separator() {
+        let mut vars = HashMap::default();
+        vars.insert("ZED_PROJECTS".to_string(), "my-project".to_string());
+        vars.insert("ZED_FILENAME".to_string(), "main.rs".to_string());
+        vars.insert("ZED_COLLAB".to_string(), "↙".to_string());
+
+        // All variables present — separators render
+        let template =
+            "${ZED_PROJECTS}${ZED_SEPARATOR: — }${ZED_FILENAME}${ZED_SEPARATOR: — }${ZED_COLLAB}";
+        assert_eq!(
+            substitute_template_variables(template, &vars).unwrap(),
+            "my-project — main.rs — ↙"
+        );
+
+        // Empty right side — trailing separator removed
+        vars.insert("ZED_COLLAB".to_string(), String::new());
+        assert_eq!(
+            substitute_template_variables(template, &vars).unwrap(),
+            "my-project — main.rs"
+        );
+
+        // Empty middle — both adjacent separators removed, outer segments joined
+        vars.insert("ZED_FILENAME".to_string(), String::new());
+        vars.insert("ZED_COLLAB".to_string(), "↙".to_string());
+        assert_eq!(
+            substitute_template_variables(template, &vars).unwrap(),
+            "my-project — ↙"
+        );
+
+        // Only first variable has content — all separators removed
+        vars.insert("ZED_FILENAME".to_string(), String::new());
+        vars.insert("ZED_COLLAB".to_string(), String::new());
+        assert_eq!(
+            substitute_template_variables(template, &vars).unwrap(),
+            "my-project"
+        );
+
+        // Different separator values per occurrence
+        let template =
+            "${ZED_PROJECTS}${ZED_SEPARATOR: | }${ZED_FILENAME}${ZED_SEPARATOR: - }${ZED_COLLAB}";
+        vars.insert("ZED_FILENAME".to_string(), "main.rs".to_string());
+        vars.insert("ZED_COLLAB".to_string(), "↙".to_string());
+        assert_eq!(
+            substitute_template_variables(template, &vars).unwrap(),
+            "my-project | main.rs - ↙"
+        );
+
+        // No separator in template — no behavior change
+        let template = "${ZED_PROJECTS} — ${ZED_FILENAME}";
+        assert_eq!(
+            substitute_template_variables(template, &vars).unwrap(),
+            "my-project — main.rs"
+        );
+
+        // Default separator value (no custom value specified)
+        let template = "${ZED_PROJECTS}${ZED_SEPARATOR}${ZED_FILENAME}";
+        assert_eq!(
+            substitute_template_variables(template, &vars).unwrap(),
+            "my-project \u{2014} main.rs"
+        );
     }
 }

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -1417,9 +1417,18 @@ pub mod test {
 
     impl TestProjectItem {
         pub fn new(id: u64, path: &str, cx: &mut App) -> Entity<Self> {
+            Self::new_with_worktree(id, path, WorktreeId::from_usize(0), cx)
+        }
+
+        pub fn new_with_worktree(
+            id: u64,
+            path: &str,
+            worktree_id: WorktreeId,
+            cx: &mut App,
+        ) -> Entity<Self> {
             let entry_id = Some(ProjectEntryId::from_proto(id));
             let project_path = Some(ProjectPath {
-                worktree_id: WorktreeId::from_usize(0),
+                worktree_id,
                 path: rel_path(path).into(),
             });
             cx.new(|_| Self {
@@ -1551,14 +1560,13 @@ pub mod test {
         }
 
         fn tab_content_text(&self, detail: usize, _cx: &App) -> SharedString {
-            self.tab_descriptions
-                .as_ref()
-                .and_then(|descriptions| {
-                    let description = *descriptions.get(detail).or_else(|| descriptions.last())?;
-                    description.into()
-                })
-                .unwrap_or_default()
-                .into()
+            if let Some(descriptions) = &self.tab_descriptions {
+                if let Some(description) = descriptions.get(detail).or_else(|| descriptions.last())
+                {
+                    return (*description).into();
+                }
+            }
+            self.label.clone().into()
         }
 
         fn telemetry_event_text(&self) -> Option<&'static str> {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -122,6 +122,7 @@ use std::{
     time::Duration,
 };
 use task::{DebugScenario, SharedTaskContext, SpawnInTerminal};
+use task::{file_template_variables, substitute_template_variables, template_references_variable};
 use theme::{ActiveTheme, GlobalTheme, SystemAppearance, ThemeSettings};
 pub use toolbar::{
     PaneSearchBarCallbacks, Toolbar, ToolbarItemEvent, ToolbarItemLocation, ToolbarItemView,
@@ -1327,6 +1328,11 @@ impl Workspace {
             })
             .detach();
         }
+
+        cx.observe_global_in::<SettingsStore>(window, |this, window, cx| {
+            this.update_window_title(window, cx);
+        })
+        .detach();
 
         cx.subscribe_in(&project, window, move |this, _, event, window, cx| {
             match event {
@@ -5115,53 +5121,99 @@ impl Workspace {
     }
 
     fn update_window_title(&mut self, window: &mut Window, cx: &mut App) {
+        let template = WorkspaceSettings::get_global(cx)
+            .window_title_template
+            .clone();
+
         let project = self.project().read(cx);
-        let mut title = String::new();
+        let mut variables = HashMap::default();
 
-        for (i, worktree) in project.visible_worktrees(cx).enumerate() {
-            let name = {
-                let settings_location = SettingsLocation {
-                    worktree_id: worktree.read(cx).id(),
-                    path: RelPath::empty(),
+        let needs_projects = template_references_variable(&template, "ZED_PROJECTS");
+        if needs_projects {
+            let mut projects = String::new();
+            for (i, worktree) in project.visible_worktrees(cx).enumerate() {
+                let name = {
+                    let settings_location = SettingsLocation {
+                        worktree_id: worktree.read(cx).id(),
+                        path: RelPath::empty(),
+                    };
+                    let settings = WorktreeSettings::get(Some(settings_location), cx);
+                    match &settings.project_name {
+                        Some(name) => name.as_str(),
+                        None => worktree.read(cx).root_name_str(),
+                    }
                 };
-
-                let settings = WorktreeSettings::get(Some(settings_location), cx);
-                match &settings.project_name {
-                    Some(name) => name.as_str(),
-                    None => worktree.read(cx).root_name_str(),
+                if i > 0 {
+                    projects.push_str(", ");
                 }
+                projects.push_str(name);
+            }
+            variables.insert("ZED_PROJECTS".to_string(), projects);
+        }
+
+        if template_references_variable(&template, "ZED_TAB_TITLE") {
+            let tab_title = self
+                .active_item(cx)
+                .map(|item| item.tab_content_text(0, cx).to_string())
+                .unwrap_or_default();
+            variables.insert("ZED_TAB_TITLE".to_string(), tab_title);
+        }
+
+        if template_references_variable(&template, "ZED_COLLAB") {
+            let collab = if project.is_via_collab() {
+                "↙"
+            } else if project.is_shared() {
+                "↗"
+            } else {
+                ""
             };
-            if i > 0 {
-                title.push_str(", ");
+            variables.insert("ZED_COLLAB".to_string(), collab.to_string());
+        }
+
+        let needs_file_vars = [
+            "ZED_FILE",
+            "ZED_FILENAME",
+            "ZED_STEM",
+            "ZED_DIRNAME",
+            "ZED_RELATIVE_FILE",
+            "ZED_RELATIVE_DIR",
+            "ZED_WORKTREE_ROOT",
+        ]
+        .iter()
+        .any(|var| template_references_variable(&template, var));
+
+        let file_var_names = [
+            "ZED_FILE",
+            "ZED_FILENAME",
+            "ZED_STEM",
+            "ZED_DIRNAME",
+            "ZED_RELATIVE_FILE",
+            "ZED_RELATIVE_DIR",
+            "ZED_WORKTREE_ROOT",
+        ];
+        if needs_file_vars {
+            if let Some(project_path) = self.active_item(cx).and_then(|item| item.project_path(cx))
+            {
+                if let Some(worktree) = project.worktree_for_id(project_path.worktree_id, cx) {
+                    let worktree = worktree.read(cx);
+                    let abs_worktree = worktree.abs_path();
+                    let abs_file = abs_worktree.join(project_path.path.as_std_path());
+                    variables.extend(file_template_variables(
+                        &abs_file,
+                        &abs_worktree,
+                        project_path.path.as_std_path(),
+                    ));
+                }
             }
-            title.push_str(name);
-        }
-
-        if title.is_empty() {
-            title = "empty project".to_string();
-        }
-
-        if let Some(path) = self.active_item(cx).and_then(|item| item.project_path(cx)) {
-            let filename = path.path.file_name().or_else(|| {
-                Some(
-                    project
-                        .worktree_for_id(path.worktree_id, cx)?
-                        .read(cx)
-                        .root_name_str(),
-                )
-            });
-
-            if let Some(filename) = filename {
-                title.push_str(" — ");
-                title.push_str(filename.as_ref());
+            for var in &file_var_names {
+                variables.entry(var.to_string()).or_default();
             }
         }
 
-        if project.is_via_collab() {
-            title.push_str(" ↙");
-        } else if project.is_shared() {
-            title.push_str(" ↗");
-        }
+        let title = substitute_template_variables(&template, &variables)
+            .unwrap_or_else(|| "Zed".into())
+            .trim()
+            .to_string();
 
         if let Some(last_title) = self.last_window_title.as_ref()
             && &title == last_title
@@ -13162,5 +13214,89 @@ mod tests {
             );
             assert!(panel.is_zoomed(window, cx));
         });
+    }
+
+    #[gpui::test]
+    async fn test_window_title_updates(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        // "root" matches the project name we expect in default title
+        let project = Project::test(fs, ["/root".as_ref()], cx).await;
+
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
+
+        // Wait for usage of default title
+        cx.run_until_parked();
+
+        // 1. Check default title (with just "root" project, no file open)
+        let initial_title = cx.window_title().unwrap();
+        // Default template: "${ZED_PROJECTS:empty project}${ZED_SEPARATOR: — }${ZED_FILENAME:}${ZED_SEPARATOR: — }${ZED_COLLAB}"
+        // ZED_PROJECTS -> "root", ZED_FILENAME -> "" (default), ZED_COLLAB -> ""
+        // Separators collapse because adjacent content is empty
+        assert_eq!(
+            initial_title, "root",
+            "Default title with no file should have no trailing separator"
+        );
+
+        // 2. Change the template to something simple
+        cx.update_global(|store: &mut SettingsStore, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings.workspace.window_title_template =
+                    Some("Title: ${ZED_PROJECTS} | Item: ${ZED_TAB_TITLE}".to_string());
+            });
+        });
+        cx.run_until_parked();
+
+        // 3. Open a file to set the tab title
+        let worktree_id = project.read_with(cx, |project, cx| {
+            project.worktrees(cx).next().unwrap().read(cx).id()
+        });
+        let item = cx.new(|cx| {
+            TestItem::new(cx)
+                .with_label("my_file.txt")
+                .with_project_items(&[TestProjectItem::new_with_worktree(
+                    1,
+                    "my_file.txt",
+                    worktree_id,
+                    cx,
+                )])
+        });
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.add_item_to_active_pane(Box::new(item), None, true, window, cx);
+        });
+        cx.run_until_parked();
+
+        assert_eq!(
+            cx.window_title().unwrap(),
+            "Title: root | Item: my_file.txt"
+        );
+
+        // 4. Test file variable: ZED_FILENAME
+        cx.update_global(|store: &mut SettingsStore, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings.workspace.window_title_template =
+                    Some("File: ${ZED_FILENAME}".to_string());
+            });
+        });
+        cx.run_until_parked();
+        assert_eq!(cx.window_title().unwrap(), "File: my_file.txt");
+
+        // 5. Test file variable: ZED_WORKTREE_ROOT
+        cx.update_global(|store: &mut SettingsStore, cx| {
+            store.update_user_settings(cx, |settings| {
+                settings.workspace.window_title_template = Some("${ZED_WORKTREE_ROOT}".to_string());
+            });
+        });
+        cx.run_until_parked();
+        let title = cx.window_title().unwrap();
+        // The fake fs root might be slightly different depending on platform/internal implementation
+        // but it should contain "root"
+        assert!(
+            title.contains("root") || title.contains("/root"),
+            "Title '{}' should contain root path",
+            title
+        );
     }
 }

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -35,6 +35,7 @@ pub struct WorkspaceSettings {
     pub use_system_window_tabs: bool,
     pub zoomed_padding: bool,
     pub window_decorations: settings::WindowDecorations,
+    pub window_title_template: String,
 }
 
 #[derive(Copy, Clone, PartialEq, Debug, Default)]
@@ -113,6 +114,7 @@ impl Settings for WorkspaceSettings {
             use_system_window_tabs: workspace.use_system_window_tabs.unwrap(),
             zoomed_padding: workspace.zoomed_padding.unwrap(),
             window_decorations: workspace.window_decorations.unwrap(),
+            window_title_template: workspace.window_title_template.clone().unwrap(),
         }
     }
 }


### PR DESCRIPTION
new window_title_template setting


Before you mark this PR as ready for review, make sure that you have:
- [x ] Added a solid test coverage and/or screenshots from doing manual testing
- [x ] Done a self-review taking into account security and performance aspects
- [ x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Added Window title customization through window_title_template setting



This adds window title customization using similar templating to the existing task code with ZED_* variables.   This should be in line with Zed’s contribution guidelines of “Small extra features, like keybindings or actions you miss from other editors or extensions.”  This allows for similar functionality to vscodes window.title (` "window.title": "${rootName}${separator}${dirty}${activeEditorShort}${separator}${appName}”` ) and allow for sublime style titles where untitled files still can change the window title.  This is useful for those who might also use zed as something of a multi-window scratch pad so it shows something rather than just “empty project”.

The biggest area for potential improvement is probably performance related.   I don’t think the current code does any large amounts of work and I tried to add some minor early pruning by only computing template variables that are contained in the string.   This customization shouldn’t change the default behavior as the default string `` should emulate the current window title fairly well.  

Note there are a good 50+ lines of this PR just around the ZED_SEPERATOR support.   If we were OK with a slightly degraded from current experience where when there wasn't a file open for example it would show "project - " with nothing after, then we could remove it.   The separator implementation here is implemented differently from vscode is a bit of a simpler fashion using sentinels rather than keeping the entire thing segments.   We are also abusing the bash default shorthand to allow the user to override the separator value (basically a reverse of the default option).  This is a bit more dynamic that VSCode that just allows setting the separator as a global setting vs here where you could have different separators for different parts.


<img width="947" height="386" alt="image" src="https://github.com/user-attachments/assets/355d36fc-d529-4c54-8e5d-0c5281bc45ac" />
