### PR TITLE
Fix subagent card buttons getting clipped by long titles

### DIFF
--- a/crates/agent_ui/src/acp/thread_view/active_thread.rs
+++ b/crates/agent_ui/src/acp/thread_view/active_thread.rs
@@ -6104,9 +6104,16 @@ impl AcpThreadView {
                     .bg(self.tool_card_header_bg(cx))
                     .child(
                         h_flex()
+                            .id(format!("subagent-title-{}-{}", entry_ix, context_ix))
+                            .min_w_0()
+                            .overflow_hidden()
                             .gap_1p5()
                             .child(icon)
-                            .child(Label::new(title.to_string()).size(LabelSize::Small))
+                            .child(
+                                Label::new(title.to_string())
+                                    .size(LabelSize::Small)
+                                    .truncate(),
+                            )
                             .when(files_changed > 0, |this| {
                                 this.child(
                                     h_flex()
@@ -6126,11 +6133,13 @@ impl AcpThreadView {
                                             diff_stats.lines_removed as usize,
                                         )),
                                 )
-                            }),
+                            })
+                            .tooltip(Tooltip::text(title.to_string())),
                     )
                     .when_some(session_id, |this, session_id| {
                         this.child(
                             h_flex()
+                                .flex_shrink_0()
                                 .when(has_expandable_content, |this| {
                                     this.child(
                                         IconButton::new(


### PR DESCRIPTION
When a subagent title is long, the header buttons (expand/collapse, maximize, stop) were pushed out of view because the title area grew unconstrained.

## Fix

- Add `min_w_0()` and `overflow_hidden()` to the title container so it can shrink below its content width
- Add `truncate()` to the title label so it shows an ellipsis when clipped
- Add `flex_shrink_0()` to the buttons container so it never gets squeezed out
- Add a tooltip on the title area showing the full text on hover

Release Notes:

- N/A