### PR TITLE
Fix visual test screenshot functionality 

### DIFF
--- a/crates/gpui_platform/Cargo.toml
+++ b/crates/gpui_platform/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/gpui_platform.rs"
 [features]
 default = []
 font-kit = ["gpui_macos/font-kit"]
-test-support = ["gpui/test-support"]
+test-support = ["gpui/test-support", "gpui_macos/test-support"]
 screen-capture = ["gpui/screen-capture", "gpui_macos/screen-capture", "gpui_windows/screen-capture", "gpui_linux/screen-capture"]
 wayland = ["gpui_linux/wayland"]
 x11 = ["gpui_linux/x11"]

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -30,6 +30,7 @@ test-support = [
 visual-tests = [
     "gpui/test-support",
     "gpui_platform/screen-capture",
+    "gpui_platform/test-support",
     "dep:image",
     "dep:semver",
     "dep:tempfile",


### PR DESCRIPTION
After #49277 was merged, all visual tests failed to run with the error "FAILED - render_to_image not implemented for this platform".

Release Notes:

- N/A
