### PR TITLE
Fix docs suggestion automation workflow issues

### DIFF
--- a/.github/workflows/docs_suggestions.yml
+++ b/.github/workflows/docs_suggestions.yml
@@ -312,7 +312,7 @@ jobs:
           # Unset GH_TOKEN first to allow gh auth login to store credentials
           echo "$GH_TOKEN" | (unset GH_TOKEN && gh auth login --with-token)
           
-          OUTPUT_FILE=$(mktemp)
+          OUTPUT_FILE="${RUNNER_TEMP}/suggestions.md"
           
           # Cherry-picks don't get preview callout
           # Retry with exponential backoff for transient Factory API failures
@@ -341,11 +341,7 @@ jobs:
              grep -q "Documentation Suggestions" "$OUTPUT_FILE" && \
              ! grep -q "No Documentation Updates Needed" "$OUTPUT_FILE"; then
             echo "has_suggestions=true" >> "$GITHUB_OUTPUT"
-            {
-              echo 'suggestions<<EOF'
-              cat "$OUTPUT_FILE"
-              echo 'EOF'
-            } >> "$GITHUB_OUTPUT"
+            echo "suggestions_file=$OUTPUT_FILE" >> "$GITHUB_OUTPUT"
           else
             echo "has_suggestions=false" >> "$GITHUB_OUTPUT"
           fi
@@ -356,9 +352,12 @@ jobs:
       - name: Post suggestions as PR comment
         if: steps.analyze.outputs.has_suggestions == 'true'
         uses: actions/github-script@v7
+        env:
+          SUGGESTIONS_FILE: ${{ steps.analyze.outputs.suggestions_file }}
         with:
           script: |
-            const suggestions = `${{ steps.analyze.outputs.suggestions }}`;
+            const fs = require('fs');
+            const suggestions = fs.readFileSync(process.env.SUGGESTIONS_FILE, 'utf8');
             
             const body = `## 📚 Documentation Suggestions
 
@@ -413,7 +412,7 @@ jobs:
             if [ "${{ steps.analyze.outputs.has_suggestions }}" == "true" ]; then
               echo "Suggestions posted as PR comment."
               echo ""
-              echo "${{ steps.analyze.outputs.suggestions }}"
+              cat "${{ steps.analyze.outputs.suggestions_file }}"
             else
               echo "No documentation suggestions for this cherry-pick."
             fi

--- a/script/docs-strip-preview-callouts
+++ b/script/docs-strip-preview-callouts
@@ -213,8 +213,7 @@ And:
 > **Changed in Preview (v0.XXX).** See [release notes](/releases#0.XXX).
 \`\`\`
 
-These features are now in Stable, so the callouts are no longer needed." \
-    --label "documentation"
+These features are now in Stable, so the callouts are no longer needed."
 
 PR_URL=$(gh pr view --json url --jq '.url')
 

--- a/script/docs-suggest-publish
+++ b/script/docs-suggest-publish
@@ -221,7 +221,7 @@ EOF
 cat "$SUGGESTIONS_FILE" >> "$APPLY_PROMPT_FILE"
 
 log "Running Droid auto-apply with model: $MODEL"
-droid exec -m "$MODEL" -f "$APPLY_PROMPT_FILE" > "$APPLY_SUMMARY_FILE"
+droid exec -m "$MODEL" --auto medium -f "$APPLY_PROMPT_FILE" > "$APPLY_SUMMARY_FILE"
 
 if [[ -n "$(git status --porcelain | grep -vE '^.. docs/' || true)" ]]; then
     error "Auto-apply modified non-doc files. Revert and re-run."
@@ -232,7 +232,7 @@ if [[ -z "$(git status --porcelain docs/ | grep '^.. docs/src/' || true)" ]]; th
 fi
 
 log "Running docs formatter"
-./script/prettier
+./script/prettier --write
 
 if [[ -z "$(git status --porcelain docs/ | grep '^.. docs/src/' || true)" ]]; then
     error "No docs/src changes remain after formatting; aborting PR creation."
@@ -324,8 +324,7 @@ log "Creating PR..."
 PR_URL=$(gh pr create \
     --draft \
     --title "docs: auto-apply preview release suggestions" \
-    --body-file "$PR_BODY_FILE" \
-    --label "documentation")
+    --body-file "$PR_BODY_FILE")
 
 echo ""
 echo -e "${GREEN}PR created:${NC} $PR_URL"


### PR DESCRIPTION
## Summary

This PR fixes several issues discovered while running the docs automation workflow for the preview release.

## Fixes

1. **Fix JS syntax error in docs_suggestions.yml cherry-pick job** - The markdown interpolation broke when content contained backticks (e.g., \`gemini-3.1-pro-preview\`). Now writes suggestions to a file first and reads it in the script, avoiding interpolation issues.

2. **Add \`--auto medium\` flag to droid exec** - The droid CLI requires permission flags for file editing operations.

3. **Add \`--write\` flag to prettier call** - The script was calling prettier in check mode which fails instead of formatting the files.

4. **Remove deprecated \`documentation\` label** - The label doesn't exist in the repository (deprecated for issue type 'Docs').

## Testing

Successfully ran \`script/docs-suggest-publish --keep-queue\` after these fixes, which created:
- https://github.com/zed-industries/zed/pull/49650

Release Notes:

- N/A