### PR TITLE
Sign out upon receiving an Unauthorized response when acquiring an LLM token

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3035,6 +3035,7 @@ dependencies = [
  "http_client",
  "parking_lot",
  "serde_json",
+ "thiserror 2.0.17",
  "yawc",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9106,6 +9106,7 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "client",
+ "cloud_api_client",
  "cloud_api_types",
  "cloud_llm_client",
  "collections",

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -552,10 +552,12 @@ impl Client {
             rpc_url: RwLock::default(),
         });
         this._handle_sign_out.lock().replace(cx.spawn({
-            let client = this.clone();
+            let weak_client = Arc::downgrade(&this);
             async move |cx| {
                 while sign_out_rx.next().await.is_some() {
-                    client.sign_out(&cx).await;
+                    if let Some(client) = weak_client.upgrade() {
+                        client.sign_out(&cx).await;
+                    }
                 }
             }
         }));

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -19,11 +19,12 @@ use credentials_provider::CredentialsProvider;
 use feature_flags::FeatureFlagAppExt as _;
 use futures::{
     AsyncReadExt, FutureExt, SinkExt, Stream, StreamExt, TryFutureExt as _, TryStreamExt,
-    channel::oneshot, future::BoxFuture,
+    channel::{mpsc, oneshot},
+    future::BoxFuture,
 };
 use gpui::{App, AsyncApp, Entity, Global, Task, WeakEntity, actions};
 use http_client::{HttpClient, HttpClientWithUrl, http, read_proxy_from_env};
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
 use postage::watch;
 use proxy::connect_proxy_stream;
 use rand::prelude::*;
@@ -195,8 +196,10 @@ pub struct Client {
     telemetry: Arc<Telemetry>,
     credentials_provider: ClientCredentialsProvider,
     state: RwLock<ClientState>,
-    handler_set: parking_lot::Mutex<ProtoMessageHandlerSet>,
-    message_to_client_handlers: parking_lot::Mutex<Vec<MessageToClientHandler>>,
+    handler_set: Mutex<ProtoMessageHandlerSet>,
+    message_to_client_handlers: Mutex<Vec<MessageToClientHandler>>,
+    sign_out_tx: mpsc::UnboundedSender<()>,
+    _handle_sign_out: Mutex<Option<Task<()>>>,
 
     #[allow(clippy::type_complexity)]
     #[cfg(any(test, feature = "test-support"))]
@@ -527,7 +530,8 @@ impl Client {
         http: Arc<HttpClientWithUrl>,
         cx: &mut App,
     ) -> Arc<Self> {
-        Arc::new(Self {
+        let (sign_out_tx, mut sign_out_rx) = mpsc::unbounded();
+        let this = Arc::new(Self {
             id: AtomicU64::new(0),
             peer: Peer::new(0),
             telemetry: Telemetry::new(clock, http.clone(), cx),
@@ -536,7 +540,9 @@ impl Client {
             credentials_provider: ClientCredentialsProvider::new(cx),
             state: Default::default(),
             handler_set: Default::default(),
-            message_to_client_handlers: parking_lot::Mutex::new(Vec::new()),
+            message_to_client_handlers: Mutex::new(Vec::new()),
+            sign_out_tx,
+            _handle_sign_out: Mutex::new(None),
 
             #[cfg(any(test, feature = "test-support"))]
             authenticate: Default::default(),
@@ -544,7 +550,17 @@ impl Client {
             establish_connection: Default::default(),
             #[cfg(any(test, feature = "test-support"))]
             rpc_url: RwLock::default(),
-        })
+        });
+        this._handle_sign_out.lock().replace(cx.spawn({
+            let client = this.clone();
+            async move |cx| {
+                while sign_out_rx.next().await.is_some() {
+                    client.sign_out(&cx).await;
+                }
+            }
+        }));
+
+        this
     }
 
     pub fn production(cx: &mut App) -> Arc<Self> {
@@ -1519,6 +1535,11 @@ impl Client {
         }
     }
 
+    /// Requests a sign out to be performed asynchronously.
+    pub fn request_sign_out(&self) {
+        self.sign_out_tx.unbounded_send(()).ok();
+    }
+
     pub fn disconnect(self: &Arc<Self>, cx: &AsyncApp) {
         self.peer.teardown();
         self.set_status(Status::SignedOut, cx);
@@ -1706,7 +1727,7 @@ impl ProtoClient for Client {
         self.peer.send_dynamic(connection_id, envelope)
     }
 
-    fn message_handler_set(&self) -> &parking_lot::Mutex<ProtoMessageHandlerSet> {
+    fn message_handler_set(&self) -> &Mutex<ProtoMessageHandlerSet> {
         &self.handler_set
     }
 

--- a/crates/cloud_api_client/Cargo.toml
+++ b/crates/cloud_api_client/Cargo.toml
@@ -20,4 +20,5 @@ gpui_tokio.workspace = true
 http_client.workspace = true
 parking_lot.workspace = true
 serde_json.workspace = true
+thiserror.workspace = true
 yawc.workspace = true

--- a/crates/cloud_api_client/src/cloud_api_client.rs
+++ b/crates/cloud_api_client/src/cloud_api_client.rs
@@ -11,6 +11,7 @@ use gpui_tokio::Tokio;
 use http_client::http::request;
 use http_client::{AsyncBody, HttpClientWithUrl, HttpRequestExt, Method, Request, StatusCode};
 use parking_lot::RwLock;
+use thiserror::Error;
 use yawc::WebSocket;
 
 use crate::websocket::Connection;
@@ -18,6 +19,14 @@ use crate::websocket::Connection;
 struct Credentials {
     user_id: u32,
     access_token: String,
+}
+
+#[derive(Debug, Error)]
+pub enum ClientApiError {
+    #[error("Unauthorized")]
+    Unauthorized,
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
 }
 
 pub struct CloudApiClient {
@@ -58,7 +67,9 @@ impl CloudApiClient {
         build_request(req, body, credentials)
     }
 
-    pub async fn get_authenticated_user(&self) -> Result<GetAuthenticatedUserResponse> {
+    pub async fn get_authenticated_user(
+        &self,
+    ) -> Result<GetAuthenticatedUserResponse, ClientApiError> {
         let request = self.build_request(
             Request::builder().method(Method::GET).uri(
                 self.http_client
@@ -71,19 +82,31 @@ impl CloudApiClient {
         let mut response = self.http_client.send(request).await?;
 
         if !response.status().is_success() {
-            let mut body = String::new();
-            response.body_mut().read_to_string(&mut body).await?;
+            if response.status() == StatusCode::UNAUTHORIZED {
+                return Err(ClientApiError::Unauthorized);
+            }
 
-            anyhow::bail!(
+            let mut body = String::new();
+            response
+                .body_mut()
+                .read_to_string(&mut body)
+                .await
+                .context("failed to read response body")?;
+
+            return Err(ClientApiError::Other(anyhow::anyhow!(
                 "Failed to get authenticated user.\nStatus: {:?}\nBody: {body}",
                 response.status()
-            )
+            )));
         }
 
         let mut body = String::new();
-        response.body_mut().read_to_string(&mut body).await?;
+        response
+            .body_mut()
+            .read_to_string(&mut body)
+            .await
+            .context("failed to read response body")?;
 
-        Ok(serde_json::from_str(&body)?)
+        Ok(serde_json::from_str(&body).context("failed to parse response body")?)
     }
 
     pub fn connect(&self, cx: &App) -> Result<Task<Result<Connection>>> {
@@ -118,7 +141,7 @@ impl CloudApiClient {
     pub async fn create_llm_token(
         &self,
         system_id: Option<String>,
-    ) -> Result<CreateLlmTokenResponse> {
+    ) -> Result<CreateLlmTokenResponse, ClientApiError> {
         let request_builder = Request::builder()
             .method(Method::POST)
             .uri(
@@ -135,19 +158,31 @@ impl CloudApiClient {
         let mut response = self.http_client.send(request).await?;
 
         if !response.status().is_success() {
-            let mut body = String::new();
-            response.body_mut().read_to_string(&mut body).await?;
+            if response.status() == StatusCode::UNAUTHORIZED {
+                return Err(ClientApiError::Unauthorized);
+            }
 
-            anyhow::bail!(
+            let mut body = String::new();
+            response
+                .body_mut()
+                .read_to_string(&mut body)
+                .await
+                .context("failed to read response body")?;
+
+            return Err(ClientApiError::Other(anyhow::anyhow!(
                 "Failed to create LLM token.\nStatus: {:?}\nBody: {body}",
                 response.status()
-            )
+            )));
         }
 
         let mut body = String::new();
-        response.body_mut().read_to_string(&mut body).await?;
+        response
+            .body_mut()
+            .read_to_string(&mut body)
+            .await
+            .context("failed to read response body")?;
 
-        Ok(serde_json::from_str(&body)?)
+        Ok(serde_json::from_str(&body).context("failed to parse response body")?)
     }
 
     pub async fn validate_credentials(&self, user_id: u32, access_token: &str) -> Result<bool> {

--- a/crates/language_model/Cargo.toml
+++ b/crates/language_model/Cargo.toml
@@ -21,6 +21,7 @@ anyhow.workspace = true
 credentials_provider.workspace = true
 base64.workspace = true
 client.workspace = true
+cloud_api_client.workspace = true
 cloud_api_types.workspace = true
 cloud_llm_client.workspace = true
 collections.workspace = true

--- a/crates/language_model/src/model/cloud_model.rs
+++ b/crates/language_model/src/model/cloud_model.rs
@@ -56,7 +56,7 @@ impl LlmApiToken {
             }
             Err(err) => match err {
                 ClientApiError::Unauthorized => {
-                    // client.sign_out(cx);
+                    client.request_sign_out();
                     Err(err).context("failed to create LLM token")
                 }
                 ClientApiError::Other(err) => Err(err),

--- a/crates/language_model/src/model/cloud_model.rs
+++ b/crates/language_model/src/model/cloud_model.rs
@@ -1,8 +1,9 @@
 use std::fmt;
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 use client::Client;
+use cloud_api_client::ClientApiError;
 use cloud_api_types::websocket_protocol::MessageToClient;
 use cloud_llm_client::{EXPIRED_LLM_TOKEN_HEADER_NAME, OUTDATED_LLM_TOKEN_HEADER_NAME};
 use gpui::{App, AppContext as _, Context, Entity, EventEmitter, Global, ReadGlobal as _};
@@ -47,9 +48,20 @@ impl LlmApiToken {
             .system_id()
             .map(|system_id| system_id.to_string());
 
-        let response = client.cloud_client().create_llm_token(system_id).await?;
-        *lock = Some(response.token.0.clone());
-        Ok(response.token.0)
+        let result = client.cloud_client().create_llm_token(system_id).await;
+        match result {
+            Ok(response) => {
+                *lock = Some(response.token.0.clone());
+                Ok(response.token.0)
+            }
+            Err(err) => match err {
+                ClientApiError::Unauthorized => {
+                    // client.sign_out(cx);
+                    Err(err).context("failed to create LLM token")
+                }
+                ClientApiError::Other(err) => Err(err),
+            },
+        }
     }
 }
 

--- a/crates/language_model/src/model/cloud_model.rs
+++ b/crates/language_model/src/model/cloud_model.rs
@@ -57,7 +57,7 @@ impl LlmApiToken {
             Err(err) => match err {
                 ClientApiError::Unauthorized => {
                     client.request_sign_out();
-                    Err(err).context("failed to create LLM token")
+                    Err(err).context("Failed to create LLM token")
                 }
                 ClientApiError::Other(err) => Err(err),
             },


### PR DESCRIPTION
This PR makes it so the user gets signed out upon receiving an Unauthorized response when acquiring an LLM token.

Closes CLO-324.

Release Notes:

- N/A
