### PR TITLE
Fix Windows build

### DIFF
--- a/crates/gpui_windows/src/directx_renderer.rs
+++ b/crates/gpui_windows/src/directx_renderer.rs
@@ -1709,7 +1709,7 @@ pub(crate) mod shader_resources {
             let mut compile_blob = None;
             let mut error_blob = None;
             let shader_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-                .join(&format!("src/platform/windows/{}", shader_name))
+                .join(&format!("src/{}", shader_name))
                 .canonicalize()?;
 
             let entry_point = PCSTR::from_raw(entry.as_ptr());

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -120,6 +120,7 @@ go_to_line.workspace = true
 system_specs.workspace = true
 gpui = { workspace = true, features = [
     "wayland",
+    "windows-manifest",
     "x11",
 ] }
 gpui_platform = {workspace = true, features=["screen-capture", "font-kit", "wayland", "x11"]}


### PR DESCRIPTION
Fix regressions from https://github.com/zed-industries/zed/pull/49277:

- The fusion manifest was not being embedded for Zed.exe, making it non-functional.
- The relative path used to load shaders in debug mode was incorrect.

Release Notes:

- N/A