### PR TITLE
editor: Add copy button for project diagnostics messages

### DIFF
--- a/crates/diagnostics/src/diagnostic_renderer.rs
+++ b/crates/diagnostics/src/diagnostic_renderer.rs
@@ -233,24 +233,26 @@ impl DiagnosticBlock {
             .bg(background_color)
             .border_color(border_color)
             .child(
-                MarkdownElement::new(
-                    self.markdown.clone(),
-                    diagnostics_markdown_style(bcx.window, cx),
-                )
-                .code_block_renderer(markdown::CodeBlockRenderer::Default {
-                    copy_button: false,
-                    copy_button_on_hover: false,
-                    border: false,
-                })
-                .on_url_click({
-                    move |link, window, cx| {
-                        editor
-                            .update(cx, |editor, cx| {
-                                Self::open_link(editor, &diagnostics_editor, link, window, cx)
-                            })
-                            .ok();
-                    }
-                }),
+                div().flex_1().min_w_0().child(
+                    MarkdownElement::new(
+                        self.markdown.clone(),
+                        diagnostics_markdown_style(bcx.window, cx),
+                    )
+                    .code_block_renderer(markdown::CodeBlockRenderer::Default {
+                        copy_button: false,
+                        copy_button_on_hover: false,
+                        border: false,
+                    })
+                    .on_url_click({
+                        move |link, window, cx| {
+                            editor
+                                .update(cx, |editor, cx| {
+                                    Self::open_link(editor, &diagnostics_editor, link, window, cx)
+                                })
+                                .ok();
+                        }
+                    }),
+                ),
             )
             .child(
                 CopyButton::new(copy_button_id, self.copy_message.clone())

--- a/crates/diagnostics/src/diagnostic_renderer.rs
+++ b/crates/diagnostics/src/diagnostic_renderer.rs
@@ -213,6 +213,7 @@ impl DiagnosticBlock {
         let editor_line_height = (settings.line_height() * settings.buffer_font_size(cx)).round();
         let line_height = editor_line_height;
         let diagnostics_editor = self.diagnostics_editor.clone();
+
         let copy_button_id = format!(
             "copy-diagnostic-{}-{}-{}-{}",
             self.initial_range.start.row,
@@ -221,15 +222,16 @@ impl DiagnosticBlock {
             self.initial_range.end.column
         );
 
-        div()
-            .relative()
+        h_flex()
+            .max_w(max_width)
+            .pl_1p5()
+            .pr_0p5()
+            .items_start()
+            .gap_1()
             .border_l_2()
-            .px_2()
-            .pr_8()
             .line_height(line_height)
             .bg(background_color)
             .border_color(border_color)
-            .max_w(max_width)
             .child(
                 MarkdownElement::new(
                     self.markdown.clone(),
@@ -251,12 +253,8 @@ impl DiagnosticBlock {
                 }),
             )
             .child(
-                div().absolute().top_0().right_1().bottom_0().child(
-                    v_flex().justify_center().child(
-                        CopyButton::new(copy_button_id, self.copy_message.clone())
-                            .tooltip_label("Copy Diagnostic"),
-                    ),
-                ),
+                CopyButton::new(copy_button_id.clone(), self.copy_message.clone())
+                    .tooltip_label("Copy Diagnostic"),
             )
             .into_any_element()
     }

--- a/crates/diagnostics/src/diagnostic_renderer.rs
+++ b/crates/diagnostics/src/diagnostic_renderer.rs
@@ -12,10 +12,7 @@ use markdown::{Markdown, MarkdownElement};
 use settings::Settings;
 use text::{AnchorRangeExt, Point};
 use theme::ThemeSettings;
-use ui::{
-    ActiveTheme, AnyElement, App, Context, CopyButton, IntoElement, ParentElement, SharedString,
-    Styled, Window, div, v_flex,
-};
+use ui::{CopyButton, prelude::*};
 use util::maybe;
 
 use crate::toolbar_controls::DiagnosticsToolbarEditor;

--- a/crates/diagnostics/src/diagnostic_renderer.rs
+++ b/crates/diagnostics/src/diagnostic_renderer.rs
@@ -253,7 +253,7 @@ impl DiagnosticBlock {
                 }),
             )
             .child(
-                CopyButton::new(copy_button_id.clone(), self.copy_message.clone())
+                CopyButton::new(copy_button_id, self.copy_message.clone())
                     .tooltip_label("Copy Diagnostic"),
             )
             .into_any_element()

--- a/crates/diagnostics/src/diagnostic_renderer.rs
+++ b/crates/diagnostics/src/diagnostic_renderer.rs
@@ -13,8 +13,8 @@ use settings::Settings;
 use text::{AnchorRangeExt, Point};
 use theme::ThemeSettings;
 use ui::{
-    ActiveTheme, AnyElement, App, Context, IntoElement, ParentElement, SharedString, Styled,
-    Window, div,
+    ActiveTheme, AnyElement, App, Context, CopyButton, IntoElement, ParentElement, SharedString,
+    Styled, Window, div, v_flex,
 };
 use util::maybe;
 
@@ -81,6 +81,7 @@ impl DiagnosticRenderer {
                     initial_range: primary.range.clone(),
                     severity: primary.diagnostic.severity,
                     diagnostics_editor: diagnostics_editor.clone(),
+                    copy_message: primary.diagnostic.message.clone().into(),
                     markdown: cx.new(|cx| {
                         Markdown::new(markdown.into(), language_registry.clone(), None, cx)
                     }),
@@ -95,6 +96,7 @@ impl DiagnosticRenderer {
                     initial_range: entry.range.clone(),
                     severity: entry.diagnostic.severity,
                     diagnostics_editor: diagnostics_editor.clone(),
+                    copy_message: entry.diagnostic.message.clone().into(),
                     markdown: cx.new(|cx| {
                         Markdown::new(markdown.into(), language_registry.clone(), None, cx)
                     }),
@@ -191,6 +193,7 @@ pub(crate) struct DiagnosticBlock {
     pub(crate) severity: DiagnosticSeverity,
     pub(crate) markdown: Entity<Markdown>,
     pub(crate) diagnostics_editor: Option<Arc<dyn DiagnosticsToolbarEditor>>,
+    pub(crate) copy_message: SharedString,
 }
 
 impl DiagnosticBlock {
@@ -213,10 +216,19 @@ impl DiagnosticBlock {
         let editor_line_height = (settings.line_height() * settings.buffer_font_size(cx)).round();
         let line_height = editor_line_height;
         let diagnostics_editor = self.diagnostics_editor.clone();
+        let copy_button_id = format!(
+            "copy-diagnostic-{}-{}-{}-{}",
+            self.initial_range.start.row,
+            self.initial_range.start.column,
+            self.initial_range.end.row,
+            self.initial_range.end.column
+        );
 
         div()
+            .relative()
             .border_l_2()
             .px_2()
+            .pr_8()
             .line_height(line_height)
             .bg(background_color)
             .border_color(border_color)
@@ -240,6 +252,14 @@ impl DiagnosticBlock {
                             .ok();
                     }
                 }),
+            )
+            .child(
+                div().absolute().top_0().right_1().bottom_0().child(
+                    v_flex().justify_center().child(
+                        CopyButton::new(copy_button_id, self.copy_message.clone())
+                            .tooltip_label("Copy Diagnostic"),
+                    ),
+                ),
             )
             .into_any_element()
     }


### PR DESCRIPTION
| Before | After |
|---|---|
| <img width="734" height="178" alt="before" src="https://github.com/user-attachments/assets/1cea5854-e1b5-45a5-92ee-ed66bde06cc6" /> | <img width="834" height="186" alt="after" src="https://github.com/user-attachments/assets/bddb9280-89b3-4800-b9c9-08e456bc9ed8" /> |

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Added copy button for project diagnostics messages
