### PR TITLE
Fix Nightly panic when edit prediction provider is Copilot/Supermaven/None

### DIFF
--- a/crates/edit_prediction/src/edit_prediction.rs
+++ b/crates/edit_prediction/src/edit_prediction.rs
@@ -1699,10 +1699,11 @@ impl EditPredictionStore {
                 | EditPredictionProvider::Experimental(_) => (true, 2),
                 EditPredictionProvider::Ollama => (false, 1),
                 EditPredictionProvider::OpenAiCompatibleApi => (false, 2),
+                // These providers don't support diagnostics-driven predictions.
                 EditPredictionProvider::None
                 | EditPredictionProvider::Copilot
                 | EditPredictionProvider::Supermaven
-                | EditPredictionProvider::Codestral => unreachable!(),
+                | EditPredictionProvider::Codestral => return,
             };
 
         let drop_on_cancel = !needs_acceptance_tracking;


### PR DESCRIPTION
`queue_prediction_refresh` had an `unreachable!()` for Copilot, Supermaven, Codestral, and None providers, but it was reachable via diagnostics updates when the Zeta2 feature flag was enabled. Since Copilot is the default provider, this caused a crash on startup for most users with the flag enabled as soon as LSP diagnostics arrived.

Replace the `unreachable!()` with an early return so that `queue_prediction_refresh` gracefully does nothing for providers that don't support this code path.

Closes AI-51

No release notes because this only applies to feature-flagged code.

Release Notes:

- N/A