### PR TITLE
Fix stale folded buffers in split diff view

### DIFF
--- a/crates/editor/src/split.rs
+++ b/crates/editor/src/split.rs
@@ -5763,4 +5763,86 @@ mod tests {
             &mut cx,
         );
     }
+
+    #[gpui::test]
+    async fn test_split_after_removing_folded_buffer(cx: &mut gpui::TestAppContext) {
+        use rope::Point;
+        use unindent::Unindent as _;
+
+        let (editor, mut cx) = init_test(cx, SoftWrap::None, DiffViewStyle::Unified).await;
+
+        let base_text_a = "
+            aaa
+            bbb
+            ccc
+        "
+        .unindent();
+        let current_text_a = "
+            aaa
+            bbb modified
+            ccc
+        "
+        .unindent();
+
+        let base_text_b = "
+            xxx
+            yyy
+            zzz
+        "
+        .unindent();
+        let current_text_b = "
+            xxx
+            yyy modified
+            zzz
+        "
+        .unindent();
+
+        let (buffer_a, diff_a) = buffer_with_diff(&base_text_a, &current_text_a, &mut cx);
+        let (buffer_b, diff_b) = buffer_with_diff(&base_text_b, &current_text_b, &mut cx);
+
+        let path_a = cx.read(|cx| PathKey::for_buffer(&buffer_a, cx));
+        let path_b = cx.read(|cx| PathKey::for_buffer(&buffer_b, cx));
+
+        editor.update(cx, |editor, cx| {
+            editor.set_excerpts_for_path(
+                path_a.clone(),
+                buffer_a.clone(),
+                vec![Point::new(0, 0)..buffer_a.read(cx).max_point()],
+                0,
+                diff_a.clone(),
+                cx,
+            );
+            editor.set_excerpts_for_path(
+                path_b.clone(),
+                buffer_b.clone(),
+                vec![Point::new(0, 0)..buffer_b.read(cx).max_point()],
+                0,
+                diff_b.clone(),
+                cx,
+            );
+        });
+
+        cx.run_until_parked();
+
+        let buffer_a_id = buffer_a.read_with(cx, |buffer, _| buffer.remote_id());
+        editor.update(cx, |editor, cx| {
+            editor
+                .rhs_editor()
+                .update(cx, |right_editor, cx| right_editor.fold_buffer(buffer_a_id, cx));
+        });
+
+        cx.run_until_parked();
+
+        editor.update(cx, |editor, cx| {
+            editor.remove_excerpts_for_path(path_a.clone(), cx);
+        });
+
+        cx.run_until_parked();
+
+        editor.update_in(cx, |editor, window, cx| {
+            editor.split(window, cx);
+        });
+
+        cx.run_until_parked();
+    }
 }

--- a/crates/editor/src/split.rs
+++ b/crates/editor/src/split.rs
@@ -5826,9 +5826,9 @@ mod tests {
 
         let buffer_a_id = buffer_a.read_with(cx, |buffer, _| buffer.remote_id());
         editor.update(cx, |editor, cx| {
-            editor
-                .rhs_editor()
-                .update(cx, |right_editor, cx| right_editor.fold_buffer(buffer_a_id, cx));
+            editor.rhs_editor().update(cx, |right_editor, cx| {
+                right_editor.fold_buffer(buffer_a_id, cx)
+            });
         });
 
         cx.run_until_parked();
@@ -5836,13 +5836,33 @@ mod tests {
         editor.update(cx, |editor, cx| {
             editor.remove_excerpts_for_path(path_a.clone(), cx);
         });
-
         cx.run_until_parked();
 
-        editor.update_in(cx, |editor, window, cx| {
-            editor.split(window, cx);
+        editor.update_in(cx, |editor, window, cx| editor.split(window, cx));
+        cx.run_until_parked();
+
+        editor.update(cx, |editor, cx| {
+            editor.set_excerpts_for_path(
+                path_a.clone(),
+                buffer_a.clone(),
+                vec![Point::new(0, 0)..buffer_a.read(cx).max_point()],
+                0,
+                diff_a.clone(),
+                cx,
+            );
+            assert!(
+                !editor
+                    .lhs_editor()
+                    .unwrap()
+                    .read(cx)
+                    .is_buffer_folded(buffer_a_id, cx)
+            );
+            assert!(
+                !editor
+                    .rhs_editor()
+                    .read(cx)
+                    .is_buffer_folded(buffer_a_id, cx)
+            );
         });
-
-        cx.run_until_parked();
     }
 }


### PR DESCRIPTION
When a buffer is folded in the split diff view and then removed from the multibuffer (via `remove_excerpts_for_path`), the block map's `folded_buffers` set retains a stale entry for that buffer ID. Later, when the split view syncs folded state from the RHS display map to the LHS, it tries to look up the companion mapping for this stale buffer and fails because the companion no longer tracks a buffer that's been removed from the multibuffer.

This originally caused a panic via `.expect()`. This PR:

1. Converts the panic into graceful handling by skipping unmapped buffers.
2. Actively removes stale entries from `folded_buffers` so they don't persist as ghost state — ensuring that if the same buffer is later re-added, it won't incorrectly appear as folded.
3. Adds a regression test covering the full lifecycle: fold → remove → split → re-add → assert both LHS and RHS report the buffer as not folded.

Release Notes:

- Fixed a crash in split diff view when a folded buffer was removed and re-added.