### PR TITLE
text:  Inline `text::Anchor`'s timestamp field, shrinking its size

### DIFF
--- a/crates/assistant_text_thread/src/text_thread.rs
+++ b/crates/assistant_text_thread/src/text_thread.rs
@@ -1094,7 +1094,7 @@ impl TextThread {
                 .buffer
                 .read(cx)
                 .version
-                .observed(anchor.start.timestamp),
+                .observed(anchor.start.timestamp()),
             TextThreadOperation::UpdateMessage { message_id, .. } => {
                 self.messages_metadata.contains_key(message_id)
             }
@@ -1121,10 +1121,11 @@ impl TextThread {
         cx: &App,
     ) -> bool {
         let version = &self.buffer.read(cx).version;
-        let observed_start =
-            range.start.is_min() || range.start.is_max() || version.observed(range.start.timestamp);
+        let observed_start = range.start.is_min()
+            || range.start.is_max()
+            || version.observed(range.start.timestamp());
         let observed_end =
-            range.end.is_min() || range.end.is_max() || version.observed(range.end.timestamp);
+            range.end.is_min() || range.end.is_max() || version.observed(range.end.timestamp());
         observed_start && observed_end
     }
 

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -5598,7 +5598,7 @@ impl LspStore {
 
                 buffer
                     .update(cx, |buffer, _| {
-                        buffer.wait_for_edits(Some(position.timestamp))
+                        buffer.wait_for_edits(Some(position.timestamp()))
                     })
                     .await?;
                 this.update(cx, |this, cx| {

--- a/crates/text/src/anchor.rs
+++ b/crates/text/src/anchor.rs
@@ -9,9 +9,15 @@ use sum_tree::{Bias, Dimensions};
 #[doc(alias = "TextAnchor")]
 #[derive(Copy, Clone, Eq, PartialEq, Hash)]
 pub struct Anchor {
-    /// The timestamp of the operation that inserted the text
-    /// in which this anchor is located.
-    pub timestamp: clock::Lamport,
+    // /// The timestamp of the operation that inserted the text
+    // /// in which this anchor is located.
+    // pub(crate) timestamp: clock::Lamport,
+    // we store the replica id and sequence number of the timestamp inline
+    // to avoid the alignment of our fields from increasing the size of this struct
+    // This saves 8 bytes, by allowing replica id, value and bias to occupy the padding
+    timestamp_replica_id: clock::ReplicaId,
+    timestamp_value: clock::Seq,
+
     /// The byte offset into the text inserted in the operation
     /// at `timestamp`.
     pub offset: usize,
@@ -31,7 +37,7 @@ impl Debug for Anchor {
         }
 
         f.debug_struct("Anchor")
-            .field("timestamp", &self.timestamp)
+            .field("timestamp", &self.timestamp())
             .field("offset", &self.offset)
             .field("bias", &self.bias)
             .field("buffer_id", &self.buffer_id)
@@ -41,22 +47,40 @@ impl Debug for Anchor {
 
 impl Anchor {
     pub const MIN: Self = Self {
-        timestamp: clock::Lamport::MIN,
+        timestamp_replica_id: clock::Lamport::MIN.replica_id,
+        timestamp_value: clock::Lamport::MIN.value,
         offset: usize::MIN,
         bias: Bias::Left,
         buffer_id: None,
     };
 
     pub const MAX: Self = Self {
-        timestamp: clock::Lamport::MAX,
+        timestamp_replica_id: clock::Lamport::MAX.replica_id,
+        timestamp_value: clock::Lamport::MAX.value,
         offset: usize::MAX,
         bias: Bias::Right,
         buffer_id: None,
     };
 
+    pub fn new(
+        timestamp: clock::Lamport,
+        offset: usize,
+        bias: Bias,
+        buffer_id: Option<BufferId>,
+    ) -> Self {
+        Self {
+            timestamp_replica_id: timestamp.replica_id,
+            timestamp_value: timestamp.value,
+            offset,
+            bias,
+            buffer_id,
+        }
+    }
+
     pub fn min_for_buffer(buffer_id: BufferId) -> Self {
         Self {
-            timestamp: clock::Lamport::MIN,
+            timestamp_replica_id: clock::Lamport::MIN.replica_id,
+            timestamp_value: clock::Lamport::MIN.value,
             offset: usize::MIN,
             bias: Bias::Left,
             buffer_id: Some(buffer_id),
@@ -65,7 +89,8 @@ impl Anchor {
 
     pub fn max_for_buffer(buffer_id: BufferId) -> Self {
         Self {
-            timestamp: clock::Lamport::MAX,
+            timestamp_replica_id: clock::Lamport::MAX.replica_id,
+            timestamp_value: clock::Lamport::MAX.value,
             offset: usize::MAX,
             bias: Bias::Right,
             buffer_id: Some(buffer_id),
@@ -85,7 +110,7 @@ impl Anchor {
     }
 
     pub fn cmp(&self, other: &Anchor, buffer: &BufferSnapshot) -> Ordering {
-        let fragment_id_comparison = if self.timestamp == other.timestamp {
+        let fragment_id_comparison = if self.timestamp() == other.timestamp() {
             Ordering::Equal
         } else {
             buffer
@@ -164,15 +189,23 @@ impl Anchor {
     }
 
     pub fn is_min(&self) -> bool {
-        self.timestamp == clock::Lamport::MIN
+        self.timestamp() == clock::Lamport::MIN
             && self.offset == usize::MIN
             && self.bias == Bias::Left
     }
 
     pub fn is_max(&self) -> bool {
-        self.timestamp == clock::Lamport::MAX
+        self.timestamp() == clock::Lamport::MAX
             && self.offset == usize::MAX
             && self.bias == Bias::Right
+    }
+
+    #[inline]
+    pub fn timestamp(&self) -> clock::Lamport {
+        clock::Lamport {
+            replica_id: self.timestamp_replica_id,
+            value: self.timestamp_value,
+        }
     }
 }
 


### PR DESCRIPTION
This shrinks the size of `text::Anchor` from 32 bytes to 24 and `multi_buffer::Anchor` from 72 bytes to 56

Release Notes:

- Improved the memory footprint of Zed 
