### PR TITLE
agent: Change max subagent depth to 1 for now

### DIFF
--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -60,7 +60,7 @@ use uuid::Uuid;
 
 const TOOL_CANCELED_MESSAGE: &str = "Tool canceled by user";
 pub const MAX_TOOL_NAME_LENGTH: usize = 64;
-pub const MAX_SUBAGENT_DEPTH: u8 = 4;
+pub const MAX_SUBAGENT_DEPTH: u8 = 1;
 
 /// Context passed to a subagent thread for lifecycle management
 #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
There are some UI concerns, especially for permission requests, that get extremely complicated for recurisve subagents.

We'll move this to 1 for now to reduce complexity, and revisit once we have a better way for representing all current permission requests.

Release Notes:

- N/A
