### PR TITLE
multi_buffer: Fix outdated anchors resolving incorrectly in diff hunks in `resolve_summary_for_anchor`

### DIFF
--- a/crates/editor/src/selections_collection.rs
+++ b/crates/editor/src/selections_collection.rs
@@ -1197,7 +1197,14 @@ fn resolve_selections_point<'a>(
     selections.map(move |s| {
         let start = summaries.next().unwrap();
         let end = summaries.next().unwrap();
-        assert!(start <= end, "start: {:?}, end: {:?}", start, end);
+        assert!(
+            start <= end,
+            "anchors: start: {:?}, end: {:?}; resolved to: start: {:?}, end: {:?}",
+            s.start,
+            s.end,
+            start,
+            end
+        );
         Selection {
             id: s.id,
             start,

--- a/crates/vim/src/normal/change.rs
+++ b/crates/vim/src/normal/change.rs
@@ -716,7 +716,11 @@ mod test {
         "};
 
         cx.set_state(
-            &format!("fn main() {{\n    ˇprintln!(\"new\");\n}}\n"),
+            indoc! {"
+                fn main() {
+                    ˇprintln!(\"new\");
+                }
+            "},
             Mode::Normal,
         );
         cx.set_head_text(diff_base);

--- a/crates/vim/src/normal/change.rs
+++ b/crates/vim/src/normal/change.rs
@@ -205,7 +205,8 @@ fn expand_changed_word_selection(
 mod test {
     use indoc::indoc;
 
-    use crate::test::NeovimBackedTestContext;
+    use crate::state::Mode;
+    use crate::test::{NeovimBackedTestContext, VimTestContext};
 
     #[gpui::test]
     async fn test_change_h(cx: &mut gpui::TestAppContext) {
@@ -702,5 +703,31 @@ mod test {
             .await
             .assert_matches();
         }
+    }
+
+    #[gpui::test]
+    async fn test_change_with_selection_spanning_expanded_diff_hunk(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+
+        let diff_base = indoc! {"
+            fn main() {
+                println!(\"old\");
+            }
+        "};
+
+        cx.set_state(
+            &format!("fn main() {{\n    ˇprintln!(\"new\");\n}}\n"),
+            Mode::Normal,
+        );
+        cx.set_head_text(diff_base);
+        cx.update_editor(|editor, window, cx| {
+            editor.expand_all_diff_hunks(&editor::actions::ExpandAllDiffHunks, window, cx);
+        });
+
+        // Enter visual mode and move up so the selection spans from the
+        // insertion (current line) into the deletion (diff base line).
+        // Then press `c` which in visual mode dispatches `vim::Substitute`,
+        // performing the change operation across the insertion/deletion boundary.
+        cx.simulate_keystrokes("v k c");
     }
 }


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/48441

Release Notes:

- Fixed panics with selection handling in expanded diff hunk
