### PR TITLE
gpui: Fix re-entrant BorrowMutError crash during macOS window tab sync

### DIFF
--- a/crates/gpui/src/app/async_context.rs
+++ b/crates/gpui/src/app/async_context.rs
@@ -147,6 +147,15 @@ impl AsyncApp {
         lock.update(f)
     }
 
+    /// Like [`update`](Self::update), but returns `Err` instead of panicking when the app context
+    /// is already borrowed. This is useful for platform callbacks that may be invoked re-entrantly
+    /// (e.g., macOS `display_layer` triggered during window tab synchronization).
+    pub fn try_update<R>(&self, f: impl FnOnce(&mut App) -> R) -> Result<R> {
+        let app = self.app.upgrade().context("app was released")?;
+        let mut lock = app.try_borrow_mut()?;
+        Ok(lock.update(f))
+    }
+
     /// Arrange for the given callback to be invoked whenever the given entity emits an event of a given type.
     /// The callback is provided a handle to the emitting entity and a reference to the emitted event.
     pub fn subscribe<T, Event>(
@@ -469,5 +478,30 @@ impl VisualContext for AsyncWindowContext {
         self.app.update_window(self.window, |_, window, cx| {
             view.read(cx).focus_handle(cx).focus(window, cx);
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::TestAppContext;
+
+    #[gpui_macros::test]
+    fn test_try_update_succeeds_when_not_borrowed(cx: &mut TestAppContext) {
+        let async_cx = cx.to_async();
+        let result = async_cx.try_update(|_| 42);
+        assert_eq!(result.unwrap(), 42);
+    }
+
+    #[gpui_macros::test]
+    fn test_try_update_returns_err_when_already_borrowed(cx: &mut TestAppContext) {
+        let async_cx = cx.to_async();
+        // Hold a mutable borrow on the AppCell while calling try_update,
+        // simulating the re-entrant access pattern from macOS display_layer.
+        let _guard = cx.app.borrow_mut();
+        let result = async_cx.try_update(|_| 42);
+        assert!(
+            result.is_err(),
+            "try_update should return Err when AppCell is already borrowed"
+        );
     }
 }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1173,9 +1173,10 @@ impl Window {
             let mut cx = cx.to_async();
             move || {
                 let _ = handle.update(&mut cx, |_, window, _| window.remove_window());
-                let _ = cx.update(|cx| {
+                cx.try_update(|cx| {
                     SystemWindowTabController::remove_tab(cx, window_id);
-                });
+                })
+                .log_err();
             }
         }));
         platform_window.on_request_frame(Box::new({
@@ -1186,7 +1187,18 @@ impl Window {
             let next_frame_callbacks = next_frame_callbacks.clone();
             let input_rate_tracker = input_rate_tracker.clone();
             move |request_frame_options| {
-                let thermal_state = cx.update(|cx| cx.thermal_state());
+                // Use try_update to avoid panicking when the AppCell is already
+                // borrowed. On macOS, `addTabbedWindow:ordered:` can trigger
+                // `display_layer` re-entrantly during window creation, which
+                // invokes this callback while App::open_window still holds the
+                // borrow. Skipping the frame is safe because the display link
+                // will request another one.
+                let Ok(thermal_state) = cx.try_update(|cx| cx.thermal_state()) else {
+                    log::debug!(
+                        "skipping frame: app context already borrowed (re-entrant platform callback)"
+                    );
+                    return;
+                };
 
                 if thermal_state == ThermalState::Serious || thermal_state == ThermalState::Critical
                 {


### PR DESCRIPTION
On macOS, opening a new window with tabbing enabled triggers addTabbedWindow:ordered: which synchronously calls display_layer on existing windows via _syncInactiveTabWindowSizesToWindow. The existing window's request_frame_callback then calls AsyncApp::update, which panics because AppCell is already mutably borrowed by the outer App::open_window call.

Add AsyncApp::try_update that uses try_borrow_mut instead of borrow_mut, returning Err on re-entrant access instead of panicking. Use it in the on_request_frame and on_close callbacks so they gracefully bail when the app context is unavailable. Skipping the frame is safe because the display link will request another one.

Fixes #49566

Release Notes:

- Fixed a crash on macOS when opening a new window with tabbing enabled caused by a re-entrant borrow conflict during window tab synchronization