### PR TITLE
auto_update: Persist custom icons across app updates on macOS

### DIFF
--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -990,7 +990,7 @@ async fn install_release_macos(
     };
 
     let output = new_command("rsync")
-        .args(["-av", "--delete"])
+        .args(["-av", "--delete", "--exclude", "Icon?"])
         .arg(&mounted_app_path)
         .arg(&running_app_path)
         .output()


### PR DESCRIPTION
After setting a custom icon on macOS, an `Icon\r` file is generated in the application's root directory to store the custom icon metadata. Currently, the update process uses `rsync -av --delete`, which removes this `Icon\r` file and causes the custom icon to revert to the default blue folder.

This PR adds the `--exclude 'Icon?'` parameter to ensure the file is preserved during updates.

Closes #26639 , Closes #29900.

Since I cannot trigger the auto-update mechanism manually, I mounted the latest Zed disk image and simulated the update by executing the rsync command in the terminal to verify the fix.

<img width="2254" height="1596" alt="图片" src="https://github.com/user-attachments/assets/26660fa4-447f-427a-b2dd-e6280ce3d42d" />


Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Fixed an issue where custom macOS app icons would revert to default blue folders after an update.