### PR TITLE
git_graph: Improve loading time

### DIFF
--- a/crates/git_graph/src/git_graph.rs
+++ b/crates/git_graph/src/git_graph.rs
@@ -811,7 +811,7 @@ impl GitGraph {
             repository.update(cx, |repository, cx| {
                 let (commits, _) = repository.graph_data(
                     self.log_source.clone(),
-                    self.log_order.clone(),
+                    self.log_order,
                     0..usize::MAX,
                     cx,
                 );

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -3744,9 +3744,12 @@ impl Repository {
             })
             .shared();
 
-        cx.subscribe_self(|this, event: &RepositoryEvent, _| match event {
+        cx.subscribe_self(|_this, event: &RepositoryEvent, _| match event {
             RepositoryEvent::BranchChanged | RepositoryEvent::MergeHeadsChanged => {
-                this.initial_graph_data.clear();
+                // todo(git_graph): This clears the initial graph data when the graph hasn't changed,
+                // e.g. when Zed is loading, the BranchChanged and MergeHeadsChanged event will be fired
+                // but that causes us loading the graph data multiple times
+                // this.initial_graph_data.clear();
             }
             _ => {}
         })

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -3744,17 +3744,6 @@ impl Repository {
             })
             .shared();
 
-        cx.subscribe_self(|_this, event: &RepositoryEvent, _| match event {
-            RepositoryEvent::BranchChanged | RepositoryEvent::MergeHeadsChanged => {
-                // todo(git_graph): This clears the initial graph data when the graph hasn't changed,
-                // e.g. when Zed is loading, the BranchChanged and MergeHeadsChanged event will be fired
-                // but that causes us loading the graph data multiple times
-                // this.initial_graph_data.clear();
-            }
-            _ => {}
-        })
-        .detach();
-
         Repository {
             this: cx.weak_entity(),
             git_store,

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -3744,6 +3744,16 @@ impl Repository {
             })
             .shared();
 
+        cx.subscribe_self(move |this, event: &RepositoryEvent, _| match event {
+            RepositoryEvent::BranchChanged | RepositoryEvent::MergeHeadsChanged => {
+                if this.scan_id > 1 {
+                    this.initial_graph_data.clear();
+                }
+            }
+            _ => {}
+        })
+        .detach();
+
         Repository {
             this: cx.weak_entity(),
             git_store,


### PR DESCRIPTION
This PR Fixes a loading performance regresssion inside the git graph. The main issue is that we always acted on the received repository events, this is good in 9 out of 10 cases except for the initial loading phase of the git graph. This is because we invalidate the graph data every time we receive a `GitStoreEvent::ActiveRepositoryChanged`, `RepositoryEvent::BranchChanged` or `RepositoryEvent::MergeHeadsChanged` event this still sounds good, but the caveat is that we receive these 3 events on initial repository loading. This happens when you start up Zed and is getting the active repository, branch ect. from your project. When it detects a repository/branch etc. it checks if it has been changed and emits an event for it. This is always the case for initial repository loading, because the active repository/branch always start as **None**. So receive an event for these non actual changes makes the git graph cancel its initial loading and start fetching again on every invalidated graph data call.

We fixed this by checking the **scan_id** of the repo to check if the repo has been initialized, if its bigger then 1 we know we need to invalidate the data because it was a actual user change instead of a initial loading event.

**Before** (note you see the loading state twice):

https://github.com/user-attachments/assets/c25bfae1-0e2f-4c8b-a0d0-926acb33adff

**After** (almost instant):

https://github.com/user-attachments/assets/7e4ac116-65a2-4eb6-aa4c-37291d6acd0f

-----

**Before** (switching repositories shows empty commits pane)

https://github.com/user-attachments/assets/71b04285-49e7-47bb-9660-ad53bbf15c46

**After** (switching repositories shows correct graph from the cache)

https://github.com/user-attachments/assets/38c33d93-f592-4440-b63b-567fda0fbeb8

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- N/A
