### PR TITLE
language: Fix JSDoc injection lost when editing deep inside block comment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8995,6 +8995,7 @@ dependencies = [
  "tree-sitter-embedded-template",
  "tree-sitter-heex",
  "tree-sitter-html",
+ "tree-sitter-jsdoc",
  "tree-sitter-json",
  "tree-sitter-md",
  "tree-sitter-python",

--- a/crates/language/Cargo.toml
+++ b/crates/language/Cargo.toml
@@ -90,6 +90,7 @@ tree-sitter-elixir.workspace = true
 tree-sitter-embedded-template.workspace = true
 tree-sitter-heex.workspace = true
 tree-sitter-html.workspace = true
+tree-sitter-jsdoc.workspace = true
 tree-sitter-json.workspace = true
 tree-sitter-md.workspace = true
 tree-sitter-python.workspace = true

--- a/crates/language/src/syntax_map.rs
+++ b/crates/language/src/syntax_map.rs
@@ -1553,7 +1553,10 @@ fn get_injections(
     }
 
     for query_range in changed_ranges {
-        query_cursor.set_byte_range(query_range.start.saturating_sub(1)..query_range.end + 1);
+        let effective_start = node
+            .descendant_for_byte_range(query_range.start, query_range.start)
+            .map_or(query_range.start, |descendant| descendant.start_byte());
+        query_cursor.set_byte_range(effective_start.saturating_sub(1)..query_range.end + 1);
         let mut matches = query_cursor.matches(&config.query, node, TextProvider(text.as_rope()));
         while let Some(mat) = matches.next() {
             let content_ranges = mat

--- a/crates/language/src/syntax_map/syntax_map_tests.rs
+++ b/crates/language/src/syntax_map/syntax_map_tests.rs
@@ -935,6 +935,94 @@ fn test_comment_triggered_injection_toggle(cx: &mut App) {
 }
 
 #[gpui::test]
+fn test_jsdoc_injection_preserved_after_edit_deep_in_comment(cx: &mut App) {
+    let registry = Arc::new(LanguageRegistry::test(cx.background_executor().clone()));
+
+    let javascript = Arc::new(
+        Language::new(
+            LanguageConfig {
+                name: "JavaScript".into(),
+                matcher: LanguageMatcher {
+                    path_suffixes: vec!["js".to_string()],
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            Some(tree_sitter_typescript::LANGUAGE_TSX.into()),
+        )
+        .with_injection_query(
+            r#"
+            (((comment) @_jsdoc_comment
+              (#match? @_jsdoc_comment "(?s)^/[*][*][^*].*[*]/$")) @injection.content
+              (#set! injection.language "jsdoc"))
+            "#,
+        )
+        .expect("Could not parse JavaScript injection query"),
+    );
+
+    let jsdoc = Arc::new(
+        Language::new(
+            LanguageConfig {
+                name: "JSDoc".into(),
+                grammar: Some("jsdoc".into()),
+                hidden: true,
+                ..Default::default()
+            },
+            Some(tree_sitter_jsdoc::LANGUAGE.into()),
+        )
+        .with_highlights_query("(tag_name) @keyword.jsdoc")
+        .expect("Could not parse JSDoc highlights query"),
+    );
+
+    registry.add(javascript.clone());
+    registry.add(jsdoc);
+
+    let mut buffer = Buffer::new(
+        ReplicaId::LOCAL,
+        BufferId::new(1).unwrap(),
+        "
+            /**
+             * First line of docs
+             * @param {string} name - The name
+             * @param {number} age - The age
+             * @returns {boolean} Whether valid
+             */
+            function validate(name, age) {}
+        "
+        .unindent(),
+    );
+
+    let mut syntax_map = SyntaxMap::new(&buffer);
+    syntax_map.set_language_registry(registry);
+    syntax_map.reparse(javascript.clone(), &buffer);
+
+    let has_jsdoc_layer = |syntax_map: &SyntaxMap, buffer: &Buffer| {
+        syntax_map
+            .layers(buffer)
+            .iter()
+            .any(|layer| layer.language.name().as_ref() == "JSDoc")
+    };
+
+    assert!(
+        has_jsdoc_layer(&syntax_map, &buffer),
+        "Expected JSDoc injection layer after initial parse"
+    );
+
+    // Edit deep inside the comment, far from the `/**` opening on line 0.
+    // This is the scenario that triggers the bug: the changed range doesn't
+    // cover the comment node's start byte, so the injection query misses it.
+    let edit_target = buffer.as_rope().to_string().find("The age").expect("text not found");
+    buffer.edit([(edit_target..edit_target + "The age".len(), "The person's age")]);
+    syntax_map.interpolate(&buffer);
+    syntax_map.reparse(javascript.clone(), &buffer);
+
+    assert!(
+        has_jsdoc_layer(&syntax_map, &buffer),
+        "JSDoc injection layer should be preserved after editing deep inside the comment"
+    );
+}
+
+#[gpui::test]
 fn test_syntax_map_languages_loading_with_erb(cx: &mut App) {
     let text = r#"
         <body>

--- a/crates/language/src/syntax_map/syntax_map_tests.rs
+++ b/crates/language/src/syntax_map/syntax_map_tests.rs
@@ -1011,8 +1011,15 @@ fn test_jsdoc_injection_preserved_after_edit_deep_in_comment(cx: &mut App) {
     // Edit deep inside the comment, far from the `/**` opening on line 0.
     // This is the scenario that triggers the bug: the changed range doesn't
     // cover the comment node's start byte, so the injection query misses it.
-    let edit_target = buffer.as_rope().to_string().find("The age").expect("text not found");
-    buffer.edit([(edit_target..edit_target + "The age".len(), "The person's age")]);
+    let edit_target = buffer
+        .as_rope()
+        .to_string()
+        .find("The age")
+        .expect("text not found");
+    buffer.edit([(
+        edit_target..edit_target + "The age".len(),
+        "The person's age",
+    )]);
     syntax_map.interpolate(&buffer);
     syntax_map.reparse(javascript.clone(), &buffer);
 


### PR DESCRIPTION
Closes #49681

In get_injections(), the QueryCursor::set_byte_range() only matches injection patterns whose first node starts within the given byte range. For multi-line block comments (like JSDoc /** ...
*/), editing deep inside the comment produces a changed range that doesn't reach the comment node's start byte. This causes the injection query to miss the (comment) node entirely, so no
new JSDoc layer is created, while the old one is discarded because it intersects the changed region — resulting in permanent loss of JSDoc syntax highlighting until Zed is restarted.

Changes

- crates/language/src/syntax_map.rs: Before setting the query cursor byte range, find the deepest tree-sitter node at the range start via descendant_for_byte_range() and expand the range to
include that node's start byte. This ensures injection patterns on enclosing multi-line nodes always match.
- crates/language/src/syntax_map/syntax_map_tests.rs: Added test_jsdoc_injection_preserved_after_edit_deep_in_comment — parses a multi-line JSDoc comment, edits deep inside it, and verifies
the injection layer persists.
- crates/language/Cargo.toml / Cargo.lock: Added tree-sitter-jsdoc as a dev-dependency for the new test.

Impact

This fix prevents JSDoc (and any other injection triggered by a multi-line node) from silently disappearing when users edit inside the body of the node. No changes to public API or behavior
beyond restoring correct incremental reparsing.

Release Notes:

- Fixed JSDoc syntax highlighting disappearing when editing inside multi-line documentation comments in JavaScript and TypeScript files.