### PR TITLE
Add API auth key to Ollama edit predictions

### DIFF
--- a/crates/edit_prediction/src/ollama.rs
+++ b/crates/edit_prediction/src/ollama.rs
@@ -82,11 +82,17 @@ pub(crate) async fn make_request(
     };
 
     let request_body = serde_json::to_string(&request)?;
-    let http_request = http_client::Request::builder()
+    let mut http_request_builder = http_client::Request::builder()
         .method(http_client::Method::POST)
         .uri(format!("{}/api/generate", settings.api_url))
-        .header("Content-Type", "application/json")
-        .body(http_client::AsyncBody::from(request_body))?;
+        .header("Content-Type", "application/json");
+    if settings.api_key.is_some() {
+        http_request_builder = http_request_builder.header(
+            "Authorization",
+            format!("Bearer {}", settings.api_key.unwrap()),
+        );
+    }
+    let http_request = http_request_builder.body(http_client::AsyncBody::from(request_body))?;
 
     let mut response = http_client.send(http_request).await?;
     let status = response.status();

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -466,6 +466,8 @@ pub struct OpenAiCompatibleEditPredictionSettings {
     pub max_output_tokens: u32,
     /// Custom API URL to use for Ollama.
     pub api_url: Arc<str>,
+    /// API Key
+    pub api_key: Option<String>,
     /// The prompt format to use for completions. When `None`, the format
     /// will be derived from the model name at request time.
     pub prompt_format: EditPredictionPromptFormat,
@@ -712,6 +714,7 @@ impl settings::Settings for AllLanguageSettings {
                 model: model.0,
                 max_output_tokens: ollama.max_output_tokens.unwrap(),
                 api_url: ollama.api_url.unwrap().into(),
+                api_key: ollama.api_key,
                 prompt_format: ollama.prompt_format.unwrap(),
             });
         let openai_compatible_settings = edit_predictions.open_ai_compatible_api.unwrap();
@@ -723,12 +726,20 @@ impl settings::Settings for AllLanguageSettings {
                     .api_url
                     .filter(|api_url| !api_url.is_empty()),
             )
-            .map(|(model, api_url)| OpenAiCompatibleEditPredictionSettings {
-                model,
-                max_output_tokens: openai_compatible_settings.max_output_tokens.unwrap(),
-                api_url: api_url.into(),
-                prompt_format: openai_compatible_settings.prompt_format.unwrap(),
-            });
+            .zip(
+                openai_compatible_settings
+                    .api_key
+                    .filter(|api_key| !api_key.is_empty()),
+            )
+            .map(
+                |((model, api_url), api_key)| OpenAiCompatibleEditPredictionSettings {
+                    model,
+                    max_output_tokens: openai_compatible_settings.max_output_tokens.unwrap(),
+                    api_url: api_url.into(),
+                    api_key: api_key.into(),
+                    prompt_format: openai_compatible_settings.prompt_format.unwrap(),
+                },
+            );
 
         let enabled_in_text_threads = edit_predictions.enabled_in_text_threads.unwrap();
 

--- a/crates/settings_content/src/language.rs
+++ b/crates/settings_content/src/language.rs
@@ -211,6 +211,10 @@ pub struct CustomEditPredictionProviderSettingsContent {
     ///
     /// Default: ""
     pub api_url: Option<String>,
+    /// Api authorization key to use for completions.
+    ///
+    /// Default: ""
+    pub api_key: Option<String>,
     /// The prompt format to use for completions. Set to `""` to have the format be derived from the model name.
     ///
     /// Default: ""
@@ -344,7 +348,10 @@ pub struct OllamaEditPredictionSettingsContent {
     ///
     /// Default: "http://localhost:11434"
     pub api_url: Option<String>,
-
+    /// Api authorization key to use for completions.
+    ///
+    /// Default: ""
+    pub api_key: Option<String>,
     /// The prompt format to use for completions. Set to `""` to have the format be derived from the model name.
     ///
     /// Default: ""

--- a/crates/settings_ui/src/pages/edit_prediction_provider_setup.rs
+++ b/crates/settings_ui/src/pages/edit_prediction_provider_setup.rs
@@ -13,6 +13,7 @@ use ui::{ButtonLink, ConfiguredApiCard, ContextMenu, DropdownMenu, DropdownStyle
 use workspace::AppState;
 
 const OLLAMA_API_URL_PLACEHOLDER: &str = "http://localhost:11434";
+const OLLAMA_API_KEY_PLACEHOLDER: &str = "sk-xxx";
 const OLLAMA_MODEL_PLACEHOLDER: &str = "qwen2.5-coder:3b-base";
 
 use crate::{
@@ -384,6 +385,39 @@ fn ollama_settings() -> Box<[SettingsPageItem]> {
             }),
             metadata: Some(Box::new(SettingsFieldMetadata {
                 placeholder: Some(OLLAMA_API_URL_PLACEHOLDER),
+                ..Default::default()
+            })),
+            files: USER,
+        }),
+        SettingsPageItem::SettingItem(SettingItem {
+            title: "API Key",
+            description: "API authorization key for the Ollama server.",
+            field: Box::new(SettingField {
+                pick: |settings| {
+                    settings
+                        .project
+                        .all_languages
+                        .edit_predictions
+                        .as_ref()?
+                        .ollama
+                        .as_ref()?
+                        .api_key
+                        .as_ref()
+                },
+                write: |settings, value| {
+                    settings
+                        .project
+                        .all_languages
+                        .edit_predictions
+                        .get_or_insert_default()
+                        .ollama
+                        .get_or_insert_default()
+                        .api_key = value;
+                },
+                json_path: Some("edit_predictions.ollama.api_key"),
+            }),
+            metadata: Some(Box::new(SettingsFieldMetadata {
+                placeholder: Some(OLLAMA_API_KEY_PLACEHOLDER),
                 ..Default::default()
             })),
             files: USER,


### PR DESCRIPTION
This allows the user to use Ollama for edit predictions behind something like Open WebUI. I have tried this with my setup and it worked.

Release Notes:

- Added API key to Ollama edit predictions.