### PR TITLE
Fix certain title bar elements not being interactive on Windows

### DIFF
--- a/crates/title_bar/src/collab.rs
+++ b/crates/title_bar/src/collab.rs
@@ -143,6 +143,7 @@ impl TitleBar {
 
         h_flex()
             .id("collaborator-list")
+            .occlude()
             .w_full()
             .gap_1()
             .overflow_x_scroll()

--- a/crates/title_bar/src/onboarding_banner.rs
+++ b/crates/title_bar/src/onboarding_banner.rs
@@ -120,6 +120,7 @@ impl Render for OnboardingBanner {
             .rounded_sm()
             .border_1()
             .border_color(border_color)
+            .occlude()
             .child(
                 ButtonLike::new("try-a-feature")
                     .child(


### PR DESCRIPTION
https://github.com/zed-industries/zed/pull/48330 caused the title bar to start eating input events below these controls. We should find a way to make the title bar handling less busted, but this will do for now.  

Before you mark this PR as ready for review, make sure that you have:
- [X] Added a solid test coverage and/or screenshots from doing manual testing
- [X] Done a self-review taking into account security and performance aspects

Release Notes:

- N/A
