### PR TITLE
eslint: Add support for ESLint v10

### DIFF
--- a/crates/languages/src/eslint.rs
+++ b/crates/languages/src/eslint.rs
@@ -148,6 +148,7 @@ impl LspInstaller for EsLintLspAdapter {
     ) -> Option<LanguageServerBinary> {
         let server_path =
             Self::build_destination_path(&container_dir).join(EsLintLspAdapter::SERVER_PATH);
+        fs::metadata(&server_path).await.ok()?;
         Some(LanguageServerBinary {
             path: self.node.binary_path().await.ok()?,
             env: None,

--- a/crates/languages/src/eslint.rs
+++ b/crates/languages/src/eslint.rs
@@ -34,8 +34,8 @@ pub struct EsLintLspAdapter {
 }
 
 impl EsLintLspAdapter {
-    const CURRENT_VERSION: &'static str = "2.4.4";
-    const CURRENT_VERSION_TAG_NAME: &'static str = "release/2.4.4";
+    const CURRENT_VERSION: &'static str = "3.0.10";
+    const CURRENT_VERSION_TAG_NAME: &'static str = "release/3.0.10";
 
     #[cfg(not(windows))]
     const GITHUB_ASSET_KIND: AssetKind = AssetKind::TarGz;
@@ -173,6 +173,7 @@ impl LspAdapter for EsLintLspAdapter {
         cx: &mut AsyncApp,
     ) -> Result<Value> {
         let worktree_root = delegate.worktree_root_path();
+        let eslint_major_version = eslint_major_version(delegate).await;
         let use_flat_config = Self::FLAT_CONFIG_FILE_NAMES
             .iter()
             .any(|file| worktree_root.join(file).is_file());
@@ -205,11 +206,11 @@ impl LspAdapter for EsLintLspAdapter {
                 "showDocumentation": {
                     "enable": true
                 }
-            },
-            "experimental": {
-                "useFlatConfig": use_flat_config,
             }
         });
+        if use_flat_config && eslint_major_version.is_some_and(|version| version <= 9) {
+            set_use_flat_config(&mut default_workspace_configuration);
+        }
 
         let file_path = requested_uri
             .as_ref()
@@ -260,7 +261,6 @@ impl LspAdapter for EsLintLspAdapter {
                 *wd = serde_json::to_value(working_directory)?;
             }
         }
-
         Ok(json!({
             "": default_workspace_configuration
         }))
@@ -269,6 +269,21 @@ impl LspAdapter for EsLintLspAdapter {
     fn name(&self) -> LanguageServerName {
         Self::SERVER_NAME
     }
+}
+
+fn set_use_flat_config(configuration: &mut Value) {
+    if let Some(configuration) = configuration.as_object_mut() {
+        configuration.insert("useFlatConfig".into(), json!(true));
+    }
+}
+
+async fn eslint_major_version(delegate: &Arc<dyn LspAdapterDelegate>) -> Option<u64> {
+    let (_, version) = delegate
+        .npm_package_installed_version("eslint")
+        .await
+        .ok()
+        .flatten()?;
+    Some(version.major)
 }
 
 /// On Windows, converts Unix-style separators (/) to Windows-style (\).
@@ -480,6 +495,23 @@ enum ResultWorkingDirectory {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_set_use_flat_config() {
+        let mut configuration = json!({
+            "validate": "on",
+        });
+
+        set_use_flat_config(&mut configuration);
+
+        assert_eq!(
+            configuration,
+            json!({
+                "useFlatConfig": true,
+                "validate": "on",
+            })
+        );
+    }
 
     mod glob_patterns {
         use super::*;

--- a/crates/languages/src/eslint.rs
+++ b/crates/languages/src/eslint.rs
@@ -273,7 +273,12 @@ impl LspAdapter for EsLintLspAdapter {
 
 fn set_use_flat_config(configuration: &mut Value) {
     if let Some(configuration) = configuration.as_object_mut() {
-        configuration.insert("useFlatConfig".into(), json!(true));
+        let experimental = configuration
+            .entry("experimental")
+            .or_insert_with(|| json!({}));
+        if let Some(experimental) = experimental.as_object_mut() {
+            experimental.insert("useFlatConfig".into(), json!(true));
+        }
     }
 }
 
@@ -507,7 +512,9 @@ mod tests {
         assert_eq!(
             configuration,
             json!({
-                "useFlatConfig": true,
+                "experimental": {
+                    "useFlatConfig": true,
+                },
                 "validate": "on",
             })
         );


### PR DESCRIPTION
Update ESLint LSP adapter to support v3.0.10 and flat config

- Bumpup CURRENT_VERSION to 3.0.10
- Set useFlatConfig at top level for ESLint <= 9 when flat config detected

Closes #49387 

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Fixed ESLint 10 compatibility issue
