### PR TITLE
git_ui: Ignore extraneous links in git output

### DIFF
--- a/crates/git_ui/src/remote_output.rs
+++ b/crates/git_ui/src/remote_output.rs
@@ -147,8 +147,7 @@ pub fn format_output(action: &RemoteAction, output: RemoteCommandOutput) -> Succ
                             .find_map(|line| {
                                 finder
                                     .links(line)
-                                    .filter(|link| *link.kind() == LinkKind::Url)
-                                    .next()
+                                    .find(|link| *link.kind() == LinkKind::Url)
                                     .map(|link| SuccessStyle::PushPrLink {
                                         text: mapped.to_string(),
                                         link: link.as_str().to_string(),

--- a/crates/git_ui/src/remote_output.rs
+++ b/crates/git_ui/src/remote_output.rs
@@ -139,14 +139,20 @@ pub fn format_output(action: &RemoteAction, output: RemoteCommandOutput) -> Succ
                     .find(|(indicator, _)| output.stderr.contains(indicator))
                     .and_then(|(_, mapped)| {
                         let finder = LinkFinder::new();
-                        finder
-                            .links(&output.stderr)
-                            .filter(|link| *link.kind() == LinkKind::Url)
-                            .map(|link| link.start()..link.end())
-                            .next()
-                            .map(|link| SuccessStyle::PushPrLink {
-                                text: mapped.to_string(),
-                                link: output.stderr[link].to_string(),
+
+                        output
+                            .stderr
+                            .lines()
+                            .filter(|line| line.trim_start().starts_with("remote:"))
+                            .find_map(|line| {
+                                finder
+                                    .links(line)
+                                    .filter(|link| *link.kind() == LinkKind::Url)
+                                    .next()
+                                    .map(|link| SuccessStyle::PushPrLink {
+                                        text: mapped.to_string(),
+                                        link: link.as_str().to_string(),
+                                    })
                             })
                     })
             } else {
@@ -245,7 +251,11 @@ mod tests {
 
         let output = RemoteCommandOutput {
             stdout: String::new(),
+            // Simulate an extraneous link that should not be found in top 3 lines
             stderr: indoc! {"
+                ** WARNING: connection is not using a post-quantum key exchange algorithm.
+                ** This session may be vulnerable to \"store now, decrypt later\" attacks.
+                ** The server may need to be upgraded. See https://openssh.com/pq.html
                 Total 0 (delta 0), reused 0 (delta 0), pack-reused 0 (from 0)
                 remote:
                 remote: View merge request for test:


### PR DESCRIPTION
Closes #49746 

Previously, the `LinkFinder` looked at all of the lines, which sometimes includes links unrelated to the pull request, like a post quantum cryptography warning that links to [this](https://www.openssh.org/pq.html) article.

Release Notes:

- When searching for pull request links in git output, only lines that start with `remote:` are searched.