### PR TITLE
git_ui: Disable remote buttons while push/pull/fetch is in progress

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -623,6 +623,7 @@ pub struct GitPanel {
     changes_count: usize,
     new_staged_count: usize,
     pending_commit: Option<Task<()>>,
+    pending_remote_operation: Option<Task<anyhow::Result<()>>>,
     amend_pending: bool,
     original_commit_message: Option<String>,
     signoff_enabled: bool,
@@ -786,6 +787,7 @@ impl GitPanel {
                 new_staged_count: 0,
                 changes_count: 0,
                 pending_commit: None,
+                pending_remote_operation: None,
                 amend_pending: false,
                 original_commit_message: None,
                 signoff_enabled: false,
@@ -2822,13 +2824,15 @@ impl GitPanel {
         if !self.can_push_and_pull(cx) {
             return;
         }
+        if self.pending_remote_operation.is_some() {
+            return;
+        }
 
         let Some(repo) = self.active_repository.clone() else {
             return;
         };
         telemetry::event!("Git Fetched");
         let askpass = self.askpass_delegate("git fetch", window, cx);
-        let this = cx.weak_entity();
 
         let fetch_options = if is_fetch_all {
             Task::ready(Some(FetchOptions::All))
@@ -2836,8 +2840,8 @@ impl GitPanel {
             self.get_fetch_options(window, cx)
         };
 
-        window
-            .spawn(cx, async move |cx| {
+        let task = cx.spawn_in(window, async move |this, cx| {
+            let result: anyhow::Result<()> = async {
                 let Some(fetch_options) = fetch_options.await else {
                     return Ok(());
                 };
@@ -2863,8 +2867,20 @@ impl GitPanel {
                 })
                 .ok();
                 anyhow::Ok(())
+            }
+            .await;
+
+            this.update(cx, |this, cx| {
+                this.pending_remote_operation.take();
+                cx.notify();
             })
-            .detach_and_log_err(cx);
+            .ok();
+
+            result
+        });
+
+        self.pending_remote_operation = Some(task);
+        cx.notify();
     }
 
     pub(crate) fn git_clone(&mut self, repo: String, window: &mut Window, cx: &mut Context<Self>) {
@@ -2965,6 +2981,9 @@ impl GitPanel {
         if !self.can_push_and_pull(cx) {
             return;
         }
+        if self.pending_remote_operation.is_some() {
+            return;
+        }
         let Some(repo) = self.active_repository.clone() else {
             return;
         };
@@ -2974,48 +2993,61 @@ impl GitPanel {
         telemetry::event!("Git Pulled");
         let branch = branch.clone();
         let remote = self.get_remote(false, false, window, cx);
-        cx.spawn_in(window, async move |this, cx| {
-            let remote = match remote.await {
-                Ok(Some(remote)) => remote,
-                Ok(None) => {
-                    return Ok(());
-                }
-                Err(e) => {
-                    log::error!("Failed to get current remote: {}", e);
-                    this.update(cx, |this, cx| this.show_error_toast("pull", e, cx))
-                        .ok();
-                    return Ok(());
-                }
-            };
+        let task = cx.spawn_in(window, async move |this, cx| {
+            let result: anyhow::Result<()> = async {
+                let remote = match remote.await {
+                    Ok(Some(remote)) => remote,
+                    Ok(None) => {
+                        return Ok(());
+                    }
+                    Err(e) => {
+                        log::error!("Failed to get current remote: {}", e);
+                        this.update(cx, |this, cx| this.show_error_toast("pull", e, cx))
+                            .ok();
+                        return Ok(());
+                    }
+                };
 
-            let askpass = this.update_in(cx, |this, window, cx| {
-                this.askpass_delegate(format!("git pull {}", remote.name), window, cx)
-            })?;
+                let askpass = this.update_in(cx, |this, window, cx| {
+                    this.askpass_delegate(format!("git pull {}", remote.name), window, cx)
+                })?;
 
-            let branch_name = branch
-                .upstream
-                .is_none()
-                .then(|| branch.name().to_owned().into());
+                let branch_name = branch
+                    .upstream
+                    .is_none()
+                    .then(|| branch.name().to_owned().into());
 
-            let pull = repo.update(cx, |repo, cx| {
-                repo.pull(branch_name, remote.name.clone(), rebase, askpass, cx)
-            });
+                let pull = repo.update(cx, |repo, cx| {
+                    repo.pull(branch_name, remote.name.clone(), rebase, askpass, cx)
+                });
 
-            let remote_message = pull.await?;
+                let remote_message = pull.await?;
 
-            let action = RemoteAction::Pull(remote);
-            this.update(cx, |this, cx| match remote_message {
-                Ok(remote_message) => this.show_remote_output(action, remote_message, cx),
-                Err(e) => {
-                    log::error!("Error while pulling {:?}", e);
-                    this.show_error_toast(action.name(), e, cx)
-                }
+                let action = RemoteAction::Pull(remote);
+                this.update(cx, |this, cx| match remote_message {
+                    Ok(remote_message) => this.show_remote_output(action, remote_message, cx),
+                    Err(e) => {
+                        log::error!("Error while pulling {:?}", e);
+                        this.show_error_toast(action.name(), e, cx)
+                    }
+                })
+                .ok();
+
+                anyhow::Ok(())
+            }
+            .await;
+
+            this.update(cx, |this, cx| {
+                this.pending_remote_operation.take();
+                cx.notify();
             })
             .ok();
 
-            anyhow::Ok(())
-        })
-        .detach_and_log_err(cx);
+            result
+        });
+
+        self.pending_remote_operation = Some(task);
+        cx.notify();
     }
 
     pub(crate) fn push(
@@ -3026,6 +3058,9 @@ impl GitPanel {
         cx: &mut Context<Self>,
     ) {
         if !self.can_push_and_pull(cx) {
+            return;
+        }
+        if self.pending_remote_operation.is_some() {
             return;
         }
         let Some(repo) = self.active_repository.clone() else {
@@ -3051,56 +3086,69 @@ impl GitPanel {
         };
         let remote = self.get_remote(select_remote, true, window, cx);
 
-        cx.spawn_in(window, async move |this, cx| {
-            let remote = match remote.await {
-                Ok(Some(remote)) => remote,
-                Ok(None) => {
-                    return Ok(());
-                }
-                Err(e) => {
-                    log::error!("Failed to get current remote: {}", e);
-                    this.update(cx, |this, cx| this.show_error_toast("push", e, cx))
-                        .ok();
-                    return Ok(());
-                }
-            };
+        let task = cx.spawn_in(window, async move |this, cx| {
+            let result: anyhow::Result<()> = async {
+                let remote = match remote.await {
+                    Ok(Some(remote)) => remote,
+                    Ok(None) => {
+                        return Ok(());
+                    }
+                    Err(e) => {
+                        log::error!("Failed to get current remote: {}", e);
+                        this.update(cx, |this, cx| this.show_error_toast("push", e, cx))
+                            .ok();
+                        return Ok(());
+                    }
+                };
 
-            let askpass_delegate = this.update_in(cx, |this, window, cx| {
-                this.askpass_delegate(format!("git push {}", remote.name), window, cx)
-            })?;
+                let askpass_delegate = this.update_in(cx, |this, window, cx| {
+                    this.askpass_delegate(format!("git push {}", remote.name), window, cx)
+                })?;
 
-            let push = repo.update(cx, |repo, cx| {
-                repo.push(
-                    branch.name().to_owned().into(),
-                    branch
-                        .upstream
-                        .as_ref()
-                        .filter(|u| matches!(u.tracking, UpstreamTracking::Tracked(_)))
-                        .and_then(|u| u.branch_name())
-                        .unwrap_or_else(|| branch.name())
-                        .to_owned()
-                        .into(),
-                    remote.name.clone(),
-                    options,
-                    askpass_delegate,
-                    cx,
-                )
-            });
+                let push = repo.update(cx, |repo, cx| {
+                    repo.push(
+                        branch.name().to_owned().into(),
+                        branch
+                            .upstream
+                            .as_ref()
+                            .filter(|u| matches!(u.tracking, UpstreamTracking::Tracked(_)))
+                            .and_then(|u| u.branch_name())
+                            .unwrap_or_else(|| branch.name())
+                            .to_owned()
+                            .into(),
+                        remote.name.clone(),
+                        options,
+                        askpass_delegate,
+                        cx,
+                    )
+                });
 
-            let remote_output = push.await?;
+                let remote_output = push.await?;
 
-            let action = RemoteAction::Push(branch.name().to_owned().into(), remote);
-            this.update(cx, |this, cx| match remote_output {
-                Ok(remote_message) => this.show_remote_output(action, remote_message, cx),
-                Err(e) => {
-                    log::error!("Error while pushing {:?}", e);
-                    this.show_error_toast(action.name(), e, cx)
-                }
-            })?;
+                let action = RemoteAction::Push(branch.name().to_owned().into(), remote);
+                this.update(cx, |this, cx| match remote_output {
+                    Ok(remote_message) => this.show_remote_output(action, remote_message, cx),
+                    Err(e) => {
+                        log::error!("Error while pushing {:?}", e);
+                        this.show_error_toast(action.name(), e, cx)
+                    }
+                })?;
 
-            anyhow::Ok(())
-        })
-        .detach_and_log_err(cx);
+                anyhow::Ok(())
+            }
+            .await;
+
+            this.update(cx, |this, cx| {
+                this.pending_remote_operation.take();
+                cx.notify();
+            })
+            .ok();
+
+            result
+        });
+
+        self.pending_remote_operation = Some(task);
+        cx.notify();
     }
 
     pub fn create_pull_request(&self, window: &mut Window, cx: &mut Context<Self>) {
@@ -4246,6 +4294,7 @@ impl GitPanel {
                         &branch,
                         focus_handle,
                         true,
+                        self.pending_remote_operation.is_some(),
                     ))
                 })
                 .into_any_element(),

--- a/crates/git_ui/src/git_ui.rs
+++ b/crates/git_ui/src/git_ui.rs
@@ -431,6 +431,7 @@ fn render_remote_button(
     branch: &Branch,
     keybinding_target: Option<FocusHandle>,
     show_fetch_button: bool,
+    disabled: bool,
 ) -> Option<impl IntoElement> {
     let id = id.into();
     let upstream = branch.upstream.as_ref();
@@ -440,19 +441,21 @@ fn render_remote_button(
             ..
         }) => match (*ahead, *behind) {
             (0, 0) if show_fetch_button => {
-                Some(remote_button::render_fetch_button(keybinding_target, id))
+                Some(remote_button::render_fetch_button(keybinding_target, id, disabled))
             }
             (0, 0) => None,
             (ahead, 0) => Some(remote_button::render_push_button(
                 keybinding_target,
                 id,
                 ahead,
+                disabled,
             )),
             (ahead, behind) => Some(remote_button::render_pull_button(
                 keybinding_target,
                 id,
                 ahead,
                 behind,
+                disabled,
             )),
         },
         Some(Upstream {
@@ -461,22 +464,25 @@ fn render_remote_button(
         }) => Some(remote_button::render_republish_button(
             keybinding_target,
             id,
+            disabled,
         )),
-        None => Some(remote_button::render_publish_button(keybinding_target, id)),
+        None => Some(remote_button::render_publish_button(keybinding_target, id, disabled)),
     }
 }
 
 mod remote_button {
     use gpui::{Action, AnyView, ClickEvent, Corner, FocusHandle};
     use ui::{
-        App, ButtonCommon, Clickable, ContextMenu, ElementId, FluentBuilder, Icon, IconName,
-        IconSize, IntoElement, Label, LabelCommon, LabelSize, LineHeightStyle, ParentElement,
-        PopoverMenu, SharedString, SplitButton, Styled, Tooltip, Window, div, h_flex, rems,
+        App, ButtonCommon, Clickable, ContextMenu, Disableable, ElementId, FluentBuilder, Icon,
+        IconName, IconSize, IntoElement, Label, LabelCommon, LabelSize, LineHeightStyle,
+        ParentElement, PopoverMenu, SharedString, SplitButton, Styled, Tooltip, Window, div,
+        h_flex, rems,
     };
 
     pub fn render_fetch_button(
         keybinding_target: Option<FocusHandle>,
         id: SharedString,
+        disabled: bool,
     ) -> SplitButton {
         split_button(
             id,
@@ -485,6 +491,7 @@ mod remote_button {
             0,
             Some(IconName::ArrowCircle),
             keybinding_target.clone(),
+            disabled,
             move |_, window, cx| {
                 window.dispatch_action(Box::new(git::Fetch), cx);
             },
@@ -504,6 +511,7 @@ mod remote_button {
         keybinding_target: Option<FocusHandle>,
         id: SharedString,
         ahead: u32,
+        disabled: bool,
     ) -> SplitButton {
         split_button(
             id,
@@ -512,6 +520,7 @@ mod remote_button {
             0,
             None,
             keybinding_target.clone(),
+            disabled,
             move |_, window, cx| {
                 window.dispatch_action(Box::new(git::Push), cx);
             },
@@ -532,6 +541,7 @@ mod remote_button {
         id: SharedString,
         ahead: u32,
         behind: u32,
+        disabled: bool,
     ) -> SplitButton {
         split_button(
             id,
@@ -540,6 +550,7 @@ mod remote_button {
             behind as usize,
             None,
             keybinding_target.clone(),
+            disabled,
             move |_, window, cx| {
                 window.dispatch_action(Box::new(git::Pull), cx);
             },
@@ -558,6 +569,7 @@ mod remote_button {
     pub fn render_publish_button(
         keybinding_target: Option<FocusHandle>,
         id: SharedString,
+        disabled: bool,
     ) -> SplitButton {
         split_button(
             id,
@@ -566,6 +578,7 @@ mod remote_button {
             0,
             Some(IconName::ExpandUp),
             keybinding_target.clone(),
+            disabled,
             move |_, window, cx| {
                 window.dispatch_action(Box::new(git::Push), cx);
             },
@@ -584,6 +597,7 @@ mod remote_button {
     pub fn render_republish_button(
         keybinding_target: Option<FocusHandle>,
         id: SharedString,
+        disabled: bool,
     ) -> SplitButton {
         split_button(
             id,
@@ -592,6 +606,7 @@ mod remote_button {
             0,
             Some(IconName::ExpandUp),
             keybinding_target.clone(),
+            disabled,
             move |_, window, cx| {
                 window.dispatch_action(Box::new(git::Push), cx);
             },
@@ -666,6 +681,7 @@ mod remote_button {
         behind_count: usize,
         left_icon: Option<IconName>,
         keybinding_target: Option<FocusHandle>,
+        disabled: bool,
         left_on_click: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
         tooltip: impl Fn(&mut Window, &mut App) -> AnyView + 'static,
     ) -> SplitButton {
@@ -716,6 +732,7 @@ mod remote_button {
                 .child(Label::new(left_label).size(LabelSize::Small))
                 .mr_0p5(),
         )
+        .disabled(disabled)
         .on_click(left_on_click)
         .tooltip(tooltip);
 

--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -1797,6 +1797,7 @@ impl RenderOnce for ProjectDiffEmptyState {
                             self.focus_handle,
                             "push".into(),
                             ahead_count as u32,
+                            false,
                         )))
                     } else if branch_not_on_remote {
                         this.child(
@@ -1808,7 +1809,7 @@ impl RenderOnce for ProjectDiffEmptyState {
                                 ),
                         )
                         .child(
-                            div().child(render_publish_button(self.focus_handle, "publish".into())),
+                            div().child(render_publish_button(self.focus_handle, "publish".into(), false)),
                         )
                     } else {
                         this.child(Label::new("Remote status unknown").color(Color::Muted))


### PR DESCRIPTION
## Summary

- Track pending remote operations (push, pull, fetch) with a `pending_remote_operation` task field on `GitPanel`
- While an operation is running, the remote button (Push/Pull/Fetch/Publish/Republish) is rendered in a disabled state
- New operations are rejected while one is already in progress, preventing duplicate operations from accidental repeated clicks

Release Notes:

- Fixed git panel push/pull/fetch buttons not showing a disabled state while the operation is in progress, which could lead to accidentally triggering duplicate operations.