### PR TITLE
editor: Add gutter checkboxes for split diff and restore hunk to context menu

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -29607,6 +29607,8 @@ fn render_diff_hunk_controls(
     _window: &mut Window,
     cx: &mut App,
 ) -> AnyElement {
+    let all_hunks_expanded = editor.read(cx).buffer().read(cx).all_diff_hunks_expanded();
+
     h_flex()
         .h(line_height)
         .mr_1()
@@ -29618,7 +29620,6 @@ fn render_diff_hunk_controls(
         .border_color(cx.theme().colors().border_variant)
         .rounded_b_lg()
         .bg(cx.theme().colors().editor_background)
-        .gap_1()
         .block_mouse_except_scroll()
         .shadow_md()
         .child(if status.has_secondary_hunk() {
@@ -29679,7 +29680,12 @@ fn render_diff_hunk_controls(
                 .tooltip({
                     let focus_handle = editor.focus_handle(cx);
                     move |_window, cx| {
-                        Tooltip::for_action_in("Restore Hunk", &::git::Restore, &focus_handle, cx)
+                        Tooltip::for_action_in(
+                            "Restore Hunk",
+                            &::git::Restore,
+                            &focus_handle,
+                            cx,
+                        )
                     }
                 })
                 .on_click({
@@ -29687,7 +29693,8 @@ fn render_diff_hunk_controls(
                     move |_event, window, cx| {
                         editor.update(cx, |editor, cx| {
                             let snapshot = editor.snapshot(window, cx);
-                            let point = hunk_range.start.to_point(&snapshot.buffer_snapshot());
+                            let point =
+                                hunk_range.start.to_point(&snapshot.buffer_snapshot());
                             editor.restore_hunks_in_ranges(vec![point..point], window, cx);
                         });
                     }
@@ -29695,13 +29702,12 @@ fn render_diff_hunk_controls(
                 .disabled(is_created_file),
         )
         .when(
-            !editor.read(cx).buffer().read(cx).all_diff_hunks_expanded(),
+            !all_hunks_expanded,
             |el| {
                 el.child(
                     IconButton::new(("next-hunk", row as u64), IconName::ArrowDown)
                         .shape(IconButtonShape::Square)
                         .icon_size(IconSize::Small)
-                        // .disabled(!has_multiple_hunks)
                         .tooltip({
                             let focus_handle = editor.focus_handle(cx);
                             move |_window, cx| {
@@ -29732,7 +29738,6 @@ fn render_diff_hunk_controls(
                     IconButton::new(("prev-hunk", row as u64), IconName::ArrowUp)
                         .shape(IconButtonShape::Square)
                         .icon_size(IconSize::Small)
-                        // .disabled(!has_multiple_hunks)
                         .tooltip({
                             let focus_handle = editor.focus_handle(cx);
                             move |_window, cx| {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -90,8 +90,8 @@ use theme::{ActiveTheme, Appearance, PlayerColor};
 use theme_settings::BufferLineHeight;
 use ui::utils::ensure_minimum_contrast;
 use ui::{
-    ButtonLike, ContextMenu, Indicator, KeyBinding, POPOVER_Y_PADDING, Tooltip, prelude::*,
-    right_click_menu, scrollbars::ShowScrollbar, text_for_keystroke,
+    ButtonLike, ContextMenu, Indicator, KeyBinding, POPOVER_Y_PADDING, Tooltip, checkbox,
+    prelude::*, right_click_menu, scrollbars::ShowScrollbar, text_for_keystroke,
 };
 use unicode_segmentation::UnicodeSegmentation;
 use util::post_inc;
@@ -3192,6 +3192,128 @@ impl EditorElement {
         })
     }
 
+    fn layout_staging_checkboxes(
+        &self,
+        line_height: Pixels,
+        range: Range<DisplayRow>,
+        scroll_position: gpui::Point<ScrollOffset>,
+        gutter_dimensions: &GutterDimensions,
+        gutter_hitbox: &Hitbox,
+        display_hunks: &[(DisplayDiffHunk, Option<Hitbox>)],
+        row_infos: &[RowInfo],
+        editor: Entity<Editor>,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> Vec<AnyElement> {
+        if self.split_side.is_none() {
+            return Vec::new();
+        }
+
+        let (is_read_only, delegate) = {
+            let editor = editor.read(cx);
+            (editor.read_only(cx), editor.delegate_stage_and_restore)
+        };
+        if is_read_only && !delegate {
+            return Vec::new();
+        }
+
+        let mut checkboxes = Vec::new();
+
+        for (hunk, _) in display_hunks {
+            let DisplayDiffHunk::Unfolded {
+                display_row_range,
+                multi_buffer_range,
+                status,
+                ..
+            } = hunk
+            else {
+                continue;
+            };
+
+            if display_row_range.start < range.start || display_row_range.start >= range.end {
+                continue;
+            }
+
+            let row_ix = (display_row_range.start - range.start).0 as usize;
+            if row_infos
+                .get(row_ix)
+                .is_some_and(|row_info| row_info.expand_info.is_some())
+            {
+                continue;
+            }
+
+            let toggle_state = match status.secondary {
+                buffer_diff::DiffHunkSecondaryStatus::NoSecondaryHunk
+                | buffer_diff::DiffHunkSecondaryStatus::SecondaryHunkRemovalPending => {
+                    ToggleState::Selected
+                }
+                buffer_diff::DiffHunkSecondaryStatus::OverlapsWithSecondaryHunk => {
+                    ToggleState::Indeterminate
+                }
+                buffer_diff::DiffHunkSecondaryStatus::HasSecondaryHunk
+                | buffer_diff::DiffHunkSecondaryStatus::SecondaryHunkAdditionPending => {
+                    ToggleState::Unselected
+                }
+            };
+
+            let is_pending = status.is_pending();
+            let hunk_range = multi_buffer_range.clone();
+            let editor_handle = editor.clone();
+
+            let checkbox_element = checkbox(
+                ("staging-checkbox", display_row_range.start.0 as u64),
+                toggle_state,
+            )
+            .disabled(is_pending)
+            .tooltip({
+                let focus_handle = editor.focus_handle(cx);
+                let has_secondary = status.has_secondary_hunk();
+                move |_window, cx| {
+                    if has_secondary {
+                        Tooltip::for_action_in(
+                            "Stage Hunk",
+                            &::git::ToggleStaged,
+                            &focus_handle,
+                            cx,
+                        )
+                    } else {
+                        Tooltip::for_action_in(
+                            "Unstage Hunk",
+                            &::git::ToggleStaged,
+                            &focus_handle,
+                            cx,
+                        )
+                    }
+                }
+            })
+            .on_click(move |new_state, _window, cx| {
+                let stage = matches!(new_state, ToggleState::Selected);
+                editor_handle.update(cx, |editor, cx| {
+                    editor.stage_or_unstage_diff_hunks(
+                        stage,
+                        vec![hunk_range.start..hunk_range.start],
+                        cx,
+                    );
+                });
+            })
+            .into_any_element();
+
+            let button = prepaint_gutter_button(
+                checkbox_element,
+                display_row_range.start,
+                line_height,
+                gutter_dimensions,
+                scroll_position,
+                gutter_hitbox,
+                window,
+                cx,
+            );
+            checkboxes.push(button);
+        }
+
+        checkboxes
+    }
+
     fn should_render_diff_review_button(
         &self,
         range: Range<DisplayRow>,
@@ -5737,6 +5859,10 @@ impl EditorElement {
                         sticky_top.min(max_y)
                     };
 
+                    if self.split_side.is_some() {
+                        continue;
+                    }
+
                     let mut element = render_diff_hunk_controls(
                         display_row_range.start.0,
                         status,
@@ -6435,6 +6561,10 @@ impl EditorElement {
 
             if let Some(diff_review_button) = layout.diff_review_button.as_mut() {
                 diff_review_button.paint(window, cx);
+            }
+
+            for staging_checkbox in layout.staging_checkboxes.iter_mut() {
+                staging_checkbox.paint(window, cx);
             }
         });
     }
@@ -10781,6 +10911,19 @@ impl Element for EditorElement {
                         Vec::new()
                     };
 
+                    let staging_checkboxes = self.layout_staging_checkboxes(
+                        line_height,
+                        start_row..end_row,
+                        scroll_position,
+                        &gutter_dimensions,
+                        &gutter_hitbox,
+                        &display_hunks,
+                        &row_infos,
+                        self.editor.clone(),
+                        window,
+                        cx,
+                    );
+
                     let git_gutter_width = Self::gutter_strip_width(line_height)
                         + gutter_dimensions
                             .git_blame_entries_width
@@ -11067,6 +11210,7 @@ impl Element for EditorElement {
                         selections,
                         edit_prediction_popover,
                         diff_hunk_controls,
+                        staging_checkboxes,
                         mouse_context_menu,
                         test_indicators,
                         breakpoints,
@@ -11262,6 +11406,7 @@ pub struct EditorLayout {
     crease_toggles: Vec<Option<AnyElement>>,
     expand_toggles: Vec<Option<(AnyElement, gpui::Point<Pixels>)>>,
     diff_hunk_controls: Vec<AnyElement>,
+    staging_checkboxes: Vec<AnyElement>,
     crease_trailers: Vec<Option<CreaseTrailerLayout>>,
     edit_prediction_popover: Option<AnyElement>,
     mouse_context_menu: Option<AnyElement>,

--- a/crates/editor/src/mouse_context_menu.rs
+++ b/crates/editor/src/mouse_context_menu.rs
@@ -216,6 +216,10 @@ pub fn deploy_context_menu(
                         .repository_and_path_for_buffer_id(buffer_anchor.buffer_id, cx)
                         .is_some()
                 });
+        let in_diff_hunk = {
+            let point = point.to_point(&display_map);
+            !snapshot.hunks_for_ranges([point..point]).is_empty()
+        };
 
         let evaluate_selection = window.is_action_available(&EvaluateSelectedText, cx);
         let run_to_cursor = window.is_action_available(&RunToCursor, cx);
@@ -310,7 +314,14 @@ pub fn deploy_context_menu(
                     !has_git_repo,
                     "View File History",
                     Box::new(git::FileHistory),
-                );
+                )
+                .when(has_git_repo, |builder| {
+                    builder.action_disabled_when(
+                        !in_diff_hunk,
+                        "Restore Hunk",
+                        Box::new(::git::Restore),
+                    )
+                });
             match focus {
                 Some(focus) => builder.context(focus),
                 None => builder,


### PR DESCRIPTION
Closes #49562

**Screenshots:**
- Before
<img width="2107" height="212" alt="image" src="https://github.com/user-attachments/assets/0f5177c9-0c9f-4a18-b460-54c3de056d43" />

- After
<img width="1917" height="962" alt="image" src="https://github.com/user-attachments/assets/b20af8f6-8c63-42e4-84e8-d4c588356529" />

**Motivation**

In split diff view, the floating Stage/Unstage/Restore buttons overlay the code on the hovered line, hiding the content you're trying to compare. This defeats the purpose of a side-by-side diff (GitHub #49562).

**Changes**

Gutter checkboxes in split diff mode:
- Small checkboxes in the gutter next to each diff hunk in split diff view
- Checked = staged, unchecked = unstaged, dash = partially staged
- Clicking toggles staging state without covering any code
- Disabled during pending operations to prevent double-clicks

Floating toolbar skipped in split diff mode:
- The `layout_diff_hunk_controls` loop skips calling `render_diff_hunk_controls` entirely when `split_side` is set
- Navigation arrows are not needed because split diff always expands all hunks (`set_all_diff_hunks_expanded` in `split.rs`)
- Non-split editor behavior is unchanged

"Restore Hunk" added to right-click context menu:
- Available when a git repo is present and the cursor is inside a diff hunk
- Grayed out when the cursor is outside a hunk
- Works in both split and regular editor modes

**Files changed**

- `crates/editor/src/element.rs`: new `layout_staging_checkboxes` method, painting, checkbox import
- `crates/editor/src/element.rs`: skip `render_diff_hunk_controls` call when in split mode
- `crates/editor/src/mouse_context_menu.rs`: "Restore Hunk" menu item
- `crates/agent_ui/src/agent_diff.rs`: updated closure param count
- `crates/git_ui/src/{text_diff_view,project_diff,multi_diff_view,file_diff_view}.rs`: updated closure param count

**Risk**

Low. All changes gated behind `split_side.is_some()`. No behavioral change to regular editor, unified diff view, or agent diff view. The `RenderDiffHunkControlsFn` signature change is breaking but all call sites are updated.

Release Notes:

- Added gutter checkboxes for staging hunks in split diff view and "Restore Hunk" to the right-click context menu