### PR TITLE
Fix OpenAI-compatible setting description

### DIFF
--- a/crates/settings_ui/src/pages/edit_prediction_provider_setup.rs
+++ b/crates/settings_ui/src/pages/edit_prediction_provider_setup.rs
@@ -516,7 +516,7 @@ fn open_ai_compatible_settings() -> Box<[SettingsPageItem]> {
     Box::new([
         SettingsPageItem::SettingItem(SettingItem {
             title: "API URL",
-            description: "The base URL of your OpenAI-compatible server.",
+            description: "The URL of your OpenAI-compatible server's completions API.",
             field: Box::new(SettingField {
                 pick: |settings| {
                     settings


### PR DESCRIPTION
While testing the OpenAI compatible endpoint, it didn't work, so after a bit of digging I found out it actually expects the completions endpoint instead. So I changed the description accordingly.

Maybe this is a bug in the implementation instead and the description should be correct.

---

Release Notes:

- AI: Fixed the OpenAI-compatible setting description to point to the server's completion API URL.
