### PR TITLE
gpui: Read thermal state from window handle

### DIFF
--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1186,9 +1186,12 @@ impl Window {
             let next_frame_callbacks = next_frame_callbacks.clone();
             let input_rate_tracker = input_rate_tracker.clone();
             move |request_frame_options| {
-                let thermal_state = cx.update(|cx| cx.thermal_state());
+                let thermal_state = handle
+                    .update(&mut cx, |_, _, cx| cx.thermal_state())
+                    .log_err();
 
-                if thermal_state == ThermalState::Serious || thermal_state == ThermalState::Critical
+                if thermal_state == Some(ThermalState::Serious)
+                    || thermal_state == Some(ThermalState::Critical)
                 {
                     let now = Instant::now();
                     let last_frame_time = last_frame_time.replace(Some(now));


### PR DESCRIPTION
Should close #49566

Inside `on_request_frame`, it’s conceptually incorrect to update the application directly. Instead, we should read the thermal state through the window handle, just like in the rest of the callback. That path uses `try_borrow_mut` internally, so if the application is already being updated elsewhere, we can safely skip checking the thermal state for that frame and retry on the next one.

Before you mark this PR as ready for review, make sure that you have:
- [ ] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [ ] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- N/A
