### PR TITLE
settings_ui: Improve control alignment for multiline settings rows

### DIFF
--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -967,7 +967,6 @@ impl SettingsPageItem {
                         .id(sub_page_link.title.clone())
                         .w_full()
                         .min_w_0()
-                        .items_start()
                         .justify_between()
                         .map(apply_padding)
                         .child(
@@ -1101,7 +1100,6 @@ impl SettingsPageItem {
                         .id(action_link.title.clone())
                         .w_full()
                         .min_w_0()
-                        .items_start()
                         .justify_between()
                         .map(apply_padding)
                         .child(
@@ -1161,7 +1159,6 @@ fn render_settings_item(
     h_flex()
         .id(setting_item.title)
         .min_w_0()
-        .items_start()
         .justify_between()
         .child(
             v_flex()

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -967,6 +967,7 @@ impl SettingsPageItem {
                         .id(sub_page_link.title.clone())
                         .w_full()
                         .min_w_0()
+                        .items_start()
                         .justify_between()
                         .map(apply_padding)
                         .child(
@@ -1100,6 +1101,7 @@ impl SettingsPageItem {
                         .id(action_link.title.clone())
                         .w_full()
                         .min_w_0()
+                        .items_start()
                         .justify_between()
                         .map(apply_padding)
                         .child(
@@ -1159,11 +1161,14 @@ fn render_settings_item(
     h_flex()
         .id(setting_item.title)
         .min_w_0()
+        .items_start()
         .justify_between()
         .child(
             v_flex()
                 .relative()
-                .w_3_4()
+                .w_full()
+                .max_w_2_3()
+                .min_w_0()
                 .child(
                     h_flex()
                         .w_full()


### PR DESCRIPTION
Closes #49848

Before you mark this PR as ready for review, make sure that you have:
- [ ] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

## Summary
Align right-side controls in settings rows when descriptions wrap to multiple lines, and relax the text-width cap for better balance.

## Changes
- Top-aligned settings row containers in shared settings UI render paths by adding `items_start()` to:
  - Setting rows (`render_settings_item`)
  - Sub-page link rows
  - Action link rows
- Updated the left text column width constraint in `render_settings_item` from `w_3_4` to `w_full + max_w_2_3 + min_w_0` to avoid overlap while reducing excess empty space.

## Validation
- Built and ran Zed locally with `cargo run`.
- Manual verification in Settings pages with multiline descriptions and right-side controls:
  - General
  - Appearance
  - Languages & Tools
  - Agent/Terminal-related sections
- Confirmed improved control alignment and no right-column text overlap in the tested views.

  | Before | After |
  |---|---|
  | ![1-before](https://github.com/user-attachments/assets/bf548d15-a1a6-4917-81ac-0a1afefa2ea1) | ![1-after](https://github.com/user-attachments/assets/47a61610-7b74-48bd-838d-e39e3b578d19) |
  | ![2-before](https://github.com/user-attachments/assets/92c0bd32-9772-42f4-be98-b1818556fa80) | ![2-after](https://github.com/user-attachments/assets/188e0fdf-91ea-49bf-9648-9177107d94c9) |







## Linked Issues
- #49848

Release Notes:

- Fixed settings row layout so right-side controls align better with multiline setting descriptions.
