### PR TITLE
agent: Add ability to pin threads

### DIFF
--- a/crates/acp_thread/src/connection.rs
+++ b/crates/acp_thread/src/connection.rs
@@ -241,6 +241,7 @@ pub struct AgentSessionInfo {
     pub title: Option<SharedString>,
     pub updated_at: Option<DateTime<Utc>>,
     pub meta: Option<acp::Meta>,
+    pub pinned: bool,
 }
 
 impl AgentSessionInfo {
@@ -251,6 +252,7 @@ impl AgentSessionInfo {
             title: None,
             updated_at: None,
             meta: None,
+            pinned: false,
         }
     }
 }
@@ -281,6 +283,19 @@ pub trait AgentSessionList {
 
     fn delete_sessions(&self, _cx: &mut App) -> Task<Result<()>> {
         Task::ready(Err(anyhow::anyhow!("delete_sessions not supported")))
+    }
+
+    fn supports_pin(&self) -> bool {
+        false
+    }
+
+    fn set_session_pinned(
+        &self,
+        _session_id: &acp::SessionId,
+        _pinned: bool,
+        _cx: &mut App,
+    ) -> Task<Result<()>> {
+        Task::ready(Err(anyhow::anyhow!("set_session_pinned not supported")))
     }
 
     fn watch(&self, _cx: &mut App) -> Option<smol::channel::Receiver<SessionListUpdate>> {

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -1470,6 +1470,7 @@ impl NativeAgentSessionList {
             title: Some(entry.title),
             updated_at: Some(entry.updated_at),
             meta: None,
+            pinned: entry.pinned,
         }
     }
 
@@ -1495,6 +1496,21 @@ impl AgentSessionList for NativeAgentSessionList {
 
     fn supports_delete(&self) -> bool {
         true
+    }
+
+    fn supports_pin(&self) -> bool {
+        true
+    }
+
+    fn set_session_pinned(
+        &self,
+        session_id: &acp::SessionId,
+        pinned: bool,
+        cx: &mut App,
+    ) -> Task<Result<()>> {
+        self.thread_store.update(cx, |store, cx| {
+            store.set_thread_pinned(session_id.clone(), pinned, cx)
+        })
     }
 
     fn delete_session(&self, session_id: &acp::SessionId, cx: &mut App) -> Task<Result<()>> {

--- a/crates/agent/src/db.rs
+++ b/crates/agent/src/db.rs
@@ -45,6 +45,7 @@ pub struct DbThreadMetadata {
     /// listing without decompressing thread data. The blob is the source of
     /// truth; this column is populated on save for query convenience.
     pub worktree_branch: Option<String>,
+    pub pinned: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -395,6 +396,13 @@ impl ThreadsDatabase {
             s().ok();
         }
 
+        if let Ok(mut s) = connection.exec(indoc! {"
+            ALTER TABLE threads ADD COLUMN pinned INTEGER NOT NULL DEFAULT 0
+        "})
+        {
+            s().ok();
+        }
+
         let db = Self {
             executor,
             connection: Arc::new(Mutex::new(connection)),
@@ -439,7 +447,15 @@ impl ThreadsDatabase {
         let data = compressed;
 
         let mut insert = connection.exec_bound::<(Arc<str>, Option<Arc<str>>, Option<String>, String, String, DataType, Vec<u8>)>(indoc! {"
-            INSERT OR REPLACE INTO threads (id, parent_id, worktree_branch, summary, updated_at, data_type, data) VALUES (?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO threads (id, parent_id, worktree_branch, summary, updated_at, data_type, data)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+                parent_id = excluded.parent_id,
+                worktree_branch = excluded.worktree_branch,
+                summary = excluded.summary,
+                updated_at = excluded.updated_at,
+                data_type = excluded.data_type,
+                data = excluded.data
         "})?;
 
         insert((
@@ -462,20 +478,21 @@ impl ThreadsDatabase {
             let connection = connection.lock();
 
             let mut select = connection
-                .select_bound::<(), (Arc<str>, Option<Arc<str>>, Option<String>, String, String)>(indoc! {"
-                SELECT id, parent_id, worktree_branch, summary, updated_at FROM threads ORDER BY updated_at DESC
+                .select_bound::<(), (Arc<str>, Option<Arc<str>>, Option<String>, String, String, bool)>(indoc! {"
+                SELECT id, parent_id, worktree_branch, summary, updated_at, pinned FROM threads ORDER BY pinned DESC, updated_at DESC
             "})?;
 
             let rows = select(())?;
             let mut threads = Vec::new();
 
-            for (id, parent_id, worktree_branch, summary, updated_at) in rows {
+            for (id, parent_id, worktree_branch, summary, updated_at, pinned) in rows {
                 threads.push(DbThreadMetadata {
                     id: acp::SessionId::new(id),
                     parent_session_id: parent_id.map(acp::SessionId::new),
                     title: summary.into(),
                     updated_at: DateTime::parse_from_rfc3339(&updated_at)?.with_timezone(&Utc),
                     worktree_branch,
+                    pinned,
                 });
             }
 
@@ -527,6 +544,22 @@ impl ThreadsDatabase {
             "})?;
 
             delete(id.0)?;
+
+            Ok(())
+        })
+    }
+
+    pub fn set_thread_pinned(&self, id: acp::SessionId, pinned: bool) -> Task<Result<()>> {
+        let connection = self.connection.clone();
+
+        self.executor.spawn(async move {
+            let connection = connection.lock();
+
+            let mut update = connection.exec_bound::<(bool, Arc<str>)>(indoc! {"
+                UPDATE threads SET pinned = ? WHERE id = ?
+            "})?;
+
+            update((pinned, id.0))?;
 
             Ok(())
         })
@@ -842,5 +875,138 @@ mod tests {
             plain_entry.worktree_branch.is_none(),
             "plain thread should have no worktree_branch"
         );
+    }
+
+    #[gpui::test]
+    async fn test_new_threads_default_to_unpinned(cx: &mut TestAppContext) {
+        let database = ThreadsDatabase::new(cx.executor()).unwrap();
+
+        let thread_id = session_id("thread-a");
+        let thread = make_thread(
+            "Thread A",
+            Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap(),
+        );
+
+        database
+            .save_thread(thread_id.clone(), thread)
+            .await
+            .unwrap();
+
+        let entries = database.list_threads().await.unwrap();
+        assert_eq!(entries.len(), 1);
+        assert!(!entries[0].pinned);
+    }
+
+    #[gpui::test]
+    async fn test_set_thread_pinned(cx: &mut TestAppContext) {
+        let database = ThreadsDatabase::new(cx.executor()).unwrap();
+
+        let thread_id = session_id("thread-a");
+        let thread = make_thread(
+            "Thread A",
+            Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap(),
+        );
+
+        database
+            .save_thread(thread_id.clone(), thread)
+            .await
+            .unwrap();
+
+        database
+            .set_thread_pinned(thread_id.clone(), true)
+            .await
+            .unwrap();
+
+        let entries = database.list_threads().await.unwrap();
+        assert_eq!(entries.len(), 1);
+        assert!(entries[0].pinned);
+
+        database
+            .set_thread_pinned(thread_id.clone(), false)
+            .await
+            .unwrap();
+
+        let entries = database.list_threads().await.unwrap();
+        assert_eq!(entries.len(), 1);
+        assert!(!entries[0].pinned);
+    }
+
+    #[gpui::test]
+    async fn test_pinned_threads_sort_before_unpinned(cx: &mut TestAppContext) {
+        let database = ThreadsDatabase::new(cx.executor()).unwrap();
+
+        let older_id = session_id("thread-a");
+        let newer_id = session_id("thread-b");
+
+        let older_thread = make_thread(
+            "Thread A",
+            Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap(),
+        );
+        let newer_thread = make_thread(
+            "Thread B",
+            Utc.with_ymd_and_hms(2024, 1, 2, 0, 0, 0).unwrap(),
+        );
+
+        database
+            .save_thread(older_id.clone(), older_thread)
+            .await
+            .unwrap();
+        database
+            .save_thread(newer_id.clone(), newer_thread)
+            .await
+            .unwrap();
+
+        // Without pinning, newer thread comes first
+        let entries = database.list_threads().await.unwrap();
+        assert_eq!(entries[0].id, newer_id);
+        assert_eq!(entries[1].id, older_id);
+
+        // Pin the older thread — it should now come first
+        database
+            .set_thread_pinned(older_id.clone(), true)
+            .await
+            .unwrap();
+
+        let entries = database.list_threads().await.unwrap();
+        assert_eq!(entries[0].id, older_id);
+        assert!(entries[0].pinned);
+        assert_eq!(entries[1].id, newer_id);
+        assert!(!entries[1].pinned);
+    }
+
+    #[gpui::test]
+    async fn test_save_thread_preserves_pinned_state(cx: &mut TestAppContext) {
+        let database = ThreadsDatabase::new(cx.executor()).unwrap();
+
+        let thread_id = session_id("thread-a");
+        let thread = make_thread(
+            "Thread A",
+            Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap(),
+        );
+
+        database
+            .save_thread(thread_id.clone(), thread)
+            .await
+            .unwrap();
+
+        database
+            .set_thread_pinned(thread_id.clone(), true)
+            .await
+            .unwrap();
+
+        // Re-save the thread with updated content
+        let updated_thread = make_thread(
+            "Thread A Updated",
+            Utc.with_ymd_and_hms(2024, 1, 2, 0, 0, 0).unwrap(),
+        );
+        database
+            .save_thread(thread_id.clone(), updated_thread)
+            .await
+            .unwrap();
+
+        let entries = database.list_threads().await.unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].title.as_ref(), "Thread A Updated");
+        assert!(entries[0].pinned, "pinned state should survive re-save");
     }
 }

--- a/crates/agent/src/thread_store.rs
+++ b/crates/agent/src/thread_store.rs
@@ -101,6 +101,20 @@ impl ThreadStore {
         })
     }
 
+    pub fn set_thread_pinned(
+        &mut self,
+        id: acp::SessionId,
+        pinned: bool,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<()>> {
+        let database_future = ThreadsDatabase::connect(cx);
+        cx.spawn(async move |this, cx| {
+            let database = database_future.await.map_err(|err| anyhow!(err))?;
+            database.set_thread_pinned(id, pinned).await?;
+            this.update(cx, |this, cx| this.reload(cx))
+        })
+    }
+
     pub fn delete_threads(&mut self, cx: &mut Context<Self>) -> Task<Result<()>> {
         let database_future = ThreadsDatabase::connect(cx);
         cx.spawn(async move |this, cx| {

--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -132,6 +132,7 @@ impl AgentSessionList for AcpSessionList {
                                 .map(|dt| dt.with_timezone(&chrono::Utc))
                         }),
                         meta: s.meta,
+                        pinned: false,
                     })
                     .collect(),
                 next_cursor: response.next_cursor,

--- a/crates/agent_ui/src/acp/message_editor.rs
+++ b/crates/agent_ui/src/acp/message_editor.rs
@@ -2689,6 +2689,7 @@ mod tests {
             title: Some("Previous Conversation".into()),
             updated_at: Some(chrono::Utc::now()),
             meta: None,
+            pinned: false,
         };
 
         let message_editor = cx.update(|window, cx| {
@@ -2770,6 +2771,7 @@ mod tests {
             title: Some("Previous Conversation".into()),
             updated_at: Some(chrono::Utc::now()),
             meta: None,
+            pinned: false,
         };
 
         let message_editor = cx.update(|window, cx| {

--- a/crates/agent_ui/src/acp/thread_history.rs
+++ b/crates/agent_ui/src/acp/thread_history.rs
@@ -1,5 +1,5 @@
 use crate::acp::AcpServerView;
-use crate::{AgentPanel, RemoveHistory, RemoveSelectedThread};
+use crate::{AgentPanel, RemoveHistory, RemoveSelectedThread, TogglePinThread};
 use acp_thread::{AgentSessionInfo, AgentSessionList, AgentSessionListRequest, SessionListUpdate};
 use agent_client_protocol as acp;
 use chrono::{Datelike as _, Local, NaiveDate, TimeDelta, Utc};
@@ -356,7 +356,21 @@ impl AcpThreadHistory {
     }
 
     pub(crate) fn get_recent_sessions(&self, limit: usize) -> Vec<AgentSessionInfo> {
-        self.sessions.iter().take(limit).cloned().collect()
+        let mut result: Vec<AgentSessionInfo> = self
+            .sessions
+            .iter()
+            .filter(|entry| entry.pinned)
+            .cloned()
+            .collect();
+        let remaining = limit.saturating_sub(result.len());
+        result.extend(
+            self.sessions
+                .iter()
+                .filter(|entry| !entry.pinned)
+                .take(remaining)
+                .cloned(),
+        );
+        result
     }
 
     pub fn supports_delete(&self) -> bool {
@@ -378,6 +392,56 @@ impl AcpThreadHistory {
         }
     }
 
+    pub fn supports_pin(&self) -> bool {
+        self.session_list
+            .as_ref()
+            .map(|sl| sl.supports_pin())
+            .unwrap_or(false)
+    }
+
+    pub(crate) fn set_session_pinned(
+        &self,
+        session_id: &acp::SessionId,
+        pinned: bool,
+        cx: &mut App,
+    ) -> Task<anyhow::Result<()>> {
+        if let Some(session_list) = self.session_list.as_ref() {
+            session_list.set_session_pinned(session_id, pinned, cx)
+        } else {
+            Task::ready(Ok(()))
+        }
+    }
+
+    fn toggle_pin_selected_thread(
+        &mut self,
+        _: &TogglePinThread,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.toggle_pin(self.selected_index, cx)
+    }
+
+    fn toggle_pin(&mut self, visible_item_ix: usize, cx: &mut Context<Self>) {
+        let Some(entry) = self.get_history_entry(visible_item_ix) else {
+            return;
+        };
+        if !self.supports_pin() {
+            return;
+        }
+        let new_pinned = !entry.pinned;
+        let task = self.set_session_pinned(&entry.session_id, new_pinned, cx);
+        task.detach_and_log_err(cx);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn get_pinned_sessions(&self) -> Vec<AgentSessionInfo> {
+        self.sessions
+            .iter()
+            .filter(|entry| entry.pinned)
+            .cloned()
+            .collect()
+    }
+
     fn add_list_separators(
         &self,
         entries: Vec<AgentSessionInfo>,
@@ -385,10 +449,30 @@ impl AcpThreadHistory {
     ) -> Task<Vec<ListItemType>> {
         cx.background_spawn(async move {
             let mut items = Vec::with_capacity(entries.len() + 1);
-            let mut bucket = None;
             let today = Local::now().naive_local().date();
 
-            for entry in entries.into_iter() {
+            let (pinned_entries, unpinned_entries): (Vec<_>, Vec<_>) =
+                entries.into_iter().partition(|entry| entry.pinned);
+
+            if !pinned_entries.is_empty() {
+                items.push(ListItemType::BucketSeparator(TimeBucket::Pinned));
+                for entry in pinned_entries {
+                    let entry_bucket = entry
+                        .updated_at
+                        .map(|timestamp| {
+                            let entry_date = timestamp.with_timezone(&Local).naive_local().date();
+                            TimeBucket::from_dates(today, entry_date)
+                        })
+                        .unwrap_or(TimeBucket::All);
+                    items.push(ListItemType::Entry {
+                        entry,
+                        format: entry_bucket.into(),
+                    });
+                }
+            }
+
+            let mut bucket = None;
+            for entry in unpinned_entries {
                 let entry_bucket = entry
                     .updated_at
                     .map(|timestamp| {
@@ -639,6 +723,7 @@ impl AcpThreadHistory {
     ) -> AnyElement {
         let selected = ix == self.selected_index;
         let hovered = Some(ix) == self.hovered_index;
+        let is_pinned = entry.pinned;
         let entry_time = entry.updated_at;
         let display_text = match (format, entry_time) {
             (EntryTimeFormat::DateAndTime, Some(entry_time)) => {
@@ -661,6 +746,9 @@ impl AcpThreadHistory {
             })
             .unwrap_or_else(|| "Unknown".to_string());
 
+        let supports_pin = self.supports_pin();
+        let supports_delete = self.supports_delete();
+
         h_flex()
             .w_full()
             .pb_1()
@@ -675,9 +763,24 @@ impl AcpThreadHistory {
                             .gap_2()
                             .justify_between()
                             .child(
-                                HighlightedLabel::new(thread_title(entry), highlight_positions)
-                                    .size(LabelSize::Small)
-                                    .truncate(),
+                                h_flex()
+                                    .gap_1()
+                                    .overflow_hidden()
+                                    .when(is_pinned && !hovered, |this| {
+                                        this.child(
+                                            Icon::new(IconName::Pin)
+                                                .size(IconSize::XSmall)
+                                                .color(Color::Muted),
+                                        )
+                                    })
+                                    .child(
+                                        HighlightedLabel::new(
+                                            thread_title(entry),
+                                            highlight_positions,
+                                        )
+                                        .size(LabelSize::Small)
+                                        .truncate(),
+                                    ),
                             )
                             .child(
                                 Label::new(display_text)
@@ -697,23 +800,46 @@ impl AcpThreadHistory {
 
                         cx.notify();
                     }))
-                    .end_slot::<IconButton>(if hovered && self.supports_delete() {
-                        Some(
-                            IconButton::new("delete", IconName::Trash)
-                                .shape(IconButtonShape::Square)
-                                .icon_size(IconSize::XSmall)
-                                .icon_color(Color::Muted)
-                                .tooltip(move |_window, cx| {
-                                    Tooltip::for_action("Delete", &RemoveSelectedThread, cx)
-                                })
-                                .on_click(cx.listener(move |this, _, _, cx| {
-                                    this.remove_thread(ix, cx);
-                                    cx.stop_propagation()
-                                })),
-                        )
-                    } else {
-                        None
-                    })
+                    .end_slot(
+                        h_flex()
+                            .gap_0p5()
+                            .when(hovered && supports_pin, |this| {
+                                let pin_icon = if is_pinned {
+                                    IconName::Unpin
+                                } else {
+                                    IconName::Pin
+                                };
+                                let pin_tooltip = if is_pinned { "Unpin" } else { "Pin" };
+                                this.child(
+                                    IconButton::new("pin", pin_icon)
+                                        .shape(IconButtonShape::Square)
+                                        .icon_size(IconSize::XSmall)
+                                        .icon_color(Color::Muted)
+                                        .tooltip(move |_window, cx| {
+                                            Tooltip::for_action(pin_tooltip, &TogglePinThread, cx)
+                                        })
+                                        .on_click(cx.listener(move |this, _, _, cx| {
+                                            this.toggle_pin(ix, cx);
+                                            cx.stop_propagation()
+                                        })),
+                                )
+                            })
+                            .when(hovered && supports_delete, |this| {
+                                this.child(
+                                    IconButton::new("delete", IconName::Trash)
+                                        .shape(IconButtonShape::Square)
+                                        .icon_size(IconSize::XSmall)
+                                        .icon_color(Color::Muted)
+                                        .tooltip(move |_window, cx| {
+                                            Tooltip::for_action("Delete", &RemoveSelectedThread, cx)
+                                        })
+                                        .on_click(cx.listener(move |this, _, _, cx| {
+                                            this.remove_thread(ix, cx);
+                                            cx.stop_propagation()
+                                        })),
+                                )
+                            }),
+                    )
                     .on_click(cx.listener(move |this, _, _, cx| this.confirm_entry(ix, cx))),
             )
             .into_any_element()
@@ -740,6 +866,7 @@ impl Render for AcpThreadHistory {
             .on_action(cx.listener(Self::select_last))
             .on_action(cx.listener(Self::confirm))
             .on_action(cx.listener(Self::remove_selected_thread))
+            .on_action(cx.listener(Self::toggle_pin_selected_thread))
             .on_action(cx.listener(|this, _: &RemoveHistory, window, cx| {
                 this.remove_history(window, cx);
             }))
@@ -866,6 +993,7 @@ pub struct AcpHistoryEntryElement {
     selected: bool,
     hovered: bool,
     supports_delete: bool,
+    supports_pin: bool,
     on_hover: Box<dyn Fn(&bool, &mut Window, &mut App) + 'static>,
 }
 
@@ -877,12 +1005,18 @@ impl AcpHistoryEntryElement {
             selected: false,
             hovered: false,
             supports_delete: false,
+            supports_pin: false,
             on_hover: Box::new(|_, _, _| {}),
         }
     }
 
     pub fn supports_delete(mut self, supports_delete: bool) -> Self {
         self.supports_delete = supports_delete;
+        self
+    }
+
+    pub fn supports_pin(mut self, supports_pin: bool) -> Self {
+        self.supports_pin = supports_pin;
         self
     }
 
@@ -901,6 +1035,8 @@ impl RenderOnce for AcpHistoryEntryElement {
     fn render(self, _window: &mut Window, _cx: &mut App) -> impl IntoElement {
         let id = ElementId::Name(self.entry.session_id.0.clone().into());
         let title = thread_title(&self.entry).clone();
+        let is_pinned = self.entry.pinned;
+        let is_hovered = self.hovered;
         let formatted_time = self
             .entry
             .updated_at
@@ -929,7 +1065,19 @@ impl RenderOnce for AcpHistoryEntryElement {
                     .w_full()
                     .gap_2()
                     .justify_between()
-                    .child(Label::new(title).size(LabelSize::Small).truncate())
+                    .child(
+                        h_flex()
+                            .gap_1()
+                            .overflow_hidden()
+                            .when(is_pinned && !is_hovered, |this| {
+                                this.child(
+                                    Icon::new(IconName::Pin)
+                                        .size(IconSize::XSmall)
+                                        .color(Color::Muted),
+                                )
+                            })
+                            .child(Label::new(title).size(LabelSize::Small).truncate()),
+                    )
                     .child(
                         Label::new(formatted_time)
                             .color(Color::Muted)
@@ -937,31 +1085,70 @@ impl RenderOnce for AcpHistoryEntryElement {
                     ),
             )
             .on_hover(self.on_hover)
-            .end_slot::<IconButton>(if (self.hovered || self.selected) && self.supports_delete {
-                Some(
-                    IconButton::new("delete", IconName::Trash)
-                        .shape(IconButtonShape::Square)
-                        .icon_size(IconSize::XSmall)
-                        .icon_color(Color::Muted)
-                        .tooltip(move |_window, cx| {
-                            Tooltip::for_action("Delete", &RemoveSelectedThread, cx)
-                        })
-                        .on_click({
-                            let thread_view = self.thread_view.clone();
-                            let entry = self.entry.clone();
-
-                            move |_event, _window, cx| {
-                                if let Some(thread_view) = thread_view.upgrade() {
-                                    thread_view.update(cx, |thread_view, cx| {
-                                        thread_view.delete_history_entry(entry.clone(), cx);
-                                    });
-                                }
-                            }
-                        }),
-                )
-            } else {
-                None
-            })
+            .end_slot(
+                h_flex()
+                    .gap_0p5()
+                    .when(is_hovered && self.supports_pin, {
+                        let thread_view = self.thread_view.clone();
+                        let entry = self.entry.clone();
+                        let pin_icon = if is_pinned {
+                            IconName::Unpin
+                        } else {
+                            IconName::Pin
+                        };
+                        let pin_tooltip: &'static str = if is_pinned { "Unpin" } else { "Pin" };
+                        move |this| {
+                            this.child(
+                                IconButton::new("pin", pin_icon)
+                                    .shape(IconButtonShape::Square)
+                                    .icon_size(IconSize::XSmall)
+                                    .icon_color(Color::Muted)
+                                    .tooltip(move |_window, cx| {
+                                        Tooltip::for_action(pin_tooltip, &TogglePinThread, cx)
+                                    })
+                                    .on_click({
+                                        let thread_view = thread_view.clone();
+                                        move |_event, _window, cx| {
+                                            if let Some(thread_view) = thread_view.upgrade() {
+                                                thread_view.update(cx, |thread_view, cx| {
+                                                    thread_view.toggle_pin_history_entry(
+                                                        entry.clone(),
+                                                        cx,
+                                                    );
+                                                });
+                                            }
+                                        }
+                                    }),
+                            )
+                        }
+                    })
+                    .when(is_hovered && self.supports_delete, {
+                        let thread_view = self.thread_view.clone();
+                        let entry = self.entry.clone();
+                        move |this| {
+                            this.child(
+                                IconButton::new("delete", IconName::Trash)
+                                    .shape(IconButtonShape::Square)
+                                    .icon_size(IconSize::XSmall)
+                                    .icon_color(Color::Muted)
+                                    .tooltip(move |_window, cx| {
+                                        Tooltip::for_action("Delete", &RemoveSelectedThread, cx)
+                                    })
+                                    .on_click({
+                                        let thread_view = thread_view.clone();
+                                        move |_event, _window, cx| {
+                                            if let Some(thread_view) = thread_view.upgrade() {
+                                                thread_view.update(cx, |thread_view, cx| {
+                                                    thread_view
+                                                        .delete_history_entry(entry.clone(), cx);
+                                                });
+                                            }
+                                        }
+                                    }),
+                            )
+                        }
+                    }),
+            )
             .on_click({
                 let thread_view = self.thread_view.clone();
                 let entry = self.entry;
@@ -1007,6 +1194,7 @@ impl EntryTimeFormat {
 impl From<TimeBucket> for EntryTimeFormat {
     fn from(bucket: TimeBucket) -> Self {
         match bucket {
+            TimeBucket::Pinned => EntryTimeFormat::DateAndTime,
             TimeBucket::Today => EntryTimeFormat::TimeOnly,
             TimeBucket::Yesterday => EntryTimeFormat::TimeOnly,
             TimeBucket::ThisWeek => EntryTimeFormat::DateAndTime,
@@ -1018,6 +1206,7 @@ impl From<TimeBucket> for EntryTimeFormat {
 
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 enum TimeBucket {
+    Pinned,
     Today,
     Yesterday,
     ThisWeek,
@@ -1054,11 +1243,12 @@ impl TimeBucket {
 impl Display for TimeBucket {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            TimeBucket::Pinned => write!(f, "Pinned"),
             TimeBucket::Today => write!(f, "Today"),
             TimeBucket::Yesterday => write!(f, "Yesterday"),
             TimeBucket::ThisWeek => write!(f, "This Week"),
             TimeBucket::PastWeek => write!(f, "Past Week"),
-            TimeBucket::All => write!(f, "All"),
+            TimeBucket::All => write!(f, "Older"),
         }
     }
 }
@@ -1227,6 +1417,14 @@ mod tests {
             title: Some(title.to_string().into()),
             updated_at: None,
             meta: None,
+            pinned: false,
+        }
+    }
+
+    fn test_session_pinned(session_id: &str, title: &str) -> AgentSessionInfo {
+        AgentSessionInfo {
+            pinned: true,
+            ..test_session(session_id, title)
         }
     }
 
@@ -1438,6 +1636,7 @@ mod tests {
             title: Some("Original Title".into()),
             updated_at: None,
             meta: None,
+            pinned: false,
         }];
         let session_list = Rc::new(TestSessionList::new(sessions));
 
@@ -1474,6 +1673,7 @@ mod tests {
             title: Some("Original Title".into()),
             updated_at: None,
             meta: None,
+            pinned: false,
         }];
         let session_list = Rc::new(TestSessionList::new(sessions));
 
@@ -1507,6 +1707,7 @@ mod tests {
             title: Some("Original Title".into()),
             updated_at: None,
             meta: None,
+            pinned: false,
         }];
         let session_list = Rc::new(TestSessionList::new(sessions));
 
@@ -1543,6 +1744,7 @@ mod tests {
             title: None,
             updated_at: None,
             meta: None,
+            pinned: false,
         }];
         let session_list = Rc::new(TestSessionList::new(sessions));
 
@@ -1583,6 +1785,7 @@ mod tests {
             title: Some("Server Title".into()),
             updated_at: None,
             meta: None,
+            pinned: false,
         }];
         let session_list = Rc::new(TestSessionList::new(sessions));
 
@@ -1620,6 +1823,7 @@ mod tests {
             title: Some("Original".into()),
             updated_at: None,
             meta: None,
+            pinned: false,
         }];
         let session_list = Rc::new(TestSessionList::new(sessions));
 
@@ -1682,5 +1886,142 @@ mod tests {
 
         let date = NaiveDate::from_ymd_opt(2022, 12, 28).unwrap();
         assert_eq!(TimeBucket::from_dates(new_year, date), TimeBucket::ThisWeek);
+    }
+
+    #[gpui::test]
+    async fn test_get_pinned_sessions_returns_only_pinned(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let sessions = vec![
+            test_session_pinned("pinned-1", "Pinned Thread"),
+            test_session("unpinned-1", "Regular Thread"),
+            test_session_pinned("pinned-2", "Another Pinned"),
+        ];
+        let session_list = Rc::new(TestSessionList::new(sessions));
+
+        let (history, cx) = cx.add_window_view(|window, cx| {
+            AcpThreadHistory::new(Some(session_list.clone()), window, cx)
+        });
+        cx.run_until_parked();
+
+        history.update(cx, |history, _cx| {
+            let pinned = history.get_pinned_sessions();
+            assert_eq!(pinned.len(), 2);
+            assert_eq!(pinned[0].session_id, acp::SessionId::new("pinned-1"));
+            assert_eq!(pinned[1].session_id, acp::SessionId::new("pinned-2"));
+        });
+    }
+
+    #[gpui::test]
+    async fn test_pinned_entries_appear_before_unpinned_in_visible_items(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let sessions = vec![
+            test_session_pinned("pinned-1", "Pinned Thread"),
+            test_session("unpinned-1", "Regular Thread"),
+            test_session_pinned("pinned-2", "Another Pinned"),
+        ];
+        let session_list = Rc::new(TestSessionList::new(sessions));
+
+        let (history, cx) = cx.add_window_view(|window, cx| {
+            AcpThreadHistory::new(Some(session_list.clone()), window, cx)
+        });
+        cx.run_until_parked();
+
+        history.update(cx, |history, _cx| {
+            // First item should be the Pinned separator
+            assert!(
+                matches!(
+                    &history.visible_items[0],
+                    ListItemType::BucketSeparator(TimeBucket::Pinned)
+                ),
+                "first visible item should be a Pinned separator"
+            );
+
+            // Next two items should be the pinned entries
+            let first_entry = history.visible_items[1]
+                .history_entry()
+                .expect("should be an entry");
+            assert_eq!(first_entry.session_id, acp::SessionId::new("pinned-1"));
+            assert!(first_entry.pinned);
+
+            let second_entry = history.visible_items[2]
+                .history_entry()
+                .expect("should be an entry");
+            assert_eq!(second_entry.session_id, acp::SessionId::new("pinned-2"));
+            assert!(second_entry.pinned);
+
+            // The unpinned entry should come after, preceded by its own time-bucket separator
+            let unpinned_entry = history
+                .visible_items
+                .iter()
+                .find_map(|item| item.history_entry().filter(|e| !e.pinned))
+                .expect("should have an unpinned entry");
+            assert_eq!(unpinned_entry.session_id, acp::SessionId::new("unpinned-1"));
+        });
+    }
+
+    #[gpui::test]
+    async fn test_no_pinned_separator_when_no_pinned_entries(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let sessions = vec![
+            test_session("session-1", "Thread A"),
+            test_session("session-2", "Thread B"),
+        ];
+        let session_list = Rc::new(TestSessionList::new(sessions));
+
+        let (history, cx) = cx.add_window_view(|window, cx| {
+            AcpThreadHistory::new(Some(session_list.clone()), window, cx)
+        });
+        cx.run_until_parked();
+
+        history.update(cx, |history, _cx| {
+            let has_pinned_separator = history
+                .visible_items
+                .iter()
+                .any(|item| matches!(item, ListItemType::BucketSeparator(TimeBucket::Pinned)));
+            assert!(
+                !has_pinned_separator,
+                "should not have a Pinned separator when no entries are pinned"
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_pinned_entries_appear_in_search_results(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let sessions = vec![
+            test_session_pinned("pinned-1", "Important Thread"),
+            test_session("unpinned-1", "Other Thread"),
+        ];
+        let session_list = Rc::new(TestSessionList::new(sessions));
+
+        let (history, cx) = cx.add_window_view(|window, cx| {
+            AcpThreadHistory::new(Some(session_list.clone()), window, cx)
+        });
+        cx.run_until_parked();
+
+        // Type a search query that matches the pinned entry
+        history.update(cx, |history, cx| {
+            history.search_query = "Important".into();
+            history.update_visible_items(false, cx);
+        });
+        cx.run_until_parked();
+
+        history.update(cx, |history, _cx| {
+            let search_results: Vec<_> = history
+                .visible_items
+                .iter()
+                .filter_map(|item| item.history_entry())
+                .collect();
+            assert_eq!(search_results.len(), 1);
+            assert_eq!(
+                search_results[0].session_id,
+                acp::SessionId::new("pinned-1")
+            );
+            assert!(search_results[0].pinned);
+        });
     }
 }

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -2430,6 +2430,37 @@ impl AcpServerView {
         });
         task.detach_and_log_err(cx);
     }
+
+    pub fn toggle_pin_history_entry(&mut self, entry: AgentSessionInfo, cx: &mut Context<Self>) {
+        let new_pinned = !entry.pinned;
+        let task = self.history.update(cx, |history, cx| {
+            history.set_session_pinned(&entry.session_id, new_pinned, cx)
+        });
+        task.detach_and_log_err(cx);
+    }
+
+    pub fn is_active_thread_pinned(&self, cx: &App) -> Option<bool> {
+        let session_id = self
+            .active_thread()?
+            .read(cx)
+            .thread
+            .read(cx)
+            .session_id()
+            .clone();
+        let session = self.history.read(cx).session_for_id(&session_id)?;
+        Some(session.pinned)
+    }
+
+    pub fn toggle_pin_active_thread(&mut self, cx: &mut Context<Self>) {
+        let Some(active_thread) = self.active_thread() else {
+            return;
+        };
+        let session_id = active_thread.read(cx).thread.read(cx).session_id().clone();
+        let Some(session) = self.history.read(cx).session_for_id(&session_id) else {
+            return;
+        };
+        self.toggle_pin_history_entry(session, cx);
+    }
 }
 
 fn loading_contents_spinner(size: IconSize) -> AnyElement {

--- a/crates/agent_ui/src/acp/thread_view/active_thread.rs
+++ b/crates/agent_ui/src/acp/thread_view/active_thread.rs
@@ -1558,6 +1558,7 @@ impl AcpThreadView {
                 title: Some(format!("🔗 {}", response.title).into()),
                 updated_at: Some(chrono::Utc::now()),
                 meta: None,
+                pinned: false,
             };
 
             this.update_in(cx, |this, window, cx| {
@@ -7068,6 +7069,8 @@ impl AcpThreadView {
             .size_full()
             .when(render_history, |this| {
                 let recent_history = self.recent_history_entries.clone();
+                let supports_delete = self.history.read(cx).supports_delete();
+                let supports_pin = self.history.read(cx).supports_pin();
                 this.justify_end().child(
                     v_flex()
                         .child(
@@ -7094,12 +7097,10 @@ impl AcpThreadView {
                             ),
                         )
                         .child(v_flex().p_1().pr_1p5().gap_1().children({
-                            let supports_delete = self.history.read(cx).supports_delete();
                             recent_history
                                 .into_iter()
                                 .enumerate()
                                 .map(move |(index, entry)| {
-                                    // TODO: Add keyboard navigation.
                                     let is_hovered =
                                         self.hovered_recent_history_item == Some(index);
                                     crate::acp::thread_history::AcpHistoryEntryElement::new(
@@ -7108,6 +7109,7 @@ impl AcpThreadView {
                                     )
                                     .hovered(is_hovered)
                                     .supports_delete(supports_delete)
+                                    .supports_pin(supports_pin)
                                     .on_hover(cx.listener(move |this, is_hovered, _window, cx| {
                                         if *is_hovered {
                                             this.hovered_recent_history_item = Some(index);
@@ -7590,6 +7592,7 @@ pub(crate) fn open_link(
                                 title: Some(name.into()),
                                 updated_at: None,
                                 meta: None,
+                                pinned: false,
                             },
                             window,
                             cx,

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -638,6 +638,7 @@ impl AgentPanel {
                             title: thread_info.title.map(SharedString::from),
                             updated_at: None,
                             meta: None,
+                            pinned: false,
                         };
                         panel.load_agent_thread(session_info, window, cx);
                     })?;
@@ -1461,6 +1462,7 @@ impl AgentPanel {
                 title: Some(title),
                 updated_at: Some(chrono::Utc::now()),
                 meta: None,
+                pinned: false,
             };
 
             this.update_in(cx, |this, window, cx| {
@@ -2200,6 +2202,12 @@ impl AgentPanel {
             }
             _ => false,
         };
+        let active_thread_pinned = match &self.active_view {
+            ActiveView::AgentThread { server_view } => {
+                server_view.read(cx).is_active_thread_pinned(cx)
+            }
+            _ => None,
+        };
 
         PopoverMenu::new("agent-options-menu")
             .trigger_with_tooltip(
@@ -2242,17 +2250,33 @@ impl AgentPanel {
                             }
 
                             if let Some(thread_view) = thread_view.as_ref() {
-                                menu = menu
-                                    .entry("Regenerate Thread Title", None, {
+                                menu = menu.entry("Regenerate Thread Title", None, {
+                                    let thread_view = thread_view.clone();
+                                    move |_, cx| {
+                                        Self::handle_regenerate_thread_title(
+                                            thread_view.clone(),
+                                            cx,
+                                        );
+                                    }
+                                });
+
+                                if let Some(is_pinned) = active_thread_pinned {
+                                    let pin_label = if is_pinned {
+                                        "Unpin Thread"
+                                    } else {
+                                        "Pin Thread"
+                                    };
+                                    menu = menu.entry(pin_label, None, {
                                         let thread_view = thread_view.clone();
                                         move |_, cx| {
-                                            Self::handle_regenerate_thread_title(
-                                                thread_view.clone(),
-                                                cx,
-                                            );
+                                            thread_view.update(cx, |thread_view, cx| {
+                                                thread_view.toggle_pin_active_thread(cx);
+                                            });
                                         }
-                                    })
-                                    .separator();
+                                    });
+                                }
+
+                                menu = menu.separator();
                             }
                         }
 

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -83,6 +83,8 @@ actions!(
         AddContextServer,
         /// Removes the currently selected thread.
         RemoveSelectedThread,
+        /// Toggles the pinned state of the currently selected thread.
+        TogglePinThread,
         /// Starts a chat conversation with follow-up enabled.
         ChatWithFollow,
         /// Cycles to the next inline assist suggestion.

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -958,6 +958,7 @@ fn handle_open_request(request: OpenRequest, app_state: Arc<AppState>, cx: &mut 
                         title: Some(format!("🔗 {}", response.title).into()),
                         updated_at: Some(chrono::Utc::now()),
                         meta: None,
+                        pinned: false,
                     };
 
                     let sharer_username = response.sharer_username.clone();


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/discussions/43860

It can be hard to find your way back to threads you want to revisit. Generated titles don't always help, and ongoing work gets buried in history over time. This adds pin/unpin support so you can mark threads you care about and quickly return to them with the existing conversation context.

You can pin a thread from:
- The options menu (⋯) while viewing a thread ("Pin Thread" / "Unpin Thread")
- Hovering over entries in the history view or the new thread page

Pinned threads appear at the top of the history list under a "Pinned" section, and are blended into the "Recent" list on the new thread page with a small pin icon. Pin state is stored in the threads database and preserved across thread saves.

### New thread page
Pinned threads sort to the top of the "Recent" list with a pin icon.

![New thread page](https://i.gyazo.com/0e53426e834408f18274fce3ed914106.png)

### History view
Pinned threads get their own "Pinned" section at the top. Hover to pin/unpin or delete.

![History view](https://i.gyazo.com/fa36337b95476032c93fd86900c7a0c1.png)

### A note on the `save_thread` query change

The existing `save_thread` used `INSERT OR REPLACE`, which in SQLite means "delete the row, then insert a new one." That was fine when every column was included in the INSERT, but `pinned` is managed separately from thread content, so a plain save would delete the row and reset `pinned` back to false.

The fix is `INSERT ... ON CONFLICT(id) DO UPDATE SET`, which updates only the listed columns and leaves everything else untouched. This pattern is already used in `component_preview/src/persistence.rs`.

An alternative would be to add `pinned` to the `DbThread` struct and include it in the save path, but pinning is user-level metadata, not thread content. Keeping it separate means future metadata columns (archived, color labels, etc.) would just work without touching the save path.

### Open questions

- **Branch/repo metadata on threads:** Another approach to thread discoverability would be attaching metadata like the current branch or repo to a thread, so you could filter or find threads by what you were working on. That feels complementary to pinning rather than a replacement. Pinning is manual and intentional, branch metadata would be automatic and contextual.
- **Pin/unpin icon size:** The pin and unpin SVGs in the icon library feel noticeably smaller than peers like the trash icon. Not something this PR can fix, but worth looking at on the design side.

---

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Added ability to pin agent threads so they stay at the top of history and the new thread page