### PR TITLE
Fix backward compatibility for v0.0.4 GitHub extension bindings

### DIFF
--- a/crates/extension_host/src/wasm_host/wit/since_v0_0_4.rs
+++ b/crates/extension_host/src/wasm_host/wit/since_v0_0_4.rs
@@ -1,4 +1,4 @@
-use super::latest;
+use super::{latest, since_v0_6_0};
 use crate::wasm_host::WasmState;
 use anyhow::Result;
 use extension::WorktreeDelegate;
@@ -15,7 +15,7 @@ wasmtime::component::bindgen!({
     path: "../extension_api/wit/since_v0.0.4",
     with: {
          "worktree": ExtensionWorktree,
-         "zed:extension/github": latest::zed::extension::github,
+         "zed:extension/github": since_v0_6_0::zed::extension::github,
          "zed:extension/platform": latest::zed::extension::platform,
     },
 });
@@ -129,7 +129,7 @@ impl ExtensionImports for WasmState {
         repo: String,
         options: GithubReleaseOptions,
     ) -> wasmtime::Result<Result<GithubRelease, String>> {
-        latest::zed::extension::github::Host::latest_github_release(self, repo, options).await
+        since_v0_6_0::zed::extension::github::Host::latest_github_release(self, repo, options).await
     }
 
     async fn current_platform(&mut self) -> Result<(Os, Architecture)> {


### PR DESCRIPTION
## Summary
- Route `zed:extension/github` in `since_v0_0_4` to the `since_v0_6_0` bindings
- Call `latest_github_release` through `since_v0_6_0` for compatibility with the v0.0.4 extension API

Release Notes:

- Fixed backward compatibility for v0.0.4 extension API GitHub bindings.
