### PR TITLE
git: Fix diff view buttons not working when project diff or branch diff is empty

### DIFF
--- a/crates/editor/src/split.rs
+++ b/crates/editor/src/split.rs
@@ -841,7 +841,12 @@ impl SplittableEditor {
         });
     }
 
-    fn toggle_split(&mut self, _: &ToggleSplitDiff, window: &mut Window, cx: &mut Context<Self>) {
+    pub fn toggle_split(
+        &mut self,
+        _: &ToggleSplitDiff,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         if self.lhs.is_some() {
             self.unsplit(window, cx);
         } else {

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -109,7 +109,6 @@ impl Render for BufferSearchBar {
                 .and_then(|weak| weak.upgrade())
                 .map(|splittable_editor| {
                     let is_split = splittable_editor.read(cx).is_split();
-                    let focus_handle = splittable_editor.focus_handle(cx);
                     h_flex()
                         .gap_1()
                         .child(
@@ -137,7 +136,7 @@ impl Render for BufferSearchBar {
                                         .into_any()
                                 }))
                                 .on_click({
-                                    let focus_handle = focus_handle.clone();
+                                    let splittable_editor = splittable_editor.downgrade();
                                     move |_, window, cx| {
                                         if window.modifiers().secondary() {
                                             update_settings_file(
@@ -150,9 +149,15 @@ impl Render for BufferSearchBar {
                                             );
                                         }
                                         if is_split {
-                                            focus_handle.focus(window, cx);
-                                            window
-                                                .dispatch_action(ToggleSplitDiff.boxed_clone(), cx);
+                                            splittable_editor
+                                                .update(cx, |editor, cx| {
+                                                    editor.toggle_split(
+                                                        &ToggleSplitDiff,
+                                                        window,
+                                                        cx,
+                                                    );
+                                                })
+                                                .ok();
                                         }
                                     }
                                 }),
@@ -182,6 +187,7 @@ impl Render for BufferSearchBar {
                                         .into_any()
                                 }))
                                 .on_click({
+                                    let splittable_editor = splittable_editor.downgrade();
                                     move |_, window, cx| {
                                         if window.modifiers().secondary() {
                                             update_settings_file(
@@ -194,9 +200,15 @@ impl Render for BufferSearchBar {
                                             );
                                         }
                                         if !is_split {
-                                            focus_handle.focus(window, cx);
-                                            window
-                                                .dispatch_action(ToggleSplitDiff.boxed_clone(), cx);
+                                            splittable_editor
+                                                .update(cx, |editor, cx| {
+                                                    editor.toggle_split(
+                                                        &ToggleSplitDiff,
+                                                        window,
+                                                        cx,
+                                                    );
+                                                })
+                                                .ok();
                                         }
                                     }
                                 }),


### PR DESCRIPTION
Release Notes:

- git: Fixed a bug where the buttons to toggle the split diff view would have no effect when the diff being viewed was empty.