### PR TITLE
text: Swap `anchor_range_between` and `anchor_range_around`

### DIFF
--- a/crates/text/src/text.rs
+++ b/crates/text/src/text.rs
@@ -2404,12 +2404,12 @@ impl BufferSnapshot {
     }
 
     /// Returns an anchor range for the given input position range that is anchored to the text inbetween.
-    pub fn anchor_range_around<T: ToOffset>(&self, position: Range<T>) -> Range<Anchor> {
+    pub fn anchor_range_between<T: ToOffset>(&self, position: Range<T>) -> Range<Anchor> {
         self.anchor_before(position.start)..self.anchor_after(position.end)
     }
 
     /// Returns an anchor range for the given input position range that is anchored to the text before the start position and after the end position.
-    pub fn anchor_range_between<T: ToOffset>(&self, position: Range<T>) -> Range<Anchor> {
+    pub fn anchor_range_around<T: ToOffset>(&self, position: Range<T>) -> Range<Anchor> {
         self.anchor_before(position.start)..self.anchor_after(position.end)
     }
 


### PR DESCRIPTION
These functions had their names swapped accidentally

Follow up to https://github.com/zed-industries/zed/pull/49618

Release Notes:

- N/A *or* Added/Fixed/Improved ...
