### PR TITLE
Avoid some false positives for "closed bugs w/comments" board

### DIFF
--- a/.github/workflows/add_commented_closed_issue_to_project.yml
+++ b/.github/workflows/add_commented_closed_issue_to_project.yml
@@ -20,14 +20,29 @@ jobs:
     runs-on: namespace-profile-2x4-ubuntu-2404
     timeout-minutes: 5
     steps:
-      - id: get-app-token
+      - id: is-post-close-comment
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const closedAt = new Date(context.payload.issue.closed_at);
+            const commentedAt = new Date(context.payload.comment.created_at);
+            const diffSeconds = Math.abs(commentedAt - closedAt) / 1000;
+            if (diffSeconds <= 30) {
+              core.notice(`Skipping — comment was likely part of "Close with comment" (${diffSeconds}s gap)`);
+              return false;
+            }
+            return true;
+
+      - if: steps.is-post-close-comment.outputs.result == 'true'
+        id: get-app-token
         uses: actions/create-github-app-token@bef1eaf1c0ac2b148ee2a0a74c65fbe6db0631f1 # v2.1.4
         with:
           app-id: ${{ secrets.ZED_COMMUNITY_BOT_APP_ID }}
           private-key: ${{ secrets.ZED_COMMUNITY_BOT_PRIVATE_KEY }}
           owner: zed-industries
 
-      - id: check-staff
+      - if: steps.is-post-close-comment.outputs.result == 'true'
+        id: check-staff
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           github-token: ${{ steps.get-app-token.outputs.token }}
@@ -47,16 +62,16 @@ jobs:
               throw error;
             }
 
-      - if: steps.check-staff.outputs.result == 'true'
+      - if: steps.is-post-close-comment.outputs.result == 'true' && steps.check-staff.outputs.result == 'true'
         run: |
           echo "::notice::Skipping issue #${{ github.event.issue.number }} - commenter is staff member"
 
       # github-script outputs are JSON strings, so we compare against 'false' (string)
-      - if: steps.check-staff.outputs.result == 'false'
+      - if: steps.is-post-close-comment.outputs.result == 'true' && steps.check-staff.outputs.result == 'false'
         run: |
           echo "::notice::Adding issue #${{ github.event.issue.number }} to project (comment by ${{ github.event.comment.user.login }})"
 
-      - if: steps.check-staff.outputs.result == 'false'
+      - if: steps.is-post-close-comment.outputs.result == 'true' && steps.check-staff.outputs.result == 'false'
         uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:
           project-url: https://github.com/orgs/zed-industries/projects/73


### PR DESCRIPTION
More precisely, the name of the GitHub project board in question is “Closed bugs with new comments”, and since GitHub seems to do the closing and the commenting separately (and, crucially for this automation, in that order) when the closer uses the “Close with comment” functionality, we want to skip the comments added within 30 seconds after the closing.

Release Notes:

- N/A