### PR TITLE
extension_ci: Allow some more time for tests job

### DIFF
--- a/.github/workflows/extension_tests.yml
+++ b/.github/workflows/extension_tests.yml
@@ -98,6 +98,11 @@ jobs:
       run: |
         wget --quiet "https://zed-extension-cli.nyc3.digitaloceanspaces.com/$ZED_EXTENSION_CLI_SHA/x86_64-unknown-linux-gnu/zed-extension"
         chmod +x zed-extension
+    - name: steps::cache_rust_dependencies_namespace
+      uses: namespacelabs/nscloud-cache-action@v1
+      with:
+        cache: rust
+        path: ~/.rustup
     - name: extension_tests::check
       run: |
         mkdir -p /tmp/ext-scratch

--- a/.github/workflows/extension_tests.yml
+++ b/.github/workflows/extension_tests.yml
@@ -131,7 +131,7 @@ jobs:
             echo "Version changes happen in separate PRs and will be performed by the zed-zippy bot"
             exit 42
         fi
-    timeout-minutes: 4
+    timeout-minutes: 6
   tests_pass:
     needs:
     - orchestrate

--- a/tooling/xtask/src/tasks/workflows/extension_tests.rs
+++ b/tooling/xtask/src/tasks/workflows/extension_tests.rs
@@ -85,7 +85,7 @@ pub(crate) fn check_extension() -> NamedJob {
     let job = Job::default()
         .with_repository_owner_guard()
         .runs_on(runners::LINUX_LARGE_RAM)
-        .timeout_minutes(4u32)
+        .timeout_minutes(6u32)
         .add_step(steps::checkout_repo().with_deep_history_on_non_main())
         .add_step(cache_download)
         .add_step(download_zed_extension_cli(cache_hit))

--- a/tooling/xtask/src/tasks/workflows/extension_tests.rs
+++ b/tooling/xtask/src/tasks/workflows/extension_tests.rs
@@ -5,7 +5,10 @@ use crate::tasks::workflows::{
     extension_bump::compare_versions,
     run_tests::{orchestrate_without_package_filter, tests_pass},
     runners,
-    steps::{self, CommonJobConditions, FluentBuilder, NamedJob, named},
+    steps::{
+        self, CommonJobConditions, FluentBuilder, NamedJob, cache_rust_dependencies_namespace,
+        named,
+    },
     vars::{PathCondition, StepOutput, one_workflow_per_non_main_branch},
 };
 
@@ -89,6 +92,7 @@ pub(crate) fn check_extension() -> NamedJob {
         .add_step(steps::checkout_repo().with_deep_history_on_non_main())
         .add_step(cache_download)
         .add_step(download_zed_extension_cli(cache_hit))
+        .add_step(cache_rust_dependencies_namespace()) // Extensions can compile Rust, so provide the cache if needed.
         .add_step(check())
         .add_step(check_version_job)
         .add_step(verify_version_did_not_change(version_changed));


### PR DESCRIPTION
Gives the compilation in a repository with a few more grammars some more time to run. Also adds the Rust cache which might be utilized here during Rust compilation.

Release Notes:

- N/A