### PR TITLE
git: Remove unused actions

### DIFF
--- a/crates/git_ui/src/file_history_view.rs
+++ b/crates/git_ui/src/file_history_view.rs
@@ -5,7 +5,7 @@ use git::{GitHostingProviderRegistry, GitRemote, parse_git_remote_url};
 use gpui::{
     AnyElement, AnyEntity, App, Asset, Context, Entity, EventEmitter, FocusHandle, Focusable,
     IntoElement, Render, ScrollStrategy, Task, UniformListScrollHandle, WeakEntity, Window,
-    actions, uniform_list,
+    uniform_list,
 };
 use project::{
     Project, ProjectPath,
@@ -23,16 +23,6 @@ use workspace::{
 };
 
 use crate::commit_view::CommitView;
-
-actions!(git, [ViewCommitFromHistory, LoadMoreHistory]);
-
-pub fn init(cx: &mut App) {
-    cx.observe_new(|workspace: &mut Workspace, _window, _cx| {
-        workspace.register_action(|_workspace, _: &ViewCommitFromHistory, _window, _cx| {});
-        workspace.register_action(|_workspace, _: &LoadMoreHistory, _window, _cx| {});
-    })
-    .detach();
-}
 
 const PAGE_SIZE: usize = 50;
 

--- a/crates/git_ui/src/git_ui.rs
+++ b/crates/git_ui/src/git_ui.rs
@@ -50,7 +50,6 @@ pub mod worktree_picker;
 pub fn init(cx: &mut App) {
     editor::set_blame_renderer(blame_ui::GitBlameRenderer, cx);
     commit_view::init(cx);
-    file_history_view::init(cx);
 
     cx.observe_new(|editor: &mut Editor, _, cx| {
         conflict_view::register_editor(editor, editor.buffer().clone(), cx);


### PR DESCRIPTION
Remove both `git::LoadMoreHistory` and `git::ViewCommitFromHistory` actions as although both actions were registered in the workspace, they don't actually have effect when run.

This appears to have been leftover from
https://github.com/zed-industries/zed/pull/42441 , possibly the initial implementation on how to open a commit and load more commits when the file history view was open, which is now handled with `Button.on_click` callbacks instead of relying on actions.

Closes #49288 

Before you mark this PR as ready for review, make sure that you have:

- [X] Added a solid test coverage and/or screenshots from doing manual testing
- [X] Done a self-review taking into account security and performance aspects
- [X] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Removed unused git actions – `git: load more history` and `git: view commit from history`
