### PR TITLE
agent: Subagent low context warnings

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -895,15 +895,17 @@ pub struct TokenUsage {
     pub max_output_tokens: Option<u64>,
 }
 
+pub const TOKEN_USAGE_WARNING_THRESHOLD: f32 = 0.8;
+
 impl TokenUsage {
     pub fn ratio(&self) -> TokenUsageRatio {
         #[cfg(debug_assertions)]
         let warning_threshold: f32 = std::env::var("ZED_THREAD_WARNING_THRESHOLD")
-            .unwrap_or("0.8".to_string())
+            .unwrap_or(TOKEN_USAGE_WARNING_THRESHOLD.to_string())
             .parse()
             .unwrap();
         #[cfg(not(debug_assertions))]
-        let warning_threshold: f32 = 0.8;
+        let warning_threshold: f32 = TOKEN_USAGE_WARNING_THRESHOLD;
 
         // When the maximum is unknown because there is no selected model,
         // avoid showing the token limit warning.

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -25,7 +25,7 @@ pub use tools::*;
 
 use acp_thread::{
     AcpThread, AgentModelSelector, AgentSessionInfo, AgentSessionList, AgentSessionListRequest,
-    AgentSessionListResponse, UserMessageId,
+    AgentSessionListResponse, TokenUsageRatio, UserMessageId,
 };
 use agent_client_protocol as acp;
 use anyhow::{Context as _, Result, anyhow};
@@ -1735,7 +1735,6 @@ enum SubagentPromptResult {
     Completed,
     Cancelled,
     ContextWindowWarning,
-    ContextWindowExceeded,
     Error(String),
 }
 
@@ -1769,7 +1768,7 @@ impl NativeSubagentHandle {
             acp_thread.send(vec![prompt.into()], cx)
         });
 
-        let (token_limit_tx, token_limit_rx) = oneshot::channel::<acp_thread::TokenUsageRatio>();
+        let (token_limit_tx, token_limit_rx) = oneshot::channel::<()>();
         let mut token_limit_tx = Some(token_limit_tx);
 
         let subscription = cx.subscribe(
@@ -1778,11 +1777,12 @@ impl NativeSubagentHandle {
                 if let Some(usage) = &event.0 {
                     let old_ratio = ratio_before_prompt
                         .clone()
-                        .unwrap_or(acp_thread::TokenUsageRatio::Normal);
+                        .unwrap_or(TokenUsageRatio::Normal);
                     let new_ratio = usage.ratio();
-                    if new_ratio > old_ratio && new_ratio >= acp_thread::TokenUsageRatio::Warning {
+                    if old_ratio == TokenUsageRatio::Normal && new_ratio == TokenUsageRatio::Warning
+                    {
                         if let Some(tx) = token_limit_tx.take() {
-                            tx.send(new_ratio).ok();
+                            tx.send(()).ok();
                         }
                     }
                 }
@@ -1795,7 +1795,7 @@ impl NativeSubagentHandle {
                     response = task.fuse() => match response {
                         Ok(Some(response)) =>{
                             match response.stop_reason {
-                                acp::StopReason::Cancelled=> SubagentPromptResult::Cancelled,
+                                acp::StopReason::Cancelled => SubagentPromptResult::Cancelled,
                                 acp::StopReason::MaxTokens => SubagentPromptResult::Error("The agent reached the maximum number of tokens.".into()),
                                 acp::StopReason::MaxTurnRequests => SubagentPromptResult::Error("The agent reached the maximum number of allowed requests between user turns. Try prompting again.".into()),
                                 acp::StopReason::Refusal => SubagentPromptResult::Error("The agent refused to process that prompt. Try again.".into()),
@@ -1806,12 +1806,7 @@ impl NativeSubagentHandle {
                         Ok(None) => SubagentPromptResult::Error("No response from the subagent. You can try messaging again.".into()),
                         Err(error) => SubagentPromptResult::Error(error.to_string()),
                     },
-                    ratio = token_limit_rx.fuse() => match ratio {
-                        Ok(acp_thread::TokenUsageRatio::Exceeded) => {
-                            SubagentPromptResult::ContextWindowExceeded
-                        }
-                        _ => SubagentPromptResult::ContextWindowWarning,
-                    },
+                    ratio = token_limit_rx.fuse() =>  SubagentPromptResult::ContextWindowWarning,
                 }
             })
             .shared();
@@ -1854,14 +1849,6 @@ impl SubagentHandle for NativeSubagentHandle {
                         "The subagent is nearing the end of its context window and has been \
                          stopped. You can prompt the thread again to have the agent wrap up \
                          or hand off its work."
-                    ))
-                }
-                SubagentPromptResult::ContextWindowExceeded => {
-                    thread.update(cx, |thread, cx| thread.cancel(cx)).await;
-                    Err(anyhow!(
-                        "The subagent has exceeded its context window and has been stopped. \
-                         It cannot be prompted again. Start a new subagent if more work is \
-                         needed."
                     ))
                 }
             };

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -1803,10 +1803,10 @@ impl NativeSubagentHandle {
                             }
 
                         }
-                        Ok(None) => SubagentPromptResult::Error("No response from the subagent. You can try messaging again.".into()),
+                        Ok(None) => SubagentPromptResult::Error("No response from the agent. You can try messaging again.".into()),
                         Err(error) => SubagentPromptResult::Error(error.to_string()),
                     },
-                    ratio = token_limit_rx.fuse() =>  SubagentPromptResult::ContextWindowWarning,
+                    _ = token_limit_rx.fuse() =>  SubagentPromptResult::ContextWindowWarning,
                 }
             })
             .shared();
@@ -1846,7 +1846,7 @@ impl SubagentHandle for NativeSubagentHandle {
                 SubagentPromptResult::ContextWindowWarning => {
                     thread.update(cx, |thread, cx| thread.cancel(cx)).await;
                     Err(anyhow!(
-                        "The subagent is nearing the end of its context window and has been \
+                        "The agent is nearing the end of its context window and has been \
                          stopped. You can prompt the thread again to have the agent wrap up \
                          or hand off its work."
                     ))

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -1652,33 +1652,14 @@ impl NativeThreadEnvironment {
         prompt: String,
         cx: &mut App,
     ) -> Result<Rc<dyn SubagentHandle>> {
-        parent_thread_entity.update(cx, |parent_thread, _cx| {
-            parent_thread.register_running_subagent(subagent_thread.downgrade())
-        });
-
-        let task = acp_thread.update(cx, |acp_thread, cx| {
-            acp_thread.send(vec![prompt.into()], cx)
-        });
-
-        let wait_for_prompt_to_complete = cx
-            .background_spawn(async move {
-                let response = task.await.log_err().flatten();
-                if response
-                    .is_some_and(|response| response.stop_reason == acp::StopReason::Cancelled)
-                {
-                    SubagentInitialPromptResult::Cancelled
-                } else {
-                    SubagentInitialPromptResult::Completed
-                }
-            })
-            .shared();
-
-        Ok(Rc::new(NativeSubagentHandle {
+        Ok(Rc::new(NativeSubagentHandle::new(
             session_id,
             subagent_thread,
-            parent_thread: parent_thread_entity.downgrade(),
-            wait_for_prompt_to_complete,
-        }) as _)
+            acp_thread,
+            parent_thread_entity,
+            prompt,
+            cx,
+        )) as _)
     }
 }
 
@@ -1753,6 +1734,8 @@ impl ThreadEnvironment for NativeThreadEnvironment {
 enum SubagentInitialPromptResult {
     Completed,
     Cancelled,
+    ContextWindowWarning,
+    ContextWindowExceeded,
 }
 
 pub struct NativeSubagentHandle {
@@ -1760,6 +1743,82 @@ pub struct NativeSubagentHandle {
     parent_thread: WeakEntity<Thread>,
     subagent_thread: Entity<Thread>,
     wait_for_prompt_to_complete: Shared<Task<SubagentInitialPromptResult>>,
+    _subscription: Subscription,
+}
+
+impl NativeSubagentHandle {
+    fn new(
+        session_id: acp::SessionId,
+        subagent_thread: Entity<Thread>,
+        acp_thread: Entity<acp_thread::AcpThread>,
+        parent_thread_entity: Entity<Thread>,
+        prompt: String,
+        cx: &mut App,
+    ) -> Self {
+        let ratio_before_prompt = subagent_thread
+            .read(cx)
+            .latest_token_usage()
+            .map(|usage| usage.ratio());
+
+        parent_thread_entity.update(cx, |parent_thread, _cx| {
+            parent_thread.register_running_subagent(subagent_thread.downgrade())
+        });
+
+        let task = acp_thread.update(cx, |acp_thread, cx| {
+            acp_thread.send(vec![prompt.into()], cx)
+        });
+
+        let (token_limit_tx, token_limit_rx) = oneshot::channel::<acp_thread::TokenUsageRatio>();
+        let mut token_limit_tx = Some(token_limit_tx);
+
+        let subscription = cx.subscribe(
+            &subagent_thread,
+            move |_thread, event: &TokenUsageUpdated, _cx| {
+                if let Some(usage) = &event.0 {
+                    let old_ratio = ratio_before_prompt
+                        .clone()
+                        .unwrap_or(acp_thread::TokenUsageRatio::Normal);
+                    let new_ratio = usage.ratio();
+                    if new_ratio > old_ratio && new_ratio >= acp_thread::TokenUsageRatio::Warning {
+                        if let Some(tx) = token_limit_tx.take() {
+                            tx.send(new_ratio).ok();
+                        }
+                    }
+                }
+            },
+        );
+
+        let wait_for_prompt_to_complete = cx
+            .background_spawn(async move {
+                futures::select! {
+                    response = task.fuse() => {
+                        let response = response.log_err().flatten();
+                        if response
+                            .is_some_and(|response| response.stop_reason == acp::StopReason::Cancelled)
+                        {
+                            SubagentInitialPromptResult::Cancelled
+                        } else {
+                            SubagentInitialPromptResult::Completed
+                        }
+                    }
+                    ratio = token_limit_rx.fuse() => match ratio {
+                        Ok(acp_thread::TokenUsageRatio::Exceeded) => {
+                            SubagentInitialPromptResult::ContextWindowExceeded
+                        }
+                        _ => SubagentInitialPromptResult::ContextWindowWarning,
+                    }
+                }
+            })
+            .shared();
+
+        NativeSubagentHandle {
+            session_id,
+            subagent_thread,
+            parent_thread: parent_thread_entity.downgrade(),
+            wait_for_prompt_to_complete,
+            _subscription: subscription,
+        }
+    }
 }
 
 impl SubagentHandle for NativeSubagentHandle {
@@ -1783,6 +1842,22 @@ impl SubagentHandle for NativeSubagentHandle {
                         .context("No response from subagent")
                 }),
                 SubagentInitialPromptResult::Cancelled => Err(anyhow!("User cancelled")),
+                SubagentInitialPromptResult::ContextWindowWarning => {
+                    thread.update(cx, |thread, cx| thread.cancel(cx)).await;
+                    Err(anyhow!(
+                        "The subagent is nearing the end of its context window and has been \
+                         stopped. You can prompt the thread again to have the agent wrap up \
+                         or hand off its work."
+                    ))
+                }
+                SubagentInitialPromptResult::ContextWindowExceeded => {
+                    thread.update(cx, |thread, cx| thread.cancel(cx)).await;
+                    Err(anyhow!(
+                        "The subagent has exceeded its context window and has been stopped. \
+                         It cannot be prompted again. Start a new subagent if more work is \
+                         needed."
+                    ))
+                }
             };
 
             parent_thread

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -1730,19 +1730,20 @@ impl ThreadEnvironment for NativeThreadEnvironment {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
-enum SubagentInitialPromptResult {
+#[derive(Debug, Clone)]
+enum SubagentPromptResult {
     Completed,
     Cancelled,
     ContextWindowWarning,
     ContextWindowExceeded,
+    Error(String),
 }
 
 pub struct NativeSubagentHandle {
     session_id: acp::SessionId,
     parent_thread: WeakEntity<Thread>,
     subagent_thread: Entity<Thread>,
-    wait_for_prompt_to_complete: Shared<Task<SubagentInitialPromptResult>>,
+    wait_for_prompt_to_complete: Shared<Task<SubagentPromptResult>>,
     _subscription: Subscription,
 }
 
@@ -1791,22 +1792,26 @@ impl NativeSubagentHandle {
         let wait_for_prompt_to_complete = cx
             .background_spawn(async move {
                 futures::select! {
-                    response = task.fuse() => {
-                        let response = response.log_err().flatten();
-                        if response
-                            .is_some_and(|response| response.stop_reason == acp::StopReason::Cancelled)
-                        {
-                            SubagentInitialPromptResult::Cancelled
-                        } else {
-                            SubagentInitialPromptResult::Completed
+                    response = task.fuse() => match response {
+                        Ok(Some(response)) =>{
+                            match response.stop_reason {
+                                acp::StopReason::Cancelled=> SubagentPromptResult::Cancelled,
+                                acp::StopReason::MaxTokens => SubagentPromptResult::Error("The agent reached the maximum number of tokens.".into()),
+                                acp::StopReason::MaxTurnRequests => SubagentPromptResult::Error("The agent reached the maximum number of allowed requests between user turns. Try prompting again.".into()),
+                                acp::StopReason::Refusal => SubagentPromptResult::Error("The agent refused to process that prompt. Try again.".into()),
+                                acp::StopReason::EndTurn | _ => SubagentPromptResult::Completed,
+                            }
+
                         }
-                    }
+                        Ok(None) => SubagentPromptResult::Error("No response from the subagent. You can try messaging again.".into()),
+                        Err(error) => SubagentPromptResult::Error(error.to_string()),
+                    },
                     ratio = token_limit_rx.fuse() => match ratio {
                         Ok(acp_thread::TokenUsageRatio::Exceeded) => {
-                            SubagentInitialPromptResult::ContextWindowExceeded
+                            SubagentPromptResult::ContextWindowExceeded
                         }
-                        _ => SubagentInitialPromptResult::ContextWindowWarning,
-                    }
+                        _ => SubagentPromptResult::ContextWindowWarning,
+                    },
                 }
             })
             .shared();
@@ -1835,14 +1840,15 @@ impl SubagentHandle for NativeSubagentHandle {
 
         cx.spawn(async move |cx| {
             let result = match wait_for_prompt.await {
-                SubagentInitialPromptResult::Completed => thread.read_with(cx, |thread, _cx| {
+                SubagentPromptResult::Completed => thread.read_with(cx, |thread, _cx| {
                     thread
                         .last_message()
                         .map(|m| m.to_markdown())
                         .context("No response from subagent")
                 }),
-                SubagentInitialPromptResult::Cancelled => Err(anyhow!("User cancelled")),
-                SubagentInitialPromptResult::ContextWindowWarning => {
+                SubagentPromptResult::Cancelled => Err(anyhow!("User cancelled")),
+                SubagentPromptResult::Error(message) => Err(anyhow!("{message}")),
+                SubagentPromptResult::ContextWindowWarning => {
                     thread.update(cx, |thread, cx| thread.cancel(cx)).await;
                     Err(anyhow!(
                         "The subagent is nearing the end of its context window and has been \
@@ -1850,7 +1856,7 @@ impl SubagentHandle for NativeSubagentHandle {
                          or hand off its work."
                     ))
                 }
-                SubagentInitialPromptResult::ContextWindowExceeded => {
+                SubagentPromptResult::ContextWindowExceeded => {
                     thread.update(cx, |thread, cx| thread.cancel(cx)).await;
                     Err(anyhow!(
                         "The subagent has exceeded its context window and has been stopped. \


### PR DESCRIPTION
Allow the parent agent to handle cases where the subagent is running on
of context window. Also communicates if it has completely out of
context.

Release Notes:

- N/A
