### PR TITLE
gpui: Call `ack_configure` on throttled Wayland resize events

### DIFF
--- a/crates/gpui_linux/src/linux/wayland/window.rs
+++ b/crates/gpui_linux/src/linux/wayland/window.rs
@@ -585,6 +585,7 @@ impl WaylandWindowStatePtr {
                     state.tiling = configure.tiling;
                     // Limit interactive resizes to once per vblank
                     if configure.resizing && state.resize_throttle {
+                        state.surface_state.ack_configure(serial);
                         return;
                     } else if configure.resizing {
                         state.resize_throttle = true;


### PR DESCRIPTION
when a resizing configure event is throttled (skipped to limit redraws to once per vblank) the xdg_surface serial was never acknowledged. the early return bypassed the ack_configure call that follows the throttle check, violating the xdg-shell protocol requirement that every configure serial be acknowledged before the next surface commit.

fix by calling ack_configure before the early return so the compositor always receives the acknowledgment, dosent matter whether the resize itself is applied.

Release Notes:

- N/A
