### PR TITLE
git: More rigorously test excerpt syncing for split diff, and fix a couple of bugs

### DIFF
--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -358,6 +358,19 @@ impl Companion {
         }
     }
 
+    #[cfg(test)]
+    pub(crate) fn excerpt_mappings(
+        &self,
+    ) -> (
+        &HashMap<ExcerptId, ExcerptId>,
+        &HashMap<ExcerptId, ExcerptId>,
+    ) {
+        (
+            &self.lhs_excerpt_to_rhs_excerpt,
+            &self.rhs_excerpt_to_lhs_excerpt,
+        )
+    }
+
     fn buffer_to_companion_buffer(&self, display_map_id: EntityId) -> &HashMap<BufferId, BufferId> {
         if self.is_rhs(display_map_id) {
             &self.rhs_buffer_to_lhs_buffer

--- a/crates/editor/src/split.rs
+++ b/crates/editor/src/split.rs
@@ -1133,10 +1133,10 @@ impl SplittableEditor {
         let lhs = self.lhs.as_ref().unwrap();
 
         if quiesced {
-            let rhs_snapshot = lhs
+            let lhs_snapshot = lhs
                 .editor
                 .update(cx, |editor, cx| editor.display_snapshot(cx));
-            let lhs_snapshot = self
+            let rhs_snapshot = self
                 .rhs_editor
                 .update(cx, |editor, cx| editor.display_snapshot(cx));
 
@@ -1196,21 +1196,6 @@ impl SplittableEditor {
                     "mismatch in hunk position"
                 );
             }
-
-            // Filtering out empty lines is a bit of a hack, to work around a case where
-            // the base text has a trailing newline but the current text doesn't, or vice versa.
-            // In this case, we get the additional newline on one side, but that line is not
-            // marked as added/deleted by rowinfos.
-            self.check_sides_match(cx, |snapshot| {
-                snapshot
-                    .buffer_snapshot()
-                    .text()
-                    .split("\n")
-                    .zip(snapshot.buffer_snapshot().row_infos(MultiBufferRow(0)))
-                    .filter(|(line, row_info)| !line.is_empty() && row_info.diff_status.is_none())
-                    .map(|(line, _)| line.to_owned())
-                    .collect::<Vec<_>>()
-            });
         }
     }
 
@@ -1506,90 +1491,6 @@ impl SplittableEditor {
         eprintln!("{}", "═".repeat(terminal_width));
         eprintln!("Legend: + added, - deleted, ~ modified, ~~~ block/spacer row");
         eprintln!();
-    }
-
-    fn randomly_edit_excerpts(
-        &mut self,
-        rng: &mut impl rand::Rng,
-        mutation_count: usize,
-        cx: &mut Context<Self>,
-    ) {
-        use collections::HashSet;
-        use rand::prelude::*;
-        use std::env;
-        use util::RandomCharIter;
-
-        let max_buffers = env::var("MAX_BUFFERS")
-            .map(|i| i.parse().expect("invalid `MAX_BUFFERS` variable"))
-            .unwrap_or(4);
-
-        for _ in 0..mutation_count {
-            let paths = self
-                .rhs_multibuffer
-                .read(cx)
-                .paths()
-                .cloned()
-                .collect::<Vec<_>>();
-            let excerpt_ids = self.rhs_multibuffer.read(cx).excerpt_ids();
-
-            if rng.random_bool(0.2) && !excerpt_ids.is_empty() {
-                let mut excerpts = HashSet::default();
-                for _ in 0..rng.random_range(0..excerpt_ids.len()) {
-                    excerpts.extend(excerpt_ids.choose(rng).copied());
-                }
-
-                let line_count = rng.random_range(1..5);
-
-                log::info!("Expanding excerpts {excerpts:?} by {line_count} lines");
-
-                self.expand_excerpts(
-                    excerpts.iter().cloned(),
-                    line_count,
-                    ExpandExcerptDirection::UpAndDown,
-                    cx,
-                );
-                continue;
-            }
-
-            if excerpt_ids.is_empty() || (rng.random_bool(0.8) && paths.len() < max_buffers) {
-                let len = rng.random_range(100..500);
-                let text = RandomCharIter::new(&mut *rng).take(len).collect::<String>();
-                let buffer = cx.new(|cx| Buffer::local(text, cx));
-                log::info!(
-                    "Creating new buffer {} with text: {:?}",
-                    buffer.read(cx).remote_id(),
-                    buffer.read(cx).text()
-                );
-                let buffer_snapshot = buffer.read(cx).snapshot();
-                let diff = cx.new(|cx| BufferDiff::new_unchanged(&buffer_snapshot, cx));
-                // Create some initial diff hunks.
-                buffer.update(cx, |buffer, cx| {
-                    buffer.randomly_edit(rng, 1, cx);
-                });
-                let buffer_snapshot = buffer.read(cx).text_snapshot();
-                diff.update(cx, |diff, cx| {
-                    diff.recalculate_diff_sync(&buffer_snapshot, cx);
-                });
-                let path = PathKey::for_buffer(&buffer, cx);
-                let ranges = diff.update(cx, |diff, cx| {
-                    diff.snapshot(cx)
-                        .hunks(&buffer_snapshot)
-                        .map(|hunk| hunk.buffer_range.to_point(&buffer_snapshot))
-                        .collect::<Vec<_>>()
-                });
-                self.set_excerpts_for_path(path, buffer, ranges, 2, diff, cx);
-            } else {
-                log::info!("removing excerpts");
-                let remove_count = rng.random_range(1..=paths.len());
-                let paths_to_remove = paths
-                    .choose_multiple(rng, remove_count)
-                    .cloned()
-                    .collect::<Vec<_>>();
-                for path in paths_to_remove {
-                    self.remove_excerpts_for_path(path.clone(), cx);
-                }
-            }
-        }
     }
 
     fn check_excerpt_mapping_invariants(&self, cx: &gpui::App) {
@@ -2370,7 +2271,9 @@ mod tests {
 
     #[gpui::test(iterations = 25)]
     async fn test_random_split_editor(mut rng: StdRng, cx: &mut gpui::TestAppContext) {
+        use multi_buffer::ExpandExcerptDirection;
         use rand::prelude::*;
+        use util::RandomCharIter;
 
         let (editor, cx) = init_test(cx, SoftWrap::EditorWidth, DiffViewStyle::Split).await;
         let operations = std::env::var("OPERATIONS")
@@ -2383,9 +2286,32 @@ mod tests {
             });
 
             if buffers.is_empty() {
-                log::info!("adding excerpts to empty multibuffer");
+                log::info!("creating initial buffer");
+                let len = rng.random_range(200..1000);
+                let base_text: String = RandomCharIter::new(&mut *rng).take(len).collect();
+                let buffer = cx.new(|cx| Buffer::local(base_text.clone(), cx));
+                let buffer_snapshot = buffer.read_with(cx, |b, _| b.text_snapshot());
+                let diff =
+                    cx.new(|cx| BufferDiff::new_with_base_text(&base_text, &buffer_snapshot, cx));
+                let edit_count = rng.random_range(3..8);
+                buffer.update(cx, |buffer, cx| {
+                    buffer.randomly_edit(rng, edit_count, cx);
+                });
+                let buffer_snapshot = buffer.read_with(cx, |b, _| b.text_snapshot());
+                diff.update(cx, |diff, cx| {
+                    diff.recalculate_diff_sync(&buffer_snapshot, cx);
+                });
+                let diff_snapshot = diff.read_with(cx, |diff, cx| diff.snapshot(cx));
+                let ranges = diff_snapshot
+                    .hunks(&buffer_snapshot)
+                    .map(|hunk| hunk.range)
+                    .collect::<Vec<_>>();
+                let context_lines = rng.random_range(0..2);
                 editor.update(cx, |editor, cx| {
-                    editor.randomly_edit_excerpts(rng, 2, cx);
+                    let path = PathKey::for_buffer(&buffer, cx);
+                    editor.set_excerpts_for_path(path, buffer, ranges, context_lines, diff, cx);
+                });
+                editor.update(cx, |editor, cx| {
                     editor.check_invariants(true, cx);
                 });
                 continue;
@@ -2394,26 +2320,129 @@ mod tests {
             let mut quiesced = false;
 
             match rng.random_range(0..100) {
-                0..=44 => {
+                0..=14 if buffers.len() < 6 => {
+                    log::info!("creating new buffer and setting excerpts");
+                    let len = rng.random_range(200..1000);
+                    let base_text: String = RandomCharIter::new(&mut *rng).take(len).collect();
+                    let buffer = cx.new(|cx| Buffer::local(base_text.clone(), cx));
+                    let buffer_snapshot = buffer.read_with(cx, |b, _| b.text_snapshot());
+                    let diff = cx
+                        .new(|cx| BufferDiff::new_with_base_text(&base_text, &buffer_snapshot, cx));
+                    let edit_count = rng.random_range(3..8);
+                    buffer.update(cx, |buffer, cx| {
+                        buffer.randomly_edit(rng, edit_count, cx);
+                    });
+                    let buffer_snapshot = buffer.read_with(cx, |b, _| b.text_snapshot());
+                    diff.update(cx, |diff, cx| {
+                        diff.recalculate_diff_sync(&buffer_snapshot, cx);
+                    });
+                    let diff_snapshot = diff.read_with(cx, |diff, cx| diff.snapshot(cx));
+                    let ranges = diff_snapshot
+                        .hunks(&buffer_snapshot)
+                        .map(|hunk| hunk.range)
+                        .collect::<Vec<_>>();
+                    let context_lines = rng.random_range(0..2);
+                    editor.update(cx, |editor, cx| {
+                        let path = PathKey::for_buffer(&buffer, cx);
+                        editor.set_excerpts_for_path(path, buffer, ranges, context_lines, diff, cx);
+                    });
+                }
+                15..=29 => {
                     log::info!("randomly editing multibuffer");
+                    let edit_count = rng.random_range(1..5);
                     editor.update(cx, |editor, cx| {
                         editor.rhs_multibuffer.update(cx, |multibuffer, cx| {
-                            multibuffer.randomly_edit(rng, 5, cx);
-                        })
-                    })
+                            multibuffer.randomly_edit(rng, edit_count, cx);
+                        });
+                    });
                 }
-                45..=64 => {
+                30..=44 => {
+                    log::info!("randomly editing individual buffer");
+                    let buffer = buffers.iter().choose(rng).unwrap();
+                    let edit_count = rng.random_range(1..3);
+                    buffer.update(cx, |buffer, cx| {
+                        buffer.randomly_edit(rng, edit_count, cx);
+                    });
+                }
+                45..=54 => {
+                    log::info!("recalculating diff and resetting excerpts for single buffer");
+                    let buffer = buffers.iter().choose(rng).unwrap();
+                    let buffer_snapshot = buffer.read_with(cx, |buffer, _| buffer.text_snapshot());
+                    let diff = editor.update(cx, |editor, cx| {
+                        editor
+                            .rhs_multibuffer
+                            .read(cx)
+                            .diff_for(buffer.read(cx).remote_id())
+                            .unwrap()
+                    });
+                    diff.update(cx, |diff, cx| {
+                        diff.recalculate_diff_sync(&buffer_snapshot, cx);
+                    });
+                    cx.run_until_parked();
+                    let diff_snapshot = diff.read_with(cx, |diff, cx| diff.snapshot(cx));
+                    let ranges = diff_snapshot
+                        .hunks(&buffer_snapshot)
+                        .map(|hunk| hunk.range)
+                        .collect::<Vec<_>>();
+                    let context_lines = rng.random_range(0..2);
+                    let buffer = buffer.clone();
+                    editor.update(cx, |editor, cx| {
+                        let path = PathKey::for_buffer(&buffer, cx);
+                        editor.set_excerpts_for_path(path, buffer, ranges, context_lines, diff, cx);
+                    });
+                }
+                55..=64 => {
                     log::info!("randomly undoing/redoing in single buffer");
                     let buffer = buffers.iter().choose(rng).unwrap();
                     buffer.update(cx, |buffer, cx| {
                         buffer.randomly_undo_redo(rng, cx);
                     });
                 }
-                65..=79 => {
-                    log::info!("mutating excerpts");
-                    editor.update(cx, |editor, cx| {
-                        editor.randomly_edit_excerpts(rng, 2, cx);
+                65..=74 => {
+                    log::info!("removing excerpts for a random path");
+                    let paths = editor.update(cx, |editor, cx| {
+                        editor
+                            .rhs_multibuffer
+                            .read(cx)
+                            .paths()
+                            .cloned()
+                            .collect::<Vec<_>>()
                     });
+                    if let Some(path) = paths.choose(rng) {
+                        editor.update(cx, |editor, cx| {
+                            editor.remove_excerpts_for_path(path.clone(), cx);
+                        });
+                    }
+                }
+                75..=79 => {
+                    log::info!("unsplit and resplit");
+                    editor.update_in(cx, |editor, window, cx| {
+                        editor.unsplit(window, cx);
+                    });
+                    cx.run_until_parked();
+                    editor.update_in(cx, |editor, window, cx| {
+                        editor.split(window, cx);
+                    });
+                }
+                80..=89 => {
+                    let excerpt_ids = editor.update(cx, |editor, cx| {
+                        editor.rhs_multibuffer.read(cx).excerpt_ids()
+                    });
+                    if !excerpt_ids.is_empty() {
+                        let count = rng.random_range(1..=excerpt_ids.len().min(3));
+                        let chosen: Vec<_> =
+                            excerpt_ids.choose_multiple(rng, count).copied().collect();
+                        let line_count = rng.random_range(1..5);
+                        log::info!("expanding {count} excerpts by {line_count} lines");
+                        editor.update(cx, |editor, cx| {
+                            editor.expand_excerpts(
+                                chosen.into_iter(),
+                                line_count,
+                                ExpandExcerptDirection::UpAndDown,
+                                cx,
+                            );
+                        });
+                    }
                 }
                 _ => {
                     log::info!("quiescing");
@@ -2447,198 +2476,6 @@ mod tests {
 
             editor.update(cx, |editor, cx| {
                 editor.check_invariants(quiesced, cx);
-            });
-        }
-    }
-
-    #[gpui::test(iterations = 25)]
-    async fn test_random_excerpt_management(mut rng: StdRng, cx: &mut gpui::TestAppContext) {
-        use multi_buffer::{ExcerptId, ExpandExcerptDirection};
-        use rand::prelude::*;
-        use util::RandomCharIter;
-
-        let (editor, cx) = init_test(cx, SoftWrap::EditorWidth, DiffViewStyle::Split).await;
-        let operations = std::env::var("OPERATIONS")
-            .map(|i| i.parse().expect("invalid `OPERATIONS` variable"))
-            .unwrap_or(10);
-        let rng = &mut rng;
-        let mut managed_buffers: Vec<(Entity<Buffer>, Entity<BufferDiff>)> = Vec::new();
-
-        for i in 0..operations {
-            if managed_buffers.is_empty() {
-                log::info!("op {i}: adding initial buffer");
-                let len = rng.random_range(200..1000);
-                let base_text: String = RandomCharIter::new(&mut *rng).take(len).collect();
-                let buffer = cx.new(|cx| Buffer::local(base_text.clone(), cx));
-                let buffer_snapshot = buffer.read_with(cx, |b, _| b.text_snapshot());
-                let diff =
-                    cx.new(|cx| BufferDiff::new_with_base_text(&base_text, &buffer_snapshot, cx));
-                let edit_count = rng.random_range(3..8);
-                buffer.update(cx, |buffer, cx| {
-                    buffer.randomly_edit(rng, edit_count, cx);
-                });
-                let buffer_snapshot = buffer.read_with(cx, |b, _| b.text_snapshot());
-                diff.update(cx, |diff, cx| {
-                    diff.recalculate_diff_sync(&buffer_snapshot, cx);
-                });
-                let diff_snapshot = diff.read_with(cx, |diff, cx| diff.snapshot(cx));
-                let ranges = diff_snapshot
-                    .hunks(&buffer_snapshot)
-                    .map(|hunk| hunk.range)
-                    .collect::<Vec<_>>();
-                let context_lines = rng.random_range(0..2);
-                editor.update(cx, |editor, cx| {
-                    let path = PathKey::for_buffer(&buffer, cx);
-                    editor.set_excerpts_for_path(
-                        path,
-                        buffer.clone(),
-                        ranges,
-                        context_lines,
-                        diff.clone(),
-                        cx,
-                    );
-                });
-                managed_buffers.push((buffer, diff));
-                editor.update(cx, |editor, cx| {
-                    editor.check_excerpt_mapping_invariants(cx);
-                });
-                continue;
-            }
-
-            match rng.random_range(0..100) {
-                0..=14 if managed_buffers.len() < 6 => {
-                    log::info!("op {i}: creating new buffer and setting excerpts");
-                    let len = rng.random_range(200..1000);
-                    let base_text: String = RandomCharIter::new(&mut *rng).take(len).collect();
-                    let buffer = cx.new(|cx| Buffer::local(base_text.clone(), cx));
-                    let buffer_snapshot = buffer.read_with(cx, |b, _| b.text_snapshot());
-                    let diff = cx
-                        .new(|cx| BufferDiff::new_with_base_text(&base_text, &buffer_snapshot, cx));
-                    let edit_count = rng.random_range(3..8);
-                    buffer.update(cx, |buffer, cx| {
-                        buffer.randomly_edit(rng, edit_count, cx);
-                    });
-                    let buffer_snapshot = buffer.read_with(cx, |b, _| b.text_snapshot());
-                    diff.update(cx, |diff, cx| {
-                        diff.recalculate_diff_sync(&buffer_snapshot, cx);
-                    });
-                    let diff_snapshot = diff.read_with(cx, |diff, cx| diff.snapshot(cx));
-                    let ranges = diff_snapshot
-                        .hunks(&buffer_snapshot)
-                        .map(|hunk| hunk.range)
-                        .collect::<Vec<_>>();
-                    let context_lines = rng.random_range(0..2);
-                    editor.update(cx, |editor, cx| {
-                        let path = PathKey::for_buffer(&buffer, cx);
-                        editor.set_excerpts_for_path(
-                            path,
-                            buffer.clone(),
-                            ranges,
-                            context_lines,
-                            diff.clone(),
-                            cx,
-                        );
-                    });
-                    managed_buffers.push((buffer, diff));
-                }
-
-                15..=29 => {
-                    log::info!("op {i}: randomly editing multibuffer");
-                    let edit_count = rng.random_range(1..5);
-                    editor.update(cx, |editor, cx| {
-                        editor.rhs_multibuffer.update(cx, |multibuffer, cx| {
-                            multibuffer.randomly_edit(rng, edit_count, cx);
-                        });
-                    });
-                }
-
-                30..=44 => {
-                    let idx = rng.random_range(0..managed_buffers.len());
-                    log::info!("op {i}: randomly editing individual buffer {idx}");
-                    let edit_count = rng.random_range(1..3);
-                    managed_buffers[idx].0.update(cx, |buffer, cx| {
-                        buffer.randomly_edit(rng, edit_count, cx);
-                    });
-                }
-
-                45..=59 => {
-                    let idx = rng.random_range(0..managed_buffers.len());
-                    log::info!(
-                        "op {i}: recalculating diff and resetting excerpts for buffer {idx}"
-                    );
-                    let (buffer, diff) = &managed_buffers[idx];
-                    let buffer_snapshot = buffer.read_with(cx, |b, _| b.text_snapshot());
-                    diff.update(cx, |diff, cx| {
-                        diff.recalculate_diff_sync(&buffer_snapshot, cx);
-                    });
-                    cx.run_until_parked();
-                    let diff_snapshot = diff.read_with(cx, |diff, cx| diff.snapshot(cx));
-                    let ranges = diff_snapshot
-                        .hunks(&buffer_snapshot)
-                        .map(|hunk| hunk.range)
-                        .collect::<Vec<_>>();
-                    let context_lines = rng.random_range(0..2);
-                    let buffer = buffer.clone();
-                    let diff = diff.clone();
-                    editor.update(cx, |editor, cx| {
-                        let path = PathKey::for_buffer(&buffer, cx);
-                        editor.set_excerpts_for_path(path, buffer, ranges, context_lines, diff, cx);
-                    });
-                }
-
-                60..=69 => {
-                    let idx = rng.random_range(0..managed_buffers.len());
-                    log::info!("op {i}: undo/redo on buffer {idx}");
-                    managed_buffers[idx].0.update(cx, |buffer, cx| {
-                        buffer.randomly_undo_redo(rng, cx);
-                    });
-                }
-
-                70..=79 => {
-                    let idx = rng.random_range(0..managed_buffers.len());
-                    log::info!("op {i}: removing excerpts for buffer {idx}");
-                    let (buffer, _) = managed_buffers.remove(idx);
-                    editor.update(cx, |editor, cx| {
-                        let path = PathKey::for_buffer(&buffer, cx);
-                        editor.remove_excerpts_for_path(path, cx);
-                    });
-                }
-
-                80..=84 => {
-                    log::info!("op {i}: unsplit and resplit");
-                    editor.update_in(cx, |editor, window, cx| {
-                        editor.unsplit(window, cx);
-                    });
-                    cx.run_until_parked();
-                    editor.update_in(cx, |editor, window, cx| {
-                        editor.split(window, cx);
-                    });
-                }
-
-                _ => {
-                    let excerpt_ids = editor.update(cx, |editor, cx| {
-                        editor.rhs_multibuffer.read(cx).excerpt_ids()
-                    });
-                    if !excerpt_ids.is_empty() {
-                        let count = rng.random_range(1..=excerpt_ids.len().min(3));
-                        let chosen: Vec<ExcerptId> =
-                            excerpt_ids.choose_multiple(rng, count).copied().collect();
-                        let line_count = rng.random_range(1..5);
-                        log::info!("op {i}: expanding {count} excerpts by {line_count} lines");
-                        editor.update(cx, |editor, cx| {
-                            editor.expand_excerpts(
-                                chosen.iter().copied(),
-                                line_count,
-                                ExpandExcerptDirection::UpAndDown,
-                                cx,
-                            );
-                        });
-                    }
-                }
-            }
-
-            editor.update(cx, |editor, cx| {
-                editor.check_excerpt_mapping_invariants(cx);
             });
         }
     }

--- a/crates/editor/src/split.rs
+++ b/crates/editor/src/split.rs
@@ -1121,10 +1121,8 @@ impl SplittableEditor {
 #[cfg(test)]
 impl SplittableEditor {
     fn check_invariants(&self, quiesced: bool, cx: &mut App) {
-        use multi_buffer::ExcerptId;
         use text::Bias;
 
-        use crate::DisplaySnapshot;
         use crate::display_map::Block;
         use crate::display_map::DisplayRow;
 
@@ -1177,35 +1175,28 @@ impl SplittableEditor {
                     "mismatch in hunk statuses"
                 );
 
-                let (mut lhs_point, mut rhs_point) =
+                let (lhs_point, rhs_point) =
                     if lhs_hunk.row_range.is_empty() || rhs_hunk.row_range.is_empty() {
-                        (
-                            Point::new(lhs_hunk.row_range.end.0, 0),
-                            Point::new(rhs_hunk.row_range.end.0, 0),
-                        )
+                        let lhs_end = Point::new(lhs_hunk.row_range.end.0, 0);
+                        let rhs_end = Point::new(rhs_hunk.row_range.end.0, 0);
+
+                        let lhs_exceeds = lhs_snapshot
+                            .range_for_excerpt(lhs_hunk.excerpt_id)
+                            .map_or(false, |range| lhs_end >= range.end);
+                        let rhs_exceeds = rhs_snapshot
+                            .range_for_excerpt(rhs_hunk.excerpt_id)
+                            .map_or(false, |range| rhs_end >= range.end);
+                        if lhs_exceeds != rhs_exceeds {
+                            continue;
+                        }
+
+                        (lhs_end, rhs_end)
                     } else {
                         (
                             Point::new(lhs_hunk.row_range.start.0, 0),
                             Point::new(rhs_hunk.row_range.start.0, 0),
                         )
                     };
-
-                let exceeds_excerpt =
-                    |point: Point, excerpt_id: ExcerptId, snapshot: &DisplaySnapshot| {
-                        snapshot
-                            .range_for_excerpt(excerpt_id)
-                            .map_or(false, |range| point >= range.end)
-                    };
-                let lhs_exceeds = exceeds_excerpt(lhs_point, lhs_hunk.excerpt_id, &lhs_snapshot);
-                let rhs_exceeds = exceeds_excerpt(rhs_point, rhs_hunk.excerpt_id, &rhs_snapshot);
-                if lhs_exceeds != rhs_exceeds {
-                    if lhs_exceeds && lhs_point.row > 0 {
-                        lhs_point = Point::new(lhs_point.row - 1, 0);
-                    }
-                    if rhs_exceeds && rhs_point.row > 0 {
-                        rhs_point = Point::new(rhs_point.row - 1, 0);
-                    }
-                }
 
                 let lhs_point = lhs_snapshot.point_to_display_point(lhs_point, Bias::Left);
                 let rhs_point = rhs_snapshot.point_to_display_point(rhs_point, Bias::Left);

--- a/crates/editor/src/split.rs
+++ b/crates/editor/src/split.rs
@@ -225,10 +225,12 @@ where
     for (source_buffer, buffer_offset_range, source_excerpt_id, source_context_range) in
         source_snapshot.range_to_buffer_ranges_with_context(source_bounds)
     {
-        let target_excerpt_id = excerpt_map.get(&source_excerpt_id).copied().unwrap();
-        let target_buffer = target_snapshot
-            .buffer_for_excerpt(target_excerpt_id)
-            .unwrap();
+        let Some(target_excerpt_id) = excerpt_map.get(&source_excerpt_id).copied() else {
+            continue;
+        };
+        let Some(target_buffer) = target_snapshot.buffer_for_excerpt(target_excerpt_id) else {
+            continue;
+        };
 
         let buffer_id = source_buffer.remote_id();
 
@@ -1126,15 +1128,9 @@ impl SplittableEditor {
         use crate::display_map::DisplayRow;
 
         self.debug_print(cx);
+        self.check_excerpt_mapping_invariants(cx);
 
         let lhs = self.lhs.as_ref().unwrap();
-        let rhs_excerpts = self.rhs_multibuffer.read(cx).excerpt_ids();
-        let lhs_excerpts = lhs.multibuffer.read(cx).excerpt_ids();
-        assert_eq!(
-            lhs_excerpts.len(),
-            rhs_excerpts.len(),
-            "mismatch in excerpt count"
-        );
 
         if quiesced {
             let rhs_snapshot = lhs
@@ -1593,6 +1589,112 @@ impl SplittableEditor {
                     self.remove_excerpts_for_path(path.clone(), cx);
                 }
             }
+        }
+    }
+
+    fn check_excerpt_mapping_invariants(&self, cx: &gpui::App) {
+        use multi_buffer::{ExcerptId, PathKey};
+
+        let lhs = self.lhs.as_ref().expect("should have lhs editor");
+
+        let rhs_excerpt_ids = self.rhs_multibuffer.read(cx).excerpt_ids();
+        let lhs_excerpt_ids = lhs.multibuffer.read(cx).excerpt_ids();
+        assert_eq!(
+            rhs_excerpt_ids.len(),
+            lhs_excerpt_ids.len(),
+            "excerpt count mismatch: rhs has {}, lhs has {}",
+            rhs_excerpt_ids.len(),
+            lhs_excerpt_ids.len(),
+        );
+
+        let rhs_display_map = self.rhs_editor.read(cx).display_map.clone();
+        let companion = rhs_display_map
+            .read(cx)
+            .companion()
+            .cloned()
+            .expect("should have companion");
+        let (lhs_to_rhs, rhs_to_lhs) = {
+            let c = companion.read(cx);
+            let (l, r) = c.excerpt_mappings();
+            (l.clone(), r.clone())
+        };
+
+        assert_eq!(
+            lhs_to_rhs.len(),
+            rhs_to_lhs.len(),
+            "mapping size mismatch: lhs_to_rhs has {}, rhs_to_lhs has {}",
+            lhs_to_rhs.len(),
+            rhs_to_lhs.len(),
+        );
+
+        for (&lhs_id, &rhs_id) in &lhs_to_rhs {
+            let reverse = rhs_to_lhs.get(&rhs_id);
+            assert_eq!(
+                reverse,
+                Some(&lhs_id),
+                "lhs_to_rhs maps {lhs_id:?} -> {rhs_id:?}, but rhs_to_lhs maps {rhs_id:?} -> {reverse:?}",
+            );
+        }
+        for (&rhs_id, &lhs_id) in &rhs_to_lhs {
+            let reverse = lhs_to_rhs.get(&lhs_id);
+            assert_eq!(
+                reverse,
+                Some(&rhs_id),
+                "rhs_to_lhs maps {rhs_id:?} -> {lhs_id:?}, but lhs_to_rhs maps {lhs_id:?} -> {reverse:?}",
+            );
+        }
+
+        assert_eq!(
+            lhs_to_rhs.len(),
+            rhs_excerpt_ids.len(),
+            "mapping covers {} excerpts but rhs has {}",
+            lhs_to_rhs.len(),
+            rhs_excerpt_ids.len(),
+        );
+
+        let rhs_mapped_order: Vec<ExcerptId> = rhs_excerpt_ids
+            .iter()
+            .map(|rhs_id| {
+                *rhs_to_lhs.get(rhs_id).unwrap_or_else(|| {
+                    panic!("rhs excerpt {rhs_id:?} has no mapping in rhs_to_lhs")
+                })
+            })
+            .collect();
+        assert_eq!(
+            rhs_mapped_order, lhs_excerpt_ids,
+            "excerpt ordering mismatch: mapping rhs order through rhs_to_lhs doesn't match lhs order",
+        );
+
+        let rhs_paths: Vec<PathKey> = self.rhs_multibuffer.read(cx).paths().cloned().collect();
+        let lhs_paths: Vec<PathKey> = lhs.multibuffer.read(cx).paths().cloned().collect();
+        assert_eq!(
+            rhs_paths, lhs_paths,
+            "path set mismatch between rhs and lhs"
+        );
+
+        for path in &rhs_paths {
+            let rhs_path_excerpts: Vec<ExcerptId> = self
+                .rhs_multibuffer
+                .read(cx)
+                .excerpts_for_path(path)
+                .collect();
+            let lhs_path_excerpts: Vec<ExcerptId> =
+                lhs.multibuffer.read(cx).excerpts_for_path(path).collect();
+            assert_eq!(
+                rhs_path_excerpts.len(),
+                lhs_path_excerpts.len(),
+                "excerpt count mismatch for path {path:?}: rhs has {}, lhs has {}",
+                rhs_path_excerpts.len(),
+                lhs_path_excerpts.len(),
+            );
+            let rhs_path_mapped: Vec<ExcerptId> = rhs_path_excerpts
+                .iter()
+                .map(|rhs_id| *rhs_to_lhs.get(rhs_id).unwrap())
+                .collect();
+            assert_eq!(
+                rhs_path_mapped, lhs_path_excerpts,
+                "per-path excerpt ordering mismatch for {path:?}",
+            );
         }
     }
 }
@@ -2349,113 +2451,7 @@ mod tests {
         }
     }
 
-    fn check_excerpt_mapping_invariants(editor: &SplittableEditor, cx: &gpui::App) {
-        use multi_buffer::{ExcerptId, PathKey};
-
-        let lhs = editor.lhs.as_ref().expect("should have lhs editor");
-
-        let rhs_excerpt_ids = editor.rhs_multibuffer.read(cx).excerpt_ids();
-        let lhs_excerpt_ids = lhs.multibuffer.read(cx).excerpt_ids();
-        assert_eq!(
-            rhs_excerpt_ids.len(),
-            lhs_excerpt_ids.len(),
-            "excerpt count mismatch: rhs has {}, lhs has {}",
-            rhs_excerpt_ids.len(),
-            lhs_excerpt_ids.len(),
-        );
-
-        let rhs_display_map = editor.rhs_editor.read(cx).display_map.clone();
-        let companion = rhs_display_map
-            .read(cx)
-            .companion()
-            .cloned()
-            .expect("should have companion");
-        let (lhs_to_rhs, rhs_to_lhs) = {
-            let c = companion.read(cx);
-            let (l, r) = c.excerpt_mappings();
-            (l.clone(), r.clone())
-        };
-
-        assert_eq!(
-            lhs_to_rhs.len(),
-            rhs_to_lhs.len(),
-            "mapping size mismatch: lhs_to_rhs has {}, rhs_to_lhs has {}",
-            lhs_to_rhs.len(),
-            rhs_to_lhs.len(),
-        );
-
-        for (&lhs_id, &rhs_id) in &lhs_to_rhs {
-            let reverse = rhs_to_lhs.get(&rhs_id);
-            assert_eq!(
-                reverse,
-                Some(&lhs_id),
-                "lhs_to_rhs maps {lhs_id:?} -> {rhs_id:?}, but rhs_to_lhs maps {rhs_id:?} -> {reverse:?}",
-            );
-        }
-        for (&rhs_id, &lhs_id) in &rhs_to_lhs {
-            let reverse = lhs_to_rhs.get(&lhs_id);
-            assert_eq!(
-                reverse,
-                Some(&rhs_id),
-                "rhs_to_lhs maps {rhs_id:?} -> {lhs_id:?}, but lhs_to_rhs maps {lhs_id:?} -> {reverse:?}",
-            );
-        }
-
-        assert_eq!(
-            lhs_to_rhs.len(),
-            rhs_excerpt_ids.len(),
-            "mapping covers {} excerpts but rhs has {}",
-            lhs_to_rhs.len(),
-            rhs_excerpt_ids.len(),
-        );
-
-        let rhs_mapped_order: Vec<ExcerptId> = rhs_excerpt_ids
-            .iter()
-            .map(|rhs_id| {
-                *rhs_to_lhs.get(rhs_id).unwrap_or_else(|| {
-                    panic!("rhs excerpt {rhs_id:?} has no mapping in rhs_to_lhs")
-                })
-            })
-            .collect();
-        assert_eq!(
-            rhs_mapped_order, lhs_excerpt_ids,
-            "excerpt ordering mismatch: mapping rhs order through rhs_to_lhs doesn't match lhs order",
-        );
-
-        let rhs_paths: Vec<PathKey> = editor.rhs_multibuffer.read(cx).paths().cloned().collect();
-        let lhs_paths: Vec<PathKey> = lhs.multibuffer.read(cx).paths().cloned().collect();
-        assert_eq!(
-            rhs_paths, lhs_paths,
-            "path set mismatch between rhs and lhs"
-        );
-
-        for path in &rhs_paths {
-            let rhs_path_excerpts: Vec<ExcerptId> = editor
-                .rhs_multibuffer
-                .read(cx)
-                .excerpts_for_path(path)
-                .collect();
-            let lhs_path_excerpts: Vec<ExcerptId> =
-                lhs.multibuffer.read(cx).excerpts_for_path(path).collect();
-            assert_eq!(
-                rhs_path_excerpts.len(),
-                lhs_path_excerpts.len(),
-                "excerpt count mismatch for path {path:?}: rhs has {}, lhs has {}",
-                rhs_path_excerpts.len(),
-                lhs_path_excerpts.len(),
-            );
-            let rhs_path_mapped: Vec<ExcerptId> = rhs_path_excerpts
-                .iter()
-                .map(|rhs_id| *rhs_to_lhs.get(rhs_id).unwrap())
-                .collect();
-            assert_eq!(
-                rhs_path_mapped, lhs_path_excerpts,
-                "per-path excerpt ordering mismatch for {path:?}",
-            );
-        }
-    }
-
-    #[gpui::test(iterations = 50)]
+    #[gpui::test(iterations = 25)]
     async fn test_random_excerpt_management(mut rng: StdRng, cx: &mut gpui::TestAppContext) {
         use multi_buffer::{ExcerptId, ExpandExcerptDirection};
         use rand::prelude::*;
@@ -2464,7 +2460,7 @@ mod tests {
         let (editor, cx) = init_test(cx, SoftWrap::EditorWidth, DiffViewStyle::Split).await;
         let operations = std::env::var("OPERATIONS")
             .map(|i| i.parse().expect("invalid `OPERATIONS` variable"))
-            .unwrap_or(20);
+            .unwrap_or(10);
         let rng = &mut rng;
         let mut managed_buffers: Vec<(Entity<Buffer>, Entity<BufferDiff>)> = Vec::new();
 
@@ -2504,7 +2500,7 @@ mod tests {
                 });
                 managed_buffers.push((buffer, diff));
                 editor.update(cx, |editor, cx| {
-                    check_excerpt_mapping_invariants(editor, cx);
+                    editor.check_excerpt_mapping_invariants(cx);
                 });
                 continue;
             }
@@ -2642,7 +2638,7 @@ mod tests {
             }
 
             editor.update(cx, |editor, cx| {
-                check_excerpt_mapping_invariants(editor, cx);
+                editor.check_excerpt_mapping_invariants(cx);
             });
         }
     }

--- a/crates/editor/src/split.rs
+++ b/crates/editor/src/split.rs
@@ -2471,13 +2471,13 @@ mod tests {
         for i in 0..operations {
             if managed_buffers.is_empty() {
                 log::info!("op {i}: adding initial buffer");
-                let len = rng.random_range(50..300);
+                let len = rng.random_range(200..1000);
                 let base_text: String = RandomCharIter::new(&mut *rng).take(len).collect();
                 let buffer = cx.new(|cx| Buffer::local(base_text.clone(), cx));
                 let buffer_snapshot = buffer.read_with(cx, |b, _| b.text_snapshot());
                 let diff =
                     cx.new(|cx| BufferDiff::new_with_base_text(&base_text, &buffer_snapshot, cx));
-                let edit_count = rng.random_range(1..4);
+                let edit_count = rng.random_range(3..8);
                 buffer.update(cx, |buffer, cx| {
                     buffer.randomly_edit(rng, edit_count, cx);
                 });
@@ -2490,7 +2490,7 @@ mod tests {
                     .hunks(&buffer_snapshot)
                     .map(|hunk| hunk.range)
                     .collect::<Vec<_>>();
-                let context_lines = rng.random_range(1..4);
+                let context_lines = rng.random_range(0..2);
                 editor.update(cx, |editor, cx| {
                     let path = PathKey::for_buffer(&buffer, cx);
                     editor.set_excerpts_for_path(
@@ -2512,13 +2512,13 @@ mod tests {
             match rng.random_range(0..100) {
                 0..=14 if managed_buffers.len() < 6 => {
                     log::info!("op {i}: creating new buffer and setting excerpts");
-                    let len = rng.random_range(50..300);
+                    let len = rng.random_range(200..1000);
                     let base_text: String = RandomCharIter::new(&mut *rng).take(len).collect();
                     let buffer = cx.new(|cx| Buffer::local(base_text.clone(), cx));
                     let buffer_snapshot = buffer.read_with(cx, |b, _| b.text_snapshot());
                     let diff = cx
                         .new(|cx| BufferDiff::new_with_base_text(&base_text, &buffer_snapshot, cx));
-                    let edit_count = rng.random_range(1..4);
+                    let edit_count = rng.random_range(3..8);
                     buffer.update(cx, |buffer, cx| {
                         buffer.randomly_edit(rng, edit_count, cx);
                     });
@@ -2531,7 +2531,7 @@ mod tests {
                         .hunks(&buffer_snapshot)
                         .map(|hunk| hunk.range)
                         .collect::<Vec<_>>();
-                    let context_lines = rng.random_range(1..4);
+                    let context_lines = rng.random_range(0..2);
                     editor.update(cx, |editor, cx| {
                         let path = PathKey::for_buffer(&buffer, cx);
                         editor.set_excerpts_for_path(
@@ -2581,7 +2581,7 @@ mod tests {
                         .hunks(&buffer_snapshot)
                         .map(|hunk| hunk.range)
                         .collect::<Vec<_>>();
-                    let context_lines = rng.random_range(1..4);
+                    let context_lines = rng.random_range(0..2);
                     let buffer = buffer.clone();
                     let diff = diff.clone();
                     editor.update(cx, |editor, cx| {
@@ -2605,6 +2605,17 @@ mod tests {
                     editor.update(cx, |editor, cx| {
                         let path = PathKey::for_buffer(&buffer, cx);
                         editor.remove_excerpts_for_path(path, cx);
+                    });
+                }
+
+                80..=84 => {
+                    log::info!("op {i}: unsplit and resplit");
+                    editor.update_in(cx, |editor, window, cx| {
+                        editor.unsplit(window, cx);
+                    });
+                    cx.run_until_parked();
+                    editor.update_in(cx, |editor, window, cx| {
+                        editor.split(window, cx);
                     });
                 }
 

--- a/crates/editor/src/split.rs
+++ b/crates/editor/src/split.rs
@@ -1121,9 +1121,10 @@ impl SplittableEditor {
 #[cfg(test)]
 impl SplittableEditor {
     fn check_invariants(&self, quiesced: bool, cx: &mut App) {
-        use multi_buffer::MultiBufferRow;
+        use multi_buffer::ExcerptId;
         use text::Bias;
 
+        use crate::DisplaySnapshot;
         use crate::display_map::Block;
         use crate::display_map::DisplayRow;
 
@@ -1176,7 +1177,7 @@ impl SplittableEditor {
                     "mismatch in hunk statuses"
                 );
 
-                let (lhs_point, rhs_point) =
+                let (mut lhs_point, mut rhs_point) =
                     if lhs_hunk.row_range.is_empty() || rhs_hunk.row_range.is_empty() {
                         (
                             Point::new(lhs_hunk.row_range.end.0, 0),
@@ -1188,6 +1189,24 @@ impl SplittableEditor {
                             Point::new(rhs_hunk.row_range.start.0, 0),
                         )
                     };
+
+                let exceeds_excerpt =
+                    |point: Point, excerpt_id: ExcerptId, snapshot: &DisplaySnapshot| {
+                        snapshot
+                            .range_for_excerpt(excerpt_id)
+                            .map_or(false, |range| point >= range.end)
+                    };
+                let lhs_exceeds = exceeds_excerpt(lhs_point, lhs_hunk.excerpt_id, &lhs_snapshot);
+                let rhs_exceeds = exceeds_excerpt(rhs_point, rhs_hunk.excerpt_id, &rhs_snapshot);
+                if lhs_exceeds != rhs_exceeds {
+                    if lhs_exceeds && lhs_point.row > 0 {
+                        lhs_point = Point::new(lhs_point.row - 1, 0);
+                    }
+                    if rhs_exceeds && rhs_point.row > 0 {
+                        rhs_point = Point::new(rhs_point.row - 1, 0);
+                    }
+                }
+
                 let lhs_point = lhs_snapshot.point_to_display_point(lhs_point, Bias::Left);
                 let rhs_point = rhs_snapshot.point_to_display_point(rhs_point, Bias::Left);
                 assert_eq!(
@@ -1196,29 +1215,6 @@ impl SplittableEditor {
                     "mismatch in hunk position"
                 );
             }
-        }
-    }
-
-    #[track_caller]
-    fn check_sides_match<T: std::fmt::Debug + PartialEq>(
-        &self,
-        cx: &mut App,
-        mut extract: impl FnMut(&crate::DisplaySnapshot) -> T,
-    ) {
-        let lhs = self.lhs.as_ref().expect("requires split");
-        let rhs_snapshot = self.rhs_editor.update(cx, |editor, cx| {
-            editor.display_map.update(cx, |map, cx| map.snapshot(cx))
-        });
-        let lhs_snapshot = lhs.editor.update(cx, |editor, cx| {
-            editor.display_map.update(cx, |map, cx| map.snapshot(cx))
-        });
-
-        let rhs_t = extract(&rhs_snapshot);
-        let lhs_t = extract(&lhs_snapshot);
-
-        if rhs_t != lhs_t {
-            self.debug_print(cx);
-            pretty_assertions::assert_eq!(rhs_t, lhs_t);
         }
     }
 

--- a/crates/editor/src/split.rs
+++ b/crates/editor/src/split.rs
@@ -1197,7 +1197,6 @@ impl SplittableEditor {
                             Point::new(rhs_hunk.row_range.start.0, 0),
                         )
                     };
-
                 let lhs_point = lhs_snapshot.point_to_display_point(lhs_point, Bias::Left);
                 let rhs_point = rhs_snapshot.point_to_display_point(rhs_point, Bias::Left);
                 assert_eq!(

--- a/crates/editor/src/split.rs
+++ b/crates/editor/src/split.rs
@@ -225,12 +225,10 @@ where
     for (source_buffer, buffer_offset_range, source_excerpt_id, source_context_range) in
         source_snapshot.range_to_buffer_ranges_with_context(source_bounds)
     {
-        let Some(target_excerpt_id) = excerpt_map.get(&source_excerpt_id).copied() else {
-            continue;
-        };
-        let Some(target_buffer) = target_snapshot.buffer_for_excerpt(target_excerpt_id) else {
-            continue;
-        };
+        let target_excerpt_id = excerpt_map.get(&source_excerpt_id).copied().unwrap();
+        let target_buffer = target_snapshot
+            .buffer_for_excerpt(target_excerpt_id)
+            .unwrap();
 
         let buffer_id = source_buffer.remote_id();
 
@@ -337,7 +335,7 @@ fn patch_for_excerpt(
     let mut merged_edits: Vec<text::Edit<Point>> = Vec::new();
     for edit in edits {
         if let Some(last) = merged_edits.last_mut() {
-            if edit.new.start <= last.new.end {
+            if edit.new.start <= last.new.end || edit.old.start <= last.old.end {
                 last.old.end = last.old.end.max(edit.old.end);
                 last.new.end = last.new.end.max(edit.new.end);
                 continue;
@@ -2349,6 +2347,342 @@ mod tests {
                 editor.check_invariants(quiesced, cx);
             });
         }
+    }
+
+    fn check_excerpt_mapping_invariants(editor: &SplittableEditor, cx: &gpui::App) {
+        use multi_buffer::{ExcerptId, PathKey};
+
+        let lhs = editor.lhs.as_ref().expect("should have lhs editor");
+
+        let rhs_excerpt_ids = editor.rhs_multibuffer.read(cx).excerpt_ids();
+        let lhs_excerpt_ids = lhs.multibuffer.read(cx).excerpt_ids();
+        assert_eq!(
+            rhs_excerpt_ids.len(),
+            lhs_excerpt_ids.len(),
+            "excerpt count mismatch: rhs has {}, lhs has {}",
+            rhs_excerpt_ids.len(),
+            lhs_excerpt_ids.len(),
+        );
+
+        let rhs_display_map = editor.rhs_editor.read(cx).display_map.clone();
+        let companion = rhs_display_map
+            .read(cx)
+            .companion()
+            .cloned()
+            .expect("should have companion");
+        let (lhs_to_rhs, rhs_to_lhs) = {
+            let c = companion.read(cx);
+            let (l, r) = c.excerpt_mappings();
+            (l.clone(), r.clone())
+        };
+
+        assert_eq!(
+            lhs_to_rhs.len(),
+            rhs_to_lhs.len(),
+            "mapping size mismatch: lhs_to_rhs has {}, rhs_to_lhs has {}",
+            lhs_to_rhs.len(),
+            rhs_to_lhs.len(),
+        );
+
+        for (&lhs_id, &rhs_id) in &lhs_to_rhs {
+            let reverse = rhs_to_lhs.get(&rhs_id);
+            assert_eq!(
+                reverse,
+                Some(&lhs_id),
+                "lhs_to_rhs maps {lhs_id:?} -> {rhs_id:?}, but rhs_to_lhs maps {rhs_id:?} -> {reverse:?}",
+            );
+        }
+        for (&rhs_id, &lhs_id) in &rhs_to_lhs {
+            let reverse = lhs_to_rhs.get(&lhs_id);
+            assert_eq!(
+                reverse,
+                Some(&rhs_id),
+                "rhs_to_lhs maps {rhs_id:?} -> {lhs_id:?}, but lhs_to_rhs maps {lhs_id:?} -> {reverse:?}",
+            );
+        }
+
+        assert_eq!(
+            lhs_to_rhs.len(),
+            rhs_excerpt_ids.len(),
+            "mapping covers {} excerpts but rhs has {}",
+            lhs_to_rhs.len(),
+            rhs_excerpt_ids.len(),
+        );
+
+        let rhs_mapped_order: Vec<ExcerptId> = rhs_excerpt_ids
+            .iter()
+            .map(|rhs_id| {
+                *rhs_to_lhs.get(rhs_id).unwrap_or_else(|| {
+                    panic!("rhs excerpt {rhs_id:?} has no mapping in rhs_to_lhs")
+                })
+            })
+            .collect();
+        assert_eq!(
+            rhs_mapped_order, lhs_excerpt_ids,
+            "excerpt ordering mismatch: mapping rhs order through rhs_to_lhs doesn't match lhs order",
+        );
+
+        let rhs_paths: Vec<PathKey> = editor.rhs_multibuffer.read(cx).paths().cloned().collect();
+        let lhs_paths: Vec<PathKey> = lhs.multibuffer.read(cx).paths().cloned().collect();
+        assert_eq!(
+            rhs_paths, lhs_paths,
+            "path set mismatch between rhs and lhs"
+        );
+
+        for path in &rhs_paths {
+            let rhs_path_excerpts: Vec<ExcerptId> = editor
+                .rhs_multibuffer
+                .read(cx)
+                .excerpts_for_path(path)
+                .collect();
+            let lhs_path_excerpts: Vec<ExcerptId> =
+                lhs.multibuffer.read(cx).excerpts_for_path(path).collect();
+            assert_eq!(
+                rhs_path_excerpts.len(),
+                lhs_path_excerpts.len(),
+                "excerpt count mismatch for path {path:?}: rhs has {}, lhs has {}",
+                rhs_path_excerpts.len(),
+                lhs_path_excerpts.len(),
+            );
+            let rhs_path_mapped: Vec<ExcerptId> = rhs_path_excerpts
+                .iter()
+                .map(|rhs_id| *rhs_to_lhs.get(rhs_id).unwrap())
+                .collect();
+            assert_eq!(
+                rhs_path_mapped, lhs_path_excerpts,
+                "per-path excerpt ordering mismatch for {path:?}",
+            );
+        }
+    }
+
+    #[gpui::test(iterations = 50)]
+    async fn test_random_excerpt_management(mut rng: StdRng, cx: &mut gpui::TestAppContext) {
+        use multi_buffer::{ExcerptId, ExpandExcerptDirection};
+        use rand::prelude::*;
+        use util::RandomCharIter;
+
+        let (editor, cx) = init_test(cx, SoftWrap::EditorWidth, DiffViewStyle::Split).await;
+        let operations = std::env::var("OPERATIONS")
+            .map(|i| i.parse().expect("invalid `OPERATIONS` variable"))
+            .unwrap_or(20);
+        let rng = &mut rng;
+        let mut managed_buffers: Vec<(Entity<Buffer>, Entity<BufferDiff>)> = Vec::new();
+
+        for i in 0..operations {
+            if managed_buffers.is_empty() {
+                log::info!("op {i}: adding initial buffer");
+                let len = rng.random_range(50..300);
+                let base_text: String = RandomCharIter::new(&mut *rng).take(len).collect();
+                let buffer = cx.new(|cx| Buffer::local(base_text.clone(), cx));
+                let buffer_snapshot = buffer.read_with(cx, |b, _| b.text_snapshot());
+                let diff =
+                    cx.new(|cx| BufferDiff::new_with_base_text(&base_text, &buffer_snapshot, cx));
+                let edit_count = rng.random_range(1..4);
+                buffer.update(cx, |buffer, cx| {
+                    buffer.randomly_edit(rng, edit_count, cx);
+                });
+                let buffer_snapshot = buffer.read_with(cx, |b, _| b.text_snapshot());
+                diff.update(cx, |diff, cx| {
+                    diff.recalculate_diff_sync(&buffer_snapshot, cx);
+                });
+                let diff_snapshot = diff.read_with(cx, |diff, cx| diff.snapshot(cx));
+                let ranges = diff_snapshot
+                    .hunks(&buffer_snapshot)
+                    .map(|hunk| hunk.range)
+                    .collect::<Vec<_>>();
+                let context_lines = rng.random_range(1..4);
+                editor.update(cx, |editor, cx| {
+                    let path = PathKey::for_buffer(&buffer, cx);
+                    editor.set_excerpts_for_path(
+                        path,
+                        buffer.clone(),
+                        ranges,
+                        context_lines,
+                        diff.clone(),
+                        cx,
+                    );
+                });
+                managed_buffers.push((buffer, diff));
+                editor.update(cx, |editor, cx| {
+                    check_excerpt_mapping_invariants(editor, cx);
+                });
+                continue;
+            }
+
+            match rng.random_range(0..100) {
+                0..=14 if managed_buffers.len() < 6 => {
+                    log::info!("op {i}: creating new buffer and setting excerpts");
+                    let len = rng.random_range(50..300);
+                    let base_text: String = RandomCharIter::new(&mut *rng).take(len).collect();
+                    let buffer = cx.new(|cx| Buffer::local(base_text.clone(), cx));
+                    let buffer_snapshot = buffer.read_with(cx, |b, _| b.text_snapshot());
+                    let diff = cx
+                        .new(|cx| BufferDiff::new_with_base_text(&base_text, &buffer_snapshot, cx));
+                    let edit_count = rng.random_range(1..4);
+                    buffer.update(cx, |buffer, cx| {
+                        buffer.randomly_edit(rng, edit_count, cx);
+                    });
+                    let buffer_snapshot = buffer.read_with(cx, |b, _| b.text_snapshot());
+                    diff.update(cx, |diff, cx| {
+                        diff.recalculate_diff_sync(&buffer_snapshot, cx);
+                    });
+                    let diff_snapshot = diff.read_with(cx, |diff, cx| diff.snapshot(cx));
+                    let ranges = diff_snapshot
+                        .hunks(&buffer_snapshot)
+                        .map(|hunk| hunk.range)
+                        .collect::<Vec<_>>();
+                    let context_lines = rng.random_range(1..4);
+                    editor.update(cx, |editor, cx| {
+                        let path = PathKey::for_buffer(&buffer, cx);
+                        editor.set_excerpts_for_path(
+                            path,
+                            buffer.clone(),
+                            ranges,
+                            context_lines,
+                            diff.clone(),
+                            cx,
+                        );
+                    });
+                    managed_buffers.push((buffer, diff));
+                }
+
+                15..=29 => {
+                    log::info!("op {i}: randomly editing multibuffer");
+                    let edit_count = rng.random_range(1..5);
+                    editor.update(cx, |editor, cx| {
+                        editor.rhs_multibuffer.update(cx, |multibuffer, cx| {
+                            multibuffer.randomly_edit(rng, edit_count, cx);
+                        });
+                    });
+                }
+
+                30..=44 => {
+                    let idx = rng.random_range(0..managed_buffers.len());
+                    log::info!("op {i}: randomly editing individual buffer {idx}");
+                    let edit_count = rng.random_range(1..3);
+                    managed_buffers[idx].0.update(cx, |buffer, cx| {
+                        buffer.randomly_edit(rng, edit_count, cx);
+                    });
+                }
+
+                45..=59 => {
+                    let idx = rng.random_range(0..managed_buffers.len());
+                    log::info!(
+                        "op {i}: recalculating diff and resetting excerpts for buffer {idx}"
+                    );
+                    let (buffer, diff) = &managed_buffers[idx];
+                    let buffer_snapshot = buffer.read_with(cx, |b, _| b.text_snapshot());
+                    diff.update(cx, |diff, cx| {
+                        diff.recalculate_diff_sync(&buffer_snapshot, cx);
+                    });
+                    cx.run_until_parked();
+                    let diff_snapshot = diff.read_with(cx, |diff, cx| diff.snapshot(cx));
+                    let ranges = diff_snapshot
+                        .hunks(&buffer_snapshot)
+                        .map(|hunk| hunk.range)
+                        .collect::<Vec<_>>();
+                    let context_lines = rng.random_range(1..4);
+                    let buffer = buffer.clone();
+                    let diff = diff.clone();
+                    editor.update(cx, |editor, cx| {
+                        let path = PathKey::for_buffer(&buffer, cx);
+                        editor.set_excerpts_for_path(path, buffer, ranges, context_lines, diff, cx);
+                    });
+                }
+
+                60..=69 => {
+                    let idx = rng.random_range(0..managed_buffers.len());
+                    log::info!("op {i}: undo/redo on buffer {idx}");
+                    managed_buffers[idx].0.update(cx, |buffer, cx| {
+                        buffer.randomly_undo_redo(rng, cx);
+                    });
+                }
+
+                70..=79 => {
+                    let idx = rng.random_range(0..managed_buffers.len());
+                    log::info!("op {i}: removing excerpts for buffer {idx}");
+                    let (buffer, _) = managed_buffers.remove(idx);
+                    editor.update(cx, |editor, cx| {
+                        let path = PathKey::for_buffer(&buffer, cx);
+                        editor.remove_excerpts_for_path(path, cx);
+                    });
+                }
+
+                _ => {
+                    let excerpt_ids = editor.update(cx, |editor, cx| {
+                        editor.rhs_multibuffer.read(cx).excerpt_ids()
+                    });
+                    if !excerpt_ids.is_empty() {
+                        let count = rng.random_range(1..=excerpt_ids.len().min(3));
+                        let chosen: Vec<ExcerptId> =
+                            excerpt_ids.choose_multiple(rng, count).copied().collect();
+                        let line_count = rng.random_range(1..5);
+                        log::info!("op {i}: expanding {count} excerpts by {line_count} lines");
+                        editor.update(cx, |editor, cx| {
+                            editor.expand_excerpts(
+                                chosen.iter().copied(),
+                                line_count,
+                                ExpandExcerptDirection::UpAndDown,
+                                cx,
+                            );
+                        });
+                    }
+                }
+            }
+
+            editor.update(cx, |editor, cx| {
+                check_excerpt_mapping_invariants(editor, cx);
+            });
+        }
+    }
+
+    #[gpui::test]
+    async fn test_expand_excerpt_with_hunk_before_excerpt_start(cx: &mut gpui::TestAppContext) {
+        use rope::Point;
+
+        let (editor, cx) = init_test(cx, SoftWrap::None, DiffViewStyle::Split).await;
+
+        let base_text = "aaaaaaa rest_of_line\nsecond_line\nthird_line\nfourth_line";
+        let current_text = "aaaaaaa rest_of_line\nsecond_line\nMODIFIED\nfourth_line";
+        let (buffer, diff) = buffer_with_diff(base_text, current_text, cx);
+
+        let buffer_snapshot = buffer.read_with(cx, |b, _| b.text_snapshot());
+        diff.update(cx, |diff, cx| {
+            diff.recalculate_diff_sync(&buffer_snapshot, cx);
+        });
+        cx.run_until_parked();
+
+        let diff_snapshot = diff.read_with(cx, |diff, cx| diff.snapshot(cx));
+        let ranges = diff_snapshot
+            .hunks(&buffer_snapshot)
+            .map(|hunk| hunk.range)
+            .collect::<Vec<_>>();
+
+        editor.update(cx, |editor, cx| {
+            let path = PathKey::for_buffer(&buffer, cx);
+            editor.set_excerpts_for_path(path, buffer.clone(), ranges, 0, diff.clone(), cx);
+        });
+        cx.run_until_parked();
+
+        buffer.update(cx, |buffer, cx| {
+            buffer.edit(
+                [(Point::new(0, 7)..Point::new(1, 7), "\nnew_line\n")],
+                None,
+                cx,
+            );
+        });
+
+        let excerpt_ids = editor.update(cx, |editor, cx| {
+            editor.rhs_multibuffer.read(cx).excerpt_ids()
+        });
+        editor.update(cx, |editor, cx| {
+            editor.expand_excerpts(
+                excerpt_ids.iter().copied(),
+                2,
+                multi_buffer::ExpandExcerptDirection::UpAndDown,
+                cx,
+            );
+        });
     }
 
     #[gpui::test]

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -2230,14 +2230,6 @@ impl MultiBuffer {
         let mut removed_excerpts_for_buffers = HashSet::default();
 
         while let Some(excerpt_id) = excerpt_ids.next() {
-            if let Some(path) = self.paths_by_excerpt.remove(&excerpt_id) {
-                if let Some(excerpt_list) = self.excerpts_by_path.get_mut(&path) {
-                    excerpt_list.retain(|id| *id != excerpt_id);
-                    if excerpt_list.is_empty() {
-                        self.excerpts_by_path.remove(&path);
-                    }
-                }
-            }
             // Seek to the next excerpt to remove, preserving any preceding excerpts.
             let locator = snapshot.excerpt_locator_for_id(excerpt_id);
             new_excerpts.append(cursor.slice(&Some(locator), Bias::Left), ());
@@ -2299,6 +2291,16 @@ impl MultiBuffer {
         let changed_trailing_excerpt = suffix.is_empty();
         new_excerpts.append(suffix, ());
         drop(cursor);
+        for &excerpt_id in &ids {
+            if let Some(path) = self.paths_by_excerpt.remove(&excerpt_id) {
+                if let Some(excerpt_list) = self.excerpts_by_path.get_mut(&path) {
+                    excerpt_list.retain(|id| *id != excerpt_id);
+                    if excerpt_list.is_empty() {
+                        self.excerpts_by_path.remove(&path);
+                    }
+                }
+            }
+        }
         for buffer_id in removed_excerpts_for_buffers {
             match self.buffers.get(&buffer_id) {
                 Some(buffer_state) => {

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -536,9 +536,9 @@ impl DiffState {
 }
 
 #[derive(Clone)]
-struct DiffStateSnapshot {
-    diff: BufferDiffSnapshot,
-    main_buffer: Option<language::BufferSnapshot>,
+pub struct DiffStateSnapshot {
+    pub diff: BufferDiffSnapshot,
+    pub main_buffer: Option<language::BufferSnapshot>,
 }
 
 impl std::ops::Deref for DiffStateSnapshot {
@@ -602,6 +602,8 @@ impl DiffState {
                                     base_text_changed_range,
                                     cx,
                                 )
+                            } else {
+                                this.refresh_inverted_diff_snapshot(diff, main_buffer, cx);
                             }
                             cx.emit(Event::BufferDiffChanged);
                         }
@@ -2492,6 +2494,24 @@ impl MultiBuffer {
         cx.emit(Event::Edited {
             edited_buffer: None,
         });
+    }
+
+    fn refresh_inverted_diff_snapshot(
+        &mut self,
+        diff: Entity<BufferDiff>,
+        main_buffer: Entity<language::Buffer>,
+        cx: &mut Context<Self>,
+    ) {
+        let base_text_buffer_id = diff.read(cx).base_text_buffer().read(cx).remote_id();
+        let main_buffer_snapshot = main_buffer.read(cx).snapshot();
+        let new_diff = DiffStateSnapshot {
+            diff: diff.read(cx).snapshot(cx),
+            main_buffer: Some(main_buffer_snapshot),
+        };
+        self.snapshot
+            .get_mut()
+            .diffs
+            .insert_or_replace(base_text_buffer_id, new_diff);
     }
 
     fn inverted_buffer_diff_changed(
@@ -7134,6 +7154,10 @@ impl MultiBufferSnapshot {
 
     pub fn diff_for_buffer_id(&self, buffer_id: BufferId) -> Option<&BufferDiffSnapshot> {
         self.diffs.get(&buffer_id).map(|diff| &diff.diff)
+    }
+
+    pub fn diff_state_for(&self, buffer_id: BufferId) -> Option<&DiffStateSnapshot> {
+        self.diffs.get(&buffer_id)
     }
 
     pub fn all_diff_hunks_expanded(&self) -> bool {

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -2230,7 +2230,14 @@ impl MultiBuffer {
         let mut removed_excerpts_for_buffers = HashSet::default();
 
         while let Some(excerpt_id) = excerpt_ids.next() {
-            self.paths_by_excerpt.remove(&excerpt_id);
+            if let Some(path) = self.paths_by_excerpt.remove(&excerpt_id) {
+                if let Some(excerpt_list) = self.excerpts_by_path.get_mut(&path) {
+                    excerpt_list.retain(|id| *id != excerpt_id);
+                    if excerpt_list.is_empty() {
+                        self.excerpts_by_path.remove(&path);
+                    }
+                }
+            }
             // Seek to the next excerpt to remove, preserving any preceding excerpts.
             let locator = snapshot.excerpt_locator_for_id(excerpt_id);
             new_excerpts.append(cursor.slice(&Some(locator), Bias::Left), ());

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -536,9 +536,9 @@ impl DiffState {
 }
 
 #[derive(Clone)]
-pub struct DiffStateSnapshot {
-    pub diff: BufferDiffSnapshot,
-    pub main_buffer: Option<language::BufferSnapshot>,
+struct DiffStateSnapshot {
+    diff: BufferDiffSnapshot,
+    main_buffer: Option<language::BufferSnapshot>,
 }
 
 impl std::ops::Deref for DiffStateSnapshot {
@@ -595,16 +595,12 @@ impl DiffState {
                             base_text_changed_range,
                             extended_range: _,
                         }) => {
-                            if let Some(base_text_changed_range) = base_text_changed_range.clone() {
-                                this.inverted_buffer_diff_changed(
-                                    diff,
-                                    main_buffer,
-                                    base_text_changed_range,
-                                    cx,
-                                )
-                            } else {
-                                this.refresh_inverted_diff_snapshot(diff, main_buffer, cx);
-                            }
+                            this.inverted_buffer_diff_changed(
+                                diff,
+                                main_buffer,
+                                base_text_changed_range.clone(),
+                                cx,
+                            );
                             cx.emit(Event::BufferDiffChanged);
                         }
                         BufferDiffEvent::LanguageChanged => {
@@ -2204,7 +2200,19 @@ impl MultiBuffer {
         drop(snapshot);
 
         self.resize_excerpt(excerpt_ids[0], union_range, cx);
-        self.remove_excerpts(excerpt_ids[1..].iter().copied(), cx);
+        let removed = &excerpt_ids[1..];
+        for &excerpt_id in removed {
+            if let Some(path) = self.paths_by_excerpt.get(&excerpt_id) {
+                if let Some(excerpt_list) = self.excerpts_by_path.get_mut(path) {
+                    excerpt_list.retain(|id| *id != excerpt_id);
+                    if excerpt_list.is_empty() {
+                        let path = path.clone();
+                        self.excerpts_by_path.remove(&path);
+                    }
+                }
+            }
+        }
+        self.remove_excerpts(removed.iter().copied(), cx);
 
         excerpt_ids[0]
     }
@@ -2232,6 +2240,7 @@ impl MultiBuffer {
         let mut removed_excerpts_for_buffers = HashSet::default();
 
         while let Some(excerpt_id) = excerpt_ids.next() {
+            self.paths_by_excerpt.remove(&excerpt_id);
             // Seek to the next excerpt to remove, preserving any preceding excerpts.
             let locator = snapshot.excerpt_locator_for_id(excerpt_id);
             new_excerpts.append(cursor.slice(&Some(locator), Bias::Left), ());
@@ -2293,16 +2302,6 @@ impl MultiBuffer {
         let changed_trailing_excerpt = suffix.is_empty();
         new_excerpts.append(suffix, ());
         drop(cursor);
-        for &excerpt_id in &ids {
-            if let Some(path) = self.paths_by_excerpt.remove(&excerpt_id) {
-                if let Some(excerpt_list) = self.excerpts_by_path.get_mut(&path) {
-                    excerpt_list.retain(|id| *id != excerpt_id);
-                    if excerpt_list.is_empty() {
-                        self.excerpts_by_path.remove(&path);
-                    }
-                }
-            }
-        }
         for buffer_id in removed_excerpts_for_buffers {
             match self.buffers.get(&buffer_id) {
                 Some(buffer_state) => {
@@ -2496,29 +2495,11 @@ impl MultiBuffer {
         });
     }
 
-    fn refresh_inverted_diff_snapshot(
-        &mut self,
-        diff: Entity<BufferDiff>,
-        main_buffer: Entity<language::Buffer>,
-        cx: &mut Context<Self>,
-    ) {
-        let base_text_buffer_id = diff.read(cx).base_text_buffer().read(cx).remote_id();
-        let main_buffer_snapshot = main_buffer.read(cx).snapshot();
-        let new_diff = DiffStateSnapshot {
-            diff: diff.read(cx).snapshot(cx),
-            main_buffer: Some(main_buffer_snapshot),
-        };
-        self.snapshot
-            .get_mut()
-            .diffs
-            .insert_or_replace(base_text_buffer_id, new_diff);
-    }
-
     fn inverted_buffer_diff_changed(
         &mut self,
         diff: Entity<BufferDiff>,
         main_buffer: Entity<language::Buffer>,
-        diff_change_range: Range<usize>,
+        diff_change_range: Option<Range<usize>>,
         cx: &mut Context<Self>,
     ) {
         self.sync_mut(cx);
@@ -2538,6 +2519,10 @@ impl MultiBuffer {
         snapshot
             .diffs
             .insert_or_replace(base_text_buffer_id, new_diff);
+
+        let Some(diff_change_range) = diff_change_range else {
+            return;
+        };
 
         let excerpt_edits = snapshot.excerpt_edits_for_diff_change(buffer_state, diff_change_range);
         let edits = Self::sync_diff_transforms(
@@ -2734,7 +2719,12 @@ impl MultiBuffer {
         let base_text_buffer_id = snapshot.remote_id();
         let diff_change_range = 0..snapshot.len();
         self.snapshot.get_mut().has_inverted_diff = true;
-        self.inverted_buffer_diff_changed(diff.clone(), main_buffer.clone(), diff_change_range, cx);
+        self.inverted_buffer_diff_changed(
+            diff.clone(),
+            main_buffer.clone(),
+            Some(diff_change_range),
+            cx,
+        );
         self.diffs.insert(
             base_text_buffer_id,
             DiffState::new_inverted(diff, main_buffer, cx),
@@ -7154,10 +7144,6 @@ impl MultiBufferSnapshot {
 
     pub fn diff_for_buffer_id(&self, buffer_id: BufferId) -> Option<&BufferDiffSnapshot> {
         self.diffs.get(&buffer_id).map(|diff| &diff.diff)
-    }
-
-    pub fn diff_state_for(&self, buffer_id: BufferId) -> Option<&DiffStateSnapshot> {
-        self.diffs.get(&buffer_id)
     }
 
     pub fn all_diff_hunks_expanded(&self) -> bool {

--- a/crates/multi_buffer/src/path_key.rs
+++ b/crates/multi_buffer/src/path_key.rs
@@ -188,7 +188,13 @@ impl MultiBuffer {
         direction: ExpandExcerptDirection,
         cx: &mut Context<Self>,
     ) {
-        let grouped = ids
+        let mut sorted_ids: Vec<ExcerptId> = ids.into_iter().collect();
+        sorted_ids.sort_by(|a, b| {
+            let path_a = self.paths_by_excerpt.get(a);
+            let path_b = self.paths_by_excerpt.get(b);
+            path_a.cmp(&path_b)
+        });
+        let grouped = sorted_ids
             .into_iter()
             .chunk_by(|id| self.paths_by_excerpt.get(id).cloned())
             .into_iter()


### PR DESCRIPTION
This PR adds a more rigorous test for the excerpt syncing logic in `SplittableEditor`, in preparation for refactoring that code, since we've had some bugs there.

The new test covers
- edits within the RHS multibuffer
- edits to the individual main buffers, not necessarily within the excerpt bounds of the split diff
- excerpt expansion
- excerpt removal
- excerpt recalculation based on diff hunk ranges

Bugs fixed:
- incorrect edit merging logic in `patches_for_range`
- `merge_excerpts` leaving stale excerpt IDs in `excerpts_by_path`

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [ ] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- N/A