### PR TITLE
git_graph: Add button to open up the commit view

### DIFF
--- a/crates/git_graph/src/git_graph.rs
+++ b/crates/git_graph/src/git_graph.rs
@@ -1560,6 +1560,17 @@ impl GitGraph {
                             .vertical_scrollbar_for(&self.changed_files_scroll_handle, window, cx),
                     ),
             )
+            .child(Divider::horizontal())
+            .child(
+                h_flex().p_1p5().w_full().child(
+                    Button::new("view-commit", "View Commit")
+                        .full_width()
+                        .style(ButtonStyle::Outlined)
+                        .on_click(cx.listener(|this, _, window, cx| {
+                            this.open_selected_commit_view(window, cx);
+                        })),
+                ),
+            )
             .into_any_element()
     }
 


### PR DESCRIPTION
This PR adds a button at the bottom of the commit details panel to quickly open the commit view:

<img width="500" height="806" alt="Screenshot 2026-02-23 at 2  22@2x" src="https://github.com/user-attachments/assets/770234b2-a46d-4595-9f9e-7af7eeac73be" />

---

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- N/A
