### PR TITLE
Respect `ZDOTDIR` environment variable iff set

### DIFF
--- a/script/cargo
+++ b/script/cargo
@@ -53,7 +53,7 @@ function getShellConfigPath(shell) {
   const home = os.homedir();
   switch (shell) {
     case "zsh":
-      return path.join(home, ".zshrc");
+      return path.join(process.env.ZDOTDIR || home, ".zshrc");
     case "bash":
       // Prefer .bashrc, fall back to .bash_profile
       const bashrc = path.join(home, ".bashrc");


### PR DESCRIPTION
When `ZDOTDIR` is set, `zsh` reads its configuration from that directory instead of the user’s `$HOME` directory.

| Setup | `ZDOTDIR` set? | Script writes to | Zsh reads from | Match? |
|---|---|---|---|---|
| XDG + `ZDOTDIR` | ✅ | `$ZDOTDIR/.zshrc` | `$ZDOTDIR/.zshrc` | ✅ |
| XDG without `ZDOTDIR` | ❌ | `$HOME/.zshrc` | `$HOME/.zshrc` | ✅ |
| No XDG at all | ❌ | `$HOME/.zshrc` | `$HOME/.zshrc` | ✅ |


Ref: https://zsh.sourceforge.io/Intro/intro_3.html

Release Notes:

- N/A
