### PR TITLE
docs_preprocessor: Skip keymap validation when actions are unavailable

### DIFF
--- a/crates/docs_preprocessor/src/main.rs
+++ b/crates/docs_preprocessor/src/main.rs
@@ -295,10 +295,16 @@ fn template_and_validate_json_snippets(book: &mut Book, errors: &mut HashSet<Pre
     let settings_validator = jsonschema::validator_for(&settings_schema)
         .expect("failed to compile settings JSON schema");
 
-    let keymap_schema =
-        keymap_schema_for_actions(&ALL_ACTIONS.actions, &ALL_ACTIONS.schema_definitions);
-    let keymap_validator =
-        jsonschema::validator_for(&keymap_schema).expect("failed to compile keymap JSON schema");
+    let keymap_validator = if actions_available() {
+        let keymap_schema =
+            keymap_schema_for_actions(&ALL_ACTIONS.actions, &ALL_ACTIONS.schema_definitions);
+        Some(
+            jsonschema::validator_for(&keymap_schema)
+                .expect("failed to compile keymap JSON schema"),
+        )
+    } else {
+        None
+    };
 
     fn for_each_labeled_code_block_mut(
         book: &mut Book,
@@ -404,14 +410,17 @@ fn template_and_validate_json_snippets(book: &mut Book, errors: &mut HashSet<Pre
                     snippet_json_fixed.push_str("\n]");
                 }
 
-                let value =
-                    settings::parse_json_with_comments::<serde_json::Value>(&snippet_json_fixed)?;
-                let validation_errors: Vec<String> = keymap_validator
-                    .iter_errors(&value)
-                    .map(|err| err.to_string())
-                    .collect();
-                if !validation_errors.is_empty() {
-                    anyhow::bail!("{}", validation_errors.join("\n"));
+                if let Some(keymap_validator) = &keymap_validator {
+                    let value = settings::parse_json_with_comments::<serde_json::Value>(
+                        &snippet_json_fixed,
+                    )?;
+                    let validation_errors: Vec<String> = keymap_validator
+                        .iter_errors(&value)
+                        .map(|err| err.to_string())
+                        .collect();
+                    if !validation_errors.is_empty() {
+                        anyhow::bail!("{}", validation_errors.join("\n"));
+                    }
                 }
             }
             "debug" => {


### PR DESCRIPTION
When actions are not compiled in, skip keymap schema validation instead of panicking. This allows the docs preprocessor to run in environments where action metadata is not available.

Closes #49919.

Release Notes:

- N/A
