### PR TITLE
vim: Bring highlight behavior inline with editor

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -390,7 +390,7 @@
   {
     "context": "(vim_mode == normal || vim_mode == helix_normal) && !menu",
     "bindings": {
-      "escape": "vim::Cancel",
+      "escape": "editor::Cancel",
       "shift-d": "vim::DeleteToEndOfLine",
       "shift-j": "vim::JoinLines",
       "shift-y": "vim::YankLine",

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -390,7 +390,7 @@
   {
     "context": "(vim_mode == normal || vim_mode == helix_normal) && !menu",
     "bindings": {
-      "escape": "editor::Cancel",
+      "escape": "vim::Cancel",
       "shift-d": "vim::DeleteToEndOfLine",
       "shift-j": "vim::JoinLines",
       "shift-y": "vim::YankLine",

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -86,7 +86,6 @@ pub struct BufferSearchBar {
     configured_options: SearchOptions,
     query_error: Option<String>,
     dismissed: bool,
-    cancel_suppressed: bool,
     search_history: SearchHistory,
     search_history_cursor: SearchHistoryCursor,
     replace_enabled: bool,
@@ -881,7 +880,6 @@ impl BufferSearchBar {
             pending_search: None,
             query_error: None,
             dismissed: true,
-            cancel_suppressed: false,
             search_history: SearchHistory::new(
                 Some(MAX_BUFFER_SEARCH_HISTORY_SIZE),
                 project::search_history::QueryInsertionBehavior::ReplacePreviousIfContains,
@@ -901,17 +899,25 @@ impl BufferSearchBar {
         self.dismissed
     }
 
-    pub fn set_cancel_suppressed(&mut self, suppressed: bool) {
-        self.cancel_suppressed = suppressed;
+    pub fn dismiss(&mut self, _: &Dismiss, window: &mut Window, cx: &mut Context<Self>) {
+        self.dismiss_inner(false, window, cx);
     }
 
-    pub fn dismiss(&mut self, _: &Dismiss, window: &mut Window, cx: &mut Context<Self>) {
+    pub fn dismiss_preserving_highlights(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.dismiss_inner(true, window, cx);
+    }
+
+    fn dismiss_inner(&mut self, preserve_highlights: bool, window: &mut Window, cx: &mut Context<Self>) {
         self.dismissed = true;
         cx.emit(Event::Dismissed);
         self.query_error = None;
         self.sync_select_next_case_sensitivity(cx);
 
-        if !self.cancel_suppressed {
+        if !preserve_highlights {
             for searchable_item in self.searchable_items_with_matches.keys() {
                 if let Some(searchable_item) =
                     WeakSearchableItemHandle::upgrade(searchable_item.as_ref(), cx)
@@ -920,7 +926,6 @@ impl BufferSearchBar {
                 }
             }
         }
-        self.cancel_suppressed = false;
 
         let needs_collapse_expand = self.needs_expand_collapse_option(cx);
 
@@ -946,6 +951,16 @@ impl BufferSearchBar {
             ToolbarItemLocation::Hidden,
         ));
         cx.notify();
+    }
+
+    pub fn clear_all_matches(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        for searchable_item in self.searchable_items_with_matches.keys() {
+            if let Some(searchable_item) =
+                WeakSearchableItemHandle::upgrade(searchable_item.as_ref(), cx)
+            {
+                searchable_item.clear_matches(window, cx);
+            }
+        }
     }
 
     pub fn deploy(&mut self, deploy: &Deploy, window: &mut Window, cx: &mut Context<Self>) -> bool {

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -86,6 +86,7 @@ pub struct BufferSearchBar {
     configured_options: SearchOptions,
     query_error: Option<String>,
     dismissed: bool,
+    cancel_suppressed: bool,
     search_history: SearchHistory,
     search_history_cursor: SearchHistoryCursor,
     replace_enabled: bool,
@@ -880,6 +881,7 @@ impl BufferSearchBar {
             pending_search: None,
             query_error: None,
             dismissed: true,
+            cancel_suppressed: false,
             search_history: SearchHistory::new(
                 Some(MAX_BUFFER_SEARCH_HISTORY_SIZE),
                 project::search_history::QueryInsertionBehavior::ReplacePreviousIfContains,
@@ -899,19 +901,26 @@ impl BufferSearchBar {
         self.dismissed
     }
 
+    pub fn set_cancel_suppressed(&mut self, suppressed: bool) {
+        self.cancel_suppressed = suppressed;
+    }
+
     pub fn dismiss(&mut self, _: &Dismiss, window: &mut Window, cx: &mut Context<Self>) {
         self.dismissed = true;
         cx.emit(Event::Dismissed);
         self.query_error = None;
         self.sync_select_next_case_sensitivity(cx);
 
-        for searchable_item in self.searchable_items_with_matches.keys() {
-            if let Some(searchable_item) =
-                WeakSearchableItemHandle::upgrade(searchable_item.as_ref(), cx)
-            {
-                searchable_item.clear_matches(window, cx);
+        if !self.cancel_suppressed {
+            for searchable_item in self.searchable_items_with_matches.keys() {
+                if let Some(searchable_item) =
+                    WeakSearchableItemHandle::upgrade(searchable_item.as_ref(), cx)
+                {
+                    searchable_item.clear_matches(window, cx);
+                }
             }
         }
+        self.cancel_suppressed = false;
 
         let needs_collapse_expand = self.needs_expand_collapse_option(cx);
 

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -903,28 +903,23 @@ impl BufferSearchBar {
         self.dismiss_inner(false, window, cx);
     }
 
-    pub fn dismiss_preserving_highlights(
-        &mut self,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) {
+    pub fn dismiss_preserving_highlights(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         self.dismiss_inner(true, window, cx);
     }
 
-    fn dismiss_inner(&mut self, preserve_highlights: bool, window: &mut Window, cx: &mut Context<Self>) {
+    fn dismiss_inner(
+        &mut self,
+        preserve_highlights: bool,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         self.dismissed = true;
         cx.emit(Event::Dismissed);
         self.query_error = None;
         self.sync_select_next_case_sensitivity(cx);
 
         if !preserve_highlights {
-            for searchable_item in self.searchable_items_with_matches.keys() {
-                if let Some(searchable_item) =
-                    WeakSearchableItemHandle::upgrade(searchable_item.as_ref(), cx)
-                {
-                    searchable_item.clear_matches(window, cx);
-                }
-            }
+            self.clear_all_matches(window, cx);
         }
 
         let needs_collapse_expand = self.needs_expand_collapse_option(cx);

--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -757,7 +757,7 @@ mod test {
 
     use indoc::indoc;
     use search::BufferSearchBar;
-    use settings::SettingsStore;
+    use settings::{KeymapFile, SettingsStore};
 
     #[gpui::test]
     async fn test_move_to_next(cx: &mut gpui::TestAppContext) {
@@ -1325,6 +1325,19 @@ mod test {
     #[gpui::test]
     async fn test_star_does_not_clear_highlights_on_escape(cx: &mut gpui::TestAppContext) {
         let mut cx = VimTestContext::new(cx, true).await;
+        cx.update(|_, cx| {
+            cx.bind_keys(KeymapFile::load_panic_on_failure(
+                r#"[
+                    {
+                        "context": "(vim_mode == normal || vim_mode == helix_normal) && !menu",
+                        "bindings": {
+                            "escape": "vim::Cancel"
+                        }
+                    }
+                ]"#,
+                cx,
+            ));
+        });
         cx.set_state("ˇhi\nhigh\nhi\n", Mode::Normal);
 
         cx.simulate_keystrokes("*");

--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -1353,6 +1353,17 @@ mod test {
         cx.simulate_keystrokes("escape");
         cx.run_until_parked();
 
+        cx.workspace(|workspace, _, cx| {
+            let search_bar = workspace
+                .active_pane()
+                .read(cx)
+                .toolbar()
+                .read(cx)
+                .item_of_type::<BufferSearchBar>()
+                .expect("buffer search bar should exist");
+            assert!(search_bar.read(cx).is_dismissed(), "search bar should be dismissed after first ESC");
+        });
+
         cx.update_editor(|editor, window, cx| {
             let highlights = editor.all_text_background_highlights(window, cx);
             assert!(!highlights.is_empty(), "highlights should persist after ESC");
@@ -1361,6 +1372,17 @@ mod test {
         // Second ESC should clear previously retained highlights.
         cx.simulate_keystrokes("escape");
         cx.run_until_parked();
+
+        cx.workspace(|workspace, _, cx| {
+            let search_bar = workspace
+                .active_pane()
+                .read(cx)
+                .toolbar()
+                .read(cx)
+                .item_of_type::<BufferSearchBar>()
+                .expect("buffer search bar should exist");
+            assert!(search_bar.read(cx).is_dismissed(), "search bar should remain dismissed after second ESC");
+        });
 
         cx.update_editor(|editor, window, cx| {
             let highlights = editor.all_text_background_highlights(window, cx);

--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -757,7 +757,7 @@ mod test {
 
     use indoc::indoc;
     use search::BufferSearchBar;
-    use settings::{KeymapFile, SettingsStore};
+    use settings::SettingsStore;
 
     #[gpui::test]
     async fn test_move_to_next(cx: &mut gpui::TestAppContext) {
@@ -1325,19 +1325,6 @@ mod test {
     #[gpui::test]
     async fn test_star_does_not_clear_highlights_on_escape(cx: &mut gpui::TestAppContext) {
         let mut cx = VimTestContext::new(cx, true).await;
-        cx.update(|_, cx| {
-            cx.bind_keys(KeymapFile::load_panic_on_failure(
-                r#"[
-                    {
-                        "context": "(vim_mode == normal || vim_mode == helix_normal) && !menu",
-                        "bindings": {
-                            "escape": "vim::Cancel"
-                        }
-                    }
-                ]"#,
-                cx,
-            ));
-        });
         cx.set_state("ˇhi\nhigh\nhi\n", Mode::Normal);
 
         cx.simulate_keystrokes("*");
@@ -1349,7 +1336,7 @@ mod test {
             assert!(!highlights.is_empty(), "highlights should exist after *");
         });
 
-        // ESC via vim::Cancel: bar dismisses, highlights persist
+        // First ESC: search bar dismisses but highlights persist.
         cx.simulate_keystrokes("escape");
         cx.run_until_parked();
 
@@ -1366,10 +1353,10 @@ mod test {
 
         cx.update_editor(|editor, window, cx| {
             let highlights = editor.all_text_background_highlights(window, cx);
-            assert!(!highlights.is_empty(), "highlights should persist after ESC");
+            assert!(!highlights.is_empty(), "highlights should persist after first ESC");
         });
 
-        // Second ESC should clear previously retained highlights.
+        // Second ESC clears the remaining highlights.
         cx.simulate_keystrokes("escape");
         cx.run_until_parked();
 

--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -1344,6 +1344,18 @@ mod test {
             let highlights = editor.all_text_background_highlights(window, cx);
             assert!(!highlights.is_empty(), "highlights should persist after ESC");
         });
+
+        // Second ESC should clear previously retained highlights.
+        cx.simulate_keystrokes("escape");
+        cx.run_until_parked();
+
+        cx.update_editor(|editor, window, cx| {
+            let highlights = editor.all_text_background_highlights(window, cx);
+            assert!(
+                highlights.is_empty(),
+                "highlights should clear after second ESC"
+            );
+        });
     }
 
     #[gpui::test]

--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -1323,6 +1323,30 @@ mod test {
     }
 
     #[gpui::test]
+    async fn test_star_does_not_clear_highlights_on_escape(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+        cx.set_state("ˇhi\nhigh\nhi\n", Mode::Normal);
+
+        cx.simulate_keystrokes("*");
+        cx.run_until_parked();
+        cx.assert_state("hi\nhigh\nˇhi\n", Mode::Normal);
+
+        cx.update_editor(|editor, window, cx| {
+            let highlights = editor.all_text_background_highlights(window, cx);
+            assert!(!highlights.is_empty(), "highlights should exist after *");
+        });
+
+        // ESC via vim::Cancel: bar dismisses, highlights persist
+        cx.simulate_keystrokes("escape");
+        cx.run_until_parked();
+
+        cx.update_editor(|editor, window, cx| {
+            let highlights = editor.all_text_background_highlights(window, cx);
+            assert!(!highlights.is_empty(), "highlights should persist after ESC");
+        });
+    }
+
+    #[gpui::test]
     async fn test_search_dismiss_restores_cursor(cx: &mut gpui::TestAppContext) {
         let mut cx = VimTestContext::new(cx, true).await;
         cx.set_state("ˇhello world\nfoo bar\nhello again\n", Mode::Normal);

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -163,6 +163,8 @@ actions!(
     [
         /// Switches to normal mode.
         SwitchToNormalMode,
+        /// Cancels current operation, preserving search highlights (vim normal mode ESC behavior).
+        Cancel,
         /// Switches to insert mode.
         SwitchToInsertMode,
         /// Switches to replace mode.
@@ -684,6 +686,25 @@ impl Vim {
                     vim.switch_mode(Mode::HelixNormal, true, window, cx)
                 },
             );
+            Vim::action(editor, cx, |vim, _: &Cancel, window, cx| {
+                // Preserve search highlights: set flag before dispatching editor::Cancel.
+                // The flag causes dismiss() to skip clear_matches(), so the bar hides
+                // but highlights remain visible.
+                if let Some(pane) = vim.pane(window, cx) {
+                    pane.update(cx, |pane, cx| {
+                        if let Some(search_bar) =
+                            pane.toolbar().read(cx).item_of_type::<BufferSearchBar>()
+                        {
+                            if !search_bar.read(cx).is_dismissed() {
+                                search_bar.update(cx, |bar, _cx| {
+                                    bar.set_cancel_suppressed(true);
+                                });
+                            }
+                        }
+                    });
+                }
+                window.dispatch_action(editor::actions::Cancel.boxed_clone(), cx);
+            });
             Vim::action(editor, cx, |_, _: &PushForcedMotion, _, cx| {
                 Vim::globals(cx).forced_motion = true;
             });

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -42,7 +42,7 @@ use multi_buffer::ToPoint as _;
 use normal::search::SearchSubmit;
 use object::Object;
 use schemars::JsonSchema;
-use search::BufferSearchBar;
+use search::{BufferSearchBar, buffer_search::Dismiss as BufferSearchDismiss};
 use serde::Deserialize;
 use settings::RegisterSetting;
 pub use settings::{
@@ -687,6 +687,7 @@ impl Vim {
                 },
             );
             Vim::action(editor, cx, |vim, _: &Cancel, window, cx| {
+                vim.clear_operator(window, cx);
                 // Preserve search highlights: set flag before dispatching editor::Cancel.
                 // The flag causes dismiss() to skip clear_matches(), so the bar hides
                 // but highlights remain visible.
@@ -695,11 +696,13 @@ impl Vim {
                         if let Some(search_bar) =
                             pane.toolbar().read(cx).item_of_type::<BufferSearchBar>()
                         {
-                            if !search_bar.read(cx).is_dismissed() {
-                                search_bar.update(cx, |bar, _cx| {
+                            search_bar.update(cx, |bar, cx| {
+                                if bar.is_dismissed() {
+                                    bar.dismiss(&BufferSearchDismiss, window, cx);
+                                } else {
                                     bar.set_cancel_suppressed(true);
-                                });
-                            }
+                                }
+                            });
                         }
                     });
                 }

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -42,7 +42,7 @@ use multi_buffer::ToPoint as _;
 use normal::search::SearchSubmit;
 use object::Object;
 use schemars::JsonSchema;
-use search::{BufferSearchBar, buffer_search::Dismiss as BufferSearchDismiss};
+use search::BufferSearchBar;
 use serde::Deserialize;
 use settings::RegisterSetting;
 pub use settings::{
@@ -163,8 +163,6 @@ actions!(
     [
         /// Switches to normal mode.
         SwitchToNormalMode,
-        /// Cancels current operation, preserving search highlights (vim normal mode ESC behavior).
-        Cancel,
         /// Switches to insert mode.
         SwitchToInsertMode,
         /// Switches to replace mode.
@@ -686,11 +684,8 @@ impl Vim {
                     vim.switch_mode(Mode::HelixNormal, true, window, cx)
                 },
             );
-            Vim::action(editor, cx, |vim, _: &Cancel, window, cx| {
+            Vim::action(editor, cx, |vim, _: &editor::actions::Cancel, window, cx| {
                 vim.clear_operator(window, cx);
-                // Preserve search highlights: set flag before dispatching editor::Cancel.
-                // The flag causes dismiss() to skip clear_matches(), so the bar hides
-                // but highlights remain visible.
                 if let Some(pane) = vim.pane(window, cx) {
                     pane.update(cx, |pane, cx| {
                         if let Some(search_bar) =
@@ -698,15 +693,15 @@ impl Vim {
                         {
                             search_bar.update(cx, |bar, cx| {
                                 if bar.is_dismissed() {
-                                    bar.dismiss(&BufferSearchDismiss, window, cx);
+                                    bar.clear_all_matches(window, cx);
                                 } else {
-                                    bar.set_cancel_suppressed(true);
+                                    bar.dismiss_preserving_highlights(window, cx);
                                 }
                             });
                         }
                     });
                 }
-                window.dispatch_action(editor::actions::Cancel.boxed_clone(), cx);
+                cx.propagate();
             });
             Vim::action(editor, cx, |_, _: &PushForcedMotion, _, cx| {
                 Vim::globals(cx).forced_motion = true;


### PR DESCRIPTION
Closes #34793

I implemented the behavior described in #48114 
 https://github.com/zed-industries/zed/pull/48114#pullrequestreview-3739224174

## Summary
- Added a new option to the vim keymap, 
```
{
    "context": "(vim_mode == normal || vim_mode == helix_normal) && !menu",
    "bindings": {
      "escape": "editor::Cancel", --> "escape": "vim::Cancel",
      ...,
      }
}
```
This is not enabled by default however if you enable it you get:
  - Keep highlights after first `escape` in normal mode
  - Clear retained highlights on second `escape`

## Testing
I manually verified all behaviors described, that is:
default behavior is left unchanged, which is described as a bug in #34793 but later decided to be the correct UX decision due to users already being used to how it functions.
With the new vim::Cancel option set, pressing esc w/ text highlighted will only close the search and replace bar, leaving text highlighted, then a second esc press will clear the highlight.

Also added a Vim test (Not Neovim backend) that tests the new functionality.

Video: 

https://github.com/user-attachments/assets/8718d531-4f78-4c08-9c39-b29f2fcc8a07

description: I type 'hi' on 3 lines, then select with '*', highlighting all 3 'hi''s and bringing up the find and replace menu. Next, I press 'esc' which is bound to `vim::Cancel` thus removing the find and replace menu, while highlights remain. I press 'esc' again removing the highlight.

---

Release Notes:

- added `vim::Cancel` option that allows users to preserve highlights until triggered a second time, when it will clear the highlights. This brings the UX more inline with vim and Zed's normal editor.
