### PR TITLE
Fix panic in breadcrumbs

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -7835,7 +7835,7 @@ pub fn render_breadcrumb_text(
             return styled_element;
         }
 
-        StyledText::new(segment.text.replace('\n', "⏎"))
+        StyledText::new(segment.text.replace('\n', " "))
             .with_default_highlights(&text_style, segment.highlights.unwrap_or_default())
             .into_any()
     });


### PR DESCRIPTION
The hypothesis is that some language's tree-sitter queries can return tokens containing newlines; though we weren't able to reproduce easily in a test.

Before you mark this PR as ready for review, make sure that you have:
- [ ] Added a solid test coverage and/or screenshots from doing manual testing
- [ ] Done a self-review taking into account security and performance aspects
- [ ] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Fixes https://zed-dev.sentry.io/issues/7286512714/?project=4509715135987712&query=is%3Aunresolved&referrer=issue-stream

Release Notes:

- Fix (rare) panic when breadcrumbs contain newlines (hopefully)
