### PR TITLE
Fix handling of excerpt regions in EP CLI

### DIFF
--- a/crates/edit_prediction_cli/src/example.rs
+++ b/crates/edit_prediction_cli/src/example.rs
@@ -15,9 +15,8 @@ use std::{
     collections::VecDeque,
     io::Read,
     path::{Path, PathBuf},
-    sync::Arc,
 };
-use zeta_prompt::RelatedFile;
+use zeta_prompt::ZetaPromptInput;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Example {
@@ -27,7 +26,7 @@ pub struct Example {
     /// The full content of the file where an edit is being predicted, and the
     /// actual cursor offset.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub prompt_inputs: Option<ExamplePromptInputs>,
+    pub prompt_inputs: Option<ZetaPromptInput>,
 
     /// The input and expected output from the edit prediction model.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -57,18 +56,6 @@ pub struct ExampleState {
     pub buffer: Entity<Buffer>,
     pub cursor_position: Anchor,
     pub _open_buffers: OpenedBuffers,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct ExamplePromptInputs {
-    pub content: String,
-    pub cursor_row: u32,
-    pub cursor_column: u32,
-    pub cursor_offset: usize,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub excerpt_start_row: Option<u32>,
-    pub edit_history: Vec<Arc<zeta_prompt::Event>>,
-    pub related_files: Option<Vec<RelatedFile>>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/edit_prediction_cli/src/example.rs
+++ b/crates/edit_prediction_cli/src/example.rs
@@ -45,6 +45,9 @@ pub struct Example {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub qa: Vec<Option<QaResult>>,
 
+    /// The Zed version used to generate this example.
+    pub zed_version: Option<String>,
+
     /// The application state used to process this example.
     #[serde(skip)]
     pub state: Option<ExampleState>,
@@ -327,5 +330,6 @@ fn parse_markdown_example(input: &str) -> Result<Example> {
         score: Vec::new(),
         qa: Vec::new(),
         state: None,
+        zed_version: None,
     })
 }

--- a/crates/edit_prediction_cli/src/main.rs
+++ b/crates/edit_prediction_cli/src/main.rs
@@ -684,21 +684,6 @@ async fn load_examples(
     } else {
         let max_rows_per_timestamp = remaining_limit_for_snowflake.unwrap_or(5000);
 
-        if !captured_after_timestamps.is_empty() {
-            captured_after_timestamps.sort();
-
-            let mut captured_examples = pull_examples::fetch_captured_examples_after(
-                http_client.clone(),
-                &captured_after_timestamps,
-                max_rows_per_timestamp,
-                remaining_offset,
-                background_executor.clone(),
-                Some(MIN_CAPTURE_VERSION),
-            )
-            .await?;
-            examples.append(&mut captured_examples);
-        }
-
         if !rejected_after_timestamps.is_empty() {
             rejected_after_timestamps.sort();
 

--- a/crates/edit_prediction_cli/src/parse_output.rs
+++ b/crates/edit_prediction_cli/src/parse_output.rs
@@ -133,20 +133,18 @@ fn parse_zeta2_output(
     }
 
     let old_text_trimmed = old_text.trim_end_matches('\n');
-    let (editable_region_offset, _) = prompt_inputs
-        .content
+    let excerpt = prompt_inputs.cursor_excerpt.as_ref();
+    let (editable_region_offset, _) = excerpt
         .match_indices(old_text_trimmed)
-        .min_by_key(|(index, _)| index.abs_diff(prompt_inputs.cursor_offset))
+        .min_by_key(|(index, _)| index.abs_diff(prompt_inputs.cursor_offset_in_excerpt))
         .with_context(|| {
             format!(
                 "could not find editable region in content.\nLooking for:\n{}\n\nIn content:\n{}",
-                old_text_trimmed, &prompt_inputs.content
+                old_text_trimmed, excerpt
             )
         })?;
 
-    let editable_region_start_line = prompt_inputs.content[..editable_region_offset]
-        .matches('\n')
-        .count();
+    let editable_region_start_line = excerpt[..editable_region_offset].matches('\n').count();
 
     // Use full context so cursor offset (relative to editable region start) aligns with diff content
     let editable_region_lines = old_text_normalized.lines().count() as u32;
@@ -170,7 +168,7 @@ fn parse_zeta2_output(
             &example.spec.cursor_path,
             editable_region_cursor_offset,
             &new_text,
-            &prompt_inputs.content,
+            excerpt,
             editable_region_offset,
             editable_region_start_line,
         )

--- a/crates/edit_prediction_cli/src/predict.rs
+++ b/crates/edit_prediction_cli/src/predict.rs
@@ -53,11 +53,10 @@ pub async fn run_prediction(
         );
     };
 
-    run_context_retrieval(example, app_state.clone(), example_progress, cx.clone()).await?;
-
     if let PredictionProvider::Teacher(backend) | PredictionProvider::TeacherNonBatching(backend) =
         provider
     {
+        run_context_retrieval(example, app_state.clone(), example_progress, cx.clone()).await?;
         run_format_prompt(
             example,
             &FormatPromptArgs { provider },
@@ -81,6 +80,7 @@ pub async fn run_prediction(
     }
 
     run_load_project(example, app_state.clone(), example_progress, cx.clone()).await?;
+    run_context_retrieval(example, app_state.clone(), example_progress, cx.clone()).await?;
 
     let step_progress = example_progress.start(Step::Predict);
 

--- a/crates/edit_prediction_cli/src/pull_examples.rs
+++ b/crates/edit_prediction_cli/src/pull_examples.rs
@@ -20,7 +20,6 @@ use std::fmt::Write as _;
 
 pub(crate) const SNOWFLAKE_SUCCESS_CODE: &str = "090001";
 pub(crate) const SNOWFLAKE_ASYNC_IN_PROGRESS_CODE: &str = "333334";
-const EDIT_PREDICTION_EXAMPLE_CAPTURED_EVENT: &str = "Edit Prediction Example Captured";
 const PREDICTIVE_EDIT_REQUESTED_EVENT: &str = "Predictive Edit Requested";
 const PREDICTIVE_EDIT_REJECTED_EVENT: &str = "Predictive Edit Rejected";
 const EDIT_PREDICTION_RATED_EVENT: &str = "Edit Prediction Rated";
@@ -37,19 +36,6 @@ pub struct MinCaptureVersion {
 const DEFAULT_STATEMENT_TIMEOUT_SECONDS: u64 = 120;
 pub(crate) const POLL_INTERVAL: Duration = Duration::from_secs(2);
 pub(crate) const MAX_POLL_ATTEMPTS: usize = 120;
-
-/// Earliest date where `can_collect_data` can be true in production telemetry.
-/// Queries that filter on `can_collect_data = true` clamp their start time to
-/// at least this value so Snowflake doesn't scan months of irrelevant data.
-const CAN_COLLECT_DATA_FLOOR: &str = "2026-02-18T00:00:00Z";
-
-fn clamp_after_date<'a>(after_date: &'a str) -> &'a str {
-    if after_date < CAN_COLLECT_DATA_FLOOR {
-        CAN_COLLECT_DATA_FLOOR
-    } else {
-        after_date
-    }
-}
 
 /// Parse an input token of the form `captured-after:{timestamp}`.
 pub fn parse_captured_after_input(input: &str) -> Option<&str> {
@@ -79,137 +65,6 @@ pub fn parse_rated_after_input(input: &str) -> Option<(&str, Option<EditPredicti
     } else {
         None
     }
-}
-
-pub async fn fetch_captured_examples_after(
-    http_client: Arc<dyn HttpClient>,
-    after_timestamps: &[String],
-    max_rows_per_timestamp: usize,
-    offset: usize,
-    background_executor: BackgroundExecutor,
-    _min_capture_version: Option<MinCaptureVersion>,
-) -> Result<Vec<Example>> {
-    if after_timestamps.is_empty() {
-        return Ok(Vec::new());
-    }
-
-    let progress = Progress::global();
-
-    let token = std::env::var("EP_SNOWFLAKE_API_KEY")
-        .context("missing required environment variable EP_SNOWFLAKE_API_KEY")?;
-    let base_url = std::env::var("EP_SNOWFLAKE_BASE_URL").context(
-        "missing required environment variable EP_SNOWFLAKE_BASE_URL (e.g. https://<account>.snowflakecomputing.com)",
-    )?;
-    let role = std::env::var("EP_SNOWFLAKE_ROLE").ok();
-
-    let mut all_examples = Vec::new();
-
-    for after_date in after_timestamps.iter() {
-        let step_progress_name = format!(">{after_date}");
-        let step_progress = progress.start(Step::PullExamples, &step_progress_name);
-        step_progress.set_substatus("querying");
-
-        let clamped_after_date = clamp_after_date(after_date);
-
-        let statement = indoc! {r#"
-            SELECT
-                event_properties:example AS example
-            FROM events
-            WHERE event_type = ?
-                AND time > TRY_TO_TIMESTAMP_NTZ(?)
-                AND event_properties:can_collect_data = true
-            ORDER BY time ASC
-            LIMIT ?
-            OFFSET ?
-        "#};
-
-        let request = json!({
-            "statement": statement,
-            "timeout": DEFAULT_STATEMENT_TIMEOUT_SECONDS,
-            "database": "EVENTS",
-            "schema": "PUBLIC",
-            "warehouse": "DBT",
-            "role": role,
-            "bindings": {
-                "1": { "type": "TEXT", "value": EDIT_PREDICTION_EXAMPLE_CAPTURED_EVENT },
-                "2": { "type": "TEXT", "value": clamped_after_date },
-                "3": { "type": "FIXED", "value": max_rows_per_timestamp.to_string() },
-                "4": { "type": "FIXED", "value": offset.to_string() }
-            }
-        });
-
-        let response = run_sql_with_polling(
-            http_client.clone(),
-            &base_url,
-            &token,
-            &request,
-            &step_progress,
-            background_executor.clone(),
-        )
-        .await?;
-
-        let total_rows = response
-            .result_set_meta_data
-            .as_ref()
-            .and_then(|m| m.num_rows)
-            .unwrap_or(response.data.len() as i64);
-
-        let num_partitions = response
-            .result_set_meta_data
-            .as_ref()
-            .map(|m| m.partition_info.len())
-            .unwrap_or(1)
-            .max(1);
-
-        step_progress.set_info(format!("{} rows", total_rows), InfoStyle::Normal);
-        step_progress.set_substatus("parsing");
-
-        let example_index = response
-            .result_set_meta_data
-            .as_ref()
-            .and_then(|m| {
-                m.row_type.iter().enumerate().find_map(|(index, col)| {
-                    if col.name.eq_ignore_ascii_case("example") {
-                        Some(index)
-                    } else {
-                        None
-                    }
-                })
-            })
-            .unwrap_or(0);
-
-        all_examples.extend(examples_from_response(&response, example_index)?);
-
-        if num_partitions > 1 {
-            let statement_handle = response
-                .statement_handle
-                .as_ref()
-                .context("response has multiple partitions but no statementHandle")?;
-
-            for partition in 1..num_partitions {
-                step_progress.set_substatus(format!(
-                    "fetching partition {}/{}",
-                    partition + 1,
-                    num_partitions
-                ));
-
-                let partition_response = fetch_partition(
-                    http_client.clone(),
-                    &base_url,
-                    &token,
-                    statement_handle,
-                    partition,
-                )
-                .await?;
-
-                all_examples.extend(examples_from_response(&partition_response, example_index)?);
-            }
-        }
-
-        step_progress.set_substatus("done");
-    }
-
-    Ok(all_examples)
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -246,56 +101,6 @@ struct SnowflakePartitionInfo {}
 struct SnowflakeColumnMeta {
     #[serde(default)]
     name: String,
-}
-
-fn examples_from_response(
-    response: &SnowflakeStatementResponse,
-    example_index: usize,
-) -> Result<impl Iterator<Item = Example> + '_> {
-    if let Some(code) = &response.code {
-        if code != SNOWFLAKE_SUCCESS_CODE {
-            anyhow::bail!(
-                "snowflake sql api returned error code={code} message={}",
-                response.message.as_deref().unwrap_or("<no message>")
-            );
-        }
-    }
-
-    let iter = response.data.iter().enumerate().filter_map(move |(row_index, data_row)| {
-        let Some(example_value) = data_row.get(example_index) else {
-            return None;
-        };
-        if example_value.is_null() {
-            return None;
-        }
-
-        let parse_result = match example_value {
-            JsonValue::String(encoded_json) => serde_json::from_str::<ExampleSpec>(encoded_json),
-            _ => serde_json::from_value::<ExampleSpec>(example_value.clone()),
-        };
-
-        match parse_result {
-            Ok(spec) => Some(Example {
-                spec,
-                prompt_inputs: None,
-                prompt: None,
-                predictions: Vec::new(),
-                score: Vec::new(),
-                qa: Vec::new(),
-                state: None,
-            }),
-            Err(error) => {
-                let raw_json = serde_json::to_string_pretty(example_value)
-                    .unwrap_or_else(|_| "<failed to serialize json>".to_string());
-                log::error!(
-                    "failed to parse ExampleSpec for row {row_index}: {error:#}\nraw json:\n{raw_json}"
-                );
-                None
-            }
-        }
-    });
-
-    Ok(iter)
 }
 
 async fn run_sql_with_polling(
@@ -511,8 +316,6 @@ pub async fn fetch_rejected_examples_after(
         // We filter for V3 sampling data which contains the structured input we need.
         // We also filter for predictions that were actually shown to the user (was_shown = true)
         // to focus on explicit user rejections rather than implicit cancellations.
-        let clamped_after_date = clamp_after_date(after_date);
-
         let statement = indoc! {r#"
             SELECT
                 req.event_properties:request_id::string AS request_id,
@@ -559,7 +362,7 @@ pub async fn fetch_rejected_examples_after(
             "bindings": {
                 "1": { "type": "TEXT", "value": PREDICTIVE_EDIT_REQUESTED_EVENT },
                 "2": { "type": "TEXT", "value": PREDICTIVE_EDIT_REJECTED_EVENT },
-                "3": { "type": "TEXT", "value": clamped_after_date },
+                "3": { "type": "TEXT", "value": after_date },
                 "4": { "type": "FIXED", "value": min_minor_str_ref },
                 "5": { "type": "FIXED", "value": min_minor_str_ref },
                 "6": { "type": "FIXED", "value": min_minor_str_ref },
@@ -675,8 +478,6 @@ pub async fn fetch_requested_examples_after(
         let step_progress = progress.start(Step::PullExamples, &step_progress_name);
         step_progress.set_substatus("querying");
 
-        let clamped_after_date = clamp_after_date(after_date);
-
         let statement = indoc! {r#"
             SELECT
                 req.event_properties:request_id::string AS request_id,
@@ -714,7 +515,7 @@ pub async fn fetch_requested_examples_after(
             "role": role,
             "bindings": {
                 "1": { "type": "TEXT", "value": PREDICTIVE_EDIT_REQUESTED_EVENT },
-                "2": { "type": "TEXT", "value": clamped_after_date },
+                "2": { "type": "TEXT", "value": after_date },
                 "3": { "type": "FIXED", "value": min_minor_str_ref },
                 "4": { "type": "FIXED", "value": min_minor_str_ref },
                 "5": { "type": "FIXED", "value": min_minor_str_ref },
@@ -833,8 +634,6 @@ pub async fn fetch_rated_examples_after(
             EditPredictionRating::Negative => "Negative",
         });
 
-        let clamped_after_date = clamp_after_date(after_date);
-
         let statement = indoc! {r#"
             SELECT
                 rated.event_properties:request_id::string AS request_id,
@@ -873,7 +672,7 @@ pub async fn fetch_rated_examples_after(
             "3": { "type": "TEXT", "value": EDIT_PREDICTION_RATED_EVENT },
             "4": { "type": "TEXT", "value": rating_value },
             "5": { "type": "TEXT", "value": rating_value },
-            "6": { "type": "TEXT", "value": clamped_after_date },
+            "6": { "type": "TEXT", "value": after_date },
             "7": { "type": "FIXED", "value": max_rows_per_timestamp.to_string() },
             "8": { "type": "FIXED", "value": offset.to_string() }
         });
@@ -1322,7 +1121,7 @@ fn build_example_from_snowflake(
     input: ZetaPromptInput,
     tags: Vec<String>,
     rejection: Option<RejectionInfo>,
-    _zed_version: Option<String>,
+    zed_version: Option<String>,
 ) -> Example {
     let cursor_excerpt = input.cursor_excerpt.as_ref();
     let cursor_offset = input.cursor_offset_in_excerpt;
@@ -1363,6 +1162,7 @@ fn build_example_from_snowflake(
 
     Example {
         spec,
+        zed_version,
         prompt_inputs: Some(input),
         prompt: None,
         predictions: Vec::new(),

--- a/crates/edit_prediction_cli/src/pull_examples.rs
+++ b/crates/edit_prediction_cli/src/pull_examples.rs
@@ -15,10 +15,7 @@ use zeta_prompt::ZetaPromptInput;
 use crate::example::Example;
 use crate::progress::{InfoStyle, Progress, Step};
 const EDIT_PREDICTION_DEPLOYMENT_EVENT: &str = "Edit Prediction Deployment";
-use edit_prediction::example_spec::{
-    CapturedEvent, CapturedPromptInput, CapturedRelatedExcerpt, CapturedRelatedFile, ExampleSpec,
-    TelemetrySource,
-};
+use edit_prediction::example_spec::{ExampleSpec, TelemetrySource};
 use std::fmt::Write as _;
 
 pub(crate) const SNOWFLAKE_SUCCESS_CODE: &str = "090001";
@@ -40,6 +37,19 @@ pub struct MinCaptureVersion {
 const DEFAULT_STATEMENT_TIMEOUT_SECONDS: u64 = 120;
 pub(crate) const POLL_INTERVAL: Duration = Duration::from_secs(2);
 pub(crate) const MAX_POLL_ATTEMPTS: usize = 120;
+
+/// Earliest date where `can_collect_data` can be true in production telemetry.
+/// Queries that filter on `can_collect_data = true` clamp their start time to
+/// at least this value so Snowflake doesn't scan months of irrelevant data.
+const CAN_COLLECT_DATA_FLOOR: &str = "2026-02-18T00:00:00Z";
+
+fn clamp_after_date<'a>(after_date: &'a str) -> &'a str {
+    if after_date < CAN_COLLECT_DATA_FLOOR {
+        CAN_COLLECT_DATA_FLOOR
+    } else {
+        after_date
+    }
+}
 
 /// Parse an input token of the form `captured-after:{timestamp}`.
 pub fn parse_captured_after_input(input: &str) -> Option<&str> {
@@ -99,6 +109,8 @@ pub async fn fetch_captured_examples_after(
         let step_progress = progress.start(Step::PullExamples, &step_progress_name);
         step_progress.set_substatus("querying");
 
+        let clamped_after_date = clamp_after_date(after_date);
+
         let statement = indoc! {r#"
             SELECT
                 event_properties:example AS example
@@ -120,7 +132,7 @@ pub async fn fetch_captured_examples_after(
             "role": role,
             "bindings": {
                 "1": { "type": "TEXT", "value": EDIT_PREDICTION_EXAMPLE_CAPTURED_EVENT },
-                "2": { "type": "TEXT", "value": after_date },
+                "2": { "type": "TEXT", "value": clamped_after_date },
                 "3": { "type": "FIXED", "value": max_rows_per_timestamp.to_string() },
                 "4": { "type": "FIXED", "value": offset.to_string() }
             }
@@ -499,6 +511,8 @@ pub async fn fetch_rejected_examples_after(
         // We filter for V3 sampling data which contains the structured input we need.
         // We also filter for predictions that were actually shown to the user (was_shown = true)
         // to focus on explicit user rejections rather than implicit cancellations.
+        let clamped_after_date = clamp_after_date(after_date);
+
         let statement = indoc! {r#"
             SELECT
                 req.event_properties:request_id::string AS request_id,
@@ -545,7 +559,7 @@ pub async fn fetch_rejected_examples_after(
             "bindings": {
                 "1": { "type": "TEXT", "value": PREDICTIVE_EDIT_REQUESTED_EVENT },
                 "2": { "type": "TEXT", "value": PREDICTIVE_EDIT_REJECTED_EVENT },
-                "3": { "type": "TEXT", "value": after_date },
+                "3": { "type": "TEXT", "value": clamped_after_date },
                 "4": { "type": "FIXED", "value": min_minor_str_ref },
                 "5": { "type": "FIXED", "value": min_minor_str_ref },
                 "6": { "type": "FIXED", "value": min_minor_str_ref },
@@ -661,6 +675,8 @@ pub async fn fetch_requested_examples_after(
         let step_progress = progress.start(Step::PullExamples, &step_progress_name);
         step_progress.set_substatus("querying");
 
+        let clamped_after_date = clamp_after_date(after_date);
+
         let statement = indoc! {r#"
             SELECT
                 req.event_properties:request_id::string AS request_id,
@@ -698,7 +714,7 @@ pub async fn fetch_requested_examples_after(
             "role": role,
             "bindings": {
                 "1": { "type": "TEXT", "value": PREDICTIVE_EDIT_REQUESTED_EVENT },
-                "2": { "type": "TEXT", "value": after_date },
+                "2": { "type": "TEXT", "value": clamped_after_date },
                 "3": { "type": "FIXED", "value": min_minor_str_ref },
                 "4": { "type": "FIXED", "value": min_minor_str_ref },
                 "5": { "type": "FIXED", "value": min_minor_str_ref },
@@ -817,6 +833,8 @@ pub async fn fetch_rated_examples_after(
             EditPredictionRating::Negative => "Negative",
         });
 
+        let clamped_after_date = clamp_after_date(after_date);
+
         let statement = indoc! {r#"
             SELECT
                 rated.event_properties:request_id::string AS request_id,
@@ -855,7 +873,7 @@ pub async fn fetch_rated_examples_after(
             "3": { "type": "TEXT", "value": EDIT_PREDICTION_RATED_EVENT },
             "4": { "type": "TEXT", "value": rating_value },
             "5": { "type": "TEXT", "value": rating_value },
-            "6": { "type": "TEXT", "value": after_date },
+            "6": { "type": "TEXT", "value": clamped_after_date },
             "7": { "type": "FIXED", "value": max_rows_per_timestamp.to_string() },
             "8": { "type": "FIXED", "value": offset.to_string() }
         });
@@ -1304,49 +1322,10 @@ fn build_example_from_snowflake(
     input: ZetaPromptInput,
     tags: Vec<String>,
     rejection: Option<RejectionInfo>,
-    zed_version: Option<String>,
+    _zed_version: Option<String>,
 ) -> Example {
-    let events: Vec<CapturedEvent> = input
-        .events
-        .iter()
-        .map(|event| match event.as_ref() {
-            zeta_prompt::Event::BufferChange {
-                path,
-                old_path,
-                diff,
-                predicted,
-                in_open_source_repo,
-            } => CapturedEvent {
-                path: path.clone(),
-                old_path: old_path.clone(),
-                diff: diff.clone(),
-                predicted: *predicted,
-                in_open_source_repo: *in_open_source_repo,
-            },
-        })
-        .collect();
-
-    let related_files: Vec<CapturedRelatedFile> = input
-        .related_files
-        .iter()
-        .map(|rf| CapturedRelatedFile {
-            path: rf.path.clone(),
-            max_row: rf.max_row,
-            excerpts: rf
-                .excerpts
-                .iter()
-                .map(|e| CapturedRelatedExcerpt {
-                    row_range: e.row_range.clone(),
-                    text: e.text.to_string(),
-                })
-                .collect(),
-        })
-        .collect();
-
     let cursor_excerpt = input.cursor_excerpt.as_ref();
     let cursor_offset = input.cursor_offset_in_excerpt;
-
-    let (cursor_row, cursor_column) = compute_row_column(cursor_excerpt, cursor_offset);
 
     let mut edit_history = String::new();
     for event in &input.events {
@@ -1371,17 +1350,6 @@ fn build_example_from_snowflake(
         edit_history,
         expected_patches: Vec::new(),
         rejected_patch: None,
-        captured_prompt_input: Some(CapturedPromptInput {
-            cursor_file_content: cursor_excerpt.to_string(),
-            cursor_offset,
-            cursor_row,
-            cursor_column,
-            excerpt_start_row: None,
-            events,
-            related_files,
-            in_open_source_repo: input.in_open_source_repo,
-            zed_version,
-        }),
         telemetry: Some(TelemetrySource {
             request_id,
             device_id,
@@ -1395,29 +1363,13 @@ fn build_example_from_snowflake(
 
     Example {
         spec,
-        prompt_inputs: None,
+        prompt_inputs: Some(input),
         prompt: None,
         predictions: Vec::new(),
         score: Vec::new(),
         qa: Vec::new(),
         state: None,
     }
-}
-
-fn compute_row_column(text: &str, offset: usize) -> (u32, u32) {
-    let mut row = 0u32;
-    let mut last_newline_offset = 0;
-    for (i, c) in text.char_indices() {
-        if i >= offset {
-            break;
-        }
-        if c == '\n' {
-            row += 1;
-            last_newline_offset = i + 1;
-        }
-    }
-    let column = (offset - last_newline_offset) as u32;
-    (row, column)
 }
 
 fn build_cursor_position(excerpt: &str, cursor_offset: usize) -> String {

--- a/crates/edit_prediction_cli/src/qa.rs
+++ b/crates/edit_prediction_cli/src/qa.rs
@@ -82,22 +82,19 @@ pub fn build_prompt(example: &Example) -> Result<String> {
         extract_cursor_excerpt_from_example(example).context("failed to extract cursor excerpt")?;
 
     let mut edit_history = String::new();
-    for event in &prompt_inputs.edit_history {
-        match event.as_ref() {
-            zeta_prompt::Event::BufferChange {
-                path,
-                old_path,
-                diff,
-                predicted: _,
-                in_open_source_repo: _,
-            } => {
-                edit_history.push_str(&format!("--- a{}\n", old_path.display()));
-                edit_history.push_str(&format!("+++ b{}\n", path.display()));
-                let diff_word_diff = unified_to_word_diff(diff);
-                edit_history.push_str(&diff_word_diff);
-                edit_history.push_str("\n\n");
-            }
-        }
+    for event in &prompt_inputs.events {
+        let zeta_prompt::Event::BufferChange {
+            path,
+            old_path,
+            diff,
+            predicted: _,
+            in_open_source_repo: _,
+        } = event.as_ref();
+        edit_history.push_str(&format!("--- a{}\n", old_path.display()));
+        edit_history.push_str(&format!("+++ b{}\n", path.display()));
+        let diff_word_diff = unified_to_word_diff(&diff);
+        edit_history.push_str(&diff_word_diff);
+        edit_history.push_str("\n\n");
     }
 
     let prompt_template = crate::prompt_assets::get_prompt("qa.md");

--- a/crates/edit_prediction_cli/src/reversal_tracking.rs
+++ b/crates/edit_prediction_cli/src/reversal_tracking.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use edit_prediction::udiff::apply_diff_to_string;
 use language::{char_diff, text_diff};
 
-use crate::example::ExamplePromptInputs;
+use zeta_prompt::ZetaPromptInput;
 
 fn apply_diff_to_string_lenient(diff_str: &str, text: &str) -> String {
     let hunks = parse_diff_hunks(diff_str);
@@ -609,13 +609,13 @@ fn is_predicted_event(event: &zeta_prompt::Event) -> bool {
 }
 
 pub fn compute_prediction_reversal_ratio(
-    prompt_inputs: &ExamplePromptInputs,
+    prompt_inputs: &ZetaPromptInput,
     predicted_content: &str,
     cursor_path: &Path,
 ) -> f32 {
-    let current_content = &prompt_inputs.content;
+    let current_content: &str = prompt_inputs.cursor_excerpt.as_ref();
 
-    let edit_history: &[Arc<zeta_prompt::Event>] = &prompt_inputs.edit_history;
+    let edit_history: &[Arc<zeta_prompt::Event>] = &prompt_inputs.events;
     let relevant_events = filter_edit_history_by_path(edit_history, cursor_path);
 
     let most_recent = match relevant_events.last() {
@@ -655,6 +655,26 @@ mod tests {
     use super::*;
     use edit_prediction::udiff::apply_diff_to_string;
     use indoc::indoc;
+
+    fn make_test_prompt_inputs(
+        content: &str,
+        events: Vec<Arc<zeta_prompt::Event>>,
+        excerpt_start_row: Option<u32>,
+    ) -> ZetaPromptInput {
+        ZetaPromptInput {
+            cursor_path: Arc::from(Path::new("src/test.rs")),
+            cursor_excerpt: content.into(),
+            editable_range_in_excerpt: 0..content.len(),
+            cursor_offset_in_excerpt: 0,
+            excerpt_start_row,
+            events,
+            related_files: Vec::new(),
+            excerpt_ranges: None,
+            preferred_model: None,
+            in_open_source_repo: false,
+            can_collect_data: false,
+        }
+    }
 
     #[test]
     fn test_reversal_overlap() {
@@ -1729,17 +1749,13 @@ mod tests {
 
     #[test]
     fn test_compute_prediction_reversal_ratio_full_file() {
-        let prompt_inputs = ExamplePromptInputs {
-            content: indoc! {"
+        let prompt_inputs = make_test_prompt_inputs(
+            indoc! {"
                 line1
                 user_added
                 line2
-            "}
-            .to_string(),
-            cursor_row: 0,
-            cursor_column: 0,
-            cursor_offset: 0,
-            edit_history: vec![Arc::new(zeta_prompt::Event::BufferChange {
+            "},
+            vec![Arc::new(zeta_prompt::Event::BufferChange {
                 path: Arc::from(Path::new("src/test.rs")),
                 old_path: Arc::from(Path::new("src/test.rs")),
                 diff: indoc! {"
@@ -1752,9 +1768,8 @@ mod tests {
                 predicted: false,
                 in_open_source_repo: false,
             })],
-            excerpt_start_row: None,
-            related_files: None,
-        };
+            None,
+        );
 
         let predicted = indoc! {"
             line1
@@ -1772,17 +1787,13 @@ mod tests {
 
     #[test]
     fn test_compute_prediction_reversal_ratio_with_excerpt() {
-        let prompt_inputs = ExamplePromptInputs {
-            content: indoc! {"
+        let prompt_inputs = make_test_prompt_inputs(
+            indoc! {"
                 line10
                 user_added
                 line11
-            "}
-            .to_string(),
-            cursor_row: 0,
-            cursor_column: 0,
-            cursor_offset: 0,
-            edit_history: vec![Arc::new(zeta_prompt::Event::BufferChange {
+            "},
+            vec![Arc::new(zeta_prompt::Event::BufferChange {
                 path: Arc::from(Path::new("src/test.rs")),
                 old_path: Arc::from(Path::new("src/test.rs")),
                 diff: indoc! {"
@@ -1795,9 +1806,8 @@ mod tests {
                 predicted: false,
                 in_open_source_repo: false,
             })],
-            excerpt_start_row: Some(10),
-            related_files: None,
-        };
+            Some(10),
+        );
 
         let predicted = indoc! {"
             line10
@@ -1815,18 +1825,13 @@ mod tests {
 
     #[test]
     fn test_compute_prediction_reversal_ratio_no_history() {
-        let prompt_inputs = ExamplePromptInputs {
-            content: indoc! {"
+        let prompt_inputs = make_test_prompt_inputs(
+            indoc! {"
                 original content
-            "}
-            .to_string(),
-            cursor_row: 0,
-            cursor_column: 0,
-            cursor_offset: 0,
-            edit_history: vec![],
-            excerpt_start_row: None,
-            related_files: None,
-        };
+            "},
+            vec![],
+            None,
+        );
 
         let predicted = indoc! {"
             completely different
@@ -1842,17 +1847,13 @@ mod tests {
 
     #[test]
     fn test_compute_prediction_reversal_ratio_path_filtering() {
-        let prompt_inputs = ExamplePromptInputs {
-            content: indoc! {"
+        let prompt_inputs = make_test_prompt_inputs(
+            indoc! {"
                 line1
                 user_added
                 line2
-            "}
-            .to_string(),
-            cursor_row: 0,
-            cursor_column: 0,
-            cursor_offset: 0,
-            edit_history: vec![Arc::new(zeta_prompt::Event::BufferChange {
+            "},
+            vec![Arc::new(zeta_prompt::Event::BufferChange {
                 path: Arc::from(Path::new("src/other.rs")),
                 old_path: Arc::from(Path::new("src/other.rs")),
                 diff: indoc! {"
@@ -1865,9 +1866,8 @@ mod tests {
                 predicted: false,
                 in_open_source_repo: false,
             })],
-            excerpt_start_row: None,
-            related_files: None,
-        };
+            None,
+        );
 
         let predicted = indoc! {"
             line1
@@ -1884,17 +1884,13 @@ mod tests {
 
     #[test]
     fn test_compute_prediction_reversal_ratio_lenient_fallback() {
-        let prompt_inputs = ExamplePromptInputs {
-            content: indoc! {"
+        let prompt_inputs = make_test_prompt_inputs(
+            indoc! {"
                 actual_line1
                 user_added
                 actual_line2
-            "}
-            .to_string(),
-            cursor_row: 0,
-            cursor_column: 0,
-            cursor_offset: 0,
-            edit_history: vec![Arc::new(zeta_prompt::Event::BufferChange {
+            "},
+            vec![Arc::new(zeta_prompt::Event::BufferChange {
                 path: Arc::from(Path::new("src/test.rs")),
                 old_path: Arc::from(Path::new("src/test.rs")),
                 diff: indoc! {"
@@ -1907,9 +1903,8 @@ mod tests {
                 predicted: false,
                 in_open_source_repo: false,
             })],
-            excerpt_start_row: None,
-            related_files: None,
-        };
+            None,
+        );
 
         let predicted = indoc! {"
             actual_line1
@@ -1955,18 +1950,14 @@ mod tests {
 
     #[test]
     fn test_only_most_recent_edit_tracked() {
-        let prompt_inputs = ExamplePromptInputs {
-            content: indoc! {"
+        let prompt_inputs = make_test_prompt_inputs(
+            indoc! {"
                 line1
                 first_add
                 second_add
                 line2
-            "}
-            .to_string(),
-            cursor_row: 0,
-            cursor_column: 0,
-            cursor_offset: 0,
-            edit_history: vec![
+            "},
+            vec![
                 Arc::new(zeta_prompt::Event::BufferChange {
                     path: Arc::from(Path::new("src/test.rs")),
                     old_path: Arc::from(Path::new("src/test.rs")),
@@ -1994,9 +1985,8 @@ mod tests {
                     in_open_source_repo: false,
                 }),
             ],
-            excerpt_start_row: None,
-            related_files: None,
-        };
+            None,
+        );
 
         let predicted = indoc! {"
             line1

--- a/crates/edit_prediction_cli/src/score.rs
+++ b/crates/edit_prediction_cli/src/score.rs
@@ -30,11 +30,11 @@ pub async fn run_scoring(
     let progress = example_progress.start(Step::Score);
 
     progress.set_substatus("applying patches");
-    let original_text = &example
+    let prompt_inputs = example
         .prompt_inputs
         .as_ref()
-        .context("prompt_inputs is required for scoring - run prediction first or ensure JSON includes prompt_inputs")?
-        .content;
+        .context("prompt_inputs is required for scoring - run prediction first or ensure JSON includes prompt_inputs")?;
+    let original_text: &str = prompt_inputs.cursor_excerpt.as_ref();
     let expected_patches_with_cursors = example.spec.expected_patches_with_cursor_positions();
 
     let expected_texts: Vec<String> = expected_patches_with_cursors
@@ -80,7 +80,6 @@ pub async fn run_scoring(
         deleted_tokens: 0,
     };
 
-    let prompt_inputs = example.prompt_inputs.as_ref().unwrap();
     let cursor_path = example.spec.cursor_path.as_ref();
 
     progress.set_substatus("computing metrics");

--- a/crates/edit_prediction_cli/src/split_commit.rs
+++ b/crates/edit_prediction_cli/src/split_commit.rs
@@ -371,7 +371,7 @@ pub fn generate_evaluation_example_from_ordered_commit(
         reasoning: None,
         uncommitted_diff: String::new(),
         rejected_patch: None,
-        captured_prompt_input: None,
+
         telemetry: None,
         human_feedback: Vec::new(),
         rating: None,
@@ -1370,7 +1370,7 @@ Date: Mon Jan 1 00:00:00 2024
             reasoning: None,
             uncommitted_diff: String::new(),
             rejected_patch: None,
-            captured_prompt_input: None,
+
             telemetry: None,
             human_feedback: Vec::new(),
             rating: None,

--- a/crates/edit_prediction_cli/src/synthesize.rs
+++ b/crates/edit_prediction_cli/src/synthesize.rs
@@ -792,7 +792,7 @@ async fn build_example(
         edit_history,
         expected_patches: vec![expected_patch_with_header],
         rejected_patch: None,
-        captured_prompt_input: None,
+
         telemetry: None,
         human_feedback: Vec::new(),
         rating: None,

--- a/crates/edit_prediction_ui/src/edit_prediction_ui.rs
+++ b/crates/edit_prediction_ui/src/edit_prediction_ui.rs
@@ -154,15 +154,7 @@ fn capture_example_as_markdown(
         .text_anchor_for_position(editor.selections.newest_anchor().head(), cx)?;
     let ep_store = EditPredictionStore::try_global(cx)?;
     let events = ep_store.update(cx, |store, cx| store.edit_history_for_project(&project, cx));
-    let example = capture_example(
-        project.clone(),
-        buffer,
-        cursor_anchor,
-        events,
-        Vec::new(),
-        true,
-        cx,
-    )?;
+    let example = capture_example(project.clone(), buffer, cursor_anchor, events, true, cx)?;
 
     let examples_dir = AllLanguageSettings::get_global(cx)
         .edit_predictions

--- a/crates/zeta_prompt/src/zeta_prompt.rs
+++ b/crates/zeta_prompt/src/zeta_prompt.rs
@@ -19,7 +19,7 @@ fn estimate_tokens(bytes: usize) -> usize {
 }
 
 /// The client's preferred edit prediction model. The server may override this.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum EditPredictionModelKind {
     Zeta1,
     Zeta2,
@@ -28,7 +28,7 @@ pub enum EditPredictionModelKind {
 /// Pre-computed byte offset ranges within `cursor_excerpt` for different
 /// editable and context token budgets. Allows the server to select the
 /// appropriate ranges for whichever model it uses.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Hash, Serialize, Deserialize)]
 pub struct ExcerptRanges {
     /// Editable region computed with a 150-token budget.
     pub editable_150: Range<usize>,
@@ -44,7 +44,7 @@ pub struct ExcerptRanges {
     pub editable_350_context_150: Range<usize>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Hash, Serialize, Deserialize)]
 pub struct ZetaPromptInput {
     pub cursor_path: Arc<Path>,
     pub cursor_excerpt: Arc<str>,
@@ -149,7 +149,7 @@ impl ZetaFormat {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(tag = "event")]
 pub enum Event {
     BufferChange {
@@ -200,7 +200,7 @@ pub fn write_event(prompt: &mut String, event: &Event) {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Hash, Serialize, Deserialize)]
 pub struct RelatedFile {
     pub path: Arc<Path>,
     pub max_row: u32,
@@ -209,7 +209,7 @@ pub struct RelatedFile {
     pub in_open_source_repo: bool,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Hash, Serialize, Deserialize)]
 pub struct RelatedExcerpt {
     pub row_range: Range<u32>,
     pub text: Arc<str>,


### PR DESCRIPTION
Previously, we were not computing excerpt regions correctly for EP examples captured from prod. This PR fixes that, and also simplifies the data flow in the EP CLI. Examples either come from a concise spec (like the markdown evals), or are collected from prod. Either way, we compute from them a `ZetaPromptInput`, and the downstream steps like prompt-formatting and scoring are derived from that.

Release Notes:

- N/A
