### PR TITLE
Skip docs suggestions workflow for fork PRs

### DIFF
--- a/.github/workflows/docs_suggestions.yml
+++ b/.github/workflows/docs_suggestions.yml
@@ -52,13 +52,15 @@ env:
 
 jobs:
   # Job for PRs merged to main - batch suggestions to branch
+  # Only runs for PRs from the same repo (not forks) since secrets aren't available for fork PRs
   batch-suggestions:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: |
       (github.event_name == 'pull_request' && 
        github.event.pull_request.merged == true &&
-       github.event.pull_request.base.ref == 'main') ||
+       github.event.pull_request.base.ref == 'main' &&
+       github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.event_name == 'workflow_dispatch' && inputs.mode == 'batch')
     
     steps:


### PR DESCRIPTION
## Summary

Fork PRs don't have access to repository secrets (`FACTORY_API_KEY`), causing the docs suggestions workflow to fail when triggered by external contributor PRs.

This adds a condition to skip the `batch-suggestions` job when the PR originates from a fork (`github.event.pull_request.head.repo.full_name != github.repository`).

## Context

See failing job: https://github.com/zed-industries/zed/actions/runs/22323201362/job/64586740764

The `pull_request` trigger doesn't pass secrets to workflows running on fork PRs for security reasons. This is expected GitHub behavior.

Release Notes:

- N/A