### PR TITLE
workspace: Clean up stale empty-workspace restore state

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -6086,6 +6086,22 @@ impl Workspace {
                 let display = window.display(cx).and_then(|d| d.uuid().ok());
                 // Save dock state for empty local workspaces
                 let docks = build_serialized_docks(self, window, cx);
+                let center_group = build_serialized_pane_group(&self.center.root, window, cx);
+                let workspace = SerializedWorkspace {
+                    id: database_id,
+                    location: SerializedWorkspaceLocation::Local,
+                    paths: Default::default(),
+                    center_group,
+                    window_bounds: None,
+                    display: Default::default(),
+                    docks: docks.clone(),
+                    centered_layout: self.centered_layout,
+                    session_id: None,
+                    breakpoints: Default::default(),
+                    window_id: Some(window.window_handle().window_id().as_u64()),
+                    user_toolchains: Default::default(),
+                };
+
                 window.spawn(cx, async move |_| {
                     persistence::DB
                         .set_window_open_status(
@@ -6095,10 +6111,11 @@ impl Workspace {
                         )
                         .await
                         .log_err();
-                    persistence::DB
-                        .set_session_id(database_id, None)
-                        .await
-                        .log_err();
+
+                    // Clear out any stale pane/item state while also detaching from the session.
+                    // Without this, the last serialized pane group can keep referencing items
+                    // that failed to deserialize.
+                    persistence::DB.save_workspace(workspace).await;
                     persistence::write_default_dock_state(docks).await.log_err();
                 })
             }

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -1424,9 +1424,11 @@ pub(crate) async fn restore_or_create_workspace(
                     let restore_on_startup = WorkspaceSettings::get_global(cx).restore_on_startup;
                     match restore_on_startup {
                         workspace::RestoreOnStartupBehavior::Launchpad => {}
-                        _ => {
+                        workspace::RestoreOnStartupBehavior::EmptyTab => {
                             Editor::new_file(workspace, &Default::default(), window, cx);
                         }
+                        workspace::RestoreOnStartupBehavior::LastWorkspace
+                        | workspace::RestoreOnStartupBehavior::LastSession => {}
                     }
                 },
             )

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -1423,11 +1423,11 @@ pub(crate) async fn restore_or_create_workspace(
                 |workspace, window, cx| {
                     let restore_on_startup = WorkspaceSettings::get_global(cx).restore_on_startup;
                     match restore_on_startup {
-                        workspace::RestoreOnStartupBehavior::Launchpad => {}
                         workspace::RestoreOnStartupBehavior::EmptyTab => {
                             Editor::new_file(workspace, &Default::default(), window, cx);
                         }
-                        workspace::RestoreOnStartupBehavior::LastWorkspace
+                        workspace::RestoreOnStartupBehavior::Launchpad
+                        | workspace::RestoreOnStartupBehavior::LastWorkspace
                         | workspace::RestoreOnStartupBehavior::LastSession => {}
                     }
                 },


### PR DESCRIPTION
Closes #48799

Prevents saving the workspace with stale pane data.

Whenever the session persistence code tried to reopen an `Editor` that was referenced in the workspace layout but not the `editors` table, deserializing it would fail:
```
2026-02-23T21:37:47-06:00 ERROR [crates/workspace/src/persistence/model.rs:330] Unable to deserialize editor: No entry in database for item_id: 4294967473 and workspace_id WorkspaceId(47)
```
This caused the workspace to be empty, and thus detached from the session, leaving nothing to be restored on the next startup (opening a blank buffer instead). 

Release Notes:

- Fixed an issue where Zed would sometimes start with an untitled blank buffer instead of the welcome page