### PR TITLE
agent_ui: Avoid querying `OnboardingUpsell` in prepaint

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -2330,7 +2330,7 @@ impl AcpThread {
                     text_diff(old_text.as_str(), &content)
                         .into_iter()
                         .map(|(range, replacement)| {
-                            (snapshot.anchor_range_between(range), replacement)
+                            (snapshot.anchor_range_around(range), replacement)
                         })
                         .collect::<Vec<_>>()
                 })

--- a/crates/text/src/text.rs
+++ b/crates/text/src/text.rs
@@ -2403,13 +2403,13 @@ impl BufferSnapshot {
         }
     }
 
-    /// Returns an anchor range for the given input position range that is anchored to the text inbetween.
-    pub fn anchor_range_between<T: ToOffset>(&self, position: Range<T>) -> Range<Anchor> {
-        self.anchor_before(position.start)..self.anchor_after(position.end)
+    /// Returns an anchor range for the given input position range that is anchored to the text in the range.
+    pub fn anchor_range_around<T: ToOffset>(&self, position: Range<T>) -> Range<Anchor> {
+        self.anchor_after(position.start)..self.anchor_before(position.end)
     }
 
-    /// Returns an anchor range for the given input position range that is anchored to the text before the start position and after the end position.
-    pub fn anchor_range_around<T: ToOffset>(&self, position: Range<T>) -> Range<Anchor> {
+    /// Returns an anchor range for the given input position range that is anchored to the text before and after.
+    pub fn anchor_range_between<T: ToOffset>(&self, position: Range<T>) -> Range<Anchor> {
         self.anchor_before(position.start)..self.anchor_after(position.end)
     }
 


### PR DESCRIPTION
This hits the sqlite database unnecessarily

Release Notes:

- N/A *or* Added/Fixed/Improved ...
