### PR TITLE
multibuffer: Make "Open File" button also visible on hover

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -8139,6 +8139,7 @@ pub(crate) fn render_buffer_header(
         .h(FILE_HEADER_HEIGHT as f32 * window.line_height())
         .child(
             h_flex()
+                .group("buffer-header-group")
                 .size_full()
                 .flex_basis(Length::Definite(DefiniteLength::Fraction(0.667)))
                 .pl_1()
@@ -8157,7 +8158,6 @@ pub(crate) fn render_buffer_header(
                     border.border_color(border_color)
                 })
                 .bg(colors.editor_subheader_background)
-                .group("buffer-header-group")
                 .hover(|style| style.bg(colors.element_hover))
                 .map(|header| {
                     let editor = editor.clone();

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -8333,8 +8333,8 @@ pub(crate) fn render_buffer_header(
                                     })
                             },
                         ))
-                        .when(can_open_excerpts && relative_path.is_some(), |el| {
-                            el.child(
+                        .when(can_open_excerpts && relative_path.is_some(), |this| {
+                            this.child(
                                 div()
                                     .when(!is_selected, |this| {
                                         this.visible_on_hover("buffer-header-group")
@@ -8342,11 +8342,13 @@ pub(crate) fn render_buffer_header(
                                     .child(
                                         Button::new("open-file-button", "Open File")
                                             .style(ButtonStyle::OutlinedGhost)
-                                            .key_binding(KeyBinding::for_action_in(
-                                                &OpenExcerpts,
-                                                &focus_handle,
-                                                cx,
-                                            ))
+                                            .when(is_selected, |this| {
+                                                this.key_binding(KeyBinding::for_action_in(
+                                                    &OpenExcerpts,
+                                                    &focus_handle,
+                                                    cx,
+                                                ))
+                                            })
                                             .on_click(window.listener_for(editor, {
                                                 let jump_data = jump_data.clone();
                                                 move |editor, e: &ClickEvent, window, cx| {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -8157,6 +8157,7 @@ pub(crate) fn render_buffer_header(
                     border.border_color(border_color)
                 })
                 .bg(colors.editor_subheader_background)
+                .group("buffer-header-group")
                 .hover(|style| style.bg(colors.element_hover))
                 .map(|header| {
                     let editor = editor.clone();
@@ -8332,31 +8333,34 @@ pub(crate) fn render_buffer_header(
                                     })
                             },
                         ))
-                        .when(
-                            can_open_excerpts && is_selected && relative_path.is_some(),
-                            |el| {
-                                el.child(
-                                    Button::new("open-file-button", "Open File")
-                                        .style(ButtonStyle::OutlinedGhost)
-                                        .key_binding(KeyBinding::for_action_in(
-                                            &OpenExcerpts,
-                                            &focus_handle,
-                                            cx,
-                                        ))
-                                        .on_click(window.listener_for(editor, {
-                                            let jump_data = jump_data.clone();
-                                            move |editor, e: &ClickEvent, window, cx| {
-                                                editor.open_excerpts_common(
-                                                    Some(jump_data.clone()),
-                                                    e.modifiers().secondary(),
-                                                    window,
-                                                    cx,
-                                                );
-                                            }
-                                        })),
-                                )
-                            },
-                        )
+                        .when(can_open_excerpts && relative_path.is_some(), |el| {
+                            el.child(
+                                div()
+                                    .when(!is_selected, |this| {
+                                        this.visible_on_hover("buffer-header-group")
+                                    })
+                                    .child(
+                                        Button::new("open-file-button", "Open File")
+                                            .style(ButtonStyle::OutlinedGhost)
+                                            .key_binding(KeyBinding::for_action_in(
+                                                &OpenExcerpts,
+                                                &focus_handle,
+                                                cx,
+                                            ))
+                                            .on_click(window.listener_for(editor, {
+                                                let jump_data = jump_data.clone();
+                                                move |editor, e: &ClickEvent, window, cx| {
+                                                    editor.open_excerpts_common(
+                                                        Some(jump_data.clone()),
+                                                        e.modifiers().secondary(),
+                                                        window,
+                                                        cx,
+                                                    );
+                                                }
+                                            })),
+                                    ),
+                            )
+                        })
                         .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
                         .on_click(window.listener_for(editor, {
                             let buffer_id = for_excerpt.buffer_id;


### PR DESCRIPTION
This makes the "Open File" button in the file header within multibuffers also visible as you hover over the headers. Previously, this button would only show up for the selected/focused file, but it now also shows up on hover for making mouse-based interaction easier.

Release Notes:

- N/A
