### PR TITLE
git: Capture all working tree changes for the Review Diff action

### DIFF
--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -2015,7 +2015,7 @@ impl GitRepository for RealGitRepository {
                     DiffType::MergeBase { base_ref } => {
                         new_command(&git_binary_path)
                             .current_dir(&working_directory)
-                            .args(["diff", "--merge-base", base_ref.as_ref(), "HEAD"])
+                            .args(["diff", "--merge-base", base_ref.as_ref()])
                             .output()
                             .await?
                     }


### PR DESCRIPTION
The AI-assisted "Review Diff" action was only working for committed changes because we were passing HEAD in the git command. Without it, it captures all of the working tree changes, the same way the Branch Diff view itself does. I think this is now better and more intuitive, because it shouldn't be required that you commit the changes to have them quickly reviewed by an agent.

Release Notes:

- N/A
