### PR TITLE
Fix panic in inlay hints

### DIFF
--- a/crates/editor/src/inlays/inlay_hints.rs
+++ b/crates/editor/src/inlays/inlay_hints.rs
@@ -578,6 +578,7 @@ impl Editor {
             if let Some(hovered_hint) = self
                 .visible_inlay_hints(cx)
                 .into_iter()
+                .filter(|hint| snapshot.can_resolve(&hint.position))
                 .skip_while(|hint| {
                     hint.position
                         .cmp(&previous_valid_anchor, &buffer_snapshot)


### PR DESCRIPTION
We were resolving inlay hints against an old snapshot, which
occasionally led to panics

Co-Authored-By: Cole <cole@zed.dev>

Closes #ISSUE

Before you mark this PR as ready for review, make sure that you have:
- [ ] Added a solid test coverage and/or screenshots from doing manual testing
- [ ] Done a self-review taking into account security and performance aspects
- [ ] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Fixed a (rare) panic in inlay hints
