### PR TITLE
extension_ci: Set `fetch-depth` to `0` in tests

### DIFF
--- a/.github/workflows/extension_tests.yml
+++ b/.github/workflows/extension_tests.yml
@@ -87,7 +87,7 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         clean: false
-        fetch-depth: ${{ github.ref == 'refs/heads/main' && 2 || 350 }}
+        fetch-depth: 0
     - id: cache-zed-extension-cli
       name: extension_tests::cache_zed_extension_cli
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830

--- a/tooling/xtask/src/tasks/workflows/extension_tests.rs
+++ b/tooling/xtask/src/tasks/workflows/extension_tests.rs
@@ -89,7 +89,7 @@ pub(crate) fn check_extension() -> NamedJob {
         .with_repository_owner_guard()
         .runs_on(runners::LINUX_LARGE_RAM)
         .timeout_minutes(6u32)
-        .add_step(steps::checkout_repo().with_deep_history_on_non_main())
+        .add_step(steps::checkout_repo().with_full_history())
         .add_step(cache_download)
         .add_step(download_zed_extension_cli(cache_hit))
         .add_step(cache_rust_dependencies_namespace()) // Extensions can compile Rust, so provide the cache if needed.


### PR DESCRIPTION
This makes the full history available in tests. 

Release Notes:

- N/A
