### PR TITLE
project_panel: Add markdown preview keybinding and fix re-open bug

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -900,6 +900,7 @@
       "alt-d": "project_panel::CompareMarkedFiles",
       "shift-find": "project_panel::NewSearchInDirectory",
       "ctrl-alt-shift-f": "project_panel::NewSearchInDirectory",
+      "ctrl-shift-v": "project_panel::OpenMarkdownPreview",
       "shift-down": "menu::SelectNext",
       "shift-up": "menu::SelectPrevious",
       "escape": "menu::Cancel",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -953,6 +953,7 @@
       "alt-d": "project_panel::CompareMarkedFiles",
       "cmd-alt-backspace": ["project_panel::Delete", { "skip_prompt": false }],
       "cmd-alt-shift-f": "project_panel::NewSearchInDirectory",
+      "cmd-shift-v": "project_panel::OpenMarkdownPreview",
       "shift-down": "menu::SelectNext",
       "shift-up": "menu::SelectPrevious",
       "escape": "menu::Cancel",

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -897,6 +897,7 @@
       "ctrl-shift-enter": "project_panel::OpenWithSystem",
       "alt-d": "project_panel::CompareMarkedFiles",
       "ctrl-k ctrl-shift-f": "project_panel::NewSearchInDirectory",
+      "ctrl-shift-v": "project_panel::OpenMarkdownPreview",
       "shift-down": "menu::SelectNext",
       "shift-up": "menu::SelectPrevious",
       "escape": "menu::Cancel",

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -367,6 +367,8 @@ actions!(
         SelectPrevDirectory,
         /// Opens a diff view to compare two marked files.
         CompareMarkedFiles,
+        /// Opens a markdown preview for the selected markdown file.
+        OpenMarkdownPreview,
     ]
 );
 
@@ -553,6 +555,55 @@ pub fn init(cx: &mut App) {
                         cx,
                     );
                 }
+            }
+        });
+
+        workspace.register_action(|workspace, _: &OpenMarkdownPreview, window, cx| {
+            let Some(panel) = workspace.panel::<ProjectPanel>(cx) else {
+                return;
+            };
+            let maybe_project_path = panel.read(cx).selection.and_then(|selection| {
+                let project = workspace.project().read(cx);
+                let worktree = project.worktree_for_id(selection.worktree_id, cx)?;
+                let entry = worktree.read(cx).entry_for_id(selection.entry_id)?;
+                if entry.is_file()
+                    && entry.path.extension().is_some_and(|ext| {
+                        ext.eq_ignore_ascii_case("md") || ext.eq_ignore_ascii_case("markdown")
+                    })
+                {
+                    Some(ProjectPath {
+                        worktree_id: selection.worktree_id,
+                        path: entry.path.clone(),
+                    })
+                } else {
+                    None
+                }
+            });
+
+            if let Some(project_path) = maybe_project_path {
+                let open_task = workspace.open_path_preview(
+                    project_path,
+                    None,
+                    true,
+                    false,
+                    true,
+                    window,
+                    cx,
+                );
+                window
+                    .spawn(cx, async move |cx| {
+                        open_task.await?;
+                        cx.update(|window, cx| {
+                            if let Some(focus) = window.focused(cx) {
+                                focus.dispatch_action(
+                                    &zed_actions::preview::markdown::OpenPreview,
+                                    window,
+                                    cx,
+                                );
+                            }
+                        })
+                    })
+                    .detach_and_log_err(cx);
             }
         });
     })
@@ -1124,6 +1175,10 @@ impl ProjectPanel {
                 && (cfg!(target_os = "windows")
                     || (settings.hide_root && visible_worktrees_count == 1));
             let should_show_compare = !is_dir && self.file_abs_paths_to_diff(cx).is_some();
+            let is_markdown = !is_dir
+                && entry.path.extension().is_some_and(|ext| {
+                    ext.eq_ignore_ascii_case("md") || ext.eq_ignore_ascii_case("markdown")
+                });
 
             let has_git_repo = !is_dir && {
                 let project_path = project::ProjectPath {
@@ -1143,6 +1198,12 @@ impl ProjectPanel {
                     if is_read_only {
                         menu.when(is_dir, |menu| {
                             menu.action("Search Inside", Box::new(NewSearchInDirectory))
+                        })
+                        .when(is_markdown, |menu| {
+                            menu.action(
+                                "Open Markdown Preview",
+                                Box::new(OpenMarkdownPreview),
+                            )
                         })
                     } else {
                         menu.action("New File", Box::new(NewFile))
@@ -1164,6 +1225,12 @@ impl ProjectPanel {
                                 menu.action("Open in Default App", Box::new(OpenWithSystem))
                             })
                             .action("Open in Terminal", Box::new(OpenInTerminal))
+                            .when(is_markdown, |menu| {
+                                menu.action(
+                                    "Open Markdown Preview",
+                                    Box::new(OpenMarkdownPreview),
+                                )
+                            })
                             .when(is_dir, |menu| {
                                 menu.separator()
                                     .action("Find in Folder…", Box::new(NewSearchInDirectory))


### PR DESCRIPTION
## Summary

- Add "Open Markdown Preview" context menu item for `.md` files in the project panel
- Add `cmd-shift-v` (macOS) / `ctrl-shift-v` (Linux, Windows) keybinding for `OpenMarkdownPreview` in the `ProjectPanel` context, matching the shortcut used in the Markdown editor
- Fix the preview dispatch so that re-opening a preview for an already-open file keeps the preview tab active instead of flashing the raw editor — uses synchronous `FocusHandle::dispatch_action` instead of the deferred `Window::dispatch_action`

## Test plan

- [ ] Select a `.md` file in the project panel and press `cmd-shift-v` (macOS) or `ctrl-shift-v` — markdown preview should open
- [ ] Press the shortcut on a non-`.md` file — nothing should happen
- [ ] Right-click a `.md` file in the project panel — "Open Markdown Preview" should appear in the context menu
- [ ] Open a `.md` preview via context menu, then right-click the same file and click "Open Markdown Preview" again — the preview tab should stay active (not switch to raw editor)
- [ ] Close all tabs, right-click a `.md` file, click "Open Markdown Preview" — a new preview tab should appear

Release Notes:

- Added "Open Markdown Preview" to the project panel context menu for markdown files.
- Added `cmd-shift-v` / `ctrl-shift-v` keybinding to open markdown preview from the project panel.
- Fixed markdown preview re-opening from the project panel showing the raw editor instead of the preview tab.