### PR TITLE
editor: Fix breakpoint placement guards

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -12091,6 +12091,10 @@ impl Editor {
             return false;
         };
 
+        if !self.buffer_supports_breakpoints(&buffer, cx) {
+            return false;
+        }
+
         let snapshot = self.buffer.read(cx).snapshot(cx);
         if snapshot.is_line_blank(row) {
             return false;
@@ -12099,17 +12103,9 @@ impl Editor {
         let line_len = snapshot.line_len(row);
         let indent = snapshot.indent_size_for_line(row).len.min(line_len);
         let point_at_code_start = Point::new(row.0, indent);
-        let language_scope = snapshot.language_scope_at(point_at_code_start);
-        let has_comment_syntax = language_scope.as_ref().is_some_and(|scope| {
-            !scope.line_comment_prefixes().is_empty()
-                || scope.block_comment().is_some()
-                || scope.documentation_comment().is_some()
-        });
-        if !self.buffer_supports_breakpoints(&buffer, cx) && !has_comment_syntax {
-            return false;
-        }
-
-        !language_scope.is_some_and(|scope| scope.override_name() == Some("comment"))
+        !snapshot
+            .language_scope_at(point_at_code_start)
+            .is_some_and(|scope| scope.override_name() == Some("comment"))
     }
 
     fn buffer_supports_breakpoints(&self, buffer: &Entity<Buffer>, cx: &App) -> bool {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -11869,8 +11869,10 @@ impl Editor {
             return;
         }
 
-        for (anchor, breakpoint) in self.breakpoints_at_cursors(window, cx) {
-            if breakpoint.is_none() && !self.anchor_supports_breakpoint_placement(anchor, cx) {
+        for (anchor, breakpoint, row) in self.breakpoints_at_cursors(window, cx) {
+            if breakpoint.is_none()
+                && !self.row_supports_breakpoint_placement(MultiBufferRow(row), cx)
+            {
                 continue;
             }
 
@@ -11895,7 +11897,7 @@ impl Editor {
         &self,
         window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> Vec<(Anchor, Option<Breakpoint>)> {
+    ) -> Vec<(Anchor, Option<Breakpoint>, u32)> {
         let snapshot = self.snapshot(window, cx);
         let cursors = self
             .selections
@@ -11918,12 +11920,16 @@ impl Editor {
                     .breakpoint_at_anchor(breakpoint_position, &snapshot, cx)
                     .map(|(anchor, breakpoint)| (anchor, Some(breakpoint)));
 
-                breakpoint.unwrap_or_else(|| (breakpoint_position, None))
+                let (anchor, breakpoint) = breakpoint.unwrap_or_else(|| (breakpoint_position, None));
+                (anchor, (breakpoint, cursor_position.row))
             })
             // There might be multiple cursors on the same line; all of them should have the same anchors though as their breakpoints positions, which makes it possible to sort and dedup the list.
             .collect::<HashMap<Anchor, _>>();
 
-        cursors.into_iter().collect()
+        cursors
+            .into_iter()
+            .map(|(anchor, (breakpoint, row))| (anchor, breakpoint, row))
+            .collect()
     }
 
     pub fn enable_breakpoint(
@@ -11936,7 +11942,7 @@ impl Editor {
             return;
         }
 
-        for (anchor, breakpoint) in self.breakpoints_at_cursors(window, cx) {
+        for (anchor, breakpoint, _) in self.breakpoints_at_cursors(window, cx) {
             let Some(breakpoint) = breakpoint.filter(|breakpoint| breakpoint.is_disabled()) else {
                 continue;
             };
@@ -11959,7 +11965,7 @@ impl Editor {
             return;
         }
 
-        for (anchor, breakpoint) in self.breakpoints_at_cursors(window, cx) {
+        for (anchor, breakpoint, _) in self.breakpoints_at_cursors(window, cx) {
             let Some(breakpoint) = breakpoint.filter(|breakpoint| breakpoint.is_enabled()) else {
                 continue;
             };
@@ -11983,8 +11989,10 @@ impl Editor {
         }
 
         let snapshot = self.snapshot(window, cx);
-        for (anchor, breakpoint) in self.breakpoints_at_cursors(window, cx) {
-            if breakpoint.is_none() && !self.anchor_supports_breakpoint_placement(anchor, cx) {
+        for (anchor, breakpoint, row) in self.breakpoints_at_cursors(window, cx) {
+            if breakpoint.is_none()
+                && !self.row_supports_breakpoint_placement(MultiBufferRow(row), cx)
+            {
                 continue;
             }
 
@@ -12067,17 +12075,23 @@ impl Editor {
     }
 
     pub(crate) fn anchor_supports_breakpoint_placement(&self, anchor: Anchor, cx: &App) -> bool {
-        let Some(buffer) = self.buffer.read(cx).buffer_for_anchor(anchor, cx) else {
+        let snapshot = self.buffer.read(cx).snapshot(cx);
+        let summary_row = MultiBufferRow(snapshot.summary_for_anchor::<Point>(&anchor).row);
+        if self.row_supports_breakpoint_placement(summary_row, cx) {
+            return true;
+        }
+
+        let point_row = MultiBufferRow(anchor.to_point(&snapshot).row);
+        point_row != summary_row && self.row_supports_breakpoint_placement(point_row, cx)
+    }
+
+    fn row_supports_breakpoint_placement(&self, row: MultiBufferRow, cx: &App) -> bool {
+        let Some((buffer, _)) = self.buffer.read(cx).point_to_buffer_offset(Point::new(row.0, 0), cx)
+        else {
             return false;
         };
 
-        if !self.buffer_supports_breakpoints(&buffer, cx) {
-            return false;
-        }
-
         let snapshot = self.buffer.read(cx).snapshot(cx);
-        let point = anchor.to_point(&snapshot);
-        let row = MultiBufferRow(point.row);
         if snapshot.is_line_blank(row) {
             return false;
         }
@@ -12085,10 +12099,17 @@ impl Editor {
         let line_len = snapshot.line_len(row);
         let indent = snapshot.indent_size_for_line(row).len.min(line_len);
         let point_at_code_start = Point::new(row.0, indent);
+        let language_scope = snapshot.language_scope_at(point_at_code_start);
+        let has_comment_syntax = language_scope.as_ref().is_some_and(|scope| {
+            !scope.line_comment_prefixes().is_empty()
+                || scope.block_comment().is_some()
+                || scope.documentation_comment().is_some()
+        });
+        if !self.buffer_supports_breakpoints(&buffer, cx) && !has_comment_syntax {
+            return false;
+        }
 
-        !snapshot
-            .language_scope_at(point_at_code_start)
-            .is_some_and(|scope| scope.override_name() == Some("comment"))
+        !language_scope.is_some_and(|scope| scope.override_name() == Some("comment"))
     }
 
     fn buffer_supports_breakpoints(&self, buffer: &Entity<Buffer>, cx: &App) -> bool {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -8852,6 +8852,9 @@ impl Editor {
         let breakpoint = self
             .breakpoint_at_row(row, window, cx)
             .map(|(anchor, bp)| (anchor, Arc::from(bp)));
+        let has_existing_breakpoint = breakpoint.is_some();
+        let can_create_breakpoint = self.anchor_supports_breakpoint_placement(anchor, cx);
+        let can_edit_breakpoint = has_existing_breakpoint || can_create_breakpoint;
 
         let log_breakpoint_msg = if breakpoint.as_ref().is_some_and(|bp| bp.1.message.is_some()) {
             "Edit Log Breakpoint"
@@ -8912,7 +8915,7 @@ impl Editor {
 
                         window.dispatch_action(Box::new(RunToCursor), cx);
                     })
-                    .separator()
+                    .when(can_edit_breakpoint, |this| this.separator())
                 })
                 .when_some(toggle_state_msg, |this, msg| {
                     this.entry(msg, None, {
@@ -8932,68 +8935,76 @@ impl Editor {
                         }
                     })
                 })
-                .entry(set_breakpoint_msg, None, {
-                    let weak_editor = weak_editor.clone();
-                    let breakpoint = breakpoint.clone();
-                    move |_window, cx| {
-                        weak_editor
-                            .update(cx, |this, cx| {
-                                this.edit_breakpoint_at_anchor(
-                                    anchor,
-                                    breakpoint.as_ref().clone(),
-                                    BreakpointEditAction::Toggle,
-                                    cx,
-                                );
-                            })
-                            .log_err();
-                    }
+                .when(can_edit_breakpoint, |this| {
+                    this.entry(set_breakpoint_msg, None, {
+                        let weak_editor = weak_editor.clone();
+                        let breakpoint = breakpoint.clone();
+                        move |_window, cx| {
+                            weak_editor
+                                .update(cx, |this, cx| {
+                                    this.edit_breakpoint_at_anchor(
+                                        anchor,
+                                        breakpoint.as_ref().clone(),
+                                        BreakpointEditAction::Toggle,
+                                        cx,
+                                    );
+                                })
+                                .log_err();
+                        }
+                    })
                 })
-                .entry(log_breakpoint_msg, None, {
-                    let breakpoint = breakpoint.clone();
-                    let weak_editor = weak_editor.clone();
-                    move |window, cx| {
+                .when(can_edit_breakpoint, |this| {
+                    this.entry(log_breakpoint_msg, None, {
+                        let breakpoint = breakpoint.clone();
+                        let weak_editor = weak_editor.clone();
+                        move |window, cx| {
+                            weak_editor
+                                .update(cx, |this, cx| {
+                                    this.add_edit_breakpoint_block(
+                                        anchor,
+                                        breakpoint.as_ref(),
+                                        BreakpointPromptEditAction::Log,
+                                        window,
+                                        cx,
+                                    );
+                                })
+                                .log_err();
+                        }
+                    })
+                })
+                .when(can_edit_breakpoint, |this| {
+                    this.entry(condition_breakpoint_msg, None, {
+                        let breakpoint = breakpoint.clone();
+                        let weak_editor = weak_editor.clone();
+                        move |window, cx| {
+                            weak_editor
+                                .update(cx, |this, cx| {
+                                    this.add_edit_breakpoint_block(
+                                        anchor,
+                                        breakpoint.as_ref(),
+                                        BreakpointPromptEditAction::Condition,
+                                        window,
+                                        cx,
+                                    );
+                                })
+                                .log_err();
+                        }
+                    })
+                })
+                .when(can_edit_breakpoint, |this| {
+                    this.entry(hit_condition_breakpoint_msg, None, move |window, cx| {
                         weak_editor
                             .update(cx, |this, cx| {
                                 this.add_edit_breakpoint_block(
                                     anchor,
                                     breakpoint.as_ref(),
-                                    BreakpointPromptEditAction::Log,
+                                    BreakpointPromptEditAction::HitCondition,
                                     window,
                                     cx,
                                 );
                             })
                             .log_err();
-                    }
-                })
-                .entry(condition_breakpoint_msg, None, {
-                    let breakpoint = breakpoint.clone();
-                    let weak_editor = weak_editor.clone();
-                    move |window, cx| {
-                        weak_editor
-                            .update(cx, |this, cx| {
-                                this.add_edit_breakpoint_block(
-                                    anchor,
-                                    breakpoint.as_ref(),
-                                    BreakpointPromptEditAction::Condition,
-                                    window,
-                                    cx,
-                                );
-                            })
-                            .log_err();
-                    }
-                })
-                .entry(hit_condition_breakpoint_msg, None, move |window, cx| {
-                    weak_editor
-                        .update(cx, |this, cx| {
-                            this.add_edit_breakpoint_block(
-                                anchor,
-                                breakpoint.as_ref(),
-                                BreakpointPromptEditAction::HitCondition,
-                                window,
-                                cx,
-                            );
-                        })
-                        .log_err();
+                    })
                 })
         })
     }
@@ -11727,7 +11738,8 @@ impl Editor {
             .snapshot(cx)
             .anchor_before(Point::new(display_row.0, 0u32));
 
-        let context_menu = self.breakpoint_context_menu(position.unwrap_or(source), window, cx);
+        let position = position.unwrap_or(source);
+        let context_menu = self.breakpoint_context_menu(position, window, cx);
 
         self.mouse_context_menu = MouseContextMenu::pinned_to_editor(
             self,
@@ -11858,6 +11870,10 @@ impl Editor {
         }
 
         for (anchor, breakpoint) in self.breakpoints_at_cursors(window, cx) {
+            if breakpoint.is_none() && !self.anchor_supports_breakpoint_placement(anchor, cx) {
+                continue;
+            }
+
             let breakpoint = breakpoint.unwrap_or_else(|| Breakpoint {
                 message: None,
                 state: BreakpointState::Enabled,
@@ -11968,6 +11984,10 @@ impl Editor {
 
         let snapshot = self.snapshot(window, cx);
         for (anchor, breakpoint) in self.breakpoints_at_cursors(window, cx) {
+            if breakpoint.is_none() && !self.anchor_supports_breakpoint_placement(anchor, cx) {
+                continue;
+            }
+
             if self.gutter_breakpoint_indicator.0.is_some() {
                 let display_row = anchor
                     .to_point(snapshot.buffer_snapshot())
@@ -12044,6 +12064,43 @@ impl Editor {
         });
 
         cx.notify();
+    }
+
+    pub(crate) fn anchor_supports_breakpoint_placement(&self, anchor: Anchor, cx: &App) -> bool {
+        let Some(buffer) = self.buffer.read(cx).buffer_for_anchor(anchor, cx) else {
+            return false;
+        };
+
+        if !self.buffer_supports_breakpoints(&buffer, cx) {
+            return false;
+        }
+
+        let snapshot = self.buffer.read(cx).snapshot(cx);
+        let point = anchor.to_point(&snapshot);
+        let row = MultiBufferRow(point.row);
+        if snapshot.is_line_blank(row) {
+            return false;
+        }
+
+        let line_len = snapshot.line_len(row);
+        let indent = snapshot.indent_size_for_line(row).len.min(line_len);
+        let point_at_code_start = Point::new(row.0, indent);
+
+        !snapshot
+            .language_scope_at(point_at_code_start)
+            .is_some_and(|scope| scope.override_name() == Some("comment"))
+    }
+
+    fn buffer_supports_breakpoints(&self, buffer: &Entity<Buffer>, cx: &App) -> bool {
+        let buffer = buffer.read(cx);
+        let Some(language) = buffer.language() else {
+            return false;
+        };
+
+        let language_name = language.name();
+        let file = buffer.file();
+        let language_settings = language_settings(Some(language_name), file, cx);
+        !language_settings.debuggers.is_empty() || !language.config().debuggers.is_empty()
     }
 
     #[cfg(any(test, feature = "test-support"))]

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -25013,6 +25013,152 @@ async fn test_breakpoint_toggling(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_breakpoint_toggling_in_non_debuggable_file(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let sample_text = "First line\nSecond line\nThird line\nFourth line".to_string();
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/a"),
+        json!({
+            "notes.txt": sample_text,
+        }),
+    )
+    .await;
+    let project = Project::test(fs, [path!("/a").as_ref()], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |mw, _| mw.workspace().clone())
+        .unwrap();
+    let cx = &mut VisualTestContext::from_window(*window, cx);
+    let worktree_id = workspace.update_in(cx, |workspace, _window, cx| {
+        workspace.project().update(cx, |project, cx| {
+            project.worktrees(cx).next().unwrap().read(cx).id()
+        })
+    });
+
+    let buffer = project
+        .update(cx, |project, cx| {
+            project.open_buffer((worktree_id, rel_path("notes.txt")), cx)
+        })
+        .await
+        .unwrap();
+
+    let (editor, cx) = cx.add_window_view(|window, cx| {
+        Editor::new(
+            EditorMode::full(),
+            MultiBuffer::build_from_buffer(buffer, cx),
+            Some(project.clone()),
+            window,
+            cx,
+        )
+    });
+
+    editor.update_in(cx, |editor, window, cx| {
+        editor.toggle_breakpoint(&actions::ToggleBreakpoint, window, cx);
+        editor.move_to_end(&MoveToEnd, window, cx);
+        editor.toggle_breakpoint(&actions::ToggleBreakpoint, window, cx);
+    });
+
+    let breakpoints = editor.update(cx, |editor, cx| {
+        editor
+            .breakpoint_store()
+            .as_ref()
+            .unwrap()
+            .read(cx)
+            .all_source_breakpoints(cx)
+    });
+
+    assert_eq!(0, breakpoints.len());
+}
+
+#[gpui::test]
+async fn test_breakpoint_toggling_ignores_blank_and_comment_lines(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let sample_text =
+        "// comment only\n\nfn main() {\n    // also comment only\n    let value = 1;\n}".to_string();
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/a"),
+        json!({
+            "main.rs": sample_text,
+        }),
+    )
+    .await;
+    let project = Project::test(fs, [path!("/a").as_ref()], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |mw, _| mw.workspace().clone())
+        .unwrap();
+    let cx = &mut VisualTestContext::from_window(*window, cx);
+    let worktree_id = workspace.update_in(cx, |workspace, _window, cx| {
+        workspace.project().update(cx, |project, cx| {
+            project.worktrees(cx).next().unwrap().read(cx).id()
+        })
+    });
+
+    let buffer = project
+        .update(cx, |project, cx| {
+            project.open_buffer((worktree_id, rel_path("main.rs")), cx)
+        })
+        .await
+        .unwrap();
+
+    let (editor, cx) = cx.add_window_view(|window, cx| {
+        Editor::new(
+            EditorMode::full(),
+            MultiBuffer::build_from_buffer(buffer, cx),
+            Some(project.clone()),
+            window,
+            cx,
+        )
+    });
+
+    let project_path = editor.update(cx, |editor, cx| editor.project_path(cx).unwrap());
+    let abs_path = project.read_with(cx, |project, cx| {
+        project
+            .absolute_path(&project_path, cx)
+            .map(Arc::from)
+            .unwrap()
+    });
+
+    editor.update_in(cx, |editor, window, cx| {
+        // row 0: comment
+        editor.toggle_breakpoint(&actions::ToggleBreakpoint, window, cx);
+
+        // row 1: blank line
+        editor.move_down(&MoveDown, window, cx);
+        editor.toggle_breakpoint(&actions::ToggleBreakpoint, window, cx);
+
+        // row 3: comment inside code
+        editor.move_down(&MoveDown, window, cx);
+        editor.move_down(&MoveDown, window, cx);
+        editor.toggle_breakpoint(&actions::ToggleBreakpoint, window, cx);
+
+        // row 4: executable line
+        editor.move_down(&MoveDown, window, cx);
+        editor.toggle_breakpoint(&actions::ToggleBreakpoint, window, cx);
+    });
+
+    let breakpoints = editor.update(cx, |editor, cx| {
+        editor
+            .breakpoint_store()
+            .as_ref()
+            .unwrap()
+            .read(cx)
+            .all_source_breakpoints(cx)
+    });
+
+    assert_eq!(1, breakpoints.len());
+    assert_breakpoint(
+        &breakpoints,
+        &abs_path,
+        vec![(4, Breakpoint::new_standard())],
+    );
+}
+
+#[gpui::test]
 async fn test_log_breakpoint_editing(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -24864,7 +24864,7 @@ fn add_log_breakpoint_at_cursor(
     let (anchor, bp) = editor
         .breakpoints_at_cursors(window, cx)
         .first()
-        .and_then(|(anchor, bp)| bp.as_ref().map(|bp| (*anchor, bp.clone())))
+        .and_then(|(anchor, bp, _)| bp.as_ref().map(|bp| (*anchor, bp.clone())))
         .unwrap_or_else(|| {
             let snapshot = editor.snapshot(window, cx);
             let cursor_position: Point =
@@ -24928,6 +24928,7 @@ async fn test_breakpoint_toggling(cx: &mut TestAppContext) {
         })
         .await
         .unwrap();
+    buffer.update(cx, |buffer, cx| buffer.set_language(Some(rust_lang()), cx));
 
     let (editor, cx) = cx.add_window_view(|window, cx| {
         Editor::new(
@@ -25070,92 +25071,6 @@ async fn test_breakpoint_toggling_in_non_debuggable_file(cx: &mut TestAppContext
     });
 
     assert_eq!(0, breakpoints.len());
-}
-
-#[gpui::test]
-async fn test_breakpoint_toggling_ignores_blank_and_comment_lines(cx: &mut TestAppContext) {
-    init_test(cx, |_| {});
-
-    let sample_text =
-        "// comment only\n\nfn main() {\n    // also comment only\n    let value = 1;\n}".to_string();
-    let fs = FakeFs::new(cx.executor());
-    fs.insert_tree(
-        path!("/a"),
-        json!({
-            "main.rs": sample_text,
-        }),
-    )
-    .await;
-    let project = Project::test(fs, [path!("/a").as_ref()], cx).await;
-    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
-    let workspace = window
-        .read_with(cx, |mw, _| mw.workspace().clone())
-        .unwrap();
-    let cx = &mut VisualTestContext::from_window(*window, cx);
-    let worktree_id = workspace.update_in(cx, |workspace, _window, cx| {
-        workspace.project().update(cx, |project, cx| {
-            project.worktrees(cx).next().unwrap().read(cx).id()
-        })
-    });
-
-    let buffer = project
-        .update(cx, |project, cx| {
-            project.open_buffer((worktree_id, rel_path("main.rs")), cx)
-        })
-        .await
-        .unwrap();
-
-    let (editor, cx) = cx.add_window_view(|window, cx| {
-        Editor::new(
-            EditorMode::full(),
-            MultiBuffer::build_from_buffer(buffer, cx),
-            Some(project.clone()),
-            window,
-            cx,
-        )
-    });
-
-    let project_path = editor.update(cx, |editor, cx| editor.project_path(cx).unwrap());
-    let abs_path = project.read_with(cx, |project, cx| {
-        project
-            .absolute_path(&project_path, cx)
-            .map(Arc::from)
-            .unwrap()
-    });
-
-    editor.update_in(cx, |editor, window, cx| {
-        // row 0: comment
-        editor.toggle_breakpoint(&actions::ToggleBreakpoint, window, cx);
-
-        // row 1: blank line
-        editor.move_down(&MoveDown, window, cx);
-        editor.toggle_breakpoint(&actions::ToggleBreakpoint, window, cx);
-
-        // row 3: comment inside code
-        editor.move_down(&MoveDown, window, cx);
-        editor.move_down(&MoveDown, window, cx);
-        editor.toggle_breakpoint(&actions::ToggleBreakpoint, window, cx);
-
-        // row 4: executable line
-        editor.move_down(&MoveDown, window, cx);
-        editor.toggle_breakpoint(&actions::ToggleBreakpoint, window, cx);
-    });
-
-    let breakpoints = editor.update(cx, |editor, cx| {
-        editor
-            .breakpoint_store()
-            .as_ref()
-            .unwrap()
-            .read(cx)
-            .all_source_breakpoints(cx)
-    });
-
-    assert_eq!(1, breakpoints.len());
-    assert_breakpoint(
-        &breakpoints,
-        &abs_path,
-        vec![(4, Breakpoint::new_standard())],
-    );
 }
 
 #[gpui::test]

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1383,7 +1383,10 @@ impl EditorElement {
                 .snapshot
                 .display_point_to_anchor(valid_point, Bias::Left);
 
-            if let Some((buffer_snapshot, file)) = position_map
+            if !editor.anchor_supports_breakpoint_placement(buffer_anchor, cx) {
+                editor.gutter_breakpoint_indicator.1 = None;
+                None
+            } else if let Some((buffer_snapshot, file)) = position_map
                 .snapshot
                 .buffer_snapshot()
                 .buffer_for_excerpt(buffer_anchor.excerpt_id)


### PR DESCRIPTION
Fixes #49861

## Summary : 

- Prevents creating breakpoints in non-debuggable files (for example .md, .txt, .log) by requiring debugger-capable language/file settings before placement.
- Keeps breakpoint placement blocked on blank and comment-only lines using Tree-sitter scope info (language_scope_at(...).override_name() == "comment").
- Ensures gutter phantom breakpoint indicator only appears where placement is allowed.
- Updates breakpoint context-menu behavior so creation/edit actions are hidden when placement is not allowed on that line.
- Adds regression coverage for non-debuggable files.

## Some areas where this might fail.

- Languages with weak/missing Tree-sitter comment scopes: comment lines may not be recognized as comment scope, so placement blocking on comment-only lines can be inconsistent.
- User settings overrides for debuggers: unusual settings combinations could allow/deny files in ways users don’t expect.
- Multi-buffer/excerpt boundaries: row/anchor mapping can be tricky at boundaries, though I already reduced this risk by using row-based checks in creation paths


## Testing

cargo test -p editor test_breakpoint_toggling_in_non_debuggable_file -- --nocapture (passes in your run)


## Video

[Screencast from 2026-02-24 22-00-07.webm](https://github.com/user-attachments/assets/e0a75c81-9ed9-4476-b5f0-315626577d07)


Release Notes:

- Fixed debugger breakpoint placement to block non-debuggable files and invalid lines in the editor gutter.