### PR TITLE
Redact environment variables from debugger errors

### DIFF
--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -35,6 +35,7 @@ use tree_sitter::{Query, StreamingIterator as _};
 use ui::{
     ContextMenu, Divider, PopoverMenu, PopoverMenuHandle, SplitButton, Tab, Tooltip, prelude::*,
 };
+use util::redact::redact_command;
 use util::rel_path::RelPath;
 use util::{ResultExt, debug_panic, maybe};
 use workspace::SplitDirection;
@@ -275,12 +276,13 @@ impl DebugPanel {
 
             async move |_, cx| {
                 if let Err(error) = task.await {
-                    log::error!("{error:#}");
+                    let redacted_error = redact_command(&format!("{error:#}"));
+                    log::error!("{redacted_error}");
                     session
                         .update(cx, |session, cx| {
                             session
                                 .console_output(cx)
-                                .unbounded_send(format!("error: {:#}", error))
+                                .unbounded_send(format!("error: {:#}", redacted_error))
                                 .ok();
                             session.shutdown(cx)
                         })

--- a/crates/util/src/process.rs
+++ b/crates/util/src/process.rs
@@ -36,7 +36,12 @@ impl Child {
             .stdout(stdout)
             .stderr(stderr)
             .spawn()
-            .with_context(|| format!("failed to spawn command {command:?}"))?;
+            .with_context(|| {
+                format!(
+                    "failed to spawn command {}",
+                    crate::redact::redact_command(&format!("{command:?}"))
+                )
+            })?;
         Ok(Self { process })
     }
 
@@ -55,7 +60,12 @@ impl Child {
             .stdout(stdout)
             .stderr(stderr)
             .spawn()
-            .with_context(|| format!("failed to spawn command {command:?}"))?;
+            .with_context(|| {
+                format!(
+                    "failed to spawn command {}",
+                    crate::redact::redact_command(&format!("{command:?}"))
+                )
+            })?;
 
         Ok(Self { process })
     }


### PR DESCRIPTION
Closes #50007

- Follow-up to: https://github.com/zed-industries/zed/pull/44783

Release Notes:

- Improved redaction of sensitive environment variables from debugger error logs.