### PR TITLE
Pause scheduled background agent workflow

### DIFF
--- a/.github/workflows/background_agent_mvp.yml
+++ b/.github/workflows/background_agent_mvp.yml
@@ -1,8 +1,11 @@
 name: background_agent_mvp
 
+# NOTE: Scheduled runs disabled as of 2026-02-24. The workflow can still be
+# triggered manually via workflow_dispatch. See Notion doc "Background Agent
+# for Zed" for current status and contact info to resume this work.
 on:
-  schedule:
-    - cron: "0 16 * * 1-5"
+  # schedule:
+  #   - cron: "0 16 * * 1-5"
   workflow_dispatch:
     inputs:
       crash_ids:


### PR DESCRIPTION
Disable the cron schedule for the background agent MVP workflow. Manual runs via workflow_dispatch are still available.

The workflow was running daily on weekdays but the project is being paused. This change:
- Comments out the schedule trigger
- Adds a note pointing to the Notion doc for context
- Preserves the ability to run manually

See [Background Agent for Zed](https://www.notion.so/Background-Agent-for-Zed-3038aa087eb980449b9ee02f70ae8413) Notion doc for current status and contacts to resume this work.

Release Notes:

- N/A