### PR TITLE
extension_ci: Add debugging step

### DIFF
--- a/.github/workflows/extension_tests.yml
+++ b/.github/workflows/extension_tests.yml
@@ -137,6 +137,12 @@ jobs:
             echo "Version changes happen in separate PRs and will be performed by the zed-zippy bot"
             exit 42
         fi
+    - name: extension_tests::breakpoint
+      if: failure()
+      uses: namespacelabs/breakpoint-action@ca62bf12510ebf1115a560cf337a35fad5eb052b
+      with:
+        duration: 15m
+        authorized-users: MrSubidubi
     timeout-minutes: 6
   tests_pass:
     needs:

--- a/tooling/xtask/src/tasks/workflows/extension_tests.rs
+++ b/tooling/xtask/src/tasks/workflows/extension_tests.rs
@@ -95,9 +95,21 @@ pub(crate) fn check_extension() -> NamedJob {
         .add_step(cache_rust_dependencies_namespace()) // Extensions can compile Rust, so provide the cache if needed.
         .add_step(check())
         .add_step(check_version_job)
-        .add_step(verify_version_did_not_change(version_changed));
+        .add_step(verify_version_did_not_change(version_changed))
+        .add_step(breakpoint());
 
     named::job(job)
+}
+
+fn breakpoint() -> Step<Use> {
+    named::uses(
+        "namespacelabs",
+        "breakpoint-action",
+        "ca62bf12510ebf1115a560cf337a35fad5eb052b",
+    )
+    .if_condition(Expression::new("failure()"))
+    .add_with(("duration", "15m"))
+    .add_with(("authorized-users", "MrSubidubi"))
 }
 
 pub fn cache_zed_extension_cli() -> (Step<Use>, StepOutput) {


### PR DESCRIPTION
GitHub 4 me 0 -  after testing for x times in a local and even the remote setup provided by Namespace during an action, this now adds a dedicated step to debug the failure we are seeing in extension tests to finally resolve said issue.

Release Notes:

- N/A