### PR TITLE
thread_view: Fix markdown tab title

### DIFF
--- a/crates/agent_ui/src/acp/thread_view/active_thread.rs
+++ b/crates/agent_ui/src/acp/thread_view/active_thread.rs
@@ -4138,16 +4138,33 @@ impl AcpThreadView {
             });
 
             workspace.update_in(cx, |workspace, window, cx| {
-                let buffer = cx
-                    .new(|cx| MultiBuffer::singleton(buffer, cx).with_title(thread_title.clone()));
+                let multibuffer = cx
+                    .new(|cx| MultiBuffer::singleton(buffer.clone(), cx).with_title(thread_title.clone()));
+
+                let editor = cx.new(|cx| {
+                    let mut editor =
+                        Editor::for_multibuffer(multibuffer, Some(project.clone()), window, cx);
+                    editor.set_breadcrumb_header(thread_title);
+
+                    cx.subscribe(&buffer, move |editor, buffer, event, cx| {
+                        if let language::BufferEvent::Saved = event {
+                            if let Some(file) = buffer.read(cx).file() {
+                                let file_name = file.file_name(cx).to_string();
+                                editor.buffer().update(cx, |mb, cx| {
+                                    mb.set_title(file_name.clone(), cx);
+                                });
+                                editor.set_breadcrumb_header(file_name);
+                                cx.notify();
+                            }
+                        }
+                    })
+                    .detach();
+
+                    editor
+                });
 
                 workspace.add_item_to_active_pane(
-                    Box::new(cx.new(|cx| {
-                        let mut editor =
-                            Editor::for_multibuffer(buffer, Some(project.clone()), window, cx);
-                        editor.set_breadcrumb_header(thread_title);
-                        editor
-                    })),
+                    Box::new(editor),
                     None,
                     true,
                     window,


### PR DESCRIPTION
Fixes #49958.

## Summary :
When opening an LLM thread as markdown via the "Open Thread as Markdown" action, a new editor tab is spawned with the thread's title as the explicit tab and breadcrumb title. Previously, when the user subsequently saved this buffer to a different filename, the tab title and breadcrumbs would remain as the original thread title rather than updating to match the new file name.

This PR adds a buffer event subscription to `Editor::for_multibuffer` within [open_thread_as_markdown] that listens for `language::BufferEvent::Saved`. When the buffer is successfully saved and acquires a file path, we update the multibuffer's title and the editor's breadcrumb header to reflect this new name. This allows the saved filename to immediately and correctly appear in the tab bar and breadcrumbs.

## Video

[Screencast from 2026-02-25 01-10-59.webm](https://github.com/user-attachments/assets/ff433fe5-dcd3-4905-b4b7-30a81ef1ec0f)


Release Notes:

- Fixed the tab title not updating when saving an LLM thread as Markdown with a different filename
