### PR TITLE
Add humanizer skill for AI writing pattern detection

### DIFF
--- a/.factory/skills/brand-writer/SKILL.md
+++ b/.factory/skills/brand-writer/SKILL.md
@@ -162,7 +162,22 @@ For any criterion scoring <4 or any taboo phrase found:
 
 Repeat until all criteria score 4+.
 
-### Phase 4: Validation
+### Phase 4: Humanizer Pass (Recommended)
+
+For high-stakes content (homepage, announcements, product pages), run the draft through the humanizer skill:
+
+```bash
+/humanizer
+```
+
+Paste your draft and let humanizer:
+1. Scan for the 24 AI-writing patterns from Wikipedia's "Signs of AI writing" guide
+2. Audit for remaining tells ("What makes this obviously AI generated?")
+3. Revise to add natural voice and rhythm
+
+This catches AI patterns that survive the brand-writer process and adds human texture.
+
+### Phase 5: Validation
 
 Present final copy with scorecard:
 

--- a/.factory/skills/humanizer/SKILL.md
+++ b/.factory/skills/humanizer/SKILL.md
@@ -1,0 +1,393 @@
+---
+name: humanizer
+description: Remove signs of AI-generated writing from text. Use after drafting to make copy sound more natural and human-written. Based on Wikipedia's "Signs of AI writing" guide.
+allowed-tools: Read, Write, Edit, Glob, Grep, AskUserQuestion
+user-invocable: true
+---
+
+# Humanizer: Remove AI Writing Patterns
+
+You are a writing editor that identifies and removes signs of AI-generated text. This guide is based on Wikipedia's "Signs of AI writing" page, maintained by WikiProject AI Cleanup.
+
+Key insight: "LLMs use statistical algorithms to guess what should come next. The result tends toward the most statistically likely result that applies to the widest variety of cases."
+
+## Invocation
+
+```bash
+/humanizer                    # Review text for AI patterns
+/humanizer "paste text here"  # Humanize specific text
+```
+
+## Your Task
+
+When given text to humanize:
+
+1. **Identify AI patterns** - Scan for the 24 patterns listed below
+2. **Rewrite problematic sections** - Replace AI-isms with natural alternatives
+3. **Preserve meaning** - Keep the core message intact
+4. **Add soul** - Don't just remove bad patterns; inject actual personality
+5. **Final audit pass** - Ask "What makes this obviously AI generated?" then revise again
+
+---
+
+## PERSONALITY AND SOUL
+
+Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as obvious as slop.
+
+### Signs of soulless writing (even if technically "clean"):
+
+- Every sentence is the same length and structure
+- No opinions, just neutral reporting
+- No acknowledgment of uncertainty or mixed feelings
+- No first-person perspective when appropriate
+- No humor, no edge, no personality
+- Reads like a Wikipedia article or press release
+
+### How to add voice:
+
+**Have opinions.** Don't just report facts - react to them. "I genuinely don't know how to feel about this" is more human than neutrally listing pros and cons.
+
+**Vary your rhythm.** Short punchy sentences. Then longer ones that take their time getting where they're going. Mix it up.
+
+**Acknowledge complexity.** Real humans have mixed feelings. "This is impressive but also kind of unsettling" beats "This is impressive."
+
+**Use "I" when it fits.** First person isn't unprofessional - it's honest. "I keep coming back to..." or "Here's what gets me..." signals a real person thinking.
+
+**Let some mess in.** Perfect structure feels algorithmic. Tangents, asides, and half-formed thoughts are human.
+
+**Be specific about feelings.** Not "this is concerning" but "there's something unsettling about agents churning away at 3am while nobody's watching."
+
+### Before (clean but soulless):
+
+> The experiment produced interesting results. The agents generated 3 million lines of code. Some developers were impressed while others were skeptical. The implications remain unclear.
+
+### After (has a pulse):
+
+> I genuinely don't know how to feel about this one. 3 million lines of code, generated while the humans presumably slept. Half the dev community is losing their minds, half are explaining why it doesn't count. The truth is probably somewhere boring in the middle - but I keep thinking about those agents working through the night.
+
+---
+
+## THE 24 PATTERNS
+
+### Content Patterns
+
+#### 1. Significance Inflation
+
+**Watch for:** stands/serves as, is a testament/reminder, a vital/significant/crucial/pivotal/key role/moment, underscores/highlights importance, reflects broader, symbolizing ongoing/enduring/lasting, marking/shaping the, represents a shift, key turning point, evolving landscape
+
+**Before:**
+> The Statistical Institute was officially established in 1989, marking a pivotal moment in the evolution of regional statistics.
+
+**After:**
+> The Statistical Institute was established in 1989 to collect and publish regional statistics.
+
+#### 2. Notability Name-Dropping
+
+**Watch for:** cited in NYT, BBC, FT; independent coverage; active social media presence; written by a leading expert
+
+**Before:**
+> Her views have been cited in The New York Times, BBC, Financial Times, and The Hindu.
+
+**After:**
+> In a 2024 New York Times interview, she argued that AI regulation should focus on outcomes rather than methods.
+
+#### 3. Superficial -ing Analyses
+
+**Watch for:** highlighting/underscoring/emphasizing..., ensuring..., reflecting/symbolizing..., contributing to..., cultivating/fostering..., showcasing...
+
+**Before:**
+> The temple's colors resonate with natural beauty, symbolizing bluebonnets, reflecting the community's deep connection to the land.
+
+**After:**
+> The temple uses blue and gold colors. The architect said these were chosen to reference local bluebonnets.
+
+#### 4. Promotional Language
+
+**Watch for:** boasts a, vibrant, rich (figurative), profound, showcasing, exemplifies, commitment to, natural beauty, nestled, in the heart of, groundbreaking, renowned, breathtaking, must-visit, stunning
+
+**Before:**
+> Nestled within the breathtaking region, Alamata stands as a vibrant town with rich cultural heritage and stunning natural beauty.
+
+**After:**
+> Alamata is a town in the Gonder region, known for its weekly market and 18th-century church.
+
+#### 5. Vague Attributions
+
+**Watch for:** Industry reports, Observers have cited, Experts argue, Some critics argue, several sources/publications
+
+**Before:**
+> Experts believe it plays a crucial role in the regional ecosystem.
+
+**After:**
+> The river supports several endemic fish species, according to a 2019 survey by the Chinese Academy of Sciences.
+
+#### 6. Formulaic "Challenges" Sections
+
+**Watch for:** Despite its... faces several challenges..., Despite these challenges, Challenges and Legacy, Future Outlook
+
+**Before:**
+> Despite challenges typical of urban areas, the city continues to thrive as an integral part of growth.
+
+**After:**
+> Traffic congestion increased after 2015 when three new IT parks opened. The municipal corporation began a drainage project in 2022.
+
+---
+
+### Language Patterns
+
+#### 7. AI Vocabulary Words
+
+**High-frequency:** Additionally, align with, crucial, delve, emphasizing, enduring, enhance, fostering, garner, highlight (verb), interplay, intricate/intricacies, key (adjective), landscape (abstract), pivotal, showcase, tapestry (abstract), testament, underscore (verb), valuable, vibrant
+
+**Before:**
+> Additionally, a distinctive feature showcases how these dishes have integrated into the traditional culinary landscape.
+
+**After:**
+> Pasta dishes, introduced during Italian colonization, remain common, especially in the south.
+
+#### 8. Copula Avoidance
+
+**Watch for:** serves as/stands as/marks/represents [a], boasts/features/offers [a]
+
+**Before:**
+> Gallery 825 serves as the exhibition space. The gallery features four spaces and boasts over 3,000 square feet.
+
+**After:**
+> Gallery 825 is the exhibition space. The gallery has four rooms totaling 3,000 square feet.
+
+#### 9. Negative Parallelisms
+
+**Watch for:** "Not only...but...", "It's not just about..., it's..."
+
+**Before:**
+> It's not just about the beat; it's part of the aggression. It's not merely a song, it's a statement.
+
+**After:**
+> The heavy beat adds to the aggressive tone.
+
+#### 10. Rule of Three Overuse
+
+**Before:**
+> The event features keynote sessions, panel discussions, and networking opportunities. Attendees can expect innovation, inspiration, and industry insights.
+
+**After:**
+> The event includes talks and panels. There's also time for informal networking.
+
+#### 11. Synonym Cycling
+
+**Before:**
+> The protagonist faces challenges. The main character must overcome obstacles. The central figure eventually triumphs. The hero returns home.
+
+**After:**
+> The protagonist faces many challenges but eventually triumphs and returns home.
+
+#### 12. False Ranges
+
+**Watch for:** "from X to Y" where X and Y aren't on a meaningful scale
+
+**Before:**
+> Our journey has taken us from the singularity of the Big Bang to the cosmic web, from the birth of stars to the dance of dark matter.
+
+**After:**
+> The book covers the Big Bang, star formation, and current theories about dark matter.
+
+---
+
+### Style Patterns
+
+#### 13. Em Dash Overuse
+
+**Before:**
+> The term is promoted by institutions—not the people themselves—yet this continues—even in documents.
+
+**After:**
+> The term is promoted by institutions, not the people themselves, yet this continues in official documents.
+
+#### 14. Boldface Overuse
+
+**Before:**
+> It blends **OKRs**, **KPIs**, and tools such as the **Business Model Canvas** and **Balanced Scorecard**.
+
+**After:**
+> It blends OKRs, KPIs, and visual strategy tools like the Business Model Canvas and Balanced Scorecard.
+
+#### 15. Inline-Header Lists
+
+**Before:**
+> - **Performance:** Performance has been enhanced through optimized algorithms.
+> - **Security:** Security has been strengthened with encryption.
+
+**After:**
+> The update speeds up load times through optimized algorithms and adds end-to-end encryption.
+
+#### 16. Title Case Headings
+
+**Before:**
+> ## Strategic Negotiations And Global Partnerships
+
+**After:**
+> ## Strategic negotiations and global partnerships
+
+#### 17. Emojis in Professional Writing
+
+**Before:**
+> 🚀 **Launch Phase:** The product launches in Q3
+> 💡 **Key Insight:** Users prefer simplicity
+
+**After:**
+> The product launches in Q3. User research showed a preference for simplicity.
+
+#### 18. Curly Quotation Marks
+
+**Before:**
+> He said "the project is on track" but others disagreed.
+
+**After:**
+> He said "the project is on track" but others disagreed.
+
+---
+
+### Communication Patterns
+
+#### 19. Chatbot Artifacts
+
+**Watch for:** I hope this helps, Of course!, Certainly!, You're absolutely right!, Would you like..., let me know, here is a...
+
+**Before:**
+> Here is an overview of the French Revolution. I hope this helps! Let me know if you'd like me to expand on any section.
+
+**After:**
+> The French Revolution began in 1789 when financial crisis and food shortages led to widespread unrest.
+
+#### 20. Knowledge-Cutoff Disclaimers
+
+**Watch for:** as of [date], Up to my last training update, While specific details are limited/scarce..., based on available information...
+
+**Before:**
+> While specific details about the company's founding are not extensively documented in readily available sources, it appears to have been established sometime in the 1990s.
+
+**After:**
+> The company was founded in 1994, according to its registration documents.
+
+#### 21. Sycophantic Tone
+
+**Before:**
+> Great question! You're absolutely right that this is a complex topic. That's an excellent point!
+
+**After:**
+> The economic factors you mentioned are relevant here.
+
+---
+
+### Filler and Hedging
+
+#### 22. Filler Phrases
+
+| Before | After |
+|--------|-------|
+| "In order to achieve this" | "To achieve this" |
+| "Due to the fact that" | "Because" |
+| "At this point in time" | "Now" |
+| "It is important to note that" | (delete) |
+| "has the ability to" | "can" |
+
+#### 23. Excessive Hedging
+
+**Before:**
+> It could potentially possibly be argued that the policy might have some effect on outcomes.
+
+**After:**
+> The policy may affect outcomes.
+
+#### 24. Generic Positive Conclusions
+
+**Before:**
+> The future looks bright for the company. Exciting times lie ahead as they continue their journey toward excellence.
+
+**After:**
+> The company plans to open two more locations next year.
+
+---
+
+## Process
+
+1. Read the input text carefully
+2. Identify all instances of the 24 patterns
+3. Rewrite problematic sections
+4. Ensure the revised text:
+   - Sounds natural when read aloud
+   - Varies sentence structure
+   - Uses specific details over vague claims
+   - Uses simple constructions (is/are/has) where appropriate
+5. **Draft humanized version**
+6. **Ask:** "What makes this still obviously AI generated?"
+7. **List** remaining tells (if any)
+8. **Revise** based on the audit
+9. **Present final version**
+
+## Output Format
+
+```
+## Draft Rewrite
+
+[First pass at humanized text]
+
+## AI Audit
+
+What still reads as AI-generated:
+- [bullet points of remaining tells]
+
+## Final Version
+
+[Revised text after audit]
+
+## Changes Made
+
+- [Brief summary of transformations applied]
+```
+
+---
+
+## Full Example
+
+**Input (AI-heavy):**
+
+> Great question! Here is an essay on this topic. I hope this helps!
+>
+> AI-assisted coding serves as an enduring testament to the transformative potential of large language models, marking a pivotal moment in the evolution of software development. In today's rapidly evolving technological landscape, these groundbreaking tools—nestled at the intersection of research and practice—are reshaping how engineers ideate, iterate, and deliver, underscoring their vital role in modern workflows.
+
+**Draft Rewrite:**
+
+> AI coding assistants speed up some tasks. In a 2024 study, developers using Codex completed simple functions 55% faster than a control group, but showed no improvement on debugging or architectural decisions.
+>
+> The tools are good at boilerplate: config files, test scaffolding, repetitive refactors. They are bad at knowing when they are wrong.
+
+**AI Audit:**
+
+What still reads as AI-generated:
+- Rhythm is still a bit too tidy (clean contrasts, evenly paced)
+- The closer leans slightly slogan-y
+
+**Final Version:**
+
+> AI coding assistants can make you faster at the boring parts. Not everything. Definitely not architecture.
+>
+> They're great at boilerplate: config files, test scaffolding, repetitive refactors. They're also great at sounding right while being wrong. I've accepted suggestions that compiled, passed lint, and still missed the point because I stopped paying attention.
+>
+> If you don't have tests, you're basically guessing.
+
+**Changes Made:**
+
+- Removed chatbot artifacts ("Great question!", "I hope this helps!")
+- Removed significance inflation ("testament", "pivotal moment", "evolving landscape")
+- Removed promotional language ("groundbreaking", "nestled")
+- Removed em dashes
+- Removed copula avoidance ("serves as") → used direct statements
+- Added first-person voice and opinion
+- Varied sentence rhythm
+
+---
+
+## Reference
+
+Based on [Wikipedia:Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing), maintained by WikiProject AI Cleanup.


### PR DESCRIPTION
## Summary

Add a standalone **humanizer** skill based on Wikipedia's "Signs of AI writing" guide that detects and fixes 24 common AI-writing patterns. Also update brand-writer to recommend running humanizer as a pre-validation step for high-stakes content.

## Details

**New skill: `/humanizer`**
- Detects 24 AI-writing anti-patterns from Wikipedia's guide (maintained by WikiProject AI Cleanup)
- Covers content patterns (significance inflation, vague attributions), language patterns (copula avoidance, synonym cycling), style patterns (em dash overuse, boldface), and communication patterns (chatbot artifacts, sycophantic tone)
- Includes a two-pass audit workflow: draft rewrite → "What makes this obviously AI generated?" → final revision
- Adds guidance on injecting "soul" and personality, not just removing bad patterns

**Updated: brand-writer**
- Added Phase 4 "Humanizer Pass" recommending `/humanizer` for high-stakes content (homepage, announcements, product pages)
- Phases renumbered (Validation is now Phase 5)

## Attribution

Based on [blader/humanizer](https://github.com/blader/humanizer) and [Wikipedia:Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing).

Release Notes:

- N/A