### PR TITLE
zeta2: Use editable range returned by cloud for prediction diffs

### DIFF
--- a/crates/cloud_llm_client/src/predict_edits_v3.rs
+++ b/crates/cloud_llm_client/src/predict_edits_v3.rs
@@ -1,6 +1,7 @@
 use crate::PredictEditsRequestTrigger;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
+use std::ops::Range;
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct RawCompletionRequest {
@@ -27,6 +28,11 @@ pub struct PredictEditsV3Request {
 pub struct PredictEditsV3Response {
     pub request_id: String,
     pub output: String,
+    /// The editable region byte range within `cursor_excerpt` that the
+    /// server used for this request. When present, the client should use
+    /// this range to extract the old text from its local excerpt for
+    /// diffing, rather than relying on its own format-derived range.
+    pub editable_range: Range<usize>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]


### PR DESCRIPTION
Closes #ISSUE

Before you mark this PR as ready for review, make sure that you have:
- [ ] Added a solid test coverage and/or screenshots from doing manual testing
- [ ] Done a self-review taking into account security and performance aspects
- [ ] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- N/A *or* Added/Fixed/Improved ...
