### PR TITLE
Add pane join actions for vim-like split close workflows

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -249,8 +249,14 @@ actions!(
         GoToOlderTag,
         /// Navigates forward in the tag stack.
         GoToNewerTag,
-        /// Joins this pane into the next pane.
+        /// Joins this pane into the next pane. The source pane's active tab remains active.
         JoinIntoNext,
+        /// Joins this pane into the next pane. The destination pane's active tab remains active.
+        JoinIntoNextAsInactive,
+        /// Joins this pane into the previous pane. The source pane's active tab remains active.
+        JoinIntoPrevious,
+        /// Joins this pane into the previous pane. The destination pane's active tab remains active.
+        JoinIntoPreviousAsInactive,
         /// Joins all panes into one.
         JoinAll,
         /// Reopens the most recently closed item.
@@ -310,6 +316,9 @@ pub enum Event {
     ItemUnpinned,
     JoinAll,
     JoinIntoNext,
+    JoinIntoNextAsInactive,
+    JoinIntoPrevious,
+    JoinIntoPreviousAsInactive,
     ChangeItemTitle,
     Focus,
     ZoomIn,
@@ -343,6 +352,9 @@ impl fmt::Debug for Event {
                 .finish(),
             Event::JoinAll => f.write_str("JoinAll"),
             Event::JoinIntoNext => f.write_str("JoinIntoNext"),
+            Event::JoinIntoNextAsInactive => f.write_str("JoinIntoNextAsInactive"),
+            Event::JoinIntoPrevious => f.write_str("JoinIntoPrevious"),
+            Event::JoinIntoPreviousAsInactive => f.write_str("JoinIntoPreviousAsInactive"),
             Event::ChangeItemTitle => f.write_str("ChangeItemTitle"),
             Event::Focus => f.write_str("Focus"),
             Event::ZoomIn => f.write_str("ZoomIn"),
@@ -4244,6 +4256,15 @@ impl Render for Pane {
             }))
             .on_action(cx.listener(|_, _: &JoinIntoNext, _, cx| {
                 cx.emit(Event::JoinIntoNext);
+            }))
+            .on_action(cx.listener(|_, _: &JoinIntoNextAsInactive, _, cx| {
+                cx.emit(Event::JoinIntoNextAsInactive);
+            }))
+            .on_action(cx.listener(|_, _: &JoinIntoPrevious, _, cx| {
+                cx.emit(Event::JoinIntoPrevious);
+            }))
+            .on_action(cx.listener(|_, _: &JoinIntoPreviousAsInactive, _, cx| {
+                cx.emit(Event::JoinIntoPreviousAsInactive);
             }))
             .on_action(cx.listener(|_, _: &JoinAll, _, cx| {
                 cx.emit(Event::JoinAll);

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -4654,6 +4654,15 @@ impl Workspace {
             pane::Event::JoinIntoNext => {
                 self.join_pane_into_next(pane.clone(), window, cx);
             }
+            pane::Event::JoinIntoNextAsInactive => {
+                self.join_pane_into_next_as_inactive(pane.clone(), window, cx);
+            }
+            pane::Event::JoinIntoPrevious => {
+                self.join_pane_into_previous(pane.clone(), window, cx);
+            }
+            pane::Event::JoinIntoPreviousAsInactive => {
+                self.join_pane_into_previous_as_inactive(pane.clone(), window, cx);
+            }
             pane::Event::JoinAll => {
                 self.join_all_panes(window, cx);
             }
@@ -4826,21 +4835,77 @@ impl Workspace {
         cx.notify();
     }
 
+    fn find_next_pane(&mut self, cx: &mut Context<Self>) -> Option<Entity<Pane>> {
+        self.find_pane_in_direction(SplitDirection::Right, cx)
+            .or_else(|| self.find_pane_in_direction(SplitDirection::Down, cx))
+            .or_else(|| self.find_pane_in_direction(SplitDirection::Left, cx))
+            .or_else(|| self.find_pane_in_direction(SplitDirection::Up, cx))
+    }
+
+    fn find_previous_pane(&mut self, cx: &mut Context<Self>) -> Option<Entity<Pane>> {
+        self.find_pane_in_direction(SplitDirection::Left, cx)
+            .or_else(|| self.find_pane_in_direction(SplitDirection::Up, cx))
+            .or_else(|| self.find_pane_in_direction(SplitDirection::Right, cx))
+            .or_else(|| self.find_pane_in_direction(SplitDirection::Down, cx))
+    }
+
     pub fn join_pane_into_next(
         &mut self,
         pane: Entity<Pane>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let next_pane = self
-            .find_pane_in_direction(SplitDirection::Right, cx)
-            .or_else(|| self.find_pane_in_direction(SplitDirection::Down, cx))
-            .or_else(|| self.find_pane_in_direction(SplitDirection::Left, cx))
-            .or_else(|| self.find_pane_in_direction(SplitDirection::Up, cx));
-        let Some(next_pane) = next_pane else {
+        let Some(next_pane) = self.find_next_pane(cx) else {
             return;
         };
         move_all_items(&pane, &next_pane, window, cx);
+        cx.notify();
+    }
+
+    pub fn join_pane_into_next_as_inactive(
+        &mut self,
+        pane: Entity<Pane>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(next_pane) = self.find_next_pane(cx) else {
+            return;
+        };
+        let active_item = next_pane.read(cx).active_item();
+        move_all_items(&pane, &next_pane, window, cx);
+        if let Some(active_item) = active_item {
+            self.activate_item(active_item.as_ref(), true, true, window, cx);
+        }
+        cx.notify();
+    }
+
+    pub fn join_pane_into_previous(
+        &mut self,
+        pane: Entity<Pane>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(previous_pane) = self.find_previous_pane(cx) else {
+            return;
+        };
+        move_all_items(&pane, &previous_pane, window, cx);
+        cx.notify();
+    }
+
+    pub fn join_pane_into_previous_as_inactive(
+        &mut self,
+        pane: Entity<Pane>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(previous_pane) = self.find_previous_pane(cx) else {
+            return;
+        };
+        let active_item = previous_pane.read(cx).active_item();
+        move_all_items(&pane, &previous_pane, window, cx);
+        if let Some(active_item) = active_item {
+            self.activate_item(active_item.as_ref(), true, true, window, cx);
+        }
         cx.notify();
     }
 
@@ -11234,6 +11299,206 @@ mod tests {
         workspace.update(cx, |workspace, _cx| {
             let active_pane = workspace.active_pane();
             assert_eq!(top_pane_id, active_pane.entity_id());
+        });
+    }
+
+    #[gpui::test]
+    async fn test_join_pane_into_next_as_inactive(cx: &mut gpui::TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, None, cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project, window, cx));
+
+        // Create two panes: left and right
+        // Left has left_item active, right has right_item active
+        let left_item = cx.new(|cx| {
+            TestItem::new(cx).with_project_items(&[TestProjectItem::new(1, "left.txt", cx)])
+        });
+        let right_item = cx.new(|cx| {
+            TestItem::new(cx).with_project_items(&[TestProjectItem::new(2, "right.txt", cx)])
+        });
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.add_item_to_active_pane(
+                Box::new(left_item.clone()),
+                None,
+                false,
+                window,
+                cx,
+            );
+            workspace.split_pane(
+                workspace.active_pane().clone(),
+                SplitDirection::Right,
+                window,
+                cx,
+            );
+        });
+
+        let right_pane = workspace.update_in(cx, |workspace, window, cx| {
+            let right_pane = workspace.active_pane().clone();
+            workspace.add_item_to_active_pane(
+                Box::new(right_item.clone()),
+                None,
+                false,
+                window,
+                cx,
+            );
+            // Focus back to left pane
+            workspace.activate_previous_pane(window, cx);
+            right_pane
+        });
+
+        cx.executor().run_until_parked();
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            // Active pane is left, join into right (as inactive)
+            assert_ne!(workspace.active_pane().entity_id(), right_pane.entity_id());
+            workspace
+                .join_pane_into_next_as_inactive(workspace.active_pane().clone(), window, cx);
+        });
+
+        workspace.update(cx, |workspace, cx| {
+            let active_pane = workspace.active_pane();
+            assert_eq!(active_pane.entity_id(), right_pane.entity_id());
+            assert_eq!(2, active_pane.read(cx).items_len());
+            // The right pane's original active item should still be active
+            assert_eq!(
+                active_pane.read(cx).active_item().unwrap().item_id(),
+                right_item.item_id()
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_join_pane_into_previous(cx: &mut gpui::TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, None, cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project, window, cx));
+
+        let left_item = cx.new(|cx| {
+            TestItem::new(cx).with_project_items(&[TestProjectItem::new(1, "left.txt", cx)])
+        });
+        let right_item = cx.new(|cx| {
+            TestItem::new(cx).with_project_items(&[TestProjectItem::new(2, "right.txt", cx)])
+        });
+
+        let left_pane = workspace.update_in(cx, |workspace, window, cx| {
+            let left_pane = workspace.active_pane().clone();
+            workspace.add_item_to_active_pane(
+                Box::new(left_item.clone()),
+                None,
+                false,
+                window,
+                cx,
+            );
+            workspace.split_pane(
+                workspace.active_pane().clone(),
+                SplitDirection::Right,
+                window,
+                cx,
+            );
+            left_pane
+        });
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.add_item_to_active_pane(
+                Box::new(right_item.clone()),
+                None,
+                false,
+                window,
+                cx,
+            );
+        });
+
+        cx.executor().run_until_parked();
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            assert_ne!(workspace.active_pane().entity_id(), left_pane.entity_id());
+            workspace.join_pane_into_previous(workspace.active_pane().clone(), window, cx);
+        });
+
+        workspace.update(cx, |workspace, cx| {
+            let active_pane = workspace.active_pane();
+            assert_eq!(active_pane.entity_id(), left_pane.entity_id());
+            assert_eq!(2, active_pane.read(cx).items_len());
+            let item_ids: HashSet<_> = active_pane
+                .read(cx)
+                .items()
+                .map(|item| item.item_id())
+                .collect();
+            assert!(item_ids.contains(&left_item.item_id()));
+            assert!(item_ids.contains(&right_item.item_id()));
+        });
+    }
+
+    #[gpui::test]
+    async fn test_join_pane_into_previous_as_inactive(cx: &mut gpui::TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, None, cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project, window, cx));
+
+        let left_item = cx.new(|cx| {
+            TestItem::new(cx).with_project_items(&[TestProjectItem::new(1, "left.txt", cx)])
+        });
+        let right_item = cx.new(|cx| {
+            TestItem::new(cx).with_project_items(&[TestProjectItem::new(2, "right.txt", cx)])
+        });
+
+        let left_pane = workspace.update_in(cx, |workspace, window, cx| {
+            let left_pane = workspace.active_pane().clone();
+            workspace.add_item_to_active_pane(
+                Box::new(left_item.clone()),
+                None,
+                false,
+                window,
+                cx,
+            );
+            workspace.split_pane(
+                workspace.active_pane().clone(),
+                SplitDirection::Right,
+                window,
+                cx,
+            );
+            left_pane
+        });
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.add_item_to_active_pane(
+                Box::new(right_item.clone()),
+                None,
+                false,
+                window,
+                cx,
+            );
+        });
+
+        cx.executor().run_until_parked();
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            assert_ne!(workspace.active_pane().entity_id(), left_pane.entity_id());
+            workspace.join_pane_into_previous_as_inactive(
+                workspace.active_pane().clone(),
+                window,
+                cx,
+            );
+        });
+
+        workspace.update(cx, |workspace, cx| {
+            let active_pane = workspace.active_pane();
+            assert_eq!(active_pane.entity_id(), left_pane.entity_id());
+            assert_eq!(2, active_pane.read(cx).items_len());
+            assert_eq!(
+                active_pane.read(cx).active_item().unwrap().item_id(),
+                left_item.item_id()
+            );
         });
     }
 


### PR DESCRIPTION
Follow-up to #47079 which added `tab_switcher::OpenInActivePane` for vim/helix-like buffer management (i.e. tabs hidden, buffers available in every pane). That PR noted the need for better pane close behavior — in vim/helix, closing a split (`:q`) closes the window but buffers remain available. Zed's tab model ties items to panes, so the closest equivalent is joining items into an adjacent pane without disrupting the destination's active tab.

The existing `pane::JoinIntoNext` gets partway there, but it always activates the source pane's tab in the destination, and only searches in the "next" direction (Right → Down → Left → Up). These new actions fill the gaps:

**Actions:**
- `pane::JoinIntoNext` *(existing)* — Joins this pane into the next pane. The source pane's active tab remains active.
- `pane::JoinIntoNextAsInactive` *(new)* — Joins this pane into the next pane. The destination pane's active tab remains active.
- `pane::JoinIntoPrevious` *(new)* — Joins this pane into the previous pane. The source pane's active tab remains active.
- `pane::JoinIntoPreviousAsInactive` *(new)* — Joins this pane into the previous pane. The destination pane's active tab remains active.

**Example keymap for vim-like `:q` behavior:**
```json
{
  "context": "Pane",
  "bindings": {
    "cmd-w": "pane::JoinIntoPreviousAsInactive"
  }
}
```

This closes the current split and moves its items to the previous pane (typically left/above), without disrupting the destination pane's active tab — approximating how vim/helix close windows.

**Future work:**
- Map vim's `:q` to `pane::JoinIntoPreviousAsInactive` so closing a split behaves like vim/helix out of the box.

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist) (N/A — no UI changes)

Release Notes:

- Added `pane::JoinIntoNextAsInactive`, `pane::JoinIntoPrevious`, and `pane::JoinIntoPreviousAsInactive` actions for more flexible pane join behavior, enabling vim/helix-like split close workflows.