### PR TITLE
Add MacOS and Linux settings for immediate rendering

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -43,9 +43,10 @@ use crate::{
     KeyBinding, KeyContext, Keymap, Keystroke, LayoutId, Menu, MenuItem, OwnedMenu,
     PathPromptOptions, Pixels, Platform, PlatformDisplay, PlatformKeyboardLayout,
     PlatformKeyboardMapper, Point, Priority, PromptBuilder, PromptButton, PromptHandle,
-    PromptLevel, Render, RenderImage, RenderablePromptHandle, Reservation, ScreenCaptureSource,
-    SharedString, SubscriberSet, Subscription, SvgRenderer, Task, TextRenderingMode, TextSystem,
-    ThermalState, Window, WindowAppearance, WindowHandle, WindowId, WindowInvalidator,
+    PromptLevel, Render, RenderImage, RenderablePromptHandle, RenderingMode, Reservation,
+    ScreenCaptureSource, SharedString, SubscriberSet, Subscription, SvgRenderer, Task,
+    TextRenderingMode, TextSystem, ThermalState, Window, WindowAppearance, WindowHandle, WindowId,
+    WindowInvalidator,
     colors::{Colors, GlobalColors},
     hash, init_app_menus,
 };
@@ -624,6 +625,7 @@ pub struct App {
     #[cfg(any(test, feature = "test-support", debug_assertions))]
     pub(crate) name: Option<&'static str>,
     pub(crate) text_rendering_mode: Rc<Cell<TextRenderingMode>>,
+    pub(crate) rendering_mode: Rc<Cell<RenderingMode>>,
     quit_mode: QuitMode,
     quitting: bool,
     /// Per-App element arena. This isolates element allocations between different
@@ -658,6 +660,7 @@ impl App {
                 platform: platform.clone(),
                 text_system,
                 text_rendering_mode: Rc::new(Cell::new(TextRenderingMode::default())),
+                rendering_mode: Rc::new(Cell::new(RenderingMode::default())),
                 mode: GpuiMode::Production,
                 actions: Rc::new(ActionRegistry::default()),
                 flushing_effects: false,
@@ -1157,6 +1160,19 @@ impl App {
     /// Returns the current text rendering mode for the application.
     pub fn text_rendering_mode(&self) -> TextRenderingMode {
         self.text_rendering_mode.get()
+    }
+
+    /// Sets the rendering mode for the application.
+    pub fn set_rendering_mode(&mut self, mode: RenderingMode) {
+        self.rendering_mode.set(mode);
+        self.set_global(mode);
+        #[cfg(target_os = "macos")]
+        self.platform.set_rendering_mode(mode);
+    }
+
+    /// Returns the current rendering mode for the application.
+    pub fn rendering_mode(&self) -> RenderingMode {
+        self.rendering_mode.get()
     }
 
     /// Writes data to the platform clipboard.

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -226,6 +226,12 @@ pub trait Platform: 'static {
     fn keyboard_layout(&self) -> Box<dyn PlatformKeyboardLayout>;
     fn keyboard_mapper(&self) -> Rc<dyn PlatformKeyboardMapper>;
     fn on_keyboard_layout_change(&self, callback: Box<dyn FnMut()>);
+
+    #[cfg(target_os = "macos")]
+    fn set_rendering_mode(&self, mode: RenderingMode);
+
+    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    fn set_rendering_mode(&self, mode: RenderingMode);
 }
 
 /// A handle to a platform's display, e.g. a monitor or laptop screen.
@@ -1438,6 +1444,18 @@ pub enum TextRenderingMode {
     /// Use grayscale text rendering.
     Grayscale,
 }
+
+/// The rendering mode for the GPU pipeline.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub enum RenderingMode {
+    /// Use the platform's default rendering mode.
+    #[default]
+    PlatformDefault,
+    /// Real-time rendering mode (may cause visual artifacts).
+    Immediate,
+}
+
+impl crate::Global for RenderingMode {}
 
 /// The options that can be configured for a file dialog prompt
 #[derive(Clone, Debug)]

--- a/crates/gpui/src/platform/test/platform.rs
+++ b/crates/gpui/src/platform/test/platform.rs
@@ -2,8 +2,8 @@ use crate::{
     AnyWindowHandle, BackgroundExecutor, ClipboardItem, CursorStyle, DevicePixels,
     DummyKeyboardMapper, ForegroundExecutor, Keymap, NoopTextSystem, Platform, PlatformDisplay,
     PlatformKeyboardLayout, PlatformKeyboardMapper, PlatformTextSystem, PromptButton,
-    ScreenCaptureFrame, ScreenCaptureSource, ScreenCaptureStream, SourceMetadata, Task,
-    TestDisplay, TestWindow, ThermalState, WindowAppearance, WindowParams, size,
+    RenderingMode, ScreenCaptureFrame, ScreenCaptureSource, ScreenCaptureStream, SourceMetadata,
+    Task, TestDisplay, TestWindow, ThermalState, WindowAppearance, WindowParams, size,
 };
 use anyhow::Result;
 use collections::VecDeque;
@@ -226,6 +226,8 @@ impl Platform for TestPlatform {
     }
 
     fn on_keyboard_layout_change(&self, _: Box<dyn FnMut()>) {}
+
+    fn set_rendering_mode(&self, _: RenderingMode) {}
 
     fn on_thermal_state_change(&self, _: Box<dyn FnMut()>) {}
 

--- a/crates/gpui/src/platform/visual_test.rs
+++ b/crates/gpui/src/platform/visual_test.rs
@@ -251,4 +251,6 @@ impl Platform for VisualTestPlatform {
     }
 
     fn on_thermal_state_change(&self, _callback: Box<dyn FnMut()>) {}
+
+    fn set_rendering_mode(&self, _mode: super::RenderingMode) {}
 }

--- a/crates/gpui_linux/src/linux/platform.rs
+++ b/crates/gpui_linux/src/linux/platform.rs
@@ -26,7 +26,8 @@ use gpui::{
     Action, AnyWindowHandle, BackgroundExecutor, ClipboardItem, CursorStyle, DisplayId,
     ForegroundExecutor, Keymap, Menu, MenuItem, OwnedMenu, PathPromptOptions, Platform,
     PlatformDisplay, PlatformKeyboardLayout, PlatformKeyboardMapper, PlatformTextSystem,
-    PlatformWindow, Result, RunnableVariant, Task, ThermalState, WindowAppearance, WindowParams,
+    PlatformWindow, RenderingMode, Result, RunnableVariant, Task, ThermalState, WindowAppearance,
+    WindowParams,
 };
 #[cfg(any(feature = "wayland", feature = "x11"))]
 use gpui::{Pixels, Point, px};
@@ -179,6 +180,11 @@ impl<P: LinuxClient + 'static> Platform for LinuxPlatform<P> {
     fn on_keyboard_layout_change(&self, callback: Box<dyn FnMut()>) {
         self.inner
             .with_common(|common| common.callbacks.keyboard_layout_change = Some(callback));
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+    fn set_rendering_mode(&self, mode: RenderingMode) {
+        gpui::platform::wgpu::set_rendering_mode(mode);
     }
 
     fn on_thermal_state_change(&self, _callback: Box<dyn FnMut()>) {}

--- a/crates/gpui_macos/src/metal_renderer.rs
+++ b/crates/gpui_macos/src/metal_renderer.rs
@@ -8,8 +8,8 @@ use cocoa::{
 };
 use gpui::{
     AtlasTextureId, Background, Bounds, ContentMask, DevicePixels, MonochromeSprite, PaintSurface,
-    Path, Point, PolychromeSprite, PrimitiveBatch, Quad, ScaledPixels, Scene, Shadow, Size,
-    Surface, Underline, point, size,
+    Path, Point, PolychromeSprite, PrimitiveBatch, Quad, RenderingMode, ScaledPixels, Scene,
+    Shadow, Size, Surface, Underline, point, size,
 };
 #[cfg(any(test, feature = "test-support"))]
 use image::RgbaImage;
@@ -28,6 +28,14 @@ use objc::{self, msg_send, sel, sel_impl};
 use parking_lot::Mutex;
 
 use std::{cell::Cell, ffi::c_void, mem, ptr, sync::Arc};
+
+thread_local! {
+    static RENDERING_MODE: Cell<RenderingMode> = const { Cell::new(RenderingMode::PlatformDefault) };
+}
+
+pub fn set_rendering_mode(mode: RenderingMode) {
+    RENDERING_MODE.with(|m| m.set(mode));
+}
 
 // Exported to metal
 pub(crate) type PointF = gpui::Point<f32>;
@@ -169,7 +177,11 @@ impl MetalRenderer {
         // Support direct-to-display rendering if the window is not transparent
         // https://developer.apple.com/documentation/metal/managing-your-game-window-for-metal-in-macos
         layer.set_opaque(!transparent);
-        layer.set_maximum_drawable_count(3);
+        let drawable_count = RENDERING_MODE.with(|m| m.get());
+        layer.set_maximum_drawable_count(match drawable_count {
+            RenderingMode::PlatformDefault => 3,
+            RenderingMode::Immediate => 1,
+        });
         // Allow texture reading for visual tests (captures screenshots without ScreenCaptureKit)
         #[cfg(any(test, feature = "test-support"))]
         layer.set_framebuffer_only(false);

--- a/crates/gpui_macos/src/platform.rs
+++ b/crates/gpui_macos/src/platform.rs
@@ -26,6 +26,7 @@ use core_foundation::{
 use ctor::ctor;
 use dispatch2::DispatchQueue;
 use futures::channel::oneshot;
+use gpui::RenderingMode;
 use gpui::{
     Action, AnyWindowHandle, BackgroundExecutor, ClipboardItem, CursorStyle, ForegroundExecutor,
     KeyContext, Keymap, Menu, MenuItem, OsMenu, OwnedMenu, PathPromptOptions, Platform,
@@ -869,6 +870,11 @@ impl Platform for MacPlatform {
 
     fn on_keyboard_layout_change(&self, callback: Box<dyn FnMut()>) {
         self.0.lock().on_keyboard_layout_change = Some(callback);
+    }
+
+    #[cfg(target_os = "macos")]
+    fn set_rendering_mode(&self, mode: RenderingMode) {
+        renderer::set_rendering_mode(mode);
     }
 
     fn on_app_menu_action(&self, callback: Box<dyn FnMut(&dyn Action)>) {

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -4,14 +4,23 @@ use crate::{WgpuAtlas, WgpuContext};
 use bytemuck::{Pod, Zeroable};
 use gpui::{
     AtlasTextureId, Background, Bounds, DevicePixels, GpuSpecs, MonochromeSprite, Path, Point,
-    PolychromeSprite, PrimitiveBatch, Quad, ScaledPixels, Scene, Shadow, Size, SubpixelSprite,
-    Underline, get_gamma_correction_ratios,
+    PolychromeSprite, PrimitiveBatch, Quad, RenderingMode, ScaledPixels, Scene, Shadow, Size,
+    SubpixelSprite, Underline, get_gamma_correction_ratios,
 };
 use log::warn;
 #[cfg(not(target_family = "wasm"))]
 use raw_window_handle::{HasDisplayHandle, HasWindowHandle};
+use std::cell::Cell;
 use std::num::NonZeroU64;
 use std::sync::{Arc, Mutex};
+
+thread_local! {
+    static RENDERING_MODE: Cell<RenderingMode> = const { Cell::new(RenderingMode::PlatformDefault) };
+}
+
+pub(crate) fn set_rendering_mode(mode: RenderingMode) {
+    RENDERING_MODE.with(|m| m.set(mode));
+}
 
 #[repr(C)]
 #[derive(Clone, Copy, Pod, Zeroable)]
@@ -262,13 +271,20 @@ impl WgpuRenderer {
             );
         }
 
+        let rendering_mode = RENDERING_MODE.with(|m| m.get());
         let surface_config = wgpu::SurfaceConfiguration {
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
             format: surface_format,
             width: clamped_width.max(1),
             height: clamped_height.max(1),
-            present_mode: wgpu::PresentMode::Fifo,
-            desired_maximum_frame_latency: 2,
+            present_mode: match rendering_mode {
+                RenderingMode::PlatformDefault => wgpu::PresentMode::Fifo,
+                RenderingMode::Immediate => wgpu::PresentMode::Immediate,
+            },
+            desired_maximum_frame_latency: match rendering_mode {
+                RenderingMode::PlatformDefault => 2,
+                RenderingMode::Immediate => 1,
+            },
             alpha_mode,
             view_formats: vec![],
         };

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -937,6 +937,7 @@ impl VsCodeSettings {
         WorkspaceSettingsContent {
             active_pane_modifiers: self.active_pane_modifiers(),
             text_rendering_mode: None,
+            rendering_mode: None,
             autosave: self.read_enum("files.autoSave", |s| match s {
                 "off" => Some(AutosaveSetting::Off),
                 "afterDelay" => Some(AutosaveSetting::AfterDelay {

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -19,6 +19,12 @@ pub struct WorkspaceSettingsContent {
     ///
     /// Default: platform_default
     pub text_rendering_mode: Option<TextRenderingMode>,
+    /// The rendering mode for the GPU pipeline.
+    /// - "platform_default": Use platform default rendering
+    /// - "immediate": Real-time rendering mode (may cause visual artifacts)
+    ///
+    /// Default: platform_default
+    pub rendering_mode: Option<RenderingMode>,
     /// Layout mode for the bottom dock
     ///
     /// Default: contained
@@ -621,6 +627,16 @@ pub enum TextRenderingMode {
     Subpixel,
     /// Use grayscale text rendering.
     Grayscale,
+}
+
+#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize, JsonSchema, MergeFrom)]
+#[serde(rename_all = "snake_case")]
+pub enum RenderingMode {
+    /// Use platform default rendering.
+    #[default]
+    PlatformDefault,
+    /// Real-time rendering mode (may cause visual artifacts).
+    Immediate,
 }
 
 impl OnLastWindowClosed {

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -29,6 +29,7 @@ pub struct WorkspaceSettings {
     pub when_closing_with_no_tabs: settings::CloseWindowWhenNoItems,
     pub on_last_window_closed: settings::OnLastWindowClosed,
     pub text_rendering_mode: settings::TextRenderingMode,
+    pub rendering_mode: settings::RenderingMode,
     pub resize_all_panels_in_dock: Vec<DockPosition>,
     pub close_on_file_delete: bool,
     pub close_panel_on_toggle: bool,
@@ -101,6 +102,7 @@ impl Settings for WorkspaceSettings {
             when_closing_with_no_tabs: workspace.when_closing_with_no_tabs.unwrap(),
             on_last_window_closed: workspace.on_last_window_closed.unwrap(),
             text_rendering_mode: workspace.text_rendering_mode.unwrap(),
+            rendering_mode: workspace.rendering_mode.clone().unwrap_or_default(),
             resize_all_panels_in_dock: workspace
                 .resize_all_panels_in_dock
                 .clone()

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -753,6 +753,13 @@ fn main() {
                     },
                 );
 
+                cx.set_rendering_mode(match WorkspaceSettings::get_global(cx).rendering_mode {
+                    settings::RenderingMode::PlatformDefault => {
+                        gpui::RenderingMode::PlatformDefault
+                    }
+                    settings::RenderingMode::Immediate => gpui::RenderingMode::Immediate,
+                });
+
                 let new_host = &client::ClientSettings::get_global(cx).server_url;
                 if &http.base_url() != new_host {
                     http.set_base_url(new_host);


### PR DESCRIPTION
This PR adds a user setting for immediate rendering, on MacOS and Linux. I saw noticeable improvements on MacOS 14.8.3 with Apple Silicon. I haven’t been able to manually test on Linux due to GPU virtualization issues. On my Windows VM I didn’t notice any rendering latency to begin with.

As a longtime user of Sublime Text, I love the extremely low latency from keystroke to render. The current Zed rendering latency on MacOS is the reason I haven’t used it more, but making immediate rendering the default could be a breaking change impacting more than the typing experience. 

I’m happy to refine as needed.

Possibly related to #26900.