### PR TITLE
Use a separate feature flag for EP jumps than for zeta2

### DIFF
--- a/crates/edit_prediction/src/edit_prediction.rs
+++ b/crates/edit_prediction/src/edit_prediction.rs
@@ -105,13 +105,14 @@ const ZED_PREDICT_DATA_COLLECTION_CHOICE: &str = "zed_predict_data_collection_ch
 const REJECT_REQUEST_DEBOUNCE: Duration = Duration::from_secs(15);
 
 pub struct Zeta2FeatureFlag;
+pub struct EditPredictionJumpsFeatureFlag;
 
 impl FeatureFlag for Zeta2FeatureFlag {
     const NAME: &'static str = "zeta2";
+}
 
-    fn enabled_for_staff() -> bool {
-        true
-    }
+impl FeatureFlag for EditPredictionJumpsFeatureFlag {
+    const NAME: &'static str = "edit_prediction_jumps";
 }
 
 #[derive(Clone)]
@@ -1035,7 +1036,7 @@ impl EditPredictionStore {
                 }
             }
             project::Event::DiagnosticsUpdated { .. } => {
-                if cx.has_flag::<Zeta2FeatureFlag>() {
+                if cx.has_flag::<EditPredictionJumpsFeatureFlag>() {
                     self.refresh_prediction_from_diagnostics(
                         project,
                         DiagnosticSearchScope::Global,

--- a/crates/edit_prediction_ui/src/edit_prediction_ui.rs
+++ b/crates/edit_prediction_ui/src/edit_prediction_ui.rs
@@ -3,7 +3,7 @@ mod edit_prediction_context_view;
 mod rate_prediction_modal;
 
 use command_palette_hooks::CommandPaletteFilter;
-use edit_prediction::{EditPredictionStore, ResetOnboarding, Zeta2FeatureFlag, capture_example};
+use edit_prediction::{EditPredictionStore, ResetOnboarding, capture_example};
 use edit_prediction_context_view::EditPredictionContextView;
 use editor::Editor;
 use feature_flags::FeatureFlagAppExt as _;
@@ -54,28 +54,25 @@ pub fn init(cx: &mut App) {
             capture_example_as_markdown(workspace, window, cx);
         });
         workspace.register_action_renderer(|div, _, _, cx| {
-            let has_flag = cx.has_flag::<Zeta2FeatureFlag>();
-            div.when(has_flag, |div| {
-                div.on_action(cx.listener(
-                    move |workspace, _: &OpenEditPredictionContextView, window, cx| {
-                        let project = workspace.project();
-                        workspace.split_item(
-                            SplitDirection::Right,
-                            Box::new(cx.new(|cx| {
-                                EditPredictionContextView::new(
-                                    project.clone(),
-                                    workspace.client(),
-                                    workspace.user_store(),
-                                    window,
-                                    cx,
-                                )
-                            })),
-                            window,
-                            cx,
-                        );
-                    },
-                ))
-            })
+            div.on_action(cx.listener(
+                move |workspace, _: &OpenEditPredictionContextView, window, cx| {
+                    let project = workspace.project();
+                    workspace.split_item(
+                        SplitDirection::Right,
+                        Box::new(cx.new(|cx| {
+                            EditPredictionContextView::new(
+                                project.clone(),
+                                workspace.client(),
+                                workspace.user_store(),
+                                window,
+                                cx,
+                            )
+                        })),
+                        window,
+                        cx,
+                    );
+                },
+            ))
         });
     })
     .detach();


### PR DESCRIPTION
This allows us to enable zeta2 for certain end users without opting them into the still-in-development jumps feature.

Release Notes:

- N/A
