### PR TITLE
Add side-by-side split diff view to FileDiffView

### DIFF
--- a/crates/editor/src/split.rs
+++ b/crates/editor/src/split.rs
@@ -433,6 +433,17 @@ impl SplittableEditor {
         self.lhs.as_ref().map(|s| &s.editor)
     }
 
+    pub fn update_editors(
+        &self,
+        cx: &mut Context<Self>,
+        f: impl Fn(&mut Editor, &mut Context<Editor>),
+    ) {
+        if let Some(lhs) = &self.lhs {
+            lhs.editor.update(cx, &f);
+        }
+        self.rhs_editor.update(cx, &f);
+    }
+
     pub fn diff_view_style(&self) -> DiffViewStyle {
         self.diff_view_style
     }
@@ -446,15 +457,18 @@ impl SplittableEditor {
         render_diff_hunk_controls: RenderDiffHunkControlsFn,
         cx: &mut Context<Self>,
     ) {
-        self.rhs_editor.update(cx, |editor, cx| {
+        self.update_editors(cx, |editor, cx| {
             editor.set_render_diff_hunk_controls(render_diff_hunk_controls.clone(), cx);
         });
+    }
 
-        if let Some(lhs) = &self.lhs {
-            lhs.editor.update(cx, |editor, cx| {
-                editor.set_render_diff_hunk_controls(render_diff_hunk_controls.clone(), cx);
-            });
-        }
+    pub fn disable_diff_hunk_controls(&self, cx: &mut Context<Self>) {
+        let empty_controls = Arc::new(|_, _: &_, _, _, _, _: &_, _: &mut _, _: &mut _| {
+            gpui::Empty.into_any_element()
+        });
+        self.update_editors(cx, |editor, cx| {
+            editor.set_render_diff_hunk_controls(empty_controls.clone(), cx);
+        });
     }
 
     fn focused_side(&self) -> SplitSide {
@@ -2125,14 +2139,9 @@ mod tests {
                 window,
                 cx,
             );
-            editor.rhs_editor.update(cx, |editor, cx| {
+            editor.update_editors(cx, |editor, cx| {
                 editor.set_soft_wrap_mode(soft_wrap, cx);
             });
-            if let Some(lhs) = &editor.lhs {
-                lhs.editor.update(cx, |editor, cx| {
-                    editor.set_soft_wrap_mode(soft_wrap, cx);
-                });
-            }
             editor
         });
         (editor, cx)

--- a/crates/git_ui/src/file_diff_view.rs
+++ b/crates/git_ui/src/file_diff_view.rs
@@ -2,7 +2,7 @@
 
 use anyhow::Result;
 use buffer_diff::BufferDiff;
-use editor::{Editor, EditorEvent, MultiBuffer};
+use editor::{Editor, EditorEvent, EditorSettings, MultiBuffer, SplittableEditor};
 use futures::{FutureExt, select_biased};
 use gpui::{
     AnyElement, App, AppContext as _, AsyncApp, Context, Entity, EventEmitter, FocusHandle,
@@ -10,6 +10,7 @@ use gpui::{
 };
 use language::{Buffer, HighlightedText, LanguageRegistry};
 use project::Project;
+use settings::Settings;
 use std::{
     any::{Any, TypeId},
     path::PathBuf,
@@ -26,7 +27,7 @@ use workspace::{
 };
 
 pub struct FileDiffView {
-    editor: Entity<Editor>,
+    editor: Entity<SplittableEditor>,
     old_buffer: Entity<Buffer>,
     new_buffer: Entity<Buffer>,
     buffer_changes_tx: watch::Sender<()>,
@@ -57,12 +58,14 @@ impl FileDiffView {
             let buffer_diff = build_buffer_diff(&old_buffer, &new_buffer, languages, cx).await?;
 
             workspace.update_in(cx, |workspace, window, cx| {
+                let workspace_entity = cx.entity();
                 let diff_view = cx.new(|cx| {
                     FileDiffView::new(
                         old_buffer,
                         new_buffer,
                         buffer_diff,
                         project.clone(),
+                        workspace_entity,
                         window,
                         cx,
                     )
@@ -83,6 +86,7 @@ impl FileDiffView {
         new_buffer: Entity<Buffer>,
         diff: Entity<BufferDiff>,
         project: Entity<Project>,
+        workspace: Entity<Workspace>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
@@ -92,16 +96,19 @@ impl FileDiffView {
             multibuffer
         });
         let editor = cx.new(|cx| {
-            let mut editor =
-                Editor::for_multibuffer(multibuffer.clone(), Some(project.clone()), window, cx);
-            editor.start_temporary_diff_override();
-            editor.disable_diagnostics(cx);
-            editor.set_expand_all_diff_hunks(cx);
-            editor.set_render_diff_hunk_controls(
-                Arc::new(|_, _, _, _, _, _, _, _| gpui::Empty.into_any_element()),
+            let splittable = SplittableEditor::new(
+                EditorSettings::get_global(cx).diff_view_style,
+                multibuffer.clone(),
+                project.clone(),
+                workspace,
+                window,
                 cx,
             );
-            editor
+            splittable.rhs_editor().update(cx, |editor, _| {
+                editor.start_temporary_diff_override();
+            });
+            splittable.disable_diff_hunk_controls(cx);
+            splittable
         });
 
         let (buffer_changes_tx, mut buffer_changes_rx) = watch::channel(());
@@ -268,22 +275,19 @@ impl Item for FileDiffView {
     }
 
     fn deactivated(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        self.editor
-            .update(cx, |editor, cx| editor.deactivated(window, cx));
+        self.editor.deactivated(window, cx);
     }
 
     fn act_as_type<'a>(
         &'a self,
         type_id: TypeId,
         self_handle: &'a Entity<Self>,
-        _: &'a App,
+        cx: &'a App,
     ) -> Option<gpui::AnyEntity> {
         if type_id == TypeId::of::<Self>() {
             Some(self_handle.clone().into())
-        } else if type_id == TypeId::of::<Editor>() {
-            Some(self.editor.clone().into())
         } else {
-            None
+            self.editor.act_as_type(type_id, cx)
         }
     }
 
@@ -305,8 +309,10 @@ impl Item for FileDiffView {
         _: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.editor.update(cx, |editor, _| {
-            editor.set_nav_history(Some(nav_history));
+        self.editor.update(cx, |editor, cx| {
+            editor.rhs_editor().update(cx, |editor, _| {
+                editor.set_nav_history(Some(nav_history));
+            })
         });
     }
 
@@ -316,8 +322,11 @@ impl Item for FileDiffView {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> bool {
-        self.editor
-            .update(cx, |editor, cx| editor.navigate(data, window, cx))
+        self.editor.update(cx, |editor, cx| {
+            editor
+                .rhs_editor()
+                .update(cx, |editor, cx| editor.navigate(data, window, cx))
+        })
     }
 
     fn breadcrumb_location(&self, _: &App) -> ToolbarItemLocation {
@@ -335,13 +344,14 @@ impl Item for FileDiffView {
         cx: &mut Context<Self>,
     ) {
         self.editor.update(cx, |editor, cx| {
-            editor.added_to_workspace(workspace, window, cx)
+            editor.rhs_editor().update(cx, |editor, cx| {
+                editor.added_to_workspace(workspace, window, cx)
+            })
         });
     }
 
     fn can_save(&self, cx: &App) -> bool {
-        // The editor handles the new buffer, so delegate to it
-        self.editor.read(cx).can_save(cx)
+        self.editor.read(cx).rhs_editor().read(cx).can_save(cx)
     }
 
     fn save(
@@ -351,9 +361,7 @@ impl Item for FileDiffView {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Task<Result<()>> {
-        // Delegate saving to the editor, which manages the new buffer
-        self.editor
-            .update(cx, |editor, cx| editor.save(options, project, window, cx))
+        self.editor.save(options, project, window, cx)
     }
 }
 
@@ -367,9 +375,10 @@ impl Render for FileDiffView {
 mod tests {
     use super::*;
     use editor::test::editor_test_context::assert_state_with_diff;
+    use gpui::BorrowAppContext;
     use gpui::TestAppContext;
     use project::{FakeFs, Fs, Project};
-    use settings::SettingsStore;
+    use settings::{DiffViewStyle, SettingsStore};
     use std::path::PathBuf;
     use unindent::unindent;
     use util::path;
@@ -379,6 +388,11 @@ mod tests {
         cx.update(|cx| {
             let settings_store = SettingsStore::test(cx);
             cx.set_global(settings_store);
+            cx.update_global::<SettingsStore, _>(|store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    settings.editor.diff_view_style = Some(DiffViewStyle::Unified);
+                });
+            });
             theme_settings::init(theme::LoadThemes::JustBase, cx);
         });
     }
@@ -418,7 +432,9 @@ mod tests {
 
         // Verify initial diff
         assert_state_with_diff(
-            &diff_view.read_with(cx, |diff_view, _| diff_view.editor.clone()),
+            &diff_view.read_with(cx, |diff_view, cx| {
+                diff_view.editor.read(cx).rhs_editor().clone()
+            }),
             cx,
             &unindent(
                 "
@@ -453,7 +469,9 @@ mod tests {
         // The diff now reflects the changes to the new file
         cx.executor().advance_clock(RECALCULATE_DIFF_DEBOUNCE);
         assert_state_with_diff(
-            &diff_view.read_with(cx, |diff_view, _| diff_view.editor.clone()),
+            &diff_view.read_with(cx, |diff_view, cx| {
+                diff_view.editor.read(cx).rhs_editor().clone()
+            }),
             cx,
             &unindent(
                 "
@@ -488,7 +506,9 @@ mod tests {
         // The diff now reflects the changes to the new file
         cx.executor().advance_clock(RECALCULATE_DIFF_DEBOUNCE);
         assert_state_with_diff(
-            &diff_view.read_with(cx, |diff_view, _| diff_view.editor.clone()),
+            &diff_view.read_with(cx, |diff_view, cx| {
+                diff_view.editor.read(cx).rhs_editor().clone()
+            }),
             cx,
             &unindent(
                 "
@@ -552,8 +572,10 @@ mod tests {
             .unwrap();
 
         diff_view.update_in(cx, |diff_view, window, cx| {
-            diff_view.editor.update(cx, |editor, cx| {
-                editor.insert("modified ", window, cx);
+            diff_view.editor.update(cx, |splittable, cx| {
+                splittable.rhs_editor().update(cx, |editor, cx| {
+                    editor.insert("modified ", window, cx);
+                });
             });
         });
 

--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -359,13 +359,9 @@ impl ProjectDiff {
             );
             match branch_diff.read(cx).diff_base() {
                 DiffBase::Head => {}
-                DiffBase::Merge { .. } => diff_display_editor.set_render_diff_hunk_controls(
-                    Arc::new(|_, _, _, _, _, _, _, _| gpui::Empty.into_any_element()),
-                    cx,
-                ),
+                DiffBase::Merge { .. } => diff_display_editor.disable_diff_hunk_controls(cx),
             }
             diff_display_editor.rhs_editor().update(cx, |editor, cx| {
-                editor.disable_diagnostics(cx);
                 editor.set_show_diff_review_button(true, cx);
 
                 match branch_diff.read(cx).diff_base() {

--- a/crates/git_ui/src/text_diff_view.rs
+++ b/crates/git_ui/src/text_diff_view.rs
@@ -178,14 +178,9 @@ impl TextDiffView {
                 window,
                 cx,
             );
-            splittable.set_render_diff_hunk_controls(
-                Arc::new(|_, _, _, _, _, _, _, _| gpui::Empty.into_any_element()),
-                cx,
-            );
-            splittable.rhs_editor().update(cx, |editor, cx| {
+            splittable.disable_diff_hunk_controls(cx);
+            splittable.rhs_editor().update(cx, |editor, _cx| {
                 editor.start_temporary_diff_override();
-                editor.disable_diagnostics(cx);
-                editor.set_expand_all_diff_hunks(cx);
             });
             splittable
         });

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -1680,8 +1680,7 @@ impl App {
         self.globals_by_type
             .get(&TypeId::of::<G>())
             .map(|any_state| any_state.downcast_ref::<G>().unwrap())
-            .with_context(|| format!("no state of type {} exists", type_name::<G>()))
-            .unwrap()
+            .unwrap_or_else(|| panic!("no state of type {} exists", type_name::<G>()))
     }
 
     /// Access the global of the given type if a value has been assigned.
@@ -1699,8 +1698,7 @@ impl App {
         self.globals_by_type
             .get_mut(&global_type)
             .and_then(|any_state| any_state.downcast_mut::<G>())
-            .with_context(|| format!("no state of type {} exists", type_name::<G>()))
-            .unwrap()
+            .unwrap_or_else(|| panic!("no state of type {} exists", type_name::<G>()))
     }
 
     /// Access the global of the given type mutably. A default value is assigned if a global of this type has not
@@ -1735,7 +1733,7 @@ impl App {
         *self
             .globals_by_type
             .remove(&global_type)
-            .unwrap_or_else(|| panic!("no global added for {}", std::any::type_name::<G>()))
+            .unwrap_or_else(|| panic!("no global added for {}", type_name::<G>()))
             .downcast()
             .unwrap()
     }


### PR DESCRIPTION
## Summary
- Enable VSCode-like side-by-side file comparison in FileDiffView using SplittableEditor
- Leverages existing SplittableEditor infrastructure that ProjectDiff already uses
- Controlled by the user's `diff_view_style` setting (split/unified)

## Changes
- `crates/git_ui/src/file_diff_view.rs`: Refactored to use SplittableEditor instead of plain Editor (+66/-30 lines)

## Test plan
- [ ] Open a file with git changes and verify the diff view renders correctly
- [ ] Toggle between split and unified diff view styles via settings
- [ ] Verify side-by-side comparison shows old/new content correctly

Release Notes:

- Enabled side by side diffs in the file diff view