### PR TITLE
Edit prediction: prioritize related excerpts that are referenced near the cursor

### DIFF
--- a/crates/edit_prediction_context/src/edit_prediction_context.rs
+++ b/crates/edit_prediction_context/src/edit_prediction_context.rs
@@ -39,6 +39,7 @@ struct RelatedBuffer {
     buffer: Entity<Buffer>,
     path: Arc<Path>,
     anchor_ranges: Vec<Range<Anchor>>,
+    excerpt_orders: Vec<usize>,
     cached_file: Option<CachedRelatedFile>,
 }
 
@@ -174,21 +175,21 @@ impl RelatedExcerptStore {
                 };
                 let buffer = project.get_open_buffer(&project_path, cx)?;
                 let snapshot = buffer.read(cx).snapshot();
-                let anchor_ranges = file
-                    .excerpts
-                    .iter()
-                    .map(|excerpt| {
-                        let start = snapshot.anchor_before(Point::new(excerpt.row_range.start, 0));
-                        let end_row = excerpt.row_range.end;
-                        let end_col = snapshot.line_len(end_row);
-                        let end = snapshot.anchor_after(Point::new(end_row, end_col));
-                        start..end
-                    })
-                    .collect();
+                let mut anchor_ranges = Vec::with_capacity(file.excerpts.len());
+                let mut excerpt_orders = Vec::with_capacity(file.excerpts.len());
+                for excerpt in &file.excerpts {
+                    let start = snapshot.anchor_before(Point::new(excerpt.row_range.start, 0));
+                    let end_row = excerpt.row_range.end;
+                    let end_col = snapshot.line_len(end_row);
+                    let end = snapshot.anchor_after(Point::new(end_row, end_col));
+                    anchor_ranges.push(start..end);
+                    excerpt_orders.push(excerpt.order);
+                }
                 Some(RelatedBuffer {
                     buffer,
                     path: file.path.clone(),
                     anchor_ranges,
+                    excerpt_orders,
                     cached_file: None,
                 })
             })
@@ -221,18 +222,55 @@ impl RelatedExcerptStore {
             cx.emit(RelatedExcerptStoreEvent::StartedRefresh);
         })?;
 
-        let identifiers = cx
+        let identifiers_with_ranks = cx
             .background_spawn(async move {
-                identifiers_for_position(&snapshot, position, identifier_line_count)
+                let cursor_offset = position.to_offset(&snapshot);
+                let identifiers =
+                    identifiers_for_position(&snapshot, position, identifier_line_count);
+
+                // Compute byte distance from cursor to each identifier, then sort by
+                // distance so we can assign ordinal ranks. Identifiers at the same
+                // distance share the same rank.
+                let mut identifiers_with_distance: Vec<(Identifier, usize)> = identifiers
+                    .into_iter()
+                    .map(|id| {
+                        let start = id.range.start.to_offset(&snapshot);
+                        let end = id.range.end.to_offset(&snapshot);
+                        let distance = if cursor_offset < start {
+                            start - cursor_offset
+                        } else if cursor_offset > end {
+                            cursor_offset - end
+                        } else {
+                            0
+                        };
+                        (id, distance)
+                    })
+                    .collect();
+                identifiers_with_distance.sort_by_key(|(_, distance)| *distance);
+
+                let mut cursor_distances: HashMap<Identifier, usize> = HashMap::default();
+                let mut current_rank = 0;
+                let mut previous_distance = None;
+                for (identifier, distance) in &identifiers_with_distance {
+                    if previous_distance != Some(*distance) {
+                        current_rank = cursor_distances.len();
+                        previous_distance = Some(*distance);
+                    }
+                    cursor_distances.insert(identifier.clone(), current_rank);
+                }
+
+                (identifiers_with_distance, cursor_distances)
             })
             .await;
+
+        let (identifiers_with_distance, cursor_distances) = identifiers_with_ranks;
 
         let async_cx = cx.clone();
         let start_time = Instant::now();
         let futures = this.update(cx, |this, cx| {
-            identifiers
+            identifiers_with_distance
                 .into_iter()
-                .filter_map(|identifier| {
+                .filter_map(|(identifier, _)| {
                     let task = if let Some(entry) = this.cache.get(&identifier) {
                         DefinitionTask::CacheHit(entry.clone())
                     } else {
@@ -334,7 +372,8 @@ impl RelatedExcerptStore {
         }
         mean_definition_latency /= cache_miss_count.max(1) as u32;
 
-        let (new_cache, related_buffers) = rebuild_related_files(&project, new_cache, cx).await?;
+        let (new_cache, related_buffers) =
+            rebuild_related_files(&project, new_cache, &cursor_distances, cx).await?;
 
         if let Some(file) = &file {
             log::debug!(
@@ -362,6 +401,7 @@ impl RelatedExcerptStore {
 async fn rebuild_related_files(
     project: &Entity<Project>,
     mut new_entries: HashMap<Identifier, Arc<CacheEntry>>,
+    cursor_distances: &HashMap<Identifier, usize>,
     cx: &mut AsyncApp,
 ) -> Result<(HashMap<Identifier, Arc<CacheEntry>>, Vec<RelatedBuffer>)> {
     let mut snapshots = HashMap::default();
@@ -396,12 +436,18 @@ async fn rebuild_related_files(
         }
     }
 
+    let cursor_distances = cursor_distances.clone();
     Ok(cx
         .background_spawn(async move {
             let mut ranges_by_buffer =
-                HashMap::<EntityId, (Entity<Buffer>, Vec<Range<Point>>)>::default();
+                HashMap::<EntityId, (Entity<Buffer>, Vec<(Range<Point>, usize)>)>::default();
             let mut paths_by_buffer = HashMap::default();
-            for entry in new_entries.values_mut() {
+            let mut min_rank_by_buffer = HashMap::<EntityId, usize>::default();
+            for (identifier, entry) in new_entries.iter_mut() {
+                let rank = cursor_distances
+                    .get(identifier)
+                    .copied()
+                    .unwrap_or(usize::MAX);
                 for definition in entry
                     .definitions
                     .iter()
@@ -412,11 +458,16 @@ async fn rebuild_related_files(
                     };
                     paths_by_buffer.insert(definition.buffer.entity_id(), definition.path.clone());
 
+                    let buffer_rank = min_rank_by_buffer
+                        .entry(definition.buffer.entity_id())
+                        .or_insert(usize::MAX);
+                    *buffer_rank = (*buffer_rank).min(rank);
+
                     ranges_by_buffer
                         .entry(definition.buffer.entity_id())
                         .or_insert_with(|| (definition.buffer.clone(), Vec::new()))
                         .1
-                        .push(definition.anchor_range.to_point(snapshot));
+                        .push((definition.anchor_range.to_point(snapshot), rank));
                 }
             }
 
@@ -425,7 +476,7 @@ async fn rebuild_related_files(
                 .filter_map(|(entity_id, (buffer, ranges))| {
                     let snapshot = snapshots.get(&entity_id)?;
                     let project_path = paths_by_buffer.get(&entity_id)?;
-                    let row_ranges = assemble_excerpt_ranges(snapshot, ranges);
+                    let assembled = assemble_excerpt_ranges(snapshot, ranges);
                     let root_name = worktree_root_names.get(&project_path.worktree_id)?;
 
                     let path: Arc<Path> = Path::new(&format!(
@@ -435,20 +486,21 @@ async fn rebuild_related_files(
                     ))
                     .into();
 
-                    let anchor_ranges = row_ranges
-                        .into_iter()
-                        .map(|row_range| {
-                            let start = snapshot.anchor_before(Point::new(row_range.start, 0));
-                            let end_col = snapshot.line_len(row_range.end);
-                            let end = snapshot.anchor_after(Point::new(row_range.end, end_col));
-                            start..end
-                        })
-                        .collect();
+                    let mut anchor_ranges = Vec::with_capacity(assembled.len());
+                    let mut excerpt_orders = Vec::with_capacity(assembled.len());
+                    for (row_range, order) in assembled {
+                        let start = snapshot.anchor_before(Point::new(row_range.start, 0));
+                        let end_col = snapshot.line_len(row_range.end);
+                        let end = snapshot.anchor_after(Point::new(row_range.end, end_col));
+                        anchor_ranges.push(start..end);
+                        excerpt_orders.push(order);
+                    }
 
                     let mut related_buffer = RelatedBuffer {
                         buffer,
                         path,
                         anchor_ranges,
+                        excerpt_orders,
                         cached_file: None,
                     };
                     related_buffer.fill_cache(snapshot);
@@ -456,7 +508,17 @@ async fn rebuild_related_files(
                 })
                 .collect();
 
-            related_buffers.sort_by_key(|related| related.path.clone());
+            related_buffers.sort_by(|a, b| {
+                let rank_a = min_rank_by_buffer
+                    .get(&a.buffer.entity_id())
+                    .copied()
+                    .unwrap_or(usize::MAX);
+                let rank_b = min_rank_by_buffer
+                    .get(&b.buffer.entity_id())
+                    .copied()
+                    .unwrap_or(usize::MAX);
+                rank_a.cmp(&rank_b).then_with(|| a.path.cmp(&b.path))
+            });
 
             (new_entries, related_buffers)
         })
@@ -487,12 +549,14 @@ impl RelatedBuffer {
         let excerpts = self
             .anchor_ranges
             .iter()
-            .map(|range| {
+            .zip(self.excerpt_orders.iter())
+            .map(|(range, &order)| {
                 let start = range.start.to_point(buffer);
                 let end = range.end.to_point(buffer);
                 RelatedExcerpt {
                     row_range: start.row..end.row,
                     text: buffer.text_for_range(start..end).collect::<String>().into(),
+                    order,
                 }
             })
             .collect::<Vec<_>>();

--- a/crates/zeta_prompt/src/zeta_prompt.rs
+++ b/crates/zeta_prompt/src/zeta_prompt.rs
@@ -421,52 +421,166 @@ fn format_edit_history_within_budget(
     result
 }
 
+fn excerpt_rendered_tokens(excerpt: &RelatedExcerpt, file_max_row: u32) -> usize {
+    let needs_newline = !excerpt.text.ends_with('\n');
+    let needs_ellipsis = excerpt.row_range.end < file_max_row;
+    let len = excerpt.text.len()
+        + if needs_newline { "\n".len() } else { 0 }
+        + if needs_ellipsis { "...\n".len() } else { 0 };
+    estimate_tokens(len)
+}
+
 fn format_related_files_within_budget(
     related_files: &[RelatedFile],
     file_marker: &str,
     max_tokens: usize,
 ) -> String {
-    let mut result = String::new();
+    // Collect the distinct order values across all excerpts, sorted ascending.
+    let mut order_levels: Vec<usize> = related_files
+        .iter()
+        .flat_map(|f| f.excerpts.iter().map(|e| e.order))
+        .collect();
+    order_levels.sort_unstable();
+    order_levels.dedup();
+
+    // Pre-compute file header strings and their token costs.
+    let file_headers: Vec<String> = related_files
+        .iter()
+        .map(|file| {
+            let path_str = file.path.to_string_lossy();
+            format!("{}{}\n", file_marker, path_str)
+        })
+        .collect();
+
+    // Track which excerpts are included per file.
+    let mut included: Vec<Vec<bool>> = related_files
+        .iter()
+        .map(|file| vec![false; file.excerpts.len()])
+        .collect();
+    let mut file_included: Vec<bool> = vec![false; related_files.len()];
     let mut total_tokens = 0;
 
-    for file in related_files {
-        let path_str = file.path.to_string_lossy();
-        let header = format!("{}{}\n", file_marker, path_str);
-        let header_tokens = estimate_tokens(header.len());
-
-        if total_tokens + header_tokens > max_tokens {
-            break;
+    // Process order levels from best (lowest) to worst. At each level, try to
+    // include all not-yet-included excerpts with that order across all files.
+    // If the full level doesn't fit, include a partial prefix (top-to-bottom
+    // within each file) and stop — don't proceed to worse order levels.
+    'outer: for &order in &order_levels {
+        // Gather the work for this order level: for each file that has excerpts
+        // at this order, collect the not-yet-included excerpt indices (in their
+        // original positional order) and the token cost to add them (including
+        // the file header if the file isn't already included).
+        struct FileWork {
+            file_idx: usize,
+            excerpt_indices: Vec<usize>,
+            header_cost: usize,
+            excerpt_costs: Vec<usize>,
         }
 
-        let mut file_tokens = header_tokens;
-        let mut excerpts_to_include = 0;
-
-        for excerpt in &file.excerpts {
-            let needs_newline = !excerpt.text.ends_with('\n');
-            let needs_ellipsis = excerpt.row_range.end < file.max_row;
-            let excerpt_len = excerpt.text.len()
-                + if needs_newline { "\n".len() } else { 0 }
-                + if needs_ellipsis { "...\n".len() } else { 0 };
-
-            let excerpt_tokens = estimate_tokens(excerpt_len);
-            if total_tokens + file_tokens + excerpt_tokens > max_tokens {
-                break;
+        let mut work_items: Vec<FileWork> = Vec::new();
+        for (file_idx, file) in related_files.iter().enumerate() {
+            let mut excerpt_indices = Vec::new();
+            let mut excerpt_costs = Vec::new();
+            for (eidx, excerpt) in file.excerpts.iter().enumerate() {
+                if excerpt.order == order && !included[file_idx][eidx] {
+                    excerpt_indices.push(eidx);
+                    excerpt_costs.push(excerpt_rendered_tokens(excerpt, file.max_row));
+                }
             }
-            file_tokens += excerpt_tokens;
-            excerpts_to_include += 1;
+            if excerpt_indices.is_empty() {
+                continue;
+            }
+            let header_cost = if file_included[file_idx] {
+                0
+            } else {
+                estimate_tokens(file_headers[file_idx].len())
+            };
+            work_items.push(FileWork {
+                file_idx,
+                excerpt_indices,
+                header_cost,
+                excerpt_costs,
+            });
         }
 
-        if excerpts_to_include > 0 {
-            total_tokens += file_tokens;
-            result.push_str(&header);
-            for excerpt in file.excerpts.iter().take(excerpts_to_include) {
-                result.push_str(&excerpt.text);
-                if !result.ends_with('\n') {
-                    result.push('\n');
+        // Compute the total cost for this entire order level.
+        let level_cost: usize = work_items
+            .iter()
+            .map(|w| w.header_cost + w.excerpt_costs.iter().sum::<usize>())
+            .sum();
+
+        if total_tokens + level_cost <= max_tokens {
+            // The whole level fits — include everything.
+            for work in &work_items {
+                total_tokens += work.header_cost;
+                file_included[work.file_idx] = true;
+                for (i, &eidx) in work.excerpt_indices.iter().enumerate() {
+                    included[work.file_idx][eidx] = true;
+                    total_tokens += work.excerpt_costs[i];
                 }
-                if excerpt.row_range.end < file.max_row {
-                    result.push_str("...\n");
+            }
+        } else {
+            // The whole level doesn't fit. Include as many excerpts as possible
+            // from each file (in positional order), then stop entirely.
+            for work in &work_items {
+                let available = max_tokens.saturating_sub(total_tokens);
+                let mut file_cost = work.header_cost;
+
+                let mut count = 0;
+                for i in 0..work.excerpt_indices.len() {
+                    if file_cost + work.excerpt_costs[i] > available {
+                        break;
+                    }
+                    file_cost += work.excerpt_costs[i];
+                    count += 1;
                 }
+
+                if count > 0 {
+                    total_tokens += work.header_cost;
+                    file_included[work.file_idx] = true;
+                    for (i, &eidx) in work.excerpt_indices.iter().take(count).enumerate() {
+                        included[work.file_idx][eidx] = true;
+                        total_tokens += work.excerpt_costs[i];
+                    }
+                }
+            }
+            break 'outer;
+        }
+    }
+
+    // Determine file rendering order: by the best (lowest) order of any
+    // included excerpt, breaking ties by original file index.
+    let mut file_order: Vec<(usize, usize)> = Vec::new();
+    for (file_idx, file) in related_files.iter().enumerate() {
+        if !file_included[file_idx] {
+            continue;
+        }
+        let best_order = file
+            .excerpts
+            .iter()
+            .enumerate()
+            .filter(|(eidx, _)| included[file_idx][*eidx])
+            .map(|(_, e)| e.order)
+            .min()
+            .unwrap_or(usize::MAX);
+        file_order.push((file_idx, best_order));
+    }
+    file_order.sort_by_key(|&(file_idx, best_order)| (best_order, file_idx));
+
+    // Render included files and excerpts in positional order within each file.
+    let mut result = String::new();
+    for &(file_idx, _) in &file_order {
+        let file = &related_files[file_idx];
+        result.push_str(&file_headers[file_idx]);
+        for (eidx, excerpt) in file.excerpts.iter().enumerate() {
+            if !included[file_idx][eidx] {
+                continue;
+            }
+            result.push_str(&excerpt.text);
+            if !result.ends_with('\n') {
+                result.push('\n');
+            }
+            if excerpt.row_range.end < file.max_row {
+                result.push_str("...\n");
             }
         }
     }
@@ -1298,6 +1412,149 @@ mod tests {
     }
 
     #[test]
+    fn test_truncation_prioritizes_lower_order_excerpts() {
+        // Two files: file_a has a high-order excerpt, file_b has a low-order one.
+        // With tight budget, only the lower-order excerpt from file_b should be included.
+        let input = make_input(
+            "x",
+            0..1,
+            0,
+            vec![],
+            vec![
+                RelatedFile {
+                    path: Path::new("file_a.rs").into(),
+                    max_row: 10,
+                    in_open_source_repo: false,
+                    excerpts: vec![RelatedExcerpt {
+                        row_range: 0..10,
+                        text: "low priority content\n".into(),
+                        order: 5,
+                    }],
+                },
+                RelatedFile {
+                    path: Path::new("file_b.rs").into(),
+                    max_row: 10,
+                    in_open_source_repo: false,
+                    excerpts: vec![RelatedExcerpt {
+                        row_range: 0..10,
+                        text: "high priority content\n".into(),
+                        order: 1,
+                    }],
+                },
+            ],
+        );
+
+        // With large budget, both files included; file_b (order 1) renders before file_a (order 5).
+        assert_eq!(
+            format_with_budget(&input, 10000),
+            indoc! {r#"
+                <|file_sep|>file_b.rs
+                high priority content
+                <|file_sep|>file_a.rs
+                low priority content
+                <|file_sep|>test.rs
+                <|fim_prefix|>
+                <|fim_middle|>current
+                <|user_cursor|>x
+                <|fim_suffix|>
+                <|fim_middle|>updated
+            "#}
+        );
+
+        // With tight budget, only file_b (lower order) fits.
+        // Cursor section is ~37 tokens, so budget 52 leaves ~15 for related files.
+        // file_b header (7) + excerpt (7) = 14 tokens, which fits.
+        // file_a would need another 14 tokens, which doesn't fit.
+        assert_eq!(
+            format_with_budget(&input, 52),
+            indoc! {r#"
+                <|file_sep|>file_b.rs
+                high priority content
+                <|file_sep|>test.rs
+                <|fim_prefix|>
+                <|fim_middle|>current
+                <|user_cursor|>x
+                <|fim_suffix|>
+                <|fim_middle|>updated
+            "#}
+        );
+    }
+
+    #[test]
+    fn test_truncation_drops_high_order_excerpts_within_file() {
+        // A single file has excerpts at order 1 and order 3. With a tight budget,
+        // only the order-1 excerpts are included while the order-3 excerpt is
+        // dropped — even though they belong to the same file. This also preserves
+        // the parent invariant: parent outline items have order ≤ their best
+        // child, so they're always included when any child is.
+        let input = make_input(
+            "x",
+            0..1,
+            0,
+            vec![],
+            vec![RelatedFile {
+                path: Path::new("mod.rs").into(),
+                max_row: 30,
+                in_open_source_repo: false,
+                excerpts: vec![
+                    RelatedExcerpt {
+                        row_range: 0..5,
+                        text: "mod header\n".into(),
+                        order: 1,
+                    },
+                    RelatedExcerpt {
+                        row_range: 5..15,
+                        text: "important fn\n".into(),
+                        order: 1,
+                    },
+                    RelatedExcerpt {
+                        row_range: 15..30,
+                        text: "less important fn\n".into(),
+                        order: 3,
+                    },
+                ],
+            }],
+        );
+
+        // With large budget, all three excerpts included.
+        assert_eq!(
+            format_with_budget(&input, 10000),
+            indoc! {r#"
+                <|file_sep|>mod.rs
+                mod header
+                ...
+                important fn
+                ...
+                less important fn
+                <|file_sep|>test.rs
+                <|fim_prefix|>
+                <|fim_middle|>current
+                <|user_cursor|>x
+                <|fim_suffix|>
+                <|fim_middle|>updated
+            "#}
+        );
+
+        // With tight budget, only order<=1 excerpts included (header + important fn).
+        assert_eq!(
+            format_with_budget(&input, 55),
+            indoc! {r#"
+                <|file_sep|>mod.rs
+                mod header
+                ...
+                important fn
+                ...
+                <|file_sep|>test.rs
+                <|fim_prefix|>
+                <|fim_middle|>current
+                <|user_cursor|>x
+                <|fim_suffix|>
+                <|fim_middle|>updated
+            "#}
+        );
+    }
+
+    #[test]
     fn test_truncation_drops_older_events_first() {
         let input = make_input(
             "x",
@@ -1462,6 +1719,72 @@ mod tests {
             indoc! {r#"
                 <[fim-suffix]>
                 <[fim-prefix]><filename>test.rs
+                <<<<<<< CURRENT
+                co<|user_cursor|>de
+                =======
+                <[fim-middle]>"#}
+        );
+    }
+
+    #[test]
+    fn test_seed_coder_truncation_prioritizes_lower_order() {
+        let input = make_input(
+            "code",
+            0..4,
+            2,
+            vec![],
+            vec![
+                RelatedFile {
+                    path: Path::new("low_prio.rs").into(),
+                    max_row: 5,
+                    in_open_source_repo: false,
+                    excerpts: vec![RelatedExcerpt {
+                        row_range: 0..5,
+                        text: "low prio\n".into(),
+                        order: 10,
+                    }],
+                },
+                RelatedFile {
+                    path: Path::new("high_prio.rs").into(),
+                    max_row: 5,
+                    in_open_source_repo: false,
+                    excerpts: vec![RelatedExcerpt {
+                        row_range: 0..5,
+                        text: "high prio\n".into(),
+                        order: 1,
+                    }],
+                },
+            ],
+        );
+
+        // With large budget, both included; high_prio first due to lower order.
+        assert_eq!(
+            format_seed_coder(&input),
+            indoc! {r#"
+                <[fim-suffix]>
+                <[fim-prefix]><filename>high_prio.rs
+                high prio
+                <filename>low_prio.rs
+                low prio
+
+                <filename>test.rs
+                <<<<<<< CURRENT
+                co<|user_cursor|>de
+                =======
+                <[fim-middle]>"#}
+        );
+
+        // With tight budget, only high_prio included.
+        // Cursor sections cost 25 tokens, so budget 44 leaves 19 for related files.
+        // high_prio header (7) + excerpt (3) = 10, fits. low_prio would add 10 more = 20 > 19.
+        assert_eq!(
+            format_seed_coder_with_budget(&input, 44),
+            indoc! {r#"
+                <[fim-suffix]>
+                <[fim-prefix]><filename>high_prio.rs
+                high prio
+
+                <filename>test.rs
                 <<<<<<< CURRENT
                 co<|user_cursor|>de
                 =======

--- a/crates/zeta_prompt/src/zeta_prompt.rs
+++ b/crates/zeta_prompt/src/zeta_prompt.rs
@@ -213,6 +213,8 @@ pub struct RelatedFile {
 pub struct RelatedExcerpt {
     pub row_range: Range<u32>,
     pub text: Arc<str>,
+    #[serde(default)]
+    pub order: usize,
 }
 
 pub fn prompt_input_contains_special_tokens(input: &ZetaPromptInput, format: ZetaFormat) -> bool {
@@ -1136,6 +1138,7 @@ mod tests {
             excerpts: vec![RelatedExcerpt {
                 row_range: 0..content.lines().count() as u32,
                 text: content.into(),
+                order: 0,
             }],
             in_open_source_repo: false,
         }
@@ -1244,14 +1247,17 @@ mod tests {
                     RelatedExcerpt {
                         row_range: 0..10,
                         text: "first excerpt\n".into(),
+                        order: 0,
                     },
                     RelatedExcerpt {
                         row_range: 10..20,
                         text: "second excerpt\n".into(),
+                        order: 0,
                     },
                     RelatedExcerpt {
                         row_range: 20..30,
                         text: "third excerpt\n".into(),
+                        order: 0,
                     },
                 ],
             }],


### PR DESCRIPTION
We store the byte distance between the cursor and references to each definition. When including excerpts in the prompt, we prioritize them in the order of proximity. I've updated the Edit Prediction Context view to display the excerpt's `order`, and sorting the files in order of their excerpt with the lowest order.

Release Notes:

- N/A
