### PR TITLE
Fix panic in copilot

### DIFF
--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -1035,10 +1035,9 @@ impl Copilot {
         };
         let buffer_entity = buffer.clone();
         let lsp = server.lsp.clone();
-        let registered_buffer = server
-            .registered_buffers
-            .get_mut(&buffer.entity_id())
-            .unwrap();
+        let Some(registered_buffer) = server.registered_buffers.get_mut(&buffer.entity_id()) else {
+            return Task::ready(Err(anyhow::anyhow!("buffer not registered")));
+        };
         let pending_snapshot = registered_buffer.report_changes(buffer, cx);
         let buffer = buffer.read(cx);
         let uri = registered_buffer.uri.clone();


### PR DESCRIPTION
Fixes ZED-599

register_buffer() only sometimes registers the buffer

Release Notes:

- Fixed a panic in Copilot completions
