### PR TITLE
agent_server_store: Broaden Windows asset detection to all architectures

### DIFF
--- a/crates/project/src/agent_server_store.rs
+++ b/crates/project/src/agent_server_store.rs
@@ -1615,7 +1615,7 @@ impl ExternalAgentServer for LocalCodex {
                                 &asset.browser_download_url,
                                 digest,
                                 &version_dir,
-                                if cfg!(target_os = "windows") && cfg!(target_arch = "x86_64") {
+                                if cfg!(target_os = "windows") {
                                     AssetKind::Zip
                                 } else {
                                     AssetKind::TarGz


### PR DESCRIPTION
Previously only `x86_64` Windows used ZIP archives, but ARM64 Windows builds also use ZIP format.

Closes #50039.

> [!NOTE]
> The P1 is two-fold: the user cannot download the ZIP file on Windows ARM. BUT -- the Agent Panel is stalled because of that. This ONLY makes it so that the ZIP download doesn’t fail, but if for some reason the download fails, the panel is genuinely stuck with no recovery path. Every restart attempts the same download, hits the same GZIP error, and silently drops it again.

Before you mark this PR as ready for review, make sure that you have:
- [ ] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Broaden Windows asset detection to all architectures
