### PR TITLE
languages: Add `.mdc` as a recognized Markdown file suffix

### DIFF
--- a/crates/languages/src/markdown/config.toml
+++ b/crates/languages/src/markdown/config.toml
@@ -1,6 +1,6 @@
 name = "Markdown"
 grammar = "markdown"
-path_suffixes = ["md", "mdx", "mdwn", "markdown", "MD"]
+path_suffixes = ["md", "mdx", "mdwn", "mdc", "markdown", "MD"]
 completion_query_characters = ["-"]
 block_comment = { start = "<!--", prefix = "", end = "-->", tab_size = 0 }
 autoclose_before = ";:.,=}])>"


### PR DESCRIPTION
Highlight files ending in `.mdc` as Markdown.

The `.mdc` extension is used by Cursor for its Markdown-based rule files (`.cursor/rules/*.mdc`). These files are standard Markdown with optional YAML frontmatter, which the existing Markdown grammar already handles well. Adding `.mdc` to the recognized suffixes ensures proper syntax highlighting out of the box.

This was requested during review of the agnix extension PR ([zed-industries/extensions#4743](https://github.com/zed-industries/extensions/pull/4743)) by @MrSubidubi as the preferred approach over defining a custom MDC language in an extension.

Release Notes:

- Added `.mdc` as a recognized Markdown file extension.