### PR TITLE
Fix `Collapse All Files` button being limited to the current buffer

### DIFF
--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -245,9 +245,9 @@ impl Render for BufferSearchBar {
                             cx,
                         )
                     })
-                    .on_click(|_event, window, cx| {
-                        window.dispatch_action(ToggleFoldAll.boxed_clone(), cx)
-                    })
+                    .on_click(cx.listener(|this, _: &ClickEvent, window, cx| {
+                        this.toggle_fold_all(&ToggleFoldAll, window, cx);
+                    }))
             };
 
             if self.dismissed {

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -18,7 +18,7 @@ use editor::{
 };
 use futures::channel::oneshot;
 use gpui::{
-    Action, App, ClickEvent, Context, Entity, EventEmitter, Focusable, InteractiveElement as _,
+    App, ClickEvent, Context, Entity, EventEmitter, Focusable, InteractiveElement as _,
     IntoElement, KeyContext, ParentElement as _, Render, ScrollHandle, Styled, Subscription, Task,
     WeakEntity, Window, div,
 };


### PR DESCRIPTION
Refactor buffer search bar click handler to use listener pattern

The click handler for the buffer search bar now uses the `cx.listener` pattern instead of directly dispatching the action. This approach properly binds the action handler to the component's context and ensures consistent behavior with other event handlers in the codebase.

Closes #ISSUE

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)


before:

https://github.com/user-attachments/assets/4fe5eaa4-be5c-4fe5-92d6-60a4f2059f7a

after:

https://github.com/user-attachments/assets/31238988-b664-4c4b-b143-e4d09c5f0a62



Release Notes:

- Fixed the "Collapse All Files" button to work globally, now it's limited to the current buffer
