### PR TITLE
sidebar: Zoom temporarily hides sidebar

### DIFF
--- a/crates/workspace/src/multi_workspace.rs
+++ b/crates/workspace/src/multi_workspace.rs
@@ -623,6 +623,7 @@ impl MultiWorkspace {
 impl Render for MultiWorkspace {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let multi_workspace_enabled = self.multi_workspace_enabled(cx);
+        let is_zoomed = self.workspace().read(cx).zoomed_item().is_some();
 
         let sidebar: Option<AnyElement> = if multi_workspace_enabled && self.sidebar_open {
             self.sidebar.as_ref().map(|sidebar_handle| {
@@ -676,6 +677,7 @@ impl Render for MultiWorkspace {
         client_side_decorations(
             h_flex()
                 .key_context("Workspace")
+                .relative()
                 .size_full()
                 .on_action(
                     cx.listener(|this: &mut Self, _: &NewWorkspaceInWindow, window, cx| {
@@ -722,12 +724,13 @@ impl Render for MultiWorkspace {
                         .flex_1()
                         .size_full()
                         .overflow_hidden()
+                        .when(is_zoomed, |this| this.absolute().inset_0())
                         .child(self.workspace().clone()),
                 ),
             window,
             cx,
             Tiling {
-                left: multi_workspace_enabled && self.sidebar_open,
+                left: multi_workspace_enabled && self.sidebar_open && !is_zoomed,
                 ..Tiling::default()
             },
         )


### PR DESCRIPTION
Using zoom now temporarily hides the sidebar. Unzooming reopens the sidebar

Release Notes:

- N/A *or* Added/Fixed/Improved ...
