### PR TITLE
Notify after populating MCP server IDs

### DIFF
--- a/crates/project/src/context_server_store.rs
+++ b/crates/project/src/context_server_store.rs
@@ -855,6 +855,7 @@ impl ContextServerStore {
 
                 this.update(cx, |this, cx| {
                     this.populate_server_ids(cx);
+                    cx.notify();
                     this.update_servers_task.take();
                     if this.needs_server_update {
                         this.available_context_servers_changed(cx);


### PR DESCRIPTION
The AgentConfiguration view reads server_ids() from the ContextServerStore during render to decide whether to show MCP server entries or the "No MCP servers added yet" empty state. The server_ids field starts empty and is populated asynchronously by populate_server_ids, which runs after the maintain_servers loop completes. But after updating server_ids, the ContextServerStore never called cx.notify(), so views that read it were never scheduled for re-render.

The UI would still update when at least one server changed status, because those events trigger the AgentConfiguration subscription which calls cx.notify(). That meant the bug was only visible when no servers actually started. In that case server_ids got correctly populated from the settings keys, but no event fired and the agent settings view kept showing the empty state.

In practice, that means you can have several windows with the same global settings.json (so, same MCP servers), and in some windows, you will see them in the agent settings panel, and in others, "No MCP servers added".

The fix adds cx.notify() after populate_server_ids so that the view always re-renders when the set of known server IDs changes.

Release Notes:

-Fixed a UI bug where the agent panel settings would sometimes render the empty state ("No MCP server added yet"), even if there are MCP servers configured in settings.json. In particular, this happened when one of them was hanging on startup.