### PR TITLE
agent_server: Remove root_dir from agent server connect APIs

### DIFF
--- a/crates/agent/src/native_agent_server.rs
+++ b/crates/agent/src/native_agent_server.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, path::Path, rc::Rc, sync::Arc};
+use std::{any::Any, rc::Rc, sync::Arc};
 
 use agent_client_protocol as acp;
 use agent_servers::{AgentServer, AgentServerDelegate};
@@ -35,7 +35,6 @@ impl AgentServer for NativeAgentServer {
 
     fn connect(
         &self,
-        _root_dir: Option<&Path>,
         delegate: AgentServerDelegate,
         cx: &mut App,
     ) -> Task<
@@ -44,10 +43,7 @@ impl AgentServer for NativeAgentServer {
             Option<task::SpawnInTerminal>,
         )>,
     > {
-        log::debug!(
-            "NativeAgentServer::connect called for path: {:?}",
-            _root_dir
-        );
+        log::debug!("NativeAgentServer::connect");
         let project = delegate.project().clone();
         let fs = self.fs.clone();
         let thread_store = self.thread_store.clone();

--- a/crates/agent_servers/src/agent_servers.rs
+++ b/crates/agent_servers/src/agent_servers.rs
@@ -22,7 +22,7 @@ use anyhow::Result;
 use gpui::{App, AppContext, Entity, SharedString, Task};
 use project::Project;
 use settings::SettingsStore;
-use std::{any::Any, path::Path, rc::Rc, sync::Arc};
+use std::{any::Any, rc::Rc, sync::Arc};
 
 pub use acp::AcpConnection;
 
@@ -58,7 +58,6 @@ pub trait AgentServer: Send {
     fn name(&self) -> SharedString;
     fn connect(
         &self,
-        root_dir: Option<&Path>,
         delegate: AgentServerDelegate,
         cx: &mut App,
     ) -> Task<Result<(Rc<dyn AgentConnection>, Option<task::SpawnInTerminal>)>>;

--- a/crates/agent_servers/src/codex.rs
+++ b/crates/agent_servers/src/codex.rs
@@ -1,6 +1,6 @@
+use std::any::Any;
 use std::rc::Rc;
 use std::sync::Arc;
-use std::{any::Any, path::Path};
 
 use acp_thread::AgentConnection;
 use agent_client_protocol as acp;
@@ -205,13 +205,10 @@ impl AgentServer for Codex {
 
     fn connect(
         &self,
-        root_dir: Option<&Path>,
         delegate: AgentServerDelegate,
         cx: &mut App,
     ) -> Task<Result<(Rc<dyn AgentConnection>, Option<task::SpawnInTerminal>)>> {
         let name = self.name();
-        let root_dir = root_dir.map(|root_dir| root_dir.to_string_lossy().into_owned());
-        let is_remote = delegate.project.read(cx).is_via_remote_server();
         let store = delegate.store.downgrade();
         let mut extra_env = load_proxy_env(cx);
         let default_mode = self.default_mode(cx);
@@ -232,13 +229,12 @@ impl AgentServer for Codex {
         }
 
         cx.spawn(async move |cx| {
-            let (command, root_dir, login) = store
+            let (command, login) = store
                 .update(cx, |store, cx| {
                     let agent = store
                         .get_external_agent(&CODEX_NAME.into())
                         .context("Codex is not registered")?;
                     anyhow::Ok(agent.get_command(
-                        root_dir.as_deref(),
                         extra_env,
                         delegate.status_tx,
                         delegate.new_version_available,
@@ -251,11 +247,9 @@ impl AgentServer for Codex {
                 name.clone(),
                 name,
                 command,
-                root_dir.as_ref(),
                 default_mode,
                 default_model,
                 default_config_options,
-                is_remote,
                 cx,
             )
             .await?;

--- a/crates/agent_servers/src/e2e_tests.rs
+++ b/crates/agent_servers/src/e2e_tests.rs
@@ -444,10 +444,7 @@ pub async fn new_test_thread(
     let store = project.read_with(cx, |project, _| project.agent_server_store().clone());
     let delegate = AgentServerDelegate::new(store, project.clone(), None, None);
 
-    let (connection, _) = cx
-        .update(|cx| server.connect(Some(current_dir.as_ref()), delegate, cx))
-        .await
-        .unwrap();
+    let (connection, _) = cx.update(|cx| server.connect(delegate, cx)).await.unwrap();
 
     cx.update(|cx| connection.new_session(project.clone(), current_dir.as_ref(), cx))
         .await

--- a/crates/agent_ui/src/mention_set.rs
+++ b/crates/agent_ui/src/mention_set.rs
@@ -547,7 +547,7 @@ impl MentionSet {
             None,
             None,
         );
-        let connection = server.connect(None, delegate, cx);
+        let connection = server.connect(delegate, cx);
         cx.spawn(async move |_, cx| {
             let (agent, _) = connection.await?;
             let agent = agent.downcast::<agent::NativeAgentConnection>().unwrap();

--- a/crates/project/tests/integration/ext_agent_tests.rs
+++ b/crates/project/tests/integration/ext_agent_tests.rs
@@ -9,19 +9,17 @@ struct NoopExternalAgent;
 impl ExternalAgentServer for NoopExternalAgent {
     fn get_command(
         &mut self,
-        _root_dir: Option<&str>,
         _extra_env: HashMap<String, String>,
         _status_tx: Option<watch::Sender<SharedString>>,
         _new_version_available_tx: Option<watch::Sender<Option<String>>>,
         _cx: &mut AsyncApp,
-    ) -> Task<Result<(AgentServerCommand, String, Option<task::SpawnInTerminal>)>> {
+    ) -> Task<Result<(AgentServerCommand, Option<task::SpawnInTerminal>)>> {
         Task::ready(Ok((
             AgentServerCommand {
                 path: PathBuf::from("noop"),
                 args: Vec::new(),
                 env: None,
             },
-            "".to_string(),
             None,
         )))
     }

--- a/crates/project/tests/integration/extension_agent_tests.rs
+++ b/crates/project/tests/integration/extension_agent_tests.rs
@@ -25,19 +25,17 @@ struct NoopExternalAgent;
 impl ExternalAgentServer for NoopExternalAgent {
     fn get_command(
         &mut self,
-        _root_dir: Option<&str>,
         _extra_env: HashMap<String, String>,
         _status_tx: Option<watch::Sender<SharedString>>,
         _new_version_available_tx: Option<watch::Sender<Option<String>>>,
         _cx: &mut AsyncApp,
-    ) -> Task<Result<(AgentServerCommand, String, Option<task::SpawnInTerminal>)>> {
+    ) -> Task<Result<(AgentServerCommand, Option<task::SpawnInTerminal>)>> {
         Task::ready(Ok((
             AgentServerCommand {
                 path: PathBuf::from("noop"),
                 args: Vec::new(),
                 env: None,
             },
-            "".to_string(),
             None,
         )))
     }

--- a/crates/remote_server/src/remote_editing_tests.rs
+++ b/crates/remote_server/src/remote_editing_tests.rs
@@ -2030,14 +2030,13 @@ async fn test_remote_external_agent_server(
             .collect::<Vec<_>>()
     });
     pretty_assertions::assert_eq!(names, ["gemini", "codex", "claude", "foo"]);
-    let (command, root, login) = project
+    let (command, login) = project
         .update(cx, |project, cx| {
             project.agent_server_store().update(cx, |store, cx| {
                 store
                     .get_external_agent(&"foo".into())
                     .unwrap()
                     .get_command(
-                        None,
                         HashMap::from_iter([("OTHER_VAR".into(), "other-val".into())]),
                         None,
                         None,
@@ -2058,7 +2057,6 @@ async fn test_remote_external_agent_server(
             ]))
         }
     );
-    assert_eq!(&PathBuf::from(root), paths::home_dir());
     assert!(login.is_none());
 }
 

--- a/crates/zed/src/visual_test_runner.rs
+++ b/crates/zed/src/visual_test_runner.rs
@@ -1945,7 +1945,6 @@ impl AgentServer for StubAgentServer {
 
     fn connect(
         &self,
-        _root_dir: Option<&Path>,
         _delegate: AgentServerDelegate,
         _cx: &mut App,
     ) -> gpui::Task<gpui::Result<(Rc<dyn AgentConnection>, Option<task::SpawnInTerminal>)>> {


### PR DESCRIPTION
This isn't necessary and allows us to potentially share processes across
threads.

Release Notes:

- N/A
