### PR TITLE
docs: Remove Preview callouts for stable release

### DIFF
--- a/docs/src/ai/edit-prediction.md
+++ b/docs/src/ai/edit-prediction.md
@@ -301,8 +301,6 @@ Edit Prediction also works with other providers.
 
 ### GitHub Copilot {#github-copilot}
 
-> **Changed in Preview (v0.225).** See [release notes](/releases#0.225).
-
 To use GitHub Copilot as your provider, set this in your settings file ([how to edit](../configuring-zed.md#settings-files)):
 
 ```json [settings]

--- a/docs/src/finding-navigating.md
+++ b/docs/src/finding-navigating.md
@@ -19,8 +19,6 @@ Open any file in your project with {#kb file_finder::Toggle}. Type part of the f
 
 ## Project Search
 
-> **Changed in Preview (v0.225).** See [release notes](/releases#0.225).
-
 Search across all files with {#kb pane::DeploySearch}. Start typing in the search field to begin searching—results appear as you type.
 
 Results appear in a [multibuffer](./multibuffers.md), letting you edit matches in place.

--- a/docs/src/git.md
+++ b/docs/src/git.md
@@ -72,8 +72,6 @@ To disable word diff for specific languages only, add this to your settings.json
 
 ### Diff View Styles
 
-> **Changed in Preview (v0.225).** See [release notes](/releases#0.225).
-
 Zed displays diffs in two modes: **split** (side-by-side comparison) or **unified** (inline changes). Split view is the default.
 
 #### Changing the diff view

--- a/docs/src/globs.md
+++ b/docs/src/globs.md
@@ -24,8 +24,6 @@ A glob "pattern" is used to match a file name or complete file path. For example
 
 ### Multiple Patterns
 
-> **Changed in Preview (v0.225).** See [release notes](/releases#0.225).
-
 You can specify multiple glob patterns in Project Search filters by separating them with commas. When using comma-separated patterns, Zed correctly handles braces within individual patterns:
 
 - `*.ts, *.tsx` — Match TypeScript and TSX files

--- a/docs/src/languages/json.md
+++ b/docs/src/languages/json.md
@@ -54,8 +54,6 @@ For example to for a `.luarc.json` for use with [lua-language-server](https://gi
 
 ### Schema Specification via Settings
 
-> **Preview:** This feature is available in Zed Preview. It will be included in the next Stable release.
-
 You can associate JSON Schemas with file paths using relative paths in your language server settings. Zed resolves paths relative to your project root:
 
 ```json [settings]

--- a/docs/src/languages/yaml.md
+++ b/docs/src/languages/yaml.md
@@ -12,8 +12,6 @@ YAML support is available natively in Zed.
 
 ## Configuration
 
-> **Preview:** This feature is available in Zed Preview. It will be included in the next Stable release.
-
 You can configure various [yaml-language-server settings](https://github.com/redhat-developer/yaml-language-server?tab=readme-ov-file#language-server-settings) by adding them to your Zed settings.json in a `yaml-language-server` block under the `lsp` key.
 
 You can configure custom YAML schemas using relative paths. Zed resolves paths relative to your project root:

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -519,8 +519,6 @@ Note: Dirty files (files with unsaved changes) will not be automatically closed 
 - `"unified"`: Show changes inline with added and deleted lines stacked vertically
 - `"split"`: Display old and new versions side by side in separate panes (default)
 
-> **Changed in Preview (v0.225).** Values renamed from `"stacked"`/`"side_by_side"` to `"unified"`/`"split"`.
-
 See [Git documentation](../git.md#diff-view-styles) for more details.
 
 ## Disable AI
@@ -2773,8 +2771,6 @@ The following settings can be overridden for each specific language:
 These values take in the same options as the root-level settings with the same name.
 
 ### Document Symbols
-
-> **Preview:** This feature is available in Zed Preview. It will be included in the next Stable release.
 
 - Description: Controls the source of document symbols used for outlines and breadcrumbs.
 - Setting: `document_symbols`
@@ -5139,8 +5135,6 @@ See the [debugger page](../debugger.md) for more information about debugging sup
 - `scrollbar`: When to show the scrollbar in the git panel
 
 ## Git Worktree Directory
-
-> **Preview:** This feature is available in Zed Preview. It will be included in the next Stable release.
 
 - Description: Directory where git worktrees are created, relative to the repository working directory.
 - Setting: `git.worktree_directory`

--- a/docs/src/reference/cli.md
+++ b/docs/src/reference/cli.md
@@ -71,8 +71,6 @@ zed -n ~/projects/myproject
 
 ### `-a`, `--add`
 
-> **Changed in Preview (v0.225).** See [release notes](/releases#0.225).
-
 Add paths to the currently focused workspace instead of opening a new window. When multiple workspace windows are open, files open in the focused window:
 
 ```sh

--- a/docs/src/repl.md
+++ b/docs/src/repl.md
@@ -151,8 +151,6 @@ TBD: Improve Julia REPL instructions
 
 ## Changing which kernel is used per language {#changing-kernels}
 
-> **Preview:** This feature is available in Zed Preview. It will be included in the next Stable release.
-
 Zed automatically detects available kernels and organizes them in the kernel picker:
 
 - **Recommended**: The Python environment matching your active toolchain (if detected)
@@ -192,8 +190,6 @@ To configure a different default kernel for a language, you can assign a kernel 
 ```
 
 ## Interactive Input
-
-> **Preview:** This feature is available in Zed Preview. It will be included in the next Stable release.
 
 When code execution requires user input (such as Python's `input()` function), the REPL displays an input prompt below the cell output.
 

--- a/docs/src/tasks.md
+++ b/docs/src/tasks.md
@@ -249,8 +249,6 @@ When you have a task definition that is bound to the runnable, you can quickly r
 
 ## Running Bash Scripts
 
-> **Preview:** This feature is available in Zed Preview. It will be included in the next Stable release.
-
 You can run bash scripts directly from Zed. When you open a `.sh` or `.bash` file, Zed automatically detects the script as runnable and makes it available in the task picker.
 
 To run a bash script:
@@ -275,8 +273,6 @@ If you need to pass arguments or customize the execution environment, add a task
 ```
 
 ## Shell Initialization
-
-> **Changed in Preview (v0.225).** See [release notes](/releases#0.225).
 
 When Zed runs a task, it launches the command in a login shell. This ensures your shell's initialization files (`.bash_profile`, `.zshrc`, etc.) are sourced before the task executes.
 

--- a/docs/src/vim.md
+++ b/docs/src/vim.md
@@ -248,10 +248,6 @@ Below, you'll find tables listing the commands you can use in the command palett
 
 ### File and window management
 
-> **Changed in Preview (v0.225).** See [release notes](/releases#0.225).
->
-> The `:bd[elete]` command now closes the active file across all panes. Previously, it only closed the file in the active pane.
-
 This table shows commands for managing windows, tabs, and panes. As commands don't support arguments currently, you cannot specify a filename when saving or creating a new file.
 
 | Command         | Description                                          |

--- a/script/docs-suggest-publish
+++ b/script/docs-suggest-publish
@@ -132,8 +132,8 @@ if [[ "$DRY_RUN" == "true" ]]; then
     exit 0
 fi
 
-# Ensure clean working state
-if [[ -n "$(git status --porcelain)" ]]; then
+# Ensure clean working state (ignore untracked files with grep -v '??')
+if [[ -n "$(git status --porcelain | grep -v '^??' || true)" ]]; then
     error "Working directory has uncommitted changes. Please commit or stash first."
 fi
 
@@ -221,9 +221,14 @@ EOF
 cat "$SUGGESTIONS_FILE" >> "$APPLY_PROMPT_FILE"
 
 log "Running Droid auto-apply with model: $MODEL"
-droid exec -m "$MODEL" -f "$APPLY_PROMPT_FILE" > "$APPLY_SUMMARY_FILE"
+if ! droid exec -m "$MODEL" -f "$APPLY_PROMPT_FILE" --auto high > "$APPLY_SUMMARY_FILE" 2>&1; then
+    echo "Droid exec output:"
+    cat "$APPLY_SUMMARY_FILE"
+    error "Droid exec failed. See output above."
+fi
+log "Droid completed, checking results..."
 
-if [[ -n "$(git status --porcelain | grep -vE '^.. docs/' || true)" ]]; then
+if [[ -n "$(git status --porcelain | grep -v '^??' | grep -vE '^.. docs/' || true)" ]]; then
     error "Auto-apply modified non-doc files. Revert and re-run."
 fi
 
@@ -232,7 +237,7 @@ if [[ -z "$(git status --porcelain docs/ | grep '^.. docs/src/' || true)" ]]; th
 fi
 
 log "Running docs formatter"
-./script/prettier
+./script/prettier --write
 
 if [[ -z "$(git status --porcelain docs/ | grep '^.. docs/src/' || true)" ]]; then
     error "No docs/src changes remain after formatting; aborting PR creation."
@@ -324,8 +329,7 @@ log "Creating PR..."
 PR_URL=$(gh pr create \
     --draft \
     --title "docs: auto-apply preview release suggestions" \
-    --body-file "$PR_BODY_FILE" \
-    --label "documentation")
+    --body-file "$PR_BODY_FILE")
 
 echo ""
 echo -e "${GREEN}PR created:${NC} $PR_URL"


### PR DESCRIPTION
This PR removes Preview callouts from documentation for features that are now in Stable.

Features documented with Preview callouts are now included in the stable release.

Generated by script/docs-strip-preview-callouts

Release Notes:

- N/A