### PR TITLE
Show assistant namespace in command palette independent of agent panel

### DIFF
--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -385,12 +385,12 @@ fn update_command_palette_filter(cx: &mut App) {
             if agent_enabled {
                 filter.show_namespace("agent");
                 filter.show_namespace("agents");
-                filter.show_namespace("assistant");
             } else {
                 filter.hide_namespace("agent");
                 filter.hide_namespace("agents");
-                filter.hide_namespace("assistant");
             }
+
+            filter.show_namespace("assistant");
 
             match edit_prediction_provider {
                 EditPredictionProvider::None => {
@@ -593,10 +593,6 @@ mod tests {
                 !filter.is_hidden(&NewThread),
                 "NewThread should be visible by default"
             );
-            assert!(
-                !filter.is_hidden(&text_thread_editor::CopyCode),
-                "CopyCode should be visible when agent is enabled"
-            );
         });
 
         // Disable agent
@@ -615,10 +611,6 @@ mod tests {
             assert!(
                 filter.is_hidden(&NewThread),
                 "NewThread should be hidden when agent is disabled"
-            );
-            assert!(
-                filter.is_hidden(&text_thread_editor::CopyCode),
-                "CopyCode should be hidden when agent is disabled"
             );
         });
 


### PR DESCRIPTION
The `assistant` action namespace (containing `InlineAssist`, `CopyCode`, etc.) was previously hidden from the command palette when the agent panel was disabled via settings. This was incorrect — `InlineAssist` is a feature independent of the agent panel sidebar, and a user may want inline assist without the panel button.

Now the `assistant` namespace is always visible when AI is not globally disabled (`disable_ai: false`), while the `agent`/`agents` namespaces still correctly track the `agent_enabled` setting.

Release Notes:

- Fixed inline assist being hidden from the command palette when the agent panel was disabled.