### PR TITLE
extension_ci: Shorten SHA length in PR titles

### DIFF
--- a/.github/workflows/extension_workflow_rollout.yml
+++ b/.github/workflows/extension_workflow_rollout.yml
@@ -127,7 +127,7 @@ jobs:
     - id: short-sha
       name: extension_workflow_rollout::rollout_workflows_to_extension::get_short_sha
       run: |
-        echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+        echo "sha_short=$(git rev-parse --short=7 HEAD)" >> "$GITHUB_OUTPUT"
       working-directory: zed
     - id: create-pr
       name: extension_workflow_rollout::rollout_workflows_to_extension::create_pull_request

--- a/tooling/xtask/src/tasks/workflows/extension_workflow_rollout.rs
+++ b/tooling/xtask/src/tasks/workflows/extension_workflow_rollout.rs
@@ -163,7 +163,7 @@ fn rollout_workflows_to_extension(fetch_repos_job: &NamedJob) -> NamedJob {
 
     fn get_short_sha() -> (Step<Run>, StepOutput) {
         let step = named::bash(indoc::indoc! {r#"
-            echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+            echo "sha_short=$(git rev-parse --short=7 HEAD)" >> "$GITHUB_OUTPUT"
         "#})
         .id("short-sha")
         .working_directory("zed");


### PR DESCRIPTION
This PR shortens the length of the Git SHAs in the PR titles to 7 characters, as this is the default for short SHAs.

Release Notes:

- N/A
