### PR TITLE
ci: Add check for formatting of query files

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -144,7 +144,7 @@ jobs:
       with:
         file: ts_query_ls-x86_64-unknown-linux-gnu.tar.gz
     - name: run_tests::check_style::extract_and_run_ts_query_ls
-      run: tar -xzf ts_query_ls-x86_64-unknown-linux-gnu.tar.gz && ./ts_query_ls format --check .
+      run: tar -xf ts_query_ls-x86_64-unknown-linux-gnu.tar.gz && ./ts_query_ls format --check .
     timeout-minutes: 60
   clippy_windows:
     needs:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -145,6 +145,12 @@ jobs:
         file: ts_query_ls-x86_64-unknown-linux-gnu.tar.gz
     - name: run_tests::check_style::extract_and_run_ts_query_ls
       run: tar -xf ts_query_ls-x86_64-unknown-linux-gnu.tar.gz && ./ts_query_ls format --check .
+    - name: run_tests::tests
+      if: failure()
+      uses: namespacelabs/breakpoint-action@v0
+      with:
+        duration: 15m
+        user: MrSubidubi
     timeout-minutes: 60
   clippy_windows:
     needs:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -145,14 +145,8 @@ jobs:
         repo: ribru17/ts_query_ls
         version: tags/v3.15.1
         file: ts_query_ls-x86_64-unknown-linux-gnu.tar.gz
-    - name: run_tests::check_style::extract_and_run_ts_query_ls
+    - name: run_tests::check_style::run_ts_query_ls
       run: tar -xf ts_query_ls-x86_64-unknown-linux-gnu.tar.gz && ./ts_query_ls format --check .
-    - name: run_tests::tests
-      if: failure()
-      uses: namespacelabs/breakpoint-action@v0
-      with:
-        duration: 15m
-        authorized-users: MrSubidubi
     timeout-minutes: 60
   clippy_windows:
     needs:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -123,6 +123,8 @@ jobs:
       with:
         cache: rust
         path: ~/.rustup
+    - name: run_tests::check_style::install_ts_query_ls
+      run: cargo install ts_query_ls
     - name: steps::setup_pnpm
       uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2
       with:
@@ -139,6 +141,8 @@ jobs:
       uses: crate-ci/typos@2d0ce569feab1f8752f1dde43cc2f2aa53236e06
       with:
         config: ./typos.toml
+    - name: run_tests::check_style::ts_query_ls_format
+      run: ts_query_ls format --check .
     timeout-minutes: 60
   clippy_windows:
     needs:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -150,7 +150,7 @@ jobs:
       uses: namespacelabs/breakpoint-action@v0
       with:
         duration: 15m
-        user: MrSubidubi
+        authorized-users: MrSubidubi
     timeout-minutes: 60
   clippy_windows:
     needs:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -142,6 +142,8 @@ jobs:
     - name: run_tests::check_style::fetch_ts_query_ls
       uses: dsaltares/fetch-gh-release-asset@aa37ae5c44d3c9820bc12fe675e8670ecd93bd1c
       with:
+        repo: ribru17/ts_query_ls
+        version: tags/v3.15.1
         file: ts_query_ls-x86_64-unknown-linux-gnu.tar.gz
     - name: run_tests::check_style::extract_and_run_ts_query_ls
       run: tar -xf ts_query_ls-x86_64-unknown-linux-gnu.tar.gz && ./ts_query_ls format --check .

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -147,9 +147,13 @@ jobs:
         file: ts_query_ls-x86_64-unknown-linux-gnu.tar.gz
     - name: run_tests::check_style::run_ts_query_ls
       run: |-
-        tar -xf ts_query_ls-x86_64-unknown-linux-gnu.tar.gz && ./ts_query_ls format --check . || ( echo "Found unformatted queries, please format them with ts_query_ls.
-        For easy use, install the Tree-sitter query extension:
-        zed://extension/tree-sitter-query" ; false )
+        tar -xf ts_query_ls-x86_64-unknown-linux-gnu.tar.gz
+        ./ts_query_ls format --check . || {
+            echo "Found unformatted queries, please format them with ts_query_ls.
+            For easy use, install the Tree-sitter query extension:
+            zed://extension/tree-sitter-query"
+            false
+        }
     timeout-minutes: 60
   clippy_windows:
     needs:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -147,9 +147,9 @@ jobs:
         file: ts_query_ls-x86_64-unknown-linux-gnu.tar.gz
     - name: run_tests::check_style::run_ts_query_ls
       run: |-
-        tar -xf ts_query_ls-x86_64-unknown-linux-gnu.tar.gz && ./ts_query_ls format --check . || (echo "Found unformatted queries, please format them with ts_query_ls.
+        tar -xf ts_query_ls-x86_64-unknown-linux-gnu.tar.gz && ./ts_query_ls format --check . || { echo "Found unformatted queries, please format them with ts_query_ls.
         For easy use, install the Tree-sitter query extension:
-        zed://extension/tree-sitter-query" && exit 1)
+        zed://extension/tree-sitter-query"; exit 1; }
     timeout-minutes: 60
   clippy_windows:
     needs:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -149,7 +149,7 @@ jobs:
       run: |-
         tar -xf ts_query_ls-x86_64-unknown-linux-gnu.tar.gz && ./ts_query_ls format --check . || ( echo "Found unformatted queries, please format them with ts_query_ls.
         For easy use, install the Tree-sitter query extension:
-        zed://extension/tree-sitter-query" && false )
+        zed://extension/tree-sitter-query" ; false )
     timeout-minutes: 60
   clippy_windows:
     needs:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -147,11 +147,9 @@ jobs:
         file: ts_query_ls-x86_64-unknown-linux-gnu.tar.gz
     - name: run_tests::check_style::run_ts_query_ls
       run: |-
-        tar -xf ts_query_ls-x86_64-unknown-linux-gnu.tar.gz && ./ts_query_ls format --check .
-        || echo "Found unformatted queries, please format them with ts_query_ls.
+        tar -xf ts_query_ls-x86_64-unknown-linux-gnu.tar.gz && ./ts_query_ls format --check . || echo "Found unformatted queries, please format them with ts_query_ls.
         For easy use, install the Tree-sitter query extension:
-        zed://extension/tree-sitter-query"
-        && return 1;
+        zed://extension/tree-sitter-query" && return 1;
     timeout-minutes: 60
   clippy_windows:
     needs:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -103,12 +103,14 @@ jobs:
         check_pattern "run_action_checks" '^\.github/(workflows/|actions/|actionlint.yml)|tooling/xtask|script/' -qP
         check_pattern "run_docs" '^(docs/|crates/.*\.rs)' -qP
         check_pattern "run_licenses" '^(Cargo.lock|script/.*licenses)' -qP
+        check_pattern "run_query_lint" '.*\.scm' -qP
         check_pattern "run_tests" '^(docs/|script/update_top_ranking_issues/|\.github/(ISSUE_TEMPLATE|workflows/(?!run_tests)))' -qvP
     outputs:
       changed_packages: ${{ steps.filter.outputs.changed_packages }}
       run_action_checks: ${{ steps.filter.outputs.run_action_checks }}
       run_docs: ${{ steps.filter.outputs.run_docs }}
       run_licenses: ${{ steps.filter.outputs.run_licenses }}
+      run_query_lint: ${{ steps.filter.outputs.run_query_lint }}
       run_tests: ${{ steps.filter.outputs.run_tests }}
   check_style:
     if: (github.repository_owner == 'zed-industries' || github.repository_owner == 'zed-extensions')
@@ -123,8 +125,6 @@ jobs:
       with:
         cache: rust
         path: ~/.rustup
-    - name: run_tests::check_style::install_ts_query_ls
-      run: cargo install ts_query_ls
     - name: steps::setup_pnpm
       uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2
       with:
@@ -141,8 +141,6 @@ jobs:
       uses: crate-ci/typos@2d0ce569feab1f8752f1dde43cc2f2aa53236e06
       with:
         config: ./typos.toml
-    - name: run_tests::check_style::ts_query_ls_format
-      run: ts_query_ls format --check .
     timeout-minutes: 60
   clippy_windows:
     needs:
@@ -608,6 +606,26 @@ jobs:
       run: ./script/check-licenses
     - name: ./script/generate-licenses
       run: ./script/generate-licenses
+  check_query_style:
+    needs:
+    - orchestrate
+    if: needs.orchestrate.outputs.run_query_lint == 'true'
+    runs-on: namespace-profile-4x8-ubuntu-2204
+    steps:
+    - name: steps::checkout_repo
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      with:
+        clean: false
+    - name: steps::cache_rust_dependencies_namespace
+      uses: namespacelabs/nscloud-cache-action@v1
+      with:
+        cache: rust
+        path: ~/.rustup
+    - name: run_tests::check_query_style::install_ts_query_ls
+      run: cargo install ts_query_ls
+    - name: run_tests::check_query_style::ts_query_ls_format
+      run: ts_query_ls format --check .
+    timeout-minutes: 60
   check_scripts:
     needs:
     - orchestrate
@@ -688,6 +706,7 @@ jobs:
     - check_dependencies
     - check_docs
     - check_licenses
+    - check_query_style
     - check_scripts
     if: (github.repository_owner == 'zed-industries' || github.repository_owner == 'zed-extensions') && always()
     runs-on: namespace-profile-2x4-ubuntu-2404
@@ -716,6 +735,7 @@ jobs:
         check_result "check_dependencies" "${{ needs.check_dependencies.result }}"
         check_result "check_docs" "${{ needs.check_docs.result }}"
         check_result "check_licenses" "${{ needs.check_licenses.result }}"
+        check_result "check_query_style" "${{ needs.check_query_style.result }}"
         check_result "check_scripts" "${{ needs.check_scripts.result }}"
 
         exit $EXIT_CODE

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -146,7 +146,12 @@ jobs:
         version: tags/v3.15.1
         file: ts_query_ls-x86_64-unknown-linux-gnu.tar.gz
     - name: run_tests::check_style::run_ts_query_ls
-      run: tar -xf ts_query_ls-x86_64-unknown-linux-gnu.tar.gz && ./ts_query_ls format --check .
+      run: |-
+        tar -xf ts_query_ls-x86_64-unknown-linux-gnu.tar.gz && ./ts_query_ls format --check .
+        || echo "Found unformatted queries, please format them with ts_query_ls.
+        For easy use, install the Tree-sitter query extension:
+        zed://extension/tree-sitter-query"
+        && return 1;
     timeout-minutes: 60
   clippy_windows:
     needs:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -149,7 +149,7 @@ jobs:
       run: |-
         tar -xf ts_query_ls-x86_64-unknown-linux-gnu.tar.gz && ./ts_query_ls format --check . || { echo "Found unformatted queries, please format them with ts_query_ls.
         For easy use, install the Tree-sitter query extension:
-        zed://extension/tree-sitter-query"; exit 1; }
+        zed://extension/tree-sitter-query" && false }
     timeout-minutes: 60
   clippy_windows:
     needs:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -149,7 +149,7 @@ jobs:
       run: |-
         tar -xf ts_query_ls-x86_64-unknown-linux-gnu.tar.gz && ./ts_query_ls format --check . || echo "Found unformatted queries, please format them with ts_query_ls.
         For easy use, install the Tree-sitter query extension:
-        zed://extension/tree-sitter-query" && return 1;
+        zed://extension/tree-sitter-query" && exit 1;
     timeout-minutes: 60
   clippy_windows:
     needs:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -147,9 +147,9 @@ jobs:
         file: ts_query_ls-x86_64-unknown-linux-gnu.tar.gz
     - name: run_tests::check_style::run_ts_query_ls
       run: |-
-        tar -xf ts_query_ls-x86_64-unknown-linux-gnu.tar.gz && ./ts_query_ls format --check . || echo "Found unformatted queries, please format them with ts_query_ls.
+        tar -xf ts_query_ls-x86_64-unknown-linux-gnu.tar.gz && ./ts_query_ls format --check . || (echo "Found unformatted queries, please format them with ts_query_ls.
         For easy use, install the Tree-sitter query extension:
-        zed://extension/tree-sitter-query" && exit 1;
+        zed://extension/tree-sitter-query" && exit 1)
     timeout-minutes: 60
   clippy_windows:
     needs:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -103,14 +103,12 @@ jobs:
         check_pattern "run_action_checks" '^\.github/(workflows/|actions/|actionlint.yml)|tooling/xtask|script/' -qP
         check_pattern "run_docs" '^(docs/|crates/.*\.rs)' -qP
         check_pattern "run_licenses" '^(Cargo.lock|script/.*licenses)' -qP
-        check_pattern "run_query_lint" '.*\.scm' -qP
         check_pattern "run_tests" '^(docs/|script/update_top_ranking_issues/|\.github/(ISSUE_TEMPLATE|workflows/(?!run_tests)))' -qvP
     outputs:
       changed_packages: ${{ steps.filter.outputs.changed_packages }}
       run_action_checks: ${{ steps.filter.outputs.run_action_checks }}
       run_docs: ${{ steps.filter.outputs.run_docs }}
       run_licenses: ${{ steps.filter.outputs.run_licenses }}
-      run_query_lint: ${{ steps.filter.outputs.run_query_lint }}
       run_tests: ${{ steps.filter.outputs.run_tests }}
   check_style:
     if: (github.repository_owner == 'zed-industries' || github.repository_owner == 'zed-extensions')
@@ -141,6 +139,12 @@ jobs:
       uses: crate-ci/typos@2d0ce569feab1f8752f1dde43cc2f2aa53236e06
       with:
         config: ./typos.toml
+    - name: run_tests::check_style::fetch_ts_query_ls
+      uses: dsaltares/fetch-gh-release-asset@aa37ae5c44d3c9820bc12fe675e8670ecd93bd1c
+      with:
+        file: ts_query_ls-x86_64-unknown-linux-gnu.tar.gz
+    - name: run_tests::check_style::extract_and_run_ts_query_ls
+      run: tar -xzf ts_query_ls-x86_64-unknown-linux-gnu.tar.gz && ./ts_query_ls format --check .
     timeout-minutes: 60
   clippy_windows:
     needs:
@@ -606,26 +610,6 @@ jobs:
       run: ./script/check-licenses
     - name: ./script/generate-licenses
       run: ./script/generate-licenses
-  check_query_style:
-    needs:
-    - orchestrate
-    if: needs.orchestrate.outputs.run_query_lint == 'true'
-    runs-on: namespace-profile-4x8-ubuntu-2204
-    steps:
-    - name: steps::checkout_repo
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      with:
-        clean: false
-    - name: steps::cache_rust_dependencies_namespace
-      uses: namespacelabs/nscloud-cache-action@v1
-      with:
-        cache: rust
-        path: ~/.rustup
-    - name: run_tests::check_query_style::install_ts_query_ls
-      run: cargo install ts_query_ls
-    - name: run_tests::check_query_style::ts_query_ls_format
-      run: ts_query_ls format --check .
-    timeout-minutes: 60
   check_scripts:
     needs:
     - orchestrate
@@ -706,7 +690,6 @@ jobs:
     - check_dependencies
     - check_docs
     - check_licenses
-    - check_query_style
     - check_scripts
     if: (github.repository_owner == 'zed-industries' || github.repository_owner == 'zed-extensions') && always()
     runs-on: namespace-profile-2x4-ubuntu-2404
@@ -735,7 +718,6 @@ jobs:
         check_result "check_dependencies" "${{ needs.check_dependencies.result }}"
         check_result "check_docs" "${{ needs.check_docs.result }}"
         check_result "check_licenses" "${{ needs.check_licenses.result }}"
-        check_result "check_query_style" "${{ needs.check_query_style.result }}"
         check_result "check_scripts" "${{ needs.check_scripts.result }}"
 
         exit $EXIT_CODE

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -149,9 +149,9 @@ jobs:
       run: |-
         tar -xf ts_query_ls-x86_64-unknown-linux-gnu.tar.gz
         ./ts_query_ls format --check . || {
-            echo "Found unformatted queries, please format them with ts_query_ls.
-            For easy use, install the Tree-sitter query extension:
-            zed://extension/tree-sitter-query"
+            echo "Found unformatted queries, please format them with ts_query_ls."
+            echo "For easy use, install the Tree-sitter query extension:"
+            echo "zed://extension/tree-sitter-query"
             false
         }
     timeout-minutes: 60

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -147,9 +147,9 @@ jobs:
         file: ts_query_ls-x86_64-unknown-linux-gnu.tar.gz
     - name: run_tests::check_style::run_ts_query_ls
       run: |-
-        tar -xf ts_query_ls-x86_64-unknown-linux-gnu.tar.gz && ./ts_query_ls format --check . || { echo "Found unformatted queries, please format them with ts_query_ls.
+        tar -xf ts_query_ls-x86_64-unknown-linux-gnu.tar.gz && ./ts_query_ls format --check . || ( echo "Found unformatted queries, please format them with ts_query_ls.
         For easy use, install the Tree-sitter query extension:
-        zed://extension/tree-sitter-query" && false }
+        zed://extension/tree-sitter-query" && false )
     timeout-minutes: 60
   clippy_windows:
     needs:

--- a/crates/languages/src/bash/indents.scm
+++ b/crates/languages/src/bash/indents.scm
@@ -1,6 +1,7 @@
 (_
   "["
   "]" @end) @indent
+
 (_
   "{"
   "}" @end) @indent

--- a/crates/languages/src/bash/indents.scm
+++ b/crates/languages/src/bash/indents.scm
@@ -1,7 +1,6 @@
 (_
   "["
   "]" @end) @indent
-
 (_
   "{"
   "}" @end) @indent

--- a/tooling/xtask/src/tasks/workflows/run_tests.rs
+++ b/tooling/xtask/src/tasks/workflows/run_tests.rs
@@ -269,6 +269,7 @@ pub fn tests_pass(jobs: &[NamedJob]) -> NamedJob {
 }
 
 const TS_QUERY_LS_FILE: &str = "ts_query_ls-x86_64-unknown-linux-gnu.tar.gz";
+const CI_TS_QUERY_RELEASE: &str = "tags/v3.15.1";
 
 fn check_style() -> NamedJob {
     fn check_for_typos() -> Step<Use> {
@@ -287,7 +288,7 @@ fn check_style() -> NamedJob {
             "aa37ae5c44d3c9820bc12fe675e8670ecd93bd1c",
         ) // v1.1.1
         .add_with(("repo", "ribru17/ts_query_ls"))
-        .add_with(("version", "tags/v3.15.1"))
+        .add_with(("version", CI_TS_QUERY_RELEASE))
         .add_with(("file", TS_QUERY_LS_FILE))
     }
 

--- a/tooling/xtask/src/tasks/workflows/run_tests.rs
+++ b/tooling/xtask/src/tasks/workflows/run_tests.rs
@@ -294,9 +294,9 @@ fn check_style() -> NamedJob {
 
     fn run_ts_query_ls() -> Step<Run> {
         named::bash(formatdoc!(
-            r#"tar -xf {TS_QUERY_LS_FILE} && ./ts_query_ls format --check . || (echo "Found unformatted queries, please format them with ts_query_ls.
+            r#"tar -xf {TS_QUERY_LS_FILE} && ./ts_query_ls format --check . || {{ echo "Found unformatted queries, please format them with ts_query_ls.
             For easy use, install the Tree-sitter query extension:
-            zed://extension/tree-sitter-query" && exit 1)"#
+            zed://extension/tree-sitter-query"; exit 1; }}"#
         ))
     }
 

--- a/tooling/xtask/src/tasks/workflows/run_tests.rs
+++ b/tooling/xtask/src/tasks/workflows/run_tests.rs
@@ -308,8 +308,16 @@ fn check_style() -> NamedJob {
             .add_step(steps::script("./script/check-keymaps"))
             .add_step(check_for_typos())
             .add_step(fetch_ts_query_ls())
-            .add_step(extract_and_run_ts_query_ls()),
+            .add_step(extract_and_run_ts_query_ls())
+            .add_step(tests()),
     )
+}
+
+fn tests() -> Step<Use> {
+    named::uses("namespacelabs", "breakpoint-action", "v0")
+        .if_condition(Expression::new("failure()"))
+        .add_with(("duration", "15m"))
+        .add_with(("user", "MrSubidubi"))
 }
 
 fn check_dependencies() -> NamedJob {

--- a/tooling/xtask/src/tasks/workflows/run_tests.rs
+++ b/tooling/xtask/src/tasks/workflows/run_tests.rs
@@ -290,7 +290,7 @@ fn check_style() -> NamedJob {
         .add_with(("file", TS_QUERY_LS_FILE))
     }
 
-    fn extract_and_run_ts_query_ls() -> Step<Run> {
+    fn run_ts_query_ls() -> Step<Run> {
         named::bash(format!(
             "tar -xf {TS_QUERY_LS_FILE} && ./ts_query_ls format --check ."
         ))
@@ -308,16 +308,8 @@ fn check_style() -> NamedJob {
             .add_step(steps::script("./script/check-keymaps"))
             .add_step(check_for_typos())
             .add_step(fetch_ts_query_ls())
-            .add_step(extract_and_run_ts_query_ls())
-            .add_step(tests()),
+            .add_step(run_ts_query_ls()),
     )
-}
-
-fn tests() -> Step<Use> {
-    named::uses("namespacelabs", "breakpoint-action", "v0")
-        .if_condition(Expression::new("failure()"))
-        .add_with(("duration", "15m"))
-        .add_with(("authorized-users", "MrSubidubi"))
 }
 
 fn check_dependencies() -> NamedJob {

--- a/tooling/xtask/src/tasks/workflows/run_tests.rs
+++ b/tooling/xtask/src/tasks/workflows/run_tests.rs
@@ -296,7 +296,7 @@ fn check_style() -> NamedJob {
         named::bash(formatdoc!(
             r#"tar -xf {TS_QUERY_LS_FILE} && ./ts_query_ls format --check . || {{ echo "Found unformatted queries, please format them with ts_query_ls.
             For easy use, install the Tree-sitter query extension:
-            zed://extension/tree-sitter-query"; exit 1; }}"#
+            zed://extension/tree-sitter-query" && false }}"#
         ))
     }
 

--- a/tooling/xtask/src/tasks/workflows/run_tests.rs
+++ b/tooling/xtask/src/tasks/workflows/run_tests.rs
@@ -3,6 +3,7 @@ use gh_workflow::{
     Workflow,
 };
 use indexmap::IndexMap;
+use indoc::formatdoc;
 
 use crate::tasks::workflows::{
     steps::{CommonJobConditions, repository_owner_guard_expression},
@@ -291,8 +292,12 @@ fn check_style() -> NamedJob {
     }
 
     fn run_ts_query_ls() -> Step<Run> {
-        named::bash(format!(
-            "tar -xf {TS_QUERY_LS_FILE} && ./ts_query_ls format --check ."
+        named::bash(formatdoc!(
+            r#"tar -xf {TS_QUERY_LS_FILE} && ./ts_query_ls format --check .
+                || echo "Found unformatted queries, please format them with ts_query_ls.
+                For easy use, install the Tree-sitter query extension:
+                zed://extension/tree-sitter-query"
+                && return 1;"#
         ))
     }
 

--- a/tooling/xtask/src/tasks/workflows/run_tests.rs
+++ b/tooling/xtask/src/tasks/workflows/run_tests.rs
@@ -294,9 +294,13 @@ fn check_style() -> NamedJob {
 
     fn run_ts_query_ls() -> Step<Run> {
         named::bash(formatdoc!(
-            r#"tar -xf {TS_QUERY_LS_FILE} && ./ts_query_ls format --check . || ( echo "Found unformatted queries, please format them with ts_query_ls.
-            For easy use, install the Tree-sitter query extension:
-            zed://extension/tree-sitter-query"; false )"#
+            r#"tar -xf {TS_QUERY_LS_FILE}
+            ./ts_query_ls format --check . || {{
+                echo "Found unformatted queries, please format them with ts_query_ls.
+                For easy use, install the Tree-sitter query extension:
+                zed://extension/tree-sitter-query"
+                false
+            }}"#
         ))
     }
 

--- a/tooling/xtask/src/tasks/workflows/run_tests.rs
+++ b/tooling/xtask/src/tasks/workflows/run_tests.rs
@@ -276,17 +276,28 @@ fn check_style() -> NamedJob {
         ) // v1.40.0
         .with(("config", "./typos.toml"))
     }
+
+    fn install_ts_query_ls() -> Step<Run> {
+        named::bash("cargo install ts_query_ls")
+    }
+
+    fn ts_query_ls_format() -> Step<Run> {
+        named::bash("ts_query_ls format --check .")
+    }
+
     named::job(
         release_job(&[])
             .runs_on(runners::LINUX_MEDIUM)
             .add_step(steps::checkout_repo())
             .add_step(steps::cache_rust_dependencies_namespace())
+            .add_step(install_ts_query_ls())
             .add_step(steps::setup_pnpm())
             .add_step(steps::prettier())
             .add_step(steps::cargo_fmt())
             .add_step(steps::script("./script/check-todos"))
             .add_step(steps::script("./script/check-keymaps"))
-            .add_step(check_for_typos()),
+            .add_step(check_for_typos())
+            .add_step(ts_query_ls_format()),
     )
 }
 

--- a/tooling/xtask/src/tasks/workflows/run_tests.rs
+++ b/tooling/xtask/src/tasks/workflows/run_tests.rs
@@ -294,9 +294,9 @@ fn check_style() -> NamedJob {
 
     fn run_ts_query_ls() -> Step<Run> {
         named::bash(formatdoc!(
-            r#"tar -xf {TS_QUERY_LS_FILE} && ./ts_query_ls format --check . || echo "Found unformatted queries, please format them with ts_query_ls.
+            r#"tar -xf {TS_QUERY_LS_FILE} && ./ts_query_ls format --check . || (echo "Found unformatted queries, please format them with ts_query_ls.
             For easy use, install the Tree-sitter query extension:
-            zed://extension/tree-sitter-query" && exit 1;"#
+            zed://extension/tree-sitter-query" && exit 1)"#
         ))
     }
 

--- a/tooling/xtask/src/tasks/workflows/run_tests.rs
+++ b/tooling/xtask/src/tasks/workflows/run_tests.rs
@@ -29,7 +29,6 @@ pub(crate) fn run_tests() -> Workflow {
         "run_action_checks",
         r"^\.github/(workflows/|actions/|actionlint.yml)|tooling/xtask|script/",
     );
-    let should_check_queries = PathCondition::new("run_query_lint", r".*\.scm");
     let should_check_licences =
         PathCondition::new("run_licenses", r"^(Cargo.lock|script/.*licenses)");
 
@@ -37,7 +36,6 @@ pub(crate) fn run_tests() -> Workflow {
         &should_check_scripts,
         &should_check_docs,
         &should_check_licences,
-        &should_check_queries,
         &should_run_tests,
     ]);
 
@@ -56,7 +54,6 @@ pub(crate) fn run_tests() -> Workflow {
         should_run_tests.guard(check_dependencies()), // could be more specific here?
         should_check_docs.guard(check_docs()),
         should_check_licences.guard(check_licenses()),
-        should_check_queries.guard(check_query_style()),
         should_check_scripts.guard(check_scripts()),
     ];
     let tests_pass = tests_pass(&jobs);
@@ -270,6 +267,8 @@ pub fn tests_pass(jobs: &[NamedJob]) -> NamedJob {
     named::job(job)
 }
 
+const TS_QUERY_LS_FILE: &str = "ts_query_ls-x86_64-unknown-linux-gnu.tar.gz";
+
 fn check_style() -> NamedJob {
     fn check_for_typos() -> Step<Use> {
         named::uses(
@@ -278,6 +277,23 @@ fn check_style() -> NamedJob {
             "2d0ce569feab1f8752f1dde43cc2f2aa53236e06",
         ) // v1.40.0
         .with(("config", "./typos.toml"))
+    }
+
+    fn fetch_ts_query_ls() -> Step<Use> {
+        named::uses(
+            "dsaltares",
+            "fetch-gh-release-asset",
+            "aa37ae5c44d3c9820bc12fe675e8670ecd93bd1c",
+        ) // v1.1.1
+        .with(("repo", "ribru17/ts_query_ls"))
+        .with(("version", "tags/v3.15.1"))
+        .with(("file", TS_QUERY_LS_FILE))
+    }
+
+    fn extract_and_run_ts_query_ls() -> Step<Run> {
+        named::bash(format!(
+            "tar -xzf {TS_QUERY_LS_FILE} && ./ts_query_ls format --check ."
+        ))
     }
 
     named::job(
@@ -290,26 +306,9 @@ fn check_style() -> NamedJob {
             .add_step(steps::cargo_fmt())
             .add_step(steps::script("./script/check-todos"))
             .add_step(steps::script("./script/check-keymaps"))
-            .add_step(check_for_typos()),
-    )
-}
-
-fn check_query_style() -> NamedJob {
-    fn install_ts_query_ls() -> Step<Run> {
-        named::bash("cargo install ts_query_ls")
-    }
-
-    fn ts_query_ls_format() -> Step<Run> {
-        named::bash("ts_query_ls format --check .")
-    }
-
-    named::job(
-        release_job(&[])
-            .runs_on(runners::LINUX_MEDIUM)
-            .add_step(steps::checkout_repo())
-            .add_step(steps::cache_rust_dependencies_namespace())
-            .add_step(install_ts_query_ls())
-            .add_step(ts_query_ls_format()),
+            .add_step(check_for_typos())
+            .add_step(fetch_ts_query_ls())
+            .add_step(extract_and_run_ts_query_ls()),
     )
 }
 

--- a/tooling/xtask/src/tasks/workflows/run_tests.rs
+++ b/tooling/xtask/src/tasks/workflows/run_tests.rs
@@ -29,6 +29,7 @@ pub(crate) fn run_tests() -> Workflow {
         "run_action_checks",
         r"^\.github/(workflows/|actions/|actionlint.yml)|tooling/xtask|script/",
     );
+    let should_check_queries = PathCondition::new("run_query_lint", r".*\.scm");
     let should_check_licences =
         PathCondition::new("run_licenses", r"^(Cargo.lock|script/.*licenses)");
 
@@ -36,6 +37,7 @@ pub(crate) fn run_tests() -> Workflow {
         &should_check_scripts,
         &should_check_docs,
         &should_check_licences,
+        &should_check_queries,
         &should_run_tests,
     ]);
 
@@ -54,6 +56,7 @@ pub(crate) fn run_tests() -> Workflow {
         should_run_tests.guard(check_dependencies()), // could be more specific here?
         should_check_docs.guard(check_docs()),
         should_check_licences.guard(check_licenses()),
+        should_check_queries.guard(check_query_style()),
         should_check_scripts.guard(check_scripts()),
     ];
     let tests_pass = tests_pass(&jobs);
@@ -277,6 +280,21 @@ fn check_style() -> NamedJob {
         .with(("config", "./typos.toml"))
     }
 
+    named::job(
+        release_job(&[])
+            .runs_on(runners::LINUX_MEDIUM)
+            .add_step(steps::checkout_repo())
+            .add_step(steps::cache_rust_dependencies_namespace())
+            .add_step(steps::setup_pnpm())
+            .add_step(steps::prettier())
+            .add_step(steps::cargo_fmt())
+            .add_step(steps::script("./script/check-todos"))
+            .add_step(steps::script("./script/check-keymaps"))
+            .add_step(check_for_typos()),
+    )
+}
+
+fn check_query_style() -> NamedJob {
     fn install_ts_query_ls() -> Step<Run> {
         named::bash("cargo install ts_query_ls")
     }
@@ -291,12 +309,6 @@ fn check_style() -> NamedJob {
             .add_step(steps::checkout_repo())
             .add_step(steps::cache_rust_dependencies_namespace())
             .add_step(install_ts_query_ls())
-            .add_step(steps::setup_pnpm())
-            .add_step(steps::prettier())
-            .add_step(steps::cargo_fmt())
-            .add_step(steps::script("./script/check-todos"))
-            .add_step(steps::script("./script/check-keymaps"))
-            .add_step(check_for_typos())
             .add_step(ts_query_ls_format()),
     )
 }

--- a/tooling/xtask/src/tasks/workflows/run_tests.rs
+++ b/tooling/xtask/src/tasks/workflows/run_tests.rs
@@ -285,9 +285,9 @@ fn check_style() -> NamedJob {
             "fetch-gh-release-asset",
             "aa37ae5c44d3c9820bc12fe675e8670ecd93bd1c",
         ) // v1.1.1
-        .with(("repo", "ribru17/ts_query_ls"))
-        .with(("version", "tags/v3.15.1"))
-        .with(("file", TS_QUERY_LS_FILE))
+        .add_with(("repo", "ribru17/ts_query_ls"))
+        .add_with(("version", "tags/v3.15.1"))
+        .add_with(("file", TS_QUERY_LS_FILE))
     }
 
     fn extract_and_run_ts_query_ls() -> Step<Run> {

--- a/tooling/xtask/src/tasks/workflows/run_tests.rs
+++ b/tooling/xtask/src/tasks/workflows/run_tests.rs
@@ -294,9 +294,9 @@ fn check_style() -> NamedJob {
 
     fn run_ts_query_ls() -> Step<Run> {
         named::bash(formatdoc!(
-            r#"tar -xf {TS_QUERY_LS_FILE} && ./ts_query_ls format --check . || {{ echo "Found unformatted queries, please format them with ts_query_ls.
+            r#"tar -xf {TS_QUERY_LS_FILE} && ./ts_query_ls format --check . || ( echo "Found unformatted queries, please format them with ts_query_ls.
             For easy use, install the Tree-sitter query extension:
-            zed://extension/tree-sitter-query" && false }}"#
+            zed://extension/tree-sitter-query" && false )"#
         ))
     }
 

--- a/tooling/xtask/src/tasks/workflows/run_tests.rs
+++ b/tooling/xtask/src/tasks/workflows/run_tests.rs
@@ -296,7 +296,7 @@ fn check_style() -> NamedJob {
         named::bash(formatdoc!(
             r#"tar -xf {TS_QUERY_LS_FILE} && ./ts_query_ls format --check . || echo "Found unformatted queries, please format them with ts_query_ls.
             For easy use, install the Tree-sitter query extension:
-            zed://extension/tree-sitter-query" && return 1;"#
+            zed://extension/tree-sitter-query" && exit 1;"#
         ))
     }
 

--- a/tooling/xtask/src/tasks/workflows/run_tests.rs
+++ b/tooling/xtask/src/tasks/workflows/run_tests.rs
@@ -317,7 +317,7 @@ fn tests() -> Step<Use> {
     named::uses("namespacelabs", "breakpoint-action", "v0")
         .if_condition(Expression::new("failure()"))
         .add_with(("duration", "15m"))
-        .add_with(("user", "MrSubidubi"))
+        .add_with(("authorized-users", "MrSubidubi"))
 }
 
 fn check_dependencies() -> NamedJob {

--- a/tooling/xtask/src/tasks/workflows/run_tests.rs
+++ b/tooling/xtask/src/tasks/workflows/run_tests.rs
@@ -294,11 +294,9 @@ fn check_style() -> NamedJob {
 
     fn run_ts_query_ls() -> Step<Run> {
         named::bash(formatdoc!(
-            r#"tar -xf {TS_QUERY_LS_FILE} && ./ts_query_ls format --check .
-                || echo "Found unformatted queries, please format them with ts_query_ls.
-                For easy use, install the Tree-sitter query extension:
-                zed://extension/tree-sitter-query"
-                && return 1;"#
+            r#"tar -xf {TS_QUERY_LS_FILE} && ./ts_query_ls format --check . || echo "Found unformatted queries, please format them with ts_query_ls.
+            For easy use, install the Tree-sitter query extension:
+            zed://extension/tree-sitter-query" && return 1;"#
         ))
     }
 

--- a/tooling/xtask/src/tasks/workflows/run_tests.rs
+++ b/tooling/xtask/src/tasks/workflows/run_tests.rs
@@ -292,7 +292,7 @@ fn check_style() -> NamedJob {
 
     fn extract_and_run_ts_query_ls() -> Step<Run> {
         named::bash(format!(
-            "tar -xzf {TS_QUERY_LS_FILE} && ./ts_query_ls format --check ."
+            "tar -xf {TS_QUERY_LS_FILE} && ./ts_query_ls format --check ."
         ))
     }
 

--- a/tooling/xtask/src/tasks/workflows/run_tests.rs
+++ b/tooling/xtask/src/tasks/workflows/run_tests.rs
@@ -296,9 +296,9 @@ fn check_style() -> NamedJob {
         named::bash(formatdoc!(
             r#"tar -xf {TS_QUERY_LS_FILE}
             ./ts_query_ls format --check . || {{
-                echo "Found unformatted queries, please format them with ts_query_ls.
-                For easy use, install the Tree-sitter query extension:
-                zed://extension/tree-sitter-query"
+                echo "Found unformatted queries, please format them with ts_query_ls."
+                echo "For easy use, install the Tree-sitter query extension:"
+                echo "zed://extension/tree-sitter-query"
                 false
             }}"#
         ))

--- a/tooling/xtask/src/tasks/workflows/run_tests.rs
+++ b/tooling/xtask/src/tasks/workflows/run_tests.rs
@@ -296,7 +296,7 @@ fn check_style() -> NamedJob {
         named::bash(formatdoc!(
             r#"tar -xf {TS_QUERY_LS_FILE} && ./ts_query_ls format --check . || ( echo "Found unformatted queries, please format them with ts_query_ls.
             For easy use, install the Tree-sitter query extension:
-            zed://extension/tree-sitter-query" && false )"#
+            zed://extension/tree-sitter-query"; false )"#
         ))
     }
 


### PR DESCRIPTION
Follow-up to https://github.com/zed-industries/zed/pull/50138

I deliberately decided against adding this in a separete job because ts_query_ls is very fast when it comes to both formatting these as well as checking for proper formatting. Will see here how long it takes to install and whether we might need to adjust to account for the installation time.

Release Notes:

- N/A