### PR TITLE
Edit prediction: add some typescript evals, fix a teacher model failure mode

### DIFF
--- a/crates/edit_prediction_cli/evals/.zed/settings.json
+++ b/crates/edit_prediction_cli/evals/.zed/settings.json
@@ -1,3 +1,4 @@
 {
   "remove_trailing_whitespace_on_save": false,
+  "soft_wrap": "none",
 }

--- a/crates/edit_prediction_cli/evals/vscode--add-async-and-await.md
+++ b/crates/edit_prediction_cli/evals/vscode--add-async-and-await.md
@@ -1,0 +1,88 @@
++++
+repository_url = "https://github.com/microsoft/vscode"
+revision = "29e6da6efa2287aaa981635a475d425ff4fd5d5c"
++++
+
+## Edit History
+
+```diff
+--- a/src/vs/workbench/contrib/debug/browser/debugCommands.ts
++++ b/src/vs/workbench/contrib/debug/browser/debugCommands.ts
+@@ -304,8 +304,8 @@ CommandsRegistry.registerCommand({
+ 
+ CommandsRegistry.registerCommand({
+ 	id: REVERSE_CONTINUE_ID,
+-	handler: (accessor: ServicesAccessor, _: string, context: CallStackContext | unknown) => {
+-		getThreadAndRun(accessor, context, thread => thread.reverseContinue());
++	handler: async (accessor: ServicesAccessor, _: string, context: CallStackContext | unknown) => {
++		await getThreadAndRun(accessor, context, thread => thread.reverseContinue());
+ 	}
+ });
+--- a/src/vs/workbench/contrib/debug/browser/debugCommands.ts
++++ b/src/vs/workbench/contrib/debug/browser/debugCommands.ts
+@@ -311,11 +311,11 @@ CommandsRegistry.registerCommand({
+ 
+ CommandsRegistry.registerCommand({
+ 	id: STEP_BACK_ID,
+-	handler: (accessor: ServicesAccessor, _: string, context: CallStackContext | unknown) => {
++	handler: async (accessor: ServicesAccessor, _: string, context: CallStackContext | unknown) => {
+ 		const contextKeyService = accessor.get(IContextKeyService);
+ 		if (CONTEXT_DISASSEMBLY_VIEW_FOCUS.getValue(contextKeyService)) {
+-			getThreadAndRun(accessor, context, (thread: IThread) => thread.stepBack('instruction'));
++			await getThreadAndRun(accessor, context, (thread: IThread) => thread.stepBack('instruction'));
+ 		} else {
+-			getThreadAndRun(accessor, context, (thread: IThread) => thread.stepBack());
++			await getThreadAndRun(accessor, context, (thread: IThread) => thread.stepBack());
+ 		}
+ 	}
+ });
+--- a/src/vs/workbench/contrib/debug/browser/debugCommands.ts
++++ b/src/vs/workbench/contrib/debug/browser/debugCommands.ts
+@@ -323,8 +323,8 @@ CommandsRegistry.registerCommand({
+ 
+ CommandsRegistry.registerCommand({
+ 	id: TERMINATE_THREAD_ID,
+-	handler: (accessor: ServicesAccessor, _: string, context: CallStackContext | unknown) => {
+-		getThreadAndRun(accessor, context, thread => thread.terminate());
++	handler: async (accessor: ServicesAccessor, _: string, context: CallStackContext | unknown) => {
++		await getThreadAndRun(accessor, context, thread => thread.terminate());
+ 	}
+ });
+```
+
+## Cursor Position
+
+```src/vs/workbench/contrib/debug/browser/debugCommands.ts
+	weight: KeybindingWeight.WorkbenchContrib,
+	primary: isWeb ? (KeyMod.Alt | KeyCode.F10) : KeyCode.F10, // Browsers do not allow F10 to be binded so we have to bind an alternative
+	when: CONTEXT_DEBUG_STATE.isEqualTo('stopped'),
+	handler: (accessor: ServicesAccessor, _: string, context: CallStackContext | unknown) => {
+	//       ^[CURSOR_POSITION]
+		const contextKeyService = accessor.get(IContextKeyService);
+		if (CONTEXT_DISASSEMBLY_VIEW_FOCUS.getValue(contextKeyService)) {
+			getThreadAndRun(accessor, context, (thread: IThread) => thread.next('instruction'));
+		} else {
+```
+
+## Expected Patch
+
+```diff
+--- a/src/vs/workbench/contrib/debug/browser/debugCommands.ts
++++ b/src/vs/workbench/contrib/debug/browser/debugCommands.ts
+@@ -467,10 +467,10 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
+ 	weight: KeybindingWeight.WorkbenchContrib,
+ 	primary: isWeb ? (KeyMod.Alt | KeyCode.F10) : KeyCode.F10, // Browsers do not allow F10 to be binded so we have to bind an alternative
+ 	when: CONTEXT_DEBUG_STATE.isEqualTo('stopped'),
+-	handler: (accessor: ServicesAccessor, _: string, context: CallStackContext | unknown) => {
++	handler: async (accessor: ServicesAccessor, _: string, context: CallStackContext | unknown) => {
+ 		const contextKeyService = accessor.get(IContextKeyService);
+ 		if (CONTEXT_DISASSEMBLY_VIEW_FOCUS.getValue(contextKeyService)) {
+-			getThreadAndRun(accessor, context, (thread: IThread) => thread.next('instruction'));
++			await getThreadAndRun(accessor, context, (thread: IThread) => thread.next('instruction'));
+ 		} else {
+-			getThreadAndRun(accessor, context, (thread: IThread) => thread.next());
++			await getThreadAndRun(accessor, context, (thread: IThread) => thread.next());
+ 		}
+ 	}
+ });
+```

--- a/crates/edit_prediction_cli/evals/vscode--add-class-decorator.md
+++ b/crates/edit_prediction_cli/evals/vscode--add-class-decorator.md
@@ -1,0 +1,74 @@
++++
+repository_url = "https://github.com/microsoft/vscode"
+revision = "6f6e26fcdf0a7ca5084e0da284cd7a5b2d41ae4d"
++++
+
+## Edit History
+
+```diff
+--- a/src/vs/workbench/api/common/extHostTypes.ts
++++ b/src/vs/workbench/api/common/extHostTypes.ts
+@@ -18,6 +18,14 @@ import { FileSystemProviderErrorCode, markAsFileSystemProviderError } from 'vs/
+ import type * as vscode from 'vscode';
+
++function es5ClassCompat(target: Function): any {
++	///@ts-expect-error
++	function _() { return Reflect.construct(target, arguments, this.constructor); }
++	Object.defineProperty(_, 'name', Object.getOwnPropertyDescriptor(target, 'name')!);
++	Object.setPrototypeOf(_, target);
++	Object.setPrototypeOf(_.prototype, target.prototype);
++	return _;
++}
++
++@es5ClassCompat
+ export class Disposable {
+--- a/src/vs/workbench/api/common/extHostTypes.ts
++++ b/src/vs/workbench/api/common/extHostTypes.ts
+@@ -50,6 +58,7 @@ export class Disposable {
+ 	}
+ }
+
++@es5ClassCompat
+ export class Position {
+
+ 	static Min(...positions: Position[]): Position {
+--- a/src/vs/workbench/api/common/extHostTypes.ts
++++ b/src/vs/workbench/api/common/extHostTypes.ts
+@@ -220,6 +229,7 @@ export class Position {
+ 	}
+ }
+
++@es5ClassCompat
+ export class Range {
+
+ 	static isRange(thing: any): thing is vscode.Range {
+```
+
+## Cursor Position
+
+```src/vs/workbench/api/common/extHostTypes.ts
+	Prepend = 3
+}
+
+export class TextEdit {
+// <[CURSOR_POSITION]
+
+	static isTextEdit(thing: any): thing is TextEdit {
+		if (thing instanceof TextEdit) {
+			return true;
+```
+
+## Expected Patch
+
+```diff
+--- a/src/vs/workbench/api/common/extHostTypes.ts
++++ b/src/vs/workbench/api/common/extHostTypes.ts
+@@ -475,6 +485,7 @@ export enum EnvironmentVariableMutatorType {
+ 	Prepend = 3
+ }
+
++@es5ClassCompat
+ export class TextEdit {
+
+ 	static isTextEdit(thing: any): thing is TextEdit {
+```

--- a/crates/edit_prediction_cli/evals/vscode--add-interface-method.md
+++ b/crates/edit_prediction_cli/evals/vscode--add-interface-method.md
@@ -1,0 +1,113 @@
++++
+repository_url = "https://github.com/microsoft/vscode"
+revision = "b64eaf598008e2d600a81d846108f72cb37b48e2"
++++
+
+## Edit History
+
+```diff
+--- a/src/vs/platform/window/electron-main/window.ts
++++ b/src/vs/platform/window/electron-main/window.ts
+@@ -1,49 +1,50 @@
+ export interface ICodeWindow extends IDisposable {
+ 
+ 	readonly onWillLoad: Event<ILoadEvent>;
+ 	readonly onDidSignalReady: Event<void>;
++	readonly onDidTriggerSystemContextMenu: Event<{ x: number; y: number }>;
+ 	readonly onDidClose: Event<void>;
+ 	readonly onDidDestroy: Event<void>;
+ 
+ 	readonly whenClosedOrLoaded: Promise<void>;
+--- a/src/vs/platform/windows/electron-main/window.ts
++++ b/src/vs/platform/windows/electron-main/window.ts
+@@ -63,60 +63,63 @@ const enum ReadyState {
+ export class CodeWindow extends Disposable implements ICodeWindow {
+ 
+ 	//#region Events
+ 
+ 	private readonly _onWillLoad = this._register(new Emitter<ILoadEvent>());
+ 	readonly onWillLoad = this._onWillLoad.event;
+ 
+ 	private readonly _onDidSignalReady = this._register(new Emitter<void>());
+ 	readonly onDidSignalReady = this._onDidSignalReady.event;
+ 
++	private readonly _onDidTriggerSystemContextMenu = this._register(new Emitter<{ x: number; y: number }>());
++	readonly onDidTriggerSystemContextMenu = this._onDidTriggerSystemContextMenu.event;
++
+ 	private readonly _onDidClose = this._register(new Emitter<void>());
+ 	readonly onDidClose = this._onDidClose.event;
+ 
+ 	private readonly _onDidDestroy = this._register(new Emitter<void>());
+ 	readonly onDidDestroy = this._onDidDestroy.event;
+ 
+ 	//#endregion
+--- a/src/vs/platform/windows/electron-main/windows.ts
++++ b/src/vs/platform/windows/electron-main/windows.ts
+@@ -1,54 +1,55 @@
+ export interface IWindowsMainService {
+ 
+ 	readonly _serviceBrand: undefined;
+ 
+ 	readonly onDidChangeWindowsCount: Event<IWindowsCountChangedEvent>;
+ 
+ 	readonly onDidOpenWindow: Event<ICodeWindow>;
+ 	readonly onDidSignalReadyWindow: Event<ICodeWindow>;
++	readonly onDidTriggerSystemContextMenu: Event<{ window: ICodeWindow; x: number; y: number }>;
+ 	readonly onDidDestroyWindow: Event<ICodeWindow>;
+--- a/src/vs/platform/windows/electron-main/windowsMainService.ts
++++ b/src/vs/platform/windows/electron-main/windowsMainService.ts
+@@ -160,60 +160,63 @@ interface ISingleFolderWorkspacePathToOpen extends IPathToOpen {
+ export class WindowsMainService extends Disposable implements IWindowsMainService {
+ 
+ 	declare readonly _serviceBrand: undefined;
+ 
+ 	private static readonly WINDOWS: ICodeWindow[] = [];
+ 
+ 	private readonly _onDidOpenWindow = this._register(new Emitter<ICodeWindow>());
+ 	readonly onDidOpenWindow = this._onDidOpenWindow.event;
+ 
+ 	private readonly _onDidSignalReadyWindow = this._register(new Emitter<ICodeWindow>());
+ 	readonly onDidSignalReadyWindow = this._onDidSignalReadyWindow.event;
+ 
+ 	private readonly _onDidDestroyWindow = this._register(new Emitter<ICodeWindow>());
+ 	readonly onDidDestroyWindow = this._onDidDestroyWindow.event;
+ 
+ 	private readonly _onDidChangeWindowsCount = this._register(new Emitter<IWindowsCountChangedEvent>());
+ 	readonly onDidChangeWindowsCount = this._onDidChangeWindowsCount.event;
+ 
++	private readonly _onDidTriggerSystemContextMenu = this._register(new Emitter<{ window: ICodeWindow; x: number; y: number }>());
++	readonly onDidTriggerSystemContextMenu = this._onDidTriggerSystemContextMenu.event;
++
+ 	private readonly windowsStateHandler = this._register(new WindowsStateHandler(this, this.stateMainService, this.lifecycleMainService, this.logService, this.configurationService));
+```
+
+## Cursor Position
+
+```src/vs/platform/windows/test/electron-main/windowsFinder.test.ts
+	function createTestCodeWindow(options: { lastFocusTime: number; openedFolderUri?: URI; openedWorkspace?: IWorkspaceIdentifier }): ICodeWindow {
+		return new class implements ICodeWindow {
+			onWillLoad: Event<ILoadEvent> = Event.None;
+			onDidSignalReady: Event<void> = Event.None;
+			// <[CURSOR_POSITION]
+			onDidClose: Event<void> = Event.None;
+			onDidDestroy: Event<void> = Event.None;
+			whenClosedOrLoaded: Promise<void> = Promise.resolve();
+			id: number = -1;
+```
+
+## Expected Patch
+
+```diff
+--- a/src/vs/platform/windows/test/electron-main/windowsFinder.test.ts
++++ b/src/vs/platform/windows/test/electron-main/windowsFinder.test.ts
+@@ -7,60 +7,61 @@ import * as assert from 'assert';
+ 	function createTestCodeWindow(options: { lastFocusTime: number; openedFolderUri?: URI; openedWorkspace?: IWorkspaceIdentifier }): ICodeWindow {
+ 		return new class implements ICodeWindow {
+ 			onWillLoad: Event<ILoadEvent> = Event.None;
++			onDidTriggerSystemContextMenu: Event<{ x: number; y: number }> = Event.None;
+ 			onDidSignalReady: Event<void> = Event.None;
+ 			onDidClose: Event<void> = Event.None;
+ 			onDidDestroy: Event<void> = Event.None;
+ 			whenClosedOrLoaded: Promise<void> = Promise.resolve();
+ 			id: number = -1;
+```

--- a/crates/edit_prediction_cli/src/git.rs
+++ b/crates/edit_prediction_cli/src/git.rs
@@ -91,7 +91,7 @@ pub async fn ensure_repo_cloned(repo_url: &str) -> Result<PathBuf> {
     }
 
     // Always fetch to get latest commits
-    run_git(&repo_path, &["fetch", "origin"]).await?;
+    run_git(&repo_path, &["fetch", "--depth", "1000", "origin"]).await?;
 
     // Check if we have a valid HEAD, if not checkout FETCH_HEAD
     let has_head = run_git(&repo_path, &["rev-parse", "HEAD"]).await.is_ok();

--- a/crates/edit_prediction_cli/src/main.rs
+++ b/crates/edit_prediction_cli/src/main.rs
@@ -39,6 +39,7 @@ use zeta_prompt::ZetaFormat;
 
 use reqwest_client::ReqwestClient;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::env;
 use std::fmt::Display;
 use std::fs::{File, OpenOptions};
 use std::hash::{Hash, Hasher};
@@ -897,8 +898,18 @@ fn main() {
         }
 
         Command::Synthesize(synth_args) => {
-            let Some(output_dir) = args.output else {
-                panic!("output dir is required");
+            let output_dir = if let Some(output_dir) = args.output {
+                output_dir
+            } else {
+                let default_output_dir = env::current_dir()
+                    .unwrap()
+                    .join("crates/edit_prediction_cli/evals-generated");
+                if default_output_dir.parent().unwrap().exists() {
+                    std::fs::create_dir(&default_output_dir).ok();
+                    default_output_dir
+                } else {
+                    panic!("output dir is required");
+                }
             };
             let config = SynthesizeConfig {
                 repo_urls: synth_args.repos.clone(),

--- a/crates/edit_prediction_cli/src/synthesize.rs
+++ b/crates/edit_prediction_cli/src/synthesize.rs
@@ -284,7 +284,7 @@ fn should_skip_commit(commit: &CommitInfo) -> bool {
         .lines()
         .filter(|l| l.starts_with('+') || l.starts_with('-'))
         .count();
-    lines_changed < 10
+    lines_changed < 30
         || lines_changed > 1000
         || is_non_code_commit(commit)
         || is_rename_commit(commit)
@@ -377,10 +377,13 @@ fn build_prompt(repo_url: &str, commit: &CommitInfo) -> String {
         indoc! {r#"
             You are analyzing a git commit to construct a realistic edit prediction example.
 
-            Your goal is to tell the story of a programmer's editing session: what sequence of changes did they make, and what change logically comes next? We use these examples to train a model to predict edits, so the quality of the EDIT HISTORY is what matters most.
+            Your goal is to tell the story of a programmer's editing session: what sequence
+            of changes did they make, and what change logically comes next? We use these examples
+            to train a model to predict edits, so the quality of the EDIT HISTORY is what matters most.
 
             An edit prediction example consists of:
-            1. **Edit History**: 3-6 hunks showing what the programmer did BEFORE making the expected patch. This is the most important part - it must tell a coherent story of the changes leading up to the prediction.
+            1. **Edit History**: 2-6 hunks showing what the programmer did BEFORE making the expected patch.
+               This is the most important part - it must tell a coherent story of the changes leading up to the prediction.
             2. **Expected Patch**: One small hunk that logically follows from the edit history.
 
             Both single-file and multi-file patterns are acceptable.
@@ -417,7 +420,7 @@ fn build_prompt(repo_url: &str, commit: &CommitInfo) -> String {
             First, THINK through whether this commit can support a good example:
 
             1. What is the high-level pattern in this commit?
-            2. Can you identify at least 4 related hunks (3 for edit history + 1 for expected patch)?
+            2. Can you identify at least 3 related hunks (2 or more for edit history + 1 for expected patch)?
             3. What would be the narrative? (First... then... then... finally predict...)
             4. Which specific hunk should be the expected patch (the "punchline")?
 


### PR DESCRIPTION
In some evals, the teacher produced hallucinations, seemingly due to
context rot. This makes the zeta prompt crate's budgeted rendering
usable by the teacher, so that it can truncate the list of excerpts.

I've also cleaned up the implementation of zeta_prompt's
`format_related_files_within_budget`, and changed the behavior so that
it filters the the excerpts by priority but renders the files in their
original order.

Release Notes:

- N/A
