### PR TITLE
Fix Windows remote server

### DIFF
--- a/crates/remote_server/Cargo.toml
+++ b/crates/remote_server/Cargo.toml
@@ -38,7 +38,7 @@ futures.workspace = true
 git.workspace = true
 git_hosting_providers.workspace = true
 git2 = { workspace = true, features = ["vendored-libgit2"] }
-gpui.workspace = true
+gpui = { workspace = true, features = ["windows-manifest"] }
 gpui_platform.workspace = true
 gpui_tokio.workspace = true
 http_client.workspace = true


### PR DESCRIPTION
More fallout from https://github.com/zed-industries/zed/pull/49277.

Closes #50149.

Release Notes:

- Fixed remote server failing to launch on Windows.