### PR TITLE
tests: Use path! macro in unit tests for cross-platform paths

### DIFF
--- a/crates/fs/src/fake_git_repo.rs
+++ b/crates/fs/src/fake_git_repo.rs
@@ -890,6 +890,7 @@ mod tests {
     use gpui::TestAppContext;
     use serde_json::json;
     use std::path::Path;
+    use util::path;
 
     #[gpui::test]
     async fn test_fake_worktree_lifecycle(cx: &mut TestAppContext) {
@@ -897,10 +898,10 @@ mod tests {
 
         for worktree_dir_setting in worktree_dir_settings {
             let fs = FakeFs::new(cx.executor());
-            fs.insert_tree("/project", json!({".git": {}, "file.txt": "content"}))
+            fs.insert_tree(path!("/project"), json!({".git": {}, "file.txt": "content"}))
                 .await;
             let repo = fs
-                .open_repo(Path::new("/project/.git"), None)
+                .open_repo(Path::new(path!("/project/.git")), None)
                 .expect("should open fake repo");
 
             // Initially no worktrees
@@ -908,7 +909,7 @@ mod tests {
             assert!(worktrees.is_empty());
 
             let expected_dir = git::repository::resolve_worktree_directory(
-                Path::new("/project"),
+                Path::new(path!("/project")),
                 worktree_dir_setting,
             );
 

--- a/crates/fs/tests/integration/fake_git_repo.rs
+++ b/crates/fs/tests/integration/fake_git_repo.rs
@@ -21,15 +21,15 @@ async fn test_checkpoints(executor: BackgroundExecutor) {
         }),
     )
     .await;
-    fs.with_git_state(Path::new("/foo/.git"), true, |_git| {})
+    fs.with_git_state(Path::new(path!("/foo/.git")), true, |_git| {})
         .unwrap();
     let repository = fs
-        .open_repo(Path::new("/foo/.git"), Some("git".as_ref()))
+        .open_repo(Path::new(path!("/foo/.git")), Some("git".as_ref()))
         .unwrap();
 
     let checkpoint_1 = repository.checkpoint().await.unwrap();
-    fs.write(Path::new("/foo/b"), b"IPSUM").await.unwrap();
-    fs.write(Path::new("/foo/c"), b"dolor").await.unwrap();
+    fs.write(Path::new(path!("/foo/b")), b"IPSUM").await.unwrap();
+    fs.write(Path::new(path!("/foo/c")), b"dolor").await.unwrap();
     let checkpoint_2 = repository.checkpoint().await.unwrap();
     let checkpoint_3 = repository.checkpoint().await.unwrap();
 

--- a/crates/fs/tests/integration/fs.rs
+++ b/crates/fs/tests/integration/fs.rs
@@ -530,7 +530,7 @@ async fn test_realfs_broken_symlink_metadata(executor: BackgroundExecutor) {
     let path = tempdir.path();
     let fs = RealFs::new(None, executor);
     let symlink_path = path.join("symlink");
-    smol::block_on(fs.create_symlink(&symlink_path, PathBuf::from("file_a.txt"))).unwrap();
+    smol::block_on(fs.create_symlink(&symlink_path, PathBuf::from(path!("file_a.txt")))).unwrap();
     let metadata = fs
         .metadata(&symlink_path)
         .await
@@ -550,7 +550,7 @@ async fn test_realfs_symlink_loop_metadata(executor: BackgroundExecutor) {
     let path = tempdir.path();
     let fs = RealFs::new(None, executor);
     let symlink_path = path.join("symlink");
-    smol::block_on(fs.create_symlink(&symlink_path, PathBuf::from("symlink"))).unwrap();
+    smol::block_on(fs.create_symlink(&symlink_path, PathBuf::from(path!("symlink")))).unwrap();
     let metadata = fs
         .metadata(&symlink_path)
         .await

--- a/crates/project/tests/integration/project_tests.rs
+++ b/crates/project/tests/integration/project_tests.rs
@@ -5077,7 +5077,7 @@ async fn test_save_as(cx: &mut gpui::TestAppContext) {
     let fs = FakeFs::new(cx.executor());
     fs.insert_tree("/dir", json!({})).await;
 
-    let project = Project::test(fs.clone(), ["/dir".as_ref()], cx).await;
+    let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
 
     let languages = project.update(cx, |project, _| project.languages().clone());
     languages.add(rust_lang());
@@ -5102,13 +5102,13 @@ async fn test_save_as(cx: &mut gpui::TestAppContext) {
         })
         .await
         .unwrap();
-    assert_eq!(fs.load(Path::new("/dir/file1.rs")).await.unwrap(), "abc");
+    assert_eq!(fs.load(Path::new(path!("/dir/file1.rs"))).await.unwrap(), "abc");
 
     cx.executor().run_until_parked();
     buffer.update(cx, |buffer, cx| {
         assert_eq!(
             buffer.file().unwrap().full_path(cx),
-            Path::new("dir/file1.rs")
+            Path::new(path!("dir/file1.rs"))
         );
         assert!(!buffer.is_dirty());
         assert!(!buffer.has_conflict());
@@ -5169,7 +5169,7 @@ async fn test_save_as_existing_file(cx: &mut gpui::TestAppContext) {
     buffer.update(cx, |buffer, cx| {
         assert_eq!(
             buffer.file().unwrap().full_path(cx),
-            Path::new("dir/data_b.txt")
+            Path::new(path!("dir/data_b.txt"))
         )
     });
 
@@ -5186,7 +5186,7 @@ async fn test_save_as_existing_file(cx: &mut gpui::TestAppContext) {
         assert_eq!(buffer.text(), "data about a");
         assert_eq!(
             buffer.file().unwrap().full_path(cx),
-            Path::new("dir/data_a.txt")
+            Path::new(path!("dir/data_a.txt"))
         )
     });
 }
@@ -5427,7 +5427,7 @@ async fn test_buffer_deduping(cx: &mut gpui::TestAppContext) {
     )
     .await;
 
-    let project = Project::test(fs.clone(), ["/dir".as_ref()], cx).await;
+    let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
 
     // Spawn multiple tasks to open paths, repeating some paths.
     let (buffer_a_1, buffer_b, buffer_a_2) = project.update(cx, |p, cx| {
@@ -7215,7 +7215,7 @@ async fn test_create_entry(cx: &mut gpui::TestAppContext) {
     )
     .await;
 
-    let project = Project::test(fs.clone(), ["/one/two/three".as_ref()], cx).await;
+    let project = Project::test(fs.clone(), [path!("/one/two/three").as_ref()], cx).await;
     project
         .update(cx, |project, cx| {
             let id = project.worktrees(cx).next().unwrap().read(cx).id();
@@ -7727,9 +7727,9 @@ async fn test_reordering_worktrees(cx: &mut gpui::TestAppContext) {
     let project = Project::test(
         fs,
         [
-            "/dir/a.rs".as_ref(),
-            "/dir/b.rs".as_ref(),
-            "/dir/c.rs".as_ref(),
+            path!("/dir/a.rs").as_ref(),
+            path!("/dir/b.rs").as_ref(),
+            path!("/dir/c.rs").as_ref(),
         ],
         cx,
     )
@@ -7937,9 +7937,9 @@ async fn test_unstaged_diff_for_buffer(cx: &mut gpui::TestAppContext) {
     )
     .await;
 
-    fs.set_index_for_repo(Path::new("/dir/.git"), &[("src/main.rs", staged_contents)]);
+    fs.set_index_for_repo(Path::new(path!("/dir/.git")), &[("src/main.rs", staged_contents)]);
 
-    let project = Project::test(fs.clone(), ["/dir".as_ref()], cx).await;
+    let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
 
     let buffer = project
         .update(cx, |project, cx| {
@@ -7980,7 +7980,7 @@ async fn test_unstaged_diff_for_buffer(cx: &mut gpui::TestAppContext) {
     "#
     .unindent();
 
-    fs.set_index_for_repo(Path::new("/dir/.git"), &[("src/main.rs", staged_contents)]);
+    fs.set_index_for_repo(Path::new(path!("/dir/.git")), &[("src/main.rs", staged_contents)]);
 
     cx.run_until_parked();
     unstaged_diff.update(cx, |unstaged_diff, cx| {
@@ -8038,7 +8038,7 @@ async fn test_uncommitted_diff_for_buffer(cx: &mut gpui::TestAppContext) {
     .await;
 
     fs.set_head_for_repo(
-        Path::new("/dir/.git"),
+        Path::new(path!("/dir/.git")),
         &[
             ("src/modification.rs", committed_contents),
             ("src/deletion.rs", "// the-deleted-contents\n".into()),
@@ -8046,14 +8046,14 @@ async fn test_uncommitted_diff_for_buffer(cx: &mut gpui::TestAppContext) {
         "deadbeef",
     );
     fs.set_index_for_repo(
-        Path::new("/dir/.git"),
+        Path::new(path!("/dir/.git")),
         &[
             ("src/modification.rs", staged_contents),
             ("src/deletion.rs", "// the-deleted-contents\n".into()),
         ],
     );
 
-    let project = Project::test(fs.clone(), ["/dir".as_ref()], cx).await;
+    let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
     let language_registry = project.read_with(cx, |project, _| project.languages().clone());
     let language = rust_lang();
     language_registry.add(language.clone());
@@ -8106,7 +8106,7 @@ async fn test_uncommitted_diff_for_buffer(cx: &mut gpui::TestAppContext) {
     "#
     .unindent();
     fs.set_head_for_repo(
-        Path::new("/dir/.git"),
+        Path::new(path!("/dir/.git")),
         &[
             ("src/modification.rs", committed_contents.clone()),
             ("src/deletion.rs", "// the-deleted-contents\n".into()),
@@ -8164,7 +8164,7 @@ async fn test_uncommitted_diff_for_buffer(cx: &mut gpui::TestAppContext) {
 
     // Stage the deletion of this file
     fs.set_index_for_repo(
-        Path::new("/dir/.git"),
+        Path::new(path!("/dir/.git")),
         &[("src/modification.rs", committed_contents.clone())],
     );
     cx.run_until_parked();
@@ -8223,7 +8223,7 @@ async fn test_staging_hunks(cx: &mut gpui::TestAppContext) {
         &[("file.txt", committed_contents.clone())],
     );
 
-    let project = Project::test(fs.clone(), ["/dir".as_ref()], cx).await;
+    let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
 
     let buffer = project
         .update(cx, |project, cx| {
@@ -8370,7 +8370,7 @@ async fn test_staging_hunks(cx: &mut gpui::TestAppContext) {
 
     // Simulate a problem writing to the git index.
     fs.set_error_message_for_index_write(
-        "/dir/.git".as_ref(),
+        path!("/dir/.git").as_ref(),
         Some("failed to write git index".into()),
     );
 
@@ -8471,7 +8471,7 @@ async fn test_staging_hunks(cx: &mut gpui::TestAppContext) {
     }
 
     // Allow writing to the git index to succeed again.
-    fs.set_error_message_for_index_write("/dir/.git".as_ref(), None);
+    fs.set_error_message_for_index_write(path!("/dir/.git").as_ref(), None);
 
     // Stage two hunks with separate operations.
     uncommitted_diff.update(cx, |diff, cx| {
@@ -8569,16 +8569,16 @@ async fn test_staging_hunks_with_delayed_fs_event(cx: &mut gpui::TestAppContext)
     .await;
 
     fs.set_head_for_repo(
-        "/dir/.git".as_ref(),
+        path!("/dir/.git").as_ref(),
         &[("file.txt", committed_contents.clone())],
         "deadbeef",
     );
     fs.set_index_for_repo(
-        "/dir/.git".as_ref(),
+        path!("/dir/.git").as_ref(),
         &[("file.txt", committed_contents.clone())],
     );
 
-    let project = Project::test(fs.clone(), ["/dir".as_ref()], cx).await;
+    let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
 
     let buffer = project
         .update(cx, |project, cx| {
@@ -8879,16 +8879,16 @@ async fn test_single_file_diffs(cx: &mut gpui::TestAppContext) {
     .await;
 
     fs.set_head_for_repo(
-        Path::new("/dir/.git"),
+        Path::new(path!("/dir/.git")),
         &[("src/main.rs", committed_contents.clone())],
         "deadbeef",
     );
     fs.set_index_for_repo(
-        Path::new("/dir/.git"),
+        Path::new(path!("/dir/.git")),
         &[("src/main.rs", committed_contents.clone())],
     );
 
-    let project = Project::test(fs.clone(), ["/dir/src/main.rs".as_ref()], cx).await;
+    let project = Project::test(fs.clone(), [path!("/dir/src/main.rs").as_ref()], cx).await;
 
     let buffer = project
         .update(cx, |project, cx| {
@@ -9255,7 +9255,7 @@ async fn test_git_repository_status(cx: &mut gpui::TestAppContext) {
 
     git_add("a.txt", &repo);
     git_add("c.txt", &repo);
-    git_remove_index(Path::new("d.txt"), &repo);
+    git_remove_index(Path::new(path!("d.txt")), &repo);
     git_commit("Another commit", &repo);
     tree.flush_fs_events(cx).await;
     project
@@ -11617,7 +11617,7 @@ async fn test_find_project_path_abs(
         );
 
         // Test with an absolute path outside any worktree
-        let abs_path = Path::new("/some/other/path");
+        let abs_path = Path::new(path!("/some/other/path"));
         let found_path = project.find_project_path(abs_path, cx);
         assert!(
             found_path.is_none(),

--- a/crates/project/tests/integration/yarn.rs
+++ b/crates/project/tests/integration/yarn.rs
@@ -1,30 +1,31 @@
 use project::yarn::*;
 use std::path::Path;
+use util::path;
 
 #[test]
 fn test_resolve_virtual() {
     let test_cases = vec![
         (
-            "/path/to/some/folder/__virtual__/a0b1c2d3/0/subpath/to/file.dat",
-            Some(Path::new("/path/to/some/folder/subpath/to/file.dat")),
+            path!("/path/to/some/folder/__virtual__/a0b1c2d3/0/subpath/to/file.dat"),
+            Some(Path::new(path!("/path/to/some/folder/subpath/to/file.dat"))),
         ),
         (
-            "/path/to/some/folder/__virtual__/e4f5a0b1/0/subpath/to/file.dat",
-            Some(Path::new("/path/to/some/folder/subpath/to/file.dat")),
+            path!("/path/to/some/folder/__virtual__/e4f5a0b1/0/subpath/to/file.dat"),
+            Some(Path::new(path!("/path/to/some/folder/subpath/to/file.dat"))),
         ),
         (
-            "/path/to/some/folder/__virtual__/a0b1c2d3/1/subpath/to/file.dat",
-            Some(Path::new("/path/to/some/subpath/to/file.dat")),
+            path!("/path/to/some/folder/__virtual__/a0b1c2d3/1/subpath/to/file.dat"),
+            Some(Path::new(path!("/path/to/some/subpath/to/file.dat"))),
         ),
         (
-            "/path/to/some/folder/__virtual__/a0b1c2d3/3/subpath/to/file.dat",
-            Some(Path::new("/path/subpath/to/file.dat")),
+            path!("/path/to/some/folder/__virtual__/a0b1c2d3/3/subpath/to/file.dat"),
+            Some(Path::new(path!("/path/subpath/to/file.dat"))),
         ),
-        ("/path/to/nonvirtual/", None),
-        ("/path/to/malformed/__virtual__", None),
-        ("/path/to/malformed/__virtual__/a0b1c2d3", None),
+        (path!("/path/to/nonvirtual/"), None),
+        (path!("/path/to/malformed/__virtual__"), None),
+        (path!("/path/to/malformed/__virtual__/a0b1c2d3"), None),
         (
-            "/path/to/malformed/__virtual__/a0b1c2d3/this-should-be-a-number",
+            path!("/path/to/malformed/__virtual__/a0b1c2d3/this-should-be-a-number"),
             None,
         ),
     ];


### PR DESCRIPTION
Replaced hardcoded string literals in `Path::new` and `PathBuf::from` with the `path!` macro in `crates/fs` and `crates/project` unit tests. This ensures paths are correctly formatted for the target platform (e.g., using backslashes on Windows).

Release Notes:

- N/A
