### PR TITLE
Fix panic in diff hunk rendering

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -5580,7 +5580,11 @@ impl EditorElement {
                     continue;
                 }
                 let row_ix = display_row_range.start.0.saturating_sub(row_range.start.0);
-                if row_infos[row_ix as usize].diff_status.is_none() {
+                if row_infos
+                    .get(row_ix as usize)
+                    .and_then(|row_info| row_info.diff_status)
+                    .is_none()
+                {
                     continue;
                 }
                 if highlighted_rows


### PR DESCRIPTION
When `row_infos.is_empty()` (if you have very very tiny editors) we could
end up trying to read the first item out of it.

Fixes ZED-5AT
Fixes ZED-54F
Fixes ZED-56N

Updates  #49260

cc @Veykril

Before you mark this PR as ready for review, make sure that you have:
- [ ] Added a solid test coverage and/or screenshots from doing manual testing
- [ ] Done a self-review taking into account security and performance aspects
- [ ] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Fixed a panic rendering diff hunk headers in 0-height editors
