### PR TITLE
markdown_preview: Fix panic in mermaid diagram renderer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4081,6 +4081,7 @@ dependencies = [
 name = "crashes"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "bincode",
  "cfg-if",
  "crash-handler",
@@ -9994,6 +9995,7 @@ dependencies = [
  "anyhow",
  "async-recursion",
  "collections",
+ "crashes",
  "editor",
  "fs",
  "gpui",

--- a/crates/crashes/Cargo.toml
+++ b/crates/crashes/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license = "GPL-3.0-or-later"
 
 [dependencies]
+anyhow.workspace = true
 bincode.workspace = true
 cfg-if.workspace = true
 crash-handler.workspace = true

--- a/crates/markdown_preview/Cargo.toml
+++ b/crates/markdown_preview/Cargo.toml
@@ -18,6 +18,7 @@ test-support = []
 anyhow.workspace = true
 async-recursion.workspace = true
 collections.workspace = true
+crashes.workspace = true
 editor.workspace = true
 fs.workspace = true
 gpui.workspace = true

--- a/crates/markdown_preview/src/markdown_renderer.rs
+++ b/crates/markdown_preview/src/markdown_renderer.rs
@@ -133,7 +133,10 @@ impl CachedMermaidDiagram {
         let _task = cx.spawn(async move |this, cx| {
             let value = cx
                 .background_spawn(async move {
-                    let svg_string = mermaid_rs_renderer::render(&contents.contents)?;
+                    let svg_string = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        mermaid_rs_renderer::render(&contents.contents)
+                    }))
+                    .map_err(|_| anyhow::anyhow!("mermaid renderer panicked"))??;
                     let scale = contents.scale as f32 / 100.0;
                     svg_renderer
                         .render_single_frame(svg_string.as_bytes(), scale, true)

--- a/crates/markdown_preview/src/markdown_renderer.rs
+++ b/crates/markdown_preview/src/markdown_renderer.rs
@@ -133,10 +133,9 @@ impl CachedMermaidDiagram {
         let _task = cx.spawn(async move |this, cx| {
             let value = cx
                 .background_spawn(async move {
-                    let svg_string = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    let svg_string = crashes::recoverable_panic(|| {
                         mermaid_rs_renderer::render(&contents.contents)
-                    }))
-                    .map_err(|_| anyhow::anyhow!("mermaid renderer panicked"))??;
+                    })??;
                     let scale = contents.scale as f32 / 100.0;
                     svg_renderer
                         .render_single_frame(svg_string.as_bytes(), scale, true)


### PR DESCRIPTION
The mermaid renderer can fail to render certain diagrams, and we already have a fallback for that. It's not worth crashing Zed over it.

Wrapping `catch_unwind` alone doesn't work because our panic hooks terminate the process before unwinding begins (we intentionally terminate so the crash handler subprocess can generate a minidump), so there was no way to gracefully handle panics from third-party code until now (in rare cases where we need it, like in this case). 

To handle this gracefully, we added `crashes::recoverable_panic` which tells the panic hook to stand down on the current thread so the unwind can proceed and be caught. This should be used sparingly since caught panics bypass crash reporting.

Release Notes:

- Fixed a crash when rendering mermaid diagrams in markdown preview.