### PR TITLE
sidebar: Improve git worktree support in multi-workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15789,6 +15789,7 @@ dependencies = [
  "picker",
  "project",
  "recent_projects",
+ "serde_json",
  "settings",
  "theme",
  "ui",

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1504,13 +1504,17 @@
     // When the resolved directory is inside the project root, no
     // extra component is added (it's already project-scoped).
     //
+    // When unset, auto-detects: bare clone layouts place worktrees
+    // as siblings in the repository's parent directory; normal repos
+    // use "../worktrees".
+    //
     // Examples:
-    //   "../worktrees" — ~/code/worktrees/<project>/ (default)
+    //   "../worktrees" — ~/code/worktrees/<project>/ (default for normal repos)
     //   ".git/zed-worktrees" — <project>/.git/zed-worktrees/
     //   "my-worktrees" — <project>/my-worktrees/
     //
     // Trailing slashes are ignored.
-    "worktree_directory": "../worktrees",
+    // "worktree_directory": "../worktrees",
   },
   // The list of custom Git hosting providers.
   "git_hosting_providers": [

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -56,7 +56,7 @@ use editor::{Anchor, AnchorRangeExt as _, Editor, EditorEvent, MultiBuffer};
 use extension::ExtensionEvents;
 use extension_host::ExtensionStore;
 use fs::Fs;
-use git::repository::validate_worktree_directory;
+
 use gpui::{
     Action, Animation, AnimationExt, AnyElement, App, AsyncWindowContext, ClipboardItem, Corner,
     DismissEvent, Entity, EventEmitter, ExternalPaths, FocusHandle, Focusable, KeyContext, Pixels,
@@ -2118,7 +2118,7 @@ impl AgentPanel {
     fn start_worktree_creations(
         git_repos: &[Entity<project::git_store::Repository>],
         branch_name: &str,
-        worktree_directory_setting: &str,
+        worktree_directory_setting: Option<&str>,
         cx: &mut Context<Self>,
     ) -> Result<(
         Vec<(
@@ -2134,8 +2134,12 @@ impl AgentPanel {
         for repo in git_repos {
             let (work_dir, new_path, receiver) = repo.update(cx, |repo, _cx| {
                 let original_repo = repo.original_repo_abs_path.clone();
-                let directory =
-                    validate_worktree_directory(&original_repo, worktree_directory_setting)?;
+                let work_dir = repo.work_directory_abs_path.clone();
+                let directory = git::repository::resolve_worktree_directory_for_repo(
+                    &original_repo,
+                    &work_dir,
+                    worktree_directory_setting.as_deref(),
+                )?;
                 let new_path = directory.join(branch_name);
                 let receiver = repo.create_worktree(branch_name.to_string(), directory, None);
                 let work_dir = repo.work_directory_abs_path.clone();
@@ -2277,7 +2281,7 @@ impl AgentPanel {
         let (creation_infos, path_remapping) = match Self::start_worktree_creations(
             &git_repos,
             &branch_name,
-            &worktree_directory_setting,
+            worktree_directory_setting.as_deref(),
             cx,
         ) {
             Ok(result) => result,

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -157,6 +157,25 @@ pub fn validate_worktree_directory(
     Ok(resolved)
 }
 
+/// Resolves the worktree directory for a repository, handling the optional
+/// `git.worktree_directory` setting with bare-clone auto-detection.
+///
+/// - `Some(setting)` → validates and resolves relative to `original_repo`.
+/// - `None` + bare clone (`original_repo != work_directory`) → uses
+///   `work_directory` directly (worktrees are siblings).
+/// - `None` + normal repo → falls back to `DEFAULT_WORKTREE_DIRECTORY`.
+pub fn resolve_worktree_directory_for_repo(
+    original_repo: &Path,
+    work_directory: &Path,
+    setting: Option<&str>,
+) -> Result<PathBuf> {
+    match setting {
+        Some(s) => validate_worktree_directory(original_repo, s),
+        None if original_repo != work_directory => Ok(work_directory.to_path_buf()),
+        None => validate_worktree_directory(original_repo, DEFAULT_WORKTREE_DIRECTORY),
+    }
+}
+
 /// Returns the full absolute path for a specific branch's worktree
 /// given the resolved worktree directory.
 pub fn worktree_path_for_branch(
@@ -4360,6 +4379,8 @@ mod tests {
             PathBuf::from("/code/my-project/my-worktrees/branch")
         );
     }
+
+
 
     impl RealGitRepository {
         /// Force a Git garbage collection on the repository.

--- a/crates/git_ui/src/worktree_picker.rs
+++ b/crates/git_ui/src/worktree_picker.rs
@@ -2,7 +2,7 @@ use anyhow::Context as _;
 use collections::HashSet;
 use fuzzy::StringMatchCandidate;
 
-use git::repository::{Worktree as GitWorktree, validate_worktree_directory};
+use git::repository::{Worktree as GitWorktree, resolve_worktree_directory_for_repo};
 use gpui::{
     Action, App, AsyncWindowContext, Context, DismissEvent, Entity, EventEmitter, FocusHandle,
     Focusable, InteractiveElement, IntoElement, Modifiers, ModifiersChangedEvent, ParentElement,
@@ -301,8 +301,12 @@ impl WorktreeListDelegate {
                     .worktree_directory
                     .clone();
                 let original_repo = repo.original_repo_abs_path.clone();
-                let directory =
-                    validate_worktree_directory(&original_repo, &worktree_directory_setting)?;
+                let work_dir = repo.work_directory_abs_path.clone();
+                let directory = resolve_worktree_directory_for_repo(
+                    &original_repo,
+                    &work_dir,
+                    worktree_directory_setting.as_deref(),
+                )?;
                 let new_worktree_path = directory.join(&branch);
                 let receiver = repo.create_worktree(branch.clone(), directory, commit);
                 anyhow::Ok((receiver, new_worktree_path))

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -2379,6 +2379,16 @@ impl Project {
                 let is_subdir = relative_path
                     .as_ref()
                     .is_some_and(|p| !p.as_ref().as_unix_str().is_empty());
+                // If this subdirectory is itself a git repository root (e.g. a
+                // git worktree), it should get its own workspace rather than
+                // being claimed by this one.
+                if is_subdir
+                    && relative_path
+                        .as_ref()
+                        .is_some_and(|rel| worktree.contains_git_repo_at(rel))
+                {
+                    return None;
+                }
                 let contains =
                     relative_path.is_some() && (!exclude_sub_dirs || !is_dir || !is_subdir);
                 contains.then(|| worktree.is_visible())

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -4,7 +4,7 @@ use context_server::ContextServerCommand;
 use dap::adapters::DebugAdapterName;
 use fs::Fs;
 use futures::StreamExt as _;
-use git::repository::DEFAULT_WORKTREE_DIRECTORY;
+
 use gpui::{AsyncApp, BorrowAppContext, Context, Entity, EventEmitter, Subscription, Task};
 use lsp::{DEFAULT_LSP_REQUEST_TIMEOUT_SECS, LanguageServerName};
 use paths::{
@@ -461,7 +461,7 @@ pub struct GitSettings {
     /// sibling repos don't collide.
     ///
     /// Default: ../worktrees
-    pub worktree_directory: String,
+    pub worktree_directory: Option<String>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -651,10 +651,7 @@ impl Settings for ProjectSettings {
             },
             hunk_style: git.hunk_style.unwrap(),
             path_style: git.path_style.unwrap().into(),
-            worktree_directory: git
-                .worktree_directory
-                .clone()
-                .unwrap_or_else(|| DEFAULT_WORKTREE_DIRECTORY.to_string()),
+            worktree_directory: git.worktree_directory.clone(),
         };
         Self {
             context_servers: project

--- a/crates/sidebar/Cargo.toml
+++ b/crates/sidebar/Cargo.toml
@@ -37,6 +37,7 @@ feature_flags.workspace = true
 fs = { workspace = true, features = ["test-support"] }
 gpui = { workspace = true, features = ["test-support"] }
 project = { workspace = true, features = ["test-support"] }
+serde_json.workspace = true
 recent_projects = { workspace = true, features = ["test-support"] }
 settings = { workspace = true, features = ["test-support"] }
 workspace = { workspace = true, features = ["test-support"] }

--- a/crates/sidebar/src/sidebar.rs
+++ b/crates/sidebar/src/sidebar.rs
@@ -9,6 +9,7 @@ use gpui::{
     Subscription, Task, Window, px,
 };
 use picker::{Picker, PickerDelegate};
+use project::git_store::{GitStoreEvent, RepositoryEvent};
 use project::Event as ProjectEvent;
 use recent_projects::{RecentProjectEntry, get_recent_projects};
 use std::fmt::Display;
@@ -47,12 +48,16 @@ struct WorkspaceThreadEntry {
     index: usize,
     worktree_label: SharedString,
     full_path: SharedString,
+    repo_root: Option<Arc<Path>>,
+    is_prime: bool,
     thread_info: Option<AgentThreadInfo>,
 }
 
 impl WorkspaceThreadEntry {
     fn new(index: usize, workspace: &Entity<Workspace>, cx: &App) -> Self {
         let workspace_ref = workspace.read(cx);
+        let project = workspace_ref.project().read(cx);
+        let git_store = project.git_store().read(cx);
 
         let worktrees: Vec<_> = workspace_ref
             .worktrees(cx)
@@ -60,34 +65,81 @@ impl WorkspaceThreadEntry {
             .map(|worktree| worktree.read(cx).abs_path())
             .collect();
 
-        let worktree_names: Vec<String> = worktrees
-            .iter()
-            .filter_map(|path| {
-                path.file_name()
-                    .map(|name| name.to_string_lossy().to_string())
-            })
-            .collect();
-
-        let worktree_label: SharedString = if worktree_names.is_empty() {
-            format!("Workspace {}", index + 1).into()
-        } else {
-            worktree_names.join(", ").into()
+        let best_repo = Self::best_matching_repo(&worktrees, git_store, cx);
+        let repo_root = best_repo.as_ref().map(|s| s.original_repo_abs_path.clone());
+        let is_prime = match (&repo_root, worktrees.first()) {
+            (Some(root), Some(worktree_path)) => root.as_ref() == worktree_path.as_ref(),
+            _ => true,
         };
-
-        let full_path: SharedString = worktrees
-            .iter()
-            .map(|path| path.to_string_lossy().to_string())
-            .collect::<Vec<_>>()
-            .join("\n")
-            .into();
-
-        let thread_info = Self::thread_info(workspace, cx);
 
         Self {
             index,
-            worktree_label,
-            full_path,
-            thread_info,
+            worktree_label: Self::compute_label(index, &worktrees, best_repo.as_ref()),
+            full_path: worktrees
+                .iter()
+                .map(|path| path.to_string_lossy().to_string())
+                .collect::<Vec<_>>()
+                .join("\n")
+                .into(),
+            repo_root,
+            is_prime,
+            thread_info: Self::thread_info(workspace, cx),
+        }
+    }
+
+    fn best_matching_repo(
+        worktrees: &[Arc<Path>],
+        git_store: &project::git_store::GitStore,
+        cx: &App,
+    ) -> Option<project::git_store::RepositorySnapshot> {
+        worktrees.first().and_then(|path| {
+            git_store
+                .repositories()
+                .values()
+                .filter_map(|repo| {
+                    let repo = repo.read(cx);
+                    let repo_path = &*repo.work_directory_abs_path;
+                    if path.as_ref() == repo_path || path.starts_with(repo_path) {
+                        Some((repo_path.as_os_str().len(), repo.snapshot()))
+                    } else {
+                        None
+                    }
+                })
+                .max_by_key(|(len, _)| *len)
+                .map(|(_, snapshot)| snapshot)
+        })
+    }
+
+    fn compute_label(
+        index: usize,
+        worktrees: &[Arc<Path>],
+        best_repo: Option<&project::git_store::RepositorySnapshot>,
+    ) -> SharedString {
+        let names: Vec<String> = worktrees
+            .iter()
+            .filter_map(|path| {
+                let dir_name = path.file_name()?.to_string_lossy();
+                if let Some(snapshot) = best_repo {
+                    let repo_name = snapshot
+                        .original_repo_abs_path
+                        .file_name()
+                        .map(|n| n.to_string_lossy());
+                    let branch = snapshot.branch.as_ref().map(|b| b.name().to_string());
+                    match (repo_name, branch) {
+                        (Some(repo), Some(branch)) => Some(format!("{repo} / {branch}")),
+                        (Some(repo), None) => Some(repo.to_string()),
+                        _ => Some(dir_name.to_string()),
+                    }
+                } else {
+                    Some(dir_name.to_string())
+                }
+            })
+            .collect();
+
+        if names.is_empty() {
+            format!("Workspace {}", index + 1).into()
+        } else {
+            names.join(", ").into()
         }
     }
 
@@ -259,7 +311,16 @@ impl WorkspacePickerDelegate {
         if !workspace_threads.is_empty() {
             self.entries
                 .push(SidebarEntry::Separator("Active Workspaces".into()));
-            for thread in workspace_threads {
+
+            // Sort by common_dir so related worktrees are adjacent, prime first.
+            let mut sorted = workspace_threads;
+            sorted.sort_by(|a, b| {
+                a.repo_root.cmp(&b.repo_root)
+                    .then(b.is_prime.cmp(&a.is_prime))
+                    .then(a.worktree_label.cmp(&b.worktree_label))
+            });
+
+            for thread in sorted {
                 self.entries.push(SidebarEntry::WorkspaceThread(thread));
             }
         }
@@ -435,13 +496,14 @@ impl PickerDelegate for WorkspacePickerDelegate {
                 })
                 .collect();
 
-            let separator_offset = if self.workspace_thread_count > 0 {
-                1
-            } else {
-                0
-            };
-            self.selected_index = (self.active_workspace_index + separator_offset)
-                .min(self.matches.len().saturating_sub(1));
+            self.selected_index = self
+                .matches
+                .iter()
+                .position(|m| match &m.entry {
+                    SidebarEntry::WorkspaceThread(t) => t.index == self.active_workspace_index,
+                    _ => false,
+                })
+                .unwrap_or(0);
             return Task::ready(());
         }
 
@@ -609,8 +671,7 @@ impl PickerDelegate for WorkspacePickerDelegate {
                     AgentThreadStatus::Running | AgentThreadStatus::WaitingForConfirmation
                 );
 
-                Some(
-                    ThreadItem::new(
+                let thread_item = ThreadItem::new(
                         ("workspace-item", thread_entry.index),
                         thread_subtitle.unwrap_or("New Thread".into()),
                     )
@@ -646,9 +707,9 @@ impl PickerDelegate for WorkspacePickerDelegate {
                         this.tooltip(move |_, cx| {
                             Tooltip::with_meta(worktree_label.clone(), None, full_path.clone(), cx)
                         })
-                    })
-                    .into_any_element(),
-                )
+                    });
+
+                Some(thread_item.into_any_element())
             }
             SidebarEntry::RecentProject(project_entry) => {
                 let name = project_entry.name.clone();
@@ -774,31 +835,48 @@ impl Sidebar {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Vec<Subscription> {
-        let projects: Vec<_> = self
+        let workspaces: Vec<_> = self
             .multi_workspace
             .read(cx)
             .workspaces()
-            .iter()
-            .map(|w| w.read(cx).project().clone())
-            .collect();
+            .to_vec();
 
-        projects
-            .iter()
-            .map(|project| {
-                cx.subscribe_in(
-                    project,
-                    window,
-                    |this, _project, event, window, cx| match event {
-                        ProjectEvent::WorktreeAdded(_)
-                        | ProjectEvent::WorktreeRemoved(_)
-                        | ProjectEvent::WorktreeOrderChanged => {
-                            this.update_entries(window, cx);
-                        }
-                        _ => {}
-                    },
-                )
-            })
-            .collect()
+        let mut subscriptions = Vec::new();
+        for workspace in &workspaces {
+            let project = workspace.read(cx).project().clone();
+
+            subscriptions.push(cx.subscribe_in(
+                &project,
+                window,
+                |this, _project, event, window, cx| match event {
+                    ProjectEvent::WorktreeAdded(_)
+                    | ProjectEvent::WorktreeRemoved(_)
+                    | ProjectEvent::WorktreeOrderChanged => {
+                        this.update_entries(window, cx);
+                    }
+                    _ => {}
+                },
+            ));
+
+            let git_store = project.read(cx).git_store().clone();
+            subscriptions.push(cx.subscribe_in(
+                &git_store,
+                window,
+                |this, _, event, window, cx| match event {
+                    GitStoreEvent::RepositoryAdded
+                    | GitStoreEvent::RepositoryRemoved(_)
+                    | GitStoreEvent::RepositoryUpdated(
+                        _,
+                        RepositoryEvent::BranchChanged,
+                        _,
+                    ) => {
+                        this.update_entries(window, cx);
+                    }
+                    _ => {}
+                },
+            ));
+        }
+        subscriptions
     }
 
     fn build_workspace_thread_entries(
@@ -939,6 +1017,19 @@ impl Sidebar {
                 let query = picker.query(cx);
                 picker.update_matches(query, window, cx);
             });
+
+            // Push sidebar sort order to MultiWorkspace for next/previous cycling.
+            let display_order: Vec<usize> = this.picker.read(cx).delegate.entries
+                .iter()
+                .filter_map(|entry| match entry {
+                    SidebarEntry::WorkspaceThread(t) => Some(t.index),
+                    _ => None,
+                })
+                .collect();
+            multi_workspace.update(cx, |mw, _| {
+                mw.set_display_order(display_order);
+            });
+
             let has_notifications = !this.picker.read(cx).delegate.notified_workspaces.is_empty();
             if had_notifications != has_notifications {
                 multi_workspace.update(cx, |_, cx| cx.notify());
@@ -1269,5 +1360,386 @@ mod tests {
             !has_notifications(&sidebar, cx),
             "notification should be cleared when workspace becomes active"
         );
+    }
+
+    #[gpui::test]
+    async fn test_worktree_label_shows_repo_name_and_branch(cx: &mut TestAppContext) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            "/project",
+            serde_json::json!({
+                ".git": {},
+                "src": { "main.rs": "" }
+            }),
+        )
+        .await;
+        fs.set_branch_name(Path::new("/project/.git"), Some("feature-branch"));
+        cx.update(|cx| <dyn Fs>::set_global(fs.clone(), cx));
+
+        let project = project::Project::test(fs, [Path::new("/project")], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project, window, cx));
+        cx.run_until_parked();
+
+        let label = multi_workspace.read_with(cx, |mw, cx| {
+            let workspace = mw.workspace();
+            WorkspaceThreadEntry::new(0, workspace, cx).worktree_label
+        });
+        assert_eq!(label.as_ref(), "project / feature-branch");
+    }
+
+    #[gpui::test]
+    async fn test_worktree_label_for_git_worktree(cx: &mut TestAppContext) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            "/myrepo",
+            serde_json::json!({
+                ".git": {
+                    "worktrees": {
+                        "feature-x": {
+                            "commondir": "../..\n",
+                            "HEAD": "",
+                            "config": ""
+                        }
+                    }
+                },
+                "sub": {
+                    "feature-x": {
+                        ".git": "gitdir: ../../.git/worktrees/feature-x\n",
+                        "src": { "main.rs": "" }
+                    }
+                }
+            }),
+        )
+        .await;
+        fs.set_branch_name(
+            Path::new("/myrepo/.git/worktrees/feature-x"),
+            Some("feature-x"),
+        );
+        cx.update(|cx| <dyn Fs>::set_global(fs.clone(), cx));
+
+        let project = project::Project::test(
+            fs,
+            [Path::new("/myrepo/sub/feature-x")],
+            cx,
+        )
+        .await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project, window, cx));
+        cx.run_until_parked();
+
+        let label = multi_workspace.read_with(cx, |mw, cx| {
+            let workspace = mw.workspace();
+            WorkspaceThreadEntry::new(0, workspace, cx).worktree_label
+        });
+        assert_eq!(label.as_ref(), "myrepo / feature-x");
+    }
+
+    #[gpui::test]
+    async fn test_worktree_label_without_git(cx: &mut TestAppContext) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            "/plain-dir",
+            serde_json::json!({
+                "src": { "main.rs": "" }
+            }),
+        )
+        .await;
+        cx.update(|cx| <dyn Fs>::set_global(fs.clone(), cx));
+
+        let project = project::Project::test(fs, [Path::new("/plain-dir")], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project, window, cx));
+        cx.run_until_parked();
+
+        let label = multi_workspace.read_with(cx, |mw, cx| {
+            let workspace = mw.workspace();
+            WorkspaceThreadEntry::new(0, workspace, cx).worktree_label
+        });
+        assert_eq!(label.as_ref(), "plain-dir");
+    }
+
+    #[gpui::test]
+    async fn test_display_order_follows_sidebar_sort(cx: &mut TestAppContext) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.executor());
+
+        // Four repos: alpha, bravo (two worktrees sharing common_dir), charlie.
+        // Opened in order: bravo/main(0), alpha(1), bravo/feature(2), charlie(3)
+        // Sidebar sort by common_dir: alpha(1), bravo/main(0), bravo/feature(2), charlie(3)
+        fs.insert_tree(
+            "/bravo-main",
+            serde_json::json!({ ".git": {}, "src": {} }),
+        )
+        .await;
+        fs.set_branch_name(Path::new("/bravo-main/.git"), Some("main"));
+
+        fs.insert_tree(
+            "/alpha",
+            serde_json::json!({ ".git": {}, "src": {} }),
+        )
+        .await;
+        fs.set_branch_name(Path::new("/alpha/.git"), Some("main"));
+
+        fs.insert_tree(
+            "/bravo-feature",
+            serde_json::json!({
+                ".git": "gitdir: /bravo-main/.git/worktrees/feature\n",
+                "src": {}
+            }),
+        )
+        .await;
+        fs.insert_tree(
+            "/bravo-main/.git/worktrees/feature",
+            serde_json::json!({
+                "commondir": "../..\n",
+                "HEAD": "",
+                "config": ""
+            }),
+        )
+        .await;
+        fs.set_branch_name(
+            Path::new("/bravo-main/.git/worktrees/feature"),
+            Some("feature"),
+        );
+
+        fs.insert_tree(
+            "/charlie",
+            serde_json::json!({ ".git": {}, "src": {} }),
+        )
+        .await;
+        fs.set_branch_name(Path::new("/charlie/.git"), Some("main"));
+
+        cx.update(|cx| <dyn Fs>::set_global(fs.clone(), cx));
+
+        // Workspace 0: bravo/main
+        let project0 =
+            project::Project::test(fs.clone(), [Path::new("/bravo-main")], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project0, window, cx));
+
+        let sidebar = multi_workspace.update_in(cx, |_mw, window, cx| {
+            let mw_handle = cx.entity();
+            cx.new(|cx| Sidebar::new(mw_handle, window, cx))
+        });
+        multi_workspace.update_in(cx, |mw, window, cx| {
+            mw.register_sidebar(sidebar.clone(), window, cx);
+        });
+
+        // Workspace 1: alpha
+        let project1 = project::Project::test(fs.clone(), [Path::new("/alpha")], cx).await;
+        multi_workspace.update_in(cx, |mw, window, cx| {
+            mw.test_add_workspace(project1, window, cx);
+        });
+
+        // Workspace 2: bravo/feature
+        let project2 =
+            project::Project::test(fs.clone(), [Path::new("/bravo-feature")], cx).await;
+        multi_workspace.update_in(cx, |mw, window, cx| {
+            mw.test_add_workspace(project2, window, cx);
+        });
+
+        // Workspace 3: charlie
+        let project3 =
+            project::Project::test(fs.clone(), [Path::new("/charlie")], cx).await;
+        multi_workspace.update_in(cx, |mw, window, cx| {
+            mw.test_add_workspace(project3, window, cx);
+        });
+
+        cx.run_until_parked();
+
+        // Trigger sidebar update
+        sidebar.update_in(cx, |s, window, cx| {
+            s.update_entries(window, cx);
+        });
+        cx.run_until_parked();
+
+        // Verify display_order matches sidebar sort (by common_dir, prime first)
+        let display_order = multi_workspace.read_with(cx, |mw, _cx| {
+            mw.display_order().to_vec()
+        });
+
+        // alpha(1) sorts before bravo(0,2) before charlie(3)
+        // Within bravo group: main(0) is prime, feature(2) is not
+        assert_eq!(
+            display_order,
+            vec![1, 0, 2, 3],
+            "display_order should be sorted: alpha, bravo/main, bravo/feature, charlie"
+        );
+
+        // Verify cycling from workspace 0 (bravo/main)
+        multi_workspace.update_in(cx, |mw, window, cx| {
+            mw.activate_index(0, window, cx);
+        });
+        cx.run_until_parked();
+
+        // Next from bravo/main(0) should go to bravo/feature(2)
+        multi_workspace.update_in(cx, |mw, window, cx| {
+            mw.activate_next_workspace(window, cx);
+        });
+        let active = multi_workspace.read_with(cx, |mw, _| mw.active_workspace_index());
+        assert_eq!(active, 2, "next from bravo/main should be bravo/feature");
+
+        // Next from bravo/feature(2) should go to charlie(3)
+        multi_workspace.update_in(cx, |mw, window, cx| {
+            mw.activate_next_workspace(window, cx);
+        });
+        let active = multi_workspace.read_with(cx, |mw, _| mw.active_workspace_index());
+        assert_eq!(active, 3, "next from bravo/feature should be charlie");
+
+        // Previous from charlie(3) should go back to bravo/feature(2)
+        multi_workspace.update_in(cx, |mw, window, cx| {
+            mw.activate_previous_workspace(window, cx);
+        });
+        let active = multi_workspace.read_with(cx, |mw, _| mw.active_workspace_index());
+        assert_eq!(active, 2, "previous from charlie should be bravo/feature");
+
+        // Wrap around: previous from alpha(1) should go to charlie(3)
+        multi_workspace.update_in(cx, |mw, window, cx| {
+            mw.activate_index(1, window, cx);
+        });
+        multi_workspace.update_in(cx, |mw, window, cx| {
+            mw.activate_previous_workspace(window, cx);
+        });
+        let active = multi_workspace.read_with(cx, |mw, _| mw.active_workspace_index());
+        assert_eq!(active, 3, "previous from alpha should wrap to charlie");
+    }
+
+    #[gpui::test]
+    async fn test_display_order_adjusted_after_workspace_removal(cx: &mut TestAppContext) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.executor());
+
+        // Same four-workspace setup as test_display_order_follows_sidebar_sort:
+        // Opened in order: bravo/main(0), alpha(1), bravo/feature(2), charlie(3)
+        // Sidebar sort (display_order): [1, 0, 2, 3]
+        //   i.e. alpha(1), bravo/main(0), bravo/feature(2), charlie(3)
+        fs.insert_tree(
+            "/bravo-main",
+            serde_json::json!({ ".git": {}, "src": {} }),
+        )
+        .await;
+        fs.set_branch_name(Path::new("/bravo-main/.git"), Some("main"));
+
+        fs.insert_tree(
+            "/alpha",
+            serde_json::json!({ ".git": {}, "src": {} }),
+        )
+        .await;
+        fs.set_branch_name(Path::new("/alpha/.git"), Some("main"));
+
+        fs.insert_tree(
+            "/bravo-feature",
+            serde_json::json!({
+                ".git": "gitdir: /bravo-main/.git/worktrees/feature\n",
+                "src": {}
+            }),
+        )
+        .await;
+        fs.insert_tree(
+            "/bravo-main/.git/worktrees/feature",
+            serde_json::json!({
+                "commondir": "../..\n",
+                "HEAD": "",
+                "config": ""
+            }),
+        )
+        .await;
+        fs.set_branch_name(
+            Path::new("/bravo-main/.git/worktrees/feature"),
+            Some("feature"),
+        );
+
+        fs.insert_tree(
+            "/charlie",
+            serde_json::json!({ ".git": {}, "src": {} }),
+        )
+        .await;
+        fs.set_branch_name(Path::new("/charlie/.git"), Some("main"));
+
+        cx.update(|cx| <dyn Fs>::set_global(fs.clone(), cx));
+
+        let project0 =
+            project::Project::test(fs.clone(), [Path::new("/bravo-main")], cx).await;
+        let (multi_workspace, cx) =
+            cx.add_window_view(|window, cx| MultiWorkspace::test_new(project0, window, cx));
+
+        let sidebar = multi_workspace.update_in(cx, |_mw, window, cx| {
+            let mw_handle = cx.entity();
+            cx.new(|cx| Sidebar::new(mw_handle, window, cx))
+        });
+        multi_workspace.update_in(cx, |mw, window, cx| {
+            mw.register_sidebar(sidebar.clone(), window, cx);
+        });
+
+        let project1 = project::Project::test(fs.clone(), [Path::new("/alpha")], cx).await;
+        multi_workspace.update_in(cx, |mw, window, cx| {
+            mw.test_add_workspace(project1, window, cx);
+        });
+
+        let project2 =
+            project::Project::test(fs.clone(), [Path::new("/bravo-feature")], cx).await;
+        multi_workspace.update_in(cx, |mw, window, cx| {
+            mw.test_add_workspace(project2, window, cx);
+        });
+
+        let project3 =
+            project::Project::test(fs.clone(), [Path::new("/charlie")], cx).await;
+        multi_workspace.update_in(cx, |mw, window, cx| {
+            mw.test_add_workspace(project3, window, cx);
+        });
+
+        cx.run_until_parked();
+        sidebar.update_in(cx, |s, window, cx| {
+            s.update_entries(window, cx);
+        });
+        cx.run_until_parked();
+
+        // Precondition: display_order = [1, 0, 2, 3]
+        let display_order = multi_workspace.read_with(cx, |mw, _| mw.display_order().to_vec());
+        assert_eq!(display_order, vec![1, 0, 2, 3]);
+
+        // Remove workspace 0 (bravo/main), which sits in the middle of the
+        // display order. After removal the workspace list becomes:
+        //   0: alpha (was 1), 1: bravo/feature (was 2), 2: charlie (was 3)
+        // display_order should drop the removed index and shift the rest:
+        //   [1, 0, 2, 3] → retain(!= 0) → [1, 2, 3] → decrement(> 0) → [0, 1, 2]
+        multi_workspace.update_in(cx, |mw, window, cx| {
+            mw.remove_workspace(0, window, cx);
+        });
+        cx.run_until_parked();
+
+        let display_order = multi_workspace.read_with(cx, |mw, _| mw.display_order().to_vec());
+        assert_eq!(
+            display_order,
+            vec![0, 1, 2],
+            "display_order should be adjusted after removing workspace 0"
+        );
+
+        // Cycling should follow the adjusted order: alpha(0) → bravo/feature(1) → charlie(2)
+        multi_workspace.update_in(cx, |mw, window, cx| {
+            mw.activate_index(0, window, cx);
+        });
+        multi_workspace.update_in(cx, |mw, window, cx| {
+            mw.activate_next_workspace(window, cx);
+        });
+        let active = multi_workspace.read_with(cx, |mw, _| mw.active_workspace_index());
+        assert_eq!(active, 1, "next from alpha(0) should be bravo/feature(1)");
+
+        multi_workspace.update_in(cx, |mw, window, cx| {
+            mw.activate_next_workspace(window, cx);
+        });
+        let active = multi_workspace.read_with(cx, |mw, _| mw.active_workspace_index());
+        assert_eq!(active, 2, "next from bravo/feature(1) should be charlie(2)");
+
+        // Wrap around: next from charlie(2) should go to alpha(0)
+        multi_workspace.update_in(cx, |mw, window, cx| {
+            mw.activate_next_workspace(window, cx);
+        });
+        let active = multi_workspace.read_with(cx, |mw, _| mw.active_workspace_index());
+        assert_eq!(active, 0, "next from charlie(2) should wrap to alpha(0)");
     }
 }

--- a/crates/workspace/src/multi_workspace.rs
+++ b/crates/workspace/src/multi_workspace.rs
@@ -100,6 +100,9 @@ pub struct MultiWorkspace {
     window_id: WindowId,
     workspaces: Vec<Entity<Workspace>>,
     active_workspace_index: usize,
+    /// Sidebar-sorted workspace indices for next/previous cycling.
+    /// When set, next/previous workspace follows this order instead of insertion order.
+    display_order: Vec<usize>,
     sidebar: Option<Box<dyn SidebarHandle>>,
     sidebar_open: bool,
     _sidebar_subscription: Option<Subscription>,
@@ -134,6 +137,7 @@ impl MultiWorkspace {
             window_id: window.window_handle().window_id(),
             workspaces: vec![workspace],
             active_workspace_index: 0,
+            display_order: vec![0],
             sidebar: None,
             sidebar_open: false,
             _sidebar_subscription: None,
@@ -339,8 +343,10 @@ impl MultiWorkspace {
             }
             Self::subscribe_to_workspace(&workspace, cx);
             self.workspaces.push(workspace);
+            let new_index = self.workspaces.len() - 1;
+            self.display_order.push(new_index);
             cx.notify();
-            self.workspaces.len() - 1
+            new_index
         }
     }
 
@@ -355,21 +361,43 @@ impl MultiWorkspace {
         cx.notify();
     }
 
+    pub fn set_display_order(&mut self, order: Vec<usize>) {
+        self.display_order = order;
+    }
+
+    pub fn display_order(&self) -> &[usize] {
+        &self.display_order
+    }
+
     pub fn activate_next_workspace(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         if self.workspaces.len() > 1 {
-            let next_index = (self.active_workspace_index + 1) % self.workspaces.len();
-            self.activate_index(next_index, window, cx);
+            let order = self.effective_display_order();
+            let pos = order.iter()
+                .position(|&i| i == self.active_workspace_index)
+                .unwrap_or(0);
+            let next_pos = (pos + 1) % order.len();
+            self.activate_index(order[next_pos], window, cx);
         }
     }
 
     pub fn activate_previous_workspace(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         if self.workspaces.len() > 1 {
-            let prev_index = if self.active_workspace_index == 0 {
-                self.workspaces.len() - 1
-            } else {
-                self.active_workspace_index - 1
-            };
-            self.activate_index(prev_index, window, cx);
+            let order = self.effective_display_order();
+            let pos = order.iter()
+                .position(|&i| i == self.active_workspace_index)
+                .unwrap_or(0);
+            let prev_pos = if pos == 0 { order.len() - 1 } else { pos - 1 };
+            self.activate_index(order[prev_pos], window, cx);
+        }
+    }
+
+    fn effective_display_order(&self) -> Vec<usize> {
+        if self.display_order.len() == self.workspaces.len()
+            && self.display_order.iter().all(|&i| i < self.workspaces.len())
+        {
+            self.display_order.clone()
+        } else {
+            (0..self.workspaces.len()).collect()
         }
     }
 
@@ -613,6 +641,14 @@ impl MultiWorkspace {
         }
 
         let removed_workspace = self.workspaces.remove(index);
+
+        // Update display_order: remove the index and adjust remaining indices
+        self.display_order.retain(|&i| i != index);
+        for i in self.display_order.iter_mut() {
+            if *i > index {
+                *i -= 1;
+            }
+        }
 
         if self.active_workspace_index >= self.workspaces.len() {
             self.active_workspace_index = self.workspaces.len() - 1;

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -667,6 +667,26 @@ impl Worktree {
         }
     }
 
+    /// Returns true if the given relative path within this worktree is a git
+    /// repository root. Checks the indexed git repositories map, then the
+    /// scanner's entry list. This is used to prevent git worktrees from being
+    /// claimed as subdirectories of their parent repository's workspace.
+    pub fn contains_git_repo_at(&self, relative_path: &RelPath) -> bool {
+        if let Some(local) = self.as_local() {
+            if local
+                .local_repo_for_work_directory_path(relative_path)
+                .is_some()
+            {
+                return true;
+            }
+        }
+        let Ok(dot_git) = RelPath::unix(DOT_GIT) else {
+            return false;
+        };
+        let dot_git_path = relative_path.join(dot_git);
+        self.entry_for_path(&dot_git_path).is_some()
+    }
+
     pub fn replica_id(&self) -> ReplicaId {
         match self {
             Worktree::Local(_) => ReplicaId::LOCAL,


### PR DESCRIPTION
sidebar: Improve git worktree support in multi-workspace

Consider a bare clone layout with three worktrees open:

```
~/projects/myrepo/.bare          (bare)
~/projects/myrepo/main           [main]
~/projects/myrepo/feature-x      [feature-x]
~/projects/myrepo/bugfix-y       [bugfix-y]
```

Or a traditional (non-bare) repo with linked worktrees:

```
~/code/myrepo/                   [main]        ← prime (.git is a directory)
~/code/myrepo/sub/feature-x/     [feature-x]   ← linked (.git is a file)
~/code/worktrees/bugfix-y/       [bugfix-y]    ← linked, outside the repo tree
```

Plus an unrelated repo `~/projects/alpha` on branch `main`.

**Before:** The sidebar shows `main`, `feature-x`, `bugfix-y`, `alpha` — just directory names, in whatever order they were opened. Cycling with `cmd-opt-j/k` jumps between them in that arbitrary order. Creating a new worktree from a bare clone workspace places it in `../worktrees/` rather than alongside the existing worktrees.

**After:** The sidebar shows `alpha / main`, `myrepo / main`, `myrepo / feature-x`, `myrepo / bugfix-y` — grouped by repository, prime worktree first, then alphabetical. Cycling follows this visual order so the three myrepo worktrees are contiguous. Creating a new worktree from a bare clone workspace places it alongside the existing worktrees.

#### Labels

Labels are derived from `original_repo_abs_path` and the current branch name, displayed as `"repo / branch"`. The sidebar subscribes to `RepositoryAdded` and `BranchChanged` events so labels update reactively as git info resolves, rather than waiting for user interaction.

#### Grouping and cycling

Related worktrees are sorted together by `original_repo_abs_path`. Within a group the prime worktree (where `.git` is a directory) sorts first, then alphabetically by label. Next/previous workspace cycling (`cmd-opt-j/k`) follows this sidebar sort order via a `display_order` indirection on `MultiWorkspace`, instead of using insertion order.

#### Worktree directory auto-detection

The `git.worktree_directory` setting is now optional. When unset, bare clone layouts are auto-detected: if `original_repo_abs_path` differs from `work_directory_abs_path`, the work directory is used directly as the base for new worktrees (placing them as siblings). Normal repos fall back to the existing `"../worktrees"` default. Explicit settings still override auto-detection. The resolution logic lives in `resolve_worktree_directory_for_repo` in `repository.rs`, shared by both the worktree picker and the agent panel.

**Note:** #49139 describes adding a separate `agent_worktree_directory` setting for agent worktree creation, but the code uses the shared `git.worktree_directory` for both human and agent paths. A follow-up could introduce the dedicated agent setting to decouple the two — the agent path could keep a concrete default while the human path benefits from `Option`-based auto-detection.

#### Worktree subdirectory ownership

Worktree subdirectories that are themselves git repository roots (e.g. a linked worktree nested inside a parent repo) are no longer claimed by the parent workspace. `contains_git_repo_at` checks the indexed git repos and scanner entries to detect them.

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Improved sidebar labels for git worktrees to show `"repo / branch"` format
- Added grouping of related worktrees in the sidebar with sorted cycling
- Fixed `git.worktree_directory` to auto-detect bare clone layouts when unset
- Fixed worktree subdirectories being claimed by the parent workspace