### PR TITLE
workspace: Add detachable panel windows with WorkspaceSatellite

### DIFF
--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -48,7 +48,7 @@ actions!(
         /// Toggles the terminal panel.
         Toggle,
         /// Toggles focus on the terminal panel.
-        ToggleFocus
+        ToggleFocus,
     ]
 );
 
@@ -105,6 +105,7 @@ impl TerminalPanel {
             active: false,
         };
         terminal_panel.apply_tab_bar_buttons(&terminal_panel.active_pane, cx);
+
         terminal_panel
     }
 
@@ -2364,5 +2365,371 @@ mod tests {
             editor::init(cx);
             crate::init(cx);
         });
+    }
+
+    #[gpui::test]
+    async fn test_terminal_panel_initialization(cx: &mut TestAppContext) {
+        cx.executor().allow_parking();
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let window_handle =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project, window, cx));
+
+        let terminal_panel = window_handle
+            .update(cx, |multi_workspace, window, cx| {
+                multi_workspace.workspace().update(cx, |workspace, cx| {
+                    cx.new(|cx| TerminalPanel::new(workspace, window, cx))
+                })
+            })
+            .unwrap();
+
+        // Add a terminal
+        window_handle
+            .update(cx, |_, window, cx| {
+                terminal_panel.update(cx, |panel, cx| {
+                    panel.add_local_terminal_shell(RevealStrategy::Always, window, cx)
+                })
+            })
+            .unwrap()
+            .await
+            .log_err();
+
+        // Verify one terminal in pane
+        window_handle
+            .update(cx, |_, _, cx| {
+                terminal_panel.update(cx, |panel, cx| {
+                    assert_eq!(panel.active_pane.read(cx).items().count(), 1);
+                });
+            })
+            .unwrap();
+    }
+
+    #[gpui::test]
+    async fn test_multiple_terminals_in_pane(cx: &mut TestAppContext) {
+        cx.executor().allow_parking();
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let window_handle =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project, window, cx));
+
+        let terminal_panel = window_handle
+            .update(cx, |multi_workspace, window, cx| {
+                multi_workspace.workspace().update(cx, |workspace, cx| {
+                    cx.new(|cx| TerminalPanel::new(workspace, window, cx))
+                })
+            })
+            .unwrap();
+
+        // Add two terminals
+        window_handle
+            .update(cx, |_, window, cx| {
+                terminal_panel.update(cx, |panel, cx| {
+                    panel.add_local_terminal_shell(RevealStrategy::Always, window, cx)
+                })
+            })
+            .unwrap()
+            .await
+            .log_err();
+
+        window_handle
+            .update(cx, |_, window, cx| {
+                terminal_panel.update(cx, |panel, cx| {
+                    panel.add_local_terminal_shell(RevealStrategy::Always, window, cx)
+                })
+            })
+            .unwrap()
+            .await
+            .log_err();
+
+        // Verify both terminals exist and active item is a TerminalView
+        window_handle
+            .update(cx, |_, _, cx| {
+                terminal_panel.update(cx, |panel, cx| {
+                    let pane = panel.active_pane.read(cx);
+                    assert_eq!(pane.items().count(), 2);
+                    assert!(
+                        pane.active_item()
+                            .and_then(|item| item.downcast::<TerminalView>())
+                            .is_some(),
+                        "Active item should be a TerminalView"
+                    );
+                });
+            })
+            .unwrap();
+    }
+
+    #[gpui::test]
+    async fn test_detach_removes_terminal_from_pane(cx: &mut TestAppContext) {
+        cx.executor().allow_parking();
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let window_handle =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project, window, cx));
+
+        let terminal_panel = window_handle
+            .update(cx, |multi_workspace, window, cx| {
+                multi_workspace.workspace().update(cx, |workspace, cx| {
+                    cx.new(|cx| TerminalPanel::new(workspace, window, cx))
+                })
+            })
+            .unwrap();
+
+        // Add two terminals
+        window_handle
+            .update(cx, |_, window, cx| {
+                terminal_panel.update(cx, |panel, cx| {
+                    panel.add_local_terminal_shell(RevealStrategy::Always, window, cx)
+                })
+            })
+            .unwrap()
+            .await
+            .log_err();
+
+        window_handle
+            .update(cx, |_, window, cx| {
+                terminal_panel.update(cx, |panel, cx| {
+                    panel.add_local_terminal_shell(RevealStrategy::Always, window, cx)
+                })
+            })
+            .unwrap()
+            .await
+            .log_err();
+
+        // Grab the active terminal view before detaching
+        let terminal_view = window_handle
+            .update(cx, |_, _, cx| {
+                terminal_panel.update(cx, |panel, cx| {
+                    panel
+                        .active_pane
+                        .read(cx)
+                        .active_item()
+                        .and_then(|item| item.downcast::<TerminalView>())
+                        .expect("Should have an active TerminalView")
+                })
+            })
+            .unwrap();
+
+        let terminal_view_id = terminal_view.entity_id();
+
+        // Simulate detaching: remove the item from the pane
+        window_handle
+            .update(cx, |_, window, cx| {
+                terminal_panel.update(cx, |panel, cx| {
+                    panel.active_pane.update(cx, |pane, cx| {
+                        pane.remove_item(terminal_view_id, false, false, window, cx);
+                    });
+                });
+            })
+            .unwrap();
+
+        // Verify the terminal was removed — pane should have 1 item now
+        window_handle
+            .update(cx, |_, _, cx| {
+                terminal_panel.update(cx, |panel, cx| {
+                    assert_eq!(
+                        panel.active_pane.read(cx).items().count(),
+                        1,
+                        "Pane should have one terminal after detaching the other"
+                    );
+                });
+            })
+            .unwrap();
+
+        // Verify the removed terminal view entity is still alive (not dropped)
+        cx.read(|cx| {
+            assert!(
+                terminal_view
+                    .read(cx)
+                    .terminal()
+                    .read(cx)
+                    .title(false)
+                    .len()
+                    > 0,
+                "Detached terminal entity should still be alive and readable"
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_detach_last_terminal_empties_pane(cx: &mut TestAppContext) {
+        cx.executor().allow_parking();
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let window_handle =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project, window, cx));
+
+        let terminal_panel = window_handle
+            .update(cx, |multi_workspace, window, cx| {
+                multi_workspace.workspace().update(cx, |workspace, cx| {
+                    cx.new(|cx| TerminalPanel::new(workspace, window, cx))
+                })
+            })
+            .unwrap();
+
+        // Add one terminal
+        window_handle
+            .update(cx, |_, window, cx| {
+                terminal_panel.update(cx, |panel, cx| {
+                    panel.add_local_terminal_shell(RevealStrategy::Always, window, cx)
+                })
+            })
+            .unwrap()
+            .await
+            .log_err();
+
+        let terminal_view_id = window_handle
+            .update(cx, |_, _, cx| {
+                terminal_panel.update(cx, |panel, cx| {
+                    panel
+                        .active_pane
+                        .read(cx)
+                        .active_item()
+                        .expect("Should have an active item")
+                        .item_id()
+                })
+            })
+            .unwrap();
+
+        // Remove the only terminal (simulates detach)
+        window_handle
+            .update(cx, |_, window, cx| {
+                terminal_panel.update(cx, |panel, cx| {
+                    panel.active_pane.update(cx, |pane, cx| {
+                        pane.remove_item(terminal_view_id, false, false, window, cx);
+                    });
+                });
+            })
+            .unwrap();
+
+        // Verify pane is empty — this is the condition that triggers dock auto-hide
+        window_handle
+            .update(cx, |_, _, cx| {
+                terminal_panel.update(cx, |panel, cx| {
+                    assert_eq!(
+                        panel.active_pane.read(cx).items().count(),
+                        0,
+                        "Pane should be empty after detaching the last terminal"
+                    );
+                    assert!(
+                        panel
+                            .center
+                            .panes()
+                            .iter()
+                            .all(|pane| pane.read(cx).items().count() == 0),
+                        "All panes should be empty — triggers dock auto-hide on detach"
+                    );
+                });
+            })
+            .unwrap();
+    }
+
+    #[gpui::test]
+    async fn test_reattach_adds_terminal_back_to_pane(cx: &mut TestAppContext) {
+        cx.executor().allow_parking();
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let window_handle =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project, window, cx));
+
+        let terminal_panel = window_handle
+            .update(cx, |multi_workspace, window, cx| {
+                multi_workspace.workspace().update(cx, |workspace, cx| {
+                    cx.new(|cx| TerminalPanel::new(workspace, window, cx))
+                })
+            })
+            .unwrap();
+
+        // Add a terminal
+        window_handle
+            .update(cx, |_, window, cx| {
+                terminal_panel.update(cx, |panel, cx| {
+                    panel.add_local_terminal_shell(RevealStrategy::Always, window, cx)
+                })
+            })
+            .unwrap()
+            .await
+            .log_err();
+
+        // Grab the terminal view
+        let terminal_view = window_handle
+            .update(cx, |_, _, cx| {
+                terminal_panel.update(cx, |panel, cx| {
+                    panel
+                        .active_pane
+                        .read(cx)
+                        .active_item()
+                        .and_then(|item| item.downcast::<TerminalView>())
+                        .expect("Should have an active TerminalView")
+                })
+            })
+            .unwrap();
+
+        let terminal_view_id = terminal_view.entity_id();
+
+        // Remove from pane (simulates detach)
+        window_handle
+            .update(cx, |_, window, cx| {
+                terminal_panel.update(cx, |panel, cx| {
+                    panel.active_pane.update(cx, |pane, cx| {
+                        pane.remove_item(terminal_view_id, false, false, window, cx);
+                    });
+                });
+            })
+            .unwrap();
+
+        assert_eq!(
+            window_handle
+                .update(cx, |_, _, cx| {
+                    terminal_panel
+                        .update(cx, |panel, cx| panel.active_pane.read(cx).items().count())
+                })
+                .unwrap(),
+            0,
+            "Pane should be empty after removal"
+        );
+
+        // Simulate reattach: add the terminal view back to the pane
+        window_handle
+            .update(cx, |_, window, cx| {
+                terminal_panel.update(cx, |panel, cx| {
+                    panel.active_pane.update(cx, |pane, cx| {
+                        pane.add_item(
+                            Box::new(terminal_view.clone()),
+                            true,
+                            true,
+                            None,
+                            window,
+                            cx,
+                        );
+                    });
+                });
+            })
+            .unwrap();
+
+        // Verify terminal is back in the pane
+        window_handle
+            .update(cx, |_, _, cx| {
+                terminal_panel.update(cx, |panel, cx| {
+                    let pane = panel.active_pane.read(cx);
+                    assert_eq!(pane.items().count(), 1, "Terminal should be back in pane");
+                    assert!(
+                        pane.active_item()
+                            .and_then(|item| item.downcast::<TerminalView>())
+                            .is_some(),
+                        "Reattached item should be a TerminalView"
+                    );
+                });
+            })
+            .unwrap();
     }
 }

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -1596,12 +1596,16 @@ impl Item for TerminalView {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Vec<(SharedString, Box<dyn gpui::Action>)> {
+        let mut actions: Vec<(SharedString, Box<dyn gpui::Action>)> = Vec::new();
         let terminal = self.terminal.read(cx);
         if terminal.task().is_none() {
-            vec![("Rename".into(), Box::new(RenameTerminal))]
-        } else {
-            Vec::new()
+            actions.push(("Rename".into(), Box::new(RenameTerminal)));
         }
+        actions.push((
+            "Detach Terminal".into(),
+            Box::new(workspace::DetachActiveItem),
+        ));
+        actions
     }
 
     fn buffer_kind(&self, _: &App) -> workspace::item::ItemBufferKind {

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -453,6 +453,7 @@ pub struct Pane {
     welcome_page: Option<Entity<crate::welcome::WelcomePage>>,
 
     pub in_center_group: bool,
+    pub in_satellite: bool,
 }
 
 pub struct ActivationHistoryEntry {
@@ -624,6 +625,7 @@ impl Pane {
             project_item_restoration_data: HashMap::default(),
             welcome_page: None,
             in_center_group: false,
+            in_satellite: false,
         }
     }
 
@@ -3067,6 +3069,7 @@ impl Pane {
         let is_pinned = self.is_tab_pinned(ix);
 
         let pane = cx.entity().downgrade();
+        let in_satellite = self.in_satellite;
         let menu_context = item.item_focus_handle(cx);
         let item_handle = item.boxed_clone();
 
@@ -3362,12 +3365,31 @@ impl Pane {
                         }
                     };
 
-                    // Add custom item-specific actions
+                    // Add custom item-specific actions, filtering out detach when already in satellite
+                    let extra_actions: Vec<_> = if in_satellite {
+                        extra_actions
+                            .into_iter()
+                            .filter(|(_, action)| {
+                                action
+                                    .as_any()
+                                    .downcast_ref::<super::DetachActiveItem>()
+                                    .is_none()
+                            })
+                            .collect()
+                    } else {
+                        extra_actions
+                    };
                     if !extra_actions.is_empty() {
                         menu = menu.separator();
                         for (label, action) in extra_actions {
                             menu = menu.action(label, action);
                         }
+                    }
+
+                    if in_satellite {
+                        menu = menu
+                            .separator()
+                            .action("Move to Main Window", Box::new(super::ReattachActiveItem));
                     }
 
                     menu.context(menu_context)
@@ -4181,6 +4203,9 @@ fn default_render_tab_bar_buttons(
     cx: &mut Context<Pane>,
 ) -> (Option<AnyElement>, Option<AnyElement>) {
     if !pane.has_focus(window, cx) && !pane.context_menu_focused(window, cx) {
+        return (None, None);
+    }
+    if pane.in_satellite {
         return (None, None);
     }
     let (can_clone, can_split_move) = match pane.active_item() {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -26,6 +26,7 @@ mod theme_preview;
 mod toast_layer;
 mod toolbar;
 pub mod welcome;
+pub mod workspace_satellite;
 mod workspace_settings;
 
 pub use crate::notifications::NotificationFrame;
@@ -348,6 +349,10 @@ actions!(
         RestoreBanner,
         /// Toggles expansion of the selected item.
         ToggleExpandItem,
+        /// Detaches the active item into a separate window.
+        DetachActiveItem,
+        /// Reattaches an item from a satellite window back to the main window.
+        ReattachActiveItem,
     ]
 );
 
@@ -1351,6 +1356,7 @@ pub struct Workspace {
     bottom_dock: Entity<Dock>,
     right_dock: Entity<Dock>,
     panes: Vec<Entity<Pane>>,
+    satellites: Vec<gpui::WindowHandle<workspace_satellite::WorkspaceSatellite>>,
     panes_by_item: HashMap<EntityId, WeakEntity<Pane>>,
     active_pane: Entity<Pane>,
     last_active_center_pane: Option<WeakEntity<Pane>>,
@@ -1777,6 +1783,7 @@ impl Workspace {
             previous_dock_drag_coordinates: None,
             center,
             panes: vec![center_pane.clone()],
+            satellites: Default::default(),
             panes_by_item: Default::default(),
             active_pane: center_pane.clone(),
             last_active_center_pane: Some(center_pane.downgrade()),
@@ -4401,8 +4408,8 @@ impl Workspace {
         cx.notify();
     }
 
-    fn add_pane(&mut self, window: &mut Window, cx: &mut Context<Self>) -> Entity<Pane> {
-        let pane = cx.new(|cx| {
+    fn create_pane(&mut self, window: &mut Window, cx: &mut App) -> Entity<Pane> {
+        cx.new(|cx| {
             let mut pane = Pane::new(
                 self.weak_handle(),
                 self.project.clone(),
@@ -4415,15 +4422,273 @@ impl Workspace {
             );
             pane.set_can_split(Some(Arc::new(|_, _, _, _| true)));
             pane
-        });
+        })
+    }
+
+    fn register_pane(&mut self, pane: Entity<Pane>, window: &mut Window, cx: &mut Context<Self>) {
         cx.subscribe_in(&pane, window, Self::handle_pane_event)
             .detach();
         self.panes.push(pane.clone());
-
         window.focus(&pane.focus_handle(cx), cx);
+        cx.emit(Event::PaneAdded(pane));
+    }
 
-        cx.emit(Event::PaneAdded(pane.clone()));
+    fn add_pane(&mut self, window: &mut Window, cx: &mut Context<Self>) -> Entity<Pane> {
+        let pane = self.create_pane(window, cx);
+        self.register_pane(pane.clone(), window, cx);
         pane
+    }
+
+    pub fn create_satellite(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> anyhow::Result<WindowHandle<workspace_satellite::WorkspaceSatellite>> {
+        let pane = self.create_pane(window, cx);
+
+        let current_bounds = window.bounds();
+        let new_bounds = Bounds {
+            origin: current_bounds.origin,
+            size: Size {
+                width: gpui::px(800.0),
+                height: gpui::px(600.0),
+            },
+        };
+
+        let workspace_handle = self.weak_handle();
+        let window_background = cx.theme().window_background_appearance();
+        let current_display_id = window.display(cx).map(|d| d.id());
+        let satellite_handle = cx.open_window(
+            WindowOptions {
+                titlebar: Some(gpui::TitlebarOptions {
+                    title: None,
+                    appears_transparent: true,
+                    traffic_light_position: Some(gpui::point(gpui::px(9.0), gpui::px(9.0))),
+                }),
+                window_bounds: Some(WindowBounds::Windowed(new_bounds)),
+                window_background,
+                window_decorations: Some(gpui::WindowDecorations::Client),
+                display_id: current_display_id,
+                ..Default::default()
+            },
+            {
+                let pane = pane.clone();
+                move |window, cx| {
+                    cx.new(|cx| {
+                        workspace_satellite::WorkspaceSatellite::new(
+                            pane,
+                            workspace_handle,
+                            window,
+                            cx,
+                        )
+                    })
+                }
+            },
+        )?;
+
+        cx.subscribe_in(
+            &satellite_handle.entity(cx)?,
+            window,
+            Self::handle_satellite_event,
+        )
+        .detach();
+
+        self.satellites.push(satellite_handle);
+        self.panes.push(pane);
+
+        Ok(satellite_handle)
+    }
+
+    pub fn detach_item(
+        &mut self,
+        item_id: EntityId,
+        origin: workspace_satellite::ItemOrigin,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> anyhow::Result<WindowHandle<workspace_satellite::WorkspaceSatellite>> {
+        let source_pane = self
+            .panes_by_item
+            .get(&item_id)
+            .and_then(|weak| weak.upgrade())
+            .ok_or_else(|| anyhow::anyhow!("Item not found in any pane"))?;
+
+        let satellite = self.create_satellite(window, cx)?;
+
+        satellite.update(cx, |satellite, window, cx| {
+            let dest_pane = satellite.root();
+            satellite.record_item_origin(item_id, origin);
+            move_item(&source_pane, &dest_pane, item_id, 0, true, window, cx);
+        })?;
+
+        cx.notify();
+        Ok(satellite)
+    }
+
+    pub fn detach_active_item(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> anyhow::Result<WindowHandle<workspace_satellite::WorkspaceSatellite>> {
+        let focused_pane = self.focused_pane(window, cx);
+        let active_item = focused_pane
+            .read(cx)
+            .active_item()
+            .ok_or_else(|| anyhow::anyhow!("No active item to detach"))?;
+
+        let item_id = active_item.item_id();
+
+        let origin = self.item_origin_for_pane(item_id, cx);
+
+        self.detach_item(item_id, origin, window, cx)
+    }
+
+    fn item_origin_for_pane(&self, item_id: EntityId, cx: &App) -> workspace_satellite::ItemOrigin {
+        let source_pane = self
+            .panes_by_item
+            .get(&item_id)
+            .and_then(|weak| weak.upgrade());
+
+        if let Some(source_pane) = source_pane {
+            if source_pane.read(cx).in_center_group {
+                return workspace_satellite::ItemOrigin::CenterPane;
+            }
+
+            // Check each dock for a panel that owns this pane
+            for dock in [&self.left_dock, &self.bottom_dock, &self.right_dock] {
+                if let Some(panel) = dock.read(cx).active_panel() {
+                    if let Some(pane) = panel.pane(cx) {
+                        if pane.entity_id() == source_pane.entity_id() {
+                            return workspace_satellite::ItemOrigin::DockPanel {
+                                panel_id: panel.panel_id(),
+                            };
+                        }
+                    }
+                }
+            }
+        }
+
+        workspace_satellite::ItemOrigin::CenterPane
+    }
+
+    pub fn reattach_item_from_satellite(
+        &mut self,
+        satellite_handle: WindowHandle<workspace_satellite::WorkspaceSatellite>,
+        item_id: EntityId,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> anyhow::Result<()> {
+        let origin =
+            satellite_handle.update(cx, |satellite, _, _| satellite.take_item_origin(item_id))?;
+
+        let source_pane = satellite_handle.read_with(cx, |satellite, _| satellite.root())?;
+
+        let dest_pane = match origin {
+            Some(workspace_satellite::ItemOrigin::DockPanel { panel_id }) => self
+                .find_dock_panel_pane(panel_id, cx)
+                .unwrap_or_else(|| self.active_pane.clone()),
+            _ => self
+                .last_active_center_pane
+                .as_ref()
+                .and_then(|weak| weak.upgrade())
+                .unwrap_or_else(|| self.active_pane.clone()),
+        };
+
+        move_item(&source_pane, &dest_pane, item_id, 0, true, window, cx);
+
+        cx.notify();
+        Ok(())
+    }
+
+    pub fn reattach_destination(
+        &self,
+        origin: Option<&workspace_satellite::ItemOrigin>,
+        cx: &App,
+    ) -> Entity<Pane> {
+        match origin {
+            Some(workspace_satellite::ItemOrigin::DockPanel { panel_id }) => self
+                .find_dock_panel_pane(*panel_id, cx)
+                .unwrap_or_else(|| self.active_pane.clone()),
+            _ => self
+                .last_active_center_pane
+                .as_ref()
+                .and_then(|weak| weak.upgrade())
+                .unwrap_or_else(|| self.active_pane.clone()),
+        }
+    }
+
+    fn find_dock_panel_pane(&self, panel_id: EntityId, cx: &App) -> Option<Entity<Pane>> {
+        for dock in [&self.left_dock, &self.bottom_dock, &self.right_dock] {
+            if let Some(panel) = dock.read(cx).panel_for_id(panel_id) {
+                return panel.pane(cx);
+            }
+        }
+        None
+    }
+
+    fn handle_satellite_event(
+        &mut self,
+        satellite: &Entity<workspace_satellite::WorkspaceSatellite>,
+        event: &workspace_satellite::Event,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        match event {
+            workspace_satellite::Event::ReattachRequested { item_id, origin } => {
+                let source_pane = satellite.read(cx).root();
+                let dest_pane = self.reattach_destination(origin.as_ref(), cx);
+
+                move_item(&source_pane, &dest_pane, *item_id, 0, true, window, cx);
+
+                // Reopen the dock panel so the reattached item is visible
+                if let Some(workspace_satellite::ItemOrigin::DockPanel { panel_id }) = origin {
+                    for dock in [&self.left_dock, &self.bottom_dock, &self.right_dock] {
+                        if dock.read(cx).panel_for_id(*panel_id).is_some() {
+                            dock.update(cx, |dock, cx| {
+                                dock.set_open(true, window, cx);
+                            });
+                            break;
+                        }
+                    }
+                }
+
+                // If satellite pane is now empty, clean up and close
+                if source_pane.read(cx).items().count() == 0 {
+                    self.panes.retain(|p| p != &source_pane);
+                    let satellite_id = satellite.entity_id();
+                    self.satellites.retain(|s| {
+                        s.entity(cx)
+                            .map_or(false, |e| e.entity_id() != satellite_id)
+                    });
+                }
+
+                cx.notify();
+            }
+            workspace_satellite::Event::Closing => {
+                let root = satellite.read(cx).root();
+
+                // Clean up panes_by_item for any items still in the satellite pane
+                for item in root.read(cx).items() {
+                    if let std::collections::hash_map::Entry::Occupied(entry) =
+                        self.panes_by_item.entry(item.item_id())
+                    {
+                        if entry.get().entity_id() == root.entity_id() {
+                            entry.remove();
+                        }
+                    }
+                }
+
+                // Remove the satellite pane from workspace tracking
+                self.panes.retain(|p| p != &root);
+
+                let satellite_id = satellite.entity_id();
+                self.satellites.retain(|s| {
+                    s.entity(cx)
+                        .map_or(false, |e| e.entity_id() != satellite_id)
+                });
+
+                cx.notify();
+            }
+        }
     }
 
     pub fn add_item_to_center(
@@ -7183,6 +7448,9 @@ impl Workspace {
             }))
             .on_action(cx.listener(|workspace, _: &MovePaneDown, _, cx| {
                 workspace.move_pane_to_border(SplitDirection::Down, cx)
+            }))
+            .on_action(cx.listener(|workspace, _: &DetachActiveItem, window, cx| {
+                workspace.detach_active_item(window, cx).log_err();
             }))
             .on_action(cx.listener(|this, _: &ToggleLeftDock, window, cx| {
                 this.toggle_dock(DockPosition::Left, window, cx);
@@ -15496,7 +15764,6 @@ mod tests {
         let (workspace, cx) =
             cx.add_window_view(|window, cx| Workspace::test_new(project, window, cx));
 
-        // Add two panels to the left dock and open it.
         let (panel_a, panel_b) = workspace.update_in(cx, |workspace, window, cx| {
             let panel_a = cx.new(|cx| TestPanel::new(DockPosition::Left, 100, cx));
             let panel_b = cx.new(|cx| TestPanel::new(DockPosition::Left, 101, cx));
@@ -15513,22 +15780,17 @@ mod tests {
             assert!(workspace.left_dock().read(cx).is_open());
         });
 
-        // Simulate a feature flag changing default dock positions: both panels
-        // move from Left to Right.
         workspace.update_in(cx, |_workspace, _window, cx| {
             panel_a.update(cx, |p, _cx| p.position = DockPosition::Right);
             panel_b.update(cx, |p, _cx| p.position = DockPosition::Right);
             cx.update_global::<SettingsStore, _>(|_, _| {});
         });
 
-        // Both panels should now be in the right dock.
         workspace.update_in(cx, |workspace, _, cx| {
             let right_dock = workspace.right_dock().read(cx);
             assert_eq!(right_dock.panels_len(), 2);
         });
 
-        // Open the right dock and activate panel_b (simulating the user
-        // opening the panel after it moved).
         workspace.update_in(cx, |workspace, window, cx| {
             workspace.right_dock().update(cx, |dock, cx| {
                 dock.set_open(true, window, cx);
@@ -15536,7 +15798,6 @@ mod tests {
             });
         });
 
-        // Now trigger another SettingsStore change
         workspace.update_in(cx, |_workspace, _window, cx| {
             cx.update_global::<SettingsStore, _>(|_, _| {});
         });
@@ -15550,6 +15811,144 @@ mod tests {
                 workspace.right_dock().read(cx).panels_len(),
                 2,
                 "Both panels should still be in the right dock"
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn test_detach_active_item_creates_satellite(cx: &mut gpui::TestAppContext) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
+
+        let item = cx.new(|cx| {
+            let mut item = TestItem::new(cx);
+            item.project_items
+                .push(TestProjectItem::new(1, "one.txt", cx));
+            item
+        });
+        let item_id = item.entity_id();
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.add_item_to_active_pane(Box::new(item.clone()), None, true, window, cx);
+        });
+
+        let initial_pane_count = workspace.read_with(cx, |ws, _| ws.panes.len());
+        assert_eq!(initial_pane_count, 1);
+
+        let satellite = workspace
+            .update_in(cx, |workspace, window, cx| {
+                workspace.detach_active_item(window, cx)
+            })
+            .unwrap();
+
+        workspace.update_in(cx, |workspace, _, cx| {
+            assert_eq!(workspace.satellites.len(), 1);
+            assert_eq!(workspace.panes.len(), 2);
+            assert_eq!(workspace.active_pane().read(cx).items().count(), 0);
+        });
+
+        satellite
+            .update(cx, |satellite, _, cx| {
+                let root_pane = satellite.root();
+                assert_eq!(root_pane.read(cx).items().count(), 1);
+                let satellite_item = root_pane.read(cx).active_item().unwrap();
+                assert_eq!(satellite_item.item_id(), item_id);
+            })
+            .unwrap();
+    }
+
+    #[gpui::test]
+    async fn test_reattach_returns_item_to_center_pane(cx: &mut gpui::TestAppContext) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
+
+        let item = cx.new(|cx| {
+            let mut item = TestItem::new(cx);
+            item.project_items
+                .push(TestProjectItem::new(1, "one.txt", cx));
+            item
+        });
+        let item_id = item.entity_id();
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.add_item_to_active_pane(Box::new(item.clone()), None, true, window, cx);
+        });
+
+        let satellite = workspace
+            .update_in(cx, |workspace, window, cx| {
+                workspace.detach_active_item(window, cx)
+            })
+            .unwrap();
+
+        workspace
+            .update_in(cx, |workspace, window, cx| {
+                workspace.reattach_item_from_satellite(satellite, item_id, window, cx)
+            })
+            .unwrap();
+
+        workspace.update_in(cx, |workspace, _, cx| {
+            let center_pane = workspace.active_pane();
+            assert_eq!(center_pane.read(cx).items().count(), 1);
+            let reattached_item = center_pane.read(cx).active_item().unwrap();
+            assert_eq!(reattached_item.item_id(), item_id);
+        });
+    }
+
+    #[gpui::test]
+    async fn test_satellite_cleanup_on_close(cx: &mut gpui::TestAppContext) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
+
+        let item = cx.new(|cx| {
+            let mut item = TestItem::new(cx);
+            item.project_items
+                .push(TestProjectItem::new(1, "one.txt", cx));
+            item
+        });
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.add_item_to_active_pane(Box::new(item.clone()), None, true, window, cx);
+        });
+
+        workspace
+            .update_in(cx, |workspace, window, cx| {
+                workspace.detach_active_item(window, cx)
+            })
+            .unwrap();
+
+        workspace.update_in(cx, |workspace, _, _| {
+            assert_eq!(workspace.satellites.len(), 1);
+            assert_eq!(workspace.panes.len(), 2);
+        });
+
+        let satellite_entity = workspace.read_with(cx, |workspace, cx| {
+            workspace.satellites[0].entity(cx).unwrap()
+        });
+        satellite_entity.update_in(cx, |_, _, cx| {
+            cx.emit(workspace_satellite::Event::Closing);
+        });
+
+        cx.run_until_parked();
+
+        workspace.update_in(cx, |workspace, _, _| {
+            assert_eq!(
+                workspace.satellites.len(),
+                0,
+                "Satellite should be removed after closing"
+            );
+            assert_eq!(
+                workspace.panes.len(),
+                1,
+                "Only the center pane should remain"
             );
         });
     }
@@ -15575,7 +15974,6 @@ mod tests {
             project.worktrees(cx).next().unwrap().read(cx).id()
         });
 
-        // Configure .venv as read-only
         workspace.update_in(cx, |_workspace, _window, cx| {
             cx.update_global::<SettingsStore, _>(|store, cx| {
                 store
@@ -15593,11 +15991,65 @@ mod tests {
             )])
         });
 
-        // dep.py is active but matches read_only_files → should be skipped
         workspace.update_in(cx, |workspace, window, cx| {
             workspace.add_item_to_active_pane(Box::new(item_dep.clone()), None, true, window, cx);
         });
         let path = workspace.read_with(cx, |workspace, cx| workspace.most_recent_active_path(cx));
         assert_eq!(path, None);
+    }
+
+    #[gpui::test]
+    async fn test_satellite_does_not_steal_workspace_focus(cx: &mut gpui::TestAppContext) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.executor());
+        let project = Project::test(fs, [], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
+
+        let item1 = cx.new(|cx| {
+            let mut item = TestItem::new(cx);
+            item.project_items
+                .push(TestProjectItem::new(1, "one.txt", cx));
+            item
+        });
+        let item2 = cx.new(|cx| {
+            let mut item = TestItem::new(cx);
+            item.project_items
+                .push(TestProjectItem::new(2, "two.txt", cx));
+            item
+        });
+
+        workspace.update_in(cx, |workspace, window, cx| {
+            workspace.add_item_to_active_pane(Box::new(item1.clone()), None, true, window, cx);
+            workspace.add_item_to_active_pane(Box::new(item2.clone()), None, true, window, cx);
+        });
+
+        let center_pane = workspace.read_with(cx, |workspace, _| workspace.active_pane().clone());
+
+        workspace
+            .update_in(cx, |workspace, window, cx| {
+                workspace.detach_active_item(window, cx)
+            })
+            .unwrap();
+
+        workspace.read_with(cx, |workspace, _| {
+            assert_eq!(
+                workspace.active_pane().entity_id(),
+                center_pane.entity_id(),
+                "Active pane should remain the center pane after detaching"
+            );
+        });
+
+        workspace.read_with(cx, |workspace, _| {
+            let last_center = workspace
+                .last_active_center_pane
+                .as_ref()
+                .and_then(|w| w.upgrade());
+            assert_eq!(
+                last_center.unwrap().entity_id(),
+                center_pane.entity_id(),
+                "last_active_center_pane should not be changed by satellite"
+            );
+        });
     }
 }

--- a/crates/workspace/src/workspace_satellite.rs
+++ b/crates/workspace/src/workspace_satellite.rs
@@ -1,0 +1,172 @@
+use std::collections::HashMap;
+
+use gpui::{
+    AnyWeakView, App, Context, Entity, EntityId, EventEmitter, FocusHandle, Focusable, IntoElement,
+    ParentElement, Render, Styled, WeakEntity, Window,
+};
+use theme::ActiveTheme;
+use ui::prelude::*;
+
+use crate::{
+    Workspace, client_side_decorations,
+    pane::{self, Pane},
+    pane_group::{ActivePaneDecorator, PaneGroup},
+};
+
+pub enum ItemOrigin {
+    CenterPane,
+    DockPanel { panel_id: EntityId },
+}
+
+pub enum Event {
+    Closing,
+    ReattachRequested {
+        item_id: EntityId,
+        origin: Option<ItemOrigin>,
+    },
+}
+
+impl EventEmitter<Event> for WorkspaceSatellite {}
+
+pub struct WorkspaceSatellite {
+    pub(crate) center: PaneGroup,
+    workspace: WeakEntity<Workspace>,
+    focus_handle: FocusHandle,
+    item_origins: HashMap<EntityId, ItemOrigin>,
+}
+
+impl WorkspaceSatellite {
+    pub fn new(
+        pane: Entity<Pane>,
+        workspace: WeakEntity<Workspace>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let focus_handle = cx.focus_handle();
+
+        cx.subscribe_in(&pane, window, Self::handle_pane_event)
+            .detach();
+
+        pane.update(cx, |pane, _| {
+            pane.in_satellite = true;
+        });
+
+        let mut center = PaneGroup::new(pane);
+        center.set_is_center(false);
+        center.mark_positions(cx);
+
+        Self {
+            center,
+            workspace,
+            focus_handle,
+            item_origins: HashMap::default(),
+        }
+    }
+
+    pub fn root(&self) -> Entity<Pane> {
+        self.center.first_pane()
+    }
+
+    pub fn record_item_origin(&mut self, item_id: EntityId, origin: ItemOrigin) {
+        self.item_origins.insert(item_id, origin);
+    }
+
+    pub fn take_item_origin(&mut self, item_id: EntityId) -> Option<ItemOrigin> {
+        self.item_origins.remove(&item_id)
+    }
+
+    fn handle_pane_event(
+        &mut self,
+        pane: &Entity<Pane>,
+        event: &pane::Event,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        match event {
+            pane::Event::Remove { .. } => {
+                cx.emit(Event::Closing);
+                window.remove_window();
+            }
+            pane::Event::AddItem { item } => {
+                if let Some(workspace) = self.workspace.upgrade() {
+                    let item = item.boxed_clone();
+                    let pane = pane.clone();
+                    workspace.update(cx, |workspace, cx| {
+                        item.added_to_pane(workspace, pane, window, cx);
+                    });
+                }
+            }
+            pane::Event::RemovedItem { item } => {
+                if let Some(workspace) = self.workspace.upgrade() {
+                    let item_id = item.item_id();
+                    let pane_entity_id = pane.entity_id();
+                    workspace.update(cx, |workspace, _cx| {
+                        if let std::collections::hash_map::Entry::Occupied(entry) =
+                            workspace.panes_by_item.entry(item_id)
+                        {
+                            if entry.get().entity_id() == pane_entity_id {
+                                entry.remove();
+                            }
+                        }
+                    });
+                }
+            }
+            pane::Event::ActivateItem { .. } => {}
+            _ => {}
+        }
+    }
+}
+
+impl Focusable for WorkspaceSatellite {
+    fn focus_handle(&self, _cx: &App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+impl WorkspaceSatellite {
+    fn reattach_active_item(
+        &mut self,
+        _: &crate::ReattachActiveItem,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let root = self.root();
+        let Some(active_item) = root.read(cx).active_item() else {
+            return;
+        };
+        let item_id = active_item.item_id();
+        let origin = self.take_item_origin(item_id);
+
+        cx.emit(Event::ReattachRequested { item_id, origin });
+    }
+}
+
+impl Render for WorkspaceSatellite {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let title_bar_bg = cx.theme().colors().title_bar_background;
+        let title_bar_height = ui::utils::platform_title_bar_height(window);
+
+        let reattach_listener = cx.listener(Self::reattach_active_item);
+        let root_pane = self.root();
+        let render_cx = ActivePaneDecorator::new(&root_pane, &self.workspace);
+        let zoomed: Option<&AnyWeakView> = None;
+
+        let content = self.center.render(zoomed, &render_cx, window, cx);
+
+        client_side_decorations(
+            div()
+                .id("workspace-satellite")
+                .track_focus(&self.focus_handle)
+                .on_action(reattach_listener)
+                .flex()
+                .flex_col()
+                .size_full()
+                .bg(title_bar_bg)
+                .child(div().h(title_bar_height).w_full())
+                .child(content),
+            window,
+            cx,
+            gpui::Tiling::default(),
+        )
+    }
+}


### PR DESCRIPTION
# PR: workspace: Add detachable panel windows with WorkspaceSatellite

Adds the ability to detach any panel item (starting with terminals) into a standalone OS window. The underlying entity is shared — same PTY session, same project context, no duplication. Users with multiple monitors can put their terminal on a second screen while keeping the editor focused.

Addresses #9662 and #5229.

## What this does

- **`DetachActiveItem` action** (command palette + tab context menu) pops the active item into a new OS window via `WorkspaceSatellite`
- **`ReattachActiveItem` action** (context menu in satellite) returns the item to its original location (dock panel or center pane)
- Dock panel auto-hides when all terminals are detached, reopens on reattach
- Closing the satellite window triggers cleanup via event subscription
- Satellite windows are isolated from workspace pane routing — clicking files in the project panel stays in the main window
- Non-functional toolbar buttons (new file, split, zoom) are hidden in satellite panes
- "Detach" context menu entry hidden when already in a satellite window
- Satellite window title bar matches main window styling (tab bar background)

## Architecture

- **`WorkspaceSatellite`** (`workspace_satellite.rs`) — lightweight window container with its own `PaneGroup`, subscribed to pane events for cleanup
- **`ItemOrigin`** tracking — records whether an item came from a center pane or dock panel, so reattach puts it back in the right place
- Satellite panes are tracked in `Workspace.panes` but not subscribed to workspace's `handle_pane_event`, keeping them isolated from focus/activation routing
- The satellite pane's `in_satellite` flag controls UI differences (hidden toolbar buttons, "Move to Main Window" context menu entry)

## Scope

Five files, purely additive:

| File                                          | Change                                                                |
| --------------------------------------------- | --------------------------------------------------------------------- |
| `crates/workspace/src/workspace_satellite.rs` | New — satellite window view                                           |
| `crates/workspace/src/workspace.rs`           | Satellite lifecycle, detach/reattach, item origin tracking, 4 tests   |
| `crates/workspace/src/pane.rs`                | `in_satellite` flag, hide toolbar buttons, "Move to Main Window" menu |
| `crates/terminal_view/src/terminal_panel.rs`  | Detach action handler, dock auto-hide/reopen, tests                   |
| `crates/terminal_view/src/terminal_view.rs`   | Context menu entry for detach                                         |

## Current limitations (planned follow-ups)

- **No cross-window tab dragging** — GPUI doesn't support cross-window drag-and-drop yet
- **No terminal-specific toolbar in satellite** — the "New Terminal" / "Spawn Task" buttons from the dock panel aren't replicated; toolbar is hidden instead
- **No split/zoom in satellite** — these actions are workspace-level; wiring them up for satellites is planned
- **No file opener in satellite** — opening files is routed through the main workspace

## Screenshots

<!-- 1. Context menu: "Detach Terminal" on terminal tab in dock -->

<img width="737" height="403" alt="detach_1" src="https://github.com/user-attachments/assets/374975c7-04f2-4e2f-b029-ef972e13e33b" />

*Right-click a terminal tab to detach it from the dock panel*

<!-- 2. Detached terminal running cargo build alongside main editor -->

<img width="884" height="640" alt="detach_2" src="https://github.com/user-attachments/assets/4fc9345a-c395-4964-beca-d9450189c6a4" />

*Detached terminal running a build in its own window while editing code*

<!-- 3. Satellite context menu with "Move to Main Window" -->

<img width="874" height="605" alt="detach_3" src="https://github.com/user-attachments/assets/4f6d7286-bb8b-47ca-854a-23ae7a97d897" />

*Satellite context menu — "Move to Main Window" to reattach, no redundant "Detach" entry*

<!-- 4. Full workspace with satellite terminal and editor side by side -->

<img width="1830" height="1020" alt="detach_4" src="https://github.com/user-attachments/assets/aa8475c4-cac4-4907-83cf-e52cf2c9c5e7" />

*Full workspace with detached terminal building alongside the editor — clean tab bar with no non-functional buttons*

<!-- 5. Keymap Editor showing the detach action with user-configurable keybinding -->

<img width="1760" height="1016" alt="detach_5" src="https://github.com/user-attachments/assets/c558f8ae-fb24-46b9-b8b2-da43f422c2b3" />

*`workspace: detach active item` in Keymap Editor — works on any tab, not just terminals*

<!-- 6. Command palette searching "detach" -->

<img width="970" height="602" alt="detach_6" src="https://github.com/user-attachments/assets/8e6d459e-d5d9-49ac-81c6-b4453684dd0c" />

*Command palette access for detaching the active item*

## Test plan

**Automated:**

- `cargo test -p terminal_view` — 63 pass
- `cargo test -p workspace` — 196 pass (includes 4 new satellite integration tests)
- `./script/clippy -p workspace -p terminal_view` — zero warnings

**New integration tests (workspace):**

- `test_detach_active_item_creates_satellite` — calls the real `detach_active_item()`, verifies satellite creation, item transfers out of center pane
- `test_reattach_returns_item_to_center_pane` — full round-trip detach then reattach via `reattach_item_from_satellite()`
- `test_satellite_cleanup_on_close` — satellite `Closing` event removes satellite and pane from workspace tracking
- `test_satellite_does_not_steal_workspace_focus` — `active_pane` and `last_active_center_pane` remain on center pane after detach

**Manual:**

- [x] Detach terminal, use it, reattach
- [x] Detach terminal, close satellite window (cleanup works)
- [x] Click files in project panel with satellite open — only opens in main window
- [x] Satellite toolbar buttons (new file, split, zoom) are hidden
- [x] Right-click tab in satellite shows "Move to Main Window" (no "Detach" entry)
- [x] Multiple terminals — detaching one leaves others in dock
- [x] Detach non-terminal items (editor tabs) via command palette — works generically
- [x] Satellite title bar matches main window color (tab bar background)
- [x] Tested on macOS (cross-platform testing pending)

Release Notes:

- Added ability to detach terminal into a standalone window via "Detach Terminal" in the tab context menu, with reattach support
