### PR TITLE
Add `project_panel.indent_direction` config and interface changes

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -738,6 +738,8 @@
     "git_status": true,
     // Amount of indentation for nested items.
     "indent_size": 20,
+    // Direction of indentation for nested items. Can be 'left' or 'right'.
+    "indent_direction": "right",
     // Whether to reveal it in the project panel automatically,
     // when a corresponding project entry becomes active.
     // Gitignored entries are never auto revealed.

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -5525,6 +5525,10 @@ impl ProjectPanel {
                 ListItem::new(id)
                     .indent_level(depth)
                     .indent_step_size(px(settings.indent_size))
+                    .indent_offset(match settings.indent_direction {
+                        IndentDirection::Left => SCROLLBAR_OFFSET,
+                        IndentDirection::Right => px(0.),
+                    })
                     .indent_side(match settings.indent_direction {
                         IndentDirection::Left => IndentSide::Left,
                         IndentDirection::Right => IndentSide::Right,
@@ -6305,12 +6309,15 @@ fn item_width_estimate(depth: usize, item_text_chars: usize, is_symlink: bool) -
     item_width
 }
 
+const SCROLLBAR_OFFSET: Pixels = px(12.);
+
 impl Render for ProjectPanel {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let has_worktree = !self.state.visible_entries.is_empty();
         let project = self.project.read(cx);
         let panel_settings = ProjectPanelSettings::get_global(cx);
         let indent_size = panel_settings.indent_size;
+        let indent_direction = panel_settings.indent_direction;
         let show_indent_guides = panel_settings.indent_guides.show == ShowIndentGuides::Always;
         let show_sticky_entries = {
             if panel_settings.sticky_scroll {
@@ -6549,7 +6556,7 @@ impl Render for ProjectPanel {
                                     .with_render_fn(
                                         cx.entity(),
                                         move |this, params, _, cx| {
-                                            const LEFT_OFFSET: Pixels = px(14.);
+                                            const EDGE_OFFSET: Pixels = px(14.);
                                             const PADDING_Y: Pixels = px(4.);
                                             const HITBOX_OVERDRAW: Pixels = px(3.);
 
@@ -6561,6 +6568,7 @@ impl Render for ProjectPanel {
 
                                             let indent_size = params.indent_size;
                                             let item_height = params.item_height;
+                                            let list_width = params.list_width;
 
                                             params
                                                 .indent_guides
@@ -6572,10 +6580,21 @@ impl Render for ProjectPanel {
                                                     } else {
                                                         PADDING_Y
                                                     };
+                                                    let guide_x = match indent_direction {
+                                                        IndentDirection::Left => {
+                                                            list_width
+                                                                - layout.offset.x * indent_size
+                                                                - EDGE_OFFSET
+                                                                - SCROLLBAR_OFFSET
+                                                        }
+                                                        IndentDirection::Right => {
+                                                            layout.offset.x * indent_size
+                                                                + EDGE_OFFSET
+                                                        }
+                                                    };
                                                     let bounds = Bounds::new(
                                                         point(
-                                                            layout.offset.x * indent_size
-                                                                + LEFT_OFFSET,
+                                                            guide_x,
                                                             layout.offset.y * item_height + offset,
                                                         ),
                                                         size(
@@ -6645,19 +6664,32 @@ impl Render for ProjectPanel {
                                         .with_render_fn(
                                             cx.entity(),
                                             move |_, params, _, _| {
-                                                const LEFT_OFFSET: Pixels = px(14.);
+                                                const EDGE_OFFSET: Pixels = px(14.);
 
                                                 let indent_size = params.indent_size;
                                                 let item_height = params.item_height;
+                                                let list_width = params.list_width;
 
                                                 params
                                                     .indent_guides
                                                     .into_iter()
                                                     .map(|layout| {
+                                                        let guide_x = match indent_direction {
+                                                            IndentDirection::Left => {
+                                                                list_width
+                                                                    - layout.offset.x
+                                                                        * indent_size
+                                                                    - EDGE_OFFSET
+                                                                    - SCROLLBAR_OFFSET
+                                                            }
+                                                            IndentDirection::Right => {
+                                                                layout.offset.x * indent_size
+                                                                    + EDGE_OFFSET
+                                                            }
+                                                        };
                                                         let bounds = Bounds::new(
                                                             point(
-                                                                layout.offset.x * indent_size
-                                                                    + LEFT_OFFSET,
+                                                                guide_x,
                                                                 layout.offset.y * item_height,
                                                             ),
                                                             size(

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -42,8 +42,8 @@ use rayon::slice::ParallelSliceMut;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::{
-    DockSide, ProjectPanelEntrySpacing, Settings, SettingsStore, ShowDiagnostics, ShowIndentGuides,
-    update_settings_file,
+    DockSide, IndentDirection, ProjectPanelEntrySpacing, Settings, SettingsStore, ShowDiagnostics,
+    ShowIndentGuides, update_settings_file,
 };
 use smallvec::SmallVec;
 use std::{any::TypeId, time::Instant};
@@ -59,9 +59,9 @@ use std::{
 use theme::ThemeSettings;
 use ui::{
     Color, ContextMenu, ContextMenuEntry, DecoratedIcon, Divider, Icon, IconDecoration,
-    IconDecorationKind, IndentGuideColors, IndentGuideLayout, KeyBinding, Label, LabelSize,
-    ListItem, ListItemSpacing, ScrollAxes, ScrollableHandle, Scrollbars, StickyCandidate, Tooltip,
-    WithScrollbar, prelude::*, v_flex,
+    IconDecorationKind, IndentGuideColors, IndentGuideLayout, IndentSide, KeyBinding, Label,
+    LabelSize, ListItem, ListItemSpacing, ScrollAxes, ScrollableHandle, Scrollbars,
+    StickyCandidate, Tooltip, WithScrollbar, prelude::*, v_flex,
 };
 use util::{
     ResultExt, TakeUntilExt, TryFutureExt, maybe,
@@ -5525,6 +5525,10 @@ impl ProjectPanel {
                 ListItem::new(id)
                     .indent_level(depth)
                     .indent_step_size(px(settings.indent_size))
+                    .indent_side(match settings.indent_direction {
+                        IndentDirection::Left => IndentSide::Left,
+                        IndentDirection::Right => IndentSide::Right,
+                    })
                     .spacing(match settings.entry_spacing {
                         ProjectPanelEntrySpacing::Comfortable => ListItemSpacing::Dense,
                         ProjectPanelEntrySpacing::Standard => ListItemSpacing::ExtraDense,

--- a/crates/project_panel/src/project_panel_settings.rs
+++ b/crates/project_panel/src/project_panel_settings.rs
@@ -3,8 +3,8 @@ use gpui::Pixels;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::{
-    DockSide, ProjectPanelEntrySpacing, ProjectPanelSortMode, RegisterSetting, Settings,
-    ShowDiagnostics, ShowIndentGuides,
+    DockSide, IndentDirection, ProjectPanelEntrySpacing, ProjectPanelSortMode, RegisterSetting,
+    Settings, ShowDiagnostics, ShowIndentGuides,
 };
 use ui::{
     px,
@@ -22,6 +22,7 @@ pub struct ProjectPanelSettings {
     pub folder_icons: bool,
     pub git_status: bool,
     pub indent_size: f32,
+    pub indent_direction: IndentDirection,
     pub indent_guides: IndentGuidesSettings,
     pub sticky_scroll: bool,
     pub auto_reveal_entries: bool,
@@ -103,6 +104,7 @@ impl Settings for ProjectPanelSettings {
                     .unwrap()
                     .is_git_status_enabled(),
             indent_size: project_panel.indent_size.unwrap(),
+            indent_direction: project_panel.indent_direction.unwrap(),
             indent_guides: IndentGuidesSettings {
                 show: project_panel.indent_guides.unwrap().show.unwrap(),
             },

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -793,6 +793,7 @@ impl VsCodeSettings {
             hide_root: None,
             indent_guides: None,
             indent_size: None,
+            indent_direction: None,
             scrollbar: None,
             show_diagnostics: self
                 .read_bool("problems.decorations.enabled")

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -690,6 +690,10 @@ pub struct ProjectPanelSettingsContent {
     /// Default: 20
     #[serde(serialize_with = "serialize_optional_f32_with_two_decimal_places")]
     pub indent_size: Option<f32>,
+    /// Direction of indentation for nested items.
+    ///
+    /// Default: right
+    pub indent_direction: Option<IndentDirection>,
     /// Whether to reveal it in the project panel automatically,
     /// when a corresponding project entry becomes active.
     /// Gitignored entries are never auto revealed.
@@ -766,6 +770,29 @@ pub enum ProjectPanelEntrySpacing {
     Comfortable,
     /// The standard spacing of entries.
     Standard,
+}
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    MergeFrom,
+    PartialEq,
+    Eq,
+    strum::VariantArray,
+    strum::VariantNames,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum IndentDirection {
+    /// Indent entries to the left.
+    Left,
+    /// Indent entries to the right.
+    #[default]
+    Right,
 }
 
 #[derive(

--- a/crates/ui/src/components/indent_guides.rs
+++ b/crates/ui/src/components/indent_guides.rs
@@ -116,6 +116,7 @@ impl IndentGuides {
                 indent_guides,
                 indent_size: self.indent_size,
                 item_height,
+                list_width: bounds.size.width,
             };
             custom_render(params, window, cx)
         } else {
@@ -159,6 +160,8 @@ pub struct RenderIndentGuideParams {
     pub indent_size: Pixels,
     /// The height of each item in pixels.
     pub item_height: Pixels,
+    /// The width of the list container in pixels.
+    pub list_width: Pixels,
 }
 
 /// Represents a rendered indent guide with its visual properties and interaction areas.

--- a/crates/ui/src/components/list/list_item.rs
+++ b/crates/ui/src/components/list/list_item.rs
@@ -14,6 +14,13 @@ pub enum ListItemSpacing {
     Sparse,
 }
 
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Default)]
+pub enum IndentSide {
+    Left,
+    #[default]
+    Right,
+}
+
 #[derive(IntoElement, RegisterComponent)]
 pub struct ListItem {
     id: ElementId,
@@ -23,6 +30,7 @@ pub struct ListItem {
     spacing: ListItemSpacing,
     indent_level: usize,
     indent_step_size: Pixels,
+    indent_side: IndentSide,
     /// A slot for content that appears before the children, like an icon or avatar.
     start_slot: Option<AnyElement>,
     /// A slot for content that appears after the children, usually on the other side of the header.
@@ -57,6 +65,7 @@ impl ListItem {
             spacing: ListItemSpacing::Dense,
             indent_level: 0,
             indent_step_size: px(12.),
+            indent_side: IndentSide::Right,
             start_slot: None,
             end_slot: None,
             end_hover_slot: None,
@@ -138,6 +147,11 @@ impl ListItem {
         self
     }
 
+    pub fn indent_side(mut self, indent_side: IndentSide) -> Self {
+        self.indent_side = indent_side;
+        self
+    }
+
     pub fn toggle(mut self, toggle: impl Into<Option<bool>>) -> Self {
         self.toggle = toggle.into();
         self
@@ -216,8 +230,12 @@ impl RenderOnce for ListItem {
             .relative()
             // When an item is inset draw the indent spacing outside of the item
             .when(self.inset, |this| {
-                this.ml(self.indent_level as f32 * self.indent_step_size)
-                    .px(DynamicSpacing::Base04.rems(cx))
+                let indent = self.indent_level as f32 * self.indent_step_size;
+                match self.indent_side {
+                    IndentSide::Left => this.mr(indent),
+                    IndentSide::Right => this.ml(indent),
+                }
+                .px(DynamicSpacing::Base04.rems(cx))
             })
             .when(!self.inset && !self.disabled, |this| {
                 this
@@ -298,7 +316,11 @@ impl RenderOnce for ListItem {
                             this.rounded_sm()
                         } else {
                             // When an item is not inset draw the indent spacing inside of the item
-                            this.ml(self.indent_level as f32 * self.indent_step_size)
+                            let indent = self.indent_level as f32 * self.indent_step_size;
+                            match self.indent_side {
+                                IndentSide::Left => this.mr(indent),
+                                IndentSide::Right => this.ml(indent),
+                            }
                         }
                     })
                     .children(self.toggle.map(|is_open| {

--- a/crates/ui/src/components/list/list_item.rs
+++ b/crates/ui/src/components/list/list_item.rs
@@ -4,7 +4,7 @@ use component::{Component, ComponentScope, example_group_with_title, single_exam
 use gpui::{AnyElement, AnyView, ClickEvent, MouseButton, MouseDownEvent, Pixels, px};
 use smallvec::SmallVec;
 
-use crate::{Disclosure, prelude::*};
+use crate::{Disclosure, IconName, prelude::*};
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Default)]
 pub enum ListItemSpacing {
@@ -30,6 +30,7 @@ pub struct ListItem {
     spacing: ListItemSpacing,
     indent_level: usize,
     indent_step_size: Pixels,
+    indent_offset: Pixels,
     indent_side: IndentSide,
     /// A slot for content that appears before the children, like an icon or avatar.
     start_slot: Option<AnyElement>,
@@ -65,6 +66,7 @@ impl ListItem {
             spacing: ListItemSpacing::Dense,
             indent_level: 0,
             indent_step_size: px(12.),
+            indent_offset: px(0.),
             indent_side: IndentSide::Right,
             start_slot: None,
             end_slot: None,
@@ -144,6 +146,11 @@ impl ListItem {
 
     pub fn indent_step_size(mut self, indent_step_size: Pixels) -> Self {
         self.indent_step_size = indent_step_size;
+        self
+    }
+
+    pub fn indent_offset(mut self, indent_offset: Pixels) -> Self {
+        self.indent_offset = indent_offset;
         self
     }
 
@@ -230,7 +237,8 @@ impl RenderOnce for ListItem {
             .relative()
             // When an item is inset draw the indent spacing outside of the item
             .when(self.inset, |this| {
-                let indent = self.indent_level as f32 * self.indent_step_size;
+                let indent =
+                    self.indent_level as f32 * self.indent_step_size + self.indent_offset;
                 match self.indent_side {
                     IndentSide::Left => this.mr(indent),
                     IndentSide::Right => this.ml(indent),
@@ -268,6 +276,9 @@ impl RenderOnce for ListItem {
                     .relative()
                     .gap_1()
                     .px(DynamicSpacing::Base06.rems(cx))
+                    .when(self.indent_side == IndentSide::Left, |this| {
+                        this.flex_row_reverse()
+                    })
                     .map(|this| match self.spacing {
                         ListItemSpacing::Dense => this,
                         ListItemSpacing::ExtraDense => this.py_neg_px(),
@@ -316,7 +327,8 @@ impl RenderOnce for ListItem {
                             this.rounded_sm()
                         } else {
                             // When an item is not inset draw the indent spacing inside of the item
-                            let indent = self.indent_level as f32 * self.indent_step_size;
+                            let indent =
+                                self.indent_level as f32 * self.indent_step_size + self.indent_offset;
                             match self.indent_side {
                                 IndentSide::Left => this.mr(indent),
                                 IndentSide::Right => this.ml(indent),
@@ -327,12 +339,18 @@ impl RenderOnce for ListItem {
                         div()
                             .flex()
                             .absolute()
-                            .left(rems(-1.))
+                            .map(|this| match self.indent_side {
+                                IndentSide::Left => this.right(rems(-1.)),
+                                IndentSide::Right => this.left(rems(-1.)),
+                            })
                             .when(is_open && !self.always_show_disclosure_icon, |this| {
                                 this.visible_on_hover("")
                             })
                             .child(
                                 Disclosure::new("toggle", is_open)
+                                    .when(self.indent_side == IndentSide::Left, |this| {
+                                        this.closed_icon(IconName::ChevronLeft)
+                                    })
                                     .on_toggle_expanded(self.on_toggle),
                             )
                     }))
@@ -342,6 +360,9 @@ impl RenderOnce for ListItem {
                             .flex_shrink_0()
                             .flex_basis(relative(0.25))
                             .gap(DynamicSpacing::Base06.rems(cx))
+                            .when(self.indent_side == IndentSide::Left, |this| {
+                                this.flex_row_reverse()
+                            })
                             .map(|list_content| {
                                 if self.overflow_x {
                                     list_content


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/discussions/50190

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Added project_panel.indent_direction setting to control which side the tree indentation grows toward, useful for right-docked project panels.

## Motivation

I like my sidebar on the right but I wanted to align the folders on the right side and have the indentation happen from right to left instead of the other way around

So I coded it to see if it felt right. I liked it so decided to submit this PR in case someone else would also benefit from it.

## Considerations

- turns out it feels kinda funky reading the folders that start with dot 🤔 but i still like it
- i heavily vibe coded this while trying out warp.dev's oz agent on genius mode

<img width="601" height="317" alt="Screenshot 2026-02-26 at 21 51 15" src="https://github.com/user-attachments/assets/c679105c-e2a5-4a5a-9914-bfaf3e3a3d34" />

## Screenshots

### Default
"project_panel.dock": "left"
"project_panel.indent_direction": "right" (default)

<img width="1050" height="651" alt="Screenshot 2026-02-26 at 21 46 06" src="https://github.com/user-attachments/assets/ae320239-afad-405e-b03b-6e5d0f2373d3" />

### New Feature
"project_panel.dock": "right"
"project_panel.indent_direction": "left"

<img width="1045" height="655" alt="Screenshot 2026-02-26 at 21 45 10" src="https://github.com/user-attachments/assets/4304a819-b3c8-47b4-a203-203bdf7aa9ee" />
