### PR TITLE
ui: Fix modals not using UI font and text color

### DIFF
--- a/crates/workspace/src/multi_workspace.rs
+++ b/crates/workspace/src/multi_workspace.rs
@@ -723,6 +723,9 @@ impl Render for MultiWorkspace {
             None
         };
 
+        let ui_font = theme::setup_ui_font(window, cx);
+        let text_color = cx.theme().colors().text;
+
         let workspace = self.workspace().clone();
         let workspace_key_context = workspace.update(cx, |workspace, cx| workspace.key_context(cx));
         let root = workspace.update(cx, |workspace, cx| workspace.actions(h_flex(), window, cx));
@@ -731,6 +734,8 @@ impl Render for MultiWorkspace {
             root.key_context(workspace_key_context)
                 .relative()
                 .size_full()
+                .font(ui_font)
+                .text_color(text_color)
                 .on_action(cx.listener(Self::close_window))
                 .on_action(
                     cx.listener(|this: &mut Self, _: &NewWorkspaceInWindow, window, cx| {


### PR DESCRIPTION
The bug occurred because we weren't setting the right text style on the root div anymore (Multiworkspace), which was introduce in #49995

### Before
<img width="3248" height="2122" alt="image" src="https://github.com/user-attachments/assets/eca71731-5009-4e47-a948-d80eb3f13938" />

### After
<img width="3248" height="2122" alt="image" src="https://github.com/user-attachments/assets/75d8c591-f539-413e-a171-71e4fc847f13" />


Before you mark this PR as ready for review, make sure that you have:
- [ ] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- N/A
