### PR TITLE
git: Fix a panic when searching the split diff

### DIFF
--- a/crates/editor/src/split.rs
+++ b/crates/editor/src/split.rs
@@ -1106,13 +1106,11 @@ impl SplittableEditor {
         SearchToken::new(self.focused_side() as u64)
     }
 
-    fn editor_for_token(&self, token: SearchToken) -> &Entity<Editor> {
+    fn editor_for_token(&self, token: SearchToken) -> Option<&Entity<Editor>> {
         if token.value() == SplitSide::Left as u64 {
-            if let Some(lhs) = &self.lhs {
-                return &lhs.editor;
-            }
+            return self.lhs.as_ref().map(|lhs| &lhs.editor);
         }
-        &self.rhs_editor
+        Some(&self.rhs_editor)
     }
 
     fn companion(&self, cx: &App) -> Option<Entity<Companion>> {
@@ -1883,7 +1881,10 @@ impl SearchableItem for SplittableEditor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.editor_for_token(token).update(cx, |editor, cx| {
+        let Some(target) = self.editor_for_token(token) else {
+            return;
+        };
+        target.update(cx, |editor, cx| {
             editor.update_matches(matches, active_match_index, token, window, cx);
         });
     }
@@ -1929,7 +1930,10 @@ impl SearchableItem for SplittableEditor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.editor_for_token(token).update(cx, |editor, cx| {
+        let Some(target) = self.editor_for_token(token) else {
+            return;
+        };
+        target.update(cx, |editor, cx| {
             editor.activate_match(index, matches, token, window, cx);
         });
     }
@@ -1941,7 +1945,10 @@ impl SearchableItem for SplittableEditor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.editor_for_token(token).update(cx, |editor, cx| {
+        let Some(target) = self.editor_for_token(token) else {
+            return;
+        };
+        target.update(cx, |editor, cx| {
             editor.select_matches(matches, token, window, cx);
         });
     }
@@ -1954,7 +1961,10 @@ impl SearchableItem for SplittableEditor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.editor_for_token(token).update(cx, |editor, cx| {
+        let Some(target) = self.editor_for_token(token) else {
+            return;
+        };
+        target.update(cx, |editor, cx| {
             editor.replace(identifier, query, token, window, cx);
         });
     }
@@ -1998,7 +2008,7 @@ impl SearchableItem for SplittableEditor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Option<usize> {
-        self.editor_for_token(token).update(cx, |editor, cx| {
+        self.editor_for_token(token)?.update(cx, |editor, cx| {
             editor.active_match_index(direction, matches, token, window, cx)
         })
     }


### PR DESCRIPTION
This could happen when you initiated a search on the left side, then toggled into the unified view, then tried to select the next match.

Closes ZED-55G

Release Notes:

- Fixed a panic when toggling the split diff view while searching.