### PR TITLE
Get collab test suite passing

### DIFF
--- a/crates/gpui_linux/src/linux/platform.rs
+++ b/crates/gpui_linux/src/linux/platform.rs
@@ -55,10 +55,12 @@ pub(crate) trait LinuxClient {
     fn display(&self, id: DisplayId) -> Option<Rc<dyn PlatformDisplay>>;
     fn primary_display(&self) -> Option<Rc<dyn PlatformDisplay>>;
 
+    #[allow(dead_code)]
     fn is_screen_capture_supported(&self) -> bool {
         false
     }
 
+    #[allow(dead_code)]
     fn screen_capture_sources(
         &self,
     ) -> oneshot::Receiver<Result<Vec<Rc<dyn gpui::ScreenCaptureSource>>>> {


### PR DESCRIPTION
The test suite was failing with this error: methods `is_screen_capture_supported` and `screen_capture_sources` are never used. I added allow(dead_code) attribute on both methods to fix it

action that was failing: https://github.com/zed-industries/zed/actions/runs/22444029970/job/64993825469

Before you mark this PR as ready for review, make sure that you have:
- [ ] Added a solid test coverage and/or screenshots from doing manual testing
- [ ] Done a self-review taking into account security and performance aspects
- [ ] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- N/A
