### PR TITLE
project_panel: Add `sort_order` settings 

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -806,7 +806,7 @@
     // 4. Pure Unicode codepoint comparison.
     //    No case folding, no natural number sorting:
     //    "unicode"
-    "sort_order_lexicographic": "default",
+    "sort_order": "default",
     // Whether to show error and warning count badges next to file names in the project panel.
     "diagnostic_badges": false,
     // Whether to show the git status indicator next to file names in the project panel.

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -739,6 +739,8 @@
     "auto_fold_dirs": true,
     // Whether to show folder names with bold text in the project panel.
     "bold_folder_labels": false,
+    // Whether to sort files and directories case-sensitive in the project panel.
+    "case_sensitive": false,
     // Scrollbar-related settings
     "scrollbar": {
       // When to show the scrollbar in the project panel.

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -739,8 +739,21 @@
     "auto_fold_dirs": true,
     // Whether to show folder names with bold text in the project panel.
     "bold_folder_labels": false,
-    // Whether to sort files and directories case-sensitive in the project panel.
-    "case_sensitive": false,
+    // Whether to sort file and folder names case-sensitively in the project panel.
+    // This setting can take four values:
+    //
+    // 1. Case-insensitive natural sort with lowercase preferred in ties (default):
+    //    "default"
+    // 2. Uppercase names are grouped before lowercase names,
+    //    with case-insensitive natural sort within each group:
+    //    "upper"
+    // 3. Lowercase names are grouped before uppercase names,
+    //    with case-insensitive natural sort within each group:
+    //    "lower"
+    // 4. Pure Unicode codepoint comparison.
+    //    No case folding, no natural number sorting:
+    //    "unicode"
+    "sort_order_lexicographic": "default",
     // Scrollbar-related settings
     "scrollbar": {
       // When to show the scrollbar in the project panel.

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -739,21 +739,6 @@
     "auto_fold_dirs": true,
     // Whether to show folder names with bold text in the project panel.
     "bold_folder_labels": false,
-    // Whether to sort file and folder names case-sensitively in the project panel.
-    // This setting can take four values:
-    //
-    // 1. Case-insensitive natural sort with lowercase preferred in ties (default):
-    //    "default"
-    // 2. Uppercase names are grouped before lowercase names,
-    //    with case-insensitive natural sort within each group:
-    //    "upper"
-    // 3. Lowercase names are grouped before uppercase names,
-    //    with case-insensitive natural sort within each group:
-    //    "lower"
-    // 4. Pure Unicode codepoint comparison.
-    //    No case folding, no natural number sorting:
-    //    "unicode"
-    "sort_order_lexicographic": "default",
     // Scrollbar-related settings
     "scrollbar": {
       // When to show the scrollbar in the project panel.
@@ -807,6 +792,21 @@
     // 3. Show files first, then directories:
     //    "files_first"
     "sort_mode": "directories_first",
+    // Whether to sort file and folder names case-sensitively in the project panel.
+    // This setting can take four values:
+    //
+    // 1. Case-insensitive natural sort with lowercase preferred in ties (default):
+    //    "default"
+    // 2. Uppercase names are grouped before lowercase names,
+    //    with case-insensitive natural sort within each group:
+    //    "upper"
+    // 3. Lowercase names are grouped before uppercase names,
+    //    with case-insensitive natural sort within each group:
+    //    "lower"
+    // 4. Pure Unicode codepoint comparison.
+    //    No case folding, no natural number sorting:
+    //    "unicode"
+    "sort_order_lexicographic": "default",
     // Whether to show error and warning count badges next to file names in the project panel.
     "diagnostic_badges": false,
     // Whether to show the git status indicator next to file names in the project panel.

--- a/crates/project/src/project_search.rs
+++ b/crates/project/src/project_search.rs
@@ -617,7 +617,7 @@ impl Search {
                 (None, None) => a.remote_id().cmp(&b.remote_id()),
                 (None, Some(_)) => std::cmp::Ordering::Less,
                 (Some(_), None) => std::cmp::Ordering::Greater,
-                (Some(a), Some(b)) => compare_rel_paths((a.path(), true), (b.path(), true), false),
+                (Some(a), Some(b)) => compare_rel_paths((a.path(), true), (b.path(), true)),
             }
         });
 

--- a/crates/project/src/project_search.rs
+++ b/crates/project/src/project_search.rs
@@ -617,7 +617,7 @@ impl Search {
                 (None, None) => a.remote_id().cmp(&b.remote_id()),
                 (None, Some(_)) => std::cmp::Ordering::Less,
                 (Some(_), None) => std::cmp::Ordering::Greater,
-                (Some(a), Some(b)) => compare_rel_paths((a.path(), true), (b.path(), true)),
+                (Some(a), Some(b)) => compare_rel_paths((a.path(), true), (b.path(), true), false),
             }
         });
 

--- a/crates/project_panel/benches/sorting.rs
+++ b/crates/project_panel/benches/sorting.rs
@@ -45,47 +45,32 @@ fn load_linux_repo_snapshot() -> Vec<GitEntry> {
 fn criterion_benchmark(c: &mut Criterion) {
     let snapshot = load_linux_repo_snapshot();
 
-    c.bench_function("Sort linux worktree snapshot", |b| {
-        b.iter_batched(
-            || snapshot.clone(),
-            |mut snapshot| {
-                par_sort_worktree_entries(
-                    &mut snapshot,
-                    ProjectPanelSortMode::DirectoriesFirst,
-                    ProjectPanelSortOrderLexicographic::Default,
-                )
-            },
-            criterion::BatchSize::LargeInput,
-        );
-    });
+    let modes = [
+        ("DirectoriesFirst", ProjectPanelSortMode::DirectoriesFirst),
+        ("Mixed", ProjectPanelSortMode::Mixed),
+        ("FilesFirst", ProjectPanelSortMode::FilesFirst),
+    ];
+    let orders = [
+        ("Default", ProjectPanelSortOrderLexicographic::Default),
+        ("Upper", ProjectPanelSortOrderLexicographic::Upper),
+        ("Lower", ProjectPanelSortOrderLexicographic::Lower),
+        ("Unicode", ProjectPanelSortOrderLexicographic::Unicode),
+    ];
 
-    c.bench_function("Sort linux worktree snapshot (Mixed)", |b| {
-        b.iter_batched(
-            || snapshot.clone(),
-            |mut snapshot| {
-                par_sort_worktree_entries(
-                    &mut snapshot,
-                    ProjectPanelSortMode::Mixed,
-                    ProjectPanelSortOrderLexicographic::Default,
-                )
-            },
-            criterion::BatchSize::LargeInput,
-        );
-    });
-
-    c.bench_function("Sort linux worktree snapshot (FilesFirst)", |b| {
-        b.iter_batched(
-            || snapshot.clone(),
-            |mut snapshot| {
-                par_sort_worktree_entries(
-                    &mut snapshot,
-                    ProjectPanelSortMode::FilesFirst,
-                    ProjectPanelSortOrderLexicographic::Default,
-                )
-            },
-            criterion::BatchSize::LargeInput,
-        );
-    });
+    for (mode_name, mode) in &modes {
+        for (order_name, order) in &orders {
+            c.bench_function(
+                &format!("Sort linux worktree snapshot ({mode_name}, {order_name})"),
+                |b| {
+                    b.iter_batched(
+                        || snapshot.clone(),
+                        |mut snapshot| par_sort_worktree_entries(&mut snapshot, *mode, *order),
+                        criterion::BatchSize::LargeInput,
+                    );
+                },
+            );
+        }
+    }
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/crates/project_panel/benches/sorting.rs
+++ b/crates/project_panel/benches/sorting.rs
@@ -1,7 +1,7 @@
 use criterion::{Criterion, criterion_group, criterion_main};
 use project::{Entry, EntryKind, GitEntry, ProjectEntryId};
-use project_panel::par_sort_worktree_entries_with_mode;
-use settings::ProjectPanelSortMode;
+use project_panel::par_sort_worktree_entries;
+use settings::{ProjectPanelSortMode, SortOrderLexicographic};
 use std::sync::Arc;
 use util::rel_path::RelPath;
 
@@ -49,9 +49,10 @@ fn criterion_benchmark(c: &mut Criterion) {
         b.iter_batched(
             || snapshot.clone(),
             |mut snapshot| {
-                par_sort_worktree_entries_with_mode(
+                par_sort_worktree_entries(
                     &mut snapshot,
                     ProjectPanelSortMode::DirectoriesFirst,
+                    SortOrderLexicographic::Default,
                 )
             },
             criterion::BatchSize::LargeInput,
@@ -62,7 +63,11 @@ fn criterion_benchmark(c: &mut Criterion) {
         b.iter_batched(
             || snapshot.clone(),
             |mut snapshot| {
-                par_sort_worktree_entries_with_mode(&mut snapshot, ProjectPanelSortMode::Mixed)
+                par_sort_worktree_entries(
+                    &mut snapshot,
+                    ProjectPanelSortMode::Mixed,
+                    SortOrderLexicographic::Default,
+                )
             },
             criterion::BatchSize::LargeInput,
         );
@@ -72,7 +77,11 @@ fn criterion_benchmark(c: &mut Criterion) {
         b.iter_batched(
             || snapshot.clone(),
             |mut snapshot| {
-                par_sort_worktree_entries_with_mode(&mut snapshot, ProjectPanelSortMode::FilesFirst)
+                par_sort_worktree_entries(
+                    &mut snapshot,
+                    ProjectPanelSortMode::FilesFirst,
+                    SortOrderLexicographic::Default,
+                )
             },
             criterion::BatchSize::LargeInput,
         );

--- a/crates/project_panel/benches/sorting.rs
+++ b/crates/project_panel/benches/sorting.rs
@@ -1,7 +1,7 @@
 use criterion::{Criterion, criterion_group, criterion_main};
 use project::{Entry, EntryKind, GitEntry, ProjectEntryId};
 use project_panel::par_sort_worktree_entries;
-use settings::{ProjectPanelSortMode, SortOrderLexicographic};
+use settings::{ProjectPanelSortMode, ProjectPanelSortOrderLexicographic};
 use std::sync::Arc;
 use util::rel_path::RelPath;
 
@@ -52,7 +52,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 par_sort_worktree_entries(
                     &mut snapshot,
                     ProjectPanelSortMode::DirectoriesFirst,
-                    SortOrderLexicographic::Default,
+                    ProjectPanelSortOrderLexicographic::Default,
                 )
             },
             criterion::BatchSize::LargeInput,
@@ -66,7 +66,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 par_sort_worktree_entries(
                     &mut snapshot,
                     ProjectPanelSortMode::Mixed,
-                    SortOrderLexicographic::Default,
+                    ProjectPanelSortOrderLexicographic::Default,
                 )
             },
             criterion::BatchSize::LargeInput,
@@ -80,7 +80,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 par_sort_worktree_entries(
                     &mut snapshot,
                     ProjectPanelSortMode::FilesFirst,
-                    SortOrderLexicographic::Default,
+                    ProjectPanelSortOrderLexicographic::Default,
                 )
             },
             criterion::BatchSize::LargeInput,

--- a/crates/project_panel/benches/sorting.rs
+++ b/crates/project_panel/benches/sorting.rs
@@ -1,7 +1,7 @@
 use criterion::{Criterion, criterion_group, criterion_main};
 use project::{Entry, EntryKind, GitEntry, ProjectEntryId};
 use project_panel::par_sort_worktree_entries;
-use settings::{ProjectPanelSortMode, ProjectPanelSortOrderLexicographic};
+use settings::{ProjectPanelSortMode, ProjectPanelSortOrder};
 use std::sync::Arc;
 use util::rel_path::RelPath;
 
@@ -51,10 +51,10 @@ fn criterion_benchmark(c: &mut Criterion) {
         ("FilesFirst", ProjectPanelSortMode::FilesFirst),
     ];
     let orders = [
-        ("Default", ProjectPanelSortOrderLexicographic::Default),
-        ("Upper", ProjectPanelSortOrderLexicographic::Upper),
-        ("Lower", ProjectPanelSortOrderLexicographic::Lower),
-        ("Unicode", ProjectPanelSortOrderLexicographic::Unicode),
+        ("Default", ProjectPanelSortOrder::Default),
+        ("Upper", ProjectPanelSortOrder::Upper),
+        ("Lower", ProjectPanelSortOrder::Lower),
+        ("Unicode", ProjectPanelSortOrder::Unicode),
     ];
 
     for (mode_name, mode) in &modes {

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -2492,7 +2492,8 @@ impl ProjectPanel {
                 .collect();
 
         let mode = ProjectPanelSettings::get_global(cx).sort_mode;
-        sort_worktree_entries_with_mode(&mut siblings, mode);
+        let case_sensitive = ProjectPanelSettings::get_global(cx).case_sensitive;
+        sort_worktree_entries_with_mode(&mut siblings, mode, case_sensitive);
         let sibling_entry_index = siblings
             .iter()
             .position(|sibling| sibling.id == latest_entry.id)?;
@@ -3921,6 +3922,7 @@ impl ProjectPanel {
         let auto_collapse_dirs = settings.auto_fold_dirs;
         let hide_gitignore = settings.hide_gitignore;
         let sort_mode = settings.sort_mode;
+        let case_sensitive = settings.case_sensitive;
         let project = self.project.read(cx);
         let repo_snapshots = project.git_store().read(cx).repo_snapshots(cx);
 
@@ -4155,6 +4157,7 @@ impl ProjectPanel {
                         par_sort_worktree_entries_with_mode(
                             &mut visible_worktree_entries,
                             sort_mode,
+                            case_sensitive,
                         );
                         new_state.visible_entries.push(VisibleEntriesForWorktree {
                             worktree_id,
@@ -7273,41 +7276,43 @@ impl ClipboardEntry {
 }
 
 #[inline]
-fn cmp_directories_first(a: &Entry, b: &Entry) -> cmp::Ordering {
-    util::paths::compare_rel_paths((&a.path, a.is_file()), (&b.path, b.is_file()))
+fn cmp_directories_first(a: &Entry, b: &Entry, case_sensitive: bool) -> cmp::Ordering {
+    util::paths::compare_rel_paths((&a.path, a.is_file()), (&b.path, b.is_file()), case_sensitive)
 }
 
 #[inline]
-fn cmp_mixed(a: &Entry, b: &Entry) -> cmp::Ordering {
-    util::paths::compare_rel_paths_mixed((&a.path, a.is_file()), (&b.path, b.is_file()))
+fn cmp_mixed(a: &Entry, b: &Entry, case_sensitive: bool) -> cmp::Ordering {
+    util::paths::compare_rel_paths_mixed((&a.path, a.is_file()), (&b.path, b.is_file()), case_sensitive)
 }
 
 #[inline]
-fn cmp_files_first(a: &Entry, b: &Entry) -> cmp::Ordering {
-    util::paths::compare_rel_paths_files_first((&a.path, a.is_file()), (&b.path, b.is_file()))
+fn cmp_files_first(a: &Entry, b: &Entry, case_sensitive: bool) -> cmp::Ordering {
+    util::paths::compare_rel_paths_files_first((&a.path, a.is_file()), (&b.path, b.is_file()), case_sensitive)
 }
 
 #[inline]
-fn cmp_with_mode(a: &Entry, b: &Entry, mode: &settings::ProjectPanelSortMode) -> cmp::Ordering {
+fn cmp_with_mode(a: &Entry, b: &Entry, mode: &settings::ProjectPanelSortMode, case_sensitive: bool) -> cmp::Ordering {
     match mode {
-        settings::ProjectPanelSortMode::DirectoriesFirst => cmp_directories_first(a, b),
-        settings::ProjectPanelSortMode::Mixed => cmp_mixed(a, b),
-        settings::ProjectPanelSortMode::FilesFirst => cmp_files_first(a, b),
+        settings::ProjectPanelSortMode::DirectoriesFirst => cmp_directories_first(a, b, case_sensitive),
+        settings::ProjectPanelSortMode::Mixed => cmp_mixed(a, b, case_sensitive),
+        settings::ProjectPanelSortMode::FilesFirst => cmp_files_first(a, b, case_sensitive),
     }
 }
 
 pub fn sort_worktree_entries_with_mode(
     entries: &mut [impl AsRef<Entry>],
     mode: settings::ProjectPanelSortMode,
+    case_sensitive: bool,
 ) {
-    entries.sort_by(|lhs, rhs| cmp_with_mode(lhs.as_ref(), rhs.as_ref(), &mode));
+    entries.sort_by(|lhs, rhs| cmp_with_mode(lhs.as_ref(), rhs.as_ref(), &mode, case_sensitive));
 }
 
 pub fn par_sort_worktree_entries_with_mode(
     entries: &mut Vec<GitEntry>,
     mode: settings::ProjectPanelSortMode,
+    case_sensitive: bool,
 ) {
-    entries.par_sort_by(|lhs, rhs| cmp_with_mode(lhs, rhs, &mode));
+    entries.par_sort_by(|lhs, rhs| cmp_with_mode(lhs, rhs, &mode, case_sensitive));
 }
 
 fn git_status_indicator(git_status: GitSummary) -> Option<(&'static str, Color)> {

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -2491,9 +2491,9 @@ impl ProjectPanel {
                 .map(|entry| entry.to_owned())
                 .collect();
 
-        let mode = ProjectPanelSettings::get_global(cx).sort_mode;
+        let sort_mode = ProjectPanelSettings::get_global(cx).sort_mode;
         let sort_order = ProjectPanelSettings::get_global(cx).sort_order_lexicographic;
-        sort_worktree_entries(&mut siblings, mode, sort_order);
+        sort_worktree_entries(&mut siblings, sort_mode, sort_order);
         let sibling_entry_index = siblings
             .iter()
             .position(|sibling| sibling.id == latest_entry.id)?;

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -7280,7 +7280,7 @@ fn cmp_worktree_entries(
     a: &Entry,
     b: &Entry,
     mode: &settings::ProjectPanelSortMode,
-    order: &settings::SortOrderLexicographic,
+    order: &settings::ProjectPanelSortOrderLexicographic,
 ) -> cmp::Ordering {
     let a = (&*a.path, a.is_file());
     let b = (&*b.path, b.is_file());
@@ -7301,7 +7301,7 @@ fn cmp_worktree_entries(
 pub fn sort_worktree_entries(
     entries: &mut [impl AsRef<Entry>],
     mode: settings::ProjectPanelSortMode,
-    order: settings::SortOrderLexicographic,
+    order: settings::ProjectPanelSortOrderLexicographic,
 ) {
     entries.sort_by(|lhs, rhs| cmp_worktree_entries(lhs.as_ref(), rhs.as_ref(), &mode, &order));
 }
@@ -7309,7 +7309,7 @@ pub fn sort_worktree_entries(
 pub fn par_sort_worktree_entries(
     entries: &mut Vec<GitEntry>,
     mode: settings::ProjectPanelSortMode,
-    order: settings::SortOrderLexicographic,
+    order: settings::ProjectPanelSortOrderLexicographic,
 ) {
     entries.par_sort_by(|lhs, rhs| cmp_worktree_entries(lhs, rhs, &mode, &order));
 }

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -847,9 +847,7 @@ impl ProjectPanel {
                     if project_panel_settings.sort_mode != new_settings.sort_mode {
                         this.update_visible_entries(None, false, false, window, cx);
                     }
-                    if project_panel_settings.sort_order_lexicographic
-                        != new_settings.sort_order_lexicographic
-                    {
+                    if project_panel_settings.sort_order != new_settings.sort_order {
                         this.update_visible_entries(None, false, false, window, cx);
                     }
                     if project_panel_settings.sticky_scroll && !new_settings.sticky_scroll {
@@ -2497,7 +2495,7 @@ impl ProjectPanel {
                 .collect();
 
         let sort_mode = ProjectPanelSettings::get_global(cx).sort_mode;
-        let sort_order = ProjectPanelSettings::get_global(cx).sort_order_lexicographic;
+        let sort_order = ProjectPanelSettings::get_global(cx).sort_order;
         sort_worktree_entries(&mut siblings, sort_mode, sort_order);
         let sibling_entry_index = siblings
             .iter()
@@ -3927,7 +3925,7 @@ impl ProjectPanel {
         let auto_collapse_dirs = settings.auto_fold_dirs;
         let hide_gitignore = settings.hide_gitignore;
         let sort_mode = settings.sort_mode;
-        let sort_order = settings.sort_order_lexicographic;
+        let sort_order = settings.sort_order;
         let project = self.project.read(cx);
         let repo_snapshots = project.git_store().read(cx).repo_snapshots(cx);
 
@@ -7285,7 +7283,7 @@ fn cmp_worktree_entries(
     a: &Entry,
     b: &Entry,
     mode: &settings::ProjectPanelSortMode,
-    order: &settings::ProjectPanelSortOrderLexicographic,
+    order: &settings::ProjectPanelSortOrder,
 ) -> cmp::Ordering {
     let a = (&*a.path, a.is_file());
     let b = (&*b.path, b.is_file());
@@ -7295,7 +7293,7 @@ fn cmp_worktree_entries(
 pub fn sort_worktree_entries(
     entries: &mut [impl AsRef<Entry>],
     mode: settings::ProjectPanelSortMode,
-    order: settings::ProjectPanelSortOrderLexicographic,
+    order: settings::ProjectPanelSortOrder,
 ) {
     entries.sort_by(|lhs, rhs| cmp_worktree_entries(lhs.as_ref(), rhs.as_ref(), &mode, &order));
 }
@@ -7303,7 +7301,7 @@ pub fn sort_worktree_entries(
 pub fn par_sort_worktree_entries(
     entries: &mut Vec<GitEntry>,
     mode: settings::ProjectPanelSortMode,
-    order: settings::ProjectPanelSortOrderLexicographic,
+    order: settings::ProjectPanelSortOrder,
 ) {
     entries.par_sort_by(|lhs, rhs| cmp_worktree_entries(lhs, rhs, &mode, &order));
 }

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -847,6 +847,11 @@ impl ProjectPanel {
                     if project_panel_settings.sort_mode != new_settings.sort_mode {
                         this.update_visible_entries(None, false, false, window, cx);
                     }
+                    if project_panel_settings.sort_order_lexicographic
+                        != new_settings.sort_order_lexicographic
+                    {
+                        this.update_visible_entries(None, false, false, window, cx);
+                    }
                     if project_panel_settings.sticky_scroll && !new_settings.sticky_scroll {
                         this.sticky_items_count = 0;
                     }

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -2492,8 +2492,8 @@ impl ProjectPanel {
                 .collect();
 
         let mode = ProjectPanelSettings::get_global(cx).sort_mode;
-        let case_sensitive = ProjectPanelSettings::get_global(cx).case_sensitive;
-        sort_worktree_entries_with_mode(&mut siblings, mode, case_sensitive);
+        let sort_order = ProjectPanelSettings::get_global(cx).sort_order_lexicographic;
+        sort_worktree_entries(&mut siblings, mode, sort_order);
         let sibling_entry_index = siblings
             .iter()
             .position(|sibling| sibling.id == latest_entry.id)?;
@@ -3922,7 +3922,7 @@ impl ProjectPanel {
         let auto_collapse_dirs = settings.auto_fold_dirs;
         let hide_gitignore = settings.hide_gitignore;
         let sort_mode = settings.sort_mode;
-        let case_sensitive = settings.case_sensitive;
+        let sort_order = settings.sort_order_lexicographic;
         let project = self.project.read(cx);
         let repo_snapshots = project.git_store().read(cx).repo_snapshots(cx);
 
@@ -4154,10 +4154,10 @@ impl ProjectPanel {
                             entry_iter.advance();
                         }
 
-                        par_sort_worktree_entries_with_mode(
+                        par_sort_worktree_entries(
                             &mut visible_worktree_entries,
                             sort_mode,
-                            case_sensitive,
+                            sort_order,
                         );
                         new_state.visible_entries.push(VisibleEntriesForWorktree {
                             worktree_id,
@@ -7276,43 +7276,42 @@ impl ClipboardEntry {
 }
 
 #[inline]
-fn cmp_directories_first(a: &Entry, b: &Entry, case_sensitive: bool) -> cmp::Ordering {
-    util::paths::compare_rel_paths((&a.path, a.is_file()), (&b.path, b.is_file()), case_sensitive)
-}
-
-#[inline]
-fn cmp_mixed(a: &Entry, b: &Entry, case_sensitive: bool) -> cmp::Ordering {
-    util::paths::compare_rel_paths_mixed((&a.path, a.is_file()), (&b.path, b.is_file()), case_sensitive)
-}
-
-#[inline]
-fn cmp_files_first(a: &Entry, b: &Entry, case_sensitive: bool) -> cmp::Ordering {
-    util::paths::compare_rel_paths_files_first((&a.path, a.is_file()), (&b.path, b.is_file()), case_sensitive)
-}
-
-#[inline]
-fn cmp_with_mode(a: &Entry, b: &Entry, mode: &settings::ProjectPanelSortMode, case_sensitive: bool) -> cmp::Ordering {
+fn cmp_worktree_entries(
+    a: &Entry,
+    b: &Entry,
+    mode: &settings::ProjectPanelSortMode,
+    order: &settings::SortOrderLexicographic,
+) -> cmp::Ordering {
+    let a = (&*a.path, a.is_file());
+    let b = (&*b.path, b.is_file());
+    let order = order.clone().into();
     match mode {
-        settings::ProjectPanelSortMode::DirectoriesFirst => cmp_directories_first(a, b, case_sensitive),
-        settings::ProjectPanelSortMode::Mixed => cmp_mixed(a, b, case_sensitive),
-        settings::ProjectPanelSortMode::FilesFirst => cmp_files_first(a, b, case_sensitive),
+        settings::ProjectPanelSortMode::DirectoriesFirst => {
+            util::paths::compare_rel_paths_with_sort_order(a, b, order)
+        }
+        settings::ProjectPanelSortMode::Mixed => {
+            util::paths::compare_rel_paths_mixed_with_sort_order(a, b, order)
+        }
+        settings::ProjectPanelSortMode::FilesFirst => {
+            util::paths::compare_rel_paths_files_first_with_sort_order(a, b, order)
+        }
     }
 }
 
-pub fn sort_worktree_entries_with_mode(
+pub fn sort_worktree_entries(
     entries: &mut [impl AsRef<Entry>],
     mode: settings::ProjectPanelSortMode,
-    case_sensitive: bool,
+    order: settings::SortOrderLexicographic,
 ) {
-    entries.sort_by(|lhs, rhs| cmp_with_mode(lhs.as_ref(), rhs.as_ref(), &mode, case_sensitive));
+    entries.sort_by(|lhs, rhs| cmp_worktree_entries(lhs.as_ref(), rhs.as_ref(), &mode, &order));
 }
 
-pub fn par_sort_worktree_entries_with_mode(
+pub fn par_sort_worktree_entries(
     entries: &mut Vec<GitEntry>,
     mode: settings::ProjectPanelSortMode,
-    case_sensitive: bool,
+    order: settings::SortOrderLexicographic,
 ) {
-    entries.par_sort_by(|lhs, rhs| cmp_with_mode(lhs, rhs, &mode, case_sensitive));
+    entries.par_sort_by(|lhs, rhs| cmp_worktree_entries(lhs, rhs, &mode, &order));
 }
 
 fn git_status_indicator(git_status: GitSummary) -> Option<(&'static str, Color)> {

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -7284,18 +7284,7 @@ fn cmp_worktree_entries(
 ) -> cmp::Ordering {
     let a = (&*a.path, a.is_file());
     let b = (&*b.path, b.is_file());
-    let order = order.clone().into();
-    match mode {
-        settings::ProjectPanelSortMode::DirectoriesFirst => {
-            util::paths::compare_rel_paths_with_sort_order(a, b, order)
-        }
-        settings::ProjectPanelSortMode::Mixed => {
-            util::paths::compare_rel_paths_mixed_with_sort_order(a, b, order)
-        }
-        settings::ProjectPanelSortMode::FilesFirst => {
-            util::paths::compare_rel_paths_files_first_with_sort_order(a, b, order)
-        }
-    }
+    util::paths::compare_rel_paths_by(a, b, (*mode).into(), (*order).into())
 }
 
 pub fn sort_worktree_entries(

--- a/crates/project_panel/src/project_panel_settings.rs
+++ b/crates/project_panel/src/project_panel_settings.rs
@@ -3,7 +3,7 @@ use gpui::Pixels;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::{
-    DockSide, ProjectPanelEntrySpacing, ProjectPanelSortMode, ProjectPanelSortOrderLexicographic,
+    DockSide, ProjectPanelEntrySpacing, ProjectPanelSortMode, ProjectPanelSortOrder,
     RegisterSetting, Settings, ShowDiagnostics, ShowIndentGuides,
 };
 use ui::{
@@ -35,7 +35,7 @@ pub struct ProjectPanelSettings {
     pub drag_and_drop: bool,
     pub auto_open: AutoOpenSettings,
     pub sort_mode: ProjectPanelSortMode,
-    pub sort_order_lexicographic: ProjectPanelSortOrderLexicographic,
+    pub sort_order: ProjectPanelSortOrder,
     pub diagnostic_badges: bool,
     pub git_status_indicator: bool,
 }
@@ -142,7 +142,7 @@ impl Settings for ProjectPanelSettings {
                 }
             },
             sort_mode: project_panel.sort_mode.unwrap(),
-            sort_order_lexicographic: project_panel.sort_order_lexicographic.unwrap(),
+            sort_order: project_panel.sort_order.unwrap(),
             diagnostic_badges: project_panel.diagnostic_badges.unwrap(),
             git_status_indicator: project_panel.git_status_indicator.unwrap(),
         }

--- a/crates/project_panel/src/project_panel_settings.rs
+++ b/crates/project_panel/src/project_panel_settings.rs
@@ -35,9 +35,9 @@ pub struct ProjectPanelSettings {
     pub drag_and_drop: bool,
     pub auto_open: AutoOpenSettings,
     pub sort_mode: ProjectPanelSortMode,
+    pub sort_order_lexicographic: ProjectPanelSortOrderLexicographic,
     pub diagnostic_badges: bool,
     pub git_status_indicator: bool,
-    pub sort_order_lexicographic: ProjectPanelSortOrderLexicographic,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -142,9 +142,9 @@ impl Settings for ProjectPanelSettings {
                 }
             },
             sort_mode: project_panel.sort_mode.unwrap(),
+            sort_order_lexicographic: project_panel.sort_order_lexicographic.unwrap(),
             diagnostic_badges: project_panel.diagnostic_badges.unwrap(),
             git_status_indicator: project_panel.git_status_indicator.unwrap(),
-            sort_order_lexicographic: project_panel.sort_order_lexicographic.unwrap(),
         }
     }
 }

--- a/crates/project_panel/src/project_panel_settings.rs
+++ b/crates/project_panel/src/project_panel_settings.rs
@@ -3,8 +3,8 @@ use gpui::Pixels;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::{
-    DockSide, ProjectPanelEntrySpacing, ProjectPanelSortMode, RegisterSetting, Settings,
-    ShowDiagnostics, ShowIndentGuides, SortOrderLexicographic,
+    DockSide, ProjectPanelEntrySpacing, ProjectPanelSortMode, ProjectPanelSortOrderLexicographic,
+    RegisterSetting, Settings, ShowDiagnostics, ShowIndentGuides,
 };
 use ui::{
     px,
@@ -37,7 +37,7 @@ pub struct ProjectPanelSettings {
     pub sort_mode: ProjectPanelSortMode,
     pub diagnostic_badges: bool,
     pub git_status_indicator: bool,
-    pub sort_order_lexicographic: SortOrderLexicographic,
+    pub sort_order_lexicographic: ProjectPanelSortOrderLexicographic,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]

--- a/crates/project_panel/src/project_panel_settings.rs
+++ b/crates/project_panel/src/project_panel_settings.rs
@@ -37,6 +37,7 @@ pub struct ProjectPanelSettings {
     pub sort_mode: ProjectPanelSortMode,
     pub diagnostic_badges: bool,
     pub git_status_indicator: bool,
+    pub case_sensitive: bool,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -143,6 +144,7 @@ impl Settings for ProjectPanelSettings {
             sort_mode: project_panel.sort_mode.unwrap(),
             diagnostic_badges: project_panel.diagnostic_badges.unwrap(),
             git_status_indicator: project_panel.git_status_indicator.unwrap(),
+            case_sensitive: project_panel.case_sensitive.unwrap(),
         }
     }
 }

--- a/crates/project_panel/src/project_panel_settings.rs
+++ b/crates/project_panel/src/project_panel_settings.rs
@@ -4,7 +4,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::{
     DockSide, ProjectPanelEntrySpacing, ProjectPanelSortMode, RegisterSetting, Settings,
-    ShowDiagnostics, ShowIndentGuides,
+    ShowDiagnostics, ShowIndentGuides, SortOrderLexicographic,
 };
 use ui::{
     px,
@@ -37,7 +37,7 @@ pub struct ProjectPanelSettings {
     pub sort_mode: ProjectPanelSortMode,
     pub diagnostic_badges: bool,
     pub git_status_indicator: bool,
-    pub case_sensitive: bool,
+    pub sort_order_lexicographic: SortOrderLexicographic,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -144,7 +144,7 @@ impl Settings for ProjectPanelSettings {
             sort_mode: project_panel.sort_mode.unwrap(),
             diagnostic_badges: project_panel.diagnostic_badges.unwrap(),
             git_status_indicator: project_panel.git_status_indicator.unwrap(),
-            case_sensitive: project_panel.case_sensitive.unwrap(),
+            sort_order_lexicographic: project_panel.sort_order_lexicographic.unwrap(),
         }
     }
 }

--- a/crates/settings/src/settings_store.rs
+++ b/crates/settings/src/settings_store.rs
@@ -2027,6 +2027,30 @@ mod tests {
             cx,
         );
 
+        // explorer sort settings
+        check_vscode_import(
+            &mut store,
+            r#"{
+            }
+            "#
+            .unindent(),
+            r#"{
+              "explorer.sortOrder": "mixed",
+              "explorer.sortOrderLexicographicOptions": "lower"
+            }"#
+            .unindent(),
+            r#"{
+              "project_panel": {
+                "sort_mode": "mixed",
+                "sort_order": "lower"
+              },
+              "base_keymap": "VSCode"
+            }
+            "#
+            .unindent(),
+            cx,
+        );
+
         // font-family
         check_vscode_import(
             &mut store,

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -810,7 +810,7 @@ impl VsCodeSettings {
             auto_open: None,
             diagnostic_badges: None,
             git_status_indicator: None,
-            case_sensitive: None,
+            sort_order_lexicographic: None,
         };
 
         if let (Some(false), Some(false)) = (

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -804,17 +804,19 @@ impl VsCodeSettings {
             show_diagnostics: self
                 .read_bool("problems.decorations.enabled")
                 .and_then(|b| if b { Some(ShowDiagnostics::Off) } else { None }),
-            sort_mode: None,
-            sort_order_lexicographic: self.read_enum(
-                "search.quickOpen.history.filterSortOrder",
-                |s| match s {
-                    "default" => Some(ProjectPanelSortOrderLexicographic::Default),
-                    "upper" => Some(ProjectPanelSortOrderLexicographic::Upper),
-                    "lower" => Some(ProjectPanelSortOrderLexicographic::Lower),
-                    "unicode" => Some(ProjectPanelSortOrderLexicographic::Unicode),
-                    _ => None,
-                },
-            ),
+            sort_mode: self.read_enum("explorer.sortOrder", |s| match s {
+                "default" | "foldersNestsFiles" => Some(ProjectPanelSortMode::DirectoriesFirst),
+                "mixed" => Some(ProjectPanelSortMode::Mixed),
+                "filesFirst" => Some(ProjectPanelSortMode::FilesFirst),
+                _ => None,
+            }),
+            sort_order: self.read_enum("explorer.sortOrderLexicographicOptions", |s| match s {
+                "default" => Some(ProjectPanelSortOrder::Default),
+                "upper" => Some(ProjectPanelSortOrder::Upper),
+                "lower" => Some(ProjectPanelSortOrder::Lower),
+                "unicode" => Some(ProjectPanelSortOrder::Unicode),
+                _ => None,
+            }),
             starts_open: None,
             sticky_scroll: None,
             auto_open: None,

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -805,12 +805,12 @@ impl VsCodeSettings {
                 .read_bool("problems.decorations.enabled")
                 .and_then(|b| if b { Some(ShowDiagnostics::Off) } else { None }),
             sort_mode: None,
+            sort_order_lexicographic: None,
             starts_open: None,
             sticky_scroll: None,
             auto_open: None,
             diagnostic_badges: None,
             git_status_indicator: None,
-            sort_order_lexicographic: None,
         };
 
         if let (Some(false), Some(false)) = (

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -810,6 +810,7 @@ impl VsCodeSettings {
             auto_open: None,
             diagnostic_badges: None,
             git_status_indicator: None,
+            case_sensitive: None,
         };
 
         if let (Some(false), Some(false)) = (

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -805,7 +805,16 @@ impl VsCodeSettings {
                 .read_bool("problems.decorations.enabled")
                 .and_then(|b| if b { Some(ShowDiagnostics::Off) } else { None }),
             sort_mode: None,
-            sort_order_lexicographic: None,
+            sort_order_lexicographic: self.read_enum(
+                "search.quickOpen.history.filterSortOrder",
+                |s| match s {
+                    "default" => Some(ProjectPanelSortOrderLexicographic::Default),
+                    "upper" => Some(ProjectPanelSortOrderLexicographic::Upper),
+                    "lower" => Some(ProjectPanelSortOrderLexicographic::Lower),
+                    "unicode" => Some(ProjectPanelSortOrderLexicographic::Unicode),
+                    _ => None,
+                },
+            ),
             starts_open: None,
             sticky_scroll: None,
             auto_open: None,

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -746,6 +746,12 @@ pub struct ProjectPanelSettingsContent {
     ///
     /// Default: directories_first
     pub sort_mode: Option<ProjectPanelSortMode>,
+    /// Whether to sort file and folder names case-sensitively in the project panel.
+    /// This works in combination with `sort_mode`. `sort_mode` controls how files and
+    /// directories are grouped, while this setting controls how names are compared.
+    ///
+    /// Default: default
+    pub sort_order_lexicographic: Option<ProjectPanelSortOrderLexicographic>,
     /// Whether to show error and warning count badges next to file names in the project panel.
     ///
     /// Default: false
@@ -754,12 +760,6 @@ pub struct ProjectPanelSettingsContent {
     ///
     /// Default: false
     pub git_status_indicator: Option<bool>,
-    /// Whether to sort file and folder names case-sensitively in the project panel.
-    /// This works in combination with `sort_mode`. `sort_mode` controls how files and
-    /// directories are grouped, while this setting controls how names are compared.
-    ///
-    /// Default: default
-    pub sort_order_lexicographic: Option<ProjectPanelSortOrderLexicographic>,
 }
 
 #[derive(

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -751,7 +751,7 @@ pub struct ProjectPanelSettingsContent {
     /// directories are grouped, while this setting controls how names are compared.
     ///
     /// Default: default
-    pub sort_order_lexicographic: Option<ProjectPanelSortOrderLexicographic>,
+    pub sort_order: Option<ProjectPanelSortOrder>,
     /// Whether to show error and warning count badges next to file names in the project panel.
     ///
     /// Default: false
@@ -825,7 +825,7 @@ pub enum ProjectPanelSortMode {
     strum::VariantNames,
 )]
 #[serde(rename_all = "snake_case")]
-pub enum ProjectPanelSortOrderLexicographic {
+pub enum ProjectPanelSortOrder {
     /// Case-insensitive natural sort with lowercase preferred in ties.
     /// Numbers in file names are compared by value (e.g., `file2` before `file10`).
     #[default]
@@ -851,13 +851,13 @@ impl From<ProjectPanelSortMode> for util::paths::SortMode {
     }
 }
 
-impl From<ProjectPanelSortOrderLexicographic> for util::paths::SortOrderLexicographic {
-    fn from(order: ProjectPanelSortOrderLexicographic) -> Self {
+impl From<ProjectPanelSortOrder> for util::paths::SortOrder {
+    fn from(order: ProjectPanelSortOrder) -> Self {
         match order {
-            ProjectPanelSortOrderLexicographic::Default => Self::Default,
-            ProjectPanelSortOrderLexicographic::Upper => Self::Upper,
-            ProjectPanelSortOrderLexicographic::Lower => Self::Lower,
-            ProjectPanelSortOrderLexicographic::Unicode => Self::Unicode,
+            ProjectPanelSortOrder::Default => Self::Default,
+            ProjectPanelSortOrder::Upper => Self::Upper,
+            ProjectPanelSortOrder::Lower => Self::Lower,
+            ProjectPanelSortOrder::Unicode => Self::Unicode,
         }
     }
 }

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -841,6 +841,16 @@ pub enum ProjectPanelSortOrderLexicographic {
     Unicode,
 }
 
+impl From<ProjectPanelSortMode> for util::paths::SortMode {
+    fn from(mode: ProjectPanelSortMode) -> Self {
+        match mode {
+            ProjectPanelSortMode::DirectoriesFirst => Self::DirectoriesFirst,
+            ProjectPanelSortMode::Mixed => Self::Mixed,
+            ProjectPanelSortMode::FilesFirst => Self::FilesFirst,
+        }
+    }
+}
+
 impl From<ProjectPanelSortOrderLexicographic> for util::paths::SortOrderLexicographic {
     fn from(order: ProjectPanelSortOrderLexicographic) -> Self {
         match order {

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -759,7 +759,7 @@ pub struct ProjectPanelSettingsContent {
     /// directories are grouped, while this setting controls how names are compared.
     ///
     /// Default: default
-    pub sort_order_lexicographic: Option<SortOrderLexicographic>,
+    pub sort_order_lexicographic: Option<ProjectPanelSortOrderLexicographic>,
 }
 
 #[derive(
@@ -825,7 +825,7 @@ pub enum ProjectPanelSortMode {
     strum::VariantNames,
 )]
 #[serde(rename_all = "snake_case")]
-pub enum SortOrderLexicographic {
+pub enum ProjectPanelSortOrderLexicographic {
     /// Case-insensitive natural sort with lowercase preferred in ties.
     /// Numbers in file names are compared by value (e.g., `file2` before `file10`).
     #[default]
@@ -841,13 +841,13 @@ pub enum SortOrderLexicographic {
     Unicode,
 }
 
-impl From<SortOrderLexicographic> for util::paths::SortOrderLexicographic {
-    fn from(order: SortOrderLexicographic) -> Self {
+impl From<ProjectPanelSortOrderLexicographic> for util::paths::SortOrderLexicographic {
+    fn from(order: ProjectPanelSortOrderLexicographic) -> Self {
         match order {
-            SortOrderLexicographic::Default => Self::Default,
-            SortOrderLexicographic::Upper => Self::Upper,
-            SortOrderLexicographic::Lower => Self::Lower,
-            SortOrderLexicographic::Unicode => Self::Unicode,
+            ProjectPanelSortOrderLexicographic::Default => Self::Default,
+            ProjectPanelSortOrderLexicographic::Upper => Self::Upper,
+            ProjectPanelSortOrderLexicographic::Lower => Self::Lower,
+            ProjectPanelSortOrderLexicographic::Unicode => Self::Unicode,
         }
     }
 }

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -754,10 +754,12 @@ pub struct ProjectPanelSettingsContent {
     ///
     /// Default: false
     pub git_status_indicator: Option<bool>,
-    /// Whether to sort files and directories case-sensitive in the project panel.
+    /// Whether to sort file and folder names case-sensitively in the project panel.
+    /// This works in combination with `sort_mode`. `sort_mode` controls how files and
+    /// directories are grouped, while this setting controls how names are compared.
     ///
-    /// Default: false
-    pub case_sensitive: Option<bool>,
+    /// Default: default
+    pub sort_order_lexicographic: Option<SortOrderLexicographic>,
 }
 
 #[derive(
@@ -806,6 +808,48 @@ pub enum ProjectPanelSortMode {
     Mixed,
     /// Show files first, then directories
     FilesFirst,
+}
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    Default,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    MergeFrom,
+    PartialEq,
+    Eq,
+    strum::VariantArray,
+    strum::VariantNames,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum SortOrderLexicographic {
+    /// Case-insensitive natural sort with lowercase preferred in ties.
+    /// Numbers in file names are compared by value (e.g., `file2` before `file10`).
+    #[default]
+    Default,
+    /// Uppercase names are grouped before lowercase names, with case-insensitive
+    /// natural sort within each group. Dot-prefixed names sort before both groups.
+    Upper,
+    /// Lowercase names are grouped before uppercase names, with case-insensitive
+    /// natural sort within each group. Dot-prefixed names sort before both groups.
+    Lower,
+    /// Pure Unicode codepoint comparison. No case folding, no natural number sorting.
+    /// Uppercase ASCII sorts before lowercase. Accented characters sort after ASCII.
+    Unicode,
+}
+
+impl From<SortOrderLexicographic> for util::paths::SortOrderLexicographic {
+    fn from(order: SortOrderLexicographic) -> Self {
+        match order {
+            SortOrderLexicographic::Default => Self::Default,
+            SortOrderLexicographic::Upper => Self::Upper,
+            SortOrderLexicographic::Lower => Self::Lower,
+            SortOrderLexicographic::Unicode => Self::Unicode,
+        }
+    }
 }
 
 #[with_fallible_options]

--- a/crates/settings_content/src/workspace.rs
+++ b/crates/settings_content/src/workspace.rs
@@ -754,6 +754,10 @@ pub struct ProjectPanelSettingsContent {
     ///
     /// Default: false
     pub git_status_indicator: Option<bool>,
+    /// Whether to sort files and directories case-sensitive in the project panel.
+    ///
+    /// Default: false
+    pub case_sensitive: Option<bool>,
 }
 
 #[derive(

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -4949,6 +4949,28 @@ fn panels_page() -> SettingsPage {
                 files: USER,
             }),
             SettingsPageItem::SettingItem(SettingItem {
+                title: "Sort Order (Lexicographic)",
+                description: "Whether to sort file and folder names case-sensitively in the project panel.",
+                field: Box::new(SettingField {
+                    pick: |settings_content| {
+                        settings_content
+                            .project_panel
+                            .as_ref()?
+                            .sort_order_lexicographic
+                            .as_ref()
+                    },
+                    write: |settings_content, value| {
+                        settings_content
+                            .project_panel
+                            .get_or_insert_default()
+                            .sort_order_lexicographic = value;
+                    },
+                    json_path: Some("project_panel.sort_order_lexicographic"),
+                }),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
                 title: "Auto Open Files On Create",
                 description: "Whether to automatically open newly created files in the editor.",
                 field: Box::new(SettingField {
@@ -5041,28 +5063,6 @@ fn panels_page() -> SettingsPage {
                     }
                     .unimplemented(),
                 ),
-                metadata: None,
-                files: USER,
-            }),
-            SettingsPageItem::SettingItem(SettingItem {
-                title: "Sort Order (Lexicographic)",
-                description: "Whether to sort file and folder names case-sensitively in the project panel.",
-                field: Box::new(SettingField {
-                    pick: |settings_content| {
-                        settings_content
-                            .project_panel
-                            .as_ref()?
-                            .sort_order_lexicographic
-                            .as_ref()
-                    },
-                    write: |settings_content, value| {
-                        settings_content
-                            .project_panel
-                            .get_or_insert_default()
-                            .sort_order_lexicographic = value;
-                    },
-                    json_path: Some("project_panel.sort_order_lexicographic"),
-                }),
                 metadata: None,
                 files: USER,
             }),

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -4948,6 +4948,12 @@ fn panels_page() -> SettingsPage {
                 metadata: None,
                 files: USER,
             }),
+        ]
+    }
+
+    fn auto_open_files_section() -> [SettingsPageItem; 6] {
+        [
+            SettingsPageItem::SectionHeader("Auto Open Files"),
             SettingsPageItem::SettingItem(SettingItem {
                 title: "Auto Open Files On Create",
                 description: "Whether to automatically open newly created files in the editor.",
@@ -5041,6 +5047,28 @@ fn panels_page() -> SettingsPage {
                     }
                     .unimplemented(),
                 ),
+                metadata: None,
+                files: USER,
+            }),
+            SettingsPageItem::SettingItem(SettingItem {
+                title: "Case-Sensitive",
+                description: "Whether to sort files and directories case-sensitive in the project panel.",
+                field: Box::new(SettingField {
+                    pick: |settings_content| {
+                        settings_content
+                            .project_panel
+                            .as_ref()?
+                            .case_sensitive
+                            .as_ref()
+                    },
+                    write: |settings_content, value| {
+                        settings_content
+                            .project_panel
+                            .get_or_insert_default()
+                            .case_sensitive = value;
+                    },
+                    json_path: Some("project_panel.case_sensitive"),
+                }),
                 metadata: None,
                 files: USER,
             }),

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -4949,23 +4949,19 @@ fn panels_page() -> SettingsPage {
                 files: USER,
             }),
             SettingsPageItem::SettingItem(SettingItem {
-                title: "Sort Order (Lexicographic)",
+                title: "Sort Order",
                 description: "Whether to sort file and folder names case-sensitively in the project panel.",
                 field: Box::new(SettingField {
                     pick: |settings_content| {
-                        settings_content
-                            .project_panel
-                            .as_ref()?
-                            .sort_order_lexicographic
-                            .as_ref()
+                        settings_content.project_panel.as_ref()?.sort_order.as_ref()
                     },
                     write: |settings_content, value| {
                         settings_content
                             .project_panel
                             .get_or_insert_default()
-                            .sort_order_lexicographic = value;
+                            .sort_order = value;
                     },
-                    json_path: Some("project_panel.sort_order_lexicographic"),
+                    json_path: Some("project_panel.sort_order"),
                 }),
                 metadata: None,
                 files: USER,

--- a/crates/settings_ui/src/page_data.rs
+++ b/crates/settings_ui/src/page_data.rs
@@ -4450,7 +4450,7 @@ fn window_and_layout_page() -> SettingsPage {
 }
 
 fn panels_page() -> SettingsPage {
-    fn project_panel_section() -> [SettingsPageItem; 28] {
+    fn project_panel_section() -> [SettingsPageItem; 29] {
         [
             SettingsPageItem::SectionHeader("Project Panel"),
             SettingsPageItem::SettingItem(SettingItem {
@@ -4948,12 +4948,6 @@ fn panels_page() -> SettingsPage {
                 metadata: None,
                 files: USER,
             }),
-        ]
-    }
-
-    fn auto_open_files_section() -> [SettingsPageItem; 6] {
-        [
-            SettingsPageItem::SectionHeader("Auto Open Files"),
             SettingsPageItem::SettingItem(SettingItem {
                 title: "Auto Open Files On Create",
                 description: "Whether to automatically open newly created files in the editor.",
@@ -5051,23 +5045,23 @@ fn panels_page() -> SettingsPage {
                 files: USER,
             }),
             SettingsPageItem::SettingItem(SettingItem {
-                title: "Case-Sensitive",
-                description: "Whether to sort files and directories case-sensitive in the project panel.",
+                title: "Sort Order (Lexicographic)",
+                description: "Whether to sort file and folder names case-sensitively in the project panel.",
                 field: Box::new(SettingField {
                     pick: |settings_content| {
                         settings_content
                             .project_panel
                             .as_ref()?
-                            .case_sensitive
+                            .sort_order_lexicographic
                             .as_ref()
                     },
                     write: |settings_content, value| {
                         settings_content
                             .project_panel
                             .get_or_insert_default()
-                            .case_sensitive = value;
+                            .sort_order_lexicographic = value;
                     },
-                    json_path: Some("project_panel.case_sensitive"),
+                    json_path: Some("project_panel.sort_order_lexicographic"),
                 }),
                 metadata: None,
                 files: USER,

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -486,6 +486,7 @@ fn init_renderers(cx: &mut App) {
         .add_basic_renderer::<settings::ShowCloseButton>(render_dropdown)
         .add_basic_renderer::<settings::ProjectPanelEntrySpacing>(render_dropdown)
         .add_basic_renderer::<settings::ProjectPanelSortMode>(render_dropdown)
+        .add_basic_renderer::<settings::SortOrderLexicographic>(render_dropdown)
         .add_basic_renderer::<settings::RewrapBehavior>(render_dropdown)
         .add_basic_renderer::<settings::FormatOnSave>(render_dropdown)
         .add_basic_renderer::<settings::IndentGuideColoring>(render_dropdown)

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -486,7 +486,7 @@ fn init_renderers(cx: &mut App) {
         .add_basic_renderer::<settings::ShowCloseButton>(render_dropdown)
         .add_basic_renderer::<settings::ProjectPanelEntrySpacing>(render_dropdown)
         .add_basic_renderer::<settings::ProjectPanelSortMode>(render_dropdown)
-        .add_basic_renderer::<settings::SortOrderLexicographic>(render_dropdown)
+        .add_basic_renderer::<settings::ProjectPanelSortOrderLexicographic>(render_dropdown)
         .add_basic_renderer::<settings::RewrapBehavior>(render_dropdown)
         .add_basic_renderer::<settings::FormatOnSave>(render_dropdown)
         .add_basic_renderer::<settings::IndentGuideColoring>(render_dropdown)

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -486,7 +486,7 @@ fn init_renderers(cx: &mut App) {
         .add_basic_renderer::<settings::ShowCloseButton>(render_dropdown)
         .add_basic_renderer::<settings::ProjectPanelEntrySpacing>(render_dropdown)
         .add_basic_renderer::<settings::ProjectPanelSortMode>(render_dropdown)
-        .add_basic_renderer::<settings::ProjectPanelSortOrderLexicographic>(render_dropdown)
+        .add_basic_renderer::<settings::ProjectPanelSortOrder>(render_dropdown)
         .add_basic_renderer::<settings::RewrapBehavior>(render_dropdown)
         .add_basic_renderer::<settings::FormatOnSave>(render_dropdown)
         .add_basic_renderer::<settings::IndentGuideColoring>(render_dropdown)

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -1112,6 +1112,7 @@ fn stem_and_extension(filename: &str) -> (Option<&str>, Option<&str>) {
 pub fn compare_rel_paths(
     (path_a, a_is_file): (&RelPath, bool),
     (path_b, b_is_file): (&RelPath, bool),
+    case_sensitive: bool,
 ) -> Ordering {
     let mut components_a = path_a.components();
     let mut components_b = path_b.components();
@@ -1133,7 +1134,13 @@ pub fn compare_rel_paths(
                     let path_string_b = if b_is_file { b_stem } else { Some(component_b) };
 
                     let compare_components = match (path_string_a, path_string_b) {
-                        (Some(a), Some(b)) => natural_sort(&a, &b),
+                        (Some(a), Some(b)) => {
+                            if case_sensitive {
+                                a.cmp(&b)
+                            } else {
+                                natural_sort(&a, &b)
+                            }
+                        }
                         (Some(_), None) => Ordering::Greater,
                         (None, Some(_)) => Ordering::Less,
                         (None, None) => Ordering::Equal,
@@ -1168,6 +1175,7 @@ pub fn compare_rel_paths(
 pub fn compare_rel_paths_mixed(
     (path_a, a_is_file): (&RelPath, bool),
     (path_b, b_is_file): (&RelPath, bool),
+    case_sensitive: bool,
 ) -> Ordering {
     let original_paths_equal = std::ptr::eq(path_a, path_b) || path_a == path_b;
     let mut components_a = path_a.components();
@@ -1197,21 +1205,33 @@ pub fn compare_rel_paths_mixed(
                 };
 
                 let ordering = match (a_key, b_key) {
-                    (Some(a), Some(b)) => natural_sort_no_tiebreak(a, b)
-                        .then_with(|| match (a_leaf_file, b_leaf_file) {
-                            (true, false) if a.eq_ignore_ascii_case(b) => Ordering::Greater,
-                            (false, true) if a.eq_ignore_ascii_case(b) => Ordering::Less,
-                            _ => Ordering::Equal,
-                        })
-                        .then_with(|| {
-                            if a_leaf_file && b_leaf_file {
-                                let a_ext_str = a_ext.unwrap_or_default().to_lowercase();
-                                let b_ext_str = b_ext.unwrap_or_default().to_lowercase();
-                                b_ext_str.cmp(&a_ext_str)
-                            } else {
-                                Ordering::Equal
-                            }
-                        }),
+                    (Some(a), Some(b)) => {
+                        let base_cmp = if case_sensitive {
+                            a.cmp(b)
+                        } else {
+                            natural_sort_no_tiebreak(a, b)
+                        };
+
+                        base_cmp
+                            .then_with(|| match (a_leaf_file, b_leaf_file) {
+                                (true, false) if a.eq_ignore_ascii_case(b) => Ordering::Greater,
+                                (false, true) if a.eq_ignore_ascii_case(b) => Ordering::Less,
+                                _ => Ordering::Equal,
+                            })
+                            .then_with(|| {
+                                if a_leaf_file && b_leaf_file {
+                                    if case_sensitive {
+                                        b_ext.unwrap_or_default().cmp(a_ext.unwrap_or_default())
+                                    } else {
+                                        let a_ext_str = a_ext.unwrap_or_default().to_lowercase();
+                                        let b_ext_str = b_ext.unwrap_or_default().to_lowercase();
+                                        b_ext_str.cmp(&a_ext_str)
+                                    }
+                                } else {
+                                    Ordering::Equal
+                                }
+                            })
+                    }
                     (Some(_), None) => Ordering::Greater,
                     (None, Some(_)) => Ordering::Less,
                     (None, None) => Ordering::Equal,
@@ -1224,10 +1244,13 @@ pub fn compare_rel_paths_mixed(
             (Some(_), None) => return Ordering::Greater,
             (None, Some(_)) => return Ordering::Less,
             (None, None) => {
-                // Deterministic tie-break: use natural sort to prefer lowercase when paths
-                // are otherwise equal but still differ in casing.
+                // Deterministic tie-break
                 if !original_paths_equal {
-                    return natural_sort(path_a.as_unix_str(), path_b.as_unix_str());
+                    return if case_sensitive {
+                        path_a.as_unix_str().cmp(path_b.as_unix_str())
+                    } else {
+                        natural_sort(path_a.as_unix_str(), path_b.as_unix_str())
+                    }
                 }
                 return Ordering::Equal;
             }
@@ -1242,6 +1265,7 @@ pub fn compare_rel_paths_mixed(
 pub fn compare_rel_paths_files_first(
     (path_a, a_is_file): (&RelPath, bool),
     (path_b, b_is_file): (&RelPath, bool),
+    case_sensitive: bool,
 ) -> Ordering {
     let original_paths_equal = std::ptr::eq(path_a, path_b) || path_a == path_b;
     let mut components_a = path_a.components();
@@ -1277,11 +1301,21 @@ pub fn compare_rel_paths_files_first(
                         } else if !a_leaf_file && b_leaf_file {
                             Ordering::Greater
                         } else {
-                            natural_sort_no_tiebreak(a, b).then_with(|| {
+                            let base_cmp = if case_sensitive {
+                                a.cmp(b)
+                            } else {
+                                natural_sort_no_tiebreak(a, b)
+                            };
+
+                            base_cmp.then_with(|| {
                                 if a_leaf_file && b_leaf_file {
-                                    let a_ext_str = a_ext.unwrap_or_default().to_lowercase();
-                                    let b_ext_str = b_ext.unwrap_or_default().to_lowercase();
-                                    a_ext_str.cmp(&b_ext_str)
+                                    if case_sensitive {
+                                        a_ext.unwrap_or_default().cmp(b_ext.unwrap_or_default())
+                                    } else {
+                                        let a_ext_str = a_ext.unwrap_or_default().to_lowercase();
+                                        let b_ext_str = b_ext.unwrap_or_default().to_lowercase();
+                                        a_ext_str.cmp(&b_ext_str)
+                                    }
                                 } else {
                                     Ordering::Equal
                                 }
@@ -1300,10 +1334,13 @@ pub fn compare_rel_paths_files_first(
             (Some(_), None) => return Ordering::Greater,
             (None, Some(_)) => return Ordering::Less,
             (None, None) => {
-                // Deterministic tie-break: use natural sort to prefer lowercase when paths
-                // are otherwise equal but still differ in casing.
+                // Deterministic tie-break
                 if !original_paths_equal {
-                    return natural_sort(path_a.as_unix_str(), path_b.as_unix_str());
+                    return if case_sensitive {
+                        path_a.as_unix_str().cmp(path_b.as_unix_str())
+                    } else {
+                        natural_sort(path_a.as_unix_str(), path_b.as_unix_str())
+                    }
                 }
                 return Ordering::Equal;
             }
@@ -1715,7 +1752,7 @@ mod tests {
             (RelPath::unix("Carrot").unwrap(), false),
             (RelPath::unix("aardvark.txt").unwrap(), true),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b));
+        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b, false));
         // Case-insensitive: aardvark < Apple < banana < Carrot < zebra
         assert_eq!(
             paths,
@@ -1739,7 +1776,7 @@ mod tests {
             (RelPath::unix("Carrot").unwrap(), false),
             (RelPath::unix("aardvark.txt").unwrap(), true),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_files_first(a, b));
+        paths.sort_by(|&a, &b| compare_rel_paths_files_first(a, b, false));
         // Files first (case-insensitive), then directories (case-insensitive)
         assert_eq!(
             paths,
@@ -1763,7 +1800,7 @@ mod tests {
             (RelPath::unix("carrot").unwrap(), false),
             (RelPath::unix("Aardvark.txt").unwrap(), true),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_files_first(a, b));
+        paths.sort_by(|&a, &b| compare_rel_paths_files_first(a, b, false));
         assert_eq!(
             paths,
             vec![
@@ -1786,7 +1823,7 @@ mod tests {
             (RelPath::unix("dir10").unwrap(), false),
             (RelPath::unix("file1.txt").unwrap(), true),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_files_first(a, b));
+        paths.sort_by(|&a, &b| compare_rel_paths_files_first(a, b, false));
         assert_eq!(
             paths,
             vec![
@@ -1807,7 +1844,7 @@ mod tests {
             (RelPath::unix("readme.txt").unwrap(), true),
             (RelPath::unix("ReadMe.rs").unwrap(), true),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b));
+        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b, false));
         // All "readme" variants should group together, sorted by extension
         assert_eq!(
             paths,
@@ -1828,7 +1865,7 @@ mod tests {
             (RelPath::unix("file1.txt").unwrap(), true),
             (RelPath::unix("dir2").unwrap(), false),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b));
+        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b, false));
         // Case-insensitive: dir1, dir2, file1, file2 (all mixed)
         assert_eq!(
             paths,
@@ -1847,7 +1884,7 @@ mod tests {
             (RelPath::unix("Hello.txt").unwrap(), true),
             (RelPath::unix("hello").unwrap(), false),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b));
+        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b, false));
         assert_eq!(
             paths,
             vec![
@@ -1860,7 +1897,7 @@ mod tests {
             (RelPath::unix("hello").unwrap(), false),
             (RelPath::unix("Hello.txt").unwrap(), true),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b));
+        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b, false));
         assert_eq!(
             paths,
             vec![
@@ -1879,7 +1916,7 @@ mod tests {
             (RelPath::unix("src").unwrap(), false),
             (RelPath::unix("target").unwrap(), false),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b));
+        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b, false));
         assert_eq!(
             paths,
             vec![
@@ -1900,7 +1937,7 @@ mod tests {
             (RelPath::unix("src").unwrap(), false),
             (RelPath::unix("tests").unwrap(), false),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_files_first(a, b));
+        paths.sort_by(|&a, &b| compare_rel_paths_files_first(a, b, false));
         assert_eq!(
             paths,
             vec![
@@ -1921,7 +1958,7 @@ mod tests {
             (RelPath::unix(".github").unwrap(), false),
             (RelPath::unix("src").unwrap(), false),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b));
+        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b, false));
         assert_eq!(
             paths,
             vec![
@@ -1942,7 +1979,7 @@ mod tests {
             (RelPath::unix(".github").unwrap(), false),
             (RelPath::unix("src").unwrap(), false),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_files_first(a, b));
+        paths.sort_by(|&a, &b| compare_rel_paths_files_first(a, b, false));
         assert_eq!(
             paths,
             vec![
@@ -1962,7 +1999,7 @@ mod tests {
             (RelPath::unix("file.md").unwrap(), true),
             (RelPath::unix("file.txt").unwrap(), true),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b));
+        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b, false));
         assert_eq!(
             paths,
             vec![
@@ -1981,7 +2018,7 @@ mod tests {
             (RelPath::unix("main.c").unwrap(), true),
             (RelPath::unix("main").unwrap(), false),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_files_first(a, b));
+        paths.sort_by(|&a, &b| compare_rel_paths_files_first(a, b, false));
         assert_eq!(
             paths,
             vec![
@@ -2001,7 +2038,7 @@ mod tests {
             (RelPath::unix("a.txt").unwrap(), true),
             (RelPath::unix("A.txt").unwrap(), true),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b));
+        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b, false));
         assert_eq!(
             paths,
             vec![

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -1111,7 +1111,7 @@ fn stem_and_extension(filename: &str) -> (Option<&str>, Option<&str>) {
 
 /// Controls the lexicographic sorting of file and folder names.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
-pub enum SortOrderLexicographic {
+pub enum SortOrder {
     /// Case-insensitive natural sort with lowercase preferred in ties.
     /// Numbers in file names are compared by value (e.g., `file2` before `file10`).
     #[default]
@@ -1139,20 +1139,20 @@ pub enum SortMode {
     FilesFirst,
 }
 
-fn case_group_key(name: &str, order: SortOrderLexicographic) -> u8 {
+fn case_group_key(name: &str, order: SortOrder) -> u8 {
     let first = match name.chars().next() {
         Some(c) => c,
         None => return 0,
     };
     match order {
-        SortOrderLexicographic::Upper => {
+        SortOrder::Upper => {
             if first.is_lowercase() {
                 1
             } else {
                 0
             }
         }
-        SortOrderLexicographic::Lower => {
+        SortOrder::Lower => {
             if first.is_uppercase() {
                 1
             } else {
@@ -1163,16 +1163,16 @@ fn case_group_key(name: &str, order: SortOrderLexicographic) -> u8 {
     }
 }
 
-fn compare_strings(a: &str, b: &str, order: SortOrderLexicographic) -> Ordering {
+fn compare_strings(a: &str, b: &str, order: SortOrder) -> Ordering {
     match order {
-        SortOrderLexicographic::Unicode => a.cmp(b),
+        SortOrder::Unicode => a.cmp(b),
         _ => natural_sort(a, b),
     }
 }
 
-fn compare_strings_no_tiebreak(a: &str, b: &str, order: SortOrderLexicographic) -> Ordering {
+fn compare_strings_no_tiebreak(a: &str, b: &str, order: SortOrder) -> Ordering {
     match order {
-        SortOrderLexicographic::Unicode => a.cmp(b),
+        SortOrder::Unicode => a.cmp(b),
         _ => natural_sort_no_tiebreak(a, b),
     }
 }
@@ -1185,7 +1185,7 @@ pub fn compare_rel_paths(
         (path_a, a_is_file),
         (path_b, b_is_file),
         SortMode::DirectoriesFirst,
-        SortOrderLexicographic::Default,
+        SortOrder::Default,
     )
 }
 
@@ -1193,7 +1193,7 @@ pub fn compare_rel_paths_by(
     (path_a, a_is_file): (&RelPath, bool),
     (path_b, b_is_file): (&RelPath, bool),
     mode: SortMode,
-    order: SortOrderLexicographic,
+    order: SortOrder,
 ) -> Ordering {
     let needs_final_tiebreak =
         mode != SortMode::DirectoriesFirst && !(std::ptr::eq(path_a, path_b) || path_a == path_b);
@@ -1256,7 +1256,7 @@ pub fn compare_rel_paths_by(
                         name_cmp.then_with(|| {
                             if a_leaf_file && b_leaf_file {
                                 match order {
-                                    SortOrderLexicographic::Unicode => {
+                                    SortOrder::Unicode => {
                                         a_ext.unwrap_or_default().cmp(b_ext.unwrap_or_default())
                                     }
                                     _ => {
@@ -1573,7 +1573,7 @@ mod tests {
     fn sorted_rel_paths(
         mut paths: Vec<(&'static RelPath, bool)>,
         mode: SortMode,
-        order: SortOrderLexicographic,
+        order: SortOrder,
     ) -> Vec<(&'static RelPath, bool)> {
         paths.sort_by(|&a, &b| compare_rel_paths_by(a, b, mode, order));
         paths
@@ -1708,9 +1708,7 @@ mod tests {
             (RelPath::unix("Carrot").unwrap(), false),
             (RelPath::unix("aardvark.txt").unwrap(), true),
         ];
-        paths.sort_by(|&a, &b| {
-            compare_rel_paths_by(a, b, SortMode::Mixed, SortOrderLexicographic::Default)
-        });
+        paths.sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::Mixed, SortOrder::Default));
         // Case-insensitive: aardvark < Apple < banana < Carrot < zebra
         assert_eq!(
             paths,
@@ -1734,9 +1732,8 @@ mod tests {
             (RelPath::unix("Carrot").unwrap(), false),
             (RelPath::unix("aardvark.txt").unwrap(), true),
         ];
-        paths.sort_by(|&a, &b| {
-            compare_rel_paths_by(a, b, SortMode::FilesFirst, SortOrderLexicographic::Default)
-        });
+        paths
+            .sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::FilesFirst, SortOrder::Default));
         // Files first (case-insensitive), then directories (case-insensitive)
         assert_eq!(
             paths,
@@ -1760,9 +1757,8 @@ mod tests {
             (RelPath::unix("carrot").unwrap(), false),
             (RelPath::unix("Aardvark.txt").unwrap(), true),
         ];
-        paths.sort_by(|&a, &b| {
-            compare_rel_paths_by(a, b, SortMode::FilesFirst, SortOrderLexicographic::Default)
-        });
+        paths
+            .sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::FilesFirst, SortOrder::Default));
         assert_eq!(
             paths,
             vec![
@@ -1785,9 +1781,8 @@ mod tests {
             (RelPath::unix("dir10").unwrap(), false),
             (RelPath::unix("file1.txt").unwrap(), true),
         ];
-        paths.sort_by(|&a, &b| {
-            compare_rel_paths_by(a, b, SortMode::FilesFirst, SortOrderLexicographic::Default)
-        });
+        paths
+            .sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::FilesFirst, SortOrder::Default));
         assert_eq!(
             paths,
             vec![
@@ -1808,9 +1803,7 @@ mod tests {
             (RelPath::unix("readme.txt").unwrap(), true),
             (RelPath::unix("ReadMe.rs").unwrap(), true),
         ];
-        paths.sort_by(|&a, &b| {
-            compare_rel_paths_by(a, b, SortMode::Mixed, SortOrderLexicographic::Default)
-        });
+        paths.sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::Mixed, SortOrder::Default));
         // All "readme" variants should group together, sorted by extension
         assert_eq!(
             paths,
@@ -1831,9 +1824,7 @@ mod tests {
             (RelPath::unix("file1.txt").unwrap(), true),
             (RelPath::unix("dir2").unwrap(), false),
         ];
-        paths.sort_by(|&a, &b| {
-            compare_rel_paths_by(a, b, SortMode::Mixed, SortOrderLexicographic::Default)
-        });
+        paths.sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::Mixed, SortOrder::Default));
         // Case-insensitive: dir1, dir2, file1, file2 (all mixed)
         assert_eq!(
             paths,
@@ -1852,9 +1843,7 @@ mod tests {
             (RelPath::unix("Hello.txt").unwrap(), true),
             (RelPath::unix("hello").unwrap(), false),
         ];
-        paths.sort_by(|&a, &b| {
-            compare_rel_paths_by(a, b, SortMode::Mixed, SortOrderLexicographic::Default)
-        });
+        paths.sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::Mixed, SortOrder::Default));
         assert_eq!(
             paths,
             vec![
@@ -1867,9 +1856,7 @@ mod tests {
             (RelPath::unix("hello").unwrap(), false),
             (RelPath::unix("Hello.txt").unwrap(), true),
         ];
-        paths.sort_by(|&a, &b| {
-            compare_rel_paths_by(a, b, SortMode::Mixed, SortOrderLexicographic::Default)
-        });
+        paths.sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::Mixed, SortOrder::Default));
         assert_eq!(
             paths,
             vec![
@@ -1888,9 +1875,7 @@ mod tests {
             (RelPath::unix("src").unwrap(), false),
             (RelPath::unix("target").unwrap(), false),
         ];
-        paths.sort_by(|&a, &b| {
-            compare_rel_paths_by(a, b, SortMode::Mixed, SortOrderLexicographic::Default)
-        });
+        paths.sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::Mixed, SortOrder::Default));
         assert_eq!(
             paths,
             vec![
@@ -1911,9 +1896,8 @@ mod tests {
             (RelPath::unix("src").unwrap(), false),
             (RelPath::unix("tests").unwrap(), false),
         ];
-        paths.sort_by(|&a, &b| {
-            compare_rel_paths_by(a, b, SortMode::FilesFirst, SortOrderLexicographic::Default)
-        });
+        paths
+            .sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::FilesFirst, SortOrder::Default));
         assert_eq!(
             paths,
             vec![
@@ -1934,9 +1918,7 @@ mod tests {
             (RelPath::unix(".github").unwrap(), false),
             (RelPath::unix("src").unwrap(), false),
         ];
-        paths.sort_by(|&a, &b| {
-            compare_rel_paths_by(a, b, SortMode::Mixed, SortOrderLexicographic::Default)
-        });
+        paths.sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::Mixed, SortOrder::Default));
         assert_eq!(
             paths,
             vec![
@@ -1957,9 +1939,8 @@ mod tests {
             (RelPath::unix(".github").unwrap(), false),
             (RelPath::unix("src").unwrap(), false),
         ];
-        paths.sort_by(|&a, &b| {
-            compare_rel_paths_by(a, b, SortMode::FilesFirst, SortOrderLexicographic::Default)
-        });
+        paths
+            .sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::FilesFirst, SortOrder::Default));
         assert_eq!(
             paths,
             vec![
@@ -1979,9 +1960,7 @@ mod tests {
             (RelPath::unix("file.md").unwrap(), true),
             (RelPath::unix("file.txt").unwrap(), true),
         ];
-        paths.sort_by(|&a, &b| {
-            compare_rel_paths_by(a, b, SortMode::Mixed, SortOrderLexicographic::Default)
-        });
+        paths.sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::Mixed, SortOrder::Default));
         assert_eq!(
             paths,
             vec![
@@ -2000,9 +1979,8 @@ mod tests {
             (RelPath::unix("main.c").unwrap(), true),
             (RelPath::unix("main").unwrap(), false),
         ];
-        paths.sort_by(|&a, &b| {
-            compare_rel_paths_by(a, b, SortMode::FilesFirst, SortOrderLexicographic::Default)
-        });
+        paths
+            .sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::FilesFirst, SortOrder::Default));
         assert_eq!(
             paths,
             vec![
@@ -2022,9 +2000,7 @@ mod tests {
             (RelPath::unix("a.txt").unwrap(), true),
             (RelPath::unix("A.txt").unwrap(), true),
         ];
-        paths.sort_by(|&a, &b| {
-            compare_rel_paths_by(a, b, SortMode::Mixed, SortOrderLexicographic::Default)
-        });
+        paths.sort_by(|&a, &b| compare_rel_paths_by(a, b, SortMode::Mixed, SortOrder::Default));
         assert_eq!(
             paths,
             vec![
@@ -2052,7 +2028,7 @@ mod tests {
             sorted_rel_paths(
                 directories_only_paths,
                 SortMode::DirectoriesFirst,
-                SortOrderLexicographic::Upper,
+                SortOrder::Upper,
             ),
             vec![
                 rel_path_entry(".hidden", false),
@@ -2079,7 +2055,7 @@ mod tests {
             sorted_rel_paths(
                 file_and_directory_paths.clone(),
                 SortMode::DirectoriesFirst,
-                SortOrderLexicographic::Upper,
+                SortOrder::Upper,
             ),
             vec![
                 rel_path_entry(".hidden", false),
@@ -2095,7 +2071,7 @@ mod tests {
             sorted_rel_paths(
                 file_and_directory_paths.clone(),
                 SortMode::Mixed,
-                SortOrderLexicographic::Upper,
+                SortOrder::Upper,
             ),
             vec![
                 rel_path_entry(".hidden", false),
@@ -2111,7 +2087,7 @@ mod tests {
             sorted_rel_paths(
                 file_and_directory_paths,
                 SortMode::FilesFirst,
-                SortOrderLexicographic::Upper,
+                SortOrder::Upper,
             ),
             vec![
                 rel_path_entry("Apple.txt", true),
@@ -2131,11 +2107,7 @@ mod tests {
             rel_path_entry("file2.txt", true),
         ];
         assert_eq!(
-            sorted_rel_paths(
-                natural_sort_paths,
-                SortMode::Mixed,
-                SortOrderLexicographic::Upper,
-            ),
+            sorted_rel_paths(natural_sort_paths, SortMode::Mixed, SortOrder::Upper,),
             vec![
                 rel_path_entry("file1.txt", true),
                 rel_path_entry("file2.txt", true),
@@ -2150,11 +2122,7 @@ mod tests {
             rel_path_entry("Apple.txt", true),
         ];
         assert_eq!(
-            sorted_rel_paths(
-                accented_paths,
-                SortMode::Mixed,
-                SortOrderLexicographic::Upper
-            ),
+            sorted_rel_paths(accented_paths, SortMode::Mixed, SortOrder::Upper),
             vec![
                 rel_path_entry("Apple.txt", true),
                 rel_path_entry("\u{00C9}something.txt", true),
@@ -2179,7 +2147,7 @@ mod tests {
             sorted_rel_paths(
                 directories_only_paths,
                 SortMode::DirectoriesFirst,
-                SortOrderLexicographic::Lower,
+                SortOrder::Lower,
             ),
             vec![
                 rel_path_entry(".hidden", false),
@@ -2206,7 +2174,7 @@ mod tests {
             sorted_rel_paths(
                 file_and_directory_paths.clone(),
                 SortMode::DirectoriesFirst,
-                SortOrderLexicographic::Lower,
+                SortOrder::Lower,
             ),
             vec![
                 rel_path_entry(".hidden", false),
@@ -2222,7 +2190,7 @@ mod tests {
             sorted_rel_paths(
                 file_and_directory_paths.clone(),
                 SortMode::Mixed,
-                SortOrderLexicographic::Lower,
+                SortOrder::Lower,
             ),
             vec![
                 rel_path_entry(".hidden", false),
@@ -2238,7 +2206,7 @@ mod tests {
             sorted_rel_paths(
                 file_and_directory_paths,
                 SortMode::FilesFirst,
-                SortOrderLexicographic::Lower,
+                SortOrder::Lower,
             ),
             vec![
                 rel_path_entry("dog.md", true),
@@ -2268,7 +2236,7 @@ mod tests {
             sorted_rel_paths(
                 directories_only_paths,
                 SortMode::DirectoriesFirst,
-                SortOrderLexicographic::Unicode,
+                SortOrder::Unicode,
             ),
             vec![
                 rel_path_entry(".hidden", false),
@@ -2295,7 +2263,7 @@ mod tests {
             sorted_rel_paths(
                 file_and_directory_paths.clone(),
                 SortMode::DirectoriesFirst,
-                SortOrderLexicographic::Unicode,
+                SortOrder::Unicode,
             ),
             vec![
                 rel_path_entry(".hidden", false),
@@ -2311,7 +2279,7 @@ mod tests {
             sorted_rel_paths(
                 file_and_directory_paths.clone(),
                 SortMode::Mixed,
-                SortOrderLexicographic::Unicode,
+                SortOrder::Unicode,
             ),
             vec![
                 rel_path_entry(".hidden", false),
@@ -2327,7 +2295,7 @@ mod tests {
             sorted_rel_paths(
                 file_and_directory_paths,
                 SortMode::FilesFirst,
-                SortOrderLexicographic::Unicode,
+                SortOrder::Unicode,
             ),
             vec![
                 rel_path_entry("Apple.txt", true),
@@ -2347,11 +2315,7 @@ mod tests {
             rel_path_entry("file20.txt", true),
         ];
         assert_eq!(
-            sorted_rel_paths(
-                numeric_paths,
-                SortMode::Mixed,
-                SortOrderLexicographic::Unicode,
-            ),
+            sorted_rel_paths(numeric_paths, SortMode::Mixed, SortOrder::Unicode,),
             vec![
                 rel_path_entry("file1.txt", true),
                 rel_path_entry("file10.txt", true),
@@ -2366,11 +2330,7 @@ mod tests {
             rel_path_entry("Apple.txt", true),
         ];
         assert_eq!(
-            sorted_rel_paths(
-                accented_paths,
-                SortMode::Mixed,
-                SortOrderLexicographic::Unicode
-            ),
+            sorted_rel_paths(accented_paths, SortMode::Mixed, SortOrder::Unicode),
             vec![
                 rel_path_entry("Apple.txt", true),
                 rel_path_entry("zebra.txt", true),

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -1109,10 +1109,77 @@ fn stem_and_extension(filename: &str) -> (Option<&str>, Option<&str>) {
     }
 }
 
+/// Controls the lexicographic sorting of file and folder names.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub enum SortOrderLexicographic {
+    /// Case-insensitive natural sort with lowercase preferred in ties.
+    /// Numbers in file names are compared by value (e.g., `file2` before `file10`).
+    #[default]
+    Default,
+    /// Uppercase names are grouped before lowercase names, with case-insensitive
+    /// natural sort within each group. Dot-prefixed names sort before both groups.
+    Upper,
+    /// Lowercase names are grouped before uppercase names, with case-insensitive
+    /// natural sort within each group. Dot-prefixed names sort before both groups.
+    Lower,
+    /// Pure Unicode codepoint comparison. No case folding, no natural number sorting.
+    /// Uppercase ASCII sorts before lowercase. Accented characters sort after ASCII.
+    Unicode,
+}
+
+fn case_group_key(name: &str, order: SortOrderLexicographic) -> u8 {
+    let first = match name.chars().next() {
+        Some(c) => c,
+        None => return 0,
+    };
+    match order {
+        SortOrderLexicographic::Upper => {
+            if first.is_lowercase() {
+                1
+            } else {
+                0
+            }
+        }
+        SortOrderLexicographic::Lower => {
+            if first.is_uppercase() {
+                1
+            } else {
+                0
+            }
+        }
+        _ => 0,
+    }
+}
+
+fn compare_strings(a: &str, b: &str, order: SortOrderLexicographic) -> Ordering {
+    match order {
+        SortOrderLexicographic::Unicode => a.cmp(b),
+        _ => natural_sort(a, b),
+    }
+}
+
+fn compare_strings_no_tiebreak(a: &str, b: &str, order: SortOrderLexicographic) -> Ordering {
+    match order {
+        SortOrderLexicographic::Unicode => a.cmp(b),
+        _ => natural_sort_no_tiebreak(a, b),
+    }
+}
+
 pub fn compare_rel_paths(
     (path_a, a_is_file): (&RelPath, bool),
     (path_b, b_is_file): (&RelPath, bool),
-    case_sensitive: bool,
+) -> Ordering {
+    compare_rel_paths_with_sort_order(
+        (path_a, a_is_file),
+        (path_b, b_is_file),
+        SortOrderLexicographic::Default,
+    )
+}
+
+pub fn compare_rel_paths_with_sort_order(
+    (path_a, a_is_file): (&RelPath, bool),
+    (path_b, b_is_file): (&RelPath, bool),
+    order: SortOrderLexicographic,
 ) -> Ordering {
     let mut components_a = path_a.components();
     let mut components_b = path_b.components();
@@ -1134,13 +1201,9 @@ pub fn compare_rel_paths(
                     let path_string_b = if b_is_file { b_stem } else { Some(component_b) };
 
                     let compare_components = match (path_string_a, path_string_b) {
-                        (Some(a), Some(b)) => {
-                            if case_sensitive {
-                                a.cmp(&b)
-                            } else {
-                                natural_sort(&a, &b)
-                            }
-                        }
+                        (Some(a), Some(b)) => case_group_key(a, order)
+                            .cmp(&case_group_key(b, order))
+                            .then_with(|| compare_strings(a, b, order)),
                         (Some(_), None) => Ordering::Greater,
                         (None, Some(_)) => Ordering::Less,
                         (None, None) => Ordering::Equal,
@@ -1175,7 +1238,18 @@ pub fn compare_rel_paths(
 pub fn compare_rel_paths_mixed(
     (path_a, a_is_file): (&RelPath, bool),
     (path_b, b_is_file): (&RelPath, bool),
-    case_sensitive: bool,
+) -> Ordering {
+    compare_rel_paths_mixed_with_sort_order(
+        (path_a, a_is_file),
+        (path_b, b_is_file),
+        SortOrderLexicographic::Default,
+    )
+}
+
+pub fn compare_rel_paths_mixed_with_sort_order(
+    (path_a, a_is_file): (&RelPath, bool),
+    (path_b, b_is_file): (&RelPath, bool),
+    order: SortOrderLexicographic,
 ) -> Ordering {
     let original_paths_equal = std::ptr::eq(path_a, path_b) || path_a == path_b;
     let mut components_a = path_a.components();
@@ -1205,33 +1279,30 @@ pub fn compare_rel_paths_mixed(
                 };
 
                 let ordering = match (a_key, b_key) {
-                    (Some(a), Some(b)) => {
-                        let base_cmp = if case_sensitive {
-                            a.cmp(b)
-                        } else {
-                            natural_sort_no_tiebreak(a, b)
-                        };
-
-                        base_cmp
-                            .then_with(|| match (a_leaf_file, b_leaf_file) {
-                                (true, false) if a.eq_ignore_ascii_case(b) => Ordering::Greater,
-                                (false, true) if a.eq_ignore_ascii_case(b) => Ordering::Less,
-                                _ => Ordering::Equal,
-                            })
-                            .then_with(|| {
-                                if a_leaf_file && b_leaf_file {
-                                    if case_sensitive {
+                    (Some(a), Some(b)) => case_group_key(a, order)
+                        .cmp(&case_group_key(b, order))
+                        .then_with(|| compare_strings_no_tiebreak(a, b, order))
+                        .then_with(|| match (a_leaf_file, b_leaf_file) {
+                            (true, false) if a.eq_ignore_ascii_case(b) => Ordering::Greater,
+                            (false, true) if a.eq_ignore_ascii_case(b) => Ordering::Less,
+                            _ => Ordering::Equal,
+                        })
+                        .then_with(|| {
+                            if a_leaf_file && b_leaf_file {
+                                match order {
+                                    SortOrderLexicographic::Unicode => {
                                         b_ext.unwrap_or_default().cmp(a_ext.unwrap_or_default())
-                                    } else {
+                                    }
+                                    _ => {
                                         let a_ext_str = a_ext.unwrap_or_default().to_lowercase();
                                         let b_ext_str = b_ext.unwrap_or_default().to_lowercase();
                                         b_ext_str.cmp(&a_ext_str)
                                     }
-                                } else {
-                                    Ordering::Equal
                                 }
-                            })
-                    }
+                            } else {
+                                Ordering::Equal
+                            }
+                        }),
                     (Some(_), None) => Ordering::Greater,
                     (None, Some(_)) => Ordering::Less,
                     (None, None) => Ordering::Equal,
@@ -1244,13 +1315,8 @@ pub fn compare_rel_paths_mixed(
             (Some(_), None) => return Ordering::Greater,
             (None, Some(_)) => return Ordering::Less,
             (None, None) => {
-                // Deterministic tie-break
                 if !original_paths_equal {
-                    return if case_sensitive {
-                        path_a.as_unix_str().cmp(path_b.as_unix_str())
-                    } else {
-                        natural_sort(path_a.as_unix_str(), path_b.as_unix_str())
-                    }
+                    return compare_strings(path_a.as_unix_str(), path_b.as_unix_str(), order);
                 }
                 return Ordering::Equal;
             }
@@ -1265,7 +1331,18 @@ pub fn compare_rel_paths_mixed(
 pub fn compare_rel_paths_files_first(
     (path_a, a_is_file): (&RelPath, bool),
     (path_b, b_is_file): (&RelPath, bool),
-    case_sensitive: bool,
+) -> Ordering {
+    compare_rel_paths_files_first_with_sort_order(
+        (path_a, a_is_file),
+        (path_b, b_is_file),
+        SortOrderLexicographic::Default,
+    )
+}
+
+pub fn compare_rel_paths_files_first_with_sort_order(
+    (path_a, a_is_file): (&RelPath, bool),
+    (path_b, b_is_file): (&RelPath, bool),
+    order: SortOrderLexicographic,
 ) -> Ordering {
     let original_paths_equal = std::ptr::eq(path_a, path_b) || path_a == path_b;
     let mut components_a = path_a.components();
@@ -1301,25 +1378,27 @@ pub fn compare_rel_paths_files_first(
                         } else if !a_leaf_file && b_leaf_file {
                             Ordering::Greater
                         } else {
-                            let base_cmp = if case_sensitive {
-                                a.cmp(b)
-                            } else {
-                                natural_sort_no_tiebreak(a, b)
-                            };
-
-                            base_cmp.then_with(|| {
-                                if a_leaf_file && b_leaf_file {
-                                    if case_sensitive {
-                                        a_ext.unwrap_or_default().cmp(b_ext.unwrap_or_default())
+                            case_group_key(a, order)
+                                .cmp(&case_group_key(b, order))
+                                .then_with(|| compare_strings_no_tiebreak(a, b, order))
+                                .then_with(|| {
+                                    if a_leaf_file && b_leaf_file {
+                                        match order {
+                                            SortOrderLexicographic::Unicode => a_ext
+                                                .unwrap_or_default()
+                                                .cmp(b_ext.unwrap_or_default()),
+                                            _ => {
+                                                let a_ext_str =
+                                                    a_ext.unwrap_or_default().to_lowercase();
+                                                let b_ext_str =
+                                                    b_ext.unwrap_or_default().to_lowercase();
+                                                a_ext_str.cmp(&b_ext_str)
+                                            }
+                                        }
                                     } else {
-                                        let a_ext_str = a_ext.unwrap_or_default().to_lowercase();
-                                        let b_ext_str = b_ext.unwrap_or_default().to_lowercase();
-                                        a_ext_str.cmp(&b_ext_str)
+                                        Ordering::Equal
                                     }
-                                } else {
-                                    Ordering::Equal
-                                }
-                            })
+                                })
                         }
                     }
                     (Some(_), None) => Ordering::Greater,
@@ -1334,13 +1413,8 @@ pub fn compare_rel_paths_files_first(
             (Some(_), None) => return Ordering::Greater,
             (None, Some(_)) => return Ordering::Less,
             (None, None) => {
-                // Deterministic tie-break
                 if !original_paths_equal {
-                    return if case_sensitive {
-                        path_a.as_unix_str().cmp(path_b.as_unix_str())
-                    } else {
-                        natural_sort(path_a.as_unix_str(), path_b.as_unix_str())
-                    }
+                    return compare_strings(path_a.as_unix_str(), path_b.as_unix_str(), order);
                 }
                 return Ordering::Equal;
             }
@@ -1752,7 +1826,7 @@ mod tests {
             (RelPath::unix("Carrot").unwrap(), false),
             (RelPath::unix("aardvark.txt").unwrap(), true),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b, false));
+        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b));
         // Case-insensitive: aardvark < Apple < banana < Carrot < zebra
         assert_eq!(
             paths,
@@ -1776,7 +1850,7 @@ mod tests {
             (RelPath::unix("Carrot").unwrap(), false),
             (RelPath::unix("aardvark.txt").unwrap(), true),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_files_first(a, b, false));
+        paths.sort_by(|&a, &b| compare_rel_paths_files_first(a, b));
         // Files first (case-insensitive), then directories (case-insensitive)
         assert_eq!(
             paths,
@@ -1800,7 +1874,7 @@ mod tests {
             (RelPath::unix("carrot").unwrap(), false),
             (RelPath::unix("Aardvark.txt").unwrap(), true),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_files_first(a, b, false));
+        paths.sort_by(|&a, &b| compare_rel_paths_files_first(a, b));
         assert_eq!(
             paths,
             vec![
@@ -1823,7 +1897,7 @@ mod tests {
             (RelPath::unix("dir10").unwrap(), false),
             (RelPath::unix("file1.txt").unwrap(), true),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_files_first(a, b, false));
+        paths.sort_by(|&a, &b| compare_rel_paths_files_first(a, b));
         assert_eq!(
             paths,
             vec![
@@ -1844,7 +1918,7 @@ mod tests {
             (RelPath::unix("readme.txt").unwrap(), true),
             (RelPath::unix("ReadMe.rs").unwrap(), true),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b, false));
+        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b));
         // All "readme" variants should group together, sorted by extension
         assert_eq!(
             paths,
@@ -1865,7 +1939,7 @@ mod tests {
             (RelPath::unix("file1.txt").unwrap(), true),
             (RelPath::unix("dir2").unwrap(), false),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b, false));
+        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b));
         // Case-insensitive: dir1, dir2, file1, file2 (all mixed)
         assert_eq!(
             paths,
@@ -1884,7 +1958,7 @@ mod tests {
             (RelPath::unix("Hello.txt").unwrap(), true),
             (RelPath::unix("hello").unwrap(), false),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b, false));
+        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b));
         assert_eq!(
             paths,
             vec![
@@ -1897,7 +1971,7 @@ mod tests {
             (RelPath::unix("hello").unwrap(), false),
             (RelPath::unix("Hello.txt").unwrap(), true),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b, false));
+        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b));
         assert_eq!(
             paths,
             vec![
@@ -1916,7 +1990,7 @@ mod tests {
             (RelPath::unix("src").unwrap(), false),
             (RelPath::unix("target").unwrap(), false),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b, false));
+        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b));
         assert_eq!(
             paths,
             vec![
@@ -1937,7 +2011,7 @@ mod tests {
             (RelPath::unix("src").unwrap(), false),
             (RelPath::unix("tests").unwrap(), false),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_files_first(a, b, false));
+        paths.sort_by(|&a, &b| compare_rel_paths_files_first(a, b));
         assert_eq!(
             paths,
             vec![
@@ -1958,7 +2032,7 @@ mod tests {
             (RelPath::unix(".github").unwrap(), false),
             (RelPath::unix("src").unwrap(), false),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b, false));
+        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b));
         assert_eq!(
             paths,
             vec![
@@ -1979,7 +2053,7 @@ mod tests {
             (RelPath::unix(".github").unwrap(), false),
             (RelPath::unix("src").unwrap(), false),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_files_first(a, b, false));
+        paths.sort_by(|&a, &b| compare_rel_paths_files_first(a, b));
         assert_eq!(
             paths,
             vec![
@@ -1999,7 +2073,7 @@ mod tests {
             (RelPath::unix("file.md").unwrap(), true),
             (RelPath::unix("file.txt").unwrap(), true),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b, false));
+        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b));
         assert_eq!(
             paths,
             vec![
@@ -2018,7 +2092,7 @@ mod tests {
             (RelPath::unix("main.c").unwrap(), true),
             (RelPath::unix("main").unwrap(), false),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_files_first(a, b, false));
+        paths.sort_by(|&a, &b| compare_rel_paths_files_first(a, b));
         assert_eq!(
             paths,
             vec![
@@ -2038,7 +2112,7 @@ mod tests {
             (RelPath::unix("a.txt").unwrap(), true),
             (RelPath::unix("A.txt").unwrap(), true),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b, false));
+        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b));
         assert_eq!(
             paths,
             vec![
@@ -2046,6 +2120,351 @@ mod tests {
                 (RelPath::unix("A/B.txt").unwrap(), true),
                 (RelPath::unix("a.txt").unwrap(), true),
                 (RelPath::unix("A.txt").unwrap(), true),
+            ]
+        );
+    }
+
+    #[perf]
+    fn compare_rel_paths_upper_directories_first() {
+        let mut paths = vec![
+            (RelPath::unix("mixedCase").unwrap(), false),
+            (RelPath::unix("Zebra").unwrap(), false),
+            (RelPath::unix("banana").unwrap(), false),
+            (RelPath::unix("ALLCAPS").unwrap(), false),
+            (RelPath::unix("Apple").unwrap(), false),
+            (RelPath::unix("dog").unwrap(), false),
+            (RelPath::unix(".hidden").unwrap(), false),
+            (RelPath::unix("Carrot").unwrap(), false),
+        ];
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_with_sort_order(a, b, SortOrderLexicographic::Upper)
+        });
+        assert_eq!(
+            paths,
+            vec![
+                (RelPath::unix(".hidden").unwrap(), false),
+                (RelPath::unix("ALLCAPS").unwrap(), false),
+                (RelPath::unix("Apple").unwrap(), false),
+                (RelPath::unix("Carrot").unwrap(), false),
+                (RelPath::unix("Zebra").unwrap(), false),
+                (RelPath::unix("banana").unwrap(), false),
+                (RelPath::unix("dog").unwrap(), false),
+                (RelPath::unix("mixedCase").unwrap(), false),
+            ]
+        );
+    }
+
+    #[perf]
+    fn compare_rel_paths_upper_mixed() {
+        let mut paths = vec![
+            (RelPath::unix("banana").unwrap(), false),
+            (RelPath::unix("Apple.txt").unwrap(), true),
+            (RelPath::unix("dog.md").unwrap(), true),
+            (RelPath::unix("ALLCAPS").unwrap(), false),
+            (RelPath::unix("file1.txt").unwrap(), true),
+            (RelPath::unix("File2.txt").unwrap(), true),
+            (RelPath::unix(".hidden").unwrap(), false),
+        ];
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_mixed_with_sort_order(a, b, SortOrderLexicographic::Upper)
+        });
+        assert_eq!(
+            paths,
+            vec![
+                (RelPath::unix(".hidden").unwrap(), false),
+                (RelPath::unix("ALLCAPS").unwrap(), false),
+                (RelPath::unix("Apple.txt").unwrap(), true),
+                (RelPath::unix("File2.txt").unwrap(), true),
+                (RelPath::unix("banana").unwrap(), false),
+                (RelPath::unix("dog.md").unwrap(), true),
+                (RelPath::unix("file1.txt").unwrap(), true),
+            ]
+        );
+    }
+
+    #[perf]
+    fn compare_rel_paths_upper_files_first() {
+        let mut paths = vec![
+            (RelPath::unix("banana").unwrap(), false),
+            (RelPath::unix("Apple.txt").unwrap(), true),
+            (RelPath::unix("dog.md").unwrap(), true),
+            (RelPath::unix("ALLCAPS").unwrap(), false),
+            (RelPath::unix("file1.txt").unwrap(), true),
+            (RelPath::unix("File2.txt").unwrap(), true),
+            (RelPath::unix(".hidden").unwrap(), false),
+        ];
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_files_first_with_sort_order(a, b, SortOrderLexicographic::Upper)
+        });
+        assert_eq!(
+            paths,
+            vec![
+                (RelPath::unix("Apple.txt").unwrap(), true),
+                (RelPath::unix("File2.txt").unwrap(), true),
+                (RelPath::unix("dog.md").unwrap(), true),
+                (RelPath::unix("file1.txt").unwrap(), true),
+                (RelPath::unix(".hidden").unwrap(), false),
+                (RelPath::unix("ALLCAPS").unwrap(), false),
+                (RelPath::unix("banana").unwrap(), false),
+            ]
+        );
+    }
+
+    #[perf]
+    fn compare_rel_paths_upper_preserves_natural_sort() {
+        let mut paths = vec![
+            (RelPath::unix("file10.txt").unwrap(), true),
+            (RelPath::unix("file1.txt").unwrap(), true),
+            (RelPath::unix("file20.txt").unwrap(), true),
+            (RelPath::unix("file2.txt").unwrap(), true),
+        ];
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_mixed_with_sort_order(a, b, SortOrderLexicographic::Upper)
+        });
+        assert_eq!(
+            paths,
+            vec![
+                (RelPath::unix("file1.txt").unwrap(), true),
+                (RelPath::unix("file2.txt").unwrap(), true),
+                (RelPath::unix("file10.txt").unwrap(), true),
+                (RelPath::unix("file20.txt").unwrap(), true),
+            ]
+        );
+    }
+
+    #[perf]
+    fn compare_rel_paths_lower_directories_first() {
+        let mut paths = vec![
+            (RelPath::unix("mixedCase").unwrap(), false),
+            (RelPath::unix("Zebra").unwrap(), false),
+            (RelPath::unix("banana").unwrap(), false),
+            (RelPath::unix("ALLCAPS").unwrap(), false),
+            (RelPath::unix("Apple").unwrap(), false),
+            (RelPath::unix("dog").unwrap(), false),
+            (RelPath::unix(".hidden").unwrap(), false),
+            (RelPath::unix("Carrot").unwrap(), false),
+        ];
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_with_sort_order(a, b, SortOrderLexicographic::Lower)
+        });
+        assert_eq!(
+            paths,
+            vec![
+                (RelPath::unix(".hidden").unwrap(), false),
+                (RelPath::unix("banana").unwrap(), false),
+                (RelPath::unix("dog").unwrap(), false),
+                (RelPath::unix("mixedCase").unwrap(), false),
+                (RelPath::unix("ALLCAPS").unwrap(), false),
+                (RelPath::unix("Apple").unwrap(), false),
+                (RelPath::unix("Carrot").unwrap(), false),
+                (RelPath::unix("Zebra").unwrap(), false),
+            ]
+        );
+    }
+
+    #[perf]
+    fn compare_rel_paths_lower_mixed() {
+        let mut paths = vec![
+            (RelPath::unix("banana").unwrap(), false),
+            (RelPath::unix("Apple.txt").unwrap(), true),
+            (RelPath::unix("dog.md").unwrap(), true),
+            (RelPath::unix("ALLCAPS").unwrap(), false),
+            (RelPath::unix("file1.txt").unwrap(), true),
+            (RelPath::unix("File2.txt").unwrap(), true),
+            (RelPath::unix(".hidden").unwrap(), false),
+        ];
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_mixed_with_sort_order(a, b, SortOrderLexicographic::Lower)
+        });
+        assert_eq!(
+            paths,
+            vec![
+                (RelPath::unix(".hidden").unwrap(), false),
+                (RelPath::unix("banana").unwrap(), false),
+                (RelPath::unix("dog.md").unwrap(), true),
+                (RelPath::unix("file1.txt").unwrap(), true),
+                (RelPath::unix("ALLCAPS").unwrap(), false),
+                (RelPath::unix("Apple.txt").unwrap(), true),
+                (RelPath::unix("File2.txt").unwrap(), true),
+            ]
+        );
+    }
+
+    #[perf]
+    fn compare_rel_paths_lower_files_first() {
+        let mut paths = vec![
+            (RelPath::unix("banana").unwrap(), false),
+            (RelPath::unix("Apple.txt").unwrap(), true),
+            (RelPath::unix("dog.md").unwrap(), true),
+            (RelPath::unix("ALLCAPS").unwrap(), false),
+            (RelPath::unix("file1.txt").unwrap(), true),
+            (RelPath::unix("File2.txt").unwrap(), true),
+            (RelPath::unix(".hidden").unwrap(), false),
+        ];
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_files_first_with_sort_order(a, b, SortOrderLexicographic::Lower)
+        });
+        assert_eq!(
+            paths,
+            vec![
+                (RelPath::unix("dog.md").unwrap(), true),
+                (RelPath::unix("file1.txt").unwrap(), true),
+                (RelPath::unix("Apple.txt").unwrap(), true),
+                (RelPath::unix("File2.txt").unwrap(), true),
+                (RelPath::unix(".hidden").unwrap(), false),
+                (RelPath::unix("banana").unwrap(), false),
+                (RelPath::unix("ALLCAPS").unwrap(), false),
+            ]
+        );
+    }
+
+    #[perf]
+    fn compare_rel_paths_unicode_directories_first() {
+        let mut paths = vec![
+            (RelPath::unix("mixedCase").unwrap(), false),
+            (RelPath::unix("Zebra").unwrap(), false),
+            (RelPath::unix("banana").unwrap(), false),
+            (RelPath::unix("ALLCAPS").unwrap(), false),
+            (RelPath::unix("Apple").unwrap(), false),
+            (RelPath::unix("dog").unwrap(), false),
+            (RelPath::unix(".hidden").unwrap(), false),
+            (RelPath::unix("Carrot").unwrap(), false),
+        ];
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_with_sort_order(a, b, SortOrderLexicographic::Unicode)
+        });
+        assert_eq!(
+            paths,
+            vec![
+                (RelPath::unix(".hidden").unwrap(), false),
+                (RelPath::unix("ALLCAPS").unwrap(), false),
+                (RelPath::unix("Apple").unwrap(), false),
+                (RelPath::unix("Carrot").unwrap(), false),
+                (RelPath::unix("Zebra").unwrap(), false),
+                (RelPath::unix("banana").unwrap(), false),
+                (RelPath::unix("dog").unwrap(), false),
+                (RelPath::unix("mixedCase").unwrap(), false),
+            ]
+        );
+    }
+
+    #[perf]
+    fn compare_rel_paths_unicode_no_natural_numbers() {
+        let mut paths = vec![
+            (RelPath::unix("file10.txt").unwrap(), true),
+            (RelPath::unix("file1.txt").unwrap(), true),
+            (RelPath::unix("file2.txt").unwrap(), true),
+            (RelPath::unix("file20.txt").unwrap(), true),
+        ];
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_mixed_with_sort_order(a, b, SortOrderLexicographic::Unicode)
+        });
+        // Unicode/lexicographic: '1' < '1'+'0' (prefix) < '2' < '2'+'0' (prefix)
+        assert_eq!(
+            paths,
+            vec![
+                (RelPath::unix("file1.txt").unwrap(), true),
+                (RelPath::unix("file10.txt").unwrap(), true),
+                (RelPath::unix("file2.txt").unwrap(), true),
+                (RelPath::unix("file20.txt").unwrap(), true),
+            ]
+        );
+    }
+
+    #[perf]
+    fn compare_rel_paths_unicode_mixed() {
+        let mut paths = vec![
+            (RelPath::unix("banana").unwrap(), false),
+            (RelPath::unix("Apple.txt").unwrap(), true),
+            (RelPath::unix("dog.md").unwrap(), true),
+            (RelPath::unix("ALLCAPS").unwrap(), false),
+            (RelPath::unix("file1.txt").unwrap(), true),
+            (RelPath::unix("File2.txt").unwrap(), true),
+            (RelPath::unix(".hidden").unwrap(), false),
+        ];
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_mixed_with_sort_order(a, b, SortOrderLexicographic::Unicode)
+        });
+        assert_eq!(
+            paths,
+            vec![
+                (RelPath::unix(".hidden").unwrap(), false),
+                (RelPath::unix("ALLCAPS").unwrap(), false),
+                (RelPath::unix("Apple.txt").unwrap(), true),
+                (RelPath::unix("File2.txt").unwrap(), true),
+                (RelPath::unix("banana").unwrap(), false),
+                (RelPath::unix("dog.md").unwrap(), true),
+                (RelPath::unix("file1.txt").unwrap(), true),
+            ]
+        );
+    }
+
+    #[perf]
+    fn compare_rel_paths_unicode_files_first() {
+        let mut paths = vec![
+            (RelPath::unix("banana").unwrap(), false),
+            (RelPath::unix("Apple.txt").unwrap(), true),
+            (RelPath::unix("dog.md").unwrap(), true),
+            (RelPath::unix("ALLCAPS").unwrap(), false),
+            (RelPath::unix("file1.txt").unwrap(), true),
+            (RelPath::unix("File2.txt").unwrap(), true),
+            (RelPath::unix(".hidden").unwrap(), false),
+        ];
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_files_first_with_sort_order(a, b, SortOrderLexicographic::Unicode)
+        });
+        assert_eq!(
+            paths,
+            vec![
+                (RelPath::unix("Apple.txt").unwrap(), true),
+                (RelPath::unix("File2.txt").unwrap(), true),
+                (RelPath::unix("dog.md").unwrap(), true),
+                (RelPath::unix("file1.txt").unwrap(), true),
+                (RelPath::unix(".hidden").unwrap(), false),
+                (RelPath::unix("ALLCAPS").unwrap(), false),
+                (RelPath::unix("banana").unwrap(), false),
+            ]
+        );
+    }
+
+    #[perf]
+    fn compare_rel_paths_unicode_accented_sorts_after_ascii() {
+        let mut paths = vec![
+            (RelPath::unix("\u{00C9}something.txt").unwrap(), true),
+            (RelPath::unix("zebra.txt").unwrap(), true),
+            (RelPath::unix("Apple.txt").unwrap(), true),
+        ];
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_mixed_with_sort_order(a, b, SortOrderLexicographic::Unicode)
+        });
+        // É (U+00C9 = 201) sorts after all ASCII
+        assert_eq!(
+            paths,
+            vec![
+                (RelPath::unix("Apple.txt").unwrap(), true),
+                (RelPath::unix("zebra.txt").unwrap(), true),
+                (RelPath::unix("\u{00C9}something.txt").unwrap(), true),
+            ]
+        );
+    }
+
+    #[perf]
+    fn compare_rel_paths_upper_accented_groups_with_uppercase() {
+        let mut paths = vec![
+            (RelPath::unix("\u{00C9}something.txt").unwrap(), true),
+            (RelPath::unix("zebra.txt").unwrap(), true),
+            (RelPath::unix("Apple.txt").unwrap(), true),
+        ];
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_mixed_with_sort_order(a, b, SortOrderLexicographic::Upper)
+        });
+        // É is uppercase, so it groups with uppercase names before lowercase
+        assert_eq!(
+            paths,
+            vec![
+                (RelPath::unix("Apple.txt").unwrap(), true),
+                (RelPath::unix("\u{00C9}something.txt").unwrap(), true),
+                (RelPath::unix("zebra.txt").unwrap(), true),
             ]
         );
     }

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -1566,6 +1566,19 @@ mod tests {
     use super::*;
     use util_macros::perf;
 
+    fn rel_path_entry(path: &'static str, is_file: bool) -> (&'static RelPath, bool) {
+        (RelPath::unix(path).unwrap(), is_file)
+    }
+
+    fn sorted_rel_paths(
+        mut paths: Vec<(&'static RelPath, bool)>,
+        mode: SortMode,
+        order: SortOrderLexicographic,
+    ) -> Vec<(&'static RelPath, bool)> {
+        paths.sort_by(|&a, &b| compare_rel_paths_by(a, b, mode, order));
+        paths
+    }
+
     #[perf]
     fn compare_paths_with_dots() {
         let mut paths = vec![
@@ -2024,361 +2037,344 @@ mod tests {
     }
 
     #[perf]
-    fn compare_rel_paths_upper_directories_first() {
-        let mut paths = vec![
-            (RelPath::unix("mixedCase").unwrap(), false),
-            (RelPath::unix("Zebra").unwrap(), false),
-            (RelPath::unix("banana").unwrap(), false),
-            (RelPath::unix("ALLCAPS").unwrap(), false),
-            (RelPath::unix("Apple").unwrap(), false),
-            (RelPath::unix("dog").unwrap(), false),
-            (RelPath::unix(".hidden").unwrap(), false),
-            (RelPath::unix("Carrot").unwrap(), false),
+    fn compare_rel_paths_upper() {
+        let directories_only_paths = vec![
+            rel_path_entry("mixedCase", false),
+            rel_path_entry("Zebra", false),
+            rel_path_entry("banana", false),
+            rel_path_entry("ALLCAPS", false),
+            rel_path_entry("Apple", false),
+            rel_path_entry("dog", false),
+            rel_path_entry(".hidden", false),
+            rel_path_entry("Carrot", false),
         ];
-        paths.sort_by(|&a, &b| {
-            compare_rel_paths_by(
-                a,
-                b,
+        assert_eq!(
+            sorted_rel_paths(
+                directories_only_paths,
                 SortMode::DirectoriesFirst,
                 SortOrderLexicographic::Upper,
-            )
-        });
-        assert_eq!(
-            paths,
+            ),
             vec![
-                (RelPath::unix(".hidden").unwrap(), false),
-                (RelPath::unix("ALLCAPS").unwrap(), false),
-                (RelPath::unix("Apple").unwrap(), false),
-                (RelPath::unix("Carrot").unwrap(), false),
-                (RelPath::unix("Zebra").unwrap(), false),
-                (RelPath::unix("banana").unwrap(), false),
-                (RelPath::unix("dog").unwrap(), false),
-                (RelPath::unix("mixedCase").unwrap(), false),
+                rel_path_entry(".hidden", false),
+                rel_path_entry("ALLCAPS", false),
+                rel_path_entry("Apple", false),
+                rel_path_entry("Carrot", false),
+                rel_path_entry("Zebra", false),
+                rel_path_entry("banana", false),
+                rel_path_entry("dog", false),
+                rel_path_entry("mixedCase", false),
+            ]
+        );
+
+        let file_and_directory_paths = vec![
+            rel_path_entry("banana", false),
+            rel_path_entry("Apple.txt", true),
+            rel_path_entry("dog.md", true),
+            rel_path_entry("ALLCAPS", false),
+            rel_path_entry("file1.txt", true),
+            rel_path_entry("File2.txt", true),
+            rel_path_entry(".hidden", false),
+        ];
+        assert_eq!(
+            sorted_rel_paths(
+                file_and_directory_paths.clone(),
+                SortMode::DirectoriesFirst,
+                SortOrderLexicographic::Upper,
+            ),
+            vec![
+                rel_path_entry(".hidden", false),
+                rel_path_entry("ALLCAPS", false),
+                rel_path_entry("banana", false),
+                rel_path_entry("Apple.txt", true),
+                rel_path_entry("File2.txt", true),
+                rel_path_entry("dog.md", true),
+                rel_path_entry("file1.txt", true),
+            ]
+        );
+        assert_eq!(
+            sorted_rel_paths(
+                file_and_directory_paths.clone(),
+                SortMode::Mixed,
+                SortOrderLexicographic::Upper,
+            ),
+            vec![
+                rel_path_entry(".hidden", false),
+                rel_path_entry("ALLCAPS", false),
+                rel_path_entry("Apple.txt", true),
+                rel_path_entry("File2.txt", true),
+                rel_path_entry("banana", false),
+                rel_path_entry("dog.md", true),
+                rel_path_entry("file1.txt", true),
+            ]
+        );
+        assert_eq!(
+            sorted_rel_paths(
+                file_and_directory_paths,
+                SortMode::FilesFirst,
+                SortOrderLexicographic::Upper,
+            ),
+            vec![
+                rel_path_entry("Apple.txt", true),
+                rel_path_entry("File2.txt", true),
+                rel_path_entry("dog.md", true),
+                rel_path_entry("file1.txt", true),
+                rel_path_entry(".hidden", false),
+                rel_path_entry("ALLCAPS", false),
+                rel_path_entry("banana", false),
+            ]
+        );
+
+        let natural_sort_paths = vec![
+            rel_path_entry("file10.txt", true),
+            rel_path_entry("file1.txt", true),
+            rel_path_entry("file20.txt", true),
+            rel_path_entry("file2.txt", true),
+        ];
+        assert_eq!(
+            sorted_rel_paths(
+                natural_sort_paths,
+                SortMode::Mixed,
+                SortOrderLexicographic::Upper,
+            ),
+            vec![
+                rel_path_entry("file1.txt", true),
+                rel_path_entry("file2.txt", true),
+                rel_path_entry("file10.txt", true),
+                rel_path_entry("file20.txt", true),
+            ]
+        );
+
+        let accented_paths = vec![
+            rel_path_entry("\u{00C9}something.txt", true),
+            rel_path_entry("zebra.txt", true),
+            rel_path_entry("Apple.txt", true),
+        ];
+        assert_eq!(
+            sorted_rel_paths(
+                accented_paths,
+                SortMode::Mixed,
+                SortOrderLexicographic::Upper
+            ),
+            vec![
+                rel_path_entry("Apple.txt", true),
+                rel_path_entry("\u{00C9}something.txt", true),
+                rel_path_entry("zebra.txt", true),
             ]
         );
     }
 
     #[perf]
-    fn compare_rel_paths_upper_mixed() {
-        let mut paths = vec![
-            (RelPath::unix("banana").unwrap(), false),
-            (RelPath::unix("Apple.txt").unwrap(), true),
-            (RelPath::unix("dog.md").unwrap(), true),
-            (RelPath::unix("ALLCAPS").unwrap(), false),
-            (RelPath::unix("file1.txt").unwrap(), true),
-            (RelPath::unix("File2.txt").unwrap(), true),
-            (RelPath::unix(".hidden").unwrap(), false),
+    fn compare_rel_paths_lower() {
+        let directories_only_paths = vec![
+            rel_path_entry("mixedCase", false),
+            rel_path_entry("Zebra", false),
+            rel_path_entry("banana", false),
+            rel_path_entry("ALLCAPS", false),
+            rel_path_entry("Apple", false),
+            rel_path_entry("dog", false),
+            rel_path_entry(".hidden", false),
+            rel_path_entry("Carrot", false),
         ];
-        paths.sort_by(|&a, &b| {
-            compare_rel_paths_by(a, b, SortMode::Mixed, SortOrderLexicographic::Upper)
-        });
         assert_eq!(
-            paths,
-            vec![
-                (RelPath::unix(".hidden").unwrap(), false),
-                (RelPath::unix("ALLCAPS").unwrap(), false),
-                (RelPath::unix("Apple.txt").unwrap(), true),
-                (RelPath::unix("File2.txt").unwrap(), true),
-                (RelPath::unix("banana").unwrap(), false),
-                (RelPath::unix("dog.md").unwrap(), true),
-                (RelPath::unix("file1.txt").unwrap(), true),
-            ]
-        );
-    }
-
-    #[perf]
-    fn compare_rel_paths_upper_files_first() {
-        let mut paths = vec![
-            (RelPath::unix("banana").unwrap(), false),
-            (RelPath::unix("Apple.txt").unwrap(), true),
-            (RelPath::unix("dog.md").unwrap(), true),
-            (RelPath::unix("ALLCAPS").unwrap(), false),
-            (RelPath::unix("file1.txt").unwrap(), true),
-            (RelPath::unix("File2.txt").unwrap(), true),
-            (RelPath::unix(".hidden").unwrap(), false),
-        ];
-        paths.sort_by(|&a, &b| {
-            compare_rel_paths_by(a, b, SortMode::FilesFirst, SortOrderLexicographic::Upper)
-        });
-        assert_eq!(
-            paths,
-            vec![
-                (RelPath::unix("Apple.txt").unwrap(), true),
-                (RelPath::unix("File2.txt").unwrap(), true),
-                (RelPath::unix("dog.md").unwrap(), true),
-                (RelPath::unix("file1.txt").unwrap(), true),
-                (RelPath::unix(".hidden").unwrap(), false),
-                (RelPath::unix("ALLCAPS").unwrap(), false),
-                (RelPath::unix("banana").unwrap(), false),
-            ]
-        );
-    }
-
-    #[perf]
-    fn compare_rel_paths_upper_preserves_natural_sort() {
-        let mut paths = vec![
-            (RelPath::unix("file10.txt").unwrap(), true),
-            (RelPath::unix("file1.txt").unwrap(), true),
-            (RelPath::unix("file20.txt").unwrap(), true),
-            (RelPath::unix("file2.txt").unwrap(), true),
-        ];
-        paths.sort_by(|&a, &b| {
-            compare_rel_paths_by(a, b, SortMode::Mixed, SortOrderLexicographic::Upper)
-        });
-        assert_eq!(
-            paths,
-            vec![
-                (RelPath::unix("file1.txt").unwrap(), true),
-                (RelPath::unix("file2.txt").unwrap(), true),
-                (RelPath::unix("file10.txt").unwrap(), true),
-                (RelPath::unix("file20.txt").unwrap(), true),
-            ]
-        );
-    }
-
-    #[perf]
-    fn compare_rel_paths_lower_directories_first() {
-        let mut paths = vec![
-            (RelPath::unix("mixedCase").unwrap(), false),
-            (RelPath::unix("Zebra").unwrap(), false),
-            (RelPath::unix("banana").unwrap(), false),
-            (RelPath::unix("ALLCAPS").unwrap(), false),
-            (RelPath::unix("Apple").unwrap(), false),
-            (RelPath::unix("dog").unwrap(), false),
-            (RelPath::unix(".hidden").unwrap(), false),
-            (RelPath::unix("Carrot").unwrap(), false),
-        ];
-        paths.sort_by(|&a, &b| {
-            compare_rel_paths_by(
-                a,
-                b,
+            sorted_rel_paths(
+                directories_only_paths,
                 SortMode::DirectoriesFirst,
                 SortOrderLexicographic::Lower,
-            )
-        });
-        assert_eq!(
-            paths,
+            ),
             vec![
-                (RelPath::unix(".hidden").unwrap(), false),
-                (RelPath::unix("banana").unwrap(), false),
-                (RelPath::unix("dog").unwrap(), false),
-                (RelPath::unix("mixedCase").unwrap(), false),
-                (RelPath::unix("ALLCAPS").unwrap(), false),
-                (RelPath::unix("Apple").unwrap(), false),
-                (RelPath::unix("Carrot").unwrap(), false),
-                (RelPath::unix("Zebra").unwrap(), false),
+                rel_path_entry(".hidden", false),
+                rel_path_entry("banana", false),
+                rel_path_entry("dog", false),
+                rel_path_entry("mixedCase", false),
+                rel_path_entry("ALLCAPS", false),
+                rel_path_entry("Apple", false),
+                rel_path_entry("Carrot", false),
+                rel_path_entry("Zebra", false),
+            ]
+        );
+
+        let file_and_directory_paths = vec![
+            rel_path_entry("banana", false),
+            rel_path_entry("Apple.txt", true),
+            rel_path_entry("dog.md", true),
+            rel_path_entry("ALLCAPS", false),
+            rel_path_entry("file1.txt", true),
+            rel_path_entry("File2.txt", true),
+            rel_path_entry(".hidden", false),
+        ];
+        assert_eq!(
+            sorted_rel_paths(
+                file_and_directory_paths.clone(),
+                SortMode::DirectoriesFirst,
+                SortOrderLexicographic::Lower,
+            ),
+            vec![
+                rel_path_entry(".hidden", false),
+                rel_path_entry("banana", false),
+                rel_path_entry("ALLCAPS", false),
+                rel_path_entry("dog.md", true),
+                rel_path_entry("file1.txt", true),
+                rel_path_entry("Apple.txt", true),
+                rel_path_entry("File2.txt", true),
+            ]
+        );
+        assert_eq!(
+            sorted_rel_paths(
+                file_and_directory_paths.clone(),
+                SortMode::Mixed,
+                SortOrderLexicographic::Lower,
+            ),
+            vec![
+                rel_path_entry(".hidden", false),
+                rel_path_entry("banana", false),
+                rel_path_entry("dog.md", true),
+                rel_path_entry("file1.txt", true),
+                rel_path_entry("ALLCAPS", false),
+                rel_path_entry("Apple.txt", true),
+                rel_path_entry("File2.txt", true),
+            ]
+        );
+        assert_eq!(
+            sorted_rel_paths(
+                file_and_directory_paths,
+                SortMode::FilesFirst,
+                SortOrderLexicographic::Lower,
+            ),
+            vec![
+                rel_path_entry("dog.md", true),
+                rel_path_entry("file1.txt", true),
+                rel_path_entry("Apple.txt", true),
+                rel_path_entry("File2.txt", true),
+                rel_path_entry(".hidden", false),
+                rel_path_entry("banana", false),
+                rel_path_entry("ALLCAPS", false),
             ]
         );
     }
 
     #[perf]
-    fn compare_rel_paths_lower_mixed() {
-        let mut paths = vec![
-            (RelPath::unix("banana").unwrap(), false),
-            (RelPath::unix("Apple.txt").unwrap(), true),
-            (RelPath::unix("dog.md").unwrap(), true),
-            (RelPath::unix("ALLCAPS").unwrap(), false),
-            (RelPath::unix("file1.txt").unwrap(), true),
-            (RelPath::unix("File2.txt").unwrap(), true),
-            (RelPath::unix(".hidden").unwrap(), false),
+    fn compare_rel_paths_unicode() {
+        let directories_only_paths = vec![
+            rel_path_entry("mixedCase", false),
+            rel_path_entry("Zebra", false),
+            rel_path_entry("banana", false),
+            rel_path_entry("ALLCAPS", false),
+            rel_path_entry("Apple", false),
+            rel_path_entry("dog", false),
+            rel_path_entry(".hidden", false),
+            rel_path_entry("Carrot", false),
         ];
-        paths.sort_by(|&a, &b| {
-            compare_rel_paths_by(a, b, SortMode::Mixed, SortOrderLexicographic::Lower)
-        });
         assert_eq!(
-            paths,
-            vec![
-                (RelPath::unix(".hidden").unwrap(), false),
-                (RelPath::unix("banana").unwrap(), false),
-                (RelPath::unix("dog.md").unwrap(), true),
-                (RelPath::unix("file1.txt").unwrap(), true),
-                (RelPath::unix("ALLCAPS").unwrap(), false),
-                (RelPath::unix("Apple.txt").unwrap(), true),
-                (RelPath::unix("File2.txt").unwrap(), true),
-            ]
-        );
-    }
-
-    #[perf]
-    fn compare_rel_paths_lower_files_first() {
-        let mut paths = vec![
-            (RelPath::unix("banana").unwrap(), false),
-            (RelPath::unix("Apple.txt").unwrap(), true),
-            (RelPath::unix("dog.md").unwrap(), true),
-            (RelPath::unix("ALLCAPS").unwrap(), false),
-            (RelPath::unix("file1.txt").unwrap(), true),
-            (RelPath::unix("File2.txt").unwrap(), true),
-            (RelPath::unix(".hidden").unwrap(), false),
-        ];
-        paths.sort_by(|&a, &b| {
-            compare_rel_paths_by(a, b, SortMode::FilesFirst, SortOrderLexicographic::Lower)
-        });
-        assert_eq!(
-            paths,
-            vec![
-                (RelPath::unix("dog.md").unwrap(), true),
-                (RelPath::unix("file1.txt").unwrap(), true),
-                (RelPath::unix("Apple.txt").unwrap(), true),
-                (RelPath::unix("File2.txt").unwrap(), true),
-                (RelPath::unix(".hidden").unwrap(), false),
-                (RelPath::unix("banana").unwrap(), false),
-                (RelPath::unix("ALLCAPS").unwrap(), false),
-            ]
-        );
-    }
-
-    #[perf]
-    fn compare_rel_paths_unicode_directories_first() {
-        let mut paths = vec![
-            (RelPath::unix("mixedCase").unwrap(), false),
-            (RelPath::unix("Zebra").unwrap(), false),
-            (RelPath::unix("banana").unwrap(), false),
-            (RelPath::unix("ALLCAPS").unwrap(), false),
-            (RelPath::unix("Apple").unwrap(), false),
-            (RelPath::unix("dog").unwrap(), false),
-            (RelPath::unix(".hidden").unwrap(), false),
-            (RelPath::unix("Carrot").unwrap(), false),
-        ];
-        paths.sort_by(|&a, &b| {
-            compare_rel_paths_by(
-                a,
-                b,
+            sorted_rel_paths(
+                directories_only_paths,
                 SortMode::DirectoriesFirst,
                 SortOrderLexicographic::Unicode,
-            )
-        });
-        assert_eq!(
-            paths,
+            ),
             vec![
-                (RelPath::unix(".hidden").unwrap(), false),
-                (RelPath::unix("ALLCAPS").unwrap(), false),
-                (RelPath::unix("Apple").unwrap(), false),
-                (RelPath::unix("Carrot").unwrap(), false),
-                (RelPath::unix("Zebra").unwrap(), false),
-                (RelPath::unix("banana").unwrap(), false),
-                (RelPath::unix("dog").unwrap(), false),
-                (RelPath::unix("mixedCase").unwrap(), false),
+                rel_path_entry(".hidden", false),
+                rel_path_entry("ALLCAPS", false),
+                rel_path_entry("Apple", false),
+                rel_path_entry("Carrot", false),
+                rel_path_entry("Zebra", false),
+                rel_path_entry("banana", false),
+                rel_path_entry("dog", false),
+                rel_path_entry("mixedCase", false),
             ]
         );
-    }
 
-    #[perf]
-    fn compare_rel_paths_unicode_no_natural_numbers() {
-        let mut paths = vec![
-            (RelPath::unix("file10.txt").unwrap(), true),
-            (RelPath::unix("file1.txt").unwrap(), true),
-            (RelPath::unix("file2.txt").unwrap(), true),
-            (RelPath::unix("file20.txt").unwrap(), true),
+        let file_and_directory_paths = vec![
+            rel_path_entry("banana", false),
+            rel_path_entry("Apple.txt", true),
+            rel_path_entry("dog.md", true),
+            rel_path_entry("ALLCAPS", false),
+            rel_path_entry("file1.txt", true),
+            rel_path_entry("File2.txt", true),
+            rel_path_entry(".hidden", false),
         ];
-        paths.sort_by(|&a, &b| {
-            compare_rel_paths_by(a, b, SortMode::Mixed, SortOrderLexicographic::Unicode)
-        });
-        // Unicode/lexicographic: '1' < '1'+'0' (prefix) < '2' < '2'+'0' (prefix)
         assert_eq!(
-            paths,
+            sorted_rel_paths(
+                file_and_directory_paths.clone(),
+                SortMode::DirectoriesFirst,
+                SortOrderLexicographic::Unicode,
+            ),
             vec![
-                (RelPath::unix("file1.txt").unwrap(), true),
-                (RelPath::unix("file10.txt").unwrap(), true),
-                (RelPath::unix("file2.txt").unwrap(), true),
-                (RelPath::unix("file20.txt").unwrap(), true),
+                rel_path_entry(".hidden", false),
+                rel_path_entry("ALLCAPS", false),
+                rel_path_entry("banana", false),
+                rel_path_entry("Apple.txt", true),
+                rel_path_entry("File2.txt", true),
+                rel_path_entry("dog.md", true),
+                rel_path_entry("file1.txt", true),
             ]
         );
-    }
-
-    #[perf]
-    fn compare_rel_paths_unicode_mixed() {
-        let mut paths = vec![
-            (RelPath::unix("banana").unwrap(), false),
-            (RelPath::unix("Apple.txt").unwrap(), true),
-            (RelPath::unix("dog.md").unwrap(), true),
-            (RelPath::unix("ALLCAPS").unwrap(), false),
-            (RelPath::unix("file1.txt").unwrap(), true),
-            (RelPath::unix("File2.txt").unwrap(), true),
-            (RelPath::unix(".hidden").unwrap(), false),
-        ];
-        paths.sort_by(|&a, &b| {
-            compare_rel_paths_by(a, b, SortMode::Mixed, SortOrderLexicographic::Unicode)
-        });
         assert_eq!(
-            paths,
+            sorted_rel_paths(
+                file_and_directory_paths.clone(),
+                SortMode::Mixed,
+                SortOrderLexicographic::Unicode,
+            ),
             vec![
-                (RelPath::unix(".hidden").unwrap(), false),
-                (RelPath::unix("ALLCAPS").unwrap(), false),
-                (RelPath::unix("Apple.txt").unwrap(), true),
-                (RelPath::unix("File2.txt").unwrap(), true),
-                (RelPath::unix("banana").unwrap(), false),
-                (RelPath::unix("dog.md").unwrap(), true),
-                (RelPath::unix("file1.txt").unwrap(), true),
+                rel_path_entry(".hidden", false),
+                rel_path_entry("ALLCAPS", false),
+                rel_path_entry("Apple.txt", true),
+                rel_path_entry("File2.txt", true),
+                rel_path_entry("banana", false),
+                rel_path_entry("dog.md", true),
+                rel_path_entry("file1.txt", true),
             ]
         );
-    }
-
-    #[perf]
-    fn compare_rel_paths_unicode_files_first() {
-        let mut paths = vec![
-            (RelPath::unix("banana").unwrap(), false),
-            (RelPath::unix("Apple.txt").unwrap(), true),
-            (RelPath::unix("dog.md").unwrap(), true),
-            (RelPath::unix("ALLCAPS").unwrap(), false),
-            (RelPath::unix("file1.txt").unwrap(), true),
-            (RelPath::unix("File2.txt").unwrap(), true),
-            (RelPath::unix(".hidden").unwrap(), false),
-        ];
-        paths.sort_by(|&a, &b| {
-            compare_rel_paths_by(a, b, SortMode::FilesFirst, SortOrderLexicographic::Unicode)
-        });
         assert_eq!(
-            paths,
+            sorted_rel_paths(
+                file_and_directory_paths,
+                SortMode::FilesFirst,
+                SortOrderLexicographic::Unicode,
+            ),
             vec![
-                (RelPath::unix("Apple.txt").unwrap(), true),
-                (RelPath::unix("File2.txt").unwrap(), true),
-                (RelPath::unix("dog.md").unwrap(), true),
-                (RelPath::unix("file1.txt").unwrap(), true),
-                (RelPath::unix(".hidden").unwrap(), false),
-                (RelPath::unix("ALLCAPS").unwrap(), false),
-                (RelPath::unix("banana").unwrap(), false),
+                rel_path_entry("Apple.txt", true),
+                rel_path_entry("File2.txt", true),
+                rel_path_entry("dog.md", true),
+                rel_path_entry("file1.txt", true),
+                rel_path_entry(".hidden", false),
+                rel_path_entry("ALLCAPS", false),
+                rel_path_entry("banana", false),
             ]
         );
-    }
 
-    #[perf]
-    fn compare_rel_paths_unicode_accented_sorts_after_ascii() {
-        let mut paths = vec![
-            (RelPath::unix("\u{00C9}something.txt").unwrap(), true),
-            (RelPath::unix("zebra.txt").unwrap(), true),
-            (RelPath::unix("Apple.txt").unwrap(), true),
+        let numeric_paths = vec![
+            rel_path_entry("file10.txt", true),
+            rel_path_entry("file1.txt", true),
+            rel_path_entry("file2.txt", true),
+            rel_path_entry("file20.txt", true),
         ];
-        paths.sort_by(|&a, &b| {
-            compare_rel_paths_by(a, b, SortMode::Mixed, SortOrderLexicographic::Unicode)
-        });
-        // É (U+00C9 = 201) sorts after all ASCII
         assert_eq!(
-            paths,
+            sorted_rel_paths(
+                numeric_paths,
+                SortMode::Mixed,
+                SortOrderLexicographic::Unicode,
+            ),
             vec![
-                (RelPath::unix("Apple.txt").unwrap(), true),
-                (RelPath::unix("zebra.txt").unwrap(), true),
-                (RelPath::unix("\u{00C9}something.txt").unwrap(), true),
+                rel_path_entry("file1.txt", true),
+                rel_path_entry("file10.txt", true),
+                rel_path_entry("file2.txt", true),
+                rel_path_entry("file20.txt", true),
             ]
         );
-    }
 
-    #[perf]
-    fn compare_rel_paths_upper_accented_groups_with_uppercase() {
-        let mut paths = vec![
-            (RelPath::unix("\u{00C9}something.txt").unwrap(), true),
-            (RelPath::unix("zebra.txt").unwrap(), true),
-            (RelPath::unix("Apple.txt").unwrap(), true),
+        let accented_paths = vec![
+            rel_path_entry("\u{00C9}something.txt", true),
+            rel_path_entry("zebra.txt", true),
+            rel_path_entry("Apple.txt", true),
         ];
-        paths.sort_by(|&a, &b| {
-            compare_rel_paths_by(a, b, SortMode::Mixed, SortOrderLexicographic::Upper)
-        });
-        // É is uppercase, so it groups with uppercase names before lowercase
         assert_eq!(
-            paths,
+            sorted_rel_paths(
+                accented_paths,
+                SortMode::Mixed,
+                SortOrderLexicographic::Unicode
+            ),
             vec![
-                (RelPath::unix("Apple.txt").unwrap(), true),
-                (RelPath::unix("\u{00C9}something.txt").unwrap(), true),
-                (RelPath::unix("zebra.txt").unwrap(), true),
+                rel_path_entry("Apple.txt", true),
+                rel_path_entry("zebra.txt", true),
+                rel_path_entry("\u{00C9}something.txt", true),
             ]
         );
     }

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -1127,6 +1127,18 @@ pub enum SortOrderLexicographic {
     Unicode,
 }
 
+/// Controls how files and directories are ordered relative to each other.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub enum SortMode {
+    /// Directories are listed before files at each level.
+    #[default]
+    DirectoriesFirst,
+    /// Files and directories are interleaved alphabetically.
+    Mixed,
+    /// Files are listed before directories at each level.
+    FilesFirst,
+}
+
 fn case_group_key(name: &str, order: SortOrderLexicographic) -> u8 {
     let first = match name.chars().next() {
         Some(c) => c,
@@ -1169,89 +1181,23 @@ pub fn compare_rel_paths(
     (path_a, a_is_file): (&RelPath, bool),
     (path_b, b_is_file): (&RelPath, bool),
 ) -> Ordering {
-    compare_rel_paths_with_sort_order(
+    compare_rel_paths_by(
         (path_a, a_is_file),
         (path_b, b_is_file),
+        SortMode::DirectoriesFirst,
         SortOrderLexicographic::Default,
     )
 }
 
-pub fn compare_rel_paths_with_sort_order(
+pub fn compare_rel_paths_by(
     (path_a, a_is_file): (&RelPath, bool),
     (path_b, b_is_file): (&RelPath, bool),
+    mode: SortMode,
     order: SortOrderLexicographic,
 ) -> Ordering {
-    let mut components_a = path_a.components();
-    let mut components_b = path_b.components();
-    loop {
-        match (components_a.next(), components_b.next()) {
-            (Some(component_a), Some(component_b)) => {
-                let a_is_file = a_is_file && components_a.rest().is_empty();
-                let b_is_file = b_is_file && components_b.rest().is_empty();
+    let needs_final_tiebreak =
+        mode != SortMode::DirectoriesFirst && !(std::ptr::eq(path_a, path_b) || path_a == path_b);
 
-                let ordering = a_is_file.cmp(&b_is_file).then_with(|| {
-                    let (a_stem, a_extension) = a_is_file
-                        .then(|| stem_and_extension(component_a))
-                        .unwrap_or_default();
-                    let path_string_a = if a_is_file { a_stem } else { Some(component_a) };
-
-                    let (b_stem, b_extension) = b_is_file
-                        .then(|| stem_and_extension(component_b))
-                        .unwrap_or_default();
-                    let path_string_b = if b_is_file { b_stem } else { Some(component_b) };
-
-                    let compare_components = match (path_string_a, path_string_b) {
-                        (Some(a), Some(b)) => case_group_key(a, order)
-                            .cmp(&case_group_key(b, order))
-                            .then_with(|| compare_strings(a, b, order)),
-                        (Some(_), None) => Ordering::Greater,
-                        (None, Some(_)) => Ordering::Less,
-                        (None, None) => Ordering::Equal,
-                    };
-
-                    compare_components.then_with(|| {
-                        if a_is_file && b_is_file {
-                            let ext_a = a_extension.unwrap_or_default();
-                            let ext_b = b_extension.unwrap_or_default();
-                            ext_a.cmp(ext_b)
-                        } else {
-                            Ordering::Equal
-                        }
-                    })
-                });
-
-                if !ordering.is_eq() {
-                    return ordering;
-                }
-            }
-            (Some(_), None) => break Ordering::Greater,
-            (None, Some(_)) => break Ordering::Less,
-            (None, None) => break Ordering::Equal,
-        }
-    }
-}
-
-/// Compare two relative paths with mixed files and directories using
-/// case-insensitive natural sorting. For example, "Apple", "aardvark.txt",
-/// and "Zebra" would be sorted as: aardvark.txt, Apple, Zebra
-/// (case-insensitive alphabetical).
-pub fn compare_rel_paths_mixed(
-    (path_a, a_is_file): (&RelPath, bool),
-    (path_b, b_is_file): (&RelPath, bool),
-) -> Ordering {
-    compare_rel_paths_mixed_with_sort_order(
-        (path_a, a_is_file),
-        (path_b, b_is_file),
-        SortOrderLexicographic::Default,
-    )
-}
-
-pub fn compare_rel_paths_mixed_with_sort_order(
-    (path_a, a_is_file): (&RelPath, bool),
-    (path_b, b_is_file): (&RelPath, bool),
-    order: SortOrderLexicographic,
-) -> Ordering {
-    let original_paths_equal = std::ptr::eq(path_a, path_b) || path_a == path_b;
     let mut components_a = path_a.components();
     let mut components_b = path_b.components();
 
@@ -1261,98 +1207,15 @@ pub fn compare_rel_paths_mixed_with_sort_order(
                 let a_leaf_file = a_is_file && components_a.rest().is_empty();
                 let b_leaf_file = b_is_file && components_b.rest().is_empty();
 
-                let (a_stem, a_ext) = a_leaf_file
-                    .then(|| stem_and_extension(component_a))
-                    .unwrap_or_default();
-                let (b_stem, b_ext) = b_leaf_file
-                    .then(|| stem_and_extension(component_b))
-                    .unwrap_or_default();
-                let a_key = if a_leaf_file {
-                    a_stem
-                } else {
-                    Some(component_a)
-                };
-                let b_key = if b_leaf_file {
-                    b_stem
-                } else {
-                    Some(component_b)
+                let file_dir_ordering = match mode {
+                    SortMode::DirectoriesFirst => a_leaf_file.cmp(&b_leaf_file),
+                    SortMode::FilesFirst => b_leaf_file.cmp(&a_leaf_file),
+                    SortMode::Mixed => Ordering::Equal,
                 };
 
-                let ordering = match (a_key, b_key) {
-                    (Some(a), Some(b)) => case_group_key(a, order)
-                        .cmp(&case_group_key(b, order))
-                        .then_with(|| compare_strings_no_tiebreak(a, b, order))
-                        .then_with(|| match (a_leaf_file, b_leaf_file) {
-                            (true, false) if a.eq_ignore_ascii_case(b) => Ordering::Greater,
-                            (false, true) if a.eq_ignore_ascii_case(b) => Ordering::Less,
-                            _ => Ordering::Equal,
-                        })
-                        .then_with(|| {
-                            if a_leaf_file && b_leaf_file {
-                                match order {
-                                    SortOrderLexicographic::Unicode => {
-                                        a_ext.unwrap_or_default().cmp(b_ext.unwrap_or_default())
-                                    }
-                                    _ => {
-                                        let a_ext_str = a_ext.unwrap_or_default().to_lowercase();
-                                        let b_ext_str = b_ext.unwrap_or_default().to_lowercase();
-                                        a_ext_str.cmp(&b_ext_str)
-                                    }
-                                }
-                            } else {
-                                Ordering::Equal
-                            }
-                        }),
-                    (Some(_), None) => Ordering::Greater,
-                    (None, Some(_)) => Ordering::Less,
-                    (None, None) => Ordering::Equal,
-                };
-
-                if !ordering.is_eq() {
-                    return ordering;
+                if !file_dir_ordering.is_eq() {
+                    return file_dir_ordering;
                 }
-            }
-            (Some(_), None) => return Ordering::Greater,
-            (None, Some(_)) => return Ordering::Less,
-            (None, None) => {
-                if !original_paths_equal {
-                    return compare_strings(path_a.as_unix_str(), path_b.as_unix_str(), order);
-                }
-                return Ordering::Equal;
-            }
-        }
-    }
-}
-
-/// Compare two relative paths with files before directories using
-/// case-insensitive natural sorting. At each directory level, all files
-/// are sorted before all directories, with case-insensitive alphabetical
-/// ordering within each group.
-pub fn compare_rel_paths_files_first(
-    (path_a, a_is_file): (&RelPath, bool),
-    (path_b, b_is_file): (&RelPath, bool),
-) -> Ordering {
-    compare_rel_paths_files_first_with_sort_order(
-        (path_a, a_is_file),
-        (path_b, b_is_file),
-        SortOrderLexicographic::Default,
-    )
-}
-
-pub fn compare_rel_paths_files_first_with_sort_order(
-    (path_a, a_is_file): (&RelPath, bool),
-    (path_b, b_is_file): (&RelPath, bool),
-    order: SortOrderLexicographic,
-) -> Ordering {
-    let original_paths_equal = std::ptr::eq(path_a, path_b) || path_a == path_b;
-    let mut components_a = path_a.components();
-    let mut components_b = path_b.components();
-
-    loop {
-        match (components_a.next(), components_b.next()) {
-            (Some(component_a), Some(component_b)) => {
-                let a_leaf_file = a_is_file && components_a.rest().is_empty();
-                let b_leaf_file = b_is_file && components_b.rest().is_empty();
 
                 let (a_stem, a_ext) = a_leaf_file
                     .then(|| stem_and_extension(component_a))
@@ -1373,33 +1236,39 @@ pub fn compare_rel_paths_files_first_with_sort_order(
 
                 let ordering = match (a_key, b_key) {
                     (Some(a), Some(b)) => {
-                        if a_leaf_file && !b_leaf_file {
-                            Ordering::Less
-                        } else if !a_leaf_file && b_leaf_file {
-                            Ordering::Greater
+                        let name_cmp = case_group_key(a, order)
+                            .cmp(&case_group_key(b, order))
+                            .then_with(|| match mode {
+                                SortMode::DirectoriesFirst => compare_strings(a, b, order),
+                                _ => compare_strings_no_tiebreak(a, b, order),
+                            });
+
+                        let name_cmp = if mode == SortMode::Mixed {
+                            name_cmp.then_with(|| match (a_leaf_file, b_leaf_file) {
+                                (true, false) if a.eq_ignore_ascii_case(b) => Ordering::Greater,
+                                (false, true) if a.eq_ignore_ascii_case(b) => Ordering::Less,
+                                _ => Ordering::Equal,
+                            })
                         } else {
-                            case_group_key(a, order)
-                                .cmp(&case_group_key(b, order))
-                                .then_with(|| compare_strings_no_tiebreak(a, b, order))
-                                .then_with(|| {
-                                    if a_leaf_file && b_leaf_file {
-                                        match order {
-                                            SortOrderLexicographic::Unicode => a_ext
-                                                .unwrap_or_default()
-                                                .cmp(b_ext.unwrap_or_default()),
-                                            _ => {
-                                                let a_ext_str =
-                                                    a_ext.unwrap_or_default().to_lowercase();
-                                                let b_ext_str =
-                                                    b_ext.unwrap_or_default().to_lowercase();
-                                                a_ext_str.cmp(&b_ext_str)
-                                            }
-                                        }
-                                    } else {
-                                        Ordering::Equal
+                            name_cmp
+                        };
+
+                        name_cmp.then_with(|| {
+                            if a_leaf_file && b_leaf_file {
+                                match order {
+                                    SortOrderLexicographic::Unicode => {
+                                        a_ext.unwrap_or_default().cmp(b_ext.unwrap_or_default())
                                     }
-                                })
-                        }
+                                    _ => {
+                                        let a_ext_str = a_ext.unwrap_or_default().to_lowercase();
+                                        let b_ext_str = b_ext.unwrap_or_default().to_lowercase();
+                                        a_ext_str.cmp(&b_ext_str)
+                                    }
+                                }
+                            } else {
+                                Ordering::Equal
+                            }
+                        })
                     }
                     (Some(_), None) => Ordering::Greater,
                     (None, Some(_)) => Ordering::Less,
@@ -1413,7 +1282,7 @@ pub fn compare_rel_paths_files_first_with_sort_order(
             (Some(_), None) => return Ordering::Greater,
             (None, Some(_)) => return Ordering::Less,
             (None, None) => {
-                if !original_paths_equal {
+                if needs_final_tiebreak {
                     return compare_strings(path_a.as_unix_str(), path_b.as_unix_str(), order);
                 }
                 return Ordering::Equal;
@@ -1826,7 +1695,9 @@ mod tests {
             (RelPath::unix("Carrot").unwrap(), false),
             (RelPath::unix("aardvark.txt").unwrap(), true),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(a, b, SortMode::Mixed, SortOrderLexicographic::Default)
+        });
         // Case-insensitive: aardvark < Apple < banana < Carrot < zebra
         assert_eq!(
             paths,
@@ -1850,7 +1721,9 @@ mod tests {
             (RelPath::unix("Carrot").unwrap(), false),
             (RelPath::unix("aardvark.txt").unwrap(), true),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_files_first(a, b));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(a, b, SortMode::FilesFirst, SortOrderLexicographic::Default)
+        });
         // Files first (case-insensitive), then directories (case-insensitive)
         assert_eq!(
             paths,
@@ -1874,7 +1747,9 @@ mod tests {
             (RelPath::unix("carrot").unwrap(), false),
             (RelPath::unix("Aardvark.txt").unwrap(), true),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_files_first(a, b));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(a, b, SortMode::FilesFirst, SortOrderLexicographic::Default)
+        });
         assert_eq!(
             paths,
             vec![
@@ -1897,7 +1772,9 @@ mod tests {
             (RelPath::unix("dir10").unwrap(), false),
             (RelPath::unix("file1.txt").unwrap(), true),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_files_first(a, b));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(a, b, SortMode::FilesFirst, SortOrderLexicographic::Default)
+        });
         assert_eq!(
             paths,
             vec![
@@ -1918,7 +1795,9 @@ mod tests {
             (RelPath::unix("readme.txt").unwrap(), true),
             (RelPath::unix("ReadMe.rs").unwrap(), true),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(a, b, SortMode::Mixed, SortOrderLexicographic::Default)
+        });
         // All "readme" variants should group together, sorted by extension
         assert_eq!(
             paths,
@@ -1939,7 +1818,9 @@ mod tests {
             (RelPath::unix("file1.txt").unwrap(), true),
             (RelPath::unix("dir2").unwrap(), false),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(a, b, SortMode::Mixed, SortOrderLexicographic::Default)
+        });
         // Case-insensitive: dir1, dir2, file1, file2 (all mixed)
         assert_eq!(
             paths,
@@ -1958,7 +1839,9 @@ mod tests {
             (RelPath::unix("Hello.txt").unwrap(), true),
             (RelPath::unix("hello").unwrap(), false),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(a, b, SortMode::Mixed, SortOrderLexicographic::Default)
+        });
         assert_eq!(
             paths,
             vec![
@@ -1971,7 +1854,9 @@ mod tests {
             (RelPath::unix("hello").unwrap(), false),
             (RelPath::unix("Hello.txt").unwrap(), true),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(a, b, SortMode::Mixed, SortOrderLexicographic::Default)
+        });
         assert_eq!(
             paths,
             vec![
@@ -1990,7 +1875,9 @@ mod tests {
             (RelPath::unix("src").unwrap(), false),
             (RelPath::unix("target").unwrap(), false),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(a, b, SortMode::Mixed, SortOrderLexicographic::Default)
+        });
         assert_eq!(
             paths,
             vec![
@@ -2011,7 +1898,9 @@ mod tests {
             (RelPath::unix("src").unwrap(), false),
             (RelPath::unix("tests").unwrap(), false),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_files_first(a, b));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(a, b, SortMode::FilesFirst, SortOrderLexicographic::Default)
+        });
         assert_eq!(
             paths,
             vec![
@@ -2032,7 +1921,9 @@ mod tests {
             (RelPath::unix(".github").unwrap(), false),
             (RelPath::unix("src").unwrap(), false),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(a, b, SortMode::Mixed, SortOrderLexicographic::Default)
+        });
         assert_eq!(
             paths,
             vec![
@@ -2053,7 +1944,9 @@ mod tests {
             (RelPath::unix(".github").unwrap(), false),
             (RelPath::unix("src").unwrap(), false),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_files_first(a, b));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(a, b, SortMode::FilesFirst, SortOrderLexicographic::Default)
+        });
         assert_eq!(
             paths,
             vec![
@@ -2073,7 +1966,9 @@ mod tests {
             (RelPath::unix("file.md").unwrap(), true),
             (RelPath::unix("file.txt").unwrap(), true),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(a, b, SortMode::Mixed, SortOrderLexicographic::Default)
+        });
         assert_eq!(
             paths,
             vec![
@@ -2092,7 +1987,9 @@ mod tests {
             (RelPath::unix("main.c").unwrap(), true),
             (RelPath::unix("main").unwrap(), false),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_files_first(a, b));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(a, b, SortMode::FilesFirst, SortOrderLexicographic::Default)
+        });
         assert_eq!(
             paths,
             vec![
@@ -2112,7 +2009,9 @@ mod tests {
             (RelPath::unix("a.txt").unwrap(), true),
             (RelPath::unix("A.txt").unwrap(), true),
         ];
-        paths.sort_by(|&a, &b| compare_rel_paths_mixed(a, b));
+        paths.sort_by(|&a, &b| {
+            compare_rel_paths_by(a, b, SortMode::Mixed, SortOrderLexicographic::Default)
+        });
         assert_eq!(
             paths,
             vec![
@@ -2137,7 +2036,12 @@ mod tests {
             (RelPath::unix("Carrot").unwrap(), false),
         ];
         paths.sort_by(|&a, &b| {
-            compare_rel_paths_with_sort_order(a, b, SortOrderLexicographic::Upper)
+            compare_rel_paths_by(
+                a,
+                b,
+                SortMode::DirectoriesFirst,
+                SortOrderLexicographic::Upper,
+            )
         });
         assert_eq!(
             paths,
@@ -2166,7 +2070,7 @@ mod tests {
             (RelPath::unix(".hidden").unwrap(), false),
         ];
         paths.sort_by(|&a, &b| {
-            compare_rel_paths_mixed_with_sort_order(a, b, SortOrderLexicographic::Upper)
+            compare_rel_paths_by(a, b, SortMode::Mixed, SortOrderLexicographic::Upper)
         });
         assert_eq!(
             paths,
@@ -2194,7 +2098,7 @@ mod tests {
             (RelPath::unix(".hidden").unwrap(), false),
         ];
         paths.sort_by(|&a, &b| {
-            compare_rel_paths_files_first_with_sort_order(a, b, SortOrderLexicographic::Upper)
+            compare_rel_paths_by(a, b, SortMode::FilesFirst, SortOrderLexicographic::Upper)
         });
         assert_eq!(
             paths,
@@ -2219,7 +2123,7 @@ mod tests {
             (RelPath::unix("file2.txt").unwrap(), true),
         ];
         paths.sort_by(|&a, &b| {
-            compare_rel_paths_mixed_with_sort_order(a, b, SortOrderLexicographic::Upper)
+            compare_rel_paths_by(a, b, SortMode::Mixed, SortOrderLexicographic::Upper)
         });
         assert_eq!(
             paths,
@@ -2245,7 +2149,12 @@ mod tests {
             (RelPath::unix("Carrot").unwrap(), false),
         ];
         paths.sort_by(|&a, &b| {
-            compare_rel_paths_with_sort_order(a, b, SortOrderLexicographic::Lower)
+            compare_rel_paths_by(
+                a,
+                b,
+                SortMode::DirectoriesFirst,
+                SortOrderLexicographic::Lower,
+            )
         });
         assert_eq!(
             paths,
@@ -2274,7 +2183,7 @@ mod tests {
             (RelPath::unix(".hidden").unwrap(), false),
         ];
         paths.sort_by(|&a, &b| {
-            compare_rel_paths_mixed_with_sort_order(a, b, SortOrderLexicographic::Lower)
+            compare_rel_paths_by(a, b, SortMode::Mixed, SortOrderLexicographic::Lower)
         });
         assert_eq!(
             paths,
@@ -2302,7 +2211,7 @@ mod tests {
             (RelPath::unix(".hidden").unwrap(), false),
         ];
         paths.sort_by(|&a, &b| {
-            compare_rel_paths_files_first_with_sort_order(a, b, SortOrderLexicographic::Lower)
+            compare_rel_paths_by(a, b, SortMode::FilesFirst, SortOrderLexicographic::Lower)
         });
         assert_eq!(
             paths,
@@ -2331,7 +2240,12 @@ mod tests {
             (RelPath::unix("Carrot").unwrap(), false),
         ];
         paths.sort_by(|&a, &b| {
-            compare_rel_paths_with_sort_order(a, b, SortOrderLexicographic::Unicode)
+            compare_rel_paths_by(
+                a,
+                b,
+                SortMode::DirectoriesFirst,
+                SortOrderLexicographic::Unicode,
+            )
         });
         assert_eq!(
             paths,
@@ -2357,7 +2271,7 @@ mod tests {
             (RelPath::unix("file20.txt").unwrap(), true),
         ];
         paths.sort_by(|&a, &b| {
-            compare_rel_paths_mixed_with_sort_order(a, b, SortOrderLexicographic::Unicode)
+            compare_rel_paths_by(a, b, SortMode::Mixed, SortOrderLexicographic::Unicode)
         });
         // Unicode/lexicographic: '1' < '1'+'0' (prefix) < '2' < '2'+'0' (prefix)
         assert_eq!(
@@ -2383,7 +2297,7 @@ mod tests {
             (RelPath::unix(".hidden").unwrap(), false),
         ];
         paths.sort_by(|&a, &b| {
-            compare_rel_paths_mixed_with_sort_order(a, b, SortOrderLexicographic::Unicode)
+            compare_rel_paths_by(a, b, SortMode::Mixed, SortOrderLexicographic::Unicode)
         });
         assert_eq!(
             paths,
@@ -2411,7 +2325,7 @@ mod tests {
             (RelPath::unix(".hidden").unwrap(), false),
         ];
         paths.sort_by(|&a, &b| {
-            compare_rel_paths_files_first_with_sort_order(a, b, SortOrderLexicographic::Unicode)
+            compare_rel_paths_by(a, b, SortMode::FilesFirst, SortOrderLexicographic::Unicode)
         });
         assert_eq!(
             paths,
@@ -2435,7 +2349,7 @@ mod tests {
             (RelPath::unix("Apple.txt").unwrap(), true),
         ];
         paths.sort_by(|&a, &b| {
-            compare_rel_paths_mixed_with_sort_order(a, b, SortOrderLexicographic::Unicode)
+            compare_rel_paths_by(a, b, SortMode::Mixed, SortOrderLexicographic::Unicode)
         });
         // É (U+00C9 = 201) sorts after all ASCII
         assert_eq!(
@@ -2456,7 +2370,7 @@ mod tests {
             (RelPath::unix("Apple.txt").unwrap(), true),
         ];
         paths.sort_by(|&a, &b| {
-            compare_rel_paths_mixed_with_sort_order(a, b, SortOrderLexicographic::Upper)
+            compare_rel_paths_by(a, b, SortMode::Mixed, SortOrderLexicographic::Upper)
         });
         // É is uppercase, so it groups with uppercase names before lowercase
         assert_eq!(

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -1291,12 +1291,12 @@ pub fn compare_rel_paths_mixed_with_sort_order(
                             if a_leaf_file && b_leaf_file {
                                 match order {
                                     SortOrderLexicographic::Unicode => {
-                                        b_ext.unwrap_or_default().cmp(a_ext.unwrap_or_default())
+                                        a_ext.unwrap_or_default().cmp(b_ext.unwrap_or_default())
                                     }
                                     _ => {
                                         let a_ext_str = a_ext.unwrap_or_default().to_lowercase();
                                         let b_ext_str = b_ext.unwrap_or_default().to_lowercase();
-                                        b_ext_str.cmp(&a_ext_str)
+                                        a_ext_str.cmp(&b_ext_str)
                                     }
                                 }
                             } else {
@@ -1923,9 +1923,9 @@ mod tests {
         assert_eq!(
             paths,
             vec![
-                (RelPath::unix("readme.txt").unwrap(), true),
-                (RelPath::unix("ReadMe.rs").unwrap(), true),
                 (RelPath::unix("README.md").unwrap(), true),
+                (RelPath::unix("ReadMe.rs").unwrap(), true),
+                (RelPath::unix("readme.txt").unwrap(), true),
             ]
         );
     }
@@ -2077,9 +2077,9 @@ mod tests {
         assert_eq!(
             paths,
             vec![
-                (RelPath::unix("file.txt").unwrap(), true),
-                (RelPath::unix("file.rs").unwrap(), true),
                 (RelPath::unix("file.md").unwrap(), true),
+                (RelPath::unix("file.rs").unwrap(), true),
+                (RelPath::unix("file.txt").unwrap(), true),
             ]
         );
     }

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -3042,7 +3042,6 @@ Examples:
 - Description:
   Preview tabs allow you to open files in preview mode, where they close automatically when you switch to another file unless you explicitly pin them. This is useful for quickly viewing files without cluttering your workspace. Preview tabs display their file names in italics. \
    There are several ways to convert a preview tab into a regular tab:
-
   - Double-clicking on the file
   - Double-clicking on the tab header
   - Using the {#action project_panel::OpenPermanent} action
@@ -5017,6 +5016,34 @@ Run the {#action theme_selector::Toggle} action in the command palette to see a 
 {
   "project_panel": {
     "sort_mode": "files_first"
+  }
+}
+```
+
+### Case-Sensitive
+
+- Description: Whether to sort files and directories case-sensitive in the project panel.
+- Setting: `case_sensitive`
+- Default: `false`
+
+**Options**
+
+1. Natural soring
+
+```json [settings]
+{
+  "project_panel": {
+    "case_sensitive": false
+  }
+}
+```
+
+2. Lexicographic sorting
+
+```json [settings]
+{
+  "project_panel": {
+    "case_sensitive": true
   }
 }
 ```

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -5020,30 +5020,50 @@ Run the {#action theme_selector::Toggle} action in the command palette to see a 
 }
 ```
 
-### Case-Sensitive
+### Sort Order (Lexicographic)
 
-- Description: Whether to sort files and directories case-sensitive in the project panel.
-- Setting: `case_sensitive`
-- Default: `false`
+- Description: Whether to sort file and folder names case-sensitively in the project panel. This setting works in combination with `sort_mode`. `sort_mode` controls how files and directories are grouped (e.g., directories first), while this setting controls how names are compared within those groups.
+- Setting: `sort_order_lexicographic`
+- Default: `default`
 
 **Options**
 
-1. Natural sorting
+1. Case-insensitive natural sort with lowercase preferred in ties. Numbers in file names are compared by their numeric value (e.g., `file2` sorts before `file10`). Names that differ only in casing are sorted with lowercase first (e.g., `apple` before `Apple`).
 
 ```json [settings]
 {
   "project_panel": {
-    "case_sensitive": false
+    "sort_order_lexicographic": "default"
   }
 }
 ```
 
-2. Lexicographic sorting
+2. Uppercase names are grouped before lowercase names, with case-insensitive natural sort within each group. Dot-prefixed names (e.g., `.gitignore`) sort before both groups. Accented uppercase letters like `É` are treated as uppercase.
 
 ```json [settings]
 {
   "project_panel": {
-    "case_sensitive": true
+    "sort_order_lexicographic": "upper"
+  }
+}
+```
+
+3. Lowercase names are grouped before uppercase names, with case-insensitive natural sort within each group. Dot-prefixed names sort before both groups.
+
+```json [settings]
+{
+  "project_panel": {
+    "sort_order_lexicographic": "lower"
+  }
+}
+```
+
+4. Pure Unicode codepoint comparison. No case folding and no natural number sorting. Uppercase ASCII letters (`A`–`Z`) sort before lowercase (`a`–`z`) as a natural consequence of their codepoint values. Accented characters like `É` (U+00C9) sort after all ASCII letters. Numbers are compared lexicographically (`file10` sorts before `file2`).
+
+```json [settings]
+{
+  "project_panel": {
+    "sort_order_lexicographic": "unicode"
   }
 }
 ```

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -3042,6 +3042,7 @@ Examples:
 - Description:
   Preview tabs allow you to open files in preview mode, where they close automatically when you switch to another file unless you explicitly pin them. This is useful for quickly viewing files without cluttering your workspace. Preview tabs display their file names in italics. \
    There are several ways to convert a preview tab into a regular tab:
+
   - Double-clicking on the file
   - Double-clicking on the tab header
   - Using the {#action project_panel::OpenPermanent} action

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -5021,10 +5021,10 @@ Run the {#action theme_selector::Toggle} action in the command palette to see a 
 }
 ```
 
-### Sort Order (Lexicographic)
+### Sort Order
 
 - Description: Whether to sort file and folder names case-sensitively in the project panel. This setting works in combination with `sort_mode`. `sort_mode` controls how files and directories are grouped (e.g., directories first), while this setting controls how names are compared within those groups.
-- Setting: `sort_order_lexicographic`
+- Setting: `sort_order`
 - Default: `default`
 
 **Options**
@@ -5034,7 +5034,7 @@ Run the {#action theme_selector::Toggle} action in the command palette to see a 
 ```json [settings]
 {
   "project_panel": {
-    "sort_order_lexicographic": "default"
+    "sort_order": "default"
   }
 }
 ```
@@ -5044,7 +5044,7 @@ Run the {#action theme_selector::Toggle} action in the command palette to see a 
 ```json [settings]
 {
   "project_panel": {
-    "sort_order_lexicographic": "upper"
+    "sort_order": "upper"
   }
 }
 ```
@@ -5054,7 +5054,7 @@ Run the {#action theme_selector::Toggle} action in the command palette to see a 
 ```json [settings]
 {
   "project_panel": {
-    "sort_order_lexicographic": "lower"
+    "sort_order": "lower"
   }
 }
 ```
@@ -5064,7 +5064,7 @@ Run the {#action theme_selector::Toggle} action in the command palette to see a 
 ```json [settings]
 {
   "project_panel": {
-    "sort_order_lexicographic": "unicode"
+    "sort_order": "unicode"
   }
 }
 ```

--- a/docs/src/reference/all-settings.md
+++ b/docs/src/reference/all-settings.md
@@ -5028,7 +5028,7 @@ Run the {#action theme_selector::Toggle} action in the command palette to see a 
 
 **Options**
 
-1. Natural soring
+1. Natural sorting
 
 ```json [settings]
 {

--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -475,7 +475,7 @@ Project panel can be shown/hidden with {#action project_panel::ToggleFocus} ({#k
     // "upper":   Uppercase names grouped before lowercase, natural sort within.
     // "lower":   Lowercase names grouped before uppercase, natural sort within.
     // "unicode":  Pure Unicode codepoint comparison, no case folding.
-    "sort_order_lexicographic": "default"
+    "sort_order_lexicographic": "default",
     // Whether to hide the root entry when only one folder is open in the window;
     // this also affects how file paths appear in the file finder history.
     "hide_root": false,

--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -474,7 +474,9 @@ Project panel can be shown/hidden with {#action project_panel::ToggleFocus} ({#k
     // this also affects how file paths appear in the file finder history.
     "hide_root": false,
     // Whether to hide the hidden entries in the project panel.
-    "hide_hidden": false
+    "hide_hidden": false,
+    // Whether to sort files and directories case-sensitive in the project panel.
+    "case_sensitive": false
   }
 ```
 

--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -475,7 +475,7 @@ Project panel can be shown/hidden with {#action project_panel::ToggleFocus} ({#k
     // "upper":   Uppercase names grouped before lowercase, natural sort within.
     // "lower":   Lowercase names grouped before uppercase, natural sort within.
     // "unicode":  Pure Unicode codepoint comparison, no case folding.
-    "sort_order_lexicographic": "default",
+    "sort_order": "default",
     // Whether to hide the root entry when only one folder is open in the window;
     // this also affects how file paths appear in the file finder history.
     "hide_root": false,

--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -475,8 +475,12 @@ Project panel can be shown/hidden with {#action project_panel::ToggleFocus} ({#k
     "hide_root": false,
     // Whether to hide the hidden entries in the project panel.
     "hide_hidden": false,
-    // Whether to sort files and directories case-sensitive in the project panel.
-    "case_sensitive": false
+    // Whether to sort file and folder names case-sensitively.
+    // "default": Case-insensitive natural sort, lowercase preferred in ties.
+    // "upper":   Uppercase names grouped before lowercase, natural sort within.
+    // "lower":   Lowercase names grouped before uppercase, natural sort within.
+    // "unicode":  Pure Unicode codepoint comparison, no case folding.
+    "sort_order_lexicographic": "default"
   }
 ```
 

--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -470,17 +470,17 @@ Project panel can be shown/hidden with {#action project_panel::ToggleFocus} ({#k
     },
     // Sort order for entries (directories_first, mixed, files_first)
     "sort_mode": "directories_first",
-    // Whether to hide the root entry when only one folder is open in the window;
-    // this also affects how file paths appear in the file finder history.
-    "hide_root": false,
-    // Whether to hide the hidden entries in the project panel.
-    "hide_hidden": false,
     // Whether to sort file and folder names case-sensitively.
     // "default": Case-insensitive natural sort, lowercase preferred in ties.
     // "upper":   Uppercase names grouped before lowercase, natural sort within.
     // "lower":   Lowercase names grouped before uppercase, natural sort within.
     // "unicode":  Pure Unicode codepoint comparison, no case folding.
     "sort_order_lexicographic": "default"
+    // Whether to hide the root entry when only one folder is open in the window;
+    // this also affects how file paths appear in the file finder history.
+    "hide_root": false,
+    // Whether to hide the hidden entries in the project panel.
+    "hide_hidden": false
   }
 ```
 


### PR DESCRIPTION
_(Feature Requests #24962)_

_"Before you mark this PR as ready for review, make sure that you have:"_

* [x] Added a solid test coverage and/or screenshots from doing manual testing
* [x] Done a self-review taking into account security and performance aspects
* [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Added a `sort_order` to `project_panel` settings which dictates how files and directories are sorted relative to each other in a `sort_mode`.