### PR TITLE
agent: Rename run_turn to send in subagent handle

### DIFF
--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -1733,7 +1733,7 @@ impl SubagentHandle for NativeSubagentHandle {
         self.session_id.clone()
     }
 
-    fn run_turn(&self, message: String, cx: &AsyncApp) -> Task<Result<String>> {
+    fn send(&self, message: String, cx: &AsyncApp) -> Task<Result<String>> {
         let thread = self.subagent_thread.clone();
         let acp_thread = self.acp_thread.clone();
         let subagent_session_id = self.session_id.clone();

--- a/crates/agent/src/tests/mod.rs
+++ b/crates/agent/src/tests/mod.rs
@@ -167,7 +167,7 @@ impl SubagentHandle for FakeSubagentHandle {
         self.session_id.clone()
     }
 
-    fn run_turn(&self, _message: String, cx: &AsyncApp) -> Task<Result<String>> {
+    fn send(&self, _message: String, cx: &AsyncApp) -> Task<Result<String>> {
         let task = self.wait_for_summary_task.clone();
         cx.background_spawn(async move { Ok(task.await) })
     }

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -606,7 +606,7 @@ pub trait TerminalHandle {
 
 pub trait SubagentHandle {
     fn id(&self) -> acp::SessionId;
-    fn run_turn(&self, message: String, cx: &AsyncApp) -> Task<Result<String>>;
+    fn send(&self, message: String, cx: &AsyncApp) -> Task<Result<String>>;
 }
 
 pub trait ThreadEnvironment {

--- a/crates/agent/src/tools/spawn_agent_tool.rs
+++ b/crates/agent/src/tools/spawn_agent_tool.rs
@@ -125,7 +125,7 @@ impl AgentTool for SpawnAgentTool {
                 Ok((subagent, subagent_session_id))
             })?;
 
-            match subagent.run_turn(input.message, cx).await {
+            match subagent.send(input.message, cx).await {
                 Ok(output) => {
                     event_stream.update_fields(
                         acp::ToolCallUpdateFields::new().content(vec![output.clone().into()]),


### PR DESCRIPTION
Align better with naming in thread. I grabbed the wrong function name :D

Release Notes:

- N/A
