### PR TITLE
Remove unwrap() from `lsp::Uri::from_file_path`

### DIFF
--- a/crates/project/src/lsp_store/lsp_ext_command.rs
+++ b/crates/project/src/lsp_store/lsp_ext_command.rs
@@ -211,10 +211,10 @@ impl LspCommand for OpenDocs {
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<OpenDocsParams> {
+        let uri =
+            lsp::Uri::from_file_path(path).map_err(|()| anyhow!("{path:?} is not a valid URI"))?;
         Ok(OpenDocsParams {
-            text_document: lsp::TextDocumentIdentifier {
-                uri: lsp::Uri::from_file_path(path).unwrap(),
-            },
+            text_document: lsp::TextDocumentIdentifier { uri },
             position: point_to_lsp(self.position),
         })
     }

--- a/crates/project/src/lsp_store/lsp_ext_command.rs
+++ b/crates/project/src/lsp_store/lsp_ext_command.rs
@@ -211,8 +211,8 @@ impl LspCommand for OpenDocs {
         _: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<OpenDocsParams> {
-        let uri =
-            lsp::Uri::from_file_path(path).map_err(|()| anyhow!("{path:?} is not a valid URI"))?;
+        let uri = lsp::Uri::from_file_path(path)
+            .map_err(|()| anyhow::anyhow!("{path:?} is not a valid URI"))?;
         Ok(OpenDocsParams {
             text_document: lsp::TextDocumentIdentifier { uri },
             position: point_to_lsp(self.position),


### PR DESCRIPTION
Fixes ZED-3BM
Fixes ZED-1RT

Release Notes:

- Windows: Fixed a panic registering a path with language servers when the UNC path cannot be represented by a Rust URI.
