### PR TITLE
New "Filter Selection Through Command"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5415,6 +5415,7 @@ dependencies = [
  "multi_buffer",
  "ordered-float 2.10.1",
  "parking_lot",
+ "picker",
  "pretty_assertions",
  "project",
  "rand 0.9.2",

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -57,6 +57,7 @@ linkify.workspace = true
 log.workspace = true
 lsp.workspace = true
 markdown.workspace = true
+picker.workspace = true
 menu.workspace = true
 multi_buffer.workspace = true
 ordered-float.workspace = true

--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -701,6 +701,15 @@ actions!(
         ReverseLines,
         /// Reloads the file from disk.
         ReloadFile,
+        /// Runs a unix command on selected text and copies output to the clipboard.
+        #[action(name = "Filter Selection Through Command (Copy Output)")]
+        RunSelectionCommandCopyOutput,
+        /// Runs a unix command on selected text and opens output in a new document.
+        #[action(name = "Filter Selection Through Command (New Document)")]
+        RunSelectionCommandNewDocument,
+        /// Runs a unix command on selected text and replaces the selected text with output.
+        #[action(name = "Filter Selection Through Command (Replace Selection)")]
+        RunSelectionCommandReplaceSelection,
         /// Rewraps text to fit within the preferred line length.
         Rewrap,
         /// Rotates selections or lines backward.

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -50,6 +50,7 @@ mod edit_prediction_tests;
 #[cfg(test)]
 mod editor_tests;
 mod signature_help;
+mod unix_command;
 #[cfg(any(test, feature = "test-support"))]
 pub mod test;
 
@@ -108,6 +109,7 @@ use editor_settings::{GoToDefinitionFallback, Minimap as MinimapSettings};
 use element::{AcceptEditPredictionBinding, LineWithInvisibles, PositionMap, layout_line};
 use futures::{
     FutureExt,
+    channel::oneshot,
     future::{self, Shared, join},
 };
 use fuzzy::{StringMatch, StringMatchCandidate};
@@ -184,6 +186,7 @@ use settings::{
     update_settings_file,
 };
 use smallvec::{SmallVec, smallvec};
+use smol::io::{AsyncReadExt, AsyncWriteExt};
 use snippet::Snippet;
 use std::{
     any::{Any, TypeId},
@@ -200,7 +203,7 @@ use std::{
     sync::Arc,
     time::{Duration, Instant},
 };
-use task::{ResolvedTask, RunnableTag, TaskTemplate, TaskVariables};
+use task::{ResolvedTask, RunnableTag, TaskContext, TaskTemplate, TaskVariables};
 use text::{BufferId, FromAnchor, OffsetUtf16, Rope, ToOffset as _, ToPoint as _};
 use theme::{
     AccentColors, ActiveTheme, GlobalTheme, PlayerColor, StatusColors, SyntaxTheme, Theme,
@@ -9147,6 +9150,204 @@ impl Editor {
                 task_store.task_context_for_location(captured_task_variables, location, cx)
             })
         })
+    }
+
+    pub fn run_selection_command_copy_output(
+        &mut self,
+        _: &RunSelectionCommandCopyOutput,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.open_unix_command_modal(unix_command::UnixCommandOutputMode::CopyOutput, window, cx);
+    }
+
+    pub fn run_selection_command_new_document(
+        &mut self,
+        _: &RunSelectionCommandNewDocument,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.open_unix_command_modal(unix_command::UnixCommandOutputMode::NewDocument, window, cx);
+    }
+
+    pub fn run_selection_command_replace_selection(
+        &mut self,
+        _: &RunSelectionCommandReplaceSelection,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.open_unix_command_modal(
+            unix_command::UnixCommandOutputMode::ReplaceSelection,
+            window,
+            cx,
+        );
+    }
+
+    fn open_unix_command_modal(&mut self, mode: unix_command::UnixCommandOutputMode, window: &mut Window, cx: &mut Context<Self>) {
+        let Some((workspace, _)) = self.workspace.clone() else {
+            return;
+        };
+        let editor = cx.entity().downgrade();
+        let _ = workspace.update(cx, |workspace, cx| {
+            workspace.toggle_modal(window, cx, |window, cx| {
+                unix_command::UnixCommandModal::new(editor.clone(), mode, window, cx)
+            });
+        });
+    }
+
+    pub(crate) fn execute_selection_unix_command(
+        &mut self,
+        command: String,
+        mode: unix_command::UnixCommandOutputMode,
+        timeout: Duration,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Option<unix_command::UnixCommandExecution> {
+        let Some((workspace, _)) = self.workspace.clone() else {
+            return None;
+        };
+        let Some(project) = self.project.clone() else {
+            return None;
+        };
+
+        let command = command.trim().to_string();
+        if command.is_empty() {
+            return None;
+        }
+
+        let task_context = self.task_context(window, cx);
+        let Some((input_text, selection_range)) = self.unix_command_input(window, cx) else {
+            return None;
+        };
+
+        let cancel_requested = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let command_cancel_requested = cancel_requested.clone();
+        let (completion_tx, completion_rx) = oneshot::channel::<bool>();
+
+        cx.spawn_in(window, async move |editor, cx| {
+            let Some(task_context) = task_context.await else {
+                let _ = completion_tx.send(false);
+                return;
+            };
+
+            let process_task =
+                project.update(cx, |project, cx| project.exec_in_shell_for_pipe(command.clone(), cx));
+
+            let output = run_piped_unix_command(
+                process_task,
+                input_text,
+                task_context,
+                timeout,
+                command_cancel_requested,
+            )
+            .await;
+
+            let output = match output {
+                Ok(output) => output,
+                Err(error) => {
+                    workspace
+                        .update_in(cx, |workspace, _, cx| {
+                            struct UnixCommandFailed;
+
+                            let message = if error.to_string().contains("command canceled") {
+                                "Command stopped".to_string()
+                            } else {
+                                format!("Command failed: {error}")
+                            };
+
+                            workspace.show_toast(
+                                Toast::new(
+                                    NotificationId::unique::<UnixCommandFailed>(),
+                                    message,
+                                ),
+                                cx,
+                            )
+                        })
+                        .ok();
+                    let _ = completion_tx.send(false);
+                    return;
+                }
+            };
+
+            match mode {
+                unix_command::UnixCommandOutputMode::CopyOutput => {
+                    editor
+                        .update(cx, |_, cx| {
+                            cx.write_to_clipboard(ClipboardItem::new_string(output));
+                        })
+                        .ok();
+                }
+                unix_command::UnixCommandOutputMode::NewDocument => {
+                    let new_editor = workspace
+                        .update_in(cx, |workspace, window, cx| {
+                            Editor::new_in_workspace(workspace, window, cx)
+                        })
+                        .ok();
+                    let Some(new_editor) = new_editor else {
+                        let _ = completion_tx.send(false);
+                        return;
+                    };
+                    let new_editor = match new_editor.await {
+                        Ok(editor) => editor,
+                        Err(_) => {
+                            let _ = completion_tx.send(false);
+                            return;
+                        }
+                    };
+
+                    new_editor
+                        .update_in(cx, |editor, window, cx| {
+                            editor.set_text(output, window, cx);
+                        })
+                        .ok();
+                }
+                unix_command::UnixCommandOutputMode::ReplaceSelection => {
+                    editor
+                        .update_in(cx, |editor, window, cx| {
+                            editor.transact(window, cx, |editor, _, cx| {
+                                editor.edit(vec![(selection_range, output)], cx);
+                            });
+                        })
+                        .ok();
+                }
+            }
+
+            let _ = completion_tx.send(true);
+        })
+        .detach();
+
+        Some(unix_command::UnixCommandExecution {
+            cancel_requested,
+            completion: completion_rx,
+        })
+    }
+
+    fn unix_command_input(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Option<(String, Range<Anchor>)> {
+        let selection = self.selections.newest_adjusted(&self.display_snapshot(cx));
+        let selection_range = selection.range();
+        let snapshot = self.snapshot(window, cx);
+        let buffer_snapshot = snapshot.display_snapshot.buffer_snapshot();
+
+        if selection_range.is_empty() {
+            let row = selection_range.start.row;
+            let line_range = Point::new(row, 0)
+                ..Point::new(row, buffer_snapshot.line_len(MultiBufferRow(row)));
+            let text = buffer_snapshot.text_for_range(line_range.clone()).collect();
+            let start = buffer_snapshot.anchor_after(line_range.start);
+            let end = buffer_snapshot.anchor_after(line_range.end);
+            Some((text, start..end))
+        } else {
+            let text = buffer_snapshot
+                .text_for_range(selection_range.clone())
+                .collect();
+            let start = buffer_snapshot.anchor_after(selection_range.start);
+            let end = buffer_snapshot.anchor_after(selection_range.end);
+            Some((text, start..end))
+        }
     }
 
     pub fn spawn_nearest_task(
@@ -26368,6 +26569,116 @@ fn char_len_with_expanded_tabs(offset: usize, text: &str, tab_size: NonZeroU32) 
 mod tests {
     use super::*;
 
+    #[cfg(not(windows))]
+    fn build_shell_command(command: &str) -> smol::process::Command {
+        let mut shell_command = smol::process::Command::new("sh");
+        shell_command.arg("-c").arg(command);
+        shell_command
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn test_run_piped_unix_command_returns_stdout() {
+        smol::block_on(async {
+            let output = run_piped_unix_command(
+                Task::ready(Ok(build_shell_command("cat"))),
+                "hello world".to_string(),
+                TaskContext::default(),
+                Duration::from_secs(1),
+                Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(output, "hello world");
+        });
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn test_run_piped_unix_command_times_out() {
+        smol::block_on(async {
+            let started_at = Instant::now();
+            let result = run_piped_unix_command(
+                Task::ready(Ok(build_shell_command("sleep 1; cat"))),
+                "hello world".to_string(),
+                TaskContext::default(),
+                Duration::from_millis(50),
+                Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            )
+            .await;
+
+            assert!(result.is_err());
+            assert!(
+                result
+                    .as_ref()
+                    .err()
+                    .is_some_and(|error| error.to_string().contains("command timed out")),
+                "unexpected error: {result:?}"
+            );
+            assert!(started_at.elapsed() < Duration::from_secs(1));
+        });
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn test_run_piped_unix_command_can_be_canceled() {
+        smol::block_on(async {
+            let started_at = Instant::now();
+            let cancel_requested = Arc::new(std::sync::atomic::AtomicBool::new(false));
+            let cancel_requested_for_task = cancel_requested.clone();
+
+            let result_task = smol::spawn(async move {
+                run_piped_unix_command(
+                    Task::ready(Ok(build_shell_command("sleep 1; cat"))),
+                    "hello world".to_string(),
+                    TaskContext::default(),
+                    Duration::from_secs(5),
+                    cancel_requested_for_task,
+                )
+                .await
+            });
+
+            smol::Timer::after(Duration::from_millis(25)).await;
+            cancel_requested.store(true, std::sync::atomic::Ordering::Relaxed);
+
+            let result = result_task.await;
+            assert!(result.is_err());
+            assert!(
+                result
+                    .as_ref()
+                    .err()
+                    .is_some_and(|error| error.to_string().contains("command canceled")),
+                "unexpected error: {result:?}"
+            );
+            assert!(started_at.elapsed() < Duration::from_secs(1));
+        });
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn test_run_piped_unix_command_non_zero_exit_uses_stderr() {
+        smol::block_on(async {
+            let result = run_piped_unix_command(
+                Task::ready(Ok(build_shell_command("echo error-msg >&2; exit 7"))),
+                "hello world".to_string(),
+                TaskContext::default(),
+                Duration::from_secs(1),
+                Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            )
+            .await;
+
+            assert!(result.is_err());
+            assert!(
+                result
+                    .as_ref()
+                    .err()
+                    .is_some_and(|error| error.to_string().contains("error-msg")),
+                "unexpected error: {result:?}"
+            );
+        });
+    }
+
     #[test]
     fn test_string_size_with_expanded_tabs() {
         let nz = |val| NonZeroU32::new(val).unwrap();
@@ -27886,6 +28197,79 @@ impl EditorSnapshot {
             })
             .collect()
     }
+}
+
+async fn run_piped_unix_command(
+    process_task: Task<Result<smol::process::Command>>,
+    input_text: String,
+    task_context: TaskContext,
+    timeout: Duration,
+    cancel_requested: Arc<std::sync::atomic::AtomicBool>,
+) -> anyhow::Result<String> {
+    let mut shell_command = process_task.await?;
+
+    if let Some(cwd) = task_context.cwd {
+        shell_command.current_dir(cwd);
+    }
+    if !task_context.project_env.is_empty() {
+        shell_command.envs(task_context.project_env);
+    }
+
+    let mut child = shell_command
+        .stdin(smol::process::Stdio::piped())
+        .stdout(smol::process::Stdio::piped())
+        .stderr(smol::process::Stdio::piped())
+        .spawn()?;
+
+    let mut stdin = child.stdin.take().context("failed to acquire stdin")?;
+    stdin.write_all(input_text.as_bytes()).await?;
+    stdin.flush().await?;
+    drop(stdin);
+
+    let mut stdout = child.stdout.take().context("failed to acquire stdout")?;
+    let mut stderr = child.stderr.take().context("failed to acquire stderr")?;
+
+    let stdout_task = smol::spawn(async move {
+        let mut stdout_bytes = Vec::new();
+        stdout.read_to_end(&mut stdout_bytes).await?;
+        anyhow::Ok(stdout_bytes)
+    });
+    let stderr_task = smol::spawn(async move {
+        let mut stderr_bytes = Vec::new();
+        stderr.read_to_end(&mut stderr_bytes).await?;
+        anyhow::Ok(stderr_bytes)
+    });
+
+    let started_at = Instant::now();
+    let exit_status = loop {
+        if let Some(exit_status) = child.try_status()? {
+            break exit_status;
+        }
+
+        if cancel_requested.load(std::sync::atomic::Ordering::Relaxed) {
+            child.kill().ok();
+            let _ = child.status().await;
+            anyhow::bail!("command canceled");
+        }
+
+        if started_at.elapsed() >= timeout {
+            child.kill().ok();
+            let _ = child.status().await;
+            anyhow::bail!("command timed out after {:.1}s", timeout.as_secs_f32());
+        }
+
+        smol::Timer::after(Duration::from_millis(10)).await;
+    };
+
+    let stdout = stdout_task.await?;
+    let stderr = stderr_task.await?;
+
+    anyhow::ensure!(
+        exit_status.success(),
+        String::from_utf8_lossy(&stderr).to_string()
+    );
+
+    Ok(String::from_utf8_lossy(&stdout).into_owned())
 }
 
 pub fn column_pixels(style: &EditorStyle, column: usize, window: &Window) -> Pixels {

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -26344,6 +26344,357 @@ async fn test_hide_mouse_context_menu_on_modal_opened(cx: &mut TestAppContext) {
     });
 }
 
+#[gpui::test]
+async fn test_run_selection_unix_command_actions_open_modal(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let fs = FakeFs::new(cx.executor());
+    let project = Project::test(fs, [], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |mw, _| mw.workspace().clone())
+        .unwrap();
+    let buffer = cx.update(|cx| MultiBuffer::build_simple("hello world", cx));
+    let cx = &mut VisualTestContext::from_window(*window, cx);
+    let editor = cx.new_window_entity(|window, cx| {
+        Editor::new(
+            EditorMode::full(),
+            buffer,
+            Some(project.clone()),
+            window,
+            cx,
+        )
+    });
+    workspace.update_in(cx, |workspace, window, cx| {
+        workspace.add_item_to_active_pane(Box::new(editor.clone()), None, true, window, cx);
+    });
+
+    let assert_modal_visible = |workspace: &Entity<workspace::Workspace>, cx: &VisualTestContext| {
+        workspace.read_with(cx, |workspace, cx| {
+            assert!(
+                workspace
+                    .active_modal::<crate::unix_command::UnixCommandModal>(cx)
+                    .is_some(),
+                "unix command modal should be visible",
+            );
+        });
+    };
+
+    editor.update_in(cx, |editor, window, cx| {
+        editor.run_selection_command_copy_output(&RunSelectionCommandCopyOutput, window, cx);
+    });
+    assert_modal_visible(&workspace, cx);
+    workspace.update_in(cx, |workspace, window, cx| {
+        assert!(workspace.hide_modal(window, cx));
+    });
+
+    editor.update_in(cx, |editor, window, cx| {
+        editor.run_selection_command_new_document(&RunSelectionCommandNewDocument, window, cx);
+    });
+    assert_modal_visible(&workspace, cx);
+    workspace.update_in(cx, |workspace, window, cx| {
+        assert!(workspace.hide_modal(window, cx));
+    });
+
+    editor.update_in(cx, |editor, window, cx| {
+        editor
+            .run_selection_command_replace_selection(&RunSelectionCommandReplaceSelection, window, cx);
+    });
+    assert_modal_visible(&workspace, cx);
+}
+
+#[gpui::test]
+async fn test_unix_command_confirm_input_does_not_panic(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let fs = FakeFs::new(cx.executor());
+    let project = Project::test(fs, [], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |mw, _| mw.workspace().clone())
+        .unwrap();
+    let buffer = cx.update(|cx| MultiBuffer::build_simple("hello world", cx));
+    let cx = &mut VisualTestContext::from_window(*window, cx);
+    let editor = cx.new_window_entity(|window, cx| {
+        Editor::new(
+            EditorMode::full(),
+            buffer,
+            Some(project.clone()),
+            window,
+            cx,
+        )
+    });
+    workspace.update_in(cx, |workspace, window, cx| {
+        workspace.add_item_to_active_pane(Box::new(editor.clone()), None, true, window, cx);
+    });
+
+    editor.update_in(cx, |editor, window, cx| {
+        editor.run_selection_command_copy_output(&RunSelectionCommandCopyOutput, window, cx);
+    });
+
+    workspace.read_with(cx, |workspace, cx| {
+        assert!(
+            workspace
+                .active_modal::<crate::unix_command::UnixCommandModal>(cx)
+                .is_some(),
+            "unix command modal should be visible",
+        );
+    });
+
+    cx.dispatch_action(picker::ConfirmInput { secondary: false });
+
+    workspace.read_with(cx, |workspace, cx| {
+        assert!(
+            workspace
+                .active_modal::<crate::unix_command::UnixCommandModal>(cx)
+                .is_some(),
+            "modal should remain open for empty command",
+        );
+    });
+}
+
+#[gpui::test]
+async fn test_unix_command_stop_requests_cancellation_for_running_modal(
+    cx: &mut TestAppContext,
+) {
+    init_test(cx, |_| {});
+
+    let fs = FakeFs::new(cx.executor());
+    let project = Project::test(fs, [], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |mw, _| mw.workspace().clone())
+        .unwrap();
+    let buffer = cx.update(|cx| MultiBuffer::build_simple("hello world", cx));
+    let cx = &mut VisualTestContext::from_window(*window, cx);
+    let editor = cx.new_window_entity(|window, cx| {
+        Editor::new(
+            EditorMode::full(),
+            buffer,
+            Some(project.clone()),
+            window,
+            cx,
+        )
+    });
+    workspace.update_in(cx, |workspace, window, cx| {
+        workspace.add_item_to_active_pane(Box::new(editor.clone()), None, true, window, cx);
+    });
+
+    editor.update_in(cx, |editor, window, cx| {
+        editor.run_selection_command_copy_output(&RunSelectionCommandCopyOutput, window, cx);
+    });
+
+    let modal = workspace
+        .read_with(cx, |workspace, cx| {
+            workspace.active_modal::<crate::unix_command::UnixCommandModal>(cx)
+        })
+        .expect("unix command modal should be visible");
+
+    let cancel_requested = modal.update(cx, |modal, cx| modal.seed_running_state_for_test(cx));
+
+    modal.read_with(cx, |modal, cx| {
+        assert!(modal.is_running_for_test(cx));
+    });
+
+    modal.update(cx, |modal, cx| {
+        modal.stop_for_test(cx);
+    });
+
+    assert!(cancel_requested.load(std::sync::atomic::Ordering::Relaxed));
+}
+
+#[gpui::test]
+async fn test_unix_command_modal_running_state_is_visible(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let fs = FakeFs::new(cx.executor());
+    let project = Project::test(fs, [], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |mw, _| mw.workspace().clone())
+        .unwrap();
+    let buffer = cx.update(|cx| MultiBuffer::build_simple("hello world", cx));
+    let cx = &mut VisualTestContext::from_window(*window, cx);
+    let editor = cx.new_window_entity(|window, cx| {
+        Editor::new(
+            EditorMode::full(),
+            buffer,
+            Some(project.clone()),
+            window,
+            cx,
+        )
+    });
+    workspace.update_in(cx, |workspace, window, cx| {
+        workspace.add_item_to_active_pane(Box::new(editor.clone()), None, true, window, cx);
+    });
+
+    editor.update_in(cx, |editor, window, cx| {
+        editor.run_selection_command_copy_output(&RunSelectionCommandCopyOutput, window, cx);
+    });
+
+    let modal = workspace
+        .read_with(cx, |workspace, cx| {
+            workspace.active_modal::<crate::unix_command::UnixCommandModal>(cx)
+        })
+        .expect("unix command modal should be visible");
+
+    modal.update(cx, |modal, cx| {
+        modal.seed_running_state_for_test(cx);
+    });
+
+    modal.read_with(cx, |modal, cx| {
+        assert!(modal.is_running_for_test(cx));
+    });
+}
+
+#[gpui::test]
+async fn test_unix_command_hide_can_dismiss_while_running(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let fs = FakeFs::new(cx.executor());
+    let project = Project::test(fs, [], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |mw, _| mw.workspace().clone())
+        .unwrap();
+    let buffer = cx.update(|cx| MultiBuffer::build_simple("hello world", cx));
+    let cx = &mut VisualTestContext::from_window(*window, cx);
+    let editor = cx.new_window_entity(|window, cx| {
+        Editor::new(
+            EditorMode::full(),
+            buffer,
+            Some(project.clone()),
+            window,
+            cx,
+        )
+    });
+    workspace.update_in(cx, |workspace, window, cx| {
+        workspace.add_item_to_active_pane(Box::new(editor.clone()), None, true, window, cx);
+    });
+
+    editor.update_in(cx, |editor, window, cx| {
+        editor.run_selection_command_copy_output(&RunSelectionCommandCopyOutput, window, cx);
+    });
+
+    let modal = workspace
+        .read_with(cx, |workspace, cx| {
+            workspace.active_modal::<crate::unix_command::UnixCommandModal>(cx)
+        })
+        .expect("unix command modal should be visible");
+
+    modal.update(cx, |modal, cx| {
+        modal.seed_running_state_for_test(cx);
+    });
+
+    workspace.update_in(cx, |workspace, window, cx| {
+        assert!(workspace.hide_modal(window, cx));
+    });
+
+    workspace.read_with(cx, |workspace, cx| {
+        assert!(
+            workspace
+                .active_modal::<crate::unix_command::UnixCommandModal>(cx)
+                .is_none(),
+            "modal should be dismissible while command runs",
+        );
+    });
+}
+
+#[gpui::test]
+async fn test_unix_command_stop_without_running_is_noop(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let fs = FakeFs::new(cx.executor());
+    let project = Project::test(fs, [], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |mw, _| mw.workspace().clone())
+        .unwrap();
+    let buffer = cx.update(|cx| MultiBuffer::build_simple("hello world", cx));
+    let cx = &mut VisualTestContext::from_window(*window, cx);
+    let editor = cx.new_window_entity(|window, cx| {
+        Editor::new(
+            EditorMode::full(),
+            buffer,
+            Some(project.clone()),
+            window,
+            cx,
+        )
+    });
+    workspace.update_in(cx, |workspace, window, cx| {
+        workspace.add_item_to_active_pane(Box::new(editor.clone()), None, true, window, cx);
+    });
+
+    editor.update_in(cx, |editor, window, cx| {
+        editor.run_selection_command_copy_output(&RunSelectionCommandCopyOutput, window, cx);
+    });
+
+    let modal = workspace
+        .read_with(cx, |workspace, cx| {
+            workspace.active_modal::<crate::unix_command::UnixCommandModal>(cx)
+        })
+        .expect("unix command modal should be visible");
+
+    modal.read_with(cx, |modal, cx| {
+        assert!(!modal.is_running_for_test(cx));
+    });
+
+    modal.update(cx, |modal, cx| {
+        modal.stop_for_test(cx);
+    });
+
+    modal.read_with(cx, |modal, cx| {
+        assert!(!modal.is_running_for_test(cx));
+    });
+}
+
+#[gpui::test]
+async fn test_unix_command_stop_is_idempotent(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let fs = FakeFs::new(cx.executor());
+    let project = Project::test(fs, [], cx).await;
+    let window = cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+    let workspace = window
+        .read_with(cx, |mw, _| mw.workspace().clone())
+        .unwrap();
+    let buffer = cx.update(|cx| MultiBuffer::build_simple("hello world", cx));
+    let cx = &mut VisualTestContext::from_window(*window, cx);
+    let editor = cx.new_window_entity(|window, cx| {
+        Editor::new(
+            EditorMode::full(),
+            buffer,
+            Some(project.clone()),
+            window,
+            cx,
+        )
+    });
+    workspace.update_in(cx, |workspace, window, cx| {
+        workspace.add_item_to_active_pane(Box::new(editor.clone()), None, true, window, cx);
+    });
+
+    editor.update_in(cx, |editor, window, cx| {
+        editor.run_selection_command_copy_output(&RunSelectionCommandCopyOutput, window, cx);
+    });
+
+    let modal = workspace
+        .read_with(cx, |workspace, cx| {
+            workspace.active_modal::<crate::unix_command::UnixCommandModal>(cx)
+        })
+        .expect("unix command modal should be visible");
+
+    let cancel_requested = modal.update(cx, |modal, cx| modal.seed_running_state_for_test(cx));
+
+    modal.update(cx, |modal, cx| {
+        modal.stop_for_test(cx);
+    });
+    modal.update(cx, |modal, cx| {
+        modal.stop_for_test(cx);
+    });
+
+    assert!(cancel_requested.load(std::sync::atomic::Ordering::Relaxed));
+}
+
 fn set_linked_edit_ranges(
     opening: (Point, Point),
     closing: (Point, Point),

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -639,6 +639,9 @@ impl EditorElement {
         register_action(editor, window, Editor::open_active_item_in_terminal);
         register_action(editor, window, Editor::reload_file);
         register_action(editor, window, Editor::spawn_nearest_task);
+        register_action(editor, window, Editor::run_selection_command_copy_output);
+        register_action(editor, window, Editor::run_selection_command_new_document);
+        register_action(editor, window, Editor::run_selection_command_replace_selection);
         register_action(editor, window, Editor::insert_uuid_v4);
         register_action(editor, window, Editor::insert_uuid_v7);
         register_action(editor, window, Editor::open_selections_in_multibuffer);

--- a/crates/editor/src/unix_command.rs
+++ b/crates/editor/src/unix_command.rs
@@ -1,0 +1,730 @@
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, AtomicU64, Ordering},
+};
+use std::time::Duration;
+
+use crate::Editor;
+use db::kvp::KEY_VALUE_STORE;
+use futures::channel::oneshot;
+use fuzzy::{StringMatch, StringMatchCandidate, match_strings};
+use gpui::{
+    Action, App, Context, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable, Render,
+    Styled, TextAlign, TextStyleRefinement,
+    Subscription, Task, WeakEntity, Window, rems,
+};
+use picker::{Picker, PickerDelegate};
+use parking_lot::Mutex;
+use ui::{Button, KeyBinding, ListItem, ListItemSpacing, Toggleable, h_flex, prelude::*, v_flex};
+use util::ResultExt;
+use workspace::ModalView;
+
+const ONESHOT_HISTORY_NAMESPACE: &str = "editor";
+const ONESHOT_HISTORY_KEY: &str = "unix_command_history";
+const MAX_HISTORY_ITEMS: usize = 500;
+const DEFAULT_TIMEOUT_SECONDS: u64 = 10;
+const MIN_TIMEOUT_SECONDS: u64 = 1;
+
+pub(crate) struct UnixCommandExecution {
+    pub(crate) cancel_requested: Arc<AtomicBool>,
+    pub(crate) completion: oneshot::Receiver<bool>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum UnixCommandOutputMode {
+    CopyOutput,
+    NewDocument,
+    ReplaceSelection,
+}
+
+pub struct UnixCommandModal {
+    picker: Entity<Picker<UnixCommandModalDelegate>>,
+    _subscription: Subscription,
+}
+
+struct SharedCommandState {
+    timeout_seconds: AtomicU64,
+    is_running: AtomicBool,
+    cancel_requested: Mutex<Option<Arc<AtomicBool>>>,
+}
+
+impl SharedCommandState {
+    fn new() -> Self {
+        Self {
+            timeout_seconds: AtomicU64::new(DEFAULT_TIMEOUT_SECONDS),
+            is_running: AtomicBool::new(false),
+            cancel_requested: Mutex::new(None),
+        }
+    }
+
+    fn timeout_seconds(&self) -> u64 {
+        self.timeout_seconds.load(Ordering::Relaxed)
+    }
+}
+
+impl UnixCommandModal {
+    pub fn new(
+        editor: WeakEntity<Editor>,
+        mode: UnixCommandOutputMode,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let modal = cx.entity().downgrade();
+        let shared_state = Arc::new(SharedCommandState::new());
+        let picker = cx.new(|cx| {
+            Picker::uniform_list(
+                UnixCommandModalDelegate::new(
+                    modal.clone(),
+                    editor.clone(),
+                    mode,
+                    shared_state.clone(),
+                    window,
+                    cx,
+                ),
+                window,
+                cx,
+            )
+            .modal(false)
+        });
+        let weak_picker = picker.downgrade();
+        picker.update(cx, |picker, _| {
+            picker.delegate.set_picker(weak_picker);
+        });
+
+        let _subscription = cx.subscribe(&picker, |_, _, _: &DismissEvent, cx| {
+            cx.emit(DismissEvent);
+        });
+
+        Self {
+            picker,
+            _subscription,
+        }
+    }
+}
+
+impl Focusable for UnixCommandModal {
+    fn focus_handle(&self, cx: &App) -> FocusHandle {
+        self.picker.focus_handle(cx)
+    }
+}
+
+#[cfg(test)]
+impl UnixCommandModal {
+    pub(crate) fn is_running_for_test(&self, cx: &App) -> bool {
+        self.picker.read(cx).delegate.is_running()
+    }
+
+    pub(crate) fn seed_running_state_for_test(&self, cx: &mut App) -> Arc<AtomicBool> {
+        let cancel_requested = Arc::new(AtomicBool::new(false));
+        let cancel_requested_for_delegate = cancel_requested.clone();
+
+        self.picker.update(cx, |picker, cx| {
+            picker
+                .delegate
+                .shared_state
+                .is_running
+                .store(true, Ordering::Relaxed);
+            picker
+                .delegate
+                .shared_state
+                .cancel_requested
+                .lock()
+                .replace(cancel_requested_for_delegate);
+            cx.notify();
+        });
+
+        cancel_requested
+    }
+
+    pub(crate) fn stop_for_test(&self, cx: &mut App) {
+        self.picker.update(cx, |picker, cx| {
+            if let Some(cancel_requested) = picker
+                .delegate
+                .shared_state
+                .cancel_requested
+                .lock()
+                .as_ref()
+                .cloned()
+            {
+                cancel_requested.store(true, Ordering::Relaxed);
+            }
+            cx.notify();
+        });
+    }
+}
+
+impl EventEmitter<DismissEvent> for UnixCommandModal {}
+impl ModalView for UnixCommandModal {}
+
+impl Render for UnixCommandModal {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        v_flex()
+            .key_context("UnixCommandModal")
+            .w(rems(40.))
+            .elevation_3(cx)
+            .bg(cx.theme().colors().elevated_surface_background)
+            .border_1()
+            .border_color(cx.theme().colors().border_variant)
+            .rounded_lg()
+            .overflow_hidden()
+            .child(self.picker.clone())
+    }
+}
+
+struct UnixCommandModalDelegate {
+    modal: WeakEntity<UnixCommandModal>,
+    picker: Option<WeakEntity<Picker<UnixCommandModalDelegate>>>,
+    editor: WeakEntity<Editor>,
+    mode: UnixCommandOutputMode,
+    timeout_input: Entity<Editor>,
+    history: Vec<String>,
+    prompt: String,
+    matches: Vec<StringMatch>,
+    selected_index: usize,
+    shared_state: Arc<SharedCommandState>,
+}
+
+impl UnixCommandModalDelegate {
+    fn new(
+        modal: WeakEntity<UnixCommandModal>,
+        editor: WeakEntity<Editor>,
+        mode: UnixCommandOutputMode,
+        shared_state: Arc<SharedCommandState>,
+        window: &mut Window,
+        cx: &mut Context<Picker<Self>>,
+    ) -> Self {
+        let timeout_input = cx.new(|cx| {
+            let mut input = Editor::single_line(window, cx);
+            input.set_text_style_refinement(TextStyleRefinement {
+                text_align: Some(TextAlign::Center),
+                ..Default::default()
+            });
+            input.set_text(DEFAULT_TIMEOUT_SECONDS.to_string(), window, cx);
+            input
+        });
+
+        Self {
+            modal,
+            picker: None,
+            editor,
+            mode,
+            timeout_input,
+            history: load_history(),
+            prompt: String::new(),
+            matches: Vec::new(),
+            selected_index: 0,
+            shared_state,
+        }
+    }
+
+    fn set_picker(&mut self, picker: WeakEntity<Picker<UnixCommandModalDelegate>>) {
+        self.picker = Some(picker);
+    }
+
+    fn is_running(&self) -> bool {
+        self.shared_state.is_running.load(Ordering::Relaxed)
+    }
+
+    fn timeout_seconds(&self) -> u64 {
+        self.shared_state.timeout_seconds()
+    }
+
+    fn update_timeout(
+        &self,
+        decrease: bool,
+        window: &mut Window,
+        cx: &mut Context<Picker<Self>>,
+    ) {
+        if self.is_running() {
+            return;
+        }
+
+        let current = self.sync_timeout_input(window, cx);
+
+        let timeout_seconds = if decrease {
+            decrement_timeout_seconds(current)
+        } else {
+            increment_timeout_seconds(current)
+        };
+
+        self.set_timeout_seconds(timeout_seconds, window, cx);
+    }
+
+    fn set_timeout_seconds(
+        &self,
+        timeout_seconds: u64,
+        window: &mut Window,
+        cx: &mut Context<Picker<Self>>,
+    ) {
+        let timeout_seconds = timeout_seconds.max(MIN_TIMEOUT_SECONDS);
+        self.shared_state
+            .timeout_seconds
+            .store(timeout_seconds, Ordering::Relaxed);
+        let timeout_text = timeout_seconds.to_string();
+
+        self.timeout_input.update(cx, |editor, cx| {
+            if editor.text(cx) != timeout_text {
+                editor.set_text(timeout_text.clone(), window, cx);
+            }
+        });
+
+        cx.notify();
+    }
+
+    fn sync_timeout_input(&self, window: &mut Window, cx: &mut Context<Picker<Self>>) -> u64 {
+        let input_text = self.timeout_input.read(cx).text(cx);
+        if let Some(timeout_seconds) = parse_timeout_seconds(&input_text) {
+            self.set_timeout_seconds(timeout_seconds, window, cx);
+            timeout_seconds
+        } else {
+            let current = self.timeout_seconds();
+            self.set_timeout_seconds(current, window, cx);
+            current
+        }
+    }
+
+    fn execute_command(
+        &mut self,
+        command: String,
+        omit_history_entry: bool,
+        window: &mut Window,
+        cx: &mut Context<Picker<Self>>,
+    ) {
+        if self.is_running() {
+            return;
+        }
+
+        if command.trim().is_empty() {
+            return;
+        }
+
+        if !omit_history_entry {
+            persist_history(&mut self.history, command.as_str(), cx);
+        }
+
+        let timeout_seconds = self.sync_timeout_input(window, cx);
+        let timeout = Duration::from_secs(timeout_seconds);
+        let mode = self.mode;
+        let editor = self.editor.clone();
+        let execution = editor
+            .update(cx, |editor, cx| {
+                editor.execute_selection_unix_command(command, mode, timeout, window, cx)
+            })
+            .ok()
+            .flatten();
+
+        let Some(execution) = execution else {
+            return;
+        };
+
+        self.shared_state.is_running.store(true, Ordering::Relaxed);
+        self.shared_state
+            .cancel_requested
+            .lock()
+            .replace(execution.cancel_requested.clone());
+        cx.notify();
+
+        let shared_state = self.shared_state.clone();
+        let picker = self.picker.clone();
+        let modal = self.modal.clone();
+        cx.spawn_in(window, async move |_, cx| {
+            let completed_successfully = execution.completion.await.unwrap_or(false);
+            shared_state.is_running.store(false, Ordering::Relaxed);
+            shared_state.cancel_requested.lock().take();
+
+            if completed_successfully {
+                modal
+                    .update(cx, |_, cx| {
+                        cx.emit(DismissEvent);
+                    })
+                    .ok();
+            }
+
+            if let Some(picker) = picker {
+                picker
+                    .update(cx, |_, cx| {
+                        cx.notify();
+                    })
+                    .ok();
+            }
+        })
+        .detach();
+    }
+}
+
+impl PickerDelegate for UnixCommandModalDelegate {
+    type ListItem = ListItem;
+
+    fn match_count(&self) -> usize {
+        self.matches.len()
+    }
+
+    fn selected_index(&self) -> usize {
+        self.selected_index
+    }
+
+    fn set_selected_index(
+        &mut self,
+        ix: usize,
+        _window: &mut Window,
+        _cx: &mut Context<Picker<Self>>,
+    ) {
+        if self.is_running() {
+            return;
+        }
+        self.selected_index = ix;
+    }
+
+    fn placeholder_text(&self, _window: &mut Window, _cx: &mut App) -> Arc<str> {
+        Arc::from("Filter selection through command")
+    }
+
+    fn update_matches(
+        &mut self,
+        query: String,
+        window: &mut Window,
+        cx: &mut Context<Picker<Self>>,
+    ) -> Task<()> {
+        if self.is_running() {
+            return Task::ready(());
+        }
+
+        self.prompt = query.clone();
+
+        let history = self.history.clone();
+        let candidates = history
+            .iter()
+            .enumerate()
+            .map(|(id, command)| StringMatchCandidate::new(id, command))
+            .collect::<Vec<_>>();
+
+        let background = cx.background_executor().clone();
+        cx.spawn_in(window, async move |picker, cx| {
+            let mut matches = if query.is_empty() {
+                candidates
+                    .into_iter()
+                    .rev()
+                    .map(|candidate| StringMatch {
+                        candidate_id: candidate.id,
+                        string: candidate.string,
+                        positions: Vec::new(),
+                        score: 0.0,
+                    })
+                    .collect::<Vec<_>>()
+            } else {
+                match_strings(
+                    &candidates,
+                    &query,
+                    true,
+                    true,
+                    100,
+                    &Default::default(),
+                    background,
+                )
+                .await
+            };
+
+            if !query.trim().is_empty()
+                && !matches.iter().any(|candidate| candidate.string == query)
+            {
+                matches.insert(
+                    0,
+                    StringMatch {
+                        candidate_id: usize::MAX,
+                        string: query,
+                        positions: Vec::new(),
+                        score: 1.0,
+                    },
+                );
+            }
+
+            picker
+                .update(cx, |picker, _| {
+                    picker.delegate.matches = matches;
+                    picker.delegate.selected_index = 0;
+                })
+                .log_err();
+        })
+    }
+
+    fn confirm(
+        &mut self,
+        omit_history_entry: bool,
+        window: &mut Window,
+        cx: &mut Context<Picker<Self>>,
+    ) {
+        if self.is_running() {
+            return;
+        }
+
+        let Some(command) = self
+            .matches
+            .get(self.selected_index)
+            .map(|candidate| candidate.string.clone())
+        else {
+            return;
+        };
+
+        self.execute_command(command, omit_history_entry, window, cx);
+    }
+
+    fn confirm_input(
+        &mut self,
+        omit_history_entry: bool,
+        window: &mut Window,
+        cx: &mut Context<Picker<Self>>,
+    ) {
+        if self.is_running() {
+            return;
+        }
+
+        let command = self.prompt.clone();
+        self.execute_command(command, omit_history_entry, window, cx);
+    }
+
+    fn dismissed(&mut self, _window: &mut Window, cx: &mut Context<Picker<Self>>) {
+        self.modal
+            .update(cx, |_, cx| {
+                cx.emit(DismissEvent);
+            })
+            .ok();
+    }
+
+    fn render_match(
+        &self,
+        ix: usize,
+        selected: bool,
+        _window: &mut Window,
+        _cx: &mut Context<Picker<Self>>,
+    ) -> Option<Self::ListItem> {
+        let command = self.matches.get(ix)?.string.clone();
+        Some(
+            ListItem::new(ix)
+                .inset(true)
+                .spacing(ListItemSpacing::Sparse)
+                .toggle_state(selected)
+                .child(Label::new(command)),
+        )
+    }
+
+    fn render_footer(
+        &self,
+        _window: &mut Window,
+        cx: &mut Context<Picker<Self>>,
+    ) -> Option<gpui::AnyElement> {
+        let action = picker::ConfirmInput { secondary: false }.boxed_clone();
+        let is_running = self.is_running();
+
+        Some(
+            h_flex()
+                .w_full()
+                .p_1p5()
+                .justify_between()
+                .border_t_1()
+                .border_color(cx.theme().colors().border_variant)
+                .when(!is_running, |this| {
+                    this.child(
+                        h_flex()
+                            .gap_1()
+                            .items_center()
+                            .child(Label::new("Timeout (s):"))
+                            .child(
+                                h_flex()
+                                    .items_center()
+                                    .gap_0()
+                                    .child(
+                                        Button::new("decrease-timeout", "-")
+                                            .on_click({
+                                                let picker = self.picker.clone();
+                                                move |_, window, cx| {
+                                                    if let Some(picker) = &picker {
+                                                        picker
+                                                            .update(cx, |picker, cx| {
+                                                                picker.delegate.update_timeout(
+                                                                    true, window, cx,
+                                                                );
+                                                            })
+                                                            .ok();
+                                                    }
+                                                }
+                                            }),
+                                    )
+                                    .child(h_flex().w(rems(6.)).child(self.timeout_input.clone()))
+                                    .child(
+                                        Button::new("increase-timeout", "+")
+                                            .on_click({
+                                                let picker = self.picker.clone();
+                                                move |_, window, cx| {
+                                                    if let Some(picker) = &picker {
+                                                        picker
+                                                            .update(cx, |picker, cx| {
+                                                                picker.delegate.update_timeout(
+                                                                    false, window, cx,
+                                                                );
+                                                            })
+                                                            .ok();
+                                                    }
+                                                }
+                                            }),
+                                    ),
+                            ),
+                    )
+                })
+                .child(
+                    h_flex()
+                        .gap_1()
+                        .when(is_running, |this| {
+                            this.child(
+                                Button::new("stop", "Stop")
+                                    .on_click({
+                                        let shared_state = self.shared_state.clone();
+                                        move |_, _, _cx| {
+                                            if let Some(cancel_requested) = shared_state
+                                                .cancel_requested
+                                                .lock()
+                                                .as_ref()
+                                                .cloned()
+                                            {
+                                                cancel_requested.store(true, Ordering::Relaxed);
+                                            }
+                                        }
+                                    }),
+                            )
+                            .child(
+                                Button::new("hide", "Hide")
+                                    .on_click({
+                                        let modal = self.modal.clone();
+                                        move |_, _, cx| {
+                                            modal
+                                                .update(cx, |_, cx| {
+                                                    cx.emit(DismissEvent);
+                                                })
+                                                .ok();
+                                        }
+                                    }),
+                            )
+                        })
+                        .when(!is_running, |this| {
+                            this.child(
+                                Button::new("run", "Run")
+                                    .key_binding(KeyBinding::for_action(&*action, cx))
+                                    .on_click(move |_, window, cx| {
+                                        window.dispatch_action(action.boxed_clone(), cx);
+                                    }),
+                            )
+                        }),
+                )
+                .into_any_element(),
+        )
+    }
+}
+
+fn load_history() -> Vec<String> {
+    KEY_VALUE_STORE
+        .scoped(ONESHOT_HISTORY_NAMESPACE)
+        .read(ONESHOT_HISTORY_KEY)
+        .ok()
+        .flatten()
+        .and_then(|serialized| serde_json::from_str::<Vec<String>>(&serialized).ok())
+        .unwrap_or_default()
+}
+
+fn persist_history(
+    history: &mut Vec<String>,
+    command: &str,
+    cx: &mut Context<Picker<UnixCommandModalDelegate>>,
+) {
+    if !remember_history_entry(history, command) {
+        return;
+    }
+
+    let Ok(serialized) = serde_json::to_string(history) else {
+        return;
+    };
+
+    cx.spawn(async move |_picker, _cx| {
+        KEY_VALUE_STORE
+            .scoped(ONESHOT_HISTORY_NAMESPACE)
+            .write(ONESHOT_HISTORY_KEY.to_string(), serialized)
+            .await
+    })
+    .detach_and_log_err(cx);
+}
+
+fn remember_history_entry(history: &mut Vec<String>, command: &str) -> bool {
+    let trimmed_command = command.trim();
+    if trimmed_command.is_empty() {
+        return false;
+    }
+
+    history.retain(|entry| entry != trimmed_command);
+    history.push(trimmed_command.to_string());
+    if history.len() > MAX_HISTORY_ITEMS {
+        let overflow = history.len() - MAX_HISTORY_ITEMS;
+        history.drain(..overflow);
+    }
+
+    true
+}
+
+fn decrement_timeout_seconds(current: u64) -> u64 {
+    current.saturating_sub(1).max(MIN_TIMEOUT_SECONDS)
+}
+
+fn increment_timeout_seconds(current: u64) -> u64 {
+    current.saturating_add(1).max(MIN_TIMEOUT_SECONDS)
+}
+
+fn parse_timeout_seconds(input: &str) -> Option<u64> {
+    input
+        .trim()
+        .parse::<u64>()
+        .ok()
+        .map(|timeout_seconds| timeout_seconds.max(MIN_TIMEOUT_SECONDS))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_remember_history_entry_dedupes_and_trims() {
+        let mut history = vec!["echo a".to_string(), "echo b".to_string()];
+
+        assert!(remember_history_entry(&mut history, "  echo a  "));
+        assert_eq!(history, vec!["echo b".to_string(), "echo a".to_string()]);
+
+        assert!(!remember_history_entry(&mut history, "   "));
+        assert_eq!(history, vec!["echo b".to_string(), "echo a".to_string()]);
+    }
+
+    #[test]
+    fn test_remember_history_entry_respects_max_size() {
+        let mut history = (0..MAX_HISTORY_ITEMS)
+            .map(|index| format!("command-{index}"))
+            .collect::<Vec<_>>();
+
+        assert!(remember_history_entry(&mut history, "new-command"));
+        assert_eq!(history.len(), MAX_HISTORY_ITEMS);
+        assert_eq!(history.first().unwrap(), "command-1");
+        assert_eq!(history.last().unwrap(), "new-command");
+    }
+
+    #[test]
+    fn test_timeout_adjustment_functions() {
+        assert_eq!(decrement_timeout_seconds(10), 9);
+        assert_eq!(decrement_timeout_seconds(1), 1);
+        assert_eq!(decrement_timeout_seconds(0), 1);
+
+        assert_eq!(increment_timeout_seconds(10), 11);
+        assert_eq!(increment_timeout_seconds(0), 1);
+    }
+
+    #[test]
+    fn test_parse_timeout_seconds() {
+        assert_eq!(parse_timeout_seconds("10"), Some(10));
+        assert_eq!(parse_timeout_seconds(" 42 "), Some(42));
+        assert_eq!(parse_timeout_seconds("0"), Some(1));
+        assert_eq!(parse_timeout_seconds("not-a-number"), None);
+    }
+}

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -5,7 +5,7 @@ use gpui::{App, AppContext as _, Context, Entity, Task, WeakEntity};
 use futures::{FutureExt, future::Shared};
 use itertools::Itertools as _;
 use language::LanguageName;
-use remote::RemoteClient;
+use remote::{Interactive, RemoteClient};
 use settings::{Settings, SettingsLocation};
 use smol::channel::bounded;
 use std::{
@@ -519,6 +519,23 @@ impl Project {
         command: String,
         cx: &mut Context<Self>,
     ) -> Task<Result<smol::process::Command>> {
+        self.exec_in_shell_with_interactive_mode(command, Interactive::Yes, cx)
+    }
+
+    pub fn exec_in_shell_for_pipe(
+        &self,
+        command: String,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<smol::process::Command>> {
+        self.exec_in_shell_with_interactive_mode(command, Interactive::No, cx)
+    }
+
+    fn exec_in_shell_with_interactive_mode(
+        &self,
+        command: String,
+        interactive: Interactive,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<smol::process::Command>> {
         let path = self.first_project_directory(cx);
         let remote_client = self.remote_client.clone();
         let settings = self.terminal_settings(&path, cx).clone();
@@ -545,12 +562,13 @@ impl Project {
             project.update(cx, move |_, cx| {
                 match remote_client {
                     Some(remote_client) => {
-                        let command_template = remote_client.read(cx).build_command(
+                        let command_template = remote_client.read(cx).build_command_with_options(
                             Some(command),
                             &args,
                             &env,
                             None,
                             None,
+                            interactive,
                         )?;
                         let mut command = new_std_command(command_template.program);
                         command.args(command_template.args);


### PR DESCRIPTION
Closes #12598

implementing pipe selection to command and replace original selection or copy to clipboard or create new document with output

<img width="833" height="306" alt="image" src="https://github.com/user-attachments/assets/284386ec-35a1-4d3c-97e4-b595ac428a5c" />
<img width="647" height="157" alt="image" src="https://github.com/user-attachments/assets/247cc708-e7ae-46e2-8963-e0d5acdba71e" />
<img width="434" height="236" alt="image" src="https://github.com/user-attachments/assets/78ae0c69-6a8b-44b3-a840-1ac68d74264f" />
