### PR TITLE
Add edit prediction evals that test related excerpt usage

### DIFF
--- a/crates/edit_prediction_cli/evals/vscode--log-object-property.md
+++ b/crates/edit_prediction_cli/evals/vscode--log-object-property.md
@@ -1,0 +1,56 @@
++++
+repository_url = "https://github.com/microsoft/vscode"
+revision = "e28a92fc1fbe9de11eca2f8ad19899334bff8525"
++++
+
+This prediction requires the model to see the `IDiffComputationResult` type definition.
+
+## Edit History
+
+```diff
+--- a/src/vs/editor/browser/widget/diffEditorWidget.ts
++++ b/src/vs/editor/browser/widget/diffEditorWidget.ts
+@@ -1117,6 +1117,7 @@
+ 				&& currentModifiedModel === this._modifiedEditor.getModel()
+ 			) {
+ 				this._setState(editorBrowser.DiffEditorState.DiffComputed);
++				console.log("did quit:")
+ 				this._diffComputationResult = result;
+ 				this._updateDecorationsRunner.schedule();
+ 				this._onDidUpdateDiff.fire();
+```
+
+## Cursor Position
+
+```src/vs/editor/browser/widget/diffEditorWidget.ts
+			if (currentToken === this._diffComputationToken
+				&& currentOriginalModel === this._originalEditor.getModel()
+				&& currentModifiedModel === this._modifiedEditor.getModel()
+			) {
+				this._setState(editorBrowser.DiffEditorState.DiffComputed);
+				console.log("did quit:")
+				//                    ^[CURSOR_POSITION]
+				this._diffComputationResult = result;
+				this._updateDecorationsRunner.schedule();
+				this._onDidUpdateDiff.fire();
+			}
+```
+
+## Expected Patch
+
+```diff
+--- a/src/vs/editor/browser/widget/diffEditorWidget.ts
++++ b/src/vs/editor/browser/widget/diffEditorWidget.ts
+@@ -1115,10 +1115,10 @@
+ 			if (currentToken === this._diffComputationToken
+ 				&& currentOriginalModel === this._originalEditor.getModel()
+ 				&& currentModifiedModel === this._modifiedEditor.getModel()
+ 			) {
+ 				this._setState(editorBrowser.DiffEditorState.DiffComputed);
+-				console.log("did quit:")
++				console.log("did quit:", result.quitEarly)
+ 				this._diffComputationResult = result;
+ 				this._updateDecorationsRunner.schedule();
+ 				this._onDidUpdateDiff.fire();
+ 			}
+```

--- a/crates/edit_prediction_cli/evals/zed--add-eprintln.md
+++ b/crates/edit_prediction_cli/evals/zed--add-eprintln.md
@@ -1,43 +1,37 @@
 +++
 repository_url = "git@github.com:zed-industries/zed"
-revision = "780a87dd98f26816876d12e2728933b17faca78d"
+revision = "b7090c9fae7390a82021b994994c0f587744d96c"
 +++
+
+This example shows the model's preference for making conservative predictions, and ability to place
+the cursor within the predicted output.
 
 ## Edit History
 
 ```diff
 --- a/crates/edit_prediction_ui/src/rate_prediction_modal.rs
 +++ b/crates/edit_prediction_ui/src/rate_prediction_modal.rs
-@@ -206,6 +206,7 @@
-         self.select_next_edit(&Default::default(), window, cx);
-         self.confirm(&Default::default(), window, cx);
-
+@@ -144,7 +144,7 @@
+     fn select_next_edit(&mut self, _: &NextEdit, _: &mut Window, cx: &mut Context<Self>) {
 +        epr
-         cx.notify();
-     }
-
+         let next_index = self
+             .ep_store
+             .read(cx)
 ```
 
 ## Cursor Position
 
 ```crates/edit_prediction_ui/src/rate_prediction_modal.rs
-        let current_completion = self
-            .active_prediction
-            .as_ref()
-            .map(|completion| completion.prediction.clone());
-        self.select_completion(current_completion, false, window, cx);
-        self.select_next_edit(&Default::default(), window, cx);
-        self.confirm(&Default::default(), window, cx);
-
+    fn select_next_edit(&mut self, _: &NextEdit, _: &mut Window, cx: &mut Context<Self>) {
         epr
         // ^[CURSOR_POSITION]
-        cx.notify();
-    }
-
-    pub fn thumbs_down_active(
-        &mut self,
-        _: &ThumbsDownActivePrediction,
-        window: &mut Window,
+        let next_index = self
+            .ep_store
+            .read(cx)
+            .shown_predictions()
+            .skip(self.selected_index)
+            .enumerate()
+            .skip(1) // Skip straight to the next item
 ```
 
 ## Expected Patch
@@ -45,12 +39,16 @@ revision = "780a87dd98f26816876d12e2728933b17faca78d"
 ```diff
 --- a/crates/edit_prediction_ui/src/rate_prediction_modal.rs
 +++ b/crates/edit_prediction_ui/src/rate_prediction_modal.rs
-@@ -201,16 +201,16 @@
-         self.confirm(&Default::default(), window, cx);
-
+@@ -144,14 +144,14 @@
+     fn select_next_edit(&mut self, _: &NextEdit, _: &mut Window, cx: &mut Context<Self>) {
 -        epr
 +        eprintln!("");
 #                   ^[CURSOR_POSITION]
-         cx.notify();
-     }
+         let next_index = self
+             .ep_store
+             .read(cx)
+             .shown_predictions()
+             .skip(self.selected_index)
+             .enumerate()
+             .skip(1) // Skip straight to the next item
 ```

--- a/crates/edit_prediction_cli/evals/zed--change-match-arm.md
+++ b/crates/edit_prediction_cli/evals/zed--change-match-arm.md
@@ -1,0 +1,68 @@
++++
+repository_url = "git@github.com:zed-industries/zed"
+revision = "be5763632dccb33470ca233c36ccd9e5e790e3b2"
++++
+
+This prediction requires the model to see the `project::Event` enum.
+
+## Edit History
+
+```diff
+--- a/crates/edit_prediction/src/edit_prediction.rs
++++ b/crates/edit_prediction/src/edit_prediction.rs
+@@ -1035,7 +1035,7 @@
+                     project_state.recent_paths.push_front(path);
+                 }
+             }
+-            project::Event::DiagnosticsUpdated { .. } => {
++            project::Event::Disk { .. } => {
+                 if cx.has_flag::<EditPredictionJumpsFeatureFlag>() {
+                     self.refresh_prediction_from_diagnostics(
+                         project,
+```
+
+## Cursor Position
+
+```crates/edit_prediction/src/edit_prediction.rs
+                    {
+                        project_state.recent_paths.remove(ix);
+                    }
+                    project_state.recent_paths.push_front(path);
+                }
+            }
+            project::Event::Disk { .. } => {
+                //              ^[CURSOR_POSITION]
+                if cx.has_flag::<EditPredictionJumpsFeatureFlag>() {
+                    self.refresh_prediction_from_diagnostics(
+                        project,
+```
+
+## Expected Patch
+
+```diff
+--- a/crates/edit_prediction/src/edit_prediction.rs
++++ b/crates/edit_prediction/src/edit_prediction.rs
+@@ -1032,10 +1032,10 @@
+                     project_state.recent_paths.push_front(path);
+                 }
+             }
+-            project::Event::Disk { .. } => {
++            project::Event::DiskBasedDiagnosticsFinished { .. } => {
+                 if cx.has_flag::<EditPredictionJumpsFeatureFlag>() {
+                     self.refresh_prediction_from_diagnostics(
+                         project,
+```
+
+```diff
+--- a/crates/edit_prediction/src/edit_prediction.rs
++++ b/crates/edit_prediction/src/edit_prediction.rs
+@@ -1032,10 +1032,10 @@
+                     project_state.recent_paths.push_front(path);
+                 }
+             }
+-            project::Event::Disk { .. } => {
++            project::Event::DiskBasedDiagnosticsStarted { .. } => {
+                 if cx.has_flag::<EditPredictionJumpsFeatureFlag>() {
+                     self.refresh_prediction_from_diagnostics(
+                         project,
+```


### PR DESCRIPTION
I've also fixed a race condition with the programmatic context retrieval in the CLI, which was causing no excerpts to be fetched for the Rust examples.

Release Notes:

- N/A
