### PR TITLE
gpui(web): Prevent crash from zero-size swapchain

### DIFF
--- a/crates/gpui_web/src/window.rs
+++ b/crates/gpui_web/src/window.rs
@@ -637,7 +637,11 @@ impl PlatformWindow for WebWindow {
     }
 
     fn draw(&self, scene: &Scene) {
-        self.inner.state.borrow_mut().renderer.draw(scene);
+        let mut state = self.inner.state.borrow_mut();
+        if state.bounds.size.width <= Pixels::ZERO || state.bounds.size.height <= Pixels::ZERO {
+            return;
+        }
+        state.renderer.draw(scene);
     }
 
     fn completed_frame(&self) {

--- a/crates/gpui_wgpu/src/wgpu_renderer.rs
+++ b/crates/gpui_wgpu/src/wgpu_renderer.rs
@@ -241,8 +241,8 @@ impl WgpuRenderer {
         let surface_config = wgpu::SurfaceConfiguration {
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
             format: surface_format,
-            width: config.size.width.0 as u32,
-            height: config.size.height.0 as u32,
+            width: (config.size.width.0 as u32).max(1),
+            height: (config.size.height.0 as u32).max(1),
             present_mode: wgpu::PresentMode::Fifo,
             desired_maximum_frame_latency: 2,
             alpha_mode,


### PR DESCRIPTION
Fixes a crash when using gpui-on-web which occurs due to the swapchain being 0x0 at startup. On firefox it would fully close the program, and on chrome it would produce errors, but still run.

Release Notes:

- N/A
