### PR TITLE
git_panel: Respect sort by path in tree view

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -211,17 +211,15 @@ fn git_panel_context_menu(
                 Some(Box::new(ToggleTreeView)),
                 move |window, cx| window.dispatch_action(Box::new(ToggleTreeView), cx),
             )
-            .when(!state.tree_view, |this| {
-                this.entry(
-                    if state.sort_by_path {
-                        "Sort by Status"
-                    } else {
-                        "Sort by Path"
-                    },
-                    Some(Box::new(ToggleSortByPath)),
-                    move |window, cx| window.dispatch_action(Box::new(ToggleSortByPath), cx),
-                )
-            })
+            .entry(
+                if state.sort_by_path {
+                    "Sort by Status"
+                } else {
+                    "Sort by Path"
+                },
+                Some(Box::new(ToggleSortByPath)),
+                move |window, cx| window.dispatch_action(Box::new(ToggleSortByPath), cx),
+            )
     })
 }
 

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -3502,7 +3502,7 @@ impl GitPanel {
 
         let sort_by_path = GitPanelSettings::get_global(cx).sort_by_path;
         let is_tree_view = matches!(self.view_mode, GitPanelViewMode::Tree(_));
-        let group_by_status = is_tree_view || !sort_by_path;
+        let group_by_status = !sort_by_path;
 
         let mut changed_entries = Vec::new();
         let mut new_entries = Vec::new();
@@ -3638,12 +3638,14 @@ impl GitPanel {
                         continue;
                     }
 
-                    push_entry(
-                        self,
-                        GitListEntry::Header(GitHeaderEntry { header: section }),
-                        true,
-                        Some(&mut tree_state.logical_indices),
-                    );
+                    if group_by_status {
+                        push_entry(
+                            self,
+                            GitListEntry::Header(GitHeaderEntry { header: section }),
+                            true,
+                            Some(&mut tree_state.logical_indices),
+                        );
+                    }
 
                     for (entry, is_visible) in
                         tree_state.build_tree_entries(section, entries, &mut seen_directories)
@@ -3668,7 +3670,7 @@ impl GitPanel {
                         continue;
                     }
 
-                    if section != Section::Tracked || !sort_by_path {
+                    if group_by_status {
                         push_entry(
                             self,
                             GitListEntry::Header(GitHeaderEntry { header: section }),
@@ -7247,6 +7249,91 @@ mod tests {
 
             assert_eq!(active_path.path, rel_path("untracked").into_arc());
         });
+    }
+
+    #[gpui::test]
+    async fn test_tree_view_sort_by_path_does_not_group_by_status(cx: &mut TestAppContext) {
+        use GitListEntry::*;
+
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.background_executor.clone());
+        fs.insert_tree(
+            path!("/project"),
+            json!({
+                ".git": {},
+                "a_untracked": "",
+                "b_tracked": "tracked\n",
+                "c_untracked": "",
+            }),
+        )
+        .await;
+
+        fs.set_status_for_repo(
+            path!("/project/.git").as_ref(),
+            &[
+                ("a_untracked", FileStatus::Untracked),
+                ("b_tracked", StatusCode::Modified.worktree()),
+                ("c_untracked", FileStatus::Untracked),
+            ],
+        );
+
+        let project = Project::test(fs.clone(), [Path::new(path!("/project"))], cx).await;
+        let window_handle =
+            cx.add_window(|window, cx| MultiWorkspace::test_new(project.clone(), window, cx));
+        let workspace = window_handle
+            .read_with(cx, |mw, _| mw.workspace().clone())
+            .unwrap();
+        let cx = &mut VisualTestContext::from_window(window_handle.into(), cx);
+
+        cx.read(|cx| {
+            project
+                .read(cx)
+                .worktrees(cx)
+                .next()
+                .unwrap()
+                .read(cx)
+                .as_local()
+                .unwrap()
+                .scan_complete()
+        })
+        .await;
+
+        cx.executor().run_until_parked();
+
+        cx.update(|_window, cx| {
+            SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings(cx, |settings| {
+                    let git_panel = settings.git_panel.get_or_insert_default();
+                    git_panel.tree_view = Some(true);
+                    git_panel.sort_by_path = Some(true);
+                })
+            });
+        });
+
+        let panel = workspace.update_in(cx, GitPanel::new);
+
+        let handle = cx.update_window_entity(&panel, |panel, _, _| {
+            std::mem::replace(&mut panel.update_visible_entries_task, Task::ready(()))
+        });
+        cx.executor().advance_clock(2 * UPDATE_DEBOUNCE);
+        handle.await;
+
+        let entries = panel.read_with(cx, |panel, _| panel.entries.clone());
+        #[rustfmt::skip]
+        pretty_assertions::assert_matches!(
+            entries.as_slice(),
+            &[
+                TreeStatus(GitTreeStatusEntry { entry: GitStatusEntry { status: FileStatus::Untracked, .. }, .. }),
+                TreeStatus(GitTreeStatusEntry { entry: GitStatusEntry { status: FileStatus::Tracked(..), .. }, .. }),
+                TreeStatus(GitTreeStatusEntry { entry: GitStatusEntry { status: FileStatus::Untracked, .. }, .. }),
+            ],
+        );
+
+        assert_entry_paths(
+            &entries,
+            &[Some("a_untracked"), Some("b_tracked"), Some("c_untracked")],
+        );
     }
 
     #[gpui::test]


### PR DESCRIPTION
https://github.com/user-attachments/assets/11a340e4-de00-4dca-ba97-047e86289377

Sort By Path had no effect when Tree View is enabled. 
Sort By Path is now respected in Tree View. 
As per the setting description Sort By Path is expected to disable the sort by status (aka disable grouping by statuses)
Now when Sort By Path and Tree View are enabled, grouping is disabled. (see last state in video)

Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- Fix Tree View mode in Git Panel to supports no grouping