### PR TITLE
Revert "sidebar: Zoom temporarily hides sidebar (#50088)"

### DIFF
--- a/crates/workspace/src/multi_workspace.rs
+++ b/crates/workspace/src/multi_workspace.rs
@@ -672,7 +672,6 @@ impl MultiWorkspace {
 impl Render for MultiWorkspace {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let multi_workspace_enabled = self.multi_workspace_enabled(cx);
-        let is_zoomed = self.workspace().read(cx).zoomed_item().is_some();
 
         let sidebar: Option<AnyElement> = if multi_workspace_enabled && self.sidebar_open {
             self.sidebar.as_ref().map(|sidebar_handle| {
@@ -784,14 +783,13 @@ impl Render for MultiWorkspace {
                         .flex_1()
                         .size_full()
                         .overflow_hidden()
-                        .when(is_zoomed, |this| this.absolute().inset_0())
                         .child(self.workspace().clone()),
                 )
                 .child(self.workspace().read(cx).modal_layer.clone()),
             window,
             cx,
             Tiling {
-                left: multi_workspace_enabled && self.sidebar_open && !is_zoomed,
+                left: multi_workspace_enabled && self.sidebar_open,
                 ..Tiling::default()
             },
         )


### PR DESCRIPTION
This reverts commit aa3a12b566, because we no longer want a zoomed item to block the sidebar.

This is because the sidebar is used for navigation and it interrupts a user's flow if they're scrolling through their active workspaces, and the sidebar just vanishes.

### Before
<img width="3248" height="2122" alt="image" src="https://github.com/user-attachments/assets/c1c94b2c-fbbc-41a4-8eb9-47160ecba994" />

### After
<img width="1624" height="1061" alt="Screenshot 2026-02-27 at 2 10 24 PM" src="https://github.com/user-attachments/assets/91d70281-f8ed-4da5-8e50-056370eb2fee" />


Before you mark this PR as ready for review, make sure that you have:
- [x] Added a solid test coverage and/or screenshots from doing manual testing
- [x] Done a self-review taking into account security and performance aspects
- [x] Aligned any UI changes with the [UI checklist](https://github.com/zed-industries/zed/blob/main/CONTRIBUTING.md#uiux-checklist)

Release Notes:

- N/A
