### PR TITLE
extension_ci: Add formatting check for Tree-sitter queries

### DIFF
--- a/.github/workflows/extension_tests.yml
+++ b/.github/workflows/extension_tests.yml
@@ -109,6 +109,21 @@ jobs:
         mkdir -p /tmp/ext-scratch
         mkdir -p /tmp/ext-output
         ./zed-extension --source-dir . --scratch-dir /tmp/ext-scratch --output-dir /tmp/ext-output
+    - name: run_tests::fetch_ts_query_ls
+      uses: dsaltares/fetch-gh-release-asset@aa37ae5c44d3c9820bc12fe675e8670ecd93bd1c
+      with:
+        repo: ribru17/ts_query_ls
+        version: tags/v3.15.1
+        file: ts_query_ls-x86_64-unknown-linux-gnu.tar.gz
+    - name: run_tests::run_ts_query_ls
+      run: |-
+        tar -xf ts_query_ls-x86_64-unknown-linux-gnu.tar.gz
+        ./ts_query_ls format --check . || {
+            echo "Found unformatted queries, please format them with ts_query_ls."
+            echo "For easy use, install the Tree-sitter query extension:"
+            echo "zed://extension/tree-sitter-query"
+            false
+        }
     - id: compare-versions-check
       name: extension_bump::compare_versions
       run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -139,13 +139,13 @@ jobs:
       uses: crate-ci/typos@2d0ce569feab1f8752f1dde43cc2f2aa53236e06
       with:
         config: ./typos.toml
-    - name: run_tests::check_style::fetch_ts_query_ls
+    - name: run_tests::fetch_ts_query_ls
       uses: dsaltares/fetch-gh-release-asset@aa37ae5c44d3c9820bc12fe675e8670ecd93bd1c
       with:
         repo: ribru17/ts_query_ls
         version: tags/v3.15.1
         file: ts_query_ls-x86_64-unknown-linux-gnu.tar.gz
-    - name: run_tests::check_style::run_ts_query_ls
+    - name: run_tests::run_ts_query_ls
       run: |-
         tar -xf ts_query_ls-x86_64-unknown-linux-gnu.tar.gz
         ./ts_query_ls format --check . || {

--- a/tooling/xtask/src/tasks/workflows/extension_tests.rs
+++ b/tooling/xtask/src/tasks/workflows/extension_tests.rs
@@ -3,7 +3,9 @@ use indoc::{formatdoc, indoc};
 
 use crate::tasks::workflows::{
     extension_bump::compare_versions,
-    run_tests::{orchestrate_without_package_filter, tests_pass},
+    run_tests::{
+        fetch_ts_query_ls, orchestrate_without_package_filter, run_ts_query_ls, tests_pass,
+    },
     runners,
     steps::{
         self, CommonJobConditions, FluentBuilder, NamedJob, cache_rust_dependencies_namespace,
@@ -94,6 +96,8 @@ pub(crate) fn check_extension() -> NamedJob {
         .add_step(download_zed_extension_cli(cache_hit))
         .add_step(cache_rust_dependencies_namespace()) // Extensions can compile Rust, so provide the cache if needed.
         .add_step(check())
+        .add_step(fetch_ts_query_ls())
+        .add_step(run_ts_query_ls())
         .add_step(check_version_job)
         .add_step(verify_version_did_not_change(version_changed));
 

--- a/tooling/xtask/src/tasks/workflows/run_tests.rs
+++ b/tooling/xtask/src/tasks/workflows/run_tests.rs
@@ -271,6 +271,29 @@ pub fn tests_pass(jobs: &[NamedJob]) -> NamedJob {
 const TS_QUERY_LS_FILE: &str = "ts_query_ls-x86_64-unknown-linux-gnu.tar.gz";
 const CI_TS_QUERY_RELEASE: &str = "tags/v3.15.1";
 
+pub(crate) fn fetch_ts_query_ls() -> Step<Use> {
+    named::uses(
+        "dsaltares",
+        "fetch-gh-release-asset",
+        "aa37ae5c44d3c9820bc12fe675e8670ecd93bd1c",
+    ) // v1.1.1
+    .add_with(("repo", "ribru17/ts_query_ls"))
+    .add_with(("version", CI_TS_QUERY_RELEASE))
+    .add_with(("file", TS_QUERY_LS_FILE))
+}
+
+pub(crate) fn run_ts_query_ls() -> Step<Run> {
+    named::bash(formatdoc!(
+        r#"tar -xf {TS_QUERY_LS_FILE}
+        ./ts_query_ls format --check . || {{
+            echo "Found unformatted queries, please format them with ts_query_ls."
+            echo "For easy use, install the Tree-sitter query extension:"
+            echo "zed://extension/tree-sitter-query"
+            false
+        }}"#
+    ))
+}
+
 fn check_style() -> NamedJob {
     fn check_for_typos() -> Step<Use> {
         named::uses(
@@ -279,29 +302,6 @@ fn check_style() -> NamedJob {
             "2d0ce569feab1f8752f1dde43cc2f2aa53236e06",
         ) // v1.40.0
         .with(("config", "./typos.toml"))
-    }
-
-    fn fetch_ts_query_ls() -> Step<Use> {
-        named::uses(
-            "dsaltares",
-            "fetch-gh-release-asset",
-            "aa37ae5c44d3c9820bc12fe675e8670ecd93bd1c",
-        ) // v1.1.1
-        .add_with(("repo", "ribru17/ts_query_ls"))
-        .add_with(("version", CI_TS_QUERY_RELEASE))
-        .add_with(("file", TS_QUERY_LS_FILE))
-    }
-
-    fn run_ts_query_ls() -> Step<Run> {
-        named::bash(formatdoc!(
-            r#"tar -xf {TS_QUERY_LS_FILE}
-            ./ts_query_ls format --check . || {{
-                echo "Found unformatted queries, please format them with ts_query_ls."
-                echo "For easy use, install the Tree-sitter query extension:"
-                echo "zed://extension/tree-sitter-query"
-                false
-            }}"#
-        ))
     }
 
     named::job(


### PR DESCRIPTION
This rolls out the formatting check to extensions also.

Release Notes:

- N/A
