### PR TITLE
Fix Linux headless build failure when screen-capture is disabled

### DIFF
--- a/crates/gpui_linux/src/linux/headless/client.rs
+++ b/crates/gpui_linux/src/linux/headless/client.rs
@@ -64,6 +64,7 @@ impl LinuxClient for HeadlessClient {
         None
     }
 
+    #[cfg(feature = "screen-capture")]
     fn screen_capture_sources(
         &self,
     ) -> futures::channel::oneshot::Receiver<anyhow::Result<Vec<Rc<dyn gpui::ScreenCaptureSource>>>>


### PR DESCRIPTION
### Summary
This PR fixes a Linux compilation error encountered during `./script/install-linux` in `gpui_linux` with:

```shell
   Compiling remote_server v0.1.0 (/home/xjin/Program/dev/zed/crates/remote_server)
error[E0407]: method `screen_capture_sources` is not a member of trait `LinuxClient`
  --> crates/gpui_linux/src/linux/headless/client.rs:67:5
   |
67 | /     fn screen_capture_sources(
68 | |         &self,
69 | |     ) -> futures::channel::oneshot::Receiver<anyhow::Result<Vec<Rc<dyn gpui...
...  |
76 | |         rx
77 | |     }
   | |_____^ not a member of trait `LinuxClient`

For more information about this error, try `rustc --explain E0407`.
error: could not compile `gpui_linux` (lib) due to 1 previous error
```

### What was the issue?
Running `./script/install-linux` failed to compile `gpui_linux` due to a trait implementation mismatch in the headless Linux client. The method `screen_capture_sources` was present in `HeadlessClient` `LinuxClient` implementation
even when the trait did not define it for the active feature set.

### Why it was happened?
`LinuxClient::screen_capture_sources` is conditionally defined behind `#[cfg(feature = "screen-capture")]`. However, `HeadlessClient` implemented `screen_capture_sources` unconditionally. When `gpui_linux` was built without the screen-capture feature (as happens in the install-linux build path), the trait method was removed by `cfg`, but the impl method remained, causing E0407.

### How we fixed it?
Aligned the `HeadlessClient` implementation with the trait definition by gating the method with the same feature flag.

This makes feature combinations consistent and prevents compilation failures when `screen-capture` is disabled.

### Validation

- `cargo check -p gpui_linux --no-default-features --features wayland,x11` passes.
- `cargo check -p gpui_linux --no-default-features --features wayland,x11,screen-capture` passes.
- Linux release build invocation used by bundle/install path passes.

Release Notes:

- Fixed a Linux build failure in headless `gpui_linux` when screen-capture is disabled.
