### PR TITLE
ACP: Provide `cwd` in `session/list` request

### DIFF
--- a/crates/agent_ui/src/connection_view.rs
+++ b/crates/agent_ui/src/connection_view.rs
@@ -39,7 +39,7 @@ use prompt_store::{PromptId, PromptStore};
 use rope::Point;
 use settings::{NotifyWhenAgentWaiting, Settings as _, SettingsStore};
 use std::cell::RefCell;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
 use std::{collections::BTreeMap, rc::Rc, time::Duration};

--- a/crates/agent_ui/src/thread_history.rs
+++ b/crates/agent_ui/src/thread_history.rs
@@ -1697,4 +1697,125 @@ mod tests {
         let date = NaiveDate::from_ymd_opt(2022, 12, 28).unwrap();
         assert_eq!(TimeBucket::from_dates(new_year, date), TimeBucket::ThisWeek);
     }
+
+    #[derive(Clone)]
+    struct CwdCapturingSessionList {
+        sessions: Vec<AgentSessionInfo>,
+        captured_cwds: Arc<Mutex<Vec<Option<PathBuf>>>>,
+        updates_tx: smol::channel::Sender<SessionListUpdate>,
+        updates_rx: smol::channel::Receiver<SessionListUpdate>,
+    }
+
+    impl CwdCapturingSessionList {
+        fn new(sessions: Vec<AgentSessionInfo>) -> Self {
+            let (tx, rx) = smol::channel::unbounded();
+            Self {
+                sessions,
+                captured_cwds: Arc::new(Mutex::new(Vec::new())),
+                updates_tx: tx,
+                updates_rx: rx,
+            }
+        }
+
+        fn captured_cwds(&self) -> Vec<Option<PathBuf>> {
+            self.captured_cwds.lock().unwrap().clone()
+        }
+    }
+
+    impl AgentSessionList for CwdCapturingSessionList {
+        fn list_sessions(
+            &self,
+            request: AgentSessionListRequest,
+            _cx: &mut App,
+        ) -> Task<anyhow::Result<AgentSessionListResponse>> {
+            self.captured_cwds.lock().unwrap().push(request.cwd);
+            Task::ready(Ok(AgentSessionListResponse::new(self.sessions.clone())))
+        }
+
+        fn watch(&self, _cx: &mut App) -> Option<smol::channel::Receiver<SessionListUpdate>> {
+            Some(self.updates_rx.clone())
+        }
+
+        fn notify_refresh(&self) {
+            self.updates_tx.try_send(SessionListUpdate::Refresh).ok();
+        }
+
+        fn into_any(self: Rc<Self>) -> Rc<dyn Any> {
+            self
+        }
+    }
+
+    #[gpui::test]
+    async fn test_cwd_is_passed_to_list_sessions(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let session_list = Rc::new(CwdCapturingSessionList::new(vec![test_session(
+            "session-1",
+            "Test Session",
+        )]));
+
+        let (history, cx) = cx.add_window_view(|window, cx| {
+            ThreadHistory::new(Some(session_list.clone()), window, cx)
+        });
+        cx.run_until_parked();
+
+        // Initial request should have no cwd
+        assert_eq!(session_list.captured_cwds(), vec![None]);
+
+        // Set a cwd and verify it's passed to list_sessions
+        let test_cwd = PathBuf::from("/test/project");
+        history.update(cx, |history, cx| {
+            history.set_cwd(Some(test_cwd.clone()), cx);
+        });
+        cx.run_until_parked();
+
+        assert_eq!(
+            session_list.captured_cwds(),
+            vec![None, Some(test_cwd.clone())]
+        );
+
+        // Refresh should continue to use the same cwd
+        history.update(cx, |history, cx| {
+            history.refresh(cx);
+        });
+        cx.run_until_parked();
+
+        assert_eq!(
+            session_list.captured_cwds(),
+            vec![None, Some(test_cwd.clone()), Some(test_cwd)]
+        );
+    }
+
+    #[gpui::test]
+    async fn test_set_cwd_does_not_refresh_if_unchanged(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let session_list = Rc::new(CwdCapturingSessionList::new(vec![test_session(
+            "session-1",
+            "Test Session",
+        )]));
+
+        let (history, cx) = cx.add_window_view(|window, cx| {
+            ThreadHistory::new(Some(session_list.clone()), window, cx)
+        });
+        cx.run_until_parked();
+
+        let test_cwd = PathBuf::from("/test/project");
+        history.update(cx, |history, cx| {
+            history.set_cwd(Some(test_cwd.clone()), cx);
+        });
+        cx.run_until_parked();
+
+        // Setting the same cwd should not trigger another refresh
+        history.update(cx, |history, cx| {
+            history.set_cwd(Some(test_cwd.clone()), cx);
+        });
+        cx.run_until_parked();
+
+        // Should only have 2 requests: initial (None) + first set_cwd
+        assert_eq!(
+            session_list.captured_cwds(),
+            vec![None, Some(test_cwd)]
+        );
+    }
 }


### PR DESCRIPTION
Set the `cwd` parameter in the `sessions/list` request. Agents can use this to filter sessions by project, if they so choose.

<img width="762" height="798" alt="image" src="https://github.com/user-attachments/assets/64a1b09c-adde-4001-a8ea-8e3eed58eafa" />

Release Notes:

- ACP: Send the `cwd` when listing past sessions, allowing agents to filter sessions by project
