### PR TITLE
Dynamically detect surface size limits on WGPU (#50340) (cherry-pick to preview)

### DIFF
--- a/crates/gpui_wgpu/src/wgpu_context.rs
+++ b/crates/gpui_wgpu/src/wgpu_context.rs
@@ -99,14 +99,18 @@ impl WgpuContext {
             );
         }
 
-        let (device, queue) = smol::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
-            label: Some("gpui_device"),
-            required_features,
-            required_limits: wgpu::Limits::default(),
-            memory_hints: wgpu::MemoryHints::MemoryUsage,
-            trace: wgpu::Trace::Off,
-            experimental_features: wgpu::ExperimentalFeatures::disabled(),
-        }))
+        let (device, queue) = smol::block_on(
+            adapter.request_device(&wgpu::DeviceDescriptor {
+                label: Some("gpui_device"),
+                required_features,
+                required_limits: wgpu::Limits::downlevel_defaults()
+                    .using_resolution(adapter.limits())
+                    .using_alignment(adapter.limits()),
+                memory_hints: wgpu::MemoryHints::MemoryUsage,
+                trace: wgpu::Trace::Off,
+                experimental_features: wgpu::ExperimentalFeatures::disabled(),
+            }),
+        )
         .map_err(|e| anyhow::anyhow!("Failed to create wgpu device: {e}"))?;
 
         Ok((device, queue, dual_source_blending_available))


### PR DESCRIPTION
Cherry-pick of #50340 to the preview branch (v0.226.x).

The original PR changed `wgpu::Limits::downlevel_defaults()` to include `.using_resolution(adapter.limits()).using_alignment(adapter.limits())` to dynamically detect surface size limits.

This cherry-pick required conflict resolution because the preview branch has a different code structure:
- Preview uses a synchronous `create_device` function with `smol::block_on`
- Preview doesn't have the WASM-related code paths
- Preview used `wgpu::Limits::default()` instead of `wgpu::Limits::downlevel_defaults()`

The change was adapted to apply the fix (`downlevel_defaults()` + `.using_resolution()` + `.using_alignment()`) to the preview branch's code structure.

Release Notes:

- N/A