### PR TITLE
ci: Use clang/++ in Build docs step to build libwebrtc

### DIFF
--- a/.github/workflows/deploy_cloudflare.yml
+++ b/.github/workflows/deploy_cloudflare.yml
@@ -23,6 +23,8 @@ jobs:
       - name: Build docs
         uses: ./.github/actions/build_docs
         env:
+          CC: clang
+          CXX: clang++
           DOCS_AMPLITUDE_API_KEY: ${{ secrets.DOCS_AMPLITUDE_API_KEY }}
 
       - name: Deploy Docs


### PR DESCRIPTION
Release Notes:

- N/A
