### PR TITLE
acp_thread: Handle UsageUpdate in ACP session notifications

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -1348,6 +1348,18 @@ impl AcpThread {
                 config_options,
                 ..
             }) => cx.emit(AcpThreadEvent::ConfigOptionsUpdated(config_options)),
+            acp::SessionUpdate::UsageUpdate(usage) => {
+                self.update_token_usage(
+                    Some(TokenUsage {
+                        max_tokens: usage.size,
+                        used_tokens: usage.used,
+                        input_tokens: 0,
+                        output_tokens: 0,
+                        max_output_tokens: None,
+                    }),
+                    cx,
+                );
+            }
             _ => {}
         }
         Ok(())


### PR DESCRIPTION
The `UsageUpdate` variant from external ACP agent servers (e.g. `claude-agent-acp`) was silently dropped by the catch-all `_ => {}` match arm in `handle_session_update()`. This adds a match arm that routes it to the existing `update_token_usage()` method.

This enables the context window progress ring and token limit warning banners that already exist in Zed's UI for ACP-based agent servers.

**What changed:**
- Added a match arm for `acp::SessionUpdate::UsageUpdate` in `AcpThread::handle_session_update()` that maps `usage.size` → `max_tokens` and `usage.used` → `used_tokens`, then calls `self.update_token_usage()`

**Why:**
- The `UsageUpdate` type is already defined in `agent-client-protocol` (behind `unstable_session_usage`, which Zed enables)
- The upstream `claude-agent-acp` server already sends `usage_update` notifications with `used`, `size`, and `cost`
- `update_token_usage()`, `TokenUsage`, the circular progress widget, and the warning banners all already exist — they just weren't wired up for ACP sessions

Before you mark this PR as ready for review, make sure that you have:
- [x] Done a self-review taking into account security and performance aspects

Release Notes:

- Fixed context window usage display (progress ring and warning banners) not appearing for external ACP agent servers