### PR TITLE
Clamp highlight ranges to valid character boundaries in tests

### DIFF
--- a/crates/gpui/src/elements/text.rs
+++ b/crates/gpui/src/elements/text.rs
@@ -945,4 +945,39 @@ mod tests {
         let _ = div().child(Cow::Borrowed("Cow"));
         let _ = div().child(SharedString::from("SharedString"));
     }
+
+    #[test]
+    fn test_with_runs_tolerates_non_char_boundary() {
+        use crate::{Font, StyledText, TextRun, black};
+
+        // "é" is 2 bytes (0xC3 0xA9). A run of len=1 splits the character.
+        let text = "é";
+        let run = TextRun {
+            len: 1,
+            font: Font::default(),
+            color: black(),
+            background_color: None,
+            underline: None,
+            strikethrough: None,
+        };
+        // Should not panic.
+        let _ = StyledText::new(text).with_runs(vec![run]);
+    }
+
+    #[test]
+    fn test_with_runs_tolerates_runs_exceeding_text_length() {
+        use crate::{Font, StyledText, TextRun, black};
+
+        let text = "hi";
+        let run = TextRun {
+            len: 10,
+            font: Font::default(),
+            color: black(),
+            background_color: None,
+            underline: None,
+            strikethrough: None,
+        };
+        // Should not panic.
+        let _ = StyledText::new(text).with_runs(vec![run]);
+    }
 }

--- a/crates/gpui/src/elements/text.rs
+++ b/crates/gpui/src/elements/text.rs
@@ -222,17 +222,26 @@ impl StyledText {
     ) -> Vec<TextRun> {
         let mut runs = Vec::new();
         let mut ix = 0;
-        for (range, highlight) in highlights {
+        for (mut range, highlight) in highlights {
+            range.start = range.start.min(text.len());
+            range.end = range.end.min(text.len());
+
+            while range.start > 0 && !text.is_char_boundary(range.start) {
+                range.start -= 1;
+            }
+
+            while range.end < text.len() && !text.is_char_boundary(range.end) {
+                range.end += 1;
+            }
+
             if ix < range.start {
-                debug_assert!(text.is_char_boundary(range.start));
                 runs.push(default_style.clone().to_run(range.start - ix));
             }
-            debug_assert!(text.is_char_boundary(range.end));
             runs.push(
                 default_style
                     .clone()
                     .highlight(highlight)
-                    .to_run(range.len()),
+                    .to_run(range.end - range.start),
             );
             ix = range.end;
         }
@@ -948,36 +957,25 @@ mod tests {
 
     #[test]
     fn test_with_runs_tolerates_non_char_boundary() {
-        use crate::{Font, StyledText, TextRun, black};
+        use crate::{HighlightStyle, StyledText, TextStyle};
+        use std::ops::Range;
 
-        // "é" is 2 bytes (0xC3 0xA9). A run of len=1 splits the character.
+        // "é" is 2 bytes (0xC3 0xA9). A highlight range that splits the character.
         let text = "é";
-        let run = TextRun {
-            len: 1,
-            font: Font::default(),
-            color: black(),
-            background_color: None,
-            underline: None,
-            strikethrough: None,
-        };
-        // Should not panic.
-        let _ = StyledText::new(text).with_runs(vec![run]);
+        let default_style = TextStyle::default();
+        let highlights = vec![(Range { start: 0, end: 1 }, HighlightStyle::default())];
+        let _ = StyledText::new(text).with_default_highlights(&default_style, highlights);
     }
 
     #[test]
     fn test_with_runs_tolerates_runs_exceeding_text_length() {
-        use crate::{Font, StyledText, TextRun, black};
+        use crate::{HighlightStyle, StyledText, TextStyle};
+        use std::ops::Range;
 
         let text = "hi";
-        let run = TextRun {
-            len: 10,
-            font: Font::default(),
-            color: black(),
-            background_color: None,
-            underline: None,
-            strikethrough: None,
-        };
-        // Should not panic.
-        let _ = StyledText::new(text).with_runs(vec![run]);
+        let default_style = TextStyle::default();
+        let highlights = vec![(Range { start: 0, end: 10 }, HighlightStyle::default())];
+
+        let _ = StyledText::new(text).with_default_highlights(&default_style, highlights);
     }
 }

--- a/crates/gpui/src/elements/text.rs
+++ b/crates/gpui/src/elements/text.rs
@@ -234,6 +234,12 @@ impl StyledText {
                 range.end += 1;
             }
 
+            // Ensure we don't rewind into already-consumed bytes
+            range.start = range.start.max(ix);
+            if range.end <= range.start {
+                continue;
+            }
+
             if ix < range.start {
                 runs.push(default_style.clone().to_run(range.start - ix));
             }
@@ -976,6 +982,20 @@ mod tests {
         let default_style = TextStyle::default();
         let highlights = vec![(Range { start: 0, end: 10 }, HighlightStyle::default())];
 
+        let _ = StyledText::new(text).with_default_highlights(&default_style, highlights);
+    }
+
+    #[test]
+    fn test_with_runs_tolerates_overlapping_highlights_on_multibyte_char() {
+        use crate::{HighlightStyle, StyledText, TextStyle};
+        use std::ops::Range;
+
+        let text = "éa";
+        let default_style = TextStyle::default();
+        let highlights = vec![
+            (Range { start: 0, end: 1 }, HighlightStyle::default()),
+            (Range { start: 1, end: 2 }, HighlightStyle::default()),
+        ];
         let _ = StyledText::new(text).with_default_highlights(&default_style, highlights);
     }
 }

--- a/crates/gpui_linux/src/linux/headless/client.rs
+++ b/crates/gpui_linux/src/linux/headless/client.rs
@@ -64,6 +64,7 @@ impl LinuxClient for HeadlessClient {
         None
     }
 
+    #[cfg(feature = "screen-capture")]
     fn screen_capture_sources(
         &self,
     ) -> futures::channel::oneshot::Receiver<anyhow::Result<Vec<Rc<dyn gpui::ScreenCaptureSource>>>>


### PR DESCRIPTION

This pull request improves the robustness of text highlighting in the `StyledText` component by ensuring that highlight ranges are always valid UTF-8 character boundaries and do not exceed the text length. Additionally, new tests are added to verify this behavior.

**Text Highlighting Robustness:**

* The `with_default_highlights` method in `StyledText` now clamps highlight ranges to the text length and adjusts start/end positions to valid UTF-8 character boundaries, preventing panics when given invalid ranges.

**Testing Improvements:**

* Added tests to ensure that `with_default_highlights` safely handles highlight ranges that split multibyte characters and ranges that exceed the text length.

**Other:**

* Added a missing `#[cfg(feature = "screen-capture")]` attribute to the `screen_capture_sources` method in the headless Linux client, ensuring correct compilation when the feature is enabled.
## Closes #50298 
--- 

## Release Notes 


- Fixed crash when jumping to definition from a diff with semantic highlighting
