### PR TITLE
Fix incorrect error response

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -2146,15 +2146,15 @@ impl AcpThread {
                         if r.stop_reason == acp::StopReason::MaxTokens {
                             this.had_error = true;
                             cx.emit(AcpThreadEvent::Error);
-                            let max_output_tokens = this
-                                .token_usage
-                                .as_ref()
-                                .and_then(|usage| usage.max_output_tokens)
-                                .map_or("unknown".to_string(), |tokens| tokens.to_string());
-                            let message = format!(
-                                "Max output tokens reached for this response (limit: {max_output_tokens}). Send 'continue' to resume."
-                            );
-                            log::error!("Max tokens reached for the response. Usage: {:?}", this.token_usage);
+                            log::error!("Max tokens reached. Usage: {:?}", this.token_usage);
+                            let message = if let Some(token_usage) = this.token_usage.as_ref()
+                                && let Some(max_output_tokens) = token_usage.max_output_tokens
+                                && token_usage.output_tokens >= max_output_tokens
+                            {
+                                "Maximum output tokens reached"
+                            } else {
+                                "Maximum tokens reached"
+                            };
                             return Err(anyhow!(message));
                         }
 

--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -2146,8 +2146,16 @@ impl AcpThread {
                         if r.stop_reason == acp::StopReason::MaxTokens {
                             this.had_error = true;
                             cx.emit(AcpThreadEvent::Error);
-                            log::error!("Max tokens reached. Usage: {:?}", this.token_usage);
-                            return Err(anyhow!("Max tokens reached"));
+                            let max_output_tokens = this
+                                .token_usage
+                                .as_ref()
+                                .and_then(|usage| usage.max_output_tokens)
+                                .map_or("unknown".to_string(), |tokens| tokens.to_string());
+                            let message = format!(
+                                "Max output tokens reached for this response (limit: {max_output_tokens}). Send 'continue' to resume."
+                            );
+                            log::error!("Max tokens reached for the response. Usage: {:?}", this.token_usage);
+                            return Err(anyhow!(message));
                         }
 
                         let canceled = matches!(r.stop_reason, acp::StopReason::Cancelled);


### PR DESCRIPTION
### Fixes #50254

This change clarifies a misleading Agent error when generation stops due to per-response output limits.

Previously, Zed surfaced Max tokens reached, which implied the full context window (max_tokens) was exhausted. In affected cases, the actual limit was max_output_tokens for a single response.
The error now explicitly states that the output-token cap for the current response was reached, includes the limit value when available, and provides actionable guidance to send continue to resume.

### Updated:

Runtime error text in ACP thread handling


Release Notes

- Agent: Improve max token error