### PR TITLE
Fix renaming with `.` in JSX tags

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -1988,8 +1988,16 @@ impl AcpThread {
                         if r.stop_reason == acp::StopReason::MaxTokens {
                             this.had_error = true;
                             cx.emit(AcpThreadEvent::Error);
-                            log::error!("Max tokens reached. Usage: {:?}", this.token_usage);
-                            return Err(anyhow!("Max tokens reached"));
+                            let max_output_tokens = this
+                                .token_usage
+                                .as_ref()
+                                .and_then(|usage| usage.max_output_tokens)
+                                .map_or("unknown".to_string(), |tokens| tokens.to_string());
+                            let message = format!(
+                                "Max output tokens reached for this response (limit: {max_output_tokens}). Send 'continue' to resume."
+                            );
+                            log::error!("Max tokens reached for the response. Usage: {:?}", this.token_usage);
+                            return Err(anyhow!(message));
                         }
 
                         let canceled = matches!(r.stop_reason, acp::StopReason::Cancelled);

--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -1988,16 +1988,8 @@ impl AcpThread {
                         if r.stop_reason == acp::StopReason::MaxTokens {
                             this.had_error = true;
                             cx.emit(AcpThreadEvent::Error);
-                            let max_output_tokens = this
-                                .token_usage
-                                .as_ref()
-                                .and_then(|usage| usage.max_output_tokens)
-                                .map_or("unknown".to_string(), |tokens| tokens.to_string());
-                            let message = format!(
-                                "Max output tokens reached for this response (limit: {max_output_tokens}). Send 'continue' to resume."
-                            );
-                            log::error!("Max tokens reached for the response. Usage: {:?}", this.token_usage);
-                            return Err(anyhow!(message));
+                            log::error!("Max tokens reached. Usage: {:?}", this.token_usage);
+                            return Err(anyhow!("Max tokens reached"));
                         }
 
                         let canceled = matches!(r.stop_reason, acp::StopReason::Cancelled);

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4893,8 +4893,10 @@ impl Editor {
                         .scope_context(Some(CharScopeContext::LinkedEdit));
                     classifier.is_word(char)
                 });
+                let is_dot = text.as_ref() == ".";
+                let should_apply_linked_edit = is_word_char || is_dot;
 
-                if is_word_char {
+                if should_apply_linked_edit {
                     let anchor_range = start_anchor.text_anchor..anchor.text_anchor;
                     linked_edits.push(&self, anchor_range, text.clone(), cx);
                 } else {

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -26623,6 +26623,48 @@ async fn test_linked_edits_on_typing_punctuation(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_linked_edits_on_typing_dot_without_language_override(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+    let language = Arc::new(Language::new(
+        LanguageConfig {
+            name: "HTML".into(),
+            matcher: LanguageMatcher {
+                path_suffixes: vec!["html".to_string()],
+                ..LanguageMatcher::default()
+            },
+            brackets: BracketPairConfig {
+                pairs: vec![BracketPair {
+                    start: "<".into(),
+                    end: ">".into(),
+                    close: true,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        Some(tree_sitter_html::LANGUAGE.into()),
+    ));
+    cx.update_buffer(|buffer, cx| buffer.set_language(Some(language), cx));
+
+    cx.set_state("<Tableˇ></Table>");
+    cx.update_editor(|editor, _, cx| {
+        set_linked_edit_ranges(
+            (Point::new(0, 1), Point::new(0, 6)),
+            (Point::new(0, 9), Point::new(0, 14)),
+            editor,
+            cx,
+        );
+    });
+    cx.update_editor(|editor, window, cx| {
+        editor.handle_input(".", window, cx);
+    });
+    cx.assert_editor_state("<Table.ˇ></Table.>");
+}
+
+#[gpui::test]
 async fn test_invisible_worktree_servers(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 


### PR DESCRIPTION
Fixes #50245

### Summary :
This PR fixes linked tag renaming when typing . in tag names like <Table.Headers>...</Table.Headers>.

Previously, linked editing treated . as punctuation (unless a language explicitly configured it as a linked-edit character), so renaming could stop syncing at the dot and produce mismatched closing tags.

### What changed
Updated linked-edit input handling to preserve linked edits when the typed input is exactly ".", even if the active language does not explicitly include dot in linked_edit_characters.
Added a regression test covering dot typing in linked edits without language override.

Kept existing punctuation behavior (e.g. >) unchanged.

### Files changed
[editor.rs]
[editor_tests.rs]

### Why this approach
Minimal, targeted fix in shared linked-edit path.
Works for .svelte and similar markup contexts where dot-separated component names are valid in practice.
Avoids requiring every language/extension to add dot config individually.

### Validation
Manual repro confirmed: opening tag rename with dot now keeps closing tag synced.
Added test: test_linked_edits_on_typing_dot_without_language_override.
Existing related test remains relevant: test_linked_edits_on_typing_punctuation.