### PR TITLE
Fix "Select larger syntax node" for Rust doc comments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,7 +217,7 @@ dependencies = [
  "text",
  "theme",
  "thiserror 2.0.17",
- "tree-sitter-rust",
+ "tree-sitter-rust-orchard",
  "ui",
  "unindent",
  "url",
@@ -5255,7 +5255,7 @@ dependencies = [
  "thiserror 2.0.17",
  "time",
  "toml 0.8.23",
- "tree-sitter-rust",
+ "tree-sitter-rust-orchard",
  "ui",
  "util",
  "uuid",
@@ -5484,7 +5484,7 @@ dependencies = [
  "tree-sitter-html",
  "tree-sitter-md",
  "tree-sitter-python",
- "tree-sitter-rust",
+ "tree-sitter-rust-orchard",
  "tree-sitter-typescript",
  "tree-sitter-yaml",
  "ui",
@@ -7462,7 +7462,7 @@ dependencies = [
  "settings",
  "text",
  "theme",
- "tree-sitter-rust",
+ "tree-sitter-rust-orchard",
  "tree-sitter-typescript",
  "ui",
  "util",
@@ -9184,7 +9184,7 @@ dependencies = [
  "tempfile",
  "theme",
  "tree-sitter-json",
- "tree-sitter-rust",
+ "tree-sitter-rust-orchard",
  "ui",
  "ui_input",
  "util",
@@ -9303,7 +9303,7 @@ dependencies = [
  "tree-sitter-md",
  "tree-sitter-python",
  "tree-sitter-ruby",
- "tree-sitter-rust",
+ "tree-sitter-rust-orchard",
  "tree-sitter-typescript",
  "unicase",
  "unindent",
@@ -9558,7 +9558,7 @@ dependencies = [
  "tree-sitter-md",
  "tree-sitter-python",
  "tree-sitter-regex",
- "tree-sitter-rust",
+ "tree-sitter-rust-orchard",
  "tree-sitter-typescript",
  "tree-sitter-yaml",
  "unindent",
@@ -11668,7 +11668,7 @@ dependencies = [
  "settings",
  "smol",
  "theme",
- "tree-sitter-rust",
+ "tree-sitter-rust-orchard",
  "tree-sitter-typescript",
  "ui",
  "util",
@@ -17173,7 +17173,7 @@ dependencies = [
  "serde",
  "serde_json",
  "task",
- "tree-sitter-rust",
+ "tree-sitter-rust-orchard",
  "tree-sitter-typescript",
  "ui",
  "util",
@@ -18341,10 +18341,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tree-sitter-rust"
-version = "0.24.0"
+name = "tree-sitter-rust-orchard"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9b18034c684a2420722be8b2a91c9c44f2546b631c039edf575ccba8c61be1"
+checksum = "6a21c4915730924e2ae96bcaa1c3bad45e666a546b7b5642bf595a3df6705797"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -21879,7 +21879,7 @@ dependencies = [
  "toolchain_selector",
  "tracing",
  "tree-sitter-md",
- "tree-sitter-rust",
+ "tree-sitter-rust-orchard",
  "ui",
  "ui_prompt",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -743,7 +743,7 @@ tree-sitter-md = { git = "https://github.com/tree-sitter-grammars/tree-sitter-ma
 tree-sitter-python = "0.25"
 tree-sitter-regex = "0.24"
 tree-sitter-ruby = "0.23"
-tree-sitter-rust = "0.24"
+tree-sitter-rust = { package = "tree-sitter-rust-orchard", version = "0.16" }
 tree-sitter-typescript = { git = "https://github.com/zed-industries/tree-sitter-typescript", rev = "e2c53597d6a5d9cf7bbe8dccde576fe1e46c5899" } # https://github.com/tree-sitter/tree-sitter-typescript/pull/347
 tree-sitter-yaml = { git = "https://github.com/zed-industries/tree-sitter-yaml", rev = "baff0b51c64ef6a1fb1f8390f3ad6015b83ec13a" }
 tracing = "0.1.40"

--- a/crates/languages/src/rust/highlights.scm
+++ b/crates/languages/src/rust/highlights.scm
@@ -103,9 +103,13 @@
 "#" @punctuation.special
 
 [
+  "auto"
   "as"
   "async"
+  "await"
+  "become"
   "const"
+  "~const"
   "default"
   "dyn"
   "enum"
@@ -113,12 +117,15 @@
   "fn"
   "impl"
   "let"
-  "macro_rules!"
+  "macro_rules"
+  "macro"
   "mod"
   "move"
   "pub"
   "raw"
   "ref"
+  "return"
+  "safe"
   "static"
   "struct"
   "for"
@@ -171,6 +178,8 @@
 ] @comment
 
 [
+  (line_outer_doc_comment)
+  (block_outer_doc_comment)
   (line_comment
     (doc_comment))
   (block_comment

--- a/crates/languages/src/rust/outline.scm
+++ b/crates/languages/src/rust/outline.scm
@@ -49,7 +49,7 @@
 
 (macro_definition
   .
-  "macro_rules!" @context
+  "macro_rules" @context
   name: (_) @name) @item
 
 (mod_item
@@ -59,10 +59,6 @@
 
 (type_item
   (visibility_modifier)? @context
-  "type" @context
-  name: (_) @name) @item
-
-(associated_type
   "type" @context
   name: (_) @name) @item
 


### PR DESCRIPTION
Closes #44331.

This switches to a version of the Rust tree-sitter parser which correctly attaches the doc comments to the nodes they annotate.

This new parser also contains a range of improvements to the parsing of other aspects of the language, meaning that the query files required more adaptations in other places. You can see the details of those changes [in the commit log of the grammar](https://codeberg.org/grammar-orchard/tree-sitter-rust-orchard/commits/branch/main). Many of such changes have been [submitted upstream](https://github.com/tree-sitter/tree-sitter-rust/pull/269), but the upstream repo isn't very actively maintained.

Release Notes:

- Improved Rust support by switching to the `tree-sitter-rust-orchard` parser
